### PR TITLE
Adds an API for General Sidewalk Stats

### DIFF
--- a/app/controllers/ProjectSidewalkAPIController.scala
+++ b/app/controllers/ProjectSidewalkAPIController.scala
@@ -799,8 +799,8 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
     }
   }
 
-  def getOverallSidewalkStats(filetype: Option[String]) = UserAwareAction.async { implicit request =>
+  def getOverallSidewalkStats(filterLowQuality: Boolean, filetype: Option[String]) = UserAwareAction.async { implicit request =>
     apiLogging(request.remoteAddress, request.identity, request.toString)
-    Future.successful(Ok(APIFormats.projectSidewalkStatsToJson(LabelTable.getOverallStatsForAPI)))
+    Future.successful(Ok(APIFormats.projectSidewalkStatsToJson(LabelTable.getOverallStatsForAPI(filterLowQuality))))
   }
 }

--- a/app/controllers/ProjectSidewalkAPIController.scala
+++ b/app/controllers/ProjectSidewalkAPIController.scala
@@ -15,7 +15,7 @@ import math._
 import models.region._
 import models.daos.slick.DBTableDefinitions.{DBUser, UserTable}
 import models.gsv.GSVDataTable
-import models.label.{LabelLocation, LabelTable}
+import models.label.{LabelLocation, LabelTable, ProjectSidewalkStats}
 import models.street.{OsmWayStreetEdge, OsmWayStreetEdgeTable}
 import models.street.{StreetEdge, StreetEdgeInfo, StreetEdgeTable}
 import models.user.{User, UserStatTable, WebpageActivity, WebpageActivityTable}
@@ -801,6 +801,39 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
 
   def getOverallSidewalkStats(filterLowQuality: Boolean, filetype: Option[String]) = UserAwareAction.async { implicit request =>
     apiLogging(request.remoteAddress, request.identity, request.toString)
-    Future.successful(Ok(APIFormats.projectSidewalkStatsToJson(LabelTable.getOverallStatsForAPI(filterLowQuality))))
+    // In CSV format.
+    if (filetype.isDefined && filetype.get == "csv") {
+      val sidewalkStatsFile = new java.io.File("project_sidewalk_stats.csv")
+      val writer = new java.io.PrintStream(sidewalkStatsFile)
+
+      val stats: ProjectSidewalkStats = LabelTable.getOverallStatsForAPI(filterLowQuality)
+      writer.println(s"KM Explored,${stats.kmExplored}")
+      writer.println(s"KM Explored Without Overlap,${stats.kmExploreNoOverlap}")
+      writer.println(s"Total User Count,${stats.nUsers}")
+      writer.println(s"Explorer User Count,${stats.nExplorers}")
+      writer.println(s"Validate User Count,${stats.nValidators}")
+      writer.println(s"Registered User Count,${stats.nRegistered}")
+      writer.println(s"Anonymous User Count,${stats.nAnon}")
+      writer.println(s"Turker User Count,${stats.nTurker}")
+      writer.println(s"Researcher User Count,${stats.nResearcher}")
+      writer.println(s"Total Label Count,${stats.nResearcher}")
+      for ((labType, sevStats) <- stats.severityByLabelType) {
+        writer.println(s"$labType Count,${sevStats.n}")
+        writer.println(s"$labType Count With Severity,${sevStats.nWithSeverity}")
+        writer.println(s"$labType Severity Mean,${sevStats.severityMean.map(_.toString).getOrElse("NA")}")
+        writer.println(s"$labType Severity SD,${sevStats.severitySD.map(_.toString).getOrElse("NA")}")
+      }
+      writer.println(s"Total Validations,${stats.nValidations}")
+      for ((labType, accStats) <- stats.accuracyByLabelType) {
+        writer.println(s"$labType Labels Validated,${accStats.n}")
+        writer.println(s"$labType Agreed Count,${accStats.nAgree}")
+        writer.println(s"$labType Disagreed Count,${accStats.nDisagree}")
+        writer.println(s"$labType Accuracy,${accStats.accuracy.map(_.toString).getOrElse("NA")}")
+      }
+      writer.close()
+      Future.successful(Ok.sendFile(content = sidewalkStatsFile, onClose = () => sidewalkStatsFile.delete()))
+    } else { // In JSON format.
+      Future.successful(Ok(APIFormats.projectSidewalkStatsToJson(LabelTable.getOverallStatsForAPI(filterLowQuality))))
+    }
   }
 }

--- a/app/controllers/ProjectSidewalkAPIController.scala
+++ b/app/controllers/ProjectSidewalkAPIController.scala
@@ -5,6 +5,7 @@ import com.mohiva.play.silhouette.impl.authenticators.SessionAuthenticator
 import com.vividsolutions.jts.geom._
 import com.vividsolutions.jts.index.kdtree.{KdNode, KdTree}
 import controllers.headers.ProvidesHeader
+import formats.json.APIFormats
 import java.sql.Timestamp
 import java.time.Instant
 import javax.inject.Inject
@@ -796,5 +797,10 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
     } else { // In JSON format.
       Future.successful(Ok(Json.toJson(UserStatTable.getStatsForAPI.map(_.toJSON))))
     }
+  }
+
+  def getOverallSidewalkStats(filetype: Option[String]) = UserAwareAction.async { implicit request =>
+    apiLogging(request.remoteAddress, request.identity, request.toString)
+    Future.successful(Ok(APIFormats.projectSidewalkStatsToJson(LabelTable.getOverallStatsForAPI)))
   }
 }

