### PR TITLE
#2981: Password reset email is no longer case sensitive

### DIFF
--- a/app/controllers/ForgotPasswordController.scala
+++ b/app/controllers/ForgotPasswordController.scala
@@ -44,7 +44,7 @@ class ForgotPasswordController @Inject() (
     ForgotPasswordForm.form.bindFromRequest.fold (
       form => Future.successful(BadRequest(views.html.forgotPassword(form))),
       email => {
-        val loginInfo = LoginInfo(CredentialsProvider.ID, email)
+        val loginInfo = LoginInfo(CredentialsProvider.ID, email.toLowerCase)
         val result = Redirect(routes.UserController.forgotPassword()).flashing("info" -> Messages("reset.pw.email.reset.pw.sent"))
         userService.retrieve(loginInfo).flatMap {
           case Some(user) =>


### PR DESCRIPTION
Resolves #2981 

Password reset email is no longer case sensitive.

##### Testing instructions
1. Create an account, then sign out
2. Click the "Forgot Password" option and input your account email with random capital letters (not all lowercase)
3. When you click "Send Email" it should send a password reset

