### PR TITLE
fixes bug where terms and conditions does not show

### DIFF
--- a/conf/messages.en
+++ b/conf/messages.en
@@ -185,7 +185,7 @@ authenticate.new = Are you new? <a href="#" id="form-open-sign-up">Sign up!</a>
 authenticate.non.member = Not a member? <a href="/signUp">Sign up now</a>
 authenticate.username = Username
 authenticate.confirm.password = Confirm password
-authenticate.terms = You agree to our <a target="_blank" href="@routes.ApplicationController.terms">Terms of Use and Privacy Policy</a>
+authenticate.terms = You agree to our <a target="_blank" href="/terms">Terms of Use and Privacy Policy</a>
 authenticate.signup = Sign up
 authenticate.signup.new.account = Sign up for a new account
 authenticate.has.account = Have an account? <a href="#" id="form-open-sign-in">Sign in</a>

--- a/conf/messages.es
+++ b/conf/messages.es
@@ -184,7 +184,7 @@ authenticate.new = ¿Eres nuevo/a? <a href="#" id="form-open-sign-up">¡Regístr
 authenticate.non.member = ¿No eres un miembro? <a href="/signUp">Regístrate ahora</a>
 authenticate.username = Nombre de usuario/a
 authenticate.confirm.password = Confirmar contraseña
-authenticate.terms = Usted acepta nuestros <a target="_blank" href="@routes.ApplicationController.terms">Términos de uso y Política de privacidad</a>
+authenticate.terms = Usted acepta nuestros <a target="_blank" href="/terms">Términos de uso y Política de privacidad</a>
 authenticate.signup = Regístrate
 authenticate.signup.new.account = Regístrate para una nueva cuenta
 authenticate.has.account = ¿Tienes una cuenta? <a href="#" id="form-open-sign-in">Iniciar sesión</a>


### PR DESCRIPTION
Fixes #2226 

Fixes the bug where clicking on "Terms and Conditions" brought you an error message instead of our terms/conditions.