### PR TITLE
#2239 Add comment box to labelmap GSV popup

### DIFF
--- a/app/formats/json/CommentSubmissionFormats.scala
+++ b/app/formats/json/CommentSubmissionFormats.scala
@@ -12,6 +12,10 @@ object CommentSubmissionFormats {
                                          gsvPanoramaId: String, heading: Double, pitch: Double,
                                          zoom: Int, lat: Double, lng: Double)
 
+  case class LabelMapValidationCommentSubmission(labelId: Int, labelType: String, comment: String, 
+                                        gsvPanoramaId: String, heading: Double, pitch: Double, zoom: Int, 
+                                        lat: Double, lng: Double)
+
   implicit val commentSubmissionReads: Reads[CommentSubmission] = (
     (JsPath \ "audit_task_id").read[Int] and
       (JsPath \ "mission_id").read[Int] and
@@ -36,4 +40,16 @@ object CommentSubmissionFormats {
       (JsPath \ "lat").read[Double] and
       (JsPath \ "lng").read[Double]
   )(ValidationCommentSubmission.apply _)
+  
+  implicit val labelMapValidationCommentSubmissionReads : Reads[LabelMapValidationCommentSubmission] = (
+    (JsPath \ "label_id").read[Int] and
+      (JsPath \ "label_type").read[String] and
+      (JsPath \ "comment").read[String] and
+      (JsPath \ "gsv_panorama_id").read[String] and
+      (JsPath \ "heading").read[Double] and
+      (JsPath \ "pitch").read[Double] and
+      (JsPath \ "zoom").read[Int] and
+      (JsPath \ "lat").read[Double] and
+      (JsPath \ "lng").read[Double]
+  )(LabelMapValidationCommentSubmission.apply _)
 }

--- a/conf/routes
+++ b/conf/routes
@@ -103,7 +103,8 @@ POST    /task                                                @controllers.TaskCo
 POST    /taskBeacon                                          @controllers.TaskController.postBeacon
 POST    /validationTask                                      @controllers.ValidationTaskController.post
 POST    /validationTaskBeacon                                @controllers.ValidationTaskController.postBeacon
-POST    /validationLabelMap                                  @controllers.ValidationTaskController.postLabelMap
+POST    /labelmap/validate                                   @controllers.ValidationTaskController.postLabelMapValidation
+POST    /labelmap/comment                                    @controllers.ValidationTaskController.postLabelMapComment
 
 # Missions
 GET     /neighborhoodMissions                                @controllers.MissionController.getMissionsInCurrentRegion()

--- a/public/javascripts/Admin/src/Admin.GSVLabelView.js
+++ b/public/javascripts/Admin/src/Admin.GSVLabelView.js
@@ -128,6 +128,15 @@ function AdminGSVLabelView(admin) {
             _validateLabel("NotSure");
         });
 
+        self.commentButton = self.modal.find("#comment-submit-button");
+        self.commentTextArea = self.modal.find("#validation-label-comment");
+        self.commentButton.click(function() {
+            var comment = self.commentTextArea.val();
+            if (comment) {
+                _submitComment(comment);
+            }
+        });
+
         self.modalTitle = self.modal.find("#myModalLabel");
         self.modalTimestamp = self.modal.find("#timestamp");
         self.modalLabelTypeValue = self.modal.find("#label-type-value");
