### PR TITLE
Fixes labels not showing on mini map

### DIFF
--- a/conf/evolutions/default/181.sql
+++ b/conf/evolutions/default/181.sql
@@ -1,0 +1,50 @@
+# --- !Ups
+-- Fix incorrect lat/lngs since last update.
+UPDATE label_point
+SET geom = ST_Project(
+    ST_SetSRID(ST_Point(gsv_data.lng, gsv_data.lat), 4326),
+    GREATEST(0.0, 20.8794248 + 0.0184087 * (gsv_data.height / 2 - pano_y) + 0.0022135 * canvas_y),
+    CASE
+        WHEN heading -27.5267447 + 0.0784357 * canvas_x < -360 THEN radians(360 + heading -27.5267447 + 0.0784357 * canvas_x)
+        WHEN heading -27.5267447 + 0.0784357 * canvas_x > 360 THEN radians(-360 + heading -27.5267447 + 0.0784357 * canvas_x)
+        ELSE radians(heading -27.5267447 + 0.0784357 * canvas_x)
+        END
+)::geometry
+FROM label
+INNER JOIN gsv_data ON label.gsv_panorama_id = gsv_data.gsv_panorama_id
+WHERE label_point.label_id = label.label_id
+    AND computation_method = 'approximation2'
+    AND time_created > (SELECT version_start_time FROM version WHERE version_id = '7.13.0');
+
+UPDATE label_point
+SET lat = ST_Y(geom),
+    lng = ST_X(geom)
+FROM label
+WHERE label_point.label_id = label.label_id
+    AND computation_method = 'approximation2'
+    AND time_created > (SELECT version_start_time FROM version WHERE version_id = '7.13.0');
+
+# --- !Downs
+UPDATE label_point
+SET geom = ST_Project(
+    ST_SetSRID(ST_Point(gsv_data.lng, gsv_data.lat), 4326),
+    GREATEST(0.0, 20.8794248 + 0.0184087 * pano_y + 0.0022135 * canvas_y),
+    CASE
+        WHEN heading -27.5267447 + 0.0784357 * canvas_x < -360 THEN radians(360 + heading -27.5267447 + 0.0784357 * canvas_x)
+        WHEN heading -27.5267447 + 0.0784357 * canvas_x > 360 THEN radians(-360 + heading -27.5267447 + 0.0784357 * canvas_x)
+        ELSE radians(heading -27.5267447 + 0.0784357 * canvas_x)
+        END
+)::geometry
+FROM label
+    INNER JOIN gsv_data ON label.gsv_panorama_id = gsv_data.gsv_panorama_id
+WHERE label_point.label_id = label.label_id
+    AND computation_method = 'approximation2'
+    AND time_created > (SELECT version_start_time FROM version WHERE version_id = '7.13.0');
+
+UPDATE label_point
+SET lat = ST_Y(geom),
+    lng = ST_X(geom)
+FROM label
+WHERE label_point.label_id = label.label_id
+    AND computation_method = 'approximation2'
+    AND time_created > (SELECT version_start_time FROM version WHERE version_id = '7.13.0');

--- a/public/javascripts/SVLabel/src/SVLabel/label/Label.js
+++ b/public/javascripts/SVLabel/src/SVLabel/label/Label.js
@@ -412,6 +412,7 @@ function Label(params) {
             var canvasX = getProperty('originalCanvasXY').x;
             var canvasY = getProperty('originalCanvasXY').y;
             var panoY = getProperty('panoXY').y;
+            var panoHeight = getProperty('panoHeight');
             // Estimate heading diff and distance from pano using output from a regression analysis.
             // https://github.com/ProjectSidewalk/label-latlng-estimation/blob/master/scripts/label-latlng-estimation.md#results
             var estHeadingDiff =
@@ -419,7 +420,7 @@ function Label(params) {
                 LATLNG_ESTIMATION_PARAMS[zoom].headingCanvasXSlope * canvasX;
             var estDistanceFromPanoKm = Math.max(0,
                 LATLNG_ESTIMATION_PARAMS[zoom].distanceIntercept +
-                LATLNG_ESTIMATION_PARAMS[zoom].distancePanoYSlope * panoY +
+                LATLNG_ESTIMATION_PARAMS[zoom].distancePanoYSlope * (panoHeight / 2 - panoY) +
                 LATLNG_ESTIMATION_PARAMS[zoom].distanceCanvasYSlope * canvasY
             ) / 1000.0;
             var estHeading = panoHeading + estHeadingDiff;


### PR DESCRIPTION
Resolves #3201 

Fixes a bug where labels weren't showing on the mini map because the lat lng estimation was broken. I broke when updating how we record the `pano_y` location for labels; I forgot that it's used when estimating lat/lngs! Easy fix, and I'm retroactively fixing labels from that past two days that were messed up using this PR.

##### Before/After screenshots (if applicable)
Before
![Screenshot from 2023-04-12 15-27-44](https://user-images.githubusercontent.com/6518824/231603942-8afd6f2b-700e-4ea3-b244-d392b4e59a59.png)

After
![Screenshot from 2023-04-12 15-27-28](https://user-images.githubusercontent.com/6518824/231603972-f6cdddce-b611-42d8-ae2a-558fc6c7d985.png)

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've included before/after screenshots above.
