### PR TITLE
Fixing zooming bugs on Validate

### DIFF
--- a/public/javascripts/Admin/src/Admin.GSVLabelView.js
+++ b/public/javascripts/Admin/src/Admin.GSVLabelView.js
@@ -212,10 +212,9 @@ function AdminGSVLabelView(admin, source) {
 
         // This is the POV of the viewport center - this is where the user is looking.
         var userPov = self.panorama.panorama.getPov();
-        var zoom = self.panorama.panorama.getZoom();
 
         // Calculates the center xy coordinates of the kabel on the current viewport.
-        var pixelCoordinates = self.panoProp.povToPixel3d(panomarkerPov, userPov, zoom, canvasWidth, canvasHeight);
+        var pixelCoordinates = self.panoProp.povToPixel3d(panomarkerPov, userPov, canvasWidth, canvasHeight);
 
         // If the user has panned away from the label and it is no longer visible on the canvas, set canvasX/Y to null.
         // We add/subtract the radius of the label so that we still record these values when only a fraction of the
@@ -322,7 +321,6 @@ function AdminGSVLabelView(admin, source) {
      */
     function _submitComment(comment) {
         var userPov = self.panorama.panorama.getPov();
-        var zoom = self.panorama.panorama.getZoom();
         var pos = self.panorama.panorama.getPosition();
         var button = document.getElementById("comment-button");
 
@@ -335,7 +333,7 @@ function AdminGSVLabelView(admin, source) {
             gsv_panorama_id: self.panorama.panoId,
             heading: userPov.heading,
             pitch: userPov.pitch,
-            zoom: zoom,
+            zoom: userPov.zoom,
             lat: pos.lat(),
             lng: pos.lng()
         };

--- a/public/javascripts/SVValidate/src/label/Label.js
+++ b/public/javascripts/SVValidate/src/label/Label.js
@@ -229,11 +229,9 @@ function Label(params) {
 
         // This is the POV of the viewport center - this is where the user is looking.
         let userPov = svv.panorama.getPov();
-        let zoom = svv.panorama.getZoom();
 
         // Calculates the center xy coordinates of the Label on the current viewport.
-        let pixelCoordinates = svv.util.properties.panorama.povToPixel3d(panomarkerPov, userPov,
-            zoom, svv.canvasWidth, svv.canvasHeight);
+        let pixelCoordinates = svv.util.properties.panorama.povToPixel3d(panomarkerPov, userPov, svv.canvasWidth, svv.canvasHeight);
 
         // If the user has panned away from the label and it is no longer visible on the canvas, set canvasX/Y to null.
         // We add/subtract the radius of the label so that we still record these values when only a fraction of the

--- a/public/javascripts/SVValidate/src/panorama/Panorama.js
+++ b/public/javascripts/SVValidate/src/panorama/Panorama.js
@@ -149,14 +149,6 @@ function Panorama (label) {
     }
 
     /**
-     * Returns the zoom level of this panorama.
-     * @returns Zoom level from {1.1, 2.1, 3.1}
-     */
-    function getZoom() {
-        return panorama.getZoom();
-    }
-
-    /**
      * Gets a specific property from this Panorama.
      * @param key   Property name.
      * @returns     Value associated with this property or null.
@@ -363,7 +355,6 @@ function Panorama (label) {
     self.getPosition = getPosition;
     self.getProperty = getProperty;
     self.getPov = getPov;
-    self.getZoom = getZoom;
     self.getPanomarker = getPanomarker;
     self.renderLabel = renderLabel;
     self.setLabel = setLabel;

--- a/public/javascripts/SVValidate/src/util/PanoProperties.js
+++ b/public/javascripts/SVValidate/src/util/PanoProperties.js
@@ -81,13 +81,12 @@ function PanoProperties () {
      * @param {StreetViewPov} targetPov The point-of-view whose coordinates are
      *     requested.
      * @param {StreetViewPov} currentPov POV of the viewport center.
-     * @param {number} zoom The current zoom level.
      * @param {number} canvasWidth of the panorama canvas.
      * @param {number} canvasHeight of the panorama canvas.
      * @return {Object} Top and Left offsets for the given viewport that point to
      *     the desired point-of-view.
      */
-    function povToPixel3d(targetPov, currentPov, zoom, canvasWidth, canvasHeight) {
+    function povToPixel3d(targetPov, currentPov, canvasWidth, canvasHeight) {
 
         // Gather required variables and convert to radians where necessary.
         let width = canvasWidth;
@@ -105,7 +104,7 @@ function PanoProperties () {
         };
 
         let DEG_TO_RAD = Math.PI / 180.0;
-        let fov = _get3dFov(zoom) * DEG_TO_RAD;
+        let fov = _get3dFov(currentPov.zoom) * DEG_TO_RAD;
         let h0 = currentPov.heading * DEG_TO_RAD;
         let p0 = currentPov.pitch * DEG_TO_RAD;
         let h = targetPov.heading * DEG_TO_RAD;

--- a/public/javascripts/SVValidate/src/zoom/PinchZoomDetector.js
+++ b/public/javascripts/SVValidate/src/zoom/PinchZoomDetector.js
@@ -34,7 +34,7 @@ function PinchZoomDetector () {
      */
     function processTouchstart (e) {
         if (e.touches.length >= 2) {
-            prevZoomLevel = svv.panorama.getZoom();
+            prevZoomLevel = svv.panorama.getPov().zoom;
             pinchZooming = true;
             pinchZoomCode = ZOOM_UNKNOWN_CODE;
         }
@@ -45,7 +45,7 @@ function PinchZoomDetector () {
      * @private
      */
     function processZoomChange () {
-        let currentZoom = svv.panorama.getZoom();
+        let currentZoom = svv.panorama.getPov().zoom;
         // Logs interaction only if a user is pinch zooming and current zoom is less than max zoom.
         if (pinchZooming && currentZoom <= 4) {
             let zoomChange = currentZoom - prevZoomLevel;

--- a/public/javascripts/SVValidate/src/zoom/ZoomControl.js
+++ b/public/javascripts/SVValidate/src/zoom/ZoomControl.js
@@ -31,7 +31,7 @@ function ZoomControl () {
      * Zoom levels: {1, 2, 3}
      */
     function zoomIn () {
-        let zoomLevel = svv.panorama.getZoom();
+        let zoomLevel = svv.panorama.getPov().zoom;
         if (zoomLevel <= 2) {
             zoomLevel += 1;
             svv.panorama.setZoom(zoomLevel);
@@ -45,7 +45,7 @@ function ZoomControl () {
      * Zoom levels: {1, 2, 3}
      */
     function zoomOut () {
-        let zoomLevel = svv.panorama.getZoom();
+        let zoomLevel = svv.panorama.getPov().zoom;
         if (zoomLevel >= 2) {
             zoomLevel -= 1;
             svv.panorama.setZoom(zoomLevel);
@@ -60,7 +60,7 @@ function ZoomControl () {
      * Zoom levels: { 1 (Zoom-out Disabled), 2 (Both buttons enabled), 3 (Zoom-In Disabled) }
      */
     function updateZoomAvailability() {
-        let zoomLevel = svv.panorama.getZoom();
+        let zoomLevel = svv.panorama.getPov().zoom;
         if (zoomLevel >= 3) {
             zoomInButton.css('opacity', 0.5);
             zoomInButton.addClass('disabled');

--- a/public/javascripts/SVValidate/src/zoom/ZoomControl.js
+++ b/public/javascripts/SVValidate/src/zoom/ZoomControl.js
@@ -28,11 +28,11 @@ function ZoomControl () {
     /**
      * Increases zoom for the Google StreetView Panorama and checks if 'Zoom In' button needs
      * to be disabled.
-     * Zoom levels: {1.1, 2.1, 3.1}
+     * Zoom levels: {1, 2, 3}
      */
     function zoomIn () {
         let zoomLevel = svv.panorama.getZoom();
-        if (zoomLevel <= 2.1) {
+        if (zoomLevel <= 2) {
             zoomLevel += 1;
             svv.panorama.setZoom(zoomLevel);
         }
@@ -42,11 +42,11 @@ function ZoomControl () {
     /**
      * Decreases zoom for the Google StreetView Panorama and checks if 'Zoom Out' button needs
      * to be disabled.
-     * Zoom levels: {1.1, 2.1, 3.1}
+     * Zoom levels: {1, 2, 3}
      */
     function zoomOut () {
         let zoomLevel = svv.panorama.getZoom();
-        if (zoomLevel >= 2.1) {
+        if (zoomLevel >= 2) {
             zoomLevel -= 1;
             svv.panorama.setZoom(zoomLevel);
         }
@@ -57,15 +57,16 @@ function ZoomControl () {
      * Changes the opacity and enables/disables the zoom buttons depending on the 'zoom level'. It
      * disables and 'greys-out' the zoom in button in the most zoomed in state and the zoom out
      * button in the most zoomed out state.
-     * Zoom levels: {1.1(Zoom-out Disabled), 2.1(Both buttons enabled), 3.1(Zoom-In Disabled)}
+     * Zoom levels: { 1 (Zoom-out Disabled), 2 (Both buttons enabled), 3 (Zoom-In Disabled) }
      */
     function updateZoomAvailability() {
-        if (svv.panorama.getZoom() >= 3.1) {
+        let zoomLevel = svv.panorama.getZoom();
+        if (zoomLevel >= 3) {
             zoomInButton.css('opacity', 0.5);
             zoomInButton.addClass('disabled');
             zoomOutButton.css('opacity', 1);
             zoomOutButton.removeClass('disabled');
-        } else if (svv.panorama.getZoom() <= 1.1) {
+        } else if (zoomLevel <= 1) {
             zoomOutButton.css('opacity', 0.5);
             zoomOutButton.addClass('disabled');
             zoomInButton.css('opacity', 1);

--- a/public/javascripts/common/Panomarker.js
+++ b/public/javascripts/common/Panomarker.js
@@ -220,12 +220,11 @@
      * @param {StreetViewPov} targetPov The point-of-view whose coordinates are
      *     requested.
      * @param {StreetViewPov} currentPov POV of the viewport center.
-     * @param {number} zoom The current zoom level.
      * @param {Element} viewport The current viewport containing the panorama.
      * @return {Object} Top and Left offsets for the given viewport that point to
      *     the desired point-of-view.
      */
-    PanoMarker.povToPixel3d = function(targetPov, currentPov, zoom, viewport) {
+    PanoMarker.povToPixel3d = function(targetPov, currentPov, viewport) {
 
         // Gather required variables and convert to radians where necessary
         var width = viewport.offsetWidth;
@@ -237,7 +236,7 @@
         };
 
         var DEG_TO_RAD = Math.PI / 180.0;
-        var fov = PanoMarker.get3dFov(zoom) * DEG_TO_RAD;
+        var fov = PanoMarker.get3dFov(currentPov.zoom) * DEG_TO_RAD;
         var h0 = currentPov.heading * DEG_TO_RAD;
         var p0 = currentPov.pitch * DEG_TO_RAD;
         var h = targetPov.heading * DEG_TO_RAD;
@@ -354,12 +353,11 @@
      * @param {StreetViewPov} targetPov The point-of-view whose coordinates are
      *     requested.
      * @param {StreetViewPov} currentPov POV of the viewport center.
-     * @param {number} zoom The current zoom level.
      * @param {Element} viewport The current viewport containing the panorama.
      * @return {Object} Top and Left offsets for the given viewport that point to
      *     the desired point-of-view.
      */
-    PanoMarker.povToPixel2d = function(targetPov, currentPov, zoom, viewport) {
+    PanoMarker.povToPixel2d = function(targetPov, currentPov, viewport) {
         // Gather required variables
         var width = viewport.offsetWidth;
         var height = viewport.offsetHeight;
@@ -370,7 +368,7 @@
         };
 
         // In the 2D environment, the FOV follows the documented curve.
-        var hfov = 180 / Math.pow(2, zoom);
+        var hfov = 180 / Math.pow(2, currentPov.zoom);
         var vfov = hfov * (height / width);
         var dh = PanoMarker.wrapHeading(targetPov.heading - currentPov.heading);
         var dv = targetPov.pitch - currentPov.pitch;
@@ -496,7 +494,6 @@
         // panorama container, we pass it on as the viewport because it has the actual viewport dimensions.
         var offset = this.povToPixel_(this.position_,
             this.pano_.getPov(),
-            typeof this.pano_.getZoom() !== 'undefined' ? this.pano_.getZoom() : 1,
             this.container_);
         if (this.marker_) {
             if (offset !== null) {


### PR DESCRIPTION
Fixes #3309 

Fixes some zooming bugs on the Validate page. I believe that Google must have changed the underlying API at some point without documenting it... The crux of the issue is that there is a `getZoom()` function for the `StreetViewService` object that can return the wrong zoom level if the zoom level was set using the `setPov()` function. However the `getPov()` function always returns the correct zoom level, so I've replaced all uses of `getZoom()` with `getPov().zoom`!

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've tested on mobile (only needed for validation page).
