### PR TITLE
Adds border to interactive GSV in Gallery when label is validated

### DIFF
--- a/public/javascripts/Gallery/css/modal.css
+++ b/public/javascripts/Gallery/css/modal.css
@@ -54,6 +54,7 @@
 
 .actual-pano {
     border: 6px solid transparent;
+    border-radius: 5px;
     background-color: transparent;
 }
 
@@ -84,7 +85,7 @@
     display: flex;
     height: 20%;
     /* Full width of modal minus 50px for prev arrow and 50px for next arrow, plus a few extra for the pano border. */
-    width: calc(100% - 104px);
+    width: calc(100% - 105px);
     flex-wrap: wrap;
     font-size: 1vw;
 }
@@ -147,21 +148,10 @@
     align-content: space-between;
     margin-bottom: 5px;
     /* Full width of modal minus 50px for prev arrow and 50px for next arrow, plus a few extra for the pano border. */
-    width: calc(100% - 104px);
+    width: calc(100% - 105px);
 }
 
 .modal-severity-circle {
-    /* color: black;
-    border: 1px solid black;
-    padding: 1px 0px; /* Quite a hacky fix in order to center numbers correctly, reassess */
-    /* width: 1.5vw;
-    height: 1.5vw;
-    border-radius: 50%;
-    text-align: center;
-    line-height: 100%;
-    margin: 2px;
-    background-color: white;
-    font-size: 1vw; */
     width: 1.75vw;
     height: 1.75vw;
 }

--- a/public/javascripts/Gallery/css/modal.css
+++ b/public/javascripts/Gallery/css/modal.css
@@ -37,7 +37,6 @@
     width: 100%;
     height: 100%;
     margin-top: 15px;
-    margin-bottom: 15px;
     font-family: 'raleway-bold', sans-serif;
     font-size: 1.5vw;
     color: #2d2a3f;
@@ -50,7 +49,12 @@
     flex-direction: row;
     align-items: center;
     justify-content: center;
