### PR TITLE
Update DB connection pooler config

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -39,6 +39,9 @@ db.default.url="jdbc:postgresql://localhost:5432/sidewalk"
 # db.default.user=sa
 db.default.user="sidewalk"
 db.default.password="sidewalk"
+db.default.idleMaxAge=30 second  # default is 10 minutes
+db.default.acquireRetryDelay=3 second  # default is 1 second
+db.default.acquireRetryAttempts=20  # default is 10
 
 
 #override default url if environment variable is present

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -39,9 +39,10 @@ db.default.url="jdbc:postgresql://localhost:5432/sidewalk"
 # db.default.user=sa
 db.default.user="sidewalk"
 db.default.password="sidewalk"
-db.default.idleMaxAge=30 second  # default is 10 minutes
-db.default.acquireRetryDelay=3 second  # default is 1 second
-db.default.acquireRetryAttempts=20  # default is 10
+db.default.idleMaxAge=2 minute  # default is 10 minutes
+db.default.acquireRetryDelay=5 second  # default is 1 second
+db.default.acquireRetryAttempts=42  # default is 10
+db.default.minConnectionsPerPartition=4  # default is 5
 
 
 #override default url if environment variable is present


### PR DESCRIPTION
Resolves #3316 

Updates the following database connection pooler configs, with the goals of reducing the number of idle connections we hold on to, and reducing the likelihood that a server fails to ever connect to a database after an auto-deploy.
```
db.default.idleMaxAge=2 minute  # default is 10 minutes
db.default.acquireRetryDelay=5 second  # default is 1 second
db.default.acquireRetryAttempts=42  # default is 10
db.default.minConnectionsPerPartition=4  # default is 5
```

##### Testing instructions
1. Make sure the server is running and you've loaded a webpage
2. SSH into db container: `make ssh target=db`
3. Connect to a db: `psql -U sidewalk -d sidewalk`
4. Run this command to list open connections
    ```
    SELECT datname, SUM(numbackends) AS "num_conn"
    FROM pg_stat_database
    GROUP BY datname
    HAVING SUM(numbackends) > 0;
    ```
5. If you decrease the `idleMaxAge` to be just a few seconds and you keep running this query, you can watch how the number of connections increases when you load a page, and then goes back down to `minConnectionsPerPartition` after `idleMaxAge`.

The retry configs will be a lot easier to test on the test servers!

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
