### PR TITLE
#2644 Tags in Modal dont wrap

### DIFF
--- a/public/javascripts/Gallery/css/cards.css
+++ b/public/javascripts/Gallery/css/cards.css
@@ -143,6 +143,7 @@ with respect to the image holder. This allows the validation menu to be placed o
     align-items: center;
     width: 100%;
     flex-direction: row;
+    flex-wrap: wrap;
 }
 
 .label-tags-content {

--- a/public/javascripts/Gallery/css/modal.css
+++ b/public/javascripts/Gallery/css/modal.css
@@ -108,7 +108,8 @@
 
 .gallery-modal-info-tags {
     width: 60%;
-    height: 40%;
+    height: 5.5vw;
+    overflow-y: auto;
 }
 
 .gallery-modal-info-temporary {

--- a/public/javascripts/Gallery/src/displays/TagDisplay.js
+++ b/public/javascripts/Gallery/src/displays/TagDisplay.js
@@ -75,9 +75,11 @@ function TagDisplay(container, tags, isModal=false) {
                     tagEl.title = tagsText[i];
                 } else {
                     // If the tag does not fit at all, add it to the list of hidden tags to show in the popover.
-                    tagEl.remove();
-                    tagEl.classList.add("not-added");
-                    hiddenTags.push(tagEl);
+                    if (!isModal) {
+                        tagEl.remove();
+                        tagEl.classList.add("not-added");
+                        hiddenTags.push(tagEl);
+                    }
                 }
             }
 


### PR DESCRIPTION
Resolves #2644 

- Gallery tags will wrap to a maximum of two rows. 
- In the case where there are more tags that can fit within two rows, a vertical scrollbar appears. 
- Works on all screen sizes. 

##### Before/After screenshots (if applicable)
Before:
![before](https://user-images.githubusercontent.com/41341006/145266554-e4a5c5b6-d158-42a5-ab1a-80d778bd5760.PNG)
After:
![after](https://user-images.githubusercontent.com/41341006/145266572-959e6f70-cf70-4edb-8a34-67541823bf73.PNG)



##### Testing instructions
1. For testing, add many tags and see if intended functionality works. 
2. Check on many screen sizes.


