### PR TITLE
Hide broken tooltips when no example image available

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/canvas/Canvas.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/Canvas.js
@@ -152,26 +152,6 @@ function Canvas(ribbon) {
                 targetLabel: status.currentLabel,
                 targetLabelColor: labelColor.fillStyle
             });
-            if (labelType === "Other") {
-              // No tooltips for other.
-              $('#severity-one').tooltip('destroy');
-              $('#severity-three').tooltip('destroy');
-              $('#severity-five').tooltip('destroy');
-            } else {
-              // Update tooltips.
-              $('#severity-one').tooltip('destroy').tooltip({
-                  placement: "top", html: true, delay: { "show": 300, "hide": 10 },
-                  title: i18next.t('center-ui.context-menu.severity-example', {n: 1}) + "<br/><img src='/assets/javascripts/SVLabel/img/severity_popups/" + labelType + "_Severity1.png' height='110' alt='CRseverity 1'/><br/><i>" + i18next.t('center-ui.context-menu.severity-shortcuts') + "</i>"
-              });
-              $('#severity-three').tooltip('destroy').tooltip({
-                  placement: "top", html: true, delay: { "show": 300, "hide": 10 },
-                  title: i18next.t('center-ui.context-menu.severity-example', {n: 3}) + "<br/><img src='/assets/javascripts/SVLabel/img/severity_popups/" + labelType + "_Severity3.png' height='110' alt='CRseverity 3'/><br/><i>" + i18next.t('center-ui.context-menu.severity-shortcuts') + "</i>"
-              });
-              $('#severity-five').tooltip('destroy').tooltip({
-                  placement: "top", html: true, delay: { "show": 300, "hide": 10 },
-                  title: i18next.t('center-ui.context-menu.severity-example', {n: 5}) + "<br/><img src='/assets/javascripts/SVLabel/img/severity_popups/" + labelType + "_Severity5.png' height='110' alt='CRseverity 5'/><br/><i>" + i18next.t('center-ui.context-menu.severity-shortcuts') + "</i>"
-              });
-            }
         }
 
         svl.tracker.push('LabelingCanvas_FinishLabeling', {

--- a/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
@@ -521,24 +521,40 @@ function ContextMenu (uiContextMenu) {
      * @private
      */
     function _setSeverityTooltips(labelType) {
-        if (labelType === "Other") {
-            // No tooltips for other.
-            $('#severity-one').tooltip('destroy');
-            $('#severity-three').tooltip('destroy');
-            $('#severity-five').tooltip('destroy');
-        } else {
-            // Update tooltips.
-            $('#severity-one').tooltip('destroy').tooltip({
-                placement: "top", html: true, delay: { "show": 300, "hide": 10 },
-                title: i18next.t('center-ui.context-menu.severity-example', {n: 1}) + "<br/><img src='/assets/javascripts/SVLabel/img/severity_popups/" + labelType + "_Severity1.png' height='110' alt='CRseverity 1'/><br/><i>" + i18next.t('center-ui.context-menu.severity-shortcuts') + "</i>"
+        var sevTooltipOne = $('#severity-one');
+        var sevTooltipThree = $('#severity-three');
+        var sevTooltipFive = $('#severity-five');
+        var sevImgUrlOne = `/assets/javascripts/SVLabel/img/severity_popups/${labelType}_Severity1.png`
+        var sevImgUrlThree = `/assets/javascripts/SVLabel/img/severity_popups/${labelType}_Severity3.png`
+        var sevImgUrlFive = `/assets/javascripts/SVLabel/img/severity_popups/${labelType}_Severity5.png`
+
+        // Remove old tooltips.
+        sevTooltipOne.tooltip('destroy');
+        sevTooltipThree.tooltip('destroy');
+        sevTooltipFive.tooltip('destroy');
+
+        // Add severity tooltips for the current label type if we have images for them.
+        if (util.fileExists(sevImgUrlOne)) {
+            sevTooltipOne.tooltip({
+                placement: "top", html: true, delay: {"show": 300, "hide": 10},
+                title: i18next.t('center-ui.context-menu.severity-example', {n: 1}) + "<br/><img src='" + sevImgUrlOne +
+                    "' height='110'/><br/><i>" + i18next.t('center-ui.context-menu.severity-shortcuts') + "</i>"
             });
-            $('#severity-three').tooltip('destroy').tooltip({
-                placement: "top", html: true, delay: { "show": 300, "hide": 10 },
-                title: i18next.t('center-ui.context-menu.severity-example', {n: 3}) + "<br/><img src='/assets/javascripts/SVLabel/img/severity_popups/" + labelType + "_Severity3.png' height='110' alt='CRseverity 3'/><br/><i>" + i18next.t('center-ui.context-menu.severity-shortcuts') + "</i>"
+        }
+        if (util.fileExists(sevImgUrlThree)) {
+            sevTooltipThree.tooltip({
+                placement: "top", html: true, delay: {"show": 300, "hide": 10},
+                title: i18next.t('center-ui.context-menu.severity-example', {n: 1}) + "<br/><img src='" +
+                    sevImgUrlThree + "' height='110'/><br/><i>" +
+                    i18next.t('center-ui.context-menu.severity-shortcuts') + "</i>"
             });
-            $('#severity-five').tooltip('destroy').tooltip({
-                placement: "top", html: true, delay: { "show": 300, "hide": 10 },
-                title: i18next.t('center-ui.context-menu.severity-example', {n: 5}) + "<br/><img src='/assets/javascripts/SVLabel/img/severity_popups/" + labelType + "_Severity5.png' height='110' alt='CRseverity 5'/><br/><i>" + i18next.t('center-ui.context-menu.severity-shortcuts') + "</i>"
+        }
+        if (util.fileExists(sevImgUrlFive)) {
+            sevTooltipFive.tooltip({
+                placement: "top", html: true, delay: {"show": 300, "hide": 10},
+                title: i18next.t('center-ui.context-menu.severity-example', {n: 1}) + "<br/><img src='" +
+                    sevImgUrlFive + "' height='110'/><br/><i>" +
+                    i18next.t('center-ui.context-menu.severity-shortcuts') + "</i>"
             });
         }
     }

--- a/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
@@ -469,30 +469,32 @@ function ContextMenu (uiContextMenu) {
 
                         // Convert the first letter of tag text to uppercase and get keyboard shortcut character.
                         const underlineClassOffset = 15;
-                        var keypressChar;
+                        var keyChar;
                         var tooltipHeader;
                         // If first letter is used for keyboard shortcut, the string will start with "<tag-underline".
                         if (tagText[0] === '<') {
-                            keypressChar = tagText[underlineClassOffset];
+                            keyChar = tagText[underlineClassOffset];
                             tooltipHeader = tagText.substring(0,underlineClassOffset) +
                                 tagText[underlineClassOffset].toUpperCase() +
                                 tagText.substring(underlineClassOffset + 1);
                         } else {
                             let underlineIndex = tagText.indexOf('<');
-                            keypressChar = tagText[underlineIndex + underlineClassOffset];
+                            keyChar = tagText[underlineIndex + underlineClassOffset];
                             tooltipHeader = tagText[0].toUpperCase() + tagText.substring(1);
                         }
 
-                        // Add tooltip with tag example.
-                        tagHolder.find("button[id=" + count + "]").tooltip("destroy").tooltip(({
-                            placement: 'top',
-                            html: true,
-                            delay: { "show": 300, "hide": 10 },
-                            height: '130',
-                            title: tooltipHeader + "<br/><img src='/assets/javascripts/SVLabel/img/label_tag_popups/" +
-                                tag.tag_id + ".png' height='125'/><br/> <i>" +
-                                i18next.t('center-ui.context-menu.label-popup-shortcuts', {c: keypressChar}) + "</i>"
-                        })).tooltip("show").tooltip("hide");
+                        // Add tooltip with tag example if we have an example image to show.
+                        var imageUrl = `/assets/javascripts/SVLabel/img/label_tag_popups/${tag.tag_id}.png`;
+                        if (util.fileExists(imageUrl)) {
+                            tagHolder.find("button[id=" + count + "]").tooltip("destroy").tooltip(({
+                                placement: 'top',
+                                html: true,
+                                delay: {"show": 300, "hide": 10},
+                                height: '130',
+                                title: tooltipHeader + "<br/><img src='" + imageUrl + "' height='125'/><br/> <i>" +
+                                    i18next.t('center-ui.context-menu.label-popup-shortcuts', {c: keyChar}) + "</i>"
+                            })).tooltip("show").tooltip("hide");
+                        }
 
                         count += 1;
                     }

--- a/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
@@ -515,6 +515,35 @@ function ContextMenu (uiContextMenu) {
     }
 
     /**
+     * Set context menu severity tooltips to the correct text/images for the given label type.
+     *
+     * @param labelType
+     * @private
+     */
+    function _setSeverityTooltips(labelType) {
+        if (labelType === "Other") {
+            // No tooltips for other.
+            $('#severity-one').tooltip('destroy');
+            $('#severity-three').tooltip('destroy');
+            $('#severity-five').tooltip('destroy');
+        } else {
+            // Update tooltips.
+            $('#severity-one').tooltip('destroy').tooltip({
+                placement: "top", html: true, delay: { "show": 300, "hide": 10 },
+                title: i18next.t('center-ui.context-menu.severity-example', {n: 1}) + "<br/><img src='/assets/javascripts/SVLabel/img/severity_popups/" + labelType + "_Severity1.png' height='110' alt='CRseverity 1'/><br/><i>" + i18next.t('center-ui.context-menu.severity-shortcuts') + "</i>"
+            });
+            $('#severity-three').tooltip('destroy').tooltip({
+                placement: "top", html: true, delay: { "show": 300, "hide": 10 },
+                title: i18next.t('center-ui.context-menu.severity-example', {n: 3}) + "<br/><img src='/assets/javascripts/SVLabel/img/severity_popups/" + labelType + "_Severity3.png' height='110' alt='CRseverity 3'/><br/><i>" + i18next.t('center-ui.context-menu.severity-shortcuts') + "</i>"
+            });
+            $('#severity-five').tooltip('destroy').tooltip({
+                placement: "top", html: true, delay: { "show": 300, "hide": 10 },
+                title: i18next.t('center-ui.context-menu.severity-example', {n: 5}) + "<br/><img src='/assets/javascripts/SVLabel/img/severity_popups/" + labelType + "_Severity5.png' height='110' alt='CRseverity 5'/><br/><i>" + i18next.t('center-ui.context-menu.severity-shortcuts') + "</i>"
+            });
+        }
+    }
+
+    /**
      * Show the context menu
      * @param x x-coordinate on the canvas pane
      * @param y y-coordinate on the canvas pane
@@ -593,6 +622,7 @@ function ContextMenu (uiContextMenu) {
             }
         }
         self.updateRadioButtonImages();
+        _setSeverityTooltips(labelType);
     }
 
     /**

--- a/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
+++ b/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
@@ -896,42 +896,12 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
                         targetLabel: selectedLabel,
                         targetLabelColor: selectedLabel.getProperty("labelFillStyle")
                     });
-                    var labelType = selectedLabel.getProperty("labelType");
-                    if (labelType === "Other") {
-                        // No tooltips for other.
-                        $('#severity-one').tooltip('destroy');
-                        $('#severity-three').tooltip('destroy');
-                        $('#severity-five').tooltip('destroy');
-                    } else {
-                        // Update tooltips.
-                        $('#severity-one').tooltip('destroy').tooltip({
-                            placement: "top", html: true, delay: { "show": 300, "hide": 10 },
-                            title: i18next.t('center-ui.context-menu.severity-example', { n: 1 }) +
-                                "<br/><img src='/assets/javascripts/SVLabel/img/severity_popups/" + labelType +
-                                "_Severity1.png' height='110' alt='CRseverity 1'/><br/><i>" +
-                                i18next.t('center-ui.context-menu.severity-shortcuts') + "</i>"
-                        });
-                        $('#severity-three').tooltip('destroy').tooltip({
-                            placement: "top", html: true, delay: { "show": 300, "hide": 10 },
-                            title: i18next.t('center-ui.context-menu.severity-example', { n: 3 }) +
-                                "<br/><img src='/assets/javascripts/SVLabel/img/severity_popups/" + labelType +
-                                "_Severity3.png' height='110' alt='CRseverity 3'/><br/><i>" +
-                                i18next.t('center-ui.context-menu.severity-shortcuts') + "</i>"
-                        });
-                        $('#severity-five').tooltip('destroy').tooltip({
-                            placement: "top", html: true, delay: { "show": 300, "hide": 10 },
-                            title: i18next.t('center-ui.context-menu.severity-example', { n: 5 }) +
-                                "<br/><img src='/assets/javascripts/SVLabel/img/severity_popups/" + labelType +
-                                "_Severity5.png' height='110' alt='CRseverity 5'/><br/><i>" +
-                                i18next.t('center-ui.context-menu.severity-shortcuts') + "</i>"
-                        });
-                    }
                 }
                 contextMenuWasOpen = false;
             }
         } else if (currTime - mouseStatus.prevMouseUpTime < 300) {
             // Continue logging double click. We don't have any features for it now, but it's good to know how
-            // frequently people are trying to double click. They might be trying to zoom?
+            // frequently people are trying to double-click. They might be trying to zoom?
             svl.tracker.push('ViewControl_DoubleClick');
         }
         setViewControlLayerCursor('OpenHand');

--- a/public/javascripts/common/Utilities.js
+++ b/public/javascripts/common/Utilities.js
@@ -50,6 +50,14 @@ function getURLParameter(argName) {
 }
 util.getURLParameter = getURLParameter;
 
+function fileExists(url) {
+    var http = new XMLHttpRequest();
+    http.open('HEAD', url, false);
+    http.send();
+    return http.status !== 404;
+}
+util.fileExists = fileExists;
+
 // Array Remove - By John Resig (MIT Licensed)
 // http://stackoverflow.com/questions/500606/javascript-array-delete-elements
 Array.prototype.remove = function(from, to) {


### PR DESCRIPTION
Resolves #2791 

Instead of showing a broken tooltip on the Explore page when there is no example image available, we show no tooltip at all anymore.

##### Before/After screenshots (if applicable)
Before
![tooltip-before](https://user-images.githubusercontent.com/6518824/159810240-1942ecb6-2d00-40bf-b365-00fae0d19369.png)

After
![tooltip-after](https://user-images.githubusercontent.com/6518824/159810251-34689245-24e5-44a2-acbb-87521c121842.png)

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
