### PR TITLE
fixes interface hanging when no validations left

### DIFF
--- a/public/javascripts/SVValidate/src/data/Form.js
+++ b/public/javascripts/SVValidate/src/data/Form.js
@@ -81,6 +81,7 @@ function Form(url, beaconUrl) {
                         }
                     } else {
                         // Otherwise, display popup that says there are no more labels left.
+                        svv.modalMissionComplete.hide();
                         svv.modalNoNewMission.show();
                     }
                 }


### PR DESCRIPTION
Fixes #1977 

Fixes the mission complete screen hanging when there are no validations left.

The problem was that I needed to hide the normal mission complete screen (`svv.modalMissionComplete.hide();`) before showing the no validations left screen (`svv.modalNoNewMission.show();`). Seems to be working as expected now.