### PR TITLE
hotfix for #2120, mission progress bar should not be stuck at 0 now

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/mission/Mission.js
+++ b/public/javascripts/SVLabel/src/SVLabel/mission/Mission.js
@@ -117,6 +117,13 @@ function Mission(parameters) {
 
                 var missionDistance = svl.missionContainer.getCompletedMissionDistance();
                 currentMissionCompletedDistance = taskDistance - missionDistance + offset;
+                // Hotfix for an issue where the mission completion distance was negative. Need to find root cause.
+                // https://github.com/ProjectSidewalk/SidewalkWebpage/issues/2120
+                if (currentMissionCompletedDistance < 0) {
+                    svl.missionContainer.setTasksMissionsOffset(offset - currentMissionCompletedDistance);
+                    console.error(`Mission progress was set to ${currentMissionCompletedDistance}, resetting to 0.`);
+                    currentMissionCompletedDistance = 0;
+                }
             }
             setProperty("distanceProgress", currentMissionCompletedDistance);
         }

--- a/public/javascripts/SVLabel/src/SVLabel/mission/MissionFactory.js
+++ b/public/javascripts/SVLabel/src/SVLabel/mission/MissionFactory.js
@@ -27,8 +27,6 @@ function MissionFactory (missionModel) {
             parameters.distance = parameters.distance_meters;
         if (!parameters.hasOwnProperty("distanceProgress") && parameters.hasOwnProperty("distance_progress"))
             parameters.distanceProgress = parameters.distance_progress;
-        if (!parameters.hasOwnProperty("skipped") && parameters.hasOwnProperty("skipped"))
-            parameters.skipped = parameters.skipped;
 
         var mission = self.create(parameters.missionId, parameters.missionType, parameters.regionId,
             parameters.isComplete, parameters.pay, parameters.paid, parameters.distance, parameters.distanceProgress,


### PR DESCRIPTION
Partially fixes #2120 

We were running into an issue where the mission progress bar was being stuck at 0%. This was because the progress for your mission was somehow being set to a negative number, and the progress bar stayed at 0% while you crawled out of that hole.

This is a hotfix that just checks if the progress is negative when updating every step and sets it to 0 if so. If it is negative, it also logs an error to the console, which I will be keeping an eye on in the future. This should fix all symptoms of the problem. I just have not found the root cause of it, as it is hard to reproduce.