### PR TITLE
updated some text in FAQ

### DIFF
--- a/app/views/faq.scala.html
+++ b/app/views/faq.scala.html
@@ -305,12 +305,7 @@
                                     </tr>
                                     <tr>
                                         <th></th>
-                                        <th><kbd>Enter</kbd></th>
-                                        <td>Close label rating</td>
-                                    </tr>
-                                    <tr>
-                                        <th></th>
-                                        <th><kbd>Esc</kbd></th>
+                                        <th><kbd>Enter</kbd> or <kbd>Esc</kbd></th>
                                         <td>Close label rating</td>
                                     </tr>
                                     <tr>

--- a/app/views/faq.scala.html
+++ b/app/views/faq.scala.html
@@ -28,22 +28,22 @@
                     <div class="row">
                         <div class="col-sm-12">
                             <p>
-                                Great! We really appreciate your help! It would be very helpful if you could use our tool to <i>audit accessibility of neighborhoods.</i>
+                                Thanks for chipping in! You can help us out by using our tool to <i>audit the accessibility of neighborhoods.</i>
                                 By accessibility audit, we mean:
                             </p>
                             <ol>
                                 <li>
-                                    Click <a href='@routes.AuditController.audit'>Start Auditing</a>.
+                                    Click <a href='@routes.AuditController.audit'>Start Mapping</a>.
                                 </li>
                                 <li>
-                                    Take an interactive tutorial to learn how to use our tool (if you haven't taken one before).
+                                    Take an interactive tutorial to learn how to use our tool (if you haven't taken it before).
                                 </li>
                                 <li>
                                     Walk along the streets and explore the neighborhood to find and label accessibility features.
                                 </li>
                             </ol>
                             <p>
-                                Please watch the following video to see the demo of how the accessibility audit works:
+                                Please watch the following video to see a demo of how an accessibility audit works:
                             </p>
                         </div>
                         <div class="video col-sm-12" style="text-align:center">
@@ -53,11 +53,11 @@
                 </div>
 
                 <div class="faq-item">
-                    <h2 class="question" id="can-i-select-a-neighborhood-to-audit">Can I select a neighborhood to audit?</h2>
+                    <h2 class="question" id="can-i-select-a-neighborhood-to-audit">Can I pick which neighborhood I audit?</h2>
                     <div class="row">
                         <div class="col-sm-12">
                             <p>
-                                Yes! Please follow the following steps:
+                                Yes! Just follow these steps:
                             </p>
                             <ol>
                                 <li>
@@ -179,13 +179,14 @@
                 </div>
 
                 <div class="faq-item">
-                    <h2 class="question" id="what-to-do-when-navigation-arrow-disappears">What to do when navigation arrow disappears?</h2>
+                    <h2 class="question" id="what-to-do-when-navigation-arrow-disappears">What to do when the navigation arrow disappears?</h2>
                     <div class="row">
                         <div class="col-sm-12">
                             <p>
-                                Sometimes during auditing, you would have noticed that the navigation arrows go missing, especially, while walking straight.
+                                Sometimes while auditing, you may have noticed that the navigation arrows go missing, especially while walking straight.
                                 Worry not, there is a simple solution! <br/><br/>
-                                Just double click on the street to move ahead and you are all set!
+                                Just double click on the street to move ahead and you are all set! <br/><br/>
+                                And if you are still stuck, you can always use the Jump button on the left.
 
                             </p>
                         </div>
@@ -233,7 +234,7 @@
                             </p>
                             <p>
                                 So, <i>why</i> does it work like this? Well, the answer is kind of complicated but the short answer is:
-                                    the Google Street View interface is akin to a 3-dimensional interface similar to walking in the real world.
+                                    the Google Street View interface is akin to a 3-dimensional interface, similar to walking in the real world.
                                     When you place a label, we convert the 3D position of the label to a 2D lat/long position. However, once you take a
                                     step to a new location, we cannot accurately recompute the label's position in 3D for that new view. See, we told
                                     you it was kind of complicated. :)
@@ -248,7 +249,7 @@
                 </div>
 
                 <div class="faq-item">
-                    <h2 class="question" id="are-there-keyboard-shortcuts-for-the-image-labeling-interface">Are there keyboard shortcuts for the image labeling interface?</h2>
+                    <h2 class="question" id="are-there-keyboard-shortcuts-for-the-image-labeling-interface">Are there keyboard shortcuts?</h2>
                     <div class="row">
                         <div class="col-sm-12">
                             <div class="spacer10"></div>
@@ -305,6 +306,11 @@
                                     <tr>
                                         <th></th>
                                         <th><kbd>Enter</kbd></th>
+                                        <td>Close label rating</td>
+                                    </tr>
+                                    <tr>
+                                        <th></th>
+                                        <th><kbd>Esc</kbd></th>
                                         <td>Close label rating</td>
                                     </tr>
                                     <tr>


### PR DESCRIPTION
Improved some grammar, readability, conciseness in the FAQ page. Also updated a thing or two to reflect changes since the FAQ was originally created (e.g., it now says Start Mapping instead of Start Auditing). 

Also added the Esc keyboard shortcut to the table. But I want some feedback on this, since it has the same function as the Enter key. So we could either leave it out, or one of the following option...
![shortcut1](https://user-images.githubusercontent.com/6518824/28025324-16a5d604-6561-11e7-94a4-c50e651cd201.png)
![shortcuts2](https://user-images.githubusercontent.com/6518824/28025325-16a6b056-6561-11e7-9a1b-d2cf0588ec3f.png)

I currently have the 1st option in this PR.