### PR TITLE
changed links on api page

### DIFF
--- a/app/views/developer.scala.html
+++ b/app/views/developer.scala.html
@@ -106,8 +106,8 @@
                                 <dt>200</dt>
                                 <dd>
                                     The API returns all the available accessibility attributes in the specified area
-                                    as a <a href="http://geojson.org/geojson-spec.html#feature-collection-objects">Feature Collection</a> of
-                                        <a href="http://geojson.org/geojson-spec.html#point">Point features.</a>
+                                    as a <a href="https://datatracker.ietf.org/doc/html/rfc7946#section-3.3">Feature Collection</a> of
+                                        <a href="https://datatracker.ietf.org/doc/html/rfc7946#section-3.1.2">Point features.</a>
                                     Properties of the attributes include label type, neighborhood name, severity, whether the
                                         problem was marked as temporary, and a unique attribute id (see
                                         <a data-scroll href="#disclaimer">disclaimer section</a> for caveats). The
@@ -203,8 +203,8 @@
                             <dl>
                                 <dt>200</dt>
                                 <dd>
-                                    The API returns the streets that have been audited at least once as a <a href="http://geojson.org/geojson-spec.html#feature-collection-objects">Feature Collection</a> of
-                                    <a href="http://geojson.org/geojson-spec.html#linestring">LineString features.</a> Each LineString feature
+                                    The API returns the streets that have been audited at least once as a <a href="https://datatracker.ietf.org/doc/html/rfc7946#section-3.3">Feature Collection</a> of
+                                    <a href="https://datatracker.ietf.org/doc/html/rfc7946#appendix-A.2">LineString features.</a> Each LineString feature
                                     include street's geometry as well as the corresponding Access Score.
                                 </dd>
                             </dl>
@@ -294,8 +294,8 @@
                             <dl>
                                 <dt>200</dt>
                                 <dd>
-                                    The API returns neighborhoods in a given area as a <a href="http://geojson.org/geojson-spec.html#feature-collection-objects">Feature Collection</a> of
-                                    <a href="http://geojson.org/geojson-spec.html#polygon">Polygon features.</a> Each Polygon feature
+                                    The API returns neighborhoods in a given area as a <a href="https://datatracker.ietf.org/doc/html/rfc7946#section-3.3">Feature Collection</a> of
+                                    <a href="https://datatracker.ietf.org/doc/html/rfc7946#appendix-A.3">Polygon features.</a> Each Polygon feature
                                     includes its geometry as well as the corresponding Access Score.
                                 </dd>
                             </dl>

--- a/app/views/developer.scala.html
+++ b/app/views/developer.scala.html
@@ -107,7 +107,7 @@
                                 <dd>
                                     The API returns all the available accessibility attributes in the specified area
                                     as a <a href="https://datatracker.ietf.org/doc/html/rfc7946#section-3.3">Feature Collection</a> of
-                                        <a href="https://datatracker.ietf.org/doc/html/rfc7946#section-3.1.2">Point features.</a>
+                                        <a href="https://datatracker.ietf.org/doc/html/rfc7946#appendix-A.1">Point features.</a>
                                     Properties of the attributes include label type, neighborhood name, severity, whether the
                                         problem was marked as temporary, and a unique attribute id (see
                                         <a data-scroll href="#disclaimer">disclaimer section</a> for caveats). The


### PR DESCRIPTION
Resolves #2689

Replaced the obsolete links with links to the updated document.
##### Before/After screenshots (if applicable)

##### Testing instructions
1.  check the links on https://sidewalk-sea.cs.washington.edu/developer to make sure they link to the right pages:

Three feature collection links should be changed from 
https://geojson.org/geojson-spec.html#feature-collection-objects
to
https://datatracker.ietf.org/doc/html/rfc7946#section-3.3

The Point features link should be changed from
https://geojson.org/geojson-spec.html#point
to
https://datatracker.ietf.org/doc/html/rfc7946#section-3.1.2

The LineString features link should be changed from
https://geojson.org/geojson-spec.html#linestring
to
https://datatracker.ietf.org/doc/html/rfc7946#section-3.1.4

The Polygon features link should be changed from
https://geojson.org/geojson-spec.html#polygon
to
https://datatracker.ietf.org/doc/html/rfc7946#section-3.1.6

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x ] I've written a descriptive PR title.