### PR TITLE
Show previous validations in Gallery

### DIFF
--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -127,26 +127,24 @@ object LabelTable {
 
   case class LabelMetadataWithValidation(labelId: Int, gsvPanoramaId: String, tutorial: Boolean, imageDate: String,
                                          heading: Float, pitch: Float, zoom: Int, canvasX: Int, canvasY: Int,
-                                         canvasWidth: Int, canvasHeight: Int,
-                                         auditTaskId: Int,
-                                         userId: String, username: String,
-                                         timestamp: Option[java.sql.Timestamp],
-                                         labelTypeKey:String, labelTypeValue: String, severity: Option[Int],
-                                         temporary: Boolean, description: Option[String],
-                                         validations: Map[String, Int], tags: List[String])
+                                         canvasWidth: Int, canvasHeight: Int, auditTaskId: Int, userId: String,
+                                         username: String, timestamp: Option[java.sql.Timestamp], labelTypeKey: String,
+                                         labelTypeValue: String, severity: Option[Int], temporary: Boolean,
+                                         description: Option[String], validations: Map[String, Int], tags: List[String])
 
   // NOTE: canvas_x and canvas_y are null when the label is not visible when validation occurs.
   case class LabelValidationMetadata(labelId: Int, labelType: String, gsvPanoramaId: String, imageDate: String,
                                      timestamp: Option[java.sql.Timestamp], heading: Float, pitch: Float, zoom: Int,
                                      canvasX: Int, canvasY: Int, canvasWidth: Int, canvasHeight: Int,
                                      severity: Option[Int], temporary: Boolean, description: Option[String],
-                                     tags: List[String])
+                                     userValidation: Option[Int], tags: List[String])
 
   case class LabelValidationMetadataWithoutTags(labelId: Int, labelType: String, gsvPanoramaId: String,
                                                 imageDate: String, timestamp: Option[java.sql.Timestamp],
                                                 heading: Float, pitch: Float, zoom: Int, canvasX: Int, canvasY: Int,
                                                 canvasWidth: Int, canvasHeight: Int, severity: Option[Int],
-                                                temporary: Boolean, description: Option[String]);
+                                                temporary: Boolean, description: Option[String],
+                                                userValidation: Option[Int]);
 
   case class LabelCVMetadata(gsvPanoramaId: String, svImageX: Int, svImageY: Int,
                              labelTypeId: Int, photographerHeading: Float, heading: Float,
@@ -176,13 +174,15 @@ object LabelTable {
   implicit val labelValidationMetadataWithoutTagsConverter = GetResult[LabelValidationMetadataWithoutTags](r =>
     LabelValidationMetadataWithoutTags(
       r.nextInt, r.nextString, r.nextString, r.nextString, r.nextTimestampOption, r.nextFloat, r.nextFloat, r.nextInt,
-      r.nextInt, r.nextInt, r.nextInt, r.nextInt, r.nextIntOption, r.nextBoolean, r.nextStringOption))
+      r.nextInt, r.nextInt, r.nextInt, r.nextInt, r.nextIntOption, r.nextBoolean, r.nextStringOption, r.nextIntOption
+    )
+  )
 
   implicit val labelValidationMetadataConverter = GetResult[LabelValidationMetadata](r =>
     LabelValidationMetadata(
       r.nextInt, r.nextString, r.nextString, r.nextString, r.nextTimestampOption, r.nextFloat, r.nextFloat, r.nextInt,
       r.nextInt, r.nextInt, r.nextInt, r.nextInt, r.nextIntOption, r.nextBoolean, r.nextStringOption,
-      r.nextStringOption.map(tags => tags.split(",").toList).getOrElse(List())
+      r.nextIntOption, r.nextStringOption.map(tags => tags.split(",").toList).getOrElse(List())
     )
   )
 
