### PR TITLE
Replace first 1000-ft mission with two 500-ft missions

### DIFF
--- a/app/controllers/MissionController.scala
+++ b/app/controllers/MissionController.scala
@@ -21,6 +21,10 @@ import scala.concurrent.Future
 class MissionController @Inject() (implicit val env: Environment[User, SessionAuthenticator])
   extends Silhouette[User, SessionAuthenticator] with ProvidesHeader {
 
+  val precision = 0.10
+  val missionLength1000 = 1000.0
+  val missionLength500 = 500.0
+
   /**
     * Return the completed missions in a JSON array
     * @return
@@ -37,22 +41,39 @@ class MissionController @Inject() (implicit val env: Environment[User, SessionAu
         }
 
         val completedMissions: List[Mission] = MissionTable.selectCompletedMissionsByAUser(user.userId)
-        val regionsWhereOriginal1000FtMissionCompleted = completedMissions.filter(m => 
-          m.coverage match {
-            case None => ~=(m.distance_ft.getOrElse(Double.PositiveInfinity), 1000.0, 0.10)
+
+        // Finds the regions where the user has completed the original 1000-ft mission
+        // Filters original 1000-ft mission out from incomplete missions for each region since it has been replaced by
+        // new 500-ft and 1000-ft mission (https://github.com/ProjectSidewalk/SidewalkWebpage/issues/841)
+        // If user has already completed the original 1000-ft mission in a region, filters out the new 500-ft and 
+        // 1000-ft missions in that region
+        val regionsWhereOriginal1000FtMissionCompleted = completedMissions.filter(m => {
+          val coverage = m.coverage
+          val distanceFt = m.distance_ft.getOrElse(Double.PositiveInfinity)
+          coverage match {
+            case None => ~=(distanceFt, missionLength1000, precision)
             case _ => false
           }
-        ).map(_.regionId.getOrElse(-1)).filter(_ != -1)
-        val incompleteMissions: List[Mission] = MissionTable.selectIncompleteMissionsByAUser(user.userId).filter(m =>
-          !(m.coverage match {
+        }).map(_.regionId.getOrElse(-1)).filter(_ != -1)
+        val incompleteMissions: List[Mission] = MissionTable.selectIncompleteMissionsByAUser(user.userId).filter(m => {
+          val coverage = m.coverage
+          val distanceFt = m.distance_ft.getOrElse(Double.PositiveInfinity)
+          val missionRegionId = m.regionId.getOrElse(-1)
+
+          !(coverage match {
             case None => 
-              ~=(m.distance_ft.getOrElse(Double.PositiveInfinity), 1000.0, 0.10) ||
-              regionsWhereOriginal1000FtMissionCompleted.exists(_ == m.regionId.getOrElse(-1)) && ~=(m.distance_ft.getOrElse(Double.PositiveInfinity), 500.0, 0.10)
+              // Filter out original 1000-ft missions
+              ~=(distanceFt, missionLength1000, precision) ||
+              // Filter out new 500-ft mission if user has already completed original 1000-ft mission in that region
+              (regionsWhereOriginal1000FtMissionCompleted.exists(_ == missionRegionId) &&
+               ~=(distanceFt, missionLength500, precision))
             case _ =>
-              regionsWhereOriginal1000FtMissionCompleted.exists(_ == m.regionId.getOrElse(-1)) && ~=(m.distance_ft.getOrElse(Double.PositiveInfinity), 1000.0, 0.10)
+              // Filter out new 1000-ft mission if user has already completed original 1000-ft mission in that region
+              regionsWhereOriginal1000FtMissionCompleted.exists(_ == missionRegionId) &&
+              ~=(distanceFt, missionLength1000, precision)
             }
           )
-        )
+        })
 
         val completedMissionJsonObjects: List[JsObject] = completedMissions.map( m =>
           Json.obj("is_completed" -> true,
@@ -80,13 +101,20 @@ class MissionController @Inject() (implicit val env: Environment[User, SessionAu
 
         val concatenated = completedMissionJsonObjects ++ incompleteMissionJsonObjects
         Future.successful(Ok(JsArray(concatenated)))
+
+
+
+      // For anonymous users
       case _ =>
-        val missions = MissionTable.selectMissions.filter(m => 
-          m.coverage match {
-            case None => !(~=(m.distance_ft.getOrElse(Double.PositiveInfinity), 1000.0, 0.10))
+        // Selects all missions except the original 1000-ft mission
+        val missions = MissionTable.selectMissions.filter(m => {
+          val coverage = m.coverage
+          val distanceFt = m.distance_ft.getOrElse(Double.PositiveInfinity)
+          coverage match {
+            case None => !(~=(distanceFt, missionLength1000, precision))
             case _ => true
           }
-        ) // Don't include the original 1000-ft mission
+        })
         val missionJsonObjects: List[JsObject] = missions.map( m =>
           Json.obj("is_completed" -> false,
             "mission_id" -> m.missionId,
@@ -98,10 +126,10 @@ class MissionController @Inject() (implicit val env: Environment[User, SessionAu
             "distance_mi" -> m.distance_mi,
             "coverage" -> m.coverage)
         )
-
         Future.successful(Ok(JsArray(missionJsonObjects)))
     }
   }
+
 
   def post = UserAwareAction.async(BodyParsers.parse.json) { implicit request =>
     // Validation https://www.playframework.com/documentation/2.3.x/ScalaJson
@@ -128,44 +156,65 @@ class MissionController @Inject() (implicit val env: Environment[User, SessionAu
     )
   }
 
+
+  // Approximate equality check for Doubles
+  // https://alvinalexander.com/scala/how-to-compare-floating-point-numbers-in-scala-float-double
   def ~=(x: Double, y: Double, precision: Double) = { // Approximate equality check for Doubles
     if ((x - y).abs < precision) true else false
   }
+
 
   /**
     *
     * @param userId
     * @param regionId
     */
+  // Checks total audit distance for a user in a particular region
+  // Creates MissionUser entries for missions in that region whose distance is less than user's total audited distance
+  // in the region
   def updatedUnmarkedCompletedMissionsAsCompleted(userId: UUID, regionId: Int): Unit = {
+    // Checks if user has completed original 1000-ft mission
     val completedMissions = MissionTable.selectCompletedMissionsByAUser(userId, regionId)
-    val hasCompletedOriginal1000FtMission = completedMissions.exists(m => 
-      m.coverage match {
-        case None => ~=(m.distance_ft.getOrElse(Double.PositiveInfinity), 1000.0, 0.10)
+    val hasCompletedOriginal1000FtMission = completedMissions.exists(m => {
+      val coverage = m.coverage
+      val distanceFt = m.distance_ft.getOrElse(Double.PositiveInfinity)
+      coverage match {
+        case None => ~=(distanceFt, missionLength1000, precision)
         case _ => false
       }
-    )
-    val missions = MissionTable.selectIncompleteMissionsByAUser(userId, regionId)
+    })
+
+    val incompleteMissions = MissionTable.selectIncompleteMissionsByAUser(userId, regionId)
+
+    // Calculates total distance audited in the region by this user
     val streets = StreetEdgeTable.selectStreetsAuditedByAUser(userId, regionId)
     val CRSEpsg4326 = CRS.decode("epsg:4326")
     val CRSEpsg26918 = CRS.decode("epsg:26918")
     val transform = CRS.findMathTransform(CRSEpsg4326, CRSEpsg26918)
     val completedDistance_m = streets.map(s => JTS.transform(s.geom, transform).getLength).sum
 
-    // If User has audited more distance than a mission's distance in a particular region, mark the mission as completed
-    val missionsToComplete = missions.filter(m =>
-      m.distance.getOrElse(Double.PositiveInfinity) < completedDistance_m &&
-      !(m.coverage match {
+    // If User has audited more distance than a particular mission's distance in this region, marks the mission as
+    // completed, unless user has completed original 1000-ft mission (in which case the new 500-ft and 1000-ft 
+    // missions are not marked as completed). Also does not mark original 1000-ft mission as completed, ever
+    val missionsToComplete = incompleteMissions.filter(m => {
+      val distance = m.distance.getOrElse(Double.PositiveInfinity)
+      val distanceFt = m.distance_ft.getOrElse(Double.PositiveInfinity)
+      val coverage = m.coverage
+
+      distance < completedDistance_m &&
+      !(coverage match {
         case None => (
-          (hasCompletedOriginal1000FtMission && ~=(m.distance_ft.getOrElse(Double.PositiveInfinity), 500.0, 0.10)) ||
-          ~=(m.distance_ft.getOrElse(Double.PositiveInfinity), 1000.0, 0.10)
+          // Does not mark original 1000-ft mission as completed
+          ~=(distanceFt, missionLength1000, precision) ||
+          // Does not mark new 500-ft mission as completed if user has already completed original 1000-ft mission
+          (hasCompletedOriginal1000FtMission && ~=(distanceFt, missionLength500, precision))
         )
         case _ => (
-          hasCompletedOriginal1000FtMission && ~=(m.distance_ft.getOrElse(Double.PositiveInfinity), 1000.0, 0.10)
-        ) // Don't add the new 500-ft and 1000-ft missions if the user has already completed the old 1000-ft mission
-          // Don't add the old 1000-ft mission
+          // Does not mark new 1000-ft mission as completed if user has already completed original 1000-ft mission
+          hasCompletedOriginal1000FtMission && ~=(distanceFt, missionLength1000, precision)
+        )
       })
-    )
+    })
     missionsToComplete.foreach { m =>
       MissionUserTable.save(m.missionId, userId.toString)
     }

--- a/app/formats/json/TaskFormats.scala
+++ b/app/formats/json/TaskFormats.scala
@@ -26,7 +26,7 @@ object TaskFormats {
   // case class AuditTaskInteraction(auditTaskInteractionId: Int, auditTaskId: Int, action: String, gsvPanoramaId: Option[String], lat: Option[Float], lng: Option[Float], heading: Option[Float],
   // pitch: Option[Float], zoom: Option[Int],note: Option[String], temporaryLabelId: Option[Int], timestamp: java.sql.Timestamp)
 
-  implicit val auidtTaskInteractionWrites: Writes[AuditTaskInteraction] = (
+  implicit val auditTaskInteractionWrites: Writes[AuditTaskInteraction] = (
     (__ \ "audit_task_interaction_id").write[Int] and
       (__ \ "audit_task_id").write[Int] and
       (__ \ "action").write[String] and

--- a/conf/evolutions/default/4.sql
+++ b/conf/evolutions/default/4.sql
@@ -1,0 +1,21 @@
+
+# --- !Ups
+INSERT INTO mission (region_id, label, level, deleted, coverage, distance, distance_ft, distance_mi)
+SELECT region_id, label, level, deleted, coverage, distance/2, distance_ft/2, distance_mi/2
+FROM mission
+WHERE deleted = 'f' and distance_ft = 1000;
+
+INSERT INTO mission (region_id, label, level, deleted, coverage, distance, distance_ft, distance_mi)
+SELECT region_id, label, level, deleted, coverage/2, distance, distance_ft, distance_mi
+FROM (
+  SELECT m1.region_id, m1.label, m1.level, m1.deleted, m2.coverage, m1.distance, m1.distance_ft, m1.distance_mi
+  FROM mission m1 INNER JOIN mission m2 ON m1.region_id = m2.region_id
+  WHERE m1.deleted = 'f' AND m2.deleted = 'f' AND m1.distance_ft = 1000 AND m2.distance_ft = 2000 
+) m3;
+
+# --- !Downs
+DELETE FROM mission
+WHERE deleted = 'f' AND distance_ft = 500;
+
+DELETE FROM mission
+WHERE deleted = 'f' AND distance_ft = 1000 AND coverage IS NOT NULL

--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMission.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMission.js
@@ -175,7 +175,10 @@ ModalMission.prototype._auidtDistanceToString = function  (distance, unit) {
     if (!unit) unit = "kilometers";
 
     if (unit == "miles") {
-        if (distance <= 0.20) {
+        if (distance <= 0.10){
+            return "500ft";
+        }
+        else if (distance <= 0.20) {
             return "1000ft";
         } else if (distance <= 0.25) {
             return "&frac14;mi";

--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMission.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMission.js
@@ -116,7 +116,7 @@ function ModalMission (missionContainer, neighborhoodContainer, uiModalMission, 
                 templateHTML = initialMissionHTML;
             }
 
-            distanceString = this._auidtDistanceToString(mission.getProperty("auditDistanceMi"), "miles");
+            distanceString = this._auditDistanceToString(mission.getProperty("auditDistanceMi"), "miles");
 
             missionTitle = missionTitle.replace("__DISTANCE_PLACEHOLDER__", distanceString);
             missionTitle = missionTitle.replace("__NEIGHBORHOOD_PLACEHOLDER__", neighborhood.getProperty("name"));
@@ -171,11 +171,11 @@ function ModalMission (missionContainer, neighborhoodContainer, uiModalMission, 
     uiModalMission.closeButton.on("click", this._handleCloseButtonClick);
 }
 
-ModalMission.prototype._auidtDistanceToString = function  (distance, unit) {
+ModalMission.prototype._auditDistanceToString = function  (distance, unit) {
     if (!unit) unit = "kilometers";
 
     if (unit == "miles") {
-        if (distance <= 0.10){
+        if (distance <= 0.12){
             return "500ft";
         }
         else if (distance <= 0.20) {

--- a/public/javascripts/SVLabel/src/SVLabel/status/StatusFieldMission.js
+++ b/public/javascripts/SVLabel/src/SVLabel/status/StatusFieldMission.js
@@ -34,7 +34,7 @@ function StatusFieldMission (modalModel, uiStatusField) {
 
         if (missionLabel == "distance-mission") {
             var distance = mission.getProperty("auditDistanceMi");
-            var distanceString = this._auidtDistanceToString(distance, "miles");
+            var distanceString = this._auditDistanceToString(distance, "miles");
             missionMessage = missionMessage.replace("__PLACEHOLDER__", distanceString);
 
         } else if (missionLabel == "area-coverage-mission") {
@@ -46,7 +46,7 @@ function StatusFieldMission (modalModel, uiStatusField) {
     };
 }
 
-StatusFieldMission.prototype._auidtDistanceToString = function (distance, unit) {
+StatusFieldMission.prototype._auditDistanceToString = function (distance, unit) {
     if (!unit) unit = "kilometers";
 
     if (unit == "miles") {

--- a/public/javascripts/SVLabel/src/SVLabel/status/StatusFieldMission.js
+++ b/public/javascripts/SVLabel/src/SVLabel/status/StatusFieldMission.js
@@ -50,7 +50,10 @@ StatusFieldMission.prototype._auditDistanceToString = function (distance, unit) 
     if (!unit) unit = "kilometers";
 
     if (unit == "miles") {
-        if (distance <= 0.20) {
+        if(distance <= 0.12){
+            return "500ft";
+        }
+        else if (distance <= 0.20) {
             return "1000ft";
         } else if (distance <= 0.25) {
             return "&frac14;mi";


### PR DESCRIPTION
Resolves #841 : Adds a 500-ft and 1000-ft mission to each region. Old 1000-ft mission is no longer sent to users, and if user has already finished old 1000-ft mission they do not receive the new ones. If the user has already completed the old 1000-ft mission, the new missions are not marked as completed by the user, and if the user completes the new 500-ft and 1000-ft missions the old 1000-ft mission is not marked as completed.