### PR TITLE
adds validation data to /labelmap popup

### DIFF
--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -1,6 +1,7 @@
 package controllers
 
 import java.util.UUID
+
 import javax.inject.Inject
 import java.net.URLDecoder
 
@@ -13,7 +14,7 @@ import formats.json.UserRoleSubmissionFormats._
 import models.attribute.{GlobalAttribute, GlobalAttributeTable}
 import models.audit.{AuditTaskInteractionTable, AuditTaskTable, InteractionWithLabel}
 import models.daos.slick.DBTableDefinitions.UserTable
-import models.label.LabelTable.LabelMetadata
+import models.label.LabelTable.LabelMetadataWithValidation
 import models.label.{LabelPointTable, LabelTable, LabelTypeTable, LabelValidationTable}
 import models.mission.MissionTable
 import models.region.RegionCompletionTable
@@ -360,8 +361,8 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
     if (isAdmin(request.identity)) {
       LabelPointTable.find(labelId) match {
         case Some(labelPointObj) =>
-          val labelMetadata: LabelMetadata = LabelTable.getLabelMetadata(labelId)
-          val labelMetadataJson: JsObject = LabelTable.labelMetadataToJsonAdmin(labelMetadata)
+          val labelMetadata: LabelMetadataWithValidation = LabelTable.getLabelMetadata(labelId)
+          val labelMetadataJson: JsObject = LabelTable.labelMetadataWithValidationToJsonAdmin(labelMetadata)
           Future.successful(Ok(labelMetadataJson))
         case _ => Future.successful(Ok(Json.obj("error" -> "no such label")))
       }
@@ -378,8 +379,8 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
   def getLabelData(labelId: Int) = UserAwareAction.async { implicit request =>
     LabelPointTable.find(labelId) match {
       case Some(labelPointObj) =>
-        val labelMetadata: LabelMetadata = LabelTable.getLabelMetadata(labelId)
-        val labelMetadataJson: JsObject = LabelTable.labelMetadataToJson(labelMetadata)
+        val labelMetadata: LabelMetadataWithValidation = LabelTable.getLabelMetadata(labelId)
+        val labelMetadataJson: JsObject = LabelTable.labelMetadataWithValidationToJson(labelMetadata)
         Future.successful(Ok(labelMetadataJson))
       case _ => Future.successful(Ok(Json.obj("error" -> "no such label")))
     }

--- a/public/javascripts/Admin/src/Admin.GSVLabelView.js
+++ b/public/javascripts/Admin/src/Admin.GSVLabelView.js
@@ -59,8 +59,12 @@ function AdminGSVLabelView(admin) {
                                     '<td colspan="3" id="tags"></td>'+
                                 '</tr>'+
                                 '<tr>'+
-                                    '<th>Description</th>'+
-                                    '<td colspan="3" id="label-description"></td>'+
+                                '<th>Description</th>'+
+                                '<td colspan="3" id="label-description"></td>'+
+                                '</tr>'+
+                                '<tr>'+
+                                '<th>Validations</th>'+
+                                '<td colspan="3" id="label-validations"></td>'+
                                 '</tr>'+
                                 '<tr>'+
                                     '<th>Time Submitted</th>'+
@@ -115,6 +119,7 @@ function AdminGSVLabelView(admin) {
         self.modalTemporary = self.modal.find("#temporary");
         self.modalTags = self.modal.find("#tags");
         self.modalDescription = self.modal.find("#label-description");
+        self.modalValidations = self.modal.find("#label-validations");
         self.modalImageDate = self.modal.find("#image-date");
         self.modalTask = self.modal.find("#task");
     }
@@ -230,6 +235,10 @@ function AdminGSVLabelView(admin) {
             labelMetadata['pitch'], labelMetadata['zoom']);
         self.panorama.setLabel(adminPanoramaLabel);
 
+        var validationsText = '' + labelMetadata['num_agree'] + ' Agree, ' +
+            labelMetadata['num_disagree'] + ' Disagree, ' +
+            labelMetadata['num_unsure'] + ' Not Sure';
+
         var labelDate = moment(new Date(labelMetadata['timestamp']));
         var imageDate = moment(new Date(labelMetadata['image_date']));
         self.modalTimestamp.html(labelDate.format('MMMM Do YYYY, h:mm:ss') + " (" + labelDate.fromNow() + ")");
@@ -238,6 +247,7 @@ function AdminGSVLabelView(admin) {
         self.modalTemporary.html(labelMetadata['temporary'] ? "True": "False");
         self.modalTags.html(labelMetadata['tags'].join(', ')); // Join to format using commas and spaces.
         self.modalDescription.html(labelMetadata['description'] != null ? labelMetadata['description'] : "No description");
+        self.modalValidations.html(validationsText);
         self.modalImageDate.html(imageDate.format('MMMM YYYY'));
 
         if (self.admin) {


### PR DESCRIPTION
Resolves #1932 

Adds validation data when clicking on a label on /labelmap or the admin page.

![labelmap-validation-metadata](https://user-images.githubusercontent.com/6518824/68337873-4327d600-0096-11ea-92e5-7e6ee00b1205.png)
