### PR TITLE
Add stairs and garage entrance tags in Zurich

### DIFF
--- a/conf/cityparams.conf
+++ b/conf/cityparams.conf
@@ -271,11 +271,9 @@ city-params {
     ]
     zurich = [
       "tactile warning"
-      "garage entrance"
       "street vendor"
       "uncovered manhole"
       "APS"
-      "stairs"
       "level with sidewalk"
     ]
   }


### PR DESCRIPTION
Resolves #3086 

Adds the "stairs" and "garage entrance" tags for Obstacle labels in our Zurich deployment.

##### Before/After screenshots (if applicable)
Before
<img width="390" alt="Screenshot 2022-12-07 at 10 53 30 AM" src="https://user-images.githubusercontent.com/6518824/206271160-07877684-9f19-46c5-ac52-0cda963a1571.png">

After
<img width="390" alt="Screenshot 2022-12-07 at 10 54 40 AM" src="https://user-images.githubusercontent.com/6518824/206271188-9806c44c-8674-4ac1-8e85-e913ecc2ba27.png">

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've included before/after screenshots above.
