### PR TITLE
fixed bug where users were not being assigned regions

### DIFF
--- a/app/controllers/AuditController.scala
+++ b/app/controllers/AuditController.scala
@@ -115,7 +115,7 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
         WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, "Visit_Audit", timestamp))
 
         // Update the currently assigned region for the user
-        UserCurrentRegionTable.update(user.userId, regionId)
+        UserCurrentRegionTable.saveOrUpdate(user.userId, regionId)
 
         val task: Option[NewTask] = AuditTaskTable.selectANewTaskInARegion(regionId, user.userId)
         Future.successful(Ok(views.html.audit("Project Sidewalk - Audit", task, region, Some(user))))

--- a/app/controllers/RegionController.scala
+++ b/app/controllers/RegionController.scala
@@ -45,7 +45,7 @@ class RegionController @Inject() (implicit val env: Environment[User, SessionAut
             submission.regionId match {
               case Some(regId) =>
                 // Sets a region based on the request from the user
-                UserCurrentRegionTable.update(user.userId, regId)
+                UserCurrentRegionTable.saveOrUpdate(user.userId, regId)
 
               case None =>
                 // Assigns a region to the user on request from a signed in user

--- a/app/models/user/UserCurrentRegionTable.scala
+++ b/app/models/user/UserCurrentRegionTable.scala
@@ -128,6 +128,7 @@ object UserCurrentRegionTable {
     */
   def saveOrUpdate(userId: UUID, regionId: Int): Int = db.withSession { implicit session =>
     val rowsUpdated: Int = update(userId, regionId)
+    // If no rows are updated, a new record needs to be created
     if (rowsUpdated == 0) {
       save(userId, regionId)
     }

--- a/app/models/user/UserCurrentRegionTable.scala
+++ b/app/models/user/UserCurrentRegionTable.scala
@@ -52,7 +52,7 @@ object UserCurrentRegionTable {
     */
   def assignEasyRegion(userId: UUID): Option[NamedRegion] = db.withSession { implicit session =>
     val newRegion: Option[NamedRegion] = RegionTable.selectAHighPriorityEasyRegion(userId)
-    newRegion.map(r => update(userId, r.regionId)) // If region successfully selected, assign it to them.
+    newRegion.map(r => saveOrUpdate(userId, r.regionId)) // If region successfully selected, assign it to them.
     newRegion
   }
 
@@ -67,7 +67,7 @@ object UserCurrentRegionTable {
     val newRegion: Option[NamedRegion] =
       if(isUserExperienced(userId)) RegionTable.selectAHighPriorityRegion(userId)
       else RegionTable.selectAHighPriorityEasyRegion(userId)
-    newRegion.map(r => update(userId, r.regionId)) // If region successfully selected, assign it to them.
+    newRegion.map(r => saveOrUpdate(userId, r.regionId)) // If region successfully selected, assign it to them.
     newRegion
   }
 
@@ -109,10 +109,28 @@ object UserCurrentRegionTable {
     *
     * @param userId user ID
     * @param regionId region id
+    * @return the number of rows updated
     */
   def update(userId: UUID, regionId: Int): Int = db.withSession { implicit session =>
     val q = for { ucr <- userCurrentRegions if ucr.userId === userId.toString } yield ucr.regionId
     q.update(regionId)
+  }
+
+  /**
+    * Update the current region, or save a new entry if the user does not have one.
+    *
+    * Reference:
+    * http://slick.typesafe.com/doc/2.1.0/queries.html#updating
+    *
+    * @param userId user ID
+    * @param regionId region id
+    * @return region id
+    */
+  def saveOrUpdate(userId: UUID, regionId: Int): Int = db.withSession { implicit session =>
+    val rowsUpdated: Int = update(userId, regionId)
+    if (rowsUpdated == 0) {
+      save(userId, regionId)
+    }
     regionId
   }
 }

--- a/app/views/admin/user.scala.html
+++ b/app/views/admin/user.scala.html
@@ -57,8 +57,8 @@
                     <tr>
                         <th class="col-md-2">Current Neighborhood</th>
                         <td class="col-md-10">
-                            @UserCurrentRegionTable.currentRegion(UUID.fromString(user.get.userId)).map {_ => RegionPropertyTable.neighborhoodName(_)}.getOrElse("Unassigned")
-                            (Region ID: @UserCurrentRegionTable.currentRegion(UUID.fromString(user.get.userId)).map{_ => _}.getOrElse("NA"))
+                            @(UserCurrentRegionTable.currentRegion(UUID.fromString(user.get.userId)).map {x => RegionPropertyTable.neighborhoodName(x)}.getOrElse("Unassigned"))
+                            (Region ID: @(UserCurrentRegionTable.currentRegion(UUID.fromString(user.get.userId)).map{x => x}.getOrElse("NA")))
                         </td>
                     </tr>
                 </table>


### PR DESCRIPTION
It seems that we were trying to update entries in the `user_current_region` table without checking whether or not there was any entry in the table to update. I created a new `saveOrUpdate` function that does the appropriate check, and adds a new entry for the user if they don't have one.

This also fixes the bug #1220 where the region for user was being displayed incorrectly on the admin dashboard.

You can test this by trying to come to the site as a new turker (i.e., through a referrer link like [http://localhost:9000?referrer=mturk&workerId=testworker1&assignmentId=testasmt1&hitId=testhit1](http://localhost:9000?referrer=mturk&workerId=testworker1&assignmentId=testasmt1&hitId=testhit1). It should assign you a new region when it automatically signs you up. So you can then check the `user_current_region_table` or the new turker's user dashboard to verify that they were assigned the region.

This was also a problem for registered users since they used the same function. You can log in as a registered user, delete you entry in the `user_current_region` table if you have one, then start auditing in any way. You should now be assigned a region in the same manner as for turkers.

Check that the admin dashboard bug is fixed by checking /admin/user/<username> and seeing that the region name and id shows up.

Resolves #1225 
Resolves #1220 