### PR TITLE
1146 change name of user table to sidewalk_user

### DIFF
--- a/anonymize.py
+++ b/anonymize.py
@@ -15,7 +15,7 @@ def anonymize(sql_filename):
 
 
     terminate_line = "\."
-    copy_user_start_line = """COPY "user" (user_id, username, email) FROM stdin;"""
+    copy_user_start_line = """COPY sidewalk_user (user_id, username, email) FROM stdin;"""
     copy_login_info_start_line = """COPY login_info (login_info_id, provider_id, provider_key) FROM stdin;"""
 
 

--- a/anonymize.py
+++ b/anonymize.py
@@ -39,7 +39,7 @@ def anonymize(sql_filename):
 
             new_line = line
 
-            # Substitute lines in the user table
+            # Substitute lines in the sidewalk_user table
             if read_user_table:
                 line_list = line.split("\t")
                 if line_list[1] != "anonymous":

--- a/app/controllers/ApplicationController.scala
+++ b/app/controllers/ApplicationController.scala
@@ -72,7 +72,7 @@ class ApplicationController @Inject() (implicit val env: Environment[User, Sessi
                 val confirmationCode = Some(s"${Random.alphanumeric take 8 mkString("")}")
                 val asg: AMTAssignment = AMTAssignment(0, hitId, assignmentId, timestamp, None, workerId, confirmationCode, false)
                 val asgId: Option[Int] = Option(AMTAssignmentTable.save(asg))
-                // Since the turker doesnt exist in the user table create a new record with the role set to "Turker".
+                // Since the turker doesn't exist in the sidewalk_user table create new record with Turker role.
                 val redirectTo = List("turkerSignUp", hitId, workerId, assignmentId).reduceLeft(_ +"/"+ _)
                 Future.successful(Redirect(redirectTo))
             }

--- a/app/models/audit/AuditTaskInteractionTable.scala
+++ b/app/models/audit/AuditTaskInteractionTable.scala
@@ -168,14 +168,14 @@ def selectAllAuditTimes(): List[UserAuditTime] = db.withSession { implicit sessi
       |    FROM audit_task_interaction
       |    INNER JOIN audit_task
       |        ON audit_task.audit_task_id = audit_task_interaction.audit_task_id
-      |    INNER JOIN sidewalk.user
-      |        ON audit_task.user_id = sidewalk.user.user_id
+      |    INNER JOIN sidewalk_user
+      |        ON audit_task.user_id = sidewalk_user.user_id
       |    INNER JOIN user_role
       |        ON audit_task.user_id = user_role.user_id
       |    INNER JOIN role
       |        ON user_role.role_id = role.role_id
       |    WHERE action = 'ViewControl_MouseDown'
-      |        AND sidewalk.user.username <> 'anonymous'
+      |        AND sidewalk_user.username <> 'anonymous'
       |        AND role.role IN ('Registered', 'Anonymous', 'Turker')
       |    ) user_audit_times
       |WHERE diff < '00:05:00.000' AND diff > '00:00:00.000'

--- a/app/models/daos/UserDAOImpl.scala
+++ b/app/models/daos/UserDAOImpl.scala
@@ -131,11 +131,11 @@ object UserDAOImpl {
     val countQuery = Q.query[String, Int](
       """SELECT COUNT(DISTINCT(audit_task.user_id))
         |FROM sidewalk.audit_task
-        |INNER JOIN sidewalk.user ON sidewalk.user.user_id = audit_task.user_id
-        |INNER JOIN sidewalk.user_role ON sidewalk.user.user_id = sidewalk.user_role.user_id
-        |INNER JOIN sidewalk.role ON sidewalk.user_role.role_id = sidewalk.role.role_id
+        |INNER JOIN sidewalk_user ON sidewalk_user.user_id = audit_task.user_id
+        |INNER JOIN sidewalk_user_role ON sidewalk_user.user_id = sidewalk_user_role.user_id
+        |INNER JOIN sidewalk.role ON sidewalk_user_role.role_id = sidewalk.role.role_id
         |WHERE audit_task.task_end::date = now()::date
-        |    AND sidewalk.user.username <> 'anonymous'
+        |    AND sidewalk_user.username <> 'anonymous'
         |    AND role.role = ?
         |    AND audit_task.completed = true""".stripMargin
     )
@@ -177,11 +177,11 @@ object UserDAOImpl {
     val countQuery = Q.query[String, Int](
       """SELECT COUNT(DISTINCT(audit_task.user_id))
         |FROM sidewalk.audit_task
-        |INNER JOIN sidewalk.user ON sidewalk.user.user_id = audit_task.user_id
-        |INNER JOIN sidewalk.user_role ON sidewalk.user.user_id = sidewalk.user_role.user_id
-        |INNER JOIN sidewalk.role ON sidewalk.user_role.role_id = sidewalk.role.role_id
+        |INNER JOIN sidewalk_user ON sidewalk_user.user_id = audit_task.user_id
+        |INNER JOIN sidewalk_user_role ON sidewalk_user.user_id = sidewalk_user_role.user_id
+        |INNER JOIN sidewalk.role ON sidewalk_user_role.role_id = sidewalk.role.role_id
         |WHERE audit_task.task_end::date = now()::date - interval '1' day
-        |    AND sidewalk.user.username <> 'anonymous'
+        |    AND sidewalk_user.username <> 'anonymous'
         |    AND role.role = ?
         |    AND audit_task.completed = true""".stripMargin
     )

--- a/app/models/daos/UserDAOImpl.scala
+++ b/app/models/daos/UserDAOImpl.scala
@@ -132,8 +132,8 @@ object UserDAOImpl {
       """SELECT COUNT(DISTINCT(audit_task.user_id))
         |FROM sidewalk.audit_task
         |INNER JOIN sidewalk_user ON sidewalk_user.user_id = audit_task.user_id
-        |INNER JOIN sidewalk_user_role ON sidewalk_user.user_id = sidewalk_user_role.user_id
-        |INNER JOIN sidewalk.role ON sidewalk_user_role.role_id = sidewalk.role.role_id
+        |INNER JOIN user_role ON sidewalk_user.user_id = user_role.user_id
+        |INNER JOIN sidewalk.role ON user_role.role_id = sidewalk.role.role_id
         |WHERE audit_task.task_end::date = now()::date
         |    AND sidewalk_user.username <> 'anonymous'
         |    AND role.role = ?
@@ -178,8 +178,8 @@ object UserDAOImpl {
       """SELECT COUNT(DISTINCT(audit_task.user_id))
         |FROM sidewalk.audit_task
         |INNER JOIN sidewalk_user ON sidewalk_user.user_id = audit_task.user_id
-        |INNER JOIN sidewalk_user_role ON sidewalk_user.user_id = sidewalk_user_role.user_id
-        |INNER JOIN sidewalk.role ON sidewalk_user_role.role_id = sidewalk.role.role_id
+        |INNER JOIN user_role ON sidewalk_user.user_id = user_role.user_id
+        |INNER JOIN sidewalk.role ON user_role.role_id = sidewalk.role.role_id
         |WHERE audit_task.task_end::date = now()::date - interval '1' day
         |    AND sidewalk_user.username <> 'anonymous'
         |    AND role.role = ?

--- a/app/models/daos/slick/DBTableDefinitions.scala
+++ b/app/models/daos/slick/DBTableDefinitions.scala
@@ -7,7 +7,7 @@ object DBTableDefinitions {
 
   case class DBUser (userId: String, username: String, email: String )
 
-  class UserTable(tag: Tag) extends Table[DBUser](tag, Some("sidewalk"), "user") {
+  class UserTable(tag: Tag) extends Table[DBUser](tag, Some("sidewalk"), "sidewalk_user") {
     def userId = column[String]("user_id", O.PrimaryKey)
     def username = column[String]("username")
     def email = column[String]("email")

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -277,7 +277,7 @@ object LabelTable {
         |       lb_big.description
         |FROM sidewalk.label AS lb1,
         |     sidewalk.audit_task AS at,
-        |     sidewalk.user AS u,
+        |     sidewalk_user AS u,
         |     sidewalk.label_point AS lp,
         |			(
         |         SELECT lb.label_id,
@@ -328,7 +328,7 @@ object LabelTable {
         |       lb_big.description
         |FROM sidewalk.label AS lb1,
         |     sidewalk.audit_task AS at,
-        |     sidewalk.user AS u,
+        |     sidewalk_user AS u,
         |     sidewalk.label_point AS lp,
         |			(
         |         SELECT lb.label_id,
@@ -380,7 +380,7 @@ object LabelTable {
         |       lb_big.description
         |FROM sidewalk.label AS lb1,
         |     sidewalk.audit_task AS at,
-        |     sidewalk.user AS u,
+        |     sidewalk_user AS u,
         |     sidewalk.label_point AS lp,
         |		  (
         |         SELECT lb.label_id,

--- a/app/models/sidewalk/SidewalkEdgeTable.scala
+++ b/app/models/sidewalk/SidewalkEdgeTable.scala
@@ -89,7 +89,7 @@ object SidewalkEdgeTable {
 //    import Q.interpolation
 //
 //    val columns = MTable.getTables(None, None, None, None).list.filter(_.name.name == "USER")
-//    val user = sql"""SELECT * FROM "user" WHERE "id" = $id""".as[List[String]].firstOption.map(columns zip _ toMap)
+//    val user = sql"""SELECT * FROM sidewalk_user WHERE "id" = $id""".as[List[String]].firstOption.map(columns zip _ toMap)
 //    user
 //  }
 }

--- a/conf/evolutions/default/19.sql
+++ b/conf/evolutions/default/19.sql
@@ -1,0 +1,5 @@
+# --- !Ups
+ALTER TABLE "user" RENAME TO sidewalk_user;
+
+# --- !Downs
+ALTER TABLE sidewalk_user RENAME TO "user";

--- a/hit_approve_bonus.py
+++ b/hit_approve_bonus.py
@@ -24,12 +24,12 @@ try:
     #(Find the same user in the amt_assignment table and get the hit id and assignment id for this)
 
     cur.execute("""SELECT username,mission.mission_id,mission_user.mission_user_id,mission.label,
-        region_id,distance,distance_ft,distance_mi, hit_id, assignment_id, paid 
-        from mission_user 
-        join mission on(mission.mission_id = mission_user.mission_id) 
-        join user_role on(user_role.user_id=mission_user.user_id and user_role.role_id=2) 
-        join sidewalk.user on(sidewalk.user.user_id = mission_user.user_id) 
-        join amt_assignment on(username = amt_assignment.turker_id) 
+        region_id,distance,distance_ft,distance_mi, hit_id, assignment_id, paid
+        from mission_user
+        join mission on(mission.mission_id = mission_user.mission_id)
+        join user_role on(user_role.user_id=mission_user.user_id and user_role.role_id=2)
+        join sidewalk_user on(sidewalk_user.user_id = mission_user.user_id)
+        join amt_assignment on(username = amt_assignment.turker_id)
         where mission.deleted = false and mission.label !='onboarding';""")
 
     mission_rows = cur.fetchall()


### PR DESCRIPTION
Resolves #1146 

Changes the name of the `user` table to `sidewalk_user` so that we don't have to put the name of the table in quotes or use "sidewalk.user" each time we reference the table. We no longer have a table with the same name as a postgres keyword :roll_eyes: 

NOTE: Do not review this PR until PR #1319 (updating mission infrastructure), #1327, and #1328 have been merged. I branched this code off of the code in that PR instead of the code on develop (b/c each of these PRs creates a new evolutions file, and it would be annoying to have a merge commit where I change the name of the evolutions file every time I merge a PR.

Testing:
* Test that the evolution file works correctly in that the table name changes to `sidewalk_user` when compiling and running the code on this branch, and changes back to `user` when compiling and running code on `develop` again.
* Do a few things on the website that would definitely make use of the `sidewalk_user` table (log in, audit a bit, check the user dashboard, log out) and just make sure that no errors occur.
* Search through the code to see if you can find any places where I missed a reference to the "user" table that still needs to be changed.