### PR TITLE
LabelMap MVP

### DIFF
--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -77,10 +77,10 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
   // JSON APIs
 
   /**
-    * Get a list of all labels
-    *
-    * @return
-    */
+   * Get a list of all labels
+   *
+   * @return
+   */
   def getAllLabels = UserAwareAction.async { implicit request =>
     if (isAdmin(request.identity)) {
       val labels = LabelTable.selectLocationsAndSeveritiesOfLabels
@@ -100,6 +100,27 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
     } else {
       Future.successful(Redirect("/"))
     }
+  }
+
+  /**
+   * Get a list of all labels
+   *
+   * @return
+   */
+  def getAllLabelsForLabelMap = UserAwareAction.async { implicit request =>
+    val labels = LabelTable.selectLocationsAndSeveritiesOfLabels
+    val features: List[JsObject] = labels.map { label =>
+      val point = geojson.Point(geojson.LatLng(label.lat.toDouble, label.lng.toDouble))
+      val properties = Json.obj(
+        "label_id" -> label.labelId,
+        "gsv_panorama_id" -> label.gsvPanoramaId,
+        "label_type" -> label.labelType,
+        "severity" -> label.severity
+      )
+      Json.obj("type" -> "Feature", "geometry" -> point, "properties" -> properties)
+    }
+    val featureCollection = Json.obj("type" -> "FeatureCollection", "features" -> features)
+    Future.successful(Ok(featureCollection))
   }
 
   /**

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -351,17 +351,37 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
     }
   }
 
-  def getLabelData(labelId: Int) = UserAwareAction.async { implicit request =>
+  /**
+   * Get metadata for a given label ID (for admins; includes personal identifiers like username).
+   * @param labelId
+   * @return
+   */
+  def getAdminLabelData(labelId: Int) = UserAwareAction.async { implicit request =>
     if (isAdmin(request.identity)) {
       LabelPointTable.find(labelId) match {
         case Some(labelPointObj) =>
           val labelMetadata: LabelMetadata = LabelTable.getLabelMetadata(labelId)
-          val labelMetadataJson: JsObject = LabelTable.labelMetadataToJson(labelMetadata)
+          val labelMetadataJson: JsObject = LabelTable.labelMetadataToJsonAdmin(labelMetadata)
           Future.successful(Ok(labelMetadataJson))
         case _ => Future.successful(Ok(Json.obj("error" -> "no such label")))
       }
     } else {
       Future.successful(Redirect("/"))
+    }
+  }
+
+  /**
+   * Get metadata for a given label ID (excludes personal identifiers like username).
+   * @param labelId
+   * @return
+   */
+  def getLabelData(labelId: Int) = UserAwareAction.async { implicit request =>
+    LabelPointTable.find(labelId) match {
+      case Some(labelPointObj) =>
+        val labelMetadata: LabelMetadata = LabelTable.getLabelMetadata(labelId)
+        val labelMetadataJson: JsObject = LabelTable.labelMetadataToJson(labelMetadata)
+        Future.successful(Ok(labelMetadataJson))
+      case _ => Future.successful(Ok(Json.obj("error" -> "no such label")))
     }
   }
 

