### PR TITLE
Adds "parallel lines" tag for Curb Ramps in Burnaby

### DIFF
--- a/conf/evolutions/default/199.sql
+++ b/conf/evolutions/default/199.sql
@@ -1,0 +1,20 @@
+# --- !Ups
+INSERT INTO tag (tag_id, label_type_id, tag) SELECT 66, label_type_id, 'parallel lines' FROM label_type WHERE label_type.label_type = 'CurbRamp';
+
+UPDATE config SET excluded_tags = REPLACE(excluded_tags, '"]', '" "parallel lines"]') WHERE current_database() != 'sidewalk-burnaby';
+
+# --- !Downs
+UPDATE config SET excluded_tags = REPLACE(excluded_tags, ' "parallel lines"', '');
+
+DELETE FROM label_tag
+USING tag, label_type
+WHERE label_tag.tag_id = tag.tag_id
+    AND tag.label_type_id = label_type.label_type_id
+    AND label_type.label_type = 'CurbRamp'
+    AND tag.tag IN ('parallel lines');
+
+DELETE FROM tag
+    USING label_type
+WHERE tag.label_type_id = label_type.label_type_id
+  AND label_type.label_type = 'CurbRamp'
+  AND tag.tag IN ('parallel lines');

--- a/public/javascripts/common/UtilitiesSidewalk.js
+++ b/public/javascripts/common/UtilitiesSidewalk.js
@@ -108,6 +108,10 @@ function UtilitiesMisc (JSON) {
                     'pooled water': {
                         keyChar: 'D',
                         text: i18next.t('center-ui.context-menu.tag.pooled-water')
+                    },
+                    'parallel lines': {
+                        keyChar: 'J',
+                        text: i18next.t('center-ui.context-menu.tag.parallel-lines')
                     }
                 }
             },

--- a/public/locales/de/audit.json
+++ b/public/locales/de/audit.json
@@ -115,6 +115,7 @@
                 "not-level-with-street": "nicht auf dem selben Ni<tag-underline>v</tag-underline>eau wie Strasse",
                 "surface-problem": "Obe<tag-underline>r</tag-underline>flächenproblem",
                 "pooled-water": "Wasserpfütze (<tag-underline>d</tag-underline>)",
+                "parallel-lines": "parallele Linien (<tag-underline>j</tag-underline>)",
                 "alternate-route-present": "<tag-underline>a</tag-underline>lternative Route vorhanden",
                 "no-alternate-route": "keine a<tag-underline>l</tag-underline>ternative Route vorhanden",
                 "unclear-if-needed": "<tag-underline>u</tag-underline>nklar ob notwendig",

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -63,6 +63,7 @@
         "not level with street": "nicht auf dem selben Niveau wie Strasse",
         "surface problem": "Oberflächenproblem",
         "pooled water": "Wasserpfütze",
+        "parallel lines": "parallele Linien",
         "alternate route present": "alternative Route vorhanden",
         "no alternate route": "keine alternative Route vorhanden",
         "unclear if needed": "unklar ob notwendig",

--- a/public/locales/en/audit.json
+++ b/public/locales/en/audit.json
@@ -115,6 +115,7 @@
                 "not-level-with-street": "not le<tag-underline>v</tag-underline>el with street",
                 "surface-problem": "su<tag-underline>r</tag-underline>face problem",
                 "pooled-water": "poole<tag-underline>d</tag-underline> water",
+                "parallel-lines": "parallel lines (<tag-underline>j</tag-underline>)",
                 "alternate-route-present": "<tag-underline>a</tag-underline>lternate route present",
                 "no-alternate-route": "no a<tag-underline>l</tag-underline>ternate route",
                 "unclear-if-needed": "<tag-underline>u</tag-underline>nclear if needed",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -63,6 +63,7 @@
         "not level with street": "not level with street",
         "surface problem": "surface problem",
         "pooled water": "pooled water",
+        "parallel lines": "parallel lines",
         "alternate route present": "alternate route present",
         "no alternate route": "no alternate route",
         "unclear if needed": "unclear if needed",

--- a/public/locales/es/audit.json
+++ b/public/locales/es/audit.json
@@ -115,6 +115,7 @@
                 "not-level-with-street": "con desni<tag-underline>v</tag-underline>el",
                 "surface-problem": "problema en supe<tag-underline>r</tag-underline>ficie",
                 "pooled-water": "encharca<tag-underline>d</tag-underline>a",
