### PR TITLE
Resolve 1054: Mission completion popup showing 0 labels placed

### DIFF
--- a/app/views/audit.scala.html
+++ b/app/views/audit.scala.html
@@ -438,7 +438,7 @@
                             <form action="" method="post" id="submitHITForm">
                                 <input type="hidden" name="assignmentId" id="assignmentId" value="" />
                                 <input type="hidden" name="randomString" id="randomString" value="randomResultString" />
-                                <button class="btn blue-btn" id="modal-mission-complete-hit-submission-button" type="submit">Submit HIT</button>
+                                <button class="btn blue-btn" id="modal-mission-complete-hit-submission-button" type="submit">You're all done! Submit HIT!</button>
                             </form>
 
                         </div>

--- a/public/javascripts/SVLabel/src/SVLabel/mission/MissionProgress.js
+++ b/public/javascripts/SVLabel/src/SVLabel/mission/MissionProgress.js
@@ -35,6 +35,7 @@ function MissionProgress (svl, gameEffectModel, missionModel, modalModel, neighb
 
         self._completeTheCurrentMission(mission, neighborhood);
         self._completeMissionsWithSatisfiedCriteria(neighborhood);
+        _modalModel.updateModalMissionComplete(mission, neighborhood);
 
         self._updateTheCurrentMission(mission, neighborhood);
 
@@ -44,7 +45,6 @@ function MissionProgress (svl, gameEffectModel, missionModel, modalModel, neighb
         if (svl.modalMissionComplete.isOpen())
             return;
 
-        _modalModel.updateModalMissionComplete(mission, neighborhood);
         _modalModel.showModalMissionComplete();
     });
 
@@ -75,7 +75,7 @@ function MissionProgress (svl, gameEffectModel, missionModel, modalModel, neighb
         // it becomes necessary to trigger route completion event at the end of a mission.
         // In the previous implementation route lengths were usually close to or slightly lower than mission distance
         // which is why route completion was triggered when there was a null nextTask as in MapService.js
-
+        _modalModel.updateModalMissionComplete(mission, neighborhood);
         var currentRoute = svl.routeContainer.getCurrentRoute();
         _routeModel.routeCompleted(currentRoute.getProperty("routeId"), mission, neighborhood);
 
@@ -90,7 +90,6 @@ function MissionProgress (svl, gameEffectModel, missionModel, modalModel, neighb
         if (svl.modalMissionComplete.isOpen())
             return;
 
-        _modalModel.updateModalMissionComplete(mission, neighborhood);
         _modalModel.showModalMissionComplete();
     };
 

--- a/public/javascripts/SVLabel/src/SVLabel/mission/MissionProgress.js
+++ b/public/javascripts/SVLabel/src/SVLabel/mission/MissionProgress.js
@@ -33,9 +33,9 @@ function MissionProgress (svl, gameEffectModel, missionModel, modalModel, neighb
         statusModel.setProgressBar(completionRate);
         //self.finishMission(mission, neighborhood);
 
+        _modalModel.updateModalMissionComplete(mission, neighborhood);
         self._completeTheCurrentMission(mission, neighborhood);
         self._completeMissionsWithSatisfiedCriteria(neighborhood);
-        _modalModel.updateModalMissionComplete(mission, neighborhood);
 
         self._updateTheCurrentMission(mission, neighborhood);
 
@@ -75,7 +75,6 @@ function MissionProgress (svl, gameEffectModel, missionModel, modalModel, neighb
         // it becomes necessary to trigger route completion event at the end of a mission.
         // In the previous implementation route lengths were usually close to or slightly lower than mission distance
         // which is why route completion was triggered when there was a null nextTask as in MapService.js
-        _modalModel.updateModalMissionComplete(mission, neighborhood);
         var currentRoute = svl.routeContainer.getCurrentRoute();
         _routeModel.routeCompleted(currentRoute.getProperty("routeId"), mission, neighborhood);
 
@@ -90,6 +89,7 @@ function MissionProgress (svl, gameEffectModel, missionModel, modalModel, neighb
         if (svl.modalMissionComplete.isOpen())
             return;
 
+        _modalModel.updateModalMissionComplete(mission, neighborhood);
         _modalModel.showModalMissionComplete();
     };
 

--- a/public/javascripts/SVLabel/src/SVLabel/mission/MissionProgress.js
+++ b/public/javascripts/SVLabel/src/SVLabel/mission/MissionProgress.js
@@ -34,9 +34,17 @@ function MissionProgress (svl, gameEffectModel, missionModel, modalModel, neighb
         //self.finishMission(mission, neighborhood);
 
         _modalModel.updateModalMissionComplete(mission, neighborhood);
+        //Checks if the route completed event occurred before mission completed event
+        var route_completion_event_before_mission = false;
+        if(mission.getLabelCount() == undefined){
+            route_completion_event_before_mission = true;
+        }
         self._completeTheCurrentMission(mission, neighborhood);
         self._completeMissionsWithSatisfiedCriteria(neighborhood);
 
+        if(route_completion_event_before_mission){
+            _modalModel.updateModalMissionComplete(mission, neighborhood);
+        }
         self._updateTheCurrentMission(mission, neighborhood);
 
         // While the mission complete modal is open, after the **neighborhood** is 100% audited,
@@ -145,7 +153,6 @@ function MissionProgress (svl, gameEffectModel, missionModel, modalModel, neighb
         //Added code here to bring up the submit HIT button and post to the turkSubmit link
         // Or just trigger an event here such that the form submission (POST request to turkSubmit) happens on this event
         if (nextMission == null) {
-            _modalModel.updateModalMissionComplete(currentMission, currentNeighborhood);
             _modalModel.showModalMissionComplete();
             _modalModel.showModalMissionCompleteHITSubmission();
             console.error("No missions available");


### PR DESCRIPTION
Resolves #1054 . The mission completion popup stats were being updated after the next route and mission were loaded. This caused the stats to get reset to zero and show up as such. 

To test this just audit any random condition and place some number of labels. The label count on the mission completion popup should be the same as the number and type of labels you actually placed.

Also verify that the HIT submission button text is now "You're all done! Submit HIT!"