### PR TITLE
Fixes bug where you can't place a label

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/Main.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Main.js
@@ -31,10 +31,6 @@ function Main (params) {
     svl.svImageWidth = 13312;
     svl.alpha_x = 4.6;
     svl.alpha_y = -4.65;
-    svl._labelCounter = 0;
-    svl.getLabelCounter = function () {
-        return svl._labelCounter++;
-    };
     svl.zoomFactor = {
         1: 1,
         2: 2.1,

--- a/public/javascripts/SVLabel/src/SVLabel/canvas/Canvas.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/Canvas.js
@@ -131,7 +131,6 @@ function Canvas(ribbon) {
             canvasHeight: svl.canvasHeight,
             canvasDistortionAlphaX: svl.alpha_x,
             canvasDistortionAlphaY: svl.alpha_y,
-            //labelId: svl.getLabelCounter(),
             tutorial: svl.missionContainer.getCurrentMission().getProperty("missionType") === "auditOnboarding",
             labelType: labelDescription.id,
             labelDescription: labelDescription.text,

--- a/public/javascripts/SVLabel/src/SVLabel/canvas/Canvas.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/Canvas.js
@@ -141,7 +141,7 @@ function Canvas(ribbon) {
             panoramaLng: latlng.lng,
             panoramaHeading: pov.heading,
             panoramaPitch: pov.pitch,
-            panoramaZoom: pov.zoom,
+            panoramaZoom: parseInt(pov.zoom, 10),
             svImageWidth: svl.svImageWidth,
             svImageHeight: svl.svImageHeight,
             svMode: 'html4'


### PR DESCRIPTION
Fixes #2460 

Fixes the bug that I introduced with my lat/lng estimation fix. The `zoom` value is now parsed to an integer immediately when we get it so that it can safely be used for indexing. I also just removed a couple lines of unused code that I found :grin: 