### PR TITLE
1304 newcity landing page

### DIFF
--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -33,9 +33,12 @@
                     <br>
                     <a class="bodyStartBtn" href="@routes.AuditController.audit()">Start Exploring Seattle</a>
                     <br><br>
-                    @* TODO: Make automatically fill in with city url and hardcoded like this*@
-                    <a class="otherCityStartBtn" href="https://sidewalk.cs.washington.edu/audit">Map Washington DC</a> &nbsp;
-                    <a class="otherCityStartBtn" href="https://sidewalk-newberg.cs.washington.edu/audit">Map Newberg, OR</a>
+                    @* TODO: Make the city btn list automatically fill in with city url and NOT hardcoded like this*@
+                    @*<a class="otherCityStartBtn" href="https://sidewalk.cs.washington.edu/audit">Map Washington DC</a> &nbsp;*@
+                    @*<a class="otherCityStartBtn" href="https://sidewalk-newberg.cs.washington.edu/audit">Map Newberg, OR</a>*@
+                    <span class="header-text">We are also available in:</span>
+                    <a class="exploremaplink" href="https://sidewalk.cs.washington.edu/audit">Washington DC</a> &nbsp;
+                    <a class="exploremaplink" href="https://sidewalk-newberg.cs.washington.edu/audit">Newberg, OR</a>
 
                 </div>
                 <div class="col-sm-3"></div>

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -31,8 +31,11 @@
                         <span class="tagline">Let's create a path for everyone</span>
                     </p>
                     <br>
-                    <a class="bodyStartBtn" href="@routes.AuditController.audit()">Start Exploring</a>
+                    <a class="bodyStartBtn" href="@routes.AuditController.audit()">Start Exploring Seattle</a>
                     <br><br>
+                    @* TODO: Make automatically fill in with city url and hardcoded like this*@
+                    <a class="otherCityStartBtn" href="https://sidewalk.cs.washington.edu/audit">Map Washington DC</a> &nbsp;
+                    <a class="otherCityStartBtn" href="https://sidewalk-newberg.cs.washington.edu/audit">Map Newberg, OR</a>
 
                 </div>
                 <div class="col-sm-3"></div>

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -31,7 +31,7 @@
                         <span class="tagline">Let's create a path for everyone</span>
                     </p>
                     <br>
