### PR TITLE
Partially addresses Issue #2227: clicking on city name on landing page brings you to landing page of other city (rather than /audit)

### DIFF
--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -34,7 +34,8 @@
                     <span class="header-text">@Messages("landing.also.in")</span>
                     @for((cityName, cityURL) <- otherCityURLs) {
                         <!-- Replacing a space with a nbsp in order to make sure wrapping works as intended. -->
-                        <a id="@cityName" class="otherCityLink" href="@{cityURL + "/audit"}">@cityName.replace(" ", " ")</a> &nbsp;
+                        <!-- JEF: per Issue #2227, changing link to just be cityURL rather than cityURL + "/audit" -->
+                        <a id="@cityName" class="otherCityLink" href="@{cityURL}">@cityName.replace(" ", " ")</a> &nbsp;
                     }
                     <br>
                     @if(mapathonLink.isDefined) {


### PR DESCRIPTION
Partially addresses https://github.com/ProjectSidewalk/SidewalkWebpage/issues/2227.

Changes the default url for city names to just the city server rather than the /audit page of the city server.

Note: I didn't change the header text (so it still just says "Let's create a path for everyone" rather than "<city name>, let's create a path for everyone" as described in Issue #2227)