### PR TITLE
Fixes missing commas in JSON APIs

### DIFF
--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -411,6 +411,7 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
       writer.print(features.map(_.toString).mkString(","))
       startIndex += batchSize
       if (features.length < batchSize) moreWork = false
+      else writer.print(",")
     }
     writer.print("]")
     writer.close()

--- a/app/controllers/ProjectSidewalkAPIController.scala
+++ b/app/controllers/ProjectSidewalkAPIController.scala
@@ -177,6 +177,7 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
         writer.print(features.map(_.toString).mkString(","))
         startIndex += batchSize
         if (features.length < batchSize) moreWork = false
+        else writer.print(",")
       }
       writer.print("]}")
       writer.close()
@@ -235,6 +236,7 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
         writer.print(features.map(_.toString).mkString(","))
         startIndex += batchSize
         if (features.length < batchSize) moreWork = false
+        else writer.print(",")
       }
       writer.print("]}")
       writer.close()


### PR DESCRIPTION
Resolves #3334

Fixes an issue where a comma was being missed every 10k labels in the `/v2/access/attributes`, `/v2/access/attributesWithLabels`, and `/adminapi/labels/cvMetadata` APIs. In #3276 I switched us to adding 10k labels at a time to a JSON file to prevent the server from running out of heap space, but I forgot to include a comma between every 10k :facepalm: 

##### Testing instructions
I tested on a database that had 35k labels on my local dev env and tried each of the three API endpoints. I used [this site](https://codebeautify.org/jsonvalidator#) to validate the JSON.

