### PR TITLE
Encourage labeling nearby objects in labeling guide

### DIFF
--- a/app/views/labelingGuide.scala.html
+++ b/app/views/labelingGuide.scala.html
@@ -49,7 +49,7 @@
                                 (including ADA citations where appropriate).
                             </p>
                             <h3>How to Place a Label</h3>
-                            <p>You should place labels at the center of curb ramps or surface problems, and at the base of obstacles.</p>
+                            <p>You should place labels at the center of curb ramps or surface problems, and at the base of obstacles. Try to get as close as possible to an object that you are labeling. Labeling from farther away will be less accurate!</p>
                             <div>
                                 <div class="col-md-6">
                                     <figure class="text-center">

--- a/public/stylesheets/help.css
+++ b/public/stylesheets/help.css
@@ -79,10 +79,6 @@ figure figcaption {
 }
 
 /* the youtube videos */
-iframe {
-    margin-top: 30px;
-}
-
 ul.reference {
     list-style-type: none;
     padding-left: 0;


### PR DESCRIPTION
Resolves #2453 

Adds a note to the top of the labeling guide encouraging users to label objects up close because it is more accurate. I also noticed a small CSS issue on the /help page and fixed that.

##### Before/After screenshots (if applicable)
Before
![Screenshot from 2021-04-21 13-29-15](https://user-images.githubusercontent.com/6518824/115617990-ec708500-a2a6-11eb-8dd4-ea35bef71876.png)

After
![Screenshot from 2021-04-21 13-31-28](https://user-images.githubusercontent.com/6518824/115617993-ee3a4880-a2a6-11eb-9c85-429c9c328120.png)

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've included before/after screenshots above.
