### PR TITLE
Added routes to logs for multi-page link clicks

### DIFF
--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -180,7 +180,7 @@
             });
 
             // Log clicks on links in the information footer to WebpageActivityTable
-            // Log is of form: "Click_module=InfoFooter_target=<link>"
+            // Log is of form: "Click_module=InfoFooter_target=<link>_route=</|/audit|/faq|...>"
             $('#info-footer').on('click','a', function(e){
                 var currentRoute = window.location.pathname;
                 var link = e.currentTarget.id.split("-")[0];

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -149,6 +149,7 @@
             // Column is 'Connect'
             //    log is of form: "Click_module=Footer_section=connect_platform=<"github", "twitter", or "email">"
             $("#footer-container").on('click', 'a', function(e){
+                var currentRoute = window.location.pathname;
                 var id = e.currentTarget.id.split("-");
                 var column = id[0];
                 var link = id[1];
@@ -160,6 +161,7 @@
                 else{
                     activity = activity+"platform="+link;
                 }
+                activity = activity + "_route="+currentRoute;
 
                 var url = "/userapi/logWebpageActivity";
                 var async = true;
@@ -180,8 +182,9 @@
             // Log clicks on links in the information footer to WebpageActivityTable
             // Log is of form: "Click_module=InfoFooter_target=<link>"
             $('#info-footer').on('click','a', function(e){
+                var currentRoute = window.location.pathname;
                 var link = e.currentTarget.id.split("-")[0];
-                var activity = "Click_module=InfoFooter_"+"target="+link;
+                var activity = "Click_module=InfoFooter_"+"target="+link + "_route="+currentRoute;
                 var url = "/userapi/logWebpageActivity";
                 var async = true;
                 $.ajax({

--- a/app/views/navbar.scala.html
+++ b/app/views/navbar.scala.html
@@ -88,6 +88,55 @@
         <!-- /.container -->
 </nav>
     <!-- /.navbar -->
+
+<!-- Script loads regardless of whether user is registered or not -->
+<script>
+    function logWebpageActivity(activity){
+        var currentRoute = window.location.pathname;
+        var url = "/userapi/logWebpageActivity";
+        var async = true;
+        $.ajax({
+            async: async,
+            contentType: 'application/json; charset=utf-8',
+            url: url,
+            type: 'post',
+            data: JSON.stringify(activity + "_location=Navbar_route="+currentRoute),
+            dataType: 'json',
+            success: function(result){},
+            error: function (result) {
+                console.error(result);
+            }
+        });
+    }
+
+    // Triggered when 'Sign In' in navbar is clicked
+    // Logs "Click_module=SignIn"
+    $("#sign-in-button").on('click', function(){
+        logWebpageActivity("Click_module=SignIn");
+    });
+
+    // Triggered when 'Start Mapping' in navbar is clicked
+    // Logs "Click_module=StartMapping_location=Index"
+    $(".navbarStartBtn").on('click', function(){
+        logWebpageActivity("Click_module=StartMapping");
+    });
+    
+    
+    $(".navbarLink").on('click', function(e){
+        var activity = "Click_module=RetakeTutorial";
+        if(e.currentTarget.innerHTML.includes("FAQ")){
+            activity = "Click_module=FAQ";
+        }
+        logWebpageActivity(activity);
+    });
+
+    // Triggered when Project Sidewalk logo on navbar is clicked
+    // Logs "Click_module=PSLogo_location=Navbar_route=<currentRoute>"
+    $("#brand").on('click', function(){
+        logWebpageActivity("Click_module=PSLogo");
+    });
+</script>
+
 @if(!user) {
     <script type="text/javascript">
             $(document).ready(function () {
@@ -98,36 +147,6 @@
                 $("#form-open-sign-in").on("mouseup", function () {
                     $("#sign-up-modal").addClass("hidden");
                     $("#sign-in-modal").removeClass("hidden");
-                });
-
-                function logWebpageActivity(activity){
-                    var currentRoute = window.location.pathname;
-                    var url = "/userapi/logWebpageActivity";
-                    var async = true;
-                    $.ajax({
-                        async: async,
-                        contentType: 'application/json; charset=utf-8',
-                        url: url,
-                        type: 'post',
-                        data: JSON.stringify(activity + "_route="+currentRoute),
-                        dataType: 'json',
-                        success: function(result){},
-                        error: function (result) {
-                            console.error(result);
-                        }
-                    });
-                }
-
-                // Triggered when 'Sign In' in navbar is clicked
-                // Logs "Click_module=SignIn"
-                $("#sign-in-button").on('click', function(){
-                    logWebpageActivity("Click_module=SignIn");
-                });
-
-                // Triggered when 'Start Mapping' in navbar is clicked
-                // Logs "Click_module=StartMapping_location=Index"
-                $(".navbarStartBtn").on('click', function(){
-                    logWebpageActivity("Click_module=StartMapping_location=Navbar");
                 });
             });
     </script>
@@ -207,6 +226,7 @@
                     // $(this).closest("." + $(this).attr("data-hide")).hide();
                 });
             });
+            
 
             function validateEmail(email) {
                 var regex = /\S+@@\S+\.\S+/;

--- a/app/views/navbar.scala.html
+++ b/app/views/navbar.scala.html
@@ -120,8 +120,8 @@
     $(".navbarStartBtn").on('click', function(){
         logWebpageActivity("Click_module=StartMapping");
     });
-    
-    
+
+
     $(".navbarLink").on('click', function(e){
         var activity = "Click_module=RetakeTutorial";
         if(e.currentTarget.innerHTML.includes("FAQ")){
@@ -276,7 +276,7 @@
 
                 // Append the link to the admin interface if it the user is admin
                 if (data.roles && data.roles.indexOf("Administrator") >= 0) {
-                    var adminLi = '<li role="presentation"><a href="/admin" role="menuitem">Admin</a></li>';
+                    var adminLi = '<li role="presentation"><a href="@routes.AdminController.index" role="menuitem">Admin</a></li>';
                     $('#nav-user-menu').children('#dashboard-link').after(adminLi);
                 }
 

--- a/app/views/navbar.scala.html
+++ b/app/views/navbar.scala.html
@@ -91,16 +91,18 @@
 
 <!-- Script loads regardless of whether user is registered or not -->
 <script>
+$(document).ready(function () {
     function logWebpageActivity(activity){
         var currentRoute = window.location.pathname;
         var url = "/userapi/logWebpageActivity";
         var async = true;
+        var activityToSend = activity + "_location=Navbar_route=" + currentRoute;
         $.ajax({
             async: async,
             contentType: 'application/json; charset=utf-8',
             url: url,
             type: 'post',
-            data: JSON.stringify(activity + "_location=Navbar_route="+currentRoute),
+            data: JSON.stringify(activityToSend),
             dataType: 'json',
             success: function(result){},
             error: function (result) {
@@ -121,7 +123,8 @@
         logWebpageActivity("Click_module=StartMapping");
     });
 
-
+    // Triggered when links in the navbar are pressed when on the Audit page
+    // Logs "Click_module=<RetakeTutorial|FAQ>_location=Navbar_route=<currentRoute>"
     $(".navbarLink").on('click', function(e){
         var activity = "Click_module=RetakeTutorial";
         if(e.currentTarget.innerHTML.includes("FAQ")){
@@ -135,6 +138,19 @@
     $("#brand").on('click', function(){
         logWebpageActivity("Click_module=PSLogo");
     });
+
+    // Triggered when items in the user menu are clicked
+    // Logs "Click_module=<SignOut|ToDashboard|ToAdmin>_location=Navbar_route=<currentRoute>""
+    $("#nav-user-menu").on('click', function(e){
+        var activity = "Click_module=SignOut";
+        if(e.target.innerText.includes("Admin")){
+            activity = "Click_module=ToAdmin";
+        }else if(e.target.innerText.includes("dashboard")){
+            activity = "Click_module=ToDashboard";
+        }
+        logWebpageActivity(activity);
+    });
+});
 </script>
 
 @if(!user) {

--- a/app/views/navbar.scala.html
+++ b/app/views/navbar.scala.html
@@ -112,7 +112,7 @@ $(document).ready(function () {
     }
 
     // Triggered when 'Sign In' in navbar is clicked
-    // Logs "Click_module=SignIn"
+    // Logs "Click_module=SignIn_location=Navbar_route=</|/audit|/faq|...>"
     $("#sign-in-button").on('click', function(){
         logWebpageActivity("Click_module=SignIn");
     });
@@ -124,7 +124,7 @@ $(document).ready(function () {
     });
 
     // Triggered when links in the navbar are pressed when on the Audit page
-    // Logs "Click_module=<RetakeTutorial|FAQ>_location=Navbar_route=<currentRoute>"
+    // Logs "Click_module=<RetakeTutorial|FAQ>_location=Navbar_route=</|/audit|/faq|...>"
     $(".navbarLink").on('click', function(e){
         var activity = "Click_module=RetakeTutorial";
         if(e.currentTarget.innerHTML.includes("FAQ")){
@@ -134,13 +134,13 @@ $(document).ready(function () {
     });
 
     // Triggered when Project Sidewalk logo on navbar is clicked
-    // Logs "Click_module=PSLogo_location=Navbar_route=<currentRoute>"
+    // Logs "Click_module=PSLogo_location=Navbar_route=</|/audit|/faq|...>"
     $("#brand").on('click', function(){
         logWebpageActivity("Click_module=PSLogo");
     });
 
     // Triggered when items in the user menu are clicked
-    // Logs "Click_module=<SignOut|ToDashboard|ToAdmin>_location=Navbar_route=<currentRoute>""
+    // Logs "Click_module=<SignOut|ToDashboard|ToAdmin>_location=Navbar_route=</|/audit|/faq|...>""
     $("#nav-user-menu").on('click', function(e){
         var activity = "Click_module=SignOut";
         if(e.target.innerText.includes("Admin")){

--- a/app/views/navbar.scala.html
+++ b/app/views/navbar.scala.html
@@ -101,6 +101,7 @@
                 });
 
                 function logWebpageActivity(activity){
+                    var currentRoute = window.location.pathname;
                     var url = "/userapi/logWebpageActivity";
                     var async = true;
                     $.ajax({
@@ -108,7 +109,7 @@
                         contentType: 'application/json; charset=utf-8',
                         url: url,
                         type: 'post',
-                        data: JSON.stringify(activity),
+                        data: JSON.stringify(activity + "_route="+currentRoute),
                         dataType: 'json',
                         success: function(result){},
                         error: function (result) {


### PR DESCRIPTION
Resolves #874 ; logs for clicking links that appear on more than one page (i.e. the navbar links including Sign-In and Start Mapping, footer links and info-footer links) now have an additional key/value pair at the end of their log strings of the form `route=/<route>`, where `<route>` is obtained from the actual page the browser is currently on.