### PR TITLE
Removed errant comma

### DIFF
--- a/app/views/audit.scala.html
+++ b/app/views/audit.scala.html
@@ -95,7 +95,7 @@
                         <span class="overlay-header">Advanced Neighborhood</span>
                     </p>
                     <p>
-                        <b>Warning:</b> This neighborhood is difficult to travel, and is only recommended for experienced users. Are you sure you would like to explore this neighborhood?
+                        <b>Warning:</b> This neighborhood is difficult to travel and is only recommended for experienced users. Are you sure you would like to explore this neighborhood?
                     </p>
                     <p>
                         If you get stuck, click the Jump button to navigate to a different area.


### PR DESCRIPTION
Resolves https://github.com/ProjectSidewalk/SidewalkWebpage/issues/1104#issuecomment-332334864

Removes the comma in the advanced neighborhood overlay.

![image](https://user-images.githubusercontent.com/2873216/30884757-a999ee04-a2c5-11e7-9812-9a0ff57c8f17.png)
