### PR TITLE
1207 full priority based routing

### DIFF
--- a/app/controllers/AuditController.scala
+++ b/app/controllers/AuditController.scala
@@ -9,13 +9,12 @@ import com.mohiva.play.silhouette.impl.authenticators.SessionAuthenticator
 import com.vividsolutions.jts.geom._
 import controllers.headers.ProvidesHeader
 import formats.json.IssueFormats._
-import formats.json.TaskSubmissionFormats._
 import formats.json.CommentSubmissionFormats._
 import models.audit._
 import models.daos.slick.DBTableDefinitions.{DBUser, UserTable}
 import models.mission.MissionTable
 import models.region._
-import models.street.{StreetEdgeAssignmentCountTable, StreetEdgeIssue, StreetEdgeIssueTable}
+import models.street.{StreetEdgeIssue, StreetEdgeIssueTable}
 import models.user._
 import org.joda.time.{DateTime, DateTimeZone}
 import play.api.libs.json._

--- a/app/controllers/AuditController.scala
+++ b/app/controllers/AuditController.scala
@@ -110,42 +110,6 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
     }
   }
 
-  /**
-    * Deprecated now: Main audit controller is being used for this
-    *
-    * Returns an audit page for an easy region, if any are available.
-    *
-    * @return
-    */
-  def auditNewEasyRegion = UserAwareAction.async { implicit request =>
-    val now = new DateTime(DateTimeZone.UTC)
-    val timestamp: Timestamp = new Timestamp(now.getMillis)
-    val ipAddress: String = request.remoteAddress
-
-    request.identity match {
-      case Some(user) =>
-        WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, "Visit_Audit", timestamp))
-
-        UserCurrentRegionTable.assignEasyRegion(user.userId)
-
-        var region: Option[NamedRegion] = RegionTable.selectTheCurrentNamedRegion(user.userId)
-        region = RegionTable.selectTheCurrentNamedRegion(user.userId)
-
-        val task: NewTask =
-          if (region.isDefined) AuditTaskTable.selectANewTaskInARegion(region.get.regionId, user.userId)
-          else AuditTaskTable.selectANewTask(user.userId)
-        region = RegionTable.selectTheCurrentNamedRegion(user.userId)
-
-        Future.successful(Ok(views.html.audit("Project Sidewalk - Audit", Some(task), region, Some(user))))
-      case None =>
-        WebpageActivityTable.save(WebpageActivity(0, anonymousUser.userId.toString, ipAddress, "Visit_Audit", timestamp))
-
-        val region: Option[NamedRegion] = RegionTable.selectALeastAuditedEasyRegion
-        val task: NewTask = AuditTaskTable.selectANewTaskInARegion(region.get.regionId)
-        Future.successful(Ok(views.html.audit("Project Sidewalk - Audit", Some(task), region, None)))
-    }
-  }
-
 
   /**
     * Audit a given region

--- a/app/controllers/AuditController.scala
+++ b/app/controllers/AuditController.scala
@@ -62,7 +62,7 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
             UserCurrentRegionTable.assignEasyRegion(user.userId)
             region = RegionTable.selectTheCurrentNamedRegion(user.userId)
           case Some("regular") =>
-            // Assign an easy region if the query string has nextRegion=regular
+            // Assign a difficult region if the query string has nextRegion=regular and the user is experienced
             UserCurrentRegionTable.assignNextRegion(user.userId)
             region = RegionTable.selectTheCurrentNamedRegion(user.userId)
           case Some(illformedString) =>
@@ -145,7 +145,6 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
     * @return
     */
   def auditStreet(streetEdgeId: Int) = UserAwareAction.async { implicit request =>
-    // val regions: List[Region] = RegionTable.getRegionsIntersectingAStreet(streetEdgeId)
     val regions: List[NamedRegion] = RegionTable.selectNamedRegionsIntersectingAStreet(streetEdgeId)
     val region: Option[NamedRegion] = try {
       Some(regions.head)
@@ -155,7 +154,7 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
     }
 
     // TODO: Should this function be modified?
-    val task: NewTask = AuditTaskTable.selectANewTask(streetEdgeId)
+    val task: NewTask = AuditTaskTable.selectANewTask(streetEdgeId, request.identity.map(_.userId))
     request.identity match {
       case Some(user) => Future.successful(Ok(views.html.audit("Project Sidewalk - Audit", Some(task), region, Some(user))))
       case None => Future.successful(Ok(views.html.audit("Project Sidewalk - Audit", Some(task), region, None)))

--- a/app/controllers/AuditPriorityController.scala
+++ b/app/controllers/AuditPriorityController.scala
@@ -47,15 +47,4 @@ class AuditPriorityController @Inject() (implicit val env: Environment[User, Ses
       Future.successful(Redirect("/"))
     }
   }
-
-  /**
-    * Returns the street edge priority for all streets in a region.
-    *
-    * @param regionId
-    * @return
-    */
-  def getRegionStreetPriority(regionId: Int) = UserAwareAction.async { implicit request =>
-    val regionStreetPriorities: List[JsObject] = StreetEdgePriorityTable.getAllStreetEdgeInRegionPriority(regionId).map(_.toJSON)
-    Future.successful(Ok(JsArray(regionStreetPriorities)))
-  }
 }

--- a/app/controllers/TaskController.scala
+++ b/app/controllers/TaskController.scala
@@ -1,7 +1,6 @@
 package controllers
 
 import java.sql.Timestamp
-import java.util.{Calendar, Date, TimeZone, UUID}
 import javax.inject.Inject
 
 import com.mohiva.play.silhouette.api.{Environment, Silhouette}
@@ -9,7 +8,6 @@ import com.mohiva.play.silhouette.impl.authenticators.SessionAuthenticator
 import com.vividsolutions.jts.geom._
 import controllers.headers.ProvidesHeader
 import formats.json.MissionFormats._
-import formats.json.CommentSubmissionFormats._
 import formats.json.TaskSubmissionFormats._
 import models.amt.{AMTAssignment, AMTAssignmentTable}
 import models.audit._
@@ -19,7 +17,7 @@ import models.label._
 import models.mission.{Mission, MissionStatus, MissionTable}
 import models.region._
 import models.street.StreetEdgeAssignmentCountTable
-import models.user.{User, UserCurrentRegionTable}
+import models.user.User
 import org.joda.time.{DateTime, DateTimeZone}
 import play.api.Logger
 import play.api.libs.json._

--- a/app/controllers/TaskController.scala
+++ b/app/controllers/TaskController.scala
@@ -37,24 +37,11 @@ class TaskController @Inject() (implicit val env: Environment[User, SessionAuthe
   case class TaskPostReturnValue(auditTaskId: Int, streetEdgeId: Int, completedMissions: List[Mission])
 
   /**
-   * This method returns a task definition in the GeoJSON format.
-   * @return Task definition
-   */
-  def getTask = UserAwareAction.async { implicit request =>
-    request.identity match {
-      case Some(user) =>
-        val task = AuditTaskTable.selectANewTask(user.userId)
-        Future.successful(Ok(task.toJSON))
-      case None => Future.successful(Ok(AuditTaskTable.selectANewTask.toJSON))
-    }
-  }
-
-  /**
     * This method returns a task definition specified by the streetEdgeId.
     * @return Task definition
     */
   def getTaskByStreetEdgeId(streetEdgeId: Int) = UserAwareAction.async { implicit request =>
-    val task = AuditTaskTable.selectANewTask(streetEdgeId)
+    val task = AuditTaskTable.selectANewTask(streetEdgeId, None)
     Future.successful(Ok(task.toJSON))
   }
 

--- a/app/controllers/UserProfileController.scala
+++ b/app/controllers/UserProfileController.scala
@@ -10,7 +10,7 @@ import controllers.headers.ProvidesHeader
 import formats.json.UserFormats._
 import formats.json.TaskFormats._
 import forms._
-import models.audit.{AuditTaskInteraction, AuditTaskInteractionTable, AuditTaskTable, InteractionWithLabel}
+import models.audit.{AuditTaskInteractionTable, AuditTaskTable, InteractionWithLabel}
 import models.label.LabelTable
 import models.mission.MissionTable
 import models.user.User

--- a/app/models/audit/AuditTaskTable.scala
+++ b/app/models/audit/AuditTaskTable.scala
@@ -356,6 +356,7 @@ object AuditTaskTable {
       _task <- completedTasks if _task.userId === _user.userId
     } yield (_user.username.?, _task.streetEdgeId.?)
 
+    println("Called selectANewTask:userid - no region assigned")
     // Gets list of streets that user has not audited, takes 100, then picks the one with highest priority to assign
     // TODO: Remove randomness once real-time updates of priority have been implemented.
     val edges = (for {
@@ -392,6 +393,7 @@ object AuditTaskTable {
 
     // Take up to 100 of the highest priority edges, and assign one at random
     // TODO Remove randomness once real-time updates of priority have been implemented.
+    println("Called selectANewTask:anon - backup")
     val maxPriority: Option[Double] = streetEdgePriorities.map(_.priority).max.run
     val possibleTasks = (for {
       sep <- streetEdgePriorities if sep.priority === maxPriority
@@ -441,6 +443,7 @@ object AuditTaskTable {
    */
   def selectANewTaskInARegion(regionId: Int): NewTask = db.withSession { implicit session =>
     val timestamp: Timestamp = new Timestamp(Calendar.getInstance(TimeZone.getTimeZone("UTC")).getTime.getTime)
+    println("Called selectANewTask:anon - in a region")
 
     val edgesInRegion = for {
       _ser <- nonDeletedStreetEdgeRegions if _ser.regionId === regionId
@@ -476,6 +479,7 @@ object AuditTaskTable {
    */
   def selectANewTaskInARegion(regionId: Int, user: UUID): NewTask = db.withSession { implicit session =>
     val timestamp: Timestamp = new Timestamp(Calendar.getInstance(TimeZone.getTimeZone("UTC")).getTime.getTime)
+    println("Called selectANewTask:user - in a region")
 
     val edgesAuditedByUser: List[Int] =
       completedTasks.filter(_.userId === user.toString).groupBy(_.streetEdgeId).map(_._1).list

--- a/app/models/audit/AuditTaskTable.scala
+++ b/app/models/audit/AuditTaskTable.scala
@@ -356,7 +356,6 @@ object AuditTaskTable {
       _task <- completedTasks if _task.userId === _user.userId
     } yield (_user.username.?, _task.streetEdgeId.?)
 
-    println("Called selectANewTask:userid - no region assigned")
     // Gets list of streets that user has not audited, takes 100, then picks the one with highest priority to assign
     // TODO: Remove randomness once real-time updates of priority have been implemented.
     val edges = (for {
@@ -393,7 +392,6 @@ object AuditTaskTable {
 
     // Take up to 100 of the highest priority edges, and assign one at random
     // TODO Remove randomness once real-time updates of priority have been implemented.
-    println("Called selectANewTask:anon - backup")
     val maxPriority: Option[Double] = streetEdgePriorities.map(_.priority).max.run
     val possibleTasks = (for {
       sep <- streetEdgePriorities if sep.priority === maxPriority
@@ -443,7 +441,6 @@ object AuditTaskTable {
    */
   def selectANewTaskInARegion(regionId: Int): NewTask = db.withSession { implicit session =>
     val timestamp: Timestamp = new Timestamp(Calendar.getInstance(TimeZone.getTimeZone("UTC")).getTime.getTime)
-    println("Called selectANewTask:anon - in a region")
 
     val edgesInRegion = for {
       _ser <- nonDeletedStreetEdgeRegions if _ser.regionId === regionId
@@ -479,7 +476,6 @@ object AuditTaskTable {
    */
   def selectANewTaskInARegion(regionId: Int, user: UUID): NewTask = db.withSession { implicit session =>
     val timestamp: Timestamp = new Timestamp(Calendar.getInstance(TimeZone.getTimeZone("UTC")).getTime.getTime)
-    println("Called selectANewTask:user - in a region")
 
     val edgesAuditedByUser: List[Int] =
       completedTasks.filter(_.userId === user.toString).groupBy(_.streetEdgeId).map(_._1).list

--- a/app/models/region/RegionTable.scala
+++ b/app/models/region/RegionTable.scala
@@ -3,7 +3,6 @@ package models.region
 import java.util.UUID
 
 import com.vividsolutions.jts.geom.Polygon
-import models.mission.MissionTable
 
 import math._
 import models.street.{StreetEdgeAssignmentCountTable, StreetEdgeTable}

--- a/app/models/street/StreetEdgePriorityTable.scala
+++ b/app/models/street/StreetEdgePriorityTable.scala
@@ -71,16 +71,6 @@ object StreetEdgePriorityTable {
     streetEdgePriorities.filter{ edg => edg.streetEdgeId === streetEdgeId}.map(_.priority).list.head
   }
 
-  def getAllStreetEdgeInRegionPriority(regionId: Int): List[StreetEdgePriority] = db.withTransaction { implicit session =>
-    // Merge with street edge region table
-    val priorities = for {
-      _priorities <- streetEdgePriorities
-      _edgeRegions <- StreetEdgeRegionTable.nonDeletedStreetEdgeRegions if _priorities.streetEdgeId === _edgeRegions.streetEdgeId
-      if _edgeRegions.regionId === regionId
-    } yield _priorities
-    priorities.list
-  }
-
   def resetAllStreetEdge(priority: Double) = db.withTransaction { implicit session =>
     streetEdgePriorities.map(_.priority).update(priority)
   }

--- a/app/models/street/StreetEdgePriorityTable.scala
+++ b/app/models/street/StreetEdgePriorityTable.scala
@@ -1,7 +1,5 @@
 package models.street
 
-import models.audit.AuditTaskTable
-import models.region.RegionTable
 import models.utils.MyPostgresDriver.simple._
 import play.api.Play.current
 import play.api.libs.json._

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -32,7 +32,7 @@
     <script src='@routes.Assets.at("javascripts/lib/leaflet-omnivore.min.js")'></script>
     <script src='@routes.Assets.at("javascripts/lib/js.cookie.js")'></script>
     <script type="text/javascript"
-        src="https://maps.googleapis.com/maps/api/js?v=3.29&key=AIzaSyB0ToxwyHzvubTo9gm0zbtECWuEe3yYo8M&libraries=geometry">
+        src="https://maps.googleapis.com/maps/api/js?v=3.31&key=AIzaSyB0ToxwyHzvubTo9gm0zbtECWuEe3yYo8M&libraries=geometry">
     </script>
     <link href='@routes.Assets.at("stylesheets/fonts.css")' rel="stylesheet"/>
     <link href='@routes.Assets.at("stylesheets/mapbox.css")' rel='stylesheet' />

--- a/conf/routes
+++ b/conf/routes
@@ -65,7 +65,6 @@ PUT     /adminapi/setRole                                    @controllers.AdminC
 
 # Auditing tasks
 GET     /audit                                               @controllers.AuditController.audit(nextRegion: Option[String] ?= None)
-#GET     /audit/easyRegion                                    @controllers.AuditController.auditNewEasyRegion
 GET     /audit/region/:id                                    @controllers.AuditController.auditRegion(id: Int)
 GET     /audit/street/:id                                    @controllers.AuditController.auditStreet(id: Int)
 GET     /audit/recalculateStreetPriority                     @controllers.AuditPriorityController.recalculateStreetPriority

--- a/conf/routes
+++ b/conf/routes
@@ -52,8 +52,8 @@ GET     /adminapi/labelCounts/registered                     @controllers.AdminC
 GET     /adminapi/labelCounts/anonymous                      @controllers.AdminController.getAllAnonUserLabelCounts
 GET     /adminapi/labelCounts/turker                         @controllers.AdminController.getAllTurkerUserLabelCounts
 GET     /adminapi/audittimes                                 @controllers.AdminController.getAuditTimes()
-GET     /adminiapi/audittimesAnon                            @controllers.AdminController.getAnonAuditTimes()
-GET     /adminapi/audittimesTurker                           @controllers.AdminController.getTurkerAuditTimes()
+GET     /adminapi/auditTimesAnon                             @controllers.AdminController.getAnonAuditTimes()
+GET     /adminapi/auditTimesTurker                           @controllers.AdminController.getTurkerAuditTimes()
 
 GET     /adminapi/webpageActivity                            @controllers.AdminController.getAllWebpageActivities
 GET     /adminapi/webpageActivity/:activity                  @controllers.AdminController.getWebpageActivities(activity: String)

--- a/conf/routes
+++ b/conf/routes
@@ -69,7 +69,6 @@ GET     /audit                                               @controllers.AuditC
 GET     /audit/region/:id                                    @controllers.AuditController.auditRegion(id: Int)
 GET     /audit/street/:id                                    @controllers.AuditController.auditStreet(id: Int)
 GET     /audit/recalculateStreetPriority                     @controllers.AuditPriorityController.recalculateStreetPriority
-GET     /audit/getRegionStreetPriority/:regionId             @controllers.AuditPriorityController.getRegionStreetPriority(regionId: Int)
 POST    /audit/comment                                       @controllers.AuditController.postComment
 POST    /audit/nostreetview                                  @controllers.AuditController.postNoStreetView
 

--- a/conf/routes
+++ b/conf/routes
@@ -72,7 +72,6 @@ POST    /audit/comment                                       @controllers.AuditC
 POST    /audit/nostreetview                                  @controllers.AuditController.postNoStreetView
 
 # Task API.
-GET     /task                                                @controllers.TaskController.getTask
 GET     /task/street/:id                                     @controllers.TaskController.getTaskByStreetEdgeId(id: Int)
 GET     /tasks                                               @controllers.TaskController.getTasksInARegion(regionId: Int)
 POST    /task                                                @controllers.TaskController.post

--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -767,8 +767,8 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
 
             //Draw a chart of total time spent auditing
             $.getJSON("/adminapi/audittimes", function (regData) {
-                  $.getJSON("/adminiapi/audittimesAnon", function (anonData) {
-                      $.getJSON("/adminapi/audittimesTurker", function (turkerData) {
+                  $.getJSON("/adminapi/auditTimesAnon", function (anonData) {
+                      $.getJSON("/adminapi/auditTimesTurker", function (turkerData) {
                           var allTimes = [];
                           var regTimes = [];
                           var anonTimes = [];

--- a/public/javascripts/SVLabel/src/SVLabel/task/Task.js
+++ b/public/javascripts/SVLabel/src/SVLabel/task/Task.js
@@ -35,6 +35,7 @@ function Task (geojson, currentLat, currentLng) {
 
         self.setProperty("streetEdgeId", _geojson.features[0].properties.street_edge_id);
         self.setProperty("completionCount", _geojson.features[0].properties.completion_count);
+        self.setProperty("priority", _geojson.features[0].properties.priority);
 
         if (_geojson.features[0].properties.completed) {
             self.complete();
@@ -340,6 +341,10 @@ function Task (geojson, currentLat, currentLng) {
 
     this.getStreetCompletionCount = function () {
         return _geojson.features[0].properties.completion_count;
+    };
+
+    this.getStreetPriority = function () {
+        return _geojson.features[0].properties.priority;
     };
 
     /**

--- a/public/javascripts/SVLabel/src/SVLabel/task/Task.js
+++ b/public/javascripts/SVLabel/src/SVLabel/task/Task.js
@@ -347,6 +347,12 @@ function Task (geojson, currentLat, currentLng) {
         return _geojson.features[0].properties.priority;
     };
 
+    // Returns an integer in the range 0 to n-1, where larger n means higher priority.
+    this.getStreetPriorityDiscretized = function() {
+        var n = 4;
+        return Math.min(Math.floor(_geojson.features[0].properties.priority / 0.25), n - 1);
+    };
+
     /**
      * Returns the task start time
      */

--- a/public/javascripts/SVLabel/src/SVLabel/task/Task.js
+++ b/public/javascripts/SVLabel/src/SVLabel/task/Task.js
@@ -347,7 +347,16 @@ function Task (geojson, currentLat, currentLng) {
         return _geojson.features[0].properties.priority;
     };
 
-    // Returns an integer in the range 0 to n-1, where larger n means higher priority.
+    /**
+     * Returns an integer in the range 0 to n-1, where larger n means higher priority.
+     *
+     * Explanation:
+     * We want to split the range [0,1] into n = 4 ranges, each sub-range has a length of 1 / n = 1 / 4 = 0.25.
+     * To get the discretized order, we take the floor(priority / 0.25), which brings [0,0.25) -> 0, [0.25,0.5) -> 1,
+     * [0.5,0.75) -> 2, [0.75,1) -> 3, and 1 -> 4. But we really want [0.75-1] -> 3, so instead of
+     * floor(priority / (1 / n)), we have min(floor(priority / (1 / n)), n - 1).
+     * @returns {number}
+     */
     this.getStreetPriorityDiscretized = function() {
         var n = 4;
         return Math.min(Math.floor(_geojson.features[0].properties.priority / (1 / n)), n - 1);

--- a/public/javascripts/SVLabel/src/SVLabel/task/Task.js
+++ b/public/javascripts/SVLabel/src/SVLabel/task/Task.js
@@ -350,7 +350,7 @@ function Task (geojson, currentLat, currentLng) {
     // Returns an integer in the range 0 to n-1, where larger n means higher priority.
     this.getStreetPriorityDiscretized = function() {
         var n = 4;
-        return Math.min(Math.floor(_geojson.features[0].properties.priority / 0.25), n - 1);
+        return Math.min(Math.floor(_geojson.features[0].properties.priority / (1 / n)), n - 1);
     };
 
     /**

--- a/public/javascripts/SVLabel/src/SVLabel/task/TaskContainer.js
+++ b/public/javascripts/SVLabel/src/SVLabel/task/TaskContainer.js
@@ -217,13 +217,6 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
             if (!threshold) threshold = 0.01;  // 0.01 km.
             if (!unit) unit = "kilometers";
 
-            console.log("Before task completion filter");
-            for(var i = 0; i < tasks.length; i++){
-                var task_i = tasks[i];
-                console.log(task_i.getStreetEdgeId() + ":" + task_i.isCompleted() + ":" + task_i.getStreetCompletionCount() + ":" +
-                    task_i.getStreetPriority());
-            }
-
             tasks = tasks.filter(function (t) { return !t.isCompleted(); });
 
             if (taskIn) {
@@ -461,19 +454,16 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
             return null;
         }
         var highestPriorityTask = tasksNotCompletedByUser[0];
-        console.log("Highest Priority Task:" + highestPriorityTask.getStreetEdgeId());
 
         // If any of the connected tasks has max discretized priority, pick the highest priority one, o/w take the
         // highest priority task in the region.
         userCandidateTasks = self._findConnectedTasks(currentNeighborhoodId, finishedTask, false, null, null);
-        console.log(userCandidateTasks);
 
         userCandidateTasks = userCandidateTasks.filter(function(t) {
             return !t.isCompleted() && t.getStreetPriorityDiscretized() === highestPriorityTask.getStreetPriorityDiscretized();
         }).sort(function(t1,t2) {
             return t2.getStreetPriority() - t1.getStreetPriority();
         });
-        console.log(userCandidateTasks);
 
         if (userCandidateTasks.length > 0) {
             newTask = userCandidateTasks[0];

--- a/public/javascripts/SVLabel/src/SVLabel/task/TaskContainer.js
+++ b/public/javascripts/SVLabel/src/SVLabel/task/TaskContainer.js
@@ -216,6 +216,14 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
             var connectedTasks = [];
             if (!threshold) threshold = 0.01;  // 0.01 km.
             if (!unit) unit = "kilometers";
+
+            console.log("Before task completion filter");
+            for(var i = 0; i < tasks.length; i++){
+                var task_i = tasks[i];
+                console.log(task_i.getStreetEdgeId() + ":" + task_i.isCompleted() + ":" + task_i.getStreetCompletionCount() + ":" +
+                    task_i.getStreetPriority());
+            }
+
             tasks = tasks.filter(function (t) { return !t.isCompleted(); });
 
             if (taskIn) {
@@ -453,7 +461,7 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
             return null;
         }
         var highestPriorityTask = tasksNotCompletedByUser[0];
-        console.log(highestPriorityTask);
+        console.log("Highest Priority Task:" + highestPriorityTask.getStreetEdgeId());
 
         // If any of the connected tasks has max discretized priority, pick the highest priority one, o/w take the
         // highest priority task in the region.

--- a/public/javascripts/SVLabel/src/SVLabel/task/TaskContainer.js
+++ b/public/javascripts/SVLabel/src/SVLabel/task/TaskContainer.js
@@ -434,14 +434,6 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
      * - If the street you just audited connects to any of those, pick the highest priority one
      * - O/w jump to the highest priority street
      *
-     *
-     * If the neighborhood is not 100% complete (across all users)
-     *    - If the street you just audited connects to any
-     *     streets that no one has audited, then pick one, otherwise jump.
-     * Else
-     *    - If the street you just audited connects to any streets
-     *     that you have not personally audited, pick any one of those at random. Otherwise, jump.
-     *
      * @param finishedTask The task that has been finished.
      * @returns {*} Next task
      */

--- a/public/javascripts/SVLabel/src/SVLabel/task/TaskContainer.js
+++ b/public/javascripts/SVLabel/src/SVLabel/task/TaskContainer.js
@@ -449,7 +449,7 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
         }).sort(function(t1, t2) {
             return t2.getStreetPriority() - t1.getStreetPriority();
         });
-        if (tasksNotCompletedByUser.length === 0) {
+        if (tasksNotCompletedByUser.length === 0) { // user has audited entire region
             return null;
         }
         var highestPriorityTask = tasksNotCompletedByUser[0];


### PR DESCRIPTION
#### What this PR does
* Updates the front-end routing to be entirely based on priority
* Rewrites the task selection code in AuditTaskTable.scala to assign tasks based on priority instead of completion count. This is the most annoying part to test, because there are something like 6 different cases to test for.
* Removes a few large-ish chunks of code that we are no longer using, and I don't see a reason to keep - let me know if you disagree with any of those choices :)
* Generally cleaned up any code I saw that needed some cleaning... So I removed a bunch of unused import statements (which is why the PR has 11 modified files), fixed misspellings, renamed variable, made some minor changes to syntax to make things more readable/consistent, etc. I'm going to go through the PR and add comments next to anything that is essentially just cosmetic, and I don't think requires testing.

#### Description of how new priority-based routing works
This PR primarily fleshes out the priority based routing that @maddalihanumateja had started working on for the front-end. Users are now always routed to a street that has roughly the same priority level as the highest priority street in the region in which they are auditing. To do this, I discretized the priority (which goes from 0 to 1) into 4 levels; [0,0.25), [0.25,0.5), [0.5,0.75), [0.75,1].

Since our priority system is currently just based on audit count, where priority = 1/(1+audit_count), for audit counts 0, 1, 2, 3, 4, 5, ...; we have priority 1, 0.5, 0.33, 0.25, 0.2, 0.17, ...; this maps into priority levels 3, 2, 1, 1, 0, 0, ... Thus, within a given region, all streets with audit count = 0 will be audited, followed by those with audit count = 1, then those with audit count _either_ 2 _or_ 3, followed by anything else.

The way this works in practice is analogous to how we had talked about routing based on audit count beforehand, @manaswis. Example: If the entire region has been audited completely twice over, then when a user finishes a street, they will only jump if _none_ of the adjacent streets have an audit count of 2 or 3 (i.e., a street with region-wide maximum discretized priority). If the user does not have to jump, we take the highest priority adjacent street. If they do jump, we take the highest priority street in the entire region.

#### How to test
1. For the changes to the functions in AuditTaskTable.scala: I would go to each function that has been rewritten, add a print statement of some sort (to verify that this code was actually run when you try to test it), add in whatever print statements or whatever else you need to assure yourself that it is correct. Each one is sort of different, and I think you should just do whatever you need to feel good about its correctness.

    I made the comment above each of these functions more descriptive, so it now tells you when the code should be called, hopefully making testing easier. For example, I changed one description from "Get a task that is in a given region." to "Get a task that is in a given region. Used if a user has already been assigned a region, or from /audit/region."

2. For the priority-based routing code: I added some console logging statements to help guide you with this. For example, when a user finishes a street, I log the highest priority task in the region, the list of adjacent streets, then the list of adjacent streets after filtering out the ones with priority that is too low. You should go through and make sure the behavior seems correct, in the you get routed down streets with appropriate priority, you are only forced to jump when the priority of adjacent streets is too low, when you do jump you should be sent to a high-priority street, etc.

    In the console, I found the following functions of the Tasks to be useful: isCompleted(), getStreetEdgeId(), getStreetPriority(), getStreetPriorityDiscretized(), getStreetCompletionCount().


Let me know if I can clarify anything. Thanks!

Resolves #1207 