### PR TITLE
Added ability to use custom url to access any PS page

### DIFF
--- a/app/controllers/ApplicationController.scala
+++ b/app/controllers/ApplicationController.scala
@@ -21,46 +21,37 @@ class ApplicationController @Inject() (implicit val env: Environment[User, Sessi
   val anonymousUser: DBUser = UserTable.find("anonymous").get
 
   /**
-   * Returns an index page.
-    *
-    * @return
-   */
-  def index = UserAwareAction.async { implicit request =>
-    val now = new DateTime(DateTimeZone.UTC)
-    val timestamp: Timestamp = new Timestamp(now.getMillis)
-    val ipAddress: String = request.remoteAddress
-
-    request.identity match {
-      case Some(user) =>
-        WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, "Visit_Index", timestamp))
-        Future.successful(Ok(views.html.index("Project Sidewalk", Some(user))))
-      case None =>
-        WebpageActivityTable.save(WebpageActivity(0, anonymousUser.userId.toString, ipAddress, "Visit_Index", timestamp))
-        Future.successful(Ok(views.html.index("Project Sidewalk")))
-    }
-  }
-
-  /**
     * Logs that someone is coming to the site using a custom URL, then redirects to the specified page.
     *
-    * @param referrer
-    * @param endPoint
     * @return
     */
-  def customUrlRedirect(referrer: String, endPoint: Option[String]) = UserAwareAction.async { implicit request =>
+  def index(referrer: Option[String], redirectTo: String) = UserAwareAction.async { implicit request =>
     val now = new DateTime(DateTimeZone.UTC)
     val timestamp: Timestamp = new Timestamp(now.getMillis)
     val ipAddress: String = request.remoteAddress
-    val redirectTo: String = endPoint.getOrElse("/")
-    val activityLogText: String = "Referrer=" + referrer + "_SendTo=" + redirectTo
 
-    request.identity match {
-      case Some(user) =>
-        WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, activityLogText, timestamp))
-        Future.successful(Redirect(redirectTo))
+    referrer match {
+      // If someone is to the site from a custom URL, log it, and send them to the correct location
+      case Some(ref) =>
+        val activityLogText: String = "Referrer=" + ref + "_SendTo=" + redirectTo
+        request.identity match {
+          case Some(user) =>
+            WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, activityLogText, timestamp))
+            Future.successful(Redirect(redirectTo))
+          case None =>
+            WebpageActivityTable.save(WebpageActivity(0, anonymousUser.userId.toString, ipAddress, activityLogText, timestamp))
+            Future.successful(Redirect(redirectTo))
+        }
+      // Otherwise, just load the landing page
       case None =>
-        WebpageActivityTable.save(WebpageActivity(0, anonymousUser.userId.toString, ipAddress, activityLogText, timestamp))
-        Future.successful(Redirect(redirectTo))
+        request.identity match {
+          case Some(user) =>
+            WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, "Visit_Index", timestamp))
+            Future.successful(Ok(views.html.index("Project Sidewalk", Some(user))))
+          case None =>
+            WebpageActivityTable.save(WebpageActivity(0, anonymousUser.userId.toString, ipAddress, "Visit_Index", timestamp))
+            Future.successful(Ok(views.html.index("Project Sidewalk")))
+        }
     }
   }
 

