### PR TITLE
#2085 Add dark polygon outline and gray overlay to neighborhoods

### DIFF
--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -97,9 +97,9 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
     function initializeNeighborhoodPolygons(map) {
         var neighborhoodPolygonStyle = {
                 color: '#888',
-                weight: 1,
-                opacity: 0.25,
-                fillColor: "#ccc",
+                weight: 2,
+                opacity: 0.80,
+                fillColor: "#808080",
                 fillOpacity: 0.1
             },
             layers = [],

--- a/public/javascripts/LabelMap.js
+++ b/public/javascripts/LabelMap.js
@@ -108,10 +108,10 @@ function LabelMap(_, $) {
      */
     function initializeNeighborhoodPolygons(map) {
         var neighborhoodPolygonStyle = {
-                color: 'red',
-                weight: 3,
-                opacity: 0.25,
-                fillColor: "#ccc",
+                color: '#888',
+                weight: 2,
+                opacity: 0.80,
+                fillColor: "#808080",
                 fillOpacity: 0.1
             },
             layers = [],

--- a/public/javascripts/LabelMap.js
+++ b/public/javascripts/LabelMap.js
@@ -108,8 +108,8 @@ function LabelMap(_, $) {
      */
     function initializeNeighborhoodPolygons(map) {
         var neighborhoodPolygonStyle = {
-                color: '#888',
-                weight: 1,
+                color: 'red',
+                weight: 3,
                 opacity: 0.25,
                 fillColor: "#ccc",
                 fillOpacity: 0.1

--- a/public/javascripts/Progress/src/Progress.js
+++ b/public/javascripts/Progress/src/Progress.js
@@ -7,10 +7,10 @@ function Progress (_, $, c3, L, role, difficultRegionIds) {
     var completedInitializingAuditedTasks = false;
 
     var neighborhoodPolygonStyle = {
-            color: 'red',
-            weight: 3,
-            opacity: 0.25,
-            fillColor: "#ccc",
+            color: '#888',
+            weight: 2,
+            opacity: 0.80,
+            fillColor: "#808080",
             fillOpacity: 0.1
         },
         layers = [],

--- a/public/javascripts/Progress/src/Progress.js
+++ b/public/javascripts/Progress/src/Progress.js
@@ -7,8 +7,8 @@ function Progress (_, $, c3, L, role, difficultRegionIds) {
     var completedInitializingAuditedTasks = false;
 
     var neighborhoodPolygonStyle = {
-            color: '#888',
-            weight: 1,
+            color: 'red',
+            weight: 3,
             opacity: 0.25,
             fillColor: "#ccc",
             fillOpacity: 0.1


### PR DESCRIPTION
Resolves #2085 

Adds dark polygon outline and gray overlay to neighborhoods on the label map and userdashboard map.  Feel free to test various colors, opacities, and border weights in the `Progress.js` and `LabelMap.js` files.

User Dashboard Before:
![BeforeUserDashboard](https://user-images.githubusercontent.com/32688680/86037304-04170e00-b9f4-11ea-9c93-26222594c7a1.jpg)
Label Map Before:
![BeforeLabelMap](https://user-images.githubusercontent.com/32688680/86037314-09745880-b9f4-11ea-852f-db54925183b1.jpg)
User Dashboard After:
![AfterUserDashboard](https://user-images.githubusercontent.com/32688680/86037336-12652a00-b9f4-11ea-99c8-5af472b944d2.jpg)
Label Map After:
![AfterLabelMap](https://user-images.githubusercontent.com/32688680/86037345-17c27480-b9f4-11ea-8b9e-57d1f93b6db5.jpg)