### PR TITLE
changes map locations to focus on one spgg neighborhood

### DIFF
--- a/conf/cityparams.conf
+++ b/conf/cityparams.conf
@@ -69,7 +69,7 @@ city-params {
     seattle-wa = 47.615
     columbus-oh = 40.000
     cdmx = 19.490
-    spgg = 25.648
+    spgg = 25.660
   }
   city-center-lng {
     newberg-or = -122.958
@@ -77,7 +77,7 @@ city-params {
     seattle-wa = -122.332
     columbus-oh = -83.002
     cdmx = -99.180
-    spgg = -100.370
+    spgg = -100.405
   }
   southwest-boundary-lat {
     newberg-or = 45.265
@@ -125,7 +125,7 @@ city-params {
     seattle-wa = 12.0
     columbus-oh = 12.75
     cdmx = 14.0
-    spgg = 13.0
+    spgg = 14.75
   }
   api-demos {
     attribute-center-lat {
@@ -134,7 +134,7 @@ city-params {
       seattle-wa = 47.619
       columbus-oh = 39.965
       cdmx = 19.490
-      spgg = 25.661
+      spgg = 25.660
     }
     attribute-center-lng {
       newberg-or = -122.975
@@ -142,7 +142,7 @@ city-params {
       seattle-wa = -122.300
       columbus-oh = -83.000
       cdmx = -99.180
-      spgg = -100.366
+      spgg = -100.409
     }
     attribute-zoom {
       newberg-or = 16.0
@@ -158,7 +158,7 @@ city-params {
       seattle-wa = 47.615
       columbus-oh = 39.962
       cdmx = 19.040
-      spgg = 25.657
+      spgg = 25.656
     }
     attribute-lng1 {
       newberg-or = -123.000
@@ -166,7 +166,7 @@ city-params {
       seattle-wa = -122.307
       columbus-oh = -82.995
       cdmx = -99.600
-      spgg = -100.370
+      spgg = -100.413
     }
     attribute-lat2 {
       newberg-or = 45.327
@@ -174,7 +174,7 @@ city-params {
       seattle-wa = 47.623
       columbus-oh = 39.968
       cdmx = 19.600
-      spgg = 25.665
+      spgg = 25.664
     }
     attribute-lng2 {
       newberg-or = -122.960
@@ -182,7 +182,7 @@ city-params {
       seattle-wa = -122.293
       columbus-oh = -83.004
       cdmx = -98.700
-      spgg = -100.362
+      spgg = -100.405
     }
     street-center-lat {
       newberg-or = 45.319
@@ -190,7 +190,7 @@ city-params {
       seattle-wa = 47.618
       columbus-oh = 39.960
       cdmx = 19.490
-      spgg = 25.661
+      spgg = 25.660
     }
     street-center-lng {
       newberg-or = -122.975
@@ -198,7 +198,7 @@ city-params {
       seattle-wa = -122.299
       columbus-oh = -82.992
       cdmx = -99.180
-      spgg = -100.366
+      spgg = -100.409
     }
     street-zoom {
       newberg-or = 14.0
@@ -214,7 +214,7 @@ city-params {
       seattle-wa = 47.611
       columbus-oh = 39.950
       cdmx = 19.040
-      spgg = 25.651
+      spgg = 25.650
     }
     street-lng1 {
       newberg-or = -123.000
@@ -222,7 +222,7 @@ city-params {
       seattle-wa = -122.309
       columbus-oh = -82.982
       cdmx = -99.600
-      spgg = -100.376
+      spgg = -100.419
     }
     street-lat2 {
       newberg-or = 45.327
@@ -230,7 +230,7 @@ city-params {
       seattle-wa = 47.625
       columbus-oh = 39.970
       cdmx = 19.600
-      spgg = 25.671
+      spgg = 25.670
     }
     street-lng2 {
       newberg-or = -122.960
@@ -238,7 +238,7 @@ city-params {
       seattle-wa = -122.289
       columbus-oh = -83.002
       cdmx = -98.700
-      spgg = -100.356
+      spgg = -100.399
     }
     region-center-lat {
       newberg-or = 45.319
@@ -246,7 +246,7 @@ city-params {
       seattle-wa = 47.616
       columbus-oh = 39.965
       cdmx = 19.490
-      spgg = 25.650
+      spgg = 25.660
     }
     region-center-lng {
       newberg-or = -122.975
@@ -254,7 +254,7 @@ city-params {
       seattle-wa = -122.296
       columbus-oh = -83.002
       cdmx = -99.180
-      spgg = -100.370
+      spgg = -100.409
     }
     region-zoom {
       newberg-or = 13.0
@@ -270,7 +270,7 @@ city-params {
       seattle-wa = 47.600
       columbus-oh = 39.950
       cdmx = 19.040
-      spgg = 25.630
+      spgg = 25.658
     }
     region-lng1 {
       newberg-or = -123.010
@@ -278,7 +278,7 @@ city-params {
       seattle-wa = -122.320
       columbus-oh = -82.980
       cdmx = -99.600
-      spgg = -100.400
+      spgg = -100.408
     }
     region-lat2 {
       newberg-or = 45.345
@@ -286,7 +286,7 @@ city-params {
       seattle-wa = 47.636
       columbus-oh = 40.000
       cdmx = 19.600
-      spgg = 25.675
+      spgg = 25.662
     }
     region-lng2 {
       newberg-or = -122.950
@@ -294,7 +294,7 @@ city-params {
       seattle-wa = -122.275
       columbus-oh = -83.050
       cdmx = -98.700
-      spgg = -100.340
+      spgg = -100.402
     }
   }
 }


### PR DESCRIPTION
Resolves #2147 

Changes the default pan/zoom on the maps for the SPGG server to focus on just the San Pedro neighborhood. This code change should be accompanied by first running the following queries on the relevant server before pushing code to it:

```
UPDATE region SET deleted = TRUE WHERE region_id <> 7;

UPDATE street_edge
SET deleted = TRUE
FROM street_edge_region
WHERE street_edge.street_edge_id = street_edge_region.street_edge_id
    AND region_id <> 7;

DELETE FROM street_edge_priority
USING street_edge
WHERE street_edge_priority.street_edge_id = street_edge.street_edge_id
    AND deleted = TRUE;

TRUNCATE TABLE region_completion;
```

This will make the necessary changes in the database. The code then adjusts the maps appropriately.