### PR TITLE
Updates Taiwan tags: covered walkway & pedestrian lane marking

### DIFF
--- a/conf/cityparams.conf
+++ b/conf/cityparams.conf
@@ -203,8 +203,8 @@ city-params {
       "level with sidewalk"
       "APS"
       "missing crosswalk"
-      "painted sidewalk"
-      "pedestrian arcade"
+      "pedestrian lane marking"
+      "covered walkway"
       "too close to traffic"
     ]
     mexico-default = [
@@ -216,8 +216,8 @@ city-params {
       "level with sidewalk"
       "APS"
       "missing crosswalk"
-      "painted sidewalk"
-      "pedestrian arcade"
+      "pedestrian lane marking"
+      "covered walkway"
       "too close to traffic"
     ]
     newberg-or = ${city-params.excluded-tags.united-states-default}
@@ -237,8 +237,8 @@ city-params {
       "uncovered manhole"
       "APS"
       "missing crosswalk"
-      "painted sidewalk"
-      "pedestrian arcade"
+      "pedestrian lane marking"
+      "covered walkway"
       "too close to traffic"
     ]
     la-piedad = ${city-params.excluded-tags.mexico-default}
@@ -251,8 +251,8 @@ city-params {
       "uncovered manhole"
       "level with sidewalk"
       "missing crosswalk"
-      "painted sidewalk"
-      "pedestrian arcade"
+      "pedestrian lane marking"
+      "covered walkway"
       "too close to traffic"
     ]
     zurich = [
@@ -262,8 +262,8 @@ city-params {
       "APS"
       "level with sidewalk"
       "missing crosswalk"
-      "painted sidewalk"
-      "pedestrian arcade"
+      "pedestrian lane marking"
+      "covered walkway"
       "too close to traffic"
     ]
     taipei = [
@@ -285,8 +285,8 @@ city-params {
       "level with sidewalk"
       "APS"
       "missing crosswalk"
-      "painted sidewalk"
-      "pedestrian arcade"
+      "pedestrian lane marking"
+      "covered walkway"
       "too close to traffic"
     ]
     cuenca = ${city-params.excluded-tags.mexico-default}

--- a/conf/evolutions/default/190.sql
+++ b/conf/evolutions/default/190.sql
@@ -1,0 +1,64 @@
+# --- !Ups
+-- Mark all labels with 'painted sidewalk' or 'pedestrian arcade' as deleted.
+UPDATE label
+SET deleted = TRUE
+FROM label_tag
+INNER JOIN tag ON label_tag.tag_id = tag.tag_id
+INNER JOIN label_type ON tag.label_type_id = label_type.label_type_id
+WHERE label.label_id = label_tag.label_id
+    AND (
+        label_type.label_type = 'SurfaceProblem' AND tag.tag = 'painted sidewalk'
+        OR label_type.label_type = 'Obstacle' AND tag.tag = 'pedestrian arcade'
+    );
+
+-- Delete all label_tag entries for 'painted sidewalk' or 'pedestrian arcade'.
+DELETE FROM label_tag
+USING tag
+INNER JOIN label_type ON tag.label_type_id = label_type.label_type_id
+WHERE label_tag.tag_id = tag.tag_id
+    AND (
+        label_type.label_type = 'SurfaceProblem' AND tag.tag = 'painted sidewalk'
+        OR label_type.label_type = 'Obstacle' AND tag.tag = 'pedestrian arcade'
+    );
+
+-- Rename tags to 'pedestrian lane marking' and 'covered walkway', change label_type for both to 'NoSidewalk'.
+UPDATE tag
+SET label_type_id = (SELECT label_type_id FROM label_type WHERE label_type = 'NoSidewalk'),
+    tag = 'pedestrian lane marking'
+WHERE tag = 'painted sidewalk'
+    AND label_type_id = (SELECT label_type_id FROM label_type WHERE label_type = 'SurfaceProblem');
+
+UPDATE tag
+SET label_type_id = (SELECT label_type_id FROM label_type WHERE label_type = 'NoSidewalk'),
+    tag = 'covered walkway'
+WHERE tag = 'pedestrian arcade'
+    AND label_type_id = (SELECT label_type_id FROM label_type WHERE label_type = 'Obstacle');
+
+# --- !Downs
+UPDATE label
+SET deleted = TRUE
+FROM label_tag
+INNER JOIN tag ON label_tag.tag_id = tag.tag_id
+INNER JOIN label_type ON tag.label_type_id = label_type.label_type_id
+WHERE label.label_id = label_tag.label_id
+  AND label_type.label_type = 'NoSidewalk'
+  AND tag.tag IN ('pedestrian lane marking', 'covered walkway');
+
+DELETE FROM label_tag
+USING tag
+INNER JOIN label_type ON tag.label_type_id = label_type.label_type_id
+WHERE label_tag.tag_id = tag.tag_id
+  AND label_type.label_type = 'NoSidewalk'
+  AND tag.tag IN ('pedestrian lane marking', 'covered walkway');
+
+UPDATE tag
+SET label_type_id = (SELECT label_type_id FROM label_type WHERE label_type = 'SurfaceProblem'),
+    tag = 'painted sidewalk'
+WHERE tag = 'pedestrian lane marking'
+  AND label_type_id = (SELECT label_type_id FROM label_type WHERE label_type = 'NoSidewalk');
+
+UPDATE tag
+SET label_type_id = (SELECT label_type_id FROM label_type WHERE label_type = 'Obstacle'),
+    tag = 'pedestrian arcade'
+WHERE tag = 'covered walkway'
+  AND label_type_id = (SELECT label_type_id FROM label_type WHERE label_type = 'NoSidewalk');

--- a/public/javascripts/common/UtilitiesSidewalk.js
+++ b/public/javascripts/common/UtilitiesSidewalk.js
@@ -196,10 +196,6 @@ function UtilitiesMisc (JSON) {
                     'parked scooter/motorcycle': {
                         keyChar: 'Y',
                         text: i18next.t('center-ui.context-menu.tag.parked-scooter-motorcycle')
-                    },
-                    'pedestrian arcade': {
-                        keyChar: 'Q',
-                        text: i18next.t('center-ui.context-menu.tag.pedestrian-arcade')
                     }
                 }
             },
@@ -255,10 +251,6 @@ function UtilitiesMisc (JSON) {
                         keyChar: 'E',
                         text: i18next.t('center-ui.context-menu.tag.uncovered-manhole')
                     },
-                    'painted sidewalk': {
-                        keyChar: 'H',
-                        text: i18next.t('center-ui.context-menu.tag.painted-sidewalk')
-                    },
                     'utility panel': {
                         keyChar: 'E',
                         text: i18next.t('center-ui.context-menu.tag.utility-panel')
@@ -288,6 +280,14 @@ function UtilitiesMisc (JSON) {
                     'shared pedestrian/car space': {
                         keyChar: 'E',
                         text: i18next.t('center-ui.context-menu.tag.shared-pedestrian-car-space')
+                    },
+                    'covered walkway': {
+                        keyChar: 'Q',
+                        text: i18next.t('center-ui.context-menu.tag.covered-walkway')
+                    },
+                    'pedestrian lane marking': {
+                        keyChar: 'H',
+                        text: i18next.t('center-ui.context-menu.tag.pedestrian-lane-marking')
                     }
                 }
             },

--- a/public/javascripts/common/UtilitiesSidewalk.js
+++ b/public/javascripts/common/UtilitiesSidewalk.js
@@ -281,13 +281,13 @@ function UtilitiesMisc (JSON) {
                         keyChar: 'E',
                         text: i18next.t('center-ui.context-menu.tag.shared-pedestrian-car-space')
                     },
-                    'covered walkway': {
-                        keyChar: 'Q',
-                        text: i18next.t('center-ui.context-menu.tag.covered-walkway')
-                    },
                     'pedestrian lane marking': {
-                        keyChar: 'H',
+                        keyChar: 'I',
                         text: i18next.t('center-ui.context-menu.tag.pedestrian-lane-marking')
+                    },
+                    'covered walkway': {
+                        keyChar: 'L',
+                        text: i18next.t('center-ui.context-menu.tag.covered-walkway')
                     }
                 }
             },

