### PR TITLE
#1051: Adds a circle size that represents 100 labels

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/status/LabelCounter.js
+++ b/public/javascripts/SVLabel/src/SVLabel/status/LabelCounter.js
@@ -8,15 +8,16 @@
 function LabelCounter (d3) {
     var self = this;
 
-    var radius = 0.2, dR = radius / 3,
-        svgWidth = 200, svgHeight = 120,
-        margin = {top: 10, right: 10, bottom: 10, left: 0},
-        padding = {left: 5, top: 15},
-        width = 200 - margin.left - margin.right,
-        height = 40 - margin.top - margin.bottom,
-        colorScheme = util.misc.getLabelColors(),
-        imageWidth = 22, imageHeight = 22,
-        rightColumn = 1.8;
+    var svgWidth = 200;
+    var svgHeight = 120;
+    var margin = {top: 10, right: 10, bottom: 10, left: 0};
+    var padding = {left: 5, top: 15};
+    var width = 200 - margin.left - margin.right;
+    var height = 40 - margin.top - margin.bottom;
+    var colorScheme = util.misc.getLabelColors();
+    var imageWidth = 22;
+    var imageHeight = 22;
+    var rightColumn = 1.8;
 
     // Prepare a group to store svg elements, and declare a text
     var dotPlots = {
@@ -171,62 +172,65 @@ function LabelCounter (d3) {
         function _update(key) {
             if (keys.indexOf(key) == -1) { key = "Other"; }
 
-            var hundredCircles = parseInt(dotPlots[key].count / 100),
-              fiftyCircles = parseInt((dotPlots[key].count % 100) / 50),
-              tenCircles = parseInt((dotPlots[key].count % 50) / 10),
-              oneCircles = dotPlots[key].count % 10,
-              count = hundredCircles + fiftyCircles + tenCircles + oneCircles;
+            var hundredCircles = parseInt(dotPlots[key].count / 100);
+            var fiftyCircles = parseInt((dotPlots[key].count % 100) / 50);
+            var tenCircles = parseInt((dotPlots[key].count % 50) / 10);
+            var oneCircles = dotPlots[key].count % 10;
+            var count = hundredCircles + fiftyCircles + tenCircles + oneCircles;
+            var multiplier = 1.0 - parseInt(dotPlots[key].count) / 1500.0;
+            if (multiplier < 0.5) { multiplier = 0.5; }
+            var radius = 0.2 * multiplier;
+            var dR = radius / 3;
 
-            /* 
-            the code of these three functions was being used so much I decided to separately declare them
-            the d3 calls look much cleaner now :)
-            */
+            // The code of these three functions was being used so much I decided to separately declare them.
+            // The d3 calls look much cleaner now. :)
             function setCX(d, i){
-               if (i < hundredCircles && hundredCircles != 0){
+               if (i < hundredCircles && hundredCircles != 0) {
                    return x(i * 5.33 * radius + 2 * dR)
                }
-               else if (i < hundredCircles + fiftyCircles && fiftyCircles != 0){
+               else if (i < hundredCircles + fiftyCircles && fiftyCircles != 0) {
                    return x(hundredCircles * 5.33 * radius);
                }
-               else if (i < hundredCircles + fiftyCircles + tenCircles && tenCircles != 0){
-                   return x(hundredCircles * 2.5 * radius) + x(fiftyCircles * 3.4 * radius) +
+               else if (i < hundredCircles + fiftyCircles + tenCircles && tenCircles != 0) {
+                   return x(hundredCircles * 2.6 * radius) + x(fiftyCircles * 3.3 * radius) +
                      x((i - fiftyCircles) * 2 * (radius + dR));
                }
-               else{
-                   return x(hundredCircles * 3.1 * radius) + x(fiftyCircles * 1.3 * radius) +
-                     x(tenCircles * 1.9 * (radius + dR))+ x((i - tenCircles) * 2 * radius);
+               else {
+                   return x(hundredCircles * 3.2 * radius) + x(fiftyCircles * 1.3 * radius) +
+                     x(tenCircles * 1.95 * (radius + dR))+ x((i - tenCircles) * 2 * radius);
                }
             }
             
             function setCY(d, i){
-              if (i < hundredCircles && hundredCircles != 0){
+              if (i < hundredCircles && hundredCircles != 0) {
                 return 0;
               }
-              else if (i < hundredCircles + fiftyCircles && fiftyCircles != 0){
+              else if (i < hundredCircles + fiftyCircles && fiftyCircles != 0) {
                 return x(2 * dR);
               }
-              else if (i < hundredCircles + fiftyCircles + tenCircles && tenCircles != 0){
+              else if (i < hundredCircles + fiftyCircles + tenCircles && tenCircles != 0) {
                 return x(radius + dR);
               }
-              else{
+              else {
                 return x(2 * radius);
               }
             }
 
             function setR(d, i){
-              if (i < hundredCircles && hundredCircles != 0){
-                return x(2 * (radius + dR))
+              if (i < hundredCircles && hundredCircles != 0) {
+                return x(2 * (radius + dR));
               }
-              else if (i < hundredCircles + fiftyCircles && fiftyCircles != 0){
+              else if (i < hundredCircles + fiftyCircles && fiftyCircles != 0) {
                 return x(2 * radius);
               }
-              else if (i < hundredCircles + fiftyCircles + tenCircles && tenCircles != 0){
+              else if (i < hundredCircles + fiftyCircles + tenCircles && tenCircles != 0) {
                 return x(radius + dR);
               }
-              else{
+              else {
                 return x(radius);
               }
             }
+
             // Update the dot plot
             if (dotPlots[key].data.length >= count) {
               // Remove dots

--- a/public/javascripts/SVLabel/src/SVLabel/status/LabelCounter.js
+++ b/public/javascripts/SVLabel/src/SVLabel/status/LabelCounter.js
@@ -177,8 +177,7 @@ function LabelCounter (d3) {
             var tenCircles = parseInt((dotPlots[key].count % 50) / 10);
             var oneCircles = dotPlots[key].count % 10;
             var count = hundredCircles + fiftyCircles + tenCircles + oneCircles;
-            var multiplier = 1.0 - parseInt(dotPlots[key].count) / 1500.0;
-            if (multiplier < 0.5) { multiplier = 0.5; }
+            var multiplier = Math.max(0.5, 1.0 - parseInt(dotPlots[key].count) / 1500.0);
             var radius = 0.2 * multiplier;
             var dR = radius / 3;
 

--- a/public/javascripts/SVLabel/src/SVLabel/status/LabelCounter.js
+++ b/public/javascripts/SVLabel/src/SVLabel/status/LabelCounter.js
@@ -171,44 +171,56 @@ function LabelCounter (d3) {
         function _update(key) {
             if (keys.indexOf(key) == -1) { key = "Other"; }
 
-            var fiftyCircles = parseInt(dotPlots[key].count / 50),
+            var hundredCircles = parseInt(dotPlots[key].count / 100),
+              fiftyCircles = parseInt((dotPlots[key].count % 100) / 50),
               tenCircles = parseInt((dotPlots[key].count % 50) / 10),
               oneCircles = dotPlots[key].count % 10,
-              count = fiftyCircles + tenCircles + oneCircles;
+              count = hundredCircles + fiftyCircles + tenCircles + oneCircles;
 
             /* 
             the code of these three functions was being used so much I decided to separately declare them
             the d3 calls look much cleaner now :)
             */
             function setCX(d, i){
-              if (i < fiftyCircles && fiftyCircles != 0){
-                return x(i * 4 * radius + dR);
-              }
-              else if (i < fiftyCircles + tenCircles && tenCircles != 0){
-                return x(fiftyCircles * 4 * radius + dR) + x((i - fiftyCircles) * 2 * (radius + dR));
-              }
-              else{
-                return x(fiftyCircles * 2 * radius + dR) + x(tenCircles * 1.9 * (radius + dR))+ x((i - tenCircles) * 2 * radius);
-              }
+               if (i < hundredCircles && hundredCircles != 0){
+                   return x(i * 5.33 * radius + 2 * dR)
+               }
+               else if (i < hundredCircles + fiftyCircles && fiftyCircles != 0){
+                   return x(hundredCircles * 5.33 * radius);
+               }
+               else if (i < hundredCircles + fiftyCircles + tenCircles && tenCircles != 0){
+                   return x(hundredCircles * 2.5 * radius) + x(fiftyCircles * 3.4 * radius) +
+                     x((i - fiftyCircles) * 2 * (radius + dR));
+               }
+               else{
+                   return x(hundredCircles * 3.1 * radius) + x(fiftyCircles * 1.3 * radius) +
+                     x(tenCircles * 1.9 * (radius + dR))+ x((i - tenCircles) * 2 * radius);
+               }
             }
             
             function setCY(d, i){
-              if (i < fiftyCircles && fiftyCircles != 0){
+              if (i < hundredCircles && hundredCircles != 0){
                 return 0;
               }
-              else if (i < fiftyCircles + tenCircles && tenCircles != 0){
-                return x(dR);
+              else if (i < hundredCircles + fiftyCircles && fiftyCircles != 0){
+                return x(2 * dR);
+              }
+              else if (i < hundredCircles + fiftyCircles + tenCircles && tenCircles != 0){
+                return x(radius + dR);
               }
               else{
-                return x(radius);
+                return x(2 * radius);
               }
             }
 
             function setR(d, i){
-              if (i < fiftyCircles && fiftyCircles != 0){
+              if (i < hundredCircles && hundredCircles != 0){
+                return x(2 * (radius + dR))
+              }
+              else if (i < hundredCircles + fiftyCircles && fiftyCircles != 0){
                 return x(2 * radius);
               }
-              else if (i < fiftyCircles + tenCircles && tenCircles != 0){
+              else if (i < hundredCircles + fiftyCircles + tenCircles && tenCircles != 0){
                 return x(radius + dR);
               }
               else{


### PR DESCRIPTION
Resolves #1051
Helps a bit with keeping label images from going off-screen when they reach too high a number.
Before: (goes off-screen at 189 labels; circles of size 50, 10, and 1)
![Project Sidewalk Issue 1051 No Sidewalk](https://user-images.githubusercontent.com/35845622/60550716-c0ed6680-9cdd-11e9-999a-eb7dfc1ef778.PNG)
After: (goes off-screen at 249 labels; circles of size 100, 50, 10, and 1)
![Project Sidewalk Issue 1051 After 249](https://user-images.githubusercontent.com/35845622/60546312-e2485580-9cd1-11e9-8541-1541edc182e6.PNG)