### PR TITLE
#2402: Press link broken on landing page - I replaced the broken URL to the new URL, for both image and the text. 

### DIFF
--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -245,7 +245,7 @@
                 </a>
             </div>
             <div class="col-sm-4">
-                <a class="newslink" href="http://www.dbknews.com/2016/10/14/university-of-maryland-app-washington-disability-access/" id="diamondback-img-link">
+                <a class="newslink" href="https://dbknews.com/2016/10/13/university-of-maryland-app-washington-disability-access/" id="diamondback-img-link">
                     <img src='@routes.Assets.at("assets/diamondback.png")' height="70" alt="Diamondback Logo">
                 </a>
             </div>
@@ -262,7 +262,7 @@
                 </a>
             </div>
             <div class="col-sm-4">
-                <a class="newslink" href="http://www.dbknews.com/2016/10/14/university-of-maryland-app-washington-disability-access/" id="diamondback-text-link">
+                <a class="newslink" href="https://dbknews.com/2016/10/13/university-of-maryland-app-washington-disability-access/" id="diamondback-text-link">
                     A UMD team made an app highlighting D.C. areas inaccessible to people with disabilities
                 </a>
             </div>


### PR DESCRIPTION
Resolves #2402 

Replaced the link to the article in The Diamondback, as it was broken, to the new one. Made sure the new link was attached both for image and the text, tested it on Chrome using localhost. 

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've made sure my code and comments follow the [style guide](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Style-Guide).
- [x] I've tested on multiple browsers.
- [x] I've verified that this PR is set to merge into the develop branch.
- [x] I've written a descriptive PR title.
