### PR TITLE
#2428 Fixes hidden legend on results map

### DIFF
--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -413,7 +413,8 @@
                     <div class="row">
                         <div class="col-lg-12">
                             <div id="map-holder">
-                                <div id="legend" style="display:none;">
+                                <div id="admin-choropleth"></div>
+                                <div id="admin-percentage-legend">
                                     <strong>Percent of Neighborhood Complete</strong>
                                     <nav class='legend clearfix'>
                                         <span style='background:#03152f;width:9.09%'></span>
@@ -432,7 +433,6 @@
                                         <label style='width:3%'>0%</label>
                                     </nav>
                                 </div>
-                                <div id="admin-choropleth"></div>
                             </div>
                         </div>
 
@@ -801,6 +801,7 @@
 
     </div>
     <link href='@routes.Assets.at("stylesheets/dataTables.bootstrap.min.css")' rel="stylesheet"/>
+    <link href='@routes.Assets.at("stylesheets/choropleth.css")' rel="stylesheet"/>
     <link rel="stylesheet" href="//code.jquery.com/ui/1.12.1/themes/smoothness/jquery-ui.css">
     <link href='@routes.Assets.at("stylesheets/admin.css")' rel="stylesheet"/>
 

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -428,7 +428,7 @@
                                         <span style='background:#9ecae1;width:9.09%'></span>
                                        <span style='background:#b3d3e8;width:9.09%'></span>
                                         <span style='background:#c6dbef;width:9.09%'></span>
-                                         <div id="landing-legend-percentages-container">
+                                         <div id="legend-percentages-container">
                                             <label style='text-align: left'>0%</label>
                                             <label style='text-align: right'>100%</label>
                                         </div>

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -426,7 +426,7 @@
                                         <span style='background:#6baed6;width:9.09%'></span>
                                         <span style='background:#82badb;width:9.09%'></span>
                                         <span style='background:#9ecae1;width:9.09%'></span>
-                                       <span style='background:#b3d3e8;width:9.09%'></span>
+                                        <span style='background:#b3d3e8;width:9.09%'></span>
                                         <span style='background:#c6dbef;width:9.09%'></span>
                                          <div id="legend-percentages-container">
                                             <label style='text-align: left'>0%</label>

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -426,11 +426,12 @@
                                         <span style='background:#6baed6;width:9.09%'></span>
                                         <span style='background:#82badb;width:9.09%'></span>
                                         <span style='background:#9ecae1;width:9.09%'></span>
-                                        <span style='background:#b3d3e8;width:9.09%'></span>
+                                       <span style='background:#b3d3e8;width:9.09%'></span>
                                         <span style='background:#c6dbef;width:9.09%'></span>
-                                        <label style='width:5%'>100%</label>
-                                        <label style='width:92%'></label>
-                                        <label style='width:3%'>0%</label>
+                                         <div id="landing-legend-percentages-container">
+                                            <label style='text-align: left'>0%</label>
+                                            <label style='text-align: right'>100%</label>
+                                        </div>
                                     </nav>
                                 </div>
                             </div>

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -102,17 +102,19 @@
             <div id="landing-legend">
                 <strong style="font-size: 18px">@Messages("landing.choropleth.legend")</strong>
                 <nav class='legend clearfix'>
-                    <span style='background:#03152f;width:9.09%'></span>
-                    <span style='background:#08306b;width:9.09%'></span>
-                    <span style='background:#08519c;width:9.09%'></span>
-                    <span style='background:#08719c;width:9.09%'></span>
-                    <span style='background:#2171b5;width:9.09%'></span>
-                    <span style='background:#4292c6;width:9.09%'></span>
-                    <span style='background:#6baed6;width:9.09%'></span>
-                    <span style='background:#82badb;width:9.09%'></span>
-                    <span style='background:#9ecae1;width:9.09%'></span>
-                    <span style='background:#b3d3e8;width:9.09%'></span>
-                    <span style='background:#c6dbef;width:9.09%'></span>
+                    <div style='width:100%;padding:0;'>
+                        <span style='background:#03152f;width:9.09%'></span>
+                        <span style='background:#08306b;width:9.09%'></span>
+                        <span style='background:#08519c;width:9.09%'></span>
+                        <span style='background:#08719c;width:9.09%'></span>
+                        <span style='background:#2171b5;width:9.09%'></span>
+                        <span style='background:#4292c6;width:9.09%'></span>
+                        <span style='background:#6baed6;width:9.09%'></span>
+                        <span style='background:#82badb;width:9.09%'></span>
+                        <span style='background:#9ecae1;width:9.09%'></span>
+                        <span style='background:#b3d3e8;width:9.09%'></span>
+                        <span style='background:#c6dbef;width:9.09%'></span>
+                    </div>
                     <div id='landing-legend-percentages-container'>
                         <label>0%</label>
                         <label>100%</label>

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -115,7 +115,7 @@
                         <span style='background:#b3d3e8;width:9.09%'></span>
                         <span style='background:#c6dbef;width:9.09%'></span>
                     </div>
