### PR TITLE
1517 grunt not found when setting up dev environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,8 @@ services:
     depends_on:
       - db
     volumes:
-      - "./:/opt/"
+      - "./:/opt"
+      - "/opt/node_modules"
     ports:
       - "127.0.0.1:9000:9000"
     environment:


### PR DESCRIPTION
Resolves #1517 

The issue occurs when we run make dev for the first time when setting up a new dev environment. Basically, the node_modules folder that contains all dependencies was not created properly after 'npm install' was run in Dockerfile.

<img width="730" alt="Screen Shot 2019-07-15 at 2 09 11 PM" src="https://user-images.githubusercontent.com/51970755/61249474-2ee85380-a70a-11e9-8abb-9fb8c39ec383.png">


I made a small change in docker-compose.yml to create a data volume for node_modules, as these data volumes are properly mounted.

For testing: Remove node_modules folder from inside docker container. Stop and delete all projectsidewalk's containers, volumes. Rerun make dev to make sure node_modules is created with all dependencies installed.