### PR TITLE
Fixes neighborhood complete message showing erroneously

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
+++ b/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
@@ -672,8 +672,8 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
 
         if (!status.labelBeforeJumpListenerSet) {
 
-            // Get a new task and check if its disconnected from the current task. If yes, then finish the current task
-            // after the user has labeling the the current location before jumping to the new location.
+            // Get a new task and check if it's disconnected from the current task. If yes, then finish the current task
+            // after the user has labeling the current location.
 
             missionJump = mission;
             var nextTask = svl.taskContainer.nextTask(task);
@@ -804,7 +804,7 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
             if ("compass" in svl) {
                 svl.compass.update();
             }
-            if (!isOnboarding && "taskContainer" in svl) {
+            if (!isOnboarding && "taskContainer" in svl && svl.taskContainer.tasksLoaded()) {
                 svl.taskContainer.update();
 
                 // End of the task if the user is close enough to the end point and we aren't in the tutorial.

--- a/public/javascripts/SVLabel/src/SVLabel/task/TaskContainer.js
+++ b/public/javascripts/SVLabel/src/SVLabel/task/TaskContainer.js
@@ -15,8 +15,14 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
     var previousTasks = [];
     var currentTask = null;
     var beforeJumpNewTask = null;
+    var tasksFinishedLoading = false;
 
     self._tasks = [];
+
+    self.tasksLoaded = function() {
+        return tasksFinishedLoading;
+    }
+
     self.getFinishedAndInitNextTask = function (finished) {
         var newTask = self.nextTask(finished);
         if (!newTask) {
@@ -146,6 +152,7 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
                         }
                     }
                 }
+                tasksFinishedLoading = true;
 
                 if (callback) callback();
             },


### PR DESCRIPTION
Resolves #1449 

This (should) _finally_ prevent the neighborhood complete message from showing erroneously when loading the audit page! We had a check in there that was meant to check that we had loaded the list of streets in the neighborhood, but that check really only checked that the object that holds the list of streets was created. I added a boolean that gets set when the streets have _actually_ finished loading, and it solved the issue!

In addition to this being a race condition, the other reason that this was hard to reproduce, was because this code only gets called when the user was being started near the end of the street they were assigned. This only happens when resuming a mostly finished street, or if you are assigned a very short street segment. There are many such short street segments in Zurich, which made it much easier to reproduce the issue there!

##### Before/After screenshots (if applicable)
Here's what the screen looked like before!
![image](https://user-images.githubusercontent.com/1621749/54279456-5e1b6800-4552-11e9-9563-c09701bce710.png)

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've included before/after screenshots above.
