### PR TITLE
Adds rough approximation of latlng without depth data

### DIFF
--- a/app/controllers/TaskController.scala
+++ b/app/controllers/TaskController.scala
@@ -292,7 +292,7 @@ class TaskController @Inject() (implicit val env: Environment[User, SessionAuthe
             LabelPointTable.save(LabelPoint(0, labelId, point.svImageX, point.svImageY, point.canvasX,
               point.canvasY, point.heading, point.pitch, point.zoom,
               point.canvasHeight, point.canvasWidth, point.alphaX, point.alphaY,
-              point.lat, point.lng, pointGeom))
+              point.lat, point.lng, pointGeom, point.computationMethod))
           }
         }
 

--- a/app/formats/json/TaskSubmissionFormats.scala
+++ b/app/formats/json/TaskSubmissionFormats.scala
@@ -8,7 +8,7 @@ import play.api.libs.functional.syntax._
 object TaskSubmissionFormats {
   case class EnvironmentSubmission(browser: Option[String], browserVersion: Option[String], browserWidth: Option[Int], browserHeight: Option[Int], availWidth: Option[Int], availHeight: Option[Int], screenWidth: Option[Int], screenHeight: Option[Int], operatingSystem: Option[String], language: String)
   case class InteractionSubmission(action: String, gsvPanoramaId: Option[String], lat: Option[Float], lng: Option[Float], heading: Option[Float], pitch: Option[Float], zoom: Option[Int], note: Option[String], temporaryLabelId: Option[Int], timestamp: Long)
-  case class LabelPointSubmission(svImageX: Int, svImageY: Int, canvasX: Int, canvasY: Int, heading: Float, pitch: Float, zoom: Int, canvasHeight: Int, canvasWidth: Int, alphaX: Float, alphaY: Float, lat: Option[Float], lng: Option[Float])
+  case class LabelPointSubmission(svImageX: Int, svImageY: Int, canvasX: Int, canvasY: Int, heading: Float, pitch: Float, zoom: Int, canvasHeight: Int, canvasWidth: Int, alphaX: Float, alphaY: Float, lat: Option[Float], lng: Option[Float], computationMethod: Option[String])
   case class LabelSubmission(gsvPanoramaId: String, auditTaskId: Int, labelType: String, photographerHeading: Float, photographerPitch: Float, panoramaLat: Float, panoramaLng: Float, deleted: JsBoolean, severity: Option[Int], temporaryLabel: Option[JsBoolean], description: Option[String], tagIds: Seq[Int], points: Seq[LabelPointSubmission], temporaryLabelId: Option[Int], timeCreated: Option[Long], tutorial: Boolean)
   case class TaskSubmission(streetEdgeId: Int, taskStart: String, auditTaskId: Option[Int], completed: Option[Boolean], currentLat: Float, currentLng: Float, startPointReversed: Boolean)
   case class IncompleteTaskSubmission(issueDescription: String, lat: Float, lng: Float)
@@ -63,7 +63,8 @@ object TaskSubmissionFormats {
       (JsPath \ "alpha_x").read[Float] and
       (JsPath \ "alpha_y").read[Float] and
       (JsPath \ "lat").readNullable[Float] and
-      (JsPath \ "lng").readNullable[Float]
+      (JsPath \ "lng").readNullable[Float] and
+      (JsPath \ "computation_method").readNullable[String]
     )(LabelPointSubmission.apply _)
 
   implicit val labelSubmissionReads: Reads[LabelSubmission] = (

--- a/app/models/label/LabelPointTable.scala
+++ b/app/models/label/LabelPointTable.scala
@@ -7,7 +7,8 @@ import scala.slick.lifted.ForeignKeyQuery
 
 case class LabelPoint(labelPointId: Int, labelId: Int, svImageX: Int, svImageY: Int, canvasX: Int, canvasY: Int,
                       heading: Float, pitch: Float, zoom: Int, canvasHeight: Int, canvasWidth: Int,
-                      alphaX: Float, alphaY: Float, lat: Option[Float], lng: Option[Float], geom: Option[Point])
+                      alphaX: Float, alphaY: Float, lat: Option[Float], lng: Option[Float], geom: Option[Point],
+                      computationMethod: Option[String])
 
 class LabelPointTable(tag: slick.lifted.Tag) extends Table[LabelPoint](tag, Some("sidewalk"), "label_point") {
   def labelPointId = column[Int]("label_point_id", O.PrimaryKey, O.AutoInc)
@@ -26,9 +27,10 @@ class LabelPointTable(tag: slick.lifted.Tag) extends Table[LabelPoint](tag, Some
   def lat = column[Option[Float]]("lat", O.Nullable)
   def lng = column[Option[Float]]("lng", O.Nullable)
   def geom = column[Option[Point]]("geom", O.Nullable)
+  def computationMethod = column[Option[String]]("computation_method", O.Nullable)
 
   def * = (labelPointId, labelId, svImageX, svImageY, canvasX, canvasY, heading, pitch, zoom,
-    canvasHeight, canvasWidth, alphaX, alphaY, lat, lng, geom) <> ((LabelPoint.apply _).tupled, LabelPoint.unapply)
+    canvasHeight, canvasWidth, alphaX, alphaY, lat, lng, geom, computationMethod) <> ((LabelPoint.apply _).tupled, LabelPoint.unapply)
 
   def label: ForeignKeyQuery[LabelTable, Label] =
     foreignKey("label_point_label_id_fkey", labelId, TableQuery[LabelTable])(_.labelId)

--- a/conf/evolutions/default/93.sql
+++ b/conf/evolutions/default/93.sql
@@ -10,7 +10,10 @@ UPDATE label_point
 SET computation_method = 'approximation1',
     lat = panorama_lat + (10 * cos(radians(heading)) / 111111),
     lng = panorama_lng + (10 * sin(radians(heading)) / (111111 * cos(radians(panorama_lat)))),
-    geom = ST_SetSRID( ST_Point( panorama_lng + (10 * sin(radians(heading)) / (111111 * cos(radians(panorama_lat)))), panorama_lat + (10 * cos(radians(heading)) / 111111)), 4326)
+    geom = ST_SetSRID( ST_Point(
+        panorama_lng + (10 * sin(radians(heading)) / (111111 * cos(radians(panorama_lat)))),
+        panorama_lat + (10 * cos(radians(heading)) / 111111)
+    ), 4326)
 FROM label
 WHERE label_point.label_id = label.label_id
     AND computation_method IS NULL;

--- a/conf/evolutions/default/93.sql
+++ b/conf/evolutions/default/93.sql
@@ -1,0 +1,26 @@
+# --- !Ups
+ALTER TABLE label_point
+    ADD COLUMN computation_method TEXT;
+
+UPDATE label_point
+SET computation_method = 'depth'
+WHERE lat IS NOT NULL AND lng IS NOT NULL AND geom IS NOT NULL;
+
+UPDATE label_point
+SET computation_method = 'approximation1',
+    lat = panorama_lat + (10 * cos(radians(heading)) / 111111),
+    lng = panorama_lng + (10 * sin(radians(heading)) / (111111 * cos(radians(panorama_lat)))),
+    geom = ST_SetSRID( ST_Point( panorama_lng + (10 * sin(radians(heading)) / (111111 * cos(radians(panorama_lat)))), panorama_lat + (10 * cos(radians(heading)) / 111111)), 4326)
+FROM label
+WHERE label_point.label_id = label.label_id
+    AND computation_method IS NULL;
+
+# --- !Downs
+UPDATE label_point
+SET lat = NULL,
+    lng = NULL,
+    geom = NULL
+WHERE computation_method = 'approximation1';
+
+ALTER TABLE label_point
+    DROP COLUMN computation_method;

--- a/public/javascripts/SVLabel/src/SVLabel/PointCloud.js
+++ b/public/javascripts/SVLabel/src/SVLabel/PointCloud.js
@@ -69,41 +69,9 @@ function PointCloud (params) {
         _callbacks[panoId].push(func);
     }
 
-    /**
-     * Given the coordinate x, y (and z), return index of the point cloud data.
-     * To further calculate the x- and y-coordinates, do as follows:
-     *
-     * ix = idx / 3 % w
-     * iy = (idx / 3 - ix) / w
-     *
-     * @panoId
-     * @param panoId
-     * @param param An object that could contain z-coordinate and a distance tolerance (r).
-     * @return idx
-     */
-    function search(panoId, param) {
-        if (panoId in _pointClouds && getPointCloud(panoId)){
-            var pc = getPointCloud(panoId);
-
-            // kd-tree. It's slooooooow. I'll try Three.js later.
-            // https://github.com/ubilabs/kd-tree-javascript
-            //var point = pc.tree.nearest({x: param.x, y: param.y, z: param.z}, 1, 100);
-            var point = pc.tree.nearest({x: param.x, y: param.y, z: param.z}, 1, 40);
-            if (point && point[0]) {
-                var idx = point[0][0].id;
-                return idx;
-                //var ix = idx / 3 % w;
-                //var iy = (idx / 3 - ix) / w;
-                //return {ix: ix, iy: iy};
-            }
-        }
-        return null;
-    }
-
     self.createPointCloud = createPointCloud;
     self.getPointCloud = getPointCloud;
     self.ready = ready;
-    self.search = search;
 
     _init(params);
     return self;

--- a/public/javascripts/SVLabel/src/SVLabel/data/Form.js
+++ b/public/javascripts/SVLabel/src/SVLabel/data/Form.js
@@ -80,7 +80,7 @@ function Form (labelContainer, missionModel, missionContainer, navigationModel, 
             var tempLabelId = label.getProperty('temporary_label_id');
             var auditTaskId = label.getProperty('audit_task_id');
 
-            // if this label is a new label, get the timestamp of its creation from the corresponding interaction
+            // If this label is a new label, get the timestamp of its creation from the corresponding interaction.
             var associatedInteraction = data.interactions.find(interaction =>
                 interaction.action === 'LabelingCanvas_FinishLabeling' && interaction.temporary_label_id === tempLabelId
                 && interaction.audit_task_id === auditTaskId);
@@ -129,6 +129,7 @@ function Form (labelContainer, missionModel, missionContainer, navigationModel, 
                 if (labelLatLng) {
                     pointParam.lat = labelLatLng.lat;
                     pointParam.lng = labelLatLng.lng;
+                    pointParam.computation_method = labelLatLng.computationMethod;
                 }
                 temp.label_points.push(pointParam);
             }

--- a/public/javascripts/common/UtilitiesMath.js
+++ b/public/javascripts/common/UtilitiesMath.js
@@ -38,20 +38,6 @@ function latlngOffset(lat, dx, dy) {
 util.math.latlngOffset = latlngOffset;
 
 /**
- * given a latlng offset, return offset in distanx along x- and y-axis.
- * @param lat
- * @param dLat
- * @param dLng
- * @returns {{dx: number, dy: number}}
- */
-function latlngInverseOffset(lat, dLat, dLng) {
-    var dy = 111111 * dLat;
-    var dx = 111111 * Math.cos(toRadians(lat)) * dLng;
-    return {dx: dx, dy: dy};
-}
-util.math.latlngInverseOffset = latlngInverseOffset;
-
-/**
  * This function takes two latlon coordinates and returns the angle that forms aroud the z-axis.
  *
  * @param lat1

--- a/public/javascripts/common/UtilitiesPanomarker.js
+++ b/public/javascripts/common/UtilitiesPanomarker.js
@@ -149,30 +149,6 @@ function calculateImageCoordinateFromPointPov (pov) {
 util.panomarker.calculateImageCoordinateFromPointPov = calculateImageCoordinateFromPointPov;
 
 /**
- * 0 for image y-axis is at *3328*! So the top-left corner of the image is (0, 3328).
- *
- * @param imageX
- * @param imageY
- * @param currentPov
- */
-function imageCoordinateToCanvasCoordinate(imageX, imageY, currentPov) {
-
-    // var canvasX = (ix - svl.svImageWidth * pov.heading / 360) * zoomFactor / svl.alpha_x + svl.canvasWidth / 2;
-    // var canvasY = (iy - svl.svImageHeight * pov.pitch / 180) * zoomFactor / svl.alpha_y + svl.canvasHeight / 2;
-
-    var povChange = svl.map.getPovChangeStatus();
-    povChange["status"] = true;
-
-    var canvasCoordinate;
-    var origPointPov = calculatePointPovFromImageCoordinate(imageX, imageY, currentPov);
-    canvasCoordinate = getCanvasCoordinate (canvasCoordinate, origPointPov, currentPov);
-    povChange["status"] = false;
-
-    return {x: canvasCoordinate.x, y: canvasCoordinate.y};
-}
-util.panomarker.imageCoordinateToCanvasCoordinate = imageCoordinateToCanvasCoordinate;
-
-/**
  * This function maps canvas coordinate to image coordinate
  * @param canvasX
  * @param canvasY


### PR DESCRIPTION
Resolves (partially) #2362 

Given that we no longer have depth data from Google, this PR uses the rough fallback approximation we have for the mini map for the back end as well. This fixes the issue of null lat/lngs in the database.

The approximation is quite crude. I believe it just assumes you are placing the label 10 meters or so in front of you, where "in front of" only takes into account your heading. So if you place labels on the top left and bottom right of the screen, they will show up in the same location as long as you did not pan between placing the labels.

I'm sure that we can improve on this approximation, but I wanted to get out _anything_ ASAP so that it doesn't look like we are missing data on our maps and such. Adding new approximations or altering old ones will be quite easy using the method I've used.