### PR TITLE
Resolves #1106: Landing Page Legend Choropleth Extra Space

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1252,7 +1252,7 @@ kbd {
     top: 0px;
     width: 425px;
     max-width: 500px;
-    height: 130px;
+    height: 80px;
 }
 #results-choropleth-container {
     background-color: #fff;


### PR DESCRIPTION
Resolves #1106 

There was a lot of extra white space on the landing page legend choropleth. By editing the width in main.css, I was able to decrease the white space. 