### PR TITLE
Improves logging of authentication & resetting passwords

### DIFF
--- a/app/controllers/ForgotPasswordController.scala
+++ b/app/controllers/ForgotPasswordController.scala
@@ -6,11 +6,13 @@ import javax.inject.Inject
 import com.mohiva.play.silhouette.api._
 import com.mohiva.play.silhouette.impl.providers.CredentialsProvider
 import forms.ForgotPasswordForm
-import models.services.{ UserService, AuthTokenService }
+import models.services.{AuthTokenService, UserService}
 import com.mohiva.play.silhouette.impl.authenticators.SessionAuthenticator
 import models.user._
 import play.api.i18n.Messages
 import controllers.headers.ProvidesHeader
+import models.daos.slick.DBTableDefinitions.UserTable
+import play.api.Logger
 import play.api.libs.concurrent.Execution.Implicits._
 import scala.concurrent.Future
 import play.api.libs.mailer._
@@ -37,6 +39,7 @@ class ForgotPasswordController @Inject() (
   def submit = UserAwareAction.async { implicit request =>
     val ipAddress: String = request.remoteAddress
     val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
+    val userId: String = request.identity.map(_.userId.toString).getOrElse(UserTable.find("anonymous").get.userId)
 
     ForgotPasswordForm.form.bindFromRequest.fold (
       form => Future.successful(BadRequest(views.html.forgotPassword(form))),
@@ -56,11 +59,14 @@ class ForgotPasswordController @Inject() (
               )
 
               MailerPlugin.send(resetEmail)
-              WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, "PasswordResetRequest=" + email, timestamp))
+              WebpageActivityTable.save(WebpageActivity(0, userId, ipAddress, "PasswordResetRequest=" + email, timestamp))
               result
             }
 
-          case None => Future.successful(result)
+          case None =>
+            Logger.warn("Tried to reset password, but email not found in database: " + email)
+            WebpageActivityTable.save(WebpageActivity(0, userId, ipAddress, "PasswordResetRequestFailed=" + email, timestamp))
+            Future.successful(result)
         }
       }
     )

--- a/app/controllers/UserController.scala
+++ b/app/controllers/UserController.scala
@@ -30,6 +30,7 @@ class UserController @Inject() (implicit val env: Environment[User, SessionAuthe
    */
   def signIn(url: String) = UserAwareAction.async { implicit request =>
     if (request.identity.isEmpty || request.identity.get.role.getOrElse("") == "Anonymous") {
+      logPageVisit(request.identity, request.remoteAddress, "Visit_SignIn")
       Future.successful(Ok(views.html.signIn(SignInForm.form, url)))
     } else {
       Future.successful(Redirect(url))
@@ -41,6 +42,7 @@ class UserController @Inject() (implicit val env: Environment[User, SessionAuthe
    */
   def signInMobile(url: String) = UserAwareAction.async { implicit request =>
     if (request.identity.isEmpty || request.identity.get.role.getOrElse("") == "Anonymous") {
+      logPageVisit(request.identity, request.remoteAddress, "Visit_MobileSignIn")
       Future.successful(Ok(views.html.signInMobile(SignInForm.form, url)))
     } else {
       Future.successful(Redirect(url))
@@ -52,6 +54,7 @@ class UserController @Inject() (implicit val env: Environment[User, SessionAuthe
    */
   def signUp(url: String) = UserAwareAction.async { implicit request =>
     if (request.identity.isEmpty || request.identity.get.role.getOrElse("") == "Anonymous") {
+      logPageVisit(request.identity, request.remoteAddress, "Visit_SignUp")
       Future.successful(Ok(views.html.signUp(SignUpForm.form)))
     } else {
       Future.successful(Redirect(url))
@@ -63,6 +66,7 @@ class UserController @Inject() (implicit val env: Environment[User, SessionAuthe
    */
   def signUpMobile(url: String) = UserAwareAction.async { implicit request =>
     if (request.identity.isEmpty || request.identity.get.role.getOrElse("") == "Anonymous") {
+      logPageVisit(request.identity, request.remoteAddress, "Visit_MobileSignUp")
       Future.successful(Ok(views.html.signUpMobile(SignUpForm.form)))
     } else {
       Future.successful(Redirect(url))
@@ -87,6 +91,7 @@ class UserController @Inject() (implicit val env: Environment[User, SessionAuthe
    */
   def forgotPassword(url: String) = UserAwareAction.async { implicit request =>
     if (request.identity.isEmpty || request.identity.get.role.getOrElse("") == "Anonymous") {
+      logPageVisit(request.identity, request.remoteAddress, "Visit_ForgotPassword")
       Future.successful(Ok(views.html.forgotPassword(ForgotPasswordForm.form)))
     } else {
       Future.successful(Redirect(url))
@@ -98,7 +103,9 @@ class UserController @Inject() (implicit val env: Environment[User, SessionAuthe
    */
   def resetPassword(token: UUID) = UserAwareAction.async { implicit request =>
     authTokenService.validate(token).map {
-      case Some(_) => Ok(views.html.resetPassword(ResetPasswordForm.form, token))
+      case Some(_) =>
+        logPageVisit(request.identity, request.remoteAddress, "Visit_ResetPassword")
+        Ok(views.html.resetPassword(ResetPasswordForm.form, token))
       case None => Redirect(routes.UserController.signIn()).flashing("error" -> Messages("reset.pw.invalid.reset.link"))
     }
   }


### PR DESCRIPTION
Resolves #2683 

Improves logging of authentication & resetting passwords. We were only logging when a password reset email was sent, when a password was successfully reset, and when a user successfully signs in/up. We were not logging when someone visits one of the sign in/up or password forgotten/reset pages. I added logging for whenever you visit a page, and logging when someone tries to reset a password with an email address that is not associated with an account. This should make debugging easier when users email me about not getting a password reset email :)

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure the documentation on [this wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Descriptions-of-Logged-Events) is up to date for the logs you added/updated.
- [x] I've tested on mobile (only needed for validation page).
