### PR TITLE
1871 validation skip and feedback button not working

### DIFF
--- a/public/javascripts/SVValidate/css/svv-modal.css
+++ b/public/javascripts/SVValidate/css/svv-modal.css
@@ -99,7 +99,7 @@
     left: 5px;
     visibility: visible;
     width: 720px;
-    z-index: 1;
+    z-index: 2;
 
     border-radius: 3px 3px 3px 3px;
     -webkit-border-radius: 3px 3px 3px 3px;

--- a/public/javascripts/SVValidate/src/panorama/PanoramaContainer.js
+++ b/public/javascripts/SVValidate/src/panorama/PanoramaContainer.js
@@ -82,7 +82,7 @@ function PanoramaContainer (labelList, idList) {
             success: function (labelMetadata) {
                 labels.push(_createSingleLabel(labelMetadata));
                 svv.missionContainer.updateAMissionSkip();
-                loadNewLabelOntoPanorama();
+                loadNewLabelOntoPanorama(svv.panorama);
             }
         });
     }


### PR DESCRIPTION
Fixes #1871 

A function was incorrectly called when the skip label button is clicked.
The comment box sits underneath the newly introduced GSV overlay.

This PR has code that fixes the issues above.

After: https://youtu.be/g_pTexUZVPM