### PR TITLE
Adds description of Stuck and Jump buttons to Help page

### DIFF
--- a/app/views/help.scala.html
+++ b/app/views/help.scala.html
@@ -313,7 +313,7 @@
                                     <tr>
                                         <th></th>
                                         <th><kbd>N</kbd></th>
-                                        <td>Switch to the "No Sidewalk" mode</td>
+                                        <td>Switch to "No Sidewalk" mode</td>
                                     </tr>
                                     <tr>
                                         <th></th>


### PR DESCRIPTION
Resolves #2918 

Adds an explanation of the difference between the Jump button and Stuck button to the Help page. Since I was there, I updated the table of keyboard shortcuts on that page as well.

##### Before/After screenshots (if applicable)
New Jump vs Stuck section

<img width="755" alt="Screen Shot 2022-07-14 at 10 46 13 AM" src="https://user-images.githubusercontent.com/6518824/179050664-8a2c4692-7225-4f26-b2c3-836bc3a974f8.png">

Old keyboard shortcut section
<img width="755" alt="Screen Shot 2022-07-14 at 10 25 35 AM" src="https://user-images.githubusercontent.com/6518824/179050793-e2d918f9-b338-46aa-bbea-5569452857b9.png">

New keyboard shortcut section
<img width="751" alt="Screen Shot 2022-07-14 at 11 00 53 AM" src="https://user-images.githubusercontent.com/6518824/179051477-9f91b7a1-278f-4fba-af61-4627bc2fa17a.png">

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've included before/after screenshots above.
