### PR TITLE
added decimal to percentage of city complete on landing page

### DIFF
--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -222,7 +222,7 @@
                     if(@("%.0f".format(StreetEdgeTable.streetDistanceCompletionRate(1) * 100))<100){
                         document.getElementById('conditional-text').innerHTML = "Users like you have already mapped @("%.0f".format(StreetEdgeTable.auditedStreetDistance(1))) miles of @cityName, @stateAbbreviation&mdash;that's @("%.1f".format(StreetEdgeTable.streetDistanceCompletionRate(1) * 100))% of the city!";
                     } else {
-                        document.getElementById('conditional-text') .innerHTML = "We did it! Users like you have mapped all @("%.0f".format(StreetEdgeTable.auditedStreetDistance(1))) miles of @cityName, @stateAbbreviation. However, we are not done. The more users who contribute, the better quality data. So start exploring today!";
+                        document.getElementById('conditional-text').innerHTML = "We did it! Users like you have mapped all @("%.0f".format(StreetEdgeTable.auditedStreetDistance(1))) miles of @cityName, @stateAbbreviation. However, we are not done. The more users who contribute, the better quality data. So start exploring today!";
                     }
 
                     var percentageAnim = new CountUp("percentage", 0, @("%.1f".format(StreetEdgeTable.streetDistanceCompletionRate(1) * 100)),1,2.5,{suffix:'%'});

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -220,14 +220,14 @@
             </div>
             <script language="javascript">
                     if(@("%.0f".format(StreetEdgeTable.streetDistanceCompletionRate(1) * 100))<100){
-                        document.getElementById('conditional-text').innerHTML = "Users like you have already mapped @("%.0f".format(StreetEdgeTable.auditedStreetDistance(1))) miles of @cityName, @stateAbbreviation&mdash;that's nearly @("%.0f".format(StreetEdgeTable.streetDistanceCompletionRate(1) * 100))% of the city!";
+                        document.getElementById('conditional-text').innerHTML = "Users like you have already mapped @("%.0f".format(StreetEdgeTable.auditedStreetDistance(1))) miles of @cityName, @stateAbbreviation&mdash;that's @("%.1f".format(StreetEdgeTable.streetDistanceCompletionRate(1) * 100))% of the city!";
                     } else {
-                        document.getElementById('conditional-text').innerHTML = "We did it! Users like you have mapped all @("%.0f".format(StreetEdgeTable.auditedStreetDistance(1))) miles of @cityName, @stateAbbreviation. However, we are not done. The more users who contribute, the better quality data. So start exploring today!";
+                        document.getElementById('conditional-text') .innerHTML = "We did it! Users like you have mapped all @("%.0f".format(StreetEdgeTable.auditedStreetDistance(1))) miles of @cityName, @stateAbbreviation. However, we are not done. The more users who contribute, the better quality data. So start exploring today!";
                     }
 
-                    var percentageAnim = new CountUp("percentage", 0, @("%.0f".format(StreetEdgeTable.streetDistanceCompletionRate(1) * 100)),0,2.5,{suffix:'%'});
+                    var percentageAnim = new CountUp("percentage", 0, @("%.1f".format(StreetEdgeTable.streetDistanceCompletionRate(1) * 100)),1,2.5,{suffix:'%'});
                     var labelsAnim = new CountUp("numlabels", 0, @LabelTable.countLabels,0,2.5,{suffix:''});
-                    var milesAnim = new CountUp("nummiles", 0, @("%.2f".format(StreetEdgeTable.auditedStreetDistance(1))),0,2.5,{suffix:''});
+                    var milesAnim = new CountUp("nummiles", 0, @("%.1f".format(StreetEdgeTable.auditedStreetDistance(1))),1,2.5,{suffix:''});
             </script>
         </div>
     </div>


### PR DESCRIPTION
Fixes #1614 

Deals with the weird wording of "that's nearly 0% of the city!" by removing the word "nearly" and adding a decimal to the percentage. We also added a decimal to the number of miles audited.

Before
![landing-page-no-decimals](https://user-images.githubusercontent.com/6518824/55655985-8e999f00-57aa-11e9-9f98-b1e140b643c0.png)

After
![landing-page-with-decimals](https://user-images.githubusercontent.com/6518824/55655965-7e81bf80-57aa-11e9-8c8c-0c9cfc0bc81f.png)

Trivial change so not asking anyone to test.