### PR TITLE
Resolves #1237: allows keyboard shortcuts to close context menu

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/keyboard/Keyboard.js
+++ b/public/javascripts/SVLabel/src/SVLabel/keyboard/Keyboard.js
@@ -240,14 +240,16 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
                         });
                         break;
                     case util.misc.getLabelDescriptions('CurbRamp')['shortcut']['keyNumber']:
+                        if (contextMenu.isOpen()) {
+                            _closeContextMenu(e.keyCode);
+                        }
+
                         // "c" for CurbRamp. Switch the mode to the CurbRamp labeling mode.
                         if (!contextMenu.isOpen()) {
                             ribbon.modeSwitch("CurbRamp");
                             svl.tracker.push("KeyboardShortcut_ModeSwitch_CurbRamp", {
                                 keyCode: e.keyCode
                             });
-                        } else {
-                            _closeContextMenu(e.keyCode);
                         }
                         break;
                     case util.misc.getLabelDescriptions('Walk')['shortcut']['keyNumber']:
@@ -258,14 +260,15 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
                         });
                         break;
                     case util.misc.getLabelDescriptions('NoCurbRamp')['shortcut']['keyNumber']:
+                        if (contextMenu.isOpen()) {
+                            _closeContextMenu(e.keyCode);
+                        }
                         // "m" for MissingCurbRamp. Switch the mode to the MissingCurbRamp labeling mode.
                         if (!contextMenu.isOpen()) {
                             ribbon.modeSwitch("NoCurbRamp");
                             svl.tracker.push("KeyboardShortcut_ModeSwitch_NoCurbRamp", {
                                 keyCode: e.keyCode
                             });
-                        } else {
-                            _closeContextMenu(e.keyCode);
                         }
                         break;
                     case util.misc.getLabelDescriptions('NoSidewalk')['shortcut']['keyNumber']:
@@ -275,24 +278,28 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
                         });
                         break;
                     case util.misc.getLabelDescriptions('Obstacle')['shortcut']['keyNumber']:
+                        if (contextMenu.isOpen()) {
+                            _closeContextMenu(e.keyCode);
+                        }
+
                         // "o" for Obstacle
                         if (!contextMenu.isOpen()) {
                             ribbon.modeSwitch("Obstacle");
                             svl.tracker.push("KeyboardShortcut_ModeSwitch_Obstacle", {
                                 keyCode: e.keyCode
                             });
-                        } else {
-                            _closeContextMenu(e.keyCode);
                         }
                         break;
                     case util.misc.getLabelDescriptions('SurfaceProblem')['shortcut']['keyNumber']:
+                        if (contextMenu.isOpen()) {
+                            _closeContextMenu(e.keyCode);
+                        }
+
                         if (!contextMenu.isOpen()) {
                             ribbon.modeSwitch("SurfaceProblem");
                             svl.tracker.push("KeyboardShortcut_ModeSwitch_SurfaceProblem", {
                                 keyCode: e.keyCode
                             });
-                        } else {
-                            _closeContextMenu(e.keyCode);
                         }
                         break;
                     case 16: //shift

--- a/public/javascripts/SVLabel/src/SVLabel/keyboard/Keyboard.js
+++ b/public/javascripts/SVLabel/src/SVLabel/keyboard/Keyboard.js
@@ -231,7 +231,6 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
              */
             status.shiftDown = e.shiftKey;
             if (!status.focusOnTextField) {
-                var label = contextMenu.isOpen() ? contextMenu.getTargetLabel() : undefined;
                 switch (e.keyCode) {
                     case util.misc.getLabelDescriptions('Occlusion')['shortcut']['keyNumber']:
                         // "b" for a blocked view
@@ -247,12 +246,8 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
                             svl.tracker.push("KeyboardShortcut_ModeSwitch_CurbRamp", {
                                 keyCode: e.keyCode
                             });
-                        } else if (contextMenu.isOpen() && label.getProperty('labelType') === 'CurbRamp') {
-                            contextMenu.hide();
-                            svl.tracker.push("ContextMenu_CloseKeyboardShortcut", {
-                                keyCode: e.keyCode
-                            });
-                            svl.tracker.push("KeyboardShortcut_CloseContextMenu");
+                        } else {
+                            _closeContextMenu(e.keyCode);
                         }
                         break;
                     case util.misc.getLabelDescriptions('Walk')['shortcut']['keyNumber']:
@@ -269,12 +264,8 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
                             svl.tracker.push("KeyboardShortcut_ModeSwitch_NoCurbRamp", {
                                 keyCode: e.keyCode
                             });
-                        } else if (contextMenu.isOpen() && label.getProperty('labelType') === 'NoCurbRamp') {
-                            contextMenu.hide();
-                            svl.tracker.push("ContextMenu_CloseKeyboardShortcut", {
-                                keyCode: e.keyCode
-                            });
-                            svl.tracker.push("KeyboardShortcut_CloseContextMenu");
+                        } else {
+                            _closeContextMenu(e.keyCode);
                         }
                         break;
                     case util.misc.getLabelDescriptions('NoSidewalk')['shortcut']['keyNumber']:
