### PR TITLE
1214 assign region from priority

### DIFF
--- a/app/controllers/AuditController.scala
+++ b/app/controllers/AuditController.scala
@@ -62,18 +62,12 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
             if (UserCurrentRegionTable.isAssigned(user.userId)) RegionTable.selectTheCurrentNamedRegion(user.userId)
             else UserCurrentRegionTable.assignRegion(user.userId)
         }
-        println(region.map(_.regionId))
-        println("IS REGION EMPTY? " + region.isEmpty)
-        println("IS TASK AVAILABLE? " + AuditTaskTable.isTaskAvailable(user.userId, region.get.regionId))
-        println("IS MISSION AVAILABLE? " + MissionTable.isMissionAvailable(user.userId, region.get.regionId))
 
         // Check if a user still has tasks available in this region.
         if (region.isEmpty ||
             !AuditTaskTable.isTaskAvailable(user.userId, region.get.regionId) ||
             !MissionTable.isMissionAvailable(user.userId, region.get.regionId)) {
-          println(region.map(_.regionId))
           region = UserCurrentRegionTable.assignRegion(user.userId)
-          println(region.map(_.regionId))
         }
 
         nextRegion match {
@@ -86,7 +80,6 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
             WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, "Visit_Audit", timestamp))
 
             val task: Option[NewTask] = AuditTaskTable.selectANewTaskInARegion(region.get.regionId, user.userId)
-
             Future.successful(Ok(views.html.audit("Project Sidewalk - Audit", task, region, Some(user))))
         }
       // For anonymous users.

