### PR TITLE
improved logging when there is no GSV imagery

### DIFF
--- a/app/views/audit.scala.html
+++ b/app/views/audit.scala.html
@@ -872,8 +872,9 @@
                 else {
                     // no street view available in this range.
                     console.error("Error loading Street View imagery: " + status);
-                    svl.tracker.push("PanoId_NotFound_Onload", {'Location': JSON.stringify(latLng)});
-                    // Reload page (May need a better solution than this one)
+                    console.log("Street edge we are trying to audit: " + @task.map(_.edgeId).getOrElse(-1));
+                    svl.tracker.push("PanoId_NotFound_Onload", {'Location': JSON.stringify(latLng), 'StreetEdgeId': @task.map(_.edgeId).getOrElse(-1)});
+                    // Reload page (May need a better solution than this one, issue #1570)
                     window.location.href = window.location.origin + "/audit";
 //                  throw "Error loading Street View imagery.";
 


### PR DESCRIPTION
Partially resolves #1570 

This improves the logging when there is no GSV imagery. We now report which street edge the user is trying to audit when we find no imagery. This is now being logged in the console and in the `audit_task_interaction` table.

Not asking for a tester b/c this PR just adds two logging statements.