### PR TITLE
comment submitted popover no longer pushes down content

### DIFF
--- a/public/javascripts/Admin/src/Admin.GSVLabelView.js
+++ b/public/javascripts/Admin/src/Admin.GSVLabelView.js
@@ -43,7 +43,7 @@ function AdminGSVLabelView(admin) {
                             '</div>' +
                             '<div id="validation-comment-holder" style="padding-top: 10px; padding-bottom: 15px;">' +
                                 '<textarea id="comment-textarea" placeholder="' + i18next.t('common:label-map.add-comment') + '" class="validation-comment-box"></textarea>' +
-                                '<button id="comment-button" class="submit-button" data-toggle="popover" data-placement="top" data-content="' + i18next.t('common:label-map.comment-submitted') + '" data-trigger="manual">' +
+                                '<button id="comment-button" class="submit-button" data-container="body" data-toggle="popover" data-placement="top" data-content="' + i18next.t('common:label-map.comment-submitted') + '" data-trigger="manual">' +
                                     i18next.t('common:label-map.submit') +
                                 '</button>' +
                             '</div>' +


### PR DESCRIPTION
Fixes #3015 

Comment submitted popover no longer pushes content down when visible.

##### Testing instructions
1.  Go to /labelMap.
2. Click on a label.
3. Submit a comment through the interface.
