### PR TITLE
Streamlines issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,18 +1,14 @@
-<!-- Note that this template has a lot of sections that _could_ be filled in, but you don't need to fill them all in. If you don't have answers to some questions and/or you don't have time to figure it out right now, just skip them, we can always fill it in later. Having the issue filed at all is what's most important. -->
-##### Brief description of issue/feature
+<!-- DELETE ANY SECTION(S) THAT ARE NOT RELEVANT! -->
+##### Brief description of problem/feature
 
-<!-- This part mostly applies for features/design ideas; delete this if you're just reporting a bug. -->
+##### System info (OS, browser, city, and local/prod/test)
+
 ##### Design ideas & mockups
 
-<!-- Include any of the below that applies to you, delete any headers that don't apply -->
 ##### Expected behavior
 
-<!-- For current behavior, include screenshots/recordings if applicable; check terminal & browser console for errors -->
-##### Current behavior
+##### Current behavior (add screenshots if applicable; check terminal & browser console for errors)
 
 ##### Steps to reproduce
 
 ##### Potential solution(s)
-
-<!-- prod vs test vs dev env, which city/cities, language(s), browser(s), OS(s)? -->
-##### Where has the error occurred?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,23 +2,15 @@ Resolves #123
 
 This is a brief description of the problem solved or feature implemented and how you implemented it.
 
-##### Before/After screenshots <!-- delete if not applicable -->
-
-##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
-- [ ] If there is a visual design component, I've posted before/after screenshots on the relevant issue thread and have been given a thumbs up on my design.
-- [ ] I've asked for and added translations for any user facing text that was added or modified.
-- [ ] I've updated logging if applicable. Clicks, keyboard presses, and other interactions should be logged in the `audit_task_interaction` or `validation_task_interaction` tables. If you added/modified an element that users can interact with, you may need to add/change the logging. Links between pages should be logged in the `webpage_activity` table. If you're not sure if you need to update the logging, ask Mikey.
-- [ ] I've added/modified comments for large or confusing blocks of code.
-- [ ] I've made sure my code and comments follow the [style guide](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Style-Guide).
-- [ ] I've tested on multiple browsers.
-- [ ] I've tested as an Anonymous user, Registered user, and as a Turker.
-- [ ] I've tested in both English and Spanish.
-- [ ] I've tested on both desktop and mobile (as of Aug 2020, only need to test mobile for validation sign in page changes).
-- [ ] I've verified that this PR is set to merge into the develop branch.
-- [ ] I've written a descriptive PR title.
-
-##### Steps to reproduce the bug <!-- delete if not applicable -->
-1.
+##### Before/After screenshots (if applicable)
 
 ##### Testing instructions
-1.
+1. 
+
+##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
+- [ ] I've written a descriptive PR title.
+- [ ] I've added/updated comments for large or confusing blocks of code.
+- [ ] I've included before/after screenshots above.
+- [ ] I've asked for and included translations for any user facing text that was added or modified.
+- [ ] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey.
+- [ ] I've tested on mobile (only needed for validation page).


### PR DESCRIPTION
Resolves #2308 

Streamlines the Issue and PR templates by cutting down on wordiness and cutting less important sections.

My first attempt was overly verbose and specific. I think it was sometimes helpful for very new interns to help them realize all the different things they can/should be thinking about when making a new Issue/PR. But after day 1, it just became overly cumbersome and no one wanted to use it. I'm hoping that the redesign strikes a better balance!