### PR TITLE
Separates test and prod servers analytics IDs

### DIFF
--- a/app/controllers/ApplicationController.scala
+++ b/app/controllers/ApplicationController.scala
@@ -120,6 +120,7 @@ class ApplicationController @Inject() (implicit val env: Environment[User, Sessi
             if(qString.isEmpty){
               WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, "Visit_Index", timestamp))
               // Get city configs.
+              val envType: String = Play.configuration.getString("environment-type").get
               val cityStr: String = Play.configuration.getString("city-id").get
               val cityName: String = Play.configuration.getString("city-params.city-name." + cityStr).get
               val stateAbbreviation: String = Play.configuration.getString("city-params.state-abbreviation." + cityStr).get
@@ -131,7 +132,7 @@ class ApplicationController @Inject() (implicit val env: Environment[User, Sessi
               val otherCityUrls: List[(String, String)] = otherCities.map { otherCity =>
                 val otherName: String = Play.configuration.getString("city-params.city-name." + otherCity).get
                 val otherState: String = Play.configuration.getString("city-params.state-abbreviation." + otherCity).get
-                val otherURL: String = Play.configuration.getString("city-params.landing-page-url." + otherCity).get
+                val otherURL: String = Play.configuration.getString("city-params.landing-page-url." + envType + "." + otherCity).get
                 (otherName + ", " + otherState, otherURL)
               }
               // Get total audited distance. If using metric system, convert from miles to kilometers.

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -154,7 +154,7 @@
                     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
             })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-            var analyticsStr = "@{Play.configuration.getString("city-params.google-analytics-id." + Play.configuration.getString("city-id").get)}";
+            var analyticsStr = "@{Play.configuration.getString("city-params.google-analytics-id." + Play.configuration.getString("environment-type").get + "." + Play.configuration.getString("city-id").get)}";
             ga('create', analyticsStr, 'auto');
             ga('send', 'pageview');
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -107,6 +107,8 @@ play {
 
 geotrellis.catalog = "app/assets/catalog.json"
 
+environment-type = ${?ENV_TYPE}
+
 smtp.host="smtp.gmail.com"
 smtp.port=465
 smtp.ssl=true

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -107,6 +107,8 @@ play {
 
 geotrellis.catalog = "app/assets/catalog.json"
 
+# Environment type: test or prod.
+environment-type = "test"
 environment-type = ${?ENV_TYPE}
 
 smtp.host="smtp.gmail.com"

--- a/conf/cityparams.conf
+++ b/conf/cityparams.conf
@@ -62,13 +62,24 @@ city-params {
     columbus-oh = "https://opencolumbus.page.link/mapping"
   }
   google-analytics-id {
-    newberg-or = "UA-136713858-1"
-    washington-dc = "UA-76528208-1"
-    seattle-wa = "UA-136685580-1"
-    columbus-oh = "UA-151353296-1"
-    cdmx = "UA-153189107-1"
-    spgg = "UA-167201803-1"
-    pittsburgh-pa = "UA-173904238-1"
+    prod {
+      newberg-or = "UA-136713858-1"
+      washington-dc = "UA-76528208-1"
+      seattle-wa = "UA-136685580-1"
+      columbus-oh = "UA-151353296-1"
+      cdmx = "UA-153189107-1"
+      spgg = "UA-167201803-1"
+      pittsburgh-pa = "UA-173904238-1"
+    }
+    test {
+      newberg-or = "UA-136713858-2"
+      washington-dc = "UA-76528208-3"
+      seattle-wa = "UA-136685580-2"
+      columbus-oh = "UA-151353296-2"
+      cdmx = "UA-153189107-2"
+      spgg = "UA-167201803-2"
+      pittsburgh-pa = "UA-173904238-2"
+    }
   }
   city-center-lat {
     newberg-or = 45.308

--- a/conf/cityparams.conf
+++ b/conf/cityparams.conf
@@ -50,13 +50,24 @@ city-params {
 
   }
   landing-page-url {
-    newberg-or = "https://sidewalk-newberg.cs.washington.edu"
-    washington-dc = "https://sidewalk-dc.cs.washington.edu"
-    seattle-wa = "https://sidewalk-sea.cs.washington.edu"
-    columbus-oh = "https://sidewalk-columbus.cs.washington.edu"
-    cdmx = "https://sidewalk-cdmx.cs.washington.edu"
-    spgg = "https://sidewalk-spgg.cs.washington.edu"
-    pittsburgh-pa = "https://sidewalk-pittsburgh.cs.washington.edu"
+    prod {
+      newberg-or = "https://sidewalk-newberg.cs.washington.edu"
+      washington-dc = "https://sidewalk-dc.cs.washington.edu"
+      seattle-wa = "https://sidewalk-sea.cs.washington.edu"
+      columbus-oh = "https://sidewalk-columbus.cs.washington.edu"
+      cdmx = "https://sidewalk-cdmx.cs.washington.edu"
+      spgg = "https://sidewalk-spgg.cs.washington.edu"
+      pittsburgh-pa = "https://sidewalk-pittsburgh.cs.washington.edu"
+    }
+    test {
+      newberg-or = "https://sidewalk-newberg-test.cs.washington.edu"
+      washington-dc = "https://sidewalk-dc-test.cs.washington.edu"
+      seattle-wa = "https://sidewalk-sea-test.cs.washington.edu"
+      columbus-oh = "https://sidewalk-columbus-test.cs.washington.edu"
+      cdmx = "https://sidewalk-cdmx-test.cs.washington.edu"
+      spgg = "https://sidewalk-spgg-test.cs.washington.edu"
+      pittsburgh-pa = "https://sidewalk-pittsburgh-test.cs.washington.edu"
+    }
   }
   mapathon-event-link {
     columbus-oh = "https://opencolumbus.page.link/mapping"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       - SIDEWALK_CITY_ID=washington-dc
       - SIDEWALK_EMAIL_ADDRESS=DUMMY_EMAIL_ADDRESS
       - SIDEWALK_EMAIL_PASSWORD=DUMMY_EMAIL_PASSWORD
+      - ENV_TYPE=test
 
   db:
     image: projectsidewalk/db


### PR DESCRIPTION
Resolves #2113 

Since @mechanicjay recently added an ENV_TYPE environment variable to our servers with values "test" and "prod", I am now able to make a few changes in the code to differentiate those servers further. The changes made here are:
1. The test servers now have their own Google Analytics IDs. Each city had their own before, but now each city will have two, one for test and one for prod.
1. The links to other cities on the landing page now point to servers of the same type. So test servers now link to other test servers
1. I've added `ENV_TYPE=test` to the docker-compose.yml for the dev environment, so now our local dev environments should be using the test server analytics IDs and link to test servers on the landing pages.