### PR TITLE
adds .gitattributes file to fix line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Declare files that will always have CRLF line endings on checkout.
+*.sh text eol=crlf
+db/*.sh text eol=crlf
+


### PR DESCRIPTION
Fixes #1527 

FIxes an issue in setting up our Docker dev environment where our shell scripts had CRLF line endings which caused them to fail with a cryptic error. This is fixed by adding a .gitattributes file to set the default line endings for shell scripts. I used [this tutorial](https://help.github.com/en/articles/dealing-with-line-endings#per-repository-settings) to create our .gitattributes file.