### PR TITLE
2734: Fixed issue where panning makes the first tutorial arrow disappear

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/onboarding/Onboarding.js
+++ b/public/javascripts/SVLabel/src/SVLabel/onboarding/Onboarding.js
@@ -221,14 +221,6 @@ function Onboarding(svl, audioEffect, compass, form, handAnimation, mapService, 
             imY = state.annotations[i].y;
             origPointPov = null;
 
-            // For the first arrow to be applied, looking at the initial heading (initialize state) of the onboarding.
-            // This avoids applying the first arrow if the heading is not set correctly.
-            // This will avoid incorrect POV calculation.
-            var initialHeading = getState("initialize").properties.heading;
-            if (state.annotations[i].name === "arrow-1a" && currentPov.heading !== initialHeading) {
-                povChange["status"] = false;
-                return this;
-            }
             // Setting the original POV and mapping an image coordinate to a canvas coordinate.
             if (currentPov.heading < 180) {
                 if (imX > svl.svImageWidth - 3328 && imX > 3328) {

--- a/public/javascripts/SVLabel/src/SVLabel/onboarding/OnboardingStates.js
+++ b/public/javascripts/SVLabel/src/SVLabel/onboarding/OnboardingStates.js
@@ -75,7 +75,6 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "panoId": panoId,
             "annotations": [
                 {
-                    "name": "arrow-1a",
                     "type": "arrow",
                     "x": 9730,
                     "y": -350,
@@ -106,7 +105,6 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "panoId": panoId,
             "annotations": [
                 {
-                    "name": "arrow-1b",
                     "type": "arrow",
                     "x": 9730,
                     "y": -350,
@@ -140,7 +138,6 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "panoId": panoId,
             "annotations": [
                 {
-                    "name": "arrow-1a",
                     "type": "arrow",
                     "x": 9730,
                     "y": -350,
@@ -167,7 +164,6 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "panoId": panoId,
             "annotations": [
                 {
-                    "name": "arrow-1a",
                     "type": "arrow",
                     "x": 9730,
                     "y": -350,


### PR DESCRIPTION
Resolves #2734

Removed name key from onboarding states which caused the bug, and removed outdated section of onboarding which relied on the name parameter

##### Before/After screenshots (if applicable)
Before:
![image](https://user-images.githubusercontent.com/77756028/170773952-4555245c-53b4-418a-8b19-e68aa9764f48.png)

After:
![image](https://user-images.githubusercontent.com/77756028/170773827-284a3bba-8cae-4d14-acf4-b27653ffb4c0.png)

##### Testing instructions
1. Load the tutorial
2. Pan the screen either through dragging or the arrow keys
3. If the arrow does not disappear, it works!

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've included before/after screenshots above.