### PR TITLE
Maps in Taiwan now pointing to revealed villages

### DIFF
--- a/conf/cityparams.conf
+++ b/conf/cityparams.conf
@@ -439,8 +439,8 @@ city-params {
     validation-study = ${city-params.city-center-lat.seattle-wa}
     zurich = 47.373
     taipei = 25.060
-    new-taipei-tw = ${city-params.city-center-lat.taipei}
-    keelung-tw = ${city-params.city-center-lat.taipei}
+    new-taipei-tw = 25.036
+    keelung-tw = 25.112
     auckland = -36.958
     cuenca = -2.898
     crowdstudy = ${city-params.city-center-lat.seattle-wa}
@@ -461,7 +461,7 @@ city-params {
     zurich = 8.542
     taipei = 121.536
     new-taipei-tw = 121.550
-    keelung-tw = ${city-params.city-center-lng.taipei}
+    keelung-tw = 121.730
     auckland = 174.765458
     cuenca = -79.005
     crowdstudy = ${city-params.city-center-lng.seattle-wa}
@@ -587,7 +587,7 @@ city-params {
     zurich = 15.0
     taipei = 13.0
     new-taipei-tw = 13.0
-    keelung-tw = ${city-params.default-map-zoom.taipei}
+    keelung-tw = 13.25
     auckland = 12.0
     cuenca = 15.75
     crowdstudy = 11.75

--- a/conf/cityparams.conf
+++ b/conf/cityparams.conf
@@ -438,7 +438,7 @@ city-params {
     oradell-nj = 40.955
     validation-study = ${city-params.city-center-lat.seattle-wa}
     zurich = 47.373
-    taipei = 25.036
+    taipei = 25.060
     new-taipei-tw = ${city-params.city-center-lat.taipei}
     keelung-tw = ${city-params.city-center-lat.taipei}
     auckland = -36.958
@@ -585,7 +585,7 @@ city-params {
     oradell-nj = 14.5
     validation-study = 12.0
     zurich = 15.0
-    taipei = 14.25
+    taipei = 13.0
     new-taipei-tw = 13.0
     keelung-tw = ${city-params.default-map-zoom.taipei}
     auckland = 12.0

--- a/conf/cityparams.conf
+++ b/conf/cityparams.conf
@@ -460,7 +460,7 @@ city-params {
     validation-study = ${city-params.city-center-lng.seattle-wa}
     zurich = 8.542
     taipei = 121.536
-    new-taipei-tw = ${city-params.city-center-lng.taipei}
+    new-taipei-tw = 121.550
     keelung-tw = ${city-params.city-center-lng.taipei}
     auckland = 174.765458
     cuenca = -79.005
@@ -586,7 +586,7 @@ city-params {
     validation-study = 12.0
     zurich = 15.0
     taipei = 14.25
-    new-taipei-tw = ${city-params.default-map-zoom.taipei}
+    new-taipei-tw = 13.0
     keelung-tw = ${city-params.default-map-zoom.taipei}
     auckland = 12.0
     cuenca = 15.75


### PR DESCRIPTION
Resolves #3305 

The lat/lngs for all of the maps (except for those on the API page) have been updated to be centered on the revealed neighborhoods in Taiwan (Taipei, New Taipei, and Keelung servers).