@@ -201,7 +210,7 @@ function AdminGSVLabelView(admin) {
         $.ajax({
             async: true,
             contentType: 'application/json; charset=utf-8',
-            url: "/validationLabelMap",
+            url: "/labelmap/validate",
             type: 'post',
             data: JSON.stringify(data),
             dataType: 'json',
@@ -210,6 +219,46 @@ function AdminGSVLabelView(admin) {
             },
             error: function (result) {
                 console.error(result);
+            }
+        });
+    }
+
+    /**
+     * Submit a comment as a POST request.
+     * @private
+     */
+    function _submitComment(comment) {
+        var userPov = self.panorama.panorama.getPov();
+        var zoom = self.panorama.panorama.getZoom();
+        var pos = self.panorama.panorama.getPosition();
+
+        let data = {
+            label_id: self.panorama.label.labelId,
+            label_type: self.panorama.label.label_type,
+            comment: comment,
+            gsv_panorama_id: self.panorama.panoId,
+            heading: userPov.heading,
+            pitch: userPov.pitch,
+            zoom: zoom,
+            lat: pos.lat(),
+            lng: pos.lng(),
+        };
+
+        // Submit the comment via POST request.
+        $.ajax({
+            async: true,
+            contentType: 'application/json; charset=utf-8',
+            url: "/labelmap/comment",
+            type: 'POST',
+            data: JSON.stringify(data),
+            dataType: 'json',
+            success: function (result) {
+                self.commentTextArea.val('');
+            },
+            error: function(xhr, textStatus, error){
+                console.error(xhr.statusText);
+                console.error(textStatus);
+                console.error(error);
             }
         });
     }

