### PR TITLE
#2966: Added high quality column to user table in admin dashboard

### DIFF
--- a/app/models/daos/slick/UserDAOSlick.scala
+++ b/app/models/daos/slick/UserDAOSlick.scala
@@ -510,10 +510,10 @@ object UserDAOSlick {
     }.toMap
 
     val userHighQuality =
-      UserStatTable.userStats.map { x => (x.userId, x.highQuality) }.toMap
+      UserStatTable.userStats.map { x => (x.userId, x.highQuality) }.list.toMap
 
     // Now left join them all together and put into UserStatsForAdminPage objects.
-    usersMinusAnonUsersWithNoLabels.list.map{ u =>
+    usersMinusAnonUsersWithNoLabels.list.map { u =>
       val ownValidatedCounts = validatedCounts.getOrElse(u.userId, ("", 0, 0, 0, 0))
       val ownValidatedTotal = ownValidatedCounts._2
       val ownValidatedAgreed = ownValidatedCounts._3

--- a/app/models/daos/slick/UserDAOSlick.scala
+++ b/app/models/daos/slick/UserDAOSlick.scala
@@ -9,7 +9,7 @@ import models.daos.UserDAO
 import models.label.LabelValidationTable
 import models.label.LabelTable
 import models.mission.MissionTable
-import models.user.{RoleTable, WebpageActivityTable}
+import models.user.{RoleTable, WebpageActivityTable, UserStatTable}
 import models.user.{UserRoleTable, User}
 import play.api.db.slick._
 import play.api.db.slick.Config.driver.simple._
@@ -22,7 +22,7 @@ case class UserStatsForAdminPage(userId: String, username: String, email: String
                                  signUpTime: Option[Timestamp], lastSignInTime: Option[Timestamp], signInCount: Int,
                                  completedMissions: Int, completedAudits: Int, labels: Int, ownValidated: Int,
                                  ownValidatedAgreedPct: Double, ownValidatedDisagreedPct: Double, ownValidatedNotsurePct: Double,
-                                 othersValidated: Int, othersValidatedAgreedPct: Double)
+                                 othersValidated: Int, othersValidatedAgreedPct: Double, highQuality: Boolean)
 
 class UserDAOSlick extends UserDAO {
   /**
@@ -509,6 +509,9 @@ object UserDAOSlick {
       (valCount._1, (valCount._2, valCount._3))
     }.toMap
 
+    val userHighQuality =
+      UserStatTable.userStats.map { x => (x.userId, x.highQuality) }.toMap
+
     // Now left join them all together and put into UserStatsForAdminPage objects.
     usersMinusAnonUsersWithNoLabels.list.map{ u =>
       val ownValidatedCounts = validatedCounts.getOrElse(u.userId, ("", 0, 0, 0, 0))
@@ -550,7 +553,8 @@ object UserDAOSlick {
         ownValidatedDisagreedPct,
         ownValidatedNotsurePct,
         otherValidatedTotal,
-        otherValidatedAgreedPct
+        otherValidatedAgreedPct,
+        userHighQuality.getOrElse(u.userId, true)
       )
     }
   }

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -764,6 +764,7 @@
                                         <th class="col-md-2">Date Registered</th>
                                         <th class="col-md-2" data-class-name="priority">Last Login</th>
                                         <th class="col-md-1">Login Count</th>
+                                        <th class="col-md-1">High Quality</th>
                                     </tr>
                                 </thead>
                                 <tbody>
@@ -802,6 +803,7 @@
                                     <td class = 'timestamp'>@u.signUpTime</td>
                                     <td class = 'timestamp'>@u.lastSignInTime</td>
                                     <td>@u.signInCount</td>
+                                    <td>@u.highQuality</td>
                                 </tr>
                                 }
                                 </tbody>


### PR DESCRIPTION
Resolves #2966 

![BeforeHighQualityColumn](https://user-images.githubusercontent.com/69987726/181820671-2779684b-275a-4603-930a-e897226190a8.JPG)

![AfterHighQualityColumn](https://user-images.githubusercontent.com/69987726/181820115-6e407759-1a23-4a4d-bca6-9e6e8091f60f.JPG)

1. Open the Users tab on the admin page
2. Scroll to the far right, and there should be a high-quality column with true and false values

