### PR TITLE
#2957: Added label outlines in validate and gallery

### DIFF
--- a/public/javascripts/Gallery/css/cards.css
+++ b/public/javascripts/Gallery/css/cards.css
@@ -156,9 +156,9 @@ with respect to the image holder. This allows the validation menu to be placed o
     position: absolute;
     width: 1.1vw;
     z-index: 1;
-    background-color: black;
     border: 1px solid black;
     border-radius: 100%;
+    outline: 0.5px solid white;
 }
 
 .validation-button, .validation-button-selected {

--- a/public/javascripts/Gallery/css/cards.css
+++ b/public/javascripts/Gallery/css/cards.css
@@ -156,8 +156,9 @@ with respect to the image holder. This allows the validation menu to be placed o
     position: absolute;
     width: 1.1vw;
     z-index: 1;
+    background-color: black;
     border: 1px solid black;
-    border-radius: 80%;
+    border-radius: 100%;
 }
 
 .validation-button, .validation-button-selected {

--- a/public/javascripts/Gallery/css/cards.css
+++ b/public/javascripts/Gallery/css/cards.css
@@ -156,6 +156,8 @@ with respect to the image holder. This allows the validation menu to be placed o
     position: absolute;
     width: 1.1vw;
     z-index: 1;
+    border: 1px solid black;
+    border-radius: 80%;
 }
 
 .validation-button, .validation-button-selected {

--- a/public/javascripts/SVLabel/src/SVLabel/label/Label.js
+++ b/public/javascripts/SVLabel/src/SVLabel/label/Label.js
@@ -423,6 +423,17 @@ function Label (svl, pathIn, params) {
             // Renders the label image.
             path.render2(ctx, pov);
 
+            // Draws an outline around the label icon.
+            ctx.lineWidth = .7;
+            ctx.beginPath();
+            ctx.arc(getCoordinate().x, getCoordinate().y, 15.3, 0, 2 * Math.PI);
+            ctx.strokeStyle = 'black';
+            ctx.stroke();
+            ctx.beginPath();
+            ctx.arc(getCoordinate().x, getCoordinate().y, 16.2, 0, 2 * Math.PI);
+            ctx.strokeStyle = 'white';
+            ctx.stroke();
+
             // Only render severity warning if there's a severity option.
             if (properties.labelType !== 'Occlusion' && properties.labelType !== 'Signal') {
                 if (properties.severity === null) {

--- a/public/javascripts/common/Panomarker.js
+++ b/public/javascripts/common/Panomarker.js
@@ -408,6 +408,11 @@
         marker.style.height = this.size_.height + 'px';
         marker.style.display = this.visible_ ? 'block' : 'none';
         marker.style.zIndex = this.zIndex_;
+        marker.style.border = 'solid black';
+        marker.style.borderWidth = '1px';
+        marker.style.borderRadius = '25px';
+        marker.style.outline = 'solid white';
+        marker.style.outlineWidth = '0.5px';
 
         // Set other css attributes based on the given parameters
         if (this.id_) { marker.id = this.id_; }


### PR DESCRIPTION
Resolves #2957 

I added a white and black outline to all label icons using CSS.

Before Outlines:
![2957BeforeExplore](https://user-images.githubusercontent.com/69987726/178614734-fedbd53c-2666-452e-80c5-ab192f5ee130.JPG)
![2957BeforeGallery](https://user-images.githubusercontent.com/69987726/178614740-68b286f7-a35c-4bc6-be15-4fa48fa45b5a.JPG)
![2957BeforeLabelMap](https://user-images.githubusercontent.com/69987726/178614743-7528888c-57e2-4d1a-8294-f973351a8421.JPG)
![2957BeforeValidation](https://user-images.githubusercontent.com/69987726/178614746-6551c9aa-c8f7-412d-a53f-6f9d64b7186b.JPG)

After Outlines:
![2957FinalExploreOutline](https://user-images.githubusercontent.com/69987726/178614777-8cb8ac63-5bb0-4e35-8069-124371d8459e.JPG)
![2957FinalGalleryOutline](https://user-images.githubusercontent.com/69987726/178614778-e0ca0101-d4fe-4d9c-ba3e-7e8f0bd69d89.JPG)
![2957FinalLabelMapOutline](https://user-images.githubusercontent.com/69987726/178614781-aab86290-db70-4b11-8ccf-48ced51c0139.JPG)
![2957FinalValidationOutline](https://user-images.githubusercontent.com/69987726/178614784-b04f5bfa-f4b9-4d88-ada0-06a9ebe37923.JPG)


##### Testing instructions
1. Locate a label in Gallery, Validate, or Label Map and it should have an inner black outline and an outer white outline
2. Place a label in Explore and it should have an inner black outline and an outer white outline

