### PR TITLE
Audits completed today/yesterday now excludes incomplete audits

### DIFF
--- a/app/models/audit/AuditTaskTable.scala
+++ b/app/models/audit/AuditTaskTable.scala
@@ -148,7 +148,8 @@ object AuditTaskTable {
     val countTasksQuery = Q.queryNA[Int](
       """SELECT audit_task_id
          | FROM sidewalk.audit_task
-         | WHERE audit_task.task_end::date = now()::date""".stripMargin
+         | WHERE audit_task.task_end::date = now()::date
+         |  AND audit_task.completed = TRUE""".stripMargin
     )
     countTasksQuery.list.size
   }
@@ -163,7 +164,8 @@ object AuditTaskTable {
     val countTasksQuery = Q.queryNA[Int](
       """SELECT audit_task_id
         | FROM sidewalk.audit_task
-        | WHERE audit_task.task_end::date = now()::date - interval '1' day""".stripMargin
+        | WHERE audit_task.task_end::date = now()::date - interval '1' day
+        |  AND audit_task.completed = TRUE""".stripMargin
     )
     countTasksQuery.list.size
   }

--- a/app/models/daos/UserDAOImpl.scala
+++ b/app/models/daos/UserDAOImpl.scala
@@ -201,7 +201,7 @@ object UserDAOImpl {
   * Date: Nov 11, 2016
   */
   def countRegisteredUsersVisitedToday: Int = db.withSession { implicit session =>
-    // TODO: Condense both calculations into one query and then using filters
+    // TODO: Condense both calculations into one query and then use filters
     val countQuery = Q.queryNA[(Int)](
       """SELECT COUNT(DISTINCT(audit_task.user_id))
         |  FROM sidewalk.audit_task


### PR DESCRIPTION
Resolves #886 

The issue was that the audit count queries for today and yesterday did not exclude audits that were not marked as complete; this has been fixed in this PR. The total audit count query was already correct.