### PR TITLE
Resolves 1067: HIT progress (number of missions completed and left) is now visible to Turkers

### DIFF
--- a/app/views/audit.scala.html
+++ b/app/views/audit.scala.html
@@ -150,7 +150,7 @@
                         <h2 id="link-neighborhood-name"><span id="status-holder-neighborhood-name"></span>D.C.</h2>
                     </a>-->
 
-                    <div class="status-row">
+                    <div class="status-row" style="display:none;">
                         <span class="status-column-half">
                             <img src='@routes.Assets.at("javascripts/SVLabel/img/icons/WalkingFeet2.png")' class="status-icon" alt="Map icon" align="">
                             <span><span class="bold" id="status-audited-distance">0.00</span> <small>miles</small></span>
@@ -160,6 +160,10 @@
                             <span><span class="bold" id="status-neighborhood-label-count">0</span> <small>labels</small></span>
                         </span>
                     </div>
+                </div>
+                <div class="status-box">
+                    <h1 class="status-holder-header-1">HIT Progress</h1>
+                    <h2><span id="status-holder-mission-counter"></span></h2>
                 </div>
                 <div class="status-box">
                     <h1>Current Mission</h1>
@@ -415,18 +419,20 @@
                                     <td id="modal-mission-complete-other-count" class="col-right"></td>
                                 </tr>
                             </table>
-                            <h3>Neighborhood Progress</h3>
-                            <div id="modal-mission-complete-complete-bar"></div>
+                            <h3 style="display: none">Neighborhood Progress</h3>
+                            <div id="modal-mission-complete-complete-bar" style="display: none"></div>
+                            <h3>HIT Progress</h3>
+                            <div id="modal-mission-complete-mission-counter"></div>
                             <table class="table">
                                 <tr>
                                     <th>Audited in this mission</th>
                                     <td id="modal-mission-complete-mission-distance" class="col-right"></td>
                                 </tr>
-                                <tr>
+                                <tr style="display: none">
                                     <th>Audited in this neighborhood</th>
                                     <td id="modal-mission-complete-total-audited-distance" class="col-right"></td>
                                 </tr>
-                                <tr>
+                                <tr style="display: none">
                                     <th>Remaining in this neighborhood</th>
                                     <td id="modal-mission-complete-remaining-distance" class="col-right"></td>
                                 </tr>

--- a/app/views/audit.scala.html
+++ b/app/views/audit.scala.html
@@ -163,7 +163,7 @@
                 </div>
                 <div class="status-box">
                     <h1 class="status-holder-header-1">HIT Progress</h1>
-                    <h2><span id="status-holder-mission-counter"></span></h2>
+                    <h2><span id="status-holder-mission-counter">Started Onboarding</span></h2>
                 </div>
                 <div class="status-box">
                     <h1>Current Mission</h1>
@@ -422,7 +422,7 @@
                             <h3 style="display: none">Neighborhood Progress</h3>
                             <div id="modal-mission-complete-complete-bar" style="display: none"></div>
                             <h3>HIT Progress</h3>
-                            <div id="modal-mission-complete-mission-counter"></div>
+                            <h5><div id="modal-mission-complete-mission-counter"></div></h5>
                             <table class="table">
                                 <tr>
                                     <th>Audited in this mission</th>

--- a/app/views/audit.scala.html
+++ b/app/views/audit.scala.html
@@ -163,7 +163,7 @@
                 </div>
                 <div class="status-box">
                     <h1 class="status-holder-header-1">HIT Progress</h1>
-                    <h2><span id="status-holder-mission-counter">Started Onboarding</span></h2>
+                    <h2><span id="status-holder-mission-counter">Started Tutorial</span></h2>
                 </div>
                 <div class="status-box">
                     <h1>Current Mission</h1>

