### PR TITLE
#244: <mission-complete-bar-pixel> 

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
@@ -26,9 +26,9 @@
  * @returns {{className: string}}
  * @constructor
  */
-function ModalMissionComplete (svl, missionContainer, missionModel, taskContainer,
-                               modalMissionCompleteMap, modalMissionProgressBar,
-                               uiModalMissionComplete, modalModel, statusModel, onboardingModel, userModel) {
+function ModalMissionComplete(svl, missionContainer, missionModel, taskContainer,
+                              modalMissionCompleteMap, modalMissionProgressBar,
+                              uiModalMissionComplete, modalModel, statusModel, onboardingModel, userModel) {
     var self = this;
     var _missionModel = missionModel;
     var _missionContainer = missionContainer;
@@ -66,7 +66,7 @@ function ModalMissionComplete (svl, missionContainer, missionModel, taskContaine
         self.hide();
     });
 
-    svl.neighborhoodModel.on("Neighborhood:completed", function(parameters) {
+    svl.neighborhoodModel.on("Neighborhood:completed", function (parameters) {
         var neighborhood = svl.neighborhoodContainer.getCurrentNeighborhood();
         var neighborhoodName = neighborhood.getProperty("name");
         self.setMissionTitle("Bravo! You completed " + neighborhoodName + " neighborhood!");
@@ -77,7 +77,7 @@ function ModalMissionComplete (svl, missionContainer, missionModel, taskContaine
         self._canShowContinueButton = false;
     });
 
-    _missionContainer.on("MissionContainer:missionLoaded", function(mission) {
+    _missionContainer.on("MissionContainer:missionLoaded", function (mission) {
         self._canShowContinueButton = true;
         if (self.showingMissionCompleteScreen) {
             uiModalMissionComplete.closeButton.on("click", self._handleCloseButtonClick); // enable clicking
@@ -108,14 +108,13 @@ function ModalMissionComplete (svl, missionContainer, missionModel, taskContaine
         if (svl.missionsCompleted === 2) {
             // Load the validation page since they've done 2 missions.
             window.location.replace('/validate');
-        }
-        else if (svl.neighborhoodModel.isNeighborhoodCompleted) {
+        } else if (svl.neighborhoodModel.isNeighborhoodCompleted) {
             // Reload the page to load another neighborhood.
             window.location.replace('/audit');
         } else {
             // TODO can we require that we have a new mission before doing this?
             var nextMission = missionContainer.getCurrentMission();
-            _modalModel.triggerMissionCompleteClosed( { nextMission: nextMission } );
+            _modalModel.triggerMissionCompleteClosed({nextMission: nextMission});
             self.hide();
         }
     };
@@ -130,7 +129,7 @@ function ModalMissionComplete (svl, missionContainer, missionModel, taskContaine
         this._modalMissionCompleteMap.hide();
         statusModel.setProgressBar(0);
         statusModel.setMissionCompletionRate(0);
-        if(this._uiModalMissionComplete.confirmationText!=null && this._uiModalMissionComplete.confirmationText!=undefined){
+        if (this._uiModalMissionComplete.confirmationText != null && this._uiModalMissionComplete.confirmationText != undefined) {
             this._uiModalMissionComplete.confirmationText.empty();
             this._uiModalMissionComplete.confirmationText.remove();
             delete this._uiModalMissionComplete.confirmationText;
@@ -180,7 +179,7 @@ function ModalMissionComplete (svl, missionContainer, missionModel, taskContaine
          Display the generate confirmation button. When clicked, remove this button completely
          and make the Continue button visible again.
          */
-        if(uiModalMissionComplete.generateConfirmationButton!=null && uiModalMissionComplete.generateConfirmationButton!=undefined) {
+        if (uiModalMissionComplete.generateConfirmationButton != null && uiModalMissionComplete.generateConfirmationButton != undefined) {
             uiModalMissionComplete.closeButton.css('visibility', "hidden");
             // Assignment Completion Data
             var data = {
@@ -215,9 +214,9 @@ function ModalMissionComplete (svl, missionContainer, missionModel, taskContaine
             uiModalMissionComplete.generateConfirmationButton.remove();
             delete uiModalMissionComplete.generateConfirmationButton;
 
-            svl.ui.leftColumn.confirmationCode.attr('data-toggle','popover');
-            svl.ui.leftColumn.confirmationCode.attr('title','Submit this code for HIT verification on Amazon Mechanical Turk');
-            svl.ui.leftColumn.confirmationCode.attr('data-content',svl.confirmationCode);
+            svl.ui.leftColumn.confirmationCode.attr('data-toggle', 'popover');
+            svl.ui.leftColumn.confirmationCode.attr('title', 'Submit this code for HIT verification on Amazon Mechanical Turk');
+            svl.ui.leftColumn.confirmationCode.attr('data-content', svl.confirmationCode);
 
             //Hide the mTurk confirmation code popover on clicking the background (i.e. outside the popover)
             //https://stackoverflow.com/questions/11703093/how-to-dismiss-a-twitter-bootstrap-popover-by-clicking-outside
@@ -227,10 +226,10 @@ function ModalMissionComplete (svl, missionContainer, missionModel, taskContaine
                     //the 'is' for buttons that trigger popups
                     //the 'has' for icons within a button that triggers a popup
                     if (!$(this).is(e.target) && $(this).has(e.target).length === 0 && $('.popover').has(e.target).length === 0) {
-                        (($(this).popover('hide').data('bs.popover')||{}).inState||{}).click = false
+                        (($(this).popover('hide').data('bs.popover') || {}).inState || {}).click = false
                     }
 
-                });
+                 });
             });
         }
     };
@@ -240,12 +239,28 @@ function ModalMissionComplete (svl, missionContainer, missionModel, taskContaine
         var unit = {units: 'miles'};
         var regionId = neighborhood.getProperty("regionId");
 
+        console.log("User has finished a particular mission...");
+
         var missionDistance = mission.getDistance("miles");
+        missionDistance = Math.round(missionDistance * 10) / 10;
+        console.log("mission distance for this time is " + missionDistance);
         var missionPay = mission.getProperty("pay");
+
         var userAuditedDistance = neighborhood.completedLineDistance(unit);
+        userAuditedDistance = Math.round(userAuditedDistance * 10) / 10;
+        console.log("user audited distance is " + userAuditedDistance);
+
         var allAuditedDistance = neighborhood.completedLineDistanceAcrossAllUsersUsingPriority(unit);
+        allAuditedDistance = Math.round(allAuditedDistance * 10) / 10;
+        console.log("total audited distance is " + allAuditedDistance);
+
         var otherAuditedDistance = allAuditedDistance - userAuditedDistance;
+        otherAuditedDistance = Math.round(otherAuditedDistance * 10) / 10;
+        console.log("others' audited distance is " + otherAuditedDistance);
+
         var remainingDistance = neighborhood.totalLineDistanceInNeighborhood(unit) - allAuditedDistance;
+        remainingDistance = Math.round(remainingDistance * 10) / 10;
+        console.log("remaining distance is " + remainingDistance);
 
         var userCompletedTasks = taskContainer.getCompletedTasks(regionId);
         var allCompletedTasks = taskContainer.getCompletedTasksAllUsersUsingPriority();
@@ -257,7 +272,7 @@ function ModalMissionComplete (svl, missionContainer, missionModel, taskContaine
 
         var labelCount = mission.getLabelCount(),
             curbRampCount = labelCount ? labelCount["CurbRamp"] : 0,
-            noCurbRampCount = labelCount ? labelCount["NoCurbRamp"] : 0 ,
+            noCurbRampCount = labelCount ? labelCount["NoCurbRamp"] : 0,
             obstacleCount = labelCount ? labelCount["Obstacle"] : 0,
             surfaceProblemCount = labelCount ? labelCount["SurfaceProblem"] : 0,
             noSidewalkCount = labelCount ? labelCount["NoSidewalk"] : 0,
@@ -278,7 +293,6 @@ function ModalMissionComplete (svl, missionContainer, missionModel, taskContaine
     uiModalMissionComplete.closeButton.on("click", this._handleCloseButtonClick);
     this.hide();
 }
-
 
 
 ModalMissionComplete.prototype.getProperty = function (key) {
@@ -307,7 +321,7 @@ ModalMissionComplete.prototype._updateMissionProgressStatistics = function (miss
 
     // Update the reward HTML if the user is a turker.
     if (this._userModel.getUser().getProperty("role") === "Turker") {
-        svl.ui.modalMissionComplete.missionReward.html("<span style='color:forestgreen'>$"+missionReward.toFixed(2)+"</span>");
+        svl.ui.modalMissionComplete.missionReward.html("<span style='color:forestgreen'>$" + missionReward.toFixed(2) + "</span>");
     }
 };
 

--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
@@ -26,9 +26,9 @@
  * @returns {{className: string}}
  * @constructor
  */
-function ModalMissionComplete(svl, missionContainer, missionModel, taskContainer,
-                              modalMissionCompleteMap, modalMissionProgressBar,
-                              uiModalMissionComplete, modalModel, statusModel, onboardingModel, userModel) {
+function ModalMissionComplete (svl, missionContainer, missionModel, taskContainer,
+                               modalMissionCompleteMap, modalMissionProgressBar,
+                               uiModalMissionComplete, modalModel, statusModel, onboardingModel, userModel) {
     var self = this;
     var _missionModel = missionModel;
     var _missionContainer = missionContainer;
@@ -66,7 +66,7 @@ function ModalMissionComplete(svl, missionContainer, missionModel, taskContainer
         self.hide();
     });
 
-    svl.neighborhoodModel.on("Neighborhood:completed", function (parameters) {
+    svl.neighborhoodModel.on("Neighborhood:completed", function(parameters) {
         var neighborhood = svl.neighborhoodContainer.getCurrentNeighborhood();
         var neighborhoodName = neighborhood.getProperty("name");
         self.setMissionTitle("Bravo! You completed " + neighborhoodName + " neighborhood!");
@@ -77,7 +77,7 @@ function ModalMissionComplete(svl, missionContainer, missionModel, taskContainer
         self._canShowContinueButton = false;
     });
 
-    _missionContainer.on("MissionContainer:missionLoaded", function (mission) {
+    _missionContainer.on("MissionContainer:missionLoaded", function(mission) {
         self._canShowContinueButton = true;
         if (self.showingMissionCompleteScreen) {
             uiModalMissionComplete.closeButton.on("click", self._handleCloseButtonClick); // enable clicking
@@ -108,13 +108,14 @@ function ModalMissionComplete(svl, missionContainer, missionModel, taskContainer
         if (svl.missionsCompleted === 2) {
             // Load the validation page since they've done 2 missions.
             window.location.replace('/validate');
-        } else if (svl.neighborhoodModel.isNeighborhoodCompleted) {
+        }
+        else if (svl.neighborhoodModel.isNeighborhoodCompleted) {
             // Reload the page to load another neighborhood.
             window.location.replace('/audit');
         } else {
             // TODO can we require that we have a new mission before doing this?
             var nextMission = missionContainer.getCurrentMission();
-            _modalModel.triggerMissionCompleteClosed({nextMission: nextMission});
+            _modalModel.triggerMissionCompleteClosed( { nextMission: nextMission } );
             self.hide();
         }
     };
@@ -129,7 +130,7 @@ function ModalMissionComplete(svl, missionContainer, missionModel, taskContainer
         this._modalMissionCompleteMap.hide();
         statusModel.setProgressBar(0);
         statusModel.setMissionCompletionRate(0);
-        if (this._uiModalMissionComplete.confirmationText != null && this._uiModalMissionComplete.confirmationText != undefined) {
+        if(this._uiModalMissionComplete.confirmationText!=null && this._uiModalMissionComplete.confirmationText!=undefined){
             this._uiModalMissionComplete.confirmationText.empty();
             this._uiModalMissionComplete.confirmationText.remove();
             delete this._uiModalMissionComplete.confirmationText;
@@ -179,7 +180,7 @@ function ModalMissionComplete(svl, missionContainer, missionModel, taskContainer
          Display the generate confirmation button. When clicked, remove this button completely
          and make the Continue button visible again.
          */
-        if (uiModalMissionComplete.generateConfirmationButton != null && uiModalMissionComplete.generateConfirmationButton != undefined) {
+        if(uiModalMissionComplete.generateConfirmationButton!=null && uiModalMissionComplete.generateConfirmationButton!=undefined) {
             uiModalMissionComplete.closeButton.css('visibility', "hidden");
             // Assignment Completion Data
             var data = {
@@ -214,9 +215,9 @@ function ModalMissionComplete(svl, missionContainer, missionModel, taskContainer
             uiModalMissionComplete.generateConfirmationButton.remove();
             delete uiModalMissionComplete.generateConfirmationButton;
 
-            svl.ui.leftColumn.confirmationCode.attr('data-toggle', 'popover');
-            svl.ui.leftColumn.confirmationCode.attr('title', 'Submit this code for HIT verification on Amazon Mechanical Turk');
-            svl.ui.leftColumn.confirmationCode.attr('data-content', svl.confirmationCode);
+            svl.ui.leftColumn.confirmationCode.attr('data-toggle','popover');
+            svl.ui.leftColumn.confirmationCode.attr('title','Submit this code for HIT verification on Amazon Mechanical Turk');
+            svl.ui.leftColumn.confirmationCode.attr('data-content',svl.confirmationCode);
 
             //Hide the mTurk confirmation code popover on clicking the background (i.e. outside the popover)
             //https://stackoverflow.com/questions/11703093/how-to-dismiss-a-twitter-bootstrap-popover-by-clicking-outside
@@ -226,10 +227,10 @@ function ModalMissionComplete(svl, missionContainer, missionModel, taskContainer
                     //the 'is' for buttons that trigger popups
                     //the 'has' for icons within a button that triggers a popup
                     if (!$(this).is(e.target) && $(this).has(e.target).length === 0 && $('.popover').has(e.target).length === 0) {
-                        (($(this).popover('hide').data('bs.popover') || {}).inState || {}).click = false
+                        (($(this).popover('hide').data('bs.popover')||{}).inState||{}).click = false
                     }
 
-                 });
+                });
             });
         }
     };
@@ -239,28 +240,12 @@ function ModalMissionComplete(svl, missionContainer, missionModel, taskContainer
         var unit = {units: 'miles'};
         var regionId = neighborhood.getProperty("regionId");
 
-        console.log("User has finished a particular mission...");
-
         var missionDistance = mission.getDistance("miles");
-        missionDistance = Math.round(missionDistance * 10) / 10;
-        console.log("mission distance for this time is " + missionDistance);
         var missionPay = mission.getProperty("pay");
-
         var userAuditedDistance = neighborhood.completedLineDistance(unit);
-        userAuditedDistance = Math.round(userAuditedDistance * 10) / 10;
-        console.log("user audited distance is " + userAuditedDistance);
-
         var allAuditedDistance = neighborhood.completedLineDistanceAcrossAllUsersUsingPriority(unit);
-        allAuditedDistance = Math.round(allAuditedDistance * 10) / 10;
-        console.log("total audited distance is " + allAuditedDistance);
-
         var otherAuditedDistance = allAuditedDistance - userAuditedDistance;
-        otherAuditedDistance = Math.round(otherAuditedDistance * 10) / 10;
-        console.log("others' audited distance is " + otherAuditedDistance);
-
         var remainingDistance = neighborhood.totalLineDistanceInNeighborhood(unit) - allAuditedDistance;
-        remainingDistance = Math.round(remainingDistance * 10) / 10;
-        console.log("remaining distance is " + remainingDistance);
 
         var userCompletedTasks = taskContainer.getCompletedTasks(regionId);
         var allCompletedTasks = taskContainer.getCompletedTasksAllUsersUsingPriority();
@@ -272,7 +257,7 @@ function ModalMissionComplete(svl, missionContainer, missionModel, taskContainer
 
         var labelCount = mission.getLabelCount(),
             curbRampCount = labelCount ? labelCount["CurbRamp"] : 0,
-            noCurbRampCount = labelCount ? labelCount["NoCurbRamp"] : 0,
+            noCurbRampCount = labelCount ? labelCount["NoCurbRamp"] : 0 ,
             obstacleCount = labelCount ? labelCount["Obstacle"] : 0,
             surfaceProblemCount = labelCount ? labelCount["SurfaceProblem"] : 0,
             noSidewalkCount = labelCount ? labelCount["NoSidewalk"] : 0,
@@ -293,6 +278,7 @@ function ModalMissionComplete(svl, missionContainer, missionModel, taskContainer
     uiModalMissionComplete.closeButton.on("click", this._handleCloseButtonClick);
     this.hide();
 }
+
 
 
 ModalMissionComplete.prototype.getProperty = function (key) {
@@ -321,7 +307,7 @@ ModalMissionComplete.prototype._updateMissionProgressStatistics = function (miss
 
     // Update the reward HTML if the user is a turker.
     if (this._userModel.getUser().getProperty("role") === "Turker") {
-        svl.ui.modalMissionComplete.missionReward.html("<span style='color:forestgreen'>$" + missionReward.toFixed(2) + "</span>");
+        svl.ui.modalMissionComplete.missionReward.html("<span style='color:forestgreen'>$"+missionReward.toFixed(2)+"</span>");
     }
 };
 

--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionCompleteProgressBar.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionCompleteProgressBar.js
@@ -73,9 +73,9 @@ function ModalMissionCompleteProgressBar (uiModalMissionComplete) {
     this.update = function (missionDistanceRate, userAuditedDistanceRate, otherAuditedDistanceRate) {
 
         // Round the rates to 0.01 accuracy.
-        var roundedMissionDistanceRate = parseFloat(missionDistanceRate.toFixed(2));
-        var roundedUserAuditedDistanceRate = parseFloat(userAuditedDistanceRate.toFixed(2));
-        var roundedOtherAuditedDistanceRate = parseFloat(otherAuditedDistanceRate.toFixed(2));
+        var roundedMissionDistanceRate = parseFloat(missionDistanceRate.toFixed(3));
+        var roundedUserAuditedDistanceRate = parseFloat(userAuditedDistanceRate.toFixed(3));
+        var roundedOtherAuditedDistanceRate = parseFloat(otherAuditedDistanceRate.toFixed(3));
 
         horizontalBarOtherContribution.attr("width", 0)
             .transition()
@@ -95,7 +95,7 @@ function ModalMissionCompleteProgressBar (uiModalMissionComplete) {
             .transition()
             .delay(1400)
             .duration(600)
-            .attr("width", roundedMissionDistanceRate * svgCoverageBarWidth);
+            .attr("width", Math.max(1, roundedMissionDistanceRate * svgCoverageBarWidth));
         horizontalBarMissionLabel.text(parseInt(((roundedUserAuditedDistanceRate + roundedMissionDistanceRate) * 100).toString(), 10) + "%");
     };
 }

--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionCompleteProgressBar.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionCompleteProgressBar.js
@@ -71,30 +71,30 @@ function ModalMissionCompleteProgressBar (uiModalMissionComplete) {
      * @private
      */
     this.update = function (missionDistanceRate, userAuditedDistanceRate, otherAuditedDistanceRate) {
-        // rounding rates to .1 accuracy to avoid floating value arithmetic error
-        missionDistanceRate = missionDistanceRate.toFixed(1);
-        userAuditedDistanceRate = userAuditedDistanceRate.toFixed(1);
-        otherAuditedDistanceRate = otherAuditedDistanceRate.toFixed(1);
+        // Rounding rates to .1 accuracy to avoid floating value arithmetic error.
+        var roundedMissionDistanceRate = missionDistanceRate.toFixed(1);
+        var roundedUserAuditedDistanceRate = userAuditedDistanceRate.toFixed(1);
+        var roundedOtherAuditedDistanceRate = otherAuditedDistanceRate.toFixed(1);
 
         horizontalBarOtherContribution.attr("width", 0)
             .transition()
             .delay(200)
             .duration(600)
-            .attr("width", otherAuditedDistanceRate * svgCoverageBarWidth);
+            .attr("width", roundedOtherAuditedDistanceRate * svgCoverageBarWidth);
 
         horizontalBarPreviousContribution.attr("width", 0)
-            .attr("x", otherAuditedDistanceRate * svgCoverageBarWidth)
+            .attr("x", roundedOtherAuditedDistanceRate * svgCoverageBarWidth)
             .transition()
             .delay(800)
             .duration(600)
-            .attr("width", userAuditedDistanceRate * svgCoverageBarWidth);
+            .attr("width", roundedUserAuditedDistanceRate * svgCoverageBarWidth);
 
         horizontalBarMission.attr("width", 0)
-            .attr("x", (otherAuditedDistanceRate + userAuditedDistanceRate) * svgCoverageBarWidth)
+            .attr("x", (roundedOtherAuditedDistanceRate + roundedUserAuditedDistanceRate) * svgCoverageBarWidth)
             .transition()
             .delay(1400)
             .duration(600)
-            .attr("width", missionDistanceRate * svgCoverageBarWidth);
-        horizontalBarMissionLabel.text(parseInt((userAuditedDistanceRate + missionDistanceRate) * 100, 10) + "%");
+            .attr("width", roundedMissionDistanceRate * svgCoverageBarWidth);
+        horizontalBarMissionLabel.text(parseInt((roundedUserAuditedDistanceRate + roundedMissionDistanceRate) * 100, 10) + "%");
     };
 }

--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionCompleteProgressBar.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionCompleteProgressBar.js
@@ -71,10 +71,11 @@ function ModalMissionCompleteProgressBar (uiModalMissionComplete) {
      * @private
      */
     this.update = function (missionDistanceRate, userAuditedDistanceRate, otherAuditedDistanceRate) {
-        // Rounding rates to .1 accuracy to avoid floating value arithmetic error.
-        var roundedMissionDistanceRate = missionDistanceRate.toFixed(1);
-        var roundedUserAuditedDistanceRate = userAuditedDistanceRate.toFixed(1);
-        var roundedOtherAuditedDistanceRate = otherAuditedDistanceRate.toFixed(1);
+
+        // Round the rates to 0.01 accuracy.
+        var roundedMissionDistanceRate = parseFloat(missionDistanceRate.toFixed(2));
+        var roundedUserAuditedDistanceRate = parseFloat(userAuditedDistanceRate.toFixed(2));
+        var roundedOtherAuditedDistanceRate = parseFloat(otherAuditedDistanceRate.toFixed(2));
 
         horizontalBarOtherContribution.attr("width", 0)
             .transition()
@@ -95,6 +96,6 @@ function ModalMissionCompleteProgressBar (uiModalMissionComplete) {
             .delay(1400)
             .duration(600)
             .attr("width", roundedMissionDistanceRate * svgCoverageBarWidth);
-        horizontalBarMissionLabel.text(parseInt((roundedUserAuditedDistanceRate + roundedMissionDistanceRate) * 100, 10) + "%");
+        horizontalBarMissionLabel.text(parseInt(((roundedUserAuditedDistanceRate + roundedMissionDistanceRate) * 100).toString(), 10) + "%");
     };
 }

--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionCompleteProgressBar.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionCompleteProgressBar.js
@@ -71,6 +71,11 @@ function ModalMissionCompleteProgressBar (uiModalMissionComplete) {
      * @private
      */
     this.update = function (missionDistanceRate, userAuditedDistanceRate, otherAuditedDistanceRate) {
+        // rounding rates to .1 accuracy to avoid floating value arithmetic error
+        missionDistanceRate = missionDistanceRate.toFixed(1);
+        userAuditedDistanceRate = userAuditedDistanceRate.toFixed(1);
+        otherAuditedDistanceRate = otherAuditedDistanceRate.toFixed(1);
+
         horizontalBarOtherContribution.attr("width", 0)
             .transition()
             .delay(200)


### PR DESCRIPTION
 Resolves #244

Fixes mission complete progress bar 1 pixel for 'previous mission' even though none has been completed. The screen should not be drawing either blue or black bar when there is no previous mission or other users' completed.

To test, run on local host and on the web page, select a neighborhood that shows 0% complete. Once a mission is complete in that neighborhood, look at the pop-up mission complete progress pixel bar, there should be only the blue bar drawn, and no other color.

Before:
![da8ddcdc-69d7-11e6-8d71-8956346b5396](https://user-images.githubusercontent.com/45343348/60555452-bf2d9e00-9cf1-11e9-8935-fcfaaf8baa3b.png)

After:
<img width="808" alt="Screen Shot 2019-07-02 at 4 49 23 PM" src="https://user-images.githubusercontent.com/45343348/60555461-c8b70600-9cf1-11e9-8dee-ea0b559c52c6.png">


