### PR TITLE
Tags on Gallery cards end in ellipsis when appropriate

### DIFF
--- a/public/javascripts/Gallery/src/displays/TagDisplay.js
+++ b/public/javascripts/Gallery/src/displays/TagDisplay.js
@@ -33,48 +33,64 @@ function TagDisplay(container, tags, isModal=false) {
             tagContainer.className = 'label-tags-holder';
             $(container).append(tagContainer);
 
-            // The width (amount of horizontal space) we have for our tags is
-            // the length of the container subtracted by the space taken up by
-            // the header. 1.25 to deal with the padding from the space between the "Tag"
-            // header and the actual list of tags.
-            let remainingWidth = $(container).width() - ($(tagHeader).width() * 1.25);
+            // The width (amount of horizontal space) we have for our tags is the length of the container subtracted by
+            // the space taken up by the header. 1.25 to deal with the padding from the space between the "Tag" header
+            // and the actual list of tags. For the modal, it's simply the width of the tags section.
+            let remainingWidth;
+            if (isModal) remainingWidth = parseFloat($('.gallery-modal-info-tags').css('width'));
+            else         remainingWidth = $(container).width() - ($(tagHeader).width() * 1.25);
 
-            let hiddenCount = 0;
+            const MARGIN_BW_TAGS =
+                parseFloat($('.gallery-tag').css('marginLeft')) + parseFloat($('.gallery-tag').css('marginRight'));
+            const WIDTH_FOR_PLUS_N = 30;
+            const MIN_TAG_WIDTH = 75;
 
-            // Order tags so that the tags that match the selected tags come first.
             let orderedTags = orderTags(tags);
             let tagsText = orderedTags.map(t => i18next.t('tag.' + t));
-            let unaddedTags = [];
-
-            // Try to append as many tags as possible into the parent container.
+            let hiddenTags = [];
             for (let i = 0; i < tagsText.length; i++) {
-                let tagTest = document.createElement('div');
+                let tagEl = document.createElement('div');
                 // We may want to rename the thumbnail-tag class if we every choose to make tags editable in modal mode.
-                tagTest.className = 'gallery-tag thumbnail-tag';
-                tagTest.innerText = tagsText[i];
-                $(tagContainer).append(tagTest);
-                // 14 is from the 7px of padding/margin on all tags (both left and right) and the 5 is from the spacing beween tags (5px).
-                // Careful though, as .width() doesn't necessarily seem to return px width. Need to find better solution.
-                remainingWidth -= ($(tagTest).width() + 14 + 5); //TODO: Define these constants. Better way to do so?
-                if (remainingWidth < 0 && !isModal) {
-                    // No room for this tag, this will be one of the hidden tags, so we increment counter.
-                    tagTest.remove();
-                    tagTest.classList.add("not-added");
-                    unaddedTags.push(tagTest);
-                    hiddenCount += 1;
+                tagEl.className = 'gallery-tag thumbnail-tag';
+                tagEl.innerText = tagsText[i];
+                $(tagContainer).append(tagEl);
+
+                // If there is enough space to fit the full tag, add it. If there isn't enough to show the full tag but
+                // there is still a decent amount of space (75 px if this is the last tag or 105 px if we also need to
+                // add the '+n' text), add the tag with a max-width so that it gets cut off with an ellipsis. If we
+                // can't fit the tag at all, will need to add to the hidden tags in the '+n' popover.
+                let isLastTag = i === tagsText.length - 1;
+                let tagWidth = parseFloat($(tagEl).css('width'));
+                let extraSpaceNeeded = isLastTag ? MARGIN_BW_TAGS : MARGIN_BW_TAGS + WIDTH_FOR_PLUS_N;
+                let spaceForShortenedTag = isLastTag ? MIN_TAG_WIDTH : MIN_TAG_WIDTH + WIDTH_FOR_PLUS_N;
+                if ((remainingWidth > tagWidth + extraSpaceNeeded)) {
+                    // Show the entire tag if there is enough space.
+                    remainingWidth -= (tagWidth + MARGIN_BW_TAGS);
+                } else if (remainingWidth > spaceForShortenedTag) {
+                    // Show a tag abbreviated with an ellipsis if there's some space, just not enough for the full tag.
+                    $(tagEl).css('maxWidth', remainingWidth - extraSpaceNeeded);
+                    tagWidth = parseFloat($(tagEl).css('width'));
+                    remainingWidth -= (tagWidth + MARGIN_BW_TAGS);
+                    // Since we cut off with an ellipsis, add a tooltip with the full text.
+                    tagEl.title = tagsText[i];
+                } else {
+                    // If the tag does not fit at all, add it to the list of hidden tags to show in the popover.
+                    tagEl.remove();
+                    tagEl.classList.add("not-added");
+                    hiddenTags.push(tagEl);
                 }
             }
 
-            if (hiddenCount > 0) {
-                // We have hidden tags.
+            // If there was not enough space to display all the tags, show the rest in a popover on the '+n' text.
+            if (hiddenTags.length > 0) {
                 let additional = document.createElement('div');
                 additional.className = "gallery-tag additional-count";
-                additional.innerText = " + " + hiddenCount;
+                additional.innerText = " + " + hiddenTags.length;
                 $(additional).popover("destroy").popover({
                     placement: 'top',
                     html: true,
                     delay: { "show": 300, "hide": 10 },
-                    content: unaddedTags.map(tag => tag.outerHTML).join(""),
+                    content: hiddenTags.map(tag => tag.outerHTML).join(""),
                     trigger: 'hover',
                     template: popoverTemplate
                 }).popover("show").popover("hide");
@@ -92,7 +108,7 @@ function TagDisplay(container, tags, isModal=false) {
         let orderedTags = [];
         let appliedTags = sg.tagContainer.getAppliedTagNames();
         for (let tag of tags) {
-            if (orderedTags.length == 0) {
+            if (orderedTags.length === 0) {
                 orderedTags.push(tag);
             } else {
                 if (appliedTags.includes(tag)) {
@@ -103,7 +119,6 @@ function TagDisplay(container, tags, isModal=false) {
                 }
             }
         }
-
         return orderedTags;
     }
 


### PR DESCRIPTION
Resolves #2612 

The tags on the cards in Gallery now end in an ellipsis if they don't fit. I set it up so that it requires a minimum amount of available space in order to show a truncated tag over putting it in the list of tags hidden in the '+n' tooltip.

##### Before/After screenshots (if applicable)
Before
![Screenshot from 2021-08-06 19-53-15](https://user-images.githubusercontent.com/6518824/128585752-a1a6c51b-3224-462f-a78c-b078be768339.png)
![Screenshot from 2021-08-06 19-52-58](https://user-images.githubusercontent.com/6518824/128585755-51d123de-bf56-4d3c-816e-436d66aca0d7.png)

After
![Screenshot from 2021-08-06 19-53-38](https://user-images.githubusercontent.com/6518824/128585759-8b4c10eb-24ef-4c65-aaff-7d7447a7bf61.png)
![Screenshot from 2021-08-06 19-52-19](https://user-images.githubusercontent.com/6518824/128585762-6d2cd8e5-8cc6-4f9d-91cb-c02b2ef1d6e9.png)

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
