### PR TITLE
comments out turker stuff on validate page

### DIFF
--- a/app/views/validation.scala.html
+++ b/app/views/validation.scala.html
@@ -22,28 +22,30 @@
     <link rel="stylesheet" href='@routes.Assets.at("stylesheets/animate.css")'/>
     <div id="page-loading"><img id="loading-gif" src='@routes.Assets.at("assets/page-load.gif")'/></div>
     <div class="container toolUI" style = "visibility: visible;">
-        <div id="HIT-expiration-overlay">
-            <div class="overlay-text">
-                <div id="HIT-expiration-text">
-                    <p>
-                        <span class="overlay-header">Assignment Expired!</span>
-                    </p>
-                    <p>
-                        You should receive your bonus amount in the next day or two. If you completed the HIT but did
-                        not submit your confirmation code on the mturk website, send us an email at
-                        <a href="mailto:makeability.sidewalk@@gmail.com">makeability.sidewalk@@gmail.com</a> with your
-                        confirmation code (@{models.mission.MissionTable.getMostRecentConfirmationCodeIfCompletedAuditMission(user.get.username).getOrElse("")}).
-                    </p>
-                </div>
-            </div>
-        </div>
+@*        TODO this code was removed for issue #1693, search for "#1693" and uncomment all later.@
+@*        <div id="HIT-expiration-overlay">*@
+@*            <div class="overlay-text">*@
+@*                <div id="HIT-expiration-text">*@
+@*                    <p>*@
+@*                        <span class="overlay-header">Assignment Expired!</span>*@
+@*                    </p>*@
+@*                    <p>*@
+@*                        You should receive your bonus amount in the next day or two. If you completed the HIT but did*@
+@*                        not submit your confirmation code on the mturk website, send us an email at*@
+@*                        <a href="mailto:makeability.sidewalk@@gmail.com">makeability.sidewalk@@gmail.com</a> with your*@
+@*                        confirmation code (@{models.mission.MissionTable.getMostRecentConfirmationCodeIfCompletedAuditMission(user.get.username).getOrElse("")}).*@
+@*                    </p>*@
+@*                </div>*@
+@*            </div>*@
+@*        </div>*@
         <div id="svv-application-holder">
             <div id="left-column-control-pane">
                 <div id="left-column-button-holder">
-                    <div id="left-column-confirmation-code-button" class="button">
-                        <img src='@routes.Assets.at("javascripts/SVLabel/img/icons/Icon_OrangeCheckmark.png")'  alt="Confirmation Code icon" align="">
-                        Mturk Code
-                    </div>
+@*                    TODO this code was removed for issue #1693, search for "#1693" and uncomment all later.*@
+@*                    <div id="left-column-confirmation-code-button" class="button">*@
+@*                        <img src='@routes.Assets.at("javascripts/SVLabel/img/icons/Icon_OrangeCheckmark.png")'  alt="Confirmation Code icon" align="">*@
+@*                        Mturk Code*@
+@*                    </div>*@
                     <div id="left-column-jump-button" class="button">
                         <img src='@routes.Assets.at("javascripts/SVLabel/img/icons/refresh.png")'  alt="Jump icon" align="">
                         <br>Skip
@@ -214,43 +216,44 @@
         var param = {};
 
         // Hide confirmation code if turker hasn't completed a mission.
