### PR TITLE
1750 - Fix keyboard shortcuts firing off

### DIFF
--- a/public/javascripts/SVValidate/src/Main.js
+++ b/public/javascripts/SVValidate/src/Main.js
@@ -134,6 +134,15 @@ function Main (param) {
 
         svv.missionContainer = new MissionContainer();
         svv.missionContainer.createAMission(param.mission, param.progress);
+
+        $('#sign-in-modal-container').on('hide.bs.modal', function () {
+            svv.keyboard.enableKeyboard();
+            $(".toolUI").css('opacity', 1);
+        });
+        $('#sign-in-modal-container').on('show.bs.modal', function () {
+            svv.keyboard.disableKeyboard();
+            $(".toolUI").css('opacity', 0.5);
+        });
     }
 
     _initUI();

--- a/public/javascripts/SVValidate/src/keyboard/Keyboard.js
+++ b/public/javascripts/SVValidate/src/keyboard/Keyboard.js
@@ -100,23 +100,25 @@ function Keyboard(menuUI) {
     };
 
     this._documentKeyUp = function (e) {
-        switch (e.keyCode) {
-            // "a" key
-            case 65:
-                menuUI.agreeButton.removeClass("validate");
-                status.keyPressed = false;
-                break;
-            // "d" key
-            case 68:
-                menuUI.disagreeButton.removeClass("validate");
-                status.keyPressed = false;
-                break;
-            // "n" key
-            case 78:
-                menuUI.notSureButton.removeClass("validate");
-                status.keyPressed = false;
-                break;
-        }
+        if (!status.disableKeyboard) {
+            switch (e.keyCode) {
+                // "a" key
+                case 65:
+                    menuUI.agreeButton.removeClass("validate");
+                    status.keyPressed = false;
+                    break;
+                // "d" key
+                case 68:
+                    menuUI.disagreeButton.removeClass("validate");
+                    status.keyPressed = false;
+                    break;
+                // "n" key
+                case 78:
+                    menuUI.notSureButton.removeClass("validate");
+                    status.keyPressed = false;
+                    break;
+            }
+         }
     };
 
     $(document).bind('keyup', this._documentKeyUp);

--- a/public/javascripts/SVValidate/src/modal/ModalMission.js
+++ b/public/javascripts/SVValidate/src/modal/ModalMission.js
@@ -25,7 +25,13 @@ function ModalMission (uiModalMission, user) {
      * Hides the new/continuing mission screen
      */
     function hide () {
-        svv.keyboard.enableKeyboard();
+        // We still want to disable keyboard shortcuts if the
+	// comment box is shown
+        if ($('#modal-comment-box').is(":hidden")) {
+            svv.keyboard.enableKeyboard();
+        } else {
+            svv.keyboard.disableKeyboard();
+        }
         uiModalMission.background.css('visibility', 'hidden');
         uiModalMission.holder.css('visibility', 'hidden');
         uiModalMission.foreground.css('visibility', 'hidden');


### PR DESCRIPTION
Fixes #1750 

Added code to check if either the comment box or sign-in modal is shown and disable keyboard shortcuts accordingly.

For testing: check if the keyboard shortcuts still go off when typing to the sign-in box or comment box.
