### PR TITLE
Resolves #1110: Fixes window in the advanced neighborhood overlay

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1181,17 +1181,17 @@ kbd {
 #advanced-neighborhood-text, #neighborhood-completion-text{
     color: white;
     text-align: center;
-    width: 90%;
+    width: 70%;
     position: relative;
     margin: auto;
     border-radius: 5px;
     font-size: 21px;
 }
 #advanced-neighborhood-text {
-    top: 30%;
+    top: 28%;
 }
 #neighborhood-completion-text {
-    top: 30%;
+    top: 28%;
 }
 #advanced-neighborhood-text p, #neighborhood-completion-text p{
     border-radius: 5px;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1181,17 +1181,17 @@ kbd {
 #advanced-neighborhood-text, #neighborhood-completion-text{
     color: white;
     text-align: center;
-    width: 65%;
+    width: 90%;
     position: relative;
     margin: auto;
     border-radius: 5px;
     font-size: 21px;
 }
 #advanced-neighborhood-text {
-    top: 35%;
+    top: 30%;
 }
 #neighborhood-completion-text {
-    top: 40%;
+    top: 30%;
 }
 #advanced-neighborhood-text p, #neighborhood-completion-text p{
     border-radius: 5px;


### PR DESCRIPTION
Resolves Issue #1110 

Edited the width percentages in the main.css file to make the Advanced Neighborhood overlay box more centered on the page. 

![image](https://user-images.githubusercontent.com/2873216/30982998-f4ce38e8-a43d-11e7-9b65-e6e6debc7870.png)
