### PR TITLE
Removes labels validated as incorrect from the API

### DIFF
--- a/app/models/attribute/UserClusteringSessionTable.scala
+++ b/app/models/attribute/UserClusteringSessionTable.scala
@@ -74,7 +74,8 @@ object UserClusteringSessionTable {
       _lab <- LabelTable.labelsWithoutDeletedOrOnboarding if _lab.missionId === _mission.missionId
       _latlng <- LabelTable.labelPoints if _lab.labelId === _latlng.labelId
       _type <- LabelTable.labelTypes if _lab.labelTypeId === _type.labelTypeId
-      if _region.deleted === false
+      if _region.deleted === false &&
+        (_lab.correct.isEmpty || _lab.correct === true) // Filter out labels validated as incorrect.
     } yield (_mission.userId, _lab.labelId, _type.labelType, _latlng.lat, _latlng.lng, _lab.severity, _lab.temporary)
 
     labels.list.map(LabelToCluster.tupled)

--- a/app/models/user/UserStatTable.scala
+++ b/app/models/user/UserStatTable.scala
@@ -133,7 +133,8 @@ object UserStatTable {
       _stat <- userStats if _stat.highQuality
       _mission <- MissionTable.auditMissions if _mission.userId === _stat.userId
       _label <- LabelTable.labelsWithoutDeletedOrOnboarding if _mission.missionId === _label.missionId
-      if _label.timeCreated > cutoffTime
+      if (_label.correct.isEmpty || _label.correct === true) && // Filter out labels validated as incorrect.
+        _label.timeCreated > cutoffTime
     } yield _stat.userId
 
     // SELECT DISTINCT on the user_ids.


### PR DESCRIPTION
Resolves #3003 

Filters out labels that have been validated as incorrect, even if they come from users marked as "high quality".

On my local dev environment that's using a database from Seattle in 2021, here's how clustering changed.
* Labels into clustering: 107,108 (before) -> 96,750 (after)
* Clusters created from single-user clustering: 86,008 -> 78,452
* Time for single-user clustering: 19.2 minutes -> 17.9 minutes
* Final number of clustered attributes from multi-user clustering: 74,802 -> 68,020
* Time for multi-user clustering: 22.9 minutes -> 21.2 minute
