### PR TITLE
Replaces deprecate Mapbox styles

### DIFF
--- a/public/javascripts/AccessibilityChoropleth.js
+++ b/public/javascripts/AccessibilityChoropleth.js
@@ -16,7 +16,7 @@ function AccessibilityChoropleth(_, $, turf, difficultRegionIds) {
 
 // a grayscale tileLayer for the choropleth
     L.mapbox.accessToken = 'pk.eyJ1IjoibWlzYXVnc3RhZCIsImEiOiJjajN2dTV2Mm0wMDFsMndvMXJiZWcydDRvIn0.IXE8rQNF--HikYDjccA7Ug';
-    var choropleth = L.mapbox.map('choropleth', "kotarohara.8e0c6890", {
+    var choropleth = L.mapbox.map('choropleth', "mapbox.light", {
         maxZoom: 19,
         minZoom: 9,
         zoomControl: false,
@@ -39,8 +39,6 @@ function AccessibilityChoropleth(_, $, turf, difficultRegionIds) {
             choropleth.setView([data.city_center.lat, data.city_center.lng], data.default_zoom);
         }
     });
-
-    L.mapbox.styleLayer('mapbox://styles/mapbox/light-v9').addTo(choropleth);
 
     L.control.zoomslider().addTo(choropleth);
 

--- a/public/javascripts/Admin/src/Admin.Task.js
+++ b/public/javascripts/Admin/src/Admin.Task.js
@@ -9,7 +9,7 @@ function AdminTask(params) {
         attribution: '<a href="http://www.mapbox.com/about/maps/" target="_blank">Terms &amp; Feedback</a>'
     });
 
-    var map = L.mapbox.map('map', "kotarohara.8e0c6890", {zoomControl: false})
+    var map = L.mapbox.map('map', "mapbox.streets", {zoomControl: false})
     // .addLayer(mapboxTiles)
         .setView([38.910, -77.040], 17);
 

--- a/public/javascripts/Admin/src/Admin.User.js
+++ b/public/javascripts/Admin/src/Admin.User.js
@@ -12,7 +12,7 @@ function AdminUser(params) {
     var mapboxTiles = L.tileLayer(tileUrl, {
         attribution: '<a href="http://www.mapbox.com/about/maps/" target="_blank">Terms &amp; Feedback</a>'
     });
-    var map = L.mapbox.map('admin-map', "kotarohara.8e0c6890", {
+    var map = L.mapbox.map('admin-map', "mapbox.streets", {
         maxZoom: 19,
         minZoom: 9,
         zoomSnap: 0.5

--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -38,7 +38,7 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
     var mapboxTiles = L.tileLayer(tileUrl, {
         attribution: '<a href="http://www.mapbox.com/about/maps/" target="_blank">Terms &amp; Feedback</a>'
     });
-    var map = L.mapbox.map('admin-map', "kotarohara.8e0c6890", {
+    var map = L.mapbox.map('admin-map', "mapbox.streets", {
         maxZoom: 19,
         minZoom: 9,
         zoomSnap: 0.5
@@ -46,7 +46,7 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
 
     // a grayscale tileLayer for the choropleth
     L.mapbox.accessToken = 'pk.eyJ1IjoibWlzYXVnc3RhZCIsImEiOiJjajN2dTV2Mm0wMDFsMndvMXJiZWcydDRvIn0.IXE8rQNF--HikYDjccA7Ug';
-    var choropleth = L.mapbox.map('admin-choropleth', "kotarohara.8e0c6890", {
+    var choropleth = L.mapbox.map('admin-choropleth', "mapbox.light", {
         maxZoom: 19,
         minZoom: 9,
         legendControl: {
@@ -64,8 +64,6 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
         choropleth.setZoom(data.default_zoom);
         initializeOverlayPolygon(map, data.city_center.lat, data.city_center.lng);
     });
-
-    L.mapbox.styleLayer('mapbox://styles/mapbox/light-v9').addTo(choropleth);
 
     // Initialize the map
     /**

--- a/public/javascripts/Choropleth.js
+++ b/public/javascripts/Choropleth.js
@@ -9,7 +9,7 @@ function Choropleth(_, $, difficultRegionIds) {
 
 // a grayscale tileLayer for the choropleth
     L.mapbox.accessToken = 'pk.eyJ1IjoibWlzYXVnc3RhZCIsImEiOiJjajN2dTV2Mm0wMDFsMndvMXJiZWcydDRvIn0.IXE8rQNF--HikYDjccA7Ug';
-    var choropleth = L.mapbox.map('choropleth', "kotarohara.8e0c6890", {
+    var choropleth = L.mapbox.map('choropleth', "mapbox.light", {
         maxZoom: 19,
         minZoom: 9,
         zoomControl: false,
@@ -19,8 +19,6 @@ function Choropleth(_, $, difficultRegionIds) {
         zoomSnap: 0.5
     });
     choropleth.scrollWheelZoom.disable();
-
-    L.mapbox.styleLayer('mapbox://styles/mapbox/light-v9').addTo(choropleth);
 
     L.control.zoomslider().addTo(choropleth);
 

--- a/public/javascripts/LabelMap.js
+++ b/public/javascripts/LabelMap.js
@@ -42,7 +42,7 @@ function LabelMap(_, $) {
     var mapboxTiles = L.tileLayer(tileUrl, {
         attribution: '<a href="http://www.mapbox.com/about/maps/" target="_blank">Terms &amp; Feedback</a>'
     });
-    var map = L.mapbox.map('admin-map', "kotarohara.8e0c6890", {
+    var map = L.mapbox.map('admin-map', "mapbox.streets", {
         maxZoom: 19,
         minZoom: 9,
         zoomSnap: 0.5

--- a/public/javascripts/Progress/src/Progress.js
+++ b/public/javascripts/Progress/src/Progress.js
@@ -31,7 +31,7 @@ function Progress (_, $, c3, L, role, difficultRegionIds) {
     var mapboxTiles = L.tileLayer(tileUrl, {
         attribution: '<a href="http://www.mapbox.com/about/maps/" target="_blank">Terms &amp; Feedback</a>'
     });
-    var map = L.mapbox.map('map', "kotarohara.8e0c6890", {
+    var map = L.mapbox.map('map', "mapbox.streets", {
         maxZoom: 19,
         minZoom: 9,
         zoomSnap: 0.5

--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionCompleteMap.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionCompleteMap.js
@@ -2,7 +2,7 @@ function ModalMissionCompleteMap(uiModalMissionComplete) {
     // Map visualization
     L.mapbox.accessToken = 'pk.eyJ1IjoicHJvamVjdHNpZGV3YWxrIiwiYSI6ImNpdmZtODFobjAxcjEydHBkbmg0Y2F0MGgifQ.tDBFPXecLVjgJA0Z1LFhhw';
     var self = this;
-    this._map = L.mapbox.map(uiModalMissionComplete.map.get(0), "kotarohara.8e0c6890", {
+    this._map = L.mapbox.map(uiModalMissionComplete.map.get(0), "mapbox.streets", {
         maxZoom: 19,
         minZoom: 10,
         style: 'mapbox://styles/projectsidewalk/civfm8qwi000l2iqo9ru4uhhj',

--- a/public/javascripts/accessScoreDemo.js
+++ b/public/javascripts/accessScoreDemo.js
@@ -4,7 +4,7 @@ $(document).ready(function () {
     L.mapbox.accessToken = 'pk.eyJ1Ijoia290YXJvaGFyYSIsImEiOiJDdmJnOW1FIn0.kJV65G6eNXs4ATjWCtkEmA';
 
     tileUrl = "https:\/\/a.tiles.mapbox.com\/v4\/kotarohara.8e0c6890\/{z}\/{x}\/{y}.png?access_token=pk.eyJ1Ijoia290YXJvaGFyYSIsImEiOiJDdmJnOW1FIn0.kJV65G6eNXs4ATjWCtkEmA";
-    map = L.mapbox.map('map', "kotarohara.8e0c6890", {
+    map = L.mapbox.map('map', "mapbox.streets", {
         maxZoom: 19,
         minZoom: 9,
         zoomSnap: 0.5

--- a/public/javascripts/developer.js
+++ b/public/javascripts/developer.js
@@ -8,17 +8,17 @@ $(document).ready(function () {
     });
 
     // Maps
-    var mapAccessAttributes = L.mapbox.map('developer-access-attribute-map', "kotarohara.8e0c6890", {
+    var mapAccessAttributes = L.mapbox.map('developer-access-attribute-map', "mapbox.streets", {
         maxZoom: 19,
         minZoom: 9,
         zoomSnap: 0.5
     });
-    var mapAccessScoreStreets = L.mapbox.map('developer-access-score-streets-map', "kotarohara.8e0c6890", {
+    var mapAccessScoreStreets = L.mapbox.map('developer-access-score-streets-map', "mapbox.streets", {
         maxZoom: 19,
         minZoom: 9,
         zoomSnap: 0.5
     });
-    var mapAccessScoreNeighborhoods = L.mapbox.map('developer-access-score-neighborhoods-map', "kotarohara.8e0c6890", {
+    var mapAccessScoreNeighborhoods = L.mapbox.map('developer-access-score-neighborhoods-map', "mapbox.streets", {
         maxZoom: 19,
         minZoom: 9
     });

--- a/public/javascripts/index.js
+++ b/public/javascripts/index.js
@@ -7,7 +7,7 @@ $(document).ready(function () {
         attribution: '<a href="http://www.mapbox.com/about/maps/" target="_blank">Terms &amp; Feedback</a>'
     });
 
-    var map = L.mapbox.map('map', "kotarohara.8e0c6890", {zoomControl: false})
+    var map = L.mapbox.map('map', "mapbox.streets", {zoomControl: false})
             // .addLayer(mapboxTiles)
             .setView([38.910, -77.040], 17);
 

--- a/public/javascripts/mapEdit.js
+++ b/public/javascripts/mapEdit.js
@@ -12,7 +12,7 @@ $(document).ready(function () {
         mapboxTiles = L.tileLayer(tileUrl, {
             attribution: '<a href="http://www.mapbox.com/about/maps/" target="_blank">Terms &amp; Feedback</a>'
         }),
-        map = L.mapbox.map('map', "kotarohara.8e0c6890", {
+        map = L.mapbox.map('map', "mapbox.streets", {
             // set that bounding box as maxBounds to restrict moving the map
             // see full maxBounds documentation:
             // http://leafletjs.com/reference.html#map-maxbounds

--- a/public/javascripts/previousAudit.js
+++ b/public/javascripts/previousAudit.js
@@ -7,7 +7,7 @@ $(document).ready(function () {
         attribution: '<a href="http://www.mapbox.com/about/maps/" target="_blank">Terms &amp; Feedback</a>'
     });
 
-    var map = L.mapbox.map('map', "kotarohara.8e0c6890", {zoomControl: false})
+    var map = L.mapbox.map('map', "mapbox.streets", {zoomControl: false})
             // .addLayer(mapboxTiles)
             .setView([38.910, -77.040], 17);
 


### PR DESCRIPTION
Resolves #2013 

Old styles created through Mapbox Studio Classic have been deprecated. This PR replaces those old styles we were using with more current ones that looks similar. We only had two different styles we were using across our maps; the minor differences shown below:

Landing page before
![landing-before](https://user-images.githubusercontent.com/6518824/76575227-c5c50580-647b-11ea-992b-9a2353410be0.png)

Landing page after
![landing-after](https://user-images.githubusercontent.com/6518824/76575230-c9f12300-647b-11ea-947b-84180ad427c9.png)

User dashboard before
![user-dashboard-old](https://user-images.githubusercontent.com/6518824/76575241-ce1d4080-647b-11ea-8ef7-3fdaf9ca8b3f.png)

User dashboard after
![user-dashboard-new](https://user-images.githubusercontent.com/6518824/76575247-d2495e00-647b-11ea-8115-580f13bb7e5b.png)