### PR TITLE
Fixes bug where results map wouldn't load

### DIFF
--- a/app/models/audit/AuditTaskTable.scala
+++ b/app/models/audit/AuditTaskTable.scala
@@ -157,12 +157,12 @@ object AuditTaskTable {
     */
   def countCompletedAuditsToday: Int = db.withSession { implicit session =>
     val countTasksQuery = Q.queryNA[Int](
-      """SELECT audit_task_id
+      """SELECT COUNT(audit_task_id)
         |FROM sidewalk.audit_task
         |WHERE (audit_task.task_end AT TIME ZONE 'PST')::date = (now() AT TIME ZONE 'PST')::date
         |    AND audit_task.completed = TRUE""".stripMargin
     )
-    countTasksQuery.list.size
+    countTasksQuery.list.head
   }
 
   /**
@@ -170,12 +170,12 @@ object AuditTaskTable {
     */
   def countCompletedAuditsYesterday: Int = db.withSession { implicit session =>
     val countTasksQuery = Q.queryNA[Int](
-      """SELECT audit_task_id
+      """SELECT COUNT(audit_task_id)
         |FROM sidewalk.audit_task
         |WHERE (audit_task.task_end AT TIME ZONE 'PST')::date = (now() AT TIME ZONE 'PST')::date - interval '1' day
         |    AND audit_task.completed = TRUE""".stripMargin
     )
-    countTasksQuery.list.size
+    countTasksQuery.list.head
   }
 
   /**

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -196,13 +196,13 @@ object LabelTable {
   def countTodayLabels: Int = db.withSession { implicit session =>
 
     val countQuery = Q.queryNA[(Int)](
-      """SELECT label.label_id
+      """SELECT COUNT(label.label_id)
         |FROM sidewalk.audit_task
         |INNER JOIN sidewalk.label ON label.audit_task_id = audit_task.audit_task_id
         |WHERE (audit_task.task_end AT TIME ZONE 'PST')::date = (now() AT TIME ZONE 'PST')::date
         |    AND label.deleted = false""".stripMargin
     )
-    countQuery.list.size
+    countQuery.list.head
   }
 
   /*
@@ -212,7 +212,7 @@ object LabelTable {
   */
   def countTodayLabelsBasedOnType(labelType: String): Int = db.withSession { implicit session =>
 
-    val countQuery = s"""SELECT label.label_id
+    val countQuery = s"""SELECT COUNT(label.label_id)
                          |  FROM sidewalk.audit_task
                          |INNER JOIN sidewalk.label
                          |  ON label.audit_task_id = audit_task.audit_task_id
@@ -222,7 +222,7 @@ object LabelTable {
                          |														WHERE lt.label_type='$labelType')""".stripMargin
     val countQueryResult = Q.queryNA[(Int)](countQuery)
 
-    countQueryResult.list.size
+    countQueryResult.list.head
   }
 
   /*
@@ -230,13 +230,13 @@ object LabelTable {
   */
   def countYesterdayLabels: Int = db.withTransaction { implicit session =>
     val countQuery = Q.queryNA[(Int)](
-      """SELECT label.label_id
+      """SELECT COUNT(label.label_id)
         |FROM sidewalk.audit_task
         |INNER JOIN sidewalk.label ON label.audit_task_id = audit_task.audit_task_id
         |WHERE (audit_task.task_end AT TIME ZONE 'PST')::date = (now() AT TIME ZONE 'PST')::date - interval '1' day
         |    AND label.deleted = false""".stripMargin
     )
-    countQuery.list.size
+    countQuery.list.head
   }
 
   /*
@@ -244,7 +244,7 @@ object LabelTable {
   * Date: Aug 28, 2016
   */
   def countYesterdayLabelsBasedOnType(labelType: String): Int = db.withTransaction { implicit session =>
-    val countQuery = s"""SELECT label.label_id
+    val countQuery = s"""SELECT COUNT(label.label_id)
                          |  FROM sidewalk.audit_task
                          |INNER JOIN sidewalk.label
                          |  ON label.audit_task_id = audit_task.audit_task_id
@@ -254,7 +254,7 @@ object LabelTable {
                          |														WHERE lt.label_type='$labelType')""".stripMargin
     val countQueryResult = Q.queryNA[(Int)](countQuery)
 
-    countQueryResult.list.size
+    countQueryResult.list.head
   }
 
 

--- a/app/models/label/LabelValidationTable.scala
+++ b/app/models/label/LabelValidationTable.scala
@@ -302,11 +302,11 @@ object LabelValidationTable {
     */
   def countTodayValidations: Int = db.withSession { implicit session =>
     val countQuery = Q.queryNA[(Int)](
-      """SELECT v.label_id
+      """SELECT COUNT(v.label_id)
         |FROM sidewalk.label_validation v
         |WHERE (v.end_timestamp AT TIME ZONE 'PST')::date = (NOW() AT TIME ZONE 'PST')::date""".stripMargin
     )
