### PR TITLE
Fix getRegionId

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/Main.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Main.js
@@ -157,7 +157,7 @@ function Main (params) {
         svl.modalExample = new ModalExample(svl.modalModel, svl.onboardingModel, svl.ui.modalExample);
 
         svl.infoPopover = new GSVInfoPopover(svl.ui.dateHolder, svl.panorama, svl.map.getPosition, svl.map.getPanoId,
-            svl.taskContainer.getCurrentTask().getStreetEdgeId, svl.taskContainer.getCurrentTask().getRegionId,
+            svl.taskContainer.getCurrentTask().getStreetEdgeId, svl.neighborhoodContainer.getCurrentNeighborhood().getRegionId,
             svl.map.getPov, true, function() { svl.tracker.push('GSVInfoButton_Click'); },
             function() { svl.tracker.push('GSVInfoCopyToClipboard_Click'); },
             function() { svl.tracker.push('GSVInfoViewInGSV_Click'); }

--- a/public/javascripts/SVLabel/src/SVLabel/neighborhood/Neighborhood.js
+++ b/public/javascripts/SVLabel/src/SVLabel/neighborhood/Neighborhood.js
@@ -63,6 +63,13 @@ function Neighborhood (parameters) {
         return this;
     }
 
+    /**
+     * @returns region id of this neighborhood
+     */
+    function getRegionId () {
+        return getProperty('regionId');
+    }
+
     function totalLineDistanceInNeighborhood (unit) {
         if (!unit) unit = {units: 'kilometers'};
         if ("taskContainer" in svl && svl.taskContainer) {
@@ -90,5 +97,6 @@ function Neighborhood (parameters) {
     self.setProperty = setProperty;
     self.totalLineDistanceInNeighborhood = totalLineDistanceInNeighborhood;
     self.getGeoJSON = getGeoJSON;
+    self.getRegionId = getRegionId;
     return self;
 }

--- a/public/javascripts/SVLabel/src/SVLabel/task/Task.js
+++ b/public/javascripts/SVLabel/src/SVLabel/task/Task.js
@@ -269,10 +269,6 @@ function Task (geojson, tutorialTask, currentLat, currentLng, startPointReversed
         return _geojson.features[0].properties.street_edge_id;
     };
 
-    this.getRegionId = function () {
-        return _geojson.features[0].properties.region_id;
-    }
-
     this.streetCompletedByAnyUser = function () {
         return properties.completedByAnyUser;
     };


### PR DESCRIPTION
Resolves #3087 

Fixed Region ID not showing on GSV info popup on the Explore page.

##### Before/After screenshots (if applicable)
Before:
![image](https://user-images.githubusercontent.com/106000281/216453714-a552c1cf-e4ac-411f-a6a8-0418a6a5be52.png)
After:
![image](https://user-images.githubusercontent.com/106000281/216453735-be05e337-4977-4eab-9572-f80b6bacad7d.png)

##### Testing instructions
1. Navigate to Explore page and click on the GSV info button to see popup.

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
