### PR TITLE
Fixes postgres user for dev env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,5 +30,5 @@ services:
     ports:
       - "5432:5432"
     environment: 
-      - POSTGRES_USER=sidewalk
+      - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=sidewalk


### PR DESCRIPTION
Fixes #2066 

Changes the POSTGRES_USER env variable to be "postgres" instead of "sidewalk" for the dev environment. Should fix the dev env issue of the postgres user not existing.