### PR TITLE
Issue #849 Fix Error with Closing Context Menu

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
@@ -22,6 +22,7 @@ function ContextMenu (uiContextMenu) {
         var clicked_out = !(context_menu_el.contains(event.target));
         if (isOpen()){
             hide();
+            wasOpen = true;
             if (clicked_out) _handleSeverityPopup();
         }
     }); //handles clicking outside of context menu holder

--- a/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
+++ b/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
@@ -53,7 +53,8 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
             beforeJumpListenerHandle: undefined
         },
         jumpLocation = undefined,
-        missionJump = undefined;
+        missionJump = undefined
+        wasOpen = false;
 
     var initialPositionUpdate = true,
         panoramaOptions,
@@ -1088,6 +1089,7 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
         //    setViewControlLayerCursor('ZoomOut');
         //}
 
+
         currTime = new Date().getTime();
 
         var point = _canvas.isOn(mouseStatus.currX, mouseStatus.currY);
@@ -1098,10 +1100,14 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
 
             _canvas.setCurrentLabel(selectedLabel);
             if ('contextMenu' in svl) {
+              if(wasOpen){
+                svl.contextMenu.hide();
+              } else{
                 svl.contextMenu.show(canvasCoordinate.x, canvasCoordinate.y, {
                     targetLabel: selectedLabel,
                     targetLabelColor: selectedLabel.getProperty("labelFillStyle")
-                });
+              });}
+              wasOpen = false;
             }
         } else if (currTime - mouseStatus.prevMouseUpTime < 300) {
             // Double click
@@ -1158,6 +1164,7 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
         }
 
 
+        setViewControlLayerCursor('OpenHand');
         mouseStatus.prevMouseUpTime = currTime;
     }
 


### PR DESCRIPTION
On mousedown, the context menu will close, but now it will not immediately reopen on mouseup (which was the most significant annoyance reported by @misaugstad)

Resolves #849 