### PR TITLE
Fixes #386: Admin Interface - Add in Filtering Based on Severity

### DIFF
--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -77,14 +77,15 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
     */
   def getAllLabels = UserAwareAction.async { implicit request =>
     if (isAdmin(request.identity)) {
-      val labels = LabelTable.selectLocationsOfLabels
+      val labels = LabelTable.selectLocationsAndSeveritiesOfLabels
       val features: List[JsObject] = labels.map { label =>
         val point = geojson.Point(geojson.LatLng(label.lat.toDouble, label.lng.toDouble))
         val properties = Json.obj(
           "audit_task_id" -> label.auditTaskId,
           "label_id" -> label.labelId,
           "gsv_panorama_id" -> label.gsvPanoramaId,
-          "label_type" -> label.labelType
+          "label_type" -> label.labelType,
+          "severity" -> label.severity
         )
         Json.obj("type" -> "Feature", "geometry" -> point, "properties" -> properties)
       }

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -12,69 +12,76 @@
 
 @main(title) {
     @navbar(user)
+
+<!--<style>
+    .filter td{
+        padding-left:4px!important;
+        padding-right:4px!important;
+    }
+
+</style>-->
     <div class="container">
         <div class="row">
             <div class="col-lg-12">
                 <div id="map-holder">
                     <div id="admin-map"></div>
                     <div id="map-label-legend">
-                        <table class="table">
+                        <table class="table filter">
                             <tr>
-                                <td id="map-legend-curb-ramp" width="10%"></td>
-                                <td width="30%">Curb Ramp</td>
-                                <td width="5%"><input type="checkbox" value="displaylabel" id="curbramp" checked="true" onclick="admin.updateVisibleMarkers();"></td>
-                                <td width="15%" align="right">Severity:</td>
-                                <td width="30%"align="left"><div id = "curb-ramp-slider"></div></td>
-                                <td width="20%" align= "center"><span id="curb-ramp-severity-label">All</span></td>
+                                <td></td>
+                                <td colspan="2" align="left" style="font-weight:bold"> Type</td>
+                                <td colspan="2" align="left" style="font-weight:bold">Severity</td>
+
+                            </tr>
+                            <tr>
+                                <td id="map-legend-curb-ramp" width="12px"></td>
+                                <td width="190px">Curb Ramp</td>
+                                <td width="12px"  align="center"><input type="checkbox" value="displaylabel" id="curbramp" checked="true" onclick="admin.updateVisibleMarkers();"></td>
+                                <td width="121px"align="center"><div id = "curb-ramp-slider" style="margin-top:3px"></div></td>
+                                <td width="85px" align= "center" ><span id="curb-ramp-severity-label">All</span></td>
 
                             </tr>
                             <tr>
                                 <td id="map-legend-no-curb-ramp"></td>
-                                <td width = "30%">Missing Curb Ramp</td>
-                                <td width="5"><input type="checkbox" value="displaylabel" id="missingcurbramp" checked="true" onclick="admin.updateVisibleMarkers();"></td>
-                                <td width="15%" align="right">Severity:</td>
-                                <td width="30%"align="left"><div id = "missing-curb-ramp-slider"></div></td>
-                                <td width="20%" align= "center"><span id="missing-curb-ramp-severity-label">All</span></td>
+                                <td>Missing Curb Ramp</td>
+                                <td><input type="checkbox" value="displaylabel" id="missingcurbramp" checked="true" onclick="admin.updateVisibleMarkers();"></td>
+                                <td align="left"><div id = "missing-curb-ramp-slider" style="margin-top:3px"></div></td>
+                                <td align= "center"><span id="missing-curb-ramp-severity-label">All</span></td>
                             </tr>
 
                             <tr>
                                 <td id="map-legend-obstacle"></td>
                                 <td>Obstacle in Path</td>
                                 <td><input type="checkbox" value="displaylabel" id="obstacle" checked="true" onclick="admin.updateVisibleMarkers();"></td>
-                                <td width="15%" align="right">Severity:</td>
-                                <td width="30%"align="left"><div id = "obstacle-slider"></div></td>
-                                <td width="20%" align= "center"><span id="obstacle-severity-label">All</span></td>
+                                <td align="left"><div id = "obstacle-slider" style="margin-top:3px"></div></td>
+                                <td align= "center"><span id="obstacle-severity-label">All</span></td>
                             </tr>
                             <tr><td id="map-legend-surface-problem"></td>
                                 <td>Surface Problem</td>
                                 <td><input type="checkbox" value="displaylabel" id="surfaceprob" checked="true" onclick="admin.updateVisibleMarkers();"></td>
-                                <td width="15%" align="right">Severity:</td>
-                                <td width="30%"align="left"><div id = "surface-problem-slider"></div></td>
-                                <td width="20%" align= "center"><span id="surface-problem-severity-label">All</span></td>
+                                <td align="left"><div id = "surface-problem-slider" style="margin-top:3px"></div></td>
+                                <td align="center"><span id="surface-problem-severity-label">All</span></td>
                             </tr>
                             <tr>
                                 <td id="map-legend-occlusion"></td>
                                 <td>Can't see sidewalk</td>
                                 <td><input type="checkbox" value="displaylabel" id="occlusion" checked="true" onclick="admin.updateVisibleMarkers();"></td>
-                                <td width="15%" align="right">Severity:</td>
-                                <td width="30%"align="left"><div id = "occlusion-slider"></div></td>
-                                <td width="20%" align= "center"><span id="occlusion-severity-label">All</span></td>
+                                <td align="left"><div id = "occlusion-slider" style="margin-top:3px"></div></td>
+                                <td align= "center"><span id="occlusion-severity-label">All</span></td>
                             </tr>
                             <tr>
                                 <td id="map-legend-nosidewalk"></td>
                                 <td>No Sidewalk</td>
                                 <td><input type="checkbox" value="displaylabel" id="nosidewalk" checked="true" onclick="admin.updateVisibleMarkers();"></td>
-                                <td width="15%" align="right">Severity:</td>
-                                <td width="30%"align="left"><div id = "no-sidewalk-slider"></div></td>
-                                <td width="20%" align= "center"><span id="no-sidewalk-severity-label">All</span></td>
+                                <td align="left"><div id = "no-sidewalk-slider" style="margin-top:3px"></div></td>
+                                <td  align= "center"><span id="no-sidewalk-severity-label">All</span></td>
                             </tr>
                             <tr>
                                 <td id="map-legend-other"></td>
                                 <td>Other</td>
                                 <td><input type="checkbox" value="displaylabel" id="other" checked="true" onclick="admin.updateVisibleMarkers();"></td>
-                                <td width="15%" align="right">Severity:</td>
-                                <td width="30%"align="left"><div id = "other-slider"></div></td>
-                                <td width="20%" align= "center"><span id="other-severity-label">All</span></td>
+                                <td align="left"><div id = "other-slider" style="margin-top:3px"></div></td>
+                                <td align= "center"><span id="other-severity-label">All</span></td>
                             </tr>
                             <tr><td id="map-legend-audited-street"></td><td>Audited Street</td><td><input type="checkbox" value="displaylabel" id="auditedstreet" checked="true" onclick="admin.updateVisibleMarkers();"></td></tr>
 

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -412,6 +412,9 @@
                 slide: function(event, ui) {
                     $(sliderToLabelMap[this.id]).text(labelArr[ui.value]);
                    // $("#curb-ramp-severity-label").text(labelArr[ui.value]);
+                },
+                change: function(event,ui) {
+                    admin.updateVisibleMarkers();
                 }
             });
         });

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -19,13 +19,63 @@
                     <div id="admin-map"></div>
                     <div id="map-label-legend">
                         <table class="table">