--- a/public/javascripts/SVLabel/src/SVLabel/Main.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Main.js
@@ -435,9 +435,9 @@ function Main (params) {
         var distance = svl.taskContainer.getCompletedTaskDistance(neighborhood.getProperty("regionId"), unit);
         svl.statusFieldNeighborhood.setAuditedDistance(distance.toFixed(1), unit);
         //Update the completed mission count on the dashboard
-        var total_missions_available = svl.missionContainer.getMissionsByRegionId(neighborhood.getProperty("regionId")).length;
-        var complete_missions = total_missions_available - svl.missionContainer.getIncompleteMissionsByRegionId(neighborhood.getProperty("regionId")).length;
-        svl.statusFieldNeighborhood.setMissionCount(complete_missions,total_missions_available);
+        var totalMissionsAvailable = svl.missionContainer.getMissionsByRegionId(neighborhood.getProperty("regionId")).length;
+        var completeMissions = totalMissionsAvailable - svl.missionContainer.getIncompleteMissionsByRegionId(neighborhood.getProperty("regionId")).length;
+        svl.statusFieldNeighborhood.setMissionCount(completeMissions,totalMissionsAvailable);
 
     }
 

--- a/public/javascripts/SVLabel/src/SVLabel/Main.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Main.js
@@ -434,6 +434,10 @@ function Main (params) {
         var unit = "miles";
         var distance = svl.taskContainer.getCompletedTaskDistance(neighborhood.getProperty("regionId"), unit);
         svl.statusFieldNeighborhood.setAuditedDistance(distance.toFixed(1), unit);
+        //Update the completed mission count on the dashboard
+        var total_missions_available = svl.missionContainer.getMissionsByRegionId(neighborhood.getProperty("regionId")).length;
+        var complete_missions = total_missions_available - svl.missionContainer.getIncompleteMissionsByRegionId(neighborhood.getProperty("regionId")).length;
+        svl.statusFieldNeighborhood.setMissionCount(complete_missions,total_missions_available);
 
     }
 
@@ -466,6 +470,7 @@ function Main (params) {
                 currentNeighborhood = svl.neighborhoodContainer.getStatus("currentNeighborhood");
                 svl.missionContainer.setCurrentMission(mission);
                 $("#mini-footer-audit").css("visibility", "visible");
+
                 startTheMission(mission, currentNeighborhood);
             }
         }