-                    <div id='landing-legend-percentages-container'>
+                    <div id='legend-percentages-container'>
                         <label>0%</label>
                         <label>100%</label>
                     </div>

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -98,7 +98,8 @@
         </div>
         <br>
         <div id="map-holder">
-            <div id="legend" style="display:none;">
+            <div id="choropleth"></div>
+            <div id="landing-legend">
                 <strong style="font-size: 18px">@Messages("landing.choropleth.legend")</strong>
                 <nav class='legend clearfix'>
                     <span style='background:#03152f;width:9.09%'></span>
@@ -117,7 +118,6 @@
                     <label style='width:2%'>0%</label>
                 </nav>
             </div>
-            <div id="choropleth"></div>
         </div>
     </div>
     <div class="ps-skyline">

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -113,9 +113,10 @@
                     <span style='background:#9ecae1;width:9.09%'></span>
                     <span style='background:#b3d3e8;width:9.09%'></span>
                     <span style='background:#c6dbef;width:9.09%'></span>
-                    <label style='width:8%'>100%</label>
-                    <label style='width:90%'></label>
-                    <label style='width:2%'>0%</label>
+                    <div id='landing-legend-percentages-container'>
+                        <label>0%</label>
+                        <label>100%</label>
+                    </div>
                 </nav>
             </div>
         </div>

--- a/app/views/results.scala.html
+++ b/app/views/results.scala.html
@@ -8,7 +8,8 @@
     <div class="container" id="results-choropleth-container" style="width: 100%;
         position: relative;">
         <div id="map-holder">
-            <div id="legend">
+            <div id="choropleth"></div>
+            <div id="legend" style="display: none">
                 <strong style="font-size: 18px">@Messages("results.problems.per.mile")</strong>
                 <nav class='legend clearfix'>
                     <span style='background:#99000a;'></span>
@@ -35,7 +36,6 @@
                 <div>
                     <p style="font-size: 11px;margin-top: 7px;line-height: 14px;">@Messages("results.legend.body")</div>
             </div>
-            <div id="choropleth"></div>
             <div id="page-loading">
                 <div id="loading-gif">
                     <p class="loading-text">@Messages("loading")</p>
@@ -47,7 +47,6 @@
             </div>
         </div>
     </div>
-
 
 <script src='https://api.mapbox.com/mapbox.js/v3.1.1/mapbox.js'></script>
 <link href='https://api.mapbox.com/mapbox.js/v3.1.1/mapbox.css' rel='stylesheet' />

--- a/app/views/results.scala.html
+++ b/app/views/results.scala.html
@@ -22,7 +22,7 @@
                     <span style='background:#ff6670;'></span>
                     <span style='background:#ff8088;'></span>
                     <span style='background:#ff99a0;'></span>
-                    <div id="landing-legend-percentages-container">
+                    <div id="legend-percentages-container">
                         <label style='font-size: 14px;'>@Messages("results.legend.low")</label>
                         <label style='font-size: 14px; text-align: right;'>@Messages("results.legend.high")</label>
                     </div>

--- a/app/views/results.scala.html
+++ b/app/views/results.scala.html
@@ -9,7 +9,7 @@
         position: relative;">
         <div id="map-holder">
             <div id="choropleth"></div>
-            <div id="legend" style="display: none">
+            <div id="results-legend" style="display: none">
                 <strong style="font-size: 18px">@Messages("results.problems.per.mile")</strong>
                 <nav class='legend clearfix'>
                     <span style='background:#99000a;'></span>

--- a/app/views/results.scala.html
+++ b/app/views/results.scala.html
@@ -8,7 +8,7 @@
     <div class="container" id="results-choropleth-container" style="width: 100%;
         position: relative;">
         <div id="map-holder">
-            <div id="legend" style="display:none;">
+            <div id="legend">
                 <strong style="font-size: 18px">@Messages("results.problems.per.mile")</strong>
                 <nav class='legend clearfix'>
                     <span style='background:#99000a;'></span>

--- a/app/views/results.scala.html
+++ b/app/views/results.scala.html
@@ -22,16 +22,10 @@
                     <span style='background:#ff6670;'></span>
                     <span style='background:#ff8088;'></span>
                     <span style='background:#ff99a0;'></span>
