### PR TITLE
#1044 Changed - difficult region overlay centered

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1183,15 +1183,15 @@ kbd {
     text-align: center;
     width: 65%;
     position: relative;
-    margin-left: 18vw;
+    margin: auto;
     border-radius: 5px;
     font-size: 21px;
 }
 #advanced-neighborhood-text {
-    margin-top: 20vh;
+    top: 35%;
 }
 #neighborhood-completion-text {
-    margin-top: 23vh;
+    top: 40%;
 }
 #advanced-neighborhood-text p, #neighborhood-completion-text p{
     border-radius: 5px;


### PR DESCRIPTION
Removed the margin top and left because it was a fixed position.

Added margin: auto to keep the overlay centered at all times. 

Resolves #1044 