### PR TITLE
Resolves #1046 excludes researcher HITs from condition assignment calculation

### DIFF
--- a/app/models/amt/AMTConditionTable.scala
+++ b/app/models/amt/AMTConditionTable.scala
@@ -46,10 +46,15 @@ object AMTConditionTable {
 
     val selectConditionIdQuery = Q.query[Int, Int](
       """SELECT amt_condition_id
-        |  FROM (SELECT amt_condition.amt_condition_id, count(condition_id) as cnt FROM sidewalk.amt_assignment Right JOIN sidewalk.amt_condition ON (amt_assignment.condition_id = amt_condition.amt_condition_id)
+        |  FROM (SELECT amt_condition.amt_condition_id, count(condition_id) as cnt FROM
+        |  (select * from sidewalk.amt_assignment
+        |  where turker_id not in ('APQS1PRMDXAFH','A1SZNIADA6B4OF','A2G18P2LDT3ZUE','TESTWORKERID')) t2
+        |  Right JOIN sidewalk.amt_condition
+        |  ON (t2.condition_id = amt_condition.amt_condition_id)
         |  group by amt_condition.amt_condition_id
         |  ) t1
-        |  WHERE cnt<? order by cnt asc LIMIT 1;
+        |  WHERE amt_condition_id not in (74, 87)
+        |  and cnt<? order by cnt asc LIMIT 1;
       """.stripMargin
     )
 


### PR DESCRIPTION
Resolves #1046. Changed the sql query that checks which conditionId s have been worked on the least. Excluded HITs completed by mikey, steven, and ryan's workerIds along with a test id. Also included a filter for conditions (hardcoded in the sql query right now).

Testing this is probably easier by connecting to the database and running the following sql queries:
 - **Get a list of non-researcher HIT assignments**:  This should return an empty view 
`Select * from sidewalk.amt_assignment where turker_id not in ('APQS1PRMDXAFH','A1SZNIADA6B4OF','A2G18P2LDT3ZUE','TESTWORKERID')`. 
 - **Get a list of conditionIds along with the count of non-researchers who have worked on them**: This should return a zero count for every conditionId 
`SELECT amt_condition.amt_condition_id, count(condition_id) as cnt FROM
  (select * from sidewalk.amt_assignment
  where turker_id not in ('APQS1PRMDXAFH','A1SZNIADA6B4OF','A2G18P2LDT3ZUE','TESTWORKERID')) t2
  Right JOIN sidewalk.amt_condition
  ON (t2.condition_id = amt_condition.amt_condition_id)
  group by amt_condition.amt_condition_id`
 - **Get a list of conditionId's that have less than 5 people who've worked on them (in ascending order by count)** :
`SELECT amt_condition_id, cnt FROM (SELECT amt_condition.amt_condition_id, count(condition_id) as cnt FROM (select * from sidewalk.amt_assignment where turker_id not in ('APQS1PRMDXAFH','A1SZNIADA6B4OF','A2G18P2LDT3ZUE','TESTWORKERID')) t2 Right JOIN sidewalk.amt_condition ON (t2.condition_id = amt_condition.amt_condition_id) group by amt_condition.amt_condition_id) t1 WHERE amt_condition_id not in (74,87) and cnt<5 order by cnt asc`
 - Repeat the above by excluding one of the researchers from the list to simulate having a turker.