### PR TITLE
Adds configs for Cuenca, Ecuador server

### DIFF
--- a/conf/cityparams.conf
+++ b/conf/cityparams.conf
@@ -714,17 +714,17 @@ city-params {
       washington-dc = 38.920
       seattle-wa = 47.618
       columbus-oh = 39.960
-      cdmx = 19.491
+      cdmx = ${city-params.api-demos.attribute-center-lat.cdmx}
       spgg = 25.660
-      pittsburgh-pa = 40.446
+      pittsburgh-pa = ${city-params.api-demos.attribute-center-lat.pittsburgh-pa}
       chicago-il = 42.085
       amsterdam = 52.355
-      la-piedad = 20.345
-      oradell-nj = 40.947
-      validation-study = 41.575
-      zurich = 47.376
-      taipei = 25.023
-      auckland = -36.908
+      la-piedad = ${city-params.api-demos.attribute-center-lat.la-piedad}
+      oradell-nj = ${city-params.api-demos.attribute-center-lat.oradell-nj}
+      validation-study = ${city-params.api-demos.attribute-center-lat.validation-study}
+      zurich = ${city-params.api-demos.attribute-center-lat.zurich}
+      taipei = ${city-params.api-demos.attribute-center-lat.taipei}
+      auckland = ${city-params.api-demos.attribute-center-lat.auckland}
       cuenca = ${city-params.api-demos.attribute-center-lat.cuenca}
     }
     street-center-lng {
@@ -732,17 +732,17 @@ city-params {
       washington-dc = -77.019
       seattle-wa = -122.299
       columbus-oh = -82.992
-      cdmx = -99.185
+      cdmx = ${city-params.api-demos.attribute-center-lng.cdmx}
       spgg = -100.409
-      pittsburgh-pa = -79.959
+      pittsburgh-pa = ${city-params.api-demos.attribute-center-lng.pittsburgh-pa}
       chicago-il = -87.985
       amsterdam = 4.795
-      la-piedad = -102.036
-      oradell-nj = -74.041
-      validation-study = -87.865
-      zurich = 8.544
-      taipei = 121.534
-      auckland = 174.671
+      la-piedad = ${city-params.api-demos.attribute-center-lng.la-piedad}
+      oradell-nj = ${city-params.api-demos.attribute-center-lng.oradell-nj}
+      validation-study = ${city-params.api-demos.attribute-center-lng.validation-study}
+      zurich = ${city-params.api-demos.attribute-center-lng.zurich}
+      taipei = ${city-params.api-demos.attribute-center-lng.taipei}
+      auckland = ${city-params.api-demos.attribute-center-lng.auckland}
       cuenca = ${city-params.api-demos.attribute-center-lng.cuenca}
     }
     street-zoom {
@@ -750,17 +750,17 @@ city-params {
       washington-dc = 14.0
       seattle-wa = 16.0
       columbus-oh = 15.0
-      cdmx = 16.25
+      cdmx = ${city-params.api-demos.attribute-zoom.cdmx}
       spgg = 16.0
-      pittsburgh-pa = 15.25
+      pittsburgh-pa = ${city-params.api-demos.attribute-zoom.pittsburgh-pa}
       chicago-il = 15.25
       amsterdam = 15.25
-      la-piedad = 16.0
-      oradell-nj = 16.0
-      validation-study = 13.0
-      zurich = 16.5
-      taipei = 16.0
-      auckland = 15.5
+      la-piedad = ${city-params.api-demos.attribute-zoom.la-piedad}
+      oradell-nj = ${city-params.api-demos.attribute-zoom.oradell-nj}
+      validation-study = ${city-params.api-demos.attribute-zoom.validation-study}
+      zurich = ${city-params.api-demos.attribute-zoom.zurich}
+      taipei = ${city-params.api-demos.attribute-zoom.taipei}
+      auckland = ${city-params.api-demos.attribute-zoom.auckland}
       cuenca = ${city-params.api-demos.attribute-zoom.cuenca}
     }
     street-lat1 {
@@ -768,17 +768,17 @@ city-params {
       washington-dc = 38.910
       seattle-wa = 47.611
       columbus-oh = 39.950
-      cdmx = 19.487
+      cdmx = ${city-params.api-demos.attribute-lat1.cdmx}
       spgg = 25.650
-      pittsburgh-pa = 40.443
+      pittsburgh-pa = ${city-params.api-demos.attribute-lat1.pittsburgh-pa}
       chicago-il = 42.076
       amsterdam = 52.300
-      la-piedad = 20.343
-      oradell-nj = 40.946
-      validation-study = 41.560
-      zurich = 47.375
-      taipei = 25.020
-      auckland = -36.910
+      la-piedad = ${city-params.api-demos.attribute-lat1.la-piedad}
+      oradell-nj = ${city-params.api-demos.attribute-lat1.oradell-nj}
+      validation-study = ${city-params.api-demos.attribute-lat1.validation-study}
+      zurich = ${city-params.api-demos.attribute-lat1.zurich}
+      taipei = ${city-params.api-demos.attribute-lat1.taipei}
+      auckland = ${city-params.api-demos.attribute-lat1.auckland}
       cuenca = ${city-params.api-demos.attribute-lat1.cuenca}
     }
     street-lng1 {
@@ -786,17 +786,17 @@ city-params {
       washington-dc = -77.028
       seattle-wa = -122.309
       columbus-oh = -82.982
-      cdmx = -99.190
+      cdmx = ${city-params.api-demos.attribute-lng1.cdmx}
       spgg = -100.419
-      pittsburgh-pa = -79.963
+      pittsburgh-pa = ${city-params.api-demos.attribute-lng1.pittsburgh-pa}
       chicago-il = -87.993
       amsterdam = 4.600
-      la-piedad = -102.034
-      oradell-nj = -74.044
-      validation-study = -87.885
-      zurich = 8.543
-      taipei = 121.531
-      auckland = 174.668
+      la-piedad = ${city-params.api-demos.attribute-lng1.la-piedad}
+      oradell-nj = ${city-params.api-demos.attribute-lng1.oradell-nj}
+      validation-study = ${city-params.api-demos.attribute-lng1.validation-study}
+      zurich = ${city-params.api-demos.attribute-lng1.zurich}
+      taipei = ${city-params.api-demos.attribute-lng1.taipei}
+      auckland = ${city-params.api-demos.attribute-lng1.auckland}
       cuenca = ${city-params.api-demos.attribute-lng1.cuenca}
     }
     street-lat2 {
@@ -804,17 +804,17 @@ city-params {
       washington-dc = 38.929
       seattle-wa = 47.625
       columbus-oh = 39.970
-      cdmx = 19.495
+      cdmx = ${city-params.api-demos.attribute-lat2.cdmx}
       spgg = 25.670
-      pittsburgh-pa = 40.449
+      pittsburgh-pa = ${city-params.api-demos.attribute-lat2.pittsburgh-pa}
       chicago-il = 42.094
       amsterdam = 52.400
-      la-piedad = 20.347
-      oradell-nj = 40.948
-      validation-study = 41.590
-      zurich = 47.377
-      taipei = 25.026
-      auckland = -36.908
+      la-piedad = ${city-params.api-demos.attribute-lat2.la-piedad}
+      oradell-nj = ${city-params.api-demos.attribute-lat2.oradell-nj}
+      validation-study = ${city-params.api-demos.attribute-lat2.validation-study}
+      zurich = ${city-params.api-demos.attribute-lat2.zurich}
+      taipei = ${city-params.api-demos.attribute-lat2.taipei}
+      auckland = ${city-params.api-demos.attribute-lat2.auckland}
       cuenca = ${city-params.api-demos.attribute-lat2.cuenca}
     }
     street-lng2 {
@@ -822,17 +822,17 @@ city-params {
       washington-dc = -77.009
       seattle-wa = -122.289
       columbus-oh = -83.002
-      cdmx = -99.180
+      cdmx = ${city-params.api-demos.attribute-lng2.cdmx}
       spgg = -100.399
-      pittsburgh-pa = -79.955
+      pittsburgh-pa = ${city-params.api-demos.attribute-lng2.pittsburgh-pa}
       chicago-il = -87.963
       amsterdam = 4.850
-      la-piedad = -102.038
-      oradell-nj = -74.038
-      validation-study = -87.847
-      zurich = 8.545
-      taipei = 121.537
-      auckland = 174.674
+      la-piedad = ${city-params.api-demos.attribute-lng2.la-piedad}
+      oradell-nj = ${city-params.api-demos.attribute-lng2.oradell-nj}
+      validation-study = ${city-params.api-demos.attribute-lng2.validation-study}
+      zurich = ${city-params.api-demos.attribute-lng2.zurich}
+      taipei = ${city-params.api-demos.attribute-lng2.taipei}
+      auckland = ${city-params.api-demos.attribute-lng2.auckland}
       cuenca = ${city-params.api-demos.attribute-lng2.cuenca}
     }
     region-center-lat {

--- a/conf/cityparams.conf
+++ b/conf/cityparams.conf
@@ -184,7 +184,7 @@ city-params {
     cuenca = -4
   }
   excluded-tags {
-    newberg-or = [
+    united-states-default = [
       "tactile warning"
       "garage entrance"
       "street vendor"
@@ -194,37 +194,7 @@ city-params {
       "APS"
       "missing crosswalk"
     ]
-    washington-dc = [
-      "tactile warning"
-      "garage entrance"
-      "street vendor"
-      "no pedestrian priority"
-      "uncovered manhole"
-      "level with sidewalk"
-      "APS"
-      "missing crosswalk"
-    ]
-    seattle-wa = [
-      "tactile warning"
-      "garage entrance"
-      "street vendor"
-      "no pedestrian priority"
-      "uncovered manhole"
-      "level with sidewalk"
-      "APS"
-      "missing crosswalk"
-    ]
-    columbus-oh = [
-      "tactile warning"
-      "garage entrance"
-      "street vendor"
-      "no pedestrian priority"
-      "uncovered manhole"
-      "level with sidewalk"
-      "APS"
-      "missing crosswalk"
-    ]
-    cdmx = [
+    mexico-default = [
       "tactile warning"
       "fire hydrant"
       "parked bike"
@@ -234,36 +204,14 @@ city-params {
       "APS"
       "missing crosswalk"
     ]
-    spgg = [
-      "tactile warning"
-      "fire hydrant"
-      "parked bike"
-      "construction"
-      "no pedestrian priority"
-      "level with sidewalk"
-      "APS"
-      "missing crosswalk"
-    ]
-    pittsburgh-pa = [
-      "tactile warning"
-      "garage entrance"
-      "street vendor"
-      "no pedestrian priority"
-      "uncovered manhole"
-      "level with sidewalk"
-      "APS"
-      "missing crosswalk"
-    ]
-    chicago-il = [
-      "tactile warning"
-      "garage entrance"
-      "street vendor"
-      "no pedestrian priority"
-      "uncovered manhole"
-      "level with sidewalk"
-      "APS"
-      "missing crosswalk"
-    ]
+    newberg-or = ${city-params.excluded-tags.united-states-default}
+    washington-dc = ${city-params.excluded-tags.united-states-default}
+    seattle-wa = ${city-params.excluded-tags.united-states-default}
+    columbus-oh = ${city-params.excluded-tags.united-states-default}
+    cdmx = ${city-params.excluded-tags.mexico-default}
+    spgg = ${city-params.excluded-tags.mexico-default}
+    pittsburgh-pa = ${city-params.excluded-tags.united-states-default}
+    chicago-il = ${city-params.excluded-tags.united-states-default}
     amsterdam = [
       "garage entrance"
       "street vendor"
@@ -274,26 +222,8 @@ city-params {
       "APS"
       "missing crosswalk"
     ]
-    la-piedad = [
-      "tactile warning"
-      "fire hydrant"
-      "parked bike"
-      "construction"
-      "no pedestrian priority"
-      "level with sidewalk"
-      "APS"
-      "missing crosswalk"
-    ]
-    oradell-nj = [
-      "tactile warning"
-      "garage entrance"
-      "street vendor"
-      "no pedestrian priority"
-      "uncovered manhole"
-      "level with sidewalk"
-      "APS"
-      "missing crosswalk"
-    ]
+    la-piedad = ${city-params.excluded-tags.mexico-default}
+    oradell-nj = ${city-params.excluded-tags.united-states-default}
     validation-study = [
       "tactile warning"
       "garage entrance"
@@ -329,16 +259,7 @@ city-params {
       "APS"
       "missing crosswalk"
     ]
-    cuenca = [
-      "tactile warning"
-      "fire hydrant"
-      "parked bike"
-      "construction"
-      "no pedestrian priority"
-      "level with sidewalk"
-      "APS"
-      "missing crosswalk"
-    ]
+    cuenca = ${city-params.excluded-tags.mexico-default}
   }
   landing-page-url {
     prod {
@@ -450,7 +371,7 @@ city-params {
     amsterdam = 52.345
     la-piedad = 20.345
     oradell-nj = 40.955
-    validation-study = 47.615
+    validation-study = ${city-params.city-center-lat.seattle-wa}
     zurich = 47.373
     taipei = 25.036
     auckland = -36.958
@@ -468,7 +389,7 @@ city-params {
     amsterdam = 4.925
     la-piedad = -102.036
     oradell-nj = -74.030
-    validation-study = -122.332
+    validation-study = ${city-params.city-center-lng.seattle-wa}
     zurich = 8.542
     taipei = 121.536
     auckland = 174.765458
@@ -486,7 +407,7 @@ city-params {
     amsterdam = 52.055
     la-piedad = 20.240
     oradell-nj = 40.155
-    validation-study = 40.750
+    validation-study = ${city-params.southwest-boundary-lat.chicago-il}
     zurich = 47.297
     taipei = 21.684
     auckland = -37.870572
@@ -504,7 +425,7 @@ city-params {
     amsterdam = 4.425
     la-piedad = -102.335
     oradell-nj = -74.230
-    validation-study = -122.664
+    validation-study = ${city-params.southwest-boundary-lng.seattle-wa}
     zurich = 8.427
     taipei = 119.947
     auckland = 173.765458
@@ -522,7 +443,7 @@ city-params {
     amsterdam = 52.655
     la-piedad = 20.440
     oradell-nj = 41.755
-    validation-study = 47.850
+    validation-study = ${city-params.northeast-boundary-lat.seattle-wa}
     zurich = 47.457
     taipei = 25.306
     auckland = -35.870572
@@ -540,7 +461,7 @@ city-params {
     amsterdam = 5.425
     la-piedad = -101.735
     oradell-nj = -73.830
-    validation-study = -86.500
+    validation-study = ${city-params.northeast-boundary-lng.chicago-il}
     zurich = 8.639
     taipei = 122.282
     auckland = 175.765458

--- a/conf/cityparams.conf
+++ b/conf/cityparams.conf
@@ -19,6 +19,7 @@ city-params {
     "zurich"
     "taipei"
     "auckland"
+    "cuenca"
   ]
   city-name {
     newberg-or = "Newberg"
@@ -36,6 +37,7 @@ city-params {
     zurich = "Zürich"
     taipei = "Taipei"
     auckland = "Auckland"
+    cuenca = "Cuenca"
   }
   state-name {
     newberg-or = "Oregon"
@@ -53,6 +55,7 @@ city-params {
     zurich = "Switzerland"
     taipei = "Taiwan"
     auckland = "New Zealand"
+    cuenca = "Ecuador"
   }
   state-abbreviation {
     newberg-or = "OR"
@@ -70,6 +73,7 @@ city-params {
     zurich = "CH"
     taipei = "TW"
     auckland = "NZ"
+    cuenca = "EC"
   }
   city-short-name {
     newberg-or = "Newberg"
@@ -87,6 +91,7 @@ city-params {
     zurich = "Zürich"
     taipei = "Taipei"
     auckland = "Auckland"
+    cuenca = "Cuenca"
   }
   open-status {
     newberg-or = "fully"
@@ -104,6 +109,7 @@ city-params {
     zurich = "partially"
     taipei = "partially"
     auckland = "partially"
+    cuenca = "partially"
   }
   status {
     newberg-or = "public"
@@ -121,6 +127,7 @@ city-params {
     zurich = "private"
     taipei = "private"
     auckland = "private"
+    cuenca = "private"
   }
   skyline-img = {
     newberg-or = "skyline1.png"
@@ -138,6 +145,7 @@ city-params {
     zurich = "skyline1.png"
     taipei = "skyline1.png"
     auckland = "skyline1.png"
+    cuenca = "skyline1.png"
   }
   logo-img = {
     newberg-or = "sidewalk-logo.png"
@@ -155,10 +163,11 @@ city-params {
     zurich = "sidewalk-logo.png"
     taipei = "sidewalk-logo.png"
     auckland = "sidewalk-logo.png"
+    cuenca = "sidewalk-logo.png"
   }
   update-offset-hours {
     newberg-or = 4
-    washington-dc = -5
+    washington-dc = -9
     seattle-wa = 3
     columbus-oh = -2
     cdmx = 2
@@ -167,11 +176,12 @@ city-params {
     chicago-il = 1
     amsterdam = -6
     la-piedad = -3
-    oradell-nj = -4
+    oradell-nj = -5
     validation-study = -7
     zurich = -8
     taipei = 10
     auckland = 6
+    cuenca = -4
   }
   excluded-tags {
     newberg-or = [
@@ -319,6 +329,16 @@ city-params {
       "APS"
       "missing crosswalk"
     ]
+    cuenca = [
+      "tactile warning"
+      "fire hydrant"
+      "parked bike"
+      "construction"
+      "no pedestrian priority"
+      "level with sidewalk"
+      "APS"
+      "missing crosswalk"
+    ]
   }
   landing-page-url {
     prod {
@@ -337,6 +357,7 @@ city-params {
       zurich = "https://sidewalk-zurich.cs.washington.edu"
       taipei = "https://sidewalk-taipei.cs.washington.edu"
       auckland = "https://sidewalk-auckland.cs.washington.edu"
+      cuenca = "https://sidewalk-cuenca.cs.washington.edu"
     }
     test {
       newberg-or = "https://sidewalk-newberg-test.cs.washington.edu"
@@ -354,6 +375,7 @@ city-params {
       zurich = "https://sidewalk-zurich-test.cs.washington.edu"
       taipei = "https://sidewalk-taipei-test.cs.washington.edu"
       auckland = "https://sidewalk-auckland-test.cs.washington.edu"
+      cuenca = "https://sidewalk-cuenca-test.cs.washington.edu"
     }
   }
   mapathon-event-link {
@@ -375,6 +397,7 @@ city-params {
       zurich = "G-YQJ74CTZ1P"
       taipei = "G-JTBZS5RFBQ"
       auckland = "G-W07Z26D3BS"
+      cuenca = "G-8RFKJNGS5K"
     }
     test {
       newberg-or = "G-P2JPSFFN3H"
@@ -391,6 +414,7 @@ city-params {
       zurich = "G-QFM536EGLN"
       taipei = "G-H92Z46T5DG"
       auckland = "G-NVMCC4Y30W"
+      cuenca = "G-EL9FFHKQTZ"
     }
   }
   // New cities have ony GA 4. Old cities also retain the old GA tracking.
@@ -430,6 +454,7 @@ city-params {
     zurich = 47.373
     taipei = 25.036
     auckland = -36.958
+    cuenca = -2.898
   }
   city-center-lng {
     newberg-or = -122.958
@@ -447,6 +472,7 @@ city-params {
     zurich = 8.542
     taipei = 121.536
     auckland = 174.765458
+    cuenca = -79.005
   }
   southwest-boundary-lat {
     newberg-or = 45.265
@@ -464,6 +490,7 @@ city-params {
     zurich = 47.297
     taipei = 21.684
     auckland = -37.870572
+    cuenca = -3.892
   }
   southwest-boundary-lng {
     newberg-or = -123.010
@@ -481,6 +508,7 @@ city-params {
     zurich = 8.427
     taipei = 119.947
     auckland = 173.765458
+    cuenca = -80.008
   }
   northeast-boundary-lat {
     newberg-or = 45.345
@@ -498,6 +526,7 @@ city-params {
     zurich = 47.457
     taipei = 25.306
     auckland = -35.870572
+    cuenca = -1.892
   }
   northeast-boundary-lng {
     newberg-or = -122.900
@@ -515,6 +544,7 @@ city-params {
     zurich = 8.639
     taipei = 122.282
     auckland = 175.765458
+    cuenca = -78.008
   }
   tutorial-street-edge-id {
     newberg-or = 1692
@@ -532,6 +562,7 @@ city-params {
     zurich = 11242
     taipei = 26434
     auckland = 76949
+    cuenca = 15431
   }
   default-map-zoom {
     newberg-or = 13.75
@@ -549,6 +580,7 @@ city-params {
     zurich = 15.0
     taipei = 14.25
     auckland = 12.0
+    cuenca = 15.75
   }
   api-demos {
     attribute-center-lat {
@@ -567,6 +599,7 @@ city-params {
       zurich = 47.376
       taipei = 25.023
       auckland = -36.908
+      cuenca = -2.900
     }
     attribute-center-lng {
       newberg-or = -122.975
@@ -584,6 +617,7 @@ city-params {
       zurich = 8.544
       taipei = 121.534
       auckland = 174.671
+      cuenca = -79.005
     }
     attribute-zoom {
       newberg-or = 16.0
@@ -601,6 +635,7 @@ city-params {
       zurich = 16.5
       taipei = 16.0
       auckland = 15.5
+      cuenca = 16.0
     }
     attribute-lat1 {
       newberg-or = 45.305
@@ -618,6 +653,7 @@ city-params {
       zurich = 47.375
       taipei = 25.020
       auckland = -36.910
+      cuenca = -2.902
     }
     attribute-lng1 {
       newberg-or = -123.000
@@ -635,6 +671,7 @@ city-params {
       zurich = 8.543
       taipei = 121.531
       auckland = 174.668
+      cuenca = -79.008
     }
     attribute-lat2 {
       newberg-or = 45.327
@@ -652,6 +689,7 @@ city-params {
       zurich = 47.377
       taipei = 25.026
       auckland = -36.908
+      cuenca = -2.898
     }
     attribute-lng2 {
       newberg-or = -122.960
@@ -669,6 +707,7 @@ city-params {
       zurich = 8.545
       taipei = 121.537
       auckland = 174.674
+      cuenca = -79.002
     }
     street-center-lat {
       newberg-or = 45.319
@@ -686,6 +725,7 @@ city-params {
       zurich = 47.376
       taipei = 25.023
       auckland = -36.908
+      cuenca = ${city-params.api-demos.attribute-center-lat.cuenca}
     }
     street-center-lng {
       newberg-or = -122.975
@@ -703,6 +743,7 @@ city-params {
       zurich = 8.544
       taipei = 121.534
       auckland = 174.671
+      cuenca = ${city-params.api-demos.attribute-center-lng.cuenca}
     }
     street-zoom {
       newberg-or = 14.0
@@ -720,6 +761,7 @@ city-params {
       zurich = 16.5
       taipei = 16.0
       auckland = 15.5
+      cuenca = ${city-params.api-demos.attribute-zoom.cuenca}
     }
     street-lat1 {
       newberg-or = 45.310
@@ -737,6 +779,7 @@ city-params {
       zurich = 47.375
       taipei = 25.020
       auckland = -36.910
+      cuenca = ${city-params.api-demos.attribute-lat1.cuenca}
     }
     street-lng1 {
       newberg-or = -123.000
@@ -754,6 +797,7 @@ city-params {
       zurich = 8.543
       taipei = 121.531
       auckland = 174.668
+      cuenca = ${city-params.api-demos.attribute-lng1.cuenca}
     }
     street-lat2 {
       newberg-or = 45.327
@@ -771,6 +815,7 @@ city-params {
       zurich = 47.377
       taipei = 25.026
       auckland = -36.908
+      cuenca = ${city-params.api-demos.attribute-lat2.cuenca}
     }
     street-lng2 {
       newberg-or = -122.960
@@ -788,6 +833,7 @@ city-params {
       zurich = 8.545
       taipei = 121.537
       auckland = 174.674
+      cuenca = ${city-params.api-demos.attribute-lng2.cuenca}
     }
     region-center-lat {
       newberg-or = 45.319
@@ -805,6 +851,7 @@ city-params {
       zurich = 47.3755
       taipei = 25.021
       auckland = -36.909
+      cuenca = -2.898
     }
     region-center-lng {
       newberg-or = -122.975
@@ -822,6 +869,7 @@ city-params {
       zurich = 8.543
       taipei = 121.532
       auckland = 174.666
+      cuenca = -79.005
     }
     region-zoom {
       newberg-or = 13.0
@@ -839,6 +887,7 @@ city-params {
       zurich = 14.5
       taipei = 14.5
       auckland = 13.0
+      cuenca = 14.0
     }
     region-lat1 {
       newberg-or = 45.305
@@ -856,6 +905,7 @@ city-params {
       zurich = 47.370
       taipei = 25.016
       auckland = -36.921
+      cuenca = -2.906
     }
     region-lng1 {
       newberg-or = -123.010
@@ -873,6 +923,7 @@ city-params {
       zurich = 8.540
       taipei = 119.947
       auckland = 174.655
+      cuenca = -79.012
     }
     region-lat2 {
       newberg-or = 45.345
@@ -890,6 +941,7 @@ city-params {
       zurich = 47.380
       taipei = 25.027
       auckland = -36.896
+      cuenca = -2.891
     }
     region-lng2 {
       newberg-or = -122.950
@@ -907,6 +959,7 @@ city-params {
       zurich = 8.548
       taipei = 122.282
       auckland = 174.679
+      cuenca = -78.998
     }
   }
 }


### PR DESCRIPTION
Resolves #3186 

Adds the configs for a new server in Cuenca, Ecuador! I also realized that the HOCON syntax for our config files lets us reference values in other parts of the config, so I updated it a bit to have few values copied in multiple places. In particular, it's nice that we now have a `united-states-default` and `mexico-default` list of excluded tags! :grin: 