### PR TITLE
FAQ Column Widths

### DIFF
--- a/app/views/faq.scala.html
+++ b/app/views/faq.scala.html
@@ -258,8 +258,8 @@
                             <div class="panel panel-default">
                                 <table class="table table-striped table-condensed">
                                     <tr>
-                                        <th class="col-sm-2"></th>
-                                        <th class="col-sm-2">Key</th>
+                                        <th class="col-sm-3"></th>
+                                        <th class="col-sm-3.5">Key</th>
                                         <th>What it does</th>
                                     </tr>
                                     <tr>


### PR DESCRIPTION
I changed the column widths of the keys column to be slightly wider so it does not overlap when the page is reduced. It should not have any side-effects on other parts of the page.

Resolves <#617>