### PR TITLE
Add Choropleth vs Start Mapping click statistic to admin page

### DIFF
--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -384,14 +384,14 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
     * @param activity
     */
   def getWebpageActivities(activity: String) = UserAwareAction.async{implicit request =>
-    if (isAdmin(request.identity)) {
-        val activities = WebpageActivityTable.webpageActivityListToJson(WebpageActivityTable.find(activity))
-        if(activities.length == 0){
-          Future.successful(BadRequest(Json.obj("status" -> "Error", "message" -> "Invalid activity name")))
-        } else {
-          Future.successful(Ok(Json.arr(activities)))
-        }
-    } else {
+    if (isAdmin(request.identity)){
+      val activities = WebpageActivityTable.webpageActivityListToJson(WebpageActivityTable.findKeyVal(activity, Array()))
+      if(activities.length == 0){
+        Future.successful(BadRequest(Json.obj("status" -> "Error", "message" -> "Invalid activity name")))
+      } else {
+        Future.successful(Ok(Json.arr(activities)))
+      }
+    }else{
       Future.successful(Redirect("/"))
     }
   }
@@ -404,9 +404,15 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
     }
   }
 
-  def getWebpageActivitiesKeyVal(activity: String, key: String, value: String) = UserAwareAction.async{ implicit request =>
+  def getWebpageActivitiesKeyVal(activity: String, keyValPairs: String) = UserAwareAction.async{ implicit request =>
     if (isAdmin(request.identity)){
-      Future.successful(Ok(Json.arr(WebpageActivityTable.webpageActivityListToJson(WebpageActivityTable.findKeyVal(activity, key, value)))))
+      val keyVals: Array[String] = keyValPairs.split("/")
+      val activities = WebpageActivityTable.webpageActivityListToJson(WebpageActivityTable.findKeyVal(activity, keyVals))
+      if(activities.length == 0){
+        Future.successful(BadRequest(Json.obj("status" -> "Error", "message" -> "Invalid activity name and/or key-value pair")))
+      } else {
+        Future.successful(Ok(Json.arr(activities)))
+      }
     }else{
       Future.successful(Redirect("/"))
     }

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -376,4 +376,31 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
     )))
     Future.successful(Ok(json))
   }
+
+
+  /** If no argument is provided, returns all webpage activities
+    * Otherwise, returns all activities that match the activity provided
+    * If the activity provided doesn't exist, returns 400 (Bad Request)
+    * @param activity
+    */
+  def getWebpageActivities(activity: String) = UserAwareAction.async{implicit request =>
+    if (isAdmin(request.identity)) {
+        val activities = WebpageActivityTable.webpageActivityListToJson(WebpageActivityTable.find(activity))
+        if(activities.length == 0){
+          Future.successful(BadRequest(Json.obj("status" -> "Error", "message" -> "Invalid activity name")))
+        } else {
+          Future.successful(Ok(Json.arr(activities)))
+        }
+    } else {
+      Future.successful(Redirect("/"))
+    }
+  }
+
+  def getAllWebpageActivities = UserAwareAction.async{implicit request =>
+    if (isAdmin(request.identity)){
+      Future.successful(Ok(Json.arr(WebpageActivityTable.webpageActivityListToJson(WebpageActivityTable.getAllActivities))))
+    }else{
+      Future.successful(Redirect("/"))
+    }
+  }
 }

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -400,9 +400,10 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
     Future.successful(Ok(json))
   }
 
-  /** If no argument is provided, returns all webpage activities
-    * Otherwise, returns all activities that match the activity provided
-    * If the activity provided doesn't exist, returns 400 (Bad Request)
+  /**
+    * If no argument is provided, returns all webpage activity records. O/w, returns all records with matching activity
+    * If the activity provided doesn't exist, returns 400 (Bad Request).
+    *
     * @param activity
     */
   def getWebpageActivities(activity: String) = UserAwareAction.async{implicit request =>
@@ -418,6 +419,7 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
     }
   }
 
+  /** Returns all records in the webpage_interactions table as a JSON array. */
   def getAllWebpageActivities = UserAwareAction.async{implicit request =>
     if (isAdmin(request.identity)){
       Future.successful(Ok(Json.arr(WebpageActivityTable.webpageActivityListToJson(WebpageActivityTable.getAllActivities))))
@@ -426,20 +428,24 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
     }
   }
 
+  /**
+    * Returns all records in webpage_activity table with activity field containing both activity and all keyValPairs.
+    *
+    * @param activity
+    * @param keyValPairs
+    * @return
+    */
   def getWebpageActivitiesKeyVal(activity: String, keyValPairs: String) = UserAwareAction.async{ implicit request =>
     if (isAdmin(request.identity)){
       val keyVals: Array[String] = keyValPairs.split("/").map(URLDecoder.decode(_, "UTF-8"))
       val activities = WebpageActivityTable.webpageActivityListToJson(WebpageActivityTable.findKeyVal(activity, keyVals))
-      if(activities.length == 0){
-        Future.successful(BadRequest(Json.obj("status" -> "Error", "message" -> "Invalid activity name and/or key-value pair")))
-      } else {
-        Future.successful(Ok(Json.arr(activities)))
-      }
+      Future.successful(Ok(Json.arr(activities)))
     }else{
       Future.successful(Redirect("/"))
     }
   }
 
+  /** Returns number of records in webpage_activity table containing the specified activity. */
   def getNumWebpageActivities(activity: String) =   UserAwareAction.async{implicit request =>
     if (isAdmin(request.identity)){
       val activities = WebpageActivityTable.webpageActivityListToJson(WebpageActivityTable.findKeyVal(activity, Array()))
@@ -448,6 +454,8 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
       Future.successful(Redirect("/"))
     }
   }
+
+  /** Returns number of records in webpage_activity table containing the specified activity and other keyValPairs. */
   def getNumWebpageActivitiesKeyVal(activity: String, keyValPairs: String) = UserAwareAction.async{ implicit request =>
     if (isAdmin(request.identity)){
       val keyVals: Array[String] = keyValPairs.split("/").map(URLDecoder.decode(_, "UTF-8"))

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -407,7 +407,7 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
 
   def getWebpageActivitiesKeyVal(activity: String, keyValPairs: String) = UserAwareAction.async{ implicit request =>
     if (isAdmin(request.identity)){
-      val keyVals: Array[String] = keyValPairs.split("/")
+      val keyVals: Array[String] = keyValPairs.split("/").map(URLDecoder.decode(_, "UTF-8"))
       val activities = WebpageActivityTable.webpageActivityListToJson(WebpageActivityTable.findKeyVal(activity, keyVals))
       if(activities.length == 0){
         Future.successful(BadRequest(Json.obj("status" -> "Error", "message" -> "Invalid activity name and/or key-value pair")))

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -2,6 +2,7 @@ package controllers
 
 import java.util.UUID
 import javax.inject.Inject
+import java.net.URLDecoder
 
 import com.mohiva.play.silhouette.api.{Environment, LogoutEvent, Silhouette}
 import com.mohiva.play.silhouette.impl.authenticators.SessionAuthenticator
@@ -428,7 +429,7 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
   }
   def getNumWebpageActivitiesKeyVal(activity: String, keyValPairs: String) = UserAwareAction.async{ implicit request =>
     if (isAdmin(request.identity)){
-      val keyVals: Array[String] = keyValPairs.split("/")
+      val keyVals: Array[String] = keyValPairs.split("/").map(URLDecoder.decode(_, "UTF-8"))
       val activities = WebpageActivityTable.webpageActivityListToJson(WebpageActivityTable.findKeyVal(activity, keyVals))
       Future.successful(Ok(activities.length + ""))
     }else{

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -417,4 +417,22 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
       Future.successful(Redirect("/"))
     }
   }
+
+  def getNumWebpageActivities(activity: String) =   UserAwareAction.async{implicit request =>
+    if (isAdmin(request.identity)){
+      val activities = WebpageActivityTable.webpageActivityListToJson(WebpageActivityTable.findKeyVal(activity, Array()))
+      Future.successful(Ok(activities.length + ""))
+    }else{
+      Future.successful(Redirect("/"))
+    }
+  }
+  def getNumWebpageActivitiesKeyVal(activity: String, keyValPairs: String) = UserAwareAction.async{ implicit request =>
+    if (isAdmin(request.identity)){
+      val keyVals: Array[String] = keyValPairs.split("/")
+      val activities = WebpageActivityTable.webpageActivityListToJson(WebpageActivityTable.findKeyVal(activity, keyVals))
+      Future.successful(Ok(activities.length + ""))
+    }else{
+      Future.successful(Redirect("/"))
+    }
+  }
 }

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -403,4 +403,12 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
       Future.successful(Redirect("/"))
     }
   }
+
+  def getWebpageActivitiesKeyVal(activity: String, key: String, value: String) = UserAwareAction.async{ implicit request =>
+    if (isAdmin(request.identity)){
+      Future.successful(Ok(Json.arr(WebpageActivityTable.webpageActivityListToJson(WebpageActivityTable.findKeyVal(activity, key, value)))))
+    }else{
+      Future.successful(Redirect("/"))
+    }
+  }
 }

