### PR TITLE
Hide severity on occlusion cards

### DIFF
--- a/public/javascripts/Gallery/src/cards/Card.js
+++ b/public/javascripts/Gallery/src/cards/Card.js
@@ -116,10 +116,12 @@ function Card (params, imageUrl, modal) {
         cardInfo.appendChild(cardData);
 
         // Create the div to store the severity of the label.
-        let cardSeverity = document.createElement('div');
-        cardSeverity.className = 'card-severity';
-        let severityHolder = new SeverityDisplay(cardSeverity, properties.severity);
-        cardData.appendChild(cardSeverity);
+        if (getLabelType() !== "Occlusion") {
+            let cardSeverity = document.createElement('div');
+            cardSeverity.className = 'card-severity';
+            let severityHolder = new SeverityDisplay(cardSeverity, properties.severity);
+            cardData.appendChild(cardSeverity);
+        }
 
         // Create the div to store the tags related to a card. Tags won't be populated until card is added to the DOM.
         let cardTags = document.createElement('div');


### PR DESCRIPTION
Resolves #2639 

I hid the severity on the occlusion cards in the gallery by adding a conditional statement. Should we also hide the severity on this view?

<img src="https://user-images.githubusercontent.com/15069663/140019486-403dc5cc-9a59-4ec3-bf30-e1204d24a1eb.png" width=500 align=center>


##### Before/After screenshots (if applicable)

![image](https://user-images.githubusercontent.com/15069663/140019015-d913e68d-f5bf-496d-977a-78a311ea9176.png)

##### Testing instructions
1.  Go to `/gallery` and filter based on "Can't See Sidewalk"
