### PR TITLE
1576 split google analytics by city

### DIFF
--- a/app/models/user/VersionTable.scala
+++ b/app/models/user/VersionTable.scala
@@ -45,7 +45,7 @@ object VersionTable {
   }
 
   /**
-    * Reads in Google Maps API key from google_maps_api_key.txt (ask Mikey Saugstad for the file if you don't have it)
+    * Read in Google Maps API key from google_maps_api_key.txt (ask Mikey Saugstad for the file if you don't have it).
     *
     * @return
     */

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -155,7 +155,8 @@
                     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
             })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-            ga('create', 'UA-76528208-1', 'auto');
+            var analyticsStr = "@{Play.configuration.getString("city-params.google-analytics-id." + Play.configuration.getString("city-id").get)}";
+            ga('create', analyticsStr, 'auto');
             ga('send', 'pageview');
 
 

--- a/conf/cityparams.conf
+++ b/conf/cityparams.conf
@@ -23,6 +23,11 @@ city-params {
     washington-dc = "DC"
     seattle-wa = "Seattle"
   }
+  google-analytics-id {
+    newberg-or = "UA-136713858-1"
+    washington-dc = "UA-76528208-1"
+    seattle-wa = "UA-136685580-1"
+  }
   city-center-lat {
     newberg-or = 45.308
     washington-dc = 38.892


### PR DESCRIPTION
Resolves #1576 

Splits the Google Analytics b/w cities. Creates separate Google Analytics accounts for Newberg and Seattle. I've given @jonfroehlich full access to these accounts, did you get the confirmation emails @jonfroehlich?

Simple fix, so I won't ask anyone to test.