### PR TITLE
2517: Changed Credentials for Database Tools in README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ To look at and run queries on your database, you will want to install a database
 You'll connect to the database using the following credentials:
 ```
 Host: localhost:5432
-User: sidewalk
+User: postgres
 Password: sidewalk
 Database: sidewalk
 ```


### PR DESCRIPTION
Resolves #2517

Changed user in the credentials for database tools to be "postgres" instead of "sidewalk", as for users where "sidewalk" will work, "postgres" will also work. 

##### Before/After screenshots (if applicable)
Before
![dbcredentials](https://user-images.githubusercontent.com/41148074/112712031-eba42900-8e89-11eb-9ea5-61f0026a03af.jpg)

After
![dbcredentialsafter](https://user-images.githubusercontent.com/41148074/112712036-f19a0a00-8e89-11eb-93d3-dbcfcad1099d.jpg)


##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've included before/after screenshots above.
