### PR TITLE
Fixed neighborhood name commas breaking csv formatting

### DIFF
--- a/app/controllers/ProjectSidewalkAPIController.scala
+++ b/app/controllers/ProjectSidewalkAPIController.scala
@@ -147,7 +147,9 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
       writer.println(header)
       // Write each row in the CSV.
       for (current <- GlobalAttributeTable.getGlobalAttributesWithLabelsInBoundingBox(minLat, minLng, maxLat, maxLng, severity)) {
-        writer.println(current.attributesToArray.mkString(","))
+        val rowArr: Array[String] = current.attributesToArray
+        rowArr(6) = "\"" + rowArr(6) + "\""
+        writer.println(rowArr.mkString(","))
       }
       writer.close()
       Future.successful(Ok.sendFile(content = file, onClose = () => file.delete()))
@@ -214,7 +216,10 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
       writer.println("Attribute ID,Label Type,Street ID,OSM Street ID,Neighborhood Name,Attribute Latitude,Attribute Longitude,Avg Image Capture Date,Avg Label Date,Severity,Temporary,Agree Count,Disagree Count,Not Sure Count,Cluster Size,User IDs")
       // Write each row in the CSV.
       for (current <- GlobalAttributeTable.getGlobalAttributesInBoundingBox(minLat, minLng, maxLat, maxLng, severity)) {
-        writer.println(current.attributesToArray.mkString(","))
+        // Add double quotes around Neighborhood Name in case of comma in name
+        val rowArr: Array[Any] = current.attributesToArray
+        rowArr(4) = "\"" + rowArr(4) + "\""
+        writer.println(rowArr.mkString(","))
       }
       writer.close()
       Future.successful(Ok.sendFile(content = accessAttributesfile, onClose = () => accessAttributesfile.delete()))
