### PR TITLE
Adds validation status filters to the UI in Label Map

### DIFF
--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -95,7 +95,7 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
    */
   def getAllLabels = UserAwareAction.async { implicit request =>
     if (isAdmin(request.identity)) {
-      val labels = LabelTable.selectLocationsAndSeveritiesOfLabels(false)
+      val labels = LabelTable.selectLocationsAndSeveritiesOfLabels
       val features: List[JsObject] = labels.map { label =>
         val point = geojson.Point(geojson.LatLng(label.lat.toDouble, label.lng.toDouble))
         val properties = Json.obj(
@@ -104,7 +104,8 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
           "gsv_panorama_id" -> label.gsvPanoramaId,
           "label_type" -> label.labelType,
           "severity" -> label.severity,
-          "correct" -> label.correct
+          "correct" -> label.correct,
+          "high_quality_user" -> label.highQualityUser
         )
         Json.obj("type" -> "Feature", "geometry" -> point, "properties" -> properties)
       }
@@ -118,8 +119,8 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
   /**
    * Get a list of all labels with metadata needed for /labelMap.
    */
-  def getAllLabelsForLabelMap(filterLowQuality: Boolean) = UserAwareAction.async { implicit request =>
-    val labels = LabelTable.selectLocationsAndSeveritiesOfLabels(filterLowQuality)
+  def getAllLabelsForLabelMap = UserAwareAction.async { implicit request =>
+    val labels = LabelTable.selectLocationsAndSeveritiesOfLabels
     val features: List[JsObject] = labels.map { label =>
       val point = geojson.Point(geojson.LatLng(label.lat.toDouble, label.lng.toDouble))
       val properties = Json.obj(
@@ -128,7 +129,8 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
         "label_type" -> label.labelType,
         "severity" -> label.severity,
         "correct" -> label.correct,
-        "expired" -> label.expired
+        "expired" -> label.expired,
+        "high_quality_user" -> label.highQualityUser
       )
       Json.obj("type" -> "Feature", "geometry" -> point, "properties" -> properties)
     }

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -353,7 +353,7 @@
                                         </tr>
                                         <tr>
                                             <td id="map-legend-curb-ramp" width="12px"></td>
-                                            <td width="190px">Curb Ramp</td>
+                                            <td width="190px">@Messages("curb.ramp")</td>
                                             <td width="12px"  align="center"><input type="checkbox" value="displaylabel" id="curbramp" checked="true" onclick = "admin.toggleLayers('CurbRamp', 'curbramp', '#curb-ramp-slider')"></td>
                                             <td width="126px"align="center"><div id = "curb-ramp-slider" style="margin-top:3px"></div></td>
                                             <td width="80px" align= "center" ><span id="curb-ramp-severity-label">N/A - 5</span></td>
@@ -361,48 +361,48 @@
                                         </tr>
                                         <tr>
                                             <td id="map-legend-no-curb-ramp"></td>
-                                            <td>Missing Curb Ramp</td>
+                                            <td>@Messages("no.ramp")</td>
                                             <td><input type="checkbox" value="displaylabel" id="missingcurbramp" checked="true" onclick = "admin.toggleLayers('NoCurbRamp', 'missingcurbramp', '#missing-curb-ramp-slider')"></td>
                                             <td align="left"><div id = "missing-curb-ramp-slider" style="margin-top:3px"></div></td>
                                             <td align= "center"><span id="missing-curb-ramp-severity-label">N/A - 5</span></td>
                                         </tr>
                                         <tr>
                                             <td id="map-legend-obstacle"></td>
-                                            <td>Obstacle in Path</td>
+                                            <td>@Messages("obstacle")</td>
                                             <td><input type="checkbox" value="displaylabel" id="obstacle" checked="true" onclick="admin.toggleLayers('Obstacle', 'obstacle', '#obstacle-slider')"></td>
                                             <td align="left"><div id = "obstacle-slider" style="margin-top:3px"></div></td>
                                             <td align= "center"><span id="obstacle-severity-label">N/A - 5</span></td>
                                         </tr>
                                         <tr><td id="map-legend-surface-problem"></td>
-                                            <td>Surface Problem</td>
+                                            <td>@Messages("surface.problem")</td>
                                             <td><input type="checkbox" value="displaylabel" id="surfaceprob" checked="true" onclick="admin.toggleLayers('SurfaceProblem', 'surfaceprob', '#surface-problem-slider')"></td>
                                             <td align="left"><div id = "surface-problem-slider" style="margin-top:3px"></div></td>
                                             <td align="center"><span id="surface-problem-severity-label">N/A - 5</span></td>
                                         </tr>
                                         <tr>
                                             <td id="map-legend-crosswalk"></td>
-                                            <td>Crosswalk</td>
+                                            <td>@Messages("crosswalk")</td>
                                             <td><input type="checkbox" value="displaylabel" id="crosswalk" checked="true" onclick="admin.toggleLayers('Crosswalk', 'crosswalk', '#crosswalk-slider')"></td>
                                             <td align="left"><div id = "crosswalk-slider" style="margin-top:3px"></div></td>
                                             <td align="center"><span id="crosswalk-severity-label">N/A - 5</span></td>
                                         </tr>
                                         <tr>
                                             <td id="map-legend-no-sidewalk"></td>
-                                            <td>No Sidewalk</td>
+                                            <td>@Messages("no.sidewalk")</td>
                                             <td><input type="checkbox" value="displaylabel" id="nosidewalk" checked="true" onclick="admin.toggleLayers('NoSidewalk', 'nosidewalk', '#no-sidewalk-slider')"></td>
                                             <td align="left"><div id = "no-sidewalk-slider" style="margin-top:3px"></div></td>
                                             <td align="center"><span id="no-sidewalk-severity-label">N/A - 5</span></td>
                                         </tr>
                                         <tr>
                                             <td id="map-legend-other"></td>
-                                            <td>Other</td>
+                                            <td>@Messages("other")</td>
                                             <td><input type="checkbox" value="displaylabel" id="other" checked="true" onclick="admin.toggleLayers('Other', 'other', '#other-slider')"></td>
                                             <td align="left"><div id = "other-slider" style="margin-top:3px"></div></td>
                                             <td align= "center"><span id="other-severity-label">N/A - 5</span></td>
                                         </tr>
                                         <tr>
                                             <td id="map-legend-signal"></td>
-                                            <td>Pedestrian Signal</td>
+                                            <td>@Messages("signal")</td>
                                             <td><input type="checkbox" value="displaylabel" id="signal" checked="true" onclick="admin.toggleLayers('Signal', 'signal', undefined)"></td>
                                         </tr>
                                         <tr>

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -411,9 +411,24 @@
                                             <td><input type="checkbox" value="displaylabel" id="occlusion" checked="true" onclick="admin.toggleLayers('Occlusion', 'occlusion', undefined)"></td>
                                         </tr>
                                         <tr>
-                                        <td id="map-legend-audited-street"></td>
-                                        <td>Audited Street</td>
-                                        <td><input type="checkbox" value="displaylabel" id="auditedstreet" checked="true" onclick="admin.toggleAuditedStreetLayer()"></td>
+                                            <td id="map-legend-correct"></td>
+                                            <td>Validated correct</td>
+                                            <td><input type="checkbox" value="displaylabel" id="correct" checked="true" onclick="admin.filterLayers('correct')"></td>
+                                        </tr>
+                                        <tr>
+                                            <td id="map-legend-incorrect"></td>
+                                            <td>Validated incorrect</td>
+                                            <td><input type="checkbox" value="displaylabel" id="incorrect" checked="false" onclick="admin.filterLayers('incorrect')"></td>
+                                        </tr>
+                                        <tr>
+                                            <td id="map-legend-unvalidated"></td>
+                                            <td>Unvalidated</td>
+                                            <td><input type="checkbox" value="displaylabel" id="unvalidated" checked="true" onclick="admin.filterLayers('unvalidated')"></td>
+                                        </tr>
+                                        <tr>
+                                            <td id="map-legend-audited-street"></td>
+                                            <td>Audited Street</td>
+                                            <td><input type="checkbox" value="displaylabel" id="auditedstreet" checked="true" onclick="admin.toggleAuditedStreetLayer()"></td>
                                         </tr>
                                     </table>
                                 </div>

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -411,17 +411,17 @@
                                             <td><input type="checkbox" value="displaylabel" id="occlusion" checked="true" onclick="admin.toggleLayers('Occlusion', 'occlusion', undefined)"></td>
                                         </tr>
                                         <tr>
-                                            <td id="map-legend-correct"></td>
+                                            <td id="map-legend-correct"><img src='@routes.Assets.at("javascripts/SVValidate/img/Checkmark.png")' style="width: 23px; padding: 3px;"></td>
                                             <td>Validated correct</td>
                                             <td><input type="checkbox" value="displaylabel" id="correct" checked="true" onclick="admin.filterLayers('correct')"></td>
                                         </tr>
                                         <tr>
-                                            <td id="map-legend-incorrect"></td>
+                                            <td id="map-legend-incorrect"><img src='@routes.Assets.at("javascripts/SVValidate/img/Cross.png")' style="width: 23px; padding: 3px;"></td>
                                             <td>Validated incorrect</td>
                                             <td><input type="checkbox" value="displaylabel" id="incorrect" onclick="admin.filterLayers('incorrect')"></td>
                                         </tr>
                                         <tr>
-                                            <td id="map-legend-unvalidated"></td>
+                                            <td id="map-legend-unvalidated"><img src='@routes.Assets.at("javascripts/SVValidate/img/QuestionMark.png")' style="width: 18px; padding: 2px; padding-left: 6px;"></td>
                                             <td>Unvalidated</td>
                                             <td><input type="checkbox" value="displaylabel" id="unvalidated" checked="true" onclick="admin.filterLayers('unvalidated')"></td>
                                         </tr>

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -906,6 +906,9 @@
                 }
             });
         });
+        console.log("To add data from users marked as 'low quality'', use the following commands. You can run them again with 'false' to remove.");
+        console.log("map.mapData.lowQualityUsers = true;");
+        console.log("filterLayers('',map.mapData);");
 
     </script>
     <script>

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -380,6 +380,13 @@
                                             <td align="center"><span id="surface-problem-severity-label">N/A - 5</span></td>
                                         </tr>
                                         <tr>
+                                            <td id="map-legend-crosswalk"></td>
+                                            <td>Crosswalk</td>
+                                            <td><input type="checkbox" value="displaylabel" id="crosswalk" checked="true" onclick="admin.toggleLayers('Crosswalk', 'crosswalk', '#crosswalk-slider')"></td>
+                                            <td align="left"><div id = "crosswalk-slider" style="margin-top:3px"></div></td>
+                                            <td align="center"><span id="crosswalk-severity-label">N/A - 5</span></td>
+                                        </tr>
+                                        <tr>
                                             <td id="map-legend-no-sidewalk"></td>
                                             <td>No Sidewalk</td>
                                             <td><input type="checkbox" value="displaylabel" id="nosidewalk" checked="true" onclick="admin.toggleLayers('NoSidewalk', 'nosidewalk', '#no-sidewalk-slider')"></td>
@@ -392,6 +399,11 @@
                                             <td><input type="checkbox" value="displaylabel" id="other" checked="true" onclick="admin.toggleLayers('Other', 'other', '#other-slider')"></td>
                                             <td align="left"><div id = "other-slider" style="margin-top:3px"></div></td>
                                             <td align= "center"><span id="other-severity-label">N/A - 5</span></td>
