### PR TITLE
#2861: NSF Funding Info Footer

### DIFF
--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -100,10 +100,7 @@
                     <a href="https://www.nsf.gov/awardsearch/showAward?AWD_ID=1302338" id="nsf-link">
                         <img src="@routes.Assets.at("assets/nsf.png")">
                     </a>
-                    <div class="col-sm-2" id="awardnum">
-                        Award <a href = "https://www.nsf.gov/awardsearch/showAward?AWD_ID=1302338" id = "nsf-link">#1302338</a>
-                        and <a href = "https://www.nsf.gov/awardsearch/showAward?AWD_ID=2125087" id = "nsf-link">#2125087</a>
-                    </div>
+                    <div class="col-sm-2" id="awardnum">@Html(Messages("footer.award"))</div>
                 </div>
                 <div class="col-sm-3">
                     <a href="http://www.google.com/" id="google-link"><img src="@routes.Assets.at("assets/google.png")" style="margin-top:20px;"></a>

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -100,6 +100,10 @@
                     <a href="https://www.nsf.gov/awardsearch/showAward?AWD_ID=1302338" id="nsf-link">
                         <img src="@routes.Assets.at("assets/nsf.png")">
                     </a>
+                    <div class="col-sm-2" id="awardnum">
+                        Award <a href = "https://www.nsf.gov/awardsearch/showAward?AWD_ID=1302338" id = "nsf-link">#1302338</a>
+                        and <a href = "https://www.nsf.gov/awardsearch/showAward?AWD_ID=2125087" id = "nsf-link">#2125087</a>
+                    </div>
                 </div>
                 <div class="col-sm-3">
                     <a href="http://www.google.com/" id="google-link"><img src="@routes.Assets.at("assets/google.png")" style="margin-top:20px;"></a>
@@ -121,10 +125,6 @@
                 </div>
             </div>
             <div class="row" style="max-width: 1000px; margin: 0 auto;">
-                <div class="col-sm-2" id="awardnum">
-                    Award <a href = "https://www.nsf.gov/awardsearch/showAward?AWD_ID=1302338" id = "nsf-link">#1302338</a><br>
-                    and <a href = "https://www.nsf.gov/awardsearch/showAward?AWD_ID=2125087" id = "nsf-link">#2125087</a>
-                </div>
                 <div class="col-sm-8"></div>
             </div>
 

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -121,7 +121,10 @@
                 </div>
             </div>
             <div class="row" style="max-width: 1000px; margin: 0 auto;">
-                <div class="col-sm-2" id="awardnum">Award #1302338</div>
+                <div class="col-sm-2" id="awardnum">
+                    Award <a href = "https://www.nsf.gov/awardsearch/showAward?AWD_ID=1302338" id = "nsf-link">#1302338</a><br>
+                    and <a href = "https://www.nsf.gov/awardsearch/showAward?AWD_ID=2125087" id = "nsf-link">#2125087</a>
+                </div>
                 <div class="col-sm-8"></div>
             </div>
 

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -77,7 +77,7 @@ footer.api = Sidewalk API
 footer.connect = CONNECT
 footer.email = Email Us
 footer.funding = WE ARE PROUDLY FUNDED BY
-footer.award = Award <a href = "https://www.nsf.gov/awardsearch/showAward?AWD_ID=1302338" target="_blank" id = "nsf-link">#1302338</a> and <a href = "https://www.nsf.gov/awardsearch/showAward?AWD_ID=2125087" target="_blank" id = "nsf-link">#2125087</a>
+footer.award = Award <a href = "https://www.nsf.gov/awardsearch/showAward?AWD_ID=1302338" target="_blank" id = "nsf-link">#1302338</a> <br> and <a href = "https://www.nsf.gov/awardsearch/showAward?AWD_ID=2125087" target="_blank" id = "nsf-link">#2125087</a>
 footer.designed.operated = Project Sidewalk is designed and operated by the <a id="makeabilitylab" href="https://makeabilitylab.cs.washington.edu/">Makeability Lab</a> at the <a id="universityofwashington" href="http://www.cs.uw.edu/">University of Washington</a>
 footer.version = Version {0} | Last Updated: <span class = "timestamp date">{1}</span>
 

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -77,6 +77,7 @@ footer.api = Sidewalk API
 footer.connect = CONNECT
 footer.email = Email Us
 footer.funding = WE ARE PROUDLY FUNDED BY
