### PR TITLE
1656 - Out of labels validation screen broken

### DIFF
--- a/public/javascripts/SVValidate/src/Main.js
+++ b/public/javascripts/SVValidate/src/Main.js
@@ -141,6 +141,7 @@ function Main (param) {
     if (param.hasNextMission) {
         _init();
     } else {
+        svv.keyboard = new Keyboard(svv.ui.validation);
         svv.form = new Form(param.dataStoreUrl);
         svv.tracker = new Tracker();
         svv.modalNoNewMission = new ModalNoNewMission(svv.ui.modalMission);

--- a/public/javascripts/SVValidate/src/modal/ModalNoNewMission.js
+++ b/public/javascripts/SVValidate/src/modal/ModalNoNewMission.js
@@ -21,7 +21,7 @@ function ModalNoNewMission (uiModalMission) {
     }
 
     function show () {
-        svv.disableKeyboard();
+        svv.keyboard.disableKeyboard();
         uiModalMission.background.css('visibility', 'visible');
         uiModalMission.instruction.html(noMissionsRemaining);
         uiModalMission.missionTitle.html("No more validation missions left");


### PR DESCRIPTION
Fixes #1656 

Added small changes to fix out of labels validation screen broken issue.

Before:
<img width="1246" alt="validationPageBefore" src="https://user-images.githubusercontent.com/51970755/59955581-dc37b680-943f-11e9-8260-47728557a9f4.png">

After:
<img width="1232" alt="validationPageAfter" src="https://user-images.githubusercontent.com/51970755/59955585-e1950100-943f-11e9-8fac-c4026b9e361f.png">
