### PR TITLE
#1152 Neighborhood Completion Overlay Now Fills Screen

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1171,7 +1171,9 @@ kbd {
 .overlay-text{
     height: 100%;
     width: 100%;
-    position: absolute;
+    position: fixed;
+    top: 0;
+    left: 0;
     background: rgba(0,0,0,0.89);
     z-index: 5;
 }


### PR DESCRIPTION
Resolves #1152

Changes the neighborhood completion overlay to fill the screen instead of being confined to the center portion of the screen. To test this overlay easily without having to actually move through the neighborhood you can go to the Javascript file `TaskContainer.js` and change the if statement inside the function `updateNeighborhoodCompleteAcrossAllUsersStatus` to show the overlay even when the neighborhood is incomplete.