### PR TITLE
Improve label latlng estimation

### DIFF
--- a/conf/evolutions/default/98.sql
+++ b/conf/evolutions/default/98.sql
@@ -1,0 +1,31 @@
+# --- !Ups
+UPDATE label_point
+SET computation_method = 'approximation2',
+    geom = ST_Project(
+        ST_SetSRID(ST_Point(panorama_lng, panorama_lat), 4326),
+        20.8794248 + 0.0184087 * sv_image_y + 0.0022135 * canvas_y,
+        radians(heading -27.5267447 + 0.0784357 * canvas_x)
+        )::geometry
+FROM label
+WHERE label_point.label_id = label.label_id
+  AND computation_method <> 'depth';
+
+UPDATE label_point
+SET lat = ST_Y(geom),
+    lng = ST_X(geom)
+FROM label
+WHERE label_point.label_id = label.label_id
+  AND computation_method = 'approximation2';
+
+# --- !Downs
+UPDATE label_point
+SET computation_method = 'approximation1',
+    lat = panorama_lat + (10 * cos(radians(heading)) / 111111),
+    lng = panorama_lng + (10 * sin(radians(heading)) / (111111 * cos(radians(panorama_lat)))),
+    geom = ST_SetSRID( ST_Point(
+                                   panorama_lng + (10 * sin(radians(heading)) / (111111 * cos(radians(panorama_lat)))),
+                                   panorama_lat + (10 * cos(radians(heading)) / 111111)
+                           ), 4326)
+FROM label
+WHERE label_point.label_id = label.label_id
+  AND computation_method = 'approximation2';

--- a/conf/evolutions/default/98.sql
+++ b/conf/evolutions/default/98.sql
@@ -8,7 +8,7 @@ SET computation_method = 'approximation2',
         )::geometry
 FROM label
 WHERE label_point.label_id = label.label_id
-  AND computation_method <> 'depth';
+  AND (computation_method <> 'depth' OR computation_method IS NULL);
 
 UPDATE label_point
 SET lat = ST_Y(geom),

--- a/conf/evolutions/default/98.sql
+++ b/conf/evolutions/default/98.sql
@@ -3,7 +3,7 @@ UPDATE label_point
 SET computation_method = 'approximation2',
     geom = ST_Project(
         ST_SetSRID(ST_Point(panorama_lng, panorama_lat), 4326),
-        20.8794248 + 0.0184087 * sv_image_y + 0.0022135 * canvas_y,
+        GREATEST(0.0, 20.8794248 + 0.0184087 * sv_image_y + 0.0022135 * canvas_y),
         radians(heading -27.5267447 + 0.0784357 * canvas_x)
         )::geometry
 FROM label

