### PR TITLE
2331-Differentiate-User-Description-On-Tags

### DIFF
--- a/public/javascripts/SVValidate/src/label/LabelDescriptionBox.js
+++ b/public/javascripts/SVValidate/src/label/LabelDescriptionBox.js
@@ -64,13 +64,13 @@ function LabelDescriptionBox () {
         if (tags && tags.length > 0) {
             // Translate to correct language and separate tags with a comma.
             let tag = tags.map(t => i18next.t('center-ui.tag.' + t)).join(', ');
-            let htmlString = document.createTextNode('tags: ' + tag);
+            let htmlString = document.createTextNode(i18next.t('tags') + tag);
             desBox.appendChild(htmlString);
             desBox.appendChild(document.createElement("br"));
         }
 
         if (description && description.trim().length > 0) {
-            let htmlString = document.createTextNode('user description: ' + description);
+            let htmlString = document.createTextNode(i18next.t('user-description') + description);
             desBox.appendChild(htmlString);
         }
 

--- a/public/javascripts/SVValidate/src/label/LabelDescriptionBox.js
+++ b/public/javascripts/SVValidate/src/label/LabelDescriptionBox.js
@@ -70,7 +70,7 @@ function LabelDescriptionBox () {
         }
 
         if (description && description.trim().length > 0) {
-            let htmlString = document.createTextNode(description);
+            let htmlString = document.createTextNode('user description: ' + description);
             desBox.appendChild(htmlString);
         }
 

--- a/public/locales/en/validate.json
+++ b/public/locales/en/validate.json
@@ -5,6 +5,8 @@
   "surface-problem-caps": "Surface Problem",
   "no-sidewalk-caps": "No Sidewalk",
   "severity": "Severity: ",
+  "tags": "Tags: ",
+  "user-description": "User Description: ",
   "temporary": "Temporary",
   "top-ui": {
     "title": {

--- a/public/locales/es/validate.json
+++ b/public/locales/es/validate.json
@@ -5,6 +5,8 @@
   "surface-problem-caps": "Problema en superficie",
   "no-sidewalk-caps": "No hay banqueta",
   "severity": "Calificación: ",
+  "tags": "Etiquitas: ",
+  "user-description": "Descripción de usuario: ",
   "temporary": "Temporal",
   "top-ui": {
     "title": {


### PR DESCRIPTION
Resolves #2331 

Adds a heading of "user description: " for user comments on tags, displayed during validation.

![image](https://user-images.githubusercontent.com/71039842/99454759-b7b56780-28db-11eb-8f97-9154c322d202.png)
