### PR TITLE
Fixes Validate bug where mission would change after starting it

### DIFF
--- a/public/javascripts/SVValidate/src/Tracker.js
+++ b/public/javascripts/SVValidate/src/Tracker.js
@@ -105,7 +105,7 @@ function Tracker() {
         var prevItem = actions.slice(-1)[0];
         actions.push(item);
         if (actions.length > 200) {
-            let data = svv.form.compileSubmissionData();
+            let data = svv.form.compileSubmissionData(false);
             svv.form.submit(data, true);
         }
         // If there is a one-hour break between interactions (in ms), refresh the page to avoid weird bugs.

--- a/public/javascripts/SVValidate/src/data/Form.js
+++ b/public/javascripts/SVValidate/src/data/Form.js
@@ -7,8 +7,9 @@ function Form(url, beaconUrl) {
     /**
      * Compiles data into a format that can be parsed by our backend.
      * @returns {{}}
+     * @param {boolean} missionComplete Whether or not the mission is complete. To ensure we only send once per mission.
      */
-    function compileSubmissionData() {
+    function compileSubmissionData(missionComplete) {
         let data = {};
         let missionContainer = svv.missionContainer;
         let mission = missionContainer ? missionContainer.getCurrentMission() : null;
@@ -24,7 +25,7 @@ function Form(url, beaconUrl) {
                 mission_type: mission.getProperty("missionType"),
                 labels_progress: mission.getProperty("labelsProgress"),
                 label_type_id: mission.getProperty("labelTypeId"),
-                completed: mission.getProperty("completed"),
+                completed: missionComplete ? missionComplete : false,
                 skipped: mission.getProperty("skipped")
             };
         }
@@ -114,7 +115,7 @@ function Form(url, beaconUrl) {
         //
         // Source for fix and ongoing discussion is here:
         // https://bugs.chromium.org/p/chromium/issues/detail?id=490015
-        let data = [compileSubmissionData()];
+        let data = compileSubmissionData(false);
         let jsonData = JSON.stringify(data);
         navigator.sendBeacon(properties.beaconDataStoreUrl, jsonData);
     });

--- a/public/javascripts/SVValidate/src/data/Form.js
+++ b/public/javascripts/SVValidate/src/data/Form.js
@@ -29,7 +29,7 @@ function Form(url, beaconUrl) {
             };
         }
 
-        // Only label list if there is a label list when we're compiling submission data.
+        // Only include labels if there is a label list when we're compiling submission data.
         if (labelList) {
             data.labels = svv.labelContainer.getCurrentLabels();
             svv.labelContainer.refresh();
@@ -65,10 +65,6 @@ function Form(url, beaconUrl) {
     function submit(data, async) {
         if (typeof async === "undefined") {
             async = false;
-        }
-
-        if (data.constructor !== Array) {
-            data = [data];
         }
 
         $.ajax({


### PR DESCRIPTION
Fixes #3261 

Fixes a bug on Validate where, on missions after your first, the mission could suddenly change during your first or second label of that mission.

Thank you @jonfroehlich for all of your testing and screen recordings!! The recordings made it much easier to track down.

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
