### PR TITLE
1193 Fixes None.get error after truncating user_current_region table

### DIFF
--- a/app/views/admin/user.scala.html
+++ b/app/views/admin/user.scala.html
@@ -57,8 +57,8 @@
                     <tr>
                         <th class="col-md-2">Current Neighborhood</th>
                         <td class="col-md-10">
-                            @RegionPropertyTable.neighborhoodName(UserCurrentRegionTable.currentRegion(UUID.fromString(user.get.userId)).get)
-                            (Region ID: @UserCurrentRegionTable.currentRegion(UUID.fromString(user.get.userId)))
+                            @UserCurrentRegionTable.currentRegion(UUID.fromString(user.get.userId)).map {_ => RegionPropertyTable.neighborhoodName(_)}.getOrElse("Unassigned")
+                            (Region ID: @UserCurrentRegionTable.currentRegion(UUID.fromString(user.get.userId)).map{_ => _}.getOrElse("NA"))
                         </td>
                     </tr>
                 </table>


### PR DESCRIPTION
Before:
![admin_user_before](https://user-images.githubusercontent.com/6518824/33797194-c3f81c44-dcd1-11e7-9acb-4dab9218e4c2.png)

After:
![admin_user_after](https://user-images.githubusercontent.com/6518824/33797195-c86906f8-dcd1-11e7-9fed-acbe37103fd1.png)

What it looks like when there _is_ an entry in the table:
![admin_user_correct](https://user-images.githubusercontent.com/6518824/33797212-0fd5db24-dcd2-11e7-9c90-6388a466e323.png)


And for the person reviewing the PR, I guess you can't use the .getOrElse method in this situation, because it is in a .scala.html file. Not entirely sure what that's about, but I guess we have to use .map first? Anyway, I guess this is how you do it when using the Play framework, so there you go.

Resolves #1193 