--- a/public/locales/de/audit.json
+++ b/public/locales/de/audit.json
@@ -167,8 +167,8 @@
                 "missing-crosswalk": "fehlender Fussgängerstre<tag-underline>i</tag-underline>fen",
                 "no-bus-stop-access": "kein Zugang zur H<tag-underline>a</tag-underline>ltestelle",
                 "height-difference": "Höhenunterschie<tag-underline>d</tag-underline>",
-                "pedestrian-lane-marking": "Fußgängerza<tag-underline>h</tag-underline>nmarkierung",
-                "covered-walkway": "überdachter Gehweg (<tag-underline>q</tag-underline>)",
+                "pedestrian-lane-marking": "Fußgängerzahnmark<tag-underline>i</tag-underline>erung",
+                "covered-walkway": "überdachter Gehweg (<tag-underline>l</tag-underline>)",
                 "too-close-to-traffic": "zu nah am Verkehr (<tag-underline>t</tag-underline>)",
                 "utility-panel": "B<tag-underline>e</tag-underline>dienungsfeld"
             },

--- a/public/locales/de/audit.json
+++ b/public/locales/de/audit.json
@@ -167,10 +167,10 @@
                 "missing-crosswalk": "fehlender Fussgängerstre<tag-underline>i</tag-underline>fen",
                 "no-bus-stop-access": "kein Zugang zur H<tag-underline>a</tag-underline>ltestelle",
                 "height-difference": "Höhenunterschie<tag-underline>d</tag-underline>",
