### PR TITLE
1611 temp fix for user dashboard not working

### DIFF
--- a/public/javascripts/Admin/src/Admin.User.js
+++ b/public/javascripts/Admin/src/Admin.User.js
@@ -21,7 +21,7 @@ function AdminUser(params) {
     // Set the city-specific default zoom, location, and max bounding box to prevent the user from panning away.
     $.getJSON('/cityMapParams', function(data) {
         map.setView([data.city_center.lat, data.city_center.lng]);
-        map.setZoom(data.default_zoom);
+        map.setZoom(Math.floor(data.default_zoom));
     });
 
     // Visualize audited streets

--- a/public/javascripts/Progress/src/Progress.js
+++ b/public/javascripts/Progress/src/Progress.js
@@ -44,7 +44,7 @@ function Progress (_, $, c3, L, role, difficultRegionIds) {
         var southWest = L.latLng(data.southwest_boundary.lat, data.southwest_boundary.lng);
         var northEast = L.latLng(data.northeast_boundary.lat, data.northeast_boundary.lng);
         map.setMaxBounds(L.latLngBounds(southWest, northEast));
-        map.setZoom(data.default_zoom);
+        map.setZoom(Math.floor(data.default_zoom));
     });
 
     var popup = L.popup().setContent('<p>Hello!</p>');


### PR DESCRIPTION
This is a bandage for #1611 

On the #1611 thread @htadeusiak fully describes our current situation, where we need to upgrade our Leaflet version on the user dashboard and audit pages, but that causes other problems. The early version of Leaflet we are using on those pages does not work with the fractional zoom we are using in Seattle. So the temp fix I am doing is to just take the floor of the zoom level we are given on the user dashboard.

The Seattle deployment is in full swing, so I want users to be able to see their dashboard while we work on figuring out a legitimate fix for this issue.