### PR TITLE
1928 labelmap add date to pano

### DIFF
--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -115,8 +115,8 @@ object LabelTable {
 
   case class LabelCountPerDay(date: String, count: Int)
 
-  case class LabelMetadata(labelId: Int, gsvPanoramaId: String, tutorial: Boolean, heading: Float, pitch: Float,
-                           zoom: Int, canvasX: Int, canvasY: Int, canvasWidth: Int, canvasHeight: Int,
+  case class LabelMetadata(labelId: Int, gsvPanoramaId: String, tutorial: Boolean, imageDate: String, heading: Float,
+                           pitch: Float, zoom: Int, canvasX: Int, canvasY: Int, canvasWidth: Int, canvasHeight: Int,
                            auditTaskId: Int,
                            userId: String, username: String,
                            timestamp: Option[java.sql.Timestamp],
@@ -339,12 +339,13 @@ object LabelTable {
 
   // TODO translate the following three queries to Slick
   def retrieveLabelMetadata(takeN: Int): List[LabelMetadata] = db.withSession { implicit session =>
-    val selectQuery = Q.query[Int, (Int, String, Boolean, Float, Float, Int, Int, Int, Int, Int,
+    val selectQuery = Q.query[Int, (Int, String, Boolean, String, Float, Float, Int, Int, Int, Int, Int,
       Int, String, String, Option[java.sql.Timestamp], String, String, Option[Int], Boolean,
       Option[String])](
       """SELECT lb1.label_id,
         |       lb1.gsv_panorama_id,
         |       lb1.tutorial,
+        |       gsv_data.image_date,
         |       lp.heading,
         |       lp.pitch,
         |       lp.zoom,
@@ -362,6 +363,7 @@ object LabelTable {
         |       lb_big.temp,
         |       lb_big.description
         |FROM sidewalk.label AS lb1,
+        |     sidewalk.gsv_data,
         |     sidewalk.audit_task AS at,
         |     sidewalk_user AS u,
         |     sidewalk.label_point AS lp,
@@ -380,6 +382,7 @@ object LabelTable {
         |				  LEFT JOIN sidewalk.label_temporariness as lab_temp ON lb.label_id = lab_temp.label_id
         |		  ) AS lb_big
         |WHERE lb1.deleted = FALSE
+        |    AND lb1.gsv_panorama_id = gsv_data.gsv_panorama_id
         |    AND lb1.audit_task_id = at.audit_task_id
         |    AND lb1.label_id = lb_big.label_id
         |    AND at.user_id = u.user_id
@@ -391,12 +394,13 @@ object LabelTable {
   }
 
   def retrieveLabelMetadata(takeN: Int, userId: String): List[LabelMetadata] = db.withSession { implicit session =>
-    val selectQuery = Q.query[(String, Int),(Int, String, Boolean, Float, Float, Int, Int, Int, Int, Int,
+    val selectQuery = Q.query[(String, Int),(Int, String, Boolean, String, Float, Float, Int, Int, Int, Int, Int,
       Int, String, String, Option[java.sql.Timestamp], String, String, Option[Int], Boolean,
       Option[String])](
       """SELECT lb1.label_id,
         |       lb1.gsv_panorama_id,
         |       lb1.tutorial,
+        |       gsv_data.image_date,
         |       lp.heading,
         |       lp.pitch,
         |       lp.zoom,
@@ -414,6 +418,7 @@ object LabelTable {
         |       lb_big.temp,
         |       lb_big.description
         |FROM sidewalk.label AS lb1,
+        |     sidewalk.gsv_data,
         |     sidewalk.audit_task AS at,
         |     sidewalk_user AS u,
         |     sidewalk.label_point AS lp,
@@ -433,6 +438,7 @@ object LabelTable {
         |			) AS lb_big
         |WHERE u.user_id = ?
         |      AND lb1.deleted = FALSE
+        |      AND lb1.gsv_panorama_id = gsv_data.gsv_panorama_id
         |      AND lb1.audit_task_id = at.audit_task_id
         |      AND lb1.label_id = lb_big.label_id
         |      AND at.user_id = u.user_id
@@ -444,12 +450,13 @@ object LabelTable {
   }
 
   def retrieveSingleLabelMetadata(labelId: Int): LabelMetadata = db.withSession { implicit session =>
-    val selectQuery = Q.query[Int,(Int, String, Boolean, Float, Float, Int, Int, Int, Int, Int,
+    val selectQuery = Q.query[Int,(Int, String, Boolean, String, Float, Float, Int, Int, Int, Int, Int,
       Int, String, String, Option[java.sql.Timestamp], String, String, Option[Int], Boolean,
       Option[String])](
       """SELECT lb1.label_id,
         |       lb1.gsv_panorama_id,
         |       lb1.tutorial,
+        |       gsv_data.image_date,
         |       lp.heading,
         |       lp.pitch,
         |       lp.zoom,
@@ -467,6 +474,7 @@ object LabelTable {
         |       lb_big.temp,
         |       lb_big.description
         |FROM sidewalk.label AS lb1,
+        |     sidewalk.gsv_data,
         |     sidewalk.audit_task AS at,
         |     sidewalk_user AS u,
         |     sidewalk.label_point AS lp,
@@ -486,6 +494,7 @@ object LabelTable {
         |			) AS lb_big
         |WHERE lb1.label_id = ?
         |      AND lb1.audit_task_id = at.audit_task_id
+        |      AND lb1.gsv_panorama_id = gsv_data.gsv_panorama_id
         |      AND lb1.label_id = lb_big.label_id
         |      AND at.user_id = u.user_id
         |      AND lb1.label_id = lp.label_id
@@ -741,10 +750,10 @@ object LabelTable {
     * @param tags list of tags as strings
     * @return LabelMetadata object
     */
-  def labelAndTagsToLabelMetadata(label: (Int, String, Boolean, Float, Float, Int, Int, Int, Int, Int, Int, String, String, Option[java.sql.Timestamp], String, String, Option[Int], Boolean, Option[String]), tags: List[String]): LabelMetadata = {
+  def labelAndTagsToLabelMetadata(label: (Int, String, Boolean, String, Float, Float, Int, Int, Int, Int, Int, Int, String, String, Option[java.sql.Timestamp], String, String, Option[Int], Boolean, Option[String]), tags: List[String]): LabelMetadata = {
       LabelMetadata(label._1, label._2, label._3, label._4, label._5, label._6, label._7, label._8,
                     label._9,label._10,label._11,label._12,label._13,label._14,label._15,label._16,
-                    label._17, label._18, label._19, tags)
+                    label._17, label._18, label._19, label._20, tags)
   }
 
 //  case class LabelMetadata(labelId: Int, gsvPanoramaId: String, tutorial: Boolean heading: Float, pitch: Float,
@@ -759,6 +768,7 @@ object LabelTable {
       "label_id" -> labelMetadata.labelId,
       "gsv_panorama_id" -> labelMetadata.gsvPanoramaId,
       "tutorial" -> labelMetadata.tutorial,
+      "image_date" -> labelMetadata.imageDate,
       "heading" -> labelMetadata.heading,
       "pitch" -> labelMetadata.pitch,
       "zoom" -> labelMetadata.zoom,
@@ -784,6 +794,7 @@ object LabelTable {
       "label_id" -> labelMetadata.labelId,
       "gsv_panorama_id" -> labelMetadata.gsvPanoramaId,
       "tutorial" -> labelMetadata.tutorial,
+      "image_date" -> labelMetadata.imageDate,
       "heading" -> labelMetadata.heading,
       "pitch" -> labelMetadata.pitch,
       "zoom" -> labelMetadata.zoom,

--- a/public/javascripts/Admin/src/Admin.GSVLabelView.js
+++ b/public/javascripts/Admin/src/Admin.GSVLabelView.js
@@ -66,7 +66,7 @@ function AdminGSVLabelView(admin) {
         }
         self.modal = $(modalText);
 
-        self.panorama = AdminPanorama(self.modal.find("#svholder")[0]);
+        self.panorama = AdminPanorama(self.modal.find("#svholder")[0], admin);
 
         self.modalTimestamp = self.modal.find("#timestamp");
         self.modalLabelTypeValue = self.modal.find("#label-type-value");

--- a/public/javascripts/Admin/src/Admin.GSVLabelView.js
+++ b/public/javascripts/Admin/src/Admin.GSVLabelView.js
@@ -43,7 +43,10 @@ function AdminGSVLabelView(admin) {
                                 '<tr>'+
                                     '<th>Time Submitted</th>'+
                                     '<td id="timestamp" colspan="3"></td>'+
-                                '</tr>';
+                                '</tr>'+
+                                    '<th>Image Date</th>'+
+                                    '<td id="image-date" colspan="3"></td>'+
+            '                   </tr>';
         if (self.admin) {
             modalText += '<tr>'+
                 '<th>Task ID</th>' +
@@ -71,6 +74,7 @@ function AdminGSVLabelView(admin) {
         self.modalTemporary = self.modal.find("#temporary");
         self.modalTags = self.modal.find("#tags");
         self.modalDescription = self.modal.find("#label-description");
+        self.modalImageDate = self.modal.find("#image-date");
         self.modalTask = self.modal.find("#task");
     }
 
@@ -97,13 +101,14 @@ function AdminGSVLabelView(admin) {
         self.panorama.setLabel(adminPanoramaLabel);
 
         var labelDate = moment(new Date(labelMetadata['timestamp']));
+        var imageDate = moment(new Date(labelMetadata['image_date']));
         self.modalTimestamp.html(labelDate.format('MMMM Do YYYY, h:mm:ss') + " (" + labelDate.fromNow() + ")");
         self.modalLabelTypeValue.html(labelMetadata['label_type_value']);
         self.modalSeverity.html(labelMetadata['severity'] != null ? labelMetadata['severity'] : "No severity");
         self.modalTemporary.html(labelMetadata['temporary'] ? "True": "False");
-        //join is here to make the formatting nice, otherwise we don't have commas or spaces.
-        self.modalTags.html(labelMetadata['tags'].join(', '));
+        self.modalTags.html(labelMetadata['tags'].join(', ')); // Join to format using commas and spaces.
         self.modalDescription.html(labelMetadata['description'] != null ? labelMetadata['description'] : "No description");
+        self.modalImageDate.html(imageDate.format('MMMM YYYY'));
 
         if (self.admin) {
             self.modalTask.html("<a href='/admin/task/"+labelMetadata['audit_task_id']+"'>"+

--- a/public/javascripts/Admin/src/Admin.Panorama.js
+++ b/public/javascripts/Admin/src/Admin.Panorama.js
@@ -2,16 +2,18 @@
  *
  *
  * @param svHolder: One single DOM element
+ * @param admin
  * @returns {{className: string}}
  * @constructor
  */
-function AdminPanorama(svHolder) {
+function AdminPanorama(svHolder, admin) {
     var self = {
         className: "AdminPanorama",
         label: undefined,
         labelMarker: undefined,
         panoId: undefined,
-        panorama: undefined
+        panorama: undefined,
+        admin: admin
     };
 
     var icons = {
@@ -73,7 +75,7 @@ function AdminPanorama(svHolder) {
 
         if (self.panorama) {
             self.panorama.set('addressControl', false);
-            self.panorama.set('clickToGo', true);
+            self.panorama.set('clickToGo', false);
             self.panorama.set('disableDefaultUI', true);
             self.panorama.set('linksControl', false);
             self.panorama.set('navigationControl', false);
@@ -83,6 +85,10 @@ function AdminPanorama(svHolder) {
             self.panorama.set('motionTracking', false);
             self.panorama.set('motionTrackingControl', false);
             self.panorama.set('showRoadLabels', false);
+
+            // Disable moving by clicking if on /labelmap, enable if on admin page.
+            if (admin) self.panorama.set('clickToGo', true);
+            else       self.panorama.set('clickToGo', false);
         }
 
         return this;


### PR DESCRIPTION
Resolves #1928 
Resolves #1929 

Adds image date to the table below the pano on the /labelmap endpoint and on the admin page.

Also prevents walking by clicking on /labelmap (we left that functionality on the admin page). You can still navigate this way on the admin page. You can also still navigate if you use the arrow keys, but the fix for that was more complex than is worth expending on this.

Before
![labelmap-before](https://user-images.githubusercontent.com/6518824/67605380-1806c380-f733-11e9-9a23-49264db04ec7.png)

After
![labelmap-after](https://user-images.githubusercontent.com/6518824/67605384-1b01b400-f733-11e9-9175-b1d9949763ce.png)
