### PR TITLE
2098 Fixes bug where we lose user authentication

### DIFF
--- a/app/controllers/SignUpController.scala
+++ b/app/controllers/SignUpController.scala
@@ -64,14 +64,16 @@ class SignUpController @Inject() (
         UserTable.find(data.username) match {
           case Some(user) =>
             WebpageActivityTable.save(WebpageActivity(0, oldUserId, ipAddress, "Duplicate_Username_Error", timestamp))
-            Future.successful(Redirect(routes.UserController.signUp()).flashing("error" -> Messages("authenticate.error.username.exists")))
+//            Future.successful(Redirect(routes.UserController.signUp()).flashing("error" -> Messages("authenticate.error.username.exists")))
+            Future.successful(Status(409)(Messages("authenticate.error.username.exists")))
           case None =>
 
             // Check presence of user by email.
             UserTable.findEmail(data.email) match {
               case Some(user) =>
                 WebpageActivityTable.save(WebpageActivity(0, oldUserId, ipAddress, "Duplicate_Email_Error", timestamp))
-                Future.successful(Redirect(routes.UserController.signUp()).flashing("error" -> Messages("authenticate.error.email.exists")))
+//                Future.successful(Redirect(routes.UserController.signUp()).flashing("error" -> Messages("authenticate.error.email.exists")))
+                Future.successful(Status(409)(Messages("authenticate.error.email.exists")))
               case None =>
                 // Check if passwords match and are at least 6 characters.
                 if (data.password != data.passwordConfirm) {

--- a/app/controllers/SignUpController.scala
+++ b/app/controllers/SignUpController.scala
@@ -9,6 +9,7 @@ import com.mohiva.play.silhouette.api.services.{AuthInfoService, AvatarService}
 import com.mohiva.play.silhouette.api.util.PasswordHasher
 import com.mohiva.play.silhouette.impl.authenticators.SessionAuthenticator
 import com.mohiva.play.silhouette.impl.providers._
+import play.api.libs.Crypto
 import controllers.headers.ProvidesHeader
 import formats.json.UserFormats._
 import forms.SignUpForm
@@ -16,11 +17,12 @@ import models.services.UserService
 import models.user._
 import play.api.i18n.Messages
 import play.api.libs.concurrent.Execution.Implicits._
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, JsError}
 import play.api.mvc.{Action, RequestHeader}
-import play.api.Play
+import play.api.{Play, Logger}
 import play.api.Play.current
 import models.daos.slick.DBTableDefinitions.{DBUser, UserTable}
+import models.daos.UserDAO
 
 import scala.concurrent.Future
 import scala.util.Random
@@ -37,6 +39,7 @@ import scala.util.Random
 class SignUpController @Inject() (
                                    implicit val env: Environment[User, SessionAuthenticator],
                                    val userService: UserService,
+                                   val userDAO: UserDAO,
                                    val authInfoService: AuthInfoService,
                                    val avatarService: AvatarService,
                                    val passwordHasher: PasswordHasher)
@@ -48,24 +51,23 @@ class SignUpController @Inject() (
    *
    * @return The result to display.
    */
-  def signUp(url: String) = UserAwareAction.async { implicit request =>
+  def signUp(url: Option[String]) = UserAwareAction.async { implicit request =>
     val ipAddress: String = request.remoteAddress
     val anonymousUser: DBUser = UserTable.find("anonymous").get
     val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
     val oldUserId: String = request.identity.map(_.userId.toString).getOrElse(anonymousUser.userId.toString)
 
-    SignUpForm.form.bindFromRequest.fold (
+    SignUpForm.form.bindFromRequest.fold(
       form => Future.successful(BadRequest(views.html.signUp(form))),
-
       data => {
-        // Check presence of user by username
+        // Check presence of user by username.
         UserTable.find(data.username) match {
           case Some(user) =>
             WebpageActivityTable.save(WebpageActivity(0, oldUserId, ipAddress, "Duplicate_Username_Error", timestamp))
             Future.successful(Redirect(routes.UserController.signUp()).flashing("error" -> Messages("authenticate.error.username.exists")))
           case None =>
 
-            // Check presence of user by email
+            // Check presence of user by email.
             UserTable.findEmail(data.email) match {
               case Some(user) =>
                 WebpageActivityTable.save(WebpageActivity(0, oldUserId, ipAddress, "Duplicate_Email_Error", timestamp))
@@ -86,28 +88,58 @@ class SignUpController @Inject() (
                     role = None
                   )
 
-                  for {
+                  val newAuthenticator: Future[SessionAuthenticator] = for {
                     user <- userService.save(user)
                     authInfo <- authInfoService.save(user.loginInfo, authInfo)
                     authenticator <- env.authenticatorService.create(user.loginInfo)
-                    value <- env.authenticatorService.init(authenticator)
-                    result <- env.authenticatorService.embed(value, Future.successful(
-                      Redirect(url)
-                    ))
                   } yield {
                     // Set the user role, assign the neighborhood to audit, and add to the user_stat table.
                     UserRoleTable.setRole(user.userId, "Registered")
                     UserCurrentRegionTable.assignEasyRegion(user.userId)
                     UserStatTable.addUserStatIfNew(user.userId)
 
-                    // Add Timestamp
+                    // Add Timestamp.
                     val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
                     WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, "SignUp", timestamp))
                     WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, "SignIn", timestamp))
 
                     env.eventBus.publish(SignUpEvent(user, request, request2lang))
                     env.eventBus.publish(LoginEvent(user, request, request2lang))
-                    result
+                    authenticator
+                  }
+                  request.authenticator match {
+                    case Some(oldAuthenticator) =>
+                      // If someone was already authenticated (i.e., they were signed into an anon user account), Play
+                      // doesn't let us sign one account out and the other back in in one response header. So we start
+                      // by redirecting to the "/finishSignUp" endpoint, discarding the old authenticator info and
+                      // sending the new authenticator info in a temp element in the session cookie. The "/finishSignUp"
+                      // endpoint will then move authenticator we put in "temp-authenticator" over to "authenticator"
+                      // where it belongs, finally completing the sign up.
+                      val redirectURL: String = url match {
+                        case Some(u) => "/finishSignUp?url=" + u
+                        case None => "/finishSignUp"
+                      }
+                      val result = newAuthenticator.map { newAuth =>
+                        // When we encrypt/serialize, we're doing the work of init, serialize, and embed. Found here:
+                        // https://github.com/mohiva/play-silhouette/blob/2.0.x/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/SessionAuthenticator.scala
+                        val authSerialized: String = Crypto.encryptAES(Json.toJson(newAuth).toString())
+                        Redirect(redirectURL).withSession("temp-authenticator" -> authSerialized)
+                      }
+                      oldAuthenticator.discard(result)
+
+                    case None =>
+                      // If no account was signed in before, we can skip the "/finishSignUp" endpoint step. Instead, we
+                      // embed the authenticator into the session cookie in the normal way and either forward to the
+                      // new URL or simply send the newly authenticated user object.
+                      val result = url match {
+                        case Some(u) => Future.successful(Redirect(u))
+                        case None => Future.successful(Ok(Json.toJson(user)))
+                      }
+                      for {
+                        newA <- newAuthenticator
+                        value <- env.authenticatorService.init(newA)
+                        resultWithAuth <- env.authenticatorService.embed(value, result)
+                      } yield resultWithAuth
                   }
                 }
             }
@@ -116,66 +148,42 @@ class SignUpController @Inject() (
     )
   }
 
-  def postSignUp = UserAwareAction.async { implicit request =>
-    val ipAddress: String = request.remoteAddress
-    val anonymousUser: DBUser = UserTable.find("anonymous").get
-    val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
-    val oldUserId: String = request.identity.map(_.userId.toString).getOrElse(anonymousUser.userId.toString)
+  /**
+   * Finishes the sign up process started by /signUp.
+   *
+   * If someone tried to sign up but was already authenticated (i.e., they were signed into an anon user account), Play
+   * doesn't let us sign one account out and the other back in in one response header; we need a redirect between them.
+   * So /signUp handles the validation and database portions, it discards to old authenticator from the session cookie
+   * and stores the new one in a temporary element, and then it redirects to /finishSignUp. Here, we remove the temp
+   * authenticator and move it's data into the correct element in the cookie, finally completing the sign up.
+   * @param url
+   * @return
+   */
+  def finishSignUp(url: Option[String]) = UserAwareAction.async { implicit request =>
+    if (request.session.get("authenticator").isEmpty && request.session.get("temp-authenticator").isDefined) {
+      // Read the new authenticator from the session cookie.
+      val authenticatorJson: String = Crypto.decryptAES(request.session.get("temp-authenticator").get)
+      val authenticator: SessionAuthenticator = Json.parse(authenticatorJson).validate[SessionAuthenticator].get
 
-    SignUpForm.form.bindFromRequest.fold (
-      form => Future.successful(BadRequest(views.html.signUp(form))),
-      data => {
-        // Check presence of user by username
-        UserTable.find(data.username) match {
-          case Some(user) =>
-            WebpageActivityTable.save(WebpageActivity(0, oldUserId, ipAddress, "Duplicate_Username_Error", timestamp))
-            Future.successful(Status(409)(Messages("authenticate.error.username.exists")))
-          case None =>
-
-            // Check presence of user by email
-            UserTable.findEmail(data.email) match {
-              case Some(user) =>
-                WebpageActivityTable.save(WebpageActivity(0, oldUserId, ipAddress, "Duplicate_Email_Error", timestamp))
-                Future.successful(Status(409)(Messages("authenticate.error.email.exists")))
-              case None =>
-                val loginInfo = LoginInfo(CredentialsProvider.ID, data.email)
-                val authInfo = passwordHasher.hash(data.password)
-                val user = User(
-                  userId = request.identity.map(_.userId).getOrElse(UUID.randomUUID()),
-                  loginInfo = loginInfo,
-                  username = data.username,
-                  email = data.email,
-                  role = None
-                )
-
-                for {
-                  user <- userService.save(user)
-                  authInfo <- authInfoService.save(loginInfo, authInfo)
-                  authenticator <- env.authenticatorService.create(user.loginInfo)
-                  value <- env.authenticatorService.init(authenticator)
-                  result <- env.authenticatorService.embed(value, Future.successful(
-                    Ok(Json.toJson(user))
-                  ))
-                } yield {
-                  // Set the user role, assign the neighborhood to audit, and add to the user_stat table.
-                  UserRoleTable.setRole(user.userId, "Registered")
-                  UserCurrentRegionTable.assignEasyRegion(user.userId)
-                  UserStatTable.addUserStatIfNew(user.userId)
-
-                  // Add Timestamp
-                  val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
-                  WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, "SignUp", timestamp))
-                  WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, "SignIn", timestamp))
-
-                  env.eventBus.publish(SignUpEvent(user, request, request2lang))
-                  env.eventBus.publish(LoginEvent(user, request, request2lang))
-
-                  result
-                }
-            }
-        }
+      // Either forward to the new URL or simply send the newly authenticated user object.
+      val result = url match {
+        case Some(u) => Future.successful(Redirect(u))
+        case None => userDAO.find(authenticator.loginInfo).map(x => Ok(Json.toJson(x)))
       }
-    )
+      // Move the data from "new-authenticator" into "authenticator" to finish the sign up. We are
+      // encrypting/serializing the authenticator ourselves so that we can both add the new one and remove the
+      // temporary "temp-authenticator" in a single call to withSession. We are basically doing the work of the init,
+      // serialize, and embed functions found here:
+      // https://github.com/mohiva/play-silhouette/blob/2.0.x/silhouette/app/com/mohiva/play/silhouette/impl/authenticators/SessionAuthenticator.scala
+      val authSerialized: String = Crypto.encryptAES(Json.toJson(authenticator).toString())
+      result.map(_.withSession(request.session - "temp-authenticator" + ("authenticator" -> authSerialized)))
+    } else {
+      // This shouldn't happen. But if it does, we log it and send them over to /anonSignUp to clean up the mess.
+      val oldDef: Boolean = request.session.get("authenticator").isDefined
+      val newDef: Boolean = request.session.get("temp-authenticator").isDefined
+      Logger.debug(s"Hit /finishSignUp endpoint with wrong authenticators. Old defined: $oldDef, new defined: $newDef")
+      Future.successful(Redirect("/anonSignUp?url=/"))
+    }
   }
 
   /**

--- a/app/views/accessScoreDemo.scala.html
+++ b/app/views/accessScoreDemo.scala.html
@@ -2,7 +2,7 @@
 @(title: String, user: Option[User] = None, cityShortName: String)(implicit lang: Lang)
 
 @main(title) {
-    @navbar(user)
+    @navbar(user, Some("/demo"))
     <div id="map-holder">
         <div id="map"></div>
         <div id="map-legend" class="map-text-box">

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -14,7 +14,7 @@
 
 @(title: String, user: Option[User] = None)(implicit lang: Lang)
 @main(title) {
-@navbar(user)
+@navbar(user, Some("/admin"))
 <style>
     .no-js #loader { display: none;  }
     .js #loader { display: block; position: absolute; left: 100px; top: 0; }

--- a/app/views/auditCreateCVMissionForm.scala.html
+++ b/app/views/auditCreateCVMissionForm.scala.html
@@ -2,7 +2,7 @@
 @(title: String, user: Option[User] = None)
 
 @main(title) {
-    @navbar(user)
+    @navbar(user, Some("/audit/groundtruth"))
     <script>
             /**
              * After user provides list of panoIds and clicks submit, this method checks that the provided panoIds are valid

--- a/app/views/clustering.scala.html
+++ b/app/views/clustering.scala.html
@@ -2,7 +2,7 @@
 
 @(title: String, user: Option[User] = None)(implicit lang: Lang)
 @main(title) {
-    @navbar(user)
+    @navbar(user, Some("/clustering"))
     <div id="content">
         <div class="container">
             <h1>Clustering labels into attributes</h1>

--- a/app/views/developer.scala.html
+++ b/app/views/developer.scala.html
@@ -3,7 +3,7 @@
 @(title: String, user: Option[User] = None)(implicit lang: Lang)
 
 @main(title) {
-    @navbar(user)
+    @navbar(user, Some("/api"))
     <div class="container">
         <h1>Developer Zone</h1>
         <p class="text-justify">

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -6,7 +6,7 @@
 @(title: String, user: Option[User] = None, cityName: String, stateAbbreviation: String, cityShortName: String, mapathonLink: Option[String], cityId: String, otherCityURLs: List[(String, String)])(implicit lang: Lang)
 
 @main(title) {
-    @navbar(user)
+    @navbar(user, Some("/"))
     <script src='@routes.Assets.at("assets/detectMobileBrowser.js")'></script>
     <script src='@routes.Assets.at("assets/homepage.js")'></script>
     <div id="vidbanner">

--- a/app/views/labelMap.scala.html
+++ b/app/views/labelMap.scala.html
@@ -4,7 +4,7 @@
 @(title: String, user: Option[User] = None)(implicit lang: Lang)
 
 @main(title) {
-    @navbar(user)
+    @navbar(user, Some("/labelmap"))
     <script src='@routes.Assets.at("assets/detectMobileBrowser.js")'></script>
 
 

--- a/app/views/labelingGuide.scala.html
+++ b/app/views/labelingGuide.scala.html
@@ -2,7 +2,7 @@
 @(title: String, user: Option[User] = None)(implicit lang: Lang)
 
 @main(title) {
-    @navbar(user)
+    @navbar(user, Some("/labelingGuide"))
     <script type="text/javascript" src='@routes.Assets.at("javascripts/sidebarSubtopics.js")'></script>
     <link rel="stylesheet" href='@routes.Assets.at("stylesheets/help.css")'/>
     <link rel="stylesheet" href='@routes.Assets.at("stylesheets/labelingGuide.css")'/>

--- a/app/views/labelingGuideCurbRamps.scala.html
+++ b/app/views/labelingGuideCurbRamps.scala.html
@@ -2,7 +2,7 @@
 @(title: String, user: Option[User] = None)(implicit lang: Lang)
 
 @main(title) {
-    @navbar(user)
+    @navbar(user, Some("/labelingGuide/curbRamps"))
     <script type="text/javascript" src='@routes.Assets.at("javascripts/sidebarSubtopics.js")'></script>
     <link rel="stylesheet" href='@routes.Assets.at("stylesheets/help.css")'/>
     <link rel="stylesheet" href='@routes.Assets.at("stylesheets/labelingGuide.css")'/>

--- a/app/views/labelingGuideNoSidewalk.scala.html
+++ b/app/views/labelingGuideNoSidewalk.scala.html
@@ -2,7 +2,7 @@
 @(title: String, user: Option[User] = None)(implicit lang: Lang)
 
 @main(title) {
-    @navbar(user)
+    @navbar(user, Some("/labelingGuide/noSidewalk"))
     <script type="text/javascript" src='@routes.Assets.at("javascripts/sidebarSubtopics.js")'></script>
     <link rel="stylesheet" href='@routes.Assets.at("stylesheets/help.css")'/>
     <link rel="stylesheet" href='@routes.Assets.at("stylesheets/labelingGuide.css")'/>

--- a/app/views/labelingGuideObstacles.scala.html
+++ b/app/views/labelingGuideObstacles.scala.html
@@ -2,7 +2,7 @@
 @(title: String, user: Option[User] = None)(implicit lang: Lang)
 
 @main(title) {
-    @navbar(user)
+    @navbar(user, Some("/labelingGuide/obstacles"))
     <script type="text/javascript" src='@routes.Assets.at("javascripts/sidebarSubtopics.js")'></script>
     <link rel="stylesheet" href='@routes.Assets.at("stylesheets/help.css")'/>
     <link rel="stylesheet" href='@routes.Assets.at("stylesheets/labelingGuide.css")'/>

--- a/app/views/labelingGuideOcclusion.scala.html
+++ b/app/views/labelingGuideOcclusion.scala.html
@@ -2,7 +2,7 @@
 @(title: String, user: Option[User] = None)(implicit lang: Lang)
 
 @main(title) {
-    @navbar(user)
+    @navbar(user, Some("/labelingGuide/occlusion"))
     <script type="text/javascript" src='@routes.Assets.at("javascripts/sidebarSubtopics.js")'></script>
     <link rel="stylesheet" href='@routes.Assets.at("stylesheets/help.css")'/>
     <link rel="stylesheet" href='@routes.Assets.at("stylesheets/labelingGuide.css")'/>

--- a/app/views/labelingGuideSurfaceProblems.scala.html
+++ b/app/views/labelingGuideSurfaceProblems.scala.html
@@ -2,7 +2,7 @@
 @(title: String, user: Option[User] = None)(implicit lang: Lang)
 
 @main(title) {
-    @navbar(user)
+    @navbar(user, Some("/labelingGuide/surfaceProblems"))
     <script type="text/javascript" src='@routes.Assets.at("javascripts/sidebarSubtopics.js")'></script>
     <link rel="stylesheet" href='@routes.Assets.at("stylesheets/help.css")'/>
     <link rel="stylesheet" href='@routes.Assets.at("stylesheets/labelingGuide.css")'/>

--- a/app/views/mapEdit.scala.html
+++ b/app/views/mapEdit.scala.html
@@ -2,7 +2,7 @@
 @(title: String, user: Option[User] = None)
 
 @main(title) {
-    @navbar(user)
+    @navbar(user, Some("/map/edit"))
     <div class="container">
         <div id="map-edit-holder">
             <div id="map">

--- a/app/views/navbar.scala.html
+++ b/app/views/navbar.scala.html
@@ -284,7 +284,8 @@ $(document).ready(function () {
                     <div id="incorrect-signup-alert"></div>
                     <div id="invalid-signup-alert"></div>
 
-                    @helper.form(action = routes.SignUpController.signUp(url.getOrElse("/")), args ='id -> "sign-up-form") {
+                    <!-- "action" tag replaced by use of onSubmit handler in JS (jquery $().submit(func)) -->
+                    <form action="javascript:void(0);" id="sign-up-form">
                     @text(forms.SignUpForm.form("username"), Messages("authenticate.username"), icon = "person")
                     @text(forms.SignUpForm.form("email"), Messages("authenticate.email"), icon = "at")
                     @password(forms.SignUpForm.form("password"), Messages("authenticate.password"), icon = "key")
@@ -297,7 +298,7 @@ $(document).ready(function () {
                             <button id="sign-up-submit" type="submit" value="submit" class="btn btn-primary btn-block" disabled>@Messages("authenticate.signup")</button>
                         </div>
                     </div>
-                }
+                    </form>
                 </div>
                 <div class="modal-footer">
                     <div>@Html(Messages("authenticate.has.account"))</div>
@@ -399,7 +400,7 @@ $(document).ready(function () {
                 }
             }
 
-            // Handles sign-in event and refresh the webpage.
+            // Handles sign-in event and refresh the webpage. Replaces use of the "action" HTML tag in the form.
             $('#sign-in-form').submit(function () {
                 var formData = $('#sign-in-form :input');
                 var email = formData[0].value;
@@ -433,6 +434,7 @@ $(document).ready(function () {
                 });
             });
 
+            // Handle sign up form submission. Replaces use of the "action" HTML tag in the form.
             $('#sign-up-form').submit(function () {
                 var formData = $('#sign-up-form :input');
                 var username = formData[0].value;
@@ -440,17 +442,15 @@ $(document).ready(function () {
                 var password = formData[2].value;
 		var passwordConfirm = formData[3].value;
 
+                // If not a valid username/email/password, do not submit form.
                 if(!username){
                     invalidSignInUpAlert(false, "@Messages("authenticate.error.missing.username")");
                     return false;
                 }
-
-                //if not a valid email address, do not submit form
                 if(!email){
                     invalidSignInUpAlert(false, "@Messages("authenticate.error.missing.email")");
                     return false;
                 }
-
                 if(!password){
                     invalidSignInUpAlert(false, "@Messages("authenticate.error.missing.password")");
                     return false;
@@ -468,7 +468,7 @@ $(document).ready(function () {
 
                 var data = $(this).serialize();
 
-                var url = '/authapi/signup';
+                var url = '/signUp';
                 $.post(url, data, handleSignIn).fail(function(e){
                     var errorMessage = "";
                     if(e.status === 409){

--- a/app/views/noAvailableMissionIndex.scala.html
+++ b/app/views/noAvailableMissionIndex.scala.html
@@ -2,7 +2,7 @@
 @(title: String, user: Option[User] = None, url: Option[String] = Some("/"))
 
 @main(title) {
-    @navbar(user)
+    @navbar(user, Some("/noAvailableMissionIndex"))
     <div id="content">
         <div class="container">
             <h2>You've already completed this HIT!</h2>

--- a/app/views/previousAudit.scala.html
+++ b/app/views/previousAudit.scala.html
@@ -2,7 +2,7 @@
 @(title: String, user: Option[User] = None)
 
 @main(title) {
-@navbar(user)
+@navbar(user, Some("/contribution/previousAudit"))
     <div class="container">
         <div class="row">
             <div class="col-lg-12">

--- a/app/views/results.scala.html
+++ b/app/views/results.scala.html
@@ -4,7 +4,7 @@
 @(title: String, user: Option[User] = None)(implicit lang: Lang)
 
 @main(title) {
-    @navbar(user)
+    @navbar(user, Some("/results"))
     <script src='@routes.Assets.at("assets/detectMobileBrowser.js")'></script>
 
     <!--

--- a/app/views/signUp.scala.html
+++ b/app/views/signUp.scala.html
@@ -12,7 +12,7 @@
     }
     <fieldset class="col-md-6 col-md-offset-3" style="margin-top:51px">
         <legend>@Messages("authenticate.signup.new.account")</legend>
-        @helper.form(action = routes.SignUpController.signUp(url)) {
+        @helper.form(action = routes.SignUpController.signUp(Some(url))) {
             @text(signInForm("username"), Messages("authenticate.username"), icon = "person")
             @text(signInForm("email"), Messages("authenticate.email"), icon = "at")
             @password(signInForm("password"), Messages("authenticate.password"), icon = "key")

--- a/app/views/terms.scala.html
+++ b/app/views/terms.scala.html
@@ -2,7 +2,7 @@
 @(title: String, user: Option[User] = None)(implicit lang: Lang)
 
 @main(title) {
-    @navbar(user)
+    @navbar(user, Some("/terms"))
     <div class="container">
         <div class="row">
             <div class="col-lg-12">

--- a/app/views/turkerIdExists.scala.html
+++ b/app/views/turkerIdExists.scala.html
@@ -2,7 +2,7 @@
 @(title: String, user: Option[User] = None, url: Option[String] = Some("/"))
 
 @main(title) {
-    @navbar(user)
+    @navbar(user, Some("/turkerIdExists"))
     <div id="content">
         <div class="container">
             <h2>This HIT cannot be started</h2>

--- a/app/views/userProfile.scala.html
+++ b/app/views/userProfile.scala.html
@@ -5,7 +5,7 @@
 @(title: String, user: Option[User] = None)(implicit lang: Lang)
 
 @main(title) {
-    @navbar(user)
+    @navbar(user, user.map(u=> "/contribution/" + u.username))
     <div class="container">
         <div class="row" id="maprow">
             <div class="col-lg-12" id="mapcolumn">

--- a/conf/routes
+++ b/conf/routes
@@ -34,10 +34,10 @@ GET     /forgotPassword                                      @controllers.UserCo
 GET     /resetPassword                                       @controllers.UserController.resetPassword(token: java.util.UUID)
 GET     /turkerSignUp/:hitId/:workerId/:assignmentId         @controllers.SignUpController.turkerSignUp(hitId: String, workerId: String, assignmentId: String)
 GET     /anonSignUp                                          @controllers.SignUpController.signUpAnon(url: String ?= "/")
-POST    /signUp                                              @controllers.SignUpController.signUp(url: String ?= "/")
+GET     /finishSignUp                                        @controllers.SignUpController.finishSignUp(url: Option[String])
+POST    /signUp                                              @controllers.SignUpController.signUp(url: Option[String])
 POST    /authenticate/credentials                            @controllers.CredentialsAuthController.authenticate(url: String ?= "/")
 POST    /authapi/authenticate                                @controllers.CredentialsAuthController.postAuthenticate
-POST    /authapi/signup                                      @controllers.SignUpController.postSignUp
 POST    /forgotPassword                                      @controllers.ForgotPasswordController.submit
 POST    /resetPassword                                       @controllers.ResetPasswordController.reset(token: java.util.UUID)
 


### PR DESCRIPTION
Partially fixes #2098 

The issue was that when a user signed up, the session cookie was not being updated to reflect that change. The authentication info would be saved on the server, the navbar would update with the new username, but the cookie was still using the old anon user account info. Then whenever data was sent to the server, it failed to authenticate that old anon user account info, and thus we were losing data.

This only started happening recently, because we used to save the old anon user authentication info in the database anyway under the same user_id. So the now signed up user would continue working, and the session cookie would say it was the anon user authentication info, but it would still be saved in the database under the correct user_id. Since @ThatOneGoat added the reset password functionality (#2057), we are now deleting the old authentication info, which made this problem come to light.

I've done a bit of a temporary fix here. Play doesn't seem to be letting me drop the old auth info and add the new one into the session cookie in one go, so I added a special redirect that it goes through so it can do the two steps and successfully authenticate. I think there might be a better way to do this that I'm looking into now. Also a bunch of sign up code needs some more cleanup. However, we have a mapathon tomorrow, so users need to be able to sign up!!