### PR TITLE
Label Counter Improvement

### DIFF
--- a/sidewalk-webpage/public/javascripts/SVLabel/build/SVLabel.js
+++ b/sidewalk-webpage/public/javascripts/SVLabel/build/SVLabel.js
@@ -8341,19 +8341,16 @@ function MissionProgress () {
      * This method updates the filler of the completion bar
      */
     function updateMissionCompletionBar (completionRate) {
-        var r, g, b, color, colorIntensity = 200;
-        if (completionRate < 0.6) {
-            r = colorIntensity * 1.3;
-            g = parseInt(colorIntensity * completionRate * 2);
-            b = 20;
+        var g, b, color;
+        if (completionRate < 1) {
+            g = 161;
+            b = 203;
         }
-        // TODO change green threshold to ~90%
         else {
-            r = parseInt(colorIntensity * (1 - completionRate) * 1.7);
-            g = colorIntensity;
-            b = 100;
+            g = 222;
+            b = 38;
         }
-        color = 'rgba(' + r + ',' + g + ',' + b + ',1)';
+        color = 'rgba(0,' + g + ',' + b + ',1)';
         printCompletionRate(completionRate);
         completionRate *=  100;
         if (completionRate > 100) completionRate = 100;
@@ -9399,8 +9396,8 @@ function LabelCounter (d3) {
       "NoCurbRamp": {
           id: "NoCurbRamp",
           description: "missing curb ramp",
-          left: margin.left + width / 2,
-          top: margin.top,
+          left: margin.left,
+          top: (2 * margin.top) + margin.bottom + height,
           // top: 2 * margin.top + margin.bottom + height,
           fillColor: colorScheme["NoCurbRamp"].fillStyle,
           imagePath: svl.rootDirectory + "/img/icons/Sidewalk/Icon_NoCurbRamp.png",
@@ -9410,9 +9407,9 @@ function LabelCounter (d3) {
       "Obstacle": {
         id: "Obstacle",
         description: "obstacle",
-        left: margin.left,
+        left: margin.left + (width/1.7),
         // top: 3 * margin.top + 2 * margin.bottom + 2 * height,
-          top: 2 * margin.top + margin.bottom + height,
+          top: (2 * margin.top) + margin.bottom + height,
         fillColor: colorScheme["Obstacle"].fillStyle,
           imagePath: svl.rootDirectory + "/img/icons/Sidewalk/Icon_Obstacle.png",
         count: 0,
@@ -9421,9 +9418,9 @@ function LabelCounter (d3) {
       "SurfaceProblem": {
         id: "SurfaceProblem",
         description: "surface problem",
-        left: margin.left + width / 2,
+        left: margin.left,
         //top: 4 * margin.top + 3 * margin.bottom + 3 * height,
-          top: 2 * margin.top + margin.bottom + height,
+          top: (3 * margin.top) + (2 * margin.bottom) + (2 * height),
         fillColor: colorScheme["SurfaceProblem"].fillStyle,
           imagePath: svl.rootDirectory + "/img/icons/Sidewalk/Icon_SurfaceProblem.png",
         count: 0,
@@ -9432,8 +9429,8 @@ function LabelCounter (d3) {
         "Other": {
             id: "Other",
             description: "other",
-            left: margin.left,
-            top: 3 * margin.top + 2 * margin.bottom + 2 * height,
+            left: margin.left + (width/1.7),
+            top: (3 * margin.top) + (2 * margin.bottom) + (2 * height),
             fillColor: colorScheme["Other"].fillStyle,
             imagePath: svl.rootDirectory + "/img/icons/Sidewalk/Icon_Other.png",
             count: 0,
@@ -9529,10 +9526,11 @@ function LabelCounter (d3) {
         function _update(key) {
             if (keys.indexOf(key) == -1) { key = "Other"; }
 
-            var firstDigit = dotPlots[key].count % 10,
-              higherDigits = (dotPlots[key].count - firstDigit) / 10,
-              count = firstDigit + higherDigits;
-
+            var fiftyCircles = parseInt(dotPlots[key].count / 50),
+              tenCircles = parseInt((dotPlots[key].count % 50) / 10),
+              oneCircles = dotPlots[key].count % 10,
+              count = fiftyCircles + tenCircles + oneCircles;
+          
             // Update the label
             //dotPlots[key].countLabel
             //  .transition().duration(1000)
@@ -9547,6 +9545,45 @@ function LabelCounter (d3) {
             //    return dotPlots[key].count;
             //  });
 
+            /* 
+            the code of these three functions was being used so much I decided to seperately declare them
+            the d3 calls look much cleaner now :)
+            */
+            function setCX(d, i){
+              if (i < fiftyCircles && fiftyCircles != 0){
+                return x(i * 4 * radius + dR);
+              }
+              else if (i < fiftyCircles + tenCircles && tenCircles != 0){
+                return x(fiftyCircles * 4 * radius + dR) + x((i - fiftyCircles) * 2 * (radius + dR));
+              }
+              else{
+                return x(fiftyCircles * 2 * radius + dR) + x(tenCircles * 1.9 * (radius + dR))+ x((i - tenCircles) * 2 * radius);
+              }
+            }
+            
+            function setCY(d, i){
+              if (i < fiftyCircles && fiftyCircles != 0){
+                return 0;
+              }
+              else if (i < fiftyCircles + tenCircles && tenCircles != 0){
+                return x(dR);
+              }
+              else{
+                return x(radius);
+              }
+            }
+
+            function setR(d, i){
+              if (i < fiftyCircles && fiftyCircles != 0){
+                return x(2 * radius);
+              }
+              else if (i < fiftyCircles + tenCircles && tenCircles != 0){
+                return x(radius + dR);
+              }
+              else{
+                return x(radius);
+              }
+            }
             // Update the dot plot
             if (dotPlots[key].data.length >= count) {
               // Remove dots
@@ -9554,16 +9591,9 @@ function LabelCounter (d3) {
 
                 dotPlots[key].plot.selectAll("circle")
                   .transition().duration(500)
-                  .attr("r", function (d, i) {
-                    return i < higherDigits ? x(radius + dR) : x(radius);
-                  })
-                  .attr("cy", function (d, i) {
-                    if (i < higherDigits) {
-                        return 0;
-                    } else {
-                        return x(dR);
-                    }
-                  });
+                  .attr("r", setR)
+                  .attr("cy", setCY)
+                  .attr("cx", setCX);
 
                 dotPlots[key].plot.selectAll("circle")
                   .data(dotPlots[key].data)
@@ -9571,7 +9601,7 @@ function LabelCounter (d3) {
                   .transition()
                   .duration(500)
                   .attr("cx", function () {
-                    return x(higherDigits);
+                    return 0;
                   })
                   .attr("r", 0)
                   .remove();
@@ -9582,30 +9612,19 @@ function LabelCounter (d3) {
                   dotPlots[key].data.push([len + i, 0, radius])
               }
               dotPlots[key].plot.selectAll("circle")
+                .attr("r", setR) 
+                .attr("cy", setCY)
+                .attr("cx", setCX)
                 .data(dotPlots[key].data)
                 .enter().append("circle")
                 .attr("cx", x(0))
-                .attr("cy", 0)
-                .attr("r", x(radius + dR))
+                .attr("cy", setCY)
+                .attr("r", radius)
                 .style("fill", dotPlots[key].fillColor)
                 .transition().duration(1000)
-                .attr("cx", function (d, i) {
-                  if (i <= higherDigits) {
-                    return x(d[0] * 2 * (radius + dR));
-                  } else {
-                    return x((higherDigits) * 2 * (radius + dR)) + x((i - higherDigits) * 2 * radius)
-                  }
-                })
-                .attr("cy", function (d, i) {
-                  if (i < higherDigits) {
-                    return 0;
-                  } else {
-                    return x(dR);
-                  }
-                })
-                .attr("r", function (d, i) {
-                  return i < higherDigits ? x(radius + dR) : x(radius);
-                });
+                .attr("cx", setCX)
+                .attr("cy", setCY)
+                .attr("r", setR);
             }
             dotPlots[key].label.text(function () {
                 var ret = dotPlots[key].count + " " + dotPlots[key].description;


### PR DESCRIPTION
![labelcounter](https://cloud.githubusercontent.com/assets/13355765/15786409/6e3c01f4-298a-11e6-9d0f-c0b9c64f1d67.PNG)
(Merge conflict is probably because I did not have push/pull permission while developing this task)

Rearranged the Label Counters so that Curb Ramp has its own row. The whole Label Counter section should probably be wider(obstacles is cut off). 
Created a larger circle to break down larger quantities by 50s. Updated the d3 plotting and animation. There were some issues with inconsistencies  and glitches when counts were changed. This was fixed by updating the attributes of the existing circles, as well as the new ones.
Tested on Chrome with the results pictured above. Works in increments of +/-1 as the user would do, as well as changing from or to any value.