### PR TITLE
Fixes slow landing page load times in Seattle

### DIFF
--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -158,9 +158,8 @@
             var distanceAnim = new CountUp("distance", 0, @("%.1f".format(auditedDistance)),1,2.5,{suffix:''});
             var labelsAnim = new CountUp("numlabels", 0, @LabelTable.countLabels,0,2.5,{suffix:''});
             var validationsAnim = new CountUp("numvalidation", 0, @LabelValidationTable.countValidations,0,2.5,{suffix:''});
-    </script>
+        </script>
     </div>
-    <!-- @leaderboard(5) -->
 
     <div class="container" id="machinelearning-container">
             <div class="im-centered3">


### PR DESCRIPTION
Fixes #2461 

This should fix the slow load times on the landing page in Seattle. The issue is some code that we had commented out in a template scala file (`.scala.html`) using an HTML comment instead of a template scala comment. Which means that the code was being run, and only the visible HTML output was being commented out. This was code for a leaderboard that we thought about adding to the landing page. The leaderboard query takes a long time in Seattle at this point (5 seconds). I just removed that commented out code completely for now. Hopefully this speeds things up!