### PR TITLE
2062 show more detail in city coverage graph

### DIFF
--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -637,31 +637,56 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
 
             $.getJSON("/adminapi/completionRateByDate", function (data) {
                 var chart = {
-                    "height": 300,
-                    "width": 875,
-                    "mark": "area",
                     "data": {"values": data[0], "format": {"type": "json"}},
-                    "encoding": {
-                        "x": {
-                            "field": "date",
-                            "type": "temporal",
-                            "axis": {"title": "Date", "labelAngle": 0}
-                        },
-                        "y": {
-                            "field": "completion",
-                            "type": "quantitative", "scale": {
-                                "domain": [0,100]
-                            },
-                            "axis": {
-                                "title": "City Coverage (%)"
-                            }
-                        }
-                    },
                     "config": {
                         "axis": {
                             "titleFontSize": 16
                         }
-                    }
+                    },
+                    "vconcat": [
+                        {
+                            "height":300,
+                            "width": 875,
+                            "mark": "area",
+                            "encoding": {
+                                "x": {
+                                    "field": "date",
+                                    "type": "temporal",
+                                    "scale": {"domain": {"selection": "brush", "field": "date"}},
+                                    "axis": {"title": "Date", "labelAngle": 0}
+                                },
+                                "y": {
+                                    "field": "completion", 
+                                    "type": "quantitative", "scale": {
+                                        "domain": [0,100]
+                                    },
+                                    "axis": {"title": "City Coverage (%)"}
+                                }
+                            }
+                        },
+                        {
+                        "height": 60,
+                        "width": 875,
+                        "mark": "area",
+                        "selection": {"brush": {"type": "interval", "encodings": ["x"]}},
+                        "encoding": {
+                            "x": {
+                                "field": "date", 
+                                "type": "temporal",
+                                "axis": {"title": "Date", "labelAngle": 0}
+                            },
+                            "y": {
+                                "field": "completion",
+                                "type": "quantitative", "scale": {
+                                    "domain": [0,100]
+                                },
+                                "axis": {
+                                    "title": "City Coverage (%)",
+                                    "tickCount": 3, "grid": true}
+                            }
+                        }
+                        }
+                    ]
                 };
                 vega.embed("#completion-progress-chart", chart, opt, function(error, results) {});
             });


### PR DESCRIPTION
Resolves #2062 
Updated city coverage progress graph in admin analytics to shows more detail using vega selection brush.  Seen in attached picture. 
![citycoverageUpdate](https://user-images.githubusercontent.com/64165755/84704723-1af73400-af0f-11ea-9295-ecb98706b66a.png)


