### PR TITLE
Add timestamp field to label table

### DIFF
--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -355,7 +355,7 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
     if (isAdmin(request.identity)) {
       LabelPointTable.find(labelId) match {
         case Some(labelPointObj) =>
-          val labelMetadata = LabelTable.getLabelMetadata(labelId)
+          val labelMetadata: LabelMetadata = LabelTable.getLabelMetadata(labelId)
           val labelMetadataJson: JsObject = LabelTable.labelMetadataToJson(labelMetadata)
           Future.successful(Ok(labelMetadataJson))
         case _ => Future.successful(Ok(Json.obj("error" -> "no such label")))

--- a/app/controllers/TaskController.scala
+++ b/app/controllers/TaskController.scala
@@ -179,7 +179,7 @@ class TaskController @Inject() (implicit val env: Environment[User, SessionAuthe
               case None =>
                 LabelTable.save(Label(0, auditTaskId, label.gsvPanoramaId, labelTypeId, label.photographerHeading,
                                       label.photographerPitch, label.panoramaLat, label.panoramaLng,
-                                      label.deleted.value, label.temporaryLabelId))
+                                      label.deleted.value, label.temporaryLabelId, None))
             }
 
             // Insert label points

--- a/app/controllers/TaskController.scala
+++ b/app/controllers/TaskController.scala
@@ -177,9 +177,16 @@ class TaskController @Inject() (implicit val env: Environment[User, SessionAuthe
                 LabelTable.updateDeleted(labId, label.deleted.value)
                 labId
               case None =>
+                // get the timestamp for a new label being added to db, log an error if there is a problem w/ timestamp
+                val timeCreated: Option[Timestamp] = label.timeCreated match {
+                  case Some(time) => Some(new Timestamp(time))
+                  case None =>
+                    Logger.error("No timestamp given for a new label")
+                    None
+                }
                 LabelTable.save(Label(0, auditTaskId, label.gsvPanoramaId, labelTypeId, label.photographerHeading,
                                       label.photographerPitch, label.panoramaLat, label.panoramaLng,
-                                      label.deleted.value, label.temporaryLabelId, None))
+                                      label.deleted.value, label.temporaryLabelId, timeCreated))
             }
 
             // Insert label points
