### PR TITLE
Removes severity options for Pedestrian Signal label type

### DIFF
--- a/public/javascripts/Gallery/src/cards/Card.js
+++ b/public/javascripts/Gallery/src/cards/Card.js
@@ -118,7 +118,7 @@ function Card (params, imageUrl, modal) {
         cardInfo.appendChild(cardData);
 
         // Create the div to store the severity of the label.
-        if (getLabelType() !== "Occlusion") {
+        if (getLabelType() !== 'Occlusion' && getLabelType() !== 'Signal') {
             let cardSeverity = document.createElement('div');
             cardSeverity.className = 'card-severity';
             let severityHolder = new SeverityDisplay(cardSeverity, properties.severity);

--- a/public/javascripts/Gallery/src/filter/CardFilter.js
+++ b/public/javascripts/Gallery/src/filter/CardFilter.js
@@ -102,6 +102,13 @@ function CardFilter(uiCardFilter, labelTypeMenu, cityMenu) {
         } else {
             $("#filters").show();
             $("#horizontal-line").show();
+            if (status.currentLabelType === 'Signal') {
+                $('#severity-header').hide();
+                $('#severity-select').hide();
+            } else {
+                $('#severity-header').show();
+                $('#severity-select').show();
+            }
         }
 
         severities.render(uiCardFilter.severity);

--- a/public/javascripts/SVLabel/css/svl-context-menu.css
+++ b/public/javascripts/SVLabel/css/svl-context-menu.css
@@ -27,10 +27,6 @@
     margin-bottom: 5px;
 }
 
-#severity-menu {
-    height: 50px;
-}
-
 .context-menu-wheelchair-icons {
     cursor: default;
     width: 30px;

--- a/public/javascripts/SVLabel/src/SVLabel/Main.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Main.js
@@ -493,6 +493,7 @@ function Main (params) {
         svl.ui.contextMenu = {};
         svl.ui.contextMenu.holder = $("#context-menu-holder");
         svl.ui.contextMenu.connector = $("#context-menu-vertical-connector");
+        svl.ui.contextMenu.severityMenu = $("#severity-menu");
         svl.ui.contextMenu.radioButtons = $("input[name='label-severity']");
         svl.ui.contextMenu.temporaryLabelCheckbox = $("#context-menu-temporary-problem-checkbox");
         svl.ui.contextMenu.tagHolder = $("#context-menu-tag-holder");

--- a/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
@@ -8,6 +8,7 @@ function ContextMenu (uiContextMenu) {
         };
     var $menuWindow = uiContextMenu.holder,
         $connector = uiContextMenu.connector,
+        $severityMenu = uiContextMenu.severityMenu,
         $radioButtons = uiContextMenu.radioButtons,
         $temporaryLabelCheckbox = uiContextMenu.temporaryLabelCheckbox,
         $descriptionTextBox = uiContextMenu.textBox,
@@ -572,8 +573,7 @@ function ContextMenu (uiContextMenu) {
         $descriptionTextBox.val(null);
         if (x && y && ('targetLabel' in param)) {
             var labelType = param.targetLabel.getLabelType();
-            var acceptedLabelTypes = ['SurfaceProblem', 'Obstacle', 'NoCurbRamp', 'NoSidewalk', 'Other', 'CurbRamp', 'Crosswalk', 'Signal'];
-            if (acceptedLabelTypes.indexOf(labelType) !== -1) {
+            if (labelType !== 'Obstruction') {
                 setStatus('targetLabel', param.targetLabel);
                 setTags(param.targetLabel);
                 setTagColor(param.targetLabel);
@@ -603,7 +603,7 @@ function ContextMenu (uiContextMenu) {
                     description = param.targetLabel.getProperty('description');
                 if (severity) {
                     $radioButtons.each(function (i, v) {
-                       if (severity == i + 1) { $(this).prop("checked", true); }
+                       if (severity === i + 1) { $(this).prop("checked", true); }
                     });
                 }
 
@@ -622,6 +622,13 @@ function ContextMenu (uiContextMenu) {
                     top: topCoordinate + connectorCoordinate,
                     left: x - 3
                 });
+
+                // Hide the severity menu for the Pedestrian Signal label type.
+                if (labelType === 'Signal') {
+                    $severityMenu.css({visibility: 'hidden', height: '0px'});
+                } else {
+                    $severityMenu.css({visibility: 'inherit', height: '50px'});
+                }
 
                 setStatus('visibility', 'visible');
 

--- a/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
@@ -573,7 +573,7 @@ function ContextMenu (uiContextMenu) {
         $descriptionTextBox.val(null);
         if (x && y && ('targetLabel' in param)) {
             var labelType = param.targetLabel.getLabelType();
-            if (labelType !== 'Obstruction') {
+            if (labelType !== 'Occlusion') {
                 setStatus('targetLabel', param.targetLabel);
                 setTags(param.targetLabel);
                 setTagColor(param.targetLabel);


### PR DESCRIPTION
Resolves #2795 

Removes severity as an option for the Pedestrian Signal label type, as the severity metric doesn't make much sense for that type. This also removes severity from the list of filters for Pedestrian Signal in Gallery.

##### Before/After screenshots (if applicable)
Before
![context-menu-before](https://user-images.githubusercontent.com/6518824/159814632-c7a6757e-655e-4122-b394-349548da3376.png)
![gallery-before](https://user-images.githubusercontent.com/6518824/159814635-c07cfe27-b679-4cb7-9141-60a825c47837.png)

After
![context-menu-after](https://user-images.githubusercontent.com/6518824/159814640-062291c7-7652-433c-b0f6-9c8d1d1059bf.png)
![gallery-after](https://user-images.githubusercontent.com/6518824/159814649-d80d6d71-e61c-45d5-be10-a8b542013cab.png)

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