--- a/public/javascripts/Admin/src/Admin.GSVLabelView.js
+++ b/public/javascripts/Admin/src/Admin.GSVLabelView.js
@@ -43,7 +43,7 @@ function AdminGSVLabelView(admin) {
                         '<div id="validation-comment-holder">' +
                             '<textarea id="validation-label-comment" placeholder="' + i18next.t('label-map.add-comment') + '" class="validation-comment-box"></textarea>' +
                             '<button id="comment-submit-button" class="submit-button">' +
-                                'Submit' +
+                                i18next.t('label-map.submit') +
                             '</button>' +
                         '</div>' +
                         '<div class="modal-footer">' +

--- a/public/javascripts/Admin/src/Admin.GSVLabelView.js
+++ b/public/javascripts/Admin/src/Admin.GSVLabelView.js
@@ -41,8 +41,8 @@ function AdminGSVLabelView(admin) {
                             '</button>' +
                         '</div>' +
                         '<div id="validation-comment-holder">' +
-                            '<textarea id="validation-label-comment" placeholder="' + i18next.t('label-map.add-comment') + '" class="validation-comment-box"></textarea>' +
-                            '<button id="comment-submit-button" class="submit-button">' +
+                            '<textarea id="comment-textarea" placeholder="' + i18next.t('label-map.add-comment') + '" class="validation-comment-box"></textarea>' +
+                            '<button id="comment-button" class="submit-button">' +
                                 i18next.t('label-map.submit') +
                             '</button>' +
                         '</div>' +
@@ -128,8 +128,8 @@ function AdminGSVLabelView(admin) {
             _validateLabel("NotSure");
         });
 
-        self.commentButton = self.modal.find("#comment-submit-button");
-        self.commentTextArea = self.modal.find("#validation-label-comment");
+        self.commentButton = self.modal.find("#comment-button");
+        self.commentTextArea = self.modal.find("#comment-textarea");
         self.commentButton.click(function() {
             var comment = self.commentTextArea.val();
             if (comment) {

--- a/public/javascripts/Admin/src/Admin.GSVLabelView.js
+++ b/public/javascripts/Admin/src/Admin.GSVLabelView.js
@@ -25,22 +25,27 @@ function AdminGSVLabelView(admin) {
                         '<div class="modal-body">' +
                             '<div id="svholder" style="width: 540px; height:360px">' +
                         '</div>' +
+                        '<h3>Is this label correct?</h3>' +
                         '<div id="validation-button-holder">' +
-                            '<h3>Is this label correct?</h3>' +
                             '<button id="validation-agree-button" class="validation-button"' +
-                                'style="height: 50px; width: 179px; background-color: white; margin-right: 2px border-radius: 5px; border-width: 2px; border-color: lightgrey;">' +
+                                'style="height: 50px; width: 179px; background-color: white; margin-right: 2px; border-radius: 5px; border-width: 2px; border-color: lightgrey;">' +
                                 'Agree' +
                             '</button>' +
                             '<button id="validation-disagree-button" class="validation-button"' +
-                                'style="height: 50px; width: 179px; background-color: white; margin-right: 2px border-radius: 5px; border-width: 2px; border-color: lightgrey;">' +
+                                'style="height: 50px; width: 179px; background-color: white; margin-right: 2px; border-radius: 5px; border-width: 2px; border-color: lightgrey;">' +
                                 'Disagree' +
                             '</button>' +
                             '<button id="validation-not-sure-button" class="validation-button"' +
-                                'style="height: 50px; width: 179px; background-color: white; margin-right: 2px border-radius: 5px; border-width: 2px; border-color: lightgrey;">' +
+                                'style="height: 50px; width: 179px; background-color: white; margin-right: 2px; border-radius: 5px; border-width: 2px; border-color: lightgrey;">' +
                                 'Not sure' +
                             '</button>' +
                         '</div>' +
-                        '<textarea id="validation-label-comment" placeholder="' + i18next.t('label-map.add-comment') + '" class="validation-comment-box"></textarea>' +
+                        '<div id="validation-comment-holder">' +
+                            '<textarea id="validation-label-comment" placeholder="' + i18next.t('label-map.add-comment') + '" class="validation-comment-box"></textarea>' +
+                            '<button id="comment-submit-button" class="submit-button">' +
+                                'Submit' +
+                            '</button>' +
+                        '</div>' +
                         '<div class="modal-footer">' +
                             '<table class="table table-striped" style="font-size:small; margin-bottom: 0">' +
                                 '<tr>' +

--- a/public/javascripts/Admin/src/Admin.GSVLabelView.js
+++ b/public/javascripts/Admin/src/Admin.GSVLabelView.js
@@ -15,16 +15,16 @@ function AdminGSVLabelView(admin) {
 
     function _resetModal() {
         var modalText =
-            '<div class="modal fade" id="labelModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">'+
-                '<div class="modal-dialog" role="document" style="width: 570px">'+
-                    '<div class="modal-content">'+
-                        '<div class="modal-header">'+
-                            '<button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>'+
-                            '<h4 class="modal-title" id="myModalLabel"></h4>'+
-                        '</div>'+
-                        '<div class="modal-body">'+
-                            '<div id="svholder" style="width: 540px; height:360px">'+
-                        '</div>'+
+            '<div class="modal fade" id="labelModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">' +
+                '<div class="modal-dialog" role="document" style="width: 570px">' +
+                    '<div class="modal-content">' +
+                        '<div class="modal-header">' +
+                            '<button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>' +
+                            '<h4 class="modal-title" id="myModalLabel"></h4>' +
+                        '</div>' +
+                        '<div class="modal-body">' +
+                            '<div id="svholder" style="width: 540px; height:360px">' +
+                        '</div>' +
                         '<div id="validation-button-holder">' +
                             '<h3>Is this label correct?</h3>' +
                             '<button id="validation-agree-button" class="validation-button"' +
@@ -40,63 +40,64 @@ function AdminGSVLabelView(admin) {
                                 'Not sure' +
                             '</button>' +
                         '</div>' +
-                        '<div class="modal-footer">'+
-                            '<table class="table table-striped" style="font-size:small; margin-bottom: 0">'+
-                                '<tr>'+
-                                    '<th>Label Type</th>'+
-                                    '<td id="label-type-value"></td>'+
-                                '</tr>'+
+                        '<textarea id="validation-label-comment" placeholder="' + i18next.t('label-map.add-comment') + '" class="validation-comment-box"></textarea>' +
+                        '<div class="modal-footer">' +
+                            '<table class="table table-striped" style="font-size:small; margin-bottom: 0">' +
                                 '<tr>' +
-                                    '<th>Severity</th>'+
-                                    '<td id="severity"></td>'+
-                                '</tr>'+
+                                    '<th>Label Type</th>' +
+                                    '<td id="label-type-value"></td>' +
+                                '</tr>' +
                                 '<tr>' +
-                                    '<th>Temporary</th>'+
-                                    '<td id="temporary"></td>'+
-                                '</tr>'+
-                                '<tr>'+
-                                    '<th>Tags</th>'+
-                                    '<td colspan="3" id="tags"></td>'+
-                                '</tr>'+
-                                '<tr>'+
-                                    '<th>Description</th>'+
-                                    '<td colspan="3" id="label-description"></td>'+
-                                '</tr>'+
-                                '<tr>'+
-                                    '<th>Validations</th>'+
-                                    '<td colspan="3" id="label-validations"></td>'+
-                                '</tr>'+
-                                '<tr>'+
-                                    '<th>Time Submitted</th>'+
-                                    '<td id="timestamp" colspan="3"></td>'+
-                                '</tr>'+
-                                    '<th>Image Date</th>'+
-                                    '<td id="image-date" colspan="3"></td>'+
-            '                   </tr>'+
-                                '<tr>'+
+                                    '<th>Severity</th>' +
+                                    '<td id="severity"></td>' +
+                                '</tr>' +
+                                '<tr>' +
+                                    '<th>Temporary</th>' +
+                                    '<td id="temporary"></td>' +
+                                '</tr>' +
+                                '<tr>' +
+                                    '<th>Tags</th>' +
+                                    '<td colspan="3" id="tags"></td>' +
+                                '</tr>' +
+                                '<tr>' +
+                                    '<th>Description</th>' +
+                                    '<td colspan="3" id="label-description"></td>' +
+                                '</tr>' +
+                                '<tr>' +
+                                    '<th>Validations</th>' +
+                                    '<td colspan="3" id="label-validations"></td>' +
+                                '</tr>' +
+                                '<tr>' +
+                                    '<th>Time Submitted</th>' +
+                                    '<td id="timestamp" colspan="3"></td>' +
+                                '</tr>' +
+                                    '<th>Image Date</th>' +
+                                    '<td id="image-date" colspan="3"></td>' +
+                                '</tr>' +
+                                '<tr>' +
                                     '<th>Pano ID</th>' +
                                     '<td id="pano-id" colspan="3"></td>' +
                                 '</tr>';
         if (self.admin) {
             modalText +=
-                                '<tr>'+
-                                    '<th>Label ID</th>'+
-                                    '<td id="label-id" colspan="3"></td>'+
-                                '</tr>'+
-                                '<tr>'+
+                                '<tr>' +
+                                    '<th>Label ID</th>' +
+                                    '<td id="label-id" colspan="3"></td>' +
+                                '</tr>' +
+                                '<tr>' +
                                     '<th>Task ID</th>' +
                                     '<td id="task"></td>' +
-                                '</tr>'+
-                            '</table>'+
-                        '</div>'+
-                    '</div>'+
-                '</div>'+
+                                '</tr>' +
+                            '</table>' +
+                        '</div>' +
+                    '</div>' +
+                '</div>' +
                 '</div>'
         } else {
-            modalText += '</table>'+
-                '</div>'+
-                '</div>'+
-                '</div>'+
+            modalText += '</table>' +
+                '</div>' +
+                '</div>' +
+                '</div>' +
                 '</div>'
         }
         self.modal = $(modalText);

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -24,6 +24,7 @@
     "percent-complete": "{{percent}}% Complete"
   },
   "label-map": {
-    "add-comment": "Add comment here..."
+    "add-comment": "Add comment here...",
+    "submit": "Submit"
   }
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -25,6 +25,6 @@
   },
   "label-map": {
     "add-comment": "Add comment here...",
-    "submit": "Submit"
+    "submit": "Submit Comment"
   }
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -22,5 +22,8 @@
     "thanks": "Thanks for all your help!",
     "100-percent-complete": "100% Complete!",
     "percent-complete": "{{percent}}% Complete"
+  },
+  "label-map": {
+    "add-comment": "Add comment here..."
   }
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -25,6 +25,6 @@
   },
   "label-map": {
     "add-comment": "Add comment here...",
-    "submit": "Submit Comment"
+    "submit": "Submit comment"
   }
 }

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -25,6 +25,6 @@
   },
   "label-map": {
     "add-comment": "Agrega un comentario aquí...",
-    "submit": "Enviar"
+    "submit": "Enviar Comentario"
   }
 }

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -25,6 +25,6 @@
   },
   "label-map": {
     "add-comment": "Agrega un comentario aquí...",
-    "submit": "Enviar Comentario"
+    "submit": "Enviar comentario"
   }
 }

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -22,5 +22,8 @@
     "thanks": "¡Gracias por tu ayuda!",
     "100-percent-complete": "¡100% Completa!",
     "percent-complete": "{{percent}}% Completa"
