### PR TITLE
Adds route ID to the Explore sidebar

### DIFF
--- a/app/views/explore.scala.html
+++ b/app/views/explore.scala.html
@@ -377,8 +377,8 @@
                     </div>
                 </div>
                 <div id="mission-completion-status-box" class="status-box">
-                    <h1>@Messages("audit.right.ui.current.mission")</h1>
-                    <h2 id="current-mission-description">Let's make this neighborhood accessible</h2>
+                    <h1 id="current-mission-header"></h1>
+                    <h2 id="current-mission-description"></h2>
                     <div id='status-current-mission-completion-bar'>
                         <div id='status-current-mission-completion-bar-filler'>
                             <div id='status-current-mission-completion-rate'></div>

--- a/conf/messages.de
+++ b/conf/messages.de
@@ -160,7 +160,6 @@ audit.left.ui.jump.explore.button.new.neighborhood = In ein neues Quartier wechs
 audit.right.ui.overall.stats = Gesamtübersicht
 audit.right.ui.current.neighborhood = Aktuelles Quartier
 audit.right.ui.distance = Kilometer
-audit.right.ui.current.mission = Aktuelle Mission
 
 audit.center.ui.passable = Passierbar
 audit.center.ui.not.passable = Nicht passierbar

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -160,7 +160,6 @@ audit.left.ui.jump.explore.button.new.neighborhood = Go to a new neighborhood
 audit.right.ui.overall.stats = Overall Stats
 audit.right.ui.current.neighborhood = Current Neighborhood
 audit.right.ui.distance = kilometers
-audit.right.ui.current.mission = Current Mission
 
 audit.center.ui.passable = Passable
 audit.center.ui.not.passable = Not Passable

--- a/conf/messages.es
+++ b/conf/messages.es
@@ -160,7 +160,6 @@ audit.left.ui.jump.explore.button.new.neighborhood = Ir a un nuevo barrio
 audit.right.ui.overall.stats = Estadísticas generales
 audit.right.ui.current.neighborhood = Colonia actual
 audit.right.ui.distance = kilómetros
-audit.right.ui.current.mission = Misión actual
 
 audit.center.ui.passable = Transitable
 audit.center.ui.not.passable = No es transitable

--- a/conf/messages.nl
+++ b/conf/messages.nl
@@ -160,7 +160,6 @@ audit.left.ui.jump.explore.button.new.neighborhood = Ga naar een nieuwe wijk
 audit.right.ui.overall.stats = Algemene statistieken
 audit.right.ui.current.neighborhood = Huidige Wijk
 audit.right.ui.distance = kilometer
-audit.right.ui.current.mission = Huidige Missie
 
 audit.center.ui.passable = Begaanbaar
 audit.center.ui.not.passable = Niet Begaanbaar

--- a/conf/messages.zh
+++ b/conf/messages.zh
@@ -160,7 +160,6 @@ audit.left.ui.jump.explore.button.new.neighborhood = 前往新的鄰里
 audit.right.ui.overall.stats = 整體統計數據
 audit.right.ui.current.neighborhood = 目前所在鄰里
 audit.right.ui.distance = 公里
-audit.right.ui.current.mission = 目前任務
 
 audit.center.ui.passable = 可通過的
 audit.center.ui.not.passable = 不可通過的

--- a/public/javascripts/SVLabel/css/svl-status.css
+++ b/public/javascripts/SVLabel/css/svl-status.css
@@ -22,7 +22,7 @@
 }
 
 .status-box h1 {
-    font-size: 12pt;
+    font-size: 11pt;
     margin: 0 0 4px 0;
 }
 

