### PR TITLE
2816: Temporarily hiding the Chicago Server "Results Map" button

### DIFF
--- a/app/views/navbar.scala.html
+++ b/app/views/navbar.scala.html
@@ -117,11 +117,14 @@
                         <b class="caret"></b>
                     </a>
                     <ul id="nav-data-menu" class="dropdown-menu" role="menu" aria-label="Data Options">
-                        <li>
-                            <a id="navbar-results-btn" role="menuitem" href="@routes.ApplicationController.results">@Messages("navbar.results")</a>
-                        </li>
+                        <!-- Hides the "Results Map" tab for the Chicago server version-->
+                        @if(!List("chicago-il").contains(currentCity)) {
+                            <li>
+                                <a id="navbar-results-btn" role="menuitem" href="@routes.ApplicationController.results">@Messages("navbar.results")</a>
+                            </li>
+                        }
                         <!-- Only show Label Map link if the city does not have too much data to load that page quickly. -->
-                        @if(!List("seattle-wa").contains(Play.configuration.getString("city-id").get)) {
+                        @if(!List("seattle-wa").contains(currentCity)) {
                             <li>
                                 <a id="navbar-labelmap-btn" role="menuitem" href="@routes.ApplicationController.labelMap">@Messages("navbar.labelmap")</a>
                             </li>


### PR DESCRIPTION
Resolves #2816

Results map tab is now hidden whenever the current server is Chicago, IL. Also removed redundancy in hiding local map tab for Seattle server.

##### Before/After screenshots (if applicable)

Before:
![image](https://user-images.githubusercontent.com/77756028/160731913-9071ea1e-4ef3-4cb9-8163-0a2817856b13.png)

After:
![image](https://user-images.githubusercontent.com/77756028/160731355-97eaacfa-2deb-40c1-b206-74246851a73d.png)

##### Testing instructions
1. Load up the Chicago Test Server
2. Click on the "data" tab in the navbar
3. If the first dropdown button is NOT "results map" then the button was hidden correctly!

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
