### PR TITLE
(Partially?) Resolves #1584: Fix problem with prematurely ending missions

### DIFF
--- a/app/controllers/ValidationController.scala
+++ b/app/controllers/ValidationController.scala
@@ -14,6 +14,7 @@ import models.amt.AMTAssignmentTable
 import models.daos.slick.DBTableDefinitions.{DBUser, UserTable}
 import models.label.LabelTable
 import models.label.LabelTable.LabelValidationMetadata
+import models.label.LabelValidationTable
 import models.mission.Mission
 import models.mission.MissionTable
 import models.validation._
@@ -51,16 +52,13 @@ class ValidationController @Inject() (implicit val env: Environment[User, Sessio
             val index: Int = if (possibleLabelTypeIds.size > 1) scala.util.Random.nextInt(possibleLabelTypeIds.size - 1) else 0
             val labelTypeId: Int = possibleLabelTypeIds(index)
             val mission: Mission = MissionTable.resumeOrCreateNewValidationMission(user.userId, AMTAssignmentTable.TURKER_PAY_PER_LABEL_VALIDATION, 0.0, labelTypeId).get
-            val labelsProgress: Int = mission.labelsProgress.get
-            val labelsValidated: Int = mission.labelsValidated.get
-            val labelsToRetrieve: Int = labelsValidated - labelsProgress
-
-            val labelList: JsValue = getLabelListForValidation(user.userId, labelsToRetrieve, labelTypeId)
+            val labelList: JsValue = getLabelListForValidation(user.userId, labelTypeId, mission)
             val missionJsObject: JsObject = mission.toJSON
-            Future.successful(Ok(views.html.validation("Project Sidewalk - Validate", Some(user), Some(missionJsObject), Some(labelList), true)))
+            val progressJsObject: JsObject = LabelValidationTable.getValidationProgress(mission.missionId)
+            Future.successful(Ok(views.html.validation("Project Sidewalk - Validate", Some(user), Some(missionJsObject), Some(labelList), Some(progressJsObject), true)))
           }
           case false => {
-            Future.successful(Ok(views.html.validation("Project Sidewalk - Validate", Some(user), None, None, false)))
+            Future.successful(Ok(views.html.validation("Project Sidewalk - Validate", Some(user), None, None, None, false)))
           }
         }
       case None =>
