### PR TITLE
#1793: Change "Audit" Language

### DIFF
--- a/app/views/audit.scala.html
+++ b/app/views/audit.scala.html
@@ -586,15 +586,15 @@
                                     }
                                 }
                                 <tr>
-                                    <th>You audited in this mission</th>
+                                    <th>You explored in this mission</th>
                                     <td id="modal-mission-complete-mission-distance" class="col-right"></td>
                                 </tr>
                                 <tr>
-                                    <th>You audited in this neighborhood</th>
+                                    <th>You explored in this neighborhood</th>
                                     <td id="modal-mission-complete-total-audited-distance" class="col-right"></td>
                                 </tr>
                                 <tr>
-                                    <th>Others audited in this neighborhood</th>
+                                    <th>Others explored in this neighborhood</th>
                                     <td id="modal-mission-complete-others-distance" class="col-right"></td>
                                 </tr>
                                 <tr>

--- a/app/views/userProfile.scala.html
+++ b/app/views/userProfile.scala.html
@@ -28,7 +28,7 @@
         <div class="row">
             <table class="table table-striped table-condensed">
                 <tr>
-                    <th>Total Distance Audited</th>
+                    <th>Total Distance Explored</th>
                     <th>Number of Missions Completed</th>
                     @if(user){
                         @if(user.get.role.getOrElse("") == "Turker") {

--- a/public/javascripts/SVLabel/spec/SVLabel/modal/ModalMission-spec.js
+++ b/public/javascripts/SVLabel/spec/SVLabel/modal/ModalMission-spec.js
@@ -105,24 +105,24 @@ describe("ModalMission", function () {
 
         it("should set the title", function () {
             modalMission.setMissionMessage(mission_4000ft, neighborhood, null, null);
-            expect(uiModalMission.missionTitle.text()).toBe("Audit ½mi of Test Neighborhood");
+            expect(uiModalMission.missionTitle.text()).toBe("Explore ½mi of Test Neighborhood");
 
             modalMission.setMissionMessage(mission_1mi, neighborhood, null, null);
-            expect(uiModalMission.missionTitle.text()).toBe("Audit ¼mi of Test Neighborhood");
+            expect(uiModalMission.missionTitle.text()).toBe("Explore ¼mi of Test Neighborhood");
 
             modalMission.setMissionMessage(mission_2mi, neighborhood, null, null);
-            expect(uiModalMission.missionTitle.text()).toBe("Audit ½mi of Test Neighborhood");
+            expect(uiModalMission.missionTitle.text()).toBe("Explore ½mi of Test Neighborhood");
         });
 
         it("should set the body text", function () {
             modalMission.setMissionMessage(mission_4000ft, neighborhood, null, null);
-            expect(uiModalMission.instruction.text().trim()).toBe("Your mission is to audit ½mi of Test Neighborhood and find all the accessibility features that affect mobility impaired travelers!");
+            expect(uiModalMission.instruction.text().trim()).toBe("Your mission is to explore ½mi of Test Neighborhood and find all the accessibility features that affect mobility impaired travelers!");
 
             modalMission.setMissionMessage(mission_1mi, neighborhood, null, null);
-            expect(uiModalMission.instruction.text().trim()).toBe("Your mission is to audit ¼mi of Test Neighborhood and find all the accessibility features that affect mobility impaired travelers!");
+            expect(uiModalMission.instruction.text().trim()).toBe("Your mission is to explore ¼mi of Test Neighborhood and find all the accessibility features that affect mobility impaired travelers!");
 
             modalMission.setMissionMessage(mission_2mi, neighborhood, null, null);
-            expect(uiModalMission.instruction.text().trim()).toBe("Your mission is to audit ½mi of Test Neighborhood and find all the accessibility features that affect mobility impaired travelers!");
+            expect(uiModalMission.instruction.text().trim()).toBe("Your mission is to explore ½mi of Test Neighborhood and find all the accessibility features that affect mobility impaired travelers!");
         })
     });
 

--- a/public/javascripts/SVLabel/spec/SVLabel/modal/ModalMissionComplete-spec.js
+++ b/public/javascripts/SVLabel/spec/SVLabel/modal/ModalMissionComplete-spec.js
@@ -58,11 +58,11 @@ describe("ModalMissionComplete", function () {
                 <div id="modal-mission-complete-complete-bar"></div> \
                 <table class="table"> \
                 <tr> \
-                    <th>Audited in this mission</th> \
+                    <th>Explored in this mission</th> \
                     <td id="modal-mission-complete-mission-distance" class="col-right"></td> \
                 </tr> \
                 <tr> \
-                    <th>Audited in this neighborhood</th> \
+                    <th>Explored in this neighborhood</th> \
                     <td id="modal-mission-complete-total-audited-distance" class="col-right"></td> \
                 </tr> \
                 <tr> \

--- a/public/javascripts/SVLabel/spec/SVLabel/status/StatusFieldMission-spec.js
+++ b/public/javascripts/SVLabel/spec/SVLabel/status/StatusFieldMission-spec.js
@@ -75,16 +75,16 @@ describe("StatusFieldMission module", function () {
     describe("`setMessage` method", function () {
         it("should set the mission instruction", function () {
             statusFieldMission.setMessage(mission1);
-            expect($missionMessage.text()).toBe("Audit 1000ft of this neighborhood");
+            expect($missionMessage.text()).toBe("Explore 1000ft of this neighborhood");
 
             statusFieldMission.setMessage(mission2);
-            expect($missionMessage.text()).toBe("Audit 1000ft of this neighborhood");
+            expect($missionMessage.text()).toBe("Explore 1000ft of this neighborhood");
 
             statusFieldMission.setMessage(mission3);
-            expect($missionMessage.text()).toBe("Audit ½mi of this neighborhood");
+            expect($missionMessage.text()).toBe("Explore ½mi of this neighborhood");
 
             statusFieldMission.setMessage(mission4);
-            expect($missionMessage.text()).toBe("Audit ¼mi of this neighborhood");
+            expect($missionMessage.text()).toBe("Explore ¼mi of this neighborhood");
         });
     });
 

--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMission.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMission.js
@@ -41,21 +41,21 @@ function ModalMission (missionContainer, neighborhoodContainer, uiModalMission, 
         <img src="/assets/javascripts/SVLabel/img/icons/AccessibilityFeatures.png" class="modal-mission-images center-block" alt="Street accessibility features" /> \
         </figure> \
         <div class="spacer10"></div>\
-        <p>Your <span class="bold">first mission</span> is to audit __DISTANCE_PLACEHOLDER__ in __NEIGHBORHOOD_PLACEHOLDER__</span> and find all the accessibility features that affect mobility impaired travelers!</p>\
+        <p>Your <span class="bold">first mission</span> is to explore __DISTANCE_PLACEHOLDER__ in __NEIGHBORHOOD_PLACEHOLDER__</span> and find all the accessibility features that affect mobility impaired travelers!</p>\
         <div class="spacer10"></div>';
 
     var distanceMissionHTML = ' <figure> \
         <img src="/assets/javascripts/SVLabel/img/icons/AccessibilityFeatures.png" class="modal-mission-images center-block" alt="Street accessibility features" /> \
         </figure> \
         <div class="spacer10"></div>\
-        <p>Your mission is to audit __DISTANCE_PLACEHOLDER__ in __NEIGHBORHOOD_PLACEHOLDER__</span> and find all the accessibility features that affect mobility impaired travelers!</p>\
+        <p>Your mission is to explore __DISTANCE_PLACEHOLDER__ in __NEIGHBORHOOD_PLACEHOLDER__</span> and find all the accessibility features that affect mobility impaired travelers!</p>\
         <div class="spacer10"></div>';
 
     var returningToMissionHTML = ' <figure> \
         <img src="/assets/javascripts/SVLabel/img/icons/AccessibilityFeatures.png" class="modal-mission-images center-block" alt="Street accessibility features" /> \
         </figure> \
         <div class="spacer10"></div>\
-        <p>Continue auditing __DISTANCE_PLACEHOLDER__ in __NEIGHBORHOOD_PLACEHOLDER__</span> for accessibility features!</p>\
+        <p>Continue exploring __DISTANCE_PLACEHOLDER__ in __NEIGHBORHOOD_PLACEHOLDER__</span> for accessibility features!</p>\
         <div class="spacer10"></div>';
 
     this._handleBackgroundClick = function () {
@@ -112,7 +112,7 @@ function ModalMission (missionContainer, neighborhoodContainer, uiModalMission, 
         // Set the title and the instruction of this mission.
 
         var missionType = mission.getProperty("missionType");
-        var missionTitle = "Audit __DISTANCE_PLACEHOLDER__ in __NEIGHBORHOOD_PLACEHOLDER__";
+        var missionTitle = "Explore __DISTANCE_PLACEHOLDER__ in __NEIGHBORHOOD_PLACEHOLDER__";
         var templateHTML;
 
         svl.popUpMessage.disableInteractions();

--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
@@ -70,7 +70,7 @@ function ModalMissionComplete (svl, missionContainer, missionModel, taskContaine
         var neighborhood = svl.neighborhoodContainer.getCurrentNeighborhood();
         var neighborhoodName = neighborhood.getProperty("name");
         self.setMissionTitle("Bravo! You completed " + neighborhoodName + " neighborhood!");
-        uiModalMissionComplete.closeButtonPrimary.html('Audit Another Neighborhood');
+        uiModalMissionComplete.closeButtonPrimary.html('Explore Another Neighborhood');
         self._canShowContinueButton = true;
         if (self.showingMissionCompleteScreen) {
             self._enableContinueButton();

--- a/public/javascripts/SVLabel/src/SVLabel/navigation/Compass.js
+++ b/public/javascripts/SVLabel/src/SVLabel/navigation/Compass.js
@@ -230,7 +230,7 @@ function Compass (svl, mapService, taskContainer, uiCompass) {
     }
 
     function setBackToRouteMessage () {
-        var message = "Uh-oh, you're quite far away from the audit route. <br />" +
+        var message = "Uh-oh, you're quite far away from the route. <br />" +
             "<span class='bold'>Click here to jump back.</span>";
         uiCompass.message.html(message);
     }

--- a/public/javascripts/SVLabel/src/SVLabel/status/StatusFieldMission.js
+++ b/public/javascripts/SVLabel/src/SVLabel/status/StatusFieldMission.js
@@ -19,7 +19,7 @@ function StatusFieldMission (modalModel, uiStatusField) {
         } else if (svl.missionContainer.isTheFirstMission()) {
             missionMessage = "Walk for __PLACEHOLDER__ and find all the sidewalk accessibility attributes"
         } else {
-            missionMessage = "Audit __PLACEHOLDER__ of this neighborhood";
+            missionMessage = "Explore __PLACEHOLDER__ of this neighborhood";
         }
 
         if (missionType === "audit") {

--- a/public/javascripts/SVLabel/src/SVLabel/util/UtilitiesSidewalk.js
+++ b/public/javascripts/SVLabel/src/SVLabel/util/UtilitiesSidewalk.js
@@ -126,7 +126,7 @@ function UtilitiesMisc (JSON) {
         return {
             'Walk' : {
                 'id' : 'Walk',
-                'instructionalText' : 'Audit the streets and find all the accessibility attributes',
+                'instructionalText' : 'Explore the streets and find all the accessibility attributes',
                 'textColor' : 'rgba(255,255,255,1)'
             },
             CurbRamp: {


### PR DESCRIPTION
Resolves/Fixes #1793
Changed the instances of the word "audit" to "explore" where applicable to create a more user-friendly experience