### PR TITLE
Resolves #976: Fixes initial blank panorama

### DIFF
--- a/public/javascripts/Admin/src/Admin.GSVLabelView.js
+++ b/public/javascripts/Admin/src/Admin.GSVLabelView.js
@@ -74,23 +74,17 @@ function AdminGSVLabel() {
         $.getJSON(adminLabelUrl, function (data) {
             _handleData(data);
         });
-        self.panorama.refreshGSV();
     }
 
     function _handleData(labelMetadata) {
-        self.panorama.changePanoId(labelMetadata['gsv_panorama_id']);
-
-        self.panorama.setPov({
-            heading: labelMetadata['heading'],
-            pitch: labelMetadata['pitch'],
-            zoom: labelMetadata['zoom']
-        });
+        self.panorama.setPano(labelMetadata['gsv_panorama_id'], labelMetadata['heading'],
+            labelMetadata['pitch'], labelMetadata['zoom']);
 
         var adminPanoramaLabel = AdminPanoramaLabel(labelMetadata['label_type_key'],
             labelMetadata['canvas_x'], labelMetadata['canvas_y'],
             labelMetadata['canvas_width'], labelMetadata['canvas_height'], labelMetadata['heading'],
             labelMetadata['pitch'], labelMetadata['zoom']);
-        self.panorama.renderLabel(adminPanoramaLabel);
+        self.panorama.setLabel(adminPanoramaLabel);
 
         var labelDate = moment(new Date(labelMetadata['timestamp']));
         self.modalTimestamp.html(labelDate.format('MMMM Do YYYY, h:mm:ss') + " (" + labelDate.fromNow() + ")");


### PR DESCRIPTION
Fixes #976 

The blank panorama is caused by a bug in the Google StreetView API that doesn't load the panorama w/ the PanoID correctly the first time. There was a workaround we used earlier of resizing the window (because I think it forces the panorama to refresh). I added a callback function (which is similar to what we do in Onboarding) that will force the panorama to refresh itself. It should load without having to resize the window now.

I also modified the zoom levels in the admin panorama to more closely reflect what the user sees. (The zoomLevel seems to depend on what size the Google StreetView window is, which is sort of odd -- when I made the window bigger in #1308, I forgot to adjust the zoomLevel too).

**Testing Instructions**
* Open the admin page. Go to page ~100(ish) on the contributions page, and try opening a few panoramas. Panoramas with the label should load properly (i.e. without resizing the window)
    * If the screen is black, open the developer window and see if there's a 404 error (if the panorama doesn't exist anymore, the screen will be black).
* Go to Map page, and repeat the steps above.