+                                        </tr>
+                                        <tr>
+                                            <td id="map-legend-signal"></td>
+                                            <td>Pedestrian Signal</td>
+                                            <td><input type="checkbox" value="displaylabel" id="signal" checked="true" onclick="admin.toggleLayers('Signal', 'signal', '#signal-slider')"></td>
                                         </tr>
                                         <tr>
                                             <td id="map-legend-occlusion"></td>
@@ -844,6 +856,8 @@
         sliderToLabelMap['surface-problem-slider'] = '#surface-problem-severity-label';
         sliderToLabelMap['occlusion-slider']  = '#occlusion-severity-label';
         sliderToLabelMap['no-sidewalk-slider'] = '#no-sidewalk-severity-label';
+        sliderToLabelMap["crosswalk-slider"]  = "#crosswalk-severity-label";
+        sliderToLabelMap["signal-slider"]  = "#signal-severity-label";
         sliderToLabelMap['other-slider'] = '#other-severity-label';
 
         $("*[id*='slider']").each(function() {
@@ -873,6 +887,10 @@
                         admin.toggleLayers('Occlusion', 'occlusion', '#occlusion-slider');
                     } else if (this.id === 'no-sidewalk-slider') {
                         admin.toggleLayers('NoSidewalk', 'nosidewalk', '#no-sidewalk-slider');
+                    } else if (this.id === 'crosswalk-slider') {
+                        admin.toggleLayers('Crosswalk', 'crosswalk', '#crosswalk-slider');
+                    } else if (this.id === 'signal-slider') {
+                        admin.toggleLayers('Signal', 'signal', '#signal-slider');
                     } else if (this.id === 'other-slider') {
                         admin.toggleLayers('Other', 'other', '#other-slider');
                     }

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -403,12 +403,12 @@
                                         <tr>
                                             <td id="map-legend-signal"></td>
                                             <td>Pedestrian Signal</td>
-                                            <td><input type="checkbox" value="displaylabel" id="signal" checked="true" onclick="admin.toggleLayers('Signal', 'signal', '#signal-slider')"></td>
+                                            <td><input type="checkbox" value="displaylabel" id="signal" checked="true" onclick="admin.toggleLayers('Signal', 'signal', undefined)"></td>
                                         </tr>
                                         <tr>
                                             <td id="map-legend-occlusion"></td>
                                             <td>Can't see sidewalk</td>
-                                            <td><input type="checkbox" value="displaylabel" id="occlusion" checked="true" onclick="admin.toggleLayers('Occlusion', 'occlusion', '#occlusion-slider')"></td>
+                                            <td><input type="checkbox" value="displaylabel" id="occlusion" checked="true" onclick="admin.toggleLayers('Occlusion', 'occlusion', undefined)"></td>
                                         </tr>
                                         <tr>
                                         <td id="map-legend-audited-street"></td>
@@ -854,10 +854,8 @@
         sliderToLabelMap['missing-curb-ramp-slider'] = '#missing-curb-ramp-severity-label';
         sliderToLabelMap['obstacle-slider'] = '#obstacle-severity-label';
         sliderToLabelMap['surface-problem-slider'] = '#surface-problem-severity-label';
-        sliderToLabelMap['occlusion-slider']  = '#occlusion-severity-label';
         sliderToLabelMap['no-sidewalk-slider'] = '#no-sidewalk-severity-label';
         sliderToLabelMap["crosswalk-slider"]  = "#crosswalk-severity-label";
-        sliderToLabelMap["signal-slider"]  = "#signal-severity-label";
         sliderToLabelMap['other-slider'] = '#other-severity-label';
 
         $("*[id*='slider']").each(function() {
@@ -883,14 +881,10 @@
                         admin.toggleLayers('Obstacle', 'obstacle', '#obstacle-slider');
                     } else if (this.id === 'surface-problem-slider') {
                         admin.toggleLayers('SurfaceProblem', 'surfaceprob', '#surface-problem-slider');
-                    } else if (this.id === 'occlusion-slider') {
-                        admin.toggleLayers('Occlusion', 'occlusion', '#occlusion-slider');
                     } else if (this.id === 'no-sidewalk-slider') {
                         admin.toggleLayers('NoSidewalk', 'nosidewalk', '#no-sidewalk-slider');
                     } else if (this.id === 'crosswalk-slider') {
                         admin.toggleLayers('Crosswalk', 'crosswalk', '#crosswalk-slider');
-                    } else if (this.id === 'signal-slider') {
-                        admin.toggleLayers('Signal', 'signal', '#signal-slider');
                     } else if (this.id === 'other-slider') {
                         admin.toggleLayers('Other', 'other', '#other-slider');
                     }

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -418,7 +418,7 @@
                                         <tr>
                                             <td id="map-legend-incorrect"></td>
                                             <td>Validated incorrect</td>
-                                            <td><input type="checkbox" value="displaylabel" id="incorrect" checked="false" onclick="admin.filterLayers('incorrect')"></td>
+                                            <td><input type="checkbox" value="displaylabel" id="incorrect" onclick="admin.filterLayers('incorrect')"></td>
                                         </tr>
                                         <tr>
                                             <td id="map-legend-unvalidated"></td>

--- a/app/views/admin/user.scala.html
+++ b/app/views/admin/user.scala.html
@@ -26,6 +26,8 @@
                             <tr><td id="map-legend-obstacle"></td><td>@Messages("obstacle")</td><td id="td-number-of-obstacles"></td></tr>
                             <tr><td id="map-legend-surface-problem"></td><td>@Messages("surface.problem")</td><td id="td-number-of-surface-problems"></td></tr>
                             <tr><td id="map-legend-no-sidewalk"></td><td>@Messages("no.sidewalk")</td><td id="td-number-of-no-sidewalks"></td></tr>
+                            <tr><td id="map-legend-crosswalk"></td><td>@Messages("crosswalk")</td><td id="td-number-of-crosswalks"></td></tr>
+                            <tr><td id="map-legend-signal"></td><td>@Messages("signal")</td><td id="td-number-of-signals"></td></tr>
                             <tr><td id="map-legend-audited-street"></td><td>@Messages("dashboard.audited.street")</td></tr>
                         </table>
                     </div>

--- a/app/views/labelMap.scala.html
+++ b/app/views/labelMap.scala.html
@@ -80,6 +80,21 @@
                         <td><input type="checkbox" value="displaylabel" id="occlusion" checked="true" onclick="toggleLayers('Occlusion', 'occlusion', undefined, map.map, map.mapData)"></td>
                     </tr>
                     <tr>
+                        <td id="map-legend-correct"></td>
+                        <td>Validated correct</td>
+                        <td><input type="checkbox" value="displaylabel" id="correct" checked="true" onclick="filterLayers('correct', map.mapData)"></td>
+                    </tr>
+                    <tr>
+                        <td id="map-legend-incorrect"></td>
+                        <td>Validated incorrect</td>
+                        <td><input type="checkbox" value="displaylabel" id="incorrect" checked="false" onclick="filterLayers('incorrect', map.mapData)"></td>
+                    </tr>
+                    <tr>
+                        <td id="map-legend-unvalidated"></td>
+                        <td>Unvalidated</td>
+                        <td><input type="checkbox" value="displaylabel" id="unvalidated" checked="true" onclick="filterLayers('unvalidated', map.mapData)"></td>
+                    </tr>
+                    <tr>
                         <td id="map-legend-audited-street"></td>
                         <td>Audited Street</td>
                         <td><input type="checkbox" value="displaylabel" id="auditedstreet" checked="true" onclick="toggleAuditedStreetLayer(map.map, map.auditedStreetLayer)"></td>

--- a/app/views/labelMap.scala.html
+++ b/app/views/labelMap.scala.html
@@ -87,7 +87,7 @@
                     <tr>
                         <td id="map-legend-incorrect"></td>
                         <td>Validated incorrect</td>
-                        <td><input type="checkbox" value="displaylabel" id="incorrect" checked="false" onclick="filterLayers('incorrect', map.mapData)"></td>
+                        <td><input type="checkbox" value="displaylabel" id="incorrect" onclick="filterLayers('incorrect', map.mapData)"></td>
                     </tr>
                     <tr>
                         <td id="map-legend-unvalidated"></td>

--- a/app/views/labelMap.scala.html
+++ b/app/views/labelMap.scala.html
@@ -23,7 +23,7 @@
                     <tr>
                         <td id="map-legend-curb-ramp" width="12px"></td>
                         <td width="190px">Curb Ramp</td>
-                        <td width="12px"  align="center"><input type="checkbox" value="displaylabel" id="curbramp" checked="true" onclick = "toggleLayers('CurbRamp', 'curbramp', '#curb-ramp-slider', map.map, map.mapData.allLayers)"></td>
+                        <td width="12px"  align="center"><input type="checkbox" value="displaylabel" id="curbramp" checked="true" onclick = "toggleLayers('CurbRamp', 'curbramp', '#curb-ramp-slider', map.mapData.allLayers)"></td>
                         <td width="126px"align="center"><div id = "curb-ramp-slider" style="margin-top:3px"></div></td>
                         <td width="80px" align= "center" ><span id="curb-ramp-severity-label">N/A - 5</span></td>
 
@@ -31,53 +31,53 @@
                     <tr>
                         <td id="map-legend-no-curb-ramp"></td>
                         <td>Missing Curb Ramp</td>
-                        <td><input type="checkbox" value="displaylabel" id="missingcurbramp" checked="true" onclick = "toggleLayers('NoCurbRamp', 'missingcurbramp', '#missing-curb-ramp-slider', map.map, map.mapData.allLayers)"></td>
+                        <td><input type="checkbox" value="displaylabel" id="missingcurbramp" checked="true" onclick = "toggleLayers('NoCurbRamp', 'missingcurbramp', '#missing-curb-ramp-slider', map.mapData.allLayers)"></td>
                         <td align="left"><div id = "missing-curb-ramp-slider" style="margin-top:3px"></div></td>
                         <td align= "center"><span id="missing-curb-ramp-severity-label">N/A - 5</span></td>
                     </tr>
                     <tr>
                         <td id="map-legend-obstacle"></td>
                         <td>Obstacle in Path</td>
-                        <td><input type="checkbox" value="displaylabel" id="obstacle" checked="true" onclick="toggleLayers('Obstacle', 'obstacle', '#obstacle-slider', map.map, map.mapData.allLayers)"></td>
+                        <td><input type="checkbox" value="displaylabel" id="obstacle" checked="true" onclick="toggleLayers('Obstacle', 'obstacle', '#obstacle-slider', map.mapData.allLayers)"></td>
                         <td align="left"><div id = "obstacle-slider" style="margin-top:3px"></div></td>
                         <td align= "center"><span id="obstacle-severity-label">N/A - 5</span></td>
                     </tr>
                     <tr><td id="map-legend-surface-problem"></td>
                         <td>Surface Problem</td>
-                        <td><input type="checkbox" value="displaylabel" id="surfaceprob" checked="true" onclick="toggleLayers('SurfaceProblem', 'surfaceprob', '#surface-problem-slider', map.map, map.mapData.allLayers)"></td>
+                        <td><input type="checkbox" value="displaylabel" id="surfaceprob" checked="true" onclick="toggleLayers('SurfaceProblem', 'surfaceprob', '#surface-problem-slider', map.mapData.allLayers)"></td>
                         <td align="left"><div id = "surface-problem-slider" style="margin-top:3px"></div></td>
                         <td align="center"><span id="surface-problem-severity-label">N/A - 5</span></td>
                     </tr>
                     <tr>
                         <td id="map-legend-no-sidewalk"></td>
                         <td>No Sidewalk</td>
-                        <td><input type="checkbox" value="displaylabel" id="nosidewalk" checked="true" onclick="toggleLayers('NoSidewalk', 'nosidewalk', '#no-sidewalk-slider', map.map, map.mapData.allLayers)"></td>
+                        <td><input type="checkbox" value="displaylabel" id="nosidewalk" checked="true" onclick="toggleLayers('NoSidewalk', 'nosidewalk', '#no-sidewalk-slider', map.mapData.allLayers)"></td>
                         <td align="left"><div id = "no-sidewalk-slider" style="margin-top:3px"></div></td>
                         <td align="center"><span id="no-sidewalk-severity-label">N/A - 5</span></td>
                     </tr>
                     <tr>
                         <td id="map-legend-crosswalk"></td>
                         <td>Crosswalk</td>
-                        <td><input type="checkbox" value="displaylabel" id="crosswalk" checked="true" onclick="toggleLayers('Crosswalk', 'crosswalk', '#crosswalk-slider', map.map, map.mapData.allLayers)"></td>
+                        <td><input type="checkbox" value="displaylabel" id="crosswalk" checked="true" onclick="toggleLayers('Crosswalk', 'crosswalk', '#crosswalk-slider', map.mapData.allLayers)"></td>
                         <td align="left"><div id = "crosswalk-slider" style="margin-top:3px"></div></td>
                         <td align="center"><span id="crosswalk-severity-label">N/A - 5</span></td>
                     </tr>
                     <tr>
                         <td id="map-legend-other"></td>
                         <td>Other</td>
-                        <td><input type="checkbox" value="displaylabel" id="other" checked="true" onclick="toggleLayers('Other', 'other', '#other-slider', map.map, map.mapData.allLayers)"></td>
+                        <td><input type="checkbox" value="displaylabel" id="other" checked="true" onclick="toggleLayers('Other', 'other', '#other-slider', map.mapData.allLayers)"></td>
                         <td align="left"><div id = "other-slider" style="margin-top:3px"></div></td>
                         <td align= "center"><span id="other-severity-label">N/A - 5</span></td>
                     </tr>
                     <tr>
                         <td id="map-legend-signal"></td>
                         <td>Pedestrian Signal</td>
-                        <td><input type="checkbox" value="displaylabel" id="signal" checked="true" onclick="toggleLayers('Signal', 'signal', '#signal-slider', map.map, map.mapData.allLayers)"></td>
+                        <td><input type="checkbox" value="displaylabel" id="signal" checked="true" onclick="toggleLayers('Signal', 'signal', undefined, map.mapData.allLayers)"></td>
                     </tr>
                     <tr>
                         <td id="map-legend-occlusion"></td>
                         <td>Can't see sidewalk</td>
-                        <td><input type="checkbox" value="displaylabel" id="occlusion" checked="true" onclick="toggleLayers('Occlusion', 'occlusion', '#occlusion-slider', map.map, map.mapData.allLayers)"></td>
+                        <td><input type="checkbox" value="displaylabel" id="occlusion" checked="true" onclick="toggleLayers('Occlusion', 'occlusion', undefined, map.mapData.allLayers)"></td>
                     </tr>
                     <tr>
                         <td id="map-legend-audited-street"></td>
@@ -126,10 +126,8 @@
             sliderToLabelMap["missing-curb-ramp-slider"] = "#missing-curb-ramp-severity-label";
             sliderToLabelMap["obstacle-slider"] = "#obstacle-severity-label";
             sliderToLabelMap["surface-problem-slider"] = "#surface-problem-severity-label";
-            sliderToLabelMap["occlusion-slider"]  = "#occlusion-severity-label";
             sliderToLabelMap["no-sidewalk-slider"] = "#no-sidewalk-severity-label";
             sliderToLabelMap["crosswalk-slider"]  = "#crosswalk-severity-label";
-            sliderToLabelMap["signal-slider"]  = "#signal-severity-label";
             sliderToLabelMap["other-slider"] = "#other-severity-label";
 
             $( "*[id*='slider']" ).each(function() {
@@ -148,23 +146,19 @@
                     },
                     change: function(event,ui) {
                         if (this.id === "curb-ramp-slider") {
-                            toggleLayers('CurbRamp', 'curbramp', '#curb-ramp-slider', map.map, map.mapData.allLayers);
+                            toggleLayers('CurbRamp', 'curbramp', '#curb-ramp-slider', map.mapData.allLayers);
                         } else if (this.id === "missing-curb-ramp-slider") {
-                            toggleLayers('NoCurbRamp', 'missingcurbramp', '#missing-curb-ramp-slider', map.map, map.mapData.allLayers);
+                            toggleLayers('NoCurbRamp', 'missingcurbramp', '#missing-curb-ramp-slider', map.mapData.allLayers);
                         } else if (this.id === "obstacle-slider") {
-                            toggleLayers('Obstacle', 'obstacle', '#obstacle-slider', map.map, map.mapData.allLayers)
+                            toggleLayers('Obstacle', 'obstacle', '#obstacle-slider', map.mapData.allLayers)
                         } else if (this.id === 'surface-problem-slider') {
-                            toggleLayers('SurfaceProblem', 'surfaceprob', '#surface-problem-slider', map.map, map.mapData.allLayers);
-                        } else if (this.id === 'occlusion-slider') {
-                            toggleLayers('Occlusion', 'occlusion', '#occlusion-slider', map.map, map.mapData.allLayers);
+                            toggleLayers('SurfaceProblem', 'surfaceprob', '#surface-problem-slider', map.mapData.allLayers);
                         } else if (this.id === 'no-sidewalk-slider') {
-                            toggleLayers('NoSidewalk', 'nosidewalk', '#no-sidewalk-slider', map.map, map.mapData.allLayers);
+                            toggleLayers('NoSidewalk', 'nosidewalk', '#no-sidewalk-slider', map.mapData.allLayers);
                         } else if (this.id === 'crosswalk-slider') {
-                            toggleLayers('Crosswalk', 'crosswalk', '#crosswalk-slider', map.map, map.mapData.allLayers);
-                        } else if (this.id === 'signal-slider') {
-                            toggleLayers('Signal', 'signal', '#signal-slider', map.map, map.mapData.allLayers);
+                            toggleLayers('Crosswalk', 'crosswalk', '#crosswalk-slider', map.mapData.allLayers);
                         } else if (this.id === 'other-slider') {
-                            toggleLayers('Other', 'other', '#other-slider', map.map, map.mapData.allLayers);
+                            toggleLayers('Other', 'other', '#other-slider', map.mapData.allLayers);
                         }
                     }
                 });

--- a/app/views/labelMap.scala.html
+++ b/app/views/labelMap.scala.html
@@ -23,7 +23,7 @@
                     <tr>
                         <td id="map-legend-curb-ramp" width="12px"></td>
                         <td width="190px">Curb Ramp</td>
-                        <td width="12px"  align="center"><input type="checkbox" value="displaylabel" id="curbramp" checked="true" onclick = "toggleLayers('CurbRamp', 'curbramp', '#curb-ramp-slider', map.mapData.allLayers)"></td>
+                        <td width="12px"  align="center"><input type="checkbox" value="displaylabel" id="curbramp" checked="true" onclick = "toggleLayers('CurbRamp', 'curbramp', '#curb-ramp-slider', map.map, map.map, map.mapData.allLayers)"></td>
                         <td width="126px"align="center"><div id = "curb-ramp-slider" style="margin-top:3px"></div></td>
                         <td width="80px" align= "center" ><span id="curb-ramp-severity-label">N/A - 5</span></td>
 
@@ -31,53 +31,53 @@
                     <tr>
                         <td id="map-legend-no-curb-ramp"></td>
                         <td>Missing Curb Ramp</td>
-                        <td><input type="checkbox" value="displaylabel" id="missingcurbramp" checked="true" onclick = "toggleLayers('NoCurbRamp', 'missingcurbramp', '#missing-curb-ramp-slider', map.mapData.allLayers)"></td>
+                        <td><input type="checkbox" value="displaylabel" id="missingcurbramp" checked="true" onclick = "toggleLayers('NoCurbRamp', 'missingcurbramp', '#missing-curb-ramp-slider', map.map, map.mapData.allLayers)"></td>
                         <td align="left"><div id = "missing-curb-ramp-slider" style="margin-top:3px"></div></td>
                         <td align= "center"><span id="missing-curb-ramp-severity-label">N/A - 5</span></td>
                     </tr>
                     <tr>
                         <td id="map-legend-obstacle"></td>
                         <td>Obstacle in Path</td>
-                        <td><input type="checkbox" value="displaylabel" id="obstacle" checked="true" onclick="toggleLayers('Obstacle', 'obstacle', '#obstacle-slider', map.mapData.allLayers)"></td>
+                        <td><input type="checkbox" value="displaylabel" id="obstacle" checked="true" onclick="toggleLayers('Obstacle', 'obstacle', '#obstacle-slider', map.map, map.mapData.allLayers)"></td>
                         <td align="left"><div id = "obstacle-slider" style="margin-top:3px"></div></td>
                         <td align= "center"><span id="obstacle-severity-label">N/A - 5</span></td>
                     </tr>
                     <tr><td id="map-legend-surface-problem"></td>
                         <td>Surface Problem</td>
-                        <td><input type="checkbox" value="displaylabel" id="surfaceprob" checked="true" onclick="toggleLayers('SurfaceProblem', 'surfaceprob', '#surface-problem-slider', map.mapData.allLayers)"></td>
+                        <td><input type="checkbox" value="displaylabel" id="surfaceprob" checked="true" onclick="toggleLayers('SurfaceProblem', 'surfaceprob', '#surface-problem-slider', map.map, map.mapData.allLayers)"></td>
                         <td align="left"><div id = "surface-problem-slider" style="margin-top:3px"></div></td>
                         <td align="center"><span id="surface-problem-severity-label">N/A - 5</span></td>
                     </tr>
                     <tr>
                         <td id="map-legend-no-sidewalk"></td>
                         <td>No Sidewalk</td>
-                        <td><input type="checkbox" value="displaylabel" id="nosidewalk" checked="true" onclick="toggleLayers('NoSidewalk', 'nosidewalk', '#no-sidewalk-slider', map.mapData.allLayers)"></td>
+                        <td><input type="checkbox" value="displaylabel" id="nosidewalk" checked="true" onclick="toggleLayers('NoSidewalk', 'nosidewalk', '#no-sidewalk-slider', map.map, map.mapData.allLayers)"></td>
                         <td align="left"><div id = "no-sidewalk-slider" style="margin-top:3px"></div></td>
                         <td align="center"><span id="no-sidewalk-severity-label">N/A - 5</span></td>
                     </tr>
                     <tr>
                         <td id="map-legend-crosswalk"></td>
                         <td>Crosswalk</td>
-                        <td><input type="checkbox" value="displaylabel" id="crosswalk" checked="true" onclick="toggleLayers('Crosswalk', 'crosswalk', '#crosswalk-slider', map.mapData.allLayers)"></td>
+                        <td><input type="checkbox" value="displaylabel" id="crosswalk" checked="true" onclick="toggleLayers('Crosswalk', 'crosswalk', '#crosswalk-slider', map.map, map.mapData.allLayers)"></td>
                         <td align="left"><div id = "crosswalk-slider" style="margin-top:3px"></div></td>
                         <td align="center"><span id="crosswalk-severity-label">N/A - 5</span></td>
                     </tr>
                     <tr>
                         <td id="map-legend-other"></td>
                         <td>Other</td>
-                        <td><input type="checkbox" value="displaylabel" id="other" checked="true" onclick="toggleLayers('Other', 'other', '#other-slider', map.mapData.allLayers)"></td>
+                        <td><input type="checkbox" value="displaylabel" id="other" checked="true" onclick="toggleLayers('Other', 'other', '#other-slider', map.map, map.mapData.allLayers)"></td>
                         <td align="left"><div id = "other-slider" style="margin-top:3px"></div></td>
                         <td align= "center"><span id="other-severity-label">N/A - 5</span></td>
                     </tr>
                     <tr>
                         <td id="map-legend-signal"></td>
                         <td>Pedestrian Signal</td>
-                        <td><input type="checkbox" value="displaylabel" id="signal" checked="true" onclick="toggleLayers('Signal', 'signal', undefined, map.mapData.allLayers)"></td>
+                        <td><input type="checkbox" value="displaylabel" id="signal" checked="true" onclick="toggleLayers('Signal', 'signal', undefined, map.map, map.mapData.allLayers)"></td>
                     </tr>
                     <tr>
                         <td id="map-legend-occlusion"></td>
                         <td>Can't see sidewalk</td>
-                        <td><input type="checkbox" value="displaylabel" id="occlusion" checked="true" onclick="toggleLayers('Occlusion', 'occlusion', undefined, map.mapData.allLayers)"></td>
+                        <td><input type="checkbox" value="displaylabel" id="occlusion" checked="true" onclick="toggleLayers('Occlusion', 'occlusion', undefined, map.map, map.mapData.allLayers)"></td>
                     </tr>
                     <tr>
                         <td id="map-legend-audited-street"></td>
@@ -146,19 +146,19 @@
                     },
                     change: function(event,ui) {
                         if (this.id === "curb-ramp-slider") {
-                            toggleLayers('CurbRamp', 'curbramp', '#curb-ramp-slider', map.mapData.allLayers);
+                            toggleLayers('CurbRamp', 'curbramp', '#curb-ramp-slider', map.map, map.mapData.allLayers);
                         } else if (this.id === "missing-curb-ramp-slider") {
-                            toggleLayers('NoCurbRamp', 'missingcurbramp', '#missing-curb-ramp-slider', map.mapData.allLayers);
+                            toggleLayers('NoCurbRamp', 'missingcurbramp', '#missing-curb-ramp-slider', map.map, map.mapData.allLayers);
                         } else if (this.id === "obstacle-slider") {
-                            toggleLayers('Obstacle', 'obstacle', '#obstacle-slider', map.mapData.allLayers)
+                            toggleLayers('Obstacle', 'obstacle', '#obstacle-slider', map.map, map.mapData.allLayers)
                         } else if (this.id === 'surface-problem-slider') {
-                            toggleLayers('SurfaceProblem', 'surfaceprob', '#surface-problem-slider', map.mapData.allLayers);
+                            toggleLayers('SurfaceProblem', 'surfaceprob', '#surface-problem-slider', map.map, map.mapData.allLayers);
                         } else if (this.id === 'no-sidewalk-slider') {
-                            toggleLayers('NoSidewalk', 'nosidewalk', '#no-sidewalk-slider', map.mapData.allLayers);
+                            toggleLayers('NoSidewalk', 'nosidewalk', '#no-sidewalk-slider', map.map, map.mapData.allLayers);
                         } else if (this.id === 'crosswalk-slider') {
-                            toggleLayers('Crosswalk', 'crosswalk', '#crosswalk-slider', map.mapData.allLayers);
+                            toggleLayers('Crosswalk', 'crosswalk', '#crosswalk-slider', map.map, map.mapData.allLayers);
                         } else if (this.id === 'other-slider') {
-                            toggleLayers('Other', 'other', '#other-slider', map.mapData.allLayers);
+                            toggleLayers('Other', 'other', '#other-slider', map.map, map.mapData.allLayers);
                         }
                     }
                 });

