### PR TITLE
Adds La Piedad to the list of publicly deployed cities

### DIFF
--- a/conf/cityparams.conf
+++ b/conf/cityparams.conf
@@ -83,7 +83,7 @@ city-params {
     pittsburgh-pa = "public"
     chicago-il = "private"
     amsterdam = "public"
-    la-piedad = "private"
+    la-piedad = "public"
     oradell-nj = "public"
     validation-study = "private"
   }


### PR DESCRIPTION
Resolves #2909 

Switches the La Piedad server from 'private' to 'public', so it now shows up in the drop-down list of cities in the navbar.