### PR TITLE
Implements #516 - Adding a 'select all' checkbox to the admin map

### DIFF
--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -20,16 +20,17 @@
                     <div id="admin-map"></div>
                     <div id="map-label-legend">
                         <table class="table filter">
-                            <tr>
+                            <tr style="border-bottom: 1px solid; border-bottom-color: lightgray">
                                 <td></td>
-                                <td colspan="2" align="left" style="font-weight:bold">Label Type</td>
+                                <td colspan="1" align="left" style="font-weight:bold">Label Type</td>
+                                <td width="12px" align="center" ><input type="checkbox" id="check_all" checked="true" onclick="admin.toggleAll();"></td>
                                 <td colspan="2" align="left" style="font-weight:bold">Severity</td>
                             </tr>
                             <tr>
                                 <td id="map-legend-curb-ramp" width="12px"></td>
                                 <td width="190px">Curb Ramp</td>
                                 <td width="12px"  align="center"><input type="checkbox" value="displaylabel" id="curbramp" checked="true" onclick="admin.updateVisibleMarkers();"></td>
-                                <td width="126px"align="center"><div id = "curb-ramp-slider" style="margin-top:3px"></div></td>
+                                <td width="126px"align="center"><div id = "curb-ramp-slider" style="margin-top:4px"></div></td>
                                 <td width="60px" align= "center" ><span id="curb-ramp-severity-label">All</span></td>
 
                             </tr>

--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -550,6 +550,14 @@ function Admin (_, $, c3, turf) {
 
     }
 
+    // Toggles the state of the checkboxes for all the labels on the map
+    function toggleAll() {
+        var checked = document.getElementById("check_all").checked;
+        var checkBoxes = $("input[value=displaylabel]");
+        checkBoxes.prop('checked', checked);
+        updateVisibleMarkers();
+    }
+
 
     // A helper method to make an histogram of an array.
     function makeAHistogramArray(arrayOfNumbers, numberOfBins) {
@@ -591,5 +599,6 @@ function Admin (_, $, c3, turf) {
     self.clearAuditedStreetLayer = clearAuditedStreetLayer;
     self.redrawAuditedStreetLayer = redrawAuditedStreetLayer;
     self.updateVisibleMarkers = updateVisibleMarkers;
+    self.toggleAll = toggleAll;
     return self;
 }


### PR DESCRIPTION
Resolves #516.

Added in a checkbox that allows a user to easily select/deselect all the label types in the map legend.

<img src="http://drive.google.com/uc?export=view&id=0B687BEjGtgFVaTNYNHZpcml2Yzg"  />