@@ -224,7 +231,7 @@ class TaskController @Inject() (implicit val env: Environment[User, SessionAuthe
           }
 
           // Insert interaction
-          for (interaction <- data.interactions) {
+          for (interaction: InteractionSubmission <- data.interactions) {
             AuditTaskInteractionTable.save(AuditTaskInteraction(0, auditTaskId, interaction.action,
               interaction.gsvPanoramaId, interaction.lat, interaction.lng, interaction.heading, interaction.pitch,
               interaction.zoom, interaction.note, interaction.temporaryLabelId, new Timestamp(interaction.timestamp)))

--- a/app/formats/json/LabelFormat.scala
+++ b/app/formats/json/LabelFormat.scala
@@ -1,5 +1,7 @@
 package formats.json
 
+import java.sql.Timestamp
+
 import models.label._
 import play.api.libs.json._
 import play.api.libs.functional.syntax._
@@ -28,7 +30,8 @@ object LabelFormats {
       (__ \ "panorama_lat").write[Float] and
       (__ \ "panorama_lng").write[Float] and
       (__ \ "deleted").write[Boolean] and
-      (__ \ "temporary_label_id").writeNullable[Int]
+      (__ \ "temporary_label_id").writeNullable[Int] and
+      (__ \ "time_created").writeNullable[Timestamp]
     )(unlift(Label.unapply _))
 
 }

--- a/app/formats/json/TaskSubmissionFormats.scala
+++ b/app/formats/json/TaskSubmissionFormats.scala
@@ -1,6 +1,9 @@
 package formats.json
 
+import java.sql.Timestamp
+
 import play.api.libs.json.{JsBoolean, JsPath, Reads}
+
 import scala.collection.immutable.Seq
 import play.api.libs.functional.syntax._
 
@@ -8,7 +11,7 @@ object TaskSubmissionFormats {
   case class EnvironmentSubmission(browser: Option[String], browserVersion: Option[String], browserWidth: Option[Int], browserHeight: Option[Int], availWidth: Option[Int], availHeight: Option[Int], screenWidth: Option[Int], screenHeight: Option[Int], operatingSystem: Option[String])
   case class InteractionSubmission(action: String, gsvPanoramaId: Option[String], lat: Option[Float], lng: Option[Float], heading: Option[Float], pitch: Option[Float], zoom: Option[Int], note: Option[String], temporaryLabelId: Option[Int], timestamp: Long)
   case class LabelPointSubmission(svImageX: Int, svImageY: Int, canvasX: Int, canvasY: Int, heading: Float, pitch: Float, zoom: Int, canvasHeight: Int, canvasWidth: Int, alphaX: Float, alphaY: Float, lat: Option[Float], lng: Option[Float])
-  case class LabelSubmission(gsvPanoramaId: String, auditTaskId: Int, labelType: String, photographerHeading: Float, photographerPitch: Float, panoramaLat: Float, panoramaLng: Float, deleted: JsBoolean, severity: Option[Int], temporaryProblem: Option[JsBoolean], description: Option[String], points: Seq[LabelPointSubmission], temporaryLabelId: Option[Int])
+  case class LabelSubmission(gsvPanoramaId: String, auditTaskId: Int, labelType: String, photographerHeading: Float, photographerPitch: Float, panoramaLat: Float, panoramaLng: Float, deleted: JsBoolean, severity: Option[Int], temporaryProblem: Option[JsBoolean], description: Option[String], points: Seq[LabelPointSubmission], temporaryLabelId: Option[Int], timeCreated: Option[Long])
   case class TaskSubmission(streetEdgeId: Int, taskStart: String, auditTaskId: Option[Int], completed: Option[Boolean])
   case class AMTAssignmentSubmission(hitId: String, assignmentId: String, assignmentStart: String)
   case class IncompleteTaskSubmission(issueDescription: String, lat: Float, lng: Float)
@@ -76,7 +79,8 @@ object TaskSubmissionFormats {
       (JsPath \ "temporary_problem").readNullable[JsBoolean] and
       (JsPath \ "description").readNullable[String] and
       (JsPath \ "label_points").read[Seq[LabelPointSubmission]] and
-      (JsPath \ "temporary_label_id").readNullable[Int]
+      (JsPath \ "temporary_label_id").readNullable[Int] and
+      (JsPath \ "time_created").readNullable[Long]
     )(LabelSubmission.apply _)
 
   implicit val auditTaskReads: Reads[TaskSubmission] = (

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -101,7 +101,7 @@ object LabelTable {
                            canvasX: Int, canvasY: Int, canvasWidth: Int, canvasHeight: Int,
                            auditTaskId: Int,
                            userId: String, username: String,
-                           timestamp: java.sql.Timestamp,
+                           timestamp: Option[java.sql.Timestamp],
                            labelTypeKey:String, labelTypeValue: String, severity: Option[Int],
                            temporary: Boolean, description: Option[String])
 
@@ -253,7 +253,7 @@ object LabelTable {
   // TODO translate the following three queries to Slick
   def retrieveLabelMetadata(takeN: Int): List[LabelMetadata] = db.withSession { implicit session =>
     val selectQuery = Q.query[Int, (Int, String, Float, Float, Int, Int, Int, Int, Int,
-      Int, String, String, java.sql.Timestamp, String, String, Option[Int], Boolean,
+      Int, String, String, Option[java.sql.Timestamp], String, String, Option[Int], Boolean,
       Option[String])](
       """SELECT lb1.label_id, lb1.gsv_panorama_id, lp.heading, lp.pitch, lp.zoom, lp.canvas_x, lp.canvas_y,
         |       lp.canvas_width, lp.canvas_height, lb1.audit_task_id, u.user_id, u.username, lb1.time_created,
@@ -283,7 +283,7 @@ object LabelTable {
 
   def retrieveLabelMetadata(takeN: Int, userId: String): List[LabelMetadata] = db.withSession { implicit session =>
     val selectQuery = Q.query[(String, Int),(Int, String, Float, Float, Int, Int, Int, Int, Int,
-      Int, String, String, java.sql.Timestamp, String, String, Option[Int], Boolean,
+      Int, String, String, Option[java.sql.Timestamp], String, String, Option[Int], Boolean,
       Option[String])](
       """SELECT lb1.label_id, lb1.gsv_panorama_id, lp.heading, lp.pitch, lp.zoom, lp.canvas_x, lp.canvas_y,
         |       lp.canvas_width, lp.canvas_height, lb1.audit_task_id, u.user_id, u.username, lb1.time_created,
@@ -314,7 +314,7 @@ object LabelTable {
 
   def retrieveSingleLabelMetadata(labelId: Int): LabelMetadata = db.withSession { implicit session =>
     val selectQuery = Q.query[Int,(Int, String, Float, Float, Int, Int, Int, Int, Int,
-      Int, String, String, java.sql.Timestamp, String, String, Option[Int], Boolean,
+      Int, String, String, Option[java.sql.Timestamp], String, String, Option[Int], Boolean,
       Option[String])](
       """SELECT lb1.label_id, lb1.gsv_panorama_id, lp.heading, lp.pitch, lp.zoom, lp.canvas_x, lp.canvas_y,
         |       lp.canvas_width, lp.canvas_height, lb1.audit_task_id, u.user_id, u.username, lb1.time_created,

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -1,9 +1,10 @@
 package models.label
 
+import java.sql.Timestamp
 import java.util.UUID
 
 import com.vividsolutions.jts.geom.LineString
-import models.audit.{AuditTask, AuditTaskInteraction, AuditTaskTable, AuditTaskEnvironmentTable}
+import models.audit.{AuditTask, AuditTaskEnvironmentTable, AuditTaskInteraction, AuditTaskTable}
 import models.region.RegionTable
 import models.utils.MyPostgresDriver.simple._
 import play.api.Play.current
@@ -21,7 +22,8 @@ case class Label(labelId: Int,
                  panoramaLat: Float,
                  panoramaLng: Float,
                  deleted: Boolean,
-                 temporaryLabelId: Option[Int])
+                 temporaryLabelId: Option[Int],
+                 timeCreated: Option[Timestamp])
 
 case class LabelLocation(labelId: Int,
                          auditTaskId: Int,
@@ -54,9 +56,10 @@ class LabelTable(tag: Tag) extends Table[Label](tag, Some("sidewalk"), "label") 
   def panoramaLng = column[Float]("panorama_lng", O.NotNull)
   def deleted = column[Boolean]("deleted", O.NotNull)
   def temporaryLabelId = column[Option[Int]]("temporary_label_id", O.Nullable)
+  def timeCreated = column[Option[Timestamp]]("time_created", O.Nullable)
 
   def * = (labelId, auditTaskId, gsvPanoramaId, labelTypeId, photographerHeading, photographerPitch,
-    panoramaLat, panoramaLng, deleted, temporaryLabelId) <> ((Label.apply _).tupled, Label.unapply)
+    panoramaLat, panoramaLng, deleted, temporaryLabelId, timeCreated) <> ((Label.apply _).tupled, Label.unapply)
 
   def auditTask: ForeignKeyQuery[AuditTaskTable, AuditTask] =
     foreignKey("label_audit_task_id_fkey", auditTaskId, TableQuery[AuditTaskTable])(_.auditTaskId)

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -255,9 +255,9 @@ object LabelTable {
       Int, String, String, java.sql.Timestamp, String, String, Option[Int], Boolean,
       Option[String])](
       """SELECT lb1.label_id, lb1.gsv_panorama_id, lp.heading, lp.pitch, lp.zoom, lp.canvas_x, lp.canvas_y,
-        |       lp.canvas_width, lp.canvas_height, lb1.audit_task_id, u.user_id, u.username, ati.timestamp,
+        |       lp.canvas_width, lp.canvas_height, lb1.audit_task_id, u.user_id, u.username, lb1.time_created,
         |       lb_big.label_type, lb_big.label_type_desc, lb_big.severity, lb_big.temp_problem, lb_big.description
-        |	FROM sidewalk.label as lb1, sidewalk.audit_task as at, sidewalk.audit_task_interaction as ati,
+        |	FROM sidewalk.label as lb1, sidewalk.audit_task as at,
         |       sidewalk.user as u, sidewalk.label_point as lp,
         |				(SELECT lb.label_id, lb.gsv_panorama_id, lbt.label_type, lbt.description as label_type_desc, sev.severity,
         |               COALESCE(prob_temp.temporary_problem,'FALSE') as temp_problem,
@@ -272,10 +272,9 @@ object LabelTable {
         |				LEFT JOIN sidewalk.problem_temporariness as prob_temp
         |					ON lb.label_id = prob_temp.label_id
         |				) AS lb_big
-        |WHERE lb1.deleted = FALSE and lb1.audit_task_id = at.audit_task_id and (lb1.audit_task_id = ati.audit_task_id and
-        |      lb1.temporary_label_id = ati.temporary_label_id and ati.action = 'LabelingCanvas_FinishLabeling') and
+        |WHERE lb1.deleted = FALSE and lb1.audit_task_id = at.audit_task_id and
         |      lb1.label_id = lb_big.label_id and at.user_id = u.user_id and lb1.label_id = lp.label_id
-        |	ORDER BY ati.timestamp DESC""".stripMargin
+        |	ORDER BY lb1.label_id DESC""".stripMargin
     )
     selectQuery.list.map(label => LabelMetadata.tupled(label))
   }

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -334,8 +334,7 @@ object LabelTable {
         |				LEFT JOIN sidewalk.problem_temporariness as prob_temp
         |					ON lb.label_id = prob_temp.label_id
         |				) AS lb_big
-        |WHERE lb1.label_id = ? and
-        |      lb1.deleted = FALSE and lb1.audit_task_id = at.audit_task_id and
+        |WHERE lb1.label_id = ? and lb1.audit_task_id = at.audit_task_id and
         |      lb1.label_id = lb_big.label_id and at.user_id = u.user_id and lb1.label_id = lp.label_id
         |	ORDER BY lb1.label_id DESC""".stripMargin
     )

--- a/conf/evolutions/default/5.sql
+++ b/conf/evolutions/default/5.sql
@@ -1,0 +1,8 @@
+
+# --- !Ups
+ALTER TABLE label
+    ADD time_created TIMESTAMP;
+
+# --- !Downs
+ALTER TABLE label
+    DROP time_created;

--- a/public/javascripts/Admin/src/Admin.GSVLabelView.js
+++ b/public/javascripts/Admin/src/Admin.GSVLabelView.js
@@ -37,7 +37,7 @@ function AdminGSVLabel() {
                             '</tr>'+
                             '<tr>'+
                                 '<th>Description</th>'+
-                                '<td colspan="3" id="description"></td>'+
+                                '<td colspan="3" id="label-description"></td>'+
                             '</tr>'+
                             '<tr>'+
                             '<th>Time Submitted</th>'+
@@ -55,7 +55,7 @@ function AdminGSVLabel() {
         self.modalLabelTypeValue = self.modal.find("#label-type-value");
         self.modalSeverity = self.modal.find("#severity");
         self.modalTemporary = self.modal.find("#temporary");
-        self.modalDescription = self.modal.find("#description");
+        self.modalDescription = self.modal.find("#label-description");
         self.modalTask = self.modal.find("#task");
     }
 

--- a/public/javascripts/SVLabel/src/SVLabel/data/Form.js
+++ b/public/javascripts/SVLabel/src/SVLabel/data/Form.js
@@ -62,10 +62,12 @@ function Form (labelContainer, missionModel, navigationModel, neighborhoodModel,
             var points = label.getPath().getPoints();
             var labelLatLng = label.toLatLng();
             var tempLabelId = label.getProperty('temporary_label_id');
+            var auditTaskId = label.getProperty('audit_task_id');
 
             // if this label is a new label, get the timestamp of its creation from the corresponding interaction
             var associatedInteraction = data.interactions.find(interaction =>
-                interaction.action === 'LabelingCanvas_FinishLabeling' && interaction.temporary_label_id === tempLabelId);
+                interaction.action === 'LabelingCanvas_FinishLabeling' && interaction.temporary_label_id === tempLabelId
+                && interaction.audit_task_id === auditTaskId);
             var timeCreated = associatedInteraction ? associatedInteraction.timestamp : null;
 
 
@@ -77,8 +79,8 @@ function Form (labelContainer, missionModel, navigationModel, neighborhoodModel,
                 photographer_pitch : prop.photographerPitch,
                 panorama_lat: prop.panoramaLat,
                 panorama_lng: prop.panoramaLng,
-                temporary_label_id: label.getProperty('temporary_label_id'),
-                audit_task_id: label.getProperty('audit_task_id'),
+                temporary_label_id: tempLabelId,
+                audit_task_id: auditTaskId,
                 gsv_panorama_id : prop.panoId,
                 label_points : [],
                 severity: label.getProperty('severity'),

--- a/public/javascripts/SVLabel/src/SVLabel/data/Form.js
+++ b/public/javascripts/SVLabel/src/SVLabel/data/Form.js
@@ -61,6 +61,13 @@ function Form (labelContainer, missionModel, navigationModel, neighborhoodModel,
             var prop = label.getProperties();
             var points = label.getPath().getPoints();
             var labelLatLng = label.toLatLng();
+            var tempLabelId = label.getProperty('temporary_label_id');
+
+            // if this label is a new label, get the timestamp of its creation from the corresponding interaction
+            var associatedInteraction = data.interactions.find(interaction =>
+                interaction.action === 'LabelingCanvas_FinishLabeling' && interaction.temporary_label_id === tempLabelId);
+            var timeCreated = associatedInteraction ? associatedInteraction.timestamp : null;
+
 
             var temp = {
                 deleted : label.isDeleted(),
@@ -76,7 +83,8 @@ function Form (labelContainer, missionModel, navigationModel, neighborhoodModel,
                 label_points : [],
                 severity: label.getProperty('severity'),
                 temporary_problem: label.getProperty('temporaryProblem'),
-                description: label.getProperty('description')
+                description: label.getProperty('description'),
+                time_created: timeCreated
             };
 
             for (var j = 0, pathLen = points.length; j < pathLen; j += 1) {


### PR DESCRIPTION
Resolves #967 
Resolves #935

This adds a time_created field to the label table. All new labels that are added to the database get a timestamp, but the ones currently in the database have that field as null for now. We will backfill the old data later, as described in #974 