### PR TITLE
Fix persistant filter on refresh

### DIFF
--- a/app/views/gallery.scala.html
+++ b/app/views/gallery.scala.html
@@ -18,7 +18,7 @@
                 <div id="ribbon-menu-holder">
                     <span id="label-type-holder">
                         <h4><b>@Messages("gallery.show")</b></h4>
-                        <select id="label-select" disabled>
+                        <select id="label-select" autocomplete="off" disabled>
                             <option value="Assorted">@Messages("gallery.all")</option>
                             <option value="CurbRamp">@Messages("curb.ramp")</option>
                             <option value="NoCurbRamp">@Messages("missing.ramp")</option>


### PR DESCRIPTION
Resolves #2663 

Fixed the persistance of the dropdown in the `/gallery` page (in firefox) by adding the `autocomplete="off"` tag to dropdown menu. I additionally verified that this bug no longer existed in Chrome, Firefox, and Edge. Are there any other browsers that I need to test this on?

##### Recordings of refreshing
Chrome:
https://user-images.githubusercontent.com/15069663/139382012-5d316a73-8b0f-4433-987f-3cb535771985.mp4

Firefox:
https://user-images.githubusercontent.com/15069663/139382055-6549f47c-081d-4b6f-a1a9-2c973f80522d.mp4

Edge:
https://user-images.githubusercontent.com/15069663/139382081-69499e16-446d-4a0e-85e1-0f2c74955ce9.mp4

##### Testing instructions
1.  Select a filter in `/gallery` under the "Show" header
2. Refresh the page
3. The filter should now reset to "All"
