### PR TITLE
Initial Instructions After Tutorial

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/Main.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Main.js
@@ -340,7 +340,7 @@ function Main (params) {
         }
 
         // Popup the message explaining the goal of the current mission
-        if (svl.missionContainer.isTheFirstMission()) {
+        if (svl.missionContainer.isTheFirstMission() || svl.missionContainer.onlyMissionOnboardingDone()) {
             var neighborhood = svl.neighborhoodContainer.getCurrentNeighborhood();
             svl.initialMissionInstruction = new InitialMissionInstruction(svl.compass, svl.map,
                 svl.neighborhoodContainer, svl.popUpMessage, svl.taskContainer, svl.labelContainer);

--- a/public/javascripts/SVLabel/src/SVLabel/Main.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Main.js
@@ -676,6 +676,7 @@ function Main (params) {
 
     self.getStatus = getStatus;
     self.setStatus = setStatus;
+    self.isAnAnonymousUser = isAnAnonymousUser;
 
     return self;
 }

--- a/public/javascripts/SVLabel/src/SVLabel/mission/MissionContainer.js
+++ b/public/javascripts/SVLabel/src/SVLabel/mission/MissionContainer.js
@@ -105,7 +105,7 @@ function MissionContainer (statusFieldMission, missionModel, taskModel) {
             if (missionIds.indexOf(mission.missionId) < 0) self._missionStoreByRegionId[regionId].push(mission);
         }
     };
-    this.onlyMissionOnboarding = function (){
+    this.onlyMissionOnboardingDone = function (){
        return self._completedMissions.length == 1 && self._completedMissions[0].getProperty("label") === "onboarding";
     };
 

--- a/public/javascripts/SVLabel/src/SVLabel/mission/MissionContainer.js
+++ b/public/javascripts/SVLabel/src/SVLabel/mission/MissionContainer.js
@@ -105,7 +105,9 @@ function MissionContainer (statusFieldMission, missionModel, taskModel) {
             if (missionIds.indexOf(mission.missionId) < 0) self._missionStoreByRegionId[regionId].push(mission);
         }
     };
-
+    this.onlyMissionOnboarding = function (){
+       return self._completedMissions.length == 1 && self._completedMissions[0].getProperty("label") === "onboarding";
+    };
 
     /** Get current mission */
     function getCurrentMission () {

--- a/public/javascripts/SVLabel/src/SVLabel/onboarding/Onboarding.js
+++ b/public/javascripts/SVLabel/src/SVLabel/onboarding/Onboarding.js
@@ -475,7 +475,15 @@ function Onboarding(svl, actionStack, audioEffect, compass, form, handAnimation,
         var mission = missions[0];
 
         missionContainer.setCurrentMission(mission);
-        modalMission.setMissionMessage(mission, neighborhood);
+        if (missionContainer.isTheFirstMission()) {
+            svl.initialMissionInstruction = new InitialMissionInstruction(svl.compass, svl.map,
+                svl.neighborhoodContainer, svl.popUpMessage, svl.taskContainer, svl.labelContainer);
+            modalMission.setMissionMessage(mission, neighborhood, null, function () {
+                svl.initialMissionInstruction.start(neighborhood);
+            });
+        }else{
+            modalMission.setMissionMessage(mission, neighborhood);
+        }
         modalMission.show();
 
         taskContainer.getFinishedAndInitNextTask();

--- a/public/javascripts/SVLabel/src/SVLabel/onboarding/Onboarding.js
+++ b/public/javascripts/SVLabel/src/SVLabel/onboarding/Onboarding.js
@@ -475,7 +475,7 @@ function Onboarding(svl, actionStack, audioEffect, compass, form, handAnimation,
         var mission = missions[0];
 
         missionContainer.setCurrentMission(mission);
-        if (missionContainer.isTheFirstMission() && user.getProperty("username") === "anonymous") {
+        if (missionContainer.onlyMissionOnboarding() || missionContainer.isTheFirstMission()) {
             svl.initialMissionInstruction = new InitialMissionInstruction(svl.compass, svl.map,
                 svl.neighborhoodContainer, svl.popUpMessage, svl.taskContainer, svl.labelContainer);
             modalMission.setMissionMessage(mission, neighborhood, null, function () {

--- a/public/javascripts/SVLabel/src/SVLabel/onboarding/Onboarding.js
+++ b/public/javascripts/SVLabel/src/SVLabel/onboarding/Onboarding.js
@@ -475,7 +475,7 @@ function Onboarding(svl, actionStack, audioEffect, compass, form, handAnimation,
         var mission = missions[0];
 
         missionContainer.setCurrentMission(mission);
-        if (missionContainer.onlyMissionOnboarding() || missionContainer.isTheFirstMission()) {
+        if (missionContainer.onlyMissionOnboardingDone() || missionContainer.isTheFirstMission()) {
             svl.initialMissionInstruction = new InitialMissionInstruction(svl.compass, svl.map,
                 svl.neighborhoodContainer, svl.popUpMessage, svl.taskContainer, svl.labelContainer);
             modalMission.setMissionMessage(mission, neighborhood, null, function () {

--- a/public/javascripts/SVLabel/src/SVLabel/onboarding/Onboarding.js
+++ b/public/javascripts/SVLabel/src/SVLabel/onboarding/Onboarding.js
@@ -475,7 +475,7 @@ function Onboarding(svl, actionStack, audioEffect, compass, form, handAnimation,
         var mission = missions[0];
 
         missionContainer.setCurrentMission(mission);
-        if (missionContainer.isTheFirstMission()) {
+        if (missionContainer.isTheFirstMission() && user.getProperty("username") === "anonymous") {
             svl.initialMissionInstruction = new InitialMissionInstruction(svl.compass, svl.map,
                 svl.neighborhoodContainer, svl.popUpMessage, svl.taskContainer, svl.labelContainer);
             modalMission.setMissionMessage(mission, neighborhood, null, function () {

--- a/public/javascripts/SVLabel/src/SVLabel/onboarding/OnboardingStates.js
+++ b/public/javascripts/SVLabel/src/SVLabel/onboarding/OnboardingStates.js
@@ -1442,7 +1442,7 @@ function OnboardingStates (compass, mapService, statusModel, tracker) {
             "panoId": afterWalkPanoId,
             "annotations": null,
             "transition": function () {
-                var completedRate = 35 / numStates;
+                var completedRate = 34 / numStates;
                 statusModel.setMissionCompletionRate(completedRate);
                 statusModel.setProgressBar(completedRate);
                 tracker.push('Onboarding_Transition', {onboardingTransition: "instruction-3"});


### PR DESCRIPTION
Resolves #730 by displaying mission instructions after user completes tutorial. The pop-ups only show at the start of the first mission.

This PR also partially resolves #700 by displaying the mission instructions after the user clicks "skip the tutorial" without previously completing a mission. 