### PR TITLE
Fixes warning from multiple HTML elements with the same ID

### DIFF
--- a/app/forms/ForgotPasswordForm.scala
+++ b/app/forms/ForgotPasswordForm.scala
@@ -12,6 +12,6 @@ object ForgotPasswordForm {
    * A play framework form.
    */
   val form = Form(
-    "email" -> email
+    "emailForgotPassword" -> email
   )
 }

--- a/app/forms/ResetPasswordForm.scala
+++ b/app/forms/ResetPasswordForm.scala
@@ -13,8 +13,8 @@ object ResetPasswordForm {
    */
   val form = Form(
     mapping(
-      "password" -> nonEmptyText,
-      "passwordConfirm" -> nonEmptyText
+      "passwordReset" -> nonEmptyText,
+      "passwordResetConfirm" -> nonEmptyText
     )(PasswordData.apply)(PasswordData.unapply)
   )
 

--- a/app/forms/SignInForm.scala
+++ b/app/forms/SignInForm.scala
@@ -8,7 +8,7 @@ object SignInForm {
   val form = Form(
     mapping(
       "identifier" -> email,
-      "password" -> nonEmptyText
+      "passwordSignIn" -> nonEmptyText
     )(Credentials.apply)(Credentials.unapply)
   )
 }

--- a/app/views/forgotPassword.scala.html
+++ b/app/views/forgotPassword.scala.html
@@ -23,7 +23,7 @@
         <legend>@Messages("reset.pw.forgot.title")</legend>
         @helper.form(action = routes.ForgotPasswordController.submit()) {
             <p class="info">@Messages("reset.pw.forgot.submit.email")</p>
-            @text(forgotPasswordForm("email"), Messages("authenticate.email"), icon = "at")
+            @text(forgotPasswordForm("emailForgotPassword"), Messages("authenticate.email"), icon = "at")
             <div class="form-group">
                 <div>
                     <button id="submit" type="submit" value="submit" class="btn btn-lg btn-primary btn-block">@Messages("reset.pw.email.send.link")</button>

--- a/app/views/navbar.scala.html
+++ b/app/views/navbar.scala.html
@@ -262,7 +262,7 @@ $(document).ready(function () {
 
                     @helper.form(action = routes.CredentialsAuthController.authenticate(url.getOrElse("/")), args = 'id -> "sign-in-form") {
                         @text(forms.SignInForm.form("identifier"), Messages("authenticate.email"))
-                        @password(forms.SignInForm.form("password"), Messages("authenticate.password"))
+                        @password(forms.SignInForm.form("passwordSignIn"), Messages("authenticate.password"))
                         <button id="sign-in-submit" type="submit" value="submit" class="btn btn-sm btn-primary btn-block">@Messages("navbar.signin")</button>
                     }
                 </div>
@@ -321,6 +321,12 @@ $(document).ready(function () {
                     // -or-, see below
                     // $(this).closest("." + $(this).attr("data-hide")).hide();
                 });
+
+                // If on the sign in or sign up pages, remove the sign in button from the navbar.
+                if (location.pathname === '/signIn' || location.pathname === '/signUp') {
+                    $('#sign-in-modal-container').remove();
+                    $('#navbar-dropdown-list').remove();
+                }
             });
 
             // Callback function for checking sign-in results

--- a/app/views/resetPassword.scala.html
+++ b/app/views/resetPassword.scala.html
@@ -14,8 +14,8 @@
         <legend>@Messages("reset.pw.message")</legend>
         @helper.form(action = routes.ResetPasswordController.reset(token), 'autocomplete -> "off") {
             <p class="info">@Messages("reset.pw.submit.new.pw")</p>
-            @password(resetPasswordForm("password"), Messages("authenticate.password"), icon = "key")
-            @password(resetPasswordForm("passwordConfirm"), Messages("authenticate.confirm.password"), icon = "key")
+            @password(resetPasswordForm("passwordReset"), Messages("authenticate.password"), icon = "key")
+            @password(resetPasswordForm("passwordResetConfirm"), Messages("authenticate.confirm.password"), icon = "key")
             <div class="form-group">
                 <div>
                     <button id="submit" type="submit" value="submit" class="btn btn-lg btn-primary btn-block">@Messages("reset.pw.message")</button>

--- a/app/views/signIn.scala.html
+++ b/app/views/signIn.scala.html
@@ -33,7 +33,7 @@
         <legend>@Messages("authenticate.signin.with.credentials")</legend>
         @helper.form(action = routes.CredentialsAuthController.authenticate(url)) {
         @text(signInForm("identifier"), Messages("authenticate.email"), icon = "at")
-        @password(signInForm("password"), Messages("authenticate.password"), icon = "key")
+        @password(signInForm("passwordSignIn"), Messages("authenticate.password"), icon = "key")
         <div class="form-group">
             <div>
                 <button id="submit" type="submit" value="submit" class="btn btn-lg btn-primary btn-block">@Messages("authenticate.submit")</button>


### PR DESCRIPTION
Fixes #2040 

Fixes the warnings about multiple HTML elements having the ID. The issue was that all of our various sign in/up methods used identical IDs. So the password field had the ID "password" on the sign in page, sign up page, in the navbar sign in, navbar sign up, and on the password reset page. Multiple of these fields could be present at the same time. For example, at /signIn, there was the password field in the main form on the page, plus the password fields in the sign and and sign up forms within the navbar.

This PR fixes this issue by changing the names of a few elements to make them unique and removing the sign in button from the navbar on /signIn and /signUp.