### PR TITLE
Issue #812 Context Menu Cut Off

### DIFF
--- a/public/javascripts/SVLabel/css/svl-context-menu.css
+++ b/public/javascripts/SVLabel/css/svl-context-menu.css
@@ -16,7 +16,7 @@
 
 #context-menu-vertical-connector {
     position: absolute;
-    top: -13px;
+    top: 0px;
     left: 178px;
     height: 13px;
     width: 6px;

--- a/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
@@ -10,6 +10,7 @@ function ContextMenu (uiContextMenu) {
         $temporaryProblemCheckbox = uiContextMenu.temporaryProblemCheckbox,
         $descriptionTextBox = uiContextMenu.textBox,
         windowWidth = $menuWindow.width();
+        windowHeight = $menuWindow.height();
     var $OKButton = $menuWindow.find("#context-menu-ok-button");
     var $radioButtonLabels = $menuWindow.find(".radio-button-labels");
 
@@ -57,7 +58,7 @@ function ContextMenu (uiContextMenu) {
         if (isMac){
             if (lastKeyCmd && down[91] && isOpen() && down[65]){
                 $descriptionTextBox.select();
-                down[65] = false; //reset A key 
+                down[65] = false; //reset A key
             }//A key, menu shown
 
         }//mac
@@ -295,10 +296,20 @@ function ContextMenu (uiContextMenu) {
                 acceptedLabelTypes = ['SurfaceProblem', 'Obstacle', 'NoCurbRamp', 'Other', 'CurbRamp'];
             if (acceptedLabelTypes.indexOf(labelType) != -1) {
                 setStatus('targetLabel', param.targetLabel);
+                var topCoordinate = y + 20;
+                var connectorCoordinate = -13;
+                //if the menu is so far down the screen that it will get cut off
+                if(topCoordinate>370){
+                  topCoordinate = y - 40 - windowHeight;
+                  connectorCoordinate = windowHeight + 13;
+                }
                 $menuWindow.css({
                     visibility: 'visible',
                     left: x - windowWidth / 2,
-                    top: y + 20
+                    top: topCoordinate
+                });
+                $connector.css({
+                  top: connectorCoordinate
                 });
 
                 if (param) {


### PR DESCRIPTION
If the context menu is low enough on the screen to get cut off, it will appear above the label rather than below label.

Normal:
![image](https://user-images.githubusercontent.com/19720010/27971260-fc3a79e8-631f-11e7-9fe7-64f7ce5b2476.png)

Too Low:
![image](https://user-images.githubusercontent.com/19720010/27971268-02330914-6320-11e7-8c4f-89f5dbafecf1.png)

Resolves #812 