### PR TITLE
Standardize audited distance calculation

### DIFF
--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -13,6 +13,7 @@ import formats.json.LabelFormat
 import formats.json.TaskFormats._
 import formats.json.UserRoleSubmissionFormats._
 import formats.json.LabelFormat._
+import javassist.NotFoundException
 import models.attribute.{GlobalAttribute, GlobalAttributeTable}
 import models.audit.{AuditTaskInteractionTable, AuditTaskTable, AuditedStreetWithTimestamp, InteractionWithLabel}
 import models.daos.slick.DBTableDefinitions.UserTable
@@ -80,8 +81,8 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
             if (Messages("measurement.system") == "metric") AuditTaskTable.getDistanceAudited(userId) / 1000F
             else AuditTaskTable.getDistanceAudited(userId) * METERS_TO_MILES
           }
-          Future.successful(Ok(views.html.admin.user("Project Sidewalk", request.identity, Some(user), auditedDistance)))
-        case _ => Future.successful(Ok(views.html.admin.user("Project Sidewalk", request.identity)))
+          Future.successful(Ok(views.html.admin.user("Project Sidewalk", request.identity.get, user, auditedDistance)))
+        case _ => Future.failed(new NotFoundException("Username not found."))
       }
     } else {
       Future.failed(new AuthenticationException("User is not an administrator"))
@@ -278,7 +279,7 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
           }
           val featureCollection = Json.obj("type" -> "FeatureCollection", "features" -> features)
           Future.successful(Ok(featureCollection))
-        case _ => Future.successful(Ok(views.html.admin.user("Project Sidewalk", request.identity)))
+        case _ => Future.failed(new NotFoundException("Username not found."))
       }
     } else {
       Future.failed(new AuthenticationException("User is not an administrator"))
@@ -305,7 +306,7 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
           }
           val featureCollection = Json.obj("type" -> "FeatureCollection", "features" -> features)
           Future.successful(Ok(featureCollection))
