### PR TITLE
Resolves 550 - Cursor_ZoomOut.png not loading occasionally

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
+++ b/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
@@ -1431,7 +1431,7 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
     function setViewControlLayerCursor(type) {
         switch(type) {
             case 'ZoomOut':
-                uiMap.viewControlLayer.css("cursor", "url(" + svl.rootDirectory + "img/cursors/Cursor_ZoomOut.png) 4 4, move");
+                uiMap.viewControlLayer.css("cursor", "url(" + svl.rootDirectory + "img/cursors/ZoomOut.png) 4 4, move");
                 break;
             case 'OpenHand':
                 uiMap.viewControlLayer.css("cursor", "url(" + svl.rootDirectory + "img/cursors/openhand.cur) 4 4, move");


### PR DESCRIPTION
Resolves #550 : The file-not-found error used to occur when pressing Shift+Z and moving simultaneously. Replaced one instance of the filename 'Cursor_ZoomOut.png,' which does not exist, with 'ZoomOut.png.'