### PR TITLE
Fixes Explore page not working on Firefox

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/task/Task.js
+++ b/public/javascripts/SVLabel/src/SVLabel/task/Task.js
@@ -48,7 +48,7 @@ function Task (geojson, tutorialTask, currentLat, currentLng, startPointReversed
         self.setProperty("completedByAnyUser", _geojson.features[0].properties.completed_by_any_user);
         self.setProperty("priority", _geojson.features[0].properties.priority);
         self.setProperty("currentMissionId", currMissionId);
-        self.setProperty("taskStart", new Date(`${_geojson.features[0].properties.task_start} UTC`));
+        self.setProperty("taskStart", new Date(`${_geojson.features[0].properties.task_start}Z`));
         if (_geojson.features[0].properties.completed) {
             status.isComplete = true;
         }


### PR DESCRIPTION
Resolves #3133 

Fixes a bug that caused no data to be sent to the back end in Firefox. No data was saved, and you couldn't move on to a second mission. The issue was a different implementation of the `Date.parser()` in JavaScript between different browsers.
