### PR TITLE
1595 shorten mission lengths

### DIFF
--- a/app/models/mission/MissionTable.scala
+++ b/app/models/mission/MissionTable.scala
@@ -93,10 +93,9 @@ object MissionTable {
   val labelTypes = TableQuery[LabelTypeTable]
   val regionProperties = TableQuery[RegionPropertyTable]
 
-  // Distances for first few missions: 500ft, 500ft, 1000ft, 1000ft, then 1/4 mile for all remaining. This is just a
-  // temporary setup for that sake of testing the new missions infrastructure.
+  // Distances for first few missions: 500 ft, 500 ft, 750 ft, then 1,000 ft for all remaining.
   val distancesForFirstAuditMissions: List[Float] = List(152.4F, 152.4F, 228.6F)
-  val distanceForLaterMissions: Float = 304.8F // 1/4 mile
+  val distanceForLaterMissions: Float = 304.8F // 1,000 ft
 
   // Number of labels for validation mission
   val validationMissionLabelCount: Int = 10

--- a/app/models/mission/MissionTable.scala
+++ b/app/models/mission/MissionTable.scala
@@ -95,8 +95,8 @@ object MissionTable {
 
   // Distances for first few missions: 500ft, 500ft, 1000ft, 1000ft, then 1/4 mile for all remaining. This is just a
   // temporary setup for that sake of testing the new missions infrastructure.
-  val distancesForFirstAuditMissions: List[Float] = List(152.4F, 152.4F, 304.8F, 304.8F)
-  val distanceForLaterMissions: Float = 402.336F // 1/4 mile
+  val distancesForFirstAuditMissions: List[Float] = List(152.4F, 152.4F, 228.6F)
+  val distanceForLaterMissions: Float = 304.8F // 1/4 mile
 
   // Number of labels for validation mission
   val validationMissionLabelCount: Int = 10

--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMission.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMission.js
@@ -204,8 +204,10 @@ ModalMission.prototype._distanceToString = function  (distance, unit) {
 
     distance = distance.toPrecision(4);
 
-    if (distance === "0.0947"){
+    if (distance === "0.0947") {
         return "500ft";
+    } else if (distance === "0.1420") {
+        return "750ft";
     } else if (distance === "0.1894") {
         return "1000ft";
     } else if (distance === "0.2500") {

--- a/public/javascripts/SVLabel/src/SVLabel/status/StatusFieldMission.js
+++ b/public/javascripts/SVLabel/src/SVLabel/status/StatusFieldMission.js
@@ -43,6 +43,8 @@ StatusFieldMission.prototype._distanceToString = function (distance, unit) {
 
     if (distance === "0.0947"){
         return "500ft";
+    } else if (distance === "0.1420") {
+        return "750ft";
     } else if (distance === "0.1894") {
         return "1000ft";
     } else if (distance === "0.2500") {


### PR DESCRIPTION
Resolves #1595 

Shortens mission lengths from 500 ft, 500 ft, 1000 ft, 1000 ft, the rest 1/4 mile to 500 ft, 500 ft, 750 ft, the rest 1000 ft.

Very simple change so not asking anyone to review/test.