### PR TITLE
Speeds up nightly computation of user stats

### DIFF
--- a/app/models/user/UserStatTable.scala
+++ b/app/models/user/UserStatTable.scala
@@ -6,6 +6,7 @@ import models.label.LabelTable
 import models.mission.MissionTable
 import models.utils.MyPostgresDriver.simple._
 import play.api.Play.current
+import java.sql.Timestamp
 import scala.slick.lifted.ForeignKeyQuery
 import scala.slick.jdbc.{StaticQuery => Q}
 
@@ -59,24 +60,32 @@ object UserStatTable {
   }
 
   /**
-    * Call helper functions to update all columns in user_stat table.
+    * Calls functions to update all columns in user_stat table. Only updates users who have audited since cutoff time.
     */
-  def updateUserStatTable() = db.withSession { implicit session =>
-    updateAuditedDistance()
-    updateLabelsPerMeter()
-    updateHighQuality()
+  def updateUserStatTable(cutoffTime: Timestamp) = db.withSession { implicit session =>
+    updateAuditedDistance(cutoffTime)
+    updateLabelsPerMeter(cutoffTime)
+    updateHighQuality(cutoffTime)
   }
 
   /**
-    * Update meters_audited column in the user_stat table for all users.
+    * Update meters_audited column in the user_stat table for users who have done any auditing since `cutoffTime`.
     */
-  def updateAuditedDistance() = db.withSession { implicit session =>
+  def updateAuditedDistance(cutoffTime: Timestamp) = db.withSession { implicit session =>
 
-    // Computes the audited distance in meters using the distance_progress column of the mission table.
-    val auditedDists: List[(String, Option[Float])] = (for {
+    // Get the list of users who have done any auditing since the cutoff time.
+    val usersToUpdate: List[String] = (for {
       _user <- userTable if _user.username =!= "anonymous"
       _mission <- MissionTable.auditMissions if _mission.userId === _user.userId
-    } yield (_user.userId, _mission.distanceProgress)).groupBy(_._1).map(x => (x._1, x._2.map(_._2).sum)).list
+      if _mission.missionEnd > cutoffTime
+    } yield _user.userId).groupBy(x => x).map(_._1).list
+
+    // Computes the audited distance in meters using the distance_progress column of the mission table.
+    val auditedDists: List[(String, Option[Float])] =
+      MissionTable.auditMissions
+        .filter(_.userId inSet usersToUpdate)
+        .groupBy(_.userId).map(x => (x._1, x._2.map(_.distanceProgress).sum))
+        .list
 
     // Update the meters_audited column in the user_stat table.
     for ((userId, auditedDist) <- auditedDists) {
@@ -86,20 +95,23 @@ object UserStatTable {
   }
 
   /**
-    * Update labels_per_meter column in the user_stat table for all users, run after `updateAuditedDistance`.
+    * Update labels_per_meter column in the user_stat table for all users who have done any auditing since `cutoffTime`.
     */
-  def updateLabelsPerMeter() = db.withSession { implicit session =>
+  def updateLabelsPerMeter(cutoffTime: Timestamp) = db.withSession { implicit session =>
 
-    // Compute label counts for each user that has audited.
+    // Get the list of users who have done any auditing since the cutoff time.
+    val usersStatsToUpdate: List[String] = usersThatAuditedSinceCutoffTime(cutoffTime)
+
+    // Compute label counts for each of those users.
     val labelCounts = (for {
-      _stat <- userStats if _stat.metersAudited > 0F
-      _mission <- MissionTable.auditMissions if _stat.userId === _mission.userId
+      _mission <- MissionTable.auditMissions
       _label <- LabelTable.labelsWithoutDeletedOrOnboarding if _mission.missionId === _label.missionId
-    } yield (_stat.userId, _label.labelId)).groupBy(_._1).map(x => (x._1, x._2.length))
+      if _mission.userId inSet usersStatsToUpdate
+    } yield (_mission.userId, _label.labelId)).groupBy(_._1).map(x => (x._1, x._2.length))
 
     // Compute labeling frequency using label counts above and the meters_audited column in user_stat table.
     val labelFreq: List[(String, Float)] = userStats
-      .filter(_.metersAudited > 0F)
+      .filter(_.userId inSet usersStatsToUpdate)
       .leftJoin(labelCounts).on(_.userId === _._1)
       .map { case (_stat, _count) =>
         (_stat.userId, _count._2.ifNull(0.asColumnOf[Int]).asColumnOf[Float] / _stat.metersAudited)
@@ -113,9 +125,11 @@ object UserStatTable {
   }
 
   /**
-    * Update high_quality column in the user_stat table, run after `updateAuditedDistance` and `updateLabelsPerMeter`.
-    */
-  def updateHighQuality() = db.withSession { implicit session =>
+   * Update high_quality column in the user_stat table, run after `updateAuditedDistance` and `updateLabelsPerMeter`.
+   *
+   * @return Number of user's whose records were updated.
+   */
+  def updateHighQuality(cutoffTime: Timestamp): Int = db.withSession { implicit session =>
 
     // Get users manually marked as low quality first.
     val lowQualityUsers: List[(String, Boolean)] =
@@ -133,11 +147,34 @@ object UserStatTable {
         )
       }.list
 
-    // Update the high_quality column in the user_stat table.
-    for ((userId, highQuality) <- lowQualityUsers ++ userQuality) {
-      val updateQuery = for {_userStat <- userStats if _userStat.userId === userId} yield _userStat.highQuality
-      updateQuery.update(highQuality)
-    }
+    // Get the list of users who have done any auditing since the cutoff time. Will only update these users.
+    val usersStatsToUpdate: List[String] = usersThatAuditedSinceCutoffTime(cutoffTime)
+
+    // Make separate lists for low vs high quality users, then bulk update each.
+    val updateToLowQuaity: List[String] =
+      (lowQualityUsers ++ userQuality.filterNot(_._2)).map(_._1).filter(x => usersStatsToUpdate.contains(x))
+    val updateToHighQuality: List[String] =
+      userQuality.filter(_._2).map(_._1).filter(x => usersStatsToUpdate.contains(x))
+
+    val lowQualityUpdateQuery = for { _u <- userStats if _u.userId inSet updateToLowQuaity } yield _u.highQuality
+    val highQualityUpdateQuery = for { _u <- userStats if _u.userId inSet updateToHighQuality } yield _u.highQuality
+
+    // Do both bulk updates, and return total number of updated rows.
+    lowQualityUpdateQuery.update(false) + highQualityUpdateQuery.update(true)
+  }
+
+  /**
+   * Helper function to get list of users who have done any auditing since the cutoff time.
+   */
+  def usersThatAuditedSinceCutoffTime(cutoffTime: Timestamp): List[String] = db.withSession { implicit session =>
+    (for {
+      _user <- userTable
+      _userStat <- userStats if _user.userId === _userStat.userId
+      _mission <- MissionTable.auditMissions if _mission.userId === _user.userId
+      if _user.username =!= "anonymous"
+      if _userStat.metersAudited > 0F
+      if _mission.missionEnd > cutoffTime
+    } yield _user.userId).list
   }
 
   /**

--- a/app/utils/actor/UserStatActor.scala
+++ b/app/utils/actor/UserStatActor.scala
@@ -5,6 +5,8 @@ import java.util.{Calendar, Locale, TimeZone}
 import akka.actor.{Actor, Cancellable, Props}
 import models.user.UserStatTable
 import play.api.Logger
+import java.sql.Timestamp
+import java.time.Instant
 import scala.concurrent.duration._
 
 // Template code comes from this helpful StackOverflow post:
@@ -58,7 +60,10 @@ class UserStatActor extends Actor {
 
       val currentTimeStart: String = dateFormatter.format(Calendar.getInstance(TIMEZONE).getTime)
       Logger.info(s"Auto-scheduled computation of user stats starting at: $currentTimeStart")
-      UserStatTable.updateUserStatTable()
+      // Update stats for anyone who audited in past 36 hours.
+      val msCutoff: Long = 36 * 3600000L
+      val cutoffTime: Timestamp = new Timestamp(Instant.now.toEpochMilli - msCutoff)
+      UserStatTable.updateUserStatTable(cutoffTime)
       val currentEndTime: String = dateFormatter.format(Calendar.getInstance(TIMEZONE).getTime)
       Logger.info(s"Updating user stats completed at: $currentEndTime")
   }

--- a/conf/routes
+++ b/conf/routes
@@ -69,6 +69,7 @@ GET     /adminapi/labelCounts                                @controllers.AdminC
 GET     /adminapi/attributes/all                             @controllers.AdminController.getAllAttributes
 GET     /adminapi/validationCounts                           @controllers.AdminController.getAllUserValidationCounts
 PUT     /adminapi/clearPlayCache                             @controllers.AdminController.clearPlayCache
+GET     /adminapi/updateUserStats                            @controllers.AdminController.updateUserStats(hoursCutoff: Option[Int])
 
 GET     /adminapi/webpageActivity                            @controllers.AdminController.getAllWebpageActivities
 GET     /adminapi/webpageActivity/:activity                  @controllers.AdminController.getWebpageActivities(activity: String)


### PR DESCRIPTION
Resolves #2107 

Speeds up the nightly computation of user stats. There are two big optimizations:
1. Only updating stats for users who have audited in the past 36 hours instead of recomputing stats for everyone.
2. Using the bulk update feature in Slick for updating the `high_quality` column. Doing two bulk updates (one for high quality users and one for low quality users) is much faster than doing a thousand individual updates.

Since I set it to only look at users who audited in the past 36 hours by default, I added a separate admin endpoint (`/adminapi/updateUserStats`) where we can do a full recomputation of stats for everyone, in case that ever comes up. We can also specify an arbitrary cutoff time at that endpoint.

On my local dev environment using a Seattle database dump from Feb 2021 (very recent), calculating the stats was taking ~4.5 minutes on the develop branch. On this branch with the optimizations, it's taking around 20 seconds now :ok_hand: On production, it's taking around 20 minutes, but that might be because multiple servers are trying to do the same updates at once.

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've added/updated comments for large or confusing blocks of code.
