### PR TITLE
resolves #1282 fix tag naming conflicts

### DIFF
--- a/app/models/attribute/GlobalAttributeTable.scala
+++ b/app/models/attribute/GlobalAttributeTable.scala
@@ -10,7 +10,7 @@ import models.utils.MyPostgresDriver.simple._
 import play.api.Play.current
 import play.api.db.slick
 
-import scala.slick.lifted.{ForeignKeyQuery, ProvenShape}
+import scala.slick.lifted.{ForeignKeyQuery, ProvenShape, Tag}
 import scala.language.postfixOps
 
 case class GlobalAttribute(globalAttributeId: Int,

--- a/app/models/attribute/UserAttributeLabelTable.scala
+++ b/app/models/attribute/UserAttributeLabelTable.scala
@@ -9,7 +9,7 @@ import models.utils.MyPostgresDriver.simple._
 import play.api.Play.current
 import play.api.db.slick
 
-import scala.slick.lifted.{ForeignKeyQuery, ProvenShape}
+import scala.slick.lifted.{ForeignKeyQuery, ProvenShape, Tag}
 import scala.language.postfixOps
 
 case class UserAttributeLabel(userAttributeLabelId: Int, userAttributeId: Int, labelId: Int)

--- a/app/models/attribute/UserAttributeTable.scala
+++ b/app/models/attribute/UserAttributeTable.scala
@@ -10,7 +10,7 @@ import models.utils.MyPostgresDriver.simple._
 import play.api.Play.current
 import play.api.db.slick
 
-import scala.slick.lifted.{ForeignKeyQuery, ProvenShape}
+import scala.slick.lifted.{ForeignKeyQuery, ProvenShape, Tag}
 import scala.language.postfixOps
 
 case class UserAttribute(userAttributeId: Int,

--- a/app/models/attribute/UserClusteringSessionTable.scala
+++ b/app/models/attribute/UserClusteringSessionTable.scala
@@ -12,7 +12,7 @@ import play.api.Play.current
 import play.api.db.slick
 import play.api.libs.json.{JsObject, Json}
 
-import scala.slick.lifted.{ForeignKeyQuery, ProvenShape}
+import scala.slick.lifted.{ForeignKeyQuery, ProvenShape, Tag}
 import scala.slick.jdbc.{GetResult, StaticQuery => Q}
 import scala.language.postfixOps
 

--- a/app/models/audit/AuditTaskInteractionTable.scala
+++ b/app/models/audit/AuditTaskInteractionTable.scala
@@ -34,7 +34,7 @@ case class InteractionWithLabel(auditTaskInteractionId: Int, auditTaskId: Int, a
 case class UserAuditTime(userId: String, duration: Option[Float], ipAddress: Option[String])
 
 
-class AuditTaskInteractionTable(tag: Tag) extends Table[AuditTaskInteraction](tag, Some("sidewalk"), "audit_task_interaction") {
+class AuditTaskInteractionTable(tag: slick.lifted.Tag) extends Table[AuditTaskInteraction](tag, Some("sidewalk"), "audit_task_interaction") {
   def auditTaskInteractionId = column[Int]("audit_task_interaction_id", O.PrimaryKey, O.AutoInc)
   def auditTaskId = column[Int]("audit_task_id", O.NotNull)
   def action = column[String]("action", O.NotNull)

--- a/app/models/audit/AuditTaskTable.scala
+++ b/app/models/audit/AuditTaskTable.scala
@@ -53,7 +53,7 @@ case class NewTask(edgeId: Int, geom: LineString, x1: Float, y1: Float, x2: Floa
 /**
  *
  */
-class AuditTaskTable(tag: Tag) extends Table[AuditTask](tag, Some("sidewalk"), "audit_task") {
+class AuditTaskTable(tag: slick.lifted.Tag) extends Table[AuditTask](tag, Some("sidewalk"), "audit_task") {
   def auditTaskId = column[Int]("audit_task_id", O.PrimaryKey, O.AutoInc)
   def amtAssignmentId = column[Option[Int]]("amt_assignment_id", O.Nullable)
   def userId = column[String]("user_id", O.NotNull)

--- a/app/models/street/StreetEdgePriorityTable.scala
+++ b/app/models/street/StreetEdgePriorityTable.scala
@@ -24,7 +24,7 @@ case class StreetEdgePriority(streetEdgePriorityId: Int, streetEdgeId: Int, prio
   }
 }
 
-class StreetEdgePriorityTable(tag: Tag) extends Table[StreetEdgePriority](tag, Some("sidewalk"),  "street_edge_priority") {
+class StreetEdgePriorityTable(tag: slick.lifted.Tag) extends Table[StreetEdgePriority](tag, Some("sidewalk"),  "street_edge_priority") {
   def streetEdgePriorityId = column[Int]("street_edge_priority_id", O.NotNull, O.PrimaryKey, O.AutoInc)
   def streetEdgeId = column[Int]("street_edge_id", O.NotNull)
   def priority = column[Double]("priority", O.NotNull)


### PR DESCRIPTION
Fixes conflicting imports of Tag objects from different libraries by making each import more explicit. I tested that this now compiles correctly from scratch on the dev server.

Fixes #1282 