### PR TITLE
Instructions no longer cover UI in tutorial

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/onboarding/Onboarding.js
+++ b/public/javascripts/SVLabel/src/SVLabel/onboarding/Onboarding.js
@@ -77,6 +77,14 @@ function Onboarding(svl, audioEffect, compass, form, handAnimation, mapService, 
         compass.hideMessage();
         compass.disableCompassClick();
 
+        // Make sure that the context menu covers instructions when hovering over the context menu.
+        svl.ui.contextMenu.holder.on('mouseover', function() {
+            uiOnboarding.messageHolder.css('z-index', 2);
+        });
+        svl.ui.contextMenu.holder.on('mouseout', function() {
+            uiOnboarding.messageHolder.css('z-index', 3);
+        });
+
         _visit(getState("initialize"));
         handAnimation.initializeHandAnimation();
 
@@ -303,6 +311,7 @@ function Onboarding(svl, audioEffect, compass, form, handAnimation, mapService, 
     function showMessage(parameters) {
         var message = parameters.message;
 
+        // Make the message flash yellow once to catch your attention.
         uiOnboarding.messageHolder.toggleClass("yellow-background");
         setTimeout(function () {
             uiOnboarding.messageHolder.toggleClass("yellow-background");


### PR DESCRIPTION
Fixes #3187 

Fixes an issue where the instructions in the tutorial would cover UI elements that you needed to click to progress. @jonfroehlich suggested changing the z-index of the instructions / context menu when hovering over the context menu, which worked great!

##### Before/After screenshots (if applicable)
Before
![Screenshot from 2023-03-28 12-29-01](https://user-images.githubusercontent.com/6518824/228347538-d016fd70-46e3-44b0-bb06-befa9b4812e7.png)

After
![z-index-tutorial-instruction](https://user-images.githubusercontent.com/6518824/228347555-3f48f1dd-0e35-4613-a806-59ea31715235.gif)

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