+                "parallel-lines": "lineas paralelas (<tag-underline>j</tag-underline>)",
                 "alternate-route-present": "hay una ruta <tag-underline>a</tag-underline>lternativa segura para cruzar",
                 "no-alternate-route": "no hay una ruta a<tag-underline>l</tag-underline>ternativa para cruzar",
                 "unclear-if-needed": "poco claro si es necesario (<tag-underline>u</tag-underline>)",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -63,6 +63,7 @@
         "not level with street": "con desnivel",
         "surface-problem": "problema en superficie",
         "pooled water": "encharcada",
+        "parallel lines": "lineas paralelas",
         "alternate route present": "hay una ruta alternativa segura para cruzar",
         "no alternate route": "no hay una ruta alternativa para cruzar",
         "unclear if needed": "poco claro si es necesario",

--- a/public/locales/nl/audit.json
+++ b/public/locales/nl/audit.json
@@ -115,6 +115,7 @@
                 "not-level-with-street": "niet zelfde ni<tag-underline>v</tag-underline>eau met straat",
                 "surface-problem": "oppervlakte p<tag-underline>r</tag-underline>obleem",
                 "pooled-water": "gepool<tag-underline>d</tag-underline> water",
+                "parallel-lines": "parallelle li<tag-underline>j</tag-underline>nen",
                 "alternate-route-present": "<tag-underline>a</tag-underline>lternatieve route aanwezig",
                 "no-alternate-route": "geen a<tag-underline>l</tag-underline>ternatieve route",
                 "unclear-if-needed": "ond<tag-underline>u</tag-underline>idelijk of het nodig is",

--- a/public/locales/nl/common.json
+++ b/public/locales/nl/common.json
@@ -63,6 +63,7 @@
         "not level with street": "niet zelfde niveau met straat",
         "surface-problem": "oppervlakte probleem",
         "pooled water": "gepoold water",
+        "parallel lines": "parallelle lijnen",
         "alternate route present": "alternatieve route aanwezig",
         "no alternate route": "geen alternatieve route",
         "unclear if needed": "onduidelijk of het nodig is",

--- a/public/locales/zh-TW/audit.json
+++ b/public/locales/zh-TW/audit.json
@@ -115,6 +115,7 @@
                 "not-level-with-street": "與街道高度未齊平(<tag-underline>v</tag-underline>)",
                 "surface-problem": "鋪面問題(<tag-underline>r</tag-underline>)",
                 "pooled-water": "積水(<tag-underline>d</tag-underline>)",
+                "parallel-lines": "平行線(<tag-underline>j</tag-underline>)",
                 "alternate-route-present": "有替代路徑(<tag-underline>a</tag-underline>)",
                 "no-alternate-route": "無替代路徑(<tag-underline>l</tag-underline>)",
                 "unclear-if-needed": "不確定是否需要(<tag-underline>u</tag-underline>)",

--- a/public/locales/zh-TW/common.json
+++ b/public/locales/zh-TW/common.json
@@ -63,6 +63,7 @@
         "not level with street": "與街道高度未切齊",
         "surface problem": "鋪面問題",
         "pooled water": "積水",
+        "parallel lines": "平行線",
         "alternate route present": "有替代路徑",
         "no alternate route": "無替代路徑",
         "unclear if needed": "不確定是否需要",


### PR DESCRIPTION
Resolves #3363 

Adds a new tag called "parallel lines" (working title) to the Curb Ramp label type for the Burnaby server only. Screenshot below of the thing we are trying to tag with this label type. It's a type of tactile warning.
![Tactile on curbramps](https://github.com/ProjectSidewalk/SidewalkWebpage/assets/6518824/9a6df6c9-85b6-4ec1-b78a-6da88e8e782a)

##### Before/After screenshots
Before
![Screenshot from 2023-08-14 16-40-35](https://github.com/ProjectSidewalk/SidewalkWebpage/assets/6518824/847310f2-e611-4951-9e5e-f6558e846371)

After
![Screenshot from 2023-08-14 16-39-56](https://github.com/ProjectSidewalk/SidewalkWebpage/assets/6518824/91cc0fb2-c973-4185-bd2e-79a5ec06f261)

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've included before/after screenshots above.
- [x] I've asked for and included translations for any user facing text that was added or modified.