### PR TITLE
adds buffer room when deciding if a user can validate a label type

### DIFF
--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -657,7 +657,7 @@ object LabelTable {
     * @return
     */
   def retrievePossibleLabelTypeIds(userId: UUID, count: Int, currentLabelTypeId: Option[Int]): List[Int] = {
-    getAvailableValidationLabelsByType(userId).filter(_._2 > count).map(_._1).filter(labelTypeIdList.contains(_))
+    getAvailableValidationLabelsByType(userId).filter(_._2 > count * 2).map(_._1).filter(labelTypeIdList.contains(_))
   }
 
     /**


### PR DESCRIPTION
Resolves #1854 

We recently had a bug that occurred when every label of a certain type had been validated. I wanted to make sure that I also fixed this for when a single user validated all the labels of a certain label type.

Through my investigation I found that the logic looks sound (I actually fixed it during that other PR where I fixed the issue mentioned above).

One thing I did do in this PR is to add a buffer to how many labels need to be available for us to assign a validation mission for that label type. I foresaw a problem if there were only 10 obstacle labels left to validate, but then one of them didn't have imagery, this likely would have thrown us into an infinite loops on the back-end again (though honestly it would have been very very unlikely). We now require that a there are 20 (n * 2) labels available for that label type before we assign it.