### PR TITLE
1869 validation first two labels are the same

### DIFF
--- a/public/javascripts/SVValidate/src/panorama/PanoramaContainer.js
+++ b/public/javascripts/SVValidate/src/panorama/PanoramaContainer.js
@@ -124,6 +124,7 @@ function PanoramaContainer (labelList, idList) {
 
         idList.forEach(function(id) {
            panos[id].setLabel(labels[id]);
+           setProperty("progress", getProperty("progress") + 1);
         });
     }
 


### PR DESCRIPTION
Fixes #1869 

On the validation interface, when a new mission is loaded, the progress field (label index) does not get updated properly. This PR has code that makes sure this field get incremented correctly.

Bug: 
<img width="1416" alt="Screen Shot 2019-08-21 at 3 16 45 PM" src="https://user-images.githubusercontent.com/51970755/63473205-7957a100-c429-11e9-9960-b79b4fcbd567.png">

No bug:
<img width="1421" alt="Screen Shot 2019-08-21 at 3 18 29 PM" src="https://user-images.githubusercontent.com/51970755/63473218-8a081700-c429-11e9-929e-8724360419cd.png">

