### PR TITLE
landing page city links are now white

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1045,7 +1045,7 @@ video#bgvid {
 }
 
 .exploremaplink:link {
-    color: rgba(251, 215, 139, 1);
+    color: #fff;
     text-decoration:underline;
     font-family: raleway;
     font-size: 15px;
@@ -1056,10 +1056,10 @@ video#bgvid {
     cursor: pointer;
 }
 .exploremaplink:visited {
-    color: rgba(251, 215, 139, 1);
+    color: #fff;
 }
 .exploremaplink:hover {
-    color: #fff;
+    color: rgba(251, 215, 139, 1);
 }
 
 


### PR DESCRIPTION
Resolves #1949 

Links to other cities on the landing page are now white (then yellow on hover) instead of yellow and then white on hover. This should make them more readable.

Before
![image](https://user-images.githubusercontent.com/1621749/68253150-144d2980-ffdc-11e9-8f39-3070c58bf7c4.png)
After
![white-landing-page-links](https://user-images.githubusercontent.com/6518824/68425056-1e953200-015a-11ea-98aa-5a688fa6dfec.png)
