### PR TITLE
Improves Gallery hover and disable UI for filters

### DIFF
--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -34,7 +34,7 @@
     <script type="text/javascript" src='@routes.Assets.at("javascripts/lib/backbone-min.js")'></script>
     <script src='@routes.Assets.at("javascripts/lib/js.cookie.js")'></script>
     <script type="text/javascript"
-        src="https://maps.googleapis.com/maps/api/js?v=quarterly&key=@Play.configuration.getString("google-maps-api-key").get&language=@lang.code">
+        src="https://maps.googleapis.com/maps/api/js?v=quarterly&key=@Play.configuration.getString("google-maps-api-key").get&language=@lang.code&callback=Function.prototype">
     </script>
     <link href='@routes.Assets.at("stylesheets/fonts.css")' rel="stylesheet"/>
     <link rel="stylesheet" href='@routes.Assets.at("stylesheets/main.css")'>

--- a/public/javascripts/Gallery/css/filter.css
+++ b/public/javascripts/Gallery/css/filter.css
@@ -5,7 +5,7 @@
 .gallery-filter:disabled {
     cursor: default;
     opacity: 50%;
-    background-color: white;
+    pointer-events: none;
 }
 
 .severity-filter-image {
@@ -53,7 +53,9 @@
     border-width: 1px;
     border-radius: 5px;
     text-align: left;
+    background-color: white;
     color: black;
+    border-color: black;
     width: fit-content;
     white-space: nowrap;
     max-width: 98%;
@@ -61,8 +63,16 @@
     text-overflow: ellipsis;
 }
 
+.gallery-filter-button-selected {
+    background-color: #76c9ab;
+    color: white;
+    border-color: #76c9ab;
+}
+
 .gallery-filter-button:hover {
-    background-color: #78c8aa;
+    background-color: rgba(167,222,202,0.1);
+    color: #40bd90;
+    border-color: #40bd90;
     white-space: normal;
 }
 

--- a/public/javascripts/Gallery/css/tags.css
+++ b/public/javascripts/Gallery/css/tags.css
@@ -21,6 +21,7 @@
     border-style: none;
     font-weight: bold;
     cursor: pointer;
+    background-color: inherit;
 }
 
 #tags-header {

--- a/public/javascripts/Gallery/src/cards/CardContainer.js
+++ b/public/javascripts/Gallery/src/cards/CardContainer.js
@@ -325,16 +325,12 @@ function CardContainer(uiCardContainer, initialFilters) {
                 uiCardContainer.holder.css('margin-left', sg.ui.cardFilter.wrapper.css('width'));
                 sg.scrollStatus.stickySidebar = true;
                 sg.cardFilter.enable();
-                sg.ui.labelTypeMenu.select.prop("disabled", false);
-                sg.ui.cityMenu.select.prop("disabled", false);
             });
         } else {
             // TODO: figure out how to better do the toggling of this element.
             sg.labelsNotFound.show();
             sg.pageLoading.hide();
             sg.cardFilter.enable();
-            sg.ui.labelTypeMenu.select.prop("disabled", false);
-            sg.ui.cityMenu.select.prop("disabled", false);
         }
     }
 
