### PR TITLE
Fixed logging of new results button on navbar

### DIFF
--- a/app/views/navbar.scala.html
+++ b/app/views/navbar.scala.html
@@ -24,7 +24,7 @@
                         <button class="navbarStartBtn" onclick="location.href='@routes.AuditController.audit'">Start Mapping</button>
                     </li>
                     <li class="active">
-                        <button class="navbarStartBtn navbarResultsBtn" onclick="location.href='@routes.ApplicationController.results'">See Results</button>
+                        <button class="navbarResultsBtn" onclick="location.href='@routes.ApplicationController.results'">See Results</button>
                     </li>
 
                 } else {
@@ -121,9 +121,15 @@ $(document).ready(function () {
     });
 
     // Triggered when 'Start Mapping' in navbar is clicked
-    // Logs "Click_module=StartMapping_location=Index"
+    // Logs "Click_module=StartMapping_location=Navbar_route=</|/audit|/faq|...>"
     $(".navbarStartBtn").on('click', function(){
         logWebpageActivity("Click_module=StartMapping");
+    });
+
+    // Triggered when 'Results' in navbar is clicked
+    // Logs "Click_module=Results_location=Navbar_route=</|/audit|/faq|...>"
+    $(".navbarResultsBtn ").on('click', function(){
+        logWebpageActivity("Click_module=Results");
     });
 
     // Triggered when links in the navbar are pressed when on the Audit page

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -129,7 +129,7 @@ footer {
     max-height: 30px;
 }
 
-.navbarStartBtn {
+.navbarStartBtn, .navbarResultsBtn {
     background-color:#ffffff;
     -moz-border-radius:15px;
     -webkit-border-radius:15px;
@@ -146,6 +146,9 @@ footer {
     padding:5px 25px;
     text-decoration:none;
     transition: border-color 0.4s ease 0s, background-color 0.4s ease 0s;
+}
+.navbarResultsBtn{
+    margin-left: 8px;
 }
 .navbarStartBtn:hover {
     background-color:#FCECBE;
@@ -1240,7 +1243,4 @@ kbd {
 #results-choropleth-container {
     background-color: #fff;
     width: 100%;
-}
-.navbarResultsBtn{
-    margin-left: 8px;
 }

--- a/public/javascripts/AccessibilityChoropleth.js
+++ b/public/javascripts/AccessibilityChoropleth.js
@@ -259,7 +259,7 @@ function AccessibilityChoropleth(_, $, turf, difficultRegionIds) {
 
 
     $.getJSON('/adminapi/neighborhoodCompletionRate', function (data) {
-        console.log(data);
+        //console.log(data);
 
         $.getJSON('/adminapi/choroplethCounts', function (labelCounts) {
 


### PR DESCRIPTION
When clicking on the new Results button on the navbar, it was erroneously being logged as if the Start Mapping button was clicked. This should be fixed now.