### PR TITLE
846 mission complete progress across all users

### DIFF
--- a/app/views/audit.scala.html
+++ b/app/views/audit.scala.html
@@ -518,7 +518,8 @@
                             </div>
                             <div id="map-legend">
                                 <span><svg class="legend-label" width="15" height="10"><rect width="15" height="10" id="green-square"></rect></svg> This Mission</span><br>
-                                <span><svg class="legend-label" width="15" height="10"><rect width="15" height="10" id="blue-square"></rect></svg> Previous Missions</span>
+                                <span><svg class="legend-label" width="15" height="10"><rect width="15" height="10" id="blue-square"></rect></svg> Previous Missions</span><br>
+                                <span><svg class="legend-label" width="15" height="10"><rect width="15" height="10" id="gray-square"></rect></svg> Other Users' Missions</span>
                             </div>
 
                         </div>

--- a/app/views/audit.scala.html
+++ b/app/views/audit.scala.html
@@ -563,12 +563,16 @@
                                     }
                                 }
                                 <tr>
-                                    <th>Audited in this mission</th>
+                                    <th>You audited in this mission</th>
                                     <td id="modal-mission-complete-mission-distance" class="col-right"></td>
                                 </tr>
                                 <tr>
-                                    <th>Audited in this neighborhood</th>
+                                    <th>You audited in this neighborhood</th>
                                     <td id="modal-mission-complete-total-audited-distance" class="col-right"></td>
+                                </tr>
+                                <tr>
+                                    <th>Others audited in this neighborhood</th>
+                                    <td id="modal-mission-complete-others-distance" class="col-right"></td>
                                 </tr>
                                 <tr>
                                     <th>Remaining in this neighborhood</th>

--- a/public/javascripts/SVLabel/css/svl-modal.css
+++ b/public/javascripts/SVLabel/css/svl-modal.css
@@ -115,8 +115,8 @@
     position: absolute;
     top: 375px;
     right: 25px;
-    width: 120px; 
-    height: 40px; 
+    width: 140px;
+    height: 50px;
     border-radius: 3px;
     background-color: rgba(240,240,240,1);
 }
@@ -131,6 +131,10 @@
 }
 
 .modal-foreground .mapbox #map-legend #blue-square {
+    fill: rgba(70,130,180,1);
+}
+
+.modal-foreground .mapbox #map-legend #gray-square {
     fill: rgba(100,100,100,1);
 }
 

--- a/public/javascripts/SVLabel/css/svl-modal.css
+++ b/public/javascripts/SVLabel/css/svl-modal.css
@@ -113,7 +113,7 @@
 .modal-foreground .mapbox #map-legend {
     font-size: 8pt;
     position: absolute;
-    top: 375px;
+    top: 360px;
     right: 25px;
     width: 140px;
     height: 50px;

