### PR TITLE
1372 Give options for mission flow

### DIFF
--- a/app/views/audit.scala.html
+++ b/app/views/audit.scala.html
@@ -607,7 +607,8 @@
                                     <button class="btn blue-btn" id="modal-mission-complete-generate-confirmation-button">Click to generate HIT confirmation code</button>
                                 }
                             }
-                            <button class="btn blue-btn" id="modal-mission-complete-close-button">Continue</button>
+                            <button class="btn btn-primary" id="modal-mission-complete-close-button-primary"></button>
+                            <button class="btn btn-secondary" id="modal-mission-complete-close-button-secondary"></button>
                         </div>
                     </div>
                 </div>

--- a/app/views/validation.scala.html
+++ b/app/views/validation.scala.html
@@ -137,7 +137,7 @@
                     <h1 class="normal" id="modal-mission-complete-title"></h1>
                     <p><div id="modal-mission-complete-message"></div></p>
                     <div id="modal-mission-complete-table">
-                        <div class="col-sm-8">
+                        <div class="col-sm-9">
                             <h3>Category</h3>
                             <table class="table">
                                 <tr>
@@ -153,7 +153,8 @@
                                     <td id="modal-mission-complete-not-sure-count" class="col-right text-right"></td>
                                 </tr>
                             </table>
-                            <button class="btn blue-btn" id="modal-mission-complete-close-button">Validate more labels</button>
+                            <button class="btn btn-main" id="modal-mission-complete-close-button-primary">Validate more labels</button>
+                            <button class="btn btn-secondary" id="modal-mission-complete-close-button-secondary">Continue Validating</button>
                         </div>
                     </div>
                 </div>

--- a/app/views/validation.scala.html
+++ b/app/views/validation.scala.html
@@ -153,8 +153,8 @@
                                     <td id="modal-mission-complete-not-sure-count" class="col-right text-right"></td>
                                 </tr>
                             </table>
-                            <button class="btn btn-main" id="modal-mission-complete-close-button-primary">Validate more labels</button>
-                            <button class="btn btn-secondary" id="modal-mission-complete-close-button-secondary">Continue Validating</button>
+                            <button class="btn btn-primary" id="modal-mission-complete-close-button-primary"></button>
+                            <button class="btn btn-secondary" id="modal-mission-complete-close-button-secondary"></button>
                         </div>
                     </div>
                 </div>

