### PR TITLE
Fixes scroll wheel zoom on choropleths

### DIFF
--- a/app/views/labelMap.scala.html
+++ b/app/views/labelMap.scala.html
@@ -187,6 +187,7 @@
                 },
                 polygonFillMode: 'singleColor',
                 zoomControl: true,
+                scrollWheelZoom: true,
                 clickData: true,
                 mapName: 'label-map',
                 mapStyle: 'mapbox://styles/mapbox/streets-v11'

--- a/public/javascripts/Admin/src/Admin.User.js
+++ b/public/javascripts/Admin/src/Admin.User.js
@@ -21,6 +21,7 @@ function AdminUser(user) {
         webpageActivity: 'Click_module=AdminUserMap_regionId=',
         polygonFillMode: 'singleColor',
         zoomControl: true,
+        scrollWheelZoom: true,
         mapName: 'admin-map',
         mapStyle: 'mapbox://styles/mapbox/streets-v11'
     };

--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -54,7 +54,7 @@ function Admin(_, $, difficultRegionIds) {
             weight: 2
         },
         polygonFillMode: 'singleColor',
-        scrollWheel: true,
+        scrollWheelZoom: true,
         zoomControl: true,
         mapName: 'label-map',
         mapStyle: 'mapbox://styles/mapbox/streets-v11'

--- a/public/javascripts/Progress/src/Progress.js
+++ b/public/javascripts/Progress/src/Progress.js
@@ -21,6 +21,7 @@ function Progress (_, $, difficultRegionIds, userRole) {
         webpageActivity: 'Click_module=UserMap_regionId=',
         polygonFillMode: 'singleColor',
         zoomControl: true,
+        scrollWheelZoom: true,
         clickData: true,
         mapName: 'map',
         mapStyle: 'mapbox://styles/mapbox/streets-v11'


### PR DESCRIPTION
Fixes #2379 

Fixes the lack of scroll wheel zoom on label map, the user dashboard, and the admin interface. I had just forgotten to include those parameters when changing the choropleth code recently.