### PR TITLE
Resolves #965: Temporary label IDs properly null after ContextMenu

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
@@ -21,11 +21,11 @@ function ContextMenu (uiContextMenu) {
         //event.stopPropagation();
         var clicked_out = !(context_menu_el.contains(event.target));
         if (isOpen()){
-            hide();
             if (clicked_out) {
              svl.tracker.push('ContextMenu_CloseClickOut');
             handleSeverityPopup();
             }
+            hide();
         }
     }); //handles clicking outside of context menu holder
     //document.addEventListener("mousedown", hide);
@@ -127,16 +127,16 @@ function ContextMenu (uiContextMenu) {
     }
 
     function handleCloseButtonClick () {
-        hide();
         svl.tracker.push('ContextMenu_CloseButtonClick');
         handleSeverityPopup();
+        hide();
 
     }
 
     function _handleOKButtonClick () {
-        hide();
         svl.tracker.push('ContextMenu_OKButtonClick');
         handleSeverityPopup();
+        hide();
 
     }
 

--- a/public/javascripts/SVLabel/src/SVLabel/keyboard/Keyboard.js
+++ b/public/javascripts/SVLabel/src/SVLabel/keyboard/Keyboard.js
@@ -300,8 +300,8 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
                         break;
                     case 90:
                         if (contextMenu.isOpen()) {
-                            contextMenu.hide();
                             svl.tracker.push("KeyboardShortcut_CloseContextMenu");
+                            contextMenu.hide();
                         }
                         // "z" for zoom. By default, it will zoom in. If "shift" is down, it will zoom out.
                         // if shift was down w/in 100 ms of the z up, then it will also zoom out. 
@@ -421,17 +421,17 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
                     // "Enter"
                     if(contextMenu.isOpen()) {
                         svl.tracker.push("KeyboardShortcut_CloseContextMenu");
-                        contextMenu.hide();
                         contextMenu.handleSeverityPopup();
                         svl.tracker.push("ContextMenu_ClosePressEnter");
+                        contextMenu.hide();
                     }
                     break;
                 case 27:
                     // "Escape"
                     if(contextMenu.isOpen()) {
                         svl.tracker.push("KeyboardShortcut_CloseContextMenu");
-                        contextMenu.hide();
                         svl.tracker.push("ContextMenu_CloseKeyboardShortcut");
+                        contextMenu.hide();
                     }
 
                     if (canvas.getStatus('drawing')) {
@@ -451,10 +451,10 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
     function _closeContextMenu(key) {
         if (contextMenu.isOpen()) {
             svl.tracker.push("KeyboardShortcut_CloseContextMenu");
-            contextMenu.hide();
             svl.tracker.push("ContextMenu_CloseKeyboardShortcut", {
                 keyCode: key
             });
+            contextMenu.hide();
         }
     }
 

--- a/public/javascripts/SVLabel/src/SVLabel/onboarding/Onboarding.js
+++ b/public/javascripts/SVLabel/src/SVLabel/onboarding/Onboarding.js
@@ -833,8 +833,8 @@ function Onboarding(svl, audioEffect, compass, form, handAnimation, mapService, 
         var callback = function () {
             if (listener) google.maps.event.removeListener(listener);
             $target.off("click", callback);
-            contextMenu.hide();
             tracker.push("ContextMenu_CloseOnboarding");
+            contextMenu.hide();
             next.call(this, state.transition);
         };
         $target.on("click", callback);


### PR DESCRIPTION
Resolves #965

I moved `contextMenu.hide()` calls to after the logging of `ContextMenu_Close...` events.

To test:
- Ensure that temporary label IDs are null when not in context menu