### PR TITLE
Label Counter Improvement

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/status/LabelCounter.js
+++ b/public/javascripts/SVLabel/src/SVLabel/status/LabelCounter.js
@@ -8,17 +8,14 @@
 function LabelCounter (d3) {
     var self = {className: 'LabelCounter'};
 
-    var radius = 0.4,
-        dR = radius / 2,
-        svgWidth = 200,
-        svgHeight = 120,
+    var radius = 0.4, dR = radius / 2,
+        svgWidth = 200, svgHeight = 120,
         margin = {top: 10, right: 10, bottom: 10, left: 0},
         padding = {left: 5, top: 15},
         width = 200 - margin.left - margin.right,
         height = 40 - margin.top - margin.bottom,
         colorScheme = svl.misc.getLabelColors(),
-        imageWidth = 22,
-        imageHeight = 22;
+        imageWidth = 22, imageHeight = 22;
 
     // Prepare a group to store svg elements, and declare a text
     var dotPlots = {
@@ -35,8 +32,8 @@ function LabelCounter (d3) {
       "NoCurbRamp": {
           id: "NoCurbRamp",
           description: "missing curb ramp",
-          left: margin.left + width / 2,
-          top: margin.top,
+          left: margin.left,
+          top: (2 * margin.top) + margin.bottom + height,
           // top: 2 * margin.top + margin.bottom + height,
           fillColor: colorScheme["NoCurbRamp"].fillStyle,
           imagePath: svl.rootDirectory + "/img/icons/Sidewalk/Icon_NoCurbRamp.png",
@@ -46,9 +43,9 @@ function LabelCounter (d3) {
       "Obstacle": {
         id: "Obstacle",
         description: "obstacle",
-        left: margin.left,
+        left: margin.left + (width/1.7),
         // top: 3 * margin.top + 2 * margin.bottom + 2 * height,
-          top: 2 * margin.top + margin.bottom + height,
+          top: (2 * margin.top) + margin.bottom + height,
         fillColor: colorScheme["Obstacle"].fillStyle,
           imagePath: svl.rootDirectory + "/img/icons/Sidewalk/Icon_Obstacle.png",
         count: 0,
@@ -57,9 +54,9 @@ function LabelCounter (d3) {
       "SurfaceProblem": {
         id: "SurfaceProblem",
         description: "surface problem",
-        left: margin.left + width / 2,
+        left: margin.left,
         //top: 4 * margin.top + 3 * margin.bottom + 3 * height,
-          top: 2 * margin.top + margin.bottom + height,
+          top: (3 * margin.top) + (2 * margin.bottom) + (2 * height),
         fillColor: colorScheme["SurfaceProblem"].fillStyle,
           imagePath: svl.rootDirectory + "/img/icons/Sidewalk/Icon_SurfaceProblem.png",
         count: 0,
@@ -68,8 +65,8 @@ function LabelCounter (d3) {
         "Other": {
             id: "Other",
             description: "other",
-            left: margin.left,
-            top: 3 * margin.top + 2 * margin.bottom + 2 * height,
+            left: margin.left + (width/1.7),
+            top: (3 * margin.top) + (2 * margin.bottom) + (2 * height),
             fillColor: colorScheme["Other"].fillStyle,
             imagePath: svl.rootDirectory + "/img/icons/Sidewalk/Icon_Other.png",
             count: 0,
@@ -128,16 +125,149 @@ function LabelCounter (d3) {
             .attr("width", imageWidth)
             .attr("height", imageHeight)
             .attr('transform', 'translate(0,-15)');
+      //dotPlots[key].countLabel = dotPlots[key].plot.selectAll("text.count-label")
+      //  .data([0])
+      //  .enter()
+      //  .append("text")
+      //  .style("font-size", "11px")
+      //  .style("fill", "gray")
+      //  .attr("class", "visible");
     }
 
     /**
-     *
-     * @param labelType Label type
-     * @returns {integer}
+     * Set label counts to 0
      */
-    function countLabel(labelType) {
-        return labelType in dotPlots ? dotPlots[labelType].count : null;
+    function reset () {
+        for (var key in dotPlots) {
+            set(key, 0);
+        }
+    }
 
+    /**
+     * Update the label count visualization.
+     * @param key {string} Label type
+     */
+    function update(key) {
+        // If a key is given, udpate the dot plot for that specific data.
+        // Otherwise update all.
+        if (key) {
+          _update(key)
+        } else {
+          for (var key in dotPlots) {
+            _update(key);
+          }
+        }
+
+        // Actual update function
+        function _update(key) {
+            if (keys.indexOf(key) == -1) { key = "Other"; }
+
+            var fiftyCircles = parseInt(dotPlots[key].count / 50),
+              tenCircles = parseInt((dotPlots[key].count % 50) / 10),
+              oneCircles = dotPlots[key].count % 10,
+              count = fiftyCircles + tenCircles + oneCircles;
+          
+            // Update the label
+            //dotPlots[key].countLabel
+            //  .transition().duration(1000)
+            //  .attr("x", function () {
+            //    return x(higherDigits * 2 * (radius + dR) + firstDigit * 2 * radius)
+            //  })
+            //  .attr("y", function () {
+            //    return x(radius + dR - 0.05);
+            //  })
+            //  // .transition().duration(1000)
+            //  .text(function (d) {
+            //    return dotPlots[key].count;
+            //  });
+
+            /* 
+            the code of these three functions was being used so much I decided to seperately declare them
+            the d3 calls look much cleaner now :)
+            */
+            function setCX(d, i){
+              if (i < fiftyCircles && fiftyCircles != 0){
+                return x(i * 4 * radius + dR);
+              }
+              else if (i < fiftyCircles + tenCircles && tenCircles != 0){
+                return x(fiftyCircles * 4 * radius + dR) + x((i - fiftyCircles) * 2 * (radius + dR));
+              }
+              else{
+                return x(fiftyCircles * 2 * radius + dR) + x(tenCircles * 1.9 * (radius + dR))+ x((i - tenCircles) * 2 * radius);
+              }
+            }
+            
+            function setCY(d, i){
+              if (i < fiftyCircles && fiftyCircles != 0){
+                return 0;
+              }
+              else if (i < fiftyCircles + tenCircles && tenCircles != 0){
+                return x(dR);
+              }
+              else{
+                return x(radius);
+              }
+            }
+
+            function setR(d, i){
+              if (i < fiftyCircles && fiftyCircles != 0){
+                return x(2 * radius);
+              }
+              else if (i < fiftyCircles + tenCircles && tenCircles != 0){
+                return x(radius + dR);
+              }
+              else{
+                return x(radius);
+              }
+            }
+            // Update the dot plot
+            if (dotPlots[key].data.length >= count) {
+              // Remove dots
+              dotPlots[key].data = dotPlots[key].data.slice(0, count);
+
+                dotPlots[key].plot.selectAll("circle")
+                  .transition().duration(500)
+                  .attr("r", setR)
+                  .attr("cy", setCY)
+                  .attr("cx", setCX);
+
+                dotPlots[key].plot.selectAll("circle")
+                  .data(dotPlots[key].data)
+                  .exit()
+                  .transition()
+                  .duration(500)
+                  .attr("cx", function () {
+                    return 0;
+                  })
+                  .attr("r", 0)
+                  .remove();
+            } else {
+              // Add dots
+              var len = dotPlots[key].data.length;
+              for (var i = 0; i < count - len; i++) {
+                  dotPlots[key].data.push([len + i, 0, radius])
+              }
+              dotPlots[key].plot.selectAll("circle")
+                .attr("r", setR) 
+                .attr("cy", setCY)
+                .attr("cx", setCX)
+                .data(dotPlots[key].data)
+                .enter().append("circle")
+                .attr("cx", x(0))
+                .attr("cy", setCY)
+                .attr("r", radius)
+                .style("fill", dotPlots[key].fillColor)
+                .transition().duration(1000)
+                .attr("cx", setCX)
+                .attr("cy", setCY)
+                .attr("r", setR);
+            }
+            dotPlots[key].label.text(function () {
+                var ret = dotPlots[key].count + " " + dotPlots[key].description;
+                ret += dotPlots[key].count > 1 ? "s" : "";
+                return ret;
+            });
+        }
     }
 
     /**
@@ -164,16 +294,6 @@ function LabelCounter (d3) {
         }
     }
 
-
-    /**
-     * Set label counts to 0
-     */
-    function reset () {
-        for (var key in dotPlots) {
-            set(key, 0);
-        }
-    }
-
     /**
      * Set the number of label count
      * @param key {string} Label type
@@ -184,105 +304,11 @@ function LabelCounter (d3) {
         update(key);
     }
 
-    /**
-     * Update the label count visualization.
-     * @param key {string} Label type
-     */
-    function update(key) {
-        // If a key is given, udpate the dot plot for that specific data.
-        // Otherwise update all.
-        if (key) {
-            _update(key)
-        } else {
-            for (var key in dotPlots) {
-                _update(key);
-            }
-        }
-
-        // Actual update function
-        function _update(key) {
-            if (keys.indexOf(key) == -1) { key = "Other"; }
-
-            var firstDigit = dotPlots[key].count % 10,
-                higherDigits = (dotPlots[key].count - firstDigit) / 10,
-                count = firstDigit + higherDigits;
-
-
-            // Update the dot plot
-            if (dotPlots[key].data.length >= count) {
-                // Remove dots
-                dotPlots[key].data = dotPlots[key].data.slice(0, count);
-
-                dotPlots[key].plot.selectAll("circle")
-                    .transition().duration(500)
-                    .attr("r", function (d, i) {
-                        return i < higherDigits ? x(radius + dR) : x(radius);
-                    })
-                    .attr("cy", function (d, i) {
-                        if (i < higherDigits) {
-                            return 0;
-                        } else {
-                            return x(dR);
-                        }
-                    });
-
-                dotPlots[key].plot.selectAll("circle")
-                    .data(dotPlots[key].data)
-                    .exit()
-                    .transition()
-                    .duration(500)
-                    .attr("cx", function () {
-                        return x(higherDigits);
-                    })
-                    .attr("r", 0)
-                    .remove();
-            } else {
-                // Add dots
-                var len = dotPlots[key].data.length;
-                for (var i = 0; i < count - len; i++) {
-                    dotPlots[key].data.push([len + i, 0, radius])
-                }
-                dotPlots[key].plot.selectAll("circle")
-                    .data(dotPlots[key].data)
-                    .enter().append("circle")
-                    .attr("cx", x(0))
-                    .attr("cy", 0)
-                    .attr("r", x(radius + dR))
-                    .style("fill", dotPlots[key].fillColor)
-                    .transition().duration(1000)
-                    .attr("cx", function (d, i) {
-                        if (i <= higherDigits) {
-                            return x(d[0] * 2 * (radius + dR));
-                        } else {
-                            return x((higherDigits) * 2 * (radius + dR)) + x((i - higherDigits) * 2 * radius)
-                        }
-                    })
-                    .attr("cy", function (d, i) {
-                        if (i < higherDigits) {
-                            return 0;
-                        } else {
-                            return x(dR);
-                        }
-                    })
-                    .attr("r", function (d, i) {
-                        return i < higherDigits ? x(radius + dR) : x(radius);
-                    });
-            }
-            dotPlots[key].label.text(function () {
-                var ret = dotPlots[key].count + " " + dotPlots[key].description;
-                ret += dotPlots[key].count > 1 ? "s" : "";
-                return ret;
-            });
-        }
-    }
-
-
     // Initialize
     update();
 
     self.increment = increment;
     self.decrement = decrement;
-    self.countLabel = countLabel;
     self.set = set;
     self.reset = reset;
     return self;


### PR DESCRIPTION

![labelcounter](https://cloud.githubusercontent.com/assets/13355765/15788961/effeadce-2997-11e6-87d6-79880c4f4a8e.PNG)

Rearranged the Label Counters so that Curb Ramp has its own row. The whole Label Counter section should probably be wider(obstacles is cut off). 
Created a larger circle to break down larger quantities by 50s. Updated the d3 plotting and animation. There were some issues with inconsistencies and glitches when counts were changed. This was fixed by updating the attributes of the existing circles, as well as the new ones.
Tested on Chrome with the results pictured above. Works in increments of +/-1 as the user would do, as well as changing from or to any value.