### PR TITLE
#2066 added postgres environment variables to docker-compose from develop branch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,3 +29,8 @@ services:
       - "./db:/opt"
     ports:
       - "5432:5432"
+    environment: 
+      - POSTGRESS_USER=sidewalk
+      - POSTGRES_PASSWORD=sidewalk
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,5 +32,3 @@ services:
     environment: 
       - POSTGRESS_USER=sidewalk
       - POSTGRES_PASSWORD=sidewalk
-
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,5 +30,5 @@ services:
     ports:
       - "5432:5432"
     environment: 
-      - POSTGRESS_USER=sidewalk
+      - POSTGRES_USER=sidewalk
       - POSTGRES_PASSWORD=sidewalk


### PR DESCRIPTION
Resolves #2066 
Adds a POSTGRES_USER and POSTGRES_PASSWORD environment variables to the DB container in order for the container to start up properly.