### PR TITLE
Changes default zoom and map center for Columbus

### DIFF
--- a/conf/cityparams.conf
+++ b/conf/cityparams.conf
@@ -59,7 +59,7 @@ city-params {
     newberg-or = 45.308
     washington-dc = 38.892
     seattle-wa = 47.615
-    columbus-oh = 39.965
+    columbus-oh = 40.000
     cdmx = 19.490
   }
   city-center-lng {
@@ -87,7 +87,7 @@ city-params {
     newberg-or = 45.345
     washington-dc = 39.060
     seattle-wa = 47.850
-    columbus-oh = 40.005
+    columbus-oh = 40.105
     cdmx = 19.600
   }
   northeast-boundary-lng {
@@ -108,7 +108,7 @@ city-params {
     newberg-or = 14.0
     washington-dc = 12.0
     seattle-wa = 12.0
-    columbus-oh = 13.75
+    columbus-oh = 12.75
     cdmx = 14.0
   }
   api-demos {


### PR DESCRIPTION
Resolves #2024 

Changes the default zoom and map centering for Columbus, OH to accommodate expanding to more neighborhoods.