### PR TITLE
1423 admin user page illegalformatconversion error

### DIFF
--- a/app/views/admin/user.scala.html
+++ b/app/views/admin/user.scala.html
@@ -155,7 +155,7 @@
                         <td class="col-md-2">@mission.missionType</td>
                         <td class="col-md-1">@mission.regionId</td>
                         <td class="col-md-2">@mission.regionName</td>
-                        <td class="col-md-3">@("%1.1f".format(mission.distanceMeters.getOrElse(0))) / @{"%1.1f".format(mission.distanceMeters.getOrElse(0F) * 3.28084F)} / @{"%1.1f".format(mission.distanceMeters.getOrElse(0F) / 1609.344051499F)}</td>
+                        <td class="col-md-3">@("%1.1f".format(mission.distanceMeters.getOrElse(0F))) / @{"%1.1f".format(mission.distanceMeters.getOrElse(0F) * 3.28084F)} / @{"%1.1f".format(mission.distanceMeters.getOrElse(0F) / 1609.344051499F)}</td>
                         <th class="col-md-2">@mission.labelsValidated.getOrElse(0)</th>
                     </tr>
                 }

--- a/app/views/admin/user.scala.html
+++ b/app/views/admin/user.scala.html
@@ -153,8 +153,8 @@
                     <tr>
                         <td class="col-md-2">@mission.missionId</td>
                         <td class="col-md-2">@mission.missionType</td>
-                        <td class="col-md-1">@mission.regionId</td>
-                        <td class="col-md-2">@mission.regionName</td>
+                        <td class="col-md-1">@mission.regionId.map(_.toString).getOrElse("N/A")</td>
+                        <td class="col-md-2">@mission.regionName.getOrElse("N/A")</td>
                         <td class="col-md-3">@("%1.1f".format(mission.distanceMeters.getOrElse(0F))) / @{"%1.1f".format(mission.distanceMeters.getOrElse(0F) * 3.28084F)} / @{"%1.1f".format(mission.distanceMeters.getOrElse(0F) / 1609.344051499F)}</td>
                         <td class="col-md-2">@mission.labelsValidated.getOrElse(0)</td>
                     </tr>

--- a/app/views/admin/user.scala.html
+++ b/app/views/admin/user.scala.html
@@ -156,7 +156,7 @@
                         <td class="col-md-1">@mission.regionId</td>
                         <td class="col-md-2">@mission.regionName</td>
                         <td class="col-md-3">@("%1.1f".format(mission.distanceMeters.getOrElse(0F))) / @{"%1.1f".format(mission.distanceMeters.getOrElse(0F) * 3.28084F)} / @{"%1.1f".format(mission.distanceMeters.getOrElse(0F) / 1609.344051499F)}</td>
-                        <th class="col-md-2">@mission.labelsValidated.getOrElse(0)</th>
+                        <td class="col-md-2">@mission.labelsValidated.getOrElse(0)</td>
                     </tr>
                 }
                 </tbody>


### PR DESCRIPTION
Fixes #1423 

Fixes the illegalformatconversion error on the admin user page `/admin/user/<username>` that prevented the page from loading. This was caused by the 0-distance missions (e.g., the tutorial or validation missions). The error was with a line of the form `mission.distanceMeters.getOrElse(0)`, which should have been `mission.distanceMeters.getOrElse(0F)` (we were passing in an Int instead of a Float).

Testing instructions: Load the `/admin/user/misaugstad` endpoint and make sure that it actually loads and the table with the list of missions looks okay.

I won't ask anyone to test b/c this was a really simple fix.