### PR TITLE
Removes deleted or tutorial labels from some counts/maps

### DIFF
--- a/app/models/audit/AuditTaskTable.scala
+++ b/app/models/audit/AuditTaskTable.scala
@@ -103,7 +103,6 @@ object AuditTaskTable {
 
   val db = play.api.db.slick.DB
   val auditTasks = TableQuery[AuditTaskTable]
-  val labels = TableQuery[LabelTable]
   val labelTypes = TableQuery[LabelTypeTable]
   val streetEdges = TableQuery[StreetEdgeTable]
   val streetEdgePriorities = TableQuery[StreetEdgePriorityTable]
@@ -250,8 +249,7 @@ object AuditTaskTable {
     } yield (_users.userId, _users.username, _tasks.auditTaskId, _tasks.streetEdgeId, _tasks.taskStart, _tasks.taskEnd)
 
     val userTaskLabels = for {
-      (_userTasks, _labels) <- userTasks.leftJoin(labels).on(_._3 === _.auditTaskId)
-      if _labels.deleted === false
+      (_userTasks, _labels) <- userTasks.leftJoin(LabelTable.labelsWithoutDeletedOrOnboarding).on(_._3 === _.auditTaskId)
     } yield (_userTasks._1, _userTasks._2, _userTasks._3, _userTasks._4, _userTasks._5, _userTasks._6, _labels.labelId.?, _labels.temporaryLabelId, _labels.labelTypeId.?)
 
     val tasksWithLabels = for {

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -259,7 +259,7 @@ object LabelTable {
   def countLabelsByUserId(userId: UUID): Int = db.withSession { implicit session =>
     val tasks = auditTasks.filter(_.userId === userId.toString)
     val _labels = for {
-      (_tasks, _labels) <- tasks.innerJoin(labelsWithoutDeleted).on(_.auditTaskId === _.auditTaskId)
+      (_tasks, _labels) <- tasks.innerJoin(labelsWithoutDeletedOrOnboarding).on(_.auditTaskId === _.auditTaskId)
     } yield _labels
     _labels.length.run
   }
@@ -434,6 +434,7 @@ object LabelTable {
         |			) AS lb_big
         |WHERE u.user_id = ?
         |      AND lb1.deleted = FALSE
+        |      AND lb1.tutorial = FALSE
         |      AND lb1.gsv_panorama_id = gsv_data.gsv_panorama_id
         |      AND lb1.audit_task_id = at.audit_task_id
         |      AND lb1.label_id = lb_big.label_id
@@ -927,7 +928,7 @@ object LabelTable {
    */
   def selectLocationsOfLabelsByUserId(userId: UUID): List[LabelLocation] = db.withSession { implicit session =>
     val _labels = for {
-      ((_auditTasks, _labels), _labelTypes) <- auditTasks leftJoin labelsWithoutDeleted on(_.auditTaskId === _.auditTaskId) leftJoin labelTypes on (_._2.labelTypeId === _.labelTypeId)
+      ((_auditTasks, _labels), _labelTypes) <- auditTasks leftJoin labelsWithoutDeletedOrOnboarding on(_.auditTaskId === _.auditTaskId) leftJoin labelTypes on (_._2.labelTypeId === _.labelTypeId)
       if _auditTasks.userId === userId.toString
     } yield (_labels.labelId, _labels.auditTaskId, _labels.gsvPanoramaId, _labelTypes.labelType, _labels.panoramaLat, _labels.panoramaLng)
 

--- a/app/views/admin/user.scala.html
+++ b/app/views/admin/user.scala.html
@@ -115,7 +115,7 @@
                         <th class="col-xs-1">No Sidewalk</th>
                         <th class="col-xs-1">Other</th>
                     </tr></thead>
-                <tbody id="task-contribution-table" ></tbody>
+                <tbody id="task-contribution-table"></tbody>
             </table>
         </div>
 


### PR DESCRIPTION
Fixes #2380 

Makes some of the label counts on the admin pages more consistent by removing deleted and/or tutorial labels from them.