### PR TITLE
Adds inter-team leaderboard

### DIFF
--- a/app/views/leaderboard.scala.html
+++ b/app/views/leaderboard.scala.html
@@ -4,7 +4,9 @@
 
 @leaderboardStats = @{UserStatTable.getLeaderboardStats(10)}
 @leaderboardStatsThisWeek = @{UserStatTable.getLeaderboardStats(10, "weekly")}
-@leaderboardStatsOrg = @{UserStatTable.getLeaderboardStats(10, "overall", UserOrgTable.getAllOrgs(user.get.userId).headOption)}
+@leaderboardStatsByOrg = @{UserStatTable.getLeaderboardStats(10, "overall", true)}
+@leaderboardStatsOrg = @{UserStatTable.getLeaderboardStats(10, "overall", false, UserOrgTable.getAllOrgs(user.get.userId).headOption)}
+
 
 <div class="leaderboard-container">
     <div class="item leaderboard-table">
@@ -85,6 +87,76 @@
             </table>
         </div>
     </div>
+    @if(leaderboardStatsByOrg.asInstanceOf[List[LeaderboardStat]].length >= 0) {
+        <div class="item leaderboard-table">
+            <h1 class="leaderboard-header">@Messages("leaderboard.inter.org.title")</h1>
+            <h5>@Messages("leaderboard.overall.detail")</h5>
+            <div class="panel panel-default">
+                <table class="table table-bordered leaderboard-table-striped">
+                    <thead class="leaderboard-table-header">
+                        <tr>
+                            <th class="leaderboard-table-font" scope="col">#</th>
+                            <th class="leaderboard-table-font" scope="col">@Messages("leaderboard.header.team")</th>
+                            <th class="leaderboard-table-font" scope="col">@Messages("leaderboard.header.labels")</th>
+                            <th class="leaderboard-table-font" scope="col">@Messages("leaderboard.header.missions")</th>
+                            <th class="leaderboard-table-font" scope="col">@Messages("leaderboard.header.distance")</th>
+                            <th class="leaderboard-table-font" scope="col">@Messages("leaderboard.header.accuracy")</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                    @for((stat, i) <- leaderboardStatsByOrg.view.zipWithIndex) {
+                        <tr>
+                            <th class="leaderboard-table-font" scope="row">@{
+                                i + 1
+                            }</th>
+                            <td class="leaderboard-table-font">@{
+                                stat.asInstanceOf[LeaderboardStat].username
+                            }</td>
+                            <td class="leaderboard-table-font">@{
+                                stat.asInstanceOf[LeaderboardStat].labelCount
+                            }</td>
+                            <td class="leaderboard-table-font">@{
+                                stat.asInstanceOf[LeaderboardStat].missionCount
+                            }</td>
+                            @if(Messages("measurement.system") == "metric") {
+                                @if(stat.asInstanceOf[LeaderboardStat].distanceMeters.asInstanceOf[Float] > 2000) {
+                                    <td class="leaderboard-table-font">@{
+                                        "%.1f".format(stat.asInstanceOf[LeaderboardStat].distanceMeters.asInstanceOf[Float]/ 1000)
+                                    } km</td>
+                                } else {
+                                    <td class="leaderboard-table-font">@{
+                                        "%.1f".format(stat.asInstanceOf[LeaderboardStat].distanceMeters)
+                                    } m</td>
+                                }
+                            } else {
+                                @if(stat.asInstanceOf[LeaderboardStat].distanceMeters.asInstanceOf[Float] * 3.28 > 5280) {
+                                    <td class="leaderboard-table-font">@{
+                                        "%.1f".format(stat.asInstanceOf[LeaderboardStat].distanceMeters.asInstanceOf[Float] * 3.28 / 5280)
+                                    } miles</td>
+                                } else {
+                                    <td class="leaderboard-table-font">@{
+                                        "%.1f".format(stat.asInstanceOf[LeaderboardStat].distanceMeters.asInstanceOf[Float] * 3.28)
+                                    } ft</td>
+                                }
+                            }
+                            @if(stat.asInstanceOf[LeaderboardStat].accuracy.getOrElse(0.00f).asInstanceOf[Float] * 100 < 10)  {
+                                <td class="leaderboard-table-font accuracy-cell">N/A
+                                    <span class="accuracy-tooltip">
+                                    @Messages("leaderboard.tooltip.accuracy")
+                                    </span>
+                                </td>
+                            } else {
+                                <td class="leaderboard-table-font">@{
+                                    "%.1f".format(stat.asInstanceOf[LeaderboardStat].accuracy.getOrElse(0.00f).asInstanceOf[Float] * 100)
+                                }%</td>
+                            }
+                        </tr>
+                    }
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    }
     @if(leaderboardStatsThisWeek.asInstanceOf[List[LeaderboardStat]].length >= min) {
         <div class="item leaderboard-table">
             <h1 class="leaderboard-header">@Messages("leaderboard.weekly.title")</h1>

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -290,10 +290,12 @@ admin.clear.play.cache = Clear Play cache
 
 leaderboard.overall.title = Overall Leaderboard
 leaderboard.weekly.title = Weekly Leaderboard
+leaderboard.inter.org.title = Teams Leaderboard
 leaderboard.org.title = {0} Leaderboard
 leaderboard.overall.detail = Leaders are calculated based on their labels, distance, and accuracy
 leaderboard.weekly.detail = Stats reset every Sunday morning at 12 AM Pacific
-leaderboard.org.detail = Top 10 overall contributers to {0}
+leaderboard.org.detail = Top 10 overall contributors to {0}
+leaderboard.header.team = Team
 leaderboard.header.labels = Labels
 leaderboard.header.missions = Missions
 leaderboard.header.distance = Distance

--- a/conf/messages.es
+++ b/conf/messages.es
@@ -288,10 +288,12 @@ admin.clear.play.cache = Borrar caché de Play
 
 leaderboard.overall.title = Tabla de clasificación general
 leaderboard.weekly.title = Tabla de clasificación semanal
+leaderboard.inter.org.title = Tabla de clasificación de equipos
 leaderboard.org.title = Tabla de {0}
 leaderboard.overall.detail = Las posiciones se calculan en base a las etiquetas, distancia y precisión
 leaderboard.weekly.detail = Las estadísticas se restablecen todos los domingos por la mañana a las 12:00 a.m. (PT)
 leaderboard.org.detail = Los 10 contribuyentes mayor a {0}
+leaderboard.header.team = Equipo
 leaderboard.header.labels = Etiquetas
 leaderboard.header.missions = Misiones
 leaderboard.header.distance = Distancia


### PR DESCRIPTION
Resolves #2691 

Adds an inter-team leaderboard to the /leaderboard page. This allows you to compare your team to other teams on the same server!

##### Before/After screenshots (if applicable)
After
<img width="1019" alt="Screen Shot 2021-10-18 at 6 37 16 PM" src="https://user-images.githubusercontent.com/6518824/137830260-4848031b-9890-41c6-86d3-2971d3e53e01.png">


##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
- [x] I've asked for and included translations for any user facing text that was added or modified.
