### PR TITLE
Adds gsv_onboarding_pano table, filters onboarding labels from results choropleth

### DIFF
--- a/app/models/gsv/GSVOnboardingPanos.scala
+++ b/app/models/gsv/GSVOnboardingPanos.scala
@@ -1,0 +1,24 @@
+package models.gsv
+
+import models.utils.MyPostgresDriver.simple._
+import play.api.Play.current
+
+
+case class GSVOnboardingPano(gsvPanoramaId: String, hasLabels: Boolean)
+
+class GSVOnboardingPanoTable(tag: Tag) extends Table[GSVOnboardingPano](tag, Some("sidewalk"), "gsv_onboarding_pano") {
+  def gsvPanoramaId = column[String]("gsv_panorama_id", O.PrimaryKey)
+  def hasLabels = column[Boolean]("has_labels", O.NotNull)
+
+  def * = (gsvPanoramaId, hasLabels) <> ((GSVOnboardingPano.apply _).tupled, GSVOnboardingPano.unapply)
+}
+
+object GSVOnboardingPanoTable {
+  val db = play.api.db.slick.DB
+  val onboardingPanos = TableQuery[GSVOnboardingPanoTable]
+
+  def save(newOnboardingPano: GSVOnboardingPano): String = db.withTransaction { implicit session =>
+    onboardingPanos += newOnboardingPano
+    newOnboardingPano.gsvPanoramaId
+  }
+}

--- a/app/models/gsv/GSVOnboardingPanos.scala
+++ b/app/models/gsv/GSVOnboardingPanos.scala
@@ -7,7 +7,7 @@ import play.api.Play.current
 case class GSVOnboardingPano(gsvPanoramaId: String, hasLabels: Boolean)
 
 // NOTE: We chose to add this as a separate table solely because of the ease of implementation. Perhaps it would be best
