### PR TITLE
Added tracking for anonymous first mission completion

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/Main.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Main.js
@@ -345,8 +345,7 @@ function Main (params) {
         }
 
         // Popup the message explaining the goal of the current mission
-        if ((svl.missionContainer.onlyMissionOnboardingDone() || svl.missionContainer.isTheFirstMission())
-            && !svl.storage.get('completedMissionAnonymously')) {
+        if (svl.missionContainer.onlyMissionOnboardingDone() || svl.missionContainer.isTheFirstMission()) {
             var neighborhood = svl.neighborhoodContainer.getCurrentNeighborhood();
             svl.initialMissionInstruction = new InitialMissionInstruction(svl.compass, svl.map,
                 svl.neighborhoodContainer, svl.popUpMessage, svl.taskContainer, svl.labelContainer, svl.tracker);

--- a/public/javascripts/SVLabel/src/SVLabel/Main.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Main.js
@@ -345,7 +345,8 @@ function Main (params) {
         }
 
         // Popup the message explaining the goal of the current mission
-        if (svl.missionContainer.isTheFirstMission() || svl.missionContainer.onlyMissionOnboardingDone()) {
+        if ((svl.missionContainer.onlyMissionOnboardingDone() || svl.missionContainer.isTheFirstMission())
+            && !svl.storage.get('completedMissionAnonymously')) {
             var neighborhood = svl.neighborhoodContainer.getCurrentNeighborhood();
             svl.initialMissionInstruction = new InitialMissionInstruction(svl.compass, svl.map,
                 svl.neighborhoodContainer, svl.popUpMessage, svl.taskContainer, svl.labelContainer, svl.tracker);

--- a/public/javascripts/SVLabel/src/SVLabel/Storage.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Storage.js
@@ -39,8 +39,8 @@ function TemporaryStorage(JSON, params) {
             set("completedOnboarding", null);
         }
 
-        if (!get("completedMissionAnonymously")){
-            set("completedMissionAnonymously", null);
+        if (!get("completedFirstMission")){
+            set("completedFirstMission", null);
         }
 
         if (!get("muted")) {
@@ -65,7 +65,7 @@ function TemporaryStorage(JSON, params) {
         set("tracker", []);
         set("labels", []);
         set("completedOnboarding", null);
-        set("completedMissionAnonymously", null);
+        set("completedFirstMission", null);
         set("muted", false);
     }
 

--- a/public/javascripts/SVLabel/src/SVLabel/Storage.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Storage.js
@@ -39,6 +39,10 @@ function TemporaryStorage(JSON, params) {
             set("completedOnboarding", null);
         }
 
+        if (!get("completedMissionAnonymously")){
+            set("completedMissionAnonymously", null);
+        }
+
         if (!get("muted")) {
             set("muted", false);
         }
@@ -61,6 +65,7 @@ function TemporaryStorage(JSON, params) {
         set("tracker", []);
         set("labels", []);
         set("completedOnboarding", null);
+        set("completedMissionAnonymously", null);
         set("muted", false);
     }
 

--- a/public/javascripts/SVLabel/src/SVLabel/keyboard/Keyboard.js
+++ b/public/javascripts/SVLabel/src/SVLabel/keyboard/Keyboard.js
@@ -55,6 +55,11 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
         svl.map.timeoutWalking();
         //restore user ability to walk after param moveTime
         setTimeout(svl.map.resetWalking, moveTime);
+        //additional check to hide arrows after the fact
+        //pop-up may become visible during timeout period
+        if (svl.popUpMessage.getStatus('isVisible')){
+            svl.panorama.set('linksControl', false);//disable arrows
+        }
     }
 
     this._moveForward = function (){

--- a/public/javascripts/SVLabel/src/SVLabel/mission/Mission.js
+++ b/public/javascripts/SVLabel/src/SVLabel/mission/Mission.js
@@ -154,8 +154,8 @@ function Mission(parameters) {
             svl.labelCounter.reset();
         }
 
-        if (svl.main.isAnAnonymousUser() && !svl.onboarding.isOnboarding()){
-            svl.storage.set('completedMissionAnonymously', true);
+        if (!svl.onboarding.isOnboarding()){
+            svl.storage.set('completedFirstMission', true);
         }
     }
 

--- a/public/javascripts/SVLabel/src/SVLabel/mission/Mission.js
+++ b/public/javascripts/SVLabel/src/SVLabel/mission/Mission.js
@@ -153,6 +153,10 @@ function Mission(parameters) {
             };
             svl.labelCounter.reset();
         }
+
+        if (svl.main.isAnAnonymousUser() && !svl.onboarding.isOnboarding()){
+            svl.storage.set('completedMissionAnonymously', true);
+        }
     }
 
     /**

--- a/public/javascripts/SVLabel/src/SVLabel/mission/Mission.js
+++ b/public/javascripts/SVLabel/src/SVLabel/mission/Mission.js
@@ -154,7 +154,7 @@ function Mission(parameters) {
             svl.labelCounter.reset();
         }
 
-        if (!svl.onboarding.isOnboarding()){
+        if (!svl.isOnboarding()){
             svl.storage.set('completedFirstMission', true);
         }
     }

--- a/public/javascripts/SVLabel/src/SVLabel/mission/MissionContainer.js
+++ b/public/javascripts/SVLabel/src/SVLabel/mission/MissionContainer.js
@@ -106,7 +106,7 @@ function MissionContainer (statusFieldMission, missionModel, taskModel) {
         }
     };
     this.onlyMissionOnboardingDone = function (){
-       return self._completedMissions.length == 1 && self._completedMissions[0].getProperty("label") === "onboarding";
+       return self._completedMissions.length == 1 && self._completedMissions[0].getProperty("label") === "onboarding" && !svl.storage.get("completedFirstMission");
     };
 
     /** Get current mission */
@@ -190,7 +190,7 @@ function MissionContainer (statusFieldMission, missionModel, taskModel) {
      * @returns {boolean}
      */
     function isTheFirstMission () {
-        return getCompletedMissions().length == 0;
+        return getCompletedMissions().length == 0 && !svl.storage.get("completedFirstMission");
     }
 
     /**

--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMission.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMission.js
@@ -110,7 +110,8 @@ function ModalMission (missionContainer, neighborhoodContainer, uiModalMission, 
                 distanceString;
                 templateHTML = distanceMissionHTML;
 
-            if(missionContainer.isTheFirstMission()){
+            if ((missionContainer.onlyMissionOnboardingDone() || missionContainer.isTheFirstMission())
+                && !svl.storage.get('completedMissionAnonymously')) {
                 missionTitle = "First Mission: " + missionTitle;
                 templateHTML = initialMissionHTML;
             }

--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMission.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMission.js
@@ -110,8 +110,7 @@ function ModalMission (missionContainer, neighborhoodContainer, uiModalMission, 
                 distanceString;
                 templateHTML = distanceMissionHTML;
 
-            if ((missionContainer.onlyMissionOnboardingDone() || missionContainer.isTheFirstMission())
-                && !svl.storage.get('completedMissionAnonymously')) {
+            if (missionContainer.onlyMissionOnboardingDone() || missionContainer.isTheFirstMission()) {
                 missionTitle = "First Mission: " + missionTitle;
                 templateHTML = initialMissionHTML;
             }

--- a/public/javascripts/SVLabel/src/SVLabel/onboarding/Onboarding.js
+++ b/public/javascripts/SVLabel/src/SVLabel/onboarding/Onboarding.js
@@ -544,8 +544,7 @@ function Onboarding(svl, actionStack, audioEffect, compass, form, handAnimation,
         var mission = missions[0];
 
         missionContainer.setCurrentMission(mission);
-        if ((missionContainer.onlyMissionOnboardingDone() || missionContainer.isTheFirstMission())
-            && !storage.get('completedMissionAnonymously')) {
+        if (missionContainer.onlyMissionOnboardingDone() || missionContainer.isTheFirstMission()) {
 
             svl.initialMissionInstruction = new InitialMissionInstruction(svl.compass, svl.map,
                 svl.neighborhoodContainer, svl.popUpMessage, svl.taskContainer, svl.labelContainer, svl.tracker);

--- a/public/javascripts/SVLabel/src/SVLabel/onboarding/Onboarding.js
+++ b/public/javascripts/SVLabel/src/SVLabel/onboarding/Onboarding.js
@@ -544,12 +544,15 @@ function Onboarding(svl, actionStack, audioEffect, compass, form, handAnimation,
         var mission = missions[0];
 
         missionContainer.setCurrentMission(mission);
-        if (missionContainer.onlyMissionOnboardingDone() || missionContainer.isTheFirstMission()) {
+        if ((missionContainer.onlyMissionOnboardingDone() || missionContainer.isTheFirstMission())
+            && !storage.get('completedMissionAnonymously')) {
+
             svl.initialMissionInstruction = new InitialMissionInstruction(svl.compass, svl.map,
                 svl.neighborhoodContainer, svl.popUpMessage, svl.taskContainer, svl.labelContainer, svl.tracker);
             modalMission.setMissionMessage(mission, neighborhood, null, function () {
                 svl.initialMissionInstruction.start(neighborhood);
             });
+
         }else{
             modalMission.setMissionMessage(mission, neighborhood);
         }


### PR DESCRIPTION
Resolves #826.

Now, as an anonymous user, if you have completed a mission other than onboarding in a browser session, the initial mission instructions will not appear even if you refresh or open the page in another tab.

Also resolved a minor issue of the link controls appearing behind the pop-up messages. 