### PR TITLE
Adds link to mapathons on landing page

### DIFF
--- a/app/controllers/ApplicationController.scala
+++ b/app/controllers/ApplicationController.scala
@@ -122,6 +122,7 @@ class ApplicationController @Inject() (implicit val env: Environment[User, Sessi
               val cityName: String = Play.configuration.getString("city-params.city-name." + cityStr).get
               val stateAbbreviation: String = Play.configuration.getString("city-params.state-abbreviation." + cityStr).get
               val cityShortName: String = Play.configuration.getString("city-params.city-short-name." + cityStr).get
+              val mapathonLink: Option[String] = Play.configuration.getString("city-params.mapathon-event-link." + cityStr)
               // Get names and URLs for other cities so we can link to them on landing page.
               val otherCities: List[String] =
                 Play.configuration.getStringList("city-params.city-ids").get.asScala.toList.filterNot(_ == cityStr)
@@ -131,7 +132,7 @@ class ApplicationController @Inject() (implicit val env: Environment[User, Sessi
                 val otherURL: String = Play.configuration.getString("city-params.landing-page-url." + otherCity).get
                 (otherName + ", " + otherState, otherURL)
               }
-              Future.successful(Ok(views.html.index("Project Sidewalk", Some(user), cityName, stateAbbreviation, cityShortName, cityStr, otherCityUrls)))
+              Future.successful(Ok(views.html.index("Project Sidewalk", Some(user), cityName, stateAbbreviation, cityShortName, mapathonLink, cityStr, otherCityUrls)))
             } else{
               WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, activityLogText, timestamp))
               Future.successful(Redirect("/"))

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -3,7 +3,7 @@
 @import models.label._
 @import models.street.StreetEdgeTable
 @import play.api.libs.json.Json
-@(title: String, user: Option[User] = None, cityName: String, stateAbbreviation: String, cityShortName: String, cityId: String, otherCityURLs: List[(String, String)])(implicit lang: Lang)
+@(title: String, user: Option[User] = None, cityName: String, stateAbbreviation: String, cityShortName: String, mapathonLink: Option[String], cityId: String, otherCityURLs: List[(String, String)])(implicit lang: Lang)
 
 @main(title) {
     @navbar(user)
@@ -23,8 +23,6 @@
         </div>
         <div class="container" id="banner">
             <div class="row" id="bigtext">
-
-
                 <div class="col-sm-3"></div>
                 <div class="col-sm-6" id="bannertext">
                     <p id="text">
@@ -37,7 +35,10 @@
                     @for((cityName, cityURL) <- otherCityURLs.filter(_._1 != "Mexico City, MX")) {
                         <a class="exploremaplink" href="@{cityURL + "/audit"}">@cityName</a> &nbsp;
                     }
-
+                    <br>
+                    @if(mapathonLink.isDefined) {
+                        <span class="header-text">Live in @cityName? Stop by <a class="exploremaplink" href="@mapathonLink.get" target="_blank">a mapathon event in your area!</a></span>
+                    }
                 </div>
                 <div class="col-sm-3"></div>
             </div>

--- a/conf/cityparams.conf
+++ b/conf/cityparams.conf
@@ -45,6 +45,9 @@ city-params {
     columbus-oh = "https://sidewalk-columbus.cs.washington.edu"
     cdmx = "https://sidewalk-cdmx.cs.washington.edu"
   }
+  mapathon-event-link {
+    columbus-oh = "https://opencolumbus.page.link/mapping"
+  }
   google-analytics-id {
     newberg-or = "UA-136713858-1"
     washington-dc = "UA-76528208-1"


### PR DESCRIPTION
Resolves #2012 

Adds a link to upcoming mapathon events to the landing page. This only shows up on servers for cities where we there are upcoming events (if there is a link in the conf/cityparams.conf file). If there are no upcoming events, then the text is absent. Here is with/without:

![landing-page-with-link](https://user-images.githubusercontent.com/6518824/74292449-e53a0880-4cec-11ea-8132-874772352b44.png)
![landing-page-no-link](https://user-images.githubusercontent.com/6518824/74292451-e66b3580-4cec-11ea-9740-ea09cc294167.png)
