### PR TITLE
Adds Label Map link to navbar

### DIFF
--- a/app/views/navbar.scala.html
+++ b/app/views/navbar.scala.html
@@ -69,66 +69,37 @@
                         }, 1000);
                     </script>
                 }
-                @if(url.isDefined && url.get != "/audit" && url.get != "/validate") {
-                   <li class="active navbarLink">
-                        <a class="navbarBtn navbarStartBtn" href="@routes.AuditController.audit()">@Messages("navbar.explore")</a>
+                @if(url.isDefined && url.get == "/audit") {
+                    <li class="navbarLink">
+                        <a class="navbarBtn" href="#" id="toolbar-onboarding-link">@Messages("navbar.retake.tutorial")</a>
                     </li>
-                    <li class="active navbarLink">
+                }
+                @if(url.isDefined && url.get != "/validate") {
+                    <li class="navbarLink">
                         <a class="navbarBtn navbarValidateBtn" href="@routes.ValidationController.validate()">@Messages("navbar.validate")</a>
                     </li>
+                }
+                @if(url.isDefined && url.get != "/audit") {
                     <li class="active navbarLink">
-                        <a class="navbarBtn navbarGuideBtn" href="@routes.ApplicationController.labelingGuide">@Messages("navbar.howto")</a>
+                        <a class="navbarBtn navbarStartBtn" href="@routes.AuditController.audit()">@Messages("navbar.explore")</a>
                     </li>
+                }
+                <li class="active navbarLink">
+                    <a class="navbarBtn navbarResultsBtn" href="@routes.ApplicationController.results">@Messages("navbar.results")</a>
+                </li>
+                <!-- Only show Label Map link if the city does not have too much data to load that page quickly. -->
+                @if(!List("seattle-wa").contains(Play.configuration.getString("city-id").get)) {
                     <li class="active navbarLink">
-                        <a class="navbarBtn navbarResultsBtn" href="@routes.ApplicationController.results">@Messages("navbar.results")</a>
+                        <a class="navbarBtn navbarLabelMapBtn" href="@routes.ApplicationController.labelMap">@Messages("navbar.labelmap")</a>
                     </li>
-                    <!-- Only show Label Map link if the city does not have too much data to load that page quickly. -->
-                    @if(!List("seattle-wa").contains(Play.configuration.getString("city-id").get)) {
-                        <li class="active navbarLink">
-                            <a class="navbarBtn navbarLabelMapBtn" href="@routes.ApplicationController.labelMap">@Messages("navbar.labelmap")</a>
-                        </li>
-                    }
-
-                } else {
-                    @if(url.isDefined && url.get != "/validate") {
-                        <li class="navbarLink">
-                            <a class="navbarBtn" href="#" id="toolbar-onboarding-link">@Messages("navbar.retake.tutorial")</a>
-                        </li>
-                        <li class="navbarLink">
-                            <a class="navbarBtn navbarValidateBtn" href="@routes.ValidationController.validate()">@Messages("navbar.validate")</a>
-                        </li>
-                        <li class="navbarLink">
-                            <a class="navbarBtn navbarGuideBtn" href='@routes.ApplicationController.labelingGuide' id="toolbar-labeling-guide-link" target="_blank">@Messages("navbar.howto")</a>
-                        </li>
-                        <li class = "navbarLink">
-                          <a class="navbarBtn" href='@routes.ApplicationController.help' id="toolbar-help-link" target="_blank">@Messages("navbar.help")</a>
-                        </li>
-                        <li class="active navbarLink">
-                            <a class="navbarBtn navbarResultsBtn" href="@routes.ApplicationController.results">@Messages("navbar.results")</a>
-                        </li>
-                            <!-- Only show Label Map link if the city does not have too much data to load that page quickly. -->
-                        @if(!List("seattle-wa").contains(Play.configuration.getString("city-id").get)) {
-                            <li class="active navbarLink">
-                                <a class="navbarBtn navbarLabelMapBtn" href="@routes.ApplicationController.labelMap">@Messages("navbar.labelmap")</a>
-                            </li>
-                        }
-                    } else {
-                        <li class="navbarLink">
-                            <a class="navbarBtn navbarStartBtn" href="@routes.AuditController.audit()">@Messages("navbar.explore")</a>
-                        </li>
-                        <li class="navbarLink">
-                            <a class="navbarBtn navbarGuideBtn" href="@routes.ApplicationController.labelingGuide">@Messages("navbar.howto")</a>
-                        </li>
-                        <li class="navbarLink">
-                            <a class="navbarBtn navbarResultsBtn" href="@routes.ApplicationController.results">@Messages("navbar.results")</a>
-                        </li>
-                            <!-- Only show Label Map link if the city does not have too much data to load that page quickly. -->
-                        @if(!List("seattle-wa").contains(Play.configuration.getString("city-id").get)) {
-                            <li class="active navbarLink">
-                                <a class="navbarBtn navbarLabelMapBtn" href="@routes.ApplicationController.labelMap">@Messages("navbar.labelmap")</a>
-                            </li>
-                        }
-                    }
+                }
+                <li class="active navbarLink">
+                    <a class="navbarBtn navbarGuideBtn" href="@routes.ApplicationController.labelingGuide">@Messages("navbar.howto")</a>
+                </li>
+                @if(url.isDefined && url.get == "/audit") {
+                    <li class = "navbarLink">
+                        <a class="navbarBtn" href='@routes.ApplicationController.help' id="toolbar-help-link" target="_blank">@Messages("navbar.help")</a>
+                    </li>
                 }
 
                 <!--<li><a href="#">Explore Accessibility!</a></li>-->

--- a/app/views/navbar.scala.html
+++ b/app/views/navbar.scala.html
@@ -1,4 +1,6 @@
 @import models.user.User
+@import play.api.Play
+@import play.api.Play.current
 @(user: Option[User] = None, url: Option[String] = Some("/"))(implicit lang: Lang)
 
 @import views.html.bootstrap._
@@ -68,7 +70,6 @@
                     </script>
                 }
                 @if(url.isDefined && url.get != "/audit" && url.get != "/validate") {
-
                    <li class="active navbarLink">
                         <a class="navbarBtn navbarStartBtn" href="@routes.AuditController.audit()">@Messages("navbar.explore")</a>
                     </li>
@@ -81,13 +82,15 @@
                     <li class="active navbarLink">
                         <a class="navbarBtn navbarResultsBtn" href="@routes.ApplicationController.results">@Messages("navbar.results")</a>
                     </li>
-                    <li class="active navbarLink">
-                        <a class="navbarBtn navbarLabelMapBtn" href="@routes.ApplicationController.labelMap">@Messages("navbar.labelmap")</a>
-                    </li>
+                    <!-- Only show Label Map link if the city does not have too much data to load that page quickly. -->
+                    @if(!List("seattle-wa").contains(Play.configuration.getString("city-id").get)) {
+                        <li class="active navbarLink">
+                            <a class="navbarBtn navbarLabelMapBtn" href="@routes.ApplicationController.labelMap">@Messages("navbar.labelmap")</a>
+                        </li>
+                    }
 
                 } else {
                     @if(url.isDefined && url.get != "/validate") {
-
                         <li class="navbarLink">
                             <a class="navbarBtn" href="#" id="toolbar-onboarding-link">@Messages("navbar.retake.tutorial")</a>
                         </li>
@@ -103,12 +106,13 @@
                         <li class="active navbarLink">
                             <a class="navbarBtn navbarResultsBtn" href="@routes.ApplicationController.results">@Messages("navbar.results")</a>
                         </li>
-                        <li class="active navbarLink">
-                            <a class="navbarBtn navbarLabelMapBtn" href="@routes.ApplicationController.labelMap">@Messages("navbar.labelmap")</a>
-                        </li>
-
+                            <!-- Only show Label Map link if the city does not have too much data to load that page quickly. -->
+                        @if(!List("seattle-wa").contains(Play.configuration.getString("city-id").get)) {
+                            <li class="active navbarLink">
+                                <a class="navbarBtn navbarLabelMapBtn" href="@routes.ApplicationController.labelMap">@Messages("navbar.labelmap")</a>
+                            </li>
+                        }
                     } else {
-
                         <li class="navbarLink">
                             <a class="navbarBtn navbarStartBtn" href="@routes.AuditController.audit()">@Messages("navbar.explore")</a>
                         </li>
@@ -118,10 +122,12 @@
                         <li class="navbarLink">
                             <a class="navbarBtn navbarResultsBtn" href="@routes.ApplicationController.results">@Messages("navbar.results")</a>
                         </li>
-                        <li class="active navbarLink">
-                            <a class="navbarBtn navbarLabelMapBtn" href="@routes.ApplicationController.labelMap">@Messages("navbar.labelmap")</a>
-                        </li>
-
+                            <!-- Only show Label Map link if the city does not have too much data to load that page quickly. -->
+                        @if(!List("seattle-wa").contains(Play.configuration.getString("city-id").get)) {
+                            <li class="active navbarLink">
+                                <a class="navbarBtn navbarLabelMapBtn" href="@routes.ApplicationController.labelMap">@Messages("navbar.labelmap")</a>
+                            </li>
+                        }
                     }
                 }
 

