### PR TITLE
#2197 Some admin dashboard visualizations are not loading

### DIFF
--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -1149,6 +1149,7 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
                 var turkerChart = getVegaLiteHistogram(turkerData, turkerStats.mean, turkerStats.median, turkerHistOpts);
                 var anonChart = getVegaLiteHistogram(anonData, anonStats.mean, anonStats.median, anonHistOpts);
 
+                // Only includes charts with data as charts with no data prevent all charts from rendering.
                 var combinedChart = {"hconcat": []};
                 var combinedChartFiltered = {"hconcat": []};
                 
@@ -1231,6 +1232,7 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
                 var turkerChart = getVegaLiteHistogram(turkerData, turkerStats.mean, turkerStats.median, turkerHistOpts);
                 var anonChart = getVegaLiteHistogram(anonData, anonStats.mean, anonStats.median, anonHistOpts);
 
+                // Only includes charts with data as charts with no data prevent all charts from rendering.
                 var combinedChart = {"hconcat": []};
                 var combinedChartFiltered = {"hconcat": []};
 
@@ -1313,6 +1315,7 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
                 var turkerChart = getVegaLiteHistogram(turkerData, turkerStats.mean, turkerStats.median, turkerHistOpts);
                 var anonChart = getVegaLiteHistogram(anonData, anonStats.mean, anonStats.median, anonHistOpts);
 
+                // Only includes charts with data as charts with no data prevent all charts from rendering.
                 var combinedChart = {"hconcat": []};
                 var combinedChartFiltered = {"hconcat": []};
 

--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -540,7 +540,7 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
         std /= filteredData.length;
         std = Math.sqrt(std);
 
-        return {mean:mean, median:median, std:std, min:min, max};
+        return {mean:mean, median:median, std:std, min:min, max:max};
     }
 
     // takes in some data, summary stats, and optional arguments, and outputs the spec for a vega-lite chart
@@ -1112,6 +1112,11 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
                 var turkerStats = getSummaryStats(turkerData, "count");
                 var anonStats = getSummaryStats(anonData, "count");
 
