### PR TITLE
#2733 new team leaderboard visibility requirements

### DIFF
--- a/app/views/leaderboard.scala.html
+++ b/app/views/leaderboard.scala.html
@@ -1,6 +1,6 @@
 @import models.user._
 
-@(min: Int, user: Option[User] = None, url: Option[String] = Some("/"))(implicit lang: Lang)
+@(min: Int = 1, user: Option[User] = None, url: Option[String] = Some("/"))(implicit lang: Lang)
 
 @leaderboardStats = @{UserStatTable.getLeaderboardStats(10)}
 @leaderboardStatsThisWeek = @{UserStatTable.getLeaderboardStats(10, "weekly")}
@@ -87,7 +87,7 @@
             </table>
         </div>
     </div>
-    @if(leaderboardStatsByOrg.asInstanceOf[List[LeaderboardStat]].length >= 0) {
+    @if(leaderboardStatsByOrg.asInstanceOf[List[LeaderboardStat]].length >= min) {
         <div class="item leaderboard-table">
             <h1 class="leaderboard-header">@Messages("leaderboard.inter.org.title")</h1>
             <h5>@Messages("leaderboard.overall.detail")</h5>


### PR DESCRIPTION
Toggles the team leaderboard's visibility based on whether the team leaderboard has any entries. 

Resolves #2733 

Before fix: 
<img width="1264" alt="Team_Leaderboard_Before" src="https://user-images.githubusercontent.com/29639493/145119160-166263bf-12c1-413c-a152-28dd4f2ed090.png">

After fix:
<img width="1268" alt="Team_Leaderboard_After" src="https://user-images.githubusercontent.com/29639493/145119171-dfafdbbb-777a-4a54-82f3-cc8b5b2a5b18.png">