### PR TITLE
Fixes broken tutorial

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
+++ b/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
@@ -249,10 +249,11 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
                 tiles: {
                     tileSize: new google.maps.Size(2048, 1024),
                     worldSize: new google.maps.Size(4096, 2048),
+                    centerHeading: 50.3866,
                     originHeading: 50.3866,
                     originPitch: -1.13769,
                     getTileUrl: function(pano, zoom, tileX, tileY) {
-                        return svl.rootDirectory + "img/onboarding/tiles/tutorial/" + zoom + "-" + tileX + "-" + tileY + ".jpg";
+                        return `${svl.rootDirectory}img/onboarding/tiles/tutorial/${zoom}-${tileX}-${tileY}.jpg`;
                     }
                 }
             };
@@ -268,10 +269,11 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
                 tiles: {
                     tileSize: new google.maps.Size(1700, 850),
                     worldSize: new google.maps.Size(3400, 1700),
+                    centerHeading: 344,
                     originHeading: 344,
                     originPitch: 0,
                     getTileUrl: function(pano, zoom, tileX, tileY) {
-                        return svl.rootDirectory + "img/onboarding/tiles/afterwalktutorial/" + zoom + "-" + tileX + "-" + tileY + ".jpg";
+                        return `${svl.rootDirectory}img/onboarding/tiles/afterwalktutorial/${zoom}-${tileX}-${tileY}.jpg`;
                     }
                 }
             };

--- a/public/javascripts/SVLabel/src/SVLabel/onboarding/Onboarding.js
+++ b/public/javascripts/SVLabel/src/SVLabel/onboarding/Onboarding.js
@@ -786,6 +786,7 @@ function Onboarding(svl, audioEffect, compass, form, handAnimation, mapService, 
             var panoData = svl.panoramaContainer.getPanorama(state.panoId).data();
             var svImgWidth = panoData.tiles.worldSize.width;
             var svImgHeight = panoData.tiles.worldSize.height;
+            var cameraHeading = panoData.tiles.originHeading;
 
             while (i < properties.length && !labelAppliedCorrectly) {
                 var imageX = properties[i].imageX;
@@ -797,7 +798,7 @@ function Onboarding(svl, audioEffect, compass, form, handAnimation, mapService, 
                 var canvasX = clickCoordinate.x;
                 var canvasY = clickCoordinate.y;
                 var panoXY = util.panomarker.canvasXYToPanoXY(
-                    pov, canvasX, canvasY, util.EXPLORE_CANVAS_WIDTH, util.EXPLORE_CANVAS_HEIGHT, svl.panorama.getPhotographerPov().heading, svImgWidth, svImgHeight
+                    pov, canvasX, canvasY, util.EXPLORE_CANVAS_WIDTH, util.EXPLORE_CANVAS_HEIGHT, cameraHeading, svImgWidth, svImgHeight
                 );
                 panoXY.x *= svl.TUTORIAL_PANO_SCALE_FACTOR;
                 panoXY.y *= svl.TUTORIAL_PANO_SCALE_FACTOR;

--- a/public/javascripts/SVLabel/src/SVLabel/onboarding/OnboardingStates.js
+++ b/public/javascripts/SVLabel/src/SVLabel/onboarding/OnboardingStates.js
@@ -93,7 +93,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
                 "action": "LabelAccessibilityAttribute",
                 "labelType": "CurbRamp",
                 "imageX": 1170,
-                "imageY": -350,
+                "imageY": 3800,
                 "tolerance": 300,
                 "minHeading": headingRanges["stage-1"][0],
                 "maxHeading": headingRanges["stage-1"][1]
@@ -308,8 +308,8 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "properties": [{
                 "action": "LabelAccessibilityAttribute",
                 "labelType": "CurbRamp",
-                "imageX": 12932,
-                "imageY": -340,
+                "imageX": 12950,
+                "imageY": 3720,
                 "tolerance": 300,
                 "minHeading": headingRanges["stage-2"][0],
                 "maxHeading": headingRanges["stage-2"][1]
@@ -539,8 +539,8 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "properties": [{
                 "action": "LabelAccessibilityAttribute",
                 "labelType": "NoCurbRamp",
-                "imageX": 12552,
-                "imageY": -340,
+                "imageX": 12560,
+                "imageY": 3720,
                 "tolerance": 300,
                 "minHeading": headingRanges["stage-2"][0],
                 "maxHeading": headingRanges["stage-2"][1]
@@ -841,15 +841,15 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
                 "action": "LabelAccessibilityAttribute",
                 "labelType": "CurbRamp",
                 "imageX": 9730,
-                "imageY": -720,
+                "imageY": 4150,
                 "tolerance": 300,
                 "minHeading": headingRanges["stage-3"][0],
                 "maxHeading": headingRanges["stage-3"][1]
             },{
                 "action": "LabelAccessibilityAttribute",
                 "labelType": "CurbRamp",
-                "imageX": 8652,
-                "imageY": -840,
+                "imageX": 8660,
+                "imageY": 4250,
                 "tolerance": 300
             }],
             "message": {
@@ -1055,8 +1055,8 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "properties": [{
                 "action": "LabelAccessibilityAttribute",
                 "labelType": "CurbRamp",
-                "imageX": 8652,
-                "imageY": -840,
+                "imageX": 8660,
+                "imageY": 4250,
                 "tolerance": 300,
                 "minHeading": headingRanges["stage-3"][0],
                 "maxHeading": headingRanges["stage-3"][1]
@@ -1233,7 +1233,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
                 "action": "LabelAccessibilityAttribute",
                 "labelType": "CurbRamp",
                 "imageX": 9730,
-                "imageY": -720,
+                "imageY": 4150,
                 "tolerance": 300,
                 "minHeading": headingRanges["stage-3"][0],
                 "maxHeading": headingRanges["stage-3"][1]
@@ -1465,8 +1465,8 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "properties": [{
                 "action": "LabelAccessibilityAttribute",
                 "labelType": "NoSidewalk",
-                "imageX": 7528,
-                "imageY": -500,
+                "imageX": 7550,
+                "imageY": 3900,
                 "tolerance": 300,
                 "minHeading": headingRanges["stage-3"][0],
                 "maxHeading": headingRanges["stage-3"][1]
@@ -1735,8 +1735,8 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "properties": [{
                 "action": "LabelAccessibilityAttribute",
                 "labelType": "CurbRamp",
-                "imageX": 5502,
-                "imageY": -670,
+                "imageX": 5550,
+                "imageY": 4080,
                 "tolerance": 250,
                 "minHeading": headingRanges["stage-4"][0],
                 "maxHeading": headingRanges["stage-4"][1]


### PR DESCRIPTION
Fixes #3208

Fixes the tutorial where annotations were in the wrong place, and placing labels correctly didn't move you forward!

When I updated the `pano_y` values to range from 0 to `pano_height` (instead of `-pano_height/2` to 0), I forgot to update that in the tutorial since all of that is hard-coded! Big apologies on my part, I really should be testing the tutorial before every push to prod :pray: 

Before
![Screenshot from 2023-04-18 17-02-32](https://user-images.githubusercontent.com/6518824/232930204-0e4434e1-cb1d-4f73-ad74-ca61e0f101b2.png)

After
![Screenshot from 2023-04-18 17-02-06](https://user-images.githubusercontent.com/6518824/232930216-48635cd4-5682-4f89-9429-f1aec5a17773.png)


##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've included before/after screenshots above.
