### PR TITLE
Record more panorama metadata

### DIFF
--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -21,7 +21,7 @@ import models.mission.MissionTable
 import models.region.RegionCompletionTable
 import models.street.StreetEdgeTable
 import models.user._
-import play.api.libs.json.{JsArray, JsError, JsObject, Json}
+import play.api.libs.json.{JsArray, JsError, JsObject, JsValue, Json}
 import play.extras.geojson
 import play.api.mvc.BodyParsers
 import play.api.Play
@@ -396,7 +396,7 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
    */
   def getAllPanoIds() = UserAwareAction.async { implicit request =>
     val panos: List[(String, Option[Int], Option[Int])] = GSVDataTable.getAllPanos()
-    val json: JsArray = Json.arr(panos.map(p =>
+    val json: JsValue = Json.toJson(panos.map(p =>
       Json.obj("gsv_panorama_id" -> p._1, "image_width" -> p._2, "image_height" -> p._3)
     ))
     Future.successful(Ok(json))

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -393,6 +393,7 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
 
   /**
    * Get the list of pano IDs in our database.
+   * TODO remove the /adminapi/labels/panoid endpoint once all have shifted to /adminapi/panos
    */
   def getAllPanoIds() = UserAwareAction.async { implicit request =>
     val panos: List[(String, Option[Int], Option[Int])] = GSVDataTable.getAllPanos()

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -14,6 +14,7 @@ import formats.json.UserRoleSubmissionFormats._
 import models.attribute.{GlobalAttribute, GlobalAttributeTable}
 import models.audit.{AuditTaskInteractionTable, AuditTaskTable, InteractionWithLabel}
 import models.daos.slick.DBTableDefinitions.UserTable
+import models.gsv.GSVDataTable
 import models.label.LabelTable.LabelMetadata
 import models.label.{LabelPointTable, LabelTable, LabelTypeTable, LabelValidationTable}
 import models.mission.MissionTable
@@ -26,7 +27,6 @@ import play.api.mvc.BodyParsers
 import play.api.Play
 import play.api.Play.current
 import play.api.cache.EhCachePlugin
-
 import javax.naming.AuthenticationException
 import scala.concurrent.Future
 
@@ -392,20 +392,14 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
   }
 
   /**
-   * Get the list of pano IDs associated with labels in our database.
+   * Get the list of pano IDs in our database.
    */
   def getAllPanoIds() = UserAwareAction.async { implicit request =>
-
-    val labels = LabelTable.selectLocationsOfLabels
-    val features: List[JsObject] = labels.map { label =>
-
-      val properties = Json.obj(
-        "gsv_panorama_id" -> label.gsvPanoramaId
-      )
-      Json.obj("properties" -> properties)
-    }
-    val featureCollection = Json.obj("type" -> "FeatureCollection", "features" -> features)
-    Future.successful(Ok(featureCollection))
+    val panos: List[(String, Option[Int], Option[Int])] = GSVDataTable.getAllPanos()
+    val json: JsArray = Json.arr(panos.map(p =>
+      Json.obj("gsv_panorama_id" -> p._1, "image_width" -> p._2, "image_height" -> p._3)
+    ))
+    Future.successful(Ok(json))
   }
 
   /**

--- a/app/controllers/TaskController.scala
+++ b/app/controllers/TaskController.scala
@@ -373,7 +373,7 @@ class TaskController @Inject() (implicit val env: Environment[User, SessionAuthe
           val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
           val gsvData: GSVData = GSVData(panorama.gsvPanoramaId, panorama.imageWidth, panorama.imageHeight,
             panorama.tileWidth, panorama.tileHeight, panorama.centerHeading, panorama.originHeading,
-            panorama.originPitch, panorama.imageDate, 1, "", false, Some(timestamp))
+            panorama.originPitch, panorama.imageDate, 1, panorama.copyright, false, Some(timestamp))
           GSVDataTable.save(gsvData)
 
           for (link <- panorama.links) {

--- a/app/controllers/TaskController.scala
+++ b/app/controllers/TaskController.scala
@@ -371,7 +371,9 @@ class TaskController @Inject() (implicit val env: Environment[User, SessionAuthe
         // Check the presence of the data.
         if (!GSVDataTable.panoramaExists(panorama.gsvPanoramaId)) {
           val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
-          val gsvData: GSVData = GSVData(panorama.gsvPanoramaId, 13312, 6656, 512, 512, panorama.imageDate, 1, "", false, Some(timestamp))
+          val gsvData: GSVData = GSVData(panorama.gsvPanoramaId, panorama.imageWidth, panorama.imageHeight,
+            panorama.tileWidth, panorama.tileHeight, panorama.centerHeading, panorama.originHeading,
+            panorama.originPitch, panorama.imageDate, 1, "", false, Some(timestamp))
           GSVDataTable.save(gsvData)
 
           for (link <- panorama.links) {

--- a/app/controllers/TaskController.scala
+++ b/app/controllers/TaskController.scala
@@ -373,7 +373,7 @@ class TaskController @Inject() (implicit val env: Environment[User, SessionAuthe
           val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
           val gsvData: GSVData = GSVData(panorama.gsvPanoramaId, panorama.imageWidth, panorama.imageHeight,
             panorama.tileWidth, panorama.tileHeight, panorama.centerHeading, panorama.originHeading,
-            panorama.originPitch, panorama.imageDate, 1, panorama.copyright, false, Some(timestamp))
+            panorama.originPitch, panorama.imageDate, panorama.copyright, false, Some(timestamp))
           GSVDataTable.save(gsvData)
 
           for (link <- panorama.links) {

--- a/app/formats/json/TaskSubmissionFormats.scala
+++ b/app/formats/json/TaskSubmissionFormats.scala
@@ -13,7 +13,7 @@ object TaskSubmissionFormats {
   case class TaskSubmission(streetEdgeId: Int, taskStart: String, auditTaskId: Option[Int], completed: Option[Boolean], currentLat: Float, currentLng: Float, startPointReversed: Boolean, lastPriorityUpdateTime: Long, requestUpdatedStreetPriority: Boolean)
   case class IncompleteTaskSubmission(issueDescription: String, lat: Float, lng: Float)
   case class GSVLinkSubmission(targetGsvPanoramaId: String, yawDeg: Double, description: String)
-  case class GSVPanoramaSubmission(gsvPanoramaId: String, imageDate: String, imageWidth: Int, imageHeight: Int, tileWidth: Int, tileHeight: Int, centerHeading: Option[Float], originHeading: Option[Float], originPitch: Option[Float], links: Seq[GSVLinkSubmission], copyright: String)
+  case class GSVPanoramaSubmission(gsvPanoramaId: String, imageDate: String, imageWidth: Option[Int], imageHeight: Option[Int], tileWidth: Option[Int], tileHeight: Option[Int], centerHeading: Option[Float], originHeading: Option[Float], originPitch: Option[Float], links: Seq[GSVLinkSubmission], copyright: String)
   case class AuditMissionProgress(missionId: Int, distanceProgress: Option[Float], completed: Boolean, auditTaskId: Option[Int], skipped: Boolean)
   case class AuditTaskSubmission(missionProgress: AuditMissionProgress, auditTask: TaskSubmission, labels: Seq[LabelSubmission], interactions: Seq[InteractionSubmission], environment: EnvironmentSubmission, incomplete: Option[IncompleteTaskSubmission], gsvPanoramas: Seq[GSVPanoramaSubmission], amtAssignmentId: Option[Int])
   case class AMTAssignmentCompletionSubmission(assignmentId: Int, completed: Option[Boolean])
@@ -107,10 +107,10 @@ object TaskSubmissionFormats {
   implicit val gsvPanoramaSubmissionReads: Reads[GSVPanoramaSubmission] = (
     (JsPath \ "panorama_id").read[String] and
       (JsPath \ "image_date").read[String] and
-      (JsPath \ "image_width").read[Int] and
-      (JsPath \ "image_height").read[Int] and
-      (JsPath \ "tile_width").read[Int] and
-      (JsPath \ "tile_height").read[Int] and
+      (JsPath \ "image_width").readNullable[Int] and
+      (JsPath \ "image_height").readNullable[Int] and
+      (JsPath \ "tile_width").readNullable[Int] and
+      (JsPath \ "tile_height").readNullable[Int] and
       (JsPath \ "center_heading").readNullable[Float] and
       (JsPath \ "origin_heading").readNullable[Float] and
       (JsPath \ "origin_pitch").readNullable[Float] and

--- a/app/formats/json/TaskSubmissionFormats.scala
+++ b/app/formats/json/TaskSubmissionFormats.scala
@@ -13,7 +13,7 @@ object TaskSubmissionFormats {
   case class TaskSubmission(streetEdgeId: Int, taskStart: String, auditTaskId: Option[Int], completed: Option[Boolean], currentLat: Float, currentLng: Float, startPointReversed: Boolean, lastPriorityUpdateTime: Long, requestUpdatedStreetPriority: Boolean)
   case class IncompleteTaskSubmission(issueDescription: String, lat: Float, lng: Float)
   case class GSVLinkSubmission(targetGsvPanoramaId: String, yawDeg: Double, description: String)
-  case class GSVPanoramaSubmission(gsvPanoramaId: String, imageDate: String, links: Seq[GSVLinkSubmission], copyright: String)
+  case class GSVPanoramaSubmission(gsvPanoramaId: String, imageDate: String, imageWidth: Int, imageHeight: Int, tileWidth: Int, tileHeight: Int, centerHeading: Option[Float], originHeading: Option[Float], originPitch: Option[Float], links: Seq[GSVLinkSubmission], copyright: String)
   case class AuditMissionProgress(missionId: Int, distanceProgress: Option[Float], completed: Boolean, auditTaskId: Option[Int], skipped: Boolean)
   case class AuditTaskSubmission(missionProgress: AuditMissionProgress, auditTask: TaskSubmission, labels: Seq[LabelSubmission], interactions: Seq[InteractionSubmission], environment: EnvironmentSubmission, incomplete: Option[IncompleteTaskSubmission], gsvPanoramas: Seq[GSVPanoramaSubmission], amtAssignmentId: Option[Int])
   case class AMTAssignmentCompletionSubmission(assignmentId: Int, completed: Option[Boolean])
@@ -107,6 +107,13 @@ object TaskSubmissionFormats {
   implicit val gsvPanoramaSubmissionReads: Reads[GSVPanoramaSubmission] = (
     (JsPath \ "panorama_id").read[String] and
       (JsPath \ "image_date").read[String] and
+      (JsPath \ "image_width").read[Int] and
+      (JsPath \ "image_height").read[Int] and
+      (JsPath \ "tile_width").read[Int] and
+      (JsPath \ "tile_height").read[Int] and
+      (JsPath \ "center_heading").readNullable[Float] and
+      (JsPath \ "origin_heading").readNullable[Float] and
+      (JsPath \ "origin_pitch").readNullable[Float] and
       (JsPath \ "links").read[Seq[GSVLinkSubmission]] and
       (JsPath \ "copyright").read[String]
     )(GSVPanoramaSubmission.apply _)

--- a/app/models/gsv/GSVDataTable.scala
+++ b/app/models/gsv/GSVDataTable.scala
@@ -6,7 +6,7 @@ import play.api.Play.current
 
 case class GSVData(gsvPanoramaId: String, imageWidth: Option[Int], imageHeight: Option[Int], tileWidth: Option[Int],
                    tileHeight: Option[Int], centerHeading: Option[Float], originHeading: Option[Float],
-                   originPitch: Option[Float], imageDate: String, imageryType: Int, copyright: String, expired: Boolean,
+                   originPitch: Option[Float], imageDate: String, copyright: String, expired: Boolean,
                    lastViewed: Option[java.sql.Timestamp])
 
 class GSVDataTable(tag: Tag) extends Table[GSVData](tag, Some("sidewalk"), "gsv_data") {
@@ -19,13 +19,12 @@ class GSVDataTable(tag: Tag) extends Table[GSVData](tag, Some("sidewalk"), "gsv_
   def originHeading = column[Option[Float]]("origin_heading")
   def originPitch = column[Option[Float]]("origin_pitch")
   def imageDate = column[String]("image_date", O.NotNull)
-  def imageryType = column[Int]("imagery_type", O.NotNull)
   def copyright = column[String]("copyright", O.NotNull)
   def expired = column[Boolean]("expired", O.NotNull)
   def lastViewed = column[Option[java.sql.Timestamp]]("last_viewed", O.Nullable)
 
   def * = (gsvPanoramaId, imageWidth, imageHeight, tileWidth, tileHeight, centerHeading,
-    originHeading, originPitch, imageDate, imageryType, copyright, expired, lastViewed) <>
+    originHeading, originPitch, imageDate, copyright, expired, lastViewed) <>
     ((GSVData.apply _).tupled, GSVData.unapply)
 }
 

--- a/app/models/gsv/GSVDataTable.scala
+++ b/app/models/gsv/GSVDataTable.scala
@@ -32,6 +32,10 @@ object GSVDataTable {
   val db = play.api.db.slick.DB
   val gsvDataRecords = TableQuery[GSVDataTable]
 
+  def getAllPanos(): List[(String, Option[Int], Option[Int])] = db.withSession { implicit session =>
+    gsvDataRecords.filter(_.gsvPanoramaId =!= "tutorial").map(p => (p.gsvPanoramaId, p.imageWidth, p.imageHeight)).list
+  }
+
   /**
     * This method marks the expired column of a panorama to be true.
     *

--- a/app/models/gsv/GSVDataTable.scala
+++ b/app/models/gsv/GSVDataTable.scala
@@ -5,6 +5,7 @@ import models.utils.MyPostgresDriver.simple._
 import play.api.Play.current
 
 case class GSVData(gsvPanoramaId: String, imageWidth: Int, imageHeight: Int, tileWidth: Int, tileHeight: Int,
+                   centerHeading: Option[Float], originHeading: Option[Float], originPitch: Option[Float],
                    imageDate: String, imageryType: Int, copyright: String, expired: Boolean,
                    lastViewed: Option[java.sql.Timestamp])
 
@@ -14,14 +15,17 @@ class GSVDataTable(tag: Tag) extends Table[GSVData](tag, Some("sidewalk"), "gsv_
   def imageHeight = column[Int]("image_height", O.NotNull)
   def tileWidth = column[Int]("tile_width", O.NotNull)
   def tileHeight = column[Int]("tile_height", O.NotNull)
+  def centerHeading = column[Option[Float]]("center_heading")
+  def originHeading = column[Option[Float]]("origin_heading")
+  def originPitch = column[Option[Float]]("origin_pitch")
   def imageDate = column[String]("image_date", O.NotNull)
   def imageryType = column[Int]("imagery_type", O.NotNull)
   def copyright = column[String]("copyright", O.NotNull)
   def expired = column[Boolean]("expired", O.NotNull)
   def lastViewed = column[Option[java.sql.Timestamp]]("last_viewed", O.Nullable)
 
-  def * = (gsvPanoramaId, imageWidth, imageHeight, tileWidth, tileHeight, imageDate, imageryType,
-    copyright, expired, lastViewed) <>
+  def * = (gsvPanoramaId, imageWidth, imageHeight, tileWidth, tileHeight, centerHeading,
+    originHeading, originPitch, imageDate, imageryType, copyright, expired, lastViewed) <>
     ((GSVData.apply _).tupled, GSVData.unapply)
 }
 

--- a/app/models/gsv/GSVDataTable.scala
+++ b/app/models/gsv/GSVDataTable.scala
@@ -4,17 +4,17 @@ import java.sql.Timestamp
 import models.utils.MyPostgresDriver.simple._
 import play.api.Play.current
 
-case class GSVData(gsvPanoramaId: String, imageWidth: Int, imageHeight: Int, tileWidth: Int, tileHeight: Int,
-                   centerHeading: Option[Float], originHeading: Option[Float], originPitch: Option[Float],
-                   imageDate: String, imageryType: Int, copyright: String, expired: Boolean,
+case class GSVData(gsvPanoramaId: String, imageWidth: Option[Int], imageHeight: Option[Int], tileWidth: Option[Int],
+                   tileHeight: Option[Int], centerHeading: Option[Float], originHeading: Option[Float],
+                   originPitch: Option[Float], imageDate: String, imageryType: Int, copyright: String, expired: Boolean,
                    lastViewed: Option[java.sql.Timestamp])
 
 class GSVDataTable(tag: Tag) extends Table[GSVData](tag, Some("sidewalk"), "gsv_data") {
   def gsvPanoramaId = column[String]("gsv_panorama_id", O.PrimaryKey)
-  def imageWidth = column[Int]("image_width", O.NotNull)
-  def imageHeight = column[Int]("image_height", O.NotNull)
-  def tileWidth = column[Int]("tile_width", O.NotNull)
-  def tileHeight = column[Int]("tile_height", O.NotNull)
+  def imageWidth = column[Option[Int]]("image_width")
+  def imageHeight = column[Option[Int]]("image_height")
+  def tileWidth = column[Option[Int]]("tile_width")
+  def tileHeight = column[Option[Int]]("tile_height")
   def centerHeading = column[Option[Float]]("center_heading")
   def originHeading = column[Option[Float]]("origin_heading")
   def originPitch = column[Option[Float]]("origin_pitch")

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -1072,22 +1072,6 @@ object LabelTable {
   }
 
   /**
-    * Returns all the submitted labels.
-    */
-  def selectLocationsOfLabels: List[LabelLocation] = db.withSession { implicit session =>
-    val _labels = for {
-      (_labels, _labelTypes) <- labelsWithoutDeleted.innerJoin(labelTypes).on(_.labelTypeId === _.labelTypeId)
-    } yield (_labels.labelId, _labels.auditTaskId, _labels.gsvPanoramaId, _labelTypes.labelType, _labels.panoramaLat, _labels.panoramaLng)
-
-    val _points = for {
-      (l, p) <- _labels.innerJoin(labelPoints).on(_._1 === _.labelId)
-    } yield (l._1, l._2, l._3, l._4, p.lat.getOrElse(0.toFloat), p.lng.getOrElse(0.toFloat))
-
-    val labelLocationList: List[LabelLocation] = _points.list.map(label => LabelLocation(label._1, label._2, label._3, label._4, label._5, label._6))
-    labelLocationList
-  }
-
-  /**
     * Returns all the submitted labels with their severities included.
     */
   def selectLocationsAndSeveritiesOfLabels(filterLowQuality: Boolean): List[LabelLocationWithSeverity] = db.withSession { implicit session =>

--- a/conf/evolutions/default/135.sql
+++ b/conf/evolutions/default/135.sql
@@ -3,6 +3,7 @@ ALTER TABLE gsv_data
     ADD COLUMN center_heading FLOAT,
     ADD COLUMN origin_heading FLOAT,
     ADD COLUMN origin_pitch FLOAT,
+    DROP COLUMN imagery_type,
     ALTER COLUMN image_width DROP NOT NULL,
     ALTER COLUMN image_height DROP NOT NULL,
     ALTER COLUMN tile_width DROP NOT NULL,
@@ -18,4 +19,8 @@ WHERE image_width IS NULL OR image_height IS NULL OR tile_width IS NULL OR tile_
 ALTER TABLE gsv_data
     DROP COLUMN center_heading,
     DROP COLUMN origin_heading,
-    DROP COLUMN origin_pitch;
+    DROP COLUMN origin_pitch,
+    ADD COLUMN imagery_type INTEGER;
+
+UPDATE gsv_data SET imagery_type = 1;
+ALTER TABLE gsv_data ALTER COLUMN imagery_type SET NOT NULL;

--- a/conf/evolutions/default/135.sql
+++ b/conf/evolutions/default/135.sql
@@ -2,9 +2,19 @@
 ALTER TABLE gsv_data
     ADD COLUMN center_heading FLOAT,
     ADD COLUMN origin_heading FLOAT,
-    ADD COLUMN origin_pitch FLOAT;
+    ADD COLUMN origin_pitch FLOAT,
+    ALTER COLUMN image_width DROP NOT NULL,
+    ALTER COLUMN image_height DROP NOT NULL,
+    ALTER COLUMN tile_width DROP NOT NULL,
+    ALTER COLUMN tile_height DROP NOT NULL;
+
+UPDATE gsv_data SET image_width = NULL, image_height = NULL, tile_width = NULL, tile_height = NULL;
 
 # --- !Downs
+UPDATE gsv_data
+SET image_width = 13312, image_height = 6656, tile_width = 512, tile_height = 512
+WHERE image_width IS NULL OR image_height IS NULL OR tile_width IS NULL OR tile_height IS NULL;
+
 ALTER TABLE gsv_data
     DROP COLUMN center_heading,
     DROP COLUMN origin_heading,

--- a/conf/evolutions/default/135.sql
+++ b/conf/evolutions/default/135.sql
@@ -1,0 +1,11 @@
+# --- !Ups
+ALTER TABLE gsv_data
+    ADD COLUMN center_heading FLOAT,
+    ADD COLUMN origin_heading FLOAT,
+    ADD COLUMN origin_pitch FLOAT;
+
+# --- !Downs
+ALTER TABLE gsv_data
+    DROP COLUMN center_heading,
+    DROP COLUMN origin_heading,
+    DROP COLUMN origin_pitch;

--- a/conf/routes
+++ b/conf/routes
@@ -63,10 +63,11 @@ GET     /adminapi/auditpath/:id                              @controllers.AdminC
 GET     /adminapi/auditedStreets/:username                   @controllers.AdminController.getStreetsAuditedByAUser(username: String)
 GET     /adminapi/labelLocations/:username                   @controllers.AdminController.getLabelsCollectedByAUser(username: String)
 GET     /adminapi/labels/all                                 @controllers.AdminController.getAllLabels
-GET     /adminapi/labels/panoid                              @controllers.AdminController.getAllPanoIds
 GET     /adminapi/labels/cv                                  @controllers.AdminController.getAllLabelCVMetadata
 GET     /adminapi/label/id/:labelId                          @controllers.AdminController.getAdminLabelData(labelId: Int)
 GET     /adminapi/labelCounts                                @controllers.AdminController.getAllUserLabelCounts
+GET     /adminapi/labels/panoid                              @controllers.AdminController.getAllPanoIds
+GET     /adminapi/panos                                      @controllers.AdminController.getAllPanoIds
 GET     /adminapi/attributes/all                             @controllers.AdminController.getAllAttributes
 GET     /adminapi/validationCounts                           @controllers.AdminController.getAllUserValidationCounts
 PUT     /adminapi/clearPlayCache                             @controllers.AdminController.clearPlayCache

--- a/public/javascripts/SVLabel/src/SVLabel/data/Form.js
+++ b/public/javascripts/SVLabel/src/SVLabel/data/Form.js
@@ -164,6 +164,13 @@ function Form (labelContainer, missionModel, missionContainer, navigationModel, 
             temp = {
                 panorama_id: ("location" in panoramaData && "pano" in panoramaData.location) ? panoramaData.location.pano : "",
                 image_date: "imageDate" in panoramaData ? panoramaData.imageDate : "",
+                image_width: panoramaData.tiles.worldSize.width,
+                image_height: panoramaData.tiles.worldSize.height,
+                tile_width: panoramaData.tiles.tileSize.width,
+                tile_height: panoramaData.tiles.tileSize.height,
+                center_heading: panoramaData.tiles.centerHeading,
+                origin_heading: panoramaData.tiles.originHeading,
+                origin_pitch: panoramaData.tiles.originPitch,
                 links: links,
                 copyright: "copyright" in panoramaData ? panoramaData.copyright : ""
             };


### PR DESCRIPTION
Begins to fix #2485 

We are now recording a lot more metadata about the panoramas that we're using. This also fixes incorrect recording of the metadata that we had been doing in the past. Here's a list of changes:
* We are now correctly recording `image_width`, `image_height`, `tile_width`, and `tile_height` in the `gsv_data` table. We had previously been recording hard coded values of 13312, 6656, 512, and 512 respectively, but these are not actually constant across all panoramas. Going forward, we are recording the correct values from the StreetView API. I've marked all previous data as `NULL`, and I'm hoping that we can write a script to correct the metadata for the imagery that is still available.
* We are now also recording the `center_heading`, `origin_heading`, and `origin_pitch` in the `gsv_data` table. I'm not sure whether or not these will be useful, but it's data that's available, so it's worth recording.
* Removes the `imagery_type` column from the `gsv_data` table. This column was being given a hard-coded value of 1 everywhere. There was also no key for what that value means anywhere, so this column had no purpose.
* Updates the `/adminapi/labels/panoid` API endpoint to include the `image_width` and `image_height` values. I also simplified the JSON output for this endpoint. Previously it was set up as a Feature Collection in GeoJSON, but there's actually no geographic info being included here. So we are now simply outputting an array of objects.
* I've renamed the endpoint from `/adminapi/labels/panoid` to `/adminapi/panos` because that's a more accurate naming. Both endpoints point to the same thing for now. Once all our external tools switch to the new name, I can remove the old one.

##### Before/After screenshots (if applicable)
Before:
```
{
    "type": "FeatureCollection",
    "features": [
        {
            "properties": {
                "gsv_panorama_id": "example-id"
            }
        },
        ...
    ]
}
```

After:
```
[
    {
        "gsv_panorama_id": "example-id",
        "image_width": 16384,
        "image_height": 8192
    },
    ...
]
```

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've included before/after screenshots above.
