### PR TITLE
Fixes Windows CRLF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,6 @@
 * text=auto
 
 # Declare files that will always have CRLF line endings on checkout.
-*.sh text eol=crlf
-db/*.sh text eol=crlf
+*.sh text eol=lf
+db/*.sh text eol=lf
 


### PR DESCRIPTION
Fixes #1527

Users should now have the correct style of line endings when cloning the repo. When I had fixed this last time, I had accidentally made exactly the _wrong_ line endings the default!