### PR TITLE
Issue #780 Disable Photospheres

### DIFF
--- a/app/views/audit.scala.html
+++ b/app/views/audit.scala.html
@@ -654,7 +654,7 @@
             svl.taskContainer = new TaskContainer(svl.navigationModel, svl.neighborhoodModel, streetViewService, svl, svl.taskModel, svl.tracker);
 
             // Todo. Issue #43 Here, we may want to check if there is a previous task that is cached in user's browser.
-            streetViewService.getPanoramaByLocation(latLng, STREETVIEW_MAX_DISTANCE, function (streetViewPanoramaData, status) {
+            streetViewService.getPanorama({location: latLng, radius: STREETVIEW_MAX_DISTANCE, source: google.maps.StreetViewSource.OUTDOOR}, function (streetViewPanoramaData, status) {
                 if (status === google.maps.StreetViewStatus.OK) {
                     // Ok
                     var newTask = svl.taskFactory.create(geojson, lat1, lng1);

--- a/public/javascripts/SVLabel/lib/gsv/GSVPano.js
+++ b/public/javascripts/SVLabel/lib/gsv/GSVPano.js
@@ -101,7 +101,7 @@ GSVPANO.PanoLoader = function (parameters) {
     
         console.log('Load for', location);
         var self = this;
-        _panoClient.getPanoramaByLocation(location, 50, function (result, status) {
+        _panoClient.getPanorama({location: location, radius: 50, source: google.maps.StreetViewSource.OUTDOOR}, function (result, status) {
             if (status === google.maps.StreetViewStatus.OK) {
                 if( self.onPanoramaData ) self.onPanoramaData( result );
                 var h = google.maps.geometry.spherical.computeHeading(location, result.location.latLng);

--- a/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
+++ b/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
@@ -575,7 +575,7 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
         console.log("[" + rId + "]\n Pano: " + getPanoId() + "\nNewLatLng:" + JSON.stringify(newLatLng));
 
         if (svl.streetViewService) {
-            svl.streetViewService.getPanoramaByLocation(newLatLng, STREETVIEW_MAX_DISTANCE,
+            svl.streetViewService.getPanorama({location: newLatLng, radius: STREETVIEW_MAX_DISTANCE, source: google.maps.StreetViewSource.OUTDOOR},
                 function (data, status) {
                     console.error("[" + rId + "]\nPano:" + getPanoId() + " Round:" + round + " LOC:Status: " + status);
 
@@ -1095,8 +1095,8 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
                     if (newLatlng) {
                         var distance = util.math.haversine(latlng.lat, latlng.lng, newLatlng.lat, newLatlng.lng);
                         if (distance < STREETVIEW_MAX_DISTANCE) {
-                            svl.streetViewService.getPanoramaByLocation(new google.maps.LatLng(newLatlng.lat, newLatlng.lng),
-                                STREETVIEW_MAX_DISTANCE, function (streetViewPanoramaData, status) {
+                            svl.streetViewService.getPanorama({location: new google.maps.LatLng(newLatlng.lat, newLatlng.lng),
+                                radius: STREETVIEW_MAX_DISTANCE, source: google.maps.StreetViewSource.OUTDOOR}, function (streetViewPanoramaData, status) {
                                 if (status === google.maps.StreetViewStatus.OK) {
                                     self.setPano(streetViewPanoramaData.location.pano);
                                     //self.handlerPositionUpdate();
@@ -1399,8 +1399,7 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
         if (!status.disableWalking) {
             // Check the presence of the Google Street View. If it exists, then set the location. Other wise error.
             var gLatLng = new google.maps.LatLng(lat, lng);
-            
-            svl.streetViewService.getPanoramaByLocation(gLatLng, STREETVIEW_MAX_DISTANCE,
+            svl.streetViewService.getPanorama({location: gLatLng, radius: STREETVIEW_MAX_DISTANCE, source: google.maps.StreetViewSource.OUTDOOR},
                 function (streetViewPanoramaData, status) {
                     if (status === google.maps.StreetViewStatus.OK) {
 

--- a/public/javascripts/SVLabel/src/SVLabel/task/TaskContainer.js
+++ b/public/javascripts/SVLabel/src/SVLabel/task/TaskContainer.js
@@ -54,7 +54,7 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
         navigationModel.disableWalking();
 
         if (streetViewService) {
-            streetViewService.getPanoramaByLocation(latLng, STREETVIEW_MAX_DISTANCE,
+            streetViewService.getPanorama({location: latLng, radius: STREETVIEW_MAX_DISTANCE, source: google.maps.StreetViewSource.OUTDOOR},
                 function (streetViewPanoramaData, status) {
                     navigationModel.enableWalking();
                     if (status === google.maps.StreetViewStatus.OK) {


### PR DESCRIPTION
Each getParamByLocation() was changed to getParam() with a source property set to OUTSIDE, while maintaining the location and radius properties.

"...search only returns panoramas where it's possible to determine whether they're indoors or outdoors. For example, PhotoSpheres are not returned because it's unknown whether they are indoors or outdoors."

Therefore, photospheres are blocked from being returned.

Resolves #668 
Resolves #780 
Partially Resolves #718 