### PR TITLE
Fixes LabelMap curb ramp checkbox

### DIFF
--- a/app/views/labelMap.scala.html
+++ b/app/views/labelMap.scala.html
@@ -23,7 +23,7 @@
                     <tr>
                         <td id="map-legend-curb-ramp" width="12px"></td>
                         <td width="190px">@Messages("curb.ramp")</td>
-                        <td width="12px"  align="center"><input type="checkbox" value="displaylabel" id="curbramp" checked="true" onclick = "toggleLayers('CurbRamp', 'curbramp', '#curb-ramp-slider', map.map, map.map, map.mapData)"></td>
+                        <td width="12px"  align="center"><input type="checkbox" value="displaylabel" id="curbramp" checked="true" onclick = "toggleLayers('CurbRamp', 'curbramp', '#curb-ramp-slider', map.map, map.mapData)"></td>
                         <td width="126px"align="center"><div id = "curb-ramp-slider" style="margin-top:3px"></div></td>
                         <td width="80px" align= "center" ><span id="curb-ramp-severity-label">N/A - 5</span></td>
 


### PR DESCRIPTION
Resolves #2854 

Fixes the checkbox on LabelMap for the curb ramp labels! It was a small copy/paste error that I missed.