--- a/public/javascripts/SVLabel/css/svl-modal.css
+++ b/public/javascripts/SVLabel/css/svl-modal.css
@@ -114,10 +114,35 @@
 }
 
 .modal-foreground .blue-btn {
-    background: rgba(49,130,189,1);
     color: white;
     font-size: 14pt;
-    width: 100%;
+}
+
+.modal-foreground .btn-primary {
+    color: white;
+    background: #3182bd;
+    cursor: pointer;
+    border: 1px solid transparent;
+    font-size: 14pt;
+    opacity: 1.0;
+}
+
+.modal-foreground .btn-secondary {
+    color: black;
+    background: white;
+    cursor: pointer;
+    border: 1px solid black;
+    font-size: 14pt;
+    opacity: 1.0;
+}
+
+.modal-foreground .btn-loading {
+    color: white;
+    background: #7f7f7f;
+    cursor: wait;
+    border: 1px solid transparent;
+    font-size: 14pt;
+    opacity: 0.35;
 }
 
 .modal-foreground .button {

--- a/public/javascripts/SVLabel/src/SVLabel/Main.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Main.js
@@ -578,7 +578,8 @@ function Main (params) {
         svl.ui.modalMissionComplete.message = $("#modal-mission-complete-message");
         svl.ui.modalMissionComplete.map = $("#modal-mission-complete-map");
         svl.ui.modalMissionComplete.completeBar = $('#modal-mission-complete-complete-bar');
-        svl.ui.modalMissionComplete.closeButton = $("#modal-mission-complete-close-button");
+        svl.ui.modalMissionComplete.closeButtonPrimary = $("#modal-mission-complete-close-button-primary");
+        svl.ui.modalMissionComplete.closeButtonSecondary = $("#modal-mission-complete-close-button-secondary");
         svl.ui.modalMissionComplete.totalAuditedDistance = $("#modal-mission-complete-total-audited-distance");
         svl.ui.modalMissionComplete.othersAuditedDistance = $("#modal-mission-complete-others-distance");
         svl.ui.modalMissionComplete.missionDistance = $("#modal-mission-complete-mission-distance");

--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
@@ -121,15 +121,16 @@ function ModalMissionComplete (svl, missionContainer, missionModel, taskContaine
     /**
      * Closes mission complete modal. Either starts a new mission or loads the validation page.
      *
-     * If the user clicks the 'Start validating' button (which only shows up if this was their first audit mission ever
-     * or their third in a row) send them to the validation page. If they just finished their neighborhood, reload the
-     * audit page with a new neighborhood. Otherwise start a new audit mission like normal.
+     * If the user clicks the 'Start validating' button send them to the validation page (only shows up if this was
+     * their third audit mission in a row or they are not a turker and this is their first audit mission ever). If they
+     * just finished a neighborhood, reload the audit page. Otherwise start a new audit mission like normal.
      * @param event
      * @private
      */
     this._closeModal = function (event) {
-        if (event.data.button === 'primary' &&
-            ((!svl.userHasCompletedAMission && svl.missionsCompleted === 1) || svl.missionsCompleted % 3 === 0)) {
+        var isTurker = self._userModel.getUser().getProperty("role") === "Turker";
+        var firstMission = !svl.userHasCompletedAMission && svl.missionsCompleted === 1;
+        if (event.data.button === 'primary' && ((!isTurker && firstMission) || svl.missionsCompleted % 3 === 0)) {
             window.location.replace('/validate');
         } else if (svl.neighborhoodModel.isNeighborhoodCompleted) {
             // Reload the page to load another neighborhood.
@@ -177,10 +178,13 @@ function ModalMissionComplete (svl, missionContainer, missionModel, taskContaine
         uiModalMissionComplete.background.off("click");
         uiModalMissionComplete.closeButtonPrimary.css('visibility', "visible");
 
-        // If the user just completed their first audit mission ever or their third in a row, make the primary button
-        // they see a 'Start validating' button. If they are not a turker, then also show a secondary button that lets
-        // them continue auditing. On any other mission just show a 'Continue' button that has them audit more.
-        if ((!svl.userHasCompletedAMission && svl.missionsCompleted === 1) || svl.missionsCompleted % 3 === 0) {
+        // If the user just completed their first audit mission ever (and they aren't a turker) or they finished their
+        // third in a row, make the primary button they see a 'Start validating' button. If they are not a turker, then
+        // also show a secondary button that lets them continue auditing. On any other mission just show a 'Continue'
+        // button that has them audit more.
+        var isTurker = self._userModel.getUser().getProperty("role") === "Turker";
+        var firstMission = !svl.userHasCompletedAMission && svl.missionsCompleted === 1;
+        if ((!isTurker && firstMission) || svl.missionsCompleted % 3 === 0) {
             uiModalMissionComplete.closeButtonPrimary.html('Start validating');
 
             if (self._userModel.getUser().getProperty("role") === 'Turker') {

--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
@@ -156,7 +156,8 @@ function ModalMissionComplete (svl, missionContainer, missionModel, taskContaine
         this._modalMissionCompleteMap.hide();
         statusModel.setProgressBar(0);
         statusModel.setMissionCompletionRate(0);
-        if(this._uiModalMissionComplete.confirmationText!=null && this._uiModalMissionComplete.confirmationText!=undefined){
+        if (this._uiModalMissionComplete.confirmationText !== null
+            && this._uiModalMissionComplete.confirmationText !== undefined) {
             this._uiModalMissionComplete.confirmationText.empty();
             this._uiModalMissionComplete.confirmationText.remove();
             delete this._uiModalMissionComplete.confirmationText;
@@ -211,11 +212,10 @@ function ModalMissionComplete (svl, missionContainer, missionModel, taskContaine
         // horizontalBarMissionLabel.style("visibility", "visible");
         modalMissionCompleteMap.show();
 
-        //If the user has completed their first mission then hide the continue button. Display the generate confirmation
-        // button. When clicked, remove this button completely and make the Continue button visible again.
-        if(uiModalMissionComplete.generateConfirmationButton!=null && uiModalMissionComplete.generateConfirmationButton!=undefined) {
-            uiModalMissionComplete.closeButtonPrimary.css('visibility', "hidden");
-            // Assignment Completion Data
+        // If the user has completed their first mission then display the confirmation code and add show the
+        // confirmation code button on the left column UI.
+        if (uiModalMissionComplete.generateConfirmationButton !== null
+            && uiModalMissionComplete.generateConfirmationButton !== undefined) {
             var data = {
                 amt_assignment_id: svl.amtAssignmentId,
                 completed: true
@@ -244,7 +244,6 @@ function ModalMissionComplete (svl, missionContainer, missionModel, taskContaine
             confirmationCodeElement.setAttribute("id", "modal-mission-complete-confirmation-text");
             uiModalMissionComplete.generateConfirmationButton.after(confirmationCodeElement);
             uiModalMissionComplete.confirmationText = $("#modal-mission-complete-confirmation-text");
-            uiModalMissionComplete.closeButtonPrimary.css('visibility', "visible");
             uiModalMissionComplete.generateConfirmationButton.remove();
             delete uiModalMissionComplete.generateConfirmationButton;
 

--- a/public/javascripts/SVValidate/css/svv-modal.css
+++ b/public/javascripts/SVValidate/css/svv-modal.css
@@ -148,6 +148,7 @@
     cursor: pointer;
     border: 1px solid transparent;
     font-size: 14pt;
+    opacity: 1.0;
 }
 
 .modal-foreground .btn-secondary {
@@ -156,6 +157,7 @@
     cursor: pointer;
     border: 1px solid black;
     font-size: 14pt;
+    opacity: 1.0;
 }
 
 .modal-foreground .btn-loading {
@@ -164,6 +166,7 @@
     cursor: wait;
     border: 1px solid transparent;
     font-size: 14pt;
+    opacity: 0.35;
 }
 
 .modal-foreground .blue-btn:focus {

--- a/public/javascripts/SVValidate/css/svv-modal.css
+++ b/public/javascripts/SVValidate/css/svv-modal.css
@@ -134,13 +134,36 @@
 
 #modal-mission-complete-table {
     height: 190px;
-    padding-left: 215px;
+    padding-left: 175px;
 }
 
 .modal-foreground .blue-btn {
     color: white;
     font-size: 14pt;
-    width: 100%;
+}
+
+.modal-foreground .btn-primary {
+    color: white;
+    background: #3182bd;
+    cursor: pointer;
+    border: 1px solid transparent;
+    font-size: 14pt;
+}
+
+.modal-foreground .btn-secondary {
+    color: black;
+    background: white;
+    cursor: pointer;
+    border: 1px solid black;
+    font-size: 14pt;
+}
+
+.modal-foreground .btn-loading {
+    color: white;
+    background: #7f7f7f;
+    cursor: wait;
+    border: 1px solid transparent;
+    font-size: 14pt;
 }
 
 .modal-foreground .blue-btn:focus {

--- a/public/javascripts/SVValidate/src/Main.js
+++ b/public/javascripts/SVValidate/src/Main.js
@@ -83,7 +83,8 @@ function Main (param) {
         svv.ui.modalMissionComplete = {};
         svv.ui.modalMissionComplete.agreeCount = $("#modal-mission-complete-agree-count");
         svv.ui.modalMissionComplete.background = $("#modal-mission-complete-background");
-        svv.ui.modalMissionComplete.closeButton = $("#modal-mission-complete-close-button");
+        svv.ui.modalMissionComplete.closeButtonPrimary = $("#modal-mission-complete-close-button-primary");
+        svv.ui.modalMissionComplete.closeButtonSecondary = $("#modal-mission-complete-close-button-secondary");
         svv.ui.modalMissionComplete.disagreeCount = $("#modal-mission-complete-disagree-count");
         svv.ui.modalMissionComplete.foreground = $("#modal-mission-complete-foreground");
         svv.ui.modalMissionComplete.holder = $("#modal-mission-complete-holder");

--- a/public/javascripts/SVValidate/src/modal/ModalMissionComplete.js
+++ b/public/javascripts/SVValidate/src/modal/ModalMissionComplete.js
@@ -89,19 +89,25 @@ function ModalMissionComplete (uiModalMissionComplete, user, confirmationCode) {
         uiModalMissionComplete.holder.css('visibility', 'visible');
         uiModalMissionComplete.foreground.css('visibility', 'visible');
 
-        // Set button text to auditing if they've completed 3 validation missions (and are on a laptop/desktop).
+        // Set button text to auditing if they've completed 3 validation missions (and are on a laptop/desktop). If they
+        // are a turker, only give them the option to audit. O/w let them choose b/w auditing and validating.
         if (svv.missionsCompleted % 3 === 0 && !isMobile()) {
             uiModalMissionComplete.closeButtonPrimary.html('Start an exploration mission');
             uiModalMissionComplete.closeButtonPrimary.css('visibility', 'visible');
-            uiModalMissionComplete.closeButtonPrimary.css('width', '60%');
 
-            uiModalMissionComplete.closeButtonSecondary.css('visibility', 'visible');
-            uiModalMissionComplete.closeButtonSecondary.css('width', '39%');
+            if (user.getProperty('role') === 'Turker') {
+                uiModalMissionComplete.closeButtonPrimary.css('width', '100%');
+                uiModalMissionComplete.closeButtonSecondary.css('visibility', 'hidden');
+            } else {
+                uiModalMissionComplete.closeButtonPrimary.css('width', '60%');
+                uiModalMissionComplete.closeButtonSecondary.css('visibility', 'visible');
+                uiModalMissionComplete.closeButtonSecondary.css('width', '39%');
+            }
         } else {
             uiModalMissionComplete.closeButtonPrimary.html('Validate more labels');
             uiModalMissionComplete.closeButtonPrimary.css('visibility', 'visible');
             uiModalMissionComplete.closeButtonPrimary.css('width', '100%');
-            
+
             uiModalMissionComplete.closeButtonSecondary.css('visibility', 'hidden');
         }
 

--- a/public/javascripts/SVValidate/src/modal/ModalMissionComplete.js
+++ b/public/javascripts/SVValidate/src/modal/ModalMissionComplete.js
@@ -5,9 +5,9 @@ function ModalMissionComplete (uiModalMissionComplete, user, confirmationCode) {
     };
     let watch;
 
-    function _handleButtonClick() {
-        if (svv.missionsCompleted === 3 && !isMobile()) {
-            // Load the audit page since they've done 3 missions.
+    function _handleButtonClick(event) {
+        // If they've done three missions and clicked the audit button, load the audit page.
+        if (event.data.button === 'primary' && svv.missionsCompleted % 3 === 0 && !isMobile()) {
             window.location.replace('/audit');
         } else {
             self.hide();
@@ -29,10 +29,13 @@ function ModalMissionComplete (uiModalMissionComplete, user, confirmationCode) {
             svv.keyboard.enableKeyboard();
         }
 
-        uiModalMissionComplete.closeButton.off('click');
+        uiModalMissionComplete.closeButtonPrimary.off('click');
+        uiModalMissionComplete.closeButtonSecondary.off('click');
         uiModalMissionComplete.background.css('visibility', 'hidden');
         uiModalMissionComplete.holder.css('visibility', 'hidden');
         uiModalMissionComplete.foreground.css('visibility', 'hidden');
+        uiModalMissionComplete.closeButtonPrimary.css('visibility', 'hidden');
+        uiModalMissionComplete.closeButtonSecondary.css('visibility', 'hidden');
     }
 
     function setProperty(key, value) {
@@ -54,18 +57,23 @@ function ModalMissionComplete (uiModalMissionComplete, user, confirmationCode) {
         let message = "You just validated " + totalLabels + " " +
             svv.labelTypeNames[mission.getProperty("labelTypeId")] + " labels!";
 
-        // Disable user from clicking the "Validate next mission" button and set background to gray
-        uiModalMissionComplete.closeButton.css('background', '#7f7f7f');
-        uiModalMissionComplete.closeButton.css('cursor', 'wait');
+        // Disable user from clicking the "Validate next mission" button and set background to gray.
+        uiModalMissionComplete.closeButtonPrimary.removeClass('btn-primary');
+        uiModalMissionComplete.closeButtonPrimary.addClass('btn-loading');
+        uiModalMissionComplete.closeButtonSecondary.removeClass('btn-secondary');
+        uiModalMissionComplete.closeButtonSecondary.addClass('btn-loading');
 
-        // Wait until next mission has been loaded before allowing the user to click the button
+        // Wait until next mission has been loaded before allowing the user to click the button.
         clearInterval(watch);
         watch = window.setInterval(function () {
             if (getProperty('clickable')) {
-                // Enable button clicks, change the background to blue
-                uiModalMissionComplete.closeButton.css('background', '#3182bd');
-                uiModalMissionComplete.closeButton.css('cursor', 'pointer');
-                uiModalMissionComplete.closeButton.on('click', _handleButtonClick);
+                // Enable button clicks, reset the CSS for primary/secondary close buttons.
+                uiModalMissionComplete.closeButtonPrimary.removeClass('btn-loading');
+                uiModalMissionComplete.closeButtonPrimary.addClass('btn-primary');
+                uiModalMissionComplete.closeButtonPrimary.on('click', { button: 'primary' }, _handleButtonClick);
+                uiModalMissionComplete.closeButtonSecondary.removeClass('btn-loading');
+                uiModalMissionComplete.closeButtonSecondary.addClass('btn-secondary');
+                uiModalMissionComplete.closeButtonSecondary.on('click', { button: 'secondary' }, _handleButtonClick);
                 setProperty('clickable', false);
                 clearInterval(watch);
             }
@@ -82,10 +90,19 @@ function ModalMissionComplete (uiModalMissionComplete, user, confirmationCode) {
         uiModalMissionComplete.foreground.css('visibility', 'visible');
 
         // Set button text to auditing if they've completed 3 validation missions (and are on a laptop/desktop).
-        if (svv.missionsCompleted === 3 && !isMobile()) {
-            uiModalMissionComplete.closeButton.html('Start an exploration mission');
+        if (svv.missionsCompleted % 3 === 0 && !isMobile()) {
+            uiModalMissionComplete.closeButtonPrimary.html('Start an exploration mission');
+            uiModalMissionComplete.closeButtonPrimary.css('visibility', 'visible');
+            uiModalMissionComplete.closeButtonPrimary.css('width', '60%');
+
+            uiModalMissionComplete.closeButtonSecondary.css('visibility', 'visible');
+            uiModalMissionComplete.closeButtonSecondary.css('width', '39%');
         } else {
-            uiModalMissionComplete.closeButton.html('Validate more labels');
+            uiModalMissionComplete.closeButtonPrimary.html('Validate more labels');
+            uiModalMissionComplete.closeButtonPrimary.css('visibility', 'visible');
+            uiModalMissionComplete.closeButtonPrimary.css('width', '100%');
+            
+            uiModalMissionComplete.closeButtonSecondary.css('visibility', 'hidden');
         }
 
         // TODO this code was removed for issue #1693, search for "#1693" and uncomment all later.

--- a/public/javascripts/SVValidate/src/modal/ModalMissionComplete.js
+++ b/public/javascripts/SVValidate/src/modal/ModalMissionComplete.js
@@ -100,6 +100,7 @@ function ModalMissionComplete (uiModalMissionComplete, user, confirmationCode) {
                 uiModalMissionComplete.closeButtonSecondary.css('visibility', 'hidden');
             } else {
                 uiModalMissionComplete.closeButtonPrimary.css('width', '60%');
+                uiModalMissionComplete.closeButtonSecondary.html('Continue validating');
                 uiModalMissionComplete.closeButtonSecondary.css('visibility', 'visible');
                 uiModalMissionComplete.closeButtonSecondary.css('width', '39%');
             }


### PR DESCRIPTION
Resolves #1372 

Non turkers are now given the option to continue auditing after their third audit mission or continue validating after their third validation mission.

![flow-audit-2](https://user-images.githubusercontent.com/6518824/68810133-4422af80-0622-11ea-83a1-702133baa605.png)
![flow-validate-2](https://user-images.githubusercontent.com/6518824/68810130-438a1900-0622-11ea-8a46-db1867b05383.png)

TODO I need to make sure I didn't break anything in mobile validation since I messed with the CSS.