### PR TITLE
1551 change landing page choropleth color

### DIFF
--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -330,10 +330,10 @@
                                     <span style='background:#2171b5;width:9.09%'></span>
                                     <span style='background:#4292c6;width:9.09%'></span>
                                     <span style='background:#6baed6;width:9.09%'></span>
+                                    <span style='background:#82badb;width:9.09%'></span>
                                     <span style='background:#9ecae1;width:9.09%'></span>
+                                    <span style='background:#b3d3e8;width:9.09%'></span>
                                     <span style='background:#c6dbef;width:9.09%'></span>
-                                    <span style='background:#deebf7;width:9.09%'></span>
-                                    <span style='background:#f7fbff;width:9.09%'></span>
                                     <label style='width:5%'>100%</label>
                                     <label style='width:92%'></label>                                    
                                     <label style='width:3%'>0%</label>

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -178,10 +178,10 @@
                         <span style='background:#2171b5;width:9.09%'></span>
                         <span style='background:#4292c6;width:9.09%'></span>
                         <span style='background:#6baed6;width:9.09%'></span>
+                        <span style='background:#82badb;width:9.09%'></span>
                         <span style='background:#9ecae1;width:9.09%'></span>
+                        <span style='background:#b3d3e8;width:9.09%'></span>
                         <span style='background:#c6dbef;width:9.09%'></span>
-                        <span style='background:#deebf7;width:9.09%'></span>
-                        <span style='background:#f7fbff;width:9.09%'></span>
                         <label style='width:8%'>100%</label>
                         <label style='width:90%'></label>                                    
                         <label style='width:2%'>0%</label>

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -172,19 +172,19 @@
                 <strong style="font-size: 18px">Percent of Neighborhood Complete</strong>
                 <nav class='legend clearfix'>
                     <span style='background:#03152f;width:9.09%'></span>
-                        <span style='background:#08306b;width:9.09%'></span>
-                        <span style='background:#08519c;width:9.09%'></span>
-                        <span style='background:#08719c;width:9.09%'></span>
-                        <span style='background:#2171b5;width:9.09%'></span>
-                        <span style='background:#4292c6;width:9.09%'></span>
-                        <span style='background:#6baed6;width:9.09%'></span>
-                        <span style='background:#82badb;width:9.09%'></span>
-                        <span style='background:#9ecae1;width:9.09%'></span>
-                        <span style='background:#b3d3e8;width:9.09%'></span>
-                        <span style='background:#c6dbef;width:9.09%'></span>
-                        <label style='width:8%'>100%</label>
-                        <label style='width:90%'></label>                                    
-                        <label style='width:2%'>0%</label>
+                    <span style='background:#08306b;width:9.09%'></span>
+                    <span style='background:#08519c;width:9.09%'></span>
+                    <span style='background:#08719c;width:9.09%'></span>
+                    <span style='background:#2171b5;width:9.09%'></span>
+                    <span style='background:#4292c6;width:9.09%'></span>
+                    <span style='background:#6baed6;width:9.09%'></span>
+                    <span style='background:#82badb;width:9.09%'></span>
+                    <span style='background:#9ecae1;width:9.09%'></span>
+                    <span style='background:#b3d3e8;width:9.09%'></span>
+                    <span style='background:#c6dbef;width:9.09%'></span>
+                    <label style='width:8%'>100%</label>
+                    <label style='width:90%'></label>
+                    <label style='width:2%'>0%</label>
                 </nav>
             </div>
             <div id="choropleth"></div>

--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -142,16 +142,16 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
     function getColor(p) {
         //since this is a float, we cannot directly compare. Using epsilon to avoid floating point errors
         return Math.abs(p - 100) < Number.EPSILON ? '#03152f':
-                p > 90 ? '#08306b' :
-                    p > 80 ? '#08519c' :
-                        p > 70 ? '#08719c' :
-                            p > 60 ? '#2171b5' :
-                                p > 50 ? '#4292c6' :
-                                    p > 40 ? '#6baed6' :
-                                        p > 30 ? '#9ecae1' :
-                                            p > 20 ? '#c6dbef' :
-                                                p > 10 ? '#deebf7' :
-                                                    '#f7fbff';
+            p > 90 ? '#08306b' :
+                p > 80 ? '#08519c' :
+                    p > 70 ? '#08719c' :
+                        p > 60 ? '#2171b5' :
+                            p > 50 ? '#4292c6' :
+                                p > 40 ? '#6baed6' :
+                                    p > 30 ? '#82badb' :
+                                        p > 20 ? '#9ecae1' :
+                                            p > 10 ? '#b3d3e8' :
+                                                '#c6dbef';
     }
 
     /**
@@ -177,7 +177,7 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
                         weight: 1,
                         opacity: 0.25,
                         fillColor: getColor(rates[i].rate),
-                        fillOpacity: 0.25 + (0.5 * rates[i].rate / 100.0)
+                        fillOpacity: 0.35 + (0.4 * rates[i].rate / 100.0)
                     }
                 }
             }

--- a/public/javascripts/Choropleth.js
+++ b/public/javascripts/Choropleth.js
@@ -48,10 +48,10 @@ function Choropleth(_, $, turf, difficultRegionIds) {
                             p > 60 ? '#2171b5' :
                                 p > 50 ? '#4292c6' :
                                     p > 40 ? '#6baed6' :
-                                        p > 30 ? '#9ecae1' :
-                                            p > 20 ? '#c6dbef' :
-                                                p > 10 ? '#deebf7' :
-                                                    '#f7fbff';
+                                        p > 30 ? '#82badb' :
+                                            p > 20 ? '#9ecae1' :
+                                                p > 10 ? '#b3d3e8' :
+                                                    '#c6dbef';
     }
 
     /**

--- a/public/javascripts/Choropleth.js
+++ b/public/javascripts/Choropleth.js
@@ -78,7 +78,7 @@ function Choropleth(_, $, turf, difficultRegionIds) {
                         weight: 1,
                         opacity: 0.25,
                         fillColor: getColor(100.0 * rates[i].rate),
-                        fillOpacity: 0.25 + (0.5 * rates[i].rate)
+                        fillOpacity: 0.35 + (0.4 * rates[i].rate)
                     }
                 }
             }


### PR DESCRIPTION
Resolves #1551 

Modifies the colors and opacity of the neighborhoods in the choropleth on the landing and admin pages. This makes the outline of the neighborhood more visible when the neighborhoods have not been audited at all.

Before:
![seattle-old](https://user-images.githubusercontent.com/6518824/54470195-20405e80-4761-11e9-958f-6ddc742fabe1.png)
![newberg-old](https://user-images.githubusercontent.com/6518824/54470197-220a2200-4761-11e9-8e57-644563f1a6bc.png)

After:
![seattle-new](https://user-images.githubusercontent.com/6518824/54470198-25051280-4761-11e9-8a3f-ba5bbb0c318e.png)
![newberg-new](https://user-images.githubusercontent.com/6518824/54470199-26ced600-4761-11e9-8712-625635bf9622.png)

A simple change, so I'm not asking anyone to test.