### PR TITLE
#3116: Fix street id not updating

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/Main.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Main.js
@@ -157,7 +157,7 @@ function Main (params) {
         svl.modalExample = new ModalExample(svl.modalModel, svl.onboardingModel, svl.ui.modalExample);
 
         svl.infoPopover = new GSVInfoPopover(svl.ui.dateHolder, svl.panorama, svl.map.getPosition, svl.map.getPanoId,
-            svl.taskContainer.getCurrentTask().getStreetEdgeId, svl.neighborhoodContainer.getCurrentNeighborhood().getRegionId,
+            svl.taskContainer.getCurrentTaskStreetEdgeIdFunction, svl.neighborhoodContainer.getCurrentNeighborhood().getRegionId,
             svl.map.getPov, true, function() { svl.tracker.push('GSVInfoButton_Click'); },
             function() { svl.tracker.push('GSVInfoCopyToClipboard_Click'); },
             function() { svl.tracker.push('GSVInfoViewInGSV_Click'); }

--- a/public/javascripts/SVLabel/src/SVLabel/task/TaskContainer.js
+++ b/public/javascripts/SVLabel/src/SVLabel/task/TaskContainer.js
@@ -494,6 +494,17 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
     };
 
     /**
+     * Get street id of current task
+     */
+    function getCurrentTaskStreetEdgeId() {
+        return currentTask ? currentTask.getStreetEdgeId() : null;
+    }
+
+    function getCurrentTaskStreetEdgeIdFunction() {
+        return getCurrentTaskStreetEdgeId;
+    }
+
+    /**
      * Store the before jump new task
      * @param task
      */
@@ -585,4 +596,5 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
     self.update = update;
     self.updateAuditedDistance = updateAuditedDistance;
     self.updateTaskPriorities = updateTaskPriorities;
+    self.getCurrentTaskStreetEdgeIdFunction = getCurrentTaskStreetEdgeIdFunction();
 }


### PR DESCRIPTION
Resolves #3116 

Fixed Street ID not updating in the Explore page GSV info button popup when the user is directed onto a different street.

##### Before/After screenshots (if applicable)
Before: 
1. Street ID of old street
![image](https://user-images.githubusercontent.com/106000281/218246103-0a4d4c64-9d23-4622-9fff-2ed89eff6e53.png)
2. New street, same Street ID as old street
![image](https://user-images.githubusercontent.com/106000281/218246117-198d93ca-bdd2-4bb5-8f60-0410b4415dd6.png)
3. page refresh, new Street ID to reflect street change
![image](https://user-images.githubusercontent.com/106000281/218246129-77e84a1d-2e95-4fc7-a0af-a02f9887e6f5.png)

After: 
1. Street ID of old street
![image](https://user-images.githubusercontent.com/106000281/218245975-cbf9287f-bec5-48fb-83d1-54a152a4afb2.png)
2. Street ID of new street without page refresh
![image](https://user-images.githubusercontent.com/106000281/218246005-b7447b09-e161-4421-b4f9-700fe14a9234.png)

##### Testing instructions
1. Go to Explore page
2. Check Street ID on GSV info popup
3. Move forward until directed to new task or street
4. Check new Street ID on GSV info popup

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
- [x] I've written a descriptive PR title.
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
