### PR TITLE
#2761: Fix for keeping the PLUS_N indicator in the same line on the gallery page.

### DIFF
--- a/public/javascripts/Gallery/src/displays/TagDisplay.js
+++ b/public/javascripts/Gallery/src/displays/TagDisplay.js
@@ -61,8 +61,12 @@ function TagDisplay(container, tags, isModal=false) {
                 // can't fit the tag at all, will need to add to the hidden tags in the '+n' popover.
                 let isLastTag = i === tagsText.length - 1;
                 let tagWidth = parseFloat($(tagEl).css('width'));
-                let extraSpaceNeeded = isLastTag ? MARGIN_BW_TAGS : MARGIN_BW_TAGS + WIDTH_FOR_PLUS_N;
-                let spaceForShortenedTag = isLastTag ? MIN_TAG_WIDTH : MIN_TAG_WIDTH + WIDTH_FOR_PLUS_N;
+
+                // If this is the last tag, and there are hidden tags, then we need to account for the PLUS_N indicator in addition to the margin between tags in the extra space needed.
+                // Otherwise, we just need to account for the margin between tags.
+                let extraSpaceNeeded = (isLastTag && hiddenTags.length === 0) ? MARGIN_BW_TAGS : MARGIN_BW_TAGS + WIDTH_FOR_PLUS_N;
+                let spaceForShortenedTag = (isLastTag && hiddenTags.length === 0) ? MIN_TAG_WIDTH : MIN_TAG_WIDTH + WIDTH_FOR_PLUS_N;
+
                 if ((remainingWidth > tagWidth + extraSpaceNeeded)) {
                     // Show the entire tag if there is enough space.
                     remainingWidth -= (tagWidth + MARGIN_BW_TAGS);

--- a/public/javascripts/Gallery/src/displays/TagDisplay.js
+++ b/public/javascripts/Gallery/src/displays/TagDisplay.js
@@ -62,8 +62,9 @@ function TagDisplay(container, tags, isModal=false) {
                 let isLastTag = i === tagsText.length - 1;
                 let tagWidth = parseFloat($(tagEl).css('width'));
 
-                // If this is the last tag, and there are hidden tags, then we need to account for the PLUS_N indicator in addition to the margin between tags in the extra space needed.
-                // Otherwise, we just need to account for the margin between tags.
+                // If this is the last tag and there are hidden tags, then we need to account for the PLUS_N indicator
+                // in addition to the margin between tags in the extra space needed. Otherwise, we just need to account
+                // for the margin between tags.
                 let extraSpaceNeeded = (isLastTag && hiddenTags.length === 0) ? MARGIN_BW_TAGS : MARGIN_BW_TAGS + WIDTH_FOR_PLUS_N;
                 let spaceForShortenedTag = (isLastTag && hiddenTags.length === 0) ? MIN_TAG_WIDTH : MIN_TAG_WIDTH + WIDTH_FOR_PLUS_N;
 

--- a/public/javascripts/Gallery/src/displays/TagDisplay.js
+++ b/public/javascripts/Gallery/src/displays/TagDisplay.js
@@ -67,8 +67,8 @@ function TagDisplay(container, tags, isModal=false) {
                 let extraSpaceNeeded = (isLastTag && hiddenTags.length === 0) ? MARGIN_BW_TAGS : MARGIN_BW_TAGS + WIDTH_FOR_PLUS_N;
                 let spaceForShortenedTag = (isLastTag && hiddenTags.length === 0) ? MIN_TAG_WIDTH : MIN_TAG_WIDTH + WIDTH_FOR_PLUS_N;
 
-                if ((remainingWidth > tagWidth + extraSpaceNeeded)) {
-                    // Show the entire tag if there is enough space.
+                if (isModal || (remainingWidth > tagWidth + extraSpaceNeeded)) {
+                    // Show the entire tag if there is enough space. Always show in modal bc we have a scrollbar.
                     remainingWidth -= (tagWidth + MARGIN_BW_TAGS);
                 } else if (remainingWidth > spaceForShortenedTag) {
                     // Show a tag abbreviated with an ellipsis if there's some space, just not enough for the full tag.
@@ -79,11 +79,9 @@ function TagDisplay(container, tags, isModal=false) {
                     tagEl.title = tagsText[i];
                 } else {
                     // If the tag does not fit at all, add it to the list of hidden tags to show in the popover.
-                    if (!isModal) {
-                        tagEl.remove();
-                        tagEl.classList.add("not-added");
-                        hiddenTags.push(tagEl);
-                    }
+                    tagEl.remove();
+                    tagEl.classList.add("not-added");
+                    hiddenTags.push(tagEl);
                 }
             }
 


### PR DESCRIPTION
Resolves #2761 

This is a brief description of the problem solved or feature implemented and how you implemented it.
Modified the condition to compute extra space needed while displaying tags to account for the presence of hidden tags.

##### Before/After screenshots (if applicable)
Before
<img width="380" alt="Screen Shot 2022-10-15 at 6 40 24 PM" src="https://user-images.githubusercontent.com/8168506/196014705-5b89bb3b-40fe-4105-80e9-b40cda36c296.png">

After
<img width="381" alt="Screen Shot 2022-10-14 at 10 01 53 PM" src="https://user-images.githubusercontent.com/8168506/196014730-4b5619c2-02f0-4262-8230-803b398b0a75.png">


##### Testing instructions
1. Add the following tags to a 'Surface Problem' card—bumpy, grass, uneven/slanted, very broken. This combination of tags should show the PLUS_N (in this case '+1') in the next line on a Macbook Pro 13.3-inch (2560 × 1600) display.
2. With the new fix, the PLUS_N should be '+2' and should be shown on the same line as tags.
3. Add different combination of tags to cards and verify that the PLUS_N indicator doesn't get pushed to the next line in any case.

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
