### PR TITLE
changed narrow tag keyboard shortcut for curb ramps from a to w

### DIFF
--- a/public/javascripts/common/UtilitiesSidewalk.js
+++ b/public/javascripts/common/UtilitiesSidewalk.js
@@ -195,8 +195,8 @@ function UtilitiesMisc (JSON) {
                 },
                 tagInfo: {
                     'narrow': {
-                        keyNumber: 65,
-                        keyChar: 'A',
+                        keyNumber: 87,
+                        keyChar: 'W',
                         text: i18next.t('center-ui.context-menu.tag.narrow')
                     },
                     'points into traffic': {

--- a/public/locales/en/audit.json
+++ b/public/locales/en/audit.json
@@ -116,7 +116,7 @@
             "severity-shortcuts": "Press keys 1-5 for severity",
             "label-popup-shortcuts": "Press <tag-underline>{{c}}</tag-underline> to add tag",
             "tag": {
-                "narrow": "n<tag-underline>a</tag-underline>rrow",
+                "narrow": "narro<tag-underline>w</tag-underline>",
                 "points-into-traffic": "<tag-underline>p</tag-underline>oints into traffic",
                 "missing-friction-strip": "missing <tag-underline>f</tag-underline>riction strip",
                 "steep": "s<tag-underline>t</tag-underline>eep",

--- a/public/locales/es/audit.json
+++ b/public/locales/es/audit.json
@@ -116,7 +116,7 @@
             "severity-shortcuts": "Presiona las teclas 1-5 para gravedad",
             "label-popup-shortcuts": "Presiona <tag-underline>{{c}}</tag-underline> para agregar la etiqueta",
             "tag": {
-                "narrow": "muy <tag-underline>a</tag-underline>ngosta",
+                "narrow": "muy angosta (<tag-underline>w</tag-underline>)",
                 "points-into-traffic": "orientada hacia el tráfico (<tag-underline>p</tag-underline>)",
                 "missing-friction-strip": "pavimento de advertencia táctil ausente (<tag-underline>f</tag-underline>)",
                 "steep": "empinada (mucha pendien<tag-underline>t</tag-underline>e)",


### PR DESCRIPTION
Resolves #2549 

This is a brief description of the problem solved or feature implemented and how you implemented it.

##### Before/After screenshots (if applicable)
Before:

![253739496_266725968726793_1114438036026931826_n](https://user-images.githubusercontent.com/68749645/140628850-0a4d972b-6b16-4614-9ae5-746b27bc7c2c.png)

![254096263_188977873399024_7434776635025057801_n](https://user-images.githubusercontent.com/68749645/140628851-b9e8e2ac-4c91-4be8-9f97-26fce15eb948.png)

After:

![253166842_256554479770666_8181630333407675366_n](https://user-images.githubusercontent.com/68749645/140628847-ede5cd0e-495c-49ce-bc7b-85ae856e1ddf.png)

![253051065_3043695185901839_3155608998325126432_n](https://user-images.githubusercontent.com/68749645/140628838-1c674664-f9a0-42f7-92ff-4cc3ea8d0592.png)

##### Testing instructions
1. On the main page, click on Start Exploring
2. Click on Let's Get Started
3. Click on curb ramp
4. Click on the image to place the curb ramp marker
5. Check/test to make sure the w is underlined for "narrow" and that pressing w will highlight the "narrow" keyword
6. Change the language to Spanish and follow the same steps, except the "narrow" keyword will now be called "muy angosta".

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've included before/after screenshots above.
- [x] I've asked for and included translations for any user facing text that was added or modified.
- [ ] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure the documentation on [this wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Descriptions-of-Logged-Events) is up to date for the logs you added/updated.
