### PR TITLE
#2762: Changing language on the sign in/up pages sends you to landing page

### DIFF
--- a/app/views/signIn.scala.html
+++ b/app/views/signIn.scala.html
@@ -4,7 +4,7 @@
 @import views.html.bootstrap._
 
 @main("Project Sidewalk - Sign In") {
-    @navbar(None, Some(url))
+    @navbar(None, Some("/signIn"))
     @request.flash.get("success").map { msg =>
         <div class="col-md-6 col-md-offset-3 alert alert-success"
         style="float:none;margin-top:20px;margin-bottom:0px">

--- a/app/views/signUp.scala.html
+++ b/app/views/signUp.scala.html
@@ -2,7 +2,7 @@
 @import views.html.bootstrap._
 
 @main("Project Sidewalk - Sign Up") {
-    @navbar(None)
+    @navbar(None, Some("/signUp"))
     @request.flash.get("error").map { msg =>
         <div class="col-md-6 col-md-offset-3 alert alert-danger alert-error"
          style="float:none;margin-top:20px;margin-bottom:0px">


### PR DESCRIPTION
Resolves #2762 

If you were to try to change the language using the navbar on either the sign-in or sign-up page, it would take you to the home page (in the language you changed it to) rather than just staying on the sign-in or sign-up page. To fix this, I just added "some(\signIn)" or "some(\signUp)" (depending on page) so that when the language is changed, it doesn't go to home, but just goes to the page that it is on.

Before:
Goes from sign-in/sign-up page to home page when language changed.

After:
Stays on sign-in/sign-up page with page language changed.

Testing instructions
1.  Run locally
2. Go to /signUp
3. Change language (to see if language changes, but page stays the same)
4. Try creating an account (to see if sign-up form still works)
5. Go to another page using navbar (ie: Home)
6. Log out and repeat with signIn (sign in using fake account created earlier)