### PR TITLE
Added 99% round down check to avoid unwanted display of mission 100% complete

### DIFF
--- a/public/javascripts/SVLabel/spec/SVLabel/status/StatusFieldMissionProgressBar-spec.js
+++ b/public/javascripts/SVLabel/spec/SVLabel/status/StatusFieldMissionProgressBar-spec.js
@@ -77,6 +77,10 @@ describe("StatusFieldMissionProgressBar module", function () {
 
             statusFieldMissionProgressBar.setCompletionRate(0.51432423);
             expect($completionRate.text()).toBe("51% complete");
+
+            statusFieldMissionProgressBar.setCompletionRate(0.99632423);
+            expect($completionRate.text()).toBe("99% complete");
+
         });
     });
 

--- a/public/javascripts/SVLabel/src/SVLabel/status/StatusFieldMissionProgressBar.js
+++ b/public/javascripts/SVLabel/src/SVLabel/status/StatusFieldMissionProgressBar.js
@@ -32,6 +32,7 @@ function StatusFieldMissionProgressBar (modalModel, statusModel, uiStatusField) 
     this.setCompletionRate = function (completionRate) {
         completionRate *= 100;
         if (completionRate > 100) completionRate = 100;
+        if (completionRate < 100 && completionRate >= 99.5) completionRate = 99;
         completionRate = completionRate.toFixed(0, 10);
         completionRate = completionRate + "% complete";
         $completionRate.html(completionRate);

--- a/public/javascripts/SVLabel/src/SVLabel/status/StatusFieldMissionProgressBar.js
+++ b/public/javascripts/SVLabel/src/SVLabel/status/StatusFieldMissionProgressBar.js
@@ -31,8 +31,11 @@ function StatusFieldMissionProgressBar (modalModel, statusModel, uiStatusField) 
 
     this.setCompletionRate = function (completionRate) {
         completionRate *= 100;
+        // if check exists since the user could audit more than the
+        // expected amount for the mission (e.g. the user audits 503 ft
+        // even though the mission is to audit 500 ft)
         if (completionRate > 100) completionRate = 100;
-        if (completionRate < 100 && completionRate >= 99.5) completionRate = 99;
+        else if (completionRate < 100 && completionRate >= 99.5) completionRate = 99;
         completionRate = completionRate.toFixed(0, 10);
         completionRate = completionRate + "% complete";
         $completionRate.html(completionRate);


### PR DESCRIPTION
Resolves #510 

Added an if check so if the percentage of the mission complete is less than 100% and greater than or equal to 99.5%, the percentage complete gets rounded down to 99%. Also, added a unit test to check that this code change works properly.

To test:

- Run the StatusFieldMissionProgressBar-spec tests to ensure the newly added test properly rounds down the percentage