### PR TITLE
Resolves #1458: Add separate logging for keyboard tag changes

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
@@ -227,6 +227,7 @@ function ContextMenu (uiContextMenu) {
         var label = getTargetLabel();
         var labelTags = label.getProperty('tagIds');
 
+        // Use position of cursor to determine whether or not the click came from the mouse, or from a keyboard shortcut
         var wasClickedByMouse = e.originalEvent.clientX != 0 && e.originalEvent.clientY != 0;
 
         $("body").unbind('click').on('click', 'button', function (e) {

--- a/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
@@ -223,9 +223,11 @@ function ContextMenu (uiContextMenu) {
     /**
      * Records tag ID when clicked and updates tag color
      */
-    function _handleTagClick () {
+    function _handleTagClick (e) {
         var label = getTargetLabel();
         var labelTags = label.getProperty('tagIds');
+
+        var wasClickedByMouse = e.originalEvent.clientX != 0 && e.originalEvent.clientY != 0;
 
         $("body").unbind('click').on('click', 'button', function (e) {
             if (e.target.name == 'tag') {
@@ -246,13 +248,23 @@ function ContextMenu (uiContextMenu) {
                             }
 
                             labelTags.push(tag.tag_id);
-                            svl.tracker.push('ContextMenu_TagAdded',
-                                {tagId: tag.tag_id, tagName: tag.tag});
+                            if (wasClickedByMouse) {
+                                svl.tracker.push('ContextMenu_TagAdded',
+                                    {tagId: tag.tag_id, tagName: tag.tag});
+                            } else {
+                                svl.tracker.push('KeyboardShortcut_TagAdded',
+                                    {tagId: tag.tag_id, tagName: tag.tag});
+                            }
                         } else {
                             var index = labelTags.indexOf(tag.tag_id);
                             labelTags.splice(index, 1);
-                            svl.tracker.push('ContextMenu_TagRemoved',
-                                {tagId: tag.tag_id, tagName: tag.tag});
+                            if (wasClickedByMouse) {
+                                svl.tracker.push('ContextMenu_TagRemoved',
+                                    {tagId: tag.tag_id, tagName: tag.tag});
+                            } else {
+                                svl.tracker.push('KeyboardShortcut_TagRemoved',
+                                    {tagId: tag.tag_id, tagName: tag.tag});
+                            }
                         }
                         _toggleTagColor(labelTags, tag.tag_id, e.target);
                         label.setProperty('tagIds', labelTags);


### PR DESCRIPTION
Resolves #1458 

Adds a separate log entry in `audit_tak_interaction` for when a user selects a tag with a keyboard shortcut as opposed to clicking on it. 

To test: ensure that the `audit_task_interaction` table now has `KeyboardShortcut_TagRemoved` and `KeyboardShortcut_TagAdded` logs when appropriate. 