--- a/app/formats/json/APIFormats.scala
+++ b/app/formats/json/APIFormats.scala
@@ -8,8 +8,8 @@ object APIFormats {
   implicit val labelSeverityStatsWrites: Writes[LabelSeverityStats] = (
     (__ \ "count").write[Int] and
       (__ \ "count_with_severity").write[Int] and
-        (__ \ "count_with_severity").writeNullable[Float] and
-        (__ \ "count_with_severity").writeNullable[Float]
+        (__ \ "severity_mean").writeNullable[Float] and
+        (__ \ "severity_sd").writeNullable[Float]
   )(unlift(LabelSeverityStats.unapply))
 
   implicit val labelAccuracyWrites: Writes[LabelAccuracy] = (

--- a/app/formats/json/APIFormats.scala
+++ b/app/formats/json/APIFormats.scala
@@ -1,0 +1,47 @@
+package formats.json
+
+import models.label.{LabelAccuracy, LabelSeverityStats, ProjectSidewalkStats}
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
+
+object APIFormats {
+  implicit val labelSeverityStatsWrites: Writes[LabelSeverityStats] = (
+    (__ \ "count").write[Int] and
+      (__ \ "count_with_severity").write[Int] and
+        (__ \ "count_with_severity").writeNullable[Float] and
+        (__ \ "count_with_severity").writeNullable[Float]
+  )(unlift(LabelSeverityStats.unapply))
+
+  implicit val labelAccuracyWrites: Writes[LabelAccuracy] = (
+    (__ \ "validated").write[Int] and
+      (__ \ "agreed").write[Int] and
+      (__ \ "disagreed").write[Int] and
+      (__ \ "accuracy").writeNullable[Float]
+    ) (unlift(LabelAccuracy.unapply))
+
+  def projectSidewalkStatsToJson(stats: ProjectSidewalkStats): JsObject = {
+    Json.obj(
+      "km_explored" -> stats.kmExplored,
+      "km_explored_no_overlap" -> stats.kmExploreNoOverlap,
+      "user_counts" -> Json.obj(
+        "all_users" -> stats.nUsers,
+        "labelers" -> stats.nExplorers,
+        "validators" -> stats.nValidators,
+        "registered" -> stats.nRegistered,
+        "anonymous" -> stats.nAnon,
+        "turker" -> stats.nTurker,
+        "researcher" -> stats.nResearcher
+      ),
+      "labels" -> JsObject(
+        Seq(("label_count", JsNumber(stats.nLabels.toDouble))) ++
+          // Turns into { "CurbRamp" -> { "count" -> ###, ... }, ... }.
+          stats.severityByLabelType.map { case (labType, sevStats) => labType -> Json.toJson(sevStats) }
+      ),
+      "validations" -> JsObject(
+        Seq("total_validations" -> JsNumber(stats.nValidations.toDouble)) ++
+          // Turns into { "Overall" -> { "validated" -> ###, ... }, "CurbRamp" -> { "validated" -> ###, ... }, ... }.
+        stats.accuracyByLabelType.map { case (labType, accStats) => labType -> Json.toJson(accStats) }
+      )
+    )
+  }
+}

--- a/app/models/daos/slick/UserDAOSlick.scala
+++ b/app/models/daos/slick/UserDAOSlick.scala
@@ -199,8 +199,8 @@ object UserDAOSlick {
 
     // Add in the optional SQL WHERE statement for filtering on high quality users.
     val highQualityOnlySql =
-      if (highQualityOnly) "(user_stat.high_quality_manual = TRUE OR user_stat.high_quality_manual IS NULL)"
-      else "TRUE"
+      if (highQualityOnly) "user_stat.high_quality"
+      else "NOT user_stat.excluded"
 
     // Add in the task completion logic.
     val auditTaskCompletedSql = if (taskCompletedOnly) "audit_task.completed = TRUE" else "TRUE"

--- a/app/models/daos/slick/UserDAOSlick.scala
+++ b/app/models/daos/slick/UserDAOSlick.scala
@@ -233,21 +233,21 @@ object UserDAOSlick {
    */
   def countValidationUsersContributed(roles: List[String], labelValidated: Boolean): Int = db.withSession { implicit session =>
 
-    val validationMissions =
-      if (labelValidated) MissionTable.validationMissions.filter(_.labelsProgress > 0)
-      else MissionTable.validationMissions
+    val users =
+      if (labelValidated) LabelValidationTable.validationLabels.map(_.userId)
+      else MissionTable.validationMissions.map(_.userId)
 
-    val users = for {
-      _mission <- validationMissions
-      _user <- userTable if _mission.userId === _user.userId
-      _userRole <- userRoleTable if _user.userId === _userRole.userId
+    val filteredUsers = for {
+      _users <- users
+      _userTable <- userTable if _users === _userTable.userId
+      _userRole <- userRoleTable if _userTable.userId === _userRole.userId
       _role <- roleTable if _userRole.roleId === _role.roleId
-      if _user.username =!= "anonymous"
+      if _userTable.username =!= "anonymous"
       if _role.role inSet roles
-    } yield _user.userId
+    } yield _userTable.userId
 
     // The group by and map does a SELECT DISTINCT, and the list.length does the COUNT.
-    users.groupBy(x => x).map(_._1).length.run
+    filteredUsers.groupBy(x => x).map(_._1).length.run
   }
 
   /**

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -37,6 +37,13 @@ case class LabelLocationWithSeverity(labelId: Int, auditTaskId: Int, gsvPanorama
                                      lat: Float, lng: Float, correct: Option[Boolean], expired: Boolean,
                                      highQualityUser: Boolean, severity: Option[Int])
 
+case class LabelSeverityStats(n: Int, nWithSeverity: Int, severityMean: Option[Float], severitySD: Option[Float])
+case class LabelAccuracy(n: Int, nAgree: Int, nDisagree: Int, accuracy: Option[Float])
+case class ProjectSidewalkStats(kmExplored: Float, kmExploreNoOverlap: Float, nUsers: Int, nExplorers: Int,
+                                nValidators: Int, nRegistered: Int, nAnon: Int, nTurker: Int, nResearcher: Int,
+                                nLabels: Int, severityByLabelType: Map[String, LabelSeverityStats], nValidations: Int,
+                                accuracyByLabelType: Map[String, LabelAccuracy])
+
 class LabelTable(tag: slick.lifted.Tag) extends Table[Label](tag, Some("sidewalk"), "label") {
   def labelId = column[Int]("label_id", O.PrimaryKey, O.AutoInc)
   def auditTaskId = column[Int]("audit_task_id", O.NotNull)
@@ -219,6 +226,34 @@ object LabelTable {
       r.nextStringOption.map(tags => tags.split(",").map(_.toInt).toList).getOrElse(List())
     )
   )
+
+  implicit val projectSidewalkStatsConverter = GetResult[ProjectSidewalkStats](r => ProjectSidewalkStats(
+    r.nextFloat, r.nextFloat, r.nextInt, r.nextInt, r.nextInt, r.nextInt, r.nextInt, r.nextInt, r.nextInt, r.nextInt,
+    Map(
+      "CurbRamp" -> LabelSeverityStats(r.nextInt, r.nextInt, r.nextFloatOption, r.nextFloatOption),
+      "NoCurbRamp" -> LabelSeverityStats(r.nextInt, r.nextInt, r.nextFloatOption, r.nextFloatOption),
+      "Obstacle" -> LabelSeverityStats(r.nextInt, r.nextInt, r.nextFloatOption, r.nextFloatOption),
+      "SurfaceProblem" -> LabelSeverityStats(r.nextInt, r.nextInt, r.nextFloatOption, r.nextFloatOption),
+      "NoSidewalk" -> LabelSeverityStats(r.nextInt, r.nextInt, r.nextFloatOption, r.nextFloatOption),
+      "Crosswalk" -> LabelSeverityStats(r.nextInt, r.nextInt, r.nextFloatOption, r.nextFloatOption),
+      "Signal" -> LabelSeverityStats(r.nextInt, r.nextInt, r.nextFloatOption, r.nextFloatOption),
+      "Occlusion" -> LabelSeverityStats(r.nextInt, r.nextInt, r.nextFloatOption, r.nextFloatOption),
+      "Other" -> LabelSeverityStats(r.nextInt, r.nextInt, r.nextFloatOption, r.nextFloatOption)
+    ),
+    r.nextInt,
+    Map(
+      "Overall" -> LabelAccuracy(r.nextInt, r.nextInt, r.nextInt, r.nextFloatOption),
+      "CurbRamp" -> LabelAccuracy(r.nextInt, r.nextInt, r.nextInt, r.nextFloatOption),
+      "NoCurbRamp" -> LabelAccuracy(r.nextInt, r.nextInt, r.nextInt, r.nextFloatOption),
+      "Obstacle" -> LabelAccuracy(r.nextInt, r.nextInt, r.nextInt, r.nextFloatOption),
+      "SurfaceProblem" -> LabelAccuracy(r.nextInt, r.nextInt, r.nextInt, r.nextFloatOption),
+      "NoSidewalk" -> LabelAccuracy(r.nextInt, r.nextInt, r.nextInt, r.nextFloatOption),
+      "Crosswalk" -> LabelAccuracy(r.nextInt, r.nextInt, r.nextInt, r.nextFloatOption),
+      "Signal" -> LabelAccuracy(r.nextInt, r.nextInt, r.nextInt, r.nextFloatOption),
+      "Occlusion" -> LabelAccuracy(r.nextInt, r.nextInt, r.nextInt, r.nextFloatOption),
+      "Other" -> LabelAccuracy(r.nextInt, r.nextInt, r.nextInt, r.nextFloatOption)
+    )
+  ))
 
   // Valid label type ids for the /validate -- excludes Other and Occlusion labels.
   val valLabelTypeIds: List[Int] = List(1, 2, 3, 4, 7, 9, 10)
@@ -1118,6 +1153,219 @@ object LabelTable {
         |   AND label_point.lat IS NOT NULL AND label_point.lng IS NOT NULL;""".stripMargin
     )
     labelsInRegionQuery.list
+  }
+
+  def getOverallStatsForAPI: ProjectSidewalkStats = db.withSession { implicit session =>
+    val overallStatsQuery = Q.queryNA[ProjectSidewalkStats](
+      s"""SELECT km_audited.km_audited AS km_audited,
+         |       km_audited_no_overlap.km_audited_no_overlap AS km_audited_no_overlap,
+         |       users.total_users,
+         |       users.audit_users,
+         |       users.validation_users,
+         |       users.registered_users,
+         |       users.anon_users,
+         |       users.turker_users,
+         |       users.researcher_users,
+         |       label_counts_and_severity.label_count,
+         |       label_counts_and_severity.n_ramp,
+         |       label_counts_and_severity.n_ramp_with_sev,
+         |       label_counts_and_severity.ramp_sev_mean,
+         |       label_counts_and_severity.ramp_sev_sd,
+         |       label_counts_and_severity.n_noramp,
+         |       label_counts_and_severity.n_noramp_with_sev,
+         |       label_counts_and_severity.noramp_sev_mean,
+         |       label_counts_and_severity.noramp_sev_sd,
+         |       label_counts_and_severity.n_obs,
+         |       label_counts_and_severity.n_obs_with_sev,
+         |       label_counts_and_severity.obs_sev_mean,
+         |       label_counts_and_severity.obs_sev_sd,
+         |       label_counts_and_severity.n_surf,
+         |       label_counts_and_severity.n_surf_with_sev,
+         |       label_counts_and_severity.surf_sev_mean,
+         |       label_counts_and_severity.surf_sev_sd,
+         |       label_counts_and_severity.n_nosidewalk,
+         |       label_counts_and_severity.n_nosidewalk_with_sev,
+         |       label_counts_and_severity.nosidewalk_sev_mean,
+         |       label_counts_and_severity.nosidewalk_sev_sd,
+         |       label_counts_and_severity.n_crswlk,
+         |       label_counts_and_severity.n_crswlk_with_sev,
+         |       label_counts_and_severity.crswlk_sev_mean,
+         |       label_counts_and_severity.crswlk_sev_sd,
+         |       label_counts_and_severity.n_signal,
+         |       0 AS signal_with_sev,
+         |       NULL AS signal_sev_mean,
+         |       NULL AS signal_sev_sd,
+         |       label_counts_and_severity.n_occlusion,
+         |       0 AS occlusion_with_sev,
+         |       NULL AS occlusion_sev_mean,
+         |       NULL AS occlusion_sev_sd,
+         |       label_counts_and_severity.n_other,
+         |       label_counts_and_severity.n_other_with_sev,
+         |       label_counts_and_severity.other_sev_mean,
+         |       label_counts_and_severity.other_sev_sd,
+         |       val_counts.total_validations,
+         |       val_counts.n_validated,
+         |       val_counts.n_agree,
+         |       val_counts.n_disagree,
+         |       1.0 * val_counts.n_agree / NULLIF(val_counts.n_validated, 0) AS overall_accuracy,
+         |       val_counts.n_ramp_total,
+         |       val_counts.n_ramp_agree,
+         |       val_counts.n_ramp_disagree,
+         |       1.0 * val_counts.n_ramp_agree / NULLIF(val_counts.n_ramp_total, 0) AS ramp_accuracy,
+         |       val_counts.n_noramp_total,
+         |       val_counts.n_noramp_agree,
+         |       val_counts.n_noramp_disagree,
+         |       1.0 * val_counts.n_noramp_agree / NULLIF(val_counts.n_noramp_total, 0) AS noramp_accuracy,
+         |       val_counts.n_obs_total,
+         |       val_counts.n_obs_agree,
+         |       val_counts.n_obs_disagree,
+         |       1.0 * val_counts.n_obs_agree / NULLIF(val_counts.n_obs_total, 0) AS obs_accuracy,
+         |       val_counts.n_surf_total,
+         |       val_counts.n_surf_agree,
+         |       val_counts.n_surf_disagree,
+         |       1.0 * val_counts.n_surf_agree / NULLIF(val_counts.n_surf_total, 0) AS surf_accuracy,
+         |       val_counts.n_nosidewalk_total,
+         |       val_counts.n_nosidewalk_agree,
+         |       val_counts.n_nosidewalk_disagree,
+         |       1.0 * val_counts.n_nosidewalk_agree / NULLIF(val_counts.n_nosidewalk_total, 0) AS nosidewalk_accuracy,
+         |       val_counts.n_crswlk_total,
+         |       val_counts.n_crswlk_agree,
+         |       val_counts.n_crswlk_disagree,
+         |       1.0 * val_counts.n_crswlk_agree / NULLIF(val_counts.n_crswlk_total, 0) AS crswlk_accuracy,
+         |       val_counts.n_signal_total,
+         |       val_counts.n_signal_agree,
+         |       val_counts.n_signal_disagree,
+         |       1.0 * val_counts.n_signal_agree / NULLIF(val_counts.n_signal_total, 0) AS signal_accuracy,
+         |       val_counts.n_occlusion_total,
+         |       val_counts.n_occlusion_agree,
+         |       val_counts.n_occlusion_disagree,
+         |       1.0 * val_counts.n_occlusion_agree / NULLIF(val_counts.n_occlusion_total, 0) AS occlusion_accuracy,
+         |       val_counts.n_other_total,
+         |       val_counts.n_other_agree,
+         |       val_counts.n_other_disagree,
+         |       1.0 * val_counts.n_other_agree / NULLIF(val_counts.n_other_total, 0) AS other_accuracy
+         |FROM (
+         |    SELECT SUM(distance_progress) / 1000 AS km_audited
+         |    FROM mission
+         |    INNER JOIN user_stat ON mission.user_id = user_stat.user_id
+         |    WHERE high_quality_manual = TRUE OR high_quality_manual IS NULL
+         |) AS km_audited, (
+         |    SELECT SUM(ST_LENGTH(ST_TRANSFORM(geom, 26918))) / 1000 AS km_audited_no_overlap
+         |    FROM (
+         |        SELECT DISTINCT street_edge.street_edge_id, geom
+         |        FROM street_edge
+         |        INNER JOIN audit_task ON street_edge.street_edge_id = audit_task.street_edge_id
+         |        INNER JOIN user_stat ON audit_task.user_id = user_stat.user_id
+         |        WHERE completed = TRUE AND (high_quality_manual = TRUE OR high_quality_manual IS NULL)
+         |    ) x
+         |) AS km_audited_no_overlap, (
+         |    SELECT COUNT(DISTINCT(users.user_id)) AS total_users,
+         |           COUNT(CASE WHEN mission_type = 'validation' THEN 1 END) AS validation_users,
+         |           COUNT(CASE WHEN mission_type = 'audit' THEN 1 END) AS audit_users,
+         |           COUNT(DISTINCT(CASE WHEN role = 'Registered' THEN user_id END)) AS registered_users,
+         |           COUNT(DISTINCT(CASE WHEN role = 'Anonymous' THEN user_id END)) AS anon_users,
+         |           COUNT(DISTINCT(CASE WHEN role = 'Turker' THEN user_id END)) AS turker_users,
+         |           COUNT(DISTINCT(CASE WHEN role IN ('Researcher', 'Administrator', 'Owner') THEN user_id END)) AS researcher_users
+         |    FROM (
+         |        SELECT users_with_type.user_id, mission_type, role.role
+         |        FROM (
+         |            SELECT DISTINCT(label_validation.user_id), 'validation' AS mission_type
+         |            FROM label_validation
+         |            UNION
+         |            SELECT DISTINCT(user_id), 'audit' AS mission_type
+         |            FROM audit_task
+         |            WHERE audit_task.completed = TRUE
+         |        ) users_with_type
+         |        INNER JOIN user_role ON users_with_type.user_id = user_role.user_id
+         |        INNER JOIN role ON user_role.role_id = role.role_id
+         |    ) users
+         |) AS users, (
+         |    SELECT COUNT(*) AS label_count,
+         |           COUNT(CASE WHEN label_type.label_type = 'CurbRamp' THEN 1 END) AS n_ramp,
+         |           COUNT(CASE WHEN label_type.label_type = 'CurbRamp' AND severity IS NOT NULL THEN 1 END) AS n_ramp_with_sev,
+         |           avg(CASE WHEN label_type.label_type = 'CurbRamp' THEN severity END) AS ramp_sev_mean,
+         |           stddev(CASE WHEN label_type.label_type = 'CurbRamp' THEN severity END) AS ramp_sev_sd,
+         |           COUNT(CASE WHEN label_type.label_type = 'NoCurbRamp' THEN 1 END) AS n_noramp,
+         |           COUNT(CASE WHEN label_type.label_type = 'NoCurbRamp' AND severity IS NOT NULL THEN 1 END) AS n_noramp_with_sev,
+         |           avg(CASE WHEN label_type.label_type = 'NoCurbRamp' THEN severity END) AS noramp_sev_mean,
+         |           stddev(CASE WHEN label_type.label_type = 'NoCurbRamp' THEN severity END) AS noramp_sev_sd,
+         |           COUNT(CASE WHEN label_type.label_type = 'Obstacle' THEN 1 END) AS n_obs,
+         |           COUNT(CASE WHEN label_type.label_type = 'Obstacle' AND severity IS NOT NULL THEN 1 END) AS n_obs_with_sev,
+         |           avg(CASE WHEN label_type.label_type = 'Obstacle' THEN severity END) AS obs_sev_mean,
+         |           stddev(CASE WHEN label_type.label_type = 'Obstacle' THEN severity END) AS obs_sev_sd,
+         |           COUNT(CASE WHEN label_type.label_type = 'SurfaceProblem' THEN 1 END) AS n_surf,
+         |           COUNT(CASE WHEN label_type.label_type = 'SurfaceProblem' AND severity IS NOT NULL THEN 1 END) AS n_surf_with_sev,
+         |           avg(CASE WHEN label_type.label_type = 'SurfaceProblem' THEN severity END) AS surf_sev_mean,
+         |           stddev(CASE WHEN label_type.label_type = 'SurfaceProblem' THEN severity END) AS surf_sev_sd,
+         |           COUNT(CASE WHEN label_type.label_type = 'NoSidewalk' THEN 1 END) AS n_nosidewalk,
+         |           COUNT(CASE WHEN label_type.label_type = 'NoSidewalk' AND severity IS NOT NULL THEN 1 END) AS n_nosidewalk_with_sev,
+         |           avg(CASE WHEN label_type.label_type = 'NoSidewalk' THEN severity END) AS nosidewalk_sev_mean,
+         |           stddev(CASE WHEN label_type.label_type = 'NoSidewalk' THEN severity END) AS nosidewalk_sev_sd,
+         |           COUNT(CASE WHEN label_type.label_type = 'Crosswalk' THEN 1 END) AS n_crswlk,
+         |           COUNT(CASE WHEN label_type.label_type = 'Crosswalk' AND severity IS NOT NULL THEN 1 END) AS n_crswlk_with_sev,
+         |           avg(CASE WHEN label_type.label_type = 'Crosswalk' THEN severity END) AS crswlk_sev_mean,
+         |           stddev(CASE WHEN label_type.label_type = 'Crosswalk' THEN severity END) AS crswlk_sev_sd,
+         |           COUNT(CASE WHEN label_type.label_type = 'Signal' THEN 1 END) AS n_signal,
+         |           COUNT(CASE WHEN label_type.label_type = 'Occlusion' THEN 1 END) AS n_occlusion,
+         |           COUNT(CASE WHEN label_type.label_type = 'Other' THEN 1 END) AS n_other,
+         |           COUNT(CASE WHEN label_type.label_type = 'Other' AND severity IS NOT NULL THEN 1 END) AS n_other_with_sev,
+         |           avg(CASE WHEN label_type.label_type = 'Other' THEN severity END) AS other_sev_mean,
+         |           stddev(CASE WHEN label_type.label_type = 'Other' THEN severity END) AS other_sev_sd
+         |    FROM label
+         |    INNER JOIN mission ON label.mission_id = mission.mission_id
+         |    INNER JOIN user_stat ON mission.user_id = user_stat.user_id
+         |    INNER JOIN label_type ON label.label_type_id = label_type.label_type_id
+         |    INNER JOIN audit_task ON label.audit_task_id = audit_task.audit_task_id
+         |    WHERE (user_stat.high_quality_manual = TRUE OR user_stat.high_quality_manual IS NULL)
+         |        AND deleted = FALSE
+         |        AND tutorial = FALSE
+         |        AND label.street_edge_id <> (SELECT MAX(street_edge_id) FROM street_edge WHERE timestamp = '2015-11-16 20:20:19.46-08')
+         |        AND audit_task.street_edge_id <> (SELECT MAX(street_edge_id) FROM street_edge WHERE timestamp = '2015-11-16 20:20:19.46-08')
+         |) AS label_counts_and_severity, (
+         |    SELECT SUM(agree_count) + SUM(disagree_count) + SUM(notsure_count) AS total_validations,
+         |           COUNT(CASE WHEN correct THEN 1 END) AS n_agree,
+         |           COUNT(CASE WHEN NOT correct THEN 1 END) AS n_disagree,
+         |           COUNT(CASE WHEN correct IS NOT NULL THEN 1 END) AS n_validated,
+         |           COUNT(CASE WHEN label_type = 'CurbRamp' AND correct THEN 1 END) AS n_ramp_agree,
+         |           COUNT(CASE WHEN label_type = 'CurbRamp' AND NOT correct THEN 1 END) AS n_ramp_disagree,
+         |           COUNT(CASE WHEN label_type = 'CurbRamp' AND correct IS NOT NULL THEN 1 END) AS n_ramp_total,
+         |           COUNT(CASE WHEN label_type = 'NoCurbRamp' AND correct THEN 1 END) AS n_noramp_agree,
+         |           COUNT(CASE WHEN label_type = 'NoCurbRamp' AND NOT correct THEN 1 END) AS n_noramp_disagree,
+         |           COUNT(CASE WHEN label_type = 'NoCurbRamp' AND correct IS NOT NULL THEN 1 END) AS n_noramp_total,
+         |           COUNT(CASE WHEN label_type = 'Obstacle' AND correct THEN 1 END) AS n_obs_agree,
+         |           COUNT(CASE WHEN label_type = 'Obstacle' AND NOT correct THEN 1 END) AS n_obs_disagree,
+         |           COUNT(CASE WHEN label_type = 'Obstacle' AND correct IS NOT NULL THEN 1 END) AS n_obs_total,
+         |           COUNT(CASE WHEN label_type = 'SurfaceProblem' AND correct THEN 1 END) AS n_surf_agree,
+         |           COUNT(CASE WHEN label_type = 'SurfaceProblem' AND NOT correct THEN 1 END) AS n_surf_disagree,
+         |           COUNT(CASE WHEN label_type = 'SurfaceProblem' AND correct IS NOT NULL THEN 1 END) AS n_surf_total,
+         |           COUNT(CASE WHEN label_type = 'NoSidewalk' AND correct THEN 1 END) AS n_nosidewalk_agree,
+         |           COUNT(CASE WHEN label_type = 'NoSidewalk' AND NOT correct THEN 1 END) AS n_nosidewalk_disagree,
+         |           COUNT(CASE WHEN label_type = 'NoSidewalk' AND correct IS NOT NULL THEN 1 END) AS n_nosidewalk_total,
+         |           COUNT(CASE WHEN label_type = 'Crosswalk' AND correct THEN 1 END) AS n_crswlk_agree,
+         |           COUNT(CASE WHEN label_type = 'Crosswalk' AND NOT correct THEN 1 END) AS n_crswlk_disagree,
+         |           COUNT(CASE WHEN label_type = 'Crosswalk' AND correct IS NOT NULL THEN 1 END) AS n_crswlk_total,
+         |           COUNT(CASE WHEN label_type = 'Signal' AND correct THEN 1 END) AS n_signal_agree,
+         |           COUNT(CASE WHEN label_type = 'Signal' AND NOT correct THEN 1 END) AS n_signal_disagree,
+         |           COUNT(CASE WHEN label_type = 'Signal' AND correct IS NOT NULL THEN 1 END) AS n_signal_total,
+         |           COUNT(CASE WHEN label_type = 'Occlusion' AND correct THEN 1 END) AS n_occlusion_agree,
+         |           COUNT(CASE WHEN label_type = 'Occlusion' AND NOT correct THEN 1 END) AS n_occlusion_disagree,
+         |           COUNT(CASE WHEN label_type = 'Occlusion' AND correct IS NOT NULL THEN 1 END) AS n_occlusion_total,
+         |           COUNT(CASE WHEN label_type = 'Other' AND correct THEN 1 END) AS n_other_agree,
+         |           COUNT(CASE WHEN label_type = 'Other' AND NOT correct THEN 1 END) AS n_other_disagree,
+         |           COUNT(CASE WHEN label_type = 'Other' AND correct IS NOT NULL THEN 1 END) AS n_other_total
+         |    FROM label
+         |    INNER JOIN label_type ON label.label_type_id = label_type.label_type_id
+         |    INNER JOIN mission ON label.mission_id = mission.mission_id
+         |    INNER JOIN user_stat ON mission.user_id = user_stat.user_id
+         |    INNER JOIN audit_task ON label.audit_task_id = audit_task.audit_task_id
+         |    WHERE (user_stat.high_quality_manual = TRUE OR user_stat.high_quality_manual IS NULL)
+         |        AND deleted = FALSE
+         |        AND tutorial = FALSE
+         |        AND label.street_edge_id <> (SELECT MAX(street_edge_id) FROM street_edge WHERE timestamp = '2015-11-16 20:20:19.46-08')
+         |        AND audit_task.street_edge_id <> (SELECT MAX(street_edge_id) FROM street_edge WHERE timestamp = '2015-11-16 20:20:19.46-08')
+         |) AS val_counts;""".stripMargin
+    )
+    overallStatsQuery.first
   }
 
   /**

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -1245,10 +1245,11 @@ object LabelTable {
          |       val_counts.n_other_disagree,
          |       1.0 * val_counts.n_other_agree / NULLIF(val_counts.n_other_total, 0) AS other_accuracy
          |FROM (
-         |    SELECT SUM(distance_progress) / 1000 AS km_audited
-         |    FROM mission
-         |    INNER JOIN user_stat ON mission.user_id = user_stat.user_id
-         |    WHERE high_quality_manual = TRUE OR high_quality_manual IS NULL
+         |    SELECT SUM(ST_LENGTH(ST_TRANSFORM(geom, 26918))) / 1000 AS km_audited
+         |    FROM street_edge
+         |    INNER JOIN audit_task ON street_edge.street_edge_id = audit_task.street_edge_id
+         |    INNER JOIN user_stat ON audit_task.user_id = user_stat.user_id
+         |    WHERE completed = TRUE AND (high_quality_manual = TRUE OR high_quality_manual IS NULL)
          |) AS km_audited, (
          |    SELECT SUM(ST_LENGTH(ST_TRANSFORM(geom, 26918))) / 1000 AS km_audited_no_overlap
          |    FROM (
@@ -1257,7 +1258,7 @@ object LabelTable {
          |        INNER JOIN audit_task ON street_edge.street_edge_id = audit_task.street_edge_id
          |        INNER JOIN user_stat ON audit_task.user_id = user_stat.user_id
          |        WHERE completed = TRUE AND (high_quality_manual = TRUE OR high_quality_manual IS NULL)
-         |    ) x
+         |    ) distinct_streets
          |) AS km_audited_no_overlap, (
          |    SELECT COUNT(DISTINCT(users.user_id)) AS total_users,
          |           COUNT(CASE WHEN mission_type = 'validation' THEN 1 END) AS validation_users,

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -1319,8 +1319,8 @@ object LabelTable {
          |    WHERE (user_stat.high_quality_manual = TRUE OR user_stat.high_quality_manual IS NULL)
          |        AND deleted = FALSE
          |        AND tutorial = FALSE
-         |        AND label.street_edge_id <> (SELECT MAX(street_edge_id) FROM street_edge WHERE timestamp = '2015-11-16 20:20:19.46-08')
-         |        AND audit_task.street_edge_id <> (SELECT MAX(street_edge_id) FROM street_edge WHERE timestamp = '2015-11-16 20:20:19.46-08')
+         |        AND label.street_edge_id <> $tutorialStreetId
+         |        AND audit_task.street_edge_id <> $tutorialStreetId
          |) AS label_counts_and_severity, (
          |    SELECT SUM(agree_count) + SUM(disagree_count) + SUM(notsure_count) AS total_validations,
          |           COUNT(CASE WHEN correct THEN 1 END) AS n_agree,
@@ -1361,8 +1361,8 @@ object LabelTable {
          |    WHERE (user_stat.high_quality_manual = TRUE OR user_stat.high_quality_manual IS NULL)
          |        AND deleted = FALSE
          |        AND tutorial = FALSE
-         |        AND label.street_edge_id <> (SELECT MAX(street_edge_id) FROM street_edge WHERE timestamp = '2015-11-16 20:20:19.46-08')
-         |        AND audit_task.street_edge_id <> (SELECT MAX(street_edge_id) FROM street_edge WHERE timestamp = '2015-11-16 20:20:19.46-08')
+         |        AND label.street_edge_id <> $tutorialStreetId
+         |        AND audit_task.street_edge_id <> $tutorialStreetId
          |) AS val_counts;""".stripMargin
     )
     overallStatsQuery.first

--- a/app/models/street/StreetEdgeTable.scala
+++ b/app/models/street/StreetEdgeTable.scala
@@ -75,7 +75,12 @@ object StreetEdgeTable {
   val userRoles = TableQuery[UserRoleTable]
   val userTable = TableQuery[UserTable]
   val roleTable = TableQuery[RoleTable]
-  val completedAuditTasks = auditTasks.filter(_.completed === true)
+
+  val completedAuditTasks = for {
+    _tasks <- auditTasks
+    _stat <- UserStatTable.userStats if _tasks.userId === _stat.userId
+    if _tasks.completed && !_stat.excluded
+  } yield _tasks
 
   val turkerCompletedAuditTasks = for {
     _tasks <- completedAuditTasks
@@ -179,7 +184,7 @@ object StreetEdgeTable {
         for {
             tasks <- auditTaskQuery
             stats <- UserStatTable.userStats if tasks.userId === stats.userId
-            if stats.highQuality && !stats.excluded
+            if stats.highQuality
         } yield tasks
       } else {
           auditTaskQuery
@@ -304,7 +309,7 @@ object StreetEdgeTable {
         for {
             tasks <- auditTasksQuery
             stats <- UserStatTable.userStats if tasks.userId === stats.userId
-            if stats.highQuality && !stats.excluded
+            if stats.highQuality
         } yield tasks
       } else {
           auditTasksQuery

--- a/app/models/user/UserStatTable.scala
+++ b/app/models/user/UserStatTable.scala
@@ -264,7 +264,7 @@ object UserStatTable {
     // First get users manually marked as low quality or marked to be excluded for other reasons.
     val lowQualUsers: List[(String, Boolean)] =
       userStats.filter(u => u.excluded || !u.highQualityManual.getOrElse(true))
-        .map(x => (x.userId, x.highQualityManual.get)).list
+        .map(x => (x.userId, false)).list
 
     // Decide if each user is high quality. Conditions in the method comment. Users manually marked for exclusion or
     // low quality are filtered out later (using results from the previous query).

--- a/app/views/developer.scala.html
+++ b/app/views/developer.scala.html
@@ -321,7 +321,42 @@
 
         <div class="row">
             <div class="col-sm-12">
-                <h2 id="access-dataset">Users API</h2>
+                <h2 id="general-stats-api">General Project Sidewalk Stats API</h2>
+                <table class="table">
+                    <tr>
+                        <th>URL</th>
+                        <td><code>/v2/overallStats</code></td>
+                    </tr>
+                    <tr>
+                        <th>Method</th>
+                        <td>GET</td>
+                    </tr>
+                    <tr>
+                        <th>Examples</th>
+                        <td>
+                            <a href="/v2/overallStats" target="_blank">
+                                <code>/v2/overallStats</code>
+                            </a><br>
+                            <a href="/v2/overallStats?filterLowQuality=true" target="_blank">
+                                <code>/v2/overallStats?filterLowQuality=true</code>
+                            </a><br>
+                            <a href="/v2/overallStats?filetype=csv" target="_blank">
+                                <code>/v2/overallStats?filetype=csv</code>
+                            </a>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>Description</th>
+                        <td>
+                            This endpoint gives some general stats about the data collected through Project Sidewalk in
+                            this city. It includes stats like the number of users and km audited. It also includes the
+                            following, broken down by label type: labels placed, average severity, and accuracy. There
+                            is an optional <code>filterLowQuality</code> parameter to remove low quality data.
+                        </td>
+                    </tr>
+                </table>
+
+                <h2 id="users-api">Users API</h2>
                 <table class="table">
                     <tr>
                         <th>URL</th>

--- a/conf/evolutions/default/169.sql
+++ b/conf/evolutions/default/169.sql
@@ -1,0 +1,10 @@
+# --- !Ups
+-- I've confirmed that neither timestamp is null in any database, so I'm just setting to now() to make things easy.
+UPDATE label_validation SET end_timestamp = now() WHERE end_timestamp IS NULL;
+ALTER TABLE label_validation ALTER COLUMN end_timestamp SET NOT NULL;
+UPDATE label_validation SET start_timestamp = now() WHERE start_timestamp IS NULL;
+ALTER TABLE label_validation ALTER COLUMN start_timestamp SET NOT NULL;
+
+# --- !Downs
+ALTER TABLE label_validation ALTER COLUMN start_timestamp DROP NOT NULL;
+ALTER TABLE label_validation ALTER COLUMN end_timestamp DROP NOT NULL;

--- a/conf/routes
+++ b/conf/routes
@@ -147,7 +147,7 @@ GET     /v2/access/attributesWithLabels                      @controllers.Projec
 GET     /v2/access/score/streets                             @controllers.ProjectSidewalkAPIController.getAccessScoreStreetsV2(lat1: Double, lng1: Double, lat2: Double, lng2: Double, filetype: Option[String])
 GET     /v2/access/score/neighborhoods                       @controllers.ProjectSidewalkAPIController.getAccessScoreNeighborhoodsV2(lat1: Double, lng1: Double, lat2: Double, lng2: Double, filetype: Option[String])
 GET     /v2/userStats                                        @controllers.ProjectSidewalkAPIController.getUsersAPIStats(filetype: Option[String])
-GET     /v2/overallStats                                     @controllers.ProjectSidewalkAPIController.getOverallSidewalkStats(filetype: Option[String])
+GET     /v2/overallStats                                     @controllers.ProjectSidewalkAPIController.getOverallSidewalkStats(filterLowQuality: Boolean ?= false, filetype: Option[String])
 GET     /v1/access/features                                  @controllers.ProjectSidewalkAPIController.getAccessAttributesV1(lat1: Double, lng1: Double, lat2: Double, lng2: Double)
 GET     /v1/access/attributes                                @controllers.ProjectSidewalkAPIController.getAccessAttributesV1(lat1: Double, lng1: Double, lat2: Double, lng2: Double)
 GET     /v1/access/score/neighborhoods                       @controllers.ProjectSidewalkAPIController.getAccessScoreNeighborhoodsV1(lat1: Double, lng1: Double, lat2: Double, lng2: Double)

--- a/conf/routes
+++ b/conf/routes
@@ -147,6 +147,7 @@ GET     /v2/access/attributesWithLabels                      @controllers.Projec
 GET     /v2/access/score/streets                             @controllers.ProjectSidewalkAPIController.getAccessScoreStreetsV2(lat1: Double, lng1: Double, lat2: Double, lng2: Double, filetype: Option[String])
 GET     /v2/access/score/neighborhoods                       @controllers.ProjectSidewalkAPIController.getAccessScoreNeighborhoodsV2(lat1: Double, lng1: Double, lat2: Double, lng2: Double, filetype: Option[String])
 GET     /v2/userStats                                        @controllers.ProjectSidewalkAPIController.getUsersAPIStats(filetype: Option[String])
+GET     /v2/overallStats                                     @controllers.ProjectSidewalkAPIController.getOverallSidewalkStats(filetype: Option[String])
 GET     /v1/access/features                                  @controllers.ProjectSidewalkAPIController.getAccessAttributesV1(lat1: Double, lng1: Double, lat2: Double, lng2: Double)
 GET     /v1/access/attributes                                @controllers.ProjectSidewalkAPIController.getAccessAttributesV1(lat1: Double, lng1: Double, lat2: Double, lng2: Double)
 GET     /v1/access/score/neighborhoods                       @controllers.ProjectSidewalkAPIController.getAccessScoreNeighborhoodsV1(lat1: Double, lng1: Double, lat2: Double, lng2: Double)


### PR DESCRIPTION
Resolves #2882 

Adds a new API endpoint with some general Project Sidewalk stats. We primarily plan to use this for writing reports, grants, etc. I added the option to output as a CSV, and I added minimal documentation for it to the /api page. The JSON output looks like this (ordering when broken down by label type not guaranteed):

```
{
    km_explored: ###.##,
    km_explored_without_overlap: ###.##,
    users_counts: {
        all_users: ####,
        labelers: ####,
        validators: ####,
        registered: ###,
        ...
    },
    labels: {
        label_count: ###,
        CurbRamp: {
            count: ###,
            count_with_severity: ###,
            severity_mean: #.#,
            severity_sd: #.#
        }
        ...
    },
    validations: {
        total_validations: ###,
        Overall: {
            validated: ###,
            agreed: ###,
            disagreed: ###,
            accuracy: ##.##%
        },
        CurbRamp: {
            validated: ###,
            agreed: ###,
            disagreed: ###,
            accuracy: ##.##%
        },
        ...
    }
}
```

##### Screenshots
![Screenshot from 2022-11-16 16-13-23](https://user-images.githubusercontent.com/6518824/202324380-ad237b0f-12dc-41b3-a170-c5deaa54a7dc.png)
![Screenshot from 2022-11-16 16-12-50](https://user-images.githubusercontent.com/6518824/202324381-65fad61c-237c-4618-80ef-5091445b810a.png)
![Screenshot from 2022-11-16 16-12-25](https://user-images.githubusercontent.com/6518824/202324383-ad1cd6a8-3491-4872-87d6-5a0438fea8ef.png)



##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.