### PR TITLE
Fixes hidden Other label type on Explore page Safari

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/ribbon/RibbonMenu.js
+++ b/public/javascripts/SVLabel/src/SVLabel/ribbon/RibbonMenu.js
@@ -37,7 +37,7 @@ function RibbonMenu(overlayMessageBox, tracker, uiRibbonMenu) {
         blinkInterval;
 
     function _init() {
-        // Initialize the jQuery DOM elements
+        // Initialize the jQuery DOM elements.
         if (uiRibbonMenu) {
             setLabelTypeButtonBorderColors(status.mode);
 
@@ -61,6 +61,14 @@ function RibbonMenu(overlayMessageBox, tracker, uiRibbonMenu) {
             $signInModalPassword.on('focus', disableModeSwitch);
             $signInModalPassword.on('blur', enableModeSwitch);
         }
+
+        // TODO For some reason the Other label type button doesn't show in Safari if we don't reset the display attr??
+        // https://github.com/ProjectSidewalk/SidewalkWebpage/issues/3180
+        var otherButton = document.getElementById('mode-switch-button-other');
+        otherButton.style.display = 'block';
+        setTimeout(function() {
+            otherButton.style.display = 'inline-block';
+        }, 500);
     }
 
     /**
@@ -496,7 +504,6 @@ function RibbonMenu(overlayMessageBox, tracker, uiRibbonMenu) {
     self.stopBlinking = stopBlinking;
     self.unlockDisableMode = unlockDisableMode;
     self.unlockDisableModeSwitch = unlockDisableModeSwitch;
-
 
     _init();
 


### PR DESCRIPTION
Resolves #3180 

Fixes a visual issue where the Other label type was not visible on the Explore page in Safari, it was being pushed down to the next row, below the Explore button.

This is very much a hotfix. When I changed the CSS `display` attribute to something different, and then back to `inline-block` (which is where it should be), then the button gets put in the right place! So there is clearly enough space for the button... It might just be that when it is first rendered, some other element may not have fully loaded yet, which is causing the issue.

I don't think that digging into the root cause is important enough right now, so I just added some code the toggles the `display` attribute back and forth. It puts the button in the right place, and you never see it missing now 🤷 

##### Before/After screenshots
Before
<img width="735" alt="Screenshot 2023-03-20 at 12 13 01 PM" src="https://user-images.githubusercontent.com/6518824/226442714-118695e9-f5b3-4fb6-97bc-7e8c7d9f6da0.png">

After
<img width="735" alt="Screenshot 2023-03-20 at 1 46 14 PM" src="https://user-images.githubusercontent.com/6518824/226461990-211b4f2b-d17f-45b8-83d5-65cdc2342d06.png">

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
