### PR TITLE
German translation fixes on Explore mission complete

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
@@ -173,12 +173,12 @@ function ModalMissionComplete (svl, missionContainer, missionModel, taskContaine
 
         // Set mission complete title text differently if user finished their route or the whole neighborhood.
         if (svl.neighborhoodModel.isRouteComplete) {
-            self.setMissionTitle("Bravo! You completed your route!");
+            self.setMissionTitle(i18next.t('mission-complete.title-route-complete'));
             self._canShowContinueButton = true;
         } else if (svl.neighborhoodModel.isNeighborhoodComplete) {
             var neighborhood = svl.neighborhoodContainer.getCurrentNeighborhood();
             var neighborhoodName = neighborhood.getProperty("name");
-            self.setMissionTitle("Bravo! You completed the " + neighborhoodName + " neighborhood!");
+            self.setMissionTitle(i18next.t('mission-complete.title-neighborhood-complete', { neighborhoodName: neighborhoodName }));
             self._canShowContinueButton = true;
         }
 
@@ -293,7 +293,7 @@ function ModalMissionComplete (svl, missionContainer, missionModel, taskContaine
             otherCount = labelCount ? labelCount["Other"] : 0;
 
         var neighborhoodName = neighborhood.getProperty("name");
-        this.setMissionTitle(neighborhoodName + ": " + i18next.t('mission-complete.title'));
+        this.setMissionTitle(neighborhoodName + ": " + i18next.t('mission-complete.title-generic'));
 
         modalMissionCompleteMap.updateStreetSegments(missionTasks, userCompletedTasks, allCompletedTasks, mission.getProperty('missionId'), incompleteTasks);
         modalMissionProgressBar.update(missionDistanceRate, userAuditedDistanceRate, otherAuditedDistanceRate);

--- a/public/locales/de/audit.json
+++ b/public/locales/de/audit.json
@@ -67,7 +67,9 @@
     },
     "mission-complete": {
         "distance-type-display-string": "Kilometer",
-        "title": "Mission erfüllt!",
+        "title-generic": "Mission erfüllt!",
+        "title-neighborhood-complete": "Bravo! Sie haben die {{neighborhoodName}} -Nachbarschaft abgeschlossen!",
+        "title-route-complete": "Bravo! Sie haben Ihre Route beendet!",
         "map-legend-label-other-users": "Missionen anderer Nutzenden",
         "progress-neighborhood-title": "Fortschritt im Quartier",
         "progress-route-title": "Fortschritt auf der Route",

--- a/public/locales/de/audit.json
+++ b/public/locales/de/audit.json
@@ -76,7 +76,7 @@
         "progress-neighborhood-remaining": "Verbleibend in diesem Quartier",
         "progress-route-remaining": "Verbleibend auf Ihrer Route",
         "button-start-validating": "Validierung starten",
-        "button-keep-exploring": "Erkundung fortsetzen",
+        "button-keep-exploring": "Weiter erkunden",
         "button-continue": "Fortsetzen"
     },
     "top-ui": {
@@ -156,7 +156,7 @@
                 "missing-crosswalk": "fehlender Fussgängerstre<tag-underline>i</tag-underline>fen",
                 "no-bus-stop-access": "kein Zugang zur H<tag-underline>a</tag-underline>ltestelle",
                 "height-difference": "Höhenunterschie<tag-underline>d</tag-underline>",
-                "pedestrian-lane-marking": "Fußgängerzahnmark<tag-underline>i</tag-underline>erung",
+                "pedestrian-lane-marking": "Längsstre<tag-underline>i</tag-underline>fen / Gehwegmark<tag-underline>i</tag-underline>erung",
                 "covered-walkway": "überdachter Gehweg (<tag-underline>l</tag-underline>)",
                 "too-close-to-traffic": "zu nah am Verkehr (<tag-underline>t</tag-underline>)",
                 "utility-panel": "Schaltkast<tag-underline>e</tag-underline>n"

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -107,7 +107,7 @@
         "APS": "akustische Orientierungshilfe",
         "missing crosswalk": "fehlender Fussgängerstreifen",
         "no bus stop access": "kein Zugang zur Haltestelle",
-        "pedestrian lane marking": "Fußgängerzahnmarkierung",
+        "pedestrian lane marking": "Längsstreifen / Gehwegmarkierung",
         "covered walkway": "überdachter Gehweg",
         "too close to traffic": "zu nah am Verkehr",
         "utility panel": "Schaltkasten"

--- a/public/locales/en/audit.json
+++ b/public/locales/en/audit.json
@@ -67,7 +67,9 @@
     },
     "mission-complete": {
         "distance-type-display-string": "kilometers",
-        "title": "Mission Complete!",
+        "title-generic": "Mission Complete!",
+        "title-neighborhood-complete": "Bravo! You completed the {{neighborhoodName}} neighborhood!",
+        "title-route-complete": "Bravo! You completed your route!",
         "map-legend-label-other-users": "Other Users' Missions",
         "progress-neighborhood-title": "Neighborhood Progress",
         "progress-route-title": "Route Progress",

--- a/public/locales/es/audit.json
+++ b/public/locales/es/audit.json
@@ -67,7 +67,9 @@
     },
     "mission-complete": {
         "distance-type-display-string": "kilómetros",
-        "title": "¡Misión cumplida!",
+        "title-generic": "¡Misión cumplida!",
+        "title-neighborhood-complete": "¡Bravo! ¡Completaste el vecindario {{neighborhoodName}}!",
+        "title-route-complete": "¡Bravo! ¡Completaste tu ruta!",
         "map-legend-label-other-users": "Misiones de otras",
         "progress-neighborhood-title": "Progreso del barrio",
         "progress-route-title": "Progreso de la ruta",

--- a/public/locales/nl/audit.json
+++ b/public/locales/nl/audit.json
@@ -67,7 +67,9 @@
     },
     "mission-complete": {
         "distance-type-display-string": "kilometers",
-        "title": "Missie geslaagd!",
+        "title-generic": "Missie geslaagd!",
+        "title-neighborhood-complete": "Bravo! Je hebt de {{neighborhoodName}} -buurt voltooid!",
+        "title-route-complete": "Bravo! Je hebt je route voltooid!",
         "map-legend-label-other-users": "Missies Van Anderen",
         "progress-neighborhood-title": "Wijk voortgang",
         "progress-route-title": "Routevoortgang",

--- a/public/locales/zh-TW/audit.json
+++ b/public/locales/zh-TW/audit.json
@@ -67,7 +67,9 @@
     },
     "mission-complete": {
         "distance-type-display-string": "公里",
-        "title": "任務完成！",
+        "title-generic": "任務完成！",
+        "title-neighborhood-complete": "勇敢！您完成了{{neighborhoodName}}社區！",
+        "title-route-complete": "勇敢！您完成了路線！",
         "map-legend-label-other-users": "其他標記者的任務",
         "progress-neighborhood-title": "鄰里進度",
         "progress-route-title": "路線進度",


### PR DESCRIPTION
Resolves (partially) #3351 

Updates some German translations so that they fit better on the mission complete map on the Explore page. Also added translations in all languages for the mission complete titles for completing a route or a neighborhood.

#3351 Also asks us to add a new tag in Zurich. I'm going to do that in a separate PR so that I have an example to give to interns for how we add new tags that doesn't have other things mixed in to the PR.

##### Before/After screenshots
Before
![Screenshot from 2023-08-14 12-15-10](https://github.com/ProjectSidewalk/SidewalkWebpage/assets/6518824/f0481527-4f8b-4985-ad78-a2e1561174c0)

After
![Screenshot from 2023-08-14 12-29-25](https://github.com/ProjectSidewalk/SidewalkWebpage/assets/6518824/064a9f37-4a58-4b0e-bc80-bd315ed796b0)

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've included before/after screenshots above.
- [x] I've asked for and included translations for any user facing text that was added or modified.