--- a/public/javascripts/SVLabel/src/SVLabel/Main.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Main.js
@@ -441,6 +441,7 @@ function Main (params) {
         svl.ui.status.neighborhoodName = $("#status-holder-neighborhood-name");
         svl.ui.status.neighborhoodLink = $("#status-neighborhood-link");
         svl.ui.status.neighborhoodLabelCount = $("#status-neighborhood-label-count");
+        svl.ui.status.currentMissionHeader = $("#current-mission-header");
         svl.ui.status.currentMissionDescription = $("#current-mission-description");
         svl.ui.status.currentMissionReward = $("#current-mission-reward");
         svl.ui.status.totalMissionReward = $("#total-mission-reward");

--- a/public/javascripts/SVLabel/src/SVLabel/status/StatusFieldMission.js
+++ b/public/javascripts/SVLabel/src/SVLabel/status/StatusFieldMission.js
@@ -1,5 +1,6 @@
 function StatusFieldMission (modalModel, uiStatusField) {
     var self = this;
+    var $missionHeader = uiStatusField.holder.find("#current-mission-header");
     var $missionDescription = uiStatusField.holder.find("#current-mission-description");
 
     modalModel.on("ModalMissionComplete:closed", function (param) {
@@ -11,6 +12,13 @@ function StatusFieldMission (modalModel, uiStatusField) {
      * @param mission
      */
     this.setMessage = function (mission) {
+        // Set header first. We just add "Route: <route-number>" if we are on a user-defined route.
+        if (svl.neighborhoodModel.isRoute) {
+            $missionHeader.html(i18next.t('right-ui.current-mission.header-route', { route_number: svl.routeId }));
+        } else {
+            $missionHeader.html(i18next.t('right-ui.current-mission.header'));
+        }
+
         var missionType = mission.getProperty("missionType");
 
         var missionMessage;

--- a/public/locales/de/audit.json
+++ b/public/locales/de/audit.json
@@ -86,6 +86,8 @@
         "accuracy-tooltip": "Die Bewertung Ihrer Genauigkeit basiert auf der Validierung durch andere Nutzende. Wenn Ihre Genauigkeit tief ist, sehen Sie sich häufige Fehler unter <a href=\"/dashboard\" target=\"_blank\" id=\"tooltip-dashboard-link\">Ihrem Dashboard</a> an, um sich zu verbessern!",
         "no-accuracy-tooltip": "Wir benötigen mehr Daten, um Ihre Genauigkeit zu bewerten. Fügen Sie mehr Beschriftungen hinzu und melden Sie sich an, um die Bewertung Ihrer Genauigkeit zu verfolgen!",
         "current-mission": {
+            "header": "Aktuelle Mission",
+            "header-route": "$t(right-ui.current-mission.header): Route {{route_number}}",
             "message-first-mission": "Erkunden Sie __PLACEHOLDER__ und finden Sie alle Zugänglichkeitsmerkmale entlang des Gehwegs",
             "message": "Erkunden Sie __PLACEHOLDER__ von diesem Quartier"
         },

--- a/public/locales/en/audit.json
+++ b/public/locales/en/audit.json
@@ -86,6 +86,8 @@
         "accuracy-tooltip": "Accuracy is based on validations from other users. If your accuracy is low, check out some recent mistakes on <a href=\"/dashboard\" target=\"_blank\" id=\"tooltip-dashboard-link\">your User Dashboard</a> to help you improve!",
         "no-accuracy-tooltip": "We need more data to calculate an accuracy rating for you. Add more labels and sign up to keep track of your accuracy rating!",
         "current-mission": {
+            "header": "Current Mission",
+            "header-route": "$t(right-ui.current-mission.header): Route {{route_number}}",
             "message-first-mission": "Explore for __PLACEHOLDER__ and find all the sidewalk accessibility attributes",
             "message": "Explore __PLACEHOLDER__ of this neighborhood"
         },

--- a/public/locales/es/audit.json
+++ b/public/locales/es/audit.json
@@ -86,6 +86,8 @@
         "accuracy-tooltip": "La precisión se basa en validaciones de otros usuarios. Si su precisión es baja, consulte algunos errores recientes en <a href=\"/dashboard\" target=\"_blank\" id=\"tooltip-dashboard-link\">su panel de usuario</a> para ayudarlo a mejorar.",
         "no-accuracy-tooltip": "Necesitamos más datos para calcular una calificación de precisión para usted. ¡Agregue más etiquetas y regístrese para realizar un seguimiento de su calificación de precisión!",
         "current-mission": {
+            "header": "Misión actual",
+            "header-route": "$t(right-ui.current-mission.header): Ruta {{route_number}}",
             "message-first-mission": "Explora __PLACEHOLDER__ y encuentra todos los atributos de accesibilidad de la banqueta",
             "message": "Explora __PLACEHOLDER__ de este barrio"
         },

--- a/public/locales/nl/audit.json
+++ b/public/locales/nl/audit.json
@@ -86,6 +86,8 @@
         "accuracy-tooltip": "Nauwkeurigheid is gebaseerd op validaties van andere gebruikers. Als uw nauwkeurigheid laag is, bekijk dan enkele recente fouten op <a href=\"/dashboard\" target=\"_blank\" id=\"tooltip-dashboard-link\">uw gebruikersdashboard</a> om u te helpen verbeteren!",
         "no-accuracy-tooltip": "We hebben meer gegevens nodig om een nauwkeurigheidsbeoordeling voor u te berekenen. Voeg meer labels toe en meld u aan om uw nauwkeurigheidsbeoordeling bij te houden!",
         "current-mission": {
+            "header": "Huidige Missie",
+            "header-route": "$t(right-ui.current-mission.header): Route {{route_number}}",
             "message-first-mission": "Zoek voor __PLACEHOLDER__ en vind alle trottoir toegankelijkheidskenmerken",
             "message": "Zoek __PLACEHOLDER__ voor deze wijk"
         },

--- a/public/locales/zh/audit.json
+++ b/public/locales/zh/audit.json
@@ -86,6 +86,8 @@
         "accuracy-tooltip": "精準度是依照其他用戶的檢核。若您的精準度很低，請查看近期檢核出的錯誤於 <a href=\"/dashboard\" target=\"_blank\" id=\"tooltip-dashboard-link\">您的用戶儀表板</a> 以協助您增加精準度！",
         "no-accuracy-tooltip": "我們需要更多的資料以計算您的精準度。請新增更多的標記並註冊帳號以持續追蹤進度及精準度！",
         "current-mission": {
+            "header": "目前任務",
+            "header-route": "$t(right-ui.current-mission.header): 路線{{route_number}}",
             "message-first-mission": "探索__PLACEHOLDER__並找到所有人行道無障礙選項",
             "message": "探索__PLACEHOLDER__ "
         },


### PR DESCRIPTION
Partial resolution to #3272 

Adds the current Route ID in the Explore page sidebar if you're on a user-created route. UI looks the same if you're doing a normal mission.

##### Screenshots
On a route
![Screenshot from 2023-08-09 12-10-37](https://github.com/ProjectSidewalk/SidewalkWebpage/assets/6518824/d45c2f8a-936d-4701-baed-6ede488a1ebb)

Not on a route
![Screenshot from 2023-08-09 12-10-15](https://github.com/ProjectSidewalk/SidewalkWebpage/assets/6518824/57200c47-ba20-46eb-a4b8-fa51251bf970)

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
- [x] I've asked for and included translations for any user facing text that was added or modified.