-        @if(user) {
-            @if(user.get.role.getOrElse("") == "Turker") {
-                svv.assignmentId = "@AMTAssignmentTable.getMostRecentAssignmentId(user.get.username)";
-                svv.amtAssignmentId = @AMTAssignmentTable.getMostRecentAMTAssignmentId(user.get.username);
-                svv.confirmationCode = "@AMTAssignmentTable.getConfirmationCode(user.get.username,AMTAssignmentTable.getMostRecentAssignmentId(user.get.username))";
-                @if(!MissionTable.hasCompletedAuditMissionInThisAmtAssignment(user.get.username)) {
-                    $("#left-column-confirmation-code-button").css('visibility', "hidden");
-                } else {
-                    $("#left-column-confirmation-code-button").css('visibility', "");
-                    $("#left-column-confirmation-code-button").attr('data-toggle','popover');
-                    $("#left-column-confirmation-code-button").attr('title','Submit this code for HIT verification on Amazon Mechanical Turk');
-                    $("#left-column-confirmation-code-button").attr('data-content', svv.confirmationCode);
-                    $("#left-column-confirmation-code-button").popover();
+        // TODO this code was removed for issue #1693, search for "#1693" and uncomment all later.
+@*        @if(user) {*@
+@*            @if(user.get.role.getOrElse("") == "Turker") {*@
+@*                svv.assignmentId = "@AMTAssignmentTable.getMostRecentAssignmentId(user.get.username)";*@
+@*                svv.amtAssignmentId = @AMTAssignmentTable.getMostRecentAMTAssignmentId(user.get.username);*@
+@*                svv.confirmationCode = "@AMTAssignmentTable.getConfirmationCode(user.get.username,AMTAssignmentTable.getMostRecentAssignmentId(user.get.username))";*@
+@*                @if(!MissionTable.hasCompletedAuditMissionInThisAmtAssignment(user.get.username)) {*@
+@*                    $("#left-column-confirmation-code-button").css('visibility', "hidden");*@
+@*                } else {*@
+@*                    $("#left-column-confirmation-code-button").css('visibility', "");*@
+@*                    $("#left-column-confirmation-code-button").attr('data-toggle','popover');*@
+@*                    $("#left-column-confirmation-code-button").attr('title','Submit this code for HIT verification on Amazon Mechanical Turk');*@
+@*                    $("#left-column-confirmation-code-button").attr('data-content', svv.confirmationCode);*@
+@*                    $("#left-column-confirmation-code-button").popover();*@
 
-                    //Hide the confirmation popover on clicking the background
-                    //https://stackoverflow.com/questions/11703093/how-to-dismiss-a-twitter-bootstrap-popover-by-clicking-outside
+@*                    //Hide the confirmation popover on clicking the background*@
+@*                    //https://stackoverflow.com/questions/11703093/how-to-dismiss-a-twitter-bootstrap-popover-by-clicking-outside*@
 
-                    $(document).on('click', function(e) {
-                        $("#left-column-confirmation-code-button").each(function () {
-                            //the 'is' for buttons that trigger popups
-                            //the 'has' for icons within a button that triggers a popup
-                            if (!$(this).is(e.target) && $(this).has(e.target).length === 0 && $('.popover').has(e.target).length === 0) {
-                                (($(this).popover('hide').data('bs.popover')||{}).inState||{}).click = false
-                            }
+@*                    $(document).on('click', function(e) {*@
+@*                        $("#left-column-confirmation-code-button").each(function () {*@
+@*                            //the 'is' for buttons that trigger popups*@
+@*                            //the 'has' for icons within a button that triggers a popup*@
+@*                            if (!$(this).is(e.target) && $(this).has(e.target).length === 0 && $('.popover').has(e.target).length === 0) {*@
+@*                                (($(this).popover('hide').data('bs.popover')||{}).inState||{}).click = false*@
+@*                            }*@
 
-                        });
-                    });
-                }
-                $("#current-mission-reward").show();
-                $("#total-mission-reward").show();
-                $("#modal-mission-reward-text").show();
-            } else {
-                $("#left-column-confirmation-code-button").css('visibility', "hidden");
-            }
-        } else{
-            $("#left-column-confirmation-code-button").css('visibility', "hidden");
-        }
+@*                        });*@
+@*                    });*@
+@*                }*@
+@*                $("#current-mission-reward").show();*@
+@*                $("#total-mission-reward").show();*@
+@*                $("#modal-mission-reward-text").show();*@
+@*            } else {*@
+@*                $("#left-column-confirmation-code-button").css('visibility', "hidden");*@
+@*            }*@
+@*        } else{*@
+@*            $("#left-column-confirmation-code-button").css('visibility', "hidden");*@
+@*        }*@
 
         // Store user object.
         var userParam = {};

