### PR TITLE
3351 add outdoor dining area tag

### DIFF
--- a/conf/evolutions/default/198.sql
+++ b/conf/evolutions/default/198.sql
@@ -1,0 +1,14 @@
+# --- !Ups
+INSERT INTO tag (tag_id, label_type_id, tag) SELECT 65, label_type_id, 'outdoor dining area' FROM label_type WHERE label_type.label_type = 'Obstacle';
+
+UPDATE config SET excluded_tags = REPLACE(excluded_tags, '"]', '" "outdoor dining area"]') WHERE current_database() != 'sidewalk-zurich';
+
+# --- !Downs
+UPDATE config SET excluded_tags = REPLACE(excluded_tags, ' "outdoor dining area"', '');
+
+DELETE FROM label_tag
+USING tag, label_type
+WHERE label_tag.tag_id = tag.tag_id
+    AND tag.label_type_id = label_type.label_type_id
+    AND label_type.label_type = 'Obstacle'
+    AND tag.tag IN ('outdoor dining area');

--- a/conf/evolutions/default/198.sql
+++ b/conf/evolutions/default/198.sql
@@ -12,3 +12,9 @@ WHERE label_tag.tag_id = tag.tag_id
     AND tag.label_type_id = label_type.label_type_id
     AND label_type.label_type = 'Obstacle'
     AND tag.tag IN ('outdoor dining area');
+
+DELETE FROM tag
+    USING label_type
+WHERE tag.label_type_id = label_type.label_type_id
+  AND label_type.label_type = 'Obstacle'
+  AND tag.tag IN ('outdoor dining area');

--- a/public/javascripts/common/UtilitiesSidewalk.js
+++ b/public/javascripts/common/UtilitiesSidewalk.js
@@ -196,6 +196,10 @@ function UtilitiesMisc (JSON) {
                     'parked scooter/motorcycle': {
                         keyChar: 'Y',
                         text: i18next.t('center-ui.context-menu.tag.parked-scooter-motorcycle')
+                    },
+                    'outdoor dining area': {
+                        keyChar: 'Q',
+                        text: i18next.t('center-ui.context-menu.tag.outdoor-dining-area')
                     }
                 }
             },

--- a/public/locales/de/audit.json
+++ b/public/locales/de/audit.json
@@ -161,7 +161,8 @@
                 "pedestrian-lane-marking": "Längsstre<tag-underline>i</tag-underline>fen / Gehwegmark<tag-underline>i</tag-underline>erung",
                 "covered-walkway": "überdachter Gehweg (<tag-underline>l</tag-underline>)",
                 "too-close-to-traffic": "zu nah am Verkehr (<tag-underline>t</tag-underline>)",
