### PR TITLE
1372 validation change number of audit missions

### DIFF
--- a/app/models/mission/MissionTable.scala
+++ b/app/models/mission/MissionTable.scala
@@ -150,6 +150,20 @@ object MissionTable {
   }
 
   /**
+    * Count number of missions of the given type completed by the given user.
+    * @param userId
+    * @param missionType
+    * @return
+    */
+  def countCompletedMissions(userId: UUID, missionType: String): Int = db.withSession { implicit session =>
+    (for {
+      _missionType <- missionTypes
+      _mission <- missions if _missionType.missionTypeId === _mission.missionTypeId
+      if _missionType.missionType === missionType && _mission.userId === userId.toString && _mission.completed === true
+    } yield _mission.missionId).length.run
+  }
+
+  /**
     * Returns true if the user has an amt_assignment and has completed a mission during it, false o/w.
     *
     * @param username

--- a/app/views/audit.scala.html
+++ b/app/views/audit.scala.html
@@ -7,7 +7,7 @@
 @import play.api.libs.json.Json
 @import views.html.bootstrap._
 
-@(title: String, task: Option[models.audit.NewTask] = None, mission: Mission, region: NamedRegion, nextTempLabelId: Int, user: Option[User] = None, cityShortName: String, tutorialStreetId: Int, lat: Option[Double] = None, lng: Option[Double] = None, panoId: Option[String] = None, enableCVGroundTruthLabelingMode: Boolean = false)
+@(title: String, task: Option[models.audit.NewTask] = None, mission: Mission, region: NamedRegion, hasCompletedMission: Boolean, nextTempLabelId: Int, user: Option[User] = None, cityShortName: String, tutorialStreetId: Int, lat: Option[Double] = None, lng: Option[Double] = None, panoId: Option[String] = None, enableCVGroundTruthLabelingMode: Boolean = false)
 
 @main(title, Some("/audit")) {
     @navbar(user, Some("/audit"))
@@ -1051,7 +1051,8 @@
 
             mainParam.nextTemporaryLabelId = @nextTempLabelId;
             mainParam.mission = @Html(mission.toJSON.toString);
-            mainParam.tutorialStreetId = @tutorialStreetId
+            mainParam.tutorialStreetId = @tutorialStreetId;
+            mainParam.hasCompletedAMission = @hasCompletedMission;
 
             svl.main = new Main(mainParam);
         }

--- a/public/javascripts/SVLabel/src/SVLabel/Main.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Main.js
@@ -83,6 +83,8 @@ function Main (params) {
 
     function _init (params) {
         params = params || {};
+
+        svl.userHasCompletedAMission = params.hasCompletedAMission;
         var panoId = params.panoId;
         var SVLat = parseFloat(params.initLat), SVLng = parseFloat(params.initLng);
 

--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
@@ -105,8 +105,8 @@ function ModalMissionComplete (svl, missionContainer, missionModel, taskContaine
     };
 
     this._closeModal = function (e) {
-        if (svl.missionsCompleted === 1) {
-            // Load the validation page since they've done 1 mission.
+        if ((!svl.userHasCompletedAMission && svl.missionsCompleted === 1) || svl.missionsCompleted === 3) {
+            // Load the validation page since they've either completed their audit first mission or just finished 3.
             window.location.replace('/validate');
         }
         else if (svl.neighborhoodModel.isNeighborhoodCompleted) {

--- a/public/javascripts/SVValidate/src/modal/ModalMissionComplete.js
+++ b/public/javascripts/SVValidate/src/modal/ModalMissionComplete.js
@@ -7,7 +7,7 @@ function ModalMissionComplete (uiModalMissionComplete, user, confirmationCode) {
 
     function _handleButtonClick() {
         if (svv.missionsCompleted === 3) {
-            // Load the audit page since they've done 2 missions.
+            // Load the audit page since they've done 3 missions.
             window.location.replace('/audit');
         } else {
             self.hide();


### PR DESCRIPTION
This is a small test of something suggested in #1372 

We are toying with the audit/validation mission flow so that it feels less jarring for returning users. Being taken out of an auditing after only 1 or 2 audit missions seems to quick for returning users, but new users should have a chance to try validating right away.

To this end, this PR sets things up so that a new user will do one audit mission, then be sent to validations for 3 missions. If a user has already completed an audit mission, they will get 3 audit missions in a row before being sent to validation for 3 missions.

This setup probably isn't going to be our end goal, but we want to try out some slight modifications before completely overhauling and giving users more choice.