### PR TITLE
1930 labelmap validation support

### DIFF
--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -351,17 +351,37 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
     }
   }
 
-  def getLabelData(labelId: Int) = UserAwareAction.async { implicit request =>
+  /**
+   * Get metadata for a given label ID (for admins; includes personal identifiers like username).
+   * @param labelId
+   * @return
+   */
+  def getAdminLabelData(labelId: Int) = UserAwareAction.async { implicit request =>
     if (isAdmin(request.identity)) {
       LabelPointTable.find(labelId) match {
         case Some(labelPointObj) =>
           val labelMetadata: LabelMetadata = LabelTable.getLabelMetadata(labelId)
-          val labelMetadataJson: JsObject = LabelTable.labelMetadataToJson(labelMetadata)
+          val labelMetadataJson: JsObject = LabelTable.labelMetadataToJsonAdmin(labelMetadata)
           Future.successful(Ok(labelMetadataJson))
         case _ => Future.successful(Ok(Json.obj("error" -> "no such label")))
       }
     } else {
       Future.successful(Redirect("/"))
+    }
+  }
+
+  /**
+   * Get metadata for a given label ID (excludes personal identifiers like username).
+   * @param labelId
+   * @return
+   */
+  def getLabelData(labelId: Int) = UserAwareAction.async { implicit request =>
+    LabelPointTable.find(labelId) match {
+      case Some(labelPointObj) =>
+        val labelMetadata: LabelMetadata = LabelTable.getLabelMetadata(labelId)
+        val labelMetadataJson: JsObject = LabelTable.labelMetadataToJson(labelMetadata)
+        Future.successful(Ok(labelMetadataJson))
+      case _ => Future.successful(Ok(Json.obj("error" -> "no such label")))
     }
   }
 

--- a/app/controllers/ValidationTaskController.scala
+++ b/app/controllers/ValidationTaskController.scala
@@ -145,7 +145,7 @@ class ValidationTaskController @Inject() (implicit val env: Environment[User, Se
           MissionTable.resumeOrCreateNewValidationMission(userId, 0.0D, 0.0D, "labelmapValidation", labelTypeId).get
 
         // Insert a label_validation entry for this label.
-        LabelValidationTable.save(LabelValidation(0, submission.labelId, submission.validationResult,
+        LabelValidationTable.insertOrUpdate(LabelValidation(0, submission.labelId, submission.validationResult,
           request.identity.get.userId.toString, mission.missionId, submission.canvasX, submission.canvasY,
           submission.heading, submission.pitch, submission.zoom, submission.canvasHeight, submission.canvasWidth,
           new Timestamp(submission.startTimestamp), new Timestamp(submission.endTimestamp), submission.isMobile))

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -754,7 +754,7 @@ object LabelTable {
 //                           timestamp: java.sql.Timestamp,
 //                           labelTypeKey:String, labelTypeValue: String, severity: Option[Int],
 //                           temporary: Boolean, description: Option[String])
-  def labelMetadataToJson(labelMetadata: LabelMetadata): JsObject = {
+  def labelMetadataToJsonAdmin(labelMetadata: LabelMetadata): JsObject = {
     Json.obj(
       "label_id" -> labelMetadata.labelId,
       "gsv_panorama_id" -> labelMetadata.gsvPanoramaId,
@@ -769,6 +769,28 @@ object LabelTable {
       "audit_task_id" -> labelMetadata.auditTaskId,
       "user_id" -> labelMetadata.userId,
       "username" -> labelMetadata.username,
+      "timestamp" -> labelMetadata.timestamp,
+      "label_type_key" -> labelMetadata.labelTypeKey,
+      "label_type_value" -> labelMetadata.labelTypeValue,
+      "severity" -> labelMetadata.severity,
+      "temporary" -> labelMetadata.temporary,
+      "description" -> labelMetadata.description,
+      "tags" -> labelMetadata.tags
+    )
+  }
+  // Has the label metadata excluding username, user_id, and audit_task_id.
+  def labelMetadataToJson(labelMetadata: LabelMetadata): JsObject = {
+    Json.obj(
+      "label_id" -> labelMetadata.labelId,
+      "gsv_panorama_id" -> labelMetadata.gsvPanoramaId,
+      "tutorial" -> labelMetadata.tutorial,
+      "heading" -> labelMetadata.heading,
+      "pitch" -> labelMetadata.pitch,
+      "zoom" -> labelMetadata.zoom,
+      "canvas_x" -> labelMetadata.canvasX,
+      "canvas_y" -> labelMetadata.canvasY,
+      "canvas_width" -> labelMetadata.canvasWidth,
+      "canvas_height" -> labelMetadata.canvasHeight,
       "timestamp" -> labelMetadata.timestamp,
       "label_type_key" -> labelMetadata.labelTypeKey,
       "label_type_value" -> labelMetadata.labelTypeValue,

--- a/app/models/label/LabelValidationTable.scala
+++ b/app/models/label/LabelValidationTable.scala
@@ -116,6 +116,26 @@ object LabelValidationTable {
   }
 
   /**
+   * Updates validation if one already exists for this mission. Inserts a new one o/w.
+   * @param label
+   * @return
+   */
+  def insertOrUpdate(label: LabelValidation): Int = db.withTransaction { implicit session =>
+    val oldValidation: Option[LabelValidation] =
+      validationLabels.filter(x => x.labelId === label.labelId && x.missionId === label.missionId).list.headOption
+
+    oldValidation match {
+      case Some(oldLabel) =>
+        val q = for {
+          validation <- validationLabels if validation.labelId === label.labelId && validation.missionId === label.missionId
+        } yield (validation.validationResult, validation. startTimestamp, validation. endTimestamp)
+        q.update((label.labelValidationId, label.startTimestamp, label.endTimestamp))
+      case None =>
+        save(label)
+    }
+  }
+
+  /**
     * Select validation counts per user.
     *
     * @return list of tuples of (labeler_id, validator_role, distinct_labels_validated, validation_count,

--- a/conf/evolutions/default/68.sql
+++ b/conf/evolutions/default/68.sql
@@ -3,7 +3,7 @@ INSERT INTO mission_type (mission_type) VALUES ('labelmapValidation');
 
 # --- !Downs
 UPDATE mission
-SET mission_type_id = 4, completed = TRUE, labels_validated = 1, labels_progress = 1
+SET mission_type_id = 4, completed = TRUE, labels_progress = 1
 WHERE mission_type_id = 7;
 
 DELETE FROM mission_type WHERE mission_type = 'labelmapValidation';

--- a/conf/routes
+++ b/conf/routes
@@ -55,7 +55,7 @@ GET     /adminapi/labelLocations/:username                   @controllers.AdminC
 GET     /adminapi/labels/all                                 @controllers.AdminController.getAllLabels
 GET     /adminapi/labels/panoid                              @controllers.AdminController.getAllPanoIds
 GET     /adminapi/labels/cv                                  @controllers.AdminController.getAllLabelCVMetadata
-GET     /adminapi/label/:labelId                             @controllers.AdminController.getLabelData(labelId: Int)
+GET     /adminapi/label/:labelId                             @controllers.AdminController.getAdminLabelData(labelId: Int)
 GET     /adminapi/labelCounts                                @controllers.AdminController.getAllUserLabelCounts
 GET     /adminapi/attributes/all                             @controllers.AdminController.getAllAttributes
 GET     /adminapi/validationCounts                           @controllers.AdminController.getAllUserValidationCounts
@@ -69,6 +69,7 @@ GET     /adminapi/choroplethCounts                           @controllers.AdminC
 PUT     /adminapi/setRole                                    @controllers.AdminController.setUserRole
 
 GET     /labels/all                                          @controllers.AdminController.getAllLabelsForLabelMap
+GET     /label/:labelId                                      @controllers.AdminController.getLabelData(labelId: Int)
 
 # Auditing tasks
 GET     /audit                                               @controllers.AuditController.audit(nextRegion: Option[String] ?= None, retakeTutorial: Option[Boolean] ?= None)

--- a/public/javascripts/Admin/src/Admin.GSVLabelView.js
+++ b/public/javascripts/Admin/src/Admin.GSVLabelView.js
@@ -88,7 +88,7 @@ function AdminGSVLabelView(admin) {
         }
         self.modal = $(modalText);
 
-        self.panorama = AdminPanorama(self.modal.find("#svholder")[0], admin);
+        self.panorama = AdminPanorama(self.modal.find("#svholder")[0], self.modal.find("#validation-button-holder"), admin);
 
         self.agreeButton = self.modal.find("#validation-agree-button");
         self.disagreeButton = self.modal.find("#validation-disagree-button");
@@ -205,7 +205,7 @@ function AdminGSVLabelView(admin) {
         }
         var currButton = self.resultButtons[action];
         currButton.css('background-color', '#696969');
-        currButton.css('color', '#FFFFFF');
+        currButton.css('color', 'white');
     }
 
     function showLabel(labelId) {

--- a/public/javascripts/Admin/src/Admin.GSVLabelView.js
+++ b/public/javascripts/Admin/src/Admin.GSVLabelView.js
@@ -18,6 +18,21 @@ function AdminGSVLabelView(admin) {
                         '<div class="modal-body">'+
                             '<div id="svholder" style="width: 540px; height:360px">'+
                         '</div>'+
+                        '<div id="validation-button-holder">' +
+                            '<p>Is this label correct?</p>' +
+                            '<button id="validation-agree-button" class="validation-button"' +
+                                'style="height: 50px; width: 179px; background-color: white; margin-right: 2px border-radius: 5px; border-width: 2px; border-color: lightgrey;">' +
+                                'Agree' +
+                            '</button>' +
+                            '<button id="validation-disagree-button" class="validation-button"' +
+                                'style="height: 50px; width: 179px; background-color: white; margin-right: 2px border-radius: 5px; border-width: 2px; border-color: lightgrey;">' +
+                                'Disagree' +
+                            '</button>' +
+                            '<button id="validation-not-sure-button" class="validation-button"' +
+                                'style="height: 50px; width: 179px; background-color: white; margin-right: 2px border-radius: 5px; border-width: 2px; border-color: lightgrey;">' +
+                                'Not sure' +
+                            '</button>' +
+                        '</div>' +
                         '<div class="modal-footer">'+
                             '<table class="table table-striped" style="font-size:small; margin-bottom: 0">'+
                                 '<tr>'+
@@ -65,6 +80,20 @@ function AdminGSVLabelView(admin) {
 
         self.panorama = AdminPanorama(self.modal.find("#svholder")[0]);
 
+        self.agreeButton = self.modal.find("#validation-agree-button");
+        self.disagreeButton = self.modal.find("#validation-disagree-button");
+        self.notSureButton = self.modal.find("#validation-not-sure-button");
+
+        self.agreeButton.click(function() {
+            _validateLabel("Agree");
+        });
+        self.disagreeButton.click(function() {
+            _validateLabel("Disagree");
+        });
+        self.notSureButton.click(function() {
+            _validateLabel("NotSure");
+        });
+
         self.modalTimestamp = self.modal.find("#timestamp");
         self.modalLabelTypeValue = self.modal.find("#label-type-value");
         self.modalSeverity = self.modal.find("#severity");
@@ -72,6 +101,11 @@ function AdminGSVLabelView(admin) {
         self.modalTags = self.modal.find("#tags");
         self.modalDescription = self.modal.find("#label-description");
         self.modalTask = self.modal.find("#task");
+    }
+
+    function _validateLabel(action) {
+        var timestamp = new Date().getTime();
+        console.log("post req to say we clicked " + action);
     }
 
     function showLabel(labelId) {

--- a/public/javascripts/Admin/src/Admin.GSVLabelView.js
+++ b/public/javascripts/Admin/src/Admin.GSVLabelView.js
@@ -1,13 +1,14 @@
-function AdminGSVLabelView() {
+function AdminGSVLabelView(admin) {
     var self = {};
+    self.admin = admin;
 
     var _init = function() {
         _resetModal();
     };
 
     function _resetModal() {
-        self.modal =
-            $('<div class="modal fade" id="labelModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">'+
+        var modalText =
+            '<div class="modal fade" id="labelModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">'+
                 '<div class="modal-dialog" role="document" style="width: 570px">'+
                     '<div class="modal-content">'+
                         '<div class="modal-header">'+
@@ -19,39 +20,48 @@ function AdminGSVLabelView() {
                         '</div>'+
                         '<div class="modal-footer">'+
                             '<table class="table table-striped" style="font-size:small; margin-bottom: 0">'+
-                            '<tr>'+
-                                '<th>Label Type</th>'+
-                                '<td id="label-type-value"></td>'+
-                            '</tr>'+
-                            '<tr>' +
-                                '<th>Severity</th>'+
-                                '<td id="severity"></td>'+
-                            '</tr>'+
-                            '<tr>'+
-                                '<th>Task ID</th>' +
-                                '<td id="task"></td>' +
-                            '</tr>'+
-                            '<tr>' +
-                                '<th>Temporary</th>'+
-                                '<td id="temporary"></td>'+
-                            '</tr>'+
-                            '<tr>'+
-                                '<th>Tags</th>'+
-                                '<td colspan="3" id="tags"></td>'+
-                            '</tr>'+
-                            '<tr>'+
-                                '<th>Description</th>'+
-                                '<td colspan="3" id="label-description"></td>'+
-                            '</tr>'+
-                            '<tr>'+
-                            '<th>Time Submitted</th>'+
-                            '<td id="timestamp" colspan="3"></td>'+
-                            '</tr>'+
-                            '</table>'+
-                        '</div>'+
-                    '</div>'+
+                                '<tr>'+
+                                    '<th>Label Type</th>'+
+                                    '<td id="label-type-value"></td>'+
+                                '</tr>'+
+                                '<tr>' +
+                                    '<th>Severity</th>'+
+                                    '<td id="severity"></td>'+
+                                '</tr>'+
+                                '<tr>' +
+                                    '<th>Temporary</th>'+
+                                    '<td id="temporary"></td>'+
+                                '</tr>'+
+                                '<tr>'+
+                                    '<th>Tags</th>'+
+                                    '<td colspan="3" id="tags"></td>'+
+                                '</tr>'+
+                                '<tr>'+
+                                    '<th>Description</th>'+
+                                    '<td colspan="3" id="label-description"></td>'+
+                                '</tr>'+
+                                '<tr>'+
+                                    '<th>Time Submitted</th>'+
+                                    '<td id="timestamp" colspan="3"></td>'+
+                                '</tr>';
+        if (self.admin) {
+            modalText += '<tr>'+
+                '<th>Task ID</th>' +
+                '<td id="task"></td>' +
+                '</tr>'+
+                '</table>'+
                 '</div>'+
-            '</div>');
+                '</div>'+
+                '</div>'+
+                '</div>'
+        } else {
+            modalText += '</table>'+
+                '</div>'+
+                '</div>'+
+                '</div>'+
+                '</div>'
+        }
+        self.modal = $(modalText);
 
         self.panorama = AdminPanorama(self.modal.find("#svholder")[0]);
 
@@ -70,9 +80,9 @@ function AdminGSVLabelView() {
         self.modal.modal({
             'show': true
         });
-        var adminLabelUrl = "/adminapi/label/" + labelId;
+        var adminLabelUrl = admin ? "/adminapi/label/" + labelId : "/label/" + labelId;
         $.getJSON(adminLabelUrl, function (data) {
-            _handleData(data);
+            _handleData(data, admin);
         });
     }
 
@@ -94,9 +104,12 @@ function AdminGSVLabelView() {
         //join is here to make the formatting nice, otherwise we don't have commas or spaces.
         self.modalTags.html(labelMetadata['tags'].join(', '));
         self.modalDescription.html(labelMetadata['description'] != null ? labelMetadata['description'] : "No description");
-        self.modalTask.html("<a href='/admin/task/"+labelMetadata['audit_task_id']+"'>"+
-            labelMetadata['audit_task_id']+"</a> by <a href='/admin/user/" + labelMetadata['username'] + "'>" +
-            labelMetadata['username'] + "</a>");
+
+        if (self.admin) {
+            self.modalTask.html("<a href='/admin/task/"+labelMetadata['audit_task_id']+"'>"+
+                labelMetadata['audit_task_id']+"</a> by <a href='/admin/user/" + labelMetadata['username'] + "'>" +
+                labelMetadata['username'] + "</a>");
+        }
     }
 
     _init();

--- a/public/javascripts/Admin/src/Admin.GSVLabelView.js
+++ b/public/javascripts/Admin/src/Admin.GSVLabelView.js
@@ -26,7 +26,7 @@ function AdminGSVLabelView(admin) {
                             '<div id="svholder" style="width: 540px; height:360px">'+
                         '</div>'+
                         '<div id="validation-button-holder">' +
-                            '<p>Is this label correct?</p>' +
+                            '<h3>Is this label correct?</h3>' +
                             '<button id="validation-agree-button" class="validation-button"' +
                                 'style="height: 50px; width: 179px; background-color: white; margin-right: 2px border-radius: 5px; border-width: 2px; border-color: lightgrey;">' +
                                 'Agree' +

--- a/public/javascripts/Admin/src/Admin.GSVLabelView.js
+++ b/public/javascripts/Admin/src/Admin.GSVLabelView.js
@@ -93,6 +93,11 @@ function AdminGSVLabelView(admin) {
         self.agreeButton = self.modal.find("#validation-agree-button");
         self.disagreeButton = self.modal.find("#validation-disagree-button");
         self.notSureButton = self.modal.find("#validation-not-sure-button");
+        self.resultButtons = {
+            "Agree": self.agreeButton,
+            "Disagree": self.disagreeButton,
+            "NotSure": self.notSureButton
+        };
 
         self.agreeButton.click(function() {
             _validateLabel("Agree");
@@ -178,12 +183,29 @@ function AdminGSVLabelView(admin) {
             data: JSON.stringify(data),
             dataType: 'json',
             success: function (result) {
-                console.log(result);
+                _resetButtonColors(action);
             },
             error: function (result) {
                 console.error(result);
             }
         });
+    }
+
+    /**
+     * Sets background color of clicked button to gray, resets all others to white.
+     * @param action
+     * @private
+     */
+    function _resetButtonColors(action) {
+        for (var button in self.resultButtons) {
+            if (self.resultButtons.hasOwnProperty(button)) {
+                self.resultButtons[button].css('background-color', 'white');
+                self.resultButtons[button].css('color', 'black');
+            }
+        }
+        var currButton = self.resultButtons[action];
+        currButton.css('background-color', '#696969');
+        currButton.css('color', '#FFFFFF');
     }
 
     function showLabel(labelId) {

--- a/public/javascripts/Admin/src/Admin.LabelSearch.js
+++ b/public/javascripts/Admin/src/Admin.LabelSearch.js
@@ -3,7 +3,7 @@ function AdminLabelSearch() {
 
 
     function _init() {
-        adminGSVLabelView = AdminGSVLabelView();
+        adminGSVLabelView = AdminGSVLabelView(true);
     }
 
     // Prevents the page from refreshing when the enter key is pressed.

--- a/public/javascripts/Admin/src/Admin.Panorama.js
+++ b/public/javascripts/Admin/src/Admin.Panorama.js
@@ -48,7 +48,16 @@ function AdminPanorama(svHolder) {
             height: self.svHolder.height()
         })[0];
 
+        self.panoNotAvailable = $("<div id='pano-not-avail'>No imagery available, try another label!</div>").css({
+            width: '100%',
+            height: '100%',
+            position: 'absolute',
+            top: '0',
+            'font-size': '200%'
+        })[0];
+
         self.svHolder.append($(self.panoCanvas));
+        self.svHolder.append($(self.panoNotAvailable));
 
         self.panorama = typeof google != "undefined" ? new google.maps.StreetViewPanorama(self.panoCanvas, { mode: 'html4' }) : null;
         self.panorama.addListener('pano_changed', function() {
@@ -105,7 +114,16 @@ function AdminPanorama(svHolder) {
                 self.panorama.set('pov', {heading: heading, pitch: pitch});
                 self.panorama.set('zoom', zoomLevel[zoom]);
                 self.svHolder.css('visibility', 'visible');
-                renderLabel(self.label);
+
+                // Show pano if it exists, or an error message if there is no GSV imagery.
+                if (self.panorama.getStatus() === "OK") {
+                    $(self.panoCanvas).css('visibility', 'visible');
+                    $(self.panoNotAvailable).css('visibility', 'hidden');
+                    renderLabel(self.label);
+                } else {
+                    $(self.panoCanvas).css('visibility', 'hidden');
+                    $(self.panoNotAvailable).css('visibility', 'visible');
+                }
             }
             setTimeout(callback, 500);
         }

--- a/public/javascripts/Admin/src/Admin.Panorama.js
+++ b/public/javascripts/Admin/src/Admin.Panorama.js
@@ -6,7 +6,7 @@
  * @returns {{className: string}}
  * @constructor
  */
-function AdminPanorama(svHolder, admin) {
+function AdminPanorama(svHolder, buttonHolder, admin) {
     var self = {
         className: "AdminPanorama",
         label: undefined,
@@ -37,6 +37,7 @@ function AdminPanorama(svHolder, admin) {
      * This function initializes the Panorama
      */
     function _init () {
+        self.buttonHolder = $(buttonHolder);
         self.svHolder = $(svHolder);
         self.svHolder.addClass("admin-panorama");
 
@@ -126,15 +127,18 @@ function AdminPanorama(svHolder, admin) {
                 if (self.panorama.getStatus() === "OK") {
                     $(self.panoCanvas).css('visibility', 'visible');
                     $(self.panoNotAvailable).css('visibility', 'hidden');
+                    $(self.buttonHolder).css('visibility', 'visible');
                     renderLabel(self.label);
                 } else if (self.panorama.getStatus() === "ZERO_RESULTS") {
                     $(self.panoNotAvailable).text('No imagery available, try another label!');
                     $(self.panoCanvas).css('visibility', 'hidden');
                     $(self.panoNotAvailable).css('visibility', 'visible');
+                    $(self.buttonHolder).css('visibility', 'hidden');
                 } else if (n < 1) {
                     $(self.panoNotAvailable).text('We had trouble connecting to Google Street View, please try again later!');
                     $(self.panoCanvas).css('visibility', 'hidden');
                     $(self.panoNotAvailable).css('visibility', 'visible');
+                    $(self.buttonHolder).css('visibility', 'hidden');
                 } else {
                     setTimeout(callback, 100, n - 1);
                 }

--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -480,7 +480,7 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
     }
 
     function initializeAdminGSVLabelView() {
-        self.adminGSVLabelView = AdminGSVLabelView();
+        self.adminGSVLabelView = AdminGSVLabelView(true);
     }
 
     function initializeAdminLabelSearch() {

--- a/public/javascripts/LabelMap.js
+++ b/public/javascripts/LabelMap.js
@@ -210,7 +210,6 @@ function LabelMap(_, $) {
     function initializeSubmittedLabels(map) {
 
         $.getJSON("/labels/all", function (data) {
-            console.log("doing the label thing");
             // Count a number of each label type
             var labelCounter = {
                 "CurbRamp": 0,

--- a/public/javascripts/LabelMap.js
+++ b/public/javascripts/LabelMap.js
@@ -347,7 +347,7 @@ function LabelMap(_, $) {
     }, 1);
 
     function initializeAdminGSVLabelView() {
-        self.adminGSVLabelView = AdminGSVLabelView();
+        self.adminGSVLabelView = AdminGSVLabelView(false);
     }
 
 


### PR DESCRIPTION
Resolves #1930 

Adds validation support to the /labelmap endpoint. This also adds it to the map tab on the admin page.
![labelmap-1](https://user-images.githubusercontent.com/6518824/68061229-1a33c980-fcc1-11e9-8181-e846200e00eb.png)

When you click on the button, it sends a request to the back-end to update the `label_validation` table. Once it has been updated, the button changes shade. If you pick a different option afterward, it gets updated in the database and the shading switches to the new button.
![labelmap-2](https://user-images.githubusercontent.com/6518824/68061275-3b94b580-fcc1-11e9-8d51-5b417f96b9ab.png)
![labelmap-3](https://user-images.githubusercontent.com/6518824/68061278-3cc5e280-fcc1-11e9-8963-58341d0339d3.png)

These validations are separated from normal validations by having a different mission type. 