### PR TITLE
Adds region query param for LabelMap

### DIFF
--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -9,6 +9,7 @@ import com.mohiva.play.silhouette.api.{Environment, Silhouette}
 import com.mohiva.play.silhouette.impl.authenticators.SessionAuthenticator
 import com.vividsolutions.jts.geom.Coordinate
 import controllers.headers.ProvidesHeader
+import controllers.helper.ControllerUtils.parseIntegerList
 import formats.json.LabelFormat
 import formats.json.TaskFormats._
 import formats.json.UserRoleSubmissionFormats._
@@ -19,7 +20,7 @@ import models.audit.{AuditTaskInteractionTable, AuditTaskTable, AuditedStreetWit
 import models.daos.slick.DBTableDefinitions.UserTable
 import models.gsv.{GSVDataExtended, GSVDataTable}
 import models.label.LabelTable.{LabelCVMetadata, LabelMetadata}
-import models.label.{LabelPointTable, LabelTable, LabelTypeTable, LabelValidationTable}
+import models.label.{LabelLocationWithSeverity, LabelPointTable, LabelTable, LabelTypeTable, LabelValidationTable}
 import models.mission.MissionTable
 import models.region.RegionCompletionTable
 import models.street.StreetEdgeTable
@@ -32,6 +33,7 @@ import play.api.Play
 import play.api.Play.current
 import play.api.cache.EhCachePlugin
 import play.api.i18n.Messages
+import play.extras.geojson.{LatLng, Point}
 import javax.naming.AuthenticationException
 import scala.concurrent.Future
 
@@ -107,7 +109,7 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
    */
   def getAllLabels = UserAwareAction.async { implicit request =>
     if (isAdmin(request.identity)) {
-      val labels = LabelTable.selectLocationsAndSeveritiesOfLabels
+      val labels = LabelTable.selectLocationsAndSeveritiesOfLabels(List())
       val features: List[JsObject] = labels.map { label =>
         val point = geojson.Point(geojson.LatLng(label.lat.toDouble, label.lng.toDouble))
         val properties = Json.obj(
@@ -131,11 +133,12 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
   /**
    * Get a list of all labels with metadata needed for /labelMap.
    */
-  def getAllLabelsForLabelMap = UserAwareAction.async { implicit request =>
-    val labels = LabelTable.selectLocationsAndSeveritiesOfLabels
+  def getAllLabelsForLabelMap(regions: Option[String]) = UserAwareAction.async { implicit request =>
+    val regionIds: List[Int] = regions.map(parseIntegerList).getOrElse(List())
+    val labels: List[LabelLocationWithSeverity] = LabelTable.selectLocationsAndSeveritiesOfLabels(regionIds)
     val features: List[JsObject] = labels.map { label =>
-      val point = geojson.Point(geojson.LatLng(label.lat.toDouble, label.lng.toDouble))
-      val properties = Json.obj(
+      val point: Point[LatLng] = geojson.Point(geojson.LatLng(label.lat.toDouble, label.lng.toDouble))
+      val properties: JsObject = Json.obj(
         "label_id" -> label.labelId,
         "gsv_panorama_id" -> label.gsvPanoramaId,
         "label_type" -> label.labelType,
@@ -146,7 +149,7 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
       )
       Json.obj("type" -> "Feature", "geometry" -> point, "properties" -> properties)
     }
-    val featureCollection = Json.obj("type" -> "FeatureCollection", "features" -> features)
+    val featureCollection: JsObject = Json.obj("type" -> "FeatureCollection", "features" -> features)
     Future.successful(Ok(featureCollection))
   }
 
@@ -175,10 +178,11 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
   /**
     * Get audit coverage of each neighborhood.
     */
-  def getNeighborhoodCompletionRate = UserAwareAction.async { implicit request =>
-    RegionCompletionTable.initializeRegionCompletionTable
+  def getNeighborhoodCompletionRate(regions: Option[String]) = UserAwareAction.async { implicit request =>
+    RegionCompletionTable.initializeRegionCompletionTable()
 
-    val neighborhoods = RegionCompletionTable.selectAllNamedNeighborhoodCompletions
+    val regionIds: List[Int] = regions.map(parseIntegerList).getOrElse(List())
+    val neighborhoods = RegionCompletionTable.selectAllNamedNeighborhoodCompletions(regionIds)
     val completionRates: List[JsObject] = for (neighborhood <- neighborhoods) yield {
       val completionRate: Double =
         if (neighborhood.totalDistance > 0) neighborhood.auditedDistance / neighborhood.totalDistance

--- a/app/controllers/RegionController.scala
+++ b/app/controllers/RegionController.scala
@@ -5,6 +5,7 @@ import com.mohiva.play.silhouette.api.{Environment, Silhouette}
 import com.mohiva.play.silhouette.impl.authenticators.SessionAuthenticator
 import play.api.libs.json._
 import controllers.headers.ProvidesHeader
+import controllers.helper.ControllerUtils.parseIntegerList
 import models.user.User
 import scala.concurrent.Future
 import play.api.mvc._
@@ -25,11 +26,12 @@ class RegionController @Inject() (implicit val env: Environment[User, SessionAut
   /**
     * Get list of all neighborhoods with a boolean indicating if the given user has fully audited that neighborhood.
     */
-  def listNeighborhoods = UserAwareAction.async { implicit request =>
+  def listNeighborhoods(regions: Option[String]) = UserAwareAction.async { implicit request =>
     request.identity match {
       case Some(user) =>
+        val regionIds: List[Int] = regions.map(parseIntegerList).getOrElse(List())
         val features: List[JsObject] =
-          RegionTable.getNeighborhoodsWithUserCompletionStatus(user.userId).map { case (region, userCompleted) =>
+          RegionTable.getNeighborhoodsWithUserCompletionStatus(user.userId, regionIds).map { case (region, userCompleted) =>
             val properties: JsObject = Json.obj(
               "region_id" -> region.regionId,
               "region_name" -> region.name,
@@ -40,7 +42,9 @@ class RegionController @Inject() (implicit val env: Environment[User, SessionAut
         val featureCollection: JsObject = Json.obj("type" -> "FeatureCollection", "features" -> features)
         Future.successful(Ok(featureCollection))
       case None =>
-        Future.successful(Redirect(s"/anonSignUp?url=/neighborhoods"))
+        // UTF-8 codes needed to pass a URL that contains parameters: ? is %3F, & is %26
+        val queryParams: String = regions.map(r => s"%3Fregions=$r").getOrElse("")
+        Future.successful(Redirect(s"/anonSignUp?url=/neighborhoods" + queryParams))
     }
   }
 }

--- a/app/controllers/UserProfileController.scala
+++ b/app/controllers/UserProfileController.scala
@@ -8,6 +8,7 @@ import com.mohiva.play.silhouette.api.{Environment, Silhouette}
 import com.mohiva.play.silhouette.impl.authenticators.SessionAuthenticator
 import com.vividsolutions.jts.geom.Coordinate
 import controllers.headers.ProvidesHeader
+import controllers.helper.ControllerUtils.parseIntegerList
 import formats.json.LabelFormat.labelMetadataUserDashToJson
 import models.audit.{AuditTaskTable, StreetEdgeWithAuditStatus}
 import models.user.UserOrgTable
@@ -17,7 +18,6 @@ import models.utils.CommonUtils.METERS_TO_MILES
 import play.api.libs.json.{JsObject, JsValue, Json}
 import play.extras.geojson
 import play.api.i18n.Messages
-
 import scala.concurrent.Future
 
 /**
@@ -78,8 +78,9 @@ class UserProfileController @Inject() (implicit val env: Environment[User, Sessi
   /**
    * Get the list of all streets and whether they have been audited or not, regardless of user.
    */
-  def getAllStreets(filterLowQuality: Boolean) = UserAwareAction.async { implicit request =>
-    val streets: List[StreetEdgeWithAuditStatus] = AuditTaskTable.selectStreetsWithAuditStatus(filterLowQuality)
+  def getAllStreets(filterLowQuality: Boolean, regions: Option[String]) = UserAwareAction.async { implicit request =>
+    val regionIds: List[Int] = regions.map(parseIntegerList).getOrElse(List())
+    val streets: List[StreetEdgeWithAuditStatus] = AuditTaskTable.selectStreetsWithAuditStatus(filterLowQuality, regionIds)
     val features: List[JsObject] = streets.map { edge =>
       val coordinates: Array[Coordinate] = edge.geom.getCoordinates
       val latlngs: List[geojson.LatLng] = coordinates.map(coord => geojson.LatLng(coord.y, coord.x)).toList  // Map it to an immutable list

--- a/app/controllers/helper/ControllerUtils.scala
+++ b/app/controllers/helper/ControllerUtils.scala
@@ -12,6 +12,7 @@ import org.apache.http.impl.client.DefaultHttpClient
 import org.apache.http.message.BasicNameValuePair
 import java.io.InputStream
 import java.util
+import scala.util.Try
 
 object ControllerUtils {
     implicit val context: ExecutionContext = play.api.libs.concurrent.Execution.Implicits.defaultContext
@@ -68,5 +69,9 @@ object ControllerUtils {
                 Logger.warn(e.getMessage)
                 throw e
         }
+    }
+
+    def parseIntegerList(listOfInts: String): List[Int] = {
+        listOfInts.split(",").flatMap(s => Try(s.toInt).toOption).toList.distinct
     }
 }

--- a/app/models/audit/AuditTaskTable.scala
+++ b/app/models/audit/AuditTaskTable.scala
@@ -306,9 +306,9 @@ object AuditTaskTable {
   }
 
   /**
-    * Return all street edges and whether they have been audited or not.
+    * Return all street edges and whether they have been audited or not. If provided, filter for only given regions.
     */
-  def selectStreetsWithAuditStatus(filterLowQuality: Boolean): List[StreetEdgeWithAuditStatus] = db.withSession { implicit session =>
+  def selectStreetsWithAuditStatus(filterLowQuality: Boolean, regionIds: List[Int]): List[StreetEdgeWithAuditStatus] = db.withSession { implicit session =>
     // Optionally filter out data marked as low quality.
     val _filteredTasks = if (filterLowQuality) {
       for {
@@ -326,6 +326,7 @@ object AuditTaskTable {
     // Left join list of streets with list of audited streets to record whether each street has been audited.
     val streetsWithAuditedStatus = streetEdgesWithoutDeleted
       .innerJoin(StreetEdgeRegionTable.streetEdgeRegionTable).on(_.streetEdgeId === _.streetEdgeId)
+      .filter(x => (x._2.regionId inSet regionIds) || regionIds.isEmpty)
       .leftJoin(_distinctCompleted).on(_._1.streetEdgeId === _)
       .map(s => (s._1._1.streetEdgeId, s._1._1.geom, s._1._2.regionId, s._1._1.wayType, !s._2.?.isEmpty))
 

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -935,9 +935,9 @@ object LabelTable {
   }
 
   /**
-    * Returns all the submitted labels with their severities included.
+    * Returns all the submitted labels with their severities included. If provided, filter for only given regions.
     */
-  def selectLocationsAndSeveritiesOfLabels: List[LabelLocationWithSeverity] = db.withSession { implicit session =>
+  def selectLocationsAndSeveritiesOfLabels(regionIds: List[Int]): List[LabelLocationWithSeverity] = db.withSession { implicit session =>
     val _labels = for {
       _l <- labels
       _lType <- labelTypes if _l.labelTypeId === _lType.labelTypeId
@@ -945,6 +945,8 @@ object LabelTable {
       _gsv <- gsvData if _l.gsvPanoramaId === _gsv.gsvPanoramaId
       _at <- auditTasks if _l.auditTaskId === _at.auditTaskId
       _us <- UserStatTable.userStats if _at.userId === _us.userId
+      _ser <- StreetEdgeRegionTable.streetEdgeRegionTable if _l.streetEdgeId === _ser.streetEdgeId
+      if (_ser.regionId inSet regionIds) || regionIds.isEmpty
       if _lPoint.lat.isDefined && _lPoint.lng.isDefined // Make sure they are NOT NULL so we can safely use .get later.
     } yield (_l.labelId, _l.auditTaskId, _l.gsvPanoramaId, _lType.labelType, _lPoint.lat.get, _lPoint.lng.get, _l.correct, _gsv.expired, _us.highQuality, _l.severity)
 

--- a/app/models/region/RegionCompletionTable.scala
+++ b/app/models/region/RegionCompletionTable.scala
@@ -43,12 +43,13 @@ object RegionCompletionTable {
   } yield se
 
   /**
-    * Returns a list of all neighborhoods with names.
+    * Returns a list of all neighborhoods with names. If provided, filter for only given regions.
     */
-  def selectAllNamedNeighborhoodCompletions: List[NamedRegionCompletion] = db.withSession { implicit session =>
+  def selectAllNamedNeighborhoodCompletions(regionIds: List[Int]): List[NamedRegionCompletion] = db.withSession { implicit session =>
     val namedRegionCompletions = for {
       _rc <- regionCompletions
       _r <- regionsWithoutDeleted if _rc.regionId === _r.regionId
+      if (_r.regionId inSet regionIds) || regionIds.isEmpty
     } yield (_r.regionId, _r.name, _rc.totalDistance, _rc.auditedDistance)
 
     namedRegionCompletions.list.map(x => NamedRegionCompletion.tupled(x))

--- a/app/views/labelMap.scala.html
+++ b/app/views/labelMap.scala.html
@@ -1,5 +1,5 @@
 @import models.user.User
-@(title: String, user: Option[User] = None)(implicit lang: Lang)
+@(title: String, user: Option[User] = None, regionIds: List[Int])(implicit lang: Lang)
 
 @main(title) {
     @navbar(user, Some("/labelmap"))
@@ -226,11 +226,22 @@
 
             var self = {};
             var map;
-            var loadPolygons = $.getJSON('/neighborhoods');
-            var loadPolygonRates = $.getJSON('/adminapi/neighborhoodCompletionRate');
+
+            // If a region filter was passed in, pass that along when requesting street/label data.
+            var regionsParam = '@{regionIds.mkString(",")}';
+            var loadPolygons, loadPolygonRates, loadStreets, loadSubmittedLabels;
+            if (regionsParam) {
+                loadPolygons = $.getJSON(`/neighborhoods?regions=${regionsParam}`);
+                loadPolygonRates = $.getJSON(`/adminapi/neighborhoodCompletionRate?regions=${regionsParam}`);
+                loadStreets = $.getJSON(`/contribution/streets/all?filterLowQuality=true&regions=${regionsParam}`);
+                loadSubmittedLabels = $.getJSON(`/labels/all?regions=${regionsParam}`);
+            } else {
+                loadPolygons = $.getJSON('/neighborhoods');
+                loadPolygonRates = $.getJSON('/adminapi/neighborhoodCompletionRate');
+                loadStreets = $.getJSON('/contribution/streets/all?filterLowQuality=true');
+                loadSubmittedLabels = $.getJSON('/labels/all');
+            }
             var loadMapParams = $.getJSON('/cityMapParams');
-            var loadStreets = $.getJSON('/contribution/streets/all?filterLowQuality=true');
-            var loadSubmittedLabels = $.getJSON('/labels/all');
             // When the polygons, polygon rates, and map params are all loaded the polygon regions can be rendered.
             var renderPolygons = $.when(loadPolygons, loadPolygonRates, loadMapParams).done(function(data1, data2, data3) {
                 map = Choropleth(_, $, params, [], data1[0], data2[0], data3[0]);

--- a/app/views/navbar.scala.html
+++ b/app/views/navbar.scala.html
@@ -126,7 +126,7 @@
                         <!-- Only show Label Map link if the city does not have too much data to load that page quickly. -->
                         @if(!List("seattle-wa").contains(currentCity)) {
                             <li>
-                                <a id="navbar-labelmap-btn" role="menuitem" href="@routes.ApplicationController.labelMap">@Messages("navbar.labelmap")</a>
+                                <a id="navbar-labelmap-btn" role="menuitem" href="@routes.ApplicationController.labelMap(None)">@Messages("navbar.labelmap")</a>
                             </li>
                         }
                         <li>

--- a/conf/routes
+++ b/conf/routes
@@ -11,8 +11,8 @@ GET     /developer                                           @controllers.Applic
 GET     /terms                                               @controllers.ApplicationController.terms
 GET     /demo                                                @controllers.ApplicationController.demo
 GET     /results                                             @controllers.ApplicationController.results
-GET     /labelMap                                            @controllers.ApplicationController.labelMap
-GET     /labelmap                                            @controllers.ApplicationController.labelMap
+GET     /labelMap                                            @controllers.ApplicationController.labelMap(regions: Option[String] ?= None)
+GET     /labelmap                                            @controllers.ApplicationController.labelMap(regions: Option[String] ?= None)
 GET     /gallery                                             @controllers.ApplicationController.gallery(labelType: String ?= "Assorted", severities: String ?= "", tags: String ?= "", validationOptions: String ?= "correct,unvalidated")
 GET     /help                                                @controllers.ApplicationController.help
 GET     /labelingGuide                                       @controllers.ApplicationController.labelingGuide
@@ -57,7 +57,7 @@ GET     /admin                                               @controllers.AdminC
 GET     /admin/user/:username                                @controllers.AdminController.userProfile(username: String)
 GET     /admin/task/:taskId                                  @controllers.AdminController.task(taskId: Int)
 
-GET     /adminapi/neighborhoodCompletionRate                 @controllers.AdminController.getNeighborhoodCompletionRate
+GET     /adminapi/neighborhoodCompletionRate                 @controllers.AdminController.getNeighborhoodCompletionRate(regions: Option[String] ?= None)
 GET     /adminapi/userMissionCounts                          @controllers.AdminController.getAllUserCompletedMissionCounts
 GET     /adminapi/allSignInCounts                            @controllers.AdminController.getAllUserSignInCounts
 GET     /adminapi/completionRateByDate                       @controllers.AdminController.getCompletionRateByDate
@@ -85,7 +85,7 @@ GET     /adminapi/numWebpageActivity/:activity/*keyValPairs  @controllers.AdminC
 GET     /adminapi/choroplethCounts                           @controllers.AdminController.getRegionNegativeLabelCounts
 PUT     /adminapi/setRole                                    @controllers.AdminController.setUserRole
 
-GET     /labels/all                                          @controllers.AdminController.getAllLabelsForLabelMap
+GET     /labels/all                                          @controllers.AdminController.getAllLabelsForLabelMap(regions: Option[String] ?= None)
 GET     /label/id/:labelId                                   @controllers.AdminController.getLabelData(labelId: Int)
 
 # Auditing tasks
@@ -123,12 +123,12 @@ POST    /label/labels                                        @controllers.Galler
 POST    /label/geo/random/:labelType/:labelId                @controllers.ValidationTaskController.getRandomLabelData(labelType: Int, labelId: Int)
 
 # Neighborhoods
-GET     /neighborhoods                                       @controllers.RegionController.listNeighborhoods
+GET     /neighborhoods                                       @controllers.RegionController.listNeighborhoods(regions: Option[String] ?= None)
 
 # User status
 # /:username has to come last in the list. Otherwise it eats other urls.
 GET     /contribution/streets                                @controllers.UserProfileController.getAuditedStreets
-GET     /contribution/streets/all                            @controllers.UserProfileController.getAllStreets(filterLowQuality: Boolean ?= false)
+GET     /contribution/streets/all                            @controllers.UserProfileController.getAllStreets(filterLowQuality: Boolean ?= false, regions: Option[String] ?= None)
 GET     /contribution/auditCounts/all                        @controllers.UserProfileController.getAllAuditCounts
 GET     /dashboard                                           @controllers.UserProfileController.userProfile
 GET     /userapi/mistakes                                    @controllers.UserProfileController.getRecentMistakes(n: Int ?= 5)


### PR DESCRIPTION
Resolves #3190 

Adds a query parameter to LabelMap to filter for only data in given neighborhoods (`/labelMap?regions=1,2,3`).

We had talked about centering the map on the filtered data and zooming into it, but I cut that out in the interest of time. Especially since I'm not sure how frequently we plan on using this. Plus I like having the context of the whole city!

##### Before/After screenshots (if applicable)
Before
![Screenshot from 2023-03-28 15-47-09](https://user-images.githubusercontent.com/6518824/228384017-6f5ce9d7-b579-4320-910c-4f7081d3f149.png)

After
![Screenshot from 2023-03-28 15-46-27](https://user-images.githubusercontent.com/6518824/228384026-1e9fcf50-9786-4cd8-8a3b-04252d72a5cc.png)

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
- [x] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure the documentation on [this wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Descriptions-of-Logged-Events) is up to date for the logs you added/updated.
