### PR TITLE
1451 labeling guide curb cuts as curb ramps

### DIFF
--- a/app/views/labelingGuideCurbRamps.scala.html
+++ b/app/views/labelingGuideCurbRamps.scala.html
@@ -331,11 +331,14 @@
                     <div class="row">
                         <div class="col-sm-12">
                             <p>
-                                If the island interferes with the crosswalk, you should place a <i>Curb Ramp</i> label or
+                                If the island would interfere with the crosswalk, you should place a <i>Curb Ramp</i> label or
                                 a <i>Missing Curb Ramp</i> label as in the image below (<a href="https://www.ada.gov/regs2010/2010ADAStandards/2010ADAstandards.htm#curbramps">ADA 406.7</a>).
                             </p>
                             <p>
-                                If the island is cut or if the island does not interfere with the crosswalk, you should
+                                If the island has a curb cut as in the middle image below, you should place a <i>Curb Ramp</i> label.
+                            </p>
+                            <p>
+                                If the island does not interfere with the crosswalk, you should
                                 <strong>not</strong> place a <i>Curb Ramp</i> label or a <i>Missing Curb Ramp</i> label.
                             </p>
                             <p>

--- a/app/views/labelingGuideSurfaceProblems.scala.html
+++ b/app/views/labelingGuideSurfaceProblems.scala.html
@@ -184,16 +184,16 @@
                 </div>
 
                 <div class="help-item">
-                    <h3 class="question" id="cobblestone-and-other-rough-surfaces">
-                        How should I label cobblestone and other rough surfaces?
-                        <a href="#cobblestone-and-other-rough-surfaces" title="Permalink to this sub-section" class="permalink-anchor">
+                    <h3 class="question" id="cobblestone-brick-and-other-rough-surfaces">
+                        How should I label cobblestone, brick, and other rough surfaces?
+                        <a href="#cobblestone-brick-and-other-rough-surfaces" title="Permalink to this sub-section" class="permalink-anchor">
                             <img src='@routes.Assets.at("assets/link.png")' alt="A link" class="permalink-icon">
                         </a>
                     </h3>
                     <div class="row">
                         <div class="col-sm-12">
                             <p>
-                                You should label cobblestone and other rough surfaces, since they can be difficult and
+                                You should label cobblestone, brick, and other rough surfaces, since they can be difficult and
                                 painful to traverse due to the vibrations and catching of wheelchair casters
                                 (<a href="https://www.ada.gov/regs2010/2010ADAStandards/2010ADAstandards.htm#pgfId-1006158">USAB ADA guidelines
                                 302.1</a>). These surfaces can also make it difficult to control the joystick in electric


### PR DESCRIPTION
Fixes #1421 
Fixes #1451 

Slightly reworded a few sections of the labeling guide to make it clear that curb cuts should be labeled as curb ramps and brick should be marked as a surface problem.

Curb cut before
![curb-cut-before](https://user-images.githubusercontent.com/6518824/53906868-d0df8d00-4000-11e9-9b8c-47b0498d63e7.png)

Curb cut after
![curb-cut-after](https://user-images.githubusercontent.com/6518824/53906718-75ad9a80-4000-11e9-82c2-f763f918892b.png)

Brick before
![brick-before](https://user-images.githubusercontent.com/6518824/53906875-d3da7d80-4000-11e9-92d6-91e69eaaa2e3.png)

Brick after
![brick-after](https://user-images.githubusercontent.com/6518824/53906712-734b4080-4000-11e9-8b66-cb8590562aff.png)

I'm not going to ask anyone to review this PR, b/c it just changes some wording (note that I did verify that I didn't break the direct links to sub-sections).