### PR TITLE
679 tutorial gsv error

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import scalariform.formatter.preferences._
 
 name := """sidewalk-webpage"""
 
-version := "3.1.3"
+version := "3.1.4"
 
 scalaVersion := "2.10.4"
 

--- a/public/javascripts/SVLabel/src/SVLabel/onboarding/OnboardingStates.js
+++ b/public/javascripts/SVLabel/src/SVLabel/onboarding/OnboardingStates.js
@@ -1,7 +1,7 @@
 function OnboardingStates (compass, mapService, statusModel, tracker) {
     var numStates = 32;
     var panoId = "stxXyCKAbd73DmkM2vsIHA";
-    var afterWalkPanoId = "bdmGHJkiSgmO7_80SnbzXw";
+    var afterWalkPanoId = "stxXyCKAbd73DmkM2vsIHA";
     this.states = {
         "initialize": {
             "properties": {
@@ -770,8 +770,8 @@ function OnboardingStates (compass, mapService, statusModel, tracker) {
             "annotations": [
                 {
                     "type": "arrow",
-                    "x": 1300,
-                    "y": -650,
+                    "x": 730,
+                    "y": -690,
                     "length": 50,
                     "angle": 0,
                     "text": null,
@@ -790,8 +790,8 @@ function OnboardingStates (compass, mapService, statusModel, tracker) {
             "properties": {
                 "action": "LabelAccessibilityAttribute",
                 "labelType": "CurbRamp",
-                "imageX": 1492,
-                "imageY": -783,
+                "imageX": 700,
+                "imageY": -690,
                 "tolerance": 250
             },
             "message": {
@@ -803,8 +803,8 @@ function OnboardingStates (compass, mapService, statusModel, tracker) {
             "annotations": [
                 {
                     "type": "arrow",
-                    "x": 1300,
-                    "y": -650,
+                    "x": 730,
+                    "y": -690,
                     "length": 50,
                     "angle": 0,
                     "text": null,


### PR DESCRIPTION
Fixes #679. Uses (temporarily) the tutorial pano id as the id after walking.