### PR TITLE
Optimize some queries that get tags or validations

### DIFF
--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -722,7 +722,6 @@ object LabelTable {
   def retrieveLabelsOfTypeBySeverityAndTags(labelTypeId: Int, n: Int, loadedLabelIds: Set[Int], severity: Set[Int], tags: Set[String]): Seq[LabelValidationMetadata] = db.withSession { implicit session => 
     // List to return.
     val selectedLabels: ListBuffer[LabelValidationMetadata] = new ListBuffer[LabelValidationMetadata]()
-    Logger.debug("Grabbing labels by type severity and tags");
 
     // Init random function.
     val rand = SimpleFunction.nullary[Double]("random")
@@ -818,7 +817,6 @@ object LabelTable {
   def retrieveAssortedLabels(n: Int, loadedLabelIds: Set[Int], severity: Option[Set[Int]] = None): Seq[LabelValidationMetadata] = db.withSession { implicit session => 
     // List to return.
     val selectedLabels: ListBuffer[LabelValidationMetadata] = new ListBuffer[LabelValidationMetadata]()
-    Logger.debug("Grabbing random assortment of labels");
 
     // Init random function
     val rand = SimpleFunction.nullary[Double]("random")
@@ -865,22 +863,17 @@ object LabelTable {
     } yield (l._1.labelId, l._3, l._1.gsvPanoramaId, l._2.heading, l._2.pitch,
              l._2.zoom, l._2.canvasX, l._2.canvasY, l._2.canvasWidth, l._2.canvasHeight, l._4, l._5, d.description.?)
 
-    Logger.debug(addDescriptions.list.size + " addDescriptions")
-
     // Randomize and convert to LabelValidationMetadataWithoutTags.
     val newRandomLabelsList = addDescriptions.sortBy(x => rand).list.map(l => LabelValidationMetadataWithoutTags.tupled(l))
 
     val labelTypesAsStrings = LabelTypeTable.validLabelTypes
 
     for (labelType <- labelTypesAsStrings) {
-      Logger.debug("in the loop")
       val labelsFilteredByType = newRandomLabelsList.filter(label => label.labelType == labelType)
-      Logger.debug(labelsFilteredByType.size + " filtered by type size")
       val selectedLabelsOfType: ListBuffer[LabelValidationMetadata] = new ListBuffer[LabelValidationMetadata]()
       var potentialStartIdx: Int = 0
 
       while (selectedLabelsOfType.length < (n / labelTypesAsStrings.size) + 1 && potentialStartIdx < labelsFilteredByType.size) {
-        Logger.debug("entered the loop with " + selectedLabelsOfType.length + " labels")
         val labelsNeeded: Int = (n / labelTypesAsStrings.size) + 1 - selectedLabelsOfType.length
         val newLabels: Seq[LabelValidationMetadata] =
           labelsFilteredByType.slice(potentialStartIdx, potentialStartIdx + labelsNeeded).par.flatMap { currLabel =>
@@ -956,14 +949,10 @@ object LabelTable {
     } yield (l._1.labelId, l._3, l._1.gsvPanoramaId, l._2.heading, l._2.pitch,
              l._2.zoom, l._2.canvasX, l._2.canvasY, l._2.canvasWidth, l._2.canvasHeight, l._4, l._5, d.description.?)
 
-    Logger.debug(addDescriptions.list.size + " addDescriptions")
-
     // Randomize and convert to LabelValidationMetadataWithoutTags.
     val newRandomLabelsList = addDescriptions.sortBy(x => rand).list.map(l => LabelValidationMetadataWithoutTags.tupled(l))
 
     var potentialStartIdx: Int = 0
-
-    Logger.debug(newRandomLabelsList.size + "")
 
     // While the desired query size has not been met and there are still possibly valid labels to consider, traverse
     // through the list incrementally and see if a potentially valid label has pano data for viewability.

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -15,7 +15,6 @@ import org.joda.time.{DateTime, DateTimeZone}
 import play.api.Play
 import play.api.Play.current
 import play.api.libs.json.{JsObject, Json}
-import play.api.Logger
 
 import scala.collection.mutable.ListBuffer
 import scala.slick.jdbc.{GetResult, StaticQuery => Q}
@@ -770,7 +769,7 @@ object LabelTable {
              l._2.zoom, l._2.canvasX, l._2.canvasY, l._2.canvasWidth, l._2.canvasHeight, l._4, l._5, d.description.?)
 
     // Randomize and convert to LabelValidationMetadataWithoutTags.
-    val newRandomLabelsList = addDescriptions.sortBy(x => rand).list.map(l => LabelValidationMetadataWithoutTags.tupled(l))
+    val newRandomLabelsList = addDescriptions.sortBy(x => rand).list.map(LabelValidationMetadataWithoutTags.tupled)
 
     var potentialStartIdx: Int = 0
 
@@ -864,7 +863,7 @@ object LabelTable {
              l._2.zoom, l._2.canvasX, l._2.canvasY, l._2.canvasWidth, l._2.canvasHeight, l._4, l._5, d.description.?)
 
     // Randomize and convert to LabelValidationMetadataWithoutTags.
-    val newRandomLabelsList = addDescriptions.sortBy(x => rand).list.map(l => LabelValidationMetadataWithoutTags.tupled(l))
+    val newRandomLabelsList = addDescriptions.sortBy(x => rand).list.map(LabelValidationMetadataWithoutTags.tupled)
 
     val labelTypesAsStrings = LabelTypeTable.validLabelTypes
 
@@ -950,7 +949,7 @@ object LabelTable {
              l._2.zoom, l._2.canvasX, l._2.canvasY, l._2.canvasWidth, l._2.canvasHeight, l._4, l._5, d.description.?)
 
     // Randomize and convert to LabelValidationMetadataWithoutTags.
-    val newRandomLabelsList = addDescriptions.sortBy(x => rand).list.map(l => LabelValidationMetadataWithoutTags.tupled(l))
+    val newRandomLabelsList = addDescriptions.sortBy(x => rand).list.map(LabelValidationMetadataWithoutTags.tupled)
 
     var potentialStartIdx: Int = 0
 

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -234,14 +234,17 @@ object LabelTable {
   */
   def countTodayLabelsBasedOnType(labelType: String): Int = db.withSession { implicit session =>
 
-    val countQuery = s"""SELECT COUNT(label.label_id)
-                         |  FROM sidewalk.audit_task
-                         |INNER JOIN sidewalk.label
-                         |  ON label.audit_task_id = audit_task.audit_task_id
-                         |WHERE (audit_task.task_end AT TIME ZONE 'US/Pacific')::date = (now() AT TIME ZONE 'US/Pacific')::date
-                         |  AND label.deleted = false AND label.label_type_id = (SELECT label_type_id
-                         |														FROM sidewalk.label_type as lt
-                         |														WHERE lt.label_type='$labelType')""".stripMargin
+    val countQuery =
+      s"""SELECT COUNT(label.label_id)
+         |FROM sidewalk.audit_task
+         |INNER JOIN sidewalk.label ON label.audit_task_id = audit_task.audit_task_id
+         |WHERE (audit_task.task_end AT TIME ZONE 'US/Pacific')::date = (now() AT TIME ZONE 'US/Pacific')::date
+         |    AND label.deleted = false
+         |    AND label.label_type_id = (
+         |        SELECT label_type_id
+         |        FROM sidewalk.label_type as lt
+         |        WHERE lt.label_type='$labelType'
+         |    )""".stripMargin
     val countQueryResult = Q.queryNA[(Int)](countQuery)
 
     countQueryResult.list.head
@@ -266,14 +269,17 @@ object LabelTable {
   * Date: Aug 28, 2016
   */
   def countPastWeekLabelsBasedOnType(labelType: String): Int = db.withTransaction { implicit session =>
-    val countQuery = s"""SELECT COUNT(label.label_id)
-                         |  FROM sidewalk.audit_task
-                         |INNER JOIN sidewalk.label
-                         |  ON label.audit_task_id = audit_task.audit_task_id
-                         |WHERE (audit_task.task_end AT TIME ZONE 'US/Pacific') > (now() AT TIME ZONE 'US/Pacific') - interval '168 hours'
-                         |  AND label.deleted = false AND label.label_type_id = (SELECT label_type_id
-                         |														FROM sidewalk.label_type as lt
-                         |														WHERE lt.label_type='$labelType')""".stripMargin
+    val countQuery =
+      s"""SELECT COUNT(label.label_id)
+         |FROM sidewalk.audit_task
+         |INNER JOIN sidewalk.label ON label.audit_task_id = audit_task.audit_task_id
+         |WHERE (audit_task.task_end AT TIME ZONE 'US/Pacific') > (now() AT TIME ZONE 'US/Pacific') - interval '168 hours'
+         |    AND label.deleted = false
+         |    AND label.label_type_id = (
+         |        SELECT label_type_id
+         |        FROM sidewalk.label_type as lt
+         |        WHERE lt.label_type='$labelType'
+         |    )""".stripMargin
     val countQueryResult = Q.queryNA[(Int)](countQuery)
 
     countQueryResult.list.head
@@ -441,7 +447,7 @@ object LabelTable {
         |     sidewalk.audit_task AS at,
         |     sidewalk_user AS u,
         |     sidewalk.label_point AS lp,
-        |			(
+        |      (
         |         SELECT lb.label_id,
         |                lb.gsv_panorama_id,
         |                lbt.label_type,
@@ -449,12 +455,12 @@ object LabelTable {
         |                sev.severity,
         |                COALESCE(lab_temp.temporary, 'FALSE') AS temp,
         |                lab_desc.description
-        |					FROM label AS lb
-        |		  		LEFT JOIN sidewalk.label_type AS lbt ON lb.label_type_id = lbt.label_type_id
-        |			  	LEFT JOIN sidewalk.label_severity AS sev ON lb.label_id = sev.label_id
-        |			  	LEFT JOIN sidewalk.label_description AS lab_desc ON lb.label_id = lab_desc.label_id
-        |				  LEFT JOIN sidewalk.label_temporariness AS lab_temp ON lb.label_id = lab_temp.label_id
-        |			) AS lb_big
+        |          FROM label AS lb
+        |          LEFT JOIN sidewalk.label_type AS lbt ON lb.label_type_id = lbt.label_type_id
+        |          LEFT JOIN sidewalk.label_severity AS sev ON lb.label_id = sev.label_id
+        |          LEFT JOIN sidewalk.label_description AS lab_desc ON lb.label_id = lab_desc.label_id
+        |          LEFT JOIN sidewalk.label_temporariness AS lab_temp ON lb.label_id = lab_temp.label_id
+        |      ) AS lb_big
         |WHERE u.user_id = ?
         |      AND lb1.deleted = FALSE
         |      AND lb1.tutorial = FALSE
@@ -498,7 +504,7 @@ object LabelTable {
         |     sidewalk.audit_task AS at,
         |     sidewalk_user AS u,
         |     sidewalk.label_point AS lp,
-        |		  (
+        |      (
         |         SELECT lb.label_id,
         |                lb.gsv_panorama_id,
         |                lbt.label_type,
@@ -506,12 +512,12 @@ object LabelTable {
         |                sev.severity,
         |                COALESCE(lab_temp.temporary, 'FALSE') AS temp,
         |                lab_desc.description
-        |					FROM label AS lb
-        |		  		LEFT JOIN sidewalk.label_type AS lbt ON lb.label_type_id = lbt.label_type_id
-        |		  		LEFT JOIN sidewalk.label_severity AS sev ON lb.label_id = sev.label_id
-        |				  LEFT JOIN sidewalk.label_description AS lab_desc ON lb.label_id = lab_desc.label_id
-        |				  LEFT JOIN sidewalk.label_temporariness AS lab_temp ON lb.label_id = lab_temp.label_id
-        |			) AS lb_big
+        |          FROM label AS lb
+        |          LEFT JOIN sidewalk.label_type AS lbt ON lb.label_type_id = lbt.label_type_id
+        |          LEFT JOIN sidewalk.label_severity AS sev ON lb.label_id = sev.label_id
+        |          LEFT JOIN sidewalk.label_description AS lab_desc ON lb.label_id = lab_desc.label_id
+        |          LEFT JOIN sidewalk.label_temporariness AS lab_temp ON lb.label_id = lab_temp.label_id
+        |      ) AS lb_big
         |WHERE lb1.label_id = ?
         |      AND lb1.audit_task_id = at.audit_task_id
         |      AND lb1.gsv_panorama_id = gsv_data.gsv_panorama_id


### PR DESCRIPTION
Resolves #2474 

Improves load time of some web pages by optimizing queries that get label tags.

I tested on my local dev environment, running an up to date Seattle database dump (our largest database atm). Speed improvements will be smaller for smaller databases.
* Loading the admin page went from 45 seconds to 20 seconds
* Loading an admin version of a user's page went from 8 seconds to 2 seconds for a user with a lot of labels. If the user has very few labels, the load time should be around 2 seconds regardless.
* Loading the validation page had no significant change in load time, but I updated the query for labels to validate in the same way. This added consistency and allowed me to delete a few helper functions we were using for the old method.

The reason we see speedups in the first two cases is due to the large number of labels being queries; max 15k for admin, max 1k for admin user dashboard, but less than 100 for the validation page.

@ThatOneGoat @kumararoosh I also tried this approach for Gallery, but it actually slowed things down a little bit. The reason is that the way you have the queries right now, you're querying for _all_ labels that match the description, then you only grab the tags for the labels that you're going to use. If instead we only queries for a number of labels on the first go, and wrapped the whole thing in a loop so we could search again if we don't find enough with non-expired imagery, we might see a minor performance improvement. However, I don't think the added complexity is worth the trouble, given how minor the impact would be (the bigger time sink is verifying that the panos exist).