### PR TITLE
Usernames in URIs now being encoded everywhere

### DIFF
--- a/public/javascripts/Admin/src/Admin.GSVLabelView.js
+++ b/public/javascripts/Admin/src/Admin.GSVLabelView.js
@@ -266,7 +266,7 @@ function AdminGSVLabelView(admin) {
         if (self.admin) {
             self.modalLabelId.html(labelMetadata['label_id']);
             self.modalTask.html("<a href='/admin/task/"+labelMetadata['audit_task_id']+"'>"+
-                labelMetadata['audit_task_id']+"</a> by <a href='/admin/user/" + labelMetadata['username'] + "'>" +
+                labelMetadata['audit_task_id']+"</a> by <a href='/admin/user/" + encodeURI(labelMetadata['username']) + "'>" +
                 labelMetadata['username'] + "</a>");
         }
     }

--- a/public/javascripts/Admin/src/Admin.User.js
+++ b/public/javascripts/Admin/src/Admin.User.js
@@ -37,8 +37,8 @@ function AdminUser(user) {
     var loadPolygons = $.getJSON('/neighborhoods');
     var loadPolygonRates = $.getJSON('/adminapi/neighborhoodCompletionRate');
     var loadMapParams = $.getJSON('/cityMapParams');
-    var loadAuditedStreets = $.getJSON('/adminapi/auditedStreets/' + user);
-    var loadSubmittedLabels = $.getJSON('/adminapi/labelLocations/' + user);
+    var loadAuditedStreets = $.getJSON('/adminapi/auditedStreets/' + encodeURI(user));
+    var loadSubmittedLabels = $.getJSON('/adminapi/labelLocations/' + encodeURI(user));
     // When the polygons, polygon rates, and map params are all loaded the polygon regions can be rendered.
     var renderPolygons = $.when(loadPolygons, loadPolygonRates, loadMapParams).done(function(data1, data2, data3) {
         map = Choropleth(_, $, 'null', params, layers, data1[0], data2[0], data3[0]);
@@ -55,7 +55,7 @@ function AdminUser(user) {
         setRegionFocus(map, layers)
     })
     
-    $.getJSON('/adminapi/tasks/' + user, function (data) {
+    $.getJSON('/adminapi/tasks/' + encodeURI(user), function (data) {
         var grouped = _.groupBy(data, function (o) { return o.audit_task_id});
         var auditTaskId;
         var auditTaskIds = Object.keys(grouped);

--- a/public/javascripts/SVLabel/src/SVLabel/status/StatusFieldNeighborhood.js
+++ b/public/javascripts/SVLabel/src/SVLabel/status/StatusFieldNeighborhood.js
@@ -14,7 +14,7 @@ function StatusFieldNeighborhood (neighborhoodModel, statusModel, userModel, uiS
 
         var user = self._userModel.getUser();
         if (user && user.getProperty("role") != "Anonymous") {
-            var href = "/contribution/" + user.getProperty("username") + "?regionId=" + newNeighborhood.getProperty("regionId");
+            var href = "/contribution/" + encodeURI(user.getProperty("username")) + "?regionId=" + newNeighborhood.getProperty("regionId");
             self.setHref(href);
         }
     });


### PR DESCRIPTION
Fixes #2389 

Fixes the issue of spaces in usernames leading to issues by making sure that anytime a username is used in a URL in JavaScript, it is encoded using `encodeURI()`.