### PR TITLE
Fixes a bug where labels had the wrong tags

### DIFF
--- a/app/controllers/TaskController.scala
+++ b/app/controllers/TaskController.scala
@@ -328,6 +328,10 @@ class TaskController @Inject() (implicit val env: Environment[User, SessionAuthe
             LabelPointTable.save(LabelPoint(0, newLabelId, point.panoX, point.panoY, point.canvasX, point.canvasY,
               point.heading, point.pitch, point.zoom, point.lat, point.lng, pointGeom, point.computationMethod))
 
+            // Add any added tags to the label_tag table.
+            val labelTagIds: Set[Int] = label.tagIds.toSet
+            labelTagIds.map { tagId => LabelTagTable.save(LabelTag(0, newLabelId, tagId)) }
+
             newLabels += ((newLabelId, timeCreated))
             newLabelId
         }

--- a/app/controllers/TaskController.scala
+++ b/app/controllers/TaskController.scala
@@ -215,6 +215,7 @@ class TaskController @Inject() (implicit val env: Environment[User, SessionAuthe
    */
   def processAuditTaskSubmissions(submission: Seq[AuditTaskSubmission], remoteAddress: String, identity: Option[User]) = {
     var newLabels: ListBuffer[(Int, Timestamp)] = ListBuffer()
+    var refreshPage: Boolean = false // If we notice something out of whack, tell the front-end to refresh the page.
     val returnValues: Seq[TaskPostReturnValue] = for (data <- submission) yield {
       val userOption: Option[User] = identity
       val streetEdgeId: Int = data.auditTask.streetEdgeId
@@ -276,7 +277,7 @@ class TaskController @Inject() (implicit val env: Environment[User, SessionAuthe
       for (label: LabelSubmission <- data.labels) {
         val labelTypeId: Int =  LabelTypeTable.labelTypeToId(label.labelType)
 
-        val existingLabelId: Option[Int] = if (label.temporaryLabelId.isDefined && userOption.isDefined) {
+        val existingLabel: Option[Label] = if (label.temporaryLabelId.isDefined && userOption.isDefined) {
           LabelTable.find(label.temporaryLabelId.get, userOption.get.userId)
         } else {
           Logger.error("Received label with Null temporary_label_id or user_id")
@@ -284,19 +285,26 @@ class TaskController @Inject() (implicit val env: Environment[User, SessionAuthe
         }
 
         // If the label already exists, update deleted, severity, temporary, description, & tags, o/w insert new label.
-        val labelId: Int = existingLabelId match {
-          case Some(labId) =>
-            LabelTable.update(labId, label.deleted, label.severity, label.temporary, label.description)
+        val labelId: Int = existingLabel match {
+          case Some(existingLab) =>
+            // If there is already a label with this temp id but a mismatched label type, the user probably has the
+            // Explore page open in multiple browsers. Don't add the label, and tell the front-end to refresh the page.
+            if (existingLab.labelTypeId != labelTypeId) {
+              refreshPage = true
+              -1
+            } else {
+              LabelTable.update(existingLab.labelId, label.deleted, label.severity, label.temporary, label.description)
 
-            // Remove any tag entries from database that were removed on the front-end and add any new ones.
-            val labelTagIds: Set[Int] = label.tagIds.toSet
-            val existingTagIds: Set[Int] = LabelTagTable.selectTagIdsForLabelId(labId).toSet
-            val tagsToRemove: Set[Int] = existingTagIds -- labelTagIds
-            val tagsToAdd: Set[Int] = labelTagIds -- existingTagIds
-            tagsToRemove.map { tagId => LabelTagTable.delete(labId, tagId) }
-            tagsToAdd.map { tagId => LabelTagTable.save(LabelTag(0, labId, tagId)) }
+              // Remove any tag entries from database that were removed on the front-end and add any new ones.
+              val labelTagIds: Set[Int] = label.tagIds.toSet
+              val existingTagIds: Set[Int] = LabelTagTable.selectTagIdsForLabelId(existingLab.labelId).toSet
+              val tagsToRemove: Set[Int] = existingTagIds -- labelTagIds
+              val tagsToAdd: Set[Int] = labelTagIds -- existingTagIds
+              tagsToRemove.map { tagId => LabelTagTable.delete(existingLab.labelId, tagId) }
+              tagsToAdd.map { tagId => LabelTagTable.save(LabelTag(0, existingLab.labelId, tagId)) }
 
-            labId
+              existingLab.labelId
+            }
           case None =>
             // Get the timestamp for a new label being added to db, log an error if there is a problem w/ timestamp.
             val timeCreated: Timestamp = label.timeCreated match {
@@ -408,7 +416,8 @@ class TaskController @Inject() (implicit val env: Environment[User, SessionAuthe
       "street_edge_id" -> returnValues.head.streetEdgeId,
       "mission" -> returnValues.head.mission.map(_.toJSON),
       "switch_to_validation" -> returnValues.head.switchToValidation,
-      "updated_streets" -> returnValues.head.updatedStreets.map(_.toJSON)
+      "updated_streets" -> returnValues.head.updatedStreets.map(_.toJSON),
+      "refresh_page" -> refreshPage
     )))
   }
 }

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -261,12 +261,12 @@ object LabelTable {
   /**
     * Find a label based on temp_label_id and user_id.
     */
-  def find(tempLabelId: Int, userId: UUID): Option[Int] = db.withSession { implicit session =>
+  def find(tempLabelId: Int, userId: UUID): Option[Label] = db.withSession { implicit session =>
     (for {
       m <- missions
       l <- labelsUnfiltered if l.missionId === m.missionId
       if l.temporaryLabelId === tempLabelId && m.userId === userId.toString
-    } yield l.labelId).firstOption
+    } yield l).firstOption
   }
 
   def countLabels: Int = db.withSession(implicit session =>

--- a/public/javascripts/SVLabel/src/SVLabel/Tracker.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Tracker.js
@@ -212,6 +212,7 @@ function Tracker() {
         }
 
         var item = self.create(action, notes, extraData);
+        var prevItem = actions.slice(-1)[0];
         actions.push(item);
         var contextMenuLabel = true;
 
@@ -219,7 +220,7 @@ function Tracker() {
             contextMenuLabel = false;
         }
 
-        //we are no longer interacting with a label, set currentLabel to null
+        // We are no longer interacting with a label, set currentLabel to null.
         if (self._isContextMenuClose(action) || self._isDeleteLabelAction(action) || !contextMenuLabel) {
             currentLabel = null;
         }
@@ -228,6 +229,9 @@ function Tracker() {
         if (actions.length > 200 && !self._isCanvasInteraction(action) && !self._isContextMenuAction(action)) {
             self.submitForm();
         }
+
+        // If there is a one-hour break between interactions (in ms), refresh the page to avoid weird bugs.
+        if (prevItem && item.timestamp - prevItem.timestamp > 3600000) window.location.reload();
 
         return this;
     };

--- a/public/javascripts/SVLabel/src/SVLabel/Tracker.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Tracker.js
@@ -248,7 +248,8 @@ function Tracker() {
      * Put the previous labeling actions into prevActions. Then refresh the current actions.
      */
     this.refresh = function() {
-        prevActions = prevActions.concat(actions);
+        // Commented out to save memory since we aren't using prevActions right now.
+        // prevActions = prevActions.concat(actions);
         actions = [];
 
         updatedLabels = [];

--- a/public/javascripts/SVLabel/src/SVLabel/data/Form.js
+++ b/public/javascripts/SVLabel/src/SVLabel/data/Form.js
@@ -256,6 +256,9 @@ function Form (labelContainer, missionModel, missionContainer, navigationModel, 
                     // prevent turkers from modifying JS variables to prevent switching to validation).
                     if (result.switch_to_validation) window.location.replace('/validate');
 
+                    // If the back-end says that something is messed up and that we should refresh page, do that now.
+                    if (result.refresh_page) window.location.reload();
+
                     // If a new mission was sent and we aren't in onboarding, create an object for it on the front-end.
                     if (result.mission && !svl.isOnboarding()) missionModel.createAMission(result.mission);
 

--- a/public/javascripts/SVValidate/src/Tracker.js
+++ b/public/javascripts/SVValidate/src/Tracker.js
@@ -102,11 +102,14 @@ function Tracker() {
      */
     function push(action, notes, extraData) {
         let item = _createAction(action, notes, extraData);
+        var prevItem = actions.slice(-1)[0];
         actions.push(item);
         if (actions.length > 200) {
             let data = svv.form.compileSubmissionData();
             svv.form.submit(data, true);
         }
+        // If there is a one-hour break between interactions (in ms), refresh the page to avoid weird bugs.
+        if (prevItem && item.timestamp - prevItem.timestamp > 3600000) window.location.reload();
         return this;
     }
 

--- a/public/javascripts/SVValidate/src/Tracker.js
+++ b/public/javascripts/SVValidate/src/Tracker.js
@@ -114,7 +114,8 @@ function Tracker() {
      * Empties actions stored in the Tracker.
      */
     function refresh() {
-        prevActions = prevActions.concat(actions);
+        // Commented out to save memory since we aren't using prevActions right now.
+        // prevActions = prevActions.concat(actions);
         actions = [];
         self.push("RefreshTracker");
     }


### PR DESCRIPTION
Fixes #3222 

This should prevent a bug that happened when a user had multiple Explore pages open at the same time, where metadata for labels were being overwritten instead of new ones being created.

The issue: The front end keeps track of a "temporary label id", which should uniquely identify a label for each user. When loading the page, it's given a temp label id, and it increments it whenever a label is placed. The back end then uses the `user_id` and `temporary_label_id` to uniquely identify a label; this is how the back end knows whether you're submitting a new label or editing an old one. If you open the Explore page in two different locations, you could start adding labels with the same `temporary_label_id`. The back end would then think that you're just updating an old label; it wouldn't add a new label, and it would replace your old tags/severity.

The solution going forward: We opted to just add in a few checks which will trigger the Explore page to reload, which will prevent this issue. I went with this route because it sounds like a nightmare to try to think through all the implications of someone auditing simultaneously with the same account on two separate browsers. Who knows what other issues might arise from this situation! Now the page will refresh if you come back to the site after leaving for more than an hour. It will also refresh if the back end notices that you are trying to "edit" a label while the metadata shows that it's the "wrong" label type.

The damage: I'm seeing a little over 1,000 examples of this in Seattle, which would be about 0.5% of labels. This means that the severity and tags are incorrect for those labels in the database, but also that 1,000 were just never added to the database that _should_ have been! I haven't really looked into other cities, but expect it to be similar.

Fixing the bad data: There are three things we'd like to fix here in an ideal world...

1. Recovering the labels that were never added: I personally do not think that it is worth the time investment to recover those labels. I'm not even sure if it is possible to recover all of the data that we would need from the logs to be able to do this. But even if we did, it would be a huge hassle to implement this.
2. Recovering the correct severity rating: I've written a query that mostly does this... The query will update the severity to be the first severity rating that was given to the label. If the user changed their mind, then it will still be incorrect. But at least it won't be the severity for an entirely different label!
3. Recovering the correct tags: This one is also kind of difficult. I wrote a query that will just delete the tags for the labels in question so that we don't have tags for the wrong label type in there. I believe code could be written recover the data, but again I don't think that the time investment is worth it to recover the tags for these labels.

@jonfroehlich if you disagree when it comes to the importance of recovering this data, let me know and we can discuss what this would look like at our next 1:1! The ability to recover this data will not disappear after this PR is merged!

Here's the severity update query
```
UPDATE label
SET severity = severity_interactions.new_severity
FROM audit_task
INNER JOIN (
    SELECT user_id, temporary_label_id, COUNT(*) AS label_count
    FROM audit_task_interaction
    INNER JOIN audit_task ON audit_task_interaction.audit_task_id = audit_task.audit_task_id
    WHERE action = 'LabelingCanvas_FinishLabeling'
    GROUP BY user_id, temporary_label_id
    HAVING COUNT(*) > 1
) duplicated_ids
    ON audit_task.user_id = duplicated_ids.user_id
LEFT JOIN (
    SELECT DISTINCT ON (user_id, temporary_label_id) user_id, temporary_label_id,
           CAST(COALESCE(SUBSTRING(note FROM 'RadioValue:(\d)'), SUBSTRING(action FROM 'Severity_(\d)')) AS INT) AS new_severity
    FROM audit_task_interaction
    INNER JOIN audit_task ON audit_task_interaction.audit_task_id = audit_task.audit_task_id
    WHERE action = 'ContextMenu_RadioChange'
        OR action LIKE 'KeyboardShortcut_Severity__'
    ORDER BY user_id, temporary_label_id, timestamp
) severity_interactions
    ON audit_task.user_id = severity_interactions.user_id
WHERE audit_task.audit_task_id = label.audit_task_id
    AND label.temporary_label_id = duplicated_ids.temporary_label_id
    AND label.temporary_label_id = severity_interactions.temporary_label_id;
```

And here is the tag deleting query
```
DELETE FROM label_tag
USING label
INNER JOIN audit_task ON label.audit_task_id = audit_task.audit_task_id
INNER JOIN (
    SELECT user_id, temporary_label_id
    FROM audit_task_interaction
    INNER JOIN audit_task ON audit_task_interaction.audit_task_id = audit_task.audit_task_id
    WHERE action = 'LabelingCanvas_FinishLabeling'
    GROUP BY user_id, temporary_label_id
    HAVING COUNT(*) > 1
) duplicated_ids
    ON label.temporary_label_id = duplicated_ids.temporary_label_id
    AND audit_task.user_id = duplicated_ids.user_id
WHERE label_tag.label_id = label.label_id;
```

Since these queries use the `audit_task_interaction` table, I'm going to run them manually on the databases after pushing to prod. This is just so that we don't muck up the build process by trying to run a query that takes multiple minutes to run since it's using such a large table.
