### PR TITLE
Fixes a bug where you can't label in Safari

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/label/Label.js
+++ b/public/javascripts/SVLabel/src/SVLabel/label/Label.js
@@ -406,11 +406,10 @@ function Label(params) {
             var panoLat = getProperty("panoramaLat");
             var panoLng = getProperty("panoramaLng");
             var panoHeading = getProperty("originalPov").heading;
-            var zoom = getProperty("originalPov").zoom;
+            var zoom = Math.round(getProperty("originalPov").zoom); // Need to round specifically for Safari.
             var canvasX = getProperty('originalCanvasCoordinate').x;
             var canvasY = getProperty('originalCanvasCoordinate').y;
             var svImageY = getProperty('svImageCoordinate').y;
-
             // Estimate heading diff and distance from pano using output from a regression analysis.
             // https://github.com/ProjectSidewalk/label-latlng-estimation/blob/master/scripts/label-latlng-estimation.md#results
             var estHeadingDiff =


### PR DESCRIPTION
Resolves #3177 

Fixes a bug where you were unable to label on the Explore page in Safari (outside of the tutorial). It seems that Google's `StreetViewPanorama` objec'ts `getPov()` method will return an integer `1` in Chrome/Firefox, but `1.0000000000000002` in Safari. I must have removed rounding it to an integer. The rounding has been reinstated!

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
