### PR TITLE
433 fix timestamps in local timezone

### DIFF
--- a/conf/evolutions/default/26.sql
+++ b/conf/evolutions/default/26.sql
@@ -1,0 +1,9 @@
+# --- !Ups
+ALTER TABLE label
+    ALTER COLUMN time_created TYPE TIMESTAMPTZ USING time_created AT TIME ZONE 'UTC',
+    ALTER COLUMN time_created SET DEFAULT now();
+
+# --- !Downs
+ALTER TABLE label
+    ALTER COLUMN time_created TYPE TIMESTAMP,
+    ALTER COLUMN time_created DROP DEFAULT;

--- a/conf/evolutions/default/26.sql
+++ b/conf/evolutions/default/26.sql
@@ -3,7 +3,59 @@ ALTER TABLE label
     ALTER COLUMN time_created TYPE TIMESTAMPTZ USING time_created AT TIME ZONE 'PST',
     ALTER COLUMN time_created SET DEFAULT now();
 
+ALTER TABLE user_survey_text_submission
+    ALTER COLUMN time_submitted TYPE TIMESTAMPTZ USING time_submitted AT TIME ZONE 'PST',
+    ALTER COLUMN time_submitted SET DEFAULT now();
+
+ALTER TABLE user_survey_option_submission
+    ALTER COLUMN time_submitted TYPE TIMESTAMPTZ USING time_submitted AT TIME ZONE 'PST',
+    ALTER COLUMN time_submitted SET DEFAULT now();
+
+ALTER TABLE version
+    ALTER COLUMN version_start_time TYPE TIMESTAMPTZ USING version_start_time AT TIME ZONE 'PST',
+    ALTER COLUMN version_start_time SET DEFAULT now();
+
+ALTER TABLE user_clustering_session
+    ALTER COLUMN time_created TYPE TIMESTAMPTZ USING time_created AT TIME ZONE 'PST',
+    ALTER COLUMN time_created SET DEFAULT now();
+
+ALTER TABLE global_clustering_session
+    ALTER COLUMN time_created TYPE TIMESTAMPTZ USING time_created AT TIME ZONE 'PST',
+    ALTER COLUMN time_created SET DEFAULT now();
+
+ALTER TABLE mission
+    ALTER COLUMN mission_start TYPE TIMESTAMPTZ USING mission_start AT TIME ZONE 'PST',
+    ALTER COLUMN mission_start SET DEFAULT now(),
+    ALTER COLUMN mission_end TYPE TIMESTAMPTZ USING mission_end AT TIME ZONE 'PST',
+    ALTER COLUMN mission_end SET DEFAULT now();
+
 # --- !Downs
+ALTER TABLE mission
+    ALTER COLUMN mission_start TYPE TIMESTAMP,
+    ALTER COLUMN mission_start DROP DEFAULT,
+    ALTER COLUMN mission_end TYPE TIMESTAMP,
+    ALTER COLUMN mission_end DROP DEFAULT;
+
+ALTER TABLE global_clustering_session
+    ALTER COLUMN time_created TYPE TIMESTAMP,
+    ALTER COLUMN time_created SET DEFAULT current_timestamp;
+
+ALTER TABLE user_clustering_session
+    ALTER COLUMN time_created TYPE TIMESTAMP,
+    ALTER COLUMN time_created SET DEFAULT current_timestamp;
+
+ALTER TABLE version
+    ALTER COLUMN version_start_time TYPE TIMESTAMP,
+    ALTER COLUMN version_start_time DROP DEFAULT;
+
+ALTER TABLE user_survey_option_submission
+    ALTER COLUMN time_submitted TYPE TIMESTAMP,
+    ALTER COLUMN time_submitted DROP DEFAULT;
+
+ALTER TABLE user_survey_text_submission
+    ALTER COLUMN time_submitted TYPE TIMESTAMP,
+    ALTER COLUMN time_submitted DROP DEFAULT;
+
 ALTER TABLE label
     ALTER COLUMN time_created TYPE TIMESTAMP,
     ALTER COLUMN time_created DROP DEFAULT;

--- a/conf/evolutions/default/26.sql
+++ b/conf/evolutions/default/26.sql
@@ -1,6 +1,6 @@
 # --- !Ups
 ALTER TABLE label
-    ALTER COLUMN time_created TYPE TIMESTAMPTZ USING time_created AT TIME ZONE 'UTC',
+    ALTER COLUMN time_created TYPE TIMESTAMPTZ USING time_created AT TIME ZONE 'PST',
     ALTER COLUMN time_created SET DEFAULT now();
 
 # --- !Downs


### PR DESCRIPTION
Fixes #433 

This PR adds an evolution file that modifies all the timestamp columns that were added over the past few years (mostly by me) from timestamps without time zones to timestamps _with_ time zones.

To test:
1. Check out the `develop` branch and audit a bit.
1. Take a look at the entries in the `label`, `user_survey_text_submission`, `user_survey_option_submission`, `version`, `user_clustering_session`, `global_clustering_session`, and `mission` tables (don't worry if there are none for any given table). Take a look at their timestamp columns. 
1. Check out the `433-fix-timestamps-in-local-timezone` branch and run it.
1. Check that the timestamp columns in those tables jumped forward 8 hours from PST to UTC
1. Check out the `develop` branch again and run it.
1. Verify that the timestamps went back 8 hours to PST.