### PR TITLE
Validation accuracy is now used for determining street audit priority

### DIFF
--- a/app/models/label/LabelValidationTable.scala
+++ b/app/models/label/LabelValidationTable.scala
@@ -109,6 +109,20 @@ object LabelValidationTable {
 
   case class ValidationCountPerDay(date: String, count: Int)
 
+  /**
+    * Get the user_ids of the users who placed the given labels.
+    *
+    * @param labelIds
+    * @return
+    */
+  def usersValidated(labelIds: List[Int]): List[String] = db.withSession { implicit session =>
+    (for {
+      l <- labels
+      m <- MissionTable.missions if l.missionId === m.missionId
+      if l.labelId inSet labelIds
+    } yield m.userId).groupBy(x => x).map(_._1).list
+  }
+
   def save(label: LabelValidation): Int = db.withTransaction { implicit session =>
     val labelValidationId: Int =
       (validationLabels returning validationLabels.map(_.labelValidationId)) += label

--- a/app/models/street/StreetEdgePriorityTable.scala
+++ b/app/models/street/StreetEdgePriorityTable.scala
@@ -152,6 +152,7 @@ object StreetEdgePriorityTable {
     val completions = AuditTaskTable.completedTasks
       .groupBy(task => (task.streetEdgeId, task.userId)).map(_._1)  // select distinct on street edge id and user id
       .innerJoin(UserStatTable.getQualityOfUsers).on(_._2 === _._1)  // join on user_id
+      .filterNot(_._2._3.getOrElse(false)) // filter out users marked with exclude_manual = TRUE
       .map { case (_task, _qual) => (_task._1, _qual._2) }  // SELECT street_edge_id, is_good_user
 
     /********** Compute Audit Counts **********/

--- a/app/models/user/UserStatTable.scala
+++ b/app/models/user/UserStatTable.scala
@@ -193,9 +193,10 @@ object UserStatTable {
    */
   def updateHighQuality(cutoffTime: Timestamp): Int = db.withSession { implicit session =>
 
-    // Get users manually marked as low quality first.
+    // First get users manually marked as low quality or marked to be excluded for other reasons.
     val lowQualityUsers: List[(String, Boolean)] =
-      userStats.filterNot(_.highQualityManual).map(x => (x.userId, x.highQualityManual.get)).list
+      (userStats.filterNot(_.highQualityManual) union userStats.filter(_.excludeManual))
+        .map(x => (x.userId, x.highQualityManual.get)).list
 
     // Decide if each user is high quality. First check if user was manually marked as high quality, then if they have
     // an audited distance of 0 (meaning an infinite labeling frequency), then if labeling frequency is over threshold.

--- a/app/models/user/UserStatTable.scala
+++ b/app/models/user/UserStatTable.scala
@@ -218,12 +218,12 @@ object UserStatTable {
     val usersStatsToUpdate: List[String] = usersThatAuditedSinceCutoffTime(cutoffTime)
 
     // Make separate lists for low vs high quality users, then bulk update each.
-    val updateToLowQuaity: List[String] =
+    val updateToLowQuality: List[String] =
       (lowQualityUsers ++ userQuality.filterNot(_._2)).map(_._1).filter(x => usersStatsToUpdate.contains(x))
     val updateToHighQuality: List[String] =
       userQuality.filter(_._2).map(_._1).filter(x => usersStatsToUpdate.contains(x))
 
-    val lowQualityUpdateQuery = for { _u <- userStats if _u.userId inSet updateToLowQuaity } yield _u.highQuality
+    val lowQualityUpdateQuery = for { _u <- userStats if _u.userId inSet updateToLowQuality } yield _u.highQuality
     val highQualityUpdateQuery = for { _u <- userStats if _u.userId inSet updateToHighQuality } yield _u.highQuality
 
     // Do both bulk updates, and return total number of updated rows.

--- a/app/models/user/UserStatTable.scala
+++ b/app/models/user/UserStatTable.scala
@@ -48,8 +48,8 @@ object UserStatTable {
   /**
     * Return query with user_id and high_quality columns.
     */
-  def getQualityOfUsers: Query[(Column[String], Column[Boolean]), (String, Boolean), Seq] = db.withSession { implicit session =>
-    userStats.map(x => (x.userId, x.highQuality))
+  def getQualityOfUsers: Query[(Column[String], Column[Boolean], Column[Option[Boolean]]), (String, Boolean, Option[Boolean]), Seq] = db.withSession { implicit session =>
+    userStats.map(x => (x.userId, x.highQuality, x.excludeManual))
   }
 
 

--- a/app/models/user/UserStatTable.scala
+++ b/app/models/user/UserStatTable.scala
@@ -236,7 +236,7 @@ object UserStatTable {
       if _user.username =!= "anonymous"
       if _userStat.metersAudited > 0F
       if _mission.missionEnd > cutoffTime
-    } yield _user.userId).list
+    } yield _user.userId).groupBy(x => x).map(_._1).list
   }
 
   /**

--- a/app/models/user/UserStatTable.scala
+++ b/app/models/user/UserStatTable.scala
@@ -302,7 +302,7 @@ object UserStatTable {
         |    WHERE label.deleted = FALSE
         |        AND label.tutorial = FALSE
         |        AND role.role IN ('Registered', 'Administrator', 'Researcher')
-        |        AND (user_stat.high_quality_manual = TRUE OR user_stat.high_quality_manual IS NULL)
+        |        AND (user_stat.exclude_manual = FALSE OR user_stat.exclude_manual IS NULL)
         |        AND (label.time_created AT TIME ZONE 'US/Pacific') > $statStartTime
         |        $orgFilter
         |    GROUP BY $groupingCol

--- a/conf/evolutions/default/124.sql
+++ b/conf/evolutions/default/124.sql
@@ -1,0 +1,9 @@
+# --- !Ups
+ALTER TABLE user_stat
+    ADD COLUMN accuracy DOUBLE PRECISION,
+    ADD COLUMN exclude_manual BOOLEAN;
+
+# --- !Downs
+ALTER TABLE user_stat
+    DROP COLUMN exclude_manual,
+    DROP COLUMN accuracy;

--- a/conf/evolutions/default/125.sql
+++ b/conf/evolutions/default/125.sql
@@ -1,9 +1,11 @@
 # --- !Ups
 ALTER TABLE user_stat
+    ADD COLUMN own_labels_validated INTEGER NOT NULL DEFAULT 0,
     ADD COLUMN accuracy DOUBLE PRECISION,
     ADD COLUMN exclude_manual BOOLEAN;
 
 # --- !Downs
 ALTER TABLE user_stat
     DROP COLUMN exclude_manual,
-    DROP COLUMN accuracy;
+    DROP COLUMN accuracy,
+    DROP COLUMN own_labels_validated;


### PR DESCRIPTION
Resolves #2698

We are now including accuracy as determined by user validations into our heuristics for determining the quality of users' work. This is used primarily for routing right now. The new heuristic is that a user's data is considered "high quality" if they have a labeling frequency of at least 3.75 labels per 100 meters AND an accuracy of at least 60%. If less than 50 of the user's labels have been validated, then we revert to just the labeling frequency heuristic.

The new `accuracy` column of the `user_stat` table is being updated in real time as validations come in, but the `high_quality` column is only being updated nightly because it would require other things to update in real time as well.

This also adds a new `exclude_manual` column to the `user_stat` table. This is meant to differentiate between low quality work, and vandalism. If `exclude_manual` is set to TRUE, users data is ignored when it comes to street auditing priority and those users will not show up on the leaderboard.

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've added/updated comments for large or confusing blocks of code.