@@ -290,12 +281,8 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
                             svl.tracker.push("KeyboardShortcut_ModeSwitch_Obstacle", {
                                 keyCode: e.keyCode
                             });
-                        } else if (contextMenu.isOpen() && label.getProperty('labelType') === 'Obstacle') {
-                            contextMenu.hide();
-                            svl.tracker.push("ContextMenu_CloseKeyboardShortcut", {
-                                keyCode: e.keyCode
-                            });
-                            svl.tracker.push("KeyboardShortcut_CloseContextMenu");
+                        } else {
+                            _closeContextMenu(e.keyCode);
                         }
                         break;
                     case util.misc.getLabelDescriptions('SurfaceProblem')['shortcut']['keyNumber']:
@@ -304,12 +291,8 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
                             svl.tracker.push("KeyboardShortcut_ModeSwitch_SurfaceProblem", {
                                 keyCode: e.keyCode
                             });
-                        } else if (contextMenu.isOpen() && label.getProperty('labelType') === 'SurfaceProblem') {
-                            contextMenu.hide();
-                            svl.tracker.push("ContextMenu_CloseKeyboardShortcut", {
-                                keyCode: e.keyCode
-                            });
-                            svl.tracker.push("KeyboardShortcut_CloseContextMenu");
+                        } else {
+                            _closeContextMenu(e.keyCode);
                         }
                         break;
                     case 16: //shift
@@ -374,6 +357,14 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
             contextMenu.updateRadioButtonImages();
         }
     };
