### PR TITLE
997 assign least audited region to new users

### DIFF
--- a/app/controllers/AuditController.scala
+++ b/app/controllers/AuditController.scala
@@ -59,7 +59,7 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
         nextRegion match {
           case Some("easy") =>
             // Assign an easy region is the query string has nextRegion=easy
-            UserCurrentRegionTable.assignNextEasyRegion(user.userId)
+            UserCurrentRegionTable.assignEasyRegion(user.userId)
             region = RegionTable.selectTheCurrentNamedRegion(user.userId)
           case Some("regular") =>
             // Assign an easy region is the query string has nextRegion=regular
@@ -114,7 +114,7 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
       case Some(user) =>
         WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, "Visit_Audit", timestamp))
 
-        UserCurrentRegionTable.assignNextEasyRegion(user.userId)
+        UserCurrentRegionTable.assignEasyRegion(user.userId)
 
         var region: Option[NamedRegion] = RegionTable.selectTheCurrentNamedRegion(user.userId)
         region = RegionTable.selectTheCurrentNamedRegion(user.userId)

--- a/app/controllers/AuditController.scala
+++ b/app/controllers/AuditController.scala
@@ -19,6 +19,7 @@ import models.street.{StreetEdgeAssignmentCountTable, StreetEdgeIssue, StreetEdg
 import models.user._
 import org.joda.time.{DateTime, DateTimeZone}
 import play.api.libs.json._
+import play.api.Logger
 import play.api.libs.concurrent.Execution.Implicits._
 import play.api.mvc._
 import play.api.Play.current
@@ -58,14 +59,16 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
 
         nextRegion match {
           case Some("easy") =>
-            // Assign an easy region is the query string has nextRegion=easy
+            // Assign an easy region if the query string has nextRegion=easy
             UserCurrentRegionTable.assignEasyRegion(user.userId)
             region = RegionTable.selectTheCurrentNamedRegion(user.userId)
           case Some("regular") =>
-            // Assign an easy region is the query string has nextRegion=regular
+            // Assign an easy region if the query string has nextRegion=regular
             UserCurrentRegionTable.assignNextRegion(user.userId)
             region = RegionTable.selectTheCurrentNamedRegion(user.userId)
-          case _ =>
+          case Some(illformedString) =>
+            Logger.warn(s"Parameter to audit must be \'easy\' or \'regular\', but \'$illformedString\' was passed.")
+          case None =>
             ;
         }
 

--- a/app/controllers/AuditController.scala
+++ b/app/controllers/AuditController.scala
@@ -71,6 +71,7 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
       case None =>
         WebpageActivityTable.save(WebpageActivity(0, anonymousUser.userId.toString, ipAddress, "Visit_Audit", timestamp))
         val region: Option[NamedRegion] = RegionTable.selectAnEasyNamedRegionRoundRobin
+        println(region.get.regionId)
         val task: NewTask = AuditTaskTable.selectANewTaskInARegion(region.get.regionId)
         Future.successful(Ok(views.html.audit("Project Sidewalk - Audit", Some(task), region, None)))
     }

--- a/app/controllers/AuditController.scala
+++ b/app/controllers/AuditController.scala
@@ -92,7 +92,7 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
       case None =>
         WebpageActivityTable.save(WebpageActivity(0, anonymousUser.userId.toString, ipAddress, "Visit_Audit", timestamp))
 
-        val region: Option[NamedRegion] = RegionTable.selectAnEasyNamedRegionRoundRobin
+        val region: Option[NamedRegion] = RegionTable.selectALeastAuditedEasyRegion
         val task: NewTask = AuditTaskTable.selectANewTaskInARegion(region.get.regionId)
         Future.successful(Ok(views.html.audit("Project Sidewalk - Audit", Some(task), region, None)))
     }
@@ -128,7 +128,7 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
       case None =>
         WebpageActivityTable.save(WebpageActivity(0, anonymousUser.userId.toString, ipAddress, "Visit_Audit", timestamp))
 
-        val region: Option[NamedRegion] = RegionTable.selectAnEasyNamedRegionRoundRobin
+        val region: Option[NamedRegion] = RegionTable.selectALeastAuditedEasyRegion
         val task: NewTask = AuditTaskTable.selectANewTaskInARegion(region.get.regionId)
         Future.successful(Ok(views.html.audit("Project Sidewalk - Audit", Some(task), region, None)))
     }

--- a/app/controllers/AuditController.scala
+++ b/app/controllers/AuditController.scala
@@ -40,7 +40,7 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
     *
     * @return
     */
-  def audit = UserAwareAction.async { implicit request =>
+  def audit(nextRegion: Option[Boolean]) = UserAwareAction.async { implicit request =>
     val now = new DateTime(DateTimeZone.UTC)
     val timestamp: Timestamp = new Timestamp(now.getMillis)
     val ipAddress: String = request.remoteAddress
@@ -51,14 +51,23 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
 
         // Check and make sure that the user has been assigned to a region
         if (!UserCurrentRegionTable.isAssigned(user.userId)) {
+          // Note: This condition is never true because a region is assigned immediately after the user signs up
           UserCurrentRegionTable.assignRandomly(user.userId)
         }
 
         var region: Option[NamedRegion] = RegionTable.selectTheCurrentNamedRegion(user.userId)
 
+        val nextRegionVal = nextRegion match {
+          case Some(next) =>
+            println("Within if else executing when next is set to: " + nextRegion.get)
+            nextRegion.get
+          case _ =>
+            false
+        }
         // Check if a user still has tasks available in this region.
         if (!AuditTaskTable.isTaskAvailable(user.userId, region.get.regionId) ||
-            !MissionTable.isMissionAvailable(user.userId, region.get.regionId)) {
+            !MissionTable.isMissionAvailable(user.userId, region.get.regionId) || nextRegionVal) {
+          //println("Executing when next is set to: " + nextRegion)
           UserCurrentRegionTable.assignNextRegion(user.userId)
           region = RegionTable.selectTheCurrentNamedRegion(user.userId)
         }
@@ -70,8 +79,8 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
         Future.successful(Ok(views.html.audit("Project Sidewalk - Audit", Some(task), region, Some(user))))
       case None =>
         WebpageActivityTable.save(WebpageActivity(0, anonymousUser.userId.toString, ipAddress, "Visit_Audit", timestamp))
+
         val region: Option[NamedRegion] = RegionTable.selectAnEasyNamedRegionRoundRobin
-        println(region.get.regionId)
         val task: NewTask = AuditTaskTable.selectANewTaskInARegion(region.get.regionId)
         Future.successful(Ok(views.html.audit("Project Sidewalk - Audit", Some(task), region, None)))
     }

--- a/app/controllers/AuditController.scala
+++ b/app/controllers/AuditController.scala
@@ -96,11 +96,17 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
             Future.successful(Ok(views.html.audit("Project Sidewalk - Audit", Some(task), region, Some(user))))
         }
       case None =>
