### PR TITLE
Expand SPGG into Del Valle neighborhood

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ To run the web server locally, from the root of the SidewalkWebpage directory:
 1. SSH into containers: To ssh into the containers, run `make ssh target=[web|db]`. Note that `[web|db]` is not a literal syntax, it specifies which container you would want to ssh into. For example, you can do `make ssh target=web`.
 
 ### Programming environment
-The IDE [IntelliJ IDEA](https://www.jetbrains.com/idea/) is highly recommended for development, particularly with Scala. You should be able to get a [student license](https://www.jetbrains.com/student/) to use get the "ultimate" edition of IntelliJ IDEA. If using IntelliJ IDEA, we would recommend installing the [Play Routes](https://plugins.jetbrains.com/plugin/10053-play-routes/) and [i18n support](https://plugins.jetbrains.com/plugin/12981-i18n-support/) plugins.
+The IDE [IntelliJ IDEA](https://www.jetbrains.com/idea/) is highly recommended for development, particularly with Scala. You should be able to get a [student license](https://www.jetbrains.com/student/) to get the "ultimate" edition of IntelliJ IDEA. If using IntelliJ IDEA, we would recommend installing the [Play Routes](https://plugins.jetbrains.com/plugin/10053-play-routes/), [i18n support](https://plugins.jetbrains.com/plugin/12981-i18n-support/), and [HOCON](https://plugins.jetbrains.com/plugin/10481-hocon) plugins.
 
 To look at and run queries on your database, you will want to install a database client. [Valentina Studio](https://www.valentina-db.com/en/valentina-studio-overview) is a good cross-platform database client. People also like using [Postico](https://eggerapps.at/postico/) for Mac or [PGAdmin](https://www.pgadmin.org/download/) on Windows/Mac.
 

--- a/conf/cityparams.conf
+++ b/conf/cityparams.conf
@@ -107,7 +107,7 @@ city-params {
     seattle-wa = -122.332
     columbus-oh = -83.002
     cdmx = -99.180
-    spgg = -100.405
+    spgg = -100.385
     pittsburgh-pa = -79.950
   }
   southwest-boundary-lat {
@@ -161,7 +161,7 @@ city-params {
     seattle-wa = 12.0
     columbus-oh = 12.75
     cdmx = 14.0
-    spgg = 14.75
+    spgg = 14.5
     pittsburgh-pa = 13.5
   }
   api-demos {


### PR DESCRIPTION
Resolves #2232 

Adjusts the default lat/lng and zoom for maps on the website so that the Del Valle neighborhood of SPGG is also in view. I've already added the neighborhood through the database, this will just update the maps accordingly.