### PR TITLE
926 overlay post neighborhood completion

### DIFF
--- a/app/views/audit.scala.html
+++ b/app/views/audit.scala.html
@@ -20,16 +20,33 @@
 
     <div class="container toolUI" style = "visibility: hidden;">
         <div id="advanced-overlay">
-            <div id="overlay-text">
+            <div class="overlay-text">
                 <div id="advanced-neighborhood-text">
                     <p>
-                        <b>Notice:</b> This neighborhood is difficult to travel, and is only recommended for experienced users. Are you sure you would like to explore this neighborhood?
+                        <span class="overlay-header">Advanced Neighborhood</span>
+                    </p>
+                    <p>
+                        <b>Warning:</b> This neighborhood is difficult to travel, and is only recommended for experienced users. Are you sure you would like to explore this neighborhood?
                     </p>
                     <p>
                         If you get stuck, click the Jump button to navigate to a different area.
                     </p>
-                    <span class="advanced-neighborhood-option" id="continue-advanced">Yes, continue</span>
-                    <span class="advanced-neighborhood-option" id="redirect-advanced">No, take me somewhere else</span>
+                    <span class="overlay-option" id="continue-advanced">Yes, continue in this neighborhood</span>
+                    <span class="overlay-option" id="redirect-advanced">No, go to another neighborhood</span>
+                </div>
+            </div>
+        </div>
+        <div id="neighborhood-completion-overlay">
+            <div class="overlay-text">
+                <div id="neighborhood-completion-text">
+                    <p>
+                        <span class="overlay-header">Neighborhood Completed!</span>
+                    </p>
+                    <p>
+                        <b>Hurray!</b> You just helped complete this neighborhood! You can:
+                    </p>
+                    <span class="overlay-option" id="continue-current">Continue in this neighborhood</span>
+                    <span class="overlay-option" id="redirect-new">Go to a new neighborhood</span>
                 </div>
             </div>
         </div>
@@ -634,6 +651,7 @@
     <script type="text/javascript">
         // Todo. Try to move the following code to Main.js
         var svl = svl || {};
+        var mainParam = {};
         svl.storage = new TemporaryStorage(JSON);
         if (!("tracker" in svl)) {
             svl.tracker = new Tracker();
@@ -697,12 +715,24 @@
             document.onselectstart = function () { return false; };
             enableTouchSupport();
 
+            // Advanced Neighborhood Overlay
             $('#continue-advanced').on('click', function(){
+                mainParam.advancedOverlay = false;
                 $('#advanced-overlay').hide();
             });
 
             $('#redirect-advanced').on('click', function(){
+                mainParam.advancedOverlay = false;
                 $(location).attr('href', '/audit?nextRegion=easy');
+            });
+
+            // Neighborhood Completion Overlay
+            $('#continue-current').on('click', function(){
+                $('#neighborhood-completion-overlay').hide();
+            });
+
+            $('#redirect-new').on('click', function(){
+                $(location).attr('href', '/audit?nextRegion=regular');
             });
         });
 
@@ -736,7 +766,7 @@
         }
 
         function init() {
-            var mainParam = {},
+            var mainParam = mainParam || {},
                     formParam = {},
                     initialLocation = svl.taskContainer.getCurrentTask().getStartCoordinate();
             formParam.dataStoreUrl = '@routes.TaskController.post';
@@ -763,6 +793,7 @@
                 mainParam.regionLayer = omnivore.wkt.parse("@region.get.geom");
                 if(@UserCurrentRegionTable.difficultRegionIds.contains(region.get.regionId)){
                        $('#advanced-overlay').show();
+                       mainParam.advancedOverlay = true
                 }
             } else {
                 mainParam.regionId = 1;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1167,42 +1167,56 @@ kbd {
 .toolUI{
     position: relative;
 }
-#advanced-overlay{
+/*Overlay box - start*/
+#advanced-overlay, #neighborhood-completion-overlay{
     display:none;
 }
-#overlay-text{
+.overlay-text{
     height: 100%;
     width: 100%;
     position: absolute;
-    background: rgba(0,0,0,0.85);
+    background: rgba(0,0,0,0.89);
     z-index: 5;
 }
-#advanced-neighborhood-text{
+#advanced-neighborhood-text, #neighborhood-completion-text{
     color: white;
     text-align: center;
-    width: 59%;
+    width: 65%;
     position: relative;
-    margin-top: 27vh;
     margin-left: 18vw;
     border-radius: 5px;
     font-size: 21px;
 }
