### PR TITLE
Mission Completion Bar changed to Blue/Green

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/status/MissionStatus.js
+++ b/public/javascripts/SVLabel/src/SVLabel/status/MissionStatus.js
@@ -68,24 +68,17 @@ function MissionStatus () {
      * This method updates the filler of the completion bar
      */
     function updateMissionCompletionBar (completionRate) {
-        var r, g, b, color, colorIntensity = 200;
-
+        var color;
         // Update the %
         printCompletionRate(completionRate);
 
         // Update the bar
-        if (completionRate < 0.6) {
-            r = colorIntensity * 1.3;
-            g = parseInt(colorIntensity * completionRate * 2);
-            b = 20;
+        if (completionRate < 1) {
+            color = 'rgba(0, 161, 203, 1)'; // obstacle blue
         }
-        // TODO change green threshold to ~90%
         else {
-            r = parseInt(colorIntensity * (1 - completionRate) * 1.7);
-            g = colorIntensity;
-            b = 100;
-        }
-        color = 'rgba(' + r + ',' + g + ',' + b + ',1)';
+            color = 'rgba(0, 222, 38, 1)'; // curb ramp green
+        }   
         completionRate *=  100;
         if (completionRate > 100) completionRate = 100;
         completionRate = completionRate.toFixed(0, 10);


### PR DESCRIPTION
Addressing https://github.com/ProjectSidewalk/SidewalkWebpage/issues/164
Implementing design from one of my first tasks.

Bar is the same shade of blue for all values below 100% at which point it becomes green.
![image](https://cloud.githubusercontent.com/assets/13355765/16924770/e25b1f70-4cee-11e6-97f2-c79f4588d564.png)
![image](https://cloud.githubusercontent.com/assets/13355765/16924784/f00179bc-4cee-11e6-9229-810df4852d64.png)
![image](https://cloud.githubusercontent.com/assets/13355765/16924731/c1be51ba-4cee-11e6-8069-245172f7a0ba.png)
