### PR TITLE
Fixes #498. Resets the label count after onboarding ends

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/onboarding/Onboarding.js
+++ b/public/javascripts/SVLabel/src/SVLabel/onboarding/Onboarding.js
@@ -268,6 +268,9 @@ function Onboarding (svl, actionStack, audioEffect, compass, form, handAnimation
         form.submit(data, task);
         uiOnboarding.background.css("visibility", "hidden");
 
+        //Reset the label counts to zero after the onboarding
+        svl.labelCounter.reset();
+
         $("#toolbar-onboarding-link").css("visibility", "visible");
 
         mapService.unlockDisableWalking();


### PR DESCRIPTION
Fixes #498. Added a line of code to reset the svl.labelCounter object in the _endTheOnboarding() function