### PR TITLE
#1017 Resolves the delayed updation of amt_assignment_id in the audit task table

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/mission/MissionProgress.js
+++ b/public/javascripts/SVLabel/src/SVLabel/mission/MissionProgress.js
@@ -168,19 +168,6 @@ function MissionProgress (svl, gameEffectModel, missionModel, modalModel, neighb
         svl.routeContainer.setCurrentRoute(route);
         var url = "/audit/amtAssignment ";
 
-        // Fetch tasks for the route
-        taskContainer.fetchTasksOnARoute(nextRouteId, function () {
-            // Replace current task with the first task from the next route
-            var newStreetEdgeId = Object.keys(taskContainer._taskStoreByRouteId[nextRouteId]).filter(function start(el){return taskContainer._taskStoreByRouteId[nextRouteId][el]['isStartEdge'];})[0];
-            var newTask = taskContainer._taskStoreByRouteId[nextRouteId][newStreetEdgeId].task;
-            var currentStreetEdgeId = taskContainer.getCurrentTask().getStreetEdgeId();
-            if(currentStreetEdgeId != newStreetEdgeId){
-                // Jump if the first street edge in the next route is not the same as the last street edge on the completed route.
-                svl.map.moveToTheTaskLocation(newTask);
-                taskContainer.setCurrentTask(newTask);
-            }
-        });
-
         missionContainer.setCurrentMission(nextMission);
 
         $.ajax({
@@ -197,6 +184,18 @@ function MissionProgress (svl, gameEffectModel, missionModel, modalModel, neighb
             dataType: 'json',
             success: function (result) {
                 svl.amtAssignmentId = result["asg_id"];
+                // Fetch tasks for the route
+                taskContainer.fetchTasksOnARoute(nextRouteId, function () {
+                    // Replace current task with the first task from the next route
+                    var newStreetEdgeId = Object.keys(taskContainer._taskStoreByRouteId[nextRouteId]).filter(function start(el){return taskContainer._taskStoreByRouteId[nextRouteId][el]['isStartEdge'];})[0];
+                    var newTask = taskContainer._taskStoreByRouteId[nextRouteId][newStreetEdgeId].task;
+                    var currentStreetEdgeId = taskContainer.getCurrentTask().getStreetEdgeId();
+                    if(currentStreetEdgeId != newStreetEdgeId){
+                        // Jump if the first street edge in the next route is not the same as the last street edge on the completed route.
+                        svl.map.moveToTheTaskLocation(newTask);
+                        taskContainer.setCurrentTask(newTask);
+                    }
+                });
             },
             error: function (result) {
                 console.error(result);


### PR DESCRIPTION
The svl.amtAssignmentId variable is used to set the assignmentId directly for new tasks and indirectly for audit task table's amt_assignment_id. In the previous code all the tasks for the new route were being fetched before the svl.amtAssignmentId variable was updated so they would have the value of the previous amtAssignmentId. I changed the location of the code which fetches the tasks on a route to after the svl.amtAssignmentId variable was updated which resolves the issue.

Note: When @misaugstad encountered #1017 he had only worked on 2 routes which ended up having the same amt_assignment_id s. I used a set of routes for testing. This resulted in the first 2 routes having the same amt_assignment_id and the third route having the amt_assignment_id that was expected for the second route. So I realized that there was actually an issue with *where* the svl.amtAssignmentId variable was being updated.