-        WebpageActivityTable.save(WebpageActivity(0, anonymousUser.userId.toString, ipAddress, "Visit_Audit", timestamp))
+        nextRegion match {
+          case Some(regionType) =>
+            Logger.warn(s"Anon users cannot have region difficulty specified via a parameter, but $regionType was passed")
+            Future.successful(Redirect("/audit"))
+          case None =>
+            WebpageActivityTable.save(WebpageActivity(0, anonymousUser.userId.toString, ipAddress, "Visit_Audit", timestamp))
 
-        val region: Option[NamedRegion] = RegionTable.selectALeastAuditedEasyRegion
-        val task: NewTask = AuditTaskTable.selectANewTaskInARegion(region.get.regionId)
-        Future.successful(Ok(views.html.audit("Project Sidewalk - Audit", Some(task), region, None)))
+            val region: Option[NamedRegion] = RegionTable.selectALeastAuditedEasyRegion
+            val task: NewTask = AuditTaskTable.selectANewTaskInARegion(region.get.regionId)
+            Future.successful(Ok(views.html.audit("Project Sidewalk - Audit", Some(task), region, None)))
+        }
     }
   }
 

--- a/app/controllers/AuditController.scala
+++ b/app/controllers/AuditController.scala
@@ -52,7 +52,7 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
         // Check and make sure that the user has been assigned to a region
         if (!UserCurrentRegionTable.isAssigned(user.userId)) {
           // Note: This condition is never true because a region is assigned immediately after the user signs up
-          UserCurrentRegionTable.assignRandomly(user.userId)
+          UserCurrentRegionTable.assignEasyRegion(user.userId)
         }
 
         var region: Option[NamedRegion] = RegionTable.selectTheCurrentNamedRegion(user.userId)

