### PR TITLE
1570 deal with missing gsv imagery

### DIFF
--- a/app/views/audit.scala.html
+++ b/app/views/audit.scala.html
@@ -880,13 +880,9 @@
                     }}                    
                 }
                 else {
-                    // no street view available in this range.
+                    // No street view available in this range.
                     console.error("Error loading Street View imagery: " + status);
                     console.log("Street edge we are trying to audit: " + @task.map(_.edgeId).getOrElse(-1));
-                    svl.tracker.push("PanoId_NotFound_Onload", {'Location': JSON.stringify(latLng), 'StreetEdgeId': @task.map(_.edgeId).getOrElse(-1)});
-                    // Reload page (May need a better solution than this one, issue #1570)
-                    window.location.href = window.location.origin + "/audit";
-//                  throw "Error loading Street View imagery.";
 
                 }
             });

--- a/check_streets_for_imagery.py
+++ b/check_streets_for_imagery.py
@@ -22,8 +22,9 @@ if __name__ == '__main__':
 
     for index, street in street_data.iterrows():
         # Check if there is imagery at each endpoint
-        first_endpoint = requests.get('https://maps.googleapis.com/maps/api/streetview/metadata?source=outdoor&radius=25&location=' + str(street.y1) + ',' + str(street.x1) + '&key=' + api_key)
-        second_endpoint = requests.get('https://maps.googleapis.com/maps/api/streetview/metadata?source=outdoor&radius=25&location=' + str(street.y2) + ',' + str(street.x2) + '&key=' + api_key)
+        gsv_url = 'https://maps.googleapis.com/maps/api/streetview/metadata?source=outdoor&radius=25&key=' + api_key
+        first_endpoint = requests.get(gsv_url + '&location=' + str(street.y1) + ',' + str(street.x1))
+        second_endpoint = requests.get(gsv_url + '&location=' + str(street.y2) + ',' + str(street.x2))
 
         first_endpoint_status = json_normalize(first_endpoint.json()).status[0]
         second_endpoint_status = json_normalize(second_endpoint.json()).status[0]

--- a/check_streets_for_imagery.py
+++ b/check_streets_for_imagery.py
@@ -1,0 +1,47 @@
+import requests
+import pandas as pd
+from pandas.io.json import json_normalize
+
+# Create CSV from street_edge table with street_edge_id, x1, y1, x2, y2
+# Name it street_edge_endpoints.csv and put it in the root directory, then run this script.
+# It will output a CSV called streets_with_no_imagery.csv. Use this to mark those edges as "deleted" in the database.
+
+if __name__ == '__main__':
+
+    # Read google maps API key from file.
+    api_key_file = open("google_maps_api_key.txt", "r")
+    api_key = api_key_file.readline().strip()
+    api_key_file.close()
+
+    # Read street edge data from CSV.
+    street_data = pd.read_csv('street_edge_endpoints.csv')
+
+    # Create dataframes that will hold output data.
+    one_endpoint_data = pd.DataFrame(columns=['street_edge_id','problem_endpoint'])
+    both_endpoints_data = pd.DataFrame(columns=['street_edge_id'])
+
+    for index, street in street_data.iterrows():
+        # Check if there is imagery at each endpoint
+        first_endpoint = requests.get('https://maps.googleapis.com/maps/api/streetview/metadata?source=outdoor&radius=25&location=' + str(street.y1) + ',' + str(street.x1) + '&key=' + api_key)
+        second_endpoint = requests.get('https://maps.googleapis.com/maps/api/streetview/metadata?source=outdoor&radius=25&location=' + str(street.y2) + ',' + str(street.x2) + '&key=' + api_key)
+
+        first_endpoint_status = json_normalize(first_endpoint.json()).status[0]
+        second_endpoint_status = json_normalize(second_endpoint.json()).status[0]
+
+        # If there is no GSV data at either endpoint, add to both_endpoints_data. If only one endpoint is missing GSV
+        # imagery, add to one_endpoint_data.
+        if first_endpoint_status == 'ZERO_RESULTS' and second_endpoint_status == 'ZERO_RESULTS':
+            both_endpoints_data = both_endpoints_data.append({'street_edge_id': street.street_edge_id}, ignore_index=True)
+        elif first_endpoint_status == 'ZERO_RESULTS':
+            one_endpoint_data = one_endpoint_data.append({'street_edge_id': street.street_edge_id, 'problem_endpoint': 1}, ignore_index=True)
+        elif second_endpoint_status == 'ZERO_RESULTS':
+            one_endpoint_data = one_endpoint_data.append({'street_edge_id': street.street_edge_id, 'problem_endpoint': 2}, ignore_index=True)
+
+    # Convert street_edge_id columns from float to int.
+    one_endpoint_data.street_edge_id = one_endpoint_data.street_edge_id.astype('int32')
+    one_endpoint_data.problem_endpoint = one_endpoint_data.problem_endpoint.astype('int32')
+    both_endpoints_data.street_edge_id = both_endpoints_data.street_edge_id.astype('int32')
+
+    # Output both_endpoints_data and one_endpoint_data as CSVs.
+    one_endpoint_data.to_csv('streets_with_partial_imagery.csv', index=False)
+    both_endpoints_data.to_csv('streets_with_no_imagery.csv', index=False)

