### PR TITLE
Add current panoid display to CV ground truth tool to resolve #1660

### DIFF
--- a/app/views/audit.scala.html
+++ b/app/views/audit.scala.html
@@ -307,6 +307,7 @@
                 <div id="groundtruth-info-panel">
                     <button type="button" class="button" id="next-pano-btn" onClick="svl.cvGroundTruthMission.cvGroundTruthNextPano();">Next Pano</button>
                     <p id="remaining-pano-text">50 remaining</p>
+                    <p id="current-panoid-text"></p>
                 </div>
             </div>
             <div id="interaction-area-holder" onSelectStart="return true;">

--- a/app/views/auditCreateCVMissionForm.scala.html
+++ b/app/views/auditCreateCVMissionForm.scala.html
@@ -74,7 +74,7 @@
                     <span class="overlay-header">CV Ground Truth Audit Tool</span>
                 </p>
                 <p>
-                    Enter PanoIDs to audit below:<br>
+                    Enter PanoIDs to audit below, one per line:<br>
                     <textarea id="panoid-textarea" rows="25" cols="50"></textarea>
                 </p>
                 <span class="overlay-option" onClick="verifyAndSubmitCVGroundTruthAuditPanoids()">Start</span>

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1365,7 +1365,7 @@ kbd {
     display:none;
     position:absolute;
     left: 735px;
-    top: 380px;
+    top: 340px;
     width: 200px;
 }
 #groundtruth-info-panel {

--- a/public/javascripts/SVLabel/src/SVLabel/mission/CVGroundTruthMission.js
+++ b/public/javascripts/SVLabel/src/SVLabel/mission/CVGroundTruthMission.js
@@ -36,7 +36,7 @@ function CVGroundTruthMission(mission) {
                     svl.panorama.setPano(self.currentPano);
                     svl.popUpMessage.enableInteractions();
                     $("#remaining-pano-text").text((self.remainingPanos.length + 1) + " remaining")
-
+                    $("#current-panoid-text").text("Current Pano: " + self.currentPano);
                 },
                 error: function (xhr, ajaxOptions, thrownError) {
                     console.log(thrownError);
@@ -76,7 +76,8 @@ function CVGroundTruthMission(mission) {
         if (self.remainingPanos.length > 0) {
             self.currentPano = self.remainingPanos.shift();
             svl.panorama.setPano(self.currentPano);
-            $("#remaining-pano-text").text((self.remainingPanos.length + 1) + " remaining")
+            $("#remaining-pano-text").text((self.remainingPanos.length + 1) + " remaining");
+            $("#current-panoid-text").text("Current Pano: " + self.currentPano);
             $.ajax({
                 async: true,
                 contentType: 'application/json; charset=utf-8',


### PR DESCRIPTION
A very minor PR to show the current PanoID in the CV Ground Truth Audit tool. Also tweaked panoId input form to mention required format.

Before:
![before](https://user-images.githubusercontent.com/7234278/56466770-f45d6c00-63e3-11e9-98cc-fb75051a4637.png)

After:
![showpanoid](https://user-images.githubusercontent.com/7234278/56466705-32a65b80-63e3-11e9-917a-1a873ee517e6.png)

Testing:
* Verified the panoId shown matches result of `svl.panorama.getPano()` in console.