### PR TITLE
Added functionality for the plus sign in the sidebar menu of the labeling guide page for each subtopic

### DIFF
--- a/app/views/labelingGuideCurbRamps.scala.html
+++ b/app/views/labelingGuideCurbRamps.scala.html
@@ -26,6 +26,21 @@
                             <li><a href='@routes.ApplicationController.labelingGuide'>Introduction</a></li>
                             <li class="topic"><a href='@routes.ApplicationController.labelingGuideCurbRamps'><strong>Curb Ramps</strong></a>
                                 <span class="plusminus">+</span></li>
+                                <script language="javascript"> 
+                                    $(document).ready(function(){
+                                        $(".labeling-heading").click(function(){  
+                                              if($(".labeling-body").is(':visible')){  /* check the condition accordion-body is visible or not */
+                                                  $(".labeling-body").slideUp(600);  /*if content is visible then close accordion-body with specific time duration */
+                                                $(".plusminus").text('+')    /* add plus sign */
+                                            }
+                                            else{
+                                                $(this).next(".labeling-body").slideDown(600); /*if content not visible then 
+                                                                                                                                            show the accordion-body */
+                                                $(this).children(".plusminus").text('-');  /* add minus sign */
+                                            }
+                                        });
+                                    });
+                                </script>
                             <div id="subtopics">
                             </div>
                             <li><a href='@routes.ApplicationController.labelingGuideSurfaceProblems'>Surface Problems</a></li>


### PR DESCRIPTION
Resolves #2830 

Before clicking the plus sign on the sidebar of the labeling guide pages, for example next to curb ramp did not show the menu of headings. 

<img width="265" alt="image" src="https://user-images.githubusercontent.com/69694786/176095406-1c6cf5a4-2109-48ca-b9e3-2e7b11e15082.png">

After I added the script tags and JavaScript code to show information underneath the plus sign. 

<img width="223" alt="image" src="https://user-images.githubusercontent.com/69694786/176095466-d236375a-ed4e-44af-acda-ba3c64b9bd1a.png">


##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [ x] I've written a descriptive PR title.
- [ x] I've added/updated comments for large or confusing blocks of code.
- [ x] I've included before/after screenshots above.
- [ x] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure the documentation on [this wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Descriptions-of-Logged-Events) is up to date for the logs you added/updated.
