### PR TITLE
Removes missing crosswalk tag from "Other" label on Explore.

### DIFF
--- a/conf/cityparams.conf
+++ b/conf/cityparams.conf
@@ -182,6 +182,7 @@ city-params {
       "uncovered manhole"
       "level with sidewalk"
       "APS"
+      "missing crosswalk"
     ]
     washington-dc = [
       "tactile warning"
@@ -191,6 +192,7 @@ city-params {
       "uncovered manhole"
       "level with sidewalk"
       "APS"
+      "missing crosswalk"
     ]
     seattle-wa = [
       "tactile warning"
@@ -200,6 +202,7 @@ city-params {
       "uncovered manhole"
       "level with sidewalk"
       "APS"
+      "missing crosswalk"
     ]
     columbus-oh = [
       "tactile warning"
@@ -209,6 +212,7 @@ city-params {
       "uncovered manhole"
       "level with sidewalk"
       "APS"
+      "missing crosswalk"
     ]
     cdmx = [
       "tactile warning"
@@ -218,6 +222,7 @@ city-params {
       "no pedestrian priority"
       "level with sidewalk"
       "APS"
+      "missing crosswalk"
     ]
     spgg = [
       "tactile warning"
@@ -227,6 +232,7 @@ city-params {
       "no pedestrian priority"
       "level with sidewalk"
       "APS"
+      "missing crosswalk"
     ]
     pittsburgh-pa = [
       "tactile warning"
@@ -236,6 +242,7 @@ city-params {
       "uncovered manhole"
       "level with sidewalk"
       "APS"
+      "missing crosswalk"
     ]
     chicago-il = [
       "tactile warning"
@@ -245,6 +252,7 @@ city-params {
       "uncovered manhole"
       "level with sidewalk"
       "APS"
+      "missing crosswalk"
     ]
     amsterdam = [
       "garage entrance"
@@ -254,6 +262,7 @@ city-params {
       "brick/cobblestone"
       "uncovered manhole"
       "APS"
+      "missing crosswalk"
     ]
     la-piedad = [
       "tactile warning"
@@ -263,6 +272,7 @@ city-params {
       "no pedestrian priority"
       "level with sidewalk"
       "APS"
+      "missing crosswalk"
     ]
     oradell-nj = [
       "tactile warning"
@@ -272,6 +282,7 @@ city-params {
       "uncovered manhole"
       "level with sidewalk"
       "APS"
+      "missing crosswalk"
     ]
     validation-study = [
       "tactile warning"
@@ -280,6 +291,7 @@ city-params {
       "no pedestrian priority"
       "uncovered manhole"
       "level with sidewalk"
+      "missing crosswalk"
     ]
     zurich = [
       "tactile warning"
@@ -287,12 +299,14 @@ city-params {
       "uncovered manhole"
       "APS"
       "level with sidewalk"
+      "missing crosswalk"
     ]
     taipei = [
       "tactile warning"
       "uncovered manhole"
       "APS"
       "level with sidewalk"
+      "missing crosswalk"
     ]
     auckland = [
       "tactile warning"
@@ -303,6 +317,7 @@ city-params {
       "uncovered manhole"
       "level with sidewalk"
       "APS"
+      "missing crosswalk"
     ]
   }
   landing-page-url {


### PR DESCRIPTION
Resolves #3158 

Removes missing crosswalk tag from "Other" label on Explore by adding missing crosswalk to excluded tags.

##### Before/After screenshots (if applicable)
Before: 
![image](https://user-images.githubusercontent.com/106000281/226521197-e2e45e6e-0f58-4e9b-a4a1-3b332b65a62a.png)

After: 
![image](https://user-images.githubusercontent.com/106000281/226521244-d2aeadd1-e8f8-4ae2-8b40-e2ad1b972bc1.png)

##### Testing instructions
1. Navigate to Explore page
2. Add "Other" label - see tags available

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've included before/after screenshots above.