-                "painted-sidewalk": "painted sidewalk (<tag-underline>h</tag-underline>)",
-                "pedestrian-arcade": "pedestrian arcade (<tag-underline>q</tag-underline>)",
-                "too-close-to-traffic": "too close to <tag-underline>t</tag-underline>raffic",
-                "utility-panel": "utility pan<tag-underline>e</tag-underline>l"
+                "pedestrian-lane-marking": "Fußgängerza<tag-underline>h</tag-underline>nmarkierung",
+                "covered-walkway": "überdachter Gehweg (<tag-underline>q</tag-underline>)",
+                "too-close-to-traffic": "zu nah am Verkehr (<tag-underline>t</tag-underline>)",
+                "utility-panel": "B<tag-underline>e</tag-underline>dienungsfeld"
             },
             "tooltip": {
                 "passable": "Passierbar",

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -107,8 +107,8 @@
     "APS": "akustische Orientierungshilfe",
     "missing crosswalk": "fehlender Fussgängerstreifen",
     "no bus stop access": "kein Zugang zur Haltestelle",
-    "painted sidewalk": "gemaltes Trottoir",
-    "pedestrian arcade": "Fussgängerpassage",
+    "pedestrian lane marking": "Fußgängerzahnmarkierung",
+    "covered walkway": "überdachter Gehweg",
     "too close to traffic": "zu nah am Verkehr",
     "utility panel": "Bedienungsfeld"
   },

--- a/public/locales/en-NZ/audit.json
+++ b/public/locales/en-NZ/audit.json
@@ -70,8 +70,7 @@
                 "street-has-a-sidewalk": "st<tag-underline>r</tag-underline>eet has a footpath",
                 "street-has-no-sidewalks": "s<tag-underline>t</tag-underline>reet has no footpaths",
                 "level-with-sidewalk": "level with footpath (<tag-underline>d</tag-underline>)",
