### PR TITLE
2526 long usernames get cut off on mobile

### DIFF
--- a/public/javascripts/SVValidate/mobile/mobileValidate.css
+++ b/public/javascripts/SVValidate/mobile/mobileValidate.css
@@ -289,7 +289,7 @@ html {
 
 .gray-button-mobile {
     position: relative;
-    background-color: rgba(251, 215, 139, 1);
+    background-color: #fbd78b;
     -moz-border-radius:15px;
     -webkit-border-radius:15px;
     border-radius:10px;
@@ -305,8 +305,8 @@ html {
     text-align: center;
     font-weight: bolder;
     font-size:40px;
-    width: 250px;
-    height: 75px;
+    /* width: 250px;
+    height: 75px; */
     padding:5px 25px;
     text-decoration:none;
     transition: border-color 0.4s ease 0s, background-color 0.4s ease 0s;


### PR DESCRIPTION
- fixes long issue on mobile with long usernames getting cutoff.
- removed width and height properties, because by default they will adjust to the length of the username.

A problem that could arise with this is if someone chooses a huge username like 30+ characters, which is highly unlikely.

Resolves #2526 



##### Before/After screenshots (if applicable)

Before:
![f1](https://user-images.githubusercontent.com/41341006/142562851-aedd6f6e-0c64-4600-84ab-3bf5ea170fc5.PNG)
After:
![f2](https://user-images.githubusercontent.com/41341006/142562862-b61d516d-aa40-4baf-ac69-c53c823e3a6f.PNG)

##### Testing instructions
1. Just comment out the width and height on your localhost of the grey-button-mobile css and see what happens.

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [ ] I've written a descriptive PR title.
- [ ] I've added/updated comments for large or confusing blocks of code.
- [ ] I've included before/after screenshots above.
- [ ] I've asked for and included translations for any user facing text that was added or modified.
- [ ] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure the documentation on [this wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Descriptions-of-Logged-Events) is up to date for the logs you added/updated.
- [ ] I've tested on mobile (only needed for validation page).
