### PR TITLE
1735 - Validation fixes two button presses after skip button clicked bug

### DIFF
--- a/public/javascripts/SVValidate/src/mission/Mission.js
+++ b/public/javascripts/SVValidate/src/mission/Mission.js
@@ -78,16 +78,21 @@ function Mission(params) {
 
     /**
      * Updates status bar (UI) and current mission properties.
+     * @param skip (bool) - if true, the user clicked the skip button and the progress will not
+     *                      increase. If false the user clicked agree, disagree, or not sure and
+     *                      progress will increase.
      */
-    function updateMissionProgress() {
+    function updateMissionProgress(skip) {
         var labelsProgress = getProperty("labelsProgress");
         if (labelsProgress < getProperty("labelsValidated")) {
-            labelsProgress += 1;
+            if (!skip) {
+                labelsProgress += 1;
+            }
             svv.statusField.updateLabelCounts(labelsProgress);
             setProperty("labelsProgress", labelsProgress);
 
             // Submit mission if mission is complete
-            if (labelsProgress === getProperty("labelsValidated")) {
+            if (labelsProgress >= getProperty("labelsValidated")) {
                 setProperty("completed", true);
                 svv.missionContainer.completeAMission();
             }

--- a/public/javascripts/SVValidate/src/mission/MissionContainer.js
+++ b/public/javascripts/SVValidate/src/mission/MissionContainer.js
@@ -86,7 +86,14 @@ function MissionContainer () {
      * Updates the status of the current mission.
      */
     function updateAMission() {
-        currentMission.updateMissionProgress();
+        currentMission.updateMissionProgress(false);
+    }
+
+    /**
+     * Updates the status of the current mission if client clicked the skip button.
+     */
+    function updateAMissionSkip() {
+        currentMission.updateMissionProgress(true);
     }
 
     self.addAMission = addAMission;
@@ -94,6 +101,7 @@ function MissionContainer () {
     self.createAMission = createAMission;
     self.getCurrentMission = getCurrentMission;
     self.updateAMission = updateAMission;
+    self.updateAMissionSkip = updateAMissionSkip;
 
     return this;
 }

--- a/public/javascripts/SVValidate/src/panorama/PanoramaContainer.js
+++ b/public/javascripts/SVValidate/src/panorama/PanoramaContainer.js
@@ -68,8 +68,8 @@ function PanoramaContainer (labelList) {
             dataType: 'json',
             success: function (labelMetadata) {
                 labels.push(_createSingleLabel(labelMetadata));
-                setProperty('progress', getProperty('progress') + 1);
-                svv.panorama.setLabel(labels[getProperty('progress')]);
+                svv.missionContainer.updateAMissionSkip();
+                loadNewLabelOntoPanorama();
             }
         });
     }


### PR DESCRIPTION
Fixes #1735 

When a user clicked skip in the validation interface, the next image would require two button clicks to get past. This PR address that issue. The problem was there are two "progress" variables that keep track of where we are in the "labels" array. These trackers were set incorrectly when the user clicked skip.

Before:
![test1](https://user-images.githubusercontent.com/33988444/58376713-a2998b80-7f25-11e9-88bb-71bb3c7e92c5.gif)
After:
![test2](https://user-images.githubusercontent.com/33988444/58376754-b0034580-7f26-11e9-8045-daccc748843c.gif)
