### PR TITLE
Fix #333

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
+++ b/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
@@ -479,12 +479,12 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
     // missions greater than 3000 feet are measured in miles
     function distanceLeftFeetOrMiles(){
         var remainingRate = 1 - svl.missionContainer.getCurrentMission().getMissionCompletionRate();
-        var missionDistance = svl.missionContainer.getCurrentMission().getProperty("distanceFt");
+        var missionDistance = svl.missionContainer.getCurrentMission().getProperty("auditDistanceFt");
         if(missionDistance < 3000){
             return parseInt(missionDistance * remainingRate) + " feet";
         }
         else{
-            missionDistance = svl.missionContainer.getCurrentMission().getProperty("distanceMi");
+            missionDistance = svl.missionContainer.getCurrentMission().getProperty("auditDistanceMi");
             var miles = missionDistance * remainingRate;
             return miles.toFixed(2) + " miles";
         }


### PR DESCRIPTION
Missions have two types of somewhat confusing properties, the `auditDistance` property of a mission is the distance that has to be audited in the mission, whereas the `distance` property is the distance that has to be audited in this mission and all the previous missions.

The updated code uses `auditDistance` property instead of `distance`. 