### PR TITLE
839 assign unaudited streets

### DIFF
--- a/app/controllers/AuditController.scala
+++ b/app/controllers/AuditController.scala
@@ -55,6 +55,7 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
         // val region: Option[Region] = RegionTable.getCurrentRegion(user.userId)
         var region: Option[NamedRegion] = RegionTable.selectTheCurrentNamedRegion(user.userId)
 
+        // TODO: Change here for unaudited routes - #839
         // Check if a user still has tasks available in this region.
         if (!AuditTaskTable.isTaskAvailable(user.userId, region.get.regionId) ||
             !MissionTable.isMissionAvailable(user.userId, region.get.regionId)) {

--- a/app/controllers/AuditController.scala
+++ b/app/controllers/AuditController.scala
@@ -52,7 +52,6 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
         if (!UserCurrentRegionTable.isAssigned(user.userId)) {
           UserCurrentRegionTable.assignRandomly(user.userId)
         }
-        // val region: Option[Region] = RegionTable.getCurrentRegion(user.userId)
         var region: Option[NamedRegion] = RegionTable.selectTheCurrentNamedRegion(user.userId)
 
         // TODO: Change here for unaudited routes - #839
@@ -68,7 +67,6 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
         Future.successful(Ok(views.html.audit("Project Sidewalk - Audit", Some(task), region, Some(user))))
       case None =>
         WebpageActivityTable.save(WebpageActivity(0, anonymousUser.userId.toString, ipAddress, "Visit_Audit", timestamp))
-        // val region: Option[Region] = RegionTable.getRegion
         val region: Option[NamedRegion] = RegionTable.selectAnEasyNamedRegionRoundRobin
         val task: NewTask = AuditTaskTable.selectANewTaskInARegion(region.get.regionId)
         Future.successful(Ok(views.html.audit("Project Sidewalk - Audit", Some(task), region, None)))

--- a/app/controllers/AuditController.scala
+++ b/app/controllers/AuditController.scala
@@ -50,9 +50,12 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
 
         // Check and make sure that the user has been assigned to a region
         if (!UserCurrentRegionTable.isAssigned(user.userId)) {
+          println("Not Assigned")
           UserCurrentRegionTable.assignRandomly(user.userId)
         }
+
         var region: Option[NamedRegion] = RegionTable.selectTheCurrentNamedRegion(user.userId)
+        println("Assigned" + region.get.regionId)
 
         // TODO: Change here for unaudited routes - #839
         // Check if a user still has tasks available in this region.

--- a/app/controllers/AuditController.scala
+++ b/app/controllers/AuditController.scala
@@ -57,7 +57,6 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
 
         var region: Option[NamedRegion] = RegionTable.selectTheCurrentNamedRegion(user.userId)
 
-        // TODO: Change here for unaudited routes - #839
         // Check if a user still has tasks available in this region.
         if (!AuditTaskTable.isTaskAvailable(user.userId, region.get.regionId) ||
             !MissionTable.isMissionAvailable(user.userId, region.get.regionId)) {
@@ -67,6 +66,8 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
 
         val task: NewTask = if (region.isDefined) AuditTaskTable.selectANewTaskInARegion(region.get.regionId, user.userId)
                             else AuditTaskTable.selectANewTask(user.userId)
+        region = RegionTable.selectTheCurrentNamedRegion(user.userId)
+
         Future.successful(Ok(views.html.audit("Project Sidewalk - Audit", Some(task), region, Some(user))))
       case None =>
         WebpageActivityTable.save(WebpageActivity(0, anonymousUser.userId.toString, ipAddress, "Visit_Audit", timestamp))
@@ -94,9 +95,12 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
 
         var region: Option[NamedRegion] = RegionTable.selectTheCurrentNamedRegion(user.userId)
         region = RegionTable.selectTheCurrentNamedRegion(user.userId)
+
         val task: NewTask =
           if (region.isDefined) AuditTaskTable.selectANewTaskInARegion(region.get.regionId, user.userId)
           else AuditTaskTable.selectANewTask(user.userId)
+        region = RegionTable.selectTheCurrentNamedRegion(user.userId)
+
         Future.successful(Ok(views.html.audit("Project Sidewalk - Audit", Some(task), region, Some(user))))
       case None =>
         WebpageActivityTable.save(WebpageActivity(0, anonymousUser.userId.toString, ipAddress, "Visit_Audit", timestamp))

--- a/app/controllers/AuditController.scala
+++ b/app/controllers/AuditController.scala
@@ -56,7 +56,7 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
         }
 
         var region: Option[NamedRegion] = RegionTable.selectTheCurrentNamedRegion(user.userId)
-        println("Assigned" + region.get.regionId)
+        println("Assigned: " + region.get.regionId)
 
         // TODO: Change here for unaudited routes - #839
         // Check if a user still has tasks available in this region.
@@ -140,7 +140,7 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
         Future.successful(Ok(views.html.audit("Project Sidewalk - Audit", Some(task), region, Some(user))))
       case None =>
         WebpageActivityTable.save(WebpageActivity(0, anonymousUser.userId.toString, ipAddress, "Visit_Audit", timestamp))
-        val task: NewTask = AuditTaskTable.selectANewTask(regionId)
+        val task: NewTask = AuditTaskTable.selectANewTaskInARegion(regionId)
         Future.successful(Ok(views.html.audit("Project Sidewalk - Audit", Some(task), region, None)))
     }
   }

