### PR TITLE
Log choropleth neighborhood clicks

### DIFF
--- a/app/controllers/UserController.scala
+++ b/app/controllers/UserController.scala
@@ -78,7 +78,7 @@ class UserController @Inject() (implicit val env: Environment[User, SessionAuthe
 
 
   // Post function that receives a String and saves it into WebpageActivityTable with userId, ipAddress, timestamp
-  def postSelfAssign = UserAwareAction.async(BodyParsers.parse.json) { implicit request =>
+  def logWebpageActivity = UserAwareAction.async(BodyParsers.parse.json) { implicit request =>
     // Validation https://www.playframework.com/documentation/2.3.x/ScalaJson
     val submission = request.body.validate[String]
     val anonymousUser: DBUser = UserTable.find("anonymous").get

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -255,7 +255,7 @@
             <div class="row" style="padding-top: 40px;">
                 <div class="col-sm-6">
                     <div class="quotebox">
-                        Using machine learning, big data, & civic kindness, <a href="https://twitter.com/umd_sidewalk" target="_blank">@@umd_sidewalk</a> is making D.C. more accessible one mile at a time
+                        Using machine learning, big data, & civic kindness, <a href="https://twitter.com/umd_sidewalk" target="_blank" id="microsoftdesign-author-twitter">@@umd_sidewalk</a> is making D.C. more accessible one mile at a time
                         <br>
                         <span class="quoteauthor">@@microsoftdesign</span>
 
@@ -264,7 +264,7 @@
                 </div>
                 <div class="col-sm-6">
                     <div class="quotebox">
-                        <a href="https://twitter.com/umd_sidewalk" target="_blank">@@umd_sidewalk</a> is mapping accessibility in DC. Looks like C St NE and Oklahoma Ave need work!
+                        <a href="https://twitter.com/umd_sidewalk" target="_blank" id="kpkindc-author-twitter">@@umd_sidewalk</a> is mapping accessibility in DC. Looks like C St NE and Oklahoma Ave need work!
                         <br>
                         <span class="quoteauthor">@@kpkindc</span>
                     </div>

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -289,18 +289,18 @@
             vertical-align: middle;
         ">
             <div class="col-sm-4">
-                <a class="newslink" href="http://technical.ly/dc/2016/11/30/project-sidewalk-accessibility/">
+                <a class="newslink" href="http://technical.ly/dc/2016/11/30/project-sidewalk-accessibility/" id="technically-img-link">
                     <img src='@routes.Assets.at("assets/technically.png")' height="70" alt="Technically Logo">
                 </a>
             </div>
             <div class="col-sm-4">
-                <a class="newslink" href="http://dc.curbed.com/2017/2/20/14669990/project-sidewalk">
+                <a class="newslink" href="http://dc.curbed.com/2017/2/20/14669990/project-sidewalk" id="curbed-img-link">
                     <img style="position: relative; left:10px; top: -30px;" src='@routes.Assets.at("assets/curbed.jpg")' height="100" alt="Curbed DC Logo">
 
                 </a>
             </div>
             <div class="col-sm-4">
-                <a class="newslink" href="http://www.dbknews.com/2016/10/14/university-of-maryland-app-washington-disability-access/">
+                <a class="newslink" href="http://www.dbknews.com/2016/10/14/university-of-maryland-app-washington-disability-access/" id="diamondback-img-link">
                     <img src='@routes.Assets.at("assets/diamondback.png")' height="70" alt="Diamondback Logo">
                 </a>
             </div>
@@ -310,20 +310,20 @@
             text-align: center;
         ">
             <div class="col-sm-4">
-                <a class="newslink" href="http://technical.ly/dc/2016/11/30/project-sidewalk-accessibility/">
+                <a class="newslink" href="http://technical.ly/dc/2016/11/30/project-sidewalk-accessibility/" id="technically-text-link">
 
                     How Project Sidewalk is making DC more accessible
                 </a>
             </div>
             <div class="col-sm-4">
-                <a class="newslink" href="http://dc.curbed.com/2017/2/20/14669990/project-sidewalk">
+                <a class="newslink" href="http://dc.curbed.com/2017/2/20/14669990/project-sidewalk" id="curbed-text-link">
 
                     Make D.C.'s sidewalks more accessible with this crowd-sourced map
 
                 </a>
             </div>
             <div class="col-sm-4">
-                <a class="newslink" href="http://www.dbknews.com/2016/10/14/university-of-maryland-app-washington-disability-access/">
+                <a class="newslink" href="http://www.dbknews.com/2016/10/14/university-of-maryland-app-washington-disability-access/" id="diamondback-text-link">
 
                     A UMD team made an app highlighting D.C. areas inaccessible to people with disabilities
                 </a>

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -65,19 +65,19 @@
             <div class="col-sm-4 footerlink">
                 <span class="footerheader">PROJECT SIDEWALK</span><br/>
                 <!-- Back to top<br>-->
-                <a href='@routes.ApplicationController.about'>About Us</a> <br/>
-                <a href='@routes.ApplicationController.terms'>Terms of Use</a> <br/>
-                <a href='@routes.ApplicationController.faq'>FAQ</a> <br/>
+                <a href='@routes.ApplicationController.about' id="sidewalk-about-link">About Us</a> <br/>
+                <a href='@routes.ApplicationController.terms' id="sidewalk-terms-link">Terms of Use</a> <br/>
+                <a href='@routes.ApplicationController.faq' id="sidewalk-faq-link">FAQ</a> <br/>
             </div>
             <div class="col-sm-4 footerlink">
                 <span class="footerheader">DEVELOPER</span><br/>
-                <a href='@routes.ApplicationController.developer'>Sidewalk API </a><br/>
+                <a href='@routes.ApplicationController.developer' id="developer-api-link">Sidewalk API </a><br/>
             </div>
             <div class="col-sm-4 footerlink">
                 <span class="footerheader">CONNECT</span><br/>
-                <a target="_blank" href="https://github.com/ProjectSidewalk/SidewalkWebpage"><img width="15" src='@routes.Assets.at("assets/github_logo.png")'>&nbsp;Github</a> <br/>
-                <a target="_blank" href="https://twitter.com/umd_sidewalk"><img width="15" src='@routes.Assets.at("assets/twitter_logo.png")'>&nbsp;Twitter</a><br/>
-                <a target="_blank" href="mailto:sidewalk@@umiacs.umd.edu"><img width="15" src='@routes.Assets.at("assets/email.png")'>&nbsp;Email Us</a><br/>
+                <a target="_blank" href="https://github.com/ProjectSidewalk/SidewalkWebpage" id="connect-github-link"><img width="15" src='@routes.Assets.at("assets/github_logo.png")'>&nbsp;Github</a> <br/>
+                <a target="_blank" href="https://twitter.com/umd_sidewalk" id="connect-twitter-link"><img width="15" src='@routes.Assets.at("assets/twitter_logo.png")'>&nbsp;Twitter</a><br/>
+                <a target="_blank" href="mailto:sidewalk@@umiacs.umd.edu" id="connect-email-link"><img width="15" src='@routes.Assets.at("assets/email.png")'>&nbsp;Email Us</a><br/>
             </div>
         </div>
     </div>
@@ -87,12 +87,12 @@
         <div class="row" style="max-width: 340px; margin: 0 auto;">
 
             <div class="col-sm-6">
-                <a href="https://www.nsf.gov/awardsearch/showAward?AWD_ID=1302338">
+                <a href="https://www.nsf.gov/awardsearch/showAward?AWD_ID=1302338" id="nsf-link">
                     <img src="@routes.Assets.at("assets/nsf.png")">
                 </a>
             </div>
             <div class="col-sm-6">
-                <a href="http://www.google.com/"><img src="@routes.Assets.at("assets/google.png")" style="margin-top:20px;"></a>
+                <a href="http://www.google.com/" id="google-link"><img src="@routes.Assets.at("assets/google.png")" style="margin-top:20px;"></a>
             </div>
 
         </div>
@@ -108,8 +108,8 @@
         </div>
 
         Project Sidewalk is designed and operated by the
-        <a href="https://makeabilitylab.umiacs.umd.edu/">Makeability Lab</a> at the
-        <a href="http://www.umd.edu/">University of Maryland</a><br>
+        <a href="https://makeabilitylab.umiacs.umd.edu/" id="makeability-link">Makeability Lab</a> at the
+        <a href="http://www.umd.edu/" id="umd-link">University of Maryland</a><br>
         <span id="application-version"></span>
     </div>
     <script>
@@ -121,6 +121,62 @@
             ga('create', 'UA-76528208-1', 'auto');
             ga('send', 'pageview');
 
+
+            // Log clicks on links in the footer to WebpageActivityTable
+            // Depending on column, form of log varies by the following:
+            // Column is 'Project Sidewalk' or "Developer'
+            //    log is of form: "Click_module=Footer_section=<"sidewalk" or "developer">_target=<link>"
+            // Column is 'Connect'
+            //    log is of form: "Click_module=Footer_section=connect_platform=<"github", "twitter", or "email">"
+            $("#footer-container").on('click', 'a', function(e){
+                var id = e.currentTarget.id.split("-");
+                var column = id[0];
+                var link = id[1];
+
+                var activity = "Click_module=Footer_section="+column+"_";
+                if(column === "sidewalk" || column === "developer"){
+                    activity = activity+"target="+link;
+                }
+                else{
+                    activity = activity+"platform="+link;
+                }
+
+                var url = "/userapi/logWebpageActivity";
+                var async = true;
+                $.ajax({
+                    async: async,
+                    contentType: 'application/json; charset=utf-8',
+                    url: url,
+                    type: 'post',
+                    data: JSON.stringify(activity),
+                    dataType: 'json',
+                    success: function(result){},
+                    error: function (result) {
+                        console.error(result);
+                    }
+                });
+            });
+
+            // Log clicks on links in the information footer to WebpageActivityTable
+            // Log is of form: "Click_module=InfoFooter_target=<link>"
+            $('#info-footer').on('click', function(e){
+                var link = e.currentTarget.id.split("-")[0];
+                var activity = "Click_module=InfoFooter_"+"target="+link;
+                var url = "/userapi/logWebpageActivity";
+                var async = true;
+                $.ajax({
+                    async: async,
+                    contentType: 'application/json; charset=utf-8',
+                    url: url,
+                    type: 'post',
+                    data: JSON.stringify(activity),
+                    dataType: 'json',
+                    success: function(result){},
+                    error: function (result) {
+                        console.error(result);
+                    }
+                });
+            });
     </script>
 </body>
 

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -159,7 +159,7 @@
 
             // Log clicks on links in the information footer to WebpageActivityTable
             // Log is of form: "Click_module=InfoFooter_target=<link>"
-            $('#info-footer').on('click', function(e){
+            $('#info-footer').on('click','a', function(e){
                 var link = e.currentTarget.id.split("-")[0];
                 var activity = "Click_module=InfoFooter_"+"target="+link;
                 var url = "/userapi/logWebpageActivity";

--- a/app/views/navbar.scala.html
+++ b/app/views/navbar.scala.html
@@ -98,6 +98,25 @@
                     $("#sign-up-modal").addClass("hidden");
                     $("#sign-in-modal").removeClass("hidden");
                 });
+
+                // Log if user /clicks/ on sign-in button, but not necessarily signs in
+                $("#sign-in-button").on('click', function(){
+                    var url = "/userapi/logWebpageActivity";
+                    var async = true;
+                    var activity = "Click_SignIn";
+                    $.ajax({
+                        async: async,
+                        contentType: 'application/json; charset=utf-8',
+                        url: url,
+                        type: 'post',
+                        data: JSON.stringify(activity),
+                        dataType: 'json',
+                        success: function(result){},
+                        error: function (result) {
+                            console.error(result);
+                        }
+                    });
+                });
             });
     </script>
     <div class="modal fade" id="sign-in-modal-container" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">

--- a/app/views/navbar.scala.html
+++ b/app/views/navbar.scala.html
@@ -103,7 +103,7 @@
                 $("#sign-in-button").on('click', function(){
                     var url = "/userapi/logWebpageActivity";
                     var async = true;
-                    var activity = "Click_SignIn";
+                    var activity = "Click_module=SignIn";
                     $.ajax({
                         async: async,
                         contentType: 'application/json; charset=utf-8',

--- a/conf/routes
+++ b/conf/routes
@@ -83,7 +83,7 @@ GET     /contribution/auditInteractions         @controllers.UserProfileControll
 GET     /contribution/previousAudit             @controllers.UserProfileController.previousAudit
 GET     /contribution/:username                 @controllers.UserProfileController.userProfile(username: String)
 
-POST    /userapi/selfAssign                     @controllers.UserController.postSelfAssign
+POST    /userapi/logWebpageActivity             @controllers.UserController.logWebpageActivity
 
 # Geometry API
 

--- a/public/assets/homepage.js
+++ b/public/assets/homepage.js
@@ -158,18 +158,26 @@ $( document ).ready(function() {
 
 
     // Triggered when "Watch Now" or the arrow next to it is clicked
-    // Logs "Click_WatchNow" in WebpageActivityTable
+    // Logs "Click_module=WatchNow" in WebpageActivityTable
     $("#playlink").on('click', function(e){
         if(e.target.innerText === "Watch Now"){
-            logWebpageActivity("Click_WatchNow");
+            logWebpageActivity("Click_module=WatchNow");
         }
     });
 
     // Triggered upon clicking tabs in "How you can help" section
-    // Logs "Click_HowYouCanHelp_Tab<tabNumber>" in WebpageActivityTable
+    // Logs "Click_module=HowYouCanHelp_tab=<tabNumber>" in WebpageActivityTable
     $("#numbersrow").on('click','.col-sm-4', function(e){
         // Gets tab number as a string (i.e. "1", "2", or "3")
         var id = e.target.innerText.charAt(1);
-        logWebpageActivity("Click_HowYouCanHelp_Tab"+id);
+        logWebpageActivity("Click_module=HowYouCanHelp_tab="+id);
+    });
+
+    // Triggered when links in Press section are clicked
+    // Logs "Click_module=Press_type=<"img" or "text">_source=<"technically," "curbed," or "diamondback">"
+    $("#press-container2").on('click', '.newslink', function(e){
+        var type = e.currentTarget.id.split('-')[1];
+        var source = e.currentTarget.id.split('-')[0];
+        logWebpageActivity("Click_module=Press_type="+type+"_source="+source);
     });
 });

--- a/public/assets/homepage.js
+++ b/public/assets/homepage.js
@@ -180,4 +180,11 @@ $( document ).ready(function() {
         var source = e.currentTarget.id.split('-')[0];
         logWebpageActivity("Click_module=Press_type="+type+"_source="+source);
     });
+
+    // Triggered when twitter links are clicked
+    // Logs "Click_module=Quotes_author=<"microsoftdesign" or "kpkindc">"
+    $("#quotebox-container").on('click', 'a', function(e){
+        var author = e.currentTarget.id.split('-')[0];
+        logWebpageActivity("Click_module=Quotes_author="+author);
+    });
 });

--- a/public/assets/homepage.js
+++ b/public/assets/homepage.js
@@ -118,6 +118,25 @@ function switchToVideo(vidnum){
 
 }
 
+function logWebpageActivity(activity){
+    var url = "/userapi/logWebpageActivity";
+    var async = true;
+    $.ajax({
+        async: async,
+        contentType: 'application/json; charset=utf-8',
+        url: url,
+        type: 'post',
+        data: JSON.stringify(activity),
+        dataType: 'json',
+        success: function(result){},
+        error: function (result) {
+            console.error(result);
+        }
+    });
+}
+
+
+
 $( document ).ready(function() {
 
     switchToVideo(1)
@@ -138,5 +157,19 @@ $( document ).ready(function() {
     autoAdvanceLaptopVideos();
 
 
+    // Triggered when "Watch Now" or the arrow next to it is clicked
+    // Logs "Click_WatchNow" in WebpageActivityTable
+    $("#playlink").on('click', function(e){
+        if(e.target.innerText === "Watch Now"){
+            logWebpageActivity("Click_WatchNow");
+        }
+    });
 
+    // Triggered upon clicking tabs in "How you can help" section
+    // Logs "Click_HowYouCanHelp_Tab<tabNumber>" in WebpageActivityTable
+    $("#numbersrow").on('click','.col-sm-4', function(e){
+        // Gets tab number as a string (i.e. "1", "2", or "3")
+        var id = e.target.innerText.charAt(1);
+        logWebpageActivity("Click_HowYouCanHelp_Tab"+id);
+    });
 });

--- a/public/javascripts/Choropleth.js
+++ b/public/javascripts/Choropleth.js
@@ -145,9 +145,31 @@ function Choropleth(_, $, turf) {
                 map.setView(latlng, zoom, {animate: true});
                 currentLayer = this;
 
+
                 // Log when a user clicks on a region on the choropleth
+                // Logs are of the form "Click_module=Choropleth_regionId=<regionId>_distanceLeft=<"0", "<1", "1" or ">1">_target=inspect"
+                // Log is stored in WebpageActivityTable
                 var regionId = e.target.feature.properties.region_id;
-                postToWebpageActivity("ChoroplethClickRegion"+regionId);
+                var ratesEl = rates.find(function(x){
+                    return regionId == x.region_id;
+                })
+                var compRate = Math.round(100.0 * ratesEl.rate);
+                var milesLeft = Math.round(0.000621371 * (ratesEl.total_distance_m - ratesEl.completed_distance_m));
+                var distanceLeft = "";
+                if(compRate === 100){
+                    distanceLeft = "0";
+                }
+                else if(milesLeft === 0){
+                    distanceLeft = "<1";
+                }
+                else if(milesLeft === 1){
+                    distanceLeft = "1";
+                }
+                else{
+                    distanceLeft = ">1";
+                }
+                var activity = "Click_module=Choropleth_regionId="+regionId+"_distanceLeft="+distanceLeft+"_target=inspect";
+                postToWebpageActivity(activity);
             });
         }
 
@@ -161,10 +183,9 @@ function Choropleth(_, $, turf) {
         });
 
 
-        // When a region is selected and 'Click here' is clicked, this function runs
-        // Sends String to be logged in WebpageActivityTable of the form
-        // SelfAssign_Region<regionId>_<distanceLeft>MilesLeft_Choropleth
-        // where distanceLeft is 0, <1, 1 or >1
+        // Logs when a region is selected from the choropleth and 'Click here' is clicked
+        // Logs are of the form "Click_module=Choropleth_regionId=<regionId>_distanceLeft=<"0", "<1", "1" or ">1">_target=audit"
+        // Log is stored in WebpageActivityTable
         $("#choropleth").on('click', '.region-selection-trigger', function () {
             var regionId = $(this).attr('regionId');
             var ratesEl = rates.find(function(x){
@@ -186,7 +207,7 @@ function Choropleth(_, $, turf) {
                 distanceLeft = ">1";
             }
 
-            var data = "SelfAssign_Region"+regionId+"_"+distanceLeft+"MilesLeft_Choropleth";
+            var data = "Click_module=Choropleth_regionId="+regionId+"_distanceLeft="+distanceLeft+"_target=audit";
             postToWebpageActivity(data);
         });
     }

--- a/public/javascripts/Choropleth.js
+++ b/public/javascripts/Choropleth.js
@@ -144,6 +144,10 @@ function Choropleth(_, $, turf) {
 
                 map.setView(latlng, zoom, {animate: true});
                 currentLayer = this;
+
+                // Log when a user clicks on a region on the choropleth
+                var regionId = e.target.feature.properties.region_id;
+                postToWebpageActivity("ChoroplethClickRegion"+regionId);
             });
         }
 
@@ -181,22 +185,9 @@ function Choropleth(_, $, turf) {
             else{
                 distanceLeft = ">1";
             }
-            var url = "/userapi/logWebpageActivity";
-            var async = true;
+
             var data = "SelfAssign_Region"+regionId+"_"+distanceLeft+"MilesLeft";
-            $.ajax({
-                async: async,
-                contentType: 'application/json; charset=utf-8',
-                url: url,
-                type: 'post',
-                data: JSON.stringify(data),
-                dataType: 'json',
-                success: function (result) {
-                },
-                error: function (result) {
-                    console.error(result);
-                }
-            });
+            postToWebpageActivity(data);
         });
     }
 
@@ -209,4 +200,23 @@ function Choropleth(_, $, turf) {
             choropleth.invalidateSize(false);
         }, 1);
     });
