### PR TITLE
Clicking navigation message now does smooth panning

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/navigation/Compass.js
+++ b/public/javascripts/SVLabel/src/SVLabel/navigation/Compass.js
@@ -327,7 +327,7 @@ function Compass (svl, mapService, taskContainer, uiCompass) {
             if (direction === 'straight') {
                 mapService.moveForward('CompassMove_Success', 'CompassMove_GSVNotAvailable', null);
             } else {
-                mapService.setPovToRouteDirection();
+                mapService.setPovToRouteDirection(250);
             }
         } else {
             svl.tracker.push('Click_Compass_FarFromRoute');

--- a/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
+++ b/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
@@ -1301,12 +1301,12 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
                 pitchIncrement = pitchDelta * (timeSegment / durationMs);
 
                 interval = window.setInterval(function () {
-                    var headingDelta = pov.heading - currentPov.heading;
-                    if (Math.abs(headingDelta) > 1) {
+                    var headingDelta = (pov.heading - currentPov.heading + 360) % 360;
+                    if (headingDelta > 1 && headingDelta < 359) {
                         // Update heading angle and pitch angle.
                         currentPov.heading += headingIncrement;
                         currentPov.pitch += pitchIncrement;
-                        currentPov.heading = (currentPov.heading + 360) % 360; //Math.ceil(currentPov.heading);
+                        currentPov.heading = (currentPov.heading + 360) % 360;
                         svl.panorama.setPov(currentPov);
                     } else {
                         // Set the pov to adjust zoom level, then clear the interval. Invoke a callback if there is one.
@@ -1481,11 +1481,15 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
     }
 
     // Set the POV in the same direction as the route.
-    function setPovToRouteDirection() {
+    function setPovToRouteDirection(durationMs) {
         var pov = svl.panorama.getPov();
         var compassAngle = svl.compass.getCompassAngle();
-        pov.heading = parseInt(pov.heading - compassAngle, 10) % 360;
-        svl.panorama.setPov(pov);
+        var newPov = {
+            heading: parseInt(pov.heading - compassAngle, 10) % 360,
+            pitch: pov.pitch,
+            zoom: pov.zoom
+        }
+        setPov(newPov, durationMs);
     }
 
     function getMoveDelay() {


### PR DESCRIPTION
Resolves #2825 

Adds smooth panning to the callback when clicking on the navigation messages in the bottom-right of the audit page.

It turns out that this feature had actually already existed! It was just not being used anywhere. And it was kinda broken and would sometimes spin in circles forever :grin: I fixed the bug and we're good to go now!
