### PR TITLE
Chrome now makes async requests on page close

### DIFF
--- a/public/javascripts/SVValidate/src/data/Form.js
+++ b/public/javascripts/SVValidate/src/data/Form.js
@@ -90,9 +90,23 @@ function Form(url) {
         svv.tracker.push("Unload");
         var data = compileSubmissionData();
 
+        // Synchronous ajax requests have been disabled in Google Chrome, so our beforeunload requests are now failing.
+        // The alternative we would like to use is Navigator.sendBeacon, but application/json is currently disabled
+        // there :( So one small improvement we are making is to send _asynchronous_ requests in Chrome. These are not
+        // guaranteed to send like sendBeacon or synchronous requests, but they will at least send some of the time. So
+        // we will use synchronous for other browsers to guarantee data is sent and async on Chrome so it sometimes
+        // sends until we are able to switch to something more reliable like sendBeacon. Make sure to make this change
+        // on the audit page as well when a fix is found. How to check if Chrome:
+        // https://stackoverflow.com/questions/9847580/how-to-detect-safari-chrome-ie-firefox-and-opera-browser
+        let asyncParam;
+        if (!!window.chrome && (!!window.chrome.webstore || !!window.chrome.runtime))
+            asyncParam = true;
+        else
+            asyncParam = false;
+
         // Old code: this does not work on the newest versions of Google Chrome.
         // TODO: Replace with beacon (or some ajax alternative) asap. Starter code below.
-        self.submit(data, false);
+        self.submit(data, asyncParam);
 
         // April 17, 2019
         // It looks like this isn't working at the moment. I'm replacing this method with what we


### PR DESCRIPTION
Bandage for #1648 

This PR switches to using _asynchronous_ ajax requests in _only Chrome_ when the page is closed/refreshed. Data is not guaranteed to be sent, but it is now at least sent _sometimes_ when the page refreshes instead of never. Firefox/Safari should continue to always send the data successfully.

This is a bandage until `application/json` support is restored for `navigator.sendBeacon` or until we find an alternative.

Testing:
1. Check out the develop  and go to the validate page in Chrome. Try agreeing with a single label and immediately refreshing the page. Notice how the mission completion percentage never increases.
1. Do the same thing on the audit page by taking a step and refreshing. Notice how the percentage also does not increase.
1. Try both of the above in Firefox or Safari and notice how the mission completion percentage _does_ increase in both of those scenarios.
1. Check out the 1648 branch and run those same tests in Firefox/Safari to verify that the functionality is not broken there.
1. Now do those tests in Chrome. You should see that at least _sometimes_ the mission complete progress does increase on page reload. For me it seemed to work about half of the time on the /validate page and just about every time on the /audit page.