@@ -71,14 +69,18 @@ class ValidationController @Inject() (implicit val env: Environment[User, Sessio
   /**
     * This gets a random list of labels to validate for this mission.
     * @param userId     User ID for current user.
-    * @param count      Number of labels to retrieve for this list.
     * @param labelType  Label type id of labels to retrieve.
+    * @param mission    Mission object for the current mission
     * @return           JsValue containing a list of labels with the following attributes:
     *                   {label_id, label_type, gsv_panorama_id, heading, pitch, zoom, canvas_x,
     *                   canvas_y, canvas_width, canvas_height}
     */
-  def getLabelListForValidation(userId: UUID, count: Int, labelType: Int): JsValue = {
-    val labelMetadata: Seq[LabelValidationMetadata] = LabelTable.retrieveLabelListForValidation(userId, count, labelType)
+  def getLabelListForValidation(userId: UUID, labelType: Int, mission: Mission): JsValue = {
+    val labelsProgress: Int = mission.labelsProgress.get
+    val labelsValidated: Int = mission.labelsValidated.get
+    val labelsToRetrieve: Int = labelsValidated - labelsProgress
+
+    val labelMetadata: Seq[LabelValidationMetadata] = LabelTable.retrieveLabelListForValidation(userId, labelsToRetrieve, labelType)
     val labelMetadataJsonSeq: Seq[JsObject] = labelMetadata.map(label => LabelTable.validationLabelMetadataToJson(label))
     val labelMetadataJson : JsValue = Json.toJson(labelMetadataJsonSeq)
     labelMetadataJson

--- a/app/models/label/LabelValidationTable.scala
+++ b/app/models/label/LabelValidationTable.scala
@@ -72,19 +72,17 @@ object LabelValidationTable {
     * Gets a JSON object that holds additional information about the number of label validation
     * results for the current mission
     * @param missionId  Mission ID of the current mission
-    * @return
+    * @return           JSON Object with information about agree/disagree/not sure counts
     */
   def getValidationProgress (missionId: Int): JsObject = {
-    // We should probably move this somewhere else later...
     val agreeCount: Int = countResultsFromValidationMission(missionId, 1)
     val disagreeCount: Int = countResultsFromValidationMission(missionId, 2)
-    val unsureCount: Int = countResultsFromValidationMission(missionId, 3)
-    println("Agree Count: " + agreeCount + ", disagreeCount: " + disagreeCount + ", unsureCount: " + unsureCount)
+    val notSureCount: Int = countResultsFromValidationMission(missionId, 3)
 
     Json.obj(
       "agree_count" -> agreeCount,
       "disagree_count" -> disagreeCount,
-      "unsure_count" -> unsureCount
+      "not_sure_count" -> notSureCount
     )
   }
 

--- a/app/models/label/LabelValidationTable.scala
+++ b/app/models/label/LabelValidationTable.scala
@@ -56,11 +56,41 @@ class LabelValidationTable (tag: slick.lifted.Tag) extends Table[LabelValidation
   */
 object LabelValidationTable {
   val db = play.api.db.slick.DB
-  val labelValidationTable = TableQuery[LabelValidationTable]
+  val validationLabels = TableQuery[LabelValidationTable]
+
+  /**
+    * Returns how many agree, disagree, or unsure validations a user entered for a given mission
+    * @param missionId  Mission ID of mission
+    * @param result     Validation result (1 - agree, 2 - disagree, 3 - unsure)
+    * @return           Number of labels that were
+    */
+  def countResultsFromValidationMission(missionId: Int, result: Int): Int = db.withSession { implicit session =>
+    validationLabels.filter(_.missionId === missionId).filter(_.validationResult === result).list.size
+  }
+
+  /**
+    * Gets a JSON object that holds additional information about the number of label validation
+    * results for the current mission
+    * @param missionId  Mission ID of the current mission
+    * @return
+    */
+  def getValidationProgress (missionId: Int): JsObject = {
+    // We should probably move this somewhere else later...
+    val agreeCount: Int = countResultsFromValidationMission(missionId, 1)
+    val disagreeCount: Int = countResultsFromValidationMission(missionId, 2)
+    val unsureCount: Int = countResultsFromValidationMission(missionId, 3)
+    println("Agree Count: " + agreeCount + ", disagreeCount: " + disagreeCount + ", unsureCount: " + unsureCount)
+
+    Json.obj(
+      "agree_count" -> agreeCount,
+      "disagree_count" -> disagreeCount,
+      "unsure_count" -> unsureCount
+    )
+  }
 
   def save(label: LabelValidation): Int = db.withTransaction { implicit session =>
     val labelValidationId: Int =
-      (labelValidationTable returning labelValidationTable.map(_.labelValidationId)) += label
+      (validationLabels returning validationLabels.map(_.labelValidationId)) += label
     labelValidationId
   }
 }

--- a/app/views/validation.scala.html
+++ b/app/views/validation.scala.html
@@ -286,7 +286,6 @@
                 param.labelList = @Html(labelList.getOrElse("\"\"").toString);
                 param.progress = @Html(progress.getOrElse("\"\"").toString);
 
-                console.log(param.progress);
                 // Initializes an object of labels from label metadata.
                 // {key, labelMetadata} --> {key, Label}, where key = the index of the label.
                 Object.keys(param.labelList).map(function (key, index) {

--- a/app/views/validation.scala.html
+++ b/app/views/validation.scala.html
@@ -7,7 +7,7 @@
 @import play.api.libs.json.JsValue
 @import views.html.bootstrap._
 
-@(title: String, user: Option[User] = None, mission: Option[JsValue], labelList: Option[JsValue], hasNextMission: Boolean)
+@(title: String, user: Option[User] = None, mission: Option[JsValue], labelList: Option[JsValue], progress: Option[JsValue], hasNextMission: Boolean)
 
 @main(title, Some("/validate")) {
     @navbar(user, Some("/validate"))
@@ -284,7 +284,9 @@
             if (@hasNextMission) {
                 param.mission = @Html(mission.getOrElse("\"\"").toString);
                 param.labelList = @Html(labelList.getOrElse("\"\"").toString);
+                param.progress = @Html(progress.getOrElse("\"\"").toString);
 
+                console.log(param.progress);
                 // Initializes an object of labels from label metadata.
                 // {key, labelMetadata} --> {key, Label}, where key = the index of the label.
                 Object.keys(param.labelList).map(function (key, index) {

--- a/public/javascripts/SVValidate/css/svv-left-column.css
+++ b/public/javascripts/SVValidate/css/svv-left-column.css
@@ -1,7 +1,7 @@
 #left-column-control-pane {
     position: relative;
     left: -60px;
-    top: 290px;
+    top: 210px;
 }
 
 #left-column-button-holder .button {

--- a/public/javascripts/SVValidate/src/Main.js
+++ b/public/javascripts/SVValidate/src/Main.js
@@ -131,7 +131,7 @@ function Main (param) {
         svv.modalNoNewMission = new ModalNoNewMission(svv.ui.modalMission);
 
         svv.missionContainer = new MissionContainer();
-        svv.missionContainer.createAMission(param.mission);
+        svv.missionContainer.createAMission(param.mission, param.progress);
     }
 
     _initUI();

--- a/public/javascripts/SVValidate/src/data/Form.js
+++ b/public/javascripts/SVValidate/src/data/Form.js
@@ -67,7 +67,7 @@ function Form(url) {
                     // If a mission was returned after posting data, create a new mission.
                     if (result.hasMissionAvailable) {
                         if (result.mission) {
-                            svv.missionContainer.createAMission(result.mission);
+                            svv.missionContainer.createAMission(result.mission, result.progress);
                             svv.panoramaContainer.reset();
                             svv.panoramaContainer.setLabelList(result.labels);
                             svv.panoramaContainer.loadNewLabelOntoPanorama();

--- a/public/javascripts/SVValidate/src/mission/Mission.js
+++ b/public/javascripts/SVValidate/src/mission/Mission.js
@@ -25,6 +25,8 @@ function Mission(params) {
      * Initializes a front-end mission object from metadata.
      */
     function _init() {
+        if ("agreeCount" in params) setProperty("agreeCount", params.agreeCount);
+        if ("disagreeCount" in params) setProperty("disagreeCount", params.disagreeCount);
         if ("missionId" in params) setProperty("missionId", params.missionId);
         if ("missionType" in params) setProperty("missionType", params.missionType);
         if ("regionId" in params) setProperty("regionId", params.regionId);
@@ -34,6 +36,7 @@ function Mission(params) {
         if ("labelsProgress" in params) setProperty("labelsProgress", params.labelsProgress);
         if ("labelsValidated" in params) setProperty("labelsValidated", params.labelsValidated);
         if ("labelTypeId" in params) setProperty("labelTypeId", params.labelTypeId);
+        if ("notSureCount" in params) setProperty("notSureCount", params.notSureCount);
         if ("skipped" in params) setProperty("skipped", params.skipped);
     }
 
@@ -84,7 +87,7 @@ function Mission(params) {
             setProperty("labelsProgress", labelsProgress);
 
             // Submit mission if mission is complete
-            if (labelsProgress == getProperty("labelsValidated")) {
+            if (labelsProgress === getProperty("labelsValidated")) {
                 setProperty("completed", true);
                 svv.missionContainer.completeAMission();
             }

--- a/public/javascripts/SVValidate/src/mission/MissionContainer.js
+++ b/public/javascripts/SVValidate/src/mission/MissionContainer.js
@@ -51,16 +51,21 @@ function MissionContainer () {
     /**
      * Creates a mission by parsing a JSON file
      * @param missionMetadata   JSON metadata for mission (from backend)
+     * @param progressMetadata  JSON metadata about mission progress
+     *                          (counts of agree/disagree/unsure labels for this mission)
      * @private
      */
-    function createAMission(missionMetadata) {
+    function createAMission(missionMetadata, progressMetadata) {
         var metadata = {
+            agreeCount: progressMetadata.agree_count,
             completed : missionMetadata.completed,
+            disagreeCount: progressMetadata.disagree_count,
             labelsProgress : missionMetadata.labels_progress,
             labelsValidated : missionMetadata.labels_validated,
             labelTypeId : missionMetadata.label_type_id,
             missionId : missionMetadata.mission_id,
             missionType : missionMetadata.mission_type,
+            notSureCount: progressMetadata.not_sure_count,
             skipped : missionMetadata.skipped,
             pay: missionMetadata.pay
         };

--- a/public/javascripts/SVValidate/src/modal/ModalMission.js
+++ b/public/javascripts/SVValidate/src/modal/ModalMission.js
@@ -1,11 +1,18 @@
 function ModalMission (uiModalMission, user) {
     var self = this;
 
-    var validationMissionDescriptionHTML = ' <figure> \
+    var validationStartMissionHTML = ' <figure> \
         <img src="/assets/javascripts/SVLabel/img/icons/AccessibilityFeatures.png" class="modal-mission-images center-block" alt="Street accessibility features" /> \
         </figure> \
         <div class="spacer10"></div>\
         <p>Your mission is to determine the correctness of  __LABELCOUNT_PLACEHOLDER__ __LABELTYPE_PLACEHOLDER__</span> labels placed by other users!</p>\
+        <div class="spacer10"></div>';
+
+    var validationResumeMissionHTML = ' <figure> \
+        <img src="/assets/javascripts/SVLabel/img/icons/AccessibilityFeatures.png" class="modal-mission-images center-block" alt="Street accessibility features" /> \
+        </figure> \
+        <div class="spacer10"></div>\
+        <p>Continue validating  __LABELCOUNT_PLACEHOLDER__ __LABELTYPE_PLACEHOLDER__</span> labels placed by other users!</p>\
         <div class="spacer10"></div>';
 
     function _handleButtonClick() {
@@ -13,19 +20,32 @@ function ModalMission (uiModalMission, user) {
         hide();
     }
 
+    /**
+     * Hides the new/continuing mission screen
+     */
     function hide () {
         uiModalMission.background.css('visibility', 'hidden');
         uiModalMission.holder.css('visibility', 'hidden');
         uiModalMission.foreground.css('visibility', 'hidden');
     }
 
+    /**
+     * Generates HTML for the new mission screen with information about the current mission
+     * (label type, length of validation mission)
+     * @param mission   Mission object for the new mission
+     */
     function setMissionMessage(mission) {
         if (mission.getProperty("labelsProgress") === 0) {
             var validationMissionStartTitle = "Validate " + mission.getProperty("labelsValidated")
                 + " " + svv.labelTypeNames[mission.getProperty("labelTypeId")] + " labels";
-            validationMissionDescriptionHTML = validationMissionDescriptionHTML.replace("__LABELCOUNT_PLACEHOLDER__", mission.getProperty("labelsValidated"));
-            validationMissionDescriptionHTML = validationMissionDescriptionHTML.replace("__LABELTYPE_PLACEHOLDER__", svv.labelTypeNames[mission.getProperty("labelTypeId")]);
-            show(validationMissionStartTitle, validationMissionDescriptionHTML);
+            validationStartMissionHTML = validationStartMissionHTML.replace("__LABELCOUNT_PLACEHOLDER__", mission.getProperty("labelsValidated"));
+            validationStartMissionHTML = validationStartMissionHTML.replace("__LABELTYPE_PLACEHOLDER__", svv.labelTypeNames[mission.getProperty("labelTypeId")]);
+            show(validationMissionStartTitle, validationStartMissionHTML);
+        } else {
+            validationMissionStartTitle = "Return to your mission";
+            validationResumeMissionHTML = validationResumeMissionHTML.replace("__LABELCOUNT_PLACEHOLDER__", mission.getProperty("labelsValidated"));
+            validationResumeMissionHTML = validationResumeMissionHTML.replace("__LABELTYPE_PLACEHOLDER__", svv.labelTypeNames[mission.getProperty("labelTypeId")]);
+            show(validationMissionStartTitle, validationResumeMissionHTML);
         }
 
         // Update the reward HTML if the user is a turker.
@@ -51,8 +71,11 @@ function ModalMission (uiModalMission, user) {
     }
 
     function show (title, instruction) {
+        if (instruction) {
+            uiModalMission.instruction.html(instruction);
+        }
+
         uiModalMission.background.css('visibility', 'visible');
-        uiModalMission.instruction.html(instruction);
         uiModalMission.missionTitle.html(title);
         uiModalMission.holder.css('visibility', 'visible');
         uiModalMission.foreground.css('visibility', 'visible');

--- a/public/javascripts/SVValidate/src/modal/ModalMissionComplete.js
+++ b/public/javascripts/SVValidate/src/modal/ModalMissionComplete.js
@@ -35,7 +35,9 @@ function ModalMissionComplete (uiModalMissionComplete, user, confirmationCode) {
      * @param mission   Object for the mission that was just completed.
      */
     function show (mission) {
-        var message = "You just validated " + mission.getProperty("labelsValidated") + " " +
+        var totalLabels = mission.getProperty("agreeCount") + mission.getProperty("disagreeCount")
+            + mission.getProperty("notSureCount");
+        var message = "You just validated " + totalLabels + " " +
             svv.labelTypeNames[mission.getProperty("labelTypeId")] + " labels!";
 
         // Disable user from clicking the "Validate next mission" button and set background go gray

--- a/public/javascripts/SVValidate/src/status/StatusExample.js
+++ b/public/javascripts/SVValidate/src/status/StatusExample.js
@@ -86,10 +86,10 @@ function StatusExample (statusUI) {
         var prefix = svv.statusField.createPrefix(labelType);
         if (id.includes("counterexample")) {
             statusUI.popupTitle.html("Not " + prefix + labelName);
-            statusUI.popup.css('top', '208px');
+            statusUI.popup.css('top', '118px');
         } else {
             statusUI.popupTitle.html(labelName);
-            statusUI.popup.css('top', '-8px');
+            statusUI.popup.css('top', '-98px');
         }
     }
 


### PR DESCRIPTION
(Partially?) Resolves #1584.

**Changes**
* Changed the "You validated 10 labels" text on mission complete screen to be the number of labels the user validated in their current session (rather than the number of labels in the mission)
* Added a resume mission screen to hopefully clear up some confusion about receiving validation missions that were partially complete

**Testing Instructions**
* Do some validation missions. Refresh the page part-way through some of these missions.
* When you complete a mission, check that the complete mission screen shows the accurate label counts (both in the description below the title and in the table)
* When you are getting a new mission (either on page load, or after you click "Validate more labels", check that the appropriate new mission/resume mission screen appears).

I tried to reproduce the issue where validation missions were ending prematurely, but couldn't seem to do it. In this process, I realized that some of our UI was a little confusing when we receive incomplete missions. This PR attempts to clear up some of that confusion.

Since we have multiple validation mission types (one mission type per label), it's possible for us to start a (fresh) new mission, and then receive a partially completed mission for a different label type later on. Incomplete validation missions work the following way: if you were given a mission to validate 10 obstacle in path labels, but only validated 4 labels, then the next time that you are given a obstacle validation mission, you would just have to validate 6 more labels to finish your old mission.

Before:
![image](https://user-images.githubusercontent.com/25534091/55672533-f30f3980-5850-11e9-8f71-91c87fe1a347.png)

After:
![image](https://user-images.githubusercontent.com/25534091/55672525-e1c62d00-5850-11e9-9a13-9b6c4e447642.png)

This is also what the new resume mission screen looks like:
![image](https://user-images.githubusercontent.com/25534091/55678388-ae65bb80-58ad-11e9-9932-71c5f2414fb7.png)
