### PR TITLE
Resolves #1276: Adds keyboard shortcuts for selecting label tags

### DIFF
--- a/public/javascripts/SVLabel/css/svl-context-menu.css
+++ b/public/javascripts/SVLabel/css/svl-context-menu.css
@@ -175,3 +175,7 @@
     font-size: 10px;
     outline: none;
 }
+
+tag-underline {
+    text-decoration: underline;
+}

--- a/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
@@ -262,6 +262,7 @@ function ContextMenu (uiContextMenu) {
             }
         });
     }
+
     /**
      *
      * @param e

--- a/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
@@ -64,60 +64,6 @@ function ContextMenu (uiContextMenu) {
             }//ctrl+A while context menu open
         }//windows
 
-        // Add shortcuts for tag selection
-        if (isOpen() && document.activeElement.nodeName != 'INPUT') {
-            var labelType = getTargetLabel().getProperty('labelType');
-            if (labelType == 'CurbRamp') { // Curb Ramp
-                if (down[65]) { // 'a' for 'narrow'
-                    document.getElementsByClassName('context-menu-tag')[0].click();
-                } else if (down[80]) { // 'p' for 'points into traffic'
-                    document.getElementsByClassName('context-menu-tag')[1].click();
-                } else if (down[70]) { // 'f' for 'missing friction strip'
-                    document.getElementsByClassName('context-menu-tag')[2].click();
-                } else if (down[84]) { // 't' for steep
-                    document.getElementsByClassName('context-menu-tag')[3].click();
-                }
-            } else if (labelType == 'NoCurbRamp') { // Missing Curb Ramp
-                if (down[65]) { // 'a' for 'alternate route present'
-                    document.getElementsByClassName('context-menu-tag')[0].click();
-                } else if (down[76]) { // 'l' for 'no alternate route'
-                    document.getElementsByClassName('context-menu-tag')[1].click();
-                } else if (down[85]) { // 'u' for 'unclear if needed'
-                    document.getElementsByClassName('context-menu-tag')[2].click();
-                }
-            } else if (labelType == 'Obstacle') { // Obstacle in Path
-                if (down[82]) { // 'r' for 'trash can'
-                    document.getElementsByClassName('context-menu-tag')[0].click();
-                } else if (down[70]) { // 'f' for 'fire hydrant'
-                    document.getElementsByClassName('context-menu-tag')[1].click();
-                } else if (down[80]) { // 'p' for 'pole'
-                    document.getElementsByClassName('context-menu-tag')[2].click();
-                } else if (down[84]) { // 't' for 'tree'
-                    document.getElementsByClassName('context-menu-tag')[3].click();
-                } else if (down[86]) { // 'v' for vegetation
-                    document.getElementsByClassName('context-menu-tag')[4].click();
-                }
-            } else if (labelType == 'SurfaceProblem') { // Surface Problem
-                if (down[80]) { // 'p' for 'bumpy'
-                    document.getElementsByClassName('context-menu-tag')[0].click();
-                } else if (down[85]) { // 'u' for 'uneven'
-                    document.getElementsByClassName('context-menu-tag')[1].click();
-                } else if (down[82]) { // 'r' for 'cracks'
-                    document.getElementsByClassName('context-menu-tag')[2].click();
-                } else if (down[71]) { // 'g' for 'grass'
-                    document.getElementsByClassName('context-menu-tag')[3].click();
-                } else if (down[65]) { // 'a' for 'narrow sidewalk'
-                    document.getElementsByClassName('context-menu-tag')[4].click();
-                }
-            } else if (labelType == 'Other') { // No Sidewalk
-                if (down[73]) { // 'i' for 'missing crosswalk'
-                    document.getElementsByClassName('context-menu-tag')[0].click();
-                } else if (down[65]) { // 'a' for 'no bus stop access'
-                    document.getElementsByClassName('context-menu-tag')[1].click();
-                }
-            }
-        }
-
         // Log last keypresses
         if (e.type == 'keydown') {
             lastKeyPressed = e.keyCode;

--- a/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
@@ -65,7 +65,7 @@ function ContextMenu (uiContextMenu) {
         }//windows
 
         // Add shortcuts for tag selection
-        if (isOpen()) {
+        if (isOpen() && document.activeElement.nodeName != 'INPUT') {
             var labelType = getTargetLabel().getProperty('labelType');
             if (labelType == 'CurbRamp') { // Curb Ramp
                 if (down[65]) { // 'a' for 'narrow'

--- a/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
@@ -91,9 +91,9 @@ function ContextMenu (uiContextMenu) {
     }
 
     /**
-     * Returns a status
-     * @param key
-     * @returns {null}
+     * Returns a the value in status given a key
+     * @param key The key to find in status
+     * @returns The value in status if it exists. If it doesn't, returns null
      */
     function getStatus (key) {
         return (key in status) ? status[key] : null;

--- a/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
@@ -66,10 +66,55 @@ function ContextMenu (uiContextMenu) {
 
         // Add shortcuts for tag selection
         if (isOpen()) {
-            var label = getTargetLabel();
-            if (down[65]) {
-                //
-                document.getElementsByClassName('context-menu-tag')[0].click();
+            var labelType = getTargetLabel().getProperty('labelType');
+            if (labelType == 'CurbRamp') { // Curb Ramp
+                if (down[65]) { // 'a' for 'narrow'
+                    document.getElementsByClassName('context-menu-tag')[0].click();
+                } else if (down[80]) { // 'p' for 'points into traffic'
+                    document.getElementsByClassName('context-menu-tag')[1].click();
+                } else if (down[70]) { // 'f' for 'missing friction strip'
+                    document.getElementsByClassName('context-menu-tag')[2].click();
+                } else if (down[84]) { // 't' for steep
+                    document.getElementsByClassName('context-menu-tag')[3].click();
+                }
+            } else if (labelType == 'NoCurbRamp') { // Missing Curb Ramp
+                if (down[65]) { // 'a' for 'alternate route present'
+                    document.getElementsByClassName('context-menu-tag')[0].click();
+                } else if (down[76]) { // 'l' for 'no alternate route'
+                    document.getElementsByClassName('context-menu-tag')[1].click();
+                } else if (down[85]) { // 'u' for 'unclear if needed'
+                    document.getElementsByClassName('context-menu-tag')[2].click();
+                }
+            } else if (labelType == 'Obstacle') { // Obstacle in Path
+                if (down[82]) { // 'r' for 'trash can'
+                    document.getElementsByClassName('context-menu-tag')[0].click();
+                } else if (down[70]) { // 'f' for 'fire hydrant'
+                    document.getElementsByClassName('context-menu-tag')[1].click();
+                } else if (down[80]) { // 'p' for 'pole'
+                    document.getElementsByClassName('context-menu-tag')[2].click();
+                } else if (down[84]) { // 't' for 'tree'
+                    document.getElementsByClassName('context-menu-tag')[3].click();
+                } else if (down[86]) { // 'v' for vegetation
+                    document.getElementsByClassName('context-menu-tag')[4].click();
+                }
+            } else if (labelType == 'SurfaceProblem') { // Surface Problem
+                if (down[80]) { // 'p' for 'bumpy'
+                    document.getElementsByClassName('context-menu-tag')[0].click();
+                } else if (down[85]) { // 'u' for 'uneven'
+                    document.getElementsByClassName('context-menu-tag')[1].click();
+                } else if (down[82]) { // 'r' for 'cracks'
+                    document.getElementsByClassName('context-menu-tag')[2].click();
+                } else if (down[71]) { // 'g' for 'grass'
+                    document.getElementsByClassName('context-menu-tag')[3].click();
+                } else if (down[65]) { // 'a' for 'narrow sidewalk'
+                    document.getElementsByClassName('context-menu-tag')[4].click();
+                }
+            } else if (labelType == 'Other') { // No Sidewalk
+                if (down[73]) { // 'i' for 'missing crosswalk'
+                    document.getElementsByClassName('context-menu-tag')[0].click();
+                } else if (down[65]) { // 'a' for 'no bus stop access'
+                    document.getElementsByClassName('context-menu-tag')[1].click();
+                }
             }
         }
 

--- a/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
@@ -392,10 +392,17 @@ function ContextMenu (uiContextMenu) {
                 labelTags.forEach(function (tag) {
                     if (tag.label_type === label.getProperty('labelType')) {
 
+                        // Remove all leftover tags from last labeling. Warning to future devs: will remove any other classes you add to the tags
+                        $("body").find("button[id=" + count + "]").attr('class', 'context-menu-tag');
+
+                        // Add tag name as a class so that finding the element is easier laster. For example, will add "CurbRamp-tag" as a class
+                        var newClass = util.misc.getLabelDescriptions(tag.label_type)['tagInfo'][tag.tag]['id'] + "-tag";
+                        $("body").find("button[id=" + count + "]").addClass(newClass);
+
                         // Set tag texts to new underlined version as defined in the util label description map
                         var tagText = util.misc.getLabelDescriptions(tag.label_type)['tagInfo'][tag.tag]['text'];
-
                         $("body").find("button[id=" + count + "]").html(tagText);
+
                         $("body").find("button[id=" + count + "]").css({
                             visibility: 'inherit',
                             position: 'inherit'

--- a/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
@@ -45,29 +45,41 @@ function ContextMenu (uiContextMenu) {
     var down = {};
     var lastKeyPressed = 0;
     var lastKeyCmd = false;
-    onkeydown = onkeyup = function(e){
+    onkeydown = onkeyup = function (e) {
         e = e || event; // to deal with IE
         var isMac = navigator.platform.indexOf('Mac') > -1;
         down[e.keyCode] = e.type == 'keydown';
-        if (isMac){
-            if (lastKeyCmd && down[91] && isOpen() && down[65]){
+
+        // Code to highlight description box on command+A or ctrl+A (depending on OS)
+        if (isMac) {
+            if (lastKeyCmd && down[91] && isOpen() && down[65]) {
                 $descriptionTextBox.select();
                 down[65] = false; //reset A key
             }//A key, menu shown
 
         }//mac
-        else{
-            if (lastKeyPressed == 17 && isOpen() && down[65]){
+        else {
+            if (lastKeyPressed == 17 && isOpen() && down[65]) {
                 $descriptionTextBox.select();
             }//ctrl+A while context menu open
         }//windows
-        if (e.type == 'keydown'){
+
+        // Add shortcuts for tag selection
+        if (isOpen()) {
+            if (down[65]) {
+
+            }
+        }
+
+        // Log last keypresses
+        if (e.type == 'keydown') {
             lastKeyPressed = e.keyCode;
             lastKeyCmd = e.metaKey;
-        }else{
+        } else {
             lastKeyPressed = 0;
             lastKeyCmd = false;
         }
+
     }; //handles both key down and key up events
 
     function checkRadioButton (value) {
@@ -248,6 +260,29 @@ function ContextMenu (uiContextMenu) {
             }
         });
     }
+
+    /**
+     * Toggles selection of a tag. Will record the ID, as well as update the tag color.
+     * @param tagValue The String text content of the tag to be toggled.
+     */
+    self.toggleTag = function (tagValue) {
+        self.labelTags.forEach(function (tag) {
+            if (tag.tag === tagValue) {
+                if (!labelTags.includes(tag.tag_id)) {
+                    labelTags.push(tag.tag_id);
+                    svl.tracker.push('ContextMenu_TagAdded',
+                        { tagId: tag.tag_id, tagName: tag.tag });
+                } else {
+                    var index = labelTags.indexOf(tag.tag_id);
+                    labelTags.splice(index, 1);
+                    svl.tracker.push('ContextMenu_TagRemoved',
+                        { tagId: tag.tag_id, tagName: tag.tag });
+                }
+                _toggleTagColor(labelTags, tag.tag_id, e.target);
+                label.setProperty('tagIds', labelTags);
+            }
+        })
+    };
 
     /**
      *

--- a/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
@@ -392,68 +392,8 @@ function ContextMenu (uiContextMenu) {
                 labelTags.forEach(function (tag) {
                     if (tag.label_type === label.getProperty('labelType')) {
 
-                        var tagText = tag.tag;
-
-                        // Set underlines on tags to represent hotkeys
-                        switch (tagText) {
-                            case 'narrow':
-                                tagText = 'n<tag-underline>a</tag-underline>rrow';
-                                break;
-                            case 'points into traffic':
-                                tagText = '<tag-underline>p</tag-underline>oints into traffic';
-                                break;
-                            case 'missing friction strip':
-                                tagText = 'missing <tag-underline>f</tag-underline>riction strip';
-                                break;
-                            case 'steep':
-                                tagText = 's<tag-underline>t</tag-underline>eep';
-                                break;
-                            case 'alternate route present':
-                                tagText = '<tag-underline>a</tag-underline>lternate route present';
-                                break;
-                            case 'no alternate route':
-                                tagText = 'no a<tag-underline>l</tag-underline>ternate route';
-                                break;
-                            case 'unclear if needed':
-                                tagText = '<tag-underline>u</tag-underline>nclear if needed';
-                                break;
-                            case 'trash can':
-                                tagText = 't<tag-underline>r</tag-underline>ash can';
-                                break;
-                            case 'fire hydrant':
-                                tagText = '<tag-underline>f</tag-underline>ire hydrant';
-                                break;
-                            case 'pole':
-                                tagText = '<tag-underline>p</tag-underline>ole';
-                                break;
-                            case 'tree':
-                                tagText = '<tag-underline>t</tag-underline>ree';
-                                break;
-                            case 'vegetation':
-                                tagText = '<tag-underline>v</tag-underline>egetation';
-                                break;
-                            case 'bumpy':
-                                tagText = 'bum<tag-underline>p</tag-underline>y';
-                                break;
-                            case 'uneven':
-                                tagText = '<tag-underline>u</tag-underline>neven';
-                                break;
-                            case 'cracks':
-                                tagText = 'c<tag-underline>r</tag-underline>acks';
-                                break;
-                            case 'grass':
-                                tagText = '<tag-underline>g</tag-underline>rass';
-                                break;
-                            case 'narrow sidewalk':
-                                tagText = 'n<tag-underline>a</tag-underline>rrow sidewalk';
-                                break;
-                            case 'missing crosswalk':
-                                tagText = 'm<tag-underline>i</tag-underline>ssing crosswalk';
-                                break;
-                            case 'no bus stop access':
-                                tagText = 'no bus stop <tag-underline>a</tag-underline>ccess'
-                                break;
-                        }
+                        // Set tag texts to new underlined version as defined in the util label description map
+                        var tagText = util.misc.getLabelDescriptions(tag.label_type)['tagInfo'][tag.tag]['text'];
 
                         $("body").find("button[id=" + count + "]").html(tagText);
                         $("body").find("button[id=" + count + "]").css({

--- a/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
@@ -235,13 +235,13 @@ function ContextMenu (uiContextMenu) {
      */
     function _handleTagClick () {
         var label = getTargetLabel();
+        var labelTags = label.getProperty('tagIds');
 
         $("body").unbind('click').on('click', 'button', function (e) {
             if (e.target.name == 'tag') {
                 var tagValue = e.target.textContent || e.target.innerText;
 
                 // Adds or removes tag from the label's current list of tags.
-                var labelTags = label.getProperty('tagIds');
                 self.labelTags.forEach(function (tag) {
                     if (tag.tag === tagValue) {
                         if (!labelTags.includes(tag.tag_id)) {

--- a/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
@@ -233,56 +233,43 @@ function ContextMenu (uiContextMenu) {
      */
     function _handleTagClick () {
         var label = getTargetLabel();
-        var labelTags = label.getProperty('tagIds');
 
-        $("body").unbind('click').on('click', 'button', function(e){
+        $("body").unbind('click').on('click', 'button', function (e) {
             if (e.target.name == 'tag') {
                 var tagValue = e.target.textContent || e.target.innerText;
 
                 // Adds or removes tag from the label's current list of tags.
-                self.labelTags.forEach(function (tag) {
-                    if (tag.tag === tagValue) {
-                        if (!labelTags.includes(tag.tag_id)) {
-                            labelTags.push(tag.tag_id);
-                            svl.tracker.push('ContextMenu_TagAdded',
-                                { tagId: tag.tag_id, tagName: tag.tag });
-                        } else {
-                            var index = labelTags.indexOf(tag.tag_id);
-                            labelTags.splice(index, 1);
-                            svl.tracker.push('ContextMenu_TagRemoved',
-                                { tagId: tag.tag_id, tagName: tag.tag });
-                        }
-                        _toggleTagColor(labelTags, tag.tag_id, e.target);
-                        label.setProperty('tagIds', labelTags);
-                    }
-                })
-                e.target.blur();
+                toggleTag(e, label, tagValue);
             }
         });
     }
 
     /**
-     * Toggles selection of a tag. Will record the ID, as well as update the tag color.
+     * Toggles selection of a tag. Adds or removes tag from the label's current list of tags, as well as update the tag color.
+     * @param e The tag element
+     * @param label The label that we are toggling the tag for
      * @param tagValue The String text content of the tag to be toggled.
      */
-    self.toggleTag = function (tagValue) {
+    function toggleTag (e, label, tagValue) {
+        var labelTags = label.getProperty('tagIds');
         self.labelTags.forEach(function (tag) {
             if (tag.tag === tagValue) {
                 if (!labelTags.includes(tag.tag_id)) {
                     labelTags.push(tag.tag_id);
                     svl.tracker.push('ContextMenu_TagAdded',
-                        { tagId: tag.tag_id, tagName: tag.tag });
+                        {tagId: tag.tag_id, tagName: tag.tag});
                 } else {
                     var index = labelTags.indexOf(tag.tag_id);
                     labelTags.splice(index, 1);
                     svl.tracker.push('ContextMenu_TagRemoved',
-                        { tagId: tag.tag_id, tagName: tag.tag });
+                        {tagId: tag.tag_id, tagName: tag.tag});
                 }
                 _toggleTagColor(labelTags, tag.tag_id, e.target);
                 label.setProperty('tagIds', labelTags);
             }
-        })
-    };
+        });
+        e.target.blur();
+    }
 
     /**
      *

--- a/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
@@ -418,7 +418,71 @@ function ContextMenu (uiContextMenu) {
                 // Go through each label tag, modify each button to display tag.
                 labelTags.forEach(function (tag) {
                     if (tag.label_type === label.getProperty('labelType')) {
-                        $("body").find("button[id=" + count + "]").html(tag.tag);
+
+                        var tagText = tag.tag;
+
+                        // Set underlines on tags to represent hotkeys
+                        switch (tagText) {
+                            case 'narrow':
+                                tagText = 'n<tag-underline>a</tag-underline>rrow';
+                                break;
+                            case 'points into traffic':
+                                tagText = '<tag-underline>p</tag-underline>oints into traffic';
+                                break;
+                            case 'missing friction strip':
+                                tagText = 'missing <tag-underline>f</tag-underline>riction strip';
+                                break;
+                            case 'steep':
+                                tagText = 's<tag-underline>t</tag-underline>eep';
+                                break;
+                            case 'alternate route present':
+                                tagText = '<tag-underline>a</tag-underline>lternate route present';
+                                break;
+                            case 'no alternate route':
+                                tagText = 'no a<tag-underline>l</tag-underline>ternate route';
+                                break;
+                            case 'unclear if needed':
+                                tagText = '<tag-underline>u</tag-underline>nclear if needed';
+                                break;
+                            case 'trash can':
+                                tagText = 't<tag-underline>r</tag-underline>ash can';
+                                break;
+                            case 'fire hydrant':
+                                tagText = '<tag-underline>f</tag-underline>ire hydrant';
+                                break;
+                            case 'pole':
+                                tagText = '<tag-underline>p</tag-underline>ole';
+                                break;
+                            case 'tree':
+                                tagText = '<tag-underline>t</tag-underline>ree';
+                                break;
+                            case 'vegetation':
+                                tagText = '<tag-underline>v</tag-underline>egetation';
+                                break;
+                            case 'bumpy':
+                                tagText = 'bum<tag-underline>p</tag-underline>y';
+                                break;
+                            case 'uneven':
+                                tagText = '<tag-underline>u</tag-underline>neven';
+                                break;
+                            case 'cracks':
+                                tagText = 'c<tag-underline>r</tag-underline>acks';
+                                break;
+                            case 'grass':
+                                tagText = '<tag-underline>g</tag-underline>rass';
+                                break;
+                            case 'narrow sidewalk':
+                                tagText = 'n<tag-underline>a</tag-underline>rrow sidewalk';
+                                break;
+                            case 'missing crosswalk':
+                                tagText = 'm<tag-underline>i</tag-underline>ssing crosswalk';
+                                break;
+                            case 'no bus stop access':
+                                tagText = 'no bus stop <tag-underline>a</tag-underline>ccess'
+                                break;
+                        }
+
+                        $("body").find("button[id=" + count + "]").html(tagText);
                         $("body").find("button[id=" + count + "]").css({
                             visibility: 'inherit',
                             position: 'inherit'

--- a/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
@@ -395,7 +395,7 @@ function ContextMenu (uiContextMenu) {
                         // Remove all leftover tags from last labeling. Warning to future devs: will remove any other classes you add to the tags
                         $("body").find("button[id=" + count + "]").attr('class', 'context-menu-tag');
 
-                        // Add tag name as a class so that finding the element is easier laster. For example, will add "CurbRamp-tag" as a class
+                        // Add tag name as a class so that finding the element is easier laster. For example, will add "narrowSidewalk-tag" as a class
                         var newClass = util.misc.getLabelDescriptions(tag.label_type)['tagInfo'][tag.tag]['id'] + "-tag";
                         $("body").find("button[id=" + count + "]").addClass(newClass);
 

--- a/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
@@ -66,8 +66,10 @@ function ContextMenu (uiContextMenu) {
 
         // Add shortcuts for tag selection
         if (isOpen()) {
+            var label = getTargetLabel();
             if (down[65]) {
-
+                //
+                document.getElementsByClassName('context-menu-tag')[0].click();
             }
         }
 
@@ -239,38 +241,27 @@ function ContextMenu (uiContextMenu) {
                 var tagValue = e.target.textContent || e.target.innerText;
 
                 // Adds or removes tag from the label's current list of tags.
-                toggleTag(e, label, tagValue);
+                var labelTags = label.getProperty('tagIds');
+                self.labelTags.forEach(function (tag) {
+                    if (tag.tag === tagValue) {
+                        if (!labelTags.includes(tag.tag_id)) {
+                            labelTags.push(tag.tag_id);
+                            svl.tracker.push('ContextMenu_TagAdded',
+                                {tagId: tag.tag_id, tagName: tag.tag});
+                        } else {
+                            var index = labelTags.indexOf(tag.tag_id);
+                            labelTags.splice(index, 1);
+                            svl.tracker.push('ContextMenu_TagRemoved',
+                                {tagId: tag.tag_id, tagName: tag.tag});
+                        }
+                        _toggleTagColor(labelTags, tag.tag_id, e.target);
+                        label.setProperty('tagIds', labelTags);
+                    }
+                });
+                e.target.blur();
             }
         });
     }
-
-    /**
-     * Toggles selection of a tag. Adds or removes tag from the label's current list of tags, as well as update the tag color.
-     * @param e The tag element
-     * @param label The label that we are toggling the tag for
-     * @param tagValue The String text content of the tag to be toggled.
-     */
-    function toggleTag (e, label, tagValue) {
-        var labelTags = label.getProperty('tagIds');
-        self.labelTags.forEach(function (tag) {
-            if (tag.tag === tagValue) {
-                if (!labelTags.includes(tag.tag_id)) {
-                    labelTags.push(tag.tag_id);
-                    svl.tracker.push('ContextMenu_TagAdded',
-                        {tagId: tag.tag_id, tagName: tag.tag});
-                } else {
-                    var index = labelTags.indexOf(tag.tag_id);
-                    labelTags.splice(index, 1);
-                    svl.tracker.push('ContextMenu_TagRemoved',
-                        {tagId: tag.tag_id, tagName: tag.tag});
-                }
-                _toggleTagColor(labelTags, tag.tag_id, e.target);
-                label.setProperty('tagIds', labelTags);
-            }
-        });
-        e.target.blur();
-    }
-
     /**
      *
      * @param e

--- a/public/javascripts/SVLabel/src/SVLabel/keyboard/Keyboard.js
+++ b/public/javascripts/SVLabel/src/SVLabel/keyboard/Keyboard.js
@@ -326,73 +326,73 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
                 if (labelType == 'CurbRamp') { // Curb Ramp
                     switch (e.keyCode) {
                         case util.misc.getLabelDescriptions('CurbRamp')['tagInfo']['narrow']['keyNumber']: // 'a' for 'narrow'
-                            document.getElementsByClassName('context-menu-tag')[0].click();
+                            $("button:contains(narrow)").click();
                             break;
                         case util.misc.getLabelDescriptions('CurbRamp')['tagInfo']['points into traffic']['keyNumber']: // 'p' for 'points into traffic'
-                            document.getElementsByClassName('context-menu-tag')[1].click();
+                            $("button:contains(points into traffic)").click();
                             break;
                         case util.misc.getLabelDescriptions('CurbRamp')['tagInfo']['missing friction strip']['keyNumber']: // 'f' for 'missing friction strip'
-                            document.getElementsByClassName('context-menu-tag')[2].click();
+                            $("button:contains(missing friction strip)").click();
                             break;
                         case util.misc.getLabelDescriptions('CurbRamp')['tagInfo']['steep']['keyNumber']: // 't' for 'steep'
-                            document.getElementsByClassName('context-menu-tag')[3].click();
+                            $("button:contains(steep)").click();
                             break;
                     }
                 } else if (labelType == 'NoCurbRamp') { // Missing Curb Ramp
                     switch (e.keyCode) {
                         case util.misc.getLabelDescriptions('NoCurbRamp')['tagInfo']['alternate route present']['keyNumber']: // 'a' for 'alternate route present'
-                            document.getElementsByClassName('context-menu-tag')[0].click();
+                            $("button:contains(alternate route present)").click();
                             break;
                         case util.misc.getLabelDescriptions('NoCurbRamp')['tagInfo']['no alternate route']['keyNumber']: // 'l' for 'no alternate route'
-                            document.getElementsByClassName('context-menu-tag')[1].click();
+                            $("button:contains(no alternate route)").click();
                             break;
                         case util.misc.getLabelDescriptions('NoCurbRamp')['tagInfo']['unclear if needed']['keyNumber']: // 'u' for 'unclear if needed'
-                            document.getElementsByClassName('context-menu-tag')[2].click();
+                            $("button:contains(unclear if needed)").click();
                             break;
                     }
                 } else if (labelType == 'Obstacle') { // Obstacle in Path
                     switch (e.keyCode) {
                         case util.misc.getLabelDescriptions('Obstacle')['tagInfo']['trash can']['keyNumber']: // 'r' for 'trash can'
-                            document.getElementsByClassName('context-menu-tag')[0].click();
+                            $("button:contains(trash can)").click();
                             break;
                         case util.misc.getLabelDescriptions('Obstacle')['tagInfo']['fire hydrant']['keyNumber']: // 'f' for 'fire hydrant'
-                            document.getElementsByClassName('context-menu-tag')[1].click();
+                            $("button:contains(fire hydrant)").click();
                             break;
                         case util.misc.getLabelDescriptions('Obstacle')['tagInfo']['pole']['keyNumber']: // 'p' for 'pole'
-                            document.getElementsByClassName('context-menu-tag')[2].click();
+                            $("button:contains(pole)").click();
                             break;
                         case util.misc.getLabelDescriptions('Obstacle')['tagInfo']['tree']['keyNumber']: // 't' for 'tree'
-                            document.getElementsByClassName('context-menu-tag')[3].click();
+                            $("button:contains(tree)").click();
                             break;
                         case util.misc.getLabelDescriptions('Obstacle')['tagInfo']['vegetation']['keyNumber']: // 'v' for 'vegetation'
-                            document.getElementsByClassName('context-menu-tag')[4].click();
+                            $("button:contains(vegetation)").click();
                             break;
                     }
                 } else if (labelType == 'SurfaceProblem') { // Surface Problem
                     switch (e.keyCode) {
                         case util.misc.getLabelDescriptions('SurfaceProblem')['tagInfo']['bumpy']['keyNumber']: // 'p' for 'bumpy'
-                            document.getElementsByClassName('context-menu-tag')[0].click();
+                            $("button:contains(bumpy)").click();
                             break;
                         case util.misc.getLabelDescriptions('SurfaceProblem')['tagInfo']['uneven']['keyNumber']: // 'u' for 'uneven'
-                            document.getElementsByClassName('context-menu-tag')[1].click();
+                            $("button:contains(uneven)").click();
                             break;
                         case util.misc.getLabelDescriptions('SurfaceProblem')['tagInfo']['cracks']['keyNumber']: // 'r' for 'cracks'
-                            document.getElementsByClassName('context-menu-tag')[2].click();
+                            $("button:contains(cracks)").click();
                             break;
                         case util.misc.getLabelDescriptions('SurfaceProblem')['tagInfo']['grass']['keyNumber']: // 'g' for 'grass'
-                            document.getElementsByClassName('context-menu-tag')[3].click();
+                            $("button:contains(grass)").click();
                             break;
                         case util.misc.getLabelDescriptions('SurfaceProblem')['tagInfo']['narrow sidewalk']['keyNumber']  : // 'a' for 'narrow sidewalk'
-                            document.getElementsByClassName('context-menu-tag')[4].click();
+                            $("button:contains(narrow sidewalk)").click();
                             break;
                     }
                 } else if (labelType == 'Other') { // No Sidewalk
                     switch (e.keyCode) {
                         case util.misc.getLabelDescriptions('Other')['tagInfo']['missing crosswalk']['keyNumber']: // 'i' for 'missing crosswalk'
-                            document.getElementsByClassName('context-menu-tag')[0].click();
+                            $("button:contains(missing crosswalk)").click();
                             break;
                         case util.misc.getLabelDescriptions('Other')['tagInfo']['no bus stop access']['keyNumber']: // 'a' for 'no bus stop access'
-                            document.getElementsByClassName('context-menu-tag')[1].click();
+                            $("button:contains(no bus stop access)").click();
                             break;
                     }
                 }

--- a/public/javascripts/SVLabel/src/SVLabel/keyboard/Keyboard.js
+++ b/public/javascripts/SVLabel/src/SVLabel/keyboard/Keyboard.js
@@ -321,76 +321,77 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
                         }
                 }
 
+                // Hotkeys for tag selection
                 var labelType = contextMenu.getTargetLabel().getProperty('labelType');
                 if (labelType == 'CurbRamp') { // Curb Ramp
                     switch (e.keyCode) {
-                        case 65: // 'a' for 'narrow'
+                        case util.misc.getLabelDescriptions('CurbRamp')['tagInfo']['narrow']['keyNumber']: // 'a' for 'narrow'
                             document.getElementsByClassName('context-menu-tag')[0].click();
                             break;
-                        case 80: // 'p' for 'points into traffic'
+                        case util.misc.getLabelDescriptions('CurbRamp')['tagInfo']['points into traffic']['keyNumber']: // 'p' for 'points into traffic'
                             document.getElementsByClassName('context-menu-tag')[1].click();
                             break;
-                        case 70: // 'f' for 'missing friction strip'
+                        case util.misc.getLabelDescriptions('CurbRamp')['tagInfo']['missing friction strip']['keyNumber']: // 'f' for 'missing friction strip'
                             document.getElementsByClassName('context-menu-tag')[2].click();
                             break;
-                        case 84: // 't' for steep
+                        case util.misc.getLabelDescriptions('CurbRamp')['tagInfo']['steep']['keyNumber']: // 't' for 'steep'
                             document.getElementsByClassName('context-menu-tag')[3].click();
                             break;
                     }
                 } else if (labelType == 'NoCurbRamp') { // Missing Curb Ramp
                     switch (e.keyCode) {
-                        case 65: // 'a' for 'alternate route present'
+                        case util.misc.getLabelDescriptions('NoCurbRamp')['tagInfo']['alternate route present']['keyNumber']: // 'a' for 'alternate route present'
                             document.getElementsByClassName('context-menu-tag')[0].click();
                             break;
-                        case 76: // 'l' for 'no alternate route'
+                        case util.misc.getLabelDescriptions('NoCurbRamp')['tagInfo']['no alternate route']['keyNumber']: // 'l' for 'no alternate route'
                             document.getElementsByClassName('context-menu-tag')[1].click();
                             break;
-                        case 85: // 'u' for 'unclear if needed'
+                        case util.misc.getLabelDescriptions('NoCurbRamp')['tagInfo']['unclear if needed']['keyNumber']: // 'u' for 'unclear if needed'
                             document.getElementsByClassName('context-menu-tag')[2].click();
                             break;
                     }
                 } else if (labelType == 'Obstacle') { // Obstacle in Path
                     switch (e.keyCode) {
-                        case 82: // 'r' for 'trash can'
+                        case util.misc.getLabelDescriptions('Obstacle')['tagInfo']['trash can']['keyNumber']: // 'r' for 'trash can'
                             document.getElementsByClassName('context-menu-tag')[0].click();
                             break;
-                        case 70: // 'f' for 'fire hydrant'
+                        case util.misc.getLabelDescriptions('Obstacle')['tagInfo']['fire hydrant']['keyNumber']: // 'f' for 'fire hydrant'
                             document.getElementsByClassName('context-menu-tag')[1].click();
                             break;
-                        case 80: // 'p' for 'pole'
+                        case util.misc.getLabelDescriptions('Obstacle')['tagInfo']['pole']['keyNumber']: // 'p' for 'pole'
                             document.getElementsByClassName('context-menu-tag')[2].click();
                             break;
-                        case 84: // 't' for 'tree'
+                        case util.misc.getLabelDescriptions('Obstacle')['tagInfo']['tree']['keyNumber']: // 't' for 'tree'
                             document.getElementsByClassName('context-menu-tag')[3].click();
                             break;
-                        case 86: // 'v' for vegetation
+                        case util.misc.getLabelDescriptions('Obstacle')['tagInfo']['vegetation']['keyNumber']: // 'v' for 'vegetation'
                             document.getElementsByClassName('context-menu-tag')[4].click();
                             break;
                     }
                 } else if (labelType == 'SurfaceProblem') { // Surface Problem
                     switch (e.keyCode) {
-                        case 80 :// 'p' for 'bumpy'
+                        case util.misc.getLabelDescriptions('SurfaceProblem')['tagInfo']['bumpy']['keyNumber']: // 'p' for 'bumpy'
                             document.getElementsByClassName('context-menu-tag')[0].click();
                             break;
-                        case 85:  // 'u' for 'uneven'
+                        case util.misc.getLabelDescriptions('SurfaceProblem')['tagInfo']['uneven']['keyNumber']: // 'u' for 'uneven'
                             document.getElementsByClassName('context-menu-tag')[1].click();
                             break;
-                        case 82: // 'r' for 'cracks'
+                        case util.misc.getLabelDescriptions('SurfaceProblem')['tagInfo']['cracks']['keyNumber']: // 'r' for 'cracks'
                             document.getElementsByClassName('context-menu-tag')[2].click();
                             break;
-                        case 71 : // 'g' for 'grass'
+                        case util.misc.getLabelDescriptions('SurfaceProblem')['tagInfo']['grass']['keyNumber']: // 'g' for 'grass'
                             document.getElementsByClassName('context-menu-tag')[3].click();
                             break;
-                        case 65 : // 'a' for 'narrow sidewalk'
+                        case util.misc.getLabelDescriptions('SurfaceProblem')['tagInfo']['narrow sidewalk']['keyNumber']  : // 'a' for 'narrow sidewalk'
                             document.getElementsByClassName('context-menu-tag')[4].click();
                             break;
                     }
                 } else if (labelType == 'Other') { // No Sidewalk
                     switch (e.keyCode) {
-                        case 73: // 'i' for 'missing crosswalk'
+                        case util.misc.getLabelDescriptions('Other')['tagInfo']['missing crosswalk']['keyNumber']: // 'i' for 'missing crosswalk'
                             document.getElementsByClassName('context-menu-tag')[0].click();
                             break;
-                        case 65: // 'a' for 'no bus stop access'
+                        case util.misc.getLabelDescriptions('Other')['tagInfo']['no bus stop access']['keyNumber']: // 'a' for 'no bus stop access'
                             document.getElementsByClassName('context-menu-tag')[1].click();
                             break;
                     }

--- a/public/javascripts/SVLabel/src/SVLabel/keyboard/Keyboard.js
+++ b/public/javascripts/SVLabel/src/SVLabel/keyboard/Keyboard.js
@@ -326,73 +326,73 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
                 if (labelType == 'CurbRamp') { // Curb Ramp
                     switch (e.keyCode) {
                         case util.misc.getLabelDescriptions('CurbRamp')['tagInfo']['narrow']['keyNumber']: // 'a' for 'narrow'
-                            document.getElementsByClassName('context-menu-tag')[0].click();
+                            document.getElementsByClassName('narrow-tag')[0].click();
                             break;
                         case util.misc.getLabelDescriptions('CurbRamp')['tagInfo']['points into traffic']['keyNumber']: // 'p' for 'points into traffic'
-                            document.getElementsByClassName('context-menu-tag')[1].click();
+                            document.getElementsByClassName('pointIntoTraffic-tag')[0].click();
                             break;
                         case util.misc.getLabelDescriptions('CurbRamp')['tagInfo']['missing friction strip']['keyNumber']: // 'f' for 'missing friction strip'
-                            document.getElementsByClassName('context-menu-tag')[2].click();
+                            document.getElementsByClassName('missingFrictionStrip-tag')[0].click();
                             break;
                         case util.misc.getLabelDescriptions('CurbRamp')['tagInfo']['steep']['keyNumber']: // 't' for 'steep'
-                            document.getElementsByClassName('context-menu-tag')[3].click();
+                            document.getElementsByClassName('steep-tag')[0].click();
                             break;
                     }
                 } else if (labelType == 'NoCurbRamp') { // Missing Curb Ramp
                     switch (e.keyCode) {
                         case util.misc.getLabelDescriptions('NoCurbRamp')['tagInfo']['alternate route present']['keyNumber']: // 'a' for 'alternate route present'
-                            document.getElementsByClassName('context-menu-tag')[0].click();
+                            document.getElementsByClassName('alternateRoutePresent-tag')[0].click();
                             break;
                         case util.misc.getLabelDescriptions('NoCurbRamp')['tagInfo']['no alternate route']['keyNumber']: // 'l' for 'no alternate route'
-                            document.getElementsByClassName('context-menu-tag')[1].click();
+                            document.getElementsByClassName('noAlternateRoute-tag')[0].click();
                             break;
                         case util.misc.getLabelDescriptions('NoCurbRamp')['tagInfo']['unclear if needed']['keyNumber']: // 'u' for 'unclear if needed'
-                            document.getElementsByClassName('context-menu-tag')[2].click();
+                            document.getElementsByClassName('unclearIfNeeded-tag')[0].click();
                             break;
                     }
                 } else if (labelType == 'Obstacle') { // Obstacle in Path
                     switch (e.keyCode) {
                         case util.misc.getLabelDescriptions('Obstacle')['tagInfo']['trash can']['keyNumber']: // 'r' for 'trash can'
-                            document.getElementsByClassName('context-menu-tag')[0].click();
+                            document.getElementsByClassName('trashCan-tag')[0].click();
                             break;
                         case util.misc.getLabelDescriptions('Obstacle')['tagInfo']['fire hydrant']['keyNumber']: // 'f' for 'fire hydrant'
-                            document.getElementsByClassName('context-menu-tag')[1].click();
+                            document.getElementsByClassName('fireHydrant-tag')[0].click();
                             break;
                         case util.misc.getLabelDescriptions('Obstacle')['tagInfo']['pole']['keyNumber']: // 'p' for 'pole'
-                            document.getElementsByClassName('context-menu-tag')[2].click();
+                            document.getElementsByClassName('pole-tag')[0].click();
                             break;
                         case util.misc.getLabelDescriptions('Obstacle')['tagInfo']['tree']['keyNumber']: // 't' for 'tree'
-                            document.getElementsByClassName('context-menu-tag')[3].click();
+                            document.getElementsByClassName('tree-tag')[0].click();
                             break;
                         case util.misc.getLabelDescriptions('Obstacle')['tagInfo']['vegetation']['keyNumber']: // 'v' for 'vegetation'
-                            document.getElementsByClassName('context-menu-tag')[4].click();
+                            document.getElementsByClassName('vegetation-tag')[0].click();
                             break;
                     }
                 } else if (labelType == 'SurfaceProblem') { // Surface Problem
                     switch (e.keyCode) {
                         case util.misc.getLabelDescriptions('SurfaceProblem')['tagInfo']['bumpy']['keyNumber']: // 'p' for 'bumpy'
-                            document.getElementsByClassName('context-menu-tag')[0].click();
+                            document.getElementsByClassName('bumpy-tag')[0].click();
                             break;
                         case util.misc.getLabelDescriptions('SurfaceProblem')['tagInfo']['uneven']['keyNumber']: // 'u' for 'uneven'
-                            document.getElementsByClassName('context-menu-tag')[1].click();
+                            document.getElementsByClassName('uneven-tag')[0].click();
                             break;
                         case util.misc.getLabelDescriptions('SurfaceProblem')['tagInfo']['cracks']['keyNumber']: // 'r' for 'cracks'
-                            document.getElementsByClassName('context-menu-tag')[2].click();
+                            document.getElementsByClassName('cracks-tag')[0].click();
                             break;
                         case util.misc.getLabelDescriptions('SurfaceProblem')['tagInfo']['grass']['keyNumber']: // 'g' for 'grass'
-                            document.getElementsByClassName('context-menu-tag')[3].click();
+                            document.getElementsByClassName('grass-tag')[0].click();
                             break;
                         case util.misc.getLabelDescriptions('SurfaceProblem')['tagInfo']['narrow sidewalk']['keyNumber']  : // 'a' for 'narrow sidewalk'
-                            document.getElementsByClassName('context-menu-tag')[4].click();
+                            document.getElementsByClassName('narrowSidewalk-tag')[0].click();
                             break;
                     }
                 } else if (labelType == 'Other') { // No Sidewalk
                     switch (e.keyCode) {
                         case util.misc.getLabelDescriptions('Other')['tagInfo']['missing crosswalk']['keyNumber']: // 'i' for 'missing crosswalk'
-                            document.getElementsByClassName('context-menu-tag')[0].click();
+                            document.getElementsByClassName('missingCrosswalk-tag')[0].click();
                             break;
                         case util.misc.getLabelDescriptions('Other')['tagInfo']['no bus stop access']['keyNumber']: // 'a' for 'no bus stop access'
-                            document.getElementsByClassName('context-menu-tag')[1].click();
+                            document.getElementsByClassName('noBusStopAccess-tag')[0].click();
                             break;
                     }
                 }

--- a/public/javascripts/SVLabel/src/SVLabel/keyboard/Keyboard.js
+++ b/public/javascripts/SVLabel/src/SVLabel/keyboard/Keyboard.js
@@ -326,73 +326,73 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
                 if (labelType == 'CurbRamp') { // Curb Ramp
                     switch (e.keyCode) {
                         case util.misc.getLabelDescriptions('CurbRamp')['tagInfo']['narrow']['keyNumber']: // 'a' for 'narrow'
-                            $("button:contains(narrow)").click();
+                            document.getElementsByClassName('context-menu-tag')[0].click();
                             break;
                         case util.misc.getLabelDescriptions('CurbRamp')['tagInfo']['points into traffic']['keyNumber']: // 'p' for 'points into traffic'
-                            $("button:contains(points into traffic)").click();
+                            document.getElementsByClassName('context-menu-tag')[1].click();
                             break;
                         case util.misc.getLabelDescriptions('CurbRamp')['tagInfo']['missing friction strip']['keyNumber']: // 'f' for 'missing friction strip'
-                            $("button:contains(missing friction strip)").click();
+                            document.getElementsByClassName('context-menu-tag')[2].click();
                             break;
                         case util.misc.getLabelDescriptions('CurbRamp')['tagInfo']['steep']['keyNumber']: // 't' for 'steep'
-                            $("button:contains(steep)").click();
+                            document.getElementsByClassName('context-menu-tag')[3].click();
                             break;
                     }
                 } else if (labelType == 'NoCurbRamp') { // Missing Curb Ramp
                     switch (e.keyCode) {
                         case util.misc.getLabelDescriptions('NoCurbRamp')['tagInfo']['alternate route present']['keyNumber']: // 'a' for 'alternate route present'
-                            $("button:contains(alternate route present)").click();
+                            document.getElementsByClassName('context-menu-tag')[0].click();
                             break;
                         case util.misc.getLabelDescriptions('NoCurbRamp')['tagInfo']['no alternate route']['keyNumber']: // 'l' for 'no alternate route'
-                            $("button:contains(no alternate route)").click();
+                            document.getElementsByClassName('context-menu-tag')[1].click();
                             break;
                         case util.misc.getLabelDescriptions('NoCurbRamp')['tagInfo']['unclear if needed']['keyNumber']: // 'u' for 'unclear if needed'
-                            $("button:contains(unclear if needed)").click();
+                            document.getElementsByClassName('context-menu-tag')[2].click();
                             break;
                     }
                 } else if (labelType == 'Obstacle') { // Obstacle in Path
                     switch (e.keyCode) {
                         case util.misc.getLabelDescriptions('Obstacle')['tagInfo']['trash can']['keyNumber']: // 'r' for 'trash can'
-                            $("button:contains(trash can)").click();
+                            document.getElementsByClassName('context-menu-tag')[0].click();
                             break;
                         case util.misc.getLabelDescriptions('Obstacle')['tagInfo']['fire hydrant']['keyNumber']: // 'f' for 'fire hydrant'
-                            $("button:contains(fire hydrant)").click();
+                            document.getElementsByClassName('context-menu-tag')[1].click();
                             break;
                         case util.misc.getLabelDescriptions('Obstacle')['tagInfo']['pole']['keyNumber']: // 'p' for 'pole'
-                            $("button:contains(pole)").click();
+                            document.getElementsByClassName('context-menu-tag')[2].click();
                             break;
                         case util.misc.getLabelDescriptions('Obstacle')['tagInfo']['tree']['keyNumber']: // 't' for 'tree'
-                            $("button:contains(tree)").click();
+                            document.getElementsByClassName('context-menu-tag')[3].click();
                             break;
                         case util.misc.getLabelDescriptions('Obstacle')['tagInfo']['vegetation']['keyNumber']: // 'v' for 'vegetation'
-                            $("button:contains(vegetation)").click();
+                            document.getElementsByClassName('context-menu-tag')[4].click();
                             break;
                     }
                 } else if (labelType == 'SurfaceProblem') { // Surface Problem
                     switch (e.keyCode) {
                         case util.misc.getLabelDescriptions('SurfaceProblem')['tagInfo']['bumpy']['keyNumber']: // 'p' for 'bumpy'
-                            $("button:contains(bumpy)").click();
+                            document.getElementsByClassName('context-menu-tag')[0].click();
                             break;
                         case util.misc.getLabelDescriptions('SurfaceProblem')['tagInfo']['uneven']['keyNumber']: // 'u' for 'uneven'
-                            $("button:contains(uneven)").click();
+                            document.getElementsByClassName('context-menu-tag')[1].click();
                             break;
                         case util.misc.getLabelDescriptions('SurfaceProblem')['tagInfo']['cracks']['keyNumber']: // 'r' for 'cracks'
-                            $("button:contains(cracks)").click();
+                            document.getElementsByClassName('context-menu-tag')[2].click();
                             break;
                         case util.misc.getLabelDescriptions('SurfaceProblem')['tagInfo']['grass']['keyNumber']: // 'g' for 'grass'
-                            $("button:contains(grass)").click();
+                            document.getElementsByClassName('context-menu-tag')[3].click();
                             break;
                         case util.misc.getLabelDescriptions('SurfaceProblem')['tagInfo']['narrow sidewalk']['keyNumber']  : // 'a' for 'narrow sidewalk'
-                            $("button:contains(narrow sidewalk)").click();
+                            document.getElementsByClassName('context-menu-tag')[4].click();
                             break;
                     }
                 } else if (labelType == 'Other') { // No Sidewalk
                     switch (e.keyCode) {
                         case util.misc.getLabelDescriptions('Other')['tagInfo']['missing crosswalk']['keyNumber']: // 'i' for 'missing crosswalk'
-                            $("button:contains(missing crosswalk)").click();
+                            document.getElementsByClassName('context-menu-tag')[0].click();
                             break;
                         case util.misc.getLabelDescriptions('Other')['tagInfo']['no bus stop access']['keyNumber']: // 'a' for 'no bus stop access'
-                            $("button:contains(no bus stop access)").click();
+                            document.getElementsByClassName('context-menu-tag')[1].click();
                             break;
                     }
                 }

--- a/public/javascripts/SVLabel/src/SVLabel/keyboard/Keyboard.js
+++ b/public/javascripts/SVLabel/src/SVLabel/keyboard/Keyboard.js
@@ -264,6 +264,7 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
                         }
                         break;
                     case util.misc.getLabelDescriptions('NoSidewalk')['shortcut']['keyNumber']:
+                        // "n" for NoSidewalk
                         _closeContextMenu(e.keyCode);
                         ribbon.modeSwitch("NoSidewalk");
                         svl.tracker.push("KeyboardShortcut_ModeSwitch_NoSidewalk", {
@@ -281,6 +282,7 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
                         }
                         break;
                     case util.misc.getLabelDescriptions('SurfaceProblem')['shortcut']['keyNumber']:
+                        // "s" for surface problem
                         _closeContextMenu(e.keyCode);
                         if (!contextMenu.isOpen()) {
                             ribbon.modeSwitch("SurfaceProblem");

--- a/public/javascripts/SVLabel/src/SVLabel/keyboard/Keyboard.js
+++ b/public/javascripts/SVLabel/src/SVLabel/keyboard/Keyboard.js
@@ -227,6 +227,7 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
             status.shiftDown = e.shiftKey;
             if (!status.focusOnTextField) {
                 switch (e.keyCode) {
+                    // Label selection hotkeys
                     case util.misc.getLabelDescriptions('Occlusion')['shortcut']['keyNumber']:
                         // "b" for a blocked view.
                         // Context menu may be open for a different label.
@@ -291,6 +292,8 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
                             });
                         }
                         break;
+                        
+                    // Zoom Hotkeys
                     case 16: //shift
                         // store the timestamp here so that we can check if the z-up event is in the buffer range
                         lastShiftKeyUpTimestamp = e.timeStamp;
@@ -316,6 +319,81 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
                                 keyCode: e.keyCode
                             });
                         }
+                }
+
+                var labelType = contextMenu.getTargetLabel().getProperty('labelType');
+                if (labelType == 'CurbRamp') { // Curb Ramp
+                    switch (e.keyCode) {
+                        case 65: // 'a' for 'narrow'
+                            document.getElementsByClassName('context-menu-tag')[0].click();
+                            break;
+                        case 80: // 'p' for 'points into traffic'
+                            document.getElementsByClassName('context-menu-tag')[1].click();
+                            break;
+                        case 70: // 'f' for 'missing friction strip'
+                            document.getElementsByClassName('context-menu-tag')[2].click();
+                            break;
+                        case 84: // 't' for steep
+                            document.getElementsByClassName('context-menu-tag')[3].click();
+                            break;
+                    }
+                } else if (labelType == 'NoCurbRamp') { // Missing Curb Ramp
+                    switch (e.keyCode) {
+                        case 65: // 'a' for 'alternate route present'
+                            document.getElementsByClassName('context-menu-tag')[0].click();
+                            break;
+                        case 76: // 'l' for 'no alternate route'
+                            document.getElementsByClassName('context-menu-tag')[1].click();
+                            break;
+                        case 85: // 'u' for 'unclear if needed'
+                            document.getElementsByClassName('context-menu-tag')[2].click();
+                            break;
+                    }
+                } else if (labelType == 'Obstacle') { // Obstacle in Path
+                    switch (e.keyCode) {
+                        case 82: // 'r' for 'trash can'
+                            document.getElementsByClassName('context-menu-tag')[0].click();
+                            break;
+                        case 70: // 'f' for 'fire hydrant'
+                            document.getElementsByClassName('context-menu-tag')[1].click();
+                            break;
+                        case 80: // 'p' for 'pole'
+                            document.getElementsByClassName('context-menu-tag')[2].click();
+                            break;
+                        case 84: // 't' for 'tree'
+                            document.getElementsByClassName('context-menu-tag')[3].click();
+                            break;
+                        case 86: // 'v' for vegetation
+                            document.getElementsByClassName('context-menu-tag')[4].click();
+                            break;
+                    }
+                } else if (labelType == 'SurfaceProblem') { // Surface Problem
+                    switch (e.keyCode) {
+                        case 80 :// 'p' for 'bumpy'
+                            document.getElementsByClassName('context-menu-tag')[0].click();
+                            break;
+                        case 85:  // 'u' for 'uneven'
+                            document.getElementsByClassName('context-menu-tag')[1].click();
+                            break;
+                        case 82: // 'r' for 'cracks'
+                            document.getElementsByClassName('context-menu-tag')[2].click();
+                            break;
+                        case 71 : // 'g' for 'grass'
+                            document.getElementsByClassName('context-menu-tag')[3].click();
+                            break;
+                        case 65 : // 'a' for 'narrow sidewalk'
+                            document.getElementsByClassName('context-menu-tag')[4].click();
+                            break;
+                    }
+                } else if (labelType == 'Other') { // No Sidewalk
+                    switch (e.keyCode) {
+                        case 73: // 'i' for 'missing crosswalk'
+                            document.getElementsByClassName('context-menu-tag')[0].click();
+                            break;
+                        case 65: // 'a' for 'no bus stop access'
+                            document.getElementsByClassName('context-menu-tag')[1].click();
+                            break;
+                    }
                 }
             }
 

--- a/public/javascripts/SVLabel/src/SVLabel/util/UtilitiesSidewalk.js
+++ b/public/javascripts/SVLabel/src/SVLabel/util/UtilitiesSidewalk.js
@@ -230,22 +230,26 @@ function UtilitiesMisc (JSON) {
                     'narrow': {
                         keyNumber: 65,
                         keyChar: 'A',
-                        text: 'n<tag-underline>a</tag-underline>rrow'
+                        text: 'n<tag-underline>a</tag-underline>rrow',
+                        id: 'narrow'
                     },
                     'points into traffic': {
                         keyNumber: 80,
                         keyChar: 'P',
-                        text: '<tag-underline>p</tag-underline>oints into traffic'
+                        text: '<tag-underline>p</tag-underline>oints into traffic',
+                        id: 'pointIntoTraffic'
                     },
                     'missing friction strip': {
                         keyNumber: 70,
                         keyChar: 'F',
-                        text: 'missing <tag-underline>f</tag-underline>riction strip'
+                        text: 'missing <tag-underline>f</tag-underline>riction strip',
+                        id: 'missingFrictionStrip'
                     },
                     'steep': {
                         keyNumber: 84,
                         keyChar: 'T',
-                        text: 's<tag-underline>t</tag-underline>eep'
+                        text: 's<tag-underline>t</tag-underline>eep',
+                        id: 'steep'
                     }
                 }
             },
@@ -260,17 +264,20 @@ function UtilitiesMisc (JSON) {
                     'alternate route present': {
                         keyNumber: 65,
                         keyChar: 'A',
-                        text: '<tag-underline>a</tag-underline>lternate route present'
+                        text: '<tag-underline>a</tag-underline>lternate route present',
+                        id: 'alternateRoutePresent'
                     },
                     'no alternate route': {
                         keyNumber: 76,
                         keyChar: 'L',
-                        text: 'no a<tag-underline>l</tag-underline>ternate route'
+                        text: 'no a<tag-underline>l</tag-underline>ternate route',
+                        id: 'noAlternateRoute'
                     },
                     'unclear if needed': {
                         keyNumber: 85,
                         keyChar: 'U',
-                        text: '<tag-underline>u</tag-underline>nclear if needed'
+                        text: '<tag-underline>u</tag-underline>nclear if needed',
+                        id: 'unclearIfNeeded'
                     }
                 }
             },
@@ -285,27 +292,32 @@ function UtilitiesMisc (JSON) {
                     'trash can': {
                         keyNumber: 82,
                         keyChar: 'R',
-                        text: 't<tag-underline>r</tag-underline>ash can'
+                        text: 't<tag-underline>r</tag-underline>ash can',
+                        id: 'trashCan'
                     },
                     'fire hydrant': {
                         keyNumber: 70,
                         keyChar: 'F',
-                        text: '<tag-underline>f</tag-underline>ire hydrant'
+                        text: '<tag-underline>f</tag-underline>ire hydrant',
+                        id: 'fireHydrant'
                     },
                     'pole': {
                         keyNumber: 80,
                         keyChar: 'P',
-                        text: '<tag-underline>p</tag-underline>ole'
+                        text: '<tag-underline>p</tag-underline>ole',
+                        id: 'pole'
                     },
                     'tree': {
                         keyNumber: 84,
                         keyChar: 'T',
-                        text: '<tag-underline>t</tag-underline>ree'
+                        text: '<tag-underline>t</tag-underline>ree',
+                        id: 'tree'
                     },
                     'vegetation': {
                         keyNumber: 86,
                         keyChar: 'V',
-                        text: '<tag-underline>v</tag-underline>egetation'
+                        text: '<tag-underline>v</tag-underline>egetation',
+                        id: 'vegetation'
                     }
                 }
             },
@@ -316,12 +328,14 @@ function UtilitiesMisc (JSON) {
                     'missing crosswalk': {
                         keyNumber: 73,
                         keyChar: 'I',
-                        text: 'm<tag-underline>i</tag-underline>ssing crosswalk'
+                        text: 'm<tag-underline>i</tag-underline>ssing crosswalk',
+                        id: 'missingCrosswalk'
                     },
                     'no bus stop access': {
                         keyNumber: 65,
                         keyChar: 'A',
-                        text: 'no bus stop <tag-underline>a</tag-underline>ccess'
+                        text: 'no bus stop <tag-underline>a</tag-underline>ccess',
+                        id: 'noBusStopAccess'
                     }
                 }
             },
@@ -352,27 +366,32 @@ function UtilitiesMisc (JSON) {
                     'bumpy': {
                         keyNumber: 80,
                         keyChar: 'P',
-                        text: 'bum<tag-underline>p</tag-underline>y'
+                        text: 'bum<tag-underline>p</tag-underline>y',
+                        id: 'bumpy'
                     },
                     'uneven': {
                         keyNumber: 85,
                         keyChar: 'U',
-                        text: '<tag-underline>u</tag-underline>neven'
+                        text: '<tag-underline>u</tag-underline>neven',
+                        id: 'uneven'
                     },
                     'cracks': {
                         keyNumber: 82,
                         keyChar: 'R',
-                        text: 'c<tag-underline>r</tag-underline>acks'
+                        text: 'c<tag-underline>r</tag-underline>acks',
+                        id: 'cracks'
                     },
                     'grass': {
                         keyNumber: 71,
                         keyChar: 'G',
-                        text: '<tag-underline>g</tag-underline>rass'
+                        text: '<tag-underline>g</tag-underline>rass',
+                        id: 'grass'
                     },
                     'narrow sidewalk': {
                         keyNumber: 65,
                         keyChar: 'A',
-                        text: 'n<tag-underline>a</tag-underline>rrow sidewalk'
+                        text: 'n<tag-underline>a</tag-underline>rrow sidewalk',
+                        id: 'narrowSidewalk'
                     }
                 }
             },

--- a/public/javascripts/SVLabel/src/SVLabel/util/UtilitiesSidewalk.js
+++ b/public/javascripts/SVLabel/src/SVLabel/util/UtilitiesSidewalk.js
@@ -209,11 +209,11 @@ function UtilitiesMisc (JSON) {
         }
     }
 
-    function getLabelDescriptions (category) {
+    function getLabelDescriptions(category) {
         var descriptions = {
-            'Walk' : {
-                'id' : 'Walk',
-                'text' : 'Walk',
+            'Walk': {
+                'id': 'Walk',
+                'text': 'Walk',
                 shortcut: {
                     keyNumber: 69,
                     keyChar: 'E'
@@ -225,6 +225,24 @@ function UtilitiesMisc (JSON) {
                 shortcut: {
                     keyNumber: 67,
                     keyChar: 'C'
+                },
+                tagInfo: {
+                    'narrow': {
+                        keyNumber: 65,
+                        keyChar: 'A'
+                    },
+                    'points into traffic': {
+                        keyNumber: 80,
+                        keyChar: 'P'
+                    },
+                    'missing friction strip': {
+                        keyNumber: 70,
+                        keyChar: 'F'
+                    },
+                    'steep': {
+                        keyNumber: 84,
+                        keyChar: 'T'
+                    }
                 }
             },
             NoCurbRamp: {
@@ -233,6 +251,20 @@ function UtilitiesMisc (JSON) {
                 shortcut: {
                     keyNumber: 77,
                     keyChar: 'M'
+                },
+                tagInfo: {
+                    'alternate route present': {
+                        keyNumber: 65,
+                        keyChar: 'A'
+                    },
+                    'no alternate route': {
+                        keyNumber: 76,
+                        keyChar: 'L'
+                    },
+                    'unclear if needed': {
+                        keyNumber: 85,
+                        keyChar: 'U'
+                    }
                 }
             },
             Obstacle: {
@@ -241,11 +273,43 @@ function UtilitiesMisc (JSON) {
                 shortcut: {
                     keyNumber: 79,
                     keyChar: 'O'
+                },
+                tagInfo: {
+                    'trash can': {
+                        keyNumber: 82,
+                        keyChar: 'R'
+                    },
+                    'fire hydrant': {
+                        keyNumber: 70,
+                        keyChar: 'F'
+                    },
+                    'pole': {
+                        keyNumber: 80,
+                        keyChar: 'P'
+                    },
+                    'tree': {
+                        keyNumber: 84,
+                        keyChar: 'T'
+                    },
+                    'vegetation': {
+                        keyNumber: 86,
+                        keyChar: 'V'
+                    }
                 }
             },
             Other: {
                 id: 'Other',
-                text: 'Other'
+                text: 'Other',
+                tagInfo: {
+                    'missing crosswalk': {
+                        keyNumber: 73,
+                        keyChar: 'I'
+                    },
+                    'no bus stop access': {
+                        keyNumber: 65,
+                        keyChar: 'A'
+                    }
+                }
             },
             Occlusion: {
                 id: 'Occlusion',
@@ -269,6 +333,28 @@ function UtilitiesMisc (JSON) {
                 shortcut: {
                     keyNumber: 83,
                     keyChar: 'S'
+                },
+                tagInfo: {
+                    'bumpy': {
+                        keyNumber: 80,
+                        keyChar: 'P'
+                    },
+                    'uneven': {
+                        keyNumber: 85,
+                        keyChar: 'U'
+                    },
+                    'cracks': {
+                        keyNumber: 82,
+                        keyChar: 'R'
+                    },
+                    'grass': {
+                        keyNumber: 71,
+                        keyChar: 'G'
+                    },
+                    'narrow sidewalk': {
+                        keyNumber: 65,
+                        keyChar: 'A'
+                    }
                 }
             },
             Void: {

--- a/public/javascripts/SVLabel/src/SVLabel/util/UtilitiesSidewalk.js
+++ b/public/javascripts/SVLabel/src/SVLabel/util/UtilitiesSidewalk.js
@@ -229,19 +229,23 @@ function UtilitiesMisc (JSON) {
                 tagInfo: {
                     'narrow': {
                         keyNumber: 65,
-                        keyChar: 'A'
+                        keyChar: 'A',
+                        text: 'n<tag-underline>a</tag-underline>rrow'
                     },
                     'points into traffic': {
                         keyNumber: 80,
-                        keyChar: 'P'
+                        keyChar: 'P',
+                        text: '<tag-underline>p</tag-underline>oints into traffic'
                     },
                     'missing friction strip': {
                         keyNumber: 70,
-                        keyChar: 'F'
+                        keyChar: 'F',
+                        text: 'missing <tag-underline>f</tag-underline>riction strip'
                     },
                     'steep': {
                         keyNumber: 84,
-                        keyChar: 'T'
+                        keyChar: 'T',
+                        text: 's<tag-underline>t</tag-underline>eep'
                     }
                 }
             },
@@ -255,15 +259,18 @@ function UtilitiesMisc (JSON) {
                 tagInfo: {
                     'alternate route present': {
                         keyNumber: 65,
-                        keyChar: 'A'
+                        keyChar: 'A',
+                        text: '<tag-underline>a</tag-underline>lternate route present'
                     },
                     'no alternate route': {
                         keyNumber: 76,
-                        keyChar: 'L'
+                        keyChar: 'L',
+                        text: 'no a<tag-underline>l</tag-underline>ternate route'
                     },
                     'unclear if needed': {
                         keyNumber: 85,
-                        keyChar: 'U'
+                        keyChar: 'U',
+                        text: '<tag-underline>u</tag-underline>nclear if needed'
                     }
                 }
             },
@@ -277,23 +284,28 @@ function UtilitiesMisc (JSON) {
                 tagInfo: {
                     'trash can': {
                         keyNumber: 82,
-                        keyChar: 'R'
+                        keyChar: 'R',
+                        text: 't<tag-underline>r</tag-underline>ash can'
                     },
                     'fire hydrant': {
                         keyNumber: 70,
-                        keyChar: 'F'
+                        keyChar: 'F',
+                        text: '<tag-underline>f</tag-underline>ire hydrant'
                     },
                     'pole': {
                         keyNumber: 80,
-                        keyChar: 'P'
+                        keyChar: 'P',
+                        text: '<tag-underline>p</tag-underline>ole'
                     },
                     'tree': {
                         keyNumber: 84,
-                        keyChar: 'T'
+                        keyChar: 'T',
+                        text: '<tag-underline>t</tag-underline>ree'
                     },
                     'vegetation': {
                         keyNumber: 86,
-                        keyChar: 'V'
+                        keyChar: 'V',
+                        text: '<tag-underline>v</tag-underline>egetation'
                     }
                 }
             },
@@ -303,11 +315,13 @@ function UtilitiesMisc (JSON) {
                 tagInfo: {
                     'missing crosswalk': {
                         keyNumber: 73,
-                        keyChar: 'I'
+                        keyChar: 'I',
+                        text: 'm<tag-underline>i</tag-underline>ssing crosswalk'
                     },
                     'no bus stop access': {
                         keyNumber: 65,
-                        keyChar: 'A'
+                        keyChar: 'A',
+                        text: 'no bus stop <tag-underline>a</tag-underline>ccess'
                     }
                 }
             },
@@ -337,23 +351,28 @@ function UtilitiesMisc (JSON) {
                 tagInfo: {
                     'bumpy': {
                         keyNumber: 80,
-                        keyChar: 'P'
+                        keyChar: 'P',
+                        text: 'bum<tag-underline>p</tag-underline>y'
                     },
                     'uneven': {
                         keyNumber: 85,
-                        keyChar: 'U'
+                        keyChar: 'U',
+                        text: '<tag-underline>u</tag-underline>neven'
                     },
                     'cracks': {
                         keyNumber: 82,
-                        keyChar: 'R'
+                        keyChar: 'R',
+                        text: 'c<tag-underline>r</tag-underline>acks'
                     },
                     'grass': {
                         keyNumber: 71,
-                        keyChar: 'G'
+                        keyChar: 'G',
+                        text: '<tag-underline>g</tag-underline>rass'
                     },
                     'narrow sidewalk': {
                         keyNumber: 65,
-                        keyChar: 'A'
+                        keyChar: 'A',
+                        text: 'n<tag-underline>a</tag-underline>rrow sidewalk'
                     }
                 }
             },


### PR DESCRIPTION
Resolves #1276 

I've added keyboard shortcuts for selecting label tags. All you have to do is open a label, and press one of the underlined letters to toggle its corresponding tag. 

Here are some screenshots of the label screens:

![image](https://user-images.githubusercontent.com/12887715/51661479-d52a7c00-1f65-11e9-86b8-3e15c5667c27.png)
![image](https://user-images.githubusercontent.com/12887715/51661486-d9569980-1f65-11e9-97c3-b62a11c292c0.png)
![image](https://user-images.githubusercontent.com/12887715/51661496-dcea2080-1f65-11e9-90f7-498c5d92dcba.png)
![image](https://user-images.githubusercontent.com/12887715/51661502-e1163e00-1f65-11e9-95e1-73e28090faf4.png)
![image](https://user-images.githubusercontent.com/12887715/51661509-e4a9c500-1f65-11e9-8aeb-58621fd2cb5a.png)

To test:
- Ensure that all of the hotkeys toggle the tags as intended
- Ensure that the hotkeys do not interfere with other hotkeys we have (in case I missed something!)
- Ensure that everything else with labels works as before

I have performed these test on Chrome and Firefox on my machine and everything works fine!