### PR TITLE
1355 updated gmaps api account

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,7 @@ download
 # Keys
 rootkey.csv
 special_api_key.txt
+google_maps_api_key.txt
 
 # sidewalk-webpage-binary directory
 sidewalk-webpage/

--- a/README.md
+++ b/README.md
@@ -9,37 +9,39 @@ The development environment is set up using Docker containers. Hence, in order t
 ### Running the Application Locally
 To run the web server locally, from the root of the SidewalkWebpage directory:
 
+1. Email Mikey (michaelssaugstad@gmail.com) and ask for the two API key files and a database dump. You will put the API key files into the root directory of the project. You will need the database dump later on. You can continue with the rest of the instructions here, but the website will not work fully until you've received these three files from Mikey.
+
 1. Run `make dev`. This will download the docker images and spin up the containers. The containers will have all the necessary packages and tools so no installation is necessary. Though, the container executes a bash shell running Ubuntu Jessie, which allows you to install whatever tool you prefer that can run on this flavor of linux (vi, etc.). This command also sets up the `sidewalk` database with the schema (just the schema, not the data - see Importing SQL dump in Additional Tools section) from the production dump, which lives in `db/schema.sql`. Successful output of this command will look like:
 
-```
-Successfully built [container-id]
-Successfully tagged projectsidewalk/web:latest
-WARNING: Image for service web was built because it did not already exist. To rebuild this image you must use `docker-compose build` or `docker-compose up --build`.
-root@[container-id]:/opt#
-```
+    ```
+    Successfully built [container-id]
+    Successfully tagged projectsidewalk/web:latest
+    WARNING: Image for service web was built because it did not already exist. To rebuild this image you must use `docker-compose build` or `docker-compose up --build`.
+    root@[container-id]:/opt#
+    ```
 
-2. Run `npm start`. The result of this command is dictated by what `start` is supposed to do as defined in `package.json` file. As per the current code, running this command will run `grunt watch` & `sbt compile "~ run"` (`~` here is triggered execution that allows for the server to run in watch mode). This should start the web server. Note that the first time compilation takes time. Successful output of this command will look like:
+1. Run `npm start`. The result of this command is dictated by what `start` is supposed to do as defined in `package.json` file. As per the current code, running this command will run `grunt watch` & `sbt compile "~ run"` (`~` here is triggered execution that allows for the server to run in watch mode). This should start the web server. Note that the first time compilation takes time. Successful output of this command will look like:
 
-```
-> grunt watch & sbt clean "~ run"
+    ```
+    > grunt watch & sbt clean "~ run"
 
-Running "watch" task
-Waiting...
-[info] Loading project definition from /opt/project
-[info] Set current project to sidewalk-webpage (in build file:/opt/)
-[success] Total time: 78 s, completed Dec 20, 2018 8:06:19 AM
-[info] Updating {file:/opt/}root...
-[info] Resolving it.geosolutions.jaiext.errordiffusion#jt-errordiffusion;1.0.8 .[info] Resolving org.fusesource.jansi#jansi;1.4 ...
-[info] Done updating.
+    Running "watch" task
+    Waiting...
+    [info] Loading project definition from /opt/project
+    [info] Set current project to sidewalk-webpage (in build file:/opt/)
+    [success] Total time: 78 s, completed Dec 20, 2018 8:06:19 AM
+    [info] Updating {file:/opt/}root...
+    [info] Resolving it.geosolutions.jaiext.errordiffusion#jt-errordiffusion;1.0.8 .[info] Resolving org.fusesource.jansi#jansi;1.4 ...
+    [info] Done updating.
 
---- (Running the application, auto-reloading is enabled) ---
+    --- (Running the application, auto-reloading is enabled) ---
 
-[info] play - Listening for HTTP on /0.0.0.0:9000
+    [info] play - Listening for HTTP on /0.0.0.0:9000
 
-(Server started, use Ctrl+D to stop and go back to the console...)
-```
+    (Server started, use Ctrl+D to stop and go back to the console...)
+    ```
 
