### PR TITLE
898 results choropleth add reset zoom

### DIFF
--- a/app/views/results.scala.html
+++ b/app/views/results.scala.html
@@ -69,6 +69,9 @@
             <div id="loadingChoropleth">
                 <img src='/assets/images/loader.gif' alt='loading' />
             </div>
+            <div>
+                <a id="reset-button" href="javascript:null"> Reset View </a>
+            </div>
         </div>
     </div>
 

--- a/public/javascripts/AccessibilityChoropleth.js
+++ b/public/javascripts/AccessibilityChoropleth.js
@@ -36,6 +36,7 @@ function AccessibilityChoropleth(_, $, turf, difficultRegionIds) {
         choropleth.setZoom(data.default_zoom);
         $("#reset-button").click(reset);
         function reset() {
+            choropleth.setView([data.city_center.lat, data.city_center.lng]);
             choropleth.setZoom(data.default_zoom);
         }
     });

--- a/public/javascripts/AccessibilityChoropleth.js
+++ b/public/javascripts/AccessibilityChoropleth.js
@@ -37,6 +37,7 @@ function AccessibilityChoropleth(_, $, turf, difficultRegionIds) {
         $("#reset-button").click(reset);
         function reset() {
             choropleth.setView([data.city_center.lat, data.city_center.lng]);
+            choropleth.setMaxBounds(L.latLngBounds(southWest, northEast));
             choropleth.setZoom(data.default_zoom);
         }
     });

--- a/public/javascripts/AccessibilityChoropleth.js
+++ b/public/javascripts/AccessibilityChoropleth.js
@@ -34,6 +34,10 @@ function AccessibilityChoropleth(_, $, turf, difficultRegionIds) {
         var northEast = L.latLng(data.northeast_boundary.lat, data.northeast_boundary.lng);
         choropleth.setMaxBounds(L.latLngBounds(southWest, northEast));
         choropleth.setZoom(data.default_zoom);
+        $("#reset-button").click(reset);
+        function reset() {
+            choropleth.setZoom(data.default_zoom);
+        }
     });
 
     L.mapbox.styleLayer('mapbox://styles/mapbox/light-v9').addTo(choropleth);

--- a/public/javascripts/AccessibilityChoropleth.js
+++ b/public/javascripts/AccessibilityChoropleth.js
@@ -36,9 +36,7 @@ function AccessibilityChoropleth(_, $, turf, difficultRegionIds) {
         choropleth.setZoom(data.default_zoom);
         $("#reset-button").click(reset);
         function reset() {
-            choropleth.setView([data.city_center.lat, data.city_center.lng]);
-            choropleth.setMaxBounds(L.latLngBounds(southWest, northEast));
-            choropleth.setZoom(data.default_zoom);
+            choropleth.setView([data.city_center.lat, data.city_center.lng], data.default_zoom);
         }
     });
 

--- a/public/stylesheets/choropleth.css
+++ b/public/stylesheets/choropleth.css
@@ -3,6 +3,30 @@
     height: 800px;
 }
 
+#reset-button {
+    background-color:#ffffff;
+    -moz-border-radius:15px;
+    -webkit-border-radius:15px;
+    border-radius:10px;
+    border:2px solid #808080;
+    display:inline-block;
+    position: absolute;
+    top: 22%;
+    right: 94.9%;
+    cursor:pointer;
+    color:#2D2A3F;
+    font: normal normal normal 12px/1.4em raleway,sans-serif;
+    font-family: 'Raleway', sans-serif;
+    font-size:10px;
+    width: 40px;
+    padding:5px 6px;
+    text-align: center;
+    text-decoration:none;
+    /*background-image: url("../assets/reset-zoom.png");*/
+    transition: border-color 0.4s ease 0s, background-color 0.4s ease 0s;
+    outline: none;
+}
+
 .legend label,
 .legend span {
     display:block;

--- a/public/stylesheets/choropleth.css
+++ b/public/stylesheets/choropleth.css
@@ -12,7 +12,7 @@
     display:inline-block;
     position: absolute;
     top: 22%;
-    right: 94.9%;
+    left: 24.5px;
     cursor:pointer;
     color:#2D2A3F;
     font: normal normal normal 12px/1.4em raleway,sans-serif;
@@ -22,7 +22,6 @@
     padding:5px 6px;
     text-align: center;
     text-decoration:none;
-    /*background-image: url("../assets/reset-zoom.png");*/
     transition: border-color 0.4s ease 0s, background-color 0.4s ease 0s;
     outline: none;
 }


### PR DESCRIPTION
Resolves #898. Adds a reset zoom button to the results choropleth. The button restores the original zoom value of the map when it is clicked. The changes add the physical button to the map in results.scala.html, add the button styling in choropleth.css, and add the button's functionality in AccessibilityChoropleth.js. 

Before:
![image](https://user-images.githubusercontent.com/49606862/62744777-fd0e9800-b9fc-11e9-9491-44c105e8790c.png)

After 
![image](https://user-images.githubusercontent.com/49606862/62744648-5d510a00-b9fc-11e9-8a99-8f7f86a9fbd6.png)

For testing if button works well, check if 
- button works on all results choropleths (for Washington DC, Seattle, and Newberg)
- button appears on different browsers and screen sizes