### PR TITLE
fixed front-end timer for turker HITs

### DIFF
--- a/app/models/amt/AMTAssignmentTable.scala
+++ b/app/models/amt/AMTAssignmentTable.scala
@@ -1,6 +1,7 @@
 package models.amt
 
 import java.sql.Timestamp
+import java.time.Instant
 
 import models.utils.MyPostgresDriver.simple._
 import play.api.Play.current
@@ -57,6 +58,18 @@ object AMTAssignmentTable {
 
   def getMostRecentAsmtEnd(workerId: String): Option[Timestamp] = db.withSession { implicit session =>
     amtAssignments.filter(_.workerId === workerId).sortBy(_.assignmentStart.desc).map(_.assignmentEnd).list.headOption
+  }
+
+  /**
+    * Get the number of milliseconds between now and the end time of the worker's most recent assignment.
+    *
+    * @param workerId
+    * @return
+    */
+  def getMsLeftOnMostRecentAsmt(workerId: String): Option[Long] = db.withSession { implicit session =>
+    val now: Timestamp = new Timestamp(Instant.now.toEpochMilli)
+    val endOption: Option[Timestamp] = getMostRecentAsmtEnd(workerId)
+    endOption.map(end => end.getTime - now.getTime)
   }
 
   def getMostRecentConfirmationCode(workerId: String): Option[String] = db.withSession { implicit session =>

--- a/app/views/audit.scala.html
+++ b/app/views/audit.scala.html
@@ -822,10 +822,8 @@
         svl.userModel._user = svl.user;
         var hitExpired = false;
         @if(user && user.get.role.getOrElse("") == "Turker") {
-            var asmtEndTime = new Date("@AMTAssignmentTable.getMostRecentAsmtEnd(user.get.username)");
-            var now = new Date().getTime();
-            var timeRemaining = asmtEndTime - now;
-            if (timeRemaining < 0) {
+            var msRemaining = @AMTAssignmentTable.getMsLeftOnMostRecentAsmt(user.get.username);
+            if (msRemaining < 0) {
                 hitExpired = true;
             }
         }
@@ -968,7 +966,6 @@
                 @if(user.get.role.getOrElse("") == "Turker") {
                     svl.assignmentId = "@AMTAssignmentTable.getMostRecentAssignmentId(user.get.username)";
                     svl.amtAssignmentId = @AMTAssignmentTable.getMostRecentAMTAssignmentId(user.get.username);
-                    svl.asmtEndTime = new Date("@AMTAssignmentTable.getMostRecentAsmtEnd(user.get.username)");
                     svl.confirmationCode = "@AMTAssignmentTable.getConfirmationCode(user.get.username,AMTAssignmentTable.getMostRecentAssignmentId(user.get.username))";
                     @if(!MissionTable.hasCompletedMissionInThisAmtAssignment(user.get.username)){
                         $("#left-column-confirmation-code-button").css('visibility', "hidden");

--- a/app/views/navbar.scala.html
+++ b/app/views/navbar.scala.html
@@ -19,21 +19,21 @@
                     <li><p id="navbarTimer" style="width:75px;margin-top:19px;">Loading...</p></li>
                     <script>
                         // Got this code from https://www.w3schools.com/jsref/met_win_setinterval.asp
-                        var asmtEndTime = new Date("@{models.amt.AMTAssignmentTable.getMostRecentAsmtEnd(user.get.username)}");
                         var expired = true;
+                        var msRemaining = @{models.amt.AMTAssignmentTable.getMsLeftOnMostRecentAsmt(user.get.username)};
 
                         // Update the count down every 1 second
                         var timerInterval = setInterval(function() {
                             var now = new Date().getTime();
-                            var timeRemaining = asmtEndTime - now;
+                            msRemaining -= 1000;
 
                             // Time calculations for days, hours, minutes and seconds
-                            var hours = Math.floor(timeRemaining / (1000 * 60 * 60));
-                            var minutes = Math.floor((timeRemaining % (1000 * 60 * 60)) / (1000 * 60));
-                            var seconds = Math.floor((timeRemaining % (1000 * 60)) / 1000);
+                            var hours = Math.floor(msRemaining / (1000 * 60 * 60));
+                            var minutes = Math.floor((msRemaining % (1000 * 60 * 60)) / (1000 * 60));
+                            var seconds = Math.floor((msRemaining % (1000 * 60)) / 1000);
 
                             // Output the result in an element with id="navbarTimer"
-                            if (timeRemaining < 0) {
+                            if (msRemaining < 0) {
                                 clearInterval(timerInterval);
                                 document.getElementById("navbarTimer").innerHTML = "EXPIRED";
 
@@ -54,7 +54,7 @@
                             }
                             // If there are less than 15 minutes remaining, color the text red.
                             var fifteenMinutes = 1000 * 60 * 15;
-                            if (timeRemaining < fifteenMinutes) {
+                            if (msRemaining < fifteenMinutes) {
                                 document.getElementById('navbarTimer').style.color = 'red'
                             }
                         }, 1000);


### PR DESCRIPTION
Fixes #1537 

This fixes a bug where the front-end timer for turkers was off b/c of time zone differences from UTC. Instead of sending a timestamp of when the HIT ends to the front-end, we now compute how many milliseconds are left before the HIT has expired on the back-end and send that number.

Testing instructions:
1. Check out the develop branch and go to localhost:9000/?referrer=mturk&hitId=h1&workerId=worker1&assignmentId=a1&minutes=5 -- you should be redirected to the audit page and the timer should show something like 8 hours and 5 minutes.
1. Check out the 1537 branch and go to localhost:9000/?referrer=mturk&hitId=h2&workerId=worker2&assignmentId=a2&minutes=5 -- you should be redirected to the audit page and the timer should show 5 minutes remaining.

I'm not going to ask anyone to test this, since the functionality is not being used yet... Once I have the whole pipeline set up I will ask others to test the whole thing :+1: 