### PR TITLE
1590 no hardcoded dates admin page

### DIFF
--- a/app/models/audit/AuditTaskTable.scala
+++ b/app/models/audit/AuditTaskTable.scala
@@ -141,13 +141,12 @@ object AuditTaskTable {
     */
   def auditCounts: List[AuditCountPerDay] = db.withSession { implicit session =>
     val selectAuditCountQuery =  Q.queryNA[(String, Int)](
-      """SELECT calendar_date::date, COUNT(audit_task_id)
+      """SELECT calendar_date, COUNT(audit_task_id)
         |FROM
         |(
-        |    SELECT  current_date - (n || ' day')::INTERVAL AS calendar_date
-        |    FROM generate_series(0, current_date - '11/17/2015') n
+        |    SELECT audit_task_id, task_start::date AS calendar_date
+        |    FROM audit_task
         |) AS calendar
-        |LEFT JOIN sidewalk.audit_task ON audit_task.task_start::date = calendar_date::date
         |GROUP BY calendar_date
         |ORDER BY calendar_date""".stripMargin
     )

--- a/app/models/audit/AuditTaskTable.scala
+++ b/app/models/audit/AuditTaskTable.scala
@@ -135,7 +135,7 @@ object AuditTaskTable {
   }
 
   /**
-    * Returns a count of the number of audits performed on each day since the tool was launched (11/17/2015).
+    * Returns a count of the number of audits performed on each day with audits.
     *
     * @return
     */

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -926,14 +926,14 @@ object LabelTable {
     */
   def selectLabelCountsPerDay: List[LabelCountPerDay] = db.withSession { implicit session =>
     val selectLabelCountQuery =  Q.queryNA[(String, Int)](
-      """SELECT calendar_date::date, COUNT(label_id)
+      """SELECT calendar_date, COUNT(label_id)
         |FROM
         |(
-        |    SELECT current_date - (n || ' day')::INTERVAL AS calendar_date
-        |    FROM generate_series(0, current_date - '11/17/2015') n
+        |    SELECT label_id, task_start::date AS calendar_date
+        |    FROM audit_task
+        |    INNER JOIN label ON audit_task.audit_task_id = label.audit_task_id
+        |    WHERE deleted = FALSE
         |) AS calendar
-        |LEFT JOIN sidewalk.audit_task ON audit_task.task_start::date = calendar_date::date
-        |LEFT JOIN sidewalk.label ON label.audit_task_id = audit_task.audit_task_id
         |GROUP BY calendar_date
         |ORDER BY calendar_date""".stripMargin
     )

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -920,7 +920,7 @@ object LabelTable {
   }
 
   /**
-    * Returns a count of the number of labels placed on each day since the tool was launched (11/17/2015).
+    * Returns a count of the number of labels placed on each day there were labels placed.
     *
     * @return
     */

--- a/app/models/label/LabelValidationTable.scala
+++ b/app/models/label/LabelValidationTable.scala
@@ -270,13 +270,13 @@ object LabelValidationTable {
     */
   def getValidationsByDate: List[ValidationCountPerDay] = db.withSession { implicit session =>
     val selectValidationCountQuery = Q.queryNA[(String, Int)](
-      """SELECT calendar_date::date, COUNT(label_id)
+      """SELECT calendar_date, COUNT(label_validation_id)
         |FROM
         |(
-        |    SELECT current_date - (n || ' day')::INTERVAL AS calendar_date
-        |    FROM generate_series(0, current_date - '12/17/2018') n
+        |    SELECT label_validation_id, end_timestamp::date AS calendar_date
+        |    FROM label_validation
+        |    WHERE label_validation IS NOT NULL
         |) AS calendar
-        |LEFT JOIN sidewalk.label_validation ON label_validation.end_timestamp::date = calendar_date::date
         |GROUP BY calendar_date
         |ORDER BY calendar_date""".stripMargin
     )


### PR DESCRIPTION
Fixes #1590 

Removes the hardcoded dates for the graphs on the admin page. They now start whenever we begin having data. Note that the data looks a bit sparse in the graphs below b/c it is the data used in my dev environment, not the last few months of production data.

Before:
![daily-before-1](https://user-images.githubusercontent.com/6518824/57163496-37d1b600-6da6-11e9-9781-9a34490a7ae0.png)
![daily-before-2](https://user-images.githubusercontent.com/6518824/57163498-3902e300-6da6-11e9-9d37-a23eb071971e.png)

After:
![daily-after-1](https://user-images.githubusercontent.com/6518824/57163456-1d97d800-6da6-11e9-95b6-58079fcbb4a8.png)
![daily-after-2](https://user-images.githubusercontent.com/6518824/57163458-1ec90500-6da6-11e9-9faf-dcb3865584c6.png)

Really easy change, so not asking anyone to test before putting it on test servers.