### PR TITLE
fixes mission complete CSS for mobile and rapid validate

### DIFF
--- a/app/views/mobileValidate.scala.html
+++ b/app/views/mobileValidate.scala.html
@@ -109,7 +109,7 @@
                 <h1 class="normal" id="modal-mission-complete-title"></h1>
                 <p><div id="modal-mission-complete-message"></div></p>
                 <div id="modal-mission-complete-table">
-                    <div class="col-sm-8">
+                    <div class="col-sm-9">
                         <h3>Category</h3>
                         <table class="table">
                             <tr>
@@ -125,7 +125,8 @@
                                 <td id="modal-mission-complete-not-sure-count" class="col-right text-right"></td>
                             </tr>
                         </table>
-                        <button class="btn blue-btn" id="modal-mission-complete-close-button">Validate more labels</button>
+                        <button class="btn btn-primary" id="modal-mission-complete-close-button-primary"></button>
+                        <button class="btn btn-secondary" id="modal-mission-complete-close-button-secondary"></button>
                     </div>
                 </div>
             </div>

--- a/app/views/rapidValidation.scala.html
+++ b/app/views/rapidValidation.scala.html
@@ -253,7 +253,7 @@
                     <h1 class="normal" id="modal-mission-complete-title"></h1>
                     <div id="modal-mission-complete-message"></div>
                     <div id="modal-mission-complete-table">
-                        <div class="col-sm-8">
+                        <div class="col-sm-9">
                             <h3>Category</h3>
                             <table class="table">
                                 <tr>
@@ -269,7 +269,8 @@
                                     <td id="modal-mission-complete-not-sure-count" class="col-right text-right"></td>
                                 </tr>
                             </table>
-                            <button class="btn blue-btn" id="modal-mission-complete-close-button">Validate more labels</button>
+                            <button class="btn btn-primary" id="modal-mission-complete-close-button-primary"></button>
+                            <button class="btn btn-secondary" id="modal-mission-complete-close-button-secondary"></button>
                         </div>
                     </div>
                 </div>

--- a/public/javascripts/SVLabel/spec/SVLabel/modal/ModalMissionComplete-spec.js
+++ b/public/javascripts/SVLabel/spec/SVLabel/modal/ModalMissionComplete-spec.js
@@ -70,7 +70,7 @@ describe("ModalMissionComplete", function () {
                     <td id="modal-mission-complete-remaining-distance" class="col-right"></td> \
                 </tr> \
             </table> \
-            <button class="btn blue-btn" id="modal-mission-complete-close-button">Continue</button> \
+            <button class="btn btn-primary" id="modal-mission-complete-close-button-primary">Continue</button> \
             </div> \
         </div> \
         </div> \

--- a/public/javascripts/SVLabel/spec/SVLabel/modal/ModalMissionCompleteProgressBar-spec.js
+++ b/public/javascripts/SVLabel/spec/SVLabel/modal/ModalMissionCompleteProgressBar-spec.js
@@ -62,7 +62,7 @@ describe("ModalMissionCompleteProgressBar tests", function () {
             <td id="modal-mission-complete-remaining-distance" class="col-right"></td> \
         </tr> \
     </table> \
-    <button class="btn blue-btn" id="modal-mission-complete-close-button">Continue</button> \
+    <button class="btn btn-primary" id="modal-mission-complete-close-button-primary">Continue</button> \
     </div> \
 </div> \
 </div> \

--- a/public/javascripts/SVValidate/css/svv-modal.css
+++ b/public/javascripts/SVValidate/css/svv-modal.css
@@ -137,11 +137,6 @@
     padding-left: 175px;
 }
 
-.modal-foreground .blue-btn {
-    color: white;
-    font-size: 14pt;
-}
-
 .modal-foreground .btn-primary {
     color: white;
     background: #3182bd;

--- a/public/javascripts/SVValidate/mobile/mobileValidate.css
+++ b/public/javascripts/SVValidate/mobile/mobileValidate.css
@@ -166,11 +166,6 @@ html {
     font-size: 50pt;
 }
 
-#modal-mission-complete-close-button {
-    font-size: 30pt;
-    width: 500px;
-}
-
 #ps-logo {
     width: 500px;
 }

--- a/public/javascripts/SVValidate/src/modal/ModalMissionComplete.js
+++ b/public/javascripts/SVValidate/src/modal/ModalMissionComplete.js
@@ -74,6 +74,7 @@ function ModalMissionComplete (uiModalMissionComplete, user, confirmationCode) {
                 uiModalMissionComplete.closeButtonSecondary.removeClass('btn-loading');
                 uiModalMissionComplete.closeButtonSecondary.addClass('btn-secondary');
                 uiModalMissionComplete.closeButtonSecondary.on('click', { button: 'secondary' }, _handleButtonClick);
+                if (isMobile()) uiModalMissionComplete.closeButtonPrimary.css('font-size', '30pt');
                 setProperty('clickable', false);
                 clearInterval(watch);
             }
@@ -111,6 +112,7 @@ function ModalMissionComplete (uiModalMissionComplete, user, confirmationCode) {
 
             uiModalMissionComplete.closeButtonSecondary.css('visibility', 'hidden');
         }
+        if (isMobile()) uiModalMissionComplete.closeButtonPrimary.css('font-size', '30pt');
 
         // TODO this code was removed for issue #1693, search for "#1693" and uncomment all later.
         // If this is a turker and the confirmation code button hasn't been shown yet, mark amt_assignment as complete


### PR DESCRIPTION
My updates to the CSS in #1968 messed up the look of the mission complete buttons on both the mobile and rapid validation interfaces. This PR just corrects those visual issues.