### PR TITLE
853 imporove tutorial wording

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/onboarding/OnboardingStates.js
+++ b/public/javascripts/SVLabel/src/SVLabel/onboarding/OnboardingStates.js
@@ -167,8 +167,9 @@ function OnboardingStates (compass, mapService, statusModel, tracker) {
                 "maxLabelCount": 1
             },
             "message": {
-                "message": 'Uh-oh, you should rate this curb ramp as 2, somewhat passable. ' +
-                '<span class="bold">Let\s click "2" to set its quality.</span><br> ' +
+                "message": 'Uh-oh, you should rate this curb ramp as 2, somewhat passable. It is a high quality curb ' +
+                    'ramp but points into traffic a bit. ' +
+                '<span class="bold">Let’s click "2" to set its quality.</span><br> ' +
                 '<img src="' + svl.rootDirectory + "img/onboarding/RatingCurbRampQuality-severity-2.gif" +
                 '" class="width-75" style="margin: 5px auto;display:block;" ' +
                 'alt="Rating curb ramp quality as 2, somewhat passable">',
@@ -344,8 +345,9 @@ function OnboardingStates (compass, mapService, statusModel, tracker) {
                 "maxLabelCount": 2
             },
             "message": {
-                "message": 'Uh-oh, you should rate this curb ramp as 2, somewhat passable. ' +
-                '<span class="bold">Let\s click "2" to set its quality.</span><br> ' +
+                "message": 'Uh-oh, you should rate this curb ramp as 2, somewhat passable. It is a high quality curb ' +
+                    'ramp but it has no landing space at the top of the ramp for making turns. ' +
+                '<span class="bold">Let’s click "2" to set its quality.</span><br> ' +
                 '<img src="' + svl.rootDirectory + "img/onboarding/RatingCurbRampQuality-severity-2.gif" +
                 '" class="width-75" style="margin: 5px auto;display:block;" alt="Rating curb ramp quality as 2, ' +
                 'somewhat passable">',
@@ -443,12 +445,12 @@ function OnboardingStates (compass, mapService, statusModel, tracker) {
                 "maxLabelCount": 3
             },
             "message": {
-                "message": 'Since this missing curb ramp is next to an existing curb ramp, this accessibility problem ' +
-                'is less severe. So, let’s <span class="bold">rate it as a 3.</span> ' +
-                'When you rate accessibility, we just ask that you use <span class="bold">your best judgment!</span><br>' +
+                "message": 'Since this missing curb ramp is next to an existing curb ramp, this accessibility problem' +
+                    ' is less severe. So <span class="bold">let’s rate it as a 3.</span> When you rate accessibility,' +
+                    ' we just ask that you <span class="bold">use your best judgment!</span><br>' +
                 '<img src="' + svl.rootDirectory + "img/onboarding/RatingNoCurbRampSeverity.gif" +
-                '" class="width-75" style="margin: 5px auto;display:block;" alt="Rating the no curb ramp quality as 3, ' +
-                'a slightly severe problem">',
+                '" class="width-75" style="margin: 5px auto;display:block;" alt="Rating the no curb ramp quality as ' +
+                    '3, a slightly severe problem">',
                 "position": "top-right",
                 "parameters": null
             },
@@ -473,8 +475,9 @@ function OnboardingStates (compass, mapService, statusModel, tracker) {
                 "maxLabelCount": 3
             },
             "message": {
-                "message": 'Hmm, this is a slightly severe problem. ' +
-                '<span class="bold">Let\s click "3" to change the severity of the missing curb ramp.</span><br> ' +
+                "message": 'Hmm, since this missing curb ramp is next to an existing curb ramp, this accessibility ' +
+                    'problem is less severe. ' +
+                '<span class="bold">Let’s click "3" to change the severity of the missing curb ramp.</span><br> ' +
                 '<img src="' + svl.rootDirectory + "img/onboarding/RatingNoCurbRampSeverity.gif" +
                 '" class="width-75" style="margin: 5px auto;display:block;" alt="Rating the no curb ramp quality as 3, ' +
                 'a slightly severe problem">',
@@ -680,7 +683,7 @@ function OnboardingStates (compass, mapService, statusModel, tracker) {
             },
             "message": {
                 "message": 'Now <span class="bold">rate the curb ramp’s quality</span>. ' +
-                'Use your best judgment. You can also write in notes in the <span class="bold">Description Box.</span><br>' +
+                'Use your best judgment. You can also write notes in the <span class="bold">Description Box.</span><br>' +
                 '<img src="' + svl.rootDirectory + "img/onboarding/RatingCurbRampQuality.gif" +
                 '" class="width-75" style="margin: 5px auto;display:block;" alt="Rating curb ramp quality as 1, passable">',
                 "position": "top-right",
@@ -707,8 +710,9 @@ function OnboardingStates (compass, mapService, statusModel, tracker) {
                 "maxLabelCount": 4
             },
             "message": {
-                "message": 'Hmm, you should rate this curb ramp as 1, passable. ' +
-                '<span class="bold">Let\s click "1" to change its rating.</span><br> ' +
+                "message": 'Hmm, you should rate this curb ramp as 1, passable. This curb ramp is wide enough, has a ' +
+                    'friction strip, and doesn\'t point into traffic. ' +
+                '<span class="bold">Let’s click "1" to change its rating.</span><br> ' +
                 '<img src="' + svl.rootDirectory + "img/onboarding/RatingCurbRampQuality.gif" +
                 '" class="width-75" style="margin: 5px auto;display:block;" alt="Rating curb ramp quality as 1, passable">',
                 "position": "top-right",
@@ -803,7 +807,7 @@ function OnboardingStates (compass, mapService, statusModel, tracker) {
                 "maxLabelCount": 5
             },
             "message": {
-                "message": 'Let’s <span class="bold">rate the quality</span> of the curb ramp.<br>' +
+                "message": '<span class="bold">Let’s rate the quality</span> of the curb ramp.<br>' +
                 '<img src="' + svl.rootDirectory + "img/onboarding/RatingCurbRampQuality-severity-2.gif" +
                 '" class="width-75" style="margin: 5px auto;display:block;" alt="Rating curb ramp quality as 1, passable">',
                 "position": "top-right",
@@ -830,8 +834,9 @@ function OnboardingStates (compass, mapService, statusModel, tracker) {
                 "maxLabelCount": 5
             },
             "message": {
-                "message": 'Hmm, you should rate this curb ramp as 1, passable. ' +
-                '<span class="bold">Let\s click "1" to change its rating.</span><br> ' +
+                "message": 'Hmm, you should rate this curb ramp as 1, passable. This curb ramp is wide enough, has a ' +
+                    'friction strip, and doesn\'t point into traffic. ' +
+                '<span class="bold">Let’s click "1" to change its rating.</span><br> ' +
                 '<img src="' + svl.rootDirectory + "img/onboarding/RatingCurbRampQuality.gif" +
                 '" class="width-75" style="margin: 5px auto;display:block;" alt="Rating curb ramp quality as 1, passable">',
                 "position": "top-right",
@@ -928,7 +933,7 @@ function OnboardingStates (compass, mapService, statusModel, tracker) {
             },
             "message": {
                 "message": 'Now <span class="bold">rate the curb ramp’s quality</span>. ' +
-                'Use your best judgment. You can also write in notes in the <span class="bold">Description Box.</span><br>' +
+                'Use your best judgment. You can also write notes in the <span class="bold">Description Box.</span><br>' +
                 '<img src="' + svl.rootDirectory + "img/onboarding/RatingCurbRampQuality.gif" + '" class="width-75" style="margin: 5px auto;display:block;" alt="Rating curb ramp quality as 1, passable">',
                 "position": "top-right",
                 "parameters": null
@@ -954,8 +959,9 @@ function OnboardingStates (compass, mapService, statusModel, tracker) {
                 "maxLabelCount": 5
             },
             "message": {
-                "message": 'Hmm, you should rate this curb ramp as 1, passable. ' +
-                '<span class="bold">Let\s click "1" to change its rating.</span><br> ' +
+                "message": 'Hmm, you should rate this curb ramp as 1, passable. This curb ramp is wide enough, has a ' +
+                    'friction strip, and doesn\'t point into traffic. ' +
+                '<span class="bold">Let’s click "1" to change its rating.</span><br> ' +
                 '<img src="' + svl.rootDirectory + "img/onboarding/RatingCurbRampQuality.gif" +
                 '" class="width-75" style="margin: 5px auto;display:block;" alt="Rating curb ramp quality as 1, passable">',
                 "position": "top-right",
@@ -979,7 +985,7 @@ function OnboardingStates (compass, mapService, statusModel, tracker) {
                 "maxLabelCount": 4
             },
             "message": {
-                "message": 'Let’s <span class="bold">rate the quality</span> of the curb ramp.<br>' +
+                "message": '<span class="bold">Let’s rate the quality</span> of the curb ramp.<br>' +
                 '<img src="' + svl.rootDirectory + "img/onboarding/RatingCurbRampQuality.gif" +
                 '" class="width-75" style="margin: 5px auto;display:block;" alt="Rating curb ramp quality as 1, passable">',
                 "position": "top-right",
@@ -1006,8 +1012,9 @@ function OnboardingStates (compass, mapService, statusModel, tracker) {
                 "maxLabelCount": 4
             },
             "message": {
-                "message": 'Hmm, you should rate this curb ramp as 1, passable. ' +
-                '<span class="bold">Let\s click "1" to change its rating.</span><br> ' +
+                "message": 'Hmm, you should rate this curb ramp as 1, passable. This curb ramp is wide enough, has a ' +
+                    'friction strip, and doesn\'t point into traffic. ' +
+                '<span class="bold">Let’s click "1" to change its rating.</span><br> ' +
                 '<img src="' + svl.rootDirectory + "img/onboarding/RatingCurbRampQuality.gif" +
                 '" class="width-75" style="margin: 5px auto;display:block;" alt="Rating curb ramp quality as 1, passable">',
                 "position": "top-right",
@@ -1199,7 +1206,7 @@ function OnboardingStates (compass, mapService, statusModel, tracker) {
                 "maxLabelCount": 7
             },
             "message": {
-                "message": 'Let’s <span class="bold">rate the quality</span> of the curb ramp.<br>' +
+                "message": '<span class="bold">Let’s rate the quality</span> of the curb ramp.<br>' +
                 '<img src="' + svl.rootDirectory + "img/onboarding/RatingCurbRampQuality.gif" +
                 '" class="width-75" style="margin: 5px auto;display:block;" ' +
                 'alt="Rating curb ramp quality as 1, passable">',
@@ -1227,8 +1234,9 @@ function OnboardingStates (compass, mapService, statusModel, tracker) {
                 "maxLabelCount": 7
             },
             "message": {
-                "message": 'Hmm, you should rate this curb ramp as 1, passable. ' +
-                '<span class="bold">Let\s click "1" to change its rating.</span><br> ' +
+                "message": 'Hmm, you should rate this curb ramp as 1, passable. This curb ramp is wide enough, has a ' +
+                    'friction strip, and doesn\'t point into traffic. ' +
+                '<span class="bold">Let’s click "1" to change its rating.</span><br> ' +
                 '<img src="' + svl.rootDirectory + "img/onboarding/RatingCurbRampQuality.gif" +
                 '" class="width-75" style="margin: 5px auto;display:block;" ' +
                 'alt="Rating curb ramp quality as 1, passable">',
@@ -1253,7 +1261,7 @@ function OnboardingStates (compass, mapService, statusModel, tracker) {
                 "maxLabelCount": 7
             },
             "message": {
-                "message": 'Great Job! We are almost done. Now let\'s learn how to walk. ' +
+                "message": 'Great Job! We are almost done. Now let’s learn how to walk. ' +
                 '<span class="bold">Grab and drag the Street View image</span>.',
                 "position": "top-right",
                 "parameters": null
@@ -1339,7 +1347,7 @@ function OnboardingStates (compass, mapService, statusModel, tracker) {
                 "maxLabelCount": 7
             },
             "message": {
-                "message": 'Now let\'s actually take a step! <span class="bold">' +
+                "message": 'Now let’s actually take a step! <span class="bold">' +
                 'Double click on the street</span> in the direction you want to move. ' +
                 'In this case, double click in the circle below.',
                 "position": "top-right",
@@ -1452,7 +1460,7 @@ function OnboardingStates (compass, mapService, statusModel, tracker) {
                 "message": 'Ordinarily, you would label the areas under the flashing arrows with a Missing Curb Ramp ' +
                 '<img src="' + svl.rootDirectory + "img/cursors/Cursor_NoCurbRamp.png" +
                 '" style="width: 8%; height:auto" alt="Missing Curb Ramp Label">. ' +
-                'However, we want to get you started on actual missions, so let\'s <span class="bold">finish this ' +
+                'However, we want to get you started on actual missions, so let’s <span class="bold">finish this ' +
                 'tutorial!</span>',
                 "position": "top-right",
                 "width": 400,

--- a/public/javascripts/SVLabel/src/SVLabel/onboarding/OnboardingStates.js
+++ b/public/javascripts/SVLabel/src/SVLabel/onboarding/OnboardingStates.js
@@ -101,7 +101,7 @@ function OnboardingStates (compass, mapService, statusModel, tracker) {
                 "maxLabelCount": 0
             }],
             "message": {
-                "message": 'Good! Now, <span class="bold">click the curb ramp</span> ' +
+                "message": 'Good! Now <span class="bold">click the curb ramp</span> ' +
                 'beneath the flashing yellow arrow to label it.',
                 "position": "top-right",
                 "parameters": null
@@ -138,9 +138,9 @@ function OnboardingStates (compass, mapService, statusModel, tracker) {
                 "maxLabelCount": 1
             },
             "message": {
-                "message": 'Now, you can rate the quality of the curb ramp where 1 is passable and 5 is not ' +
-                'passable for a wheelchair user. ' +
-                '<span class="bold">Let’s rate it as 2, somewhat passable.</span><br> ' +
+                "message": 'Now you can rate the quality of the curb ramp where 1 is passable and 5 is not passable ' +
+                    'for a wheelchair user. Because it points into traffic a bit ' +
+                '<span class="bold">let’s rate it as 2, somewhat passable.</span><br> ' +
                 '<img src="' + svl.rootDirectory + "img/onboarding/RatingCurbRampQuality-severity-2.gif" +
                 '" class="width-75" style="margin: 5px auto;display:block;" alt="Rating curb ramp quality as 2, passable">',
                 "position": "top-right",
@@ -282,7 +282,7 @@ function OnboardingStates (compass, mapService, statusModel, tracker) {
                 "maxLabelCount": 1
             }],
             "message": {
-                "message": 'Now, <span class="bold">click the curb ramp</span> beneath the flashing yellow arrow to label it.',
+                "message": 'Now <span class="bold">click the curb ramp</span> beneath the flashing yellow arrow to label it.',
                 "position": "top-right",
                 "parameters": null
             },
@@ -498,7 +498,7 @@ function OnboardingStates (compass, mapService, statusModel, tracker) {
                 "maxLabelCount": 3
             },
             "message": {
-                "message": 'Now, let’s zoom out and look at the next intersection corner. ' +
+                "message": 'Now let’s zoom out and look at the next intersection corner. ' +
                 '<span class="bold">Click the “Zoom Out” button</span>.',
                 "position": "top-right",
                 "fade-direction": "fadeInUp",
@@ -628,7 +628,7 @@ function OnboardingStates (compass, mapService, statusModel, tracker) {
                 "tolerance": 300
             }],
             "message": {
-                "message": 'Now, <span class="bold">click on one of the curb ramps</span> to label it.',
+                "message": 'Now <span class="bold">click on one of the curb ramps</span> to label it.',
                 "position": "top-right",
                 "parameters": null
             },
@@ -768,7 +768,7 @@ function OnboardingStates (compass, mapService, statusModel, tracker) {
                 "maxLabelCount": 4
             }],
             "message": {
-                "message": 'Now, <span class="bold">click the curb ramp</span> beneath the flashing yellow arrow to label it.',
+                "message": 'Now <span class="bold">click the curb ramp</span> beneath the flashing yellow arrow to label it.',
                 "position": "top-right",
                 "parameters": null
             },
@@ -892,7 +892,7 @@ function OnboardingStates (compass, mapService, statusModel, tracker) {
                 "maxLabelCount": 4
             }],
             "message": {
-                "message": 'Now, <span class="bold">click the curb ramp</span> beneath the flashing yellow arrow to label it.',
+                "message": 'Now <span class="bold">click the curb ramp</span> beneath the flashing yellow arrow to label it.',
                 "position": "top-right",
                 "parameters": null
             },
@@ -1253,7 +1253,7 @@ function OnboardingStates (compass, mapService, statusModel, tracker) {
                 "maxLabelCount": 7
             },
             "message": {
-                "message": 'Great Job! We are almost done. Now, let\'s learn how to walk. ' +
+                "message": 'Great Job! We are almost done. Now let\'s learn how to walk. ' +
                 '<span class="bold">Grab and drag the Street View image</span>.',
                 "position": "top-right",
                 "parameters": null
@@ -1277,7 +1277,7 @@ function OnboardingStates (compass, mapService, statusModel, tracker) {
                 "maxLabelCount": 7
             },
             "message": {
-                "message": 'Good! Now, to figure out where to walk, you will follow the ' +
+                "message": 'Good! Now to figure out where to walk, you will follow the ' +
                 '<span class="bold" style="color: #ff0000;">red</span> line on this mini map.',
                 "position": "top-right",
                 "fade-direction": "fadeInLeft",
@@ -1339,7 +1339,7 @@ function OnboardingStates (compass, mapService, statusModel, tracker) {
                 "maxLabelCount": 7
             },
             "message": {
-                "message": 'Now, let\'s actually take a step! <span class="bold">' +
+                "message": 'Now let\'s actually take a step! <span class="bold">' +
                 'Double click on the street</span> in the direction you want to move. ' +
                 'In this case, double click in the circle below.',
                 "position": "top-right",
@@ -1402,7 +1402,7 @@ function OnboardingStates (compass, mapService, statusModel, tracker) {
                 "maxLabelCount": 7
             },
             "message": {
-                "message": 'Now, you can look for more issues at this ' +
+                "message": 'Now you can look for more issues at this ' +
                 'location. In this case, notice how there is a crosswalk with <span class="bold">no curb ramps</span>.',
                 "position": "top-right",
                 "width": 400,


### PR DESCRIPTION
Resolves #853 

This improves wording in the tutorial. In particular, it lets users know _why_ they should be rating a certain severity when they get it wrong the first time. The full set of text changes was discussed on the #853 thread.

To test, I need someone to go through the tutorial and carefully read each dialog that comes up. So you will need to rate each severity incorrectly on your first attempt so you end up seeing all of the text. Watch out for typos and such.