### PR TITLE
Issue #569 Update About Page Links

### DIFF
--- a/app/views/about.scala.html
+++ b/app/views/about.scala.html
@@ -347,7 +347,7 @@
                         <dl>
                             <dt>
                                 <a href='@routes.Assets.at("documents/papers/Hara_AnInitialStudyOfAutomaticCurbRampDetectionWithCrowdsourcedVerificationUsingGoogleStreetViewImages_HCOMP2013.pdf")'>
-                                    Combining Crowdsourcing and Google Street View to Identify Street-level Accessibility Problems
+                                  An Initial Study of Automatic Curb Ramp Detection with Crowdsource Verification using Google Street View Images
                                 </a>
                             </dt>
                             <dd>
@@ -412,7 +412,8 @@
                         <dl>
                             <dt>
                                 <a href='@routes.Assets.at("documents/papers/Hara_AFeasibilityStudyOfCrowdsourcingAndGoogleStreetViewToDetermineSidewalkAccessibility_ASSETS2012.pdf")'>
-                                    Combining Crowdsourcing and Google Street View to Identify Street-level Accessibility Problems
+                                  A Feasibility Study of Crowdsourcing and Google Street View to Determine Sidewalk Accessibility
+
                                 </a>
                             </dt>
                             <dd>


### PR DESCRIPTION
All of the publication links and titles on the About page are corrected.

Before:
![image](https://user-images.githubusercontent.com/19720010/27665998-cb6c275e-5c3e-11e7-9ec5-c204655ed4e1.png)

After:
![image](https://user-images.githubusercontent.com/19720010/27666016-e102f930-5c3e-11e7-9197-ce8516fc8ae4.png)

Resolves #569 