@@ -605,7 +605,7 @@ object LabelTable {
     * @param skippedLabelId Label ID of the label that was just skipped (if applicable).
     * @return               Seq[LabelValidationMetadata]
     */
-  def retrieveLabelListForValidation(userId: UUID, n: Int, labelTypeId: Int, skippedLabelId: Option[Int]) : Seq[LabelValidationMetadata] = db.withSession { implicit session =>
+  def retrieveLabelListForValidation(userId: UUID, n: Int, labelTypeId: Int, skippedLabelId: Option[Int]): Seq[LabelValidationMetadata] = db.withSession { implicit session =>
     var selectedLabels: ListBuffer[LabelValidationMetadata] = new ListBuffer[LabelValidationMetadata]()
     var potentialLabels: List[LabelValidationMetadata] = List()
     val userIdStr = userId.toString
@@ -615,7 +615,7 @@ object LabelTable {
         s"""SELECT label.label_id, label_type.label_type, label.gsv_panorama_id, gsv_data.image_date,
           |        label.time_created, label_point.heading, label_point.pitch, label_point.zoom, label_point.canvas_x,
           |        label_point.canvas_y, label_point.canvas_width, label_point.canvas_height, label_severity.severity,
-          |        label_temporariness.temporary, label_description.description, the_tags.tag_list
+          |        label_temporariness.temporary, label_description.description, NULL AS user_val, the_tags.tag_list
           |FROM label
           |INNER JOIN label_type ON label.label_type_id = label_type.label_type_id
           |INNER JOIN label_point ON label.label_id = label_point.label_id
@@ -718,7 +718,7 @@ object LabelTable {
    * @param tags Set of tags the labels grabbed can have.
    * @return Seq[LabelValidationMetadata]
    */
-  def retrieveLabelsOfTypeBySeverityAndTags(labelTypeId: Int, n: Int, loadedLabelIds: Set[Int], severity: Set[Int], tags: Set[String]): Seq[LabelValidationMetadata] = db.withSession { implicit session => 
+  def getLabelsOfTypeBySeverityAndTags(labelTypeId: Int, n: Int, loadedLabelIds: Set[Int], severity: Set[Int], tags: Set[String], userId: UUID): Seq[LabelValidationMetadata] = db.withSession { implicit session =>
     // List to return.
     val selectedLabels: ListBuffer[LabelValidationMetadata] = new ListBuffer[LabelValidationMetadata]()
 
@@ -772,8 +772,15 @@ object LabelTable {
     } yield (l._1.labelId, l._3, l._1.gsvPanoramaId, l._6, l._1.timeCreated, l._2.heading, l._2.pitch,
              l._2.zoom, l._2.canvasX, l._2.canvasY, l._2.canvasWidth, l._2.canvasHeight, l._4, l._5, d.description.?)
 
+    // Join with the most recent validations that the user has given.
+    val userValidations = getMostRecentValidationsPerLabel(userId)
+    val addValidations = for {
+      (l, v) <- addDescriptions.leftJoin(userValidations).on(_._1 === _._1)
+    } yield (l._1, l._2, l._3, l._4, l._5, l._6, l._7, l._8, l._9, l._10, l._11, l._12, l._13, l._14, l._15, v._2.?)
+    println(addValidations.size.run)
+
     // Randomize and convert to LabelValidationMetadataWithoutTags.
-    val newRandomLabelsList = addDescriptions.sortBy(x => rand).list.map(LabelValidationMetadataWithoutTags.tupled)
+    val newRandomLabelsList = addValidations.sortBy(x => rand).list.map(LabelValidationMetadataWithoutTags.tupled)
 
     var potentialStartIdx: Int = 0
 
@@ -806,7 +813,6 @@ object LabelTable {
     selectedLabels
   }
 
-
   /**
    * Retrieve n random labels of assorted types. 
    *
@@ -815,7 +821,7 @@ object LabelTable {
    * @param severity Optional set of severities the labels grabbed can have.
    * @return Seq[LabelValidationMetadata]
    */
-  def retrieveAssortedLabels(n: Int, loadedLabelIds: Set[Int], severity: Option[Set[Int]] = None): Seq[LabelValidationMetadata] = db.withSession { implicit session => 
+  def getAssortedLabels(n: Int, loadedLabelIds: Set[Int], userId: UUID, severity: Option[Set[Int]] = None): Seq[LabelValidationMetadata] = db.withSession { implicit session =>
     // List to return.
     val selectedLabels: ListBuffer[LabelValidationMetadata] = new ListBuffer[LabelValidationMetadata]()
 
@@ -867,8 +873,14 @@ object LabelTable {
     } yield (l._1.labelId, l._3, l._1.gsvPanoramaId, l._6, l._1.timeCreated, l._2.heading, l._2.pitch,
              l._2.zoom, l._2.canvasX, l._2.canvasY, l._2.canvasWidth, l._2.canvasHeight, l._4, l._5, d.description.?)
 
+    // Join with the most recent validations that the user has given.
+    val userValidations = getMostRecentValidationsPerLabel(userId)
+    val addValidations = for {
+      (l, v) <- addDescriptions.leftJoin(userValidations).on(_._1 === _._1)
+    } yield (l._1, l._2, l._3, l._4, l._5, l._6, l._7, l._8, l._9, l._10, l._11, l._12, l._13, l._14, l._15, v._2.?)
+
     // Randomize and convert to LabelValidationMetadataWithoutTags.
-    val newRandomLabelsList = addDescriptions.sortBy(x => rand).list.map(LabelValidationMetadataWithoutTags.tupled)
+    val newRandomLabelsList = addValidations.sortBy(x => rand).list.map(LabelValidationMetadataWithoutTags.tupled)
 
     val labelTypesAsStrings = LabelTypeTable.validLabelTypes
 
@@ -909,7 +921,7 @@ object LabelTable {
    * @param loadedLabelIds Label Ids of labels already grabbed.
    * @return Seq[LabelValidationMetadata]
    */
-  def retrieveLabelsByType(labelTypeId: Int, n: Int, loadedLabelIds: Set[Int]): Seq[LabelValidationMetadata] = db.withSession { implicit session =>
+  def getLabelsByType(labelTypeId: Int, n: Int, loadedLabelIds: Set[Int], userId: UUID): Seq[LabelValidationMetadata] = db.withSession { implicit session =>
     // List to return.
     val selectedLabels: ListBuffer[LabelValidationMetadata] = new ListBuffer[LabelValidationMetadata]()
     
@@ -955,8 +967,15 @@ object LabelTable {
     } yield (l._1.labelId, l._3, l._1.gsvPanoramaId, l._6, l._1.timeCreated, l._2.heading, l._2.pitch,
              l._2.zoom, l._2.canvasX, l._2.canvasY, l._2.canvasWidth, l._2.canvasHeight, l._4, l._5, d.description.?)
 
+    // Join with the most recent validations that the user has given.
+    val userValidations = getMostRecentValidationsPerLabel(userId)
+    val addValidations = for {
+      (l, v) <- addDescriptions.leftJoin(userValidations).on(_._1 === _._1)
+    } yield (l._1, l._2, l._3, l._4, l._5, l._6, l._7, l._8, l._9, l._10, l._11, l._12, l._13, l._14, l._15, v._2.?)
+    println(addValidations.size.run)
+
     // Randomize and convert to LabelValidationMetadataWithoutTags.
-    val newRandomLabelsList = addDescriptions.sortBy(x => rand).list.map(LabelValidationMetadataWithoutTags.tupled)
+    val newRandomLabelsList = addValidations.sortBy(x => rand).list.map(LabelValidationMetadataWithoutTags.tupled)
 
     var potentialStartIdx: Int = 0
 
@@ -982,8 +1001,47 @@ object LabelTable {
       potentialStartIdx += labelsNeeded
       selectedLabels ++= newLabels
     }
-
     selectedLabels
+  }
+
+  /**
+   * For the given user, get the most recent validation result from each label they've validated, regardless of method.
+   *
+   * Ideally, we'd like to group by label_id, filter for most recent validation, and return the corresponding validation
+   * result. The methods to do that are a bit wonky in postgres, and even wonkier when we use Slick. In raw psql:
+   * SELECT DISTINCT ON (label_id) label_id, validation_result
+   * FROM label_validation
+   * WHERE user_id = '$userId'
+   * ORDER BY label_id, end_timestamp DESC;
+   *
+   * But in Slick, we can't use DISTINCT ON in this way (at least with Slick 2.1). So we instead group by label_id and
+   * get the newest validation timestamp (from the given user) for each label. Then we have to join that back with the
+   * label_validation table, joining on the label_id AND the timestamp. This _should_ be sufficient, but it is
+   * theoretically possible that a user could submitted multiple validations with identical timestamps, which would mean
+   * duplicates that we don't want. In the interest of performance (and because there was some issues converting it to
+   * Slick) we are skipping that grouping step. Below is the plain SQL that we converted to Slick syntax in the code.
+   * SELECT label_validation.label_id, validation_result
+   * FROM label_validation
+   * INNER JOIN (
+   *     SELECT label_id, MAX(end_timestamp) AS most_recent_timestamp
+   *     FROM label_validation
+   *     WHERE user_id = '$userId'
+   *     GROUP BY label_id
+   * ) most_recent_val
+   *     ON label_validation.label_id = most_recent_val.label_id
+   *     AND label_validation.end_timestamp = most_recent_val.most_recent_timestamp
+   * WHERE label_validation.user_id = '$userId';
+   *
+   * @param userId
+   * @return A query with the integer columns label_id and validation_result
+   */
+  def getMostRecentValidationsPerLabel(userId: UUID): Query[(Column[Int], Column[Int]), (Int, Int), Seq] = {
+    val userValidations = labelValidations.filter(_.userId === userId.toString)
+
+    userValidations.groupBy(_.labelId).map {
+      case (labId, group) => (labId, group.map(_.endTimestamp).max)
+    }.innerJoin(userValidations).on { case (x, y) => x._1 === y.labelId && x._2 === y.endTimestamp }
+      .map(x => (x._2.labelId, x._2.validationResult))
   }
 
   /**
@@ -997,7 +1055,7 @@ object LabelTable {
       LabelValidationMetadata(
         label.labelId, label.labelType, label.gsvPanoramaId, label.imageDate, label.timestamp, label.heading,
         label.pitch, label.zoom, label.canvasX, label.canvasY, label.canvasWidth, label.canvasHeight, label.severity,
-        label.temporary, label.description, tags
+        label.temporary, label.description, label.userValidation, tags
       )
   }
 
@@ -1061,6 +1119,7 @@ object LabelTable {
       "severity" -> labelMetadata.severity,
       "temporary" -> labelMetadata.temporary,
       "description" -> labelMetadata.description,
+      "user_validation" -> labelMetadata.userValidation.map(LabelValidationTable.validationOptions.get),
       "tags" -> labelMetadata.tags
     )
   }

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -1040,8 +1040,9 @@ object LabelTable {
 
     userValidations.groupBy(_.labelId).map {
       case (labId, group) => (labId, group.map(_.endTimestamp).max)
-    }.innerJoin(userValidations).on { case (x, y) => x._1 === y.labelId && x._2 === y.endTimestamp }
-      .map(x => (x._2.labelId, x._2.validationResult))
+    }.innerJoin(userValidations).on {
+      case (recentVal, userVal) => recentVal._1 === userVal.labelId && recentVal._2 === userVal.endTimestamp
+    }.map(x => (x._2.labelId, x._2.validationResult))
   }
 
   /**

--- a/app/models/label/LabelValidationTable.scala
+++ b/app/models/label/LabelValidationTable.scala
@@ -76,6 +76,7 @@ object LabelValidationTable {
   val labels = TableQuery[LabelTable]
   val labelsWithoutDeleted = labels.filter(_.deleted === false)
 
+  val validationOptions: Map[Int, String] = Map(1 -> "Agree", 2 -> "Disagree", 3 -> "NotSure")
 
   /**
     * Returns how many agree, disagree, or unsure validations a user entered for a given mission.

--- a/public/javascripts/Gallery/css/cards.css
+++ b/public/javascripts/Gallery/css/cards.css
@@ -92,7 +92,7 @@ with respect to the image holder. This allows the validation menu to be placed o
     border-bottom-left-radius: 20px;
     border-bottom-right-radius: 20px;
 }
-.card-info:hover {
+.gallery-card:hover > .card-info {
     border-width: 0; /* Using a drop shadow on hover, and we don't need both the border and shadow. */
 }
 

--- a/public/javascripts/Gallery/src/cards/Card.js
+++ b/public/javascripts/Gallery/src/cards/Card.js
@@ -36,6 +36,7 @@ function Card (params, imageUrl) {
         severity: undefined,
         temporary: undefined,
         description: undefined,
+        user_validation: undefined,
         tags: []
     };
 

--- a/public/javascripts/Gallery/src/validation/ValidationMenu.js
+++ b/public/javascripts/Gallery/src/validation/ValidationMenu.js
@@ -14,10 +14,15 @@ function ValidationMenu(uiCardImage, cardProperties) {
     };
 
     // A kind of wack way to do this, explore better options.
-    const classToResult = {
+    const classToValidationOption = {
         "validate-agree": "Agree",
         "validate-disagree": "Disagree",
         "validate-not-sure": "NotSure"
+    };
+    const validationOptionToClass = {
+        "Agree": "validate-agree",
+        "Disagree": "validate-disagree",
+        "NotSure": "validate-not-sure"
     };
 
     let currSelected = null;
@@ -29,7 +34,6 @@ function ValidationMenu(uiCardImage, cardProperties) {
             <button id="gallery-card-not-sure-button" class="validation-button">${i18next.t('gallery:not-sure')}</button>
         </div>
     `;
-
     let overlay = $(overlayHTML);
 
     let validationButtons = {
@@ -45,21 +49,34 @@ function ValidationMenu(uiCardImage, cardProperties) {
     function _init() {
         for (const [valKey, button] of Object.entries(validationButtons)) {
             button.click(function() {
-                if (currSelected) {
-                    validationButtons[currSelected].attr('class', 'validation-button');
-                    if (galleryCard.classList.contains(currSelected)) {
-                        galleryCard.classList.remove(currSelected);
-                    }
-                }
-
-                currSelected = valKey;
-                button.attr('class', 'validation-button-selected');
-                galleryCard.classList.add(valKey);
-
-                validateLabel(classToResult[valKey]);
-            })
+                _showValidated(classToValidationOption[valKey]);
+                validateLabel(classToValidationOption[valKey]);
+            });
         }
+        // If the signed in user had already validated this label before loading the page, style the card to show that.
+        if (cardProperties.user_validation) {
+            _showValidated(cardProperties.user_validation);
+        }
+
         uiCardImage.append(overlay[0]);
+    }
+
+    // Sets the look of the card to show that the label has been validated.
+    function _showValidated(validationOption) {
+        const validationClass = validationOptionToClass[validationOption];
+
+        // If the label had already been validated differently, remove the visual effects from the older validation.
+        if (currSelected && currSelected !== validationClass) {
+            validationButtons[currSelected].attr('class', 'validation-button');
+            if (galleryCard.classList.contains(currSelected)) {
+                galleryCard.classList.remove(currSelected);
+            }
+        }
+
+        // Add the visual effects from the new validation.
+        currSelected = validationClass;
+        validationButtons[validationClass].attr('class', 'validation-button-selected');
+        galleryCard.classList.add(validationClass);
     }
 
     /**


### PR DESCRIPTION
Resolves #2603 

If you are signed in, validations that you had made in the past now show up on Gallery when it loads. This incorporates your validations from /validate, /labelMap, /gallery, or through the admin page!

##### Before/After screenshots (if applicable)
Before (on initial page load)
![Screenshot from 2021-06-30 17-04-40](https://user-images.githubusercontent.com/6518824/124046084-f826a900-d9c5-11eb-837d-c81c60a94dc3.png)

After (on initial page load)
![Screenshot from 2021-06-30 17-04-51](https://user-images.githubusercontent.com/6518824/124046089-fa890300-d9c5-11eb-9246-334fc3b21247.png)

##### Testing instructions
1. Visit Gallery
2. Filter for a specific label type, severity, and/or tag. Drill down however far you need to so that there are only a small number of labels, which will make it easier to test.
3. Validate a bunch of those labels in Gallery
4. Reload Gallery and add the same filters. You should see your previous validations showing up!

Testing that contributions through /validate or /labelMap are a lot easier on a smaller database, since there will be fewer non-validated labels to sift through.

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
