### PR TITLE
Fixes tooltips showing up on the wrong tags

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
@@ -452,18 +452,20 @@ function ContextMenu (uiContextMenu) {
                 // Go through each label tag, modify each button to display tag.
                 labelTags.forEach(function (tag) {
                     if (tag.label_type === label.getProperty('labelType')) {
+                        var buttonIndex = count; // Save index in a separate var b/c tooltips are added asynchronously.
+
                         // Remove all leftover tags from last labeling.
                         // Warning to future devs: will remove any other classes you add to the tags.
-                        tagHolder.find("button[id=" + count + "]").attr('class', 'context-menu-tag');
+                        tagHolder.find("button[id=" + buttonIndex + "]").attr('class', 'context-menu-tag');
 
                         // Add tag id as a class so that finding the element is easier later.
-                        tagHolder.find("button[id=" + count + "]").addClass("tag-id-" + tag.tag_id);
+                        tagHolder.find("button[id=" + buttonIndex + "]").addClass("tag-id-" + tag.tag_id);
 
                         // Set tag texts to new underlined version as defined in the util label description map.
                         var tagText = util.misc.getLabelDescriptions(tag.label_type)['tagInfo'][tag.tag]['text'];
-                        tagHolder.find("button[id=" + count + "]").html(tagText);
+                        tagHolder.find("button[id=" + buttonIndex + "]").html(tagText);
 
-                        tagHolder.find("button[id=" + count + "]").css({
+                        tagHolder.find("button[id=" + buttonIndex + "]").css({
                             visibility: 'inherit',
                             position: 'inherit'
                         });
@@ -473,7 +475,6 @@ function ContextMenu (uiContextMenu) {
 
                         // Add tooltip with tag example if we have an example image to show.
                         var imageUrl = `/assets/javascripts/SVLabel/img/label_tag_popups/${tag.tag_id}.png`;
-                        var buttonIndex = count; // Save index in a separate var b/c tooltips added asynchronously.
                         util.getImage(imageUrl).then(img => {
                             // Convert the first letter of tag text to uppercase and get keyboard shortcut character.
                             const underlineClassOffset = 15;
@@ -494,7 +495,7 @@ function ContextMenu (uiContextMenu) {
                             var tooltipImage = `<img src="${img}" height="125"/>`
 
                             // Create the tooltip.
-                            tagHolder.find("button[id=" + buttonIndex + "]").tooltip("destroy").tooltip(({
+                            tagHolder.find("button[id=" + buttonIndex + "]").tooltip(({
                                 placement: 'top',
                                 html: true,
                                 delay: {"show": 300, "hide": 10},


### PR DESCRIPTION
Resolves #2862 

Fixes an issue where label tags with no image to put in the tooltip on the explore page were showing a tooltip for a different tag altogether.

##### Before/After screenshots (if applicable)
Before
![Screenshot from 2022-04-19 11-10-35](https://user-images.githubusercontent.com/6518824/164068667-6679a818-91c8-4e24-86bc-b466ae62bd15.png)

After
![Screenshot from 2022-04-19 11-10-55](https://user-images.githubusercontent.com/6518824/164068679-d8ed3a00-815a-4256-83d9-7d84534a5e63.png)

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've included before/after screenshots above.