@@ -364,14 +369,14 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
       val coordinates: Array[Coordinate] = geom.getCoordinates
       val coordStr: String = "\"[" + coordinates.map(c => "(" + c.x + "," + c.y + ")").mkString(",") + "]\""
       if (region.coverage > 0.0D) {
-        writer.println(region.name + "," + region.regionID + "," + region.score + "," + coordStr + "," +
+        writer.println("\"" + region.name + "\"," + region.regionID + "," + region.score + "," + coordStr + "," +
           region.coverage + "," + region.attributeScores(0) + "," + region.attributeScores(1) + "," +
           region.attributeScores(2) + "," + region.attributeScores(3) + "," + region.significanceScores(0) + "," +
           region.significanceScores(1) + "," + region.significanceScores(2) + "," + region.significanceScores(3) + "," +
           region.avgImageCaptureDate.map(_.toString).getOrElse("NA") + "," +
           region.avgLabelDate.map(_.toString).getOrElse("NA"))
       } else {
-        writer.println(region.name + "," + region.regionID + "," + "NA" + "," + coordStr + ","  + 0.0 + "," + "NA" +
+        writer.println("\"" + region.name + "\"," + region.regionID + "," + "NA" + "," + coordStr + ","  + 0.0 + "," + "NA" +
           "," + "NA" + "," + "NA" + "," + "NA" + "," + region.significanceScores(0) + "," +
           region.significanceScores(1) + "," + region.significanceScores(2) + "," + region.significanceScores(3) + "," +
           "NA" + "," + "NA")

--- a/app/controllers/ProjectSidewalkAPIController.scala
+++ b/app/controllers/ProjectSidewalkAPIController.scala
@@ -147,9 +147,7 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
       writer.println(header)
       // Write each row in the CSV.
       for (current <- GlobalAttributeTable.getGlobalAttributesWithLabelsInBoundingBox(minLat, minLng, maxLat, maxLng, severity)) {
-        val rowArr: Array[String] = current.attributesToArray
-        rowArr(6) = "\"" + rowArr(6) + "\""
-        writer.println(rowArr.mkString(","))
+        writer.println(current.attributesToArray.mkString(","))
       }
       writer.close()
       Future.successful(Ok.sendFile(content = file, onClose = () => file.delete()))
@@ -216,10 +214,7 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
       writer.println("Attribute ID,Label Type,Street ID,OSM Street ID,Neighborhood Name,Attribute Latitude,Attribute Longitude,Avg Image Capture Date,Avg Label Date,Severity,Temporary,Agree Count,Disagree Count,Not Sure Count,Cluster Size,User IDs")
       // Write each row in the CSV.
       for (current <- GlobalAttributeTable.getGlobalAttributesInBoundingBox(minLat, minLng, maxLat, maxLng, severity)) {
-        // Add double quotes around Neighborhood Name in case of comma in name
-        val rowArr: Array[Any] = current.attributesToArray
-        rowArr(4) = "\"" + rowArr(4) + "\""
-        writer.println(rowArr.mkString(","))
+        writer.println(current.attributesToArray.mkString(","))
       }
       writer.close()
       Future.successful(Ok.sendFile(content = accessAttributesfile, onClose = () => accessAttributesfile.delete()))

--- a/app/models/attribute/GlobalAttributeTable.scala
+++ b/app/models/attribute/GlobalAttributeTable.scala
@@ -61,8 +61,8 @@ case class GlobalAttributeForAPI(val globalAttributeId: Int,
       )
     )
   }
-  val attributesToArray = Array(globalAttributeId, labelType, streetEdgeId, osmStreetId, neighborhoodName, lat.toString,
-                                lng.toString, avgImageCaptureDate, avgLabelDate.toString,
+  val attributesToArray = Array(globalAttributeId, labelType, streetEdgeId, osmStreetId, "\"" + neighborhoodName + "\"",
+                                lat.toString, lng.toString, avgImageCaptureDate, avgLabelDate.toString,
                                 severity.getOrElse("NA").toString, temporary.toString, agreeCount.toString,
                                 disagreeCount.toString, notsureCount.toString, labelCount.toString,
                                 "\"[" + usersList.mkString(",") + "]\"")
@@ -134,7 +134,7 @@ case class GlobalAttributeWithLabelForAPI(val globalAttributeId: Int,
   }
   val attributesToArray = Array(globalAttributeId.toString, labelType, attributeSeverity.getOrElse("NA").toString,
                                 attributeTemporary.toString, streetEdgeId.toString, osmStreetId.toString,
-                                neighborhoodName, labelId.toString, gsvPanoramaId, attributeLatLng._1.toString,
+                                "\"" + neighborhoodName + "\"", labelId.toString, gsvPanoramaId, attributeLatLng._1.toString,
                                 attributeLatLng._2.toString, labelLatLng._1.toString, labelLatLng._2.toString,
                                 headingPitchZoom._1.toString, headingPitchZoom._2.toString, headingPitchZoom._3.toString,
                                 canvasXY._1.toString, canvasXY._2.toString, LabelPointTable.canvasWidth.toString,


### PR DESCRIPTION
Resolves #3390

Neighborhood names containing commas would break the CSV file formatting, acting as an unintended delimiter. This PR adds double quotes around each instance of neighborhood names being referenced in CSV files, namely in these API calls:

- /v2/access/attributes
- /v2/access/attributesWithLabels
- /v2/access/score/neighborhoods

##### Before/After screenshots (if applicable)

Before:
![image](https://github.com/ProjectSidewalk/SidewalkWebpage/assets/77756028/b458a081-b000-4827-aebd-607b49cf27b2)

After:
![image](https://github.com/ProjectSidewalk/SidewalkWebpage/assets/77756028/0ef226b0-364e-4347-86d9-afb93e093517)


##### Testing instructions
1. Check the Label Map to find the coordinates of an area populated with labels. Choose a min/max lat and min/max long.
2. Use this URL to fetch the csv file from the API: 
 - `localhost:9000/v2/access/attributes?lat1=<x1>&lng1=<y1>&lat2=<x2>&lng2=<y2>&filetype=csv`
 - `localhost:9000/v2/access/attributesWithLabels?lat1=<x1>&lng1=<y1>&lat2=<x2>&lng2=<y2>&filetype=csv`
 - `localhost:9000/v2/access/score/neighborhoods?lat1=<x1>&lng1=<y1>&lat2=<x2>&lng2=<y2>&filetype=csv`
 a. If you have coordinates with a known neighborhood with commas in the name, use that instead! (i.e. https://sidewalk-chicago.cs.washington.edu/v2/access/attributes?lat1=41.863085&lng1=-87.661878&lat2=41.874468&lng2=-87.646729&filetype=csv on the Chicago database)
3. View the downloaded CSV. Make sure the Neighborhood Name column is correct and that subsequent columns are in the right spot
 
##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.