### PR TITLE
Adds API endpoint for label metadata for CV project

### DIFF
--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -11,11 +11,12 @@ import com.vividsolutions.jts.geom.Coordinate
 import controllers.headers.ProvidesHeader
 import formats.json.TaskFormats._
 import formats.json.UserRoleSubmissionFormats._
+import formats.json.LabelFormat._
 import models.attribute.{GlobalAttribute, GlobalAttributeTable}
 import models.audit.{AuditTaskInteractionTable, AuditTaskTable, AuditedStreetWithTimestamp, InteractionWithLabel}
 import models.daos.slick.DBTableDefinitions.UserTable
 import models.gsv.GSVDataTable
-import models.label.LabelTable.LabelMetadata
+import models.label.LabelTable.{LabelMetadata, LabelCVMetadata}
 import models.label.{LabelPointTable, LabelTable, LabelTypeTable, LabelValidationTable}
 import models.mission.MissionTable
 import models.region.RegionCompletionTable
@@ -375,6 +376,15 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
         Future.successful(Ok(labelMetadataJson))
       case _ => Future.successful(Ok(Json.obj("error" -> "no such label")))
     }
+  }
+
+  /**
+   * Get metadata used for 2022 CV project for all labels, and output as JSON.
+   */
+  def getAllLabelMetadataForCV = UserAwareAction.async { implicit request =>
+    val labels: List[LabelCVMetadata] = LabelTable.getLabelCVMetadata
+    val json: JsValue = Json.toJson(labels.map(l => Json.toJson(l)))
+    Future.successful(Ok(json))
   }
 
   /**

--- a/app/formats/json/LabelFormat.scala
+++ b/app/formats/json/LabelFormat.scala
@@ -27,4 +27,28 @@ object LabelFormat {
       (__ \ "notsure_count").write[Int] and
       (__ \ "correct").writeNullable[Boolean]
     )(unlift(Label.unapply _))
+
+  implicit val labelCVMetadataWrite: Writes[LabelTable.LabelCVMetadata] = (
+    (__ \ "label_id").write[Int] and
+      (__ \ "gsv_panorama_id").write[String] and
+      (__ \ "label_type_id").write[Int] and
+      (__ \ "deleted").write[Boolean] and
+      (__ \ "tutorial").write[Boolean] and
+      (__ \ "agree_count").write[Int] and
+      (__ \ "disagree_count").write[Int] and
+      (__ \ "notsure_count").write[Int] and
+      (__ \ "image_width").writeNullable[Int] and
+      (__ \ "image_height").writeNullable[Int] and
+      (__ \ "sv_image_x").write[Int] and
+      (__ \ "sv_image_y").write[Int] and
+      (__ \ "canvas_width").write[Int] and
+      (__ \ "canvas_height").write[Int] and
+      (__ \ "canvas_x").write[Int] and
+      (__ \ "canvas_y").write[Int] and
+      (__ \ "zoom").write[Int] and
+      (__ \ "heading").write[Float] and
+      (__ \ "pitch").write[Float] and
+      (__ \ "photographer_heading").write[Float] and
+      (__ \ "photographer_pitch").write[Float]
+  )(unlift(LabelTable.LabelCVMetadata.unapply _))
 }

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -20,42 +20,16 @@ import scala.collection.mutable.ListBuffer
 import scala.slick.jdbc.{GetResult, StaticQuery => Q}
 import scala.slick.lifted.ForeignKeyQuery
 
-case class Label(labelId: Int,
-                 auditTaskId: Int,
-                 missionId: Int,
-                 gsvPanoramaId: String,
-                 labelTypeId: Int,
-                 photographerHeading: Float,
-                 photographerPitch: Float,
-                 panoramaLat: Float,
-                 panoramaLng: Float,
-                 deleted: Boolean,
-                 temporaryLabelId: Option[Int],
-                 timeCreated: Option[Timestamp],
-                 tutorial: Boolean,
-                 streetEdgeId: Int,
-                 agreeCount: Int,
-                 disagreeCount: Int,
-                 notsureCount: Int,
-                 correct: Option[Boolean])
+case class Label(labelId: Int, auditTaskId: Int, missionId: Int, gsvPanoramaId: String, labelTypeId: Int,
+                 photographerHeading: Float, photographerPitch: Float, panoramaLat: Float, panoramaLng: Float,
+                 deleted: Boolean, temporaryLabelId: Option[Int], timeCreated: Option[Timestamp], tutorial: Boolean,
+                 streetEdgeId: Int, agreeCount: Int, disagreeCount: Int, notsureCount: Int, correct: Option[Boolean])
 
-case class LabelLocation(labelId: Int,
-                         auditTaskId: Int,
-                         gsvPanoramaId: String,
-                         labelType: String,
-                         lat: Float,
-                         lng: Float)
+case class LabelLocation(labelId: Int, auditTaskId: Int, gsvPanoramaId: String, labelType: String, lat: Float, lng: Float)
 
-case class LabelLocationWithSeverity(labelId: Int,
-                                     auditTaskId: Int,
-                                     gsvPanoramaId: String,
-                                     labelType: String,
-                                     lat: Float,
-                                     lng: Float,
-                                     correct: Option[Boolean],
-                                     expired: Boolean,
-                                     highQualityUser: Boolean,
-                                     severity: Option[Int])
+case class LabelLocationWithSeverity(labelId: Int, auditTaskId: Int, gsvPanoramaId: String, labelType: String,
+                                     lat: Float, lng: Float, correct: Option[Boolean], expired: Boolean,
+                                     highQualityUser: Boolean, severity: Option[Int])
 
 class LabelTable(tag: slick.lifted.Tag) extends Table[Label](tag, Some("sidewalk"), "label") {
   def labelId = column[Int]("label_id", O.PrimaryKey, O.AutoInc)

--- a/build.sbt
+++ b/build.sbt
@@ -61,7 +61,7 @@ scalacOptions ++= Seq(
 
 javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
 
-javaOptions ++= Seq("-Xmx3072M", "-Xms2048M")
+javaOptions ++= Seq("-Xmx4096M", "-Xms2048M")
 
 javaOptions in Test += "-Dconfig.file=conf/application.test.conf"
 

--- a/conf/routes
+++ b/conf/routes
@@ -67,6 +67,7 @@ GET     /adminapi/labels/all                                 @controllers.AdminC
 GET     /adminapi/label/id/:labelId                          @controllers.AdminController.getAdminLabelData(labelId: Int)
 GET     /adminapi/labelCounts                                @controllers.AdminController.getAllUserLabelCounts
 GET     /adminapi/labels/panoid                              @controllers.AdminController.getAllPanoIds
+GET     /adminapi/labels/cvMetadata                          @controllers.AdminController.getAllLabelMetadataForCV
 GET     /adminapi/panos                                      @controllers.AdminController.getAllPanoIds
 GET     /adminapi/attributes/all                             @controllers.AdminController.getAllAttributes
 GET     /adminapi/validationCounts                           @controllers.AdminController.getAllUserValidationCounts

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "grunt-concat": "grunt concat && grunt concat_css",
     "build": "npm install && grunt",
     "debug": "npm run grunt-concat && grunt watch & sbt -jvm-debug 9998 run",
-    "start": "npm run grunt-concat && grunt watch & sbt -Dsbt.ivy.home='.ivy2' -Dsbt.global.base='.sbt' -Dsbt.repository.config='.sbt/repositories' compile \"~ run\" shell",
+    "start": "npm run grunt-concat && grunt watch & sbt -Dsbt.ivy.home='.ivy2' -Dsbt.global.base='.sbt' -Dsbt.repository.config='.sbt/repositories' -mem 2048 compile \"~ run\" shell",
     "test": "grunt && grunt test"
   }
 }


### PR DESCRIPTION
Adds an API endpoint at `/adminapi/labels/cvMetadata` to get the metadata for labels that we need for our most recent computer vision project. Here is some example output:
```
[
    {
        "label_id": 173572,
        "gsv_panorama_id": "qos0p3mBdh7Pynq2N-1SWw",
        "label_type_id": 4,
        "deleted": false,
        "tutorial": false,
        "agree_count": 0,
        "disagree_count": 0,
        "notsure_count": 1,
        "sv_image_x": 9927,
        "sv_image_y": -624,
        "canvas_width": 720,
        "canvas_height": 480,
        "canvas_x": 384,
        "canvas_y": 212,
        "zoom": 3,
        "heading": 267.84820556640625,
        "pitch": -18.546875,
        "photographer_heading": 180.2176055908203,
        "photographer_pitch": 0.13916778564453125
    },
    ...
]
```

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've added/updated comments for large or confusing blocks of code.
