### PR TITLE
1211 priority with labeling frequency

### DIFF
--- a/app/controllers/AuditPriorityController.scala
+++ b/app/controllers/AuditPriorityController.scala
@@ -41,10 +41,10 @@ class AuditPriorityController @Inject() (implicit val env: Environment[User, Ses
 
       //Final Priority for each street edge is calculated by some transformation (paramScalingFunction)
       //of the weighted sum (weights are given by the weightVector) of the priority parameters.
-      val paramScalingFunction: (Double) => Double = StreetEdgePriorityTable.logisticFunction
+//      val paramScalingFunction: (Double) => Double = StreetEdgePriorityTable.logisticFunction
       val weightVector: List[Double] = List(1)
 //      val weightVector: List[Double] = List(0.1,0.9) -- how it would look with two priority param funcs
-      StreetEdgePriorityTable.updateAllStreetEdgePriorities(rankParameterGeneratorList, weightVector)
+      StreetEdgePriorityTable.updateAllStreetEdgePrioritiesTakeTwo(rankParameterGeneratorList, weightVector)
       Future.successful(Ok("Successfully recalculated street priorities"))
     } else {
       Future.successful(Redirect("/"))

--- a/app/controllers/AuditPriorityController.scala
+++ b/app/controllers/AuditPriorityController.scala
@@ -29,18 +29,21 @@ class AuditPriorityController @Inject() (implicit val env: Environment[User, Ses
     */
   def recalculateStreetPriority = UserAwareAction.async { implicit request =>
     if (isAdmin(request.identity)) {
-      //Example function pointer to the function that returns the completion count for each edge
-      //The functions being pointed to should always have the signature ()=>List[StreetEdgePriorityParameter]
+      // Function pointer to the function that returns priority based on audit counts of good/bad users
+      // The functions being pointed to should always have the signature ()=>List[StreetEdgePriorityParameter]
       // (Takes no input arguments and returns a List[StreetEdgePriorityParameter])
-      val completionCountPriority = () => {StreetEdgePriorityTable.selectCompletionCountPriority}
-      //Example list of function pointers that will generate priority parameters.
-      //In this case I'm assuming I have 2 functions (but both are the same completion count functions)
+      val completionCountPriority = () => { StreetEdgePriorityTable.selectGoodBadUserCompletionCountPriority }
+
+      // List of function pointers that will generate priority parameters.
       val rankParameterGeneratorList: List[() => List[StreetEdgePriorityParameter]] =
-        List(completionCountPriority,completionCountPriority)
+        List(completionCountPriority)
+//        List(completionCountPriority1,completionCountPriority2) // how it would look with two priority param funcs
+
       //Final Priority for each street edge is calculated by some transformation (paramScalingFunction)
       //of the weighted sum (weights are given by the weightVector) of the priority parameters.
       val paramScalingFunction: (Double) => Double = StreetEdgePriorityTable.logisticFunction
-      val weightVector: List[Double] = List(0.1,0.9)
+      val weightVector: List[Double] = List(1)
+//      val weightVector: List[Double] = List(0.1,0.9) -- how it would look with two priority param funcs
       StreetEdgePriorityTable.updateAllStreetEdgePriorities(rankParameterGeneratorList, weightVector)
       Future.successful(Ok("Successfully recalculated street priorities"))
     } else {

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -6,6 +6,7 @@ import java.util.UUID
 import com.vividsolutions.jts.geom.LineString
 import models.audit.{AuditTask, AuditTaskEnvironmentTable, AuditTaskInteraction, AuditTaskTable}
 import models.daos.slick.DBTableDefinitions.UserTable
+import models.gsv.GSVOnboardingPanoTable
 import models.region.RegionTable
 import models.user.{RoleTable, UserRoleTable}
 import models.utils.MyPostgresDriver.simple._
@@ -88,6 +89,8 @@ object LabelTable {
 
   val labelsWithoutDeleted = labels.filter(_.deleted === false)
   val neighborhoods = regions.filter(_.deleted === false).filter(_.regionTypeId === 2)
+
+  val labelsWithoutDeletedOrOnboarding = labelsWithoutDeleted.filterNot(_.gsvPanoramaId inSet GSVOnboardingPanoTable.getOnboardingPanoIds)
 
 
   val anonId = "97760883-8ef0-4309-9a5e-0c086ef27573"

--- a/conf/evolutions/default/12.sql
+++ b/conf/evolutions/default/12.sql
@@ -9,7 +9,7 @@ CREATE TABLE street_edge_priority
 );
 
 INSERT INTO street_edge_priority (street_edge_id)
-SELECT DISTINCT(street_edge_id) FROM street_edge_region;
+SELECT street_edge_id FROM street_edge WHERE deleted = FALSE;
 
 # --- !Downs
 DROP TABLE street_edge_priority;


### PR DESCRIPTION
NOTE: Do not review this PR until PR #1206 has been merged into develop.

This PR does the following
* Replaces the audit count priority function with one that discounts the audits of users with low labeling frequency. Assuming "bad" labelers are those with a labeling frequency less than 3.75 labels / 100 meters, the new priority function is as follows:
    ```
    if good_user_audit_count == 0 -> priority = 1
    else -> priority = 1 / (1 + good_user_audit_count + 0.25*bad_user_audit_count)
    ```
* Improves the speed with which the `street_edge_priority` table is updated, by saving intermediate values in a Scala object instead of doing all updates directly on the table entries
* Fixes the evolutions file that adds the `street_edge_priority` table, which was adding more entries than was necessary.

### Testing
First, recalculate the street priorities using the new function by going to the route [/audit/recalculateStreetPriority](http://localhost:9000/audit/recalculateStreetPriority). You can then peruse the `street_edge_priority` table, ensuring that (1) there are no priority values of 0 (b/c of the fix in the 3rd bullet above), (2) values in the table are no longer restricted to 1/(1+0), 1/(1+1), 1/(1+2), ...; they now have possible values of 1 or 1/(1+1.0), 1/(1+1.25), 1/(1 + 1.5), ... _Note that there still should not be values in (0.5,1), exclusive._

The only other thing I think you would want to do for testing is to verify that a few values in the table are correct. This requires manually calculating the different values in the priority function described above. I'll add some SQL queries below that should give you those values. _Note: make sure that you do this test after recalculating all street priorities, and before you do any auditing_.

Let's say you want to verify the priority for street edge `<S>`. You will need the `good_user_audit_count` and `bad_user_audit_count`. First, just get the list of users with completed audits for that street.
#### List of users
Registered users:
```
SELECT DISTINCT(user_id)
FROM audit_task
WHERE completed = TRUE
  AND street_edge_id = <S>
  AND user_id <> '97760883-8ef0-4309-9a5e-0c086ef27573';
```
Anonymous users:
```
SELECT DISTINCT(ip_address)
FROM audit_task
INNER JOIN audit_task_environment ON audit_task.audit_task_id = audit_task_environment.audit_task_id
WHERE completed = TRUE
  AND street_edge_id = <S>
  AND user_id = '97760883-8ef0-4309-9a5e-0c086ef27573';
```

Now for each user `<U>`, or IP address `<IP>`, you need to find their labeling frequency, so we need to calculate the number of labels they've placed, and the distance they've audited. First, the number of labels placed for a user (note that we include _incomplete_ audits in the label count):
#### Label counts
Registered users:
```
SELECT COUNT(*)
FROM audit_task
INNER JOIN label ON audit_task.audit_task_id = label.audit_task_id
WHERE audit_task.user_id = <U>
  AND label.deleted = FALSE
  AND label.gsv_panorama_id NOT IN ('bdmGHJkiSgmO7_80SnbzXw', 'OgLbmLAuC4urfE5o7GP_JQ', 'stxXyCKAbd73DmkM2vsIHA');
```
Anonymous users:
```
SELECT COUNT(DISTINCT(label_id))
FROM audit_task_environment
INNER JOIN audit_task ON audit_task_environment.audit_task_id = audit_task.audit_task_id
INNER JOIN label ON audit_task.audit_task_id = label.audit_task_id
WHERE ip_address = <IP>
  AND audit_task.user_id = '97760883-8ef0-4309-9a5e-0c086ef27573'
  AND label.deleted = FALSE
  AND label.gsv_panorama_id NOT IN ('bdmGHJkiSgmO7_80SnbzXw', 'OgLbmLAuC4urfE5o7GP_JQ', 'stxXyCKAbd73DmkM2vsIHA');
```

And for each user, the distance that they've audited in meters:
#### Audited distance
Registered users:
```
SELECT SUM(ST_LENGTH(ST_TRANSFORM(geom,26918)))
FROM audit_task
INNER JOIN street_edge ON audit_task.street_edge_id = street_edge.street_edge_id
WHERE audit_task.user_id = <U>
  AND audit_task.completed = TRUE;
```
Anonymous users:
```
SELECT SUM(ST_LENGTH(ST_TRANSFORM(geom,26918)))
FROM
(
  SELECT DISTINCT(street_edge.street_edge_id), geom
  FROM audit_task_environment
  INNER JOIN audit_task ON audit_task_environment.audit_task_id = audit_task.audit_task_id
  INNER JOIN street_edge ON audit_task.street_edge_id = street_edge.street_edge_id
  WHERE ip_address = <IP>
    AND audit_task.user_id = '97760883-8ef0-4309-9a5e-0c086ef27573'
    AND audit_task.completed = TRUE
) AS "edges"
```

Then for each user, take `100*label_count / audited_distance` (*100 b/c we are looking at labels/100m). For each user with `labeling_frequency > 3.75`, add one to the `good_user_audit_count`; and vice-versa for users with a lower labeling frequency.

Resolves #1211 