### PR TITLE
Add in old code for submitting data

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/data/Form.js
+++ b/public/javascripts/SVLabel/src/SVLabel/data/Form.js
@@ -260,16 +260,19 @@ function Form (labelContainer, missionModel, missionContainer, navigationModel, 
 
     $(window).on('beforeunload', function () {
         tracker.push("Unload");
-        var task = taskContainer.getCurrentTask();
+
+        // Old code: this does not work on the newest versions of Google Chrome.
+        // TODO: Replace with beacon (or some ajax alternative) asap. Starter code below.
+        self.submitData(false);
+
+        // // April 17, 2019
+        // // What we want here is type: 'application/json'. Can't do that quite yet because the
+        // // feature has been disabled, but we should switch back when we can.
+        //
+        // // Source for fix and ongoing discussion is here:
+        // // https://bugs.chromium.org/p/chromium/issues/detail?id=490015
         var data = self.compileSubmissionData(task);
         var jsonData = JSON.stringify(data);
-
-        // April 17, 2019
-        // What we want here is type: 'appilcation/json'. Can't do that quite yet because the
-        // feature has been disabled, but we should switch back when we can.
-
-        // Source for fix and ongoing discussion is here:
-        // https://bugs.chromium.org/p/chromium/issues/detail?id=490015
         var headers = {
             type: 'application/x-www-form-urlencoded'
         };

--- a/public/javascripts/SVValidate/src/data/Form.js
+++ b/public/javascripts/SVValidate/src/data/Form.js
@@ -84,20 +84,31 @@ function Form(url) {
                 console.error(result);
             }
         });
-        return data;
     }
 
     $(window).on('beforeunload', function () {
         svv.tracker.push("Unload");
         var data = compileSubmissionData();
-        var jsonData = JSON.stringify(data);
+
+        // Old code: this does not work on the newest versions of Google Chrome.
+        // TODO: Replace with beacon (or some ajax alternative) asap. Starter code below.
+        self.submit(data, false);
 
         // April 17, 2019
-        // What we want here is type: 'appilcation/json'. Can't do that quite yet because the
+        // It looks like this isn't working at the moment. I'm replacing this method with what we
+        // had previously, but I'm not convinced that it works on Chrome (at the very least, it
+        // sends us an error message, but I'm not sure if it (reluctantly) submits data as well.
+        //
+        // var data = compileSubmissionData();
+        var jsonData = JSON.stringify(data);
+        //
+        // April 17, 2019
+        // What we want here is type: 'application/json'. Can't do that quite yet because the
         // feature has been disabled, but we should switch back when we can.
-
+        //
         // Source for fix and ongoing discussion is here:
         // https://bugs.chromium.org/p/chromium/issues/detail?id=490015
+        //
         var headers = {
             type: 'application/x-www-form-urlencoded'
         };


### PR DESCRIPTION
Related to #1643, #1645. (Doesn't resolve anything, hah).

I added some code that tried to use beacons to submit code to the backend before unload that doesn't seem to be working. I decided to add back the code from what we were doing previously (synchronous ajax call) -- even though this doesn't work on the newest version of chrome. But perhaps it works on other browsers or older versions of Chrome, so having something that partially works is probably better than nothing 😬.

(Note: on the newest version of Chrome, this means that we lose the data from between the "last time" the form was submitted -- which happens when there are over 200 interactions logged (including LowLevel events like mousemove, keyboard presses) or when a user completes a mission. 