--- a/app/models/user/WebpageActivityTable.scala
+++ b/app/models/user/WebpageActivityTable.scala
@@ -90,8 +90,16 @@ object WebpageActivityTable {
   def find(activity: String): List[WebpageActivity] = db.withSession { implicit session =>
     activities.filter(_.activity.like("%"++activity++"%")).list
   }
-  // Returns all WebpageActivities that contain the given string and keyValue pairs in their 'activity' field
-  // Partial activity searches work (for example, if activity is "Cli" then WebpageActivities whose activity begins with "Cli..." will be matched)
+
+  /** Returns all WebpageActivities that contain the given string and keyValue pairs in their 'activity' field
+    *
+    * Partial activity searches work (for example, if activity is "Cli" then WebpageActivities whose activity begins
+    * with "Cli...", such as "Click" will be matched)
+    *
+    * @param activity
+    * @param keyVals
+    * @return
+    */
   def findKeyVal(activity: String, keyVals: Array[String]): List[WebpageActivity] = db.withSession { implicit session =>
     var filteredActivities = activities.filter(x => (x.activity.startsWith(activity++"_") || x.activity === activity))
     for(keyVal <- keyVals) yield {
@@ -99,6 +107,7 @@ object WebpageActivityTable {
     }
     filteredActivities.list
   }
+
   // Returns all webpage activities
   def getAllActivities: List[WebpageActivity] = db.withSession{implicit session =>
     activities.list
@@ -107,6 +116,7 @@ object WebpageActivityTable {
   def webpageActivityListToJson(webpageActivities: List[WebpageActivity]): List[JsObject] = {
     webpageActivities.map(webpageActivity => webpageActivityToJson(webpageActivity)).toList
   }
+
   def webpageActivityToJson(webpageActivity: WebpageActivity): JsObject = {
     Json.obj(
       "webpageActivityId" -> webpageActivity.webpageActivityId,

--- a/app/models/user/WebpageActivityTable.scala
+++ b/app/models/user/WebpageActivityTable.scala
@@ -88,7 +88,10 @@ object WebpageActivityTable {
     * Returns all instances of a specific activity
     */
   def find(activity: String): List[WebpageActivity] = db.withSession { implicit session =>
-    activities.filter(_.activity === activity).list
+    activities.filter(_.activity.like("%"++activity++"%")).list
+  }
+  def findKeyVal(activity: String, key: String, value: String): List[WebpageActivity] = db.withSession { implicit session =>
+    activities.filter(thisActivity => thisActivity.activity.like("%"++key++"="++value++"%") && thisActivity.activity.like("%"++activity++"%")).list
   }
   // Returns all webpage activities
   def getAllActivities: List[WebpageActivity] = db.withSession{implicit session =>

--- a/app/models/user/WebpageActivityTable.scala
+++ b/app/models/user/WebpageActivityTable.scala
@@ -91,11 +91,11 @@ object WebpageActivityTable {
     activities.filter(_.activity.like("%"++activity++"%")).list
   }
   // Returns all WebpageActivities that contain the given string and keyValue pairs in their 'activity' field
-  // Really, it doesn't have to be a key-value pair. It could just be a key. Or a value. Or even part of a key or value.
+  // Partial activity searches work (for example, if activity is "Cli" then WebpageActivities whose activity begins with "Cli..." will be matched)
   def findKeyVal(activity: String, keyVals: Array[String]): List[WebpageActivity] = db.withSession { implicit session =>
-    var filteredActivities = activities.filter(_.activity.like("%"++activity++"%"))
+    var filteredActivities = activities.filter(x => (x.activity.startsWith(activity++"_") || x.activity === activity))
     for(keyVal <- keyVals) yield {
-      filteredActivities = filteredActivities.filter(_.activity.like("%"++keyVal++"%"))
+      filteredActivities = filteredActivities.filter(x => (x.activity.indexOf("_"++keyVal++"_") >= 0) || x.activity.endsWith("_"+keyVal))
     }
     filteredActivities.list
   }

--- a/app/models/user/WebpageActivityTable.scala
+++ b/app/models/user/WebpageActivityTable.scala
@@ -4,6 +4,7 @@ import java.util.UUID
 
 import models.utils.MyPostgresDriver.simple._
 import play.api.Play.current
+import play.api.libs.json.{JsObject, Json}
 
 case class WebpageActivity(webpageActivityId: Int, userId: String, ipAddress: String, description: String, timestamp: java.sql.Timestamp)
 
@@ -81,5 +82,29 @@ object WebpageActivityTable {
     activities.filter(_.activity === "SignIn").groupBy(x => x.userId).map{
       case (id, group) => (id, group.map(_.activity).length)
     }.list
+  }
+
+  /**
+    * Returns all instances of a specific activity
+    */
+  def find(activity: String): List[WebpageActivity] = db.withSession { implicit session =>
+    activities.filter(_.activity === activity).list
+  }
+  // Returns all webpage activities
+  def getAllActivities: List[WebpageActivity] = db.withSession{implicit session =>
+    activities.list
+  }
+
+  def webpageActivityListToJson(webpageActivities: List[WebpageActivity]): List[JsObject] = {
+    webpageActivities.map(webpageActivity => webpageActivityToJson(webpageActivity)).toList
+  }
+  def webpageActivityToJson(webpageActivity: WebpageActivity): JsObject = {
+    Json.obj(
+      "webpageActivityId" -> webpageActivity.webpageActivityId,
+      "userId" -> webpageActivity.userId,
+      "ipAddress" -> webpageActivity.ipAddress,
+      "activity" -> webpageActivity.description,
+      "timestamp" -> webpageActivity.timestamp
+    )
   }
 }

--- a/app/models/user/WebpageActivityTable.scala
+++ b/app/models/user/WebpageActivityTable.scala
@@ -85,13 +85,19 @@ object WebpageActivityTable {
   }
 
   /**
-    * Returns all instances of a specific activity
+    * Returns all WebpageActivities that contain the given string in their 'activity' field
     */
   def find(activity: String): List[WebpageActivity] = db.withSession { implicit session =>
     activities.filter(_.activity.like("%"++activity++"%")).list
   }
-  def findKeyVal(activity: String, key: String, value: String): List[WebpageActivity] = db.withSession { implicit session =>
-    activities.filter(thisActivity => thisActivity.activity.like("%"++key++"="++value++"%") && thisActivity.activity.like("%"++activity++"%")).list
+  // Returns all WebpageActivities that contain the given string and keyValue pairs in their 'activity' field
+  // Really, it doesn't have to be a key-value pair. It could just be a key. Or a value. Or even part of a key or value.
+  def findKeyVal(activity: String, keyVals: Array[String]): List[WebpageActivity] = db.withSession { implicit session =>
+    var filteredActivities = activities.filter(_.activity.like("%"++activity++"%"))
+    for(keyVal <- keyVals) yield {
+      filteredActivities = filteredActivities.filter(_.activity.like("%"++keyVal++"%"))
+    }
+    filteredActivities.list
   }
   // Returns all webpage activities
   def getAllActivities: List[WebpageActivity] = db.withSession{implicit session =>

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -388,7 +388,7 @@
                     <label><input type="checkbox" id="login-count-include-researchers-checkbox"> Include researchers</label>
 
                     <h2>How users access Audit Page from Landing Page:</h2>
-                    <div class="col-lg-6 col-md-4" style="align:left">
+                    <div class="col-lg-8 col-md-4" style="align:left">
                         <table class="table table-bordered">
                             <thead>
                                 <tr>
@@ -405,7 +405,7 @@
                                     <td style="text-align: right;">Click <i>Start Mapping (Navbar)</i></td>
                                 </tr>
                                 <tr id="audit-access-table-choro">
-                                    <td style="text-align: right;">Click Choropleth</td>
+                                    <td style="text-align: right;">Click Via Choropleth</td>
                                 </tr>
                                 <tr id="audit-access-table-total">
                                     <td style="text-align: right;">Total <i>(Visit Audit)</i></td>

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -387,9 +387,24 @@
                     </div>
                     <label><input type="checkbox" id="login-count-include-researchers-checkbox"> Include researchers</label>
 
-                    <h2>Choropleth vs Start Mapping in Accessing Audit Page</h2>
-                    <div class="col-lg-12">
-                        <div id="audit-access-method-chart" class="col-lg-12" style="position:relative;"></div>
+                    <h2>How Users Access Audit Page:</h2>
+                    <div class="col-lg-4 col-md-4" style="align:left">
+                        <table class="table table-bordered">
+                            <tbody>
+                                <tr>
+                                    <td style="text-align: right;">Visit Audit</td>
+                                    <td id="table-cell-num-visit-audit"></td>
+                                </tr>
+                                <tr>
+                                    <td style="text-align: right;">Click "Start Mapping"</td>
+                                    <td id="table-cell-num-click-start"></td>
+                                </tr>
+                                <tr>
+                                    <td style="text-align: right;">Click Choropleth</td>
+                                    <td id="table-cell-num-choro-click"></td>
+                                </tr>
+                            </tbody>
+                        </table>
                     </div>
 
                 </div>

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -389,7 +389,7 @@
 
                     <h2>Choropleth vs Start Mapping in Accessing Audit Page</h2>
                     <div class="col-lg-12">
-                        <div id="audit-access-method-chart"></div>
+                        <div id="audit-access-method-chart" class="col-lg-12" style="position:relative;"></div>
                     </div>
 
                 </div>

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -399,16 +399,16 @@
                             </thead>
                             <tbody>
                                 <tr id="audit-access-table-start-main">
-                                    <td style="text-align: right;">Click "Start Mapping (Main)"</td>
+                                    <td style="text-align: right;">Click <i>Start Mapping (Main)</i></td>
                                 </tr>
                                 <tr id="audit-access-table-start-nav">
-                                    <td style="text-align: right;">Click "Start Mapping (Navbar)"</td>
+                                    <td style="text-align: right;">Click <i>Start Mapping (Navbar)</i></td>
                                 </tr>
                                 <tr id="audit-access-table-choro">
                                     <td style="text-align: right;">Click Choropleth</td>
                                 </tr>
                                 <tr id="audit-access-table-total">
-                                    <td style="text-align: right;">Total (Visit Audit)</td>
+                                    <td style="text-align: right;">Total <i>(Visit Audit)</i></td>
                                 </tr>
                             </tbody>
                         </table>

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -388,20 +388,27 @@
                     <label><input type="checkbox" id="login-count-include-researchers-checkbox"> Include researchers</label>
 
                     <h2>How Users Access Audit Page:</h2>
-                    <div class="col-lg-4 col-md-4" style="align:left">
+                    <div class="col-lg-6 col-md-4" style="align:left">
                         <table class="table table-bordered">
+                            <thead>
+                                <tr>
+                                    <th style="text-align: right;">Activity</th>
+                                    <th style="text-align: right;">Number</th>
+                                    <th style="text-align: right;">Percentage (%)</th>
+                                </tr>
+                            </thead>
                             <tbody>
-                                <tr>
+                                <tr id="audit-access-table-audit">
                                     <td style="text-align: right;">Visit Audit</td>
-                                    <td id="table-cell-num-visit-audit"></td>
                                 </tr>
-                                <tr>
+                                <tr id="audit-access-table-start">
                                     <td style="text-align: right;">Click "Start Mapping"</td>
-                                    <td id="table-cell-num-click-start"></td>
                                 </tr>
-                                <tr>
+                                <tr id="audit-access-table-choro">
                                     <td style="text-align: right;">Click Choropleth</td>
-                                    <td id="table-cell-num-choro-click"></td>
+                                </tr>
+                                <tr id="audit-access-table-total">
+                                    <td style="text-align: right;">Total (Visit Index)</td>
                                 </tr>
                             </tbody>
                         </table>

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -387,6 +387,11 @@
                     </div>
                     <label><input type="checkbox" id="login-count-include-researchers-checkbox"> Include researchers</label>
 
+                    <h2>Choropleth vs Start Mapping in Accessing Audit Page</h2>
+                    <div class="col-lg-12">
+                        <div id="audit-access-method-chart"></div>
+                    </div>
+
                 </div>
             </div>
             <div id="tabs-4" class="tab-pane">

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -387,28 +387,28 @@
                     </div>
                     <label><input type="checkbox" id="login-count-include-researchers-checkbox"> Include researchers</label>
 
-                    <h2>How Users Access Audit Page:</h2>
+                    <h2>How users access Audit Page from Landing Page:</h2>
                     <div class="col-lg-6 col-md-4" style="align:left">
                         <table class="table table-bordered">
                             <thead>
                                 <tr>
                                     <th style="text-align: right;">Activity</th>
                                     <th style="text-align: right;">Number</th>
-                                    <th style="text-align: right;">Percentage (%)</th>
+                                    <th style="text-align: right;">Percentage of Audit Visitors(%)</th>
                                 </tr>
                             </thead>
                             <tbody>
-                                <tr id="audit-access-table-audit">
-                                    <td style="text-align: right;">Visit Audit</td>
+                                <tr id="audit-access-table-start-main">
+                                    <td style="text-align: right;">Click "Start Mapping (Main)"</td>
                                 </tr>
-                                <tr id="audit-access-table-start">
-                                    <td style="text-align: right;">Click "Start Mapping"</td>
+                                <tr id="audit-access-table-start-nav">
+                                    <td style="text-align: right;">Click "Start Mapping (Navbar)"</td>
                                 </tr>
                                 <tr id="audit-access-table-choro">
                                     <td style="text-align: right;">Click Choropleth</td>
                                 </tr>
                                 <tr id="audit-access-table-total">
-                                    <td style="text-align: right;">Total (Visit Index)</td>
+                                    <td style="text-align: right;">Total (Visit Audit)</td>
                                 </tr>
                             </tbody>
                         </table>

--- a/conf/routes
+++ b/conf/routes
@@ -50,6 +50,8 @@ GET     /adminapi/labelCounts/anonymous         @controllers.AdminController.get
 GET     /adminapi/webpageActivities             @controllers.AdminController.getAllWebpageActivities
 GET     /adminapi/webpageActivities/:activity   @controllers.AdminController.getWebpageActivities(activity: String)
 GET     /adminapi/webpageActivities/:activity/*keyValPairs  @controllers.AdminController.getWebpageActivitiesKeyVal(activity: String, keyValPairs: String)
+GET     /adminapi/numWebpageActivities/:activity @controllers.AdminController.getNumWebpageActivities(activity: String)
+GET     /adminapi/numWebpageActivities/:activity/*keyValPairs  @controllers.AdminController.getNumWebpageActivitiesKeyVal(activity: String, keyValPairs: String)
 
 
 # Auditing tasks

--- a/conf/routes
+++ b/conf/routes
@@ -49,11 +49,12 @@ GET     /adminapi/labelCounts/registered        @controllers.AdminController.get
 GET     /adminapi/labelCounts/anonymous         @controllers.AdminController.getAllAnonUserLabelCounts
 GET     /adminapi/webpageActivities             @controllers.AdminController.getAllWebpageActivities
 GET     /adminapi/webpageActivities/:activity   @controllers.AdminController.getWebpageActivities(activity: String)
+GET     /adminapi/webpageActivities/:activity/:key/:value   @controllers.AdminController.getWebpageActivitiesKeyVal(activity: String, key: String, value: String)
 
 
 # Auditing tasks
 GET     /audit                                  @controllers.AuditController.audit
-GET     /audit/easyRegion                        @controllers.AuditController.auditNewEasyRegion
+GET     /audit/easyRegion                       @controllers.AuditController.auditNewEasyRegion
 GET     /audit/region/:id                       @controllers.AuditController.auditRegion(id: Int)
 GET     /audit/street/:id                       @controllers.AuditController.auditStreet(id: Int)
 POST    /audit/comment                          @controllers.AuditController.postComment

--- a/conf/routes
+++ b/conf/routes
@@ -49,7 +49,7 @@ GET     /adminapi/labelCounts/registered        @controllers.AdminController.get
 GET     /adminapi/labelCounts/anonymous         @controllers.AdminController.getAllAnonUserLabelCounts
 GET     /adminapi/webpageActivities             @controllers.AdminController.getAllWebpageActivities
 GET     /adminapi/webpageActivities/:activity   @controllers.AdminController.getWebpageActivities(activity: String)
-GET     /adminapi/webpageActivities/:activity/:key/:value   @controllers.AdminController.getWebpageActivitiesKeyVal(activity: String, key: String, value: String)
+GET     /adminapi/webpageActivities/:activity/*keyValPairs  @controllers.AdminController.getWebpageActivitiesKeyVal(activity: String, keyValPairs: String)
 
 
 # Auditing tasks

--- a/conf/routes
+++ b/conf/routes
@@ -3,50 +3,50 @@
 # ~~~~
 
 # Home page
-GET     /                                       @controllers.ApplicationController.index
-POST    /                                       controllers.TeaserController.teaserPost
+GET     /                                                    @controllers.ApplicationController.index
+POST    /                                                    controllers.TeaserController.teaserPost
 
-GET     /home                                   @controllers.ApplicationController.index
-GET     /about                                  @controllers.ApplicationController.about
-GET     /api                                    @controllers.ApplicationController.developer
-GET     /developer                              @controllers.ApplicationController.developer
-GET     /terms                                  @controllers.ApplicationController.terms
-GET     /demo                                   @controllers.ApplicationController.demo
-GET     /results                                @controllers.ApplicationController.results
-GET     /faq                                    @controllers.ApplicationController.faq
-GET     /student                                @controllers.ApplicationController.student
-GET     /mobile                                 @controllers.ApplicationController.mobile
+GET     /home                                                @controllers.ApplicationController.index
+GET     /about                                               @controllers.ApplicationController.about
+GET     /api                                                 @controllers.ApplicationController.developer
+GET     /developer                                           @controllers.ApplicationController.developer
+GET     /terms                                               @controllers.ApplicationController.terms
+GET     /demo                                                @controllers.ApplicationController.demo
+GET     /results                                             @controllers.ApplicationController.results
+GET     /faq                                                 @controllers.ApplicationController.faq
+GET     /student                                             @controllers.ApplicationController.student
+GET     /mobile                                              @controllers.ApplicationController.mobile
 
 # User authentication
-GET     /signIn                                 @controllers.UserController.signIn(url: String ?= "/")
-GET     /signUp                                 @controllers.UserController.signUp(url: String ?= "/")
-GET     /signOut                                               @controllers.UserController.signOut(url: String ?="/")
-POST    /signUp                                                @controllers.SignUpController.signUp(url: String ?= "/")
-POST    /authenticate/credentials                              @controllers.CredentialsAuthController.authenticate(url: String ?= "/")
-POST    /authapi/authenticate                                  @controllers.CredentialsAuthController.postAuthenticate
-POST    /authapi/signup                                        @controllers.SignUpController.postSignUp
+GET     /signIn                                              @controllers.UserController.signIn(url: String ?= "/")
+GET     /signUp                                              @controllers.UserController.signUp(url: String ?= "/")
+GET     /signOut                                             @controllers.UserController.signOut(url: String ?="/")
+POST    /signUp                                              @controllers.SignUpController.signUp(url: String ?= "/")
+POST    /authenticate/credentials                            @controllers.CredentialsAuthController.authenticate(url: String ?= "/")
+POST    /authapi/authenticate                                @controllers.CredentialsAuthController.postAuthenticate
+POST    /authapi/signup                                      @controllers.SignUpController.postSignUp
 
 # Admin
-GET     /admin                                                 @controllers.AdminController.index
-GET     /admin/user/:username                                  @controllers.AdminController.userProfile(username: String)
-GET     /admin/task/:taskId                                    @controllers.AdminController.task(taskId: Int)
+GET     /admin                                               @controllers.AdminController.index
+GET     /admin/user/:username                                @controllers.AdminController.userProfile(username: String)
+GET     /admin/task/:taskId                                  @controllers.AdminController.task(taskId: Int)
 
-GET     /adminapi/missionsCompletedByUsers                     @controllers.AdminController.getMissionsCompletedByUsers
-GET     /adminapi/neighborhoodCompletionRate                   @controllers.AdminController.getNeighborhoodCompletionRate
-GET     /adminapi/anonUserMissionCounts                        @controllers.AdminController.getAllAnonUserCompletedMissionCounts
-GET     /adminapi/allSignInCounts                              @controllers.AdminController.getAllUserSignInCounts
-GET     /adminapi/completionRateByDate                         @controllers.AdminController.getCompletionRateByDate
-GET     /adminapi/tasks/:username                              @controllers.AdminController.getSubmittedTasksWithLabels(username: String)
-GET     /adminapi/interactions/:username                       @controllers.AdminController.getAuditTaskInteractionsOfAUser(username: String)
-GET     /adminapi/onboardingInteractions                       @controllers.AdminController.getOnboardingTaskInteractions
-GET     /adminapi/auditpath/:id                                @controllers.AdminController.getAnAuditTaskPath(id: Int)
-GET     /adminapi/auditedStreets/:username                     @controllers.AdminController.getStreetsAuditedByAUser(username: String)
-GET     /adminapi/labelLocations/:username                     @controllers.AdminController.getLabelsCollectedByAUser(username: String)
-GET     /adminapi/labels/all                                   @controllers.AdminController.getAllLabels
-GET     /adminapi/labels/panoid                                @controllers.AdminController.getAllPanoIds
-GET     /adminapi/label/:labelId                               @controllers.AdminController.getLabelData(labelId: Int)
-GET     /adminapi/labelCounts/registered                       @controllers.AdminController.getAllRegisteredUserLabelCounts
-GET     /adminapi/labelCounts/anonymous                        @controllers.AdminController.getAllAnonUserLabelCounts
+GET     /adminapi/missionsCompletedByUsers                   @controllers.AdminController.getMissionsCompletedByUsers
+GET     /adminapi/neighborhoodCompletionRate                 @controllers.AdminController.getNeighborhoodCompletionRate
+GET     /adminapi/anonUserMissionCounts                      @controllers.AdminController.getAllAnonUserCompletedMissionCounts
+GET     /adminapi/allSignInCounts                            @controllers.AdminController.getAllUserSignInCounts
+GET     /adminapi/completionRateByDate                       @controllers.AdminController.getCompletionRateByDate
+GET     /adminapi/tasks/:username                            @controllers.AdminController.getSubmittedTasksWithLabels(username: String)
+GET     /adminapi/interactions/:username                     @controllers.AdminController.getAuditTaskInteractionsOfAUser(username: String)
+GET     /adminapi/onboardingInteractions                     @controllers.AdminController.getOnboardingTaskInteractions
+GET     /adminapi/auditpath/:id                              @controllers.AdminController.getAnAuditTaskPath(id: Int)
+GET     /adminapi/auditedStreets/:username                   @controllers.AdminController.getStreetsAuditedByAUser(username: String)
+GET     /adminapi/labelLocations/:username                   @controllers.AdminController.getLabelsCollectedByAUser(username: String)
+GET     /adminapi/labels/all                                 @controllers.AdminController.getAllLabels
+GET     /adminapi/labels/panoid                              @controllers.AdminController.getAllPanoIds
+GET     /adminapi/label/:labelId                             @controllers.AdminController.getLabelData(labelId: Int)
+GET     /adminapi/labelCounts/registered                     @controllers.AdminController.getAllRegisteredUserLabelCounts
+GET     /adminapi/labelCounts/anonymous                      @controllers.AdminController.getAllAnonUserLabelCounts
 
 GET     /adminapi/webpageActivity                            @controllers.AdminController.getAllWebpageActivities
 GET     /adminapi/webpageActivity/:activity                  @controllers.AdminController.getWebpageActivities(activity: String)
@@ -54,62 +54,60 @@ GET     /adminapi/webpageActivity/:activity/*keyValPairs     @controllers.AdminC
 GET     /adminapi/numWebpageActivity/:activity               @controllers.AdminController.getNumWebpageActivities(activity: String)
 GET     /adminapi/numWebpageActivity/:activity/*keyValPairs  @controllers.AdminController.getNumWebpageActivitiesKeyVal(activity: String, keyValPairs: String)
 
-GET     /adminapi/choroplethCounts              @controllers.AdminController.getRegionNegativeLabelCounts
-
+GET     /adminapi/choroplethCounts                           @controllers.AdminController.getRegionNegativeLabelCounts
 
 # Auditing tasks
-GET     /audit                                  @controllers.AuditController.audit
-GET     /audit/easyRegion                       @controllers.AuditController.auditNewEasyRegion
-GET     /audit/region/:id                       @controllers.AuditController.auditRegion(id: Int)
-GET     /audit/street/:id                       @controllers.AuditController.auditStreet(id: Int)
-POST    /audit/comment                          @controllers.AuditController.postComment
-POST    /audit/nostreetview                     @controllers.AuditController.postNoStreetView
+GET     /audit                                               @controllers.AuditController.audit
+GET     /audit/easyRegion                                    @controllers.AuditController.auditNewEasyRegion
+GET     /audit/region/:id                                    @controllers.AuditController.auditRegion(id: Int)
+GET     /audit/street/:id                                    @controllers.AuditController.auditStreet(id: Int)
+POST    /audit/comment                                       @controllers.AuditController.postComment
+POST    /audit/nostreetview                                  @controllers.AuditController.postNoStreetView
 
 # Task API.
-GET     /task                                   @controllers.TaskController.getTask
-GET     /task/street/:id                        @controllers.TaskController.getTaskByStreetEdgeId(id: Int)
-GET     /tasks                                  @controllers.TaskController.getTasksInARegion(regionId: Int)
-POST    /task                                   @controllers.TaskController.post
-
+GET     /task                                                @controllers.TaskController.getTask
+GET     /task/street/:id                                     @controllers.TaskController.getTaskByStreetEdgeId(id: Int)
+GET     /tasks                                               @controllers.TaskController.getTasksInARegion(regionId: Int)
+POST    /task                                                @controllers.TaskController.post
 
 # Missions
-GET     /mission                                @controllers.MissionController.getMissions
-POST    /mission                                @controllers.MissionController.post
+GET     /mission                                             @controllers.MissionController.getMissions
+POST    /mission                                             @controllers.MissionController.post
 
 # Labels
-GET     /label/currentMission                   @controllers.LabelController.getLabelsFromCurrentMission(regionId: Int)
+GET     /label/currentMission                                @controllers.LabelController.getLabelsFromCurrentMission(regionId: Int)
 
 # Neighborhoods
-GET     /neighborhoods                          @controllers.RegionController.listNeighborhoods
-POST    /neighborhood/assignment                @controllers.RegionController.setANewRegion
+GET     /neighborhoods                                       @controllers.RegionController.listNeighborhoods
+POST    /neighborhood/assignment                             @controllers.RegionController.setANewRegion
 
 # Map Edit
-GET     /map/edit                               @controllers.MapController.edit
+GET     /map/edit                                            @controllers.MapController.edit
 
 # User status
 # /:username has to come last in the list. Otherwise it eats other urls.
-GET     /contribution/streets                   @controllers.UserProfileController.getAuditedStreets
-GET     /contribution/streets/all               @controllers.UserProfileController.getAllAuditedStreets
-GET     /contribution/tasks                     @controllers.UserProfileController.getSubmittedTasksWithLabels
-GET     /contribution/auditCounts               @controllers.UserProfileController.getAuditCounts
-GET     /contribution/auditCounts/all           @controllers.UserProfileController.getAllAuditCounts
-GET     /contribution/auditInteractions         @controllers.UserProfileController.getInteractions
-GET     /contribution/previousAudit             @controllers.UserProfileController.previousAudit
-GET     /contribution/:username                 @controllers.UserProfileController.userProfile(username: String)
+GET     /contribution/streets                                @controllers.UserProfileController.getAuditedStreets
+GET     /contribution/streets/all                            @controllers.UserProfileController.getAllAuditedStreets
+GET     /contribution/tasks                                  @controllers.UserProfileController.getSubmittedTasksWithLabels
+GET     /contribution/auditCounts                            @controllers.UserProfileController.getAuditCounts
+GET     /contribution/auditCounts/all                        @controllers.UserProfileController.getAllAuditCounts
+GET     /contribution/auditInteractions                      @controllers.UserProfileController.getInteractions
+GET     /contribution/previousAudit                          @controllers.UserProfileController.previousAudit
+GET     /contribution/:username                              @controllers.UserProfileController.userProfile(username: String)
 
-GET     /userapi/labels                         @controllers.UserProfileController.getSubmittedLabels(regionId: Option[Int] ?= None)
-GET     /userapi/labelCounts/all                @controllers.UserProfileController.getAllLabelCounts
-GET     /userapi/completedMissionCounts/all     @controllers.UserProfileController.getAllUserCompletedMissionCounts
+GET     /userapi/labels                                      @controllers.UserProfileController.getSubmittedLabels(regionId: Option[Int] ?= None)
+GET     /userapi/labelCounts/all                             @controllers.UserProfileController.getAllLabelCounts
+GET     /userapi/completedMissionCounts/all                  @controllers.UserProfileController.getAllUserCompletedMissionCounts
 
-POST    /userapi/logWebpageActivity             @controllers.UserController.logWebpageActivity
+POST    /userapi/logWebpageActivity                          @controllers.UserController.logWebpageActivity
 
 # Geometry API
 
 # Access Feature and Access Score APIs
-GET     /v1/access/features             @controllers.ProjectSidewalkAPIController.getAccessFeatures(lat1: Double, lng1: Double, lat2: Double, lng2: Double)
-GET     /v1/access/score/neighborhoods  @controllers.ProjectSidewalkAPIController.getAccessScoreNeighborhoods(lat1: Double, lng1: Double, lat2: Double, lng2: Double)
-GET     /v1/access/score/streets        @controllers.ProjectSidewalkAPIController.getAccessScoreStreets(lat1: Double, lng1: Double, lat2: Double, lng2: Double)
+GET     /v1/access/features                                  @controllers.ProjectSidewalkAPIController.getAccessFeatures(lat1: Double, lng1: Double, lat2: Double, lng2: Double)
+GET     /v1/access/score/neighborhoods                       @controllers.ProjectSidewalkAPIController.getAccessScoreNeighborhoods(lat1: Double, lng1: Double, lat2: Double, lng2: Double)
+GET     /v1/access/score/streets                             @controllers.ProjectSidewalkAPIController.getAccessScoreStreets(lat1: Double, lng1: Double, lat2: Double, lng2: Double)
 
 # Map static resources from the /public folder to the /assets URL path
-GET     /assets/*file                           controllers.Assets.at(path="/public", file)
-GET     /webjars/*file                          controllers.WebJarAssets.at(file)
+GET     /assets/*file                                        controllers.Assets.at(path="/public", file)
+GET     /webjars/*file                                       controllers.WebJarAssets.at(file)

--- a/conf/routes
+++ b/conf/routes
@@ -20,39 +20,39 @@ GET     /mobile                                 @controllers.ApplicationControll
 # User authentication
 GET     /signIn                                 @controllers.UserController.signIn(url: String ?= "/")
 GET     /signUp                                 @controllers.UserController.signUp(url: String ?= "/")
-GET     /signOut                                @controllers.UserController.signOut(url: String ?="/")
-POST    /signUp                                 @controllers.SignUpController.signUp(url: String ?= "/")
-POST    /authenticate/credentials               @controllers.CredentialsAuthController.authenticate(url: String ?= "/")
-POST    /authapi/authenticate                   @controllers.CredentialsAuthController.postAuthenticate
-POST    /authapi/signup                         @controllers.SignUpController.postSignUp
+GET     /signOut                                               @controllers.UserController.signOut(url: String ?="/")
+POST    /signUp                                                @controllers.SignUpController.signUp(url: String ?= "/")
+POST    /authenticate/credentials                              @controllers.CredentialsAuthController.authenticate(url: String ?= "/")
+POST    /authapi/authenticate                                  @controllers.CredentialsAuthController.postAuthenticate
+POST    /authapi/signup                                        @controllers.SignUpController.postSignUp
 
 # Admin
-GET     /admin                                  @controllers.AdminController.index
-GET     /admin/user/:username                   @controllers.AdminController.userProfile(username: String)
-GET     /admin/task/:taskId                     @controllers.AdminController.task(taskId: Int)
+GET     /admin                                                 @controllers.AdminController.index
+GET     /admin/user/:username                                  @controllers.AdminController.userProfile(username: String)
+GET     /admin/task/:taskId                                    @controllers.AdminController.task(taskId: Int)
 
-GET     /adminapi/missionsCompletedByUsers      @controllers.AdminController.getMissionsCompletedByUsers
-GET     /adminapi/neighborhoodCompletionRate    @controllers.AdminController.getNeighborhoodCompletionRate
-GET     /adminapi/anonUserMissionCounts         @controllers.AdminController.getAllAnonUserCompletedMissionCounts
-GET     /adminapi/allSignInCounts               @controllers.AdminController.getAllUserSignInCounts
-GET     /adminapi/completionRateByDate          @controllers.AdminController.getCompletionRateByDate
-GET     /adminapi/tasks/:username               @controllers.AdminController.getSubmittedTasksWithLabels(username: String)
-GET     /adminapi/interactions/:username        @controllers.AdminController.getAuditTaskInteractionsOfAUser(username: String)
-GET     /adminapi/onboardingInteractions        @controllers.AdminController.getOnboardingTaskInteractions
-GET     /adminapi/auditpath/:id                 @controllers.AdminController.getAnAuditTaskPath(id: Int)
-GET     /adminapi/auditedStreets/:username      @controllers.AdminController.getStreetsAuditedByAUser(username: String)
-GET     /adminapi/labelLocations/:username      @controllers.AdminController.getLabelsCollectedByAUser(username: String)
-GET     /adminapi/labels/all                    @controllers.AdminController.getAllLabels
-GET     /adminapi/labels/panoid                 @controllers.AdminController.getAllPanoIds
-GET     /adminapi/label/:labelId                @controllers.AdminController.getLabelData(labelId: Int)
-GET     /adminapi/labelCounts/registered        @controllers.AdminController.getAllRegisteredUserLabelCounts
-GET     /adminapi/labelCounts/anonymous         @controllers.AdminController.getAllAnonUserLabelCounts
+GET     /adminapi/missionsCompletedByUsers                     @controllers.AdminController.getMissionsCompletedByUsers
+GET     /adminapi/neighborhoodCompletionRate                   @controllers.AdminController.getNeighborhoodCompletionRate
+GET     /adminapi/anonUserMissionCounts                        @controllers.AdminController.getAllAnonUserCompletedMissionCounts
+GET     /adminapi/allSignInCounts                              @controllers.AdminController.getAllUserSignInCounts
+GET     /adminapi/completionRateByDate                         @controllers.AdminController.getCompletionRateByDate
+GET     /adminapi/tasks/:username                              @controllers.AdminController.getSubmittedTasksWithLabels(username: String)
+GET     /adminapi/interactions/:username                       @controllers.AdminController.getAuditTaskInteractionsOfAUser(username: String)
+GET     /adminapi/onboardingInteractions                       @controllers.AdminController.getOnboardingTaskInteractions
+GET     /adminapi/auditpath/:id                                @controllers.AdminController.getAnAuditTaskPath(id: Int)
+GET     /adminapi/auditedStreets/:username                     @controllers.AdminController.getStreetsAuditedByAUser(username: String)
+GET     /adminapi/labelLocations/:username                     @controllers.AdminController.getLabelsCollectedByAUser(username: String)
+GET     /adminapi/labels/all                                   @controllers.AdminController.getAllLabels
+GET     /adminapi/labels/panoid                                @controllers.AdminController.getAllPanoIds
+GET     /adminapi/label/:labelId                               @controllers.AdminController.getLabelData(labelId: Int)
+GET     /adminapi/labelCounts/registered                       @controllers.AdminController.getAllRegisteredUserLabelCounts
+GET     /adminapi/labelCounts/anonymous                        @controllers.AdminController.getAllAnonUserLabelCounts
 
-GET     /adminapi/webpageActivities             @controllers.AdminController.getAllWebpageActivities
-GET     /adminapi/webpageActivities/:activity   @controllers.AdminController.getWebpageActivities(activity: String)
-GET     /adminapi/webpageActivities/:activity/*keyValPairs  @controllers.AdminController.getWebpageActivitiesKeyVal(activity: String, keyValPairs: String)
-GET     /adminapi/numWebpageActivities/:activity @controllers.AdminController.getNumWebpageActivities(activity: String)
-GET     /adminapi/numWebpageActivities/:activity/*keyValPairs  @controllers.AdminController.getNumWebpageActivitiesKeyVal(activity: String, keyValPairs: String)
+GET     /adminapi/webpageActivity                            @controllers.AdminController.getAllWebpageActivities
+GET     /adminapi/webpageActivity/:activity                  @controllers.AdminController.getWebpageActivities(activity: String)
+GET     /adminapi/webpageActivity/:activity/*keyValPairs     @controllers.AdminController.getWebpageActivitiesKeyVal(activity: String, keyValPairs: String)
+GET     /adminapi/numWebpageActivity/:activity               @controllers.AdminController.getNumWebpageActivities(activity: String)
+GET     /adminapi/numWebpageActivity/:activity/*keyValPairs  @controllers.AdminController.getNumWebpageActivitiesKeyVal(activity: String, keyValPairs: String)
 
 GET     /adminapi/choroplethCounts              @controllers.AdminController.getRegionNegativeLabelCounts
 

--- a/conf/routes
+++ b/conf/routes
@@ -47,6 +47,9 @@ GET     /adminapi/labels/panoid                 @controllers.AdminController.get
 GET     /adminapi/label/:labelId                @controllers.AdminController.getLabelData(labelId: Int)
 GET     /adminapi/labelCounts/registered        @controllers.AdminController.getAllRegisteredUserLabelCounts
 GET     /adminapi/labelCounts/anonymous         @controllers.AdminController.getAllAnonUserLabelCounts
+GET     /adminapi/webpageActivities             @controllers.AdminController.getAllWebpageActivities
+GET     /adminapi/webpageActivities/:activity   @controllers.AdminController.getWebpageActivities(activity: String)
+
 
 # Auditing tasks
 GET     /audit                                  @controllers.AuditController.audit

--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -1195,12 +1195,22 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
             // Chart showing how many audit page visits there are, how many people click the choropleth, and how many people
             // click "start mapping"
             $.getJSON("/adminapi/webpageActivities/Visit_Audit", function(visitAuditEvents){
-            $.getJSON("/adminapi/numWebpageActivities/Click/module=StartMapping/location=Index", function(numClickStartMappingMainIndex){
-            $.getJSON("/adminapi/numWebpageActivities/Click/module=Choropleth/target=audit", function(numChoroplethClicks){
-            $.getJSON("/adminapi/numWebpageActivities/Click/module=StartMapping/location=Navbar/"+encodeURIComponent("route=/"), function(numClickStartMappingNavIndex){
+            $.getJSON("/adminapi/webpageActivities/Click/module=StartMapping/location=Index", function(clickStartMappingMainIndexEvents){
+            $.getJSON("/adminapi/webpageActivities/Click/module=Choropleth/target=audit", function(choroplethClickEvents){
+            $.getJSON("/adminapi/numWebpageActivities/Click/module=StartMapping/location=Navbar/"+encodeURIComponent("route=/"), function(clickStartMappingNavIndexEvents){
+                // Only consider events that take place after all logging was merged (timestamp equivalent to July 20, 2017 17:02:00)
                 var numVisitAudit = visitAuditEvents[0].filter(function(event){
-                    return event.timestamp > 1500584520000; // Counts VisitAudits that take place after other logging was merged (timestamp is equivalent to July 20, 2017 17:02:00)
+                    return event.timestamp > 1500584520000;
                 }).length;
+                var numClickStartMappingMainIndex = clickStartMappingMainIndexEvents[0].filter(function(event){
+                    return event.timestamp > 1500584520000;
+                }).length;
+                var numChoroplethClicks = choroplethClickEvents[0].filter(function(event){
+                    return event.timestamp > 1500584520000;
+                }).length;
+                var numClickStartMappingNavIndex = clickStartMappingNavIndexEvents[0].filter(function(event){
+                    return event.timestamp > 1500584520000;
+                }).length;                                
 
 
                 $("#audit-access-table-start-main").append(

--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -1197,9 +1197,15 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
             $.getJSON("/adminapi/numWebpageActivities/Visit_Audit", function(numVisitAudit){
             $.getJSON("/adminapi/numWebpageActivities/Click/module=StartMapping", function(numClickStartMapping){
             $.getJSON("/adminapi/numWebpageActivities/Click/module=Choropleth/target=audit", function(numChoroplethClicks){
+            $.getJSON("/adminapi/numWebpageActivities/Visit_Index", function(numVisitIndex){
                 $("#table-cell-num-visit-audit").prepend(numVisitAudit);
                 $("#table-cell-num-click-start").prepend(numClickStartMapping);
                 $("#table-cell-num-choro-click").prepend(numChoroplethClicks);
+                $("#audit-access-table-audit").append('<td style="text-align: right;">'+numVisitAudit+'</td><td style="text-align: right;">'+(parseInt(numVisitAudit)/parseInt(numVisitIndex)*100).toFixed(4)+"%</td>");
+                $("#audit-access-table-start").append('<td style="text-align: right;">'+numClickStartMapping+'</td><td style="text-align: right;">'+(parseInt(numClickStartMapping)/parseInt(numVisitIndex)*100).toFixed(4)+"%</td>");
+                $("#audit-access-table-choro").append('<td style="text-align: right;">'+numChoroplethClicks+'</td><td style="text-align: right;">'+(parseInt(numChoroplethClicks)/parseInt(numVisitIndex)*100).toFixed(4)+"%</td>");
+                $("#audit-access-table-total").append('<td style="text-align: right;">'+numVisitIndex+'</td><td style="text-align: right;">100.0000%</td>');
+            });
             });
             });
             });

--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -1194,10 +1194,15 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
 
             // Chart showing how many audit page visits there are, how many people click the choropleth, and how many people
             // click "start mapping"
-            $.getJSON("/adminapi/numWebpageActivities/Visit_Audit", function(numVisitAudit){
+            $.getJSON("/adminapi/webpageActivities/Visit_Audit", function(visitAuditEvents){
             $.getJSON("/adminapi/numWebpageActivities/Click/module=StartMapping/location=Index", function(numClickStartMappingMainIndex){
             $.getJSON("/adminapi/numWebpageActivities/Click/module=Choropleth/target=audit", function(numChoroplethClicks){
             $.getJSON("/adminapi/numWebpageActivities/Click/module=StartMapping/location=Navbar/"+encodeURIComponent("route=/"), function(numClickStartMappingNavIndex){
+                var numVisitAudit = visitAuditEvents[0].filter(function(event){
+                    return event.timestamp > 1500584520000; // Counts VisitAudits that take place after other logging was merged (timestamp is equivalent to July 20, 2017 17:02:00)
+                }).length;
+
+
                 $("#audit-access-table-start-main").append(
                     '<td style="text-align: right;">'+
                         numClickStartMappingMainIndex+

--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -1197,7 +1197,7 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
             $.getJSON("/adminapi/webpageActivities/Visit_Audit", function(visitAuditEvents){
             $.getJSON("/adminapi/webpageActivities/Click/module=StartMapping/location=Index", function(clickStartMappingMainIndexEvents){
             $.getJSON("/adminapi/webpageActivities/Click/module=Choropleth/target=audit", function(choroplethClickEvents){
-            $.getJSON("/adminapi/numWebpageActivities/Click/module=StartMapping/location=Navbar/"+encodeURIComponent("route=/"), function(clickStartMappingNavIndexEvents){
+            $.getJSON("/adminapi/webpageActivities/Click/module=StartMapping/location=Navbar/"+encodeURIComponent("route=/"), function(clickStartMappingNavIndexEvents){
                 // Only consider events that take place after all logging was merged (timestamp equivalent to July 20, 2017 17:02:00)
                 var numVisitAudit = visitAuditEvents[0].filter(function(event){
                     return event.timestamp > 1500584520000;

--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -1197,58 +1197,9 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
             $.getJSON("/adminapi/numWebpageActivities/Visit_Audit", function(numVisitAudit){
             $.getJSON("/adminapi/numWebpageActivities/Click/module=StartMapping", function(numClickStartMapping){
             $.getJSON("/adminapi/numWebpageActivities/Click/module=Choropleth/target=audit", function(numChoroplethClicks){
-                var data = [{'name': "Visit_Audit", 'rate': numVisitAudit},
-                            {'name': "StartMapping", 'rate': numClickStartMapping},
-                            {'name': "Click Choropleth", 'rate': numChoroplethClicks}];
-                var height = 300;
-                var width = 600;
-                var maxRate = Math.max(Math.max(numVisitAudit, numClickStartMapping), numChoroplethClicks);
-
-                var coverageRateChartSortedByCompletion = {
-                    "data": {
-                        "values": data
-                    },
-                    "width": 600,
-                    "height": 300,
-                    "mark": "bar",
-                    "encoding": {
-                        "y": {
-                            "field": "name",
-                            "type": "nominal",
-                            "sort": {"op": "mean", "field": "rate", "order": "ascending"}
-                        },
-                        "x": {
-                            "field": "rate",
-                            "type": "quantitative"
-                        }
-                    },
-                    "config": {
-                        "axis": {
-                            "labelFontSize": 14
-                        }
-                    }
-                };
-
-                vega.embed("#audit-access-method-chart", coverageRateChartSortedByCompletion, opt, function(error, results) {});
-
-                // Draw numbers on another, overlapping canvas
-                var drawNumbersAccessChart = function(){
-                    var chartContainer = $('#audit-access-method-chart');
-                    var canvasWidth =  chartContainer.children('canvas.marks').attr('width');
-                    var canvasHeight = chartContainer.children('canvas.marks').attr('height');
-                    chartContainer.attr('style', 'height: '+canvasHeight+'; z-index:0;');
-                    chartContainer.children('canvas.marks').attr('style', 'position:absolute;');
-                    chartContainer.children('canvas.marks').after('<canvas id="audit-access-method-numbers"'
-                        + 'height="'+canvasHeight+'" width="'+(parseInt(canvasWidth)+15)+'"style="z-index:1;"></canvas>');
-                    var ctx = $('#audit-access-method-numbers')[0].getContext('2d');
-                    data.forEach(function(bar){
-                        var y = (data.indexOf(bar) + 0.5)*(height/data.length) + 12;
-                        var x = (bar.rate/maxRate) * 588 + 135;
-                        ctx.font = '12px sans-serif';
-                        ctx.fillText(bar.rate, x, y);
-                    });  
-                }
-                drawNumbersAccessChart();
+                $("#table-cell-num-visit-audit").prepend(numVisitAudit);
+                $("#table-cell-num-click-start").prepend(numClickStartMapping);
+                $("#table-cell-num-choro-click").prepend(numChoroplethClicks);
             });
             });
             });

--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -1195,7 +1195,7 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
             // Chart showing how many audit page visits there are, how many people click the choropleth, and how many people
             // click "start mapping"
             $.getJSON("/adminapi/numWebpageActivities/Visit_Audit", function(numVisitAudit){
-            $.getJSON("/adminapi/numWebpageActivities/Click/module=StartMapping", function(numClickStartMapping){
+            $.getJSON("/adminapi/numWebpageActivities/Click/module=StartMapping/location=Index", function(numClickStartMapping){
             $.getJSON("/adminapi/numWebpageActivities/Click/module=Choropleth/target=audit", function(numChoroplethClicks){
             $.getJSON("/adminapi/numWebpageActivities/Visit_Index", function(numVisitIndex){
                 $("#table-cell-num-visit-audit").prepend(numVisitAudit);

--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -1192,13 +1192,15 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
                 });
             });
 
-            // Chart showing how many audit page visits there are, how many people click the choropleth, and how many people
-            // click "start mapping"
+            // Creates chart showing how many audit page visits there are, how many people click via choropleth, how
+            // many click "start mapping" on navbar, and how many click "start mapping" on the landing page itself.
             $.getJSON("/adminapi/webpageActivity/Visit_Audit", function(visitAuditEvents){
             $.getJSON("/adminapi/webpageActivity/Click/module=StartMapping/location=Index", function(clickStartMappingMainIndexEvents){
             $.getJSON("/adminapi/webpageActivity/Click/module=Choropleth/target=audit", function(choroplethClickEvents){
             $.getJSON("/adminapi/webpageActivity/Click/module=StartMapping/location=Navbar/"+encodeURIComponent("route=/"), function(clickStartMappingNavIndexEvents){
                 // Only consider events that take place after all logging was merged (timestamp equivalent to July 20, 2017 17:02:00)
+                // TODO switch this to make use of versioning on the backend once it is implemented...
+                // See: https://github.com/ProjectSidewalk/SidewalkWebpage/issues/653
                 var numVisitAudit = visitAuditEvents[0].filter(function(event){
                     return event.timestamp > 1500584520000;
                 }).length;
@@ -1212,7 +1214,7 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
                     return event.timestamp > 1500584520000;
                 }).length;                                
 
-
+                // Fill in values in "How users access Audit Page from Landing Page:" table
                 $("#audit-access-table-start-main").append(
                     '<td style="text-align: right;">'+
                         numClickStartMappingMainIndex+

--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -1195,16 +1195,41 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
             // Chart showing how many audit page visits there are, how many people click the choropleth, and how many people
             // click "start mapping"
             $.getJSON("/adminapi/numWebpageActivities/Visit_Audit", function(numVisitAudit){
-            $.getJSON("/adminapi/numWebpageActivities/Click/module=StartMapping/location=Index", function(numClickStartMapping){
+            $.getJSON("/adminapi/numWebpageActivities/Click/module=StartMapping/location=Index", function(numClickStartMappingMainIndex){
             $.getJSON("/adminapi/numWebpageActivities/Click/module=Choropleth/target=audit", function(numChoroplethClicks){
-            $.getJSON("/adminapi/numWebpageActivities/Visit_Index", function(numVisitIndex){
-                $("#table-cell-num-visit-audit").prepend(numVisitAudit);
-                $("#table-cell-num-click-start").prepend(numClickStartMapping);
-                $("#table-cell-num-choro-click").prepend(numChoroplethClicks);
-                $("#audit-access-table-audit").append('<td style="text-align: right;">'+numVisitAudit+'</td><td style="text-align: right;">'+(parseInt(numVisitAudit)/parseInt(numVisitIndex)*100).toFixed(1)+"%</td>");
-                $("#audit-access-table-start").append('<td style="text-align: right;">'+numClickStartMapping+'</td><td style="text-align: right;">'+(parseInt(numClickStartMapping)/parseInt(numVisitIndex)*100).toFixed(1)+"%</td>");
-                $("#audit-access-table-choro").append('<td style="text-align: right;">'+numChoroplethClicks+'</td><td style="text-align: right;">'+(parseInt(numChoroplethClicks)/parseInt(numVisitIndex)*100).toFixed(1)+"%</td>");
-                $("#audit-access-table-total").append('<td style="text-align: right;">'+numVisitIndex+'</td><td style="text-align: right;">100.0%</td>');
+            $.getJSON("/adminapi/numWebpageActivities/Click/module=StartMapping/location=Navbar/"+encodeURIComponent("route=/"), function(numClickStartMappingNavIndex){
+                $("#audit-access-table-start-main").append(
+                    '<td style="text-align: right;">'+
+                        numClickStartMappingMainIndex+
+                    '</td>'+
+                    '<td style="text-align: right;">'+
+                        (parseInt(numClickStartMappingMainIndex)/parseInt(numVisitAudit)*100).toFixed(1)+'%'+
+                    '</td>'
+                );
+                $("#audit-access-table-start-nav").append(
+                    '<td style="text-align: right;">'+
+                        numClickStartMappingNavIndex+
+                    '</td>'+
+                    '<td style="text-align: right;">'+
+                        (parseInt(numClickStartMappingNavIndex)/parseInt(numVisitAudit)*100).toFixed(1)+'%'+
+                    '</td>'
+                );
+                $("#audit-access-table-choro").append(
+                    '<td style="text-align: right;">'+
+                        numChoroplethClicks+
+                    '</td>'+
+                    '<td style="text-align: right;">'+
+                        (parseInt(numChoroplethClicks)/parseInt(numVisitAudit)*100).toFixed(1)+'%'+
+                    '</td>'
+                );
+                $("#audit-access-table-total").append(
+                    '<td style="text-align: right;">'+
+                        numVisitAudit+
+                    '</td>'+
+                    '<td style="text-align: right;">'+
+                        '100.0%'+
+                    '</td>'
+                );
             });
             });
             });

--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -1201,10 +1201,10 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
                 $("#table-cell-num-visit-audit").prepend(numVisitAudit);
                 $("#table-cell-num-click-start").prepend(numClickStartMapping);
                 $("#table-cell-num-choro-click").prepend(numChoroplethClicks);
-                $("#audit-access-table-audit").append('<td style="text-align: right;">'+numVisitAudit+'</td><td style="text-align: right;">'+(parseInt(numVisitAudit)/parseInt(numVisitIndex)*100).toFixed(4)+"%</td>");
-                $("#audit-access-table-start").append('<td style="text-align: right;">'+numClickStartMapping+'</td><td style="text-align: right;">'+(parseInt(numClickStartMapping)/parseInt(numVisitIndex)*100).toFixed(4)+"%</td>");
-                $("#audit-access-table-choro").append('<td style="text-align: right;">'+numChoroplethClicks+'</td><td style="text-align: right;">'+(parseInt(numChoroplethClicks)/parseInt(numVisitIndex)*100).toFixed(4)+"%</td>");
-                $("#audit-access-table-total").append('<td style="text-align: right;">'+numVisitIndex+'</td><td style="text-align: right;">100.0000%</td>');
+                $("#audit-access-table-audit").append('<td style="text-align: right;">'+numVisitAudit+'</td><td style="text-align: right;">'+(parseInt(numVisitAudit)/parseInt(numVisitIndex)*100).toFixed(1)+"%</td>");
+                $("#audit-access-table-start").append('<td style="text-align: right;">'+numClickStartMapping+'</td><td style="text-align: right;">'+(parseInt(numClickStartMapping)/parseInt(numVisitIndex)*100).toFixed(1)+"%</td>");
+                $("#audit-access-table-choro").append('<td style="text-align: right;">'+numChoroplethClicks+'</td><td style="text-align: right;">'+(parseInt(numChoroplethClicks)/parseInt(numVisitIndex)*100).toFixed(1)+"%</td>");
+                $("#audit-access-table-total").append('<td style="text-align: right;">'+numVisitIndex+'</td><td style="text-align: right;">100.0%</td>');
             });
             });
             });

--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -1194,10 +1194,10 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
 
             // Chart showing how many audit page visits there are, how many people click the choropleth, and how many people
             // click "start mapping"
-            $.getJSON("/adminapi/webpageActivities/Visit_Audit", function(visitAuditEvents){
-            $.getJSON("/adminapi/webpageActivities/Click/module=StartMapping/location=Index", function(clickStartMappingMainIndexEvents){
-            $.getJSON("/adminapi/webpageActivities/Click/module=Choropleth/target=audit", function(choroplethClickEvents){
-            $.getJSON("/adminapi/webpageActivities/Click/module=StartMapping/location=Navbar/"+encodeURIComponent("route=/"), function(clickStartMappingNavIndexEvents){
+            $.getJSON("/adminapi/webpageActivity/Visit_Audit", function(visitAuditEvents){
+            $.getJSON("/adminapi/webpageActivity/Click/module=StartMapping/location=Index", function(clickStartMappingMainIndexEvents){
+            $.getJSON("/adminapi/webpageActivity/Click/module=Choropleth/target=audit", function(choroplethClickEvents){
+            $.getJSON("/adminapi/webpageActivity/Click/module=StartMapping/location=Navbar/"+encodeURIComponent("route=/"), function(clickStartMappingNavIndexEvents){
                 // Only consider events that take place after all logging was merged (timestamp equivalent to July 20, 2017 17:02:00)
                 var numVisitAudit = visitAuditEvents[0].filter(function(event){
                     return event.timestamp > 1500584520000;


### PR DESCRIPTION
Fixes #860 

![image](https://user-images.githubusercontent.com/13080218/28287936-7bd7819e-6b0b-11e7-8a64-38e0c6864008.png)

In a previous commit I made a bar chart to display this data but it seemed unnecessary for such few values and the VisitAudit value dwarfed the other two graphically. Replaced the chart with a table as pictured above. If a chart is desired, the most recent commit can be rolled back. Below is the chart for comparison:

![image](https://user-images.githubusercontent.com/13080218/28288168-48522d50-6b0c-11e7-896d-84fbbab47dfb.png)
