### PR TITLE
Fixes the look of neighborhoods with holes

### DIFF
--- a/app/controllers/UserProfileController.scala
+++ b/app/controllers/UserProfileController.scala
@@ -10,7 +10,6 @@ import com.vividsolutions.jts.geom.Coordinate
 import controllers.headers.ProvidesHeader
 import models.audit.AuditTaskTable
 import models.mission.MissionTable
-import models.user.OrganizationTable
 import models.user.UserOrgTable
 import models.label.{LabelTable, LabelValidationTable}
 import models.user.{User, WebpageActivityTable, WebpageActivity}

--- a/app/models/gallery/GalleryTaskInteractionTable.scala
+++ b/app/models/gallery/GalleryTaskInteractionTable.scala
@@ -1,14 +1,7 @@
 package models.gallery
 
-import java.util.UUID
 import models.utils.MyPostgresDriver.simple._
 import play.api.Play.current
-import play.api.libs.json.{JsObject, Json}
-import play.extras.geojson
-
-import scala.slick.jdbc.{GetResult, StaticQuery => Q}
-import scala.slick.lifted.ForeignKeyQuery
-
 
 case class GalleryTaskInteraction(galleryTaskInteractionId: Int,
                                      action: String,


### PR DESCRIPTION
Fixes #2668 

Fixes how neighborhoods with holes look on our website. I had thought that the geometries themselves were messed up, but it turns out that we just were not using the GeoJSON spec correctly for polygons with holes! It's a little bit more complicated and there weren't functions to do it for me in one line, but it was only a couple extra lines to fix. I made this change for both the endpoint that we use for maps, and for the API endpoint that returns polygons.

##### Before/After screenshots (if applicable)
Before
![Screenshot from 2021-08-19 17-20-59](https://user-images.githubusercontent.com/6518824/130160517-be8a8d2b-7ed0-41cf-9a66-bb0347acd08c.png)
![Screenshot from 2021-08-19 17-21-02](https://user-images.githubusercontent.com/6518824/130160523-d28a33ef-05f8-4fe8-afc9-30ceef15592c.png)

After
![Screenshot from 2021-08-19 17-21-47](https://user-images.githubusercontent.com/6518824/130160530-3736b6e4-b84d-422f-8811-578e941fec5c.png)
![Screenshot from 2021-08-19 17-21-51](https://user-images.githubusercontent.com/6518824/130160532-728e3133-d179-4e1f-bb19-67ebfced4922.png)

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
