### PR TITLE
Reorganizes navbar, adds RouteBuilder to navbar

### DIFF
--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -28,7 +28,7 @@
                         <span class="tagline">@Messages("landing.create.path")</span>
                     </p>
                     <br>
-                    <a class="body-start-btn" href="@routes.AuditController.explore()">@Messages("navbar.explore") @cityShortName</a>
+                    <a class="body-start-btn" href="@routes.AuditController.explore()">@Messages("landing.start.exploring") @cityShortName</a>
                     <br><br>
                     <span class="header-text">@Messages("landing.also.in")</span>
                     @for((id, cityName, cityURL, visible) <- Random.shuffle(otherCityURLs.filter(c => c._4 == "public")).take(4)) {

--- a/app/views/navbar.scala.html
+++ b/app/views/navbar.scala.html
@@ -132,6 +132,9 @@
                                 <a id="navbar-labelmap-btn" role="menuitem" href="@routes.ApplicationController.labelMap(None)">@Messages("navbar.labelmap")</a>
                             </li>
                         }
+                        <li>
+                            <a id="navbar-route-builder-btn" role="menuitem" href='@routes.ApplicationController.routeBuilder'>@Messages("route.builder.name")</a>
+                        </li>
                         <!-- Hides the "Results Map" tab for the Chicago server version-->
                         @if(!List("chicago-il").contains(currentCity)) {
                             <li>
@@ -262,22 +265,25 @@ $(document).ready(function () {
     $("#navbar-help-btn").on('click', function() {
         logWebpageActivity("Click_module=Help");
     });
+    $("#navbar-api-btn").on('click', function() {
+        logWebpageActivity("Click_module=SidewalkAPI");
+    });
 
     // The following buttons are in the Data drop down menu.
-    $("#navbar-results-btn").on('click', function() {
-        logWebpageActivity("Click_module=Results");
-    });
-    $("#navbar-labelmap-btn").on('click', function() {
-        logWebpageActivity("Click_module=LabelMap");
-    });
     $("#navbar-gallery-btn").on('click', function() {
         logWebpageActivity("Click_module=Gallery");
     });
     $("#navbar-leaderboard-btn").on('click', function() {
         logWebpageActivity("Click_module=Leaderboard");
-    }); 
-    $("#navbar-api-btn").on('click', function() {
-        logWebpageActivity("Click_module=SidewalkAPI");
+    });
+    $("#navbar-labelmap-btn").on('click', function() {
+        logWebpageActivity("Click_module=LabelMap");
+    });
+    $("#navbar-route-builder-btn").on('click', function() {
+        logWebpageActivity("Click_module=RouteBuilder");
+    });
+    $("#navbar-results-btn").on('click', function() {
+        logWebpageActivity("Click_module=Results");
     });
 
     // The buttons in the City drop down menu. Log clicks to any of them but the current city.

--- a/app/views/navbar.scala.html
+++ b/app/views/navbar.scala.html
@@ -110,34 +110,34 @@
                         <a class="navbar-button" id="navbar-help-btn" href='@routes.ApplicationController.help' target="_blank">@Messages("navbar.help")</a>
                     </li>
                 }
+                <li class="active navbar-lnk">
+                    <a class="navbar-button" id="navbar-api-btn" href="@routes.ApplicationController.developer" aria-label="Developer API">@Messages("navbar.api")</a>
+                </li>
 
                 <li class="active dropdown navbar-lnk" id="navbar-data-dropdown-list">
                     <a id="nav-data-dropdown" class="navbar-button" role="button" data-toggle="dropdown" href="#" aria-label="Data Dropdown">
-                        @Messages("navbar.data")
+                        @Messages("navbar.tools")
                         <b class="caret"></b>
                     </a>
                     <ul id="nav-data-menu" class="dropdown-menu" role="menu" aria-label="Data Options">
-                        <!-- Hides the "Results Map" tab for the Chicago server version-->
-                        @if(!List("chicago-il").contains(currentCity)) {
-                            <li>
-                                <a id="navbar-results-btn" role="menuitem" href="@routes.ApplicationController.results">@Messages("navbar.results")</a>
-                            </li>
-                        }
-                        <!-- Only show Label Map link if the city does not have too much data to load that page quickly. -->
-                        @if(!List("seattle-wa").contains(currentCity)) {
-                            <li>
-                                <a id="navbar-labelmap-btn" role="menuitem" href="@routes.ApplicationController.labelMap(None)">@Messages("navbar.labelmap")</a>
-                            </li>
-                        }
                         <li>
                             <a id="navbar-gallery-btn" role="menuitem" href="@routes.ApplicationController.gallery("Assorted", "", "", "correct,unvalidated")">@Messages("gallery")</a>
                         </li>
                         <li>
                             <a id="navbar-leaderboard-btn" role="menuitem" href='@routes.ApplicationController.leaderboard'>@Messages("navbar.leaderboard")</a>
                         </li>
-                        <li>
-                            <a id="navbar-api-btn" role="menuitem" href='@routes.ApplicationController.developer' aria-label="Developer A.P.I.">@Messages("footer.api")</a>
-                        </li>
+                            <!-- Only show Label Map link if the city does not have too much data to load that page quickly. -->
+                        @if(!List("seattle-wa").contains(currentCity)) {
+                            <li>
+                                <a id="navbar-labelmap-btn" role="menuitem" href="@routes.ApplicationController.labelMap(None)">@Messages("navbar.labelmap")</a>
+                            </li>
+                        }
+                        <!-- Hides the "Results Map" tab for the Chicago server version-->
+                        @if(!List("chicago-il").contains(currentCity)) {
+                            <li>
+                                <a id="navbar-results-btn" role="menuitem" href="@routes.ApplicationController.results">@Messages("navbar.results")</a>
+                            </li>
+                        }
                     </ul>
                 </li>
 

--- a/conf/messages.de
+++ b/conf/messages.de
@@ -47,11 +47,12 @@ press.keys = Drücken Sie die Tasten "{0}"
 feedback.title = Weitere Ideen? War etwas verwirrend? Haben Sie einen Fehler gefunden?<br>Schicken Sie uns eine Rückmeldung!
 feedback.submitted = Rückmeldung gesendet
 
-navbar.explore = Erkundung starten
-navbar.validate = Validierung starten
+navbar.explore = Erkunden
+navbar.validate = Valideren
 navbar.howto = Beschriftungsanleitung
+navbar.api = API
+navbar.tools = Werkzeug
 navbar.results = Ergebniskarte
-navbar.data = Daten
 navbar.labelmap = Beschriftungskarte
 navbar.help = Hilfe
 navbar.leaderboard = Bestenliste
@@ -65,6 +66,7 @@ navbar.lang.aria = Sprachoptionen
 navbar.lang.icon.alt = Sprachsymbol
 
 landing.create.path = Schaffen wir einen Weg für alle!
+landing.start.exploring = Erkundung starten
 landing.also.in = Wir sind auch in:
 landing.mapathon = Leben Sie in {0}? Besuchen Sie <a id="mapathonLink" class="other-city-link" href="{1}" target="_blank">eine Mapathon-Veranstaltung in Ihrer Nähe!</a>
 landing.how.you.help = Wie Sie dazu beitragen

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -47,11 +47,12 @@ press.keys = Press the "{0}" keys
 feedback.title = Any thoughts? Found something confusing? Spotted a bug?<br>Send us comments!
 feedback.submitted = Feedback Submitted
 
-navbar.explore = Start Exploring
-navbar.validate = Start Validating
+navbar.explore = Explore
+navbar.validate = Validate
 navbar.howto = How to Label
+navbar.api = API
+navbar.tools = Tools
 navbar.results = Results Map
-navbar.data = Data
 navbar.labelmap = Label Map
 navbar.help = Help
 navbar.leaderboard = Leaderboard
@@ -65,6 +66,7 @@ navbar.lang.aria = Language Options
 navbar.lang.icon.alt = languages icon
 
 landing.create.path = Let''s create a path for everyone
+landing.start.exploring = Start Exploring
 landing.also.in = We are also in:
 landing.mapathon = Live in {0}? Stop by <a id="mapathonLink" class="other-city-link" href="{1}" target="_blank">a mapathon event in your area!</a>
 landing.how.you.help = How you can help

--- a/conf/messages.es
+++ b/conf/messages.es
@@ -47,11 +47,12 @@ press.keys = Presiona las teclas "{0}"
 feedback.title = ¿Alguna idea? ¿Encontraste algo confuso? ¿Has visto un error?<br>¡Envíanos tus comentarios!
 feedback.submitted = Comentarios enviados
 
-navbar.explore = Comienza a explorar
-navbar.validate = Comienza a validar
+navbar.explore = Explorar
+navbar.validate = Validar
 navbar.howto = Cómo etiquetar
+navbar.api = API
+navbar.tools = Herramientas
 navbar.results = Mapa de resultados
-navbar.data = Datos
 navbar.labelmap = Mapa de etiquetas
 navbar.help = Ayuda
 navbar.leaderboard = Tabla de clasificación
@@ -65,6 +66,7 @@ navbar.lang.aria = Opciones de idioma
 navbar.lang.icon.alt = icono de idiomas
 
 landing.create.path = Creemos un camino para todas las personas
+landing.start.exploring = Comienza a explorar
 landing.also.in = También estamos en:
 landing.mapathon = ¿Vives en {0}? ¡Pasa por <a id="mapathonLink" class="other-city-link" href="{1}" target="_blank">un evento "mapathon" en tu área!</a>
 landing.how.you.help = Cómo puedes ayudar

--- a/conf/messages.nl
+++ b/conf/messages.nl
@@ -47,11 +47,12 @@ press.keys = Druk op de "{0}" toetsen
 feedback.title = Nog ideeën? Ben je tegen iets verwarrends aangelopen? Of heb je een fout gevonden?<br>Stuur ons een reactie!
 feedback.submitted = Feedback Ingediend
 
-navbar.explore = Start met Verkennen
-navbar.validate = Start met Valideren
+navbar.explore = Ontdekken
+navbar.validate = Bevestigen
 navbar.howto = Hoe te Labelen
+navbar.api = API
+navbar.tools = Hulpmiddelen
 navbar.results = Resultaten kaart
-navbar.data = Data
 navbar.labelmap = Label Kaart
 navbar.help = Help
 navbar.leaderboard = Scoreboard
@@ -65,6 +66,7 @@ navbar.lang.aria = Taal opties
 navbar.lang.icon.alt = talen icoon
 
 landing.create.path = Laten we een pad creëren voor iedereen!
+landing.start.exploring = Start met Verkennen
 landing.also.in = We zijn ook in:
 landing.mapathon = Woon je in {0}? Kom dan langs <a id="mapathonLink" class="other-city-link" href="{1}" target="_blank"> bij een van onze mapathon events in jouw buurt!</a>
 landing.how.you.help = Hoe je kunt helpen

--- a/conf/messages.zh
+++ b/conf/messages.zh
@@ -47,11 +47,12 @@ press.keys = 點擊 "{0}" 鍵
 feedback.title = 有任何想法或問題嗎？或是找到bug了！<br>任何回饋都很歡迎！
 feedback.submitted = 回饋已提交
 
-navbar.explore = 開始探索
-navbar.validate = 開始檢核
+navbar.explore = 探索
+navbar.validate = 證實
 navbar.howto = 如何標記
+navbar.api = API
+navbar.tools = 工具
 navbar.results = 成果地圖
-navbar.data = 資料
 navbar.labelmap = 標記地圖
 navbar.help = 協助
 navbar.leaderboard = 排行榜
@@ -65,6 +66,7 @@ navbar.lang.aria = 語言選項
 navbar.lang.icon.alt = 語言圖標
 
 landing.create.path = 讓我們為大家創造好走的路吧！
+landing.start.exploring = 開始探索
 landing.also.in = 我們也在：
 landing.mapathon = 住在 {0}嗎？ 來參加 < id="mapathonLink" class="other-city-link" href="{1}" target="_blank">您關心區域的地圖松活動吧！</a>
 landing.how.you.help = 您可以如何協助


### PR DESCRIPTION
Resolves #3152 

Reorganizes items in the navbar and adds RouteBuilder to it. Full list of changes:
1. Start Exploring renamed to Explore
2. Start Validating renamed to Validate
3. Sidewalk API renamed to API and moved out of the Data menu
4. Data menu renamed to Tools
5. RouteBuilder added to the Tools menu
6. I also reorganized the items in the Tools menu to put the ones that we use the most higher up.

##### Before/After screenshots (if applicable)
Before
![Screenshot from 2023-06-19 16-13-39](https://github.com/ProjectSidewalk/SidewalkWebpage/assets/6518824/5cda9b83-cb44-458b-bbcc-2304ed9f56a0)

After
![Screenshot from 2023-06-19 16-09-07](https://github.com/ProjectSidewalk/SidewalkWebpage/assets/6518824/5c1be43a-b28c-4e77-9bba-856f164a0feb)

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've included before/after screenshots above.
- [x] I've asked for and included translations for any user facing text that was added or modified.
- [x] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure the documentation on [this wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Descriptions-of-Logged-Events) is up to date for the logs you added/updated.
