### PR TITLE
Removes extra whitespace in Gallery, increases card size

### DIFF
--- a/public/javascripts/Gallery/css/cards.css
+++ b/public/javascripts/Gallery/css/cards.css
@@ -4,7 +4,7 @@
     padding: 0px;
     margin: 5px;
     border-radius: 20px;
-    width: 22vw;
+    width: 25vw;
     height: auto;
     box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.1), 0 6px 20px 0 rgba(0, 0, 0, 0.05);
 }

--- a/public/javascripts/Gallery/css/gallery.css
+++ b/public/javascripts/Gallery/css/gallery.css
@@ -61,7 +61,7 @@
     grid-template-areas: 
         'sidebar main gallery-modal'
         'sidebar paging gallery-modal';
-    grid-template-columns: 1fr 3fr;
+    grid-template-columns: 0.5fr 3fr;
     grid-gap: 2px;
     padding: 10px;
 }

--- a/public/javascripts/Gallery/src/modal/Modal.js
+++ b/public/javascripts/Gallery/src/modal/Modal.js
@@ -52,7 +52,7 @@ function Modal(uiModal) {
      * Performs the actions to close the Modal.
      */
     function closeModal() {
-        $('.grid-container').css("grid-template-columns", "1fr 3fr");
+        $('.grid-container').css("grid-template-columns", "0.5fr 3fr");
         uiModal.hide();
     }
 


### PR DESCRIPTION
Fixes one issue raised in #2587 

This removes the extra whitespace between the filtering section and the actual cards. Since I'm getting rid of that whitespace, I increased the size of the cards slightly.

##### Before/After screenshots (if applicable)
Before
![Screenshot from 2021-06-18 13-17-21](https://user-images.githubusercontent.com/6518824/122612625-4f2c9580-d038-11eb-8b6e-b1a57a12e612.png)

After
![Screenshot from 2021-06-18 13-16-18](https://user-images.githubusercontent.com/6518824/122612620-4cca3b80-d038-11eb-969c-7057d347cfd0.png)

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've included before/after screenshots above.