### PR TITLE
2595 - Fixed text issue on validate

### DIFF
--- a/public/javascripts/SVValidate/src/label/LabelDescriptionBox.js
+++ b/public/javascripts/SVValidate/src/label/LabelDescriptionBox.js
@@ -37,7 +37,7 @@ function LabelDescriptionBox () {
 
         if (severity && severity != 0) {
             let span = document.createElement('span');
-            let htmlString = document.createTextNode(i18next.t('common:severity') + severity + ' ');
+            let htmlString = document.createTextNode(i18next.t('common:severity') + ": " +  severity + ' ');
             desBox.appendChild(htmlString);
             let img = document.createElement('img');
             img.setAttribute('src', smileyScale[severity]);
@@ -64,7 +64,7 @@ function LabelDescriptionBox () {
         if (tags && tags.length > 0) {
             // Translate to correct language and separate tags with a comma.
             let tag = tags.map(t => i18next.t('common:tag.' + t)).join(', ');
-            let htmlString = document.createTextNode(i18next.t('common:tags') + tag);
+            let htmlString = document.createTextNode(i18next.t('common:tags') + ": " + tag);
             desBox.appendChild(htmlString);
             desBox.appendChild(document.createElement("br"));
         }


### PR DESCRIPTION
Resolves #2595 

Description: On /validate, the label descriptions are formatted incorrectly. I added some strings in the JS file: "LabelDescriptionBox.js" and it fixed it.

##### Before/After screenshots 
![image](https://user-images.githubusercontent.com/33397020/123870519-487b0980-d8e7-11eb-8bcb-d9b19bd6e369.png)
![image](https://user-images.githubusercontent.com/33397020/123870856-cb03c900-d8e7-11eb-9c8b-b273f00aa337.png)

##### Testing instructions
1. Hover over the label and see the fix
2. 
- [X] I've written a descriptive PR title.
- [X] I've added/updated comments for large or confusing blocks of code.
- [X] I've included before/after screenshots above.
- [x] I've tested on mobile (only needed for validation page).