+
+
+    // Makes POST request that logs `activity` in WebpageActivityTable
+    function postToWebpageActivity(activity){
+        var url = "/userapi/logWebpageActivity";
+        var async = true;
+        $.ajax({
+            async: async,
+            contentType: 'application/json; charset=utf-8',
+            url: url,
+            type: 'post',
+            data: JSON.stringify(activity),
+            dataType: 'json',
+            success: function(result){},
+            error: function (result) {
+                console.error(result);
+            }
+        });
+    }
 }

--- a/public/javascripts/Choropleth.js
+++ b/public/javascripts/Choropleth.js
@@ -163,7 +163,7 @@ function Choropleth(_, $, turf) {
 
         // When a region is selected and 'Click here' is clicked, this function runs
         // Sends String to be logged in WebpageActivityTable of the form
-        // SelfAssign_Region<regionId>_<distanceLeft>MilesLeft
+        // SelfAssign_Region<regionId>_<distanceLeft>MilesLeft_Choropleth
         // where distanceLeft is 0, <1, 1 or >1
         $("#choropleth").on('click', '.region-selection-trigger', function () {
             var regionId = $(this).attr('regionId');
@@ -186,7 +186,7 @@ function Choropleth(_, $, turf) {
                 distanceLeft = ">1";
             }
 
-            var data = "SelfAssign_Region"+regionId+"_"+distanceLeft+"MilesLeft";
+            var data = "SelfAssign_Region"+regionId+"_"+distanceLeft+"MilesLeft_Choropleth";
             postToWebpageActivity(data);
         });
     }

