### PR TITLE
2995 fixing missing imagery errors

### DIFF
--- a/app/models/user/VersionTable.scala
+++ b/app/models/user/VersionTable.scala
@@ -35,10 +35,6 @@ object VersionTable {
   // Get an HMAC-SHA1 signing key from the raw key bytes.
   val sha1Key: SecretKeySpec = new SecretKeySpec(secretKey, "HmacSHA1")
 
-  // Get an HMAC-SHA1 Mac instance and initialize it with the HMAC-SHA1 key.
-  val mac: Mac = Mac.getInstance("HmacSHA1")
-  mac.init(sha1Key)
-
   /**
     * Returns current version ID.
     */
@@ -63,6 +59,10 @@ object VersionTable {
 
     // Gets everything but URL protocol and host that we want to sign.
     val resource: String = url.getPath() + '?' + url.getQuery()
+
+    // Get an HMAC-SHA1 Mac instance and initialize it with the HMAC-SHA1 key.
+    val mac: Mac = Mac.getInstance("HmacSHA1")
+    mac.init(sha1Key)
 
     // Compute the binary signature for the request.
     val sigBytes: Array[Byte] = mac.doFinal(resource.getBytes())


### PR DESCRIPTION
Resolves #2995 

Fixes a couple issues that caused Gallery, Validate, and the user dashboard to try and show labels on GSV imagery that had expired.

There were two causes. The first is that Google seems to have made a change to the response to their `https://maps.google.com/cbk?output=tile` API, such that it always returns a 200 OK response code, with just a black image if the imagery is no longer available.

The second was an issue in the way in which we generate URL signatures. We have some code that gets an HMAC-SHA1 Mac instance and initialize it with the HMAC-SHA1 key, and we were doing that only once. It turns out that we need to create that instance every time we want to generate a new URL signature -- Don't ask me why, it's just how their example code works, and when I switched ours over to doing the same thing, it fixed an issue where half of our URL signatures were incorrect :shrug: 

I also made a small change where we no longer mark an image as expired if there is some sort of network or IO exception. I'm assuming that that would come from something like a network error, etc. So I don't want to mark imagery as expired prematurely.

##### Before/After screenshots (if applicable)
Before
![Screenshot from 2022-08-18 16-00-59](https://user-images.githubusercontent.com/6518824/185509671-31067a42-6cda-46e2-b908-7bfedec77676.png)

After
![Screenshot from 2022-08-18 16-00-35](https://user-images.githubusercontent.com/6518824/185509673-3021ac69-c75d-423c-99de-6e2965c96260.png)

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
