### PR TITLE
fixes previous mission loading after 2nd validation mission

### DIFF
--- a/public/javascripts/SVValidate/src/modal/ModalMissionComplete.js
+++ b/public/javascripts/SVValidate/src/modal/ModalMissionComplete.js
@@ -19,7 +19,7 @@ function ModalMissionComplete (uiModalMissionComplete, user, confirmationCode) {
      * first label has been loaded onto the screen.
      */
     function hide () {
-        uiModalMissionComplete.closeButton.on('click', null);
+        uiModalMissionComplete.closeButton.off('click');
         uiModalMissionComplete.background.css('visibility', 'hidden');
         uiModalMissionComplete.holder.css('visibility', 'hidden');
         uiModalMissionComplete.foreground.css('visibility', 'hidden');
@@ -41,7 +41,7 @@ function ModalMissionComplete (uiModalMissionComplete, user, confirmationCode) {
         var message = "You just validated " + totalLabels + " " +
             svv.labelTypeNames[mission.getProperty("labelTypeId")] + " labels!";
 
-        // Disable user from clicking the "Validate next mission" button and set background go gray
+        // Disable user from clicking the "Validate next mission" button and set background to gray
         uiModalMissionComplete.closeButton.css('background', '#7f7f7f');
         uiModalMissionComplete.closeButton.css('cursor', 'wait');
 


### PR DESCRIPTION
Fixes #1528 

Fixes an issue where the old mission would load on the validation interface if you clicked the continue button too early. Just needed to change the line `closeButton.on('click', null);` to `closeButton.off('click');`, which is how it is done on the audit page.