### PR TITLE
Modified hit_creation.py to suit our current iteration of experiments

### DIFF
--- a/app/models/amt/AMTConditionTable.scala
+++ b/app/models/amt/AMTConditionTable.scala
@@ -48,7 +48,7 @@ object AMTConditionTable {
       """SELECT amt_condition_id
         |  FROM (SELECT amt_condition.amt_condition_id, count(condition_id) as cnt FROM
         |  (select * from sidewalk.amt_assignment
-        |  where turker_id not in ('APQS1PRMDXAFH','A1SZNIADA6B4OF','A2G18P2LDT3ZUE','AKRNZU81S71QI','TESTWORKERID')) t2
+        |  where turker_id not in ('APQS1PRMDXAFH','A1SZNIADA6B4OF','A2G18P2LDT3ZUE','AKRNZU81S71QI','A1Y6PQWK6BYEDD','TESTWORKERID')) t2
         |  Right JOIN sidewalk.amt_condition
         |  ON (t2.condition_id = amt_condition.amt_condition_id)
         |  group by amt_condition.amt_condition_id

--- a/app/models/amt/AMTConditionTable.scala
+++ b/app/models/amt/AMTConditionTable.scala
@@ -46,15 +46,16 @@ object AMTConditionTable {
 
     val selectConditionIdQuery = Q.query[Int, Int](
       """SELECT amt_condition_id
-        |  FROM (SELECT amt_condition.amt_condition_id, count(condition_id) as cnt FROM
-        |  (select * from sidewalk.amt_assignment
-        |  where turker_id not in ('APQS1PRMDXAFH','A1SZNIADA6B4OF','A2G18P2LDT3ZUE','AKRNZU81S71QI','A1Y6PQWK6BYEDD','TESTWORKERID')) t2
-        |  Right JOIN sidewalk.amt_condition
-        |  ON (t2.condition_id = amt_condition.amt_condition_id)
-        |  group by amt_condition.amt_condition_id
+        |  FROM (SELECT amt_condition.amt_condition_id, count(condition_id) AS cnt FROM
+        |  (
+        |    SELECT * FROM sidewalk.amt_assignment
+        |    WHERE turker_id NOT IN ('APQS1PRMDXAFH','A1SZNIADA6B4OF','A2G18P2LDT3ZUE','AKRNZU81S71QI','A1Y6PQWK6BYEDD','TESTWORKERID')) t2
+        |    RIGHT JOIN sidewalk.amt_condition
+        |    ON (t2.condition_id = amt_condition.amt_condition_id)
+        |    GROUP BY amt_condition.amt_condition_id
         |  ) t1
-        |  WHERE amt_condition_id not in (74, 87)
-        |  and cnt<? order by cnt asc LIMIT 1;
+        |  WHERE amt_condition_id IN (72, 120) AND cnt < ?
+        |  ORDER BY cnt ASC LIMIT 1;
       """.stripMargin
     )
 

--- a/app/models/amt/AMTConditionTable.scala
+++ b/app/models/amt/AMTConditionTable.scala
@@ -48,7 +48,7 @@ object AMTConditionTable {
       """SELECT amt_condition_id
         |  FROM (SELECT amt_condition.amt_condition_id, count(condition_id) as cnt FROM
         |  (select * from sidewalk.amt_assignment
-        |  where turker_id not in ('APQS1PRMDXAFH','A1SZNIADA6B4OF','A2G18P2LDT3ZUE','TESTWORKERID')) t2
+        |  where turker_id not in ('APQS1PRMDXAFH','A1SZNIADA6B4OF','A2G18P2LDT3ZUE','AKRNZU81S71QI','TESTWORKERID')) t2
         |  Right JOIN sidewalk.amt_condition
         |  ON (t2.condition_id = amt_condition.amt_condition_id)
         |  group by amt_condition.amt_condition_id

--- a/connect.py
+++ b/connect.py
@@ -16,8 +16,8 @@ def connect_to_mturk():
             secret_key[name.strip()] = str(var.strip())
 
     # Setup mTurk parameters
-    #host = 'https://mturk-requester-sandbox.us-east-1.amazonaws.com/'
-    host = 'https://mturk-requester.us-east-1.amazonaws.com'
+    host = 'https://mturk-requester-sandbox.us-east-1.amazonaws.com/'
+    #host = 'https://mturk-requester.us-east-1.amazonaws.com'
     region_name = 'us-east-1'
     aws_access_key_id = secret_key["AWSAccessKeyId"]
     aws_secret_access_key = secret_key["AWSSecretKey"]

--- a/hit_creation.py
+++ b/hit_creation.py
@@ -72,7 +72,7 @@ previously, the assignment of turkers to conditions is handled by the sidewalk-m
 def create_hits(number_of_assignments = 1):
     # HIT Parameters
 
-    title = "Help make our sidewalks more accessible for wheelchair users with Google Maps"
+    title = "Help us find and label sidewalk problems in Washington DC"
 
     description = "In this task, you will virtually walk through city streets " + \
     "in Washington DC to find and label accessibility features (e.g., " + \


### PR DESCRIPTION
Made the following changes:
 - Modified hit_creation.py. This is the main HIT generation function. It will create a single HIT with the specified number of HIT assignments i.e. number of people who will need to work on the conditions. The turkers will be assigned to each condition in a round robin fashion. The function doesnt explicitly create a HIT for each condition since, as mentioned previously, the assignment of turkers to conditions is handled by the sidewalk-mturk server on the "\" endpoint.
- I've added my MTurk worker_id to the list of ids to exclude. (I was testing on MTurk sandbox and left the test mission incomplete).

To test:
 - You will just need to modify the number_of_assignments to some small number (It is 1 by default) and run the hit_creation.py file.
 - Check the worker MTurk sandbox to see if a HIT with the specified number of assignments was created.
 - Click on the HIT to see if you are assigned a condition automatically.

Before the actual run:
 - Change the host for the HITs from sandbox to the actual [requester site](https://mturk-requester.us-east-1.amazonaws.com)
 - Change the reward for each HIT.
 - Check if the HIT title and description match with what is in the [advertising google doc](https://docs.google.com/document/d/10fPLQlBQF2joPh6OQJ1TsjdTQ8OfzRr-zM-HKEe1P68/edit#)
 - Check the duration allotted for the task, expiration ...
