### PR TITLE
#2271 Removed unwanted href on landing page

### DIFF
--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -211,9 +211,7 @@
             <span class="ps-skyline-stats-holder-stat-number" id="percentage">NA</span>
             <span class="ps-skyline-stats-holder-stat-number" id="distance">NA</span>
             <span class="ps-skyline-stats-holder-stat-number" id="numlabels">NA</span>
-            <a href="/validate">
-                <span class="ps-skyline-stats-holder-stat-number" id="numvalidation">NA</span>
-            </a>
+            <span class="ps-skyline-stats-holder-stat-number" id="numvalidation">NA</span>
             <span class="ps-skyline-stats-holder-stat-label">@Messages("landing.stats.percent", cityShortName)</span>
             <span class="ps-skyline-stats-holder-stat-label">@Messages("landing.stats.distance")</span>
             <span class="ps-skyline-stats-holder-stat-label">@Messages("landing.stats.labels")</span>

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -215,9 +215,7 @@
             <span class="ps-skyline-stats-holder-stat-label">@Messages("landing.stats.percent", cityShortName)</span>
             <span class="ps-skyline-stats-holder-stat-label">@Messages("landing.stats.distance")</span>
             <span class="ps-skyline-stats-holder-stat-label">@Messages("landing.stats.labels")</span>
-            <a href="/validate">
-                <span class="ps-skyline-stats-holder-stat-label" >@Messages("landing.stats.validations")</span>
-            </a>
+            <span class="ps-skyline-stats-holder-stat-label" >@Messages("landing.stats.validations")</span>
         </div>
         <div class="ps-skyline-overlay">
             <div class="row" id="skyline-spacing">@Messages("landing.stats.title")</div>


### PR DESCRIPTION
Resolves #2271 

Landing page had an unnecessary href to "/validate". Simply deleted it from code.
