### PR TITLE
Adds zoom slider to choropleth on landing page

### DIFF
--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -335,6 +335,8 @@
 
 <script src='https://api.mapbox.com/mapbox.js/v3.1.1/mapbox.js'></script>
 <link href='https://api.mapbox.com/mapbox.js/v3.1.1/mapbox.css' rel='stylesheet' />
+<script src='https://api.mapbox.com/mapbox.js/plugins/leaflet-zoomslider/v0.7.0/L.Control.Zoomslider.js'></script>
+<link href='https://api.mapbox.com/mapbox.js/plugins/leaflet-zoomslider/v0.7.0/L.Control.Zoomslider.css' rel='stylesheet' />
 <script type="text/javascript" src='@routes.Assets.at("javascripts/lib/turf.min.js")'></script>
 <link href='@routes.Assets.at("stylesheets/choropleth.css")' rel="stylesheet"/>
 <script type="text/javascript" src='@routes.Assets.at("javascripts/Choropleth.js")'></script>

--- a/public/javascripts/Choropleth.js
+++ b/public/javascripts/Choropleth.js
@@ -22,6 +22,7 @@ function Choropleth(_, $, turf) {
         maxBounds: bounds,
         maxZoom: 19,
         minZoom: 9,
+        zoomControl: false,
         legendControl: {
             position: 'bottomleft'
         }
@@ -31,6 +32,8 @@ function Choropleth(_, $, turf) {
     choropleth.scrollWheelZoom.disable();
 
     L.mapbox.styleLayer('mapbox://styles/mapbox/light-v9').addTo(choropleth);
+
+    L.control.zoomslider().addTo(choropleth);
 
 
     /**

--- a/public/stylesheets/choropleth.css
+++ b/public/stylesheets/choropleth.css
@@ -13,3 +13,11 @@
     font-size:8px;
     color:#808080;
 }
+
+/* Adjustments to account for mapbox.css box-sizing rules */
+.leaflet-control-zoomslider-knob { width:14px; height:6px; }
+.leaflet-container .leaflet-control-zoomslider-body {
+    -webkit-box-sizing:content-box;
+    -moz-box-sizing:content-box;
+    box-sizing:content-box;
+}


### PR DESCRIPTION
Old look:
![full-choropleth-10lvls](https://user-images.githubusercontent.com/6518824/27269013-6adc343e-5481-11e7-9fc1-a6d97fe0560e.png)

New look:
![zoom-slider](https://user-images.githubusercontent.com/6518824/27454680-c2ae5572-5768-11e7-866c-95edc4b9b66f.png)

This zoom slider is more prominent, making zooming more obvious. This is important since mouse wheel zooming is disabled on the choropleth on the landing page.

Resolves #725 #723 