### PR TITLE
Crowstudy server: disables survey, updates mission complete buttons

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/mission/MissionProgress.js
+++ b/public/javascripts/SVLabel/src/SVLabel/mission/MissionProgress.js
@@ -97,6 +97,7 @@ function MissionProgress(svl, missionModel, modalModel, neighborhoodModel, statu
         // 1. User has completed numMissionsBeforeSurvey number of missions
         // 2. The user has just completed more than 60% of the current mission
         // 3. The user has not been shown the survey before
+        // 4. They are not on the crowdstudy server that has pre- and post-study questionnaires.
         if (completionRate > 0.6 && completionRate < 0.9) {
             $.ajax({
                 async: true,

--- a/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
+++ b/public/javascripts/SVLabel/src/SVLabel/modal/ModalMissionComplete.js
@@ -185,10 +185,11 @@ function ModalMissionComplete (svl, missionContainer, missionModel, taskContaine
         // If the user just completed their first audit mission ever (and they aren't a turker) or they finished their
         // third in a row, make the primary button they see a 'Start validating' button. If they are not a turker, then
         // also show a secondary button that lets them continue auditing. On any other mission just show a 'Continue'
-        // button that has them audit more.
+        // button that has them audit more. If we are on the crowdstudy server: don't show any buttons if they finished
+        // their route, otherwise show a 'Continue' button.
         var isTurker = self._userModel.getUser().getProperty("role") === "Turker";
         var firstMission = !svl.userHasCompletedAMission && svl.missionsCompleted === 1;
-        if ((!isTurker && firstMission) || svl.missionsCompleted % 3 === 0 || svl.neighborhoodModel.isRouteOrNeighborhoodComplete()) {
+        if (svl.cityId !== 'crowdstudy' && ((!isTurker && firstMission) || svl.missionsCompleted % 3 === 0 || svl.neighborhoodModel.isRouteOrNeighborhoodComplete())) {
             uiModalMissionComplete.closeButtonPrimary.html(i18next.t('mission-complete.button-start-validating'));
             this._status.primaryAction = 'validate';
 
@@ -206,6 +207,9 @@ function ModalMissionComplete (svl, missionContainer, missionModel, taskContaine
                     this._status.secondaryAction = 'explore';
                 }
             }
+        } else if (svl.cityId === 'crowdstudy' && svl.neighborhoodModel.isRouteComplete) {
+            uiModalMissionComplete.closeButtonPrimary.css('visibility', "hidden");
+            uiModalMissionComplete.closeButtonSecondary.css('visibility', "hidden");
         } else {
             uiModalMissionComplete.closeButtonPrimary.css('width', "100%");
             uiModalMissionComplete.closeButtonPrimary.html(i18next.t('mission-complete.button-continue'));


### PR DESCRIPTION
Resolves #3357 
Resolves #3356 

On the crowdstudy server (where we are using the prediction model), the survey on the Explore page is now disabled (since we have similar pre- and post- study survey questions in person. This also updates the Explore page mission complete buttons to always show "Continue" instead of "Keep exploring" and "Start validating", and now buttons are shown when the user finishes their route.

Here's the look when they finish their route:
![Screenshot from 2023-08-15 12-18-02](https://github.com/ProjectSidewalk/SidewalkWebpage/assets/6518824/ec825947-16f9-4ad4-b417-1d7a822d3635)

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
