### PR TITLE
Fixes sv_image_x calculation

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/label/Label.js
+++ b/public/javascripts/SVLabel/src/SVLabel/label/Label.js
@@ -93,8 +93,8 @@ function Label(params) {
 
             properties.svImageWidth = panoData.tiles.worldSize.width;
             properties.svImageHeight = panoData.tiles.worldSize.height;
-            properties.svImageCoordinate = util.panomarker.calculateImageCoordinateFromPointPov(
-                properties.povOfLabelIfCentered, properties.svImageWidth, properties.svImageHeight
+            properties.svImageCoordinate = util.panomarker.calculateImageCoordinateFromPov(
+                properties.povOfLabelIfCentered, properties.photographerHeading, properties.svImageWidth, properties.svImageHeight
             );
         }
 

--- a/public/javascripts/SVLabel/src/SVLabel/onboarding/Onboarding.js
+++ b/public/javascripts/SVLabel/src/SVLabel/onboarding/Onboarding.js
@@ -797,7 +797,7 @@ function Onboarding(svl, audioEffect, compass, form, handAnimation, mapService, 
                 var canvasX = clickCoordinate.x;
                 var canvasY = clickCoordinate.y;
                 var imageCoordinate = util.panomarker.canvasCoordinateToImageCoordinate(
-                    pov, canvasX, canvasY, util.EXPLORE_CANVAS_WIDTH, util.EXPLORE_CANVAS_HEIGHT, svImgWidth, svImgHeight
+                    pov, canvasX, canvasY, util.EXPLORE_CANVAS_WIDTH, util.EXPLORE_CANVAS_HEIGHT, svl.panorama.getPhotographerPov().heading, svImgWidth, svImgHeight
                 );
                 imageCoordinate.x *= svl.TUTORIAL_PANO_SCALE_FACTOR;
                 imageCoordinate.y *= svl.TUTORIAL_PANO_SCALE_FACTOR;

--- a/public/javascripts/SVLabel/src/SVLabel/onboarding/OnboardingStates.js
+++ b/public/javascripts/SVLabel/src/SVLabel/onboarding/OnboardingStates.js
@@ -92,7 +92,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "properties": [{
                 "action": "LabelAccessibilityAttribute",
                 "labelType": "CurbRamp",
-                "imageX": 9730,
+                "imageX": 1170,
                 "imageY": -350,
                 "tolerance": 300,
                 "minHeading": headingRanges["stage-1"][0],
@@ -308,7 +308,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "properties": [{
                 "action": "LabelAccessibilityAttribute",
                 "labelType": "CurbRamp",
-                "imageX": 8180,
+                "imageX": 12932,
                 "imageY": -340,
                 "tolerance": 300,
                 "minHeading": headingRanges["stage-2"][0],
@@ -539,7 +539,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "properties": [{
                 "action": "LabelAccessibilityAttribute",
                 "labelType": "NoCurbRamp",
-                "imageX": 7800,
+                "imageX": 12552,
                 "imageY": -340,
                 "tolerance": 300,
                 "minHeading": headingRanges["stage-2"][0],
@@ -840,7 +840,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "properties": [{
                 "action": "LabelAccessibilityAttribute",
                 "labelType": "CurbRamp",
-                "imageX": 4920,
+                "imageX": 9730,
                 "imageY": -720,
                 "tolerance": 300,
                 "minHeading": headingRanges["stage-3"][0],
@@ -848,7 +848,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             },{
                 "action": "LabelAccessibilityAttribute",
                 "labelType": "CurbRamp",
-                "imageX": 3900,
+                "imageX": 8652,
                 "imageY": -840,
                 "tolerance": 300
             }],
@@ -1055,7 +1055,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "properties": [{
                 "action": "LabelAccessibilityAttribute",
                 "labelType": "CurbRamp",
-                "imageX": 3900,
+                "imageX": 8652,
                 "imageY": -840,
                 "tolerance": 300,
                 "minHeading": headingRanges["stage-3"][0],
@@ -1232,7 +1232,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "properties": [{
                 "action": "LabelAccessibilityAttribute",
                 "labelType": "CurbRamp",
-                "imageX": 4920,
+                "imageX": 9730,
                 "imageY": -720,
                 "tolerance": 300,
                 "minHeading": headingRanges["stage-3"][0],
@@ -1465,7 +1465,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "properties": [{
                 "action": "LabelAccessibilityAttribute",
                 "labelType": "NoSidewalk",
-                "imageX": 2776,
+                "imageX": 7528,
                 "imageY": -500,
                 "tolerance": 300,
                 "minHeading": headingRanges["stage-3"][0],
@@ -1735,7 +1735,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "properties": [{
                 "action": "LabelAccessibilityAttribute",
                 "labelType": "CurbRamp",
-                "imageX": 750,
+                "imageX": 5502,
                 "imageY": -670,
                 "tolerance": 250,
                 "minHeading": headingRanges["stage-4"][0],


### PR DESCRIPTION
Working towards #2485 

This PR fixes the calculation of `sv_image_x` (the x-pixel location on the GSV image) for all labels going forward. The crux of the fix is that we now incorporate the `photographer_heading` into the calculation. I haven't written a script to fix this retroactively for past labels, but that should be coming soon! As should a fix for the `sv_image_y` values.

##### Before/After screenshots (if applicable)
Here's an example image with the before/after locations that I posted in #2485 
![Screenshot from 2023-03-23 15-25-33](https://user-images.githubusercontent.com/6518824/227387648-82682e73-e6d0-4eb3-9073-b6685ebb7b35.png)

And here are the two locations that we get:
![Screenshot from 2023-03-23 15-47-25](https://user-images.githubusercontent.com/6518824/227387664-095b4b32-d2b2-4bd1-a141-1b488aae14b4.png)

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
