### PR TITLE
1281 next city make tagging more noticeable

### DIFF
--- a/app/views/audit.scala.html
+++ b/app/views/audit.scala.html
@@ -389,6 +389,7 @@
                                 <input type="text" class="form-control" placeholder="Description" id="context-menu-problem-description-text-box">
                             </div>
                             <div id="context-menu-tag-holder">
+                                <div class="add-tags-label">Add Tags:</div>
                                 <button class="context-menu-tag" name='tag' id="0"></button>
                                 <button class="context-menu-tag" name='tag' id="1"></button>
                                 <button class="context-menu-tag" name='tag' id="2"></button>

--- a/public/javascripts/SVLabel/css/svl-context-menu.css
+++ b/public/javascripts/SVLabel/css/svl-context-menu.css
@@ -169,7 +169,7 @@
     display: inline-block;
     position: inherit;
     margin: 0px 0px 0px 0px;
-    padding: 2px 6px 2px 6px;
+    padding: 2px 3px 2px 3px;
     border-radius: 5px;
     border: 1px solid rgb(200, 200, 200);
     font-size: 10px;

--- a/public/javascripts/SVLabel/css/svl-context-menu.css
+++ b/public/javascripts/SVLabel/css/svl-context-menu.css
@@ -159,11 +159,17 @@
     margin: 5px;
 }
 
-#context-menu-tag-holder button {
-    position: inherit;
+.add-tags-label {
     display: inline-block;
-    margin: 0px 2px 2px 0px;
-    padding: 2px 10px 2px 10px;
+    position: inherit;
+    font-size: 10px;
+}
+
+#context-menu-tag-holder button {
+    display: inline-block;
+    position: inherit;
+    margin: 0px 0px 0px 0px;
+    padding: 2px 6px 2px 6px;
     border-radius: 5px;
     border: 1px solid rgb(200, 200, 200);
     font-size: 10px;


### PR DESCRIPTION
Partially resolves #1281.

This adds an "Add Tags:" label to the tags, to make them more noticeable as the user is completing the mission. I had to change the padding on each of the tags to make it fit for all features. 

To test, launch a mission and validate that the "Add Tags" label is showing up correctly.

Here is how it looks for each accessibility feature:
![image](https://user-images.githubusercontent.com/16949591/50726817-80d46f00-1112-11e9-808e-0c5b2cce8b5b.png)
![image](https://user-images.githubusercontent.com/16949591/50726820-8b8f0400-1112-11e9-9d8d-37e2f0a6c36c.png)
![image](https://user-images.githubusercontent.com/16949591/50726826-98135c80-1112-11e9-9fc3-6ccfdf98fd93.png)
![image](https://user-images.githubusercontent.com/16949591/50726833-a5304b80-1112-11e9-8913-49a12db5b76b.png)
![image](https://user-images.githubusercontent.com/16949591/50726839-b24d3a80-1112-11e9-8f0d-bc8662a557f2.png)
