### PR TITLE
#2831: Fix Dutch Measurement System

### DIFF
--- a/conf/messages.nl
+++ b/conf/messages.nl
@@ -1,4 +1,4 @@
-measurement.system = metrisch
+measurement.system = metric
 curb.ramp = Trottoir oprit
 curb.ramps = Trottoir opritten
 missing.ramp = Ontbrekende trottoir oprit

--- a/public/locales/nl/common.json
+++ b/public/locales/nl/common.json
@@ -1,5 +1,5 @@
 {
-  "measurement-system": "metriek",
+  "measurement-system": "metric",
   "admin-clear-play-cache": "Cache succesvol gewist",
   "unit-distance-abbreviation": "km",
   "unit-abbreviation-mission-distance": "m",


### PR DESCRIPTION
Resolves #2831

Adjusted Dutch language files to set measurement system to 'metric' instead of 'metriek' to allow metric calculations to be used on Dutch version of the webpage.

##### Before/After screenshots (if applicable)

Before:
![image](https://user-images.githubusercontent.com/77756028/159764398-a634aa9f-8a37-45ab-ac41-b34fa4e5a8b0.png)
![image](https://user-images.githubusercontent.com/77756028/159764416-ea18af8a-1995-41ba-b163-b2fdf1da8cf4.png)

After:
![image](https://user-images.githubusercontent.com/77756028/159764443-fc2e7c54-c086-4df1-acca-fbffedcbc94f.png)

##### Testing instructions
1. Check the "Miles Covered" stat on the front page of the en-US version
2. Compare to the "Kilometers afgelegd" stat on the front page of the nl version
3. If the stats are significantly different (calculated properly between miles and kilometers) it should be working!

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've included before/after screenshots above.
