### PR TITLE
2248 remove Pittsburgh and DC links from landing page

### DIFF
--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -32,7 +32,7 @@
                     <a class="bodyStartBtn" href="@routes.AuditController.audit()">@Messages("navbar.explore") @cityShortName</a>
                     <br><br>
                     <span class="header-text">@Messages("landing.also.in")</span>
-                    @for((cityName, cityURL) <- otherCityURLs) {
+                    @for((cityName, cityURL) <- otherCityURLs.filter(c => c._1 != "Washington, DC" && c._1 != "Pittsburgh, PA")) {
                         <!-- Replacing a space with a nbsp in order to make sure wrapping works as intended. -->
                         <a id="@cityName" class="otherCityLink" href="@{cityURL + "/audit"}">@cityName.replace(" ", " ")</a> &nbsp;
                     }

--- a/conf/cityparams.conf
+++ b/conf/cityparams.conf
@@ -4,13 +4,13 @@ city-id = ${?SIDEWALK_CITY_ID}
 
 city-params {
   city-ids = [
-    "newberg-or"
-    "washington-dc"
     "seattle-wa"
     "columbus-oh"
     "cdmx"
     "spgg"
     "pittsburgh-pa"
+    "newberg-or"
+    "washington-dc"
   ]
   city-name {
     newberg-or = "Newberg"


### PR DESCRIPTION
Resolves #2248 

Removes links on the landing page to DC (permanently) and Pittsburgh (until we have the prod server set up). I also reordered the links on the landing page
from Newberg -> Seattle -> Columbus -> CDMX -> SPGG -> Pittsburgh
to Seattle -> Columbus -> CDMX -> SPGG -> Pittsburgh -> Newberg

##### Before/After screenshots <!-- delete if not applicable -->
Before on Columbus server
![Screenshot from 2020-09-25 19-27-00](https://user-images.githubusercontent.com/6518824/94328175-24a82300-ff65-11ea-837c-3bb850b42e43.png)

After
![Screenshot from 2020-09-25 19-27-15](https://user-images.githubusercontent.com/6518824/94328177-27a31380-ff65-11ea-991d-4bc4c660d598.png)