--- a/public/javascripts/Choropleth.js
+++ b/public/javascripts/Choropleth.js
@@ -181,7 +181,7 @@ function Choropleth(_, $, turf) {
             else{
                 distanceLeft = ">1";
             }
-            var url = "/userapi/selfAssign";
+            var url = "/userapi/logWebpageActivity";
             var async = true;
             var data = "SelfAssign_Region"+regionId+"_"+distanceLeft+"MilesLeft";
             $.ajax({

--- a/public/javascripts/Progress/build/Progress.js
+++ b/public/javascripts/Progress/build/Progress.js
@@ -169,6 +169,46 @@ function Progress (_, $, c3, L) {
 
                 map.setView(latlng, zoom, { animate: true });
                 currentLayer = this;
+
+
+                // Log when a user clicks on a region on the user map
+                // Logs are of the form "Click_module=UserMap_regionId=<regionId>_distanceLeft=<"0", "<1", "1" or ">1">_target=inspect"
+                // Log is stored in WebpageActivityTable
+                var regionId = $(this).attr('regionId');
+                var ratesEl = rates.find(function(x){
+                    return regionId == x.region_id;
+                })
+                var compRate = Math.round(100.0 * ratesEl.rate);
+                var milesLeft = Math.round(0.000621371 * (ratesEl.total_distance_m - ratesEl.completed_distance_m));
+                var distanceLeft = "";
+                if(compRate === 100){
+                    distanceLeft = "0";
+                }
+                else if(milesLeft === 0){
+                    distanceLeft = "<1";
+                }
+                else if(milesLeft === 1){
+                    distanceLeft = "1";
+                }
+                else{
+                    distanceLeft = ">1";
+                }
+                var url = "/userapi/logWebpageActivity";
+                var async = true;
+                var data = "Click_module=UserMap_regionId="+regionId+"_distanceLeft="+distanceLeft+"_target=inspect";
+                $.ajax({
+                    async: async,
+                    contentType: 'application/json; charset=utf-8',
+                    url: url,
+                    type: 'post',
+                    data: JSON.stringify(data),
+                    dataType: 'json',
+                    success: function (result) {
+                    },
+                    error: function (result) {
+                        console.error(result);
+                    }
+                });
             });
 
         }
@@ -186,12 +226,11 @@ function Progress (_, $, c3, L) {
             completedInitializingNeighborhoodPolygons = true;
             handleInitializationComplete(map);
         });
