### PR TITLE
2238 Mission-Complete-Visual-Bug-Fix

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
@@ -239,9 +239,10 @@ function ModalMissionComplete (svl, missionContainer, missionModel, taskContaine
             confirmationCodeElement.innerHTML = "<img src='/assets/javascripts/SVLabel/img/icons/Icon_OrangeCheckmark.png'  \" +\n" +
                 "                \"alt='Confirmation Code icon' align='middle' style='top:-1px;position:relative;width:18px;height:18px;'> " +
                 i18next.t('common:mission-complete-confirmation-code') +
-                svl.confirmationCode +
-                "<p></p>";
+                svl.confirmationCode;
             confirmationCodeElement.setAttribute("id", "modal-mission-complete-confirmation-text");
+            confirmationCodeElement.style.marginTop = "1px";
+            confirmationCodeElement.style.marginBottom = "1px";
             uiModalMissionComplete.generateConfirmationButton.after(confirmationCodeElement);
             uiModalMissionComplete.confirmationText = $("#modal-mission-complete-confirmation-text");
             uiModalMissionComplete.generateConfirmationButton.remove();


### PR DESCRIPTION
Resolves #2238 

Changes the margin of surrounding elements in order to prevent the 'Continue' button from overlapping other elements. This can occur during resizing(zooming in/out) or at 100% zoom based on the size of the viewing window.

Before:
![image](https://user-images.githubusercontent.com/71039842/95946813-2f0a4f80-0da2-11eb-9cf8-685a87caa2d7.png)


After:
![image](https://user-images.githubusercontent.com/71039842/95946739-02563800-0da2-11eb-8223-b8e33fc3cd02.png)
