### PR TITLE
Resolves #1127: Landing Page miles static. Should be dynamically calculated

### DIFF
--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -206,7 +206,7 @@
             <div class="row" style="margin: 0 auto; width: 450px;">Your work is making a difference</div>
             <div class="row" id="content-text-2">
                 <p>Users like you have already mapped the accessibility of nearly half of Washington DC.
-                    That's 450miles—more than the distance from DC to Boston.</p>
+                    That's @("%.0f".format(StreetEdgeTable.auditedStreetDistance(1))) miles—more than the distance from DC to Boston.</p>
             </div>
             <button id="exploreButton" onclick="location.href = '@routes.ApplicationController.results';">
                 See results</button>


### PR DESCRIPTION
Resolves #1127 : 
Before, the miles within the landing page text did no match the one displayed below it. 

I edited it so that the two numbers circled in red are equal to one another. 
![image](https://user-images.githubusercontent.com/31173144/31309572-30e3a588-ab56-11e7-95e1-4e43926a5662.png)

Issue was the text was static, just had to change it to be the variable that pulls the number of miles in. 