### PR TITLE
Resolves #1490: Arrow keys now move properly

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/Tracker.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Tracker.js
@@ -53,7 +53,7 @@ function Tracker () {
     };
 
     this._isContextMenuClose = function (action) {
-        return action.indexOf("ContextMenu_Close") >= 0 || action.indexOf("ContextMenu_OKButtonClick") >= 0;
+        return action === "ContextMenu_Close";
     };
 
     this._isDeleteLabelAction = function (action) {

--- a/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
@@ -324,14 +324,13 @@ function ContextMenu (uiContextMenu) {
     function hide () {
         if(isOpen()) {
             $descriptionTextBox.blur(); // force the blur event before the ContextMenu close event
+            svl.tracker.push('ContextMenu_Close');
         }
 
         $menuWindow.css('visibility', 'hidden');
         $connector.css('visibility', 'hidden');
         setBorderColor('black');
         setStatus('visibility', 'hidden');
-
-        svl.tracker.push('ContextMenu_Close');
         return this;
     }
 


### PR DESCRIPTION
Resolves #1490 

ContextMenu_Close is now the only "context menu close event" and only triggers when the context menu is open.

To test:
- Ensure that arrow keys work properly when moving