### PR TITLE
Update labels in the database with changes from the frontend: severity, description, temporary status or deletions

### DIFF
--- a/app/controllers/TaskController.scala
+++ b/app/controllers/TaskController.scala
@@ -177,7 +177,6 @@ class TaskController @Inject() (implicit val env: Environment[User, SessionAuthe
                 LabelTable.updateDeleted(labId, label.deleted.value)
                 labId
               case None =>
-                println(label)
                 LabelTable.save(Label(0, auditTaskId, label.gsvPanoramaId, labelTypeId, label.photographerHeading,
                                       label.photographerPitch, label.panoramaLat, label.panoramaLng,
                                       label.deleted.value, label.temporaryLabelId))

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -94,7 +94,7 @@ object LabelTable {
 
   case class LabelCountPerDay(date: String, count: Int)
 
-  case class LabelMetadata(labelId: Int, deleted: Boolean, gsvPanoramaId: String, heading: Float, pitch: Float, zoom: Int,
+  case class LabelMetadata(labelId: Int, gsvPanoramaId: String, heading: Float, pitch: Float, zoom: Int,
                            canvasX: Int, canvasY: Int, canvasWidth: Int, canvasHeight: Int,
                            auditTaskId: Int,
                            userId: String, username: String,
@@ -269,10 +269,10 @@ object LabelTable {
   }
 
   def retrieveLabelMetadata: List[LabelMetadata] = db.withSession { implicit session =>
-    val selectQuery = Q.queryNA[(Int, Boolean, String, Float, Float, Int, Int, Int, Int, Int,
+    val selectQuery = Q.queryNA[(Int, String, Float, Float, Int, Int, Int, Int, Int,
       Int, String, String, java.sql.Timestamp, String, String, Option[Int], Boolean,
       Option[String])](
-      """SELECT lb1.label_id, lb1.deleted, lb1.gsv_panorama_id, lp.heading, lp.pitch, lp.zoom, lp.canvas_x, lp.canvas_y,
+      """SELECT lb1.label_id, lb1.gsv_panorama_id, lp.heading, lp.pitch, lp.zoom, lp.canvas_x, lp.canvas_y,
         |       lp.canvas_width, lp.canvas_height, lb1.audit_task_id, u.user_id, u.username, ati.timestamp,
         |       lb_big.label_type, lb_big.label_type_desc, lb_big.severity, lb_big.temp_problem, lb_big.description
         |	FROM sidewalk.label as lb1, sidewalk.audit_task as at, sidewalk.audit_task_interaction as ati,

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -94,7 +94,7 @@ object LabelTable {
 
   case class LabelCountPerDay(date: String, count: Int)
 
-  case class LabelMetadata(labelId: Int, gsvPanoramaId: String, heading: Float, pitch: Float, zoom: Int,
+  case class LabelMetadata(labelId: Int, deleted: Boolean, gsvPanoramaId: String, heading: Float, pitch: Float, zoom: Int,
                            canvasX: Int, canvasY: Int, canvasWidth: Int, canvasHeight: Int,
                            auditTaskId: Int,
                            userId: String, username: String,
@@ -269,10 +269,10 @@ object LabelTable {
   }
 
   def retrieveLabelMetadata: List[LabelMetadata] = db.withSession { implicit session =>
-    val selectQuery = Q.queryNA[(Int, String, Float, Float, Int, Int, Int, Int, Int,
+    val selectQuery = Q.queryNA[(Int, Boolean, String, Float, Float, Int, Int, Int, Int, Int,
       Int, String, String, java.sql.Timestamp, String, String, Option[Int], Boolean,
       Option[String])](
-      """SELECT lb1.label_id, lb1.gsv_panorama_id, lp.heading, lp.pitch, lp.zoom, lp.canvas_x, lp.canvas_y,
+      """SELECT lb1.label_id, lb1.deleted, lb1.gsv_panorama_id, lp.heading, lp.pitch, lp.zoom, lp.canvas_x, lp.canvas_y,
         |       lp.canvas_width, lp.canvas_height, lb1.audit_task_id, u.user_id, u.username, ati.timestamp,
         |       lb_big.label_type, lb_big.label_type_desc, lb_big.severity, lb_big.temp_problem, lb_big.description
         |	FROM sidewalk.label as lb1, sidewalk.audit_task as at, sidewalk.audit_task_interaction as ati,
@@ -291,7 +291,8 @@ object LabelTable {
         |					ON lb.label_id = prob_temp.label_id
         |				) AS lb_big
         |WHERE lb1.audit_task_id = at.audit_task_id and (lb1.audit_task_id = ati.audit_task_id and
-        |      lb1.temporary_label_id = ati.temporary_label_id) and lb1.label_id = lb_big.label_id and
+        |      lb1.temporary_label_id = ati.temporary_label_id and ati.note = 'LabelingCanvas_FinishLabeling')
+        |      and lb1.label_id = lb_big.label_id and
         |      at.user_id = u.user_id and lb1.label_id = lp.label_id
         |	ORDER BY ati.timestamp DESC""".stripMargin
     )

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -290,7 +290,7 @@ object LabelTable {
         |				LEFT JOIN sidewalk.problem_temporariness as prob_temp
         |					ON lb.label_id = prob_temp.label_id
         |				) AS lb_big
-        |WHERE lb1.audit_task_id = at.audit_task_id and (lb1.audit_task_id = ati.audit_task_id and
+        |WHERE lb1.deleted = FALSE and lb1.audit_task_id = at.audit_task_id and (lb1.audit_task_id = ati.audit_task_id and
         |      lb1.temporary_label_id = ati.temporary_label_id and ati.action = 'LabelingCanvas_FinishLabeling') and
         |      lb1.label_id = lb_big.label_id and at.user_id = u.user_id and lb1.label_id = lp.label_id
         |	ORDER BY ati.timestamp DESC""".stripMargin

--- a/app/models/label/ProblemTemporarinessTable.scala
+++ b/app/models/label/ProblemTemporarinessTable.scala
@@ -47,8 +47,8 @@ object ProblemTemporarinessTable {
     * @return
     */
   def updateTemporariness(tempId: Int, newTemp: Boolean) = db.withTransaction { implicit session =>
-    val temproraryLabelRecords = problemTemporarinesses.filter(_.problemTemporarinessId === tempId).map(x => x.temporaryProblem)
-    temproraryLabelRecords.update(newTemp)
+    val temporaryLabelRecords = problemTemporarinesses.filter(_.problemTemporarinessId === tempId).map(x => x.temporaryProblem)
+    temporaryLabelRecords.update(newTemp)
   }
 }
 

--- a/app/models/label/ProblemTemporarinessTable.scala
+++ b/app/models/label/ProblemTemporarinessTable.scala
@@ -47,8 +47,8 @@ object ProblemTemporarinessTable {
     * @return
     */
   def updateTemporariness(tempId: Int, newTemp: Boolean) = db.withTransaction { implicit session =>
-    val severities = problemTemporarinesses.filter(_.problemTemporarinessId === tempId).map(x => x.temporaryProblem)
-    severities.update(newTemp)
+    val temproraryLabelRecords = problemTemporarinesses.filter(_.problemTemporarinessId === tempId).map(x => x.temporaryProblem)
+    temproraryLabelRecords.update(newTemp)
   }
 }
 

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -427,7 +427,6 @@
                                 <th class="col-md-2">Username</th>
                                 <th class="col-md-3" data-class-name="priority">Timestamp</th>
                                 <th class="col-md-2">Label Type</th>
-                                <th class="col-md-2">Deleted</th>
                                 <th class="col-md-1">Severity</th>
                                 <th class="col-md-1">Temporary?</th>
                                 <th class="col-md-5">Description</th>
@@ -441,7 +440,6 @@
                                 </td>
                                 <td>@label.timestamp</td>
                                 <td>@label.labelTypeValue</td>
-                                <td>@label.deleted</td>
                                 <td>@label.severity</td>
                                 <td>@label.temporary</td>
                                 <td>@label.description</td>

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -427,6 +427,7 @@
                                 <th class="col-md-2">Username</th>
                                 <th class="col-md-3" data-class-name="priority">Timestamp</th>
                                 <th class="col-md-2">Label Type</th>
+                                <th class="col-md-2">Deleted</th>
                                 <th class="col-md-1">Severity</th>
                                 <th class="col-md-1">Temporary?</th>
                                 <th class="col-md-5">Description</th>
@@ -440,6 +441,7 @@
                                 </td>
                                 <td>@label.timestamp</td>
                                 <td>@label.labelTypeValue</td>
+                                <td>@label.deleted</td>
                                 <td>@label.severity</td>
                                 <td>@label.temporary</td>
                                 <td>@label.description</td>

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import scalariform.formatter.preferences._
 
 name := """sidewalk-webpage"""
 
-version := "4.1.0"
+version := "4.1.1"
 
 scalaVersion := "2.10.4"
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import scalariform.formatter.preferences._
 
 name := """sidewalk-webpage"""
 
-version := "4.1.1"
+version := "4.1.2"
 
 scalaVersion := "2.10.4"
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import scalariform.formatter.preferences._
 
 name := """sidewalk-webpage"""
 
-version := "4.0.3"
+version := "4.1.0"
 
 scalaVersion := "2.10.4"
 

--- a/public/javascripts/SVLabel/src/SVLabel/Main.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Main.js
@@ -126,6 +126,7 @@ function Main (params) {
         svl.navigationModel._mapService = svl.map;
 
         svl.form = new Form(svl.labelContainer, svl.missionModel, svl.navigationModel, svl.neighborhoodModel, svl.panoramaContainer, svl.taskContainer, svl.map, svl.compass, svl.tracker, params.form);
+        svl.tracker.initTaskId();
         svl.statusField = new StatusField(svl.ui.status);
         svl.statusFieldNeighborhood = new StatusFieldNeighborhood(svl.neighborhoodModel, svl.statusModel, svl.userModel, svl.ui.status);
         svl.statusFieldMissionProgressBar = new StatusFieldMissionProgressBar(svl.modalModel, svl.statusModel, svl.ui.status);
@@ -492,12 +493,12 @@ function Main (params) {
         return _tasks.length > 0;
     }
 
-    function getStatus (key) { 
-        return key in status ? status[key] : null; 
+    function getStatus (key) {
+        return key in status ? status[key] : null;
     }
 
-    function setStatus (key, value) { 
-        status[key] = value; return this; 
+    function setStatus (key, value) {
+        status[key] = value; return this;
     }
 
     /**

--- a/public/javascripts/SVLabel/src/SVLabel/Tracker.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Tracker.js
@@ -51,6 +51,10 @@ function Tracker () {
         return action.indexOf("Click_LabelDelete") >= 0;
     };
 
+    this._isTaskStartAction = function (action) {
+        return action.indexOf("TaskStart") >= 0;
+    }
+
     /** Returns actions */
     this.getActions = function () {
         return actions;
@@ -169,17 +173,24 @@ function Tracker () {
             currentLabel = svl.canvas.getCurrentLabel().getProperties().temporary_label_id;
             updatedLabels.push(currentLabel);
             svl.labelContainer.addUpdatedLabel(currentLabel);
-
         }
 
         // Submit the data collected thus far if actions is too long.
         if (actions.length > 200 && !self._isCanvasInteraction(action) && !self._isContextMenuAction(action)) {
-            var task = svl.taskContainer.getCurrentTask();
-            var data = svl.form.compileSubmissionData(task);
-            svl.form.submit(data, task);
+            self.submitForm();
         }
         return this;
     };
+
+    this.submitForm = function() {
+        var task = svl.taskContainer.getCurrentTask();
+        var data = svl.form.compileSubmissionData(task);
+        svl.form.submit(data, task);
+    }
+
+    this.initTaskId = function() {
+        self.submitForm();
+    }
 
     /**
      * Put the previous labeling actions into prevActions. Then refresh the current actions.

--- a/public/javascripts/SVLabel/src/SVLabel/Tracker.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Tracker.js
@@ -48,6 +48,10 @@ function Tracker () {
         return action.indexOf("ContextMenu") >= 0;
     };
 
+    this._isContextMenuClose = function (action) {
+        return action.indexOf("ContextMenu_Close") >= 0 || action.indexOf("ContextMenu_OKButtonClick") >= 0;
+    }
+
     this._isDeleteLabelAction = function (action) {
         return action.indexOf("Click_LabelDelete") >= 0;
     };
@@ -198,6 +202,10 @@ function Tracker () {
 
         var item = self.create(action, notes, extraData);
         actions.push(item);
+
+        if(self._isContextMenuClose(action)){
+            currentLabel = null;
+        }
 
         // Submit the data collected thus far if actions is too long.
         if (actions.length > 200 && !self._isCanvasInteraction(action) && !self._isContextMenuAction(action)) {

--- a/public/javascripts/SVLabel/src/SVLabel/Tracker.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Tracker.js
@@ -18,7 +18,7 @@ function Tracker () {
 
     this.getCurrentLabel = function(){
         return currentLabel;
-    }
+    };
 
     this.trackWindowEvents = function() {
         var prefix = "LowLevelEvent_";
@@ -49,7 +49,7 @@ function Tracker () {
 
     this._isDeleteLabelAction = function (action) {
         return action.indexOf("Click_LabelDelete") >= 0;
-    }
+    };
 
     /** Returns actions */
     this.getActions = function () {
@@ -86,7 +86,7 @@ function Tracker () {
         var note = this._notesToString(notes);
 
         if ('temporaryLabelId' in extraData) {
-            if(currentLabel != null){
+            if(currentLabel !== null){
                 updatedLabels.push(currentLabel);
                 svl.labelContainer.addUpdatedLabel(currentLabel);
             }
@@ -154,7 +154,7 @@ function Tracker () {
         var item = self.create(action, notes, extraData);
         actions.push(item);
 
-        if(self._isContextMenuAction(action) && currentLabel != null) {
+        if(self._isContextMenuAction(action) && currentLabel !== null) {
             currentLabel = svl.contextMenu.getTargetLabel().getProperties().temporary_label_id;
             updatedLabels.push(currentLabel);
             svl.labelContainer.addUpdatedLabel(currentLabel);
@@ -183,7 +183,7 @@ function Tracker () {
         actions = [];
 
         updatedLabels = [];
-        if(currentLabel != null){
+        if(currentLabel !== null){
             updatedLabels.push(currentLabel);
             svl.labelContainer.addUpdatedLabel(currentLabel);
         }

--- a/public/javascripts/SVLabel/src/SVLabel/Tracker.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Tracker.js
@@ -21,6 +21,10 @@ function Tracker () {
         return currentLabel;
     };
 
+    this.setAuditTaskID = function(taskID) {
+        currentAuditTask = taskID;
+    };
+
     this.trackWindowEvents = function() {
         var prefix = "LowLevelEvent_";
 
@@ -105,7 +109,7 @@ function Tracker () {
         if ('canvas' in svl && svl.canvas.getCurrentLabel()){
             audit_task_id = svl.canvas.getCurrentLabel().getProperties().audit_task_id;
         } else {
-            audit_task_id = this.currentAuditTask;
+            audit_task_id = currentAuditTask;
         }
 
         if ('temporaryLabelId' in extraData) {
@@ -176,7 +180,8 @@ function Tracker () {
      */
     this.push = function (action, notes, extraData) {
 
-        if((self._isContextMenuAction(action) || self._isSeverityShortcutAction(action)) && currentLabel !== null) {
+        console.log("Task ID: " + currentAuditTask +" Current Label: " + currentLabel + " Action: " + action);
+        if((self._isContextMenuAction(action) || self._isSeverityShortcutAction(action))) {
 
             var labelProperties = svl.contextMenu.getTargetLabel().getProperties();
             currentLabel = labelProperties.temporary_label_id;
@@ -188,6 +193,7 @@ function Tracker () {
             } else {
                 notes['auditTaskId'] = labelProperties.audit_task_id;
             }
+            console.log("Current Label: " + currentLabel + " " + action);
 
         } else if (self._isDeleteLabelAction(action)){
 

--- a/public/javascripts/SVLabel/src/SVLabel/Tracker.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Tracker.js
@@ -81,9 +81,15 @@ function Tracker () {
         if (!extraData)
             extraData = {};
 
-        var pov, latlng, panoId;
+        var pov, latlng, panoId, audit_task_id;
 
         var note = this._notesToString(notes);
+
+        if ('canvas' in svl && svl.canvas.getCurrentLabel()){
+            audit_task_id = svl.canvas.getCurrentLabel().getProperties().audit_task_id;
+        } else {
+            audit_task_id = null;
+        }
 
         if ('temporaryLabelId' in extraData) {
             if(currentLabel !== null){
@@ -140,6 +146,7 @@ function Tracker () {
             zoom: pov.zoom,
             note: note,
             temporary_label_id: currentLabel,
+            audit_task_id: audit_task_id,
             timestamp: timestamp
         };
         return item;
@@ -162,7 +169,6 @@ function Tracker () {
             currentLabel = svl.canvas.getCurrentLabel().getProperties().temporary_label_id;
             updatedLabels.push(currentLabel);
             svl.labelContainer.addUpdatedLabel(currentLabel);
-
 
         }
 

--- a/public/javascripts/SVLabel/src/SVLabel/Tracker.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Tracker.js
@@ -180,7 +180,7 @@ function Tracker () {
      */
     this.push = function (action, notes, extraData) {
 
-        console.log("Task ID: " + currentAuditTask +" Current Label: " + currentLabel + " Action: " + action);
+        //console.log("Task ID: " + currentAuditTask +" Current Label: " + currentLabel + " Action: " + action);
         if((self._isContextMenuAction(action) || self._isSeverityShortcutAction(action))) {
 
             var labelProperties = svl.contextMenu.getTargetLabel().getProperties();
@@ -193,7 +193,7 @@ function Tracker () {
             } else {
                 notes['auditTaskId'] = labelProperties.audit_task_id;
             }
-            console.log("Current Label: " + currentLabel + " " + action);
+            //console.log("Current Label: " + currentLabel + " " + action);
 
         } else if (self._isDeleteLabelAction(action)){
 

--- a/public/javascripts/SVLabel/src/SVLabel/Tracker.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Tracker.js
@@ -47,6 +47,10 @@ function Tracker () {
         return action.indexOf("ContextMenu") >= 0;
     };
 
+    this._isDeleteLabelAction = function (action) {
+        return action.indexOf("Click_LabelDelete") >= 0;
+    }
+
     /** Returns actions */
     this.getActions = function () {
         return actions;
@@ -154,6 +158,12 @@ function Tracker () {
             currentLabel = svl.contextMenu.getTargetLabel().getProperties().temporary_label_id;
             updatedLabels.push(currentLabel);
             svl.labelContainer.addUpdatedLabel(currentLabel);
+        } else if (self._isDeleteLabelAction(action)){
+            currentLabel = svl.canvas.getCurrentLabel().getProperties().temporary_label_id;
+            updatedLabels.push(currentLabel);
+            svl.labelContainer.addUpdatedLabel(currentLabel);
+
+
         }
 
         // Submit the data collected thus far if actions is too long.

--- a/public/javascripts/SVLabel/src/SVLabel/Tracker.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Tracker.js
@@ -64,6 +64,10 @@ function Tracker () {
         return action.indexOf("KeyboardShortcut_Severity") >= 0;
     }
 
+    this._isFinishLabelingAction = function (action) {
+        return action.indexOf("LabelingCanvas_FinishLabeling") >= 0;
+    }
+
     /** Returns actions */
     this.getActions = function () {
         return actions;
@@ -203,8 +207,14 @@ function Tracker () {
         var item = self.create(action, notes, extraData);
         actions.push(item);
 
+        var contextMenuLabel = true;
+
+        if(self._isFinishLabelingAction(action) && (notes['labelType'] === 'NoSidewalk' || notes['labelType'] === 'Occlusion')){
+            contextMenuLabel = false;
+        }
+
         //we are no longer interacting with a label, set currentLabel to null
-        if(self._isContextMenuClose(action) || self._isDeleteLabelAction(action)){
+        if(self._isContextMenuClose(action) || self._isDeleteLabelAction(action) || !contextMenuLabel){
             currentLabel = null;
         }
 

--- a/public/javascripts/SVLabel/src/SVLabel/Tracker.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Tracker.js
@@ -181,7 +181,7 @@ function Tracker () {
     this.push = function (action, notes, extraData) {
 
         //console.log("Task ID: " + currentAuditTask +" Current Label: " + currentLabel + " Action: " + action);
-        if((self._isContextMenuAction(action) || self._isSeverityShortcutAction(action))) {
+        if(self._isContextMenuAction(action) || self._isSeverityShortcutAction(action)) {
 
             var labelProperties = svl.contextMenu.getTargetLabel().getProperties();
             currentLabel = labelProperties.temporary_label_id;

--- a/public/javascripts/SVLabel/src/SVLabel/Tracker.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Tracker.js
@@ -11,6 +11,7 @@ function Tracker () {
 
     var currentLabel = null;
     var updatedLabels = [];
+    var currentAuditTask = null;
 
     this.init = function () {
         this.trackWindowEvents();
@@ -92,7 +93,7 @@ function Tracker () {
         if ('canvas' in svl && svl.canvas.getCurrentLabel()){
             audit_task_id = svl.canvas.getCurrentLabel().getProperties().audit_task_id;
         } else {
-            audit_task_id = null;
+            audit_task_id = this.currentAuditTask;
         }
 
         if ('temporaryLabelId' in extraData) {

--- a/public/javascripts/SVLabel/src/SVLabel/Tracker.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Tracker.js
@@ -50,7 +50,7 @@ function Tracker () {
 
     this._isContextMenuClose = function (action) {
         return action.indexOf("ContextMenu_Close") >= 0 || action.indexOf("ContextMenu_OKButtonClick") >= 0;
-    }
+    };
 
     this._isDeleteLabelAction = function (action) {
         return action.indexOf("Click_LabelDelete") >= 0;
@@ -58,15 +58,15 @@ function Tracker () {
 
     this._isTaskStartAction = function (action) {
         return action.indexOf("TaskStart") >= 0;
-    }
+    };
 
     this._isSeverityShortcutAction = function (action) {
         return action.indexOf("KeyboardShortcut_Severity") >= 0;
-    }
+    };
 
     this._isFinishLabelingAction = function (action) {
         return action.indexOf("LabelingCanvas_FinishLabeling") >= 0;
-    }
+    };
 
     /** Returns actions */
     this.getActions = function () {
@@ -229,11 +229,11 @@ function Tracker () {
         var task = svl.taskContainer.getCurrentTask();
         var data = svl.form.compileSubmissionData(task);
         svl.form.submit(data, task);
-    }
+    };
 
     this.initTaskId = function() {
         self.submitForm();
-    }
+    };
 
     /**
      * Put the previous labeling actions into prevActions. Then refresh the current actions.

--- a/public/javascripts/SVLabel/src/SVLabel/Tracker.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Tracker.js
@@ -203,7 +203,8 @@ function Tracker () {
         var item = self.create(action, notes, extraData);
         actions.push(item);
 
-        if(self._isContextMenuClose(action)){
+        //we are no longer interacting with a label, set currentLabel to null
+        if(self._isContextMenuClose(action) || self._isDeleteLabelAction(action)){
             currentLabel = null;
         }
 

--- a/public/javascripts/SVLabel/src/SVLabel/Tracker.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Tracker.js
@@ -9,9 +9,16 @@ function Tracker () {
     var actions = [];
     var prevActions = [];
 
+    var currentLabel = null;
+    var updatedLabels = [];
+
     this.init = function () {
         this.trackWindowEvents();
     };
+
+    this.getCurrentLabel = function(){
+        return currentLabel;
+    }
 
     this.trackWindowEvents = function() {
         var prefix = "LowLevelEvent_";
@@ -70,12 +77,16 @@ function Tracker () {
         if (!extraData)
             extraData = {};
 
-        var pov, latlng, panoId, temporaryLabelId;
+        var pov, latlng, panoId;
 
         var note = this._notesToString(notes);
 
         if ('temporaryLabelId' in extraData) {
-            temporaryLabelId = extraData['temporaryLabelId'];
+            if(currentLabel != null){
+                updatedLabels.push(currentLabel);
+                svl.labelContainer.addUpdatedLabel(currentLabel);
+            }
+            currentLabel = extraData['temporaryLabelId'];
         }
 
         // Initialize variables. Note you cannot get pov, panoid, or position
@@ -124,7 +135,7 @@ function Tracker () {
             pitch: pov.pitch,
             zoom: pov.zoom,
             note: note,
-            temporary_label_id: temporaryLabelId,
+            temporary_label_id: currentLabel,
             timestamp: timestamp
         };
         return item;
@@ -154,9 +165,15 @@ function Tracker () {
     this.refresh = function () {
         prevActions = prevActions.concat(actions);
         actions = [];
+
+        updatedLabels = [];
+        if(currentLabel != null){
+            updatedLabels.push(currentLabel);
+            svl.labelContainer.addUpdatedLabel(currentLabel);
+        }
+
         self.push("RefreshTracker");
     };
 
     this.init();
 }
-

--- a/public/javascripts/SVLabel/src/SVLabel/Tracker.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Tracker.js
@@ -150,6 +150,12 @@ function Tracker () {
         var item = self.create(action, notes, extraData);
         actions.push(item);
 
+        if(self._isContextMenuAction(action) && currentLabel != null) {
+            currentLabel = svl.contextMenu.getTargetLabel().getProperties().temporary_label_id;
+            updatedLabels.push(currentLabel);
+            svl.labelContainer.addUpdatedLabel(currentLabel);
+        }
+
         // Submit the data collected thus far if actions is too long.
         if (actions.length > 200 && !self._isCanvasInteraction(action) && !self._isContextMenuAction(action)) {
             var task = svl.taskContainer.getCurrentTask();

--- a/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
@@ -355,11 +355,13 @@ function ContextMenu (uiContextMenu) {
                         example = " (e.g., unleveled due to a tree root)";
                     }
                     $descriptionTextBox.prop("placeholder", defaultText + example);
+
+                    //don't push event on Occlusion or NoSidewalk labels
+                    svl.tracker.push('ContextMenu_Open', null, {'temporaryLabelId': self.getTargetLabel().getProperties().temporary_label_id});
                 }
             }
         }
         self.updateRadioButtonImages();
-        svl.tracker.push('ContextMenu_Open', null, {'temporaryLabelId': self.getTargetLabel().getProperties().temporary_label_id});
     }
 
     self.getContextMenuUI = getContextMenuUI;

--- a/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
@@ -359,6 +359,8 @@ function ContextMenu (uiContextMenu) {
             }
         }
         self.updateRadioButtonImages();
+        console.log(self.getTargetLabel().getProperties());
+        svl.tracker.push('ContextMenu_Open', null, {'temporaryLabelId': self.getTargetLabel().getProperties().temporary_label_id});
     }
 
     self.getContextMenuUI = getContextMenuUI;

--- a/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
@@ -355,12 +355,11 @@ function ContextMenu (uiContextMenu) {
                         example = " (e.g., unleveled due to a tree root)";
                     }
                     $descriptionTextBox.prop("placeholder", defaultText + example);
-
-                    var labelProperties = self.getTargetLabel().getProperties();
-
-                    //don't push event on Occlusion or NoSidewalk labels; they don't open ContextMenus
-                    svl.tracker.push('ContextMenu_Open', {'auditTaskId': labelProperties.audit_task_id}, {'temporaryLabelId': labelProperties.temporary_label_id});
                 }
+                var labelProperties = self.getTargetLabel().getProperties();
+
+                //don't push event on Occlusion or NoSidewalk labels; they don't open ContextMenus
+                svl.tracker.push('ContextMenu_Open', {'auditTaskId': labelProperties.audit_task_id}, {'temporaryLabelId': labelProperties.temporary_label_id});
             }
         }
         self.updateRadioButtonImages();

--- a/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
@@ -359,7 +359,6 @@ function ContextMenu (uiContextMenu) {
             }
         }
         self.updateRadioButtonImages();
-        console.log(self.getTargetLabel().getProperties());
         svl.tracker.push('ContextMenu_Open', null, {'temporaryLabelId': self.getTargetLabel().getProperties().temporary_label_id});
     }
 

--- a/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
@@ -356,8 +356,10 @@ function ContextMenu (uiContextMenu) {
                     }
                     $descriptionTextBox.prop("placeholder", defaultText + example);
 
-                    //don't push event on Occlusion or NoSidewalk labels
-                    svl.tracker.push('ContextMenu_Open', null, {'temporaryLabelId': self.getTargetLabel().getProperties().temporary_label_id});
+                    var labelProperties = self.getTargetLabel().getProperties();
+
+                    //don't push event on Occlusion or NoSidewalk labels; they don't open ContextMenus
+                    svl.tracker.push('ContextMenu_Open', {'auditTaskId': labelProperties.audit_task_id}, {'temporaryLabelId': labelProperties.temporary_label_id});
                 }
             }
         }

--- a/public/javascripts/SVLabel/src/SVLabel/data/Form.js
+++ b/public/javascripts/SVLabel/src/SVLabel/data/Form.js
@@ -178,7 +178,7 @@ function Form (labelContainer, missionModel, navigationModel, neighborhoodModel,
     this.skip = function (task, skipReasonLabel) {
         var data = self._prepareSkipData(skipReasonLabel);
 
-        if (skipReasonLabel == "GSVNotAvailable") {
+        if (skipReasonLabel === "GSVNotAvailable") {
             task.complete();
             taskContainer.push(task);
             util.misc.reportNoStreetView(task.getStreetEdgeId());
@@ -222,7 +222,7 @@ function Form (labelContainer, missionModel, navigationModel, neighborhoodModel,
      * @param async
      */
     this.submit = function (data, task, async) {
-        if (typeof async == "undefined") { async = true; }
+        if (typeof async === "undefined") { async = true; }
 
         if (data.constructor !== Array) { data = [data]; }
 

--- a/public/javascripts/SVLabel/src/SVLabel/data/Form.js
+++ b/public/javascripts/SVLabel/src/SVLabel/data/Form.js
@@ -247,7 +247,7 @@ function Form (labelContainer, missionModel, navigationModel, neighborhoodModel,
             success: function (result) {
                 if (result) {
                     task.setProperty("auditTaskId", result.audit_task_id);
-                    svl.tracker.currentAuditTask = result.audit_task_id;
+                    svl.tracker.setAuditTaskID(result.audit_task_id);
                 }
             },
             error: function (result) {

--- a/public/javascripts/SVLabel/src/SVLabel/data/Form.js
+++ b/public/javascripts/SVLabel/src/SVLabel/data/Form.js
@@ -245,7 +245,10 @@ function Form (labelContainer, missionModel, navigationModel, neighborhoodModel,
             data: JSON.stringify(data),
             dataType: 'json',
             success: function (result) {
-                if (result) task.setProperty("auditTaskId", result.audit_task_id);
+                if (result) {
+                    task.setProperty("auditTaskId", result.audit_task_id);
+                    svl.tracker.currentAuditTask = result.audit_task_id;
+                }
             },
             error: function (result) {
                 console.error(result);

--- a/public/javascripts/SVLabel/src/SVLabel/data/Form.js
+++ b/public/javascripts/SVLabel/src/SVLabel/data/Form.js
@@ -1,11 +1,12 @@
 /**
  *
  * @param labelContainer
+ * @param missionModel
  * @param navigationModel
  * @param neighborhoodModel
  * @param panoramaContainer
  * @param taskContainer
-	 * @param mapService
+ * @param mapService
  * @param compass
  * @param tracker
  * @param params
@@ -70,6 +71,7 @@ function Form (labelContainer, missionModel, navigationModel, neighborhoodModel,
                 panorama_lat: prop.panoramaLat,
                 panorama_lng: prop.panoramaLng,
                 temporary_label_id: label.getProperty('temporary_label_id'),
+                audit_task_id: label.getProperty('audit_task_id'),
                 gsv_panorama_id : prop.panoId,
                 label_points : [],
                 severity: label.getProperty('severity'),

--- a/public/javascripts/SVLabel/src/SVLabel/data/Form.js
+++ b/public/javascripts/SVLabel/src/SVLabel/data/Form.js
@@ -235,7 +235,7 @@ function Form (labelContainer, missionModel, navigationModel, neighborhoodModel,
 
         labelContainer.refresh();
 
-        console.log(data);
+        //console.log(data);
 
         $.ajax({
             async: async,

--- a/public/javascripts/SVLabel/src/SVLabel/data/Form.js
+++ b/public/javascripts/SVLabel/src/SVLabel/data/Form.js
@@ -233,6 +233,8 @@ function Form (labelContainer, missionModel, navigationModel, neighborhoodModel,
 
         labelContainer.refresh();
 
+        console.log(data);
+
         $.ajax({
             async: async,
             contentType: 'application/json; charset=utf-8',

--- a/public/javascripts/SVLabel/src/SVLabel/label/Label.js
+++ b/public/javascripts/SVLabel/src/SVLabel/label/Label.js
@@ -334,8 +334,8 @@ function Label (svl, pathIn, params) {
      * @param key
      * @returns {*}
      */
-    function getStatus (key) { 
-        return status[key]; 
+    function getStatus (key) {
+        return status[key];
     }
 
     function getVisibility () { return status.visibility; }
@@ -469,7 +469,7 @@ function Label (svl, pathIn, params) {
                     var imageCoordinateY = 3328 - iy * 26;
                     var canvasPoint = util.panomarker.imageCoordinateToCanvasCoordinate(imageCoordinateX, imageCoordinateY, pov);
 
-                    console.log(canvasPoint);
+                    //console.log(canvasPoint);
                     ctx.save();
                     ctx.strokeStyle = 'rgba(255,255,255,1)';
                     ctx.lineWidth = 2;

--- a/public/javascripts/SVLabel/src/SVLabel/label/LabelContainer.js
+++ b/public/javascripts/SVLabel/src/SVLabel/label/LabelContainer.js
@@ -88,12 +88,13 @@ function LabelContainer($) {
                 return label.getProperty("temporary_label_id") !== tempId;
             });
 
-        //if there are no temporary labels with this ID then just add it
-        //otherwise get rid of all old instances and add the new label
+        //if there are no temporary labels with this ID in currentCanvasLabels
+        //then add it to that list
+        //otherwise get rid of all old instances in currentCanvasLabels and add the updated label
 
         var match = this.findLabelByTempId(tempId);
 
-        // Label with this id doesn't exist
+        // Label with this id doesn't exist in currentCanvasLabels
         if(otherLabels.length === currentCanvasLabels.length){
             currentCanvasLabels.push(match);
         } else {

--- a/public/javascripts/SVLabel/src/SVLabel/label/LabelContainer.js
+++ b/public/javascripts/SVLabel/src/SVLabel/label/LabelContainer.js
@@ -51,7 +51,7 @@ function LabelContainer($) {
     };
 
     /**
-     * Returns canvas labels. NOTE: I don't think this is used anywhere anymore.
+     * Returns canvas labels.
      */
     this.getCanvasLabels = function () {
         return prevCanvasLabels.concat(currentCanvasLabels);
@@ -66,6 +66,29 @@ function LabelContainer($) {
         return prevCanvasLabels;
     };
 
+    //find most recent instance of label with matching temporary ID
+    this.findLabelByTempId = function (tempId) {
+        var matchingLabels =  _.filter(svl.labelContainer.getCanvasLabels(),
+            function(label) {
+                return label.getProperty("temporary_label_id") == tempId;
+            });
+
+        if(matchingLabels.length == 0){
+            return [];
+        }
+        
+        return matchingLabels[matchingLabels.length - 1];
+    }
+
+    //remove old versions of this label, add updated label
+    this.addUpdatedLabel = function (tempId) {
+        currentCanvasLabels = _.filter(currentCanvasLabels,
+            function(label){
+                return label.getProperty("temporary_label_id") != tempId;
+            });
+        currentCanvasLabels.push(this.findLabelByTempId(tempId));
+    }
+
     /** Load labels */
     function load () {
         currentCanvasLabels = svl.storage.get("labels");
@@ -78,7 +101,7 @@ function LabelContainer($) {
     this.push = function (label) {
         currentCanvasLabels.push(label);
         svl.labelCounter.increment(label.getProperty("labelType"));
-        
+
         // Keep panorama meta data, especially the date when the Street View picture was taken to keep track of when the problem existed
         var panoramaId = label.getProperty("panoId");
         if ("panoramaContainer" in svl && svl.panoramaContainer && panoramaId && !svl.panoramaContainer.getPanorama(panoramaId)) {

--- a/public/javascripts/SVLabel/src/SVLabel/label/LabelContainer.js
+++ b/public/javascripts/SVLabel/src/SVLabel/label/LabelContainer.js
@@ -74,19 +74,31 @@ function LabelContainer($) {
             });
 
         if(matchingLabels.length == 0){
-            return [];
+            return null;
         }
-        
+
+        //returns most recent version of label
         return matchingLabels[matchingLabels.length - 1];
     }
 
     //remove old versions of this label, add updated label
     this.addUpdatedLabel = function (tempId) {
-        currentCanvasLabels = _.filter(currentCanvasLabels,
+        var otherLabels = _.filter(currentCanvasLabels,
             function(label){
                 return label.getProperty("temporary_label_id") != tempId;
             });
-        currentCanvasLabels.push(this.findLabelByTempId(tempId));
+
+        //if there are no temporary labels with this ID then just add it
+        //otherwise get rid of all old instances and add the new label
+
+        var match = this.findLabelByTempId(tempId);
+        if(otherLabels.length == currentCanvasLabels.length){
+            currentCanvasLabels.push(match);
+        } else {
+            currentCanvasLabels = otherLabels;
+            if(match != null)
+                currentCanvasLabels.push(match);
+        }
     }
 
     /** Load labels */

--- a/public/javascripts/SVLabel/src/SVLabel/label/LabelContainer.js
+++ b/public/javascripts/SVLabel/src/SVLabel/label/LabelContainer.js
@@ -70,36 +70,36 @@ function LabelContainer($) {
     this.findLabelByTempId = function (tempId) {
         var matchingLabels =  _.filter(svl.labelContainer.getCanvasLabels(),
             function(label) {
-                return label.getProperty("temporary_label_id") == tempId;
+                return label.getProperty("temporary_label_id") === tempId;
             });
 
-        if(matchingLabels.length == 0){
+        if(matchingLabels.length === 0){
             return null;
         }
 
         //returns most recent version of label
         return matchingLabels[matchingLabels.length - 1];
-    }
+    };
 
     //remove old versions of this label, add updated label
     this.addUpdatedLabel = function (tempId) {
         var otherLabels = _.filter(currentCanvasLabels,
             function(label){
-                return label.getProperty("temporary_label_id") != tempId;
+                return label.getProperty("temporary_label_id") !== tempId;
             });
 
         //if there are no temporary labels with this ID then just add it
         //otherwise get rid of all old instances and add the new label
 
         var match = this.findLabelByTempId(tempId);
-        if(otherLabels.length == currentCanvasLabels.length){
+        if(otherLabels.length === currentCanvasLabels.length){
             currentCanvasLabels.push(match);
         } else {
             currentCanvasLabels = otherLabels;
-            if(match != null)
+            if(match !== null)
                 currentCanvasLabels.push(match);
         }
-    }
+    };
 
     /** Load labels */
     function load () {
@@ -143,13 +143,13 @@ function LabelContainer($) {
         for (; i < len; i++) {
             storedLabel = neighborhoodLabels[neighborhoodId][i];
 
-            if (storedLabel.getProperty("labelId") != "DefaultValue" &&
-                storedLabel.getProperty("labelId") == label.getProperty("labelId")) {
+            if (storedLabel.getProperty("labelId") !== "DefaultValue" &&
+                storedLabel.getProperty("labelId") === label.getProperty("labelId")) {
                 return;
             }
 
             if (storedLabel.getProperty("temporary_label_id") &&
-                storedLabel.getProperty("temporary_label_id") == label.getProperty("temporary_label_id")) {
+                storedLabel.getProperty("temporary_label_id") === label.getProperty("temporary_label_id")) {
                 return
             }
         }

--- a/public/javascripts/SVLabel/src/SVLabel/label/LabelContainer.js
+++ b/public/javascripts/SVLabel/src/SVLabel/label/LabelContainer.js
@@ -92,6 +92,8 @@ function LabelContainer($) {
         //otherwise get rid of all old instances and add the new label
 
         var match = this.findLabelByTempId(tempId);
+
+        // Label with this id doesn't exist
         if(otherLabels.length === currentCanvasLabels.length){
             currentCanvasLabels.push(match);
         } else {

--- a/public/javascripts/SVLabel/src/SVLabel/label/LabelFactory.js
+++ b/public/javascripts/SVLabel/src/SVLabel/label/LabelFactory.js
@@ -12,6 +12,7 @@ function LabelFactory (svl) {
             if (label) {
                 if (!('labelId' in param)) {
                     var currentTask = svl.taskContainer.getCurrentTask();
+                    //console.log("AT " + currentTask.getAuditTaskId() + " ST " + currentTask.getStreetEdgeId());
                     label.setProperty("audit_task_id", currentTask.getAuditTaskId());
                     label.setProperty("temporary_label_id", temporaryLabelId);
                     temporaryLabelId++;

--- a/public/javascripts/SVLabel/src/SVLabel/label/LabelFactory.js
+++ b/public/javascripts/SVLabel/src/SVLabel/label/LabelFactory.js
@@ -11,6 +11,8 @@ function LabelFactory (svl) {
             var label = new Label(svl, path, param);
             if (label) {
                 if (!('labelId' in param)) {
+                    var currentTask = svl.taskContainer.getCurrentTask();
+                    label.setProperty("audit_task_id", currentTask.getAuditTaskId());
                     label.setProperty("temporary_label_id", temporaryLabelId);
                     temporaryLabelId++;
                 }

--- a/public/javascripts/SVLabel/src/SVLabel/label/LabelFactory.js
+++ b/public/javascripts/SVLabel/src/SVLabel/label/LabelFactory.js
@@ -12,7 +12,6 @@ function LabelFactory (svl) {
             if (label) {
                 if (!('labelId' in param)) {
                     var currentTask = svl.taskContainer.getCurrentTask();
-                    //console.log("AT " + currentTask.getAuditTaskId() + " ST " + currentTask.getStreetEdgeId());
                     label.setProperty("audit_task_id", currentTask.getAuditTaskId());
                     label.setProperty("temporary_label_id", temporaryLabelId);
                     temporaryLabelId++;


### PR DESCRIPTION
Resolves #937.

Our front end system on the audit page is now capable of updating labels after the first submission. Additionally, labels that have ratings / descriptions added after the first submission will continue to be updated as they are entered.

These are submitted as new label objects in the `submit` function within `Form.js` with the same temporary_label_id and task as the first label submitted. Next, we need to create a backend handler for these labels, likely within `TaskController.scala` to update rows in the table with matching temporary_label_id and task fields. @misaugstad and @manaswis told me today that they could work on this over the weekend.

As @jonfroehlich mentioned, this will need a lot of testing. While I ran through multiple interaction sequences (e.g. creating two labels, deleting one, then updating the other, etc.) and ensured expected behavior, we will need to create some testing protocol for ensuring that logging is successful this time around.