### PR TITLE
3096 - noting that validation comments are seen

### DIFF
--- a/app/views/validation.scala.html
+++ b/app/views/validation.scala.html
@@ -108,6 +108,7 @@
                         </button>
                     </div>
                     <textarea id="validation-label-comment" placeholder="@Messages("validate.bottom.ui.add.comment")" class="validation-comment-box"></textarea>
+                    <span>@Html(Messages("validate.dashboard.redirect"))</span>
                 </div>
             </div>
             <div id="modal-comment-holder" class="hidden">

--- a/app/views/validation.scala.html
+++ b/app/views/validation.scala.html
@@ -108,7 +108,6 @@
                         </button>
                     </div>
                     <textarea id="validation-label-comment" placeholder="@Messages("validate.bottom.ui.add.comment")" class="validation-comment-box"></textarea>
-                    <span>@Html(Messages("validate.dashboard.redirect"))</span>
                 </div>
             </div>
             <div id="modal-comment-holder" class="hidden">

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -202,7 +202,7 @@ validate.left.ui.feedback = Feedback
 validate.bottom.ui.agree = <u>A</u>gree
 validate.bottom.ui.disagree = <u>D</u>isagree
 validate.bottom.ui.not.sure = <u>N</u>ot sure
-validate.bottom.ui.add.comment = Add comment here...
+validate.bottom.ui.add.comment = If you disagree, please enter your reasoning here, which can be seen by the labeler in their dashboard
 validate.right.ui.current.mission = Current Mission
 validate.right.ui.correct.examples = <strong>Correct</strong> Examples
 validate.right.ui.incorrect.examples = <strong>Incorrect</strong> Examples
@@ -211,7 +211,6 @@ validate.mission.complete.agree = Agree
 validate.mission.complete.disagree = Disagree
 validate.mission.complete.not.sure = Not Sure
 validate.mission.complete.your.overall.total = Your Overall Total
-validate.dashboard.redirect = Comments from validations can be viewed on the <a href = "/dashboard">dashboard</a>
 
 
 mobile.validate.leave.feedback = Leave Feedback

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -211,6 +211,7 @@ validate.mission.complete.agree = Agree
 validate.mission.complete.disagree = Disagree
 validate.mission.complete.not.sure = Not Sure
 validate.mission.complete.your.overall.total = Your Overall Total
+validate.dashboard.redirect = Comments from validations can be viewed on the <a href = "/dashboard">dashboard</a>
 
 
 mobile.validate.leave.feedback = Leave Feedback

--- a/conf/messages.es
+++ b/conf/messages.es
@@ -212,7 +212,6 @@ validate.mission.complete.disagree = No Estoy de acuerdo
 validate.mission.complete.not.sure = No Estoy de seguro
 validate.mission.complete.your.overall.total = Su total en general
 
-
 mobile.validate.leave.feedback = Retroalimentación
 
 turk.expired.navbar = SE ACABÓ EL TIEMPO

--- a/conf/messages.es
+++ b/conf/messages.es
@@ -211,8 +211,9 @@ validate.mission.complete.agree = De Acuerdo
 validate.mission.complete.disagree = No Estoy de acuerdo
 validate.mission.complete.not.sure = No Estoy de seguro
 validate.mission.complete.your.overall.total = Su total en general
+validate.dashboard.redirect = Los comentarios de las validaciones se pueden ver en el <a href = "/dashboard">tablero</a>
 
-mobile.validate.leave.feedback = Retroalimentación
+        mobile.validate.leave.feedback = Retroalimentación
 
 turk.expired.navbar = SE ACABÓ EL TIEMPO
 turk.expired.title = ¡Se acabó el tiempo!

--- a/conf/messages.es
+++ b/conf/messages.es
@@ -202,7 +202,7 @@ validate.left.ui.feedback = <span style="overflow-wrap: break-word;">Retroalimen
 validate.bottom.ui.agree = De <u>a</u>cuerdo
 validate.bottom.ui.disagree = No estoy <u>d</u>e acuerdo
 validate.bottom.ui.not.sure = <u>N</u>o estoy de seguro
