### PR TITLE
2311 last login before user registered

### DIFF
--- a/app/models/daos/slick/UserDAOSlick.scala
+++ b/app/models/daos/slick/UserDAOSlick.scala
@@ -487,7 +487,7 @@ object UserDAOSlick {
     // Map(user_id: String -> (most_recent_sign_in_time: Option[Timestamp], sign_in_count: Int)).
     val signInTimesAndCounts =
       WebpageActivityTable.activities.filter(_.activity inSet List("AnonAutoSignUp", "SignIn"))
-        .groupBy(_.userId).map{ case (_userId, group) => (_userId, group.map(_.timestamp).min, group.length) }
+        .groupBy(_.userId).map{ case (_userId, group) => (_userId, group.map(_.timestamp).max, group.length) }
         .list.map{ case (_userId, _time, _count) => (_userId, (_time, _count)) }.toMap
 
     // Map(user_id: String -> mission_count: Int).
@@ -543,6 +543,9 @@ object UserDAOSlick {
         if (otherValidatedTotal == 0) 0f
         else otherValidatedAgreed * 1.0 / otherValidatedTotal
 
+      if (u.userId == "ccbb092e-d8ba-4717-959f-e35bd768aa2e") {
+        print(signUpTimes.get(u.userId))
+      }
       UserStatsForAdminPage(
         u.userId, u.username, u.email,
         roles.getOrElse(u.userId, ""),

--- a/app/models/daos/slick/UserDAOSlick.scala
+++ b/app/models/daos/slick/UserDAOSlick.scala
@@ -486,7 +486,7 @@ object UserDAOSlick {
 
     // Map(user_id: String -> (most_recent_sign_in_time: Option[Timestamp], sign_in_count: Int)).
     val signInTimesAndCounts =
-      WebpageActivityTable.activities.filter(_.activity inSet List("SignIn"))
+      WebpageActivityTable.activities.filter(_.activity inSet List("AnonAutoSignUp", "SignIn"))
         .groupBy(_.userId).map{ case (_userId, group) => (_userId, group.map(_.timestamp).max, group.length) }
         .list.map{ case (_userId, _time, _count) => (_userId, (_time, _count)) }.toMap
 

--- a/app/models/daos/slick/UserDAOSlick.scala
+++ b/app/models/daos/slick/UserDAOSlick.scala
@@ -543,9 +543,6 @@ object UserDAOSlick {
         if (otherValidatedTotal == 0) 0f
         else otherValidatedAgreed * 1.0 / otherValidatedTotal
 
-      if (u.userId == "ccbb092e-d8ba-4717-959f-e35bd768aa2e") {
-        print(signUpTimes.get(u.userId))
-      }
       UserStatsForAdminPage(
         u.userId, u.username, u.email,
         roles.getOrElse(u.userId, ""),

--- a/app/models/daos/slick/UserDAOSlick.scala
+++ b/app/models/daos/slick/UserDAOSlick.scala
@@ -486,7 +486,7 @@ object UserDAOSlick {
 
     // Map(user_id: String -> (most_recent_sign_in_time: Option[Timestamp], sign_in_count: Int)).
     val signInTimesAndCounts =
-      WebpageActivityTable.activities.filter(_.activity inSet List("AnonAutoSignUp", "SignIn"))
+      WebpageActivityTable.activities.filter(_.activity inSet List("SignIn"))
         .groupBy(_.userId).map{ case (_userId, group) => (_userId, group.map(_.timestamp).max, group.length) }
         .list.map{ case (_userId, _time, _count) => (_userId, (_time, _count)) }.toMap
 


### PR DESCRIPTION
Resolves #2311

**What I did**
Around line 490 in `app/models/daos/slick/UserDAOSlick.scala`, I changed `.min` to `.max`. The statement was taking the minimum sign in date, which would return the least recent date. `.max` returns the most recent date. 
I also removed `AnonAutoSignUp` when counting the logins because it would give us one extra login that was not really a login.
 
**Problem that arises**
Some users do not have a last login because I removed `AnonAutoSignUp`. This happens mostly for users who only signed in once. I think `SignIn` was not logged into the `WebpageActivityTable` because of issue #2361, so they do not have a `Last Login` value.
  