### PR TITLE
Fixes various street and neighborhood API bugs

### DIFF
--- a/app/controllers/ProjectSidewalkAPIController.scala
+++ b/app/controllers/ProjectSidewalkAPIController.scala
@@ -16,7 +16,7 @@ import models.daos.slick.DBTableDefinitions.{DBUser, UserTable}
 import models.gsv.GSVDataTable
 import models.label.{LabelLocation, LabelTable}
 import models.street.{OsmWayStreetEdge, OsmWayStreetEdgeTable}
-import models.street.{StreetEdge, StreetEdgeInformation, StreetEdgeTable}
+import models.street.{StreetEdge, StreetEdgeInfo, StreetEdgeTable}
 import models.user.{User, UserStatTable, WebpageActivity, WebpageActivityTable}
 import play.api.Play.current
 import play.api.libs.json._
@@ -298,8 +298,8 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
   def getAccessScoreNeighborhoodsShapefile(coordinates: Array[Double]): java.io.File = {
     // Gather all of the data that will be written to the Shapefile.
     val labelsForScore: List[AttributeForAccessScore] = getLabelsForScore(version = 2, coordinates)
-    val streets: List[StreetEdgeInformation] = StreetEdgeTable.selectStreetsIntersecting(coordinates(0), coordinates(2), coordinates(1), coordinates(3))
-    val auditedStreets: List[StreetEdgeInformation] = streets.filter(_.audited)
+    val streets: List[StreetEdgeInfo] = StreetEdgeTable.selectStreetsIntersecting(coordinates(0), coordinates(2), coordinates(1), coordinates(3))
+    val auditedStreets: List[StreetEdgeInfo] = streets.filter(_.audited)
     val neighborhoods: List[NamedRegion] = RegionTable.selectNamedNeighborhoodsWithin(coordinates(0), coordinates(2), coordinates(1), coordinates(3))
     val significance: Array[Double] = Array(0.75, -1.0, -1.0, -1.0)
     // Create a list of NeighborhoodAttributeSignificance objects to pass to the helper class.
@@ -307,7 +307,7 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
     // Populate every object in the list.
     for (neighborhood <- neighborhoods) {
       val coordinates: Array[JTSCoordinate] = neighborhood.geom.getCoordinates.map(c => new JTSCoordinate(c.x, c.y))
-      val auditedStreetsIntersecting = auditedStreets.filter(_.streetEdge.geom.intersects(neighborhood.geom))
+      val auditedStreetsIntersecting = auditedStreets.filter(_.street.geom.intersects(neighborhood.geom))
       // set default values for everything to 0, so null values will be 0 as well.
       var coverage: Double = 0.0
       var accessScore: Double = 0.0
@@ -329,7 +329,7 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
         avgImageDate = avgImageAge.map(age => new Timestamp(age))
         avgLabelDate = avgLabelAge.map(age => new Timestamp(age))
         accessScore = computeAccessScore(averagedStreetFeatures, significance)
-        val streetsIntersecting = streets.filter(_.streetEdge.geom.intersects(neighborhood.geom))
+        val streetsIntersecting = streets.filter(_.street.geom.intersects(neighborhood.geom))
         coverage = auditedStreetsIntersecting.size.toDouble / streetsIntersecting.size
 
         assert(coverage <= 1.0)
@@ -367,14 +367,14 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
     // Write the column headers.
     writer.println(header)
     val labelsForScore: List[AttributeForAccessScore] = getLabelsForScore(version, coordinates)
-    val streets: List[StreetEdgeInformation] = StreetEdgeTable.selectStreetsIntersecting(coordinates(0), coordinates(2), coordinates(1), coordinates(3))
-    val auditedStreets: List[StreetEdgeInformation] = streets.filter(_.audited)
+    val streets: List[StreetEdgeInfo] = StreetEdgeTable.selectStreetsIntersecting(coordinates(0), coordinates(2), coordinates(1), coordinates(3))
+    val auditedStreets: List[StreetEdgeInfo] = streets.filter(_.audited)
     val neighborhoods: List[NamedRegion] = RegionTable.selectNamedNeighborhoodsWithin(coordinates(0), coordinates(2), coordinates(1), coordinates(3))
     val significance = Array(0.75, -1.0, -1.0, -1.0)
     // Write each row in the CSV.
     for (neighborhood <- neighborhoods) {
       val coordinates: Array[Coordinate] = neighborhood.geom.getCoordinates
-      val auditedStreetsIntersecting = auditedStreets.filter(_.streetEdge.geom.intersects(neighborhood.geom))
+      val auditedStreetsIntersecting = auditedStreets.filter(_.street.geom.intersects(neighborhood.geom))
       val coordStr: String = "\"[" + coordinates.map(c => "(" + c.x + "," + c.y + ")").mkString(",") + "]\""
       if (auditedStreetsIntersecting.nonEmpty) {
         val streetAccessScores: List[AccessScoreStreet] = computeAccessScoresForStreets(auditedStreetsIntersecting, labelsForScore)
@@ -391,7 +391,7 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
         val avgImageDate: Option[Timestamp] = avgImageAge.map(age => new Timestamp(age))
         val avgLabelDate: Option[Timestamp] = avgLabelAge.map(age => new Timestamp(age))
         val accessScore: Double = computeAccessScore(averagedStreetFeatures, significance)
-        val streetsIntersecting = streets.filter(_.streetEdge.geom.intersects(neighborhood.geom))
+        val streetsIntersecting = streets.filter(_.street.geom.intersects(neighborhood.geom))
         val coverage: Double = auditedStreetsIntersecting.size.toDouble / streetsIntersecting.size
 
         assert(coverage <= 1.0)
@@ -443,15 +443,15 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
     // Retrieve data and cluster them by location and label type.
     def featureCollection = {
       val labelsForScore: List[AttributeForAccessScore] = getLabelsForScore(version, coordinates)
-      val streets: List[StreetEdgeInformation] = StreetEdgeTable.selectStreetsIntersecting(coordinates(0), coordinates(2), coordinates(1), coordinates(3))
-      val auditedStreets: List[StreetEdgeInformation] = streets.filter(_.audited)
+      val streets: List[StreetEdgeInfo] = StreetEdgeTable.selectStreetsIntersecting(coordinates(0), coordinates(2), coordinates(1), coordinates(3))
+      val auditedStreets: List[StreetEdgeInfo] = streets.filter(_.audited)
       val neighborhoods: List[NamedRegion] = RegionTable.selectNamedNeighborhoodsWithin(coordinates(0), coordinates(2), coordinates(1), coordinates(3))
       val neighborhoodsJson: List[JsObject] = for (neighborhood <- neighborhoods) yield {
         val neighborhoodJson: JsonMultiPolygon[JsonLatLng] = neighborhood.geom.toJSON
 
         // Get access score
         // Element-wise sum of arrays: http://stackoverflow.com/questions/32878818/how-to-sum-up-every-column-of-a-scala-array
-        val auditedStreetsIntersecting = auditedStreets.filter(_.streetEdge.geom.intersects(neighborhood.geom))
+        val auditedStreetsIntersecting = auditedStreets.filter(_.street.geom.intersects(neighborhood.geom))
         if (auditedStreetsIntersecting.nonEmpty) {
           val streetAccessScores: List[AccessScoreStreet] = computeAccessScoresForStreets(auditedStreetsIntersecting, labelsForScore)
           val averagedStreetFeatures = streetAccessScores.map(_.attributes).transpose.map(_.sum / streetAccessScores.size).toArray
@@ -469,7 +469,7 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
           val significance = Array(0.75, -1.0, -1.0, -1.0)
           val accessScore: Double = computeAccessScore(averagedStreetFeatures, significance)
 
-          val streetsIntersecting = streets.filter(_.streetEdge.geom.intersects(neighborhood.geom))
+          val streetsIntersecting = streets.filter(_.street.geom.intersects(neighborhood.geom))
           val coverage: Double = auditedStreetsIntersecting.size.toDouble / streetsIntersecting.size
 
           assert(coverage <= 1.0)
@@ -609,7 +609,7 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
   def getAccessScoreStreetsGeneric(lat1: Double, lng1: Double, lat2: Double, lng2: Double, version: Int): List[AccessScoreStreet]  = {
     val coordinates = Array(min(lat1, lat2), max(lat1, lat2), min(lng1, lng2), max(lng1, lng2))
     // Retrieve data and cluster them by location and label type.
-    val streetEdges: List[StreetEdgeInformation] = StreetEdgeTable.selectStreetsIntersecting(coordinates(0), coordinates(2), coordinates(1), coordinates(3))
+    val streetEdges: List[StreetEdgeInfo] = StreetEdgeTable.selectStreetsIntersecting(coordinates(0), coordinates(2), coordinates(1), coordinates(3))
     computeAccessScoresForStreets(streetEdges, getLabelsForScore(version, coordinates))
   }
 
@@ -666,18 +666,18 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
     * @param labelLocations List of AttributeForAccessScore
     *
     */
-  def computeAccessScoresForStreets(streets: List[StreetEdgeInformation], labelLocations: List[AttributeForAccessScore]): List[AccessScoreStreet] = {
+  def computeAccessScoresForStreets(streets: List[StreetEdgeInfo], labelLocations: List[AttributeForAccessScore]): List[AccessScoreStreet] = {
     val radius = 3.0E-4  // Approximately 10 meters
     val pm = new PrecisionModel()
     val srid = 4326
     val factory: GeometryFactory = new GeometryFactory(pm, srid)
 
-    val streetsWithOsmWayIds: List[(StreetEdgeInformation, OsmWayStreetEdge)] = OsmWayStreetEdgeTable.selectOsmWayIdsForStreets(streets)
+    val streetsWithOsmWayIds: List[(StreetEdgeInfo, OsmWayStreetEdge)] = OsmWayStreetEdgeTable.selectOsmWayIdsForStreets(streets)
 
     val streetAccessScores = streetsWithOsmWayIds.map { item =>
-      val (edge: StreetEdgeInformation, osmStreetId: OsmWayStreetEdge) = item;
+      val (edge: StreetEdgeInfo, osmStreetId: OsmWayStreetEdge) = item;
       // Expand each edge a little bit and count the number of accessibility attributes.
-      val buffer: Geometry = edge.streetEdge.geom.buffer(radius)
+      val buffer: Geometry = edge.street.geom.buffer(radius)
 
       //  Increment a value in Map: http://stackoverflow.com/questions/15505048/access-initialize-and-update-values-in-a-mutable-map
       val labelCounter = collection.mutable.Map[String, Int](
@@ -709,7 +709,7 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
       val attributes = Array(labelCounter("CurbRamp"), labelCounter("NoCurbRamp"), labelCounter("Obstacle"), labelCounter("SurfaceProblem")).map(_.toDouble)
       val significance = Array(0.75, -1.0, -1.0, -1.0)
       val accessScore: Double = computeAccessScore(attributes, significance)
-      AccessScoreStreet(edge.streetEdge, osmStreetId.osmWayId, accessScore, edge.audited, attributes, significance, avgImageDate, avgLabelDate, nImages, nLabels)
+      AccessScoreStreet(edge.street, osmStreetId.osmWayId, accessScore, edge.audited, attributes, significance, avgImageDate, avgLabelDate, nImages, nLabels)
     }
     streetAccessScores
   }

--- a/app/controllers/TaskController.scala
+++ b/app/controllers/TaskController.scala
@@ -244,11 +244,11 @@ class TaskController @Inject() (implicit val env: Environment[User, SessionAuthe
             labId
           case None =>
             // Get the timestamp for a new label being added to db, log an error if there is a problem w/ timestamp.
-            val timeCreated: Option[Timestamp] = label.timeCreated match {
-              case Some(time) => Some(new Timestamp(time))
+            val timeCreated: Timestamp = label.timeCreated match {
+              case Some(time) => new Timestamp(time)
               case None =>
-                Logger.error("No timestamp given for a new label")
-                None
+                Logger.error("No timestamp given for a new label, using current time instead.")
+                new Timestamp(Instant.now.toEpochMilli)
             }
 
             var calculatedStreetEdgeId: Int = streetEdgeId;

--- a/app/controllers/helper/ShapefilesCreatorHelper.java
+++ b/app/controllers/helper/ShapefilesCreatorHelper.java
@@ -255,7 +255,7 @@ public class ShapefilesCreatorHelper {
                         + "streetId:Integer," // StreetId
                         + "osmWayId:Integer," // osmWayId
                         + "score:Double," // street score
-                        + "audited:Boolean," // boolean representing whether the street is audited
+                        + "auditCount:Integer," // boolean representing whether the street is audited
                         + "sigRamp:Double," // curb ramp significance score
                         + "sigNoRamp:Double," // no Curb ramp significance score
                         + "sigObs:Double," // obstacle significance score
@@ -286,7 +286,7 @@ public class ShapefilesCreatorHelper {
             featureBuilder.add(s.streetID());
             featureBuilder.add(s.osmID());
             featureBuilder.add(s.score());
-            featureBuilder.add(s.audited());
+            featureBuilder.add(s.auditCount());
             featureBuilder.add(s.significanceScores()[0]);
             featureBuilder.add(s.significanceScores()[1]);
             featureBuilder.add(s.significanceScores()[2]);

--- a/app/controllers/helper/ShapefilesCreatorHelper.java
+++ b/app/controllers/helper/ShapefilesCreatorHelper.java
@@ -1,6 +1,7 @@
 package controllers.helper;
 
 import java.io.*;
+import java.sql.Timestamp;
 import java.util.*;
 import java.util.zip.*;
 import org.geotools.data.*;
@@ -12,7 +13,6 @@ import org.geotools.data.collection.ListFeatureCollection;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.geotools.geometry.jts.JTSFactoryFinder;
 import org.locationtech.jts.geom.GeometryFactory;
-import scala.Option;
 import scala.runtime.AbstractFunction0;
 
 import models.attribute.GlobalAttributeForAPI;
@@ -295,8 +295,18 @@ public class ShapefilesCreatorHelper {
             featureBuilder.add(s.attributeScores()[1]);
             featureBuilder.add(s.attributeScores()[2]);
             featureBuilder.add(s.attributeScores()[3]);
-            featureBuilder.add(s.avgImageDate());
-            featureBuilder.add(s.avgLabelDate());
+            featureBuilder.add(s.avgImageDate().getOrElse(new AbstractFunction0<Timestamp>() {
+                @Override
+                public Timestamp apply() {
+                    return null;
+                }
+            }));
+            featureBuilder.add(s.avgLabelDate().getOrElse(new AbstractFunction0<Timestamp>() {
+                @Override
+                public Timestamp apply() {
+                    return null;
+                }
+            }));
 
             SimpleFeature feature = featureBuilder.buildFeature(null);
             features.add(feature);
@@ -358,8 +368,18 @@ public class ShapefilesCreatorHelper {
             featureBuilder.add(n.attributeScores()[1]);
             featureBuilder.add(n.attributeScores()[2]);
             featureBuilder.add(n.attributeScores()[3]);
-            featureBuilder.add(n.avgImageDate());
-            featureBuilder.add(n.avgLabelDate());
+            featureBuilder.add(n.avgImageDate().getOrElse(new AbstractFunction0<Timestamp>() {
+                @Override
+                public Timestamp apply() {
+                    return null;
+                }
+            }));
+            featureBuilder.add(n.avgLabelDate().getOrElse(new AbstractFunction0<Timestamp>() {
+                @Override
+                public Timestamp apply() {
+                    return null;
+                }
+            }));
 
             SimpleFeature feature = featureBuilder.buildFeature(null);
             features.add(feature);

--- a/app/formats/json/LabelFormat.scala
+++ b/app/formats/json/LabelFormat.scala
@@ -20,7 +20,7 @@ object LabelFormat {
       (__ \ "panorama_lng").write[Float] and
       (__ \ "deleted").write[Boolean] and
       (__ \ "temporary_label_id").writeNullable[Int] and
-      (__ \ "time_created").writeNullable[Timestamp] and
+      (__ \ "time_created").write[Timestamp] and
       (__ \ "tutorial").write[Boolean] and
       (__ \ "street_edge_id").write[Int] and
       (__ \ "agree_count").write[Int] and

--- a/app/models/attribute/GlobalAttributeTable.scala
+++ b/app/models/attribute/GlobalAttributeTable.scala
@@ -220,7 +220,7 @@ object GlobalAttributeTable {
           |        SUM(label.disagree_count) AS disagree_count,
           |        SUM(label.notsure_count) AS notsure_count,
           |        TO_TIMESTAMP(AVG(extract(epoch from label.time_created))) AS avg_label_date,
-          |        COUNT(label.time_created) AS label_count
+          |        COUNT(label.label_id) AS label_count
           |FROM global_attribute
           |INNER JOIN global_attribute_user_attribute ON global_attribute.global_attribute_id = global_attribute_user_attribute.global_attribute_id
           |INNER JOIN user_attribute_label ON global_attribute_user_attribute.user_attribute_id = user_attribute_label.user_attribute_id

--- a/app/models/attribute/GlobalAttributeTable.scala
+++ b/app/models/attribute/GlobalAttributeTable.scala
@@ -247,8 +247,8 @@ object GlobalAttributeTable {
           |          label_type.label_type,
           |          global_attribute.lat,
           |          global_attribute.lng,
-          |          label.severity,
-          |          label.temporary,
+          |          global_attribute.severity,
+          |          global_attribute.temporary,
           |          validation_counts.agree_count,
           |          validation_counts.disagree_count,
           |          validation_counts.notsure_count,
@@ -262,9 +262,6 @@ object GlobalAttributeTable {
           |FROM global_attribute
           |INNER JOIN label_type ON global_attribute.label_type_id = label_type.label_type_id
           |INNER JOIN region ON global_attribute.region_id = region.region_id
-          |INNER JOIN global_attribute_user_attribute ON global_attribute.global_attribute_id = global_attribute_user_attribute.global_attribute_id
-          |INNER JOIN user_attribute_label ON global_attribute_user_attribute.user_attribute_id = user_attribute_label.user_attribute_id
-          |INNER JOIN label ON user_attribute_label.label_id = label.label_id
           |INNER JOIN osm_way_street_edge ON global_attribute.street_edge_id = osm_way_street_edge.street_edge_id
           |INNER JOIN ($validationCounts) validation_counts ON global_attribute.global_attribute_id = validation_counts.global_attribute_id
           |INNER JOIN ($imageDates) image_dates ON global_attribute.global_attribute_id = image_dates.global_attribute_id

--- a/app/models/street/OsmWayStreetEdgeTable.scala
+++ b/app/models/street/OsmWayStreetEdgeTable.scala
@@ -25,8 +25,8 @@ object OsmWayStreetEdgeTable {
     * @return a list of (streetEdge, OsmWayStreetEdge) pairs where each list element represents a
     *         streetEdge and its corresponding OsmWayStreetEdge.
     */
-  def selectOsmWayIdsForStreets(streetEdges: List[StreetEdgeInformation]): List[(StreetEdgeInformation, OsmWayStreetEdge)] = db.withSession { implicit session =>
-    val streetEdgeIds: List[Int] = streetEdges.map(_.streetEdge.streetEdgeId)
+  def selectOsmWayIdsForStreets(streetEdges: List[StreetEdgeInfo]): List[(StreetEdgeInfo, OsmWayStreetEdge)] = db.withSession { implicit session =>
+    val streetEdgeIds: List[Int] = streetEdges.map(_.street.streetEdgeId)
     val streetEdgesWithOsmIds = for {
       _osm <- osmStreetTable if _osm.streetEdgeId inSetBind streetEdgeIds
     } yield (

--- a/app/models/street/StreetEdgeTable.scala
+++ b/app/models/street/StreetEdgeTable.scala
@@ -356,54 +356,9 @@ object StreetEdgeTable {
     streetEdgesWithoutDeleted.filter(_.streetEdgeId === streetEdgeId).groupBy(x => x).map(_._1.geom.transform(26918).length).first
   }
 
-  def selectStreetsIntersecting(minLat: Double, minLng: Double, maxLat: Double, maxLng: Double): List[StreetEdge] = db.withSession { implicit session =>
+  def selectStreetsIntersecting(minLat: Double, minLng: Double, maxLat: Double, maxLng: Double): List[StreetEdgeInformation] = db.withSession { implicit session =>
     // http://gis.stackexchange.com/questions/60700/postgis-select-by-lat-long-bounding-box
     // http://postgis.net/docs/ST_MakeEnvelope.html
-    val selectEdgeQuery = Q.query[(Double, Double, Double, Double), StreetEdge](
-      """SELECT st_e.street_edge_id,
-        |       st_e.geom,
-        |       st_e.x1,
-        |       st_e.y1,
-        |       st_e.x2,
-        |       st_e.y2,
-        |       st_e.way_type,
-        |       st_e.deleted,
-        |       st_e.timestamp
-        |FROM street_edge AS st_e
-        |WHERE st_e.deleted = FALSE
-        |    AND ST_Intersects(st_e.geom, ST_MakeEnvelope(?, ?, ?, ?, 4326))""".stripMargin
-    )
-
-    val edges: List[StreetEdge] = selectEdgeQuery((minLng, minLat, maxLng, maxLat)).list
-    edges
-  }
-
-  def selectAuditedStreetsIntersecting(minLat: Double, minLng: Double, maxLat: Double, maxLng: Double): List[StreetEdgeInformation] = db.withSession { implicit session =>
-    // http://gis.stackexchange.com/questions/60700/postgis-select-by-lat-long-bounding-box
-    // http://postgis.net/docs/ST_MakeEnvelope.html
-    val selectEdgeQuery = Q.query[(Double, Double, Double, Double), StreetEdgeInformation](
-      """SELECT street_edge.street_edge_id,
-        |       street_edge.geom,
-        |       street_edge.x1,
-        |       street_edge.y1,
-        |       street_edge.x2,
-        |       street_edge.y2,
-        |       street_edge.way_type,
-        |       street_edge.deleted,
-        |       street_edge.timestamp,
-        |       TRUE AS completed
-        |FROM street_edge
-        |INNER JOIN street_edge_priority ON street_edge.street_edge_id = street_edge_priority.street_edge_id
-        |WHERE street_edge.deleted = FALSE
-        |    AND ST_Intersects(street_edge.geom, ST_MakeEnvelope(?, ?, ?, ?, 4326))
-        |    AND street_edge_priority.priority < 1""".stripMargin
-    )
-
-    val edges: List[StreetEdgeInformation] = selectEdgeQuery((minLng, minLat, maxLng, maxLat)).list
-    edges
-  }
-
-  def selectStreetsWithin(minLat: Double, minLng: Double, maxLat: Double, maxLng: Double): List[StreetEdgeInformation] = db.withSession { implicit session =>
     val selectEdgeQuery = Q.query[(Double, Double, Double, Double), StreetEdgeInformation](
       """SELECT street_edge.street_edge_id,
         |       street_edge.geom,

--- a/conf/evolutions/default/163.sql
+++ b/conf/evolutions/default/163.sql
@@ -1,0 +1,24 @@
+# --- !Ups
+-- Try updating time_created using audit_task_interaction table first, since it will be more accurate.
+UPDATE label
+SET time_created = new_timestamp
+FROM (
+    SELECT label.label_id,
+           MIN(audit_task_interaction.timestamp) AS new_timestamp
+    FROM label
+    INNER JOIN audit_task_interaction ON label.audit_task_id = audit_task_interaction.audit_task_id
+        AND label.temporary_label_id = audit_task_interaction.temporary_label_id
+    WHERE label.time_created IS NULL
+    GROUP BY label.label_id
+) AS new_timestamps
+WHERE label.label_id = new_timestamps.label_id
+    AND label.time_created IS NULL;
+
+-- If we don't find matching interactions, just use task_start from the audit_task table as an imperfect backup.
+UPDATE label
+SET time_created = task_start
+FROM audit_task
+WHERE label.audit_task_id = audit_task.audit_task_id
+  AND label.time_created IS NULL;
+
+# --- !Downs


### PR DESCRIPTION
Resolves #3032

This fixes a few bugs introduced by our recent PRs in the `/v2/access/score/streets` and `/v2/access/score/neighborhoods` APIs, particularly on streets with no label data.

Here's a mostly comprehensive list of bugs I found. All of these are new as of the most recent version.
* There were cases where we were returning duplicate attributes in the `attributes` and `attributesWithLabels` endpoints
* If there are no labels on a street/neighborhood, we were returning an incorrect timestamp. Now we are just returning `null`
* If a street or neighborhood had no labels, sometimes there would just be a server error
* For the streets API, we were computing the average image and label age based on any type of label on the street, whereas AccessScore only uses our four primary label types. We now only include the four primary label types in this calculation.

In addition, instead of saying whether a street has been audited, we now say how many audits the street has had (there are zero audits if it is unaudited).

And finally, I cleaned up the code to hopefully prevent further mistakes in the API, mostly by reusing more code!

##### Before/After screenshots (if applicable)
Before (streets API)
![Screenshot from 2022-09-19 15-38-38](https://user-images.githubusercontent.com/6518824/191132097-7d00706e-7040-4386-9c0e-b1e336ebe9af.png)

After
![Screenshot from 2022-09-19 13-52-47](https://user-images.githubusercontent.com/6518824/191132104-a5ed1518-004b-4f90-abda-a7f5ed443a43.png)

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
