### PR TITLE
Updates email SMTP relay address

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -127,7 +127,7 @@ scistarter-api-key = ${?SCISTARTER_API_KEY}
 
 internal-api-key = ${?INTERNAL_API_KEY}
 
-smtp.host="smtp-relay.sendinblue.com"
+smtp.host="smtp-relay.brevo.com"
 smtp.port=587
 smtp.tls=true
 smtp.user=${?SIDEWALK_EMAIL_ADDRESS}


### PR DESCRIPTION
Resolves #3328 

Our email sender is rebranding from "sendinblue" to "brevo", so we needed to update our smtp relay address accordingly. I was actually not able to test this, because pw reset emails still do not work in our dev environment or test servers (#3124). But the change is very straightforward, so I'm not expecting an issue. I'll test after pushing to prod later today to make sure it worked!