### PR TITLE
Add time audited/validated to admin user page

### DIFF
--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -721,27 +721,27 @@
                 <div id="tabs-5" class="tab-pane">
                     <div class="row">
                         <h1>Users</h1>
-                        <div class="col-lg-12">
+                        <div id="user-table-container" class="col-lg-12">
                             <table id="user-table" data-order='[[ 4, "desc" ]]' class="table table-striped table-condensed">
                                 <thead>
-                                <tr>
-                                    <th class="col-md-1">Username</th>
-                                    <th class="col-md-2">User Id</th>
-                                    <th class="col-md-1">Email</th>
-                                    <th class="col-md-1">Role</th>
-                                    <th class="col-md-1">Mission Count</th>
-                                    <th class="col-md-1">Audit Count</th>
-                                    <th class="col-md-1">Label Count</th>
-                                    <th class="col-md-1">Own Labels Validated</th>
-                                    <th class="col-md-1">% Own Labels Agree</th>
-                                    <th class="col-md-1">% Own Labels Disagree</th>
-                                    <th class="col-md-1">% Own Labels Unsure</th>
-                                    <th class="col-md-1">Others' Labels Validated</th>
-                                    <th class="col-md-1">% Others' Labels Validated & Agreed</th>
-                                    <th class="col-md-2">Date Registered</th>
-                                    <th class="col-md-2" data-class-name="priority">Last Login</th>
-                                    <th class="col-md-1">Login Count</th>
-                                </tr>
+                                    <tr>
+                                        <th class="col-md-1">Username</th>
+                                        <th class="col-md-2">User Id</th>
+                                        <th class="col-md-1">Email</th>
+                                        <th class="col-md-1">Role</th>
+                                        <th class="col-md-1">Mission Count</th>
+                                        <th class="col-md-1">Audit Count</th>
+                                        <th class="col-md-1">Label Count</th>
+                                        <th class="col-md-1">Own Labels Validated</th>
+                                        <th class="col-md-1">%Own Labels Agree</th>
+                                        <th class="col-md-1">%Own Labels Disagree</th>
+                                        <th class="col-md-1">%Own Labels Unsure</th>
+                                        <th class="col-md-1">Others' Labels Validated</th>
+                                        <th class="col-md-1">%Others' Labels Agreed</th>
+                                        <th class="col-md-2">Date Registered</th>
+                                        <th class="col-md-2" data-class-name="priority">Last Login</th>
+                                        <th class="col-md-1">Login Count</th>
+                                    </tr>
                                 </thead>
                                 <tbody>
                                 @UserDAOSlick.getUserStatsForAdminPage.map { u =>
@@ -752,7 +752,7 @@
                                     <td>
                                         @if(u.role != "Owner"){
                                             <div class="dropdown">
-                                                <button class="btn btn-default dropdown-toggle" type="button" id="userRoleDropdown@u.userId" data-toggle="dropdown" style="cursor: default">
+                                                <button class="btn btn-default dropdown-toggle role-dropdown" type="button" id="userRoleDropdown@u.userId" data-toggle="dropdown">
                                                     @u.role
                                                     <span class="caret"></span>
                                                 </button>

--- a/app/views/admin/user.scala.html
+++ b/app/views/admin/user.scala.html
@@ -9,6 +9,7 @@
 @import models.user.UserCurrentRegionTable
 
 @import models.region.RegionTable
+@import models.audit.AuditTaskInteractionTable
 @(title: String, admin: Option[User] = None, user: Option[DBUser] = Some(DBUser("unknown", "unknown", "unknown")))(implicit lang: Lang)
 
 @main(title) {
@@ -39,30 +40,34 @@
                         <th class="col-md">Username</th>
                         <th class="col-md">User Id</th>
                         <th class="col-md">Email</th>
-                        <th class="col-md">Mission Count</th>
-                        <th class="col-md">Audited Street Count</th>
-                        <th class="col-md">Label Count</th>
-                        <th class="col-md">Total Distance Audited</th>
+                        <th class="col-md">Current Neighborhood</th>
                     </tr>
                     <tr>
                         <td>@user.get.username</td>
                         <td>@user.get.userId</td>
                         <td>@user.get.email</td>
-                        <td>@MissionTable.countCompletedMissionsByUserId(UUID.fromString(user.get.userId), includeOnboarding = false, includeSkipped = false)</td>
-                        <td>@AuditTaskTable.countCompletedAuditsByUserId(UUID.fromString(user.get.userId))</td>
-                        <td>@LabelTable.countLabelsByUserId(UUID.fromString(user.get.userId))</td>
-                        <td id="td-total-distance-audited-admin"></td>
+                        <td>
+                            @(UserCurrentRegionTable.currentRegion(UUID.fromString(user.get.userId)).map {x => RegionTable.neighborhoodName(x)}.getOrElse("Unassigned"))
+                            (Region ID: @(UserCurrentRegionTable.currentRegion(UUID.fromString(user.get.userId)).map{x => x}.getOrElse("NA")))
+                        </td>
                     </tr>
                 </table>
             </div>
             <div class="col-lg-12">
-                <table class="table">
+                <table class="table table-striped table-condensed">
                     <tr>
-                        <th class="col-md-2">Current Neighborhood</th>
-                        <td class="col-md-10">
-                            @(UserCurrentRegionTable.currentRegion(UUID.fromString(user.get.userId)).map {x => RegionTable.neighborhoodName(x)}.getOrElse("Unassigned"))
-                            (Region ID: @(UserCurrentRegionTable.currentRegion(UUID.fromString(user.get.userId)).map{x => x}.getOrElse("NA")))
-                        </td>
+                        <th class="col-md">Mission Count</th>
+                        <th class="col-md">Audited Street Count</th>
+                        <th class="col-md">Label Count</th>
+                        <th class="col-md">Total Distance Audited</th>
+                        <th class="col-md">Time spent auditing/validating</th>
+                    </tr>
+                    <tr>
+                        <td>@MissionTable.countCompletedMissionsByUserId(UUID.fromString(user.get.userId), includeOnboarding = false, includeSkipped = false)</td>
+                        <td>@AuditTaskTable.countCompletedAuditsByUserId(UUID.fromString(user.get.userId))</td>
+                        <td>@LabelTable.countLabelsByUserId(UUID.fromString(user.get.userId))</td>
+                        <td id="td-total-distance-audited-admin"></td>
+                        <td>@AuditTaskInteractionTable.getHoursAuditingAndValidating(user.get.userId) hours</td>
                     </tr>
                 </table>
             </div>

--- a/public/stylesheets/admin.css
+++ b/public/stylesheets/admin.css
@@ -14,6 +14,24 @@
     border-bottom-width: 0;
 }
 
+#user-table-container {
+    overflow-x: scroll;
+    -webkit-transform: rotateX(180deg); /* Moves scrollbar to top for easier navigation. */
+    width: 110%;
+}
+#user-table_wrapper {
+    -webkit-transform: rotateX(180deg); /* Adding scrollbar flips all text, this flips it back. */
+    font-size: 12px;
+}
+
+.role-dropdown {
+    font-size: 12px;
+}
+
+.change-role {
+    font-size: 12px;
+}
+
 #label-map, #admin-map {
     width: 100%;
     height: 800px;


### PR DESCRIPTION
Resolves #266 

Adds combined time spent auditing/validating to the dashboard at `/admin/user`. We have to look through interaction logs, so it was too time consuming to add to the full table of users on the admin dashboard, but we could add it to this page. I also fixed up some CSS for the user table on the admin page because we have lost horizontal scrolling at some point!

##### Before/After screenshots (if applicable)
Before
![Screenshot from 2021-04-21 16-52-43](https://user-images.githubusercontent.com/6518824/115636245-58141b80-a2c2-11eb-86a0-e6c4363c46d5.png)

After
![Screenshot from 2021-04-21 16-52-15](https://user-images.githubusercontent.com/6518824/115636247-59dddf00-a2c2-11eb-82bc-fd93882dcf4a.png)

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
