### PR TITLE
2272 update admin time queries

### DIFF
--- a/app/models/audit/AuditTaskTable.scala
+++ b/app/models/audit/AuditTaskTable.scala
@@ -158,7 +158,7 @@ object AuditTaskTable {
     val countTasksQuery = Q.queryNA[Int](
       """SELECT COUNT(audit_task_id)
         |FROM sidewalk.audit_task
-        |WHERE (audit_task.task_end AT TIME ZONE 'PST')::date = (now() AT TIME ZONE 'PST')::date
+        |WHERE (audit_task.task_end AT TIME ZONE 'US/Pacific')::date = (now() AT TIME ZONE 'US/Pacific')::date
         |    AND audit_task.completed = TRUE""".stripMargin
     )
     countTasksQuery.list.head
@@ -171,7 +171,7 @@ object AuditTaskTable {
     val countTasksQuery = Q.queryNA[Int](
       """SELECT COUNT(audit_task_id)
         |FROM sidewalk.audit_task
-        |WHERE (audit_task.task_end AT TIME ZONE 'PST')::date = (now() AT TIME ZONE 'PST')::date - interval '1' day
+        |WHERE (audit_task.task_end AT TIME ZONE 'US/Pacific')::date = (now() AT TIME ZONE 'US/Pacific')::date - interval '1' day
         |    AND audit_task.completed = TRUE""".stripMargin
     )
     countTasksQuery.list.head

--- a/app/models/daos/slick/UserDAOSlick.scala
+++ b/app/models/daos/slick/UserDAOSlick.scala
@@ -285,7 +285,7 @@ object UserDAOSlick {
         |INNER JOIN sidewalk_user ON sidewalk_user.user_id = mission.user_id
         |INNER JOIN user_role ON sidewalk_user.user_id = user_role.user_id
         |INNER JOIN sidewalk.role ON user_role.role_id = sidewalk.role.role_id
-        |WHERE (label_validation.end_timestamp AT TIME ZONE 'PST')::date = (NOW() AT TIME ZONE 'PST')::date
+        |WHERE (label_validation.end_timestamp AT TIME ZONE 'US/Pacific')::date = (NOW() AT TIME ZONE 'US/Pacific')::date
         |    AND sidewalk_user.username <> 'anonymous'
         |    AND role.role = ?""".stripMargin
     )
@@ -324,7 +324,7 @@ object UserDAOSlick {
         |INNER JOIN sidewalk_user ON sidewalk_user.user_id = mission.user_id
         |INNER JOIN user_role ON sidewalk_user.user_id = user_role.user_id
         |INNER JOIN sidewalk.role ON user_role.role_id = sidewalk.role.role_id
-        |WHERE (label_validation.end_timestamp AT TIME ZONE 'PST')::date = (NOW() AT TIME ZONE 'PST')::date - interval '1' day
+        |WHERE (label_validation.end_timestamp AT TIME ZONE 'US/Pacific')::date = (NOW() AT TIME ZONE 'US/Pacific')::date - interval '1' day
         |    AND sidewalk_user.username <> 'anonymous'
         |    AND role.role = ?""".stripMargin
     )
@@ -398,7 +398,7 @@ object UserDAOSlick {
         |INNER JOIN sidewalk_user ON sidewalk_user.user_id = audit_task.user_id
         |INNER JOIN user_role ON sidewalk_user.user_id = user_role.user_id
         |INNER JOIN sidewalk.role ON user_role.role_id = sidewalk.role.role_id
-        |WHERE (audit_task.task_end AT TIME ZONE 'PST')::date = (NOW() AT TIME ZONE 'PST')::date
+        |WHERE (audit_task.task_end AT TIME ZONE 'US/Pacific')::date = (NOW() AT TIME ZONE 'US/Pacific')::date
         |    AND sidewalk_user.username <> 'anonymous'
         |    AND role.role = ?
         |    AND audit_task.completed = true""".stripMargin
@@ -437,7 +437,7 @@ object UserDAOSlick {
         |INNER JOIN sidewalk_user ON sidewalk_user.user_id = audit_task.user_id
         |INNER JOIN user_role ON sidewalk_user.user_id = user_role.user_id
         |INNER JOIN sidewalk.role ON user_role.role_id = sidewalk.role.role_id
-        |WHERE (audit_task.task_end AT TIME ZONE 'PST')::date = (now() AT TIME ZONE 'PST')::date - interval '1' day
+        |WHERE (audit_task.task_end AT TIME ZONE 'US/Pacific')::date = (now() AT TIME ZONE 'US/Pacific')::date - interval '1' day
         |    AND sidewalk_user.username <> 'anonymous'
         |    AND role.role = ?
         |    AND audit_task.completed = true""".stripMargin

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -191,7 +191,7 @@ object LabelTable {
       """SELECT COUNT(label.label_id)
         |FROM sidewalk.audit_task
         |INNER JOIN sidewalk.label ON label.audit_task_id = audit_task.audit_task_id
-        |WHERE (audit_task.task_end AT TIME ZONE 'PST')::date = (now() AT TIME ZONE 'PST')::date
+        |WHERE (audit_task.task_end AT TIME ZONE 'US/Pacific')::date = (now() AT TIME ZONE 'US/Pacific')::date
         |    AND label.deleted = false""".stripMargin
     )
     countQuery.list.head
@@ -208,7 +208,7 @@ object LabelTable {
                          |  FROM sidewalk.audit_task
                          |INNER JOIN sidewalk.label
                          |  ON label.audit_task_id = audit_task.audit_task_id
-                         |WHERE (audit_task.task_end AT TIME ZONE 'PST')::date = (now() AT TIME ZONE 'PST')::date
+                         |WHERE (audit_task.task_end AT TIME ZONE 'US/Pacific')::date = (now() AT TIME ZONE 'US/Pacific')::date
                          |  AND label.deleted = false AND label.label_type_id = (SELECT label_type_id
                          |														FROM sidewalk.label_type as lt
                          |														WHERE lt.label_type='$labelType')""".stripMargin
@@ -225,7 +225,7 @@ object LabelTable {
       """SELECT COUNT(label.label_id)
         |FROM sidewalk.audit_task
         |INNER JOIN sidewalk.label ON label.audit_task_id = audit_task.audit_task_id
-        |WHERE (audit_task.task_end AT TIME ZONE 'PST')::date = (now() AT TIME ZONE 'PST')::date - interval '1' day
+        |WHERE (audit_task.task_end AT TIME ZONE 'US/Pacific')::date = (now() AT TIME ZONE 'US/Pacific')::date - interval '1' day
         |    AND label.deleted = false""".stripMargin
     )
     countQuery.list.head
@@ -240,7 +240,7 @@ object LabelTable {
                          |  FROM sidewalk.audit_task
                          |INNER JOIN sidewalk.label
                          |  ON label.audit_task_id = audit_task.audit_task_id
-                         |WHERE (audit_task.task_end AT TIME ZONE 'PST')::date = (now() AT TIME ZONE 'PST')::date - interval '1' day
+                         |WHERE (audit_task.task_end AT TIME ZONE 'US/Pacific')::date = (now() AT TIME ZONE 'US/Pacific')::date - interval '1' day
                          |  AND label.deleted = false AND label.label_type_id = (SELECT label_type_id
                          |														FROM sidewalk.label_type as lt
                          |														WHERE lt.label_type='$labelType')""".stripMargin

--- a/app/models/label/LabelValidationTable.scala
+++ b/app/models/label/LabelValidationTable.scala
@@ -304,7 +304,7 @@ object LabelValidationTable {
     val countQuery = Q.queryNA[(Int)](
       """SELECT COUNT(v.label_id)
         |FROM sidewalk.label_validation v
-        |WHERE (v.end_timestamp AT TIME ZONE 'PST')::date = (NOW() AT TIME ZONE 'PST')::date""".stripMargin
+        |WHERE (v.end_timestamp AT TIME ZONE 'US/Pacific')::date = (NOW() AT TIME ZONE 'US/Pacific')::date""".stripMargin
     )
     countQuery.list.head
   }
@@ -316,7 +316,7 @@ object LabelValidationTable {
     val countQuery = Q.queryNA[(Int)](
       """SELECT COUNT(v.label_id)
         |FROM sidewalk.label_validation v
-        |WHERE (v.end_timestamp AT TIME ZONE 'PST')::date = (NOW() AT TIME ZONE 'PST')::date - interval '1' day""".stripMargin
+        |WHERE (v.end_timestamp AT TIME ZONE 'US/Pacific')::date = (NOW() AT TIME ZONE 'US/Pacific')::date - interval '1' day""".stripMargin
     )
     countQuery.list.head
   }
@@ -328,7 +328,7 @@ object LabelValidationTable {
     val countQuery = Q.queryNA[(Int)](
       s"""SELECT COUNT(v.label_id)
         |FROM sidewalk.label_validation v
-        |WHERE (v.end_timestamp AT TIME ZONE 'PST')::date = (NOW() AT TIME ZONE 'PST')::date
+        |WHERE (v.end_timestamp AT TIME ZONE 'US/Pacific')::date = (NOW() AT TIME ZONE 'US/Pacific')::date
         |   AND v.validation_result = $result""".stripMargin
     )
     countQuery.list.head
@@ -341,7 +341,7 @@ object LabelValidationTable {
     val countQuery = Q.queryNA[(Int)](
       s"""SELECT COUNT(v.label_id)
          |FROM sidewalk.label_validation v
-         |WHERE (v.end_timestamp AT TIME ZONE 'PST')::date = (NOW() AT TIME ZONE 'PST')::date - interval '1' day
+         |WHERE (v.end_timestamp AT TIME ZONE 'US/Pacific')::date = (NOW() AT TIME ZONE 'US/Pacific')::date - interval '1' day
          |   AND v.validation_result = $result""".stripMargin
     )
     countQuery.list.head

--- a/app/models/street/StreetEdgeTable.scala
+++ b/app/models/street/StreetEdgeTable.scala
@@ -186,7 +186,7 @@ object StreetEdgeTable {
       """SELECT SUM(ST_Length(ST_Transform(geom, 26918)))
         |FROM street_edge
         |INNER JOIN audit_task ON street_edge.street_edge_id = audit_task.street_edge_id
-        |WHERE (audit_task.task_end AT TIME ZONE 'PST')::date = (now() AT TIME ZONE 'PST')::date
+        |WHERE (audit_task.task_end AT TIME ZONE 'US/Pacific')::date = (now() AT TIME ZONE 'US/Pacific')::date
         |     AND street_edge.deleted = FALSE
         |     AND audit_task.completed = TRUE""".stripMargin
     )
@@ -203,7 +203,7 @@ object StreetEdgeTable {
         """SELECT SUM(ST_Length(ST_Transform(geom, 26918)))
             |FROM street_edge
             |INNER JOIN audit_task ON street_edge.street_edge_id = audit_task.street_edge_id
-            |WHERE (audit_task.task_end AT TIME ZONE 'PST')::date = (now() AT TIME ZONE 'PST')::date - interval '1' day
+            |WHERE (audit_task.task_end AT TIME ZONE 'US/Pacific')::date = (now() AT TIME ZONE 'US/Pacific')::date - interval '1' day
             |     AND street_edge.deleted = FALSE
             |     AND audit_task.completed = TRUE""".stripMargin
         )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - "9000:9000"
     environment:
       - DATABASE_URL=jdbc:postgresql://db:5432/sidewalk
-      - SIDEWALK_CITY_ID=columbus-oh
+      - SIDEWALK_CITY_ID=washington-dc
       - SIDEWALK_EMAIL_ADDRESS=DUMMY_EMAIL_ADDRESS
       - SIDEWALK_EMAIL_PASSWORD=DUMMY_EMAIL_PASSWORD
       - ENV_TYPE=test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - "9000:9000"
     environment:
       - DATABASE_URL=jdbc:postgresql://db:5432/sidewalk
-      - SIDEWALK_CITY_ID=washington-dc
+      - SIDEWALK_CITY_ID=columbus-oh
       - SIDEWALK_EMAIL_ADDRESS=DUMMY_EMAIL_ADDRESS
       - SIDEWALK_EMAIL_PASSWORD=DUMMY_EMAIL_PASSWORD
       - ENV_TYPE=test


### PR DESCRIPTION
Resolves #2272 

Changed some SQL queries that relied on time data to use 'US/Pacific' instead of 'PST', since 'PST' is only accurate for 6 months of a year due to daylight savings. 

These changes are reflected in the admin table and can be tested by performing two labeling missions (must have separate audit ids) and manually changing one of them to a day before with this command: 
```docker exec -it projectsidewalk-db psql -c "UPDATE sidewalk.audit_task SET task_end = '<updated time>' WHERE audit_task.audit_task_id = <audit_task_id>" -U sidewalk -d sidewalk```