### PR TITLE
Gallery assorted labels are now randomized again

### DIFF
--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -699,10 +699,10 @@ object LabelTable {
     // Randomize, check for GSV imagery, & add tag info. If no label type is specified, do it by label type.
     if (labelTypeId.isDefined) {
       val rand = SimpleFunction.nullary[Double]("random")
-      val _randomLabels = _uniqueLabels.sortBy(x => rand).list.map(LabelValidationMetadataWithoutTags.tupled)
+      val _randomizedLabels = _uniqueLabels.sortBy(x => rand).list.map(LabelValidationMetadataWithoutTags.tupled)
 
       // Take the first `n` labels with non-expired GSV imagery.
-      checkForGsvImagery(_randomLabels, n)
+      checkForGsvImagery(_randomizedLabels, n)
         .map(l => labelAndTagsToLabelValidationMetadata(l, getTagsFromLabelId(l.labelId)))
     } else {
       val _potentialLabels: Map[String, List[LabelValidationMetadataWithoutTags]] =
@@ -710,9 +710,10 @@ object LabelTable {
           .groupBy(_.labelType).map(l => l._1 -> scala.util.Random.shuffle(l._2))
       val nPerType: Int = n / LabelTypeTable.primaryLabelTypes.size
 
-      // Take the first `nPerType` labels with non-expired GSV imagery for each label type.
-      checkForImageryByLabelType(_potentialLabels, nPerType)
+      // Take the first `nPerType` labels with non-expired GSV imagery for each label type, then randomize them.
+      val chosenLabels: Seq[LabelValidationMetadata] = checkForImageryByLabelType(_potentialLabels, nPerType)
         .map(l => labelAndTagsToLabelValidationMetadata(l, getTagsFromLabelId(l.labelId)))
+      scala.util.Random.shuffle(chosenLabels)
     }
   }
 


### PR DESCRIPTION
Fixes #3128 

Fixes the default Gallery view where we show assorted label types. The label types are not mixed randomly again!

##### Before/After screenshots (if applicable)
Before
![Screenshot from 2023-02-28 11-14-36](https://user-images.githubusercontent.com/6518824/221955948-515b21ab-7c3f-4a7b-8664-258faffa9597.png)

After
![Screenshot from 2023-02-28 11-12-13](https://user-images.githubusercontent.com/6518824/221955962-66b356a0-71e3-488f-9840-6fc46a2c5e7d.png)

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
