### PR TITLE
Fixes location of GSV terms of use links

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
+++ b/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
@@ -38,6 +38,7 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
             lockDisablePanning: false,
             lockDisableWalking : false,
             panoLinkListenerSet: false,
+            bottomLinksClickable: false,
             svLinkArrowsLoaded : false,
             labelBeforeJumpListenerSet: false,
             jumpMsgShown: false,
@@ -498,14 +499,6 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
      */
     function getNavArrowsLayer() {
         return uiMap.pano.find('svg').parent();
-    }
-
-    /**
-     * Get layer of bottom terms/report a problem links.
-     * @returns {*}
-     */
-    function getBottomLinkLayer() {
-        return $('.gm-style-cc').slice(1, 3);
     }
 
     self.getStatus = function (key) {
@@ -1001,11 +994,21 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
      * This method brings the links (<, >) to the view control layer so that a user can click them to walk around.
      */
     function makeArrowsAndLinksClickable() {
-        // Bring the layer with arrows and bottom links forward.
+        // Bring the links on the bottom of GSV and the mini map to the top layer so they are clickable.
+        var bottomLinks = $('.gm-style-cc');
+        if (!status.bottomLinksClickable && bottomLinks.length > 7) {
+            status.bottomLinksClickable = true;
+            bottomLinks[0].remove(); // Remove GSV keyboard shortcuts link.
+            bottomLinks[4].remove(); // Remove mini map keyboard shortcuts link.
+            bottomLinks[5].remove(); // Remove mini map copyright text (duplicate of GSV).
+            bottomLinks[7].remove(); // Remove mini map terms of use link (duplicate of GSV).
+            uiMap.viewControlLayer.append($(bottomLinks[1]).parent().parent());
+            svl.ui.googleMaps.overlay.append($(bottomLinks[8]).parent().parent());
+        }
+
+        // Bring the layer with arrows forward.
         var $navArrows = getNavArrowsLayer();
-        var $bottomlinks = getBottomLinkLayer();
         uiMap.viewControlLayer.append($navArrows);
-        uiMap.viewControlLayer.append($bottomlinks);
 
         // Add an event listener to the nav arrows to log their clicks.
         if (!status.panoLinkListenerSet) {

--- a/public/javascripts/SVValidate/src/panorama/Panorama.js
+++ b/public/javascripts/SVValidate/src/panorama/Panorama.js
@@ -197,10 +197,11 @@ function Panorama (label) {
                 function (data, status) {
                     if (status === google.maps.StreetViewStatus.OK) {
                         document.getElementById("svv-panorama-date").innerText = moment(data.imageDate).format('MMM YYYY');
-                        // Make Terms of Use & Report a problem links on GSV clickable. Should only be done once.
+                        // Remove Keyboard shortcuts link and make Terms of Use & Report a problem links  clickable.
                         // https://github.com/ProjectSidewalk/SidewalkWebpage/issues/2546
                         if (!bottomLinksClickable) {
-                            $("#view-control-layer").append($('.gm-style-cc').slice(1, 3));
+                            $('.gm-style-cc')[0].remove();
+                            $("#view-control-layer").append($($('.gm-style-cc')[0]).parent().parent());
                             bottomLinksClickable = true;
                         } 
                     } else {


### PR DESCRIPTION
Resolves #2993 

Google switched up some of the DOM structure and number of links they have on the bottom of their GSV windows. I've adjusted our code to appropriately deal with these changes.

They added a new keyboard shortcuts link that we don't want to show. And we had to change how to raise these links to the top layer so that the terms of use remain clickable. I also updated things to remove some of the unnecessary links on the mini map on the Explore page, raising the little bug report link to the top so that it's now clickable.

##### Before/After screenshots (if applicable)
Explore before
<img width="912" alt="Screen Shot 2022-08-19 at 12 34 40 PM" src="https://user-images.githubusercontent.com/6518824/185695006-c3a1c203-e5d6-47ae-b41d-31c61b6815b2.png">

Explore after
<img width="912" alt="Screen Shot 2022-08-19 at 12 33 28 PM" src="https://user-images.githubusercontent.com/6518824/185694931-c120304b-39ce-4ead-937f-e07636c9233a.png">

Validate before
<img width="912" alt="Screen Shot 2022-08-19 at 12 34 28 PM" src="https://user-images.githubusercontent.com/6518824/185694985-c93d4bff-81ff-4ced-ad56-b7a64de4bf11.png">

Validate after
<img width="912" alt="Screen Shot 2022-08-19 at 12 33 51 PM" src="https://user-images.githubusercontent.com/6518824/185694946-8b7ae39b-a48d-49ce-8f30-1b003adff119.png">

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
- [x] I've tested on mobile (only needed for validation page).
