### PR TITLE
1963 update password requirements

### DIFF
--- a/app/views/signUp.scala.html
+++ b/app/views/signUp.scala.html
@@ -16,6 +16,7 @@
             @text(signInForm("username"), "Username", icon = "person")
             @text(signInForm("email"), "Email", icon = "at")
             @password(signInForm("password"), "Password", icon = "key")
+            @password(signInForm("passwordConfirm"), "Confirm password", icon = "key")
             <div class="form-group">
                 <div class="checkbox">
                     <label><input type="checkbox" id="sign-up-page-agree-to-terms">


### PR DESCRIPTION
Fixes #1963 

Fixes the issue of not being able to sign up at the /signUp endpoint.

The problem was that when we added a 6 character minimum req for passwords and added a password confirmation field in PR #1755 we only added this to signing up via the navbar, and not to the /signUp endpoint. Adding the functionality there fixes the bug where we couldn't sign up.