### PR TITLE
Fix completion percentage on maps

### DIFF
--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -165,7 +165,7 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
     * Get audit coverage of each neighborhood.
     */
   def getNeighborhoodCompletionRate = UserAwareAction.async { implicit request =>
-    RegionCompletionTable.initializeRegionCompletionTable()
+    RegionCompletionTable.initializeRegionCompletionTable
 
     val neighborhoods = RegionCompletionTable.selectAllNamedNeighborhoodCompletions
     val completionRates: List[JsObject] = for (neighborhood <- neighborhoods) yield {

--- a/app/models/daos/slick/UserDAOSlick.scala
+++ b/app/models/daos/slick/UserDAOSlick.scala
@@ -247,7 +247,7 @@ object UserDAOSlick {
     } yield _user.userId
 
     // The group by and map does a SELECT DISTINCT, and the list.length does the COUNT.
-    users.groupBy(x => x).map(_._1).size.run
+    users.groupBy(x => x).map(_._1).length.run
   }
 
   /**
@@ -361,7 +361,7 @@ object UserDAOSlick {
     } yield _user.userId
 
     // The group by and map does a SELECT DISTINCT, and the list.length does the COUNT.
-    users.groupBy(x => x).map(_._1).size.run
+    users.groupBy(x => x).map(_._1).length.run
   }
 
   /**

--- a/app/models/label/LabelValidationTable.scala
+++ b/app/models/label/LabelValidationTable.scala
@@ -290,7 +290,7 @@ object LabelValidationTable {
 
     validationLabels.innerJoin(labelsWithoutDeleted).on(_.labelId === _.labelId)
       .filter(_._2.labelTypeId === typeID)
-      .size.run
+      .length.run
   }
 
   /**
@@ -302,7 +302,7 @@ object LabelValidationTable {
     validationLabels.innerJoin(labelsWithoutDeleted).on(_.labelId === _.labelId)
       .filter(_._2.labelTypeId === typeID)
       .filter(_._1.validationResult === result)
-      .size.run
+      .length.run
   }
 
   /**
@@ -311,7 +311,7 @@ object LabelValidationTable {
    * @returns the number of validations performed by this user
    */
   def countValidations(userId: UUID): Int = db.withSession { implicit session =>
-    validationLabels.filter(_.userId === userId.toString).size.run
+    validationLabels.filter(_.userId === userId.toString).length.run
   }
 
   /**

--- a/app/models/region/RegionCompletionTable.scala
+++ b/app/models/region/RegionCompletionTable.scala
@@ -4,7 +4,7 @@ import models.street.{StreetEdgePriorityTable, StreetEdgeRegionTable, StreetEdge
 import models.utils.MyPostgresDriver
 import models.utils.MyPostgresDriver.simple._
 import play.api.Play.current
-import scala.slick.jdbc.GetResult
+import scala.slick.jdbc.{GetResult, StaticQuery => Q}
 
 case class RegionCompletion(regionId: Int, totalDistance: Double, auditedDistance: Double)
 case class NamedRegionCompletion(regionId: Int, name: String, totalDistance: Double, auditedDistance: Double)
@@ -89,7 +89,7 @@ object RegionCompletionTable {
 
     if (regionCompletions.length.run == 0) {
 
-      val neighborhoods = RegionTable.selectAllNamedNeighborhoods
+      val neighborhoods: List[NamedRegion] = RegionTable.selectAllNamedNeighborhoods
       for (neighborhood <- neighborhoods) yield {
 
         // Check if the neighborhood is fully audited, and set audited_distance equal to total_distance if so. We are
@@ -106,5 +106,9 @@ object RegionCompletionTable {
         }
       }
     }
+  }
+
+  def truncateTable(): Unit = db.withTransaction { implicit session =>
+    Q.updateNA("TRUNCATE TABLE region_completion").execute
   }
 }

--- a/app/models/region/RegionCompletionTable.scala
+++ b/app/models/region/RegionCompletionTable.scala
@@ -73,7 +73,7 @@ object RegionCompletionTable {
           // audited in that neighborhood; this has never been observed, but it could theoretically be an issue if there
           // is a sizable error, while there is a single (very very short) street segment left to be audited. That case
           // shouldn't happen, but we are just being safe, and setting audited_distance to be less than total_distance.
-          if (StreetEdgeRegionTable.allStreetsInARegionAudited(regionId)) {
+          if (StreetEdgePriorityTable.allStreetsInARegionAuditedUsingPriority(regionId)) {
             q.map(_.auditedDistance).update(rC.totalDistance)
           } else if (rC.auditedDistance + distToAdd > rC.totalDistance) {
             q.map(_.auditedDistance).update(rC.totalDistance * 0.995)
@@ -94,7 +94,7 @@ object RegionCompletionTable {
 
         // Check if the neighborhood is fully audited, and set audited_distance equal to total_distance if so. We are
         // doing this to fix floating point error, so that in the end, the region is marked as exactly 100% complete.
-        if (StreetEdgeRegionTable.allStreetsInARegionAudited(neighborhood.regionId)) {
+        if (StreetEdgePriorityTable.allStreetsInARegionAuditedUsingPriority(neighborhood.regionId)) {
           val totalDistance: Double = StreetEdgeTable.getTotalDistanceOfARegion(neighborhood.regionId).toDouble
 
           regionCompletions += RegionCompletion(neighborhood.regionId, totalDistance, totalDistance)

--- a/app/models/street/StreetEdgePriorityTable.scala
+++ b/app/models/street/StreetEdgePriorityTable.scala
@@ -79,7 +79,7 @@ object StreetEdgePriorityTable {
       if ser.regionId === regionId
       if sep.priority === 1.0
     } yield sep
-    streetsToAudit.size.run == 0
+    streetsToAudit.length.run == 0
   }
 
   def streetDistanceCompletionRateUsingPriority: Float = db.withSession { implicit session =>

--- a/app/models/street/StreetEdgePriorityTable.scala
+++ b/app/models/street/StreetEdgePriorityTable.scala
@@ -66,6 +66,22 @@ object StreetEdgePriorityTable {
     }
   }
 
+  /**
+   * Checks if all streets have been audited by a high quality user (if all have priority < 1).
+   *
+   * @param regionId
+   * @return
+   */
+  def allStreetsInARegionAuditedUsingPriority(regionId: Int): Boolean = db.withSession { implicit session =>
+    val streetsToAudit = for {
+      ser <- StreetEdgeTable.streetEdgeRegion
+      sep <- streetEdgePriorities if ser.streetEdgeId === sep.streetEdgeId
+      if ser.regionId === regionId
+      if sep.priority === 1.0
+    } yield sep
+    streetsToAudit.size.run == 0
+  }
+
   def streetDistanceCompletionRateUsingPriority: Float = db.withSession { implicit session =>
     val auditedDistance: Float = auditedStreetDistanceUsingPriority
     val totalDistance: Float = StreetEdgeTable.totalStreetDistance()

--- a/app/models/street/StreetEdgeRegionTable.scala
+++ b/app/models/street/StreetEdgeRegionTable.scala
@@ -49,20 +49,4 @@ object StreetEdgeRegionTable {
   def selectNonDeletedByRegionId(regionId: Int): List[StreetEdgeRegion] = db.withSession { implicit session =>
     nonDeletedStreetEdgeRegions.filter(item => item.regionId === regionId).list
   }
-
-  /**
-    * Checks if every street in the region has an associated completed audit task.
-    *
-    * @param regionId
-    * @return
-    */
-  def allStreetsInARegionAudited(regionId: Int): Boolean = db.withSession { implicit session =>
-    val edgesInRegion: Int = selectNonDeletedByRegionId(regionId).length
-    val edgesAuditedInRegion: Int = (for {
-      _edgeRegions <- nonDeletedStreetEdgeRegions if _edgeRegions.regionId === regionId
-      _audits <- AuditTaskTable.completedTasks if _audits.streetEdgeId === _edgeRegions.streetEdgeId
-    } yield _audits.streetEdgeId).groupBy(x => x).map(_._1).size.run
-
-    edgesAuditedInRegion == edgesInRegion
-  }
 }

--- a/app/models/street/StreetEdgeTable.scala
+++ b/app/models/street/StreetEdgeTable.scala
@@ -96,7 +96,7 @@ object StreetEdgeTable {
     * @return
     */
   def countTotalStreets(): Int = db.withSession { implicit session =>
-    streetEdgesWithoutDeleted.size.run
+    streetEdgesWithoutDeleted.length.run
   }
 
   /**
@@ -108,7 +108,7 @@ object StreetEdgeTable {
     */
   def auditCompletionRate(auditCount: Int, userType: String = "All"): Float = db.withSession { implicit session =>
     val auditedStreetCount = countAuditedStreets(1, userType).toFloat
-    val allEdgesCount: Int = streetEdgesWithoutDeleted.size.run
+    val allEdgesCount: Int = streetEdgesWithoutDeleted.length.run
     auditedStreetCount / allEdgesCount
   }
 

--- a/app/utils/actor/RecalculateStreetPriorityActor.scala
+++ b/app/utils/actor/RecalculateStreetPriorityActor.scala
@@ -3,6 +3,7 @@ package utils.actor
 import java.text.SimpleDateFormat
 import java.util.{Calendar, Locale, TimeZone}
 import akka.actor.{Actor, Cancellable, Props}
+import models.region.RegionCompletionTable
 import models.street.StreetEdgePriorityTable
 import play.api.Play.current
 import play.api.{Logger, Play}
@@ -62,7 +63,9 @@ class RecalculateStreetPriorityActor extends Actor {
 
       val currentTimeStart: String = dateFormatter.format(Calendar.getInstance(TIMEZONE).getTime)
       Logger.info(s"Auto-scheduled recalculation of street priority starting at: $currentTimeStart")
-      StreetEdgePriorityTable.recalculateStreetPriority
+      StreetEdgePriorityTable.recalculateStreetPriority()
+      RegionCompletionTable.truncateTable()
+      RegionCompletionTable.initializeRegionCompletionTable()
       val currentEndTime: String = dateFormatter.format(Calendar.getInstance(TIMEZONE).getTime)
       Logger.info(s"Street priority recalculation completed at: $currentEndTime")
   }


### PR DESCRIPTION
Resolves #2872 

Fixes an issue with the maps on our site, where they would sometimes show up as "100% audited" when they really were not! I also added in a nightly wipe of the `region_completion` table, which is where those completion percentages come from. We recalculate the priority for street edges every night, so we should be recalculating these completion percentages as well, since they are based on the audit priority of streets.

##### Before/After screenshots (if applicable)
This before/after is on a local database dump, where I've done some extra fake auditing. So the change is more drastic locally than it will be on the production servers. The nice part is that it makes it easier to see the changes ;)

Before
![Screenshot from 2022-06-16 14-34-57](https://user-images.githubusercontent.com/6518824/174177975-92e0e052-607a-4418-a7bc-cc4da2132c07.png)

After
![Screenshot from 2022-06-16 14-40-09](https://user-images.githubusercontent.com/6518824/174178049-9edb030c-b589-40d0-acc9-c01c02dec92a.png)

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
