### PR TITLE
#617 FAQ Improved text spacing in the keyboard shortcuts table

### DIFF
--- a/app/views/faq.scala.html
+++ b/app/views/faq.scala.html
@@ -258,8 +258,8 @@
                             <div class="panel panel-default">
                                 <table class="table table-striped table-condensed">
                                     <tr>
-                                        <th class="col-sm-2"></th>
-                                        <th class="col-sm-2">Key</th>
+                                        <th class="col-sm-3"></th>
+                                        <th class="col-sm-3.5">Key</th>
                                         <th>What it does</th>
                                     </tr>
                                     <tr>


### PR DESCRIPTION
This change adds more space to the Key column of the FAQ Keyboard Shortcut table to prevent key overlapping. It does not have any side-effects to other parts of the application.

Resolves  #617