-                    <label style='font-size: 14px; text-align: right;'>@Messages("results.legend.high")</label>
-                    <label></label>
-                    <label></label>
-                    <label></label>
-                    <label></label>
-                    <label></label>
-                    <label></label>
-                    <label></label>
-                    <label></label>
-                    <label style='font-size: 14px;'>@Messages("results.legend.low")</label>
+                    <div id="landing-legend-percentages-container">
+                        <label style='font-size: 14px;'>@Messages("results.legend.low")</label>
+                        <label style='font-size: 14px; text-align: right;'>@Messages("results.legend.high")</label>
+                    </div>
                 </nav>
                 <div>
                     <p style="font-size: 11px;margin-top: 7px;line-height: 14px;">@Messages("results.legend.body")</div>

--- a/public/javascripts/Choropleths/Choropleth.js
+++ b/public/javascripts/Choropleths/Choropleth.js
@@ -330,6 +330,7 @@ function Choropleth(_, $, difficultRegionIds, params, layers, polygonData, polyg
             initializeChoroplethNeighborhoodPolygons(choropleth, data, layers, labelData);
         }
         $('#page-loading').hide();
+        $('#legend').show();
     }
 
     // Makes POST request that logs `activity` in WebpageActivityTable.

--- a/public/javascripts/Choropleths/Choropleth.js
+++ b/public/javascripts/Choropleths/Choropleth.js
@@ -330,7 +330,7 @@ function Choropleth(_, $, difficultRegionIds, params, layers, polygonData, polyg
             initializeChoroplethNeighborhoodPolygons(choropleth, data, layers, labelData);
         }
         $('#page-loading').hide();
-        $('#legend').show();
+        $('#results-legend').show();
     }
 
     // Makes POST request that logs `activity` in WebpageActivityTable.

--- a/public/stylesheets/choropleth.css
+++ b/public/stylesheets/choropleth.css
@@ -46,7 +46,7 @@
     background: rgb(255, 255, 255);
     width: 325px;
     font-family: 'Raleway', sans-serif;
-    padding: 6px 6px 0px 6px;
+    padding: 6px 20px 0px 6px;
 }
 
 #admin-percentage-legend {
@@ -57,7 +57,7 @@
     background: rgb(255, 255, 255);;
     width: 325px;
     font-family: 'Raleway', sans-serif;
-    padding: 6px 6px 0px 6px;
+    padding: 6px 20px 0px 6px;
 }
 
 .legend label,

--- a/public/stylesheets/choropleth.css
+++ b/public/stylesheets/choropleth.css
@@ -27,6 +27,17 @@
     word-wrap: break-word;
 }
 
+#legend {
+    display: block;
+    position: absolute;
+    right: 20px;
+    top: 10px;
+    background: rgb(255, 255, 255);
+    width: 350px;
+    font-family: 'Raleway', sans-serif;
+    padding: 10px;
+}
+
 .legend label,
 .legend span {
     display:block;
@@ -36,6 +47,10 @@
     text-align:left;
     font-size:16px;
     color:#808080;
+}
+
+.clearfix {
+    width: 100%;
 }
 
 .map-legends.wax-legends {

--- a/public/stylesheets/choropleth.css
+++ b/public/stylesheets/choropleth.css
@@ -30,12 +30,12 @@
 #legend {
     display: block;
     position: absolute;
-    right: 20px;
+    right: 26px;
     top: 10px;
     background: rgb(255, 255, 255);
     width: 375px;
     font-family: 'Raleway', sans-serif;
-    padding: 10px;
+    padding: 10px 10px 0px 10px;
 }
 
 .legend label,

--- a/public/stylesheets/choropleth.css
+++ b/public/stylesheets/choropleth.css
@@ -79,10 +79,14 @@
     color:#808080;
 }
 
-#landing-legend-percentages-container {
+#legend-percentages-container {
     width: 100%;
     display: flex;
     justify-content: space-between;
+}
+
+#legend-percentages-container label {
+    padding: 0;
 }
 
 

--- a/public/stylesheets/choropleth.css
+++ b/public/stylesheets/choropleth.css
@@ -33,7 +33,7 @@
     right: 20px;
     top: 10px;
     background: rgb(255, 255, 255);
-    width: 350px;
+    width: 375px;
     font-family: 'Raleway', sans-serif;
     padding: 10px;
 }

--- a/public/stylesheets/choropleth.css
+++ b/public/stylesheets/choropleth.css
@@ -60,12 +60,20 @@
     padding: 6px 6px 0px 6px;
 }
 
