### PR TITLE
Admins and owners now excluded from histograms on admin page

### DIFF
--- a/app/models/daos/UserDAOImpl.scala
+++ b/app/models/daos/UserDAOImpl.scala
@@ -243,7 +243,7 @@ object UserDAOImpl {
             |  ON sidewalk.user.user_id = sidewalk.user_role.user_id
             |INNER JOIN sidewalk.role
             |  ON sidewalk.role.role_id = sidewalk.user_role.role_id
-            |WHERE role.role in ('Owner', 'Administrator', 'Researcher')
+            |WHERE role.role IN ('Owner', 'Administrator', 'Researcher')
             |  AND audit_task.completed = true
           """.stripMargin
         )
@@ -257,7 +257,7 @@ object UserDAOImpl {
             |  ON sidewalk.user.user_id = sidewalk.user_role.user_id
             |INNER JOIN sidewalk.role
             |  ON sidewalk.role.role_id = sidewalk.user_role.role_id
-            |WHERE role.role in ('Owner', 'Administrator', 'Researcher')
+            |WHERE role.role IN ('Owner', 'Administrator', 'Researcher')
           """.stripMargin
         )
     }

--- a/app/models/user/UserRoleTable.scala
+++ b/app/models/user/UserRoleTable.scala
@@ -55,6 +55,6 @@ object UserRoleTable {
   }
 
   def isResearcher(userId: UUID): Boolean = db.withSession { implicit session =>
-    getRole(userId) == "Researcher"
+    List("Researcher", "Administrator", "Owner").contains(getRole(userId))
   }
 }


### PR DESCRIPTION
For the mission, label, and login count histograms on the admin page, there is a checkbox that includes/excludes researchers. During our update in how roles are implemented (PR #951 ), administrators and owners ended up being excluded from this list. This is the small fix to those graphs that we had forgotten when making the aforementioned update.