### PR TITLE
#2829: Changing the Navbar's "city" button to the current city shortname

### DIFF
--- a/app/views/navbar.scala.html
+++ b/app/views/navbar.scala.html
@@ -143,7 +143,7 @@
 
                 <li id="navbar-city-dropdown" class="active dropdown navbar-lnk">
                     <a id="nav-city-dropdown" class="navbar-button" role="button" data-toggle="dropdown" href="#" aria-label="City selection dropdown">
-                        @Messages("navbar.city")
+                        @Play.configuration.getString("city-params.city-short-name." + currentCity).get
                     <b class="caret"></b>
                     </a>
                     <ul id="nav-city-menu" class="dropdown-menu" role="menu" aria-label="City options">


### PR DESCRIPTION
Resolves #2829 

Changed city dropdown button to display current city's shortname.

##### Before/After screenshots (if applicable)
Before:
![image](https://user-images.githubusercontent.com/77756028/161644319-195a00aa-e2e4-485d-9a88-a9a71c19832b.png)

After:
![image](https://user-images.githubusercontent.com/77756028/161643671-d9b9bb82-2c62-4624-88b5-5cf1b3baed65.png)

##### Testing instructions
1. After loading in page, check the navbar buttons on the top right
2. If the 3rd to last button (after "Data" and before "Sign In") is the shortname of the current city, the change works. If it still says "city" then it did not go through.

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've included before/after screenshots above.
