### PR TITLE
Resolves #155: Add label counter table to admin user interface

### DIFF
--- a/app/views/admin/user.scala.html
+++ b/app/views/admin/user.scala.html
@@ -64,10 +64,30 @@
                     </tr>
                 </table>
             </div>
+            <div class="col-lg-12">
+                <table class="table table-striped table-condensed">
+                    <tr>
+                        <th>Attribute Type</th>
+                        <th>Curb Ramps</th>
+                        <th>Missing Curb Ramps</th>
+                        <th>Obstacles</th>
+                        <th>Surface Problems</th>
+                        <th>No Sidewalk</th>
+                    </tr>
+                    <tr>
+                        <th>Number of Labels</th>
+                        <td id="td-number-of-curb-ramps"></td>
+                        <td id="td-number-of-missing-curb-ramps"></td>
+                        <td id="td-number-of-obstacles"></td>
+                        <td id="td-number-of-surface-problems"></td>
+                        <td id="td-number-of-no-sidewalks"></td>
+                    </tr>
+                </table>
+            </div>
         </div>
 
+        <h1>Labels</h1>
         <div class="row">
-            <h1>Labels</h1>
             <div class="col-lg-12">
                 <p>Recent labels</p>
                 <table id="labelTable" data-order='[[ 0, "desc" ]]' class="table table-striped table-condensed">
@@ -94,7 +114,6 @@
                 </table>
             </div>
         </div>
-
 
         <h1>Audited Streets</h1>
         <div class="row">
@@ -142,9 +161,8 @@
             </table>
         </div>
 
-
+        <h1>Feedback</h1>
         <div class="row">
-            <h1>Feedback</h1>
             <div class="col-lg-12">
                 <table class="table table-striped table-condensed">
                     <tr><th class="col-md-3">Timestamp</th><th class="col-md-3">Panorama Id</th><th class="col-md-6">Comment</th></tr>

--- a/app/views/admin/user.scala.html
+++ b/app/views/admin/user.scala.html
@@ -67,7 +67,7 @@
             <div class="col-lg-12">
                 <table class="table table-striped table-condensed">
                     <tr>
-                        <th>Attribute Type</th>
+                        <th>Label Type</th>
                         <th>Curb Ramps</th>
                         <th>Missing Curb Ramps</th>
                         <th>Obstacles</th>

--- a/app/views/userProfile.scala.html
+++ b/app/views/userProfile.scala.html
@@ -44,7 +44,7 @@
             </table>
             <table class="table table-striped table-condensed">
                 <tr>
-                    <th>Attribute Type</th>
+                    <th>Label Type</th>
                     <th>Curb Ramps</th>
                     <th>Missing Curb Ramps</th>
                     <th>Obstacles</th>

--- a/public/javascripts/Admin/src/Admin.User.js
+++ b/public/javascripts/Admin/src/Admin.User.js
@@ -75,6 +75,11 @@ function AdminUser(params) {
             };
 
         for (var i = data.features.length - 1; i >= 0; i--) labelCounter[data.features[i].properties.label_type] += 1;
+        document.getElementById("td-number-of-curb-ramps").innerHTML = labelCounter["CurbRamp"];
+        document.getElementById("td-number-of-missing-curb-ramps").innerHTML = labelCounter["NoCurbRamp"];
+        document.getElementById("td-number-of-obstacles").innerHTML = labelCounter["Obstacle"];
+        document.getElementById("td-number-of-surface-problems").innerHTML = labelCounter["SurfaceProblem"];
+        document.getElementById("td-number-of-no-sidewalks").innerHTML = labelCounter["NoSidewalk"];
 
         document.getElementById("map-legend-curb-ramp").innerHTML = "<svg width='20' height='20'><circle r='6' cx='10' cy='10' fill='" + colorMapping['CurbRamp'].fillStyle + "'></svg>";
         document.getElementById("map-legend-no-curb-ramp").innerHTML = "<svg width='20' height='20'><circle r='6' cx='10' cy='10' fill='" + colorMapping['NoCurbRamp'].fillStyle + "'></svg>";


### PR DESCRIPTION
For #155

| Before | After |
| ------ | ------ |
| ![image](https://user-images.githubusercontent.com/25534091/42187515-35ea43b6-7e05-11e8-8c44-37436636589f.png) | ![image](https://user-images.githubusercontent.com/25534091/42187524-3dd002fa-7e05-11e8-8392-d3cc47382aa6.png) |
| ![image](https://user-images.githubusercontent.com/25534091/42187530-45b87aba-7e05-11e8-8377-d23100a56aa7.png) | ![image](https://user-images.githubusercontent.com/25534091/42187542-4b3b661e-7e05-11e8-89cf-1bd2338b8863.png) |

Changes:
* Added another section under General Info to display total label counts
* Aligned header text for Labels/Feedback sections (snuck in this change because it's a quick fix)



