### PR TITLE
Endpoint to drop researcher at particular location

### DIFF
--- a/app/views/audit.scala.html
+++ b/app/views/audit.scala.html
@@ -679,6 +679,22 @@
                     var newTask = svl.taskFactory.create(geojson, lat1, lng1);
                     svl.taskContainer.setCurrentTask(newTask);
                     init();
+
+
+                    // Handle query strings for panoId or latLng (panoId, lat, lng only Some[] when user is Admin)
+                    @if(panoId){
+                        try{
+                            svl.streetViewService.getPanorama({pano: "@panoId.get"}, function(panoData){
+                                var lat = panoData.location.latLng.lat();
+                                var lng = panoData.location.latLng.lng();
+                                svl.map.setPositionByIdAndLatLng("@panoId.get", lat, lng);
+                            });
+                        } catch (e) {
+                            console.error("Invalid panorama ID");
+                        }                        
+                    } else {@if(lat && lng) {
+                        svl.map.setPosition(@lat.get, @lng.get);
+                    }}                    
                 }
                 else {
                     // no street view available in this range.
@@ -771,7 +787,6 @@
                 mainParam.regionLayer = null;
             }
             svl.main = new Main(mainParam);
-
         }
     </script>
 

--- a/app/views/audit.scala.html
+++ b/app/views/audit.scala.html
@@ -3,7 +3,7 @@
 @import models.region.NamedRegion
 @import models.mission.MissionTable
 @import play.api.libs.json.Json
-@(title: String, task: Option[models.audit.NewTask] = None, region: Option[NamedRegion], user: Option[User] = None)
+@(title: String, task: Option[models.audit.NewTask] = None, region: Option[NamedRegion], user: Option[User] = None, lat: Option[Double] = None, lng: Option[Double] = None, panoId: Option[String] = None)
 
 @main(title, Some("/audit")) {
     @navbar(user, Some("/audit"))

--- a/conf/routes
+++ b/conf/routes
@@ -61,6 +61,7 @@ GET     /audit                                               @controllers.AuditC
 GET     /audit/easyRegion                                    @controllers.AuditController.auditNewEasyRegion
 GET     /audit/region/:id                                    @controllers.AuditController.auditRegion(id: Int)
 GET     /audit/street/:id                                    @controllers.AuditController.auditStreet(id: Int)
+GET 	/audit/street/:id/location 							 @controllers.AuditController.auditLocation(id: Int, lat: Option[Double], lng: Option[Double], panoId: Option[String])
 POST    /audit/comment                                       @controllers.AuditController.postComment
 POST    /audit/nostreetview                                  @controllers.AuditController.postNoStreetView
 

--- a/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
+++ b/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
@@ -1466,6 +1466,24 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
         return this;
     };
 
+    // For setting the position when the exact panorama is known
+    self.setPositionByIdAndLatLng = function(panoId, lat, lng){
+        // Only set the location if walking is enabled
+        if (!status.disableWalking) {
+            var gLatLng = new google.maps.LatLng(lat, lng);
+
+            self.enableWalking();
+
+            self.setPano(panoId);
+            map.setCenter(gLatLng);
+
+            self.disableWalking();
+            window.setTimeout(function() { self.enableWalking(); }, 1000);
+        }
+        return this;
+    }
+
+
     /**
      * Stop blinking google maps
      */


### PR DESCRIPTION
Resolves #948; created the endpoint `/audit/street/<streetEdgeId>/location<queryString>`, where `<queryString>` should be of the form `?panoId=<panoId>` or `?lat=<lat>&lng=<lng>` (or `?lng=<lng>&lat=<lat>`).
If the user requesting the endpoint is anonymous or not an admin then they will receive the functionality of `/audit/street/<streetEdgeId>` and be placed at that street edge. If a `panoId` is in the query string then it will take precedence over the `lat` and `lng` if they are also present. If the panoId or latLng are not valid then an error is thrown and the user is placed at the street edge.
Required for resolving #879 