### PR TITLE
#2384 Reduce size of vertical footer on landing page

### DIFF
--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -74,7 +74,7 @@
     <div class="filler" style="position:relative;top: 0px;background-color:#fff; min-height:50px;"></div>
 
     <div class="container" id="footer-container">
-        <div class="row" style="padding-top: 50px; width: 900px; position:relative; left:80px;">
+        <div class="row" style="width: 900px; position:relative; left:80px;">
             <div class="col-sm-4 footerlink">
                 <span class="footerheader">PROJECT SIDEWALK</span><br/>
                 <!-- Back to top<br>-->

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -765,8 +765,7 @@ p#conditional-text {
 #info-footer {
     position: relative;
     width: 100%;
-    min-height: 250px;
-    padding-top: 30px;
+    min-height: 220px;
     background-color: rgba(45, 42, 63, 1);
     text-align: center;
     font-family: raleway;

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -731,7 +731,9 @@ p#conditional-text {
     top: 00px;
     width: 100%;
     background-image: url(../assets/footer.jpg);
-    min-height: 300px;
+    min-height: 200px;
+    padding-top: 50px;
+    padding-bottom: 50px;
     background-attachment: fixed;
     background-position: center;
     background-repeat: no-repeat;


### PR DESCRIPTION
Resolves #2384

The footer was too tall before with some empty space after it. I made it shorter and have consistent vertical padding of 50px. This only affects css by id, so it shouldn't have any affect on other code and it's static.

##### Before/After screenshots <!-- delete if not applicable -->
before (header height is large):
<img width="1217" alt="Screen Shot 2021-02-01 at 2 11 16 PM" src="https://user-images.githubusercontent.com/45296521/106524406-c275a680-649f-11eb-87b4-dd8ad60210bc.png">

after (smaller header height):
<img width="1412" alt="Screen Shot 2021-02-01 at 12 44 50 PM" src="https://user-images.githubusercontent.com/45296521/106524114-598e2e80-649f-11eb-8729-7389d9b18607.png">

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [check] If there is a visual design component, I've posted before/after screenshots on the relevant issue thread and have been given a thumbs up on my design.
- [check] I've added/modified comments for large or confusing blocks of code.
- [check] I've made sure my code and comments follow the [style guide](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Style-Guide).
- [firefox, chrome, safari] I've tested on multiple browsers.
- [check] I've verified that this PR is set to merge into the develop branch.
- [check] I've written a descriptive PR title.

##### Testing instructions
1. Go to landing page and scroll down to see footer size modified
