### PR TITLE
Resolves #1644: Fixes Panomarker stickiness in Safari and Firefox

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/Panomarker.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Panomarker.js
@@ -105,8 +105,19 @@
          * @private
          * @type {function(StreetViewPov, StreetViewPov, number, Element): Object}
          */
-        this.povToPixel_ = !!window.chrome ? PanoMarker.povToPixel3d :
-            PanoMarker.povToPixel2d;
+
+        // Original code:
+        // this.povToPixel_ = !!window.chrome ? PanoMarker.povToPixel3d :
+        //     PanoMarker.povToPixel2d;
+
+        // New code (April 17, 2019) -- modified by Aileen
+        // Source: https://github.com/marmat/google-maps-api-addons/issues/36#issuecomment-342774699
+        this.povToPixel_ = PanoMarker.povToPixel2d;
+        var pixelCanvas = document.createElement("canvas");
+
+        if (pixelCanvas && (pixelCanvas.getContext("experimental-webgl") || pixelCanvas.getContext("webgl"))) {
+            this.povToPixel_ = PanoMarker.povToPixel3d;
+        }
 
         /** @private @type {google.maps.Point} */
         this.anchor_ = opts.anchor || new google.maps.Point(16, 16);


### PR DESCRIPTION
Resolves #1644.

Fixes issue where the Panomarker moves around in the validation in Safari and Firefox.

**Testing Instructions**
* Open up the validation interface in Safari/Firefox/Chrome. Pan around the interface and check that the label is properly sticking.
    * I don't have Firefox installed so I have only tested on Safari/Chrome.

