### PR TITLE
653 adds version table

### DIFF
--- a/app/models/user/VersionTable.scala
+++ b/app/models/user/VersionTable.scala
@@ -1,0 +1,33 @@
+package models.user
+
+import java.sql.Timestamp
+
+import models.utils.MyPostgresDriver.simple._
+import play.api.Play.current
+
+case class Version(versionId: String, versionStartTime: Timestamp, description: Option[String])
+
+class VersionTable(tag: Tag) extends Table[Version](tag, Some("sidewalk"), "version") {
+  def versionId = column[String]("version_id", O.PrimaryKey)
+  def versionStartTime = column[Timestamp]("version_start_time", O.NotNull)
+  def description = column[Option[String]]("description")
+
+  def * = (versionId, versionStartTime, description) <> ((Version.apply _).tupled, Version.unapply)
+}
+
+/**
+  * Data access object for the amt_assignment table
+  */
+object VersionTable {
+  val db = play.api.db.slick.DB
+  val versions = TableQuery[VersionTable]
+
+  def save(v: Version): String = db.withSession { implicit session =>
+    (versions returning versions.map(_.versionId)) += v
+  }
+
+  def all: List[Version] = db.withSession { implicit session =>
+    versions.list
+  }
+}
+

--- a/conf/evolutions/default/20.sql
+++ b/conf/evolutions/default/20.sql
@@ -1,0 +1,11 @@
+# --- !Ups
+CREATE TABLE version
+(
+  version_id TEXT NOT NULL,
+  version_start_time TIMESTAMP NOT NULL,
+  description TEXT,
+  PRIMARY KEY (version_id)
+);
+
+# --- !Downs
+DROP TABLE version;


### PR DESCRIPTION
Resolves #653 

This PR adds a `version` table that has the following columns:
* `version_id` a string,
* `version_start_time` a timestamp, and
* `description` an optional string

Using this table, we will be able to keep track of the times when versions are released, which should help us to version-based queries in the future. For example, we may improve our logging in some future version, and we may need to calculate something for the admin page differently for the two different modes of logging (which has happened to us in the past). We can then get the timestamp of the change in version from this table, and use that timestamp in our queries where appropriate.

The way I see entries being added to this table is as follows: When we merge code into master, we just increment the version number in the `build.sbt`. In addition, we should now create a new evolutions file that adds an entry to the `version` table with that same version number used in the `build.sbt`, the timestamp column we can just use `now()` in SQL, and we can add a description if there is a need to do so.

I'll add this to the documentation for deploying new versions (which is currently being revised since we are switching to UW servers).

NOTE: This PR is really simple so I don't think it requires testing. But if anyone has comments on what I outlined above, please let me know!