--- a/app/views/labelMap.scala.html
+++ b/app/views/labelMap.scala.html
@@ -22,7 +22,7 @@
                     </tr>
                     <tr>
                         <td id="map-legend-curb-ramp" width="12px"></td>
-                        <td width="190px">Curb Ramp</td>
+                        <td width="190px">@Messages("curb.ramp")</td>
                         <td width="12px"  align="center"><input type="checkbox" value="displaylabel" id="curbramp" checked="true" onclick = "toggleLayers('CurbRamp', 'curbramp', '#curb-ramp-slider', map.map, map.map, map.mapData)"></td>
                         <td width="126px"align="center"><div id = "curb-ramp-slider" style="margin-top:3px"></div></td>
                         <td width="80px" align= "center" ><span id="curb-ramp-severity-label">N/A - 5</span></td>
@@ -30,48 +30,48 @@
                     </tr>
                     <tr>
                         <td id="map-legend-no-curb-ramp"></td>
-                        <td>Missing Curb Ramp</td>
+                        <td>@Messages("missing.ramp")</td>
                         <td><input type="checkbox" value="displaylabel" id="missingcurbramp" checked="true" onclick = "toggleLayers('NoCurbRamp', 'missingcurbramp', '#missing-curb-ramp-slider', map.map, map.mapData)"></td>
                         <td align="left"><div id = "missing-curb-ramp-slider" style="margin-top:3px"></div></td>
                         <td align= "center"><span id="missing-curb-ramp-severity-label">N/A - 5</span></td>
                     </tr>
                     <tr>
                         <td id="map-legend-obstacle"></td>
