### PR TITLE
Standardize and shortens function names

### DIFF
--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -273,7 +273,7 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
     if (isAdmin(request.identity)) {
       UserTable.find(username) match {
         case Some(user) =>
-          val labels = LabelTable.selectLocationsOfLabelsByUserId(UUID.fromString(user.userId))
+          val labels = LabelTable.getLabelLocations(UUID.fromString(user.userId))
           val features: List[JsObject] = labels.map { label =>
             val point = geojson.Point(geojson.LatLng(label.lat.toDouble, label.lng.toDouble))
             val properties = Json.obj(
@@ -300,7 +300,7 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
     if (isAdmin(request.identity)) {
       UserTable.find(username) match {
         case Some(user) =>
-          val streets = AuditTaskTable.selectStreetsAuditedByAUser(UUID.fromString(user.userId))
+          val streets = AuditTaskTable.getAuditedStreets(UUID.fromString(user.userId))
           val features: List[JsObject] = streets.map { edge =>
             val coordinates: Array[Coordinate] = edge.geom.getCoordinates
             val latlngs: List[geojson.LatLng] = coordinates.map(coord => geojson.LatLng(coord.y, coord.x)).toList // Map it to an immutable list

--- a/app/controllers/AuditController.scala
+++ b/app/controllers/AuditController.scala
@@ -296,7 +296,7 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
           case Some(user) =>
             if(isAdmin(request.identity) && MissionTable.userOwnsMission(user.userId, submission.missionId)) {
               // Get the ongoing CV ground truth mission for this user.
-              val currentCVMission: Option[Mission] = MissionTable.getMissionById(submission.missionId)
+              val currentCVMission: Option[Mission] = MissionTable.getMission(submission.missionId)
 
               // Mark the pano complete.
               currentCVMission match {

--- a/app/controllers/MissionController.scala
+++ b/app/controllers/MissionController.scala
@@ -32,7 +32,7 @@ class MissionController @Inject() (implicit val env: Environment[User, SessionAu
           println(s"problem with /neighborhoodMissions: user has no current region.")
 
         val completedMissions: List[Mission] =
-          MissionTable.selectCompletedAuditMissionsByAUser(user.userId, userCurrentRegion.get, includeOnboarding = true)
+          MissionTable.selectCompletedAuditMissions(user.userId, userCurrentRegion.get, includeOnboarding = true)
 
         Future.successful(Ok(JsArray(completedMissions.map(_.toJSON))))
 

--- a/app/controllers/SurveyController.scala
+++ b/app/controllers/SurveyController.scala
@@ -53,7 +53,7 @@ class SurveyController @Inject() (implicit val env: Environment[User, SessionAut
         val ipAddress: String = request.remoteAddress
         WebpageActivityTable.save(WebpageActivity(0, userId, ipAddress, "SurveySubmit", timestamp))
 
-        val numMissionsCompleted: Int = MissionTable.countCompletedMissionsByUserId(UUID.fromString(userId), includeOnboarding = false, includeSkipped = true)
+        val numMissionsCompleted: Int = MissionTable.countCompletedMissions(UUID.fromString(userId), includeOnboarding = false, includeSkipped = true)
 
         val allSurveyQuestions: List[SurveyQuestion] = SurveyQuestionTable.listAll
         val allSurveyQuestionIds: List[Int] = allSurveyQuestions.map(_.surveyQuestionId)
@@ -112,7 +112,7 @@ class SurveyController @Inject() (implicit val env: Environment[User, SessionAut
         // The survey will show exactly once, in the middle of the 2nd mission.
         val numMissionsBeforeSurvey = 1
         val surveyShown = WebpageActivityTable.findUserActivity("SurveyShown", userId).length
-        val displaySurvey = (MissionTable.countCompletedMissionsByUserId(userId, includeOnboarding = false, includeSkipped = true) == numMissionsBeforeSurvey && (surveyShown == 0))
+        val displaySurvey = (MissionTable.countCompletedMissions(userId, includeOnboarding = false, includeSkipped = true) == numMissionsBeforeSurvey && (surveyShown == 0))
 
         //maps displaymodal to true in the future.
         Future.successful(Ok(Json.obj("displayModal" -> displaySurvey)))

--- a/app/controllers/UserProfileController.scala
+++ b/app/controllers/UserProfileController.scala
@@ -49,7 +49,7 @@ class UserProfileController @Inject() (implicit val env: Environment[User, Sessi
   def getAuditedStreets = UserAwareAction.async { implicit request =>
     request.identity match {
       case Some(user) =>
-        val streets = AuditTaskTable.selectStreetsAuditedByAUser(user.userId)
+        val streets = AuditTaskTable.getAuditedStreets(user.userId)
         val features: List[JsObject] = streets.map { edge =>
           val coordinates: Array[Coordinate] = edge.geom.getCoordinates
           val latlngs: List[geojson.LatLng] = coordinates.map(coord => geojson.LatLng(coord.y, coord.x)).toList
@@ -95,8 +95,8 @@ class UserProfileController @Inject() (implicit val env: Environment[User, Sessi
     request.identity match {
       case Some(user) =>
         val labels = regionId match {
-          case Some(rid) => LabelTable.selectLocationsOfLabelsByUserIdAndRegionId(user.userId, rid)
-          case None => LabelTable.selectLocationsOfLabelsByUserId(user.userId)
+          case Some(rid) => LabelTable.getLabelLocations(user.userId, rid)
+          case None => LabelTable.getLabelLocations(user.userId)
         }
 
         val features: List[JsObject] = labels.map { label =>

--- a/app/controllers/ValidationController.scala
+++ b/app/controllers/ValidationController.scala
@@ -99,7 +99,7 @@ class ValidationController @Inject() (implicit val env: Environment[User, Sessio
     val possibleLabTypeIds: List[Int] = LabelTable.retrievePossibleLabelTypeIds(user.userId, labelCount, None)
     val hasWork: Boolean = possibleLabTypeIds.nonEmpty
 
-    val completedValidations: Int = MissionTable.countCompletedValidationsByUserID(user.userId)
+    val completedValidations: Int = MissionTable.countCompletedValidations(user.userId)
     // Checks if there are still labels in the database for the user to validate.
     if (hasWork && missionSetProgress.missionType == "validation") {
       // possibleLabTypeIds can contain [1, 2, 3, 4, 7]. Select ids 1, 2, 3, 4 if possible, o/w choose 7.

--- a/app/models/audit/AuditTaskInteractionTable.scala
+++ b/app/models/audit/AuditTaskInteractionTable.scala
@@ -134,11 +134,11 @@ object AuditTaskInteractionTable {
         |       label_point.canvas_y AS canvas_y,
         |       label_point.canvas_width AS canvas_width,
         |       label_point.canvas_height AS canvas_height
-        |FROM sidewalk.audit_task_interaction AS interaction
-        |LEFT JOIN sidewalk.label ON interaction.temporary_label_id = label.temporary_label_id
+        |FROM audit_task_interaction AS interaction
+        |LEFT JOIN label ON interaction.temporary_label_id = label.temporary_label_id
         |                         AND interaction.audit_task_id = label.audit_task_id
-        |LEFT JOIN sidewalk.label_type ON label.label_type_id = label_type.label_type_id
-        |LEFT JOIN sidewalk.label_point ON label.label_id = label_point.label_id
+        |LEFT JOIN label_type ON label.label_type_id = label_type.label_type_id
+        |LEFT JOIN label_point ON label.label_id = label_point.label_id
         |WHERE interaction.audit_task_id = ?
         |    AND interaction.action NOT IN (
         |        'LowLevelEvent_mousemove', 'LowLevelEvent_mouseover', 'LowLevelEvent_mouseout', 'LowLevelEvent_click',

--- a/app/models/audit/AuditTaskTable.scala
+++ b/app/models/audit/AuditTaskTable.scala
@@ -156,7 +156,7 @@ object AuditTaskTable {
   def countCompletedAuditsToday: Int = db.withSession { implicit session =>
     val countTasksQuery = Q.queryNA[Int](
       """SELECT COUNT(audit_task_id)
-        |FROM sidewalk.audit_task
+        |FROM audit_task
         |WHERE (audit_task.task_end AT TIME ZONE 'US/Pacific')::date = (now() AT TIME ZONE 'US/Pacific')::date
         |    AND audit_task.completed = TRUE""".stripMargin
     )
@@ -169,7 +169,7 @@ object AuditTaskTable {
   def countCompletedAuditsPastWeek: Int = db.withSession { implicit session =>
     val countTasksQuery = Q.queryNA[Int](
       """SELECT COUNT(audit_task_id)
-        |FROM sidewalk.audit_task
+        |FROM audit_task
         |WHERE (audit_task.task_end AT TIME ZONE 'US/Pacific') > (now() AT TIME ZONE 'US/Pacific') - interval '168 hours'
         |    AND audit_task.completed = TRUE""".stripMargin
     )

--- a/app/models/audit/AuditTaskTable.scala
+++ b/app/models/audit/AuditTaskTable.scala
@@ -179,7 +179,7 @@ object AuditTaskTable {
   /**
     * Returns the number of tasks completed by the given user.
     */
-  def countCompletedAuditsByUserId(userId: UUID): Int = db.withSession { implicit session =>
+  def countCompletedAudits(userId: UUID): Int = db.withSession { implicit session =>
     completedTasks.filter(_.userId === userId.toString).length.run
   }
 
@@ -194,7 +194,7 @@ object AuditTaskTable {
   /**
     * Gets list streets that the user has not audited.
     */
-  def streetEdgeIdsNotAuditedByUser(user: UUID): List[Int] = db.withSession { implicit session =>
+  def getStreetEdgeIdsNotAudited(user: UUID): List[Int] = db.withSession { implicit session =>
 
     val edgesAuditedByUser: List[Int] =
       completedTasks.filter(_.userId === user.toString).groupBy(_.streetEdgeId).map(_._1).list
@@ -205,7 +205,7 @@ object AuditTaskTable {
   /**
     * Gets the list of streets in the specified region that the user has not audited.
     */
-  def streetEdgeIdsNotAuditedByUser(user: UUID, regionId: Int): List[Int] = db.withSession { implicit session =>
+  def getStreetEdgeIdsNotAudited(user: UUID, regionId: Int): List[Int] = db.withSession { implicit session =>
 
     val edgesAuditedByUser: List[Int] =
       completedTasks.filter(_.userId === user.toString).groupBy(_.streetEdgeId).map(_._1).list
@@ -224,7 +224,7 @@ object AuditTaskTable {
     */
   def isTaskAvailable(user: UUID, regionId: Int): Boolean = db.withSession { implicit session =>
 
-    val availableTasks: Int = streetEdgeIdsNotAuditedByUser(user, regionId).length
+    val availableTasks: Int = getStreetEdgeIdsNotAudited(user, regionId).length
     availableTasks > 0
   }
 
@@ -233,7 +233,7 @@ object AuditTaskTable {
     */
   def selectIncompleteRegions(user: UUID): Set[Int] = db.withSession { implicit session =>
     nonDeletedStreetEdgeRegions
-      .filter(_.streetEdgeId inSet streetEdgeIdsNotAuditedByUser(user))
+      .filter(_.streetEdgeId inSet getStreetEdgeIdsNotAudited(user))
       .map(_.regionId)
       .list.toSet
   }
@@ -286,7 +286,7 @@ object AuditTaskTable {
   /**
    * Return street edges audited by the given user.
    */
-  def selectStreetsAuditedByAUser(userId: UUID): List[StreetEdge] =  db.withSession { implicit session =>
+  def getAuditedStreets(userId: UUID): List[StreetEdge] =  db.withSession { implicit session =>
     val _streetEdges = for {
       (_tasks, _edges) <- completedTasks.innerJoin(streetEdgesWithoutDeleted).on(_.streetEdgeId === _.streetEdgeId)
       if _tasks.userId === userId.toString
@@ -299,7 +299,7 @@ object AuditTaskTable {
     * Get the sum of the line distance of all streets in the region that the user has not audited.
     */
   def getUnauditedDistance(userId: UUID, regionId: Int): Float = db.withSession { implicit session =>
-    val streetsLeft: List[Int] = streetEdgeIdsNotAuditedByUser(userId, regionId)
+    val streetsLeft: List[Int] = getStreetEdgeIdsNotAudited(userId, regionId)
     streetEdgesWithoutDeleted.filter(_.streetEdgeId inSet streetsLeft).map(_.geom.transform(26918).length).list.sum
   }
 
@@ -361,7 +361,7 @@ object AuditTaskTable {
     val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
 
     // Get the streets that the user has not already completed.
-    val edgesInRegion = streetEdges.filter(_.streetEdgeId inSet streetEdgeIdsNotAuditedByUser(user, regionId))
+    val edgesInRegion = streetEdges.filter(_.streetEdgeId inSet getStreetEdgeIdsNotAudited(user, regionId))
 
     // Join with other queries to get completion count and priority for each of the street edges.
     val possibleTasks = for {

--- a/app/models/daos/slick/UserDAOSlick.scala
+++ b/app/models/daos/slick/UserDAOSlick.scala
@@ -278,7 +278,7 @@ object UserDAOSlick {
         |INNER JOIN mission ON label_validation.user_id = mission.user_id
         |INNER JOIN sidewalk_user ON sidewalk_user.user_id = mission.user_id
         |INNER JOIN user_role ON sidewalk_user.user_id = user_role.user_id
-        |INNER JOIN sidewalk.role ON user_role.role_id = sidewalk.role.role_id
+        |INNER JOIN role ON user_role.role_id = role.role_id
         |WHERE (label_validation.end_timestamp AT TIME ZONE 'US/Pacific')::date = (NOW() AT TIME ZONE 'US/Pacific')::date
         |    AND sidewalk_user.username <> 'anonymous'
         |    AND role.role = ?""".stripMargin
@@ -317,7 +317,7 @@ object UserDAOSlick {
         |INNER JOIN mission ON label_validation.user_id = mission.user_id
         |INNER JOIN sidewalk_user ON sidewalk_user.user_id = mission.user_id
         |INNER JOIN user_role ON sidewalk_user.user_id = user_role.user_id
-        |INNER JOIN sidewalk.role ON user_role.role_id = sidewalk.role.role_id
+        |INNER JOIN role ON user_role.role_id = role.role_id
         |WHERE (label_validation.end_timestamp AT TIME ZONE 'US/Pacific') > (NOW() AT TIME ZONE 'US/Pacific') - interval '168 hours'
         |    AND sidewalk_user.username <> 'anonymous'
         |    AND role.role = ?""".stripMargin
@@ -388,10 +388,10 @@ object UserDAOSlick {
   def countAuditUsersContributedToday(role: String): Int = db.withSession { implicit session =>
     val countQuery = Q.query[String, Int](
       """SELECT COUNT(DISTINCT(audit_task.user_id))
-        |FROM sidewalk.audit_task
+        |FROM audit_task
         |INNER JOIN sidewalk_user ON sidewalk_user.user_id = audit_task.user_id
         |INNER JOIN user_role ON sidewalk_user.user_id = user_role.user_id
-        |INNER JOIN sidewalk.role ON user_role.role_id = sidewalk.role.role_id
+        |INNER JOIN role ON user_role.role_id = role.role_id
         |WHERE (audit_task.task_end AT TIME ZONE 'US/Pacific')::date = (NOW() AT TIME ZONE 'US/Pacific')::date
         |    AND sidewalk_user.username <> 'anonymous'
         |    AND role.role = ?
@@ -427,10 +427,10 @@ object UserDAOSlick {
   def countAuditUsersContributedPastWeek(role: String): Int = db.withSession { implicit session =>
     val countQuery = Q.query[String, Int](
       """SELECT COUNT(DISTINCT(audit_task.user_id))
-        |FROM sidewalk.audit_task
+        |FROM audit_task
         |INNER JOIN sidewalk_user ON sidewalk_user.user_id = audit_task.user_id
         |INNER JOIN user_role ON sidewalk_user.user_id = user_role.user_id
-        |INNER JOIN sidewalk.role ON user_role.role_id = sidewalk.role.role_id
+        |INNER JOIN role ON user_role.role_id = role.role_id
         |WHERE (audit_task.task_end AT TIME ZONE 'US/Pacific') > (now() AT TIME ZONE 'US/Pacific') - interval '168 hours'
         |    AND sidewalk_user.username <> 'anonymous'
         |    AND role.role = ?

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -235,8 +235,8 @@ object LabelTable {
   def countTodayLabels: Int = db.withSession { implicit session =>
     val countQuery = Q.queryNA[(Int)](
       """SELECT COUNT(label.label_id)
-        |FROM sidewalk.audit_task
-        |INNER JOIN sidewalk.label ON label.audit_task_id = audit_task.audit_task_id
+        |FROM audit_task
+        |INNER JOIN label ON label.audit_task_id = audit_task.audit_task_id
         |WHERE (audit_task.task_end AT TIME ZONE 'US/Pacific')::date = (now() AT TIME ZONE 'US/Pacific')::date
         |    AND label.deleted = false""".stripMargin
     )
@@ -251,13 +251,13 @@ object LabelTable {
   def countTodayLabels(labelType: String): Int = db.withSession { implicit session =>
     val countQuery = Q.queryNA[Int](
       s"""SELECT COUNT(label.label_id)
-         |FROM sidewalk.audit_task
-         |INNER JOIN sidewalk.label ON label.audit_task_id = audit_task.audit_task_id
+         |FROM audit_task
+         |INNER JOIN label ON label.audit_task_id = audit_task.audit_task_id
          |WHERE (audit_task.task_end AT TIME ZONE 'US/Pacific')::date = (now() AT TIME ZONE 'US/Pacific')::date
          |    AND label.deleted = false
          |    AND label.label_type_id = (
          |        SELECT label_type_id
-         |        FROM sidewalk.label_type as lt
+         |        FROM label_type as lt
          |        WHERE lt.label_type='$labelType'
          |    )""".stripMargin
     )
@@ -270,8 +270,8 @@ object LabelTable {
   def countPastWeekLabels: Int = db.withTransaction { implicit session =>
     val countQuery = Q.queryNA[(Int)](
       """SELECT COUNT(label.label_id)
-        |FROM sidewalk.audit_task
-        |INNER JOIN sidewalk.label ON label.audit_task_id = audit_task.audit_task_id
+        |FROM audit_task
+        |INNER JOIN label ON label.audit_task_id = audit_task.audit_task_id
         |WHERE (audit_task.task_end AT TIME ZONE 'US/Pacific') > (now() AT TIME ZONE 'US/Pacific') - interval '168 hours'
         |    AND label.deleted = false""".stripMargin
     )
@@ -284,13 +284,13 @@ object LabelTable {
   def countPastWeekLabels(labelType: String): Int = db.withTransaction { implicit session =>
     val countQuery = Q.queryNA[Int](
       s"""SELECT COUNT(label.label_id)
-         |FROM sidewalk.audit_task
-         |INNER JOIN sidewalk.label ON label.audit_task_id = audit_task.audit_task_id
+         |FROM audit_task
+         |INNER JOIN label ON label.audit_task_id = audit_task.audit_task_id
          |WHERE (audit_task.task_end AT TIME ZONE 'US/Pacific') > (now() AT TIME ZONE 'US/Pacific') - interval '168 hours'
          |    AND label.deleted = false
          |    AND label.label_type_id = (
          |        SELECT label_type_id
-         |        FROM sidewalk.label_type as lt
+         |        FROM label_type as lt
          |        WHERE lt.label_type='$labelType'
          |    )""".stripMargin
     )
@@ -376,11 +376,11 @@ object LabelTable {
         |       lb_big.description,
         |       val.val_counts,
         |       lb_big.tag_list
-        |FROM sidewalk.label AS lb1,
-        |     sidewalk.gsv_data,
-        |     sidewalk.audit_task AS at,
+        |FROM label AS lb1,
+        |     gsv_data,
+        |     audit_task AS at,
         |     sidewalk_user AS u,
-        |     sidewalk.label_point AS lp,
+        |     label_point AS lp,
         |     (
         |         SELECT lb.label_id,
         |                lb.gsv_panorama_id,
@@ -391,14 +391,14 @@ object LabelTable {
         |                lab_desc.description,
         |                the_tags.tag_list
         |         FROM label AS lb
-        |         LEFT JOIN sidewalk.label_type as lbt ON lb.label_type_id = lbt.label_type_id
-        |         LEFT JOIN sidewalk.label_severity as sev ON lb.label_id = sev.label_id
-        |         LEFT JOIN sidewalk.label_description as lab_desc ON lb.label_id = lab_desc.label_id
-        |         LEFT JOIN sidewalk.label_temporariness as lab_temp ON lb.label_id = lab_temp.label_id
+        |         LEFT JOIN label_type as lbt ON lb.label_type_id = lbt.label_type_id
+        |         LEFT JOIN label_severity as sev ON lb.label_id = sev.label_id
+        |         LEFT JOIN label_description as lab_desc ON lb.label_id = lab_desc.label_id
+        |         LEFT JOIN label_temporariness as lab_temp ON lb.label_id = lab_temp.label_id
         |         LEFT JOIN (
         |             SELECT label_id, array_to_string(array_agg(tag.tag), ',') AS tag_list
-        |             FROM sidewalk.label_tag
-        |             INNER JOIN sidewalk.tag ON label_tag.tag_id = tag.tag_id
+        |             FROM label_tag
+        |             INNER JOIN tag ON label_tag.tag_id = tag.tag_id
         |             GROUP BY label_id
         |         ) AS the_tags
         |             ON lb.label_id = the_tags.label_id
@@ -452,11 +452,11 @@ object LabelTable {
         |       lb_big.temp,
         |       lb_big.description,
         |       lb_big.tag_list
-        |FROM sidewalk.label AS lb1,
-        |     sidewalk.gsv_data,
-        |     sidewalk.audit_task AS at,
+        |FROM label AS lb1,
+        |     gsv_data,
+        |     audit_task AS at,
         |     sidewalk_user AS u,
-        |     sidewalk.label_point AS lp,
+        |     label_point AS lp,
         |     (
         |         SELECT lb.label_id,
         |                lb.gsv_panorama_id,
@@ -467,14 +467,14 @@ object LabelTable {
         |                lab_desc.description,
         |                the_tags.tag_list
         |         FROM label AS lb
-        |         LEFT JOIN sidewalk.label_type AS lbt ON lb.label_type_id = lbt.label_type_id
-        |         LEFT JOIN sidewalk.label_severity AS sev ON lb.label_id = sev.label_id
-        |         LEFT JOIN sidewalk.label_description AS lab_desc ON lb.label_id = lab_desc.label_id
-        |         LEFT JOIN sidewalk.label_temporariness AS lab_temp ON lb.label_id = lab_temp.label_id
+        |         LEFT JOIN label_type AS lbt ON lb.label_type_id = lbt.label_type_id
+        |         LEFT JOIN label_severity AS sev ON lb.label_id = sev.label_id
+        |         LEFT JOIN label_description AS lab_desc ON lb.label_id = lab_desc.label_id
+        |         LEFT JOIN label_temporariness AS lab_temp ON lb.label_id = lab_temp.label_id
         |         LEFT JOIN (
         |             SELECT label_id, array_to_string(array_agg(tag.tag), ',') AS tag_list
-        |             FROM sidewalk.label_tag
-        |             INNER JOIN sidewalk.tag ON label_tag.tag_id = tag.tag_id
+        |             FROM label_tag
+        |             INNER JOIN tag ON label_tag.tag_id = tag.tag_id
         |             GROUP BY label_id
         |         ) AS the_tags
         |             ON lb.label_id = the_tags.label_id
@@ -517,11 +517,11 @@ object LabelTable {
         |       lb_big.description,
         |       lb_val.val_counts,
         |       lb_big.tag_list
-        |FROM sidewalk.label AS lb1,
-        |     sidewalk.gsv_data,
-        |     sidewalk.audit_task AS at,
+        |FROM label AS lb1,
+        |     gsv_data,
+        |     audit_task AS at,
         |     sidewalk_user AS u,
-        |     sidewalk.label_point AS lp,
+        |     label_point AS lp,
         |     (
         |         SELECT array_to_string(array_agg(concat_ws(':', validation_options.text, COALESCE(count, 0))), ',') AS val_counts
         |         FROM (
@@ -542,14 +542,14 @@ object LabelTable {
         |                lab_desc.description,
         |                the_tags.tag_list
         |         FROM label AS lb
-        |         LEFT JOIN sidewalk.label_type AS lbt ON lb.label_type_id = lbt.label_type_id
-        |         LEFT JOIN sidewalk.label_severity AS sev ON lb.label_id = sev.label_id
-        |         LEFT JOIN sidewalk.label_description AS lab_desc ON lb.label_id = lab_desc.label_id
-        |         LEFT JOIN sidewalk.label_temporariness AS lab_temp ON lb.label_id = lab_temp.label_id
+        |         LEFT JOIN label_type AS lbt ON lb.label_type_id = lbt.label_type_id
+        |         LEFT JOIN label_severity AS sev ON lb.label_id = sev.label_id
+        |         LEFT JOIN label_description AS lab_desc ON lb.label_id = lab_desc.label_id
+        |         LEFT JOIN label_temporariness AS lab_temp ON lb.label_id = lab_temp.label_id
         |         LEFT JOIN (
         |             SELECT label_id, array_to_string(array_agg(tag.tag), ',') AS tag_list
-        |             FROM sidewalk.label_tag
-        |             INNER JOIN sidewalk.tag ON label_tag.tag_id = tag.tag_id
+        |             FROM label_tag
+        |             INNER JOIN tag ON label_tag.tag_id = tag.tag_id
         |             GROUP BY label_id
         |         ) AS the_tags
         |             ON lb.label_id = the_tags.label_id
@@ -1121,11 +1121,11 @@ object LabelTable {
   def getTagsFromLabelId(labelId: Int): List[String] = db.withSession { implicit session =>
       val getTagsQuery = Q.query[Int, (String)](
         """SELECT tag
-          |FROM sidewalk.tag
+          |FROM tag
           |WHERE tag.tag_id IN
           |(
           |    SELECT tag_id
-          |    FROM sidewalk.label_tag
+          |    FROM label_tag
           |    WHERE label_tag.label_id = ?
           |)""".stripMargin
       )
@@ -1199,9 +1199,9 @@ object LabelTable {
         |       label_type.label_type,
         |       label_point.lat,
         |       label_point.lng
-        |FROM sidewalk.label
-        |INNER JOIN sidewalk.label_type ON label.label_type_id = label_type.label_type_id
-        |INNER JOIN sidewalk.label_point ON label.label_id = label_point.label_id
+        |FROM label
+        |INNER JOIN label_type ON label.label_type_id = label_type.label_type_id
+        |INNER JOIN label_point ON label.label_id = label_point.label_id
         |WHERE label.deleted = false
         |    AND label_point.lat IS NOT NULL
         |    AND ST_Intersects(label_point.geom, ST_MakeEnvelope(?, ?, ?, ?, 4326))""".stripMargin
@@ -1235,11 +1235,11 @@ object LabelTable {
         |       label_point.lat,
         |       label_point.lng,
         |       region.region_id
-        |FROM sidewalk.label
-        |INNER JOIN sidewalk.label_type ON label.label_type_id = label_type.label_type_id
-        |INNER JOIN sidewalk.label_point ON label.label_id = label_point.label_id
-        |INNER JOIN sidewalk.audit_task ON audit_task.audit_task_id = label.audit_task_id
-        |INNER JOIN sidewalk.region ON ST_Intersects(region.geom, label_point.geom)
+        |FROM label
+        |INNER JOIN label_type ON label.label_type_id = label_type.label_type_id
+        |INNER JOIN label_point ON label.label_id = label_point.label_id
+        |INNER JOIN audit_task ON audit_task.audit_task_id = label.audit_task_id
+        |INNER JOIN region ON ST_Intersects(region.geom, label_point.geom)
         |WHERE label.deleted = FALSE
         |    AND label_point.lat IS NOT NULL
         |    AND region.deleted = FALSE

--- a/app/models/label/LabelValidationTable.scala
+++ b/app/models/label/LabelValidationTable.scala
@@ -303,7 +303,7 @@ object LabelValidationTable {
   def countTodayValidations: Int = db.withSession { implicit session =>
     val countQuery = Q.queryNA[(Int)](
       """SELECT COUNT(v.label_id)
-        |FROM sidewalk.label_validation v
+        |FROM label_validation v
         |WHERE (v.end_timestamp AT TIME ZONE 'US/Pacific')::date = (NOW() AT TIME ZONE 'US/Pacific')::date""".stripMargin
     )
     countQuery.first
@@ -315,7 +315,7 @@ object LabelValidationTable {
   def countPastWeekValidations: Int = db.withSession { implicit session =>
     val countQuery = Q.queryNA[(Int)](
       """SELECT COUNT(v.label_id)
-        |FROM sidewalk.label_validation v
+        |FROM label_validation v
         |WHERE (v.end_timestamp AT TIME ZONE 'US/Pacific') > (NOW() AT TIME ZONE 'US/Pacific') - interval '168 hours'""".stripMargin
     )
     countQuery.first
@@ -327,7 +327,7 @@ object LabelValidationTable {
   def countTodayValidationsBasedOnResult(result: Int): Int = db.withSession { implicit session =>
     val countQuery = Q.queryNA[(Int)](
       s"""SELECT COUNT(v.label_id)
-        |FROM sidewalk.label_validation v
+        |FROM label_validation v
         |WHERE (v.end_timestamp AT TIME ZONE 'US/Pacific')::date = (NOW() AT TIME ZONE 'US/Pacific')::date
         |   AND v.validation_result = $result""".stripMargin
     )
@@ -340,7 +340,7 @@ object LabelValidationTable {
   def countPastWeekValidationsBasedOnResult(result: Int): Int = db.withSession { implicit session =>
     val countQuery = Q.queryNA[(Int)](
       s"""SELECT COUNT(v.label_id)
-         |FROM sidewalk.label_validation v
+         |FROM label_validation v
          |WHERE (v.end_timestamp AT TIME ZONE 'US/Pacific') > (NOW() AT TIME ZONE 'US/Pacific') - interval '168 hours'
          |   AND v.validation_result = $result""".stripMargin
     )

--- a/app/models/label/LabelValidationTable.scala
+++ b/app/models/label/LabelValidationTable.scala
@@ -254,7 +254,7 @@ object LabelValidationTable {
   /**
     * @return count of validations for the given label type
     */
-  def countValidationsByLabelType(labelType: String): Int = db.withSession { implicit session =>
+  def countValidations(labelType: String): Int = db.withSession { implicit session =>
     val typeID = LabelTypeTable.labelTypeToId(labelType)
 
     validationLabels.innerJoin(labelsWithoutDeleted).on(_.labelId === _.labelId)
@@ -265,7 +265,7 @@ object LabelValidationTable {
   /**
     * @return count of validations for the given validation result and label type
     */
-  def countValidationsByResultAndLabelType(result: Int, labelType: String): Int = db.withSession { implicit session =>
+  def countValidationsByResult(result: Int, labelType: String): Int = db.withSession { implicit session =>
     val typeID = LabelTypeTable.labelTypeToId(labelType)
 
     validationLabels.innerJoin(labelsWithoutDeleted).on(_.labelId === _.labelId)
@@ -279,7 +279,7 @@ object LabelValidationTable {
    *
    * @returns the number of validations performed by this user
    */
-  def countValidationsByUserId(userId: UUID): Int = db.withSession { implicit session =>
+  def countValidations(userId: UUID): Int = db.withSession { implicit session =>
     validationLabels.filter(_.userId === userId.toString).size.run
   }
 
@@ -293,7 +293,7 @@ object LabelValidationTable {
   /**
     * @return total number of validations with a given result
     */
-  def countValidationsBasedOnResult(result: Int): Int = db.withTransaction(implicit session =>
+  def countValidationsByResult(result: Int): Int = db.withTransaction(implicit session =>
     validationLabels.filter(_.validationResult === result).length.run
   )
 
@@ -324,7 +324,7 @@ object LabelValidationTable {
   /**
     * @return total number of today's validations with a given result
     */
-  def countTodayValidationsBasedOnResult(result: Int): Int = db.withSession { implicit session =>
+  def countTodayValidationsByResult(result: Int): Int = db.withSession { implicit session =>
     val countQuery = Q.queryNA[(Int)](
       s"""SELECT COUNT(v.label_id)
         |FROM label_validation v
@@ -337,7 +337,7 @@ object LabelValidationTable {
   /**
     * @return total number of the past week's validations with a given result
     */
-  def countPastWeekValidationsBasedOnResult(result: Int): Int = db.withSession { implicit session =>
+  def countPastWeekValidationsByResult(result: Int): Int = db.withSession { implicit session =>
     val countQuery = Q.queryNA[(Int)](
       s"""SELECT COUNT(v.label_id)
          |FROM label_validation v

--- a/app/models/street/StreetEdgeTable.scala
+++ b/app/models/street/StreetEdgeTable.scala
@@ -349,7 +349,7 @@ object StreetEdgeTable {
         |       st_e.way_type,
         |       st_e.deleted,
         |       st_e.timestamp
-        |FROM sidewalk.street_edge AS st_e
+        |FROM street_edge AS st_e
         |WHERE st_e.deleted = FALSE
         |    AND ST_Intersects(st_e.geom, ST_MakeEnvelope(?, ?, ?, ?, 4326))""".stripMargin
     )
@@ -371,8 +371,8 @@ object StreetEdgeTable {
         |       street_edge.way_type,
         |       street_edge.deleted,
         |       street_edge.timestamp
-        |FROM sidewalk.street_edge
-        |INNER JOIN sidewalk.audit_task ON street_edge.street_edge_id = audit_task.street_edge_id
+        |FROM street_edge
+        |INNER JOIN audit_task ON street_edge.street_edge_id = audit_task.street_edge_id
         |WHERE street_edge.deleted = FALSE
         |    AND ST_Intersects(street_edge.geom, ST_MakeEnvelope(?, ?, ?, ?, 4326))
         |    AND audit_task.completed = TRUE""".stripMargin
@@ -393,8 +393,8 @@ object StreetEdgeTable {
         |       street_edge.way_type,
         |       street_edge.deleted,
         |       street_edge.timestamp
-        |FROM sidewalk.street_edge
-        |INNER JOIN sidewalk.audit_task ON street_edge.street_edge_id = audit_task.street_edge_id
+        |FROM street_edge
+        |INNER JOIN audit_task ON street_edge.street_edge_id = audit_task.street_edge_id
         |WHERE street_edge.deleted = FALSE
         |    AND ST_Within(street_edge.geom, ST_MakeEnvelope(?, ?, ?, ?, 4326))
         |    AND audit_task.completed = TRUE""".stripMargin

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -107,45 +107,45 @@
                                 </tr>
                                 <tr style="font-size: 90%;">
                                     <td style="padding-left: 30px">Curb Ramp</td>
-                                    <td>@LabelTable.countLabelsBasedOnType("CurbRamp")</td>
-                                    <td>@LabelTable.countTodayLabelsBasedOnType("CurbRamp")</td>
-                                    <td>@LabelTable.countPastWeekLabelsBasedOnType("CurbRamp")</td>
+                                    <td>@LabelTable.countLabels("CurbRamp")</td>
+                                    <td>@LabelTable.countTodayLabels("CurbRamp")</td>
+                                    <td>@LabelTable.countPastWeekLabels("CurbRamp")</td>
                                 </tr>
                                 <tr style="font-size: 90%;">
                                     <td style="padding-left: 30px">Missing Curb Ramp</td>
-                                    <td>@LabelTable.countLabelsBasedOnType("NoCurbRamp")</td>
-                                    <td>@LabelTable.countTodayLabelsBasedOnType("NoCurbRamp")</td>
-                                    <td>@LabelTable.countPastWeekLabelsBasedOnType("NoCurbRamp")</td>
+                                    <td>@LabelTable.countLabels("NoCurbRamp")</td>
+                                    <td>@LabelTable.countTodayLabels("NoCurbRamp")</td>
+                                    <td>@LabelTable.countPastWeekLabels("NoCurbRamp")</td>
                                 </tr>
                                 <tr style="font-size: 90%;">
                                     <td style="padding-left: 30px">Obstacle in Path</td>
-                                    <td>@LabelTable.countLabelsBasedOnType("Obstacle")</td>
-                                    <td>@LabelTable.countTodayLabelsBasedOnType("Obstacle")</td>
-                                    <td>@LabelTable.countPastWeekLabelsBasedOnType("Obstacle")</td>
+                                    <td>@LabelTable.countLabels("Obstacle")</td>
+                                    <td>@LabelTable.countTodayLabels("Obstacle")</td>
+                                    <td>@LabelTable.countPastWeekLabels("Obstacle")</td>
                                 </tr>
                                 <tr style="font-size: 90%;">
                                     <td style="padding-left: 30px">Surface Problem</td>
-                                    <td>@LabelTable.countLabelsBasedOnType("SurfaceProblem")</td>
-                                    <td>@LabelTable.countTodayLabelsBasedOnType("SurfaceProblem")</td>
-                                    <td>@LabelTable.countPastWeekLabelsBasedOnType("SurfaceProblem")</td>
+                                    <td>@LabelTable.countLabels("SurfaceProblem")</td>
+                                    <td>@LabelTable.countTodayLabels("SurfaceProblem")</td>
+                                    <td>@LabelTable.countPastWeekLabels("SurfaceProblem")</td>
                                 </tr>
                                 <tr style="font-size: 90%;">
                                     <td style="padding-left: 30px">No Sidewalk</td>
-                                    <td>@LabelTable.countLabelsBasedOnType("NoSidewalk")</td>
-                                    <td>@LabelTable.countTodayLabelsBasedOnType("NoSidewalk")</td>
-                                    <td>@LabelTable.countPastWeekLabelsBasedOnType("NoSidewalk")</td>
+                                    <td>@LabelTable.countLabels("NoSidewalk")</td>
+                                    <td>@LabelTable.countTodayLabels("NoSidewalk")</td>
+                                    <td>@LabelTable.countPastWeekLabels("NoSidewalk")</td>
                                 </tr>
                                 <tr style="font-size: 90%;">
                                     <td style="padding-left: 30px">Other</td>
-                                    <td>@LabelTable.countLabelsBasedOnType("Other")</td>
-                                    <td>@LabelTable.countTodayLabelsBasedOnType("Other")</td>
-                                    <td>@LabelTable.countPastWeekLabelsBasedOnType("Other")</td>
+                                    <td>@LabelTable.countLabels("Other")</td>
+                                    <td>@LabelTable.countTodayLabels("Other")</td>
+                                    <td>@LabelTable.countPastWeekLabels("Other")</td>
                                 </tr>
                                 <tr style="font-size: 90%;">
                                     <td style="padding-left: 30px">Occlusion</td>
-                                    <td>@LabelTable.countLabelsBasedOnType("Occlusion")</td>
-                                    <td>@LabelTable.countTodayLabelsBasedOnType("Occlusion")</td>
-                                    <td>@LabelTable.countPastWeekLabelsBasedOnType("Occlusion")</td>
+                                    <td>@LabelTable.countLabels("Occlusion")</td>
+                                    <td>@LabelTable.countTodayLabels("Occlusion")</td>
+                                    <td>@LabelTable.countPastWeekLabels("Occlusion")</td>
                                 </tr>
 
                                 <tr>
@@ -200,23 +200,23 @@
 
                                 <tr style="font-size: 90%;">
                                     <td style="padding-left: 30px">Agreed</td>
-                                    <td>@LabelValidationTable.countValidationsBasedOnResult(1) (@("%.0f".format(LabelValidationTable.countValidationsBasedOnResult(1) * 100.0 / LabelValidationTable.countValidations))%)</td>
-                                    <td>@LabelValidationTable.countTodayValidationsBasedOnResult(1) (@("%.0f".format(LabelValidationTable.countTodayValidationsBasedOnResult(1) * 100.0 / LabelValidationTable.countTodayValidations))%)</td>
-                                    <td>@LabelValidationTable.countPastWeekValidationsBasedOnResult(1) (@("%.0f".format(LabelValidationTable.countPastWeekValidationsBasedOnResult(1) * 100.0 / LabelValidationTable.countPastWeekValidations))%)</td>
+                                    <td>@LabelValidationTable.countValidationsByResult(1) (@("%.0f".format(LabelValidationTable.countValidationsByResult(1) * 100.0 / LabelValidationTable.countValidations))%)</td>
+                                    <td>@LabelValidationTable.countTodayValidationsByResult(1) (@("%.0f".format(LabelValidationTable.countTodayValidationsByResult(1) * 100.0 / LabelValidationTable.countTodayValidations))%)</td>
+                                    <td>@LabelValidationTable.countPastWeekValidationsByResult(1) (@("%.0f".format(LabelValidationTable.countPastWeekValidationsByResult(1) * 100.0 / LabelValidationTable.countPastWeekValidations))%)</td>
                                 </tr>
 
                                 <tr style="font-size: 90%;">
                                     <td style="padding-left: 30px">Disagreed</td>
-                                    <td>@LabelValidationTable.countValidationsBasedOnResult(2) (@("%.0f".format(LabelValidationTable.countValidationsBasedOnResult(2) * 100.0 / LabelValidationTable.countValidations))%)</td>
-                                    <td>@LabelValidationTable.countTodayValidationsBasedOnResult(2) (@("%.0f".format(LabelValidationTable.countTodayValidationsBasedOnResult(2) * 100.0 / LabelValidationTable.countTodayValidations))%)</td>
-                                    <td>@LabelValidationTable.countPastWeekValidationsBasedOnResult(2) (@("%.0f".format(LabelValidationTable.countPastWeekValidationsBasedOnResult(2) * 100.0 / LabelValidationTable.countPastWeekValidations))%)</td>
+                                    <td>@LabelValidationTable.countValidationsByResult(2) (@("%.0f".format(LabelValidationTable.countValidationsByResult(2) * 100.0 / LabelValidationTable.countValidations))%)</td>
+                                    <td>@LabelValidationTable.countTodayValidationsByResult(2) (@("%.0f".format(LabelValidationTable.countTodayValidationsByResult(2) * 100.0 / LabelValidationTable.countTodayValidations))%)</td>
+                                    <td>@LabelValidationTable.countPastWeekValidationsByResult(2) (@("%.0f".format(LabelValidationTable.countPastWeekValidationsByResult(2) * 100.0 / LabelValidationTable.countPastWeekValidations))%)</td>
                                 </tr>
 
                                 <tr style="font-size: 90%;">
                                     <td style="padding-left: 30px">Not Sure</td>
-                                    <td>@LabelValidationTable.countValidationsBasedOnResult(3) (@("%.0f".format(LabelValidationTable.countValidationsBasedOnResult(3) * 100.0 / LabelValidationTable.countValidations))%)</td>
-                                    <td>@LabelValidationTable.countTodayValidationsBasedOnResult(3) (@("%.0f".format(LabelValidationTable.countTodayValidationsBasedOnResult(3) * 100.0 / LabelValidationTable.countTodayValidations))%)</td>
-                                    <td>@LabelValidationTable.countPastWeekValidationsBasedOnResult(3) (@("%.0f".format(LabelValidationTable.countPastWeekValidationsBasedOnResult(3) * 100.0 / LabelValidationTable.countPastWeekValidations))%)</td>
+                                    <td>@LabelValidationTable.countValidationsByResult(3) (@("%.0f".format(LabelValidationTable.countValidationsByResult(3) * 100.0 / LabelValidationTable.countValidations))%)</td>
+                                    <td>@LabelValidationTable.countTodayValidationsByResult(3) (@("%.0f".format(LabelValidationTable.countTodayValidationsByResult(3) * 100.0 / LabelValidationTable.countTodayValidations))%)</td>
+                                    <td>@LabelValidationTable.countPastWeekValidationsByResult(3) (@("%.0f".format(LabelValidationTable.countPastWeekValidationsByResult(3) * 100.0 / LabelValidationTable.countPastWeekValidations))%)</td>
                                 </tr>
                             </table>
                             <sup>*</sup>For cells with the format X (Y). The "Y" is the number of users who have completed
@@ -628,44 +628,44 @@
                                     <tr>
                                         <th>Overall</th>
                                         <th>@LabelValidationTable.countValidations</th>
-                                        <th>@("%.0f".format(DataFormatter.nanToZero(LabelValidationTable.countValidationsBasedOnResult(1) * 100.0 / LabelValidationTable.countValidations)))%</th>
-                                        <th>@("%.0f".format(DataFormatter.nanToZero(LabelValidationTable.countValidationsBasedOnResult(2) * 100.0 / LabelValidationTable.countValidations)))%</th>
-                                        <th>@("%.0f".format(DataFormatter.nanToZero(LabelValidationTable.countValidationsBasedOnResult(3) * 100.0 / LabelValidationTable.countValidations)))%</th>
+                                        <th>@("%.0f".format(DataFormatter.nanToZero(LabelValidationTable.countValidationsByResult(1) * 100.0 / LabelValidationTable.countValidations)))%</th>
+                                        <th>@("%.0f".format(DataFormatter.nanToZero(LabelValidationTable.countValidationsByResult(2) * 100.0 / LabelValidationTable.countValidations)))%</th>
+                                        <th>@("%.0f".format(DataFormatter.nanToZero(LabelValidationTable.countValidationsByResult(3) * 100.0 / LabelValidationTable.countValidations)))%</th>
                                     </tr>
                                     <tr style="font-size: 90%;">
                                         <td style="padding-left: 30px">Curb Ramp</td>
-                                        <td>@LabelValidationTable.countValidationsByLabelType("CurbRamp")</td>
-                                        <td>@("%.0f".format(DataFormatter.nanToZero(LabelValidationTable.countValidationsByResultAndLabelType(1, "CurbRamp") * 100.0 / LabelValidationTable.countValidationsByLabelType("CurbRamp"))))%</td>
-                                        <td>@("%.0f".format(DataFormatter.nanToZero(LabelValidationTable.countValidationsByResultAndLabelType(2, "CurbRamp") * 100.0 / LabelValidationTable.countValidationsByLabelType("CurbRamp"))))%</td>
-                                        <td>@("%.0f".format(DataFormatter.nanToZero(LabelValidationTable.countValidationsByResultAndLabelType(3, "CurbRamp") * 100.0 / LabelValidationTable.countValidationsByLabelType("CurbRamp"))))%</td>
+                                        <td>@LabelValidationTable.countValidations("CurbRamp")</td>
+                                        <td>@("%.0f".format(DataFormatter.nanToZero(LabelValidationTable.countValidationsByResult(1, "CurbRamp") * 100.0 / LabelValidationTable.countValidations("CurbRamp"))))%</td>
+                                        <td>@("%.0f".format(DataFormatter.nanToZero(LabelValidationTable.countValidationsByResult(2, "CurbRamp") * 100.0 / LabelValidationTable.countValidations("CurbRamp"))))%</td>
+                                        <td>@("%.0f".format(DataFormatter.nanToZero(LabelValidationTable.countValidationsByResult(3, "CurbRamp") * 100.0 / LabelValidationTable.countValidations("CurbRamp"))))%</td>
                                     </tr>
                                     <tr style="font-size: 90%;">
                                         <td style="padding-left: 30px">Missing Curb Ramp</td>
-                                        <td>@LabelValidationTable.countValidationsByLabelType("NoCurbRamp")</td>
-                                        <td>@("%.0f".format(DataFormatter.nanToZero(LabelValidationTable.countValidationsByResultAndLabelType(1, "NoCurbRamp") * 100.0 / LabelValidationTable.countValidationsByLabelType("NoCurbRamp"))))%</td>
-                                        <td>@("%.0f".format(DataFormatter.nanToZero(LabelValidationTable.countValidationsByResultAndLabelType(2, "NoCurbRamp") * 100.0 / LabelValidationTable.countValidationsByLabelType("NoCurbRamp"))))%</td>
-                                        <td>@("%.0f".format(DataFormatter.nanToZero(LabelValidationTable.countValidationsByResultAndLabelType(3, "NoCurbRamp") * 100.0 / LabelValidationTable.countValidationsByLabelType("NoCurbRamp"))))%</td>
+                                        <td>@LabelValidationTable.countValidations("NoCurbRamp")</td>
+                                        <td>@("%.0f".format(DataFormatter.nanToZero(LabelValidationTable.countValidationsByResult(1, "NoCurbRamp") * 100.0 / LabelValidationTable.countValidations("NoCurbRamp"))))%</td>
+                                        <td>@("%.0f".format(DataFormatter.nanToZero(LabelValidationTable.countValidationsByResult(2, "NoCurbRamp") * 100.0 / LabelValidationTable.countValidations("NoCurbRamp"))))%</td>
+                                        <td>@("%.0f".format(DataFormatter.nanToZero(LabelValidationTable.countValidationsByResult(3, "NoCurbRamp") * 100.0 / LabelValidationTable.countValidations("NoCurbRamp"))))%</td>
                                     </tr>
                                     <tr style="font-size: 90%;">
                                         <td style="padding-left: 30px">Obstacle in Path</td>
-                                        <td>@LabelValidationTable.countValidationsByLabelType("Obstacle")</td>
-                                        <td>@("%.0f".format(DataFormatter.nanToZero(LabelValidationTable.countValidationsByResultAndLabelType(1, "Obstacle") * 100.0 / LabelValidationTable.countValidationsByLabelType("Obstacle"))))%</td>
-                                        <td>@("%.0f".format(DataFormatter.nanToZero(LabelValidationTable.countValidationsByResultAndLabelType(2, "Obstacle") * 100.0 / LabelValidationTable.countValidationsByLabelType("Obstacle"))))%</td>
-                                        <td>@("%.0f".format(DataFormatter.nanToZero(LabelValidationTable.countValidationsByResultAndLabelType(3, "Obstacle") * 100.0 / LabelValidationTable.countValidationsByLabelType("Obstacle"))))%</td>
+                                        <td>@LabelValidationTable.countValidations("Obstacle")</td>
+                                        <td>@("%.0f".format(DataFormatter.nanToZero(LabelValidationTable.countValidationsByResult(1, "Obstacle") * 100.0 / LabelValidationTable.countValidations("Obstacle"))))%</td>
+                                        <td>@("%.0f".format(DataFormatter.nanToZero(LabelValidationTable.countValidationsByResult(2, "Obstacle") * 100.0 / LabelValidationTable.countValidations("Obstacle"))))%</td>
+                                        <td>@("%.0f".format(DataFormatter.nanToZero(LabelValidationTable.countValidationsByResult(3, "Obstacle") * 100.0 / LabelValidationTable.countValidations("Obstacle"))))%</td>
                                     </tr>
                                     <tr style="font-size: 90%;">
                                         <td style="padding-left: 30px">Surface Problem</td>
-                                        <td>@LabelValidationTable.countValidationsByLabelType("SurfaceProblem")</td>
-                                        <td>@("%.0f".format(DataFormatter.nanToZero(LabelValidationTable.countValidationsByResultAndLabelType(1, "SurfaceProblem") * 100.0 / LabelValidationTable.countValidationsByLabelType("SurfaceProblem"))))%</td>
-                                        <td>@("%.0f".format(DataFormatter.nanToZero(LabelValidationTable.countValidationsByResultAndLabelType(2, "SurfaceProblem") * 100.0 / LabelValidationTable.countValidationsByLabelType("SurfaceProblem"))))%</td>
-                                        <td>@("%.0f".format(DataFormatter.nanToZero(LabelValidationTable.countValidationsByResultAndLabelType(3, "SurfaceProblem") * 100.0 / LabelValidationTable.countValidationsByLabelType("SurfaceProblem"))))%</td>
+                                        <td>@LabelValidationTable.countValidations("SurfaceProblem")</td>
+                                        <td>@("%.0f".format(DataFormatter.nanToZero(LabelValidationTable.countValidationsByResult(1, "SurfaceProblem") * 100.0 / LabelValidationTable.countValidations("SurfaceProblem"))))%</td>
+                                        <td>@("%.0f".format(DataFormatter.nanToZero(LabelValidationTable.countValidationsByResult(2, "SurfaceProblem") * 100.0 / LabelValidationTable.countValidations("SurfaceProblem"))))%</td>
+                                        <td>@("%.0f".format(DataFormatter.nanToZero(LabelValidationTable.countValidationsByResult(3, "SurfaceProblem") * 100.0 / LabelValidationTable.countValidations("SurfaceProblem"))))%</td>
                                     </tr>
                                     <tr style="font-size: 90%;">
                                         <td style="padding-left: 30px">No Sidewalk</td>
-                                        <td>@LabelValidationTable.countValidationsByLabelType("NoSidewalk")</td>
-                                        <td>@("%.0f".format(DataFormatter.nanToZero(LabelValidationTable.countValidationsByResultAndLabelType(1, "NoSidewalk") * 100.0 / LabelValidationTable.countValidationsByLabelType("NoSidewalk"))))%</td>
-                                        <td>@("%.0f".format(DataFormatter.nanToZero(LabelValidationTable.countValidationsByResultAndLabelType(3, "NoSidewalk") * 100.0 / LabelValidationTable.countValidationsByLabelType("NoSidewalk"))))%</td>
-                                        <td>@("%.0f".format(DataFormatter.nanToZero(LabelValidationTable.countValidationsByResultAndLabelType(2, "NoSidewalk") * 100.0 / LabelValidationTable.countValidationsByLabelType("NoSidewalk"))))%</td>
+                                        <td>@LabelValidationTable.countValidations("NoSidewalk")</td>
+                                        <td>@("%.0f".format(DataFormatter.nanToZero(LabelValidationTable.countValidationsByResult(1, "NoSidewalk") * 100.0 / LabelValidationTable.countValidations("NoSidewalk"))))%</td>
+                                        <td>@("%.0f".format(DataFormatter.nanToZero(LabelValidationTable.countValidationsByResult(3, "NoSidewalk") * 100.0 / LabelValidationTable.countValidations("NoSidewalk"))))%</td>
+                                        <td>@("%.0f".format(DataFormatter.nanToZero(LabelValidationTable.countValidationsByResult(2, "NoSidewalk") * 100.0 / LabelValidationTable.countValidations("NoSidewalk"))))%</td>
                                     </tr>
                                 </table>
                             </div>
@@ -695,7 +695,7 @@
                                 </thead>
                                 <!-- using this id to locate the labelTags so we can insert the tags-->
                                 <tbody id = 'labelRows'>
-                                    @LabelTable.selectTopLabelsAndMetadata(5000).map { label =>
+                                    @LabelTable.getRecentLabelMetadataWithValidations(5000).map { label =>
                                         <tr>
                                             <td><a href='@routes.AdminController.userProfile(label.username)'>@label.username</a>
                                             </td>

--- a/app/views/admin/user.scala.html
+++ b/app/views/admin/user.scala.html
@@ -63,9 +63,9 @@
                         <th class="col-md">Time spent auditing/validating</th>
                     </tr>
                     <tr>
-                        <td>@MissionTable.countCompletedMissionsByUserId(UUID.fromString(user.get.userId), includeOnboarding = false, includeSkipped = false)</td>
-                        <td>@AuditTaskTable.countCompletedAuditsByUserId(UUID.fromString(user.get.userId))</td>
-                        <td>@LabelTable.countLabelsByUserId(UUID.fromString(user.get.userId))</td>
+                        <td>@MissionTable.countCompletedMissions(UUID.fromString(user.get.userId), includeOnboarding = false, includeSkipped = false)</td>
+                        <td>@AuditTaskTable.countCompletedAudits(UUID.fromString(user.get.userId))</td>
+                        <td>@LabelTable.countLabels(UUID.fromString(user.get.userId))</td>
                         <td id="td-total-distance-audited-admin"></td>
                         <td>@AuditTaskInteractionTable.getHoursAuditingAndValidating(user.get.userId) hours</td>
                     </tr>
@@ -90,7 +90,7 @@
                     </tr>
                     </thead>
                     <tbody>
-                    @LabelTable.selectTopLabelsAndMetadataByUser(1000, UUID.fromString(user.get.userId)).map { userLabel =>
+                    @LabelTable.getRecentLabelMetadata(1000, UUID.fromString(user.get.userId)).map { userLabel =>
                         <tr>
                             <td class = 'timestamp'>@userLabel.timestamp</td>
                             <td>@userLabel.labelTypeKey</td>

--- a/app/views/userProfile.scala.html
+++ b/app/views/userProfile.scala.html
@@ -41,10 +41,10 @@
                 <img src='@routes.Assets.at("images/icons/noun_validation_1876484_cropped.png")' alt="@Messages("dashboard.validation.icon.alt")"/>
                 <img src='@routes.Assets.at("images/icons/noun_target_3485590_cropped.png")' alt="@Messages("dashboard.accuracy.icon.alt")" title="@Messages("dashboard.accuracy.icon.tooltip")"/>
 
-                <span class="user-stats-stat">@MissionTable.countCompletedMissionsByUserId(user.get.userId, true, false)</span>
+                <span class="user-stats-stat">@MissionTable.countCompletedMissions(user.get.userId, true, false)</span>
                 <span class="user-stats-stat">@{s"%.2f ${Messages("dist.metric.abbr")}".format(auditedDistance)}</span>
-                <span class="user-stats-stat">@LabelTable.countLabelsByUserId(user.get.userId)</span>
-                <span class="user-stats-stat">@LabelValidationTable.countValidationsByUserId(user.get.userId)</span>
+                <span class="user-stats-stat">@LabelTable.countLabels(user.get.userId)</span>
+                <span class="user-stats-stat">@LabelValidationTable.countValidations(user.get.userId)</span>
                 <span class="user-stats-stat">@LabelValidationTable.getUserAccuracy(user.get.userId).map(a => "%.1f%%".format(a * 100)).getOrElse("N/A")</span>
 
             </div>
@@ -158,10 +158,10 @@
 
             const achievementTracker = new AchievementTracker();
             achievementTracker.updateBadgeAchievementGrid(
-                @MissionTable.countCompletedMissionsByUserId(user.get.userId, includeOnboarding = true, includeSkipped = false),
+                @MissionTable.countCompletedMissions(user.get.userId, includeOnboarding = true, includeSkipped = false),
                 @auditedDistance,
-                @LabelTable.countLabelsByUserId(user.get.userId),
-                @LabelValidationTable.countValidationsByUserId(user.get.userId),
+                @LabelTable.countLabels(user.get.userId),
+                @LabelValidationTable.countValidations(user.get.userId),
             );
         });
     });


### PR DESCRIPTION
Resolves #2265 

Standardizes and shortens function names in the `app/model` files. @jonfroehlich pointed out that some, but not all, of the functions that take in a user ID were named `getBlahByUserId`. I decided to remove the `ByX` in any function names where the `X` there is just one of the parameters to the function. It should be clear when you say `countLabels(userId)` that you are counting the labels for that user, so it doesn't need to be called `countLabelsByUserId(userId)`. This standardizes our naming conventions and shortens some of the really long function names we had.

I also removed some instances of including the schema name (which is "sidewalk") in some queries, since it is implied. This just means I changed a lot of `FROM sidewalk.audit_task` to `FROM audit_task`.

None of these modifications change any functionality of the site.

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
