### PR TITLE
1028-Results Choropleth Updated Legend Position

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -83,3 +83,5 @@ ScalariformKeys.preferences := ScalariformKeys.preferences.value
   .setPreference(PreserveDanglingCloseParenthesis, true)
 
 fork in run := true
+
+fork in run := true

--- a/build.sbt
+++ b/build.sbt
@@ -83,5 +83,3 @@ ScalariformKeys.preferences := ScalariformKeys.preferences.value
   .setPreference(PreserveDanglingCloseParenthesis, true)
 
 fork in run := true
-
-fork in run := true

--- a/public/javascripts/AccessibilityChoropleth.js
+++ b/public/javascripts/AccessibilityChoropleth.js
@@ -31,7 +31,7 @@ function AccessibilityChoropleth(_, $, turf, difficultRegionIds) {
         minZoom: 9,
         zoomControl: false,
         legendControl: {
-            position: 'bottomleft'
+            position: 'topright'
         }
     })
         .fitBounds(bounds)


### PR DESCRIPTION
Moved the legend to the top right corner so you no longer have to scroll to the bottom of the screen to see it.

Before: 
![image](https://user-images.githubusercontent.com/31173144/29942654-a4e5fcf6-8e64-11e7-8605-3775962ea282.png)


After:
![image](https://user-images.githubusercontent.com/31173144/29942612-88804e90-8e64-11e7-8f6f-8d703ed88198.png)
