### PR TITLE
Adds an API endpoint to get user stats

### DIFF
--- a/app/formats/json/UserFormats.scala
+++ b/app/formats/json/UserFormats.scala
@@ -25,4 +25,10 @@ object UserFormats {
       (__ \ "role").writeNullable[String]
     )(unlift(User.unapply _))
 
+  implicit val labelTypeStatWrites: Writes[LabelTypeStat] = (
+    (__ \ "labels").write[Int] and
+      (__ \ "validated_correct").write[Int] and
+      (__ \ "validated_incorrect").write[Int] and
+      (__ \ "not_validated").write[Int]
+  )(unlift(LabelTypeStat.unapply _))
 }

--- a/app/views/developer.scala.html
+++ b/app/views/developer.scala.html
@@ -321,6 +321,38 @@
 
         <div class="row">
             <div class="col-sm-12">
+                <h2 id="access-dataset">Users API</h2>
+                <table class="table">
+                    <tr>
+                        <th>URL</th>
+                        <td><code>/v2/userStats</code></td>
+                    </tr>
+                    <tr>
+                        <th>Method</th>
+                        <td>GET</td>
+                    </tr>
+                    <tr>
+                        <th>Examples</th>
+                        <td>
+                            <a href="/v2/userStats" target="_blank">
+                                <code>/v2/userStats</code>
+                            </a><br>
+                            <a href="/v2/userStats?filetype=csv" target="_blank">
+                                <code>/v2/userStats?filetype=csv</code>
+                            </a>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>Description</th>
+                        <td>
+                            This endpoint gives some statistics about Project Sidewalk users. It includes some overall
+                            statistics like accuracy and meters explored. It also gives counts of the number of labels
+                            placed for each label type. More formal documentation is in the works! The IDs for users are
+                            anonymized, but persistent over time.
+                        </td>
+                    </tr>
+                </table>
+
                 <h2 id="access-dataset">Access Dataset</h2>
                 <p>We are working on this!</p>
 

--- a/conf/routes
+++ b/conf/routes
@@ -147,6 +147,7 @@ GET     /v2/access/attributes                                @controllers.Projec
 GET     /v2/access/attributesWithLabels                      @controllers.ProjectSidewalkAPIController.getAccessAttributesWithLabelsV2(lat1: Double, lng1: Double, lat2: Double, lng2: Double, severity: Option[String], filetype: Option[String])
 GET     /v2/access/score/streets                             @controllers.ProjectSidewalkAPIController.getAccessScoreStreetsV2(lat1: Double, lng1: Double, lat2: Double, lng2: Double, filetype: Option[String])
 GET     /v2/access/score/neighborhoods                       @controllers.ProjectSidewalkAPIController.getAccessScoreNeighborhoodsV2(lat1: Double, lng1: Double, lat2: Double, lng2: Double, filetype: Option[String])
+GET     /v2/userStats                                        @controllers.ProjectSidewalkAPIController.getUsersAPIStats(filetype: Option[String])
 GET     /v1/access/features                                  @controllers.ProjectSidewalkAPIController.getAccessAttributesV1(lat1: Double, lng1: Double, lat2: Double, lng2: Double)
 GET     /v1/access/attributes                                @controllers.ProjectSidewalkAPIController.getAccessAttributesV1(lat1: Double, lng1: Double, lat2: Double, lng2: Double)
 GET     /v1/access/score/neighborhoods                       @controllers.ProjectSidewalkAPIController.getAccessScoreNeighborhoodsV1(lat1: Double, lng1: Double, lat2: Double, lng2: Double)


### PR DESCRIPTION
Resolves #2890 

Adds an API endpoint to get various statistics about Project Sidewalk users. Mostly around counts of labels, validations, as well as accuracy, distance audited, etc. Here's some sample output:
```
[
    {
        "user_id":"0047c5c4-fc44-4843-9453-b79389b15246",
        "labels":40,
        "meters_explored":2565.70068359375,
        "labels_per_meter":0.015590283088386059,
        "high_quality":false,
        "high_quality_manual":null,
        "label_accuracy":0.7599999904632568,
        "validated_labels":25,
        "validations_received":88,
        "labels_validated_correct":19,
        "labels_validated_incorrect":6,
        "labels_not_validated":15,
        "validations_given":44,
        "dissenting_validations_given":36,
        "agree_validations_given":6,
        "disagree_validations_given":2,
        "notsure_validations_given":10,
        "stats_by_label_type":{
            "curb_ramp":{
                "labels":13,
                "validated_correct":6,
                "validated_incorrect":2,
                "not_validated":5
            },
            "no_curb_ramp":{
                "labels":3,
                "validated_correct":0,
                "validated_incorrect":3,
                "not_validated":0
            },
            "obstacle":{
                "labels":18,
                "validated_correct":13,
                "validated_incorrect":0,
                "not_validated":5
            },
            "surface_problem":{
                "labels":0,
                "validated_correct":0,
                "validated_incorrect":0,
                "not_validated":0
            },
            "no_sidewalk":{
                "labels":1,
                "validated_correct":0,
                "validated_incorrect":1,
                "not_validated":0
            },
            "crosswalk":{
                "labels":5,
                "validated_correct":0,
                "validated_incorrect":0,
                "not_validated":5
            },
            "pedestrian_signal":{
                "labels":0,
                "validated_correct":0,
                "validated_incorrect":0,
                "not_validated":0
            },
            "cant_see_sidewalk":{
                "labels":0,
                "validated_correct":0,
                "validated_incorrect":0,
                "not_validated":0
            },
            "other":{
                "labels":0,
                "validated_correct":0,
                "validated_incorrect":0,
                "not_validated":0
            }
        }
    }
]
```

Some notes:
* Above is the JSON output, we can also output as CSV with the query parameter `filetype=csv` (same as other public APIs)
* I did not include support for outputting as a shapefile because we are not outputting any geographic data. Plus shapefiles have something like a 10 character limit on column names, which would make this data pretty confusing.
* I added some documentation to the /api page for the endpoint. I didn't spend a ton of time on it since we really just need to add better formal documentation for all of our public APIs. But a picture is below.

![Screenshot from 2022-06-16 13-49-54](https://user-images.githubusercontent.com/6518824/174161847-32ed7bdc-70c3-4793-a37c-276545b1c74d.png)

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
- [x] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure the documentation on [this wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Descriptions-of-Logged-Events) is up to date for the logs you added/updated.
