### PR TITLE
Marginally improves efficiency for SQL COUNT queries

### DIFF
--- a/app/models/amt/AMTAssignmentTable.scala
+++ b/app/models/amt/AMTAssignmentTable.scala
@@ -45,19 +45,19 @@ object AMTAssignmentTable {
   }
 
   def getConfirmationCode(workerId: String, assignmentId: String): String = db.withTransaction { implicit session =>
-    amtAssignments.filter( x => x.workerId === workerId && x.assignmentId === assignmentId).sortBy(_.assignmentStart.desc).map(_.confirmationCode).list.head
+    amtAssignments.filter(a => a.workerId === workerId && a.assignmentId === assignmentId).sortBy(_.assignmentStart.desc).map(_.confirmationCode).first
   }
 
   def getMostRecentAssignmentId(workerId: String): String = db.withTransaction { implicit session =>
-    amtAssignments.filter( x => x.workerId === workerId).sortBy(_.assignmentStart.desc).map(_.assignmentId).list.head
+    amtAssignments.filter(_.workerId === workerId).sortBy(_.assignmentStart.desc).map(_.assignmentId).first
   }
 
   def getMostRecentAMTAssignmentId(workerId: String): Int = db.withTransaction { implicit session =>
-    amtAssignments.filter( x => x.workerId === workerId).sortBy(_.assignmentStart.desc).map(_.amtAssignmentId).list.head
+    amtAssignments.filter(_.workerId === workerId).sortBy(_.assignmentStart.desc).map(_.amtAssignmentId).first
   }
 
   def getMostRecentAsmtEnd(workerId: String): Option[Timestamp] = db.withSession { implicit session =>
-    amtAssignments.filter(_.workerId === workerId).sortBy(_.assignmentStart.desc).map(_.assignmentEnd).list.headOption
+    amtAssignments.filter(_.workerId === workerId).sortBy(_.assignmentStart.desc).map(_.assignmentEnd).firstOption
   }
 
   /**
@@ -70,15 +70,15 @@ object AMTAssignmentTable {
   }
 
   def getMostRecentConfirmationCode(workerId: String): Option[String] = db.withSession { implicit session =>
-    amtAssignments.filter(_.workerId === workerId).sortBy(_.assignmentStart.desc).map(_.confirmationCode).list.headOption
+    amtAssignments.filter(_.workerId === workerId).sortBy(_.assignmentStart.desc).map(_.confirmationCode).firstOption
   }
 
   def getMostRecentAssignment(workerId: String): Option[AMTAssignment] = db.withSession { implicit session =>
-    amtAssignments.filter(_.workerId === workerId).sortBy(_.assignmentStart.desc).list.headOption
+    amtAssignments.filter(_.workerId === workerId).sortBy(_.assignmentStart.desc).firstOption
   }
 
   def getAssignment(workerId: String, assignmentId: String): Option[AMTAssignment] = db.withSession { implicit session =>
-    amtAssignments.filter(a => a.workerId === workerId && a.assignmentId === assignmentId).list.headOption
+    amtAssignments.filter(a => a.workerId === workerId && a.assignmentId === assignmentId).firstOption
   }
 
   /**

--- a/app/models/audit/AuditTaskTable.scala
+++ b/app/models/audit/AuditTaskTable.scala
@@ -160,7 +160,7 @@ object AuditTaskTable {
         |WHERE (audit_task.task_end AT TIME ZONE 'US/Pacific')::date = (now() AT TIME ZONE 'US/Pacific')::date
         |    AND audit_task.completed = TRUE""".stripMargin
     )
-    countTasksQuery.list.head
+    countTasksQuery.first
   }
 
   /**
@@ -173,7 +173,7 @@ object AuditTaskTable {
         |WHERE (audit_task.task_end AT TIME ZONE 'US/Pacific') > (now() AT TIME ZONE 'US/Pacific') - interval '168 hours'
         |    AND audit_task.completed = TRUE""".stripMargin
     )
-    countTasksQuery.list.head
+    countTasksQuery.first
   }
 
   /**

--- a/app/models/daos/slick/UserDAOSlick.scala
+++ b/app/models/daos/slick/UserDAOSlick.scala
@@ -225,7 +225,7 @@ object UserDAOSlick {
                    |WHERE $highQualityOnlySql;
                  """.stripMargin
 
-    Q.queryNA[Int](countQuery).list.head
+    Q.queryNA[Int](countQuery).first
   }
 
   /**
@@ -247,7 +247,7 @@ object UserDAOSlick {
     } yield _user.userId
 
     // The group by and map does a SELECT DISTINCT, and the list.length does the COUNT.
-    users.groupBy(x => x).map(_._1).list.length
+    users.groupBy(x => x).map(_._1).size.run
   }
 
   /**
@@ -283,7 +283,7 @@ object UserDAOSlick {
         |    AND sidewalk_user.username <> 'anonymous'
         |    AND role.role = ?""".stripMargin
     )
-    countQuery(role).list.head
+    countQuery(role).first
   }
 
   /**
@@ -322,7 +322,7 @@ object UserDAOSlick {
         |    AND sidewalk_user.username <> 'anonymous'
         |    AND role.role = ?""".stripMargin
     )
-    countQuery(role).list.head
+    countQuery(role).first
   }
 
   /**
@@ -361,7 +361,7 @@ object UserDAOSlick {
     } yield _user.userId
 
     // The group by and map does a SELECT DISTINCT, and the list.length does the COUNT.
-    users.groupBy(x => x).map(_._1).list.length
+    users.groupBy(x => x).map(_._1).size.run
   }
 
   /**
@@ -397,7 +397,7 @@ object UserDAOSlick {
         |    AND role.role = ?
         |    AND audit_task.completed = true""".stripMargin
     )
-    countQuery(role).list.head
+    countQuery(role).first
   }
 
   /**
@@ -436,7 +436,7 @@ object UserDAOSlick {
         |    AND role.role = ?
         |    AND audit_task.completed = true""".stripMargin
     )
-    countQuery(role).list.head
+    countQuery(role).first
   }
 
   /**

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -213,10 +213,10 @@ object LabelTable {
     * Find a label based on temp_label_id and audit_task_id.
     */
   def find(tempLabelId: Int, auditTaskId: Int): Option[Int] = db.withSession { implicit session =>
-    val labelIds = labels.filter(x => x.temporaryLabelId === tempLabelId && x.auditTaskId === auditTaskId).map{
+    val labelIds = labels.filter(x => x.temporaryLabelId === tempLabelId && x.auditTaskId === auditTaskId).map {
       label => label.labelId
     }
-    labelIds.list.headOption
+    labelIds.firstOption
   }
 
   def countLabels: Int = db.withTransaction(implicit session =>
@@ -241,7 +241,7 @@ object LabelTable {
         |WHERE (audit_task.task_end AT TIME ZONE 'US/Pacific')::date = (now() AT TIME ZONE 'US/Pacific')::date
         |    AND label.deleted = false""".stripMargin
     )
-    countQuery.list.head
+    countQuery.first
   }
 
   /*
@@ -264,7 +264,7 @@ object LabelTable {
          |    )""".stripMargin
     val countQueryResult = Q.queryNA[(Int)](countQuery)
 
-    countQueryResult.list.head
+    countQueryResult.first
   }
 
   /*
@@ -278,7 +278,7 @@ object LabelTable {
         |WHERE (audit_task.task_end AT TIME ZONE 'US/Pacific') > (now() AT TIME ZONE 'US/Pacific') - interval '168 hours'
         |    AND label.deleted = false""".stripMargin
     )
-    countQuery.list.head
+    countQuery.first
   }
 
   /*
@@ -299,7 +299,7 @@ object LabelTable {
          |    )""".stripMargin
     val countQueryResult = Q.queryNA[(Int)](countQuery)
 
-    countQueryResult.list.head
+    countQueryResult.first
   }
 
 
@@ -568,7 +568,7 @@ object LabelTable {
         |    AND lb1.label_id = lp.label_id
         |ORDER BY lb1.label_id DESC""".stripMargin
     )
-    selectQuery.list.head
+    selectQuery.first
   }
 
   /**
@@ -1318,7 +1318,7 @@ object LabelTable {
          |LIMIT 1""".stripMargin
     )
     //NOTE: these parameters are being passed in correctly. ST_MakePoint accepts lng first, then lat.
-    selectStreetEdgeIdQuery((lng, lat)).list.headOption
+    selectStreetEdgeIdQuery((lng, lat)).firstOption
   }
 
   /**
@@ -1328,7 +1328,7 @@ object LabelTable {
     val recentMissionId: Option[Int] = MissionTable.missions
         .filter(m => m.userId === userId.toString && m.regionId === regionId)
         .sortBy(_.missionStart.desc)
-        .map(_.missionId).list.headOption
+        .map(_.missionId).firstOption
 
     recentMissionId match {
       case Some(missionId) => labelsWithoutDeleted.filter(_.missionId === missionId).list

--- a/app/models/label/LabelTypeTable.scala
+++ b/app/models/label/LabelTypeTable.scala
@@ -36,13 +36,13 @@ object LabelTypeTable {
     * Gets the label type id from the label type name.
     */
   def labelTypeToId(labelType: String): Int = db.withTransaction { implicit session =>
-    labelTypes.filter(_.labelType === labelType).map(_.labelTypeId).list.head
+    labelTypes.filter(_.labelType === labelType).map(_.labelTypeId).first
   }
 
   /**
     * Gets the label type name from the label type id.
     */
   def labelTypeIdToLabelType(labelTypeId: Int): String = db.withTransaction { implicit session =>
-    labelTypes.filter(_.labelTypeId === labelTypeId).map(_.labelType).list.head
+    labelTypes.filter(_.labelTypeId === labelTypeId).map(_.labelType).first
   }
 }

--- a/app/models/label/LabelValidationTable.scala
+++ b/app/models/label/LabelValidationTable.scala
@@ -119,7 +119,7 @@ object LabelValidationTable {
    */
   def insertOrUpdate(label: LabelValidation): Int = db.withTransaction { implicit session =>
     val oldValidation: Option[LabelValidation] =
-      validationLabels.filter(x => x.labelId === label.labelId && x.missionId === label.missionId).list.headOption
+      validationLabels.filter(x => x.labelId === label.labelId && x.missionId === label.missionId).firstOption
 
     oldValidation match {
       case Some(oldLabel) =>
@@ -168,7 +168,7 @@ object LabelValidationTable {
         GROUP BY user_id
       ) "accuracy";""".stripMargin
     )
-    accuracyQuery(userId.toString).list.headOption.flatten
+    accuracyQuery(userId.toString).firstOption.flatten
   }
 
   /**
@@ -306,7 +306,7 @@ object LabelValidationTable {
         |FROM sidewalk.label_validation v
         |WHERE (v.end_timestamp AT TIME ZONE 'US/Pacific')::date = (NOW() AT TIME ZONE 'US/Pacific')::date""".stripMargin
     )
-    countQuery.list.head
+    countQuery.first
   }
 
   /**
@@ -318,7 +318,7 @@ object LabelValidationTable {
         |FROM sidewalk.label_validation v
         |WHERE (v.end_timestamp AT TIME ZONE 'US/Pacific') > (NOW() AT TIME ZONE 'US/Pacific') - interval '168 hours'""".stripMargin
     )
-    countQuery.list.head
+    countQuery.first
   }
 
   /**
@@ -331,7 +331,7 @@ object LabelValidationTable {
         |WHERE (v.end_timestamp AT TIME ZONE 'US/Pacific')::date = (NOW() AT TIME ZONE 'US/Pacific')::date
         |   AND v.validation_result = $result""".stripMargin
     )
-    countQuery.list.head
+    countQuery.first
   }
 
   /**
@@ -344,7 +344,7 @@ object LabelValidationTable {
          |WHERE (v.end_timestamp AT TIME ZONE 'US/Pacific') > (NOW() AT TIME ZONE 'US/Pacific') - interval '168 hours'
          |   AND v.validation_result = $result""".stripMargin
     )
-    countQuery.list.head
+    countQuery.first
   }
 
   /**

--- a/app/models/mission/MissionProgressCVGroundtruthTable.scala
+++ b/app/models/mission/MissionProgressCVGroundtruthTable.scala
@@ -70,7 +70,7 @@ object MissionProgressCVGroundtruthTable {
     * Note: these lat/lng positions are supplied by the client when the ground truth audit mission is created.
     * @param userId a user id
     * @param panoId a panoId that is part of an active CV ground truth audit mission for this user
-    * @return a lat/lng tuple specifing the location of the pano
+    * @return a lat/lng tuple specifying the location of the pano
     */
   def getPanoLatLng(userId: UUID, panoId: String):(Option[Float],Option[Float]) = db.withSession { implicit session =>
     val activeMission: Option[Mission] = MissionTable.getIncompleteCVGroundTruthMission(userId)
@@ -79,7 +79,7 @@ object MissionProgressCVGroundtruthTable {
         val result: CVMissionPanoStatus = cvMissionPanoStatuses.filter(statusEntry =>
           statusEntry.linkedMissionId === mission.missionId &&
           statusEntry.panoId === panoId
-        ).take(1).list.head
+        ).take(1).first
         (Some(result.lat), Some(result.lng))
       case None =>
         (None, None)

--- a/app/models/mission/MissionTable.scala
+++ b/app/models/mission/MissionTable.scala
@@ -90,12 +90,12 @@ object MissionTable {
   val userRoles = TableQuery[UserRoleTable]
   val roles = TableQuery[RoleTable]
   val auditMissionTypeId: Int = db.withSession { implicit session =>
-    missionTypes.filter(_.missionType === "audit").map(_.missionTypeId).list.head
+    missionTypes.filter(_.missionType === "audit").map(_.missionTypeId).first
   }
   val auditMissions = missions.filter(_.missionTypeId === auditMissionTypeId)
 
   val validationMissionTypeId: Int = db.withSession { implicit session =>
-    missionTypes.filter(_.missionType === "validation").map(_.missionTypeId).list.head
+    missionTypes.filter(_.missionType === "validation").map(_.missionTypeId).first
   }
   val validationMissions = missions.filter(_.missionTypeId === validationMissionTypeId)
 
@@ -250,14 +250,14 @@ object MissionTable {
     * Checks if the specified mission is an onboarding mission.
     */
   def isOnboardingMission(missionId: Int): Boolean = db.withSession { implicit session =>
-    MissionTypeTable.onboardingTypeIds.contains(missions.filter(_.missionId === missionId).map(_.missionTypeId).list.head)
+    MissionTypeTable.onboardingTypeIds.contains(missions.filter(_.missionId === missionId).map(_.missionTypeId).first)
   }
 
   /**
     * Checks if the specified mission is a CV ground truth mission.
     */
   def isCVGroundTruthMission(missionId: Int): Boolean = db.withSession { implicit session =>
-    MissionTypeTable.missionTypeToId("cvGroundTruth") == missions.filter(_.missionId === missionId).map(_.missionTypeId).list.head
+    MissionTypeTable.missionTypeToId("cvGroundTruth") == missions.filter(_.missionId === missionId).map(_.missionTypeId).first
   }
 
   /**
@@ -281,14 +281,14 @@ object MissionTable {
     * Get the user's incomplete mission in the region if there is one.
     */
   def getCurrentMissionInRegion(userId: UUID, regionId: Int): Option[Mission] = db.withSession { implicit session =>
-    missions.filter(m => m.userId === userId.toString && m.regionId === regionId && !m.completed).list.headOption
+    missions.filter(m => m.userId === userId.toString && m.regionId === regionId && !m.completed).firstOption
   }
 
   /**
     * Returns the mission with the provided ID, if it exists.
     */
   def getMissionById(missionId: Int): Option[Mission] = db.withSession { implicit session =>
-    missions.filter(m => m.missionId === missionId).list.headOption
+    missions.filter(m => m.missionId === missionId).firstOption
   }
 
   def getCurrentValidationMission(userId: UUID, labelTypeId: Int, missionType: String): Option[Mission] = db.withSession { implicit session =>
@@ -298,7 +298,7 @@ object MissionTable {
         && m.missionTypeId === missionTypeId
         && m.labelTypeId === labelTypeId
         && !m.completed
-    ).list.headOption
+    ).firstOption
   }
 
   /**
@@ -308,17 +308,17 @@ object MissionTable {
     * @return an incomplete CV ground truth audit mission
     */
   def getIncompleteCVGroundTruthMission(userId: UUID): Option[Mission] = db.withSession { implicit session =>
-    val cvGroundTruthId: Int = missionTypes.filter(_.missionType === "cvGroundTruth").map(_.missionTypeId).list.head
+    val cvGroundTruthId: Int = missionTypes.filter(_.missionType === "cvGroundTruth").map(_.missionTypeId).first
     missions.filter(m => m.userId === userId.toString && m.missionTypeId === cvGroundTruthId && !m.completed)
-      .sortBy(_.missionId).list.headOption
+      .sortBy(_.missionId).firstOption
   }
 
   /**
     * Get the user's incomplete auditOnboarding mission if there is one.
     */
   def getIncompleteAuditOnboardingMission(userId: UUID): Option[Mission] = db.withSession { implicit session =>
-    val tutorialId: Int = missionTypes.filter(_.missionType === "auditOnboarding").map(_.missionTypeId).list.head
-    missions.filter(m => m.userId === userId.toString && m.missionTypeId === tutorialId && !m.completed).list.headOption
+    val tutorialId: Int = missionTypes.filter(_.missionType === "auditOnboarding").map(_.missionTypeId).first
+    missions.filter(m => m.userId === userId.toString && m.missionTypeId === tutorialId && !m.completed).firstOption
   }
 
   /**
@@ -620,7 +620,7 @@ object MissionTable {
     val missionTypeId: Int = MissionTypeTable.missionTypeToId("audit")
     val newMission = Mission(0, missionTypeId, userId.toString, now, now, false, pay, false, Some(distance), Some(0.0.toFloat), Some(regionId), None, None, None, false, None)
     val missionId: Int = (missions returning missions.map(_.missionId)) += newMission
-    missions.filter(_.missionId === missionId).list.head
+    missions.filter(_.missionId === missionId).first
   }
 
   /**
@@ -639,7 +639,7 @@ object MissionTable {
     val missionTypeId: Int = MissionTypeTable.missionTypeToId(missionType)
     val newMission = Mission(0, missionTypeId, userId.toString, now, now, false, pay, false, None, None, None, Some(labelsToValidate), Some(0.0.toInt), Some(labelTypeId), false, None)
     val missionId: Int = (missions returning missions.map(_.missionId)) += newMission
-    missions.filter(_.missionId === missionId).list.head
+    missions.filter(_.missionId === missionId).first
   }
 
   /**
@@ -652,7 +652,7 @@ object MissionTable {
     val missionTypeId: Int = MissionTypeTable.missionTypeToId("cvGroundTruth")
     val newMission: Mission = Mission(0, missionTypeId, userId.toString, now, now, false, 0, false, None, None, None, None, None, None, false, None)
     val missionId: Int = (missions returning missions.map(_.missionId)) += newMission
-    missions.filter(_.missionId === missionId).list.head
+    missions.filter(_.missionId === missionId).first
   }
 
   /**
@@ -665,7 +665,7 @@ object MissionTable {
     val mTypeId: Int = MissionTypeTable.missionTypeToId("auditOnboarding")
     val newMiss = Mission(0, mTypeId, userId.toString, now, now, false, pay, false, None, None, None, None, None, None, false, None)
     val missionId: Int = (missions returning missions.map(_.missionId)) += newMiss
-    missions.filter(_.missionId === missionId).list.head
+    missions.filter(_.missionId === missionId).first
   }
 
   /**
@@ -675,7 +675,7 @@ object MissionTable {
     (for {
       _mission <- missions if _mission.missionId === missionId
       _missionType <- missionTypes if _mission.missionTypeId === _missionType.missionTypeId
-    } yield _missionType.missionType).list.headOption
+    } yield _missionType.missionType).firstOption
   }
 
   /**
@@ -742,7 +742,7 @@ object MissionTable {
     */
   def updateValidationProgress(missionId: Int, labelsProgress: Int): Int = db.withSession { implicit session =>
     val now: Timestamp = new Timestamp(Instant.now.toEpochMilli)
-    val missionLabels: Int = missions.filter(_.missionId === missionId).map(_.labelsValidated).list.head.get
+    val missionLabels: Int = missions.filter(_.missionId === missionId).map(_.labelsValidated).first.get
     val missionToUpdate = for { m <- missions if m.missionId === missionId } yield (m.labelsProgress, m.missionEnd)
 
     if (labelsProgress <= missionLabels) {

--- a/app/models/mission/MissionTypeTable.scala
+++ b/app/models/mission/MissionTypeTable.scala
@@ -31,7 +31,7 @@ object MissionTypeTable {
     * @return               ID associated with this mission type
     */
   def missionTypeToId(missionType: String): Int = db.withTransaction { implicit session =>
-    missionTypes.filter(_.missionType === missionType).map(_.missionTypeId).list.head
+    missionTypes.filter(_.missionType === missionType).map(_.missionTypeId).first
   }
 
   /**
@@ -41,7 +41,7 @@ object MissionTypeTable {
     * @return               Name field for this mission type
     */
   def missionTypeIdToMissionType(missionTypeId: Int): String = db.withTransaction { implicit session =>
-    missionTypes.filter(_.missionTypeId === missionTypeId).map(_.missionType).list.head
+    missionTypes.filter(_.missionTypeId === missionTypeId).map(_.missionType).first
   }
 
   /**

--- a/app/models/region/RegionPropertyTable.scala
+++ b/app/models/region/RegionPropertyTable.scala
@@ -24,10 +24,7 @@ object RegionPropertyTable {
     * Return the neighborhood name of the given region.
     */
   def neighborhoodName(regionId: Int): Option[String] = db.withSession { implicit session =>
-    val regionProperty = regionProperties.filter(_.regionId === regionId).filter(_.key === "Neighborhood Name").list.headOption
-    regionProperty match {
-      case Some(rp) => Some(rp.value)
-      case _ => None
-    }
+    val regionProperty: Option[RegionProperty] = regionProperties.filter(_.regionId === regionId).filter(_.key === "Neighborhood Name").firstOption
+    regionProperty.map(_.value)
   }
 }

--- a/app/models/region/RegionTable.scala
+++ b/app/models/region/RegionTable.scala
@@ -145,7 +145,7 @@ object RegionTable {
       (_neighborhoods, _properties) <- filteredNeighborhoods.leftJoin(regionProperties).on(_.regionId === _.regionId)
       if _properties.key === "Neighborhood Name"
     } yield (_neighborhoods.regionId, _properties.value.?, _neighborhoods.geom)
-    _regions.list.headOption.map(x => NamedRegion.tupled(x))
+    _regions.firstOption.map(x => NamedRegion.tupled(x))
   }
 
   /**
@@ -161,7 +161,7 @@ object RegionTable {
         (_regions, _properties) <- currentRegions.leftJoin(regionProperties).on(_.regionId === _.regionId)
         if _properties.key === "Neighborhood Name"
       } yield (_regions.regionId, _properties.value.?, _regions.geom)
-      _regions.list.headOption.map(x => NamedRegion.tupled(x))
+      _regions.firstOption.map(x => NamedRegion.tupled(x))
   }
 
   /**
@@ -220,6 +220,6 @@ object RegionTable {
         |    AND region_type_id = 2;
       """.stripMargin
     )
-    closestNeighborhoodQuery((lng, lat, lng, lat)).list.head
+    closestNeighborhoodQuery((lng, lat, lng, lat)).first
   }
 }

--- a/app/models/street/StreetEdgeRegionTable.scala
+++ b/app/models/street/StreetEdgeRegionTable.scala
@@ -61,7 +61,7 @@ object StreetEdgeRegionTable {
     val edgesAuditedInRegion: Int = (for {
       _edgeRegions <- nonDeletedStreetEdgeRegions if _edgeRegions.regionId === regionId
       _audits <- AuditTaskTable.completedTasks if _audits.streetEdgeId === _edgeRegions.streetEdgeId
-    } yield _audits.streetEdgeId).groupBy(x => x).map(_._1).list.length
+    } yield _audits.streetEdgeId).groupBy(x => x).map(_._1).size.run
 
     edgesAuditedInRegion == edgesInRegion
   }

--- a/app/models/street/StreetEdgeTable.scala
+++ b/app/models/street/StreetEdgeTable.scala
@@ -170,8 +170,7 @@ object StreetEdgeTable {
       }
 
       // Get length of each street segment, sum the lengths, and convert from meters to miles.
-      val distances: List[Float] = edgesWithAuditCounts.filter(_._2 >= auditCount).map(_._1).list
-      (distances.sum * 0.000621371).toFloat
+      edgesWithAuditCounts.filter(_._2 >= auditCount).map(_._1).sum.run.map(_ * 0.000621371F).getOrElse(0.0F)
     }
   }
 
@@ -334,7 +333,7 @@ object StreetEdgeTable {
 
   /** Returns the distance of the given street edge. */
   def getStreetEdgeDistance(streetEdgeId: Int): Float = db.withSession { implicit session =>
-    streetEdgesWithoutDeleted.filter(_.streetEdgeId === streetEdgeId).groupBy(x => x).map(_._1.geom.transform(26918).length).list.head
+    streetEdgesWithoutDeleted.filter(_.streetEdgeId === streetEdgeId).groupBy(x => x).map(_._1.geom.transform(26918).length).first
   }
 
   def selectStreetsIntersecting(minLat: Double, minLng: Double, maxLat: Double, maxLng: Double): List[StreetEdge] = db.withSession { implicit session =>

--- a/app/models/survey/SurveyQuestionTable.scala
+++ b/app/models/survey/SurveyQuestionTable.scala
@@ -23,7 +23,7 @@ object SurveyQuestionTable{
   val surveyOptions = TableQuery[SurveyOptionTable]
 
   def getQuestionById(surveyQuestionId: Int): Option[SurveyQuestion] = db.withTransaction { implicit session =>
-    surveyQuestions.filter(_.surveyQuestionId === surveyQuestionId).list.headOption
+    surveyQuestions.filter(_.surveyQuestionId === surveyQuestionId).firstOption
   }
 
   def listOptionsByQuestion(surveyQuestionId: Int): Option[List[SurveyOption]] = db.withTransaction { implicit session =>

--- a/app/models/user/UserRoleTable.scala
+++ b/app/models/user/UserRoleTable.scala
@@ -46,7 +46,7 @@ object UserRoleTable {
   }
 
   def setRole(userId: UUID, newRole: Int): Int = db.withTransaction { implicit session =>
-    val userRoleId: Option[Int] = userRoles.filter(_.userId === userId.toString).map(_.userRoleId).list.headOption
+    val userRoleId: Option[Int] = userRoles.filter(_.userId === userId.toString).map(_.userRoleId).firstOption
     userRoles.insertOrUpdate(UserRole(userRoleId.getOrElse(0), userId.toString, newRole))
   }
 }

--- a/app/models/user/VersionTable.scala
+++ b/app/models/user/VersionTable.scala
@@ -43,14 +43,14 @@ object VersionTable {
     * Returns current version ID.
     */
   def currentVersionId(): String = db.withSession { implicit session =>
-    versions.sortBy(_.versionStartTime.desc).list.head.versionId
+    versions.sortBy(_.versionStartTime.desc).first.versionId
   }
 
   /**
     * Returns timestamp of most recent update.
     */
   def currentVersionTimestamp(): String = db.withSession { implicit session =>
-    versions.sortBy(_.versionStartTime.desc).list.head.versionStartTime.toString
+    versions.sortBy(_.versionStartTime.desc).first.versionStartTime.toString
   }
 
   /**


### PR DESCRIPTION
Resolves #2101 

Marginally improves the efficiency of SQL queries that just output a `COUNT` by changing `.list.size` to `.size.run`, `list.head` to `.first`, and `.list.headOption` to `.firstOption`. The first one moves the counting computation out of Scala and into SQL. The latter two just remove the middle step of putting the result into a Scala list and then taking the first element; instead, we just grab that first element directly.

I don't expect these changes to have any material impact on website performance because I had already fixed the egregious examples of this problem. But this is technically more efficient and a better style, and it was really easy/fast to fix in one go, so I think it was worth it :wink: 

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
