### PR TITLE
added QWER-based input for marking tags

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/keyboard/Keyboard.js
+++ b/public/javascripts/SVLabel/src/SVLabel/keyboard/Keyboard.js
@@ -156,6 +156,7 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
              */
             if (!status.focusOnTextField) {
                 var label;
+                var tagSelected;
                 switch (e.keyCode) {
                     case 16:
                         // "Shift"
@@ -227,6 +228,22 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
                             }
                         }
                         break;
+
+                    case 81: //Q
+                        tagSelected = $('#context-menu-tag-holder').find('.context-menu-tag')[0];
+                        break;
+
+                    case 87: //W
+                        tagSelected = $('#context-menu-tag-holder').find('.context-menu-tag')[1];
+                        break;
+
+                    case 69: //E
+                        tagSelected = $('#context-menu-tag-holder').find('.context-menu-tag')[2];
+                        break;
+
+                    case 82: //R
+                        tagSelected = $('#context-menu-tag-holder').find('.context-menu-tag')[3];
+                        break;
                     case util.misc.getLabelDescriptions('Occlusion')['shortcut']['keyNumber']:
                         // "b" for a blocked view
                         ribbon.modeSwitch("Occlusion");
@@ -293,6 +310,17 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
                                 keyCode: e.keyCode
                             });
                         }
+                }
+                //if we have a tag, then select it.
+                if(tagSelected) {
+                    selectTag($(tagSelected).text());
+                    //toggle the background color to indicate that the tag was selected
+                    if(tagSelected.style.backgroundColor !== 'rgb(200, 200, 200)'){
+                        tagSelected.style.backgroundColor = 'rgb(200, 200, 200)';
+                    }
+                    else{
+                        tagSelected.style.backgroundColor = 'white';
+                    }
                 }
             }
 
@@ -362,6 +390,27 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
             status[key] = value;
         }
     };
+
+    function selectTag(tagValue){
+        var label = contextMenu.getTargetLabel();
+        var labelTags = label.getProperty('tagIds');
+        // Adds or removes tag from the label's current list of tags.
+        contextMenu.labelTags.forEach(function (tag) {
+            if (tag.tag === tagValue) {
+                if (!labelTags.includes(tag.tag_id)) {
+                    labelTags.push(tag.tag_id);
+                    svl.tracker.push('ContextMenu_TagAdded',
+                        { tagId: tag.tag_id, tagName: tag.tag });
+                } else {
+                    var index = labelTags.indexOf(tag.tag_id);
+                    labelTags.splice(index, 1);
+                    svl.tracker.push('ContextMenu_TagRemoved',
+                        { tagId: tag.tag_id, tagName: tag.tag });
+                }
+            }
+        });
+        label.setProperty('tagIds', labelTags);
+    }
 
 
     $(document).bind('keyup', this._documentKeyUp);


### PR DESCRIPTION
fixes #1276
now you can add tags using the keys 'q', 'w', 'e', and 'r'.
Should make labeling easier since the serverity shortcuts (12345) are very close to the tags shortcuts (qwer). Tags look and behave exactly the same. 

Here's how it looks before I press any keys:
![image](https://user-images.githubusercontent.com/21998904/43426735-9d6e7edc-940b-11e8-998f-224a6d391786.png)

Here's how it looks when I press 'q'
![image](https://user-images.githubusercontent.com/21998904/43426767-bec808d2-940b-11e8-9a40-97396777a4d9.png)

Pressing q again makes it:
![image](https://user-images.githubusercontent.com/21998904/43426804-e0fe8fe8-940b-11e8-8a49-037b9ac9104b.png)

We can also do multiple keypresses at the same time. Pressing q, w, and e at the same time gives us:
![image](https://user-images.githubusercontent.com/21998904/43426831-fba797f4-940b-11e8-9e62-b1c5f02eafb1.png)

Clicking still works fine. Clicking "missing friction strip after the above gives us:
![image](https://user-images.githubusercontent.com/21998904/43426944-6a618d08-940c-11e8-8b56-1367834e10d2.png)


