### PR TITLE
Fixes bug preventing users from completing tutorial

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/Tracker.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Tracker.js
@@ -189,13 +189,19 @@ function Tracker () {
         if(self._isContextMenuAction(action) || self._isSeverityShortcutAction(action)) {
             var labelProperties = svl.contextMenu.getTargetLabel().getProperties();
             currentLabel = labelProperties.temporary_label_id;
-            updatedLabels.push(currentLabel);
-            svl.labelContainer.addUpdatedLabel(currentLabel);
 
             if (notes === null || typeof (notes) === 'undefined') {
                 notes = {'auditTaskId': labelProperties.audit_task_id};
             } else {
                 notes['auditTaskId'] = labelProperties.audit_task_id;
+            }
+
+            // Reset currentLabel to null if this is a context menu event that fired after the menu already closed.
+            if (svl.contextMenu.isOpen()) {
+                updatedLabels.push(currentLabel);
+                svl.labelContainer.addUpdatedLabel(currentLabel);
+            } else {
+                currentLabel = null;
             }
 
         } else if (self._isClickLabelDeleteAction(action)){
@@ -209,7 +215,6 @@ function Tracker () {
             } else {
                 notes['auditTaskId'] = labelProperties.audit_task_id;
             }
-
         }
 
         var item = self.create(action, notes, extraData);

--- a/public/javascripts/SVLabel/src/SVLabel/Tracker.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Tracker.js
@@ -4,7 +4,7 @@
  * @constructor
  * @memberof svl
  */
-function Tracker () {
+function Tracker() {
     var self = this;
     var actions = [];
     var prevActions = [];
@@ -13,11 +13,11 @@ function Tracker () {
     var updatedLabels = [];
     var currentAuditTask = null;
 
-    this.init = function () {
+    this.init = function() {
         this.trackWindowEvents();
     };
 
-    this.getCurrentLabel = function(){
+    this.getCurrentLabel = function() {
         return currentLabel;
     };
 
@@ -50,35 +50,35 @@ function Tracker () {
         });
     };
 
-    this._isCanvasInteraction = function (action) {
+    this._isCanvasInteraction = function(action) {
         return action.indexOf("LabelingCanvas") >= 0;
     };
 
-    this._isContextMenuAction = function (action) {
+    this._isContextMenuAction = function(action) {
         return action.indexOf("ContextMenu") >= 0;
     };
 
-    this._isContextMenuClose = function (action) {
+    this._isContextMenuClose = function(action) {
         return action === "ContextMenu_Close";
     };
 
-    this._isDeleteLabelAction = function (action) {
+    this._isDeleteLabelAction = function(action) {
         return action.indexOf("RemoveLabel") >= 0;
     };
 
-    this._isClickLabelDeleteAction = function (action) {
+    this._isClickLabelDeleteAction = function(action) {
         return action.indexOf("Click_LabelDelete") >= 0;
     };
 
-    this._isTaskStartAction = function (action) {
+    this._isTaskStartAction = function(action) {
         return action.indexOf("TaskStart") >= 0;
     };
 
-    this._isSeverityShortcutAction = function (action) {
+    this._isSeverityShortcutAction = function(action) {
         return action.indexOf("KeyboardShortcut_Severity") >= 0;
     };
 
-    this._isFinishLabelingAction = function (action) {
+    this._isFinishLabelingAction = function(action) {
         return action.indexOf("LabelingCanvas_FinishLabeling") >= 0;
     };
 
@@ -87,9 +87,8 @@ function Tracker () {
         return actions;
     };
 
-    this._notesToString = function (param) {
-        if (!param)
-            return "";
+    this._notesToString = function(param) {
+        if (!param) return "";
 
         var note = "";
         for (var key in param) {
@@ -97,7 +96,6 @@ function Tracker () {
                 note += ",";
             note += key + ':' + param[key];
         }
-
         return note;
     };
 
@@ -105,25 +103,22 @@ function Tracker () {
      * This function pushes action type, time stamp, current pov, and current panoId into actions list.
      */
 
-    this.create = function (action, notes, extraData) {
-        if (!notes)
-            notes = {};
-
-        if (!extraData)
-            extraData = {};
+    this.create = function(action, notes, extraData) {
+        if (!notes) notes = {};
+        if (!extraData) extraData = {};
 
         var pov, latlng, panoId, audit_task_id;
 
         var note = this._notesToString(notes);
 
-        if ('canvas' in svl && svl.canvas.getCurrentLabel()){
+        if ('canvas' in svl && svl.canvas.getCurrentLabel()) {
             audit_task_id = svl.canvas.getCurrentLabel().getProperties().audit_task_id;
         } else {
             audit_task_id = currentAuditTask;
         }
 
         if ('temporaryLabelId' in extraData) {
-            if(currentLabel !== null){
+            if (currentLabel !== null) {
                 updatedLabels.push(currentLabel);
                 svl.labelContainer.addUpdatedLabel(currentLabel);
             }
@@ -186,7 +181,7 @@ function Tracker () {
      * @param extraData: (optional) extra data that should not be stored in the notes field in db
      */
     this.push = function (action, notes, extraData) {
-        if(self._isContextMenuAction(action) || self._isSeverityShortcutAction(action)) {
+        if (self._isContextMenuAction(action) || self._isSeverityShortcutAction(action)) {
             var labelProperties = svl.contextMenu.getTargetLabel().getProperties();
             currentLabel = labelProperties.temporary_label_id;
 
@@ -204,13 +199,13 @@ function Tracker () {
                 currentLabel = null;
             }
 
-        } else if (self._isClickLabelDeleteAction(action)){
+        } else if (self._isClickLabelDeleteAction(action)) {
             var labelProperties = svl.canvas.getCurrentLabel().getProperties();
             currentLabel = labelProperties.temporary_label_id;
             updatedLabels.push(currentLabel);
             svl.labelContainer.addUpdatedLabel(currentLabel);
 
-            if(notes === null || typeof(notes) === 'undefined') {
+            if (notes === null || typeof(notes) === 'undefined') {
                 notes = {'auditTaskId' : labelProperties.audit_task_id};
             } else {
                 notes['auditTaskId'] = labelProperties.audit_task_id;
@@ -221,12 +216,12 @@ function Tracker () {
         actions.push(item);
         var contextMenuLabel = true;
 
-        if(self._isFinishLabelingAction(action) && (notes['labelType'] === 'NoSidewalk' || notes['labelType'] === 'Occlusion')){
+        if (self._isFinishLabelingAction(action) && (notes['labelType'] === 'NoSidewalk' || notes['labelType'] === 'Occlusion')) {
             contextMenuLabel = false;
         }
 
         //we are no longer interacting with a label, set currentLabel to null
-        if(self._isContextMenuClose(action) || self._isDeleteLabelAction(action) || !contextMenuLabel){
+        if (self._isContextMenuClose(action) || self._isDeleteLabelAction(action) || !contextMenuLabel) {
             currentLabel = null;
         }
 
@@ -253,12 +248,12 @@ function Tracker () {
     /**
      * Put the previous labeling actions into prevActions. Then refresh the current actions.
      */
-    this.refresh = function () {
+    this.refresh = function() {
         prevActions = prevActions.concat(actions);
         actions = [];
 
         updatedLabels = [];
-        if(currentLabel !== null){
+        if (currentLabel !== null) {
             updatedLabels.push(currentLabel);
             svl.labelContainer.addUpdatedLabel(currentLabel);
         }

--- a/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
@@ -20,10 +20,10 @@ function ContextMenu (uiContextMenu) {
     var lastShownLabelColor;
 
     var context_menu_el = document.getElementById('context-menu-holder');
-    document.addEventListener('mousedown', function(event){
+    document.addEventListener('mousedown', function(event) {
         //event.stopPropagation();
         var clicked_out = !(context_menu_el.contains(event.target));
-        if (isOpen()){
+        if (isOpen()) {
             if (clicked_out) {
              svl.tracker.push('ContextMenu_CloseClickOut');
             handleSeverityPopup();
@@ -82,7 +82,7 @@ function ContextMenu (uiContextMenu) {
         uiContextMenu.radioButtons.filter(function() {return this.value == value}).prop("checked", true).trigger("click", {lowLevelLogging: false});
     }
 
-    function getContextMenuUI(){
+    function getContextMenuUI() {
         return uiContextMenu;
     }
 
@@ -95,7 +95,7 @@ function ContextMenu (uiContextMenu) {
         return (key in status) ? status[key] : null;
     }
 
-    function getTargetLabel () {
+    function getTargetLabel() {
         return getStatus('targetLabel');
     }
 
@@ -129,24 +129,24 @@ function ContextMenu (uiContextMenu) {
         svl.keyboard.setStatus('focusOnTextField', true);
     }
 
-    function handleCloseButtonClick () {
+    function handleCloseButtonClick() {
         svl.tracker.push('ContextMenu_CloseButtonClick');
         handleSeverityPopup();
         hide();
 
     }
 
-    function _handleOKButtonClick () {
+    function _handleOKButtonClick() {
         svl.tracker.push('ContextMenu_OKButtonClick');
         handleSeverityPopup();
         hide();
 
     }
 
-    function handleSeverityPopup () {
+    function handleSeverityPopup() {
         var labels = svl.labelContainer.getCurrentLabels();
         var prev_labels = svl.labelContainer.getPreviousLabels();
-        if (labels.length == 0){
+        if (labels.length == 0) {
             labels = prev_labels;
         }
         if (labels.length > 0) {
@@ -172,12 +172,12 @@ function ContextMenu (uiContextMenu) {
         }
     }
 
-    function _handleRadioButtonLabelMouseEnter () {
+    function _handleRadioButtonLabelMouseEnter() {
         var radioValue = parseInt($(this).find("input").attr("value"), 10);
         self.updateRadioButtonImages(radioValue);
     }
 
-    function _handleRadioButtonLabelMouseLeave () {
+    function _handleRadioButtonLabelMouseLeave() {
         self.updateRadioButtonImages();
     }
 
@@ -332,8 +332,8 @@ function ContextMenu (uiContextMenu) {
      * Hide the context menu
      * @returns {hide}
      */
-    function hide () {
-        if(isOpen()) {
+    function hide() {
+        if (isOpen()) {
             $descriptionTextBox.blur(); // force the blur event before the ContextMenu close event
             svl.tracker.push('ContextMenu_Close');
         }
@@ -349,7 +349,7 @@ function ContextMenu (uiContextMenu) {
      * Unhide the context menu
      * @returns {hide}
      */
-    function unhide () {
+    function unhide() {
         $menuWindow.css('visibility', 'visible');
         if (lastShownLabelColor) {
             setBorderColor(lastShownLabelColor);
@@ -363,7 +363,7 @@ function ContextMenu (uiContextMenu) {
      * @returns {boolean}
      */
     function isOpen() {
-        return getStatus('visibility') == 'visible';
+        return getStatus('visibility') === 'visible';
     }
 
     /**
@@ -390,7 +390,7 @@ function ContextMenu (uiContextMenu) {
      * Disable tagging. Adds the disabled visual effects to the
      * tags on current context menu.
      */
-    function disableTagging () {
+    function disableTagging() {
         setStatus('disableTagging', true);
         $("body").find("button[name=tag]").each(function(t) {
             $(this).addClass('disabled');
@@ -401,7 +401,7 @@ function ContextMenu (uiContextMenu) {
      * Enable tagging. Removes the disabled visual effects to the
      * tags on current context menu.
      */
-    function enableTagging () {
+    function enableTagging() {
         setStatus('disableTagging', false);
         $("body").find("button[name=tag]").each(function(t) {
             $(this).removeClass('disabled');
@@ -411,7 +411,7 @@ function ContextMenu (uiContextMenu) {
     /**
      * Returns true if tagging is currently disabled.
      */
-    function isTagDisabled () {
+    function isTagDisabled() {
         return getStatus('disableTagging');
     }
 
@@ -592,7 +592,7 @@ function ContextMenu (uiContextMenu) {
                 var connectorCoordinate = -5;
 
                 // Determine coordinates for context menu when displayed above the label.
-                if(y + windowHeight + 22 > 480) {
+                if (y + windowHeight + 22 > 480) {
                     topCoordinate = y - windowHeight - 22;
                     connectorCoordinate = windowHeight;
                 }

--- a/public/javascripts/SVLabel/src/SVLabel/label/LabelContainer.js
+++ b/public/javascripts/SVLabel/src/SVLabel/label/LabelContainer.js
@@ -162,7 +162,7 @@ function LabelContainer($) {
                 return label.getProperty("temporary_label_id") === tempId;
             });
 
-        if(matchingLabels.length === 0){
+        if (matchingLabels.length === 0) {
             return null;
         }
 
@@ -174,36 +174,32 @@ function LabelContainer($) {
     this.addUpdatedLabel = function (tempId) {
         // All labels that don't have the specified tempId reduced to an array.
         var otherLabels = _.filter(this.getCurrentLabels(),
-            function(label){
+            function(label) {
                 return label.getProperty("temporary_label_id") !== tempId;
             });
 
-        // If there are no temporary labels with this ID in currentCanvasLabels
-        // then add it to that list.
+        // If there are no temporary labels with this ID in currentCanvasLabels then add it to that list.
         // Otherwise get rid of all old instances in currentCanvasLabels and add the updated label.
 
         var match = this.findLabelByTempId(tempId);
 
         // Label with this id doesn't exist in currentCanvasLabels as the
         // filtered vs unfiltered arrays are the same length.
-        if(otherLabels.length === this.getCurrentLabels().length){
+        if (otherLabels.length === this.getCurrentLabels().length) {
             if (!(match.getPanoId() in currentCanvasLabels)) {
                 currentCanvasLabels[match.getPanoId()] = [];
             }
-            
-            // Add updated label
+            // Add updated label.
             currentCanvasLabels[match.getPanoId()].push(match);
         } else {
             for (let key in currentCanvasLabels) {
                 currentCanvasLabels[key] = currentCanvasLabels[key].filter(label => label.getProperty("temporary_label_id") !== tempId);
             }
-
-            if(match !== null) {
+            if (match !== null) {
                 if (!(match.getPanoId() in currentCanvasLabels)) {
                     currentCanvasLabels[match.getPanoId()] = [];
                 }
-            
-                // Add updated label
+                // Add updated label.
                 currentCanvasLabels[match.getPanoId()].push(match);
             }
         }


### PR DESCRIPTION
Resolves #2924 

Fixes a bug that prevented users from completing the final step of the tutorial, simply clicking the 'OK' button at the end.

The cause seemed to be that PR #2154 unknowingly introduced a requirement that all context menu related actions be logged before the context menu is closed. This isn't an issue in the normal course of labeling, since it takes time for a human to go from rating severity to closing the menu, for example. The problem with the tutorial is that we programmatically close the context menu immediately upon rating severity or adding tags, causing a race condition. And closing the context menu tended to win that race!

So I added a check when logging context menu related actions to put everything in the correct state depending on whether or not the context menu is still open.

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've added/updated comments for large or confusing blocks of code.