-                            <tr><td id="map-legend-curb-ramp"></td><td>Curb Ramp</td><td><input type="checkbox" value="displaylabel" id="curbramp" checked="true" onclick="admin.updateVisibleMarkers();"></td></tr>
-                            <tr><td id="map-legend-no-curb-ramp"></td><td>Missing Curb Ramp</td><td><input type="checkbox" value="displaylabel" id="missingcurbramp" checked="true" onclick="admin.updateVisibleMarkers();"></td></tr>
-                            <tr><td id="map-legend-obstacle"></td><td>Obstacle in Path</td><td><input type="checkbox" value="displaylabel" id="obstacle" checked="true" onclick="admin.updateVisibleMarkers();"></td></tr>
-                            <tr><td id="map-legend-surface-problem"></td><td>Surface Problem</td><td><input type="checkbox" value="displaylabel" id="surfaceprob" checked="true" onclick="admin.updateVisibleMarkers();"></td></tr>
-                            <tr><td id="map-legend-occlusion"></td><td>Can't see sidewalk</td><td><input type="checkbox" value="displaylabel" id="occlusion" checked="true" onclick="admin.updateVisibleMarkers();"></td></tr>
-                            <tr><td id="map-legend-nosidewalk"></td><td>No Sidewalk</td><td><input type="checkbox" value="displaylabel" id="nosidewalk" checked="true" onclick="admin.updateVisibleMarkers();"></td></tr>
-                            <tr><td id="map-legend-other"></td><td>Other</td><td><input type="checkbox" value="displaylabel" id="other" checked="true" onclick="admin.updateVisibleMarkers();"></td></tr>
+                            <tr>
+                                <td id="map-legend-curb-ramp" width="10%"></td>
+                                <td width="30%">Curb Ramp</td>
+                                <td width="5%"><input type="checkbox" value="displaylabel" id="curbramp" checked="true" onclick="admin.updateVisibleMarkers();"></td>
+                                <td width="15%" align="right">Severity:</td>
+                                <td width="30%"align="left"><div id = "curb-ramp-slider"></div></td>
+                                <td width="20%" align= "center"><span id="curb-ramp-severity-label">All</span></td>
+
+                            </tr>
+                            <tr>
+                                <td id="map-legend-no-curb-ramp"></td>
+                                <td width = "30%">Missing Curb Ramp</td>
+                                <td width="5"><input type="checkbox" value="displaylabel" id="missingcurbramp" checked="true" onclick="admin.updateVisibleMarkers();"></td>
+                                <td width="15%" align="right">Severity:</td>
+                                <td width="30%"align="left"><div id = "missing-curb-ramp-slider"></div></td>
+                                <td width="20%" align= "center"><span id="missing-curb-ramp-severity-label">All</span></td>
+                            </tr>
+
+                            <tr>
+                                <td id="map-legend-obstacle"></td>
+                                <td>Obstacle in Path</td>
+                                <td><input type="checkbox" value="displaylabel" id="obstacle" checked="true" onclick="admin.updateVisibleMarkers();"></td>
+                                <td width="15%" align="right">Severity:</td>
+                                <td width="30%"align="left"><div id = "obstacle-slider"></div></td>
+                                <td width="20%" align= "center"><span id="obstacle-severity-label">All</span></td>
+                            </tr>
+                            <tr><td id="map-legend-surface-problem"></td>
+                                <td>Surface Problem</td>
+                                <td><input type="checkbox" value="displaylabel" id="surfaceprob" checked="true" onclick="admin.updateVisibleMarkers();"></td>
+                                <td width="15%" align="right">Severity:</td>
+                                <td width="30%"align="left"><div id = "surface-problem-slider"></div></td>
+                                <td width="20%" align= "center"><span id="surface-problem-severity-label">All</span></td>
+                            </tr>
+                            <tr>
+                                <td id="map-legend-occlusion"></td>
+                                <td>Can't see sidewalk</td>
+                                <td><input type="checkbox" value="displaylabel" id="occlusion" checked="true" onclick="admin.updateVisibleMarkers();"></td>
+                                <td width="15%" align="right">Severity:</td>
+                                <td width="30%"align="left"><div id = "occlusion-slider"></div></td>
+                                <td width="20%" align= "center"><span id="occlusion-severity-label">All</span></td>
+                            </tr>
+                            <tr>
+                                <td id="map-legend-nosidewalk"></td>
+                                <td>No Sidewalk</td>
+                                <td><input type="checkbox" value="displaylabel" id="nosidewalk" checked="true" onclick="admin.updateVisibleMarkers();"></td>
+                                <td width="15%" align="right">Severity:</td>
+                                <td width="30%"align="left"><div id = "no-sidewalk-slider"></div></td>
+                                <td width="20%" align= "center"><span id="no-sidewalk-severity-label">All</span></td>
+                            </tr>
+                            <tr>
+                                <td id="map-legend-other"></td>
+                                <td>Other</td>
+                                <td><input type="checkbox" value="displaylabel" id="other" checked="true" onclick="admin.updateVisibleMarkers();"></td>
+                                <td width="15%" align="right">Severity:</td>
+                                <td width="30%"align="left"><div id = "other-slider"></div></td>
+                                <td width="20%" align= "center"><span id="other-severity-label">All</span></td>
+                            </tr>
                             <tr><td id="map-legend-audited-street"></td><td>Audited Street</td><td><input type="checkbox" value="displaylabel" id="auditedstreet" checked="true" onclick="admin.updateVisibleMarkers();"></td></tr>
 
                         </table>
