### PR TITLE
#627 Updated text that allows the user to select a neighborhood in the user dashboard

### DIFF
--- a/public/javascripts/Progress/build/Progress.js
+++ b/public/javascripts/Progress/build/Progress.js
@@ -109,9 +109,8 @@ function Progress (_, $, c3, L) {
         function onEachNeighborhoodFeature(feature, layer) {
 
             var regionId = feature.properties.region_id,
-                regionName = feature.properties.region_name,
                 url = "/audit/region/" + regionId,
-                popupContent = "Do you want to find accessibility problems in " + regionName + "? " + 
+                popupContent = "Do you want to explore this area to find accessibility issues? " + 
                     "<a href='" + url + "' class='region-selection-trigger' regionId='" + regionId + "'>Sure!</a>";
             layer.bindPopup(popupContent);
             layers.push(layer);

--- a/public/javascripts/Progress/build/Progress.js
+++ b/public/javascripts/Progress/build/Progress.js
@@ -109,8 +109,9 @@ function Progress (_, $, c3, L) {
         function onEachNeighborhoodFeature(feature, layer) {
 
             var regionId = feature.properties.region_id,
+                regionName = feature.properties.region_name,
                 url = "/audit/region/" + regionId,
-                popupContent = "Do you want to explore this area to find accessibility issues? " + 
+                popupContent = "Do you want to find accessibility problems in " + regionName + "? " + 
                     "<a href='" + url + "' class='region-selection-trigger' regionId='" + regionId + "'>Sure!</a>";
             layer.bindPopup(popupContent);
             layers.push(layer);

--- a/public/javascripts/Progress/build/Progress.js
+++ b/public/javascripts/Progress/build/Progress.js
@@ -109,8 +109,9 @@ function Progress (_, $, c3, L) {
         function onEachNeighborhoodFeature(feature, layer) {
 
             var regionId = feature.properties.region_id,
+                regionName = feature.properties.region_name,
                 url = "/audit/region/" + regionId,
-                popupContent = "Do you want to explore this area to find accessibility issues? " +
+                popupContent = "Do you want to find accessibility problems in " + regionName + "? " + 
                     "<a href='" + url + "' class='region-selection-trigger' regionId='" + regionId + "'>Sure!</a>";
             layer.bindPopup(popupContent);
             layers.push(layer);

--- a/public/javascripts/Progress/src/Progress.js
+++ b/public/javascripts/Progress/src/Progress.js
@@ -109,8 +109,9 @@ function Progress (_, $, c3, L) {
         function onEachNeighborhoodFeature(feature, layer) {
 
             var regionId = feature.properties.region_id,
+                regionName = feature.properties.region_name,
                 url = "/audit/region/" + regionId,
-                popupContent = "Do you want to explore this area to find accessibility issues? " +
+                popupContent = "Do you want to find accessibility problems in " + regionName + "? " + 
                     "<a href='" + url + "' class='region-selection-trigger' regionId='" + regionId + "'>Sure!</a>";
             layer.bindPopup(popupContent);
             layers.push(layer);


### PR DESCRIPTION
This change allows the user to actively see the Neighborhood names as they click on the respective regions. This does not have any side-effects on other parts of the application.

Resolves #627 