### PR TITLE
Fixes race condition where tag translations did not load in Gallery

### DIFF
--- a/public/javascripts/Gallery/src/Main.js
+++ b/public/javascripts/Gallery/src/Main.js
@@ -67,11 +67,10 @@ function Main (params) {
         debug: false
     }, function(err, t) {
         if (err) return console.log('something went wrong loading', err);
-        i18next.t('key');
-    });
 
-    _initUI();
-    _init();
+        _initUI();
+        _init();
+    });
 
     return self;
 }

--- a/public/javascripts/Gallery/src/filter/CardFilter.js
+++ b/public/javascripts/Gallery/src/filter/CardFilter.js
@@ -49,9 +49,9 @@ function CardFilter(uiCardFilter, ribbonMenu) {
      */
     function getTags(callback) {
         $.getJSON("/label/tags", function (data) {
-            let tag,
-                i = 0,
-                len = data.length;
+            let tag;
+            let i = 0;
+            let len = data.length;
             for (; i < len; i++) {
                 tag = new Tag(data[i]);
                 tagsByType[tag.getLabelType()].push(tag);


### PR DESCRIPTION
Fixes #2554 

There was a race condition that could occur in Gallery which would cause some of the translations to not load, namely, the tag names in the filtering section. It wasn't caught in our dev environments just because of the timing difference when sending something over a network.

I fixed it by putting the `_initUI()` and `_init()` functions for Gallery in `Main.js` inside the callback to `i18next.init()` instead of just being called after it. This must have just slipped my mind during the initial code review, oops!

##### Before/After screenshots (if applicable)
Before:
![Screenshot from 2021-06-18 11-57-07](https://user-images.githubusercontent.com/6518824/122606212-6914ab00-d02d-11eb-8812-8a6967ffa9dc.png)

And in the worst case:
![Screenshot from 2021-06-18 11-56-43](https://user-images.githubusercontent.com/6518824/122606220-6ca83200-d02d-11eb-834a-e2db85419785.png)

After:
![Screenshot from 2021-06-18 11-57-32](https://user-images.githubusercontent.com/6518824/122606226-6fa32280-d02d-11eb-86e4-52c7eb01f10b.png)

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
