### PR TITLE
Fix Gallery logging

### DIFF
--- a/app/controllers/GalleryTaskController.scala
+++ b/app/controllers/GalleryTaskController.scala
@@ -27,17 +27,17 @@ class GalleryTaskController @Inject() (implicit val env: Environment[User, Sessi
     * @return
     */
   def processGalleryTaskSubmissions(submission: Seq[GalleryTaskSubmission], remoteAddress: String, identity: Option[User]) = {
-    val userOption = identity
+    val userId: Option[String] = identity.map(_.userId.toString)
     for (data <- submission) yield {
       GalleryTaskInteractionTable.saveMultiple(data.interactions.map { interaction =>
-        GalleryTaskInteraction(0, interaction.action, interaction.panoId, interaction.note, new Timestamp(interaction.timestamp))
+        GalleryTaskInteraction(0, interaction.action, interaction.panoId, interaction.note, new Timestamp(interaction.timestamp), userId)
       })
 
       // Insert Environment.
       val env: GalleryEnvironmentSubmission = data.environment
       val taskEnv: GalleryTaskEnvironment = GalleryTaskEnvironment(0, env.browser,
         env.browserVersion, env.browserWidth, env.browserHeight, env.availWidth, env.availHeight, env.screenWidth,
-        env.screenHeight, env.operatingSystem, Some(remoteAddress), env.language)
+        env.screenHeight, env.operatingSystem, Some(remoteAddress), env.language, userId)
       GalleryTaskEnvironmentTable.save(taskEnv)
     }
     

--- a/app/models/gallery/GalleryTaskEnvironmentTable.scala
+++ b/app/models/gallery/GalleryTaskEnvironmentTable.scala
@@ -1,15 +1,15 @@
 package models.gallery
 
+import models.daos.slick.DBTableDefinitions.{DBUser, UserTable}
 import models.utils.MyPostgresDriver.simple._
 import play.api.Play.current
-
 import scala.slick.lifted.ForeignKeyQuery
 
 case class GalleryTaskEnvironment(galleryTaskEnvironmentId: Int, browser: Option[String],
                                 browserVersion: Option[String], browserWidth: Option[Int], browserHeight: Option[Int],
                                 availWidth: Option[Int], availHeight: Option[Int], screenWidth: Option[Int],
                                 screenHeight: Option[Int], operatingSystem: Option[String], ipAddress: Option[String],
-                                language: String)
+                                language: String, userId: Option[String])
 
 class GalleryTaskEnvironmentTable(tag: Tag) extends Table[GalleryTaskEnvironment](tag, Some("sidewalk"), "gallery_task_environment") {
   def galleryTaskEnvironmentId = column[Int]("gallery_task_environment_id", O.PrimaryKey, O.AutoInc)
@@ -24,9 +24,13 @@ class GalleryTaskEnvironmentTable(tag: Tag) extends Table[GalleryTaskEnvironment
   def operatingSystem = column[Option[String]]("operating_system", O.Nullable)
   def ipAddress = column[Option[String]]("ip_address", O.Nullable)
   def language = column[String]("language", O.NotNull)
+  def userId = column[Option[String]]("user_id", O.Nullable)
 
   def * = (galleryTaskEnvironmentId, browser, browserVersion, browserWidth, browserHeight, availWidth,
-    availHeight, screenWidth, screenHeight, operatingSystem, ipAddress, language) <> ((GalleryTaskEnvironment.apply _).tupled, GalleryTaskEnvironment.unapply)
+    availHeight, screenWidth, screenHeight, operatingSystem, ipAddress, language, userId) <> ((GalleryTaskEnvironment.apply _).tupled, GalleryTaskEnvironment.unapply)
+
+  def user: ForeignKeyQuery[UserTable, DBUser] =
+    foreignKey("gallery_task_environment_user_id_fkey", userId, TableQuery[UserTable])(_.userId)
 }
 
 /**

--- a/app/models/gallery/GalleryTaskInteractionTable.scala
+++ b/app/models/gallery/GalleryTaskInteractionTable.scala
@@ -1,13 +1,12 @@
 package models.gallery
 
+import models.daos.slick.DBTableDefinitions.{DBUser, UserTable}
 import models.utils.MyPostgresDriver.simple._
 import play.api.Play.current
+import scala.slick.lifted.ForeignKeyQuery
 
-case class GalleryTaskInteraction(galleryTaskInteractionId: Int,
-                                     action: String,
-                                     panoId: Option[String],
-                                     note: Option[String],
-                                     timestamp: java.sql.Timestamp)
+case class GalleryTaskInteraction(galleryTaskInteractionId: Int, action: String, panoId: Option[String],
+                                  note: Option[String], timestamp: java.sql.Timestamp, userId: Option[String])
 
 class GalleryTaskInteractionTable(tag: slick.lifted.Tag) extends Table[GalleryTaskInteraction](tag, Some("sidewalk"), "gallery_task_interaction") {
   def galleryTaskInteractionId = column[Int]("gallery_task_interaction_id", O.PrimaryKey, O.AutoInc)
@@ -15,8 +14,12 @@ class GalleryTaskInteractionTable(tag: slick.lifted.Tag) extends Table[GalleryTa
   def panoId = column[Option[String]]("pano_id", O.Nullable)
   def note = column[Option[String]]("note", O.Nullable)
   def timestamp = column[java.sql.Timestamp]("timestamp", O.NotNull)
+  def userId = column[Option[String]]("user_id", O.Nullable)
 
-  def * = (galleryTaskInteractionId, action, panoId, note, timestamp) <> ((GalleryTaskInteraction.apply _).tupled, GalleryTaskInteraction.unapply)
+  def * = (galleryTaskInteractionId, action, panoId, note, timestamp, userId) <> ((GalleryTaskInteraction.apply _).tupled, GalleryTaskInteraction.unapply)
+
+  def user: ForeignKeyQuery[UserTable, DBUser] =
+    foreignKey("gallery_task_interaction_user_id_fkey", userId, TableQuery[UserTable])(_.userId)
 }
 
 object GalleryTaskInteractionTable {

--- a/conf/evolutions/default/144.sql
+++ b/conf/evolutions/default/144.sql
@@ -7,6 +7,11 @@ ALTER TABLE gallery_task_interaction
     ADD COLUMN user_id TEXT,
     ADD CONSTRAINT gallery_task_interaction_user_id_fkey FOREIGN KEY (user_id) REFERENCES sidewalk_user(user_id);
 
+-- Standardize logs. We switched from Validate_MenuClick=<result> to Validate_MenuClick<result> awhile back.
+UPDATE gallery_task_interaction
+SET action = REPLACE(action, 'Validate_MenuClick=', 'Validate_MenuClick')
+WHERE action LIKE 'Validate_MenuClick=%';
+
 # --- !Downs
 ALTER TABLE gallery_task_interaction
     DROP CONSTRAINT IF EXISTS gallery_task_interaction_user_id_fkey,

--- a/conf/evolutions/default/144.sql
+++ b/conf/evolutions/default/144.sql
@@ -1,0 +1,17 @@
+# --- !Ups
+ALTER TABLE gallery_task_environment
+    ADD COLUMN user_id TEXT,
+    ADD CONSTRAINT gallery_task_environment_user_id_fkey FOREIGN KEY (user_id) REFERENCES sidewalk_user(user_id);
+
+ALTER TABLE gallery_task_interaction
+    ADD COLUMN user_id TEXT,
+    ADD CONSTRAINT gallery_task_interaction_user_id_fkey FOREIGN KEY (user_id) REFERENCES sidewalk_user(user_id);
+
+# --- !Downs
+ALTER TABLE gallery_task_interaction
+    DROP CONSTRAINT IF EXISTS gallery_task_interaction_user_id_fkey,
+    DROP COLUMN user_id;
+
+ALTER TABLE gallery_task_environment
+    DROP CONSTRAINT IF EXISTS gallery_task_environment_user_id_fkey,
+    DROP COLUMN user_id;

--- a/public/javascripts/Gallery/src/validation/ValidationMenu.js
+++ b/public/javascripts/Gallery/src/validation/ValidationMenu.js
@@ -164,7 +164,7 @@ function ValidationMenu(refCard, uiCardImage, cardProperties, modal, onExpandedV
         referenceCard.setProperty('user_validation', action);
 
         let actionStr = onExpandedView ? 'Validate_ExpandedMenuClick' + action : 'Validate_MenuClick' + action;
-        sg.tracker.push(actionStr, {panoId: currCardProperties.gsv_panorama_id}, {labelId: cardProperties.label_id});
+        sg.tracker.push(actionStr, {panoId: currCardProperties.gsv_panorama_id}, {labelId: currCardProperties.label_id});
         let validationTimestamp = new Date().getTime();
 
         let data = {

--- a/public/javascripts/Gallery/src/validation/ValidationMenu.js
+++ b/public/javascripts/Gallery/src/validation/ValidationMenu.js
@@ -164,7 +164,7 @@ function ValidationMenu(refCard, uiCardImage, cardProperties, modal, onExpandedV
         referenceCard.setProperty('user_validation', action);
 
         let actionStr = onExpandedView ? 'Validate_ExpandedMenuClick' + action : 'Validate_MenuClick' + action;
-        sg.tracker.push(actionStr);
+        sg.tracker.push(actionStr, { panoId: currCardProperties.gsv_panorama_id });
         let validationTimestamp = new Date().getTime();
 
         let data = {

--- a/public/javascripts/Gallery/src/validation/ValidationMenu.js
+++ b/public/javascripts/Gallery/src/validation/ValidationMenu.js
@@ -164,7 +164,7 @@ function ValidationMenu(refCard, uiCardImage, cardProperties, modal, onExpandedV
         referenceCard.setProperty('user_validation', action);
 
         let actionStr = onExpandedView ? 'Validate_ExpandedMenuClick' + action : 'Validate_MenuClick' + action;
-        sg.tracker.push(actionStr, { panoId: currCardProperties.gsv_panorama_id });
+        sg.tracker.push(actionStr, {panoId: currCardProperties.gsv_panorama_id}, {labelId: cardProperties.label_id});
         let validationTimestamp = new Date().getTime();
 
         let data = {


### PR DESCRIPTION
Resolves #2885 

Fixes the logging in Gallery so that we can connect logs back to users in the future. Adds a `user_id` column to the `gallery_task_interaction` and `gallery_task_environment` tables. We also start to actually record the `gsv_panorama_id`, and start recording the `label_id` in the `note` section for validation actions in Gallery here.

We aren't going back to try and fix old logs, since that would be impossible in some cases, and would be a lot of work either way. I recorded this issue on the [relevant wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Developer-notes).

##### Before/After screenshots (if applicable)
Before
![Screenshot from 2022-05-12 12-58-08](https://user-images.githubusercontent.com/6518824/168159893-81f2e954-8d2c-4838-81df-31364869fb23.png)

After
![Screenshot from 2022-05-12 12-57-35](https://user-images.githubusercontent.com/6518824/168159904-3007068c-5dbf-4ab0-8782-b99bbfd0239a.png)

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
- [x] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure the documentation on [this wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Descriptions-of-Logged-Events) is up to date for the logs you added/updated.
