### PR TITLE
Adds APS tag for pedestrian signals to validation study server

### DIFF
--- a/conf/cityparams.conf
+++ b/conf/cityparams.conf
@@ -152,6 +152,7 @@ city-params {
       "no pedestrian priority"
       "uncovered manhole"
       "level with sidewalk"
+      "APS"
     ]
     washington-dc = [
       "tactile warning"
@@ -161,6 +162,7 @@ city-params {
       "no pedestrian priority"
       "uncovered manhole"
       "level with sidewalk"
+      "APS"
     ]
     seattle-wa = [
       "tactile warning"
@@ -170,6 +172,7 @@ city-params {
       "no pedestrian priority"
       "uncovered manhole"
       "level with sidewalk"
+      "APS"
     ]
     columbus-oh = [
       "tactile warning"
@@ -179,6 +182,7 @@ city-params {
       "no pedestrian priority"
       "uncovered manhole"
       "level with sidewalk"
+      "APS"
     ]
     cdmx = [
       "tactile warning"
@@ -187,6 +191,7 @@ city-params {
       "construction"
       "no pedestrian priority"
       "level with sidewalk"
+      "APS"
     ]
     spgg = [
       "tactile warning"
@@ -195,6 +200,7 @@ city-params {
       "construction"
       "no pedestrian priority"
       "level with sidewalk"
+      "APS"
     ]
     pittsburgh-pa = [
       "tactile warning"
@@ -204,6 +210,7 @@ city-params {
       "no pedestrian priority"
       "uncovered manhole"
       "level with sidewalk"
+      "APS"
     ]
     chicago-il = [
       "tactile warning"
@@ -213,6 +220,7 @@ city-params {
       "no pedestrian priority"
       "uncovered manhole"
       "level with sidewalk"
+      "APS"
     ]
     amsterdam = [
       "garage entrance"
@@ -221,6 +229,7 @@ city-params {
       "missing tactile warning"
       "brick/cobblestone"
       "uncovered manhole"
+      "APS"
     ]
     la-piedad = [
       "tactile warning"
@@ -229,6 +238,7 @@ city-params {
       "construction"
       "no pedestrian priority"
       "level with sidewalk"
+      "APS"
     ]
     oradell-nj = [
       "tactile warning"
@@ -238,6 +248,7 @@ city-params {
       "no pedestrian priority"
       "uncovered manhole"
       "level with sidewalk"
+      "APS"
     ]
     validation-study = [
       "tactile warning"

--- a/conf/evolutions/default/154.sql
+++ b/conf/evolutions/default/154.sql
@@ -1,0 +1,18 @@
+# --- !Ups
+-- Add 'level with sidewalk' tag for Crosswalks.
+INSERT INTO tag (tag_id, label_type_id, tag) SELECT 60, label_type_id, 'APS' FROM label_type WHERE label_type.label_type = 'Signal';
+
+# --- !Downs
+-- Remove 'level with sidewalk' tag for Crosswalks.
+DELETE FROM label_tag
+USING tag, label_type
+WHERE label_tag.tag_id = tag.tag_id
+    AND tag.label_type_id = label_type.label_type_id
+    AND label_type.label_type = 'Signal'
+    AND tag.tag = 'APS';
+
+DELETE FROM tag
+USING label_type
+WHERE tag.label_type_id = label_type.label_type_id
+    AND label_type.label_type = 'Signal'
+    AND tag.tag = 'APS';

--- a/public/javascripts/common/UtilitiesSidewalk.js
+++ b/public/javascripts/common/UtilitiesSidewalk.js
@@ -339,6 +339,10 @@ function UtilitiesMisc (JSON) {
                     'button waist height': {
                         keyChar: 'H',
                         text: i18next.t('center-ui.context-menu.tag.button-waist-height')
+                    },
+                    'APS': {
+                        keyChar: 'A',
+                        text: i18next.t('center-ui.context-menu.tag.APS')
                     }
                 }
             },

--- a/public/locales/en/audit.json
+++ b/public/locales/en/audit.json
@@ -168,6 +168,7 @@
                 "level-with-sidewalk": "level with si<tag-underline>d</tag-underline>ewalk",
                 "has-button": "has b<tag-underline>u</tag-underline>tton",
                 "button-waist-height": "button waist <tag-underline>h</tag-underline>eight",
+                "APS": "<tag-underline>A</tag-underline>PS",
                 "missing-crosswalk": "m<tag-underline>i</tag-underline>ssing crosswalk",
                 "no-bus-stop-access": "no bus stop <tag-underline>a</tag-underline>ccess",
                 "height-difference": "height <tag-underline>d</tag-underline>ifference"

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -87,6 +87,7 @@
     "level with sidewalk": "level with sidewalk",
     "has button": "has button",
     "button waist height": "button waist height",
+    "APS": "APS",
     "missing crosswalk": "missing crosswalk",
     "no bus stop access": "no bus stop access"
   },

--- a/public/locales/es/audit.json
+++ b/public/locales/es/audit.json
@@ -166,6 +166,7 @@
                 "level-with-sidewalk": "al nivel <tag-underline>d</tag-underline>e la acera",
                 "has-button": "tiene botón (<tag-underline>u</tag-underline>)",
                 "button-waist-height": "botón a la altura de la cintura (<tag-underline>h</tag-underline>)",
+                "APS": "<tag-underline>A</tag-underline>PS",
                 "missing-crosswalk": "paso peatonal ausente (<tag-underline>i</tag-underline>)",
                 "no-bus-stop-access": "No hay <tag-underline>a</tag-underline>cceso a la parada de autobús",
                 "height-difference": "<tag-underline>d</tag-underline>esnivel"

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -87,6 +87,7 @@
     "level with sidewalk": "al nivel de la acera",
     "has button": "tiene botón",
     "button waist height": "botón a la altura de la cintura",
+    "APS": "APS",
     "missing crosswalk": "paso peatonal ausente (i)",
     "no bus stop access": "No hay acceso a la parada de autobús"
   },

--- a/public/locales/nl/audit.json
+++ b/public/locales/nl/audit.json
@@ -168,6 +168,7 @@
                 "level-with-sidewalk": "niveau met stoep (<tag-underline>d</tag-underline>)",
                 "has-button": "heeft een knop (<tag-underline>u</tag-underline>)",
                 "button-waist-height": "knop op <tag-underline>h</tag-underline>euphoogte",
+                "APS": "<tag-underline>A</tag-underline>PS",
                 "missing-crosswalk": "m<tag-underline>i</tag-underline>ssend zebrapad",
                 "no-bus-stop-access": "geen bush<tag-underline>a</tag-underline>lte toegang",
                 "height-difference": "hoogte verschil (<tag-underline>d</tag-underline>)"

--- a/public/locales/nl/common.json
+++ b/public/locales/nl/common.json
@@ -87,6 +87,7 @@
     "level with sidewalk": "niveau met stoep",
     "has button": "heeft een knop",
     "button waist height": "knop op heuphoogte",
+    "APS": "APS",
     "missing crosswalk": "missend zebrapad",
     "no bus stop access": "geen bushalte toegang"
   },


### PR DESCRIPTION
Resolves #2888 

Adds APS as a tag for the Signal label type to the validation study server. We want to add this tag to other servers as well, but we will need more documentation so that users now how to apply the tag.