### PR TITLE
Fixes bug where accuracy was null when it should be 0% or 100%

### DIFF
--- a/app/models/label/LabelValidationTable.scala
+++ b/app/models/label/LabelValidationTable.scala
@@ -218,7 +218,7 @@ object LabelValidationTable {
     val accuracyQuery = Q.query[String, Option[Float]](
       """SELECT CASE WHEN validated_count > 9 THEN accuracy ELSE NULL END AS accuracy
         |FROM (
-        |    SELECT CAST(SUM(CASE WHEN correct THEN 1 END) AS FLOAT) / NULLIF(SUM(CASE WHEN correct THEN 1 END) + SUM(CASE WHEN NOT correct THEN 1 END), 0) AS accuracy,
+        |    SELECT CAST(SUM(CASE WHEN correct THEN 1 ELSE 0 END) AS FLOAT) / NULLIF(SUM(CASE WHEN correct THEN 1 ELSE 0 END) + SUM(CASE WHEN NOT correct THEN 1 ELSE 0 END), 0) AS accuracy,
         |           COUNT(CASE WHEN correct IS NOT NULL THEN 1 END) AS validated_count
         |    FROM mission
         |    INNER JOIN label ON mission.mission_id = label.mission_id

--- a/app/models/user/UserStatTable.scala
+++ b/app/models/user/UserStatTable.scala
@@ -211,7 +211,7 @@ object UserStatTable {
   }
 
   /**
-    * Update the accuracy column in the user_stat table for every user.
+    * Update the accuracy column in the user_stat table for the given users, or every user if list is empty.
     *
     * @param users A list of user_ids to update, update all users if list is empty.
     */
@@ -227,7 +227,7 @@ object UserStatTable {
          |FROM user_stat
          |INNER JOIN (
          |    SELECT user_id,
-         |           CAST(SUM(CASE WHEN correct THEN 1 END) AS FLOAT) / NULLIF(SUM(CASE WHEN correct THEN 1 END) + SUM(CASE WHEN NOT correct THEN 1 END), 0) AS new_accuracy,
+         |           CAST(SUM(CASE WHEN correct THEN 1 ELSE 0 END) AS FLOAT) / NULLIF(SUM(CASE WHEN correct THEN 1 ELSE 0 END) + SUM(CASE WHEN NOT correct THEN 1 ELSE 0 END), 0) AS new_accuracy,
          |           COUNT(CASE WHEN correct IS NOT NULL THEN 1 END) AS new_validated_count
          |    FROM mission
          |    INNER JOIN label ON mission.mission_id = label.mission_id
@@ -405,7 +405,7 @@ object UserStatTable {
         |) "missions_and_distance" ON label_counts.$groupingColName = missions_and_distance.$groupingColName
         |LEFT JOIN (
         |    SELECT $groupingColName,
-        |           CAST(SUM(CASE WHEN correct THEN 1 END) AS FLOAT) / NULLIF(SUM(CASE WHEN correct THEN 1 END) + SUM(CASE WHEN NOT correct THEN 1 END), 0) AS accuracy_temp,
+        |           CAST(SUM(CASE WHEN correct THEN 1 ELSE 0 END) AS FLOAT) / NULLIF(SUM(CASE WHEN correct THEN 1 ELSE 0 END) + SUM(CASE WHEN NOT correct THEN 1 ELSE 0 END), 0) AS accuracy_temp,
         |           COUNT(CASE WHEN correct IS NOT NULL THEN 1 END) AS validated_count
         |    FROM label
         |    INNER JOIN mission ON label.mission_id = mission.mission_id


### PR DESCRIPTION
Fixes #3069 

If accuracy should have been 0% or 100% in our database, it was showing up as null. The issue is that in our queries to compute accuracy, we would count the number of correct labels as:
```
SUM(CASE WHEN correct THEN 1 END)
```
But if there were no correct labels, then we were basically taking the sum of a bunch of nulls, which gave us null! There are two correct ways to do this, either of the following:
```
SUM(CASE WHEN correct THEN 1 ELSE 0 END)
COUNT(CASE WHEN correct THEN 1 END)
```

I went with the latter, since it changes our code the least :shrug: I also did a quick search through our code, and it looks like I only made this mistake when calculating accuracy. We do it correctly everywhere else.
