### PR TITLE
1960 labelmap other label type blank

### DIFF
--- a/conf/evolutions/default/70.sql
+++ b/conf/evolutions/default/70.sql
@@ -1,0 +1,5 @@
+# --- !Ups
+UPDATE label_type SET description = 'Other' WHERE label_type = 'Other';
+
+# --- !Downs
+UPDATE label_type SET description = '' WHERE label_type = 'Other';

--- a/public/javascripts/Admin/src/Admin.GSVLabelView.js
+++ b/public/javascripts/Admin/src/Admin.GSVLabelView.js
@@ -20,7 +20,7 @@ function AdminGSVLabelView(admin) {
                     '<div class="modal-content">'+
                         '<div class="modal-header">'+
                             '<button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>'+
-                            '<h4 class="modal-title" id="myModalLabel">Label</h4>'+
+                            '<h4 class="modal-title" id="myModalLabel"></h4>'+
                         '</div>'+
                         '<div class="modal-body">'+
                             '<div id="svholder" style="width: 540px; height:360px">'+
@@ -113,6 +113,7 @@ function AdminGSVLabelView(admin) {
             _validateLabel("NotSure");
         });
 
+        self.modalTitle = self.modal.find("#myModalLabel");
         self.modalTimestamp = self.modal.find("#timestamp");
         self.modalLabelTypeValue = self.modal.find("#label-type-value");
         self.modalSeverity = self.modal.find("#severity");
@@ -241,6 +242,7 @@ function AdminGSVLabelView(admin) {
 
         var labelDate = moment(new Date(labelMetadata['timestamp']));
         var imageDate = moment(new Date(labelMetadata['image_date']));
+        self.modalTitle.html('Label Type: ' + labelMetadata['label_type_value']);
         self.modalTimestamp.html(labelDate.format('MMMM Do YYYY, h:mm:ss') + " (" + labelDate.fromNow() + ")");
         self.modalLabelTypeValue.html(labelMetadata['label_type_value']);
         self.modalSeverity.html(labelMetadata['severity'] != null ? labelMetadata['severity'] : "No severity");


### PR DESCRIPTION
Fixes #1960 

The label type row for "Other" labels is no longer blank on the label popup on /labelmap. Also adds the label type to the title of the label popup.

![labelmap-other](https://user-images.githubusercontent.com/6518824/68509172-32599a80-0225-11ea-9978-f9d6ad9d48c0.png)
