### PR TITLE
added version info to footer

### DIFF
--- a/app/models/user/VersionTable.scala
+++ b/app/models/user/VersionTable.scala
@@ -4,6 +4,7 @@ import java.sql.Timestamp
 
 import models.utils.MyPostgresDriver.simple._
 import play.api.Play.current
+import java.text.SimpleDateFormat
 
 case class Version(versionId: String, versionStartTime: Timestamp, description: Option[String])
 
@@ -28,6 +29,17 @@ object VersionTable {
 
   def all: List[Version] = db.withSession { implicit session =>
     versions.list
+  }
+
+  /**
+    * Formats the current version of the code in the format "Version <version_number> | Last Updated: <version_time>"
+    *
+    * @return
+    */
+  def currentVersionStr(): String = db.withSession { implicit session =>
+    val currentVersion = versions.sortBy(_.versionStartTime.desc).list.head
+    val timestampAsDate: String = new SimpleDateFormat("yyyy-MM-dd").format(currentVersion.versionStartTime)
+    s"Version ${currentVersion.versionId} | Last Updated: $timestampAsDate"
   }
 }
 

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -1,4 +1,5 @@
 @import models.user.User
+@import models.user.VersionTable
 @(title: String, url: Option[String] = Some("/"))(content: Html)
 
 
@@ -78,7 +79,7 @@
           <a href="https://makeabilitylab.cs.washington.edu/">Makeability Lab</a> at the
           <a href="http://www.umd.edu/">University of Maryland</a> and
               <a href="http://www.uw.edu/" id="umd-link">University of Washington</a><br>
-          <span id="application-version"></span>
+          <span id="application-version">@VersionTable.currentVersionStr()</span>
         </div>
 
     } else{
@@ -143,7 +144,7 @@
         <a href="https://makeabilitylab.cs.washington.edu/" id="makeability-link">Makeability Lab</a> at the
         <a href="http://www.umd.edu/" id="umd-link">University of Maryland</a> and
         <a href="http://www.uw.edu/" id="umd-link">University of Washington</a><br>
-        <span id="application-version"></span>
+        <span id="application-version">@VersionTable.currentVersionStr()</span>
     </div>
 
   }


### PR DESCRIPTION
Resolves #1350 

Adds version information to the footer of the website. Here is what it looks like:

![footer-with-version-new](https://user-images.githubusercontent.com/6518824/53661848-45d45080-3c16-11e9-9a28-964ec293bf3f.png)

To test, go around to some different pages of the site and make sure the footer has the correctly formatted version information. Specifically make sure to check the audit page, b/c it is handled differently from other pages.

