### PR TITLE
fixes bug where labelmap said there was no imagery

### DIFF
--- a/public/javascripts/Admin/src/Admin.Panorama.js
+++ b/public/javascripts/Admin/src/Admin.Panorama.js
@@ -115,23 +115,31 @@ function AdminPanorama(svHolder, admin) {
             // causes the screen to go black.
             // This callback gives time for the pano to load for 500ms. Afterwards, we trigger a
             // resize and reset the POV/Zoom.
-            function callback () {
+            function callback (n) {
                 google.maps.event.trigger(self.panorama, 'resize');
                 self.panorama.set('pov', {heading: heading, pitch: pitch});
                 self.panorama.set('zoom', zoomLevel[zoom]);
                 self.svHolder.css('visibility', 'visible');
 
-                // Show pano if it exists, or an error message if there is no GSV imagery.
+                // Show pano if it exists, an error message if there is no GSV imagery, and another error message if we
+                // wait a full 2 seconds without getting a response from Google.
                 if (self.panorama.getStatus() === "OK") {
                     $(self.panoCanvas).css('visibility', 'visible');
                     $(self.panoNotAvailable).css('visibility', 'hidden');
                     renderLabel(self.label);
-                } else {
+                } else if (self.panorama.getStatus() === "ZERO_RESULTS") {
+                    $(self.panoNotAvailable).text('No imagery available, try another label!');
                     $(self.panoCanvas).css('visibility', 'hidden');
                     $(self.panoNotAvailable).css('visibility', 'visible');
+                } else if (n < 1) {
+                    $(self.panoNotAvailable).text('We had trouble connecting to Google Street View, please try again later!');
+                    $(self.panoCanvas).css('visibility', 'hidden');
+                    $(self.panoNotAvailable).css('visibility', 'visible');
+                } else {
+                    setTimeout(callback, 100, n - 1);
                 }
             }
-            setTimeout(callback, 500);
+            setTimeout(callback, 100, 20);
         }
         return this;
     }


### PR DESCRIPTION
fixes #1935 

**Before**: we would query Google, wait 500ms, then show the pano if we had it, and showed a no imagery error message if we didn't have it (whether this was b/c we hadn't received a response yet OR if we received a response saying there was no imagery).

**After**: we query Google, then every 100ms we check if we've got a response. If it is a good response we show the pano. If it says there is no imagery, we show the no imagery error message. If we wait a full 2 seconds without getting a response from Google, we show a message saying we had trouble connecting with Google and they should try again later.

This will improve performance on good connections, where the pano (or no imagery error message) will now show after only 200-300ms instead of the 500ms we were waiting every time before. And on a slow connection the pano should show after 1 second or however long it takes.

Here is what the new error message looks like (I don't expect to see this much, if ever).

![try-again-later](https://user-images.githubusercontent.com/6518824/67790999-f14ad480-fa33-11e9-8085-d74fcd51dc09.png)