-                "missing-crosswalk": "m<tag-underline>i</tag-underline>ssing pedestrian crossing",
-                "painted-sidewalk": "painted footpat<tag-underline>h</tag-underline>"
+                "missing-crosswalk": "m<tag-underline>i</tag-underline>ssing pedestrian crossing"
             }
         },
         "compass": {

--- a/public/locales/en-NZ/common.json
+++ b/public/locales/en-NZ/common.json
@@ -19,8 +19,7 @@
     "street has a sidewalk": "street has a footpath",
     "street has no sidewalks": "street has no footpaths",
     "level with sidewalk": "level with footpath",
-    "missing crosswalk": "missing pedestrian crossing",
-    "painted sidewalk": "painted footpath"
+    "missing crosswalk": "missing pedestrian crossing"
   },
   "mission-start-tutorial": {
     "curb-ramp": {

--- a/public/locales/en/audit.json
+++ b/public/locales/en/audit.json
@@ -167,8 +167,8 @@
                 "missing-crosswalk": "m<tag-underline>i</tag-underline>ssing crosswalk",
                 "no-bus-stop-access": "no bus stop <tag-underline>a</tag-underline>ccess",
                 "height-difference": "height <tag-underline>d</tag-underline>ifference",
-                "painted-sidewalk": "painted sidewalk (<tag-underline>h</tag-underline>)",
-                "pedestrian-arcade": "pedestrian arcade (<tag-underline>q</tag-underline>)",
+                "pedestrian-lane-marking": "pedestrian lane marking (<tag-underline>h</tag-underline>)",
+                "covered-walkway": "covered walkway (<tag-underline>q</tag-underline>)",
                 "too-close-to-traffic": "too close to <tag-underline>t</tag-underline>raffic",
                 "utility-panel": "utility pan<tag-underline>e</tag-underline>l"
             },

--- a/public/locales/en/audit.json
+++ b/public/locales/en/audit.json
@@ -167,8 +167,8 @@
                 "missing-crosswalk": "m<tag-underline>i</tag-underline>ssing crosswalk",
                 "no-bus-stop-access": "no bus stop <tag-underline>a</tag-underline>ccess",
                 "height-difference": "height <tag-underline>d</tag-underline>ifference",
-                "pedestrian-lane-marking": "pedestrian lane marking (<tag-underline>h</tag-underline>)",
-                "covered-walkway": "covered walkway (<tag-underline>q</tag-underline>)",
+                "pedestrian-lane-marking": "pedestr<tag-underline>i</tag-underline>an lane marking",
+                "covered-walkway": "covered wa<tag-underline>l</tag-underline>kway",
                 "too-close-to-traffic": "too close to <tag-underline>t</tag-underline>raffic",
                 "utility-panel": "utility pan<tag-underline>e</tag-underline>l"
             },

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -107,8 +107,8 @@
     "APS": "APS",
     "missing crosswalk": "missing crosswalk",
     "no bus stop access": "no bus stop access",
-    "painted sidewalk": "painted sidewalk",
-    "pedestrian arcade": "pedestrian arcade",
+    "pedestrian lane marking": "pedestrian lane marking",
+    "covered walkway": "covered walkway",
     "too close to traffic": "too close to traffic",
     "utility panel": "utility panel"
   },

--- a/public/locales/es/audit.json
+++ b/public/locales/es/audit.json
@@ -167,8 +167,8 @@
                 "missing-crosswalk": "paso peatonal ausente (<tag-underline>i</tag-underline>)",
                 "no-bus-stop-access": "No hay <tag-underline>a</tag-underline>cceso a la parada de autobús",
                 "height-difference": "<tag-underline>d</tag-underline>esnivel",
-                "pedestrian-lane-marking": "marcado de carril peatonal (<tag-underline>h</tag-underline>)",
-                "covered-walkway": "pasarela cubierta (<tag-underline>q</tag-underline>)",
+                "pedestrian-lane-marking": "marcado de carr<tag-underline>i</tag-underline>l peatonal",
+                "covered-walkway": "pasare<tag-underline>l</tag-underline>a cubierta",
                 "too-close-to-traffic": "demasiado cerca del <tag-underline>t</tag-underline>ráfico",
                 "utility-panel": "pan<tag-underline>e</tag-underline>l de utilidad"
             },

--- a/public/locales/es/audit.json
+++ b/public/locales/es/audit.json
@@ -167,8 +167,8 @@
                 "missing-crosswalk": "paso peatonal ausente (<tag-underline>i</tag-underline>)",
                 "no-bus-stop-access": "No hay <tag-underline>a</tag-underline>cceso a la parada de autobús",
                 "height-difference": "<tag-underline>d</tag-underline>esnivel",
