### PR TITLE
Staggers nightly updates by city

### DIFF
--- a/app/utils/actor/ClusterLabelAttributesActor.scala
+++ b/app/utils/actor/ClusterLabelAttributesActor.scala
@@ -4,8 +4,8 @@ import java.text.SimpleDateFormat
 import java.util.{Calendar, Locale, TimeZone}
 import akka.actor.{Actor, Cancellable, Props}
 import controllers.helper.AttributeControllerHelper
-import play.api.Logger
-
+import play.api.Play.current
+import play.api.{Logger, Play}
 import java.sql.Timestamp
 import java.time.Instant
 import scala.concurrent.duration._
@@ -17,25 +17,27 @@ class ClusterLabelAttributesActor extends Actor {
   private var cancellable: Option[Cancellable] = None
   val TIMEZONE = TimeZone.getTimeZone("UTC")
 
-
   override def preStart(): Unit = {
     super.preStart()
-    // If we want to update the cluster table at 3:30am every day, we need to figure out how much time there is b/w now
-    // and the next 3:30am, then we can set the update interval to be 24 hours. So we make a calendar object for right
-    // now, and one for 3:30am today. If it is after 3:30am right now, we set the 3:30am object to be 3:30am tomorrow.
-    // Then we get the time difference between the 3:30am object and now.
+    // Get the number of hours later to run the code in this city. Used to stagger computation/resource use.
+    val cityId: String = Play.configuration.getString("city-id").get
+    val hoursOffset: Int = Play.configuration.getInt(s"city-params.update-offset-hours.${cityId}").get
 
+    // If we want to update the cluster table at 1 am PDT every day, we need to figure out how much time there is b/w
+    // now and the next 1 am, then we can set the update interval to be 24 hours. So we make a calendar object for right
+    // now, and one for 1 am today. If it is after 1 am right now, we set the 1 am object to be 1 am tomorrow. Then we
+    // get the time difference between the 1 am object and now.
     val currentTime: Calendar = Calendar.getInstance(TIMEZONE)
-    var timeOfNextUpdate: Calendar = Calendar.getInstance(TIMEZONE)
-    timeOfNextUpdate.set(Calendar.HOUR_OF_DAY, 10)
-    timeOfNextUpdate.set(Calendar.MINUTE, 30)
+    val timeOfNextUpdate: Calendar = Calendar.getInstance(TIMEZONE)
+    timeOfNextUpdate.set(Calendar.HOUR_OF_DAY, 8 + hoursOffset)
+    timeOfNextUpdate.set(Calendar.MINUTE, 0)
     timeOfNextUpdate.set(Calendar.SECOND, 0)
 
-    // If already past 3:30am, set next update to 3:30am tomorrow.
+    // If already past 1 am, set next update to 1 am tomorrow.
     if (currentTime.after(timeOfNextUpdate)) {
       timeOfNextUpdate.add(Calendar.HOUR_OF_DAY, 24)
     }
-    // If it is after 3:30am, this should have just incremented.
+    // If it is after 1 am, this should have just incremented.
     val millisUntilNextupdate: Long = timeOfNextUpdate.getTimeInMillis - currentTime.getTimeInMillis
     val durationToNextUpdate: FiniteDuration = FiniteDuration(millisUntilNextupdate, MILLISECONDS)
 

--- a/app/utils/actor/UserStatActor.scala
+++ b/app/utils/actor/UserStatActor.scala
@@ -4,7 +4,8 @@ import java.text.SimpleDateFormat
 import java.util.{Calendar, Locale, TimeZone}
 import akka.actor.{Actor, Cancellable, Props}
 import models.user.UserStatTable
-import play.api.Logger
+import play.api.Play.current
+import play.api.{Logger, Play}
 import java.sql.Timestamp
 import java.time.Instant
 import scala.concurrent.duration._
@@ -18,22 +19,25 @@ class UserStatActor extends Actor {
 
   override def preStart(): Unit = {
     super.preStart()
-    // If we want to update the user_stat table at 2:30am every day, we need to figure out how much time there
-    // is b/w now and the next 2:30am, then we can set the update interval to be 24 hours. So we make a calendar object
-    // for right now, and one for 2:30am today. If it is after 2:30am right now, we set the 2:30am object to be 2:30am
-    // tomorrow. Then we get the time difference between the 2:30am object and now.
+    // Get the number of hours later to run the code in this city. Used to stagger computation/resource use.
+    val cityId: String = Play.configuration.getString("city-id").get
+    val hoursOffset: Int = Play.configuration.getInt(s"city-params.update-offset-hours.${cityId}").get
 
+    // If we want to update the user_stat table at 12:30 am PDT every day, we need to figure out how much time there is
+    // b/w now and the next 12:30 am, then we can set the update interval to be 24 hours. So we make a calendar object
+    // for right now, and one for 12:30 am today. If it is after 12:30 am right now, we set the 12:30 am object to be
+    // 12:30 am tomorrow. Then we get the time difference between the 12:30 am object and now.
     val currentTime: Calendar = Calendar.getInstance(TIMEZONE)
-    var timeOfNextUpdate: Calendar = Calendar.getInstance(TIMEZONE)
-    timeOfNextUpdate.set(Calendar.HOUR_OF_DAY, 9)
+    val timeOfNextUpdate: Calendar = Calendar.getInstance(TIMEZONE)
+    timeOfNextUpdate.set(Calendar.HOUR_OF_DAY, 7 + hoursOffset)
     timeOfNextUpdate.set(Calendar.MINUTE, 30)
     timeOfNextUpdate.set(Calendar.SECOND, 0)
 
-    // If already past 2:30am, set next update to 2:30am tomorrow.
+    // If already past 12:30 am, set next update to 12:30 am tomorrow.
     if (currentTime.after(timeOfNextUpdate)) {
       timeOfNextUpdate.add(Calendar.HOUR_OF_DAY, 24)
     }
-    // If it is after 2:30am, this should have just incremented.
+    // If it is after 12:30 am, this should have just incremented.
     val millisUntilNextupdate: Long = timeOfNextUpdate.getTimeInMillis - currentTime.getTimeInMillis
     val durationToNextUpdate: FiniteDuration = FiniteDuration(millisUntilNextupdate, MILLISECONDS)
 

--- a/conf/cityparams.conf
+++ b/conf/cityparams.conf
@@ -47,7 +47,15 @@ city-params {
     cdmx = "CDMX"
     spgg = "SPGG"
     pittsburgh-pa = "Pittsburgh"
-
+  }
+  update-offset-hours {
+    newberg-or = 3
+    washington-dc = -3
+    seattle-wa = 2
+    columbus-oh = -2
+    cdmx = 1
+    spgg = 0
+    pittsburgh-pa = -1
   }
   excluded-tags {
     newberg-or = [


### PR DESCRIPTION
Resolves #2504 

Staggers when the nightly updates occur by city. The difference in time zones let's us start start the updates within a smaller window in local time. Here are the start times we're looking at now:
10:30 pm PDT - Columbus (1:30 am local)
11:30 pm PDT - Pittsburgh (2:30 am local)
12:30 am PDT - SPGG (1:30 am local)
1:30 am PDT - CDMX (2:30 am local)
2:30 am PDT - Seattle (2:30 am local)
3:30 am PDT - Newberg (3:30 am local)

Given the different time zones, we're able to start the updates an hour apart in each of the 6 cities while starting between 1:30 am and 3:30 am (a 2 hour window).

Hopefully this will spread out the load on the shared resources and might be improve performance slightly.

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've added/updated comments for large or confusing blocks of code.