### PR TITLE
Auditing Time Histograms

### DIFF
--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -272,7 +272,7 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
   */
 def getAuditTimes() = UserAwareAction.async { implicit request =>
   if (isAdmin(request.identity)) {
-      val interactions = AuditTaskInteractionTable.selectAllAuditTimes("97760883-8ef0-4309-9a5e-0c086ef27573").map(timestamps => Json.obj(
+        val interactions = AuditTaskInteractionTable.selectAllAuditTimes().map(timestamps => Json.obj(
       "time" -> timestamps.timestamp))
       Future.successful(Ok(JsArray(interactions)))
   } else {
@@ -287,7 +287,7 @@ def getAuditTimes() = UserAwareAction.async { implicit request =>
   */
 def getAnonAuditTimes() = UserAwareAction.async { implicit request =>
   if (isAdmin(request.identity)) {
-      val interactionsAnon = AuditTaskInteractionTable.selectAllAnonAuditTimes("97760883-8ef0-4309-9a5e-0c086ef27573").map(timestamps => Json.obj(
+      val interactionsAnon = AuditTaskInteractionTable.selectAllAnonAuditTimes().map(timestamps => Json.obj(
       "time" -> timestamps.timestamp))
       Future.successful(Ok(JsArray(interactionsAnon)))
   } else {

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -272,9 +272,9 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
   */
 def getAuditTimes() = UserAwareAction.async { implicit request =>
   if (isAdmin(request.identity)) {
-        val interactions = AuditTaskInteractionTable.selectAllAuditTimes().map(timestamps => Json.obj(
-      "time" -> timestamps.timestamp))
-      Future.successful(Ok(JsArray(interactions)))
+        val auditTimes = AuditTaskInteractionTable.selectAllAuditTimes().map(auditTime =>
+          Json.obj("user_id" -> auditTime.userId, "time" -> auditTime.duration, "ip_address" -> auditTime.ipAddress))
+      Future.successful(Ok(JsArray(auditTimes)))
   } else {
     Future.successful(Redirect("/"))
   }
@@ -287,9 +287,9 @@ def getAuditTimes() = UserAwareAction.async { implicit request =>
   */
 def getAnonAuditTimes() = UserAwareAction.async { implicit request =>
   if (isAdmin(request.identity)) {
-      val interactionsAnon = AuditTaskInteractionTable.selectAllAnonAuditTimes().map(timestamps => Json.obj(
-      "time" -> timestamps.timestamp))
-      Future.successful(Ok(JsArray(interactionsAnon)))
+      val anonAuditTimes = AuditTaskInteractionTable.selectAllAnonAuditTimes().map(auditTime =>
+        Json.obj("user_id" -> auditTime.userId, "time" -> auditTime.duration, "ip_address" -> auditTime.ipAddress))
+      Future.successful(Ok(JsArray(anonAuditTimes)))
   } else {
     Future.successful(Redirect("/"))
   }

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -2,6 +2,7 @@ package controllers
 
 import java.util.UUID
 import javax.inject.Inject
+import java.sql.Time
 import java.net.URLDecoder
 
 import com.mohiva.play.silhouette.api.{Environment, LogoutEvent, Silhouette}
@@ -263,6 +264,37 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
       Future.successful(Redirect("/"))
     }
   }
+
+  /**
+  * Get all auditing times
+  *
+  * @return
+  */
+def getAuditTimes() = UserAwareAction.async { implicit request =>
+  if (isAdmin(request.identity)) {
+      val interactions = AuditTaskInteractionTable.selectAllAuditTimes("97760883-8ef0-4309-9a5e-0c086ef27573").map(timestamps => Json.obj(
+      "time" -> timestamps.timestamp))
+      Future.successful(Ok(JsArray(interactions)))
+  } else {
+    Future.successful(Redirect("/"))
+  }
+}
+
+/**
+  * Get all anonymous auditing times
+  *
+  * @return
+  */
+def getAnonAuditTimes() = UserAwareAction.async { implicit request =>
+  if (isAdmin(request.identity)) {
+      val interactionsAnon = AuditTaskInteractionTable.selectAllAnonAuditTimes("97760883-8ef0-4309-9a5e-0c086ef27573").map(timestamps => Json.obj(
+      "time" -> timestamps.timestamp))
+      Future.successful(Ok(JsArray(interactionsAnon)))
+  } else {
+    Future.successful(Redirect("/"))
+  }
+}
+
 
   /**
     * This method returns the tasks and labels submitted by the given user.

--- a/app/models/audit/AuditTaskInteractionTable.scala
+++ b/app/models/audit/AuditTaskInteractionTable.scala
@@ -132,15 +132,20 @@ object AuditTaskInteractionTable {
   */
 def selectAllAuditTimes(): List[AuditInteractionTimeStamp] = db.withSession { implicit session =>
   val selectAuditTimestampQuery = Q.query[String, AuditInteractionTimeStamp](
-    """SELECT CAST(extract( second from SUM(diff) ) /60 + extract( minute from SUM(diff) ) + extract( hour from SUM(diff) ) * 60 AS decimal(10,2)) AS total_time_spent_auditing
-    |FROM (
-    |   SELECT audit_task.user_id, (timestamp - LAG(timestamp, 1) OVER(PARTITION BY user_id ORDER BY timestamp)) AS diff
-    |FROM audit_task_interaction
-    |LEFT JOIN audit_task ON audit_task.audit_task_id = audit_task_interaction.audit_task_id
-    |WHERE action = 'ViewControl_MouseDown' AND audit_task.user_id <> ? AND audit_task.user_id NOT IN (SELECT user_id FROM user_role WHERE role_id > 1)
-    |) step1
-    |WHERE diff < '00:05:00.000' AND diff > '00:00:00.000'
-    |GROUP BY user_id;""".stripMargin
+    """SELECT CAST(extract( second from SUM(diff) ) /60 +
+      |            extract( minute from SUM(diff) ) +
+      |            extract( hour from SUM(diff) ) * 60 AS decimal(10,2)) AS total_time_spent_auditing
+      |FROM (
+      |    SELECT audit_task.user_id, (timestamp - LAG(timestamp, 1) OVER(PARTITION BY user_id ORDER BY timestamp)) AS diff
+      |    FROM audit_task_interaction
+      |    LEFT JOIN audit_task
+      |       ON audit_task.audit_task_id = audit_task_interaction.audit_task_id
+      |    WHERE action = 'ViewControl_MouseDown'
+      |        AND audit_task.user_id <> ?
+      |        AND audit_task.user_id NOT IN (SELECT user_id FROM user_role WHERE role_id > 1)
+      |    ) step1
+      |WHERE diff < '00:05:00.000' AND diff > '00:00:00.000'
+      |GROUP BY user_id;""".stripMargin
     )
     val timestamps: List[AuditInteractionTimeStamp] = selectAuditTimestampQuery(anonUserId).list
     timestamps
@@ -148,26 +153,35 @@ def selectAllAuditTimes(): List[AuditInteractionTimeStamp] = db.withSession { im
 
 /**
   * Select all audit task interaction times for anonymous users
+  *
   * @return
   */
 def selectAllAnonAuditTimes(): List[AuditInteractionTimeStamp] = db.withSession { implicit session =>
   val selectAuditTimestampQuery = Q.query[String, AuditInteractionTimeStamp](
-    """|SELECT CAST(extract( second from SUM(diff) ) /60 + extract( minute from SUM(diff) ) + extract( hour from SUM(diff) ) * 60 AS decimal(10,2)) AS total_time_spent_auditing
-        |FROM (
-        |SELECT ip_address, (timestamp - Lag(timestamp, 1) OVER(PARTITION BY user_id ORDER BY timestamp)) AS diff
-        |FROM audit_task_interaction
-        |LEFT JOIN audit_task ON audit_task.audit_task_id = audit_task_interaction.audit_task_id
-        |LEFT JOIN audit_task_environment ON audit_task.audit_task_id = audit_task_environment.audit_task_id
-        |WHERE action = 'ViewControl_MouseDown' AND audit_task.user_id = ?  AND ip_address IN (SELECT ip_address
-        |FROM audit_task_environment
-        |INNER JOIN audit_task ON audit_task.audit_task_id = audit_task_environment.audit_task_id
-        |WHERE completed = true)
-        |) step1
-        |WHERE diff < '00:05:00.000' AND diff > '00:00:00.000'
-        |GROUP BY ip_address;""".stripMargin
-    )
-    val timestamps: List[AuditInteractionTimeStamp] = selectAuditTimestampQuery(anonUserId).list
-    timestamps
+    """SELECT CAST(extract( second from SUM(diff) ) /60 +
+      |            extract( minute from SUM(diff) ) +
+      |            extract( hour from SUM(diff) ) * 60 AS decimal(10,2)) AS total_time_spent_auditing
+      |FROM
+      |(
+      |    SELECT ip_address, (timestamp - Lag(timestamp, 1) OVER(PARTITION BY user_id ORDER BY timestamp)) AS diff
+      |    FROM audit_task_interaction
+      |    LEFT JOIN audit_task ON audit_task.audit_task_id = audit_task_interaction.audit_task_id
+      |    LEFT JOIN audit_task_environment ON audit_task.audit_task_id = audit_task_environment.audit_task_id
+      |    WHERE action = 'ViewControl_MouseDown'
+      |    AND audit_task.user_id = ?
+      |    AND ip_address IN
+      |    (
+      |        SELECT ip_address
+      |        FROM audit_task_environment
+      |        INNER JOIN audit_task ON audit_task.audit_task_id = audit_task_environment.audit_task_id
+      |        WHERE completed = true
+      |    )
+      |) step1
+      |WHERE diff < '00:05:00.000' AND diff > '00:00:00.000'
+      |GROUP BY ip_address;""".stripMargin
+  )
+  val timestamps: List[AuditInteractionTimeStamp] = selectAuditTimestampQuery(anonUserId).list
+  timestamps
 }
 
 

--- a/app/models/audit/AuditTaskInteractionTable.scala
+++ b/app/models/audit/AuditTaskInteractionTable.scala
@@ -34,8 +34,6 @@ case class InteractionWithLabel(auditTaskInteractionId: Int, auditTaskId: Int, a
 case class UserAuditTime(userId: String, duration: Option[Float], ipAddress: Option[String])
 
 
-
-
 class AuditTaskInteractionTable(tag: Tag) extends Table[AuditTaskInteraction](tag, Some("sidewalk"), "audit_task_interaction") {
   def auditTaskInteractionId = column[Int]("audit_task_interaction_id", O.PrimaryKey, O.AutoInc)
   def auditTaskId = column[Int]("audit_task_id", O.NotNull)
@@ -152,8 +150,8 @@ def selectAllAuditTimes(): List[UserAuditTime] = db.withSession { implicit sessi
       |WHERE diff < '00:05:00.000' AND diff > '00:00:00.000'
       |GROUP BY user_id;""".stripMargin
     )
-    val timestamps: List[UserAuditTime] = selectAuditTimesQuery(anonUserId).list
-    timestamps
+    val auditTimes: List[UserAuditTime] = selectAuditTimesQuery(anonUserId).list
+    auditTimes
 }
 
 /**
@@ -167,7 +165,7 @@ def selectAllAnonAuditTimes(): List[UserAuditTime] = db.withSession { implicit s
       |       CAST(extract( second from SUM(diff) ) /60 +
       |            extract( minute from SUM(diff) ) +
       |            extract( hour from SUM(diff) ) * 60 AS decimal(10,2)) AS total_time_spent_auditing,
-      |       NULL
+      |       user_audit_times.ip_address
       |FROM
       |(
       |    SELECT user_id, ip_address, (timestamp - Lag(timestamp, 1) OVER(PARTITION BY user_id ORDER BY timestamp)) AS diff
@@ -187,8 +185,8 @@ def selectAllAnonAuditTimes(): List[UserAuditTime] = db.withSession { implicit s
       |WHERE diff < '00:05:00.000' AND diff > '00:00:00.000'
       |GROUP BY ip_address;""".stripMargin
   )
-  val timestamps: List[UserAuditTime] = selectAnonAuditTimesQuery((anonUserId, anonUserId)).list
-  timestamps
+  val auditTimes: List[UserAuditTime] = selectAnonAuditTimesQuery((anonUserId, anonUserId)).list
+  auditTimes
 }
 
 

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -351,6 +351,9 @@
                                 <span>
                                     Note: Researchers are excluded from these graphs.
                                 </span>
+                                <span>
+                                    Note: All times over 200 minutes are placed in final bin.
+                                </span>
                                 <div class="col-lg-12">
                                   <div id="auditing-duration-time-histogram"></div>
                                 </div>

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -341,7 +341,19 @@
                     <div class="col-lg-12">
                         <div id="onboarding-completion-duration-histogram"></div>
                     </div>
-
+                    <h2>Total Time Spent Auditing</h2>
+                                <span>Standard Deviation (all users): </span><span id="all-audittimes-std"></span><br>
+                                <span>Standard Deviation (registered users): </span><span id="reg-audittimes-std"></span><br>
+                                <span>Standard Deviation (anon users): </span><span id="anon-audittimes-std"></span><br>
+                                <span>
+                                    Note: An anonymous user is defined as an IP address that is associated with at least one completed audit task.
+                                </span><br>
+                                <span>
+                                    Note: Researchers are excluded from these graphs.
+                                </span>
+                                <div class="col-lg-12">
+                                  <div id="auditing-duration-time-histogram"></div>
+                                </div>
                     <h2>Missions Completed By Users</h2>
                     <div class="col-lg-12">
                         <p>

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -352,7 +352,7 @@
                         </span><br>
                         <span>
                             Note: Researchers are excluded from these graphs.
-                        </span>
+                        </span><br>
                         <span>
                             Note: All times over 200 minutes are placed in final bin.
                         </span>

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -341,22 +341,25 @@
                     <div class="col-lg-12">
                         <div id="onboarding-completion-duration-histogram"></div>
                     </div>
+
                     <h2>Total Time Spent Auditing</h2>
-                                <span>Standard Deviation (all users): </span><span id="all-audittimes-std"></span><br>
-                                <span>Standard Deviation (registered users): </span><span id="reg-audittimes-std"></span><br>
-                                <span>Standard Deviation (anon users): </span><span id="anon-audittimes-std"></span><br>
-                                <span>
-                                    Note: An anonymous user is defined as an IP address that is associated with at least one completed audit task.
-                                </span><br>
-                                <span>
-                                    Note: Researchers are excluded from these graphs.
-                                </span>
-                                <span>
-                                    Note: All times over 200 minutes are placed in final bin.
-                                </span>
-                                <div class="col-lg-12">
-                                  <div id="auditing-duration-time-histogram"></div>
-                                </div>
+                    <div class="col-lg-12">
+                        <span>Standard Deviation (all users): </span><span id="all-audittimes-std"></span><br>
+                        <span>Standard Deviation (registered users): </span><span id="reg-audittimes-std"></span><br>
+                        <span>Standard Deviation (anon users): </span><span id="anon-audittimes-std"></span><br>
+                        <span>
+                            Note: An anonymous user is defined as an IP address that is associated with at least one completed audit task.
+                        </span><br>
+                        <span>
+                            Note: Researchers are excluded from these graphs.
+                        </span>
+                        <span>
+                            Note: All times over 200 minutes are placed in final bin.
+                        </span>
+                        <div class="col-lg-12">
+                          <div id="auditing-duration-time-histogram"></div>
+                        </div>
+                    </div>
                     <h2>Missions Completed By Users</h2>
                     <div class="col-lg-12">
                         <p>

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -34,7 +34,7 @@ application.global=app.Global
 # You can declare as many datasources as you want.
 # By convention, the default datasource is named `default`
 #
-db.default.driver=org.postgresql.Driver 
+db.default.driver=org.postgresql.Driver
 db.default.url="jdbc:postgresql://localhost:5432/sidewalk"
 # db.default.user=sa
 db.default.user="sidewalk"
@@ -102,4 +102,3 @@ play {
 geotrellis.catalog = "app/assets/catalog.json"
 
 include "silhouette.conf"
-

--- a/conf/routes
+++ b/conf/routes
@@ -47,6 +47,8 @@ GET     /adminapi/labels/panoid                              @controllers.AdminC
 GET     /adminapi/label/:labelId                             @controllers.AdminController.getLabelData(labelId: Int)
 GET     /adminapi/labelCounts/registered                     @controllers.AdminController.getAllRegisteredUserLabelCounts
 GET     /adminapi/labelCounts/anonymous                      @controllers.AdminController.getAllAnonUserLabelCounts
+GET     /adminapi/audittimes                                 @controllers.AdminController.getAuditTimes()
+GET     /adminiapi/audittimesAnon                            @controllers.AdminController.getAnonAuditTimes()
 
 GET     /adminapi/webpageActivity                            @controllers.AdminController.getAllWebpageActivities
 GET     /adminapi/webpageActivity/:activity                  @controllers.AdminController.getWebpageActivities(activity: String)
@@ -92,8 +94,6 @@ GET     /contribution/tasks                                  @controllers.UserPr
 GET     /contribution/auditCounts                            @controllers.UserProfileController.getAuditCounts
 GET     /contribution/auditCounts/all                        @controllers.UserProfileController.getAllAuditCounts
 GET     /contribution/auditInteractions                      @controllers.UserProfileController.getInteractions
-GET     /adminapi/audittimes                                  @controllers.AdminController.getAuditTimes()
-GET     /adminiapi/audittimesAnon                            @controllers.AdminController.getAnonAuditTimes()
 GET     /contribution/previousAudit                          @controllers.UserProfileController.previousAudit
 GET     /contribution/:username                              @controllers.UserProfileController.userProfile(username: String)
 

--- a/conf/routes
+++ b/conf/routes
@@ -92,6 +92,8 @@ GET     /contribution/tasks                                  @controllers.UserPr
 GET     /contribution/auditCounts                            @controllers.UserProfileController.getAuditCounts
 GET     /contribution/auditCounts/all                        @controllers.UserProfileController.getAllAuditCounts
 GET     /contribution/auditInteractions                      @controllers.UserProfileController.getInteractions
+GET     /adminapi/audittimes                                  @controllers.AdminController.getAuditTimes()
+GET     /adminiapi/audittimesAnon                            @controllers.AdminController.getAnonAuditTimes()
 GET     /contribution/previousAudit                          @controllers.UserProfileController.previousAudit
 GET     /contribution/:username                              @controllers.UserProfileController.userProfile(username: String)
 

--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -780,44 +780,44 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
             });
 
             //Draw a chart of total time spent auditing
-                        $.getJSON("/adminapi/audittimes", function (regData) {
-                              $.getJSON("/adminiapi/audittimesAnon", function (anonData) {
-                                  var allTimes = [];
-                                  var regTimes = [];
-                                  var anonTimes = [];
-                                  for (var i = 0; i < regData.length; i++) {
-                                      regTimes.push({time: regData[i].time, binned: Math.min(200.0, regData[i].time)});
-                                      allTimes.push({time: regData[i].time, binned: Math.min(200.0, regData[i].time)});
-                                  }
-                                  for (var i = 0; i < anonData.length; i++) {
-                                      allTimes.push({time: anonData[i].time, binned: Math.min(200.0, anonData[i].time)});
-                                      anonTimes.push({time: anonData[i].time, binned: Math.min(200.0, anonData[i].time)});
-                                  }
+            $.getJSON("/adminapi/audittimes", function (regData) {
+                  $.getJSON("/adminiapi/audittimesAnon", function (anonData) {
+                      var allTimes = [];
+                      var regTimes = [];
+                      var anonTimes = [];
+                      for (var i = 0; i < regData.length; i++) {
+                          regTimes.push({time: regData[i].time, binned: Math.min(200.0, regData[i].time)});
+                          allTimes.push({time: regData[i].time, binned: Math.min(200.0, regData[i].time)});
+                      }
+                      for (var i = 0; i < anonData.length; i++) {
+                          allTimes.push({time: anonData[i].time, binned: Math.min(200.0, anonData[i].time)});
+                          anonTimes.push({time: anonData[i].time, binned: Math.min(200.0, anonData[i].time)});
+                      }
 
-                                  var allStats = getSummaryStats(allTimes, "time");
-                                  var regStats = getSummaryStats(regTimes, "time");
-                                  var anonStats = getSummaryStats(anonTimes, "time");
+                      var allStats = getSummaryStats(allTimes, "time");
+                      var regStats = getSummaryStats(regTimes, "time");
+                      var anonStats = getSummaryStats(anonTimes, "time");
 
-                                  var allHistOpts = {col:"binned", xAxisTitle:"Total Auditing Time (minutes) - All Users", yAxisTitle:"Counts (users)", xDomain:[0, 200],
-                                                  width:250, height:250, binStep:10, legendOffset:-80};
-                                  var regHistOpts = {col:"binned", xAxisTitle:"Total Auditing Time (minutes) - Registered Users", yAxisTitle:"Counts (users)", xDomain:[0, 200],
-                                                  width:250, height:250, binStep:10, legendOffset:-80};
-                                  var anonHistOpts = {col:"binned", xAxisTitle:"Total Auditing Time (minutes) - Anon Users", yAxisTitle:"Counts (users)", xDomain:[0, 200],
-                                                  width:250, height:250, binStep:10, legendOffset:-80};
+                      var allHistOpts = {col:"binned", xAxisTitle:"Total Auditing Time (minutes) - All Users", yAxisTitle:"Counts (users)", xDomain:[0, 200],
+                                      width:250, height:250, binStep:10, legendOffset:-80};
+                      var regHistOpts = {col:"binned", xAxisTitle:"Total Auditing Time (minutes) - Registered Users", yAxisTitle:"Counts (users)", xDomain:[0, 200],
+                                      width:250, height:250, binStep:10, legendOffset:-80};
+                      var anonHistOpts = {col:"binned", xAxisTitle:"Total Auditing Time (minutes) - Anon Users", yAxisTitle:"Counts (users)", xDomain:[0, 200],
+                                      width:250, height:250, binStep:10, legendOffset:-80};
 
-                                  var allChart = getVegaLiteHistogram(allTimes, allStats.mean, allStats.median, allHistOpts);
-                                  var regChart = getVegaLiteHistogram(regTimes, regStats.mean, regStats.median, regHistOpts);
-                                  var anonChart = getVegaLiteHistogram(anonTimes, anonStats.mean, anonStats.median, anonHistOpts);
+                      var allChart = getVegaLiteHistogram(allTimes, allStats.mean, allStats.median, allHistOpts);
+                      var regChart = getVegaLiteHistogram(regTimes, regStats.mean, regStats.median, regHistOpts);
+                      var anonChart = getVegaLiteHistogram(anonTimes, anonStats.mean, anonStats.median, anonHistOpts);
 
-                                  $("#all-audittimes-std").html((allStats.std).toFixed(2) + " Minutes");
-                                  $("#reg-audittimes-std").html((regStats.std).toFixed(2) + " Minutes");
-                                  $("#anon-audittimes-std").html((anonStats.std).toFixed(2) + " Minutes");
+                      $("#all-audittimes-std").html((allStats.std).toFixed(2) + " Minutes");
+                      $("#reg-audittimes-std").html((regStats.std).toFixed(2) + " Minutes");
+                      $("#anon-audittimes-std").html((anonStats.std).toFixed(2) + " Minutes");
 
-                                  var combinedChart = {"hconcat": [allChart, regChart, anonChart]};
+                      var combinedChart = {"hconcat": [allChart, regChart, anonChart]};
 
-                                  vega.embed("#auditing-duration-time-histogram", combinedChart, opt, function(error, results) {});
-                                });
-                        });
+                      vega.embed("#auditing-duration-time-histogram", combinedChart, opt, function(error, results) {});
+                    });
+            });
 
             $.getJSON('/adminapi/labels/all', function (data) {
                 for (var i = 0; i < data.features.length; i++) {

--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -798,12 +798,15 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
                       var regStats = getSummaryStats(regTimes, "time");
                       var anonStats = getSummaryStats(anonTimes, "time");
 
-                      var allHistOpts = {col:"binned", xAxisTitle:"Total Auditing Time (minutes) - All Users", yAxisTitle:"Counts (users)", xDomain:[0, 200],
-                                      width:250, height:250, binStep:10, legendOffset:-80};
-                      var regHistOpts = {col:"binned", xAxisTitle:"Total Auditing Time (minutes) - Registered Users", yAxisTitle:"Counts (users)", xDomain:[0, 200],
-                                      width:250, height:250, binStep:10, legendOffset:-80};
-                      var anonHistOpts = {col:"binned", xAxisTitle:"Total Auditing Time (minutes) - Anon Users", yAxisTitle:"Counts (users)", xDomain:[0, 200],
-                                      width:250, height:250, binStep:10, legendOffset:-80};
+                      var allHistOpts = {col:"binned", xAxisTitle:"Total Auditing Time (minutes) - All Users",
+                                         yAxisTitle:"Counts (users)", xDomain:[0, 200], width:250, height:250,
+                                         binStep:10, legendOffset:-80};
+                      var regHistOpts = {col:"binned", xAxisTitle:"Total Auditing Time (minutes) - Registered Users",
+                                         yAxisTitle:"Counts (users)", xDomain:[0, 200], width:250, height:250,
+                                         binStep:10, legendOffset:-80};
+                      var anonHistOpts = {col:"binned", xAxisTitle:"Total Auditing Time (minutes) - Anon Users",
+                                          yAxisTitle:"Counts (users)", xDomain:[0, 200],  width:250, height:250,
+                                          binStep:10, legendOffset:-80};
 
                       var allChart = getVegaLiteHistogram(allTimes, allStats.mean, allStats.median, allHistOpts);
                       var regChart = getVegaLiteHistogram(regTimes, regStats.mean, regStats.median, regHistOpts);


### PR DESCRIPTION
*This issue was tabled earlier, as the ground truth resolution tool was a higher priority.

Now, histograms are added to the Admin page that show total time users have spent interacting with the audit tool (all users, registered users, anonymous users). Researchers are excluded.

Total time is calculated by looking at meaningful audit task interactions, and any that occur more than 5 minutes apart, that elapsed time is not included. The user was likely not actively engaging with the tool, and left their computer stagnant.

![image](https://user-images.githubusercontent.com/19720010/29567627-db8b69ee-871b-11e7-96cc-9f4c34740e10.png)

This query can be modified to calculate onboarding times or time per 1000 feet, as requested.

Resolves #983 
Resolves #984 