### PR TITLE
1613 randomize first street in neighborhood

### DIFF
--- a/app/models/audit/AuditTaskTable.scala
+++ b/app/models/audit/AuditTaskTable.scala
@@ -447,7 +447,7 @@ object AuditTaskTable {
     } yield (se.streetEdgeId, se.geom, se.x1, se.y1, se.x2, se.y2, timestamp, sc._2, sp.priority, false)
 
     // Get the priority of the highest priority task.
-    val highestPriority: Option[Double] = possibleTasks.map(_._9).min.run
+    val highestPriority: Option[Double] = possibleTasks.map(_._9).max.run
 
     // Get list of tasks that have this priority.
     val highestPriorityTasks: Option[List[NewTask]] = highestPriority.map { highPriority =>

--- a/app/models/audit/AuditTaskTable.scala
+++ b/app/models/audit/AuditTaskTable.scala
@@ -446,8 +446,16 @@ object AuditTaskTable {
       sc <- streetCompletedByAnyUser if se.streetEdgeId === sc._1
     } yield (se.streetEdgeId, se.geom, se.x1, se.y1, se.x2, se.y2, timestamp, sc._2, sp.priority, false)
 
-    // Get the highest priority task.
-    possibleTasks.sortBy(_._9.desc).firstOption.map(NewTask.tupled)
+    // Get the priority of the highest priority task.
+    val highestPriority: Option[Double] = possibleTasks.map(_._9).min.run
+
+    // Get list of tasks that have this priority.
+    val highestPriorityTasks: Option[List[NewTask]] = highestPriority.map { highPriority =>
+      possibleTasks.filter(_._9 === highPriority).list.map(NewTask.tupled)
+    }
+
+    // Choose one of the highest priority tasks at random.
+    highestPriorityTasks.flatMap(scala.util.Random.shuffle(_).headOption)
   }
 
   /**


### PR DESCRIPTION
Fixes #1613 

Instead of running a query that sorts the streets by priority and taking the first street that is returned, we now take one street randomly from the list of streets with the highest priority in the region.

Super easy change so I'm not asking anyone to test.