### PR TITLE
Adds validation filters to Gallery, adds all filters as query parameters

### DIFF
--- a/app/controllers/ApplicationController.scala
+++ b/app/controllers/ApplicationController.scala
@@ -13,7 +13,6 @@ import models.amt.{AMTAssignment, AMTAssignmentTable}
 import models.audit.AuditTaskInteractionTable
 import models.daos.slick.DBTableDefinitions.UserTable
 import models.label.TagTable.selectTagsByLabelType
-import models.label.Tag
 import models.street.StreetEdgePriorityTable
 import models.utils.Configs
 import play.api.Play

--- a/app/controllers/ApplicationController.scala
+++ b/app/controllers/ApplicationController.scala
@@ -361,7 +361,7 @@ class ApplicationController @Inject() (implicit val env: Environment[User, Sessi
   /**
    * Returns the Gallery page.
    */
-  def gallery(labelType: String, severities: String) = UserAwareAction.async { implicit request =>
+  def gallery(labelType: String, severities: String, validationOptions: String) = UserAwareAction.async { implicit request =>
     request.identity match {
       case Some(user) =>
         val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
@@ -387,14 +387,15 @@ class ApplicationController @Inject() (implicit val env: Environment[User, Sessi
         )
         val labType: String = if (labelTypes.exists(x => { x._1 == labelType })) labelType else "Assorted"
 
-        // Make sure that list of severities is formatted correctly.
+        // Make sure that list of severities and validation options are formatted correctly.
         val severityList: List[Int] = severities.split(",").flatMap(s => Try(s.toInt).toOption).filter(s => s > 0 && s < 6).toList
+        val valOptions: List[String] = validationOptions.split(",").filter(List("correct", "incorrect", "unvalidated").contains(_)).toList
 
-        Future.successful(Ok(views.html.gallery("Gallery", Some(user), cityStr, cityUrls, labType, labelTypes, severityList)))
+        Future.successful(Ok(views.html.gallery("Gallery", Some(user), cityStr, cityUrls, labType, labelTypes, severityList, valOptions)))
       case None =>
         // Send them through anon signup so that there activities on sidewalk gallery are logged as anon.
         // UTF-8 codes needed to pass a URL that contains parameters: ? is %3F, & is %26
-        Future.successful(Redirect(s"/anonSignUp?url=/gallery%3labelType=$labelType%26severities=$severities"))
+        Future.successful(Redirect(s"/anonSignUp?url=/gallery%3labelType=$labelType%26severities=$severities%26validationOptions=${validationOptions}"))
     }
   }
 

--- a/app/controllers/ApplicationController.scala
+++ b/app/controllers/ApplicationController.scala
@@ -369,8 +369,6 @@ class ApplicationController @Inject() (implicit val env: Environment[User, Sessi
         val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
         val ipAddress: String = request.remoteAddress
 
-        // Log visit to Gallery.
-        WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, "Visit_Gallery", timestamp))
         // Get current city.
         val cityStr: String = Play.configuration.getString("city-id").get
         // Get names and URLs for cities to display in Gallery dropdown.
@@ -395,6 +393,10 @@ class ApplicationController @Inject() (implicit val env: Environment[User, Sessi
         val severityList: List[Int] = severities.split(",").flatMap(s => Try(s.toInt).toOption).filter(s => s > 0 && s < 6).toList
         val tagList: List[String] = tags.split(",").filter(possibleTags.contains).toList
         val valOptions: List[String] = validationOptions.split(",").filter(List("correct", "incorrect", "unvalidated").contains(_)).toList
+
+        // Log visit to Gallery.
+        val activityStr: String = s"Visit_Gallery_LabelType=${labType}_Severity=${severityList}_Tags=${tagList}_Validations=$valOptions"
+        WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, activityStr, timestamp))
 
         Future.successful(Ok(views.html.gallery("Gallery", Some(user), cityStr, cityUrls, labType, labelTypes, severityList, tagList, valOptions)))
       case None =>

--- a/app/controllers/ApplicationController.scala
+++ b/app/controllers/ApplicationController.scala
@@ -385,12 +385,12 @@ class ApplicationController @Inject() (implicit val env: Environment[User, Sessi
           ("Signal", Messages("signal")),
           ("Other", Messages("other"))
         )
-        val realLabel: String = if (labels.exists(x => {x._1 == labelType.getOrElse("Assorted")})) {
+        val labType: String = if (labels.exists(x => {x._1 == labelType.getOrElse("Assorted")})) {
           labelType.getOrElse("Assorted")
         } else {
           "Assorted"
         }
-        Future.successful(Ok(views.html.gallery("Gallery", Some(user), cityStr, cityUrls, realLabel, labels, List())))
+        Future.successful(Ok(views.html.gallery("Gallery", Some(user), cityStr, cityUrls, labType, labels, List())))
       case None =>
         // Send them through anon signup so that there activities on sidewalk gallery are logged as anon.
         // UTF-8 codes needed to pass a URL that contains parameters: ? is %3F, & is %26

--- a/app/controllers/ApplicationController.scala
+++ b/app/controllers/ApplicationController.scala
@@ -12,6 +12,8 @@ import models.user._
 import models.amt.{AMTAssignment, AMTAssignmentTable}
 import models.audit.AuditTaskInteractionTable
 import models.daos.slick.DBTableDefinitions.UserTable
+import models.label.TagTable.selectTagsByLabelType
+import models.label.Tag
 import models.street.StreetEdgePriorityTable
 import models.utils.Configs
 import play.api.Play
@@ -361,7 +363,7 @@ class ApplicationController @Inject() (implicit val env: Environment[User, Sessi
   /**
    * Returns the Gallery page.
    */
-  def gallery(labelType: String, severities: String, validationOptions: String) = UserAwareAction.async { implicit request =>
+  def gallery(labelType: String, severities: String, tags: String, validationOptions: String) = UserAwareAction.async { implicit request =>
     request.identity match {
       case Some(user) =>
         val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
@@ -385,17 +387,20 @@ class ApplicationController @Inject() (implicit val env: Environment[User, Sessi
           ("Signal", Messages("signal")),
           ("Other", Messages("other"))
         )
-        val labType: String = if (labelTypes.exists(x => { x._1 == labelType })) labelType else "Assorted"
+        val (labType, possibleTags): (String, List[String]) =
+          if (labelTypes.exists(x => { x._1 == labelType })) (labelType, selectTagsByLabelType(labelType).map(_.tag))
+          else ("Assorted", List())
 
         // Make sure that list of severities and validation options are formatted correctly.
         val severityList: List[Int] = severities.split(",").flatMap(s => Try(s.toInt).toOption).filter(s => s > 0 && s < 6).toList
+        val tagList: List[String] = tags.split(",").filter(possibleTags.contains).toList
         val valOptions: List[String] = validationOptions.split(",").filter(List("correct", "incorrect", "unvalidated").contains(_)).toList
 
-        Future.successful(Ok(views.html.gallery("Gallery", Some(user), cityStr, cityUrls, labType, labelTypes, severityList, valOptions)))
+        Future.successful(Ok(views.html.gallery("Gallery", Some(user), cityStr, cityUrls, labType, labelTypes, severityList, tagList, valOptions)))
       case None =>
         // Send them through anon signup so that there activities on sidewalk gallery are logged as anon.
         // UTF-8 codes needed to pass a URL that contains parameters: ? is %3F, & is %26
-        Future.successful(Redirect(s"/anonSignUp?url=/gallery%3labelType=$labelType%26severities=$severities%26validationOptions=${validationOptions}"))
+        Future.successful(Redirect(s"/anonSignUp?url=/gallery%3labelType=$labelType%26severities=$severities%26tags=$tags%26validationOptions=${validationOptions}"))
     }
   }
 

--- a/app/controllers/ApplicationController.scala
+++ b/app/controllers/ApplicationController.scala
@@ -400,7 +400,7 @@ class ApplicationController @Inject() (implicit val env: Environment[User, Sessi
       case None =>
         // Send them through anon signup so that there activities on sidewalk gallery are logged as anon.
         // UTF-8 codes needed to pass a URL that contains parameters: ? is %3F, & is %26
-        Future.successful(Redirect(s"/anonSignUp?url=/gallery%3labelType=$labelType%26severities=$severities%26tags=$tags%26validationOptions=${validationOptions}"))
+        Future.successful(Redirect(s"/anonSignUp?url=/gallery%3FlabelType=$labelType%26severities=$severities%26tags=$tags%26validationOptions=$validationOptions"))
     }
   }
 

--- a/app/controllers/GalleryController.scala
+++ b/app/controllers/GalleryController.scala
@@ -63,9 +63,8 @@ class GalleryController @Inject() (implicit val env: Environment[User, SessionAu
               }
             // Shuffle labels if needed.
             val realLabels: Seq[LabelValidationMetadata] =
-              if (submission.severities.isEmpty && submission.tags.isEmpty) {
-                scala.util.Random.shuffle(labels)
-              } else labels
+              if (severitiesToSelect.isEmpty && tagsToSelect.isEmpty) scala.util.Random.shuffle(labels) else labels
+
 
             val jsonList: Seq[JsObject] = realLabels.map(l => Json.obj(
                 "label" -> LabelFormat.validationLabelMetadataToJson(l),

--- a/app/controllers/GalleryController.scala
+++ b/app/controllers/GalleryController.scala
@@ -42,7 +42,9 @@ class GalleryController @Inject() (implicit val env: Environment[User, SessionAu
       submission => {
         request.identity match {
           case Some(user) =>
+            val n: Int = submission.n
             val loadedLabelIds: Set[Int] = submission.loadedLabels.toSet
+            val valOptions: Set[String] = submission.validationOptions.toSet
             val severitiesToSelect: Set[Int] = submission.severities.getOrElse(Seq()).toSet
             val tagsToSelect: Set[String] = submission.tags.getOrElse(Seq()).toSet
 
@@ -50,18 +52,18 @@ class GalleryController @Inject() (implicit val env: Environment[User, SessionAu
             val labels: Seq[LabelValidationMetadata] =
               if (validLabTypes.contains(submission.labelTypeId)) {
                 if (severitiesToSelect.isEmpty && tagsToSelect.isEmpty) {
-                  LabelTable.getLabelsByType(submission.labelTypeId, submission.n, loadedLabelIds, user.userId)
+                  LabelTable.getLabelsByType(submission.labelTypeId, n, loadedLabelIds, valOptions, user.userId)
                 } else {
                   LabelTable.getLabelsOfTypeBySeverityAndTags(
-                    submission.labelTypeId, submission.n, loadedLabelIds, severitiesToSelect, tagsToSelect, user.userId
+                    submission.labelTypeId, n, loadedLabelIds, valOptions, severitiesToSelect, tagsToSelect, user.userId
                   )
                 }
               } else {
-                LabelTable.getAssortedLabels(submission.n, loadedLabelIds, user.userId, Some(severitiesToSelect))
+                LabelTable.getAssortedLabels(n, loadedLabelIds, valOptions, user.userId, Some(severitiesToSelect))
               }
-            // Shuffle labels if needed
-            val realLabels =
-              if (submission.severities == None && submission.tags == None) {
+            // Shuffle labels if needed.
+            val realLabels: Seq[LabelValidationMetadata] =
+              if (submission.severities.isEmpty && submission.tags.isEmpty) {
                 scala.util.Random.shuffle(labels)
               } else labels
 

--- a/app/controllers/GalleryController.scala
+++ b/app/controllers/GalleryController.scala
@@ -59,7 +59,7 @@ class GalleryController @Inject() (implicit val env: Environment[User, SessionAu
                   )
                 }
               } else {
-                LabelTable.getAssortedLabels(n, loadedLabelIds, valOptions, user.userId, Some(severitiesToSelect))
+                LabelTable.getAssortedLabels(n, loadedLabelIds, valOptions, user.userId, severitiesToSelect)
               }
             // Shuffle labels if needed.
             val realLabels: Seq[LabelValidationMetadata] =

--- a/app/formats/json/GalleryFormats.scala
+++ b/app/formats/json/GalleryFormats.scala
@@ -8,7 +8,7 @@ object GalleryFormats {
   case class GalleryEnvironmentSubmission(browser: Option[String], browserVersion: Option[String], browserWidth: Option[Int], browserHeight: Option[Int], screenWidth: Option[Int], screenHeight: Option[Int], availWidth: Option[Int], availHeight: Option[Int], operatingSystem: Option[String], language: String)
   case class GalleryInteractionSubmission(action: String, panoId: Option[String], note: Option[String], timestamp: Long)
   case class GalleryTaskSubmission(environment: GalleryEnvironmentSubmission, interactions: Seq[GalleryInteractionSubmission])
-  case class GalleryLabelsRequest(labelTypeId: Int, n: Int, validationOptions: Seq[String], severities: Option[Seq[Int]], tags: Option[Seq[String]], loadedLabels: Seq[Int])
+  case class GalleryLabelsRequest(n: Int, labelTypeId: Option[Int], validationOptions: Option[Seq[String]], severities: Option[Seq[Int]], tags: Option[Seq[String]], loadedLabels: Seq[Int])
 
   implicit val galleryEnvironmentSubmissionReads: Reads[GalleryEnvironmentSubmission] = (
     (JsPath \ "browser").readNullable[String] and
@@ -36,9 +36,9 @@ object GalleryFormats {
     )(GalleryTaskSubmission.apply _)
 
   implicit val galleryLabelsRequestReads: Reads[GalleryLabelsRequest] = (
-    (JsPath \ "label_type_id").read[Int] and
-      (JsPath \ "n").read[Int] and
-      (JsPath \ "validation_options").read[Seq[String]] and
+    (JsPath \ "n").read[Int] and
+      (JsPath \ "label_type_id").readNullable[Int] and
+      (JsPath \ "validation_options").readNullable[Seq[String]] and
       (JsPath \ "severities").readNullable[Seq[Int]] and
       (JsPath \ "tags").readNullable[Seq[String]] and
       (JsPath \ "loaded_labels").read[Seq[Int]]

--- a/app/formats/json/GalleryFormats.scala
+++ b/app/formats/json/GalleryFormats.scala
@@ -8,7 +8,7 @@ object GalleryFormats {
   case class GalleryEnvironmentSubmission(browser: Option[String], browserVersion: Option[String], browserWidth: Option[Int], browserHeight: Option[Int], screenWidth: Option[Int], screenHeight: Option[Int], availWidth: Option[Int], availHeight: Option[Int], operatingSystem: Option[String], language: String)
   case class GalleryInteractionSubmission(action: String, panoId: Option[String], note: Option[String], timestamp: Long)
   case class GalleryTaskSubmission(environment: GalleryEnvironmentSubmission, interactions: Seq[GalleryInteractionSubmission])
-  case class GalleryLabelsRequest(labelTypeId: Int, n: Int, severities: Option[Seq[Int]], tags: Option[Seq[String]], loadedLabels: Seq[Int])
+  case class GalleryLabelsRequest(labelTypeId: Int, n: Int, validationOptions: Seq[String], severities: Option[Seq[Int]], tags: Option[Seq[String]], loadedLabels: Seq[Int])
 
   implicit val galleryEnvironmentSubmissionReads: Reads[GalleryEnvironmentSubmission] = (
     (JsPath \ "browser").readNullable[String] and
@@ -36,10 +36,11 @@ object GalleryFormats {
     )(GalleryTaskSubmission.apply _)
 
   implicit val galleryLabelsRequestReads: Reads[GalleryLabelsRequest] = (
-    (JsPath \ "labelTypeId").read[Int] and
+    (JsPath \ "label_type_id").read[Int] and
       (JsPath \ "n").read[Int] and
+      (JsPath \ "validation_options").read[Seq[String]] and
       (JsPath \ "severities").readNullable[Seq[Int]] and
       (JsPath \ "tags").readNullable[Seq[String]] and
-      (JsPath \ "loadedLabels").read[Seq[Int]]
+      (JsPath \ "loaded_labels").read[Seq[Int]]
   )(GalleryLabelsRequest.apply _)
 }

--- a/app/formats/json/LabelFormat.scala
+++ b/app/formats/json/LabelFormat.scala
@@ -73,6 +73,7 @@ object LabelFormat {
       "description" -> labelMetadata.description,
       "street_edge_id" -> labelMetadata.streetEdgeId,
       "region_id" -> labelMetadata.regionId,
+      "correctness" -> labelMetadata.correct,
       "user_validation" -> labelMetadata.userValidation.map(LabelValidationTable.validationOptions.get),
       "tags" -> labelMetadata.tags
     )

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -165,14 +165,15 @@ object LabelTable {
                                      timestamp: java.sql.Timestamp, heading: Float, pitch: Float, zoom: Int,
                                      canvasX: Int, canvasY: Int, canvasWidth: Int, canvasHeight: Int,
                                      severity: Option[Int], temporary: Boolean, description: Option[String],
-                                     streetEdgeId: Int, regionId: Int, userValidation: Option[Int], tags: List[String]) extends BasicLabelMetadata
+                                     streetEdgeId: Int, regionId: Int, correct: Option[Boolean],
+                                     userValidation: Option[Int], tags: List[String]) extends BasicLabelMetadata
 
   case class LabelValidationMetadataWithoutTags(labelId: Int, labelType: String, gsvPanoramaId: String,
                                                 imageDate: String, timestamp: java.sql.Timestamp, heading: Float,
                                                 pitch: Float, zoom: Int, canvasX: Int, canvasY: Int, canvasWidth: Int,
                                                 canvasHeight: Int, severity: Option[Int], temporary: Boolean,
                                                 description: Option[String], streetEdgeId: Int, regionId: Int,
-                                                userValidation: Option[Int]) extends BasicLabelMetadata
+                                                correct: Option[Boolean], userValidation: Option[Int]) extends BasicLabelMetadata
 
   case class ResumeLabelMetadata(labelData: Label, labelType: String, pointData: LabelPoint, svImageWidth: Int,
                                  svImageHeight: Int, tagIds: List[Int])
@@ -196,7 +197,7 @@ object LabelTable {
     LabelValidationMetadataWithoutTags(
       r.nextInt, r.nextString, r.nextString, r.nextString, r.nextTimestamp, r.nextFloat,
       r.nextFloat, r.nextInt, r.nextInt, r.nextInt, r.nextInt, r.nextInt, r.nextIntOption, r.nextBoolean,
-      r.nextStringOption, r.nextInt, r.nextInt, r.nextIntOption
+      r.nextStringOption, r.nextInt, r.nextInt, r.nextBooleanOption, r.nextIntOption
     )
   )
 
@@ -204,7 +205,8 @@ object LabelTable {
     LabelValidationMetadata(
       r.nextInt, r.nextString, r.nextString, r.nextString, r.nextTimestamp, r.nextFloat, r.nextFloat, r.nextInt,
       r.nextInt, r.nextInt, r.nextInt, r.nextInt, r.nextIntOption, r.nextBoolean, r.nextStringOption, r.nextInt,
-      r.nextInt, r.nextIntOption, r.nextStringOption.map(tags => tags.split(",").toList).getOrElse(List())
+      r.nextInt, r.nextBooleanOption, r.nextIntOption,
+      r.nextStringOption.map(tags => tags.split(",").toList).getOrElse(List())
     )
   )
 
@@ -553,7 +555,7 @@ object LabelTable {
           |        label.time_created, label_point.heading, label_point.pitch, label_point.zoom, label_point.canvas_x,
           |        label_point.canvas_y, label_point.canvas_width, label_point.canvas_height, label.severity,
           |        label.temporary, label.description, label.street_edge_id, street_edge_region.region_id,
-          |        user_validation.validation_result, the_tags.tag_list
+          |        label.correct, user_validation.validation_result, the_tags.tag_list
           |FROM label
           |INNER JOIN label_type ON label.label_type_id = label_type.label_type_id
           |INNER JOIN label_point ON label.label_id = label_point.label_id
@@ -683,7 +685,7 @@ object LabelTable {
       (l, v) <- _galleryLabels.leftJoin(userValidations).on(_._1.labelId === _._1)
     } yield (l._1.labelId, l._3.labelType, l._1.gsvPanoramaId, l._4.imageDate, l._1.timeCreated, l._2.heading,
       l._2.pitch, l._2.zoom, l._2.canvasX, l._2.canvasY, l._2.canvasWidth, l._2.canvasHeight, l._1.severity,
-      l._1.temporary, l._1.description, l._1.streetEdgeId, l._5.regionId, v._2.?)
+      l._1.temporary, l._1.description, l._1.streetEdgeId, l._5.regionId, l._1.correct, v._2.?)
 
     // Remove duplicates that we got from joining with the `label_tag` table.
     val uniqueLabels = addValidations.groupBy(x => x).map(_._1)
@@ -743,7 +745,7 @@ object LabelTable {
       (l, v) <- _labels.leftJoin(userValidations).on(_._1.labelId === _._1)
     } yield (l._1.labelId, l._3.labelType, l._1.gsvPanoramaId, l._4.imageDate, l._1.timeCreated, l._2.heading,
       l._2.pitch, l._2.zoom, l._2.canvasX, l._2.canvasY, l._2.canvasWidth, l._2.canvasHeight, l._1.severity,
-      l._1.temporary, l._1.description, l._1.streetEdgeId, l._5.regionId, v._2.?)
+      l._1.temporary, l._1.description, l._1.streetEdgeId, l._5.regionId, l._1.correct, v._2.?)
 
     // Run query, group by label type, and randomize order.
     val potentialLabels: Map[String, List[LabelValidationMetadataWithoutTags]] =
@@ -801,7 +803,7 @@ object LabelTable {
       (l, v) <- _labels.leftJoin(userValidations).on(_._1.labelId === _._1)
     } yield (l._1.labelId, l._3.labelType, l._1.gsvPanoramaId, l._4.imageDate, l._1.timeCreated, l._2.heading,
       l._2.pitch, l._2.zoom, l._2.canvasX, l._2.canvasY, l._2.canvasWidth, l._2.canvasHeight, l._1.severity,
-      l._1.temporary, l._1.description, l._1.streetEdgeId, l._5.regionId, v._2.?)
+      l._1.temporary, l._1.description, l._1.streetEdgeId, l._5.regionId, l._1.correct, v._2.?)
 
     // Randomize and convert to LabelValidationMetadataWithoutTags.
     val newRandomLabelsList = addValidations.sortBy(x => rand).list.map(LabelValidationMetadataWithoutTags.tupled)
@@ -970,7 +972,7 @@ object LabelTable {
       LabelValidationMetadata(
         label.labelId, label.labelType, label.gsvPanoramaId, label.imageDate, label.timestamp, label.heading,
         label.pitch, label.zoom, label.canvasX, label.canvasY, label.canvasWidth, label.canvasHeight, label.severity,
-        label.temporary, label.description, label.streetEdgeId, label.regionId, label.userValidation, tags
+        label.temporary, label.description, label.streetEdgeId, label.regionId, label.correct, label.userValidation, tags
       )
   }
 

--- a/app/models/label/TagTable.scala
+++ b/app/models/label/TagTable.scala
@@ -27,4 +27,11 @@ object TagTable {
   def selectAllTags(): List[Tag] = db.withSession { implicit session =>
     tagTable.list
   }
+
+  def selectTagsByLabelType(labelType: String): List[Tag] = db.withSession { implicit session =>
+    tagTable
+      .innerJoin(LabelTypeTable.labelTypes).on(_.labelTypeId === _.labelTypeId)
+      .filter(_._2.labelType === labelType)
+      .map(_._1).list
+  }
 }

--- a/app/views/gallery.scala.html
+++ b/app/views/gallery.scala.html
@@ -1,5 +1,5 @@
 @import models.user.User
-@(title: String, user: Option[User] = None, cityId: String, otherCityURLs: List[(String, String, String, String)], labelType: String, labels: List[(String, String)], severity: List[Int])(implicit lang: Lang)
+@(title: String, user: Option[User] = None, cityId: String, otherCityURLs: List[(String, String, String, String)], labelType: String, labels: List[(String, String)], severities: List[Int])(implicit lang: Lang)
 
 @main(title) {
     <script type="text/javascript" src='@routes.Assets.at("javascripts/Gallery/build/Gallery.js")'></script>
@@ -123,7 +123,8 @@
 
             // Initial set of sidebar filters.
             params.initialFilters = {
-                labelType: '@labelType'
+                labelType: '@labelType',
+                severities: @{severities.mkString("[", ",", "]")}
             }
 
             params.language = "@lang.code";

--- a/app/views/gallery.scala.html
+++ b/app/views/gallery.scala.html
@@ -1,5 +1,5 @@
 @import models.user.User
-@(title: String, user: Option[User] = None, cityId: String, otherCityURLs: List[(String, String, String, String)], labelType: String, labels: List[(String, String)], severities: List[Int], validationOptions: List[String])(implicit lang: Lang)
+@(title: String, user: Option[User] = None, cityId: String, otherCityURLs: List[(String, String, String, String)], labelType: String, labels: List[(String, String)], severities: List[Int], tags: List[String], valOptions: List[String])(implicit lang: Lang)
 
 @main(title) {
     <script type="text/javascript" src='@routes.Assets.at("javascripts/Gallery/build/Gallery.js")'></script>
@@ -125,7 +125,8 @@
             params.initialFilters = {
                 labelType: '@labelType',
                 severities: @{severities.mkString("[", ",", "]")},
-                validationOptions: @{if (validationOptions.isEmpty) "[]" else Html(validationOptions.mkString("['", "','", "']"))}
+                validationOptions: @{if (valOptions.isEmpty) "[]" else Html(valOptions.mkString("['", "','", "']"))},
+                tags: @{if (tags.isEmpty) "[]" else Html(tags.mkString("['", "','", "']"))}
             }
 
             params.language = "@lang.code";

--- a/app/views/gallery.scala.html
+++ b/app/views/gallery.scala.html
@@ -1,5 +1,5 @@
 @import models.user.User
-@(title: String, user: Option[User] = None, cityId: String, otherCityURLs: List[(String, String, String, String)], label: String, labels: List[(String, String)], severity: List[Int])(implicit lang: Lang)
+@(title: String, user: Option[User] = None, cityId: String, otherCityURLs: List[(String, String, String, String)], labelType: String, labels: List[(String, String)], severity: List[Int])(implicit lang: Lang)
 
 @main(title) {
     <script type="text/javascript" src='@routes.Assets.at("javascripts/Gallery/build/Gallery.js")'></script>
@@ -55,7 +55,7 @@
                         <h4><b>@Messages("gallery.show")</b></h4>
                         <select id="label-select" class="gallery-filter" disabled>
                             @for((value, message) <- labels) {
-                                @if(value == label) {
+                                @if(value == labelType) {
                                     <option value="@value" selected>@message</option>
                                 } else {
                                     <option value="@value">@message</option>
@@ -120,6 +120,11 @@
             // URLs for where to send interaction data
             params.dataStoreUrl = '@routes.GalleryTaskController.post';
             params.beaconDataStoreUrl = params.dataStoreUrl + "Beacon";
+
+            // Initial set of sidebar filters.
+            params.initialFilters = {
+                labelType: '@labelType'
+            }
 
             params.language = "@lang.code";
 

--- a/app/views/gallery.scala.html
+++ b/app/views/gallery.scala.html
@@ -1,5 +1,5 @@
 @import models.user.User
-@(title: String, user: Option[User] = None, cityId: String, otherCityURLs: List[(String, String, String, String)], labelType: String, labels: List[(String, String)], severities: List[Int])(implicit lang: Lang)
+@(title: String, user: Option[User] = None, cityId: String, otherCityURLs: List[(String, String, String, String)], labelType: String, labels: List[(String, String)], severities: List[Int], validationOptions: List[String])(implicit lang: Lang)
 
 @main(title) {
     <script type="text/javascript" src='@routes.Assets.at("javascripts/Gallery/build/Gallery.js")'></script>
@@ -124,7 +124,8 @@
             // Initial set of sidebar filters.
             params.initialFilters = {
                 labelType: '@labelType',
-                severities: @{severities.mkString("[", ",", "]")}
+                severities: @{severities.mkString("[", ",", "]")},
+                validationOptions: @{if (validationOptions.isEmpty) "[]" else Html(validationOptions.mkString("['", "','", "']"))}
             }
 
             params.language = "@lang.code";

--- a/app/views/gallery.scala.html
+++ b/app/views/gallery.scala.html
@@ -71,6 +71,8 @@
                     <span id="severity-select"></span>
                     <h5 id="tags-header" class="filter-subheader">@Messages("gallery.tags")</h5>
                     <span id="tags"></span>
+                    <h5 id="validation-options-header" class="filter-subheader">Validations</h5>
+                    <span id="validation-options"></span>
                 </div>
             </div>
         </div>

--- a/app/views/gallery.scala.html
+++ b/app/views/gallery.scala.html
@@ -71,7 +71,7 @@
                     <span id="severity-select"></span>
                     <h5 id="tags-header" class="filter-subheader">@Messages("gallery.tags")</h5>
                     <span id="tags"></span>
-                    <h5 id="validation-options-header" class="filter-subheader">Validations</h5>
+                    <h5 id="validation-options-header" class="filter-subheader">@Messages("gallery.validations")</h5>
                     <span id="validation-options"></span>
                 </div>
             </div>

--- a/app/views/navbar.scala.html
+++ b/app/views/navbar.scala.html
@@ -130,7 +130,7 @@
                             </li>
                         }
                         <li>
-                            <a id="navbar-gallery-btn" role="menuitem" href="@routes.ApplicationController.gallery("Assorted", "")">@Messages("gallery")</a>
+                            <a id="navbar-gallery-btn" role="menuitem" href="@routes.ApplicationController.gallery("Assorted", "", "correct,unvalidated")">@Messages("gallery")</a>
                         </li>
                         <li>
                             <a id="navbar-leaderboard-btn" role="menuitem" href='@routes.ApplicationController.leaderboard'>@Messages("navbar.leaderboard")</a>

--- a/app/views/navbar.scala.html
+++ b/app/views/navbar.scala.html
@@ -130,7 +130,7 @@
                             </li>
                         }
                         <li>
-                            <a id="navbar-gallery-btn" role="menuitem" href="@routes.ApplicationController.gallery(None, None)">@Messages("gallery")</a>
+                            <a id="navbar-gallery-btn" role="menuitem" href="@routes.ApplicationController.gallery("Assorted", "")">@Messages("gallery")</a>
                         </li>
                         <li>
                             <a id="navbar-leaderboard-btn" role="menuitem" href='@routes.ApplicationController.leaderboard'>@Messages("navbar.leaderboard")</a>

--- a/app/views/navbar.scala.html
+++ b/app/views/navbar.scala.html
@@ -130,7 +130,7 @@
                             </li>
                         }
                         <li>
-                            <a id="navbar-gallery-btn" role="menuitem" href="@routes.ApplicationController.gallery("Assorted", "", "correct,unvalidated")">@Messages("gallery")</a>
+                            <a id="navbar-gallery-btn" role="menuitem" href="@routes.ApplicationController.gallery("Assorted", "", "", "correct,unvalidated")">@Messages("gallery")</a>
                         </li>
                         <li>
                             <a id="navbar-leaderboard-btn" role="menuitem" href='@routes.ApplicationController.leaderboard'>@Messages("navbar.leaderboard")</a>

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -335,6 +335,7 @@ gallery.show = Show
 gallery.filter.by = Filter By
 gallery.severity = Severity
 gallery.tags = Tags
+gallery.validations = Validations
 gallery.all = All
 gallery.occlusion = Can''t See Sidewalk
 gallery.labels.not.found = No matches. <a href="/audit">Start exploring</a> to contribute more data!

--- a/conf/messages.es
+++ b/conf/messages.es
@@ -333,6 +333,7 @@ gallery.show = Mostrar
 gallery.filter.by = Filtrar por
 gallery.severity = Calificación
 gallery.tags = Etiquitas
+gallery.validations = Validaciones
 gallery.all = Todos
 gallery.occlusion = No puedo ver la banqueta
 gallery.labels.not.found = No hay resultados. ¡<a href="/audit">Comienza a explorar</a> para aportar más datos!

--- a/conf/messages.nl
+++ b/conf/messages.nl
@@ -332,6 +332,7 @@ gallery.show = Tonen
 gallery.filter.by = Filteren op
 gallery.severity = Ernst
 gallery.tags = Tags
+gallery.validations = Validaties
 gallery.all = Alles
 gallery.occlusion = Kan de stoep niet zien
 gallery.labels.not.found = Geen overeenkomsten. <a href="/audit">Begin met verkennen</a> om meer data bij te dragen!

--- a/conf/routes
+++ b/conf/routes
@@ -13,7 +13,7 @@ GET     /demo                                                @controllers.Applic
 GET     /results                                             @controllers.ApplicationController.results
 GET     /labelMap                                            @controllers.ApplicationController.labelMap
 GET     /labelmap                                            @controllers.ApplicationController.labelMap
-GET     /gallery                                             @controllers.ApplicationController.gallery(label: Option[String], severity: Option[String])
+GET     /gallery                                             @controllers.ApplicationController.gallery(labelType: Option[String], severity: Option[String])
 GET     /help                                                @controllers.ApplicationController.help
 GET     /labelingGuide                                       @controllers.ApplicationController.labelingGuide
 GET     /labelingguide                                       @controllers.ApplicationController.labelingGuide

--- a/conf/routes
+++ b/conf/routes
@@ -13,7 +13,7 @@ GET     /demo                                                @controllers.Applic
 GET     /results                                             @controllers.ApplicationController.results
 GET     /labelMap                                            @controllers.ApplicationController.labelMap
 GET     /labelmap                                            @controllers.ApplicationController.labelMap
-GET     /gallery                                             @controllers.ApplicationController.gallery(labelType: String ?= "Assorted", severities: String ?= "", validationOptions: String ?= "correct,unvalidated")
+GET     /gallery                                             @controllers.ApplicationController.gallery(labelType: String ?= "Assorted", severities: String ?= "", tags: String ?= "", validationOptions: String ?= "correct,unvalidated")
 GET     /help                                                @controllers.ApplicationController.help
 GET     /labelingGuide                                       @controllers.ApplicationController.labelingGuide
 GET     /labelingguide                                       @controllers.ApplicationController.labelingGuide

--- a/conf/routes
+++ b/conf/routes
@@ -13,7 +13,7 @@ GET     /demo                                                @controllers.Applic
 GET     /results                                             @controllers.ApplicationController.results
 GET     /labelMap                                            @controllers.ApplicationController.labelMap
 GET     /labelmap                                            @controllers.ApplicationController.labelMap
-GET     /gallery                                             @controllers.ApplicationController.gallery(labelType: Option[String], severity: Option[String])
+GET     /gallery                                             @controllers.ApplicationController.gallery(labelType: String ?= "Assorted", severities: String ?= "[]")
 GET     /help                                                @controllers.ApplicationController.help
 GET     /labelingGuide                                       @controllers.ApplicationController.labelingGuide
 GET     /labelingguide                                       @controllers.ApplicationController.labelingGuide

--- a/conf/routes
+++ b/conf/routes
@@ -13,7 +13,7 @@ GET     /demo                                                @controllers.Applic
 GET     /results                                             @controllers.ApplicationController.results
 GET     /labelMap                                            @controllers.ApplicationController.labelMap
 GET     /labelmap                                            @controllers.ApplicationController.labelMap
-GET     /gallery                                             @controllers.ApplicationController.gallery(labelType: String ?= "Assorted", severities: String ?= "[]")
+GET     /gallery                                             @controllers.ApplicationController.gallery(labelType: String ?= "Assorted", severities: String ?= "", validationOptions: String ?= "correct,unvalidated")
 GET     /help                                                @controllers.ApplicationController.help
 GET     /labelingGuide                                       @controllers.ApplicationController.labelingGuide
 GET     /labelingguide                                       @controllers.ApplicationController.labelingGuide

--- a/public/javascripts/Gallery/css/filter.css
+++ b/public/javascripts/Gallery/css/filter.css
@@ -46,3 +46,27 @@
     flex-direction: row;
     margin-left: -3px;
 }
+
+.gallery-filter-button, .gallery-tag {
+    padding: 0px 5px;
+    border-style: solid;
+    border-width: 1px;
+    border-radius: 5px;
+    text-align: left;
+    color: black;
+    width: fit-content;
+    white-space: nowrap;
+    max-width: 98%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.gallery-filter-button:hover {
+    background-color: #78c8aa;
+    white-space: normal;
+}
+
+.gallery-filter-validation-button {
+    display: block;
+    margin: 4px 2px;
+}

--- a/public/javascripts/Gallery/css/gallery.css
+++ b/public/javascripts/Gallery/css/gallery.css
@@ -4,7 +4,7 @@
 }
 
 #card-filter {
-    padding: 5px;
+    padding: 0 5px 5px 5px;
     width: inherit;
 }
 
@@ -22,7 +22,7 @@
     background-color: white;
     border-radius: 5px;
     border-width: 1px;
-    margin: 0px 2px;
+    margin: 0 2px;
 }
 
 .paging:disabled {
@@ -45,7 +45,6 @@
 /* Note that the side bar is out of the "flow" of the grid container b/c it is fixed when we aren't loading anything. */
 .sidebar {
     padding-left: 10px;
-    padding-top: 20px;
     min-height: calc(100vh - 610px);
     width: 239px;
     grid-row: 1/2;
@@ -76,7 +75,7 @@
         'main gallery-modal'
         'paging gallery-modal';
     grid-gap: 2px;
-    padding: 10px;
+    padding: 0 10px 10px 10px;
 }
 
 .cards {

--- a/public/javascripts/Gallery/css/tags.css
+++ b/public/javascripts/Gallery/css/tags.css
@@ -1,25 +1,6 @@
 .gallery-tag {
     display: inline-block;
-    padding: 0px 5px;
-    border-style: solid;
-    border-width: 1px;
-    border-radius: 5px;
     margin: 2px 2px;
-    text-align: left;
-    color: black;
-    width: fit-content;
-    white-space: nowrap;
-}
-
-.gallery-tag, .gallery-tag-sidebar {
-    max-width: 98%;
-    overflow: hidden;
-    text-overflow: ellipsis;
-}
-
-.gallery-tag-sidebar:hover {
-    background-color: #78c8aa;
-    white-space: normal;
 }
 
 .thumbnail-tag {

--- a/public/javascripts/Gallery/src/Main.js
+++ b/public/javascripts/Gallery/src/Main.js
@@ -73,6 +73,7 @@ function Main (params) {
         sg.labelTypeMenu = new LabelTypeMenu(sg.ui.labelTypeMenu);
 
         // sg.cardSortMenu = new CardSortMenu(sg.ui.cardSortMenu);
+        // TODO rename sg.tagContainer because it holds all the filters.
         sg.tagContainer = new CardFilter(sg.ui.cardFilter, sg.labelTypeMenu, sg.cityMenu);
         sg.cardContainer = new CardContainer(sg.ui.cardContainer);
         sg.modal = sg.cardContainer.getModal;

--- a/public/javascripts/Gallery/src/Main.js
+++ b/public/javascripts/Gallery/src/Main.js
@@ -73,8 +73,7 @@ function Main (params) {
         sg.labelTypeMenu = new LabelTypeMenu(sg.ui.labelTypeMenu);
 
         // sg.cardSortMenu = new CardSortMenu(sg.ui.cardSortMenu);
-        // TODO rename sg.tagContainer because it holds all the filters.
-        sg.tagContainer = new CardFilter(sg.ui.cardFilter, sg.labelTypeMenu, sg.cityMenu);
+        sg.cardFilter = new CardFilter(sg.ui.cardFilter, sg.labelTypeMenu, sg.cityMenu);
         sg.cardContainer = new CardContainer(sg.ui.cardContainer);
         sg.modal = sg.cardContainer.getModal;
         // Initialize data collection.

--- a/public/javascripts/Gallery/src/Main.js
+++ b/public/javascripts/Gallery/src/Main.js
@@ -70,11 +70,11 @@ function Main (params) {
 
         // Initialize functional components of UI elements.
         sg.cityMenu = new CityMenu(sg.ui.cityMenu);
-        sg.labelTypeMenu = new LabelTypeMenu(sg.ui.labelTypeMenu);
+        sg.labelTypeMenu = new LabelTypeMenu(sg.ui.labelTypeMenu, params.initialFilters.labelType);
 
         // sg.cardSortMenu = new CardSortMenu(sg.ui.cardSortMenu);
-        sg.cardFilter = new CardFilter(sg.ui.cardFilter, sg.labelTypeMenu, sg.cityMenu);
-        sg.cardContainer = new CardContainer(sg.ui.cardContainer);
+        sg.cardFilter = new CardFilter(sg.ui.cardFilter, sg.labelTypeMenu, sg.cityMenu, params.initialFilters);
+        sg.cardContainer = new CardContainer(sg.ui.cardContainer, params.initialFilters);
         sg.modal = sg.cardContainer.getModal;
         // Initialize data collection.
         sg.form = new Form(params.dataStoreUrl, params.beaconDataStoreUrl);

--- a/public/javascripts/Gallery/src/Main.js
+++ b/public/javascripts/Gallery/src/Main.js
@@ -25,8 +25,9 @@ function Main (params) {
         sg.ui.cardFilter = {};
         sg.ui.cardFilter.wrapper = $(".sidebar");
         sg.ui.cardFilter.holder = $("#card-filter");
-        sg.ui.cardFilter.tags = $("#tags");
         sg.ui.cardFilter.severity = $("#severity-select");
+        sg.ui.cardFilter.tags = $("#tags");
+        sg.ui.cardFilter.validationOptions = $("#validation-options");
 
         // Initializes city select component in sidebar.
         sg.ui.cityMenu = {};

--- a/public/javascripts/Gallery/src/cards/Card.js
+++ b/public/javascripts/Gallery/src/cards/Card.js
@@ -35,6 +35,7 @@ function Card (params, imageUrl, modal) {
         description: undefined,
         street_edge_id: undefined,
         region_id: undefined,
+        correctness: undefined,
         user_validation: undefined,
         tags: []
     };
@@ -83,6 +84,9 @@ function Card (params, imageUrl, modal) {
                 properties[attrName] = param[attrName];
             }
         }
+        if (properties.correctness) properties.correctness = "correct";
+        else if (properties.correctness === false) properties.correctness = "incorrect";
+        else properties.correctness = "unvalidated";
 
         // Place label icon.
         labelIcon.src = iconImagePaths[getLabelType()];

--- a/public/javascripts/Gallery/src/cards/CardBucket.js
+++ b/public/javascripts/Gallery/src/cards/CardBucket.js
@@ -31,7 +31,7 @@ function CardBucket(inputCards) {
 
     /**
      * Filters cards upon a non-empty array of severities.
-     * 
+     *
      * @param {*} severities Severities to filter upon.
      */
     function filterOnSeverities(severities) {
@@ -39,6 +39,16 @@ function CardBucket(inputCards) {
             let severitySet = new Set(severities);
             bucket = bucket.filter(card => severitySet.has(card.getProperty("severity")));
         }
+    }
+
+    /**
+     * Filters cards upon an array of validation options.
+     *
+     * @param {*} validationOptions Validation Options to filter upon.
+     */
+    function filterOnValidationOptions(validationOptions) {
+        let validationOptionsSet = new Set(validationOptions);
+        bucket = bucket.filter(card => validationOptionsSet.has(card.getProperty("correctness")));
     }
 
     /**
@@ -93,6 +103,7 @@ function CardBucket(inputCards) {
     self.push = push;
     self.filterOnTags = filterOnTags;
     self.filterOnSeverities = filterOnSeverities;
+    self.filterOnValidationOptions = filterOnValidationOptions;
     self.getCards = getCards;
     self.getSize = getSize;
     self.copy = copy;

--- a/public/javascripts/Gallery/src/cards/CardBucket.js
+++ b/public/javascripts/Gallery/src/cards/CardBucket.js
@@ -23,7 +23,7 @@ function CardBucket(inputCards) {
      * @param {*} tags Tags to filter upon.
      */
     function filterOnTags(tags) {
-        if (tags.length > 0) {
+        if (tags !== undefined && tags.length > 0) {
             let tagSet = new Set(tags);
             bucket = bucket.filter(card => card.getProperty("tags").some(tag => tagSet.has(tag)));
         }
@@ -35,7 +35,7 @@ function CardBucket(inputCards) {
      * @param {*} severities Severities to filter upon.
      */
     function filterOnSeverities(severities) {
-        if (severities.length > 0) {
+        if (severities !== undefined && severities.length > 0) {
             let severitySet = new Set(severities);
             bucket = bucket.filter(card => severitySet.has(card.getProperty("severity")));
         }

--- a/public/javascripts/Gallery/src/cards/CardContainer.js
+++ b/public/javascripts/Gallery/src/cards/CardContainer.js
@@ -2,10 +2,11 @@
  * Card Container module. This is responsible for managing the Card objects that are to be rendered.
  * 
  * @param {*} uiCardContainer UI element tied with this CardContainer.
+ * @param initialFilters Object containing initial set of filters in sidebar.
  * @returns {CardContainer}
  * @constructor
  */
-function CardContainer(uiCardContainer) {
+function CardContainer(uiCardContainer, initialFilters) {
     let self = this;
 
     // The number of labels to grab from database on initial page load.
@@ -35,7 +36,7 @@ function CardContainer(uiCardContainer) {
     };
 
     // Current label type of cards being shown.
-    let currentLabelType = 'Assorted';
+    let currentLabelType = initialFilters.labelType;
     let currentPage = 1;
     let lastPage = false;
     let pageNumberDisplay = null;
@@ -83,8 +84,9 @@ function CardContainer(uiCardContainer) {
         cardsByType[currentLabelType] = new CardBucket();
 
 
+        let appliedSeverities = sg.cardFilter.getAppliedSeverities();
         // Grab first batch of labels to show.
-        fetchLabels(labelTypeIds.Assorted, initialLoad, sg.cardFilter.getAppliedValidationOptions(), Array.from(loadedLabelIds), undefined, undefined, function() {
+        fetchLabels(labelTypeIds[currentLabelType], initialLoad, sg.cardFilter.getAppliedValidationOptions(), Array.from(loadedLabelIds), undefined, undefined, function() {
             currentCards = cardsByType[currentLabelType].copy();
             render();
         });
@@ -178,6 +180,7 @@ function CardContainer(uiCardContainer) {
      * @param {*} callback Function to be called when labels arrive.
      */
     function fetchLabels(labelTypeId, n, validationOptions, loadedLabels, severities, tags, callback) {
+        console.trace();
         var url = "/label/labels";
         let data = {
             label_type_id: labelTypeId,

--- a/public/javascripts/Gallery/src/cards/CardContainer.js
+++ b/public/javascripts/Gallery/src/cards/CardContainer.js
@@ -239,7 +239,7 @@ function CardContainer(uiCardContainer, initialFilters) {
     /**
      * Updates cardsOfType when new label type selected.
      */
-    function updateCardsByType() {
+    function updateCardsByLabelType() {
         refreshUI();
 
         let filterLabelType = sg.cardFilter.getStatus().currentLabelType;
@@ -300,10 +300,10 @@ function CardContainer(uiCardContainer, initialFilters) {
     }
 
     /**
-     * When a tag or severity filter is updated, update Cards to be shown.
+     * When a severity, tag, or validation filter is updated; update Cards to be shown.
      * TODO rename this function.
      */
-    function updateCardsByTagsAndSeverity() {
+    function updateCardsBySeverityTagsOrValidation() {
         setPage(1);
         updateCardsNewPage();
     }
@@ -467,8 +467,8 @@ function CardContainer(uiCardContainer, initialFilters) {
     self.getCurrentCards = getCurrentCards;
     self.isLastPage = isLastPage;
     self.push = push;
-    self.updateCardsByType = updateCardsByType;
-    self.updateCardsByTagsAndSeverity = updateCardsByTagsAndSeverity;
+    self.updateCardsByLabelType = updateCardsByLabelType;
+    self.updateCardsBySeverityTagsOrValidation = updateCardsBySeverityTagsOrValidation;
     self.updateCardsNewPage = updateCardsNewPage;
     self.sortCards = sortCards;
     self.render = render;

--- a/public/javascripts/Gallery/src/cards/CardContainer.js
+++ b/public/javascripts/Gallery/src/cards/CardContainer.js
@@ -83,10 +83,8 @@ function CardContainer(uiCardContainer, initialFilters) {
         sg.ui.cardContainer.prevPage.prop("disabled", true);
         cardsByType[currentLabelType] = new CardBucket();
 
-
-        let appliedSeverities = sg.cardFilter.getAppliedSeverities();
         // Grab first batch of labels to show.
-        fetchLabels(labelTypeIds[currentLabelType], initialLoad, sg.cardFilter.getAppliedValidationOptions(), Array.from(loadedLabelIds), undefined, undefined, function() {
+        fetchLabels(labelTypeIds[currentLabelType], initialLoad, sg.cardFilter.getAppliedValidationOptions(), Array.from(loadedLabelIds), initialFilters.severities, undefined, function() {
             currentCards = cardsByType[currentLabelType].copy();
             render();
         });

--- a/public/javascripts/Gallery/src/cards/CardContainer.js
+++ b/public/javascripts/Gallery/src/cards/CardContainer.js
@@ -32,7 +32,7 @@ function CardContainer(uiCardContainer, initialFilters) {
         NoSidewalk: 7,
         Crosswalk: 9,
         Signal: 10,
-        Assorted: -1
+        Assorted: null
     };
 
     // Current label type of cards being shown.

--- a/public/javascripts/Gallery/src/cards/CardContainer.js
+++ b/public/javascripts/Gallery/src/cards/CardContainer.js
@@ -78,13 +78,13 @@ function CardContainer(uiCardContainer) {
         pageNumberDisplay.innerText = "1";
         uiCardContainer.pageNumber.append(pageNumberDisplay);
         sg.ui.pageControl.hide();
-        sg.tagContainer.disable();
+        sg.cardFilter.disable();
         sg.ui.cardContainer.prevPage.prop("disabled", true);
         cardsByType[currentLabelType] = new CardBucket();
 
 
         // Grab first batch of labels to show.
-        fetchLabels(labelTypeIds.Assorted, initialLoad, sg.tagContainer.getAppliedValidationOptions(), Array.from(loadedLabelIds), undefined, undefined, function() {
+        fetchLabels(labelTypeIds.Assorted, initialLoad, sg.cardFilter.getAppliedValidationOptions(), Array.from(loadedLabelIds), undefined, undefined, function() {
             currentCards = cardsByType[currentLabelType].copy();
             render();
         });
@@ -241,14 +241,14 @@ function CardContainer(uiCardContainer) {
     function updateCardsByType() {
         refreshUI();
 
-        let filterLabelType = sg.tagContainer.getStatus().currentLabelType;
+        let filterLabelType = sg.cardFilter.getStatus().currentLabelType;
         if (currentLabelType !== filterLabelType) {
             // Reset back to the first page.
             setPage(1);
-            sg.tagContainer.unapplyTags(currentLabelType);
+            sg.cardFilter.unapplyTags(currentLabelType);
             currentLabelType = filterLabelType;
 
-            fetchLabels(labelTypeIds[filterLabelType], cardsPerPage * 2, sg.tagContainer.getAppliedValidationOptions(), Array.from(loadedLabelIds), undefined, undefined, function () {
+            fetchLabels(labelTypeIds[filterLabelType], cardsPerPage * 2, sg.cardFilter.getAppliedValidationOptions(), Array.from(loadedLabelIds), undefined, undefined, function () {
                 currentCards = cardsByType[currentLabelType].copy();
 
                 // We query double the amount of cards per page, "prepping" for the next page. If after querying we see
@@ -265,9 +265,9 @@ function CardContainer(uiCardContainer) {
     function updateCardsNewPage() {
         refreshUI();
 
-        let appliedTags = sg.tagContainer.getAppliedTagNames();
-        let appliedSeverities = sg.tagContainer.getAppliedSeverities();
-        let appliedValOptions = sg.tagContainer.getAppliedValidationOptions();
+        let appliedTags = sg.cardFilter.getAppliedTagNames();
+        let appliedSeverities = sg.cardFilter.getAppliedSeverities();
+        let appliedValOptions = sg.cardFilter.getAppliedValidationOptions();
 
         currentCards = cardsByType[currentLabelType].copy();
         currentCards.filterOnTags(appliedTags);
@@ -277,13 +277,13 @@ function CardContainer(uiCardContainer) {
         if (currentCards.getSize() < cardsPerPage * currentPage + 1) {
             // When we don't have enough cards of specific query to show on one page, see if more can be grabbed.
             if (currentLabelType === "Occlusion") {
-                fetchLabels(labelTypeIds[currentLabelType], cardsPerPage * 2, sg.tagContainer.getAppliedValidationOptions(), Array.from(loadedLabelIds), undefined, undefined, function () {
+                fetchLabels(labelTypeIds[currentLabelType], cardsPerPage * 2, sg.cardFilter.getAppliedValidationOptions(), Array.from(loadedLabelIds), undefined, undefined, function () {
                     currentCards = cardsByType[currentLabelType].copy();
                     lastPage = currentCards.getCards().length <= currentPage * cardsPerPage;
                     render();
                 });
             } else {
-                fetchLabels(labelTypeIds[currentLabelType], cardsPerPage * 2, sg.tagContainer.getAppliedValidationOptions(), Array.from(loadedLabelIds), appliedSeverities, appliedTags, function() {
+                fetchLabels(labelTypeIds[currentLabelType], cardsPerPage * 2, sg.cardFilter.getAppliedValidationOptions(), Array.from(loadedLabelIds), appliedSeverities, appliedTags, function() {
                     currentCards = cardsByType[currentLabelType].copy();
                     currentCards.filterOnTags(appliedTags);
                     currentCards.filterOnSeverities(appliedSeverities);
@@ -346,7 +346,7 @@ function CardContainer(uiCardContainer) {
                 sg.ui.cardFilter.wrapper.css('top', '');
                 uiCardContainer.holder.css('margin-left', sg.ui.cardFilter.wrapper.css('width'));
                 sg.scrollStatus.stickySidebar = true;
-                sg.tagContainer.enable();
+                sg.cardFilter.enable();
                 sg.ui.labelTypeMenu.select.prop("disabled", false);
                 sg.ui.cityMenu.select.prop("disabled", false);
             });
@@ -354,7 +354,7 @@ function CardContainer(uiCardContainer) {
             // TODO: figure out how to better do the toggling of this element.
             sg.labelsNotFound.show();
             sg.pageLoading.hide();
-            sg.tagContainer.enable();
+            sg.cardFilter.enable();
             sg.ui.labelTypeMenu.select.prop("disabled", false);
             sg.ui.cityMenu.select.prop("disabled", false);
         }
@@ -378,7 +378,7 @@ function CardContainer(uiCardContainer) {
         sg.pageLoading.show();
 
         // Disable interactable UI elements while query loads.
-        sg.tagContainer.disable();
+        sg.cardFilter.disable();
         sg.ui.labelTypeMenu.select.prop("disabled", true);
         sg.ui.cityMenu.select.prop("disabled", true);
         sg.labelsNotFound.hide();

--- a/public/javascripts/Gallery/src/cards/CardContainer.js
+++ b/public/javascripts/Gallery/src/cards/CardContainer.js
@@ -84,7 +84,7 @@ function CardContainer(uiCardContainer, initialFilters) {
         cardsByType[currentLabelType] = new CardBucket();
 
         // Grab first batch of labels to show.
-        fetchLabels(labelTypeIds[currentLabelType], initialLoad, sg.cardFilter.getAppliedValidationOptions(), Array.from(loadedLabelIds), initialFilters.severities, undefined, function() {
+        fetchLabels(labelTypeIds[currentLabelType], initialLoad, initialFilters.validationOptions, Array.from(loadedLabelIds), initialFilters.severities, undefined, function() {
             currentCards = cardsByType[currentLabelType].copy();
             render();
         });

--- a/public/javascripts/Gallery/src/cards/CardContainer.js
+++ b/public/javascripts/Gallery/src/cards/CardContainer.js
@@ -178,11 +178,12 @@ function CardContainer(uiCardContainer) {
     function fetchLabels(labelTypeId, n, loadedLabels, severities, tags, callback) {
         var url = "/label/labels";
         let data = {
-            labelTypeId: labelTypeId,
+            label_type_id: labelTypeId,
             n: n,
+            validation_options: ['correct', 'unvalidated'],
             ...(severities !== undefined && {severities: severities}),
             ...(tags !== undefined && {tags: tags}),
-            loadedLabels: loadedLabels
+            loaded_labels: loadedLabels
         }
         $.ajax({
             async: true,

--- a/public/javascripts/Gallery/src/cards/CardContainer.js
+++ b/public/javascripts/Gallery/src/cards/CardContainer.js
@@ -178,7 +178,6 @@ function CardContainer(uiCardContainer, initialFilters) {
      * @param {*} callback Function to be called when labels arrive.
      */
     function fetchLabels(labelTypeId, n, validationOptions, loadedLabels, severities, tags, callback) {
-        console.trace();
         var url = "/label/labels";
         let data = {
             label_type_id: labelTypeId,

--- a/public/javascripts/Gallery/src/cards/CardContainer.js
+++ b/public/javascripts/Gallery/src/cards/CardContainer.js
@@ -84,7 +84,7 @@ function CardContainer(uiCardContainer, initialFilters) {
         cardsByType[currentLabelType] = new CardBucket();
 
         // Grab first batch of labels to show.
-        fetchLabels(labelTypeIds[currentLabelType], initialLoad, initialFilters.validationOptions, Array.from(loadedLabelIds), initialFilters.severities, undefined, function() {
+        fetchLabels(labelTypeIds[currentLabelType], initialLoad, initialFilters.validationOptions, Array.from(loadedLabelIds), initialFilters.severities, initialFilters.tags, function() {
             currentCards = cardsByType[currentLabelType].copy();
             render();
         });

--- a/public/javascripts/Gallery/src/cards/CardContainer.js
+++ b/public/javascripts/Gallery/src/cards/CardContainer.js
@@ -294,6 +294,7 @@ function CardContainer(uiCardContainer) {
 
     /**
      * When a tag or severity filter is updated, update Cards to be shown.
+     * TODO rename this function.
      */
     function updateCardsByTagsAndSeverity() {
         setPage(1);

--- a/public/javascripts/Gallery/src/displays/TagDisplay.js
+++ b/public/javascripts/Gallery/src/displays/TagDisplay.js
@@ -111,7 +111,7 @@ function TagDisplay(container, tags, isModal=false) {
      */
     function orderTags(tags) {
         let orderedTags = [];
-        let appliedTags = sg.tagContainer.getAppliedTagNames();
+        let appliedTags = sg.cardFilter.getAppliedTagNames();
         for (let tag of tags) {
             if (orderedTags.length === 0) {
                 orderedTags.push(tag);

--- a/public/javascripts/Gallery/src/filter/CardFilter.js
+++ b/public/javascripts/Gallery/src/filter/CardFilter.js
@@ -174,6 +174,20 @@ function CardFilter(uiCardFilter, labelTypeMenu, cityMenu) {
     }
 
     /**
+     * Return list of validationOptions.
+     */
+    function getValidationOptions() {
+        return validationOptions.getValidationOptions();
+    }
+
+    /**
+     * Return list of selected validationOptions by user.
+     */
+    function getAppliedValidationOptions() {
+        return validationOptions.getAppliedValidationOptions();
+    }
+
+    /**
      * Unapply all tags of specified label type.
      * 
      * @param {*} labelType Label type of tags to unapply.
@@ -220,6 +234,8 @@ function CardFilter(uiCardFilter, labelTypeMenu, cityMenu) {
     self.setStatus = setStatus;
     self.getSeverities = getSeverities;
     self.getAppliedSeverities = getAppliedSeverities;
+    self.getValidationOptions = getValidationOptions;
+    self.getAppliedValidationOptions = getAppliedValidationOptions;
     self.unapplyTags = unapplyTags;
     self.disable = disable;
     self.enable = enable;

--- a/public/javascripts/Gallery/src/filter/CardFilter.js
+++ b/public/javascripts/Gallery/src/filter/CardFilter.js
@@ -132,26 +132,18 @@ function CardFilter(uiCardFilter, labelTypeMenu, cityMenu, initialFilters) {
      * Render tags and severities in sidebar.
      */
     function render() {
+        if (['Signal', 'Occlusion'].includes(status.currentLabelType)) {
+            $('#severity-header').hide();
+            $('#severity-select').hide();
+        } else {
+            $('#severity-header').show();
+            $('#severity-select').show();
+        }
         if (currentTags.getTags().length > 0) {
-            // TODO: think about how to better show tags header in an organized manner.
             $("#tags-header").show();
             currentTags.render(uiCardFilter.tags);
         } else {
             $("#tags-header").hide();
-        }
-        if (status.currentLabelType === "Occlusion") {
-            $("#filters").hide();
-            $("#horizontal-line").hide();
-        } else {
-            $("#filters").show();
-            $("#horizontal-line").show();
-            if (status.currentLabelType === 'Signal') {
-                $('#severity-header').hide();
-                $('#severity-select').hide();
-            } else {
-                $('#severity-header').show();
-                $('#severity-select').show();
-            }
         }
 
         severities.render(uiCardFilter.severity);

--- a/public/javascripts/Gallery/src/filter/CardFilter.js
+++ b/public/javascripts/Gallery/src/filter/CardFilter.js
@@ -73,7 +73,7 @@ function CardFilter(uiCardFilter, labelTypeMenu, cityMenu) {
         let currentCity = cityMenu.getCurrentCity();
         if (status.currentCity !== currentCity) {
             // Future: add URI parameters to link.
-            window.location.href = currentCity + '/gallery?label=' + status.currentLabelType;
+            window.location.href = currentCity + '/gallery?labelType=' + status.currentLabelType;
         } else {
             let currentLabelType = labelTypeMenu.getCurrentLabelType();
             if (status.currentLabelType !== currentLabelType) {

--- a/public/javascripts/Gallery/src/filter/CardFilter.js
+++ b/public/javascripts/Gallery/src/filter/CardFilter.js
@@ -46,6 +46,7 @@ function CardFilter(uiCardFilter, labelTypeMenu, cityMenu, initialFilters) {
         getTags(function () {
             render();
         });
+        updateURL();
     }
 
     /**
@@ -83,12 +84,17 @@ function CardFilter(uiCardFilter, labelTypeMenu, cityMenu, initialFilters) {
             render();
         }
         sg.cardContainer.updateCardsByFilter();
+        updateURL();
+    }
 
-        // If the city was changed, redirect to that server. Otherwise, update the URL query params.
+    /**
+     * If the city was changed, redirect to that server. Otherwise, update the URL query params.
+     */
+    function updateURL() {
         let newUrl = _buildCurrentURL();
         let currentCity = cityMenu.getCurrentCity();
         if (status.currentCity !== currentCity) {
-            // window.location.href = currentCity + newUrl;
+            window.location.href = currentCity + newUrl;
         } else {
             let fullUrl = `${window.location.protocol}//${window.location.host}${newUrl}`;
             if (fullUrl !== window.location.href) {

--- a/public/javascripts/Gallery/src/filter/CardFilter.js
+++ b/public/javascripts/Gallery/src/filter/CardFilter.js
@@ -35,6 +35,8 @@ function CardFilter(uiCardFilter, labelTypeMenu, cityMenu) {
 
     // Collection of severities.
     let severities = new SeverityBucket();
+
+    let validationOptions = new ValidationOptionBucket();
    
     /**
      * Initialize CardFilter.
@@ -90,7 +92,7 @@ function CardFilter(uiCardFilter, labelTypeMenu, cityMenu) {
      */
     function render() {
         if (currentTags.getTags().length > 0) {
-            // TODO: think about to better show tags header in an organized manner.
+            // TODO: think about how to better show tags header in an organized manner.
             $("#tags-header").show();
             currentTags.render(uiCardFilter.tags);
         } else {
@@ -112,6 +114,7 @@ function CardFilter(uiCardFilter, labelTypeMenu, cityMenu) {
         }
 
         severities.render(uiCardFilter.severity);
+        validationOptions.render(uiCardFilter.validationOptions)
     }
 
     /**
@@ -195,6 +198,7 @@ function CardFilter(uiCardFilter, labelTypeMenu, cityMenu) {
      */
     function disable() {
         severities.disable();
+        validationOptions.disable();
         $('.gallery-tag').prop("disabled", true);
     }
 
@@ -203,6 +207,7 @@ function CardFilter(uiCardFilter, labelTypeMenu, cityMenu) {
      */
     function enable() {
         severities.enable();
+        validationOptions.enable();
         $('.gallery-tag').prop("disabled", false);
     }
 

--- a/public/javascripts/Gallery/src/filter/CardFilter.js
+++ b/public/javascripts/Gallery/src/filter/CardFilter.js
@@ -32,7 +32,7 @@ function CardFilter(uiCardFilter, labelTypeMenu, cityMenu, initialFilters) {
     };
 
     // Tags of the current label type.
-    let currentTags = new TagBucket();
+    let currentTags = tagsByType[status.currentLabelType];
 
     // Collection of severities.
     let severities = new SeverityBucket(initialFilters.severities);
@@ -59,7 +59,10 @@ function CardFilter(uiCardFilter, labelTypeMenu, cityMenu, initialFilters) {
             let i = 0;
             let len = data.length;
             for (; i < len; i++) {
-                tag = new Tag(data[i]);
+                if (data[i].label_type === status.currentLabelType && initialFilters.tags.includes(data[i].tag))
+                    tag = new Tag(data[i], true);
+                else
+                    tag = new Tag(data[i], false);
                 tagsByType[tag.getLabelType()].push(tag);
             }
 
@@ -104,11 +107,16 @@ function CardFilter(uiCardFilter, labelTypeMenu, cityMenu, initialFilters) {
         let newUrl = '/gallery';
         let firstQueryParam = true;
         let currSeverities = severities.getAppliedSeverities();
+        let currAppliedTags = currentTags.getAppliedTags().map(t => t.getTag()).join();
         let currValOptions = validationOptions.getAppliedValidationOptions().sort().join();
 
         // For each type of filter, check if it matches the default. If it doesn't, add to URL in a query param.
         if (status.currentLabelType !== 'Assorted') {
             newUrl += `?labelType=${status.currentLabelType}`;
+            // Can only have applied tags if there is a specific label type chosen.
+            if (currAppliedTags.length > 0) {
+                newUrl += `&tags=${currAppliedTags}`;
+            }
             firstQueryParam = false;
         }
         if (currSeverities.length > 0) {

--- a/public/javascripts/Gallery/src/filter/CardFilter.js
+++ b/public/javascripts/Gallery/src/filter/CardFilter.js
@@ -80,11 +80,9 @@ function CardFilter(uiCardFilter, labelTypeMenu, cityMenu, initialFilters) {
             clearCurrentTags();
             setStatus('currentLabelType', currLabelType);
             currentTags = tagsByType[currLabelType];
-            sg.cardContainer.updateCardsByLabelType();
             render();
-        } else {
-            sg.cardContainer.updateCardsBySeverityTagsOrValidation();
         }
+        sg.cardContainer.updateCardsByFilter();
 
         // If the city was changed, redirect to that server. Otherwise, update the URL query params.
         let newUrl = _buildCurrentURL();

--- a/public/javascripts/Gallery/src/filter/CardFilter.js
+++ b/public/javascripts/Gallery/src/filter/CardFilter.js
@@ -5,15 +5,16 @@
  * @param uiCardFilter UI element representing filter components of sidebar.
  * @param labelTypeMenu UI element representing dropdown to select label type in sidebar.
  * @param cityMenu UI element representing dropdown to select city in sidebar.
+ * @param initialFilters Object containing initial set of filters to pass along.
  * @returns {CardFilter}
  * @constructor
  */
-function CardFilter(uiCardFilter, labelTypeMenu, cityMenu) {
+function CardFilter(uiCardFilter, labelTypeMenu, cityMenu, initialFilters) {
     let self = this;
 
     let status = {
         currentCity: cityMenu.getCurrentCity(),
-        currentLabelType: "Assorted"
+        currentLabelType: initialFilters.labelType
     };
 
     // Map label type to their collection of tags.

--- a/public/javascripts/Gallery/src/filter/CardFilter.js
+++ b/public/javascripts/Gallery/src/filter/CardFilter.js
@@ -37,7 +37,7 @@ function CardFilter(uiCardFilter, labelTypeMenu, cityMenu, initialFilters) {
     // Collection of severities.
     let severities = new SeverityBucket(initialFilters.severities);
 
-    let validationOptions = new ValidationOptionBucket();
+    let validationOptions = new ValidationOptionBucket(initialFilters.validationOptions);
    
     /**
      * Initialize CardFilter.

--- a/public/javascripts/Gallery/src/filter/CardFilter.js
+++ b/public/javascripts/Gallery/src/filter/CardFilter.js
@@ -35,7 +35,7 @@ function CardFilter(uiCardFilter, labelTypeMenu, cityMenu, initialFilters) {
     let currentTags = new TagBucket();
 
     // Collection of severities.
-    let severities = new SeverityBucket();
+    let severities = new SeverityBucket(initialFilters.severities);
 
     let validationOptions = new ValidationOptionBucket();
    
@@ -74,7 +74,7 @@ function CardFilter(uiCardFilter, labelTypeMenu, cityMenu, initialFilters) {
         let currentCity = cityMenu.getCurrentCity();
         if (status.currentCity !== currentCity) {
             // Future: add URI parameters to link.
-            window.location.href = currentCity + '/gallery?labelType=' + status.currentLabelType;
+            window.location.href = currentCity + `/gallery?labelType=${status.currentLabelType}&severities=${severities.getAppliedSeverities()}`;
         } else {
             let currentLabelType = labelTypeMenu.getCurrentLabelType();
             if (status.currentLabelType !== currentLabelType) {

--- a/public/javascripts/Gallery/src/filter/CardFilter.js
+++ b/public/javascripts/Gallery/src/filter/CardFilter.js
@@ -45,8 +45,8 @@ function CardFilter(uiCardFilter, labelTypeMenu, cityMenu, initialFilters) {
     function _init() {
         getTags(function () {
             render();
+            updateURL();
         });
-        updateURL();
     }
 
     /**

--- a/public/javascripts/Gallery/src/filter/CityMenu.js
+++ b/public/javascripts/Gallery/src/filter/CityMenu.js
@@ -31,7 +31,7 @@ function CityMenu(uiCityMenu) {
         let city = $(this).val();
         setStatus("currentCity", city);
         sg.tracker.push("Filter_City=" + city);
-        sg.tagContainer.update();
+        sg.cardFilter.update();
     }
 
     /**

--- a/public/javascripts/Gallery/src/filter/LabelTypeMenu.js
+++ b/public/javascripts/Gallery/src/filter/LabelTypeMenu.js
@@ -31,7 +31,7 @@ function LabelTypeMenu(labelTypeMenu) {
         let labelType = $(this).val();
         setStatus("currentLabelType", labelType);
         sg.tracker.push("Filter_LabelType=" + labelType);
-        sg.tagContainer.update();
+        sg.cardFilter.update();
     }
 
     /**

--- a/public/javascripts/Gallery/src/filter/LabelTypeMenu.js
+++ b/public/javascripts/Gallery/src/filter/LabelTypeMenu.js
@@ -19,7 +19,7 @@ function LabelTypeMenu(uiLabelTypeMenu, initialLabelType) {
     function _init() {
         if (uiLabelTypeMenu) {
             uiLabelTypeMenu.select.bind({
-                change: labelSelectCallback
+                change: labelTypeSelectCallback
             })
         }
     }
@@ -27,11 +27,15 @@ function LabelTypeMenu(uiLabelTypeMenu, initialLabelType) {
     /**
      * Handles what happens when a label type is selected.
      */
-    function labelSelectCallback() {
-        let labelType = $(this).val();
-        setStatus("currentLabelType", labelType);
-        sg.tracker.push("Filter_LabelType=" + labelType);
-        sg.cardFilter.update();
+    function labelTypeSelectCallback() {
+        let newLabelType = $(this).val();
+        let oldLabelType = status.currentLabelType;
+        // Check if the label type changed. Prevents this code from running on initial page load.
+        if (newLabelType !== oldLabelType) {
+            setStatus("currentLabelType", newLabelType);
+            sg.tracker.push("Filter_LabelType=" + newLabelType);
+            sg.cardFilter.update();
+        }
     }
 
     /**

--- a/public/javascripts/Gallery/src/filter/LabelTypeMenu.js
+++ b/public/javascripts/Gallery/src/filter/LabelTypeMenu.js
@@ -2,23 +2,23 @@
  * Label Type Menu module.
  * This is responsible for holding the buttons allowing users to filter labels by label type.
  *
- * @param labelTypeMenu UI element corresponding to LabelTypeMenu.
+ * @param uiLabelTypeMenu UI element corresponding to LabelTypeMenu.
  * @returns {LabelTypeMenu}
  * @constructor
  */
-function LabelTypeMenu(labelTypeMenu) {
+function LabelTypeMenu(uiLabelTypeMenu, initialLabelType) {
     let self = this;
 
     let status = {
-        currentLabelType: null
+        currentLabelType: initialLabelType
     };
 
     /**
      * Initialize LabelTypeMenu.
      */
     function _init() {
-        if (labelTypeMenu) {
-            labelTypeMenu.select.bind({
+        if (uiLabelTypeMenu) {
+            uiLabelTypeMenu.select.bind({
                 change: labelSelectCallback
             })
         }

--- a/public/javascripts/Gallery/src/filter/Severity.js
+++ b/public/javascripts/Gallery/src/filter/Severity.js
@@ -63,7 +63,7 @@ function Severity (params, active) {
             apply();
         }
 
-        sg.cardContainer.updateCardsByTagsAndSeverity();
+        sg.cardFilter.update();
     }
 
     function _showSelected() {

--- a/public/javascripts/Gallery/src/filter/Severity.js
+++ b/public/javascripts/Gallery/src/filter/Severity.js
@@ -6,7 +6,7 @@
  * @returns {Severity}
  * @constructor
  */
-function Severity (params, active){
+function Severity (params, active) {
     let self = this;
 
     // UI element of the severity container and image.

--- a/public/javascripts/Gallery/src/filter/SeverityBucket.js
+++ b/public/javascripts/Gallery/src/filter/SeverityBucket.js
@@ -1,7 +1,7 @@
 /**
  * A Severity Bucket to store Severities.
  * 
- * @param bucket array containing Severities
+ * @param inputSeverities array containing Severities
  * @returns {SeverityBucket}
  * @constructor
  */

--- a/public/javascripts/Gallery/src/filter/SeverityBucket.js
+++ b/public/javascripts/Gallery/src/filter/SeverityBucket.js
@@ -1,22 +1,22 @@
 /**
  * A Severity Bucket to store Severities.
  * 
- * @param inputSeverities array containing Severities
+ * @param initialActiveSeverities array of severity levels to start out as active. Received from query params.
  * @returns {SeverityBucket}
  * @constructor
  */
-function SeverityBucket(inputSeverities) {
+function SeverityBucket(initialActiveSeverities) {
     let self = this;
 
     // List of severities.
-    let bucket = inputSeverities || [];
+    let bucket = [];
 
     /**
      * Initialize SeverityBucket.
      */
     function _init() {
-        for(let i = 1; i <= 5; i++ ){
-            push(new Severity(i, false));
+        for (let i = 1; i <= 5; i++ ) {
+            push(new Severity(i, initialActiveSeverities ? initialActiveSeverities.includes(i) > 0 : false));
         }
     }
 

--- a/public/javascripts/Gallery/src/filter/Tag.js
+++ b/public/javascripts/Gallery/src/filter/Tag.js
@@ -58,7 +58,7 @@ function Tag (params) {
             apply();
         }
 
-        sg.cardContainer.updateCardsByTagsAndSeverity();
+        sg.cardFilter.update();
     }
 
     /**

--- a/public/javascripts/Gallery/src/filter/Tag.js
+++ b/public/javascripts/Gallery/src/filter/Tag.js
@@ -32,7 +32,7 @@ function Tag (params) {
         Object.keys(param).forEach( attrName => properties[attrName] = param[attrName]);
 
         tagElement = document.createElement('button');
-        tagElement.className = "gallery-tag gallery-tag-sidebar gallery-filter";
+        tagElement.className = "gallery-tag gallery-filter-button gallery-filter";
         tagElement.id = properties.tag;
         tagElement.innerText = i18next.t('tag.' + properties.tag);
         tagElement.disabled = true;

--- a/public/javascripts/Gallery/src/filter/Tag.js
+++ b/public/javascripts/Gallery/src/filter/Tag.js
@@ -2,10 +2,11 @@
  * A Tag module.
  * 
  * @param {*} params Properties of tag.
+ * @param applied A boolean to see if the tag filter is active.
  * @returns {Tag}
  * @constructor
  */
-function Tag (params) {
+function Tag (params, applied) {
     let self = this;
 
     // UI element of Tag.
@@ -20,7 +21,7 @@ function Tag (params) {
 
     // Status of the tag.
     let status = {
-        applied: false
+        applied: applied
     };
 
     /**
@@ -36,6 +37,10 @@ function Tag (params) {
         tagElement.id = properties.tag;
         tagElement.innerText = i18next.t('tag.' + properties.tag);
         tagElement.disabled = true;
+
+        if (status.applied) {
+            apply()
+        }
 
         tagElement.onclick = tagClickCallback;
     }

--- a/public/javascripts/Gallery/src/filter/TagBucket.js
+++ b/public/javascripts/Gallery/src/filter/TagBucket.js
@@ -1,15 +1,14 @@
 /**
  * A Tag Bucket to store Tags.
- * 
- * @param inputTags array containing Tags
+ *
  * @returns {TagBucket}
  * @constructor
  */
-function TagBucket(inputTags) {
+function TagBucket() {
     let self = this;
 
     // List of Tags.
-    let bucket = inputTags || [];
+    let bucket = [];
 
     /**
      * Add Tag.

--- a/public/javascripts/Gallery/src/filter/TagBucket.js
+++ b/public/javascripts/Gallery/src/filter/TagBucket.js
@@ -1,7 +1,7 @@
 /**
  * A Tag Bucket to store Tags.
  * 
- * @param bucket array containing Tags
+ * @param inputTags array containing Tags
  * @returns {TagBucket}
  * @constructor
  */

--- a/public/javascripts/Gallery/src/filter/ValidationOption.js
+++ b/public/javascripts/Gallery/src/filter/ValidationOption.js
@@ -31,7 +31,7 @@ function ValidationOption (params, applied){
         Object.keys(param).forEach( attrName => properties[attrName] = param[attrName]);
 
         validationOptionElement = document.createElement('button');
-        validationOptionElement.className = "gallery-tag gallery-tag-sidebar gallery-filter";
+        validationOptionElement.className = "gallery-filter-validation-button gallery-filter-button gallery-filter";
         validationOptionElement.id = properties.validationOption;
         validationOptionElement.innerText = properties.validationOption;
 

--- a/public/javascripts/Gallery/src/filter/ValidationOption.js
+++ b/public/javascripts/Gallery/src/filter/ValidationOption.js
@@ -56,7 +56,7 @@ function ValidationOption (params, applied){
             apply();
         }
 
-        sg.cardContainer.updateCardsByTagsAndSeverity();
+        sg.cardFilter.update();
     }
 
     /**

--- a/public/javascripts/Gallery/src/filter/ValidationOption.js
+++ b/public/javascripts/Gallery/src/filter/ValidationOption.js
@@ -6,7 +6,7 @@
  * @returns {ValidationOption}
  * @constructor
  */
-function ValidationOption (params, applied){
+function ValidationOption (params, applied) {
     let self = this;
 
     // UI element of the validation option container and image.
@@ -37,8 +37,6 @@ function ValidationOption (params, applied){
 
         if (status.applied) {
             apply();
-        } else {
-            unapply();
         }
 
         validationOptionElement.onclick = handleOnClickCallback;

--- a/public/javascripts/Gallery/src/filter/ValidationOption.js
+++ b/public/javascripts/Gallery/src/filter/ValidationOption.js
@@ -1,0 +1,127 @@
+/**
+ * A Validation Option module.
+ *
+ * @param {*} params Properties of validation option.
+ * @param applied A boolean to see if the current validation option filter is active.
+ * @returns {ValidationOption}
+ * @constructor
+ */
+function ValidationOption (params, applied){
+    let self = this;
+
+    // UI element of the validation option container and image.
+    let validationOptionElement = null;
+    let interactionEnabled = false;
+
+    let properties = {
+        validationOption: undefined
+    };
+
+    // A boolean to see if the current validation option filter is active.
+    let status = {
+        applied: applied
+    };
+
+    /**
+     * Initialize ValidationOption.
+     *
+     * @param {int} param ValidationOption.
+     */
+    function _init(param) {
+        Object.keys(param).forEach( attrName => properties[attrName] = param[attrName]);
+
+        validationOptionElement = document.createElement('button');
+        validationOptionElement.className = "gallery-tag gallery-tag-sidebar gallery-filter";
+        validationOptionElement.id = properties.validationOption;
+        validationOptionElement.innerText = properties.validationOption;
+
+        if (status.applied) {
+            apply();
+        } else {
+            unapply();
+        }
+
+        validationOptionElement.onclick = handleOnClickCallback;
+    }
+
+    /**
+     * Handles when validation option is selected/deselected.
+     */
+    function handleOnClickCallback() {
+        if (status.applied) {
+            sg.tracker.push("ValidationOptionUnapply", null, { ValidationOption: properties.validationOption });
+            unapply();
+        } else {
+            sg.tracker.push("ValidationOptionApply", null, { ValidationOption: properties.validationOption });
+            apply();
+        }
+
+        sg.cardContainer.updateCardsByTagsAndSeverity();
+    }
+
+    /**
+     * Applies a validation option filter.
+     */
+    function apply() {
+        status.applied = true;
+        validationOptionElement.setAttribute("style", "background-color: #78c8aa");
+    }
+
+    /**
+     * Unapplies a validation option filter.
+     */
+    function unapply() {
+        status.applied = false;
+        validationOptionElement.setAttribute("style", "background-color: none");
+    }
+
+    /**
+     * Renders ValidationOption in sidebar.
+     *
+     * @param {*} filterContainer UI element to render ValidationOption in.
+     */
+    function render(filterContainer) {
+        filterContainer.append(validationOptionElement);
+    }
+
+    /**
+     * Returns whether ValidationOption is applied or not.
+     */
+    function getActive(){
+        return status.applied;
+    }
+
+    /**
+     * Returns validation option value of ValidationOption.
+     */
+    function getValidationOption() {
+        return properties.validationOption;
+    }
+
+    /**
+     * Disables interaction with ValidationOption.
+     */
+    function disable() {
+        interactionEnabled = false;
+    }
+
+    /**
+     * Enables interaction with ValidationOption.
+     */
+    function enable() {
+        interactionEnabled = true;
+    }
+
+    self.handleOnClickCallback = handleOnClickCallback;
+    self.apply = apply;
+    self.unapply = unapply;
+    self.getActive = getActive;
+    self.getValidationOption = getValidationOption;
+    self.render = render;
+    self.disable = disable;
+    self.enable = enable;
+
+    _init(params);
+
+    return this;
+}

--- a/public/javascripts/Gallery/src/filter/ValidationOption.js
+++ b/public/javascripts/Gallery/src/filter/ValidationOption.js
@@ -33,7 +33,7 @@ function ValidationOption (params, applied) {
         validationOptionElement = document.createElement('button');
         validationOptionElement.className = "gallery-filter-validation-button gallery-filter-button gallery-filter";
         validationOptionElement.id = properties.validationOption;
-        validationOptionElement.innerText = properties.validationOption;
+        validationOptionElement.innerText = i18next.t('gallery:' + properties.validationOption);
 
         if (status.applied) {
             apply();

--- a/public/javascripts/Gallery/src/filter/ValidationOptionBucket.js
+++ b/public/javascripts/Gallery/src/filter/ValidationOptionBucket.js
@@ -1,23 +1,23 @@
 /**
  * A Validation Option Bucket to store ValidationOptions.
  * 
- * @param inputValidationOptions array containing ValidationOptions
+ * @param initialValidationOptions array containing validation options to set on page load.
  * @returns {ValidationOptionBucket}
  * @constructor
  */
-function ValidationOptionBucket(inputValidationOptions) {
+function ValidationOptionBucket(initialValidationOptions) {
     let self = this;
 
     // List of validationOptions.
-    let bucket = inputValidationOptions || [];
+    let bucket = [];
 
     /**
      * Initialize ValidationOptionBucket.
      */
     function _init() {
-        push(new ValidationOption({ validationOption: 'correct'}, true));
-        push(new ValidationOption({ validationOption: 'incorrect'}, false));
-        push(new ValidationOption({ validationOption: 'unvalidated'}, true));
+        push(new ValidationOption({ validationOption: 'correct'}, initialValidationOptions.includes('correct')));
+        push(new ValidationOption({ validationOption: 'incorrect'}, initialValidationOptions.includes('incorrect')));
+        push(new ValidationOption({ validationOption: 'unvalidated'}, initialValidationOptions.includes('unvalidated')));
     }
 
     /**

--- a/public/javascripts/Gallery/src/filter/ValidationOptionBucket.js
+++ b/public/javascripts/Gallery/src/filter/ValidationOptionBucket.js
@@ -1,7 +1,7 @@
 /**
  * A Validation Option Bucket to store ValidationOptions.
  * 
- * @param bucket array containing ValidationOptions
+ * @param inputValidationOptions array containing ValidationOptions
  * @returns {ValidationOptionBucket}
  * @constructor
  */
@@ -15,9 +15,9 @@ function ValidationOptionBucket(inputValidationOptions) {
      * Initialize ValidationOptionBucket.
      */
     function _init() {
-        for (const valOption of ['Validated Correct', 'Validated Incorrect', 'Unvalidated']) {
-            push(new ValidationOption({ validationOption: valOption }, false));
-        }
+        push(new ValidationOption({ validationOption: 'correct'}, true));
+        push(new ValidationOption({ validationOption: 'incorrect'}, false));
+        push(new ValidationOption({ validationOption: 'unvalidated'}, true));
     }
 
     /**

--- a/public/javascripts/Gallery/src/filter/ValidationOptionBucket.js
+++ b/public/javascripts/Gallery/src/filter/ValidationOptionBucket.js
@@ -1,0 +1,94 @@
+/**
+ * A Validation Option Bucket to store ValidationOptions.
+ * 
+ * @param bucket array containing ValidationOptions
+ * @returns {ValidationOptionBucket}
+ * @constructor
+ */
+function ValidationOptionBucket(inputValidationOptions) {
+    let self = this;
+
+    // List of validationOptions.
+    let bucket = inputValidationOptions || [];
+
+    /**
+     * Initialize ValidationOptionBucket.
+     */
+    function _init() {
+        for (const valOption of ['Validated Correct', 'Validated Incorrect', 'Unvalidated']) {
+            push(new ValidationOption({ validationOption: valOption }, false));
+        }
+    }
+
+    /**
+     * Add validationOption.
+     * 
+     * @param {*} validationOption
+     */
+    function push(validationOption) {
+        bucket.push(validationOption);
+    }
+
+    /**
+     * Render ValidationOptions in ValidationOptionBucket.
+     * @param {*} uiValidationOptionHolder UI element to render ValidationOptions in.
+     */
+    function render(uiValidationOptionHolder) {
+        bucket.forEach(validationOption => validationOption.render(uiValidationOptionHolder));
+    }
+
+    /**
+     * Unapply all ValidationOptions.
+     */
+    function unapplyValidationOptions() {
+        bucket.forEach(validationOption => validationOption.unapply());
+    }
+
+    /**
+     * Return list of ValidationOptions.
+     */
+    function getValidationOptions() {
+        return bucket;
+    }
+
+    /**
+     * Return number of ValidationOptions.
+     */
+    function getSize() {
+        return bucket.length;
+    }
+
+    /**
+     * Return list of applied ValidationOptions.
+     */
+    function getAppliedValidationOptions() {
+        return bucket.filter(valOption => valOption.getActive()).map(valOption => valOption.getValidationOption());
+    }
+
+    /**
+     * Disable interaction with ValidationOptions.
+     */
+    function disable() {
+        bucket.forEach(validationOption => validationOption.disable());
+    }
+    
+    /**
+     * Enable interaction with ValidationOptions.
+     */
+    function enable() {
+        bucket.forEach(validationOption => validationOption.enable());
+    }
+
+    self.push = push;
+    self.render = render;
+    self.unapplyValidationOptions = unapplyValidationOptions;
+    self.getValidationOptions = getValidationOptions;
+    self.getSize = getSize;
+    self.getAppliedValidationOptions = getAppliedValidationOptions;
+    self.disable = disable;
+    self.enable = enable;
+
+    _init();
+
+    return this;
+}

--- a/public/locales/en/gallery.json
+++ b/public/locales/en/gallery.json
@@ -3,5 +3,8 @@
     "none": "none",
     "agree": "Agree",
     "disagree": "Disagree",
-    "not-sure": "Not Sure"
+    "not-sure": "Not Sure",
+    "correct": "Validated correct",
+    "incorrect": "Validated incorrect",
+    "unvalidated": "Unvalidated"
 }

--- a/public/locales/es/gallery.json
+++ b/public/locales/es/gallery.json
@@ -3,5 +3,8 @@
     "none": "ninguna",
     "agree": "De acuerdo",
     "disagree": "No estoy de acuerdo",
-    "not-sure": "No estoy de seguro"
+    "not-sure": "No estoy de seguro",
+    "correct": "Validada correcta",
+    "incorrect": "Validada incorrecta",
+    "unvalidated": "No validada"
 }

--- a/public/locales/nl/gallery.json
+++ b/public/locales/nl/gallery.json
@@ -3,5 +3,8 @@
     "none": "geen",
     "agree": "Eens",
     "disagree": "Oneens",
-    "not-sure": "Niet zeker"
+    "not-sure": "Niet zeker",
+    "correct": "Gevalideerd juist",
+    "incorrect": "Gevalideerd onjuist",
+    "unvalidated": "Niet gevalideerd"
 }


### PR DESCRIPTION
Resolves #2358 
Resolves #2746 
Fixes #2445 

New features
* Adds filters on validation (correct, incorrect, unvalidated), defaulting to correct and unvalidated. Looks and works similar to tag filters. Issue #2358 
* Adds query parameters for filtering on severity, tags, and validations. Issue #2746 
* URL query params in address bar now update as you apply filters, making it easier to share. Also #2746 

Bugs fixed
* Query param filters weren't being saved when switching cities. [no open issue]
* When filtering on label type and severity but _not_ on tags, back end was still only returning labels with tags. Issue #2445 

##### Before/After screenshots (if applicable)
Before
![Screenshot from 2023-02-03 11-47-44](https://user-images.githubusercontent.com/6518824/216694278-070d7c34-247d-469d-8ae3-2a69ce2cb495.png)

After (also notice the address bar!)
![Screenshot from 2023-02-03 11-47-01](https://user-images.githubusercontent.com/6518824/216694313-ad0ed8b9-6434-4a84-a99d-ed3e524bc9ed.png)

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
- [x] I've asked for and included translations for any user facing text that was added or modified.
- [x] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure the documentation on [this wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Descriptions-of-Logged-Events) is up to date for the logs you added/updated.
