### PR TITLE
2602 Allow the use of modal arrows to navigate between pages.

### DIFF
--- a/public/javascripts/Gallery/src/cards/CardContainer.js
+++ b/public/javascripts/Gallery/src/cards/CardContainer.js
@@ -278,23 +278,25 @@ function CardContainer(uiCardContainer) {
         currentCards.filterOnTags(appliedTags);
         currentCards.filterOnSeverities(appliedSeverities);
 
-        if (currentCards.getSize() < cardsPerPage * currentPage) {
+        if (currentCards.getSize() < cardsPerPage * currentPage + 1) {
             // When we don't have enough cards of specific query to show on one page, see if more can be grabbed.
             if (currentLabelType === "Occlusion") {
-                fetchLabelsByType(labelTypeIds[currentLabelType], cardsPerPage, Array.from(loadedLabelIds), function () {
+                fetchLabelsByType(labelTypeIds[currentLabelType], cardsPerPage * 2, Array.from(loadedLabelIds), function () {
                     currentCards = cardsByType[currentLabelType].copy();
+                    lastPage = currentCards.getCards().length <= currentPage * cardsPerPage;
                     render();
                 });
             } else {
-                fetchLabelsBySeverityAndTags(labelTypeIds[currentLabelType], cardsPerPage, Array.from(loadedLabelIds), appliedSeverities, appliedTags, function() {
+                fetchLabelsBySeverityAndTags(labelTypeIds[currentLabelType], cardsPerPage * 2, Array.from(loadedLabelIds), appliedSeverities, appliedTags, function() {
                     currentCards = cardsByType[currentLabelType].copy();
                     currentCards.filterOnTags(appliedTags);
                     currentCards.filterOnSeverities(appliedSeverities);
-
+                    lastPage = currentCards.getCards().length <= currentPage * cardsPerPage;
                     render();
                 });
             }
         } else {
+            lastPage = false;
             render();
         }
     }
@@ -337,7 +339,12 @@ function CardContainer(uiCardContainer) {
         let imagePromises = imagesToLoad.map(img => img.loadImage());
 
         if (imagesToLoad.length > 0) {
-            if (imagesToLoad.length < cardsPerPage) {
+            // if (imagesToLoad.length < cardsPerPage) {
+            //     sg.ui.cardContainer.nextPage.prop("disabled", true);
+            // } else {
+            //     sg.ui.cardContainer.nextPage.prop("disabled", false);
+            // }
+            if (lastPage) {
                 sg.ui.cardContainer.nextPage.prop("disabled", true);
             } else {
                 sg.ui.cardContainer.nextPage.prop("disabled", false);
@@ -436,9 +443,18 @@ function CardContainer(uiCardContainer) {
         return currentPageCards;
     }
 
+    /**
+     * Returns whether the current page is the last page of queried cards.
+     * @returns True if current page is last page of cards that satisfies applied query, false otherwise.
+     */
+    function isLastPage() {
+        return lastPage;
+    }
+
     self.fetchLabelsByType = fetchLabelsByType;
     self.getCards = getCards;
     self.getCurrentCards = getCurrentCards;
+    self.isLastPage = isLastPage;
     self.push = push;
     self.updateCardsByType = updateCardsByType;
     self.updateCardsByTagsAndSeverity = updateCardsByTagsAndSeverity;

--- a/public/javascripts/Gallery/src/cards/CardContainer.js
+++ b/public/javascripts/Gallery/src/cards/CardContainer.js
@@ -93,7 +93,6 @@ function CardContainer(uiCardContainer) {
             // Otherwise, the user will have clicked on an existing "+n" icon on the card, meaning we need to acquire
             // the cardId from the card-tags DOM element (as well as perform an additional prepend to put the ID in
             // the correct form).
-            // TODO(micdun): this is pretty janky, think of better way?
             let clickedImage = event.target.classList.contains("static-gallery-image")
             let cardId = clickedImage ? event.target.id :
                                         "label_id_" + event.target.closest(".card-tags").id;
@@ -273,8 +272,6 @@ function CardContainer(uiCardContainer) {
      * Updates Cards being shown when user moves to next/previous page.
      */
     function updateCardsNewPage() {
-        // TODO: lots of repeated code among this method and updateCardsByTag and updateCardsBySeverity.
-        // Think about improving code design.
         refreshUI();
 
         let appliedTags = sg.tagContainer.getAppliedTagNames();
@@ -345,11 +342,6 @@ function CardContainer(uiCardContainer) {
         let imagePromises = imagesToLoad.map(img => img.loadImage());
 
         if (imagesToLoad.length > 0) {
-            // if (imagesToLoad.length < cardsPerPage) {
-            //     sg.ui.cardContainer.nextPage.prop("disabled", true);
-            // } else {
-            //     sg.ui.cardContainer.nextPage.prop("disabled", false);
-            // }
             if (lastPage) {
                 sg.ui.cardContainer.nextPage.prop("disabled", true);
             } else {

--- a/public/javascripts/Gallery/src/cards/CardContainer.js
+++ b/public/javascripts/Gallery/src/cards/CardContainer.js
@@ -86,7 +86,7 @@ function CardContainer(uiCardContainer) {
         // Creates the Modal object in the DOM element currently present.
         modal = new Modal($('.gallery-modal'));
         // Add the click event for opening the Modal when a card is clicked.
-        $("#image-card-container").on('click', '.static-gallery-image',  (event) => {
+        sg.ui.cardContainer.holder.on('click', '.static-gallery-image',  (event) => {
             $('.gallery-modal').attr('style', 'display: flex');
             $('.grid-container').css("grid-template-columns", "1fr 2fr 3fr");
             const cardId = event.target.id;
@@ -373,6 +373,7 @@ function CardContainer(uiCardContainer) {
      */
     function refreshUI() {
         modal.closeModal();
+        window.scrollTo(0, 0);
         sg.tagContainer.disable();
         $("#label-select").prop("disabled", true);
         $("#labels-not-found").hide();

--- a/public/javascripts/Gallery/src/filter/Severity.js
+++ b/public/javascripts/Gallery/src/filter/Severity.js
@@ -49,7 +49,7 @@ function Severity (params){
             apply();
         }
 
-        sg.cardContainer.updateCardsBySeverity();
+        sg.cardContainer.updateCardsByTagsAndSeverity();
     }
 
     /**

--- a/public/javascripts/Gallery/src/filter/Tag.js
+++ b/public/javascripts/Gallery/src/filter/Tag.js
@@ -58,7 +58,7 @@ function Tag (params) {
             apply();
         }
 
-        sg.cardContainer.updateCardsByTag();
+        sg.cardContainer.updateCardsByTagsAndSeverity();
     }
 
     /**

--- a/public/javascripts/Gallery/src/modal/Modal.js
+++ b/public/javascripts/Gallery/src/modal/Modal.js
@@ -153,9 +153,12 @@ function Modal(uiModal) {
     }
 
     function highlightThumbnail(galleryCard) {
-        // Centers the card thumbnail that was selected. If it's the last card, we shouldn't center (use "end").
+        // Centers the card thumbnail that was selected. If it's the last card, we scroll such that the card is at the
+        // bottom of the visible window.
+        let index = self.cardIndex;
+        let page = sg.cardContainer.getCurrentPage();
         galleryCard.scrollIntoView({
-            block: 'center',
+            block: (index < page * cardsPerPage - 1) ? 'center' : 'end',
             behavior: 'smooth'
         });
 
@@ -210,19 +213,20 @@ function Modal(uiModal) {
      */
     function updateModalCardByIndex(index) {
         self.cardIndex = index;
+        console.log(self.cardIndex);
         updateProperties(sg.cardContainer.getCardByIndex(index).getProperties());
         openModal();
         let page = sg.cardContainer.getCurrentPage();
-        if (index > (page - 1) * cardsPerPage) {
-            self.leftArrow.prop('disabled', false);
-        } else {
-            self.leftArrow.prop('disabled', true);
-        }
-        if (index < page * cardsPerPage - 1) {
-            self.rightArrow.prop('disabled', false);
-        } else {
-            self.rightArrow.prop('disabled', true);
-        }
+        // if (index > (page - 1) * cardsPerPage) {
+        //     self.leftArrow.prop('disabled', false);
+        // } else {
+        //     self.leftArrow.prop('disabled', true);
+        // }
+        // if (index < page * cardsPerPage - 1) {
+        //     self.rightArrow.prop('disabled', false);
+        // } else {
+        //     self.rightArrow.prop('disabled', true);
+        // }
     }
 
     /**
@@ -231,7 +235,13 @@ function Modal(uiModal) {
     function nextLabel() {
         let page = sg.cardContainer.getCurrentPage();
         if (self.cardIndex < page * cardsPerPage - 1) {
+            // Iterate to next card on the page, updating the label being shown in the modal to be
+            // that of the next card.
             updateModalCardByIndex(self.cardIndex + 1);
+        } else {
+            // TODO: We probably want to put a confirmation here whenever we switch pages.
+            // Move to the next page as the current card is the last on the page.
+            sg.ui.cardContainer.nextPage.click();
         }
     }
 
@@ -241,7 +251,12 @@ function Modal(uiModal) {
     function previousLabel() {
         let page = sg.cardContainer.getCurrentPage();
         if (self.cardIndex > (page - 1) * cardsPerPage) {
+            // Iterate to previous card on the page, updating the label being shown in the modal to be
+            // that of the previous card.
             updateModalCardByIndex(self.cardIndex - 1);
+        } else {
+            // Move to the previous page as the current card is the first on the page.
+            sg.ui.cardContainer.prevPage.click();
         }
     }
 

--- a/public/javascripts/Gallery/src/modal/Modal.js
+++ b/public/javascripts/Gallery/src/modal/Modal.js
@@ -22,8 +22,6 @@ function Modal(uiModal) {
                 // We check to make sure that the mutation effects the childList (adding/removing child nodes) of the
                 // card container and that cards (child nodes) were added in the mutation, indicating the cards have
                 // been rendered.
-                console.log('CHild node added: Cards have been rendered');
-                console.log("reopening modal");
                 $('.gallery-modal').attr('style', 'display: flex');
                 $('.grid-container').css("grid-template-columns", "1fr 2fr 3fr");
     
@@ -239,7 +237,6 @@ function Modal(uiModal) {
         self.leftArrow.prop('disabled', false);
         self.rightArrow.prop('disabled', false);
         self.cardIndex = index;
-        console.log(self.cardIndex);
         updateProperties(sg.cardContainer.getCardByIndex(index).getProperties());
         openModal();
         if (self.cardIndex == 0) {
@@ -254,16 +251,6 @@ function Modal(uiModal) {
                 self.rightArrow.prop('disabled', true);
             }
         }
-        // if (index > (page - 1) * cardsPerPage) {
-        //     self.leftArrow.prop('disabled', false);
-        // } else {
-        //     self.leftArrow.prop('disabled', true);
-        // }
-        // if (index < page * cardsPerPage - 1) {
-        //     self.rightArrow.prop('disabled', false);
-        // } else {
-        //     self.rightArrow.prop('disabled', true);
-        // }
     }
 
     /**
@@ -279,18 +266,14 @@ function Modal(uiModal) {
             // Increment cardIndex now as the observer is ignorant of whether the prev or next arrow was clicked.
             self.cardIndex += 1;
 
-            // TODO: We probably want to put a confirmation here whenever we switch pages.
             // Move to the next page as the current card is the last on the page.
             sg.ui.cardContainer.nextPage.click();
 
             // The target we will observe.
             let cardHolder = sg.ui.cardContainer.holder[0];
-            console.log(cardHolder.id);
                         
             // Options for the observer.
             let config = {childList: true};
-
-            console.log("observing");
 
             // Start observing the target node for configured mutations
             observer.observe(cardHolder, config);
@@ -315,12 +298,9 @@ function Modal(uiModal) {
 
             // The target we will observe.
             let cardHolder = sg.ui.cardContainer.holder[0];
-            console.log(cardHolder.id);
                         
             // Options for the observer.
             let config = {childList: true};
-
-            console.log("observing");
 
             // Start observing the target node for configured mutations
             observer.observe(cardHolder, config);

--- a/public/javascripts/Gallery/src/modal/Modal.js
+++ b/public/javascripts/Gallery/src/modal/Modal.js
@@ -17,7 +17,7 @@ function Modal(uiModal) {
     // We need this because the prev/next page actions are asynchronous (they query the backend), so before reopening
     // the modal on a new page, we need to make sure the cards have actually been rendered in gallery view.
     const observer = new MutationObserver((mutationsList, observer) => {
-        for(let mutation of mutationsList) {
+        for (let mutation of mutationsList) {
             if (mutation.type === 'childList' && mutation.addedNodes.length > 0) {
                 // We check to make sure that the mutation effects the childList (adding/removing child nodes) of the
                 // card container and that cards (child nodes) were added in the mutation, indicating the cards have
@@ -239,14 +239,14 @@ function Modal(uiModal) {
         self.cardIndex = index;
         updateProperties(sg.cardContainer.getCardByIndex(index).getProperties());
         openModal();
-        if (self.cardIndex == 0) {
+        if (self.cardIndex === 0) {
             self.leftArrow.prop('disabled', true);
         }
 
         if (sg.cardContainer.isLastPage()) {
             let page = sg.cardContainer.getCurrentPage();
             let lastCardIndex = (page - 1) * cardsPerPage + sg.cardContainer.getCurrentPageCards().length - 1;
-            if (self.cardIndex == lastCardIndex) {
+            if (self.cardIndex === lastCardIndex) {
                 // The current page is the last page and the current card being rendered is the last card on the page.
                 self.rightArrow.prop('disabled', true);
             }
@@ -257,9 +257,10 @@ function Modal(uiModal) {
      * Moves to the next label.
      */
     function nextLabel() {
+        console.log('next label');
         let page = sg.cardContainer.getCurrentPage();
         if (self.cardIndex < page * cardsPerPage - 1) {
-            // Iterate to next card on the page, updating the label being shown in the modal to be
+            // Iterate to next card on the page, updating the label being shown in the expanded view to be
             // that of the next card.
             updateModalCardByIndex(self.cardIndex + 1);
         } else {
@@ -271,12 +272,9 @@ function Modal(uiModal) {
 
             // The target we will observe.
             let cardHolder = sg.ui.cardContainer.holder[0];
-                        
-            // Options for the observer.
-            let config = {childList: true};
 
-            // Start observing the target node for configured mutations
-            observer.observe(cardHolder, config);
+            // Start observing the target node for configured mutations.
+            observer.observe(cardHolder, { childList: true });
         }
     }
 
@@ -298,12 +296,9 @@ function Modal(uiModal) {
 
             // The target we will observe.
             let cardHolder = sg.ui.cardContainer.holder[0];
-                        
-            // Options for the observer.
-            let config = {childList: true};
 
-            // Start observing the target node for configured mutations
-            observer.observe(cardHolder, config);
+            // Start observing the target node for configured mutations.
+            observer.observe(cardHolder, { childList: true });
         }
     }
 

--- a/public/javascripts/Gallery/src/modal/Modal.js
+++ b/public/javascripts/Gallery/src/modal/Modal.js
@@ -212,11 +212,24 @@ function Modal(uiModal) {
      * @param {Number} index The index of the card to update to
      */
     function updateModalCardByIndex(index) {
+        self.leftArrow.prop('disabled', false);
+        self.rightArrow.prop('disabled', false);
         self.cardIndex = index;
         console.log(self.cardIndex);
         updateProperties(sg.cardContainer.getCardByIndex(index).getProperties());
         openModal();
-        let page = sg.cardContainer.getCurrentPage();
+        if (self.cardIndex == 0) {
+            self.leftArrow.prop('disabled', true);
+        }
+
+        if (sg.cardContainer.isLastPage()) {
+            let page = sg.cardContainer.getCurrentPage();
+            let lastCardIndex = (page - 1) * cardsPerPage + sg.cardContainer.getCurrentPageCards().length - 1;
+            if (self.cardIndex == lastCardIndex) {
+                // The current page is the last page and the current card being rendered is the last card on the page.
+                self.rightArrow.prop('disabled', true);
+            }
+        }
         // if (index > (page - 1) * cardsPerPage) {
         //     self.leftArrow.prop('disabled', false);
         // } else {


### PR DESCRIPTION
Resolves #2602

This PR aims to allow users to be able to iterate through gallery pages while remaining in modal view through the use of the modal arrows.

