### PR TITLE
Filter out low quality data from LabelMap

### DIFF
--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -95,7 +95,7 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
    */
   def getAllLabels = UserAwareAction.async { implicit request =>
     if (isAdmin(request.identity)) {
-      val labels = LabelTable.selectLocationsAndSeveritiesOfLabels
+      val labels = LabelTable.selectLocationsAndSeveritiesOfLabels(false)
       val features: List[JsObject] = labels.map { label =>
         val point = geojson.Point(geojson.LatLng(label.lat.toDouble, label.lng.toDouble))
         val properties = Json.obj(
@@ -103,7 +103,8 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
           "label_id" -> label.labelId,
           "gsv_panorama_id" -> label.gsvPanoramaId,
           "label_type" -> label.labelType,
-          "severity" -> label.severity
+          "severity" -> label.severity,
+          "correct" -> label.correct
         )
         Json.obj("type" -> "Feature", "geometry" -> point, "properties" -> properties)
       }
@@ -117,8 +118,8 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
   /**
    * Get a list of all labels with metadata needed for /labelMap.
    */
-  def getAllLabelsForLabelMap = UserAwareAction.async { implicit request =>
-    val labels = LabelTable.selectLocationsAndSeveritiesOfLabels
+  def getAllLabelsForLabelMap(filterLowQuality: Boolean) = UserAwareAction.async { implicit request =>
+    val labels = LabelTable.selectLocationsAndSeveritiesOfLabels(filterLowQuality)
     val features: List[JsObject] = labels.map { label =>
       val point = geojson.Point(geojson.LatLng(label.lat.toDouble, label.lng.toDouble))
       val properties = Json.obj(
@@ -126,6 +127,7 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
         "gsv_panorama_id" -> label.gsvPanoramaId,
         "label_type" -> label.labelType,
         "severity" -> label.severity,
+        "correct" -> label.correct,
         "expired" -> label.expired
       )
       Json.obj("type" -> "Feature", "geometry" -> point, "properties" -> properties)

--- a/app/controllers/UserProfileController.scala
+++ b/app/controllers/UserProfileController.scala
@@ -75,8 +75,8 @@ class UserProfileController @Inject() (implicit val env: Environment[User, Sessi
   /**
    * Get the list of streets that have been audited by any user.
    */
-  def getAllAuditedStreets = UserAwareAction.async { implicit request =>
-    val streets = AuditTaskTable.selectStreetsAudited
+  def getAllAuditedStreets(filterLowQuality: Boolean) = UserAwareAction.async { implicit request =>
+    val streets = AuditTaskTable.selectStreetsAudited(filterLowQuality)
     val features: List[JsObject] = streets.map { edge =>
       val coordinates: Array[Coordinate] = edge.geom.getCoordinates
       val latlngs: List[geojson.LatLng] = coordinates.map(coord => geojson.LatLng(coord.y, coord.x)).toList  // Map it to an immutable list

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -52,6 +52,7 @@ case class LabelLocationWithSeverity(labelId: Int,
                                      labelType: String,
                                      lat: Float,
                                      lng: Float,
+                                     correct: Option[Boolean],
                                      expired: Boolean,
                                      severity: Option[Int])
 
@@ -185,7 +186,7 @@ object LabelTable {
     MiniMapResumeMetadata(r.nextInt, r.nextString, r.nextFloatOption, r.nextFloatOption))
 
   implicit val labelSeverityConverter = GetResult[LabelLocationWithSeverity](r =>
-    LabelLocationWithSeverity(r.nextInt, r.nextInt, r.nextString, r.nextString, r.nextFloat, r.nextFloat, r.nextBoolean, r.nextIntOption))
+    LabelLocationWithSeverity(r.nextInt, r.nextInt, r.nextString, r.nextString, r.nextFloat, r.nextFloat, r.nextBooleanOption, r.nextBoolean, r.nextIntOption))
 
   // Valid label type ids -- excludes Other and Occlusion labels
   val labelTypeIdList: List[Int] = List(1, 2, 3, 4, 7)
@@ -1089,18 +1090,30 @@ object LabelTable {
   /**
     * Returns all the submitted labels with their severities included.
     */
-  def selectLocationsAndSeveritiesOfLabels: List[LabelLocationWithSeverity] = db.withSession { implicit session =>
+  def selectLocationsAndSeveritiesOfLabels(filterLowQuality: Boolean): List[LabelLocationWithSeverity] = db.withSession { implicit session =>
     val _labels = for {
       _l <- labelsWithoutDeleted
       _lType <- labelTypes if _l.labelTypeId === _lType.labelTypeId
       _lPoint <- labelPoints if _l.labelId === _lPoint.labelId
       _gsv <- gsvData if _l.gsvPanoramaId === _gsv.gsvPanoramaId
       if _lPoint.lat.isDefined && _lPoint.lng.isDefined // Make sure they are NOT NULL so we can safely use .get later.
-    } yield (_l.labelId, _l.auditTaskId, _l.gsvPanoramaId, _lType.labelType, _lPoint.lat, _lPoint.lng, _gsv.expired)
+    } yield (_l.labelId, _l.auditTaskId, _l.gsvPanoramaId, _lType.labelType, _lPoint.lat, _lPoint.lng, _l.correct, _gsv.expired)
+
+    // Optionally filter out data marked as low quality.
+    val _filteredLabels = if (filterLowQuality) {
+      for {
+        _l <- _labels
+        _at <- auditTasks if _l._2 === _at.auditTaskId
+        _ut <- UserStatTable.userStats if _at.userId === _ut.userId
+        if _ut.highQuality && _l._7.getOrElse(true)
+      } yield _l
+    } else {
+      _labels
+    }
 
     val _labelsWithSeverity = for {
-      (l, s) <- _labels.leftJoin(severities).on(_._1 === _.labelId)
-    } yield (l._1, l._2, l._3, l._4, l._5.get, l._6.get, l._7, s.severity.?)
+      (l, s) <- _filteredLabels.leftJoin(severities).on(_._1 === _.labelId)
+    } yield (l._1, l._2, l._3, l._4, l._5.get, l._6.get, l._7, l._8, s.severity.?)
 
     _labelsWithSeverity.list.map(LabelLocationWithSeverity.tupled)
   }

--- a/app/views/labelMap.scala.html
+++ b/app/views/labelMap.scala.html
@@ -202,8 +202,8 @@
             var loadPolygons = $.getJSON('/neighborhoods');
             var loadPolygonRates = $.getJSON('/adminapi/neighborhoodCompletionRate');
             var loadMapParams = $.getJSON('/cityMapParams');
-            var loadAuditedStreets = $.getJSON('/contribution/streets/all');
-            var loadSubmittedLabels = $.getJSON('/labels/all');
+            var loadAuditedStreets = $.getJSON('/contribution/streets/all?filterLowQuality=true');
+            var loadSubmittedLabels = $.getJSON('/labels/all?filterLowQuality=true');
             // When the polygons, polygon rates, and map params are all loaded the polygon regions can be rendered.
             var renderPolygons = $.when(loadPolygons, loadPolygonRates, loadMapParams).done(function(data1, data2, data3) {
                 map = Choropleth(_, $, difficultRegionIds, params, [], data1[0], data2[0], data3[0]);

--- a/conf/routes
+++ b/conf/routes
@@ -80,7 +80,7 @@ GET     /adminapi/numWebpageActivity/:activity/*keyValPairs  @controllers.AdminC
 GET     /adminapi/choroplethCounts                           @controllers.AdminController.getRegionNegativeLabelCounts
 PUT     /adminapi/setRole                                    @controllers.AdminController.setUserRole
 
-GET     /labels/all                                          @controllers.AdminController.getAllLabelsForLabelMap
+GET     /labels/all                                          @controllers.AdminController.getAllLabelsForLabelMap(filterLowQuality: Boolean ?= false)
 GET     /label/id/:labelId                                   @controllers.AdminController.getLabelData(labelId: Int)
 
 # Auditing tasks
@@ -132,7 +132,7 @@ GET     /neighborhoods/difficult                             @controllers.Region
 # User status
 # /:username has to come last in the list. Otherwise it eats other urls.
 GET     /contribution/streets                                @controllers.UserProfileController.getAuditedStreets
-GET     /contribution/streets/all                            @controllers.UserProfileController.getAllAuditedStreets
+GET     /contribution/streets/all                            @controllers.UserProfileController.getAllAuditedStreets(filterLowQuality: Boolean ?= false)
 GET     /contribution/auditCounts/all                        @controllers.UserProfileController.getAllAuditCounts
 GET     /dashboard                                           @controllers.UserProfileController.userProfile
 


### PR DESCRIPTION
Begins to address #2786 

For now, we are simply filtering out all data from "low quality" users, and all labels with more disagree validations than agree validations. We are going to make this configurable in the UI in the next week or two, but this was a quick change we could make for now to improve the look of the map! From my two test databases, we're filtering about 7% of the labels in Columbus and 23% of the labels in Seattle (though we don't show LabelMap publicly in Seattle anyway).

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've added/updated comments for large or confusing blocks of code.
