### PR TITLE
Rewords mturk HIT timeout overlay

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,47 +18,47 @@ eslint-fix: | lint-fix-eslint
 stylelint-fix: | lint-fix-stylelint
 
 lint:
-    @make lint-eslint; make lint-htmlhint; make lint-stylelint
+	@make lint-eslint; make lint-htmlhint; make lint-stylelint
 
 lint-fix:
-    @make lint-fix-eslint; make lint-fix-stylelint
+	@make lint-fix-eslint; make lint-fix-stylelint
 
 docker-up:
-    @docker-compose up -d
+	@docker-compose up -d
 
 docker-up-db:
-    @docker-compose up -d db
+	@docker-compose up -d db
 
 docker-stop:
-    @docker-compose stop
-    @docker-compose rm -f
+	@docker-compose stop
+	@docker-compose rm -f
 
 docker-run:
-    @docker-compose run --rm --service-ports --name projectsidewalk-web web /bin/bash
+	@docker-compose run --rm --service-ports --name projectsidewalk-web web /bin/bash
 
 ssh:
-    @docker exec -it projectsidewalk-$${target} /bin/bash
+	@docker exec -it projectsidewalk-$${target} /bin/bash
 
 import-dump:
-    @docker exec -it projectsidewalk-db sh -c "/opt/import-dump.sh $(db)"
+	@docker exec -it projectsidewalk-db sh -c "/opt/import-dump.sh $(db)"
 
 lint-htmlhint:
-    @echo "Running HTMLHint...";
-    @if [ "$(dir)" = "./" ]; then \
-        ./node_modules/htmlhint/bin/htmlhint $(args) --ignore $(html-ignore) ./app/views; \
-    else \
-        ./node_modules/htmlhint/bin/htmlhint $(args) --ignore $(html-ignore) $(dir); \
-    fi
-    @echo "Finished Running HTMLHint";
+	@echo "Running HTMLHint...";
+	@if [ "$(dir)" = "./" ]; then \
+		./node_modules/htmlhint/bin/htmlhint $(args) --ignore $(html-ignore) ./app/views; \
+	else \
+		./node_modules/htmlhint/bin/htmlhint $(args) --ignore $(html-ignore) $(dir); \
+	fi
+	@echo "Finished Running HTMLHint";
 
 lint-eslint:
-    @echo "Running eslint..."; ./node_modules/eslint/bin/eslint.js $(args) $(dir); echo "Finished Running eslint"
+	@echo "Running eslint..."; ./node_modules/eslint/bin/eslint.js $(args) $(dir); echo "Finished Running eslint"
 
 lint-stylelint:
-    @echo "Running stylelint..."; ./node_modules/stylelint/bin/stylelint.js $(args) $(dir); echo "Finished Running stylelint"
+	@echo "Running stylelint..."; ./node_modules/stylelint/bin/stylelint.js $(args) $(dir); echo "Finished Running stylelint"
 
 lint-fix-eslint:
-    @echo "Running eslint..."; ./node_modules/eslint/bin/eslint.js --fix $(args) $(dir); echo "Finished Running eslint"
+	@echo "Running eslint..."; ./node_modules/eslint/bin/eslint.js --fix $(args) $(dir); echo "Finished Running eslint"
 
 lint-fix-stylelint:
-    @echo "Running stylelint..."; ./node_modules/stylelint/bin/stylelint.js --fix $(args) $(dir); echo "Finished Running stylelint"
+	@echo "Running stylelint..."; ./node_modules/stylelint/bin/stylelint.js --fix $(args) $(dir); echo "Finished Running stylelint"

--- a/app/views/navbar.scala.html
+++ b/app/views/navbar.scala.html
@@ -42,7 +42,7 @@
                             // Output the result in an element with id="navbarTimer"
                             if (msRemaining < 0) {
                                 clearInterval(timerInterval);
-                                document.getElementById("navbarTimer").innerHTML = "EXPIRED";
+                                document.getElementById("navbarTimer").innerHTML = "@Messages("turk.expired.navbar")";
 
                                 // If on the audit or validation page and the timer has just expired, refresh page to
                                 // show HIT expiration overlay so they are unable to audit.

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -192,8 +192,9 @@ validate.mission.complete.your.overall.total = Your Overall Total
 
 mobile.validate.leave.feedback = Leave Feedback
 
-turk.expired.title = Assignment Expired!
-turk.expired.body = You should receive your bonus amount in the next day or two. If you completed the HIT but did not submit your confirmation code on the mturk website, send us an email at <a href="mailto:makeability.sidewalk@@gmail.com">makeability.sidewalk@@gmail.com</a> with your confirmation code
+turk.expired.navbar = TIME''S UP
+turk.expired.title = Time''s up!
+turk.expired.body = You should receive your bonus amount in the next two days. Please submit your confirmation code on the mturk website. If the assignment has already expired, send us an email at <a href="mailto:makeability.sidewalk@@gmail.com">makeability.sidewalk@@gmail.com</a> with your confirmation code
 turk.submit.code = Submit this code for HIT verification on Amazon Mechanical Turk
 turk.mturk.code = Mturk Code
 turk.reward.earned = Total earned reward

--- a/conf/messages.es
+++ b/conf/messages.es
@@ -191,8 +191,9 @@ validate.mission.complete.your.overall.total = Su total en general
 
 mobile.validate.leave.feedback = Retroalimentación
 
-turk.expired.title = ¡Asignación vencida!
-turk.expired.body = Deberías recibir el monto de tu bono en los próximos dos días. Si completaste el HIT pero no enviaste tu código de confirmación en el sitio web de mturk, envíanos un correo electrónico a <a href="mailto:makeability.sidewalk@@gmail.com">makeability.sidewalk@@gmail.com</a> con tu código de confirmación
+turk.expired.navbar = SE ACABÓ EL TIEMPO
+turk.expired.title = ¡Se acabó el tiempo!
+turk.expired.body = Deberías recibir el monto de tu bono en los próximos dos días. Por favor enviar su código de confirmación en el sitio web de mturk. Si la asignación ya ha vencido, envíanos un correo electrónico a <a href="mailto:makeability.sidewalk@@gmail.com">makeability.sidewalk@@gmail.com</a> con tu código de confirmación
 turk.submit.code = Envía este código para la verificación HIT en Amazon Mechanical Turk
 turk.mturk.code = Código de Mturk
 turk.reward.earned = Recompensa actual de la misión


### PR DESCRIPTION
Resolves #2138 

Rewords the text on the overlay that lets turkers know that their auditing time is up. I also fixed the Makefile because I recently replaced the tabs with spaces, and I guess the tabs are important in the Makefile :sweat_smile: 

##### Before/After screenshots (if applicable)
Before/after English:
![Screenshot from 2021-03-12 17-12-23](https://user-images.githubusercontent.com/6518824/111013907-279da100-8356-11eb-80db-600cfb11cf1d.png)
![Screenshot from 2021-03-12 17-03-17](https://user-images.githubusercontent.com/6518824/111013913-2f5d4580-8356-11eb-9e01-ed833db1135e.png)

Before/after Spanish:
![Screenshot from 2021-03-12 17-10-11](https://user-images.githubusercontent.com/6518824/111013916-34ba9000-8356-11eb-8ed7-07987b0b5fb9.png)
![Screenshot from 2021-03-12 17-05-38](https://user-images.githubusercontent.com/6518824/111013920-35ebbd00-8356-11eb-9779-e747b773798f.png)

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've included before/after screenshots above.
- [x] I've asked for and included translations for any user facing text that was added or modified.
