### PR TITLE
1094 Fixed Rounding for remaning neighborhood distance

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
@@ -332,6 +332,9 @@ ModalMissionComplete.prototype.setMissionTitle = function (missionTitle) {
 
 ModalMissionComplete.prototype._updateMissionProgressStatistics = function (missionDistance, missionReward, userTotalDistance, othersAuditedDistance, remainingDistance) {
     var distanceType = i18next.t('mission-complete.distance-type-display-string');
+    if(remainingDistance > 0.00 && remainingDistance <= 0.10){
+        remainingDistance = 0.1
+    }
     var positiveRemainingDistance = Math.max(remainingDistance, 0);
     var positiveOthersAuditedDistance = Math.max(othersAuditedDistance, 0);
     this._uiModalMissionComplete.missionDistance.html(missionDistance.toFixed(1) + " " + distanceType);


### PR DESCRIPTION
Resolves #1094 

When nearing the completion of a neighborhood, occasionally the value would round itself to 0.00 when really there was still a mission or two to complete (seen in #1094 ). Now, adjusted the rounding to ensure that remaining distance will never show 0 when there is still some distance to go.