### PR TITLE
Increases legend size of landing page choropleth

### DIFF
--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -155,7 +155,7 @@
         <br>
         <div id="map-holder">
             <div id="legend" style="display:none;">
-                <strong>Percent of Neighborhood Complete</strong>
+                <strong style="font-size: 18px">Percent of Neighborhood Complete</strong>
                 <nav class='legend clearfix'>
                     <span style='background:#08306b;'></span>
                     <span style='background:#08519c;'></span>

--- a/public/stylesheets/choropleth.css
+++ b/public/stylesheets/choropleth.css
@@ -10,6 +10,13 @@
     height:15px;
     width:10%;
     text-align:left;
-    font-size:8px;
+    font-size:16px;
     color:#808080;
+}
+
+.map-legends.wax-legends {
+    right: 0px;
+    top: 0px;
+    width: 350px;
+    max-width: 500px;
 }


### PR DESCRIPTION
The legend size has been significantly increased...
Before:
![legendsize-before](https://user-images.githubusercontent.com/6518824/27486243-fc9c096a-57fd-11e7-969e-f3ed8fe7d0c8.png)

After:
![legendsize-after](https://user-images.githubusercontent.com/6518824/27486252-023204f6-57fe-11e7-9394-62b9b27334a4.png)

I don't think that we should make it much larger than this to avoid taking up too much space on small screens.

Partially addresses: #723 