-3. Head on over to your browser and navigate to `127.0.0.1:9000`. This should display the Project Sidewalk webpage. Note that the first time compilation takes time.
+4. Head on over to your browser and navigate to `127.0.0.1:9000`. This should display the Project Sidewalk webpage. Note that the first time compilation takes time.
 
 ### Additional Tools
 1. Importing SQL dump: The Postgres database schema has already been set up in the db docker container. To import production db dump, get the dump as per [instructions](https://github.com/ProjectSidewalk/Instructions), rename the file `[database]-dump`, place it in the `db` folder, and run `make import-dump db=[database]` from the base folder. Note: Restart the server once the dump is complete.

--- a/README.md
+++ b/README.md
@@ -41,63 +41,62 @@ To run the web server locally, from the root of the SidewalkWebpage directory:
     (Server started, use Ctrl+D to stop and go back to the console...)
     ```
 
-4. Head on over to your browser and navigate to `127.0.0.1:9000`. This should display the Project Sidewalk webpage. Note that the first time compilation takes time.
+1. Head on over to your browser and navigate to `127.0.0.1:9000`. This should display the Project Sidewalk webpage. Note that the first time compilation takes time.
 
 ### Additional Tools
 1. Importing SQL dump: The Postgres database schema has already been set up in the db docker container. To import production db dump, get the dump as per [instructions](https://github.com/ProjectSidewalk/Instructions), rename the file `[database]-dump`, place it in the `db` folder, and run `make import-dump db=[database]` from the base folder. Note: Restart the server once the dump is complete.
 
-2. SSH into containers: To ssh into the containers, run `make ssh target=[web|db]`. Note that `[web|db]` is not a literal syntax, it specifies which container you would want to ssh into. For example, you can do `make ssh target=web`.
+1. SSH into containers: To ssh into the containers, run `make ssh target=[web|db]`. Note that `[web|db]` is not a literal syntax, it specifies which container you would want to ssh into. For example, you can do `make ssh target=web`.
 
 ### Making changes
 1. If you make any changes to the `build.sbt` or the configs, you'd need to press `Ctrl+D` and then `sbt clean` and then `npm start`.
 
-2. If you make any changes to the views or other scala files, these changes will be automatically picked up by `sbt`. You'd need to reload the browser once the compilation finishes. For example, a change to `index.scala.html` file results in:
+1. If you make any changes to the views or other scala files, these changes will be automatically picked up by `sbt`. You'd need to reload the browser once the compilation finishes. For example, a change to `index.scala.html` file results in:
 
-```
-[info] Compiling 1 Scala source to /opt/target/scala-2.10/classes...
-[success] Compiled in 260s
+    ```
+    [info] Compiling 1 Scala source to /opt/target/scala-2.10/classes...
+    [success] Compiled in 260s
 
---- (RELOAD) ---
+    --- (RELOAD) ---
 
-[info] play - Shutdown application default Akka system.
-[info] play - database [default] connected at jdbc:postgresql://db:5432/sidewalk
-[info] play - Starting application default Akka system.
-[info] play - Application started (Dev)
-[success] Compiled in 124s
-```
+    [info] play - Shutdown application default Akka system.
+    [info] play - database [default] connected at jdbc:postgresql://db:5432/sidewalk
+    [info] play - Starting application default Akka system.
+    [info] play - Application started (Dev)
+    [success] Compiled in 124s
+    ```
 
-3. If you make any changes to the assets (look in `Gruntfile.js` under `watch` block), these changes will be picked up by `grunt`. You'd need to reload the browser once the compilation finishes. For example, a change to `public/javascripts/FAQ/src/tableOfContents.js` file results in (output has been trimmed):
+1. If you make any changes to the assets (look in `Gruntfile.js` under `watch` block), these changes will be picked up by `grunt`. You'd need to reload the browser once the compilation finishes. For example, a change to `public/javascripts/FAQ/src/tableOfContents.js` file results in (output has been trimmed):
 
-```
->> File "public/javascripts/FAQ/src/tableOfContents.js" changed.
-Running "concat:dist_svl" (concat) task
-Running "concat:dist_progress" (concat) task
-Running "concat:dist_admin" (concat) task
-Running "concat:dist_faq" (concat) task
-Running "concat_css:all" (concat_css) task
-File "public/javascripts/SVLabel/build/SVLabel.css" created.
+    ```
+    >> File "public/javascripts/FAQ/src/tableOfContents.js" changed.
+    Running "concat:dist_svl" (concat) task
+    Running "concat:dist_progress" (concat) task
+    Running "concat:dist_admin" (concat) task
+    Running "concat:dist_faq" (concat) task
+    Running "concat_css:all" (concat_css) task
+    File "public/javascripts/SVLabel/build/SVLabel.css" created.
 
-Done.
-Completed in 23.905s at Thu Dec 20 2018 09:31:45 GMT+0000 (Coordinated Universal Time) - Waiting...
+    Done.
+    Completed in 23.905s at Thu Dec 20 2018 09:31:45 GMT+0000 (Coordinated Universal Time) - Waiting...
 
-[success] Compiled in 90s
-```
+    [success] Compiled in 90s
+    ```
 
 ### Debugging Notes
 1. As mentioned above, `npm start` is a shorthand to run `grunt watch` and `sbt run`. If you prefer, you can manually run these separately (and can, for this matter, choose to use `activator` instead of `sbt`). `activator run` or `sbt run` needs to be run on the top directory where `build.sbt` is located. For `grunt`, run `grunt watch` so the changes you make to SVLabel JavaScript library will be automatically built on file updates. If `grunt watch` is not responding, you can run `grunt concat` and `grunt concat_css` to build the files.
 
-2. If you see an error like:
+1. If you see an error like:
+    ```
+    Execution exception[[NoSuchElementException: None.get]]
+    ```
 
-```
-Execution exception[[NoSuchElementException: None.get]]
-```
-
-This is because the data from the database is missing and you'd need to import the sql dump. The schema import that's a part of init script only sets the schema and does not import the data.
+    This is because the data from the database is missing and you'd need to import the sql dump. The schema import that's a part of init script only sets the schema and does not import the data.
 
 ## Running the Application Remotely
 To run the application remotely,
 
 1. Use Play's dist tool to create jar files of the project (i,e., `activator dist`): https://www.playframework.com/documentation/2.3.x/ProductionDist
-2. Upload the zip file to the web server
-3. SSH into the server and unarchive the zip file (e.g., `unzip filename`).
-4. Run `nohup bin/sidewalk-webpage -Dhttp.port=9000 &` ([reference](http://alvinalexander.com/scala/play-framework-deploying-application-production-server)). Sometimes the application tells you that port 9000 (i.e., default port for a Play app) is taken. To kill an application that is occupying the port, first identify pid with the netstat command `netstat -tulpn | grep :9000` and then use the `kill` command.
+1. Upload the zip file to the web server
+1. SSH into the server and unarchive the zip file (e.g., `unzip filename`).
+1. Run `nohup bin/sidewalk-webpage -Dhttp.port=9000 &` ([reference](http://alvinalexander.com/scala/play-framework-deploying-application-production-server)). Sometimes the application tells you that port 9000 (i.e., default port for a Play app) is taken. To kill an application that is occupying the port, first identify pid with the netstat command `netstat -tulpn | grep :9000` and then use the `kill` command.

--- a/app/models/user/VersionTable.scala
+++ b/app/models/user/VersionTable.scala
@@ -6,6 +6,8 @@ import models.utils.MyPostgresDriver.simple._
 import play.api.Play.current
 import java.text.SimpleDateFormat
 
+import scala.io.Source
+
 case class Version(versionId: String, versionStartTime: Timestamp, description: Option[String])
 
 class VersionTable(tag: Tag) extends Table[Version](tag, Some("sidewalk"), "version") {
@@ -40,6 +42,19 @@ object VersionTable {
     val currentVersion = versions.sortBy(_.versionStartTime.desc).list.head
     val timestampAsDate: String = new SimpleDateFormat("yyyy-MM-dd").format(currentVersion.versionStartTime)
     s"Version ${currentVersion.versionId} | Last Updated: $timestampAsDate"
+  }
+
+  /**
+    * Reads in Google Maps API key from google_maps_api_key.txt (ask Mikey Saugstad for the file if you don't have it)
+    *
+    * @return
+    */
+  def getGoogleMapsAPIKey(): String = {
+    val bufferedSource = Source.fromFile("google_maps_api_key.txt")
+    val lines = bufferedSource.getLines()
+    val key: String = lines.next()
+    bufferedSource.close
+    key
   }
 }
 

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -33,7 +33,7 @@
     <script src='@routes.Assets.at("javascripts/lib/leaflet-omnivore.min.js")'></script>
     <script src='@routes.Assets.at("javascripts/lib/js.cookie.js")'></script>
     <script type="text/javascript"
-        src="https://maps.googleapis.com/maps/api/js?v=quarterly&key=AIzaSyB0ToxwyHzvubTo9gm0zbtECWuEe3yYo8M&libraries=geometry">
+        src="https://maps.googleapis.com/maps/api/js?v=quarterly&key=AIzaSyB340rRhzcPaLHTqYbnz5T73abRQOv01FM&libraries=geometry">
     </script>
     <link href='@routes.Assets.at("stylesheets/fonts.css")' rel="stylesheet"/>
     <link href='@routes.Assets.at("stylesheets/mapbox.css")' rel='stylesheet' />

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -33,7 +33,7 @@
     <script src='@routes.Assets.at("javascripts/lib/leaflet-omnivore.min.js")'></script>
     <script src='@routes.Assets.at("javascripts/lib/js.cookie.js")'></script>
     <script type="text/javascript"
-        src="https://maps.googleapis.com/maps/api/js?v=quarterly&key=AIzaSyB340rRhzcPaLHTqYbnz5T73abRQOv01FM&libraries=geometry">
+        src="https://maps.googleapis.com/maps/api/js?v=quarterly&key=@VersionTable.getGoogleMapsAPIKey()&libraries=geometry">
     </script>
     <link href='@routes.Assets.at("stylesheets/fonts.css")' rel="stylesheet"/>
     <link href='@routes.Assets.at("stylesheets/mapbox.css")' rel='stylesheet' />

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -33,7 +33,7 @@
     <script src='@routes.Assets.at("javascripts/lib/leaflet-omnivore.min.js")'></script>
     <script src='@routes.Assets.at("javascripts/lib/js.cookie.js")'></script>
     <script type="text/javascript"
-        src="https://maps.googleapis.com/maps/api/js?v=3.31&key=AIzaSyB0ToxwyHzvubTo9gm0zbtECWuEe3yYo8M&libraries=geometry">
+        src="https://maps.googleapis.com/maps/api/js?v=quarterly&key=AIzaSyB0ToxwyHzvubTo9gm0zbtECWuEe3yYo8M&libraries=geometry">
     </script>
     <link href='@routes.Assets.at("stylesheets/fonts.css")' rel="stylesheet"/>
     <link href='@routes.Assets.at("stylesheets/mapbox.css")' rel='stylesheet' />


### PR DESCRIPTION
Resolves #1355 
Resolves #1356 

Changes
1. Switched our Google Maps API version from saying 3.3.1 to "quarterly", which is the "stable" version of the API (which is updated quarterly). Version 3.1.1 was already technically deleted and we were being forced into the quarterly version, but since we didn't specify "quarterly" we were getting a warning in the console whenever we used GSV.
1. Switched out the old API key that was linked to @manaswis's account. We are now using a ML lab one.
1. Removed the API key from the actual codebase. It now lives in a file that won't be in our source tree. People will thus have to ask me for the API key so they can add it to their own dev environments. This is important so that randos can't scrape Github to find GMaps API keys and use them.
1. Updated the README instructions to say that people need to ask me (Mikey) for the API keys (and also the database dump).
1. Made other minor format changes to README.md (just messed with some indentation).

To test:
1. Ask me for the GMaps API key file and put it in the root directory of the repo.
1. Load the audit and validation pages to make sure that we can still look at Google Street View. 