### PR TITLE
Fixes bug preventing users from doing a 2nd Validate mission

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import play.PlayScala
 
 name := """sidewalk-webpage"""
 
-version := "7.15.0"
+version := "7.15.1"
 
 scalaVersion := "2.10.7"
 

--- a/conf/evolutions/default/192.sql
+++ b/conf/evolutions/default/192.sql
@@ -1,0 +1,6 @@
+# --- !Ups
+UPDATE mission
+SET completed = TRUE
+WHERE completed = FALSE AND labels_progress = 10 AND labels_validated = 10;
+
+# --- !Downs

--- a/conf/evolutions/default/193.sql
+++ b/conf/evolutions/default/193.sql
@@ -1,0 +1,5 @@
+# --- !Ups
+INSERT INTO version VALUES ('7.15.1', now(), 'Fixes a bug that prevented users from doing a second Validate mission.');
+
+# --- !Downs
+DELETE FROM version WHERE version_id = '7.15.1';

--- a/public/javascripts/SVValidate/src/mission/MissionContainer.js
+++ b/public/javascripts/SVValidate/src/mission/MissionContainer.js
@@ -44,7 +44,7 @@ function MissionContainer () {
     function completeAMission () {
         svv.missionsCompleted += 1;
         svv.modalMissionComplete.show(currentMission);
-        let data = svv.form.compileSubmissionData();
+        let data = svv.form.compileSubmissionData(true);
         svv.form.submit(data, true);
         _addToCompletedMissions(currentMission);
     }


### PR DESCRIPTION
Fixes #3271 

Fixed a bug that I caused after #3262 that prevented users from moving on after their first Validate mission.

It seems that one line of code I was using locally while testing that PR was never included, which caused the catastrophic bug! Easy one line change.
