### PR TITLE
Removed linksControl setting statements

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
+++ b/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
@@ -1210,7 +1210,6 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
         var $paths = $("#viewControlLayer").find('path');
         $paths.css('visibility', 'hidden');
         $paths.css('pointer-events', 'none');
-        svl.panorama.set('linksControl', false);
         // if (properties.browser === 'chrome') {
         //     // Somehow chrome does not allow me to select path
         //     // and fadeOut. Instead, I'm just manipulating path's style
@@ -1476,7 +1475,6 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
         if (!status.svLinkArrowsLoaded) {
             var numPath = uiMap.viewControlLayer.find("path").length;
             if (numPath === 0) {
-                svl.panorama.set('linksControl', true);
                 makeLinksClickable();
             } else {
                 status.svLinkArrowsLoaded = true;

--- a/public/javascripts/SVLabel/src/SVLabel/onboarding/Onboarding.js
+++ b/public/javascripts/SVLabel/src/SVLabel/onboarding/Onboarding.js
@@ -68,7 +68,7 @@ function Onboarding(svl, actionStack, audioEffect, compass, form, handAnimation,
         var canvas = uiOnboarding.canvas.get(0);
         if (canvas) ctx = canvas.getContext('2d');
         uiOnboarding.holder.css("visibility", "visible");
-
+        
         mapService.unlockDisableWalking();
         mapService.disableWalking();
         mapService.lockDisableWalking();


### PR DESCRIPTION
Fixing bug caused by a commit in PR #701. Navigation arrows don’t show up again when the label is applied.