### PR TITLE
Forces turkers into specific mission flow

### DIFF
--- a/app/controllers/ApplicationController.scala
+++ b/app/controllers/ApplicationController.scala
@@ -63,7 +63,7 @@ class ApplicationController @Inject() (implicit val env: Environment[User, Sessi
             request.identity match {
               case Some(user) =>
                 // Have different cases when the user.username is the same as the workerId and when it isn't.
-                user.username match{
+                user.username match {
                   case `workerId` =>
                     activityLogText = activityLogText + "_reattempt=true"
                     // Unless they are mid-assignment, create a new assignment.
@@ -93,7 +93,7 @@ class ApplicationController @Inject() (implicit val env: Environment[User, Sessi
             }
 
           case _ =>
-            val redirectTo: String = qString.get("to") match{
+            val redirectTo: String = qString.get("to") match {
               case Some(to) =>
                 to
               case None =>

--- a/app/controllers/AuditController.scala
+++ b/app/controllers/AuditController.scala
@@ -16,7 +16,7 @@ import models.amt.AMTAssignmentTable
 import models.audit._
 import models.daos.slick.DBTableDefinitions.{DBUser, UserTable}
 import models.label.LabelTable
-import models.mission.{CVMissionPanoStatus, Mission, MissionProgressCVGroundtruthTable, MissionTable}
+import models.mission.{CVMissionPanoStatus, Mission, MissionProgressCVGroundtruthTable, MissionTable, MissionSetProgress}
 import models.region._
 import models.street.{StreetEdgeIssue, StreetEdgeIssueTable, StreetEdgeRegionTable}
 import models.user._
@@ -94,6 +94,10 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
               if (retakingTutorial || role != "Turker") AMTAssignmentTable.VOLUNTEER_PAY
               else AMTAssignmentTable.TURKER_TUTORIAL_PAY
 
+            val missionSetProgress: MissionSetProgress =
+              if (role == "Turker") MissionTable.getProgressOnMissionSet(user.username)
+              else MissionTable.defaultAuditMissionSetProgress
+
             val mission: Mission =
               if(retakingTutorial) MissionTable.resumeOrCreateNewAuditOnboardingMission(user.userId, tutorialPay).get
               else MissionTable.resumeOrCreateNewAuditMission(user.userId, regionId, payPerMeter, tutorialPay).get
@@ -113,7 +117,11 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
             val cityStr: String = Play.configuration.getString("city-id").get
             val tutorialStreetId: Int = Play.configuration.getInt("city-params.tutorial-street-edge-id." + cityStr).get
             val cityShortName: String = Play.configuration.getString("city-params.city-short-name." + cityStr).get
-            Future.successful(Ok(views.html.audit("Project Sidewalk - Audit", task, mission, region.get, completedMission, nextTempLabelId, Some(user), cityShortName, tutorialStreetId)))
+            if (missionSetProgress.missionType != "audit") {
+              Future.successful(Redirect("/validate"))
+            } else {
+              Future.successful(Ok(views.html.audit("Project Sidewalk - Audit", task, mission, region.get, missionSetProgress.numComplete, completedMission, nextTempLabelId, Some(user), cityShortName, tutorialStreetId)))
+            }
         }
       // For anonymous users.
       case None =>
@@ -155,6 +163,10 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
             val mission: Mission =
               MissionTable.resumeOrCreateNewAuditMission(userId, regionId, payPerMeter, tutorialPay).get
 
+            val missionSetProgress: MissionSetProgress =
+              if (role == "Turker") MissionTable.getProgressOnMissionSet(user.username)
+              else MissionTable.defaultAuditMissionSetProgress
+
             // If there is a partially completed task in this mission, get that, o/w make a new one.
             val task: Option[NewTask] =
               if (mission.currentAuditTaskId.isDefined)
@@ -170,7 +182,11 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
             val cityStr: String = Play.configuration.getString("city-id").get
             val tutorialStreetId: Int = Play.configuration.getInt("city-params.tutorial-street-edge-id." + cityStr).get
             val cityShortName: String = Play.configuration.getString("city-params.city-short-name." + cityStr).get
-            Future.successful(Ok(views.html.audit("Project Sidewalk - Audit", task, mission, namedRegion, completedMission, nextTempLabelId, Some(user), cityShortName, tutorialStreetId)))
+            if (missionSetProgress.missionType != "audit") {
+              Future.successful(Redirect("/validate"))
+            } else {
+              Future.successful(Ok(views.html.audit("Project Sidewalk - Audit", task, mission, namedRegion, missionSetProgress.numComplete, completedMission, nextTempLabelId, Some(user), cityShortName, tutorialStreetId)))
+            }
           case None =>
             Logger.error(s"Tried to audit region $regionId, but there is no neighborhood with that id.")
             Future.successful(Redirect("/audit"))
@@ -218,8 +234,9 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
               // Check if they have already completed an audit mission. We send them to /validate after their first audit
               // mission, but only after every third audit mission after that.
               val completedMission: Boolean = MissionTable.countCompletedMissions(user.userId, missionType = "audit") > 0
+              val missionSetProgress: MissionSetProgress = MissionTable.defaultAuditMissionSetProgress
 
-              Future.successful(Ok(views.html.audit("Project Sidewalk - CV Audit", task, m, r, completedMission, nextTempLabelId, Some(user), cityShortName, tutorialStreetId, enableCVGroundTruthLabelingMode = true)))
+              Future.successful(Ok(views.html.audit("Project Sidewalk - CV Audit", task, m, r, missionSetProgress.numComplete, completedMission, nextTempLabelId, Some(user), cityShortName, tutorialStreetId, enableCVGroundTruthLabelingMode = true)))
             case (Some(r), None) =>
               // If no mission is provided, we render a different page containing a form allowing user to enter
               // panoIds to create a new CV audit mission.
@@ -373,6 +390,10 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
             MissionTable.resumeOrCreateNewAuditMission(userId, regionId, payPerMeter, tutorialPay).get
           val nextTempLabelId: Int = LabelTable.nextTempLabelId(mission.currentAuditTaskId)
 
+          val missionSetProgress: MissionSetProgress =
+            if (role == "Turker") MissionTable.getProgressOnMissionSet(user.username)
+            else MissionTable.defaultAuditMissionSetProgress
+
           // Check if they have already completed an audit mission. We send them to /validate after their first audit
           // mission, but only after every third audit mission after that.
           val completedMission: Boolean = MissionTable.countCompletedMissions(user.userId, missionType = "audit") > 0
@@ -387,7 +408,11 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
           val cityStr: String = Play.configuration.getString("city-id").get
           val tutorialStreetId: Int = Play.configuration.getInt("city-params.tutorial-street-edge-id." + cityStr).get
           val cityShortName: String = Play.configuration.getString("city-params.city-short-name." + cityStr).get
-          Future.successful(Ok(views.html.audit("Project Sidewalk - Audit", Some(task), mission, region, completedMission, nextTempLabelId, Some(user), cityShortName, tutorialStreetId)))
+          if (missionSetProgress.missionType != "audit") {
+            Future.successful(Redirect("/validate"))
+          } else {
+            Future.successful(Ok(views.html.audit("Project Sidewalk - Audit", Some(task), mission, region, missionSetProgress.numComplete, completedMission, nextTempLabelId, Some(user), cityShortName, tutorialStreetId)))
+          }
         }
       case None =>
         Future.successful(Redirect(s"/anonSignUp?url=/audit/street/$streetEdgeId"))
@@ -422,6 +447,10 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
           MissionTable.resumeOrCreateNewAuditMission(userId, region.regionId, payPerMeter, tutorialPay).get
         val nextTempLabelId: Int = LabelTable.nextTempLabelId(mission.currentAuditTaskId)
 
+        val missionSetProgress: MissionSetProgress =
+          if (role == "Turker") MissionTable.getProgressOnMissionSet(user.username)
+          else MissionTable.defaultAuditMissionSetProgress
+
         // Check if they have already completed an audit mission. We send them to /validate after their first audit
         // mission, but only after every third audit mission after that.
         val completedMission: Boolean = MissionTable.countCompletedMissions(user.userId, missionType = "audit") > 0
@@ -429,17 +458,22 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
         val cityStr: String = Play.configuration.getString("city-id").get
         val tutorialStreetId: Int = Play.configuration.getInt("city-params.tutorial-street-edge-id." + cityStr).get
         val cityShortName: String = Play.configuration.getString("city-params.city-short-name." + cityStr).get
-        if(isAdmin(request.identity)){
-          panoId match {
-            case Some(panoId) => Future.successful(Ok(views.html.audit("Project Sidewalk - Audit", Some(task), mission, region, completedMission, nextTempLabelId, Some(user), cityShortName, tutorialStreetId, None, None, Some(panoId))))
-            case None =>
-              (lat, lng) match {
-                case (Some(lat), Some(lng)) => Future.successful(Ok(views.html.audit("Project Sidewalk - Audit", Some(task), mission, region, completedMission, nextTempLabelId, Some(user), cityShortName, tutorialStreetId, Some(lat), Some(lng))))
-                case (_, _) => Future.successful(Ok(views.html.audit("Project Sidewalk - Audit", Some(task), mission, region, completedMission, nextTempLabelId, None, cityShortName, tutorialStreetId)))
-              }
-          }
+
+        if (missionSetProgress.missionType != "audit") {
+          Future.successful(Redirect("/validate"))
         } else {
-          Future.successful(Ok(views.html.audit("Project Sidewalk - Audit", Some(task), mission, region, completedMission, nextTempLabelId, Some(user), cityShortName, tutorialStreetId)))
+          if (isAdmin(request.identity)) {
+            panoId match {
+              case Some(panoId) => Future.successful(Ok(views.html.audit("Project Sidewalk - Audit", Some(task), mission, region, missionSetProgress.numComplete, completedMission, nextTempLabelId, Some(user), cityShortName, tutorialStreetId, None, None, Some(panoId))))
+              case None =>
+                (lat, lng) match {
+                  case (Some(lat), Some(lng)) => Future.successful(Ok(views.html.audit("Project Sidewalk - Audit", Some(task), mission, region, missionSetProgress.numComplete, completedMission, nextTempLabelId, Some(user), cityShortName, tutorialStreetId, Some(lat), Some(lng))))
+                  case (_, _) => Future.successful(Ok(views.html.audit("Project Sidewalk - Audit", Some(task), mission, region, missionSetProgress.numComplete, completedMission, nextTempLabelId, None, cityShortName, tutorialStreetId)))
+                }
+            }
+          } else {
+            Future.successful(Ok(views.html.audit("Project Sidewalk - Audit", Some(task), mission, region, missionSetProgress.numComplete, completedMission, nextTempLabelId, Some(user), cityShortName, tutorialStreetId)))
+          }
         }
       case None => Future.successful(Redirect(s"/anonSignUp?url=/audit/street/$streetEdgeId/location%3Flat=$lat%lng=$lng%3FpanoId=$panoId"))
     }    

--- a/app/controllers/SignUpController.scala
+++ b/app/controllers/SignUpController.scala
@@ -238,8 +238,8 @@ class SignUpController @Inject() (
         activityLogText = activityLogText + "_reattempt=true"
         WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, activityLogText, timestamp))
 
-        val turker_email: String = workerId + "@sidewalk.mturker.umd.edu"
-        val loginInfo = LoginInfo(CredentialsProvider.ID, turker_email)
+        val turkerEmail: String = workerId + "@sidewalk.mturker.umd.edu"
+        val loginInfo = LoginInfo(CredentialsProvider.ID, turkerEmail)
         userService.retrieve(loginInfo).flatMap {
           case Some(user) => env.authenticatorService.create(loginInfo).flatMap { authenticator =>
             val session: Future[SessionAuthenticator#Value] = turkerSignIn(user, authenticator)
@@ -254,16 +254,16 @@ class SignUpController @Inject() (
 
       case None =>
         // Create a dummy email and password. Keep the username as the workerId.
-        val turker_email: String = workerId + "@sidewalk.mturker.umd.edu"
-        val turker_password: String = hitId + assignmentId + s"${Random.alphanumeric take 16 mkString("")}"
+        val turkerEmail: String = workerId + "@sidewalk.mturker.umd.edu"
+        val turkerPassword: String = hitId + assignmentId + s"${Random.alphanumeric take 16 mkString("")}"
 
-        val loginInfo = LoginInfo(CredentialsProvider.ID, turker_email)
-        val authInfo = passwordHasher.hash(turker_password)
+        val loginInfo = LoginInfo(CredentialsProvider.ID, turkerEmail)
+        val authInfo = passwordHasher.hash(turkerPassword)
         val user = User(
           userId = UUID.randomUUID(),
           loginInfo = loginInfo,
           username = workerId,
-          email = turker_email,
+          email = turkerEmail,
           role = None
         )
 

--- a/app/models/amt/AMTAssignmentTable.scala
+++ b/app/models/amt/AMTAssignmentTable.scala
@@ -36,7 +36,7 @@ object AMTAssignmentTable {
   val TURKER_TUTORIAL_PAY: Double = 1.00D
   val TURKER_PAY_PER_MILE: Double = 5.00D
   val TURKER_PAY_PER_METER: Double = TURKER_PAY_PER_MILE / 1609.34D
-  val TURKER_PAY_PER_LABEL_VALIDATION = 0.0D
+  val TURKER_PAY_PER_LABEL_VALIDATION = 0.012D
   val VOLUNTEER_PAY: Double = 0.0D
 
   def save(asg: AMTAssignment): Int = db.withTransaction { implicit session =>

--- a/app/models/mission/MissionTable.scala
+++ b/app/models/mission/MissionTable.scala
@@ -118,6 +118,9 @@ object MissionTable {
   val normalValidationMissionLabelsToRetrieve: Int = 10
   val rapidValidationMissionLabelsToRetrieve: Int = 19
 
+  val defaultAuditMissionSetProgress: MissionSetProgress = MissionSetProgress("audit", 0)
+  val defaultValidationMissionSetProgress: MissionSetProgress = MissionSetProgress("validation", 0)
+
   implicit val missionConverter = GetResult[Mission](r => {
     val missionId: Int = r.nextInt
     val missionTypeId: Int = r.nextInt
@@ -216,8 +219,7 @@ object MissionTable {
   def getProgressOnMissionSet(username: String): MissionSetProgress = db.withSession { implicit session =>
     val asmt: Option[AMTAssignment] = AMTAssignmentTable.getMostRecentAssignment(username)
     if (asmt.isEmpty) {
-      MissionSetProgressprintln("assignment empty")
-      ("audit", 0)
+      defaultAuditMissionSetProgress
     } else {
       val missionsInThisAsmt: List[String] = missions.filter(m =>
         m.missionEnd > asmt.get.assignmentStart

--- a/app/views/audit.scala.html
+++ b/app/views/audit.scala.html
@@ -7,7 +7,7 @@
 @import play.api.libs.json.Json
 @import views.html.bootstrap._
 
-@(title: String, task: Option[models.audit.NewTask] = None, mission: Mission, region: NamedRegion, hasCompletedMission: Boolean, nextTempLabelId: Int, user: Option[User] = None, cityShortName: String, tutorialStreetId: Int, lat: Option[Double] = None, lng: Option[Double] = None, panoId: Option[String] = None, enableCVGroundTruthLabelingMode: Boolean = false)
+@(title: String, task: Option[models.audit.NewTask] = None, mission: Mission, region: NamedRegion, missionSetProgress: Int, hasCompletedMission: Boolean, nextTempLabelId: Int, user: Option[User] = None, cityShortName: String, tutorialStreetId: Int, lat: Option[Double] = None, lng: Option[Double] = None, panoId: Option[String] = None, enableCVGroundTruthLabelingMode: Boolean = false)
 
 @main(title, Some("/audit")) {
     @navbar(user, Some("/audit"))
@@ -1056,6 +1056,7 @@
             mainParam.nextTemporaryLabelId = @nextTempLabelId;
             mainParam.mission = @Html(mission.toJSON.toString);
             mainParam.tutorialStreetId = @tutorialStreetId;
+            mainParam.missionSetProgress = @missionSetProgress;
             mainParam.hasCompletedAMission = @hasCompletedMission;
 
             svl.main = new Main(mainParam);

--- a/app/views/mobileValidate.scala.html
+++ b/app/views/mobileValidate.scala.html
@@ -7,7 +7,7 @@
 @import play.api.libs.json.JsValue
 @import views.html.bootstrap._
 
-@(title: String, user: Option[User] = None, mission: Option[JsValue], labelList: Option[JsValue], progress: Option[JsValue], hasNextMission: Boolean)
+@(title: String, user: Option[User] = None, mission: Option[JsValue], labelList: Option[JsValue], progress: Option[JsValue], missionSetProgress: Int, hasNextMission: Boolean)
 
 @main(title) {
     <script type="text/javascript" src='@routes.Assets.at("javascripts/SVValidate/build/SVValidate.js")'></script>
@@ -179,6 +179,7 @@
             param.dataStoreUrl = '@routes.ValidationTaskController.post';
             param.beaconDataStoreUrl = param.dataStoreUrl + "Beacon";
             param.hasNextMission = @hasNextMission;
+            param.missionSetProgress = @missionSetProgress;
             param.canvasHeight = window.innerHeight;
             param.canvasWidth = window.innerWidth;
             param.canvasCount = 1;

--- a/app/views/rapidValidation.scala.html
+++ b/app/views/rapidValidation.scala.html
@@ -22,30 +22,9 @@
     <link rel="stylesheet" href='@routes.Assets.at("stylesheets/animate.css")'/>
     <div id="page-loading"><img id="loading-gif" src='@routes.Assets.at("assets/page-load.gif")'/></div>
     <div class="container toolUI" style = "visibility: visible;">
-        @*        TODO this code was removed for issue #1693, search for "#1693" and uncomment all later.@
-        @*        <div id="HIT-expiration-overlay">*@
-        @*            <div class="overlay-text">*@
-        @*                <div id="HIT-expiration-text">*@
-        @*                    <p>*@
-        @*                        <span class="overlay-header">Assignment Expired!</span>*@
-        @*                    </p>*@
-        @*                    <p>*@
-        @*                        You should receive your bonus amount in the next day or two. If you completed the HIT but did*@
-        @*                        not submit your confirmation code on the mturk website, send us an email at*@
-        @*                        <a href="mailto:makeability.sidewalk@@gmail.com">makeability.sidewalk@@gmail.com</a> with your*@
-        @*                        confirmation code (@{models.mission.MissionTable.getMostRecentConfirmationCodeIfCompletedAuditMission(user.get.username).getOrElse("")}).*@
-        @*                    </p>*@
-        @*                </div>*@
-        @*            </div>*@
-        @*        </div>*@
         <div id="svv-application-holder">
             <div id="left-column-control-pane">
                 <div id="left-column-button-holder">
-                    @*                    TODO this code was removed for issue #1693, search for "#1693" and uncomment all later.*@
-                    @*                    <div id="left-column-confirmation-code-button" class="button">*@
-                    @*                        <img src='@routes.Assets.at("javascripts/SVLabel/img/icons/Icon_OrangeCheckmark.png")'  alt="Confirmation Code icon" align="">*@
-                    @*                        Mturk Code*@
-                    @*                    </div>*@
                     <div id="left-column-jump-button" class="button">
                         <img src='@routes.Assets.at("javascripts/SVLabel/img/icons/refresh.png")'  alt="Jump icon" align="">
                         <br>Skip

--- a/app/views/rapidValidation.scala.html
+++ b/app/views/rapidValidation.scala.html
@@ -7,7 +7,7 @@
 @import play.api.libs.json.JsValue
 @import views.html.bootstrap._
 
-@(title: String, user: Option[User] = None, mission: Option[JsValue], labelList: Option[JsValue], progress: Option[JsValue], hasNextMission: Boolean)
+@(title: String, user: Option[User] = None, mission: Option[JsValue], labelList: Option[JsValue], progress: Option[JsValue], missionSetProgress: Int, hasNextMission: Boolean)
 
 @main(title, Some("/validate")) {
     @navbar(user, Some("/validate"))
@@ -404,6 +404,7 @@
             } else {
                 param.dataStoreUrl = '@routes.ValidationTaskController.post';
                 param.hasNextMission = @hasNextMission;
+                param.missionSetProgress = @missionSetProgress;
 
                 // Set information about panorama size (to be used by JS), number of panoramas
                 param.canvasHeight = 130;

--- a/app/views/validation.scala.html
+++ b/app/views/validation.scala.html
@@ -7,7 +7,7 @@
 @import play.api.libs.json.JsValue
 @import views.html.bootstrap._
 
-@(title: String, user: Option[User] = None, mission: Option[JsValue], labelList: Option[JsValue], progress: Option[JsValue], hasNextMission: Boolean)
+@(title: String, user: Option[User] = None, mission: Option[JsValue], labelList: Option[JsValue], progress: Option[JsValue], missionSetProgress: Int, hasNextMission: Boolean)
 
 @main(title, Some("/validate")) {
     @navbar(user, Some("/validate"))
@@ -287,6 +287,7 @@
             param.dataStoreUrl = '@routes.ValidationTaskController.post';
             param.beaconDataStoreUrl = param.dataStoreUrl + "Beacon";
             param.hasNextMission = @hasNextMission;
+            param.missionSetProgress = @missionSetProgress;
             param.canvasHeight = 440;
             param.canvasWidth = 720;
             param.canvasCount = 1;

--- a/app/views/validation.scala.html
+++ b/app/views/validation.scala.html
@@ -22,30 +22,28 @@
     <link rel="stylesheet" href='@routes.Assets.at("stylesheets/animate.css")'/>
     <div id="page-loading"><img id="loading-gif" src='@routes.Assets.at("assets/page-load.gif")'/></div>
     <div class="container toolUI" style = "visibility: visible;">
-@*        TODO this code was removed for issue #1693, search for "#1693" and uncomment all later.@
-@*        <div id="HIT-expiration-overlay">*@
-@*            <div class="overlay-text">*@
-@*                <div id="HIT-expiration-text">*@
-@*                    <p>*@
-@*                        <span class="overlay-header">Assignment Expired!</span>*@
-@*                    </p>*@
-@*                    <p>*@
-@*                        You should receive your bonus amount in the next day or two. If you completed the HIT but did*@
-@*                        not submit your confirmation code on the mturk website, send us an email at*@
-@*                        <a href="mailto:makeability.sidewalk@@gmail.com">makeability.sidewalk@@gmail.com</a> with your*@
-@*                        confirmation code (@{models.mission.MissionTable.getMostRecentConfirmationCodeIfCompletedAuditMission(user.get.username).getOrElse("")}).*@
-@*                    </p>*@
-@*                </div>*@
-@*            </div>*@
-@*        </div>*@
+        <div id="HIT-expiration-overlay">
+            <div class="overlay-text">
+                <div id="HIT-expiration-text">
+                    <p>
+                        <span class="overlay-header">Assignment Expired!</span>
+                    </p>
+                    <p>
+                        You should receive your bonus amount in the next day or two. If you completed the HIT but did
+                        not submit your confirmation code on the mturk website, send us an email at
+                        <a href="mailto:makeability.sidewalk@@gmail.com">makeability.sidewalk@@gmail.com</a> with your
+                        confirmation code (@{models.mission.MissionTable.getMostRecentConfirmationCodeIfCompletedAuditMission(user.get.username).getOrElse("")}).
+                    </p>
+                </div>
+            </div>
+        </div>
         <div id="svv-application-holder">
             <div id="left-column-control-pane">
                 <div id="left-column-button-holder">
-@*                    TODO this code was removed for issue #1693, search for "#1693" and uncomment all later.*@
-@*                    <div id="left-column-confirmation-code-button" class="button">*@
-@*                        <img src='@routes.Assets.at("javascripts/SVLabel/img/icons/Icon_OrangeCheckmark.png")'  alt="Confirmation Code icon" align="">*@
-@*                        Mturk Code*@
-@*                    </div>*@
+                    <div id="left-column-confirmation-code-button" class="button">
+                        <img src='@routes.Assets.at("javascripts/SVLabel/img/icons/Icon_OrangeCheckmark.png")'  alt="Confirmation Code icon" align="">
+                        Mturk Code
+                    </div>
                     <div id="left-column-jump-button" class="button">
                         <img src='@routes.Assets.at("javascripts/SVLabel/img/icons/refresh.png")'  alt="Jump icon" align="">
                         <br>Skip
@@ -278,8 +276,8 @@
 
         let hitExpired = false;
         @if(user && user.get.role.getOrElse("") == "Turker") {
-            let msRemaining = @AMTAssignmentTable.getMsLeftOnMostRecentAsmt(user.get.username);
-            if (msRemaining < 0) {
+            let msRemainingInHIT = @AMTAssignmentTable.getMsLeftOnMostRecentAsmt(user.get.username);
+            if (msRemainingInHIT < 0) {
                 hitExpired = true;
             }
         }

--- a/app/views/validation.scala.html
+++ b/app/views/validation.scala.html
@@ -220,44 +220,43 @@
         var param = {};
 
         // Hide confirmation code if turker hasn't completed a mission.
-        // TODO this code was removed for issue #1693, search for "#1693" and uncomment all later.
-@*        @if(user) {*@
-@*            @if(user.get.role.getOrElse("") == "Turker") {*@
-@*                svv.assignmentId = "@AMTAssignmentTable.getMostRecentAssignmentId(user.get.username)";*@
-@*                svv.amtAssignmentId = @AMTAssignmentTable.getMostRecentAMTAssignmentId(user.get.username);*@
-@*                svv.confirmationCode = "@AMTAssignmentTable.getConfirmationCode(user.get.username,AMTAssignmentTable.getMostRecentAssignmentId(user.get.username))";*@
-@*                @if(!MissionTable.hasCompletedAuditMissionInThisAmtAssignment(user.get.username)) {*@
-@*                    $("#left-column-confirmation-code-button").css('visibility', "hidden");*@
-@*                } else {*@
-@*                    $("#left-column-confirmation-code-button").css('visibility', "");*@
-@*                    $("#left-column-confirmation-code-button").attr('data-toggle','popover');*@
-@*                    $("#left-column-confirmation-code-button").attr('title','Submit this code for HIT verification on Amazon Mechanical Turk');*@
-@*                    $("#left-column-confirmation-code-button").attr('data-content', svv.confirmationCode);*@
-@*                    $("#left-column-confirmation-code-button").popover();*@
+        @if(user) {
+            @if(user.get.role.getOrElse("") == "Turker") {
+                svv.assignmentId = "@AMTAssignmentTable.getMostRecentAssignmentId(user.get.username)";
+                svv.amtAssignmentId = @AMTAssignmentTable.getMostRecentAMTAssignmentId(user.get.username);
+                svv.confirmationCode = "@AMTAssignmentTable.getConfirmationCode(user.get.username,AMTAssignmentTable.getMostRecentAssignmentId(user.get.username))";
+                @if(!MissionTable.hasCompletedAuditMissionInThisAmtAssignment(user.get.username)) {
+                    $("#left-column-confirmation-code-button").css('visibility', 'hidden');
+                } else {
+                    $("#left-column-confirmation-code-button").css('visibility', "");
+                    $("#left-column-confirmation-code-button").attr('data-toggle','popover');
+                    $("#left-column-confirmation-code-button").attr('title','Submit this code for HIT verification on Amazon Mechanical Turk');
+                    $("#left-column-confirmation-code-button").attr('data-content', svv.confirmationCode);
+                    $("#left-column-confirmation-code-button").popover();
 
-@*                    //Hide the confirmation popover on clicking the background*@
-@*                    //https://stackoverflow.com/questions/11703093/how-to-dismiss-a-twitter-bootstrap-popover-by-clicking-outside*@
+                    //Hide the confirmation popover on clicking the background
+                    //https://stackoverflow.com/questions/11703093/how-to-dismiss-a-twitter-bootstrap-popover-by-clicking-outside
 
-@*                    $(document).on('click', function(e) {*@
-@*                        $("#left-column-confirmation-code-button").each(function () {*@
-@*                            //the 'is' for buttons that trigger popups*@
-@*                            //the 'has' for icons within a button that triggers a popup*@
-@*                            if (!$(this).is(e.target) && $(this).has(e.target).length === 0 && $('.popover').has(e.target).length === 0) {*@
-@*                                (($(this).popover('hide').data('bs.popover')||{}).inState||{}).click = false*@
-@*                            }*@
+                    $(document).on('click', function(e) {
+                        $("#left-column-confirmation-code-button").each(function () {
+                            //the 'is' for buttons that trigger popups
+                            //the 'has' for icons within a button that triggers a popup
+                            if (!$(this).is(e.target) && $(this).has(e.target).length === 0 && $('.popover').has(e.target).length === 0) {
+                                (($(this).popover('hide').data('bs.popover')||{}).inState||{}).click = false
+                            }
 
-@*                        });*@
-@*                    });*@
-@*                }*@
-@*                $("#current-mission-reward").show();*@
-@*                $("#total-mission-reward").show();*@
-@*                $("#modal-mission-reward-text").show();*@
-@*            } else {*@
-@*                $("#left-column-confirmation-code-button").css('visibility', "hidden");*@
-@*            }*@
-@*        } else{*@
-@*            $("#left-column-confirmation-code-button").css('visibility', "hidden");*@
-@*        }*@
+                        });
+                    });
+                }
+                $("#current-mission-reward").show();
+                $("#total-mission-reward").show();
+                $("#modal-mission-reward-text").show();
+            } else {
+                $("#left-column-confirmation-code-button").css('visibility', "hidden");
+            }
+        } else{
+            $("#left-column-confirmation-code-button").css('visibility', "hidden");
+        }
 
         // Store user object.
         let userParam = {};

--- a/public/javascripts/SVLabel/src/SVLabel/Main.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Main.js
@@ -24,7 +24,7 @@ function Main (params) {
     svl.isOnboarding = function () {
         return svl.onboarding != null && svl.onboarding.isOnboarding();
     };
-    svl.missionsCompleted = 0;
+    svl.missionsCompleted = params.missionSetProgress;
     svl.canvasWidth = 720;
     svl.canvasHeight = 480;
     svl.svImageHeight = 6656;

--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
@@ -123,8 +123,9 @@ function ModalMissionComplete (svl, missionContainer, missionModel, taskContaine
     };
 
     this._closeModal = function (e) {
-        if ((!svl.userHasCompletedAMission && svl.missionsCompleted === 1) || svl.missionsCompleted === 3) {
-            // Load the validation page since they've either completed their audit first mission or just finished 3.
+        if ((self._userModel.getUser().getProperty("role") !== "Turker" && !svl.userHasCompletedAMission && svl.missionsCompleted === 1) || svl.missionsCompleted === 3) {
+            // Load the validation page since they are either a non-turker who completed their audit first mission or
+            // they are anyone that just finished 3 audit missions.
             window.location.replace('/validate');
         }
         else if (svl.neighborhoodModel.isNeighborhoodCompleted) {

--- a/public/javascripts/SVValidate/src/Main.js
+++ b/public/javascripts/SVValidate/src/Main.js
@@ -153,9 +153,7 @@ function Main (param) {
 
         svv.modalComment = new ModalComment(svv.ui.modalComment);
         svv.modalMission = new ModalMission(svv.ui.modalMission, svv.user);
-        // TODO this code was removed for issue #1693, search for "#1693" and uncomment all later.
-        // svv.modalMissionComplete = new ModalMissionComplete(svv.ui.modalMissionComplete, svv.user, svv.ui.modalConfirmation.confirmationCode);
-        svv.modalMissionComplete = new ModalMissionComplete(svv.ui.modalMissionComplete, svv.user, null);
+        svv.modalMissionComplete = new ModalMissionComplete(svv.ui.modalMissionComplete, svv.user, svv.ui.modalConfirmation.confirmationCode);
         svv.modalSkip = new ModalSkip(svv.ui.modalSkip);
         svv.modalInfo = new ModalInfo(svv.ui.modalInfo);
         svv.modalLandscape = new ModalLandscape(svv.ui.modalLandscape);

--- a/public/javascripts/SVValidate/src/Main.js
+++ b/public/javascripts/SVValidate/src/Main.js
@@ -11,7 +11,7 @@ function Main (param) {
     svv.canvasHeight = param.canvasHeight;
     svv.canvasWidth = param.canvasWidth;
 
-    svv.missionsCompleted = 0;
+    svv.missionsCompleted = param.missionSetProgress;
 
     // Maps label types to label names
     svv.labelNames = {


### PR DESCRIPTION
Resolves #1915 

Turkers will now be required to go from 3 audit missions to 3 validation missions, and vice versa. And they should not be able to get around it by clicking the "start validating" or "start exploring" like other users can right now. Nothing should be changed for normal users.

This also adds a payment amount of $0.12 per validation mission that is shown on the validation page.

This also prevents turkers from visiting the /rapidValidate or /mobile endpoints.