### PR TITLE
3059 - added reminder user regarding accounts not being transferable between cities

### DIFF
--- a/app/views/forgotPassword.scala.html
+++ b/app/views/forgotPassword.scala.html
@@ -23,6 +23,7 @@
         <legend>@Messages("reset.pw.forgot.title")</legend>
         @helper.form(action = routes.ForgotPasswordController.submit()) {
             <p class="info">@Messages("reset.pw.forgot.submit.email")</p>
+            <p class = "info">@Messages("reset.pw.forgot.suggest")</p>
             @text(forgotPasswordForm("emailForgotPassword"), Messages("authenticate.email"), icon = "at")
             <div class="form-group">
                 <div>

--- a/app/views/forgotPassword.scala.html
+++ b/app/views/forgotPassword.scala.html
@@ -22,8 +22,8 @@
     <fieldset class="col-md-6 col-md-offset-3" style="margin-top:51px">
         <legend>@Messages("reset.pw.forgot.title")</legend>
         @helper.form(action = routes.ForgotPasswordController.submit()) {
-            <p class="info">@Messages("reset.pw.forgot.submit.email")</p>
             <p class = "info">@Messages("reset.pw.forgot.suggest")</p>
+            <p class="info">@Messages("reset.pw.forgot.submit.email")</p>
             @text(forgotPasswordForm("emailForgotPassword"), Messages("authenticate.email"), icon = "at")
             <div class="form-group">
                 <div>

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -251,8 +251,8 @@ authenticate.error.invalid.credentials = Invalid credentials!
 authenticate.error.generic = Something went wrong processing your request. Please make sure all your information is correct and then try again
 
 reset.pw.forgot.title = Forgot your password?
-reset.pw.forgot.submit.email = No worries, type in your email and we’ll send you a link to reset your password.
-reset.pw.forgot.suggest = Note: Accounts are not interchangeable between different cities. You will need to make an account for each city.
+reset.pw.forgot.submit.email = Type in your email and we’ll send you a link to reset your password.
+reset.pw.forgot.suggest = If you are having trouble logging in or resetting your password, check that you are looking at the city where you made your account by checking the navbar on the top-right of the page. Accounts are not interchangeable between different cities, so you'll need to make a new account for each city (you can use the same username/password).
 
 reset.pw.email.hello = Hi {0},
 reset.pw.email.reset.title = Reset Your Project Sidewalk Account Password

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -252,6 +252,7 @@ authenticate.error.generic = Something went wrong processing your request. Pleas
 
 reset.pw.forgot.title = Forgot your password?
 reset.pw.forgot.submit.email = No worries, type in your email and we’ll send you a link to reset your password.
+reset.pw.forgot.suggest = Note: Accounts are not interchangeable between different cities. You will need to make an account for each city.
 
 reset.pw.email.hello = Hi {0},
 reset.pw.email.reset.title = Reset Your Project Sidewalk Account Password

--- a/conf/messages.es
+++ b/conf/messages.es
@@ -251,6 +251,7 @@ authenticate.error.generic = Algo salió mal al procesar su solicitud. Por favor
 
 reset.pw.forgot.title = Olvidaste tu contraseña
 reset.pw.forgot.submit.email = No te preocupes, escribe tu correo electrónico y te enviaremos un enlace para restablecer tu contraseña.
+reset.pw.forgot.suggest = Nota: Las cuentas no son intercambiables entre diferentes ciudades. Deberá crear una cuenta para cada ciudad.
 
 reset.pw.email.hello = Hola {0},
 reset.pw.email.reset.title = Restablecer la contraseña de tu cuenta de Project Sidewalk

--- a/conf/messages.es
+++ b/conf/messages.es
@@ -250,8 +250,8 @@ authenticate.error.invalid.credentials = Credenciales inválidas
 authenticate.error.generic = Algo salió mal al procesar su solicitud. Por favor, asegúrese de que toda su información sea correcta y vuelva a intentarlo
 
 reset.pw.forgot.title = Olvidaste tu contraseña
-reset.pw.forgot.submit.email = No te preocupes, escribe tu correo electrónico y te enviaremos un enlace para restablecer tu contraseña.
-reset.pw.forgot.suggest = Nota: Las cuentas no son intercambiables entre diferentes ciudades. Deberá crear una cuenta para cada ciudad.
+reset.pw.forgot.submit.email = Escribe tu correo electrónico y te enviaremos un enlace para restablecer tu contraseña.
+reset.pw.forgot.suggest = Si tiene problemas para iniciar sesión o restablecer su contraseña, compruebe que está mirando la ciudad donde creó su cuenta consultando la barra de navegación en la parte superior derecha de la página. Las cuentas no son intercambiables entre diferentes ciudades, por lo que deberá crear una nueva cuenta para cada ciudad (puede usar el mismo nombre de usuario/contraseña).
 
 reset.pw.email.hello = Hola {0},
 reset.pw.email.reset.title = Restablecer la contraseña de tu cuenta de Project Sidewalk

--- a/conf/messages.nl
+++ b/conf/messages.nl
@@ -251,6 +251,8 @@ authenticate.error.generic = Er is iets misgegaan bij het verwerken van uw verzo
 
 reset.pw.forgot.title = Wachtwoord vergeten?
 reset.pw.forgot.submit.email = Geen zorgen, typ je e-mail in en we sturen je een link om je wachtwoord opnieuw in te stellen.
+reset.pw.forgot.suggest = Opmerking: Accounts zijn niet uitwisselbaar tussen verschillende steden. Je moet voor elke stad een account aanmaken.
+
 
 reset.pw.email.hello = Hi {0},
 reset.pw.email.reset.title = Reset het wachtwoord van je Project Sidewalk-account

--- a/conf/messages.nl
+++ b/conf/messages.nl
@@ -253,7 +253,6 @@ reset.pw.forgot.title = Wachtwoord vergeten?
 reset.pw.forgot.submit.email = Geen zorgen, typ je e-mail in en we sturen je een link om je wachtwoord opnieuw in te stellen.
 reset.pw.forgot.suggest = Opmerking: Accounts zijn niet uitwisselbaar tussen verschillende steden. Je moet voor elke stad een account aanmaken.
 
-
 reset.pw.email.hello = Hi {0},
 reset.pw.email.reset.title = Reset het wachtwoord van je Project Sidewalk-account
 reset.pw.email.send.link = E-mail verzenden

--- a/conf/messages.nl
+++ b/conf/messages.nl
@@ -250,8 +250,8 @@ authenticate.error.invalid.credentials = Ongeldige inloggegevens!
 authenticate.error.generic = Er is iets misgegaan bij het verwerken van uw verzoek. Zorg ervoor dat al uw informatie correct is en probeer het opnieuw
 
 reset.pw.forgot.title = Wachtwoord vergeten?
-reset.pw.forgot.submit.email = Geen zorgen, typ je e-mail in en we sturen je een link om je wachtwoord opnieuw in te stellen.
-reset.pw.forgot.suggest = Opmerking: Accounts zijn niet uitwisselbaar tussen verschillende steden. Je moet voor elke stad een account aanmaken.
+reset.pw.forgot.submit.email = Typ je e-mail in en we sturen je een link om je wachtwoord opnieuw in te stellen.
+reset.pw.forgot.suggest = Als je problemen hebt met inloggen of het resetten van je wachtwoord, controleer dan of je naar de stad kijkt waar je je account hebt aangemaakt door naar de navigatiebalk rechtsboven op de pagina te kijken. Accounts zijn niet uitwisselbaar tussen verschillende steden, dus je moet voor elke stad een nieuw account aanmaken (je kunt dezelfde gebruikersnaam en hetzelfde wachtwoord gebruiken).
 
 reset.pw.email.hello = Hi {0},
 reset.pw.email.reset.title = Reset het wachtwoord van je Project Sidewalk-account


### PR DESCRIPTION
Resolves #3059 

Added message above textbox for email to reminder users that project sidewalk accounts are not transferable between cities.  

##### Before/After screenshots (if applicable)
![3059_before](https://user-images.githubusercontent.com/56641275/216799188-07e7cce5-35b1-4dc7-a219-a39f4d9ceb54.png)
![3059_after](https://user-images.githubusercontent.com/56641275/216799190-0efd4c3c-e468-4ab2-96ff-0d698fbb0eb5.png)
![Screenshot 2023-02-04 at 7 30 45 PM](https://user-images.githubusercontent.com/56641275/216799967-d47b5fdd-47e6-4bd2-9152-fd3b4ac7ccf8.png)
![Screenshot 2023-02-04 at 7 30 45 PM](https://user-images.githubusercontent.com/56641275/216800003-a032320b-c50a-4cc7-a440-ef9c34c25c46.png)
![Screenshot 2023-02-04 at 7 30 53 PM](https://user-images.githubusercontent.com/56641275/216800018-a4399d3d-9cc0-40b2-bc91-10ef6a0e4f45.png)
![Screenshot 2023-02-04 at 7 30 34 PM](https://user-images.githubusercontent.com/56641275/216800019-47031f04-ec05-4138-ac27-27672d250a26.png)

##### Testing instructions
1. Go to Forgot Password page in each respective language and view updated text

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [X] I've written a descriptive PR title.
- [X] I've included before/after screenshots above.
- [X] I've asked for and included translations for any user facing text that was added or modified.
