### PR TITLE
Removed zoom and center on click from all choropleths

### DIFF
--- a/public/javascripts/AccessibilityChoropleth.js
+++ b/public/javascripts/AccessibilityChoropleth.js
@@ -181,15 +181,7 @@ function AccessibilityChoropleth(_, $, turf, difficultRegionIds) {
                 }
             });
             layer.on('click', function (e) {
-                var center = turf.center(this.feature),
-                    coordinates = center.geometry.coordinates,
-                    latlng = L.latLng(coordinates[1], coordinates[0]),
-                    zoom = map.getZoom();
-                zoom = zoom > 14 ? zoom : 14;
-
-                map.setView(latlng, zoom, {animate: true});
                 currentLayer = this;
-
 
                 // Log when a user clicks on a region on the choropleth
                 // Logs are of the form "Click_module=Choropleth_regionId=<regionId>_distanceLeft=<"0", "<1", "1" or ">1">_target=inspect"

--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -132,13 +132,6 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
                 //this.setStyle(neighborhoodPolygonStyle);
             });
             layer.on('click', function (e) {
-                var center = turf.center(this.feature),
-                    coordinates = center.geometry.coordinates,
-                    latlng = L.latLng(coordinates[1], coordinates[0]),
-                    zoom = map.getZoom();
-                zoom = zoom > 14 ? zoom : 14;
-
-                map.setView(latlng, zoom, {animate: true});
                 currentLayer = this;
             });
         }
@@ -300,13 +293,6 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
                 //this.setStyle(neighborhoodPolygonStyle);
             });
             layer.on('click', function (e) {
-                var center = turf.center(this.feature),
-                    coordinates = center.geometry.coordinates,
-                    latlng = L.latLng(coordinates[1], coordinates[0]),
-                    zoom = map.getZoom();
-                zoom = zoom > 14 ? zoom : 14;
-
-                map.setView(latlng, zoom, {animate: true});
                 currentLayer = this;
             });
         }

--- a/public/javascripts/Choropleth.js
+++ b/public/javascripts/Choropleth.js
@@ -145,15 +145,7 @@ function Choropleth(_, $, turf, difficultRegionIds) {
                 }
             });
             layer.on('click', function (e) {
-                var center = turf.center(this.feature),
-                    coordinates = center.geometry.coordinates,
-                    latlng = L.latLng(coordinates[1], coordinates[0]),
-                    zoom = map.getZoom();
-                zoom = zoom > 14 ? zoom : 14;
-
-                map.setView(latlng, zoom, {animate: true});
                 currentLayer = this;
-
 
                 // Log when a user clicks on a region on the choropleth
                 // Logs are of the form "Click_module=Choropleth_regionId=<regionId>_distanceLeft=<"0", "<1", "1" or ">1">_target=inspect"

--- a/public/javascripts/Progress/src/Progress.js
+++ b/public/javascripts/Progress/src/Progress.js
@@ -167,13 +167,6 @@ function Progress (_, $, c3, L, difficultRegionIds) {
                 //this.setStyle(neighborhoodPolygonStyle);
             });
             layer.on('click', function (e) {
-                var center = turf.center(this.feature),
-                    coordinates = center.geometry.coordinates,
-                    latlng = L.latLng(coordinates[1], coordinates[0]),
-                    zoom = map.getZoom();
-                zoom = zoom > 14 ? zoom : 14;
-
-                map.setView(latlng, zoom, { animate: true });
                 currentLayer = this;
 
 


### PR DESCRIPTION
I have removed the zooming and centering that occurs when clicking on a neighborhood in all choropleths. Here are the choropleths that I have verified that the zoom in has been removed from:
1. landing page
2. user dashboard
3. results page
4. admin dashboard map tab
5. admin dashboard analytics tab

Let me know if I have forgotten any!

Before clicking on a region (looks the same):
![pre-click](https://user-images.githubusercontent.com/6518824/31567742-eef2f78a-b03e-11e7-9480-f5d5ff0467e2.png)

How it used to look after clicking:
![yes-zoom](https://user-images.githubusercontent.com/6518824/31567756-fd9cc086-b03e-11e7-9133-b6c239923673.png)

How it looks with the changes I made:
![no-zoom](https://user-images.githubusercontent.com/6518824/31567761-02e18220-b03f-11e7-8fca-ce28a4622cda.png)

Resolves #1141 