### PR TITLE
Fix #262: Escape closes the example modal as well

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/keyboard/Keyboard.js
+++ b/public/javascripts/SVLabel/src/SVLabel/keyboard/Keyboard.js
@@ -209,6 +209,7 @@ function Keyboard (svl, canvas, contextMenu, ribbon, zoomControl) {
                 } else {
                     ribbon.backToWalk();
                 }
+                svl.modalExample.hide();
                 break;
         }
 


### PR DESCRIPTION
Fixes #262 