### PR TITLE
Adds Mexico City link to landing page

### DIFF
--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -32,7 +32,7 @@
                     <a class="bodyStartBtn" href="@routes.AuditController.audit()">@Messages("navbar.explore") @cityShortName</a>
                     <br><br>
                     <span class="header-text">@Messages("landing.also.in")</span>
-                    @for((cityName, cityURL) <- otherCityURLs.filter(_._1 != "Mexico City, MX")) {
+                    @for((cityName, cityURL) <- otherCityURLs) {
                         <a class="exploremaplink" href="@{cityURL + "/audit"}">@cityName</a> &nbsp;
                     }
                     <br>


### PR DESCRIPTION
Fixes #2059 

Removes the line that filters out the Mexico City link on the landing page since the public version is up and running.