### PR TITLE
Resolves #1300: Standardize Dates

### DIFF
--- a/app/controllers/ApplicationController.scala
+++ b/app/controllers/ApplicationController.scala
@@ -1,6 +1,7 @@
 package controllers
 
 import java.sql.Timestamp
+import java.time.Instant
 import javax.inject.Inject
 
 import com.mohiva.play.silhouette.api.{Environment, Silhouette}
@@ -9,9 +10,7 @@ import controllers.headers.ProvidesHeader
 import models.user._
 import models.amt.{AMTAssignment, AMTAssignmentTable}
 import models.daos.slick.DBTableDefinitions.{DBUser, UserTable}
-import org.joda.time.{DateTime, DateTimeZone}
 import play.api.mvc._
-
 
 import scala.concurrent.Future
 import scala.util.Random
@@ -28,8 +27,7 @@ class ApplicationController @Inject() (implicit val env: Environment[User, Sessi
     * @return
     */
   def index = UserAwareAction.async { implicit request =>
-    val now = new DateTime(DateTimeZone.UTC)
-    val timestamp: Timestamp = new Timestamp(now.getMillis)
+    val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
     val ipAddress: String = request.remoteAddress
     val qString = request.queryString.map { case (k, v) => k.mkString -> v.mkString }
 
@@ -126,8 +124,7 @@ class ApplicationController @Inject() (implicit val env: Environment[User, Sessi
   def about = UserAwareAction.async { implicit request =>
     request.identity match {
       case Some(user) =>
-        val now = new DateTime(DateTimeZone.UTC)
-        val timestamp: Timestamp = new Timestamp(now.getMillis)
+        val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
         val ipAddress: String = request.remoteAddress
 
         WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, "Visit_About", timestamp))
@@ -145,8 +142,7 @@ class ApplicationController @Inject() (implicit val env: Environment[User, Sessi
   def mobile = UserAwareAction.async { implicit request =>
     request.identity match {
       case Some(user) =>
-        val now = new DateTime(DateTimeZone.UTC)
-        val timestamp: Timestamp = new Timestamp(now.getMillis)
+        val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
         val ipAddress: String = request.remoteAddress
 
         WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, "Visit_MobileIndex", timestamp))
@@ -164,8 +160,7 @@ class ApplicationController @Inject() (implicit val env: Environment[User, Sessi
   def developer = UserAwareAction.async { implicit request =>
     request.identity match {
       case Some(user) =>
-        val now = new DateTime(DateTimeZone.UTC)
-        val timestamp: Timestamp = new Timestamp(now.getMillis)
+        val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
         val ipAddress: String = request.remoteAddress
 
         WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, "Visit_Developer", timestamp))
@@ -183,8 +178,7 @@ class ApplicationController @Inject() (implicit val env: Environment[User, Sessi
   def help = UserAwareAction.async { implicit request =>
     request.identity match {
       case Some(user) =>
-        val now = new DateTime(DateTimeZone.UTC)
-        val timestamp: Timestamp = new Timestamp(now.getMillis)
+        val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
         val ipAddress: String = request.remoteAddress
 
         WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, "Visit_Help", timestamp))
@@ -200,8 +194,7 @@ class ApplicationController @Inject() (implicit val env: Environment[User, Sessi
     */
 
   def labelingGuide = UserAwareAction.async { implicit request =>
-    val now = new DateTime(DateTimeZone.UTC)
-    val timestamp: Timestamp = new Timestamp(now.getMillis)
+    val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
     val ipAddress: String = request.remoteAddress
 
     request.identity match {
@@ -214,8 +207,7 @@ class ApplicationController @Inject() (implicit val env: Environment[User, Sessi
   }
 
   def labelingGuideCurbRamps = UserAwareAction.async { implicit request =>
-    val now = new DateTime(DateTimeZone.UTC)
-    val timestamp: Timestamp = new Timestamp(now.getMillis)
+    val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
     val ipAddress: String = request.remoteAddress
 
     request.identity match {
@@ -228,8 +220,7 @@ class ApplicationController @Inject() (implicit val env: Environment[User, Sessi
   }
 
   def labelingGuideSurfaceProblems = UserAwareAction.async { implicit request =>
-    val now = new DateTime(DateTimeZone.UTC)
-    val timestamp: Timestamp = new Timestamp(now.getMillis)
+    val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
     val ipAddress: String = request.remoteAddress
 
     request.identity match {
@@ -242,8 +233,7 @@ class ApplicationController @Inject() (implicit val env: Environment[User, Sessi
   }
 
   def labelingGuideObstacles = UserAwareAction.async { implicit request =>
-    val now = new DateTime(DateTimeZone.UTC)
-    val timestamp: Timestamp = new Timestamp(now.getMillis)
+    val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
     val ipAddress: String = request.remoteAddress
 
     request.identity match {
@@ -256,8 +246,7 @@ class ApplicationController @Inject() (implicit val env: Environment[User, Sessi
   }
 
   def labelingGuideNoSidewalk = UserAwareAction.async { implicit request =>
-    val now = new DateTime(DateTimeZone.UTC)
-    val timestamp: Timestamp = new Timestamp(now.getMillis)
+    val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
     val ipAddress: String = request.remoteAddress
 
     request.identity match {
@@ -270,8 +259,7 @@ class ApplicationController @Inject() (implicit val env: Environment[User, Sessi
   }
 
   def labelingGuideOcclusion = UserAwareAction.async { implicit request =>
-    val now = new DateTime(DateTimeZone.UTC)
-    val timestamp: Timestamp = new Timestamp(now.getMillis)
+    val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
     val ipAddress: String = request.remoteAddress
 
     request.identity match {
@@ -291,8 +279,7 @@ class ApplicationController @Inject() (implicit val env: Environment[User, Sessi
   def terms = UserAwareAction.async { implicit request =>
     request.identity match {
       case Some(user) =>
-        val now = new DateTime(DateTimeZone.UTC)
-        val timestamp: Timestamp = new Timestamp(now.getMillis)
+        val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
         val ipAddress: String = request.remoteAddress
 
         WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, "Visit_Terms", timestamp))
@@ -310,8 +297,7 @@ class ApplicationController @Inject() (implicit val env: Environment[User, Sessi
   def results = UserAwareAction.async { implicit request =>
     request.identity match {
       case Some(user) =>
-        val now = new DateTime(DateTimeZone.UTC)
-        val timestamp: Timestamp = new Timestamp(now.getMillis)
+        val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
         val ipAddress: String = request.remoteAddress
 
         WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, "Visit_Results", timestamp))
@@ -329,8 +315,7 @@ class ApplicationController @Inject() (implicit val env: Environment[User, Sessi
   def demo = UserAwareAction.async { implicit request =>
     request.identity match {
       case Some(user) =>
-        val now = new DateTime(DateTimeZone.UTC)
-        val timestamp: Timestamp = new Timestamp(now.getMillis)
+        val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
         val ipAddress: String = request.remoteAddress
 
         WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, "Visit_Map", timestamp))

--- a/app/controllers/AttributeController.scala
+++ b/app/controllers/AttributeController.scala
@@ -1,6 +1,7 @@
 package controllers
 
 import java.sql.Timestamp
+import java.time.Instant
 import javax.inject.Inject
 
 import com.mohiva.play.silhouette.api.{Environment, Silhouette}
@@ -18,7 +19,6 @@ import models.attribute._
 import models.label.LabelTypeTable
 import models.region.RegionTable
 import models.street.StreetEdgePriorityTable
-import org.joda.time.{DateTime, DateTimeZone}
 import play.api.Logger
 
 import collection.immutable.Seq
@@ -240,8 +240,7 @@ class AttributeController @Inject() (implicit val env: Environment[User, Session
 
           // Group the labels by the cluster they were put into.
           val groupedLabels: Map[Int, List[AttributeFormats.ClusteredLabelSubmission]] = labels.groupBy(_.clusterNum)
-          val now = new DateTime(DateTimeZone.UTC)
-          val timestamp: Timestamp = new Timestamp(now.getMillis)
+          val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
 
           // Add corresponding entry to the user_clustering_session table
           val userSessionId: Int = UserClusteringSessionTable.save(UserClusteringSession(0, userId, timestamp))
@@ -304,8 +303,7 @@ class AttributeController @Inject() (implicit val env: Environment[User, Session
 
           // Group the labels by the cluster they were put into.
           val groupedLabels: Map[Int, List[AttributeFormats.ClusteredLabelSubmission]] = labels.groupBy(_.clusterNum)
-          val now = new DateTime(DateTimeZone.UTC)
-          val timestamp: Timestamp = new Timestamp(now.getMillis)
+          val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
 
           // Add corresponding entry to the global_clustering_session table
           val globalSessionId: Int = GlobalClusteringSessionTable.save(GlobalClusteringSession(0, regionId, timestamp))

--- a/app/controllers/AuditController.scala
+++ b/app/controllers/AuditController.scala
@@ -1,6 +1,7 @@
 package controllers
 
 import java.sql.Timestamp
+import java.time.Instant
 import java.util.UUID
 
 import javax.inject.Inject
@@ -17,7 +18,6 @@ import models.mission.{Mission, MissionTable}
 import models.region._
 import models.street.{StreetEdgeIssue, StreetEdgeIssueTable}
 import models.user._
-import org.joda.time.{DateTime, DateTimeZone}
 import play.api.libs.json._
 import play.api.Logger
 import play.api.mvc._
@@ -37,8 +37,7 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
     * @return
     */
   def audit(nextRegion: Option[String], retakeTutorial: Option[Boolean]) = UserAwareAction.async { implicit request =>
-    val now = new DateTime(DateTimeZone.UTC)
-    val timestamp: Timestamp = new Timestamp(now.getMillis)
+    val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
     val ipAddress: String = request.remoteAddress
 
     val retakingTutorial: Boolean = retakeTutorial.isDefined && retakeTutorial.get
@@ -115,8 +114,7 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
     request.identity match {
       case Some(user) =>
         val userId: UUID = user.userId
-        val now = new DateTime(DateTimeZone.UTC)
-        val timestamp: Timestamp = new Timestamp(now.getMillis)
+        val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
         val ipAddress: String = request.remoteAddress
         val region: Option[NamedRegion] = RegionTable.selectANamedRegion(regionId)
         WebpageActivityTable.save(WebpageActivity(0, userId.toString, ipAddress, "Visit_Audit", timestamp))
@@ -201,8 +199,7 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
             user.get.userId.toString
         }
         val ipAddress: String = request.remoteAddress
-        val now = new DateTime(DateTimeZone.UTC)
-        val timestamp: Timestamp = new Timestamp(now.toInstant.getMillis)
+        val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
 
         val comment = AuditTaskComment(0, submission.auditTaskId, submission.missionId, submission.streetEdgeId, userId,
                                        ipAddress, submission.gsvPanoramaId, submission.heading, submission.pitch,
@@ -233,8 +230,7 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
             val user: Option[DBUser] = UserTable.find("anonymous")
             user.get.userId.toString
         }
-        val now = new DateTime(DateTimeZone.UTC)
-        val timestamp: Timestamp = new Timestamp(now.getMillis)
+        val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
         val ipAddress: String = request.remoteAddress
 
         val issue = StreetEdgeIssue(0, submission.streetEdgeId, "GSVNotAvailable", userId, ipAddress, timestamp)

--- a/app/controllers/CredentialsAuthController.scala
+++ b/app/controllers/CredentialsAuthController.scala
@@ -1,6 +1,7 @@
 package controllers
 
 import java.sql.Timestamp
+import java.time.Instant
 import javax.inject.Inject
 
 import com.mohiva.play.silhouette.api._
@@ -13,7 +14,6 @@ import formats.json.UserFormats._
 import forms.SignInForm
 import models.services.UserService
 import models.user._
-import org.joda.time.{DateTime, DateTimeZone}
 import play.api.Play.current
 import play.api.i18n.Messages
 import play.api.libs.concurrent.Execution.Implicits._
@@ -108,8 +108,7 @@ class CredentialsAuthController @Inject() (
     }
 
     // Add Timestamp
-    val now = new DateTime(DateTimeZone.UTC)
-    val timestamp: Timestamp = new Timestamp(now.getMillis)
+    val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
     WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, "SignIn", timestamp))
 
     // Logger.info(updatedAuthenticator.toString)

--- a/app/controllers/MissionController.scala
+++ b/app/controllers/MissionController.scala
@@ -2,10 +2,10 @@ package controllers
 
 import javax.inject.Inject
 import java.sql.Timestamp
+import java.time.Instant
 
 import com.mohiva.play.silhouette.api.{Environment, Silhouette}
 import com.mohiva.play.silhouette.impl.authenticators.SessionAuthenticator
-import org.joda.time.{DateTime, DateTimeZone}
 import controllers.headers.ProvidesHeader
 import formats.json.TaskSubmissionFormats.AMTAssignmentCompletionSubmission
 import models.mission.{Mission, MissionTable}
@@ -60,8 +60,7 @@ class MissionController @Inject() (implicit val env: Environment[User, SessionAu
 
     val submission = request.body.validate[AMTAssignmentCompletionSubmission]
 
-    val now = new DateTime(DateTimeZone.UTC)
-    val timestamp: Timestamp = new Timestamp(now.getMillis)
+    val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
 
     submission.fold(
       errors => {

--- a/app/controllers/ProjectSidewalkAPIController.scala
+++ b/app/controllers/ProjectSidewalkAPIController.scala
@@ -8,6 +8,7 @@ import com.vividsolutions.jts.geom._
 import com.vividsolutions.jts.index.kdtree.{KdNode, KdTree}
 import controllers.headers.ProvidesHeader
 import java.sql.Timestamp
+import java.time.Instant
 import javax.inject.Inject
 
 import math._
@@ -16,7 +17,6 @@ import models.daos.slick.DBTableDefinitions.{DBUser, UserTable}
 import models.label.{LabelLocation, LabelTable}
 import models.street.{StreetEdge, StreetEdgeTable}
 import models.user.{User, WebpageActivity, WebpageActivityTable}
-import org.joda.time.{DateTime, DateTimeZone}
 import play.api.cache.Cache
 import play.api.Play.current
 import play.api.libs.json._
@@ -35,8 +35,7 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
   def getAccessFeatures(lat1: Double, lng1: Double, lat2: Double, lng2: Double) = UserAwareAction.async { implicit request =>
     // Logging
     if (request.remoteAddress != "0:0:0:0:0:0:0:1") {
-      val now = new DateTime(DateTimeZone.UTC)
-      val timestamp: Timestamp = new Timestamp(now.getMillis)
+      val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
       val ipAddress: String = request.remoteAddress
       request.identity match {
         case Some(user) =>
@@ -95,8 +94,7 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
   def getAccessScoreNeighborhoods(lat1: Double, lng1: Double, lat2: Double, lng2: Double) = UserAwareAction.async { implicit request =>
     // Logging
     if (request.remoteAddress != "0:0:0:0:0:0:0:1") {
-      val now = new DateTime(DateTimeZone.UTC)
-      val timestamp: Timestamp = new Timestamp(now.getMillis)
+      val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
       val ipAddress: String = request.remoteAddress
       request.identity match {
         case Some(user) =>
@@ -203,8 +201,7 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
   def getAccessScoreStreets(lat1: Double, lng1: Double, lat2: Double, lng2: Double) = UserAwareAction.async { implicit request =>
     // Logging
     if (request.remoteAddress != "0:0:0:0:0:0:0:1") {
-      val now = new DateTime(DateTimeZone.UTC)
-      val timestamp: Timestamp = new Timestamp(now.getMillis)
+      val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
       val ipAddress: String = request.remoteAddress
       request.identity match {
         case Some(user) =>

--- a/app/controllers/SignUpController.scala
+++ b/app/controllers/SignUpController.scala
@@ -1,9 +1,9 @@
 package controllers
 
 import java.sql.Timestamp
+import java.time.Instant
 import java.util.UUID
 import javax.inject.Inject
-
 import com.mohiva.play.silhouette.api._
 import com.mohiva.play.silhouette.api.services.{AuthInfoService, AvatarService}
 import com.mohiva.play.silhouette.api.util.PasswordHasher
@@ -14,7 +14,6 @@ import formats.json.UserFormats._
 import forms.SignUpForm
 import models.services.UserService
 import models.user._
-import org.joda.time.{DateTime, DateTimeZone}
 import play.api.i18n.Messages
 import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.json.Json
@@ -52,8 +51,7 @@ class SignUpController @Inject() (
   def signUp(url: String) = UserAwareAction.async { implicit request =>
     val ipAddress: String = request.remoteAddress
     val anonymousUser: DBUser = UserTable.find("anonymous").get
-    val now = new DateTime(DateTimeZone.UTC)
-    val timestamp: Timestamp = new Timestamp(now.getMillis)
+    val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
     val oldUserId: String = request.identity.map(_.userId.toString).getOrElse(anonymousUser.userId.toString)
 
     SignUpForm.form.bindFromRequest.fold (
@@ -96,8 +94,7 @@ class SignUpController @Inject() (
                   UserCurrentRegionTable.assignEasyRegion(user.userId)
 
                   // Add Timestamp
-                  val now = new DateTime(DateTimeZone.UTC)
-                  val timestamp: Timestamp = new Timestamp(now.getMillis)
+                  val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
                   WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, "SignUp", timestamp))
                   WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, "SignIn", timestamp))
 
@@ -114,8 +111,7 @@ class SignUpController @Inject() (
   def postSignUp = UserAwareAction.async { implicit request =>
     val ipAddress: String = request.remoteAddress
     val anonymousUser: DBUser = UserTable.find("anonymous").get
-    val now = new DateTime(DateTimeZone.UTC)
-    val timestamp: Timestamp = new Timestamp(now.getMillis)
+    val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
     val oldUserId: String = request.identity.map(_.userId.toString).getOrElse(anonymousUser.userId.toString)
 
     SignUpForm.form.bindFromRequest.fold (
@@ -158,8 +154,7 @@ class SignUpController @Inject() (
                   UserCurrentRegionTable.assignEasyRegion(user.userId)
 
                   // Add Timestamp
-                  val now = new DateTime(DateTimeZone.UTC)
-                  val timestamp: Timestamp = new Timestamp(now.getMillis)
+                  val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
                   WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, "SignUp", timestamp))
                   WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, "SignIn", timestamp))
 
@@ -217,8 +212,7 @@ class SignUpController @Inject() (
           UserRoleTable.setRole(user.userId, "Anonymous")
 
           // Add Timestamp
-          val now = new DateTime(DateTimeZone.UTC)
-          val timestamp: Timestamp = new Timestamp(now.getMillis)
+          val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
           WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, "AnonAutoSignUp", timestamp))
 
           env.eventBus.publish(SignUpEvent(user, request, request2lang))
@@ -232,8 +226,7 @@ class SignUpController @Inject() (
   def turkerSignUp (hitId: String, workerId: String, assignmentId: String) = Action.async { implicit request =>
     val ipAddress: String = request.remoteAddress
     val anonymousUser: DBUser = UserTable.find("anonymous").get
-    val now = new DateTime(DateTimeZone.UTC)
-    val timestamp: Timestamp = new Timestamp(now.getMillis)
+    val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
     var activityLogText: String = "Referrer=mturk"+ "_workerId=" + workerId + "_assignmentId=" + assignmentId + "_hitId=" + hitId
 
     UserTable.find(workerId) match {
@@ -285,8 +278,7 @@ class SignUpController @Inject() (
           UserCurrentRegionTable.assignEasyRegion(user.userId)
 
           // Add Timestamp
-          val now = new DateTime(DateTimeZone.UTC)
-          val timestamp: Timestamp = new Timestamp(now.getMillis)
+          val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
           WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, activityLogText, timestamp))
           WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, "SignUp", timestamp))
           WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, "SignIn", timestamp))
@@ -314,8 +306,7 @@ class SignUpController @Inject() (
     }
 
     // Log the sign in.
-    val now = new DateTime(DateTimeZone.UTC)
-    val timestamp: Timestamp = new Timestamp(now.getMillis)
+    val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
     WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, "SignIn", timestamp))
 
     // Logger.info(updatedAuthenticator.toString)

--- a/app/controllers/SurveyController.scala
+++ b/app/controllers/SurveyController.scala
@@ -1,9 +1,9 @@
 package controllers
 
 import java.sql.Timestamp
+import java.time.Instant
 import java.util.UUID
 import javax.inject.Inject
-
 import com.mohiva.play.silhouette.api.{Environment, Silhouette}
 import com.mohiva.play.silhouette.impl.authenticators.SessionAuthenticator
 import controllers.headers.ProvidesHeader
@@ -12,7 +12,6 @@ import models.daos.slick.DBTableDefinitions.{DBUser, UserTable}
 import models.survey._
 import models.user._
 import models.mission.MissionTable
-import org.joda.time.{DateTime, DateTimeZone}
 import play.api.Logger
 import play.api.libs.json._
 import play.api.mvc._
@@ -45,8 +44,7 @@ class SurveyController @Inject() (implicit val env: Environment[User, SessionAut
             user.get.userId.toString
         }
 
-        val now = new DateTime(DateTimeZone.UTC)
-        val timestamp: Timestamp = new Timestamp(now.toInstant.getMillis)
+        val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
         val numMissionsCompleted: Int = MissionTable.countCompletedMissionsByUserId(UUID.fromString(userId), includeOnboarding = false)
 
         val allSurveyQuestions = SurveyQuestionTable.listAll

--- a/app/controllers/TaskController.scala
+++ b/app/controllers/TaskController.scala
@@ -1,6 +1,7 @@
 package controllers
 
 import java.sql.Timestamp
+import java.time.Instant
 import java.util.UUID
 
 import javax.inject.Inject
@@ -18,7 +19,6 @@ import models.mission.{Mission, MissionTable}
 import models.region._
 import models.street.StreetEdgePriorityTable
 import models.user.{User, UserCurrentRegionTable}
-import org.joda.time.{DateTime, DateTimeZone}
 import play.api.Logger
 import play.api.libs.json._
 import play.api.mvc._
@@ -69,14 +69,12 @@ class TaskController @Inject() (implicit val env: Environment[User, SessionAuthe
     if (auditTask.auditTaskId.isDefined) {
       // Update the existing audit task row
       val id = auditTask.auditTaskId.get
-      val now = new DateTime(DateTimeZone.UTC)
-      val timestamp: Timestamp = new Timestamp(now.getMillis)
+      val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
       AuditTaskTable.updateTaskEnd(id, timestamp)
       id
     } else {
       // Insert audit task
-      val now = new DateTime(DateTimeZone.UTC)
-      val timestamp: Timestamp = new Timestamp(now.getMillis)
+      val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
       val auditTaskObj = user match {
         case Some(user) => AuditTask(0, amtAssignmentId, user.userId.toString, auditTask.streetEdgeId,
           Timestamp.valueOf(auditTask.taskStart), Some(timestamp), completed=false)

--- a/app/controllers/UserController.scala
+++ b/app/controllers/UserController.scala
@@ -1,8 +1,8 @@
 package controllers
 
 import java.sql.Timestamp
+import java.time.Instant
 import javax.inject.Inject
-
 import com.mohiva.play.silhouette.api.{Environment, LogoutEvent, Silhouette}
 import com.mohiva.play.silhouette.impl.authenticators.SessionAuthenticator
 import controllers.headers.ProvidesHeader

--- a/app/controllers/UserController.scala
+++ b/app/controllers/UserController.scala
@@ -12,7 +12,6 @@ import models.user._
 import models.daos.slick.DBTableDefinitions.{DBUser, UserTable}
 import play.api.mvc.BodyParsers
 import play.api.libs.json._
-import org.joda.time.{DateTime, DateTimeZone}
 import scala.concurrent.Future
 
 /**
@@ -81,8 +80,7 @@ class UserController @Inject() (implicit val env: Environment[User, SessionAuthe
         Future.successful(BadRequest(Json.obj("status" -> "Error", "message" -> JsError.toFlatJson(errors))))
       },
       submission => {
-        val now = new DateTime(DateTimeZone.UTC)
-        val timestamp: Timestamp = new Timestamp(now.getMillis)
+        val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
         val ipAddress: String = request.remoteAddress
         request.identity match {
           case Some(user) =>

--- a/app/models/audit/AuditTaskTable.scala
+++ b/app/models/audit/AuditTaskTable.scala
@@ -2,7 +2,8 @@ package models.audit
 
 import com.vividsolutions.jts.geom.{Coordinate, LineString}
 import java.sql.Timestamp
-import java.util.{Calendar, TimeZone, UUID}
+import java.time.Instant
+import java.util.UUID
 
 import models.street._
 import models.utils.MyPostgresDriver
@@ -410,7 +411,7 @@ object AuditTaskTable {
     * @return
     */
   def selectANewTask(streetEdgeId: Int, user: Option[UUID]): NewTask = db.withSession { implicit session =>
-    val timestamp: Timestamp = new Timestamp(Calendar.getInstance(TimeZone.getTimeZone("UTC")).getTime.getTime)
+    val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
 
     // Set completed to true if the user has already audited this street.
     val userCompleted: Boolean = if (user.isDefined) userHasAuditedStreet(streetEdgeId, user.get) else false
@@ -433,7 +434,7 @@ object AuditTaskTable {
    * @return
    */
   def selectANewTaskInARegion(regionId: Int, user: UUID): Option[NewTask] = db.withSession { implicit session =>
-    val timestamp: Timestamp = new Timestamp(Calendar.getInstance(TimeZone.getTimeZone("UTC")).getTime.getTime)
+    val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
 
     // Get the streets that the user has not already completed.
     val edgesInRegion = streetEdges.filter(_.streetEdgeId inSet streetEdgeIdsNotAuditedByUser(user, regionId))
@@ -456,7 +457,7 @@ object AuditTaskTable {
     * @return
     */
   def selectTasksInARegion(regionId: Int): List[NewTask] = db.withSession { implicit session =>
-    val timestamp: Timestamp = new Timestamp(Calendar.getInstance(TimeZone.getTimeZone("UTC")).getTime.getTime)
+    val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
 
     val tasks = for {
       ser <- nonDeletedStreetEdgeRegions if ser.regionId === regionId
@@ -476,7 +477,7 @@ object AuditTaskTable {
     * @return
     */
   def selectTasksInARegion(regionId: Int, user: UUID): List[NewTask] = db.withSession { implicit session =>
-    val timestamp: Timestamp = new Timestamp(Calendar.getInstance(TimeZone.getTimeZone("UTC")).getTime.getTime)
+    val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
 
     val edgesInRegion = nonDeletedStreetEdgeRegions.filter(_.regionId === regionId)
 

--- a/test/models/audit/AuditTaskInteractionSpec.scala
+++ b/test/models/audit/AuditTaskInteractionSpec.scala
@@ -1,7 +1,8 @@
 package models.audit
 
 import java.sql.Timestamp
-import java.util.{Calendar, Date, UUID}
+import java.time.Instant
+import java.util.UUID
 
 import com.vividsolutions.jts.geom.{Coordinate, GeometryFactory, LineString, Polygon}
 import models.daos.slick.DBTableDefinitions.{DBUser, UserTable}
@@ -9,7 +10,6 @@ import models.label.{Label, LabelTable, LabelType, LabelTypeTable}
 import models.region.{Region, RegionTable, RegionType, RegionTypeTable}
 import models.street.{StreetEdge, StreetEdgeTable}
 import models.utils.MyPostgresDriver.simple._
-import org.joda.time.{DateTime, DateTimeZone}
 import org.specs2.mutable._
 import play.api.db.slick.DB
 import play.api.test._
@@ -37,7 +37,7 @@ class AuditTaskInteractionSpec extends Specification  {
         ddl.create
 
         try {
-          lazy val timestamp: Timestamp = new Timestamp(new DateTime(DateTimeZone.UTC).getMillis)
+          lazy val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
           lazy val auditTaskInteraction = AuditTaskInteraction(1, 1, "TestAction", Some("TestPanoramaId"),
             Some(0.0f), Some(0.0f), Some(0.0f), Some(0.0f), Some(1), Some("TestNote"), Some(1), timestamp)
 
@@ -80,7 +80,7 @@ class AuditTaskInteractionSpec extends Specification  {
 
         try {
           // Populate data
-          lazy val timestamp: Timestamp = new Timestamp(new DateTime(DateTimeZone.UTC).getMillis)
+          lazy val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
           lazy val auditTaskInteraction = AuditTaskInteraction(1, 1, "TestAction", Some("TestPanoramaId"),
             Some(0.0f), Some(0.0f), Some(0.0f), Some(0.0f), Some(1), Some("TestNote"), Some(1), timestamp)
 
@@ -150,7 +150,7 @@ class AuditTaskInteractionSpec extends Specification  {
 
         try {
           // Populate data
-          lazy val timestamp: Timestamp = new Timestamp(new DateTime(DateTimeZone.UTC).getMillis)
+          lazy val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
 
           lazy val gf: GeometryFactory = new GeometryFactory()
           lazy val coordinates_1: Array[Coordinate] = Array(new Coordinate(0, 0), new Coordinate(1, 0))

--- a/test/models/labels/LabelTableSpec.scala
+++ b/test/models/labels/LabelTableSpec.scala
@@ -2,7 +2,8 @@ package models.labels
 
 
 import java.sql.Timestamp
-import java.util.{Calendar, Date, UUID}
+import java.time.Instant
+import java.util.UUID
 
 import com.vividsolutions.jts.geom.{Coordinate, GeometryFactory}
 import controllers.helper.LabelControllerHelper
@@ -12,7 +13,6 @@ import models.label.{Label, LabelTable, LabelType, LabelTypeTable}
 import models.region.{Region, RegionTable, RegionType, RegionTypeTable}
 import models.street.{StreetEdge, StreetEdgeTable}
 import models.utils.MyPostgresDriver.simple._
-import org.joda.time.{DateTime, DateTimeZone}
 import org.specs2.mutable._
 import play.api.db.slick.DB
 import play.api.Logger._
@@ -52,7 +52,7 @@ class LabelTableSpec extends Specification  {
 
         try {
           // Prepare data to populate the database
-          lazy val timestamp: Timestamp = new Timestamp(new DateTime(DateTimeZone.UTC).getMillis)
+          lazy val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
 
           lazy val gf: GeometryFactory = new GeometryFactory()
           lazy val coordinates_1: Array[Coordinate] = Array(new Coordinate(0, 0), new Coordinate(0.5, 0))
@@ -157,7 +157,7 @@ class LabelTableSpec extends Specification  {
 
         try {
           // Prepare data to populate the database
-          lazy val timestamp: Timestamp = new Timestamp(new DateTime(DateTimeZone.UTC).getMillis)
+          lazy val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
 
           lazy val gf: GeometryFactory = new GeometryFactory()
           lazy val coordinates_1: Array[Coordinate] = Array(new Coordinate(0, 0), new Coordinate(0.5, 0))


### PR DESCRIPTION
Resolves #1300 

I replaced any usage of the `Timestamp` class to use `Instant.now.toEpochMilli` instead of whatever alternative it had used before, as per the instructions in #1300. Most of the previous code was using the joda library, so I removed those imports as well. 

To test:
- Make sure that timestamps are working the same as before. Everything should compile and function identically
- Any Timestamps initialized as `lazy val`s I kept as lazy values, make sure this keeps the intended functionality