### PR TITLE
#1857 Fixed No Sidewalk Validation Description 

### DIFF
--- a/public/javascripts/SVValidate/src/status/StatusPopupDescriptions.js
+++ b/public/javascripts/SVValidate/src/status/StatusPopupDescriptions.js
@@ -98,9 +98,9 @@ function StatusPopupDescriptions () {
             case "example-image-2":
                 return "This is an abruptly ending sidewalk";
             case "example-image-3":
-                return "This street is has no sidewalk";
+                return "This street has no sidewalk";
             case "example-image-4":
-                return "This intersection is has no sidewalk";
+                return "This intersection has no sidewalk";
             case "counterexample-image-1":
                 return "Narrow sidewalks should not be labeled as no sidewalk";
             case "counterexample-image-2":


### PR DESCRIPTION
Fixed grammar mistakes in two of the No Sidewalk validation examples, removing the unnecessary "is" from both statements.

Resolves #1857 