-validate.bottom.ui.add.comment = Agrega un comentario aquí...
+validate.bottom.ui.add.comment = Si no está de acuerdo, ingrese su razonamiento aquí, que puede ser visto por el etiquetador en su tablero
 validate.right.ui.current.mission = Misión actual
 validate.right.ui.correct.examples = Ejemplo <strong>Correcto</strong>
 validate.right.ui.incorrect.examples = Ejemplo <strong>Incorrecto</strong>
@@ -211,7 +211,6 @@ validate.mission.complete.agree = De Acuerdo
 validate.mission.complete.disagree = No Estoy de acuerdo
 validate.mission.complete.not.sure = No Estoy de seguro
 validate.mission.complete.your.overall.total = Su total en general
-validate.dashboard.redirect = Los comentarios de las validaciones se pueden ver en el <a href = "/dashboard">tablero</a>
 
 
 mobile.validate.leave.feedback = Retroalimentación

--- a/conf/messages.es
+++ b/conf/messages.es
@@ -213,7 +213,8 @@ validate.mission.complete.not.sure = No Estoy de seguro
 validate.mission.complete.your.overall.total = Su total en general
 validate.dashboard.redirect = Los comentarios de las validaciones se pueden ver en el <a href = "/dashboard">tablero</a>
 
-        mobile.validate.leave.feedback = Retroalimentación
+
+mobile.validate.leave.feedback = Retroalimentación
 
 turk.expired.navbar = SE ACABÓ EL TIEMPO
 turk.expired.title = ¡Se acabó el tiempo!

--- a/conf/messages.nl
+++ b/conf/messages.nl
@@ -210,6 +210,7 @@ validate.mission.complete.agree = Eens
 validate.mission.complete.disagree = Oneens
 validate.mission.complete.not.sure = Niet Zeker
 validate.mission.complete.your.overall.total = Je Totaal
+validate.dashboard.redirect = Opmerkingen van validaties kunnen worden bekeken op <a href = "/dashboard">het dashboard worden bekeken</a>
 
 
 mobile.validate.leave.feedback = Geef feedback

--- a/conf/messages.nl
+++ b/conf/messages.nl
@@ -201,7 +201,7 @@ validate.left.ui.feedback = Feedback
 validate.bottom.ui.agree = Eens (<u>a</u>)
 validate.bottom.ui.disagree = Oneens (<u>d</u>)
 validate.bottom.ui.not.sure = <u>N</u>iet zeker
-validate.bottom.ui.add.comment = Voeg opmerking hier toe...
+validate.bottom.ui.add.comment = Als u het er niet mee eens bent, voer dan hier uw redenering in, die kan worden gezien door de labeler in hun dashboard
 validate.right.ui.current.mission = Huidige Missie
 validate.right.ui.correct.examples = <strong>Correcte</strong> Voorbeelden
 validate.right.ui.incorrect.examples = <strong>Incorrecte</strong> Voorbeelden
@@ -210,7 +210,6 @@ validate.mission.complete.agree = Eens
 validate.mission.complete.disagree = Oneens
 validate.mission.complete.not.sure = Niet Zeker
 validate.mission.complete.your.overall.total = Je Totaal
-validate.dashboard.redirect = Opmerkingen van validaties kunnen worden bekeken op <a href = "/dashboard">het dashboard worden bekeken</a>
 
 
 mobile.validate.leave.feedback = Geef feedback

--- a/conf/messages.zh
+++ b/conf/messages.zh
@@ -211,6 +211,7 @@ validate.mission.complete.agree = 同意
 validate.mission.complete.disagree = 不同意
 validate.mission.complete.not.sure = 不確定
 validate.mission.complete.your.overall.total = 您的總成績
