### PR TITLE
Adds zooming suggestion to help page

### DIFF
--- a/app/views/help.scala.html
+++ b/app/views/help.scala.html
@@ -99,7 +99,6 @@
                                 accurate than it is already.
                             </p>
 
-                            <br/>
                             <h3>References</h3>
                             <div class="spacer10"></div>
                             <ul class="reference">
@@ -107,7 +106,8 @@
                                     <div class="title">
                                         [1] &nbsp;
                                         <a href="@routes.Assets.at("documents/papers/Hara_TohmeDetectingCurbRampsInGoogleStreetViewUsingCrowdsourcingComputerVisionAndMachineLearning_UIST2014.pdf")">
-                                            Tohme: Detecting Curb Ramps in Google Street View Using Crowdsourcing, Computer Vision, and Machine Learning
+                                            Tohme: Detecting Curb Ramps in Google Street View Using Crowdsourcing,
+                                            Computer Vision, and Machine Learning
                                         </a>
                                     </div>
                                     <div class="desc">
@@ -119,12 +119,13 @@
                                     <div class="title">
                                         [2] &nbsp;
                                         <a href="@routes.Assets.at("documents/papers/Hara_ImprovingPublicTransitAccessibilityForBlindRidersByCrowdsourcingBusStopLandmarkLocationsWithGoogleStreetViewAnExtendedAnalysis_TACCESS2015.pdf")">
-                                            Improving Public Transit Accessibility for Blind Riders by Crowdsourcing Bus Stop Landmark Locations with Google Street View: An Extended Analysis
+                                            Improving Public Transit Accessibility for Blind Riders by Crowdsourcing Bus
+                                            Stop Landmark Locations with Google Street View: An Extended Analysis
                                         </a>
                                     </div>
                                     <div class="desc">
-                                        Hara, K., Azenkot, S., Campbell, M., Bennett, C., Le, V., Pannella, S., Moore, R., Minckler, K., Ng, R., and
-                                        Froehlich, J.
+                                        Hara, K., Azenkot, S., Campbell, M., Bennett, C., Le, V., Pannella, S., Moore,
+                                        R., Minckler, K., Ng, R., and Froehlich, J.
                                         <i>ACM Transactions on Accessibility.</i> <br/>
                                     </div>
                                 </li>
@@ -132,13 +133,11 @@
                                     <div class="title">
                                         [3] &nbsp;
                                         <a href="http://link.springer.com/article/10.1007/s11524-010-9505-x">
-                                            Can virtual streetscape audits reliably
-                                            replace physical streetscape audits?
+                                            Can virtual streetscape audits reliably replace physical streetscape audits?
                                         </a>
                                     </div>
                                     <div class="desc">
-                                        Badland, H.M., Opit, S., Witten, K., Kearns, R.A. and
-                                        Mavoa, S.
+                                        Badland, H.M., Opit, S., Witten, K., Kearns, R.A. and Mavoa, S.
                                         <i>Journal of urban health : bulletin of the New York Academy of Medicine.</i>
                                     </div>
                                 </li>
@@ -146,14 +145,12 @@
                                     <div class="title">
                                         [4] &nbsp;
                                         <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2952684/">
-                                            Using Google Earth to conduct a
-                                            neighborhood audit: reliability of a virtual audit
-                                            instrument.
+                                            Using Google Earth to conduct a neighborhood audit:
+                                            reliability of a virtual audit instrument.
                                         </a>
                                     </div>
                                     <div class="desc">
-                                        Clarke, P., Ailshire, J., Melendez, R., Bader, M. and
-                                        Morenoff, J.
+                                        Clarke, P., Ailshire, J., Melendez, R., Bader, M. and Morenoff, J.
                                         <i>Health & place.</i>
                                     </div>
                                 </li>
@@ -161,19 +158,29 @@
                                     <div class="title">
                                         [5] &nbsp;
                                         <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3031144/">
-                                        Using Google
-                                        Street View to audit neighborhood environments.
+                                            Using Google Street View to audit neighborhood environments.
                                         </a>
                                     </div>
                                     <div class="desc">
-                                        Rundle, A.G., Bader, M.D.M., Richards, C.A.,
-                                        Neckerman, K.M. and Teitler, J.O.
+                                        Rundle, A.G., Bader, M.D.M., Richards, C.A., Neckerman, K.M. and Teitler, J.O.
                                         <i>American journal of preventive medicine.</i>
                                     </div>
                                 </li>
                             </ul>
+                        </div>
+                    </div>
+                </div>
 
-                            @*4, 9, 21, 25, 40*@
+                <div class="help-item">
+                    <h2 class="question" id="why-is-the-interface-so-small">Why is the interface so small?</h2>
+                    <div class="row">
+                        <div class="col-sm-12">
+                            <p>
+                                On larger screens, the interface looks pretty small by default. You can make it larger
+                                by zooming in using your browser. You can do this on a Mac by holding down
+                                <code>Cmd</code> and typing <code>+</code>. On Windows, you would hold <code>Ctrl</code>
+                                and type <code>+</code>.
+                            </p>
                         </div>
                     </div>
                 </div>
@@ -183,15 +190,11 @@
                     <div class="row">
                         <div class="col-sm-12">
                             <p>
-                                Sometimes while auditing, you may have noticed that the navigation arrows go missing, especially while walking straight.
-                                Worry not, there is a simple solution! <br/><br/>
-                                Just double click on the street to move ahead and you are all set! <br/><br/>
-                                And if you are still stuck, you can always use the Jump button on the left.
-
+                                Sometimes while auditing, you may have noticed that the navigation arrows go missing,
+                                especially while walking straight. Worry not, there is a simple solution! <br/><br/>
+                                Just click on the "Stuck" button on the left side of the screen! If you still cannot
+                                move forward, keep clicking the Stuck button until you are moved to a better spot.
                             </p>
-                        </div>
-                        <div class="video col-sm-12" style="text-align:center">
-                            <iframe width="560" height="315" src="https://www.youtube.com/embed/eqnoAcqgNrw?rel=0" frameborder="0" allowfullscreen></iframe>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Resolves #178 

This adds a question to the help/FAQ page about the interface being too small, and instructs users to use their browser zoom. I also noticed that the help page has old instructions to double click to move forward (including a video), which has been replaced by the Stuck button. So I removed the video and updated the text for that question as well.

We need a better long term solution for the need for zooming in our tools. Either through better user training or through actually making our interface zoom dynamically. But we've needed to make those changes for years, so I figured it's better to get _something_ into the /help page now than to just continue to wait for us to implement something more sustainable.

##### Before/After screenshots (if applicable)
Before
![Screenshot from 2021-04-21 14-00-11](https://user-images.githubusercontent.com/6518824/115620645-49216f00-a2aa-11eb-81c7-38605873f3ef.png)

After
![Screenshot from 2021-04-21 13-58-52](https://user-images.githubusercontent.com/6518824/115620651-4aeb3280-a2aa-11eb-81be-af166194ed7b.png)

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've included before/after screenshots above.
