### PR TITLE
Fixing mission screens for browser zoom levels: 110%, 125%, and 133%.

### DIFF
--- a/public/javascripts/SVValidate/css/validate-mission-start-tutorial.css
+++ b/public/javascripts/SVValidate/css/validate-mission-start-tutorial.css
@@ -352,6 +352,8 @@
     .mst-content {
         width: 900px;
     }
+
+    /* We need to create space for the image at this zoom level. */
     .mts-text-area {
         width: 230px;
     }

--- a/public/javascripts/SVValidate/css/validate-mission-start-tutorial.css
+++ b/public/javascripts/SVValidate/css/validate-mission-start-tutorial.css
@@ -22,7 +22,7 @@
 
 .mission-start-tutorial-overlay {
     position: absolute;
-    height: calc(100vh - 91px); /* 91 is the height of the navbar + margin + border */
+    height: 710px;
     width: 100%;
     min-width: 1170px; /*  */
     background: white;
@@ -30,6 +30,7 @@
     display: flex;
     flex-shrink: 0;
     justify-content: center;
+    overflow: auto;
 
     /* Default font should be defined only here and should be overridden wherever needed. */
     font-family: 'Open Sans', sans-serif;
@@ -37,11 +38,7 @@
 
 .mst-content {
     margin-top: 25px;
-    display: flex;
-    flex-shrink: 0;
-    flex-wrap: wrap;
     width: 1020px;
-    flex-direction: column;
 }
 
 .mst-instruction-1 {
@@ -345,4 +342,17 @@
 
 .mst-carousel-location-indicator.current-location {
     background: #2C2A3D;
+}
+
+/* This block handles layout on browser zoom. */
+@media (max-width: 1170px) {
+    .mission-start-tutorial-overlay {
+        min-width: 1069px;
+    }
+    .mst-content {
+        width: 900px;
+    }
+    .mts-text-area {
+        width: 230px;
+    }
 }


### PR DESCRIPTION
Resolves #3103 

The validate mission screens were looking bad at different zoom levels. This PR fixes it with some CSS changes and media queries.

##### Before/After screenshots (if applicable)
Before
<img width="1439" alt="Screenshot 2023-01-12 at 12 56 02 PM" src="https://user-images.githubusercontent.com/8168506/212179660-d29e2ac4-f42b-407a-add6-d60267fbb8f6.png">

After
<img width="1440" alt="Screenshot 2023-01-12 at 12 55 28 PM" src="https://user-images.githubusercontent.com/8168506/212179699-b2a1a384-4f5a-4978-ab81-410ceb5e5a37.png">


##### Testing instructions
1. Open the validate mission tutorial.
2. Change the browser zoom to the following levels: 110%, 125%, and 133%. 
3. Ensure that the layout is optimum in all cases. 


##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