+  },
+  "label-map": {
+    "add-comment": "Agrega un comentario aquí..."
   }
 }

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -24,6 +24,7 @@
     "percent-complete": "{{percent}}% Completa"
   },
   "label-map": {
-    "add-comment": "Agrega un comentario aquí..."
+    "add-comment": "Agrega un comentario aquí...",
+    "submit": "Enviar"
   }
 }

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -1225,11 +1225,20 @@ kbd {
     align-items: center;
 }
 
-.validation-comment-box {
+#validation-button-holder {
+    display: flex;
+    justify-content: space-between;
+}
+
+#validation-comment-holder {
+    padding-top: 5px;
+    padding-bottom: 5px;
+}
+
+#validation-label-comment {
     height: 33px;
-    width: 100%;
+    width: 453px;
     background-color: "#F5F5F5";
-    margin-top: 5px;
     color: black;
     border-radius: 5px;
     padding: 5px;
@@ -1238,6 +1247,19 @@ kbd {
     border-color: grey;
     resize: none;    
     outline: none;
+    vertical-align: middle;
+    margin-right: 2px;
+}
+
+#comment-submit-button {
+    height: 33px;
+    width: 80px;
+    background-color: white;
+    margin-right: 2px;
+    border-radius: 5px;
+    border-width: 2px;
+    border-color: lightgrey;
+    vertical-align: middle;
 }
 
 /*

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -1225,6 +1225,21 @@ kbd {
     align-items: center;
 }
 
+.validation-comment-box {
+    height: 33px;
+    width: 100%;
+    background-color: "#F5F5F5";
+    margin-top: 5px;
+    color: black;
+    border-radius: 5px;
+    padding: 5px;
+    line-height: normal;
+    border-width: 2px;
+    border-color: grey;
+    resize: none;    
+    outline: none;
+}
+
 /*
 * Hamburger Menu styling based on Bootstrap 3.3.5's collapsible navbar
 * https://bootstrapdocs.com/v3.3.5/docs/components/#navbar

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -1235,7 +1235,7 @@ kbd {
     padding-bottom: 5px;
 }
 
-#validation-label-comment {
+#comment-textarea {
     height: 33px;
     width: 453px;
     background-color: "#F5F5F5";
@@ -1251,7 +1251,7 @@ kbd {
     margin-right: 2px;
 }
 
-#comment-submit-button {
+#comment-button {
     height: 33px;
     width: 80px;
     background-color: white;

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -1237,7 +1237,7 @@ kbd {
 
 #comment-textarea {
     height: 33px;
-    width: 453px;
+    width: 395px;
     background-color: "#F5F5F5";
     color: black;
     border-radius: 5px;
@@ -1253,8 +1253,8 @@ kbd {
 
 #comment-button {
     height: 33px;
-    width: 80px;
-    background-color: white;
+    width: 138px;
+    background-color: #f9f9f9;
     margin-right: 2px;
     border-radius: 5px;
     border-width: 2px;


### PR DESCRIPTION
Resolves #2239 

This PR adds a comment box and submit button to the labelmap GSV popup for validation.

This is what it looks like:
<img width="1284" alt="Screen Shot 2020-12-03 at 12 45 17 PM" src="https://user-images.githubusercontent.com/43970567/101086654-0a428500-3566-11eb-8f1e-7846f084d020.png">

This is it working:
<img width="1323" alt="Screen Shot 2020-12-03 at 12 46 46 PM" src="https://user-images.githubusercontent.com/43970567/101086656-0adb1b80-3566-11eb-92dc-24e6e38d716f.png">
<img width="1226" alt="Screen Shot 2020-12-03 at 12 47 11 PM" src="https://user-images.githubusercontent.com/43970567/101086659-0b73b200-3566-11eb-8698-a7806e20dc0d.png">

Here is the Spanish version:
<img width="1316" alt="Screen Shot 2020-12-03 at 1 01 56 PM" src="https://user-images.githubusercontent.com/43970567/101096243-23eac900-3574-11eb-9b1f-ad5abc68af1d.png">
