### PR TITLE
Resolves #1501: Improves how labels are loaded on the validation interface

### DIFF
--- a/public/javascripts/SVValidate/src/panorama/Panorama.js
+++ b/public/javascripts/SVValidate/src/panorama/Panorama.js
@@ -6,7 +6,6 @@
  */
 function Panorama (label) {
     var currentLabel = label;
-    var init = true;
     var panoCanvas = document.getElementById("svv-panorama");
     var panorama = undefined;
     var properties = {
@@ -30,6 +29,7 @@ function Panorama (label) {
      */
     function _init () {
         _createNewPanorama();
+        _addListeners();
         setLabel(currentLabel);
     }
 
@@ -213,27 +213,16 @@ function Panorama (label) {
         setProperty("panoId", panoId);
         setProperty("prevPanoId", panoId);
 
-        if (init) {
+        // Adding in callback function because there are some issues with Google Maps
+        // setPano function. Will start to running an infinite loop if panorama does not
+        // load in time.
+        function changePano() {
             panorama.setPano(panoId);
             panorama.set('pov', {heading: heading, pitch: pitch});
             panorama.set('zoom', zoomLevel[zoom]);
-            _addListeners();
-            init = false;
-        } else {
-
-            // Adding in callback function because there are some issues with Google Maps
-            // setPano function. Will start to running an infinite loop if panorama does not
-            // load in time.
-            function changePano() {
-                _createNewPanorama();
-                _addListeners();
-                panorama.setPano(panoId);
-                panorama.set('pov', {heading: heading, pitch: pitch});
-                panorama.set('zoom', zoomLevel[zoom]);
-                renderLabel();
-            }
-            setTimeout(changePano, 300);
+            renderLabel();
         }
+        setTimeout(changePano, 300);
         return this;
     }
 


### PR DESCRIPTION
Resolves #1501 

It looks like we're creating a new panorama every time we load a new validation label onto the screen. I think this used to be necessary for avoiding some GSV infinite loop bugs when we changed panorama IDs. I don't think this is necessary anymore since we've changed the way we're loading labels (+ creating a new panorama every time is super slow!).

**Testing Instructions**
* Go to the validation interface
* Stress test the system by hitting keyboard shortcuts / clicking the button quickly. Make sure we don't go into an infinite loop! (this happens if you see the panomarker jumping around + a black screen)