### PR TITLE
#1653 Convert Admin Interface to PST Time

### DIFF
--- a/app/models/audit/AuditTaskTable.scala
+++ b/app/models/audit/AuditTaskTable.scala
@@ -187,7 +187,7 @@ object AuditTaskTable {
     val countTasksQuery = Q.queryNA[Int](
       """SELECT audit_task_id
         |FROM sidewalk.audit_task
-        |WHERE audit_task.task_end::date = now()::date
+        |WHERE (audit_task.task_end AT TIME ZONE 'PST')::date = (now() AT TIME ZONE 'PST')::date
         |    AND audit_task.completed = TRUE""".stripMargin
     )
     countTasksQuery.list.size
@@ -203,7 +203,7 @@ object AuditTaskTable {
     val countTasksQuery = Q.queryNA[Int](
       """SELECT audit_task_id
         |FROM sidewalk.audit_task
-        |WHERE audit_task.task_end::date = now()::date - interval '1' day
+        |WHERE (audit_task.task_end AT TIME ZONE 'PST')::date = (now() AT TIME ZONE 'PST')::date - interval '1' day
         |    AND audit_task.completed = TRUE""".stripMargin
     )
     countTasksQuery.list.size

--- a/app/models/daos/UserDAOImpl.scala
+++ b/app/models/daos/UserDAOImpl.scala
@@ -2,6 +2,9 @@ package models.daos
 
 import java.sql.Timestamp
 import java.util.UUID
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
 
 import com.mohiva.play.silhouette.api.LoginInfo
 import models.daos.UserDAOImpl._
@@ -166,18 +169,21 @@ object UserDAOImpl {
    */
   def countValidationUsersContributedToday(role: String): Int = db.withSession { implicit session =>
     val countQuery = Q.query[String, Int](
-      """SELECT COUNT(DISTINCT(mission.user_id))
+      """
+        |SELECT COUNT(DISTINCT(mission.user_id))
         |FROM label_validation
         |INNER JOIN mission ON label_validation.user_id = mission.user_id
         |INNER JOIN sidewalk_user ON sidewalk_user.user_id = mission.user_id
         |INNER JOIN user_role ON sidewalk_user.user_id = user_role.user_id
         |INNER JOIN sidewalk.role ON user_role.role_id = sidewalk.role.role_id
-        |WHERE label_validation.end_timestamp::date = now()::date
+        |WHERE (label_validation.end_timestamp AT TIME ZONE 'PST')::date = (NOW() AT TIME ZONE 'PST')::date
         |    AND sidewalk_user.username <> 'anonymous'
         |    AND role.role = ?""".stripMargin
     )
     countQuery(role).list.head
   }
+
+
 
   /**
    * Count the number of researchers who contributed validations today (incl Researcher, Adminstrator, and Owner roles).
@@ -218,7 +224,7 @@ object UserDAOImpl {
         |INNER JOIN sidewalk_user ON sidewalk_user.user_id = mission.user_id
         |INNER JOIN user_role ON sidewalk_user.user_id = user_role.user_id
         |INNER JOIN sidewalk.role ON user_role.role_id = sidewalk.role.role_id
-        |WHERE label_validation.end_timestamp::date = now()::date - interval '1' day
+        |WHERE (label_validation.end_timestamp AT TIME ZONE 'PST')::date = (NOW() AT TIME ZONE 'PST')::date - interval '1' day
         |    AND sidewalk_user.username <> 'anonymous'
         |    AND role.role = ?""".stripMargin
     )
@@ -309,7 +315,7 @@ object UserDAOImpl {
         |INNER JOIN sidewalk_user ON sidewalk_user.user_id = audit_task.user_id
         |INNER JOIN user_role ON sidewalk_user.user_id = user_role.user_id
         |INNER JOIN sidewalk.role ON user_role.role_id = sidewalk.role.role_id
-        |WHERE audit_task.task_end::date = now()::date
+        |WHERE (audit_task.task_end AT TIME ZONE 'PST')::date = (NOW() AT TIME ZONE 'PST')::date
         |    AND sidewalk_user.username <> 'anonymous'
         |    AND role.role = ?
         |    AND audit_task.completed = true""".stripMargin
@@ -355,7 +361,7 @@ object UserDAOImpl {
         |INNER JOIN sidewalk_user ON sidewalk_user.user_id = audit_task.user_id
         |INNER JOIN user_role ON sidewalk_user.user_id = user_role.user_id
         |INNER JOIN sidewalk.role ON user_role.role_id = sidewalk.role.role_id
-        |WHERE audit_task.task_end::date = now()::date - interval '1' day
+        |WHERE (audit_task.task_end AT TIME ZONE 'PST')::date = (now() AT TIME ZONE 'PST')::date - interval '1' day
         |    AND sidewalk_user.username <> 'anonymous'
         |    AND role.role = ?
         |    AND audit_task.completed = true""".stripMargin

--- a/app/models/daos/UserDAOImpl.scala
+++ b/app/models/daos/UserDAOImpl.scala
@@ -2,9 +2,6 @@ package models.daos
 
 import java.sql.Timestamp
 import java.util.UUID
-import java.time.LocalDate
-import java.time.ZoneOffset
-import java.time.format.DateTimeFormatter
 
 import com.mohiva.play.silhouette.api.LoginInfo
 import models.daos.UserDAOImpl._

--- a/app/models/daos/UserDAOImpl.scala
+++ b/app/models/daos/UserDAOImpl.scala
@@ -166,8 +166,7 @@ object UserDAOImpl {
    */
   def countValidationUsersContributedToday(role: String): Int = db.withSession { implicit session =>
     val countQuery = Q.query[String, Int](
-      """
-        |SELECT COUNT(DISTINCT(mission.user_id))
+      """SELECT COUNT(DISTINCT(mission.user_id))
         |FROM label_validation
         |INNER JOIN mission ON label_validation.user_id = mission.user_id
         |INNER JOIN sidewalk_user ON sidewalk_user.user_id = mission.user_id
@@ -179,8 +178,6 @@ object UserDAOImpl {
     )
     countQuery(role).list.head
   }
-
-
 
   /**
    * Count the number of researchers who contributed validations today (incl Researcher, Adminstrator, and Owner roles).

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -227,7 +227,7 @@ object LabelTable {
       """SELECT label.label_id
         |FROM sidewalk.audit_task
         |INNER JOIN sidewalk.label ON label.audit_task_id = audit_task.audit_task_id
-        |WHERE audit_task.task_end::date = now()::date
+        |WHERE (audit_task.task_end AT TIME ZONE 'PST')::date = (now() AT TIME ZONE 'PST')::date
         |    AND label.deleted = false""".stripMargin
     )
     countQuery.list.size
@@ -245,7 +245,7 @@ object LabelTable {
                          |  FROM sidewalk.audit_task
                          |INNER JOIN sidewalk.label
                          |  ON label.audit_task_id = audit_task.audit_task_id
-                         |WHERE audit_task.task_end::date = now()::date
+                         |WHERE (audit_task.task_end AT TIME ZONE 'PST')::date = (now() AT TIME ZONE 'PST')::date
                          |  AND label.deleted = false AND label.label_type_id = (SELECT label_type_id
                          |														FROM sidewalk.label_type as lt
                          |														WHERE lt.label_type='$labelType')""".stripMargin
@@ -263,7 +263,7 @@ object LabelTable {
       """SELECT label.label_id
         |FROM sidewalk.audit_task
         |INNER JOIN sidewalk.label ON label.audit_task_id = audit_task.audit_task_id
-        |WHERE audit_task.task_end::date = now()::date - interval '1' day
+        |WHERE (audit_task.task_end AT TIME ZONE 'PST')::date = (now() AT TIME ZONE 'PST')::date - interval '1' day
         |    AND label.deleted = false""".stripMargin
     )
     countQuery.list.size
@@ -278,7 +278,7 @@ object LabelTable {
                          |  FROM sidewalk.audit_task
                          |INNER JOIN sidewalk.label
                          |  ON label.audit_task_id = audit_task.audit_task_id
-                         |WHERE audit_task.task_end::date = now()::date - interval '1' day
+                         |WHERE (audit_task.task_end AT TIME ZONE 'PST')::date = (now() AT TIME ZONE 'PST')::date - interval '1' day
                          |  AND label.deleted = false AND label.label_type_id = (SELECT label_type_id
                          |														FROM sidewalk.label_type as lt
                          |														WHERE lt.label_type='$labelType')""".stripMargin

--- a/app/models/label/LabelValidationTable.scala
+++ b/app/models/label/LabelValidationTable.scala
@@ -259,7 +259,7 @@ object LabelValidationTable {
     val countQuery = Q.queryNA[(Int)](
       """SELECT v.label_id
         |FROM sidewalk.label_validation v
-        |WHERE v.end_timestamp::date = now()::date""".stripMargin
+        |WHERE (v.end_timestamp AT TIME ZONE 'PST')::date = (NOW() AT TIME ZONE 'PST')::date""".stripMargin
     )
     countQuery.list.size
   }
@@ -271,7 +271,7 @@ object LabelValidationTable {
     val countQuery = Q.queryNA[(Int)](
       """SELECT v.label_id
         |FROM sidewalk.label_validation v
-        |WHERE v.end_timestamp::date = now()::date - interval '1' day""".stripMargin
+        |WHERE (v.end_timestamp AT TIME ZONE 'PST')::date = (NOW() AT TIME ZONE 'PST')::date - interval '1' day""".stripMargin
     )
     countQuery.list.size
   }
@@ -283,7 +283,7 @@ object LabelValidationTable {
     val countQuery = Q.queryNA[(Int)](
       s"""SELECT v.label_id
         |FROM sidewalk.label_validation v
-        |WHERE v.end_timestamp::date = now()::date
+        |WHERE (v.end_timestamp AT TIME ZONE 'PST')::date = (NOW() AT TIME ZONE 'PST')::date
         |   AND v.validation_result = $result""".stripMargin
     )
     countQuery.list.size
@@ -296,7 +296,7 @@ object LabelValidationTable {
     val countQuery = Q.queryNA[(Int)](
       s"""SELECT v.label_id
          |FROM sidewalk.label_validation v
-         |WHERE v.end_timestamp::date = now()::date - interval '1' day
+         |WHERE (v.end_timestamp AT TIME ZONE 'PST')::date = (NOW() AT TIME ZONE 'PST')::date - interval '1' day
          |   AND v.validation_result = $result""".stripMargin
     )
     countQuery.list.size


### PR DESCRIPTION
Converted all data on the admin interface to be displayed in respect to PST time instead of UTC time. Did this by converting timestamps in the "end_timestamp" column from PostgreSQL database into PST time.

Resolves issue #1653