### PR TITLE
Fixes smooth panning

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/navigation/Compass.js
+++ b/public/javascripts/SVLabel/src/SVLabel/navigation/Compass.js
@@ -39,7 +39,7 @@ function Compass (svl, mapService, taskContainer, uiCompass) {
      * Get the angle to the next goal.
      * @returns {number}
      */
-    function _getTargetAngle() {
+    function getTargetAngle() {
         var task = taskContainer.getCurrentTask();
         var latlng = mapService.getPosition();
         var geometry = task.getGeometry();  // get the street geometry of the current task
@@ -157,10 +157,10 @@ function Compass (svl, mapService, taskContainer, uiCompass) {
      * Get the compass angle
      * @returns {number}
      */
-    function getCompassAngle () {
+    function _getCompassAngle () {
         var heading = mapService.getPov().heading;
-        var targetAngle = _getTargetAngle();
-        return heading - targetAngle;
+        var targetAngle = getTargetAngle();
+        return (heading - targetAngle) % 360;
     }
 
     /**
@@ -200,7 +200,7 @@ function Compass (svl, mapService, taskContainer, uiCompass) {
     function setTurnMessage () {
         var image,
             message,
-            angle = self.getCompassAngle(),
+            angle = _getCompassAngle(),
             direction = _angleToDirection(angle);
 
         image = "<img src='" + directionToImagePath(direction) + "' class='compass-turn-images' alt='Turn icon' />";
@@ -320,7 +320,7 @@ function Compass (svl, mapService, taskContainer, uiCompass) {
         if (_checkEnRoute()) {
             svl.stuckAlert.compassOrStuckClicked();
 
-            var angle = self.getCompassAngle();
+            var angle = _getCompassAngle();
             var direction = _angleToDirection(angle);
             svl.tracker.push(`Click_Compass_Direction=${direction}`);
 
@@ -339,8 +339,8 @@ function Compass (svl, mapService, taskContainer, uiCompass) {
     self.blink = blink;
     self.directionToImagePath = directionToImagePath;
     self.resetBeforeJump = resetBeforeJump;
-    self.getCompassAngle = getCompassAngle;
     self.getCompassMessageHolder = getCompassMessageHolder;
+    self.getTargetAngle = getTargetAngle;
     self.hideMessage = hideMessage;
     self.setTurnMessage = setTurnMessage;
     self.enableCompassClick = enableCompassClick;

--- a/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
+++ b/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
@@ -1453,9 +1453,8 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
     // Set the POV in the same direction as the route.
     function setPovToRouteDirection(durationMs) {
         var pov = svl.panorama.getPov();
-        var compassAngle = svl.compass.getCompassAngle();
         var newPov = {
-            heading: parseInt(pov.heading - compassAngle, 10) % 360,
+            heading: parseInt(svl.compass.getTargetAngle() + 360, 10) % 360,
             pitch: pov.pitch,
             zoom: pov.zoom
         }


### PR DESCRIPTION
Resolves #2850 

Fixes an issue with the smooth panning on the Explore page. Indeed, some function expected a positive angle as an input, and we were not always providing a positive number.
