### PR TITLE
Resolves #1476: Fixed lazyplay not resuming videos

### DIFF
--- a/public/assets/homepage.js
+++ b/public/assets/homepage.js
@@ -246,12 +246,12 @@ function lazyPlayVideos() {
 function lazyPlay(el, video) {
     if (isElementVerticallyVisible(el)) {
         if (!isVideoPlaying(video)) {
-            pausedVideos[video] = false;
+            pausedVideos[video.id] = false;
             video.play();
         }
     } else {
         if (isVideoPlaying(video)) {
-            pausedVideos[video] = true;
+            pausedVideos[video.id] = true;
             video.pause();
         }
     }
@@ -259,7 +259,7 @@ function lazyPlay(el, video) {
 
 // Returns true if the given video is playing
 function isVideoPlaying(video) {
-    return !pausedVideos[video];
+    return !pausedVideos[video.id];
 }
 
 // Returns true if the given element is in the vertical viewport


### PR DESCRIPTION
Resolves #1476

JavaScript objects only allow string keys and I was using an HTMLVideoElement as the key, so the object I used to keep track of which videos were paused only had 1 entry which would be shared for all videos. I changed it to use the video's ID instead.

To test:
- Ensure that videos lazy-play properly on the landing page