### PR TITLE
2404 differentiate roads and regions

### DIFF
--- a/.ivy2/cache/com.google.code.findbugs/jsr305/ivydata-[1.3, 1.4).properties
+++ b/.ivy2/cache/com.google.code.findbugs/jsr305/ivydata-[1.3, 1.4).properties
@@ -1,4 +1,4 @@
 #ivy cached data file for com.google.code.findbugs#jsr305;[1.3, 1.4)
-#Tue Jan 12 20:40:47 UTC 2021
-resolved.time=1610484047427
+#Sun Feb 21 17:00:01 UTC 2021
+resolved.time=1613926801226
 resolved.revision=1.3.9

--- a/.ivy2/cache/com.google.inject.extensions/guice-multibindings/ivydata-4.0-beta5.properties
+++ b/.ivy2/cache/com.google.inject.extensions/guice-multibindings/ivydata-4.0-beta5.properties
@@ -1,5 +1,5 @@
 #ivy cached data file for com.google.inject.extensions#guice-multibindings;4.0-beta5
-#Tue Jan 12 20:40:47 UTC 2021
+#Sun Feb 21 17:00:01 UTC 2021
 artifact\:guice-multibindings\#jar\#jar\#-1382091433.location=https\://repo1.maven.org/maven2/com/google/inject/extensions/guice-multibindings/4.0-beta5/guice-multibindings-4.0-beta5.jar
 artifact\:guice-multibindings\#pom.original\#pom\#270471229.is-local=false
 artifact\:guice-multibindings\#jar\#jar\#-1382091433.is-local=false

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.watcherExclude": {
+        "**/target": true
+    }
+}

--- a/public/javascripts/Choropleths/MapUtilities.js
+++ b/public/javascripts/Choropleths/MapUtilities.js
@@ -3,7 +3,7 @@
  */
 function toggleLayers(label, checkboxId, sliderId, map, allLayers) {
     if (document.getElementById(checkboxId).checked) {
-        if(checkboxId === 'occlusion'){
+        if(checkboxId === 'occlusion'){ a 
             for (let i = 0; i < allLayers[label].length; i++) {
                 if (!map.hasLayer(allLayers[label][i])) {
                     map.addLayer(allLayers[label][i]);

--- a/public/javascripts/Progress/src/Progress.js
+++ b/public/javascripts/Progress/src/Progress.js
@@ -2,10 +2,10 @@ function Progress (_, $, difficultRegionIds, userRole) {
     var params = {
         popupType: 'completionRate',
         neighborhoodPolygonStyle: {
-            color: '#888',
+            color: '#606060',
             weight: 2,
             opacity: 0.80,
-            fillColor: '#808080',
+            fillColor: '#606060',
             fillOpacity: 0.1
         },
         mouseoverStyle: {
@@ -14,7 +14,7 @@ function Progress (_, $, difficultRegionIds, userRole) {
             weight: 3
         },
         mouseoutStyle: {
-            color: '#888',
+            color: '#606060',
             opacity: 0.8,
             weight: 2
         },

--- a/public/javascripts/Progress/src/Progress.js
+++ b/public/javascripts/Progress/src/Progress.js
@@ -2,7 +2,7 @@ function Progress (_, $, difficultRegionIds, userRole) {
     var params = {
         popupType: 'completionRate',
         neighborhoodPolygonStyle: {
-            color: '#606060',
+            color: '#656565',
             weight: 2,
             opacity: 0.80,
             fillColor: '#606060',
@@ -14,7 +14,7 @@ function Progress (_, $, difficultRegionIds, userRole) {
             weight: 3
         },
         mouseoutStyle: {
-            color: '#606060',
+            color: '#656565',
             opacity: 0.8,
             weight: 2
         },


### PR DESCRIPTION
Resolves #2404

Changed neighborhoodPolygonStyle's color and mouseoutStyle's color from #888 (888888) to #656565 and changed neighborhoodPolygonStyle's fillColor from #808080 to #606060 to differentiate them with streetColor of rgba(128, 128, 128, 1.0)(this is equivalent to #808080). 

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've made sure my code and comments follow the [style guide](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Style-Guide).
- [x] I've verified that this PR is set to merge into the develop branch.
- [x] I've written a descriptive PR title.
