### PR TITLE
#514 FAQ page twitter update link

### DIFF
--- a/app/views/faq.scala.html
+++ b/app/views/faq.scala.html
@@ -556,7 +556,7 @@
                 <p class="text-justify">
                     You have more questions? Email us (sidewalk@@umiacs.umd.edu),
                     post a <a href="https://github.com/ProjectSidewalk/SidewalkWebpage/issues">GitHub issue</a>, or follow and talk to us
-                    on <a href="https://twitter.com/umd_sidewalk">Twitter (@@umd_sidewalk)!</a>
+                    on <a href="https://twitter.com/projsidewalk">Twitter (@@projsidewalk)!</a>
                 </p>
             </div>
         </div>


### PR DESCRIPTION
Found another twitter link I had not previously updated, at the bottom of the FAQ page in the "Contact Us" section. That link is now updated to @projsidewalk. 

![image](https://user-images.githubusercontent.com/19720010/27658777-1c3052a2-5c1f-11e7-8937-b3da624b545d.png)

Resolves #514 