### PR TITLE
#2801: Weekly Leaderboard Fix

### DIFF
--- a/app/views/leaderboard.scala.html
+++ b/app/views/leaderboard.scala.html
@@ -159,8 +159,7 @@
     }
     @if(leaderboardStatsThisWeek.asInstanceOf[List[LeaderboardStat]].length >= min) {
         <div class="item leaderboard-table">
-            <h1 class="leaderboard-header">@Messages("leaderboard.weekly.title")</h1>
-            <h5>@Messages("leaderboard.weekly.detail")</h5>
+            <h1 class="leaderboard-header weekly-header">@Messages("leaderboard.weekly.title")</h1>
             <div class="panel panel-default">
                 <table class="table table-bordered leaderboard-table-striped">
                     <thead class="leaderboard-table-header">

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -297,7 +297,6 @@ leaderboard.weekly.title = Weekly Leaderboard
 leaderboard.inter.org.title = Teams Leaderboard
 leaderboard.org.title = {0} Leaderboard
 leaderboard.overall.detail = Leaders are calculated based on their labels, distance, and accuracy
-leaderboard.weekly.detail = Stats reset every Sunday morning at 12 AM Pacific
 leaderboard.org.detail = Top 10 overall contributors to {0}
 leaderboard.header.team = Team
 leaderboard.header.labels = Labels

--- a/conf/messages.es
+++ b/conf/messages.es
@@ -295,7 +295,6 @@ leaderboard.weekly.title = Tabla de clasificación semanal
 leaderboard.inter.org.title = Tabla de clasificación de equipos
 leaderboard.org.title = Tabla de {0}
 leaderboard.overall.detail = Las posiciones se calculan en base a las etiquetas, distancia y precisión
-leaderboard.weekly.detail = Las estadísticas se restablecen todos los domingos por la mañana a las 12:00 a.m. (PT)
 leaderboard.org.detail = Los 10 contribuyentes mayor a {0}
 leaderboard.header.team = Equipo
 leaderboard.header.labels = Etiquetas

--- a/conf/messages.nl
+++ b/conf/messages.nl
@@ -295,7 +295,6 @@ leaderboard.overall.title = Algemeen klassement
 leaderboard.weekly.title = Wekelijks Scoreboard
 leaderboard.org.title = {0} Scoreboard
 leaderboard.overall.detail = Leiders worden berekend op basis van hun labels, afstand en nauwkeurigheid
-leaderboard.weekly.detail = Statistieken worden elke zondagochtend om 12.00 uur Pacific Time gereset
 leaderboard.org.detail = Top 10 algemene bijdragers aan {0}
 leaderboard.header.labels = Labels
 leaderboard.header.missions = Missies

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -1168,6 +1168,10 @@ kbd {
     font-family: Raleway-regular, sans-serif;
 }
 
+.weekly-header {
+    margin-bottom: 35px;
+}
+
 .leaderboard-detail {
     font-family: Raleway-regular, sans-serif;
 }


### PR DESCRIPTION
Resolves #2801:

Removed incorrect weekly leadership message along with its message and associated translations in the conf conf folder and adjusted css for weekly leaderboard header to add additional spacing to make weekly and overall leaderboard tables still align when shown horizontally

##### Before/After screenshots (if applicable)
Before:
![image](https://user-images.githubusercontent.com/77756028/159591189-588cbd4f-8d7b-4bc4-a25a-4b9ab222a265.png)

After:
![image](https://user-images.githubusercontent.com/77756028/159591081-87946b83-6d57-4952-b6c3-b66780b9edf7.png)

##### Testing instructions
1. Make sure a user has been active within the last week so the weekly leaderboard appears.
2. Go to the "leaderboard" page under the "data" tab to see the page.
3. Check overall leaderboard and weekly leaderboard table alignment when fullscreened (alignment not necessary when display is small enough to stack tables vertically).

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've included before/after screenshots above.