--- a/app/controllers/CredentialsAuthController.scala
+++ b/app/controllers/CredentialsAuthController.scala
@@ -108,7 +108,7 @@ class CredentialsAuthController @Inject() (
     val updatedAuthenticator = authenticator.copy(expirationDate=expirationDate, idleTimeout = Some(2592000))
 
     if (!UserCurrentRegionTable.isAssigned(user.userId)) {
-      UserCurrentRegionTable.assignRandomly(user.userId)
+      UserCurrentRegionTable.assignEasyRegion(user.userId)
     }
 
     // Add Timestamp

--- a/app/controllers/RegionController.scala
+++ b/app/controllers/RegionController.scala
@@ -44,16 +44,18 @@ class RegionController @Inject() (implicit val env: Environment[User, SessionAut
 
             submission.regionId match {
               case Some(regId) =>
+                // Sets a region based on the request from the user
                 UserCurrentRegionTable.update(user.userId, regId)
                 regId
 
               case None =>
+                // Assigns a region to the user on request from a signed in user
                 UserCurrentRegionTable.assignNextRegion(user.userId)
                 val region = RegionTable.selectTheCurrentNamedRegion(user.userId)
                 region.get.regionId
             }
           case None =>
-          // Get a region for the anonymous user and return it
+          // Get a region for the anonymous user
             val region: Option[NamedRegion] = RegionTable.selectAnEasyNamedRegionRoundRobin
             region.get.regionId
         }

--- a/app/controllers/RegionController.scala
+++ b/app/controllers/RegionController.scala
@@ -66,6 +66,14 @@ class RegionController @Inject() (implicit val env: Environment[User, SessionAut
   }
 
   /**
+    * This returns the list of difficult neighborhood ids
+    * @return
+    */
+  def getDifficultNeighborhoods = UserAwareAction.async { implicit request =>
+    Future.successful(Ok(Json.obj("regionIds" -> UserCurrentRegionTable.difficultRegionIds)))
+  }
+
+  /**
     * This returns a list of all the streets stored in the database
     * @return
     */

--- a/app/controllers/RegionController.scala
+++ b/app/controllers/RegionController.scala
@@ -46,13 +46,10 @@ class RegionController @Inject() (implicit val env: Environment[User, SessionAut
               case Some(regId) =>
                 // Sets a region based on the request from the user
                 UserCurrentRegionTable.update(user.userId, regId)
-                regId
 
               case None =>
                 // Assigns a region to the user on request from a signed in user
                 UserCurrentRegionTable.assignNextRegion(user.userId)
-                val region = RegionTable.selectTheCurrentNamedRegion(user.userId)
-                region.get.regionId
             }
           case None =>
           // Get a region for the anonymous user

--- a/app/controllers/RegionController.scala
+++ b/app/controllers/RegionController.scala
@@ -53,7 +53,7 @@ class RegionController @Inject() (implicit val env: Environment[User, SessionAut
             }
           case None =>
           // Get a region for the anonymous user
-            val region: Option[NamedRegion] = RegionTable.selectAnEasyNamedRegionRoundRobin
+            val region: Option[NamedRegion] = RegionTable.selectALeastAuditedEasyRegion
             region.get.regionId
         }
 

--- a/app/controllers/SignUpController.scala
+++ b/app/controllers/SignUpController.scala
@@ -92,7 +92,7 @@ class SignUpController @Inject() (
                 } yield {
                   // Set the user role and assign the neighborhood to audit.
                   UserRoleTable.addUserRole(user.userId)
-                  UserCurrentRegionTable.assignRandomly(user.userId)
+                  UserCurrentRegionTable.assignEasyRegion(user.userId)
 
                   // Add Timestamp
                   val now = new DateTime(DateTimeZone.UTC)
@@ -153,7 +153,7 @@ class SignUpController @Inject() (
                 } yield {
                   // Set the user role and assign the neighborhood to audit.
                   UserRoleTable.addUserRole(user.userId)
-                  UserCurrentRegionTable.assignRandomly(user.userId)
+                  UserCurrentRegionTable.assignEasyRegion(user.userId)
 
                   // Add Timestamp
                   val now = new DateTime(DateTimeZone.UTC)

--- a/app/models/region/RegionTable.scala
+++ b/app/models/region/RegionTable.scala
@@ -161,7 +161,8 @@ object RegionTable {
     */
   def selectALeastAuditedEasyRegion: Option[NamedRegion] = db.withSession { implicit session =>
 
-    // Assign one of the least-audited regions that are easy.
+    // Assign one of the unaudited regions.
+    // TODO: Assign one of the least-audited regions that are easy.
     val completions: List[RegionCompletion] =
       RegionCompletionTable.regionCompletions
         .filterNot(_.regionId inSet UserCurrentRegionTable.difficultRegionIds)

--- a/app/models/region/RegionTable.scala
+++ b/app/models/region/RegionTable.scala
@@ -170,8 +170,7 @@ object RegionTable {
 
     val regionId: Int = completions match {
       case Nil =>
-        // Indicates amongst the unaudited regions of the user, there are no unaudited regions across all users
-        // In this case, pick any easy region amongst regions that are not audited by the user
+        // Indicates that there are no unaudited regions across all users. In this case, pick any easy region.
         val regionIds: List[Int] = namedRegions.list.map(_._1)
         scala.util.Random.shuffle(regionIds).filterNot(UserCurrentRegionTable.difficultRegionIds.contains(_)).head
       case _ =>

--- a/app/models/region/RegionTable.scala
+++ b/app/models/region/RegionTable.scala
@@ -121,6 +121,7 @@ object RegionTable {
     *
     * @return
     */
+  // TODO: #997 Needs update - give least audited region
   def selectANamedRegionRoundRobin(userId: UUID): Option[NamedRegion] = db.withSession { implicit session =>
     // If a novice user (audited less than 2 miles)
     if (StreetEdgeTable.getDistanceAudited(userId) < UserCurrentRegionTable.experiencedUserMileageThreshold) {
@@ -135,6 +136,7 @@ object RegionTable {
     *
     * @return
     */
+  // TODO: #997 Needs update - give least audited region
   def selectAnEasyNamedRegionRoundRobin: Option[NamedRegion] = db.withSession { implicit session =>
     // If the first one is an easy region, use it. O/w keep getting regions until we get an easy one (or we have
     // wrapped around back to the first region, meaning there are no easy regions left).

--- a/app/models/region/RegionTable.scala
+++ b/app/models/region/RegionTable.scala
@@ -3,6 +3,8 @@ package models.region
 import java.util.UUID
 
 import com.vividsolutions.jts.geom.Polygon
+import models.mission.MissionTable
+
 import math._
 import models.street.{StreetEdgeAssignmentCountTable, StreetEdgeTable}
 import models.user.UserCurrentRegionTable
@@ -121,7 +123,6 @@ object RegionTable {
     *
     * @return
     */
-  // TODO: #997 Needs update - give least audited region
   def selectANamedRegionRoundRobin(userId: UUID): Option[NamedRegion] = db.withSession { implicit session =>
     // If a novice user (audited less than 2 miles)
     if (StreetEdgeTable.getDistanceAudited(userId) < UserCurrentRegionTable.experiencedUserMileageThreshold) {

--- a/app/models/region/RegionTable.scala
+++ b/app/models/region/RegionTable.scala
@@ -125,7 +125,7 @@ object RegionTable {
   def selectANamedRegionRoundRobin(userId: UUID): Option[NamedRegion] = db.withSession { implicit session =>
     // If a novice user (audited less than 2 miles)
     if (StreetEdgeTable.getDistanceAudited(userId) < UserCurrentRegionTable.experiencedUserMileageThreshold) {
-      selectALeastAuditedEasyRegion
+      selectAnEasyNamedRegionRoundRobin
     } else {
       Some(namedRegionRoundRobin.next)
     }

--- a/app/models/user/UserCurrentRegionTable.scala
+++ b/app/models/user/UserCurrentRegionTable.scala
@@ -76,6 +76,8 @@ object UserCurrentRegionTable {
       save(userId, regionId)
       regionId
     } else {
+      // TODO: Which case would this be? This function is only called immediately after signing up or when the user
+      // visits the audit region which a current region being assigned
       assignNextRegion(userId)
     }
   }

--- a/app/models/user/UserCurrentRegionTable.scala
+++ b/app/models/user/UserCurrentRegionTable.scala
@@ -77,7 +77,7 @@ object UserCurrentRegionTable {
       regionId
     } else {
       // TODO: Which case would this be? This function is only called immediately after signing up or when the user
-      // visits the audit region which a current region being assigned
+      // visits the audit page when a current region is not yet assigned
       assignNextRegion(userId)
     }
   }

--- a/app/models/user/UserCurrentRegionTable.scala
+++ b/app/models/user/UserCurrentRegionTable.scala
@@ -95,7 +95,7 @@ object UserCurrentRegionTable {
         // In this case, pick any easy region amongst regions that are not audited by the user
         scala.util.Random.shuffle(regionIds).filterNot(difficultRegionIds.contains(_)).head
       case _ =>
-        // Pick an easy regions that is least audited
+        // Pick an easy region that is least audited
         scala.util.Random.shuffle(completions).head.regionId
 
     }

--- a/app/models/user/UserCurrentRegionTable.scala
+++ b/app/models/user/UserCurrentRegionTable.scala
@@ -55,7 +55,6 @@ object UserCurrentRegionTable {
     * @param userId user id
     * @return region id
     */
-  // TODO: #997 Needs update - give least audited region
   def assignRandomly(userId: UUID): Int = db.withSession { implicit session =>
     // Check if there are any records
     val _currentRegions = for {
@@ -76,8 +75,8 @@ object UserCurrentRegionTable {
       save(userId, regionId)
       regionId
     } else {
-      // TODO: Which case would this be? This function is only called immediately after signing up or when the user
-      // visits the audit page when a current region is not yet assigned
+      // TODO: Which case would this be? assignRandomly function is only called immediately after signing up or when the
+      // user visits the audit page when a current region is not yet assigned
       assignNextRegion(userId)
     }
   }

--- a/app/models/user/UserCurrentRegionTable.scala
+++ b/app/models/user/UserCurrentRegionTable.scala
@@ -50,30 +50,6 @@ object UserCurrentRegionTable {
   }
 
   /**
-    * Assign a region to the given user. This is used for the initial assignment.
-    *
-    * @param userId user id
-    * @return region id
-    */
-  def assignRandomly(userId: UUID): Int = db.withSession { implicit session =>
-    // Check if there are any records
-    val _currentRegions = for {
-      (_regions, _currentRegions) <- neighborhoods.innerJoin(userCurrentRegions).on(_.regionId === _.regionId)
-      if _currentRegions.userId === userId.toString
-    } yield _currentRegions
-    val currentRegionList = _currentRegions.list
-
-    if (currentRegionList.isEmpty) {
-      // For a new user whose current region is not assigned, assign an easy least audited region
-      assignEasyRegion(userId)
-    } else {
-      // Note: Which case would this be? assignRandomly() is only called immediately after signing up or when the
-      // user visits the audit page when a current region is not yet assigned
-      assignNextRegion(userId)
-    }
-  }
-
-  /**
     * Select an easy region (if any left) where the user hasn't completed all missions and assign that region to them.
     * @param userId
     * @return

--- a/app/models/user/UserCurrentRegionTable.scala
+++ b/app/models/user/UserCurrentRegionTable.scala
@@ -57,7 +57,8 @@ object UserCurrentRegionTable {
   def assignEasyRegion(userId: UUID): Int = db.withSession { implicit session =>
     val regionIds: Set[Int] = MissionTable.selectIncompleteRegions(userId)
 
-    // Assign one of the least-audited regions that are easy.
+    // Assign one of the unaudited regions that are easy.
+    // TODO: Assign one of the least-audited regions that are easy.
     val completions: List[RegionCompletion] =
       RegionCompletionTable.regionCompletions
         .filter(_.regionId inSet regionIds)
@@ -71,7 +72,8 @@ object UserCurrentRegionTable {
         // In this case, pick any easy region amongst regions that are not audited by the user
         scala.util.Random.shuffle(regionIds).filterNot(difficultRegionIds.contains(_)).head
       case _ =>
-        // Pick an easy region that is least audited
+        // Pick an easy region that is unaudited.
+        // TODO: Pick an easy region that is least audited.
         scala.util.Random.shuffle(completions).head.regionId
 
     }

--- a/app/models/user/UserCurrentRegionTable.scala
+++ b/app/models/user/UserCurrentRegionTable.scala
@@ -64,20 +64,46 @@ object UserCurrentRegionTable {
     val currentRegionList = _currentRegions.list
 
     if (currentRegionList.isEmpty) {
-      // For a new user whose current region is not assigned
-      val region: Option[NamedRegion] = RegionTable.selectANamedRegionRoundRobin(userId)
+      // For a new user whose current region is not assigned, assign an easy least audited region
+      assignEasyRegion(userId)
+    } else {
+      // Note: Which case would this be? assignRandomly() is only called immediately after signing up or when the
+      // user visits the audit page when a current region is not yet assigned
+      assignNextRegion(userId)
+    }
+  }
 
-      val regionId: Int = if (region.isDefined) {
-        region.get.regionId
-      } else {
-        scala.util.Random.shuffle(neighborhoods.list).map(_.regionId).filterNot(difficultRegionIds.contains(_)).head
-      }
+  /**
+    * Select an easy region (if any left) where the user hasn't completed all missions and assign that region to them.
+    * @param userId
+    * @return
+    */
+  def assignEasyRegion(userId: UUID): Int = db.withSession { implicit session =>
+    val regionIds: Set[Int] = MissionTable.selectIncompleteRegions(userId)
+
+    // Assign one of the least-audited regions that are easy.
+    val completions: List[RegionCompletion] =
+      RegionCompletionTable.regionCompletions
+        .filter(_.regionId inSet regionIds)
+        .filterNot(_.regionId inSet difficultRegionIds)
+        .filter(region => region.auditedDistance / region.totalDistance < 1.0)
+        .sortBy(region => region.auditedDistance / region.totalDistance).take(10).list
+
+    val regionId: Int = completions match {
+      case Nil =>
+        // Indicates amongst the unaudited regions of the user, there are no unaudited regions across all users
+        // In this case, pick any easy region amongst regions that are not audited by the user
+        scala.util.Random.shuffle(regionIds).filterNot(difficultRegionIds.contains(_)).head
+      case _ =>
+        // Pick an easy regions that is least audited
+        scala.util.Random.shuffle(completions).head.regionId
+
+    }
+    if (!isAssigned(userId)) {
       save(userId, regionId)
       regionId
     } else {
-      // TODO: Which case would this be? assignRandomly function is only called immediately after signing up or when the
-      // user visits the audit page when a current region is not yet assigned
-      assignNextRegion(userId)
+      update(userId, regionId)
     }
   }
 
@@ -97,46 +123,17 @@ object UserCurrentRegionTable {
         .filter(region => region.auditedDistance / region.totalDistance < 1.0)
         .sortBy(region => region.auditedDistance / region.totalDistance).list
 
-    // if they have audited less than 2 miles and there is an easy region left (or if there are no difficult regions
+    // If they have audited less than 2 miles and there is an easy region left (or if there are no difficult regions
     // left to finish), give them an easy one
     if ((regionIds.filterNot(difficultRegionIds.contains(_)).nonEmpty && !isUserExperienced(userId)) ||
         difficultRegionCompletions.isEmpty) {
-      assignNextEasyRegion(userId)
+      assignEasyRegion(userId)
     }
     else {
-      // take the least-audited difficult region
+      // Take the least-audited difficult region
       val regionId = scala.util.Random.shuffle(regionIds.intersect(difficultRegionIds.toSet)).head
       update(userId, regionId)
     }
-  }
-
-  /**
-    * Select an easy region (if any left) where the user hasn't completed all missions and assign that region to them.
-    * @param userId
-    * @return
-    */
-  def assignNextEasyRegion(userId: UUID): Int = db.withSession { implicit session =>
-    val regionIds: Set[Int] = MissionTable.selectIncompleteRegions(userId)
-
-    // Assign one of the least-audited regions that are easy.
-    val completions: List[RegionCompletion] =
-      RegionCompletionTable.regionCompletions
-        .filter(_.regionId inSet regionIds)
-        .filterNot(_.regionId inSet difficultRegionIds)
-        .filter(region => region.auditedDistance / region.totalDistance < 1.0)
-        .sortBy(region => region.auditedDistance / region.totalDistance).take(10).list
-
-    val regionId: Int = completions match {
-      case Nil =>
-        // Indicates amongst the unaudited regions of the user, there are no unaudited regions across all users
-        // In this case, pick any easy region amongst regions that are not audited by the user
-        scala.util.Random.shuffle(regionIds).head
-      case _ =>
-        // Pick an easy regions that is least audited
-        scala.util.Random.shuffle(completions).head.regionId
-
-    }
-    update(userId, regionId)
   }
 
   /**

--- a/app/views/accessScoreDemo.scala.html
+++ b/app/views/accessScoreDemo.scala.html
@@ -25,7 +25,7 @@
             </p>
             <p>
                 Note, <u>we don't have enough data to reliably calculate Access Score for some neighborhoods (yet).</u> Wanna help us improve it?
-                    <a href='@routes.AuditController.audit'>Participate in accessibility audit!</a>
+                    <a href='@routes.AuditController.audit(None)'>Participate in accessibility audit!</a>
             </p>
             <table class="table">
                 <tr>

--- a/app/views/accessScoreDemo.scala.html
+++ b/app/views/accessScoreDemo.scala.html
@@ -25,7 +25,7 @@
             </p>
             <p>
                 Note, <u>we don't have enough data to reliably calculate Access Score for some neighborhoods (yet).</u> Wanna help us improve it?
-                    <a href='@routes.AuditController.audit(None)'>Participate in accessibility audit!</a>
+                    <a href='@routes.AuditController.audit()'>Participate in accessibility audit!</a>
             </p>
             <table class="table">
                 <tr>

--- a/app/views/audit.scala.html
+++ b/app/views/audit.scala.html
@@ -702,7 +702,7 @@
             });
 
             $('#redirect-advanced').on('click', function(){
-                $(location).attr('href', '/audit/easyRegion');
+                $(location).attr('href', '/audit?nextRegion=easy');
             });
         });
 

--- a/app/views/developer.scala.html
+++ b/app/views/developer.scala.html
@@ -265,7 +265,7 @@
                     <li>We are focusing on collecting data only from Washington, D.C. at the moment.</li>
                     <li>Since we have only covered @("%.0f".format(StreetEdgeTable.streetDistanceCompletionRate(1) * 100))% of DC,
                         there are neighborhoods where we currently have very little accessibility data.
-                        Note: You can help us by <a href='@routes.AuditController.audit'>contributing to data collection</a> too ;-).</li>
+                        Note: You can help us by <a href='@routes.AuditController.audit(None)'>contributing to data collection</a> too ;-).</li>
                 </ol>
             </div>
         </div>

--- a/app/views/developer.scala.html
+++ b/app/views/developer.scala.html
@@ -265,7 +265,7 @@
                     <li>We are focusing on collecting data only from Washington, D.C. at the moment.</li>
                     <li>Since we have only covered @("%.0f".format(StreetEdgeTable.streetDistanceCompletionRate(1) * 100))% of DC,
                         there are neighborhoods where we currently have very little accessibility data.
-                        Note: You can help us by <a href='@routes.AuditController.audit(None)'>contributing to data collection</a> too ;-).</li>
+                        Note: You can help us by <a href='@routes.AuditController.audit()'>contributing to data collection</a> too ;-).</li>
                 </ol>
             </div>
         </div>

--- a/app/views/faq.scala.html
+++ b/app/views/faq.scala.html
@@ -33,7 +33,7 @@
                             </p>
                             <ol>
                                 <li>
-                                    Click <a href='@routes.AuditController.audit'>Start Mapping</a>.
+                                    Click <a href='@routes.AuditController.audit(None)'>Start Mapping</a>.
                                 </li>
                                 <li>
                                     Take an interactive tutorial to learn how to use our tool (if you haven't taken it before).

--- a/app/views/faq.scala.html
+++ b/app/views/faq.scala.html
@@ -33,7 +33,7 @@
                             </p>
                             <ol>
                                 <li>
-                                    Click <a href='@routes.AuditController.audit(None)'>Start Mapping</a>.
+                                    Click <a href='@routes.AuditController.audit()'>Start Mapping</a>.
                                 </li>
                                 <li>
                                     Take an interactive tutorial to learn how to use our tool (if you haven't taken it before).

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -33,7 +33,7 @@
                         <span class="tagline">Let's create a path for everyone</span>
                     </p>
                     <br>
-                    <button class="bodyStartBtn" onclick="location.href = '@routes.AuditController.audit(None)';">Start Mapping</button>
+                    <button class="bodyStartBtn" onclick="location.href = '@routes.AuditController.audit()';">Start Mapping</button>
                     <br><br>
 
                 </div>

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -33,7 +33,7 @@
                         <span class="tagline">Let's create a path for everyone</span>
                     </p>
                     <br>
-                    <button class="bodyStartBtn" onclick="location.href = '@routes.AuditController.audit';">Start Mapping</button>
+                    <button class="bodyStartBtn" onclick="location.href = '@routes.AuditController.audit(None)';">Start Mapping</button>
                     <br><br>
 
                 </div>

--- a/app/views/navbar.scala.html
+++ b/app/views/navbar.scala.html
@@ -21,7 +21,7 @@
                 @if(url.isDefined && url.get != "/audit") {
 
                     <li class="active">
-                        <button class="navbarStartBtn" onclick="location.href='@routes.AuditController.audit'">Start Mapping</button>
+                        <button class="navbarStartBtn" onclick="location.href='@routes.AuditController.audit(None)'">Start Mapping</button>
                     </li>
                     <li class="active">
                         <button class="navbarResultsBtn" onclick="location.href='@routes.ApplicationController.results'">See Results</button>

--- a/app/views/navbar.scala.html
+++ b/app/views/navbar.scala.html
@@ -21,7 +21,7 @@
                 @if(url.isDefined && url.get != "/audit") {
 
                     <li class="active">
-                        <button class="navbarStartBtn" onclick="location.href='@routes.AuditController.audit(None)'">Start Mapping</button>
+                        <button class="navbarStartBtn" onclick="location.href='@routes.AuditController.audit()'">Start Mapping</button>
                     </li>
                     <li class="active">
                         <button class="navbarResultsBtn" onclick="location.href='@routes.ApplicationController.results'">See Results</button>

--- a/app/views/student.scala.html
+++ b/app/views/student.scala.html
@@ -15,7 +15,7 @@
                         (e.g., my id is khara and email address is khara@@umd.edu, so I will use them for the login info).
                     </li>
                     <li>
-                        Click <a href='@routes.AuditController.audit(None)'>Start Auditing</a> and <span class="bold">complete 5 missions.</span>
+                        Click <a href='@routes.AuditController.audit()'>Start Auditing</a> and <span class="bold">complete 5 missions.</span>
                             Keep logged in while you are auditing so I can keep track of your progress!
                     </li>
                     <li>

--- a/app/views/student.scala.html
+++ b/app/views/student.scala.html
@@ -15,7 +15,7 @@
                         (e.g., my id is khara and email address is khara@@umd.edu, so I will use them for the login info).
                     </li>
                     <li>
-                        Click <a href='@routes.AuditController.audit'>Start Auditing</a> and <span class="bold">complete 5 missions.</span>
+                        Click <a href='@routes.AuditController.audit(None)'>Start Auditing</a> and <span class="bold">complete 5 missions.</span>
                             Keep logged in while you are auditing so I can keep track of your progress!
                     </li>
                     <li>

--- a/conf/routes
+++ b/conf/routes
@@ -57,8 +57,8 @@ GET     /adminapi/numWebpageActivity/:activity/*keyValPairs  @controllers.AdminC
 GET     /adminapi/choroplethCounts                           @controllers.AdminController.getRegionNegativeLabelCounts
 
 # Auditing tasks
-GET     /audit                                               @controllers.AuditController.audit(nextRegion: Option[Boolean] ?= None)
-GET     /audit/easyRegion                                    @controllers.AuditController.auditNewEasyRegion
+GET     /audit                                               @controllers.AuditController.audit(nextRegion: Option[String] ?= None)
+#GET     /audit/easyRegion                                    @controllers.AuditController.auditNewEasyRegion
 GET     /audit/region/:id                                    @controllers.AuditController.auditRegion(id: Int)
 GET     /audit/street/:id                                    @controllers.AuditController.auditStreet(id: Int)
 POST    /audit/comment                                       @controllers.AuditController.postComment

--- a/conf/routes
+++ b/conf/routes
@@ -57,7 +57,7 @@ GET     /adminapi/numWebpageActivity/:activity/*keyValPairs  @controllers.AdminC
 GET     /adminapi/choroplethCounts                           @controllers.AdminController.getRegionNegativeLabelCounts
 
 # Auditing tasks
-GET     /audit                                               @controllers.AuditController.audit
+GET     /audit                                               @controllers.AuditController.audit(nextRegion: Option[Boolean] ?= None)
 GET     /audit/easyRegion                                    @controllers.AuditController.auditNewEasyRegion
 GET     /audit/region/:id                                    @controllers.AuditController.auditRegion(id: Int)
 GET     /audit/street/:id                                    @controllers.AuditController.auditStreet(id: Int)

--- a/conf/routes
+++ b/conf/routes
@@ -79,6 +79,7 @@ GET     /label/currentMission                                @controllers.LabelC
 
 # Neighborhoods
 GET     /neighborhoods                                       @controllers.RegionController.listNeighborhoods
+GET     /neighborhoods/difficult                             @controllers.RegionController.getDifficultNeighborhoods
 POST    /neighborhood/assignment                             @controllers.RegionController.assignANewRegion
 
 # Map Edit

--- a/conf/routes
+++ b/conf/routes
@@ -79,7 +79,7 @@ GET     /label/currentMission                                @controllers.LabelC
 
 # Neighborhoods
 GET     /neighborhoods                                       @controllers.RegionController.listNeighborhoods
-POST    /neighborhood/assignment                             @controllers.RegionController.setANewRegion
+POST    /neighborhood/assignment                             @controllers.RegionController.assignANewRegion
 
 # Map Edit
 GET     /map/edit                                            @controllers.MapController.edit

--- a/public/javascripts/SVLabel/spec/SVLabel/mission/MissionProgress-spec.js
+++ b/public/javascripts/SVLabel/spec/SVLabel/mission/MissionProgress-spec.js
@@ -25,7 +25,7 @@ describe("MissionProgress module", function () {
         neighborhoodModel = _.clone(Backbone.Events);
 
         neighborhoodModel.getNeighborhood = function (regionId) { return new NeighborhoodMock(regionId); };
-        neighborhoodModel.moveToANewRegion = function (regionId) { };
+        neighborhoodModel.updateUserRegionInDatabase = function (regionId) { };
 
         statusModel = _.clone(Backbone.Events);
         missionContainer = new MissionContainerMock();
@@ -155,7 +155,7 @@ describe("MissionProgress module", function () {
 
     describe("`_updateTheCurrentNeighborhood` method", function () {
         beforeEach(function () {
-            neighborhoodModel.moveToANewRegion = function (neighborhood) { };
+            neighborhoodModel.updateUserRegionInDatabase = function (neighborhood) { };
             spyOn(neighborhoodContainer, 'setCurrentNeighborhood');
             spyOn(neighborhoodModel, 'moveToANewRegion');
             spyOn(taskContainer, 'fetchTasksInARegion');
@@ -168,7 +168,7 @@ describe("MissionProgress module", function () {
 
         it("should call `NeighborhoodModel.moveToANewRegion`", function () {
             missionProgress._updateTheCurrentNeighborhood(mission, neighborhood);
-            expect(neighborhoodModel.moveToANewRegion).toHaveBeenCalled();
+            expect(neighborhoodModel.updateUserRegionInDatabase).toHaveBeenCalled();
         });
 
         it("should call `TaskContainer.fetchTasksInARegion`", function () {
@@ -218,7 +218,7 @@ describe("MissionProgress module", function () {
         it("should should call `NeighborhoodModel.moveToANewRegion`", function () {
             var neighborhood = new NeighborhoodMock(100);
             missionProgress._updateTheCurrentNeighborhood(neighborhood);
-            expect(neighborhoodModel.moveToANewRegion).toHaveBeenCalledWith(100);
+            expect(neighborhoodModel.updateUserRegionInDatabase).toHaveBeenCalledWith(100);
         });
 
         it("should call `TaskContainer.endTask`", function () {

--- a/public/javascripts/SVLabel/spec/SVLabel/neighborhood/NeighborhoodModel-spec.js
+++ b/public/javascripts/SVLabel/spec/SVLabel/neighborhood/NeighborhoodModel-spec.js
@@ -70,7 +70,7 @@ describe("NeighborhoodModel module.", function () {
 
         it("should call `moveToANewRegion` method", function () {
             neighborhoodModel.neighborhoodCompleted(1);
-            expect(neighborhoodModel.moveToANewRegion).toHaveBeenCalled();
+            expect(neighborhoodModel.updateUserRegionInDatabase).toHaveBeenCalled();
         });
 
         it("should call `NeighborhoodContainer.setCurrentNeighborhood`", function () {

--- a/public/javascripts/SVLabel/src/SVLabel/Main.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Main.js
@@ -497,7 +497,6 @@ function Main (params) {
                 regionId = currentNeighborhood.getProperty("regionId");
             else
                 regionId = null;
-            console.log("Assigned Region: " + regionId);
 
             // TODO: This case will execute when the entire city is audited by the user. Should handle properly!
             if (regionId === null) return;  // No missions available.

--- a/public/javascripts/SVLabel/src/SVLabel/Main.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Main.js
@@ -18,6 +18,8 @@ function Main (params) {
     var loadingTasksCompleted = false;
     var loadingMissionsCompleted = false;
     var loadNeighborhoodsCompleted = false;
+    var loadDifficultNeighborhoodsCompleted = false;
+
 
     svl.rootDirectory = ('rootDirectory' in params) ? params.rootDirectory : '/';
     svl.onboarding = null;
@@ -271,6 +273,11 @@ function Main (params) {
             loadNeighborhoodsCompleted = true;
             handleDataLoadComplete();
         });
+
+        neighborhoodModel.fetchDifficultNeighborhoods(function () {
+            loadDifficultNeighborhoodsCompleted = true;
+            handleDataLoadComplete();
+        });
     }
 
     function hasCompletedOnboarding(completedMissions) {
@@ -413,7 +420,8 @@ function Main (params) {
     // This is a callback function that is executed after every loading process is done.
     function handleDataLoadComplete () {
         if (loadingAnOnboardingTaskCompleted && loadingTasksCompleted &&
-            loadingMissionsCompleted && loadNeighborhoodsCompleted) {
+            loadingMissionsCompleted && loadNeighborhoodsCompleted &&
+            loadDifficultNeighborhoodsCompleted) {
             // Check if the user has completed the onboarding tutorial..
             var completedMissions = svl.missionContainer.getCompletedMissions();
             var currentNeighborhood = svl.neighborhoodContainer.getStatus("currentNeighborhood");
@@ -441,8 +449,7 @@ function Main (params) {
                 $("#mini-footer-audit").css("visibility", "visible");
 
                 var regionId = currentNeighborhood.getProperty("regionId");
-                // TODO: Get difficult regions ids from the server
-                var difficultRegionIds = [251, 281, 317, 366];
+                var difficultRegionIds = svl.neighborhoodModel.difficultRegionIds;
                 if(difficultRegionIds.includes(regionId)){
                     $('#advanced-overlay').show();
                 }

--- a/public/javascripts/SVLabel/src/SVLabel/mission/MissionContainer.js
+++ b/public/javascripts/SVLabel/src/SVLabel/mission/MissionContainer.js
@@ -126,9 +126,9 @@ function MissionContainer (statusFieldMission, missionModel, taskModel) {
         var missions = self._missionStoreByRegionId[regionId];
 
         for (var i = 0, len = missions.length; i < len; i++) {
-            if (missions[i].getProperty("label") == label) {
+            if (missions[i].getProperty("label") === label) {
                 if (level) {
-                    if (level == missions[i].getProperty("level")) {
+                    if (level === missions[i].getProperty("level")) {
                         return missions[i];
                     }
                 } else {
@@ -223,7 +223,7 @@ function MissionContainer (statusFieldMission, missionModel, taskModel) {
         var currentRegionId = currentRegionId.toString();
         var regionIds = Object.keys(self._missionStoreByRegionId);
         regionIds = regionIds.map(function (key) { return key.toString(); });
-        regionIds = regionIds.filter(function (regionId) { return regionId != "noRegionId"; });
+        regionIds = regionIds.filter(function (regionId) { return regionId !== "noRegionId"; });
 
         var currentRegionIdIndex = regionIds.indexOf(currentRegionId);
         var nextRegionIdIndex = currentRegionIdIndex + 1;
@@ -237,9 +237,9 @@ function MissionContainer (statusFieldMission, missionModel, taskModel) {
         var nextRegionId = self._getANextRegionId(currentRegionId);
         var missions = self._missionStoreByRegionId[nextRegionId];
         missions = missions.filter(function (m) { return !m.isCompleted(); });
-        while (missions.length == 0) {
+        while (missions.length === 0) {
             nextRegionId = self._getANextRegionId(nextRegionId);
-            if (nextRegionId == currentRegionId) throw Error("No missions available");
+            if (nextRegionId === currentRegionId) throw Error("No missions available");
             missions = self._missionStoreByRegionId[nextRegionId];
             missions = missions.filter(function (m) { return !m.isCompleted(); });
         }

--- a/public/javascripts/SVLabel/src/SVLabel/mission/MissionProgress.js
+++ b/public/javascripts/SVLabel/src/SVLabel/mission/MissionProgress.js
@@ -120,7 +120,7 @@ function MissionProgress (svl, gameEffectModel, missionModel, modalModel, neighb
     this._updateTheCurrentNeighborhood = function (neighborhood) {
         var neighborhoodId = neighborhood.getProperty("regionId");
         neighborhoodContainer.setCurrentNeighborhood(neighborhood);
-        neighborhoodModel.moveToANewRegion(neighborhoodId);
+        neighborhoodModel.updateUserRegionInDatabase(neighborhoodId);
 
         var currentTask = taskContainer.getCurrentTask();
         taskContainer.endTask(currentTask);

--- a/public/javascripts/SVLabel/src/SVLabel/neighborhood/NeighborhoodModel.js
+++ b/public/javascripts/SVLabel/src/SVLabel/neighborhood/NeighborhoodModel.js
@@ -26,8 +26,8 @@ function NeighborhoodModel () {
         }
     };
 
-    this.fetchDifficultNeighborhoods = function () {
-        $.ajax({
+    this.fetchDifficultNeighborhoods = function (callback) {
+        $.when($.ajax({
             contentType: 'application/json; charset=utf-8',
             url: "/neighborhoods/difficult",
             type: 'get',
@@ -37,7 +37,7 @@ function NeighborhoodModel () {
             error: function (result) {
                 throw result;
             }
-        });
+        })).done(callback);
     };
     
     this.fetchNextLeastAuditedRegion = function (async) {

--- a/public/javascripts/SVLabel/src/SVLabel/neighborhood/NeighborhoodModel.js
+++ b/public/javascripts/SVLabel/src/SVLabel/neighborhood/NeighborhoodModel.js
@@ -25,15 +25,25 @@ function NeighborhoodModel () {
         }
     };
     
-    this.fetchNextLeastAuditedRegion = function (username, async, callback) {
+    this.fetchNextLeastAuditedRegion = function (async) {
         if (typeof async === "undefined") async = true;
         $.ajax({
             async: async,
-            url: "/neighborhoods/" + username, // Needs change - URL incorrect
-            type: 'get',
+            contentType: 'application/json; charset=utf-8',
+            url: "/neighborhood/assignment",
+            type: 'post',
+            data: JSON.stringify({"region_id": null}),
+            dataType: 'json',
             success: function (json) {
-                self._handleFetchComplete(json);
-                if (callback) callback();
+                var regionId = json.region_id;
+                if (regionId) {
+                    var neighborhood = svl.neighborhoodContainer.get(json.region_id);
+                    self.setCurrentNeighborhood(neighborhood);
+                } else {
+                    // When no region is left to assign to the user
+                    self.setCurrentNeighborhood(null);
+                    console.error("No regions to assign to the user!");
+                }
             },
             error: function (result) {
                 throw result;
@@ -58,10 +68,10 @@ NeighborhoodModel.prototype.currentNeighborhood = function () {
 };
 
 /**
- * Todo. The method name is confusing. Make it clear that this method just updates the remote database.
+ *
  * @param regionId
  */
-NeighborhoodModel.prototype.moveToANewRegion = function (regionId) {
+NeighborhoodModel.prototype.updateUserRegionInDatabase = function (regionId) {
     regionId = parseInt(regionId, 10);
     var url = "/neighborhood/assignment";
     $.ajax({

--- a/public/javascripts/SVLabel/src/SVLabel/neighborhood/NeighborhoodModel.js
+++ b/public/javascripts/SVLabel/src/SVLabel/neighborhood/NeighborhoodModel.js
@@ -3,6 +3,7 @@ function NeighborhoodModel () {
     this._neighborhoodContainer = null;
     this.isNeighborhoodCompleted = false;
     this.isNeighborhoodCompletedAcrossAllUsers = null;
+    this.difficultRegionIds = [];
 
     this._handleFetchComplete = function (geojson) {
         var geojsonLayer = L.geoJson(geojson);
@@ -23,6 +24,20 @@ function NeighborhoodModel () {
         } else {
             $.when($.ajax("/neighborhoods")).done(self._handleFetchComplete)
         }
+    };
+
+    this.fetchDifficultNeighborhoods = function () {
+        $.ajax({
+            contentType: 'application/json; charset=utf-8',
+            url: "/neighborhoods/difficult",
+            type: 'get',
+            success: function (json) {
+                self.difficultRegionIds = json.regionIds;
+            },
+            error: function (result) {
+                throw result;
+            }
+        });
     };
     
     this.fetchNextLeastAuditedRegion = function (async) {


### PR DESCRIPTION
Resolves #997 

- Updated front-end to assign a least audited new region to a registered user when the user selects a region that has already been completely audited by them
- Modified `assignRandomly()` function to now assign regions that are least audited for a new registered user
- Modify the method that assigns an easy region to an anonymous user to get least audited regions
- Updated `/audit` controller to take query string in the following way:
     - `/audit?nextRegion=easy` --> it will assign easy regions to a registered user -- Used for the screen that is shown when a difficult neighborhood is chosen. Accordingly, updated the link on the front end to use this. Therefore, user of `/audit/easyRegion` has been deprecated. (Added in PR #832)
     - `/audit?nextRegion=regular` --> for signed in user, to be assigned a new region based on their experience level  and for anon user, another easy region -- Would be used when the neighborhood completion (across all users) screen - for the button that takes the user to a new region if they choose that option. (Issue #926)
    
     Both set the URL back to `/audit` to avoid any confusion for the user.

To test, try different combinations of query string to check if it works. No new region should be assigned if the string is not the appropriate one or if no query string is given. Also, test for new registered user if the regions are being assigned correctly, as well as a experienced registered user. Finally, check that anonymous users are always assigned an easy least audited region.