### PR TITLE
Changes SPGG map pan/zoom

### DIFF
--- a/conf/cityparams.conf
+++ b/conf/cityparams.conf
@@ -132,13 +132,13 @@ city-params {
     }
   }
   city-center-lat {
-    newberg-or = 45.308
+    newberg-or = 45.306
     washington-dc = 38.892
     seattle-wa = 47.615
     columbus-oh = 40.000
     cdmx = 19.490
     spgg = 25.679
-    pittsburgh-pa = 40.440
+    pittsburgh-pa = 40.438
   }
   city-center-lng {
     newberg-or = -122.958
@@ -195,13 +195,13 @@ city-params {
     pittsburgh-pa = 26293
   }
   default-map-zoom {
-    newberg-or = 14.0
+    newberg-or = 13.75
     washington-dc = 12.0
     seattle-wa = 12.0
-    columbus-oh = 12.75
+    columbus-oh = 13.0
     cdmx = 14.0
-    spgg = 14.0
-    pittsburgh-pa = 13.5
+    spgg = 13.25
+    pittsburgh-pa = 13.75
   }
   api-demos {
     attribute-center-lat {

--- a/conf/cityparams.conf
+++ b/conf/cityparams.conf
@@ -137,7 +137,7 @@ city-params {
     seattle-wa = 47.615
     columbus-oh = 40.000
     cdmx = 19.490
-    spgg = 25.679
+    spgg = 25.663
     pittsburgh-pa = 40.438
   }
   city-center-lng {

--- a/public/javascripts/Choropleths/Choropleth.js
+++ b/public/javascripts/Choropleths/Choropleth.js
@@ -42,7 +42,7 @@ function Choropleth(_, $, difficultRegionIds, params, layers, polygonData, polyg
         minZoom: 9,
         zoomControl: params.zoomControl,
         scrollWheelZoom: params.scrollWheelZoom,
-        zoomSnap: 0.5
+        zoomSnap: 0.25
     }).addLayer(L.mapbox.styleLayer(params.mapStyle));
 
     if (params.zoomSlider) L.control.zoomslider().addTo(choropleth);

--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionCompleteMap.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionCompleteMap.js
@@ -6,7 +6,7 @@ function ModalMissionCompleteMap(uiModalMissionComplete) {
         maxZoom: 19,
         minZoom: 10,
         style: 'mapbox://styles/projectsidewalk/civfm8qwi000l2iqo9ru4uhhj',
-        zoomSnap: 0.5
+        zoomSnap: 0.25
     }).addLayer(L.mapbox.styleLayer('mapbox://styles/mapbox/light-v10'));
 
     // Set the city-specific default zoom, location, and max bounding box to prevent the user from panning away.

--- a/public/javascripts/accessScoreDemo.js
+++ b/public/javascripts/accessScoreDemo.js
@@ -7,7 +7,7 @@ $(document).ready(function () {
     map = L.mapbox.map('map', null, {
         maxZoom: 19,
         minZoom: 9,
-        zoomSnap: 0.5
+        zoomSnap: 0.25
     }).addLayer(L.mapbox.styleLayer('mapbox://styles/mapbox/streets-v11'));
 
     // Set the city-specific default zoom, location, and max bounding box to prevent the user from panning away.

--- a/public/javascripts/developer.js
+++ b/public/javascripts/developer.js
@@ -11,12 +11,12 @@ $(document).ready(function () {
     var mapAccessAttributes = L.mapbox.map('developer-access-attribute-map', null, {
         maxZoom: 19,
         minZoom: 9,
-        zoomSnap: 0.5
+        zoomSnap: 0.25
     }).addLayer(L.mapbox.styleLayer('mapbox://styles/mapbox/streets-v11'));
     var mapAccessScoreStreets = L.mapbox.map('developer-access-score-streets-map', null, {
         maxZoom: 19,
         minZoom: 9,
-        zoomSnap: 0.5
+        zoomSnap: 0.25
     }).addLayer(L.mapbox.styleLayer('mapbox://styles/mapbox/streets-v11'));
     var mapAccessScoreNeighborhoods = L.mapbox.map('developer-access-score-neighborhoods-map', null, {
         maxZoom: 19,


### PR DESCRIPTION
Resolves #2462 

Changes the default zoom/pan for maps in SPGG since we've revealed some new neighborhoods there. I also increased the granularity of the map zoom in general (from 0.5 to 0.25), and used that to slightly increase the zoom in Columbus and Pittsburgh, and slightly decrease it in Newberg. This is just to make those maps looks slightly better :ok_hand: 

Before (note that these are on my local dev env, so there isn't much data):
![Screenshot from 2021-02-16 15-29-11](https://user-images.githubusercontent.com/6518824/108134823-be36b500-706b-11eb-99e9-590ee81f58e6.png)

After:
![Screenshot from 2021-02-16 15-28-51](https://user-images.githubusercontent.com/6518824/108134831-c0990f00-706b-11eb-9394-eb3f591cb7e0.png)
