### PR TITLE
Added code to present all assigned routes successively in a single HIT session to MTurkers

### DIFF
--- a/app/controllers/AuditController.scala
+++ b/app/controllers/AuditController.scala
@@ -225,11 +225,14 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
         Future.successful(BadRequest(Json.obj("status" -> "Error", "message" -> JsError.toFlatJson(errors))))
       },
       submission => {
+
+        val conditionId = TurkerTable.getConditionIdByTurkerId(submission.turkerId).get
+        val now = new DateTime(DateTimeZone.UTC)
         val timestamp: Timestamp = new Timestamp(now.getMillis)
-        val asg: AMTAssignment = AMTAssignment(0, submission.hitId, submission.assignmentId, timestamp, None, submission.turkerId, submission.conditionId, submission.routeId, false)
+        val asg: AMTAssignment = AMTAssignment(0, submission.hitId, submission.assignmentId, timestamp, None, submission.turkerId, conditionId, Some(submission.routeId), false)
         val asgId: Option[Int] = Option(AMTAssignmentTable.save(asg))
 
-        Future.successful(Ok(Json.obj(asgId)))
+        Future.successful(Ok("New Mission Created"))
       }
     )
   }

--- a/app/controllers/AuditController.scala
+++ b/app/controllers/AuditController.scala
@@ -232,7 +232,7 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
         val asg: AMTAssignment = AMTAssignment(0, submission.hitId, submission.assignmentId, timestamp, None, submission.turkerId, conditionId, Some(submission.routeId), false)
         val asgId: Option[Int] = Option(AMTAssignmentTable.save(asg))
 
-        Future.successful(Ok("New Mission Created"))
+        Future.successful(Ok(Json.obj("asg_id" -> asgId.get)))
       }
     )
   }

--- a/app/controllers/AuditController.scala
+++ b/app/controllers/AuditController.scala
@@ -221,13 +221,14 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
       },
       submission => {
 
-        val conditionId = TurkerTable.getConditionIdByTurkerId(submission.turkerId).get
-        val now = new DateTime(DateTimeZone.UTC)
+        val conditionId: Int = TurkerTable.getConditionIdByTurkerId(submission.turkerId).get
+        val now: DateTime = new DateTime(DateTimeZone.UTC)
         val timestamp: Timestamp = new Timestamp(now.getMillis)
-        val asg: AMTAssignment = AMTAssignment(0, submission.hitId, submission.assignmentId, timestamp, None, submission.turkerId, conditionId, Some(submission.routeId), false)
-        val asgId: Option[Int] = Option(AMTAssignmentTable.save(asg))
+        val asg: AMTAssignment = AMTAssignment(0, submission.hitId, submission.assignmentId, timestamp, None,
+                                               submission.turkerId, conditionId, Some(submission.routeId), false)
+        val asgId: Int = AMTAssignmentTable.save(asg)
 
-        Future.successful(Ok(Json.obj("asg_id" -> asgId.get)))
+        Future.successful(Ok(Json.obj("asg_id" -> asgId)))
       }
     )
   }

--- a/app/controllers/AuditController.scala
+++ b/app/controllers/AuditController.scala
@@ -136,23 +136,26 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
             val routeId: Option[Int] = AMTVolunteerRouteTable.assignRouteByConditionIdAndWorkerId(conditionId,workerId)
             val route: Option[Route] = RouteTable.getRoute(routeId)
             //Set up a case statement here for when route returned is null (Indicating that the turker has finished all routes assigned to him)
