### PR TITLE
1535 switch shortcuts for nosidewalk tags

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/keyboard/Keyboard.js
+++ b/public/javascripts/SVLabel/src/SVLabel/keyboard/Keyboard.js
@@ -404,10 +404,10 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
                             case util.misc.getLabelDescriptions('NoSidewalk')['tagInfo']['ends abruptly']['keyNumber']: // 'a' for 'ends abruptly'
                                 $('.endsAbruptly-tag').first().trigger("click", {lowLevelLogging: false});
                                 break;
-                            case util.misc.getLabelDescriptions('NoSidewalk')['tagInfo']['street has a sidewalk']['keyNumber']: // 't' for 'street has a sidewalk'
+                            case util.misc.getLabelDescriptions('NoSidewalk')['tagInfo']['street has a sidewalk']['keyNumber']: // 'r' for 'street has a sidewalk'
                                 $('.streetHasASidewalk-tag').first().trigger("click", {lowLevelLogging: false});
                                 break;
-                            case util.misc.getLabelDescriptions('NoSidewalk')['tagInfo']['street has no sidewalks']['keyNumber']: // 'r' for 'street has no sidewalks'
+                            case util.misc.getLabelDescriptions('NoSidewalk')['tagInfo']['street has no sidewalks']['keyNumber']: // 't' for 'street has no sidewalks'
                                 $('.streetHasNoSidewalks-tag').first().trigger("click", {lowLevelLogging: false});
                                 break;
                         }

--- a/public/javascripts/SVLabel/src/SVLabel/util/UtilitiesSidewalk.js
+++ b/public/javascripts/SVLabel/src/SVLabel/util/UtilitiesSidewalk.js
@@ -368,15 +368,15 @@ function UtilitiesMisc (JSON) {
                         id: 'endsAbruptly'
                     },
                     'street has a sidewalk': {
-                        keyNumber: 84,
-                        keyChar: 'T',
-                        text: 's<tag-underline>t</tag-underline>reet has a sidewalk',
+                        keyNumber: 82,
+                        keyChar: 'R',
+                        text: 'st<tag-underline>r</tag-underline>eet has a sidewalk',
                         id: 'streetHasASidewalk'
                     },
                     'street has no sidewalks': {
-                        keyNumber: 82,
-                        keyChar: 'R',
-                        text: 'st<tag-underline>r</tag-underline>eet has no sidewalks',
+                        keyNumber: 84,
+                        keyChar: 'T',
+                        text: 's<tag-underline>t</tag-underline>reet has no sidewalks',
                         id: 'streetHasNoSidewalks'
                     }
                 }


### PR DESCRIPTION
Resolves #1535 

Switches the keyboard shortcut for the "street has a sidewalk" tag from 't' to 'r' and the shortcut for the "street has no sidewalks" tag from 'r' to 't'.

This was just done so the physical location on the screen matches the physical location of the keys on the keyboard.

Not asking anyone to test b/c it is a simple change. 