### PR TITLE
Fix inconsistent completion percentage

### DIFF
--- a/app/controllers/ApplicationController.scala
+++ b/app/controllers/ApplicationController.scala
@@ -2,7 +2,6 @@ package controllers
 
 import java.sql.Timestamp
 import java.time.Instant
-import scala.collection.JavaConverters._
 import javax.inject.Inject
 import com.mohiva.play.silhouette.api.{Environment, Silhouette}
 import com.mohiva.play.silhouette.impl.authenticators.SessionAuthenticator
@@ -10,7 +9,7 @@ import controllers.headers.ProvidesHeader
 import models.user._
 import models.amt.{AMTAssignment, AMTAssignmentTable}
 import models.daos.slick.DBTableDefinitions.UserTable
-import models.street.StreetEdgeTable
+import models.street.StreetEdgePriorityTable
 import models.utils.Configs
 import play.api.Play
 import play.api.Play.current
@@ -126,8 +125,8 @@ class ApplicationController @Inject() (implicit val env: Environment[User, Sessi
               val otherCityUrls: List[(String, String, String, String)] = Configs.getAllCityInfo(excludeCity=cityStr)
               // Get total audited distance. If using metric system, convert from miles to kilometers.
               val auditedDistance: Float =
-                if (Messages("measurement.system") == "metric") StreetEdgeTable.auditedStreetDistance(1) * 1.60934.toFloat
-                else StreetEdgeTable.auditedStreetDistance(1)
+                if (Messages("measurement.system") == "metric") StreetEdgePriorityTable.auditedStreetDistanceUsingPriority * 1.60934.toFloat
+                else StreetEdgePriorityTable.auditedStreetDistanceUsingPriority
               Future.successful(Ok(views.html.index("Project Sidewalk", Some(user), cityName, stateAbbreviation, cityShortName, mapathonLink, cityStr, otherCityUrls, auditedDistance)))
             } else{
               WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, activityLogText, timestamp))

