### PR TITLE
Resolves #1255: fixes duplicate pano id logging

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
+++ b/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
@@ -15,6 +15,7 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
             renderLabels : false
         },
         markers = [],
+        prevPanoId = undefined,
         properties = {
             browser : 'unknown',
             latlng : {
@@ -771,7 +772,14 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
                                     //});
                                 }
                             }
-                            svl.tracker.push("PanoId_Changed");
+
+                            // Checks if pano_id is the same as the previous one.
+                            // Google maps API triggers the pano_changed event twice: once moving
+                            // between pano_ids  and once for setting the new pano_id.
+                            if (panoId !== prevPanoId) {
+                                svl.tracker.push("PanoId_Changed");
+                                prevPanoId = panoId;
+                            }
                         }
                         else {
                             handleImageryNotFound(panoId, panoStatus);


### PR DESCRIPTION
Resolves #1255.

The Google Maps 'pano_changed' listener is triggered twice when we switch panoramas: once when we are transitioning between panoramas, and once when we set the new panorama. I added a check to see if it was the same as the previous panorama ID that was logged.

**Testing Instructions**
Go to the audit screen and try to walk around a bit. You can try stress-testing the system by rapid clicking the Street View arrows.

