### PR TITLE
Adds do and dont slides to service hours instructions

### DIFF
--- a/app/views/serviceHoursInstructions.scala.html
+++ b/app/views/serviceHoursInstructions.scala.html
@@ -28,6 +28,12 @@
                         that we are able to keep track of how long you've worked on the site.
                     </li>
                     <li>
+                        Please take a few minutes to carefully read through
+                        <a href="https://docs.google.com/presentation/d/1uO5jECSbULaC_nfX3Z5_WCIlrOv8dxATp0naabFLFog">this slide deck</a>,
+                        which shows some of the most common mistakes that are made when using Project Sidewalk. Please
+                        read carefully, it will save us both time in the long run!
+                    </li>
+                    <li>
                         When you're ready to work, click on the "Start Exploring" button above and work for one hour.
                     </li>
                     <li>


### PR DESCRIPTION
Resolves #3215 

Adds a link to a training DOs and DONTs slide deck to the instructions for new volunteers who are earning service hours.

##### Before/After screenshots (if applicable)
Before
![Screenshot from 2023-04-26 09-50-41](https://user-images.githubusercontent.com/6518824/234647049-9757bce3-0230-4a24-8a53-3f03d11dc2d7.png)

After
![Screenshot from 2023-04-26 09-50-21](https://user-images.githubusercontent.com/6518824/234647068-e52915c2-7b0c-4ec4-8cfc-bbb5a03324ce.png)

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've included before/after screenshots above.