-#advanced-neighborhood-text p{
+#advanced-neighborhood-text {
+    margin-top: 20vh;
+}
+#neighborhood-completion-text {
+    margin-top: 23vh;
+}
+#advanced-neighborhood-text p, #neighborhood-completion-text p{
     border-radius: 5px;
     padding: 7px;
 }
-.advanced-neighborhood-option{
+.overlay-header {
+    text-align: center;
+    font-size: 30px;
+    font-weight: bold;
+}
+.overlay-option{
     margin: 20px 5px;
     padding: 7px;
     border: 1px solid white;
     border-radius: 5px;
     display: inline-block;
 }
-.advanced-neighborhood-option:hover{
+.overlay-option:hover{
     background-color: white;
     color: black;
     cursor: pointer;
 }
+
+/*Overlay box - end*/
+
 .resultsImages{
     margin-top: 10px;
 }

--- a/public/javascripts/SVLabel/src/SVLabel/Main.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Main.js
@@ -194,6 +194,12 @@ function Main (params) {
           google.maps.event.addDomListener(window, 'load', task.render);
         }
 
+        // Mark neighborhood as complete if the initial task's completion count > 0
+        // Proxy for knowing if the neighborhood is complete across all users
+        if(task.getStreetCompletionCount() > 0) {
+            svl.neighborhoodModel.setNeighborhoodCompleteAcrossAllUsers();
+        }
+
         if (getStatus("isFirstTask")) {
             svl.popUpMessage.setPosition(10, 120, width=400, height=undefined, background=true);
             svl.popUpMessage.setMessage("<span class='bold'>Remember, label all the landmarks close to the bus stop.</span> " +

--- a/public/javascripts/SVLabel/src/SVLabel/Main.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Main.js
@@ -109,6 +109,7 @@ function Main (params) {
         svl.overlayMessageBox = new OverlayMessageBox(svl.modalModel, svl.ui.overlayMessage);
         svl.ribbon = new RibbonMenu(svl.overlayMessageBox, svl.tracker, svl.ui.ribbonMenu);
         svl.canvas = new Canvas(svl.ribbon);
+        svl.advancedOverlay = params.advancedOverlay;
 
 
 
@@ -450,7 +451,7 @@ function Main (params) {
 
                 var regionId = currentNeighborhood.getProperty("regionId");
                 var difficultRegionIds = svl.neighborhoodModel.difficultRegionIds;
-                if(difficultRegionIds.includes(regionId)){
+                if(difficultRegionIds.includes(regionId) && !svl.advancedOverlay){
                     $('#advanced-overlay').show();
                 }
                 startTheMission(mission, currentNeighborhood);

--- a/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
+++ b/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
@@ -806,6 +806,7 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
         var currentNeighborhood = svl.neighborhoodModel.currentNeighborhood();
         var currentNeighborhoodId = currentNeighborhood.getProperty("regionId");
         svl.neighborhoodModel.neighborhoodCompleted(currentNeighborhoodId);
+        svl.tracker.push("NeighborhoodComplete_ByUser", {'RegionId': currentNeighborhoodId});
     }
 
     function finishCurrentTaskBeforeJumping(mission){

--- a/public/javascripts/SVLabel/src/SVLabel/task/TaskContainer.js
+++ b/public/javascripts/SVLabel/src/SVLabel/task/TaskContainer.js
@@ -30,6 +30,7 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
             var currentNeighborhood = svl.neighborhoodModel.currentNeighborhood();
             var currentNeighborhoodId = currentNeighborhood.getProperty("regionId");
             svl.neighborhoodModel.neighborhoodCompleted(currentNeighborhoodId);
+            tracker.push("NeighborhoodComplete_ByUser", {'RegionId': currentNeighborhoodId});
         } else {
             svl.taskContainer.initNextTask(newTask);
         }
@@ -415,6 +416,7 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
                 //console.log("Neighborhood complete");
                 isNeighborhoodCompleteAcrossAllUsers = true;
                 $('#neighborhood-completion-overlay').show();
+                tracker.push("NeighborhoodComplete_AcrossAllUsers", {'RegionId': neighborhoodId})
             } else {
                 //console.log("Neighborhood not complete");
                 isNeighborhoodCompleteAcrossAllUsers = false;

--- a/public/javascripts/SVLabel/src/SVLabel/task/TaskContainer.js
+++ b/public/javascripts/SVLabel/src/SVLabel/task/TaskContainer.js
@@ -414,6 +414,7 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
                 neighborhoodModel.setNeighborhoodCompleteAcrossAllUsers();
                 //console.log("Neighborhood complete");
                 isNeighborhoodCompleteAcrossAllUsers = true;
+                $('#neighborhood-completion-overlay').show();
             } else {
                 //console.log("Neighborhood not complete");
                 isNeighborhoodCompleteAcrossAllUsers = false;

--- a/public/javascripts/SVLabel/src/SVLabel/task/TaskContainer.js
+++ b/public/javascripts/SVLabel/src/SVLabel/task/TaskContainer.js
@@ -402,7 +402,7 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
         return previousTasks.length;
     }
 
-    function isNeighborhoodCompleteAcrossAllUsers(neighborhoodId, finishedTask) {
+    function findNeighborhoodCompleteAcrossAllUsers(neighborhoodId, finishedTask) {
         var isNeighborhoodCompleteAcrossAllUsers = neighborhoodModel.getNeighborhoodCompleteAcrossAllUsers();
 
         // Only run this code if the neighborhood is set as incomplete
@@ -447,7 +447,7 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
         var currentNeighborhoodId = neighborhood.getProperty("regionId");
 
         // If the neighborhood is 100% complete (across all users)
-        if (isNeighborhoodCompleteAcrossAllUsers(currentNeighborhoodId, finishedTask)) {
+        if (findNeighborhoodCompleteAcrossAllUsers(currentNeighborhoodId, finishedTask)) {
             // If the street you just audited connects to any streets that you have not personally audited,
             // pick any one of those at random. Otherwise, jump.
 


### PR DESCRIPTION
Resolves #926 

**NOTE:** This code is dependent on PR #1010. This issue branch was made from the branch related to issue #997. So PR #1010 should be reviewed and merged first. Only a couple of files has changed that are relevant to this PR (once PR #1010 is merged).

### PR Details:

1. Now, after a user helps complete a neighborhood, it shows that a message box informing them and giving them two choices - (i) to continue in the same neighborhood or (ii) go to a new neighborhood (one amongst the least audited ones). Here are the screenshots:

**Case 1:** This was triggered when the user completed a street and that led to neighborhood completion. However, the mission was still incomplete.

![image](https://user-images.githubusercontent.com/2873216/29497143-d717b424-85b0-11e7-8450-05bfb3c07914.png)

**Case 2:** This was triggered at the end of a mission when the neighborhood was marked as complete.

![image](https://user-images.githubusercontent.com/2873216/29497146-db46b306-85b0-11e7-9e77-6d10f17984ca.png)

2. This PR also updated the experienced neighborhood overlay and fixed a small bug in PR #1010. Here is the updated overlay:

![image](https://user-images.githubusercontent.com/2873216/29497174-31b7a876-85b1-11e7-9bb7-99cc819754c0.png)

3. Also, logged events `NeighborhoodComplete_AcrossAllUsers`and `NeighborhoodComplete_ByUser` when the neighborhood is marked as complete for the user and across users.