### PR TITLE
Resolves #1561, 1543: cannot read property null from ‘left’

### DIFF
--- a/public/javascripts/SVValidate/src/panorama/Panorama.js
+++ b/public/javascripts/SVValidate/src/panorama/Panorama.js
@@ -212,17 +212,10 @@ function Panorama (label) {
     function setPanorama (panoId, heading, pitch, zoom) {
         setProperty("panoId", panoId);
         setProperty("prevPanoId", panoId);
-
-        // Adding in callback function because there are some issues with Google Maps
-        // setPano function. Will start to running an infinite loop if panorama does not
-        // load in time.
-        function changePano() {
-            panorama.setPano(panoId);
-            panorama.set('pov', {heading: heading, pitch: pitch});
-            panorama.set('zoom', zoomLevel[zoom]);
-            renderLabel();
-        }
-        setTimeout(changePano, 300);
+        panorama.setPano(panoId);
+        panorama.set('pov', {heading: heading, pitch: pitch});
+        panorama.set('zoom', zoomLevel[zoom]);
+        renderLabel();
         return this;
     }
 


### PR DESCRIPTION
Resolves #1561, #1543 

The reason that we've been getting this bug is because when we get the panorama POV (from `Label.js`, sometimes the data is outdated (we get the POV from the previous panorama that's loaded). 

```
var userPov = svv.panorama.getPov();
```

This sometimes caused our calculation that calculates the pixel coordinates of the Panomarker to fail one of its sanity checks and return `null` coordinates. 

I think the reason why we were getting outdated data was because I previously added a callback to set new panoramas. If you hit the validation button fast enough, that would somehow mess with the callback and cause us to get outdated information. When I originally built the validation interface, there was a GSV bug that caused me to go into an infinite loop when I directly called the `setPano` function. The only way to avoid this was to add a callback. 

Since removing the callback, I haven't run into this infinite looping issue, and haven't been able to reproduce the `null` pixelCoordinate error either.

**Testing Instructions**
* Import a Newberg database with a good number of labels on them (a few hundred)
* Spam the validation interface with agrees/disagrees. Keep the developer console open to check that we aren't getting this error (`Uncaught TypeError: Cannot read property 'left' of null`)
    * It generally takes me ~5 minutes to reproduce.
    * Also make sure you don't run into an infinite loop (it'll look like the validation interface keeps refreshing)