### PR TITLE
Moved email validation to back-end and added handling for Bad Requests

### DIFF
--- a/app/controllers/SignUpController.scala
+++ b/app/controllers/SignUpController.scala
@@ -115,7 +115,6 @@ class SignUpController @Inject() (
     val anonymousUser: DBUser = UserTable.find("anonymous").get
     val now = new DateTime(DateTimeZone.UTC)
     val timestamp: Timestamp = new Timestamp(now.getMillis)
-    println(request)
 
     SignUpForm.form.bindFromRequest.fold (
       form => Future.successful(BadRequest(views.html.signUp(form))),

--- a/app/controllers/SignUpController.scala
+++ b/app/controllers/SignUpController.scala
@@ -115,12 +115,12 @@ class SignUpController @Inject() (
     val anonymousUser: DBUser = UserTable.find("anonymous").get
     val now = new DateTime(DateTimeZone.UTC)
     val timestamp: Timestamp = new Timestamp(now.getMillis)
+    println(request)
 
     SignUpForm.form.bindFromRequest.fold (
       form => Future.successful(BadRequest(views.html.signUp(form))),
       data => {
         // Check presenc of user by username
-
         UserTable.find(data.username) match {
           case Some(user) =>
             WebpageActivityTable.save(WebpageActivity(0, anonymousUser.userId.toString, ipAddress, "Duplicate_Username_Error", timestamp))

--- a/app/views/navbar.scala.html
+++ b/app/views/navbar.scala.html
@@ -207,11 +207,6 @@
                 });
             });
 
-            function validateEmail(email) {
-                var regex = /\S+@@\S+\.\S+/;
-                return regex.test(email);
-            }
-
             // Callback function for checking sign-in results
             function handleSignIn(data) {
                 //this means that logging in failed, alert user of failure
@@ -293,7 +288,7 @@
                 var password = formData[1].value;
 
                 //if not a valid email address, do not submit form
-                if(!email || !validateEmail(email)){
+                if(!email){
                     invalidSignInUpAlert(true, 'Please enter a valid email address.');
                     return false;
                 }
@@ -322,7 +317,7 @@
                 }
 
                 //if not a valid email address, do not submit form
-                if(!email || !validateEmail(email)){
+                if(!email){
                     invalidSignInUpAlert(false, 'Please enter a valid email address.');
                     return false;
                 }

--- a/app/views/navbar.scala.html
+++ b/app/views/navbar.scala.html
@@ -301,7 +301,9 @@
                 var data = $(this).serialize();
 
                 var url = '/authapi/authenticate';
-                $.post(url, data, handleSignIn);
+                $.post(url, data, handleSignIn).fail(function(e){
+                    invalidSignInUpAlert(true, 'Something went wrong processing your request. Please make sure all your information is correct and then try again');
+                });
                 return false;
             });
 
@@ -331,15 +333,18 @@
 
                 var url = '/authapi/signup';
                 $.post(url, data, handleSignIn).fail(function(e){
-                    var errorMessage;
-                    console.log(e);
-                    if(e.responseText.toLowerCase().includes("email")){
-                        errorMessage = "That email address already exists. Please try another one."
+                    var errorMessage = "";
+                    if(e.status === 409){
+                        if(e.responseText.toLowerCase().includes("email")){
+                            errorMessage = "That email address already exists. Please try another one."
+                        }
+                        else{
+                            errorMessage = "That username already exists. Please try another one."
+                        }
                     }
-                    else{
-                        errorMessage = "That username already exists. Please try another one."
+                    else{ // Some other Bad Request
+                        errorMessage = "Something went wrong processing your request. Please make sure all your information is correct and then try again."
                     }
-                    var error = e.responseText;
                     $('#incorrect-signup-alert').hide();
                     $('#invalid-signup-alert').show();
                     $('#invalid-signup-alert').html(


### PR DESCRIPTION
Resolves #845 ; now Play's email validation is used instead of the one previously on the front-end. When 400 or 409 responses are received after incorrectly signing in or signing up, an appropriate error message is displayed.