### PR TITLE
Adds support for neighborhoods w/ disconnected parts (multipolygons)

### DIFF
--- a/app/controllers/RegionController.scala
+++ b/app/controllers/RegionController.scala
@@ -12,11 +12,10 @@ import models.region._
 import play.api.libs.json.Json
 import play.api.libs.json.Json._
 import play.extras.geojson
-import com.vividsolutions.jts.geom.Coordinate
-import collection.immutable.Seq
+import models.region.RegionTable.MultiPolygonUtils
 
 /**
- * Holds the HTTP requests associated with managing neighorhoods.
+ * Holds the HTTP requests associated with managing neighborhoods.
  *
  * @param env The Silhouette environment.
  */
@@ -37,23 +36,12 @@ class RegionController @Inject() (implicit val env: Environment[User, SessionAut
     request.identity match {
       case Some(user) =>
         val features: List[JsObject] = RegionTable.getNeighborhoodsWithUserCompletionStatus(user.userId).map { region =>
-          // Put polygon in geojson format, an array[array[latlng]], where the first array contains the latlngs for the
-          // outer boundary of the polygon, and the remaining arrays have the latlngs for any holes in the polygon.
-          val nHoles: Int = region.geom.getNumInteriorRing
-          val outerRing: Seq[Array[Coordinate]] = Seq(region.geom.getExteriorRing.getCoordinates)
-          val holes: Seq[Array[Coordinate]] = (0 until nHoles).map(i => region.geom.getInteriorRingN(i).getCoordinates)
-          val coordinates: Seq[Array[Coordinate]] = outerRing ++ holes
-          val latlngs: Seq[Seq[geojson.LatLng]] = coordinates.map { ring =>
-            ring.map(coord => geojson.LatLng(coord.y, coord.x)).toList
-          }
-          val polygon: geojson.Polygon[geojson.LatLng] = geojson.Polygon(latlngs)
-
           val properties: JsObject = Json.obj(
             "region_id" -> region.regionId,
             "region_name" -> region.name,
             "user_completed" -> region.userCompleted
           )
-          Json.obj("type" -> "Feature", "geometry" -> polygon, "properties" -> properties)
+          Json.obj("type" -> "Feature", "geometry" -> region.geom.toJSON, "properties" -> properties)
         }
         val featureCollection: JsObject = Json.obj("type" -> "FeatureCollection", "features" -> features)
         Future.successful(Ok(featureCollection))

--- a/conf/evolutions/default/120.sql
+++ b/conf/evolutions/default/120.sql
@@ -1,0 +1,11 @@
+# --- !Ups
+ALTER TABLE region
+    ALTER COLUMN geom TYPE public.geometry(MultiPolygon, 4326)
+        USING ST_Multi(geom);
+
+# --- !Downs
+-- NOTE This really only works on single polygons. If a row is truly a multipolygon, you'll need to figure out how to
+--      manually separate them into multiple regions, assign the correct streets to them, etc.
+ALTER TABLE region
+    ALTER COLUMN geom TYPE public.geometry(Polygon, 4326)
+        USING ST_GeometryN(geom, 1);


### PR DESCRIPTION
Resolves #2673 

Adds support for neighborhoods with disconnected parts. To support those types of geometries, we needed to change the data type for neighborhoods in the database from "Polygon" to "MultiPolygon", change the corresponding data types in Scala, and then update how we convert those geometries into GeoJSON. After that, everything we have on the front-end worked out of the box with multi-polygons :)

I created a test neighborhood by combining two neighborhoods that already existed in my local dev environment, so I know that it works. But I don't have any examples to show with neighborhoods from an actual deployment. My next steps are to make the database for Chicago using multi-polygons and update the wiki page documentation accordingly!

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've added/updated comments for large or confusing blocks of code.
