### PR TITLE
v6.6.5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import scalariform.formatter.preferences._
 
 name := """sidewalk-webpage"""
 
-version := "6.6.4"
+version := "6.6.5"
 
 scalaVersion := "2.10.4"
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import scalariform.formatter.preferences._
 
 name := """sidewalk-webpage"""
 
-version := "6.6.3"
+version := "6.6.4"
 
 scalaVersion := "2.10.4"
 

--- a/conf/evolutions/default/66.sql
+++ b/conf/evolutions/default/66.sql
@@ -1,0 +1,5 @@
+# --- !Ups
+INSERT INTO version VALUES ('6.6.4', now(), 'Adds a new map visualization at /labelmap.');
+
+# --- !Downs
+DELETE FROM version WHERE version_id = '6.6.4';

--- a/conf/evolutions/default/67.sql
+++ b/conf/evolutions/default/67.sql
@@ -1,0 +1,5 @@
+# --- !Ups
+INSERT INTO version VALUES ('6.6.5', now(), 'Fixes /labelmap bug erroneously saying there was no imagery.');
+
+# --- !Downs
+DELETE FROM version WHERE version_id = '6.6.5';


### PR DESCRIPTION
Fixes /labelmap bug erroneously saying there was no imagery #1935 (PR #1936)