-                        <td>Obstacle in Path</td>
+                        <td>@Messages("obstacle")</td>
                         <td><input type="checkbox" value="displaylabel" id="obstacle" checked="true" onclick="toggleLayers('Obstacle', 'obstacle', '#obstacle-slider', map.map, map.mapData)"></td>
                         <td align="left"><div id = "obstacle-slider" style="margin-top:3px"></div></td>
                         <td align= "center"><span id="obstacle-severity-label">N/A - 5</span></td>
                     </tr>
                     <tr><td id="map-legend-surface-problem"></td>
-                        <td>Surface Problem</td>
+                        <td>@Messages("surface.problem")</td>
                         <td><input type="checkbox" value="displaylabel" id="surfaceprob" checked="true" onclick="toggleLayers('SurfaceProblem', 'surfaceprob', '#surface-problem-slider', map.map, map.mapData)"></td>
                         <td align="left"><div id = "surface-problem-slider" style="margin-top:3px"></div></td>
                         <td align="center"><span id="surface-problem-severity-label">N/A - 5</span></td>
                     </tr>
                     <tr>
                         <td id="map-legend-no-sidewalk"></td>
-                        <td>No Sidewalk</td>
+                        <td>@Messages("no.sidewalk")</td>
                         <td><input type="checkbox" value="displaylabel" id="nosidewalk" checked="true" onclick="toggleLayers('NoSidewalk', 'nosidewalk', '#no-sidewalk-slider', map.map, map.mapData)"></td>
                         <td align="left"><div id = "no-sidewalk-slider" style="margin-top:3px"></div></td>
                         <td align="center"><span id="no-sidewalk-severity-label">N/A - 5</span></td>
                     </tr>
                     <tr>
                         <td id="map-legend-crosswalk"></td>
-                        <td>Crosswalk</td>
+                        <td>@Messages("crosswalk")</td>
                         <td><input type="checkbox" value="displaylabel" id="crosswalk" checked="true" onclick="toggleLayers('Crosswalk', 'crosswalk', '#crosswalk-slider', map.map, map.mapData)"></td>
                         <td align="left"><div id = "crosswalk-slider" style="margin-top:3px"></div></td>
                         <td align="center"><span id="crosswalk-severity-label">N/A - 5</span></td>
                     </tr>
                     <tr>
                         <td id="map-legend-other"></td>
-                        <td>Other</td>
+                        <td>@Messages("other")</td>
                         <td><input type="checkbox" value="displaylabel" id="other" checked="true" onclick="toggleLayers('Other', 'other', '#other-slider', map.map, map.mapData)"></td>
                         <td align="left"><div id = "other-slider" style="margin-top:3px"></div></td>
                         <td align= "center"><span id="other-severity-label">N/A - 5</span></td>
                     </tr>
                     <tr>
                         <td id="map-legend-signal"></td>
-                        <td>Pedestrian Signal</td>
+                        <td>@Messages("signal")</td>
                         <td><input type="checkbox" value="displaylabel" id="signal" checked="true" onclick="toggleLayers('Signal', 'signal', undefined, map.map, map.mapData)"></td>
                     </tr>
                     <tr>

--- a/app/views/labelMap.scala.html
+++ b/app/views/labelMap.scala.html
@@ -56,11 +56,23 @@
                         <td align="center"><span id="no-sidewalk-severity-label">N/A - 5</span></td>
                     </tr>
                     <tr>
+                        <td id="map-legend-crosswalk"></td>
+                        <td>Crosswalk</td>
+                        <td><input type="checkbox" value="displaylabel" id="crosswalk" checked="true" onclick="toggleLayers('Crosswalk', 'crosswalk', '#crosswalk-slider', map.map, map.mapData.allLayers)"></td>
+                        <td align="left"><div id = "crosswalk-slider" style="margin-top:3px"></div></td>
+                        <td align="center"><span id="crosswalk-severity-label">N/A - 5</span></td>
+                    </tr>
+                    <tr>
                         <td id="map-legend-other"></td>
                         <td>Other</td>
                         <td><input type="checkbox" value="displaylabel" id="other" checked="true" onclick="toggleLayers('Other', 'other', '#other-slider', map.map, map.mapData.allLayers)"></td>
                         <td align="left"><div id = "other-slider" style="margin-top:3px"></div></td>
                         <td align= "center"><span id="other-severity-label">N/A - 5</span></td>
+                    </tr>
+                    <tr>
+                        <td id="map-legend-signal"></td>
+                        <td>Pedestrian Signal</td>
+                        <td><input type="checkbox" value="displaylabel" id="signal" checked="true" onclick="toggleLayers('Signal', 'signal', '#signal-slider', map.map, map.mapData.allLayers)"></td>
                     </tr>
                     <tr>
                         <td id="map-legend-occlusion"></td>
@@ -116,6 +128,8 @@
             sliderToLabelMap["surface-problem-slider"] = "#surface-problem-severity-label";
             sliderToLabelMap["occlusion-slider"]  = "#occlusion-severity-label";
             sliderToLabelMap["no-sidewalk-slider"] = "#no-sidewalk-severity-label";
