### PR TITLE
"What we do with your lables" landing page text update

### DIFF
--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -236,7 +236,7 @@
             <div class="im-centered3">
                 <div class="row" style="width: 450px;">What we do with your labels</div>
                 <div class="row" id="content-text-4">
-                    <p>Your labels are used to improve city planning, build accessibility-aware mapping tools, and train machine learning algorithms to find accessibility issues automatically.</p>
+                    <p>Your labels are used to improve city planning, build accessibility-aware mapping tools, and train machine learning algorithms to automatically find accessibility issues.</p>
                 </div>
                 <br>
                 <img id="mlgif" src="@routes.Assets.at("assets/MLGraphic.gif")" >

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -236,7 +236,7 @@
             <div class="im-centered3">
                 <div class="row" style="width: 450px;">What we do with your labels</div>
                 <div class="row" id="content-text-4">
-                    <p>Your contributions help train machine learning algorithms to identify accessibility issues automatically.</p>
+                    <p>Your labels are used to improve city planning, build accessibility-aware mapping tools, and train machine learning algorithms to find accessibility issues automatically.</p>
                 </div>
                 <br>
                 <img id="mlgif" src="@routes.Assets.at("assets/MLGraphic.gif")" >


### PR DESCRIPTION
Text has been changed from:
"Your contributions help train machine learning algorithms to identify accessibility issues automatically"
to:
"Your labels are used to improve city planning, build accessibility-aware mapping tools, and train machine learning algorithms to automatically find accessibility issues."

In order to be more in line with the graphic that it is associated with.

Before and after in image form:
![image](https://user-images.githubusercontent.com/1621749/27351806-9014299a-55cc-11e7-82a9-775ea7fc5979.png)
![what-we-do-after](https://user-images.githubusercontent.com/6518824/27436768-446e4b70-572e-11e7-9a81-42510084203d.png)

Resolves #720 