### PR TITLE
Added accepted column to amt_assignment table

### DIFF
--- a/app/controllers/AuditController.scala
+++ b/app/controllers/AuditController.scala
@@ -140,7 +140,7 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
                 val routeStreetId: Option[Int] = RouteStreetTable.getFirstRouteStreetId(routeId.getOrElse(0))
 
                 // Save HIT assignment details
-                val asg: AMTAssignment = AMTAssignment(0, hitId, assignmentId, timestamp, None, workerId, conditionId, routeId, false)
+                val asg: AMTAssignment = AMTAssignment(0, hitId, assignmentId, timestamp, None, workerId, conditionId, routeId, false, None)
                 val asgId: Option[Int] = Option(AMTAssignmentTable.save(asg))
 
                 // Load the first task from the selected route
@@ -265,7 +265,7 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
                 }
 
                 // Save HIT assignment details
-                val asg: AMTAssignment = AMTAssignment(0, hitId, assignmentId, timestamp, None, workerId, conditionId, routeId, false)
+                val asg: AMTAssignment = AMTAssignment(0, hitId, assignmentId, timestamp, None, workerId, conditionId, routeId, false, None)
                 val asgId: Option[Int] = Option(AMTAssignmentTable.save(asg))
 
                 // Load the first task from the selected route
@@ -399,7 +399,7 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
                     }
 
                     // Save HIT assignment details
-                    val asg: AMTAssignment = AMTAssignment(0, hitId, assignmentId, timestamp, None, workerId, conditionId, routeId, false)
+                    val asg: AMTAssignment = AMTAssignment(0, hitId, assignmentId, timestamp, None, workerId, conditionId, routeId, false, None)
                     val asgId: Option[Int] = Option(AMTAssignmentTable.save(asg))
 
                     // Load the first task from the selected route
@@ -492,7 +492,7 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
         val now: DateTime = new DateTime(DateTimeZone.UTC)
         val timestamp: Timestamp = new Timestamp(now.getMillis)
         val asg: AMTAssignment = AMTAssignment(0, submission.hitId, submission.assignmentId, timestamp, None,
-                                               submission.turkerId, conditionId, Some(submission.routeId), false)
+                                               submission.turkerId, conditionId, Some(submission.routeId), false, None)
         val asgId: Int = AMTAssignmentTable.save(asg)
 
         Future.successful(Ok(Json.obj("asg_id" -> asgId)))

--- a/app/models/amt/AMTAssignmentTable.scala
+++ b/app/models/amt/AMTAssignmentTable.scala
@@ -11,7 +11,8 @@ import scala.slick.lifted.ForeignKeyQuery
 
 case class AMTAssignment(amtAssignmentId: Int, hitId: String, assignmentId: String,
                          assignmentStart: Timestamp, assignmentEnd: Option[Timestamp],
-                         turkerId: String, conditionId: Int, routeId: Option[Int], completed: Boolean)
+                         turkerId: String, conditionId: Int, routeId: Option[Int], completed: Boolean,
+                         accepted: Option[Boolean])
 
 /**
  *
@@ -26,9 +27,10 @@ class AMTAssignmentTable(tag: Tag) extends Table[AMTAssignment](tag, Some("sidew
   def conditionId = column[Int]("condition_id", O.NotNull)
   def routeId = column[Option[Int]]("route_id", O.NotNull)
   def completed = column[Boolean]("completed", O.NotNull)
+  def accepted = column[Option[Boolean]]("accepted")
 
   def * = (amtAssignmentId, hitId, assignmentId, assignmentStart, assignmentEnd, turkerId, conditionId, routeId,
-    completed) <> ((AMTAssignment.apply _).tupled, AMTAssignment.unapply)
+    completed, accepted) <> ((AMTAssignment.apply _).tupled, AMTAssignment.unapply)
 
   def route: ForeignKeyQuery[RouteTable, Route] =
     foreignKey("amt_assignment_route_id_fkey", routeId, TableQuery[RouteTable])(_.routeId)
@@ -81,6 +83,18 @@ object AMTAssignmentTable {
   def updateAssignmentEnd(amtAssignmentId: Int, timestamp: Timestamp) = db.withTransaction { implicit session =>
     val q = for { asg <- amtAssignments if asg.amtAssignmentId === amtAssignmentId } yield asg.assignmentEnd
     q.update(Some(timestamp))
+  }
+
+  /**
+    * Update the `accepted` column of the specified amt_assigment row
+    * 
+    * @param amtAssignmentId
+    * @param accepted
+    * @return
+    */
+  def updateAccepted(amtAssignmentId: Int, accepted: Option[Boolean]) = db.withTransaction { implicit session =>
+    val q = for { asg <- amtAssignments if asg.amtAssignmentId === amtAssignmentId } yield asg.accepted
+    q.update(accepted)
   }
 }
 

--- a/conf/evolutions/default/7.sql
+++ b/conf/evolutions/default/7.sql
@@ -1,0 +1,9 @@
+
+# --- !Ups
+ALTER TABLE amt_assignment
+  ADD accepted BOOLEAN;
+
+
+# --- !Downs
+ALTER TABLE amt_assignment
+  DROP accepted;


### PR DESCRIPTION
Resolves #1096 

I've added an `accepted` column to the amt_assignment table that defaults to null. Right now we are running a Python script that accepts/rejects assignments from mturk. Updating the rows in this database to go from `null` to `true` or `false` would be done within this script.

To test:
1. Use a dump that had previously been running `sidewalk-mturk-v2` branch; use one that already has some entries in the `amt_assignmen`t table.
2. Compile and run; check that there are not "database in an inconsistent state" errors.
3. Verify that the evolution has been applied by looking at the the `amt_assignment` table, checking that it now has a new column `accepted` which is `null` for every entry.
4. Get yourself assigned something (go to [http://localhost:9000/auditCondition?conditionId=75&assignmentId=some_string&workerId=some_string&hitId=some_string&turkSubmitTo=localhost:5000/post](http://localhost:9000/auditCondition?conditionId=75&assignmentId=some_string&workerId=some_string&hitId=some_string&turkSubmitTo=localhost:5000/post), for example.
5. Check that a new entry has been added to the `amt_assignment` table as expected.
6. Audit that condition, and check that the new entries are being added for new routes and that they are being updated correctly when you finish routes.