+            sliderToLabelMap["crosswalk-slider"]  = "#crosswalk-severity-label";
+            sliderToLabelMap["signal-slider"]  = "#signal-severity-label";
             sliderToLabelMap["other-slider"] = "#other-severity-label";
 
             $( "*[id*='slider']" ).each(function() {
@@ -133,19 +147,23 @@
                         }
                     },
                     change: function(event,ui) {
-                        if (this.id == "curb-ramp-slider") {
+                        if (this.id === "curb-ramp-slider") {
                             toggleLayers('CurbRamp', 'curbramp', '#curb-ramp-slider', map.map, map.mapData.allLayers);
-                        } else if (this.id == "missing-curb-ramp-slider") {
+                        } else if (this.id === "missing-curb-ramp-slider") {
                             toggleLayers('NoCurbRamp', 'missingcurbramp', '#missing-curb-ramp-slider', map.map, map.mapData.allLayers);
-                        } else if (this.id == "obstacle-slider") {
+                        } else if (this.id === "obstacle-slider") {
                             toggleLayers('Obstacle', 'obstacle', '#obstacle-slider', map.map, map.mapData.allLayers)
-                        } else if (this.id == 'surface-problem-slider') {
+                        } else if (this.id === 'surface-problem-slider') {
                             toggleLayers('SurfaceProblem', 'surfaceprob', '#surface-problem-slider', map.map, map.mapData.allLayers);
-                        } else if (this.id == 'occlusion-slider') {
+                        } else if (this.id === 'occlusion-slider') {
                             toggleLayers('Occlusion', 'occlusion', '#occlusion-slider', map.map, map.mapData.allLayers);
-                        } else if (this.id == 'no-sidewalk-slider') {
+                        } else if (this.id === 'no-sidewalk-slider') {
                             toggleLayers('NoSidewalk', 'nosidewalk', '#no-sidewalk-slider', map.map, map.mapData.allLayers);
-                        } else if (this.id == 'other-slider') {
+                        } else if (this.id === 'crosswalk-slider') {
+                            toggleLayers('Crosswalk', 'crosswalk', '#crosswalk-slider', map.map, map.mapData.allLayers);
+                        } else if (this.id === 'signal-slider') {
+                            toggleLayers('Signal', 'signal', '#signal-slider', map.map, map.mapData.allLayers);
+                        } else if (this.id === 'other-slider') {
                             toggleLayers('Other', 'other', '#other-slider', map.map, map.mapData.allLayers);
                         }
                     }

--- a/app/views/labelMap.scala.html
+++ b/app/views/labelMap.scala.html
@@ -203,7 +203,7 @@
             var loadPolygonRates = $.getJSON('/adminapi/neighborhoodCompletionRate');
             var loadMapParams = $.getJSON('/cityMapParams');
             var loadAuditedStreets = $.getJSON('/contribution/streets/all?filterLowQuality=true');
-            var loadSubmittedLabels = $.getJSON('/labels/all?filterLowQuality=true');
+            var loadSubmittedLabels = $.getJSON('/labels/all');
             // When the polygons, polygon rates, and map params are all loaded the polygon regions can be rendered.
             var renderPolygons = $.when(loadPolygons, loadPolygonRates, loadMapParams).done(function(data1, data2, data3) {
                 map = Choropleth(_, $, difficultRegionIds, params, [], data1[0], data2[0], data3[0]);

--- a/app/views/labelMap.scala.html
+++ b/app/views/labelMap.scala.html
@@ -245,6 +245,9 @@
                 self.mapData = InitializeSubmittedLabels(map, streetParams, AdminGSVLabelView(false), InitializeMapLayerContainer(), data2[0])
             })
             window.map = self;
+            console.log("To add data from users marked as 'low quality'', use the following commands. You can run them again with 'false' to remove.");
+            console.log("map.mapData.lowQualityUsers = true;");
+            console.log("filterLayers('',map.mapData);");
         });
         $(window).load(function() {
             $('.loader').fadeOut('slow');

--- a/app/views/labelMap.scala.html
+++ b/app/views/labelMap.scala.html
@@ -23,7 +23,7 @@
                     <tr>
                         <td id="map-legend-curb-ramp" width="12px"></td>
                         <td width="190px">Curb Ramp</td>
-                        <td width="12px"  align="center"><input type="checkbox" value="displaylabel" id="curbramp" checked="true" onclick = "toggleLayers('CurbRamp', 'curbramp', '#curb-ramp-slider', map.map, map.map, map.mapData.allLayers)"></td>
+                        <td width="12px"  align="center"><input type="checkbox" value="displaylabel" id="curbramp" checked="true" onclick = "toggleLayers('CurbRamp', 'curbramp', '#curb-ramp-slider', map.map, map.map, map.mapData)"></td>
                         <td width="126px"align="center"><div id = "curb-ramp-slider" style="margin-top:3px"></div></td>
                         <td width="80px" align= "center" ><span id="curb-ramp-severity-label">N/A - 5</span></td>
 
@@ -31,53 +31,53 @@
                     <tr>
                         <td id="map-legend-no-curb-ramp"></td>
                         <td>Missing Curb Ramp</td>
-                        <td><input type="checkbox" value="displaylabel" id="missingcurbramp" checked="true" onclick = "toggleLayers('NoCurbRamp', 'missingcurbramp', '#missing-curb-ramp-slider', map.map, map.mapData.allLayers)"></td>
+                        <td><input type="checkbox" value="displaylabel" id="missingcurbramp" checked="true" onclick = "toggleLayers('NoCurbRamp', 'missingcurbramp', '#missing-curb-ramp-slider', map.map, map.mapData)"></td>
                         <td align="left"><div id = "missing-curb-ramp-slider" style="margin-top:3px"></div></td>
                         <td align= "center"><span id="missing-curb-ramp-severity-label">N/A - 5</span></td>
                     </tr>
                     <tr>
                         <td id="map-legend-obstacle"></td>
                         <td>Obstacle in Path</td>
-                        <td><input type="checkbox" value="displaylabel" id="obstacle" checked="true" onclick="toggleLayers('Obstacle', 'obstacle', '#obstacle-slider', map.map, map.mapData.allLayers)"></td>
+                        <td><input type="checkbox" value="displaylabel" id="obstacle" checked="true" onclick="toggleLayers('Obstacle', 'obstacle', '#obstacle-slider', map.map, map.mapData)"></td>
                         <td align="left"><div id = "obstacle-slider" style="margin-top:3px"></div></td>
                         <td align= "center"><span id="obstacle-severity-label">N/A - 5</span></td>
                     </tr>
                     <tr><td id="map-legend-surface-problem"></td>
                         <td>Surface Problem</td>
-                        <td><input type="checkbox" value="displaylabel" id="surfaceprob" checked="true" onclick="toggleLayers('SurfaceProblem', 'surfaceprob', '#surface-problem-slider', map.map, map.mapData.allLayers)"></td>
+                        <td><input type="checkbox" value="displaylabel" id="surfaceprob" checked="true" onclick="toggleLayers('SurfaceProblem', 'surfaceprob', '#surface-problem-slider', map.map, map.mapData)"></td>
                         <td align="left"><div id = "surface-problem-slider" style="margin-top:3px"></div></td>
                         <td align="center"><span id="surface-problem-severity-label">N/A - 5</span></td>
                     </tr>
                     <tr>
                         <td id="map-legend-no-sidewalk"></td>
                         <td>No Sidewalk</td>
-                        <td><input type="checkbox" value="displaylabel" id="nosidewalk" checked="true" onclick="toggleLayers('NoSidewalk', 'nosidewalk', '#no-sidewalk-slider', map.map, map.mapData.allLayers)"></td>
+                        <td><input type="checkbox" value="displaylabel" id="nosidewalk" checked="true" onclick="toggleLayers('NoSidewalk', 'nosidewalk', '#no-sidewalk-slider', map.map, map.mapData)"></td>
                         <td align="left"><div id = "no-sidewalk-slider" style="margin-top:3px"></div></td>
                         <td align="center"><span id="no-sidewalk-severity-label">N/A - 5</span></td>
                     </tr>
                     <tr>
                         <td id="map-legend-crosswalk"></td>
                         <td>Crosswalk</td>
-                        <td><input type="checkbox" value="displaylabel" id="crosswalk" checked="true" onclick="toggleLayers('Crosswalk', 'crosswalk', '#crosswalk-slider', map.map, map.mapData.allLayers)"></td>
+                        <td><input type="checkbox" value="displaylabel" id="crosswalk" checked="true" onclick="toggleLayers('Crosswalk', 'crosswalk', '#crosswalk-slider', map.map, map.mapData)"></td>
                         <td align="left"><div id = "crosswalk-slider" style="margin-top:3px"></div></td>
                         <td align="center"><span id="crosswalk-severity-label">N/A - 5</span></td>
                     </tr>
                     <tr>
                         <td id="map-legend-other"></td>
                         <td>Other</td>
-                        <td><input type="checkbox" value="displaylabel" id="other" checked="true" onclick="toggleLayers('Other', 'other', '#other-slider', map.map, map.mapData.allLayers)"></td>
+                        <td><input type="checkbox" value="displaylabel" id="other" checked="true" onclick="toggleLayers('Other', 'other', '#other-slider', map.map, map.mapData)"></td>
                         <td align="left"><div id = "other-slider" style="margin-top:3px"></div></td>
                         <td align= "center"><span id="other-severity-label">N/A - 5</span></td>
                     </tr>
                     <tr>
                         <td id="map-legend-signal"></td>
                         <td>Pedestrian Signal</td>
-                        <td><input type="checkbox" value="displaylabel" id="signal" checked="true" onclick="toggleLayers('Signal', 'signal', undefined, map.map, map.mapData.allLayers)"></td>
+                        <td><input type="checkbox" value="displaylabel" id="signal" checked="true" onclick="toggleLayers('Signal', 'signal', undefined, map.map, map.mapData)"></td>
                     </tr>
                     <tr>
                         <td id="map-legend-occlusion"></td>
                         <td>Can't see sidewalk</td>
-                        <td><input type="checkbox" value="displaylabel" id="occlusion" checked="true" onclick="toggleLayers('Occlusion', 'occlusion', undefined, map.map, map.mapData.allLayers)"></td>
+                        <td><input type="checkbox" value="displaylabel" id="occlusion" checked="true" onclick="toggleLayers('Occlusion', 'occlusion', undefined, map.map, map.mapData)"></td>
                     </tr>
                     <tr>
                         <td id="map-legend-audited-street"></td>
@@ -146,19 +146,19 @@
                     },
                     change: function(event,ui) {
                         if (this.id === "curb-ramp-slider") {
-                            toggleLayers('CurbRamp', 'curbramp', '#curb-ramp-slider', map.map, map.mapData.allLayers);
+                            toggleLayers('CurbRamp', 'curbramp', '#curb-ramp-slider', map.map, map.mapData);
                         } else if (this.id === "missing-curb-ramp-slider") {
-                            toggleLayers('NoCurbRamp', 'missingcurbramp', '#missing-curb-ramp-slider', map.map, map.mapData.allLayers);
+                            toggleLayers('NoCurbRamp', 'missingcurbramp', '#missing-curb-ramp-slider', map.map, map.mapData);
                         } else if (this.id === "obstacle-slider") {
-                            toggleLayers('Obstacle', 'obstacle', '#obstacle-slider', map.map, map.mapData.allLayers)
+                            toggleLayers('Obstacle', 'obstacle', '#obstacle-slider', map.map, map.mapData)
                         } else if (this.id === 'surface-problem-slider') {
-                            toggleLayers('SurfaceProblem', 'surfaceprob', '#surface-problem-slider', map.map, map.mapData.allLayers);
+                            toggleLayers('SurfaceProblem', 'surfaceprob', '#surface-problem-slider', map.map, map.mapData);
                         } else if (this.id === 'no-sidewalk-slider') {
-                            toggleLayers('NoSidewalk', 'nosidewalk', '#no-sidewalk-slider', map.map, map.mapData.allLayers);
+                            toggleLayers('NoSidewalk', 'nosidewalk', '#no-sidewalk-slider', map.map, map.mapData);
                         } else if (this.id === 'crosswalk-slider') {
-                            toggleLayers('Crosswalk', 'crosswalk', '#crosswalk-slider', map.map, map.mapData.allLayers);
+                            toggleLayers('Crosswalk', 'crosswalk', '#crosswalk-slider', map.map, map.mapData);
                         } else if (this.id === 'other-slider') {
-                            toggleLayers('Other', 'other', '#other-slider', map.map, map.mapData.allLayers);
+                            toggleLayers('Other', 'other', '#other-slider', map.map, map.mapData);
                         }
                     }
                 });

--- a/app/views/labelMap.scala.html
+++ b/app/views/labelMap.scala.html
@@ -80,17 +80,17 @@
                         <td><input type="checkbox" value="displaylabel" id="occlusion" checked="true" onclick="toggleLayers('Occlusion', 'occlusion', undefined, map.map, map.mapData)"></td>
                     </tr>
                     <tr>
