### PR TITLE
1390-redesign-validation-buttons

### DIFF
--- a/app/views/validation.scala.html
+++ b/app/views/validation.scala.html
@@ -117,17 +117,17 @@
             </div>
 
             <div id="validation-button-holder">
-                <button id="validation-agree-button" class="validation-button">
-                    <img src='@routes.Assets.at("javascripts/SVValidate/img/Checkmark.png")' class="validation-status-icon" alt="Agree" align="">
-                    <u>A</u>gree
+                <button id="validation-not-sure-button" class="validation-button">
+                    <img src='@routes.Assets.at("javascripts/SVValidate/img/QuestionMark.png")' class="validation-status-icon" alt="Not sure" align="">
+                    <u>N</u>ot sure
                 </button>
                 <button id="validation-disagree-button" class="validation-button">
                     <img src='@routes.Assets.at("javascripts/SVValidate/img/Cross.png")' class="validation-status-icon" alt="Disagree" align="">
                     <u>D</u>isagree
                 </button>
-                <button id="validation-not-sure-button" class="validation-button">
-                    <img src='@routes.Assets.at("javascripts/SVValidate/img/QuestionMark.png")' class="validation-status-icon" alt="Not sure" align="">
-                    <u>N</u>ot sure
+                <button id="validation-agree-button" class="validation-button">
+                    <img src='@routes.Assets.at("javascripts/SVValidate/img/Checkmark.png")' class="validation-status-icon" alt="Agree" align="">
+                    <u>A</u>gree
                 </button>
             </div>
             <div id="modal-comment-background"></div>


### PR DESCRIPTION
Fixes #1390
reversed the order of the validation buttons to match validation layout for mobile.
new design on desktop:
![image](https://user-images.githubusercontent.com/21998904/53145068-a6e39080-3553-11e9-98a5-5bf8c39a16d2.png)
old design on desktop:
![image](https://user-images.githubusercontent.com/21998904/53145252-57ea2b00-3554-11e9-8ca3-fc270ee8ceb6.png)