--- a/public/javascripts/SVLabel/src/SVLabel/Main.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Main.js
@@ -543,6 +543,7 @@ function Main (params) {
         svl.ui.modalMissionComplete.completeBar = $('#modal-mission-complete-complete-bar');
         svl.ui.modalMissionComplete.closeButton = $("#modal-mission-complete-close-button");
         svl.ui.modalMissionComplete.totalAuditedDistance = $("#modal-mission-complete-total-audited-distance");
+        svl.ui.modalMissionComplete.othersAuditedDistance = $("#modal-mission-complete-others-distance");
         svl.ui.modalMissionComplete.missionDistance = $("#modal-mission-complete-mission-distance");
         svl.ui.modalMissionComplete.missionReward = $("#modal-mission-complete-mission-reward");
         svl.ui.modalMissionComplete.remainingDistance = $("#modal-mission-complete-remaining-distance");

--- a/public/javascripts/SVLabel/src/SVLabel/Main.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Main.js
@@ -193,9 +193,9 @@ function Main (params) {
           google.maps.event.addDomListener(window, 'load', task.render);
         }
 
-        // Mark neighborhood as complete if the initial task's completion count > 0
-        // Proxy for knowing if the neighborhood is complete across all users
-        if(task.streetCompletedByAnyUser()) {
+        // Mark neighborhood as complete if the initial task's priority < 1.
+        // Proxy for knowing if the neighborhood is complete across all users.
+        if(task.getStreetPriority() < 1) {
             svl.neighborhoodModel.setNeighborhoodCompleteAcrossAllUsers();
         }
 

--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
@@ -198,12 +198,12 @@ function ModalMissionComplete (svl, missionContainer, taskContainer,
         var missionDistance = mission.getDistance("miles");
         var missionPay = mission.getProperty("pay");
         var userAuditedDistance = neighborhood.completedLineDistance(unit);
-        var allAuditedDistance = neighborhood.completedLineDistanceAcrossAllUsers(unit);
+        var allAuditedDistance = neighborhood.completedLineDistanceAcrossAllUsersUsingPriority(unit);
         var otherAuditedDistance = allAuditedDistance - userAuditedDistance;
         var remainingDistance = neighborhood.totalLineDistanceInNeighborhood(unit) - allAuditedDistance;
 
         var userCompletedTasks = taskContainer.getCompletedTasks(regionId);
-        var allCompletedTasks = taskContainer.getCompletedTasksAllUsers();
+        var allCompletedTasks = taskContainer.getCompletedTasksAllUsersUsingPriority();
         var missionTasks = mission.getRoute();
         var totalLineDistance = taskContainer.totalLineDistanceInNeighborhood(unit);
         var missionDistanceRate = missionDistance / totalLineDistance;

--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
@@ -206,7 +206,8 @@ function ModalMissionComplete (svl, missionContainer, taskContainer,
         var missionTasks = mission.getRoute();
         var totalLineDistance = taskContainer.totalLineDistanceInNeighborhood(unit);
         var missionDistanceRate = missionDistance / totalLineDistance;
-        var auditedDistanceRate = Math.max(0, userAuditedDistance / totalLineDistance - missionDistanceRate);
+        var userAuditedDistanceRate = Math.max(0, userAuditedDistance / totalLineDistance - missionDistanceRate);
+        var otherAuditedDistanceRate = Math.max(0, otherAuditedDistance / totalLineDistance);
 
         var labelCount = mission.getLabelCount(),
             curbRampCount = labelCount ? labelCount["CurbRamp"] : 0,
@@ -221,7 +222,7 @@ function ModalMissionComplete (svl, missionContainer, taskContainer,
 
         modalMissionCompleteMap.update(mission, neighborhood);
         modalMissionCompleteMap.updateStreetSegments(missionTasks, completedTasks);
-        modalMissionProgressBar.update(missionDistanceRate, auditedDistanceRate);
+        modalMissionProgressBar.update(missionDistanceRate, userAuditedDistanceRate, otherAuditedDistanceRate);
 
         this._updateMissionProgressStatistics(missionDistance, missionPay, userAuditedDistance, otherAuditedDistance, remainingDistance, unit);
         this._updateMissionLabelStatistics(curbRampCount, noCurbRampCount, obstacleCount, surfaceProblemCount, noSidewalkCount, otherCount);

--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
@@ -197,14 +197,16 @@ function ModalMissionComplete (svl, missionContainer, taskContainer,
 
         var missionDistance = mission.getDistance("miles");
         var missionPay = mission.getProperty("pay");
-        var auditedDistance = neighborhood.completedLineDistance(unit);
-        var remainingDistance = neighborhood.totalLineDistanceInNeighborhood(unit) - auditedDistance;
+        var userAuditedDistance = neighborhood.completedLineDistance(unit);
+        var allAuditedDistance = neighborhood.completedLineDistanceAcrossAllUsers(unit);
+        var otherAuditedDistance = allAuditedDistance - userAuditedDistance;
+        var remainingDistance = neighborhood.totalLineDistanceInNeighborhood(unit) - otherAuditedDistance;
 
         var completedTasks = taskContainer.getCompletedTasks(regionId);
         var missionTasks = mission.getRoute();
         var totalLineDistance = taskContainer.totalLineDistanceInNeighborhood(unit);
         var missionDistanceRate = missionDistance / totalLineDistance;
-        var auditedDistanceRate = Math.max(0, auditedDistance / totalLineDistance - missionDistanceRate);
+        var auditedDistanceRate = Math.max(0, userAuditedDistance / totalLineDistance - missionDistanceRate);
 
         var labelCount = mission.getLabelCount(),
             curbRampCount = labelCount ? labelCount["CurbRamp"] : 0,
@@ -221,7 +223,7 @@ function ModalMissionComplete (svl, missionContainer, taskContainer,
         modalMissionCompleteMap.updateStreetSegments(missionTasks, completedTasks);
         modalMissionProgressBar.update(missionDistanceRate, auditedDistanceRate);
 
-        this._updateMissionProgressStatistics(missionDistance, missionPay, auditedDistance, remainingDistance, unit);
+        this._updateMissionProgressStatistics(missionDistance, missionPay, userAuditedDistance, otherAuditedDistance, remainingDistance, unit);
         this._updateMissionLabelStatistics(curbRampCount, noCurbRampCount, obstacleCount, surfaceProblemCount, noSidewalkCount, otherCount);
     };
 
@@ -248,11 +250,12 @@ ModalMissionComplete.prototype.setMissionTitle = function (missionTitle) {
     this._uiModalMissionComplete.missionTitle.html(missionTitle);
 };
 
-ModalMissionComplete.prototype._updateMissionProgressStatistics = function (missionDistance, missionReward, cumulativeAuditedDistance, remainingDistance, unit) {
+ModalMissionComplete.prototype._updateMissionProgressStatistics = function (missionDistance, missionReward, userTotalDistance, othersAuditedDistance, remainingDistance, unit) {
     if (!unit) unit = {units: 'kilometers'};
     remainingDistance = Math.max(remainingDistance, 0);
     this._uiModalMissionComplete.missionDistance.html(missionDistance.toFixed(1) + " " + unit.units);
-    this._uiModalMissionComplete.totalAuditedDistance.html(cumulativeAuditedDistance.toFixed(1) + " " + unit.units);
+    this._uiModalMissionComplete.totalAuditedDistance.html(userTotalDistance.toFixed(1) + " " + unit.units);
+    this._uiModalMissionComplete.othersAuditedDistance.html(othersAuditedDistance.toFixed(1) + " " + unit.units);
     this._uiModalMissionComplete.remainingDistance.html(remainingDistance.toFixed(1) + " " + unit.units);
 
     // Update the reward HTML if the user is a turker.

--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
@@ -202,7 +202,8 @@ function ModalMissionComplete (svl, missionContainer, taskContainer,
         var otherAuditedDistance = allAuditedDistance - userAuditedDistance;
         var remainingDistance = neighborhood.totalLineDistanceInNeighborhood(unit) - otherAuditedDistance;
 
-        var completedTasks = taskContainer.getCompletedTasks(regionId);
+        var userCompletedTasks = taskContainer.getCompletedTasks(regionId);
+        var allCompletedTasks = taskContainer.getCompletedTasksAllUsers();
         var missionTasks = mission.getRoute();
         var totalLineDistance = taskContainer.totalLineDistanceInNeighborhood(unit);
         var missionDistanceRate = missionDistance / totalLineDistance;
@@ -221,7 +222,7 @@ function ModalMissionComplete (svl, missionContainer, taskContainer,
         this.setMissionTitle(neighborhoodName + ": Mission Complete!");
 
         modalMissionCompleteMap.update(mission, neighborhood);
-        modalMissionCompleteMap.updateStreetSegments(missionTasks, completedTasks);
+        modalMissionCompleteMap.updateStreetSegments(missionTasks, userCompletedTasks, allCompletedTasks);
         modalMissionProgressBar.update(missionDistanceRate, userAuditedDistanceRate, otherAuditedDistanceRate);
 
         this._updateMissionProgressStatistics(missionDistance, missionPay, userAuditedDistance, otherAuditedDistance, remainingDistance, unit);

--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
@@ -200,7 +200,7 @@ function ModalMissionComplete (svl, missionContainer, taskContainer,
         var userAuditedDistance = neighborhood.completedLineDistance(unit);
         var allAuditedDistance = neighborhood.completedLineDistanceAcrossAllUsers(unit);
         var otherAuditedDistance = allAuditedDistance - userAuditedDistance;
-        var remainingDistance = neighborhood.totalLineDistanceInNeighborhood(unit) - otherAuditedDistance;
+        var remainingDistance = neighborhood.totalLineDistanceInNeighborhood(unit) - allAuditedDistance;
 
         var userCompletedTasks = taskContainer.getCompletedTasks(regionId);
         var allCompletedTasks = taskContainer.getCompletedTasksAllUsers();

--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionCompleteMap.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionCompleteMap.js
@@ -152,14 +152,14 @@ function ModalMissionCompleteMap(uiModalMissionComplete) {
      * @param completedTasks
      * @private
      */
-    this.updateStreetSegments = function (missionTasks, completedTasks) {
+    this.updateStreetSegments = function (missionTasks, completedTasks, allCompletedTasks) {
         // Add layers http://leafletjs.com/reference.html#map-addlayer
-        var i,
-            len,
-            geojsonFeature,
-            layer,
-            completedTaskLayerStyle = { color: "rgb(100,100,100)", opacity: 1, weight: 5 },
-            leafletMap = this._map;
+        var i;
+        var geojsonFeature;
+        var layer;
+        var completedTaskAllUsersLayerStyle = { color: "rgb(100,100,100)", opacity: 1, weight: 5 };
+        var completedTaskLayerStyle = { color: "rgb(70,130,180)", opacity: 1, weight: 5 };
+        var leafletMap = this._map;
 
         // remove previous tasks
         _.each(this._completedTasksLayer, function(element) {
@@ -173,9 +173,21 @@ function ModalMissionCompleteMap(uiModalMissionComplete) {
             .remove();
 
         var newStreets = missionTasks.map( function (t) { return t.getStreetEdgeId(); });
-        len = completedTasks.length;
+        var userOldStreets = completedTasks.map( function(t) { return t.getStreetEdgeId(); });
+
+        // Add the other users' tasks layer
+        for (i = 0; i < allCompletedTasks.length; i++) {
+            var otherUserStreet = allCompletedTasks[i].getStreetEdgeId();
+            if(userOldStreets.indexOf(otherUserStreet) == -1 && newStreets.indexOf(otherUserStreet) == -1){
+                geojsonFeature = allCompletedTasks[i].getFeature();
+                layer = L.geoJson(geojsonFeature).addTo(this._map);
+                layer.setStyle(completedTaskAllUsersLayerStyle);
+                this._completedTasksLayer.push(layer);
+            }
+        }
+
         // Add the completed task layer
-        for (i = 0; i < len; i++) {
+        for (i = 0; i < completedTasks.length; i++) {
             var streetEdgeId = completedTasks[i].getStreetEdgeId();
             if(newStreets.indexOf(streetEdgeId) == -1){
                 geojsonFeature = completedTasks[i].getFeature();
@@ -186,9 +198,8 @@ function ModalMissionCompleteMap(uiModalMissionComplete) {
         }
 
         // Add the current mission animation layer
-        len = missionTasks.length;
-        if(len > 0){
-            self._animateMissionTasks(missionTasks, 0, len - 1);
+        if (missionTasks.length > 0){
+            self._animateMissionTasks(missionTasks, 0, missionTasks.length - 1);
         }
     };
 }

--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionCompleteProgressBar.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionCompleteProgressBar.js
@@ -18,10 +18,10 @@ function ModalMissionCompleteProgressBar (uiModalMissionComplete) {
         .attr("width", svgCoverageBarWidth);
 
     var gBarChart = svgCoverageBar.append("g").attr("class", "g-bar-chart");
-    var horizontalBarPreviousContribution = gBarChart.selectAll("rect")
+    var horizontalBarOtherContribution = gBarChart.selectAll("rect")
         .data([0])
         .enter().append("rect")
-        .attr('id', 'blue-bar')
+        .attr('id', 'gray-bar')
         .attr("x", 0)
         .attr("y", 0)
         .attr("fill", "rgba(80,80,80,1)")
@@ -29,7 +29,18 @@ function ModalMissionCompleteProgressBar (uiModalMissionComplete) {
         .attr("width", 0);
 
     var gBarChart2 = svgCoverageBar.append("g").attr("class", "g-bar-chart");
-    var horizontalBarMission = gBarChart2.selectAll("rect")
+    var horizontalBarPreviousContribution = gBarChart2.selectAll("rect")
+        .data([0])
+        .enter().append("rect")
+        .attr('id', 'blue-bar')
+        .attr("x", 0)
+        .attr("y", 0)
+        .attr("fill", "rgba(70,130,180,1)")
+        .attr("height", svgCoverageBarHeight)
+        .attr("width", 0);
+
+    var gBarChart3 = svgCoverageBar.append("g").attr("class", "g-bar-chart");
+    var horizontalBarMission = gBarChart3.selectAll("rect")
         .data([0])
         .enter().append("rect")
         .attr('id', 'green-bar')
@@ -38,7 +49,7 @@ function ModalMissionCompleteProgressBar (uiModalMissionComplete) {
         .attr("fill", "rgba(20,220,120,1)")
         .attr("height", svgCoverageBarHeight)
         .attr("width", 0);
-    var horizontalBarMissionLabel = gBarChart2.selectAll("text")
+    var horizontalBarMissionLabel = gBarChart3.selectAll("text")
         .data([""])
         .enter().append("text")
         .attr('id', 'bar-text')
@@ -55,22 +66,30 @@ function ModalMissionCompleteProgressBar (uiModalMissionComplete) {
     /**
      * Update the bar graph visualization
      * @param missionDistanceRate
-     * @param auditedDistanceRate
+     * @param userAuditedDistanceRate
+     * @param otherAuditedDistanceRate
      * @private
      */
-    this.update = function (missionDistanceRate, auditedDistanceRate) {
-        horizontalBarPreviousContribution.attr("width", 0)
+    this.update = function (missionDistanceRate, userAuditedDistanceRate, otherAuditedDistanceRate) {
+        horizontalBarOtherContribution.attr("width", 0)
             .transition()
             .delay(200)
-            .duration(800)
-            .attr("width", auditedDistanceRate * svgCoverageBarWidth);
+            .duration(600)
+            .attr("width", otherAuditedDistanceRate * svgCoverageBarWidth);
+
+        horizontalBarPreviousContribution.attr("width", 0)
+            .attr("x", otherAuditedDistanceRate * svgCoverageBarWidth)
+            .transition()
+            .delay(800)
+            .duration(600)
+            .attr("width", userAuditedDistanceRate * svgCoverageBarWidth);
 
         horizontalBarMission.attr("width", 0)
-            .attr("x", auditedDistanceRate * svgCoverageBarWidth)
+            .attr("x", (otherAuditedDistanceRate + userAuditedDistanceRate) * svgCoverageBarWidth)
             .transition()
-            .delay(1000)
-            .duration(500)
+            .delay(1400)
+            .duration(600)
             .attr("width", missionDistanceRate * svgCoverageBarWidth);
-        horizontalBarMissionLabel.text(parseInt((auditedDistanceRate + missionDistanceRate) * 100, 10) + "%");
+        horizontalBarMissionLabel.text(parseInt((userAuditedDistanceRate + missionDistanceRate) * 100, 10) + "%");
     };
 }

--- a/public/javascripts/SVLabel/src/SVLabel/neighborhood/Neighborhood.js
+++ b/public/javascripts/SVLabel/src/SVLabel/neighborhood/Neighborhood.js
@@ -35,14 +35,22 @@ function Neighborhood (parameters) {
         return properties.layer ? turf.center(parameters.layer.toGeoJSON()) : null;
     }
     
-    function completedLineDistance (unit) {
+    function completedLineDistance(unit) {
         if (!unit) unit = {units: 'kilometers'};
         if ("taskContainer" in svl && svl.taskContainer) {
             return svl.taskContainer.getCompletedTaskDistance(unit);
         } else {
             return null;
         }
-        
+    }
+
+    function completedLineDistanceAcrossAllUsers(unit) {
+        if (!unit) unit = {units: 'kilometers'};
+        if ("taskContainer" in svl && svl.taskContainer) {
+            return svl.taskContainer.getCompletedTaskDistanceAcrossAllUsers(unit);
+        } else {
+            return null;
+        }
     }
 
     /** Get property */
@@ -78,6 +86,7 @@ function Neighborhood (parameters) {
 
     self.center = center;
     self.completedLineDistance = completedLineDistance;
+    self.completedLineDistanceAcrossAllUsers = completedLineDistanceAcrossAllUsers;
     self.getProperty = getProperty;
     self.setProperty = setProperty;
     self.totalLineDistanceInNeighborhood = totalLineDistanceInNeighborhood;

--- a/public/javascripts/SVLabel/src/SVLabel/neighborhood/Neighborhood.js
+++ b/public/javascripts/SVLabel/src/SVLabel/neighborhood/Neighborhood.js
@@ -44,10 +44,10 @@ function Neighborhood (parameters) {
         }
     }
 
-    function completedLineDistanceAcrossAllUsers(unit) {
+    function completedLineDistanceAcrossAllUsersUsingPriority(unit) {
         if (!unit) unit = {units: 'kilometers'};
         if ("taskContainer" in svl && svl.taskContainer) {
-            return svl.taskContainer.getCompletedTaskDistanceAcrossAllUsers(unit);
+            return svl.taskContainer.getCompletedTaskDistanceAcrossAllUsersUsingPriority(unit);
         } else {
             return null;
         }
@@ -86,7 +86,7 @@ function Neighborhood (parameters) {
 
     self.center = center;
     self.completedLineDistance = completedLineDistance;
-    self.completedLineDistanceAcrossAllUsers = completedLineDistanceAcrossAllUsers;
+    self.completedLineDistanceAcrossAllUsersUsingPriority = completedLineDistanceAcrossAllUsersUsingPriority;
     self.getProperty = getProperty;
     self.setProperty = setProperty;
     self.totalLineDistanceInNeighborhood = totalLineDistanceInNeighborhood;

--- a/public/javascripts/SVLabel/src/SVLabel/task/Task.js
+++ b/public/javascripts/SVLabel/src/SVLabel/task/Task.js
@@ -37,7 +37,7 @@ function Task (geojson, currentLat, currentLng) {
         self.setProperty("priority", _geojson.features[0].properties.priority);
 
         if (_geojson.features[0].properties.completed) {
-            self.complete();
+            status.isComplete = true;
         }
 
         if (currentLat && currentLng) {
@@ -234,11 +234,13 @@ function Task (geojson, currentLat, currentLng) {
     };
 
     /**
-     * Set the isComplete status to true and change the color of the street into green.
+     * Set the isComplete status to true.
      * @returns {complete}
      */
     this.complete = function () {
         status.isComplete = true;
+        properties.completedByAnyUser = true;
+        properties.priority = 1 / (1 + (1 / properties.priority));
         return this;
     };
 
@@ -307,11 +309,11 @@ function Task (geojson, currentLat, currentLng) {
     };
 
     this.streetCompletedByAnyUser = function () {
-        return _geojson.features[0].properties.completed_by_any_user;
+        return properties.completedByAnyUser;
     };
 
     this.getStreetPriority = function () {
-        return _geojson.features[0].properties.priority;
+        return properties.priority;
     };
 
     /**

--- a/public/javascripts/SVLabel/src/SVLabel/task/TaskContainer.js
+++ b/public/javascripts/SVLabel/src/SVLabel/task/TaskContainer.js
@@ -325,13 +325,27 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
      * This method returns the completed tasks.
      * @returns {Array}
      */
-    function getCompletedTasks () {
+    function getCompletedTasks() {
         if (!Array.isArray(self._tasks)) {
             console.error("_tasks is not an array. Probably the data is not loaded yet.");
             return null;
         }
         return self._tasks.filter(function (task) {
             return task.isComplete();
+        });
+    }
+
+    /**
+     * Return list of tasks completed by any user.
+     * @returns {Array of tasks}
+     */
+    function getCompletedTasksAllUsers() {
+        if (!Array.isArray(self._tasks)) {
+            console.error("_tasks is not an array. Probably the data is not loaded yet.");
+            return null;
+        }
+        return self._tasks.filter(function (task) {
+            return task.streetCompletedByAnyUser();
         });
     }
 
@@ -614,6 +628,7 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
     // self.endTask = endTask;
     self.fetchATask = fetchATask;
     self.getCompletedTasks = getCompletedTasks;
+    self.getCompletedTasksAllUsers = getCompletedTasksAllUsers;
     self.getCurrentTaskDistance = getCurrentTaskDistance;
     self.getCompletedTaskDistance = getCompletedTaskDistance;
     self.getCompletedTaskDistanceAcrossAllUsers = getCompletedTaskDistanceAcrossAllUsers;

--- a/public/javascripts/SVLabel/src/SVLabel/task/TaskContainer.js
+++ b/public/javascripts/SVLabel/src/SVLabel/task/TaskContainer.js
@@ -288,9 +288,9 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
      * @param {unit} String can be degrees, radians, miles, or kilometers.
      * @returns {number} distance in unit.
      */
-    function getCompletedTaskDistanceAcrossAllUsers(unit) {
+    function getCompletedTaskDistanceAcrossAllUsersUsingPriority(unit) {
         if (!unit) unit = {units: 'kilometers'};
-        var tasks = self.getTasks().filter(function(t) { return t.streetCompletedByAnyUser(); });
+        var tasks = self.getTasks().filter(function(t) { return t.getStreetPriority() < 1; });
         var geojson;
         var feature;
         var distance = 0;
@@ -339,13 +339,13 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
      * Return list of tasks completed by any user.
      * @returns {Array of tasks}
      */
-    function getCompletedTasksAllUsers() {
+    function getCompletedTasksAllUsersUsingPriority() {
         if (!Array.isArray(self._tasks)) {
             console.error("_tasks is not an array. Probably the data is not loaded yet.");
             return null;
         }
         return self._tasks.filter(function (task) {
-            return task.streetCompletedByAnyUser();
+            return task.getStreetPriority() < 1;
         });
     }
 
@@ -628,10 +628,10 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
     // self.endTask = endTask;
     self.fetchATask = fetchATask;
     self.getCompletedTasks = getCompletedTasks;
-    self.getCompletedTasksAllUsers = getCompletedTasksAllUsers;
+    self.getCompletedTasksAllUsersUsingPriority = getCompletedTasksAllUsersUsingPriority;
     self.getCurrentTaskDistance = getCurrentTaskDistance;
     self.getCompletedTaskDistance = getCompletedTaskDistance;
-    self.getCompletedTaskDistanceAcrossAllUsers = getCompletedTaskDistanceAcrossAllUsers;
+    self.getCompletedTaskDistanceAcrossAllUsersUsingPriority = getCompletedTaskDistanceAcrossAllUsersUsingPriority;
     self.getCurrentTask = getCurrentTask;
     self.getBeforeJumpNewTask = getBeforeJumpTask;
     self.isFirstTask = isFirstTask;

--- a/public/javascripts/SVLabel/src/SVLabel/task/TaskContainer.js
+++ b/public/javascripts/SVLabel/src/SVLabel/task/TaskContainer.js
@@ -261,7 +261,7 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
     /**
      * Get the total distance of completed segments
      * @params {unit} String can be degrees, radians, miles, or kilometers
-     * @returns {number} distance in meters
+     * @returns {number} distance in unit.
      */
     function getCompletedTaskDistance (unit) {
         if (!unit) unit = {units: 'kilometers'};
@@ -279,6 +279,29 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
         }
         if (!currentTask.isComplete()) distance += getCurrentTaskDistance(unit);
 
+        return distance;
+    }
+
+    /**
+     * Get the total distance of segments completed by any user.
+     *
+     * @param {unit} String can be degrees, radians, miles, or kilometers.
+     * @returns {number} distance in unit.
+     */
+    function getCompletedTaskDistanceAcrossAllUsers(unit) {
+        if (!unit) unit = {units: 'kilometers'};
+        var tasks = self.getTasks().filter(function(t) { return t.streetCompletedByAnyUser(); });
+        var geojson;
+        var feature;
+        var distance = 0;
+
+        if (tasks) {
+            for (var i = 0; i < tasks.length; i++) {
+                geojson = tasks[i].getGeoJSON();
+                feature = geojson.features[0];
+                distance += turf.length(feature, unit);
+            }
+        }
         return distance;
     }
 
@@ -593,6 +616,7 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
     self.getCompletedTasks = getCompletedTasks;
     self.getCurrentTaskDistance = getCurrentTaskDistance;
     self.getCompletedTaskDistance = getCompletedTaskDistance;
+    self.getCompletedTaskDistanceAcrossAllUsers = getCompletedTaskDistanceAcrossAllUsers;
     self.getCurrentTask = getCurrentTask;
     self.getBeforeJumpNewTask = getBeforeJumpTask;
     self.isFirstTask = isFirstTask;

--- a/public/javascripts/SVLabel/src/SVLabel/task/TaskContainer.js
+++ b/public/javascripts/SVLabel/src/SVLabel/task/TaskContainer.js
@@ -397,7 +397,7 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
      *
      * @returns {*}
      */
-    self.getIncompleteTasksAcrossAllUsers = function () {
+    self.getIncompleteTasksAcrossAllUsersUsingPriority = function () {
         if (!Array.isArray(self._tasks)) {
             console.error("_tasks is not an array. Probably the data is not loaded yet.");
             self.fetchTasks(null, false);
@@ -411,7 +411,7 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
         var incompleteTasksAcrossAllUsers = [];
         if (incompleteTasksByUser.length > 0) {
             incompleteTasksAcrossAllUsers = incompleteTasksByUser.filter(function (t) {
-                return !t.streetCompletedByAnyUser();
+                return t.getStreetPriority() === 1;
             });
         }
 
@@ -448,7 +448,7 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
 
         // Only run this code if the neighborhood was set as incomplete
         if (!wasNeighborhoodCompleteAcrossAllUsers) {
-            var candidateTasks = self.getIncompleteTasksAcrossAllUsers().filter(function (t) {
+            var candidateTasks = self.getIncompleteTasksAcrossAllUsersUsingPriority().filter(function (t) {
                 return (t.getStreetEdgeId() !== (finishedTask ? finishedTask.getStreetEdgeId() : null));
             });
             // Indicates neighborhood is complete


### PR DESCRIPTION
Resolves #846 

Changes
* The mission complete modal now shows neighborhood progress across all users. We differentiate b/w audits by other users, past audits by the current user, and the current user's most recent mission (see before/after images below).
* Neighborhood complete popup now shows up when all streets in the neighborhood have a priority less than 1 instead of when all the streets have been audited by anyone. The difference is that we aren't counting audits of "low quality" users when deciding when to say we've completed the neighborhood.

Before:
![mission-complete-before2](https://user-images.githubusercontent.com/6518824/54940471-041e8900-4ee8-11e9-9ba1-0d52740b92da.png)

After:
![mission-complete-after2](https://user-images.githubusercontent.com/6518824/54940477-07b21000-4ee8-11e9-92d2-79c791bc48fc.png)

Given time constraints on others, I won't ask anyone to review the PR. But it is a significant enough change that we will make sure to test out completing missions thoroughly on the test servers before merging into master.