### PR TITLE
1874 validation fix repeating labels

### DIFF
--- a/app/controllers/ValidationController.scala
+++ b/app/controllers/ValidationController.scala
@@ -129,7 +129,7 @@ class ValidationController @Inject() (implicit val env: Environment[User, Sessio
     val labelsToValidate: Int = MissionTable.getNumberOfLabelsToRetrieve(userId, missionType)
     val labelsToRetrieve: Int = labelsToValidate - labelsProgress
 
-    val labelMetadata: Seq[LabelValidationMetadata] = LabelTable.retrieveLabelListForValidation(userId, labelsToRetrieve, labelType)
+    val labelMetadata: Seq[LabelValidationMetadata] = LabelTable.retrieveLabelListForValidation(userId, labelsToRetrieve, labelType, skippedLabelId = None)
     val labelMetadataJsonSeq: Seq[JsObject] = labelMetadata.map(label => LabelTable.validationLabelMetadataToJson(label))
     val labelMetadataJson : JsValue = Json.toJson(labelMetadataJsonSeq)
     labelMetadataJson

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -534,12 +534,13 @@ object LabelTable {
     *
     * Starts by querying for n * 5 labels, then checks GSV API to see if each gsv_panorama_id exists until we find n.
     *
-    * @param userId       User ID for the current user.
-    * @param n            Number of labels we need to query.
-    * @param labelTypeId  Label Type ID of labels requested.
-    * @return             Seq[LabelValidationMetadata]
+    * @param userId         User ID for the current user.
+    * @param n              Number of labels we need to query.
+    * @param labelTypeId    Label Type ID of labels requested.
+    * @param skippedLabelid Label ID of the label that was just skipped (if applicable)
+    * @return               Seq[LabelValidationMetadata]
     */
-  def retrieveLabelListForValidation(userId: UUID, n: Int, labelTypeId: Int) : Seq[LabelValidationMetadata] = db.withSession { implicit session =>
+  def retrieveLabelListForValidation(userId: UUID, n: Int, labelTypeId: Int, skippedLabelId: Option[Int]) : Seq[LabelValidationMetadata] = db.withSession { implicit session =>
     var selectedLabels: ListBuffer[LabelValidationMetadata] = new ListBuffer[LabelValidationMetadata]()
     var potentialLabels: List[LabelValidationMetadata] = List()
     val userIdStr = userId.toString
@@ -595,6 +596,9 @@ object LabelTable {
       )
       potentialLabels = selectRandomLabelsQuery((userIdStr, labelTypeId, labelTypeId, userIdStr, userIdStr, n * 5)).list
 
+      // Remove label that was just skipped (if one was skipped).
+      potentialLabels = potentialLabels.filter(_.labelId != skippedLabelId.getOrElse(-1))
+
       // Randomize those n * 5 high priority labels to prevent repeated and similar labels in a mission.
       // https://github.com/ProjectSidewalk/SidewalkWebpage/issues/1874
       // https://github.com/ProjectSidewalk/SidewalkWebpage/issues/1823
@@ -638,7 +642,7 @@ object LabelTable {
   def retrieveRandomLabelListForValidation(userId: UUID, count: Int) : Seq[LabelValidationMetadata] = db.withSession { implicit session =>
     // We are currently assigning label types to missions randomly.
     val labelTypeId: Int = retrieveRandomValidationLabelTypeId()
-    retrieveLabelListForValidation(userId, count, labelTypeId)
+    retrieveLabelListForValidation(userId, count, labelTypeId, skippedLabelId = None)
   }
 
   /**

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -594,6 +594,12 @@ object LabelTable {
           |LIMIT ?""".stripMargin
       )
       potentialLabels = selectRandomLabelsQuery((userIdStr, labelTypeId, labelTypeId, userIdStr, userIdStr, n * 5)).list
+
+      // Randomize those n * 5 high priority labels to prevent repeated and similar labels in a mission.
+      // https://github.com/ProjectSidewalk/SidewalkWebpage/issues/1874
+      // https://github.com/ProjectSidewalk/SidewalkWebpage/issues/1823
+      potentialLabels = scala.util.Random.shuffle(potentialLabels)
+
       var potentialStartIdx: Int = 0
 
       // Start looking through our n * 5 labels until we find n with valid pano id or we've gone through our n * 5 and

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -633,18 +633,6 @@ object LabelTable {
     selectedLabels
   }
 
-  /**.
-    * Retrieve a list of labels for validation with a random label id
-    * @param userId User ID of the current user.
-    * @param count  Number of labels in the list.
-    * @return       Seq[LabelValidationMetadata]
-    */
-  def retrieveRandomLabelListForValidation(userId: UUID, count: Int) : Seq[LabelValidationMetadata] = db.withSession { implicit session =>
-    // We are currently assigning label types to missions randomly.
-    val labelTypeId: Int = retrieveRandomValidationLabelTypeId()
-    retrieveLabelListForValidation(userId, count, labelTypeId, skippedLabelId = None)
-  }
-
   /**
     * Retrieves a random validation label type id (1, 2, 3, 4, 7).
     * @return Integer corresponding to the label type id.

--- a/conf/routes
+++ b/conf/routes
@@ -103,7 +103,7 @@ GET     /rewardEarned                                        @controllers.Missio
 GET     /label/currentMission                                @controllers.LabelController.getLabelsFromCurrentMission(regionId: Int)
 GET     /label/tags                                          @controllers.LabelController.getLabelTags()
 GET     /label/miniMapResume                                 @controllers.LabelController.getLabelsForMiniMap(regionId: Int)
-POST    /label/geo/random/:labelType                         @controllers.ValidationTaskController.getRandomLabelData(labelType: Int)
+POST    /label/geo/random/:labelType/:labelId                @controllers.ValidationTaskController.getRandomLabelData(labelType: Int, labelId: Int)
 GET     /label/geo/:id                                       @controllers.ValidationTaskController.getLabelData(id: Int)
 
 # Neighborhoods

--- a/public/javascripts/SVValidate/src/panorama/Panorama.js
+++ b/public/javascripts/SVValidate/src/panorama/Panorama.js
@@ -296,7 +296,7 @@ function Panorama (label, id) {
      * Skips the current label on this panorama and fetches a new label for validation.
      */
     function skipLabel () {
-        svv.panoramaContainer.fetchNewLabel();
+        svv.panoramaContainer.fetchNewLabel(currentLabel.getProperty('labelId'));
     }
 
     /**

--- a/public/javascripts/SVValidate/src/panorama/PanoramaContainer.js
+++ b/public/javascripts/SVValidate/src/panorama/PanoramaContainer.js
@@ -60,10 +60,11 @@ function PanoramaContainer (labelList, idList) {
     /**
      * Fetches a single label from the database.  When the user clicks skip, need to get more
      * because missions fetch exactly the number of labels that are needed to complete the mission.
+     * @param skippedLabelId the ID of the label that we are skipping
      */
-    function fetchNewLabel () {
+    function fetchNewLabel (skippedLabelId) {
         let labelTypeId = svv.missionContainer.getCurrentMission().getProperty('labelTypeId');
-        let labelUrl = "/label/geo/random/" + labelTypeId;
+        let labelUrl = '/label/geo/random/' + labelTypeId + '/' + skippedLabelId;
 
         let data = {};
         data.labels = svv.labelContainer.getCurrentLabels();


### PR DESCRIPTION
Fixes #1874 
Resolves #1823 

This fixes the bug where you would click the skip button and the exact same label would just show up again (#1874). It also makes it less likely that you will see a bunch of labels from the same labeling mission in a validation mission (#1823).