### PR TITLE
disabled confirmation code appearing on validation interface

### DIFF
--- a/app/models/mission/MissionTable.scala
+++ b/app/models/mission/MissionTable.scala
@@ -134,7 +134,7 @@ object MissionTable {
   }
 
   /**
-    * Returns true if the user has an amt_assignment and have completed a mission during it, false o/w.
+    * Returns true if the user has an amt_assignment and has completed a mission during it, false o/w.
     *
     * @param username
     * @return
@@ -147,6 +147,26 @@ object MissionTable {
       missions.filterNot(_.missionTypeId inSet MissionTypeTable.onboardingTypeIds)
         .filter(m => m.missionEnd > asmt.get.assignmentStart && m.missionEnd < asmt.get.assignmentEnd && m.completed)
         .list.nonEmpty
+    }
+  }
+
+  /**
+    * Returns true if the user has an amt_assignment and has completed an audit mission during it, false o/w.
+    *
+    * @param username
+    * @return
+    */
+  def hasCompletedAuditMissionInThisAmtAssignment(username: String): Boolean = db.withSession { implicit session =>
+    val asmt: Option[AMTAssignment] = AMTAssignmentTable.getMostRecentAssignment(username)
+    if (asmt.isEmpty) {
+      false
+    } else {
+      val auditMissionTypeId: Int = missionTypes.filter(_.missionType === "audit").map(_.missionTypeId).list.head
+      missions.filter(m => m.missionTypeId === auditMissionTypeId
+        && m.missionEnd > asmt.get.assignmentStart
+        && m.missionEnd < asmt.get.assignmentEnd
+        && m.completed
+      ).list.nonEmpty
     }
   }
 

--- a/app/views/audit.scala.html
+++ b/app/views/audit.scala.html
@@ -597,7 +597,7 @@
                                 </tr>
                             </table>
                             @if(user){
-                                @if(user.get.role.getOrElse("") == "Turker" && !MissionTable.hasCompletedMissionInThisAmtAssignment(user.get.username)) {
+                                @if(user.get.role.getOrElse("") == "Turker" && !MissionTable.hasCompletedAuditMissionInThisAmtAssignment(user.get.username)) {
                                     <button class="btn blue-btn" id="modal-mission-complete-generate-confirmation-button">Click to generate HIT confirmation code</button>
                                 }
                             }
@@ -996,7 +996,7 @@
                     svl.assignmentId = "@AMTAssignmentTable.getMostRecentAssignmentId(user.get.username)";
                     svl.amtAssignmentId = @AMTAssignmentTable.getMostRecentAMTAssignmentId(user.get.username);
                     svl.confirmationCode = "@AMTAssignmentTable.getConfirmationCode(user.get.username,AMTAssignmentTable.getMostRecentAssignmentId(user.get.username))";
-                    @if(!MissionTable.hasCompletedMissionInThisAmtAssignment(user.get.username)){
+                    @if(!MissionTable.hasCompletedAuditMissionInThisAmtAssignment(user.get.username)){
                         $("#left-column-confirmation-code-button").css('visibility', "hidden");
                     } else{
                         $("#left-column-confirmation-code-button").css('visibility', "");

--- a/app/views/validation.scala.html
+++ b/app/views/validation.scala.html
@@ -219,7 +219,7 @@
                 svv.assignmentId = "@AMTAssignmentTable.getMostRecentAssignmentId(user.get.username)";
                 svv.amtAssignmentId = @AMTAssignmentTable.getMostRecentAMTAssignmentId(user.get.username);
                 svv.confirmationCode = "@AMTAssignmentTable.getConfirmationCode(user.get.username,AMTAssignmentTable.getMostRecentAssignmentId(user.get.username))";
-                @if(!MissionTable.hasCompletedMissionInThisAmtAssignment(user.get.username)) {
+                @if(!MissionTable.hasCompletedAuditMissionInThisAmtAssignment(user.get.username)) {
                     $("#left-column-confirmation-code-button").css('visibility', "hidden");
                 } else {
                     $("#left-column-confirmation-code-button").css('visibility', "");

--- a/public/javascripts/SVValidate/src/modal/ModalMissionComplete.js
+++ b/public/javascripts/SVValidate/src/modal/ModalMissionComplete.js
@@ -71,7 +71,9 @@ function ModalMissionComplete (uiModalMissionComplete, user, confirmationCode) {
 
         // If this is a turker and the confirmation code button hasn't been shown yet, mark amt_assignment as complete
         // and reveal the confirmation code.
-        if (user.getProperty('role') === 'Turker' && confirmationCode.css('visibility') === 'hidden') {
+        // TODO add this back in when we start doing validation missions for turkers.
+        // if (user.getProperty('role') === 'Turker' && confirmationCode.css('visibility') === 'hidden') {
+        if (false) {
             _markAmtAssignmentAsComplete();
             _showConfirmationCode();
             var confirmationCodeElement = document.createElement("h3");


### PR DESCRIPTION
Fixes #1670 

The confirmation code no longer shows up for turkers when they complete a validation mission. They now have to complete an audit mission for the confirmation code to show up. However, the code does still show on the validation page if they happen to go there and they've already completed an audit mission :)

Pretty simple PR that is time-sensitive, so I'm not asking anyone to review.