### PR TITLE
Adds some new tags for obstacle and surface problem

### DIFF
--- a/conf/evolutions/default/72.sql
+++ b/conf/evolutions/default/72.sql
@@ -1,0 +1,11 @@
+# --- !Ups
+INSERT INTO tag VALUES ( 26, 3, 'construction' );
+INSERT INTO tag VALUES ( 27, 3, 'sign' );
+INSERT INTO tag VALUES ( 28, 4, 'brick' );
+INSERT INTO tag VALUES ( 29, 4, 'construction' );
+
+# --- !Downs
+DELETE FROM label_tag
+WHERE tag_id IN (26, 27, 28, 29);
+
+DELETE FROM tag WHERE tag_id IN (26, 27, 28, 29);

--- a/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
@@ -227,6 +227,7 @@ function ContextMenu (uiContextMenu) {
      */
     function _handleTagClick (e) {
         var label = getTargetLabel();
+        var labelType = label.getLabelType();
         var labelTags = label.getProperty('tagIds');
 
         // Use position of cursor to determine whether or not the click came from the mouse, or from a keyboard shortcut
@@ -237,7 +238,7 @@ function ContextMenu (uiContextMenu) {
                 var tagValue = e.target.textContent || e.target.innerText;
 
                 // Adds or removes tag from the label's current list of tags.
-                self.labelTags.forEach(function (tag) {
+                self.labelTags.filter(tag => tag.label_type === label.getLabelType()).forEach(function (tag) {
                     if (tag.tag === tagValue) {
                         if (!labelTags.includes(tag.tag_id)) {
                             var alternateRoutePresentStr = 'alternate route present';
@@ -453,7 +454,7 @@ function ContextMenu (uiContextMenu) {
                         // Remove all leftover tags from last labeling. Warning to future devs: will remove any other classes you add to the tags
                         $("body").find("button[id=" + count + "]").attr('class', 'context-menu-tag');
 
-                        // Add tag name as a class so that finding the element is easier laster. For example, will add "narrowSidewalk-tag" as a class
+                        // Add tag name as a class so that finding the element is easier later. For example, will add "narrowSidewalk-tag" as a class
                         var newClass = util.misc.getLabelDescriptions(tag.label_type)['tagInfo'][tag.tag]['id'] + "-tag";
                         $("body").find("button[id=" + count + "]").addClass(newClass);
 

--- a/public/javascripts/SVLabel/src/SVLabel/keyboard/Keyboard.js
+++ b/public/javascripts/SVLabel/src/SVLabel/keyboard/Keyboard.js
@@ -365,7 +365,7 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
                             case util.misc.getLabelDescriptions('Obstacle')['tagInfo']['pole']['keyNumber']: // 'p' for 'pole'
                                 $('.pole-tag').first().trigger("click", {lowLevelLogging: false});
                                 break;
-                            case util.misc.getLabelDescriptions('Obstacle')['tagInfo']['tree']['keyNumber']: // 't' for 'tree'
+                            case util.misc.getLabelDescriptions('Obstacle')['tagInfo']['tree']['keyNumber']: // 'e' for 'tree'
                                 $('.tree-tag').first().trigger("click", {lowLevelLogging: false});
                                 break;
                             case util.misc.getLabelDescriptions('Obstacle')['tagInfo']['vegetation']['keyNumber']: // 'v' for 'vegetation'
@@ -376,6 +376,12 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
                                 break;
                             case util.misc.getLabelDescriptions('Obstacle')['tagInfo']['parked bike']['keyNumber']: // 'i' for 'parked bike'
                                 $('.parkedBike-tag').first().trigger("click", {lowLevelLogging: false});
+                                break;
+                            case util.misc.getLabelDescriptions('Obstacle')['tagInfo']['construction']['keyNumber']: // 't' for 'construction'
+                                $('.construction-obstacle-tag').first().trigger("click", {lowLevelLogging: false});
+                                break;
+                            case util.misc.getLabelDescriptions('Obstacle')['tagInfo']['sign']['keyNumber']: // 'g' for 'sign'
+                                $('.sign-tag').first().trigger("click", {lowLevelLogging: false});
                                 break;
                         }
                     } else if (labelType === 'SurfaceProblem') { // Surface Problem
@@ -397,6 +403,12 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
                                 break;
                             case util.misc.getLabelDescriptions('SurfaceProblem')['tagInfo']['narrow sidewalk']['keyNumber']  : // 'a' for 'narrow sidewalk'
                                 $('.narrowSidewalk-tag').first().trigger("click", {lowLevelLogging: false});
+                                break;
+                            case util.misc.getLabelDescriptions('SurfaceProblem')['tagInfo']['brick']['keyNumber']  : // 'i' for 'brick'
+                                $('.brick-tag').first().trigger("click", {lowLevelLogging: false});
+                                break;
+                            case util.misc.getLabelDescriptions('SurfaceProblem')['tagInfo']['construction']['keyNumber']  : // 't' for 'construction'
+                                $('.construction-surface-problem-tag').first().trigger("click", {lowLevelLogging: false});
                                 break;
                         }
                     } else if (labelType === 'Other') { // Other

--- a/public/javascripts/SVLabel/src/SVLabel/util/UtilitiesSidewalk.js
+++ b/public/javascripts/SVLabel/src/SVLabel/util/UtilitiesSidewalk.js
@@ -314,9 +314,9 @@ function UtilitiesMisc (JSON) {
                         id: 'pole'
                     },
                     'tree': {
-                        keyNumber: 84,
-                        keyChar: 'T',
-                        text: '<tag-underline>t</tag-underline>ree',
+                        keyNumber: 69,
+                        keyChar: 'E',
+                        text: 'tr<tag-underline>e</tag-underline>e',
                         id: 'tree'
                     },
                     'vegetation': {
@@ -336,6 +336,18 @@ function UtilitiesMisc (JSON) {
                         keyChar: 'I',
                         text: 'parked b<tag-underline>i</tag-underline>ke',
                         id: 'parkedBike'
+                    },
+                    'construction': {
+                        keyNumber: 84,
+                        keyChar: 'T',
+                        text: 'cons<tag-underline>t</tag-underline>ruction',
+                        id: 'construction-obstacle'
+                    },
+                    'sign': {
+                        keyNumber: 71,
+                        keyChar: 'G',
+                        text: 'si<tag-underline>g</tag-underline>n',
+                        id: 'sign'
                     }
                 }
             },
@@ -430,6 +442,18 @@ function UtilitiesMisc (JSON) {
                         keyChar: 'A',
                         text: 'n<tag-underline>a</tag-underline>rrow sidewalk',
                         id: 'narrowSidewalk'
+                    },
+                    'brick': {
+                        keyNumber: 73,
+                        keyChar: 'I',
+                        text: 'br<tag-underline>i</tag-underline>ck',
+                        id: 'brick'
+                    },
+                    'construction': {
+                        keyNumber: 84,
+                        keyChar: 'T',
+                        text: 'cons<tag-underline>t</tag-underline>ruction',
+                        id: 'construction-surface-problem'
                     }
                 }
             },


### PR DESCRIPTION
Resolves #1979 

Adds 'construction' and 'sign' tags to the obstacle label type, and 'construction' and 'brick' tags to the surface problem label type. Here is what the context menus look like now:

![all-obs-tags](https://user-images.githubusercontent.com/6518824/71426856-77b31980-2665-11ea-80ec-c916d9e7200e.png)
![all-surface-prob-tags](https://user-images.githubusercontent.com/6518824/71426857-78e44680-2665-11ea-8720-0548a4827e6e.png)

I made 'g' the shortcut for 'sign' (which you can't see underlined because of the font). I made 'i' the shortcut for 'brick'. And I made 't' the shortcut for 'construction' for both label types (to do that, I switched the shortcut for 'tree' from 't' to 'e').