### PR TITLE
2499 speed up label clustering

### DIFF
--- a/app/controllers/AttributeController.scala
+++ b/app/controllers/AttributeController.scala
@@ -9,7 +9,6 @@ import play.api.libs.json._
 import controllers.headers.ProvidesHeader
 import controllers.helper.AttributeControllerHelper
 import models.user.User
-
 import scala.concurrent.Future
 import play.api.mvc._
 import play.api.libs.json.Json
@@ -71,9 +70,7 @@ class AttributeController @Inject() (implicit val env: Environment[User, Session
           val msCutoff: Long = hours * 3600000L
           new Timestamp(Instant.now.toEpochMilli - msCutoff)
         case None =>
-          val msCutoff: Long = 36 * 3600000L
-//          new Timestamp(Instant.EPOCH.toEpochMilli)
-          new Timestamp(Instant.now.toEpochMilli - msCutoff)
+          new Timestamp(Instant.EPOCH.toEpochMilli)
       }
       val json = AttributeControllerHelper.runClustering(clusteringType, cutoffTime)
       Future.successful(Ok(json))

--- a/app/controllers/helper/AttributeControllerHelper.scala
+++ b/app/controllers/helper/AttributeControllerHelper.scala
@@ -55,10 +55,14 @@ object AttributeControllerHelper {
     val t1 = System.nanoTime
     val goodUsersToUpdate: List[String] = UserStatTable.getIdsOfGoodUsersWithLabels(cutoffTime)
     val t2 = System.nanoTime
+    val newBadUsers: List[String] = UserStatTable.getIdsOfNewlyLowQualityUsers
     val t3 = System.nanoTime
+    val usersToDelete: List[String] = (goodUsersToUpdate ++ newBadUsers).distinct
+    println(s"Good users to update: ${goodUsersToUpdate.length}")
+    println(s"Bad users to remove: ${newBadUsers.length}")
     // First truncate the user_clustering_session, user_attribute, and user_attribute_label tables.
 //    UserClusteringSessionTable.truncateTables()
-    UserClusteringSessionTable.deleteUsersClusteringSessions(goodUsersToUpdate)
+    UserClusteringSessionTable.deleteUsersClusteringSessions(usersToDelete)
     val t4 = System.nanoTime
 
     val key: String = Play.configuration.getString("internal-api-key").get

--- a/app/controllers/helper/AttributeControllerHelper.scala
+++ b/app/controllers/helper/AttributeControllerHelper.scala
@@ -7,21 +7,25 @@ import play.api.{Logger, Play}
 import play.api.Play.current
 import play.api.libs.json.Json
 
+import java.sql.Timestamp
+import java.time.Instant
 import scala.collection.immutable.Seq
 import scala.sys.process._
 
 object AttributeControllerHelper {
   /**
-    * Calls the appropriate clustering function(s); either single-user clustering, multi-user clustering, or both.
-    *
-    * @param clusteringType One of "singleUser", "multiUser", or "both".
-    */
-  def runClustering(clusteringType: String) = {
+   * Calls the appropriate clustering function(s); either single-user clustering, multi-user clustering, or both.
+   *
+   * @param clusteringType One of "singleUser", "multiUser", or "both".
+   * @param cutoffTime Only cluster users who have placed a label since this time. Defaults to all time.
+   * @return Counts of attributes and the labels that were clustered into those attributes in JSON.
+   */
+  def runClustering(clusteringType: String, cutoffTime: Timestamp = new Timestamp(Instant.EPOCH.toEpochMilli)) = {
     if (clusteringType == "singleUser" || clusteringType == "both") {
-      runSingleUserClusteringAllUsers()
+      runSingleUserClustering(cutoffTime)
     }
     if (clusteringType == "multiUser" || clusteringType == "both") {
-      runMultiUserClusteringAllRegions()
+      runMultiUserClustering()
     }
 
     // Gets the counts of labels/attributes from the affected tables to show how many clusters were created.
@@ -41,40 +45,52 @@ object AttributeControllerHelper {
       )
       case _ => Json.obj("error_msg" -> "Invalid clusteringType")
     }
-
     json
   }
 
   /**
-    * Runs single user clustering for each high quality user.
-    */
-  def runSingleUserClusteringAllUsers() = {
-
+   * Runs single user clustering for each high quality user who has placed a label since `cutoffTime`.
+   */
+  def runSingleUserClustering(cutoffTime: Timestamp) = {
+    val t1 = System.nanoTime
+    val goodUsersToUpdate: List[String] = UserStatTable.getIdsOfGoodUsersWithLabels(cutoffTime)
+    val t2 = System.nanoTime
+    val t3 = System.nanoTime
     // First truncate the user_clustering_session, user_attribute, and user_attribute_label tables.
-    UserClusteringSessionTable.truncateTables()
+//    UserClusteringSessionTable.truncateTables()
+    UserClusteringSessionTable.deleteUsersClusteringSessions(goodUsersToUpdate)
+    val t4 = System.nanoTime
 
     val key: String = Play.configuration.getString("internal-api-key").get
-    val goodUsers: List[String] = UserStatTable.getIdsOfGoodUsersWithLabels
-    val nUsers = goodUsers.length
+    val t5 = System.nanoTime
+    val nUsers = goodUsersToUpdate.length
     Logger.info("N users = " + nUsers)
 
     // Runs clustering for each good user.
-    for ((userId, i) <- goodUsers.view.zipWithIndex) {
+    for ((userId, i) <- goodUsersToUpdate.view.zipWithIndex) {
       Logger.info(s"Finished ${f"${100.0 * i / nUsers}%1.2f"}% of users, next: $userId.")
       val clusteringOutput =
         Seq("python", "label_clustering.py", "--key", key, "--user_id", userId).!!
       // Logger.info(clusteringOutput)
     }
+    val t6 = System.nanoTime
     Logger.info("\nFinshed 100% of users!!\n")
+    println(s"good user query time: ${(t2 - t1) / 1e9d}s")
+    println(s"bad user query time: ${(t3 - t2) / 1e9d}s")
+    println(s"delete users query time: ${(t4 - t3) / 1e9d}s")
+    println(s"get API key time: ${(t5 - t4) / 1e9d}s")
+    println(s"clustering time: ${(t6 - t5) / 1e9d}s")
   }
 
   /**
     * Runs multi user clustering for the user attributes in each region.
     */
-  def runMultiUserClusteringAllRegions() = {
+  def runMultiUserClustering() = {
+    val t1 = System.nanoTime
 
     // First truncate the global_clustering_session, global_attribute, and global_attribute_user_attribute tables.
     GlobalClusteringSessionTable.truncateTables()
+    val t2 = System.nanoTime
 
     val key: String = Play.configuration.getString("internal-api-key").get
     val regionIds: List[Int] = RegionTable.selectAllNeighborhoods.map(_.regionId).sortBy(x => x)
@@ -88,5 +104,8 @@ object AttributeControllerHelper {
       val clusteringOutput = Seq("python", "label_clustering.py", "--key", key, "--region_id", regionId.toString).!!
     }
     Logger.info("\nFinshed 100% of regions!!\n\n")
+    val t3 = System.nanoTime
+    println(s"truncate time: ${(t2 - t1) / 1e9d}s")
+    println(s"clustering time: ${(t3 - t2) / 1e9d}s")
   }
 }

--- a/app/models/attribute/GlobalClusteringSessionTable.scala
+++ b/app/models/attribute/GlobalClusteringSessionTable.scala
@@ -62,6 +62,16 @@ object GlobalClusteringSessionTable {
     Q.updateNA("TRUNCATE TABLE global_clustering_session CASCADE").execute
   }
 
+  /**
+   * Deletes the global attributes for the selected region_ids.
+   *
+   * We run the delete on the `global_clustering_session` table, and it cascades to the `global_attribute` and
+   * `global_attribute_user_attribute` tables.
+   */
+  def deleteGlobalClusteringSessions(regionIds: List[Int]): Int = db.withTransaction { implicit session =>
+    globalClusteringSessions.filter(_.regionId inSet regionIds).delete
+  }
+
   def save(newSess: GlobalClusteringSession): Int = db.withTransaction { implicit session =>
     val newId: Int = (globalClusteringSessions returning globalClusteringSessions.map(_.globalClusteringSessionId)) += newSess
     newId

--- a/app/models/attribute/GlobalClusteringSessionTable.scala
+++ b/app/models/attribute/GlobalClusteringSessionTable.scala
@@ -28,6 +28,32 @@ class GlobalClusteringSessionTable(tag: Tag) extends Table[GlobalClusteringSessi
 object GlobalClusteringSessionTable {
   val db: slick.Database = play.api.db.slick.DB
   val globalClusteringSessions: TableQuery[GlobalClusteringSessionTable] = TableQuery[GlobalClusteringSessionTable]
+  val globalAttributeUserAttributes: TableQuery[GlobalAttributeUserAttributeTable] = TableQuery[GlobalAttributeUserAttributeTable]
+
+  /**
+   * Gets list of region_ids where the underlying data has been changed during single-user clustering.
+   *
+   * Data in the `global_attribute` table that is missing from the `global_attribute_user_attribute` table means that
+   * the user who contributed the data has added data or has been marked as low quality. Data in the `user_attribute`
+   * table that is missing from the `global_attribute_user_attribute` table means that this is a new user or they've
+   * added new data. SELECT DISTINCT on the associated region_ids from both queries yields all regions to update.
+   */
+  def getNeighborhoodsToReCluster: List[Int] = db.withSession { implicit session =>
+    // global_attribute left joins with global_attribute_user_attribute, nulls mean low quality/updated users.
+    val lowQualityOrUpdated = GlobalAttributeTable.globalAttributes
+      .leftJoin(globalAttributeUserAttributes).on(_.globalAttributeId === _.globalAttributeId)
+      .filter(_._2.globalAttributeId.?.isEmpty)
+      .map(_._1.regionId)
+
+    // global_attribute_user_attribute right joins with user_attribute, nulls mean new/updated users.
+    val newOrUpdated = globalAttributeUserAttributes
+      .rightJoin(UserAttributeTable.userAttributes).on(_.userAttributeId === _.userAttributeId)
+      .filter(_._1.userAttributeId.?.isEmpty)
+      .map(_._2.regionId)
+
+    // Combine the two (union removes duplicates)
+    (lowQualityOrUpdated union newOrUpdated).list
+  }
 
   /**
     * Truncates global_clustering_session, global_attribute, and global_attribute_user_attribute.

--- a/app/models/attribute/UserClusteringSessionTable.scala
+++ b/app/models/attribute/UserClusteringSessionTable.scala
@@ -117,7 +117,7 @@ object UserClusteringSessionTable {
   }
 
   /**
-   * Deletes the entry in the `user_clustering_session` table and (almost) all connected data for the given users.
+   * Deletes the entries in the `user_clustering_session` table and (almost) all connected data for the given users.
    *
    * Deletes the entry in the `user_clustering_session` table, and the connected entries in the `user_attribute`,
    * `user_attribute_label`, and `global_attribute_user_attribute` tables. We leave the data in the `global_attribute`

--- a/app/models/attribute/UserClusteringSessionTable.scala
+++ b/app/models/attribute/UserClusteringSessionTable.scala
@@ -116,6 +116,30 @@ object UserClusteringSessionTable {
     Q.updateNA("TRUNCATE TABLE user_clustering_session CASCADE").execute
   }
 
+  /**
+   * Deletes the entry in the `user_clustering_session` table and (almost) all connected data for the given users.
+   *
+   * Deletes the entry in the `user_clustering_session` table, and the connected entries in the `user_attribute`,
+   * `user_attribute_label`, and `global_attribute_user_attribute` tables. We leave the data in the `global_attribute`
+   * alone. Since we can't use a join in a delete statement and the `user_attribute` table has foreign key constraints
+   * on both the `user_clustering_session` and `global_attribute_user_attribute` tables, we have to start by getting the
+   * list of `user_attribute_id`s to delete from the `global_attribute_user_attribute` first; then we can use
+   * `DELETE CASCADE` on the `user_clustering_session` table.
+   */
+  def deleteUsersClusteringSessions(usersToDelete: List[String]): Int = db.withTransaction { implicit session =>
+    // Get list of `user_attribute_id`s to delete from the `global_attribute_user_attribute` table.
+    val userAttributesToDelete: List[Int] = userClusteringSessions
+      .innerJoin(UserAttributeTable.userAttributes).on(_.userClusteringSessionId === _.userClusteringSessionId)
+      .filter(_._1.userId inSet usersToDelete)
+      .map(_._2.userAttributeId).list
+
+    // DELETE entries in `global_attribute_user_attribute` and then DELETE CASCADE entries in `user_clustering_session`.
+    val nGlobalAttributeLinksDeleted: Int = GlobalAttributeUserAttributeTable.globalAttributeUserAttributes
+      .filter(_.userAttributeId inSet userAttributesToDelete)
+      .delete
+    userClusteringSessions.filter(_.userId inSet usersToDelete).delete
+  }
+
   def save(newSess: UserClusteringSession): Int = db.withTransaction { implicit session =>
     val newId: Int = (userClusteringSessions returning userClusteringSessions.map(_.userClusteringSessionId)) += newSess
     newId

--- a/app/models/user/UserStatTable.scala
+++ b/app/models/user/UserStatTable.scala
@@ -1,14 +1,12 @@
 package models.user
 
 import models.attribute.UserClusteringSessionTable
-
 import java.util.UUID
 import models.daos.slick.DBTableDefinitions.{DBUser, UserTable}
 import models.label.LabelTable
 import models.mission.MissionTable
 import models.utils.MyPostgresDriver.simple._
 import play.api.Play.current
-
 import java.sql.Timestamp
 import java.time.Instant
 import scala.slick.lifted.ForeignKeyQuery

--- a/app/utils/actor/ClusterLabelAttributesActor.scala
+++ b/app/utils/actor/ClusterLabelAttributesActor.scala
@@ -5,6 +5,9 @@ import java.util.{Calendar, Locale, TimeZone}
 import akka.actor.{Actor, Cancellable, Props}
 import controllers.helper.AttributeControllerHelper
 import play.api.Logger
+
+import java.sql.Timestamp
+import java.time.Instant
 import scala.concurrent.duration._
 
 // Template code comes from this helpful StackOverflow post:
@@ -59,7 +62,10 @@ class ClusterLabelAttributesActor extends Actor {
 
       val currentTimeStart: String = dateFormatter.format(Calendar.getInstance(TIMEZONE).getTime)
       Logger.info(s"Auto-scheduled clustering of label attributes starting at: $currentTimeStart")
-      AttributeControllerHelper.runClustering("both")
+      // Update clusters for anyone who audited in the past 36 hours.
+      val msCutoff: Long = 36 * 3600000L
+      val cutoffTime: Timestamp = new Timestamp(Instant.now.toEpochMilli - msCutoff)
+      AttributeControllerHelper.runClustering("both", cutoffTime)
       val currentEndTime: String = dateFormatter.format(Calendar.getInstance(TIMEZONE).getTime)
       Logger.info(s"Label attribute clustering completed at: $currentEndTime")
   }

--- a/app/views/clustering.scala.html
+++ b/app/views/clustering.scala.html
@@ -10,7 +10,7 @@
             <button id="btn-multi-user-clustering">Multi User Clustering</button>
             <button id="btn-both-clustering">Single AND Multi User Clustering</button>
             <br/>
-            <label for="hours-to-go-back">Hours to go back (integer):</label>
+            <label for="hours-to-go-back">If updating only, (integer) hours to go back:</label>
             <input id="hours-to-go-back" type="number">
             <p id="clustering-status"></p>
         </div>

--- a/app/views/clustering.scala.html
+++ b/app/views/clustering.scala.html
@@ -6,9 +6,12 @@
     <div id="content">
         <div class="container">
             <h1>Clustering labels into attributes</h1>
-            <button id="btnSingleUserClustering">Single User Clustering</button>
-            <button id="btnMultiUserClustering">Multi User Clustering</button>
-            <button id="btnBothClustering">Single AND Multi User Clustering</button>
+            <button id="btn-single-user-clustering">Single User Clustering</button>
+            <button id="btn-multi-user-clustering">Multi User Clustering</button>
+            <button id="btn-both-clustering">Single AND Multi User Clustering</button>
+            <br/>
+            <label for="hours-to-go-back">Hours to go back (integer):</label>
+            <input id="hours-to-go-back" type="number">
             <p id="clustering-status"></p>
         </div>
     </div>
@@ -16,12 +19,14 @@
     @*Adds onclicks to each button that calls clustering code and extracts results from the response.*@
     <script>
         $(document).ready(function () {
-            let singleUserButton = document.getElementById('btnSingleUserClustering');
+            let singleUserButton = document.getElementById('btn-single-user-clustering');
             singleUserButton.onclick = function() {
                 $( "#clustering-status" ).html( 'Running...' );
+                let hours = document.getElementById('hours-to-go-back').value
+                let hoursParam = hours ? `&hoursCutoff=${hours}` : '';
                 $.ajax({
                     type: "get",
-                    url: "/runClustering?clusteringType=singleUser",
+                    url: "/runClustering?clusteringType=singleUser" + hoursParam,
                     contentType: 'application/json; charset=utf-8',
                     success: function (data) {
                         $( "#clustering-status" ).html(
@@ -37,7 +42,7 @@
             };
         });
         $(document).ready(function () {
-            let multiUserButton = document.getElementById('btnMultiUserClustering');
+            let multiUserButton = document.getElementById('btn-multi-user-clustering');
             multiUserButton.onclick = function() {
                 $( "#clustering-status" ).html( 'Running...' );
                 $.ajax({
@@ -58,12 +63,14 @@
             };
         });
         $(document).ready(function () {
-            let bothButton = document.getElementById('btnBothClustering');
+            let bothButton = document.getElementById('btn-both-clustering');
             bothButton.onclick = function() {
                 $( "#clustering-status" ).html( 'Running...' );
+                let hours = document.getElementById('hours-to-go-back').value
+                let hoursParam = hours ? `&hoursCutoff=${hours}` : '';
                 $.ajax({
                     type: "get",
-                    url: "/runClustering?clusteringType=both",
+                    url: "/runClustering?clusteringType=both" + hoursParam,
                     contentType: 'application/json; charset=utf-8',
                     success: function (data) {
                         $( "#clustering-status" ).html(

--- a/conf/evolutions/default/106.sql
+++ b/conf/evolutions/default/106.sql
@@ -15,22 +15,33 @@ ALTER TABLE user_attribute_label
 
 ALTER TABLE global_attribute_user_attribute
     DROP CONSTRAINT global_attribute_user_attribute_user_attribute_id_fkey,
+    DROP CONSTRAINT global_attribute_user_attribute_global_attribute_id_fkey,
     ADD CONSTRAINT global_attribute_user_attribute_user_attribute_id_fkey
         FOREIGN KEY (user_attribute_id)
             REFERENCES user_attribute(user_attribute_id)
+            ON DELETE CASCADE,
+    ADD CONSTRAINT global_attribute_user_attribute_global_attribute_id_fkey
+        FOREIGN KEY (global_attribute_id)
+            REFERENCES global_attribute(global_attribute_id)
             ON DELETE CASCADE;
 
 CREATE INDEX user_attribute_user_clustering_session_id_idx ON user_attribute USING btree(user_clustering_session_id);
-CREATE INDEX global_attribute_user_attribute_user_attribute_id_idx ON global_attribute_user_attribute USING btree(user_attribute_id);
 CREATE INDEX user_attribute_label_user_attribute_id_idx ON user_attribute_label USING btree(user_attribute_id);
+CREATE INDEX global_attribute_user_attribute_user_attribute_id_idx ON global_attribute_user_attribute USING btree(user_attribute_id);
+CREATE INDEX global_attribute_user_attribute_global_attribute_id_idx ON global_attribute_user_attribute USING btree(global_attribute_id);
 
 # --- !Downs
-DROP INDEX IF EXISTS user_attribute_label_user_attribute_id_idx;
+DROP INDEX IF EXISTS global_attribute_user_attribute_global_attribute_id_idx;
 DROP INDEX IF EXISTS global_attribute_user_attribute_user_attribute_id_idx;
+DROP INDEX IF EXISTS user_attribute_label_user_attribute_id_idx;
 DROP INDEX IF EXISTS user_attribute_user_clustering_session_id_idx;
 
 ALTER TABLE global_attribute_user_attribute
+    DROP CONSTRAINT global_attribute_user_attribute_global_attribute_id_fkey,
     DROP CONSTRAINT global_attribute_user_attribute_user_attribute_id_fkey,
+    ADD CONSTRAINT global_attribute_user_attribute_global_attribute_id_fkey
+        FOREIGN KEY (global_attribute_id)
+            REFERENCES global_attribute(global_attribute_id),
     ADD CONSTRAINT global_attribute_user_attribute_user_attribute_id_fkey
         FOREIGN KEY (user_attribute_id)
             REFERENCES user_attribute(user_attribute_id);

--- a/conf/evolutions/default/106.sql
+++ b/conf/evolutions/default/106.sql
@@ -25,16 +25,31 @@ ALTER TABLE global_attribute_user_attribute
             REFERENCES global_attribute(global_attribute_id)
             ON DELETE CASCADE;
 
+ALTER TABLE global_attribute
+    DROP CONSTRAINT global_attribute_global_clustering_session_id_fkey,
+    ADD CONSTRAINT global_attribute_global_clustering_session_id_fkey
+        FOREIGN KEY (global_clustering_session_id)
+            REFERENCES global_clustering_session(global_clustering_session_id)
+            ON DELETE CASCADE;
+
 CREATE INDEX user_attribute_user_clustering_session_id_idx ON user_attribute USING btree(user_clustering_session_id);
 CREATE INDEX user_attribute_label_user_attribute_id_idx ON user_attribute_label USING btree(user_attribute_id);
 CREATE INDEX global_attribute_user_attribute_user_attribute_id_idx ON global_attribute_user_attribute USING btree(user_attribute_id);
 CREATE INDEX global_attribute_user_attribute_global_attribute_id_idx ON global_attribute_user_attribute USING btree(global_attribute_id);
+CREATE INDEX global_attribute_global_clustering_session_id_idx ON global_attribute USING btree(global_clustering_session_id);
 
 # --- !Downs
+DROP INDEX IF EXISTS user_attribute_user_clustering_session_id_idx;
 DROP INDEX IF EXISTS global_attribute_user_attribute_global_attribute_id_idx;
 DROP INDEX IF EXISTS global_attribute_user_attribute_user_attribute_id_idx;
 DROP INDEX IF EXISTS user_attribute_label_user_attribute_id_idx;
-DROP INDEX IF EXISTS user_attribute_user_clustering_session_id_idx;
+DROP INDEX IF EXISTS global_attribute_global_clustering_session_id_idx;
+
+ALTER TABLE global_attribute
+    DROP CONSTRAINT global_attribute_global_clustering_session_id_fkey,
+    ADD CONSTRAINT global_attribute_global_clustering_session_id_fkey
+        FOREIGN KEY (global_clustering_session_id)
+            REFERENCES global_clustering_session(global_clustering_session_id);
 
 ALTER TABLE global_attribute_user_attribute
     DROP CONSTRAINT global_attribute_user_attribute_global_attribute_id_fkey,

--- a/conf/evolutions/default/106.sql
+++ b/conf/evolutions/default/106.sql
@@ -1,0 +1,48 @@
+# --- !Ups
+ALTER TABLE user_attribute
+    DROP CONSTRAINT user_attribute_user_clustering_session_id_fkey,
+    ADD CONSTRAINT user_attribute_user_clustering_session_id_fkey
+        FOREIGN KEY (user_clustering_session_id)
+            REFERENCES user_clustering_session(user_clustering_session_id)
+            ON DELETE CASCADE;
+
+ALTER TABLE user_attribute_label
+    DROP CONSTRAINT user_attribute_label_user_attribute_id_fkey,
+    ADD CONSTRAINT user_attribute_label_user_attribute_id_fkey
+        FOREIGN KEY (user_attribute_id)
+            REFERENCES user_attribute(user_attribute_id)
+            ON DELETE CASCADE;
+
+ALTER TABLE global_attribute_user_attribute
+    DROP CONSTRAINT global_attribute_user_attribute_user_attribute_id_fkey,
+    ADD CONSTRAINT global_attribute_user_attribute_user_attribute_id_fkey
+        FOREIGN KEY (user_attribute_id)
+            REFERENCES user_attribute(user_attribute_id)
+            ON DELETE CASCADE;
+
+CREATE INDEX user_attribute_user_clustering_session_id_idx ON user_attribute USING btree(user_clustering_session_id);
+CREATE INDEX global_attribute_user_attribute_user_attribute_id_idx ON global_attribute_user_attribute USING btree(user_attribute_id);
+CREATE INDEX user_attribute_label_user_attribute_id_idx ON user_attribute_label USING btree(user_attribute_id);
+
+# --- !Downs
+DROP INDEX IF EXISTS user_attribute_label_user_attribute_id_idx;
+DROP INDEX IF EXISTS global_attribute_user_attribute_user_attribute_id_idx;
+DROP INDEX IF EXISTS user_attribute_user_clustering_session_id_idx;
+
+ALTER TABLE global_attribute_user_attribute
+    DROP CONSTRAINT global_attribute_user_attribute_user_attribute_id_fkey,
+    ADD CONSTRAINT global_attribute_user_attribute_user_attribute_id_fkey
+        FOREIGN KEY (user_attribute_id)
+            REFERENCES user_attribute(user_attribute_id);
+
+ALTER TABLE user_attribute_label
+    DROP CONSTRAINT user_attribute_label_user_attribute_id_fkey,
+    ADD CONSTRAINT user_attribute_label_user_attribute_id_fkey
+        FOREIGN KEY (user_attribute_id)
+            REFERENCES user_attribute(user_attribute_id);
+
+ALTER TABLE user_attribute
+    DROP CONSTRAINT user_attribute_user_clustering_session_id_fkey,
+    ADD CONSTRAINT user_attribute_user_clustering_session_id_fkey
+        FOREIGN KEY (user_clustering_session_id)
+            REFERENCES user_clustering_session(user_clustering_session_id);

--- a/conf/routes
+++ b/conf/routes
@@ -166,7 +166,7 @@ POST    /amtAssignment                                       @controllers.Missio
 
 # Clustering and Attributes
 GET     /clustering                                          @controllers.AttributeController.index
-GET     /runClustering                                       @controllers.AttributeController.runClustering(clusteringType: String ?= "both")
+GET     /runClustering                                       @controllers.AttributeController.runClustering(clusteringType: String ?= "both", hoursCutoff: Option[Int])
 GET     /userLabelsToCluster                                 @controllers.AttributeController.getUserLabelsToCluster(key: String, userId: String)
 GET     /clusteredLabelsInRegion                             @controllers.AttributeController.getClusteredLabelsInRegion(key: String, regionId: Int)
 POST    /singleUserClusteringResults                         @controllers.AttributeController.postSingleUserClusteringResults(key: String, userId: String)

--- a/label_clustering.py
+++ b/label_clustering.py
@@ -70,7 +70,7 @@ if __name__ == '__main__':
     USER_ID = args.user_id.strip('\'\"') if args.user_id else None
     REGION_ID = args.region_id
 
-    N_PROCESSORS = 3
+    N_PROCESSORS = 8
 
     # Determine what type of clustering should be done from command line args, and set variable accordingly.
     getURL = None


### PR DESCRIPTION
Resolves (partially) #2499 

Speeds up the nightly clustering of labels into accessibility attributes. We achieve this by only re-clustering users and neighborhoods where the underlying data changed. The underlying data changes either because a new user joined, an existing user added new data, or an existing user changed from being low quality to high quality (or vice versa).

The time to run clustering on **all** of the Seattle data on my local machine took the same amount of time on this branch vs the develop branch: 21 minutes for single user clustering and 12 minutes for multi-user clustering. Then if I try adding some data with my own account and running the incremental clustering update with this branch, it takes 10 _seconds_ for single user clustering, and 7 minutes for multi-user clustering (because I have contributed data in 19 out of 51 neighborhoods).

This is far from maximally efficient. When a user adds new data, we are just re-clustering all of that user's data. And any neighborhood that that user has every audited in gets re-clustered as well. Which is fine for most users who haven't audited in a bunch of different neighborhoods. But whenever I (myself, personally) add data, it's going to mean a lot more clustering happens that night because I've audited in a lot of different neighborhoods.

I also think that I want to make one more PR on speeding this up. I've realized that most of the time spent here is on doing the inserts into the database, and I think that I might be able to make some improvements on that front.

Other notes:
* I've also upped the number of cores we use when clustering from 3 to 8. This shouldn't have a particularly large effect, since so much of the time spent is on moving data around.
* When we were deleting all of the data in the tables, we were using a `TRUNCATE CASCADE`, which worked fine. When trying to use a `DELETE CASCADE`, I was running into really slow delete times. I had to add an index on the foreign keys in the various tables related to clustering. I also had to add `ON DELETE CASCADE` to the foreign key constraints.

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've added/updated comments for large or confusing blocks of code.
