### PR TITLE
Fixes recording of computation method for latlngs

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/data/Form.js
+++ b/public/javascripts/SVLabel/src/SVLabel/data/Form.js
@@ -129,7 +129,7 @@ function Form (labelContainer, missionModel, missionContainer, navigationModel, 
                 if (labelLatLng) {
                     pointParam.lat = labelLatLng.lat;
                     pointParam.lng = labelLatLng.lng;
-                    pointParam.computation_method = labelLatLng.computationMethod;
+                    pointParam.computation_method = labelLatLng.latLngComputationMethod;
                 }
                 temp.label_points.push(pointParam);
             }

--- a/public/javascripts/SVLabel/src/SVLabel/label/Label.js
+++ b/public/javascripts/SVLabel/src/SVLabel/label/Label.js
@@ -872,7 +872,7 @@ function Label (svl, pathIn, params) {
                 }
                 setProperty('labelLat', latlng.lat);
                 setProperty('labelLng', latlng.lng);
-                setProperty('latLngComputationMethod', 'approximation1');
+                setProperty('latLngComputationMethod', latlng.latLngComputationMethod);
                 return latlng;
             }
         } else {


### PR DESCRIPTION
Fixes #2383 

Fixes the error I made in recording which method is being used to compute lat/lngs on the audit page.