-    countQuery.list.size
+    countQuery.list.head
   }
 
   /**
@@ -314,11 +314,11 @@ object LabelValidationTable {
     */
   def countYesterdayValidations: Int = db.withSession { implicit session =>
     val countQuery = Q.queryNA[(Int)](
-      """SELECT v.label_id
+      """SELECT COUNT(v.label_id)
         |FROM sidewalk.label_validation v
         |WHERE (v.end_timestamp AT TIME ZONE 'PST')::date = (NOW() AT TIME ZONE 'PST')::date - interval '1' day""".stripMargin
     )
-    countQuery.list.size
+    countQuery.list.head
   }
 
   /**
@@ -326,12 +326,12 @@ object LabelValidationTable {
     */
   def countTodayValidationsBasedOnResult(result: Int): Int = db.withSession { implicit session =>
     val countQuery = Q.queryNA[(Int)](
-      s"""SELECT v.label_id
+      s"""SELECT COUNT(v.label_id)
         |FROM sidewalk.label_validation v
         |WHERE (v.end_timestamp AT TIME ZONE 'PST')::date = (NOW() AT TIME ZONE 'PST')::date
         |   AND v.validation_result = $result""".stripMargin
     )
-    countQuery.list.size
+    countQuery.list.head
   }
 
   /**
@@ -339,12 +339,12 @@ object LabelValidationTable {
     */
   def countYesterdayValidationsBasedOnResult(result: Int): Int = db.withSession { implicit session =>
     val countQuery = Q.queryNA[(Int)](
-      s"""SELECT v.label_id
+      s"""SELECT COUNT(v.label_id)
          |FROM sidewalk.label_validation v
          |WHERE (v.end_timestamp AT TIME ZONE 'PST')::date = (NOW() AT TIME ZONE 'PST')::date - interval '1' day
          |   AND v.validation_result = $result""".stripMargin
     )
-    countQuery.list.size
+    countQuery.list.head
   }
 
   /**

--- a/conf/cityparams.conf
+++ b/conf/cityparams.conf
@@ -137,7 +137,7 @@ city-params {
     seattle-wa = 47.615
     columbus-oh = 40.000
     cdmx = 19.490
-    spgg = 25.660
+    spgg = 25.679
     pittsburgh-pa = 40.440
   }
   city-center-lng {
@@ -200,7 +200,7 @@ city-params {
     seattle-wa = 12.0
     columbus-oh = 12.75
     cdmx = 14.0
-    spgg = 14.5
+    spgg = 14.0
     pittsburgh-pa = 13.5
   }
   api-demos {

--- a/public/javascripts/Choropleths/Choropleth.js
+++ b/public/javascripts/Choropleths/Choropleth.js
@@ -56,6 +56,19 @@ function Choropleth(_, $, difficultRegionIds, params, layers, polygonData, polyg
         }
     }
 
+    if (params.popupType === 'issueCounts') {
+        $.getJSON('/adminapi/choroplethCounts', function (labelCounts) {
+            // Append label counts to region data with map/reduce.
+            let labelData = _.map(polygonRateData, function(region) {
+                let regionLabel = _.find(labelCounts, function(x) { return x.region_id === region.region_id });
+                return regionLabel ? regionLabel : { regionId: region.region_id, labels: {} };
+            });
+            initializeChoropleth(polygonRateData, labelData);
+        });
+    } else {
+        initializeChoropleth(polygonRateData, 'NA');
+    }
+
     // Renders the neighborhood polygons, colored by completion percentage.
     function initializeChoroplethNeighborhoodPolygons(map, rates, layers, labelData) {
          // Default region color, used to check if any regions are missing data.
@@ -196,7 +209,7 @@ function Choropleth(_, $, difficultRegionIds, params, layers, polygonData, polyg
                 else if (milesLeft === 0) distanceLeft = '<1';
                 else if (milesLeft === 1) distanceLeft = '1';
                 else distanceLeft = '>1';
-                let activity = params.webpageActivity + regionId + '_distanceLeft=' + distanceLeft + '_target=' + target;
+                let activity = params.webpageActivity + regionId + '_distanceLeft=' + distanceLeft + '_target=audit';
                 postToWebpageActivity(activity);
             });
         }
@@ -297,19 +310,6 @@ function Choropleth(_, $, difficultRegionIds, params, layers, polygonData, polyg
                '<td><img src="/assets/javascripts/SVLabel/img/cursors/Cursor_SurfaceProblem.png"></td>'+
                '<td><img src="/assets/javascripts/SVLabel/img/cursors/Cursor_Obstacle.png"></td>'+
                '<tr><td>'+ counts['NoSidewalk'] +'</td><td>'+ counts['NoCurbRamp'] +'</td><td>'+ counts['SurfaceProblem'] +'</td><td>'+ counts['Obstacle'] +'</td></tr></tbody></table></div>';    
-    }
-
-    if (params.popupType === 'issueCounts') {
-        $.getJSON('/adminapi/choroplethCounts', function (labelCounts) {
-            // Append label counts to region data with map/reduce.
-            let labelData = _.map(polygonRateData, function(region) {
-                let regionLabel = _.find(labelCounts, function(x){ return x.region_id === region.region_id });
-                return regionLabel ? regionLabel : {};
-            });
-            initializeChoropleth(polygonRateData, labelData);
-        });
-    } else {
-        initializeChoropleth(polygonRateData, 'NA');
     }
 
     /**


### PR DESCRIPTION
Resolves #2369 

Fixes a bug where the results map wouldn't load. It was a bug that came out of our choropleth refactoring (#2215) that we didn't catch because it only occurs in neighborhoods that have no labels contributed to them.

While I was there, I also made a small performance improvement to a few admin page queries and adjusted the map center/zoom in SPGG to accommodate the addition of the El Obispo neighborhood.
