### PR TITLE
#2416 Hide validation content when no imagery on labelmap.

### DIFF
--- a/public/javascripts/Admin/src/Admin.GSVLabelView.js
+++ b/public/javascripts/Admin/src/Admin.GSVLabelView.js
@@ -25,29 +25,31 @@ function AdminGSVLabelView(admin) {
                         '<div class="modal-body">' +
                             '<div id="svholder" style="width: 540px; height:360px">' +
                         '</div>' +
-                        '<h3>Is this label correct?</h3>' +
-                        '<div id="validation-button-holder">' +
-                            '<button id="validation-agree-button" class="validation-button"' +
-                                'style="height: 50px; width: 179px; background-color: white; margin-right: 2px; border-radius: 5px; border-width: 2px; border-color: lightgrey;">' +
-                                'Agree' +
-                            '</button>' +
-                            '<button id="validation-disagree-button" class="validation-button"' +
-                                'style="height: 50px; width: 179px; background-color: white; margin-right: 2px; border-radius: 5px; border-width: 2px; border-color: lightgrey;">' +
-                                'Disagree' +
-                            '</button>' +
-                            '<button id="validation-not-sure-button" class="validation-button"' +
-                                'style="height: 50px; width: 179px; background-color: white; margin-right: 2px; border-radius: 5px; border-width: 2px; border-color: lightgrey;">' +
-                                'Not sure' +
-                            '</button>' +
+                        '<div id="validation-input-holder">' +
+                            '<h3 style="margin: 0px; padding-top: 10px;">Is this label correct?</h3>' +
+                            '<div id="validation-button-holder" style="padding-top: 10px;">' +
+                                '<button id="validation-agree-button" class="validation-button"' +
+                                    'style="height: 50px; width: 179px; background-color: white; margin-right: 2px; border-radius: 5px; border-width: 2px; border-color: lightgrey;">' +
+                                    'Agree' +
+                                '</button>' +
+                                '<button id="validation-disagree-button" class="validation-button"' +
+                                    'style="height: 50px; width: 179px; background-color: white; margin-right: 2px; border-radius: 5px; border-width: 2px; border-color: lightgrey;">' +
+                                    'Disagree' +
+                                '</button>' +
+                                '<button id="validation-not-sure-button" class="validation-button"' +
+                                    'style="height: 50px; width: 179px; background-color: white; margin-right: 2px; border-radius: 5px; border-width: 2px; border-color: lightgrey;">' +
+                                    'Not sure' +
+                                '</button>' +
+                            '</div>' +
+                            '<div id="validation-comment-holder" style="padding-top: 10px; padding-bottom: 15px;">' +
+                                '<textarea id="comment-textarea" placeholder="' + i18next.t('label-map.add-comment') + '" class="validation-comment-box"></textarea>' +
+                                '<button id="comment-button" class="submit-button">' +
+                                    i18next.t('label-map.submit') +
+                                '</button>' +
+                            '</div>' +
                         '</div>' +
-                        '<div id="validation-comment-holder">' +
-                            '<textarea id="comment-textarea" placeholder="' + i18next.t('label-map.add-comment') + '" class="validation-comment-box"></textarea>' +
-                            '<button id="comment-button" class="submit-button">' +
-                                i18next.t('label-map.submit') +
-                            '</button>' +
-                        '</div>' +
-                        '<div class="modal-footer">' +
-                            '<table class="table table-striped" style="font-size:small; margin-bottom: 0">' +
+                        '<div class="modal-footer" style="padding:0px; padding-top:15px;">' +
+                            '<table class="table table-striped" style="font-size:small;>' +
                                 '<tr>' +
                                     '<th>Label Type</th>' +
                                     '<td id="label-type-value"></td>' +
@@ -107,7 +109,7 @@ function AdminGSVLabelView(admin) {
         }
         self.modal = $(modalText);
 
-        self.panorama = AdminPanorama(self.modal.find("#svholder")[0], self.modal.find("#validation-button-holder"), admin);
+        self.panorama = AdminPanorama(self.modal.find("#svholder")[0], self.modal.find("#validation-input-holder"), admin);
 
         self.agreeButton = self.modal.find("#validation-agree-button");
         self.disagreeButton = self.modal.find("#validation-disagree-button");

--- a/public/javascripts/Admin/src/Admin.Panorama.js
+++ b/public/javascripts/Admin/src/Admin.Panorama.js
@@ -53,21 +53,15 @@ function AdminPanorama(svHolder, buttonHolder, admin) {
 
         self.panoNotAvailable = $("<div id='pano-not-avail'>Oops, our fault but there is no longer imagery available " +
             "for this label.</div>").css({
-            width: '100%',
-            height: '100%',
-            position: 'absolute',
-            top: '0',
-            'font-size': '200%'
+            'font-size': '200%',
+            'padding-bottom': '15px'
         })[0];
 
         self.panoNotAvailableDetails =
             $("<div id='pano-not-avail-2'>We use the Google Maps API to show the sidewalk images and sometimes Google" +
                 " removes these images so we can no longer access them. Sorry about that.</div>").css({
-            width: '95%',
-            height: '100%',
-            position: 'absolute',
-            top: '90px',
-            'font-size': '85%'
+            'font-size': '85%',
+            'padding-bottom': '15px'
         })[0];
 
         self.svHolder.append($(self.panoCanvas));
@@ -151,23 +145,25 @@ function AdminPanorama(svHolder, buttonHolder, admin) {
                 // Show pano if it exists, an error message if there is no GSV imagery, and another error message if we
                 // wait a full 2 seconds without getting a response from Google.
                 if (self.panorama.getStatus() === "OK" || self.panoId == 'tutorial' || self.panoId == 'afterWalkTutorial') {
-                    $(self.panoCanvas).css('visibility', 'visible');
-                    $(self.panoNotAvailable).css('visibility', 'hidden');
-                    $(self.panoNotAvailableDetails).css('visibility', 'hidden');
-                    $(self.buttonHolder).css('visibility', 'visible');
+                    $(self.panoCanvas).css('display', 'block');
+                    $(self.panoNotAvailable).css('display', 'none');
+                    $(self.panoNotAvailableDetails).css('display', 'none');
+                    $(self.buttonHolder).css('display', 'block');
                     if (self.label) renderLabel(self.label);
                 } else if (self.panorama.getStatus() === "ZERO_RESULTS") {
+                    $(self.svHolder).css('height', '');
                     $(self.panoNotAvailable).text('Oops, our fault but there is no longer imagery available for this label.');
-                    $(self.panoCanvas).css('visibility', 'hidden');
-                    $(self.panoNotAvailable).css('visibility', 'visible');
-                    $(self.panoNotAvailableDetails).css('visibility', 'visible');
-                    $(self.buttonHolder).css('visibility', 'hidden');
+                    $(self.panoCanvas).css('display', 'none');
+                    $(self.panoNotAvailable).css('display', 'block');
+                    $(self.panoNotAvailableDetails).css('display', 'block');
+                    $(self.buttonHolder).css('display', 'none');
                 } else if (n < 1) {
+                    $(self.svHolder).css('height', '');
                     $(self.panoNotAvailable).text('We had trouble connecting to Google Street View, please try again later!');
-                    $(self.panoCanvas).css('visibility', 'hidden');
-                    $(self.panoNotAvailable).css('visibility', 'visible');
-                    $(self.panoNotAvailable).css('visibility', 'hidden');
-                    $(self.buttonHolder).css('visibility', 'hidden');
+                    $(self.panoCanvas).css('display', 'none');
+                    $(self.panoNotAvailable).css('display', 'block');
+                    $(self.panoNotAvailableDetails).css('display', 'none');
+                    $(self.buttonHolder).css('display', 'none');
                 } else {
                     setTimeout(callback, 200, n - 1);
                 }


### PR DESCRIPTION
Resolves #2416 

This PR makes it so that on the labelmap, if there is no imagery, then the "Is this label correct?" header and the comment submission stuff are hidden in addition to the validation buttons. Also, I did some CSS styling just to make the popup look a little nicer (in my opinion). Please let me know what you think!

Before:
![102847079-82160980-43c6-11eb-9098-6aee1503c255](https://user-images.githubusercontent.com/43970567/113462799-885d4e00-93d7-11eb-8c98-6a745fdc4679.png)

After:
<img width="475" alt="Untitled2" src="https://user-images.githubusercontent.com/43970567/113462803-8d220200-93d7-11eb-81e3-4e51fbb27753.png">
<img width="486" alt="Untitled" src="https://user-images.githubusercontent.com/43970567/113462806-8eebc580-93d7-11eb-8012-8119da37e59a.png">
<img width="466" alt="Untitled3" src="https://user-images.githubusercontent.com/43970567/113462807-8f845c00-93d7-11eb-85e0-393e9268ef8d.png">