-    margin-bottom: 3.5%;
+    margin-bottom: 4.75%;
+}
+
+.actual-pano {
+    border: 6px solid transparent;
+    background-color: transparent;
 }
 
 .gallery-modal-pano-display {
@@ -79,7 +83,8 @@
 .gallery-modal-info {
     display: flex;
     height: 20%;
-    width: calc(100% - 100px); /* Full width of modal minus 50px for prev arrow and 50px for next arrow. */
+    /* Full width of modal minus 50px for prev arrow and 50px for next arrow, plus a few extra for the pano border. */
+    width: calc(100% - 104px);
     flex-wrap: wrap;
     font-size: 1vw;
 }
@@ -140,7 +145,9 @@
 .modal-top-holder {
     display: flex;
     align-content: space-between;
-    width: calc(100% - 100px); /* Full width of modal minus 50px for prev arrow and 50px for next arrow. */
+    margin-bottom: 5px;
+    /* Full width of modal minus 50px for prev arrow and 50px for next arrow, plus a few extra for the pano border. */
+    width: calc(100% - 104px);
 }
 
 .modal-severity-circle {

--- a/public/javascripts/Gallery/src/cards/Card.js
+++ b/public/javascripts/Gallery/src/cards/Card.js
@@ -2,21 +2,18 @@
  * A Card module.
  * @param params properties of the associated label.
  * @param imageUrl google maps static image url for label.
+ * @param modal Modal object; used to update the expanded view when modifying a card.
  * @returns {Card}
  * @constructor
  */
-function Card (params, imageUrl) {
+function Card (params, imageUrl, modal) {
     let self = this;
 
     // UI card element.
     let card = null;
 
-    // Validation menu tied to label.
     let validationMenu = null;
-
-    // The width-height ratio for the card
     let widthHeightRatio = (4/3);
-
     let imageId = null;
 
     // Properties of the label in the card.
@@ -135,8 +132,7 @@ function Card (params, imageUrl) {
         imageHolder.appendChild(labelIcon);
         imageHolder.appendChild(panoImage);
         card.appendChild(cardInfo);
-        validationMenu = new ValidationMenu(imageHolder, properties, false);
-        validationMenu.updateReferenceCard(self);
+        validationMenu = new ValidationMenu(self, imageHolder, properties, modal, false);
     }
 
     /**

--- a/public/javascripts/Gallery/src/cards/CardContainer.js
+++ b/public/javascripts/Gallery/src/cards/CardContainer.js
@@ -179,7 +179,7 @@ function CardContainer(uiCardContainer) {
                 for (; i < len; i++) {
                     let labelProp = labels[i];
                     if ("label" in labelProp && "imageUrl" in labelProp) {
-                        card = new Card(labelProp.label, labelProp.imageUrl);
+                        card = new Card(labelProp.label, labelProp.imageUrl, modal);
                         self.push(card);
                         loadedLabelIds.add(card.getLabelId());
                     }
@@ -210,7 +210,7 @@ function CardContainer(uiCardContainer) {
                 for (; i < len; i++) {
                     let labelProp = labels[i];
                     if ("label" in labelProp && "imageUrl" in labelProp) {
-                        card = new Card(labelProp.label, labelProp.imageUrl);
+                        card = new Card(labelProp.label, labelProp.imageUrl, modal);
                         self.push(card);
                         loadedLabelIds.add(card.getLabelId());
                     }

--- a/public/javascripts/Gallery/src/modal/Modal.js
+++ b/public/javascripts/Gallery/src/modal/Modal.js
@@ -76,7 +76,7 @@ function Modal(uiModal) {
         self.rightArrow.click(nextLabel)
         self.leftArrow.click(previousLabel)
         self.cardIndex = -1;
-        self.validationMenu = new ValidationMenu(self.panoHolder, null, true)
+        self.validationMenu = new ValidationMenu(null, self.panoHolder, null, self, true)
     }
 
     /**
@@ -224,6 +224,10 @@ function Modal(uiModal) {
         self.validationMenu.updateReferenceCard(sg.cardContainer.getCardByIndex(self.cardIndex));
     }
 
+    function getProperty(key) {
+        return properties[key];
+    }
+
     /**
      * Updates the index of the current label being displayed in the modal.
      * 
@@ -310,6 +314,7 @@ function Modal(uiModal) {
 
     self.closeModal = closeModal;
     self.updateCardIndex = updateCardIndex;
+    self.getProperty = getProperty;
 
     return self;
 }

--- a/public/javascripts/Gallery/src/validation/ValidationMenu.js
+++ b/public/javascripts/Gallery/src/validation/ValidationMenu.js
@@ -101,6 +101,11 @@ function ValidationMenu(refCard, uiCardImage, cardProperties, modal, onExpandedV
         uiCardImage.append(overlay[0]);
     }
 
+    /**
+     * Adds the visual effects of validation to the small card (opaque button and fill color below image).
+     *
+     * @param validationOption
+     */
     function showValidationOnCard(validationOption) {
         const validationClass = validationOptionToClass[validationOption];
 
@@ -118,6 +123,12 @@ function ValidationMenu(refCard, uiCardImage, cardProperties, modal, onExpandedV
         validationButtons[validationClass].attr('class', 'validation-button-selected');
     }
 
+
+    /**
+     * Adds the visual effects of validation to the expanded view (opaque button and border color around GSV).
+     *
+     * @param validationOption
+     */
     function showValidationOnExpandedView(validationOption) {
         const validationClass = validationOptionToClass[validationOption];
 

--- a/public/javascripts/Gallery/src/validation/ValidationMenu.js
+++ b/public/javascripts/Gallery/src/validation/ValidationMenu.js
@@ -18,7 +18,6 @@ function ValidationMenu(uiCardImage, cardProperties, onExpandedView) {
     let self = this;
 
     let currentCardProperties = cardProperties;
-
     let referenceCard = null;
 
     // A kind of wack way to do this, explore better options.
@@ -31,6 +30,11 @@ function ValidationMenu(uiCardImage, cardProperties, onExpandedView) {
         "Agree": "validate-agree",
         "Disagree": "validate-disagree",
         "NotSure": "validate-not-sure"
+    };
+    const validationOptionToColor = {
+        'Agree': '#78c9ab',
+        'Disagree': '#eb734d',
+        'NotSure': '#fbd78b'
     };
 
     let currSelected = null;
@@ -71,19 +75,19 @@ function ValidationMenu(uiCardImage, cardProperties, onExpandedView) {
 
         for (const [valKey, button] of Object.entries(validationButtons)) {
             button.click(function() {
-                _showValidated(classToValidationOption[valKey]);
+                showValidated(classToValidationOption[valKey]);
                 validateLabel(classToValidationOption[valKey]);
             });
         }
         // If the signed in user had already validated this label before loading the page, style the card to show that.
         if (currentCardProperties !== null && currentCardProperties.user_validation) {
-            _showValidated(currentCardProperties.user_validation);
+            showValidated(currentCardProperties.user_validation);
         }
         uiCardImage.append(overlay[0]);
     }
 
     // Sets the look of the card to show that the label has been validated.
-    function _showValidated(validationOption) {
+    function showValidated(validationOption) {
         const validationClass = validationOptionToClass[validationOption];
 
         // If the label had already been validated differently, remove the visual effects from the older validation.
@@ -96,7 +100,6 @@ function ValidationMenu(uiCardImage, cardProperties, onExpandedView) {
             } else {
                 validationButtons[currSelected].attr('class', 'modal-validation-button');
             }
-           
         }
 
         // Add the visual effects from the new validation.
@@ -108,9 +111,21 @@ function ValidationMenu(uiCardImage, cardProperties, onExpandedView) {
             galleryCard.classList.add(validationClass);
             validationButtons[validationClass].attr('class', 'validation-button-selected');
         } else {
-            referenceCard.validationMenu._showValidated(validationOption);
+            referenceCard.validationMenu.showValidated(validationOption);
             validationButtons[validationClass].attr('class', 'modal-validation-button-selected');
+            uiCardImage.css('border-color', validationOptionToColor[validationOption]);
+            uiCardImage.css('background-color', validationOptionToColor[validationOption]);
         }
+    }
+
+    /**
+     * Resets the border to be transparent and the buttons to be less opaque, indicating a lack of validation.
+     * @private
+     */
+    function _removeExpandedValidationVisuals() {
+        uiCardImage.css('border-color', 'transparent');
+        uiCardImage.css('background-color', 'transparent');
+        Object.values(validationButtons).forEach(valButton => valButton.attr('class', 'modal-validation-button'));
     }
 
     /**
@@ -120,8 +135,6 @@ function ValidationMenu(uiCardImage, cardProperties, onExpandedView) {
      * @private
      */
     function validateLabel(action) {
-        console.log("validate method called");
-
         // TODO: do we need this log?
         sg.tracker.push("Validate_MenuClick=" + action);
         let validationTimestamp = new Date().getTime();
@@ -151,7 +164,6 @@ function ValidationMenu(uiCardImage, cardProperties, onExpandedView) {
             data: JSON.stringify(data),
             dataType: 'json',
             success: function (result) {
-                showConfirmation(action);
             },
             error: function (result) {
                 console.error(result);
@@ -160,17 +172,7 @@ function ValidationMenu(uiCardImage, cardProperties, onExpandedView) {
     }
 
     /**
-     * Confirm successful submit of validation.
-     * TODO: Probably want to remove for prod or show confirmation through something else.
-     * 
-     * @param {*} action Validation result.
-     */
-    function showConfirmation(action) {
-        console.log(action + ": validation submitted successfully :)");
-    }
-
-    /**
-     * Updates the card properties neccesary for validation.
+     * Updates the card properties necessary for validation.
      * @param {*} newProperties The properties to update to.
      */
     function updateCardProperties(newProperties) {
@@ -185,13 +187,15 @@ function ValidationMenu(uiCardImage, cardProperties, onExpandedView) {
     function updateReferenceCard(newCard) {
         referenceCard = newCard;
         if (currentCardProperties !== null && currentCardProperties.user_validation) {
-            _showValidated(currentCardProperties.user_validation);
+            showValidated(currentCardProperties.user_validation);
+        } else if (onExpandedView) {
+            _removeExpandedValidationVisuals();
         }
     }
 
     self.updateCardProperties = updateCardProperties;
     self.updateReferenceCard = updateReferenceCard;
-    self._showValidated = _showValidated;
+    self.showValidated = showValidated;
     _init();
     return self;
 }


### PR DESCRIPTION
Resolves #2651 

Adds a colored border to the interactive GSV area in the expanded view in Gallery that corresponds to the validation status of the label being shown. I also realized that the validation wasn't being updated on the expanded view when it was marked on the smaller card, so I had to restructure the code a bit to make that work correctly.

##### Before/After screenshots (if applicable)
Before (mouse on GSV)
![Screenshot from 2021-08-04 17-58-11](https://user-images.githubusercontent.com/6518824/128274818-44c7c5fd-058f-4a4b-b0b1-ebe0bda39d63.png)

After (mouse on GSV)
![Screenshot from 2021-08-04 17-57-21](https://user-images.githubusercontent.com/6518824/128274828-ebad5d1d-2d9f-468d-9da9-6f389e5731b4.png)

Before (mouse not on GSV)
![Screenshot from 2021-08-04 17-58-15](https://user-images.githubusercontent.com/6518824/128274840-0fdd41c2-2c79-46f0-8cbe-90eaf98346a6.png)

After (mouse not on GSV)
![Screenshot from 2021-08-04 17-57-24](https://user-images.githubusercontent.com/6518824/128274849-d80b2889-6b12-4149-84a9-075c0fce6ab2.png)

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
- [x] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure the documentation on [this wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Descriptions-of-Logged-Events) is up to date for the logs you added/updated.
