### PR TITLE
Resolves #1113 : The confirmation code is now auto displayed on the mission completion popup

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
@@ -126,17 +126,18 @@ function ModalMissionComplete (svl, missionContainer, taskContainer,
             });
 
             //console.log("Reached modal mission complete");
-            uiModalMissionComplete.generateConfirmationButton.onclick = function () {
-                var para = document.createElement("p");
-                var node = document.createTextNode("Confirmation Code: " + svl.confirmationCode);
-                para.appendChild(node);
-                para.setAttribute("id", "modal-mission-complete-confirmation-text");
-                this.after(para);
-                uiModalMissionComplete.confirmationText = $("#modal-mission-complete-confirmation-text");
-                uiModalMissionComplete.closeButton.css('visibility', "visible");
-                this.remove();
-                delete uiModalMissionComplete.generateConfirmationButton;
-            };
+            var confirmationCodeElement = document.createElement("h3");
+            confirmationCodeElement.innerHTML = "Confirmation Code <img src='/assets/javascripts/SVLabel/img/icons/Icon_OrangeCheckmark.png'  " +
+                "alt='Confirmation Code icon' align='middle' style='top:-1px;position:relative;width:18px;height:18px;'> : " +
+                svl.confirmationCode +
+                "<p></p>";
+            confirmationCodeElement.setAttribute("id", "modal-mission-complete-confirmation-text");
+            uiModalMissionComplete.generateConfirmationButton.after(confirmationCodeElement);
+            uiModalMissionComplete.confirmationText = $("#modal-mission-complete-confirmation-text");
+            uiModalMissionComplete.closeButton.css('visibility', "visible");
+            uiModalMissionComplete.generateConfirmationButton.remove();
+            delete uiModalMissionComplete.generateConfirmationButton;
+
             svl.ui.leftColumn.confirmationCode.attr('data-toggle','popover');
             svl.ui.leftColumn.confirmationCode.attr('title','Submit this code for HIT verification on Amazon Mechanical Turk');
             svl.ui.leftColumn.confirmationCode.attr('data-content',svl.confirmationCode);

--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
@@ -127,8 +127,9 @@ function ModalMissionComplete (svl, missionContainer, taskContainer,
 
             //console.log("Reached modal mission complete");
             var confirmationCodeElement = document.createElement("h3");
-            confirmationCodeElement.innerHTML = "Confirmation Code <img src='/assets/javascripts/SVLabel/img/icons/Icon_OrangeCheckmark.png'  " +
-                "alt='Confirmation Code icon' align='middle' style='top:-1px;position:relative;width:18px;height:18px;'> : " +
+            confirmationCodeElement.innerHTML = "<img src='/assets/javascripts/SVLabel/img/icons/Icon_OrangeCheckmark.png'  \" +\n" +
+                "                \"alt='Confirmation Code icon' align='middle' style='top:-1px;position:relative;width:18px;height:18px;'> " +
+                "Confirmation Code: " +
                 svl.confirmationCode +
                 "<p></p>";
             confirmationCodeElement.setAttribute("id", "modal-mission-complete-confirmation-text");


### PR DESCRIPTION
The action of clicking on the "generate confirmation code" would initialize the Orange MTurk code button next to the canvas. When turkers accidentally dismissed the completion popup by clicking outside the MTurk code button would remain hidden and hence #1113. I've removed the additional "click to generate code" requirement to just auto display the code and unhide the MTurk code button on the first mission's completion. 

To test:
1. Login as a turker using the mturk referrer for example localhost:9000/?referrer=mturk&hitId=h1&workerId=worker_bob&assignmentId=a1 
2. Complete the first mission.
3. Check that the mission completion popup shows the completion code instead of a "click to generate ..." button.
4. Check 2 cases 
 - Clicking outside the popup still creates the MTurk Code button to the left of the canvas.
 - Clicking on continue will create the MTurk Code button to the left of the canvas.

I've also slightly changed the text for the confirmation code by adding a smaller orange mturk code icon to it.

![image](https://user-images.githubusercontent.com/3580069/31048870-101d006c-a5f5-11e7-990a-ef23ddaff8bd.png)

