### PR TITLE
Improve consistency/quality of data across the site

### DIFF
--- a/app/controllers/AttributeController.scala
+++ b/app/controllers/AttributeController.scala
@@ -63,16 +63,9 @@ class AttributeController @Inject() (implicit val env: Environment[User, Session
     *
     * @param clusteringType One of "singleUser", "multiUser", or "both".
     */
-  def runClustering(clusteringType: String, hoursCutoff: Option[Int]) = UserAwareAction.async { implicit request =>
+  def runClustering(clusteringType: String) = UserAwareAction.async { implicit request =>
     if (isAdmin(request.identity)) {
-      val cutoffTime: Timestamp = hoursCutoff match {
-        case Some(hours) =>
-          val msCutoff: Long = hours * 3600000L
-          new Timestamp(Instant.now.toEpochMilli - msCutoff)
-        case None =>
-          new Timestamp(Instant.EPOCH.toEpochMilli)
-      }
-      val json = AttributeControllerHelper.runClustering(clusteringType, cutoffTime)
+      val json = AttributeControllerHelper.runClustering(clusteringType)
       Future.successful(Ok(json))
     } else {
       Future.successful(Redirect("/"))

--- a/app/models/attribute/GlobalAttributeTable.scala
+++ b/app/models/attribute/GlobalAttributeTable.scala
@@ -200,7 +200,7 @@ object GlobalAttributeTable {
       _ga <- globalAttributes
       _gaua <- GlobalAttributeUserAttributeTable.globalAttributeUserAttributes if _ga.globalAttributeId === _gaua.globalAttributeId
       _ual <- UserAttributeLabelTable.userAttributeLabels if _gaua.userAttributeId === _ual.userAttributeId
-      _l <- LabelTable.labels if _ual.labelId === _l.labelId
+      _l <- LabelTable.labelsUnfiltered if _ual.labelId === _l.labelId
     } yield (_ga.globalAttributeId, _l.agreeCount, _l.disagreeCount, _l.notsureCount))
       .groupBy(_._1)
       .map { case (attrId, group) => (attrId, group.map(_._2).sum, group.map(_._3).sum, group.map(_._4).sum) }

--- a/app/models/attribute/UserClusteringSessionTable.scala
+++ b/app/models/attribute/UserClusteringSessionTable.scala
@@ -71,7 +71,7 @@ object UserClusteringSessionTable {
     val labels = for {
       _mission <- MissionTable.missions if _mission.userId === userId
       _region <- RegionTable.regions if _mission.regionId === _region.regionId
-      _lab <- LabelTable.labelsWithoutDeletedOrOnboarding if _lab.missionId === _mission.missionId
+      _lab <- LabelTable.labels if _lab.missionId === _mission.missionId
       _latlng <- LabelTable.labelPoints if _lab.labelId === _latlng.labelId
       _type <- LabelTable.labelTypes if _lab.labelTypeId === _type.labelTypeId
       if _region.deleted === false &&

--- a/app/models/attribute/UserClusteringSessionTable.scala
+++ b/app/models/attribute/UserClusteringSessionTable.scala
@@ -16,8 +16,8 @@ import scala.language.postfixOps
 case class LabelToCluster(userId: String,
                           labelId: Int,
                           labelType: String,
-                          lat: Option[Float],
-                          lng: Option[Float],
+                          lat: Float,
+                          lng: Float,
                           severity: Option[Int],
                           temporary: Boolean) {
   /**
@@ -60,7 +60,7 @@ object UserClusteringSessionTable {
   val userClusteringSessions: TableQuery[UserClusteringSessionTable] = TableQuery[UserClusteringSessionTable]
 
   implicit val labelToClusterConverter = GetResult[LabelToCluster](r => {
-    LabelToCluster(r.nextString, r.nextInt, r.nextString, r.nextFloatOption, r.nextFloatOption, r.nextIntOption, r.nextBoolean)
+    LabelToCluster(r.nextString, r.nextInt, r.nextString, r.nextFloat, r.nextFloat, r.nextIntOption, r.nextBoolean)
   })
 
   /**
@@ -78,7 +78,8 @@ object UserClusteringSessionTable {
       _type <- LabelTable.labelTypes if _lab.labelTypeId === _type.labelTypeId
       if _region.deleted === false
       if _lab.correct || (_userStat.highQuality && _lab.correct.isEmpty)
-    } yield (_mission.userId, _lab.labelId, _type.labelType, _latlng.lat, _latlng.lng, _lab.severity, _lab.temporary)
+      if _latlng.lat.isDefined && _latlng.lng.isDefined
+    } yield (_mission.userId, _lab.labelId, _type.labelType, _latlng.lat.get, _latlng.lng.get, _lab.severity, _lab.temporary)
 
     labels.list.map(LabelToCluster.tupled)
   }
@@ -96,8 +97,8 @@ object UserClusteringSessionTable {
       _sess.userId,
       _att.userAttributeId,
       _type.labelType,
-      _att.lat.?,
-      _att.lng.?,
+      _att.lat,
+      _att.lng,
       _att.severity,
       _att.temporary
     )

--- a/app/models/audit/AuditTaskTable.scala
+++ b/app/models/audit/AuditTaskTable.scala
@@ -278,7 +278,7 @@ object AuditTaskTable {
     } yield (_users.userId, _users.username, _tasks.auditTaskId, _tasks.streetEdgeId, _tasks.taskStart, _tasks.taskEnd)
 
     val userTaskLabels = for {
-      (_userTasks, _labels) <- userTasks.leftJoin(LabelTable.labelsWithoutDeletedOrOnboarding).on(_._3 === _.auditTaskId)
+      (_userTasks, _labels) <- userTasks.leftJoin(LabelTable.labelsWithExcludedUsers).on(_._3 === _.auditTaskId)
     } yield (_userTasks._1, _userTasks._2, _userTasks._3, _userTasks._4, _userTasks._5, _userTasks._6, _labels.labelId.?, _labels.temporaryLabelId, _labels.labelTypeId.?)
 
     val tasksWithLabels = for {

--- a/app/models/daos/slick/UserDAOSlick.scala
+++ b/app/models/daos/slick/UserDAOSlick.scala
@@ -159,7 +159,7 @@ object UserDAOSlick {
       _userRole <- userRoleTable if _user.userId === _userRole.userId
       _role <- roleTable if _userRole.roleId === _role.roleId
       _mission <- MissionTable.missions if _user.userId === _mission.userId
-      _label <- LabelTable.labelsWithoutDeleted if _mission.missionId === _label.missionId
+      _label <- LabelTable.labelsWithTutorialAndExcludedUsers if _mission.missionId === _label.missionId
       if _role.role === "Anonymous"
     } yield _user).groupBy(x => x).map(_._1)
 
@@ -496,7 +496,7 @@ object UserDAOSlick {
 
     // Map(user_id: String -> label_count: Int).
     val labelCounts =
-      AuditTaskTable.auditTasks.innerJoin(LabelTable.labelsWithoutDeleted).on(_.auditTaskId === _.auditTaskId)
+      AuditTaskTable.auditTasks.innerJoin(LabelTable.labelsWithTutorialAndExcludedUsers).on(_.auditTaskId === _.auditTaskId)
         .groupBy(_._1.userId).map { case (_userId, group) => (_userId, group.length) }.list.toMap
 
     // Map(user_id: String -> (role: String, total: Int, agreed: Int, disagreed: Int, notsure: Int)).

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -622,7 +622,7 @@ object LabelTable {
       _a <- auditTasks if _lb.auditTaskId === _a.auditTaskId
       _us <- UserStatTable.userStats if _a.userId === _us.userId
       if _lb.labelTypeId === labelTypeId
-      if _us.highQuality
+      if _us.highQuality || (_lb.correct.isDefined && _lb.correct.get === true)
       if _lb.severity.isEmpty || (_lb.severity inSet severity)
     } yield (_lb, _lp, _lt.labelType)
 
@@ -675,7 +675,7 @@ object LabelTable {
       _lp <- labelPoints if _lb.labelId === _lp.labelId
       _a <- auditTasks if _lb.auditTaskId === _a.auditTaskId
       _us <- UserStatTable.userStats if _a.userId === _us.userId
-      if _us.highQuality
+      if _us.highQuality || (_lb.correct.isDefined && _lb.correct.get === true)
     } yield (_lb, _lp, _lt.labelType)
 
     // If severities are specified, filter by whether a label has a valid severity.
@@ -739,7 +739,8 @@ object LabelTable {
       _lp <- labelPoints if _lb.labelId === _lp.labelId
       _a <- auditTasks if _lb.auditTaskId === _a.auditTaskId
       _us <- UserStatTable.userStats if _a.userId === _us.userId
-      if _lb.labelTypeId === labelTypeId && _us.highQuality
+      if _lb.labelTypeId === labelTypeId
+      if _us.highQuality || (_lb.correct.isDefined && _lb.correct.get === true)
     } yield (_lb, _lp, _lt.labelType)
 
     // Filter out labels already grabbed before.

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -1020,8 +1020,12 @@ object LabelTable {
         |FROM label
         |INNER JOIN label_type ON label.label_type_id = label_type.label_type_id
         |INNER JOIN label_point ON label.label_id = label_point.label_id
-        |WHERE label.deleted = false
+        |INNER JOIN mission ON label.mission_id = mission.mission_id
+        |INNER JOIN user_stat ON mission.user_id = user_stat.user_id
+        |WHERE label.deleted = FALSE
+        |    AND label.tutorial = FALSE
         |    AND label_point.lat IS NOT NULL
+        |    AND user_stat.exclude_manual = FALSE
         |    AND ST_Intersects(label_point.geom, ST_MakeEnvelope(?, ?, ?, ?, 4326))""".stripMargin
     )
     selectLabelLocationQuery((minLng, minLat, maxLng, maxLat)).list

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -791,11 +791,14 @@ object LabelTable {
       _lt <- labelTypes if _lb.labelTypeId === _lt.labelTypeId
       _lp <- labelPoints if _lb.labelId === _lp.labelId
       _a <- auditTasks if _lb.auditTaskId === _a.auditTaskId
-      _vc <- _validationsWithComments if _lb.labelId === _vc._1
       _gd <- gsvData if _lb.gsvPanoramaId === _gd.gsvPanoramaId
+      _vc <- _validationsWithComments if _lb.labelId === _vc._1
+      _us <- UserStatTable.userStats if _vc._3 === _us.userId
       if _m.userId === userId.toString && // Only include the given user's labels.
         _vc._3 =!= userId.toString && // Exclude any cases where the user may have validated their own label.
         _vc._2 === 2 && // Only times where users validated as incorrect.
+        _us.excludeManual === false && // Don't use validations from excluded users
+        _us.highQuality === true && // For now we only include validations from high quality users.
         _gd.expired === false && // Only include those with non-expired GSV imagery.
         _lb.correct.isDefined && _lb.correct === false && // Exclude outlier validations on a correct label.
         (_lt.labelType inSet labTypes) // Only include given label types.

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -82,7 +82,7 @@ object LabelTable {
   import MyPostgresDriver.plainImplicits._
   
   val db = play.api.db.slick.DB
-  val labels = TableQuery[LabelTable]
+  val labelsUnfiltered = TableQuery[LabelTable]
   val auditTasks = TableQuery[AuditTaskTable]
   val gsvData = TableQuery[GSVDataTable]
   val labelTypes = TableQuery[LabelTypeTable]
@@ -96,18 +96,42 @@ object LabelTable {
   val userRoles = TableQuery[UserRoleTable]
   val roleTable = TableQuery[RoleTable]
 
-  val labelsWithoutDeleted = labels.filter(_.deleted === false)
   val neighborhoods = regions.filter(_.deleted === false)
 
   // Grab city id of database and the associated tutorial street id for the city
   val cityStr: String = Play.configuration.getString("city-id").get
   val tutorialStreetId: Int = Play.configuration.getInt("city-params.tutorial-street-edge-id." + cityStr).get
 
-  // Filters out the labels placed during onboarding (aka panoramas that are used during onboarding
-  // Onboarding labels have to be filtered out before a user's labeling frequency is computed
-  val labelsWithoutDeletedOrOnboarding = labelsWithoutDeleted.filter(_.tutorial === false)
+  // This subquery gets the most commonly accessed set of labels. It removes labels that have been deleted, labels from
+  // the tutorial, and labels from users where `exclude_manual=TRUE` in the `user_stat` table.
+  val labels = labelsUnfiltered
+    .innerJoin(auditTasks).on(_.auditTaskId === _.auditTaskId)
+    .innerJoin(UserStatTable.userStats).on(_._2.userId === _.userId)
+    .filterNot { case ((_l, _at), _us) =>
+      _l.deleted || _l.tutorial || _l.streetEdgeId === tutorialStreetId || _at.streetEdgeId === tutorialStreetId ||
+        _us.excludeManual
+    }.map(_._1._1)
 
-    // Defines some common fields for a label metadata, which allows us to create generic functions using these fields.
+  // Subquery for labels without deleted or tutorial ones, but includes "excluded" users. You might need to include
+  // these users if you're displaying a page for one of those users (like the user dashboard).
+  val labelsWithExcludedUsers = labelsUnfiltered
+    .innerJoin(auditTasks).on(_.auditTaskId === _.auditTaskId)
+    .filterNot { case (_l, _at) =>
+      _l.deleted || _l.tutorial || _l.streetEdgeId === tutorialStreetId || _at.streetEdgeId === tutorialStreetId
+    }.map(_._1)
+
+  // Subquery for labels without deleted ones, but includes tutorial labels and labels from "excluded" users. You might
+  // need to include these users if you're displaying a page for one of those users (like the user dashboard).
+  val labelsWithTutorialAndExcludedUsers = labelsUnfiltered.filter(_.deleted === false)
+
+  // Subquery for labels without deleted ones or labels from "excluded" users, but includes tutorial labels.
+  val labelsWithTutorial = labelsUnfiltered
+    .innerJoin(auditTasks).on(_.auditTaskId === _.auditTaskId)
+    .innerJoin(UserStatTable.userStats).on(_._2.userId === _.userId)
+    .filterNot { case ((_l, _at), _us) => _l.deleted || _us.excludeManual }
+    .map(_._1._1)
+
+  // Defines some common fields for a label metadata, which allows us to create generic functions using these fields.
   trait BasicLabelMetadata {
     val labelId: Int
     val labelType: String
@@ -205,17 +229,17 @@ object LabelTable {
   def find(tempLabelId: Int, userId: UUID): Option[Int] = db.withSession { implicit session =>
     (for {
       m <- missions
-      l <- labels if l.missionId === m.missionId
+      l <- labelsUnfiltered if l.missionId === m.missionId
       if l.temporaryLabelId === tempLabelId && m.userId === userId.toString
     } yield l.labelId).firstOption
   }
 
-  def countLabels: Int = db.withTransaction(implicit session =>
-    labels.filter(_.deleted === false).length.run
+  def countLabels: Int = db.withSession(implicit session =>
+    labelsWithTutorial.length.run
   )
 
-  def countLabels(labelTypeString: String): Int = db.withTransaction(implicit session =>
-    labels.filter(_.deleted === false).filter(_.labelTypeId === LabelTypeTable.labelTypeToId(labelTypeString)).length.run
+  def countLabels(labelType: String): Int = db.withSession(implicit session =>
+    labelsWithTutorial.filter(_.labelTypeId === LabelTypeTable.labelTypeToId(labelType)).length.run
   )
 
   /*
@@ -297,7 +321,7 @@ object LabelTable {
   def countLabels(userId: UUID): Int = db.withSession { implicit session =>
     val tasks = auditTasks.filter(_.userId === userId.toString)
     val _labels = for {
-      (_tasks, _labels) <- tasks.innerJoin(labelsWithoutDeletedOrOnboarding).on(_.auditTaskId === _.auditTaskId)
+      (_tasks, _labels) <- tasks.innerJoin(labelsWithExcludedUsers).on(_.auditTaskId === _.auditTaskId)
     } yield _labels
     _labels.length.run
   }
@@ -313,7 +337,7 @@ object LabelTable {
    * @return
    */
   def update(labelId: Int, deleted: Boolean, severity: Option[Int], temporary: Boolean, description: Option[String]): Int = db.withSession { implicit session =>
-    labels
+    labelsUnfiltered
       .filter(_.labelId === labelId)
       .map(l => (l.deleted, l.severity, l.temporary, l.description))
       .update((deleted, severity, temporary, description))
@@ -324,7 +348,7 @@ object LabelTable {
    */
   def save(label: Label): Int = db.withTransaction { implicit session =>
     val labelId: Int =
-      (labels returning labels.map(_.labelId)) += label
+      (labelsUnfiltered returning labelsUnfiltered.map(_.labelId)) += label
     labelId
   }
 
@@ -454,11 +478,8 @@ object LabelTable {
       _lb <- labels
       _gd <- gsvData if _gd.gsvPanoramaId === _lb.gsvPanoramaId
       _ms <- missions if _ms.missionId === _lb.missionId
-      _a <- auditTasks if _lb.auditTaskId === _a.auditTaskId
       _us <- UserStatTable.userStats if _ms.userId === _us.userId
-      if _lb.deleted === false && _lb.tutorial === false && _us.highQuality && !_us.excludeManual &&
-        _lb.streetEdgeId =!= tutorialStreetId && _a.streetEdgeId =!= tutorialStreetId && _gd.expired === false &&
-        _ms.userId =!= userIdString
+      if _us.highQuality && _gd.expired === false && _ms.userId =!= userIdString
     } yield (_lb.labelId, _lb.labelTypeId)
 
     // Left join with the labels that the user has already validated, then filter those out.
@@ -593,14 +614,14 @@ object LabelTable {
 
     // Grab labels and associated information if severity and tags satisfy query conditions.
     val _labelsUnfiltered = for {
-      _lb <- labelsWithoutDeletedOrOnboarding if !(_lb.labelId inSet deprioritized)
+      _lb <- labels if !(_lb.labelId inSet deprioritized)
       _lt <- labelTypes if _lb.labelTypeId === _lt.labelTypeId
       _lp <- labelPoints if _lb.labelId === _lp.labelId
-      _labeltags <- labelTags if _lb.labelId === _labeltags.labelId
-      _tags <- tagTable if _labeltags.tagId === _tags.tagId && ((_tags.tag inSet tags) || tags.isEmpty)
-      _a <- auditTasks if _lb.auditTaskId === _a.auditTaskId && _a.streetEdgeId =!= tutorialStreetId
+      _labelTags <- labelTags if _lb.labelId === _labelTags.labelId
+      _tags <- tagTable if _labelTags.tagId === _tags.tagId && ((_tags.tag inSet tags) || tags.isEmpty)
+      _a <- auditTasks if _lb.auditTaskId === _a.auditTaskId
       _us <- UserStatTable.userStats if _a.userId === _us.userId
-      if _lb.labelTypeId === labelTypeId && _lb.streetEdgeId =!= tutorialStreetId
+      if _lb.labelTypeId === labelTypeId
       if _us.highQuality
       if _lb.severity.isEmpty || (_lb.severity inSet severity)
     } yield (_lb, _lp, _lt.labelType)
@@ -649,12 +670,11 @@ object LabelTable {
 
     // Grab labels and associated information if severity and tags satisfy query conditions.
     val _labelsUnfiltered = for {
-      _lb <- labelsWithoutDeletedOrOnboarding if !(_lb.labelId inSet deprioritized)
+      _lb <- labels if !(_lb.labelId inSet deprioritized)
       _lt <- labelTypes if _lb.labelTypeId === _lt.labelTypeId && (_lt.labelTypeId inSet LabelTypeTable.primaryLabelTypeIds)
       _lp <- labelPoints if _lb.labelId === _lp.labelId
-      _a <- auditTasks if _lb.auditTaskId === _a.auditTaskId && _a.streetEdgeId =!= tutorialStreetId
+      _a <- auditTasks if _lb.auditTaskId === _a.auditTaskId
       _us <- UserStatTable.userStats if _a.userId === _us.userId
-      if _lb.streetEdgeId =!= tutorialStreetId
       if _us.highQuality
     } yield (_lb, _lp, _lt.labelType)
 
@@ -714,13 +734,12 @@ object LabelTable {
 
     // Grab labels and associated information if severity and tags satisfy query conditions.
     val _labelsUnfiltered = for {
-      _lb <- labelsWithoutDeletedOrOnboarding if !(_lb.labelId inSet deprioritized)
+      _lb <- labels if !(_lb.labelId inSet deprioritized)
       _lt <- labelTypes if _lb.labelTypeId === _lt.labelTypeId
       _lp <- labelPoints if _lb.labelId === _lp.labelId
-      _a <- auditTasks if _lb.auditTaskId === _a.auditTaskId && _a.streetEdgeId =!= tutorialStreetId
+      _a <- auditTasks if _lb.auditTaskId === _a.auditTaskId
       _us <- UserStatTable.userStats if _a.userId === _us.userId
-      if _lb.labelTypeId === labelTypeId && _lb.streetEdgeId =!= tutorialStreetId
-      if _us.highQuality
+      if _lb.labelTypeId === labelTypeId && _us.highQuality
     } yield (_lb, _lp, _lt.labelType)
 
     // Filter out labels already grabbed before.
@@ -767,15 +786,14 @@ object LabelTable {
 
     // Grab validations and associated label information for the given user's labels.
     val _validations = for {
-      _lb <- labelsWithoutDeletedOrOnboarding
+      _lb <- labelsWithExcludedUsers
       _m <- missions if _lb.missionId === _m.missionId
       _lt <- labelTypes if _lb.labelTypeId === _lt.labelTypeId
       _lp <- labelPoints if _lb.labelId === _lp.labelId
-      _a <- auditTasks if _lb.auditTaskId === _a.auditTaskId && _a.streetEdgeId =!= tutorialStreetId
+      _a <- auditTasks if _lb.auditTaskId === _a.auditTaskId
       _vc <- _validationsWithComments if _lb.labelId === _vc._1
       _gd <- gsvData if _lb.gsvPanoramaId === _gd.gsvPanoramaId
-      if _lb.streetEdgeId =!= tutorialStreetId && // Exclude tutorial labels.
-        _m.userId === userId.toString && // Only include the given user's labels.
+      if _m.userId === userId.toString && // Only include the given user's labels.
         _vc._3 =!= userId.toString && // Exclude any cases where the user may have validated their own label.
         _vc._2 === 2 && // Only times where users validated as incorrect.
         _gd.expired === false && // Only include those with non-expired GSV imagery.
@@ -976,14 +994,13 @@ object LabelTable {
     */
   def selectLocationsAndSeveritiesOfLabels: List[LabelLocationWithSeverity] = db.withSession { implicit session =>
     val _labels = for {
-      _l <- labelsWithoutDeletedOrOnboarding
+      _l <- labels
       _lType <- labelTypes if _l.labelTypeId === _lType.labelTypeId
       _lPoint <- labelPoints if _l.labelId === _lPoint.labelId
       _gsv <- gsvData if _l.gsvPanoramaId === _gsv.gsvPanoramaId
       _at <- auditTasks if _l.auditTaskId === _at.auditTaskId
       _us <- UserStatTable.userStats if _at.userId === _us.userId
       if _lPoint.lat.isDefined && _lPoint.lng.isDefined // Make sure they are NOT NULL so we can safely use .get later.
-      if _l.streetEdgeId =!= tutorialStreetId // Make sure they're not on the tutorial street.
     } yield (_l.labelId, _l.auditTaskId, _l.gsvPanoramaId, _lType.labelType, _lPoint.lat.get, _lPoint.lng.get, _l.correct, _gsv.expired, _us.highQuality, _l.severity)
 
     _labels.list.map(LabelLocationWithSeverity.tupled)
@@ -1015,16 +1032,13 @@ object LabelTable {
    */
   def getLabelLocations(userId: UUID): List[LabelLocation] = db.withSession { implicit session =>
     val _labels = for {
-      ((_auditTasks, _labels), _labelTypes) <- auditTasks leftJoin labelsWithoutDeletedOrOnboarding on(_.auditTaskId === _.auditTaskId) leftJoin labelTypes on (_._2.labelTypeId === _.labelTypeId)
-      if _auditTasks.userId === userId.toString
-    } yield (_labels.labelId, _labels.auditTaskId, _labels.gsvPanoramaId, _labelTypes.labelType, _labels.panoramaLat, _labels.panoramaLng)
-
-    val _points = for {
-      (l, p) <- _labels.innerJoin(labelPoints).on(_._1 === _.labelId)
-    } yield (l._1, l._2, l._3, l._4, p.lat.getOrElse(0.toFloat), p.lng.getOrElse(0.toFloat))
-
-    val labelLocationList: List[LabelLocation] = _points.list.map(label => LabelLocation(label._1, label._2, label._3, label._4, label._5, label._6))
-    labelLocationList
+      _l <- labelsWithExcludedUsers
+      _at <- auditTasks if _l.auditTaskId === _at.auditTaskId
+      _lt <- labelTypes if _l.labelTypeId === _lt.labelTypeId
+      _lp <- labelPoints if _l.labelId === _lp.labelId
+      if _at.userId === userId.toString
+    } yield (_l.labelId, _l.auditTaskId, _l.gsvPanoramaId, _lt.labelType, _lp.lat.getOrElse(0F), _lp.lng.getOrElse(0F))
+    _labels.list.map(LabelLocation.tupled)
   }
 
   def getLabelLocations(userId: UUID, regionId: Int): List[LabelLocation] = db.withSession { implicit session =>
@@ -1082,7 +1096,7 @@ object LabelTable {
       _userRole <- userRoles if _user.userId === _userRole.userId
       _role <- roleTable if _userRole.roleId === _role.roleId
       _audit <- auditTasks if _user.userId === _audit.userId
-      _label <- labelsWithoutDeleted if _audit.auditTaskId === _label.auditTaskId
+      _label <- labelsWithTutorial if _audit.auditTaskId === _label.auditTaskId
     } yield (_user.userId, _role.role, _label.labelId)
 
     // Counts the number of labels for each user by grouping by user_id and role.
@@ -1117,7 +1131,7 @@ object LabelTable {
         .map(_.missionId).firstOption
 
     recentMissionId match {
-      case Some(missionId) => labelsWithoutDeleted.filter(_.missionId === missionId).list
+      case Some(missionId) => labelsWithTutorialAndExcludedUsers.filter(_.missionId === missionId).list
       case None => List()
     }
   }
@@ -1163,14 +1177,14 @@ object LabelTable {
     )
     labelsInRegionQuery.list
   }
-  
+
   /**
     * Get next temp label id to be used. That would be the max used + 1, or just 1 if no labels in this task.
     */
   def nextTempLabelId(userId: UUID): Int = db.withSession { implicit session =>
       val userLabels = for {
         m <- missions if m.userId === userId.toString
-        l <- labels if l.missionId === m.missionId
+        l <- labelsUnfiltered if l.missionId === m.missionId
       } yield l.temporaryLabelId
       userLabels.max.run.map(x => x + 1).getOrElse(1)
   }
@@ -1192,11 +1206,7 @@ object LabelTable {
     (for {
       _l <- labels
       _lp <- labelPoints if _l.labelId === _lp.labelId
-      _at <- auditTasks if _l.auditTaskId === _at.auditTaskId
       _gsv <- gsvData if _l.gsvPanoramaId === _gsv.gsvPanoramaId
-      // Filter out deleted and tutorial labels.
-      if !_l.deleted
-      if !_l.tutorial && !(_l.streetEdgeId === tutorialStreetId) && !(_at.streetEdgeId === tutorialStreetId)
     } yield (
       _l.labelId, _gsv.gsvPanoramaId, _l.labelTypeId, _l.agreeCount, _l.disagreeCount, _l.notsureCount,
       _gsv.imageWidth, _gsv.imageHeight, _lp.svImageX, _lp.svImageY, _lp.canvasWidth, _lp.canvasHeight, _lp.canvasX,

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -616,16 +616,13 @@ object LabelTable {
       _a <- auditTasks if _lb.auditTaskId === _a.auditTaskId
       _us <- UserStatTable.userStats if _a.userId === _us.userId
       if _lb.labelTypeId === labelTypeId
-      if _us.highQuality || (_lb.correct.isDefined && _lb.correct.get === true)
+      if _us.highQuality || (_lb.correct.isDefined && _lb.correct === true)
       if _lb.disagreeCount < 3 || _lb.disagreeCount < _lb.agreeCount * 2
       if _lb.severity.isEmpty || (_lb.severity inSet severity)
     } yield (_lb, _lp, _lt.labelType)
 
-    // Could be optimized by grouping on fewer columns.
-    val _labelsGrouped = _labelsUnfiltered.groupBy(x => x).map(_._1)
-
     // Filter out labels already grabbed before.
-    val _labels = _labelsGrouped.filter(label => !(label._1.labelId inSet loadedLabelIds))
+    val _labels = _labelsUnfiltered.filter(label => !(label._1.labelId inSet loadedLabelIds))
 
     // Join with gsvData to add gsv data.
     val addGSVData = for {
@@ -643,8 +640,11 @@ object LabelTable {
       l._2.canvasX, l._2.canvasY, l._2.canvasWidth, l._2.canvasHeight, l._1.severity, l._1.temporary, l._1.description,
       v._2.?)
 
+    // Remove duplicates that we got from joining with the `label_tag` table.
+    val uniqueLabels = addValidations.groupBy(x => x).map(_._1)
+
     // Randomize and convert to LabelValidationMetadataWithoutTags.
-    val newRandomLabelsList = addValidations.sortBy(x => rand).list.map(LabelValidationMetadataWithoutTags.tupled)
+    val newRandomLabelsList = uniqueLabels.sortBy(x => rand).list.map(LabelValidationMetadataWithoutTags.tupled)
 
     // Take the first `n` labels with non-expired GSV imagery.
     checkForGsvImagery(newRandomLabelsList, n)
@@ -667,7 +667,7 @@ object LabelTable {
       _lp <- labelPoints if _lb.labelId === _lp.labelId
       _a <- auditTasks if _lb.auditTaskId === _a.auditTaskId
       _us <- UserStatTable.userStats if _a.userId === _us.userId
-      if _us.highQuality || (_lb.correct.isDefined && _lb.correct.get === true)
+      if _us.highQuality || (_lb.correct.isDefined && _lb.correct === true)
       if _lb.disagreeCount < 3 || _lb.disagreeCount < _lb.agreeCount * 2
     } yield (_lb, _lp, _lt.labelType)
 
@@ -727,7 +727,7 @@ object LabelTable {
       _a <- auditTasks if _lb.auditTaskId === _a.auditTaskId
       _us <- UserStatTable.userStats if _a.userId === _us.userId
       if _lb.labelTypeId === labelTypeId
-      if _us.highQuality || (_lb.correct.isDefined && _lb.correct.get === true)
+      if _us.highQuality || (_lb.correct.isDefined && _lb.correct === true)
       if _lb.disagreeCount < 3 || _lb.disagreeCount < _lb.agreeCount * 2
     } yield (_lb, _lp, _lt.labelType)
 

--- a/app/models/label/LabelValidationTable.scala
+++ b/app/models/label/LabelValidationTable.scala
@@ -210,7 +210,7 @@ object LabelValidationTable {
 
   /**
    * Calculates and returns the user accuracy for the supplied userId. The accuracy calculation is performed if and only
-   * if the 10 of the user's labels have been validated. A label is considered validated if it has either more agree
+   * if 10 of the user's labels have been validated. A label is considered validated if it has either more agree
    * votes than disagree votes, or more disagree votes than agree votes.
    */
   def getUserAccuracy(userId: UUID): Option[Float] = db.withSession { implicit session =>

--- a/app/models/label/LabelValidationTable.scala
+++ b/app/models/label/LabelValidationTable.scala
@@ -130,7 +130,7 @@ object LabelValidationTable {
     val oldValidation: Option[LabelValidation] =
       validationLabels.filter(x => x.labelId === label.labelId && x.userId === label.userId).firstOption
 
-    val excludedUser: Boolean = UserStatTable.userStats.filter(_.userId === label.userId).map(_.excludeManual).first
+    val excludedUser: Boolean = UserStatTable.userStats.filter(_.userId === label.userId).map(_.excluded).first
     val userThatAppliedLabel: String =
     labels.filter(_.labelId === label.labelId)
       .innerJoin(MissionTable.missions).on(_.missionId === _.missionId)

--- a/app/models/label/LabelValidationTable.scala
+++ b/app/models/label/LabelValidationTable.scala
@@ -236,7 +236,7 @@ object LabelValidationTable {
     */
   def getValidationCountsPerUser: List[(String, String, Int, Int, Int, Int)] = db.withSession { implicit session =>
     val labels = for {
-      _label <- LabelTable.labelsWithoutDeletedOrOnboarding
+      _label <- LabelTable.labelsWithExcludedUsers
       _mission <- MissionTable.missions if _label.missionId === _mission.missionId
       _user <- users if _user.username =!= "anonymous" && _user.userId === _mission.userId // User who placed the label
       _userRole <- userRoles if _user.userId === _userRole.userId

--- a/app/models/label/LabelValidationTable.scala
+++ b/app/models/label/LabelValidationTable.scala
@@ -130,11 +130,11 @@ object LabelValidationTable {
     val oldValidation: Option[LabelValidation] =
       validationLabels.filter(x => x.labelId === label.labelId && x.userId === label.userId).firstOption
 
-    val (userThatAppliedLabel, excludedUser): (String, Boolean) =
+    val excludedUser: Boolean = UserStatTable.userStats.filter(_.userId === label.userId).map(_.excludeManual).first
+    val userThatAppliedLabel: String =
     labels.filter(_.labelId === label.labelId)
       .innerJoin(MissionTable.missions).on(_.missionId === _.missionId)
-      .innerJoin(UserStatTable.userStats).on(_._2.userId === _.userId)
-      .map(x => (x._2.userId, x._2.excludeManual))
+      .map(_._2.userId)
       .list.head
 
     // If there was already a validation, update all the columns that might have changed. O/w just make a new entry.

--- a/app/models/street/StreetEdgePriorityTable.scala
+++ b/app/models/street/StreetEdgePriorityTable.scala
@@ -205,7 +205,7 @@ object StreetEdgePriorityTable {
     val completions = AuditTaskTable.completedTasks
       .groupBy(task => (task.streetEdgeId, task.userId)).map(_._1)  // select distinct on street edge id and user id
       .innerJoin(UserStatTable.getQualityOfUsers).on(_._2 === _._1)  // join on user_id
-      .filterNot(_._2._3) // filter out users marked with exclude_manual = TRUE
+      .filterNot(_._2._3) // filter out users marked with excluded = TRUE
       .map { case (_task, _qual) => (_task._1, _qual._2) }  // SELECT street_edge_id, is_good_user
 
     /********** Compute Audit Counts **********/

--- a/app/models/street/StreetEdgePriorityTable.scala
+++ b/app/models/street/StreetEdgePriorityTable.scala
@@ -205,7 +205,7 @@ object StreetEdgePriorityTable {
     val completions = AuditTaskTable.completedTasks
       .groupBy(task => (task.streetEdgeId, task.userId)).map(_._1)  // select distinct on street edge id and user id
       .innerJoin(UserStatTable.getQualityOfUsers).on(_._2 === _._1)  // join on user_id
-      .filterNot(_._2._3.getOrElse(false)) // filter out users marked with exclude_manual = TRUE
+      .filterNot(_._2._3) // filter out users marked with exclude_manual = TRUE
       .map { case (_task, _qual) => (_task._1, _qual._2) }  // SELECT street_edge_id, is_good_user
 
     /********** Compute Audit Counts **********/

--- a/app/models/street/StreetEdgeTable.scala
+++ b/app/models/street/StreetEdgeTable.scala
@@ -163,7 +163,7 @@ object StreetEdgeTable {
         for {
             tasks <- auditTaskQuery
             stats <- UserStatTable.userStats if tasks.userId === stats.userId
-            if stats.highQuality && (stats.excludeManual.isEmpty || !stats.excludeManual)
+            if stats.highQuality && !stats.excludeManual
         } yield tasks
       } else {
           auditTaskQuery
@@ -295,7 +295,7 @@ object StreetEdgeTable {
         for {
             tasks <- auditTasksQuery
             stats <- UserStatTable.userStats if tasks.userId === stats.userId
-            if stats.highQuality && (stats.excludeManual.isEmpty || !stats.excludeManual)
+            if stats.highQuality && !stats.excludeManual
         } yield tasks
       } else {
           auditTasksQuery

--- a/app/models/street/StreetEdgeTable.scala
+++ b/app/models/street/StreetEdgeTable.scala
@@ -163,7 +163,7 @@ object StreetEdgeTable {
         for {
             tasks <- auditTaskQuery
             stats <- UserStatTable.userStats if tasks.userId === stats.userId
-            if stats.highQuality && !stats.excludeManual
+            if stats.highQuality && !stats.excluded
         } yield tasks
       } else {
           auditTaskQuery
@@ -295,7 +295,7 @@ object StreetEdgeTable {
         for {
             tasks <- auditTasksQuery
             stats <- UserStatTable.userStats if tasks.userId === stats.userId
-            if stats.highQuality && !stats.excludeManual
+            if stats.highQuality && !stats.excluded
         } yield tasks
       } else {
           auditTasksQuery

--- a/app/models/user/UserStatTable.scala
+++ b/app/models/user/UserStatTable.scala
@@ -133,7 +133,7 @@ object UserStatTable {
     val usersWithLabels = for {
       _stat <- userStats if _stat.highQuality
       _mission <- MissionTable.auditMissions if _mission.userId === _stat.userId
-      _label <- LabelTable.labelsWithoutDeletedOrOnboarding if _mission.missionId === _label.missionId
+      _label <- LabelTable.labels if _mission.missionId === _label.missionId
       if (_label.correct.isEmpty || _label.correct === true) && // Filter out labels validated as incorrect.
         _label.timeCreated > cutoffTime
     } yield _stat.userId
@@ -202,7 +202,7 @@ object UserStatTable {
     // Compute label counts for each of those users.
     val labelCounts = (for {
       _mission <- MissionTable.auditMissions
-      _label <- LabelTable.labelsWithoutDeletedOrOnboarding if _mission.missionId === _label.missionId
+      _label <- LabelTable.labelsWithExcludedUsers if _mission.missionId === _label.missionId
       if _mission.userId inSet usersStatsToUpdate
     } yield (_mission.userId, _label.labelId)).groupBy(_._1).map(x => (x._1, x._2.length))
 
@@ -587,7 +587,7 @@ object UserStatTable {
     */
   def addUserStatIfNew(userId: UUID): Int = db.withTransaction { implicit session =>
     if (userStats.filter(_.userId === userId.toString).length.run == 0)
-      userStats.insert(UserStat(0, userId.toString, 0F, None, true, None, 0, None, None))
+      userStats.insert(UserStat(0, userId.toString, 0F, None, true, None, 0, None, false))
     else
       0
   }

--- a/app/models/user/UserStatTable.scala
+++ b/app/models/user/UserStatTable.scala
@@ -561,7 +561,8 @@ object UserStatTable {
          |        AND audit_task.street_edge_id <> ${LabelTable.tutorialStreetId}
          |    GROUP BY user_id
          |) label_counts ON user_stat.user_id = label_counts.user_id
-         |WHERE role.role <> 'Anonymous';""".stripMargin
+         |WHERE role.role <> 'Anonymous'
+         |    AND user_stat.exclude_manual = FALSE;""".stripMargin
     )
     statsQuery.list
   }

--- a/app/utils/actor/ClusterLabelAttributesActor.scala
+++ b/app/utils/actor/ClusterLabelAttributesActor.scala
@@ -6,8 +6,6 @@ import akka.actor.{Actor, Cancellable, Props}
 import controllers.helper.AttributeControllerHelper
 import play.api.Play.current
 import play.api.{Logger, Play}
-import java.sql.Timestamp
-import java.time.Instant
 import scala.concurrent.duration._
 
 // Template code comes from this helpful StackOverflow post:
@@ -64,10 +62,7 @@ class ClusterLabelAttributesActor extends Actor {
 
       val currentTimeStart: String = dateFormatter.format(Calendar.getInstance(TIMEZONE).getTime)
       Logger.info(s"Auto-scheduled clustering of label attributes starting at: $currentTimeStart")
-      // Update clusters for anyone who audited in the past 36 hours.
-      val msCutoff: Long = 36 * 3600000L
-      val cutoffTime: Timestamp = new Timestamp(Instant.now.toEpochMilli - msCutoff)
-      AttributeControllerHelper.runClustering("both", cutoffTime)
+      AttributeControllerHelper.runClustering("both")
       val currentEndTime: String = dateFormatter.format(Calendar.getInstance(TIMEZONE).getTime)
       Logger.info(s"Label attribute clustering completed at: $currentEndTime")
   }

--- a/conf/evolutions/default/161.sql
+++ b/conf/evolutions/default/161.sql
@@ -2,6 +2,52 @@
 UPDATE user_stat SET exclude_manual = FALSE WHERE exclude_manual IS NULL;
 ALTER TABLE user_stat ALTER COLUMN exclude_manual SET NOT NULL;
 
+UPDATE label
+SET (agree_count, disagree_count, notsure_count, correct) = (n_agree, n_disagree, n_notsure, is_correct)
+FROM (
+    SELECT label.label_id,
+           COUNT(CASE WHEN validation_result = 1 AND user_stat.user_id IS NOT NULL THEN 1 END) AS n_agree,
+           COUNT(CASE WHEN validation_result = 2 AND user_stat.user_id IS NOT NULL THEN 1 END) AS n_disagree,
+           COUNT(CASE WHEN validation_result = 3 AND user_stat.user_id IS NOT NULL THEN 1 END) AS n_notsure,
+           CASE
+               WHEN COUNT(CASE WHEN validation_result = 1 THEN 1 END) > COUNT(CASE WHEN validation_result = 2 THEN 1 END) THEN TRUE
+               WHEN COUNT(CASE WHEN validation_result = 2 THEN 1 END) > COUNT(CASE WHEN validation_result = 1 THEN 1 END) THEN FALSE
+               ELSE NULL
+               END AS is_correct
+    FROM label
+    LEFT JOIN mission ON mission.mission_id = label.mission_id
+    LEFT JOIN label_validation ON label.label_id = label_validation.label_id AND mission.user_id <> label_validation.user_id
+    LEFT JOIN user_stat ON label_validation.user_id = user_stat.user_id AND user_stat.exclude_manual = FALSE
+    GROUP BY label.label_id
+) AS validation_count
+    INNER JOIN label_validation ON validation_count.label_id = label_validation.label_id
+    INNER JOIN user_stat ON label_validation.user_id = user_stat.user_id
+WHERE label.label_id = validation_count.label_id
+    AND user_stat.exclude_manual = TRUE;
+
 # --- !Downs
+UPDATE label
+SET (agree_count, disagree_count, notsure_count, correct) = (n_agree, n_disagree, n_notsure, is_correct)
+FROM (
+    SELECT label.label_id,
+           COUNT(CASE WHEN validation_result = 1 AND user_stat.user_id IS NOT NULL THEN 1 END) AS n_agree,
+           COUNT(CASE WHEN validation_result = 2 AND user_stat.user_id IS NOT NULL THEN 1 END) AS n_disagree,
+           COUNT(CASE WHEN validation_result = 3 AND user_stat.user_id IS NOT NULL THEN 1 END) AS n_notsure,
+           CASE
+               WHEN COUNT(CASE WHEN validation_result = 1 THEN 1 END) > COUNT(CASE WHEN validation_result = 2 THEN 1 END) THEN TRUE
+               WHEN COUNT(CASE WHEN validation_result = 2 THEN 1 END) > COUNT(CASE WHEN validation_result = 1 THEN 1 END) THEN FALSE
+               ELSE NULL
+               END AS is_correct
+    FROM label
+    LEFT JOIN mission ON mission.mission_id = label.mission_id
+    LEFT JOIN label_validation ON label.label_id = label_validation.label_id AND mission.user_id <> label_validation.user_id
+    LEFT JOIN user_stat ON label_validation.user_id = user_stat.user_id
+    GROUP BY label.label_id
+) AS validation_count
+    INNER JOIN label_validation ON validation_count.label_id = label_validation.label_id
+    INNER JOIN user_stat ON label_validation.user_id = user_stat.user_id
+WHERE label.label_id = validation_count.label_id
+    AND user_stat.exclude_manual = TRUE;
+
 ALTER TABLE user_stat ALTER COLUMN exclude_manual DROP NOT NULL;
 UPDATE user_stat SET exclude_manual = NULL WHERE exclude_manual = FALSE;

--- a/conf/evolutions/default/161.sql
+++ b/conf/evolutions/default/161.sql
@@ -1,0 +1,7 @@
+# --- !Ups
+UPDATE user_stat SET exclude_manual = FALSE WHERE exclude_manual IS NULL;
+ALTER TABLE user_stat ALTER COLUMN exclude_manual SET NOT NULL;
+
+# --- !Downs
+ALTER TABLE user_stat ALTER COLUMN exclude_manual DROP NOT NULL;
+UPDATE user_stat SET exclude_manual = NULL WHERE exclude_manual = FALSE;

--- a/conf/evolutions/default/161.sql
+++ b/conf/evolutions/default/161.sql
@@ -25,7 +25,11 @@ FROM (
 WHERE label.label_id = validation_count.label_id
     AND user_stat.exclude_manual = TRUE;
 
+ALTER TABLE user_stat RENAME COLUMN exclude_manual TO excluded;
+
 # --- !Downs
+ALTER TABLE user_stat RENAME COLUMN excluded TO exclude_manual;
+
 UPDATE label
 SET (agree_count, disagree_count, notsure_count, correct) = (n_agree, n_disagree, n_notsure, is_correct)
 FROM (

--- a/conf/routes
+++ b/conf/routes
@@ -166,7 +166,7 @@ POST    /amtAssignment                                       @controllers.Missio
 
 # Clustering and Attributes
 GET     /clustering                                          @controllers.AttributeController.index
-GET     /runClustering                                       @controllers.AttributeController.runClustering(clusteringType: String ?= "both", hoursCutoff: Option[Int])
+GET     /runClustering                                       @controllers.AttributeController.runClustering(clusteringType: String ?= "both")
 GET     /userLabelsToCluster                                 @controllers.AttributeController.getUserLabelsToCluster(key: String, userId: String)
 GET     /clusteredLabelsInRegion                             @controllers.AttributeController.getClusteredLabelsInRegion(key: String, regionId: Int)
 POST    /singleUserClusteringResults                         @controllers.AttributeController.postSingleUserClusteringResults(key: String, userId: String)


### PR DESCRIPTION
Resolves #3013

We improve the quality of the data that we show on pages like Gallery and the API by removing labels from low quality users (unless their labels are marked as correct), and improve the consistency across our site and reusability of our code by making this consistent across the site.

We had been slowly rolling out filters to remove data from low quality users on various pages on the site, which led to inconsistencies and more custom code. This PR greatly improves on that issue. Full details can be found in #3013.

##### Things to check before submitting the PR
- [x] I've written a descriptive PR title.
- [x] I've added/updated comments for large or confusing blocks of code.
