### PR TITLE
#2182 in Spanish Version, visual bug with tags

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
@@ -414,34 +414,6 @@ function ContextMenu (uiContextMenu) {
     }
 
     /**
-     * Sets the color of a label's tags based off of tags that were previously chosen.
-     * @param label     Current label being modified.
-     */
-    function setTagColor(label) {
-        var labelTags = label.getProperty('tagIds');
-        $("body").find("button[name=tag]").each(function(t) {
-            var buttonText = $(this).text();
-            if (buttonText) {
-                var tagId = undefined;
-
-                // Finds the tag id based of the current button based off text description.
-                self.labelTags.forEach(function (tag) {
-                    if (tag.tag === buttonText) {
-                        tagId = tag.tag_id;
-                    }
-                });
-
-                // Sets color to be white or gray if the label tag has been selected.
-                if (labelTags.includes(tagId)) {
-                    $(this).css('background-color', 'rgb(200, 200, 200)');
-                } else {
-                    $(this).css('background-color', 'white');
-                }
-            }
-        });
-    }
-
-    /**
      * Sets the description and value of the tag based on the label type.
      * @param label     Current label being modified.
      */
@@ -505,7 +477,6 @@ function ContextMenu (uiContextMenu) {
             if (acceptedLabelTypes.indexOf(labelType) != -1) {
                 setStatus('targetLabel', param.targetLabel);
                 setTags(param.targetLabel);
-                setTagColor(param.targetLabel);
                 if (getStatus('disableTagging')) { disableTagging(); }
                 windowHeight = $('#context-menu-holder').outerHeight();
 

--- a/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
@@ -420,7 +420,7 @@ function ContextMenu (uiContextMenu) {
     function setTagColor(label) {
         var labelTags = label.getProperty('tagIds');
         $("body").find("button[name=tag]").each(function(t) {
-        var buttonText = $(this).text();
+            var buttonText = $(this).text();
             if (buttonText) {
                 var tagId = parseInt($(this).attr('class').split(" ").filter(c => c.search(/tag-id-\d+/) > -1)[0].match(/\d+/)[0], 10);
 

--- a/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
@@ -414,6 +414,27 @@ function ContextMenu (uiContextMenu) {
     }
 
     /**
+     * Sets the color of a label's tags based off of tags that were previously chosen.
+     * @param label     Current label being modified.
+     */
+    function setTagColor(label) {
+        var labelTags = label.getProperty('tagIds');
+        $("body").find("button[name=tag]").each(function(t) {
+        var buttonText = $(this).text();
+            if (buttonText) {
+                var tagId = parseInt($(this).attr('class').split(" ").filter(c => c.search(/tag-id-\d+/) > -1)[0].match(/\d+/)[0], 10);
+
+                // Sets color to be white or gray if the label tag has been selected.
+                if (labelTags.includes(tagId)) {
+                    $(this).css('background-color', 'rgb(200, 200, 200)');
+                } else {
+                    $(this).css('background-color', 'white');
+                }
+            }
+        });
+    }
+
+    /**
      * Sets the description and value of the tag based on the label type.
      * @param label     Current label being modified.
      */
@@ -477,6 +498,7 @@ function ContextMenu (uiContextMenu) {
             if (acceptedLabelTypes.indexOf(labelType) != -1) {
                 setStatus('targetLabel', param.targetLabel);
                 setTags(param.targetLabel);
+                setTagColor(param.targetLabel);
                 if (getStatus('disableTagging')) { disableTagging(); }
                 windowHeight = $('#context-menu-holder').outerHeight();
 


### PR DESCRIPTION
Resolves #2182: in the Spanish version, when a user clicked on a tag for a label, exited the context menu, and opened it again, the tag showed as not clicked (even though in the data, the tag was added).

Now, all the tags show up!
![Screenshot from 2020-08-09 23-24-38](https://user-images.githubusercontent.com/35845622/89757896-6820fd80-da9b-11ea-92a8-583387e0578a.png)
The issue was that, in the setTagColor function, the tag was being accessed through cross-checking the button tag's text with the defined tags' names. For example, the button tag would have the text of "estrecha," and the defined tags have names "narrow," "points into traffic," etc. Since the button tag text is in Spanish and the defined tags are in English, the tag could never be accessed.

Plus, this pull request fixes a smaller version of this bug that's also present in the English version! Since both the "Obstacle in Path" and "Surface Problem" labels have a tag called "construction," the Obstacle's construction tag had the same visual bug.
![Screenshot from 2020-08-09 23-55-29](https://user-images.githubusercontent.com/35845622/89758090-d4036600-da9b-11ea-8a7c-71cb7420e958.png)
But the changes in this pull request fix that, too.
