### PR TITLE
Resolves #678, #999: removes +/- (plus and minus) zoom keyboard shortcuts

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/keyboard/Keyboard.js
+++ b/public/javascripts/SVLabel/src/SVLabel/keyboard/Keyboard.js
@@ -122,12 +122,7 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
      * @private
      */
     this._documentKeyDown = function (e) {
-        // The callback method that is triggered with a keyUp event.
-        //equal button || - button
-        if (e.keyCode == 187 || e.keyCode == 189) {
-            svl.contextMenu.hide();
-            return;
-        } else if (!status.focusOnTextField && !status.disableKeyboard) {
+        if (!status.focusOnTextField && !status.disableKeyboard) {
             //only set shift if the event was made after the keyup.
             if (e.timeStamp > lastShiftKeyUpTimestamp) {
                 status.shiftDown = e.shiftKey;

--- a/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
+++ b/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
@@ -219,6 +219,7 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
             svl.panorama.set('linksControl', true);
             svl.panorama.set('navigationControl', false);
             svl.panorama.set('panControl', false);
+            svl.panorama.set('scrollwheel', false);
             svl.panorama.set('zoomControl', false);
             svl.panorama.set('keyboardShortcuts', true);
         }


### PR DESCRIPTION
Resolves #678, #999. 
* Panorama no longer zooms in when the +/- keys are pressed
* ContextMenu no longer closes when the +/- keys are pressed

I added the following line to `MapService.js` which disables +/- keyboard shortcuts.
```
svl.panorama.set('scrollwheel', false);
```