### PR TITLE
1546 - Require users to type in their password twice when signing up

### DIFF
--- a/app/forms/SignUpForm.scala
+++ b/app/forms/SignUpForm.scala
@@ -8,7 +8,8 @@ object SignUpForm {
     mapping(
       "username" -> nonEmptyText,
       "email" -> email,
-      "password" -> nonEmptyText
+      "password" -> nonEmptyText,
+      "passwordConfirm" -> nonEmptyText
    )(Data.apply)(Data.unapply)
   )
 
@@ -22,6 +23,7 @@ object SignUpForm {
   case class Data(
                  username: String,
                  email: String,
-                 password: String
+                 password: String,
+		 passwordConfirm: String
                    )
 }

--- a/app/views/navbar.scala.html
+++ b/app/views/navbar.scala.html
@@ -449,6 +449,11 @@ $(document).ready(function () {
 		    return false;
 		}
 
+		if (password.length < 8) {
+		    invalidSignInUpAlert(false, 'Password must be at least 8 characters.');
+		    return false;
+		}
+
                 var data = $(this).serialize();
 
                 var url = '/authapi/signup';

--- a/app/views/navbar.scala.html
+++ b/app/views/navbar.scala.html
@@ -449,8 +449,8 @@ $(document).ready(function () {
 		    return false;
 		}
 
-		if (password.length < 8) {
-		    invalidSignInUpAlert(false, 'Password must be at least 8 characters.');
+		if (password.length < 6) {
+		    invalidSignInUpAlert(false, 'Password must be at least 6 characters.');
 		    return false;
 		}
 

--- a/app/views/navbar.scala.html
+++ b/app/views/navbar.scala.html
@@ -282,6 +282,7 @@ $(document).ready(function () {
                     @text(forms.SignUpForm.form("username"), "Username", icon = "person")
                     @text(forms.SignUpForm.form("email"), "Email", icon = "at")
                     @password(forms.SignUpForm.form("password"), "Password", icon = "key")
+                    @password(forms.SignUpForm.form("passwordConfirm"), "Confirm password", icon = "key")
                     <div class="form-group">
                         <div class="checkbox">
                             <label><input type="checkbox" id="navbar-agree-to-terms">You agree to our <a target="_blank" href="@routes.ApplicationController.terms">Terms of Use and Privacy Policy</a></label>
@@ -425,6 +426,7 @@ $(document).ready(function () {
                 var username = formData[0].value;
                 var email = formData[1].value;
                 var password = formData[2].value;
+		var passwordConfirm = formData[3].value;
 
                 if(!username){
                     invalidSignInUpAlert(false, 'Please enter a username.');
@@ -441,6 +443,11 @@ $(document).ready(function () {
                     invalidSignInUpAlert(false, 'Please enter your password.');
                     return false;
                 }
+
+		if (password !== passwordConfirm) {
+		    invalidSignInUpAlert(false, 'Passwords do not match.');
+		    return false;
+		}
 
                 var data = $(this).serialize();
 


### PR DESCRIPTION
Fixes #1546 

Add a 'Confirm password' input box. Only allow signing up if the passwords match. Also, restrict passwords to be at least 6 characters.

After pictures:

<img width="1053" alt="Screen Shot 2019-06-25 at 4 26 16 PM" src="https://user-images.githubusercontent.com/51970755/60210410-ad3f8d00-9811-11e9-8a1e-652067946dc8.png">

<img width="1114" alt="Screen Shot 2019-06-25 at 4 24 51 PM" src="https://user-images.githubusercontent.com/51970755/60210397-a6187f00-9811-11e9-9f6b-2b798897a9cc.png">