-                        <td id="map-legend-correct"></td>
+                        <td id="map-legend-correct"><img src='@routes.Assets.at("javascripts/SVValidate/img/Checkmark.png")' style="width: 23px; padding: 3px;"></td>
                         <td>Validated correct</td>
                         <td><input type="checkbox" value="displaylabel" id="correct" checked="true" onclick="filterLayers('correct', map.mapData)"></td>
                     </tr>
                     <tr>
-                        <td id="map-legend-incorrect"></td>
+                        <td id="map-legend-incorrect"><img src='@routes.Assets.at("javascripts/SVValidate/img/Cross.png")' style="width: 23px; padding: 3px;"></td>
                         <td>Validated incorrect</td>
                         <td><input type="checkbox" value="displaylabel" id="incorrect" onclick="filterLayers('incorrect', map.mapData)"></td>
                     </tr>
                     <tr>
-                        <td id="map-legend-unvalidated"></td>
+                        <td id="map-legend-unvalidated"><img src='@routes.Assets.at("javascripts/SVValidate/img/QuestionMark.png")' style="width: 18px; padding: 2px; padding-left: 6px;"></td>
                         <td>Unvalidated</td>
                         <td><input type="checkbox" value="displaylabel" id="unvalidated" checked="true" onclick="filterLayers('unvalidated', map.mapData)"></td>
                     </tr>

--- a/app/views/userProfile.scala.html
+++ b/app/views/userProfile.scala.html
@@ -54,6 +54,8 @@
                             <tr><td id="map-legend-obstacle"></td><td>@Messages("obstacle")</td><td id="td-number-of-obstacles"></td></tr>
                             <tr><td id="map-legend-surface-problem"></td><td>@Messages("surface.problem")</td><td id="td-number-of-surface-problems"></td></tr>
                             <tr><td id="map-legend-no-sidewalk"></td><td>@Messages("no.sidewalk")</td><td id="td-number-of-no-sidewalks"></td></tr>
+                            <tr><td id="map-legend-crosswalk"></td><td>@Messages("crosswalk")</td><td id="td-number-of-crosswalks"></td></tr>
+                            <tr><td id="map-legend-signal"></td><td>@Messages("signal")</td><td id="td-number-of-signals"></td></tr>
                             <tr><td id="map-legend-audited-street"></td><td>@Messages("dashboard.audited.street")</td></tr>
                         </table>
                     </div>

--- a/conf/routes
+++ b/conf/routes
@@ -82,7 +82,7 @@ GET     /adminapi/numWebpageActivity/:activity/*keyValPairs  @controllers.AdminC
 GET     /adminapi/choroplethCounts                           @controllers.AdminController.getRegionNegativeLabelCounts
 PUT     /adminapi/setRole                                    @controllers.AdminController.setUserRole
 
-GET     /labels/all                                          @controllers.AdminController.getAllLabelsForLabelMap(filterLowQuality: Boolean ?= false)
+GET     /labels/all                                          @controllers.AdminController.getAllLabelsForLabelMap
 GET     /label/id/:labelId                                   @controllers.AdminController.getLabelData(labelId: Int)
 
 # Auditing tasks

--- a/public/javascripts/Admin/src/Admin.Panorama.js
+++ b/public/javascripts/Admin/src/Admin.Panorama.js
@@ -23,7 +23,9 @@ function AdminPanorama(svHolder, buttonHolder, admin) {
         SurfaceProblem : '/assets/images/icons/AdminTool_SurfaceProblem.png',
         Other : '/assets/images/icons/AdminTool_Other.png',
         Occlusion : '/assets/images/icons/AdminTool_Other.png',
-        NoSidewalk : '/assets/images/icons/AdminTool_NoSidewalk.png'
+        NoSidewalk : '/assets/images/icons/AdminTool_NoSidewalk.png',
+        Crosswalk : '/assets/images/icons/AdminTool_Crosswalk.png',
+        Signal : '/assets/images/icons/AdminTool_Signal.png'
     };
 
     // Determined experimentally; varies w/ GSV Panorama size

--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -100,7 +100,7 @@ function Admin(_, $, difficultRegionIds) {
     }
 
     function toggleLayersAdmin(label, checkboxId, sliderId) {
-        toggleLayers(label, checkboxId, sliderId, map, mapData.allLayers);
+        toggleLayers(label, checkboxId, sliderId, mapData.allLayers);
     }
 
     function toggleAuditedStreetLayerAdmin() {

--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -103,6 +103,10 @@ function Admin(_, $, difficultRegionIds) {
         toggleLayers(label, checkboxId, sliderId, map, mapData);
     }
 
+    function filterLayersAdmin(checkboxId) {
+        filterLayers(checkboxId, mapData);
+    }
+
     function toggleAuditedStreetLayerAdmin() {
         toggleAuditedStreetLayer(map, auditedStreetLayer);
     }
@@ -1112,6 +1116,7 @@ function Admin(_, $, difficultRegionIds) {
     
     self.clearPlayCache = clearPlayCache;
     self.toggleLayers = toggleLayersAdmin;
+    self.filterLayers = filterLayersAdmin;
     self.toggleAuditedStreetLayer = toggleAuditedStreetLayerAdmin;
 
     $('.change-role').on('click', changeRole);

--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -100,7 +100,7 @@ function Admin(_, $, difficultRegionIds) {
     }
 
     function toggleLayersAdmin(label, checkboxId, sliderId) {
-        toggleLayers(label, checkboxId, sliderId, map, mapData.allLayers);
+        toggleLayers(label, checkboxId, sliderId, map, mapData);
     }
 
     function toggleAuditedStreetLayerAdmin() {

--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -100,7 +100,7 @@ function Admin(_, $, difficultRegionIds) {
     }
 
     function toggleLayersAdmin(label, checkboxId, sliderId) {
-        toggleLayers(label, checkboxId, sliderId, mapData.allLayers);
+        toggleLayers(label, checkboxId, sliderId, map, mapData.allLayers);
     }
 
     function toggleAuditedStreetLayerAdmin() {

--- a/public/javascripts/Choropleths/Choropleth.js
+++ b/public/javascripts/Choropleths/Choropleth.js
@@ -34,7 +34,7 @@ function Choropleth(_, $, difficultRegionIds, params, layers, polygonData, polyg
 
     params.defaultZoomIncrease = params.defaultZoomIncrease ? params.defaultZoomIncrease : 0;
     mapParamData.default_zoom = mapParamData.default_zoom + params.defaultZoomIncrease;
-    
+
     // Create base map.
     L.mapbox.accessToken = 'pk.eyJ1IjoibWlzYXVnc3RhZCIsImEiOiJjajN2dTV2Mm0wMDFsMndvMXJiZWcydDRvIn0.IXE8rQNF--HikYDjccA7Ug';
     let choropleth = L.mapbox.map(params.mapName, null, {

--- a/public/javascripts/Choropleths/InitializeMapLayerContainer.js
+++ b/public/javascripts/Choropleths/InitializeMapLayerContainer.js
@@ -3,38 +3,16 @@
  */
 function InitializeMapLayerContainer() {
     var mapData = {};
-    mapData.markerLayer = null;
-    mapData.curbRampLayers = [];
-    mapData.missingCurbRampLayers = [];
-    mapData.obstacleLayers = [];
-    mapData.surfaceProblemLayers = [];
-    mapData.cantSeeSidewalkLayers = [];
-    mapData.noSidewalkLayers = [];
-    mapData.crosswalkLayers = [];
-    mapData.signalLayers = [];
-    mapData.otherLayers = [];
-    // Make arrays to hold labels split by severity (null and 1 through 5).
-    for (var i = 0; i < 6; i++) {
-        mapData.curbRampLayers[i] = [];
-        mapData.missingCurbRampLayers[i] = [];
-        mapData.obstacleLayers[i] = [];
-        mapData.surfaceProblemLayers[i] = [];
-        mapData.cantSeeSidewalkLayers[i] = [];
-        mapData.noSidewalkLayers[i] = [];
-        mapData.crosswalkLayers[i] = [];
-        mapData.signalLayers[i] = [];
-        mapData.otherLayers[i] = [];
+
+    // Make arrays to hold labels split by label type and severity (null and 1 through 5).
+    mapData.labelLayers = {};
+    let labelTypes = ['CurbRamp','NoCurbRamp','Obstacle','SurfaceProblem','Occlusion','NoSidewalk','Crosswalk','Signal','Other']
+    for (let i = 0; i < labelTypes.length; i++) {
+        let labelType = labelTypes[i];
+        mapData.labelLayers[labelType] = [];
+        for (let j = 0; j < 6; j++) {
+            mapData.labelLayers[labelType][j] = [];
+        }
     }
-    mapData.allLayers = {
-        'CurbRamp': mapData.curbRampLayers,
-        'NoCurbRamp': mapData.missingCurbRampLayers,
-        'Obstacle': mapData.obstacleLayers,
-        'SurfaceProblem': mapData.surfaceProblemLayers,
-        'Occlusion': mapData.cantSeeSidewalkLayers,
-        'NoSidewalk': mapData.noSidewalkLayers,
-        'Crosswalk': mapData.crosswalkLayers,
-        'Signal': mapData.signalLayers,
-        'Other': mapData.otherLayers
-    };
     return mapData;
 }

--- a/public/javascripts/Choropleths/InitializeMapLayerContainer.js
+++ b/public/javascripts/Choropleths/InitializeMapLayerContainer.js
@@ -3,6 +3,10 @@
  */
 function InitializeMapLayerContainer() {
     var mapData = {};
+    mapData.correct = true;
+    mapData.incorrect = false;
+    mapData.unvalidated = true;
+    mapData.lowQualityUsers = false;
 
     // Make arrays to hold labels split by label type and severity (null and 1 through 5).
     mapData.labelLayers = {};

--- a/public/javascripts/Choropleths/InitializeSubmittedLabels.js
+++ b/public/javascripts/Choropleths/InitializeSubmittedLabels.js
@@ -66,18 +66,18 @@ function InitializeSubmittedLabels(map, params, adminGSVLabelView, mapData, labe
             let labelType = labelData.features[i].properties.label_type;
             let severity = labelData.features[i].properties.severity;
             if (labelType === 'Occlusion' || labelType === 'Signal' || !severity) { // No severity level.
-                mapData.allLayers[labelType][0].push(labelData.features[i]);
+                mapData.labelLayers[labelType][0].push(labelData.features[i]);
             } else {
-                mapData.allLayers[labelType][severity].push(labelData.features[i]);
+                mapData.labelLayers[labelType][severity].push(labelData.features[i]);
             }
         }
-        Object.keys(mapData.allLayers).forEach(function (key) {
-            for (let i = 0; i < mapData.allLayers[key].length; i++) {
-                mapData.allLayers[key][i] = createLayer({
+        Object.keys(mapData.labelLayers).forEach(function (key) {
+            for (let i = 0; i < mapData.labelLayers[key].length; i++) {
+                mapData.labelLayers[key][i] = createLayer({
                     'type': 'FeatureCollection',
-                    'features': mapData.allLayers[key][i]
+                    'features': mapData.labelLayers[key][i]
                 });
-                mapData.allLayers[key][i].addTo(map);
+                mapData.labelLayers[key][i].addTo(map);
             }
         });
     }

--- a/public/javascripts/Choropleths/InitializeSubmittedLabels.js
+++ b/public/javascripts/Choropleths/InitializeSubmittedLabels.js
@@ -79,27 +79,27 @@ function InitializeSubmittedLabels(map, params, adminGSVLabelView, mapData, labe
                 });
                 mapData.allLayers[key][i].addTo(map);
             }
-        })
+        });
     }
     
