### PR TITLE
#1773: <fix negative distance in mission complete bar>

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
@@ -299,12 +299,12 @@ ModalMissionComplete.prototype.setMissionTitle = function (missionTitle) {
 
 ModalMissionComplete.prototype._updateMissionProgressStatistics = function (missionDistance, missionReward, userTotalDistance, othersAuditedDistance, remainingDistance, unit) {
     if (!unit) unit = {units: 'kilometers'};
-    remainingDistance = Math.max(remainingDistance, 0);
-    othersAuditedDistance = Math.max(othersAuditedDistance, 0);
+    var positiveRemainingDistance = Math.max(remainingDistance, 0);
+    var positiveOthersAuditedDistance = Math.max(othersAuditedDistance, 0);
     this._uiModalMissionComplete.missionDistance.html(missionDistance.toFixed(1) + " " + unit.units);
     this._uiModalMissionComplete.totalAuditedDistance.html(userTotalDistance.toFixed(1) + " " + unit.units);
-    this._uiModalMissionComplete.othersAuditedDistance.html(othersAuditedDistance.toFixed(1) + " " + unit.units);
-    this._uiModalMissionComplete.remainingDistance.html(remainingDistance.toFixed(1) + " " + unit.units);
+    this._uiModalMissionComplete.othersAuditedDistance.html(positiveOthersAuditedDistance.toFixed(1) + " " + unit.units);
+    this._uiModalMissionComplete.remainingDistance.html(positiveRemainingDistance.toFixed(1) + " " + unit.units);
 
     // Update the reward HTML if the user is a turker.
     if (this._userModel.getUser().getProperty("role") === "Turker") {

--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
@@ -300,6 +300,7 @@ ModalMissionComplete.prototype.setMissionTitle = function (missionTitle) {
 ModalMissionComplete.prototype._updateMissionProgressStatistics = function (missionDistance, missionReward, userTotalDistance, othersAuditedDistance, remainingDistance, unit) {
     if (!unit) unit = {units: 'kilometers'};
     remainingDistance = Math.max(remainingDistance, 0);
+    othersAuditedDistance = Math.max(othersAuditedDistance, 0);
     this._uiModalMissionComplete.missionDistance.html(missionDistance.toFixed(1) + " " + unit.units);
     this._uiModalMissionComplete.totalAuditedDistance.html(userTotalDistance.toFixed(1) + " " + unit.units);
     this._uiModalMissionComplete.othersAuditedDistance.html(othersAuditedDistance.toFixed(1) + " " + unit.units);


### PR DESCRIPTION
Resolves #1773

Fixes mission complete progress bar displaying a negative -0.01 distance when it should be displayed as 0.0

Fixes the bug by adding a Math.max, to ensure the value is always greater than or equal to 0.0.

To test, run on local host and on the web page, select a neighborhood that shows 0% complete. Once a mission is complete in that neighborhood, look at the pop-up mission complete progress pixel bar, the "othera audited in this neighborhood" option should display 0.0 miles. However, the bug only shows up sometimes; other times it displays 0.0 miles correctly.

Before:
<img width="708" alt="PR" src="https://user-images.githubusercontent.com/45343348/61091336-a2cae900-a3f6-11e9-92e6-206c850445b6.png">

After:
<img width="1203" alt="Screen Shot 2019-06-27 at 5 04 53 PM" src="https://user-images.githubusercontent.com/45343348/61091375-ca21b600-a3f6-11e9-8f5a-ff61bb15aa96.png">

