### PR TITLE
Modifies the messages shown to Turkers for the HITs

### DIFF
--- a/app/controllers/AuditController.scala
+++ b/app/controllers/AuditController.scala
@@ -252,7 +252,7 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
             // If route is None, turker has finished all routes assigned, so send them to homepage.
             route match {
               case None =>
-                Future.successful(Ok(views.html.index("Project Sidewalk")))
+                Future.successful(Ok(views.html.noAvailableMissionIndex("Project Sidewalk")))
               case Some(theRoute) =>
                 val routeStreetId: Option[Int] = RouteStreetTable.getFirstRouteStreetId(routeId.getOrElse(0))
 

--- a/app/controllers/AuditController.scala
+++ b/app/controllers/AuditController.scala
@@ -134,7 +134,7 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
             // If route is None, turker has finished all routes assigned, so send them to homepage.
             route match {
               case None =>
-                Future.successful(Ok(views.html.index("Project Sidewalk")))
+                Future.successful(Ok(views.html.noAvailableMissionIndex("Project Sidewalk")))
               case Some(theRoute) =>
                 val routeStreetId: Option[Int] = RouteStreetTable.getFirstRouteStreetId(routeId.getOrElse(0))
 

--- a/app/views/audit.scala.html
+++ b/app/views/audit.scala.html
@@ -808,7 +808,8 @@
                 mainParam.regionId = @region.get.regionId;
                 mainParam.regionName = '@region.get.name';
                 mainParam.regionLayer = omnivore.wkt.parse("@region.get.geom");
-                if(@UserCurrentRegionTable.difficultRegionIds.contains(region.get.regionId)){
+            // Disabled the difficult region popup for mturk experiments
+                if(false && @UserCurrentRegionTable.difficultRegionIds.contains(region.get.regionId)){
                        $('#advanced-overlay').show();
                 }
             } else {

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -30,13 +30,11 @@
 
             </p>
             <p>
-                The HIT will consist of completing simple game-like mission where you are routed along an assigned 1,000
-                feet street segment. Once you find and label all accessibility features and problems in this segment,
-                the Submit HIT button will appear allowing you to submit your work. <b>Note</b>: The first time you
+                The HIT will consist of completing simple game-like missions where you are assigned a set of 2 or 3 routes to work on.
+                The first two routes are 1,000 ft in length and the third route, if assigned, will be 2000ft in length.
+                Once you find and label all accessibility features and problems on a route you can click the 'Continue button' to move onto the next available route.
+                A Submit HIT button will appear when you have completed all assigned routes. <b>Note</b>: The first time you
                 accept a HIT in this group, you will <i>have</i> to complete a brief tutorial before the actual task.
-            </p>
-            <p>
-                <b>DISCLAIMER</b>: This HIT will work best on Google Chrome. Other browsers are not supported well yet.
             </p>
 
                 <!--<p>This is a research project at the University of Maryland. We are studying scalable methods for how

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -30,9 +30,9 @@
 
             </p>
             <p>
-                The HIT will consist of completing simple game-like missions where you are assigned a set of 2 or 3 routes to work on.
-                The first two routes are 1,000 ft in length and the third route, if assigned, will be 2000ft in length.
-                Once you find and label all accessibility features and problems on a route you can click the 'Continue button' to move onto the next available route.
+                The HIT will consist of completing a sequence of 2 or 3 simple game-like missions where you are routed along streets.
+                Once you find and label all accessibility features and problems in a mission you can click 'Continue' to load the next available mission.
+                The first two missions are 1,000 ft in length and the third route, if assigned, will be 2000ft in length.
                 A Submit HIT button will appear when you have completed all assigned routes. <b>Note</b>: The first time you
                 accept a HIT in this group, you will <i>have</i> to complete a brief tutorial before the actual task.
             </p>

--- a/app/views/indexNext.scala.html
+++ b/app/views/indexNext.scala.html
@@ -18,8 +18,8 @@
             </p>
             <ul>
                 <li>Go through a short tutorial to learn about the interface. You only need to do it once if you decide to another HIT.</li>
-                <li>Complete a "mission" of x distance and find features within a neighborhood</li>
-                <li>Submit the labels using the interface at the end of the mission to get paid</li>
+                <li>Complete a set of "missions" of x distance each and find features within neighborhoods</li>
+                <li>Submit the labels using the interface at the end of all the mission to get paid</li>
             </ul>
         </div>
 

--- a/app/views/noAvailableMissionIndex.scala.html
+++ b/app/views/noAvailableMissionIndex.scala.html
@@ -1,0 +1,20 @@
+@import models.daos.slick.DBTableDefinitions.UserTable
+@import models.user.User
+@import models.daos._
+@import models.label._
+@import models.street.StreetEdgeTable
+@(title: String, user: Option[User] = None, url: Option[String] = Some("/"))
+
+@main(title) {
+    @navbar(user)
+    <div id="content">
+        <div class="container">
+            <h2>Welcome!</h2>
+            <p>
+                You've completed all the missions that were available to you.
+                If you would like to contribute more as a volunteer please visit our public website for <a href="http://sidewalk.umiacs.umd.edu/r=mturk_no_mission_available">Project Sidewalk</a>.
+                Even five minutes of your day could help make someone else’s.
+            </p>
+        </div>
+    </div>
+}

--- a/app/views/noAvailableMissionIndex.scala.html
+++ b/app/views/noAvailableMissionIndex.scala.html
@@ -9,10 +9,11 @@
     @navbar(user)
     <div id="content">
         <div class="container">
-            <h2>Welcome!</h2>
+            <h2>You've completed all assigned missions!</h2>
             <p>
-                You've completed all the missions that were available to you.
-                If you would like to contribute more as a volunteer please visit our public website for <a href="http://sidewalk.umiacs.umd.edu/r=mturk_no_mission_available">Project Sidewalk</a>.
+                If you would like to contribute more as a volunteer please visit our public website for <a href="http://sidewalk.umiacs.umd.edu/?r=mturk_no_mission_available">Project Sidewalk</a>.
+                Your labels are used to develop new accessibility-friendly mapping tools (e.g., route planners, map visualizations), to train machine learning algorithms to semi-automatically assess cities in the future,
+                and to create better transparency about city accessibility.
                 Even five minutes of your day could help make someone else’s.
             </p>
         </div>

--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMission.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMission.js
@@ -38,7 +38,8 @@ function ModalMission (missionContainer, neighborhoodContainer, uiModalMission, 
     var missionTitles = {
         "initial-mission": "Initial Mission",
         "distance-mission": "Audit __DISTANCE_PLACEHOLDER__ in __NEIGHBORHOOD_PLACEHOLDER__",
-        "coverage-mission": "Audit __DISTANCE_PLACEHOLDER__ in __NEIGHBORHOOD_PLACEHOLDER__"
+        "coverage-mission": "Audit __DISTANCE_PLACEHOLDER__ in __NEIGHBORHOOD_PLACEHOLDER__",
+        "mturk-mission": "Audit __DISTANCE_PLACEHOLDER__ in __NEIGHBORHOOD_PLACEHOLDER__"
     };
 
     var initialMissionHTML = '<figure> \
@@ -180,13 +181,20 @@ ModalMission.prototype._auditDistanceToString = function  (distance, unit) {
         }
         else if (distance <= 0.20) {
             return "1000ft";
-        } else if (distance <= 0.25) {
+        }
+        else if (distance <= 0.25) {
             return "&frac14;mi";
-        } else if (distance <= 0.5) {
-            return "&frac12;mi"
-        } else if (distance <= 0.75) {
+        }
+        else if(distance <= 0.39){
+            return "2000ft";
+        }
+        else if (distance <= 0.5) {
+            return "&frac12;mi";
+        }
+        else if (distance <= 0.75) {
             return "&frac34;mi";
-        } else {
+        }
+        else {
             return distance.toFixed(0, 10) + "";
         }
     } else if (unit == "feet") {


### PR DESCRIPTION
The following changes have been made and need to be tested:
 - Changed the HIT preview screen from the old (single 1000 ft route) text to our current HIT composition (a set of 2 or 3 routes of length ...)
 - Disabling of the difficult regions popup. 
 - Addition of a new view that is displayed when a turker has completed all available missions and requests for a new mission. 
 - Changing the mission popup to show distance and neighborhood instead of just 'mission' for the first mission description popup. 
 - Changing the distance displayed from 1/2 mile to 2000ft for 2000ft missions.