### PR TITLE
1837 landing pagefix dc link

### DIFF
--- a/app/controllers/ValidationTaskController.scala
+++ b/app/controllers/ValidationTaskController.scala
@@ -132,7 +132,6 @@ class ValidationTaskController @Inject() (implicit val env: Environment[User, Se
     if (missionProgress.completed) {
       val labelsToRetrieve: Int = MissionTable.getNumberOfLabelsToRetrieve(userId, missionProgress.missionType)
       val possibleLabelTypeIds: List[Int] = LabelTable.retrievePossibleLabelTypeIds(userId, labelsToRetrieve, currentLabelTypeId)
-      println(possibleLabelTypeIds)
       val hasNextMission: Boolean = possibleLabelTypeIds.nonEmpty
 
       if (hasNextMission) {

--- a/conf/cityparams.conf
+++ b/conf/cityparams.conf
@@ -30,7 +30,7 @@ city-params {
   }
   landing-page-url {
     newberg-or = "https://sidewalk-newberg.cs.washington.edu"
-    washington-dc = "https://sidewalk.cs.washington.edu"
+    washington-dc = "https://sidewalk-dc.cs.washington.edu"
     seattle-wa = "https://sidewalk-sea.cs.washington.edu"
   }
   google-analytics-id {


### PR DESCRIPTION
Fixes #1837 

The link to the DC server on the landing page is now sidewalk-dc.cs.washington.edu instead sidewalk.cs.washington.edu. So it correctly links to DC and not to Seattle now!