### PR TITLE
Gallery close modal when filtering or paging

### DIFF
--- a/public/javascripts/Gallery/css/gallery.css
+++ b/public/javascripts/Gallery/css/gallery.css
@@ -16,6 +16,7 @@
     background-color: white;
     border-radius: 5px;
     border-width: 1px;
+    margin: 0px 2px;
 }
 
 .paging:disabled {

--- a/public/javascripts/Gallery/src/cards/Card.js
+++ b/public/javascripts/Gallery/src/cards/Card.js
@@ -228,6 +228,8 @@ function Card (params, imageUrl) {
      */
     function render (cardContainer) {
         // TODO: should there be a safety check here to make sure pano is loaded?
+        // If the card had transparent background from the modal being open earlier, remove transparency on rerender.
+        if (card.classList.contains('modal-background-card')) card.classList.remove('modal-background-card');
         panoImage.width = imageDim.w;
         panoImage.height = imageDim.h;
         cardContainer.append(card);

--- a/public/javascripts/Gallery/src/cards/CardContainer.js
+++ b/public/javascripts/Gallery/src/cards/CardContainer.js
@@ -285,7 +285,7 @@ function CardContainer(uiCardContainer) {
                     currentCards = cardsByType[currentLabelType].copy();
                     currentCards.filterOnTags(appliedTags);
                     currentCards.filterOnSeverities(appliedSeverities);
-        
+
                     render();
                 });
             }
@@ -390,6 +390,7 @@ function CardContainer(uiCardContainer) {
      * Refreshes the UI after each query made by user.
      */
     function refreshUI() {
+        modal.closeModal();
         sg.tagContainer.disable();
         $("#label-select").prop("disabled", true);
         $("#labels-not-found").hide();
@@ -452,12 +453,10 @@ function CardContainer(uiCardContainer) {
         let cardBucket = currentCards.getCards();
 
         let currentPageCards = [];
-
         while (idx < currentPage * cardsPerPage && idx < cardBucket.length) {
             currentPageCards.push(cardBucket[idx]);
             idx++;
         }
-
         return currentPageCards;
     }
 

--- a/public/javascripts/Gallery/src/filter/CardFilter.js
+++ b/public/javascripts/Gallery/src/filter/CardFilter.js
@@ -37,7 +37,6 @@ function CardFilter(uiCardFilter, ribbonMenu) {
      */
     function _init() {
         getTags(function () {
-            console.log("tags received");
             render();
         });
     }
@@ -62,7 +61,7 @@ function CardFilter(uiCardFilter, ribbonMenu) {
     }
 
     /**
-     * Update filter componenets when label type changes.
+     * Update filter components when label type changes.
      */
     function update() {
         let currentLabelType = ribbonMenu.getCurrentLabelType();
@@ -73,7 +72,6 @@ function CardFilter(uiCardFilter, ribbonMenu) {
             currentTags = tagsByType[currentLabelType];
             sg.cardContainer.updateCardsByType();
         }
-
         render();
     }
 
@@ -88,7 +86,7 @@ function CardFilter(uiCardFilter, ribbonMenu) {
         } else {
             $("#tags-header").hide();
         }
-        if (status.currentLabelType == "Occlusion") {
+        if (status.currentLabelType === "Occlusion") {
             $("#filters").hide();
             $("#horizontal-line").hide();
         } else {
@@ -162,8 +160,6 @@ function CardFilter(uiCardFilter, ribbonMenu) {
      */
     function unapplyTags(labelType) {
         if (labelType != null) {
-            console.log("tags unapplied");
-            console.log(labelType);
             tagsByType[labelType].unapplyTags();
         }
     }

--- a/public/javascripts/Gallery/src/modal/Modal.js
+++ b/public/javascripts/Gallery/src/modal/Modal.js
@@ -47,7 +47,7 @@ function Modal(uiModal) {
         self.closeButton = $('.gallery-modal-close')
         self.leftArrow = $('#prev-label')
         self.rightArrow = $('#next-label')
-        self.closeButton.click(closeModal)
+        self.closeButton.click(closeModalAndRemoveCardTransparency)
         self.rightArrow.click(nextLabel)
         self.leftArrow.click(previousLabel)
         self.cardIndex = -1;
@@ -55,6 +55,7 @@ function Modal(uiModal) {
 
     /**
      * Performs the actions to close the Modal.
+     * NOTE does not remove card transparency. For that, use closeModalAndRemoveCardTransparency().
      */
     function closeModal() {
         // Since we have made the sidebar a "fixed" DOM element, it no longer exists as part of the grid flow. Thus,
@@ -63,8 +64,12 @@ function Modal(uiModal) {
         // Disclaimer: I could be totally wrong lol.
         $('.grid-container').css("grid-template-columns", "none");
         uiModal.hide();
+    }
 
-        // Make sure to remove transparent effect from all cards since we are out of modal mode.
+    /**
+     * Removes transparency from the current page of cards.
+     */
+    function removeCardTransparency() {
         let currentPageCards = sg.cardContainer.getCurrentPageCards();
         for (let card of currentPageCards) {
             let cardDomEl = document.getElementById("gallery_card_" + card.getLabelId());
@@ -72,6 +77,14 @@ function Modal(uiModal) {
                 cardDomEl.classList.remove(unselectedCardClassName);
             }
         }
+    }
+
+    /**
+     * Closes modal and removes transparency from cards on the current page. Not used when loading a new page of cards.
+     */
+    function closeModalAndRemoveCardTransparency() {
+        closeModal();
+        removeCardTransparency();
     }
 
     /**
@@ -234,6 +247,7 @@ function Modal(uiModal) {
 
     self.updateProperties = updateProperties;
     self.openModal = openModal;
+    self.closeModal = closeModal;
     self.updateCardIndex = updateCardIndex;
 
     return self;


### PR DESCRIPTION
Fixes #2606 

The expanded view now closes whenever we change the filter or move to a new page in Gallery.

##### Before/After screenshots (if applicable)
Before (when you click open the modal, then change the filter)
![Screenshot from 2021-06-22 14-44-18](https://user-images.githubusercontent.com/6518824/123004095-055deb00-d369-11eb-8959-df53fb7ec60d.png)

After (same scenario)
![Screenshot from 2021-06-22 17-13-48](https://user-images.githubusercontent.com/6518824/123015435-3c3dfc00-d37d-11eb-9be3-a7f1c72ee743.png)

##### Testing instructions
1. Load gallery
2. Click on a card to open expanded view
3. Go to the filters and pick a label type that is different from the type of your current card
4. The modal should close and the newly filtered cards should load correctly

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
