### PR TITLE
Fixes instructions to require loading the database dump

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@ If you run into any problems during setup, check the [Docker troubleshooting wik
 ### Running the application locally
 To run the web server locally, from the root of the SidewalkWebpage directory:
 
-1. Email Mikey (michaelssaugstad@gmail.com) and ask for the two API key files and a database dump. You will put the API key files into the root directory of the project. You will need the database dump later on. You can continue with the rest of the instructions here, but the website will not work fully until you've received these three files from Mikey.
+1. Email Mikey (michaelssaugstad@gmail.com) and ask for the two API key files and a database dump. You will put the API key files into the root directory of the project. Rename the database dump `sidewalk-dump` and put it in the `db` directory.
 
-1. Run `make dev`. This will download the docker images, spin up the containers, and open a Docker shell into the webpage container. The containers will have all the necessary packages and tools so no installation is necessary. Though, the container executes a bash shell running Ubuntu Stretch, which allows you to install whatever tool you prefer that can run on this flavor of linux (vi, etc.). This command also sets up the `sidewalk` database with the schema (just the schema, not the data - see Importing SQL dump in Additional Tools section) from the production dump, which lives in `db/schema.sql`. Successful output of this command will look like:
+1. If the database dump is for a city other than DC, modify the 2nd line of the conf/cityparams.conf to use the appropriate ID. You can find the IDs for the cities starting at line 7 of that file.
+
+1. Run `make dev`. This will download the docker images, spin up the containers, and open a Docker shell into the webpage container. The containers (running Ubuntu Stretch) will have all the necessary packages and tools so no installation is necessary. This command also initializes the database, though we still need to import the data. Successful output of this command will look like:
 
     ```
     Successfully built [container-id]
@@ -21,6 +23,8 @@ To run the web server locally, from the root of the SidewalkWebpage directory:
     WARNING: Image for service web was built because it did not already exist. To rebuild this image you must use `docker-compose build` or `docker-compose up --build`.
     root@[container-id]:/opt#
     ```
+
+1. In a separate terminal, run `make import-dump db=sidewalk` from the root project directory outside the Docker shell. This may take awhile depending on the size of the dump.
 
 1. Run `npm start` from inside the Docker shell. The result of this command is dictated by what `start` is supposed to do as defined in `package.json` file. As per the current code, running this command will run `grunt watch` & `sbt compile "~ run"` (`~` here is triggered execution that allows for the server to run in watch mode). This should start the web server. Note that the first time compilation takes time. Successful output of this command will look like:
 
@@ -43,9 +47,7 @@ To run the web server locally, from the root of the SidewalkWebpage directory:
     (Server started, use Ctrl+D to stop and go back to the console...)
     ```
 
-1. Head on over to your browser and navigate to `127.0.0.1:9000`. This should display the Project Sidewalk webpage. Note that the first time compilation takes time.
-
-1. Importing SQL dump: The Postgres database schema has already been set up in the db docker container. To import production db dump, rename the dump file you got from Mikey to `sidewalk-dump`, place it in the `db` folder, and run `make import-dump db=sidewalk` from the base folder outside the Docker shell. When that is done, rerun `npm start` from inside the Docker shell.
+1. Head on over to your browser and navigate to `127.0.0.1:9000`. This should display the Project Sidewalk webpage.
 
 ### Setting up another database or city
 1. Acquire another database dump and rename it `[db-name]-dump`. I would suggest naming it `sidewalk-seattle-dump` if it is a Seattle database, for example. Just make sure it does not conflict with the name of any databases you already have set up.


### PR DESCRIPTION
Resolves #2065 

Updates the dev environment instructions in the README to require a database dump (since it doesn't work out of the box without one). Also makes some other tiny edits to the instructions to make them more streamlined.