### PR TITLE
Adds full city lat/lngs to the API page

### DIFF
--- a/app/views/developer.scala.html
+++ b/app/views/developer.scala.html
@@ -62,41 +62,47 @@
                         <td>
                             <dl>
                                 <dt>Required:</dt>
-                                <dd>You need to pass a pair of latlng coordinates to define a bounding
-                                    box, which is used to specify where you want to query the data from.
-                                    </dd>
+                                <dd>
+                                    You need to pass a pair of latlng coordinates to define a bounding box, which is
+                                    used to specify where you want to query the data from.
+                                    <ul>
+                                        <li>
+                                            <code>lat1=[double]</code><br />
+                                        </li>
+                                        <li>
+                                            <code>lng1=[double]</code><br />
+                                        </li>
+                                        <li>
+                                            <code>lat2=[double]</code><br />
+                                        </li>
+                                        <li>
+                                            <code>lng2=[double]</code><br />
+                                        </li>
+                                    </ul>
+                                    If you need data for the entire city, you can use the parameters below. But note
+                                    that the query could take a long time to complete, or even fail on very large
+                                    datasets (we're working on improving performance!).<br>
+                                    <code id="attributes-full-bbox" class="api-full-bbox"></code>
+                                </dd>
                             </dl>
-                            <ul>
-                                <li>
-                                    <code>lat1=[double]</code><br />
-                                </li>
-                                <li>
-                                    <code>lng1=[double]</code><br />
-                                </li>
-                                <li>
-                                    <code>lat2=[double]</code><br />
-                                </li>
-                                <li>
-                                    <code>lng2=[double]</code><br />
-                                </li>
-                            </ul>
                             <dl>
                                 <dt>Optional:</dt>
-                                <dd>You can pass a specific severity to look for and/or a specific filetype
-                                    for the returned dataset. Severity can be an integer value from 1-5 or
-                                    "none" to represent data without a severity rating. You can pass a
-                                    filetype that can be a string "csv" to represent data returned in
-                                    CSV format, "geojson" for the GeoJSON format, or "shapefile" for the ShapeFile format.
-                                    The GeoJSON format is returned by default.</dd>
+                                <dd>
+                                    You can pass a specific severity to look for and/or a specific filetype for the
+                                    returned dataset. Severity can be an integer value from 1-5 or "none" to represent
+                                    data without a severity rating. You can pass a filetype that can be a string "csv"
+                                    to represent data returned in CSV format, "geojson" for the GeoJSON format, or
+                                    "shapefile" for the ShapeFile format. The GeoJSON format is returned by default.
+                                    <ul>
+                                        <li>
+                                            <code>severity=[int|string]</code><br />
+                                        </li>
+                                        <li>
+                                            <code>filetype=csv|shapefile|geojson</code><br />
+                                        </li>
+                                    </ul>
+                                </dd>
                             </dl>
-                            <ul>
-                                <li>
-                                    <code>severity=[int|string]</code><br />
-                                </li>
-                                <li>
-                                    <code>filetype=csv|shapefile|geojson</code><br />
-                                </li>
-                            </ul>
                         </td>
                     </tr>
                     <tr>
@@ -106,13 +112,13 @@
                                 <dt>200</dt>
                                 <dd>
                                     The API returns all the available accessibility attributes in the specified area
-                                    as a <a href="https://datatracker.ietf.org/doc/html/rfc7946#section-3.3">Feature Collection</a> of
-                                        <a href="https://datatracker.ietf.org/doc/html/rfc7946#appendix-A.1">Point features.</a>
-                                    Properties of the attributes include label type, neighborhood name, severity, whether the
-                                        problem was marked as temporary, and a unique attribute id (see
-                                        <a data-scroll href="#disclaimer">disclaimer section</a> for caveats). The
-                                        attributesWithLabels endpoint also includes the parameters needed to recreate
-                                        the environment in Google Street View (including heading, pitch, etc.).
+                                    as a <a href="https://datatracker.ietf.org/doc/html/rfc7946#section-3.3">Feature Collection</a>
+                                    of <a href="https://datatracker.ietf.org/doc/html/rfc7946#appendix-A.1">Point features.</a>
+                                    Properties of the attributes include label type, neighborhood name, severity,
+                                    whether the problem was marked as temporary, and a unique attribute id (see
+                                    <a data-scroll href="#disclaimer">disclaimer section</a> for caveats). The
+                                    attributesWithLabels endpoint also includes the parameters needed to recreate the
+                                    environment in Google Street View (including heading, pitch, etc.).
                                 </dd>
                             </dl>
                         </td>
@@ -149,9 +155,8 @@
                 <table class="table">
                     <tr>
                         <td colspan="2">
-                            This API serves Accessibility Scores of the streets within a specified region.
-                            Accessibility Score is a value between 0 and 1, where 0 means inaccessible and
-                            1 means accessible.
+                            This API serves Accessibility Scores of the streets within a specified region. Accessibility
+                            Score is a value between 0 (inaccessible) and 1 (accessible).
                         </td>
                     </tr>
                     <tr>
@@ -167,34 +172,41 @@
                         <td>
                             <dl>
                                 <dt>Required:</dt>
-                                <dd>You need to pass a pair of latlng coordinates to define a bounding
-                                    box, which is used to specify where you want to query the data from.</dd>
+                                <dd>
+                                    You need to pass a pair of latlng coordinates to define a bounding box, which is
+                                    used to specify where you want to query the data from.
+                                    <ul>
+                                        <li>
+                                            <code>lat1=[double]</code><br />
+                                        </li>
+                                        <li>
+                                            <code>lng1=[double]</code><br />
+                                        </li>
+                                        <li>
+                                            <code>lat2=[double]</code><br />
+                                        </li>
+                                        <li>
+                                            <code>lng2=[double]</code><br />
+                                        </li>
+                                    </ul>
+                                    If you need data for the entire city, you can use the parameters below. But note
+                                    that the query could take a long time to complete.<br>
+                                    <code id="streets-full-bbox" class="api-full-bbox"></code>
+                                </dd>
                             </dl>
-                            <ul>
-                                <li>
-                                    <code>lat1=[double]</code><br />
-                                </li>
-                                <li>
-                                    <code>lng1=[double]</code><br />
-                                </li>
-                                <li>
-                                    <code>lat2=[double]</code><br />
-                                </li>
-                                <li>
-                                    <code>lng2=[double]</code><br />
-                                </li>
-                            </ul>
                             <dl>
                                 <dt>Optional:</dt>
-                                <dd>You can pass a filetype that can be a string "csv" to represent data
-                                    returned in CSV format, "geojson" for the GeoJSON format, or "shapefile" for the
-                                    ShapeFile format. The GeoJSON format is returned by default.</dd>
+                                <dd>
+                                    You can pass a filetype that can be a string "csv" to represent data returned in CSV
+                                    format, "geojson" for the GeoJSON format, or "shapefile" for the ShapeFile format.
+                                    The GeoJSON format is returned by default.
+                                    <ul>
+                                        <li>
+                                            <code>filetype=csv|shapefile|geojson</code><br />
+                                        </li>
+                                    </ul>
+                                </dd>
                             </dl>
-                            <ul>
-                                <li>
-                                    <code>filetype=csv|shapefile|geojson</code><br />
-                                </li>
-                            </ul>
                         </td>
                     </tr>
                     <tr>
@@ -203,9 +215,10 @@
                             <dl>
                                 <dt>200</dt>
                                 <dd>
-                                    The API returns the streets that have been audited at least once as a <a href="https://datatracker.ietf.org/doc/html/rfc7946#section-3.3">Feature Collection</a> of
-                                    <a href="https://datatracker.ietf.org/doc/html/rfc7946#appendix-A.2">LineString features.</a> Each LineString feature
-                                    include street's geometry as well as the corresponding Access Score.
+                                    The API returns the streets that have been audited at least once as a
+                                    <a href="https://datatracker.ietf.org/doc/html/rfc7946#section-3.3">Feature Collection</a>
+                                    of <a href="https://datatracker.ietf.org/doc/html/rfc7946#appendix-A.2">LineString features.</a>
+                                    Each LineString include the street geometry and the corresponding Access Score.
                                 </dd>
                             </dl>
                         </td>
@@ -240,8 +253,7 @@
                     <tr>
                         <td colspan="2">
                             This API serves Accessibility Scores of the neighborhoods within a specified region.
-                            Accessibility Score is a value between 0 and 1, where 0 means inaccessible and
-                            1 means accessible.
+                            Accessibility Score is a value between 0 (inaccessible) and 1 (accessible).
                         </td>
                     </tr>
                     <tr>
@@ -257,35 +269,41 @@
                         <td>
                             <dl>
                                 <dt>Required:</dt>
-                                <dd>You can pass a filetype that can be a string "csv" to represent data
-                                    returned in CSV format, or "shapefile" to represent data returned in the ShapeFile
-                                    format instead of the GeoJSON format returned by default.</dd>
+                                <dd>
+                                    You need to pass a pair of latlng coordinates to define a bounding box, which is
+                                    used to specify where you want to query the data from.
+                                    <ul>
+                                        <li>
+                                            <code>lat1=[double]</code><br />
+                                        </li>
+                                        <li>
+                                            <code>lng1=[double]</code><br />
+                                        </li>
+                                        <li>
+                                            <code>lat2=[double]</code><br />
+                                        </li>
+                                        <li>
+                                            <code>lng2=[double]</code><br />
+                                        </li>
+                                    </ul>
+                                    If you need data for the entire city, you can use the parameters below. But note
+                                    that the query could take a long time to complete.<br>
+                                    <code id="streets-full-bbox" class="api-full-bbox"></code>
+                                </dd>
                             </dl>
-                            <ul>
-                                <li>
-                                    <code>lat1=[double]</code><br />
-                                </li>
-                                <li>
-                                    <code>lng1=[double]</code><br />
-                                </li>
-                                <li>
-                                    <code>lat2=[double]</code><br />
-                                </li>
-                                <li>
-                                    <code>lng2=[double]</code><br />
-                                </li>
-                            </ul>
                             <dl>
                                 <dt>Optional:</dt>
-                                <dd>You can pass a filetype that can be a string "csv" to represent data
-                                    returned in CSV format, "geojson" for the GeoJSON format, or "shapefile" for the ShapeFile
-                                    format. The GeoJSON format is returned by default.</dd>
+                                <dd>
+                                    You can pass a filetype that can be a string "csv" to represent data returned in CSV
+                                    format, "geojson" for the GeoJSON format, or "shapefile" for the ShapeFile format.
+                                    The GeoJSON format is returned by default.
+                                    <ul>
+                                        <li>
+                                            <code>filetype=csv|shapefile|geojson</code><br />
+                                        </li>
+                                    </ul>
+                                </dd>
                             </dl>
-                            <ul>
-                                <li>
-                                    <code>filetype=csv|shapefile|geojson</code><br />
-                                </li>
-                            </ul>
                         </td>
                     </tr>
                     <tr>
@@ -294,9 +312,10 @@
                             <dl>
                                 <dt>200</dt>
                                 <dd>
-                                    The API returns neighborhoods in a given area as a <a href="https://datatracker.ietf.org/doc/html/rfc7946#section-3.3">Feature Collection</a> of
-                                    <a href="https://datatracker.ietf.org/doc/html/rfc7946#appendix-A.3">Polygon features.</a> Each Polygon feature
-                                    includes its geometry as well as the corresponding Access Score.
+                                    The API returns neighborhoods in a given area as a
+                                    <a href="https://datatracker.ietf.org/doc/html/rfc7946#section-3.3">Feature Collection</a>
+                                    of <a href="https://datatracker.ietf.org/doc/html/rfc7946#appendix-A.3">Polygon features.</a>
+                                    Each Polygon feature includes its geometry and the corresponding Access Score.
                                 </dd>
                             </dl>
                         </td>

--- a/public/javascripts/developer.js
+++ b/public/javascripts/developer.js
@@ -29,6 +29,7 @@ $(document).ready(function () {
         }).addLayer(L.mapbox.styleLayer('mapbox://styles/mapbox/streets-v11'));
 
         // Use parameters to fill in example URLs.
+        var fullBBox = `lat1=${data.southwest_boundary.lat}&lng1=${data.southwest_boundary.lng}&lat2=${data.northeast_boundary.lat}&lng2=${data.northeast_boundary.lng}`;
         var attributesURL = `/v2/access/attributes?lat1=${data.attribute.lat1}&lng1=${data.attribute.lng1}&lat2=${data.attribute.lat2}&lng2=${data.attribute.lng2}`;
         var attributesURLCSV = `/v2/access/attributes?lat1=${data.attribute.lat1}&lng1=${data.attribute.lng1}&lat2=${data.attribute.lat2}&lng2=${data.attribute.lng2}&filetype=csv`;
         var attributesURLShapeFile = `/v2/access/attributes?lat1=${data.attribute.lat1}&lng1=${data.attribute.lng1}&lat2=${data.attribute.lat2}&lng2=${data.attribute.lng2}&filetype=shapefile`;
@@ -41,6 +42,7 @@ $(document).ready(function () {
         var regionsURLShapeFile = `/v2/access/score/neighborhoods?lat1=${data.region.lat1}&lng1=${data.region.lng1}&lat2=${data.region.lat2}&lng2=${data.region.lng2}&filetype=shapefile`;
 
         // Fill in example URLs in HTML.
+        $('.api-full-bbox').html(fullBBox);
         $('#attributes-link').attr('href', attributesURL);
         $('#attributes-code').html(attributesURL);
         $('#attributes-with-labels-link').attr('href', attributeWithLabelsURL);


### PR DESCRIPTION
Resolves #3236 

Adds lat/lngs that encompass the entire city to the API page. I included some text explaining that this is to get data for the entire city, and that it may take a long time to run.

##### Before/After screenshots (if applicable)
Before
![Screenshot from 2023-06-20 15-37-19](https://github.com/ProjectSidewalk/SidewalkWebpage/assets/6518824/1016145b-f76d-417d-be85-a50cd4fe3fc8)
After
![Screenshot from 2023-06-20 15-35-46](https://github.com/ProjectSidewalk/SidewalkWebpage/assets/6518824/0e2f4956-524c-483b-bef5-590d4cde3089)

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've included before/after screenshots above.