--- a/app/controllers/AuditController.scala
+++ b/app/controllers/AuditController.scala
@@ -51,7 +51,6 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
 
         // Check and make sure that the user has been assigned to a region
         if (!UserCurrentRegionTable.isAssigned(user.userId)) {
-          println("Not Assigned")
           UserCurrentRegionTable.assignRandomly(user.userId)
         }
 

--- a/app/controllers/AuditController.scala
+++ b/app/controllers/AuditController.scala
@@ -146,6 +146,7 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
       case _: Throwable => None
     }
 
+    // TODO: Should this function be modified?
     val task: NewTask = AuditTaskTable.selectANewTask(streetEdgeId)
     request.identity match {
       case Some(user) => Future.successful(Ok(views.html.audit("Project Sidewalk - Audit", Some(task), region, Some(user))))

--- a/app/controllers/AuditController.scala
+++ b/app/controllers/AuditController.scala
@@ -56,7 +56,6 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
         }
 
         var region: Option[NamedRegion] = RegionTable.selectTheCurrentNamedRegion(user.userId)
-        println("Assigned: " + region.get.regionId)
 
         // TODO: Change here for unaudited routes - #839
         // Check if a user still has tasks available in this region.
@@ -65,12 +64,9 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
           UserCurrentRegionTable.assignNextRegion(user.userId)
           region = RegionTable.selectTheCurrentNamedRegion(user.userId)
         }
-        println("Current assignment: " + region.get.regionId)
 
         val task: NewTask = if (region.isDefined) AuditTaskTable.selectANewTaskInARegion(region.get.regionId, user.userId)
                             else AuditTaskTable.selectANewTask(user.userId)
-        region = RegionTable.selectTheCurrentNamedRegion(user.userId)
-        println("Current assignment: " + region.get.regionId)
         Future.successful(Ok(views.html.audit("Project Sidewalk - Audit", Some(task), region, Some(user))))
       case None =>
         WebpageActivityTable.save(WebpageActivity(0, anonymousUser.userId.toString, ipAddress, "Visit_Audit", timestamp))
@@ -97,15 +93,10 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
         UserCurrentRegionTable.assignNextEasyRegion(user.userId)
 
         var region: Option[NamedRegion] = RegionTable.selectTheCurrentNamedRegion(user.userId)
-        println("Current assignment: " + region.get.regionId)
         region = RegionTable.selectTheCurrentNamedRegion(user.userId)
-        println("Current assignment: " + region.get.regionId)
         val task: NewTask =
           if (region.isDefined) AuditTaskTable.selectANewTaskInARegion(region.get.regionId, user.userId)
           else AuditTaskTable.selectANewTask(user.userId)
