### PR TITLE
now showing last 5000 labels on admin page

### DIFF
--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -552,7 +552,7 @@
                             </thead>
                             <!-- using this id to locate the labelTags so we can insert the tags-->
                             <tbody id = 'labelRows'>
-                                @LabelTable.selectTopLabelsAndMetadata(1000).map { label =>
+                                @LabelTable.selectTopLabelsAndMetadata(5000).map { label =>
                                     <tr>
                                         <td><a href='@routes.AdminController.userProfile(label.username)'>@label.username</a>
                                         </td>


### PR DESCRIPTION
Resolves #1683 

The admin page contribution tab will now show the most recent 5000 labels instead of most recent 1000 labels, which should make it easier for me to batch when I review turker work.

Super simple PR, and we won't know if it works until I put it on Seattle production server. But the worst it can do is make the admin page unresponsive, and will be easy to revert :)