### PR TITLE
Previous user validations now show up on LabelMap and admin pages

### DIFF
--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -361,7 +361,8 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
     if (isAdmin(request.identity)) {
       LabelPointTable.find(labelId) match {
         case Some(labelPointObj) =>
-          val labelMetadata: LabelMetadataWithValidation = LabelTable.getLabelMetadata(labelId)
+          val userId: String = request.identity.get.userId.toString
+          val labelMetadata: LabelMetadataWithValidation = LabelTable.getLabelMetadata(labelId, userId)
           val labelMetadataJson: JsObject = LabelTable.labelMetadataWithValidationToJsonAdmin(labelMetadata)
           Future.successful(Ok(labelMetadataJson))
         case _ => Future.successful(Ok(Json.obj("error" -> "no such label")))
@@ -377,7 +378,8 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
   def getLabelData(labelId: Int) = UserAwareAction.async { implicit request =>
     LabelPointTable.find(labelId) match {
       case Some(labelPointObj) =>
-        val labelMetadata: LabelMetadataWithValidation = LabelTable.getLabelMetadata(labelId)
+        val userId: String = request.identity.map(_.userId.toString).getOrElse("")
+        val labelMetadata: LabelMetadataWithValidation = LabelTable.getLabelMetadata(labelId, userId)
         val labelMetadataJson: JsObject = LabelTable.labelMetadataWithValidationToJson(labelMetadata)
         Future.successful(Ok(labelMetadataJson))
       case _ => Future.successful(Ok(Json.obj("error" -> "no such label")))

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -695,7 +695,7 @@
                                 </thead>
                                 <!-- using this id to locate the labelTags so we can insert the tags-->
                                 <tbody id = 'labelRows'>
-                                    @LabelTable.getRecentLabelMetadataWithValidations(5000).map { label =>
+                                    @LabelTable.getRecentLabelMetadataWithValidations(5000, user.get.userId.toString).map { label =>
                                         <tr>
                                             <td><a href='@routes.AdminController.userProfile(label.username)'>@label.username</a>
                                             </td>

--- a/app/views/admin/user.scala.html
+++ b/app/views/admin/user.scala.html
@@ -90,7 +90,7 @@
                     </tr>
                     </thead>
                     <tbody>
-                    @LabelTable.getRecentLabelMetadata(1000, UUID.fromString(user.get.userId)).map { userLabel =>
+                    @LabelTable.getRecentLabelMetadata(1000, user.get.userId).map { userLabel =>
                         <tr>
                             <td class = 'timestamp'>@userLabel.timestamp</td>
                             <td>@userLabel.labelTypeKey</td>

--- a/public/javascripts/Admin/src/Admin.GSVLabelView.js
+++ b/public/javascripts/Admin/src/Admin.GSVLabelView.js
@@ -326,6 +326,8 @@ function AdminGSVLabelView(admin) {
                 labelMetadata['audit_task_id']+"</a> by <a href='/admin/user/" + encodeURI(labelMetadata['username']) + "'>" +
                 labelMetadata['username'] + "</a>");
         }
+        // If the signed in user has already validated this label, make the button look like it has been clicked.
+        if (labelMetadata['user_validation']) _resetButtonColors(labelMetadata['user_validation']);
     }
 
     _init();


### PR DESCRIPTION
Resolves #2626 

The agree/disagree/unsure buttons on the popup on LabelMap now appear to have been clicked if you've already validated this label with your currently logged in account. Validations you've contributed through any means count (validation page, gallery, labelmap, or admin page). We use the same popup in numerous places on the admin dashboard as well, and these changes work in all of those places.

##### Before/After screenshots (if applicable)
Before (right after a page load, showing a label that I've already validated)
![Screenshot from 2021-07-02 15-42-54](https://user-images.githubusercontent.com/6518824/124334516-3057f400-db4c-11eb-85fc-38dbd952de14.png)

After (same situation)
![Screenshot from 2021-07-02 15-26-59](https://user-images.githubusercontent.com/6518824/124334521-3221b780-db4c-11eb-82ca-e4ca021a39a8.png)

##### Testing instructions
1. Go to /labelMap and add a label
2. Refresh the page and click on the same label. The same button should look like it has been pressed!
3. Can be repeated for /admin/user/\<username\>. Can also be repeated in the Map, Contributions, and Label Search tabs on the /admin page.

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
