### PR TITLE
Tutorial - context menu can block tutorial instructions

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/onboarding/OnboardingStates.js
+++ b/public/javascripts/SVLabel/src/SVLabel/onboarding/OnboardingStates.js
@@ -3,22 +3,22 @@ function OnboardingStates (compass, mapService, statusModel, tracker) {
     var panoId = "stxXyCKAbd73DmkM2vsIHA";
     var afterWalkPanoId = "PTHUzZqpLdS1nTixJMoDSw";
     var headingRanges = {
-        "stage-1": [250, 262],
-        "stage-2-adjust": [200, 262],
-        "stage-2": [200, 210],
-        "stage-3-adjust": [97, 200],
-        "stage-3": [97, 180],
-        "stage-4-adjust": [7, 180],
-        "stage-4": [7, 115],
-        "stage-5-adjust": [320, 115],
-        "stage-5": [300, 36],
+        "stage-1": [238, 242],
+        "stage-2-adjust": [197, 242],
+        "stage-2": [197, 209],
+        "stage-3-adjust": [98, 197],
+        "stage-3": [98, 108],
+        "stage-4-adjust": [359, 108],
+        "stage-4": [355, 1],
+        "stage-5-adjust": [315, 1],
+        "stage-5": [315, 343],
         "stage-6": [281, 14]
     };
     this.states = {
         "initialize": {
             "properties": {
                 "action": "Introduction",
-                "heading": 262,
+                "heading": 241,
                 "pitch": -6,
                 "zoom": 1,
                 "lat": 38.94042608,
@@ -1396,7 +1396,7 @@ function OnboardingStates (compass, mapService, statusModel, tracker) {
         "adjust-heading-angle-4": {
             "properties": {
                 "action": "AdjustHeadingAngle",
-                "heading": 20,
+                "heading": 0,
                 "tolerance": 20,
                 "minHeading": headingRanges["stage-4-adjust"][0],
                 "maxHeading": headingRanges["stage-4-adjust"][1],


### PR DESCRIPTION
Fixes #1545 

I only made changes to the min/max head angles. It should now prevent most context menu's from covering tutorial instructions. I'm not sure exactly what you had in mind with adjusting the head angles, so I made the tutorial slightly more 'constricting' as far as user movements. 

I do know in two places where the instructions do get covered:
- In stage 2 you can cover the instructions with the missing curb context menu. There is not a way to prevent this from happening unless we added another stage.
- In stage 3 you can cover the instructions with the curb context menu if your pov is pointed up higher. Once again we would need to add another stage or have the user point the pov more to the ground to fully prevent this. 
However, for both these cases I do not view the context menu covering the instructions that big of an issue.

I would post a gif of the result, but it would be rather long and would not be able to attach to this post. It's probably best anyways to test this pr in your dev environment to look for other issues I might have missed as well as get a feel for how the movements are controlled in the updated tutorial and decide if you like it or not.
