### PR TITLE
Resolves #497: Label count was including labels that were deleted

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/label/LabelContainer.js
+++ b/public/javascripts/SVLabel/src/SVLabel/label/LabelContainer.js
@@ -180,6 +180,9 @@ function LabelContainer($) {
         svl.labelCounter.decrement(label.getProperty("labelType"));
         label.remove();
 
+        var regionId = svl.neighborhoodContainer.getCurrentNeighborhood().getProperty("regionId");
+        neighborhoodLabels[regionId].pop(label);
+
         // Review label correctness if this is a ground truth insertion task.
         if (("goldenInsertion" in svl) &&
             svl.goldenInsertion &&


### PR DESCRIPTION
Resolves #497 

As mentioned in the comment I made in issue #497 , if you deleted a label that you placed, then when you completed the mission, that deleted label was still being included within the label counts. This caused the total label counts for any neighborhood to be incorrect. 

I resolved this by fixing LabelContainer.js

In this file, anytime a user would add a label, that label was pushed to neighborhoodLabels. But whenever a user deleted a label, it was never removed from neighborhoodLabels. I just added a line to "pop" the label from neighborhoodLabels and now it functions properly. 