### PR TITLE
1602 zoom out seattle

### DIFF
--- a/app/controllers/ConfigController.scala
+++ b/app/controllers/ConfigController.scala
@@ -23,7 +23,7 @@ class ConfigController @Inject() (implicit val env: Environment[User, SessionAut
     val southwestLng: Double = Play.configuration.getDouble("city-params.southwest-boundary-lng." + cityStr).get
     val northeastLat: Double = Play.configuration.getDouble("city-params.northeast-boundary-lat." + cityStr).get
     val northeastLng: Double = Play.configuration.getDouble("city-params.northeast-boundary-lng." + cityStr).get
-    val defaultZoom: Int = Play.configuration.getInt("city-params.default-map-zoom." + cityStr).get
+    val defaultZoom: Double = Play.configuration.getDouble("city-params.default-map-zoom." + cityStr).get
     Future.successful(Ok(Json.obj(
       "city_center" -> Json.obj("lat" -> cityLat, "lng" -> cityLng),
       "southwest_boundary" -> Json.obj("lat" -> southwestLat, "lng" -> southwestLng),

--- a/conf/cityparams.conf
+++ b/conf/cityparams.conf
@@ -31,7 +31,7 @@ city-params {
   city-center-lat {
     newberg-or = 45.308
     washington-dc = 38.892
-    seattle-wa = 47.607
+    seattle-wa = 47.615
   }
   city-center-lng {
     newberg-or = -122.958
@@ -66,6 +66,6 @@ city-params {
   default-map-zoom {
     newberg-or = 14.0
     washington-dc = 12.0
-    seattle-wa = 11.0
+    seattle-wa = 11.5
   }
 }

--- a/conf/cityparams.conf
+++ b/conf/cityparams.conf
@@ -66,6 +66,6 @@ city-params {
   default-map-zoom {
     newberg-or = 14
     washington-dc = 12
-    seattle-wa = 12
+    seattle-wa = 11
   }
 }

--- a/conf/cityparams.conf
+++ b/conf/cityparams.conf
@@ -64,8 +64,8 @@ city-params {
     seattle-wa = 27645
   }
   default-map-zoom {
-    newberg-or = 14
-    washington-dc = 12
-    seattle-wa = 11
+    newberg-or = 14.0
+    washington-dc = 12.0
+    seattle-wa = 11.0
   }
 }

--- a/public/javascripts/AccessibilityChoropleth.js
+++ b/public/javascripts/AccessibilityChoropleth.js
@@ -22,7 +22,8 @@ function AccessibilityChoropleth(_, $, turf, difficultRegionIds) {
         zoomControl: false,
         legendControl: {
             position: 'topright'
-        }
+        },
+        zoomSnap: 0.5
     });
     choropleth.scrollWheelZoom.disable();
 

--- a/public/javascripts/Admin/src/Admin.User.js
+++ b/public/javascripts/Admin/src/Admin.User.js
@@ -13,7 +13,8 @@ function AdminUser(params) {
     });
     var map = L.mapbox.map('admin-map', "kotarohara.8e0c6890", {
         maxZoom: 19,
-        minZoom: 9
+        minZoom: 9,
+        zoomSnap: 0.5
     });
     var popup = L.popup().setContent('<p>Hello world!<br />This is a nice popup.</p>');
 

--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -40,18 +40,20 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
     });
     var map = L.mapbox.map('admin-map', "kotarohara.8e0c6890", {
         maxZoom: 19,
-        minZoom: 9
+        minZoom: 9,
+        zoomSnap: 0.5
     });
 
     // a grayscale tileLayer for the choropleth
     L.mapbox.accessToken = 'pk.eyJ1IjoibWlzYXVnc3RhZCIsImEiOiJjajN2dTV2Mm0wMDFsMndvMXJiZWcydDRvIn0.IXE8rQNF--HikYDjccA7Ug';
     var choropleth = L.mapbox.map('admin-choropleth', "kotarohara.8e0c6890", {
-            maxZoom: 19,
-            minZoom: 9,
-            legendControl: {
-                position: 'bottomleft'
-            }
-        });
+        maxZoom: 19,
+        minZoom: 9,
+        legendControl: {
+            position: 'bottomleft'
+        },
+        zoomSnap: 0.5
+    });
     choropleth.scrollWheelZoom.disable();
 
     // Set the city-specific default zoom and location.

