### PR TITLE
mission count chart now defaults to excluding researchers

### DIFF
--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -1095,7 +1095,7 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
                     var combinedChart = {"hconcat": [allChart, regChart, anonChart]};
                     var combinedChartFiltered = {"hconcat": [allFilteredChart, regFilteredChart, anonChart]};
 
-                    vega.embed("#mission-count-chart", combinedChart, opt, function(error, results) {});
+                    vega.embed("#mission-count-chart", combinedChartFiltered, opt, function(error, results) {});
 
                     var checkbox = document.getElementById("mission-count-include-researchers-checkbox").addEventListener("click", function(cb) {
                         if (cb.srcElement.checked) {


### PR DESCRIPTION
For the user mission counts histogram on the admin dashboard, there is a checkbox for including data from the researchers in the histogram. The histogram was meant to initially exclude researcher data. The box was unchecked, but the graph that was actually including the researcher data to start.  

![sidewalk-mission_count-admin](https://user-images.githubusercontent.com/6518824/28251424-e94e97e2-6a4a-11e7-97fe-6ec3b7eab088.png)
