### PR TITLE
Added models to manage clustering of labels and ground truth labels

### DIFF
--- a/app/controllers/ClusteringSessionController.scala
+++ b/app/controllers/ClusteringSessionController.scala
@@ -19,29 +19,28 @@ import org.geotools.referencing.CRS
 import play.api.libs.json.{JsArray, JsObject, JsValue, Json}
 import play.extras.geojson
 
-
 import scala.concurrent.Future
 
 class ClusteringSessionController @Inject()(implicit val env: Environment[User, SessionAuthenticator])
   extends Silhouette[User, SessionAuthenticator] with ProvidesHeader {
 
   /**
-    * The index page just displays all undeleted clustering sessions for now.
+    * Returns all records in clusterin_session table that are not marked as deleted.
     */
-  def index = UserAwareAction.async { implicit request =>
+  def getClusteringSessionsWithoutDeleted = UserAwareAction.async { implicit request =>
     val clusteringSessions= ClusteringSessionTable.selectSessionsWithoutDeleted
+
     val ses: List[JsObject] = clusteringSessions.map { clusteringSession =>
       val clusteringSessionId: Int = clusteringSession.clusteringSessionId
       val routeId: Int = clusteringSession.routeId
       val clustering_threshold: Double = clusteringSession.clustering_threshold
       val time_created: java.sql.Timestamp = clusteringSession.time_created
       val deleted: Boolean = clusteringSession.deleted
-      Json.obj("clusteringSessionId" -> clusteringSessionId, "routeId" -> routeId, "clustering_threshold" -> clustering_threshold, "time_created" -> time_created, "deleted" -> deleted)
+      Json.obj("clusteringSessionId" -> clusteringSessionId, "routeId" -> routeId,
+               "clustering_threshold" -> clustering_threshold, "time_created" -> time_created, "deleted" -> deleted)
     }
     val sessionCollection = Json.obj("sessions" -> ses)
     Future.successful(Ok(sessionCollection))
   }
-
-
 
 }

--- a/app/controllers/ClusteringSessionController.scala
+++ b/app/controllers/ClusteringSessionController.scala
@@ -29,7 +29,7 @@ class ClusteringSessionController @Inject()(implicit val env: Environment[User, 
     * The index page just displays all undeleted clustering sessions for now.
     */
   def index = UserAwareAction.async { implicit request =>
-    val clusteringSessions= ClusteringSessionTable.selectExistingSessions
+    val clusteringSessions= ClusteringSessionTable.selectSessionsWithoutDeleted
     val ses: List[JsObject] = clusteringSessions.map { clusteringSession =>
       val clusteringSessionId: Int = clusteringSession.clusteringSessionId
       val routeId: Int = clusteringSession.routeId

--- a/app/controllers/ClusteringSessionController.scala
+++ b/app/controllers/ClusteringSessionController.scala
@@ -1,0 +1,47 @@
+package controllers
+
+import java.util.UUID
+import javax.inject.Inject
+
+import com.mohiva.play.silhouette.api.{Environment, LogoutEvent, Silhouette}
+import com.mohiva.play.silhouette.impl.authenticators.SessionAuthenticator
+import com.vividsolutions.jts.geom.Coordinate
+import controllers.headers.ProvidesHeader
+import formats.json.TaskFormats._
+import models.daos.slick.DBTableDefinitions.UserTable
+import models.label.LabelTable.LabelMetadata
+import models.clustering_session.{ClusteringSessionTable}
+import models.user.{User, WebpageActivityTable}
+import models.daos.UserDAOImpl
+import models.user.UserRoleTable
+import org.geotools.geometry.jts.JTS
+import org.geotools.referencing.CRS
+import play.api.libs.json.{JsArray, JsObject, JsValue, Json}
+import play.extras.geojson
+
+
+import scala.concurrent.Future
+
+class ClusteringSessionController @Inject()(implicit val env: Environment[User, SessionAuthenticator])
+  extends Silhouette[User, SessionAuthenticator] with ProvidesHeader {
+
+  /**
+    * The index page just displays all undeleted clustering sessions for now.
+    */
+  def index = UserAwareAction.async { implicit request =>
+    val clusteringSessions= ClusteringSessionTable.selectExistingSessions
+    val ses: List[JsObject] = clusteringSessions.map { clusteringSession =>
+      val clusteringSessionId: Int = clusteringSession.clusteringSessionId
+      val routeId: Int = clusteringSession.routeId
+      val clustering_threshold: Double = clusteringSession.clustering_threshold
+      val time_created: java.sql.Timestamp = clusteringSession.time_created
+      val deleted: Boolean = clusteringSession.deleted
+      Json.obj("clusteringSessionId" -> clusteringSessionId, "routeId" -> routeId, "clustering_threshold" -> clustering_threshold, "time_created" -> time_created, "deleted" -> deleted)
+    }
+    val sessionCollection = Json.obj("sessions" -> ses)
+    Future.successful(Ok(sessionCollection))
+  }
+
+
+
+}

--- a/app/controllers/ClusteringSessionController.scala
+++ b/app/controllers/ClusteringSessionController.scala
@@ -1,23 +1,13 @@
 package controllers
 
-import java.util.UUID
 import javax.inject.Inject
 
-import com.mohiva.play.silhouette.api.{Environment, LogoutEvent, Silhouette}
+import com.mohiva.play.silhouette.api.{Environment, Silhouette}
 import com.mohiva.play.silhouette.impl.authenticators.SessionAuthenticator
-import com.vividsolutions.jts.geom.Coordinate
 import controllers.headers.ProvidesHeader
-import formats.json.TaskFormats._
-import models.daos.slick.DBTableDefinitions.UserTable
-import models.label.LabelTable.LabelMetadata
 import models.clustering_session.{ClusteringSessionTable}
-import models.user.{User, WebpageActivityTable}
-import models.daos.UserDAOImpl
-import models.user.UserRoleTable
-import org.geotools.geometry.jts.JTS
-import org.geotools.referencing.CRS
-import play.api.libs.json.{JsArray, JsObject, JsValue, Json}
-import play.extras.geojson
+import models.user.User
+import play.api.libs.json.{JsObject, Json}
 
 import scala.concurrent.Future
 

--- a/app/controllers/GTLabelController.scala
+++ b/app/controllers/GTLabelController.scala
@@ -26,10 +26,11 @@ class GTLabelController @Inject()(implicit val env: Environment[User, SessionAut
   extends Silhouette[User, SessionAuthenticator] with ProvidesHeader {
 
   /**
-    * The index page just displays all ground truth labels for now.
+    * Returns all records in gt_label table.
     */
-  def index = UserAwareAction.async { implicit request =>
+  def getAllGTLabels = UserAwareAction.async { implicit request =>
     val gtLabels= GTLabelTable.all
+
     val gtl: List[JsObject] = gtLabels.map { gtLabel =>
       Json.obj(
         "gtLabelId" -> gtLabel.gtLabelId, "routeId" -> gtLabel.routeId, "gsvPanoramaId" -> gtLabel.gsvPanoramaId,
@@ -46,7 +47,5 @@ class GTLabelController @Inject()(implicit val env: Environment[User, SessionAut
     val gtlCollection = Json.obj("ground_truth_labels" -> gtl)
     Future.successful(Ok(gtlCollection))
   }
-
-
 
 }

--- a/app/controllers/GTLabelController.scala
+++ b/app/controllers/GTLabelController.scala
@@ -1,24 +1,13 @@
 package controllers
 
-import java.util.UUID
 import javax.inject.Inject
 
-import com.mohiva.play.silhouette.api.{Environment, LogoutEvent, Silhouette}
+import com.mohiva.play.silhouette.api.{Environment, Silhouette}
 import com.mohiva.play.silhouette.impl.authenticators.SessionAuthenticator
-import com.vividsolutions.jts.geom.Coordinate
 import controllers.headers.ProvidesHeader
-import formats.json.TaskFormats._
-import models.daos.slick.DBTableDefinitions.UserTable
-import models.label.LabelTable.LabelMetadata
 import models.gt.{GTLabelTable}
-import models.user.{User, WebpageActivityTable}
-import models.daos.UserDAOImpl
-import models.user.UserRoleTable
-import org.geotools.geometry.jts.JTS
-import org.geotools.referencing.CRS
-import play.api.libs.json.{JsArray, JsObject, JsValue, Json}
-import play.extras.geojson
-
+import models.user.User
+import play.api.libs.json.{JsObject, Json}
 
 import scala.concurrent.Future
 

--- a/app/controllers/GTLabelController.scala
+++ b/app/controllers/GTLabelController.scala
@@ -32,11 +32,11 @@ class GTLabelController @Inject()(implicit val env: Environment[User, SessionAut
     val gtLabels= GTLabelTable.all
     val gtl: List[JsObject] = gtLabels.map { gtLabel =>
       Json.obj(
-        "gtLabelId" -> gtLabel.gtLabelId, "routeId" -> gtLabel.routeId, "has_label_id" -> gtLabel.has_label_id,
-        "gsvPanoramaId" -> gtLabel.gsvPanoramaId, "labelTypeId" -> gtLabel.labelTypeId,
-        "svImageX" -> gtLabel.svImageX, "svImageY" -> gtLabel.svImageY, "canvasX" -> gtLabel.canvasX,
-        "canvasY" -> gtLabel.canvasY, "heading" -> gtLabel.heading, "pitch" -> gtLabel.pitch, "zoom" -> gtLabel.zoom,
-        "canvasHeight" -> gtLabel.canvasHeight, "canvasWidth" -> gtLabel.canvasWidth, "alphaX" -> gtLabel.alphaX, "alphaY" -> gtLabel.alphaY,
+        "gtLabelId" -> gtLabel.gtLabelId, "routeId" -> gtLabel.routeId, "gsvPanoramaId" -> gtLabel.gsvPanoramaId,
+        "labelTypeId" -> gtLabel.labelTypeId, "svImageX" -> gtLabel.svImageX, "svImageY" -> gtLabel.svImageY,
+        "canvasX" -> gtLabel.canvasX, "canvasY" -> gtLabel.canvasY, "heading" -> gtLabel.heading,
+        "pitch" -> gtLabel.pitch, "zoom" -> gtLabel.zoom, "canvasHeight" -> gtLabel.canvasHeight,
+        "canvasWidth" -> gtLabel.canvasWidth, "alphaX" -> gtLabel.alphaX, "alphaY" -> gtLabel.alphaY,
         "lat" -> gtLabel.lat, "lng" -> gtLabel.lng,
         "description" -> gtLabel.description,
         "severity" -> gtLabel.severity,

--- a/app/controllers/GTLabelController.scala
+++ b/app/controllers/GTLabelController.scala
@@ -1,0 +1,52 @@
+package controllers
+
+import java.util.UUID
+import javax.inject.Inject
+
+import com.mohiva.play.silhouette.api.{Environment, LogoutEvent, Silhouette}
+import com.mohiva.play.silhouette.impl.authenticators.SessionAuthenticator
+import com.vividsolutions.jts.geom.Coordinate
+import controllers.headers.ProvidesHeader
+import formats.json.TaskFormats._
+import models.daos.slick.DBTableDefinitions.UserTable
+import models.label.LabelTable.LabelMetadata
+import models.gt.{GTLabelTable}
+import models.user.{User, WebpageActivityTable}
+import models.daos.UserDAOImpl
+import models.user.UserRoleTable
+import org.geotools.geometry.jts.JTS
+import org.geotools.referencing.CRS
+import play.api.libs.json.{JsArray, JsObject, JsValue, Json}
+import play.extras.geojson
+
+
+import scala.concurrent.Future
+
+class GTLabelController @Inject()(implicit val env: Environment[User, SessionAuthenticator])
+  extends Silhouette[User, SessionAuthenticator] with ProvidesHeader {
+
+  /**
+    * The index page just displays all ground truth labels for now.
+    */
+  def index = UserAwareAction.async { implicit request =>
+    val gtLabels= GTLabelTable.all
+    val gtl: List[JsObject] = gtLabels.map { gtLabel =>
+      Json.obj(
+        "gtLabelId" -> gtLabel.gtLabelId, "routeId" -> gtLabel.routeId, "has_label_id" -> gtLabel.has_label_id,
+        "gsvPanoramaId" -> gtLabel.gsvPanoramaId, "labelTypeId" -> gtLabel.labelTypeId,
+        "svImageX" -> gtLabel.svImageX, "svImageY" -> gtLabel.svImageY, "canvasX" -> gtLabel.canvasX,
+        "canvasY" -> gtLabel.canvasY, "heading" -> gtLabel.heading, "pitch" -> gtLabel.pitch, "zoom" -> gtLabel.zoom,
+        "canvasHeight" -> gtLabel.canvasHeight, "canvasWidth" -> gtLabel.canvasWidth, "alphaX" -> gtLabel.alphaX, "alphaY" -> gtLabel.alphaY,
+        "lat" -> gtLabel.lat, "lng" -> gtLabel.lng,
+        "description" -> gtLabel.description,
+        "severity" -> gtLabel.severity,
+        "temporaryProblem" -> gtLabel.temporaryProblem
+      )
+    }
+    val gtlCollection = Json.obj("ground_truth_labels" -> gtl)
+    Future.successful(Ok(gtlCollection))
+  }
+
+
+
+}

--- a/app/models/clustering_session/ClusteringSessionClusterTable.scala
+++ b/app/models/clustering_session/ClusteringSessionClusterTable.scala
@@ -1,0 +1,54 @@
+package models.clustering_session
+
+/**
+  * Created by hmaddali on 7/26/17.
+  */
+
+import models.utils.MyPostgresDriver.simple._
+import play.api.Play.current
+
+import scala.slick.lifted.ForeignKeyQuery
+
+case class ClusteringSessionCluster(clusteringSessionClusterId: Int, clusteringSessionId: Int)
+
+/**
+  *
+  */
+class ClusteringSessionClusterTable(tag: Tag) extends Table[ClusteringSessionCluster](tag, Some("sidewalk"), "clustering_session_cluster") {
+  def clusteringSessionClusterId = column[Int]("clustering_session_cluster_id", O.NotNull, O.PrimaryKey, O.AutoInc)
+  def clusteringSessionId = column[Int]("clustering_session_id", O.NotNull)
+
+  def * = (clusteringSessionClusterId, clusteringSessionId) <> ((ClusteringSessionCluster.apply _).tupled, ClusteringSessionCluster.unapply)
+
+  def clustering_session: ForeignKeyQuery[ClusteringSessionTable, ClusteringSession] =
+    foreignKey("clustering_session_cluster_cluster_session_id_fkey", clusteringSessionId, TableQuery[ClusteringSessionTable])(_.clusteringSessionId)
+
+}
+
+/**
+  * Data access object for the Clustering Session Cluster table
+  */
+object ClusteringSessionClusterTable{
+  val db = play.api.db.slick.DB
+  val clustering_session_clusters = TableQuery[ClusteringSessionClusterTable]
+
+  def getClusteringSessionCluster(clusteringSessionClusterId: Option[Int]): Option[ClusteringSessionCluster] = db.withSession { implicit session =>
+    val clustering_session_cluster = clustering_session_clusters.filter(_.clusteringSessionClusterId === clusteringSessionClusterId).list
+    clustering_session_cluster.headOption
+  }
+
+  def all: List[ClusteringSessionCluster] = db.withSession { implicit session =>
+    clustering_session_clusters.list
+  }
+
+  def getSpecificClusteringSessionClusters(clusteringSessionId: Int): List[ClusteringSessionCluster] = db.withSession { implicit session =>
+    clustering_session_clusters.filter(_.clusteringSessionId === clusteringSessionId).list
+  }
+
+  def save(clustering_session_cluster: ClusteringSessionCluster): Int = db.withTransaction { implicit session =>
+    val scId: Int =
+      (clustering_session_clusters returning clustering_session_clusters.map(_.clusteringSessionClusterId)) += clustering_session_cluster
+    scId
+  }
+
+}

--- a/app/models/clustering_session/ClusteringSessionClusterTable.scala
+++ b/app/models/clustering_session/ClusteringSessionClusterTable.scala
@@ -32,7 +32,7 @@ object ClusteringSessionClusterTable{
   val db = play.api.db.slick.DB
   val clustering_session_clusters = TableQuery[ClusteringSessionClusterTable]
 
-  def getClusteringSessionCluster(clusteringSessionClusterId: Option[Int]): Option[ClusteringSessionCluster] = db.withSession { implicit session =>
+  def getClusteringSessionCluster(clusteringSessionClusterId: Int): Option[ClusteringSessionCluster] = db.withSession { implicit session =>
     val clustering_session_cluster = clustering_session_clusters.filter(_.clusteringSessionClusterId === clusteringSessionClusterId).list
     clustering_session_cluster.headOption
   }

--- a/app/models/clustering_session/ClusteringSessionLabelTable.scala
+++ b/app/models/clustering_session/ClusteringSessionLabelTable.scala
@@ -1,0 +1,58 @@
+package models.clustering_session
+
+/**
+  * Created by hmaddali on 7/26/17.
+  */
+import models.label.{Label, LabelTable}
+import models.utils.MyPostgresDriver.simple._
+import play.api.Play.current
+
+import scala.slick.lifted.ForeignKeyQuery
+
+
+case class ClusteringSessionLabel(clusteringSessionLabelId: Int, clusteringSessionClusterId: Int, labelId: Int)
+/**
+  *
+  */
+class ClusteringSessionLabelTable(tag: Tag) extends Table[ClusteringSessionLabel](tag, Some("sidewalk"), "clustering_session_label") {
+  def clusteringSessionLabelId = column[Int]("clustering_session_label_id", O.NotNull, O.PrimaryKey, O.AutoInc)
+  def clusteringSessionClusterId = column[Int]("clustering_session_cluster_id", O.NotNull)
+  def labelId = column[Int]("label_id", O.NotNull)
+
+  def * = (clusteringSessionLabelId, clusteringSessionClusterId, labelId) <> ((ClusteringSessionLabel.apply _).tupled, ClusteringSessionLabel.unapply)
+
+  def clustering_session_cluster: ForeignKeyQuery[ClusteringSessionClusterTable, ClusteringSessionCluster] =
+    foreignKey("clustering_session_label_clustering_session_cluster_id_fkey", clusteringSessionClusterId, TableQuery[ClusteringSessionClusterTable])(_.clusteringSessionClusterId)
+
+  def label: ForeignKeyQuery[LabelTable, Label] =
+    foreignKey("clustering_session_label_label_id_fkey", labelId, TableQuery[LabelTable])(_.labelId)
+
+}
+
+/**
+  * Data access object for the Clustering Session Label table
+  */
+object ClusteringSessionLabelTable{
+  val db = play.api.db.slick.DB
+  val clustering_session_labels = TableQuery[ClusteringSessionLabelTable]
+
+  def getClusteringSessionLabel(clusteringSessionLabelId: Option[Int]): Option[ClusteringSessionLabel] = db.withSession { implicit session =>
+    val clustering_session_label = clustering_session_labels.filter(_.clusteringSessionLabelId === clusteringSessionLabelId).list
+    clustering_session_label.headOption
+  }
+
+  def all: List[ClusteringSessionLabel] = db.withSession { implicit session =>
+    clustering_session_labels.list
+  }
+
+  def getSpecificClusteringSessionLabels(clusteringSessionClusterId: Int): List[ClusteringSessionLabel] = db.withSession { implicit session =>
+    clustering_session_labels.filter(_.clusteringSessionClusterId === clusteringSessionClusterId).list
+  }
+
+  def save(clustering_session_label: ClusteringSessionLabel): Int = db.withTransaction { implicit session =>
+    val sclId: Int =
+      (clustering_session_labels returning clustering_session_labels.map(_.clusteringSessionLabelId)) += clustering_session_label
+    sclId
+  }
+
+}

--- a/app/models/clustering_session/ClusteringSessionLabelTable.scala
+++ b/app/models/clustering_session/ClusteringSessionLabelTable.scala
@@ -36,7 +36,7 @@ object ClusteringSessionLabelTable{
   val db = play.api.db.slick.DB
   val clustering_session_labels = TableQuery[ClusteringSessionLabelTable]
 
-  def getClusteringSessionLabel(clusteringSessionLabelId: Option[Int]): Option[ClusteringSessionLabel] = db.withSession { implicit session =>
+  def getClusteringSessionLabel(clusteringSessionLabelId: Int): Option[ClusteringSessionLabel] = db.withSession { implicit session =>
     val clustering_session_label = clustering_session_labels.filter(_.clusteringSessionLabelId === clusteringSessionLabelId).list
     clustering_session_label.headOption
   }

--- a/app/models/clustering_session/ClusteringSessionTable.scala
+++ b/app/models/clustering_session/ClusteringSessionTable.scala
@@ -1,0 +1,61 @@
+package models.clustering_session
+
+/**
+  * Created by hmaddali on 7/26/17.
+  */
+import models.route.{Route, RouteTable}
+import models.utils.MyPostgresDriver.simple._
+import play.api.Play.current
+
+import scala.slick.lifted.ForeignKeyQuery
+
+case class ClusteringSession(clusteringSessionId: Int, routeId: Int, clustering_threshold: Double, time_created: java.sql.Timestamp,
+                             deleted: Boolean)
+/**
+  *
+  */
+class ClusteringSessionTable(tag: Tag) extends Table[ClusteringSession](tag, Some("sidewalk"), "clustering_session") {
+  def clusteringSessionId = column[Int]("clustering_session_id", O.NotNull, O.PrimaryKey, O.AutoInc)
+  def routeId = column[Int]("route_id", O.NotNull)
+  def clustering_threshold = column[Double]("clustering_threshold", O.NotNull)
+  def deleted = column[Boolean]("deleted", O.NotNull)
+  def time_created = column[java.sql.Timestamp]("time_created",O.NotNull)
+  def * = (clusteringSessionId, routeId, clustering_threshold, time_created, deleted) <> ((ClusteringSession.apply _).tupled, ClusteringSession.unapply)
+
+  def route: ForeignKeyQuery[RouteTable, Route] =
+    foreignKey("clustering_session_route_id_fkey", routeId, TableQuery[RouteTable])(_.routeId)
+
+}
+
+/**
+  * Data access object for the Clustering Session table
+  */
+object ClusteringSessionTable{
+  val db = play.api.db.slick.DB
+  val clustering_sessions = TableQuery[ClusteringSessionTable]
+
+  def getClusteringSession(clusteringSessionId: Option[Int]): Option[ClusteringSession] = db.withSession { implicit session =>
+    val clustering_session = clustering_sessions.filter(_.clusteringSessionId === clusteringSessionId).list
+    clustering_session.headOption
+  }
+
+  def all: List[ClusteringSession] = db.withSession { implicit session =>
+    clustering_sessions.list
+  }
+
+  def selectExistingSessions: List[ClusteringSession] = db.withSession { implicit session =>
+    clustering_sessions.filter(_.deleted === false).list
+  }
+
+  def save(clustering_session: ClusteringSession): Int = db.withTransaction { implicit session =>
+    val sId: Int =
+      (clustering_sessions returning clustering_sessions.map(_.clusteringSessionId)) += clustering_session
+    sId
+  }
+
+  def updateDeleted(clustering_session_id: Int, deleted: Boolean)= db.withTransaction { implicit session =>
+    val q = for {clustering_session <- clustering_sessions if clustering_session.clusteringSessionId === clustering_session_id } yield clustering_session.deleted
+    q.update(deleted)
+  }
+
+}

--- a/app/models/clustering_session/ClusteringSessionTable.scala
+++ b/app/models/clustering_session/ClusteringSessionTable.scala
@@ -43,7 +43,7 @@ object ClusteringSessionTable{
     clustering_sessions.list
   }
 
-  def selectExistingSessions: List[ClusteringSession] = db.withSession { implicit session =>
+  def selectSessionsWithoutDeleted: List[ClusteringSession] = db.withSession { implicit session =>
     clustering_sessions.filter(_.deleted === false).list
   }
 

--- a/app/models/clustering_session/ClusteringSessionTable.scala
+++ b/app/models/clustering_session/ClusteringSessionTable.scala
@@ -9,8 +9,8 @@ import play.api.Play.current
 
 import scala.slick.lifted.ForeignKeyQuery
 
-case class ClusteringSession(clusteringSessionId: Int, routeId: Int, clustering_threshold: Double, time_created: java.sql.Timestamp,
-                             deleted: Boolean)
+case class ClusteringSession(clusteringSessionId: Int, routeId: Int, clustering_threshold: Double,
+                             time_created: java.sql.Timestamp, deleted: Boolean)
 /**
   *
   */
@@ -34,7 +34,7 @@ object ClusteringSessionTable{
   val db = play.api.db.slick.DB
   val clustering_sessions = TableQuery[ClusteringSessionTable]
 
-  def getClusteringSession(clusteringSessionId: Option[Int]): Option[ClusteringSession] = db.withSession { implicit session =>
+  def getClusteringSession(clusteringSessionId: Int): Option[ClusteringSession] = db.withSession { implicit session =>
     val clustering_session = clustering_sessions.filter(_.clusteringSessionId === clusteringSessionId).list
     clustering_session.headOption
   }

--- a/app/models/clustering_session/ClusteringSessionTable.scala
+++ b/app/models/clustering_session/ClusteringSessionTable.scala
@@ -54,7 +54,10 @@ object ClusteringSessionTable{
   }
 
   def updateDeleted(clustering_session_id: Int, deleted: Boolean)= db.withTransaction { implicit session =>
-    val q = for {clustering_session <- clustering_sessions if clustering_session.clusteringSessionId === clustering_session_id } yield clustering_session.deleted
+    val q = for {
+      clustering_session <- clustering_sessions
+      if clustering_session.clusteringSessionId === clustering_session_id
+    } yield clustering_session.deleted
     q.update(deleted)
   }
 

--- a/app/models/gt/GTExistingLabelTable.scala
+++ b/app/models/gt/GTExistingLabelTable.scala
@@ -31,7 +31,7 @@ object GTExistingLabelTable{
   val db = play.api.db.slick.DB
   val gt_existing_labels = TableQuery[GTExistingLabelTable]
 
-  def getExistingGTLabel(gtExistingLabelId: Option[Int]): Option[GTExistingLabel] = db.withSession { implicit session =>
+  def getExistingGTLabel(gtExistingLabelId: Int): Option[GTExistingLabel] = db.withSession { implicit session =>
     val gt_existing_label = gt_existing_labels.filter(_.gtExistingLabelId === gtExistingLabelId).list
     gt_existing_label.headOption
   }

--- a/app/models/gt/GTExistingLabelTable.scala
+++ b/app/models/gt/GTExistingLabelTable.scala
@@ -1,0 +1,50 @@
+package models.gt
+
+/**
+  * Created by hmaddali on 7/26/17.
+  */
+import models.label.{Label, LabelTable}
+import models.utils.MyPostgresDriver.simple._
+import play.api.Play.current
+
+import scala.slick.lifted.ForeignKeyQuery
+
+case class GTExistingLabel(gtExistingLabelId: Int, gtLabelId: Int, labelId: Int)
+
+class GTExistingLabelTable(tag: Tag) extends Table[GTExistingLabel](tag, Some("sidewalk"), "gt_existing_label") {
+
+  def gtExistingLabelId = column[Int]("gt_existing_label_id", O.NotNull, O.PrimaryKey, O.AutoInc)
+  def gtLabelId = column[Int]("gt_label_id", O.NotNull)
+  def labelId = column[Int]("label_id", O.NotNull)
+
+  def * = (gtExistingLabelId, gtLabelId, labelId) <> ((GTExistingLabel.apply _).tupled, GTExistingLabel.unapply)
+
+  def gtLabel: ForeignKeyQuery[GTLabelTable, GTLabel] =
+    foreignKey("gt_existing_label_gt_label_id_fkey", gtLabelId, TableQuery[GTLabelTable])(_.gtLabelId)
+
+  def labelType: ForeignKeyQuery[LabelTable, Label] =
+    foreignKey("gt_existing_label_label_id_fkey", labelId, TableQuery[LabelTable])(_.labelId)
+
+}
+
+object GTExistingLabelTable{
+  val db = play.api.db.slick.DB
+  val gt_existing_labels = TableQuery[GTExistingLabelTable]
+
+  def getExistingGTLabel(gtExistingLabelId: Option[Int]): Option[GTExistingLabel] = db.withSession { implicit session =>
+    val gt_existing_label = gt_existing_labels.filter(_.gtExistingLabelId === gtExistingLabelId).list
+    gt_existing_label.headOption
+  }
+
+  def all: List[GTExistingLabel] = db.withSession { implicit session =>
+    gt_existing_labels.list
+  }
+
+  def save(gt_existing_label: GTExistingLabel): Int = db.withTransaction { implicit session =>
+    val gteId: Int =
+      (gt_existing_labels returning gt_existing_labels.map(_.gtExistingLabelId)) += gt_existing_label
+    gteId
+  }
+
+}
+

--- a/app/models/gt/GTLabelTable.scala
+++ b/app/models/gt/GTLabelTable.scala
@@ -1,0 +1,87 @@
+package models.gt
+
+/**
+  * Created by hmaddali on 7/26/17.
+  */
+import models.route.{Route, RouteTable}
+import models.label.{LabelTypeTable, LabelType}
+import models.utils.MyPostgresDriver.simple._
+import play.api.Play.current
+
+import scala.slick.lifted.ForeignKeyQuery
+
+case class GTLabel(gtLabelId: Int, routeId: Int, has_label_id: Boolean, gsvPanoramaId: String, labelTypeId: Int,
+                   svImageX: Int, svImageY: Int, canvasX: Int, canvasY: Int, heading: Float, pitch: Float, zoom: Int, canvasHeight: Int, canvasWidth: Int, alphaX: Float, alphaY: Float, lat: Option[Float], lng: Option[Float],
+                   description: String,
+                   severity: Int,
+                   temporaryProblem: Boolean)
+/**
+  *
+  */
+class GTLabelTable(tag: Tag) extends Table[GTLabel](tag, Some("sidewalk"), "gt_label") {
+  def gtLabelId = column[Int]("gt_label_id", O.NotNull, O.PrimaryKey, O.AutoInc)
+  def routeId = column[Int]("route_id", O.NotNull)
+  def has_label_id = column[Boolean]("has_label_id",O.NotNull)
+  def gsvPanoramaId = column[String]("gsv_panorama_id", O.NotNull)
+  def labelTypeId = column[Int]("label_type_id", O.NotNull)
+  def svImageX = column[Int]("sv_image_x", O.NotNull)
+  def svImageY = column[Int]("sv_image_y", O.NotNull)
+  def canvasX = column[Int]("canvas_x", O.NotNull)
+  def canvasY = column[Int]("canvas_y", O.NotNull)
+  def heading = column[Float]("heading", O.NotNull)
+  def pitch = column[Float]("pitch", O.NotNull)
+  def zoom = column[Int]("zoom", O.NotNull)
+  def canvasHeight = column[Int]("canvas_height", O.NotNull)
+  def canvasWidth = column[Int]("canvas_width", O.NotNull)
+  def alphaX = column[Float]("alpha_x", O.NotNull)
+  def alphaY = column[Float]("alpha_y", O.NotNull)
+  def lat = column[Option[Float]]("lat", O.Nullable)
+  def lng = column[Option[Float]]("lng", O.Nullable)
+  def description = column[String]("description", O.NotNull)
+  def severity = column[Int]("severity", O.NotNull)
+  def temporaryProblem = column[Boolean]("temporary_problem", O.NotNull)
+
+
+
+  def * = (gtLabelId, routeId, has_label_id, gsvPanoramaId, labelTypeId, svImageX, svImageY, canvasX, canvasY, heading, pitch, zoom, canvasHeight, canvasWidth, alphaX, alphaY, lat, lng,
+    description, severity, temporaryProblem) <> ((GTLabel.apply _).tupled, GTLabel.unapply)
+
+  def route: ForeignKeyQuery[RouteTable, Route] =
+    foreignKey("gt_label_route_id_fkey", routeId, TableQuery[RouteTable])(_.routeId)
+
+  def labelType: ForeignKeyQuery[LabelTypeTable, LabelType] =
+    foreignKey("gt_label_label_type_id_fkey", labelTypeId, TableQuery[LabelTypeTable])(_.labelTypeId)
+
+}
+
+/**
+  * Data access object for the GTLabel table
+  */
+object GTLabelTable{
+  val db = play.api.db.slick.DB
+  val gt_labels = TableQuery[GTLabelTable]
+
+  def getGTLabel(gtLabelId: Option[Int]): Option[GTLabel] = db.withSession { implicit session =>
+    val gt_label = gt_labels.filter(_.gtLabelId === gtLabelId).list
+    gt_label.headOption
+  }
+
+  def all: List[GTLabel] = db.withSession { implicit session =>
+    gt_labels.list
+  }
+
+  def selectExistingLabels: List[GTLabel] = db.withSession { implicit session =>
+    gt_labels.filter(_.has_label_id === true).list
+  }
+
+  def selectAddedLabels: List[GTLabel] = db.withSession { implicit session =>
+    gt_labels.filter(_.has_label_id === false).list
+  }
+
+  def save(gt_label: GTLabel): Int = db.withTransaction { implicit session =>
+    val gtId: Int =
+      (gt_labels returning gt_labels.map(_.gtLabelId)) += gt_label
+    gtId
+  }
+
+}

--- a/app/models/gt/GTLabelTable.scala
+++ b/app/models/gt/GTLabelTable.scala
@@ -62,7 +62,7 @@ object GTLabelTable{
   val db = play.api.db.slick.DB
   val gt_labels = TableQuery[GTLabelTable]
 
-  def getGTLabel(gtLabelId: Option[Int]): Option[GTLabel] = db.withSession { implicit session =>
+  def getGTLabel(gtLabelId: Int): Option[GTLabel] = db.withSession { implicit session =>
     val gt_label = gt_labels.filter(_.gtLabelId === gtLabelId).list
     gt_label.headOption
   }

--- a/app/models/gt/GTLabelTable.scala
+++ b/app/models/gt/GTLabelTable.scala
@@ -11,7 +11,8 @@ import play.api.Play.current
 import scala.slick.lifted.ForeignKeyQuery
 
 case class GTLabel(gtLabelId: Int, routeId: Int, has_label_id: Boolean, gsvPanoramaId: String, labelTypeId: Int,
-                   svImageX: Int, svImageY: Int, canvasX: Int, canvasY: Int, heading: Float, pitch: Float, zoom: Int, canvasHeight: Int, canvasWidth: Int, alphaX: Float, alphaY: Float, lat: Option[Float], lng: Option[Float],
+                   svImageX: Int, svImageY: Int, canvasX: Int, canvasY: Int, heading: Float, pitch: Float, zoom: Int,
+                   canvasHeight: Int, canvasWidth: Int, alphaX: Float, alphaY: Float, lat: Option[Float], lng: Option[Float],
                    description: String,
                    severity: Int,
                    temporaryProblem: Boolean)
@@ -43,8 +44,9 @@ class GTLabelTable(tag: Tag) extends Table[GTLabel](tag, Some("sidewalk"), "gt_l
 
 
 
-  def * = (gtLabelId, routeId, has_label_id, gsvPanoramaId, labelTypeId, svImageX, svImageY, canvasX, canvasY, heading, pitch, zoom, canvasHeight, canvasWidth, alphaX, alphaY, lat, lng,
-    description, severity, temporaryProblem) <> ((GTLabel.apply _).tupled, GTLabel.unapply)
+  def * = (gtLabelId, routeId, has_label_id, gsvPanoramaId, labelTypeId, svImageX, svImageY,
+           canvasX, canvasY, heading, pitch, zoom, canvasHeight, canvasWidth, alphaX, alphaY,
+           lat, lng, description, severity, temporaryProblem)  <>  ((GTLabel.apply _).tupled, GTLabel.unapply)
 
   def route: ForeignKeyQuery[RouteTable, Route] =
     foreignKey("gt_label_route_id_fkey", routeId, TableQuery[RouteTable])(_.routeId)

--- a/conf/evolutions/default/4.sql
+++ b/conf/evolutions/default/4.sql
@@ -69,8 +69,8 @@ CREATE TABLE gt_existing_label
 
 # --- !Downs
 
-DROP TABLE gt_existing_label
-DROP TABLE gt_label
+DROP TABLE gt_existing_label;
+DROP TABLE gt_label;
 
 DROP TABLE clustering_session_label;
 DROP TABLE clustering_session_cluster;

--- a/conf/evolutions/default/4.sql
+++ b/conf/evolutions/default/4.sql
@@ -33,7 +33,6 @@ CREATE TABLE gt_label
 (
   gt_label_id SERIAL NOT NULL,
   route_id INT NOT NULL,
-  has_label_id Boolean NOT NULL,
   gsv_panorama_id Character Varying( 64 ) NOT NULL,
   label_type_id Integer NOT NULL,
   sv_image_x Integer NOT NULL,

--- a/conf/evolutions/default/4.sql
+++ b/conf/evolutions/default/4.sql
@@ -1,0 +1,77 @@
+
+# --- !Ups
+CREATE TABLE clustering_session
+(
+  clustering_session_id SERIAL NOT NULL,
+  route_id INT NOT NULL,
+  clustering_threshold DOUBLE PRECISION NOT NULL,
+  time_created timestamp default current_timestamp NOT NULL,
+  deleted Boolean NOT NULL,
+  PRIMARY KEY (clustering_session_id),
+  FOREIGN KEY (route_id) REFERENCES route(route_id)
+);
+
+CREATE TABLE clustering_session_cluster
+(
+  clustering_session_cluster_id SERIAL NOT NULL,
+  clustering_session_id INT NOT NULL,
+  PRIMARY KEY (clustering_session_cluster_id),
+  FOREIGN KEY (clustering_session_id) REFERENCES clustering_session(clustering_session_id)
+);
+
+CREATE TABLE clustering_session_label
+(
+  clustering_session_label_id SERIAL NOT NULL,
+  clustering_session_cluster_id INT NOT NULL,
+  label_id INT NOT NULL,
+  PRIMARY KEY (clustering_session_label_id),
+  FOREIGN KEY (label_id) REFERENCES label(label_id),
+  FOREIGN KEY (clustering_session_cluster_id) REFERENCES clustering_session_cluster(clustering_session_cluster_id)
+);
+
+CREATE TABLE gt_label
+(
+  gt_label_id SERIAL NOT NULL,
+  route_id INT NOT NULL,
+  has_label_id Boolean NOT NULL,
+  gsv_panorama_id Character Varying( 64 ) NOT NULL,
+  label_type_id Integer NOT NULL,
+  sv_image_x Integer NOT NULL,
+  sv_image_y Integer NOT NULL,
+  canvas_x Integer NOT NULL,
+  canvas_y Integer NOT NULL,
+  heading Double Precision NOT NULL,
+  pitch Double Precision NOT NULL,
+  zoom Integer NOT NULL,
+  canvas_height Integer NOT NULL,
+  canvas_width Integer NOT NULL,
+  alpha_x Double Precision NOT NULL,
+  alpha_y Double Precision NOT NULL,
+  lat Double Precision,
+  lng Double Precision,
+  description Text NOT NULL,
+  severity Int NOT NULL,
+  temporary_problem Boolean default FALSE NOT NULL,
+  PRIMARY KEY (gt_label_id),
+  FOREIGN KEY (route_id) REFERENCES route(route_id),
+  FOREIGN KEY (label_type_id) REFERENCES label_type(label_type_id)
+);
+
+CREATE TABLE gt_existing_label
+(
+  gt_existing_label_id SERIAL NOT NULL,
+  gt_label_id Integer NOT NULL,
+  label_id Integer NOT NULL,
+  PRIMARY KEY (gt_existing_label_id),
+  FOREIGN KEY (gt_label_id) REFERENCES gt_label(gt_label_id),
+  FOREIGN KEY (label_id) REFERENCES label(label_id)
+);
+
+# --- !Downs
+
+DROP TABLE gt_existing_label
+DROP TABLE gt_label
+
+DROP TABLE clustering_session_label;
+DROP TABLE clustering_session_cluster;
+DROP TABLE clustering_session;

--- a/conf/routes
+++ b/conf/routes
@@ -113,3 +113,9 @@ GET     /webjars/*file                          controllers.WebJarAssets.at(file
 # Set up ground truth resolution page
 GET     /gtresolution                            @controllers.GroundTruthResolutionController.index
 GET     /gtresolution/labelData/:labelId         @controllers.GroundTruthResolutionController.getLabelData(labelId: Int)
+
+# Clustering session end points
+GET     /clusteringsessions                             @controllers.ClusteringSessionController.index
+
+# Ground Truth Label end points
+GET     /gtlabels                                       @controllers.GTLabelController.index

--- a/conf/routes
+++ b/conf/routes
@@ -115,7 +115,7 @@ GET     /gtresolution                            @controllers.GroundTruthResolut
 GET     /gtresolution/labelData/:labelId         @controllers.GroundTruthResolutionController.getLabelData(labelId: Int)
 
 # Clustering session end points
-GET     /clusteringsessions                             @controllers.ClusteringSessionController.index
+GET     /clusteringsessions                             @controllers.ClusteringSessionController.getClusteringSessionsWithoutDeleted
 
 # Ground Truth Label end points
-GET     /gtlabels                                       @controllers.GTLabelController.index
+GET     /gtlabels                                       @controllers.GTLabelController.getAllGTLabels


### PR DESCRIPTION
Running this branch will create the following groups of tables + their related models and controller (new evolutions were put into a new .sql file):

Tables for clustering sessions
- clustering_session
- clustering_session_cluster
- clustering_session_label

Tables for ground truth labels
- gt_label
- gt_existing_label

Check if the /clusteringsessions endpoint returns a json object containing all existing (deleted = False) sessions
Check if the /gtlabels endpoint returns a json object containing all ground truth labels