### PR TITLE
952 landingpage fix twitter hyperlinks

### DIFF
--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -260,7 +260,7 @@
             <div class="row" style="padding-top: 40px;">
                 <div class="col-sm-6">
                     <div class="quotebox">
-                        Using machine learning, big data, & civic kindness, <a href="https://twitter.com/umd_sidewalk" target="_blank" id="microsoftdesign-author-twitter">@@projsidewalk</a> is making D.C. more accessible one mile at a time
+                        Using machine learning, big data, & civic kindness, <a href="https://twitter.com/projsidewalk" target="_blank" id="microsoftdesign-author-twitter">@@projsidewalk</a> is making D.C. more accessible one mile at a time
                         <br>
                         <span class="quoteauthor">@@microsoftdesign</span>
 
@@ -269,7 +269,7 @@
                 </div>
                 <div class="col-sm-6">
                     <div class="quotebox">
-                        <a href="https://twitter.com/umd_sidewalk" target="_blank" id="kpkindc-author-twitter">@@projsidewalk</a> is mapping accessibility in DC. Looks like C St NE and Oklahoma Ave need work!
+                        <a href="https://twitter.com/projsidewalk" target="_blank" id="kpkindc-author-twitter">@@projsidewalk</a> is mapping accessibility in DC. Looks like C St NE and Oklahoma Ave need work!
                         <br>
                         <span class="quoteauthor">@@kpkindc</span>
                     </div>


### PR DESCRIPTION
Fixes the two landing page tweets which incorrectly linked to our old twitter handle (@umd_sidewalk). They now appropriately point to @projsidewalk