### PR TITLE
makes canvas_x/y nullable to fix panning validation bug

### DIFF
--- a/app/formats/json/ValidationTaskSubmissionFormats.scala
+++ b/app/formats/json/ValidationTaskSubmissionFormats.scala
@@ -8,7 +8,7 @@ import play.api.libs.functional.syntax._
 
 object ValidationTaskSubmissionFormats {
   case class InteractionSubmission(action: String, missionId: Option[Int], gsvPanoramaId: Option[String], lat: Option[Float], lng: Option[Float], heading: Option[Float], pitch: Option[Float], zoom: Option[Float], note: Option[String], timestamp: Long)
-  case class LabelValidationSubmission(labelId: Int, missionId: Int, validationResult: Int, canvasX: Int, canvasY: Int, heading: Float, pitch: Float, zoom: Float, canvasHeight: Int, canvasWidth: Int, startTimestamp: Long, endTimestamp: Long)
+  case class LabelValidationSubmission(labelId: Int, missionId: Int, validationResult: Int, canvasX: Option[Int], canvasY: Option[Int], heading: Float, pitch: Float, zoom: Float, canvasHeight: Int, canvasWidth: Int, startTimestamp: Long, endTimestamp: Long)
   case class SkipLabelSubmission(labels: Seq[LabelValidationSubmission])
   case class ValidationMissionProgress(missionId: Int, labelsProgress: Int, labelTypeId: Int, completed: Boolean, skipped: Boolean)
   case class ValidationTaskSubmission(interactions: Seq[InteractionSubmission], labels: Seq[LabelValidationSubmission], missionProgress: Option[ValidationMissionProgress])
@@ -30,8 +30,8 @@ object ValidationTaskSubmissionFormats {
     (JsPath \ "label_id").read[Int] and
       (JsPath \ "mission_id").read[Int] and
       (JsPath \ "validation_result").read[Int] and
-      (JsPath \ "canvas_x").read[Int] and
-      (JsPath \ "canvas_y").read[Int] and
+      (JsPath \ "canvas_x").readNullable[Int] and
+      (JsPath \ "canvas_y").readNullable[Int] and
       (JsPath \ "heading").read[Float] and
       (JsPath \ "pitch").read[Float] and
       (JsPath \ "zoom").read[Float] and

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -126,6 +126,7 @@ object LabelTable {
                            labelTypeKey:String, labelTypeValue: String, severity: Option[Int],
                            temporary: Boolean, description: Option[String], tags: List[String])
 
+  // NOTE: canvas_x and canvas_y are null when the label is not visible when validation occurs.
   case class LabelValidationMetadata(labelId: Int, labelType: String, gsvPanoramaId: String,
                                      heading: Float, pitch: Float, zoom: Int, canvasX: Int,
                                      canvasY: Int, canvasWidth: Int, canvasHeight: Int)

--- a/app/models/label/LabelValidationTable.scala
+++ b/app/models/label/LabelValidationTable.scala
@@ -19,8 +19,9 @@ case class LabelValidation(validationId: Int,
                            labelValidationId: Int,
                            userId: String,
                            missionId: Int,
-                           canvasX: Int,
-                           canvasY: Int,
+                           // NOTE: canvas_x and canvas_y are null when the label is not visible when validation occurs.
+                           canvasX: Option[Int],
+                           canvasY: Option[Int],
                            heading: Float,
                            pitch: Float,
                            zoom: Float,
@@ -41,8 +42,8 @@ class LabelValidationTable (tag: slick.lifted.Tag) extends Table[LabelValidation
   def validationResult = column[Int]("validation_result", O.NotNull) // 1 = Agree, 2 = Disagree, 3 = Unsure
   def userId = column[String]("user_id", O.NotNull)
   def missionId = column[Int]("mission_id", O.NotNull)
-  def canvasX = column[Int]("canvas_x", O.NotNull)
-  def canvasY = column[Int]("canvas_y", O.NotNull)
+  def canvasX = column[Option[Int]]("canvas_x", O.Nullable)
+  def canvasY = column[Option[Int]]("canvas_y", O.Nullable)
   def heading = column[Float]("heading", O.NotNull)
   def pitch = column[Float]("pitch", O.NotNull)
   def zoom = column[Float]("zoom", O.NotNull)
@@ -61,7 +62,6 @@ class LabelValidationTable (tag: slick.lifted.Tag) extends Table[LabelValidation
   */
 object LabelValidationTable {
   val db = play.api.db.slick.DB
-  val labelValidationTable = TableQuery[LabelValidationTable]
   val users = TableQuery[UserTable]
   val userRoles = TableQuery[UserRoleTable]
   val roleTable = TableQuery[RoleTable]
@@ -114,7 +114,7 @@ object LabelValidationTable {
     */
   def getValidationCountsPerUser: List[(String, String, Int, Int)] = db.withSession { implicit session =>
     val audits = for {
-      _validation <- labelValidationTable
+      _validation <- validationLabels
       _label <- labelsWithoutDeleted if _label.labelId === _validation.labelId
       _audit <- auditTasks if _label.auditTaskId === _audit.auditTaskId
       _user <- users if _user.username =!= "anonymous" && _user.userId === _audit.userId // User who placed the label
@@ -141,14 +141,14 @@ object LabelValidationTable {
     * @return total number of validations
     */
   def countValidations: Int = db.withTransaction(implicit session =>
-    labelValidationTable.list.size
+    validationLabels.list.size
   )
 
   /**
     * @return total number of validations with a given result
     */
   def countValidationsBasedOnResult(result: Int): Int = db.withTransaction(implicit session =>
-    labelValidationTable.filter(_.validationResult === result).list.size
+    validationLabels.filter(_.validationResult === result).list.size
   )
 
   /**

--- a/conf/evolutions/default/44.sql
+++ b/conf/evolutions/default/44.sql
@@ -3,8 +3,8 @@ ALTER TABLE label_validation ALTER COLUMN canvas_x DROP NOT NULL;
 ALTER TABLE label_validation ALTER COLUMN canvas_y DROP NOT NULL;
 
 # --- !Downs
-UPDATE label_validation SET canvas_x = -1 WHERE canvas_x = NULL;
-UPDATE label_validation SET canvas_y = -1 WHERE canvas_y = NULL;
+UPDATE label_validation SET canvas_x = -1 WHERE canvas_x IS NULL;
+UPDATE label_validation SET canvas_y = -1 WHERE canvas_y IS NULL;
 
 ALTER TABLE label_validation ALTER COLUMN canvas_x SET NOT NULL;
 ALTER TABLE label_validation ALTER COLUMN canvas_y SET NOT NULL;

--- a/conf/evolutions/default/44.sql
+++ b/conf/evolutions/default/44.sql
@@ -1,0 +1,10 @@
+# --- !Ups
+ALTER TABLE label_validation ALTER COLUMN canvas_x DROP NOT NULL;
+ALTER TABLE label_validation ALTER COLUMN canvas_y DROP NOT NULL;
+
+# --- !Downs
+UPDATE label_validation SET canvas_x = -1 WHERE canvas_x = NULL;
+UPDATE label_validation SET canvas_y = -1 WHERE canvas_y = NULL;
+
+ALTER TABLE label_validation ALTER COLUMN canvas_x SET NOT NULL;
+ALTER TABLE label_validation ALTER COLUMN canvas_y SET NOT NULL;

--- a/public/javascripts/SVValidate/src/label/Label.js
+++ b/public/javascripts/SVValidate/src/label/Label.js
@@ -155,6 +155,9 @@ function Label(params) {
     /**
      * Updates validation status for Label, StatusField and logs interactions into Tracker. Occurs
      * when a validation button is clicked.
+     *
+     * NOTE: canvas_x and canvas_y are null when the label is not visible when validation occurs.
+     *
      * @param validationResult  Must be one of the following: {Agree, Disagree, Unsure}.
      */
     function validate(validationResult) {
@@ -174,9 +177,24 @@ function Label(params) {
         var pixelCoordinates = svv.util.properties.panorama.povToPixel3d(panomarkerPov, userPov,
             zoom, svv.canvasWidth, svv.canvasHeight);
 
+        // If the user has panned away from the label and it is no longer visible on the canvas, set canvasX/Y to null.
+        // We add/subtract the radius of the label so that we still record these values when only a fraction of the
+        // labe is still visible.
+        let labelCanvasX = null;
+        let labelCanvasY = null;
+        if (pixelCoordinates
+            && pixelCoordinates.left + getRadius() > 0
+            && pixelCoordinates.left - getRadius() < svv.canvasWidth
+            && pixelCoordinates.top + getRadius() > 0
+            && pixelCoordinates.top - getRadius() < svv.canvasHeight) {
+
+            labelCanvasX = pixelCoordinates.left - getRadius();
+            labelCanvasY = pixelCoordinates.top - getRadius();
+        }
+
         setValidationProperty("endTimestamp", new Date().getTime());
-        setValidationProperty("canvasX", pixelCoordinates.left - getRadius());
-        setValidationProperty("canvasY", pixelCoordinates.top - getRadius());
+        setValidationProperty("canvasX", labelCanvasX);
+        setValidationProperty("canvasY", labelCanvasY);
         setValidationProperty("heading", userPov.heading);
         setValidationProperty("pitch", userPov.pitch);
         setValidationProperty("zoom", userPov.zoom);


### PR DESCRIPTION
Fixes #1543 

The `canvas_x` and `canvas_y` columns in the `label_validation` table are meant to capture the location on the canvas that the label is when validation occurs. This doesn't really make sense when the user has panned away so that the label is no longer in view. This was causing a bug when the `povToPixel3d` returned `null`, b/c that was what the `povToPixel3d` function was meant to calculate.

I've made it so that `canvas_x` and `canvas_y` are nullable, and I set them to null only when the label is not at all visible on the screen.

@aileenzeng I was hoping you could just sanity check the code? You can test if you have time, but it will be easy enough for anyone to test once it is on the test servers.