+footer.award = Award <a href = "https://www.nsf.gov/awardsearch/showAward?AWD_ID=1302338" id = "nsf-link">#1302338</a> and <a href = "https://www.nsf.gov/awardsearch/showAward?AWD_ID=2125087" id = "nsf-link">#2125087</a>
 footer.designed.operated = Project Sidewalk is designed and operated by the <a id="makeabilitylab" href="https://makeabilitylab.cs.washington.edu/">Makeability Lab</a> at the <a id="universityofwashington" href="http://www.cs.uw.edu/">University of Washington</a>
 footer.version = Version {0} | Last Updated: <span class = "timestamp date">{1}</span>
 

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -77,7 +77,7 @@ footer.api = Sidewalk API
 footer.connect = CONNECT
 footer.email = Email Us
 footer.funding = WE ARE PROUDLY FUNDED BY
-footer.award = Award <a href = "https://www.nsf.gov/awardsearch/showAward?AWD_ID=1302338" id = "nsf-link">#1302338</a> and <a href = "https://www.nsf.gov/awardsearch/showAward?AWD_ID=2125087" id = "nsf-link">#2125087</a>
+footer.award = Award <a href = "https://www.nsf.gov/awardsearch/showAward?AWD_ID=1302338" target="_blank" id = "nsf-link">#1302338</a> and <a href = "https://www.nsf.gov/awardsearch/showAward?AWD_ID=2125087" target="_blank" id = "nsf-link">#2125087</a>
 footer.designed.operated = Project Sidewalk is designed and operated by the <a id="makeabilitylab" href="https://makeabilitylab.cs.washington.edu/">Makeability Lab</a> at the <a id="universityofwashington" href="http://www.cs.uw.edu/">University of Washington</a>
 footer.version = Version {0} | Last Updated: <span class = "timestamp date">{1}</span>
 

--- a/conf/messages.es
+++ b/conf/messages.es
@@ -77,7 +77,7 @@ footer.api = Sidewalk API
 footer.connect = CONECTA
 footer.email = Envíanos un correo
 footer.funding = ESTAMOS ORGULLOSAMENTE FINANCIADOS POR
-footer.award = Premio <a href = "https://www.nsf.gov/awardsearch/showAward?AWD_ID=1302338" id = "nsf-link">#1302338</a> y <a href = "https://www.nsf.gov/awardsearch/showAward?AWD_ID=2125087" id = "nsf-link">#2125087</a>
+footer.award = Premio <a href = "https://www.nsf.gov/awardsearch/showAward?AWD_ID=1302338" target="_blank" id = "nsf-link">#1302338</a> y <a href = "https://www.nsf.gov/awardsearch/showAward?AWD_ID=2125087" target="_blank" id = "nsf-link">#2125087</a>
 footer.designed.operated = Project Sidewalk está diseñado y operado por el <a id="makeabilitylab" href="https://makeabilitylab.cs.washington.edu/">Makeability Lab</a> de la <a id="universityofwashington" href="http://www.cs.uw.edu/">Universidad de Washington</a>
 footer.version = Versión {0} |  Última actualización: <span class = "timestamp date">{1}</span>
 

--- a/conf/messages.es
+++ b/conf/messages.es
@@ -77,6 +77,7 @@ footer.api = Sidewalk API
 footer.connect = CONECTA
 footer.email = Envíanos un correo
 footer.funding = ESTAMOS ORGULLOSAMENTE FINANCIADOS POR
+footer.award = Premio <a href = "https://www.nsf.gov/awardsearch/showAward?AWD_ID=1302338" id = "nsf-link">#1302338</a> y <a href = "https://www.nsf.gov/awardsearch/showAward?AWD_ID=2125087" id = "nsf-link">#2125087</a>
 footer.designed.operated = Project Sidewalk está diseñado y operado por el <a id="makeabilitylab" href="https://makeabilitylab.cs.washington.edu/">Makeability Lab</a> de la <a id="universityofwashington" href="http://www.cs.uw.edu/">Universidad de Washington</a>
 footer.version = Versión {0} |  Última actualización: <span class = "timestamp date">{1}</span>
 

--- a/conf/messages.es
+++ b/conf/messages.es
@@ -77,7 +77,7 @@ footer.api = Sidewalk API
 footer.connect = CONECTA
 footer.email = Envíanos un correo
 footer.funding = ESTAMOS ORGULLOSAMENTE FINANCIADOS POR
-footer.award = Premio <a href = "https://www.nsf.gov/awardsearch/showAward?AWD_ID=1302338" target="_blank" id = "nsf-link">#1302338</a> y <a href = "https://www.nsf.gov/awardsearch/showAward?AWD_ID=2125087" target="_blank" id = "nsf-link">#2125087</a>
+footer.award = Premio <a href = "https://www.nsf.gov/awardsearch/showAward?AWD_ID=1302338" target="_blank" id = "nsf-link">#1302338</a> <br> y <a href = "https://www.nsf.gov/awardsearch/showAward?AWD_ID=2125087" target="_blank" id = "nsf-link">#2125087</a>
 footer.designed.operated = Project Sidewalk está diseñado y operado por el <a id="makeabilitylab" href="https://makeabilitylab.cs.washington.edu/">Makeability Lab</a> de la <a id="universityofwashington" href="http://www.cs.uw.edu/">Universidad de Washington</a>
 footer.version = Versión {0} |  Última actualización: <span class = "timestamp date">{1}</span>
 

