### PR TITLE
#1338: Improve website loading times

### DIFF
--- a/app/models/street/StreetEdgeTable.scala
+++ b/app/models/street/StreetEdgeTable.scala
@@ -155,7 +155,7 @@ object StreetEdgeTable {
     * @return
     */
   def totalStreetDistance(): Float = db.withSession { implicit session =>
-    Cache.getOrElse("totalStreetDistance()", 10.minutes.toSeconds.toInt) {
+    Cache.getOrElse("totalStreetDistance()") {
       // DISTINCT query: http://stackoverflow.com/questions/18256768/select-distinct-in-scala-slick
 
       // get length of each street segment, sum the lengths, and convert from meters to miles
@@ -174,7 +174,7 @@ object StreetEdgeTable {
   def auditedStreetDistance(auditCount: Int, userType: String = "All"): Float = db.withSession { implicit session =>
     val cacheKey = s"auditedStreetDistance($auditCount, $userType)"
 
-    Cache.getOrElse(cacheKey, 10.minutes.toSeconds.toInt) {
+    Cache.getOrElse(cacheKey, 30.minutes.toSeconds.toInt) {
       val auditTaskQuery = userType match {
         case "All" => completedAuditTasks
         case "Researcher" => researcherCompletedAuditTasks

--- a/app/models/street/StreetEdgeTable.scala
+++ b/app/models/street/StreetEdgeTable.scala
@@ -174,7 +174,7 @@ object StreetEdgeTable {
   def auditedStreetDistance(auditCount: Int, userType: String = "All"): Float = db.withSession { implicit session =>
     val cacheKey = s"auditedStreetDistance($auditCount, $userType)"
 
-    Cache.getOrElse(cacheKey, 30.minutes.toSeconds.toInt) {
+    Cache.getOrElse(cacheKey, 1.hour.toSeconds.toInt) {
       val auditTaskQuery = userType match {
         case "All" => completedAuditTasks
         case "Researcher" => researcherCompletedAuditTasks

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -57,6 +57,21 @@ evolutionplugin=enabled
 
 play.evolutions.autoApplyDown=true
 
+play.filters.gzip {
+
+  contentType {
+
+    # If non empty, then a response will only be compressed if its content type is in this list.
+    #whiteList = [ "text/*", "application/javascript", "application/json" ]
+
+    # The black list is only used if the white list is empty.
+    # Compress all responses except the ones whose content type is in this list.
+    #blackList = []
+  }
+}
+
+play.filters.enabled += "play.filters.gzip.GzipFilter"
+
 applyEvolutions.default=true
 
 # Transactional DDL - causes all statements to be executed in one transaction only


### PR DESCRIPTION
Resolves #1338 

`totalStreetDistance` and `auditedStreetDistance` are now each cached for 10 minutes. **Note that this means some of the stats on the home page will update every 10 minutes.** The 10 minutes does not get reset (I tested this) when the cached value is accessed.

To test:

1. Try reaching the home page (doesn't matter if you clear cache or not, this is server sided).
2. The loading time difference should be very noticeable.