### PR TITLE
Fixes bug of new mission not setting first label correctly

### DIFF
--- a/public/javascripts/SVValidate/src/panorama/PanoramaContainer.js
+++ b/public/javascripts/SVValidate/src/panorama/PanoramaContainer.js
@@ -113,6 +113,7 @@ function PanoramaContainer (labelList) {
      */
     function reset () {
         setProperty('progress', 0);
+        svv.panorama.setLabel(labels[getProperty('progress')]);
     }
 
     /**


### PR DESCRIPTION
Fixes #2382 

This fixes the bug where the first label you validate in a new mission looks like the same label from the end of the previous mission, even if the label type is incorrect. It was a mistake I made when removing the code for the rapid validation interface.