### PR TITLE
Adds configs for New Taipei and Keelung servers

### DIFF
--- a/app/views/navbar.scala.html
+++ b/app/views/navbar.scala.html
@@ -7,7 +7,7 @@
 @(user: Option[User] = None, url: Option[String] = Some("/"))(implicit lang: Lang)
 
 @currentCity =@{Play.configuration.getString("city-id").get}
-@cities = @{Configs.getAllCityInfo().filter(c => c._1 == currentCity || c._4 == "public")}
+@cities = @{Configs.getAllCityInfo().filter(c => c._1 == currentCity || c._4 == "public" || (List("taipei", "new-taipei-tw", "keelung-tw").contains(currentCity) && List("taipei", "new-taipei-tw", "keelung-tw").contains(c._1)))}
 
 @import views.html.bootstrap._
 

--- a/conf/cityparams.conf
+++ b/conf/cityparams.conf
@@ -206,9 +206,9 @@ city-params {
     oradell-nj = -5
     validation-study = -7
     zurich = -8
-    taipei = 11
+    taipei = 10
     new-taipei-tw = 12
-    keelung-tw = 10
+    keelung-tw = 9
     auckland = 6
     cuenca = -4
     crowdstudy = 7

--- a/conf/cityparams.conf
+++ b/conf/cityparams.conf
@@ -18,6 +18,8 @@ city-params {
     "validation-study"
     "zurich"
     "taipei"
+    "new-taipei-tw"
+    "keelung-tw"
     "auckland"
     "cuenca"
     "crowdstudy"
@@ -37,6 +39,8 @@ city-params {
     validation-study = "Validation Study"
     zurich = "Zürich"
     taipei = "Taipei"
+    new-taipei-tw = "New Taipei"
+    keelung-tw = "Keelung"
     auckland = "Auckland"
     cuenca = "Cuenca"
     crowdstudy = "Seattle (Crowdstudy)"
@@ -56,6 +60,8 @@ city-params {
     validation-study = "Illinois/Washington"
     zurich = "Switzerland"
     taipei = "Taiwan"
+    new-taipei-tw = ${city-params.state-name.taipei}
+    keelung-tw = ${city-params.state-name.taipei}
     auckland = "New Zealand"
     cuenca = "Ecuador"
     crowdstudy = "Washington"
@@ -75,6 +81,8 @@ city-params {
     validation-study = "IL/WA"
     zurich = "CH"
     taipei = "TW"
+    new-taipei-tw = ${city-params.state-abbreviation.taipei}
+    keelung-tw = ${city-params.state-abbreviation.taipei}
     auckland = "NZ"
     cuenca = "EC"
     crowdstudy = "WA"
@@ -94,6 +102,8 @@ city-params {
     validation-study = "Val Study"
     zurich = "Zürich"
     taipei = "Taipei"
+    new-taipei-tw = "New Taipei"
+    keelung-tw = "Keelung"
     auckland = "Auckland"
     cuenca = "Cuenca"
     crowdstudy = "Seattle"
@@ -113,6 +123,8 @@ city-params {
     validation-study = "partially"
     zurich = "partially"
     taipei = "partially"
+    new-taipei-tw = ${city-params.open-status.taipei}
+    keelung-tw = ${city-params.open-status.taipei}
     auckland = "partially"
     cuenca = "partially"
     crowdstudy = "partially"
@@ -132,6 +144,8 @@ city-params {
     validation-study = "private"
     zurich = "private"
     taipei = "private"
+    new-taipei-tw = ${city-params.status.taipei}
+    keelung-tw = ${city-params.status.taipei}
     auckland = "private"
     cuenca = "private"
     crowdstudy = "private"
@@ -151,6 +165,8 @@ city-params {
     validation-study = "skyline1.png"
     zurich = "skyline1.png"
     taipei = "skyline1.png"
+    new-taipei-tw = ${city-params.skyline-img.taipei}
+    keelung-tw = ${city-params.skyline-img.taipei}
     auckland = "skyline1.png"
     cuenca = "skyline1.png"
     crowdstudy = "skyline-seattle.png"
@@ -170,6 +186,8 @@ city-params {
     validation-study = "sidewalk-logo.png"
     zurich = "sidewalk-logo.png"
     taipei = "sidewalk-logo.png"
+    new-taipei-tw = ${city-params.logo-img.taipei}
+    keelung-tw = ${city-params.logo-img.taipei}
     auckland = "sidewalk-logo.png"
     cuenca = "sidewalk-logo.png"
     crowdstudy = "sidewalk-logo.png"
@@ -188,7 +206,9 @@ city-params {
     oradell-nj = -5
     validation-study = -7
     zurich = -8
-    taipei = 10
+    taipei = 11
+    new-taipei-tw = 12
+    keelung-tw = 10
     auckland = 6
     cuenca = -4
     crowdstudy = 7
@@ -275,6 +295,8 @@ city-params {
       "rail/tram track"
       "brick/cobblestone"
     ]
+    new-taipei-tw = ${city-params.excluded-tags.taipei}
+    keelung-tw = ${city-params.excluded-tags.taipei}
     auckland = [
       "tactile warning"
       "fire hydrant"
@@ -308,6 +330,8 @@ city-params {
       validation-study = "https://sidewalk-validation-study.cs.washington.edu"
       zurich = "https://sidewalk-zurich.cs.washington.edu"
       taipei = "https://sidewalk-taipei.cs.washington.edu"
+      new-taipei-tw = "https://sidewalk-new-taipei.cs.washington.edu"
+      keelung-tw = "https://sidewalk-keelung.cs.washington.edu"
       auckland = "https://sidewalk-auckland.cs.washington.edu"
       cuenca = "https://sidewalk-cuenca.cs.washington.edu"
       crowdstudy = "https://sidewalk-crowdstudy.cs.washington.edu"
@@ -327,6 +351,8 @@ city-params {
       validation-study = "https://sidewalk-validation-study-test.cs.washington.edu"
       zurich = "https://sidewalk-zurich-test.cs.washington.edu"
       taipei = "https://sidewalk-taipei-test.cs.washington.edu"
+      new-taipei-tw = "https://sidewalk-new-taipei-test.cs.washington.edu"
+      keelung-tw = "https://sidewalk-keelung-test.cs.washington.edu"
       auckland = "https://sidewalk-auckland-test.cs.washington.edu"
       cuenca = "https://sidewalk-cuenca-test.cs.washington.edu"
       crowdstudy = "https://sidewalk-crowdstudy-test.cs.washington.edu"
@@ -350,6 +376,8 @@ city-params {
       validation-study = "G-XEYDVZ5QMZ"
       zurich = "G-YQJ74CTZ1P"
       taipei = "G-JTBZS5RFBQ"
+      new-taipei-tw = "G-J3X64P3YLJ"
+      keelung-tw = "G-3QZ6RGW6D1"
       auckland = "G-W07Z26D3BS"
       cuenca = "G-8RFKJNGS5K"
       crowdstudy = "G-SESXFEVR36"
@@ -368,6 +396,8 @@ city-params {
       oradell-nj = "G-GZC8MWJTVF"
       zurich = "G-QFM536EGLN"
       taipei = "G-H92Z46T5DG"
+      new-taipei-tw = "G-68V2FWTBL8"
+      keelung-tw = "G-4NR9ZPP15M"
       auckland = "G-NVMCC4Y30W"
       cuenca = "G-EL9FFHKQTZ"
       crowdstudy = "G-Y9YGMTJXJT"
@@ -409,6 +439,8 @@ city-params {
     validation-study = ${city-params.city-center-lat.seattle-wa}
     zurich = 47.373
     taipei = 25.036
+    new-taipei-tw = ${city-params.city-center-lat.taipei}
+    keelung-tw = ${city-params.city-center-lat.taipei}
     auckland = -36.958
     cuenca = -2.898
     crowdstudy = ${city-params.city-center-lat.seattle-wa}
@@ -428,6 +460,8 @@ city-params {
     validation-study = ${city-params.city-center-lng.seattle-wa}
     zurich = 8.542
     taipei = 121.536
+    new-taipei-tw = ${city-params.city-center-lng.taipei}
+    keelung-tw = ${city-params.city-center-lng.taipei}
     auckland = 174.765458
     cuenca = -79.005
     crowdstudy = ${city-params.city-center-lng.seattle-wa}
@@ -447,6 +481,8 @@ city-params {
     validation-study = ${city-params.southwest-boundary-lat.chicago-il}
     zurich = 47.297
     taipei = 21.684
+    new-taipei-tw = ${city-params.southwest-boundary-lat.taipei}
+    keelung-tw = ${city-params.southwest-boundary-lat.taipei}
     auckland = -37.870572
     cuenca = -3.892
     crowdstudy = ${city-params.southwest-boundary-lat.seattle-wa}
@@ -466,6 +502,8 @@ city-params {
     validation-study = ${city-params.southwest-boundary-lng.seattle-wa}
     zurich = 8.427
     taipei = 119.947
+    new-taipei-tw = ${city-params.southwest-boundary-lng.taipei}
+    keelung-tw = ${city-params.southwest-boundary-lng.taipei}
     auckland = 173.765458
     cuenca = -80.008
     crowdstudy = ${city-params.southwest-boundary-lng.seattle-wa}
@@ -485,6 +523,8 @@ city-params {
     validation-study = ${city-params.northeast-boundary-lat.seattle-wa}
     zurich = 47.457
     taipei = 25.306
+    new-taipei-tw = ${city-params.northeast-boundary-lat.taipei}
+    keelung-tw = ${city-params.northeast-boundary-lat.taipei}
     auckland = -35.870572
     cuenca = -1.892
     crowdstudy = ${city-params.northeast-boundary-lat.seattle-wa}
@@ -504,6 +544,8 @@ city-params {
     validation-study = ${city-params.northeast-boundary-lng.chicago-il}
     zurich = 8.639
     taipei = 122.282
+    new-taipei-tw = ${city-params.northeast-boundary-lng.taipei}
+    keelung-tw = ${city-params.northeast-boundary-lng.taipei}
     auckland = 175.765458
     cuenca = -78.008
     crowdstudy = ${city-params.northeast-boundary-lng.seattle-wa}
@@ -523,6 +565,8 @@ city-params {
     validation-study = 854
     zurich = 11242
     taipei = 26434
+    new-taipei-tw = 492898
+    keelung-tw = 492898
     auckland = 76949
     cuenca = 15431
     crowdstudy = 27645
@@ -542,6 +586,8 @@ city-params {
     validation-study = 12.0
     zurich = 15.0
     taipei = 14.25
+    new-taipei-tw = ${city-params.default-map-zoom.taipei}
+    keelung-tw = ${city-params.default-map-zoom.taipei}
     auckland = 12.0
     cuenca = 15.75
     crowdstudy = 11.75
@@ -562,6 +608,8 @@ city-params {
       validation-study = 41.575
       zurich = 47.376
       taipei = 25.023
+      new-taipei-tw = ${city-params.api-demos.attribute-center-lat.taipei}
+      keelung-tw = ${city-params.api-demos.attribute-center-lat.taipei}
       auckland = -36.908
       cuenca = -2.900
       crowdstudy = ${city-params.api-demos.attribute-center-lat.seattle-wa}
@@ -581,6 +629,8 @@ city-params {
       validation-study = -87.865
       zurich = 8.544
       taipei = 121.534
+      new-taipei-tw = ${city-params.api-demos.attribute-center-lng.taipei}
+      keelung-tw = ${city-params.api-demos.attribute-center-lng.taipei}
       auckland = 174.671
       cuenca = -79.005
       crowdstudy = ${city-params.api-demos.attribute-center-lng.seattle-wa}
@@ -600,6 +650,8 @@ city-params {
       validation-study = 13.0
       zurich = 16.5
       taipei = 16.0
+      new-taipei-tw = ${city-params.api-demos.attribute-zoom.taipei}
+      keelung-tw = ${city-params.api-demos.attribute-zoom.taipei}
       auckland = 15.5
       cuenca = 16.0
       crowdstudy = ${city-params.api-demos.attribute-zoom.seattle-wa}
@@ -619,6 +671,8 @@ city-params {
       validation-study = 41.560
       zurich = 47.375
       taipei = 25.020
+      new-taipei-tw = ${city-params.api-demos.attribute-lat1.taipei}
+      keelung-tw = ${city-params.api-demos.attribute-lat1.taipei}
       auckland = -36.910
       cuenca = -2.902
       crowdstudy = ${city-params.api-demos.attribute-lat1.seattle-wa}
@@ -638,6 +692,8 @@ city-params {
       validation-study = -87.885
       zurich = 8.543
       taipei = 121.531
+      new-taipei-tw = ${city-params.api-demos.attribute-lng1.taipei}
+      keelung-tw = ${city-params.api-demos.attribute-lng1.taipei}
       auckland = 174.668
       cuenca = -79.008
       crowdstudy = ${city-params.api-demos.attribute-lng1.seattle-wa}
@@ -657,6 +713,8 @@ city-params {
       validation-study = 41.590
       zurich = 47.377
       taipei = 25.026
+      new-taipei-tw = ${city-params.api-demos.attribute-lat2.taipei}
+      keelung-tw = ${city-params.api-demos.attribute-lat2.taipei}
       auckland = -36.908
       cuenca = -2.898
       crowdstudy = ${city-params.api-demos.attribute-lat2.seattle-wa}
@@ -676,6 +734,8 @@ city-params {
       validation-study = -87.847
       zurich = 8.545
       taipei = 121.537
+      new-taipei-tw = ${city-params.api-demos.attribute-lng2.taipei}
+      keelung-tw = ${city-params.api-demos.attribute-lng2.taipei}
       auckland = 174.674
       cuenca = -79.002
       crowdstudy = ${city-params.api-demos.attribute-lng2.seattle-wa}
@@ -695,6 +755,8 @@ city-params {
       validation-study = ${city-params.api-demos.attribute-center-lat.validation-study}
       zurich = ${city-params.api-demos.attribute-center-lat.zurich}
       taipei = ${city-params.api-demos.attribute-center-lat.taipei}
+      new-taipei-tw = ${city-params.api-demos.street-center-lat.taipei}
+      keelung-tw = ${city-params.api-demos.street-center-lat.taipei}
       auckland = ${city-params.api-demos.attribute-center-lat.auckland}
       cuenca = ${city-params.api-demos.attribute-center-lat.cuenca}
       crowdstudy = ${city-params.api-demos.street-center-lat.seattle-wa}
@@ -714,6 +776,8 @@ city-params {
       validation-study = ${city-params.api-demos.attribute-center-lng.validation-study}
       zurich = ${city-params.api-demos.attribute-center-lng.zurich}
       taipei = ${city-params.api-demos.attribute-center-lng.taipei}
+      new-taipei-tw = ${city-params.api-demos.street-center-lng.taipei}
+      keelung-tw = ${city-params.api-demos.street-center-lng.taipei}
       auckland = ${city-params.api-demos.attribute-center-lng.auckland}
       cuenca = ${city-params.api-demos.attribute-center-lng.cuenca}
       crowdstudy = ${city-params.api-demos.street-center-lng.seattle-wa}
@@ -733,6 +797,8 @@ city-params {
       validation-study = ${city-params.api-demos.attribute-zoom.validation-study}
       zurich = ${city-params.api-demos.attribute-zoom.zurich}
       taipei = ${city-params.api-demos.attribute-zoom.taipei}
+      new-taipei-tw = ${city-params.api-demos.street-zoom.taipei}
+      keelung-tw = ${city-params.api-demos.street-zoom.taipei}
       auckland = ${city-params.api-demos.attribute-zoom.auckland}
       cuenca = ${city-params.api-demos.attribute-zoom.cuenca}
       crowdstudy = ${city-params.api-demos.street-zoom.seattle-wa}
@@ -752,6 +818,8 @@ city-params {
       validation-study = ${city-params.api-demos.attribute-lat1.validation-study}
       zurich = ${city-params.api-demos.attribute-lat1.zurich}
       taipei = ${city-params.api-demos.attribute-lat1.taipei}
+      new-taipei-tw = ${city-params.api-demos.street-lat1.taipei}
+      keelung-tw = ${city-params.api-demos.street-lat1.taipei}
       auckland = ${city-params.api-demos.attribute-lat1.auckland}
       cuenca = ${city-params.api-demos.attribute-lat1.cuenca}
       crowdstudy = ${city-params.api-demos.street-lat1.seattle-wa}
@@ -771,6 +839,8 @@ city-params {
       validation-study = ${city-params.api-demos.attribute-lng1.validation-study}
       zurich = ${city-params.api-demos.attribute-lng1.zurich}
       taipei = ${city-params.api-demos.attribute-lng1.taipei}
+      new-taipei-tw = ${city-params.api-demos.street-lng1.taipei}
+      keelung-tw = ${city-params.api-demos.street-lng1.taipei}
       auckland = ${city-params.api-demos.attribute-lng1.auckland}
       cuenca = ${city-params.api-demos.attribute-lng1.cuenca}
       crowdstudy = ${city-params.api-demos.street-lng1.seattle-wa}
@@ -790,6 +860,8 @@ city-params {
       validation-study = ${city-params.api-demos.attribute-lat2.validation-study}
       zurich = ${city-params.api-demos.attribute-lat2.zurich}
       taipei = ${city-params.api-demos.attribute-lat2.taipei}
+      new-taipei-tw = ${city-params.api-demos.street-lat2.taipei}
+      keelung-tw = ${city-params.api-demos.street-lat2.taipei}
       auckland = ${city-params.api-demos.attribute-lat2.auckland}
       cuenca = ${city-params.api-demos.attribute-lat2.cuenca}
       crowdstudy = ${city-params.api-demos.street-lat2.seattle-wa}
@@ -809,6 +881,8 @@ city-params {
       validation-study = ${city-params.api-demos.attribute-lng2.validation-study}
       zurich = ${city-params.api-demos.attribute-lng2.zurich}
       taipei = ${city-params.api-demos.attribute-lng2.taipei}
+      new-taipei-tw = ${city-params.api-demos.street-lng2.taipei}
+      keelung-tw = ${city-params.api-demos.street-lng2.taipei}
       auckland = ${city-params.api-demos.attribute-lng2.auckland}
       cuenca = ${city-params.api-demos.attribute-lng2.cuenca}
       crowdstudy = ${city-params.api-demos.street-lng2.seattle-wa}
@@ -828,6 +902,8 @@ city-params {
       validation-study = 41.643
       zurich = 47.3755
       taipei = 25.021
+      new-taipei-tw = ${city-params.api-demos.region-center-lat.taipei}
+      keelung-tw = ${city-params.api-demos.region-center-lat.taipei}
       auckland = -36.909
       cuenca = -2.898
       crowdstudy = ${city-params.api-demos.region-center-lat.seattle-wa}
@@ -847,6 +923,8 @@ city-params {
       validation-study = -87.707
       zurich = 8.543
       taipei = 121.532
+      new-taipei-tw = ${city-params.api-demos.region-center-lng.taipei}
+      keelung-tw = ${city-params.api-demos.region-center-lng.taipei}
       auckland = 174.666
       cuenca = -79.005
       crowdstudy = ${city-params.api-demos.region-center-lng.seattle-wa}
@@ -866,6 +944,8 @@ city-params {
       validation-study = 13.0
       zurich = 14.5
       taipei = 14.5
+      new-taipei-tw = ${city-params.api-demos.region-zoom.taipei}
+      keelung-tw = ${city-params.api-demos.region-zoom.taipei}
       auckland = 13.0
       cuenca = 14.0
       crowdstudy = ${city-params.api-demos.region-zoom.seattle-wa}
@@ -885,6 +965,8 @@ city-params {
       validation-study = 41.622
       zurich = 47.370
       taipei = 25.016
+      new-taipei-tw = ${city-params.api-demos.region-lat1.taipei}
+      keelung-tw = ${city-params.api-demos.region-lat1.taipei}
       auckland = -36.921
       cuenca = -2.906
       crowdstudy = ${city-params.api-demos.region-lat1.seattle-wa}
@@ -904,6 +986,8 @@ city-params {
       validation-study = -87.738
       zurich = 8.540
       taipei = 119.947
+      new-taipei-tw = ${city-params.api-demos.region-lng1.taipei}
+      keelung-tw = ${city-params.api-demos.region-lng1.taipei}
       auckland = 174.655
       cuenca = -79.012
       crowdstudy = ${city-params.api-demos.region-lng1.seattle-wa}
@@ -923,6 +1007,8 @@ city-params {
       validation-study = 41.659
       zurich = 47.380
       taipei = 25.027
+      new-taipei-tw = ${city-params.api-demos.region-lat2.taipei}
+      keelung-tw = ${city-params.api-demos.region-lat2.taipei}
       auckland = -36.896
       cuenca = -2.891
       crowdstudy = ${city-params.api-demos.region-lat2.seattle-wa}
@@ -942,6 +1028,8 @@ city-params {
       validation-study = -87.683
       zurich = 8.548
       taipei = 122.282
+      new-taipei-tw = ${city-params.api-demos.region-lng2.taipei}
+      keelung-tw = ${city-params.api-demos.region-lng2.taipei}
       auckland = 174.679
       cuenca = -78.998
       crowdstudy = ${city-params.api-demos.region-lng2.seattle-wa}


### PR DESCRIPTION
Resolves #3277 

Adds initial configs for New Taipei and Keelung servers. I copied a bunch of map centering params over from the Taipei server since we haven't settled on which neighborhoods to deploy in quite yet.

I also added in a bit of hacky code that forces all the Taiwan servers to show up in the city drop down list for any other Taiwan server. We've talked about having a separate Taiwan landing page, but this should do for day 1!
