### PR TITLE
Fixes audit page after postgres 12 postgis 3 upgrade

### DIFF
--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -191,10 +191,13 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
 
     val neighborhoods = RegionCompletionTable.selectAllNamedNeighborhoodCompletions
     val completionRates: List[JsObject] = for (neighborhood <- neighborhoods) yield {
+      val completionRate: Double =
+        if (neighborhood.totalDistance > 0) neighborhood.auditedDistance / neighborhood.totalDistance
+        else 0.0D
       Json.obj("region_id" -> neighborhood.regionId,
         "total_distance_m" -> neighborhood.totalDistance,
         "completed_distance_m" -> neighborhood.auditedDistance,
-        "rate" -> (neighborhood.auditedDistance / neighborhood.totalDistance),
+        "rate" -> completionRate,
         "name" -> neighborhood.name
       )
     }

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -193,7 +193,7 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
     val completionRates: List[JsObject] = for (neighborhood <- neighborhoods) yield {
       val completionRate: Double =
         if (neighborhood.totalDistance > 0) neighborhood.auditedDistance / neighborhood.totalDistance
-        else 0.0D
+        else 1.0D
       Json.obj("region_id" -> neighborhood.regionId,
         "total_distance_m" -> neighborhood.totalDistance,
         "completed_distance_m" -> neighborhood.auditedDistance,

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -1412,7 +1412,7 @@ object LabelTable {
   def getStreetEdgeIdClosestToLatLng(lat: Float, lng: Float): Option[Int] = db.withSession { implicit session =>
     val selectStreetEdgeIdQuery = Q.query[(Float, Float), Int](
       """SELECT s.street_edge_id FROM street_edge AS s
-         |    ORDER BY ST_Distance(s.geom,ST_SetSRID(ST_MakePoint(?, ?),Find_SRID('sidewalk', 'street_edge', 'geom'))) ASC
+         |    ORDER BY ST_Distance(s.geom, ST_SetSRID(ST_MakePoint(?, ?), 4326)) ASC
          |LIMIT 1""".stripMargin
     )
     //NOTE: these parameters are being passed in correctly. ST_MakePoint accepts lng first, then lat.


### PR DESCRIPTION
Resolves #2667 

Fixes the issue where the audit page became unusable because a query that was used to add labels to the database was taking minutes instead of milliseconds. A small side change: we had a divide by 0 error for neighborhoods with no streets in them that I've fixed.

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've added/updated comments for large or confusing blocks of code.
