### PR TITLE
2191 readme now triages new city requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ coverage/
 .ivy2
 bower.json
 component.json
+db/*-dump
 
 ### IntelliJ (https://github.com/github/gitignore/blob/master/Global/JetBrains.gitignore)
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ To run the web server locally, from the root of the SidewalkWebpage directory:
 1. SSH into containers: To ssh into the containers, run `make ssh target=[web|db]`. Note that `[web|db]` is not a literal syntax, it specifies which container you would want to ssh into. For example, you can do `make ssh target=web`.
 
 ### Programming environment
-The IDE [IntelliJ IDEA](https://www.jetbrains.com/idea/) is highly recommended for development, particularly with Scala. You should be able to get a [student license](https://www.jetbrains.com/student/) to use get the "ultimate" edition of IntelliJ IDEA.
+The IDE [IntelliJ IDEA](https://www.jetbrains.com/idea/) is highly recommended for development, particularly with Scala. You should be able to get a [student license](https://www.jetbrains.com/student/) to use get the "ultimate" edition of IntelliJ IDEA. If using IntelliJ IDEA, we would recommend installing the [Play Routes](https://plugins.jetbrains.com/plugin/10053-play-routes/) and [i18n support](https://plugins.jetbrains.com/plugin/12981-i18n-support/) plugins.
 
 To look at and run queries on your database, you will want to install a database client. [Valentina Studio](https://www.valentina-db.com/en/valentina-studio-overview) is a good cross-platform database client. People also like using [Postico](https://eggerapps.at/postico/) for Mac or [PGAdmin](https://www.pgadmin.org/download/) on Windows/Mac.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Sidewalk Webpage
-The Project Sidewalk webpage. 
+Want a Project Sidewalk server set up for your city/municipality? We have had various discussions on Github about what we are looking for when choosing new cities to deploy in (geographic diversity, presence of local advocates, funding, etc.), which you can read through [here](https://github.com/ProjectSidewalk/SidewalkWebpage/issues/1379), [here](https://github.com/ProjectSidewalk/SidewalkWebpage/issues/1626), and [here](https://github.com/ProjectSidewalk/SidewalkWebpage/issues/281). If you would like to suggest that we deploy in your city/municipality, please email us at sidewalk@cs.uw.edu!
 
 ## Development Instructions
 


### PR DESCRIPTION
Resolves #2191 

Updates the README to tell people looking to deploy in their city to email us instead of just trying to set up the dev environment. I also added a few suggested plugins for IntelliJ IDEA to the README, and added the database dump files to the .gitignore.