### PR TITLE
#2063 fixed sign up link bug from /signIn

### DIFF
--- a/conf/messages.en
+++ b/conf/messages.en
@@ -30,14 +30,14 @@ navbar.email = Email address
 navbar.password = Password
 navbar.submit = Submit
 navbar.new = Are you new? <a href="#" id="form-open-sign-up">Sign up!</a>
-navbar.non.member = Not a member? <a href="@routes.UserController.signUp()">Sign up now</a>
+navbar.non.member = Not a member? <a href="/signUp">Sign up now</a>
 navbar.username = Username
 navbar.confirm.password = Confirm password
 navbar.terms = You agree to our <a target="_blank" href="@routes.ApplicationController.terms">Terms of Use and Privacy Policy</a>
 navbar.signup = Sign up
 navbar.signup.new.account = Sign up for a new account
 navbar.has.account = Have an account? <a href="#" id="form-open-sign-in">Sign in</a>
-navbar.is.member = Already a member? <a href="@routes.UserController.signIn()">Sign in now</a>
+navbar.is.member = Already a member? <a href="/signIn">Sign in now</a>
 
 landing.create.path = Let''s create a path for everyone
 landing.also.in = We are also in:

--- a/conf/messages.es
+++ b/conf/messages.es
@@ -29,14 +29,14 @@ navbar.email = Correo electrónico
 navbar.password = Contraseña
 navbar.submit = Enviar
 navbar.new = ¿Eres nuevo/a? <a href="#" id="form-open-sign-up">¡Regístrate!</a>
-navbar.non.member = ¿No eres un miembro? <a href="@routes.UserController.signUp()">Regístrate ahora</a>
+navbar.non.member = ¿No eres un miembro? <a href="/signUp">Regístrate ahora</a>
 navbar.username = Nombre de usuario/a
 navbar.confirm.password = Confirmar contraseña
 navbar.terms = Usted acepta nuestros <a target="_blank" href="@routes.ApplicationController.terms">Términos de uso y Política de privacidad</a>
 navbar.signup = Regístrate
 navbar.signup.new.account = Regístrate para una nueva cuenta
 navbar.has.account = ¿Tienes una cuenta? <a href="#" id="form-open-sign-in">Iniciar sesión</a>
-navbar.is.member = ¿Ya eres miembro? <a href="@routes.UserController.signIn()">Iniciar sesión ahora</a>
+navbar.is.member = ¿Ya eres miembro? <a href="/signIn">Iniciar sesión ahora</a>
 
 landing.create.path = Creemos un camino para todas las personas
 landing.also.in = También estamos en:


### PR DESCRIPTION
Resolves #2063 
Before, when using the sign up now link from the /signIn page, the web page would redirect to an invalid URL "/@routes.UserController.signUp()". The same goes for the sign in now link from the /signUp page. The new changes now route both correctly. The changes were made in both the messages.en and messages.es.