### PR TITLE
Added an endpoint to audit the routes associated with a specific condition

### DIFF
--- a/app/controllers/AuditController.scala
+++ b/app/controllers/AuditController.scala
@@ -161,6 +161,124 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
     }
   }
 
+  def auditCondition = UserAwareAction.async { implicit request =>
+    val now = new DateTime(DateTimeZone.UTC)
+    val timestamp: Timestamp = new Timestamp(now.getMillis)
+    val ipAddress: String = request.remoteAddress
+
+    // Get mTurk parameters
+    // Map with keys ["assignmentId","hitId","turkSubmitTo","workerId"]
+    val qString = request.queryString.map { case (k, v) => k.mkString -> v.mkString }
+    //println(timestamp + " " + qString)
+
+    var screenStatus: String = null
+    var hitId: String = null
+    var assignmentId: String = null
+    var workerId: String = null
+    var conditionId: Integer = 0
+
+    if (qString.nonEmpty && qString.contains("assignmentId")) {
+
+      assignmentId = qString("assignmentId")
+
+      if (qString("assignmentId") != "ASSIGNMENT_ID_NOT_AVAILABLE") {
+        // User clicked the ACCEPT HIT button
+        hitId = qString("hitId")
+        workerId = qString("workerId")
+        conditionId = qString("conditionId").toInt
+        screenStatus = "Assigned"
+      }
+      else {
+        screenStatus = "Preview"
+      }
+    }
+    else {
+      screenStatus = "Blank"
+    }
+
+    val completionRates = StreetEdgeAssignmentCountTable.computeNeighborhoodCompletionRate(1).sortWith(_.rate < _.rate)
+
+    request.identity match {
+      case Some(user) =>
+        // This code block doesn't work route by route
+        // Future TODO: Make mission-route mechanism for users
+
+        // Maybe just redirect them to the admin dashboard
+
+        WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, "Visit_Audit", timestamp))
+
+        // Check and make sure that the user has been assigned to a region
+        if (!UserCurrentRegionTable.isAssigned(user.userId)) {
+          UserCurrentRegionTable.assignRandomly(user.userId)
+        }
+        // val region: Option[Region] = RegionTable.getCurrentRegion(user.userId)
+        var region: Option[NamedRegion] = RegionTable.selectTheCurrentNamedRegion(user.userId)
+
+        // Check if a user still has tasks available in this region.
+        if (!AuditTaskTable.isTaskAvailable(user.userId, region.get.regionId) ||
+          !MissionTable.isMissionAvailable(user.userId, region.get.regionId)) {
+          UserCurrentRegionTable.assignNextRegion(user.userId)
+          region = RegionTable.selectTheCurrentNamedRegion(user.userId)
+        }
+
+        val route = None
+
+        val task: NewTask = if (region.isDefined) AuditTaskTable.selectANewTaskInARegion(region.get.regionId, user)
+        else AuditTaskTable.selectANewTask(user.username)
+        Future.successful(Ok(views.html.audit("Project Sidewalk - Audit", Some(task), region, route, Some(user))))
+      case None =>
+
+        screenStatus match {
+          case "Assigned" =>
+            WebpageActivityTable.save(WebpageActivity(0, anonymousUser.userId.toString, ipAddress, "Visit_Audit", timestamp))
+
+            // Retrieve the route based on the condition that the worker has been assigned to and the associated unvisited routes
+            TurkerTable.getConditionIdByTurkerId(workerId) match {
+              case Some(cId) =>
+                TurkerTable.updateConditionIdByTurkerId(workerId, conditionId)
+              case None =>
+                // No worker was found with this id (implies no condition was assigned)
+                // Save turker id and the condition specified in the query string here
+                val turker: Turker = Turker(workerId,"",conditionId)
+                TurkerTable.save(turker)
+            }
+
+            // When all condition id's have been exhausted assign a default for now (or just assign a different)
+            // We only need the workerId to assign routes since we can obtain condition id and volunteer id by doing inner joins over tables.
+            // Skipping this step since we have already obtained condition id
+            val routeId: Option[Int] = AMTVolunteerRouteTable.assignRouteByConditionIdAndWorkerId(conditionId,workerId)
+            val route: Option[Route] = RouteTable.getRoute(routeId)
+
+            // If route is None, turker has finished all routes assigned, so send them to homepage.
+            route match {
+              case None =>
+                Future.successful(Ok(views.html.index("Project Sidewalk")))
+              case Some(theRoute) =>
+                val routeStreetId: Option[Int] = RouteStreetTable.getFirstRouteStreetId(routeId.getOrElse(0))
+
+                // Save HIT assignment details
+                val asg: AMTAssignment = AMTAssignment(0, hitId, assignmentId, timestamp, None, workerId, conditionId, routeId, false)
+                val asgId: Option[Int] = Option(AMTAssignmentTable.save(asg))
+
+                // Load the first task from the selected route
+                val regionId: Int = theRoute.regionId
+                val region: Option[NamedRegion] = RegionTable.selectANamedRegion(regionId)
+                val regionName: Option[String] = region.get.name
+                val task: NewTask = AuditTaskTable.selectANewTask(routeStreetId.getOrElse(0), asgId)
+
+                Future.successful(Ok(views.html.audit("Project Sidewalk - Audit", Some(task), region, route, None)))
+            }
+
+          case "Preview" =>
+            WebpageActivityTable.save(WebpageActivity(0, anonymousUser.userId.toString, ipAddress, "Visit_Index", timestamp))
+            Future.successful(Ok(views.html.index("Project Sidewalk")))
+          case "Blank" =>
+            WebpageActivityTable.save(WebpageActivity(0, anonymousUser.userId.toString, ipAddress, "Visit_Blank", timestamp))
+            Future.successful(Ok(views.html.blankIndex("Project Sidewalk")))
+        }
+    }
+  }
+
   /**
     * Audit a given region
     *

--- a/app/models/amt/AMTAssignmentTable.scala
+++ b/app/models/amt/AMTAssignmentTable.scala
@@ -67,7 +67,8 @@ object AMTAssignmentTable {
   }
 
   def getCountOfCompletedByTurkerId(turkerId: String): Int = db.withTransaction { implicit session =>
-    amtAssignments.filter(x => x.turkerId === turkerId && x.completed === true).length.run
+    val conditionId = TurkerTable.getConditionIdByTurkerId(turkerId).get
+    amtAssignments.filter(x => x.turkerId === turkerId && x.completed === true && x.conditionId === conditionId).length.run
   }
 
   /**

--- a/app/models/turker/TurkerTable.scala
+++ b/app/models/turker/TurkerTable.scala
@@ -48,4 +48,10 @@ object TurkerTable{
       (turkers returning turkers.map(_.turkerId)) += turker
     turkerId
   }
+
+  def updateConditionIdByTurkerId(turkerId: String, conditionId: Int) =  db.withTransaction { implicit session =>
+    val q = for{ turker <- turkers if turker.turkerId === turkerId} yield turker.amtConditionId
+    q.update(conditionId)
+  }
+
 }

--- a/conf/routes
+++ b/conf/routes
@@ -20,6 +20,7 @@ GET     /clustering                             @controllers.ClusteringSessionCo
 
 # Auditing tasks
 GET     /audit                                  @controllers.AuditController.audit
+GET     /auditCondition                         @controllers.AuditController.auditCondition
 GET     /audit/region/:id                       @controllers.AuditController.auditRegion(id: Int)
 GET     /audit/street/:id                       @controllers.AuditController.auditStreet(id: Int)
 POST    /audit/comment                          @controllers.AuditController.postComment


### PR DESCRIPTION
Procedure for testing is the same as #981 . There is now a separate endpoint auditCondition that takes the conditionId in the query string.

Visit the url http://localhost:9000/?assignmentId=some_string&workerId=some_string&hitId=some_string&conditionId=come_condition_id&turkSubmitTo=localhost:5000/post . This will automatically assign you to the specified condition id.

This will be useful for ground truth collection. HITs can be generated on MTurk sandbox with a mapping between HITs and conditions.