### PR TITLE
Modified GT resolution tool to update null severities for a single labeler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,4 @@ mturk_results
 *.pyc
 
 nohup.out
+package-lock.json

--- a/app/controllers/ClusteringSessionController.scala
+++ b/app/controllers/ClusteringSessionController.scala
@@ -120,11 +120,11 @@ class ClusteringSessionController @Inject()(implicit val env: Environment[User, 
   def getLabelsForGtResolution(clusteringSessionId: String) = UserAwareAction.async { implicit request =>
     val labels = ClusteringSessionTable.getLabelsForGtResolution(clusteringSessionId.toInt)
     val json = Json.arr(labels.map(x => Json.obj(
-      "label_id" -> x.labelId, "cluster_id" -> x.clusterId, "turker_id" -> x.turkerId, "pano_id" -> x.gsvPanoramaId,
-      "label_type" -> x.labelType, "sv_image_x" -> x.svImageX, "sv_image_y" -> x.svImageY, "sv_canvas_x" -> x.canvasX,
-      "sv_canvas_y" -> x.canvasY, "heading" -> x.heading, "pitch" -> x.pitch, "zoom" -> x.zoom,
-      "canvas_height" -> x.canvasHeight, "canvas_width" -> x.canvasWidth, "alpha_x" -> x.alphaX, "alpha_y" -> x.alphaY,
-      "lat" -> x.lat, "lng" -> x.lng, "description" -> x.description, "severity" -> x.severity,
+      "label_id" -> x.labelId, "cluster_id" -> x.clusterId, "route_id" -> x.routeId, "turker_id" -> x.turkerId,
+      "pano_id" -> x.gsvPanoramaId, "label_type" -> x.labelType, "sv_image_x" -> x.svImageX, "sv_image_y" -> x.svImageY,
+      "sv_canvas_x" -> x.canvasX, "sv_canvas_y" -> x.canvasY, "heading" -> x.heading, "pitch" -> x.pitch,
+      "zoom" -> x.zoom, "canvas_height" -> x.canvasHeight, "canvas_width" -> x.canvasWidth, "alpha_x" -> x.alphaX,
+      "alpha_y" -> x.alphaY, "lat" -> x.lat, "lng" -> x.lng, "description" -> x.description, "severity" -> x.severity,
       "temporary" -> x.temporaryProblem
     )))
     Future.successful(Ok(json))

--- a/app/formats/json/ClusteringFormats.scala
+++ b/app/formats/json/ClusteringFormats.scala
@@ -14,10 +14,11 @@ import play.api.libs.functional.syntax._
 object ClusteringFormats {
 
   case class ClusteredLabelSubmission(labelId: Int, labelType: String, clusterNum: Int)
-  case class GTLabelSubmission(labelId: Option[Int], clusterId: Int, gsvPanoId: String, labelType: Int, svImageX: Int,
-                               svImageY: Int, svCanvasX: Int, svCanvasY: Int, heading: Float, pitch: Float, zoom: Int,
-                               canvasHeight: Int, canvasWidth: Int, alphaX: Float, alphaY: Float, lat: Option[Float],
-                               lng: Option[Float], description: Option[String], severity: Option[Int], temporary: Option[Boolean])
+  case class GTLabelSubmission(labelId: Option[Int], clusterId: Int, routeId: Int, gsvPanoId: String, labelType: Int,
+                               svImageX: Int, svImageY: Int, svCanvasX: Int, svCanvasY: Int, heading: Float,
+                               pitch: Float, zoom: Int, canvasHeight: Int, canvasWidth: Int, alphaX: Float,
+                               alphaY: Float, lat: Option[Float], lng: Option[Float], description: Option[String],
+                               severity: Option[Int], temporary: Option[Boolean])
 
 
   implicit val clusteredLabelSubmissionReads: Reads[ClusteredLabelSubmission] = (
@@ -29,6 +30,7 @@ object ClusteringFormats {
   implicit val gtLabelSubmissionReads: Reads[GTLabelSubmission] = (
     (JsPath \ "label_id").readNullable[Int] and
       (JsPath \ "cluster_id").read[Int] and
+      (JsPath \ "route_id").read[Int] and
       (JsPath \ "pano_id").read[String] and
       (JsPath \ "label_type").read[Int] and
       (JsPath \ "sv_image_x").read[Int] and

--- a/app/models/amt/AMTAssignmentTable.scala
+++ b/app/models/amt/AMTAssignmentTable.scala
@@ -69,7 +69,7 @@ object AMTAssignmentTable {
       _latlngs <- LabelTable.labelPoints if _labs.labelId === _latlngs.labelId
       _labPoints <- LabelTable.labelPoints if _labs.labelId === _labPoints.labelId
       _types <- LabelTable.labelTypes if _labs.labelTypeId === _types.labelTypeId
-    } yield (_labs.labelId, -1, _asmts.turkerId, _labs.gsvPanoramaId, _types.labelType,
+    } yield (_labs.labelId, -1, _asmts.routeId, _asmts.turkerId, _labs.gsvPanoramaId, _types.labelType,
       _labPoints.svImageX, _labPoints.svImageY, _labPoints.canvasX, _labPoints.canvasY, _labPoints.heading,
       _labPoints.pitch, _labPoints.zoom, _labPoints.canvasHeight, _labPoints.canvasWidth, _labPoints.alphaX,
       _labPoints.alphaY, _labPoints.lat, _labPoints.lng)
@@ -78,24 +78,26 @@ object AMTAssignmentTable {
     val labelsWithDescription = for {
       (_labs, _descriptions) <- labels.leftJoin(ProblemDescriptionTable.problemDescriptions).on(_._1 === _.labelId)
     } yield (_labs._1, _labs._2, _labs._3, _labs._4, _labs._5, _labs._6, _labs._7, _labs._8, _labs._9, _labs._10,
-      _labs._11, _labs._12, _labs._13, _labs._14, _labs._15, _labs._16, _labs._17, _labs._18, _descriptions.description.?)
+      _labs._11, _labs._12, _labs._13, _labs._14, _labs._15, _labs._16, _labs._17, _labs._18, _labs._19,
+      _descriptions.description.?)
 
     // Left joins to get severity for any labels that have them
     val labelsWithSeverity = for {
       (_labs, _severity) <- labelsWithDescription.leftJoin(LabelTable.severities).on(_._1 === _.labelId)
     } yield (_labs._1, _labs._2, _labs._3, _labs._4, _labs._5, _labs._6, _labs._7, _labs._8, _labs._9, _labs._10,
-      _labs._11, _labs._12, _labs._13, _labs._14, _labs._15, _labs._16, _labs._17, _labs._18, _labs._19, _severity.severity.?)
+      _labs._11, _labs._12, _labs._13, _labs._14, _labs._15, _labs._16, _labs._17, _labs._18, _labs._19, _labs._20,
+      _severity.severity.?)
 
     // Left joins to get temporariness for any labels that have them (those that don't are marked as temporary=false)
     val labelsWithTemporariness = for {
       (_labs, _temporariness) <- labelsWithSeverity.leftJoin(ProblemTemporarinessTable.problemTemporarinesses).on(_._1 === _.labelId)
     } yield (_labs._1, _labs._2, _labs._3, _labs._4, _labs._5, _labs._6, _labs._7, _labs._8, _labs._9, _labs._10,
       _labs._11, _labs._12, _labs._13, _labs._14, _labs._15, _labs._16, _labs._17, _labs._18, _labs._19, _labs._20,
-      _temporariness.temporaryProblem.?)
+      _labs._21, _temporariness.temporaryProblem.?)
 
     labelsWithTemporariness.list.map(x =>
-      LabelsForResolution.tupled((x._1, x._2, x._3, x._4, x._5, x._6, x._7, x._8, x._9, x._10, x._11, x._12, x._13,
-        x._14, x._15, x._16, x._17, x._18, x._19, x._20, x._21.getOrElse(false))))
+      LabelsForResolution.tupled((x._1, x._2, x._3.get, x._4, x._5, x._6, x._7, x._8, x._9, x._10, x._11, x._12, x._13,
+        x._14, x._15, x._16, x._17, x._18, x._19, x._20, x._21, x._22.getOrElse(false))))
   }
 
   /**

--- a/app/models/amt/AMTAssignmentTable.scala
+++ b/app/models/amt/AMTAssignmentTable.scala
@@ -2,8 +2,11 @@ package models.amt
 
 import java.sql.Timestamp
 
+import models.audit.AuditTaskTable
+import models.clustering_session.LabelsForResolution
+import models.label.{LabelTable, ProblemDescriptionTable, ProblemTemporarinessTable}
 import models.route.{Route, RouteTable}
-import models.turker.{Turker, TurkerTable}
+import models.turker.{TurkerTable}
 import models.utils.MyPostgresDriver.simple._
 import play.api.Play.current
 
@@ -46,6 +49,93 @@ class AMTAssignmentTable(tag: Tag) extends Table[AMTAssignment](tag, Some("sidew
 object AMTAssignmentTable {
   val db = play.api.db.slick.DB
   val amtAssignments = TableQuery[AMTAssignmentTable]
+
+
+  /**
+    * Returns the set of labels placed by a single GT labeler for the specified condition.
+    *
+    * @param conditionId
+    * @return
+    */
+  def getLabelsFromGTLabelers(conditionId: Int): List[LabelsForResolution] = db.withTransaction { implicit session =>
+    val turkers: Option[String] = getGTLabelerTurkersWhoCompletedCondition(conditionId).headOption
+    val nonOnboardingLabs = LabelTable.labelsWithoutDeleted.filterNot(_.gsvPanoramaId === "stxXyCKAbd73DmkM2vsIHA")
+
+    // Does a bunch of inner joins to go from amt_assignment table to label tables.
+    val labels = for {
+      _asmts <- amtAssignments.filter(asmt => asmt.turkerId === turkers && asmt.conditionId === conditionId)
+      _tasks <- AuditTaskTable.auditTasks if _asmts.amtAssignmentId === _tasks.amtAssignmentId
+      _labs <- nonOnboardingLabs if _tasks.auditTaskId === _labs.auditTaskId
+      _latlngs <- LabelTable.labelPoints if _labs.labelId === _latlngs.labelId
+      _labPoints <- LabelTable.labelPoints if _labs.labelId === _labPoints.labelId
+      _types <- LabelTable.labelTypes if _labs.labelTypeId === _types.labelTypeId
+    } yield (_labs.labelId, -1, _asmts.turkerId, _labs.gsvPanoramaId, _types.labelType,
+      _labPoints.svImageX, _labPoints.svImageY, _labPoints.canvasX, _labPoints.canvasY, _labPoints.heading,
+      _labPoints.pitch, _labPoints.zoom, _labPoints.canvasHeight, _labPoints.canvasWidth, _labPoints.alphaX,
+      _labPoints.alphaY, _labPoints.lat, _labPoints.lng)
+
+    // Left joins to get descriptions for any labels that have them
+    val labelsWithDescription = for {
+      (_labs, _descriptions) <- labels.leftJoin(ProblemDescriptionTable.problemDescriptions).on(_._1 === _.labelId)
+    } yield (_labs._1, _labs._2, _labs._3, _labs._4, _labs._5, _labs._6, _labs._7, _labs._8, _labs._9, _labs._10,
+      _labs._11, _labs._12, _labs._13, _labs._14, _labs._15, _labs._16, _labs._17, _labs._18, _descriptions.description.?)
+
+    // Left joins to get severity for any labels that have them
+    val labelsWithSeverity = for {
+      (_labs, _severity) <- labelsWithDescription.leftJoin(LabelTable.severities).on(_._1 === _.labelId)
+    } yield (_labs._1, _labs._2, _labs._3, _labs._4, _labs._5, _labs._6, _labs._7, _labs._8, _labs._9, _labs._10,
+      _labs._11, _labs._12, _labs._13, _labs._14, _labs._15, _labs._16, _labs._17, _labs._18, _labs._19, _severity.severity.?)
+
+    // Left joins to get temporariness for any labels that have them (those that don't are marked as temporary=false)
+    val labelsWithTemporariness = for {
+      (_labs, _temporariness) <- labelsWithSeverity.leftJoin(ProblemTemporarinessTable.problemTemporarinesses).on(_._1 === _.labelId)
+    } yield (_labs._1, _labs._2, _labs._3, _labs._4, _labs._5, _labs._6, _labs._7, _labs._8, _labs._9, _labs._10,
+      _labs._11, _labs._12, _labs._13, _labs._14, _labs._15, _labs._16, _labs._17, _labs._18, _labs._19, _labs._20,
+      _temporariness.temporaryProblem.?)
+
+    labelsWithTemporariness.list.map(x =>
+      LabelsForResolution.tupled((x._1, x._2, x._3, x._4, x._5, x._6, x._7, x._8, x._9, x._10, x._11, x._12, x._13,
+        x._14, x._15, x._16, x._17, x._18, x._19, x._20, x._21.getOrElse(false))))
+  }
+
+  /**
+    * Returns list of non-researcher turker ids for those who have completed all routes in the specified condition.
+    *
+    * @param conditionId
+    * @return
+    */
+  def getNonResearcherTurkersWhoCompletedCondition(conditionId: Int): List[String] = db.withSession { implicit session =>
+    // figure out number of routes in the condition
+    val nRoutes: Int = (for {
+      _condition <- AMTConditionTable.amtConditions if _condition.amtConditionId === conditionId
+      _routes <- AMTVolunteerRouteTable.amtVolunteerRoutes if _routes.volunteerId === _condition.volunteerId
+    } yield _routes).length.run
+
+    // find all (non-researcher) turkers who have completed all of the routes
+    val completedAsmts = AMTAssignmentTable.amtAssignments.filter(asmt => asmt.completed && asmt.conditionId === conditionId)
+    val routeCounts = completedAsmts.groupBy(_.turkerId).map { case (id, group) => (id, group.length) }
+    routeCounts.filter(_._2 === nRoutes).filterNot(_._1 inSet TurkerTable.researcherTurkerIds).map(_._1).list
+  }
+
+  /**
+    * Returns list of GT labelers' turker ids for those who have completed all routes in the specified condition.
+    *
+    * @param conditionId
+    * @return
+    */
+  def getGTLabelerTurkersWhoCompletedCondition(conditionId: Int): List[String] = db.withSession { implicit session =>
+    // figure out number of routes in the condition
+    val nRoutes: Int = (for {
+      _condition <- AMTConditionTable.amtConditions if _condition.amtConditionId === conditionId
+      _routes <- AMTVolunteerRouteTable.amtVolunteerRoutes if _routes.volunteerId === _condition.volunteerId
+    } yield _routes).length.run
+
+    // find all turkers who were GT labelers who have completed all of the routes
+    val completedAsmts = AMTAssignmentTable.amtAssignments.filter(asmt => asmt.completed && asmt.conditionId === conditionId)
+    val routeCounts = completedAsmts.groupBy(_.turkerId).map { case (id, group) => (id, group.length) }
+    routeCounts.filter(_._2 === nRoutes).filter(_._1 inSet TurkerTable.gtTurkerIds).map(_._1).list
+  }
+
 
   def save(asg: AMTAssignment): Int = db.withTransaction { implicit session =>
     val asgId: Int =

--- a/app/models/turker/TurkerTable.scala
+++ b/app/models/turker/TurkerTable.scala
@@ -31,6 +31,10 @@ object TurkerTable{
   val db = play.api.db.slick.DB
   val turkers = TableQuery[TurkerTable]
 
+  val gtTurkerIds: List[String] = List("APQS1PRMDXAFH","A1SZNIADA6B4OF","A2G18P2LDT3ZUE")
+  val researcherTurkerIds: List[String] =
+    List("APQS1PRMDXAFH","A1SZNIADA6B4OF","A2G18P2LDT3ZUE","AKRNZU81S71QI","A1Y6PQWK6BYEDD","TESTWORKERID")
+
   def getAllTurkers : List[Turker] = db.withTransaction{ implicit session =>
     turkers.list
   }

--- a/app/views/gtresolution.scala.html
+++ b/app/views/gtresolution.scala.html
@@ -13,7 +13,7 @@
             <h3 id="round" style="text-align:center; margin-bottom:15">Ground Truth Resolution Tool</h3>
 
             <div id="gt-map-nav">
-              <input name="clusterSessionId" type="text" maxlength="50" id="clusterSessionId" style="width: 45%;" placeholder="Session/Condition ID"/>
+              <input name="sessionOrConditionId" type="text" maxlength="50" id="sessionOrConditionId" style="width: 45%;" placeholder="Session/Condition ID"/>
                 <button id="submitClusterSessionId" style="width: 26%;">Fix Session</button>
                 <button id="submitConditionId" style="width: 27%;">Fix Condition</button>
               <div id="gtButtonContainer">

--- a/app/views/gtresolution.scala.html
+++ b/app/views/gtresolution.scala.html
@@ -13,8 +13,9 @@
             <h3 id="round" style="text-align:center; margin-bottom:15">Ground Truth Resolution Tool</h3>
 
             <div id="gt-map-nav">
-              <input name="clusterSessionId" type="text" maxlength="50" id="clusterSessionId" style="width: 60%;" placeholder="Input Cluster Session ID"/>
-              <button id="submitClusterSessionId" style="width: 38%;">Submit Session ID</button>
+              <input name="clusterSessionId" type="text" maxlength="50" id="clusterSessionId" style="width: 45%;" placeholder="Session/Condition ID"/>
+                <button id="submitClusterSessionId" style="width: 26%;">Fix Session</button>
+                <button id="submitConditionId" style="width: 27%;">Fix Condition</button>
               <div id="gtButtonContainer">
                 <button class="gtButton" id="gtprev">Prev</button>
                 <button class="gtButton" id="gtrefocus">Refocus</button>
@@ -57,7 +58,7 @@
         </div>
 
       <div class="gtcolumn" id="hiddenColumn">
-        <button class="gtButton" id="gtSubmit">Submit Ground Truth Labels to Data Tables</button>
+        <button class="gtButton" id="gtSubmit">Submit Ground Truth Labels to Database</button>
       </div>
 
     </div>

--- a/conf/routes
+++ b/conf/routes
@@ -130,6 +130,7 @@ GET     /gtresolution/labelData/:labelId                     @controllers.Ground
 POST    /gtresolution/results/:clustSessionId                @controllers.GroundTruthResolutionController.postGroundTruthResults(clustSessionId: Int)
 GET     /gtlabels                                            @controllers.GTLabelController.getAllGTLabels
 GET     /labelsForGtResolution/:sessionId                    @controllers.ClusteringSessionController.getLabelsForGtResolution(sessionId)
+GET     /labelsForGTFixSeverity/:conditionId                 @controllers.GroundTruthResolutionController.getLabelsForGTSeverityFix(conditionId)
 
 # Clustering session end points
 GET     /clusteringsessions                                  @controllers.ClusteringSessionController.getClusteringSessionsWithoutDeleted

--- a/conf/routes
+++ b/conf/routes
@@ -127,7 +127,7 @@ GET     /webjars/*file                                       controllers.WebJarA
 # Set up ground truth resolution page
 GET     /gtresolution                                        @controllers.GroundTruthResolutionController.index
 GET     /gtresolution/labelData/:labelId                     @controllers.GroundTruthResolutionController.getLabelData(labelId: Int)
-POST    /gtresolution/results/:clustSessionId                @controllers.GroundTruthResolutionController.postGroundTruthResults(clustSessionId: Int)
+POST    /gtresolution/results                                @controllers.GroundTruthResolutionController.postGroundTruthResults
 GET     /gtlabels                                            @controllers.GTLabelController.getAllGTLabels
 GET     /labelsForGtResolution/:sessionId                    @controllers.ClusteringSessionController.getLabelsForGtResolution(sessionId)
 GET     /labelsForGTFixSeverity/:conditionId                 @controllers.GroundTruthResolutionController.getLabelsForGTSeverityFix(conditionId)

--- a/label_clustering.py
+++ b/label_clustering.py
@@ -2,7 +2,7 @@ import requests
 import numpy as np
 from haversine import haversine # pip install haversine
 import sys
-from scipy.cluster.hierarchy import linkage, fcluster, cut_tree, dendrogram
+from scipy.cluster.hierarchy import linkage, fcluster, dendrogram
 from scipy.spatial.distance import pdist
 from collections import Counter
 # from requests.auth import HTTPDigestAuth

--- a/public/javascripts/gtresolution.js
+++ b/public/javascripts/gtresolution.js
@@ -12,8 +12,6 @@ $(document).ready(function () {
     //array that stores information about each GSV
     var panoramaContainers = [];
 
-    //current route
-    var cluster_session_id;
     //all labels not yet dealt with
     var all_labels = [];
     //labels committed to ground truth
@@ -1201,9 +1199,9 @@ $(document).ready(function () {
         // When three GT labelers were clustered, and we are resolving disagreements, this button is pressed.
         document.getElementById("submitClusterSessionId").onclick = function () {
             // Query database for the label data
-            cluster_session_id = document.getElementById("clusterSessionId").value;
+            var clusteringSessionId = document.getElementById("sessionOrConditionId").value;
             // var test_labels = gtTestData;
-            $.getJSON("/labelsForGtResolution/" + cluster_session_id, function (data) {
+            $.getJSON("/labelsForGtResolution/" + clusteringSessionId, function (data) {
                 all_labels = filterClusters(data[0]);
                 console.log(all_labels);
                 // all_labels = filterClusters(test_labels);
@@ -1226,8 +1224,8 @@ $(document).ready(function () {
         // When only one GT labeler was used and we are filling in their missing severity, this button is pressed.
         document.getElementById("submitConditionId").onclick = function () {
             // Query database for the label data
-            cluster_session_id = document.getElementById("clusterSessionId").value;
-            $.getJSON("/labelsForGTFixSeverity/" + cluster_session_id, function (data) {
+            var conditionId = document.getElementById("sessionOrConditionId").value;
+            $.getJSON("/labelsForGTFixSeverity/" + conditionId, function (data) {
                 all_labels = filterSingleLabelsHavingSeverity(data[0]);
                 updateCountersForOneLabeler(0);
                 document.getElementById("round").innerHTML = "Ground Truth Resolution Tool - Low Disagreement Round";

--- a/public/javascripts/gtresolution.js
+++ b/public/javascripts/gtresolution.js
@@ -877,9 +877,9 @@ $(document).ready(function () {
         return data;
     }// End of filterClusters
 
-    //
-    function fixSeverities(data, index) {
-        var label_data = data[index];
+    // Prompts the user to update the severity of the label at the specified index.
+    function fixSeverities(labels, index) {
+        var label_data = labels[index];
         // Set coordinates
         currentCoordinates = new google.maps.LatLng(label_data.lat, label_data.lng);
 
@@ -945,8 +945,8 @@ $(document).ready(function () {
             updateCountersForOneLabeler(next);
 
             // Move to next missing severity, otherwise we are done!
-            if (next < data.length) {
-                fixSeverities(data, next);
+            if (next < labels.length) {
+                fixSeverities(labels, next);
             } else {
                 // We are done! Pop up the alert and show the submit to ground truth button.
                 alert("All Labels Complete: Submission Allowed");
@@ -1233,6 +1233,10 @@ $(document).ready(function () {
                 // Deal with missing severities
                 if (toInvestigate.length > 0) {
                     fixSeverities(toInvestigate, 0);
+                } else {
+                    // We are done! Pop up the alert and show the submit to ground truth button.
+                    alert("All Labels Complete: Submission Allowed");
+                    document.getElementById("hiddenColumn").style.display = "inline-block";
                 }
             });
 

--- a/public/javascripts/gtresolution.js
+++ b/public/javascripts/gtresolution.js
@@ -1185,7 +1185,7 @@ $(document).ready(function () {
             $.ajax({
                 async: true,
                 contentType: 'application/json; charset=utf-8',
-                url: "/gtresolution/results/" + cluster_session_id,
+                url: "/gtresolution/results",
                 type: 'post',
                 data: JSON.stringify(data),
                 dataType: 'json',

--- a/public/javascripts/gtresolution.js
+++ b/public/javascripts/gtresolution.js
@@ -725,7 +725,7 @@ $(document).ready(function () {
         nextOpenView = calculateNextOpenPanorama();
     }// End of addClusterToPanos
 
-    // Mext and previous button functionality, direction -1 indicates previous, direction 1 indicates next
+    // Next and previous button functionality, direction -1 indicates previous, direction 1 indicates next
     function transitionDisagreement(direction) {
         // Update currentClusterIndex
         if (direction > 0) {

--- a/public/javascripts/gtresolution.js
+++ b/public/javascripts/gtresolution.js
@@ -377,7 +377,7 @@ $(document).ready(function () {
             pano.labelMarkers[markerIndex].setOptions({zIndex: maxZIndex});
             // Hide all other popovers
             for (var i = 0; i < pano.labelMarkers.length; i++) {
-                if (i !== markerIndex) {
+                if (i != markerIndex) {
                     $('#' + pano.labelMarkers[i].getId()).popover('hide');
                     var closeMarker = mapMarkers.find(mkr => mkr.meta.label_id === pano.labels[i].label_id);
                     closeMarker.setOptions({fillColor: colorMapping[closeMarker.meta.label_type].fillStyle});
@@ -725,6 +725,7 @@ $(document).ready(function () {
         nextOpenView = calculateNextOpenPanorama();
     }// End of addClusterToPanos
 
+    // Next and previous button functionality, direction -1 indicates previous, direction 1 indicates next
     // Next and previous button functionality, direction -1 indicates previous, direction 1 indicates next
     function transitionDisagreement(direction) {
         // Update currentClusterIndex
@@ -1095,7 +1096,7 @@ $(document).ready(function () {
         mapOptions = {
             center: new google.maps.LatLng(38.95965576171875, -77.07019805908203),
             mapTypeControl: false,
-            mapTypeId: typeof google !== "undefined" ? google.maps.MapTypeId.ROADMAP : null,
+            mapTypeId: typeof google != "undefined" ? google.maps.MapTypeId.ROADMAP : null,
             maxZoom: 22,
             minZoom: 19,
             overviewMapControl: false,
@@ -1107,7 +1108,7 @@ $(document).ready(function () {
             zoom: 21
         };
         var mapCanvas = document.getElementById("groundtruth-map");
-        map = typeof google !== "undefined" ? new google.maps.Map(mapCanvas, mapOptions) : null;
+        map = typeof google != "undefined" ? new google.maps.Map(mapCanvas, mapOptions) : null;
         // Styling google map.
         mapStyleOptions = [
             {

--- a/public/javascripts/gtresolution.js
+++ b/public/javascripts/gtresolution.js
@@ -212,7 +212,7 @@ $(document).ready(function () {
                 //test whether label is present within a view
                 var pano = panoramaContainers.find(panoramaContainer => panoramaContainer.cluster_id === marker.meta.cluster_id && panoramaContainer.pano_id === marker.meta.pano_id);
                 //if so, highlight that view with a border
-                if (pano !== null) {
+                if (pano != null) {
                     pano.view.style.borderStyle = "solid";
                 }
                 //emphasize label on map by highlighting pink
@@ -223,7 +223,7 @@ $(document).ready(function () {
                 //test whether label is present within a view
                 var pano = panoramaContainers.find(panoramaContainer => panoramaContainer.cluster_id === marker.meta.cluster_id && panoramaContainer.pano_id === marker.meta.pano_id);
                 //if so, highlight that view with a border
-                if (pano !== null) {
+                if (pano != null) {
                     pano.view.style.borderStyle = "hidden";
                 }
                 //deemphasize label by removing the pink highlight
@@ -310,7 +310,7 @@ $(document).ready(function () {
                         var marker = mapMarkers.find(mkr => mkr.meta.label_id === pano.labels[i].label_id);
                         var type = pano.labels[i].label_type;
                         if(type === 'Occlusion' || type === 'NoSidewalk'){type = 'Other';}
-                        if (marker !== null) {
+                        if (marker != null) {
                             pano.labelMarkers[i].setIcon("assets/javascripts/SVLabel/img" + statusInfo[marker.status].path + type + ".png?size=200");
                         }
                         else {
@@ -647,7 +647,7 @@ $(document).ready(function () {
                 closeMarker.clicked = false;
                 //remove view number label from map marker
                 var mLabel = mapLabels.find(mkr => mkr.id === labelId);
-                if (mLabel !== null) {
+                if (mLabel != null) {
                     mLabel.setOptions({visible: false});
                 }
                 // Remove marker from GSV


### PR DESCRIPTION
I have modified the GT resolution tool to also have the option of going through a single person's labels, prompting the user to fill in any severity ratings that are null. It then adds these labels (both the ones that already had severity and the newly updated ones) to the gt_label and gt_existing_label tables.

There are two main things to test: that I didn't break the previous functionality of the tool, and that my new functionality works. I will send @manaswis a dump from mturk server that is recent enough to include any data I may be assuming is present in these instructions.

One preliminary thing to do:
Make sure you have all the correct python libraries installed to run the clustering code. The easiest way to check is to open up `label_clustering.py`, copy all the import statements at the top of the file, and paste them into an interactive Python session. If any of the imports cause a problem, `pip install` them.

Make sure I didn't break the old tool:
1. Go to [http://localhost:9000/clustering](http://localhost:9000/clustering), enter a `route_id`, `hit_id` pair (e.g., (259, 'hit128'))
![clusteringfig](https://user-images.githubusercontent.com/6518824/30508085-97ede14a-9a5c-11e7-97e7-a30f0eb5c769.png)
1. Check the `clustering_session_id` of the new entry that was made into the `clustering_session` table (should just be equal to the number of records in the table)
1. Enter that `clustering_session_id` into the gt resolution tool text box at [http://localhost:9000/gtresolution](http://localhost:9000/gtresolution)
![textboxfig](https://user-images.githubusercontent.com/6518824/30508100-d8bf5258-9a5c-11e7-83bf-f523b1051dee.png)
1. Click 'Fix session'
1. It will take you through the normal process of GT resolution (2 phases)
    1. Resolve disagreements in severity or temporariness by using the checkbox and drop down
![fig1](https://user-images.githubusercontent.com/6518824/30508074-5276af34-9a5c-11e7-801e-12cfbb9ff5b7.png)
    2. manually go through all remaining labels one-by-one, clicking on them, and marking them to go into ground truth or not (after adding something to ground truth, it gives you an option to update the severity and temporariness; you can just click "update" and it will remain is it was)
![highdisagreementround-1](https://user-images.githubusercontent.com/6518824/30508126-65d61a32-9a5d-11e7-9777-6663b5f1e987.png)
![highdisagreementround-2](https://user-images.githubusercontent.com/6518824/30508127-67ac380a-9a5d-11e7-8f87-6222b0fa2298.png)
1. Note that there is a known bug where you may have multiple labels in a single panorama, but you can only get the popup to show up on one of the labels... if you just click the next button then the previous button, you can click on a new label; or you can just keep clicking next and it will cycle you back through to those labels again.
1. Once you finish, an alert will show up, just click 'OK'
![okmessage](https://user-images.githubusercontent.com/6518824/30508144-d89481f8-9a5d-11e7-8ce6-73e1b08aa831.png)
1. Look at the number of labels that are supposed to be added to ground truth (shown at the bottom of the page)
1. Click "Submit Ground Truth Labels to Database" button
1. Verify that the correct number of labels has been added to the gt_label table


Make sure my new code works:
1. Go to [http://localhost:9000/gtresolution](http://localhost:9000/gtresolution)
![textboxfig](https://user-images.githubusercontent.com/6518824/30508100-d8bf5258-9a5c-11e7-83bf-f523b1051dee.png)
1. Enter a condition id that only one of the GT labelers has done, and click `Fix Condition` this time. I suggest doing this a few times; the 3 cases I came up with is to look at are: a set of labels where ALL the severities are filled in, one where there is only ONE severity missing, and one where there is MULTIPLE. I found some conditions to test that on: 0 missing - condition 90, 1 missing - condition 94, multiple missing - condition 102.
1. You will do basically what you had to do in the first round for conflict resolution; set the appropriate severity and temporariness of each label that shows up (note the 'toggle visible' button).
![fixseverity-1](https://user-images.githubusercontent.com/6518824/30508171-7b59946e-9a5e-11e7-8306-3af327a1ea12.png)
1. You should see counts at the botton for remaining labels, those set for ground truth, and those that will not be included in ground truth. Since all of these labels are going in ground truth, the last number should remain 0. And every time you submit a severity update, remaining labels should decrement and ground truth labels should increment.
![labelcounts](https://user-images.githubusercontent.com/6518824/30508177-a4f83780-9a5e-11e7-8d50-0803be0f5eba.png)
1. Look at the number of labels that are supposed to be added to ground truth
1. Click "Submit Ground Truth Labels to Database" button
1. Verify that the correct number of labels has been added to the `gt_label` and `gt_existing_label` table
1. An extra check for these gt labels: for all the new labels that are added, verify that severity is not null in the `gt_label` table (unless they have a label_type of 6 or 7, i.e., Occlusion or NoSidewalk).

Resolves #1056 