-                "utility-panel": "Schaltkast<tag-underline>e</tag-underline>n"
+                "utility-panel": "Schaltkast<tag-underline>e</tag-underline>n",
+                "outdoor-dining-area": "Aussenbereich Gastronomie (<tag-underline>q</tag-underline>)"
             },
             "tooltip": {
                 "passable": "Passierbar",

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -110,7 +110,8 @@
         "pedestrian lane marking": "Längsstreifen / Gehwegmarkierung",
         "covered walkway": "überdachter Gehweg",
         "too close to traffic": "zu nah am Verkehr",
-        "utility panel": "Schaltkasten"
+        "utility panel": "Schaltkasten",
+        "outdoor dining area": "Aussenbereich Gastronomie"
     },
     "gsv-info": {
         "details-title": "Details",

--- a/public/locales/en/audit.json
+++ b/public/locales/en/audit.json
@@ -161,7 +161,8 @@
                 "pedestrian-lane-marking": "pedestr<tag-underline>i</tag-underline>an lane marking",
                 "covered-walkway": "covered wa<tag-underline>l</tag-underline>kway",
                 "too-close-to-traffic": "too close to <tag-underline>t</tag-underline>raffic",
-                "utility-panel": "utility pan<tag-underline>e</tag-underline>l"
+                "utility-panel": "utility pan<tag-underline>e</tag-underline>l",
+                "outdoor-dining-area": "outdoor dining area (<tag-underline>q</tag-underline>)"
             },
             "tooltip": {
                 "passable": "Passable",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -110,7 +110,8 @@
         "pedestrian lane marking": "pedestrian lane marking",
         "covered walkway": "covered walkway",
         "too close to traffic": "too close to traffic",
-        "utility panel": "utility panel"
+        "utility panel": "utility panel",
+        "outdoor dining area": "outdoor dining area"
     },
     "gsv-info": {
         "details-title": "Details",

--- a/public/locales/es/audit.json
+++ b/public/locales/es/audit.json
@@ -161,7 +161,8 @@
                 "pedestrian-lane-marking": "marcado de carr<tag-underline>i</tag-underline>l peatonal",
                 "covered-walkway": "pasare<tag-underline>l</tag-underline>a cubierta",
                 "too-close-to-traffic": "demasiado cerca del <tag-underline>t</tag-underline>ráfico",
-                "utility-panel": "pan<tag-underline>e</tag-underline>l de utilidad"
+                "utility-panel": "pan<tag-underline>e</tag-underline>l de utilidad",
+                "outdoor-dining-area": "comedor al aire libre (<tag-underline>q</tag-underline>)"
             },
             "tooltip": {
                 "passable": "Transitable",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -110,7 +110,8 @@
         "pedestrian lane marking": "marcado de carril peatonal",
         "covered walkway": "pasarela cubierta",
         "too close to traffic": "demasiado cerca del tráfico",
-        "utility panel": "panel de utilidad"
+        "utility panel": "panel de utilidad",
+        "outdoor dining area": "comedor al aire libre"
     },
     "gsv-info": {
         "details-title": "Detalles",

--- a/public/locales/nl/audit.json
+++ b/public/locales/nl/audit.json
@@ -161,7 +161,8 @@
                 "pedestrian-lane-marking": "voetgangersstrookmarker<tag-underline>i</tag-underline>ng",
                 "covered-walkway": "Overdekte <tag-underline>l</tag-underline>oopbrug",
                 "too-close-to-traffic": "<tag-underline>t</tag-underline>e dicht bij het verkeer",
-                "utility-panel": "hulpprogramma pan<tag-underline>e</tag-underline>el"
+                "utility-panel": "hulpprogramma pan<tag-underline>e</tag-underline>el",
+                "outdoor-dining-area": "buiten eetgedeelte (<tag-underline>q</tag-underline>)"
             },
             "tooltip": {
                 "passable": "Begaanbaar",

--- a/public/locales/nl/common.json
+++ b/public/locales/nl/common.json
@@ -110,7 +110,8 @@
         "pedestrian lane marking": "voetgangersstrookmarkering",
         "covered walkway": "Overdekte loopbrug",
         "too close to traffic": "te dicht bij het verkeer",
-        "utility panel": "hulpprogramma paneel"
+        "utility panel": "hulpprogramma paneel",
+        "outdoor dining area": "buiten eetgedeelte"
     },
     "gsv-info": {
         "details-title": "Details",

--- a/public/locales/zh-TW/audit.json
+++ b/public/locales/zh-TW/audit.json
@@ -161,7 +161,8 @@
                 "pedestrian-lane-marking": "行人車道標記(<tag-underline>i</tag-underline>)",
                 "covered-walkway": "有蓋的人行道(<tag-underline>l</tag-underline>)",
                 "too-close-to-traffic": "離車流太近(<tag-underline>t</tag-underline>)",
-                "utility-panel": "公用設施面板(<tag-underline>e</tag-underline>)"
+                "utility-panel": "公用設施面板(<tag-underline>e</tag-underline>)",
+                "outdoor-dining-area": "戶外用餐區(<tag-underline>q</tag-underline>)"
             },
             "tooltip": {
                 "passable": "可通行的",

--- a/public/locales/zh-TW/common.json
+++ b/public/locales/zh-TW/common.json
@@ -110,7 +110,8 @@
         "pedestrian lane marking": "行人車道標記",
         "covered walkway": "有蓋的人行道",
         "too close to traffic": "離車流太近",
-        "utility panel": "公用設施面板"
+        "utility panel": "公用設施面板",
+        "outdoor dining area": "戶外用餐區"
     },
     "gsv-info": {
         "details-title": "詳細資訊",


### PR DESCRIPTION
Resolves #3351 

Adds "outdoor dining area" tag in Zurich only. Unfortunately, we have run out of any sensible keyboard shortcuts for the tags, so this one just has the letter Q :+1: 

##### Before/After screenshots
Before
![Screenshot from 2023-08-14 13-20-16](https://github.com/ProjectSidewalk/SidewalkWebpage/assets/6518824/9cb7e735-4e82-4fac-b25d-9cea79588e83)

After
![Screenshot from 2023-08-14 13-12-25](https://github.com/ProjectSidewalk/SidewalkWebpage/assets/6518824/855ffb13-842e-40ce-b603-bd9f4f6405af)

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've asked for and included translations for any user facing text that was added or modified.
