### PR TITLE
2305 navbar messed up after signing up

### DIFF
--- a/app/views/navbar.scala.html
+++ b/app/views/navbar.scala.html
@@ -517,7 +517,7 @@ $(document).ready(function () {
             });
     </script>
     <template id="navbar-user-dropdown-list-signed-in">
-        <a id="nav-user-dropdown" role="button" data-toggle="dropdown" href="#">
+        <a id="nav-user-dropdown" class="navbarBtn" role="button" data-toggle="dropdown" href="#">
             __USERNAME__
             <b class="caret"></b>
         </a>

--- a/app/views/navbar.scala.html
+++ b/app/views/navbar.scala.html
@@ -92,7 +92,7 @@
                         <a class="navbarBtn" href='@routes.ApplicationController.help' id="toolbar-help-link" target="_blank">@Messages("navbar.help")</a>
                     </li>
                 }
-                <li class="dropdown navbarLink" id="navbar-dropdown-list">
+                <li class="dropdown navbarLink" id="navbar-data-dropdown-list">
                     <a id="nav-user-dropdown" class="navbarBtn" role="button" data-toggle="dropdown" href="#">
                         @Messages("navbar.data")
                         <b class="caret"></b>

--- a/app/views/navbar.scala.html
+++ b/app/views/navbar.scala.html
@@ -119,7 +119,7 @@
                 </li>
 
                 <!--<li><a href="#">Explore Accessibility!</a></li>-->
-                <li class="dropdown navbarLink" id="navbar-dropdown-list">
+                <li class="dropdown navbarLink" id="navbar-user-dropdown-list">
                     @if(user && user.get.role.getOrElse("") != "Anonymous") {
                         
                         <a id="nav-user-dropdown" class="navbarBtn" role="button" data-toggle="dropdown" href="#">
@@ -341,7 +341,7 @@ $(document).ready(function () {
                 // If on the sign in or sign up pages, remove the sign in button from the navbar.
                 if (location.pathname === '/signIn' || location.pathname === '/signUp') {
                     $('#sign-in-modal-container').remove();
-                    $('#navbar-dropdown-list').remove();
+                    $('#navbar-user-dropdown-list').remove();
                 }
             });
 
@@ -355,10 +355,10 @@ $(document).ready(function () {
                 }
 
                 //otherwise, reflect login changes on user's end
-                var htmlString = $("#navbar-dropdown-list-signed-in").html();
+                var htmlString = $("#navbar-user-dropdown-list-signed-in").html();
                 htmlString = htmlString.replace(/__USERNAME__/g, data.username);
 
-                $("#navbar-dropdown-list").html(htmlString);
+                $("#navbar-user-dropdown-list").html(htmlString);
                 var path = window.location.pathname;
 
                 // Toggle the sign-in modal 
@@ -516,7 +516,7 @@ $(document).ready(function () {
                 return false;
             });
     </script>
-    <template id="navbar-dropdown-list-signed-in">
+    <template id="navbar-user-dropdown-list-signed-in">
         <a id="nav-user-dropdown" role="button" data-toggle="dropdown" href="#">
             __USERNAME__
             <b class="caret"></b>
@@ -530,7 +530,7 @@ $(document).ready(function () {
             </li>
         </ul>
     </template>
-    <template id="navbar-dropdown-list-signed-out">
+    <template id="navbar-user-dropdown-list-signed-out">
         <a href="#SignIn" data-toggle="modal" data-target="#sign-in-modal-container" id="sign-in-button">
             @Messages("navbar.signin")
         </a>


### PR DESCRIPTION
Resolves #2305 

**This is how the navbar looked like before the fix:**
![broken-navbar-after-signin](https://user-images.githubusercontent.com/34140897/96672030-482a7780-1331-11eb-89ef-aa4e6a291652.png)


**This is how the navbar looks like after the fix:**
![fixed-navbar-after-signing-in](https://user-images.githubusercontent.com/34140897/96672996-77da7f00-1333-11eb-845b-d102aab701af.PNG)


**How issue was fixed**
Go to app/views/navbar.scala.html and at line ~122 change `id="navbar-dropdown-list"` to `id="navbar-data-dropdown-list"`. This changes the id of the Data dropdown button. I think this bug was happening because the Sign-In and Data buttons had the same id's of `navbar-dropdown-list`. So then when script was changing the Data button instead of the Sign-In button.

**Potential bugs/issues**
If there were scripts that call the Data button, referencing the id `navbar-dropdown-list`, then there will be a problem because the new id for the Data button is `navbar-data-dropdown-list`. It will now reference the Sign-in button with the same id. I did not see any conflicts when checking, but I am not 100% sure.

