### PR TITLE
#1221 Made expand button hidden

### DIFF
--- a/public/javascripts/SVLabel/css/svl-map.css
+++ b/public/javascripts/SVLabel/css/svl-map.css
@@ -21,3 +21,7 @@
     z-index: 1;
 
 }
+
+.gm-style > button {
+    visibility: hidden;
+  }

--- a/public/javascripts/SVLabel/css/svl-map.css
+++ b/public/javascripts/SVLabel/css/svl-map.css
@@ -24,4 +24,8 @@
 
 .gm-style > button {
     visibility: hidden;
-  }
+}
+
+.gm-svpc {
+    visibility: hidden;
+}


### PR DESCRIPTION
Resolves #1221 

Uses the svl-map.css file to hide the expand button in the mini-map on the audit page. Example seen below:
![image](https://user-images.githubusercontent.com/64165755/87720584-02767580-c76a-11ea-9c42-681641a8c0ca.png)


![image](https://user-images.githubusercontent.com/64165755/87720629-14581880-c76a-11ea-9f36-22d0c4263c19.png)