-    function onEachLabelFeature(feature, layer) {
+    function addLabelMarkerListeners(feature, marker) {
         if (params.labelPopup) {
-            layer.on('click', function () {
+            marker.on('click', function () {
                 adminGSVLabelView.showLabel(feature.properties.label_id);
             });
-            layer.on({
+            marker.on({
                 'mouseover': function () {
-                    layer.setRadius(15);
+                    marker.setRadius(15);
                 },
                 'mouseout': function () {
-                    layer.setRadius(5);
+                    marker.setRadius(5);
                 }
             });
         }
     }
 
     function createLayer(data) {
-        return L.geoJson(data, {
+        return L.mapbox.featureLayer(data, {
             pointToLayer: function (feature, latlng) {
                 let style = $.extend(true, {}, geojsonMarkerOptions);
                 style.fillColor = colorMapping[feature.properties.label_type].fillStyle;
@@ -111,10 +111,11 @@ function InitializeSubmittedLabels(map, params, adminGSVLabelView, mapData, labe
                         style.color = colorMapping[feature.properties.label_type].strokeStyle;
                     }
                 }
-                return L.circleMarker(latlng, style);
-            },
-            onEachFeature: onEachLabelFeature
-        })
+                var marker = L.circleMarker(latlng, style);
+                addLabelMarkerListeners(feature, marker);
+                return marker;
+            }
+        });
     }
     return mapData;
 }

--- a/public/javascripts/Choropleths/InitializeSubmittedLabels.js
+++ b/public/javascripts/Choropleths/InitializeSubmittedLabels.js
@@ -80,6 +80,9 @@ function InitializeSubmittedLabels(map, params, adminGSVLabelView, mapData, labe
                 mapData.labelLayers[key][i].addTo(map);
             }
         });
