### PR TITLE
1372 temp integrating validation missions

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/Main.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Main.js
@@ -24,6 +24,7 @@ function Main (params) {
     svl.isOnboarding = function () {
         return svl.onboarding != null && svl.onboarding.isOnboarding();
     };
+    svl.missionsCompleted = 0;
     svl.canvasWidth = 720;
     svl.canvasHeight = 480;
     svl.svImageHeight = 6656;

--- a/public/javascripts/SVLabel/src/SVLabel/mission/MissionProgress.js
+++ b/public/javascripts/SVLabel/src/SVLabel/mission/MissionProgress.js
@@ -64,6 +64,8 @@ function MissionProgress (svl, gameEffectModel, missionModel, modalModel, neighb
         }
 
         _missionModel.completeMission(mission);
+
+        svl.missionsCompleted += 1;
     };
 
     this._checkMissionComplete = function (mission, neighborhood) {

--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
@@ -106,7 +106,7 @@ function ModalMissionComplete (svl, missionContainer, missionModel, taskContaine
 
     this._closeModal = function (e) {
         if (svl.missionsCompleted === 2) {
-            // Load the audit page since they've done 2 missions.
+            // Load the validation page since they've done 2 missions.
             window.location.replace('/validate');
         }
         else if (svl.neighborhoodModel.isNeighborhoodCompleted) {

--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
@@ -105,8 +105,12 @@ function ModalMissionComplete (svl, missionContainer, missionModel, taskContaine
     };
 
     this._closeModal = function (e) {
-        if (svl.neighborhoodModel.isNeighborhoodCompleted) {
-            // reload the page to load another neighborhood
+        if (svl.missionsCompleted === 2) {
+            // Load the audit page since they've done 2 missions.
+            window.location.replace('/validate');
+        }
+        else if (svl.neighborhoodModel.isNeighborhoodCompleted) {
+            // Reload the page to load another neighborhood.
             window.location.replace('/audit');
         } else {
             // TODO can we require that we have a new mission before doing this?

--- a/public/javascripts/SVValidate/src/Main.js
+++ b/public/javascripts/SVValidate/src/Main.js
@@ -11,6 +11,8 @@ function Main (param) {
     svv.canvasHeight = 440;
     svv.canvasWidth = 720;
 
+    svv.missionsCompleted = 0;
+
     // Maps label types to label names
     svv.labelNames = {
         CurbRamp: "Curb Ramp",

--- a/public/javascripts/SVValidate/src/mission/MissionContainer.js
+++ b/public/javascripts/SVValidate/src/mission/MissionContainer.js
@@ -42,6 +42,7 @@ function MissionContainer () {
      * Submits this mission to the backend.
      */
     function completeAMission () {
+        svv.missionsCompleted += 1;
         svv.modalMissionComplete.show(currentMission);
         var data = svv.form.compileSubmissionData();
         svv.form.submit(data, true);

--- a/public/javascripts/SVValidate/src/modal/ModalMissionComplete.js
+++ b/public/javascripts/SVValidate/src/modal/ModalMissionComplete.js
@@ -7,7 +7,12 @@ function ModalMissionComplete (uiModalMissionComplete, user, confirmationCode) {
 
     function _handleButtonClick() {
         svv.tracker.push("ClickOk_MissionComplete");
-        self.hide();
+        if (svv.missionsCompleted === 3) {
+            // Load the audit page since they've done 2 missions.
+            window.location.replace('/audit');
+        } else {
+            self.hide();
+        }
     }
 
     function getProperty(key) {


### PR DESCRIPTION
Partially resolves #1372 

We are not sure exactly how we want to integrate validation missions into the audit workflow. This is a temporary change that we will adapt going forward. What this PR does is make is so that after 2 audit missions, you are send to the validation page, and after you finish 3 validation missions, you are sent back to the audit page. If you at any point reload the audit or validation pages, that count will start over right now.

I just want to start by testing this out to see how it feels. Planning to make a more robust PR later on once we figure out what we really want.