### PR TITLE
#2947 Dutch brick/cobblestone tag

### DIFF
--- a/public/locales/nl/common.json
+++ b/public/locales/nl/common.json
@@ -68,7 +68,7 @@
     "cracks": "scheuren",
     "grass": "gras",
     "narrow sidewalk": "smal trottoir",
-    "brick": "steen",
+    "brick/cobblestone": "steen",
     "very broken": "erg beschadigd",
     "rail/tram track": "spoor/trambaan",
     "sand/gravel": "zand/grind",


### PR DESCRIPTION
Resolves #2947 

There was a line of code in public/locales/nl that had the tag set as "brick" instead of "brick/cobblestone", and therefore couldn't be identified for translation. I changed it to be "brick/cobblestone".

##### Before/After screenshots (if applicable)
![2947Before](https://user-images.githubusercontent.com/69987726/176273608-bd1349f2-4517-476e-ae8f-901cacb67e8e.JPG)
![2947After](https://user-images.githubusercontent.com/69987726/176273961-158cd8d1-cb40-495e-9bef-e82dd329bfa1.JPG)
![2947ValidationPage](https://user-images.githubusercontent.com/69987726/176276305-b9246a35-6792-4e2a-9d2e-b4a72006c018.JPG)

##### Testing instructions
1. Navigate to the Gallery page and filter for Sidewalk Problems. The brick/cobblestone tag should be translated. If the brick/cobblestone tag is attached to a validation label, it should also be translated.