-        
 
-        // When a region is selected and 'Click here' is clicked, this function runs
-        // Sends String to be logged in WebpageActivityTable of the form
-        // SelfAssign_Region<regionId>_<distanceLeft>MilesLeft_Dashboard
-        // where distanceLeft is 0, <1, 1 or >1
+
+        // Logs when a region is selected from the user map and 'Click here' is clicked
+        // Logs are of the form "Click_module=UserMap_regionId=<regionId>_distanceLeft=<"0", "<1", "1" or ">1">_target=audit"
+        // Log is stored in WebpageActivityTable
         $("#map").on('click', '.region-selection-trigger', function () {
             var regionId = $(this).attr('regionId');
             var ratesEl = rates.find(function(x){
@@ -214,7 +253,7 @@ function Progress (_, $, c3, L) {
             }
             var url = "/userapi/logWebpageActivity";
             var async = true;
-            var data = "Click_UserMap_regionId="+regionId+"_distanceLeft="+distanceLeft;
+            var data = "Click_UserMap_regionId="+regionId+"_distanceLeft="+distanceLeft+"_target=audit";
             $.ajax({
                 async: async,
                 contentType: 'application/json; charset=utf-8',

--- a/public/javascripts/Progress/build/Progress.js
+++ b/public/javascripts/Progress/build/Progress.js
@@ -186,13 +186,12 @@ function Progress (_, $, c3, L) {
             completedInitializingNeighborhoodPolygons = true;
             handleInitializationComplete(map);
         });
+        
 
-        // Catch click even in popups
-        // https://www.mapbox.com/mapbox.js/example/v1.0.0/clicks-in-popups/
-//    $("#map").on('click', '.region-selection-trigger', function () {
-//        var regionId = $(this).attr('regionid');
-//        console.log(regionId)
-//    });
+        // When a region is selected and 'Click here' is clicked, this function runs
+        // Sends String to be logged in WebpageActivityTable of the form
+        // SelfAssign_Region<regionId>_<distanceLeft>MilesLeft_Dashboard
+        // where distanceLeft is 0, <1, 1 or >1
         $("#map").on('click', '.region-selection-trigger', function () {
             var regionId = $(this).attr('regionId');
             var ratesEl = rates.find(function(x){
@@ -213,9 +212,9 @@ function Progress (_, $, c3, L) {
             else{
                 distanceLeft = ">1";
             }
-            var url = "/userapi/selfAssign";
+            var url = "/userapi/logWebpageActivity";
             var async = true;
-            var data = "SelfAssign_Region"+regionId+"_"+distanceLeft+"MilesLeft";
+            var data = "SelfAssign_Region"+regionId+"_"+distanceLeft+"MilesLeft_Dashboard";
             $.ajax({
                 async: async,
                 contentType: 'application/json; charset=utf-8',

--- a/public/javascripts/Progress/build/Progress.js
+++ b/public/javascripts/Progress/build/Progress.js
@@ -214,7 +214,7 @@ function Progress (_, $, c3, L) {
             }
             var url = "/userapi/logWebpageActivity";
             var async = true;
-            var data = "SelfAssign_Region"+regionId+"_"+distanceLeft+"MilesLeft_Dashboard";
+            var data = "Click_UserMap_regionId="+regionId+"_distanceLeft="+distanceLeft;
             $.ajax({
                 async: async,
                 contentType: 'application/json; charset=utf-8',

--- a/public/javascripts/Progress/src/Progress.js
+++ b/public/javascripts/Progress/src/Progress.js
@@ -169,6 +169,46 @@ function Progress (_, $, c3, L) {
 
                 map.setView(latlng, zoom, { animate: true });
                 currentLayer = this;
+
+
+                // Log when a user clicks on a region on the user map
+                // Logs are of the form "Click_module=UserMap_regionId=<regionId>_distanceLeft=<"0", "<1", "1" or ">1">_target=inspect"
+                // Log is stored in WebpageActivityTable
+                var regionId = $(this).attr('regionId');
+                var ratesEl = rates.find(function(x){
+                    return regionId == x.region_id;
+                })
+                var compRate = Math.round(100.0 * ratesEl.rate);
+                var milesLeft = Math.round(0.000621371 * (ratesEl.total_distance_m - ratesEl.completed_distance_m));
+                var distanceLeft = "";
+                if(compRate === 100){
+                    distanceLeft = "0";
+                }
+                else if(milesLeft === 0){
+                    distanceLeft = "<1";
+                }
+                else if(milesLeft === 1){
+                    distanceLeft = "1";
+                }
+                else{
+                    distanceLeft = ">1";
+                }
+                var url = "/userapi/logWebpageActivity";
+                var async = true;
+                var data = "Click_module=UserMap_regionId="+regionId+"_distanceLeft="+distanceLeft+"_target=inspect";
+                $.ajax({
+                    async: async,
+                    contentType: 'application/json; charset=utf-8',
+                    url: url,
+                    type: 'post',
+                    data: JSON.stringify(data),
+                    dataType: 'json',
+                    success: function (result) {
+                    },
+                    error: function (result) {
+                        console.error(result);
+                    }
+                });
             });
 
         }
@@ -186,12 +226,11 @@ function Progress (_, $, c3, L) {
             completedInitializingNeighborhoodPolygons = true;
             handleInitializationComplete(map);
         });
-        
 
-        // When a region is selected and 'Click here' is clicked, this function runs
-        // Sends String to be logged in WebpageActivityTable of the form
-        // SelfAssign_Region<regionId>_<distanceLeft>MilesLeft_Dashboard
-        // where distanceLeft is 0, <1, 1 or >1
+
+        // Logs when a region is selected from the user map and 'Click here' is clicked
+        // Logs are of the form "Click_module=UserMap_regionId=<regionId>_distanceLeft=<"0", "<1", "1" or ">1">_target=audit"
+        // Log is stored in WebpageActivityTable
         $("#map").on('click', '.region-selection-trigger', function () {
             var regionId = $(this).attr('regionId');
             var ratesEl = rates.find(function(x){
@@ -214,7 +253,7 @@ function Progress (_, $, c3, L) {
             }
             var url = "/userapi/logWebpageActivity";
             var async = true;
-            var data = "Click_UserMap_regionId="+regionId+"_distanceLeft="+distanceLeft;
+            var data = "Click_UserMap_regionId="+regionId+"_distanceLeft="+distanceLeft+"_target=audit";
             $.ajax({
                 async: async,
                 contentType: 'application/json; charset=utf-8',

--- a/public/javascripts/Progress/src/Progress.js
+++ b/public/javascripts/Progress/src/Progress.js
@@ -212,7 +212,7 @@ function Progress (_, $, c3, L) {
             else{
                 distanceLeft = ">1";
             }
-            var url = "/userapi/selfAssign";
+            var url = "/userapi/logWebpageActivity";
             var async = true;
             var data = "SelfAssign_Region"+regionId+"_"+distanceLeft+"MilesLeft";
             $.ajax({

--- a/public/javascripts/Progress/src/Progress.js
+++ b/public/javascripts/Progress/src/Progress.js
@@ -190,7 +190,7 @@ function Progress (_, $, c3, L) {
 
         // When a region is selected and 'Click here' is clicked, this function runs
         // Sends String to be logged in WebpageActivityTable of the form
-        // SelfAssign_Region<regionId>_<distanceLeft>MilesLeft
+        // SelfAssign_Region<regionId>_<distanceLeft>MilesLeft_Dashboard
         // where distanceLeft is 0, <1, 1 or >1
         $("#map").on('click', '.region-selection-trigger', function () {
             var regionId = $(this).attr('regionId');
@@ -214,7 +214,7 @@ function Progress (_, $, c3, L) {
             }
             var url = "/userapi/logWebpageActivity";
             var async = true;
-            var data = "SelfAssign_Region"+regionId+"_"+distanceLeft+"MilesLeft";
+            var data = "SelfAssign_Region"+regionId+"_"+distanceLeft+"MilesLeft_Dashboard";
             $.ajax({
                 async: async,
                 contentType: 'application/json; charset=utf-8',

--- a/public/javascripts/Progress/src/Progress.js
+++ b/public/javascripts/Progress/src/Progress.js
@@ -214,7 +214,7 @@ function Progress (_, $, c3, L) {
             }
             var url = "/userapi/logWebpageActivity";
             var async = true;
-            var data = "SelfAssign_Region"+regionId+"_"+distanceLeft+"MilesLeft_Dashboard";
+            var data = "Click_UserMap_regionId="+regionId+"_distanceLeft="+distanceLeft;
             $.ajax({
                 async: async,
                 contentType: 'application/json; charset=utf-8',


### PR DESCRIPTION
Resolves #756 - at least, number 3 on the list. Now logs when users click on choropleth neighborhoods under the format `ChoroplethClickRegion<regionId>`.

Also, I changed logs for `Click here` link by adding if it was from the choropleth or the dashboard at the end of the activity string like this:
`SelfAssign_Region<regionId>_<distanceLeft>MilesLeft_Choropleth`
`SelfAssign_Region<regionId>_<distanceLeft>MildesLeft_Dashboard`
 Please let me know if I should remove this.

Did not log mousing over the neighborhoods as it seemed there wasn't a clear consensus on that.

More precisely, resolves #721 but most of the discussion was in #756 