### PR TITLE
Change "All" tag for Gallery to "All Label Types"

### DIFF
--- a/conf/messages.en
+++ b/conf/messages.en
@@ -332,7 +332,7 @@ gallery.show = Show
 gallery.filter.by = Filter By
 gallery.severity = Severity
 gallery.tags = Tags
-gallery.all = All
+gallery.all = All Label Types
 gallery.occlusion = Can''t See Sidewalk
 gallery.labels.not.found = No matches. <a href="/audit">Start exploring</a> to contribute more data!
 gallery.cards = Labels are sorted randomly based on selected filters


### PR DESCRIPTION
Resolves #3167 

Changed the assignment of `gallery.all = All` to `gallery.all = All Label Types`.

##### Before/After screenshots (if applicable)
Before
![image](https://user-images.githubusercontent.com/61468547/232871532-39e6cd26-00dd-4ae3-9f69-6e90720ced8a.png)

After
<img width="239" alt="image" src="https://user-images.githubusercontent.com/61468547/232871475-f47866fc-9df1-40a9-9820-53ea76d671ee.png">

##### Testing instructions
1. Visit /gallery route
2. Under "Show" at the left-hand side, it should be defaulted to "All Label Types", as shown in the After image