### PR TITLE
#759 Open FAQ in New Tab

### DIFF
--- a/app/views/navbar.scala.html
+++ b/app/views/navbar.scala.html
@@ -46,7 +46,7 @@
                         <a href="#" id="toolbar-onboarding-link">Retake tutorial</a>
                     </li>
                     <li class = "navbarLink">
-                      <a href='@routes.ApplicationController.faq' id="toolbar-onboarding-link">FAQ</a>
+                      <a href='@routes.ApplicationController.faq' id="toolbar-onboarding-link" target="_blank">FAQ</a>
                     </li>
 
                 }


### PR DESCRIPTION
The new FAQ link will now open in a separate tab from the audit page

![image](https://user-images.githubusercontent.com/19720010/27541856-835726ae-5a53-11e7-8032-206490f5d279.png)


Resolves #759 