### PR TITLE
1569 use street edge region table for audit street endpoint

### DIFF
--- a/app/models/region/RegionTable.scala
+++ b/app/models/region/RegionTable.scala
@@ -212,20 +212,6 @@ object RegionTable {
       _regions.list.headOption.map(x => NamedRegion.tupled(x))
   }
 
-  def selectNamedRegionsIntersectingAStreet(streetEdgeId: Int): List[NamedRegion] = db.withSession { implicit session =>
-    val selectRegionQuery = Q.query[Int, NamedRegion](
-      """SELECT region.region_id, region_property.value, region.geom
-        |FROM sidewalk.region
-        |INNER JOIN sidewalk.street_edge ON ST_Intersects(region.geom, street_edge.geom)
-        |LEFT JOIN sidewalk.region_property ON region.region_id = region_property.region_id
-        |WHERE street_edge.street_edge_id = ?
-        |    AND region_property.key = 'Neighborhood Name'
-        |    AND region.deleted = FALSE
-      """.stripMargin
-    )
-    selectRegionQuery(streetEdgeId).list
-  }
-
   /**
     * Returns a list of neighborhoods intersecting the given bounding box
     * @param lat1


### PR DESCRIPTION
Resolves #1569 

The /audit/street endpoints used to use a postgis `ST_Intersects` query to determine which neighborhood the street is in. But that is what the `street_edge_region` table is for :) This was causing some issues, so I removed the old query and switched to using the `street_edge_region` table like we are supposed to be doing.

To test: Make sure that the /audit/street endpoint works as expected. One street that didn't work with the old query was street edge 168 in the Newberg dataset. So you could test that street edge on develop and on this branch to make sure the issue is fixed.

I won't ask anyone to test because this is a simple fix.