### PR TITLE
1813 validation wrong title text

### DIFF
--- a/public/javascripts/SVValidate/src/panorama/Panorama.js
+++ b/public/javascripts/SVValidate/src/panorama/Panorama.js
@@ -241,6 +241,8 @@ function Panorama (label, id) {
     function setLabel (label) {
         currentLabel = label;
         currentLabel.setProperty('startTimestamp', new Date().getTime());
+        svv.statusField.updateLabelText(currentLabel.getAuditProperty('labelType'));
+        svv.statusExample.updateLabelImage(currentLabel.getAuditProperty('labelType'));
         setPanorama(label.getAuditProperty('gsvPanoramaId'), label.getAuditProperty('heading'),
             label.getAuditProperty('pitch'), label.getAuditProperty('zoom'));
         renderLabel();


### PR DESCRIPTION
Resolves #1813 

On develop branch's validation page, the title doesn't get updated for new missions. This was fixed by adding code to update this title when new labels are set.

Bug Screenshot: 
<img width="1229" alt="Screen Shot 2019-08-13 at 4 38 03 PM" src="https://user-images.githubusercontent.com/51970755/62986852-42163e00-bdf2-11e9-90fe-eb1a5df600c5.png">
