### PR TITLE
upgraded Python requests library to 2.20.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,6 @@ RUN apt-get update && \
     gfortran \
     python-numpy \
     python-pandas \
-    python-requests \
-    python-socksipy \
     sbt && \
   apt-get autoremove && \
   apt-get clean

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 futures==3.1.1
 haversine==0.4.5
 scipy==1.1.0
+requests==2.20.0
 


### PR DESCRIPTION
resolves #1515 

Upgrades the Python requests library to 2.20.0 due to a security vulnerability in previous versions.

Not asking anyone to test because it is a simple change. However I will wait to merge until I ask @mechanicjay to remove the old libraries from the Docker images.