### PR TITLE
Resolves #1627: Disable keyboard shortcuts when mission screens are shown

### DIFF
--- a/public/javascripts/SVValidate/src/data/Form.js
+++ b/public/javascripts/SVValidate/src/data/Form.js
@@ -71,12 +71,12 @@ function Form(url) {
                             svv.panoramaContainer.reset();
                             svv.panoramaContainer.setLabelList(result.labels);
                             svv.panoramaContainer.loadNewLabelOntoPanorama();
+                            svv.modalMissionComplete.setProperty('clickable', true);
                         }
                     } else {
                         // Otherwise, display popup that says there are no more labels left.
                         svv.modalNoNewMission.show();
                     }
-                    svv.modalMissionComplete.setProperty('clickable', true);
                 }
             },
             error: function (xhr, status, result) {

--- a/public/javascripts/SVValidate/src/keyboard/Keyboard.js
+++ b/public/javascripts/SVValidate/src/keyboard/Keyboard.js
@@ -100,24 +100,22 @@ function Keyboard(menuUI) {
     };
 
     this._documentKeyUp = function (e) {
-        if (!status.disableKeyboard) {
-            switch (e.keyCode) {
-                // "a" key
-                case 65:
-                    menuUI.agreeButton.removeClass("validate");
-                    status.keyPressed = false;
-                    break;
-                // "d" key
-                case 68:
-                    menuUI.disagreeButton.removeClass("validate");
-                    status.keyPressed = false;
-                    break;
-                // "n" key
-                case 78:
-                    menuUI.notSureButton.removeClass("validate");
-                    status.keyPressed = false;
-                    break;
-            }
+        switch (e.keyCode) {
+            // "a" key
+            case 65:
+                menuUI.agreeButton.removeClass("validate");
+                status.keyPressed = false;
+                break;
+            // "d" key
+            case 68:
+                menuUI.disagreeButton.removeClass("validate");
+                status.keyPressed = false;
+                break;
+            // "n" key
+            case 78:
+                menuUI.notSureButton.removeClass("validate");
+                status.keyPressed = false;
+                break;
         }
     };
 

--- a/public/javascripts/SVValidate/src/modal/ModalMission.js
+++ b/public/javascripts/SVValidate/src/modal/ModalMission.js
@@ -24,6 +24,7 @@ function ModalMission (uiModalMission, user) {
      * Hides the new/continuing mission screen
      */
     function hide () {
+        svv.keyboard.enableKeyboard();
         uiModalMission.background.css('visibility', 'hidden');
         uiModalMission.holder.css('visibility', 'hidden');
         uiModalMission.foreground.css('visibility', 'hidden');
@@ -71,6 +72,7 @@ function ModalMission (uiModalMission, user) {
     }
 
     function show (title, instruction) {
+        svv.keyboard.disableKeyboard();
         if (instruction) {
             uiModalMission.instruction.html(instruction);
         }

--- a/public/javascripts/SVValidate/src/modal/ModalMissionComplete.js
+++ b/public/javascripts/SVValidate/src/modal/ModalMissionComplete.js
@@ -35,6 +35,7 @@ function ModalMissionComplete (uiModalMissionComplete, user, confirmationCode) {
      * @param mission   Object for the mission that was just completed.
      */
     function show (mission) {
+        svv.keyboard.disableKeyboard();
         var totalLabels = mission.getProperty("agreeCount") + mission.getProperty("disagreeCount")
             + mission.getProperty("notSureCount");
         var message = "You just validated " + totalLabels + " " +

--- a/public/javascripts/SVValidate/src/modal/ModalNoNewMission.js
+++ b/public/javascripts/SVValidate/src/modal/ModalNoNewMission.js
@@ -21,6 +21,7 @@ function ModalNoNewMission (uiModalMission) {
     }
 
     function show () {
+        svv.disableKeyboard();
         uiModalMission.background.css('visibility', 'visible');
         uiModalMission.instruction.html(noMissionsRemaining);
         uiModalMission.missionTitle.html("No more validation missions left");


### PR DESCRIPTION
Resolves #1627.

When the mission complete / resume mission screens are being shown, we don't allow the users to use keyboard shortcuts. Previously, if you clicked the "A" key (or any other validation keyboard shortcut), you'd still be able to validate labels even while these screens were still visible. 

I also snuck in a brief fix for some changes from #1610. In some cases, I found that I was still able to close the "mission complete" screen before the next label was loaded because of some asynchronous weirdness. 

**Testing Instructions**
* Complete a validation mission. On each screen, use keyboard shortcuts. The label count (that is still visible above the mission screen) shouldn't change.
* Check the `validation_task_interaction` table to make sure that the keyboard shortcuts aren't being logged when these screens are up.
* As a quick sanity check, also make sure that the "Validate more labels" button can't be clicked/doesn't turn blue before the new mission is loaded. 
