### PR TITLE
Adds admin API to get times when all streets were audited

### DIFF
--- a/conf/routes
+++ b/conf/routes
@@ -61,6 +61,7 @@ GET     /adminapi/completionRateByDate                       @controllers.AdminC
 GET     /adminapi/tasks/:username                            @controllers.AdminController.getSubmittedTasksWithLabels(username: String)
 GET     /adminapi/auditpath/:id                              @controllers.AdminController.getAnAuditTaskPath(id: Int)
 GET     /adminapi/auditedStreets/:username                   @controllers.AdminController.getStreetsAuditedByAUser(username: String)
+GET     /adminapi/auditedStreetTimes                         @controllers.AdminController.getAuditedStreetsWithTimestamps
 GET     /adminapi/labelLocations/:username                   @controllers.AdminController.getLabelsCollectedByAUser(username: String)
 GET     /adminapi/labels/all                                 @controllers.AdminController.getAllLabels
 GET     /adminapi/labels/cv                                  @controllers.AdminController.getAllLabelCVMetadata


### PR DESCRIPTION
Begins to address #808 

Adds a new admin-only API endpoint at /adminapi/auditedStreetTimes that shows every audit, along with the timestamp for the audit, and some metadata about the user who performed the audit.