### PR TITLE
shows 'Other' label in user and admin tables, fixes #1234

### DIFF
--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -523,14 +523,7 @@
                                         <td><a href='@routes.AdminController.userProfile(label.username)'>@label.username</a>
                                         </td>
                                         <td>@label.timestamp</td>
-                                        <td>
-                                            <!-- in the case that the description of the label type is null or empty, just display the key value -->
-                                            @if(label.labelTypeValue == null || label.labelTypeValue.isEmpty){
-                                                @label.labelTypeKey
-                                            }else{
-                                                @label.labelTypeValue
-                                            }
-                                        </td>
+                                        <td>@label.labelTypeKey</td>
                                         <td>@label.severity</td>
                                         <td>@label.temporary</td>
                                         <td>@label.tags.mkString(", ")</td>

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -523,7 +523,14 @@
                                         <td><a href='@routes.AdminController.userProfile(label.username)'>@label.username</a>
                                         </td>
                                         <td>@label.timestamp</td>
-                                        <td>@label.labelTypeValue</td>
+                                        <td>
+                                            <!-- in the case that the description of the label type is null or empty, just display the key value -->
+                                            @if(label.labelTypeValue == null || label.labelTypeValue.isEmpty){
+                                                @label.labelTypeKey
+                                            }else{
+                                                @label.labelTypeValue
+                                            }
+                                        </td>
                                         <td>@label.severity</td>
                                         <td>@label.temporary</td>
                                         <td>@label.tags.mkString(", ")</td>

--- a/app/views/admin/user.scala.html
+++ b/app/views/admin/user.scala.html
@@ -198,4 +198,4 @@
                 $('#labelTable').dataTable();
             });
     </script>
-} 
+}

--- a/app/views/admin/user.scala.html
+++ b/app/views/admin/user.scala.html
@@ -104,7 +104,14 @@
                     @LabelTable.selectTopLabelsAndMetadataByUser(1000, UUID.fromString(user.get.userId)).map { userLabel =>
                         <tr>
                             <td>@userLabel.timestamp</td>
-                            <td>@userLabel.labelTypeValue</td>
+                            <td>
+                                <!-- in the case that the description of the label type is null or empty, just display the key value -->
+                                @if(userLabel.labelTypeValue == null || userLabel.labelTypeValue.isEmpty){
+                                    @userLabel.labelTypeKey
+                                }else{
+                                    @userLabel.labelTypeValue
+                                }
+                            </td>
                             <td>@userLabel.severity</td>
                             <td>@userLabel.temporary</td>
                             <td>@userLabel.description</td>

--- a/app/views/admin/user.scala.html
+++ b/app/views/admin/user.scala.html
@@ -104,14 +104,7 @@
                     @LabelTable.selectTopLabelsAndMetadataByUser(1000, UUID.fromString(user.get.userId)).map { userLabel =>
                         <tr>
                             <td>@userLabel.timestamp</td>
-                            <td>
-                                <!-- in the case that the description of the label type is null or empty, just display the key value -->
-                                @if(userLabel.labelTypeValue == null || userLabel.labelTypeValue.isEmpty){
-                                    @userLabel.labelTypeKey
-                                }else{
-                                    @userLabel.labelTypeValue
-                                }
-                            </td>
+                            <td>@userLabel.labelTypeKey</td>
                             <td>@userLabel.severity</td>
                             <td>@userLabel.temporary</td>
                             <td>@userLabel.description</td>

--- a/app/views/admin/user.scala.html
+++ b/app/views/admin/user.scala.html
@@ -198,4 +198,4 @@
                 $('#labelTable').dataTable();
             });
     </script>
-}
+} 


### PR DESCRIPTION
fixes #1234 
in case where description is empty or null, display the label key value instead.

new admin table:
![image](https://user-images.githubusercontent.com/21998904/44171742-f1112400-a08f-11e8-9f58-1ff244edb1e1.png)

new user table:
![image](https://user-images.githubusercontent.com/21998904/44171772-08e8a800-a090-11e8-89b8-4a641c983b08.png)

old admin table:
![image](https://user-images.githubusercontent.com/21998904/44171884-55cc7e80-a090-11e8-9a61-dbedb5dbd86a.png)



old user table:
![image](https://user-images.githubusercontent.com/21998904/44171809-2158c280-a090-11e8-890e-08aec9945a77.png)