--- a/app/controllers/ApplicationController.scala
+++ b/app/controllers/ApplicationController.scala
@@ -22,6 +22,7 @@ class ApplicationController @Inject() (implicit val env: Environment[User, Sessi
 
   /**
     * Logs that someone is coming to the site using a custom URL, then redirects to the specified page.
+    * If no referrer is specified, then it just loads the landing page
     *
     * @return
     */
@@ -31,12 +32,13 @@ class ApplicationController @Inject() (implicit val env: Environment[User, Sessi
     val ipAddress: String = request.remoteAddress
 
     referrer match {
-      // If someone is to the site from a custom URL, log it, and send them to the correct location
+      // If someone is coming to the site from a custom URL, log it, and send them to the correct location
       case Some(ref) =>
         val activityLogText: String = "Referrer=" + ref + "_SendTo=" + redirectTo
         request.identity match {
           case Some(user) =>
             WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, activityLogText, timestamp))
+            println(redirectTo)
             Future.successful(Redirect(redirectTo))
           case None =>
             WebpageActivityTable.save(WebpageActivity(0, anonymousUser.userId.toString, ipAddress, activityLogText, timestamp))

--- a/app/controllers/ApplicationController.scala
+++ b/app/controllers/ApplicationController.scala
@@ -38,7 +38,6 @@ class ApplicationController @Inject() (implicit val env: Environment[User, Sessi
         request.identity match {
           case Some(user) =>
             WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, activityLogText, timestamp))
-            println(redirectTo)
             Future.successful(Redirect(redirectTo))
           case None =>
             WebpageActivityTable.save(WebpageActivity(0, anonymousUser.userId.toString, ipAddress, activityLogText, timestamp))

--- a/app/controllers/ApplicationController.scala
+++ b/app/controllers/ApplicationController.scala
@@ -41,6 +41,30 @@ class ApplicationController @Inject() (implicit val env: Environment[User, Sessi
   }
 
   /**
+    * Logs that someone is coming to the site using a custom URL, then redirects to the specified page.
+    *
+    * @param referrer
+    * @param endPoint
+    * @return
+    */
+  def customUrlRedirect(referrer: String, endPoint: Option[String]) = UserAwareAction.async { implicit request =>
+    val now = new DateTime(DateTimeZone.UTC)
+    val timestamp: Timestamp = new Timestamp(now.getMillis)
+    val ipAddress: String = request.remoteAddress
+    val redirectTo: String = endPoint.getOrElse("/")
+    val activityLogText: String = "Referrer=" + referrer + "_SendTo=" + redirectTo
+
+    request.identity match {
+      case Some(user) =>
+        WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, activityLogText, timestamp))
+        Future.successful(Redirect(redirectTo))
+      case None =>
+        WebpageActivityTable.save(WebpageActivity(0, anonymousUser.userId.toString, ipAddress, activityLogText, timestamp))
+        Future.successful(Redirect(redirectTo))
+    }
+  }
+
+  /**
    * Returns an about page
    * @return
    */

--- a/app/controllers/CredentialsAuthController.scala
+++ b/app/controllers/CredentialsAuthController.scala
@@ -92,7 +92,7 @@ class CredentialsAuthController @Inject() (
         }
       }.recover {
         case e: ProviderException =>
-          Redirect(routes.ApplicationController.index)
+          Redirect(routes.ApplicationController.index(None))
       }
     )
   }

--- a/app/controllers/CredentialsAuthController.scala
+++ b/app/controllers/CredentialsAuthController.scala
@@ -92,7 +92,7 @@ class CredentialsAuthController @Inject() (
         }
       }.recover {
         case e: ProviderException =>
-          Redirect(routes.ApplicationController.index(None))
+          Redirect(routes.ApplicationController.index())
       }
     )
   }

--- a/conf/routes
+++ b/conf/routes
@@ -16,6 +16,7 @@ GET     /results                                             @controllers.Applic
 GET     /faq                                                 @controllers.ApplicationController.faq
 GET     /student                                             @controllers.ApplicationController.student
 GET     /mobile                                              @controllers.ApplicationController.mobile
+GET     /referral                                            @controllers.ApplicationController.customUrlRedirect(referrer: String, endPoint: Option[String])
 
 # User authentication
 GET     /signIn                                              @controllers.UserController.signIn(url: String ?= "/")

--- a/conf/routes
+++ b/conf/routes
@@ -3,10 +3,10 @@
 # ~~~~
 
 # Home page
-GET     /                                                    @controllers.ApplicationController.index
+GET     /                                                    @controllers.ApplicationController.index(referrer: Option[String] ?= None, to: String ?= "/")
 POST    /                                                    controllers.TeaserController.teaserPost
 
-GET     /home                                                @controllers.ApplicationController.index
+GET     /home                                                @controllers.ApplicationController.index(referrer: Option[String] ?= None, to: String ?= "/")
 GET     /about                                               @controllers.ApplicationController.about
 GET     /api                                                 @controllers.ApplicationController.developer
 GET     /developer                                           @controllers.ApplicationController.developer
@@ -16,7 +16,6 @@ GET     /results                                             @controllers.Applic
 GET     /faq                                                 @controllers.ApplicationController.faq
 GET     /student                                             @controllers.ApplicationController.student
 GET     /mobile                                              @controllers.ApplicationController.mobile
-GET     /referral                                            @controllers.ApplicationController.customUrlRedirect(referrer: String, endPoint: Option[String])
 
 # User authentication
 GET     /signIn                                              @controllers.UserController.signIn(url: String ?= "/")


### PR DESCRIPTION
Resolves #901 

If you visit
`projectsidewalk.io/referral?referrer=<someString>&endPoint=<someEndPoint>`
you will be redirected to `<someEndPoint>`, and in the webpage activity table, we will log
`Referrer=<someString>_SendTo=/<someEndPoint>`

A concrete example...
`projectsidewalk.io/referral?referrer=campaign1&endPoint=/results`
will send the user to `projectsidewalk.io/results` and log
`Referrer=campaign1_SendTo=/results`

And the `<endPoint>` param is optional, and will just default to the landing page.