@@ -328,6 +378,7 @@
     <link href='@routes.Assets.at("stylesheets/dataTables.bootstrap.min.css")' rel="stylesheet"/>
     <link href='@routes.Assets.at("stylesheets/ekko-lightbox.css")' rel="stylesheet"/>
     <link href='@routes.Assets.at("stylesheets/ekko-lightbox.min.css")' rel="stylesheet"/>
+    <link rel="stylesheet" href="//code.jquery.com/ui/1.12.1/themes/smoothness/jquery-ui.css">
 
     <script type="text/javascript" src='@routes.Assets.at("javascripts/lib/moment.js")'></script>
     <script type="text/javascript" src='@routes.Assets.at("javascripts/lib/d3.v3.js")'></script>
@@ -339,6 +390,52 @@
     <script type="text/javascript" src='@routes.Assets.at("javascripts/SVLabel/src/SVLabel/util/Utilities.js")'></script>
     <script type="text/javascript" src='@routes.Assets.at("javascripts/SVLabel/src/SVLabel/util/UtilitiesSidewalk.js")'></script>
     <script type="text/javascript" src='@routes.Assets.at("javascripts/SVLabel/src/SVLabel/util/UtilitiesColor.js")'></script>
+
+    <script>
+
+        var labelArr = new Array("None", 1, 2, 3, 4, 5, "All");
+        var sliderToLabelMap = {};
+        sliderToLabelMap["curb-ramp-slider"] = "#curb-ramp-severity-label";
+        sliderToLabelMap["missing-curb-ramp-slider"] = "#missing-curb-ramp-severity-label";
+        sliderToLabelMap["obstacle-slider"] = "#obstacle-severity-label";
+        sliderToLabelMap["surface-problem-slider"] = "#surface-problem-severity-label";
+        sliderToLabelMap["occlusion-slider"]  = "#occlusion-severity-label";
+        sliderToLabelMap["no-sidewalk-slider"] = "#no-sidewalk-severity-label";
+        sliderToLabelMap["other-slider"] = "#other-severity-label";
+
+        $( "*[id*='slider']" ).each(function() {
+            $(this).slider({
+                min : 0,
+                max : 6,
+                step: 1,
+                value: 6,
+                slide: function(event, ui) {
+                    $(sliderToLabelMap[this.id]).text(labelArr[ui.value]);
+                   // $("#curb-ramp-severity-label").text(labelArr[ui.value]);
+                }
+            });
+        });
+
+        /*$( "#curb-ramp-slider" ).slider({
+            min : 0,
+            max : 6,
+            step: 1,
+            value: 6,
+            slide: function(event, ui) {
+                $("#curb-ramp-severity-label").text(labelArr[ui.value]);
+            }
+        });*/
+
+       /* function severityChanger( event, ui ) {
+            $("#curb-ramp-severity-label").text(labelArr[ui.value]);
+            // $("#label").css("margin-left", (ui.value-min)/(max-min)*100+"%");
+            // $("#label").css("left", "-50px");
+        }*/
+
+
+
+    </script>
+
     <script>
         $(document).ready(function () {
 

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -83,7 +83,6 @@
                                 <td align= "center"><span id="other-severity-label">All</span></td>
                             </tr>
                             <tr><td id="map-legend-audited-street"></td><td>Audited Street</td><td><input type="checkbox" value="displaylabel" id="auditedstreet" checked="true" onclick="admin.updateVisibleMarkers();"></td></tr>
-
                         </table>
                     </div>
                 </div>

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -13,13 +13,6 @@
 @main(title) {
     @navbar(user)
 
-<!--<style>
-    .filter td{
-        padding-left:4px!important;
-        padding-right:4px!important;
-    }
-
-</style>-->
     <div class="container">
         <div class="row">
             <div class="col-lg-12">

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -29,16 +29,15 @@
                         <table class="table filter">
                             <tr>
                                 <td></td>
-                                <td colspan="2" align="left" style="font-weight:bold"> Type</td>
+                                <td colspan="2" align="left" style="font-weight:bold">Label Type</td>
                                 <td colspan="2" align="left" style="font-weight:bold">Severity</td>
-
                             </tr>
                             <tr>
                                 <td id="map-legend-curb-ramp" width="12px"></td>
                                 <td width="190px">Curb Ramp</td>
                                 <td width="12px"  align="center"><input type="checkbox" value="displaylabel" id="curbramp" checked="true" onclick="admin.updateVisibleMarkers();"></td>
-                                <td width="121px"align="center"><div id = "curb-ramp-slider" style="margin-top:3px"></div></td>
-                                <td width="85px" align= "center" ><span id="curb-ramp-severity-label">All</span></td>
+                                <td width="126px"align="center"><div id = "curb-ramp-slider" style="margin-top:3px"></div></td>
+                                <td width="60px" align= "center" ><span id="curb-ramp-severity-label">All</span></td>
 
                             </tr>
                             <tr>
@@ -399,8 +398,7 @@
     <script type="text/javascript" src='@routes.Assets.at("javascripts/SVLabel/src/SVLabel/util/UtilitiesColor.js")'></script>
 
     <script>
-
-        var labelArr = new Array("None", 1, 2, 3, 4, 5, "All");
+        var labelArr = new Array(1, 2, 3, 4, 5, "All");
         var sliderToLabelMap = {};
         sliderToLabelMap["curb-ramp-slider"] = "#curb-ramp-severity-label";
         sliderToLabelMap["missing-curb-ramp-slider"] = "#missing-curb-ramp-severity-label";
@@ -413,42 +411,21 @@
         $( "*[id*='slider']" ).each(function() {
             $(this).slider({
                 min : 0,
-                max : 6,
+                max : 5,
                 step: 1,
-                value: 6,
+                value: 5,
                 slide: function(event, ui) {
                     $(sliderToLabelMap[this.id]).text(labelArr[ui.value]);
-                   // $("#curb-ramp-severity-label").text(labelArr[ui.value]);
                 },
                 change: function(event,ui) {
                     admin.updateVisibleMarkers();
                 }
             });
         });
-
-        /*$( "#curb-ramp-slider" ).slider({
-            min : 0,
-            max : 6,
-            step: 1,
-            value: 6,
-            slide: function(event, ui) {
-                $("#curb-ramp-severity-label").text(labelArr[ui.value]);
-            }
-        });*/
-
-       /* function severityChanger( event, ui ) {
-            $("#curb-ramp-severity-label").text(labelArr[ui.value]);
-            // $("#label").css("margin-left", (ui.value-min)/(max-min)*100+"%");
-            // $("#label").css("left", "-50px");
-        }*/
-
-
-
     </script>
 
     <script>
         $(document).ready(function () {
-
 
             window.admin = Admin (_, $, c3, turf);
             $('#commentsTable').dataTable();

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -16,6 +16,7 @@
     <link href='@routes.Assets.at("stylesheets/bootstrap/bootstrap-accessibility.css")' rel='stylesheet' />
 
     <script src='@routes.Assets.at("javascripts/lib/bootstrap-accessibility-plugin/bs3.1.1/js/jquery-1.12.2.min.js")'></script>
+    <script src="//code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
     <script src='@routes.Assets.at("javascripts/lib/bootstrap-accessibility-plugin/bs3.1.1/js/bootstrap.min.js")'></script>
     <script src='@routes.Assets.at("javascripts/lib/bootstrap-accessibility-plugin/plugins/js/bootstrap-accessibility.min.js")'></script>
 

--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -491,18 +491,27 @@ function Admin (_, $, c3, turf) {
     }
 
     function updateMarkerSeverity(label, severity) {
-       if (severity === 0) {
-            self.visibleMarkers[label] = [1];
-        } else if (severity === 1) {
-            self.visibleMarkers[label] = [2];
-        } else if (severity === 2) {
-            self.visibleMarkers[label] = [3];
-        } else if (severity === 3) {
-            self.visibleMarkers[label] = [4];
-        } else if (severity === 4) {
-            self.visibleMarkers[label] = [5];
-        } else if (severity === 5) {
-            self.visibleMarkers[label] = [1,2,3,4,5];
+        switch (severity) {
+            case 0: // Slider has value '1'
+                self.visibleMarkers[label] = [1];
+                break;
+            case 1: // Slider has value '2'
+                self.visibleMarkers[label] = [2];
+                break;
+            case 2: // Slider has value '3'
+                self.visibleMarkers[label] = [3];
+                break;
+            case 3: // Slider has value '4'
+                self.visibleMarkers[label] = [4];
+                break;
+            case 4: // Slider has value '5'
+                self.visibleMarkers[label] = [5];
+                break;
+            case 5: // Slider has value 'All'
+                self.visibleMarkers[label] = [1,2,3,4,5];
+                break;
+            default:
+                break;
         }
     }
 

--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -491,19 +491,17 @@ function Admin (_, $, c3, turf) {
     }
 
     function updateMarkerSeverity(label, severity) {
-        if (severity == 0) {
-            self.visibleMarkers[label] = [];
-        } else if (severity === 1) {
+       if (severity === 0) {
             self.visibleMarkers[label] = [1];
-        } else if (severity === 2) {
+        } else if (severity === 1) {
             self.visibleMarkers[label] = [2];
-        } else if (severity === 3) {
+        } else if (severity === 2) {
             self.visibleMarkers[label] = [3];
-        } else if (severity === 4) {
+        } else if (severity === 3) {
             self.visibleMarkers[label] = [4];
-        } else if (severity === 5) {
+        } else if (severity === 4) {
             self.visibleMarkers[label] = [5];
-        } else if (severity === 6) {
+        } else if (severity === 5) {
             self.visibleMarkers[label] = [1,2,3,4,5];
         }
     }

--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -2,7 +2,8 @@ function Admin (_, $, c3, turf) {
     var self = {};
     self.markerLayer = null;
     self.auditedStreetLayer = null;
-    self.visibleMarkers = ["CurbRamp", "NoCurbRamp", "Obstacle", "SurfaceProblem", "Occlusion", "NoSidewalk", "Other"];
+    self.visibleMarkers = {"CurbRamp" : [1,2,3,4,5], "NoCurbRamp" : [1,2,3,4,5], "Obstacle" : [1,2,3,4,5],
+        "SurfaceProblem" : [1,2,3,4,5], "Occlusion" : [1,2,3,4,5], "NoSidewalk" : [1,2,3,4,5], "Other" : [1,2,3,4,5]};
 
     L.mapbox.accessToken = 'pk.eyJ1Ijoia290YXJvaGFyYSIsImEiOiJDdmJnOW1FIn0.kJV65G6eNXs4ATjWCtkEmA';
 
@@ -466,7 +467,8 @@ function Admin (_, $, c3, turf) {
                     return L.circleMarker(latlng, style);
                 },
                 filter: function (feature, layer) {
-                    return ($.inArray(feature.properties.label_type, self.visibleMarkers) > -1);
+                    return ($.inArray(feature.properties.label_type, Object.keys(self.visibleMarkers)) > - 1
+                    && $.inArray(feature.properties.severity, self.visibleMarkers[feature.properties.label_type]) > -1);
 
                 },
                 onEachFeature: onEachLabelFeature
@@ -488,28 +490,46 @@ function Admin (_, $, c3, turf) {
         initializeSubmittedLabels(map);
     }
 
+    function updateMarkerSeverity(label, severity) {
+        if (severity == 0) {
+            self.visibleMarkers[label] = [];
+        } else if (severity === 1) {
+            self.visibleMarkers[label] = [1];
+        } else if (severity === 2) {
+            self.visibleMarkers[label] = [2];
+        } else if (severity === 3) {
+            self.visibleMarkers[label] = [3];
+        } else if (severity === 4) {
+            self.visibleMarkers[label] = [4];
+        } else if (severity === 5) {
+            self.visibleMarkers[label] = [5];
+        } else if (severity === 6) {
+            self.visibleMarkers[label] = [1,2,3,4,5];
+        }
+    }
+
     function updateVisibleMarkers() {
-        self.visibleMarkers = []
+        self.visibleMarkers = {}
         if (document.getElementById("curbramp").checked) {
-            self.visibleMarkers.push("CurbRamp");
+            updateMarkerSeverity("CurbRamp", $('#curb-ramp-slider').slider("option", "value"));
         }
         if (document.getElementById("missingcurbramp").checked) {
-            self.visibleMarkers.push("NoCurbRamp");
+            updateMarkerSeverity("NoCurbRamp", $('#missing-curb-ramp-slider').slider("option", "value"));
         }
         if (document.getElementById("obstacle").checked) {
-            self.visibleMarkers.push("Obstacle");
+            updateMarkerSeverity("Obstacle", $('#obstacle-slider').slider("option", "value"));
         }
         if (document.getElementById("surfaceprob").checked) {
-            self.visibleMarkers.push("SurfaceProblem");
+            updateMarkerSeverity("SurfaceProblem", $('#surface-problem-slider').slider("option", "value"));
         }
         if (document.getElementById("occlusion").checked) {
-            self.visibleMarkers.push("Occlusion");
+            updateMarkerSeverity("Occlusion", $('#occlusion-slider').slider("option", "value"));
         }
         if (document.getElementById("nosidewalk").checked) {
-            self.visibleMarkers.push("NoSidewalk");
+            updateMarkerSeverity("NoSidewalk", $('#no-sidewalk-slider').slider("option", "value"));
         }
         if (document.getElementById("other").checked) {
-            self.visibleMarkers.push("Other");
+            updateMarkerSeverity("Other", $('#other-slider').slider("option", "value"));
         }
 
 

--- a/public/stylesheets/admin.css
+++ b/public/stylesheets/admin.css
@@ -23,7 +23,7 @@
     position: absolute;
     background: rgba(255, 255, 255, 0.75);
     left: 30px;
-    width: 620px;
+    width: 420px;
     bottom: 15px;
     border: solid 1px #ccc;
 }

--- a/public/stylesheets/admin.css
+++ b/public/stylesheets/admin.css
@@ -23,7 +23,7 @@
     position: absolute;
     background: rgba(255, 255, 255, 0.75);
     left: 30px;
-    width: 220px;
+    width: 620px;
     bottom: 15px;
     border: solid 1px #ccc;
 }

--- a/public/stylesheets/admin.css
+++ b/public/stylesheets/admin.css
@@ -23,7 +23,7 @@
     position: absolute;
     background: rgba(255, 255, 255, 0.75);
     left: 30px;
-    width: 420px;
+    width: 400px;
     bottom: 15px;
     border: solid 1px #ccc;
 }


### PR DESCRIPTION
Resolves #386.
The JSON returned by  /adminapi/labels/all has been modified so that it contains information on severity. Slider bars have also been added next to all label types (excepted 'Audited Street') in order to allow additional filtering based on the severity of a specific label type.