### PR TITLE
#2874 return all streets in api

### DIFF
--- a/app/controllers/ProjectSidewalkAPIController.scala
+++ b/app/controllers/ProjectSidewalkAPIController.scala
@@ -40,6 +40,7 @@ case class StreetAttributeSignificance (val geometry: Array[JTSCoordinate],
                                         val streetID: Int,
                                         val osmID: Int,
                                         val score: Double,
+                                        val audited: Boolean,
                                         val attributeScores: Array[Double],
                                         val significanceScores: Array[Double])
 
@@ -53,7 +54,7 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
   extends Silhouette[User, SessionAuthenticator] with ProvidesHeader {
 
   case class AttributeForAccessScore(lat: Float, lng: Float, labelType: String)
-  case class AccessScoreStreet(streetEdge: StreetEdge, osmId: Int, score: Double, attributes: Array[Double], significance: Array[Double]) {
+  case class AccessScoreStreet(streetEdge: StreetEdge, osmId: Int, score: Double, audited: Boolean, attributes: Array[Double], significance: Array[Double]) {
     def toJSON: JsObject  = {
       val latlngs: List[JsonLatLng] = streetEdge.geom.getCoordinates.map(coord => JsonLatLng(coord.y, coord.x)).toList
       val linestring: JsonLineString[JsonLatLng] = JsonLineString(latlngs)
@@ -61,6 +62,7 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
         "street_edge_id" -> streetEdge.streetEdgeId,
         "osm_id" -> osmId,
         "score" -> score,
+        "audited" -> audited,
         "significance" -> Json.obj(
           "CurbRamp" -> significance(0),
           "NoCurbRamp" -> significance(1),
@@ -286,7 +288,7 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
     // Gather all of the data that will be written to the Shapefile.
     val labelsForScore: List[AttributeForAccessScore] = getLabelsForScore(version = 2, coordinates)
     val allStreetEdges: List[StreetEdge] = StreetEdgeTable.selectStreetsIntersecting(coordinates(0), coordinates(2), coordinates(1), coordinates(3))
-    val auditedStreetEdges: List[StreetEdge] = StreetEdgeTable.selectAuditedStreetsIntersecting(coordinates(0), coordinates(2), coordinates(1), coordinates(3))
+    val auditedStreetEdges: List[(StreetEdge, Boolean)] = StreetEdgeTable.selectAuditedStreetsIntersecting(coordinates(0), coordinates(2), coordinates(1), coordinates(3))
     val neighborhoods: List[NamedRegion] = RegionTable.selectNamedNeighborhoodsWithin(coordinates(0), coordinates(2), coordinates(1), coordinates(3))
     val significance: Array[Double] = Array(0.75, -1.0, -1.0, -1.0)
     // Create a list of NeighborhoodAttributeSignificance objects to pass to the helper class.
@@ -294,7 +296,7 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
     // Populate every object in the list.
     for (neighborhood <- neighborhoods) {
       val coordinates: Array[JTSCoordinate] = neighborhood.geom.getCoordinates.map(c => new JTSCoordinate(c.x, c.y))
-      val auditedStreetsIntersectingTheNeighborhood = auditedStreetEdges.filter(_.geom.intersects(neighborhood.geom))
+      val auditedStreetsIntersectingTheNeighborhood = auditedStreetEdges.filter(_._1.geom.intersects(neighborhood.geom))
       // set default values for everything to 0, so null values will be 0 as well.
       var coverage: Double = 0.0
       var accessScore: Double = 0.0
@@ -340,13 +342,13 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
     writer.println(header)
     val labelsForScore: List[AttributeForAccessScore] = getLabelsForScore(version, coordinates)
     val allStreetEdges: List[StreetEdge] = StreetEdgeTable.selectStreetsIntersecting(coordinates(0), coordinates(2), coordinates(1), coordinates(3))
-    val auditedStreetEdges: List[StreetEdge] = StreetEdgeTable.selectAuditedStreetsIntersecting(coordinates(0), coordinates(2), coordinates(1), coordinates(3))
+    val auditedStreetEdges: List[(StreetEdge, Boolean)] = StreetEdgeTable.selectAuditedStreetsIntersecting(coordinates(0), coordinates(2), coordinates(1), coordinates(3))
     val neighborhoods: List[NamedRegion] = RegionTable.selectNamedNeighborhoodsWithin(coordinates(0), coordinates(2), coordinates(1), coordinates(3))
     val significance = Array(0.75, -1.0, -1.0, -1.0)
     // Write each row in the CSV.
     for (neighborhood <- neighborhoods) {
       val coordinates: Array[Coordinate] = neighborhood.geom.getCoordinates
-      val auditedStreetsIntersectingTheNeighborhood = auditedStreetEdges.filter(_.geom.intersects(neighborhood.geom))
+      val auditedStreetsIntersectingTheNeighborhood = auditedStreetEdges.filter(_._1.geom.intersects(neighborhood.geom))
       val coordStr: String = "\"[" + coordinates.map(c => "(" + c.x + "," + c.y + ")").mkString(",") + "]\""
       if (auditedStreetsIntersectingTheNeighborhood.nonEmpty) {
         val streetAccessScores: List[AccessScoreStreet] = computeAccessScoresForStreets(auditedStreetsIntersectingTheNeighborhood, labelsForScore)  // I'm just interested in getting the attributes
@@ -405,14 +407,14 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
     def featureCollection = {
       val labelsForScore: List[AttributeForAccessScore] = getLabelsForScore(version, coordinates)
       val allStreetEdges: List[StreetEdge] = StreetEdgeTable.selectStreetsIntersecting(coordinates(0), coordinates(2), coordinates(1), coordinates(3))
-      val auditedStreetEdges: List[StreetEdge] = StreetEdgeTable.selectAuditedStreetsIntersecting(coordinates(0), coordinates(2), coordinates(1), coordinates(3))
+      val auditedStreetEdges: List[(StreetEdge, Boolean)] = StreetEdgeTable.selectAuditedStreetsIntersecting(coordinates(0), coordinates(2), coordinates(1), coordinates(3))
       val neighborhoods: List[NamedRegion] = RegionTable.selectNamedNeighborhoodsWithin(coordinates(0), coordinates(2), coordinates(1), coordinates(3))
       val neighborhoodsJson = for (neighborhood <- neighborhoods) yield {
         val neighborhoodJson: JsonMultiPolygon[JsonLatLng] = neighborhood.geom.toJSON
 
         // Get access score
         // Element-wise sum of arrays: http://stackoverflow.com/questions/32878818/how-to-sum-up-every-column-of-a-scala-array
-        val auditedStreetsIntersectingTheNeighborhood = auditedStreetEdges.filter(_.geom.intersects(neighborhood.geom))
+        val auditedStreetsIntersectingTheNeighborhood = auditedStreetEdges.filter(_._1.geom.intersects(neighborhood.geom))
         if (auditedStreetsIntersectingTheNeighborhood.nonEmpty) {
           val streetAccessScores: List[AccessScoreStreet] = computeAccessScoresForStreets(auditedStreetsIntersectingTheNeighborhood, labelsForScore)  // I'm just interested in getting the attributes
           val averagedStreetFeatures = streetAccessScores.map(_.attributes).transpose.map(_.sum / streetAccessScores.size).toArray
@@ -498,7 +500,7 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
     if (filetype.isDefined && filetype.get == "csv") {
       val file = new java.io.File("access_score_streets.csv")
       val writer = new java.io.PrintStream(file)
-      val header: String = "Region ID,OSM ID,Access Score,Coordinates,Average Curb Ramp Score," + 
+      val header: String = "Region ID,OSM ID,Access Score,Coordinates,Audited,Average Curb Ramp Score," + 
                             "Average No Curb Ramp Score,Average Obstacle Score,Average Surface Problem Score," + 
                             "Curb Ramp Significance,No Curb Ramp Significance,Obstacle Significance," + 
                             "Surface Problem Significance"
@@ -508,7 +510,7 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
       for (streetAccessScore <- streetAccessScores) {
         val coordStr: String = "\"[" + streetAccessScore.streetEdge.geom.getCoordinates.map(c => "(" + c.x + "," + c.y + ")").mkString(",") + "]\""
         writer.println(streetAccessScore.streetEdge.streetEdgeId + "," + streetAccessScore.osmId + "," +
-                      streetAccessScore.score + "," + coordStr + "," +
+                      streetAccessScore.score + "," + coordStr + "," + streetAccessScore.audited + "," +
                       streetAccessScore.attributes(0) + "," + streetAccessScore.attributes(1) + "," + 
                       streetAccessScore.attributes(2) + "," + streetAccessScore.attributes(3) + "," + 
                       streetAccessScore.significance(0) + "," + streetAccessScore.significance(1) + "," + 
@@ -525,6 +527,7 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
             streetAccessScore.streetEdge.streetEdgeId,
             streetAccessScore.osmId,
             streetAccessScore.score,
+            streetAccessScore.audited,
             streetAccessScore.attributes,
             streetAccessScore.significance))
       }
@@ -552,8 +555,8 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
   def getAccessScoreStreetsGeneric(lat1: Double, lng1: Double, lat2: Double, lng2: Double, version: Int): List[AccessScoreStreet]  = {
     val coordinates = Array(min(lat1, lat2), max(lat1, lat2), min(lng1, lng2), max(lng1, lng2))
     // Retrieve data and cluster them by location and label type.
-    val streetEdges: List[StreetEdge] = StreetEdgeTable.selectAuditedStreetsWithin(coordinates(0), coordinates(2), coordinates(1), coordinates(3))
-    computeAccessScoresForStreets(streetEdges, getLabelsForScore(version, coordinates)) 
+    val streetEdges: List[(StreetEdge, Boolean)] = StreetEdgeTable.selectStreetsWithin(coordinates(0), coordinates(2), coordinates(1), coordinates(3))
+    computeAccessScoresForStreets(streetEdges, getLabelsForScore(version, coordinates))
   }
 
   // Helper methods
@@ -609,16 +612,16 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
     * @param labelLocations List of AttributeForAccessScore
     *
     */
-  def computeAccessScoresForStreets(streets: List[StreetEdge], labelLocations: List[AttributeForAccessScore]): List[AccessScoreStreet] = {
+  def computeAccessScoresForStreets(streets: List[(StreetEdge, Boolean)], labelLocations: List[AttributeForAccessScore]): List[AccessScoreStreet] = {
     val radius = 3.0E-4  // Approximately 10 meters
     val pm = new PrecisionModel()
     val srid = 4326
     val factory: GeometryFactory = new GeometryFactory(pm, srid)
 
-    val streetsWithOsmWayIds: List[(StreetEdge, OsmWayStreetEdge)] = OsmWayStreetEdgeTable.selectOsmWayIdsForStreets(streets)
+    val streetsWithOsmWayIds: List[(StreetEdge, Boolean, OsmWayStreetEdge)] = OsmWayStreetEdgeTable.selectOsmWayIdsForStreets(streets)
 
     val streetAccessScores = streetsWithOsmWayIds.map { item =>
-      val (edge: StreetEdge, osmStreetId: OsmWayStreetEdge) = item;
+      val (edge: StreetEdge, audited: Boolean, osmStreetId: OsmWayStreetEdge) = item;
       // Expand each edge a little bit and count the number of accessibility attributes.
       val buffer: Geometry = edge.geom.buffer(radius)
 
@@ -640,7 +643,7 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
       val attributes = Array(labelCounter("CurbRamp"), labelCounter("NoCurbRamp"), labelCounter("Obstacle"), labelCounter("SurfaceProblem")).map(_.toDouble)
       val significance = Array(0.75, -1.0, -1.0, -1.0)
       val accessScore: Double = computeAccessScore(attributes, significance)
-      AccessScoreStreet(edge, osmStreetId.osmWayId, accessScore, attributes, significance)
+      AccessScoreStreet(edge, osmStreetId.osmWayId, accessScore, audited, attributes, significance)
     }
     streetAccessScores
   }

--- a/app/controllers/helper/ShapefilesCreatorHelper.java
+++ b/app/controllers/helper/ShapefilesCreatorHelper.java
@@ -247,6 +247,7 @@ public class ShapefilesCreatorHelper {
                         + "streetId:Integer," // StreetId
                         + "osmWayId:Integer," // osmWayId
                         + "score:Double," // street score
+                        + "audited:Boolean," // boolean representing whether the street is audited
                         + "sigRamp:Double," // curb ramp significance score
                         + "sigNoRamp:Double," // no Curb ramp significance score
                         + "sigObs:Double," // obstacle significance score
@@ -275,6 +276,7 @@ public class ShapefilesCreatorHelper {
             featureBuilder.add(s.streetID());
             featureBuilder.add(s.osmID());
             featureBuilder.add(s.score());
+            featureBuilder.add(s.audited());
             featureBuilder.add(s.significanceScores()[0]);
             featureBuilder.add(s.significanceScores()[1]);
             featureBuilder.add(s.significanceScores()[2]);

--- a/app/models/street/OsmWayStreetEdgeTable.scala
+++ b/app/models/street/OsmWayStreetEdgeTable.scala
@@ -25,14 +25,14 @@ object OsmWayStreetEdgeTable {
     * @return a list of (streetEdge, OsmWayStreetEdge) pairs where each list element represents a
     *         streetEdge and its corresponding OsmWayStreetEdge.
     */
-  def selectOsmWayIdsForStreets(streetEdges: List[(StreetEdge, Boolean)]): List[(StreetEdge, Boolean, OsmWayStreetEdge)] = db.withSession { implicit session =>
-    val streetEdgeIds: List[Int] = streetEdges.map(_._1.streetEdgeId)
+  def selectOsmWayIdsForStreets(streetEdges: List[StreetEdgeInformation]): List[(StreetEdgeInformation, OsmWayStreetEdge)] = db.withSession { implicit session =>
+    val streetEdgeIds: List[Int] = streetEdges.map(_.streetEdge.streetEdgeId)
     val streetEdgesWithOsmIds = for {
       _osm <- osmStreetTable if _osm.streetEdgeId inSetBind streetEdgeIds
     } yield (
       _osm
     )
 
-    (streetEdges zip streetEdgesWithOsmIds.list).map(x => (x._1._1, x._1._2, x._2))
+    (streetEdges zip streetEdgesWithOsmIds.list)
   }
 }

--- a/app/models/street/OsmWayStreetEdgeTable.scala
+++ b/app/models/street/OsmWayStreetEdgeTable.scala
@@ -25,14 +25,14 @@ object OsmWayStreetEdgeTable {
     * @return a list of (streetEdge, OsmWayStreetEdge) pairs where each list element represents a
     *         streetEdge and its corresponding OsmWayStreetEdge.
     */
-  def selectOsmWayIdsForStreets(streetEdges: List[StreetEdge]): List[(StreetEdge, OsmWayStreetEdge)] = db.withSession { implicit session =>
-    val streetEdgeIds: List[Int] = streetEdges.map(_.streetEdgeId)
+  def selectOsmWayIdsForStreets(streetEdges: List[(StreetEdge, Boolean)]): List[(StreetEdge, Boolean, OsmWayStreetEdge)] = db.withSession { implicit session =>
+    val streetEdgeIds: List[Int] = streetEdges.map(_._1.streetEdgeId)
     val streetEdgesWithOsmIds = for {
       _osm <- osmStreetTable if _osm.streetEdgeId inSetBind streetEdgeIds
     } yield (
       _osm
     )
 
-    streetEdges zip streetEdgesWithOsmIds.list
+    (streetEdges zip streetEdgesWithOsmIds.list).map(x => (x._1._1, x._1._2, x._2))
   }
 }

--- a/app/models/street/StreetEdgeTable.scala
+++ b/app/models/street/StreetEdgeTable.scala
@@ -382,7 +382,7 @@ object StreetEdgeTable {
     // http://gis.stackexchange.com/questions/60700/postgis-select-by-lat-long-bounding-box
     // http://postgis.net/docs/ST_MakeEnvelope.html
     val selectEdgeQuery = Q.query[(Double, Double, Double, Double), StreetEdgeInformation](
-      """SELECT DISTINCT(street_edge.street_edge_id),
+      """SELECT street_edge.street_edge_id,
         |       street_edge.geom,
         |       street_edge.x1,
         |       street_edge.y1,
@@ -391,9 +391,7 @@ object StreetEdgeTable {
         |       street_edge.way_type,
         |       street_edge.deleted,
         |       street_edge.timestamp,
-        |       (CASE
-        |           WHEN street_edge_priority.priority = 1 THEN FALSE ELSE TRUE
-        |       END) AS completed
+        |       TRUE AS completed
         |FROM street_edge
         |INNER JOIN street_edge_priority ON street_edge.street_edge_id = street_edge_priority.street_edge_id
         |WHERE street_edge.deleted = FALSE
@@ -407,7 +405,7 @@ object StreetEdgeTable {
 
   def selectStreetsWithin(minLat: Double, minLng: Double, maxLat: Double, maxLng: Double): List[StreetEdgeInformation] = db.withSession { implicit session =>
     val selectEdgeQuery = Q.query[(Double, Double, Double, Double), StreetEdgeInformation](
-      """SELECT DISTINCT(street_edge.street_edge_id),
+      """SELECT street_edge.street_edge_id,
         |       street_edge.geom,
         |       street_edge.x1,
         |       street_edge.y1,
@@ -416,9 +414,7 @@ object StreetEdgeTable {
         |       street_edge.way_type,
         |       street_edge.deleted,
         |       street_edge.timestamp,
-        |       (CASE
-        |           WHEN street_edge_priority.priority = 1 THEN FALSE ELSE TRUE
-        |       END) AS completed
+        |       street_edge_priority.priority < 1 AS completed
         |FROM street_edge
         |INNER JOIN street_edge_priority ON street_edge.street_edge_id = street_edge_priority.street_edge_id
         |WHERE street_edge.deleted = FALSE

--- a/app/models/street/StreetEdgeTable.scala
+++ b/app/models/street/StreetEdgeTable.scala
@@ -17,6 +17,8 @@ import scala.slick.jdbc.{GetResult, StaticQuery => Q}
 
 case class StreetEdge(streetEdgeId: Int, geom: LineString, x1: Float, y1: Float, x2: Float, y2: Float, wayType: String, deleted: Boolean, timestamp: Option[Timestamp])
 
+case class StreetEdgeInformation(val streetEdge: StreetEdge, val audited: Boolean)
+
 class StreetEdgeTable(tag: Tag) extends Table[StreetEdge](tag, Some("sidewalk"), "street_edge") {
   def streetEdgeId = column[Int]("street_edge_id", O.PrimaryKey)
   def geom = column[LineString]("geom")
@@ -50,6 +52,20 @@ object StreetEdgeTable {
     val deleted = r.nextBoolean
     val timestamp = r.nextTimestampOption
     StreetEdge(streetEdgeId, geometry, x1, y1, x2, y2, wayType, deleted, timestamp)
+  })
+
+  implicit val streetEdgeInformationConverter = GetResult[StreetEdgeInformation](r => {
+    val streetEdgeId = r.nextInt
+    val geometry = r.nextGeometry[LineString]
+    val x1 = r.nextFloat
+    val y1 = r.nextFloat
+    val x2 = r.nextFloat
+    val y2 = r.nextFloat
+    val wayType = r.nextString
+    val deleted = r.nextBoolean
+    val timestamp = r.nextTimestampOption
+    val audited = r.nextBoolean
+    StreetEdgeInformation(StreetEdge(streetEdgeId, geometry, x1, y1, x2, y2, wayType, deleted, timestamp), audited)
   })
 
   val db = play.api.db.slick.DB
@@ -362,33 +378,10 @@ object StreetEdgeTable {
     edges
   }
 
-  def selectAuditedStreetsIntersecting(minLat: Double, minLng: Double, maxLat: Double, maxLng: Double): List[(StreetEdge, Boolean)] = db.withSession { implicit session =>
+  def selectAuditedStreetsIntersecting(minLat: Double, minLng: Double, maxLat: Double, maxLng: Double): List[StreetEdgeInformation] = db.withSession { implicit session =>
     // http://gis.stackexchange.com/questions/60700/postgis-select-by-lat-long-bounding-box
     // http://postgis.net/docs/ST_MakeEnvelope.html
-    val selectEdgeQuery = Q.query[(Double, Double, Double, Double), (StreetEdge, Boolean)](
-      """SELECT DISTINCT(street_edge.street_edge_id),
-        |       street_edge.geom,
-        |       street_edge.x1,
-        |       street_edge.y1,
-        |       street_edge.x2,
-        |       street_edge.y2,
-        |       street_edge.way_type,
-        |       street_edge.deleted,
-        |       street_edge.timestamp,
-        |       audit_task.completed
-        |FROM street_edge
-        |INNER JOIN audit_task ON street_edge.street_edge_id = audit_task.street_edge_id
-        |WHERE street_edge.deleted = FALSE
-        |    AND ST_Intersects(street_edge.geom, ST_MakeEnvelope(?, ?, ?, ?, 4326))
-        |    AND audit_task.completed = TRUE""".stripMargin
-    )
-
-    val edges: List[(StreetEdge, Boolean)] = selectEdgeQuery((minLng, minLat, maxLng, maxLat)).list
-    edges
-  }
-
-  def selectStreetsWithin(minLat: Double, minLng: Double, maxLat: Double, maxLng: Double): List[(StreetEdge, Boolean)] = db.withSession { implicit session =>
-    val selectEdgeQuery = Q.query[(Double, Double, Double, Double), (StreetEdge, Boolean)](
+    val selectEdgeQuery = Q.query[(Double, Double, Double, Double), StreetEdgeInformation](
       """SELECT DISTINCT(street_edge.street_edge_id),
         |       street_edge.geom,
         |       street_edge.x1,
@@ -399,21 +392,21 @@ object StreetEdgeTable {
         |       street_edge.deleted,
         |       street_edge.timestamp,
         |       (CASE
-        |           WHEN (SUM(CASE WHEN (audit_task.completed = TRUE) THEN 1 ELSE 0 END) > 0) THEN TRUE ELSE FALSE
+        |           WHEN street_edge_priority.priority = 1 THEN FALSE ELSE TRUE
         |       END) AS completed
         |FROM street_edge
-        |LEFT JOIN audit_task ON street_edge.street_edge_id = audit_task.street_edge_id
+        |INNER JOIN street_edge_priority ON street_edge.street_edge_id = street_edge_priority.street_edge_id
         |WHERE street_edge.deleted = FALSE
-        |    AND ST_Within(street_edge.geom, ST_MakeEnvelope(?, ?, ?, ?, 4326))
-        |GROUP BY street_edge.street_edge_id""".stripMargin
+        |    AND ST_Intersects(street_edge.geom, ST_MakeEnvelope(?, ?, ?, ?, 4326))
+        |    AND street_edge_priority.priority < 1""".stripMargin
     )
 
-    val edges: List[(StreetEdge, Boolean)] = selectEdgeQuery((minLng, minLat, maxLng, maxLat)).list
+    val edges: List[StreetEdgeInformation] = selectEdgeQuery((minLng, minLat, maxLng, maxLat)).list
     edges
   }
 
-  def selectAuditedStreetsWithin(minLat: Double, minLng: Double, maxLat: Double, maxLng: Double): List[StreetEdge] = db.withSession { implicit session =>
-    val selectEdgeQuery = Q.query[(Double, Double, Double, Double), StreetEdge](
+  def selectStreetsWithin(minLat: Double, minLng: Double, maxLat: Double, maxLng: Double): List[StreetEdgeInformation] = db.withSession { implicit session =>
+    val selectEdgeQuery = Q.query[(Double, Double, Double, Double), StreetEdgeInformation](
       """SELECT DISTINCT(street_edge.street_edge_id),
         |       street_edge.geom,
         |       street_edge.x1,
@@ -422,15 +415,17 @@ object StreetEdgeTable {
         |       street_edge.y2,
         |       street_edge.way_type,
         |       street_edge.deleted,
-        |       street_edge.timestamp
+        |       street_edge.timestamp,
+        |       (CASE
+        |           WHEN street_edge_priority.priority = 1 THEN FALSE ELSE TRUE
+        |       END) AS completed
         |FROM street_edge
-        |INNER JOIN audit_task ON street_edge.street_edge_id = audit_task.street_edge_id
+        |INNER JOIN street_edge_priority ON street_edge.street_edge_id = street_edge_priority.street_edge_id
         |WHERE street_edge.deleted = FALSE
-        |    AND ST_Within(street_edge.geom, ST_MakeEnvelope(?, ?, ?, ?, 4326))
-        |    AND audit_task.completed = TRUE""".stripMargin
+        |    AND ST_Intersects(street_edge.geom, ST_MakeEnvelope(?, ?, ?, ?, 4326))""".stripMargin
     )
 
-    val edges: List[StreetEdge] = selectEdgeQuery((minLng, minLat, maxLng, maxLat)).list
+    val edges: List[StreetEdgeInformation] = selectEdgeQuery((minLng, minLat, maxLng, maxLat)).list
     edges
   }
 }

--- a/app/models/street/StreetEdgeTable.scala
+++ b/app/models/street/StreetEdgeTable.scala
@@ -402,7 +402,7 @@ object StreetEdgeTable {
         |           WHEN (SUM(CASE WHEN (audit_task.completed = TRUE) THEN 1 ELSE 0 END) > 0) THEN TRUE ELSE FALSE
         |       END) AS completed
         |FROM street_edge
-        |INNER JOIN audit_task ON street_edge.street_edge_id = audit_task.street_edge_id
+        |LEFT JOIN audit_task ON street_edge.street_edge_id = audit_task.street_edge_id
         |WHERE street_edge.deleted = FALSE
         |    AND ST_Within(street_edge.geom, ST_MakeEnvelope(?, ?, ?, ?, 4326))
         |GROUP BY street_edge.street_edge_id""".stripMargin

--- a/public/javascripts/developer.js
+++ b/public/javascripts/developer.js
@@ -113,8 +113,8 @@ $(document).ready(function () {
                 return {
                     weight: 5,
                     opacity:0.7,
-                    color: getColor(feature.properties.score),
-                    dashArray: '3'
+                    color: feature.properties.audited ? getColor(feature.properties.score) : 'gray',
+                    dashArray: '1'
                 }
             }
 


### PR DESCRIPTION
Resolves #2874

Adds a flag to the `/streets/` API representing whether each street has been audited yet. The API now returns all streets in the bounding box, rather than just audited streets.
- A street is marked as audited as long as it has at least one corresponding audit task and that audit task is complete. It is marked false otherwise.
-  The `StreetAttributeSignificance` class used by the `/streets/` API is also used in the calculations for the `/neighborhoods/` API, so some of its code also had to be updated to ignore the added flag. I could also add a similar metric the the `/neighborhoods/` API to represent the percent of streets audited if that's of interest.

##### Before/After screenshots
Before:
<img width="843" alt="Screen Shot 2022-08-30 at 3 52 21 PM" src="https://user-images.githubusercontent.com/50668250/187532928-e5f7b378-a19b-4566-90a9-f91c674ea03b.png">
<img width="663" alt="Screen Shot 2022-08-30 at 3 53 52 PM" src="https://user-images.githubusercontent.com/50668250/187532943-80a3188b-48c0-4350-ae55-ef1fdfdd3a5a.png">

After:
<img width="806" alt="Screen Shot 2022-08-30 at 3 51 50 PM" src="https://user-images.githubusercontent.com/50668250/187533065-ed014dd6-4a2c-4275-a326-d1e523d04f93.png">
<img width="655" alt="Screen Shot 2022-08-30 at 3 53 33 PM" src="https://user-images.githubusercontent.com/50668250/187533076-ddda6c23-cf69-45a2-adc1-2e567a402a0a.png">

##### Testing instructions
1. Run branch locally
2. Navigate to the API page (`/api/`)
3. Click on the example requests under **Access Score: Streets**, and edit request URLs to test different requests. Check that all streets are represented by the returned file and that there is an `audited` flag representing whether each street is audited
4. Also try requests for the `/neighborhoods/` API (examples of this can be found under **Access Score: Neighborhoods** on the API page). This API should be working exactly as it was before
