### PR TITLE
1799 improve validation mission load time

### DIFF
--- a/app/controllers/TaskController.scala
+++ b/app/controllers/TaskController.scala
@@ -346,12 +346,12 @@ class TaskController @Inject() (implicit val env: Environment[User, SessionAuthe
         tagsToAdd.map { tagId => LabelTagTable.save(LabelTag(0, labelId, tagId)) }
       }
 
-      // Insert interaction
-      for (interaction: InteractionSubmission <- data.interactions) {
-        AuditTaskInteractionTable.save(AuditTaskInteraction(0, auditTaskId, missionId, interaction.action,
-          interaction.gsvPanoramaId, interaction.lat, interaction.lng, interaction.heading, interaction.pitch,
-          interaction.zoom, interaction.note, interaction.temporaryLabelId, new Timestamp(interaction.timestamp)))
-      }
+      // Insert interactions
+      AuditTaskInteractionTable.saveMultiple(data.interactions.map { interaction =>
+        AuditTaskInteraction(0, auditTaskId, missionId, interaction.action, interaction.gsvPanoramaId,
+          interaction.lat, interaction.lng, interaction.heading, interaction.pitch, interaction.zoom, interaction.note,
+          interaction.temporaryLabelId, new Timestamp(interaction.timestamp))
+      })
 
       // Insert environment
       val env: EnvironmentSubmission = data.environment

--- a/app/controllers/ValidationController.scala
+++ b/app/controllers/ValidationController.scala
@@ -41,7 +41,7 @@ class ValidationController @Inject() (implicit val env: Environment[User, Sessio
     request.identity match {
       case Some(user) =>
         WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, "Visit_Validate", timestamp))
-        val possibleLabelTypeIds: ListBuffer[Int] = LabelTable.retrievePossibleLabelTypeIds(user.userId, 10, None)
+        val possibleLabelTypeIds: List[Int] = LabelTable.retrievePossibleLabelTypeIds(user.userId, 10, None)
         val hasWork: Boolean = possibleLabelTypeIds.nonEmpty
 
         // Checks if there are still labels in the database for the user to validate.

--- a/app/controllers/ValidationTaskController.scala
+++ b/app/controllers/ValidationTaskController.scala
@@ -29,11 +29,11 @@ class ValidationTaskController @Inject() (implicit val env: Environment[User, Se
   def processValidationTaskSubmissions(submission: Seq[ValidationTaskSubmission], remoteAddress: String, identity: Option[User]) = {
     val user = identity
     val returnValues: Seq[ValidationTaskPostReturnValue] = for (data <- submission) yield {
-      for (interaction: InteractionSubmission <- data.interactions) {
-        ValidationTaskInteractionTable.save(ValidationTaskInteraction(0, interaction.missionId, interaction.action,
-          interaction.gsvPanoramaId, interaction.lat, interaction.lng, interaction.heading, interaction.pitch,
-          interaction.zoom, interaction.note, new Timestamp(interaction.timestamp)))
-      }
+      ValidationTaskInteractionTable.saveMultiple(data.interactions.map { interaction =>
+        ValidationTaskInteraction(0, interaction.missionId, interaction.action, interaction.gsvPanoramaId,
+          interaction.lat, interaction.lng, interaction.heading, interaction.pitch, interaction.zoom, interaction.note,
+          new Timestamp(interaction.timestamp))
+      })
 
       // We aren't always submitting labels, so check if data.labels exists.
       for (label: LabelValidationSubmission <- data.labels) {
@@ -131,7 +131,7 @@ class ValidationTaskController @Inject() (implicit val env: Environment[User, Se
     val userId: UUID = user.get.userId
     if (missionProgress.completed) {
       val labelsToRetrieve: Int = MissionTable.getNextValidationMissionLabelCount(userId)
-      val possibleLabelTypeIds: ListBuffer[Int] = LabelTable.retrievePossibleLabelTypeIds(userId, labelsToRetrieve, currentLabelTypeId)
+      val possibleLabelTypeIds: List[Int] = LabelTable.retrievePossibleLabelTypeIds(userId, labelsToRetrieve, currentLabelTypeId)
       val hasNextMission: Boolean = possibleLabelTypeIds.nonEmpty
 
       if (hasNextMission) {

--- a/app/models/audit/AuditTaskInteractionTable.scala
+++ b/app/models/audit/AuditTaskInteractionTable.scala
@@ -117,6 +117,10 @@ object AuditTaskInteractionTable {
     interactionId
   }
 
+  def saveMultiple(interactions: Seq[AuditTaskInteraction]): Seq[Int] = db.withTransaction { implicit session =>
+    (auditTaskInteractions returning auditTaskInteractions.map(_.auditTaskInteractionId)) ++= interactions
+  }
+
   /**
     * Select all audit task interaction records of the specified action
     * @param actionType

--- a/app/models/audit/AuditTaskInteractionTable.scala
+++ b/app/models/audit/AuditTaskInteractionTable.scala
@@ -117,6 +117,12 @@ object AuditTaskInteractionTable {
     interactionId
   }
 
+  /**
+    * Inserts a sequence of interactions into the audit_task_interaction table.
+    *
+    * @param interactions
+    * @return
+    */
   def saveMultiple(interactions: Seq[AuditTaskInteraction]): Seq[Int] = db.withTransaction { implicit session =>
     (auditTaskInteractions returning auditTaskInteractions.map(_.auditTaskInteractionId)) ++= interactions
   }

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -645,8 +645,12 @@ object LabelTable {
   }
 
   /**
-    * Retrieves a list of possible label types that the user can validate. This is determined by how
-    * many labels are in the database and how many labels the user has validated.
+    * Retrieves a list of possible label types that the user can validate.
+    *
+    * We do this by getting the number of labels available to validate for each label type. We then filter out label
+    * types with less than 10 labels to validate (the size of a validation mission), and we filter for labels in our
+    * labelTypeIdList (the main label types that we ask users to validate).
+    *
     * @param userId               User ID of the current user.
     * @param count                Number of labels for this mission.
     * @param currentLabelTypeId   Label ID of the current mission
@@ -657,7 +661,7 @@ object LabelTable {
   }
 
     /**
-    * Checks if the panorama associated with a label eixsts by pinging Google Maps.
+    * Checks if the panorama associated with a label exists by pinging Google Maps.
     * @param gsvPanoId  Panorama ID
     * @return           True if the panorama exists, false otherwise
     */

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -503,39 +503,30 @@ object LabelTable {
   }
 
   /**
-    * Returns whether we have enough labels for this user to validate.
-    * @param userId             User ID.
-    * @param labelTypeId        Label Type ID of labels requested.
-    * @param labelsRequired     Number of labels we need to query.
-    * @return   True if we have enough labels, false otherwise.
+    * Returns how many labels this user has available to validate for each label type.
+    *
+    * @param userId User ID.
+    * @return List[(label_type_id, label_count)]
     */
-  def hasSufficientLabels(userId: UUID, labelTypeId: Int, labelsRequired: Int): Boolean = db.withSession { implicit session =>
-    val labelCount: Int = getAvailableValidationLabels(userId, labelTypeId, None)
-    labelCount >= labelsRequired
-  }
-
-  /**
-    * Returns how many labels this user can validate for a given label type. Users are not allowed
-    * to validate labels that they have already validated or labels that they have placed.
-    * @param userId       User ID.
-    * @param labelTypeId  Type of label.
-    * @param labelIdList  List of labels to exclude (i.e., labels that have already been selected)
-    * @return             Number of labels that the user can validate.
-    */
-  def getAvailableValidationLabels(userId: UUID, labelTypeId: Int, labelIdList: Option[ListBuffer[Int]]): Int = db.withSession { implicit session =>
+  def getAvailableValidationLabelsByType(userId: UUID): List[(Int, Int)] = db.withSession { implicit session =>
     val userIdString: String = userId.toString
-    val existingLabels: ListBuffer[Int] = labelIdList.getOrElse(new ListBuffer[Int])
-    val labelsValidatedByUser = labelValidations.filter(_.userId === userIdString).map(_.labelId).list
+    val labelsValidatedByUser = labelValidations.filter(_.userId === userIdString)
 
-    val validationLabels =  for {
-      _lb <- labels if _lb.labelTypeId === labelTypeId && _lb.deleted === false && _lb.tutorial === false
-      _lt <- labelTypes if _lt.labelTypeId === _lb.labelTypeId
+    // Get labels the given user has not placed that have non-expired GSV imagery.
+    val labelsToValidate =  for {
+      _lb <- labels if _lb.deleted === false && _lb.tutorial === false
       _gd <- gsvData if _gd.gsvPanoramaId === _lb.gsvPanoramaId && _gd.expired === false
       _ms <- missions if _ms.missionId === _lb.missionId && _ms.userId =!= userIdString
-    } yield (_lb.labelId)
+    } yield (_lb.labelId, _lb.labelTypeId)
 
-    val filterUserLabels = validationLabels.filterNot(_ inSet labelsValidatedByUser)
-    filterUserLabels.list.length
+    // Left join with the labels that the user has already validated, then filter those out.
+    val filteredLabelsToValidate = for {
+      (_lab, _val) <- labelsToValidate.leftJoin(labelsValidatedByUser).on(_._1 === _.labelId)
+      if _val.labelId.?.isEmpty
+    } yield _lab
+
+    // Group by the label_type_id and count.
+    filteredLabelsToValidate.groupBy(_._2).map{ case (labType, group) => (labType, group.length) }.list
   }
 
   /**
@@ -661,15 +652,8 @@ object LabelTable {
     * @param currentLabelTypeId   Label ID of the current mission
     * @return
     */
-  def retrievePossibleLabelTypeIds(userId: UUID, count: Int, currentLabelTypeId: Option[Int]): ListBuffer[Int] = {
-    val inProgress: List[Int] = MissionTable.getInProgressValidationMissions(userId, currentLabelTypeId)
-    var possibleLabelTypeIds = new ListBuffer[Int]
-    for (labelTypeId <- labelTypeIdList) {
-      if (hasSufficientLabels(userId, labelTypeId, count) || inProgress.contains(labelTypeId)) {
-        possibleLabelTypeIds += labelTypeId
-      }
-    }
-    possibleLabelTypeIds
+  def retrievePossibleLabelTypeIds(userId: UUID, count: Int, currentLabelTypeId: Option[Int]): List[Int] = {
+    getAvailableValidationLabelsByType(userId).filter(_._2 > count).map(_._1).filter(labelTypeIdList.contains(_))
   }
 
     /**

--- a/app/models/validation/ValidationTaskInteractionTable.scala
+++ b/app/models/validation/ValidationTaskInteractionTable.scala
@@ -53,6 +53,12 @@ object ValidationTaskInteractionTable {
     interactionId
   }
 
+  /**
+    * Inserts a sequence of interactions into the validation_task_interaction table.
+    *
+    * @param interactions
+    * @return
+    */
   def saveMultiple(interactions: Seq[ValidationTaskInteraction]): Seq[Int] = db.withTransaction { implicit session =>
     (validationTaskInteractions returning validationTaskInteractions.map(_.validationTaskInteractionId)) ++= interactions
   }

--- a/app/models/validation/ValidationTaskInteractionTable.scala
+++ b/app/models/validation/ValidationTaskInteractionTable.scala
@@ -52,4 +52,8 @@ object ValidationTaskInteractionTable {
       (validationTaskInteractions returning validationTaskInteractions.map(_.validationTaskInteractionId)).insert(interaction)
     interactionId
   }
+
+  def saveMultiple(interactions: Seq[ValidationTaskInteraction]): Seq[Int] = db.withTransaction { implicit session =>
+    (validationTaskInteractions returning validationTaskInteractions.map(_.validationTaskInteractionId)) ++= interactions
+  }
 }


### PR DESCRIPTION
Resolves #1799 

Drastically improves validation mission load times. It brings the load times on my local dev environment from 4-5 seconds to 1.5-2.5 seconds (a 2.5 second improvement!). I did this by making a few improvements:
1. There was a separate query being done for each label type to check if a user had enough labels left to validate of that label type. I turned this into a single query that includes a group by. This improved load time by about 0.5 seconds.
1. When figuring out how many labels a user had remaining to validate, we were running a separate query to get all the labels that user had already validated, and turning that into a Scala object. We were then filtering those labels out. It is much more performant for large lists of labels to instead do a left join and filter instead of that separate query. I made this change for a 0.5 second speedup.
1. We used to insert validation interactions into the database one row at a time. I switched to a bulk insert function that we have available in Slick. This sped things up by 1.5 seconds!!

I also made that bulk insert improvement to the audit page. You don't really notice the improvement as an end-user, but it is a performance improvement on the back-end.