--- a/app/controllers/CredentialsAuthController.scala
+++ b/app/controllers/CredentialsAuthController.scala
@@ -108,7 +108,7 @@ class CredentialsAuthController @Inject() (
     val updatedAuthenticator = authenticator.copy(expirationDate=expirationDate, idleTimeout = Some(2592000))
 
     if (!UserCurrentRegionTable.isAssigned(user.userId)) {
-      UserCurrentRegionTable.assignEasyRegion(user.userId)
+      UserCurrentRegionTable.assignRegion(user.userId)
     }
 
     // Add Timestamp

--- a/app/controllers/RegionController.scala
+++ b/app/controllers/RegionController.scala
@@ -49,7 +49,7 @@ class RegionController @Inject() (implicit val env: Environment[User, SessionAut
 
               case None =>
                 // Assigns a region to the user on request from a signed in user
-                UserCurrentRegionTable.assignNextRegion(user.userId).get.regionId
+                UserCurrentRegionTable.assignRegion(user.userId).get.regionId
             }
           case None =>
           // Get a region for the anonymous user

--- a/app/controllers/RegionController.scala
+++ b/app/controllers/RegionController.scala
@@ -49,12 +49,11 @@ class RegionController @Inject() (implicit val env: Environment[User, SessionAut
 
               case None =>
                 // Assigns a region to the user on request from a signed in user
-                UserCurrentRegionTable.assignNextRegion(user.userId)
+                UserCurrentRegionTable.assignNextRegion(user.userId).get.regionId
             }
           case None =>
           // Get a region for the anonymous user
-            val region: Option[NamedRegion] = RegionTable.selectALeastAuditedEasyRegion
-            region.get.regionId
+            RegionTable.selectAHighPriorityEasyRegion.get.regionId
         }
 
         Future.successful(Ok(Json.obj(
@@ -69,7 +68,7 @@ class RegionController @Inject() (implicit val env: Environment[User, SessionAut
     * @return
     */
   def getDifficultNeighborhoods = UserAwareAction.async { implicit request =>
-    Future.successful(Ok(Json.obj("regionIds" -> UserCurrentRegionTable.difficultRegionIds)))
+    Future.successful(Ok(Json.obj("regionIds" -> RegionTable.difficultRegionIds)))
   }
 
   /**

--- a/app/models/audit/AuditTaskTable.scala
+++ b/app/models/audit/AuditTaskTable.scala
@@ -405,7 +405,11 @@ object AuditTaskTable {
     } yield (se.streetEdgeId, se.geom, se.x1, se.y1, se.x2, se.y2, timestamp, cc._2, sp.priority, false)
 
     // Take the highest priority street.
-    edgesWithCompletionCountAndPriority.sortBy(_._9.desc).firstOption.map(NewTask.tupled)
+    val task: Option[NewTask] = edgesWithCompletionCountAndPriority.sortBy(_._9.desc).firstOption.map(NewTask.tupled)
+
+    // If a task was found, update the street_edge_assignment_count table.
+    task.map(t => StreetEdgeAssignmentCountTable.incrementAssignment(t.edgeId))
+    task
   }
 
   /**

--- a/app/models/audit/AuditTaskTable.scala
+++ b/app/models/audit/AuditTaskTable.scala
@@ -214,25 +214,48 @@ object AuditTaskTable {
   }
 
   /**
+    * Gets list streets that the user has not audited.
+    *
+    * @param user
+    * @return
+    */
+  def streetEdgeIdsNotAuditedByUser(user: UUID): List[Int] = db.withSession { implicit session =>
+
+    val edgesAuditedByUser: List[Int] =
+      completedTasks.filter(_.userId === user.toString).groupBy(_.streetEdgeId).map(_._1).list
+
+    streetEdgesWithoutDeleted.filterNot(_.streetEdgeId inSet edgesAuditedByUser).map(_.streetEdgeId).list
+  }
+
+  /**
+    * Gets the list of streets in the specified region that the user has not audited.
+    *
+    * @param user
+    * @param regionId
+    * @return
+    */
+  def streetEdgeIdsNotAuditedByUser(user: UUID, regionId: Int): List[Int] = db.withSession { implicit session =>
+
+    val edgesAuditedByUser: List[Int] =
+      completedTasks.filter(_.userId === user.toString).groupBy(_.streetEdgeId).map(_._1).list
+
+    val unAuditedEdges = for {
+      _ser <- nonDeletedStreetEdgeRegions if _ser.regionId === regionId
+      _edges <- streetEdges if _ser.streetEdgeId === _edges.streetEdgeId
+      if !(_edges.streetEdgeId inSet edgesAuditedByUser)
+    } yield _edges
+
+    unAuditedEdges.map(_.streetEdgeId).list
+  }
+
+  /**
     * Verify if there are tasks available for the user in the given region
     *
-    * @param userId user id
+    * @param user user id
     */
-  def isTaskAvailable(userId: UUID, regionId: Int): Boolean = db.withSession { implicit session =>
-    val selectAvailableTaskQuery = Q.query[(Int, String), Int](
-      """SELECT COUNT(audit_task.*) FROM sidewalk.user_current_region
-        |INNER JOIN sidewalk.region
-        |ON region.region_id = ?
-        |INNER JOIN sidewalk.street_edge
-        |ON ST_Intersects(region.geom, street_edge.geom)
-        |LEFT JOIN sidewalk.audit_task
-        |ON street_edge.street_edge_id = audit_task.street_edge_id
-        |WHERE user_current_region.user_id = ?
-        |AND (audit_task.audit_task_id IS NULL OR NOT audit_task.completed)
-      """.stripMargin
-    )
+  def isTaskAvailable(user: UUID, regionId: Int): Boolean = db.withSession { implicit session =>
 
-    val availableTasks: Int = selectAvailableTaskQuery((regionId, userId.toString)).list.head
+    val availableTasks: Int = streetEdgeIdsNotAuditedByUser(user, regionId).length
     availableTasks > 0
   }
 
@@ -348,38 +371,29 @@ object AuditTaskTable {
    * @param user User ID.
    * @return
    */
-  def selectANewTask(user: UUID): NewTask = db.withSession { implicit session =>
+  def selectANewTask(user: UUID): Option[NewTask] = db.withSession { implicit session =>
     val timestamp: Timestamp = new Timestamp(Calendar.getInstance(TimeZone.getTimeZone("UTC")).getTime.getTime)
 
-    val tasksCompletedByUser = for {
-      _user <- users.filter(_.userId === user.toString)
-      _task <- completedTasks if _task.userId === _user.userId
-    } yield (_user.username.?, _task.streetEdgeId.?)
+    // Get list of streets that user has not audited, then pick the one with highest priority to assign.
+    val edges = streetEdges.filter(_.streetEdgeId inSet streetEdgeIdsNotAuditedByUser(user))
 
-    // Gets list of streets that user has not audited, takes 100, then picks the one with highest priority to assign
-    // TODO: Remove randomness once real-time updates of priority have been implemented.
-    val edges = (for {
-      (_edge, _task) <- streetEdgesWithoutDeleted.leftJoin(tasksCompletedByUser).on(_.streetEdgeId === _._2)
-      if _task._1.isEmpty
-    } yield _edge).take(100)
-
+    // Join with other queries to get completion count and priority for each of the street edges.
     val edgesWithCompletionCountAndPriority = for {
       se <- edges
       scc <- streetCompletionCounts if se.streetEdgeId === scc._1
       sep <- StreetEdgePriorityTable.streetEdgePriorities if scc._1 === sep.streetEdgeId
-    } yield (se.streetEdgeId, se.geom, se.x1, se.y1, se.x2, se.y2, timestamp, scc._2, sep.priority)
-    assert(edgesWithCompletionCountAndPriority.list.nonEmpty)
+    } yield (se.streetEdgeId, se.geom, se.x1, se.y1, se.x2, se.y2, timestamp, scc._2, sep.priority, false)
 
-    val maxPriority: Option[Double] = edgesWithCompletionCountAndPriority.map(_._9).max.run
-    val edge = edgesWithCompletionCountAndPriority.filter(_._9 === maxPriority).list.head
+    // Take the highest priority street.
+    val edge: Option[NewTask] = edgesWithCompletionCountAndPriority.sortBy(_._9.desc).firstOption.map(NewTask.tupled)
 
-    // Find a region that this street belongs to, and assign user to that region
-    val regionId: Int = StreetEdgeRegionTable.selectNonDeletedByStreetEdgeId(edge._1).head.regionId
-    UserCurrentRegionTable.update(user, regionId)
-
-    // Increment the assignment count and return the task
-    StreetEdgeAssignmentCountTable.incrementAssignment(edge._1)
-    NewTask(edge._1, edge._2, edge._3, edge._4, edge._5, edge._6, edge._7, edge._8, edge._9, completed=false)
+    // If we find a task that the user hasn't completed, update userCurrentRegion & streetEdgeAssignment_count tables.
+    if (edge.isDefined) {
+      val regionId: Int = StreetEdgeRegionTable.selectNonDeletedByStreetEdgeId(edge.get.edgeId).head.regionId
+      UserCurrentRegionTable.update(user, regionId)
+      StreetEdgeAssignmentCountTable.incrementAssignment(edge.get.edgeId)
+    }
+    edge
   }
 
   /**
@@ -390,21 +404,18 @@ object AuditTaskTable {
   def selectANewTask: NewTask = db.withSession { implicit session =>
     val timestamp: Timestamp = new Timestamp(Calendar.getInstance(TimeZone.getTimeZone("UTC")).getTime.getTime)
 
-    // Take up to 100 of the highest priority edges, and assign one at random
-    // TODO Remove randomness once real-time updates of priority have been implemented.
-    val maxPriority: Option[Double] = streetEdgePriorities.map(_.priority).max.run
-    val possibleTasks = (for {
-      sep <- streetEdgePriorities if sep.priority === maxPriority
+    // Join with other queries to get completion count and priority for each of the street edges.
+    val possibleTasks = for {
+      sep <- streetEdgePriorities
       se <- streetEdgesWithoutDeleted if sep.streetEdgeId === se.streetEdgeId
       scc <- streetCompletionCounts if se.streetEdgeId === scc._1
-    } yield (
-      se.streetEdgeId, se.geom, se.x1, se.y1, se.x2, se.y2, timestamp, scc._2, sep.priority, false)).take(100).list
+    } yield (se.streetEdgeId, se.geom, se.x1, se.y1, se.x2, se.y2, timestamp, scc._2, sep.priority, false)
 
-    assert(possibleTasks.nonEmpty)
-    val task = Random.shuffle(possibleTasks).head
+    // Take the highest priority street.
+    val task: NewTask = NewTask.tupled(possibleTasks.sortBy(_._9.desc).first)
 
-    StreetEdgeAssignmentCountTable.incrementAssignment(task._1)
-    NewTask.tupled(task)
+    StreetEdgeAssignmentCountTable.incrementAssignment(task.edgeId)
+    task
   }
 
   /**
@@ -419,14 +430,14 @@ object AuditTaskTable {
     // Set completed to true if the user has already audited this street.
     val userCompleted: Boolean = if (user.isDefined) userHasAuditedStreet(streetEdgeId, user.get) else false
 
-    val edges = (for {
+    // Join with other queries to get completion count and priority for each of the street edges.
+    val edges = for {
       se <- streetEdgesWithoutDeleted if se.streetEdgeId === streetEdgeId
       scc <- streetCompletionCounts if se.streetEdgeId === scc._1
       sep <- streetEdgePriorities if scc._1 === sep.streetEdgeId
-    } yield (se.streetEdgeId, se.geom, se.x1, se.y1, se.x2, se.y2, timestamp, scc._2, sep.priority, userCompleted)).list
+    } yield (se.streetEdgeId, se.geom, se.x1, se.y1, se.x2, se.y2, timestamp, scc._2, sep.priority, userCompleted)
 
-    assert(edges.nonEmpty)
-    var task: NewTask = NewTask.tupled(edges.head)
+    var task: NewTask = NewTask.tupled(edges.first)
 
     StreetEdgeAssignmentCountTable.incrementAssignment(task.edgeId)
     task
@@ -442,28 +453,25 @@ object AuditTaskTable {
   def selectANewTaskInARegion(regionId: Int): NewTask = db.withSession { implicit session =>
     val timestamp: Timestamp = new Timestamp(Calendar.getInstance(TimeZone.getTimeZone("UTC")).getTime.getTime)
 
-    val edgesInRegion = for {
-      _ser <- nonDeletedStreetEdgeRegions if _ser.regionId === regionId
-      _edges <- streetEdges if _ser.streetEdgeId === _edges.streetEdgeId
-    } yield _edges
+    // Join with other queries to get completion count and priority for each of the street edges.
+    val edgesWithCompletionCountAndPriority = for {
+      ser <- nonDeletedStreetEdgeRegions if ser.regionId === regionId
+      se <- streetEdges if ser.streetEdgeId === se.streetEdgeId
+      sp <- streetEdgePriorities if se.streetEdgeId === sp.streetEdgeId
+      cc <- streetCompletionCounts if sp.streetEdgeId === cc._1
+    } yield (se.streetEdgeId, se.geom, se.x1, se.y1, se.x2, se.y2, timestamp, cc._2, sp.priority, false)
 
-    val maxPriority: Option[Double] =
-      streetEdgePriorities.innerJoin(edgesInRegion).on(_.streetEdgeId === _.streetEdgeId).map(_._1.priority).max.run
+    // Take the highest priority street.
+    val task: Option[NewTask] = edgesWithCompletionCountAndPriority.sortBy(_._9.desc).firstOption.map(NewTask.tupled)
 
-    val highPriorityTask = (for {
-      sp <- streetEdgePriorities if sp.priority === maxPriority
-      se <- edgesInRegion if sp.streetEdgeId === se.streetEdgeId
-      cc <- streetCompletionCounts if se.streetEdgeId === cc._1
-    } yield (se.streetEdgeId, se.geom, se.x1, se.y1, se.x2, se.y2, timestamp, cc._2, sp.priority, false)).list.headOption
-
-    highPriorityTask match {
+    task match {
       case Some(e) =>
         // Increment the assignment count and return the task
-        StreetEdgeAssignmentCountTable.incrementAssignment(e._1)
-        NewTask.tupled(e)
+        StreetEdgeAssignmentCountTable.incrementAssignment(e.edgeId)
+        e
       case None =>
         Logger.warn("Unable to assign a task in region " + regionId + " to an anonymous user.")
-        selectANewTask // The list is empty for whatever the reason
+        selectANewTask // If for some reason there were no streets associated with that region id, take any street
     }
   }
 
@@ -474,38 +482,25 @@ object AuditTaskTable {
    * @param user User ID.
    * @return
    */
-  def selectANewTaskInARegion(regionId: Int, user: UUID): NewTask = db.withSession { implicit session =>
+  def selectANewTaskInARegion(regionId: Int, user: UUID): Option[NewTask] = db.withSession { implicit session =>
     val timestamp: Timestamp = new Timestamp(Calendar.getInstance(TimeZone.getTimeZone("UTC")).getTime.getTime)
 
-    val edgesAuditedByUser: List[Int] =
-      completedTasks.filter(_.userId === user.toString).groupBy(_.streetEdgeId).map(_._1).list
+    // Get the streets that the user has not already completed.
+    val edgesInRegion = streetEdges.filter(_.streetEdgeId inSet streetEdgeIdsNotAuditedByUser(user, regionId))
 
-    val edgesInRegion = for {
-      _ser <- nonDeletedStreetEdgeRegions if _ser.regionId === regionId
-      _edges <- streetEdges if _ser.streetEdgeId === _edges.streetEdgeId
-      if !(_edges.streetEdgeId inSet edgesAuditedByUser)
-    } yield _edges
-
-    val maxPriority: Option[Double] =
-      streetEdgePriorities.innerJoin(edgesInRegion).on(_.streetEdgeId === _.streetEdgeId).map(_._1.priority).max.run
-
-    val highPriorityTask = (for {
-      sp <- streetEdgePriorities if sp.priority === maxPriority
+    // Join with other queries to get completion count and priority for each of the street edges.
+    val possibleTasks = for {
+      sp <- streetEdgePriorities
       se <- edgesInRegion if sp.streetEdgeId === se.streetEdgeId
       cc <- streetCompletionCounts if se.streetEdgeId === cc._1
-    } yield (se.streetEdgeId, se.geom, se.x1, se.y1, se.x2, se.y2, timestamp, cc._2, sp.priority, false)).list.headOption
+    } yield (se.streetEdgeId, se.geom, se.x1, se.y1, se.x2, se.y2, timestamp, cc._2, sp.priority, false)
 
-    highPriorityTask match {
-      case Some(e) =>
-        // Increment the assignment count and return the task
-        StreetEdgeAssignmentCountTable.incrementAssignment(e._1)
-        NewTask.tupled(e)
+    // Get the highest priority task.
+    val task: Option[NewTask] = possibleTasks.sortBy(_._9.desc).firstOption.map(NewTask.tupled)
 
-      // If the user has already audited all streets in the region, then the count would be null, so give them a
-      // new task in a new region.
-      case None =>
-        selectANewTask(user)
-    }
+    // If a task was found, update the street_edge_assignment_count table.
+    task.map(t => StreetEdgeAssignmentCountTable.incrementAssignment(t.edgeId))
+    task
   }
 
   /**

--- a/app/models/label/LabelTypeTable.scala
+++ b/app/models/label/LabelTypeTable.scala
@@ -30,13 +30,8 @@ object LabelTypeTable {
    * @return
    */
   def labelTypeToId(labelType: String): Int = db.withTransaction { implicit session =>
-    try {
-      labelTypes.filter(_.labelType === labelType).map(_.labelTypeId).list.head
-    } catch {
-      case e: java.util.NoSuchElementException => {
-        LabelTypeTable.save(LabelType(0, labelType, ""))
-      }
-    }
+    val typeId: Option[Int] = labelTypes.filter(_.labelType === labelType).map(_.labelTypeId).list.headOption
+    typeId.getOrElse(LabelTypeTable.save(LabelType(0, labelType, "")))
   }
 
   /**

--- a/app/models/region/RegionTable.scala
+++ b/app/models/region/RegionTable.scala
@@ -122,7 +122,7 @@ object RegionTable {
     */
   def selectAHighPriorityRegion(userId: UUID): Option[NamedRegion] = db.withSession { implicit session =>
     println("REGULAR SELECTION FOR USER")
-    val possibleRegionIds: List[Int] = MissionTable.selectIncompleteRegions(userId).toList
+    val possibleRegionIds: List[Int] = MissionTable.selectIncompleteRegionsUsingTasks(userId).toList
 
     selectAHighPriorityRegionGeneric(possibleRegionIds) match {
       case Some(region) => Some(region)
@@ -139,7 +139,7 @@ object RegionTable {
   def selectAHighPriorityEasyRegion(userId: UUID): Option[NamedRegion] = db.withSession { implicit session =>
     println("EASY SELECTION FOR USER")
     val possibleRegionIds: List[Int] =
-      MissionTable.selectIncompleteRegions(userId).filterNot(difficultRegionIds.contains(_)).toList
+      MissionTable.selectIncompleteRegionsUsingTasks(userId).filterNot(difficultRegionIds.contains(_)).toList
 
     selectAHighPriorityRegionGeneric(possibleRegionIds) match {
       case Some(region) => Some(region)

--- a/app/models/region/RegionTable.scala
+++ b/app/models/region/RegionTable.scala
@@ -89,6 +89,7 @@ object RegionTable {
     * @return
     */
   def selectAHighPriorityEasyRegion: Option[NamedRegion] = db.withSession { implicit session =>
+    println("EASY SELECTION")
     val possibleRegionIds: List[Int] =
       regionsWithoutDeleted.filterNot(_.regionId inSet difficultRegionIds).map(_.regionId).list
 
@@ -104,6 +105,7 @@ object RegionTable {
     * @return
     */
   def selectAHighPriorityRegion: Option[NamedRegion] = db.withSession { implicit session =>
+    println("REGULAR SELECTION")
     val possibleRegionIds: List[Int] = regionsWithoutDeleted.map(_.regionId).list
 
     selectAHighPriorityRegionGeneric(possibleRegionIds) match {
@@ -119,6 +121,7 @@ object RegionTable {
     * @return
     */
   def selectAHighPriorityRegion(userId: UUID): Option[NamedRegion] = db.withSession { implicit session =>
+    println("REGULAR SELECTION FOR USER")
     val possibleRegionIds: List[Int] = MissionTable.selectIncompleteRegions(userId).toList
 
     selectAHighPriorityRegionGeneric(possibleRegionIds) match {
@@ -134,6 +137,7 @@ object RegionTable {
     * @return
     */
   def selectAHighPriorityEasyRegion(userId: UUID): Option[NamedRegion] = db.withSession { implicit session =>
+    println("EASY SELECTION FOR USER")
     val possibleRegionIds: List[Int] =
       MissionTable.selectIncompleteRegions(userId).filterNot(difficultRegionIds.contains(_)).toList
 
@@ -150,6 +154,7 @@ object RegionTable {
     * @return
     */
   def selectAHighPriorityRegionGeneric(possibleRegionIds: List[Int]): Option[NamedRegion] = db.withSession { implicit session =>
+    println("GENERIC SELECTION")
 
     val highestPriorityRegions: List[Int] =
       StreetEdgeRegionTable.streetEdgeRegionTable
@@ -158,7 +163,8 @@ object RegionTable {
       .map { case (_region, _priority) => (_region.regionId, _priority.priority) } // select region_id, priority
       .groupBy(_._1).map { case (_regionId, group) => (_regionId, group.map(_._2).avg) } // get avg priority by region
       .sortBy(_._2.desc).take(5).map(_._1).list // take the 5 with highest average priority, select region_id
-    println(highestPriorityRegions)
+    println("Highest priority regions: " + highestPriorityRegions)
+    println()
 
     scala.util.Random.shuffle(highestPriorityRegions).headOption.flatMap(selectANamedRegion)
   }

--- a/app/models/region/RegionTable.scala
+++ b/app/models/region/RegionTable.scala
@@ -89,7 +89,6 @@ object RegionTable {
     * @return
     */
   def selectAHighPriorityEasyRegion: Option[NamedRegion] = db.withSession { implicit session =>
-    println("EASY SELECTION")
     val possibleRegionIds: List[Int] =
       regionsWithoutDeleted.filterNot(_.regionId inSet difficultRegionIds).map(_.regionId).list
 
@@ -105,7 +104,6 @@ object RegionTable {
     * @return
     */
   def selectAHighPriorityRegion: Option[NamedRegion] = db.withSession { implicit session =>
-    println("REGULAR SELECTION")
     val possibleRegionIds: List[Int] = regionsWithoutDeleted.map(_.regionId).list
 
     selectAHighPriorityRegionGeneric(possibleRegionIds) match {
@@ -121,7 +119,6 @@ object RegionTable {
     * @return
     */
   def selectAHighPriorityRegion(userId: UUID): Option[NamedRegion] = db.withSession { implicit session =>
-    println("REGULAR SELECTION FOR USER")
     val possibleRegionIds: List[Int] = MissionTable.selectIncompleteRegionsUsingTasks(userId).toList
 
     selectAHighPriorityRegionGeneric(possibleRegionIds) match {
@@ -137,7 +134,6 @@ object RegionTable {
     * @return
     */
   def selectAHighPriorityEasyRegion(userId: UUID): Option[NamedRegion] = db.withSession { implicit session =>
-    println("EASY SELECTION FOR USER")
     val possibleRegionIds: List[Int] =
       MissionTable.selectIncompleteRegionsUsingTasks(userId).filterNot(difficultRegionIds.contains(_)).toList
 
@@ -154,7 +150,6 @@ object RegionTable {
     * @return
     */
   def selectAHighPriorityRegionGeneric(possibleRegionIds: List[Int]): Option[NamedRegion] = db.withSession { implicit session =>
-    println("GENERIC SELECTION")
 
     val highestPriorityRegions: List[Int] =
       StreetEdgeRegionTable.streetEdgeRegionTable
@@ -163,8 +158,6 @@ object RegionTable {
       .map { case (_region, _priority) => (_region.regionId, _priority.priority) } // select region_id, priority
       .groupBy(_._1).map { case (_regionId, group) => (_regionId, group.map(_._2).avg) } // get avg priority by region
       .sortBy(_._2.desc).take(5).map(_._1).list // take the 5 with highest average priority, select region_id
-    println("Highest priority regions: " + highestPriorityRegions)
-    println()
 
     scala.util.Random.shuffle(highestPriorityRegions).headOption.flatMap(selectANamedRegion)
   }

--- a/app/models/region/RegionTable.scala
+++ b/app/models/region/RegionTable.scala
@@ -3,9 +3,10 @@ package models.region
 import java.util.UUID
 
 import com.vividsolutions.jts.geom.Polygon
+import models.mission.MissionTable
 
 import math._
-import models.street.{StreetEdgeAssignmentCountTable, StreetEdgeTable}
+import models.street.{StreetEdgePriorityTable, StreetEdgeRegionTable}
 import models.user.UserCurrentRegionTable
 import models.utils.MyPostgresDriver
 import models.utils.MyPostgresDriver.simple._
@@ -56,38 +57,14 @@ object RegionTable {
   val regionProperties = TableQuery[RegionPropertyTable]
   val userCurrentRegions = TableQuery[UserCurrentRegionTable]
 
+  // These regions are buggy, so we steer new users away from them
+  val difficultRegionIds: List[Int] = List(251, 281, 317, 366)
   val regionsWithoutDeleted = regions.filter(_.deleted === false)
   val neighborhoods = regionsWithoutDeleted.filter(_.regionTypeId === 2)
   val namedRegions = for {
     (_neighborhoods, _regionProperties) <- neighborhoods.leftJoin(regionProperties).on(_.regionId === _.regionId)
     if _regionProperties.key === "Neighborhood Name"
   } yield (_neighborhoods.regionId, _regionProperties.value.?, _neighborhoods.geom)
-
-  // Create a round robin neighborhood supplier to be used in getRegion.
-  // http://stackoverflow.com/questions/19771992/is-there-a-round-robin-circular-queue-avaliable-in-scala-collections
-  // http://stackoverflow.com/questions/7619642/consume-items-from-a-scala-iterator
-  val neighborhoodRoundRobin = db.withSession { implicit session =>
-    val neighborhoods = regionsWithoutDeleted.filter(_.regionTypeId === 2).list
-    Iterator.continually(neighborhoods).flatten
-  }
-
-  val namedRegionRoundRobin = db.withSession { implicit session =>
-    val neighborhoods = regionsWithoutDeleted.filter(_.regionTypeId === 2)
-    val namedRegions = for {
-      (_neighborhoods, _regionProperties) <- neighborhoods.leftJoin(regionProperties).on(_.regionId === _.regionId)
-      if _regionProperties.key === "Neighborhood Name"
-    } yield (_neighborhoods.regionId, _regionProperties.value.?, _neighborhoods.geom)
-
-    val namedRegionsList: List[NamedRegion] = namedRegions.list.map(x => NamedRegion.tupled(x))
-    val namedRegionMap: Map[Int, NamedRegion] = namedRegionsList.map(nr => nr.regionId -> nr).toMap
-
-    // Sort the NamedRegions based on their completion rates
-    val completionRates = StreetEdgeAssignmentCountTable.computeNeighborhoodCompletionRate(1).sortWith(_.rate < _.rate)
-    val sortedRegionIds = completionRates.map(_.regionId)
-    val sortedNamedRegionList: List[NamedRegion] = for (regionId <- sortedRegionIds) yield namedRegionMap(regionId)
-
-    Iterator.continually(sortedNamedRegionList).flatten
-  }
 
   /**
    * Returns a list of all the neighborhood regions
@@ -107,78 +84,83 @@ object RegionTable {
   }
 
   /**
-    * Get a Region in a round-robin fashion.
+    * Picks one of the easy regions with highest average priority.
     *
     * @return
     */
-  def selectARegionRoundRobin: Option[Region] = db.withSession { implicit session =>
-    Some(neighborhoodRoundRobin.next)
-  }
+  def selectAHighPriorityEasyRegion: Option[NamedRegion] = db.withSession { implicit session =>
+    val possibleRegionIds: List[Int] =
+      regionsWithoutDeleted.filterNot(_.regionId inSet difficultRegionIds).map(_.regionId).list
 
-  /**
-    * Get a Named Region in a round-robin fashion, giving novice users easy regions if possible.
-    *
-    * @return
-    */
-  def selectANamedRegionRoundRobin(userId: UUID): Option[NamedRegion] = db.withSession { implicit session =>
-    // If a novice user (audited less than 2 miles)
-    if (StreetEdgeTable.getDistanceAudited(userId) < UserCurrentRegionTable.experiencedUserMileageThreshold) {
-      selectAnEasyNamedRegionRoundRobin
-    } else {
-      Some(namedRegionRoundRobin.next)
+    selectAHighPriorityRegionGeneric(possibleRegionIds) match {
+      case Some(region) => Some(region)
+      case _ => selectAHighPriorityRegion // Should only happen if all regions are difficult regions.
     }
   }
 
   /**
-    * Get a Named Region that has not been flagged as difficult (if any are left) in a round-robin fashion.
-    * Used for anonymous users
+    * Picks one of the regions with highest average priority.
     *
     * @return
     */
-  def selectAnEasyNamedRegionRoundRobin: Option[NamedRegion] = db.withSession { implicit session =>
-    // If the first one is an easy region, use it. O/w keep getting regions until we get an easy one (or we have
-    // wrapped around back to the first region, meaning there are no easy regions left).
-    val firstRegion = namedRegionRoundRobin.next
-    if (!UserCurrentRegionTable.difficultRegionIds.contains(firstRegion.regionId)) {
-      Some(firstRegion)
-    } else {
-      var currentRegion = namedRegionRoundRobin.next
-      while (currentRegion.regionId != firstRegion.regionId &&
-        UserCurrentRegionTable.difficultRegionIds.contains(currentRegion.regionId)) {
-        currentRegion = namedRegionRoundRobin.next
-      }
-      Some(currentRegion)
+  def selectAHighPriorityRegion: Option[NamedRegion] = db.withSession { implicit session =>
+    val possibleRegionIds: List[Int] = regionsWithoutDeleted.map(_.regionId).list
+
+    selectAHighPriorityRegionGeneric(possibleRegionIds) match {
+      case Some(region) => Some(region)
+      case _ => None // Should never happen.
     }
   }
 
   /**
-    * Get a named easy region that is amongst the least audited regions
-    * Used for anonymous users
+    * Picks one of the regions with highest average priority out of those that the user has not completed.
     *
+    * @param userId
     * @return
     */
-  def selectALeastAuditedEasyRegion: Option[NamedRegion] = db.withSession { implicit session =>
+  def selectAHighPriorityRegion(userId: UUID): Option[NamedRegion] = db.withSession { implicit session =>
+    val possibleRegionIds: List[Int] = MissionTable.selectIncompleteRegions(userId).toList
 
-    // Assign one of the unaudited regions.
-    // TODO: Assign one of the least-audited regions that are easy.
-    val completions: List[RegionCompletion] =
-      RegionCompletionTable.regionCompletions
-        .filterNot(_.regionId inSet UserCurrentRegionTable.difficultRegionIds)
-        .filter(region => region.auditedDistance / region.totalDistance < 0.9999)
-        .sortBy(region => region.auditedDistance / region.totalDistance).take(10).list
-
-    val regionId: Int = completions match {
-      case Nil =>
-        // Indicates that there are no unaudited regions across all users. In this case, pick any easy region.
-        val regionIds: List[Int] = namedRegions.list.map(_._1)
-        scala.util.Random.shuffle(regionIds).filterNot(UserCurrentRegionTable.difficultRegionIds.contains(_)).head
-      case _ =>
-        // Pick an easy region that is least audited
-        scala.util.Random.shuffle(completions).head.regionId
+    selectAHighPriorityRegionGeneric(possibleRegionIds) match {
+      case Some(region) => Some(region)
+      case _ => selectAHighPriorityRegion // Should only happen if user has completed all regions.
     }
-    val selectedNamedRegion = namedRegions.filter(_._1 === regionId).list.map(x => NamedRegion.tupled(x))
-    selectedNamedRegion.headOption
+  }
 
+  /**
+    * Picks one of the easy regions with highest average priority out of those that the user has not completed.
+    *
+    * @param userId
+    * @return
+    */
+  def selectAHighPriorityEasyRegion(userId: UUID): Option[NamedRegion] = db.withSession { implicit session =>
+    val possibleRegionIds: List[Int] =
+      MissionTable.selectIncompleteRegions(userId).filterNot(difficultRegionIds.contains(_)).toList
+
+    selectAHighPriorityRegionGeneric(possibleRegionIds) match {
+      case Some(region) => Some(region)
+      case _ => selectAHighPriorityRegion(userId) // Should only happen if user has completed all easy regions.
+    }
+  }
+
+  /**
+    * Out of the provided regions, picks one of the 5 with highest average priority across their street edges.
+    *
+    * @param possibleRegionIds
+    * @return
+    */
+  def selectAHighPriorityRegionGeneric(possibleRegionIds: List[Int]): Option[NamedRegion] = db.withSession { implicit session =>
+
+    val highestPriorityRegions: List[Int] =
+      StreetEdgeRegionTable.streetEdgeRegionTable
+      .filter(_.regionId inSet possibleRegionIds)
+      .innerJoin(StreetEdgePriorityTable.streetEdgePriorities).on(_.streetEdgeId === _.streetEdgeId)
+      .map { case (_region, _priority) => (_region.regionId, _priority.priority) } // select region_id, priority
+      .groupBy(_._1).map { case (_regionId, group) => (_regionId, group.map(_._2).avg) } // get avg priority by region
+      .sortBy(_._2.desc).take(5).map(_._1).list // take the 5 with highest average priority, select region_id
+    println(highestPriorityRegions)
+
+    scala.util.Random.shuffle(highestPriorityRegions).headOption.flatMap(selectANamedRegion)
   }
 
   /**
@@ -188,13 +170,7 @@ object RegionTable {
     * @return
     */
   def selectANeighborhood(regionId: Int): Option[Region] = db.withSession { implicit session =>
-    try {
-      val l = neighborhoods.filter(_.regionId === regionId).list
-      l.headOption
-    } catch {
-      case e: NoSuchElementException => None
-      case _: Throwable => None  // Shouldn't reach here
-    }
+      neighborhoods.filter(_.regionId === regionId).list.headOption
   }
 
   /**
@@ -204,18 +180,12 @@ object RegionTable {
     * @return
     */
   def selectANamedRegion(regionId: Int): Option[NamedRegion] = db.withSession { implicit session =>
-    try {
-      val filteredNeighborhoods = neighborhoods.filter(_.regionId === regionId)
-      val _regions = for {
-        (_neighborhoods, _properties) <- filteredNeighborhoods.leftJoin(regionProperties).on(_.regionId === _.regionId)
-        if _properties.key === "Neighborhood Name"
-      } yield (_neighborhoods.regionId, _properties.value.?, _neighborhoods.geom)
-      val namedRegionsList = _regions.list.map(x => NamedRegion.tupled(x))
-      namedRegionsList.headOption
-    } catch {
-      case e: NoSuchElementException => None
-      case _: Throwable => None  // Shouldn't reach here
-    }
+    val filteredNeighborhoods = neighborhoods.filter(_.regionId === regionId)
+    val _regions = for {
+      (_neighborhoods, _properties) <- filteredNeighborhoods.leftJoin(regionProperties).on(_.regionId === _.regionId)
+      if _properties.key === "Neighborhood Name"
+    } yield (_neighborhoods.regionId, _properties.value.?, _neighborhoods.geom)
+    _regions.list.headOption.map(x => NamedRegion.tupled(x))
   }
 
   /**
@@ -225,16 +195,11 @@ object RegionTable {
     * @return
     */
   def selectTheCurrentRegion(userId: UUID): Option[Region] = db.withSession { implicit session =>
-    try {
-      val currentRegions = for {
-        (r, ucr) <- regionsWithoutDeleted.filter(_.regionTypeId === 2).innerJoin(userCurrentRegions).on(_.regionId === _.regionId)
-        if ucr.userId === userId.toString
-      } yield r
-      Some(currentRegions.list.head)
-    } catch {
-      case e: NoSuchElementException => None
-      case _: Throwable => None  // Shouldn't reach here
-    }
+    val currentRegions = for {
+      (r, ucr) <- regionsWithoutDeleted.filter(_.regionTypeId === 2).innerJoin(userCurrentRegions).on(_.regionId === _.regionId)
+      if ucr.userId === userId.toString
+    } yield r
+    currentRegions.list.headOption
   }
 
   /**
@@ -244,7 +209,6 @@ object RegionTable {
     * @return
     */
   def selectTheCurrentNamedRegion(userId: UUID): Option[NamedRegion] = db.withSession { implicit session =>
-    try {
       val currentRegions = for {
         (r, ucr) <- regionsWithoutDeleted.filter(_.regionTypeId === 2).innerJoin(userCurrentRegions).on(_.regionId === _.regionId)
         if ucr.userId === userId.toString
@@ -254,11 +218,7 @@ object RegionTable {
         (_regions, _properties) <- currentRegions.leftJoin(regionProperties).on(_.regionId === _.regionId)
         if _properties.key === "Neighborhood Name"
       } yield (_regions.regionId, _properties.value.?, _regions.geom)
-      Some(_regions.list.map(x => NamedRegion.tupled(x)).head)
-    } catch {
-      case e: NoSuchElementException => None
-      case _: Throwable => None  // Shouldn't reach here
-    }
+      _regions.list.headOption.map(x => NamedRegion.tupled(x))
   }
 
   def selectNamedRegionsIntersectingAStreet(streetEdgeId: Int): List[NamedRegion] = db.withSession { implicit session =>
@@ -337,16 +297,16 @@ object RegionTable {
   def selectNamedRegionsOfAType(regionType: String): List[NamedRegion] = db.withSession { implicit session =>
 
     val _regions = for {
-      (_regions, _regionTypes) <- regionsWithoutDeleted.innerJoin(regionTypes).on(_.regionTypeId === _.regionTypeId) if _regionTypes.regionType === regionType
+      (_regions, _regionTypes) <- regionsWithoutDeleted.innerJoin(regionTypes).on(_.regionTypeId === _.regionTypeId)
+      if _regionTypes.regionType === regionType
     } yield _regions
 
 
     val _namedRegions = for {
-      (_regions, _regionProperties) <- _regions.leftJoin(regionProperties).on(_.regionId === _.regionId) if _regionProperties.key === "Neighborhood Name"
+      (_regions, _regionProperties) <- _regions.leftJoin(regionProperties).on(_.regionId === _.regionId)
+      if _regionProperties.key === "Neighborhood Name"
     } yield (_regions.regionId, _regionProperties.value.?, _regions.geom)
 
     _namedRegions.list.map(x => NamedRegion.tupled(x))
   }
-
-
 }

--- a/app/models/user/UserCurrentRegionTable.scala
+++ b/app/models/user/UserCurrentRegionTable.scala
@@ -63,7 +63,7 @@ object UserCurrentRegionTable {
     * @param userId
     * @return
     */
-  def assignNextRegion(userId: UUID): Option[NamedRegion] = db.withSession { implicit session =>
+  def assignRegion(userId: UUID): Option[NamedRegion] = db.withSession { implicit session =>
     println("REGULAR ASSIGNMENT FOR USER")
     // If user is inexperienced, restrict them to only easy regions when selecting a high priority region.
     val newRegion: Option[NamedRegion] =

--- a/app/models/user/UserCurrentRegionTable.scala
+++ b/app/models/user/UserCurrentRegionTable.scala
@@ -51,7 +51,7 @@ object UserCurrentRegionTable {
     * @return
     */
   def assignEasyRegion(userId: UUID): Option[NamedRegion] = db.withSession { implicit session =>
-
+    println("EASY ASSIGNMENT FOR USER")
     val newRegion: Option[NamedRegion] = RegionTable.selectAHighPriorityEasyRegion(userId)
     newRegion.map(r => update(userId, r.regionId)) // If region successfully selected, assign it to them.
     newRegion
@@ -64,7 +64,7 @@ object UserCurrentRegionTable {
     * @return
     */
   def assignNextRegion(userId: UUID): Option[NamedRegion] = db.withSession { implicit session =>
-
+    println("REGULAR ASSIGNMENT FOR USER")
     // If user is inexperienced, restrict them to only easy regions when selecting a high priority region.
     val newRegion: Option[NamedRegion] =
       if(isUserExperienced(userId)) RegionTable.selectAHighPriorityRegion(userId)

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -1,6 +1,6 @@
 @import models.user.User
 @import models.user.WebpageActivityTable
-@import models.user.UserCurrentRegionTable
+@import models.region.RegionTable
 @import models.user.UserRoleTable
 @import models.daos._
 @import models.audit._
@@ -696,7 +696,7 @@
     <script>
         $(document).ready(function () {
 
-        var difficultRegionIds = @Json.toJson(UserCurrentRegionTable.difficultRegionIds);
+        var difficultRegionIds = @Json.toJson(RegionTable.difficultRegionIds);
         window.admin = Admin(_, $, c3, turf, difficultRegionIds);
         $('#commentsTable').dataTable();
         $('#labelTable').dataTable();

--- a/app/views/audit.scala.html
+++ b/app/views/audit.scala.html
@@ -119,6 +119,19 @@
                 </div>
             </div>
         </div>
+        <div id="already-completed-neighborhood-overlay">
+            <div class="overlay-text">
+                <div id="already-completed-neighborhood-text">
+                    <p>
+                        <span class="overlay-header">Neighborhood Already Complete!</span>
+                    </p>
+                    <p>
+                        You already audited this entire neighborhood! We are going to send you to a neighborhood that could use some auditing.
+                    </p>
+                    <span class="overlay-option" id="accept-redirect">OK</span>
+                </div>
+            </div>
+        </div>
         <div class="page-alert-holder" id="unsupported-browser-alert" style="visibility: hidden">
             <div class="page-alert">
                 <span id="page-alert-message"><strong>Disclaimer:</strong> This site is optimized for Google Chrome. Other browsers are not fully supported yet.&nbsp;</span>
@@ -824,6 +837,9 @@
 
                 }
             });
+        } else {
+            $(".toolUI").css({"visibility": "visible"});
+            $('#already-completed-neighborhood-overlay').show();
         }
 
         $(document).ready(function(){
@@ -850,6 +866,11 @@
 
             $('#redirect-new').on('click', function(){
                 $(location).attr('href', '/audit?nextRegion=regular');
+            });
+
+            // Already Completed Neighborhood Overlay
+            $('#accept-redirect').on('click', function(){
+                $(location).attr('href', '/audit');
             });
         });
 
@@ -990,5 +1011,4 @@
         }
 
     </script>
-
 }

--- a/app/views/audit.scala.html
+++ b/app/views/audit.scala.html
@@ -1,5 +1,5 @@
 @import models.user.User
-@import models.user.UserCurrentRegionTable
+@import models.region.RegionTable
 @import models.region.NamedRegion
 @import models.mission.MissionTable
 @import models.survey._
@@ -945,7 +945,7 @@
                 mainParam.regionId = @region.get.regionId;
                 mainParam.regionName = '@region.get.name';
                 mainParam.regionLayer = omnivore.wkt.parse("@region.get.geom");
-                if(@UserCurrentRegionTable.difficultRegionIds.contains(region.get.regionId)){
+                if(@RegionTable.difficultRegionIds.contains(region.get.regionId)){
                        $('#advanced-overlay').show();
                        mainParam.advancedOverlay = true
                 }

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -1,6 +1,6 @@
 @import models.daos.slick.DBTableDefinitions.UserTable
 @import models.user.User
-@import models.user.UserCurrentRegionTable
+@import models.region.RegionTable
 @import models.daos._
 @import models.label._
 @import models.street.StreetEdgeTable
@@ -354,7 +354,7 @@
 
 <script>
         $(document).ready(function () {
-            var difficultRegionIds = @Json.toJson(UserCurrentRegionTable.difficultRegionIds);
+            var difficultRegionIds = @Json.toJson(RegionTable.difficultRegionIds);
             window.choropleth = Choropleth(_, $, turf, difficultRegionIds);
         });
 </script>

--- a/app/views/results.scala.html
+++ b/app/views/results.scala.html
@@ -1,6 +1,6 @@
 @import models.daos.slick.DBTableDefinitions.UserTable
 @import models.user.User
-@import models.user.UserCurrentRegionTable
+@import models.region.RegionTable
 @import models.daos._
 @import models.label._
 @import models.street.StreetEdgeTable
@@ -88,7 +88,7 @@
 
 <script>
         $(document).ready(function () {
-            var difficultRegionIds = @Json.toJson(UserCurrentRegionTable.difficultRegionIds);
+            var difficultRegionIds = @Json.toJson(RegionTable.difficultRegionIds);
             window.choropleth = AccessibilityChoropleth(_, $, turf, difficultRegionIds);
         });
 </script>

--- a/app/views/userProfile.scala.html
+++ b/app/views/userProfile.scala.html
@@ -1,5 +1,5 @@
 @import models.user.User
-@import models.user.UserCurrentRegionTable
+@import models.region.RegionTable
 @import models.mission.MissionTable
 @import play.api.libs.json.Json
 @(title: String, user: Option[User] = None)
@@ -89,7 +89,7 @@
     <script type="text/javascript" src='@routes.Assets.at("javascripts/Progress/build/Progress.js")'></script>
     <script>
     $(document).ready(function () {
-        var difficultRegionIds = @Json.toJson(UserCurrentRegionTable.difficultRegionIds);
+        var difficultRegionIds = @Json.toJson(RegionTable.difficultRegionIds);
         window.progress = Progress(_, $, c3, L, difficultRegionIds);
     });
     </script>

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1196,7 +1196,7 @@ kbd {
     position: relative;
 }
 /*Overlay box - start*/
-#advanced-overlay, #neighborhood-completion-overlay{
+#advanced-overlay, #neighborhood-completion-overlay, #already-completed-neighborhood-overlay{
     display:none;
 }
 .overlay-text{
@@ -1206,7 +1206,7 @@ kbd {
     background: rgba(0,0,0,0.89);
     z-index: 5;
 }
-#advanced-neighborhood-text, #neighborhood-completion-text{
+#advanced-neighborhood-text, #neighborhood-completion-text, #already-completed-neighborhood-text{
     color: white;
     text-align: center;
     width: 70%;
@@ -1221,7 +1221,10 @@ kbd {
 #neighborhood-completion-text {
     top: 28%;
 }
-#advanced-neighborhood-text p, #neighborhood-completion-text p{
+#already-completed-neighborhood-text {
+    top: 28%;
+}
+#advanced-neighborhood-text p, #neighborhood-completion-text p, #already-completed-neighborhood-text p{
     border-radius: 5px;
     padding: 7px;
 }
@@ -1241,6 +1244,9 @@ kbd {
     background-color: white;
     color: black;
     cursor: pointer;
+}
+#accept-redirect{
+    width: 75px;
 }
 
 /*Overlay box - end*/

--- a/public/javascripts/SVLabel/src/SVLabel/Main.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Main.js
@@ -349,8 +349,9 @@ function Main (params) {
 
     // Query the server for the next least unaudited region (across users)
     // and that hasn't been done by the user
+    // TODO test if this is used, we suspect it is never called and can be deleted.
     function findTheNextRegionWithMissions () {
-        svl.neighborhoodModel.fetchNextLeastAuditedRegion(false);
+        svl.neighborhoodModel.fetchNextHighPriorityRegion(false);
     }
 
     function findTheNextRegionWithMissionsOld (currentNeighborhood) {
@@ -517,6 +518,8 @@ function Main (params) {
         var availableMissions = svl.missionContainer.getIncompleteMissionsByRegionId(regionId);
         var incompleteTasks = svl.taskContainer.getIncompleteTasks(regionId);
 
+
+        // TODO test if this is used, we suspect it is never true and can be deleted. This check is done on back-end now
         if (!(incompleteMissionExists(availableMissions) && incompleteTaskExists(incompleteTasks))) {
             findTheNextRegionWithMissions();
             currentNeighborhood = svl.neighborhoodModel.currentNeighborhood();

--- a/public/javascripts/SVLabel/src/SVLabel/neighborhood/NeighborhoodModel.js
+++ b/public/javascripts/SVLabel/src/SVLabel/neighborhood/NeighborhoodModel.js
@@ -39,8 +39,9 @@ function NeighborhoodModel () {
             }
         })).done(callback);
     };
-    
-    this.fetchNextLeastAuditedRegion = function (async) {
+
+    // TODO test if this is used, we suspect it is never called and can be deleted.
+    this.fetchNextHighPriorityRegion = function (async) {
         if (typeof async === "undefined") async = true;
         $.ajax({
             async: async,


### PR DESCRIPTION
This PR updates the code that selects and assigns regions to make use of our new priority-based system.

The code is used when a new user comes to the site and needs to be assigned a neighborhood to audit, when a user finishes auditing a neighborhood completely, and any time an anonymous user visits the audit page.

Previously, a user would be assigned to one of the neighborhoods that had the lowest completion percentage. Now a user is assigned to a neighborhood with one of the 5 highest average priorities across its streets.

Testing:
I added print statements in the relevant places, so when you run each case, note the output of the print statements.
1. Visit the audit page as an anonymous user. You should see the following print statements
    EASY SELECTION
    GENERIC SELECTION
    Highest priority regions: List(r1, r2, r3, r4, r5)
2. Sign in, visit audit/nextRegion=easy. You should see the following print statements (note that for users, there is a step where we _assign_ them this region for the future, which is why you see that additional line printed; also note that the list of high priority regions should be the same, unless you have audited one of those regions completely yourself)
    EASY ASSIGNMENT FOR USER
    EASY SELECTION FOR USER
    GENERIC SELECTION
    Highest priority regions: List(r1, r2, r3, r4, r5)
3. Stay signed in, visit audit/nextRegion=regular. You should see the following print statements (there may be one or two different regions in this list, which would only happen any of the highest priority regions are "difficult" regions)
    REGULAR ASSIGNMENT FOR USER
    REGULAR SELECTION FOR USER
    GENERIC SELECTION
    Highest priority regions: List(r1, r2, r3, r4, r5)

So these are the 3 cases that we would actually expect to see while people use the tool. Most of the functions have safeguards in case no regions are found initially. For example, the function for selecting an easy region checks if something was successfully selected; if not, it calls the regular selection function instead, since the regular selection is less restrictive. The same thing goes for the functions that select based on regions that the user has not completed; if none are found, we default to the functions that assign any region.

To test some of these backups, you can go into the functions in RegionTable.scala and modify the list of possible region ids, causing the function to go to a backup. For example, you could go to line 141, where the list of region ids for easy regions that the user has not completely audited is created. You could replace it with an empty list. Then when you run the audit/nextRegion=easy route, you will see the print statements for selecting an easy region, but that fails and calls the regular selection code, so you will also see print statements for that case as well.

Resolves #1214 