### PR TITLE
3068 - remove severity label for pedestrian signal

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
@@ -150,7 +150,7 @@ function ContextMenu (uiContextMenu) {
         if (labels.length > 0) {
             var last_label = labels[labels.length - 1];
             var prop = last_label.getProperties();
-            console.log(prop.labelDescription);
+            // If the label is Pedestrian Signal, do not call ratingReminderAlert()
             if (prop.labelDescription !== 'Pedestrian Signal') {
                 svl.ratingReminderAlert.ratingClicked(prop.severity);
             }

--- a/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
@@ -150,7 +150,10 @@ function ContextMenu (uiContextMenu) {
         if (labels.length > 0) {
             var last_label = labels[labels.length - 1];
             var prop = last_label.getProperties();
-            svl.ratingReminderAlert.ratingClicked(prop.severity);
+            console.log(prop.labelDescription);
+            if (prop.labelDescription !== 'Pedestrian Signal') {
+                svl.ratingReminderAlert.ratingClicked(prop.severity);
+            }
         }
     }
 


### PR DESCRIPTION
Resolves #[3068](https://github.com/ProjectSidewalk/SidewalkWebpage/issues/3068) 

This is a brief description of the problem solved or feature implemented and how you implemented it:

Added an if prior to calling ratingReminderAlert on svl to ignore calling ratingReminderAlert if the prop's labelDescription is a Pedestrian Signal.

##### Before/After screenshots (if applicable)
![3068_before](https://user-images.githubusercontent.com/56641275/213839910-84148380-1b31-49d6-b734-497fe5314974.png)

![3068_after](https://user-images.githubusercontent.com/56641275/213839914-1d35e5b7-43f0-47ac-9b2a-3263397d1db5.png)


##### Testing instructions
1. Place 4 Pedestrian Signal labels to confirm if the severity rating reminder popup appears.
2. Place 4 of any other label (besides "Can't see the Sidewalk") to confirm if the severity rating reminder popup still appears.

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [X ] I've written a descriptive PR title.
- [ X] I've included before/after screenshots above.