-            if(route == null){
-              Future.successful(Ok(views.html.index("Project Sidewalk")))
+
+            if(routeId == None){
+                Future.successful(Ok(views.html.index("Project Sidewalk")))
             }
-            val routeStreetId: Option[Int] = RouteStreetTable.getFirstRouteStreetId(routeId.getOrElse(0))
+            else {
+              val routeStreetId: Option[Int] = RouteStreetTable.getFirstRouteStreetId(routeId.getOrElse(0))
 
-            // Save HIT assignment details
-            val asg: AMTAssignment = AMTAssignment(0, hitId, assignmentId, timestamp, None, workerId, conditionId, routeId, false)
-            val asgId: Option[Int] = Option(AMTAssignmentTable.save(asg))
+              // Save HIT assignment details
+              val asg: AMTAssignment = AMTAssignment(0, hitId, assignmentId, timestamp, None, workerId, conditionId, routeId, false)
+              val asgId: Option[Int] = Option(AMTAssignmentTable.save(asg))
 
-            // Load the first task from the selected route
-            val regionId = route.get.regionId
-            val region: Option[NamedRegion] = RegionTable.selectANamedRegion(regionId)
-            val regionName = region.get.name
-            val task: NewTask = AuditTaskTable.selectANewTask(routeStreetId.getOrElse(0), asgId)
+              // Load the first task from the selected route
+              val regionId = route.get.regionId
+              val region: Option[NamedRegion] = RegionTable.selectANamedRegion(regionId)
+              val regionName = region.get.name
+              val task: NewTask = AuditTaskTable.selectANewTask(routeStreetId.getOrElse(0), asgId)
 
 
-            Future.successful(Ok(views.html.audit("Project Sidewalk - Audit", Some(task), region, route, None)))
+              Future.successful(Ok(views.html.audit("Project Sidewalk - Audit", Some(task), region, route, None)))
+            }
           case "Preview" =>
             WebpageActivityTable.save(WebpageActivity(0, anonymousUser.userId.toString, ipAddress, "Visit_Index", timestamp))
             Future.successful(Ok(views.html.index("Project Sidewalk")))

--- a/app/controllers/MissionController.scala
+++ b/app/controllers/MissionController.scala
@@ -93,7 +93,7 @@ class MissionController @Inject() (implicit val env: Environment[User, SessionAu
   def getMTurkMissions = UserAwareAction.async { implicit request =>
     request.identity match {
       case _ =>
-        val mission = MissionTable.selectMTurkMission
+        val mission = MissionTable.selectMTurkMissions
         val missionJsonObjects: List[JsObject] = mission.map( m =>
           Json.obj("is_completed" -> false,
             "mission_id" -> m.missionId,
@@ -119,14 +119,14 @@ class MissionController @Inject() (implicit val env: Environment[User, SessionAu
         val totalMissionCount = routeId.length
         // If 2 conditions are associated with a different number of missions
         // in the same region then we need to slice the mission list to get the appropriate number of missions
-        val mission = MissionTable.selectMTurkMissionByRegion(regionId)
-        val mturk_mission = mission.filter(x => x.label == "mturk-mission").slice(0,totalMissionCount)
-        val onboarding = mission.filter(x => x.label == "onboarding")
-        val relevant_mission = mturk_mission ++ onboarding
-        val completedMissionCount = AMTAssignmentTable.getCountOfCompletedByTurkerId(turkerId)
+        val missions: List[Mission] = MissionTable.selectMTurkMissionsByRegion(regionId)
+        val mturkMissions: List[Mission] = missions.filter(x => x.label == "mturk-mission").slice(0,totalMissionCount)
+        val onboarding: List[Mission] = missions.filter(x => x.label == "onboarding")
+        val relevantMission = mturkMissions ++ onboarding
+        val completedMissionCount: Int = AMTAssignmentTable.getCountOfCompletedByTurkerId(turkerId)
 
 
-        val missionJsonObjects: List[JsObject] = relevant_mission.zipWithIndex.map( m =>
+        val missionJsonObjects: List[JsObject] = relevantMission.zipWithIndex.map( m =>
           Json.obj("is_completed" -> (m._2 < completedMissionCount),
             "mission_id" -> m._1.missionId,
             "region_id" -> m._1.regionId,

--- a/app/controllers/RouteController.scala
+++ b/app/controllers/RouteController.scala
@@ -20,7 +20,7 @@ import models.gsv.{GSVData, GSVDataTable, GSVLink, GSVLinkTable}
 import models.label._
 import models.mission.{Mission, MissionStatus, MissionTable}
 import models.region._
-import models.route.{RouteStreet, RouteStreetTable}
+import models.route.{RouteTable, RouteStreet, RouteStreetTable}
 import models.street.StreetEdgeAssignmentCountTable
 import models.user.User
 import org.joda.time.{DateTime, DateTimeZone}
@@ -80,6 +80,18 @@ class RouteController @Inject() (implicit val env: Environment[User, SessionAuth
     }
 
     Future.successful(Ok(rStreetsJsonObj))
+  }
+
+  def getRouteById(routeId: Int) = UserAwareAction.async { implicit request =>
+    val route = RouteTable.getRoute(routeId).get
+    val routeJsonObj = Json.obj(
+      "route_id": route.routeId,
+      "street_count": route.streetCount,
+      "route_length_mi": route.route_length_mi,
+      "region_id": route.regionId
+    )
+    Future.successful(Ok(JsArray(routeJsonObj)))
+
   }
 
   def updateRouteAssignmentCompleteness(amtAssignmentId: Option[Int], routeAssignment: AMTRouteAssignmentSubmission): Unit = {

--- a/app/controllers/RouteController.scala
+++ b/app/controllers/RouteController.scala
@@ -83,14 +83,14 @@ class RouteController @Inject() (implicit val env: Environment[User, SessionAuth
   }
 
   def getRouteById(routeId: Int) = UserAwareAction.async { implicit request =>
-    val route = RouteTable.getRoute(routeId).get
+    val route = RouteTable.getRoute(Some(routeId)).get
     val routeJsonObj = Json.obj(
-      "route_id": route.routeId,
-      "street_count": route.streetCount,
-      "route_length_mi": route.route_length_mi,
-      "region_id": route.regionId
+      "route_id" -> routeId,
+      "street_count" -> route.streetCount,
+      "route_length_mi" -> route.route_length_mi,
+      "region_id" -> route.regionId
     )
-    Future.successful(Ok(JsArray(routeJsonObj)))
+    Future.successful(Ok(routeJsonObj))
 
   }
 

--- a/app/controllers/RouteController.scala
+++ b/app/controllers/RouteController.scala
@@ -20,7 +20,7 @@ import models.gsv.{GSVData, GSVDataTable, GSVLink, GSVLinkTable}
 import models.label._
 import models.mission.{Mission, MissionStatus, MissionTable}
 import models.region._
-import models.route.{RouteTable, RouteStreet, RouteStreetTable}
+import models.route.{Route, RouteStreet, RouteStreetTable, RouteTable}
 import models.street.StreetEdgeAssignmentCountTable
 import models.user.User
 import org.joda.time.{DateTime, DateTimeZone}
@@ -83,7 +83,7 @@ class RouteController @Inject() (implicit val env: Environment[User, SessionAuth
   }
 
   def getRouteById(routeId: Int) = UserAwareAction.async { implicit request =>
-    val route = RouteTable.getRoute(Some(routeId)).get
+    val route: Route = RouteTable.getRoute(Some(routeId)).get
     val routeJsonObj = Json.obj(
       "route_id" -> routeId,
       "street_count" -> route.streetCount,

--- a/app/formats/json/TaskSubmissionFormats.scala
+++ b/app/formats/json/TaskSubmissionFormats.scala
@@ -16,6 +16,7 @@ object TaskSubmissionFormats {
   case class GSVLinkSubmission(targetGsvPanoramaId: String, yawDeg: Double, description: String)
   case class GSVPanoramaSubmission(gsvPanoramaId: String, imageDate: String, links: Seq[GSVLinkSubmission], copyright: String)
   case class AuditTaskSubmission(assignment: Option[AMTAssignmentSubmission], auditTask: TaskSubmission, labels: Seq[LabelSubmission], interactions: Seq[InteractionSubmission], environment: EnvironmentSubmission, incomplete: Option[IncompleteTaskSubmission], gsvPanoramas: Seq[GSVPanoramaSubmission])
+  case class AMTAssignmentCreateRecordSubmission(assignmentId: Int, hitId: String, turkerId: String, conditionId: Int, routeId: Int)
 
   implicit val incompleteTaskSubmissionReads: Reads[IncompleteTaskSubmission] = (
     (JsPath \ "issue_description").read[String] and
@@ -91,6 +92,14 @@ object TaskSubmissionFormats {
       (JsPath \ "hit_id").readNullable[String] and
       (JsPath \ "assignment_end").readNullable[String]
     )(AMTAssignmentSubmission.apply _)
+
+  implicit val aMTAssignmentCreateRecordReads: Reads[AMTAssignmentCreateRecordSubmission] =(
+    (JsPath \ "assignment_id").read[Int] and
+      (JsPath \ "hit_id").read[String] and
+      (JsPath \ "turker_id").read[String] and
+      (JsPath \ "condition_id").read[Int] and
+      (JsPath \ "route_id").read[Int]
+  )(AMTAssignmentCreateRecordSubmission.apply _)
 
   implicit val amtRouteAssignmentReads: Reads[AMTRouteAssignmentSubmission] = (
     (JsPath \ "amt_assignment_id").read[Int] and

--- a/app/formats/json/TaskSubmissionFormats.scala
+++ b/app/formats/json/TaskSubmissionFormats.scala
@@ -16,7 +16,7 @@ object TaskSubmissionFormats {
   case class GSVLinkSubmission(targetGsvPanoramaId: String, yawDeg: Double, description: String)
   case class GSVPanoramaSubmission(gsvPanoramaId: String, imageDate: String, links: Seq[GSVLinkSubmission], copyright: String)
   case class AuditTaskSubmission(assignment: Option[AMTAssignmentSubmission], auditTask: TaskSubmission, labels: Seq[LabelSubmission], interactions: Seq[InteractionSubmission], environment: EnvironmentSubmission, incomplete: Option[IncompleteTaskSubmission], gsvPanoramas: Seq[GSVPanoramaSubmission])
-  case class AMTAssignmentCreateRecordSubmission(assignmentId: Int, hitId: String, turkerId: String, conditionId: Int, routeId: Int)
+  case class AMTAssignmentCreateRecordSubmission(assignmentId: String, hitId: String, turkerId: String, routeId: Int)
 
   implicit val incompleteTaskSubmissionReads: Reads[IncompleteTaskSubmission] = (
     (JsPath \ "issue_description").read[String] and
@@ -94,10 +94,9 @@ object TaskSubmissionFormats {
     )(AMTAssignmentSubmission.apply _)
 
   implicit val aMTAssignmentCreateRecordReads: Reads[AMTAssignmentCreateRecordSubmission] =(
-    (JsPath \ "assignment_id").read[Int] and
+    (JsPath \ "assignment_id").read[String] and
       (JsPath \ "hit_id").read[String] and
       (JsPath \ "turker_id").read[String] and
-      (JsPath \ "condition_id").read[Int] and
       (JsPath \ "route_id").read[Int]
   )(AMTAssignmentCreateRecordSubmission.apply _)
 

--- a/app/models/mission/MissionTable.scala
+++ b/app/models/mission/MissionTable.scala
@@ -211,11 +211,11 @@ object MissionTable {
     * Returns mturk mission
     */
 
-  def selectMTurkMission: List[Mission] = db.withSession { implicit session =>
+  def selectMTurkMissions: List[Mission] = db.withSession { implicit session =>
     missionsWithoutDeleted.filter(_.label inSet List("mturk-mission","onboarding")).list
   }
 
-  def selectMTurkMissionByRegion(regionId: Option[Int]): List[Mission] = db.withSession { implicit session =>
+  def selectMTurkMissionsByRegion(regionId: Option[Int]): List[Mission] = db.withSession { implicit session =>
     missionsWithoutDeleted.filter(l => (l.label === "mturk-mission" && l.regionId === regionId) || l.label === "onboarding").list
   }
 

--- a/app/views/audit.scala.html
+++ b/app/views/audit.scala.html
@@ -432,10 +432,13 @@
                                 </tr>
                             </table>
 
+
+                            <button class="btn blue-btn" id="modal-mission-complete-close-button">Continue</button>
+
                             <form action="" method="post" id="submitHITForm">
                                 <input type="hidden" name="assignmentId" id="assignmentId" value="" />
                                 <input type="hidden" name="randomString" id="randomString" value="randomResultString" />
-                                <button class="btn blue-btn" id="modal-mission-complete-close-button" type="submit">Submit HIT</button>
+                                <button class="btn blue-btn" id="modal-mission-complete-hit-submission-button" type="submit" class="hidden">Submit HIT</button>
                             </form>
 
                         </div>

--- a/app/views/audit.scala.html
+++ b/app/views/audit.scala.html
@@ -438,7 +438,7 @@
                             <form action="" method="post" id="submitHITForm">
                                 <input type="hidden" name="assignmentId" id="assignmentId" value="" />
                                 <input type="hidden" name="randomString" id="randomString" value="randomResultString" />
-                                <button class="btn blue-btn" id="modal-mission-complete-hit-submission-button" type="submit" class="hidden">Submit HIT</button>
+                                <button class="btn blue-btn" id="modal-mission-complete-hit-submission-button" type="submit">Submit HIT</button>
                             </form>
 
                         </div>

--- a/conf/routes
+++ b/conf/routes
@@ -23,6 +23,7 @@ GET     /audit                                  @controllers.AuditController.aud
 GET     /audit/region/:id                       @controllers.AuditController.auditRegion(id: Int)
 GET     /audit/street/:id                       @controllers.AuditController.auditStreet(id: Int)
 POST    /audit/comment                          @controllers.AuditController.postComment
+POST    /audit/amtAssignment                    @controllers.AuditController.postAMTAssignment
 POST    /audit/nostreetview                     @controllers.AuditController.postNoStreetView
 
 # User authentication
@@ -65,6 +66,7 @@ POST    /task                                   @controllers.TaskController.post
 
 # Route API
 POST    /route                                  @controllers.RouteController.post
+GET     /route/:id                              @controllers.RouteController.getRouteById(id: Int)
 GET     /routes/:id                             @controllers.RouteController.getStreetsOnARoute(id: Int)
 
 # Missions

--- a/public/javascripts/SVLabel/src/SVLabel/Main.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Main.js
@@ -655,6 +655,8 @@ function Main (params) {
         svl.ui.modalMissionComplete.map = $("#modal-mission-complete-map");
         svl.ui.modalMissionComplete.completeBar = $('#modal-mission-complete-complete-bar');
         svl.ui.modalMissionComplete.closeButton = $("#modal-mission-complete-close-button");
+        svl.ui.modalMissionComplete.submitHITButton = $("#modal-mission-complete-hit-submission-button");
+
         svl.ui.modalMissionComplete.totalAuditedDistance = $("#modal-mission-complete-total-audited-distance");
         svl.ui.modalMissionComplete.missionDistance = $("#modal-mission-complete-mission-distance");
         svl.ui.modalMissionComplete.remainingDistance = $("#modal-mission-complete-remaining-distance");

--- a/public/javascripts/SVLabel/src/SVLabel/data/Form.js
+++ b/public/javascripts/SVLabel/src/SVLabel/data/Form.js
@@ -30,7 +30,7 @@ function Form (labelContainer, missionModel, navigationModel, neighborhoodModel,
 
         // Assignment Completion Data
         var data = {
-            amt_assignment_id: params.amtAssignmentId,
+            amt_assignment_id: svl.amtAssignmentId,
             completed: true
         };
 

--- a/public/javascripts/SVLabel/src/SVLabel/mission/Mission.js
+++ b/public/javascripts/SVLabel/src/SVLabel/mission/Mission.js
@@ -136,6 +136,7 @@ function Mission(parameters) {
         // Play the animation and audio effect after task completion.
 
         setProperty("isCompleted", true);
+        console.log("isCompleted has been set to true");
 
         // Update the neighborhood status
         if ("labelContainer" in svl) {

--- a/public/javascripts/SVLabel/src/SVLabel/mission/Mission.js
+++ b/public/javascripts/SVLabel/src/SVLabel/mission/Mission.js
@@ -13,6 +13,7 @@ function Mission(parameters) {
             auditDistanceFt: null,
             auditDistanceMi: null,
             regionId: null,
+            routeId:null,
             label: null,
             missionId: null,
             level: null,
@@ -30,6 +31,7 @@ function Mission(parameters) {
     
     function _init(parameters) {
         if ("regionId" in parameters) setProperty("regionId", parameters.regionId);
+        if ("routeId" in parameters) setProperty("routeId", parameters.routeId);
         if ("missionId" in parameters) setProperty("missionId", parameters.missionId);
         if ("level" in parameters) setProperty("level", parameters.level);
         if ("distance" in parameters) setProperty("distance", parameters.distance);

--- a/public/javascripts/SVLabel/src/SVLabel/mission/MissionContainer.js
+++ b/public/javascripts/SVLabel/src/SVLabel/mission/MissionContainer.js
@@ -239,7 +239,10 @@ function MissionContainer (statusFieldMission, missionModel, taskModel) {
         missions = missions.filter(function (m) { return !m.isCompleted(); });
         while (missions.length == 0) {
             nextRegionId = self._getANextRegionId(nextRegionId);
-            if (nextRegionId == currentRegionId) throw Error("No missions available");
+            if (nextRegionId == currentRegionId) {
+                svl.modalModel.showModalMissionCompleteHITSubmission();
+                throw Error("No missions available");
+            }
             missions = self._missionStoreByRegionId[nextRegionId];
             missions = missions.filter(function (m) { return !m.isCompleted(); });
         }

--- a/public/javascripts/SVLabel/src/SVLabel/mission/MissionFactory.js
+++ b/public/javascripts/SVLabel/src/SVLabel/mission/MissionFactory.js
@@ -10,7 +10,7 @@ function MissionFactory (missionModel) {
     var _missionModel = missionModel;
 
     _missionModel.on("MissionFactory:create", function (parameters) {
-        var mission = self.create(parameters.regionId, parameters.missionId, parameters.label, parameters.level,
+        var mission = self.create(parameters.regionId, parameters.routeId, parameters.missionId, parameters.label, parameters.level,
             parameters.distance, parameters.distanceFt, parameters.distanceMi, parameters.coverage, parameters.isCompleted);
         _missionModel.addAMission(mission);
     });
@@ -29,9 +29,10 @@ function MissionFactory (missionModel) {
  * @param isCompleted A flag indicating if this mission is completed
  * @returns {svl.Mission}
  */
-MissionFactory.prototype.create = function (regionId, missionId, label, level, distance, distanceFt, distanceMi, coverage, isCompleted) {
+MissionFactory.prototype.create = function (regionId, routeId, missionId, label, level, distance, distanceFt, distanceMi, coverage, isCompleted) {
     return new Mission({
         regionId: regionId,
+        routeId: routeId,
         missionId: missionId,
         label: label,
         level: level,

--- a/public/javascripts/SVLabel/src/SVLabel/mission/MissionModel.js
+++ b/public/javascripts/SVLabel/src/SVLabel/mission/MissionModel.js
@@ -86,6 +86,7 @@ function MissionModel () {
             for (var i = 0, len = missions.length; i < len; i++) {
                 missionParameters = {
                     regionId: missions[i].region_id,
+                    routeId: missions[i].route_id,
                     missionId: missions[i].mission_id,
                     label: missions[i].label,
                     level: missions[i].level,

--- a/public/javascripts/SVLabel/src/SVLabel/mission/MissionProgress.js
+++ b/public/javascripts/SVLabel/src/SVLabel/mission/MissionProgress.js
@@ -142,7 +142,7 @@ function MissionProgress (svl, gameEffectModel, missionModel, modalModel, neighb
     this._updateTheCurrentMission = function (currentMission, currentNeighborhood) {
         var currentNeighborhoodId = currentNeighborhood.getProperty("regionId");
         // Refresh mission completion here.
-        currentMission.setProperty("isCompleted",true);
+        currentMission.setProperty("isCompleted", true);
 
         var nextMission = missionContainer.nextMission(currentNeighborhoodId);
 
@@ -152,7 +152,7 @@ function MissionProgress (svl, gameEffectModel, missionModel, modalModel, neighb
             _modalModel.showModalMissionCompleteHITSubmission();
             throw new Error("No missions available");
         }
-        else{
+        else {
             _modalModel.hideModalMissionCompleteHITSubmission();
         }
 
@@ -160,13 +160,14 @@ function MissionProgress (svl, gameEffectModel, missionModel, modalModel, neighb
 
         var route; //Get route from next mission
         var route_json = $.ajax("/route/"+nextMission.getProperty("routeId"));
-        route = svl.routeFactory.create(nextMission.getProperty("routeId"), route_json["region_id"], route_json["route_length_mi"], route_json["street_count"]);
+        route = svl.routeFactory.create(nextMission.getProperty("routeId"), route_json["region_id"],
+                                        route_json["route_length_mi"], route_json["street_count"]);
         svl.routeContainer.add(route);
         svl.routeContainer.setCurrentRoute(route);
         var url = "/audit/amtAssignment ";
 
         // Fetch tasks for the route
-        taskContainer.fetchTasksOnARoute(nextMission.getProperty("routeId"),function () {
+        taskContainer.fetchTasksOnARoute(nextMission.getProperty("routeId"), function () {
             console.log("Tasks for the next route have been fetched");
         });
 

--- a/public/javascripts/SVLabel/src/SVLabel/mission/MissionProgress.js
+++ b/public/javascripts/SVLabel/src/SVLabel/mission/MissionProgress.js
@@ -149,12 +149,33 @@ function MissionProgress (svl, gameEffectModel, missionModel, modalModel, neighb
         // Update route here (may need to add route to taskContainer as well) and post to the audit/amtAssignment end point
 
         var route; //Get route from next mission
-        var route_json = $.ajax("/route/"+nextMission.routeId);
-        route = svl.routeFactory.create(nextMission.routeId, route_json["region_id"], route_json["route_length_mi"], route_json["street_count"]);
+        var route_json = $.ajax("/route/"+nextMission.getProperty("routeId"));
+        route = svl.routeFactory.create(nextMission.getProperty("routeId"), route_json["region_id"], route_json["route_length_mi"], route_json["street_count"]);
         svl.routeContainer.add(route);
         svl.routeContainer.setCurrentRoute(route);
+        var url = "/audit/amtAssignment ";
 
         missionContainer.setCurrentMission(nextMission);
+
+        $.ajax({
+            async: true,
+            contentType: 'application/json; charset=utf-8',
+            url: url,
+            type: 'post',
+            data: JSON.stringify({
+                "assignment_id": svl.assignmentId,
+                "hit_id": svl.hitId,
+                "turker_id": svl.turkerId,
+                "route_id": nextMission.getProperty("routeId")
+            }),
+            dataType: 'json',
+            success: function (result) {
+
+            },
+            error: function (result) {
+                console.error(result);
+            }
+        });
 
         /* Not required for mturk code. MAybe we need a flag here instead
         var nextMissionNeighborhood = neighborhoodContainer.get(nextMission.getProperty("regionId"));

--- a/public/javascripts/SVLabel/src/SVLabel/mission/MissionProgress.js
+++ b/public/javascripts/SVLabel/src/SVLabel/mission/MissionProgress.js
@@ -111,6 +111,7 @@ function MissionProgress (svl, gameEffectModel, missionModel, modalModel, neighb
             }
         );
         mission.complete();
+        console.log("mission.complete in completeTheCurrentMission in MissionProgress.js");
 
         // Todo. Audio should listen to MissionProgress instead of MissionProgress telling what to do.
         _gameEffectModel.playAudio({audioType: "yay"});
@@ -140,6 +141,9 @@ function MissionProgress (svl, gameEffectModel, missionModel, modalModel, neighb
 
     this._updateTheCurrentMission = function (currentMission, currentNeighborhood) {
         var currentNeighborhoodId = currentNeighborhood.getProperty("regionId");
+        // Refresh mission completion here.
+        currentMission.setProperty("isCompleted",true);
+
         var nextMission = missionContainer.nextMission(currentNeighborhoodId);
 
         //Add code here to bring up the submit HIT button and post to the turkSubmit link
@@ -192,8 +196,9 @@ function MissionProgress (svl, gameEffectModel, missionModel, modalModel, neighb
 
         // Adjust the target distance based on the tasks available
         //Need to check if this is require for mturk code
-        var incompleteTaskDistance = taskContainer.getIncompleteTaskDistance(currentNeighborhoodId);
-        nextMission.adjustTheTargetDistance(incompleteTaskDistance);*/
+        */
+        //var incompleteTaskDistance = taskContainer.getIncompleteTaskDistance(currentNeighborhoodId);
+        //nextMission.adjustTheTargetDistance(incompleteTaskDistance);
     };
 
     /**

--- a/public/javascripts/SVLabel/src/SVLabel/mission/MissionProgress.js
+++ b/public/javascripts/SVLabel/src/SVLabel/mission/MissionProgress.js
@@ -179,7 +179,7 @@ function MissionProgress (svl, gameEffectModel, missionModel, modalModel, neighb
             }),
             dataType: 'json',
             success: function (result) {
-
+                svl.amtAssignmentId = result["asg_id"];
             },
             error: function (result) {
                 console.error(result);

--- a/public/javascripts/SVLabel/src/SVLabel/mission/MissionProgress.js
+++ b/public/javascripts/SVLabel/src/SVLabel/mission/MissionProgress.js
@@ -81,9 +81,10 @@ function MissionProgress (svl, gameEffectModel, missionModel, modalModel, neighb
         var currentRoute = svl.routeContainer.getCurrentRoute();
         _routeModel.routeCompleted(currentRoute.getProperty("routeId"), mission, neighborhood);
 
-        if(mission.getProperty("label") != "mturk-mission") {
+        //if(mission.getProperty("label") != "mturk-mission") {
+            // Update the route within this
             this._updateTheCurrentMission(mission, neighborhood);
-        }
+        //}
 
         // While the mission complete modal is open, after the **neighborhood** is 100% audited,
         // the user is jumped to the next neighborhood, that causes the modalmodel to be updated
@@ -144,6 +145,14 @@ function MissionProgress (svl, gameEffectModel, missionModel, modalModel, neighb
         //Add code here to bring up the submit HIT button and post to the turkSubmit link
         // Or just trigger an event here such that the form submission (POST request to turkSubmit) happens on this event
         if (nextMission == null) throw new Error("No missions available");
+
+        // Update route here (may need to add route to taskContainer as well) and post to the audit/amtAssignment end point
+
+        var route; //Get route from next mission
+        var route_json = $.ajax("/route/"+nextMission.routeId);
+        route = svl.routeFactory.create(nextMission.routeId, route_json["region_id"], route_json["route_length_mi"], route_json["street_count"]);
+        svl.routeContainer.add(route);
+        svl.routeContainer.setCurrentRoute(route);
 
         missionContainer.setCurrentMission(nextMission);
 

--- a/public/javascripts/SVLabel/src/SVLabel/mission/MissionProgress.js
+++ b/public/javascripts/SVLabel/src/SVLabel/mission/MissionProgress.js
@@ -152,6 +152,9 @@ function MissionProgress (svl, gameEffectModel, missionModel, modalModel, neighb
             _modalModel.showModalMissionCompleteHITSubmission();
             throw new Error("No missions available");
         }
+        else{
+            _modalModel.hideModalMissionCompleteHITSubmission();
+        }
 
         // Update route here (may need to add route to taskContainer as well) and post to the audit/amtAssignment end point
 

--- a/public/javascripts/SVLabel/src/SVLabel/mission/MissionProgress.js
+++ b/public/javascripts/SVLabel/src/SVLabel/mission/MissionProgress.js
@@ -155,6 +155,11 @@ function MissionProgress (svl, gameEffectModel, missionModel, modalModel, neighb
         svl.routeContainer.setCurrentRoute(route);
         var url = "/audit/amtAssignment ";
 
+        // Fetch tasks for the route
+        taskContainer.fetchTasksOnARoute(nextMission.getProperty("routeId"),function () {
+            console.log("Tasks for the next route have been fetched");
+        });
+
         missionContainer.setCurrentMission(nextMission);
 
         $.ajax({

--- a/public/javascripts/SVLabel/src/SVLabel/mission/MissionProgress.js
+++ b/public/javascripts/SVLabel/src/SVLabel/mission/MissionProgress.js
@@ -148,7 +148,10 @@ function MissionProgress (svl, gameEffectModel, missionModel, modalModel, neighb
 
         //Add code here to bring up the submit HIT button and post to the turkSubmit link
         // Or just trigger an event here such that the form submission (POST request to turkSubmit) happens on this event
-        if (nextMission == null) throw new Error("No missions available");
+        if (nextMission == null) {
+            _modalModel.showModalMissionCompleteHITSubmission();
+            throw new Error("No missions available");
+        }
 
         // Update route here (may need to add route to taskContainer as well) and post to the audit/amtAssignment end point
 

--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
@@ -36,6 +36,10 @@ function ModalMissionComplete (svl, missionContainer, taskContainer,
         self.show();
     });
 
+    _modalModel.on("ModalMissionComplete:showHITSubmission", function () {
+        self.show_hit_submission();
+    });
+
     _modalModel.on("ModalMissionComplete:one", function (parameters) {
         self.one(parameters.uiComponent, parameters.eventType, parameters.callback);
     });
@@ -69,6 +73,15 @@ function ModalMissionComplete (svl, missionContainer, taskContainer,
             _modalModel.triggerMissionCompleteClosed( { nextMission: nextMission } );
             self.hide();
         }
+    };
+
+    this.show_hit_submission = function(){
+        this._uiModalMissionComplete.closeButton.css('visibility', 'hidden');
+        this._uiModalMissionComplete.submitHITButton.css('visibility', 'visible');
+    };
+    this.hide_hit_submission = function(){
+        this._uiModalMissionComplete.closeButton.css('visibility', 'visible');
+        this._uiModalMissionComplete.submitHITButton.css('visibility', 'hidden');
     };
 
     this.hide = function () {

--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
@@ -40,6 +40,10 @@ function ModalMissionComplete (svl, missionContainer, taskContainer,
         self.show_hit_submission();
     });
 
+    _modalModel.on("ModalMissionComplete:hideHITSubmission", function () {
+        self.hide_hit_submission();
+    });
+
     _modalModel.on("ModalMissionComplete:one", function (parameters) {
         self.one(parameters.uiComponent, parameters.eventType, parameters.callback);
     });
@@ -89,6 +93,8 @@ function ModalMissionComplete (svl, missionContainer, taskContainer,
         this._uiModalMissionComplete.holder.css('visibility', 'hidden');
         this._uiModalMissionComplete.foreground.css('visibility', "hidden");
         this._uiModalMissionComplete.background.css('visibility', "hidden");
+        this._uiModalMissionComplete.closeButton.css('visibility', 'hidden');
+        this._uiModalMissionComplete.submitHITButton.css('visibility', 'hidden');
         // this._horizontalBarMissionLabel.style("visibility", "hidden");
         this._modalMissionCompleteMap.hide();
 
@@ -101,6 +107,8 @@ function ModalMissionComplete (svl, missionContainer, taskContainer,
         uiModalMissionComplete.holder.css('visibility', 'visible');
         uiModalMissionComplete.foreground.css('visibility', "visible");
         uiModalMissionComplete.background.css('visibility', "visible");
+        uiModalMissionComplete.closeButton.css('visibility', 'visible');
+        uiModalMissionComplete.submitHITButton.css('visibility', 'hidden');
         // horizontalBarMissionLabel.style("visibility", "visible");
         modalMissionCompleteMap.show();
     };

--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
@@ -127,7 +127,7 @@ function ModalMissionComplete (svl, missionContainer, taskContainer,
     };
 
     //uiModalMissionComplete.background.on("click", this._handleBackgroundClick);
-    //uiModalMissionComplete.closeButton.on("click", this._handleCloseButtonClick);
+    uiModalMissionComplete.closeButton.on("click", this._handleCloseButtonClick);
     //Add code here to make missions appear consecutively on a single HIT rather on multiple HITs
     this.hide();
 }

--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalModel.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalModel.js
@@ -16,6 +16,10 @@ ModalModel.prototype.showModalMissionComplete = function () {
     this.trigger("ModalMissionComplete:show");
 };
 
+ModalModel.prototype.showModalMissionCompleteHITSubmission = function () {
+    this.trigger("ModalMissionComplete:showHITSubmission");
+};
+
 ModalModel.prototype.triggerMissionCompleteClosed = function (parameters) {
     this.trigger("ModalMissionComplete:closed", parameters);
 };

--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalModel.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalModel.js
@@ -20,6 +20,10 @@ ModalModel.prototype.showModalMissionCompleteHITSubmission = function () {
     this.trigger("ModalMissionComplete:showHITSubmission");
 };
 
+ModalModel.prototype.hideModalMissionCompleteHITSubmission = function () {
+    this.trigger("ModalMissionComplete:hideHITSubmission");
+};
+
 ModalModel.prototype.triggerMissionCompleteClosed = function (parameters) {
     this.trigger("ModalMissionComplete:closed", parameters);
 };


### PR DESCRIPTION
We can now present multiple routes to a turker as successive missions within a single HIT. Related to pull request #972 . This pull request should only be tackled after #972. This is because it builds on the code for sidewalk-mturk-v2-restrict-turker-to-single-volunteers-routes which is the more stable predecessor (partly due to how HIT are mapped to individual missions). Most of the modifications are either to javascript files or the controllers. No changes were made to the database. 

You'll see the following additions:
 - At the end of a route the modal mission completion popup will have a "Continue" button that will load the next route. When the turker has completed all assigned routes a "Submit HIT" button should replace the "Continue" button. It will perform a POST request to the MTurk server indicating HIT completion, just like in the old mturk code.
- The appearance of the mission completion message should be preceded by a post request to the amt_assignment table. This will create a new record with an updated route_id but having the same hit_id and assignment_id.
- Refreshing the audit page should bring you to the beginning of of an incomplete mission. (Trying to change this by bringing the turker back to the spot where they left).

Procedure for testing is similar to #972.
- You'll be working with a sql dump for the database ([link](https://www.dropbox.com/s/ztk5hzyuafqsuky/sidewalk-mturk-test-dump?dl=0)).
- Delete the sidewalk database on your machine and restore from the sql dump using pg_restore
- Visit the url http://localhost:9000/?assignmentId=some_string&workerId=some_string&hitId=some_string&turkSubmitTo=localhost:5000/post . This will automatically assign you to a condition id.
- Check that the turker table inserts a new record with your workerId and conditionId
- Check that a record is inserted in the amt_assignment table with a route_id that is correctly associated with the assigned condition_id.
- Check that the distance to be audited in the mission is 1000ft for the first and second missions and 2000ft (displayed as 1/2 mile for some reason) for the third mission.
- Check that the mission progress bar updation is accurate. (For example, it shows 0% at the start, progresses quickly for a 1000ft mission vs a 2000ft mission, and is around 100% at completion).
- Finish the mission associated with the route and click on the "Continue" button. This should take you to the next route. (Check if it stays on the same route and goes into a loop where every step just triggers another mission complete event till you reach the end of the street edge.)
- At the end of every mission check that the completed field for that route is changed to true in the amt_assignment table. Also check that a new record was inserted into the amt_assignment table with the route_id of the second mission and that this route_id associated with the condition assigned to workerId.
- Continue auditing routes till you see the "Submit HIT" button. This indicates that you have completed all routes that were available to you. Clicking this button shouldn't produce any visible change.

I've left many console.log statements uncommented. If you run into any errors please post a screen of those outputs.
