### PR TITLE
Mission Progress Colors + Context Menu Keyboard Shortcuts

### DIFF
--- a/sidewalk-webpage/public/javascripts/SVLabel/build/SVLabel.css
+++ b/sidewalk-webpage/public/javascripts/SVLabel/build/SVLabel.css
@@ -1370,7 +1370,7 @@ footer {
 }
 
 #progress-pov-current-completion-bar {
-    background: #EEEEEE;
+    background: rgba(210,210,210,1);
     height: 14px;
     position: absolute;
     width: 190px;

--- a/sidewalk-webpage/public/javascripts/SVLabel/build/SVLabel.js
+++ b/sidewalk-webpage/public/javascripts/SVLabel/build/SVLabel.js
@@ -3113,6 +3113,11 @@ function Keyboard ($) {
             svl.tracker.push('KeyUp', {'keyCode': e.keyCode});
           }
             switch (e.keyCode) {
+                // "Enter"
+                case 13:
+                    if ('contextMenu' in svl && svl.contextMenu.isOpen()) {
+                        svl.contextMenu.hide();
+                    }
                 case 16:
                     // "Shift"
                     status.shiftDown = false;
@@ -3125,21 +3130,51 @@ function Keyboard ($) {
                         svl.ribbon.backToWalk();
                     }
                     break;
-                case 49:
+                    case 49:
                     // "1"
-                    svl.ribbon.modeSwitchClick("CurbRamp");
+                    if ('contextMenu' in svl && svl.contextMenu.isOpen()) {
+                        svl.ui.contextMenu.radioButtons.filter(function(){return this.value=='1'}).prop("checked", true).trigger("click");
+                    }
+                    else{
+                        svl.ribbon.modeSwitchClick("CurbRamp");
+                        break;
+                    }
                     break;
                 case 50:
                     // "2"
-                    svl.ribbon.modeSwitchClick("NoCurbRamp");
+                    if ('contextMenu' in svl && svl.contextMenu.isOpen()) {
+                        svl.ui.contextMenu.radioButtons.filter(function(){return this.value=='2'}).prop("checked", true).trigger("click");
+                    }
+                    else{
+                        svl.ribbon.modeSwitchClick("NoCurbRamp");
+                    }
                     break;
                 case 51:
                     // "3"
-                    svl.ribbon.modeSwitchClick("Obstacle");
+                    if ('contextMenu' in svl && svl.contextMenu.isOpen()) {
+                        svl.ui.contextMenu.radioButtons.filter(function(){return this.value=='3'}).prop("checked", true).trigger("click");
+                    }
+                    else{
+                        svl.ribbon.modeSwitchClick("Obstacle");
+                    }
                     break;
                 case 52:
                     // "4"
-                    svl.ribbon.modeSwitchClick("SurfaceProblem");
+                    if ('contextMenu' in svl && svl.contextMenu.isOpen()) {
+                        svl.ui.contextMenu.radioButtons.filter(function(){return this.value=='4'}).prop("checked", true).trigger("click");
+                    }
+                    else{
+                        svl.ribbon.modeSwitchClick("SurfaceProblem");
+                    }
+                    break;
+                case 53:
+                    // "5"
+                    if ('contextMenu' in svl && svl.contextMenu.isOpen()) {
+                        svl.ui.contextMenu.radioButtons.filter(function(){return this.value=='5'}).prop("checked", true).trigger("click");
+                    }
+                    else{
+
+                    }
                     break;
                 case 67:
                     // "c" for CurbRamp. Switch the mode to the CurbRamp labeling mode.
@@ -6752,15 +6787,25 @@ function MissionProgress () {
      * This method updates the filler of the completion bar
      */
     function updateMissionCompletionBar (completionRate) {
-        var r, g, color, colorIntensity = 230;
-        if (completionRate < 0.5) {
-            r = colorIntensity;
+        var r, g, b, color, colorIntensity = 200;
+        if (completionRate < 0.6) {
+            r = colorIntensity * 1.3;
             g = parseInt(colorIntensity * completionRate * 2);
-        } else {
-            r = parseInt(colorIntensity * (1 - completionRate) * 2);
-            g = colorIntensity;
+            b = 20;
         }
-        color = 'rgba(' + r + ',' + g + ',0,1)';
+        /*
+        else if (completionRate >= 0.4 && completionRate <= 0.6){
+            r = parseInt(colorIntensity * (1 - completionRate) * 2.1);
+            g = colorIntensity * 0.7;
+            b = 0;
+        } */
+        else {
+            r = parseInt(colorIntensity * (1 - completionRate) * 1.7);
+            g = colorIntensity;
+            b = 100;
+        }
+        color = 'rgba(' + r + ',' + g + ',' + b + ',1)';
+        printCompletionRate(completionRate);
         completionRate *=  100;
         if (completionRate > 100) completionRate = 100;
         completionRate = completionRate.toFixed(0, 10);
@@ -11673,6 +11718,7 @@ var ColorScheme = (function () {
         }
     }
 
+
     function SidewalkColorScheme2 (category) {
         var colors = {
             Walk : {
@@ -11681,19 +11727,19 @@ var ColorScheme = (function () {
             },
             CurbRamp: {
                 id: 'CurbRamp',
-                fillStyle: 'rgba(0, 222, 38, 1)'  // 'rgba(0, 244, 38, 1)'
+                fillStyle: 'rgba(79, 180, 105, 1)'  // 'rgba(0, 244, 38, 1)'
             },
             NoCurbRamp: {
                 id: 'NoCurbRamp',
-                fillStyle: 'rgba(233, 39, 113, 1)'  // 'rgba(255, 39, 113, 1)'
+                fillStyle: 'rgba(210, 48, 30, 1)'  // 'rgba(255, 39, 113, 1)'
             },
             Obstacle: {
                 id: 'Obstacle',
-                fillStyle: 'rgba(0, 161, 203, 1)'
+                fillStyle: 'rgba(29, 150 , 240, 1)'
             },
             Other: {
                 id: 'Other',
-                fillStyle: 'rgba(179, 179, 179, 1)' //'rgba(204, 204, 204, 1)'
+                fillStyle: 'rgba(180, 150, 200, 1)' //'rgba(204, 204, 204, 1)'
             },
             Occlusion: {
                 id: 'Occlusion',
@@ -11705,7 +11751,7 @@ var ColorScheme = (function () {
             },
             SurfaceProblem: {
                 id: 'SurfaceProblem',
-                fillStyle: 'rgba(241, 141, 5, 1)'
+                fillStyle: 'rgba(240, 200, 30, 1)'
             },
             Void: {
                 id: 'Void',
@@ -11718,7 +11764,6 @@ var ColorScheme = (function () {
         };
         return category ? colors[category].fillStyle : colors;
     }
-
     /**
      * http://www.colourlovers.com/business/trends/branding/7880/Papeterie_Haute-Ville_Logo
      * @returns {{Walk: {id: string, fillStyle: string}, CurbRamp: {id: string, fillStyle: string}, NoCurbRamp: {id: string, fillStyle: string}, StopSign: {id: string, fillStyle: string}, StopSign_OneLeg: {id: string, fillStyle: string}, StopSign_TwoLegs: {id: string, fillStyle: string}, StopSign_Column: {id: string, fillStyle: string}, Landmark_Shelter: {id: string, fillStyle: string}, Landmark_Bench: {id: string, fillStyle: string}, Landmark_TrashCan: {id: string, fillStyle: string}, Landmark_MailboxAndNewsPaperBox: {id: string, fillStyle: string}, Landmark_OtherPole: {id: string, fillStyle: string}}}

--- a/sidewalk-webpage/public/javascripts/SVLabel/css/svl-status-progress-pov.css
+++ b/sidewalk-webpage/public/javascripts/SVLabel/css/svl-status-progress-pov.css
@@ -10,7 +10,7 @@
 }
 
 #progress-pov-current-completion-bar {
-    background: #EEEEEE;
+    background: rgba(210,210,210,1);
     height: 14px;
     position: absolute;
     width: 190px;

--- a/sidewalk-webpage/public/javascripts/SVLabel/src/SVLabel/Keyboard.js
+++ b/sidewalk-webpage/public/javascripts/SVLabel/src/SVLabel/Keyboard.js
@@ -80,6 +80,11 @@ function Keyboard ($) {
             svl.tracker.push('KeyUp', {'keyCode': e.keyCode});
           }
             switch (e.keyCode) {
+                // "Enter"
+                case 13:
+                    if ('contextMenu' in svl && svl.contextMenu.isOpen()) {
+                        svl.contextMenu.hide();
+                    }
                 case 16:
                     // "Shift"
                     status.shiftDown = false;
@@ -92,21 +97,51 @@ function Keyboard ($) {
                         svl.ribbon.backToWalk();
                     }
                     break;
-                case 49:
+                    case 49:
                     // "1"
-                    svl.ribbon.modeSwitchClick("CurbRamp");
+                    if ('contextMenu' in svl && svl.contextMenu.isOpen()) {
+                        svl.ui.contextMenu.radioButtons.filter(function(){return this.value=='1'}).prop("checked", true).trigger("click");
+                    }
+                    else{
+                        svl.ribbon.modeSwitchClick("CurbRamp");
+                        break;
+                    }
                     break;
                 case 50:
                     // "2"
-                    svl.ribbon.modeSwitchClick("NoCurbRamp");
+                    if ('contextMenu' in svl && svl.contextMenu.isOpen()) {
+                        svl.ui.contextMenu.radioButtons.filter(function(){return this.value=='2'}).prop("checked", true).trigger("click");
+                    }
+                    else{
+                        svl.ribbon.modeSwitchClick("NoCurbRamp");
+                    }
                     break;
                 case 51:
                     // "3"
-                    svl.ribbon.modeSwitchClick("Obstacle");
+                    if ('contextMenu' in svl && svl.contextMenu.isOpen()) {
+                        svl.ui.contextMenu.radioButtons.filter(function(){return this.value=='3'}).prop("checked", true).trigger("click");
+                    }
+                    else{
+                        svl.ribbon.modeSwitchClick("Obstacle");
+                    }
                     break;
                 case 52:
                     // "4"
-                    svl.ribbon.modeSwitchClick("SurfaceProblem");
+                    if ('contextMenu' in svl && svl.contextMenu.isOpen()) {
+                        svl.ui.contextMenu.radioButtons.filter(function(){return this.value=='4'}).prop("checked", true).trigger("click");
+                    }
+                    else{
+                        svl.ribbon.modeSwitchClick("SurfaceProblem");
+                    }
+                    break;
+                case 53:
+                    // "5"
+                    if ('contextMenu' in svl && svl.contextMenu.isOpen()) {
+                        svl.ui.contextMenu.radioButtons.filter(function(){return this.value=='5'}).prop("checked", true).trigger("click");
+                    }
+                    else{
+
+                    }
                     break;
                 case 67:
                     // "c" for CurbRamp. Switch the mode to the CurbRamp labeling mode.

--- a/sidewalk-webpage/public/javascripts/SVLabel/src/SVLabel/MissionProgress.js
+++ b/sidewalk-webpage/public/javascripts/SVLabel/src/SVLabel/MissionProgress.js
@@ -150,15 +150,25 @@ function MissionProgress () {
      * This method updates the filler of the completion bar
      */
     function updateMissionCompletionBar (completionRate) {
-        var r, g, color, colorIntensity = 230;
-        if (completionRate < 0.5) {
-            r = colorIntensity;
+        var r, g, b, color, colorIntensity = 200;
+        if (completionRate < 0.6) {
+            r = colorIntensity * 1.3;
             g = parseInt(colorIntensity * completionRate * 2);
-        } else {
-            r = parseInt(colorIntensity * (1 - completionRate) * 2);
-            g = colorIntensity;
+            b = 20;
         }
-        color = 'rgba(' + r + ',' + g + ',0,1)';
+        /*
+        else if (completionRate >= 0.4 && completionRate <= 0.6){
+            r = parseInt(colorIntensity * (1 - completionRate) * 2.1);
+            g = colorIntensity * 0.7;
+            b = 0;
+        } */
+        else {
+            r = parseInt(colorIntensity * (1 - completionRate) * 1.7);
+            g = colorIntensity;
+            b = 100;
+        }
+        color = 'rgba(' + r + ',' + g + ',' + b + ',1)';
+        printCompletionRate(completionRate);
         completionRate *=  100;
         if (completionRate > 100) completionRate = 100;
         completionRate = completionRate.toFixed(0, 10);

--- a/sidewalk-webpage/public/javascripts/SVLabel/src/SVLabel/Util/UtilitiesSidewalk.js
+++ b/sidewalk-webpage/public/javascripts/SVLabel/src/SVLabel/Util/UtilitiesSidewalk.js
@@ -348,6 +348,7 @@ var ColorScheme = (function () {
         }
     }
 
+
     function SidewalkColorScheme2 (category) {
         var colors = {
             Walk : {
@@ -356,19 +357,19 @@ var ColorScheme = (function () {
             },
             CurbRamp: {
                 id: 'CurbRamp',
-                fillStyle: 'rgba(0, 222, 38, 1)'  // 'rgba(0, 244, 38, 1)'
+                fillStyle: 'rgba(79, 180, 105, 1)'  // 'rgba(0, 244, 38, 1)'
             },
             NoCurbRamp: {
                 id: 'NoCurbRamp',
-                fillStyle: 'rgba(233, 39, 113, 1)'  // 'rgba(255, 39, 113, 1)'
+                fillStyle: 'rgba(210, 48, 30, 1)'  // 'rgba(255, 39, 113, 1)'
             },
             Obstacle: {
                 id: 'Obstacle',
-                fillStyle: 'rgba(0, 161, 203, 1)'
+                fillStyle: 'rgba(29, 150 , 240, 1)'
             },
             Other: {
                 id: 'Other',
-                fillStyle: 'rgba(179, 179, 179, 1)' //'rgba(204, 204, 204, 1)'
+                fillStyle: 'rgba(180, 150, 200, 1)' //'rgba(204, 204, 204, 1)'
             },
             Occlusion: {
                 id: 'Occlusion',
@@ -380,7 +381,7 @@ var ColorScheme = (function () {
             },
             SurfaceProblem: {
                 id: 'SurfaceProblem',
-                fillStyle: 'rgba(241, 141, 5, 1)'
+                fillStyle: 'rgba(240, 200, 30, 1)'
             },
             Void: {
                 id: 'Void',
@@ -393,7 +394,6 @@ var ColorScheme = (function () {
         };
         return category ? colors[category].fillStyle : colors;
     }
-
     /**
      * http://www.colourlovers.com/business/trends/branding/7880/Papeterie_Haute-Ville_Logo
      * @returns {{Walk: {id: string, fillStyle: string}, CurbRamp: {id: string, fillStyle: string}, NoCurbRamp: {id: string, fillStyle: string}, StopSign: {id: string, fillStyle: string}, StopSign_OneLeg: {id: string, fillStyle: string}, StopSign_TwoLegs: {id: string, fillStyle: string}, StopSign_Column: {id: string, fillStyle: string}, Landmark_Shelter: {id: string, fillStyle: string}, Landmark_Bench: {id: string, fillStyle: string}, Landmark_TrashCan: {id: string, fillStyle: string}, Landmark_MailboxAndNewsPaperBox: {id: string, fillStyle: string}, Landmark_OtherPole: {id: string, fillStyle: string}}}


### PR DESCRIPTION
**Mission Progress Colors: **
Changed the css for the bar background to make it darker so that there is more contrast with white text. Added a call to printCompletionRate() on each progress bar update so that the percentage displayed stays in sync.
My changes to the progress color algorithm are from a lot of trial and error. The yellow-ish green at around 60-70% is a little more subtle.
![progressbar1](https://cloud.githubusercontent.com/assets/13355765/14589898/57e5a084-04bb-11e6-8aba-28590865c3da.png)
I changed the sidewalk color scheme too but I can change those back if that was outside the scope of these tasks. The color on "Other" was a gray that blended into the button so I decided to change it. I see that labels for the "Other" set of labels are not functional yet so I may have been getting ahead of myself. 
![labels](https://cloud.githubusercontent.com/assets/13355765/14589924/f0e4145a-04bb-11e6-81ca-a98cb0ecb6dc.PNG)

**Context Menu Keyboard Shortcuts: **
Implemented in Keyboard.js. Pressing 1-5 when the context menu is open selects the corresponding radio button and pressing _Enter_ closes the pop-up.