### PR TITLE
Changes how turkers are forced b/w audits and validations

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/data/Form.js
+++ b/public/javascripts/SVLabel/src/SVLabel/data/Form.js
@@ -253,6 +253,12 @@ function Form (labelContainer, missionModel, missionContainer, navigationModel, 
                     var taskId = result.audit_task_id;
                     task.setProperty("auditTaskId", taskId);
                     svl.tracker.setAuditTaskID(taskId);
+
+                    // If the back-end says it is time to switch to validations, then do it immediately (mostly to
+                    // prevent turkers from modifying JS variables to prevent switching to validation).
+                    if (result.switch_to_validation) window.location.replace('/validate');
+
+                    // If a new mission was sent, create an object for it on the front-end.
                     if (result.mission) missionModel.createAMission(result.mission);
                 }
             },

--- a/public/javascripts/SVValidate/src/data/Form.js
+++ b/public/javascripts/SVValidate/src/data/Form.js
@@ -66,6 +66,11 @@ function Form(url, beaconUrl) {
             dataType: 'json',
             success: function (result) {
                 if (result) {
+
+                    // If the back-end says it is time to switch to auditing, then do it immediately (mostly to
+                    // prevent turkers from modifying JS variables to prevent switching to auditing).
+                    if (result.switch_to_auditing) window.location.replace('/audit');
+
                     // If a mission was returned after posting data, create a new mission.
                     if (result.hasMissionAvailable) {
                         if (result.mission) {


### PR DESCRIPTION
Resolves #1915 

This modifies how we force turkers between the audit and validation pages. We now rely more on the back-end to decide that it is time to switch between the two. This should prevent any errors we may have been making on the front-end, and prevent users from being able to just modify JavaScript variables to continue doing the types of missions they want.