### PR TITLE
Fixes bug where labels moved after placing them

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/canvas/Canvas.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/Canvas.js
@@ -62,7 +62,7 @@ function Canvas(ribbon) {
      * Create a label at the given X/Y canvas coordinate.
      */
     function createLabel(canvasX, canvasY) {
-        // Generate some metadata for the new lable.
+        // Generate some metadata for the new label.
         var labelType = ribbon.getStatus('selectedLabelType');
         var pov = svl.map.getPov();
         var povOfLabel = util.panomarker.calculatePointPov(

--- a/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
+++ b/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
@@ -19,8 +19,8 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
                 lng : undefined
             },
             panoramaPov : {
-                heading : 359,
-                pitch : -10,
+                heading : 0,
+                pitch : 0,
                 zoom : 1
             },
             map: null,
@@ -89,12 +89,6 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
     // http://www.w3schools.com/googleAPI/google_maps_controls.asp
     if (params.panoramaPov) {
         properties.panoramaPov = params.panoramaPov;
-    } else {
-        properties.panoramaPov = {
-            heading: 0,
-            pitch: 0,
-            zoom: 1
-        };
     }
     if (params.latlng) {
         properties.latlng = params.latlng;
@@ -234,7 +228,6 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
         if (properties.isInternetExplore) {
             uiMap.viewControlLayer.append(`<canvas width="${util.EXPLORE_CANVAS_WIDTH}px" height="${util.EXPLORE_CANVAS_HEIGHT}px"  class="window-streetview" style=""></canvas>`);
         }
-
     }
 
     /**
@@ -1248,10 +1241,6 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
         if (('panorama' in svl) && svl.panorama) {
             var currentPov = svl.panorama.getPov();
             var interval;
-
-            pov.heading = parseInt(pov.heading, 10);
-            pov.pitch = parseInt(pov.pitch, 10);
-            pov.zoom = parseInt(pov.zoom, 10);
 
             // Pov restriction.
             restrictViewPort(pov);

--- a/public/javascripts/SVValidate/src/util/PanoProperties.js
+++ b/public/javascripts/SVValidate/src/util/PanoProperties.js
@@ -82,18 +82,18 @@ function PanoProperties () {
      *     requested.
      * @param {StreetViewPov} currentPov POV of the viewport center.
      * @param {number} zoom The current zoom level.
-     * @param {number} Width of the panorama canvas.
-     * @param {number} Height of the panorama canvas.
+     * @param {number} canvasWidth of the panorama canvas.
+     * @param {number} canvasHeight of the panorama canvas.
      * @return {Object} Top and Left offsets for the given viewport that point to
      *     the desired point-of-view.
      */
-    function povToPixel3d (targetPov, currentPov, zoom, canvasWidth, canvasHeight) {
+    function povToPixel3d(targetPov, currentPov, zoom, canvasWidth, canvasHeight) {
 
-        // Gather required variables and convert to radians where necessary
+        // Gather required variables and convert to radians where necessary.
         let width = canvasWidth;
         let height = canvasHeight;
 
-        // Corrects width and height for mobile phones
+        // Corrects width and height for mobile phones.
         if (isMobile()) {
             width = window.innerWidth;
             height = window.innerHeight;

--- a/public/javascripts/common/UtilitiesPanomarker.js
+++ b/public/javascripts/common/UtilitiesPanomarker.js
@@ -37,10 +37,6 @@ function sgn(x) {
  * @returns {{heading: number, pitch: number, zoom: Number}}
  */
 function calculatePointPov(pov, canvasX, canvasY, canvasWidth, canvasHeight) {
-    var heading = parseInt(pov.heading, 10),
-        pitch = parseInt(pov.pitch, 10),
-        zoom = parseInt(pov.zoom, 10);
-
     var PI = Math.PI;
     var cos = Math.cos;
     var sin = Math.sin;
@@ -49,10 +45,10 @@ function calculatePointPov(pov, canvasX, canvasY, canvasWidth, canvasHeight) {
     var atan2 = Math.atan2;
     var asin = Math.asin;
 
-    var fov = get3dFov(zoom) * PI / 180.0;
+    var fov = get3dFov(pov.zoom) * PI / 180.0;
 
-    var h0 = heading * PI / 180.0;
-    var p0 = pitch * PI / 180.0;
+    var h0 = pov.heading * PI / 180.0;
+    var p0 = pov.pitch * PI / 180.0;
 
     var f = 0.5 * canvasWidth / tan(0.5 * fov);
 
@@ -82,7 +78,7 @@ function calculatePointPov(pov, canvasX, canvasY, canvasWidth, canvasHeight) {
     return {
         heading: h * 180.0 / PI,
         pitch: p * 180.0 / PI,
-        zoom: zoom
+        zoom: pov.zoom
     };
 }
 util.panomarker.calculatePointPov = calculatePointPov;
@@ -98,8 +94,8 @@ util.panomarker.calculatePointPov = calculatePointPov;
  */
 function calculatePointPovFromImageCoordinate(imageX, imageY, svImageWidth, svImageHeight) {
     return {
-        heading: Math.round((imageX / svImageWidth) * 360) % 360,
-        pitch: Math.round((imageY / (svImageHeight / 2)) * 90)
+        heading: (imageX / svImageWidth) * 360 % 360,
+        pitch: (imageY / (svImageHeight / 2) * 90)
     };
 }
 util.panomarker.calculatePointPovFromImageCoordinate = calculatePointPovFromImageCoordinate;


### PR DESCRIPTION
Fixes #1764 
Further work towards #2485 

This fixes a bug that cause labels to move slightly after placing them.

The issue was that there was a function where we were rounding the heading at pitch to an integer before calculating where it should be placed. Actually worse than that: we were just truncating the number to an integer using `parseInt()`. And since we restrict the pitch between 0 and -35, we were always treating the pitch like it was higher than it actually was (-12.99 truncated to -12), which is why labels always moved upwards. This is also more pronounced at higher zoom levels because of the smaller field of view; the same change in pitch had a bigger effect.

This also propagates to the `sv_image_x/y` values that we use for CV. These are changes by less than 100 pixels for the most part, given that it's a change in pitch/heading of less than 1 degree. But those small mistakes matter a lot!

This did not have an effect on how we saw labels in Validate, Gallery, or the Admin page. Which is good... But we also saw plenty of cases on Validate where users had labeled well above the actual issue... And I don't believe that my updates address that at all.

Our team has also noted other issues with the y position in the full GSV image that has something to do with the photographer pitch, and issues when on hills. But it's possible that our results there will be more conclusive once this confounding source of error is removed!

And finally, I have not made the changes retroactively in the database yet, but we do have all the info that we need to fix these!

##### Before/After screenshots (if applicable)
Below I try to label directly in the center of the shadow X. My label gets moved up and to the left. This is because I set the heading to 325.9 and pitch to -17.9. They are truncated to 325 and 17, moving the label to the left and up.
![Screenshot from 2023-03-30 18-00-18](https://user-images.githubusercontent.com/6518824/228999005-df2b0874-0f72-469c-b373-d09ea46a42b7.png)

I then made the update to the code, and the labels are even rerendered correctly on page reload! When I try to add a label directly on top of it, it works correctly as well!
![Screenshot from 2023-03-30 18-00-46](https://user-images.githubusercontent.com/6518824/228999209-e2305144-d9af-4645-bec9-4511ae998d24.png)

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