-        case _ => Future.successful(Ok(views.html.admin.user("Project Sidewalk", request.identity)))
+        case _ => Future.failed(new NotFoundException("Username not found."))
       }
     } else {
       Future.failed(new AuthenticationException("User is not an administrator"))
@@ -332,7 +333,7 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
         case Some(user) =>
           val tasksWithLabels = AuditTaskTable.selectTasksWithLabels(UUID.fromString(user.userId)).map(x => Json.toJson(x))
           Future.successful(Ok(JsArray(tasksWithLabels)))
-        case _ => Future.successful(Ok(views.html.admin.user("Project Sidewalk", request.identity)))
+        case _ => Future.failed(new NotFoundException("Username not found."))
       }
     } else {
       Future.failed(new AuthenticationException("User is not an administrator"))

--- a/app/controllers/UserProfileController.scala
+++ b/app/controllers/UserProfileController.scala
@@ -40,9 +40,9 @@ class UserProfileController @Inject() (implicit val env: Environment[User, Sessi
       val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
       val ipAddress: String = request.remoteAddress
       WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, "Visit_UserDashboard", timestamp))
-      // Get distance audited by the user. If using metric units, convert from miles to kilometers.
+      // Get distance audited by the user. Convert meters to km if using metric system, to miles if using IS.
       val auditedDistance: Float = {
-        if (Messages("measurement.system") == "metric") AuditTaskTable.getDistanceAudited(user.userId)
+        if (Messages("measurement.system") == "metric") AuditTaskTable.getDistanceAudited(user.userId) / 1000F
         else AuditTaskTable.getDistanceAudited(user.userId) * METERS_TO_MILES
       }
       Future.successful(Ok(views.html.userProfile(s"Project Sidewalk", Some(user), auditedDistance)))
@@ -201,9 +201,9 @@ class UserProfileController @Inject() (implicit val env: Environment[User, Sessi
     request.identity match {
       case Some(user) =>
         val userId: UUID = user.userId
-        // Get distance audited by the user. If using metric units, convert from miles to kilometers.
+        // Get distance audited by the user. Convert meters to km if using metric system, to miles if using IS.
         val auditedDistance: Float = {
-          if (Messages("measurement.system") == "metric") AuditTaskTable.getDistanceAudited(userId)
+          if (Messages("measurement.system") == "metric") AuditTaskTable.getDistanceAudited(userId) / 1000F
           else AuditTaskTable.getDistanceAudited(userId) * METERS_TO_MILES
         }
         Future.successful(Ok(Json.obj(

--- a/app/controllers/UserProfileController.scala
+++ b/app/controllers/UserProfileController.scala
@@ -10,13 +10,14 @@ import com.vividsolutions.jts.geom.Coordinate
 import controllers.headers.ProvidesHeader
 import formats.json.LabelFormat.labelMetadataUserDashToJson
 import models.audit.{AuditTaskTable, StreetEdgeWithAuditStatus}
-import models.mission.MissionTable
 import models.user.UserOrgTable
 import models.label.{LabelLocation, LabelTable, LabelValidationTable}
 import models.user.{User, WebpageActivity, WebpageActivityTable}
+import models.utils.CommonUtils.METERS_TO_MILES
 import play.api.libs.json.{JsObject, JsValue, Json}
 import play.extras.geojson
 import play.api.i18n.Messages
+
 import scala.concurrent.Future
 
 /**
@@ -41,8 +42,8 @@ class UserProfileController @Inject() (implicit val env: Environment[User, Sessi
       WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, "Visit_UserDashboard", timestamp))
       // Get distance audited by the user. If using metric units, convert from miles to kilometers.
       val auditedDistance: Float = {
-        if (Messages("measurement.system") == "metric") MissionTable.getDistanceAudited(user.userId) * 1.60934.toFloat
-        else MissionTable.getDistanceAudited(user.userId)
+        if (Messages("measurement.system") == "metric") AuditTaskTable.getDistanceAudited(user.userId)
+        else AuditTaskTable.getDistanceAudited(user.userId) * METERS_TO_MILES
       }
       Future.successful(Ok(views.html.userProfile(s"Project Sidewalk", Some(user), auditedDistance)))
     }
@@ -202,8 +203,8 @@ class UserProfileController @Inject() (implicit val env: Environment[User, Sessi
         val userId: UUID = user.userId
         // Get distance audited by the user. If using metric units, convert from miles to kilometers.
         val auditedDistance: Float = {
-          if (Messages("measurement.system") == "metric") MissionTable.getDistanceAudited(userId) * 1.60934.toFloat
-          else MissionTable.getDistanceAudited(userId)
+          if (Messages("measurement.system") == "metric") AuditTaskTable.getDistanceAudited(userId)
+          else AuditTaskTable.getDistanceAudited(userId) * METERS_TO_MILES
         }
         Future.successful(Ok(Json.obj(
           "distance_audited" -> auditedDistance,

--- a/app/models/audit/AuditTaskTable.scala
+++ b/app/models/audit/AuditTaskTable.scala
@@ -352,6 +352,17 @@ object AuditTaskTable {
   }
 
   /**
+    * Gets total distance audited by a user in meters.
+    */
+  def getDistanceAudited(userId: UUID): Float = db.withSession { implicit session =>
+    completedTasks
+      .filter(_.userId === userId.toString)
+      .innerJoin(streetEdges).on(_.streetEdgeId === _.streetEdgeId)
+      .map(_._2.geom.transform(26918).length)
+      .sum.run.getOrElse(0F)
+  }
+
+  /**
     * Get the sum of the line distance of all streets in the region that the user has not audited.
     */
   def getUnauditedDistance(userId: UUID, regionId: Int): Float = db.withSession { implicit session =>

--- a/app/models/mission/MissionTable.scala
+++ b/app/models/mission/MissionTable.scala
@@ -98,7 +98,6 @@ object MissionTable {
   }
   val validationMissions = missions.filter(_.missionTypeId === validationMissionTypeId)
 
-  val METERS_TO_MILES: Float = 0.000621371F
 
   // Distances for first few missions: 250 ft, 250 ft, then 500 ft for all remaining.
   val distancesForFirstAuditMissions: List[Float] = List(76.2F, 76.2F)
@@ -327,15 +326,6 @@ object MissionTable {
     */
   def totalRewardEarned(userId: UUID): Double = db.withSession { implicit session =>
     missions.filter(m => m.userId === userId.toString && m.completed).map(_.pay).sum.run.getOrElse(0.0D)
-  }
-
-  /**
-    * Gets total distance audited by a user in miles.
-    *
-    * @param userId the UUID of the user
-    */
-  def getDistanceAudited(userId: UUID): Float = db.withSession { implicit session =>
-    missions.filter(_.userId === userId.toString).map(_.distanceProgress).sum.run.getOrElse(0F) * METERS_TO_MILES
   }
 
   /**

--- a/app/models/user/UserCurrentRegionTable.scala
+++ b/app/models/user/UserCurrentRegionTable.scala
@@ -1,10 +1,12 @@
 package models.user
 
+import models.audit.AuditTaskTable
 import models.region.{Region, RegionTable}
 import models.utils.MyPostgresDriver.simple._
 import play.api.Play.current
+
 import java.util.UUID
-import models.mission.MissionTable
+import models.utils.CommonUtils.METERS_TO_MILES
 
 case class UserCurrentRegion(userCurrentRegionId: Int, userId: String, regionId: Int)
 
@@ -37,7 +39,7 @@ object UserCurrentRegionTable {
     * Checks if the given user is "experienced" (have audited at least 2 miles).
     */
   def isUserExperienced(userId: UUID): Boolean = db.withSession { implicit session =>
-    MissionTable.getDistanceAudited(userId) > experiencedUserMileageThreshold
+    AuditTaskTable.getDistanceAudited(userId) * METERS_TO_MILES > experiencedUserMileageThreshold
   }
 
   /**

--- a/app/models/user/UserStatTable.scala
+++ b/app/models/user/UserStatTable.scala
@@ -3,14 +3,18 @@ package models.user
 import formats.json.UserFormats.labelTypeStatWrites
 import models.attribute.UserAttributeLabelTable.userAttributeLabels
 import models.attribute.UserClusteringSessionTable
+import models.audit.AuditTaskTable
+
 import java.util.UUID
 import models.daos.slick.DBTableDefinitions.{DBUser, UserTable}
 import models.label.{LabelTable, LabelValidationTable}
 import models.mission.MissionTable
+import models.street.StreetEdgeTable
 import models.street.StreetEdgeTable.totalStreetDistance
 import models.utils.MyPostgresDriver.simple._
 import play.api.Play.current
 import play.api.libs.json.{JsObject, Json}
+
 import java.sql.Timestamp
 import scala.slick.lifted.ForeignKeyQuery
 import scala.slick.jdbc.{GetResult, StaticQuery => Q}
@@ -166,11 +170,12 @@ object UserStatTable {
       if _mission.missionEnd > cutoffTime
     } yield _user.userId).groupBy(x => x).map(_._1).list
 
-    // Computes the audited distance in meters using the distance_progress column of the mission table.
+    // Computes the audited distance in meters using the audit_task and street_edge tables.
     val auditedDists: List[(String, Option[Float])] =
-      MissionTable.auditMissions
+      AuditTaskTable.completedTasks
         .filter(_.userId inSet usersToUpdate)
-        .groupBy(_.userId).map(x => (x._1, x._2.map(_.distanceProgress).sum))
+        .innerJoin(StreetEdgeTable.streetEdges).on(_.streetEdgeId === _.streetEdgeId)
+        .groupBy(_._1.userId).map(x => (x._1, x._2.map(_._2.geom.transform(26918).length).sum))
         .list
 
     // Update the meters_audited column in the user_stat table.
@@ -396,13 +401,23 @@ object UserStatTable {
         |) "label_counts"
         |$usernamesJoin
         |INNER JOIN (
-        |    SELECT $groupingCol, COUNT(mission_id) AS mission_count, COALESCE(SUM(distance_progress), 0) AS distance_meters
+        |    SELECT $groupingCol, COUNT(mission_id) AS mission_count
         |    FROM mission
         |    INNER JOIN sidewalk_user ON mission.user_id = sidewalk_user.user_id
         |    $joinUserOrgTable
         |    WHERE (mission_end AT TIME ZONE 'US/Pacific') > $statStartTime
         |    GROUP BY $groupingCol
-        |) "missions_and_distance" ON label_counts.$groupingColName = missions_and_distance.$groupingColName
+        |) "missions_counts" ON label_counts.$groupingColName = missions_counts.$groupingColName
+        |INNER JOIN (
+        |    SELECT $groupingCol, COALESCE(SUM(ST_LENGTH(ST_TRANSFORM(geom, 26918))), 0) AS distance_meters
+        |    FROM street_edge
+        |    INNER JOIN audit_task ON street_edge.street_edge_id = audit_task.street_edge_id
+        |    INNER JOIN sidewalk_user ON audit_task.user_id = sidewalk_user.user_id
+        |    $joinUserOrgTable
+        |    WHERE audit_task.completed
+        |        AND (task_end AT TIME ZONE 'US/Pacific') > $statStartTime
+        |    GROUP BY $groupingCol
+        |) "distance" ON label_counts.$groupingColName = distance.$groupingColName
         |LEFT JOIN (
         |    SELECT $groupingColName,
         |           CAST(SUM(CASE WHEN correct THEN 1 ELSE 0 END) AS FLOAT) / NULLIF(SUM(CASE WHEN correct THEN 1 ELSE 0 END) + SUM(CASE WHEN NOT correct THEN 1 ELSE 0 END), 0) AS accuracy_temp,

--- a/app/models/utils/CommonUtils.scala
+++ b/app/models/utils/CommonUtils.scala
@@ -3,6 +3,8 @@ package models.utils
 import java.sql.Timestamp
 
 object CommonUtils {
+  val METERS_TO_MILES: Float = 0.000621371F
+
   // Defining ordered method for Timestamp so they can be used in sortBy.
   // https://stackoverflow.com/questions/29985911/sort-scala-arraybuffer-of-timestamp
   implicit def ordered: Ordering[Timestamp] = new Ordering[Timestamp] {

--- a/app/views/admin/user.scala.html
+++ b/app/views/admin/user.scala.html
@@ -10,7 +10,7 @@
 
 @import models.region.RegionTable
 @import models.audit.AuditTaskInteractionTable
-@(title: String, admin: Option[User] = None, user: Option[DBUser] = Some(DBUser("unknown", "unknown", "unknown")))(implicit lang: Lang)
+@(title: String, admin: Option[User] = None, user: Option[DBUser] = Some(DBUser("unknown", "unknown", "unknown")), auditedDistance: Float = 0F)(implicit lang: Lang)
 
 @main(title) {
     @navbar(admin)
@@ -68,7 +68,7 @@
                         <td>@MissionTable.countCompletedMissions(UUID.fromString(user.get.userId), includeOnboarding = false, includeSkipped = false)</td>
                         <td>@AuditTaskTable.countCompletedAudits(UUID.fromString(user.get.userId))</td>
                         <td>@LabelTable.countLabels(UUID.fromString(user.get.userId))</td>
-                        <td id="td-total-distance-audited-admin"></td>
+                        <td>@{s"%.2f ${Messages("dist.metric.abbr")}".format(auditedDistance)}</td>
                         <td>@{"%.2f".format(AuditTaskInteractionTable.getHoursAuditingAndValidating(user.get.userId))} hours</td>
                     </tr>
                 </table>

--- a/app/views/admin/user.scala.html
+++ b/app/views/admin/user.scala.html
@@ -10,10 +10,10 @@
 
 @import models.region.RegionTable
 @import models.audit.AuditTaskInteractionTable
-@(title: String, admin: Option[User] = None, user: Option[DBUser] = Some(DBUser("unknown", "unknown", "unknown")), auditedDistance: Float = 0F)(implicit lang: Lang)
+@(title: String, admin: User, user: DBUser, auditedDistance: Float = 0F)(implicit lang: Lang)
 
 @main(title) {
-    @navbar(admin)
+    @navbar(Some(admin))
     <div class="container">
         <div class="row">
             <div class="col-lg-12">
@@ -45,12 +45,12 @@
                         <th class="col-md">Current Neighborhood</th>
                     </tr>
                     <tr>
-                        <td>@user.get.username</td>
-                        <td>@user.get.userId</td>
-                        <td>@user.get.email</td>
+                        <td>@user.username</td>
+                        <td>@user.userId</td>
+                        <td>@user.email</td>
                         <td>
-                            @(UserCurrentRegionTable.currentRegion(UUID.fromString(user.get.userId)).map {x => RegionTable.neighborhoodName(x)}.getOrElse("Unassigned"))
-                            (Region ID: @(UserCurrentRegionTable.currentRegion(UUID.fromString(user.get.userId)).map{x => x}.getOrElse("NA")))
+                            @(UserCurrentRegionTable.currentRegion(UUID.fromString(user.userId)).map {x => RegionTable.neighborhoodName(x)}.getOrElse("Unassigned"))
+                            (Region ID: @(UserCurrentRegionTable.currentRegion(UUID.fromString(user.userId)).map{x => x}.getOrElse("NA")))
                         </td>
                     </tr>
                 </table>
@@ -65,11 +65,11 @@
                         <th class="col-md">Time spent auditing/validating</th>
                     </tr>
                     <tr>
-                        <td>@MissionTable.countCompletedMissions(UUID.fromString(user.get.userId), includeOnboarding = false, includeSkipped = false)</td>
-                        <td>@AuditTaskTable.countCompletedAudits(UUID.fromString(user.get.userId))</td>
-                        <td>@LabelTable.countLabels(UUID.fromString(user.get.userId))</td>
+                        <td>@MissionTable.countCompletedMissions(UUID.fromString(user.userId), includeOnboarding = false, includeSkipped = false)</td>
+                        <td>@AuditTaskTable.countCompletedAudits(UUID.fromString(user.userId))</td>
+                        <td>@LabelTable.countLabels(UUID.fromString(user.userId))</td>
                         <td>@{s"%.2f ${Messages("dist.metric.abbr")}".format(auditedDistance)}</td>
-                        <td>@{"%.2f".format(AuditTaskInteractionTable.getHoursAuditingAndValidating(user.get.userId))} hours</td>
+                        <td>@{"%.2f".format(AuditTaskInteractionTable.getHoursAuditingAndValidating(user.userId))} hours</td>
                     </tr>
                 </table>
             </div>
@@ -92,7 +92,7 @@
                     </tr>
                     </thead>
                     <tbody>
-                    @LabelTable.getRecentLabelsMetadata(1000, Some(user.get.userId)).map { userLabel =>
+                    @LabelTable.getRecentLabelsMetadata(1000, Some(user.userId)).map { userLabel =>
                         <tr>
                             <td class = 'timestamp'>@userLabel.timestamp</td>
                             <td>@userLabel.labelTypeKey</td>
@@ -140,7 +140,7 @@
                     </tr>
                 </thead>
                 <tbody>
-                @for(mission <- MissionTable.selectCompletedRegionalMission(UUID.fromString(user.get.userId))) {
+                @for(mission <- MissionTable.selectCompletedRegionalMission(UUID.fromString(user.userId))) {
                     <tr>
                         <td class="col-md-2">@mission.missionId</td>
                         <td class="col-md-2">@mission.missionType</td>
@@ -159,7 +159,7 @@
             <div class="col-lg-12">
                 <table class="table table-striped table-condensed">
                     <tr><th class="col-md-3">Timestamp</th><th class="col-md-3">Panorama Id</th><th class="col-md-6">Comment</th></tr>
-                    @AuditTaskCommentTable.all(user.get.username).getOrElse(List()).map { comment =>
+                    @AuditTaskCommentTable.all(user.username).getOrElse(List()).map { comment =>
                         <tr>
                             <td class = 'timestamp'>@comment.timestamp</td>
                             <td>@comment.gsvPanoramaId</td>
@@ -214,7 +214,7 @@
                 lng: "@lang.code",
                 debug: false
             }, function(err, t) {
-                AdminUser('@user.get.username');
+                AdminUser('@user.username');
                 $('#label-table').dataTable();
             });
         });

--- a/public/javascripts/Admin/src/Admin.User.js
+++ b/public/javascripts/Admin/src/Admin.User.js
@@ -29,9 +29,7 @@ function AdminUser(user) {
     var streetParams = {
         labelPopup: true,
         includeLabelCounts: true,
-        auditedStreetColor: 'black',
-        useTotalAuditedDistance: true,
-        progressElement: 'td-total-distance-audited-admin'
+        auditedStreetColor: 'black'
     };
     var map;
     var layers = [];

--- a/public/javascripts/Choropleths/InitializeStreets.js
+++ b/public/javascripts/Choropleths/InitializeStreets.js
@@ -9,7 +9,6 @@
 */
 function InitializeStreets(map, params, streetData) {
     let streetLayer;
-    let distanceAudited = 0;  // Distance audited in km.
     let hasUnauditedStreets = params.unauditedStreetColor != null;
 
     function onEachStreetFeature(feature, layer) {
@@ -35,28 +34,20 @@ function InitializeStreets(map, params, streetData) {
         onEachFeature: onEachStreetFeature
     })
         .addTo(map);
-    if (params.useTotalAuditedDistance) {
-        // Calculate total distance audited in km/miles depending on the measurement system used in the user's country.
-        for (let i = streetData.features.length - 1; i >= 0; i--) {
-            if (!hasUnauditedStreets || streetData.features[i].properties.audited) {
-                distanceAudited += turf.length(streetData.features[i], {units: i18next.t('common:unit-distance')});
+
+    // Get total reward if a turker.
+    if (params.userRole === 'Turker') {
+        $.ajax({
+            async: true,
+            url: '/rewardEarned',
+            type: 'get',
+            success: function(rewardData) {
+                document.getElementById('td-total-reward-earned').innerHTML = '$' + rewardData.reward_earned.toFixed(2);
+            },
+            error: function (xhr, ajaxOptions, thrownError) {
+                console.log(thrownError);
             }
-        }
-        document.getElementById(params.progressElement).innerHTML = distanceAudited.toPrecision(2) + ' ' + i18next.t('common:unit-distance-abbreviation');
-        // Get total reward if a turker.
-        if (params.userRole === 'Turker') {
-            $.ajax({
-                async: true,
-                url: '/rewardEarned',
-                type: 'get',
-                success: function(rewardData) {
-                    document.getElementById('td-total-reward-earned').innerHTML = '$' + rewardData.reward_earned.toFixed(2);
-                },
-                error: function (xhr, ajaxOptions, thrownError) {
-                    console.log(thrownError);
-                }
-            })
-        }
+        })
     }
     return streetLayer;
 }

--- a/public/javascripts/Progress/src/Progress.js
+++ b/public/javascripts/Progress/src/Progress.js
@@ -31,8 +31,6 @@ function Progress (_, $, difficultRegionIds, userRole) {
     var streetParams = {
         includeLabelCounts: true,
         auditedStreetColor: 'black',
-        useTotalAuditedDistance: false,
-        progressElement: 'td-total-distance-audited',
         userRole: userRole
     };
     var map;


### PR DESCRIPTION
Resolves #3085

Update some of our distance calculations so that they all use the length of the streets, combined with the list of completed tasks in the `audit_task` table. Prior, we were using the `distance_progress` column in the mission table for some of these calculations. But it's better to keep them consistent! It only makes the code a tiny bit more complex :)
