### PR TITLE
Created a new endpoint for the turkers to audit a specific condition

### DIFF
--- a/app/controllers/AuditController.scala
+++ b/app/controllers/AuditController.scala
@@ -161,6 +161,11 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
     }
   }
 
+  /*
+  * This function is associated with an endpoint that only the Ground Truth collectors will use
+  * to audit a specific condition
+  * */
+
   def auditCondition = UserAwareAction.async { implicit request =>
     val now = new DateTime(DateTimeZone.UTC)
     val timestamp: Timestamp = new Timestamp(now.getMillis)
@@ -269,6 +274,140 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
                 Future.successful(Ok(views.html.audit("Project Sidewalk - Audit", Some(task), region, route, None)))
             }
 
+          case "Preview" =>
+            WebpageActivityTable.save(WebpageActivity(0, anonymousUser.userId.toString, ipAddress, "Visit_Index", timestamp))
+            Future.successful(Ok(views.html.index("Project Sidewalk")))
+          case "Blank" =>
+            WebpageActivityTable.save(WebpageActivity(0, anonymousUser.userId.toString, ipAddress, "Visit_Blank", timestamp))
+            Future.successful(Ok(views.html.blankIndex("Project Sidewalk")))
+        }
+    }
+  }
+
+/*
+* This function is associated with an endpoint that only the Turkers will use
+* to audit a specific condition
+* */
+
+  def turkerAuditCondition = UserAwareAction.async { implicit request =>
+    val now = new DateTime(DateTimeZone.UTC)
+    val timestamp: Timestamp = new Timestamp(now.getMillis)
+    val ipAddress: String = request.remoteAddress
+
+    // Get mTurk parameters
+    // Map with keys ["assignmentId","hitId","turkSubmitTo","workerId"]
+    val qString = request.queryString.map { case (k, v) => k.mkString -> v.mkString }
+    //println(timestamp + " " + qString)
+
+    var screenStatus: String = null
+    var hitId: String = null
+    var assignmentId: String = null
+    var workerId: String = null
+    var conditionId: Integer = 0
+
+    if (qString.nonEmpty && qString.contains("assignmentId")) {
+
+      assignmentId = qString("assignmentId")
+
+      if (qString("assignmentId") != "ASSIGNMENT_ID_NOT_AVAILABLE") {
+        // User clicked the ACCEPT HIT button
+        hitId = qString("hitId")
+        workerId = qString("workerId")
+        conditionId = qString("conditionId").toInt
+        screenStatus = "Assigned"
+      }
+      else {
+        screenStatus = "Preview"
+      }
+    }
+    else {
+      screenStatus = "Blank"
+    }
+
+    val completionRates = StreetEdgeAssignmentCountTable.computeNeighborhoodCompletionRate(1).sortWith(_.rate < _.rate)
+
+    request.identity match {
+      case Some(user) =>
+        // This code block doesn't work route by route
+        // Future TODO: Make mission-route mechanism for users
+
+        // Maybe just redirect them to the admin dashboard
+
+        WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, "Visit_Audit", timestamp))
+
+        // Check and make sure that the user has been assigned to a region
+        if (!UserCurrentRegionTable.isAssigned(user.userId)) {
+          UserCurrentRegionTable.assignRandomly(user.userId)
+        }
+        // val region: Option[Region] = RegionTable.getCurrentRegion(user.userId)
+        var region: Option[NamedRegion] = RegionTable.selectTheCurrentNamedRegion(user.userId)
+
+        // Check if a user still has tasks available in this region.
+        if (!AuditTaskTable.isTaskAvailable(user.userId, region.get.regionId) ||
+          !MissionTable.isMissionAvailable(user.userId, region.get.regionId)) {
+          UserCurrentRegionTable.assignNextRegion(user.userId)
+          region = RegionTable.selectTheCurrentNamedRegion(user.userId)
+        }
+
+        val route = None
+
+        val task: NewTask = if (region.isDefined) AuditTaskTable.selectANewTaskInARegion(region.get.regionId, user)
+        else AuditTaskTable.selectANewTask(user.username)
+        Future.successful(Ok(views.html.audit("Project Sidewalk - Audit", Some(task), region, route, Some(user))))
+      case None =>
+
+        screenStatus match {
+          case "Assigned" =>
+            WebpageActivityTable.save(WebpageActivity(0, anonymousUser.userId.toString, ipAddress, "Visit_Audit", timestamp))
+            var loadRoutes: Boolean = true
+            // Retrieve the route based on the condition that the worker has been assigned to and the associated unvisited routes
+            TurkerTable.getConditionIdByTurkerId(workerId) match {
+              case Some(cId) =>
+                // The conditionId the Turker has requested for needs to be the same one he/she was assigned before.
+                if(cId == conditionId){
+                  loadRoutes = true
+                }
+                else{
+                  loadRoutes = false
+                }
+              case None =>
+                // No worker was found with this id (implies no condition was assigned)
+                // Save turker id and the condition specified in the query string here
+                val turker: Turker = Turker(workerId,"",conditionId)
+                TurkerTable.save(turker)
+                loadRoutes = true
+            }
+
+            // When all condition id's have been exhausted assign a default for now (or just assign a different)
+            // We only need the workerId to assign routes since we can obtain condition id and volunteer id by doing inner joins over tables.
+            // Skipping this step since we have already obtained condition id
+            loadRoutes match{
+              case true =>
+                val routeId: Option[Int] = AMTVolunteerRouteTable.assignRouteByConditionIdAndWorkerId(conditionId,workerId)
+                val route: Option[Route] = RouteTable.getRoute(routeId)
+
+                // If route is None, turker has finished all routes assigned, so send them to homepage.
+                route match {
+                  case None =>
+                    Future.successful(Ok(views.html.noAvailableMissionIndex("Project Sidewalk")))
+                  case Some(theRoute) =>
+                    val routeStreetId: Option[Int] = RouteStreetTable.getFirstRouteStreetId(routeId.getOrElse(0))
+
+                    // Save HIT assignment details
+                    val asg: AMTAssignment = AMTAssignment(0, hitId, assignmentId, timestamp, None, workerId, conditionId, routeId, false)
+                    val asgId: Option[Int] = Option(AMTAssignmentTable.save(asg))
+
+                    // Load the first task from the selected route
+                    val regionId: Int = theRoute.regionId
+                    val region: Option[NamedRegion] = RegionTable.selectANamedRegion(regionId)
+                    val regionName: Option[String] = region.get.name
+                    val task: NewTask = AuditTaskTable.selectANewTask(routeStreetId.getOrElse(0), asgId)
+
+                    Future.successful(Ok(views.html.audit("Project Sidewalk - Audit", Some(task), region, route, None)))
+                }
+              case false =>
+                Future.successful(Ok(views.html.noAvailableMissionIndex("Project Sidewalk")))
+            }
           case "Preview" =>
             WebpageActivityTable.save(WebpageActivity(0, anonymousUser.userId.toString, ipAddress, "Visit_Index", timestamp))
             Future.successful(Ok(views.html.index("Project Sidewalk")))

--- a/app/models/amt/AMTVolunteerRouteTable.scala
+++ b/app/models/amt/AMTVolunteerRouteTable.scala
@@ -44,23 +44,23 @@ object AMTVolunteerRouteTable {
   }
 
   def assignRouteByConditionIdAndWorkerId(conditionId: Int, workerId: String): Option[Int] = db.withTransaction { implicit session =>
-    // Find the first route in the list of routes associated with volunteerId (these are obtained using findRoutesIdsByVolunteerId)
-    // that hasnt been audited by workerId (this can be checked in the amt_assignment table)
-    val volunteerId = AMTConditionTable.getVolunteerIdByConditionId(conditionId)
-    val availableRoutes = findRoutesIdsByVolunteerId(volunteerId)
-    val auditedRoutes = amtAssignments.filter(_.turkerId === workerId).filter(_.completed).map(_.routeId).list.map(route => route.get)
-    var assignedRoute = (availableRoutes diff auditedRoutes).headOption
+    // Find the first route in the list of routes associated with volunteerId (these are obtained using
+    // findRoutesIdsByVolunteerId) that hasnt been audited by workerId (this can be checked in the amt_assignment table)
+    val volunteerId: String = AMTConditionTable.getVolunteerIdByConditionId(conditionId)
+    val availableRoutes: List[Int] = findRoutesIdsByVolunteerId(volunteerId)
+    val auditedRoutes: List[Int] = amtAssignments.filter(_.turkerId === workerId).filter(_.completed).map(_.routeId).list.map(route => route.get)
+    var assignedRoute: Option[Int] = (availableRoutes diff auditedRoutes).headOption
     assignedRoute
   }
 
   def getRoutesByConditionId(conditionId: Int): List[Int] = db.withTransaction{ implicit session =>
-    val volunteerId = AMTConditionTable.getVolunteerIdByConditionId(conditionId)
-    val availableRoutes = findRoutesIdsByVolunteerId(volunteerId)
+    val volunteerId: String = AMTConditionTable.getVolunteerIdByConditionId(conditionId)
+    val availableRoutes: List[Int] = findRoutesIdsByVolunteerId(volunteerId)
     availableRoutes
   }
 
   def getNeighborhoodByConditionId(conditionId: Int): Option[Int] = db.withTransaction{ implicit session =>
-    val availableRoute = getRoutesByConditionId(conditionId).headOption
+    val availableRoute: Option[Int] = getRoutesByConditionId(conditionId).headOption
     RouteTable.getRegionByRouteId(availableRoute)
   }
 

--- a/app/views/noAvailableMissionIndex.scala.html
+++ b/app/views/noAvailableMissionIndex.scala.html
@@ -9,13 +9,12 @@
     @navbar(user)
     <div id="content">
         <div class="container">
-            <h2>Please return this HIT</h2>
-            <p>You have arrived at this page for one of two reasons:</p>
+            <h3>You have arrived at this page for one of two reasons:</h3>
             <ol>
                 <li>You have already completed one of our HITs of this type. Unfortunately, you can only complete one of
                     these HITs. If you have already completed one, please return this HIT. If you finished the HIT but were
                     not able to submit it for any reason, please do not hesitate to contact us.</li>
-                <li>You already started another HIT from us, but have not finished it. Check your "HITs Assigned To You"
+                <li>You have already started another HIT from us, but have not finished it. Check your "HITs Assigned To You"
                     page to resume that HIT. If our HIT is not listed there, that means that you have not completed the
                     HIT in the allotted time and you will not be able to submit the HIT. If this seems incorrect in any
                     way, please do not hesitate to contact us.</li>

--- a/app/views/noAvailableMissionIndex.scala.html
+++ b/app/views/noAvailableMissionIndex.scala.html
@@ -9,9 +9,9 @@
     @navbar(user)
     <div id="content">
         <div class="container">
-            <h2>You've completed all assigned missions!</h2>
+            <h2>Please return this HIT</h2>
             <p>
-                If you would like to contribute more as a volunteer please visit our public website for <a href="http://sidewalk.umiacs.umd.edu/?r=mturk_no_mission_available">Project Sidewalk</a>.
+                You've already completed all assigned missions in this HIT (or are in the middle of working on another of our HITs)! If you would like to contribute more as a volunteer please visit our public website for <a href="http://sidewalk.umiacs.umd.edu/?r=mturk_no_mission_available">Project Sidewalk</a>.
                 Your labels are used to develop new accessibility-friendly mapping tools (e.g., route planners, map visualizations), to train machine learning algorithms to semi-automatically assess cities in the future,
                 and to create better transparency about city accessibility.
                 Even five minutes of your day could help make someone else’s.

--- a/app/views/noAvailableMissionIndex.scala.html
+++ b/app/views/noAvailableMissionIndex.scala.html
@@ -10,8 +10,20 @@
     <div id="content">
         <div class="container">
             <h2>Please return this HIT</h2>
-            <p>
-                You've already completed all assigned missions in this HIT (or are in the middle of working on another of our HITs)! If you would like to contribute more as a volunteer please visit our public website for <a href="http://sidewalk.umiacs.umd.edu/?r=mturk_no_mission_available">Project Sidewalk</a>.
+            <p>You have arrived at this page for one of two reasons:</p>
+            <ol>
+                <li>You have already completed one of our HITs of this type. Unfortunately, you can only complete one of
+                    these HITs. If you have already completed one, please return this HIT. If you finished the HIT but were
+                    not able to submit it for any reason, please do not hesitate to contact us.</li>
+                <li>You already started another HIT from us, but have not finished it. Check your "HITs Assigned To You"
+                    page to resume that HIT. If our HIT is not listed there, that means that you have not completed the
+                    HIT in the allotted time and you will not be able to submit the HIT. If this seems incorrect in any
+                    way, please do not hesitate to contact us.</li>
+            </ol>
+            <p>Watch out for a set of open-ended HITs (available soon!) where you can complete any number of missions,
+                receiving a bonus for each mission that you finish.
+            </p>
+            <p>If you would like to contribute more as a volunteer please visit our public website for <a href="http://sidewalk.umiacs.umd.edu/?r=mturk_no_mission_available">Project Sidewalk</a>.
                 Your labels are used to develop new accessibility-friendly mapping tools (e.g., route planners, map visualizations), to train machine learning algorithms to semi-automatically assess cities in the future,
                 and to create better transparency about city accessibility.
                 Even five minutes of your day could help make someone else’s.

--- a/conf/routes
+++ b/conf/routes
@@ -21,6 +21,7 @@ GET     /clustering                                          @controllers.Cluste
 # Auditing tasks
 GET     /audit                                               @controllers.AuditController.audit
 GET     /auditCondition                                      @controllers.AuditController.auditCondition
+GET     /turkerAuditCondition                                @controllers.AuditController.turkerAuditCondition
 GET     /audit/region/:id                                    @controllers.AuditController.auditRegion(id: Int)
 GET     /audit/street/:id                                    @controllers.AuditController.auditStreet(id: Int)
 POST    /audit/comment                                       @controllers.AuditController.postComment

--- a/hit_creation_for_conditions.py
+++ b/hit_creation_for_conditions.py
@@ -66,7 +66,7 @@ def create_missions_for_routes(engine, cursor, route_rows):
 This creates a HIT for each specified condition
 '''
 
-def create_hits_for_conditions(conditions, number_of_assignments = 3):
+def create_hits_for_conditions(conditions, end_point ="/auditCondition", number_of_assignments = 3):
     # HIT Parameters
 
     title = "Help make our sidewalks more accessible for wheelchair users with Google Maps"
@@ -93,7 +93,7 @@ def create_hits_for_conditions(conditions, number_of_assignments = 3):
         # Variable passed to the external url are workerid, assignmentid, hitid, ...
         # Once the task is successfully completed the external server needs to
         # perform a POST operation to an mturk url
-        url = 'https://sidewalk-mturk.umiacs.umd.edu/auditCondition?conditionId='+condition
+        url = 'https://sidewalk-mturk.umiacs.umd.edu'+ end_point +'?conditionId='+condition
         external_question = '<ExternalQuestion xmlns = "http://mechanicalturk.amazonaws.com/AWSMechanicalTurkDataSchemas/2006-07-14/ExternalQuestion.xsd">' + \
             '<ExternalURL>' + url + '</ExternalURL><FrameHeight>' + \
             str(frame_height) + '</FrameHeight></ExternalQuestion>'
@@ -132,7 +132,7 @@ if __name__ == '__main__':
         specific_conditions = [75]
         number_of_assignments = 3
 
-        create_hits_for_conditions(specific_conditions)
+        create_hits_for_conditions(specific_conditions,end_point = "/turkerAuditCondition",number_of_assignments)
 
         # Get all the current route_ids in  sidewalk.route
         cur.execute(


### PR DESCRIPTION
Also modified the text on the view when no missions are available either because the condition specified is not the same as the one requested, or because all the routes in that condition have been completed.

Things to test:
- If you already have some turker M1 in your turker table assigned to condition 72 visiting the turkAuditCondition endpoint with 
    - conditionId=72 ((http://localhost:9000/turkAuditCondition?assignmentId=A1M1&workerId=M1&hitId=H1M1&conditionId=72&turkSubmitTo=localhost:5000/post)) should display 
        - the next incomplete route in that set if you haven't already finished all of them.
        - a "Please return this HIT" message if you've already completed all assigned missions 
    - conditionId != 72 ((http://localhost:9000/turkAuditCondition?assignmentId=A1M1&workerId=M1&hitId=H1M1&conditionId=80&turkSubmitTo=localhost:5000/post)) should display a "Please return this HIT" message. The turker is attempting to start a HIT associated with a conditionId that doesnt match the one he/she was assigned.
- If you are a new turker you should be assigned the conditionId specified in the HIT url and start on the associated set of routes.

Resolves #1061 