### PR TITLE
Improve look of severity smileys in Gallery sidebar

### DIFF
--- a/public/javascripts/Gallery/css/cards.css
+++ b/public/javascripts/Gallery/css/cards.css
@@ -4,7 +4,7 @@
     padding: 0px;
     margin: 0.6vw;
     border-radius: 20px;
-    width: 24vw;
+    width: 25vw;
     height: auto;
 }
 .gallery-card:hover {

--- a/public/javascripts/Gallery/css/gallery.css
+++ b/public/javascripts/Gallery/css/gallery.css
@@ -41,7 +41,7 @@
     padding-left: 10px;
     padding-top: 40px;
     min-height: calc(100vh - 610px);
-    width: 250px;
+    width: 235px;
     grid-row: 1/2;
 }
 
@@ -77,6 +77,6 @@
 .cards {
     display: flex;
     flex-flow: row wrap;
-    margin-left: 250px; /* Offset to compensate for the space taken up by the sidebar. */
+    margin-left: 235px; /* Offset to compensate for the space taken up by the sidebar. */
 }
 

--- a/public/javascripts/Gallery/css/modal.css
+++ b/public/javascripts/Gallery/css/modal.css
@@ -14,8 +14,8 @@
     box-shadow: 0 5px 15px rgba(0,0,0,0.3);
     flex-direction: column;
     align-items: center;
-    width: 50vw;
-    right:2vw;
+    width: 52vw;
+    right: 3vw;
     font-family: 'raleway-regular', sans-serif;
     font-size: 18px;
 }

--- a/public/javascripts/Gallery/css/tags.css
+++ b/public/javascripts/Gallery/css/tags.css
@@ -49,7 +49,7 @@
 #severity {
     display: flex;
     flex-direction: row;
-    margin-left: -10px;
+    margin-left: -3px;
 }
 
 .gallery-severity-image {
@@ -62,7 +62,7 @@
     flex-direction: column;
     align-items: center;
     cursor: pointer;
-    width: 40px;
+    width: 30px;
 }
 
 .gallery-severity:disabled {

--- a/public/javascripts/Gallery/src/filter/Severity.js
+++ b/public/javascripts/Gallery/src/filter/Severity.js
@@ -30,15 +30,21 @@ function Severity (params){
 
         severityElement = document.createElement('div');
         severityElement.className = 'gallery-severity';
-        severityElement.onclick = handleOnClickCallback;
 
         severityImage = document.createElement('img');
         severityImage.className = 'gallery-severity-image';
         severityImage.id = properties.severity;
         severityImage.innerText = properties.severity;
-        severityImage.src = `/assets/javascripts/SVLabel/img/misc/SmileyRating_${param}-Gray.png`;
+        _showDeselected();
 
         severityElement.appendChild(severityImage);
+
+        // Show inverted smiley face on click or hover.
+        severityElement.onclick = handleOnClickCallback;
+        $(severityElement).hover(
+            function() { _showSelected(); },
+            function() { if (!filterActive) _showDeselected(); }
+        );
     }
 
     /**
@@ -46,18 +52,22 @@ function Severity (params){
      */
     function handleOnClickCallback() {
         if (filterActive) {
-            sg.tracker.push("SeverityUnapply", null, {
-                Severity: properties.severity
-            });
+            sg.tracker.push("SeverityUnapply", null, { Severity: properties.severity });
             unapply();
         } else {
-            sg.tracker.push("SeverityApply", null, {
-                Severity: properties.severity
-            });
+            sg.tracker.push("SeverityApply", null, { Severity: properties.severity });
             apply();
         }
 
         sg.cardContainer.updateCardsByTagsAndSeverity();
+    }
+
+    function _showSelected() {
+        severityImage.src = `/assets/javascripts/SVLabel/img/misc/SmileyRating_${properties.severity}_inverted.png`;
+    }
+
+    function _showDeselected() {
+        severityImage.src = `/assets/javascripts/SVLabel/img/misc/SmileyRating_${properties.severity}-Gray.png`;
     }
 
     /**
@@ -66,7 +76,7 @@ function Severity (params){
     function apply() {
         if (interactionEnabled) {
             filterActive = true;
-            severityImage.src = `/assets/javascripts/SVLabel/img/misc/SmileyRating_${properties.severity}_inverted.png`;
+            _showSelected();
         }
     }
 
@@ -76,7 +86,7 @@ function Severity (params){
     function unapply() {
         if (interactionEnabled) {
             filterActive = false;
-            severityImage.src = `/assets/javascripts/SVLabel/img/misc/SmileyRating_${properties.severity}-Gray.png`;
+            _showDeselected();
         }
     }
 


### PR DESCRIPTION
Resolves #2654 

This does a couple small things to the sidebar:
1. Decreases whitespace between smiley faces
2. Adds hover functionality to smiley faces to match the hover functionality for tags
3. Decreases the overall width of the sidebar slightly (screenshots below show the biggest change in the look of the tags that happens because of this, it's very minor).
4. Slightly increases the size of the cards and the expanded view given the decrease in the width of the sidebar.

##### Before/After screenshots (if applicable)
Before (no expanded view)
![Screenshot from 2021-08-06 13-43-41](https://user-images.githubusercontent.com/6518824/128569606-bb56bf9b-b0d5-433f-9eb9-314f8892040a.png)

After (no expanded view)
![Screenshot from 2021-08-06 13-43-20](https://user-images.githubusercontent.com/6518824/128569619-2aefbd92-6a83-4497-a2d1-d9b89f7561e0.png)

Before (expanded view)
![Screenshot from 2021-08-06 13-48-31](https://user-images.githubusercontent.com/6518824/128569635-0c094585-6086-4355-a6cb-291268be12c9.png)

After (expanded view)
![Screenshot from 2021-08-06 13-48-44](https://user-images.githubusercontent.com/6518824/128569641-7f3cfa0b-d6ba-460c-acba-0e366d5630f6.png)

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
