### PR TITLE
2335-User-Dash-Text-Correction

### DIFF
--- a/public/locales/en/dashboard.json
+++ b/public/locales/en/dashboard.json
@@ -27,7 +27,7 @@
   "badge-validations-singular": "validation",
   "badge-validations-plural": "validations",
   "more-unit-until-achievement": "<strong>{{n}} more $t({{unit}})</strong> until your $t({{firstOrNext}}) achievement.",
-  "badge-missions-earned-all": "Congratulations, you've earned all labeling badges!",
+  "badge-missions-earned-all": "Congratulations, you've earned all mission badges!",
   "badge-distance-earned-all": "Congratulations, you've earned all distance badges!",
   "badge-labels-earned-all": "Congratulations, you've earned all labeling badges!",
   "badge-validations-earned-all": "Congratulations, you've earned all validation badges!"


### PR DESCRIPTION
Resolves #2335 

Fixes text error in English version.

I am unable to replicate the bug because I do not have all the missions complete... here is the text file change.

Before:
![image](https://user-images.githubusercontent.com/71039842/98755705-f4361000-237d-11eb-8b44-5a36eece5bc5.png)

After:
![image](https://user-images.githubusercontent.com/71039842/98755637-d9639b80-237d-11eb-9dc7-ee7f6ee0b214.png)