-                    <a class="bodyStartBtn" href="@routes.AuditController.audit()">Start Exploring Seattle</a>
+                    <a class="bodyStartBtn" href="@routes.AuditController.audit()">Start Exploring @cityShortName</a>
                     <br><br>
                     <span class="header-text">We are also in:</span>
                     @for((cityName, cityURL) <- otherCityURLs) {

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -3,7 +3,7 @@
 @import models.label._
 @import models.street.StreetEdgeTable
 @import play.api.libs.json.Json
-@(title: String, user: Option[User] = None, cityName: String, stateAbbreviation: String, cityShortName: String)
+@(title: String, user: Option[User] = None, cityName: String, stateAbbreviation: String, cityShortName: String, otherCityURLs: List[(String, String)])
 
 @main(title) {
     @navbar(user)
@@ -33,12 +33,10 @@
                     <br>
                     <a class="bodyStartBtn" href="@routes.AuditController.audit()">Start Exploring Seattle</a>
                     <br><br>
-                    @* TODO: Make the city btn list automatically fill in with city url and NOT hardcoded like this*@
-                    @*<a class="otherCityStartBtn" href="https://sidewalk.cs.washington.edu/audit">Map Washington DC</a> &nbsp;*@
-                    @*<a class="otherCityStartBtn" href="https://sidewalk-newberg.cs.washington.edu/audit">Map Newberg, OR</a>*@
-                    <span class="header-text">We are also available in:</span>
-                    <a class="exploremaplink" href="https://sidewalk.cs.washington.edu/audit">Washington DC</a> &nbsp;
-                    <a class="exploremaplink" href="https://sidewalk-newberg.cs.washington.edu/audit">Newberg, OR</a>
+                    <span class="header-text">We are also in:</span>
+                    @for((cityName, cityURL) <- otherCityURLs) {
+                        <a class="exploremaplink" href="@{cityURL + "/audit"}">@cityName</a> &nbsp;
+                    }
 
                 </div>
                 <div class="col-sm-3"></div>

--- a/conf/cityparams.conf
+++ b/conf/cityparams.conf
@@ -3,6 +3,11 @@ city-id = "washington-dc"
 city-id = ${?SIDEWALK_CITY_ID}
 
 city-params {
+  city-ids = [
+    "newberg-or"
+    "washington-dc"
+    "seattle-wa"
+  ]
   city-name {
     newberg-or = "Newberg"
     washington-dc = "Washington"
@@ -22,6 +27,11 @@ city-params {
     newberg-or = "Newberg"
     washington-dc = "DC"
     seattle-wa = "Seattle"
+  }
+  landing-page-url {
+    newberg-or = "https://sidewalk-newberg.cs.washington.edu"
+    washington-dc = "http://sidewalk.cs.washington.edu"
+    seattle-wa = "https://sidewalk-sea.cs.washington.edu"
   }
   google-analytics-id {
     newberg-or = "UA-136713858-1"

--- a/conf/cityparams.conf
+++ b/conf/cityparams.conf
@@ -30,7 +30,7 @@ city-params {
   }
   landing-page-url {
     newberg-or = "https://sidewalk-newberg.cs.washington.edu"
-    washington-dc = "http://sidewalk.cs.washington.edu"
+    washington-dc = "https://sidewalk.cs.washington.edu"
     seattle-wa = "https://sidewalk-sea.cs.washington.edu"
   }
   google-analytics-id {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1039,7 +1039,6 @@ video#bgvid {
     text-align:center;
     position:relative;
     cursor: pointer;
-    /*left: -30px;*/
 }
 .exploremaplink:hover {
     color: #fff;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1047,17 +1047,34 @@ video#bgvid {
     top:1px;
 }
 
-#exploremaplink {
+.header-text {
     color: #fff;
+    font-family: raleway;
+    font-size: 15px;
+    line-height:2.8em;
+    text-align:center;
+    position:relative;
+    cursor: default;
+    /*left: -30px;*/
+}
+
+.exploremaplink {
+    color: rgba(251, 215, 139, 1);
     text-decoration:underline;
     font-family: raleway;
-    font-size: 10px;
-    line-height:1.8em;
+    font-size: 15px;
+    font-weight: bolder;
+    line-height:2.8em;
     text-align:center;
     position:relative;
     cursor: pointer;
-    left: -30px;
+    /*left: -30px;*/
 }
+.exploremaplink:hover {
+    color: #fff;
+}
+
+
 
 #menubutton {
     position: relative;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1019,6 +1019,34 @@ video#bgvid {
     top:1px;
 }
 
+.otherCityStartBtn {
+    background-color:rgba(251, 215, 139, 1);
+    -moz-border-radius:15px;
+    -webkit-border-radius:15px;
+    border-radius:10px;
+    border:0px solid #fbd78b;
+    display:inline-block;
+    cursor:pointer;
+    color:#2d2a3f;
+    font: normal normal normal 14px/1.4em raleway,sans-serif;
+    font-family: 'Raleway', sans-serif;
+    font-size:14px;
+    padding:10px 30px;
+
+    text-decoration:none;
+    transition: border-color 0.4s ease 0s, background-color 0.4s ease 0s;
+}
+.otherCityStartBtn:hover {
+    background-color:#FCECBE;
+    border:0px solid #eb734d;
+    color:#2d2a3f;
+    text-shadow: none;
+}
+.otherCityStartBtn:active{
+    position:relative;
+    top:1px;
+}
+
 #exploremaplink {
     color: #fff;
     text-decoration:underline;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1018,34 +1018,6 @@ video#bgvid {
     top:1px;
 }
 
-.otherCityStartBtn {
-    background-color:rgba(251, 215, 139, 1);
-    -moz-border-radius:15px;
-    -webkit-border-radius:15px;
-    border-radius:10px;
-    border:0px solid #fbd78b;
-    display:inline-block;
-    cursor:pointer;
-    color:#2d2a3f;
-    font: normal normal normal 14px/1.4em raleway,sans-serif;
-    font-family: 'Raleway', sans-serif;
-    font-size:14px;
-    padding:10px 30px;
-
-    text-decoration:none;
-    transition: border-color 0.4s ease 0s, background-color 0.4s ease 0s;
-}
-.otherCityStartBtn:hover {
-    background-color:#FCECBE;
-    border:0px solid #eb734d;
-    color:#2d2a3f;
-    text-shadow: none;
-}
-.otherCityStartBtn:active{
-    position:relative;
-    top:1px;
-}
-
 .header-text {
     color: #fff;
     font-family: raleway;


### PR DESCRIPTION
Partially resolves #1304 

Adds links to the audit pages for other cities to the landing page.

Before
![landing-page-no-links](https://user-images.githubusercontent.com/6518824/55819890-a7f26200-5aae-11e9-858d-016b41c50c69.png)

After
![landing-page-with-links](https://user-images.githubusercontent.com/6518824/55819894-aa54bc00-5aae-11e9-84f2-d6faa753ecdc.png)

Pretty easy change, so I won't ask anyone to test. Unless you specifically want to take a look @manaswis to make sure this meets your expectations.