@@ -573,6 +578,7 @@ function Main (params) {
         svl.ui.status.neighborhoodLabelCount = $("#status-neighborhood-label-count");
         svl.ui.status.currentMissionDescription = $("#current-mission-description");
         svl.ui.status.auditedDistance = $("#status-audited-distance");
+        svl.ui.status.missionCounter = $("#status-holder-mission-counter");
 
         // MissionDescription DOMs
         svl.ui.statusMessage = {};
@@ -656,6 +662,7 @@ function Main (params) {
         svl.ui.modalMissionComplete.completeBar = $('#modal-mission-complete-complete-bar');
         svl.ui.modalMissionComplete.closeButton = $("#modal-mission-complete-close-button");
         svl.ui.modalMissionComplete.submitHITButton = $("#modal-mission-complete-hit-submission-button");
+        svl.ui.modalMissionComplete.missionCounter = $("#modal-mission-complete-mission-counter");
 
         svl.ui.modalMissionComplete.totalAuditedDistance = $("#modal-mission-complete-total-audited-distance");
         svl.ui.modalMissionComplete.missionDistance = $("#modal-mission-complete-mission-distance");

--- a/public/javascripts/SVLabel/src/SVLabel/mission/MissionProgress.js
+++ b/public/javascripts/SVLabel/src/SVLabel/mission/MissionProgress.js
@@ -150,6 +150,11 @@ function MissionProgress (svl, gameEffectModel, missionModel, modalModel, neighb
 
         var nextMission = missionContainer.nextMission(currentNeighborhoodId);
 
+        //Update the completed mission count on the dashboard
+        var total_missions_available = svl.missionContainer.getMissionsByRegionId(currentNeighborhoodId).length;
+        var complete_missions = total_missions_available - svl.missionContainer.getIncompleteMissionsByRegionId(currentNeighborhoodId).length;
+        svl.statusFieldNeighborhood.setMissionCount(complete_missions,total_missions_available);
+
         //Added code here to bring up the submit HIT button and post to the turkSubmit link
         // Or just trigger an event here such that the form submission (POST request to turkSubmit) happens on this event
         if (nextMission == null) {

--- a/public/javascripts/SVLabel/src/SVLabel/mission/MissionProgress.js
+++ b/public/javascripts/SVLabel/src/SVLabel/mission/MissionProgress.js
@@ -151,9 +151,9 @@ function MissionProgress (svl, gameEffectModel, missionModel, modalModel, neighb
         var nextMission = missionContainer.nextMission(currentNeighborhoodId);
 
         //Update the completed mission count on the dashboard
-        var total_missions_available = svl.missionContainer.getMissionsByRegionId(currentNeighborhoodId).length;
-        var complete_missions = total_missions_available - svl.missionContainer.getIncompleteMissionsByRegionId(currentNeighborhoodId).length;
-        svl.statusFieldNeighborhood.setMissionCount(complete_missions,total_missions_available);
+        var totalMissionsAvailable = svl.missionContainer.getMissionsByRegionId(currentNeighborhoodId).length;
+        var completeMissions = totalMissionsAvailable - svl.missionContainer.getIncompleteMissionsByRegionId(currentNeighborhoodId).length;
+        svl.statusFieldNeighborhood.setMissionCount(completeMissions,totalMissionsAvailable);
 
         //Added code here to bring up the submit HIT button and post to the turkSubmit link
         // Or just trigger an event here such that the form submission (POST request to turkSubmit) happens on this event

--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMission.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMission.js
@@ -124,10 +124,10 @@ function ModalMission (missionContainer, neighborhoodContainer, uiModalMission, 
             missionTitle = missionTitle.replace("__DISTANCE_PLACEHOLDER__", distanceString);
             missionTitle = missionTitle.replace("__NEIGHBORHOOD_PLACEHOLDER__", neighborhood.getProperty("name"));
             if(label == "mturk-mission"){
-                var total_missions_available = missionContainer.getMissionsByRegionId(neighborhood.regionId).length;
-                var current_mission_number = 1+ total_missions_available - missionContainer.getIncompleteMissionsByRegionId(neighborhood.regionId).length;
-                missionTitle = missionTitle.replace("__COMPLETED_MISSION_COUNT__", current_mission_number.toString());
-                missionTitle = missionTitle.replace("__TOTAL_MISSION_COUNT__", total_missions_available.toString());
+                var totalMissionsAvailable = missionContainer.getMissionsByRegionId(neighborhood.regionId).length;
+                var currentMissionNumber = 1+ totalMissionsAvailable - missionContainer.getIncompleteMissionsByRegionId(neighborhood.regionId).length;
+                missionTitle = missionTitle.replace("__COMPLETED_MISSION_COUNT__", currentMissionNumber.toString());
+                missionTitle = missionTitle.replace("__TOTAL_MISSION_COUNT__", totalMissionsAvailable.toString());
             }
 
             templateHTML = templateHTML.replace("__DISTANCE_PLACEHOLDER__", distanceString);

--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMission.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMission.js
@@ -39,7 +39,7 @@ function ModalMission (missionContainer, neighborhoodContainer, uiModalMission, 
         "initial-mission": "Initial Mission",
         "distance-mission": "Audit __DISTANCE_PLACEHOLDER__ in __NEIGHBORHOOD_PLACEHOLDER__",
         "coverage-mission": "Audit __DISTANCE_PLACEHOLDER__ in __NEIGHBORHOOD_PLACEHOLDER__",
-        "mturk-mission": "Audit __DISTANCE_PLACEHOLDER__ in __NEIGHBORHOOD_PLACEHOLDER__"
+        "mturk-mission": "Mission __COMPLETED_MISSION_COUNT__ of __TOTAL_MISSION_COUNT__ : Audit __DISTANCE_PLACEHOLDER__ in __NEIGHBORHOOD_PLACEHOLDER__"
     };
 
     var initialMissionHTML = '<figure> \
@@ -113,7 +113,9 @@ function ModalMission (missionContainer, neighborhoodContainer, uiModalMission, 
                 templateHTML = distanceMissionHTML;
 
             if (missionContainer.onlyMissionOnboardingDone() || missionContainer.isTheFirstMission()) {
-                missionTitle = "First Mission: " + missionTitle;
+                if(label == "distance-mission"){
+                    missionTitle = "First Mission: " + missionTitle;
+                }
                 templateHTML = initialMissionHTML;
             }
 
@@ -121,6 +123,12 @@ function ModalMission (missionContainer, neighborhoodContainer, uiModalMission, 
 
             missionTitle = missionTitle.replace("__DISTANCE_PLACEHOLDER__", distanceString);
             missionTitle = missionTitle.replace("__NEIGHBORHOOD_PLACEHOLDER__", neighborhood.getProperty("name"));
+            if(label == "mturk-mission"){
+                var total_missions_available = missionContainer.getMissionsByRegionId(neighborhood.regionId).length;
+                var current_mission_number = 1+ total_missions_available - missionContainer.getIncompleteMissionsByRegionId(neighborhood.regionId).length;
+                missionTitle = missionTitle.replace("__COMPLETED_MISSION_COUNT__", current_mission_number.toString());
+                missionTitle = missionTitle.replace("__TOTAL_MISSION_COUNT__", total_missions_available.toString());
+            }
 
             templateHTML = templateHTML.replace("__DISTANCE_PLACEHOLDER__", distanceString);
             templateHTML = templateHTML.replace("__NEIGHBORHOOD_PLACEHOLDER__", neighborhood.getProperty("name"));

--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
@@ -144,6 +144,10 @@ function ModalMissionComplete (svl, missionContainer, taskContainer,
 
         this._updateMissionProgressStatistics(missionDistance, auditedDistance, remainingDistance, unit);
         this._updateMissionLabelStatistics(curbRampCount, noCurbRampCount, obstacleCount, surfaceProblemCount, otherCount);
+        //Update the completed mission count on the dashboard
+        var total_missions_available = missionContainer.getMissionsByRegionId(regionId).length;
+        var complete_missions = total_missions_available - missionContainer.getIncompleteMissionsByRegionId(regionId).length;
+        this._setMissionCount(complete_missions,total_missions_available);
 
     };
 
@@ -215,4 +219,8 @@ ModalMissionComplete.prototype._updateMissionLabelStatistics = function (curbRam
     this._uiModalMissionComplete.obstacleCount.html(obstacleCount);
     this._uiModalMissionComplete.surfaceProblemCount.html(surfaceProblemCount);
     this._uiModalMissionComplete.otherCount.html(otherCount);
+};
+
+ModalMissionComplete.prototype._setMissionCount = function (num_missions, total_mission_count) {
+    this._uiModalMissionComplete.missionCounter.html(num_missions+" out of "+total_mission_count+" missions completed");
 };

--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
@@ -145,9 +145,9 @@ function ModalMissionComplete (svl, missionContainer, taskContainer,
         this._updateMissionProgressStatistics(missionDistance, auditedDistance, remainingDistance, unit);
         this._updateMissionLabelStatistics(curbRampCount, noCurbRampCount, obstacleCount, surfaceProblemCount, otherCount);
         //Update the completed mission count on the dashboard
-        var total_missions_available = missionContainer.getMissionsByRegionId(regionId).length;
-        var complete_missions = total_missions_available - missionContainer.getIncompleteMissionsByRegionId(regionId).length;
-        this._setMissionCount(complete_missions,total_missions_available);
+        var totalMissionsAvailable = missionContainer.getMissionsByRegionId(regionId).length;
+        var completeMissions = totalMissionsAvailable - missionContainer.getIncompleteMissionsByRegionId(regionId).length;
+        this._setMissionCount(completeMissions,totalMissionsAvailable);
 
     };
 
@@ -221,6 +221,6 @@ ModalMissionComplete.prototype._updateMissionLabelStatistics = function (curbRam
     this._uiModalMissionComplete.otherCount.html(otherCount);
 };
 
-ModalMissionComplete.prototype._setMissionCount = function (num_missions, total_mission_count) {
-    this._uiModalMissionComplete.missionCounter.html(num_missions+" out of "+total_mission_count+" missions completed");
+ModalMissionComplete.prototype._setMissionCount = function (numMissions, totalMissionCount) {
+    this._uiModalMissionComplete.missionCounter.html(numMissions+" out of "+totalMissionCount+" missions completed");
 };

--- a/public/javascripts/SVLabel/src/SVLabel/onboarding/Onboarding.js
+++ b/public/javascripts/SVLabel/src/SVLabel/onboarding/Onboarding.js
@@ -544,6 +544,11 @@ function Onboarding(svl, actionStack, audioEffect, compass, form, handAnimation,
         var missions = missionContainer.getMissionsByRegionId(neighborhood.getProperty("regionId"));
         var mission = missions[0];
 
+        //Update the completed mission count on the dashboard
+        var totalMissionsAvailable = svl.missionContainer.getMissionsByRegionId(neighborhood.getProperty("regionId")).length;
+        var completeMissions = totalMissionsAvailable - svl.missionContainer.getIncompleteMissionsByRegionId(neighborhood.getProperty("regionId")).length;
+        svl.statusFieldNeighborhood.setMissionCount(completeMissions,totalMissionsAvailable);
+
         missionContainer.setCurrentMission(mission);
         if (missionContainer.onlyMissionOnboardingDone() || missionContainer.isTheFirstMission()) {
 

--- a/public/javascripts/SVLabel/src/SVLabel/status/StatusFieldNeighborhood.js
+++ b/public/javascripts/SVLabel/src/SVLabel/status/StatusFieldNeighborhood.js
@@ -27,6 +27,11 @@ function StatusFieldNeighborhood (neighborhoodModel, statusModel, userModel, uiS
         uiStatus.neighborhoodLabelCount.html(count);
     };
 
+    this.setMissionCount = function (num_missions, total_mission_count) {
+        uiStatus.missionCounter.html(num_missions+" out of "+total_mission_count+" missions completed");
+    };
+
+
     /**
      * Set the href attribute of the link
      * @param hrefString

--- a/public/javascripts/SVLabel/src/SVLabel/status/StatusFieldNeighborhood.js
+++ b/public/javascripts/SVLabel/src/SVLabel/status/StatusFieldNeighborhood.js
@@ -27,8 +27,8 @@ function StatusFieldNeighborhood (neighborhoodModel, statusModel, userModel, uiS
         uiStatus.neighborhoodLabelCount.html(count);
     };
 
-    this.setMissionCount = function (num_missions, total_mission_count) {
-        uiStatus.missionCounter.html(num_missions+" out of "+total_mission_count+" missions completed");
+    this.setMissionCount = function (numMissions, totalMissionCount) {
+        uiStatus.missionCounter.html(numMissions+" out of "+totalMissionCount+" missions completed");
     };
 
 


### PR DESCRIPTION
Resolves #1067 . Replaced neighborhood stats with the current mission number at 3 locations. 

At the start of a mission:
![image](https://user-images.githubusercontent.com/3580069/30148722-b0af58bc-9372-11e7-9c0e-460af06620da.png)

During the mission: on the dashboard:
![image](https://user-images.githubusercontent.com/3580069/30148765-dec3ce72-9372-11e7-9e54-0b7e1fe789a5.png)

On mission completion modal:
![image](https://user-images.githubusercontent.com/3580069/30148783-f0a6ecdc-9372-11e7-8768-f63dd71bc2c8.png)

I realize that I still need to make some style changes (especially on the mission completion modal). I need feedback before I do anything else.
