### PR TITLE
temporarily removed columbus city link from landing page

### DIFF
--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -34,7 +34,7 @@
                     <a class="bodyStartBtn" href="@routes.AuditController.audit()">Start Exploring @cityShortName</a>
                     <br><br>
                     <span class="header-text">We are also in:</span>
-                    @for((cityName, cityURL) <- otherCityURLs) {
+                    @for((cityName, cityURL) <- otherCityURLs.filter(_._1 != "Columbus, OH")) {
                         <a class="exploremaplink" href="@{cityURL + "/audit"}">@cityName</a> &nbsp;
                     }
 


### PR DESCRIPTION
This is a temporary code change where we manually remove the link to the nonexistent Columbus server from the landing page for Seattle and Newberg. When I added Columbus support to the configs (#1942) it automatically added a link to Columbus to Seattle and Newberg landing pages. I wanted to temporarily remove that so I can push the current develop code to the prod servers without a dead link on the landing page.