### PR TITLE
1734 validation blank screen on validation

### DIFF
--- a/app/views/validation.scala.html
+++ b/app/views/validation.scala.html
@@ -74,11 +74,12 @@
             </div>
             <div id="svv-panorama-holder">
                 <div id="svv-panorama-outline">
-                    <div id="svv-panorama-0" class="single-panorama"></div>
+                    <div id="svv-panorama-0" class="single-panorama">
+                        <div id="viewControlLayer" style="cursor: url(/assets/javascripts/SVLabel/img/cursors/openhand.cur) 4 4, move; z-index: 2;"></div>
+                    </div>
                     <div id="svv-panorama-date-holder-0" class="svv-panorama-date-holder">
                         <span id="svv-panorama-date-0">no</span>
                     </div>
-                    <div id="viewControlLayer" style="cursor: url(/assets/javascripts/SVLabel/img/cursors/openhand.cur) 4 4, move; z-index: 1;"></div>
                     <div id="validation-button-holder-large">
                         <button id="validation-agree-button-0" class="validation-button-large">
                             <img src='@routes.Assets.at("javascripts/SVValidate/img/Checkmark.png")' class="validation-status-icon" alt="Agree" align="">

--- a/app/views/validation.scala.html
+++ b/app/views/validation.scala.html
@@ -78,6 +78,7 @@
                     <div id="svv-panorama-date-holder-0" class="svv-panorama-date-holder">
                         <span id="svv-panorama-date-0">no</span>
                     </div>
+                    <div id="viewControlLayer" style="cursor: url(/assets/javascripts/SVLabel/img/cursors/openhand.cur) 4 4, move; z-index: 1;"></div>
                     <div id="validation-button-holder-large">
                         <button id="validation-agree-button-0" class="validation-button-large">
                             <img src='@routes.Assets.at("javascripts/SVValidate/img/Checkmark.png")' class="validation-status-icon" alt="Agree" align="">

--- a/public/javascripts/SVLabel/src/SVLabel/Panomarker.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Panomarker.js
@@ -164,6 +164,9 @@
         /** @private @type {number} */
         this.zIndex_ = opts.zIndex || 1;
 
+        /** @private @type {Object} */
+        this.markerContainer_ = opts.markerContainer || null;
+
         // At last, call some methods which use the initialized parameters
         this.setPano(opts.pano || null, opts.container);
     };
@@ -410,7 +413,11 @@
 
         this.marker_ = marker;
 
-        this.getPanes().overlayMouseTarget.appendChild(marker);
+        // Add marker to viewControlLayer if on validate page.
+        if (this.markerContainer_ == null) {
+            this.markerContainer_ = this.getPanes().overlayMouseTarget;
+        }
+        this.markerContainer_.appendChild(marker);
 
         // Attach to some global events
         window.addEventListener('resize', this.draw.bind(this));

--- a/public/javascripts/SVValidate/css/svv-panorama-single.css
+++ b/public/javascripts/SVValidate/css/svv-panorama-single.css
@@ -38,6 +38,14 @@
     width: 730px;
 }
 