+validate.dashboard.redirect = 來自驗證的評論可以在<a href = "/dashboard">儀表板</a>
 
 
 mobile.validate.leave.feedback = 請給予意見回饋

--- a/conf/messages.zh
+++ b/conf/messages.zh
@@ -202,7 +202,7 @@ validate.left.ui.feedback = 回饋
 validate.bottom.ui.agree = <u>A</u>同意
 validate.bottom.ui.disagree = <u>D</u>不同意
 validate.bottom.ui.not.sure = <u>N</u>不確定
-validate.bottom.ui.add.comment = 於此輸入說明...
+validate.bottom.ui.add.comment = 如果您不同意，請在此處輸入您的理由，貼標者可以在他們的儀表板中看到
 validate.right.ui.current.mission = 目前任務
 validate.right.ui.correct.examples = <strong>正確</strong> 例子
 validate.right.ui.incorrect.examples = <strong>錯誤</strong> 例子
@@ -211,7 +211,6 @@ validate.mission.complete.agree = 同意
 validate.mission.complete.disagree = 不同意
 validate.mission.complete.not.sure = 不確定
 validate.mission.complete.your.overall.total = 您的總成績
-validate.dashboard.redirect = 來自驗證的評論可以在<a href = "/dashboard">儀表板</a>
 
 
 mobile.validate.leave.feedback = 請給予意見回饋

--- a/public/javascripts/SVValidate/src/panorama/Panorama.js
+++ b/public/javascripts/SVValidate/src/panorama/Panorama.js
@@ -189,12 +189,20 @@ function Panorama (label) {
                 function (data, status) {
                     if (status === google.maps.StreetViewStatus.OK) {
                         document.getElementById("svv-panorama-date").innerText = moment(data.imageDate).format('MMM YYYY');
-                        // Remove Keyboard shortcuts link and make Terms of Use & Report a problem links  clickable.
+                        // Remove Keyboard shortcuts link and make Terms of Use & Report a problem links clickable.
                         // https://github.com/ProjectSidewalk/SidewalkWebpage/issues/2546
+                        // Uses setTimeout because it usually hasn't quite loaded yet.
                         if (!bottomLinksClickable) {
-                            $('.gm-style-cc')[0].remove();
-                            $("#view-control-layer").append($($('.gm-style-cc')[0]).parent().parent());
-                            bottomLinksClickable = true;
+                            setTimeout(function() {
+                                try {
+                                    $('.gm-style-cc')[0].remove();
+                                    $("#view-control-layer").append($($('.gm-style-cc')[0]).parent().parent());
+                                    bottomLinksClickable = true;
+                                } catch (e) {
+                                    bottomLinksClickable = false;
+                                }
+                            }, 100);
+
                         } 
                     } else {
                         console.error("Error retrieving Panoramas: " + status);


### PR DESCRIPTION
Resolves #3096 

Added text in the comment box on the validation page as a nudge to include reasoning when selecting disagree.

##### Before/After screenshots (if applicable)

Before:
![3096_before](https://user-images.githubusercontent.com/56641275/227379167-faa1c9f2-d5e5-42fc-90c5-53d1199a9e84.png)
After:
<img width="1019" alt="Screenshot 2023-03-24 at 11 07 46 AM" src="https://user-images.githubusercontent.com/56641275/227605814-9470ead6-1a38-4aa7-8d4c-64cd4b8579be.png">

All text fits within textbox except for Dutch as shown:
<img width="1071" alt="Screenshot 2023-03-24 at 11 11 45 AM" src="https://user-images.githubusercontent.com/56641275/227606917-19a9842a-6287-40dd-8ab7-8f936d38df82.png">

##### Testing instructions
1. Go to validation page and check the textbook

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [X] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [X] I've added/updated comments for large or confusing blocks of code.
- [X] I've included before/after screenshots above.
- [X] I've asked for and included translations for any user facing text that was added or modified.
