### PR TITLE
#800: Bug with nav bar calibration

### DIFF
--- a/app/views/developer.scala.html
+++ b/app/views/developer.scala.html
@@ -25,12 +25,14 @@
 
         <div class="row">
             <div class="col-lg-12">
-                <h2 id="access-api-header">Access APIs</h2>
+                <a class="anchor" id="access-api-header"></a>
+                <h2>Access APIs</h2>
             </div>
         </div>
         <hr>
         <div class="spacer-20-pixel"></div>
-        <div class="row" id="access-api-access-attribute-row">
+        <a class="anchor" id="access-api-access-attribute-row"></a>
+        <div class="row">
             <div class="col-sm-4">
                 <div id="developer-access-attribute-map" class="map"></div>
             </div>
@@ -114,7 +116,8 @@
         </div>
         <hr>
         <div class="spacer-20-pixel"></div>
-        <div class="row" id="access-api-access-score-street-row">
+        <a class="anchor" id="access-api-access-score-street-row"></a>
+        <div class="row">
             <div class="col-sm-4">
                 <div id="developer-access-score-streets-map" class="map"></div>
             </div>
@@ -299,7 +302,8 @@
 
         <div class="row">
             <div class="col-sm-12">
-                <h2 id="contribute">Contribute</h2>
+                <a class="anchor" id="contribute"></a>
+                <h2>Contribute</h2>
                 <p class="text-justify">
                     All the code for Project Sidewalk is open source. You can find it in our
                         <a href="https://github.com/ProjectSidewalk/SidewalkWebpage" target="_blank">GitHub repo</a>.

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1392,3 +1392,9 @@ kbd {
     background-color: white
 }
 
+.anchor {
+    display: block;
+    position: relative;
+    top: -85px;
+    visibility: hidden;
+}


### PR DESCRIPTION
Resolves #800 
Clicking in-page anchor links on the Developer page now scrolls the screen to the right place, keeping the navigation bar on top from blocking the content.