### PR TITLE
Resolves #1547: pressing on underlined character in tags now works

### DIFF
--- a/public/javascripts/SVLabel/css/svl-context-menu.css
+++ b/public/javascripts/SVLabel/css/svl-context-menu.css
@@ -178,4 +178,5 @@
 
 tag-underline {
     text-decoration: underline;
+    pointer-events: none;
 }


### PR DESCRIPTION
The `pointer-events: none` line was added to the style of the `tag-underline`; this prevents overlay of the `tag-underline` over the button. Now, clicking on the underlined character works in a tag works.