### PR TITLE
1906 add validation user overview stats

### DIFF
--- a/app/models/daos/UserDAOImpl.scala
+++ b/app/models/daos/UserDAOImpl.scala
@@ -255,7 +255,7 @@ object UserDAOImpl {
     * @param taskCompleted
     * @return
     */
-  def countUsersContributed(roles: List[String], taskCompleted: Boolean): Int = db.withSession { implicit session =>
+  def countAuditUsersContributed(roles: List[String], taskCompleted: Boolean): Int = db.withSession { implicit session =>
 
     val tasks = if (taskCompleted) auditTaskTable.filter(_.completed) else auditTaskTable
 
@@ -280,8 +280,8 @@ object UserDAOImpl {
     * @param taskCompleted
     * @return
     */
-  def countResearchersContributed(taskCompleted: Boolean): Int = db.withSession { implicit session =>
-    countUsersContributed(List("Researcher", "Administrator", "Owner"), taskCompleted)
+  def countAuditResearchersContributed(taskCompleted: Boolean): Int = db.withSession { implicit session =>
+    countAuditUsersContributed(List("Researcher", "Administrator", "Owner"), taskCompleted)
   }
 
   /**
@@ -290,8 +290,8 @@ object UserDAOImpl {
     * @param taskCompleted
     * @return
     */
-  def countAllUsersContributed(taskCompleted: Boolean): Int = db.withSession { implicit session =>
-    countUsersContributed(roleTable.map(_.role).list, taskCompleted)
+  def countAllAuditUsersContributed(taskCompleted: Boolean): Int = db.withSession { implicit session =>
+    countAuditUsersContributed(roleTable.map(_.role).list, taskCompleted)
   }
 
   /**
@@ -302,7 +302,7 @@ object UserDAOImpl {
     * @param role
     * @return
     */
-  def countUsersContributedToday(role: String): Int = db.withSession { implicit session =>
+  def countAuditUsersContributedToday(role: String): Int = db.withSession { implicit session =>
     val countQuery = Q.query[String, Int](
       """SELECT COUNT(DISTINCT(audit_task.user_id))
         |FROM sidewalk.audit_task
@@ -322,10 +322,10 @@ object UserDAOImpl {
     *
     * @return
     */
-  def countResearchersContributedToday: Int = db.withSession { implicit session =>
-    countUsersContributedToday("Researcher") +
-      countUsersContributedToday("Administrator") +
-      countUsersContributedToday("Owner")
+  def countAuditResearchersContributedToday: Int = db.withSession { implicit session =>
+    countAuditUsersContributedToday("Researcher") +
+      countAuditUsersContributedToday("Administrator") +
+      countAuditUsersContributedToday("Owner")
   }
 
   /**
@@ -333,11 +333,11 @@ object UserDAOImpl {
     *
     * @return
     */
-  def countAllUsersContributedToday: Int = db.withSession { implicit session =>
-    countUsersContributedToday("Registered") +
-      countUsersContributedToday("Anonymous") +
-      countUsersContributedToday("Turker") +
-      countResearchersContributedToday
+  def countAllAuditUsersContributedToday: Int = db.withSession { implicit session =>
+    countAuditUsersContributedToday("Registered") +
+      countAuditUsersContributedToday("Anonymous") +
+      countAuditUsersContributedToday("Turker") +
+      countAuditResearchersContributedToday
   }
 
   /**
@@ -348,7 +348,7 @@ object UserDAOImpl {
     * @param role
     * @return
     */
-  def countUsersContributedYesterday(role: String): Int = db.withSession { implicit session =>
+  def countAuditUsersContributedYesterday(role: String): Int = db.withSession { implicit session =>
     val countQuery = Q.query[String, Int](
       """SELECT COUNT(DISTINCT(audit_task.user_id))
         |FROM sidewalk.audit_task
@@ -368,10 +368,10 @@ object UserDAOImpl {
     *
     * @return
     */
-  def countResearchersContributedYesterday: Int = db.withSession { implicit session =>
-    countUsersContributedYesterday("Researcher") +
-      countUsersContributedYesterday("Administrator") +
-      countUsersContributedYesterday("Owner")
+  def countAuditResearchersContributedYesterday: Int = db.withSession { implicit session =>
+    countAuditUsersContributedYesterday("Researcher") +
+      countAuditUsersContributedYesterday("Administrator") +
+      countAuditUsersContributedYesterday("Owner")
   }
 
   /**
@@ -379,11 +379,11 @@ object UserDAOImpl {
     *
     * @return
     */
-  def countAllUsersContributedYesterday: Int = db.withSession { implicit session =>
-    countUsersContributedYesterday("Registered") +
-      countUsersContributedYesterday("Anonymous") +
-      countUsersContributedYesterday("Turker") +
-      countResearchersContributedYesterday
+  def countAllAuditUsersContributedYesterday: Int = db.withSession { implicit session =>
+    countAuditUsersContributedYesterday("Registered") +
+      countAuditUsersContributedYesterday("Anonymous") +
+      countAuditUsersContributedYesterday("Turker") +
+      countAuditResearchersContributedYesterday
   }
 
   /**

--- a/app/models/mission/MissionTable.scala
+++ b/app/models/mission/MissionTable.scala
@@ -97,6 +97,11 @@ object MissionTable {
   }
   val auditMissions = missions.filter(_.missionTypeId === auditMissionTypeId)
 
+  val validationMissionTypeId: Int = db.withSession { implicit session =>
+    missionTypes.filter(_.missionType === "validation").map(_.missionTypeId).list.head
+  }
+  val validationMissions = missions.filter(_.missionTypeId === validationMissionTypeId)
+
   val METERS_TO_MILES: Float = 0.000621371F
 
   val users = TableQuery[UserTable]

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -55,8 +55,9 @@
                                 <th>Today</th>
                                 <th>Yesterday</th>
                             </tr>
+
                             <tr>
-                                <th>Total Users</th>
+                                <th>Total Audit Users</th>
                                 <th>@UserDAOImpl.countAllUsersContributed(false) (@UserDAOImpl.countAllUsersContributed(true))</th>
                                 <th>@UserDAOImpl.countAllUsersContributedToday</th>
                                 <th>@UserDAOImpl.countAllUsersContributedYesterday</th>
@@ -85,6 +86,7 @@
                                 <td>@UserDAOImpl.countResearchersContributedToday</td>
                                 <td>@UserDAOImpl.countResearchersContributedYesterday</td>
                             </tr>
+
                             <tr>
                                 <th>Total Labels</th>
                                 <th>@LabelTable.countLabels</th>
@@ -134,6 +136,44 @@
                                 <td>@LabelTable.countYesterdayLabelsBasedOnType("Occlusion")</td>
                             </tr>
 
+                            <tr>
+                                <th>Audits</th>
+                                <th>@AuditTaskTable.countCompletedAudits</th>
+                                <th>@AuditTaskTable.countCompletedAuditsToday</th>
+                                <th>@AuditTaskTable.countCompletedAuditsYesterday</th>
+                            </tr>
+
+                            <tr>
+                                <th>Total Validation Users</th>
+                                <th>@UserDAOImpl.countAllValidationUsersContributed(false) (@UserDAOImpl.countAllValidationUsersContributed(true))</th>
+                                <th>@UserDAOImpl.countAllValidationUsersContributedToday</th>
+                                <th>@UserDAOImpl.countAllValidationUsersContributedYesterday</th>
+                            </tr>
+                            <tr style="font-size: 90%;">
+                                <td style="padding-left: 30px">Registered</td>
+                                <td>@UserDAOImpl.countValidationUsersContributed(List("Registered"), false) (@UserDAOImpl.countValidationUsersContributed(List("Registered"), true))</td>
+                                <td>@UserDAOImpl.countValidationUsersContributedToday("Registered")</td>
+                                <td>@UserDAOImpl.countValidationUsersContributedYesterday("Registered")</td>
+                            </tr>
+                            <tr style="font-size: 90%;">
+                                <td style="padding-left: 30px">Anonymous</td>
+                                <td>@UserDAOImpl.countValidationUsersContributed(List("Anonymous"), false) (@UserDAOImpl.countValidationUsersContributed(List("Anonymous"), true))</td>
+                                <td>@UserDAOImpl.countValidationUsersContributedToday("Anonymous")</td>
+                                <td>@UserDAOImpl.countValidationUsersContributedYesterday("Anonymous")</td>
+                            </tr>
+                            <tr style="font-size: 90%;">
+                                <td style="padding-left: 30px">Turkers</td>
+                                <td>@UserDAOImpl.countValidationUsersContributed(List("Turker"), false) (@UserDAOImpl.countValidationUsersContributed(List("Turker"), true))</td>
+                                <td>@UserDAOImpl.countValidationUsersContributedToday("Turker")</td>
+                                <td>@UserDAOImpl.countValidationUsersContributedYesterday("Turker")</td>
+                            </tr>
+                            <tr style="font-size: 90%;">
+                                <td style="padding-left: 30px">Researchers</td>
+                                <td>@UserDAOImpl.countValidationResearchersContributed(false) (@UserDAOImpl.countValidationResearchersContributed(true))</td>
+                                <td>@UserDAOImpl.countValidationResearchersContributedToday</td>
+                                <td>@UserDAOImpl.countValidationResearchersContributedYesterday</td>
+                            </tr>
+
                             <tr style="font-size: 90%;">
                                 <th>Total Validations</th>
                                 <td>@LabelValidationTable.countValidations</td>
@@ -161,17 +201,11 @@
                                 <td>@LabelValidationTable.countTodayValidationsBasedOnResult(3) (@("%.0f".format(LabelValidationTable.countTodayValidationsBasedOnResult(3) * 100.0 / LabelValidationTable.countTodayValidations))%)</td>
                                 <td>@LabelValidationTable.countYesterdayValidationsBasedOnResult(3) (@("%.0f".format(LabelValidationTable.countYesterdayValidationsBasedOnResult(3) * 100.0 / LabelValidationTable.countYesterdayValidations))%)</td>
                             </tr>
-
-                            <tr>
-                                <th>Audits</th>
-                                <th>@AuditTaskTable.countCompletedAudits</th>
-                                <th>@AuditTaskTable.countCompletedAuditsToday</th>
-                                <th>@AuditTaskTable.countCompletedAuditsYesterday</th>
-                            </tr>
                         </table>
-                        <sup>*</sup>Numbers in the parenthesis represent #users who have completed at least 1 task <br/>
-                        Numbers outside the parenthesis represent total #users who opened the audit tool
-                        regardless of finishing a task
+                        <sup>*</sup>Number of users in the parentheses represent #users who have completed at least 1
+                        audit task (in the case of # of audit users) or have validated at least one label (in the case
+                        of # of validation users). Numbers outside the parenthesis represent total #users who opened
+                        the audit tool regardless of finishing a task.
                     </div>
                     <div class="col-lg-5">
                         <h1>Coverage</h1>

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -58,33 +58,33 @@
 
                             <tr>
                                 <th>Total Audit Users</th>
-                                <th>@UserDAOImpl.countAllUsersContributed(false) (@UserDAOImpl.countAllUsersContributed(true))</th>
-                                <th>@UserDAOImpl.countAllUsersContributedToday</th>
-                                <th>@UserDAOImpl.countAllUsersContributedYesterday</th>
+                                <th>@UserDAOImpl.countAllAuditUsersContributed(false) (@UserDAOImpl.countAllAuditUsersContributed(true))</th>
+                                <th>@UserDAOImpl.countAllAuditUsersContributedToday</th>
+                                <th>@UserDAOImpl.countAllAuditUsersContributedYesterday</th>
                             </tr>
                             <tr style="font-size: 90%;">
                                 <td style="padding-left: 30px">Registered</td>
-                                <td>@UserDAOImpl.countUsersContributed(List("Registered"), false) (@UserDAOImpl.countUsersContributed(List("Registered"), true))</td>
-                                <td>@UserDAOImpl.countUsersContributedToday("Registered")</td>
-                                <td>@UserDAOImpl.countUsersContributedYesterday("Registered")</td>
+                                <td>@UserDAOImpl.countAuditUsersContributed(List("Registered"), false) (@UserDAOImpl.countAuditUsersContributed(List("Registered"), true))</td>
+                                <td>@UserDAOImpl.countAuditUsersContributedToday("Registered")</td>
+                                <td>@UserDAOImpl.countAuditUsersContributedYesterday("Registered")</td>
                             </tr>
                             <tr style="font-size: 90%;">
                                 <td style="padding-left: 30px">Anonymous</td>
-                                <td>@UserDAOImpl.countUsersContributed(List("Anonymous"), false) (@UserDAOImpl.countUsersContributed(List("Anonymous"), true))</td>
-                                <td>@UserDAOImpl.countUsersContributedToday("Anonymous")</td>
-                                <td>@UserDAOImpl.countUsersContributedYesterday("Anonymous")</td>
+                                <td>@UserDAOImpl.countAuditUsersContributed(List("Anonymous"), false) (@UserDAOImpl.countAuditUsersContributed(List("Anonymous"), true))</td>
+                                <td>@UserDAOImpl.countAuditUsersContributedToday("Anonymous")</td>
+                                <td>@UserDAOImpl.countAuditUsersContributedYesterday("Anonymous")</td>
                             </tr>
                             <tr style="font-size: 90%;">
                                 <td style="padding-left: 30px">Turkers</td>
-                                <td>@UserDAOImpl.countUsersContributed(List("Turker"), false) (@UserDAOImpl.countUsersContributed(List("Turker"), true))</td>
-                                <td>@UserDAOImpl.countUsersContributedToday("Turker")</td>
-                                <td>@UserDAOImpl.countUsersContributedYesterday("Turker")</td>
+                                <td>@UserDAOImpl.countAuditUsersContributed(List("Turker"), false) (@UserDAOImpl.countAuditUsersContributed(List("Turker"), true))</td>
+                                <td>@UserDAOImpl.countAuditUsersContributedToday("Turker")</td>
+                                <td>@UserDAOImpl.countAuditUsersContributedYesterday("Turker")</td>
                             </tr>
                             <tr style="font-size: 90%;">
                                 <td style="padding-left: 30px">Researchers</td>
-                                <td>@UserDAOImpl.countResearchersContributed(false) (@UserDAOImpl.countResearchersContributed(true))</td>
-                                <td>@UserDAOImpl.countResearchersContributedToday</td>
-                                <td>@UserDAOImpl.countResearchersContributedYesterday</td>
+                                <td>@UserDAOImpl.countAuditResearchersContributed(false) (@UserDAOImpl.countAuditResearchersContributed(true))</td>
+                                <td>@UserDAOImpl.countAuditResearchersContributedToday</td>
+                                <td>@UserDAOImpl.countAuditResearchersContributedYesterday</td>
                             </tr>
 
                             <tr>


### PR DESCRIPTION
Resolves #1906 

Adds validation user stats to the overview tab on the admin page.

Before
![admin-overview-before](https://user-images.githubusercontent.com/6518824/66348017-67af5780-e90a-11e9-9659-ff80e27a1971.png)

After
![admin-overview-after](https://user-images.githubusercontent.com/6518824/66348167-c379e080-e90a-11e9-821d-2f2e911de0cb.png)