+
+        // Set up the initial set of filters.
+        filterLayers('incorrect', mapData);
     }
     
     function addLabelMarkerListeners(feature, marker) {

--- a/public/javascripts/Choropleths/InitializeSubmittedLabels.js
+++ b/public/javascripts/Choropleths/InitializeSubmittedLabels.js
@@ -29,6 +29,7 @@ function InitializeSubmittedLabels(map, params, adminGSVLabelView, mapData, labe
     document.getElementById('map-legend-obstacle').innerHTML = "<svg width='20' height='20'><circle r='6' cx='10' cy='10' fill='" + colorMapping['Obstacle'].fillStyle + "'></svg>";
     document.getElementById('map-legend-surface-problem').innerHTML = "<svg width='20' height='20'><circle r='6' cx='10' cy='10' fill='" + colorMapping['SurfaceProblem'].fillStyle + "'></svg>";
     document.getElementById('map-legend-no-sidewalk').innerHTML = "<svg width='20' height='20'><circle r='6' cx='10' cy='10' fill='" + colorMapping['NoSidewalk'].fillStyle + "' stroke='" + colorMapping['NoSidewalk'].strokeStyle + "'></svg>";
+    document.getElementById('map-legend-crosswalk').innerHTML = "<svg width='20' height='20'><circle r='6' cx='10' cy='10' fill='" + colorMapping['Crosswalk'].fillStyle + "'></svg>";
     document.getElementById('map-legend-audited-street').innerHTML = "<svg width='20' height='20'><path stroke='" + auditedStreetColor + "' stroke-width='3' d='M 2 10 L 18 10 z'></svg>";
     if (params.includeLabelCounts) {
         // Count the number of each label type and fill in the legend with those counts.
@@ -37,7 +38,9 @@ function InitializeSubmittedLabels(map, params, adminGSVLabelView, mapData, labe
             'NoCurbRamp': 0,
             'Obstacle': 0,
             'SurfaceProblem': 0,
-            'NoSidewalk': 0
+            'NoSidewalk': 0,
+            'Crosswalk': 0,
+            'Signal': 0
         };
         for (let i = labelData.features.length - 1; i >= 0; i--) {
             labelCounter[labelData.features[i].properties.label_type] += 1;
@@ -47,6 +50,8 @@ function InitializeSubmittedLabels(map, params, adminGSVLabelView, mapData, labe
         document.getElementById('td-number-of-obstacles').innerHTML = labelCounter['Obstacle'];
         document.getElementById('td-number-of-surface-problems').innerHTML = labelCounter['SurfaceProblem'];
         document.getElementById('td-number-of-no-sidewalks').innerHTML = labelCounter['NoSidewalk'];
+        document.getElementById('td-number-of-crosswalks').innerHTML = labelCounter['Crosswalk'];
+        document.getElementById('td-number-of-signals').innerHTML = labelCounter['Signal'];
         createLayer(labelData).addTo(map);
     } else {    // When loading label map.
         document.getElementById('map-legend-other').innerHTML =
@@ -59,18 +64,11 @@ function InitializeSubmittedLabels(map, params, adminGSVLabelView, mapData, labe
         // Separate labels into an array for each label type and severity.
         for (let i = 0; i < labelData.features.length; i++) {
             let labelType = labelData.features[i].properties.label_type;
-            if (labelData.features[i].properties.severity === 1) {
-                mapData.allLayers[labelType][1].push(labelData.features[i]);
-            } else if (labelData.features[i].properties.severity === 2) {
-                mapData.allLayers[labelType][2].push(labelData.features[i]);
-            } else if (labelData.features[i].properties.severity === 3) {
-                mapData.allLayers[labelType][3].push(labelData.features[i]);
-            } else if (labelData.features[i].properties.severity === 4) {
-                mapData.allLayers[labelType][4].push(labelData.features[i]);
-            } else if (labelData.features[i].properties.severity === 5) {
-                mapData.allLayers[labelType][5].push(labelData.features[i]);
-            } else { // No severity level
+            let severity = labelData.features[i].properties.severity;
+            if (labelType === 'Occlusion' || labelType === 'Signal' || !severity) { // No severity level.
                 mapData.allLayers[labelType][0].push(labelData.features[i]);
+            } else {
+                mapData.allLayers[labelType][severity].push(labelData.features[i]);
             }
         }
         Object.keys(mapData.allLayers).forEach(function (key) {

--- a/public/javascripts/Choropleths/InitializeSubmittedLabels.js
+++ b/public/javascripts/Choropleths/InitializeSubmittedLabels.js
@@ -24,12 +24,13 @@ function InitializeSubmittedLabels(map, params, adminGSVLabelView, mapData, labe
 
     let auditedStreetColor = params.streetColor;
 
-    document.getElementById('map-legend-curb-ramp').innerHTML = "<svg width='20' height='20'><circle r='6' cx='10' cy='10' fill='" + colorMapping['CurbRamp'].fillStyle + "'></svg>";
-    document.getElementById('map-legend-no-curb-ramp').innerHTML = "<svg width='20' height='20'><circle r='6' cx='10' cy='10' fill='" + colorMapping['NoCurbRamp'].fillStyle + "'></svg>";
-    document.getElementById('map-legend-obstacle').innerHTML = "<svg width='20' height='20'><circle r='6' cx='10' cy='10' fill='" + colorMapping['Obstacle'].fillStyle + "'></svg>";
-    document.getElementById('map-legend-surface-problem').innerHTML = "<svg width='20' height='20'><circle r='6' cx='10' cy='10' fill='" + colorMapping['SurfaceProblem'].fillStyle + "'></svg>";
-    document.getElementById('map-legend-no-sidewalk').innerHTML = "<svg width='20' height='20'><circle r='6' cx='10' cy='10' fill='" + colorMapping['NoSidewalk'].fillStyle + "' stroke='" + colorMapping['NoSidewalk'].strokeStyle + "'></svg>";
-    document.getElementById('map-legend-crosswalk').innerHTML = "<svg width='20' height='20'><circle r='6' cx='10' cy='10' fill='" + colorMapping['Crosswalk'].fillStyle + "'></svg>";
+    document.getElementById('map-legend-curb-ramp').innerHTML = "<svg width='20' height='20'><circle r='6' cx='10' cy='10' fill='" + colorMapping.CurbRamp.fillStyle + "'></svg>";
+    document.getElementById('map-legend-no-curb-ramp').innerHTML = "<svg width='20' height='20'><circle r='6' cx='10' cy='10' fill='" + colorMapping.NoCurbRamp.fillStyle + "'></svg>";
+    document.getElementById('map-legend-obstacle').innerHTML = "<svg width='20' height='20'><circle r='6' cx='10' cy='10' fill='" + colorMapping.Obstacle.fillStyle + "'></svg>";
+    document.getElementById('map-legend-surface-problem').innerHTML = "<svg width='20' height='20'><circle r='6' cx='10' cy='10' fill='" + colorMapping.SurfaceProblem.fillStyle + "'></svg>";
+    document.getElementById('map-legend-no-sidewalk').innerHTML = "<svg width='20' height='20'><circle r='6' cx='10' cy='10' fill='" + colorMapping.NoSidewalk.fillStyle + "' stroke='" + colorMapping.NoSidewalk.strokeStyle + "'></svg>";
+    document.getElementById('map-legend-crosswalk').innerHTML = "<svg width='20' height='20'><circle r='6' cx='10' cy='10' fill='" + colorMapping.Crosswalk.fillStyle + "'></svg>";
+    document.getElementById('map-legend-signal').innerHTML = "<svg width='20' height='20'><circle r='6' cx='10' cy='10' fill='" + colorMapping.Signal.fillStyle + "'></svg>";
     document.getElementById('map-legend-audited-street').innerHTML = "<svg width='20' height='20'><path stroke='" + auditedStreetColor + "' stroke-width='3' d='M 2 10 L 18 10 z'></svg>";
     if (params.includeLabelCounts) {
         // Count the number of each label type and fill in the legend with those counts.

--- a/public/javascripts/Choropleths/MapUtilities.js
+++ b/public/javascripts/Choropleths/MapUtilities.js
@@ -1,32 +1,25 @@
 /**
  * Handles the toggling of layers on a map/choropleth according to the slider/checkbox.
  */
-function toggleLayers(label, checkboxId, sliderId, map, allLayers) {
-    console.log(allLayers);
+function toggleLayers(label, checkboxId, sliderId, allLayers) {
     if (document.getElementById(checkboxId).checked) {
-        if (checkboxId === 'occlusion') {
+        // For label types that don't have severity, show all labels.
+        if (sliderId === undefined) {
             for (let i = 0; i < allLayers[label].length; i++) {
-                if (!map.hasLayer(allLayers[label][i])) {
-                    map.addLayer(allLayers[label][i]);
-                }
-            }
-        } else {
-            for (let i = 0; i < allLayers[label].length; i++) {
-                if (!map.hasLayer(allLayers[label][i])
-                    && ($(sliderId).slider('option', 'values')[0] <= i &&
-                        $(sliderId).slider('option', 'values')[1] >= i )) {
-                    map.addLayer(allLayers[label][i]);
-                } else if ($(sliderId).slider('option', 'values')[0] > i
-                    || $(sliderId).slider('option', 'values')[1] < i) {
-                    map.removeLayer(allLayers[label][i]);
-                }
+                allLayers[label][i].setFilter(function() { return true; });
             }
         }
-    } else {
+        // Only show labels with severity in range of sliders. This works for null severity b/c null >= 0 === true.
         for (let i = 0; i < allLayers[label].length; i++) {
-            if (map.hasLayer(allLayers[label][i])) {
-                map.removeLayer(allLayers[label][i]);
-            }
+            allLayers[label][i].setFilter( function(feature) {
+                return feature.properties.severity >= $(sliderId).slider('option', 'values')[0] &&
+                    feature.properties.severity <= $(sliderId).slider('option', 'values')[1];
+            })
+        }
+    } else {
+        // Box is unchecked, remove all labels of that type.
+        for (let i = 0; i < allLayers[label].length; i++) {
+            allLayers[label][i].setFilter(function() { return false; });
         }
     }
 }

--- a/public/javascripts/Choropleths/MapUtilities.js
+++ b/public/javascripts/Choropleths/MapUtilities.js
@@ -7,7 +7,7 @@ function toggleLayers(label, checkboxId, sliderId, map, mapData) {
         if (sliderId === undefined) {
             for (let i = 0; i < mapData.labelLayers[label].length; i++) {
                 if (!map.hasLayer(mapData.labelLayers[label][i])) {
-                    map.addLayer(mapData.labelLayers[label][i]);
+                    map.addLayer(mapData.labelLayers[label][i])
                 }
             }
         }
@@ -16,7 +16,7 @@ function toggleLayers(label, checkboxId, sliderId, map, mapData) {
         let highRange = $(sliderId).slider('option', 'values')[1];
         for (let i = 0; i < mapData.labelLayers[label].length; i++) {
             if (lowRange <= i && highRange >= i && !map.hasLayer(mapData.labelLayers[label][i])) {
-                map.addLayer(mapData.labelLayers[label][i]);
+                map.addLayer(mapData.labelLayers[label][i])
             } else if ((lowRange > i || highRange < i) && map.hasLayer(mapData.labelLayers[label][i])) {
                 map.removeLayer(mapData.labelLayers[label][i]);
             }
@@ -31,7 +31,26 @@ function toggleLayers(label, checkboxId, sliderId, map, mapData) {
     }
 }
 
-
+/**
+ * Handles the filtering of labels based on validation status.
+ * @param checkboxId
+ * @param mapData
+ */
+function filterLayers(checkboxId, mapData) {
+    mapData[checkboxId] = document.getElementById(checkboxId).checked;
+    Object.keys(mapData.labelLayers).forEach(function (key) {
+        for (let i = 0; i < mapData.labelLayers[key].length; i++) {
+            mapData.labelLayers[key][i].setFilter(function(feature) {
+                return (mapData.lowQualityUsers || feature.properties.high_quality_user) &&
+                    (
+                        (mapData.correct && feature.properties.correct) ||
+                        (mapData.incorrect && feature.properties.correct === false) ||
+                        (mapData.unvalidated && feature.properties.correct === null)
+                    );
+            });
+        }
+    });
+}
 
 function toggleAuditedStreetLayer(map, auditedStreetLayer) {
     if (document.getElementById('auditedstreet').checked) {

--- a/public/javascripts/Choropleths/MapUtilities.js
+++ b/public/javascripts/Choropleths/MapUtilities.js
@@ -37,7 +37,7 @@ function toggleLayers(label, checkboxId, sliderId, map, mapData) {
  * @param mapData
  */
 function filterLayers(checkboxId, mapData) {
-    mapData[checkboxId] = document.getElementById(checkboxId).checked;
+    if (checkboxId) mapData[checkboxId] = document.getElementById(checkboxId).checked;
     Object.keys(mapData.labelLayers).forEach(function (key) {
         for (let i = 0; i < mapData.labelLayers[key].length; i++) {
             mapData.labelLayers[key][i].setFilter(function(feature) {

--- a/public/javascripts/Choropleths/MapUtilities.js
+++ b/public/javascripts/Choropleths/MapUtilities.js
@@ -1,25 +1,32 @@
 /**
  * Handles the toggling of layers on a map/choropleth according to the slider/checkbox.
  */
-function toggleLayers(label, checkboxId, sliderId, allLayers) {
+function toggleLayers(label, checkboxId, sliderId, map, allLayers) {
     if (document.getElementById(checkboxId).checked) {
         // For label types that don't have severity, show all labels.
         if (sliderId === undefined) {
             for (let i = 0; i < allLayers[label].length; i++) {
-                allLayers[label][i].setFilter(function() { return true; });
+                if (!map.hasLayer(allLayers[label][i])) {
+                    map.addLayer(allLayers[label][i]);
+                }
             }
         }
         // Only show labels with severity in range of sliders. This works for null severity b/c null >= 0 === true.
+        let lowRange = $(sliderId).slider('option', 'values')[0];
+        let highRange = $(sliderId).slider('option', 'values')[1];
         for (let i = 0; i < allLayers[label].length; i++) {
-            allLayers[label][i].setFilter( function(feature) {
-                return feature.properties.severity >= $(sliderId).slider('option', 'values')[0] &&
-                    feature.properties.severity <= $(sliderId).slider('option', 'values')[1];
-            })
+            if (lowRange <= i && highRange >= i && !map.hasLayer(allLayers[label][i])) {
+                map.addLayer(allLayers[label][i]);
+            } else if ((lowRange > i || highRange < i) && map.hasLayer(allLayers[label][i])) {
+                map.removeLayer(allLayers[label][i]);
+            }
         }
     } else {
         // Box is unchecked, remove all labels of that type.
         for (let i = 0; i < allLayers[label].length; i++) {
-            allLayers[label][i].setFilter(function() { return false; });
+            if (map.hasLayer(allLayers[label][i])) {
+                map.removeLayer(allLayers[label][i]);
+            }
         }
     }
 }

--- a/public/javascripts/Choropleths/MapUtilities.js
+++ b/public/javascripts/Choropleths/MapUtilities.js
@@ -1,35 +1,37 @@
 /**
  * Handles the toggling of layers on a map/choropleth according to the slider/checkbox.
  */
-function toggleLayers(label, checkboxId, sliderId, map, allLayers) {
+function toggleLayers(label, checkboxId, sliderId, map, mapData) {
     if (document.getElementById(checkboxId).checked) {
         // For label types that don't have severity, show all labels.
         if (sliderId === undefined) {
-            for (let i = 0; i < allLayers[label].length; i++) {
-                if (!map.hasLayer(allLayers[label][i])) {
-                    map.addLayer(allLayers[label][i]);
+            for (let i = 0; i < mapData.labelLayers[label].length; i++) {
+                if (!map.hasLayer(mapData.labelLayers[label][i])) {
+                    map.addLayer(mapData.labelLayers[label][i]);
                 }
             }
         }
         // Only show labels with severity in range of sliders. This works for null severity b/c null >= 0 === true.
         let lowRange = $(sliderId).slider('option', 'values')[0];
         let highRange = $(sliderId).slider('option', 'values')[1];
-        for (let i = 0; i < allLayers[label].length; i++) {
-            if (lowRange <= i && highRange >= i && !map.hasLayer(allLayers[label][i])) {
-                map.addLayer(allLayers[label][i]);
-            } else if ((lowRange > i || highRange < i) && map.hasLayer(allLayers[label][i])) {
-                map.removeLayer(allLayers[label][i]);
+        for (let i = 0; i < mapData.labelLayers[label].length; i++) {
+            if (lowRange <= i && highRange >= i && !map.hasLayer(mapData.labelLayers[label][i])) {
+                map.addLayer(mapData.labelLayers[label][i]);
+            } else if ((lowRange > i || highRange < i) && map.hasLayer(mapData.labelLayers[label][i])) {
+                map.removeLayer(mapData.labelLayers[label][i]);
             }
         }
     } else {
         // Box is unchecked, remove all labels of that type.
-        for (let i = 0; i < allLayers[label].length; i++) {
-            if (map.hasLayer(allLayers[label][i])) {
-                map.removeLayer(allLayers[label][i]);
+        for (let i = 0; i < mapData.labelLayers[label].length; i++) {
+            if (map.hasLayer(mapData.labelLayers[label][i])) {
+                map.removeLayer(mapData.labelLayers[label][i]);
             }
         }
     }
 }
+
+
 
 function toggleAuditedStreetLayer(map, auditedStreetLayer) {
     if (document.getElementById('auditedstreet').checked) {

--- a/public/javascripts/Choropleths/MapUtilities.js
+++ b/public/javascripts/Choropleths/MapUtilities.js
@@ -2,15 +2,15 @@
  * Handles the toggling of layers on a map/choropleth according to the slider/checkbox.
  */
 function toggleLayers(label, checkboxId, sliderId, map, allLayers) {
+    console.log(allLayers);
     if (document.getElementById(checkboxId).checked) {
-        if(checkboxId === 'occlusion'){
+        if (checkboxId === 'occlusion') {
             for (let i = 0; i < allLayers[label].length; i++) {
                 if (!map.hasLayer(allLayers[label][i])) {
                     map.addLayer(allLayers[label][i]);
                 }
             }
-        }
-        else {
+        } else {
             for (let i = 0; i < allLayers[label].length; i++) {
                 if (!map.hasLayer(allLayers[label][i])
                     && ($(sliderId).slider('option', 'values')[0] <= i &&

--- a/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
@@ -650,9 +650,11 @@ function ContextMenu (uiContextMenu) {
                 // Don't push event on Occlusion labels; they don't open ContextMenus.
                 svl.tracker.push('ContextMenu_Open', {'auditTaskId': labelProperties.audit_task_id}, {'temporaryLabelId': labelProperties.temporary_label_id});
             }
+            if (labelType !== 'Occlusion' && labelType !== 'Signal') {
+                self.updateRadioButtonImages();
+                _setSeverityTooltips(labelType);
+            }
         }
-        self.updateRadioButtonImages();
-        _setSeverityTooltips(labelType);
     }
 
     /**

--- a/public/javascripts/SVLabel/src/SVLabel/label/Label.js
+++ b/public/javascripts/SVLabel/src/SVLabel/label/Label.js
@@ -417,9 +417,9 @@ function Label (svl, pathIn, params) {
             // Renders the label image.
             path.render2(ctx, pov);
 
-            // Only render severity label if there's a severity option.
-            if (properties.labelType !== 'Occlusion') {
-                if (properties.severity == undefined) {
+            // Only render severity warning if there's a severity option.
+            if (properties.labelType !== 'Occlusion' && properties.labelType !== 'Signal') {
+                if (properties.severity === undefined) {
                     showSeverityAlert(ctx);
                 }
             }

--- a/public/stylesheets/admin.css
+++ b/public/stylesheets/admin.css
@@ -85,6 +85,10 @@
     border-top: 0;
 }
 
+#legend-table>tbody>tr>td {
+    padding: 2px 8px;
+}
+
 .mapbox-logo {
     left: 405px;
     bottom: 5px


### PR DESCRIPTION
Resolves #2786 

Adds validation status filters to the UI in Label Map. Also adds the ability to add back in users who have been marked as 'low quality' using the browser console. There are instructions for how to do the latter that get logged to the browser console when you load the page.

I reduced some padding in the legend since it was getting a bit unruly. There is an identical map on the admin page that has also been updated.

##### Before/After screenshots (if applicable)
Before
<img width="1440" alt="Screen Shot 2022-04-04 at 11 08 44 AM" src="https://user-images.githubusercontent.com/6518824/161605166-631bfe86-429f-4c0e-99f3-842749713281.png">


After
<img width="1440" alt="Screen Shot 2022-04-04 at 10 57 04 AM" src="https://user-images.githubusercontent.com/6518824/161605179-e38dde15-ee25-4cdc-807b-f588038eff14.png">
<img width="422" alt="Screen Shot 2022-04-04 at 10 57 28 AM" src="https://user-images.githubusercontent.com/6518824/161605202-f29b4d80-c48d-4d84-8e6c-b4b00c2ab7a1.png">


##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
- [x] I've asked for and included translations for any user facing text that was added or modified.
