### PR TITLE
#2216 Reset view error with firefox browsers

### DIFF
--- a/app/views/results.scala.html
+++ b/app/views/results.scala.html
@@ -68,7 +68,7 @@
                 <img src='/assets/images/loader.gif' alt='loading' />
             </div>
             <div>
-                <a id="reset-button" href="javascript:null"> @Messages("results.reset.view") </a>
+                <a id="reset-button"> @Messages("results.reset.view") </a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Resolves #2216 
Fixed error with reset button where on firefox browsers you would get redirected to a page which said "null". Removed `href="javascript:null"` on reset-button at around line 71 in file app/views/results.scala.html.