### PR TITLE
Fixes non-existent path in gitignore to a path that does

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,7 +94,7 @@ node_modules
 public/javascripts/SVLabel/build/*
 public/javascripts/Admin/build/*
 public/javascripts/FAQ/build/*
-public/javascripts/Admin/Progress/*
+public/javascripts/Progress/build/*
 download
 
 public/javascripts/SVLabel/build/SVLabel.js


### PR DESCRIPTION
Resolves #760 , removed non-existent path, added path that does exist and needed to be gitignored (`public/javascripts/Progress/build/*`)