### PR TITLE
Remove duplicate images from mistakes on User Dashboard

### DIFF
--- a/public/javascripts/Progress/src/MistakeCarousel.js
+++ b/public/javascripts/Progress/src/MistakeCarousel.js
@@ -70,6 +70,7 @@ function MistakeCarousel() {
                 let gsvImage = document.createElement('img');
                 gsvImage.src = label.image_url;
                 gsvImage.classList.add('mistake-img');
+                gsvImage.id = `label_id_${label.label_id}`;
                 imageWrapper.appendChild(gsvImage);
 
                 // Add the label icon onto the GSV image.


### PR DESCRIPTION
Resolves #3000

Fixes an issue where you might see the same label multiple times in the carousel of recent mistakes on the user dashboard.

##### Before/After screenshots (if applicable)
Before -- notice that there are three images (you can see three white dots near the bottom of the img), and the first two are the same
<img width="520" alt="Screen Shot 2022-08-24 at 4 37 02 PM" src="https://user-images.githubusercontent.com/6518824/186542581-3b4b640d-594b-418e-b4a6-5582c0c7a8b7.png">

<img width="520" alt="Screen Shot 2022-08-24 at 4 37 15 PM" src="https://user-images.githubusercontent.com/6518824/186542610-5fb273ff-d031-453c-bd44-a2235ebeaafc.png">

<img width="520" alt="Screen Shot 2022-08-24 at 4 37 19 PM" src="https://user-images.githubusercontent.com/6518824/186542625-0e4dd002-399c-4932-b873-05354c70615e.png">

After -- you can see only two images, no dups
<img width="520" alt="Screen Shot 2022-08-24 at 4 32 56 PM" src="https://user-images.githubusercontent.com/6518824/186542756-325d5f21-61b8-41ae-8020-0299538c5a5b.png">
<img width="520" alt="Screen Shot 2022-08-24 at 4 32 59 PM" src="https://user-images.githubusercontent.com/6518824/186542761-451b467a-05fd-4e80-b166-480e475df998.png">

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
