### PR TITLE
Update leaderboard algorithm

### DIFF
--- a/app/models/user/UserStatTable.scala
+++ b/app/models/user/UserStatTable.scala
@@ -258,7 +258,7 @@ object UserStatTable {
         |    $joinUserOrgTable
         |    WHERE label.deleted = FALSE
         |        AND label.tutorial = FALSE
-        |        AND role.role IN ('Registered', 'Administrator', 'Researcher', 'Owner')
+        |        AND role.role IN ('Registered', 'Administrator', 'Researcher')
         |        AND (user_stat.high_quality_manual = TRUE OR user_stat.high_quality_manual IS NULL)
         |        AND (label.time_created AT TIME ZONE 'US/Pacific') > $statStartTime
         |        $orgFilter


### PR DESCRIPTION
Resolves #2696 
Fixes #2695 

Updates the score that determines order on the leaderboard. It used to just be scored by the number of labels. Now it's set to `score = sqrt(# labels) * (0.5 * audited_distance / total_distance + 0.5 * accuracy)`. The main benefit is that this score now includes accuracy (as determined by other users' validations).

This PR also removes Jon and I from the leaderboards. Which is something that we used to do, and I accidentally undid in a recent PR :upside_down_face: 

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've added/updated comments for large or confusing blocks of code.
