### PR TITLE
940 Log Description Text

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
@@ -117,6 +117,7 @@ function ContextMenu (uiContextMenu) {
         if (label) {
             label.setProperty('description', description);
         }
+        svl.tracker.push('ContextMenu_TextBoxChange', { Description: description });
     }
 
     function handleDescriptionTextBoxBlur() {

--- a/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
@@ -23,7 +23,10 @@ function ContextMenu (uiContextMenu) {
         if (isOpen()){
             hide();
             wasOpen = true;
-            if (clicked_out) _handleSeverityPopup();
+            if (clicked_out) {
+             svl.tracker.push('ContextMenu_CloseClickOut');
+            _handleSeverityPopup();
+            }
         }
     }); //handles clicking outside of context menu holder
     //document.addEventListener("mousedown", hide);
@@ -32,6 +35,7 @@ function ContextMenu (uiContextMenu) {
         var key_pressed = e.which || e.keyCode;
         if (key_pressed == 13 && isOpen()){
             hide();
+            svl.tracker.push('ContextMenu_ClosePressEnter');
             _handleSeverityPopup();
         }
     };//handles pressing enter key to exit ContextMenu
@@ -114,10 +118,11 @@ function ContextMenu (uiContextMenu) {
     function handleDescriptionTextBoxChange(e) {
         var description = $(this).val(),
             label = getTargetLabel();
+        svl.tracker.push('ContextMenu_TextBoxChange', { Description: description });
+
         if (label) {
             label.setProperty('description', description);
         }
-        svl.tracker.push('ContextMenu_TextBoxChange', { Description: description });
     }
 
     function handleDescriptionTextBoxBlur() {
@@ -148,7 +153,7 @@ function ContextMenu (uiContextMenu) {
 
     }
 
-    function _handleSeverityPopup (){
+    function _handleSeverityPopup () {
         var labels = svl.labelContainer.getCurrentLabels();
         var prev_labels = svl.labelContainer.getPreviousLabels();
         if (labels.length == 0){


### PR DESCRIPTION
Resolves #940 
The tracker logs the entered description text in the event `ContextMenu_TextBoxChange` log.

Also, added logs for hitting enter and clicking outside the context menu to close the context menu - events `ContextMenu_ClosePressEnter` and `ContextMenu_CloseClickOut`