--- a/public/javascripts/SVValidate/src/Main.js
+++ b/public/javascripts/SVValidate/src/Main.js
@@ -126,7 +126,9 @@ function Main (param) {
         svv.menuButtons = new MenuButton(svv.ui.validation);
         svv.modalComment = new ModalComment(svv.ui.modalComment);
         svv.modalMission = new ModalMission(svv.ui.modalMission, svv.user);
-        svv.modalMissionComplete = new ModalMissionComplete(svv.ui.modalMissionComplete, svv.user, svv.ui.modalConfirmation.confirmationCode);
+        // TODO this code was removed for issue #1693, search for "#1693" and uncomment all later.
+        // svv.modalMissionComplete = new ModalMissionComplete(svv.ui.modalMissionComplete, svv.user, svv.ui.modalConfirmation.confirmationCode);
+        svv.modalMissionComplete = new ModalMissionComplete(svv.ui.modalMissionComplete, svv.user, null);
         svv.modalSkip = new ModalSkip(svv.ui.modalSkip);
         svv.modalNoNewMission = new ModalNoNewMission(svv.ui.modalMission);
 

--- a/public/javascripts/SVValidate/src/modal/ModalMissionComplete.js
+++ b/public/javascripts/SVValidate/src/modal/ModalMissionComplete.js
@@ -69,22 +69,21 @@ function ModalMissionComplete (uiModalMissionComplete, user, confirmationCode) {
         uiModalMissionComplete.foreground.css('visibility', 'visible');
         uiModalMissionComplete.closeButton.html('Validate more labels');
 
+        // TODO this code was removed for issue #1693, search for "#1693" and uncomment all later.
         // If this is a turker and the confirmation code button hasn't been shown yet, mark amt_assignment as complete
         // and reveal the confirmation code.
-        // TODO add this back in when we start doing validation missions for turkers.
         // if (user.getProperty('role') === 'Turker' && confirmationCode.css('visibility') === 'hidden') {
-        if (false) {
-            _markAmtAssignmentAsComplete();
-            _showConfirmationCode();
-            var confirmationCodeElement = document.createElement("h3");
-            confirmationCodeElement.innerHTML = "<img src='/assets/javascripts/SVLabel/img/icons/Icon_OrangeCheckmark.png'  \" +\n" +
-                "                \"alt='Confirmation Code icon' align='middle' style='top:-1px;position:relative;width:18px;height:18px;'> " +
-                "Confirmation Code: " +
-                svv.confirmationCode +
-                "<p></p>";
-            confirmationCodeElement.setAttribute("id", "modal-mission-complete-confirmation-text");
-            uiModalMissionComplete.message.append(confirmationCodeElement);
-        }
+        //     _markAmtAssignmentAsComplete();
+        //     _showConfirmationCode();
+        //     var confirmationCodeElement = document.createElement("h3");
+        //     confirmationCodeElement.innerHTML = "<img src='/assets/javascripts/SVLabel/img/icons/Icon_OrangeCheckmark.png'  \" +\n" +
+        //         "                \"alt='Confirmation Code icon' align='middle' style='top:-1px;position:relative;width:18px;height:18px;'> " +
+        //         "Confirmation Code: " +
+        //         svv.confirmationCode +
+        //         "<p></p>";
+        //     confirmationCodeElement.setAttribute("id", "modal-mission-complete-confirmation-text");
+        //     uiModalMissionComplete.message.append(confirmationCodeElement);
+        // }
     }
 
     function _markAmtAssignmentAsComplete() {
@@ -107,26 +106,27 @@ function ModalMissionComplete (uiModalMissionComplete, user, confirmationCode) {
         });
     }
 
-    function _showConfirmationCode() {
-        confirmationCode.css('visibility', "");
-        confirmationCode.attr('data-toggle','popover');
-        confirmationCode.attr('title','Submit this code for HIT verification on Amazon Mechanical Turk');
-        confirmationCode.attr('data-content', svv.confirmationCode);
-        confirmationCode.popover();
-
-        //Hide the confirmation popover on clicking the background
-        //https://stackoverflow.com/questions/11703093/how-to-dismiss-a-twitter-bootstrap-popover-by-clicking-outside
-        $(document).on('click', function(e) {
-            confirmationCode.each(function () {
-                // The 'is' for buttons that trigger popups.
-                // The 'has' for icons within a button that triggers a popup.
-                if (!$(this).is(e.target) && $(this).has(e.target).length === 0 && $('.popover').has(e.target).length === 0) {
-                    (($(this).popover('hide').data('bs.popover')||{}).inState||{}).click = false
-                }
-
-            });
-        });
-    }
+    // TODO this code was removed for issue #1693, search for "#1693" and uncomment all later.
+    // function _showConfirmationCode() {
+    //     confirmationCode.css('visibility', "");
+    //     confirmationCode.attr('data-toggle','popover');
+    //     confirmationCode.attr('title','Submit this code for HIT verification on Amazon Mechanical Turk');
+    //     confirmationCode.attr('data-content', svv.confirmationCode);
+    //     confirmationCode.popover();
+    //
+    //     //Hide the confirmation popover on clicking the background
+    //     //https://stackoverflow.com/questions/11703093/how-to-dismiss-a-twitter-bootstrap-popover-by-clicking-outside
+    //     $(document).on('click', function(e) {
+    //         confirmationCode.each(function () {
+    //             // The 'is' for buttons that trigger popups.
+    //             // The 'has' for icons within a button that triggers a popup.
+    //             if (!$(this).is(e.target) && $(this).has(e.target).length === 0 && $('.popover').has(e.target).length === 0) {
+    //                 (($(this).popover('hide').data('bs.popover')||{}).inState||{}).click = false
+    //             }
+    //
+    //         });
+    //     });
+    // }
 
     self.getProperty = getProperty;
     self.hide = hide;


### PR DESCRIPTION
Resolves #1693 

Comments out all turker-related code on the /validate page. I tested to make sure it works for both turkers and non-turkers. I left all the code intact though, with comments that include "#1693" at each location so that it will be easy to uncomment when we want to start using validation for turkers.

Pretty simple change so not asking anyone to test.