-                "painted-sidewalk": "acera pintada (<tag-underline>h</tag-underline>)",
-                "pedestrian-arcade": "arcada peatonal (<tag-underline>q</tag-underline>)",
+                "pedestrian-lane-marking": "marcado de carril peatonal (<tag-underline>h</tag-underline>)",
+                "covered-walkway": "pasarela cubierta (<tag-underline>q</tag-underline>)",
                 "too-close-to-traffic": "demasiado cerca del <tag-underline>t</tag-underline>ráfico",
                 "utility-panel": "pan<tag-underline>e</tag-underline>l de utilidad"
             },

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -107,8 +107,8 @@
     "APS": "APS",
     "missing crosswalk": "paso peatonal ausente (i)",
     "no bus stop access": "No hay acceso a la parada de autobús",
-    "painted sidewalk": "acera pintada",
-    "pedestrian arcade": "arcada peatonal",
+    "pedestrian lane marking": "marcado de carril peatonal",
+    "covered walkway": "pasarela cubierta",
     "too close to traffic": "demasiado cerca del tráfico",
     "utility panel": "panel de utilidad"
   },

--- a/public/locales/nl/audit.json
+++ b/public/locales/nl/audit.json
@@ -167,8 +167,8 @@
                 "missing-crosswalk": "m<tag-underline>i</tag-underline>ssend zebrapad",
                 "no-bus-stop-access": "geen bush<tag-underline>a</tag-underline>lte toegang",
                 "height-difference": "hoogte verschil (<tag-underline>d</tag-underline>)",
-                "pedestrian-lane-marking": "voetgangersstrookmarkering (<tag-underline>h</tag-underline>)",
-                "covered-walkway": "Overdekte loopbrug (<tag-underline>q</tag-underline>)",
+                "pedestrian-lane-marking": "voetgangersstrookmarker<tag-underline>i</tag-underline>ng",
+                "covered-walkway": "Overdekte <tag-underline>l</tag-underline>oopbrug",
                 "too-close-to-traffic": "<tag-underline>t</tag-underline>e dicht bij het verkeer",
                 "utility-panel": "hulpprogramma pan<tag-underline>e</tag-underline>el"
             },

--- a/public/locales/nl/audit.json
+++ b/public/locales/nl/audit.json
@@ -167,8 +167,8 @@
                 "missing-crosswalk": "m<tag-underline>i</tag-underline>ssend zebrapad",
                 "no-bus-stop-access": "geen bush<tag-underline>a</tag-underline>lte toegang",
                 "height-difference": "hoogte verschil (<tag-underline>d</tag-underline>)",
-                "painted-sidewalk": "gesc<tag-underline>h</tag-underline>ilderd trottoir",
-                "pedestrian-arcade": "voetgangers galerij (<tag-underline>q</tag-underline>)",
+                "pedestrian-lane-marking": "voetgangersstrookmarkering (<tag-underline>h</tag-underline>)",
+                "covered-walkway": "Overdekte loopbrug (<tag-underline>q</tag-underline>)",
                 "too-close-to-traffic": "<tag-underline>t</tag-underline>e dicht bij het verkeer",
                 "utility-panel": "hulpprogramma pan<tag-underline>e</tag-underline>el"
             },

--- a/public/locales/nl/common.json
+++ b/public/locales/nl/common.json
@@ -107,8 +107,8 @@
     "APS": "APS",
     "missing crosswalk": "missend zebrapad",
     "no bus stop access": "geen bushalte toegang",
-    "painted sidewalk": "geschilderd trottoir",
-    "pedestrian arcade": "voetgangers galerij",
+    "pedestrian lane marking": "voetgangersstrookmarkering",
+    "covered walkway": "Overdekte loopbrug",
     "too close to traffic": "te dicht bij het verkeer",
     "utility panel": "hulpprogramma paneel"
   },

--- a/public/locales/zh/audit.json
+++ b/public/locales/zh/audit.json
@@ -167,8 +167,8 @@
                 "missing-crosswalk": "無行人穿越道(<tag-underline>i</tag-underline>)",
                 "no-bus-stop-access": "無公車站出入空間(<tag-underline>a</tag-underline>)",
                 "height-difference": "高度差(<tag-underline>d</tag-underline>)",
