### PR TITLE
Resolves #1334: Prevent enter key from interfering with label tag selection

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
@@ -244,6 +244,7 @@ function ContextMenu (uiContextMenu) {
                         label.setProperty('tagIds', labelTags);
                     }
                 })
+                e.target.blur();
             }
         });
     }


### PR DESCRIPTION
Resolves #1334 

- Prevented the enter key from interfering with label tag selection by blurring the tag element after it has been clicked. 