+
+    function _closeContextMenu(key) {
+        contextMenu.hide();
+        svl.tracker.push("ContextMenu_CloseKeyboardShortcut", {
+            keyCode: key
+        });
+        svl.tracker.push("KeyboardShortcut_CloseContextMenu");
+    }
 
     
     /**

--- a/public/javascripts/SVLabel/src/SVLabel/keyboard/Keyboard.js
+++ b/public/javascripts/SVLabel/src/SVLabel/keyboard/Keyboard.js
@@ -233,18 +233,17 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
             if (!status.focusOnTextField) {
                 switch (e.keyCode) {
                     case util.misc.getLabelDescriptions('Occlusion')['shortcut']['keyNumber']:
-                        // "b" for a blocked view
+                        // "b" for a blocked view.
+                        // Context menu may be open for a different label.
+                        _closeContextMenu(e.keyCode);
                         ribbon.modeSwitch("Occlusion");
                         svl.tracker.push("KeyboardShortcut_ModeSwitch_Occlusion", {
                             keyCode: e.keyCode
                         });
                         break;
                     case util.misc.getLabelDescriptions('CurbRamp')['shortcut']['keyNumber']:
-                        if (contextMenu.isOpen()) {
-                            _closeContextMenu(e.keyCode);
-                        }
-
                         // "c" for CurbRamp. Switch the mode to the CurbRamp labeling mode.
+                        _closeContextMenu(e.keyCode);
                         if (!contextMenu.isOpen()) {
                             ribbon.modeSwitch("CurbRamp");
                             svl.tracker.push("KeyboardShortcut_ModeSwitch_CurbRamp", {
@@ -260,10 +259,8 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
                         });
                         break;
                     case util.misc.getLabelDescriptions('NoCurbRamp')['shortcut']['keyNumber']:
-                        if (contextMenu.isOpen()) {
-                            _closeContextMenu(e.keyCode);
-                        }
                         // "m" for MissingCurbRamp. Switch the mode to the MissingCurbRamp labeling mode.
+                        _closeContextMenu(e.keyCode);
                         if (!contextMenu.isOpen()) {
                             ribbon.modeSwitch("NoCurbRamp");
                             svl.tracker.push("KeyboardShortcut_ModeSwitch_NoCurbRamp", {
@@ -272,17 +269,15 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
                         }
                         break;
                     case util.misc.getLabelDescriptions('NoSidewalk')['shortcut']['keyNumber']:
+                        _closeContextMenu(e.keyCode);
                         ribbon.modeSwitch("NoSidewalk");
                         svl.tracker.push("KeyboardShortcut_ModeSwitch_NoSidewalk", {
                             keyCode: e.keyCode
                         });
                         break;
                     case util.misc.getLabelDescriptions('Obstacle')['shortcut']['keyNumber']:
-                        if (contextMenu.isOpen()) {
-                            _closeContextMenu(e.keyCode);
-                        }
-
                         // "o" for Obstacle
+                        _closeContextMenu(e.keyCode);
                         if (!contextMenu.isOpen()) {
                             ribbon.modeSwitch("Obstacle");
                             svl.tracker.push("KeyboardShortcut_ModeSwitch_Obstacle", {
@@ -291,10 +286,7 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
                         }
                         break;
                     case util.misc.getLabelDescriptions('SurfaceProblem')['shortcut']['keyNumber']:
-                        if (contextMenu.isOpen()) {
-                            _closeContextMenu(e.keyCode);
-                        }
-
+                        _closeContextMenu(e.keyCode);
                         if (!contextMenu.isOpen()) {
                             ribbon.modeSwitch("SurfaceProblem");
                             svl.tracker.push("KeyboardShortcut_ModeSwitch_SurfaceProblem", {
@@ -366,11 +358,13 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
     };
 
     function _closeContextMenu(key) {
-        contextMenu.hide();
-        svl.tracker.push("ContextMenu_CloseKeyboardShortcut", {
-            keyCode: key
-        });
-        svl.tracker.push("KeyboardShortcut_CloseContextMenu");
+        if (contextMenu.isOpen()) {
+            contextMenu.hide();
+            svl.tracker.push("ContextMenu_CloseKeyboardShortcut", {
+                keyCode: key
+            });
+            svl.tracker.push("KeyboardShortcut_CloseContextMenu");
+        }
     }
 
     

--- a/public/javascripts/SVLabel/src/SVLabel/keyboard/Keyboard.js
+++ b/public/javascripts/SVLabel/src/SVLabel/keyboard/Keyboard.js
@@ -232,7 +232,6 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
             status.shiftDown = e.shiftKey;
             if (!status.focusOnTextField) {
                 switch (e.keyCode) {
-
                     case util.misc.getLabelDescriptions('Occlusion')['shortcut']['keyNumber']:
                         // "b" for a blocked view
                         ribbon.modeSwitch("Occlusion");
@@ -242,10 +241,18 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
                         break;
                     case util.misc.getLabelDescriptions('CurbRamp')['shortcut']['keyNumber']:
                         // "c" for CurbRamp. Switch the mode to the CurbRamp labeling mode.
-                        ribbon.modeSwitch("CurbRamp");
-                        svl.tracker.push("KeyboardShortcut_ModeSwitch_CurbRamp", {
-                            keyCode: e.keyCode
-                        });
+                        if (!contextMenu.isOpen()) {
+                            ribbon.modeSwitch("CurbRamp");
+                            svl.tracker.push("KeyboardShortcut_ModeSwitch_CurbRamp", {
+                                keyCode: e.keyCode
+                            });
+                        } else {
+                            contextMenu.hide();
+                            svl.tracker.push("ContextMenu_CloseKeyboardShortcut", {
+                                keyCode: e.keyCode
+                            });
+                            svl.tracker.push("KeyboardShortcut_CloseContextMenu");
+                        }
                         break;
                     case util.misc.getLabelDescriptions('Walk')['shortcut']['keyNumber']:
                         // "e" for Explore. Switch the mode to Walk (camera) mode.
@@ -256,10 +263,18 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
                         break;
                     case util.misc.getLabelDescriptions('NoCurbRamp')['shortcut']['keyNumber']:
                         // "m" for MissingCurbRamp. Switch the mode to the MissingCurbRamp labeling mode.
-                        ribbon.modeSwitch("NoCurbRamp");
-                        svl.tracker.push("KeyboardShortcut_ModeSwitch_NoCurbRamp", {
-                            keyCode: e.keyCode
-                        });
+                        if (!contextMenu.isOpen()) {
+                            ribbon.modeSwitch("NoCurbRamp");
+                            svl.tracker.push("KeyboardShortcut_ModeSwitch_NoCurbRamp", {
+                                keyCode: e.keyCode
+                            });
+                        } else {
+                            contextMenu.hide();
+                            svl.tracker.push("ContextMenu_CloseKeyboardShortcut", {
+                                keyCode: e.keyCode
+                            });
+                            svl.tracker.push("KeyboardShortcut_CloseContextMenu");
+                        }
                         break;
                     case util.misc.getLabelDescriptions('NoSidewalk')['shortcut']['keyNumber']:
                         ribbon.modeSwitch("NoSidewalk");
@@ -269,16 +284,32 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
                         break;
                     case util.misc.getLabelDescriptions('Obstacle')['shortcut']['keyNumber']:
                         // "o" for Obstacle
-                        ribbon.modeSwitch("Obstacle");
-                        svl.tracker.push("KeyboardShortcut_ModeSwitch_Obstacle", {
-                            keyCode: e.keyCode
-                        });
+                        if (!contextMenu.isOpen()) {
+                            ribbon.modeSwitch("Obstacle");
+                            svl.tracker.push("KeyboardShortcut_ModeSwitch_Obstacle", {
+                                keyCode: e.keyCode
+                            });
+                        } else {
+                            contextMenu.hide();
+                            svl.tracker.push("ContextMenu_CloseKeyboardShortcut", {
+                                keyCode: e.keyCode
+                            });
+                            svl.tracker.push("KeyboardShortcut_CloseContextMenu");
+                        }
                         break;
                     case util.misc.getLabelDescriptions('SurfaceProblem')['shortcut']['keyNumber']:
-                        ribbon.modeSwitch("SurfaceProblem");
-                        svl.tracker.push("KeyboardShortcut_ModeSwitch_SurfaceProblem", {
-                            keyCode: e.keyCode
-                        });
+                        if (!contextMenu.isOpen()) {
+                            ribbon.modeSwitch("SurfaceProblem");
+                            svl.tracker.push("KeyboardShortcut_ModeSwitch_SurfaceProblem", {
+                                keyCode: e.keyCode
+                            });
+                        } else {
+                            contextMenu.hide();
+                            svl.tracker.push("ContextMenu_CloseKeyboardShortcut", {
+                                keyCode: e.keyCode
+                            });
+                            svl.tracker.push("KeyboardShortcut_CloseContextMenu");
+                        }
                         break;
                     case 16: //shift
                         // store the timestamp here so that we can check if the z-up event is in the buffer range
@@ -324,7 +355,6 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
                     break;
                 case 27:
                     // "Escape"
-
                     if (contextMenu.isOpen()) {
                         contextMenu.hide();
                         svl.tracker.push("KeyboardShortcut_CloseContextMenu");

--- a/public/javascripts/SVLabel/src/SVLabel/keyboard/Keyboard.js
+++ b/public/javascripts/SVLabel/src/SVLabel/keyboard/Keyboard.js
@@ -231,6 +231,7 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
              */
             status.shiftDown = e.shiftKey;
             if (!status.focusOnTextField) {
+                var label = contextMenu.isOpen() ? contextMenu.getTargetLabel() : undefined;
                 switch (e.keyCode) {
                     case util.misc.getLabelDescriptions('Occlusion')['shortcut']['keyNumber']:
                         // "b" for a blocked view
@@ -246,7 +247,7 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
                             svl.tracker.push("KeyboardShortcut_ModeSwitch_CurbRamp", {
                                 keyCode: e.keyCode
                             });
-                        } else {
+                        } else if (contextMenu.isOpen() && label.getProperty('labelType') === 'CurbRamp') {
                             contextMenu.hide();
                             svl.tracker.push("ContextMenu_CloseKeyboardShortcut", {
                                 keyCode: e.keyCode
@@ -268,7 +269,7 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
                             svl.tracker.push("KeyboardShortcut_ModeSwitch_NoCurbRamp", {
                                 keyCode: e.keyCode
                             });
-                        } else {
+                        } else if (contextMenu.isOpen() && label.getProperty('labelType') === 'NoCurbRamp') {
                             contextMenu.hide();
                             svl.tracker.push("ContextMenu_CloseKeyboardShortcut", {
                                 keyCode: e.keyCode
@@ -289,7 +290,7 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
                             svl.tracker.push("KeyboardShortcut_ModeSwitch_Obstacle", {
                                 keyCode: e.keyCode
                             });
-                        } else {
+                        } else if (contextMenu.isOpen() && label.getProperty('labelType') === 'Obstacle') {
                             contextMenu.hide();
                             svl.tracker.push("ContextMenu_CloseKeyboardShortcut", {
                                 keyCode: e.keyCode
@@ -303,7 +304,7 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
                             svl.tracker.push("KeyboardShortcut_ModeSwitch_SurfaceProblem", {
                                 keyCode: e.keyCode
                             });
-                        } else {
+                        } else if (contextMenu.isOpen() && label.getProperty('labelType') === 'SurfaceProblem') {
                             contextMenu.hide();
                             svl.tracker.push("ContextMenu_CloseKeyboardShortcut", {
                                 keyCode: e.keyCode


### PR DESCRIPTION
Resolves #1237.
* Allows keyboard shortcuts corresponding to the current label to close the context menu.
* Interactions for closing the context menu are logged by `ContextMenu_CloseKeyboardShortcut` and `KeyboardShortcut_CloseContextMenu`.

Testing instructions: 
* Try using keyboard shortcuts to close the context menu during a regular mission + the Onboarding tutorial, and make sure everything still works okay.
* Try closing out of the context menu with the wrong keyboard shortcut (try pressing `m` when the curb ramp context menu is open) - nothing should happen here!
* When you close the context menu using the keyboard shortcut, make sure that `ContextMenu_CloseKeyboardShortcut` and `KeyboardShortcut_CloseContextMenu` events show up in the `audit_task_interaction` table