### PR TITLE
Renames brick tag to brick/cobblestone

### DIFF
--- a/conf/cityparams.conf
+++ b/conf/cityparams.conf
@@ -197,7 +197,7 @@ city-params {
       "street vendor"
       "points into traffic"
       "missing tactile warning"
-      "brick"
+      "brick/cobblestone"
       "uncovered manhole"
     ]
     la-piedad = [

--- a/conf/evolutions/default/146.sql
+++ b/conf/evolutions/default/146.sql
@@ -1,0 +1,5 @@
+# --- !Ups
+UPDATE tag SET tag = 'brick/cobblestone' WHERE tag = 'brick';
+
+# --- !Downs
+UPDATE tag SET tag = 'brick' WHERE tag = 'brick/cobblestone';

--- a/public/javascripts/common/UtilitiesSidewalk.js
+++ b/public/javascripts/common/UtilitiesSidewalk.js
@@ -227,9 +227,9 @@ function UtilitiesMisc (JSON) {
                         keyChar: 'A',
                         text: i18next.t('center-ui.context-menu.tag.narrow')
                     },
-                    'brick': {
+                    'brick/cobblestone': {
                         keyChar: 'I',
-                        text: i18next.t('center-ui.context-menu.tag.brick')
+                        text: i18next.t('center-ui.context-menu.tag.brick-cobblestone')
                     },
                     'construction': {
                         keyChar: 'T',
@@ -301,9 +301,9 @@ function UtilitiesMisc (JSON) {
                         keyChar: 'E',
                         text: i18next.t('center-ui.context-menu.tag.uneven-surface')
                     },
-                    'brick': {
+                    'brick/cobblestone': {
                         keyChar: 'I',
-                        text: i18next.t('center-ui.context-menu.tag.brick')
+                        text: i18next.t('center-ui.context-menu.tag.brick-cobblestone')
                     },
                     'bumpy': {
                         keyChar: 'Y',

--- a/public/locales/en/audit.json
+++ b/public/locales/en/audit.json
@@ -150,7 +150,7 @@
                 "uneven-slanted": "<tag-underline>u</tag-underline>neven/slanted",
                 "cracks": "crac<tag-underline>k</tag-underline>s",
                 "grass": "<tag-underline>g</tag-underline>rass",
-                "brick": "br<tag-underline>i</tag-underline>ck",
+                "brick-cobblestone": "br<tag-underline>i</tag-underline>ck/cobblestone",
                 "very-broken": "very b<tag-underline>r</tag-underline>oken",
                 "rail-tram-track": "rai<tag-underline>l</tag-underline>/tram track",
                 "sand-gravel": "sand/gra<tag-underline>v</tag-underline>el",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -68,7 +68,7 @@
     "cracks": "cracks",
     "grass": "grass",
     "narrow sidewalk": "narrow sidewalk",
-    "brick": "brick",
+    "brick/cobblestone": "brick/cobblestone",
     "very broken": "very broken",
     "rail/tram track": "rail/tram track",
     "sand/gravel": "sand/gravel",

--- a/public/locales/es/audit.json
+++ b/public/locales/es/audit.json
@@ -148,7 +148,7 @@
                 "uneven-slanted": "dispareja/inclinada (<tag-underline>u</tag-underline>)",
                 "cracks": "grietas (<tag-underline>k</tag-underline>)",
                 "grass": "hierba (<tag-underline>g</tag-underline>)",
-                "brick": "ladr<tag-underline>i</tag-underline>llo",
+                "brick-cobblestone": "ladr<tag-underline>i</tag-underline>llo/adoquín",
                 "very-broken": "<tag-underline>r</tag-underline>ota",
                 "rail-tram-track": "vía férrea/tranvía (<tag-underline>l</tag-underline>)",
                 "sand-gravel": "arena/gra<tag-underline>v</tag-underline>a",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -68,7 +68,7 @@
     "cracks": "grietas",
     "grass": "hierba",
     "narrow sidewalk": "muy angosta",
-    "brick": "ladrillo",
+    "brick/cobblestone": "ladrillo/adoquín",
     "very broken": "rota",
     "rail/tram track": "vía férrea/tranvía",
     "sand/gravel": "arena/grava",

--- a/public/locales/nl/audit.json
+++ b/public/locales/nl/audit.json
@@ -150,7 +150,7 @@
                 "uneven-slanted": "oneven/hellend (<tag-underline>u</tag-underline>)",
                 "cracks": "scheuren (<tag-underline>k</tag-underline>)",
                 "grass": "<tag-underline>g</tag-underline>ras",
-                "brick": "steen (<tag-underline>i</tag-underline>)",
+                "brick-cobblestone": "steen (<tag-underline>i</tag-underline>)",
                 "very-broken": "e<tag-underline>r</tag-underline>nstig beschadigd",
                 "rail-tram-track": "spoor/trambaan (<tag-underline>l</tag-underline>)",
                 "sand-gravel": "zand/grind (<tag-underline>v</tag-underline>)",


### PR DESCRIPTION
Resolves #2897 

Renames the tag from 'brick' to 'brick/cobblestone' for both the Surface Problem and Crosswalk label types.