### PR TITLE
stabilize when survey pops up

### DIFF
--- a/app/controllers/SurveyController.scala
+++ b/app/controllers/SurveyController.scala
@@ -12,6 +12,7 @@ import models.daos.slick.DBTableDefinitions.{DBUser, UserTable}
 import models.survey._
 import models.user._
 import models.mission.MissionTable
+import models.user.{RoleTable, User, UserRoleTable, WebpageActivityTable}
 import play.api.Logger
 import play.api.libs.json._
 import play.api.mvc._
@@ -105,10 +106,11 @@ class SurveyController @Inject() (implicit val env: Environment[User, SessionAut
       case Some(user) =>
         val userId: UUID = user.userId
 
-        // The survey should show after the user completes their first non-tutorial mission. NOTE the number of missions
-        // before survey is actually 2, but this check is done before the next mission is updated on the back-end.
+        // The survey will show exactly once, in the middle of the 2nd mission.
+
         val numMissionsBeforeSurvey = 1
-        val displaySurvey = (MissionTable.countCompletedMissionsByUserId(userId, includeOnboarding = false) == numMissionsBeforeSurvey)
+        val surveyShown = WebpageActivityTable.findUserActivity("SurveyShown", userId).length
+        val displaySurvey = (MissionTable.countCompletedMissionsByUserId(userId, includeOnboarding = false) == numMissionsBeforeSurvey && (surveyShown == 0))
 
         //maps displaymodal to true in the future
         Future.successful(Ok(Json.obj("displayModal" -> displaySurvey)))

--- a/app/models/user/WebpageActivityTable.scala
+++ b/app/models/user/WebpageActivityTable.scala
@@ -53,6 +53,16 @@ object WebpageActivityTable {
   }
 
   /**
+    * See if the user has previous logs for a specific activity.
+    * @param userId
+    * @param activity
+    * @return List[WebpageActivity]
+    */
+  def findUserActivity(activity: String, userId: UUID): List[WebpageActivity] = db.withSession { implicit session =>
+    activities.filter(a => a.userId === userId.toString && a.activity === activity).list
+  }
+
+  /**
     * Returns all WebpageActivities that contain the given string in their 'activity' field
     */
   def find(activity: String): List[WebpageActivity] = db.withSession { implicit session =>
@@ -94,4 +104,5 @@ object WebpageActivityTable {
       "timestamp" -> webpageActivity.timestamp
     )
   }
+
 }

--- a/public/javascripts/SVLabel/src/SVLabel/mission/MissionProgress.js
+++ b/public/javascripts/SVLabel/src/SVLabel/mission/MissionProgress.js
@@ -50,42 +50,6 @@ function MissionProgress (svl, gameEffectModel, missionModel, modalModel, neighb
         );
         mission.complete();
 
-        // Survey prompt. Modal should display survey if
-        // 1. User has just completed numMissionsBeforeSurvey number of missions.
-        $.ajax({
-            async: true,
-            url: '/survey/display',
-            type: 'get',
-            success: function(data){
-                if(data.displayModal){
-                    $('#survey-modal-container').modal({
-                        backdrop: 'static',
-                        keyboard: false
-                    });
-
-                    //we will log in the webpage activity table if the survey has been shown
-                    var activity = "SurveyShown";
-                    var url = "/userapi/logWebpageActivity";
-                    var async = true;
-                    $.ajax({
-                        async: async,
-                        contentType: 'application/json; charset=utf-8',
-                        url: url,
-                        type: 'post',
-                        data: JSON.stringify(activity),
-                        dataType: 'json',
-                        success: function(result){},
-                        error: function (result) {
-                            console.error(result);
-                        }
-                    });
-                }
-            },
-            error: function (xhr, ajaxOptions, thrownError) {
-                console.log(thrownError);
-            }
-        });
-
         // TODO Audio should listen to MissionProgress instead of MissionProgress telling what to do.
         _gameEffectModel.playAudio({audioType: "yay"});
         _gameEffectModel.playAudio({audioType: "applause"});
@@ -124,5 +88,47 @@ function MissionProgress (svl, gameEffectModel, missionModel, modalModel, neighb
         statusModel.setMissionCompletionRate(completionRate);
         statusModel.setProgressBar(completionRate);
         this._checkMissionComplete(currentMission, currentRegion);
+
+        // Survey prompt. Modal should display survey if
+        // 1. User has completed numMissionsBeforeSurvey number of missions
+        // 2. The user has just completed more than 30% of the current mission
+        // 3. The user has not been shown the survey before
+        if (completionRate > 0.30 && completionRate < 0.60) {
+            $.ajax({
+                async: true,
+                url: '/survey/display',
+                type: 'get',
+                success: function (data) {
+                    if (data.displayModal) {
+                        $('#survey-modal-container').modal({
+                            backdrop: 'static',
+                            keyboard: false
+                        });
+
+                        //we will log in the webpage activity table if the survey has been shown
+                        var activity = "SurveyShown";
+                        var url = "/userapi/logWebpageActivity";
+                        var async = true;
+                        $.ajax({
+                            async: async,
+                            contentType: 'application/json; charset=utf-8',
+                            url: url,
+                            type: 'post',
+                            data: JSON.stringify(activity),
+                            dataType: 'json',
+                            success: function (result) {
+                            },
+                            error: function (result) {
+                                console.error(result);
+                            }
+                        });
+                    }
+                },
+                error: function (xhr, ajaxOptions, thrownError) {
+                    console.log(thrownError);
+                }
+            });
+        }
+
     };
 }


### PR DESCRIPTION
Fixes #1386.
Resolves #1362.

This PR accomplishes 3 things:
1. fixes the bug where the survey would sometimes come up after the 1st mission, sometimes after the 2nd
2. ensures that no user is ever shown the survey more than once
3. the survey now comes up about 1/3 of the way through the 2nd mission to avoid obscuring the "mission complete" modal and capture more users

The logic for when the survey shows is as follows: **the survey is shown the first time a user crosses the 30% completion mark of the second mission.**

To test, start mapping PS as a new user. Validate that the survey shows at the right time (always >30% into the 2nd mission), regardless of whether the user completed the tutorial.

