### PR TITLE
1892 performance improve clustering speed

### DIFF
--- a/app/controllers/helper/AttributeControllerHelper.scala
+++ b/app/controllers/helper/AttributeControllerHelper.scala
@@ -60,7 +60,7 @@ object AttributeControllerHelper {
 
     if (maybeKey.isDefined) {
       val key: String = maybeKey.get
-      val goodUsers: List[String] = UserStatTable.getIdsOfGoodUsers // All users
+      val goodUsers: List[String] = UserStatTable.getIdsOfGoodUsersWithLabels // All users
       //      val goodUsers: List[String] = List("9efaca05-53bb-492e-83ab-2b47219ee863") // Test users with a lot of labels
       //      val goodUsers: List[String] = List("53b4a67b-614e-432d-9bfa-8a97e081fea5") // Test users with fewer labels
       val nUsers = goodUsers.length

--- a/app/models/user/UserStatTable.scala
+++ b/app/models/user/UserStatTable.scala
@@ -86,7 +86,7 @@ object UserStatTable {
 
   /**
     * Update labels_per_meter column in the user_stat table for all users, run after `updateAuditedDistance`.
-    * // TODO labelsWithoutDeletedOrOnboarding
+    *
     */
   def updateLabelsPerMeter() = db.withSession { implicit session =>
 
@@ -94,7 +94,7 @@ object UserStatTable {
     val labelCounts = (for {
       _stat <- userStats if _stat.metersAudited > 0F
       _mission <- MissionTable.auditMissions if _stat.userId === _mission.userId
-      _label <- LabelTable.labelsWithoutDeleted if _mission.missionId === _label.missionId
+      _label <- LabelTable.labelsWithoutDeletedOrOnboarding if _mission.missionId === _label.missionId
     } yield (_stat.userId, _label.labelId)).groupBy(_._1).map(x => (x._1, x._2.length))
 
     // Compute labeling frequency using label counts above and the meters_audited column in user_stat table.

--- a/app/models/user/UserStatTable.scala
+++ b/app/models/user/UserStatTable.scala
@@ -86,7 +86,6 @@ object UserStatTable {
 
   /**
     * Update labels_per_meter column in the user_stat table for all users, run after `updateAuditedDistance`.
-    *
     */
   def updateLabelsPerMeter() = db.withSession { implicit session =>
 


### PR DESCRIPTION
fixes #1892 

Drastically improves the runtime of nightly clustering. We were "running clustering" on all users, even if they had never placed a label. And this involves a call to a Python script that would take about 1/4 of a second. Given that there are 10s of thousands of accounts (from anyone who simply visits our landing page), this caused the clustering to be taking 1-2 hours. It should now take more like 20-30 minutes.

I also noticed that tutorial labels were being included in the label count for users when deciding if they are a "high quality" user. I've fixed that bug as well.