### PR TITLE
1727 prioritize validations users with few validations

### DIFF
--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -608,7 +608,7 @@ object LabelTable {
           |        FROM label_validation
           |        WHERE user_id = ?
           |    )
-          |ORDER BY COALESCE(needs_validations, TRUE), RANDOM()
+          |ORDER BY COALESCE(needs_validations, TRUE) DESC, RANDOM()
           |LIMIT ?""".stripMargin
       )
       potentialLabels = selectRandomLabelsQuery((userIdStr, labelTypeId, labelTypeId, userIdStr, minCompCnt, userIdStr, n * 5)).list


### PR DESCRIPTION
As discussed in [this comment](https://github.com/ProjectSidewalk/SidewalkWebpage/issues/1727#issuecomment-510164568) on #1727, we want to prioritize doing validations of labels provided by users who have less than 10 labels validated for that label type. We want users to have a minimum of 10 labels per label type validated in order to include them in this analysis, and we were having trouble getting enough users who meet this threshold.

Choosing which labels to validate is done in one big query right now. So I added a subquery that calculates whether or not a user has 10 or more labels of the given label type validated. Then instead of ordering totally randomly, I take from users with less than 10 labels validated first, and randomly from within that group. If there are no labels left to validate from users with less than 10 validations, then it is randomly selected from all the other users.

To test that this is working, I got the list of label IDs that the query returned when visiting the validation page by adding the following line to the end of the `retrieveLabelListForValidation` function in `LabelTable.scala` (at line 646):
```
println(selectedLabels.map(_.labelId))
```

I then ran this query on the list of labels to check that the user for each label had less than 10 total validations:
```
SELECT mission.user_id, COALESCE(count, 0) AS validation_count
FROM label
INNER JOIN mission ON label.mission_id = mission.mission_id
LEFT JOIN (
    SELECT mission.user_id, COUNT(DISTINCT(label.label_id)) AS count
    FROM mission
    INNER JOIN label ON label.mission_id = mission.mission_id
    INNER JOIN label_validation ON label.label_id = label_validation.label_id
    WHERE mission.mission_type_id = 2
        AND label.deleted = FALSE
        AND label.label_type_id = <label-type-id-for-mission>
    GROUP BY mission.user_id
) needs_more_validations
    ON mission.user_id = needs_more_validations.user_id
WHERE label_id IN <label-id-list>
```