### PR TITLE
no sidewalk labels deprioritized on validation again

### DIFF
--- a/app/controllers/ValidationController.scala
+++ b/app/controllers/ValidationController.scala
@@ -77,8 +77,11 @@ class ValidationController @Inject() (implicit val env: Environment[User, Sessio
     hasWork match {
       case true => {
         // possibleLabTypeIds can contain [1, 2, 3, 4, 7]. Select ids 1, 2, 3, 4 if possible, o/w choose 7.
-        val index: Int = if (possibleLabTypeIds.size > 1) scala.util.Random.nextInt(possibleLabTypeIds.size - 1) else 0
-        val labelTypeId: Int = possibleLabTypeIds(index)
+        val possibleIds: List[Int] =
+          if (possibleLabTypeIds.size > 1) possibleLabTypeIds.filter(_ != 7)
+          else possibleLabTypeIds
+        val index: Int = if (possibleIds.size > 1) scala.util.Random.nextInt(possibleIds.size - 1) else 0
+        val labelTypeId: Int = possibleIds(index)
         val mission: Mission = MissionTable.resumeOrCreateNewValidationMission(user.userId,
           AMTAssignmentTable.TURKER_PAY_PER_LABEL_VALIDATION, 0.0, validationTypeStr, labelTypeId).get
 

--- a/app/controllers/ValidationTaskController.scala
+++ b/app/controllers/ValidationTaskController.scala
@@ -132,11 +132,16 @@ class ValidationTaskController @Inject() (implicit val env: Environment[User, Se
     if (missionProgress.completed) {
       val labelsToRetrieve: Int = MissionTable.getNumberOfLabelsToRetrieve(userId, missionProgress.missionType)
       val possibleLabelTypeIds: List[Int] = LabelTable.retrievePossibleLabelTypeIds(userId, labelsToRetrieve, currentLabelTypeId)
+      println(possibleLabelTypeIds)
       val hasNextMission: Boolean = possibleLabelTypeIds.nonEmpty
 
       if (hasNextMission) {
-        val index: Int = if (possibleLabelTypeIds.size > 1) scala.util.Random.nextInt(possibleLabelTypeIds.size - 1) else 0
-        return Some(possibleLabelTypeIds(index))
+        // possibleLabTypeIds can contain [1, 2, 3, 4, 7]. Select ids 1, 2, 3, 4 if possible, o/w choose 7.
+        val possibleIds: List[Int] =
+          if (possibleLabelTypeIds.size > 1) possibleLabelTypeIds.filter(_ != 7)
+          else possibleLabelTypeIds
+        val index: Int = if (possibleIds.size > 1) scala.util.Random.nextInt(possibleIds.size - 1) else 0
+        return Some(possibleIds(index))
       }
     }
     None


### PR DESCRIPTION
Fixes #1862 

This should fix the issue where we were getting validation missions for no sidewalk labels. The issue was that we were relying on a list to be sorted that was not necessarily sorted.