### PR TITLE
Issue #726 Embedded Youtube Videos

### DIFF
--- a/app/views/faq.scala.html
+++ b/app/views/faq.scala.html
@@ -47,7 +47,7 @@
                             </p>
                         </div>
                         <div class="video col-sm-12" style="text-align:center">
-                            <iframe width="560" height="315" src="https://www.youtube.com/embed/-kXeX230WNI" frameborder="0" allowfullscreen></iframe>
+                            <iframe width="560" height="315" src="https://www.youtube.com/embed/-kXeX230WNI?rel=0" frameborder="0" allowfullscreen></iframe>
                         </div>
                     </div>
                 </div>
@@ -72,7 +72,7 @@
                             </ol>
                         </div>
                         <div class="video col-sm-12" style="text-align:center">
-                            <iframe width="560" height="315" src="https://www.youtube.com/embed/Hgd8akPnkSM" frameborder="0" allowfullscreen></iframe>
+                            <iframe width="560" height="315" src="https://www.youtube.com/embed/Hgd8akPnkSM?rel=0" frameborder="0" allowfullscreen></iframe>
                         </div>
                     </div>
                 </div>
@@ -190,7 +190,7 @@
                             </p>
                         </div>
                         <div class="video col-sm-12" style="text-align:center">
-                            <iframe width="560" height="315" src="https://www.youtube.com/embed/eqnoAcqgNrw" frameborder="0" allowfullscreen></iframe>
+                            <iframe width="560" height="315" src="https://www.youtube.com/embed/eqnoAcqgNrw?rel=0" frameborder="0" allowfullscreen></iframe>
                         </div>
                     </div>
                 </div>
@@ -242,7 +242,7 @@
                             </p>
                         </div>
                         <div class="video col-sm-12" style="text-align:center">
-                            <iframe width="560" height="315" src="https://www.youtube.com/embed/5a9t8f7Qws4" frameborder="0" allowfullscreen></iframe>
+                            <iframe width="560" height="315" src="https://www.youtube.com/embed/5a9t8f7Qws4?rel=0" frameborder="0" allowfullscreen></iframe>
                         </div>
                     </div>
                 </div>
@@ -358,7 +358,7 @@
                             </p>
                         </div>
                         <div class="video col-sm-12" style="text-align:center">
-                            <iframe width="560" height="315" src="https://www.youtube.com/embed/a93XPAe_54c" frameborder="0" allowfullscreen></iframe>
+                            <iframe width="560" height="315" src="https://www.youtube.com/embed/a93XPAe_54c?rel=0" frameborder="0" allowfullscreen></iframe>
                         </div>
                     </div>
                 </div>

--- a/public/assets/homepage.js
+++ b/public/assets/homepage.js
@@ -4,7 +4,7 @@ var autoAdvanceLaptop = true;
 
 
 function playVideo(){
-    document.getElementById("vidembed").innerHTML = '<div class="video-container"><iframe id="youtubeframe" width="853" height="480" src="https://www.youtube.com/embed/wAdGXqRunQs?autoplay=1" frameborder="0" allowfullscreen</iframe</div>';
+    document.getElementById("vidembed").innerHTML = '<div class="video-container"><iframe id="youtubeframe" width="853" height="480" src="https://www.youtube.com/embed/wAdGXqRunQs?autoplay=1&rel=0" frameborder="0" allowfullscreen</iframe</div>';
     var vidheight = $('#youtubeframe').height();
     $('#vidembed').height(vidheight);
 }


### PR DESCRIPTION
The embedded videos on the landing page (1) and FAQ page (5) now show no suggested videos.

Instead, when the video is completed, the only thing shown will be the replay button (see below example of end of landing page video).

![image](https://user-images.githubusercontent.com/19720010/27644357-4e6005fc-5bf1-11e7-9aad-fe06bc516d5c.png)

resolves #726 