### PR TITLE
Change twitter card image path to absolute value

### DIFF
--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -40,7 +40,8 @@
     <meta name="twitter:creator" content="@@umd_sidewalk">
     <meta name="twitter:title" content="Project Sidewalk">
     <meta name="twitter:description" content="Help us make sidewalks more accessible, for everyone.">
-    <meta name="twitter:image" content="@routes.Assets.at("images/twitter_card.png")">
+    @*TODO: url should not be hardcoded*@
+    <meta name="twitter:image" content="http://sidewalk.umiacs.umd.edu@routes.Assets.at("images/twitter_card.png")">
 </head>
 <body>
     <div id="wrap">


### PR DESCRIPTION
Twitter card's image is not correctly shown. Changed the relative path of image to absolute value to see if that works.

![image](https://cloud.githubusercontent.com/assets/1576529/20363148/31428534-ac0c-11e6-92b6-f89d5bdb56da.png)