### PR TITLE
confirmation code now only shows if you finish HIT

### DIFF
--- a/app/models/mission/MissionTable.scala
+++ b/app/models/mission/MissionTable.scala
@@ -4,6 +4,7 @@ import java.sql.Timestamp
 import java.time.Instant
 import java.util.UUID
 
+import models.amt.AMTAssignmentTable.db
 import models.amt.{AMTAssignment, AMTAssignmentTable}
 import models.audit.AuditTaskTable
 import models.daos.slick.DBTableDefinitions.{DBUser, UserTable}
@@ -167,6 +168,20 @@ object MissionTable {
         && m.missionEnd < asmt.get.assignmentEnd
         && m.completed
       ).list.nonEmpty
+    }
+  }
+
+  /**
+    * Returns Some(confirmationCode) if the worker finished an audit mission, None o/w.
+    *
+    * @param username
+    * @return
+    */
+  def getMostRecentConfirmationCodeIfCompletedAuditMission(username: String): Option[String] = db.withSession { implicit session =>
+    if (hasCompletedAuditMissionInThisAmtAssignment(username)) {
+      AMTAssignmentTable.getMostRecentConfirmationCode(username)
+    } else {
+      None
     }
   }
 

--- a/app/views/audit.scala.html
+++ b/app/views/audit.scala.html
@@ -150,10 +150,10 @@
                         <span class="overlay-header">Assignment Expired!</span>
                     </p>
                     <p>
-                        You should receive your bonus amount in the next day or two. If you did not submit your
-                        confirmation code on the mturk website, send us an email at
+                        You should receive your bonus amount in the next day or two. If you completed the HIT but did
+                        not submit your confirmation code on the mturk website, send us an email at
                         <a href="mailto:makeability.sidewalk@@gmail.com">makeability.sidewalk@@gmail.com</a> with your
-                        confirmation code (@{models.amt.AMTAssignmentTable.getMostRecentConfirmationCode(user.get.username).getOrElse("")}).
+                        confirmation code (@{models.mission.MissionTable.getMostRecentConfirmationCodeIfCompletedAuditMission(user.get.username).getOrElse("")}).
                     </p>
                 </div>
             </div>

--- a/app/views/validation.scala.html
+++ b/app/views/validation.scala.html
@@ -29,10 +29,10 @@
                         <span class="overlay-header">Assignment Expired!</span>
                     </p>
                     <p>
-                        You should receive your bonus amount in the next day or two. If you did not submit your
-                        confirmation code on the mturk website, send us an email at
+                        You should receive your bonus amount in the next day or two. If you completed the HIT but did
+                        not submit your confirmation code on the mturk website, send us an email at
                         <a href="mailto:makeability.sidewalk@@gmail.com">makeability.sidewalk@@gmail.com</a> with your
-                        confirmation code (@{models.amt.AMTAssignmentTable.getMostRecentConfirmationCode(user.get.username).getOrElse("")}).
+                        confirmation code (@{models.mission.MissionTable.getMostRecentConfirmationCodeIfCompletedAuditMission(user.get.username).getOrElse("")}).
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
Fixes #1675 

On the HIT expiration overlay, we now only include the confirmation code if the turker actually finished the tutorial and first mission.

Very quick/easy fix and time-sensitive, so not asking anyone to review.