### PR TITLE
fixed  onboarding so that intersection is not obscured by instructions

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/onboarding/OnboardingStates.js
+++ b/public/javascripts/SVLabel/src/SVLabel/onboarding/OnboardingStates.js
@@ -4,8 +4,8 @@ function OnboardingStates (compass, mapService, statusModel, tracker) {
     var afterWalkPanoId = "PTHUzZqpLdS1nTixJMoDSw";
     var headingRanges = {
         "stage-1": [250, 262],
-        "stage-2-adjust": [185, 262],
-        "stage-2": [185, 210],
+        "stage-2-adjust": [200, 262],
+        "stage-2": [200, 210],
         "stage-3-adjust": [97, 200],
         "stage-3": [97, 180],
         "stage-4-adjust": [7, 180],

--- a/public/javascripts/SVLabel/src/SVLabel/onboarding/OnboardingStates.js
+++ b/public/javascripts/SVLabel/src/SVLabel/onboarding/OnboardingStates.js
@@ -4,9 +4,9 @@ function OnboardingStates (compass, mapService, statusModel, tracker) {
     var afterWalkPanoId = "PTHUzZqpLdS1nTixJMoDSw";
     var headingRanges = {
         "stage-1": [250, 262],
-        "stage-2-adjust": [200, 262],
-        "stage-2": [200, 245],
-        "stage-3-adjust": [97, 230],
+        "stage-2-adjust": [185, 262],
+        "stage-2": [185, 210],
+        "stage-3-adjust": [97, 200],
         "stage-3": [97, 180],
         "stage-4-adjust": [7, 180],
         "stage-4": [7, 115],
@@ -181,7 +181,7 @@ function OnboardingStates (compass, mapService, statusModel, tracker) {
         "adjust-heading-angle-1": {
             "properties": {
                 "action": "AdjustHeadingAngle",
-                "heading": 230,
+                "heading": 210,
                 "tolerance": 20,
                 "minHeading": headingRanges["stage-2-adjust"][0],
                 "maxHeading": headingRanges["stage-2-adjust"][1],


### PR DESCRIPTION
Fixes #1260 
Fixes the problem where the instructions obscured the curb ramp by making the user pan left a bit more. Looks like this:
![image](https://user-images.githubusercontent.com/21998904/43668475-fa301b34-9731-11e8-8f3b-b9490144ce0e.png)
