### PR TITLE
Email address is no longer case sensitive

### DIFF
--- a/app/controllers/CredentialsAuthController.scala
+++ b/app/controllers/CredentialsAuthController.scala
@@ -5,6 +5,7 @@ import java.time.Instant
 import javax.inject.Inject
 import com.mohiva.play.silhouette.api._
 import com.mohiva.play.silhouette.api.exceptions.{ConfigurationException, ProviderException}
+import com.mohiva.play.silhouette.api.util.Credentials
 import com.mohiva.play.silhouette.impl.authenticators.SessionAuthenticator
 import com.mohiva.play.silhouette.impl.exceptions.IdentityNotFoundException
 import com.mohiva.play.silhouette.impl.providers._
@@ -38,7 +39,7 @@ class CredentialsAuthController @Inject() (
     SignInForm.form.bindFromRequest.fold(
       form => Future.successful(BadRequest(views.html.signIn(form))),
       credentials => (env.providers.get(CredentialsProvider.ID) match {
-        case Some(p: CredentialsProvider) => p.authenticate(credentials)
+        case Some(p: CredentialsProvider) => p.authenticate(Credentials(credentials.identifier.toLowerCase, credentials.password))
         case _ => Future.failed(new ConfigurationException("Cannot find credentials provider"))
       }).flatMap { loginInfo =>
         userService.retrieve(loginInfo).flatMap {
@@ -66,7 +67,7 @@ class CredentialsAuthController @Inject() (
     SignInForm.form.bindFromRequest.fold(
       form => Future.successful(BadRequest(views.html.signIn(form))),
       credentials => (env.providers.get(CredentialsProvider.ID) match {
-        case Some(p: CredentialsProvider) => p.authenticate(credentials)
+        case Some(p: CredentialsProvider) => p.authenticate(Credentials(credentials.identifier.toLowerCase, credentials.password))
         case _ => Future.failed(new ConfigurationException("Cannot find credentials provider"))
       }).flatMap { loginInfo =>
         userService.retrieve(loginInfo).flatMap {

--- a/conf/evolutions/default/156.sql
+++ b/conf/evolutions/default/156.sql
@@ -1,0 +1,10 @@
+# --- !Ups
+UPDATE sidewalk_user
+SET email = LOWER(email)
+WHERE email <> LOWER(email);
+
+UPDATE login_info
+SET provider_key = LOWER(provider_key)
+WHERE provider_key <> LOWER(provider_key);
+
+# --- !Downs


### PR DESCRIPTION
Fixes #326 

Login email addresses are no longer case sensitive!

The only thing left to do is deal with the five instances where users signed up multiple times with the same email address using a different capitalization. In all cases, there is an account that clearly has more work put into it. I'll just change the email address for their less used account to a dummy email address so that the names don't clash.

##### Testing instructions
1. Create an account on the develop branch with a capital letter in the email address
2. Log out and try to sign back in, changing the capitalization (it should fail)
3. Switch to this branch and try signing back in with a different capitalization (it should work)
4. On this branch, make a new account, sign out, and sign back in with a different capitalization (it should work)
