### PR TITLE
g and r are now both shortcuts for grass tag

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/keyboard/Keyboard.js
+++ b/public/javascripts/SVLabel/src/SVLabel/keyboard/Keyboard.js
@@ -386,7 +386,10 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
                             case util.misc.getLabelDescriptions('SurfaceProblem')['tagInfo']['cracks']['keyNumber']: // 'r' for 'cracks'
                                 $('.cracks-tag').first().trigger("click", {lowLevelLogging: false});
                                 break;
-                            case util.misc.getLabelDescriptions('SurfaceProblem')['tagInfo']['grass']['keyNumber']: // 'g' for 'grass'
+                            case util.misc.getLabelDescriptions('SurfaceProblem')['tagInfo']['grass']['keyNumber'][0]: // 'g' for 'grass'
+                                $('.grass-tag').first().trigger("click", {lowLevelLogging: false});
+                                break;
+                            case util.misc.getLabelDescriptions('SurfaceProblem')['tagInfo']['grass']['keyNumber'][1]: // 'r' for 'grass'
                                 $('.grass-tag').first().trigger("click", {lowLevelLogging: false});
                                 break;
                             case util.misc.getLabelDescriptions('SurfaceProblem')['tagInfo']['narrow sidewalk']['keyNumber']  : // 'a' for 'narrow sidewalk'

--- a/public/javascripts/SVLabel/src/SVLabel/util/UtilitiesSidewalk.js
+++ b/public/javascripts/SVLabel/src/SVLabel/util/UtilitiesSidewalk.js
@@ -414,8 +414,8 @@ function UtilitiesMisc (JSON) {
                         id: 'cracks'
                     },
                     'grass': {
-                        keyNumber: 82,
-                        keyChar: 'R',
+                        keyNumber: [71, 82],
+                        keyChar: ['G', 'R'],
                         text: 'g<tag-underline>r</tag-underline>ass',
                         id: 'grass'
                     },


### PR DESCRIPTION
Resolves #1596 

Adds 'g' back in as a keyboard shortcut for the 'grass' surface problem tag. Both 'g' and 'r' are now options.