-                "pedestrian-lane-marking": "行人車道標記(<tag-underline>h</tag-underline>)",
-                "covered-walkway": "有蓋的人行道(<tag-underline>q</tag-underline>)",
+                "pedestrian-lane-marking": "行人車道標記(<tag-underline>i</tag-underline>)",
+                "covered-walkway": "有蓋的人行道(<tag-underline>l</tag-underline>)",
                 "too-close-to-traffic": "离交通太近(<tag-underline>t</tag-underline>)",
                 "utility-panel": "实用面板(<tag-underline>e</tag-underline>)"
             },

--- a/public/locales/zh/audit.json
+++ b/public/locales/zh/audit.json
@@ -167,8 +167,8 @@
                 "missing-crosswalk": "無行人穿越道(<tag-underline>i</tag-underline>)",
                 "no-bus-stop-access": "無公車站出入空間(<tag-underline>a</tag-underline>)",
                 "height-difference": "高度差(<tag-underline>d</tag-underline>)",
-                "painted-sidewalk": "彩绘人行道(<tag-underline>h</tag-underline>)",
-                "pedestrian-arcade": "步行街(<tag-underline>q</tag-underline>)",
+                "pedestrian-lane-marking": "行人車道標記(<tag-underline>h</tag-underline>)",
+                "covered-walkway": "有蓋的人行道(<tag-underline>q</tag-underline>)",
                 "too-close-to-traffic": "离交通太近(<tag-underline>t</tag-underline>)",
                 "utility-panel": "实用面板(<tag-underline>e</tag-underline>)"
             },

--- a/public/locales/zh/common.json
+++ b/public/locales/zh/common.json
@@ -107,8 +107,8 @@
     "APS": "無障礙行人號誌APS",
     "missing crosswalk": "無行人穿越道",
     "no bus stop access": "無公車站出入空間",
-    "painted sidewalk": "彩绘人行道",
-    "pedestrian arcade": "步行街",
+    "pedestrian lane marking": "行人車道標記",
+    "covered walkway": "有蓋的人行道",
     "too close to traffic": "离交通太近",
     "utility panel": "实用面板"
   },


### PR DESCRIPTION
Resolves #3258 

Renames "pedestrian arcade" to "covered walkway", renames "painted sidewalk" to "pedestrian lane marking", and moves those tags from the Obstacle and SurfaceProblem label types to the NoSidewalk label type. I also changed the keyboard shortcuts to work well with our translations, which is more of an option for the NoSidewalk label type given how few tags it has.

##### Before/After screenshots (if applicable)
Before/After No Sidewalk
![Screenshot from 2023-06-20 12-24-26](https://github.com/ProjectSidewalk/SidewalkWebpage/assets/6518824/60acaf69-4d0b-445d-b070-f99dd5da4077)
![Screenshot from 2023-06-20 12-23-11](https://github.com/ProjectSidewalk/SidewalkWebpage/assets/6518824/d5b400f1-319d-4bbd-b668-e9f24c7a9700)

Before/After Surface Problem
![Screenshot from 2023-06-20 12-24-17](https://github.com/ProjectSidewalk/SidewalkWebpage/assets/6518824/136a7556-6a09-4e36-8aab-1d2a3a057cdd)
![Screenshot from 2023-06-20 12-23-27](https://github.com/ProjectSidewalk/SidewalkWebpage/assets/6518824/d1cc8a6f-d73f-453f-9611-3a63075af385)

Before/After Obstacle
![Screenshot from 2023-06-20 12-24-09](https://github.com/ProjectSidewalk/SidewalkWebpage/assets/6518824/14873f82-00d4-4e90-9979-e42cbd78b674)
![Screenshot from 2023-06-20 12-23-37](https://github.com/ProjectSidewalk/SidewalkWebpage/assets/6518824/39dc3373-88d5-4cdf-a947-a0186ae3021b)

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've included before/after screenshots above.
- [x] I've asked for and included translations for any user facing text that was added or modified.
