### PR TITLE
Adds validation info to public APIs

### DIFF
--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -429,7 +429,7 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
     if (isAdmin(request.identity)) {
       val validationCounts = LabelValidationTable.getValidationCountsPerUser
       val json: JsArray = Json.arr(validationCounts.map(x => Json.obj(
-        "user_id" -> x._1, "role" -> x._2, "count" -> x._4, "agreed" -> x._5
+        "user_id" -> x._1, "role" -> x._2, "count" -> x._3, "agreed" -> x._4
       )))
       Future.successful(Ok(json))
     } else {

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -365,7 +365,7 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
       LabelPointTable.find(labelId) match {
         case Some(labelPointObj) =>
           val userId: String = request.identity.get.userId.toString
-          val labelMetadata: LabelMetadata = LabelTable.getLabelMetadata(labelId, userId)
+          val labelMetadata: LabelMetadata = LabelTable.getSingleLabelMetadata(labelId, userId)
           val labelMetadataJson: JsObject = LabelTable.labelMetadataWithValidationToJsonAdmin(labelMetadata)
           Future.successful(Ok(labelMetadataJson))
         case _ => Future.successful(Ok(Json.obj("error" -> "no such label")))
@@ -382,7 +382,7 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
     LabelPointTable.find(labelId) match {
       case Some(labelPointObj) =>
         val userId: String = request.identity.map(_.userId.toString).getOrElse("")
-        val labelMetadata: LabelMetadata = LabelTable.getLabelMetadata(labelId, userId)
+        val labelMetadata: LabelMetadata = LabelTable.getSingleLabelMetadata(labelId, userId)
         val labelMetadataJson: JsObject = LabelTable.labelMetadataWithValidationToJson(labelMetadata)
         Future.successful(Ok(labelMetadataJson))
       case _ => Future.successful(Ok(Json.obj("error" -> "no such label")))

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -14,7 +14,7 @@ import formats.json.UserRoleSubmissionFormats._
 import models.attribute.{GlobalAttribute, GlobalAttributeTable}
 import models.audit.{AuditTaskInteractionTable, AuditTaskTable, InteractionWithLabel}
 import models.daos.slick.DBTableDefinitions.UserTable
-import models.label.LabelTable.LabelMetadataWithValidation
+import models.label.LabelTable.LabelMetadata
 import models.label.{LabelPointTable, LabelTable, LabelTypeTable, LabelValidationTable}
 import models.mission.MissionTable
 import models.region.RegionCompletionTable
@@ -365,7 +365,7 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
       LabelPointTable.find(labelId) match {
         case Some(labelPointObj) =>
           val userId: String = request.identity.get.userId.toString
-          val labelMetadata: LabelMetadataWithValidation = LabelTable.getLabelMetadata(labelId, userId)
+          val labelMetadata: LabelMetadata = LabelTable.getLabelMetadata(labelId, userId)
           val labelMetadataJson: JsObject = LabelTable.labelMetadataWithValidationToJsonAdmin(labelMetadata)
           Future.successful(Ok(labelMetadataJson))
         case _ => Future.successful(Ok(Json.obj("error" -> "no such label")))
@@ -382,7 +382,7 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
     LabelPointTable.find(labelId) match {
       case Some(labelPointObj) =>
         val userId: String = request.identity.map(_.userId.toString).getOrElse("")
-        val labelMetadata: LabelMetadataWithValidation = LabelTable.getLabelMetadata(labelId, userId)
+        val labelMetadata: LabelMetadata = LabelTable.getLabelMetadata(labelId, userId)
         val labelMetadataJson: JsObject = LabelTable.labelMetadataWithValidationToJson(labelMetadata)
         Future.successful(Ok(labelMetadataJson))
       case _ => Future.successful(Ok(Json.obj("error" -> "no such label")))

--- a/app/controllers/AttributeController.scala
+++ b/app/controllers/AttributeController.scala
@@ -14,7 +14,7 @@ import play.api.mvc._
 import play.api.libs.json.Json
 import formats.json.AttributeFormats
 import models.attribute._
-import models.label.LabelTypeTable
+import models.label.{LabelTable, LabelTypeTable}
 import models.region.RegionTable
 import play.api.Play.current
 import play.api.{Logger, Play}
@@ -211,6 +211,7 @@ class AttributeController @Inject() (implicit val env: Environment[User, Session
                   globalSessionId,
                   thresholds(cluster.labelType),
                   LabelTypeTable.labelTypeToId(cluster.labelType),
+                  LabelTable.getStreetEdgeIdClosestToLatLng(cluster.lat, cluster.lng).get,
                   RegionTable.selectRegionIdOfClosestNeighborhood(cluster.lng, cluster.lat),
                   cluster.lat,
                   cluster.lng,

--- a/app/controllers/LabelController.scala
+++ b/app/controllers/LabelController.scala
@@ -4,7 +4,7 @@ import javax.inject.Inject
 import com.mohiva.play.silhouette.api.{Environment, Silhouette}
 import com.mohiva.play.silhouette.impl.authenticators.SessionAuthenticator
 import controllers.headers.ProvidesHeader
-import formats.json.LabelFormats._
+import formats.json.LabelFormat._
 import models.label._
 import models.user.User
 import play.api.libs.json._
@@ -56,7 +56,7 @@ class LabelController @Inject() (implicit val env: Environment[User, SessionAuth
         val featureCollection: JsObject = Json.obj("labels" -> jsonList)
         Future.successful(Ok(featureCollection))
       case None =>
-        Future.successful(Redirect(s"/anonSignUp?url=/label/currentMission?regionId=$regionId"))
+        Future.successful(Redirect(s"/anonSignUp?url=/label/miniMapResume?regionId=$regionId"))
     }
   }
 

--- a/app/controllers/ProjectSidewalkAPIController.scala
+++ b/app/controllers/ProjectSidewalkAPIController.scala
@@ -119,10 +119,10 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
     if (filetype.isDefined && filetype.get == "csv") {
       val file = new java.io.File("access_attributes_with_labels.csv")
       val writer = new java.io.PrintStream(file)
-      val header: String = "Attribute ID,Label Type,Attribute Severity,Attribute Temporary,Neighborhood Name," +
-        "Label ID,Panorama ID,Attribute Latitude,Attribute Longitude,Label Latitude,Label Longitude,Heading,Pitch," +
-        "Zoom,Canvas X,Canvas Y,Canvas Width,Canvas Height,Label Severity,Label Temporary," +
-        "Agree Count,Disagree Count,Not Sure Count"
+      val header: String = "Attribute ID,Label Type,Attribute Severity,Attribute Temporary,Street ID," +
+        "Neighborhood Name,Label ID,Panorama ID,Attribute Latitude,Attribute Longitude,Label Latitude," +
+        "Label Longitude,Heading,Pitch,Zoom,Canvas X,Canvas Y,Canvas Width,Canvas Height,Label Severity," +
+        "Label Temporary,Agree Count,Disagree Count,Not Sure Count"
       // Write column headers.
       writer.println(header)
       // Write each row in the CSV.
@@ -175,7 +175,7 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
       val accessAttributesfile = new java.io.File("access_attributes.csv")
       val writer = new java.io.PrintStream(accessAttributesfile)
       // Write column headers.
-      writer.println("Attribute ID,Label Type,Neighborhood Name,Attribute Latitude,Attribute Longitude,Severity,Temporary,Agree Count,Disagree Count,Not Sure Count")
+      writer.println("Attribute ID,Label Type,Street ID,Neighborhood Name,Attribute Latitude,Attribute Longitude,Severity,Temporary,Agree Count,Disagree Count,Not Sure Count")
       // Write each rown in the CSV.
       for (current <- GlobalAttributeTable.getGlobalAttributesInBoundingBox(minLat, minLng, maxLat, maxLng, severity)) {
         writer.println(current.attributesToArray.mkString(","))

--- a/app/controllers/ProjectSidewalkAPIController.scala
+++ b/app/controllers/ProjectSidewalkAPIController.scala
@@ -119,9 +119,10 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
     if (filetype.isDefined && filetype.get == "csv") {
       val file = new java.io.File("access_attributes_with_labels.csv")
       val writer = new java.io.PrintStream(file)
-      val header: String = "Neighborhood Name,Region ID,Access Score,Coordinates,Coverage,Average Curb Ramp Score," +
-        "Average No Curb Ramp Score,Average Obstacle Score,Average Surface Problem Score," +
-        "Curb Ramp Significance,No Curb Ramp Significance,Obstacle Significance,Surface Problem Significance"
+      val header: String = "Attribute ID,Label Type,Attribute Severity,Attribute Temporary,Neighborhood Name," +
+        "Label ID,Panorama ID,Attribute Latitude,Attribute Longitude,Label Latitude,Label Longitude,Heading,Pitch," +
+        "Zoom,Canvas X,Canvas Y,Canvas Width,Canvas Height,Label Severity,Label Temporary," +
+        "Agree Count,Disagree Count,Not Sure Count"
       // Write column headers.
       writer.println(header)
       // Write each row in the CSV.
@@ -174,7 +175,7 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
       val accessAttributesfile = new java.io.File("access_attributes.csv")
       val writer = new java.io.PrintStream(accessAttributesfile)
       // Write column headers.
-      writer.println("Attribute ID,Label Type,Neighborhood Name,Attribute Latitude,Attribute Longitude,Severity,Temporary")
+      writer.println("Attribute ID,Label Type,Neighborhood Name,Attribute Latitude,Attribute Longitude,Severity,Temporary,Agree Count,Disagree Count,Not Sure Count")
       // Write each rown in the CSV.
       for (current <- GlobalAttributeTable.getGlobalAttributesInBoundingBox(minLat, minLng, maxLat, maxLng, severity)) {
         writer.println(current.attributesToArray.mkString(","))

--- a/app/controllers/TaskController.scala
+++ b/app/controllers/TaskController.scala
@@ -301,7 +301,7 @@ class TaskController @Inject() (implicit val env: Environment[User, SessionAuthe
             LabelTable.save(Label(0, auditTaskId, missionId, label.gsvPanoramaId, labelTypeId,
               label.photographerHeading, label.photographerPitch, label.panoramaLat,
               label.panoramaLng, label.deleted.value, label.temporaryLabelId, timeCreated,
-              label.tutorial, calculatedStreetEdgeId))
+              label.tutorial, calculatedStreetEdgeId, 0, 0, 0, None))
         }
 
         // Insert label points.

--- a/app/controllers/ValidationTaskController.scala
+++ b/app/controllers/ValidationTaskController.scala
@@ -56,7 +56,7 @@ class ValidationTaskController @Inject() (implicit val env: Environment[User, Se
       for (label: LabelValidationSubmission <- data.labels) {
         userOption match {
           case Some(user) =>
-            LabelValidationTable.save(LabelValidation(0, label.labelId, label.validationResult,
+            LabelValidationTable.insertOrUpdate(LabelValidation(0, label.labelId, label.validationResult,
               user.userId.toString, label.missionId, label.canvasX, label.canvasY, label.heading,
               label.pitch, label.zoom, label.canvasHeight, label.canvasWidth,
               new Timestamp(label.startTimestamp), new Timestamp(label.endTimestamp), label.isMobile))

--- a/app/controllers/helper/ShapefilesCreatorHelper.java
+++ b/app/controllers/helper/ShapefilesCreatorHelper.java
@@ -99,10 +99,10 @@ public class ShapefilesCreatorHelper {
                         + "labelType:String," // Label type
                         + "neighborhd:String," // Neighborhood Name
                         + "severity:Integer," // Severity
+                        + "temporary:Boolean," // Temporary flag
                         + "nAgree:Integer," // Agree validations
                         + "nDisagree:Integer," // Disagree validations
-                        + "nNotsure:Integer," // Notsure validations
-                        + "temporary:Boolean" // Temporary flag
+                        + "nNotsure:Integer" // Notsure validations
                 );
 
         /*
@@ -129,10 +129,10 @@ public class ShapefilesCreatorHelper {
                     return null;
                 }
             }));
+            featureBuilder.add(a.temporary());
             featureBuilder.add(a.agreeCount());
             featureBuilder.add(a.disagreeCount());
             featureBuilder.add(a.notsureCount());
-            featureBuilder.add(a.temporary());
             SimpleFeature feature = featureBuilder.buildFeature(null);
             features.add(feature);
         }
@@ -164,9 +164,9 @@ public class ShapefilesCreatorHelper {
                         + "canvasX:Integer," // canvasX position of panorama
                         + "canvasY:Integer," // canvasY position of panorama
                         + "canvasWdth:Integer," // width of source viewfinder
-                        + "canvasHght:Integer" // height of source viewfinder
-                        + "nAgree:Integer" // Agree validations
-                        + "nDisagree:Integer" // Disagree validations
+                        + "canvasHght:Integer," // height of source viewfinder
+                        + "nAgree:Integer," // Agree validations
+                        + "nDisagree:Integer," // Disagree validations
                         + "nNotsure:Integer" // Notsure validations
                 );
 

--- a/app/controllers/helper/ShapefilesCreatorHelper.java
+++ b/app/controllers/helper/ShapefilesCreatorHelper.java
@@ -202,8 +202,8 @@ public class ShapefilesCreatorHelper {
             featureBuilder.add(l.heading());
             featureBuilder.add(l.pitch());
             featureBuilder.add(l.zoom());
-            featureBuilder.add(l.canvasXY()(1));
-            featureBuilder.add(l.canvasXY()(2));
+            featureBuilder.add(l.canvasXY()._1);
+            featureBuilder.add(l.canvasXY()._2);
             featureBuilder.add(l.canvasWidth());
             featureBuilder.add(l.canvasHeight());
             featureBuilder.add(l.agreeCount());

--- a/app/controllers/helper/ShapefilesCreatorHelper.java
+++ b/app/controllers/helper/ShapefilesCreatorHelper.java
@@ -101,7 +101,7 @@ public class ShapefilesCreatorHelper {
                         + "severity:Integer," // Severity
                         + "nAgree:Integer," // Agree validations
                         + "nDisagree:Integer," // Disagree validations
-                        + "nNotSure:Integer," // NotSure validations
+                        + "nNotsure:Integer," // Notsure validations
                         + "temporary:Boolean" // Temporary flag
                 );
 
@@ -165,6 +165,9 @@ public class ShapefilesCreatorHelper {
                         + "canvasY:Integer," // canvasY position of panorama
                         + "canvasWdth:Integer," // width of source viewfinder
                         + "canvasHght:Integer" // height of source viewfinder
+                        + "nAgree:Integer" // Agree validations
+                        + "nDisagree:Integer" // Disagree validations
+                        + "nNotsure:Integer" // Notsure validations
                 );
 
 
@@ -199,10 +202,13 @@ public class ShapefilesCreatorHelper {
             featureBuilder.add(l.heading());
             featureBuilder.add(l.pitch());
             featureBuilder.add(l.zoom());
-            featureBuilder.add(l.canvasX());
-            featureBuilder.add(l.canvasY());
+            featureBuilder.add(l.canvasXY()(1));
+            featureBuilder.add(l.canvasXY()(2));
             featureBuilder.add(l.canvasWidth());
             featureBuilder.add(l.canvasHeight());
+            featureBuilder.add(l.agreeCount());
+            featureBuilder.add(l.disagreeCount());
+            featureBuilder.add(l.notsureCount());
             SimpleFeature feature = featureBuilder.buildFeature(null);
             features.add(feature);
         }

--- a/app/controllers/helper/ShapefilesCreatorHelper.java
+++ b/app/controllers/helper/ShapefilesCreatorHelper.java
@@ -99,6 +99,9 @@ public class ShapefilesCreatorHelper {
                         + "labelType:String," // Label type
                         + "neighborhd:String," // Neighborhood Name
                         + "severity:Integer," // Severity
+                        + "nAgree:Integer," // Agree validations
+                        + "nDisagree:Integer," // Disagree validations
+                        + "nNotSure:Integer," // NotSure validations
                         + "temporary:Boolean" // Temporary flag
                 );
 
@@ -126,6 +129,9 @@ public class ShapefilesCreatorHelper {
                     return null;
                 }
             }));
+            featureBuilder.add(a.agreeCount());
+            featureBuilder.add(a.disagreeCount());
+            featureBuilder.add(a.notsureCount());
             featureBuilder.add(a.temporary());
             SimpleFeature feature = featureBuilder.buildFeature(null);
             features.add(feature);

--- a/app/controllers/helper/ShapefilesCreatorHelper.java
+++ b/app/controllers/helper/ShapefilesCreatorHelper.java
@@ -97,6 +97,7 @@ public class ShapefilesCreatorHelper {
                         "the_geom:Point:srid=4326," // the geometry attribute: Point type
                         + "id:Integer," // a attribute ID
                         + "labelType:String," // Label type
+                        + "streetId:Integer," // Street edge ID of the nearest street
                         + "neighborhd:String," // Neighborhood Name
                         + "severity:Integer," // Severity
                         + "temporary:Boolean," // Temporary flag
@@ -122,6 +123,7 @@ public class ShapefilesCreatorHelper {
             featureBuilder.add(geometryFactory.createPoint(new Coordinate(a.lng(), a.lat())));
             featureBuilder.add(a.globalAttributeId());
             featureBuilder.add(a.labelType());
+            featureBuilder.add(a.streetEdgeId());
             featureBuilder.add(a.neighborhoodName());
             featureBuilder.add(a.severity().getOrElse(new AbstractFunction0<Integer>() {
                 @Override
@@ -154,6 +156,7 @@ public class ShapefilesCreatorHelper {
                         + "labelId:Integer," // label ID
                         + "attribId:Integer," // attribute ID
                         + "labelType:String," // Label type
+                        + "streetId:Integer," // Street edge ID of the nearest street
                         + "neighborhd:String," // Neighborhood Name
                         + "severity:Integer," // Severity
                         + "temporary:Boolean," // Temporary flag
@@ -186,10 +189,11 @@ public class ShapefilesCreatorHelper {
         SimpleFeatureBuilder featureBuilder = new SimpleFeatureBuilder(TYPE);
 
         for(GlobalAttributeWithLabelForAPI l : labels){
-            featureBuilder.add(geometryFactory.createPoint(new Coordinate((double) l.labelLng(), (double) l.labelLat())));
+            featureBuilder.add(geometryFactory.createPoint(new Coordinate(Double.parseDouble(l.labelLatLng()._2.toString()), Double.parseDouble(l.labelLatLng()._1.toString()))));
             featureBuilder.add(l.labelId());
             featureBuilder.add(l.globalAttributeId());
             featureBuilder.add(l.labelType());
+            featureBuilder.add(l.streetEdgeId());
             featureBuilder.add(l.neighborhoodName());
             featureBuilder.add(l.labelSeverity().getOrElse(new AbstractFunction0<Integer>() {
                 @Override

--- a/app/formats/json/LabelFormat.scala
+++ b/app/formats/json/LabelFormat.scala
@@ -6,20 +6,7 @@ import models.label._
 import play.api.libs.json._
 import play.api.libs.functional.syntax._
 
-object LabelFormats {
-//  implicit val labelReads: Reads[Label] = (
-//    (JsPath \ "label_id").read[Int] and
-//      (JsPath \ "audit_task_id").readNullable[Int] and
-//      (JsPath \ "gsv_panorama_id").read[String] and
-//      (JsPath \ "label_type_id").read[Int] and
-//      (JsPath \ "photographer_heading").read[Float] and
-//      (JsPath \ "photographer_pitch").read[Float] and
-//      (JsPath \ "panorama_lat").read[Float] and
-//      (JsPath \ "panorama_lng").read[Float] and
-//      (JsPath \ "deleted").read[Boolean] and
-//      (JsPath \ "temporary_label_id").readNullable[Int]
-//    )(Label.apply _)
-
+object LabelFormat {
   implicit val labelWrites: Writes[Label] = (
     (__ \ "label_id").write[Int] and
       (__ \ "audit_task_id").write[Int] and
@@ -34,7 +21,11 @@ object LabelFormats {
       (__ \ "temporary_label_id").writeNullable[Int] and
       (__ \ "time_created").writeNullable[Timestamp] and
       (__ \ "tutorial").write[Boolean] and
-      (__ \ "street_edge_id").write[Int]
+      (__ \ "street_edge_id").write[Int] and
+      (__ \ "agree_count").write[Int] and
+      (__ \ "disagree_count").write[Int] and
+      (__ \ "notsure_count").write[Int] and
+      (__ \ "correct").writeNullable[Boolean]
     )(unlift(Label.unapply _))
 
 }

--- a/app/models/attribute/GlobalAttributeTable.scala
+++ b/app/models/attribute/GlobalAttributeTable.scala
@@ -60,8 +60,11 @@ case class GlobalAttributeWithLabelForAPI(val globalAttributeId: Int,
                                           val heading: Float,
                                           val pitch: Float,
                                           val zoom: Int,
-                                          val canvasX: Int, val canvasY: Int,
+                                          val canvasXY: (Int, Int),
                                           val canvasWidth: Int, val canvasHeight: Int,
+                                          val agreeCount: Int,
+                                          val disagreeCount: Int,
+                                          val notsureCount: Int,
                                           val labelSeverity: Option[Int],
                                           val labelTemporary: Boolean) {
   def toJSON: JsObject = {
@@ -80,10 +83,13 @@ case class GlobalAttributeWithLabelForAPI(val globalAttributeId: Int,
         "heading" -> heading,
         "pitch" -> pitch,
         "zoom" -> zoom,
-        "canvas_x" -> canvasX,
-        "canvas_y" -> canvasY,
+        "canvas_x" -> canvasXY._1,
+        "canvas_y" -> canvasXY._2,
         "canvas_width" -> canvasWidth,
         "canvas_height" -> canvasHeight,
+        "agree_count" -> agreeCount,
+        "disagree_count" -> disagreeCount,
+        "notsure_count" -> notsureCount,
         "label_severity" -> labelSeverity,
         "label_is_temporary" -> labelTemporary
       )
@@ -193,19 +199,19 @@ object GlobalAttributeTable {
     } yield (
       _ga.globalAttributeId, _lt.labelType, _ga.lat, _ga.lng, _ga.severity, _ga.temporary, _r.description, _l.labelId,
       _lp.lat, _lp.lng, _l.gsvPanoramaId, _lp.heading, _lp.pitch, _lp.zoom,
-      _lp.canvasX, _lp.canvasY, _lp.canvasWidth, _lp.canvasHeight
+      (_lp.canvasX, _lp.canvasY), _lp.canvasWidth, _lp.canvasHeight, _l.agreeCount, _l.disagreeCount, _l.notsureCount
     )
 
     val withSeverity = for {
       (_l, _s) <- attributesWithLabels.leftJoin(LabelSeverityTable.labelSeverities).on(_._8 === _.labelId)
-    } yield (_l._1, _l._2, _l._3, _l._4, _l._5, _l._6, _l._7, _l._8, _l._9, _l._10, _l._11, _l._12, _l._13, _l._14, _l._15, _l._16, _l._17, _l._18, _s.severity.?)
+    } yield (_l._1, _l._2, _l._3, _l._4, _l._5, _l._6, _l._7, _l._8, _l._9, _l._10, _l._11, _l._12, _l._13, _l._14, _l._15, _l._16, _l._17, _l._18, _l.19, _l.20, _s.severity.?)
 
     val withTemporary = for {
       (_l, _t) <- withSeverity.leftJoin(LabelTemporarinessTable.labelTemporarinesses).on(_._8 === _.labelId)
-    } yield (_l._1, _l._2, _l._3, _l._4, _l._5, _l._6, _l._7, _l._8, _l._9, _l._10, _l._11, _l._12, _l._13, _l._14, _l._15, _l._16, _l._17, _l._18, _l._19, _t.temporary.?)
+    } yield (_l._1, _l._2, _l._3, _l._4, _l._5, _l._6, _l._7, _l._8, _l._9, _l._10, _l._11, _l._12, _l._13, _l._14, _l._15, _l._16, _l._17, _l._18, _l._19, _l.20, _l.21, _t.temporary.?)
 
     withTemporary.list.map(a =>
-      GlobalAttributeWithLabelForAPI(a._1, a._2, a._3, a._4, a._5, a._6, a._7, a._8, a._9.get, a._10.get, a._11, a._12, a._13, a._14, a._15, a._16, a._17, a._18, a._19, a._20.getOrElse(false))
+      GlobalAttributeWithLabelForAPI(a._1, a._2, a._3, a._4, a._5, a._6, a._7, a._8, a._9.get, a._10.get, a._11, a._12, a._13, a._14, a._15, a._16, a._17, a._18, a._19, a._20, a._21, _a.22.getOrElse(false))
     )
   }
 

--- a/app/models/attribute/GlobalAttributeTable.scala
+++ b/app/models/attribute/GlobalAttributeTable.scala
@@ -44,8 +44,9 @@ case class GlobalAttributeForAPI(val globalAttributeId: Int,
       )
     )
   }
-  val attributesToArray = Array(globalAttributeId, labelType, neighborhoodName,
-                                lat.toString, lng.toString, severity.getOrElse("NA").toString, temporary.toString)
+  val attributesToArray = Array(globalAttributeId, labelType, neighborhoodName, lat.toString, lng.toString,
+                                severity.getOrElse("NA").toString, temporary.toString, agreeCount.toString,
+                                disagreeCount.toString, notsureCount.toString)
 }
 
 case class GlobalAttributeWithLabelForAPI(val globalAttributeId: Int,
@@ -87,11 +88,11 @@ case class GlobalAttributeWithLabelForAPI(val globalAttributeId: Int,
         "canvas_y" -> canvasXY._2,
         "canvas_width" -> canvasWidth,
         "canvas_height" -> canvasHeight,
+        "label_severity" -> labelSeverity,
+        "label_is_temporary" -> labelTemporary,
         "agree_count" -> agreeCount,
         "disagree_count" -> disagreeCount,
-        "notsure_count" -> notsureCount,
-        "label_severity" -> labelSeverity,
-        "label_is_temporary" -> labelTemporary
+        "notsure_count" -> notsureCount
       )
     )
   }
@@ -100,7 +101,8 @@ case class GlobalAttributeWithLabelForAPI(val globalAttributeId: Int,
                                 attributeLat.toString, attributeLng.toString, labelLat.toString, labelLng.toString,
                                 heading.toString, pitch.toString, zoom.toString, canvasXY._1.toString,
                                 canvasXY._2.toString, canvasWidth.toString, canvasHeight.toString,
-                                attributeSeverity.getOrElse("NA").toString, labelTemporary.toString)
+                                labelSeverity.getOrElse("NA").toString, labelTemporary.toString,
+                                agreeCount.toString, disagreeCount.toString, notsureCount.toString)
 }
 
 class GlobalAttributeTable(tag: Tag) extends Table[GlobalAttribute](tag, Some("sidewalk"), "global_attribute") {

--- a/app/models/attribute/GlobalAttributeTable.scala
+++ b/app/models/attribute/GlobalAttributeTable.scala
@@ -166,6 +166,7 @@ object GlobalAttributeTable {
     * Gets global attributes within a bounding box for the public API.
     */
   def getGlobalAttributesInBoundingBox(minLat: Float, minLng: Float, maxLat: Float, maxLng: Float, severity: Option[String]): List[GlobalAttributeForAPI] = db.withSession { implicit session =>
+    // Sums the validations counts of the labels that make up each global attribute.
     val validationCounts = (for {
       _ga <- globalAttributes
       _gaua <- GlobalAttributeUserAttributeTable.globalAttributeUserAttributes if _ga.globalAttributeId === _gaua.globalAttributeId

--- a/app/models/attribute/GlobalAttributeTable.scala
+++ b/app/models/attribute/GlobalAttributeTable.scala
@@ -14,6 +14,7 @@ case class GlobalAttribute(globalAttributeId: Int,
                            globalClusteringSessionId: Int,
                            clusteringThreshold: Float,
                            labelTypeId: Int,
+                           streetEdgeId: Int,
                            regionId: Int,
                            lat: Float, lng: Float,
                            severity: Option[Int],
@@ -27,6 +28,7 @@ case class GlobalAttributeForAPI(val globalAttributeId: Int,
                                  val agreeCount: Int,
                                  val disagreeCount: Int,
                                  val notsureCount: Int,
+                                 val streetEdgeId: Int,
                                  val neighborhoodName: String) {
   def toJSON: JsObject = {
     Json.obj(
@@ -35,6 +37,7 @@ case class GlobalAttributeForAPI(val globalAttributeId: Int,
       "properties" -> Json.obj(
         "attribute_id" -> globalAttributeId,
         "label_type" -> labelType,
+        "street_edge_id" -> streetEdgeId,
         "neighborhood" -> neighborhoodName,
         "severity" -> severity,
         "is_temporary" -> temporary,
@@ -44,19 +47,20 @@ case class GlobalAttributeForAPI(val globalAttributeId: Int,
       )
     )
   }
-  val attributesToArray = Array(globalAttributeId, labelType, neighborhoodName, lat.toString, lng.toString,
-                                severity.getOrElse("NA").toString, temporary.toString, agreeCount.toString,
-                                disagreeCount.toString, notsureCount.toString)
+  val attributesToArray = Array(globalAttributeId, labelType, streetEdgeId, neighborhoodName, lat.toString,
+                                lng.toString, severity.getOrElse("NA").toString, temporary.toString,
+                                agreeCount.toString, disagreeCount.toString, notsureCount.toString)
 }
 
 case class GlobalAttributeWithLabelForAPI(val globalAttributeId: Int,
                                           val labelType: String,
-                                          val attributeLat: Float, val attributeLng: Float,
+                                          val attributeLatLng: (Float, Float),
                                           val attributeSeverity: Option[Int],
                                           val attributeTemporary: Boolean,
+                                          val streetEdgeId: Int,
                                           val neighborhoodName: String,
                                           val labelId: Int,
-                                          val labelLat: Float, labelLng: Float,
+                                          val labelLatLng: (Float, Float),
                                           val gsvPanoramaId: String,
                                           val heading: Float,
                                           val pitch: Float,
@@ -71,11 +75,12 @@ case class GlobalAttributeWithLabelForAPI(val globalAttributeId: Int,
   def toJSON: JsObject = {
     Json.obj(
       "type" -> "Feature",
-      "geometry" -> geojson.Point(geojson.LatLng(attributeLat.toDouble, attributeLng.toDouble)),
-      "label_geometry" -> geojson.Point(geojson.LatLng(labelLat.toDouble, labelLng.toDouble)),
+      "geometry" -> geojson.Point(geojson.LatLng(attributeLatLng._1.toDouble, attributeLatLng._2.toDouble)),
+      "label_geometry" -> geojson.Point(geojson.LatLng(labelLatLng._1.toDouble, labelLatLng._2.toDouble)),
       "properties" -> Json.obj(
         "attribute_id" -> globalAttributeId,
         "label_type" -> labelType,
+        "street_edge_id" -> streetEdgeId,
         "neighborhood" -> neighborhoodName,
         "severity" -> attributeSeverity,
         "is_temporary" -> attributeTemporary,
@@ -97,11 +102,11 @@ case class GlobalAttributeWithLabelForAPI(val globalAttributeId: Int,
     )
   }
   val attributesToArray = Array(globalAttributeId.toString, labelType, attributeSeverity.getOrElse("NA").toString,
-                                attributeTemporary.toString, neighborhoodName, labelId.toString, gsvPanoramaId,
-                                attributeLat.toString, attributeLng.toString, labelLat.toString, labelLng.toString,
-                                heading.toString, pitch.toString, zoom.toString, canvasXY._1.toString,
-                                canvasXY._2.toString, canvasWidth.toString, canvasHeight.toString,
-                                labelSeverity.getOrElse("NA").toString, labelTemporary.toString,
+                                attributeTemporary.toString, streetEdgeId.toString, neighborhoodName, labelId.toString,
+                                gsvPanoramaId, attributeLatLng._1.toString, attributeLatLng._2.toString,
+                                labelLatLng._1.toString, labelLatLng._2.toString, heading.toString, pitch.toString,
+                                zoom.toString, canvasXY._1.toString, canvasXY._2.toString, canvasWidth.toString,
+                                canvasHeight.toString, labelSeverity.getOrElse("NA").toString, labelTemporary.toString,
                                 agreeCount.toString, disagreeCount.toString, notsureCount.toString)
 }
 
@@ -110,6 +115,7 @@ class GlobalAttributeTable(tag: Tag) extends Table[GlobalAttribute](tag, Some("s
   def globalClusteringSessionId: Column[Int] = column[Int]("global_clustering_session_id", O.NotNull)
   def clusteringThreshold: Column[Float] = column[Float]("clustering_threshold", O.NotNull)
   def labelTypeId: Column[Int] = column[Int]("label_type_id", O.NotNull)
+  def streetEdgeId: Column[Int] = column[Int]("street_edge_id", O.NotNull)
   def regionId: Column[Int] = column[Int]("region_id", O.NotNull)
   def lat: Column[Float] = column[Float]("lat", O.NotNull)
   def lng: Column[Float] = column[Float]("lng", O.NotNull)
@@ -120,6 +126,7 @@ class GlobalAttributeTable(tag: Tag) extends Table[GlobalAttribute](tag, Some("s
                                           globalClusteringSessionId,
                                           clusteringThreshold,
                                           labelTypeId,
+                                          streetEdgeId,
                                           regionId,
                                           lat, lng,
                                           severity,
@@ -179,7 +186,7 @@ object GlobalAttributeTable {
       if _lt.labelType =!= "Problem"
     } yield (
       _ga.globalAttributeId, _lt.labelType, _ga.lat, _ga.lng, _ga.severity, _ga.temporary,
-      _vc._2.getOrElse(0), _vc._3.getOrElse(0), _vc._4.getOrElse(0), _r.description
+      _vc._2.getOrElse(0), _vc._3.getOrElse(0), _vc._4.getOrElse(0), _ga.streetEdgeId, _r.description
     )
     attributes.list.map(GlobalAttributeForAPI.tupled)
   }
@@ -199,21 +206,21 @@ object GlobalAttributeTable {
       _lp <- LabelTable.labelPoints if _l.labelId === _lp.labelId
       if _lt.labelType =!= "Problem"
     } yield (
-      _ga.globalAttributeId, _lt.labelType, _ga.lat, _ga.lng, _ga.severity, _ga.temporary, _r.description, _l.labelId,
-      _lp.lat, _lp.lng, _l.gsvPanoramaId, _lp.heading, _lp.pitch, _lp.zoom,
+      _ga.globalAttributeId, _lt.labelType, (_ga.lat, _ga.lng), _ga.severity, _ga.temporary, _ga.streetEdgeId,
+      _r.description, _l.labelId, (_lp.lat, _lp.lng), _l.gsvPanoramaId, _lp.heading, _lp.pitch, _lp.zoom,
       (_lp.canvasX, _lp.canvasY), _lp.canvasWidth, _lp.canvasHeight, _l.agreeCount, _l.disagreeCount, _l.notsureCount
     )
 
     val withSeverity = for {
       (_l, _s) <- attributesWithLabels.leftJoin(LabelSeverityTable.labelSeverities).on(_._8 === _.labelId)
-    } yield (_l._1, _l._2, _l._3, _l._4, _l._5, _l._6, _l._7, _l._8, _l._9, _l._10, _l._11, _l._12, _l._13, _l._14, _l._15, _l._16, _l._17, _l._18, _l._19, _l._20, _s.severity.?)
+    } yield (_l._1, _l._2, _l._3, _l._4, _l._5, _l._6, _l._7, _l._8, _l._9, _l._10, _l._11, _l._12, _l._13, _l._14, _l._15, _l._16, _l._17, _l._18, _l._19, _s.severity.?)
 
     val withTemporary = for {
       (_l, _t) <- withSeverity.leftJoin(LabelTemporarinessTable.labelTemporarinesses).on(_._8 === _.labelId)
-    } yield (_l._1, _l._2, _l._3, _l._4, _l._5, _l._6, _l._7, _l._8, _l._9, _l._10, _l._11, _l._12, _l._13, _l._14, _l._15, _l._16, _l._17, _l._18, _l._19, _l._20, _l._21, _t.temporary.?)
+    } yield (_l._1, _l._2, _l._3, _l._4, _l._5, _l._6, _l._7, _l._8, _l._9, _l._10, _l._11, _l._12, _l._13, _l._14, _l._15, _l._16, _l._17, _l._18, _l._19, _l._20, _t.temporary.?)
 
     withTemporary.list.map(a =>
-      GlobalAttributeWithLabelForAPI(a._1, a._2, a._3, a._4, a._5, a._6, a._7, a._8, a._9.get, a._10.get, a._11, a._12, a._13, a._14, a._15, a._16, a._17, a._18, a._19, a._20, a._21, a._22.getOrElse(false))
+      GlobalAttributeWithLabelForAPI(a._1, a._2, a._3, a._4, a._5, a._6, a._7, a._8, (a._9._1.get, a._9._2.get), a._10, a._11, a._12, a._13, a._14, a._15, a._16, a._17, a._18, a._19, a._20, a._21.getOrElse(false))
     )
   }
 

--- a/app/models/attribute/UserClusteringSessionTable.scala
+++ b/app/models/attribute/UserClusteringSessionTable.scala
@@ -1,6 +1,5 @@
 package models.attribute
 
-import models.audit.AuditTaskTable
 import models.daos.slick.DBTableDefinitions.{DBUser, UserTable}
 import models.label.{LabelTable, LabelTemporarinessTable, LabelTypeTable}
 import models.mission.MissionTable

--- a/app/models/attribute/UserClusteringSessionTable.scala
+++ b/app/models/attribute/UserClusteringSessionTable.scala
@@ -2,7 +2,9 @@ package models.attribute
 
 import models.audit.AuditTaskTable
 import models.daos.slick.DBTableDefinitions.{DBUser, UserTable}
-import models.label.{LabelTable, LabelTypeTable, LabelTemporarinessTable}
+import models.label.{LabelTable, LabelTemporarinessTable, LabelTypeTable}
+import models.mission.MissionTable
+import models.region.RegionTable
 import models.utils.MyPostgresDriver.simple._
 import play.api.Play.current
 import play.api.db.slick
@@ -68,11 +70,13 @@ object UserClusteringSessionTable {
 
     // Gets all non-deleted, non-tutorial labels placed by the specified user.
     val labels = for {
-      _task <- AuditTaskTable.auditTasks if _task.userId === userId
-      _lab <- LabelTable.labelsWithoutDeletedOrOnboarding if _lab.auditTaskId === _task.auditTaskId
+      _mission <- MissionTable.missions if _mission.userId === userId
+      _region <- RegionTable.regions if _mission.regionId === _region.regionId
+      _lab <- LabelTable.labelsWithoutDeletedOrOnboarding if _lab.missionId === _mission.missionId
       _latlng <- LabelTable.labelPoints if _lab.labelId === _latlng.labelId
       _type <- LabelTable.labelTypes if _lab.labelTypeId === _type.labelTypeId
-    } yield (_task.userId, _lab.labelId, _type.labelType, _latlng.lat, _latlng.lng)
+      if _region.deleted === false
+    } yield (_mission.userId, _lab.labelId, _type.labelType, _latlng.lat, _latlng.lng)
 
     // Left joins to get severity for any labels that have them.
     val labelsWithSeverity = for {

--- a/app/models/daos/slick/UserDAOSlick.scala
+++ b/app/models/daos/slick/UserDAOSlick.scala
@@ -499,9 +499,9 @@ object UserDAOSlick {
       AuditTaskTable.auditTasks.innerJoin(LabelTable.labelsWithoutDeleted).on(_.auditTaskId === _.auditTaskId)
         .groupBy(_._1.userId).map { case (_userId, group) => (_userId, group.length) }.list.toMap
 
-    // Map(user_id: String -> (role: String, distinct: Int, total: Int, agreed: Int, disagreed: Int, unsure: Int)).
+    // Map(user_id: String -> (role: String, total: Int, agreed: Int, disagreed: Int, unsure: Int)).
     val validatedCounts = LabelValidationTable.getValidationCountsPerUser.map { valCount =>
-      (valCount._1, (valCount._2, valCount._3, valCount._4, valCount._5, valCount._6, valCount._7))
+      (valCount._1, (valCount._2, valCount._3, valCount._4, valCount._5, valCount._6))
     }.toMap
 
     // Map(user_id: String -> (count: Int, agreed: Int)).
@@ -511,12 +511,11 @@ object UserDAOSlick {
 
     // Now left join them all together and put into UserStatsForAdminPage objects.
     usersMinusAnonUsersWithNoLabels.list.map{ u =>
-      val ownValidatedCounts = validatedCounts.getOrElse(u.userId, ("", 0, 0, 0, 0, 0))
-      val ownValidatedDistinct = ownValidatedCounts._2
-      val ownValidatedTotal = ownValidatedCounts._3
-      val ownValidatedAgreed = ownValidatedCounts._4
-      val ownValidatedDisagreed = ownValidatedCounts._5
-      val ownValidatedUnsure = ownValidatedCounts._6
+      val ownValidatedCounts = validatedCounts.getOrElse(u.userId, ("", 0, 0, 0, 0))
+      val ownValidatedTotal = ownValidatedCounts._2
+      val ownValidatedAgreed = ownValidatedCounts._3
+      val ownValidatedDisagreed = ownValidatedCounts._4
+      val ownValidatedUnsure = ownValidatedCounts._5
 
       val otherValidatedCounts = othersValidatedCounts.getOrElse(u.userId, (0, 0))
       val otherValidatedTotal = otherValidatedCounts._1
@@ -546,7 +545,7 @@ object UserDAOSlick {
         missionCounts.getOrElse(u.userId, 0),
         auditCounts.getOrElse(u.userId, 0),
         labelCounts.getOrElse(u.userId, 0),
-        ownValidatedDistinct,
+        ownValidatedTotal,
         ownValidatedAgreedPct,
         ownValidatedDisagreedPct,
         ownValidatedUnsurePct,

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -1413,12 +1413,9 @@ object LabelTable {
     // Get set of deprioritized labels (to not show) by filtering out those that have been validated as "disagree" 3 or
     // more times and have twice as many disagrees as agrees.
     Q.queryNA[(Int)](
-      """SELECT label.label_id
+      """SELECT label_id
         |FROM label
-        |INNER JOIN label_validation ON label.label_id = label_validation.label_id
-        |GROUP BY label.label_id
-        |HAVING COUNT(CASE WHEN validation_result = 2 THEN 1 END) > 2 
-        |   AND COUNT(CASE WHEN validation_result = 2 THEN 1 END) >= (2 * COUNT(CASE WHEN validation_result = 1 THEN 1 END))""".stripMargin
+        |WHERE disagree_count > 2 AND disagree_count >= 2 * agree_count""".stripMargin
     ).list.toSet
   }
 }

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -33,7 +33,11 @@ case class Label(labelId: Int,
                  temporaryLabelId: Option[Int],
                  timeCreated: Option[Timestamp],
                  tutorial: Boolean,
-                 streetEdgeId: Int)
+                 streetEdgeId: Int,
+                 agreeCount: Int,
+                 disagreeCount: Int,
+                 notsureCount: Int,
+                 correct: Option[Boolean])
 
 case class LabelLocation(labelId: Int,
                          auditTaskId: Int,
@@ -66,9 +70,14 @@ class LabelTable(tag: slick.lifted.Tag) extends Table[Label](tag, Some("sidewalk
   def timeCreated = column[Option[Timestamp]]("time_created", O.Nullable)
   def tutorial = column[Boolean]("tutorial", O.NotNull)
   def streetEdgeId = column[Int]("street_edge_id", O.NotNull)
+  def agreeCount = column[Int]("agree_count", O.NotNull)
+  def disagreeCount = column[Int]("disagree_count", O.NotNull)
+  def notsureCount = column[Int]("notsure_count", O.NotNull)
+  def correct = column[Option[Boolean]]("correct", O.Nullable)
 
   def * = (labelId, auditTaskId, missionId, gsvPanoramaId, labelTypeId, photographerHeading, photographerPitch,
-    panoramaLat, panoramaLng, deleted, temporaryLabelId, timeCreated, tutorial, streetEdgeId) <> ((Label.apply _).tupled, Label.unapply)
+    panoramaLat, panoramaLng, deleted, temporaryLabelId, timeCreated, tutorial, streetEdgeId, agreeCount, disagreeCount,
+    notsureCount, correct) <> ((Label.apply _).tupled, Label.unapply)
 
   def auditTask: ForeignKeyQuery[AuditTaskTable, AuditTask] =
     foreignKey("label_audit_task_id_fkey", auditTaskId, TableQuery[AuditTaskTable])(_.auditTaskId)

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -1377,8 +1377,10 @@ object LabelTable {
     */
   def getStreetEdgeIdClosestToLatLng(lat: Float, lng: Float): Option[Int] = db.withSession { implicit session =>
     val selectStreetEdgeIdQuery = Q.query[(Float, Float), Int](
-      """SELECT s.street_edge_id FROM street_edge AS s
-         |    ORDER BY ST_Distance(s.geom, ST_SetSRID(ST_MakePoint(?, ?), 4326)) ASC
+      """SELECT street_edge_id
+         |FROM street_edge
+         |WHERE deleted = FALSE
+         |ORDER BY ST_Distance(geom, ST_SetSRID(ST_MakePoint(?, ?), 4326)) ASC
          |LIMIT 1""".stripMargin
     )
     //NOTE: these parameters are being passed in correctly. ST_MakePoint accepts lng first, then lat.

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -411,11 +411,9 @@ object LabelTable {
         |         LEFT JOIN label_description as lab_desc ON lb.label_id = lab_desc.label_id
         |         LEFT JOIN label_temporariness as lab_temp ON lb.label_id = lab_temp.label_id
         |         LEFT JOIN (
-        |             -- Gets the most recent validation from this user for each label.
-        |             SELECT DISTINCT ON (label_id) label_id, validation_result
+        |             SELECT label_id, validation_result
         |             FROM label_validation
         |             WHERE user_id = '$userId'
-        |             ORDER BY label_id, end_timestamp DESC
         |         ) AS user_validation
         |             ON lb.label_id = user_validation.label_id
         |         LEFT JOIN (
@@ -572,13 +570,10 @@ object LabelTable {
         |         LEFT JOIN label_description AS lab_desc ON lb.label_id = lab_desc.label_id
         |         LEFT JOIN label_temporariness AS lab_temp ON lb.label_id = lab_temp.label_id
         |         LEFT JOIN (
-        |             -- Gets the most recent validation from this user for each label.
         |             SELECT label_id, validation_result
         |             FROM label_validation
         |             WHERE user_id = '$userId'
         |                 AND label_id = $labelId
-        |             ORDER BY end_timestamp DESC
-        |             LIMIT 1
         |         ) AS user_validation
         |             ON lb.label_id = user_validation.label_id
         |         LEFT JOIN (
@@ -692,12 +687,11 @@ object LabelTable {
           |    GROUP BY label_id
           |) the_tags ON label.label_id = the_tags.label_id
           |LEFT JOIN (
-          |    -- Gets the most recent validation from this user for each label. Since we only want them to validate
-          |    -- labels that they've never validated, when we left join, we should only get nulls from this query.
-          |    SELECT DISTINCT ON (label_id) label_id, validation_result
+          |    -- Gets the validations from this user. Since we only want them to validate labels that
+          |    -- they've never validated, when we left join, we should only get nulls from this query.
+          |    SELECT label_id, validation_result
           |    FROM label_validation
           |    WHERE user_id = '$userIdStr'
-          |    ORDER BY label_id, end_timestamp DESC
           |) user_validation ON label.label_id = user_validation.label_id
           |WHERE label.label_type_id = $labelTypeId
           |    AND label.deleted = FALSE
@@ -822,8 +816,8 @@ object LabelTable {
     } yield (l._1.labelId, l._3, l._1.gsvPanoramaId, l._6, l._1.timeCreated, l._2.heading, l._2.pitch,
              l._2.zoom, l._2.canvasX, l._2.canvasY, l._2.canvasWidth, l._2.canvasHeight, l._4, l._5, d.description.?)
 
-    // Join with the most recent validations that the user has given.
-    val userValidations = getMostRecentValidationsPerLabel(userId)
+    // Join with the validations that the user has given.
+    val userValidations = validationsFromUser(userId)
     val addValidations = for {
       (l, v) <- addDescriptions.leftJoin(userValidations).on(_._1 === _._1)
     } yield (l._1, l._2, l._3, l._4, l._5, l._6, l._7, l._8, l._9, l._10, l._11, l._12, l._13, l._14, l._15, v._2.?)
@@ -863,9 +857,9 @@ object LabelTable {
   }
 
   /**
-   * Retrieve n random labels of assorted types. 
+   * Retrieve n random labels of assorted types.
    *
-   * @param n Number of labels to grab. 
+   * @param n Number of labels to grab.
    * @param loadedLabelIds Label Ids of labels already grabbed.
    * @param severity Optional set of severities the labels grabbed can have.
    * @return Seq[LabelValidationMetadata]
@@ -895,7 +889,7 @@ object LabelTable {
     val addSeverity = for {
       (l, s) <- _labelsUnfiltered.leftJoin(severities).on(_._1.labelId === _.labelId)
     } yield (l._1, l._2, l._3, s.severity.?)
-    
+
     // If severities are specified, filter by whether a label has a valid severity.
     val _labelsUnfilteredWithSeverity = severity match {
       case Some(severity) => if (severity.nonEmpty) addSeverity.filter(_._4 inSet severity) else addSeverity
@@ -924,8 +918,8 @@ object LabelTable {
     } yield (l._1.labelId, l._3, l._1.gsvPanoramaId, l._6, l._1.timeCreated, l._2.heading, l._2.pitch,
              l._2.zoom, l._2.canvasX, l._2.canvasY, l._2.canvasWidth, l._2.canvasHeight, l._4, l._5, d.description.?)
 
-    // Join with the most recent validations that the user has given.
-    val userValidations = getMostRecentValidationsPerLabel(userId)
+    // Join with the validations that the user has given.
+    val userValidations = validationsFromUser(userId)
     val addValidations = for {
       (l, v) <- addDescriptions.leftJoin(userValidations).on(_._1 === _._1)
     } yield (l._1, l._2, l._3, l._4, l._5, l._6, l._7, l._8, l._9, l._10, l._11, l._12, l._13, l._14, l._15, v._2.?)
@@ -975,7 +969,7 @@ object LabelTable {
   def getLabelsByType(labelTypeId: Int, n: Int, loadedLabelIds: Set[Int], userId: UUID): Seq[LabelValidationMetadata] = db.withSession { implicit session =>
     // List to return.
     val selectedLabels: ListBuffer[LabelValidationMetadata] = new ListBuffer[LabelValidationMetadata]()
-    
+
     // Init random function.
     val rand = SimpleFunction.nullary[Double]("random")
 
@@ -1020,8 +1014,8 @@ object LabelTable {
     } yield (l._1.labelId, l._3, l._1.gsvPanoramaId, l._6, l._1.timeCreated, l._2.heading, l._2.pitch,
              l._2.zoom, l._2.canvasX, l._2.canvasY, l._2.canvasWidth, l._2.canvasHeight, l._4, l._5, d.description.?)
 
-    // Join with the most recent validations that the user has given.
-    val userValidations = getMostRecentValidationsPerLabel(userId)
+    // Join with the validations that the user has given.
+    val userValidations = validationsFromUser(userId)
     val addValidations = for {
       (l, v) <- addDescriptions.leftJoin(userValidations).on(_._1 === _._1)
     } yield (l._1, l._2, l._3, l._4, l._5, l._6, l._7, l._8, l._9, l._10, l._11, l._12, l._13, l._14, l._15, v._2.?)
@@ -1057,44 +1051,13 @@ object LabelTable {
   }
 
   /**
-   * For the given user, get the most recent validation result from each label they've validated, regardless of method.
-   *
-   * Ideally, we'd like to group by label_id, filter for most recent validation, and return the corresponding validation
-   * result. The methods to do that are a bit wonky in postgres, and even wonkier when we use Slick. In raw psql:
-   * SELECT DISTINCT ON (label_id) label_id, validation_result
-   * FROM label_validation
-   * WHERE user_id = '$userId'
-   * ORDER BY label_id, end_timestamp DESC;
-   *
-   * But in Slick, we can't use DISTINCT ON in this way (at least with Slick 2.1). So we instead group by label_id and
-   * get the newest validation timestamp (from the given user) for each label. Then we have to join that back with the
-   * label_validation table, joining on the label_id AND the timestamp. This _should_ be sufficient, but it is
-   * theoretically possible that a user could submitted multiple validations with identical timestamps, which would mean
-   * duplicates that we don't want. In the interest of performance (and because there was some issues converting it to
-   * Slick) we are skipping that grouping step. Below is the plain SQL that we converted to Slick syntax in the code.
-   * SELECT label_validation.label_id, validation_result
-   * FROM label_validation
-   * INNER JOIN (
-   *     SELECT label_id, MAX(end_timestamp) AS most_recent_timestamp
-   *     FROM label_validation
-   *     WHERE user_id = '$userId'
-   *     GROUP BY label_id
-   * ) most_recent_val
-   *     ON label_validation.label_id = most_recent_val.label_id
-   *     AND label_validation.end_timestamp = most_recent_val.most_recent_timestamp
-   * WHERE label_validation.user_id = '$userId';
+   * A query to get all validations by the given user.
    *
    * @param userId
    * @return A query with the integer columns label_id and validation_result
    */
-  def getMostRecentValidationsPerLabel(userId: UUID): Query[(Column[Int], Column[Int]), (Int, Int), Seq] = {
-    val userValidations = labelValidations.filter(_.userId === userId.toString)
-
-    userValidations.groupBy(_.labelId).map {
-      case (labId, group) => (labId, group.map(_.endTimestamp).max)
-    }.innerJoin(userValidations).on {
-      case (recentVal, userVal) => recentVal._1 === userVal.labelId && recentVal._2 === userVal.endTimestamp
-    }.map(x => (x._2.labelId, x._2.validationResult))
+  def validationsFromUser(userId: UUID): Query[(Column[Int], Column[Int]), (Int, Int), Seq] = {
+    labelValidations.filter(_.userId === userId.toString).map(v => (v.labelId, v.validationResult))
   }
 
   /**

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -435,7 +435,7 @@ object LabelTable {
         |         SELECT label_id,
         |                CONCAT('agree:', CAST(agree_count AS TEXT),
         |                       ',disagree:', CAST(disagree_count AS TEXT),
-        |                       ',unclear:', CAST(notsure_count AS TEXT)) AS val_counts
+        |                       ',notsure:', CAST(notsure_count AS TEXT)) AS val_counts
         |         FROM label
         |     ) AS val
         |WHERE lb1.gsv_panorama_id = gsv_data.gsv_panorama_id
@@ -1019,7 +1019,7 @@ object LabelTable {
       "user_validation" -> labelMetadata.userValidation.map(LabelValidationTable.validationOptions.get),
       "num_agree" -> labelMetadata.validations("agree"),
       "num_disagree" -> labelMetadata.validations("disagree"),
-      "num_unsure" -> labelMetadata.validations("unclear"),
+      "num_notsure" -> labelMetadata.validations("notsure"),
       "tags" -> labelMetadata.tags
     )
   }
@@ -1046,7 +1046,7 @@ object LabelTable {
       "user_validation" -> labelMetadata.userValidation.map(LabelValidationTable.validationOptions.get),
       "num_agree" -> labelMetadata.validations("agree"),
       "num_disagree" -> labelMetadata.validations("disagree"),
-      "num_unsure" -> labelMetadata.validations("unclear"),
+      "num_notsure" -> labelMetadata.validations("notsure"),
       "tags" -> labelMetadata.tags
     )
   }

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -668,9 +668,9 @@ object LabelTable {
           |LEFT JOIN label_description ON label.label_id = label_description.label_id
           |LEFT JOIN (
           |    -- This subquery counts how many of each users' labels have been validated for the given label type. If
-          |    -- it is less than 10, then we need more validations from them in order to use them for inferring worker
+          |    -- it is less than 50, then we need more validations from them in order to use them for inferring worker
           |    -- quality, and they therefore get priority.
-          |    SELECT mission.user_id, COUNT(DISTINCT(label.label_id)) < 10 AS needs_validations
+          |    SELECT mission.user_id, COUNT(DISTINCT(label.label_id)) < 50 AS needs_validations
           |    FROM mission
           |    INNER JOIN label ON label.mission_id = mission.mission_id
           |    INNER JOIN label_validation ON label.label_id = label_validation.label_id
@@ -706,7 +706,7 @@ object LabelTable {
           |        FROM label_validation
           |        WHERE user_id = '$userIdStr'
           |    )
-          |-- Prioritize labels that have been validated fewer times and from users who have had less than 10
+          |-- Prioritize labels that have been validated fewer times and from users who have had less than 50
           |-- validations of this label type, then randomize it.
           |ORDER BY counts.validation_count, COALESCE(needs_validations, TRUE) DESC, RANDOM()
           |LIMIT ${n * 5}""".stripMargin

--- a/app/models/label/LabelValidationTable.scala
+++ b/app/models/label/LabelValidationTable.scala
@@ -130,11 +130,18 @@ object LabelValidationTable {
     val oldValidation: Option[LabelValidation] =
       validationLabels.filter(x => x.labelId === label.labelId && x.userId === label.userId).firstOption
 
+    userThatAppliedLabel: String =
+    labels.filter(_.labelId === label.labelId)
+      .innerJoin(MissionTable.missions).on(_.missionId === _.missionId)
+      .map(_._2.userId)
+      .list.head
+
     // If there was already a validation, update all the columns that might have changed. O/w just make a new entry.
     oldValidation match {
       case Some(oldLabel) =>
-        // Update validation counts in the label table.
-        updateValidationCounts(label.labelId, label.validationResult, Some(oldLabel.validationResult))
+        // Update validation counts in the label table if this is not someone validating their own label.
+        if (userThatAppliedLabel !== label.userId)
+          updateValidationCounts(label.labelId, label.validationResult, Some(oldLabel.validationResult))
 
         // Update relevant columns in the label_validation table.
         val updateQuery = for {
@@ -148,8 +155,9 @@ object LabelValidationTable {
           label.startTimestamp, label.endTimestamp, label.isMobile
         ))
       case None =>
-        // Update validation counts in the label table.
-        updateValidationCounts(label.labelId, label.validationResult, None)
+        // Update validation counts in the label table if this is not someone validating their own label.
+        if (userThatAppliedLabel !== label.userId)
+          updateValidationCounts(label.labelId, label.validationResult, None)
 
         // Insert a new validation into the label_validation table.
         (validationLabels returning validationLabels.map(_.labelValidationId)) += label

--- a/app/models/label/LabelValidationTable.scala
+++ b/app/models/label/LabelValidationTable.scala
@@ -36,7 +36,7 @@ case class LabelValidation(labelValidationId: Int,
 class LabelValidationTable (tag: slick.lifted.Tag) extends Table[LabelValidation](tag, Some("sidewalk"), "label_validation") {
   def labelValidationId = column[Int]("label_validation_id", O.AutoInc)
   def labelId = column[Int]("label_id", O.NotNull)
-  def validationResult = column[Int]("validation_result", O.NotNull) // 1 = Agree, 2 = Disagree, 3 = Unsure
+  def validationResult = column[Int]("validation_result", O.NotNull) // 1 = Agree, 2 = Disagree, 3 = Notsure
   def userId = column[String]("user_id", O.NotNull)
   def missionId = column[Int]("mission_id", O.NotNull)
   def canvasX = column[Option[Int]]("canvas_x", O.Nullable)
@@ -79,10 +79,10 @@ object LabelValidationTable {
   val validationOptions: Map[Int, String] = Map(1 -> "Agree", 2 -> "Disagree", 3 -> "NotSure")
 
   /**
-    * Returns how many agree, disagree, or unsure validations a user entered for a given mission.
+    * Returns how many agree, disagree, or notsure validations a user entered for a given mission.
     *
     * @param missionId  Mission ID of mission
-    * @param result     Validation result (1 - agree, 2 - disagree, 3 - unsure)
+    * @param result     Validation result (1 - agree, 2 - disagree, 3 - notsure)
     * @return           Number of labels that were
     */
   def countResultsFromValidationMission(missionId: Int, result: Int): Int = db.withSession { implicit session =>

--- a/app/models/label/LabelValidationTable.scala
+++ b/app/models/label/LabelValidationTable.scala
@@ -130,7 +130,7 @@ object LabelValidationTable {
     val oldValidation: Option[LabelValidation] =
       validationLabels.filter(x => x.labelId === label.labelId && x.userId === label.userId).firstOption
 
-    userThatAppliedLabel: String =
+    val userThatAppliedLabel: String =
     labels.filter(_.labelId === label.labelId)
       .innerJoin(MissionTable.missions).on(_.missionId === _.missionId)
       .map(_._2.userId)
@@ -140,7 +140,7 @@ object LabelValidationTable {
     oldValidation match {
       case Some(oldLabel) =>
         // Update validation counts in the label table if this is not someone validating their own label.
-        if (userThatAppliedLabel !== label.userId)
+        if (userThatAppliedLabel != label.userId)
           updateValidationCounts(label.labelId, label.validationResult, Some(oldLabel.validationResult))
 
         // Update relevant columns in the label_validation table.
@@ -156,7 +156,7 @@ object LabelValidationTable {
         ))
       case None =>
         // Update validation counts in the label table if this is not someone validating their own label.
-        if (userThatAppliedLabel !== label.userId)
+        if (userThatAppliedLabel != label.userId)
           updateValidationCounts(label.labelId, label.validationResult, None)
 
         // Insert a new validation into the label_validation table.

--- a/app/models/label/LabelValidationTable.scala
+++ b/app/models/label/LabelValidationTable.scala
@@ -406,7 +406,6 @@ object LabelValidationTable {
         |(
         |    SELECT label_validation_id, end_timestamp::date AS calendar_date
         |    FROM label_validation
-        |    WHERE label_validation IS NOT NULL
         |) AS calendar
         |GROUP BY calendar_date
         |ORDER BY calendar_date""".stripMargin

--- a/app/models/user/UserStatTable.scala
+++ b/app/models/user/UserStatTable.scala
@@ -14,7 +14,6 @@ import java.sql.Timestamp
 import java.time.Instant
 import scala.slick.lifted.ForeignKeyQuery
 import scala.slick.jdbc.{StaticQuery => Q}
-import play.Logger
 
 case class UserStat(userStatId: Int, userId: String, metersAudited: Float, labelsPerMeter: Option[Float],
                     highQuality: Boolean, highQualityManual: Option[Boolean], ownLabelsValidated: Int,

--- a/app/models/user/UserStatTable.scala
+++ b/app/models/user/UserStatTable.scala
@@ -272,7 +272,7 @@ object UserStatTable {
    * Top users are calculated using: score = sqrt(# labels) * (0.5 * distance_audited / city_distance + 0.5 * accuracy).
    * Stats can be calculated for individual users or across teams. Overall and weekly are the possible time periods. We
    * only include accuracy if the user has at least 10 validated labels (must have either agree or disagree based off
-   * majority vote; an unsure or tie does not count).
+   * majority vote; a notsure or tie does not count).
    * @param n The number of top users to get stats for
    * @param timePeriod The time period over which to compute stats, either "weekly" or "overall"
    * @param byOrg True if grouping by organization/team instead of by user.

--- a/app/models/user/UserStatTable.scala
+++ b/app/models/user/UserStatTable.scala
@@ -298,7 +298,7 @@ object UserStatTable {
     // There are quite a few changes to make to the query when grouping by team/org instead of user. All of those below.
     val groupingCol: String = if (byOrg) "org_id" else "sidewalk_user.user_id"
     val groupingColName: String = if (byOrg) "org_id" else "user_id"
-    val joinUserOrgForAcc: String = if (byOrg) "INNER JOIN user_org ON agree_count.user_id = user_org.user_id" else ""
+    val joinUserOrgForAcc: String = if (byOrg) "INNER JOIN user_org ON mission.user_id = user_org.user_id" else ""
     val usernamesJoin: String = {
       if (byOrg) {
         "INNER JOIN (SELECT org_id, org_name AS username FROM organization) \"usernames\" ON label_counts.org_id = usernames.org_id"
@@ -346,19 +346,12 @@ object UserStatTable {
         |) "missions_and_distance" ON label_counts.$groupingColName = missions_and_distance.$groupingColName
         |LEFT JOIN (
         |    SELECT $groupingColName,
-        |           CAST (COUNT(CASE WHEN n_agree > n_disagree THEN 1 END) AS FLOAT) / NULLIF(COUNT(CASE WHEN n_agree > n_disagree THEN 1 END) + COUNT(CASE WHEN n_disagree > n_agree THEN 1 END), 0) AS accuracy_temp,
-        |           COUNT(CASE WHEN n_agree > n_disagree THEN 1 END) + COUNT(CASE WHEN n_disagree > n_agree THEN 1 END) AS validated_count
-        |    FROM (
-        |        SELECT mission.user_id, label.label_id,
-        |               COUNT(CASE WHEN validation_result = 1 THEN 1 END) AS n_agree,
-        |               COUNT(CASE WHEN validation_result = 2 THEN 1 END) AS n_disagree
-        |        FROM mission
-        |        INNER JOIN label ON mission.mission_id = label.mission_id
-        |        INNER JOIN label_validation ON label.label_id = label_validation.label_id
-        |        WHERE (label.time_created AT TIME ZONE 'US/Pacific') > $statStartTime
-        |        GROUP BY mission.user_id, label.label_id
-        |    ) agree_count
+        |           CAST(SUM(CASE WHEN correct THEN 1 END) AS FLOAT) / NULLIF(SUM(CASE WHEN correct THEN 1 END) + SUM(CASE WHEN NOT correct THEN 1 END), 0) AS accuracy_temp,
+        |           COUNT(CASE WHEN correct IS NOT NULL THEN 1 END) AS validated_count
+        |    FROM label
+        |    INNER JOIN mission ON label.mission_id = mission.mission_id
         |    $joinUserOrgForAcc
+        |    WHERE (label.time_created AT TIME ZONE 'US/Pacific') > $statStartTime
         |    GROUP BY $groupingColName
         |) "accuracy" ON label_counts.$groupingColName = accuracy.$groupingColName
         |ORDER BY score DESC;""".stripMargin

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -692,7 +692,7 @@
                                 </thead>
                                 <!-- using this id to locate the labelTags so we can insert the tags-->
                                 <tbody id = 'labelRows'>
-                                    @LabelTable.getRecentLabelMetadataWithValidations(5000, user.get.userId.toString).map { label =>
+                                    @LabelTable.getRecentLabelsMetadata(5000, None, None).map { label =>
                                         <tr>
                                             <td><a href='@routes.AdminController.userProfile(label.username)'>@label.username</a>
                                             </td>

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -620,7 +620,7 @@
                                         <th>Total</th>
                                         <th>Agreed</th>
                                         <th>Disagreed</th>
-                                        <th>Unsure</th>
+                                        <th>Notsure</th>
                                     </tr>
                                     <tr>
                                         <th>Overall</th>
@@ -686,7 +686,7 @@
                                     <th class="col-md-2">Description</th>
                                     <th class="col-md-1">Agree</th>
                                     <th class="col-md-1">Disagree</th>
-                                    <th class="col-md-1">Unsure</th>
+                                    <th class="col-md-1">Notsure</th>
                                     <th class="col-md-1">GSV</th>
                                 </tr>
                                 </thead>
@@ -704,7 +704,7 @@
                                             <td>@label.description</td>
                                             <td>@label.validations("agree")</td>
                                             <td>@label.validations("disagree")</td>
-                                            <td>@label.validations("unclear")</td>
+                                            <td>@label.validations("notsure")</td>
                                             <td>
                                                 <a class="labelView" data-label-id="@label.labelId" href="#">View</a>
                                             </td>
@@ -732,7 +732,7 @@
                                         <th class="col-md-1">Own Labels Validated</th>
                                         <th class="col-md-1">%Own Labels Agree</th>
                                         <th class="col-md-1">%Own Labels Disagree</th>
-                                        <th class="col-md-1">%Own Labels Unsure</th>
+                                        <th class="col-md-1">%Own Labels Notsure</th>
                                         <th class="col-md-1">Others' Labels Validated</th>
                                         <th class="col-md-1">%Others' Labels Agreed</th>
                                         <th class="col-md-2">Date Registered</th>
@@ -770,7 +770,7 @@
                                     <td>@u.ownValidated</td>
                                     <td>@("%.0f".format(u.ownValidatedAgreedPct * 100))%</td>
                                     <td>@("%.0f".format(u.ownValidatedDisagreedPct * 100))%</td>
-                                    <td>@("%.0f".format(u.ownValidatedUnsurePct * 100))%</td>
+                                    <td>@("%.0f".format(u.ownValidatedNotsurePct * 100))%</td>
                                     <td>@u.othersValidated</td>
                                     <td>@("%.0f".format(u.othersValidatedAgreedPct * 100))%</td>
                                     <td class = 'timestamp'>@u.signUpTime</td>

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -692,7 +692,7 @@
                                 </thead>
                                 <!-- using this id to locate the labelTags so we can insert the tags-->
                                 <tbody id = 'labelRows'>
-                                    @LabelTable.getRecentLabelsMetadata(5000, None, None).map { label =>
+                                    @LabelTable.getRecentLabelsMetadata(5000).map { label =>
                                         <tr>
                                             <td><a href='@routes.AdminController.userProfile(label.username)'>@label.username</a>
                                             </td>

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -597,16 +597,13 @@
                             <div id="validation-count-chart"></div>
                         </div>
 
-                        <h2>Validations per User</h2>
+                        <h2># Own Labels Validated per User</h2>
                         <div class="col-lg-12">
                             <p>
                                 <span>Standard Deviation (all users): </span><span id="all-validation-std"></span><br>
                                 <span>Standard Deviation (turker users): </span><span id="turker-validation-std"></span><br>
                                 <span>Standard Deviation (registered users): </span><span id="reg-validation-std"></span><br>
                                 <span>Standard Deviation (anon users): </span><span id="anon-validation-std"></span><br>
-                                <span>
-                                    Note: We only consider anonymous users who have completed at least one validation task.
-                                </span>
                             </p>
                         </div>
                         <div class="col-lg-12">

--- a/app/views/admin/user.scala.html
+++ b/app/views/admin/user.scala.html
@@ -90,7 +90,7 @@
                     </tr>
                     </thead>
                     <tbody>
-                    @LabelTable.getRecentLabelMetadata(1000, user.get.userId).map { userLabel =>
+                    @LabelTable.getRecentLabelsMetadata(1000, Some(user.get.userId), None).map { userLabel =>
                         <tr>
                             <td class = 'timestamp'>@userLabel.timestamp</td>
                             <td>@userLabel.labelTypeKey</td>

--- a/app/views/admin/user.scala.html
+++ b/app/views/admin/user.scala.html
@@ -90,7 +90,7 @@
                     </tr>
                     </thead>
                     <tbody>
-                    @LabelTable.getRecentLabelsMetadata(1000, Some(user.get.userId), None).map { userLabel =>
+                    @LabelTable.getRecentLabelsMetadata(1000, Some(user.get.userId)).map { userLabel =>
                         <tr>
                             <td class = 'timestamp'>@userLabel.timestamp</td>
                             <td>@userLabel.labelTypeKey</td>

--- a/conf/evolutions/default/127.sql
+++ b/conf/evolutions/default/127.sql
@@ -1,0 +1,31 @@
+# --- !Ups
+ALTER TABLE label
+    ADD COLUMN agree_count INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN disagree_count INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN notsure_count INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN correct BOOLEAN;
+
+-- Populate table with current validation info.
+UPDATE label
+SET (agree_count, disagree_count, notsure_count, correct) = (n_agree, n_disagree, n_notsure, is_correct)
+FROM (
+     SELECT label_id,
+            COUNT(CASE WHEN validation_result = 1 THEN 1 END) AS n_agree,
+            COUNT(CASE WHEN validation_result = 2 THEN 1 END) AS n_disagree,
+            COUNT(CASE WHEN validation_result = 3 THEN 1 END) AS n_notsure,
+            CASE
+                WHEN COUNT(CASE WHEN validation_result = 1 THEN 1 END) > COUNT(CASE WHEN validation_result = 2 THEN 1 END) THEN TRUE
+                WHEN COUNT(CASE WHEN validation_result = 2 THEN 1 END) > COUNT(CASE WHEN validation_result = 1 THEN 1 END) THEN FALSE
+                ELSE NULL
+            END AS is_correct
+     FROM label_validation
+     GROUP BY label_id
+ ) AS validation_count
+WHERE label.label_id = validation_count.label_id;
+
+# --- !Downs
+ALTER TABLE label
+    DROP COLUMN correct,
+    DROP COLUMN notsure_count,
+    DROP COLUMN disagree_count,
+    DROP COLUMN agree_count;

--- a/conf/evolutions/default/127.sql
+++ b/conf/evolutions/default/127.sql
@@ -35,7 +35,15 @@ FROM (
  ) AS validation_count
 WHERE label.label_id = validation_count.label_id;
 
+TRUNCATE TABLE global_clustering_session CASCADE;
+TRUNCATE TABLE user_clustering_session CASCADE;
+
+ALTER TABLE global_attribute
+    ADD COLUMN street_edge_id INTEGER NOT NULL DEFAULT -1;
+
 # --- !Downs
+ALTER TABLE global_attribute DROP COLUMN street_edge_id;
+
 ALTER TABLE label
     DROP COLUMN correct,
     DROP COLUMN notsure_count,

--- a/conf/evolutions/default/127.sql
+++ b/conf/evolutions/default/127.sql
@@ -27,7 +27,10 @@ FROM (
                 WHEN COUNT(CASE WHEN validation_result = 2 THEN 1 END) > COUNT(CASE WHEN validation_result = 1 THEN 1 END) THEN FALSE
                 ELSE NULL
             END AS is_correct
-     FROM label_validation
+     FROM mission
+     INNER JOIN label ON mission.mission_id = label.mission_id
+     INNER JOIN label_validation
+        ON label.label_id = label_validation.label_id AND mission.user_id <> label_validation.user_id
      GROUP BY label_id
  ) AS validation_count
 WHERE label.label_id = validation_count.label_id;

--- a/conf/evolutions/default/127.sql
+++ b/conf/evolutions/default/127.sql
@@ -1,4 +1,13 @@
 # --- !Ups
+-- For users who validated the same label multiple times, remove all but the newest validation.
+DELETE
+FROM label_validation val_a
+    USING label_validation val_b
+WHERE val_a.label_id = val_b.label_id
+  AND val_a.user_id = val_b.user_id
+  AND val_a.end_timestamp < val_b.end_timestamp;
+
+-- Add validation count columns to the label table.
 ALTER TABLE label
     ADD COLUMN agree_count INTEGER NOT NULL DEFAULT 0,
     ADD COLUMN disagree_count INTEGER NOT NULL DEFAULT 0,

--- a/conf/evolutions/default/127.sql
+++ b/conf/evolutions/default/127.sql
@@ -18,7 +18,7 @@ ALTER TABLE label
 UPDATE label
 SET (agree_count, disagree_count, notsure_count, correct) = (n_agree, n_disagree, n_notsure, is_correct)
 FROM (
-     SELECT label_id,
+     SELECT label.label_id,
             COUNT(CASE WHEN validation_result = 1 THEN 1 END) AS n_agree,
             COUNT(CASE WHEN validation_result = 2 THEN 1 END) AS n_disagree,
             COUNT(CASE WHEN validation_result = 3 THEN 1 END) AS n_notsure,
@@ -31,7 +31,7 @@ FROM (
      INNER JOIN label ON mission.mission_id = label.mission_id
      INNER JOIN label_validation
         ON label.label_id = label_validation.label_id AND mission.user_id <> label_validation.user_id
-     GROUP BY label_id
+     GROUP BY label.label_id
  ) AS validation_count
 WHERE label.label_id = validation_count.label_id;
 

--- a/conf/evolutions/default/127.sql
+++ b/conf/evolutions/default/127.sql
@@ -1,4 +1,8 @@
 # --- !Ups
+UPDATE validation_options
+SET text = 'notsure'
+WHERE text = 'unclear';
+
 -- For users who validated the same label multiple times, remove all but the newest validation.
 DELETE
 FROM label_validation val_a
@@ -49,3 +53,7 @@ ALTER TABLE label
     DROP COLUMN notsure_count,
     DROP COLUMN disagree_count,
     DROP COLUMN agree_count;
+
+UPDATE validation_options
+SET text = 'unclear'
+WHERE text = 'notsure';

--- a/public/javascripts/Admin/src/Admin.GSVLabelView.js
+++ b/public/javascripts/Admin/src/Admin.GSVLabelView.js
@@ -306,7 +306,7 @@ function AdminGSVLabelView(admin) {
 
         var validationsText = '' + labelMetadata['num_agree'] + ' Agree, ' +
             labelMetadata['num_disagree'] + ' Disagree, ' +
-            labelMetadata['num_unsure'] + ' Not Sure';
+            labelMetadata['num_notsure'] + ' Not Sure';
 
         var labelDate = moment(new Date(labelMetadata['timestamp']));
         var imageDate = moment(new Date(labelMetadata['image_date']));

--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -889,33 +889,33 @@ function Admin(_, $, difficultRegionIds) {
                 var turkerStats = getSummaryStats(turkerData, "count");
                 var anonStats = getSummaryStats(anonData, "count");
 
-                $("#all-validation-std").html((allFilteredStats.std).toFixed(2) + " Validations");
-                $("#reg-validation-std").html((regFilteredStats.std).toFixed(2) + " Validations");
-                $("#turker-validation-std").html((turkerStats.std).toFixed(2) + " Validations");
-                $("#anon-validation-std").html((anonStats.std).toFixed(2) + " Validations");
+                $("#all-validation-std").html((allFilteredStats.std).toFixed(2) + " labels");
+                $("#reg-validation-std").html((regFilteredStats.std).toFixed(2) + " labels");
+                $("#turker-validation-std").html((turkerStats.std).toFixed(2) + " labels");
+                $("#anon-validation-std").html((anonStats.std).toFixed(2) + " labels");
 
                 var allHistOpts = {
-                    xAxisTitle: "# Validations per User (all)", xDomain: [0, allStats.max], width: 187,
+                    xAxisTitle: "# Labels Validated per User (all)", xDomain: [0, allStats.max], width: 187,
                     binStep: 50, legendOffset: -80
                 };
                 var allFilteredHistOpts = {
-                    xAxisTitle: "# Validations per User (all)", xDomain: [0, allFilteredStats.max],
+                    xAxisTitle: "# Labels Validated per User (all)", xDomain: [0, allFilteredStats.max],
                     width: 187, binStep: 50, legendOffset: -80, excludeResearchers: true
                 };
                 var regHistOpts = {
-                    xAxisTitle: "# Validations per Registered User", xDomain: [0, regStats.max], width: 187,
+                    xAxisTitle: "# Labels Validated per Registered User", xDomain: [0, regStats.max], width: 187,
                     binStep: 50, legendOffset: -80
                 };
                 var regFilteredHistOpts = {
-                    xAxisTitle: "# Validations per Registered User", width: 187, legendOffset: -80,
+                    xAxisTitle: "# Labels Validated per Registered User", width: 187, legendOffset: -80,
                     xDomain: [0, regFilteredStats.max], excludeResearchers: true, binStep: 50
                 };
                 var turkerHistOpts = {
-                    xAxisTitle: "# Validations per Turker User", xDomain: [0, turkerStats.max], width: 187,
+                    xAxisTitle: "# Labels Validated per Turker User", xDomain: [0, turkerStats.max], width: 187,
                     binStep: 50, legendOffset: -80
                 };
                 var anonHistOpts = {
-                    xAxisTitle: "# Validations per Anon User", xDomain: [0, anonStats.max],
+                    xAxisTitle: "# Labels Validated per Anon User", xDomain: [0, anonStats.max],
                     width: 187, legendOffset: -80, binStep: 2
                 };
 

--- a/public/javascripts/SVValidate/src/label/Label.js
+++ b/public/javascripts/SVValidate/src/label/Label.js
@@ -214,7 +214,7 @@ function Label(params) {
      *
      * NOTE: canvas_x and canvas_y are null when the label is not visible when validation occurs.
      *
-     * @param validationResult  Must be one of the following: {Agree, Disagree, Unsure}.
+     * @param validationResult  Must be one of the following: {Agree, Disagree, Notsure}.
      */
     function validate(validationResult, comment) {
         // This is the POV of the PanoMarker, where the PanoMarker would be loaded at the center

--- a/public/javascripts/SVValidate/src/mission/MissionContainer.js
+++ b/public/javascripts/SVValidate/src/mission/MissionContainer.js
@@ -53,7 +53,7 @@ function MissionContainer () {
      * Creates a mission by parsing a JSON file
      * @param missionMetadata   JSON metadata for mission (from backend)
      * @param progressMetadata  JSON metadata about mission progress
-     *                          (counts of agree/disagree/unsure labels for this mission)
+     *                          (counts of agree/disagree/notsure labels for this mission)
      * @private
      */
     function createAMission(missionMetadata, progressMetadata) {


### PR DESCRIPTION
Resolves #2699 

This PR does a few important things:
1. Adds validation info the our /attributes and /attributesWithLabels public APIs.
2. Adds columns for validation counts to the `label` table, making it easier to get information about validations going forward. These columns are updated in real time as validations are entered into the system.
3. I updated all places where we were using counts of validations to now use the precomputed values in the columns mentioned above.
4. Various small bug fixes related to validations, clustering, and the API.

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've added/updated comments for large or confusing blocks of code.
