### PR TITLE
Addresses #2247 (removes embedded video from landing page)

### DIFF
--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -150,16 +150,17 @@
     </div>-->
     </div>
 
-    <div class="container" id="vidembed">
-        <img src="@routes.Assets.at("assets/vidembed.jpg")" style="width: 100%;" onclick="playVideo();">
-        <div id="videooverlay">
-            <div id="videotext">
-                <span>@Messages("landing.video.title")</span>
-                <br><span id="playlink">&#9654;&nbsp;&nbsp;&nbsp;<span style="text-decoration: underline;
-                cursor: pointer;" onclick="playVideo()">@Messages("landing.video.watch")</span></span>
-            </div>
-        </div>
-    </div>
+@*    <!-- JEF: commenting out the embedded video given Issue 2247. Just commenting out for now. Can remove later. -->*@
+@*    <div class="container" id="vidembed">*@
+@*        <img src="@routes.Assets.at("assets/vidembed.jpg")" style="width: 100%;" onclick="playVideo();">*@
+@*        <div id="videooverlay">*@
+@*            <div id="videotext">*@
+@*                <span>@Messages("landing.video.title")</span>*@
+@*                <br><span id="playlink">&#9654;&nbsp;&nbsp;&nbsp;<span style="text-decoration: underline;*@
+@*                cursor: pointer;" onclick="playVideo()">@Messages("landing.video.watch")</span></span>*@
+@*            </div>*@
+@*        </div>*@
+@*    </div>*@
 
     <div class="container" id="choropleth-container" style="width: 100%;
         position: relative;">


### PR DESCRIPTION
Addresses #2247 (removes embedded video from landing page)

**After:**
![image](https://user-images.githubusercontent.com/1621749/94210630-1fbf7280-fe84-11ea-9fa8-fa439f5a2907.png)

It's just commented out for now. Can completely remove in the future.