--- a/public/javascripts/Choropleth.js
+++ b/public/javascripts/Choropleth.js
@@ -15,7 +15,8 @@ function Choropleth(_, $, turf, difficultRegionIds) {
         zoomControl: false,
         legendControl: {
             position: 'bottomleft'
-        }
+        },
+        zoomSnap: 0.5
     });
     choropleth.scrollWheelZoom.disable();
 

--- a/public/javascripts/Progress/src/Progress.js
+++ b/public/javascripts/Progress/src/Progress.js
@@ -34,7 +34,8 @@ function Progress (_, $, c3, L, role, difficultRegionIds) {
     });
     var map = L.mapbox.map('map', "kotarohara.8e0c6890", {
         maxZoom: 19,
-        minZoom: 9
+        minZoom: 9,
+        zoomSnap: 0.5
     });
 
     // Set the city-specific default zoom, location, and max bounding box to prevent the user from panning away.

--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionCompleteMap.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionCompleteMap.js
@@ -5,7 +5,8 @@ function ModalMissionCompleteMap(uiModalMissionComplete) {
     this._map = L.mapbox.map(uiModalMissionComplete.map.get(0), "kotarohara.8e0c6890", {
         maxZoom: 19,
         minZoom: 10,
-        style: 'mapbox://styles/projectsidewalk/civfm8qwi000l2iqo9ru4uhhj'
+        style: 'mapbox://styles/projectsidewalk/civfm8qwi000l2iqo9ru4uhhj',
+        zoomSnap: 0.5
     });
 
     // Set the city-specific default zoom, location, and max bounding box to prevent the user from panning away.

--- a/public/javascripts/accessScoreDemo.js
+++ b/public/javascripts/accessScoreDemo.js
@@ -5,8 +5,9 @@ $(document).ready(function () {
 
     tileUrl = "https:\/\/a.tiles.mapbox.com\/v4\/kotarohara.8e0c6890\/{z}\/{x}\/{y}.png?access_token=pk.eyJ1Ijoia290YXJvaGFyYSIsImEiOiJDdmJnOW1FIn0.kJV65G6eNXs4ATjWCtkEmA";
     map = L.mapbox.map('map', "kotarohara.8e0c6890", {
-            maxZoom: 19,
-            minZoom: 9
+        maxZoom: 19,
+        minZoom: 9,
+        zoomSnap: 0.5
     });
 
     // Set the city-specific default zoom, location, and max bounding box to prevent the user from panning away.

--- a/public/javascripts/developer.js
+++ b/public/javascripts/developer.js
@@ -15,17 +15,19 @@ $(document).ready(function () {
 
     // Maps
     var mapAccessAttributes = L.mapbox.map('developer-access-attribute-map', "kotarohara.8e0c6890", {
-            maxBounds: bounds,
-            maxZoom: 19,
-            minZoom: 9
-        })
+        maxBounds: bounds,
+        maxZoom: 19,
+        minZoom: 9,
+        zoomSnap: 0.5
+    })
         .fitBounds(bounds)
         .setView([38.910, -76.984], 15);
     var mapAccessScoreStreets = L.mapbox.map('developer-access-score-streets-map', "kotarohara.8e0c6890", {
-            maxBounds: bounds,
-            maxZoom: 19,
-            minZoom: 9
-        })
+        maxBounds: bounds,
+        maxZoom: 19,
+        minZoom: 9,
+        zoomSnap: 0.5
+    })
         .fitBounds(bounds)
         .setView([38.9195, -77.019], 14);
     var mapAccesScoreNeighborhoods = L.mapbox.map('developer-access-score-neighborhoods-map', "kotarohara.8e0c6890", {

--- a/public/javascripts/mapEdit.js
+++ b/public/javascripts/mapEdit.js
@@ -18,7 +18,8 @@ $(document).ready(function () {
             // http://leafletjs.com/reference.html#map-maxbounds
             maxBounds: bounds,
             maxZoom: 19,
-            minZoom: 9
+            minZoom: 9,
+            zoomSnap: 0.5
         })
         // .addLayer(mapboxTiles)
         .fitBounds(bounds)


### PR DESCRIPTION
Fixes #1602 

Sets the default zoom for maps of Seattle to be 0.5 zoom levels further zoomed out so that we can see all of Seattle on the maps by default. Here is a before/after:

![seattle-choropleth-zoomed](https://user-images.githubusercontent.com/6518824/55374072-15edc680-54bc-11e9-83dd-9cd10a40e02d.png)
![seattle-mid-zoom](https://user-images.githubusercontent.com/6518824/55374077-17b78a00-54bc-11e9-895b-2430fd055548.png)

Very simple fix so not asking anyone to test.