--- a/check_streets_for_imagery.py
+++ b/check_streets_for_imagery.py
@@ -1,6 +1,8 @@
 import requests
 import pandas as pd
 from pandas.io.json import json_normalize
+import time
+import sys
 
 # Create CSV from street_edge table with street_edge_id, x1, y1, x2, y2
 # Name it street_edge_endpoints.csv and put it in the root directory, then run this script.
@@ -23,7 +25,13 @@ if __name__ == '__main__':
     one_endpoint_data = pd.DataFrame(columns=['street_edge_id','problem_endpoint'])
     both_endpoints_data = pd.DataFrame(columns=['street_edge_id'])
 
+    n_rows = len(street_data)
     for index, street in street_data.iterrows():
+        # Print a progress percentage.
+        percent_complete = 100 * round(float(index + 1) / n_rows, 3)
+        sys.stdout.write("\r%.1f%% complete" % percent_complete)
+        sys.stdout.flush()
+
         # Check if there is imagery at each endpoint
         gsv_url = 'https://maps.googleapis.com/maps/api/streetview/metadata?source=outdoor&radius=25&key=' + api_key
         first_endpoint = requests.get(gsv_url + '&location=' + str(street.y1) + ',' + str(street.x1))
@@ -40,6 +48,7 @@ if __name__ == '__main__':
             one_endpoint_data = one_endpoint_data.append({'street_edge_id': street.street_edge_id, 'problem_endpoint': 1}, ignore_index=True)
         elif second_endpoint_status == 'ZERO_RESULTS':
             one_endpoint_data = one_endpoint_data.append({'street_edge_id': street.street_edge_id, 'problem_endpoint': 2}, ignore_index=True)
+    print # Adds newline after the progress percentage.
 
     # Convert street_edge_id columns from float to int.
     one_endpoint_data.street_edge_id = one_endpoint_data.street_edge_id.astype('int32')

--- a/check_streets_for_imagery.py
+++ b/check_streets_for_imagery.py
@@ -40,7 +40,7 @@ if __name__ == '__main__':
 
         # If there is no GSV data at either endpoint, add to streets_with_no_imagery.
         if first_endpoint_status == 'ZERO_RESULTS' or second_endpoint_status == 'ZERO_RESULTS':
-            both_endpoints_data = streets_with_no_imagery.append({'street_edge_id': street.street_edge_id}, ignore_index=True)
+            streets_with_no_imagery = streets_with_no_imagery.append({'street_edge_id': street.street_edge_id}, ignore_index=True)
     print # Adds newline after the progress percentage.
 
     # Convert street_edge_id column from float to int.

--- a/check_streets_for_imagery.py
+++ b/check_streets_for_imagery.py
@@ -9,9 +9,12 @@ from pandas.io.json import json_normalize
 if __name__ == '__main__':
 
     # Read google maps API key from file.
-    api_key_file = open("google_maps_api_key.txt", "r")
-    api_key = api_key_file.readline().strip()
-    api_key_file.close()
+    try:
+        with open("google_maps_api_key.txt", "r") as api_key_file:
+            api_key = api_key_file.readline().strip()
+    except IOError:
+        print "Couldn't read google_maps_api_key.txt file"
+        exit(1)
 
     # Read street edge data from CSV.
     street_data = pd.read_csv('street_edge_endpoints.csv')


### PR DESCRIPTION
Resolves #1570 

Adds a script that will look through a CSV containing the endpoints for the street edges, check the GSV API for imagery at the endpoints, and output a CSV of streets that do not have imagery at both endpoints. It shows percentage progress in the terminal as it runs :blush: 

This script should be run when creating a database for a city. You should mark all the streets in the output CSV as "deleted" in the `street_edge` table.

I also removed the page refresh when no street view imagery is found (which shouldn't happen anymore). But when it was happening, an infinite refresh wasn't a great way to deal with it. Instead I am just logging which `street_edge_id` is causing the problem in the console so we can look at that.

Testing:
1. Create CSV from street_edge table with street_edge_id, x1, y1, x2, y2. Name it `street_edge_endpoints.csv` and put it in the root directory, then run the script.

Not going to ask anyone to test b/c this is something that only I will be using anyway and isn't going to be run on the server or anything :+1: 