@@ -357,8 +353,6 @@ function CardContainer(uiCardContainer, initialFilters) {
 
         // Disable interactable UI elements while query loads.
         sg.cardFilter.disable();
-        sg.ui.labelTypeMenu.select.prop("disabled", true);
-        sg.ui.cityMenu.select.prop("disabled", true);
         sg.labelsNotFound.hide();
         sg.ui.pageControl.hide();
 

--- a/public/javascripts/Gallery/src/filter/CardFilter.js
+++ b/public/javascripts/Gallery/src/filter/CardFilter.js
@@ -251,8 +251,7 @@ function CardFilter(uiCardFilter, labelTypeMenu, cityMenu, initialFilters) {
      */
     function disable() {
         severities.disable();
-        validationOptions.disable();
-        $('.gallery-tag').prop("disabled", true);
+        $('.gallery-filter').prop("disabled", true);
     }
 
     /**
@@ -260,8 +259,7 @@ function CardFilter(uiCardFilter, labelTypeMenu, cityMenu, initialFilters) {
      */
     function enable() {
         severities.enable();
-        validationOptions.enable();
-        $('.gallery-tag').prop("disabled", false);
+        $('.gallery-filter').prop("disabled", false);
     }
 
     self.update = update;

--- a/public/javascripts/Gallery/src/filter/Tag.js
+++ b/public/javascripts/Gallery/src/filter/Tag.js
@@ -36,7 +36,7 @@ function Tag (params, applied) {
         tagElement.className = "gallery-tag gallery-filter-button gallery-filter";
         tagElement.id = properties.tag;
         tagElement.innerText = i18next.t('tag.' + properties.tag);
-        tagElement.disabled = true;
+        tagElement.disabled = true; // Will be enabled once images load.
 
         if (status.applied) {
             apply()
@@ -71,7 +71,7 @@ function Tag (params, applied) {
      */
     function apply() {
         setStatus("applied", true);
-        tagElement.setAttribute("style", "background-color: #78c8aa");
+        tagElement.classList.add("gallery-filter-button-selected");
     }
 
     /**
@@ -79,7 +79,7 @@ function Tag (params, applied) {
      */
     function unapply() {
         setStatus("applied", false);
-        tagElement.setAttribute("style", "background-color: none");
+        tagElement.classList.remove("gallery-filter-button-selected");
     }
 
     /**

--- a/public/javascripts/Gallery/src/filter/ValidationOption.js
+++ b/public/javascripts/Gallery/src/filter/ValidationOption.js
@@ -11,7 +11,6 @@ function ValidationOption (params, applied) {
 
     // UI element of the validation option container and image.
     let validationOptionElement = null;
-    let interactionEnabled = false;
 
     let properties = {
         validationOption: undefined
@@ -34,6 +33,7 @@ function ValidationOption (params, applied) {
         validationOptionElement.className = "gallery-filter-validation-button gallery-filter-button gallery-filter";
         validationOptionElement.id = properties.validationOption;
         validationOptionElement.innerText = i18next.t('gallery:' + properties.validationOption);
+        validationOptionElement.disabled = true; // Will be enabled once images load.
 
         if (status.applied) {
             apply();
@@ -62,7 +62,7 @@ function ValidationOption (params, applied) {
      */
     function apply() {
         status.applied = true;
-        validationOptionElement.setAttribute("style", "background-color: #78c8aa");
+        validationOptionElement.classList.add("gallery-filter-button-selected");
     }
 
     /**
@@ -70,7 +70,7 @@ function ValidationOption (params, applied) {
      */
     function unapply() {
         status.applied = false;
-        validationOptionElement.setAttribute("style", "background-color: none");
+        validationOptionElement.classList.remove("gallery-filter-button-selected");
     }
 
     /**
@@ -96,28 +96,12 @@ function ValidationOption (params, applied) {
         return properties.validationOption;
     }
 
-    /**
-     * Disables interaction with ValidationOption.
-     */
-    function disable() {
-        interactionEnabled = false;
-    }
-
-    /**
-     * Enables interaction with ValidationOption.
-     */
-    function enable() {
-        interactionEnabled = true;
-    }
-
     self.handleOnClickCallback = handleOnClickCallback;
     self.apply = apply;
     self.unapply = unapply;
     self.getActive = getActive;
     self.getValidationOption = getValidationOption;
     self.render = render;
-    self.disable = disable;
-    self.enable = enable;
 
     _init(params);
 

--- a/public/javascripts/Gallery/src/filter/ValidationOptionBucket.js
+++ b/public/javascripts/Gallery/src/filter/ValidationOptionBucket.js
@@ -65,28 +65,12 @@ function ValidationOptionBucket(initialValidationOptions) {
         return bucket.filter(valOption => valOption.getActive()).map(valOption => valOption.getValidationOption());
     }
 
-    /**
-     * Disable interaction with ValidationOptions.
-     */
-    function disable() {
-        bucket.forEach(validationOption => validationOption.disable());
-    }
-    
-    /**
-     * Enable interaction with ValidationOptions.
-     */
-    function enable() {
-        bucket.forEach(validationOption => validationOption.enable());
-    }
-
     self.push = push;
     self.render = render;
     self.unapplyValidationOptions = unapplyValidationOptions;
     self.getValidationOptions = getValidationOptions;
     self.getSize = getSize;
     self.getAppliedValidationOptions = getAppliedValidationOptions;
-    self.disable = disable;
-    self.enable = enable;
 
     _init();
 


### PR DESCRIPTION
Resolves #3122 

Adds a dedicated hover state to Gallery filters that is separate from the selected v deselected states.  A few other minor issues were fixed, like the validation options not looking like they were disabled when we were waiting for new images to load, and the browser console error about not having a callback func for Google Maps is now gone!

##### Before/After screenshots
Before (oops my screenshot doesn't show my mouse, but it is hovering over the 'missing tactile warning' tag!
![Screenshot from 2023-02-28 15-36-55](https://user-images.githubusercontent.com/6518824/222007952-c23ada86-08fb-46ff-aa47-5657e5088944.png)

After
![Screenshot from 2023-02-28 15-36-11](https://user-images.githubusercontent.com/6518824/222007964-646c0469-6950-40d2-adc5-0f526d2a3e58.png)

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
