### PR TITLE
2536 Long usernames cut off in mobile

### DIFF
--- a/public/javascripts/SVValidate/mobile/mobileValidate.css
+++ b/public/javascripts/SVValidate/mobile/mobileValidate.css
@@ -305,9 +305,12 @@ html {
     text-align: center;
     font-weight: bolder;
     font-size:40px;
-    width: 250px;
+    max-width: 500px;
     height: 75px;
     padding:5px 25px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
     text-decoration:none;
     transition: border-color 0.4s ease 0s, background-color 0.4s ease 0s;
 }


### PR DESCRIPTION
Resolves #2536 

Users with long (or even medium length) usernames have their name cut off on the mobile validation page when they sign in. 
Fixes include changing the width to max-width so a username can only get so long before getting cut off into ellipses in the button.

##### Before/After screenshots
Before: 
![image](https://user-images.githubusercontent.com/56496451/144527312-ab1b5590-ec76-40f7-b37a-ad6384034d93.png)

After:
![image](https://user-images.githubusercontent.com/56496451/144527356-3e1e62b5-8298-427f-bd4c-784b5b9194b7.png)
![image](https://user-images.githubusercontent.com/56496451/144527376-cc642738-9453-4c78-a270-9c4ed8dd9641.png)
![image](https://user-images.githubusercontent.com/56496451/144527428-f365a505-bb34-488c-b80a-cd6f113a74d9.png)
