### PR TITLE
Resolves #1136: Made surveys visible to all registered users

### DIFF
--- a/app/controllers/SurveyController.scala
+++ b/app/controllers/SurveyController.scala
@@ -107,16 +107,20 @@ class SurveyController @Inject() (implicit val env: Environment[User, SessionAut
       case None =>
         val user: Option[DBUser] = UserTable.find("anonymous")
         UUID.fromString(user.get.userId)
+    }
+
+    request.identity match {
+      case Some(user) =>
+        val userRole: String = UserRoleTable.getRole(userId)
+
+        val numMissionsBeforeSurvey = 2
+        val userRoleForSurvey: List[String] = List("Turker","User","Researcher","Administrator","Owner")
+
+        val displaySurvey = userRoleForSurvey.contains(userRole) //&& MissionTable.countCompletedMissionsByUserId(userId) == numMissionsBeforeSurvey
+        Future.successful(Ok(Json.obj("displayModal" -> displaySurvey)))
+      case None =>
         Future.successful(Ok(Json.obj("displayModal" -> false)))
     }
-    val userRole: String = UserRoleTable.getRole(userId)
-
-    val numMissionsBeforeSurvey = 2
-    val userRoleForSurvey: List[String] = List("Turker","User","Researcher","Administrator","Owner")
-
-    val displaySurvey = userRoleForSurvey.contains(userRole) //&& MissionTable.countCompletedMissionsByUserId(userId) == numMissionsBeforeSurvey
-    Future.successful(Ok(Json.obj("displayModal" -> displaySurvey)))
-
   }
 
 }

--- a/app/controllers/SurveyController.scala
+++ b/app/controllers/SurveyController.scala
@@ -107,13 +107,14 @@ class SurveyController @Inject() (implicit val env: Environment[User, SessionAut
       case None =>
         val user: Option[DBUser] = UserTable.find("anonymous")
         UUID.fromString(user.get.userId)
+        Future.successful(Ok(Json.obj("displayModal" -> false)))
     }
     val userRole: String = UserRoleTable.getRole(userId)
 
     val numMissionsBeforeSurvey = 2
-    val userRoleForSurvey = "Turker"
+    val userRoleForSurvey: List[String] = List("Turker","User","Researcher","Administrator","Owner")
 
-    val displaySurvey = userRole == userRoleForSurvey //&& MissionTable.countCompletedMissionsByUserId(userId) == numMissionsBeforeSurvey
+    val displaySurvey = userRoleForSurvey.contains(userRole) //&& MissionTable.countCompletedMissionsByUserId(userId) == numMissionsBeforeSurvey
     Future.successful(Ok(Json.obj("displayModal" -> displaySurvey)))
 
   }

--- a/app/views/audit.scala.html
+++ b/app/views/audit.scala.html
@@ -22,7 +22,6 @@
     <link rel="stylesheet" href='@routes.Assets.at("stylesheets/animate.css")'/>
     <div id="page-loading"><img id="loading-gif" src='@routes.Assets.at("assets/page-load.gif")'/></div>
     @if(user){
-        @if(user.get.role.getOrElse("") == "Turker"){
             <div class="modal fade" id="survey-modal-container" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
                 <div class="modal-dialog">
                     <div class="modal-content" id="survey-modal">
@@ -84,7 +83,7 @@
                     </div><!-- /.modal-content -->
                 </div><!-- /.modal-dialog -->
             </div><!-- /.modal -->
-        }
+
     }
 
     <div class="container toolUI" style = "visibility: hidden;">

--- a/public/javascripts/SVLabel/src/SVLabel/mission/MissionProgress.js
+++ b/public/javascripts/SVLabel/src/SVLabel/mission/MissionProgress.js
@@ -50,7 +50,7 @@ function MissionProgress (svl, gameEffectModel, missionModel, modalModel, neighb
         mission.complete();
 
         // Survey prompt. Modal should display survey if
-        // 1. User is a Turker (/survey/display endpoint returns true if this is the case).
+        // 1. User has a role that is allowed to submit surveys (/survey/display endpoint returns true if this is the case).
         // 2. User has just completed numMissionsBeforeSurvey number of missions.
 
             var url = '/survey/display';


### PR DESCRIPTION
Resolves #1136. 

Testing Checklist 
 - Sign up as a new user. The survey should appear only on the completion of the new registered user's 2nd mission. 
 - Access a turker account using the mturk referrer (for example: http://localhost:9000/?referrer=mturk&hitId=test7&workerId=some_turker_name&assignmentId=test7).  The survey should appear only on the completion of the turker's 2nd mission.
 - The survey shouldn't appear after 2 missions as an anon user.