### PR TITLE
Increases default zoom for Seattle maps

### DIFF
--- a/conf/cityparams.conf
+++ b/conf/cityparams.conf
@@ -104,7 +104,7 @@ city-params {
   default-map-zoom {
     newberg-or = 14.0
     washington-dc = 12.0
-    seattle-wa = 11.5
+    seattle-wa = 12.0
     columbus-oh = 13.75
     cdmx = 14.0
   }


### PR DESCRIPTION
Resolves #2014 

I've already made the changes to the database necessary to move Seattle to a two-phase deployment. This PR just increases the default zoom on all maps of Seattle given the smaller area we are focusing on.

Here's what it looked like before any changes
![zoom-before-1](https://user-images.githubusercontent.com/6518824/74270781-a1310e80-4cc0-11ea-84f6-94cf57091034.png)

Here's what it looks like after moving to a subset of Seattle, before changing the zoom (choropleth shading looks different bc they are pics from different servers)
![zoom-before-2](https://user-images.githubusercontent.com/6518824/74270806-ac843a00-4cc0-11ea-8ed0-516f907bf67b.png)

And here's what it looks like with the increased zoom
![zoom-after](https://user-images.githubusercontent.com/6518824/74270827-b443de80-4cc0-11ea-93e0-609cd176c397.png)