--- a/app/views/navbar.scala.html
+++ b/app/views/navbar.scala.html
@@ -81,6 +81,9 @@
                     <li class="active navbarLink">
                         <a class="navbarBtn navbarResultsBtn" href="@routes.ApplicationController.results">@Messages("navbar.results")</a>
                     </li>
+                    <li class="active navbarLink">
+                        <a class="navbarBtn navbarLabelMapBtn" href="@routes.ApplicationController.labelMap">@Messages("navbar.labelmap")</a>
+                    </li>
 
                 } else {
                     @if(url.isDefined && url.get != "/validate") {
@@ -97,6 +100,12 @@
                         <li class = "navbarLink">
                           <a class="navbarBtn" href='@routes.ApplicationController.help' id="toolbar-help-link" target="_blank">@Messages("navbar.help")</a>
                         </li>
+                        <li class="active navbarLink">
+                            <a class="navbarBtn navbarResultsBtn" href="@routes.ApplicationController.results">@Messages("navbar.results")</a>
+                        </li>
+                        <li class="active navbarLink">
+                            <a class="navbarBtn navbarLabelMapBtn" href="@routes.ApplicationController.labelMap">@Messages("navbar.labelmap")</a>
+                        </li>
 
                     } else {
 
@@ -108,6 +117,9 @@
                         </li>
                         <li class="navbarLink">
                             <a class="navbarBtn navbarResultsBtn" href="@routes.ApplicationController.results">@Messages("navbar.results")</a>
+                        </li>
+                        <li class="active navbarLink">
+                            <a class="navbarBtn navbarLabelMapBtn" href="@routes.ApplicationController.labelMap">@Messages("navbar.labelmap")</a>
                         </li>
 
                     }
@@ -181,26 +193,31 @@ $(document).ready(function () {
     });
 
     // Triggered when 'Start Exploring' in navbar is clicked
-    // Logs "Click_module=StartExploring_location=Navbar_route=</|/audit|/help|...>"
     $(".navbarStartBtn").on('click', function(){
         logWebpageActivity("Click_module=StartExploring");
     });
 
+    // Triggered when 'Start Validating' in navbar is clicked.
     $(".navbarValidateBtn").on('click', function(){
         logWebpageActivity("Click_module=StartValidating");
     });
 
+    // Triggered when 'How to Label' in navbar is clicked.
     $(".navbarGuideBtn").on('click', function() {
         logWebpageActivity("Click_module=LabelingGuide");
     });
 
-    // Triggered when 'Results' in navbar is clicked
-    // Logs "Click_module=Results_location=Navbar_route=</|/audit|/help|...>"
+    // Triggered when 'Results' in navbar is clicked.
     $(".navbarResultsBtn ").on('click', function(){
         logWebpageActivity("Click_module=Results");
     });
 
-    // Triggered when links in the navbar are pressed when on the Audit page
+    // Triggered when 'Label Map' in navbar is clicked.
+    $(".navbarLabelMapBtn ").on('click', function(){
+        logWebpageActivity("Click_module=LabelMap");
+    });
+
+    // Triggered when links that are only shown on the audit page are clicked.
     // Logs "Click_module=<RetakeTutorial|Help>_location=Navbar_route=</|/audit|/help|...>"
     var helpText = "@Messages("navbar.help")";
     var howtoText = "@Messages("navbar.howto")";

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -19,6 +19,7 @@ navbar.explore = Start Exploring
 navbar.validate = Start Validating
 navbar.howto = How to Label
 navbar.results = See Results
+navbar.labelmap = Label Map
 navbar.help = Help
 navbar.retake.tutorial = Retake Tutorial
 navbar.signin = Sign in

--- a/conf/messages.es
+++ b/conf/messages.es
@@ -18,6 +18,7 @@ navbar.explore = Comienza a Explorar
 navbar.validate = Comienza a Validir
 navbar.howto = Cómo Etiquetar
 navbar.results = Ver Resultados
+navbar.labelmap = Mapa de Etiquetas
 navbar.help = Ayuda
 navbar.retake.tutorial = Volver a Tomar el Tutorial
 navbar.signin = Iniciar sesión

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1351,7 +1351,7 @@ kbd {
 * Hamburger Menu styling based on Bootstrap 3.3.5's collapsible navbar
 * https://bootstrapdocs.com/v3.3.5/docs/components/#navbar
 */
-@media only screen and (max-width: 990px) {
+@media only screen and (max-width: 1250px) {
     .navbar-header {
         float: none;
     }


### PR DESCRIPTION
Resolves #2069 

Adds a link to /labelmap to the navbar, including logging of clicks. This shows up for Newberg, Columbus, and Mexico City. We don't show it for Seattle because the dataset is too large, and we don't show it for DC because it's using the old code base.

![labelmap-navbar-en](https://user-images.githubusercontent.com/6518824/80437275-0bb41c80-88b6-11ea-9a8d-60c5e81b6db2.png)
![labelmap-navbar-es](https://user-images.githubusercontent.com/6518824/80437278-0ce54980-88b6-11ea-91ee-05327a9c251c.png)
