### PR TITLE
Resolves #1043: Update a Turker's record in the assignment table on HIT completion

### DIFF
--- a/app/controllers/ApplicationController.scala
+++ b/app/controllers/ApplicationController.scala
@@ -61,7 +61,7 @@ class ApplicationController @Inject() (implicit val env: Environment[User, Sessi
               case None =>
                 //Add an entry into the amt_assignment table
                 val confirmationCode = Some(s"${Random.alphanumeric take 8 mkString("")}")
-                val asg: AMTAssignment = AMTAssignment(0, hitId, assignmentId, timestamp, None, workerId, confirmationCode)
+                val asg: AMTAssignment = AMTAssignment(0, hitId, assignmentId, timestamp, None, workerId, confirmationCode, false)
                 val asgId: Option[Int] = Option(AMTAssignmentTable.save(asg))
                 // Since the turker doesnt exist in the user table create a new record with the role set to "Turker"
                 val redirectTo = List("turkerSignUp",hitId, workerId, assignmentId).reduceLeft(_ +"/"+ _)

--- a/app/controllers/MissionController.scala
+++ b/app/controllers/MissionController.scala
@@ -174,7 +174,7 @@ class MissionController @Inject() (implicit val env: Environment[User, SessionAu
       },
       submission => {
         val amtAssignmentId: Option[Int] = Option(submission.assignmentId)
-        amtAssignmentId match{
+        amtAssignmentId match {
           case Some(asgId) =>
             // Update the AMTAssignmentTable
             AMTAssignmentTable.updateAssignmentEnd(asgId, timestamp)

--- a/app/controllers/MissionController.scala
+++ b/app/controllers/MissionController.scala
@@ -2,15 +2,18 @@ package controllers
 
 import java.util.UUID
 import javax.inject.Inject
+import java.sql.Timestamp
 
 import com.mohiva.play.silhouette.api.{Environment, Silhouette}
 import com.mohiva.play.silhouette.impl.authenticators.SessionAuthenticator
+import org.joda.time.{DateTime, DateTimeZone}
 import controllers.headers.ProvidesHeader
 import formats.json.MissionFormats._
 import formats.json.TaskSubmissionFormats.{AMTAssignmentCompletionSubmission}
 import models.mission.{Mission, MissionTable, MissionUserTable}
 import models.street.StreetEdgeTable
 import models.user.{User, UserCurrentRegionTable}
+import models.amt.{AMTAssignment, AMTAssignmentTable}
 import org.geotools.geometry.jts.JTS
 import org.geotools.referencing.CRS
 import play.api.libs.json._
@@ -162,17 +165,24 @@ class MissionController @Inject() (implicit val env: Environment[User, SessionAu
 
     val submission = request.body.validate[AMTAssignmentCompletionSubmission]
 
+    val now = new DateTime(DateTimeZone.UTC)
+    val timestamp: Timestamp = new Timestamp(now.getMillis)
+
     submission.fold(
       errors => {
         Future.successful(BadRequest(Json.obj("status" -> "Error", "message" -> JsError.toFlatJson(errors))))
       },
       submission => {
         val amtAssignmentId: Option[Int] = Option(submission.assignmentId)
-
-        // Update the AMTAssignmentTable
-        AMTAssignmentTable.updateAssignmentEnd(amtAssignmentId, timestamp)
-        AMTAssignmentTable.updateCompleted(amtAssignmentId, completed=true)
-        Future.successful(Ok(Json.obj("success" -> true)))
+        amtAssignmentId match{
+          case Some(asgId) =>
+            // Update the AMTAssignmentTable
+            AMTAssignmentTable.updateAssignmentEnd(asgId, timestamp)
+            AMTAssignmentTable.updateCompleted(asgId, completed=true)
+            Future.successful(Ok(Json.obj("success" -> true)))
+          case None =>
+            Future.successful(Ok(Json.obj("success" -> false)))
+        }
       }
     )
   }

--- a/app/controllers/MissionController.scala
+++ b/app/controllers/MissionController.scala
@@ -7,7 +7,7 @@ import com.mohiva.play.silhouette.api.{Environment, Silhouette}
 import com.mohiva.play.silhouette.impl.authenticators.SessionAuthenticator
 import controllers.headers.ProvidesHeader
 import formats.json.MissionFormats._
-import formats.json.TaskSubmissionFormats.{AMTRouteAssignmentSubmission}
+import formats.json.TaskSubmissionFormats.{AMTAssignmentCompletionSubmission}
 import models.mission.{Mission, MissionTable, MissionUserTable}
 import models.street.StreetEdgeTable
 import models.user.{User, UserCurrentRegionTable}
@@ -160,7 +160,7 @@ class MissionController @Inject() (implicit val env: Environment[User, SessionAu
   def postAMTAssignment = UserAwareAction.async(BodyParsers.parse.json) { implicit request =>
     // Validation https://www.playframework.com/documentation/2.3.x/ScalaJson
 
-    val submission = request.body.validate[AMTRouteAssignmentSubmission]
+    val submission = request.body.validate[AMTAssignmentCompletionSubmission]
 
     submission.fold(
       errors => {

--- a/app/controllers/TaskController.scala
+++ b/app/controllers/TaskController.scala
@@ -144,7 +144,7 @@ class TaskController @Inject() (implicit val env: Environment[User, SessionAuthe
           val amtAssignmentId: Option[Int] = data.assignment match {
             case Some(asg) =>
               // TODO Used an empty string for volunteer_id and None for confirmationCode. Needs to be changed.
-              val newAsg = AMTAssignment(0, asg.hitId, asg.assignmentId, Timestamp.valueOf(asg.assignmentStart), None, "",None)
+              val newAsg = AMTAssignment(0, asg.hitId, asg.assignmentId, Timestamp.valueOf(asg.assignmentStart), None, "",None, false)
               Some(AMTAssignmentTable.save(newAsg))
             case _ => None
           }

--- a/app/formats/json/TaskSubmissionFormats.scala
+++ b/app/formats/json/TaskSubmissionFormats.scala
@@ -18,7 +18,7 @@ object TaskSubmissionFormats {
   case class GSVLinkSubmission(targetGsvPanoramaId: String, yawDeg: Double, description: String)
   case class GSVPanoramaSubmission(gsvPanoramaId: String, imageDate: String, links: Seq[GSVLinkSubmission], copyright: String)
   case class AuditTaskSubmission(assignment: Option[AMTAssignmentSubmission], auditTask: TaskSubmission, labels: Seq[LabelSubmission], interactions: Seq[InteractionSubmission], environment: EnvironmentSubmission, incomplete: Option[IncompleteTaskSubmission], gsvPanoramas: Seq[GSVPanoramaSubmission])
-  case class AMTRouteAssignmentSubmission(assignmentId: Int, completed: Option[Boolean])
+  case class AMTAssignmentCompletionSubmission(assignmentId: Int, completed: Option[Boolean])
 
   implicit val incompleteTaskSubmissionReads: Reads[IncompleteTaskSubmission] = (
     (JsPath \ "issue_description").read[String] and
@@ -120,9 +120,9 @@ object TaskSubmissionFormats {
       (JsPath \ "gsv_panoramas").read[Seq[GSVPanoramaSubmission]]
     )(AuditTaskSubmission.apply _)
 
-  implicit val amtRouteAssignmentReads: Reads[AMTRouteAssignmentSubmission] = (
+  implicit val amtAssignmentCompletionReads: Reads[AMTAssignmentCompletionSubmission] = (
     (JsPath \ "amt_assignment_id").read[Int] and
       (JsPath \ "completed").readNullable[Boolean]
-    )(AMTRouteAssignmentSubmission.apply _)
+    )(AMTAssignmentCompletionSubmission.apply _)
 
 }

--- a/app/formats/json/TaskSubmissionFormats.scala
+++ b/app/formats/json/TaskSubmissionFormats.scala
@@ -18,6 +18,7 @@ object TaskSubmissionFormats {
   case class GSVLinkSubmission(targetGsvPanoramaId: String, yawDeg: Double, description: String)
   case class GSVPanoramaSubmission(gsvPanoramaId: String, imageDate: String, links: Seq[GSVLinkSubmission], copyright: String)
   case class AuditTaskSubmission(assignment: Option[AMTAssignmentSubmission], auditTask: TaskSubmission, labels: Seq[LabelSubmission], interactions: Seq[InteractionSubmission], environment: EnvironmentSubmission, incomplete: Option[IncompleteTaskSubmission], gsvPanoramas: Seq[GSVPanoramaSubmission])
+  case class AMTRouteAssignmentSubmission(assignmentId: Int, completed: Option[Boolean])
 
   implicit val incompleteTaskSubmissionReads: Reads[IncompleteTaskSubmission] = (
     (JsPath \ "issue_description").read[String] and
@@ -119,5 +120,9 @@ object TaskSubmissionFormats {
       (JsPath \ "gsv_panoramas").read[Seq[GSVPanoramaSubmission]]
     )(AuditTaskSubmission.apply _)
 
+  implicit val amtRouteAssignmentReads: Reads[AMTRouteAssignmentSubmission] = (
+    (JsPath \ "amt_assignment_id").read[Int] and
+      (JsPath \ "completed").readNullable[Boolean]
+    )(AMTRouteAssignmentSubmission.apply _)
 
 }

--- a/app/models/amt/AMTAssignmentTable.scala
+++ b/app/models/amt/AMTAssignmentTable.scala
@@ -41,6 +41,10 @@ object AMTAssignmentTable {
   def getMostRecentAssignmentId(workerId: String): String = db.withTransaction { implicit session =>
     amtAssignments.filter( x => x.workerId === workerId).sortBy(_.assignmentStart.desc).map(_.assignmentId).list.head
   }
+  def getMostRecentAMTAssignmentId(workerId: String): Int = db.withTransaction { implicit session =>
+    amtAssignments.filter( x => x.workerId === workerId).sortBy(_.assignmentStart.desc).map(_.amtAssignmentId).list.head
+  }
+
   /**
     * Update the `assignment_end` timestamp column of the specified amt_assignment row
     *

--- a/app/models/amt/AMTAssignmentTable.scala
+++ b/app/models/amt/AMTAssignmentTable.scala
@@ -5,7 +5,7 @@ import java.sql.Timestamp
 import models.utils.MyPostgresDriver.simple._
 import play.api.Play.current
 
-case class AMTAssignment(amtAssignmentId: Int, hitId: String, assignmentId: String, assignmentStart: Timestamp, assignmentEnd: Option[Timestamp], workerId: String, confirmationCode: Option[String])
+case class AMTAssignment(amtAssignmentId: Int, hitId: String, assignmentId: String, assignmentStart: Timestamp, assignmentEnd: Option[Timestamp], workerId: String, confirmationCode: Option[String], completed: Boolean)
 
 /**
  *
@@ -18,8 +18,9 @@ class AMTAssignmentTable(tag: Tag) extends Table[AMTAssignment](tag, Some("sidew
   def assignmentEnd = column[Option[Timestamp]]("assignment_end")
   def workerId = column[String]("turker_id", O.NotNull)
   def confirmationCode = column[Option[String]]("confirmation_code")
+  def completed = column[Boolean]("completed", O.NotNull)
 
-  def * = (amtAssignmentId, hitId, assignmentId, assignmentStart, assignmentEnd, workerId, confirmationCode) <> ((AMTAssignment.apply _).tupled, AMTAssignment.unapply)
+  def * = (amtAssignmentId, hitId, assignmentId, assignmentStart, assignmentEnd, workerId, confirmationCode, completed) <> ((AMTAssignment.apply _).tupled, AMTAssignment.unapply)
 }
 
 /**
@@ -39,6 +40,21 @@ object AMTAssignmentTable {
   }
   def getMostRecentAssignmentId(workerId: String): String = db.withTransaction { implicit session =>
     amtAssignments.filter( x => x.workerId === workerId).sortBy(_.assignmentStart.desc).map(_.assignmentId).list.head
+  }
+  /**
+    * Update the `assignment_end` timestamp column of the specified amt_assignment row
+    *
+    * @param amtAssignmentId
+    * @param timestamp
+    * @return
+    */
+  def updateAssignmentEnd(amtAssignmentId: Int, timestamp: Timestamp) = db.withTransaction { implicit session =>
+    val q = for { asg <- amtAssignments if asg.amtAssignmentId === amtAssignmentId } yield asg.assignmentEnd
+    q.update(Some(timestamp))
+  }
+  def updateCompleted(amtAssignmentId: Int, completed: Boolean) = db.withTransaction { implicit session =>
+    val q = for { asg <- amtAssignments if asg.amtAssignmentId === amtAssignmentId } yield asg.completed
+    q.update(completed)
   }
 }
 

--- a/app/models/amt/AMTAssignmentTable.scala
+++ b/app/models/amt/AMTAssignmentTable.scala
@@ -5,7 +5,9 @@ import java.sql.Timestamp
 import models.utils.MyPostgresDriver.simple._
 import play.api.Play.current
 
-case class AMTAssignment(amtAssignmentId: Int, hitId: String, assignmentId: String, assignmentStart: Timestamp, assignmentEnd: Option[Timestamp], workerId: String, confirmationCode: Option[String], completed: Boolean)
+case class AMTAssignment(amtAssignmentId: Int, hitId: String, assignmentId: String,
+                         assignmentStart: Timestamp, assignmentEnd: Option[Timestamp],
+                         workerId: String, confirmationCode: Option[String], completed: Boolean)
 
 /**
  *
@@ -35,12 +37,15 @@ object AMTAssignmentTable {
       (amtAssignments returning amtAssignments.map(_.amtAssignmentId)) += asg
     asgId
   }
+
   def getConfirmationCode(workerId: String, assignmentId: String): String = db.withTransaction { implicit session =>
     amtAssignments.filter( x => x.workerId === workerId && x.assignmentId === assignmentId).map(_.confirmationCode).list.head.getOrElse("")
   }
+
   def getMostRecentAssignmentId(workerId: String): String = db.withTransaction { implicit session =>
     amtAssignments.filter( x => x.workerId === workerId).sortBy(_.assignmentStart.desc).map(_.assignmentId).list.head
   }
+
   def getMostRecentAMTAssignmentId(workerId: String): Int = db.withTransaction { implicit session =>
     amtAssignments.filter( x => x.workerId === workerId).sortBy(_.assignmentStart.desc).map(_.amtAssignmentId).list.head
   }
@@ -56,6 +61,14 @@ object AMTAssignmentTable {
     val q = for { asg <- amtAssignments if asg.amtAssignmentId === amtAssignmentId } yield asg.assignmentEnd
     q.update(Some(timestamp))
   }
+
+  /**
+    * Update the `completed`  column of the specified amt_assignment row
+    *
+    * @param amtAssignmentId
+    * @param completed
+    * @return
+    */
   def updateCompleted(amtAssignmentId: Int, completed: Boolean) = db.withTransaction { implicit session =>
     val q = for { asg <- amtAssignments if asg.amtAssignmentId === amtAssignmentId } yield asg.completed
     q.update(completed)

--- a/app/views/audit.scala.html
+++ b/app/views/audit.scala.html
@@ -791,6 +791,7 @@
             @if(user){
                 @if(user.get.roles.getOrElse(Seq("")).contains("Turker") && MissionTable.countCompletedMissionsByUserId(user.get.userId)==0) {
                     svl.assignmentId = "@AMTAssignmentTable.getMostRecentAssignmentId(user.get.username)";
+                    svl.amtAssignmentId = @AMTAssignmentTable.getMostRecentAMTAssignmentId(user.get.username);
                     svl.confirmationCode = "@AMTAssignmentTable.getConfirmationCode(user.get.username,AMTAssignmentTable.getMostRecentAssignmentId(user.get.username))";
                 }
             }

--- a/conf/evolutions/default/6.sql
+++ b/conf/evolutions/default/6.sql
@@ -3,7 +3,8 @@ INSERT INTO role (role_id, role) VALUES (4, 'Turker');
 
 ALTER TABLE amt_assignment
   ADD turker_id TEXT NOT NULL,
-  ADD confirmation_code TEXT;
+  ADD confirmation_code TEXT,
+  ADD completed BOOLEAN;
 
 ALTER TABLE mission_user
   ADD paid BOOLEAN NOT NULL DEFAULT FALSE;
@@ -15,7 +16,8 @@ ALTER TABLE mission_user
 
 ALTER TABLE amt_assignment
   DROP turker_id,
-  DROP confirmation_code;
+  DROP confirmation_code,
+  DROP completed;
 
 DELETE FROM role WHERE (role_id = 4 AND role = 'Turker');
 DELETE FROM user_role WHERE role_id = 4;

--- a/conf/evolutions/default/6.sql
+++ b/conf/evolutions/default/6.sql
@@ -4,7 +4,7 @@ INSERT INTO role (role_id, role) VALUES (4, 'Turker');
 ALTER TABLE amt_assignment
   ADD turker_id TEXT NOT NULL,
   ADD confirmation_code TEXT,
-  ADD completed BOOLEAN;
+  ADD completed BOOLEAN NOT NULL DEFAULT FALSE;
 
 ALTER TABLE mission_user
   ADD paid BOOLEAN NOT NULL DEFAULT FALSE;

--- a/conf/routes
+++ b/conf/routes
@@ -117,4 +117,4 @@ GET     /assets/*file                                        controllers.Assets.
 GET     /webjars/*file                                       controllers.WebJarAssets.at(file)
 
 # Update AMTAssignment Table
-POST    /amtAssignment                                       controllers.MissionController.postAMTAssignment
+POST    /amtAssignment                                       @controllers.MissionController.postAMTAssignment

--- a/conf/routes
+++ b/conf/routes
@@ -115,3 +115,6 @@ GET     /v1/access/score/streets                             @controllers.Projec
 # Map static resources from the /public folder to the /assets URL path
 GET     /assets/*file                                        controllers.Assets.at(path="/public", file)
 GET     /webjars/*file                                       controllers.WebJarAssets.at(file)
+
+# Update AMTAssignment Table
+POST    /amtAssignment                                       controllers.MissionController.postAMTAssignment

--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
@@ -103,7 +103,23 @@ function ModalMissionComplete (svl, missionContainer, taskContainer,
          */
         if(uiModalMissionComplete.generateConfirmationButton!=null && uiModalMissionComplete.generateConfirmationButton!=undefined) {
             uiModalMissionComplete.closeButton.css('visibility', "hidden");
-            console.log("Reached modal mission complete");
+
+            $.ajax({
+                async: true,
+                contentType: 'application/json; charset=utf-8',
+                url: "/amtAssignment",
+                type: 'post',
+                data: JSON.stringify(data),
+                dataType: 'json',
+                success: function (result) {
+                    console.log(result)
+                },
+                error: function (result) {
+                    console.error(result);
+                }
+            });
+
+            //console.log("Reached modal mission complete");
             uiModalMissionComplete.generateConfirmationButton.onclick = function () {
                 var para = document.createElement("p");
                 var node = document.createTextNode("Confirmation Code: " + svl.confirmationCode);

--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
@@ -104,6 +104,12 @@ function ModalMissionComplete (svl, missionContainer, taskContainer,
         if(uiModalMissionComplete.generateConfirmationButton!=null && uiModalMissionComplete.generateConfirmationButton!=undefined) {
             uiModalMissionComplete.closeButton.css('visibility', "hidden");
 
+            // Assignment Completion Data
+            var data = {
+                amt_assignment_id: svl.amtAssignmentId,
+                completed: true
+            };
+
             $.ajax({
                 async: true,
                 contentType: 'application/json; charset=utf-8',
@@ -112,7 +118,6 @@ function ModalMissionComplete (svl, missionContainer, taskContainer,
                 data: JSON.stringify(data),
                 dataType: 'json',
                 success: function (result) {
-                    console.log(result)
                 },
                 error: function (result) {
                     console.error(result);


### PR DESCRIPTION
Resolves #1043. For turkers on the production site their HIT is considered complete when they complete their first 500ft mission. I've include code for that first mission completion event that updates the assignment_end time, and a boolean completed variable. 

To test this
 - Login as a turker by visiting the landing page using the referrer "mturk" and provide hitId, assignmentId, and workerId parameters in the query string. For example: localhost:9000/?referrer=mturk&hitId=h9h9h9h&workerId=w9w9w9w9w9&assignmentId=a9a9a9a9
 - Check if your username is the same as your workerId
 - Check the amt_assignment table and verify that a record has been inserted for your turker session. The completed field should be set to False and the assignment_end field should be blank.
 - Complete a mission on the audit page and check the amt_assignment table. The completed field should be set to True and assignment_end field should be updated according to when you completed the missiom.
 