--- a/conf/messages.nl
+++ b/conf/messages.nl
@@ -77,7 +77,7 @@ footer.api = Sidewalk API
 footer.connect = Contact
 footer.email = Email ons
 footer.funding = MET TROTS GESPONSORD DOOR
-footer.award = Prijs <a href = "https://www.nsf.gov/awardsearch/showAward?AWD_ID=1302338" target="_blank" id = "nsf-link">#1302338</a> en <a href = "https://www.nsf.gov/awardsearch/showAward?AWD_ID=2125087" target="_blank" id = "nsf-link">#2125087</a>
+footer.award = Prijs <a href = "https://www.nsf.gov/awardsearch/showAward?AWD_ID=1302338" target="_blank" id = "nsf-link">#1302338</a> <br> en <a href = "https://www.nsf.gov/awardsearch/showAward?AWD_ID=2125087" target="_blank" id = "nsf-link">#2125087</a>
 footer.designed.operated = Project Sidewalk is ontworpen en beheerd door <a id="makeabilitylab" href="https://makeabilitylab.cs.washington.edu/">Makeability Lab</a> op de <a id="universityofwashington" href="http://www.cs.uw.edu/">University of Washington</a>
 footer.version = Versie {0} | Laatst geupdated: <span class = "timestamp date">{1}</span>
 

--- a/conf/messages.nl
+++ b/conf/messages.nl
@@ -77,6 +77,7 @@ footer.api = Sidewalk API
 footer.connect = Contact
 footer.email = Email ons
 footer.funding = MET TROTS GESPONSORD DOOR
+footer.award = Prijs <a href = "https://www.nsf.gov/awardsearch/showAward?AWD_ID=1302338" target="_blank" id = "nsf-link">#1302338</a> en <a href = "https://www.nsf.gov/awardsearch/showAward?AWD_ID=2125087" target="_blank" id = "nsf-link">#2125087</a>
 footer.designed.operated = Project Sidewalk is ontworpen en beheerd door <a id="makeabilitylab" href="https://makeabilitylab.cs.washington.edu/">Makeability Lab</a> op de <a id="universityofwashington" href="http://www.cs.uw.edu/">University of Washington</a>
 footer.version = Versie {0} | Laatst geupdated: <span class = "timestamp date">{1}</span>
 

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -803,7 +803,6 @@ p#conditional-text {
     }
 }
 
-
 #awardnum {
     font-size:10px;
     color:#c0becf;

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -794,19 +794,22 @@ p#conditional-text {
 @media only screen and (max-device-width: 500px) {
     #awardnum {
         width: 100% !important;
+        right: 0% !important;
     }
 }
 
 @media only screen and (max-device-width: 800px) and (min-device-width: 500px) {
     #awardnum {
-        width: 250% !important;
+        width: 350% !important;
+        right: 45% !important;
     }
 }
 
 #awardnum {
     font-size:10px;
     color:#c0becf;
-    width: 150%;
+    width: 220%;
+    right: 35%;
 }
 #funding-title {
     font-weight: bold;

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -793,6 +793,8 @@ p#conditional-text {
 #awardnum {
     font-size:10px;
     color:#c0becf;
+    right: 27px;
+    bottom: 10px;
 }
 #funding-title {
     font-weight: bold;

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -790,11 +790,24 @@ p#conditional-text {
     color:#fff;
     text-decoration:underline;
 }
+
+@media only screen and (max-device-width: 500px) {
+    #awardnum {
+        width: 100% !important;
+    }
+}
+
+@media only screen and (max-device-width: 800px) and (min-device-width: 500px) {
+    #awardnum {
+        width: 250% !important;
+    }
+}
+
+
 #awardnum {
     font-size:10px;
     color:#c0becf;
-    right: 27px;
-    bottom: 10px;
+    width: 150%;
 }
 #funding-title {
     font-weight: bold;


### PR DESCRIPTION
Resolves #2861 

Before English and Spanish Version:
![image](https://user-images.githubusercontent.com/92624795/170169669-ed6bca93-3ad9-4b5c-9d60-07ee58f108e3.png)

After English Version:
![image](https://user-images.githubusercontent.com/92624795/170168787-d790c4f0-70a7-494c-a560-5654d4bd5bfa.png)

After Spanish Version:
![image](https://user-images.githubusercontent.com/92624795/170169787-5beca22f-1181-4f77-acd0-0634c1c1d098.png)

Changes Made:
1. Centered Text under NSF Logo (took care of mobile representations of website as well)
2. Added #2125087 with hyperlink
3. Added Spanish translation for text

Side-effects: None