### PR TITLE
#727 Cumulative Statistics on the Front Page Bleeds Over in Safari

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -405,7 +405,6 @@ video#bgvid {
     font-size: 45px;
     font-style: normal;
     font-variant: normal;
-    height: 500px;
     min-height:700px;
     line-height: 1.1em;
     color: #2D2A3F;


### PR DESCRIPTION
Resolves #727 

This PR solves a formatting issue on the Front Page. Specifically, it prevents the cumulative statistics from bleeding over in Safari.