### PR TITLE
#1849 change titles on example images on validation

### DIFF
--- a/public/javascripts/SVValidate/css/svv-status.css
+++ b/public/javascripts/SVValidate/css/svv-status.css
@@ -80,7 +80,7 @@
 }
 
 .status-box h1 {
-    font-size: 11pt;
+    font-size: 10pt;
     margin: 0 0 4px 0;
 }
 

--- a/public/javascripts/SVValidate/css/svv-status.css
+++ b/public/javascripts/SVValidate/css/svv-status.css
@@ -80,7 +80,7 @@
 }
 
 .status-box h1 {
-    font-size: 12pt;
+    font-size: 11pt;
     margin: 0 0 4px 0;
 }
 

--- a/public/javascripts/SVValidate/src/status/StatusField.js
+++ b/public/javascripts/SVValidate/src/status/StatusField.js
@@ -63,8 +63,8 @@ function StatusField() {
         svv.ui.status.upperMenuTitle.css("left", width + "px");
 
         // Changes text on on the status field (right side of the validation interface).
-        svv.ui.status.labelTypeCounterexample.html("NOT ".italics() + prefix + labelName);
-        svv.ui.status.labelTypeExample.html(labelName);
+        svv.ui.status.labelTypeCounterexample.html("INCORRECT ".italics() + labelName);
+        svv.ui.status.labelTypeExample.html("CORRECT " + labelName);
     }
 
     /**


### PR DESCRIPTION
Resolves #1849

Changed the titles for the example images on the right side of the validation interface from 'Curb Ramp' and 'NOT a Curb Ramp' to 'CORRECT Curb Ramp' and 'INCORRECT Curb Ramp', respectively.  The font size for the example text was also changed from 12 pt to 10 pt so that the validation example images didn't appear too far down as seen in the picture below:
![2020-02-02 (2)](https://user-images.githubusercontent.com/32688680/73613564-ec09a280-45ab-11ea-8bdd-d30aeef6784a.png)

Here are some new pictures with the correct validation image titles:
![2020-01-29 (7)](https://user-images.githubusercontent.com/32688680/73421866-0a397f00-42dc-11ea-85cb-6fb080c1aed5.png)
![2020-02-02 (7)](https://user-images.githubusercontent.com/32688680/73613594-591d3800-45ac-11ea-8411-c9a16cee50ac.png)
![2020-02-02 (8)](https://user-images.githubusercontent.com/32688680/73613603-7225e900-45ac-11ea-91ef-ba94e90e188a.png)

![2020-01-29 (5)](https://user-images.githubusercontent.com/32688680/73421880-16bdd780-42dc-11ea-94e6-6a59f03c8bc0.png)
