### PR TITLE
1712 speed up validation page

### DIFF
--- a/app/controllers/ValidationController.scala
+++ b/app/controllers/ValidationController.scala
@@ -80,7 +80,7 @@ class ValidationController @Inject() (implicit val env: Environment[User, Sessio
     val labelsValidated: Int = mission.labelsValidated.get
     val labelsToRetrieve: Int = labelsValidated - labelsProgress
 
-    val labelMetadata: Seq[LabelValidationMetadata] = LabelTable.retrieveNRandomLabelsFromLabelTypeForValidationStatic(userId, labelsToRetrieve, labelType)
+    val labelMetadata: Seq[LabelValidationMetadata] = LabelTable.retrieveLabelListForValidation(userId, labelsToRetrieve, labelType)
     val labelMetadataJsonSeq: Seq[JsObject] = labelMetadata.map(label => LabelTable.validationLabelMetadataToJson(label))
     val labelMetadataJson : JsValue = Json.toJson(labelMetadataJsonSeq)
     labelMetadataJson

--- a/app/controllers/ValidationController.scala
+++ b/app/controllers/ValidationController.scala
@@ -80,7 +80,7 @@ class ValidationController @Inject() (implicit val env: Environment[User, Sessio
     val labelsValidated: Int = mission.labelsValidated.get
     val labelsToRetrieve: Int = labelsValidated - labelsProgress
 
-    val labelMetadata: Seq[LabelValidationMetadata] = LabelTable.retrieveLabelListForValidation(userId, labelsToRetrieve, labelType)
+    val labelMetadata: Seq[LabelValidationMetadata] = LabelTable.retrieveNRandomLabelsFromLabelTypeForValidationStatic(userId, labelsToRetrieve, labelType)
     val labelMetadataJsonSeq: Seq[JsObject] = labelMetadata.map(label => LabelTable.validationLabelMetadataToJson(label))
     val labelMetadataJson : JsValue = Json.toJson(labelMetadataJsonSeq)
     labelMetadataJson

--- a/app/controllers/ValidationTaskController.scala
+++ b/app/controllers/ValidationTaskController.scala
@@ -167,7 +167,7 @@ class ValidationTaskController @Inject() (implicit val env: Environment[User, Se
     *                     canvas_y, canvas_width, canvas_height}
     */
   def getLabelListForValidation(userId: UUID, count: Int, labelTypeId: Int): JsValue = {
-    val labelMetadata: Seq[LabelValidationMetadata] = LabelTable.retrieveLabelListForValidation(userId, count, labelTypeId)
+    val labelMetadata: Seq[LabelValidationMetadata] = LabelTable.retrieveNRandomLabelsFromLabelTypeForValidationStatic(userId, count, labelTypeId)
     val labelMetadataJsonSeq: Seq[JsObject] = labelMetadata.map(LabelTable.validationLabelMetadataToJson)
     val labelMetadataJson : JsValue = Json.toJson(labelMetadataJsonSeq)
     labelMetadataJson

--- a/app/controllers/ValidationTaskController.scala
+++ b/app/controllers/ValidationTaskController.scala
@@ -168,7 +168,7 @@ class ValidationTaskController @Inject() (implicit val env: Environment[User, Se
     */
   def getLabelListForValidation(userId: UUID, count: Int, labelTypeId: Int): JsValue = {
     val labelMetadata: Seq[LabelValidationMetadata] = LabelTable.retrieveLabelListForValidation(userId, count, labelTypeId)
-    val labelMetadataJsonSeq: Seq[JsObject] = labelMetadata.map(label => LabelTable.validationLabelMetadataToJson(label))
+    val labelMetadataJsonSeq: Seq[JsObject] = labelMetadata.map(LabelTable.validationLabelMetadataToJson)
     val labelMetadataJson : JsValue = Json.toJson(labelMetadataJsonSeq)
     labelMetadataJson
   }
@@ -176,10 +176,10 @@ class ValidationTaskController @Inject() (implicit val env: Environment[User, Se
   /**
     * Gets the metadata for a single random label in the database. Excludes labels that were
     * originally placed by the user and labels that have already appeared on the interface.
-    * @param labelType  Label Type Id this label should have
-    * @return           Label metadata containing GSV metadata and label type
+    * @param labelTypeId  Label Type Id this label should have
+    * @return             Label metadata containing GSV metadata and label type
     */
-  def getRandomLabelData (labelType: Int) = UserAwareAction.async(BodyParsers.parse.json) { implicit request =>
+  def getRandomLabelData (labelTypeId: Int) = UserAwareAction.async(BodyParsers.parse.json) { implicit request =>
     var submission = request.body.validate[Seq[SkipLabelSubmission]]
     submission.fold(
       errors => {
@@ -194,7 +194,7 @@ class ValidationTaskController @Inject() (implicit val env: Environment[User, Se
           }
 
           val userId: UUID = request.identity.get.userId
-          val labelMetadata: LabelValidationMetadata = LabelTable.retrieveSingleRandomLabelFromLabelTypeForValidation(userId, labelType, Some(labelIdList))
+          val labelMetadata: LabelValidationMetadata = LabelTable.retrieveNRandomLabelsFromLabelTypeForValidationStatic(userId, labelTypeId, 1).head
           LabelTable.validationLabelMetadataToJson(labelMetadata)
         }
         Future.successful(Ok(labelMetadataJson.head))

--- a/app/controllers/ValidationTaskController.scala
+++ b/app/controllers/ValidationTaskController.scala
@@ -6,20 +6,14 @@ import javax.inject.Inject
 
 import com.mohiva.play.silhouette.api.{Environment, Silhouette}
 import com.mohiva.play.silhouette.impl.authenticators.SessionAuthenticator
-import com.vividsolutions.jts.geom._
 import controllers.headers.ProvidesHeader
 import formats.json.ValidationTaskSubmissionFormats._
-import models.amt.{AMTAssignment, AMTAssignmentTable}
-import models.audit._
-import models.daos.slick.DBTableDefinitions.{DBUser, UserTable}
-import models.gsv.{GSVData, GSVDataTable, GSVLink, GSVLinkTable}
+import models.amt.AMTAssignmentTable
 import models.label._
-import models.label.LabelValidationTable._
 import models.label.LabelTable.LabelValidationMetadata
 import models.mission.{Mission, MissionTable}
-import models.user.{User, UserCurrentRegionTable}
+import models.user.User
 import models.validation._
-import org.joda.time.{DateTime, DateTimeZone}
 import play.api.libs.json._
 import play.api.Logger
 import play.api.mvc._

--- a/app/controllers/ValidationTaskController.scala
+++ b/app/controllers/ValidationTaskController.scala
@@ -154,14 +154,14 @@ class ValidationTaskController @Inject() (implicit val env: Environment[User, Se
   /**
     * Gets a random list of labels to validate for this mission.
     * @param userId       User ID of the current user.
-    * @param count        Number of labels to retrieve for this list.
+    * @param n            Number of labels to retrieve for this list.
     * @param labelTypeId  Label Type to retrieve
     * @return             JsValue containing a list of labels with the following attributes:
     *                     {label_id, label_type, gsv_panorama_id, heading, pitch, zoom, canvas_x,
     *                     canvas_y, canvas_width, canvas_height}
     */
-  def getLabelListForValidation(userId: UUID, count: Int, labelTypeId: Int): JsValue = {
-    val labelMetadata: Seq[LabelValidationMetadata] = LabelTable.retrieveNRandomLabelsFromLabelTypeForValidationStatic(userId, count, labelTypeId)
+  def getLabelListForValidation(userId: UUID, n: Int, labelTypeId: Int): JsValue = {
+    val labelMetadata: Seq[LabelValidationMetadata] = LabelTable.retrieveLabelListForValidation(userId, n, labelTypeId)
     val labelMetadataJsonSeq: Seq[JsObject] = labelMetadata.map(LabelTable.validationLabelMetadataToJson)
     val labelMetadataJson : JsValue = Json.toJson(labelMetadataJsonSeq)
     labelMetadataJson
@@ -188,7 +188,7 @@ class ValidationTaskController @Inject() (implicit val env: Environment[User, Se
           }
 
           val userId: UUID = request.identity.get.userId
-          val labelMetadata: LabelValidationMetadata = LabelTable.retrieveNRandomLabelsFromLabelTypeForValidationStatic(userId, labelTypeId, 1).head
+          val labelMetadata: LabelValidationMetadata = LabelTable.retrieveLabelListForValidation(userId, n = 1, labelTypeId).head
           LabelTable.validationLabelMetadataToJson(labelMetadata)
         }
         Future.successful(Ok(labelMetadataJson.head))

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -527,7 +527,7 @@ object LabelTable {
     * @param labelTypeId  Label Type ID of labels requested.
     * @return             Seq[LabelValidationMetadata]
     */
-  def retrieveNRandomLabelsFromLabelTypeForValidationStatic(userId: UUID, n: Int, labelTypeId: Int) : Seq[LabelValidationMetadata] = db.withSession { implicit session =>
+  def retrieveLabelListForValidation(userId: UUID, n: Int, labelTypeId: Int) : Seq[LabelValidationMetadata] = db.withSession { implicit session =>
     var selectedLabels: ListBuffer[LabelValidationMetadata] = new ListBuffer[LabelValidationMetadata]()
     var potentialLabels: List[LabelValidationMetadata] = List()
 
@@ -594,7 +594,7 @@ object LabelTable {
   def retrieveRandomLabelListForValidation(userId: UUID, count: Int) : Seq[LabelValidationMetadata] = db.withSession { implicit session =>
     // We are currently assigning label types to missions randomly.
     val labelTypeId: Int = retrieveRandomValidationLabelTypeId()
-    retrieveNRandomLabelsFromLabelTypeForValidationStatic(userId, count, labelTypeId)
+    retrieveLabelListForValidation(userId, count, labelTypeId)
   }
 
   /**

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -523,11 +523,11 @@ object LabelTable {
     * Starts by querying for n * 5 labels, then checks GSV API to see if each gsv_panorama_id exists until we find n.
     *
     * @param userId       User ID for the current user.
-    * @param labelTypeId  Label Type ID of labels requested.
     * @param n            Number of labels we need to query.
-    * @return
+    * @param labelTypeId  Label Type ID of labels requested.
+    * @return             Seq[LabelValidationMetadata]
     */
-  def retrieveNRandomLabelsFromLabelTypeForValidationStatic(userId: UUID, labelTypeId: Int, n: Int) : Seq[LabelValidationMetadata] = db.withSession { implicit session =>
+  def retrieveNRandomLabelsFromLabelTypeForValidationStatic(userId: UUID, n: Int, labelTypeId: Int) : Seq[LabelValidationMetadata] = db.withSession { implicit session =>
     var selectedLabels: ListBuffer[LabelValidationMetadata] = new ListBuffer[LabelValidationMetadata]()
     var potentialLabels: List[LabelValidationMetadata] = List()
 
@@ -585,17 +585,6 @@ object LabelTable {
     selectedLabels
   }
 
-  /**
-    * Retrieves a list of labels to be validated.
-    * @param userId       User ID of the current user.
-    * @param count        Length of list.
-    * @param labelTypeId  Label Type ID of each label in the list.
-    * @return             Seq[LabelValidationMetadata]
-    */
-  def retrieveLabelListForValidation(userId: UUID, count: Int, labelTypeId: Int) : Seq[LabelValidationMetadata] = db.withSession { implicit session =>
-    retrieveNRandomLabelsFromLabelTypeForValidationStatic(userId, labelTypeId, count)
-  }
-
   /**.
     * Retrieve a list of labels for validation with a random label id
     * @param userId User ID of the current user.
@@ -605,7 +594,7 @@ object LabelTable {
   def retrieveRandomLabelListForValidation(userId: UUID, count: Int) : Seq[LabelValidationMetadata] = db.withSession { implicit session =>
     // We are currently assigning label types to missions randomly.
     val labelTypeId: Int = retrieveRandomValidationLabelTypeId()
-    retrieveLabelListForValidation(userId, count, labelTypeId)
+    retrieveNRandomLabelsFromLabelTypeForValidationStatic(userId, count, labelTypeId)
   }
 
   /**

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -4,15 +4,12 @@ import java.net.{ConnectException, HttpURLConnection, SocketException, URL}
 import java.sql.Timestamp
 import java.util.UUID
 
-import com.vividsolutions.jts.geom.LineString
-import models.audit.{AuditTask, AuditTaskEnvironmentTable, AuditTaskInteraction, AuditTaskTable}
+import models.audit.{AuditTask, AuditTaskEnvironmentTable, AuditTaskTable}
 import models.daos.slick.DBTableDefinitions.UserTable
 import models.gsv.GSVDataTable
-import models.label.LabelValidationTable._
 import models.mission.{Mission, MissionTable, MissionTypeTable}
 import models.region.RegionTable
 import models.user.{RoleTable, UserRoleTable}
-
 import models.utils.MyPostgresDriver.simple._
 import org.joda.time.{DateTime, DateTimeZone}
 import play.api.Play.current
@@ -137,6 +134,9 @@ object LabelTable {
 
   implicit val labelLocationConverter = GetResult[LabelLocation](r =>
     LabelLocation(r.nextInt, r.nextInt, r.nextString, r.nextString, r.nextFloat, r.nextFloat))
+
+  implicit val labelValidationMetadataConverter = GetResult[LabelValidationMetadata](r =>
+    LabelValidationMetadata(r.nextInt, r.nextString, r.nextString, r.nextFloat, r.nextFloat, r.nextInt, r.nextInt, r.nextInt, r.nextInt, r.nextInt))
 
   implicit val labelSeverityConverter = GetResult[LabelLocationWithSeverity](r =>
     LabelLocationWithSeverity(r.nextInt, r.nextInt, r.nextString, r.nextString, r.nextInt, r.nextFloat, r.nextFloat))
@@ -484,7 +484,7 @@ object LabelTable {
   /**
     * Returns whether we have enough labels for this user to validate.
     * @param userId             User ID.
-    * @param labelType          Label Type ID of labels requested.
+    * @param labelTypeId        Label Type ID of labels requested.
     * @param labelsRequired     Number of labels we need to query.
     * @return   True if we have enough labels, false otherwise.
     */
@@ -518,71 +518,82 @@ object LabelTable {
   }
 
   /**
-    * Retrieves a random label that has an existing GSVPanorama.
-    * Will keep querying for a random label until a suitable label has been found.
+    * Retrieve n random labels that have existing GSVPanorama.
+    *
+    * Starts by querying for n * 5 labels, then checks GSV API to see if each gsv_panorama_id exists until we find n.
+    *
     * @param userId       User ID for the current user.
-    * @param labelTypeId  Label that is retrieved from the database.
-    * @param labelIdList  List of labels that we do not want to select (i.e., labels that have
-    *                     already been selected in the current mission).
-    * @return LabelValidationMetadata of this label.
+    * @param labelTypeId  Label Type ID of labels requested.
+    * @param n            Number of labels we need to query.
+    * @return
     */
-  def retrieveSingleRandomLabelFromLabelTypeForValidation(userId: UUID, labelTypeId: Int, labelIdList: Option[ListBuffer[Int]]) : LabelValidationMetadata = db.withSession { implicit session =>
-    var exists: Boolean = false
-    var labelToValidate: LabelValidationMetadata = null;
-    var selectedLabels: ListBuffer[Int] = labelIdList.getOrElse(new ListBuffer[Int]())
+  def retrieveNRandomLabelsFromLabelTypeForValidationStatic(userId: UUID, labelTypeId: Int, n: Int) : Seq[LabelValidationMetadata] = db.withSession { implicit session =>
+    var selectedLabels: ListBuffer[LabelValidationMetadata] = new ListBuffer[LabelValidationMetadata]()
+    var potentialLabels: List[LabelValidationMetadata] = List()
 
-    val userIdString = userId.toString
-    val availableLabelCount: Int = getAvailableValidationLabels(userId, labelTypeId, labelIdList)
-    while (!exists) {
-      val r = new scala.util.Random
-      val labelOffset = r.nextInt(availableLabelCount - selectedLabels.length)
+    while (selectedLabels.length < n) {
+      val selectRandomLabelsQuery = Q.query[(Int, String, String, Int), LabelValidationMetadata](
+        """SELECT label.label_id, label_type.label_type, label.gsv_panorama_id, label_point.heading, label_point.pitch,
+          |       label_point.zoom, label_point.canvas_x, label_point.canvas_y,
+          |       label_point.canvas_width, label_point.canvas_height
+          |FROM label
+          |INNER JOIN label_type ON label.label_type_id = label_type.label_type_id
+          |INNER JOIN label_point ON label.label_id = label_point.label_id
+          |INNER JOIN gsv_data ON label.gsv_panorama_id = gsv_data.gsv_panorama_id
+          |INNER JOIN mission ON label.mission_id = mission.mission_id
+          |WHERE label.label_type_id = ?
+          |    AND label.deleted = FALSE
+          |    AND label.tutorial = FALSE
+          |    AND gsv_data.expired = FALSE
+          |    AND mission.user_id <> ?
+          |    AND label.label_id NOT IN (
+          |        SELECT label_id
+          |        FROM label_validation
+          |        WHERE user_id = ?
+          |    )
+          |ORDER BY RANDOM()
+          |LIMIT ?""".stripMargin
+      )
+      potentialLabels = selectRandomLabelsQuery((labelTypeId, userId.toString, userId.toString, n * 5)).list
+      var potentialStart: Int = 0
 
-      val labelsValidatedByUser = labelValidations.filter(_.userId === userIdString).map(_.labelId).list
-      var validationLabels = for {
-        _lb <- labels if _lb.labelTypeId === labelTypeId && _lb.deleted === false && _lb.tutorial === false
-        _lt <- labelTypes if _lt.labelTypeId === _lb.labelTypeId
-        _lp <- labelPoints if _lb.labelId === _lp.labelId
-        _gd <- gsvData if _gd.gsvPanoramaId === _lb.gsvPanoramaId && _gd.expired === false
-        _ms <- missions if _ms.missionId === _lb.missionId && _ms.userId =!= userIdString
-      } yield (_lb.labelId, _lt.labelType, _lb.gsvPanoramaId, _lp.heading, _lp.pitch, _lp.zoom,
-        _lp.canvasX, _lp.canvasY, _lp.canvasWidth, _lp.canvasHeight)
+      // Start looking through our n * 5 labels until we find n with valid pano id or we've gone through our n * 5 and
+      // need to query for some more (which we don't expect to happen in a typical use case).
+      while (selectedLabels.length < n && potentialStart < potentialLabels.length) {
 
-      validationLabels = validationLabels.filterNot(_._1 inSet labelsValidatedByUser)
-      validationLabels = validationLabels.filterNot(_._1 inSet selectedLabels)
+        val labelsNeeded: Int = n - selectedLabels.length
+        val potentialEnd: Int = potentialStart + labelsNeeded
+        val newLabels: Seq[LabelValidationMetadata] = potentialLabels.slice(potentialStart, potentialEnd).par.flatMap { currLabel =>
+          val exists = panoExists(currLabel.gsvPanoramaId)
 
-      val singleLabel: LabelValidationMetadata =
-        LabelValidationMetadata.tupled(validationLabels.drop(labelOffset).take(1).list.head)
+          // If the pano exists, mark the last time we viewed it in the database, o/w mark as expired.
+          if (exists) {
+            val now = new DateTime(DateTimeZone.UTC)
+            val timestamp: Timestamp = new Timestamp(now.getMillis)
+            GSVDataTable.markLastViewedForPanorama(currLabel.gsvPanoramaId, timestamp)
+            Some(currLabel)
+          } else {
+            GSVDataTable.markExpired(currLabel.gsvPanoramaId, expired = true)
+            None
+          }
+        }.seq
 
-      // Uses panorama ID to check if this panorama exists
-      exists = panoExists(singleLabel.gsvPanoramaId)
-
-      if (exists) {
-        labelToValidate = singleLabel
-        val now = new DateTime(DateTimeZone.UTC)
-        val timestamp: Timestamp = new Timestamp(now.getMillis)
-        GSVDataTable.markLastViewedForPanorama(singleLabel.gsvPanoramaId, timestamp)
-        selectedLabels += singleLabel.labelId
-      } else {
-        GSVDataTable.markExpired(singleLabel.gsvPanoramaId, true)
+        potentialStart += labelsNeeded
+        selectedLabels ++= newLabels
       }
     }
-    labelToValidate
+    selectedLabels
   }
 
   /**
     * Retrieves a list of labels to be validated.
     * @param userId       User ID of the current user.
     * @param count        Length of list.
-    * @param labelTypeId  Label Type of each label in the list.
+    * @param labelTypeId  Label Type ID of each label in the list.
     * @return             Seq[LabelValidationMetadata]
     */
-  def retrieveLabelListForValidation(userId: UUID, count: Int, labelType: Int) : Seq[LabelValidationMetadata] = db.withSession { implicit session =>
-    var labelList = new ListBuffer[LabelValidationMetadata]()
-    var labelIdList = new ListBuffer[Int]()
-    for (a <- 1 to count) {
-      labelList += retrieveSingleRandomLabelFromLabelTypeForValidation(userId, labelType, Some(labelIdList))
-    }
-    labelList
+  def retrieveLabelListForValidation(userId: UUID, count: Int, labelTypeId: Int) : Seq[LabelValidationMetadata] = db.withSession { implicit session =>
+    retrieveNRandomLabelsFromLabelTypeForValidationStatic(userId, labelTypeId, count)
   }
 
   /**.
@@ -716,7 +727,7 @@ object LabelTable {
   /**
     * This method returns a list of strings with all the tags associated with a label
     *
-    * @param userId Label id
+    * @param labelId Label id
     * @return A list of strings with all the tags asscociated with a label
     */
   def getTagsFromLabelId(labelId: Int): List[String] = db.withSession { implicit session =>


### PR DESCRIPTION
Fixes #1712 

Speeds up loading new missions for validation page by a few seconds.

There are two main updates I made to this.
1. Instead of querying our database 10 times (once per new label), we query the database just once. In order to do this, I had to switch from our nice compiled Slick queries to a static SQL query because (our version) of Slick doesn't have the feature where we select N labels randomly. This seems to be saving about 3.5 seconds.
1. As suggested by @aileenzeng we are now calling the GSV API for the 10 labels in parallel. This seems to be saving about 1.25 seconds. Turns out that this is ridiculously easy in Scala. So I'll keep an eye out in the future for where I can use this :)

All in all we are saving about 4.75 seconds whenever loading a new mission (and I assume the savings will increase as we add more labels). Loading a new mission does still take a few seconds, but it is noticeably faster now :)