### PR TITLE
#552: Ambiguous 'You Have Reached End Of This Route'

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/navigation/Compass.js
+++ b/public/javascripts/SVLabel/src/SVLabel/navigation/Compass.js
@@ -224,7 +224,7 @@ function Compass (svl, mapService, taskContainer, uiCompass) {
     }
 
     function setLabelBeforeJumpMessage () {
-        var message = "<div style='width: 20%'>You have reached the end of this route. Finish labeling this area and <br/> " +
+        var message = "<div style='width: 20%'>You have reached the end of this route. Finish labeling this intersection then <br/> " +
             "<span class='bold'>click here to move to a new location.</span></div>";
         uiCompass.message.html(message);
     }

--- a/public/javascripts/SVLabel/src/SVLabel/navigation/Compass.js
+++ b/public/javascripts/SVLabel/src/SVLabel/navigation/Compass.js
@@ -224,7 +224,8 @@ function Compass (svl, mapService, taskContainer, uiCompass) {
     }
 
     function setLabelBeforeJumpMessage () {
-        var message = "<div style='width: 20%'>You have reached the end of this route. Finish labeling this intersection then <br/> " +
+        var message = "<div style='width: 20%'>You have reached the end of this route. " +
+            "<span class='bold'>Finish labeling this intersection</span> then <br/> " +
             "<span class='bold'>click here to move to a new location.</span></div>";
         uiCompass.message.html(message);
     }

--- a/public/javascripts/SVLabel/src/SVLabel/navigation/Compass.js
+++ b/public/javascripts/SVLabel/src/SVLabel/navigation/Compass.js
@@ -224,8 +224,7 @@ function Compass (svl, mapService, taskContainer, uiCompass) {
     }
 
     function setLabelBeforeJumpMessage () {
-        var message = "<div style='width: 20%'>You have reached the end of this route. " +
-            "<span class='bold'>Finish labeling this intersection</span> then <br/> " +
+        var message = "<div style='width: 20%'>You have reached the end of this route. Finish labeling this intersection then <br/> " +
             "<span class='bold'>click here to move to a new location.</span></div>";
         uiCompass.message.html(message);
     }


### PR DESCRIPTION
Resolves #552 

- Changed text at end of route to help user know to highlight the last intersection

Doesn't seem like it would have any side effects. Only a text change.

To test:
- Finish mapping a neighborhood (until you reach the final intersection and see a "You have reached the end.." tooltip)
- Verify that the tooltip text has changed to "You have reached the end of this route. Finish labeling this intersection then **click here to move to a new location**."