### PR TITLE
Disabled labeling buttons on survey display

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/Main.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Main.js
@@ -219,10 +219,14 @@ function Main (params) {
         $('#survey-modal-container').on('show.bs.modal', function () {
             svl.popUpMessage.disableInteractions();
             svl.ribbon.disableModeSwitch();
+            svl.zoomControl.disableZoomIn();
+            svl.zoomControl.disableZoomOut();
         });
         $('#survey-modal-container').on('hide.bs.modal', function () {
             svl.popUpMessage.enableInteractions();
             svl.ribbon.enableModeSwitch();
+            svl.zoomControl.enableZoomIn();
+            svl.zoomControl.enableZoomOut();
         });
 
         $('#survey-modal-container').keydown(function(e) {

--- a/public/javascripts/SVLabel/src/SVLabel/Main.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Main.js
@@ -218,9 +218,11 @@ function Main (params) {
 
         $('#survey-modal-container').on('show.bs.modal', function () {
             svl.popUpMessage.disableInteractions();
+            svl.ribbon.disableModeSwitch();
         });
         $('#survey-modal-container').on('hide.bs.modal', function () {
             svl.popUpMessage.enableInteractions();
+            svl.ribbon.enableModeSwitch();
         });
 
         $('#survey-modal-container').keydown(function(e) {


### PR DESCRIPTION
Resolves #1091 . Complete the first 2 missions to display the survey. Try pressing labeling keyboard shortcuts and check that the label buttons don't get selected.

Please remember to check that the browser has reloaded svlabel.js or try this in incognito mode 