### PR TITLE
continue button now changes text for which mission is next

### DIFF
--- a/public/javascripts/SVValidate/src/modal/ModalMissionComplete.js
+++ b/public/javascripts/SVValidate/src/modal/ModalMissionComplete.js
@@ -80,7 +80,13 @@ function ModalMissionComplete (uiModalMissionComplete, user, confirmationCode) {
 
         uiModalMissionComplete.holder.css('visibility', 'visible');
         uiModalMissionComplete.foreground.css('visibility', 'visible');
-        uiModalMissionComplete.closeButton.html('Validate more labels');
+
+        // Set button text to auditing if they've completed 3 validation missions (and are on a laptop/desktop).
+        if (svv.missionsCompleted === 3 && !isMobile()) {
+            uiModalMissionComplete.closeButton.html('Start an exploration mission');
+        } else {
+            uiModalMissionComplete.closeButton.html('Validate more labels');
+        }
 
         // TODO this code was removed for issue #1693, search for "#1693" and uncomment all later.
         // If this is a turker and the confirmation code button hasn't been shown yet, mark amt_assignment as complete


### PR DESCRIPTION
Fixes #1800 

After finishing your third validation mission, the continue button now reads "Start an exploration mission" instead of "Validate more labels" before you are sent to the audit page. This remains "Validate more labels" on mobile, because we don't have a mobile audit interface right now.

![start-an-exploration-mission](https://user-images.githubusercontent.com/6518824/64046116-e3560180-cb1f-11e9-92f7-db30b46e6653.png)
