### PR TITLE
1813 wrong label type in mission text

### DIFF
--- a/public/javascripts/SVValidate/src/modal/ModalMission.js
+++ b/public/javascripts/SVValidate/src/modal/ModalMission.js
@@ -60,14 +60,14 @@ function ModalMission (uiModalMission, user) {
         if (mission.getProperty("labelsProgress") === 0) {
             var validationMissionStartTitle = "Validate " + mission.getProperty("labelsValidated")
                 + " " + svv.labelTypeNames[mission.getProperty("labelTypeId")] + " labels";
-            validationStartMissionHTML = validationStartMissionHTML.replace("__LABELCOUNT_PLACEHOLDER__", mission.getProperty("labelsValidated"));
-            validationStartMissionHTML = validationStartMissionHTML.replace("__LABELTYPE_PLACEHOLDER__", svv.labelTypeNames[mission.getProperty("labelTypeId")]);
-            show(validationMissionStartTitle, validationStartMissionHTML);
+            var validationStartMissionHTMLCopy = validationStartMissionHTML.replace("__LABELCOUNT_PLACEHOLDER__", mission.getProperty("labelsValidated"));
+            validationStartMissionHTMLCopy = validationStartMissionHTMLCopy.replace("__LABELTYPE_PLACEHOLDER__", svv.labelTypeNames[mission.getProperty("labelTypeId")]);
+            show(validationMissionStartTitle, validationStartMissionHTMLCopy);
         } else {
             validationMissionStartTitle = "Return to your mission";
-            validationResumeMissionHTML = validationResumeMissionHTML.replace("__LABELCOUNT_PLACEHOLDER__", mission.getProperty("labelsValidated"));
-            validationResumeMissionHTML = validationResumeMissionHTML.replace("__LABELTYPE_PLACEHOLDER__", svv.labelTypeNames[mission.getProperty("labelTypeId")]);
-            show(validationMissionStartTitle, validationResumeMissionHTML);
+            var validationResumeMissionHTMLCopy = validationResumeMissionHTMLCopy.replace("__LABELCOUNT_PLACEHOLDER__", mission.getProperty("labelsValidated"));
+            validationResumeMissionHTMLCopy = validationResumeMissionHTMLCopy.replace("__LABELTYPE_PLACEHOLDER__", svv.labelTypeNames[mission.getProperty("labelTypeId")]);
+            show(validationMissionStartTitle, validationResumeMissionHTMLCopy);
         }
 
         // Update the reward HTML if the user is a turker.


### PR DESCRIPTION
Resolves #1813 

The mission start text for a label type now shows the text for the label type of the current mission. Minor changes were made in ModalMission.js to fix this. The Html string has a ‘COUNT’ and ‘LABELTYPE’ variables that are to be replaced at the beginning of each mission. In the old code, the very first mission used this original string to display the text on the mission modal instead of a copy. This was the cause of this bug.

Testing: Check to see if the bug can be reproduced.

After: https://youtu.be/k5LJK7bZJhU