### PR TITLE
Fixes sidebar label counts getting cut off

### DIFF
--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -130,6 +130,13 @@ footer {
     margin-right: auto;
 }
 
+#status-neighborhood-link {
+    display: -webkit-box;
+    -webkit-line-clamp: 1;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
 #mturk-confirmation-code {
     padding-top: 18px;
     font: normal normal normal 13px/1.4em raleway, sans-serif;


### PR DESCRIPTION
Resolves #3047 

Clamps the neighborhood name in the right sidebar to 1 line (hiding overflow text) so that label counts don't get cut off when neighborhood name is longer than 1 line.

##### Before/After screenshots (if applicable)
Before: 
![3047_sidebar_label_bug](https://user-images.githubusercontent.com/106000281/227115319-26bb8788-8f09-42ea-b941-1971c0098b47.png)

After:
![3047_sidebar_label_fix](https://user-images.githubusercontent.com/106000281/227115332-35629e15-d8a1-40e9-aac3-fca622a3d4dd.png)


##### Testing instructions
1. Navigate to Results Map page
2. Choose neighborhood with long name (ex. Central Business District) and click "Click here" to explore neighborhood
3. Observe right sidebar neighborhood name and label counts

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've included before/after screenshots above.
