### PR TITLE
'Click here' on choropleth and user dashboard maps now logged

### DIFF
--- a/app/controllers/UserController.scala
+++ b/app/controllers/UserController.scala
@@ -76,6 +76,8 @@ class UserController @Inject() (implicit val env: Environment[User, SessionAuthe
     }
   }
 
+
+  // Post function that receives a String and saves it into WebpageActivityTable with userId, ipAddress, timestamp
   def postSelfAssign = UserAwareAction.async(BodyParsers.parse.json) { implicit request =>
     // Validation https://www.playframework.com/documentation/2.3.x/ScalaJson
     val submission = request.body.validate[String]

--- a/app/controllers/UserController.scala
+++ b/app/controllers/UserController.scala
@@ -1,5 +1,6 @@
 package controllers
 
+import java.sql.Timestamp
 import javax.inject.Inject
 
 import com.mohiva.play.silhouette.api.{Environment, LogoutEvent, Silhouette}
@@ -7,11 +8,11 @@ import com.mohiva.play.silhouette.impl.authenticators.SessionAuthenticator
 import controllers.headers.ProvidesHeader
 import formats.json.UserFormats._
 import forms._
-import models.user.User
-
-import play.api.libs.json.Json
-import play.api.mvc.{BodyParsers, Result, RequestHeader}
-
+import models.user._
+import models.daos.slick.DBTableDefinitions.{DBUser, UserTable}
+import play.api.mvc.{BodyParsers, RequestHeader, Result}
+import play.api.libs.json._
+import org.joda.time.{DateTime, DateTimeZone}
 import scala.concurrent.Future
 
 /**
@@ -73,5 +74,30 @@ class UserController @Inject() (implicit val env: Environment[User, SessionAuthe
       case Some(user) => Future.successful(Ok(s"Hello $username!"))
       case None => Future.successful(Redirect("/"))
     }
+  }
+
+  def postSelfAssign = UserAwareAction.async(BodyParsers.parse.json) { implicit request =>
+    // Validation https://www.playframework.com/documentation/2.3.x/ScalaJson
+    val submission = request.body.validate[String]
+    val anonymousUser: DBUser = UserTable.find("anonymous").get
+
+    submission.fold(
+      errors => {
+        Future.successful(BadRequest(Json.obj("status" -> "Error", "message" -> JsError.toFlatJson(errors))))
+      },
+      submission => {
+        val now = new DateTime(DateTimeZone.UTC)
+        val timestamp: Timestamp = new Timestamp(now.getMillis)
+        val ipAddress: String = request.remoteAddress
+        request.identity match {
+          case Some(user) =>
+            WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, submission, timestamp))
+          case None =>
+            WebpageActivityTable.save(WebpageActivity(0, anonymousUser.userId.toString, ipAddress, submission, timestamp))
+        }
+
+        Future.successful(Ok(Json.obj()))
+      }
+    )
   }
 }

--- a/conf/routes
+++ b/conf/routes
@@ -83,6 +83,8 @@ GET     /contribution/auditInteractions         @controllers.UserProfileControll
 GET     /contribution/previousAudit             @controllers.UserProfileController.previousAudit
 GET     /contribution/:username                 @controllers.UserProfileController.userProfile(username: String)
 
+POST    /userapi/selfAssign                     @controllers.UserController.postSelfAssign
+
 # Geometry API
 
 # Access Feature and Access Score APIs

--- a/public/javascripts/Choropleth.js
+++ b/public/javascripts/Choropleth.js
@@ -155,6 +155,44 @@ function Choropleth(_, $, turf) {
             })
                 .addTo(map);
         });
+
+        $("#choropleth").on('click', '.region-selection-trigger', function () {
+            var regionId = $(this).attr('regionId');
+            var ratesEl = rates.find(function(x){
+                return regionId == x.region_id;
+            })
+            var compRate = Math.round(100.0 * ratesEl.rate);
+            var milesLeft = Math.round(0.000621371 * (ratesEl.total_distance_m - ratesEl.completed_distance_m));
+            var distanceLeft = "";
+            if(compRate === 100){
+                distanceLeft = "0";
+            }
+            else if(milesLeft === 0){
+                distanceLeft = "<1";
+            }
+            else if(milesLeft === 1){
+                distanceLeft = "1";
+            }
+            else{
+                distanceLeft = ">1";
+            }
+            var url = "/userapi/selfAssign";
+            var async = true;
+            var data = "SelfAssign_Region"+regionId+"_"+distanceLeft+"MilesLeft";
+            $.ajax({
+                async: async,
+                contentType: 'application/json; charset=utf-8',
+                url: url,
+                type: 'post',
+                data: JSON.stringify(data),
+                dataType: 'json',
+                success: function (result) {
+                },
+                error: function (result) {
+                    console.error(result);
+                }
+            });
+        });
     }
 
 

--- a/public/javascripts/Choropleth.js
+++ b/public/javascripts/Choropleth.js
@@ -156,6 +156,11 @@ function Choropleth(_, $, turf) {
                 .addTo(map);
         });
 
+
+        // When a region is selected and 'Click here' is clicked, this function runs
+        // Sends String to be logged in WebpageActivityTable of the form
+        // SelfAssign_Region<regionId>_<distanceLeft>MilesLeft
+        // where distanceLeft is 0, <1, 1 or >1
         $("#choropleth").on('click', '.region-selection-trigger', function () {
             var regionId = $(this).attr('regionId');
             var ratesEl = rates.find(function(x){

--- a/public/javascripts/Progress/build/Progress.js
+++ b/public/javascripts/Progress/build/Progress.js
@@ -113,7 +113,9 @@ function Progress (_, $, c3, L) {
                 url = "/audit/region/" + regionId,
                 // default popup content if we don't find neighborhood in list of neighborhoods from query
                 popupContent = "Do you want to find accessibility problems in " + regionName + "? " + 
-                    "<a href='" + url + "' class='region-selection-trigger' regionId='" + regionId + "'>Sure!</a>";
+                    "<a href='" + url + "' class='region-selection-trigger' regionId='" + regionId + "'>Sure!</a>",
+                compRate = 0,
+                milesLeft = 0;
             for (var i = 0; i < rates.length; i++) {
                 if (rates[i].region_id === feature.properties.region_id) {
                     compRate = Math.round(100.0 * rates[i].rate);
@@ -168,6 +170,7 @@ function Progress (_, $, c3, L) {
                 map.setView(latlng, zoom, { animate: true });
                 currentLayer = this;
             });
+
         }
 
         $.getJSON("/neighborhoods", function (data) {
@@ -190,6 +193,43 @@ function Progress (_, $, c3, L) {
 //        var regionId = $(this).attr('regionid');
 //        console.log(regionId)
 //    });
+        $("#map").on('click', '.region-selection-trigger', function () {
+            var regionId = $(this).attr('regionId');
+            var ratesEl = rates.find(function(x){
+                return regionId == x.region_id;
+            })
+            var compRate = Math.round(100.0 * ratesEl.rate);
+            var milesLeft = Math.round(0.000621371 * (ratesEl.total_distance_m - ratesEl.completed_distance_m));
+            var distanceLeft = "";
+            if(compRate === 100){
+                distanceLeft = "0";
+            }
+            else if(milesLeft === 0){
+                distanceLeft = "<1";
+            }
+            else if(milesLeft === 1){
+                distanceLeft = "1";
+            }
+            else{
+                distanceLeft = ">1";
+            }
+            var url = "/userapi/selfAssign";
+            var async = true;
+            var data = "SelfAssign_Region"+regionId+"_"+distanceLeft+"MilesLeft";
+            $.ajax({
+                async: async,
+                contentType: 'application/json; charset=utf-8',
+                url: url,
+                type: 'post',
+                data: JSON.stringify(data),
+                dataType: 'json',
+                success: function (result) {
+                },
+                error: function (result) {
+                    console.error(result);
+                }
+            });
+        });
     }
 
     /**

--- a/public/javascripts/Progress/src/Progress.js
+++ b/public/javascripts/Progress/src/Progress.js
@@ -186,13 +186,12 @@ function Progress (_, $, c3, L) {
             completedInitializingNeighborhoodPolygons = true;
             handleInitializationComplete(map);
         });
+        
 
-        // Catch click even in popups
-        // https://www.mapbox.com/mapbox.js/example/v1.0.0/clicks-in-popups/
-//    $("#map").on('click', '.region-selection-trigger', function () {
-//        var regionId = $(this).attr('regionid');
-//        console.log(regionId)
-//    });
+        // When a region is selected and 'Click here' is clicked, this function runs
+        // Sends String to be logged in WebpageActivityTable of the form
+        // SelfAssign_Region<regionId>_<distanceLeft>MilesLeft
+        // where distanceLeft is 0, <1, 1 or >1
         $("#map").on('click', '.region-selection-trigger', function () {
             var regionId = $(this).attr('regionId');
             var ratesEl = rates.find(function(x){

--- a/public/javascripts/Progress/src/Progress.js
+++ b/public/javascripts/Progress/src/Progress.js
@@ -113,7 +113,9 @@ function Progress (_, $, c3, L) {
                 url = "/audit/region/" + regionId,
                 // default popup content if we don't find neighborhood in list of neighborhoods from query
                 popupContent = "Do you want to find accessibility problems in " + regionName + "? " + 
-                    "<a href='" + url + "' class='region-selection-trigger' regionId='" + regionId + "'>Sure!</a>";
+                    "<a href='" + url + "' class='region-selection-trigger' regionId='" + regionId + "'>Sure!</a>",
+                compRate = 0,
+                milesLeft = 0;
             for (var i = 0; i < rates.length; i++) {
                 if (rates[i].region_id === feature.properties.region_id) {
                     compRate = Math.round(100.0 * rates[i].rate);
@@ -168,6 +170,7 @@ function Progress (_, $, c3, L) {
                 map.setView(latlng, zoom, { animate: true });
                 currentLayer = this;
             });
+
         }
 
         $.getJSON("/neighborhoods", function (data) {
@@ -190,6 +193,43 @@ function Progress (_, $, c3, L) {
 //        var regionId = $(this).attr('regionid');
 //        console.log(regionId)
 //    });
+        $("#map").on('click', '.region-selection-trigger', function () {
+            var regionId = $(this).attr('regionId');
+            var ratesEl = rates.find(function(x){
+                return regionId == x.region_id;
+            })
+            var compRate = Math.round(100.0 * ratesEl.rate);
+            var milesLeft = Math.round(0.000621371 * (ratesEl.total_distance_m - ratesEl.completed_distance_m));
+            var distanceLeft = "";
+            if(compRate === 100){
+                distanceLeft = "0";
+            }
+            else if(milesLeft === 0){
+                distanceLeft = "<1";
+            }
+            else if(milesLeft === 1){
+                distanceLeft = "1";
+            }
+            else{
+                distanceLeft = ">1";
+            }
+            var url = "/userapi/selfAssign";
+            var async = true;
+            var data = "SelfAssign_Region"+regionId+"_"+distanceLeft+"MilesLeft";
+            $.ajax({
+                async: async,
+                contentType: 'application/json; charset=utf-8',
+                url: url,
+                type: 'post',
+                data: JSON.stringify(data),
+                dataType: 'json',
+                success: function (result) {
+                },
+                error: function (result) {
+                    console.error(result);
+                }
+            });
+        });
     }
 
     /**


### PR DESCRIPTION
Resolves #464 , now when the links in the bubbles from the choropleth or user dashboard map are clicked, it's logged in `webpage_activity` so the `activity` reads `SelfAssign_Region<RegionId>_<DistanceLeft>MilesLeft`, where the distance left is either 0, <1, 1 or >1.

![image](https://user-images.githubusercontent.com/13080218/27489623-2dd83304-5809-11e7-849d-2bb19fd6a10e.png)


Related to PR #742 