--- a/app/controllers/ApplicationController.scala
+++ b/app/controllers/ApplicationController.scala
@@ -303,10 +303,10 @@ class ApplicationController @Inject() (implicit val env: Environment[User, Sessi
   }
 
   /**
-    * Returns the results page that contains a cool visualization.
-    *
-    * @return
-    */
+   * Returns the results page that contains a cool visualization.
+   *
+   * @return
+   */
   def results = UserAwareAction.async { implicit request =>
     request.identity match {
       case Some(user) =>
@@ -317,6 +317,24 @@ class ApplicationController @Inject() (implicit val env: Environment[User, Sessi
         Future.successful(Ok(views.html.results("Project Sidewalk - Explore Accessibility", Some(user))))
       case None =>
         Future.successful(Redirect("/anonSignUp?url=/results"))
+    }
+  }
+
+  /**
+   * Returns the labelmap page that contains a cool visualization.
+   *
+   * @return
+   */
+  def labelMap = UserAwareAction.async { implicit request =>
+    request.identity match {
+      case Some(user) =>
+        val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
+        val ipAddress: String = request.remoteAddress
+
+        WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, "Visit_Results", timestamp))
+        Future.successful(Ok(views.html.labelMap("Project Sidewalk - Explore Accessibility", Some(user))))
+      case None =>
+        Future.successful(Redirect("/anonSignUp?url=/labelmap"))
     }
   }
 

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -754,7 +754,7 @@ object LabelTable {
 //                           timestamp: java.sql.Timestamp,
 //                           labelTypeKey:String, labelTypeValue: String, severity: Option[Int],
 //                           temporary: Boolean, description: Option[String])
-  def labelMetadataToJson(labelMetadata: LabelMetadata): JsObject = {
+  def labelMetadataToJsonAdmin(labelMetadata: LabelMetadata): JsObject = {
     Json.obj(
       "label_id" -> labelMetadata.labelId,
       "gsv_panorama_id" -> labelMetadata.gsvPanoramaId,
@@ -769,6 +769,28 @@ object LabelTable {
       "audit_task_id" -> labelMetadata.auditTaskId,
       "user_id" -> labelMetadata.userId,
       "username" -> labelMetadata.username,
+      "timestamp" -> labelMetadata.timestamp,
+      "label_type_key" -> labelMetadata.labelTypeKey,
+      "label_type_value" -> labelMetadata.labelTypeValue,
+      "severity" -> labelMetadata.severity,
+      "temporary" -> labelMetadata.temporary,
+      "description" -> labelMetadata.description,
+      "tags" -> labelMetadata.tags
+    )
+  }
+  // Has the label metadata excluding username, user_id, and audit_task_id.
+  def labelMetadataToJson(labelMetadata: LabelMetadata): JsObject = {
+    Json.obj(
+      "label_id" -> labelMetadata.labelId,
+      "gsv_panorama_id" -> labelMetadata.gsvPanoramaId,
+      "tutorial" -> labelMetadata.tutorial,
+      "heading" -> labelMetadata.heading,
+      "pitch" -> labelMetadata.pitch,
+      "zoom" -> labelMetadata.zoom,
+      "canvas_x" -> labelMetadata.canvasX,
+      "canvas_y" -> labelMetadata.canvasY,
+      "canvas_width" -> labelMetadata.canvasWidth,
+      "canvas_height" -> labelMetadata.canvasHeight,
       "timestamp" -> labelMetadata.timestamp,
       "label_type_key" -> labelMetadata.labelTypeKey,
       "label_type_value" -> labelMetadata.labelTypeValue,

--- a/app/views/labelMap.scala.html
+++ b/app/views/labelMap.scala.html
@@ -87,7 +87,7 @@
     <script type="text/javascript" src='@routes.Assets.at("javascripts/lib/moment.js")'></script>
 @*    <script type="text/javascript" src='@routes.Assets.at("javascripts/lib/d3.v3.js")'></script>*@
 @*    <script type="text/javascript" src='@routes.Assets.at("javascripts/lib/c3.min.js")'></script>*@
-@*    <script type="text/javascript" src='@routes.Assets.at("javascripts/Admin/build/Admin.js")'></script>*@
+    <script type="text/javascript" src='@routes.Assets.at("javascripts/Admin/build/Admin.js")'></script>
 @*    <script type="text/javascript" src='@routes.Assets.at("javascripts/lib/turf.min.js")'></script>*@
     <script type="text/javascript" src='@routes.Assets.at("javascripts/lib/jquery.dataTables.min.js")'></script>
     <script type="text/javascript" src='@routes.Assets.at("javascripts/lib/dataTables.bootstrap.min.js")'></script>
@@ -95,7 +95,7 @@
     <script type="text/javascript" src='@routes.Assets.at("javascripts/SVLabel/src/SVLabel/util/UtilitiesColor.js")'></script>
 @*    <script type="text/javascript" src='@routes.Assets.at("javascripts/SVLabel/src/SVLabel/util/UtilitiesPanomarker.js")'></script>*@
     <script type="text/javascript" src='@routes.Assets.at("javascripts/SVLabel/src/SVLabel/util/UtilitiesSidewalk.js")'></script>
-@*    <script type="text/javascript" src='@routes.Assets.at("javascripts/SVLabel/src/SVLabel/Panomarker.js")'></script>*@
+    <script type="text/javascript" src='@routes.Assets.at("javascripts/SVLabel/src/SVLabel/Panomarker.js")'></script>
 @*    <script type="text/javascript" src='@routes.Assets.at("javascripts/TimestampLocalization.js")'></script>*@
 
 @*    <script src="https://cdnjs.cloudflare.com/ajax/libs/vega/3.0.0-beta.33/vega.js"></script>*@

--- a/app/views/labelMap.scala.html
+++ b/app/views/labelMap.scala.html
@@ -1,0 +1,179 @@
+@import models.user.User
+@import models.region.RegionTable
+@import play.api.libs.json.Json
+@(title: String, user: Option[User] = None)
+
+@main(title) {
+    @navbar(user)
+    <script src='@routes.Assets.at("assets/detectMobileBrowser.js")'></script>
+
+
+    <div class="container" id="results-choropleth-container" style="width: 100%;
+        position: relative;">
+        <div id="map-holder">
+            <div id="admin-map"></div>
+            <div id="map-label-legend">
+                <table class="table filter">
+                    <tr>
+                        <td></td>
+                        <td colspan="2" align="left" style="font-weight:bold">Label Type</td>
+                        <td colspan="2" align="left" style="font-weight:bold">Severity</td>
+                    </tr>
+                    <tr>
+                        <td id="map-legend-curb-ramp" width="12px"></td>
+                        <td width="190px">Curb Ramp</td>
+                        <td width="12px"  align="center"><input type="checkbox" value="displaylabel" id="curbramp" checked="true" onclick = "map.toggleLayers('CurbRamp', 'curbramp', '#curb-ramp-slider')"></td>
+                        <td width="126px"align="center"><div id = "curb-ramp-slider" style="margin-top:3px"></div></td>
+                        <td width="80px" align= "center" ><span id="curb-ramp-severity-label">N/A - 5</span></td>
+
+                    </tr>
+                    <tr>
+                        <td id="map-legend-no-curb-ramp"></td>
+                        <td>Missing Curb Ramp</td>
+                        <td><input type="checkbox" value="displaylabel" id="missingcurbramp" checked="true" onclick = "map.toggleLayers('NoCurbRamp', 'missingcurbramp', '#missing-curb-ramp-slider')"></td>
+                        <td align="left"><div id = "missing-curb-ramp-slider" style="margin-top:3px"></div></td>
+                        <td align= "center"><span id="missing-curb-ramp-severity-label">N/A - 5</span></td>
+                    </tr>
+                    <tr>
+                        <td id="map-legend-obstacle"></td>
+                        <td>Obstacle in Path</td>
+                        <td><input type="checkbox" value="displaylabel" id="obstacle" checked="true" onclick="map.toggleLayers('Obstacle', 'obstacle', '#obstacle-slider')"></td>
+                        <td align="left"><div id = "obstacle-slider" style="margin-top:3px"></div></td>
+                        <td align= "center"><span id="obstacle-severity-label">N/A - 5</span></td>
+                    </tr>
+                    <tr><td id="map-legend-surface-problem"></td>
+                        <td>Surface Problem</td>
+                        <td><input type="checkbox" value="displaylabel" id="surfaceprob" checked="true" onclick="map.toggleLayers('SurfaceProblem', 'surfaceprob', '#surface-problem-slider')"></td>
+                        <td align="left"><div id = "surface-problem-slider" style="margin-top:3px"></div></td>
+                        <td align="center"><span id="surface-problem-severity-label">N/A - 5</span></td>
+                    </tr>
+                    <tr>
+                        <td id="map-legend-nosidewalk"></td>
+                        <td>No Sidewalk</td>
+                        <td><input type="checkbox" value="displaylabel" id="nosidewalk" checked="true" onclick="map.toggleLayers('NoSidewalk', 'nosidewalk', '#no-sidewalk-slider')"></td>
+                        <td align="left"><div id = "no-sidewalk-slider" style="margin-top:3px"></div></td>
+                        <td align="center"><span id="no-sidewalk-severity-label">N/A - 5</span></td>
+                    </tr>
+                    <tr>
+                        <td id="map-legend-other"></td>
+                        <td>Other</td>
+                        <td><input type="checkbox" value="displaylabel" id="other" checked="true" onclick="map.toggleLayers('Other', 'other', '#other-slider')"></td>
+                        <td align="left"><div id = "other-slider" style="margin-top:3px"></div></td>
+                        <td align= "center"><span id="other-severity-label">N/A - 5</span></td>
+                    </tr>
+                    <tr>
+                        <td id="map-legend-occlusion"></td>
+                        <td>Can't see sidewalk</td>
+                        <td><input type="checkbox" value="displaylabel" id="occlusion" checked="true" onclick="map.toggleLayers('Occlusion', 'occlusion', '#occlusion-slider')"></td>
+                    </tr>
+                    <tr>
+                        <td id="map-legend-audited-street"></td>
+                        <td>Audited Street</td>
+                        <td><input type="checkbox" value="displaylabel" id="auditedstreet" checked="true" onclick="map.toggleAuditedStreetLayer();"></td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+    </div>
+
+@*    <link href='@routes.Assets.at("stylesheets/c3.min.css")' rel="stylesheet"/>*@
+@*    <link href='@routes.Assets.at("stylesheets/bootstrap.min.css")' rel="stylesheet"/>*@
+@*    <link href='@routes.Assets.at("stylesheets/dataTables.bootstrap.min.css")' rel="stylesheet"/>*@
+@*    <link href='@routes.Assets.at("stylesheets/ekko-lightbox.css")' rel="stylesheet"/>*@
+@*    <link href='@routes.Assets.at("stylesheets/ekko-lightbox.min.css")' rel="stylesheet"/>*@
+@*    <link rel="stylesheet" href="//code.jquery.com/ui/1.12.1/themes/smoothness/jquery-ui.css">*@
+    <link href='@routes.Assets.at("stylesheets/admin.css")' rel="stylesheet"/>
+
+    <script type="text/javascript" src='@routes.Assets.at("javascripts/lib/moment.js")'></script>
+@*    <script type="text/javascript" src='@routes.Assets.at("javascripts/lib/d3.v3.js")'></script>*@
+@*    <script type="text/javascript" src='@routes.Assets.at("javascripts/lib/c3.min.js")'></script>*@
+@*    <script type="text/javascript" src='@routes.Assets.at("javascripts/Admin/build/Admin.js")'></script>*@
+@*    <script type="text/javascript" src='@routes.Assets.at("javascripts/lib/turf.min.js")'></script>*@
+    <script type="text/javascript" src='@routes.Assets.at("javascripts/lib/jquery.dataTables.min.js")'></script>
+    <script type="text/javascript" src='@routes.Assets.at("javascripts/lib/dataTables.bootstrap.min.js")'></script>
+    <script type="text/javascript" src='@routes.Assets.at("javascripts/SVLabel/src/SVLabel/util/Utilities.js")'></script>
+    <script type="text/javascript" src='@routes.Assets.at("javascripts/SVLabel/src/SVLabel/util/UtilitiesColor.js")'></script>
+@*    <script type="text/javascript" src='@routes.Assets.at("javascripts/SVLabel/src/SVLabel/util/UtilitiesPanomarker.js")'></script>*@
+    <script type="text/javascript" src='@routes.Assets.at("javascripts/SVLabel/src/SVLabel/util/UtilitiesSidewalk.js")'></script>
+@*    <script type="text/javascript" src='@routes.Assets.at("javascripts/SVLabel/src/SVLabel/Panomarker.js")'></script>*@
+@*    <script type="text/javascript" src='@routes.Assets.at("javascripts/TimestampLocalization.js")'></script>*@
+
+@*    <script src="https://cdnjs.cloudflare.com/ajax/libs/vega/3.0.0-beta.33/vega.js"></script>*@
+@*    <script src="https://cdnjs.cloudflare.com/ajax/libs/vega-lite/2.0.0-beta.4/vega-lite.js"></script>*@
+@*    <script src="https://cdnjs.cloudflare.com/ajax/libs/vega-embed/3.0.0-beta.17/vega-embed.js"></script>*@
+
+    <script src='https://api.mapbox.com/mapbox.js/v3.1.1/mapbox.js'></script>
+    <link href='https://api.mapbox.com/mapbox.js/v3.1.1/mapbox.css' rel='stylesheet' />
+
+
+
+
+
+@*    <script src='https://api.mapbox.com/mapbox.js/v3.1.1/mapbox.js'></script>*@
+@*    <link href='https://api.mapbox.com/mapbox.js/v3.1.1/mapbox.css' rel='stylesheet' />*@
+@*    <script src='https://api.mapbox.com/mapbox.js/plugins/leaflet-zoomslider/v0.7.0/L.Control.Zoomslider.js'></script>*@
+@*    <link href='https://api.mapbox.com/mapbox.js/plugins/leaflet-zoomslider/v0.7.0/L.Control.Zoomslider.css' rel='stylesheet' />*@
+@*    <script type="text/javascript" src='@routes.Assets.at("javascripts/lib/turf.min.js")'></script>*@
+@*    <link href='@routes.Assets.at("stylesheets/choropleth.css")' rel="stylesheet"/>*@
+    <script type="text/javascript" src='@routes.Assets.at("javascripts/LabelMap.js")'></script>
+
+
+
+
+    <script>
+            var labelArr = ["N/A", 1, 2, 3, 4, 5];
+            var sliderToLabelMap = {};
+            sliderToLabelMap["curb-ramp-slider"] = "#curb-ramp-severity-label";
+            sliderToLabelMap["missing-curb-ramp-slider"] = "#missing-curb-ramp-severity-label";
+            sliderToLabelMap["obstacle-slider"] = "#obstacle-severity-label";
+            sliderToLabelMap["surface-problem-slider"] = "#surface-problem-severity-label";
+            sliderToLabelMap["occlusion-slider"]  = "#occlusion-severity-label";
+            sliderToLabelMap["no-sidewalk-slider"] = "#no-sidewalk-severity-label";
+            sliderToLabelMap["other-slider"] = "#other-severity-label";
+
+            $( "*[id*='slider']" ).each(function() {
+                $(this).slider({
+                    range: true,
+                    min : 0,
+                    max : 5,
+                    step: 1,
+                    values: [0,5],
+                    slide: function(event, ui) {
+                        if(labelArr[ui.values[0]] === labelArr[ui.values[1]]) {
+                            $(sliderToLabelMap[this.id]).text(labelArr[ui.values[0]]);
+                        } else {
+                            $(sliderToLabelMap[this.id]).text(labelArr[ui.values[0]]+ " - " + labelArr[ui.values[1]]);
+                        }
+                    },
+                    change: function(event,ui) {
+                        if (this.id == "curb-ramp-slider") {
+                            map.toggleLayers('CurbRamp', 'curbramp', '#curb-ramp-slider');
+                        } else if (this.id == "missing-curb-ramp-slider") {
+                            map.toggleLayers('NoCurbRamp', 'missingcurbramp', '#missing-curb-ramp-slider');
+                        } else if (this.id == "obstacle-slider") {
+                            map.toggleLayers('Obstacle', 'obstacle', '#obstacle-slider')
+                        } else if (this.id == 'surface-problem-slider') {
+                            map.toggleLayers('SurfaceProblem', 'surfaceprob', '#surface-problem-slider');
+                        } else if (this.id == 'occlusion-slider') {
+                            map.toggleLayers('Occlusion', 'occlusion', '#occlusion-slider');
+                        } else if (this.id == 'no-sidewalk-slider') {
+                            map.toggleLayers('NoSidewalk', 'nosidewalk', '#no-sidewalk-slider');
+                        } else if (this.id == 'other-slider') {
+                            map.toggleLayers('Other', 'other', '#other-slider');
+                        }
+                    }
+                });
+            });
+
+    </script>
+
+
+    <script>
+            $(document).ready(function () {
+                window.map = LabelMap(_, $);
+            });
+            $(window).load(function() {
+                $(".loader").fadeOut("slow");
+            })
+    </script>
+}

--- a/app/views/labelMap.scala.html
+++ b/app/views/labelMap.scala.html
@@ -76,48 +76,23 @@
         </div>
     </div>
 
-@*    <link href='@routes.Assets.at("stylesheets/c3.min.css")' rel="stylesheet"/>*@
-@*    <link href='@routes.Assets.at("stylesheets/bootstrap.min.css")' rel="stylesheet"/>*@
-@*    <link href='@routes.Assets.at("stylesheets/dataTables.bootstrap.min.css")' rel="stylesheet"/>*@
-@*    <link href='@routes.Assets.at("stylesheets/ekko-lightbox.css")' rel="stylesheet"/>*@
-@*    <link href='@routes.Assets.at("stylesheets/ekko-lightbox.min.css")' rel="stylesheet"/>*@
     <link rel="stylesheet" href="//code.jquery.com/ui/1.12.1/themes/smoothness/jquery-ui.css">
     <link href='@routes.Assets.at("stylesheets/admin.css")' rel="stylesheet"/>
 
     <script type="text/javascript" src='@routes.Assets.at("javascripts/lib/moment.js")'></script>
-@*    <script type="text/javascript" src='@routes.Assets.at("javascripts/lib/d3.v3.js")'></script>*@
-@*    <script type="text/javascript" src='@routes.Assets.at("javascripts/lib/c3.min.js")'></script>*@
     <script type="text/javascript" src='@routes.Assets.at("javascripts/Admin/build/Admin.js")'></script>
-@*    <script type="text/javascript" src='@routes.Assets.at("javascripts/lib/turf.min.js")'></script>*@
     <script type="text/javascript" src='@routes.Assets.at("javascripts/lib/jquery.dataTables.min.js")'></script>
     <script type="text/javascript" src='@routes.Assets.at("javascripts/lib/dataTables.bootstrap.min.js")'></script>
     <script type="text/javascript" src='@routes.Assets.at("javascripts/SVLabel/src/SVLabel/util/Utilities.js")'></script>
     <script type="text/javascript" src='@routes.Assets.at("javascripts/SVLabel/src/SVLabel/util/UtilitiesColor.js")'></script>
-@*    <script type="text/javascript" src='@routes.Assets.at("javascripts/SVLabel/src/SVLabel/util/UtilitiesPanomarker.js")'></script>*@
     <script type="text/javascript" src='@routes.Assets.at("javascripts/SVLabel/src/SVLabel/util/UtilitiesSidewalk.js")'></script>
     <script type="text/javascript" src='@routes.Assets.at("javascripts/SVLabel/src/SVLabel/Panomarker.js")'></script>
-@*    <script type="text/javascript" src='@routes.Assets.at("javascripts/TimestampLocalization.js")'></script>*@
-
-@*    <script src="https://cdnjs.cloudflare.com/ajax/libs/vega/3.0.0-beta.33/vega.js"></script>*@
-@*    <script src="https://cdnjs.cloudflare.com/ajax/libs/vega-lite/2.0.0-beta.4/vega-lite.js"></script>*@
-@*    <script src="https://cdnjs.cloudflare.com/ajax/libs/vega-embed/3.0.0-beta.17/vega-embed.js"></script>*@
+    <script type="text/javascript" src='@routes.Assets.at("javascripts/TimestampLocalization.js")'></script>
 
     <script src='https://api.mapbox.com/mapbox.js/v3.1.1/mapbox.js'></script>
     <link href='https://api.mapbox.com/mapbox.js/v3.1.1/mapbox.css' rel='stylesheet' />
 
-
-
-
-
-@*    <script src='https://api.mapbox.com/mapbox.js/v3.1.1/mapbox.js'></script>*@
-@*    <link href='https://api.mapbox.com/mapbox.js/v3.1.1/mapbox.css' rel='stylesheet' />*@
-@*    <script src='https://api.mapbox.com/mapbox.js/plugins/leaflet-zoomslider/v0.7.0/L.Control.Zoomslider.js'></script>*@
-@*    <link href='https://api.mapbox.com/mapbox.js/plugins/leaflet-zoomslider/v0.7.0/L.Control.Zoomslider.css' rel='stylesheet' />*@
-@*    <script type="text/javascript" src='@routes.Assets.at("javascripts/lib/turf.min.js")'></script>*@
-@*    <link href='@routes.Assets.at("stylesheets/choropleth.css")' rel="stylesheet"/>*@
     <script type="text/javascript" src='@routes.Assets.at("javascripts/LabelMap.js")'></script>
-
-
 
 
     <script>

--- a/app/views/labelMap.scala.html
+++ b/app/views/labelMap.scala.html
@@ -81,7 +81,7 @@
 @*    <link href='@routes.Assets.at("stylesheets/dataTables.bootstrap.min.css")' rel="stylesheet"/>*@
 @*    <link href='@routes.Assets.at("stylesheets/ekko-lightbox.css")' rel="stylesheet"/>*@
 @*    <link href='@routes.Assets.at("stylesheets/ekko-lightbox.min.css")' rel="stylesheet"/>*@
-@*    <link rel="stylesheet" href="//code.jquery.com/ui/1.12.1/themes/smoothness/jquery-ui.css">*@
+    <link rel="stylesheet" href="//code.jquery.com/ui/1.12.1/themes/smoothness/jquery-ui.css">
     <link href='@routes.Assets.at("stylesheets/admin.css")' rel="stylesheet"/>
 
     <script type="text/javascript" src='@routes.Assets.at("javascripts/lib/moment.js")'></script>

--- a/conf/routes
+++ b/conf/routes
@@ -55,7 +55,7 @@ GET     /adminapi/labelLocations/:username                   @controllers.AdminC
 GET     /adminapi/labels/all                                 @controllers.AdminController.getAllLabels
 GET     /adminapi/labels/panoid                              @controllers.AdminController.getAllPanoIds
 GET     /adminapi/labels/cv                                  @controllers.AdminController.getAllLabelCVMetadata
-GET     /adminapi/label/:labelId                             @controllers.AdminController.getLabelData(labelId: Int)
+GET     /adminapi/label/:labelId                             @controllers.AdminController.getAdminLabelData(labelId: Int)
 GET     /adminapi/labelCounts                                @controllers.AdminController.getAllUserLabelCounts
 GET     /adminapi/attributes/all                             @controllers.AdminController.getAllAttributes
 GET     /adminapi/validationCounts                           @controllers.AdminController.getAllUserValidationCounts
@@ -69,6 +69,7 @@ GET     /adminapi/choroplethCounts                           @controllers.AdminC
 PUT     /adminapi/setRole                                    @controllers.AdminController.setUserRole
 
 GET     /labels/all                                          @controllers.AdminController.getAllLabelsForLabelMap
+GET     /label/:labelId                                      @controllers.AdminController.getLabelData(labelId: Int)
 
 # Auditing tasks
 GET     /audit                                               @controllers.AuditController.audit(nextRegion: Option[String] ?= None, retakeTutorial: Option[Boolean] ?= None)

--- a/conf/routes
+++ b/conf/routes
@@ -12,6 +12,7 @@ GET     /developer                                           @controllers.Applic
 GET     /terms                                               @controllers.ApplicationController.terms
 GET     /demo                                                @controllers.ApplicationController.demo
 GET     /results                                             @controllers.ApplicationController.results
+GET     /labelmap                                            @controllers.ApplicationController.labelMap
 GET     /help                                                @controllers.ApplicationController.help
 GET     /labelingGuide                                       @controllers.ApplicationController.labelingGuide
 GET     /labelingGuide/curbRamps                             @controllers.ApplicationController.labelingGuideCurbRamps
@@ -66,6 +67,8 @@ GET     /adminapi/numWebpageActivity/:activity               @controllers.AdminC
 GET     /adminapi/numWebpageActivity/:activity/*keyValPairs  @controllers.AdminController.getNumWebpageActivitiesKeyVal(activity: String, keyValPairs: String)
 GET     /adminapi/choroplethCounts                           @controllers.AdminController.getRegionNegativeLabelCounts
 PUT     /adminapi/setRole                                    @controllers.AdminController.setUserRole
+
+GET     /labels/all                                          @controllers.AdminController.getAllLabelsForLabelMap
 
 # Auditing tasks
 GET     /audit                                               @controllers.AuditController.audit(nextRegion: Option[String] ?= None, retakeTutorial: Option[Boolean] ?= None)

--- a/public/javascripts/Admin/src/Admin.GSVLabelView.js
+++ b/public/javascripts/Admin/src/Admin.GSVLabelView.js
@@ -1,13 +1,14 @@
-function AdminGSVLabelView() {
+function AdminGSVLabelView(admin) {
     var self = {};
+    self.admin = admin;
 
     var _init = function() {
         _resetModal();
     };
 
     function _resetModal() {
-        self.modal =
-            $('<div class="modal fade" id="labelModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">'+
+        var modalText =
+            '<div class="modal fade" id="labelModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">'+
                 '<div class="modal-dialog" role="document" style="width: 570px">'+
                     '<div class="modal-content">'+
                         '<div class="modal-header">'+
@@ -19,39 +20,48 @@ function AdminGSVLabelView() {
                         '</div>'+
                         '<div class="modal-footer">'+
                             '<table class="table table-striped" style="font-size:small; margin-bottom: 0">'+
-                            '<tr>'+
-                                '<th>Label Type</th>'+
-                                '<td id="label-type-value"></td>'+
-                            '</tr>'+
-                            '<tr>' +
-                                '<th>Severity</th>'+
-                                '<td id="severity"></td>'+
-                            '</tr>'+
-                            '<tr>'+
-                                '<th>Task ID</th>' +
-                                '<td id="task"></td>' +
-                            '</tr>'+
-                            '<tr>' +
-                                '<th>Temporary</th>'+
-                                '<td id="temporary"></td>'+
-                            '</tr>'+
-                            '<tr>'+
-                                '<th>Tags</th>'+
-                                '<td colspan="3" id="tags"></td>'+
-                            '</tr>'+
-                            '<tr>'+
-                                '<th>Description</th>'+
-                                '<td colspan="3" id="label-description"></td>'+
-                            '</tr>'+
-                            '<tr>'+
-                            '<th>Time Submitted</th>'+
-                            '<td id="timestamp" colspan="3"></td>'+
-                            '</tr>'+
-                            '</table>'+
-                        '</div>'+
-                    '</div>'+
+                                '<tr>'+
+                                    '<th>Label Type</th>'+
+                                    '<td id="label-type-value"></td>'+
+                                '</tr>'+
+                                '<tr>' +
+                                    '<th>Severity</th>'+
+                                    '<td id="severity"></td>'+
+                                '</tr>'+
+                                '<tr>' +
+                                    '<th>Temporary</th>'+
+                                    '<td id="temporary"></td>'+
+                                '</tr>'+
+                                '<tr>'+
+                                    '<th>Tags</th>'+
+                                    '<td colspan="3" id="tags"></td>'+
+                                '</tr>'+
+                                '<tr>'+
+                                    '<th>Description</th>'+
+                                    '<td colspan="3" id="label-description"></td>'+
+                                '</tr>'+
+                                '<tr>'+
+                                    '<th>Time Submitted</th>'+
+                                    '<td id="timestamp" colspan="3"></td>'+
+                                '</tr>';
+        if (self.admin) {
+            modalText += '<tr>'+
+                '<th>Task ID</th>' +
+                '<td id="task"></td>' +
+                '</tr>'+
+                '</table>'+
                 '</div>'+
-            '</div>');
+                '</div>'+
+                '</div>'+
+                '</div>'
+        } else {
+            modalText += '</table>'+
+                '</div>'+
+                '</div>'+
+                '</div>'+
+                '</div>'
+        }
+        self.modal = $(modalText);
 
         self.panorama = AdminPanorama(self.modal.find("#svholder")[0]);
 
@@ -70,9 +80,9 @@ function AdminGSVLabelView() {
         self.modal.modal({
             'show': true
         });
-        var adminLabelUrl = "/adminapi/label/" + labelId;
+        var adminLabelUrl = admin ? "/adminapi/label/" + labelId : "/label/" + labelId;
         $.getJSON(adminLabelUrl, function (data) {
-            _handleData(data);
+            _handleData(data, admin);
         });
     }
 
@@ -94,9 +104,12 @@ function AdminGSVLabelView() {
         //join is here to make the formatting nice, otherwise we don't have commas or spaces.
         self.modalTags.html(labelMetadata['tags'].join(', '));
         self.modalDescription.html(labelMetadata['description'] != null ? labelMetadata['description'] : "No description");
-        self.modalTask.html("<a href='/admin/task/"+labelMetadata['audit_task_id']+"'>"+
-            labelMetadata['audit_task_id']+"</a> by <a href='/admin/user/" + labelMetadata['username'] + "'>" +
-            labelMetadata['username'] + "</a>");
+
+        if (self.admin) {
+            self.modalTask.html("<a href='/admin/task/"+labelMetadata['audit_task_id']+"'>"+
+                labelMetadata['audit_task_id']+"</a> by <a href='/admin/user/" + labelMetadata['username'] + "'>" +
+                labelMetadata['username'] + "</a>");
+        }
     }
 
     _init();

--- a/public/javascripts/Admin/src/Admin.LabelSearch.js
+++ b/public/javascripts/Admin/src/Admin.LabelSearch.js
@@ -3,7 +3,7 @@ function AdminLabelSearch() {
 
 
     function _init() {
-        adminGSVLabelView = AdminGSVLabelView();
+        adminGSVLabelView = AdminGSVLabelView(true);
     }
 
     // Prevents the page from refreshing when the enter key is pressed.

--- a/public/javascripts/Admin/src/Admin.Panorama.js
+++ b/public/javascripts/Admin/src/Admin.Panorama.js
@@ -48,7 +48,16 @@ function AdminPanorama(svHolder) {
             height: self.svHolder.height()
         })[0];
 
+        self.panoNotAvailable = $("<div id='pano-not-avail'>No imagery available, try another label!</div>").css({
+            width: '100%',
+            height: '100%',
+            position: 'absolute',
+            top: '0',
+            'font-size': '200%'
+        })[0];
+
         self.svHolder.append($(self.panoCanvas));
+        self.svHolder.append($(self.panoNotAvailable));
 
         self.panorama = typeof google != "undefined" ? new google.maps.StreetViewPanorama(self.panoCanvas, { mode: 'html4' }) : null;
         self.panorama.addListener('pano_changed', function() {
@@ -105,7 +114,16 @@ function AdminPanorama(svHolder) {
                 self.panorama.set('pov', {heading: heading, pitch: pitch});
                 self.panorama.set('zoom', zoomLevel[zoom]);
                 self.svHolder.css('visibility', 'visible');
-                renderLabel(self.label);
+
+                // Show pano if it exists, or an error message if there is no GSV imagery.
+                if (self.panorama.getStatus() === "OK") {
+                    $(self.panoCanvas).css('visibility', 'visible');
+                    $(self.panoNotAvailable).css('visibility', 'hidden');
+                    renderLabel(self.label);
+                } else {
+                    $(self.panoCanvas).css('visibility', 'hidden');
+                    $(self.panoNotAvailable).css('visibility', 'visible');
+                }
             }
             setTimeout(callback, 500);
         }

--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -480,7 +480,7 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
     }
 
     function initializeAdminGSVLabelView() {
-        self.adminGSVLabelView = AdminGSVLabelView();
+        self.adminGSVLabelView = AdminGSVLabelView(true);
     }
 
     function initializeAdminLabelSearch() {

--- a/public/javascripts/LabelMap.js
+++ b/public/javascripts/LabelMap.js
@@ -210,7 +210,6 @@ function LabelMap(_, $) {
     function initializeSubmittedLabels(map) {
 
         $.getJSON("/labels/all", function (data) {
-            console.log("doing the label thing");
             // Count a number of each label type
             var labelCounter = {
                 "CurbRamp": 0,

--- a/public/javascripts/LabelMap.js
+++ b/public/javascripts/LabelMap.js
@@ -347,7 +347,7 @@ function LabelMap(_, $) {
     }, 1);
 
     function initializeAdminGSVLabelView() {
-        self.adminGSVLabelView = AdminGSVLabelView();
+        self.adminGSVLabelView = AdminGSVLabelView(false);
     }
 
 

--- a/public/javascripts/LabelMap.js
+++ b/public/javascripts/LabelMap.js
@@ -245,9 +245,9 @@ function LabelMap(_, $) {
 
 
     function onEachLabelFeature(feature, layer) {
-        // layer.on('click', function () {
-        //     self.adminGSVLabelView.showLabel(feature.properties.label_id);
-        // });
+        layer.on('click', function () {
+            self.adminGSVLabelView.showLabel(feature.properties.label_id);
+        });
         layer.on({
             'mouseover': function () {
                 layer.setRadius(15);
@@ -341,14 +341,14 @@ function LabelMap(_, $) {
     initializeNeighborhoodPolygons(map);
     initializeAuditedStreets(map);
     initializeSubmittedLabels(map);
-    // initializeAdminGSVLabelView();
+    initializeAdminGSVLabelView();
     setTimeout(function () {
         map.invalidateSize(false);
     }, 1);
 
-    // function initializeAdminGSVLabelView() {
-    //     self.adminGSVLabelView = AdminGSVLabelView();
-    // }
+    function initializeAdminGSVLabelView() {
+        self.adminGSVLabelView = AdminGSVLabelView();
+    }
 
 
     self.clearMap = clearMap;

--- a/public/javascripts/LabelMap.js
+++ b/public/javascripts/LabelMap.js
@@ -357,4 +357,6 @@ function LabelMap(_, $) {
     self.redrawAuditedStreetLayer = redrawAuditedStreetLayer;
     self.toggleLayers = toggleLayers;
     self.toggleAuditedStreetLayer = toggleAuditedStreetLayer;
+
+    return self;
 }

--- a/public/javascripts/LabelMap.js
+++ b/public/javascripts/LabelMap.js
@@ -1,0 +1,360 @@
+function LabelMap(_, $) {
+
+    var self = {};
+    self.markerLayer = null;
+    self.curbRampLayers = [];
+    self.missingCurbRampLayers = [];
+    self.obstacleLayers = [];
+    self.surfaceProblemLayers = [];
+    self.cantSeeSidewalkLayers = [];
+    self.noSidewalkLayers = [];
+    self.otherLayers = [];
+    self.mapLoaded = false;
+    self.graphsLoaded = false;
+
+    var neighborhoodPolygonLayer;
+
+    for (var i = 0; i < 6; i++) {
+        self.curbRampLayers[i] = [];
+        self.missingCurbRampLayers[i] = [];
+        self.obstacleLayers[i] = [];
+        self.surfaceProblemLayers[i] = [];
+        self.cantSeeSidewalkLayers[i] = [];
+        self.noSidewalkLayers[i] = [];
+        self.otherLayers[i] = [];
+    }
+
+    self.allLayers = {
+        "CurbRamp": self.curbRampLayers, "NoCurbRamp": self.missingCurbRampLayers, "Obstacle": self.obstacleLayers,
+        "SurfaceProblem": self.surfaceProblemLayers, "Occlusion": self.cantSeeSidewalkLayers,
+        "NoSidewalk": self.noSidewalkLayers, "Other": self.otherLayers
+    };
+
+    self.auditedStreetLayer = null;
+
+    L.mapbox.accessToken = 'pk.eyJ1Ijoia290YXJvaGFyYSIsImEiOiJDdmJnOW1FIn0.kJV65G6eNXs4ATjWCtkEmA';
+
+    // var tileUrl = "https://a.tiles.mapbox.com/v4/kotarohara.mmoldjeh/page.html?access_token=pk.eyJ1Ijoia290YXJvaGFyYSIsImEiOiJDdmJnOW1FIn0.kJV65G6eNXs4ATjWCtkEmA#13/38.8998/-77.0638";
+    var tileUrl = "https:\/\/a.tiles.mapbox.com\/v4\/kotarohara.8e0c6890\/{z}\/{x}\/{y}.png?access_token=pk.eyJ1Ijoia290YXJvaGFyYSIsImEiOiJDdmJnOW1FIn0.kJV65G6eNXs4ATjWCtkEmA";
+    var mapboxTiles = L.tileLayer(tileUrl, {
+        attribution: '<a href="http://www.mapbox.com/about/maps/" target="_blank">Terms &amp; Feedback</a>'
+    });
+    var map = L.mapbox.map('admin-map', "kotarohara.8e0c6890", {
+        maxZoom: 19,
+        minZoom: 9,
+        zoomSnap: 0.5
+    });
+
+    // Set the city-specific default zoom and location.
+    $.getJSON('/cityMapParams', function(data) {
+        map.setView([data.city_center.lat, data.city_center.lng]);
+        map.setZoom(data.default_zoom);
+    });
+
+
+    /**
+     * This function adds a semi-transparent white polygon on top of a map
+     */
+    function initializeOverlayPolygon(map) {
+        var overlayPolygon = {
+            "type": "FeatureCollection",
+            "features": [{
+                "type": "Feature", "geometry": {
+                    "type": "Polygon", "coordinates": [
+                        [[-75, 36], [-75, 40], [-80, 40], [-80, 36], [-75, 36]]
+                    ]
+                }
+            }]
+        };
+        var layer = L.geoJson(overlayPolygon);
+        layer.setStyle({color: "#ccc", fillColor: "#ccc"});
+        layer.addTo(map);
+    }
+
+
+    /**
+     * render points
+     */
+    function initializeNeighborhoodPolygons(map) {
+        var neighborhoodPolygonStyle = {
+                color: '#888',
+                weight: 1,
+                opacity: 0.25,
+                fillColor: "#ccc",
+                fillOpacity: 0.1
+            },
+            layers = [],
+            currentLayer;
+
+        function onEachNeighborhoodFeature(feature, layer) {
+
+            var regionId = feature.properties.region_id;
+            var userCompleted = feature.properties.user_completed;
+            var url = "/audit/region/" + regionId;
+            var popupContent = "???";
+
+            if (userCompleted) {
+                popupContent = "You already audited this entire neighborhood!";
+            } else {
+                popupContent = "Do you want to explore this area to find accessibility issues? " +
+                    "<a href='" + url + "' class='region-selection-trigger' regionId='" + regionId + "'>Sure!</a>";
+            }
+            layer.bindPopup(popupContent);
+            layers.push(layer);
+
+            layer.on('mouseover', function (e) {
+                this.setStyle({color: "red", fillColor: "red"});
+
+            });
+            layer.on('mouseout', function (e) {
+                for (var i = layers.length - 1; i >= 0; i--) {
+                    if (currentLayer !== layers[i])
+                        layers[i].setStyle(neighborhoodPolygonStyle);
+                }
+                //this.setStyle(neighborhoodPolygonStyle);
+            });
+            layer.on('click', function (e) {
+                currentLayer = this;
+            });
+        }
+
+        $.getJSON("/neighborhoods", function (data) {
+            neighborhoodPolygonLayer = L.geoJson(data, {
+                style: function (feature) {
+                    return $.extend(true, {}, neighborhoodPolygonStyle);
+                },
+                onEachFeature: onEachNeighborhoodFeature
+            })
+                .addTo(map);
+        });
+    }
+
+
+
+    /**
+     * This function queries the streets that the user audited and visualize them as segments on the map.
+     */
+    function initializeAuditedStreets(map) {
+            streetLinestringStyle = {
+                color: "black",
+                weight: 3,
+                opacity: 0.75
+            };
+
+        function onEachStreetFeature(feature, layer) {
+            if (feature.properties && feature.properties.type) {
+                layer.bindPopup(feature.properties.type);
+            }
+            layer.on({
+                'add': function () {
+                    layer.bringToBack()
+                }
+            })
+        }
+
+        $.getJSON("/contribution/streets/all", function (data) {
+
+            // Render audited street segments
+            self.auditedStreetLayer = L.geoJson(data, {
+                pointToLayer: L.mapbox.marker.style,
+                style: function (feature) {
+                    var style = $.extend(true, {}, streetLinestringStyle);
+                    style.color = "#000";
+                    style["stroke-width"] = 3;
+                    style.opacity = 0.75;
+                    style.weight = 3;
+
+                    return style;
+                },
+                onEachFeature: onEachStreetFeature
+            })
+                .addTo(map);
+        });
+    }
+
+
+    function initializeAllLayers(data) {
+        for (var i = 0; i < data.features.length; i++) {
+            var labelType = data.features[i].properties.label_type;
+            if (labelType === "Occlusion") {
+                // console.log(data.features[i]);
+            }
+
+            if (data.features[i].properties.severity == 1) {
+                self.allLayers[labelType][1].push(data.features[i]);
+            } else if (data.features[i].properties.severity == 2) {
+                self.allLayers[labelType][2].push(data.features[i]);
+            } else if (data.features[i].properties.severity == 3) {
+                self.allLayers[labelType][3].push(data.features[i]);
+            } else if (data.features[i].properties.severity == 4) {
+                self.allLayers[labelType][4].push(data.features[i]);
+            } else if (data.features[i].properties.severity == 5) {
+                self.allLayers[labelType][5].push(data.features[i]);
+            } else { // No severity level
+                self.allLayers[labelType][0].push(data.features[i]);
+            }
+        }
+
+        Object.keys(self.allLayers).forEach(function (key) {
+            for (var i = 0; i < self.allLayers[key].length; i++) {
+                self.allLayers[key][i] = createLayer({
+                    "type": "FeatureCollection",
+                    "features": self.allLayers[key][i]
+                });
+                self.allLayers[key][i].addTo(map);
+            }
+        })
+    }
+
+
+    function initializeSubmittedLabels(map) {
+
+        $.getJSON("/labels/all", function (data) {
+            console.log("doing the label thing");
+            // Count a number of each label type
+            var labelCounter = {
+                "CurbRamp": 0,
+                "NoCurbRamp": 0,
+                "Obstacle": 0,
+                "SurfaceProblem": 0,
+                "NoSidewalk": 0
+            };
+
+            for (var i = data.features.length - 1; i >= 0; i--) {
+                labelCounter[data.features[i].properties.label_type] += 1;
+            }
+            //document.getElementById("td-number-of-curb-ramps").innerHTML = labelCounter["CurbRamp"];
+            //document.getElementById("td-number-of-missing-curb-ramps").innerHTML = labelCounter["NoCurbRamp"];
+            //document.getElementById("td-number-of-obstacles").innerHTML = labelCounter["Obstacle"];
+            //document.getElementById("td-number-of-surface-problems").innerHTML = labelCounter["SurfaceProblem"];
+
+            document.getElementById("map-legend-curb-ramp").innerHTML = "<svg width='20' height='20'><circle r='6' cx='10' cy='10' fill='" + colorMapping['CurbRamp'].fillStyle + "'></svg>";
+            document.getElementById("map-legend-no-curb-ramp").innerHTML = "<svg width='20' height='20'><circle r='6' cx='10' cy='10' fill='" + colorMapping['NoCurbRamp'].fillStyle + "'></svg>";
+            document.getElementById("map-legend-obstacle").innerHTML = "<svg width='20' height='20'><circle r='6' cx='10' cy='10' fill='" + colorMapping['Obstacle'].fillStyle + "'></svg>";
+            document.getElementById("map-legend-surface-problem").innerHTML = "<svg width='20' height='20'><circle r='6' cx='10' cy='10' fill='" + colorMapping['SurfaceProblem'].fillStyle + "'></svg>";
+            document.getElementById("map-legend-nosidewalk").innerHTML = "<svg width='20' height='20'><circle r='6' cx='10' cy='10' fill='" + colorMapping['NoSidewalk'].fillStyle + "' stroke='" + colorMapping['NoSidewalk'].strokeStyle + "'></svg>";
+            document.getElementById("map-legend-other").innerHTML = "<svg width='20' height='20'><circle r='6' cx='10' cy='10' fill='" + colorMapping['Other'].fillStyle + "' stroke='" + colorMapping['Other'].strokeStyle + "'></svg>";
+            document.getElementById("map-legend-occlusion").innerHTML = "<svg width='20' height='20'><circle r='6' cx='10' cy='10' fill='" + colorMapping['Other'].fillStyle + "' stroke='" + colorMapping['Occlusion'].strokeStyle + "'></svg>";
+
+            document.getElementById("map-legend-audited-street").innerHTML = "<svg width='20' height='20'><path stroke='black' stroke-width='3' d='M 2 10 L 18 10 z'></svg>";
+
+            // Create layers for each of the 42 different label-severity combinations
+            initializeAllLayers(data);
+        });
+    }
+
+
+    function onEachLabelFeature(feature, layer) {
+        // layer.on('click', function () {
+        //     self.adminGSVLabelView.showLabel(feature.properties.label_id);
+        // });
+        layer.on({
+            'mouseover': function () {
+                layer.setRadius(15);
+            },
+            'mouseout': function () {
+                layer.setRadius(5);
+            }
+        })
+    }
+
+    var colorMapping = util.misc.getLabelColors();
+    var geojsonMarkerOptions = {
+            radius: 5,
+            fillColor: "#ff7800",
+            color: "#ffffff",
+            weight: 1,
+            opacity: 0.5,
+            fillOpacity: 0.5,
+            "stroke-width": 1
+        };
+
+    function createLayer(data) {
+        return L.geoJson(data, {
+            pointToLayer: function (feature, latlng) {
+                var style = $.extend(true, {}, geojsonMarkerOptions);
+                style.fillColor = colorMapping[feature.properties.label_type].fillStyle;
+                style.color = colorMapping[feature.properties.label_type].strokeStyle;
+                return L.circleMarker(latlng, style);
+            },
+            onEachFeature: onEachLabelFeature
+        })
+    }
+
+    function clearMap() {
+        map.removeLayer(self.markerLayer);
+    }
+
+    function clearAuditedStreetLayer() {
+        map.removeLayer(self.auditedStreetLayer);
+    }
+
+    function redrawAuditedStreetLayer() {
+        initializeAuditedStreets(map);
+    }
+
+    function redrawLabels() {
+        initializeSubmittedLabels(map);
+    }
+
+
+    function toggleLayers(label, checkboxId, sliderId) {
+        if (document.getElementById(checkboxId).checked) {
+            if(checkboxId == "occlusion"){
+                for (var i = 0; i < self.allLayers[label].length; i++) {
+                    if (!map.hasLayer(self.allLayers[label][i])) {
+                        map.addLayer(self.allLayers[label][i]);
+                    }
+                }
+            }
+            else {
+                for (var i = 0; i < self.allLayers[label].length; i++) {
+                    if (!map.hasLayer(self.allLayers[label][i])
+                        && ($(sliderId).slider("option", "values")[0] <= i &&
+                            $(sliderId).slider("option", "values")[1] >= i )) {
+                        map.addLayer(self.allLayers[label][i]);
+                    } else if ($(sliderId).slider("option", "values")[0] > i
+                        || $(sliderId).slider("option", "values")[1] < i) {
+                        map.removeLayer(self.allLayers[label][i]);
+                    }
+                }
+            }
+        } else {
+            for (var i = 0; i < self.allLayers[label].length; i++) {
+                if (map.hasLayer(self.allLayers[label][i])) {
+                    map.removeLayer(self.allLayers[label][i]);
+                }
+            }
+        }
+    }
+
+    function toggleAuditedStreetLayer() {
+        if (document.getElementById('auditedstreet').checked) {
+            map.addLayer(self.auditedStreetLayer);
+        } else {
+            map.removeLayer(self.auditedStreetLayer);
+        }
+    }
+
+
+    initializeOverlayPolygon(map);
+    initializeNeighborhoodPolygons(map);
+    initializeAuditedStreets(map);
+    initializeSubmittedLabels(map);
+    // initializeAdminGSVLabelView();
+    setTimeout(function () {
+        map.invalidateSize(false);
+    }, 1);
+
+    // function initializeAdminGSVLabelView() {
+    //     self.adminGSVLabelView = AdminGSVLabelView();
+    // }
+
+
+    self.clearMap = clearMap;
+    self.redrawLabels = redrawLabels;
+    self.clearAuditedStreetLayer = clearAuditedStreetLayer;
+    self.redrawAuditedStreetLayer = redrawAuditedStreetLayer;
+    self.toggleLayers = toggleLayers;
+    self.toggleAuditedStreetLayer = toggleAuditedStreetLayer;
+}


### PR DESCRIPTION
Partially resolves #1166 
Resolves #1782 

Adds the MVP for a new /labelmap endpoint that will allow users to take a look at all the labels in their city. It is the same as the map on our admin page. Users can click on an individual label on the map and it will pop up a window showing it on a pano.

I also added an error message when the given pano has been deleted so we can't get it from Google. This also now happens on the admin page (which resolves #1782).

Things we are currently missing include
1. The ability to minimize the legend
1. A checkbox so that you can view only labels that have been positively validated
1. The ability to validate directly from this interface.

![labelmap-mvp](https://user-images.githubusercontent.com/6518824/67247044-21cbb680-f415-11e9-97e5-61daf06a6b4c.png)
![labelmap-view-label](https://user-images.githubusercontent.com/6518824/67247046-23957a00-f415-11e9-96e8-ccca3e95f5ff.png)
![no-imagery-error-message](https://user-images.githubusercontent.com/6518824/67247048-255f3d80-f415-11e9-8113-22b0fa0f43ee.png)