-//       to just inclue a boolean `tutorial` column in the label table instead. This could still be done in the future.
+//       to just include a boolean `tutorial` column in the label table instead. This could still be done in the future.
 class GSVOnboardingPanoTable(tag: Tag) extends Table[GSVOnboardingPano](tag, Some("sidewalk"), "gsv_onboarding_pano") {
   def gsvPanoramaId = column[String]("gsv_panorama_id", O.PrimaryKey)
   def hasLabels = column[Boolean]("has_labels", O.NotNull)

--- a/app/models/gsv/GSVOnboardingPanos.scala
+++ b/app/models/gsv/GSVOnboardingPanos.scala
@@ -17,6 +17,14 @@ object GSVOnboardingPanoTable {
   val db = play.api.db.slick.DB
   val onboardingPanos = TableQuery[GSVOnboardingPanoTable]
 
+  def selectGSVOnboardingPanos(): List[GSVOnboardingPano] = db.withTransaction { implicit session =>
+    onboardingPanos.list
+  }
+
+  def getOnboardingPanoIds(): List[String] = db.withTransaction { implicit session =>
+    onboardingPanos.map(_.gsvPanoramaId).list
+  }
+
   def save(newOnboardingPano: GSVOnboardingPano): String = db.withTransaction { implicit session =>
     onboardingPanos += newOnboardingPano
     newOnboardingPano.gsvPanoramaId

--- a/app/models/gsv/GSVOnboardingPanos.scala
+++ b/app/models/gsv/GSVOnboardingPanos.scala
@@ -6,6 +6,8 @@ import play.api.Play.current
 
 case class GSVOnboardingPano(gsvPanoramaId: String, hasLabels: Boolean)
 
+// NOTE: We chose to add this as a separate table solely because of the ease of implementation. Perhaps it would be best
+//       to just inclue a boolean `tutorial` column in the label table instead. This could still be done in the future.
 class GSVOnboardingPanoTable(tag: Tag) extends Table[GSVOnboardingPano](tag, Some("sidewalk"), "gsv_onboarding_pano") {
   def gsvPanoramaId = column[String]("gsv_panorama_id", O.PrimaryKey)
   def hasLabels = column[Boolean]("has_labels", O.NotNull)

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -539,7 +539,6 @@ object LabelTable {
         |            FROM gsv_onboarding_pano
         |            WHERE has_labels = TRUE
         |          )
-        |          AND label.gsv_panorama_id NOT IN (SELECT gsv_panorama_id FROM gsv_onboarding_pano WHERE has_labels = TRUE)
         |          AND region_id = ?) AS labels
         |GROUP BY (labels.label_type)""".stripMargin
     )

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -533,6 +533,13 @@ object LabelTable {
         |          AND region.deleted = FALSE
         |          AND region.region_type_id = 2
         |          AND label.label_type_id NOT IN (1,5,6)
+        |          AND label.gsv_panorama_id NOT IN
+        |          (
+        |            SELECT gsv_panorama_id
+        |            FROM gsv_onboarding_pano
+        |            WHERE has_labels = TRUE
+        |          )
+        |          AND label.gsv_panorama_id NOT IN (SELECT gsv_panorama_id FROM gsv_onboarding_pano WHERE has_labels = TRUE)
         |          AND region_id = ?) AS labels
         |GROUP BY (labels.label_type)""".stripMargin
     )

--- a/conf/evolutions/default/7.sql
+++ b/conf/evolutions/default/7.sql
@@ -1,14 +1,16 @@
 
 # --- !Ups
-CREATE TABLE gsv_onboarding_panos
+CREATE TABLE gsv_onboarding_pano
 (
   gsv_panorama_id TEXT NOT NULL,
   has_labels BOOLEAN NOT NULL,
   PRIMARY KEY (gsv_panorama_id)
 );
 
-INSERT INTO gsv_onboarding_panos VALUES ('stxXyCKAbd73DmkM2vsIHA', TRUE);
-INSERT INTO gsv_onboarding_panos VALUES ('PTHUzZqpLdS1nTixJMoDSw', FALSE);
+INSERT INTO gsv_onboarding_pano VALUES ('stxXyCKAbd73DmkM2vsIHA', TRUE);
+INSERT INTO gsv_onboarding_pano VALUES ('PTHUzZqpLdS1nTixJMoDSw', FALSE);
+INSERT INTO gsv_onboarding_pano VALUES ('bdmGHJkiSgmO7_80SnbzXw', TRUE);
+INSERT INTO gsv_onboarding_pano VALUES ('OgLbmLAuC4urfE5o7GP_JQ', TRUE);
 
 # --- !Downs
-DROP TABLE gsv_onboarding_panos;
+DROP TABLE gsv_onboarding_pano;

--- a/conf/evolutions/default/7.sql
+++ b/conf/evolutions/default/7.sql
@@ -1,0 +1,14 @@
+
+# --- !Ups
+CREATE TABLE gsv_onboarding_panos
+(
+  gsv_panorama_id TEXT NOT NULL,
+  has_labels BOOLEAN NOT NULL,
+  PRIMARY KEY (gsv_panorama_id)
+);
+
+INSERT INTO gsv_onboarding_panos VALUES ('stxXyCKAbd73DmkM2vsIHA', TRUE);
+INSERT INTO gsv_onboarding_panos VALUES ('PTHUzZqpLdS1nTixJMoDSw', FALSE);
+
+# --- !Downs
+DROP TABLE gsv_onboarding_panos;

--- a/public/javascripts/AccessibilityChoropleth.js
+++ b/public/javascripts/AccessibilityChoropleth.js
@@ -268,7 +268,7 @@ function AccessibilityChoropleth(_, $, turf, difficultRegionIds) {
                 var regionLabel = _.find(labelCounts, function(x){ return x.region_id == region.region_id });
                 region.labels = regionLabel ? regionLabel.labels : {};
                 return region;
-            })
+            });
 
             // make a choropleth of neighborhood completion percentages
             initializeChoroplethNeighborhoodPolygons(choropleth, regionData);


### PR DESCRIPTION
There are many situations where we will want to weed out tutorial labels, particularly for analysis and on the admin dashboard. For now, I have just removed them from the results choropleth b/c it is public facing and we want to start driving traffic there again.

I made sure to exclude the pano ids from the current version, as well as the old version, of the tutorial.

We chose to add this as a separate table solely because of the ease of implementation. Perhaps it would be best to just include a boolean `tutorial` column in the label table instead. This could still be done in the future.

Here are before and after pictures of the results choropleth:
![old-results](https://user-images.githubusercontent.com/6518824/31469954-dacbdb34-aeb1-11e7-85d2-43d0fabc3f9e.png)
![updated-results](https://user-images.githubusercontent.com/6518824/31469955-dc33638e-aeb1-11e7-8d7c-a46b3324de2d.png)


Resolves #980 