### PR TITLE
Resolves #1118 Onboarding jump message is now aligned with the jump button

### DIFF
--- a/app/views/audit.scala.html
+++ b/app/views/audit.scala.html
@@ -905,9 +905,9 @@
                     svl.amtAssignmentId = @AMTAssignmentTable.getMostRecentAMTAssignmentId(user.get.username);
                     svl.confirmationCode = "@AMTAssignmentTable.getConfirmationCode(user.get.username,AMTAssignmentTable.getMostRecentAssignmentId(user.get.username))";
                     @if(MissionTable.countCompletedMissionsByUserId(user.get.userId)==0){
-                        $("#left-column-confirmation-code-button").hide();
+                        $("#left-column-confirmation-code-button").css('visibility', "hidden");
                     } else{
-                        $("#left-column-confirmation-code-button").show();
+                        $("#left-column-confirmation-code-button").css('visibility', "");
                         $("#left-column-confirmation-code-button").attr('data-toggle','popover');
                         $("#left-column-confirmation-code-button").attr('title','Submit this code for HIT verification on Amazon Mechanical Turk');
                         $("#left-column-confirmation-code-button").attr('data-content',svl.confirmationCode);

--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
@@ -85,7 +85,7 @@ function ModalMissionComplete (svl, missionContainer, taskContainer,
             this._uiModalMissionComplete.confirmationText.remove();
             delete this._uiModalMissionComplete.confirmationText;
             delete svl.confirmationCode;
-            svl.ui.leftColumn.confirmationCode.show();
+            svl.ui.leftColumn.confirmationCode.css('visibility', '');
             svl.ui.leftColumn.confirmationCode.popover();
         }
     };


### PR DESCRIPTION
Resolves #1118. The mturk code button was hidden using css "display:none". The button occupies zero space using this method which was messing with the position of the onboarding message for the jump button. **Ideally the position of these messages should be linked with the associated element's id but they are instead hardcoded as absolute positions**. I've switched to modifying the "visibility" attribute instead so that the mturk code button occupies space even when it is hidden.

To test:

1. Use the mturk referrer to login as a turker.
2. When you go through onboarding before completing any missions check that you only see 3 left column buttons (jump,sound, and feedback). It doesnt matter when you retake the tutorial after completing a mission since the mturk code button will be visible then.
3. Check that the onboarding state that highlights the jump button should also show the related instruction message right next to it. 
