### PR TITLE
2631: Fixed tutorial malfunction due to arrow key inputs

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/keyboard/Keyboard.js
+++ b/public/javascripts/SVLabel/src/SVLabel/keyboard/Keyboard.js
@@ -27,7 +27,8 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
         isOnboarding: false,
         shiftDown: false,
         disableKeyboard: false,
-        moving: false
+        moving: false,
+        disableMovement: false
     };
 
     this.disableKeyboard = function (){
@@ -50,8 +51,10 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
         var maxIndex = cosines.indexOf(maxVal);
         if(cosines[maxIndex] > 0.5){
             var panoramaId = svl.panorama.links[maxIndex].pano;
-
             googleMap.setPano(panoramaId);
+            return true;
+        } else {
+            return false;
         }
     };
 
@@ -59,21 +62,23 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
        Move user in specific angle relative to current view for a specific moveTime.
      */
     function timedMove(angle, moveTime){
-        if (status.moving || svl.isOnboarding() || svl.popUpMessage.getStatus("isVisible")){
+        if (status.moving || svl.popUpMessage.getStatus("isVisible")){
             svl.panorama.set("linksControl", false);
             return;
         }
         svl.contextMenu.hide();
         svl.ui.canvas.deleteIconHolder.css("visibility", "hidden");
-        self._movePano(angle);
-        //prevent user input of walking commands
-        svl.map.timeoutWalking();
-        //restore user ability to walk after param moveTime
-        setTimeout(svl.map.resetWalking, moveTime);
-        //additional check to hide arrows after the fact
-        //pop-up may become visible during timeout period
-        if (svl.popUpMessage.getStatus('isVisible')){
-            svl.panorama.set('linksControl', false);//disable arrows
+        var moveSuccess = self._movePano(angle);
+        if (moveSuccess) {
+            //prevent user input of walking commands
+            svl.map.timeoutWalking();
+            //restore user ability to walk after param moveTime
+            setTimeout(svl.map.resetWalking, moveTime);
+            //additional check to hide arrows after the fact
+            //pop-up may become visible during timeout period
+            if (svl.popUpMessage.getStatus('isVisible')){
+                svl.panorama.set('linksControl', false);//disable arrows
+            }
         }
     }
 
@@ -154,12 +159,16 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
                     case 39:  // "Right"
                         self._rotatePov(2);
                         break;
-                    case 38:
-                        self._moveForward();
-                        break;
-                    case 40:  // "down"
-                        self._moveBackward();
-                        break;
+                }
+                if (!status.disableMovement) {
+                    switch (e.keyCode) {
+                        case 38: // "up"
+                            self._moveForward();
+                            break;
+                        case 40:  // "down"
+                            self._moveBackward();
+                            break;
+                    }
                 }
                 if ([37, 38, 39, 40].indexOf(e.keyCode) > -1) {
                     e.preventDefault();

--- a/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
+++ b/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
@@ -404,6 +404,8 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
             hideLinks();
             uiMap.modeSwitchWalk.css('opacity', 0.5);
             status.disableWalking = true;
+            // Disable forward and backwards keys
+            svl.keyboard.setStatus("disableMovement", true);
         }
         return this;
     }
@@ -429,6 +431,8 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
             showNavigationArrows();
             uiMap.modeSwitchWalk.css('opacity', 1);
             status.disableWalking = false;
+            // Enable forward and backward keys
+            svl.keyboard.setStatus("disableMovement", false);
         }
         return this;
     }


### PR DESCRIPTION
Resolves #2631 

- Disabled up/down arrow keys whenever walking is disabled (Keyboard.js, MapService.js)
     - _Created "disableMovement" status parameter in Keyboard.js that enables/disables the up/down arrow keys which is enabled/disabled on calls to "enableWalking()" and "disableWalking()" in MapService.js._
- Fixed bug where timedMove() would disable walking buttons without re-enabling them or temporarily disable them unnecessarily (Keyboard.js)
     - _"\_movePano()" function now returns true if google maps successfully moves, and false otherwise. The "timedMove()" function no longer disables walking during the tutorial, and instead temporarily disables walking only if a successful move in google maps occurs._

##### Before/After screenshots (if applicable)

Before:
![image](https://user-images.githubusercontent.com/77756028/166392166-7e1722a2-844d-4740-96cd-a2d8a99d2efe.png)

After:
![image](https://user-images.githubusercontent.com/77756028/166392296-fd8e8491-b4b5-4783-9007-2dc2462594f4.png)

##### Testing instructions
1. Enter the tutorial by clicking the "Start Exploring" tab on the top. If you have already done the tutorial, hit the "Retake Tutorial" tab in the same spot on the top.
2. Go through the tutorial until you get to the section where the tutorial tells you to move forward.
3. Hit the down arrow key on your keyboard. If nothing happens, it's working fine! If the on-screen arrow button disappears and reappears, or just disappears, the "timedMove()" function is not working correctly.
4. Hit the up arrow key on your keyboard. If google maps moves forwards, it's working correctly!

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