--- a/app/controllers/TaskController.scala
+++ b/app/controllers/TaskController.scala
@@ -184,8 +184,8 @@ class TaskController @Inject() (implicit val env: Environment[User, SessionAuthe
    */
   def processAuditTaskSubmissions(submission: Seq[AuditTaskSubmission], remoteAddress: String, identity: Option[User]) = {
     val returnValues: Seq[TaskPostReturnValue] = for (data <- submission) yield {
-      val userOption = identity
-      val streetEdgeId = data.auditTask.streetEdgeId
+      val userOption: Option[User] = identity
+      val streetEdgeId: Int = data.auditTask.streetEdgeId
       val missionId: Int = data.missionProgress.missionId
 
       if (data.auditTask.auditTaskId.isDefined) {
@@ -195,7 +195,7 @@ class TaskController @Inject() (implicit val env: Environment[User, SessionAuthe
             if (!AuditTaskTable.userHasAuditedStreet(streetEdgeId, user.userId)) {
               data.auditTask.completed.map { completed =>
                 if (completed) {
-                  StreetEdgePriorityTable.partiallyUpdatePriority(streetEdgeId)
+                  StreetEdgePriorityTable.partiallyUpdatePriority(streetEdgeId, Some(user.userId.toString))
                 }
               }
             }
@@ -204,7 +204,7 @@ class TaskController @Inject() (implicit val env: Environment[User, SessionAuthe
             Logger.warn("User without user_id audited a street, but every user should have a user_id.")
             data.auditTask.completed.map { completed =>
               if (completed) {
-                StreetEdgePriorityTable.partiallyUpdatePriority(streetEdgeId)
+                StreetEdgePriorityTable.partiallyUpdatePriority(streetEdgeId, None)
               }
             }
         }

--- a/app/models/audit/AuditTaskTable.scala
+++ b/app/models/audit/AuditTaskTable.scala
@@ -296,13 +296,6 @@ object AuditTaskTable {
   }
 
   /**
-    * Returns true if there is a completed audit task for the given street edge, false otherwise.
-    */
-  def anyoneHasAuditedStreet(streetEdgeId: Int): Boolean = db.withSession { implicit session =>
-    completedTasks.filter(_.streetEdgeId === streetEdgeId).list.nonEmpty
-  }
-
-  /**
     * Return audited street edges.
     */
   def selectStreetsAudited(filterLowQuality: Boolean): List[StreetEdge] = db.withSession { implicit session =>

--- a/app/models/region/RegionCompletionTable.scala
+++ b/app/models/region/RegionCompletionTable.scala
@@ -1,6 +1,6 @@
 package models.region
 
-import models.street.{StreetEdgeRegionTable, StreetEdgeTable}
+import models.street.{StreetEdgePriorityTable, StreetEdgeRegionTable, StreetEdgeTable}
 import models.utils.MyPostgresDriver
 import models.utils.MyPostgresDriver.simple._
 import play.api.Play.current
@@ -99,7 +99,7 @@ object RegionCompletionTable {
 
           regionCompletions += RegionCompletion(neighborhood.regionId, totalDistance, totalDistance)
         } else {
-          val auditedDistance: Double = StreetEdgeTable.getDistanceAuditedInARegion(neighborhood.regionId).toDouble
+          val auditedDistance: Double = StreetEdgePriorityTable.getDistanceAuditedInARegion(neighborhood.regionId).toDouble
           val totalDistance: Double = StreetEdgeTable.getTotalDistanceOfARegion(neighborhood.regionId).toDouble
 
           regionCompletions += RegionCompletion(neighborhood.regionId, totalDistance, auditedDistance)

--- a/app/models/street/StreetEdgeTable.scala
+++ b/app/models/street/StreetEdgeTable.scala
@@ -304,21 +304,6 @@ object StreetEdgeTable {
     selectAuditedStreets(auditCount, userType).size
   }
 
-  /** Returns the sum of the lengths of all streets in the region that have been audited. */
-  def getDistanceAuditedInARegion(regionId: Int): Float = db.withSession { implicit session =>
-    val streetsInRegion = for {
-      _edgeRegions <- streetEdgeRegion if _edgeRegions.regionId === regionId
-      _edges <- streetEdgesWithoutDeleted if _edges.streetEdgeId === _edgeRegions.streetEdgeId
-    } yield _edges
-
-    val auditedStreetsInARegion = for {
-      (_edges, _tasks) <- streetsInRegion.innerJoin(completedAuditTasks).on(_.streetEdgeId === _.streetEdgeId)
-    } yield _edges
-
-    // Select distinct and sum the lengths of the streets.
-    auditedStreetsInARegion.groupBy(x => x).map(_._1.geom.transform(26918).length).list.sum
-  }
-
   /** Returns the sum of the lengths of all streets in the region. */
   def getTotalDistanceOfARegion(regionId: Int): Float = db.withSession { implicit session =>
     val streetsInRegion = for {

--- a/app/models/street/StreetEdgeTable.scala
+++ b/app/models/street/StreetEdgeTable.scala
@@ -119,8 +119,8 @@ object StreetEdgeTable {
     * @return Float between 0 and 1
     */
   def streetDistanceCompletionRate(auditCount: Int, userType: String = "All"): Float = db.withSession { implicit session =>
-    val auditedDistance = auditedStreetDistance(auditCount, userType)
-    val totalDistance = totalStreetDistance()
+    val auditedDistance: Float = auditedStreetDistance(auditCount, userType)
+    val totalDistance: Float = totalStreetDistance()
     auditedDistance / totalDistance
   }
 
@@ -149,7 +149,7 @@ object StreetEdgeTable {
   def auditedStreetDistance(auditCount: Int, userType: String = "All"): Float = db.withSession { implicit session =>
     val cacheKey = s"auditedStreetDistance($auditCount, $userType)"
 
-    Cache.getOrElse(cacheKey, 1.hour.toSeconds.toInt) {
+    Cache.getOrElse(cacheKey, 30.minutes.toSeconds.toInt) {
       val auditTaskQuery = userType match {
         case "All" => completedAuditTasks
         case "Researcher" => researcherCompletedAuditTasks

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -1,9 +1,9 @@
 @import models.user.User
 @import models.region.RegionTable
 @import models.label._
-@import models.street.StreetEdgeTable
 @import play.api.libs.json.Json
 @import scala.util.Random
+@import models.street.StreetEdgePriorityTable
 @(title: String, user: Option[User] = None, cityName: String, stateAbbreviation: String, cityShortName: String, mapathonLink: Option[String], cityId: String, otherCityURLs: List[(String, String, String, String)], auditedDistance: Float)(implicit lang: Lang)
 
 @main(title) {
@@ -152,12 +152,12 @@
             </a>
         </div>
         <script language="javascript">
-            if (@("%.0f".format(StreetEdgeTable.streetDistanceCompletionRate(1) * 100)) < 100) {
-                document.getElementById('conditional-text').innerHTML = "@Messages("landing.stats.content.unfinished", "%,.0f".format(auditedDistance), cityName, stateAbbreviation, "%.1f".format(StreetEdgeTable.streetDistanceCompletionRate(1) * 100))";
+            if (@("%.0f".format(StreetEdgePriorityTable.streetDistanceCompletionRateUsingPriority * 100)) < 100) {
+                document.getElementById('conditional-text').innerHTML = "@Messages("landing.stats.content.unfinished", "%,.0f".format(auditedDistance), cityName, stateAbbreviation, "%.1f".format(StreetEdgePriorityTable.streetDistanceCompletionRateUsingPriority * 100))";
             } else {
                 document.getElementById('conditional-text').innerHTML = "@Messages("landing.stats.content.finished", "%,.0f".format(auditedDistance), cityName, stateAbbreviation)";
             }
-            var percentageAnim = new CountUp("percentage", 0, @("%.1f".format(StreetEdgeTable.streetDistanceCompletionRate(1) * 100)),1,2.5,{suffix:'%'});
+            var percentageAnim = new CountUp("percentage", 0, @("%.1f".format(StreetEdgePriorityTable.streetDistanceCompletionRateUsingPriority * 100)),1,2.5,{suffix:'%'});
             var distanceAnim = new CountUp("distance", 0, @("%.1f".format(auditedDistance)),1,2.5,{suffix:''});
             var labelsAnim = new CountUp("numlabels", 0, @LabelTable.countLabels,0,2.5,{suffix:''});
             var validationsAnim = new CountUp("numvalidation", 0, @LabelValidationTable.countValidations,0,2.5,{suffix:''});


### PR DESCRIPTION
Resolves #2872 

Most uses of completion percentage and distance on our site now include only audits from users who have provided "high quality data". This removes a lot of the confusion between what users see on the landing page and what they see on the audit page.

I also reduced the time before these cached numbers are recalculated from every hour to every 30 minutes, so that we get to see the total percentage increase over the course of a mapathon.

I will need to wipe the `region_completion` table on every server in order for this change to fully take effect.

##### Before/After screenshots (if applicable)
Before/After Seattle stats (from January)
![Screenshot from 2022-05-11 17-32-16](https://user-images.githubusercontent.com/6518824/167969061-2e70333b-7220-456a-ad48-6029f5adbab8.png)
![Screenshot from 2022-05-11 17-13-58](https://user-images.githubusercontent.com/6518824/167969069-d907d66b-1f02-4807-8061-49a482110a23.png)

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