-.legend label,
 .legend span {
     display:block;
     float:right;
     height:15px;
-    width:10%;
+    width: 10%;
+    text-align:left;
+    font-size:16px;
+    color:#808080;
+}
+
+.legend label {
+    display:block;
+    float:right;
+    height:15px;
     text-align:left;
     font-size:16px;
     color:#808080;
@@ -75,7 +83,6 @@
     width: 100%;
     display: flex;
     justify-content: space-between;
-
 }
 
 

--- a/public/stylesheets/choropleth.css
+++ b/public/stylesheets/choropleth.css
@@ -46,7 +46,7 @@
     background: rgb(255, 255, 255);
     width: 325px;
     font-family: 'Raleway', sans-serif;
-    padding: 6px 20px 0px 6px;
+    padding: 8px 8px 0px 8px;
 }
 
 #admin-percentage-legend {
@@ -57,7 +57,7 @@
     background: rgb(255, 255, 255);;
     width: 325px;
     font-family: 'Raleway', sans-serif;
-    padding: 6px 10px 0px 6px;
+    padding: 6px 6px 0px 6px;
 }
 
 .legend label,
@@ -70,6 +70,14 @@
     font-size:16px;
     color:#808080;
 }
+
+#landing-legend-percentages-container {
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+
+}
+
 
 .clearfix {
     width: 100%;

--- a/public/stylesheets/choropleth.css
+++ b/public/stylesheets/choropleth.css
@@ -41,7 +41,7 @@
 #landing-legend {
     display: block;
     position: absolute;
-    left: 10px;
+    left: 30px;
     bottom: 10px;
     background: rgb(255, 255, 255);
     width: 325px;

--- a/public/stylesheets/choropleth.css
+++ b/public/stylesheets/choropleth.css
@@ -57,7 +57,7 @@
     background: rgb(255, 255, 255);;
     width: 325px;
     font-family: 'Raleway', sans-serif;
-    padding: 6px 20px 0px 6px;
+    padding: 6px 10px 0px 6px;
 }
 
 .legend label,

--- a/public/stylesheets/choropleth.css
+++ b/public/stylesheets/choropleth.css
@@ -27,7 +27,7 @@
     word-wrap: break-word;
 }
 
-#legend {
+#results-legend {
     display: block;
     position: absolute;
     right: 26px;
@@ -36,6 +36,28 @@
     width: 375px;
     font-family: 'Raleway', sans-serif;
     padding: 10px 10px 0px 10px;
+}
+
+#landing-legend {
+    display: block;
+    position: absolute;
+    left: 10px;
+    bottom: 10px;
+    background: rgb(255, 255, 255);
+    width: 325px;
+    font-family: 'Raleway', sans-serif;
+    padding: 6px 6px 0px 6px;
+}
+
+#admin-percentage-legend {
+    display: block;
+    position: absolute;
+    left: 30px;
+    bottom: 10px;
+    background: rgb(255, 255, 255);;
+    width: 325px;
+    font-family: 'Raleway', sans-serif;
+    padding: 6px 6px 0px 6px;
 }
 
 .legend label,


### PR DESCRIPTION
Resolves #2428

Super quick fix for the hidden results legend. The legend mistakenly had a css attribute "display: none" that was causing it to be hidden. I removed the inline css and it shows back up when I log in as a normal user or an anonymous user.

##### Before/After screenshots <!-- delete if not applicable -->
before
<img width="1136" alt="Screen Shot 2021-02-04 at 12 24 47 PM" src="https://user-images.githubusercontent.com/45296521/106950975-681d5580-66ec-11eb-9b11-e428125c462d.png">
after
<img width="1197" alt="Screen Shot 2021-02-04 at 12 20 18 PM" src="https://user-images.githubusercontent.com/45296521/106950982-6b184600-66ec-11eb-9bcd-055c90b03cda.png">

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [no design issue] If there is a visual design component, I've posted before/after screenshots on the relevant issue thread and have been given a thumbs up on my design.
- [should already be translated] I've asked for and added translations for any user facing text that was added or modified.
- [code is short] I've added/modified comments for large or confusing blocks of code.
- [check] I've made sure my code and comments follow the [style guide](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Style-Guide).
- [firefox, chrome, safari] I've tested on multiple browsers.
- [check] I've verified that this PR is set to merge into the develop branch.
- [check] I've written a descriptive PR title.

##### Steps to reproduce the bug <!-- delete if not applicable -->
1. as any user, go to the results page. The legend was missing under the nav bar. I fixed that this with this commit.

##### Testing instructions
1. as any user, go to the results page. The legend is present under the nav bar.
