### PR TITLE
Removes drop shadow from small Gallery cards

### DIFF
--- a/public/javascripts/Gallery/css/cards.css
+++ b/public/javascripts/Gallery/css/cards.css
@@ -7,6 +7,9 @@
     width: 24vw;
     height: auto;
 }
+.gallery-card:hover {
+    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.1), 0 6px 20px 0 rgba(0, 0, 0, 0.05);
+}
 
 .validate-agree {
     background-color: #78c9ab;
@@ -88,6 +91,9 @@ with respect to the image holder. This allows the validation menu to be placed o
     border-style: solid;
     border-bottom-left-radius: 20px;
     border-bottom-right-radius: 20px;
+}
+.card-info:hover {
+    border-width: 0; /* Using a drop shadow on hover, and we don't need both the border and shadow. */
 }
 
 .card-data {

--- a/public/javascripts/Gallery/css/cards.css
+++ b/public/javascripts/Gallery/css/cards.css
@@ -6,7 +6,7 @@
     border-radius: 20px;
     width: 24vw;
     height: auto;
-    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.1), 0 6px 20px 0 rgba(0, 0, 0, 0.05);
+    border-color: #dcdbdb;
 }
 
 .validate-agree {
@@ -29,19 +29,6 @@ with respect to the image holder. This allows the validation menu to be placed o
     position: relative;
 }
 
-.gallery-card:after {
-    content: '';
-    position: absolute;
-    z-index: -1;
-    width: 100%;
-    height: 100%;
-    border-radius: 20px;
-    opacity: 0;
-    bottom:0;
-    left:0;
-    box-shadow: 0 5px 15px rgba(0,0,0,0.3);
-    transition: opacity 0.3s ease-in-out;
-}
 .gallery-card:hover:after {
     opacity: 1;
 }
@@ -97,6 +84,11 @@ with respect to the image holder. This allows the validation menu to be placed o
     font-size: 0.9vw;
     font-family: 'raleway-regular', sans-serif;
     color: #2d2a3f;
+    border-width: 0 1px 1px 1px;
+    border-color: #dcdbdb;
+    border-style: solid;
+    border-bottom-left-radius: 20px;
+    border-bottom-right-radius: 20px;
 }
 
 .card-data {

--- a/public/javascripts/Gallery/css/cards.css
+++ b/public/javascripts/Gallery/css/cards.css
@@ -6,7 +6,6 @@
     border-radius: 20px;
     width: 24vw;
     height: auto;
-    border-color: #dcdbdb;
 }
 
 .validate-agree {


### PR DESCRIPTION
Resolves #2600 

Replaces a drop shadow on the small Gallery cards with a 1 px gray outline along the lower portion of the cards

##### Before/After screenshots (if applicable)
Before
![Screenshot from 2021-06-22 12-22-39](https://user-images.githubusercontent.com/6518824/122986834-ccb41680-d354-11eb-8a26-423c64026e20.png)

After
![Screenshot from 2021-06-22 12-23-25](https://user-images.githubusercontent.com/6518824/122986848-cf167080-d354-11eb-9c4e-224de86a9498.png)

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