+#viewControlLayer {
+    position: absolute;
+    width: 720px;
+    height: 440px;
+    left: 0;
+    top: 0;
+}
+
 /*
  * This code below removes the footers for the Google StreetView, but in doing so, we breach the
  * terms of service.

--- a/public/javascripts/SVValidate/src/Main.js
+++ b/public/javascripts/SVValidate/src/Main.js
@@ -123,6 +123,7 @@ function Main (param) {
 
         // There are certain features that will only make sense if we have one validation interface on the screen.
         if (param.canvasCount === 1) {
+            svv.gsvOverlay = new GSVOverlay();
             svv.keyboard = new Keyboard(svv.ui.validation);
             svv.labelVisibilityControl = new LabelVisibilityControl();
             svv.zoomControl = new ZoomControl();

--- a/public/javascripts/SVValidate/src/panorama/GSVOverlay.js
+++ b/public/javascripts/SVValidate/src/panorama/GSVOverlay.js
@@ -1,15 +1,13 @@
-/**
- * An additional layer on top of the Google StreetView object
- * on validation interface. This layer handles panning.
- *
+/*
+ * An additional layer on top of the Google StreetView object on validation interface. This layer handles panning.
  */
 function GSVOverlay () {
     let self = this;
-    var panningDisabled = false;
-    var viewControlLayer = $("#viewControlLayer");
+    let panningDisabled = false;
+    let viewControlLayer = $("#viewControlLayer");
 
-    // Mouse status and mouse event callback functions
-    var mouseStatus = {
+    // Mouse status and mouse event callback functions.
+    let mouseStatus = {
         currX: 0,
         currY: 0,
         prevX: 0,
@@ -36,8 +34,8 @@ function GSVOverlay () {
     }
 
     /**
-     * This is a callback function that is fired with the mouse down event
-     * on the view control layer (where you control street view angle.)
+     * This is a callback function that is fired with the mouse down event on the view
+     * control layer (where you control street view angle.)
      * @param e
      */
     function handlerViewControlLayerMouseDown (e) {
@@ -46,7 +44,7 @@ function GSVOverlay () {
         mouseStatus.leftDownY = mouseposition(e, this).y;
         viewControlLayer.css("cursor", "url(/assets/javascripts/SVLabel/img/cursors/closedhand.cur) 4 4, move");
 
-        //This is necessary for supporting touch devices, because there is no mouse hover
+        // This is necessary for supporting touch devices, because there is no mouse hover.
         mouseStatus.prevX = mouseposition(e, this).x;
         mouseStatus.prevY = mouseposition(e, this).y;
     }
@@ -61,8 +59,8 @@ function GSVOverlay () {
         mouseStatus.isLeftDown = false;
         mouseStatus.leftUpX = mouseposition(e, this).x;
         mouseStatus.leftUpY = mouseposition(e, this).y;
-
     }
+
     /**
      * Handles mouse leaving control view.
      * @param e
@@ -80,13 +78,14 @@ function GSVOverlay () {
         mouseStatus.currX = mouseposition(e, this).x;
         mouseStatus.currY = mouseposition(e, this).y;
 
-        var timestamp = new Date().getTime();  // waits till the pano is fully loaded
-        if ((timestamp - svv.panorama.getProperty("prevSetPanoTimestamp") > 800) && mouseStatus.isLeftDown && panningDisabled === false) {
+        let timestamp = new Date().getTime();  // Waits till the pano is fully loaded.
+        if ((timestamp - svv.panorama.getProperty("prevSetPanoTimestamp") > 500)
+            && mouseStatus.isLeftDown && panningDisabled === false) {
             // If a mouse is being dragged on the control layer, move the sv image.
-            var dx = mouseStatus.currX - mouseStatus.prevX;
-            var dy = mouseStatus.currY - mouseStatus.prevY;
-            var pov = svv.panorama.getPov();
-            var zoomLevel = pov.zoom;
+            let dx = mouseStatus.currX - mouseStatus.prevX;
+            let dy = mouseStatus.currY - mouseStatus.prevY;
+            let pov = svv.panorama.getPov();
+            let zoomLevel = pov.zoom;
             dx = dx / (2 * zoomLevel);
             dy = dy / (2 * zoomLevel);
             dx *= 1.5;
@@ -98,15 +97,15 @@ function GSVOverlay () {
     }
 
     /**
-     * Update POV of Street View as a user drag a mouse cursor.
+     * Update POV of Street View as a user drags their mouse cursor.
      * @param dx
      * @param dy
      */
     function updatePov (dx, dy) {
-        var pano = svv.panorama.getPanorama();
+        let pano = svv.panorama.getPanorama();
         if (pano) {
-            var pov = pano.getPov(),
-                alpha = 0.25;
+            let pov = pano.getPov();
+            let alpha = 0.25;
             pov.heading -= alpha * dx;
             pov.pitch += alpha * dy;
             pano.setPov(pov);
@@ -115,9 +114,10 @@ function GSVOverlay () {
         }
     }
 
-    // A cross-browser function to capture a mouse position
+    // A cross-browser function to capture mouse positions.
     function mouseposition (e, dom) {
-        var mx, my;
+        let mx;
+        let my;
         //if(e.offsetX) {
             // Chrome
         //    mx = e.offsetX;

--- a/public/javascripts/SVValidate/src/panorama/GSVOverlay.js
+++ b/public/javascripts/SVValidate/src/panorama/GSVOverlay.js
@@ -1,0 +1,143 @@
+/**
+ * An additional layer on top of the Google StreetView object
+ * on validation interface. This layer handles panning.
+ *
+ */
+function GSVOverlay () {
+    let self = this;
+    var panningDisabled = false;
+    var viewControlLayer = $("#viewControlLayer");
+
+    // Mouse status and mouse event callback functions
+    var mouseStatus = {
+        currX: 0,
+        currY: 0,
+        prevX: 0,
+        prevY: 0,
+        leftDownX: 0,
+        leftDownY: 0,
+        leftUpX: 0,
+        leftUpY: 0,
+        isLeftDown: false
+    };
+
+    /**
+     * Disables panning on the GSV window.
+     */
+    function disablePanning() {
+        panningDisabled = true;
+    }
+
+    /**
+     * Enables panning on the GSV window.
+     */
+    function enablePanning() {
+        panningDisabled = false;
+    }
+
+    /**
+     * This is a callback function that is fired with the mouse down event
+     * on the view control layer (where you control street view angle.)
+     * @param e
+     */
+    function handlerViewControlLayerMouseDown (e) {
+        mouseStatus.isLeftDown = true;
+        mouseStatus.leftDownX = mouseposition(e, this).x;
+        mouseStatus.leftDownY = mouseposition(e, this).y;
+        viewControlLayer.css("cursor", "url(/assets/javascripts/SVLabel/img/cursors/closedhand.cur) 4 4, move");
+
+        //This is necessary for supporting touch devices, because there is no mouse hover
+        mouseStatus.prevX = mouseposition(e, this).x;
+        mouseStatus.prevY = mouseposition(e, this).y;
+    }
+
+    /**
+     * This is a callback function that is called with mouse up event on
+     * the view control layer (where you change the Google Street view angle.
+     * @param e
+     */
+    function handlerViewControlLayerMouseUp (e) {
+        viewControlLayer.css("cursor", "url(/assets/javascripts/SVLabel/img/cursors/openhand.cur) 4 4, move");
+        mouseStatus.isLeftDown = false;
+        mouseStatus.leftUpX = mouseposition(e, this).x;
+        mouseStatus.leftUpY = mouseposition(e, this).y;
+
+    }
+    /**
+     * Handles mouse leaving control view.
+     * @param e
+     */
+    function handlerViewControlLayerMouseLeave (e) {
+        viewControlLayer.css("cursor", "url(/assets/javascripts/SVLabel/img/cursors/openhand.cur) 4 4, move");
+        mouseStatus.isLeftDown = false;
+    }
+
+    /**
+     * This is a callback function that is fired when a user moves a mouse on the
+     * view control layer where you change the pov.
+     */
+    function handlerViewControlLayerMouseMove (e) {
+        mouseStatus.currX = mouseposition(e, this).x;
+        mouseStatus.currY = mouseposition(e, this).y;
+
+        var timestamp = new Date().getTime();  // waits till the pano is fully loaded
+        if ((timestamp - svv.panorama.getProperty("prevSetPanoTimestamp") > 800) && mouseStatus.isLeftDown && panningDisabled === false) {
+            // If a mouse is being dragged on the control layer, move the sv image.
+            var dx = mouseStatus.currX - mouseStatus.prevX;
+            var dy = mouseStatus.currY - mouseStatus.prevY;
+            var pov = svv.panorama.getPov();
+            var zoomLevel = pov.zoom;
+            dx = dx / (2 * zoomLevel);
+            dy = dy / (2 * zoomLevel);
+            dx *= 1.5;
+            dy *= 1.5;
+            updatePov(dx, dy);
+        }
+        mouseStatus.prevX = mouseposition(e, this).x;
+        mouseStatus.prevY = mouseposition(e, this).y;
+    }
+
+    /**
+     * Update POV of Street View as a user drag a mouse cursor.
+     * @param dx
+     * @param dy
+     */
+    function updatePov (dx, dy) {
+        var pano = svv.panorama.getPanorama();
+        if (pano) {
+            var pov = pano.getPov(),
+                alpha = 0.25;
+            pov.heading -= alpha * dx;
+            pov.pitch += alpha * dy;
+            pano.setPov(pov);
+        } else {
+            throw self.className + ' updatePov(): panorama not defined!';
+        }
+    }
+
+    // A cross-browser function to capture a mouse position
+    function mouseposition (e, dom) {
+        var mx, my;
+        //if(e.offsetX) {
+            // Chrome
+        //    mx = e.offsetX;
+        //    my = e.offsetY;
+        //} else {
+        // Firefox, Safari
+            mx = e.pageX - $(dom).offset().left;
+            my = e.pageY - $(dom).offset().top;
+        //}
+        return {'x': parseInt(mx, 10) , 'y': parseInt(my, 10) };
+    }
+
+    viewControlLayer.bind('mousemove', handlerViewControlLayerMouseMove);
+    viewControlLayer.bind('mousedown', handlerViewControlLayerMouseDown);
+    viewControlLayer.bind('mouseup', handlerViewControlLayerMouseUp);
+    viewControlLayer.bind('mouseleave', handlerViewControlLayerMouseLeave);
+
+    self.disablePanning = disablePanning;
+    self.enablePanning = enablePanning;
+
+    return self;
+}
+

--- a/public/javascripts/SVValidate/src/panorama/Panorama.js
+++ b/public/javascripts/SVValidate/src/panorama/Panorama.js
@@ -14,6 +14,7 @@ function Panorama (label, id) {
         canvasId: "svv-panorama-" + id,
         panoId: undefined,
         prevPanoId: undefined,
+        prevSetPanoTimestamp: new Date().getTime(),
         validationTimestamp: new Date().getTime()
     };
 
@@ -80,6 +81,13 @@ function Panorama (label, id) {
      */
     function getCurrentLabel () {
         return currentLabel;
+    }
+
+    /**
+     * Returns the actual StreetView object.
+     */
+    function getPanorama () {
+        return panorama;
     }
 
     /**
@@ -228,6 +236,7 @@ function Panorama (label, id) {
         setProperty("panoId", panoId);
         setProperty("prevPanoId", panoId);
         panorama.setPano(panoId);
+        setProperty("prevSetPanoTimestamp", new Date().getTime());
         panorama.set('pov', {heading: heading, pitch: pitch});
         panorama.set('zoom', zoomLevel[zoom]);
         renderLabel();
@@ -303,6 +312,7 @@ function Panorama (label, id) {
     self.skipLabel = skipLabel;
     self.hideLabel = hideLabel;
     self.showLabel = showLabel;
+    self.getPanorama = getPanorama;
 
     return this;
 }

--- a/public/javascripts/SVValidate/src/panorama/Panorama.js
+++ b/public/javascripts/SVValidate/src/panorama/Panorama.js
@@ -206,7 +206,9 @@ function Panorama (label, id) {
         let pos = currentLabel.getPosition();
 
         if (!self.labelMarker) {
+            let controlLayer = document.getElementById("viewControlLayer");
             self.labelMarker = new PanoMarker({
+                markerContainer: controlLayer,
                 container: panoCanvas,
                 pano: panorama,
                 position: {heading: pos.heading, pitch: pos.pitch},


### PR DESCRIPTION
Resolves #1734 
Fixes #1662 

This bug happens when a user tries to validate labels using keyboard shortcuts while panning. I was able to reproduce the bugs multiple times:

Screen Recording: https://youtu.be/KI3UzXwEops

This was fixed by making sure that a user can only pan after the panorama is fully loaded. Doing so requires adding a layer on top of the GSV window that handles panning.

Users are now also not able to walk using arrow keys.

Testing: Test to see if this bug still happens (using keyboard shortcuts while panning), make sure nothing breaks during panning.