+                $("#missions-std").html((allFilteredStats.std).toFixed(2) + " Missions");
+                $("#reg-missions-std").html((regFilteredStats.std).toFixed(2) + " Missions");
+                $("#turker-missions-std").html((turkerStats.std).toFixed(2) + " Missions");
+                $("#anon-missions-std").html((anonStats.std).toFixed(2) + " Missions");
+
                 var allHistOpts = {
                     xAxisTitle: "# Missions per User (all)", xDomain: [0, allStats.max], width: 187,
                     binStep: 15, legendOffset: -80
@@ -1144,13 +1149,20 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
                 var turkerChart = getVegaLiteHistogram(turkerData, turkerStats.mean, turkerStats.median, turkerHistOpts);
                 var anonChart = getVegaLiteHistogram(anonData, anonStats.mean, anonStats.median, anonHistOpts);
 
-                $("#missions-std").html((allFilteredStats.std).toFixed(2) + " Missions");
-                $("#reg-missions-std").html((regFilteredStats.std).toFixed(2) + " Missions");
-                $("#turker-missions-std").html((turkerStats.std).toFixed(2) + " Missions");
-                $("#anon-missions-std").html((anonStats.std).toFixed(2) + " Missions");
-
-                var combinedChart = {"hconcat": [allChart, turkerChart, regChart, anonChart]};
-                var combinedChartFiltered = {"hconcat": [allFilteredChart, turkerChart, regFilteredChart, anonChart]};
+                var combinedChart = {"hconcat": []};
+                var combinedChartFiltered = {"hconcat": []};
+                
+                [allChart, regChart, turkerChart, anonChart].forEach(element => {
+                    if (element.data.values.length > 0) {
+                        combinedChart.hconcat.push(element);
+                    }
+                });
+                
+                [allFilteredChart, regFilteredChart, turkerChart, anonChart].forEach(element => {
+                    if (element.data.values.length > 0) {
+                        combinedChartFiltered.hconcat.push(element);
+                    }
+                });
 
                 vega.embed("#mission-count-chart", combinedChartFiltered, opt, function (error, results) {
                 });
@@ -1181,6 +1193,11 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
                 var regFilteredStats = getSummaryStats(regData, "count", {excludeResearchers: true});
                 var turkerStats = getSummaryStats(turkerData, "count");
                 var anonStats = getSummaryStats(anonData, "count");
+
+                $("#all-labels-std").html((allFilteredStats.std).toFixed(2) + " Labels");
+                $("#reg-labels-std").html((regFilteredStats.std).toFixed(2) + " Labels");
+                $("#turker-labels-std").html((turkerStats.std).toFixed(2) + " Labels");
+                $("#anon-labels-std").html((anonStats.std).toFixed(2) + " Labels");
 
                 var allHistOpts = {
                     xAxisTitle: "# Labels per User (all)", xDomain: [0, allStats.max], width: 187,
@@ -1214,13 +1231,20 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
                 var turkerChart = getVegaLiteHistogram(turkerData, turkerStats.mean, turkerStats.median, turkerHistOpts);
                 var anonChart = getVegaLiteHistogram(anonData, anonStats.mean, anonStats.median, anonHistOpts);
 
-                $("#all-labels-std").html((allFilteredStats.std).toFixed(2) + " Labels");
-                $("#reg-labels-std").html((regFilteredStats.std).toFixed(2) + " Labels");
-                $("#turker-labels-std").html((turkerStats.std).toFixed(2) + " Labels");
-                $("#anon-labels-std").html((anonStats.std).toFixed(2) + " Labels");
+                var combinedChart = {"hconcat": []};
+                var combinedChartFiltered = {"hconcat": []};
 
-                var combinedChart = {"hconcat": [allChart, turkerChart, regChart, anonChart]};
-                var combinedChartFiltered = {"hconcat": [allFilteredChart, turkerChart, regFilteredChart, anonChart]};
+                [allChart, regChart, turkerChart, anonChart].forEach(element => {
+                    if (element.data.values.length > 0) {
+                        combinedChart.hconcat.push(element);
+                    }
+                });
+                
+                [allFilteredChart, regFilteredChart, turkerChart, anonChart].forEach(element => {
+                    if (element.data.values.length > 0) {
+                        combinedChartFiltered.hconcat.push(element);
+                    }
+                });
 
                 vega.embed("#label-count-hist", combinedChartFiltered, opt, function (error, results) {
                 });
@@ -1251,6 +1275,11 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
                 var regFilteredStats = getSummaryStats(regData, "count", {excludeResearchers: true});
                 var turkerStats = getSummaryStats(turkerData, "count");
                 var anonStats = getSummaryStats(anonData, "count");
+
+                $("#all-validation-std").html((allFilteredStats.std).toFixed(2) + " Validations");
+                $("#reg-validation-std").html((regFilteredStats.std).toFixed(2) + " Validations");
+                $("#turker-validation-std").html((turkerStats.std).toFixed(2) + " Validations");
+                $("#anon-validation-std").html((anonStats.std).toFixed(2) + " Validations");
 
                 var allHistOpts = {
                     xAxisTitle: "# Validations per User (all)", xDomain: [0, allStats.max], width: 187,
@@ -1284,13 +1313,20 @@ function Admin(_, $, c3, turf, difficultRegionIds) {
                 var turkerChart = getVegaLiteHistogram(turkerData, turkerStats.mean, turkerStats.median, turkerHistOpts);
                 var anonChart = getVegaLiteHistogram(anonData, anonStats.mean, anonStats.median, anonHistOpts);
 
-                $("#all-validation-std").html((allFilteredStats.std).toFixed(2) + " Validations");
-                $("#reg-validation-std").html((regFilteredStats.std).toFixed(2) + " Validations");
-                $("#turker-validation-std").html((turkerStats.std).toFixed(2) + " Validations");
-                $("#anon-validation-std").html((anonStats.std).toFixed(2) + " Validations");
+                var combinedChart = {"hconcat": []};
+                var combinedChartFiltered = {"hconcat": []};
 
-                var combinedChart = {"hconcat": [allChart, turkerChart, regChart, anonChart]};
-                var combinedChartFiltered = {"hconcat": [allFilteredChart, turkerChart, regFilteredChart, anonChart]};
+                [allChart, regChart, turkerChart, anonChart].forEach(element => {
+                    if (element.data.values.length > 0) {
+                        combinedChart.hconcat.push(element);
+                    }
+                });
+                
+                [allFilteredChart, regFilteredChart, turkerChart, anonChart].forEach(element => {
+                    if (element.data.values.length > 0) {
+                        combinedChartFiltered.hconcat.push(element);
+                    }
+                });
 
                 vega.embed("#validation-count-hist", combinedChartFiltered, opt, function (error, results) {
                 });


### PR DESCRIPTION
Resolves #2197 

This PR fixes a bug on the analytics page of the admin dashboard where some charts were not showing up. Specifically, it ensures that when a group of charts are rendered together, only charts with data are included, as those without data (for some reason) prevent all charts from rendering.

Before:
![image](https://user-images.githubusercontent.com/43970567/91377017-4cc02d00-e7d3-11ea-9648-d8b42c593628.png)

After:
<img width="625" alt="Screen Shot 2020-08-26 at 7 36 09 PM" src="https://user-images.githubusercontent.com/43970567/91377078-6e211900-e7d3-11ea-988a-7f6b2494fa25.png">
<img width="701" alt="Screen Shot 2020-08-26 at 7 27 07 PM" src="https://user-images.githubusercontent.com/43970567/91377032-50ec4a80-e7d3-11ea-946e-7f09fb55c225.png">
