### PR TITLE
Resolves #1418: "Start Mapping" & turker analytics

### DIFF
--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -362,8 +362,7 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
   /** Returns all records in the webpage_interactions table as a JSON array. */
   def getAllWebpageActivities = UserAwareAction.async{implicit request =>
     if (isAdmin(request.identity)){
-      val x = WebpageActivityTable.getAllActivities
-      Future.successful(Ok(Json.arr(WebpageActivityTable.webpageActivityListToJson(x))))
+      Future.successful(Ok(Json.arr(WebpageActivityTable.webpageActivityListToJson(WebpageActivityTable.getAllActivities))))
     }else{
       Future.successful(Redirect("/"))
     }

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -346,7 +346,7 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
     *
     * @param activity
     */
-  def getWebpageActivities(activity: String) = UserAwareAction.async{implicit request =>
+  def getWebpageActivities(activity: String) = UserAwareAction.async{ implicit request =>
     if (isAdmin(request.identity)) {
       val activities = WebpageActivityTable.webpageActivityListToJson(WebpageActivityTable.findKeyVal(activity, Array()))
       Future.successful(Ok(Json.arr(activities)))
@@ -356,10 +356,10 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
   }
 
   /** Returns all records in the webpage_interactions table as a JSON array. */
-  def getAllWebpageActivities = UserAwareAction.async{implicit request =>
-    if (isAdmin(request.identity)){
+  def getAllWebpageActivities = UserAwareAction.async{ implicit request =>
+    if (isAdmin(request.identity)) {
       Future.successful(Ok(Json.arr(WebpageActivityTable.webpageActivityListToJson(WebpageActivityTable.getAllActivities))))
-    }else{
+    } else {
       Future.successful(Redirect("/"))
     }
   }
@@ -371,38 +371,38 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
     * @param keyValPairs
     * @return
     */
-  def getWebpageActivitiesKeyVal(activity: String, keyValPairs: String) = UserAwareAction.async{ implicit request =>
-    if (isAdmin(request.identity)){
+  def getWebpageActivitiesKeyVal(activity: String, keyValPairs: String) = UserAwareAction.async { implicit request =>
+    if (isAdmin(request.identity)) {
       val keyVals: Array[String] = keyValPairs.split("/").map(URLDecoder.decode(_, "UTF-8"))
       val activities = WebpageActivityTable.webpageActivityListToJson(WebpageActivityTable.findKeyVal(activity, keyVals))
       Future.successful(Ok(Json.arr(activities)))
-    }else{
+    } else {
       Future.successful(Redirect("/"))
     }
   }
 
   /** Returns number of records in webpage_activity table containing the specified activity. */
-  def getNumWebpageActivities(activity: String) =   UserAwareAction.async{implicit request =>
-    if (isAdmin(request.identity)){
+  def getNumWebpageActivities(activity: String) =   UserAwareAction.async { implicit request =>
+    if (isAdmin(request.identity)) {
       val activities = WebpageActivityTable.webpageActivityListToJson(WebpageActivityTable.findKeyVal(activity, Array()))
       Future.successful(Ok(activities.length + ""))
-    }else{
+    } else {
       Future.successful(Redirect("/"))
     }
   }
 
   /** Returns number of records in webpage_activity table containing the specified activity and other keyValPairs. */
-  def getNumWebpageActivitiesKeyVal(activity: String, keyValPairs: String) = UserAwareAction.async{ implicit request =>
-    if (isAdmin(request.identity)){
+  def getNumWebpageActivitiesKeyVal(activity: String, keyValPairs: String) = UserAwareAction.async { implicit request =>
+    if (isAdmin(request.identity)) {
       val keyVals: Array[String] = keyValPairs.split("/").map(URLDecoder.decode(_, "UTF-8")).map(URLDecoder.decode(_, "UTF-8"))
       val activities = WebpageActivityTable.webpageActivityListToJson(WebpageActivityTable.findKeyVal(activity, keyVals))
       Future.successful(Ok(activities.length + ""))
-    }else{
+    } else {
       Future.successful(Redirect("/"))
     }
   }
 
-  def setUserRole = UserAwareAction.async(BodyParsers.parse.json){ implicit request =>
+  def setUserRole = UserAwareAction.async(BodyParsers.parse.json) { implicit request =>
     val submission = request.body.validate[UserRoleSubmission]
 
     submission.fold(
@@ -413,7 +413,7 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
         val userId = UUID.fromString(submission.userId)
         val newRole = submission.roleId
 
-        if(isAdmin(request.identity)){
+        if(isAdmin(request.identity)) {
           UserTable.findById(userId) match {
             case Some(user) =>
               if(UserRoleTable.getRole(userId) == "Owner") {

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -347,14 +347,10 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
     * @param activity
     */
   def getWebpageActivities(activity: String) = UserAwareAction.async{implicit request =>
-    if (isAdmin(request.identity)){
+    if (isAdmin(request.identity)) {
       val activities = WebpageActivityTable.webpageActivityListToJson(WebpageActivityTable.findKeyVal(activity, Array()))
-      if(activities.length == 0){
-        Future.successful(BadRequest(Json.obj("status" -> "Error", "message" -> "Invalid activity name")))
-      } else {
-        Future.successful(Ok(Json.arr(activities)))
-      }
-    }else{
+      Future.successful(Ok(Json.arr(activities)))
+    } else {
       Future.successful(Redirect("/"))
     }
   }

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -348,7 +348,6 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
     */
   def getWebpageActivities(activity: String) = UserAwareAction.async{implicit request =>
     if (isAdmin(request.identity)){
-      println("k")
       val activities = WebpageActivityTable.webpageActivityListToJson(WebpageActivityTable.findKeyVal(activity, Array()))
       if(activities.length == 0){
         Future.successful(BadRequest(Json.obj("status" -> "Error", "message" -> "Invalid activity name")))
@@ -356,7 +355,6 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
         Future.successful(Ok(Json.arr(activities)))
       }
     }else{
-      println("L")
       Future.successful(Redirect("/"))
     }
   }
@@ -364,11 +362,9 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
   /** Returns all records in the webpage_interactions table as a JSON array. */
   def getAllWebpageActivities = UserAwareAction.async{implicit request =>
     if (isAdmin(request.identity)){
-      println("admin path")
       val x = WebpageActivityTable.getAllActivities
       Future.successful(Ok(Json.arr(WebpageActivityTable.webpageActivityListToJson(x))))
     }else{
-      println("no")
       Future.successful(Redirect("/"))
     }
   }
@@ -382,13 +378,10 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
     */
   def getWebpageActivitiesKeyVal(activity: String, keyValPairs: String) = UserAwareAction.async{ implicit request =>
     if (isAdmin(request.identity)){
-      println("a")
       val keyVals: Array[String] = keyValPairs.split("/").map(URLDecoder.decode(_, "UTF-8"))
       val activities = WebpageActivityTable.webpageActivityListToJson(WebpageActivityTable.findKeyVal(activity, keyVals))
-      println("activities: " + activities.mkString(" "))
       Future.successful(Ok(Json.arr(activities)))
     }else{
-      println("b")
       Future.successful(Redirect("/"))
     }
   }
@@ -396,11 +389,9 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
   /** Returns number of records in webpage_activity table containing the specified activity. */
   def getNumWebpageActivities(activity: String) =   UserAwareAction.async{implicit request =>
     if (isAdmin(request.identity)){
-      println("c")
       val activities = WebpageActivityTable.webpageActivityListToJson(WebpageActivityTable.findKeyVal(activity, Array()))
       Future.successful(Ok(activities.length + ""))
     }else{
-      println("d")
       Future.successful(Redirect("/"))
     }
   }
@@ -408,12 +399,10 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
   /** Returns number of records in webpage_activity table containing the specified activity and other keyValPairs. */
   def getNumWebpageActivitiesKeyVal(activity: String, keyValPairs: String) = UserAwareAction.async{ implicit request =>
     if (isAdmin(request.identity)){
-      println("e")
       val keyVals: Array[String] = keyValPairs.split("/").map(URLDecoder.decode(_, "UTF-8")).map(URLDecoder.decode(_, "UTF-8"))
       val activities = WebpageActivityTable.webpageActivityListToJson(WebpageActivityTable.findKeyVal(activity, keyVals))
       Future.successful(Ok(activities.length + ""))
     }else{
-      println("f")
       Future.successful(Redirect("/"))
     }
   }

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -348,6 +348,7 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
     */
   def getWebpageActivities(activity: String) = UserAwareAction.async{implicit request =>
     if (isAdmin(request.identity)){
+      println("k")
       val activities = WebpageActivityTable.webpageActivityListToJson(WebpageActivityTable.findKeyVal(activity, Array()))
       if(activities.length == 0){
         Future.successful(BadRequest(Json.obj("status" -> "Error", "message" -> "Invalid activity name")))
@@ -355,6 +356,7 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
         Future.successful(Ok(Json.arr(activities)))
       }
     }else{
+      println("L")
       Future.successful(Redirect("/"))
     }
   }
@@ -362,8 +364,11 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
   /** Returns all records in the webpage_interactions table as a JSON array. */
   def getAllWebpageActivities = UserAwareAction.async{implicit request =>
     if (isAdmin(request.identity)){
-      Future.successful(Ok(Json.arr(WebpageActivityTable.webpageActivityListToJson(WebpageActivityTable.getAllActivities))))
+      println("admin path")
+      val x = WebpageActivityTable.getAllActivities
+      Future.successful(Ok(Json.arr(WebpageActivityTable.webpageActivityListToJson(x))))
     }else{
+      println("no")
       Future.successful(Redirect("/"))
     }
   }
@@ -377,10 +382,13 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
     */
   def getWebpageActivitiesKeyVal(activity: String, keyValPairs: String) = UserAwareAction.async{ implicit request =>
     if (isAdmin(request.identity)){
+      println("a")
       val keyVals: Array[String] = keyValPairs.split("/").map(URLDecoder.decode(_, "UTF-8"))
       val activities = WebpageActivityTable.webpageActivityListToJson(WebpageActivityTable.findKeyVal(activity, keyVals))
+      println("activities: " + activities.mkString(" "))
       Future.successful(Ok(Json.arr(activities)))
     }else{
+      println("b")
       Future.successful(Redirect("/"))
     }
   }
@@ -388,9 +396,11 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
   /** Returns number of records in webpage_activity table containing the specified activity. */
   def getNumWebpageActivities(activity: String) =   UserAwareAction.async{implicit request =>
     if (isAdmin(request.identity)){
+      println("c")
       val activities = WebpageActivityTable.webpageActivityListToJson(WebpageActivityTable.findKeyVal(activity, Array()))
       Future.successful(Ok(activities.length + ""))
     }else{
+      println("d")
       Future.successful(Redirect("/"))
     }
   }
@@ -398,10 +408,12 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
   /** Returns number of records in webpage_activity table containing the specified activity and other keyValPairs. */
   def getNumWebpageActivitiesKeyVal(activity: String, keyValPairs: String) = UserAwareAction.async{ implicit request =>
     if (isAdmin(request.identity)){
+      println("e")
       val keyVals: Array[String] = keyValPairs.split("/").map(URLDecoder.decode(_, "UTF-8")).map(URLDecoder.decode(_, "UTF-8"))
       val activities = WebpageActivityTable.webpageActivityListToJson(WebpageActivityTable.findKeyVal(activity, keyVals))
       Future.successful(Ok(activities.length + ""))
     }else{
+      println("f")
       Future.successful(Redirect("/"))
     }
   }

--- a/app/models/user/WebpageActivityTable.scala
+++ b/app/models/user/WebpageActivityTable.scala
@@ -79,11 +79,15 @@ object WebpageActivityTable {
     * @return
     */
   def findKeyVal(activity: String, keyVals: Array[String]): List[WebpageActivity] = db.withSession { implicit session =>
+    println("findKeyVals, activity = " + activity + ", keyVals = " + keyVals.mkString(","))
     var filteredActivities = activities.filter(x => (x.activity.startsWith(activity++"_") || x.activity === activity))
     for(keyVal <- keyVals) yield {
       filteredActivities = filteredActivities.filter(x => (x.activity.indexOf("_"++keyVal++"_") >= 0) || x.activity.endsWith("_"+keyVal))
     }
-    filteredActivities.list
+
+    val x = filteredActivities.list
+    println("list: " + x.take(10).mkString(","))
+    x
   }
 
   // Returns all webpage activities

--- a/app/models/user/WebpageActivityTable.scala
+++ b/app/models/user/WebpageActivityTable.scala
@@ -79,15 +79,12 @@ object WebpageActivityTable {
     * @return
     */
   def findKeyVal(activity: String, keyVals: Array[String]): List[WebpageActivity] = db.withSession { implicit session =>
-    println("findKeyVals, activity = " + activity + ", keyVals = " + keyVals.mkString(","))
     var filteredActivities = activities.filter(x => (x.activity.startsWith(activity++"_") || x.activity === activity))
     for(keyVal <- keyVals) yield {
       filteredActivities = filteredActivities.filter(x => (x.activity.indexOf("_"++keyVal++"_") >= 0) || x.activity.endsWith("_"+keyVal))
     }
 
-    val x = filteredActivities.list
-    println("list: " + x.take(10).mkString(","))
-    x
+    filteredActivities.list
   }
 
   // Returns all webpage activities

--- a/app/models/user/WebpageActivityTable.scala
+++ b/app/models/user/WebpageActivityTable.scala
@@ -83,7 +83,6 @@ object WebpageActivityTable {
     for(keyVal <- keyVals) yield {
       filteredActivities = filteredActivities.filter(x => (x.activity.indexOf("_"++keyVal++"_") >= 0) || x.activity.endsWith("_"+keyVal))
     }
-
     filteredActivities.list
   }
 

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -454,6 +454,9 @@
                                 <tr id="audit-access-table-choro">
                                     <td style="text-align: right;">Click Via Choropleth</td>
                                 </tr>
+                                <tr id="audit-access-table-turker">
+                                    <td style="text-align: right;">Turker Redirect</td>
+                                </tr>
                                 <tr id="audit-access-table-total">
                                     <td style="text-align: right;">Total <i>(Visit Audit)</i></td>
                                 </tr>

--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -1077,6 +1077,7 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
             $.getJSON("/adminapi/webpageActivity/Visit_Audit", function(visitAuditEvents){
             $.getJSON("/adminapi/webpageActivity/Click/module=StartExploring/location=Index", function(clickStartExploringMainIndexEvents){
             $.getJSON("/adminapi/webpageActivity/Click/module=Choropleth/target=audit", function(choroplethClickEvents){
+            $.getJSON("/adminapi/webpageActivity/Referrer=mturk", function(turkerRedirectEvents){
             $.getJSON("/adminapi/webpageActivity/Click/module=StartExploring/location=Navbar/"+encodeURIComponent("route=/"), function(clickStartExploringNavIndexEvents){
             $.getJSON("/adminapi/webpageActivity/Click/module=StartMapping/location=Navbar/"+encodeURIComponent("route=/"), function(clickStartMappingNavIndexEvents){
                 // Only consider events that take place after all logging was merged (timestamp equivalent to July 20, 2017 17:02:00)
@@ -1091,7 +1092,9 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
                 var numChoroplethClicks = choroplethClickEvents[0].filter(function(event){
                     return event.timestamp > 1500584520000;
                 }).length;
-                console.log("its this", clickStartMappingNavIndexEvents);
+                var numTurkerRedirects = turkerRedirectEvents[0].filter(function(event){
+                    return event.timestamp > 1500584520000;
+                }).length;
                 var numClickStartMappingNavIndex = clickStartMappingNavIndexEvents[0].concat(clickStartExploringNavIndexEvents[0]).filter(function(event){
                     return event.timestamp > 1500584520000;
                 }).length;
@@ -1115,10 +1118,18 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
                 );
                 $("#audit-access-table-choro").append(
                     '<td style="text-align: right;">'+
-                        numChoroplethClicks+
+                    numChoroplethClicks+
                     '</td>'+
                     '<td style="text-align: right;">'+
-                        (parseInt(numChoroplethClicks)/parseInt(numVisitAudit)*100).toFixed(1)+'%'+
+                    (parseInt(numChoroplethClicks)/parseInt(numVisitAudit)*100).toFixed(1)+'%'+
+                    '</td>'
+                );
+                $("#audit-access-table-turker").append(
+                    '<td style="text-align: right;">'+
+                    numTurkerRedirects+
+                    '</td>'+
+                    '<td style="text-align: right;">'+
+                    (parseInt(numTurkerRedirects)/parseInt(numVisitAudit)*100).toFixed(1)+'%'+
                     '</td>'
                 );
                 $("#audit-access-table-total").append(
@@ -1129,6 +1140,7 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
                         '100.0%'+
                     '</td>'
                 );
+            });
             });
             });
             });

--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -1077,7 +1077,8 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
             $.getJSON("/adminapi/webpageActivity/Visit_Audit", function(visitAuditEvents){
             $.getJSON("/adminapi/webpageActivity/Click/module=StartExploring/location=Index", function(clickStartExploringMainIndexEvents){
             $.getJSON("/adminapi/webpageActivity/Click/module=Choropleth/target=audit", function(choroplethClickEvents){
-            $.getJSON("/adminapi/webpageActivity/Click/module=StartExploring/location=Navbar/"+encodeURIComponent(encodeURIComponent("route=/")), function(clickStartMappingNavIndexEvents){
+            $.getJSON("/adminapi/webpageActivity/Click/module=StartExploring/location=Navbar/"+encodeURIComponent("route=/"), function(clickStartExploringNavIndexEvents){
+            $.getJSON("/adminapi/webpageActivity/Click/module=StartMapping/location=Navbar/"+encodeURIComponent("route=/"), function(clickStartMappingNavIndexEvents){
                 // Only consider events that take place after all logging was merged (timestamp equivalent to July 20, 2017 17:02:00)
                 // TODO switch this to make use of versioning on the backend once it is implemented...
                 // See: https://github.com/ProjectSidewalk/SidewalkWebpage/issues/653
@@ -1090,7 +1091,8 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
                 var numChoroplethClicks = choroplethClickEvents[0].filter(function(event){
                     return event.timestamp > 1500584520000;
                 }).length;
-                var numClickStartMappingNavIndex = clickStartMappingNavIndexEvents[0].filter(function(event){
+                console.log("its this", clickStartMappingNavIndexEvents);
+                var numClickStartMappingNavIndex = clickStartMappingNavIndexEvents[0].concat(clickStartExploringNavIndexEvents[0]).filter(function(event){
                     return event.timestamp > 1500584520000;
                 }).length;
 
@@ -1127,6 +1129,7 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
                         '100.0%'+
                     '</td>'
                 );
+            });
             });
             });
             });


### PR DESCRIPTION
Resolves #1418 

2 things were causing the Start Mapping statistic not to display properly:
- Double `encodeURIComponent`. Changing it to 1 fixed it.
- We renamed the 'Start Exploring' activity to 'Start Mapping' and the dashboard was only loading the 'Start Mapping' ones (so old logs got ignored).

We were already logging Turker redirects, just had to add a row to the table.

To test:
- Check that the # of users that click Start Mapping is displayed in analytics
- Check that the # of turker redirects is displayed in analytics