### PR TITLE
#2949: Reinstated question mark when severity rating is missing

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/label/Label.js
+++ b/public/javascripts/SVLabel/src/SVLabel/label/Label.js
@@ -425,7 +425,7 @@ function Label (svl, pathIn, params) {
 
             // Only render severity warning if there's a severity option.
             if (properties.labelType !== 'Occlusion' && properties.labelType !== 'Signal') {
-                if (properties.severity === undefined) {
+                if (properties.severity == undefined) {
                     showSeverityAlert(ctx);
                 }
             }

--- a/public/javascripts/SVLabel/src/SVLabel/label/Label.js
+++ b/public/javascripts/SVLabel/src/SVLabel/label/Label.js
@@ -425,7 +425,7 @@ function Label (svl, pathIn, params) {
 
             // Only render severity warning if there's a severity option.
             if (properties.labelType !== 'Occlusion' && properties.labelType !== 'Signal') {
-                if (properties.severity == undefined) {
+                if (properties.severity === null) {
                     showSeverityAlert(ctx);
                 }
             }
@@ -459,7 +459,7 @@ function Label (svl, pathIn, params) {
         // labelCoordinate represents the upper left corner of the tag.
         var labelCoordinate = getCoordinate(),
             cornerRadius = 3,
-            hasSeverity = (properties.labelType !== 'Occlusion'),
+            hasSeverity = (properties.labelType !== 'Occlusion' && properties.labelType !== 'Signal'),
             i, height,
             width = 0,
             labelRows = 1,
@@ -472,7 +472,7 @@ function Label (svl, pathIn, params) {
 
         if (hasSeverity) {
             labelRows = 2;
-            if (properties.severity != undefined) {
+            if (properties.severity !== null) {
                 severityImagePath = tagProperties[properties.severity].severityImage;
                 severityImage.src = severityImagePath;
                 severityMessage = tagProperties[properties.severity].message;
@@ -535,7 +535,7 @@ function Label (svl, pathIn, params) {
         ctx.fillText(messages[0], labelCoordinate.x + padding.left, labelCoordinate.y + padding.top);
         if (hasSeverity) {
             ctx.fillText(severityMessage, labelCoordinate.x + padding.left, labelCoordinate.y + properties.tagHeight + padding.top);
-            if (properties.severity != undefined) {
+            if (properties.severity !== null) {
               ctx.drawImage(severityImage, labelCoordinate.x + padding.left + ctx.measureText(severityMessage).width + 5, labelCoordinate.y + 25, 16, 16);
             }
         }


### PR DESCRIPTION
Resolves #2949 

if (properties.severity === undefined) {
    showSeverityAlert(ctx);
}

The function above was not being called. I changed the triple equals (===) to be only a double equals (==) and that seemed to fix the issue.

![2949Before](https://user-images.githubusercontent.com/69987726/176500159-0f724321-ecab-4736-8f3c-c1c5322db6d9.JPG)
![2949After](https://user-images.githubusercontent.com/69987726/176500180-c06b8f75-f89f-4cba-bae1-53a2e06ef8a4.JPG)

![2949Check](https://user-images.githubusercontent.com/69987726/176500203-42e951d6-dbad-4f5a-b609-ca3b04f4ff9d.JPG)
The question mark only shows on labels that have an available severity rank.

##### Testing instructions
1. Place a label that has a severity rank option (e.g., curb ramp, missing curb ramp) and the red question mark should automatically show
2. If you click off of the label without submitting a severity rank, the question mark should remain
3. Once you select a severity rank, the question mark should disappear