### PR TITLE
Removed unsupported browser message

### DIFF
--- a/app/views/audit.scala.html
+++ b/app/views/audit.scala.html
@@ -12,8 +12,6 @@
     <script type="text/javascript" src='@routes.Assets.at("javascripts/SVLabel/lib/gsv/zpipe.min.js")'></script>
     <script type="text/javascript" src='@routes.Assets.at("javascripts/SVLabel/lib/gsv/jquery.base64.min.js")'></script>
     <script type="text/javascript" src='@routes.Assets.at("javascripts/SVLabel/lib/kinetic-v4.3.3.min.js")'></script>
-    <script type="text/javascript" src='@routes.Assets.at("assets/detectUnsupportedBrowser.js")'></script>
-
 
     <link rel="stylesheet" href='@routes.Assets.at("javascripts/SVLabel/build/SVLabel.css")'/>
     <link rel="stylesheet" href='@routes.Assets.at("stylesheets/animate.css")'/>
@@ -32,13 +30,6 @@
                     <span class="advanced-neighborhood-option" id="continue-advanced">Yes, continue</span>
                     <span class="advanced-neighborhood-option" id="redirect-advanced">No, take me somewhere else</span>
                 </div>
-            </div>
-        </div>
-        <div class="page-alert-holder" id="unsupported-browser-alert" style="visibility: hidden">
-            <div class="page-alert">
-                <span id="page-alert-message"><strong>Disclaimer:</strong> This site is optimized for Google Chrome. Other browsers are not fully supported yet.&nbsp;</span>
-
-                <a id="page-alert-close" onClick="hideBrowserVersionAlert();" href="#"><span class="glyphicon glyphicon-remove"></span></a>
             </div>
         </div>
         <div id="svl-application-holder">

--- a/app/views/audit.scala.html
+++ b/app/views/audit.scala.html
@@ -12,6 +12,8 @@
     <script type="text/javascript" src='@routes.Assets.at("javascripts/SVLabel/lib/gsv/zpipe.min.js")'></script>
     <script type="text/javascript" src='@routes.Assets.at("javascripts/SVLabel/lib/gsv/jquery.base64.min.js")'></script>
     <script type="text/javascript" src='@routes.Assets.at("javascripts/SVLabel/lib/kinetic-v4.3.3.min.js")'></script>
+    <script type="text/javascript" src='@routes.Assets.at("assets/detectUnsupportedBrowser.js")'></script>
+
 
     <link rel="stylesheet" href='@routes.Assets.at("javascripts/SVLabel/build/SVLabel.css")'/>
     <link rel="stylesheet" href='@routes.Assets.at("stylesheets/animate.css")'/>
@@ -30,6 +32,13 @@
                     <span class="advanced-neighborhood-option" id="continue-advanced">Yes, continue</span>
                     <span class="advanced-neighborhood-option" id="redirect-advanced">No, take me somewhere else</span>
                 </div>
+            </div>
+        </div>
+        <div class="page-alert-holder" id="unsupported-browser-alert" style="visibility: hidden">
+            <div class="page-alert">
+                <span id="page-alert-message"><strong>Disclaimer:</strong> This site is optimized for Google Chrome. Other browsers are not fully supported yet.&nbsp;</span>
+
+                <a id="page-alert-close" onClick="hideBrowserVersionAlert();" href="#"><span class="glyphicon glyphicon-remove"></span></a>
             </div>
         </div>
         <div id="svl-application-holder">

--- a/public/assets/detectUnsupportedBrowser.js
+++ b/public/assets/detectUnsupportedBrowser.js
@@ -4,7 +4,7 @@ function hideBrowserVersionAlert(){
 
 document.addEventListener('DOMContentLoaded', function() {
 
-    if(!bowser.chrome){
+    if(!bowser.chrome && !bowser.firefox && !bowser.safari){
         document.getElementById("unsupported-browser-alert").style.visibility="visible";
     }
 }, false);


### PR DESCRIPTION
Resolves #715. Now that we support all the browsers that we've tested, we no longer need to display the "Browser unsupported" message.

edit: got ahead of myself. we still should display this alert for browsers that aren't firefox, chrome, or safari. will commit this fix shortly