-        println(task)
-        region = RegionTable.selectTheCurrentNamedRegion(user.userId)
-        println("Current assignment: " + region.get.regionId)
         Future.successful(Ok(views.html.audit("Project Sidewalk - Audit", Some(task), region, Some(user))))
       case None =>
         WebpageActivityTable.save(WebpageActivity(0, anonymousUser.userId.toString, ipAddress, "Visit_Audit", timestamp))

--- a/app/controllers/TaskController.scala
+++ b/app/controllers/TaskController.scala
@@ -65,7 +65,6 @@ class TaskController @Inject() (implicit val env: Environment[User, SessionAuthe
     * @param regionId Region id
     * @return
     */
-  // TODO: Changes needed for unaudited routes - #839
   def getTasksInARegion(regionId: Int) = UserAwareAction.async { implicit request =>
     request.identity match {
       case Some(user) =>

--- a/app/controllers/TaskController.scala
+++ b/app/controllers/TaskController.scala
@@ -64,6 +64,7 @@ class TaskController @Inject() (implicit val env: Environment[User, SessionAuthe
     * @param regionId Region id
     * @return
     */
+  // TODO: Changes needed for unaudited routes - #839
   def getTasksInARegion(regionId: Int) = UserAwareAction.async { implicit request =>
     request.identity match {
       case Some(user) =>

--- a/app/controllers/TaskController.scala
+++ b/app/controllers/TaskController.scala
@@ -45,7 +45,7 @@ class TaskController @Inject() (implicit val env: Environment[User, SessionAuthe
   def getTask = UserAwareAction.async { implicit request =>
     request.identity match {
       case Some(user) =>
-        val task = AuditTaskTable.selectANewTask(user.username)
+        val task = AuditTaskTable.selectANewTask(user.userId)
         Future.successful(Ok(task.toJSON))
       case None => Future.successful(Ok(AuditTaskTable.selectANewTask.toJSON))
     }

--- a/app/models/audit/AuditTaskTable.scala
+++ b/app/models/audit/AuditTaskTable.scala
@@ -591,7 +591,6 @@ object AuditTaskTable {
     * @param userId User id
     * @return
     */
-  // TODO: Issue 839 - this pulls streets for a particular region for a user
   def selectTasksInARegion(regionId: Int, userId: UUID): List[NewTask] = db.withSession { implicit session =>
     val timestamp: Timestamp = new Timestamp(Calendar.getInstance(TimeZone.getTimeZone("UTC")).getTime.getTime)
 

--- a/app/models/audit/AuditTaskTable.scala
+++ b/app/models/audit/AuditTaskTable.scala
@@ -550,6 +550,7 @@ object AuditTaskTable {
     * @param userId User id
     * @return
     */
+  // TODO: Issue 839 - this pulls streets for a particular region for a user
   def selectTasksInARegion(regionId: Int, userId: UUID): List[NewTask] = db.withSession { implicit session =>
     val timestamp: Timestamp = new Timestamp(Calendar.getInstance(TimeZone.getTimeZone("UTC")).getTime.getTime)
 

--- a/app/models/audit/AuditTaskTable.scala
+++ b/app/models/audit/AuditTaskTable.scala
@@ -127,6 +127,13 @@ object AuditTaskTable {
   }
 
   /**
+    * Return a sub-query of the least-audited streets in a region
+    */
+  def getLeastAuditedStreetsQuery(regionId: Int) = db.withSession {implicit session =>
+    
+  }
+
+  /**
     * Returns the number of tasks completed
     * @return
     */

--- a/app/models/street/StreetEdgeRegionTable.scala
+++ b/app/models/street/StreetEdgeRegionTable.scala
@@ -6,7 +6,7 @@ import play.api.Play.current
 
 import scala.slick.lifted.ForeignKeyQuery
 
-case class StreetEdgeRegion(streetEdgeId: Int, parentEdgeId: Int)
+case class StreetEdgeRegion(streetEdgeId: Int, regionId: Int)
 
 class StreetEdgeRegionTable(tag: Tag) extends Table[StreetEdgeRegion](tag, Some("sidewalk"),  "street_edge_region") {
   def streetEdgeId = column[Int]("street_edge_id")
@@ -24,23 +24,46 @@ class StreetEdgeRegionTable(tag: Tag) extends Table[StreetEdgeRegion](tag, Some(
 object StreetEdgeRegionTable {
   val db = play.api.db.slick.DB
   val streetEdgeRegionTable = TableQuery[StreetEdgeRegionTable]
+  val nonDeletedStreetEdgeRegions = for {
+    _ser <- streetEdgeRegionTable
+    _se <- StreetEdgeTable.streetEdgesWithoutDeleted if _ser.streetEdgeId === _se.streetEdgeId
+    _r <- RegionTable.regionsWithoutDeleted if _ser.regionId === _r.regionId
+  } yield _ser
 
   /**
-   * Get records based on the child id.
-   * @param streetEdgeId
-   * @return
-   */
-  def selectStreetEdgeId(streetEdgeId: Int): List[StreetEdgeRegion] = db.withSession { implicit session =>
+    * Get records based on the street edge id.
+    * @param streetEdgeId
+    * @return
+    */
+  def selectByStreetEdgeId(streetEdgeId: Int): List[StreetEdgeRegion] = db.withSession { implicit session =>
     streetEdgeRegionTable.filter(item => item.streetEdgeId === streetEdgeId).list
   }
 
   /**
-   * Get records based on the parent id.
-   * @param regionId
-   * @return
-   */
+    * Get records based on the street edge id.
+    * @param streetEdgeId
+    * @return
+    */
+  def selectNonDeletedByStreetEdgeId(streetEdgeId: Int): List[StreetEdgeRegion] = db.withSession { implicit session =>
+    nonDeletedStreetEdgeRegions.filter(item => item.streetEdgeId === streetEdgeId).list
+  }
+
+  /**
+    * Get records based on the region id.
+    * @param regionId
+    * @return
+    */
   def selectByRegionId(regionId: Int): List[StreetEdgeRegion] = db.withSession { implicit session =>
     streetEdgeRegionTable.filter(item => item.regionId === regionId).list
+  }
+
+  /**
+    * Get records based on the region id.
+    * @param regionId
+    * @return
+    */
+  def selectNonDeletedByRegionId(regionId: Int): List[StreetEdgeRegion] = db.withSession { implicit session =>
+    nonDeletedStreetEdgeRegions.filter(item => item.regionId === regionId).list
   }
 
   /**

--- a/public/javascripts/SVLabel/src/SVLabel/Main.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Main.js
@@ -312,6 +312,14 @@ function Main (params) {
         svl.missionContainer.setCurrentMission(onboardingMission);
     }
 
+    function findTheNextRegionWithMissionsNew () {
+
+        // Query the server for the next least unaudited region (across users)
+        // and that hasn't been done by the user
+        var username = svl.user.getProperty("username");
+        return neighborhoodModel.fetchNextLeastAuditedRegion(username);
+    }
+
     function findTheNextRegionWithMissions (currentNeighborhood) {
         var currentRegionId = currentNeighborhood.getProperty("regionId");
         var allRegionIds = svl.neighborhoodContainer.getRegionIds();
@@ -471,6 +479,8 @@ function Main (params) {
 
         if (!(incompleteMissionExists(availableMissions) && incompleteTaskExists(incompleteTasks))) {
             regionId = findTheNextRegionWithMissions(currentNeighborhood);
+
+            // TODO: This case will execute when the entire city is audited by the user. Should handle properly!
             if (regionId == null) return;  // No missions available.
 
             currentNeighborhood = svl.neighborhoodContainer.get(regionId);

--- a/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
+++ b/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
@@ -967,7 +967,6 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
         var position = svl.panorama.getPosition();
         var neighborhood = svl.neighborhoodContainer.getCurrentNeighborhood();
         var currentMission = svl.missionContainer.getCurrentMission();
-        //position updated, set delay until user can walk again to properly update canvas
         // Takes care of position_changed happening after the map has already been set
         map.setCenter(position);
 
@@ -975,6 +974,8 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
         if (svl.contextMenu.isOpen()){
             svl.contextMenu.hide();
         }
+
+        // Position updated, set delay until user can walk again to properly update canvas
         if (!svl.isOnboarding() && !svl.keyboard.getStatus("moving")){
             timeoutWalking();
             setTimeout(resetWalking, moveDelay);

--- a/public/javascripts/SVLabel/src/SVLabel/neighborhood/NeighborhoodModel.js
+++ b/public/javascripts/SVLabel/src/SVLabel/neighborhood/NeighborhoodModel.js
@@ -12,6 +12,7 @@ function NeighborhoodModel () {
             layer =leafletLayers[i];
             regionId = layer.feature.properties.region_id;
             regionName = layer.feature.properties.region_name;
+            // TODO: Add a isCompleted property
             self.create(regionId, layer, regionName);
         }
     };

--- a/public/javascripts/SVLabel/src/SVLabel/neighborhood/NeighborhoodModel.js
+++ b/public/javascripts/SVLabel/src/SVLabel/neighborhood/NeighborhoodModel.js
@@ -2,6 +2,7 @@ function NeighborhoodModel () {
     var self = this;
     this._neighborhoodContainer = null;
     this.isNeighborhoodCompleted = false;
+    this.isNeighborhoodCompletedAcrossAllUsers = null;
 
     this._handleFetchComplete = function (geojson) {
         var geojsonLayer = L.geoJson(geojson);
@@ -60,6 +61,15 @@ NeighborhoodModel.prototype.moveToANewRegion = function (regionId) {
             console.error(result);
         }
     });
+};
+
+NeighborhoodModel.prototype.getNeighborhoodCompleteAcrossAllUsers = function (neighborhoodId) {
+    return this.isNeighborhoodCompletedAcrossAllUsers;
+};
+
+
+NeighborhoodModel.prototype.setNeighborhoodCompleteAcrossAllUsers = function (neighborhoodId) {
+    this.isNeighborhoodCompletedAcrossAllUsers = true;
 };
 
 NeighborhoodModel.prototype.getNeighborhood = function (neighborhoodId) {

--- a/public/javascripts/SVLabel/src/SVLabel/neighborhood/NeighborhoodModel.js
+++ b/public/javascripts/SVLabel/src/SVLabel/neighborhood/NeighborhoodModel.js
@@ -24,6 +24,22 @@ function NeighborhoodModel () {
             $.when($.ajax("/neighborhoods")).done(self._handleFetchComplete)
         }
     };
+    
+    this.fetchNextLeastAuditedRegion = function (username, async, callback) {
+        if (typeof async === "undefined") async = true;
+        $.ajax({
+            async: async,
+            url: "/neighborhoods/" + username, // Needs change - URL incorrect
+            type: 'get',
+            success: function (json) {
+                self._handleFetchComplete(json);
+                if (callback) callback();
+            },
+            error: function (result) {
+                throw result;
+            }
+        });
+    }
 }
 _.extend(NeighborhoodModel.prototype, Backbone.Events);
 

--- a/public/javascripts/SVLabel/src/SVLabel/task/Task.js
+++ b/public/javascripts/SVLabel/src/SVLabel/task/Task.js
@@ -248,7 +248,7 @@ function Task (geojson, currentLat, currentLng) {
     }
 
     this._hasAdvanced = function (currentLat, currentLng) {
-        if (typeof _furthestPoint == "undefined") return false;
+        if (typeof _furthestPoint === "undefined") return false;
         var latFurthest = _furthestPoint.geometry.coordinates[1];
         var lngFurthest = _furthestPoint.geometry.coordinates[0];
         var distanceAtTheFurthestPoint = this.getDistanceFromStart(latFurthest, lngFurthest);
@@ -343,7 +343,7 @@ function Task (geojson, currentLat, currentLng) {
     };
 
     this.getAuditedDistance = function (unit) {
-        if (typeof _furthestPoint == "undefined") return 0;
+        if (typeof _furthestPoint === "undefined") return 0;
         if (!unit) unit = "kilometers";
         var latFurthest = _furthestPoint.geometry.coordinates[1];
         var lngFurthest = _furthestPoint.geometry.coordinates[0];

--- a/public/javascripts/SVLabel/src/SVLabel/task/Task.js
+++ b/public/javascripts/SVLabel/src/SVLabel/task/Task.js
@@ -19,7 +19,8 @@ function Task (geojson, currentLat, currentLng) {
     };
     var properties = {
         auditTaskId: null,
-        streetEdgeId: null
+        streetEdgeId: null,
+        completionCount: null
     };
 
     /**
@@ -32,6 +33,7 @@ function Task (geojson, currentLat, currentLng) {
         _geojson = geojson;
 
         self.setProperty("streetEdgeId", _geojson.features[0].properties.street_edge_id);
+        self.setProperty("completionCount", _geojson.features[0].properties.completion_count);
 
         if (_geojson.features[0].properties.completed) {
             self.complete();
@@ -333,6 +335,10 @@ function Task (geojson, currentLat, currentLng) {
      */
     this.getStreetEdgeId = function () {
         return _geojson.features[0].properties.street_edge_id;
+    };
+
+    this.getStreetCompletionCount = function () {
+        return _geojson.features[0].properties.completion_count;
     };
 
     /**

--- a/public/javascripts/SVLabel/src/SVLabel/task/TaskContainer.js
+++ b/public/javascripts/SVLabel/src/SVLabel/task/TaskContainer.js
@@ -178,7 +178,6 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
                 success: function (result) {
                     var task;
                     console.log("Number of tasks received: " + result.length);
-                    console.log(result[0]);
                     for (var i = 0; i < result.length; i++) {
                         task = svl.taskFactory.create(result[i]);
                         if ((result[i].features[0].properties.completed)) task.complete();
@@ -411,9 +410,11 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
         // Indicates neighborhood is complete
         if (candidateTasks.length === 0) {
             neighborhoodModel.setNeighborhoodCompleteAcrossAllUsers();
-            return false;
-        } else {
+            console.log("Neighborhood complete");
             return true;
+        } else {
+            console.log("Neighborhood not complete");
+            return false;
         }
     }
 
@@ -447,13 +448,15 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
             userCandidateTasks = userCandidateTasks.filter(function (t) {
                 return !t.isCompleted();
             });
-            console.log("Filtered based on completion by user: " + userCandidateTasks.length);
+            console.log("Connected tasks filtered based on completion by user: " + userCandidateTasks.length);
 
             if (userCandidateTasks.length === 0) {
                 userCandidateTasks = self.getIncompleteTasks(currentNeighborhoodId).filter(function (t) {
                     return (t.getStreetEdgeId() !== (finishedTask ? finishedTask.getStreetEdgeId() : null));
                 });
             }
+            console.log("Neighborhood tasks filtered based on completion by user: " + userCandidateTasks.length);
+
         }
         // If the neighborhood is NOT 100% complete (across all users)
         else {
@@ -466,7 +469,7 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
                 return !t.isCompleted();
             });
 
-            console.log("Filtered based on completion count: " + userCandidateTasks.length);
+            console.log("Connected tasks filtered based on completion count: " + userCandidateTasks.length);
 
             // If there aren't any amongst connected tasks, select an incomplete task (or unaudited street) in the
             // neighborhood
@@ -475,6 +478,8 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
                     return (t.getStreetEdgeId() !== (finishedTask ? finishedTask.getStreetEdgeId(): null));
                 });
             }
+            console.log("Neighborhood tasks filtered based on completion count: " + userCandidateTasks.length);
+
         }
         if (userCandidateTasks.length === 0) return null;
 

--- a/public/javascripts/SVLabel/src/SVLabel/task/TaskContainer.js
+++ b/public/javascripts/SVLabel/src/SVLabel/task/TaskContainer.js
@@ -166,7 +166,6 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
      * @param callback A callback function
      * @param async {boolean}
      */
-    // TODO: Issue 839
     self.fetchTasksInARegion = function (regionId, callback, async) {
         if (typeof async == "undefined") async = true;
 
@@ -413,10 +412,10 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
             // Indicates neighborhood is complete
             if (candidateTasks.length === 0) {
                 neighborhoodModel.setNeighborhoodCompleteAcrossAllUsers();
-                console.log("Neighborhood complete");
+                //console.log("Neighborhood complete");
                 isNeighborhoodCompleteAcrossAllUsers = true;
             } else {
-                console.log("Neighborhood not complete");
+                //console.log("Neighborhood not complete");
                 isNeighborhoodCompleteAcrossAllUsers = false;
             }
         }
@@ -454,14 +453,12 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
             userCandidateTasks = userCandidateTasks.filter(function (t) {
                 return !t.isCompleted();
             });
-            console.log("Connected tasks filtered based on completion by user: " + userCandidateTasks.length);
 
             if (userCandidateTasks.length === 0) {
                 userCandidateTasks = self.getIncompleteTasks(currentNeighborhoodId).filter(function (t) {
                     return (t.getStreetEdgeId() !== (finishedTask ? finishedTask.getStreetEdgeId() : null));
                 });
             }
-            console.log("Neighborhood tasks filtered based on completion by user: " + userCandidateTasks.length);
 
         }
         // If the neighborhood is NOT 100% complete (across all users)
@@ -475,8 +472,6 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
                 return !t.isCompleted();
             });
 
-            console.log("Connected tasks filtered based on completion count: " + userCandidateTasks.length);
-
             // If there aren't any amongst connected tasks, select an incomplete task (or unaudited street) in the
             // neighborhood
             if (userCandidateTasks.length === 0) {
@@ -484,8 +479,6 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
                     return (t.getStreetEdgeId() !== (finishedTask ? finishedTask.getStreetEdgeId(): null));
                 });
             }
-            console.log("Neighborhood tasks filtered based on completion count: " + userCandidateTasks.length);
-
         }
         if (userCandidateTasks.length === 0) return null;
 

--- a/public/javascripts/SVLabel/src/SVLabel/task/TaskContainer.js
+++ b/public/javascripts/SVLabel/src/SVLabel/task/TaskContainer.js
@@ -404,18 +404,25 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
     }
 
     function isNeighborhoodCompleteAcrossAllUsers(neighborhoodId, finishedTask) {
-        var candidateTasks = self.getIncompleteTasksAcrossAllUsers(neighborhoodId).filter(function(t) {
-            return (t.getStreetEdgeId() !== (finishedTask ? finishedTask.getStreetEdgeId(): null));
-        });
-        // Indicates neighborhood is complete
-        if (candidateTasks.length === 0) {
-            neighborhoodModel.setNeighborhoodCompleteAcrossAllUsers();
-            console.log("Neighborhood complete");
-            return true;
-        } else {
-            console.log("Neighborhood not complete");
-            return false;
+        var isNeighborhoodCompleteAcrossAllUsers = neighborhoodModel.getNeighborhoodCompleteAcrossAllUsers();
+
+        // Only run this code if the neighborhood is set as incomplete
+        if (!isNeighborhoodCompleteAcrossAllUsers) {
+            var candidateTasks = self.getIncompleteTasksAcrossAllUsers(neighborhoodId).filter(function (t) {
+                return (t.getStreetEdgeId() !== (finishedTask ? finishedTask.getStreetEdgeId() : null));
+            });
+            // Indicates neighborhood is complete
+            if (candidateTasks.length === 0) {
+                neighborhoodModel.setNeighborhoodCompleteAcrossAllUsers();
+                console.log("Neighborhood complete");
+                isNeighborhoodCompleteAcrossAllUsers = true;
+            } else {
+                console.log("Neighborhood not complete");
+                isNeighborhoodCompleteAcrossAllUsers = false;
+            }
         }
+
+        return isNeighborhoodCompleteAcrossAllUsers;
     }
 
     /**

--- a/public/javascripts/SVLabel/src/SVLabel/task/TaskContainer.js
+++ b/public/javascripts/SVLabel/src/SVLabel/task/TaskContainer.js
@@ -166,6 +166,7 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
      * @param callback A callback function
      * @param async {boolean}
      */
+    // TODO: Issue 839
     self.fetchTasksInARegion = function (regionId, callback, async) {
         if (typeof async == "undefined") async = true;
 
@@ -211,7 +212,7 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
             tasks = tasks.filter(function (t) { return !t.isCompleted(); });
 
             if (taskIn) {
-                tasks = tasks.filter(function (t) { return t.getStreetEdgeId() != taskIn.getStreetEdgeId(); });
+                tasks = tasks.filter(function (t) { return t.getStreetEdgeId() !== taskIn.getStreetEdgeId(); });
 
                 for (var i = 0, len = tasks.length; i < len; i++) {
                     if (taskIn.isConnectedTo(tasks[i], threshold, unit)) {
@@ -335,7 +336,7 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
      * @returns {boolean}
      */
     function isFirstTask () {
-        return length() == 0;
+        return length() === 0;
     }
 
     /**
@@ -356,16 +357,16 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
         var neighborhood = neighborhoodModel.currentNeighborhood();
         var currentNeighborhoodId = neighborhood.getProperty("regionId");
 
-        // Seek the incomplete street edges (tasks) that are connected to the task that has been complted.
+        // Seek the incomplete street edges (tasks) that are connected to the task that has been completed.
         // If there aren't any connected tasks that are incomplete, randomly select a task from
         // any of the incomplete tasks in the neighborhood. If that is empty, return null.
         var candidateTasks = self._findConnectedTask(currentNeighborhoodId, finishedTask, null, null);
         candidateTasks = candidateTasks.filter(function (t) { return !t.isCompleted(); });
-        if (candidateTasks.length == 0) {
+        if (candidateTasks.length === 0) {
             candidateTasks = self.getIncompleteTasks(currentNeighborhoodId).filter(function(t) {
-                return (t.getStreetEdgeId() != (finishedTask ? finishedTask.getStreetEdgeId(): null));
+                return (t.getStreetEdgeId() !== (finishedTask ? finishedTask.getStreetEdgeId(): null));
             });
-            if (candidateTasks.length == 0) return null;
+            if (candidateTasks.length === 0) return null;
         }
 
         // Return the new task. Change the starting point of the new task accordingly.
@@ -424,6 +425,7 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
      * @param regionId {number} Region id
      * @param task {object} Task object
      */
+    // TODO: Issue 839
     function storeTask(regionId, task) {
         if (!(regionId in self._taskStoreByRegionId)) self._taskStoreByRegionId[regionId] = [];
         var streetEdgeIds = self._taskStoreByRegionId[regionId].map(function (task) {

--- a/public/javascripts/SVLabel/src/SVLabel/task/TaskContainer.js
+++ b/public/javascripts/SVLabel/src/SVLabel/task/TaskContainer.js
@@ -177,7 +177,6 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
                 type: 'get',
                 success: function (result) {
                     var task;
-                    console.log("Number of tasks received: " + result.length);
                     for (var i = 0; i < result.length; i++) {
                         task = svl.taskFactory.create(result[i]);
                         if ((result[i].features[0].properties.completed)) task.complete();


### PR DESCRIPTION
Resolves #839 

If the neighborhood is incomplete, it now first routes the user through the neighborhood streets that are unaudited by anyone. Once the neighborhood is complete, the routes that are unaudited by the 
user personally are given.

For testing: Choose a neighborhood that is relatively small in size and that is towards completion. I have left debug comments, so you can see in the console how the routes are assigned and how neighborhood progress happens.

**TODO: One other small thing that is remaining**: Once the user personally completes a neighborhood, they should be assigned an incomplete neighborhood. During testing, I got a completed neighborhood.