### PR TITLE
Removes empty popup when clicking on label on user dash

### DIFF
--- a/public/javascripts/Choropleths/InitializeSubmittedLabels.js
+++ b/public/javascripts/Choropleths/InitializeSubmittedLabels.js
@@ -96,10 +96,7 @@ function InitializeSubmittedLabels(map, params, adminGSVLabelView, mapData, labe
                 'mouseout': function () {
                     layer.setRadius(5);
                 }
-            })
-        // When on user dash.
-        } else { 
-            layer.bindPopup(feature.properties.type);
+            });
         }
     }
 


### PR DESCRIPTION
Fixes #2378 

Removes the blank popup that showed up when clicking on a label on the user dashboard. We shouldn't be showing any popup there.