### PR TITLE
Removes other/occlusion from Gallery All category

### DIFF
--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -865,7 +865,7 @@ object LabelTable {
     // Grab labels and associated information if severity and tags satisfy query conditions.
     val _labelsUnfiltered = for {
       _lb <- labelsWithoutDeletedOrOnboarding if !(_lb.labelId inSet deprioritized)
-      _lt <- labelTypes if _lb.labelTypeId === _lt.labelTypeId
+      _lt <- labelTypes if _lb.labelTypeId === _lt.labelTypeId && (_lt.labelTypeId inSet LabelTypeTable.primaryLabelTypeIds)
       _lp <- labelPoints if _lb.labelId === _lp.labelId
       _a <- auditTasks if _lb.auditTaskId === _a.auditTaskId && _a.streetEdgeId =!= tutorialStreetId
       if _lb.streetEdgeId =!= tutorialStreetId
@@ -913,7 +913,7 @@ object LabelTable {
     // Randomize and convert to LabelValidationMetadataWithoutTags.
     val newRandomLabelsList = addValidations.sortBy(x => rand).list.map(LabelValidationMetadataWithoutTags.tupled)
 
-    val labelTypesAsStrings = LabelTypeTable.validLabelTypes
+    val labelTypesAsStrings = LabelTypeTable.primaryLabelTypes
 
     for (labelType <- labelTypesAsStrings) {
       val labelsFilteredByType = newRandomLabelsList.filter(label => label.labelType == labelType)

--- a/app/models/label/LabelTypeTable.scala
+++ b/app/models/label/LabelTypeTable.scala
@@ -20,16 +20,22 @@ object LabelTypeTable {
   val db = play.api.db.slick.DB
   val labelTypes = TableQuery[LabelTypeTable]
 
-  /**
-    * Set of valid label types to display
-    */
+  // Set of valid/primary label types.
   def validLabelTypes: Set[String] = Set("CurbRamp", "NoCurbRamp", "Obstacle", "SurfaceProblem", "Other", "Occlusion", "NoSidewalk")
+  def primaryLabelTypes: Set[String] = Set("CurbRamp", "NoCurbRamp", "Obstacle", "SurfaceProblem", "NoSidewalk")
 
   /**
-    * Set of valid label type ids for the above valid label types
-    */
-  def validLabelTypeIds: Set[Int] = db.withTransaction { implicit session => 
+   * Set of valid label type ids for the above valid label types.
+   */
+  def validLabelTypeIds: Set[Int] = db.withTransaction { implicit session =>
     labelTypes.filter(_.labelType inSet validLabelTypes).map(_.labelTypeId).list.toSet
+  }
+
+  /**
+   * Set of primary label type ids for the above valid label types.
+   */
+  def primaryLabelTypeIds: Set[Int] = db.withTransaction { implicit session =>
+    labelTypes.filter(_.labelType inSet primaryLabelTypes).map(_.labelTypeId).list.toSet
   }
 
   /**

--- a/public/javascripts/Gallery/src/cards/CardContainer.js
+++ b/public/javascripts/Gallery/src/cards/CardContainer.js
@@ -29,7 +29,7 @@ function CardContainer(uiCardContainer) {
         Other: 5,
         Occlusion: 6,
         NoSidewalk: 7,
-        Assorted: 9
+        Assorted: -1
     };
 
     // Current label type of cards being shown.

--- a/public/javascripts/Gallery/src/filter/Tag.js
+++ b/public/javascripts/Gallery/src/filter/Tag.js
@@ -66,7 +66,6 @@ function Tag (params) {
      */
     function apply() {
         setStatus("applied", true);
-        console.log("clicked and toggled on");
         tagElement.setAttribute("style", "background-color: #78c8aa");
     }
 
@@ -75,7 +74,6 @@ function Tag (params) {
      */
     function unapply() {
         setStatus("applied", false);
-        console.log("clicked and toggled off");
         tagElement.setAttribute("style", "background-color: none");
     }
 


### PR DESCRIPTION
Resolves #2617 
Partially #2639 

Removes Other and Can't See the Sidewalk from the All category in Gallery, while leaving it available in the label type drop down.

##### Before/After screenshots (if applicable)
Before
![Screenshot from 2021-07-30 17-15-32](https://user-images.githubusercontent.com/6518824/127722636-b9d6e42f-e349-4a51-9447-c2c86f1c1097.png)

After
![Screenshot from 2021-07-30 17-14-27](https://user-images.githubusercontent.com/6518824/127722641-e280ac23-0041-4aee-a0f5-b9a77cbca8cb.png)

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