--- a/public/javascripts/SVLabel/src/SVLabel/label/Label.js
+++ b/public/javascripts/SVLabel/src/SVLabel/label/Label.js
@@ -12,6 +12,10 @@ function Label (svl, pathIn, params) {
 
     var path, googleMarker;
 
+    // Parameters determined from a series of linear regressions. Here links to the analysis and relevant Github issues:
+    // https://github.com/ProjectSidewalk/label-latlng-estimation/blob/master/scripts/label-latlng-estimation.md#results
+    // https://github.com/ProjectSidewalk/SidewalkWebpage/issues/2374
+    // https://github.com/ProjectSidewalk/SidewalkWebpage/issues/2362
     var LATLNG_ESTIMATION_PARAMS = {
         1: {
             headingIntercept: -51.2401711,
@@ -883,9 +887,9 @@ function Label (svl, pathIn, params) {
                 return latlng;
             } else {
                 // Estimate the latlng point from the camera position and the heading angle when the point cloud data is not available.
-                var cameraLat = getProperty("panoramaLat");
-                var cameraLng = getProperty("panoramaLng");
-                var cameraHeading = getProperty("panoramaHeading");
+                var panoLat = getProperty("panoramaLat");
+                var panoLng = getProperty("panoramaLng");
+                var panoHeading = getProperty("panoramaHeading");
                 var zoom = getProperty("panoramaZoom");
                 var canvasX = getPath().getPoints()[0].originalCanvasCoordinate.x;
                 var canvasY = getPath().getPoints()[0].originalCanvasCoordinate.y;
@@ -893,14 +897,19 @@ function Label (svl, pathIn, params) {
 
                 // Estimate heading diff and distance from pano using output from a regression analysis.
                 // https://github.com/ProjectSidewalk/label-latlng-estimation/blob/master/scripts/label-latlng-estimation.md#results
-                var estHeadingDiff = LATLNG_ESTIMATION_PARAMS[zoom].headingIntercept +
+                var estHeadingDiff =
+                    LATLNG_ESTIMATION_PARAMS[zoom].headingIntercept +
                     LATLNG_ESTIMATION_PARAMS[zoom].headingCanvasXSlope * canvasX;
-                var estDistanceFromPano = Math.max(0,
+                var estDistanceFromPanoKm = Math.max(0,
                     LATLNG_ESTIMATION_PARAMS[zoom].distanceIntercept +
                     LATLNG_ESTIMATION_PARAMS[zoom].distanceSvImageYSlope * svImageY +
                     LATLNG_ESTIMATION_PARAMS[zoom].distanceCanvasYSlope * canvasY
                 ) / 1000.0;
-                var destination = turf.destination(turf.point([cameraLng, cameraLat]), estDistanceFromPano, cameraHeading + estHeadingDiff, {units: 'kilometers'});
+                var estHeading = panoHeading + estHeadingDiff;
+                var startPoint = turf.point([panoLng, panoLat]);
+
+                // Use the pano location, distance from pano estimate, and heading estimate, calculate label location.
+                var destination = turf.destination(startPoint, estDistanceFromPanoKm, estHeading, {units: 'kilometers'});
                 var latlng = {
                     lat: destination.geometry.coordinates[1],
                     lng: destination.geometry.coordinates[0],


### PR DESCRIPTION
Resolves #2374 

Improves our estimation of lat/lng for labels placed through the explore page. I ran some linear regressions to create predictors for the distance from the panorama and the heading, and now we use those predicted values to calculate lat/lng of a label, given `pano_lat`, `pano_lng`, `heading`, `zoom`, `canvas_x`, `canvas_y`, and `sv_image_y`. More information on the regression analysis can be found [here](https://github.com/ProjectSidewalk/label-latlng-estimation/blob/master/scripts/label-latlng-estimation.md#overview).

Before at any zoom level (note on mini map that they all collapse to one spot):
![Screenshot from 2021-01-13 13-36-10](https://user-images.githubusercontent.com/6518824/104513340-5ab8f380-55a4-11eb-88ff-8ee7574225fd.png)

After at zoom level 1:
![Screenshot from 2021-01-13 12-49-18](https://user-images.githubusercontent.com/6518824/104513406-745a3b00-55a4-11eb-90c8-a7dfc9a49ba8.png)

After at zoom level 3 (as expected, the predicted change in heading has a smaller range):
![Screenshot from 2021-01-13 12-50-15](https://user-images.githubusercontent.com/6518824/104513419-78865880-55a4-11eb-8776-b8d299fe67c1.png)

After at zoom level 1, with the camera angled downward (note that the labels are predicted to be closer, as expected):
![Screenshot from 2021-01-13 12-51-14](https://user-images.githubusercontent.com/6518824/104513448-89cf6500-55a4-11eb-85e2-d89714963746.png)

Now here is a real world scenario...
Before:
![Screenshot from 2021-01-13 13-26-04](https://user-images.githubusercontent.com/6518824/104513590-b84d4000-55a4-11eb-899f-97be2467173e.png)

After. You'll see that you can differentiate between the curb ramps on a corner, and the no sidewalk labels are correctly considered to be further away than the curb ramp labels. Note that the issues with the lower labels looking like they are on the street have more to do with the slight discrepancy between Google Maps and the OSM road network:
![Screenshot from 2021-01-13 13-26-28](https://user-images.githubusercontent.com/6518824/104513698-e599ee00-55a4-11eb-9b27-cb603ebc907a.png)

