### PR TITLE
Resolves #1274: Make label buttons flash

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/Main.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Main.js
@@ -602,7 +602,7 @@ function Main (params) {
 
         // Ribbon menu DOMs
         svl.ui.ribbonMenu = {};
-        svl.ui.ribbonMenu.holder = $("#ribbon-menu-label-button-holder");
+        svl.ui.ribbonMenu.holder = $("#ribbon-menu-label-type-button-holder");
         svl.ui.ribbonMenu.streetViewHolder = $("#street-view-holder");
         svl.ui.ribbonMenu.buttons = $('span.modeSwitch');
         svl.ui.ribbonMenu.bottonBottomBorders = $(".ribbon-menu-mode-switch-horizontal-line");


### PR DESCRIPTION
Fixes #1274 

There was some CSS renaming that happened earlier (when removing bus stop code), and there was one part of `Main.js` that wasn't updated.

Labels in the tutorial flash again!
![image](https://user-images.githubusercontent.com/25534091/42337783-9ce1f8be-803c-11e8-89bc-d08449cf4182.png)
