### PR TITLE
Shorten audit/explore mission lengths

### DIFF
--- a/app/models/mission/MissionTable.scala
+++ b/app/models/mission/MissionTable.scala
@@ -101,9 +101,9 @@ object MissionTable {
 
   val METERS_TO_MILES: Float = 0.000621371F
 
-  // Distances for first few missions: 500 ft, 500 ft, 750 ft, then 1,000 ft for all remaining.
-  val distancesForFirstAuditMissions: List[Float] = List(152.4F, 152.4F, 228.6F)
-  val distanceForLaterMissions: Float = 304.8F // 1,000 ft
+  // Distances for first few missions: 250 ft, 250 ft, then 500 ft for all remaining.
+  val distancesForFirstAuditMissions: List[Float] = List(76.2F, 76.2F)
+  val distanceForLaterMissions: Float = 152.4F // 500 ft
 
   // Number of labels for each type of validation mission
   val normalValidationMissionLength: Int = 10

--- a/public/javascripts/SVLabel/src/SVLabel/mission/MissionProgress.js
+++ b/public/javascripts/SVLabel/src/SVLabel/mission/MissionProgress.js
@@ -96,9 +96,9 @@ function MissionProgress (svl, gameEffectModel, missionModel, modalModel, neighb
 
         // Survey prompt. Modal should display survey if
         // 1. User has completed numMissionsBeforeSurvey number of missions
-        // 2. The user has just completed more than 30% of the current mission
+        // 2. The user has just completed more than 60% of the current mission
         // 3. The user has not been shown the survey before
-        if (completionRate > 0.3 && completionRate < 0.9) {
+        if (completionRate > 0.6 && completionRate < 0.9) {
             $.ajax({
                 async: true,
                 url: '/survey/display',

--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMission.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMission.js
@@ -221,17 +221,16 @@ function ModalMission (missionContainer, neighborhoodContainer, uiModalMission, 
 ModalMission.prototype._distanceToString = function  (distance, unit) {
     if (!unit) unit = "kilometers";
 
-    // Convert to miles and round to 4 decimal places.
-    if (unit === "feet") distance = util.math.feetToMiles(distance);
-    else if (unit === "meters") distance = util.math.metersToMiles(distance);
-    else if (unit === "kilometers") distance = util.math.kilometersToMiles(distance);
+    // Convert to meters.
+    if (unit === "feet") distance = util.math.feetToMeters(distance);
+    else if (unit === "miles") distance = util.math.milesToMeters(distance);
+    else if (unit === "kilometers") distance = util.math.kilometersToMeters(distance);
 
-    distance = distance.toPrecision(4);
     var distanceType = i18next.t('common:measurement-system');
     var unitAbbreviation = i18next.t('common:unit-abbreviation-mission-distance');
 
-    if (distanceType === "metric") return this.convertToMetric(distance * 5280, unitAbbreviation);
-    else return (util.math.milesToFeet(distance)).toFixed(0) + " " + unitAbbreviation;
+    if (distanceType === "metric") return util.math.roundToTwentyFive(distance) + " " + unitAbbreviation;
+    else return util.math.roundToTwentyFive(util.math.metersToFeet(distance)) + " " + unitAbbreviation;
 };
 
 ModalMission.prototype.isOpen = function () {

--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMission.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMission.js
@@ -230,19 +230,8 @@ ModalMission.prototype._distanceToString = function  (distance, unit) {
     var distanceType = i18next.t('common:measurement-system');
     var unitAbbreviation = i18next.t('common:unit-abbreviation-mission-distance');
 
-    if (distance === "0.0947"){
-        if (distanceType === "metric") return this.convertToMetric(500, unitAbbreviation);
-        else return "500 " + unitAbbreviation;
-    } else if (distance === "0.1420") {
-        if (distanceType === "metric") return this.convertToMetric(750, unitAbbreviation);
-        else return "750 " + unitAbbreviation;
-    } else if (distance === "0.1894") {
-        if (distanceType === "metric") return this.convertToMetric(1000, unitAbbreviation);
-        else return "1000 " + unitAbbreviation;
-    } else {
-        if (distanceType === "metric") return this.convertToMetric(distance * 5280, unitAbbreviation);
-        else return (util.math.milesToFeet(distance)).toFixed(0) + " " + unitAbbreviation;
-    }
+    if (distanceType === "metric") return this.convertToMetric(distance * 5280, unitAbbreviation);
+    else return (util.math.milesToFeet(distance)).toFixed(0) + " " + unitAbbreviation;
 };
 
 ModalMission.prototype.isOpen = function () {

--- a/public/javascripts/SVLabel/src/SVLabel/status/StatusFieldMission.js
+++ b/public/javascripts/SVLabel/src/SVLabel/status/StatusFieldMission.js
@@ -43,15 +43,14 @@ function StatusFieldMission (modalModel, uiStatusField) {
 StatusFieldMission.prototype._distanceToString = function (distance, unit) {
     if (!unit) unit = "kilometers";
 
-    // Convert to miles and round to 4 decimal places.
-    if (unit === "feet") distance = util.math.feetToMiles(distance);
-    else if (unit === "meters") distance = util.math.metersToMiles(distance);
-    else if (unit === "kilometers") distance = util.math.kilometersToMiles(distance);
+    // Convert to meters.
+    if (unit === "feet") distance = util.math.feetToMeters(distance);
+    else if (unit === "miles") distance = util.math.milesToMeters(distance);
+    else if (unit === "kilometers") distance = util.math.kilometersToMeters(distance);
 
-    distance = distance.toPrecision(4);
     var distanceType = i18next.t('common:measurement-system');
     var unitAbbreviation = i18next.t('common:unit-abbreviation-mission-distance');
 
-    if (distanceType === "metric") return this.convertToMetric(distance * 5280, unitAbbreviation);
-    else return (util.math.milesToFeet(distance)).toFixed(0) + " " + unitAbbreviation;
+    if (distanceType === "metric") return util.math.roundToTwentyFive(distance) + " " + unitAbbreviation;
+    else return util.math.roundToTwentyFive(util.math.metersToFeet(distance)) + " " + unitAbbreviation;
 };

--- a/public/javascripts/SVLabel/src/SVLabel/status/StatusFieldMission.js
+++ b/public/javascripts/SVLabel/src/SVLabel/status/StatusFieldMission.js
@@ -52,17 +52,6 @@ StatusFieldMission.prototype._distanceToString = function (distance, unit) {
     var distanceType = i18next.t('common:measurement-system');
     var unitAbbreviation = i18next.t('common:unit-abbreviation-mission-distance');
 
-    if (distance === "0.0947"){
-        if (distanceType === "metric") return this.convertToMetric(500, unitAbbreviation);
-        else return "500 " + unitAbbreviation;
-    } else if (distance === "0.1420") {
-        if (distanceType === "metric") return this.convertToMetric(750, unitAbbreviation);
-        else return "750 " + unitAbbreviation;
-    } else if (distance === "0.1894") {
-        if (distanceType === "metric") return this.convertToMetric(1000, unitAbbreviation);
-        else return "1000 " + unitAbbreviation;
-    } else {
-        if (distanceType === "metric") return this.convertToMetric(distance * 5280, unitAbbreviation);
-        else return (util.math.milesToFeet(distance)).toFixed(0) + " " + unitAbbreviation;
-    }
+    if (distanceType === "metric") return this.convertToMetric(distance * 5280, unitAbbreviation);
+    else return (util.math.milesToFeet(distance)).toFixed(0) + " " + unitAbbreviation;
 };

--- a/public/javascripts/common/UtilitiesMath.js
+++ b/public/javascripts/common/UtilitiesMath.js
@@ -137,6 +137,9 @@ function distance3d(a, b) {
 }
 util.math.distance3d = distance3d;
 
+function roundToTwentyFive(num) { return Math.round(num / 25) * 25; }
+util.math.roundToTwentyFive = roundToTwentyFive;
+
 function metersToMiles(dist) { return dist / 1609.34; }
 function metersToKilometers(dist) { return dist / 1000; }
 function metersToFeet(dist) { return dist * 3.28084; }


### PR DESCRIPTION
Resolves #2324 

Changes the sequence of mission lengths from 500 ft, 500ft, 750 ft, 1000 ft, ... to 250 ft, 250 ft, 500 ft, ... I also updated the code that displays the distances to end users to round to the nearest 25. So instead of saying 76 m, 76 m, 152 m, it will say 75 m, 75 m, 150 m. Nothing changes on the back end, just wanted to display nicer numbers to end users. Due to the shortening of mission lengths, I also made it so that the survey shows up near the end of the 2nd mission instead of near the beginning.