### PR TITLE
fixes #1285, adding tags column to description overview

### DIFF
--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -266,13 +266,12 @@ object LabelTable {
       """SELECT lb1.label_id, lb1.gsv_panorama_id, lp.heading, lp.pitch, lp.zoom, lp.canvas_x, lp.canvas_y,
         |       lp.canvas_width, lp.canvas_height, lb1.audit_task_id, u.user_id, u.username, lb1.time_created,
         |       lb_big.label_type, lb_big.label_type_desc, lb_big.severity, lb_big.temp_problem, lb_big.description
-        |
         |	FROM sidewalk.label as lb1, sidewalk.audit_task as at,
         |       sidewalk.user as u, sidewalk.label_point as lp,
         |				(SELECT lb.label_id, lb.gsv_panorama_id, lbt.label_type, lbt.description as label_type_desc, sev.severity,
         |               COALESCE(prob_temp.temporary_problem,'FALSE') as temp_problem,
         |               prob_desc.description
-        |	      				FROM label as lb
+        |					FROM label as lb
         |				LEFT JOIN sidewalk.label_type as lbt
         |					ON lb.label_type_id = lbt.label_type_id
         |				LEFT JOIN sidewalk.problem_severity as sev
@@ -333,7 +332,7 @@ object LabelTable {
         |				(SELECT lb.label_id, lb.gsv_panorama_id, lbt.label_type, lbt.description as label_type_desc, sev.severity,
         |               COALESCE(prob_temp.temporary_problem,'FALSE') as temp_problem,
         |               prob_desc.description
-        |                                      FROM label as lb
+        |					FROM label as lb
         |				LEFT JOIN sidewalk.label_type as lbt
         |					ON lb.label_type_id = lbt.label_type_id
         |				LEFT JOIN sidewalk.problem_severity as sev
@@ -382,24 +381,26 @@ object LabelTable {
     )
   }
 
-  /**
-    * This method returns the tags for a specific label id as a string
-    *
-    * @param userId label id
-    * @return string of tags attatched to label
-    */
+  //seperate sql request for getting tags, gets all the tags that correspond to the label Id.
   def getTagsFromLabelId(labelId: Int): String = db.withSession { implicit session =>
       val getTagsQuery = Q.query[Int, (String)](
-        """SELECT tag
-          |FROM sidewalk.tag
-          |WHERE tag.tag_id IN
-          |(
-          |    SELECT tag_id
-          |    FROM sidewalk.label_tag
-          |    WHERE label_tag.label_id = ?
-          |)""".stripMargin
+        """SELECT tag FROM sidewalk.tag
+             WHERE tag.tag_id IN (
+                  SELECT tag_id FROM sidewalk.label_tag
+                        WHERE label_tag.label_id = ?
+             )""".stripMargin
       )
-      return getTagsQuery(labelId).list.mkString(", ")
+      var tags = getTagsQuery(labelId).list
+      var str = ""
+      var isFirst = true
+      for(tag <- tags){
+        if(!isFirst){
+          str += ", "
+        }
+        isFirst = false;
+        str += tag
+      }
+      return str
   }
 
   /*

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -111,7 +111,7 @@ object LabelTable {
                            userId: String, username: String,
                            timestamp: Option[java.sql.Timestamp],
                            labelTypeKey:String, labelTypeValue: String, severity: Option[Int],
-                           temporary: Boolean, description: Option[String], tags: String)
+                           temporary: Boolean, description: Option[String])
 
   implicit val labelLocationConverter = GetResult[LabelLocation](r =>
     LabelLocation(r.nextInt, r.nextInt, r.nextString, r.nextString, r.nextFloat, r.nextFloat))
@@ -266,12 +266,13 @@ object LabelTable {
       """SELECT lb1.label_id, lb1.gsv_panorama_id, lp.heading, lp.pitch, lp.zoom, lp.canvas_x, lp.canvas_y,
         |       lp.canvas_width, lp.canvas_height, lb1.audit_task_id, u.user_id, u.username, lb1.time_created,
         |       lb_big.label_type, lb_big.label_type_desc, lb_big.severity, lb_big.temp_problem, lb_big.description
+        |
         |	FROM sidewalk.label as lb1, sidewalk.audit_task as at,
         |       sidewalk.user as u, sidewalk.label_point as lp,
         |				(SELECT lb.label_id, lb.gsv_panorama_id, lbt.label_type, lbt.description as label_type_desc, sev.severity,
         |               COALESCE(prob_temp.temporary_problem,'FALSE') as temp_problem,
         |               prob_desc.description
-        |         FROM label as lb
+        |	      				FROM label as lb
         |				LEFT JOIN sidewalk.label_type as lbt
         |					ON lb.label_type_id = lbt.label_type_id
         |				LEFT JOIN sidewalk.problem_severity as sev
@@ -332,7 +333,7 @@ object LabelTable {
         |				(SELECT lb.label_id, lb.gsv_panorama_id, lbt.label_type, lbt.description as label_type_desc, sev.severity,
         |               COALESCE(prob_temp.temporary_problem,'FALSE') as temp_problem,
         |               prob_desc.description
-        |					FROM label as lb
+        |                                      FROM label as lb
         |				LEFT JOIN sidewalk.label_type as lbt
         |					ON lb.label_type_id = lbt.label_type_id
         |				LEFT JOIN sidewalk.problem_severity as sev
@@ -346,7 +347,6 @@ object LabelTable {
         |      lb1.label_id = lb_big.label_id and at.user_id = u.user_id and lb1.label_id = lp.label_id
         |	ORDER BY lb1.label_id DESC""".stripMargin
     )
-
     selectQuery(labelId).list.map(label => LabelMetadata.tupled(label)).head
   }
 
@@ -376,7 +376,8 @@ object LabelTable {
       "label_type_value" -> labelMetadata.labelTypeValue,
       "severity" -> labelMetadata.severity,
       "temporary" -> labelMetadata.temporary,
-      "tags" -> labelMetadata.tags,
+      //this one is different because we're pulling from the tags and label_tags databases
+      "tags" -> getTagsFromLabelId(labelMetadata.labelId),
       "description" -> labelMetadata.description
     )
   }

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -346,7 +346,6 @@ object LabelTable {
         |      lb1.label_id = lb_big.label_id and at.user_id = u.user_id and lb1.label_id = lp.label_id
         |	ORDER BY lb1.label_id DESC""".stripMargin
     )
-
     selectQuery(labelId).list.map(label => labelAndTagsToLabelMetadata(label, getTagsFromLabelId(label._1))).head
   }
 

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -266,12 +266,13 @@ object LabelTable {
       """SELECT lb1.label_id, lb1.gsv_panorama_id, lp.heading, lp.pitch, lp.zoom, lp.canvas_x, lp.canvas_y,
         |       lp.canvas_width, lp.canvas_height, lb1.audit_task_id, u.user_id, u.username, lb1.time_created,
         |       lb_big.label_type, lb_big.label_type_desc, lb_big.severity, lb_big.temp_problem, lb_big.description
+        |
         |	FROM sidewalk.label as lb1, sidewalk.audit_task as at,
         |       sidewalk.user as u, sidewalk.label_point as lp,
         |				(SELECT lb.label_id, lb.gsv_panorama_id, lbt.label_type, lbt.description as label_type_desc, sev.severity,
         |               COALESCE(prob_temp.temporary_problem,'FALSE') as temp_problem,
         |               prob_desc.description
-        |					FROM label as lb
+        |	      				FROM label as lb
         |				LEFT JOIN sidewalk.label_type as lbt
         |					ON lb.label_type_id = lbt.label_type_id
         |				LEFT JOIN sidewalk.problem_severity as sev
@@ -375,8 +376,32 @@ object LabelTable {
       "label_type_value" -> labelMetadata.labelTypeValue,
       "severity" -> labelMetadata.severity,
       "temporary" -> labelMetadata.temporary,
+      //this one is different because we're pulling from the tags and label_tags databases
+      "tags" -> getTagsFromLabelId(labelMetadata.labelId),
       "description" -> labelMetadata.description
     )
+  }
+
+  //seperate sql request for getting tags, gets all the tags that correspond to the label Id.
+  def getTagsFromLabelId(labelId: Int): String = db.withSession { implicit session =>
+      val getTagsQuery = Q.query[Int, (String)](
+        """SELECT tag FROM sidewalk.tag
+             WHERE tag.tag_id IN (
+                  SELECT tag_id FROM sidewalk.label_tag
+                        WHERE label_tag.label_id = ?
+             )""".stripMargin
+      )
+      var tags = getTagsQuery(labelId).list
+      var str = ""
+      var isFirst = true
+      for(tag <- tags){
+        if(!isFirst){
+          str += ", "
+        }
+        isFirst = false;
+        str += tag
+      }
+      return str
   }
 
   /*

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -509,12 +509,13 @@
                             <thead>
                             <tr>
                                 <th class="col-md-2">Username</th>
-                                <th class="col-md-3" data-class-name="priority">Timestamp</th>
+                                <th class="col-md-2" data-class-name="priority">Timestamp</th>
                                 <th class="col-md-2">Label Type</th>
                                 <th class="col-md-1">Severity</th>
                                 <th class="col-md-1">Temporary?</th>
-                                <th class="col-md-5">Tags</th>
-                                <th class="col-md-2">GSV</th>
+                                <th class="col-md-2">Tags</th>
+                                <th class="col-md-5">Description</th>
+                                <th class="col-md-1">GSV</th>
                             </tr>
                             </thead>
                             <tbody>
@@ -527,15 +528,9 @@
                                     <td>@label.labelTypeValue</td>
                                     <td>@label.severity</td>
                                     <td>@label.temporary</td>
-
-                                    <td>
-                                        @LabelTable.getTagsFromLabelId(label.labelId)
-                                    </td>
-
-                                    <td>
-                                        <a class="labelView" data-label-id="@label.labelId" href="#">View</a>
-                                    </td>
-
+                                    <td>@LabelTable.getTagsFromLabelId(label.labelId)</td>
+                                    <td>@label.description</td>
+                                    <td><a class="labelView" data-label-id="@label.labelId" href="#">View</a></td>
                                 </tr>
 
                             }

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -513,25 +513,31 @@
                                 <th class="col-md-2">Label Type</th>
                                 <th class="col-md-1">Severity</th>
                                 <th class="col-md-1">Temporary?</th>
-                                <th class="col-md-5">Description</th>
+                                <th class="col-md-5">Tags</th>
                                 <th class="col-md-2">GSV</th>
                             </tr>
                             </thead>
                             <tbody>
                             @LabelTable.selectTopLabelsAndMetadata(1000).map { label =>
-                            <tr>
-                                <td><a href='@routes.AdminController.userProfile(label.username)'>@label.username</a>
-                                </td>
-                                <td>@label.timestamp</td>
-                                <td>@label.labelTypeValue</td>
-                                <td>@label.severity</td>
-                                <td>@label.temporary</td>
-                                <td>@label.description</td>
-                                <td>
-                                    <a class="labelView" data-label-id="@label.labelId" href="#">View</a>
-                                </td>
 
-                            </tr>
+                                <tr>
+                                    <td><a href='@routes.AdminController.userProfile(label.username)'>@label.username</a>
+                                    </td>
+                                    <td>@label.timestamp</td>
+                                    <td>@label.labelTypeValue</td>
+                                    <td>@label.severity</td>
+                                    <td>@label.temporary</td>
+
+                                    <td>
+                                        @LabelTable.getTagsFromLabelId(label.labelId)
+                                    </td>
+
+                                    <td>
+                                        <a class="labelView" data-label-id="@label.labelId" href="#">View</a>
+                                    </td>
+
+                                </tr>
+
                             }
                             </tbody>
                         </table>

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -508,32 +508,35 @@
                         <table id="labelTable" data-order='[[ 1, "desc" ]]' class="table table-striped table-condensed">
                             <thead>
                             <tr>
-                                <th class="col-md-2">Username</th>
-                                <th class="col-md-2" data-class-name="priority">Timestamp</th>
-                                <th class="col-md-2">Label Type</th>
+                                <th class="col-md-1">Username</th>
+                                <th class="col-md-1" data-class-name="priority">Timestamp</th>
+                                <th class="col-md-1">Label Type</th>
                                 <th class="col-md-1">Severity</th>
                                 <th class="col-md-1">Temporary?</th>
-                                <th class="col-md-2">Tags</th>
-                                <th class="col-md-5">Description</th>
+                                <th class="col-md-3">Tags</th>
+                                <th class="col-md-2">Description</th>
                                 <th class="col-md-1">GSV</th>
                             </tr>
                             </thead>
-                            <tbody>
-                            @LabelTable.selectTopLabelsAndMetadata(1000).map { label =>
-
-                                <tr>
-                                    <td><a href='@routes.AdminController.userProfile(label.username)'>@label.username</a>
-                                    </td>
-                                    <td>@label.timestamp</td>
-                                    <td>@label.labelTypeValue</td>
-                                    <td>@label.severity</td>
-                                    <td>@label.temporary</td>
-                                    <td>@LabelTable.getTagsFromLabelId(label.labelId)</td>
-                                    <td>@label.description</td>
-                                    <td><a class="labelView" data-label-id="@label.labelId" href="#">View</a></td>
-                                </tr>
-
-                            }
+                            <!-- using this id to locate the labelTags so we can insert the tags-->
+                            <tbody id = 'labelRows'>
+                                @LabelTable.selectTopLabelsAndMetadata(1000).map { label =>
+                                    <tr>
+                                        <td><a href='@routes.AdminController.userProfile(label.username)'>@label.username</a>
+                                        </td>
+                                        <td>@label.timestamp</td>
+                                        <td>@label.labelTypeValue</td>
+                                        <td>@label.severity</td>
+                                        <td>@label.temporary</td>
+                                        <!-- made bit of javascript to put in the tags, couldn't just do label.tags
+                                             because then we just get raw unformatted JSON -->
+                                        <td class = "labelTags"></td>
+                                        <td>@label.description</td>
+                                        <td>
+                                            <a class="labelView" data-label-id="@label.labelId" href="#">View</a>
+                                        </td>
+                                    </tr>
+                                }
                             </tbody>
                         </table>
                     </div>

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -528,9 +528,7 @@
                                         <td>@label.labelTypeValue</td>
                                         <td>@label.severity</td>
                                         <td>@label.temporary</td>
-                                        <!-- made bit of javascript to put in the tags, couldn't just do label.tags
-                                             because then we just get raw unformatted JSON -->
-                                        <td class = "labelTags"></td>
+                                        <td>@label.tags.mkString(", ")</td>
                                         <td>@label.description</td>
                                         <td>
                                             <a class="labelView" data-label-id="@label.labelId" href="#">View</a>

--- a/public/javascripts/Admin/src/Admin.GSVLabelView.js
+++ b/public/javascripts/Admin/src/Admin.GSVLabelView.js
@@ -36,6 +36,10 @@ function AdminGSVLabel() {
                                 '<td id="temporary"></td>'+
                             '</tr>'+
                             '<tr>'+
+                                '<th>Tags</th>'+
+                                '<td colspan="3" id="tags"></td>'+
+                            '</tr>'+
+                            '<tr>'+
                                 '<th>Description</th>'+
                                 '<td colspan="3" id="label-description"></td>'+
                             '</tr>'+
@@ -55,6 +59,7 @@ function AdminGSVLabel() {
         self.modalLabelTypeValue = self.modal.find("#label-type-value");
         self.modalSeverity = self.modal.find("#severity");
         self.modalTemporary = self.modal.find("#temporary");
+        self.modalTags = self.modal.find("#tags");
         self.modalDescription = self.modal.find("#label-description");
         self.modalTask = self.modal.find("#task");
     }
@@ -90,6 +95,7 @@ function AdminGSVLabel() {
         self.modalLabelTypeValue.html(labelMetadata['label_type_value']);
         self.modalSeverity.html(labelMetadata['severity'] != null ? labelMetadata['severity'] : "No severity");
         self.modalTemporary.html(labelMetadata['temporary'] ? "True": "False");
+        self.modalTags.html(labelMetadata['tags']);
         self.modalDescription.html(labelMetadata['description'] != null ? labelMetadata['description'] : "No description");
         self.modalTask.html("<a href='/admin/task/"+labelMetadata['audit_task_id']+"'>"+
             labelMetadata['audit_task_id']+"</a> by <a href='/admin/user/" + labelMetadata['username'] + "'>" +

--- a/public/javascripts/Admin/src/Admin.GSVLabelView.js
+++ b/public/javascripts/Admin/src/Admin.GSVLabelView.js
@@ -95,7 +95,8 @@ function AdminGSVLabel() {
         self.modalLabelTypeValue.html(labelMetadata['label_type_value']);
         self.modalSeverity.html(labelMetadata['severity'] != null ? labelMetadata['severity'] : "No severity");
         self.modalTemporary.html(labelMetadata['temporary'] ? "True": "False");
-        self.modalTags.html(labelMetadata['tags']);
+        //join is here to make the formatting nice, otherwise we don't have commas or spaces.
+        self.modalTags.html(labelMetadata['tags'].join(', '));
         self.modalDescription.html(labelMetadata['description'] != null ? labelMetadata['description'] : "No description");
         self.modalTask.html("<a href='/admin/task/"+labelMetadata['audit_task_id']+"'>"+
             labelMetadata['audit_task_id']+"</a> by <a href='/admin/user/" + labelMetadata['username'] + "'>" +

--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -515,7 +515,7 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
         self.adminGSVLabelView = AdminGSVLabel();
     }
 
-    function initializeLabelTableView() {
+    function initializeLabelTable() {
         $('.labelView').click(function (e) {
             e.preventDefault();
             self.adminGSVLabelView.showLabel($(this).data('labelId'));
@@ -1444,7 +1444,7 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
     }
 
     addTagsToTable();
-    initializeLabelTableView();
+    initializeLabelTable();
     initializeAdminGSVLabelView();
 
     self.clearMap = clearMap;

--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -515,7 +515,7 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
         self.adminGSVLabelView = AdminGSVLabel();
     }
 
-    function initializeLabelTable() {
+    function initializeLabelTableView() {
         $('.labelView').click(function (e) {
             e.preventDefault();
             self.adminGSVLabelView.showLabel($(this).data('labelId'));
@@ -1428,7 +1428,23 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
         });
     }
 
-    initializeLabelTable();
+    /**
+     * This method adds the tags to the table. It looks through each label row in #labelRows, finds labelView to get the label id,
+     * and then finds the JSON to get the tags. It formats the tags, then inserts them into labelTags. Called on initalization.
+     */
+    function addTagsToTable() {
+        $('#labelRows').each(function(){
+            var labelRow = this;
+            var labelUrl = "/adminapi/label/" + parseInt($(labelRow).find('.labelView')[0].getAttribute("data-label-id").toString());
+            console.log(labelUrl);
+            $.getJSON(labelUrl, function (data) {
+                $(labelRow).find('.labelTags')[0].textContent = data['tags'].join(', ');
+            });
+        });
+    }
+
+    addTagsToTable();
+    initializeLabelTableView();
     initializeAdminGSVLabelView();
 
     self.clearMap = clearMap;

--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -1428,22 +1428,6 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
         });
     }
 
-    /**
-     * This method adds the tags to the table. It looks through each label row in #labelRows, finds labelView to get the label id,
-     * and then finds the JSON to get the tags. It formats the tags, then inserts them into labelTags. Called on initalization.
-     */
-    function addTagsToTable() {
-        $('#labelRows').each(function(){
-            var labelRow = this;
-            var labelUrl = "/adminapi/label/" + parseInt($(labelRow).find('.labelView')[0].getAttribute("data-label-id").toString());
-            console.log(labelUrl);
-            $.getJSON(labelUrl, function (data) {
-                $(labelRow).find('.labelTags')[0].textContent = data['tags'].join(', ');
-            });
-        });
-    }
-
-    addTagsToTable();
     initializeLabelTable();
     initializeAdminGSVLabelView();
 


### PR DESCRIPTION
Tags are added to admin interface, comma seperated. Looks like this:
![image](https://user-images.githubusercontent.com/21998904/43166965-0379245c-8f4d-11e8-96a9-700be900cf53.png)
and this:
![image](https://user-images.githubusercontent.com/21998904/43166981-0d20e454-8f4d-11e8-83ea-450b3dd36eed.png)
Description removed from table, but still exists in dialog.
Created seperate sql query for getting the tags because copy pasting into each of the three queries seemed redundant.
