### PR TITLE
Fix overlay label box issue

### DIFF
--- a/public/javascripts/SVLabel/css/svl-context-menu.css
+++ b/public/javascripts/SVLabel/css/svl-context-menu.css
@@ -11,7 +11,7 @@
     -webkit-border-radius: 3px 3px 3px 3px;
     -moz-border-radius: 3px 3px 3px 3px;
     visibility: hidden;
-    z-index: 100;
+    z-index: 2;
 ;
 }
 

--- a/public/javascripts/SVLabel/css/svl-context-menu.css
+++ b/public/javascripts/SVLabel/css/svl-context-menu.css
@@ -11,7 +11,8 @@
     -webkit-border-radius: 3px 3px 3px 3px;
     -moz-border-radius: 3px 3px 3px 3px;
     visibility: hidden;
-    z-index: 1;
+    z-index: 100;
+;
 }
 
 #context-menu-vertical-connector {


### PR DESCRIPTION
Fixes the problem of the top-down map’s text appearing on the label pop-up message box, when the pop-up is very close to the GSV screen border such that it overlays on top of the top-down map.

<img width="448" alt="screen shot 2016-12-18 at 7 04 11 pm" src="https://cloud.githubusercontent.com/assets/2873216/21297895/1b7f5dc2-c556-11e6-985a-a0e02e4f1c1b.png">
