### PR TITLE
3062 - adding logging for all emails to forgot password controller via logger

### DIFF
--- a/app/controllers/ForgotPasswordController.scala
+++ b/app/controllers/ForgotPasswordController.scala
@@ -78,7 +78,6 @@ class ForgotPasswordController @Inject() (
           // This is the case where the email was not found in the database
           case None =>
             WebpageActivityTable.save(WebpageActivity(0, userId, ipAddress, "PasswordResetFail_Email=" + email + "_Reason=EmailNotFound", timestamp))
-            // Should this be returned or should it be Future.failed(result)?
             Future.successful(result)
         }
       }

--- a/app/controllers/ForgotPasswordController.scala
+++ b/app/controllers/ForgotPasswordController.scala
@@ -47,11 +47,12 @@ class ForgotPasswordController @Inject() (
         val loginInfo = LoginInfo(CredentialsProvider.ID, email.toLowerCase)
         val result = Redirect(routes.UserController.forgotPassword()).flashing("info" -> Messages("reset.pw.email.reset.pw.sent"))
 
-        Logger.info("Logging user's email: " + email)
+        // Log the user's attempt to reset password here
+        WebpageActivityTable.save(WebpageActivity(0, userId, ipAddress, "PasswordResetAttempt_Email=" + email, timestamp))
 
         userService.retrieve(loginInfo).flatMap {
           case Some(user) =>
-            authTokenService.create(user.userId).map { authTokenID =>
+            authTokenService.create(user.userId).flatMap { authTokenID =>
               val url = routes.UserController.resetPassword(authTokenID).absoluteURL()
 
               val resetEmail = Email(
@@ -61,14 +62,23 @@ class ForgotPasswordController @Inject() (
                 bodyHtml = Some(views.html.emails.resetPasswordEmail(user, url).body)
               )
 
-              MailerPlugin.send(resetEmail)
-              WebpageActivityTable.save(WebpageActivity(0, userId, ipAddress, "PasswordResetRequest=" + email, timestamp))
-              result
+              try {
+                MailerPlugin.send(resetEmail)
+                WebpageActivityTable.save(WebpageActivity(0, userId, ipAddress, "PasswordResetSuccess_Email=" + email, timestamp))
+                Future.successful(result)
+              } catch {
+                case e: Exception => {
+                  WebpageActivityTable.save(WebpageActivity(0, userId, ipAddress, "PasswordResetFail_Email=" + email + "_Reason=" + e.getClass.getCanonicalName, timestamp))
+                  Logger.error(e.getCause + "")
+                  Future.failed(e)
+                }
+              }
             }
 
+          // This is the case where the email was not found in the database
           case None =>
-            Logger.warn("Tried to reset password, but email not found in database: " + email)
-            WebpageActivityTable.save(WebpageActivity(0, userId, ipAddress, "PasswordResetRequestFailed=" + email, timestamp))
+            WebpageActivityTable.save(WebpageActivity(0, userId, ipAddress, "PasswordResetFail_Email=" + email + "_Reason=EmailNotFound", timestamp))
+            // Should this be returned or should it be Future.failed(result)?
             Future.successful(result)
         }
       }

--- a/app/controllers/ForgotPasswordController.scala
+++ b/app/controllers/ForgotPasswordController.scala
@@ -46,6 +46,9 @@ class ForgotPasswordController @Inject() (
       email => {
         val loginInfo = LoginInfo(CredentialsProvider.ID, email.toLowerCase)
         val result = Redirect(routes.UserController.forgotPassword()).flashing("info" -> Messages("reset.pw.email.reset.pw.sent"))
+
+        Logger.info("Logging user's email: " + email)
+
         userService.retrieve(loginInfo).flatMap {
           case Some(user) =>
             authTokenService.create(user.userId).map { authTokenID =>

--- a/app/controllers/ForgotPasswordController.scala
+++ b/app/controllers/ForgotPasswordController.scala
@@ -48,7 +48,7 @@ class ForgotPasswordController @Inject() (
         val result = Redirect(routes.UserController.forgotPassword()).flashing("info" -> Messages("reset.pw.email.reset.pw.sent"))
 
         // Log the user's attempt to reset password here
-        WebpageActivityTable.save(WebpageActivity(0, userId, ipAddress, "PasswordResetAttempt_Email=" + email, timestamp))
+        WebpageActivityTable.save(WebpageActivity(0, userId, ipAddress, s"PasswordResetAttempt_Email=$email", timestamp))
 
         userService.retrieve(loginInfo).flatMap {
           case Some(user) =>
@@ -64,11 +64,11 @@ class ForgotPasswordController @Inject() (
 
               try {
                 MailerPlugin.send(resetEmail)
-                WebpageActivityTable.save(WebpageActivity(0, userId, ipAddress, "PasswordResetSuccess_Email=" + email, timestamp))
+                WebpageActivityTable.save(WebpageActivity(0, userId, ipAddress, s"PasswordResetSuccess_Email=$email", timestamp))
                 Future.successful(result)
               } catch {
                 case e: Exception => {
-                  WebpageActivityTable.save(WebpageActivity(0, userId, ipAddress, "PasswordResetFail_Email=" + email + "_Reason=" + e.getClass.getCanonicalName, timestamp))
+                  WebpageActivityTable.save(WebpageActivity(0, userId, ipAddress, s"PasswordResetFail_Email=${email}_Reason=${e.getClass.getCanonicalName}", timestamp))
                   Logger.error(e.getCause + "")
                   Future.failed(e)
                 }
@@ -77,7 +77,7 @@ class ForgotPasswordController @Inject() (
 
           // This is the case where the email was not found in the database
           case None =>
-            WebpageActivityTable.save(WebpageActivity(0, userId, ipAddress, "PasswordResetFail_Email=" + email + "_Reason=EmailNotFound", timestamp))
+            WebpageActivityTable.save(WebpageActivity(0, userId, ipAddress, s"PasswordResetFail_Email=${email}_Reason=EmailNotFound", timestamp))
             Future.successful(result)
         }
       }

--- a/app/controllers/ForgotPasswordController.scala
+++ b/app/controllers/ForgotPasswordController.scala
@@ -48,7 +48,7 @@ class ForgotPasswordController @Inject() (
         val result = Redirect(routes.UserController.forgotPassword()).flashing("info" -> Messages("reset.pw.email.reset.pw.sent"))
 
         // Log the user's attempt to reset password here
-        WebpageActivityTable.save(WebpageActivity(0, userId, ipAddress, s"PasswordResetAttempt_Email=$email", timestamp))
+        WebpageActivityTable.save(WebpageActivity(0, userId, ipAddress, s"""PasswordResetAttempt_Email="${email}"""", timestamp))
 
         userService.retrieve(loginInfo).flatMap {
           case Some(user) =>
@@ -64,11 +64,11 @@ class ForgotPasswordController @Inject() (
 
               try {
                 MailerPlugin.send(resetEmail)
-                WebpageActivityTable.save(WebpageActivity(0, userId, ipAddress, s"PasswordResetSuccess_Email=$email", timestamp))
+                WebpageActivityTable.save(WebpageActivity(0, userId, ipAddress, s"""PasswordResetSuccess_Email="$email"""", timestamp))
                 Future.successful(result)
               } catch {
                 case e: Exception => {
-                  WebpageActivityTable.save(WebpageActivity(0, userId, ipAddress, s"PasswordResetFail_Email=${email}_Reason=${e.getClass.getCanonicalName}", timestamp))
+                  WebpageActivityTable.save(WebpageActivity(0, userId, ipAddress, s"""PasswordResetFail_Email="${email}"_Reason=${e.getClass.getCanonicalName}""", timestamp))
                   Logger.error(e.getCause + "")
                   Future.failed(e)
                 }
@@ -77,7 +77,7 @@ class ForgotPasswordController @Inject() (
 
           // This is the case where the email was not found in the database
           case None =>
-            WebpageActivityTable.save(WebpageActivity(0, userId, ipAddress, s"PasswordResetFail_Email=${email}_Reason=EmailNotFound", timestamp))
+            WebpageActivityTable.save(WebpageActivity(0, userId, ipAddress, s"""PasswordResetFail_Email="${email}"_Reason=EmailNotFound""", timestamp))
             Future.successful(result)
         }
       }


### PR DESCRIPTION
Resolves #3062 

Added logging using the info level of logging to the ForgotPasswordController so all emails are logged when users are trying to reset their password on the forgot password page. (Note to self: Scala logging documentation [here](https://www.playframework.com/documentation/2.8.x/ScalaLogging))

##### Testing instructions
1. Go to "Forgot password" page and type in email
2. Check logs to confirm "Logging user's email: " + email entered is present

Future steps: If time permits, I want to explore the database option and making this an activity in the webpageactivity table. For now this is just to get the ticket resolved but this can be innovated in the future for sure.

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [X] I've written a descriptive PR title.
- [X] I've added/updated comments for large or confusing blocks of code.
- [TBD] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure the documentation on [this wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Descriptions-of-Logged-Events) is up to date for the logs you added/updated. 
