### PR TITLE
Hopefully preventing server crashes from running out of memory

### DIFF
--- a/app/controllers/ProjectSidewalkAPIController.scala
+++ b/app/controllers/ProjectSidewalkAPIController.scala
@@ -164,16 +164,21 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
 
       Future.successful(Ok.sendFile(content = shapefile, onClose = () => shapefile.delete()))
     } else {
-      // In GeoJSON format. Writing objects to a file to save memory.
-      val features: List[JsObject] =
-        GlobalAttributeTable.getGlobalAttributesWithLabelsInBoundingBox(minLat, minLng, maxLat, maxLng, severity).map(_.toJSON)
-      val attributesJsonFile = new java.io.File("access_attributes.json")
+      // In GeoJSON format. Writing 10k objects to a file at a time to reduce server memory usage and crashes.
+      val attributesJsonFile = new java.io.File(s"attributesWithLabels_${new Timestamp(Instant.now.toEpochMilli).toString}.json")
       val writer = new java.io.PrintStream(attributesJsonFile)
       writer.print("""{"type":"FeatureCollection","features":[""")
-      features.zipWithIndex.foreach { case (feature, i) =>
-        if (i == features.length - 1) writer.print(feature) else writer.print(feature + ",")
+
+      var startIndex: Int = 0
+      val batchSize: Int = 10000
+      var moreWork: Boolean = true
+      while (moreWork) {
+        val features: List[JsObject] = GlobalAttributeTable.getGlobalAttributesWithLabelsInBoundingBox(minLat, minLng, maxLat, maxLng, severity, Some(startIndex), Some(batchSize)).map(_.toJSON)
+        writer.print(features.map(_.toString).mkString(","))
+        startIndex += batchSize
+        if (features.length < batchSize) moreWork = false
       }
-      writer.print("""]}""")
+      writer.print("]}")
       writer.close()
 
       Future.successful(Ok.sendFile(content = attributesJsonFile, inline = true, onClose = () => attributesJsonFile.delete()))

--- a/app/models/attribute/GlobalAttributeTable.scala
+++ b/app/models/attribute/GlobalAttributeTable.scala
@@ -293,7 +293,7 @@ object GlobalAttributeTable {
   /**
     * Gets global attributes within a bounding box with the labels that make up those attributes for the public API.
     */
-  def getGlobalAttributesWithLabelsInBoundingBox(minLat: Float, minLng: Float, maxLat: Float, maxLng: Float, severity: Option[String]): List[GlobalAttributeWithLabelForAPI] = db.withSession { implicit session =>
+  def getGlobalAttributesWithLabelsInBoundingBox(minLat: Float, minLng: Float, maxLat: Float, maxLng: Float, severity: Option[String], startIndex: Option[Int] = None, n: Option[Int] = None): List[GlobalAttributeWithLabelForAPI] = db.withSession { implicit session =>
     val attributesWithLabels = Q.queryNA[GlobalAttributeWithLabelForAPI](
       s"""SELECT global_attribute.global_attribute_id,
          |       label_type.label_type,
@@ -349,7 +349,9 @@ object GlobalAttributeTable {
          |         AND ${severity.getOrElse("") == "none"}
          |         OR ${severity.isEmpty}
          |         OR global_attribute.severity = ${toInt(severity).getOrElse(-1)}
-         |        );""".stripMargin
+         |        )
+         |ORDER BY user_attribute_label_id
+         |${if (n.isDefined && startIndex.isDefined) s"LIMIT ${n.get} OFFSET ${startIndex.get}" else ""};""".stripMargin
     )
     attributesWithLabels.list
   }

--- a/app/models/attribute/GlobalAttributeTable.scala
+++ b/app/models/attribute/GlobalAttributeTable.scala
@@ -216,7 +216,7 @@ object GlobalAttributeTable {
   /**
     * Gets global attributes within a bounding box for the public API.
     */
-  def getGlobalAttributesInBoundingBox(minLat: Float, minLng: Float, maxLat: Float, maxLng: Float, severity: Option[String]): List[GlobalAttributeForAPI] = db.withSession { implicit session =>
+  def getGlobalAttributesInBoundingBox(minLat: Float, minLng: Float, maxLat: Float, maxLng: Float, severity: Option[String], startIndex: Option[Int] = None, n: Option[Int] = None): List[GlobalAttributeForAPI] = db.withSession { implicit session =>
     // Sum the validations counts, average date, and the number of the labels that make up each global attribute.
     val validationCounts =
       """SELECT global_attribute.global_attribute_id AS global_attribute_id,
@@ -285,7 +285,9 @@ object GlobalAttributeTable {
          |        AND ${severity.getOrElse("") == "none"}
          |        OR ${severity.isEmpty}
          |        OR global_attribute.severity = ${toInt(severity).getOrElse(-1)}
-         |    );""".stripMargin
+         |    )
+         |ORDER BY global_attribute.global_attribute_id
+         |${if (n.isDefined && startIndex.isDefined) s"LIMIT ${n.get} OFFSET ${startIndex.get}" else ""};""".stripMargin
     )
     attributes.list
   }

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -1333,7 +1333,7 @@ object LabelTable {
   /**
    * Get metadata used for 2022 CV project for all labels.
    */
-  def getLabelCVMetadata: List[LabelCVMetadata] = db.withSession { implicit session =>
+  def getLabelCVMetadata(startIndex: Int, batchSize: Int): List[LabelCVMetadata] = db.withSession { implicit session =>
     (for {
       _l <- labels
       _lp <- labelPoints if _l.labelId === _lp.labelId
@@ -1342,7 +1342,8 @@ object LabelTable {
     } yield (
       _l.labelId, _gsv.gsvPanoramaId, _l.labelTypeId, _l.agreeCount, _l.disagreeCount, _l.notsureCount, _gsv.width,
       _gsv.height, _lp.panoX, _lp.panoY, LabelPointTable.canvasWidth, LabelPointTable.canvasHeight, _lp.canvasX,
-      _lp.canvasY, _lp.zoom, _lp.heading, _lp.pitch, _gsv.cameraHeading.get, _gsv.cameraPitch.get
-    )).list.map(LabelCVMetadata.tupled)
+      _lp.canvasY, _lp.zoom, _lp.heading, _lp.pitch, _gsv.cameraHeading.asColumnOf[Float],
+      _gsv.cameraPitch.asColumnOf[Float]
+    )).drop(startIndex).take(batchSize).list.map(LabelCVMetadata.tupled)
   }
 }

--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -329,7 +329,6 @@ function Admin(_, $) {
                 var surfaceProblems = data.features.filter(function(label) {return label.properties.label_type === "SurfaceProblem"});
                 var noSidewalks = data.features.filter(function(label) {return label.properties.label_type === "NoSidewalk"});
                 var crosswalks = data.features.filter(function(label) {return label.properties.label_type === "Crosswalk"});
-                var pedestrianSignals = data.features.filter(function(label) {return label.properties.label_type === "Signal"});
                 
                 var curbRampStats = getSummaryStats(curbRamps, "severity");
                 $("#curb-ramp-mean").html((curbRampStats.mean).toFixed(2));


### PR DESCRIPTION
(hopefully) fixes #3224 

This PR improves the performance of two of our biggest API calls: /adminapi/labels/cvMetadata and /attributesWithLabels. Instead of trying to convert all of the labels to JSON in one go like we had before, which forces us to load everything into memory, we are now writing 10k labels at a time to JSON files. We can then transfer the JSON files with much less memory.

I tested this out on my dev environment by artificially lowering the amount of memory available to Java so that I could test with smaller datasets. This seems to be solving the issue. Will only know for sure once it is on production.

Additionally, I only did this with two API endpoints to start. If we determine that the method is working, it's pretty easy to add that workflow to other endpoints!

In the saved file we include the timestamp for when it was created, which will allow us to serve multiple concurrent API requests for the same API.

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
