### PR TITLE
Fixes no new missions

### DIFF
--- a/public/javascripts/SVValidate/src/modal/ModalNoNewMission.js
+++ b/public/javascripts/SVValidate/src/modal/ModalNoNewMission.js
@@ -35,16 +35,19 @@ function ModalNoNewMission (uiModalMission) {
         uiModalMission.missionTitle.html(i18next.t('mission-complete.no-new-mission-title'));
         uiModalMission.holder.css('visibility', 'visible');
         uiModalMission.foreground.css('visibility', 'visible');
+
         // Update and widen the button to fit more text when there is no new mission.
-        uiModalMission.closeButton.css('font-size', '20pt');
-        uiModalMission.closeButton.css('width', '40%');
-        uiModalMission.closeButton.css('margin-right', '30%');
-        let buttonText = i18next.t('mission-complete.no-new-mission-button');
         if (isMobile()) {
-            buttonText = i18next.t('mobile.no-new-mission-button') + ` Seattle, WA`;
+            uiModalMission.closeButton.html(i18next.t('mobile.no-new-mission-button') + ` Seattle, WA`);
             uiModalMission.closeButton.css('font-size', '40pt');
+            uiModalMission.closeButton.css('width', '76%');
+            uiModalMission.closeButton.css('margin-right', '12%');
+        } else {
+            uiModalMission.closeButton.html(i18next.t('mission-complete.no-new-mission-button'));
+            uiModalMission.closeButton.css('font-size', '20pt');
+            uiModalMission.closeButton.css('width', '40%');
+            uiModalMission.closeButton.css('margin-right', '30%');
         }
-        uiModalMission.closeButton.html(buttonText);
         uiModalMission.closeButton.on('click', _handleButtonClick);
         uiModalMission.holder.css('display', '');
     }

--- a/public/javascripts/SVValidate/src/modal/ModalNoNewMission.js
+++ b/public/javascripts/SVValidate/src/modal/ModalNoNewMission.js
@@ -39,9 +39,10 @@ function ModalNoNewMission (uiModalMission) {
         uiModalMission.closeButton.css('font-size', '20pt');
         uiModalMission.closeButton.css('width', '40%');
         uiModalMission.closeButton.css('margin-right', '30%');
-        let buttonText = i18next.t('mission-complete.no-new-mission-button')
+        let buttonText = i18next.t('mission-complete.no-new-mission-button');
         if (isMobile()) {
-            buttonText = i18next.t('mobile.no-new-mission-button') + ` Seattle, WA`
+            buttonText = i18next.t('mobile.no-new-mission-button') + ` Seattle, WA`;
+            uiModalMission.closeButton.css('font-size', '40pt');
         }
         uiModalMission.closeButton.html(buttonText);
         uiModalMission.closeButton.on('click', _handleButtonClick);

--- a/public/javascripts/SVValidate/src/modal/ModalNoNewMission.js
+++ b/public/javascripts/SVValidate/src/modal/ModalNoNewMission.js
@@ -8,11 +8,12 @@
 function ModalNoNewMission (uiModalMission) {
     let self = this;
 
+    let instructions = isMobile() ? i18next.t('mobile.no-new-mission-body') : i18next.t('mission-complete.no-new-mission-body');
     let noMissionsRemaining = '<figure> \
         <img src="/assets/images/icons/AccessibilityFeatures.png" class="modal-mission-images center-block" alt="Street accessibility features" /> \
         </figure> \
         <div class="spacer10"></div>\
-        <p>' + i18next.t('mission-complete.no-new-mission-body') + '</p>\
+        <p>' + instructions + '</p>\
         <div class="spacer10"></div>';
 
     function _handleButtonClick() {
@@ -35,11 +36,16 @@ function ModalNoNewMission (uiModalMission) {
         uiModalMission.holder.css('visibility', 'visible');
         uiModalMission.foreground.css('visibility', 'visible');
         // Update and widen the button to fit more text when there is no new mission.
-        uiModalMission.closeButton.css('font-size', '42pt');
-        uiModalMission.closeButton.css('width', '60%');
-        uiModalMission.closeButton.css('margin-right', '20%');
-        uiModalMission.closeButton.html(i18next.t('mission-complete.no-new-mission-button') + ` Seattle, WA`);
+        uiModalMission.closeButton.css('font-size', '20pt');
+        uiModalMission.closeButton.css('width', '40%');
+        uiModalMission.closeButton.css('margin-right', '30%');
+        let buttonText = i18next.t('mission-complete.no-new-mission-button')
+        if (isMobile()) {
+            buttonText = i18next.t('mobile.no-new-mission-button') + ` Seattle, WA`
+        }
+        uiModalMission.closeButton.html(buttonText);
         uiModalMission.closeButton.on('click', _handleButtonClick);
+        uiModalMission.holder.css('display', '');
     }
 
     self.show = show;

--- a/public/locales/de/validate.json
+++ b/public/locales/de/validate.json
@@ -126,8 +126,8 @@
         "continue": "Validierung fortsetzen",
         "explore": "Erkundungsmission starten",
         "no-new-mission-title": "Keine weiteren Validierungsmissionen übrig",
-        "no-new-mission-body": "Sie können mit einem Laptop/Desktop weitere Tags hinzufügen oder Tags in einer anderen Stadt validieren!",
-        "no-new-mission-button": "Validieren in"
+        "no-new-mission-body": "Klicken Sie auf die Schaltfläche, um mit der Erkundung zu beginnen.",
+        "no-new-mission-button": "Beginnen Sie mit der Erkundung"
     },
     "mobile": {
         "info-title-curb-ramp": "Was ist eine Trottoirabsenkung?",
@@ -136,7 +136,9 @@
         "info-title-surface-problem": "Was ist ein Oberflächenproblem?",
         "info-title-no-sidewalk": "Was ist ein \"kein Trottoir\"?",
         "info-title-crosswalk": "Was ist ein Fussgängerstreifen?",
-        "info-title-signal": "Was ist ein Fussgängerlichtsignal?"
+        "info-title-signal": "Was ist ein Fussgängerlichtsignal?",
+        "no-new-mission-body": "Sie können weitere Etiketten mit einem Laptop/Desktop-Computer hinzufügen oder Etiketten in einer anderen Stadt validieren!",
+        "no-new-mission-button": "Validieren in"
     },
     "mission-start-tutorial": {
         "mst-instruction-1": "IHRE MISSION",

--- a/public/locales/en/validate.json
+++ b/public/locales/en/validate.json
@@ -126,8 +126,8 @@
         "continue": "Continue validating",
         "explore": "Start an exploration mission",
         "no-new-mission-title": "No more validation missions left",
-        "no-new-mission-body": "You can add more labels using a laptop/desktop computer, or you can validate labels in another city!",
-        "no-new-mission-button": "Validate in"
+        "no-new-mission-body": "Click the button to start exploring.",
+        "no-new-mission-button": "Start Exploring"
     },
     "mobile": {
         "info-title-curb-ramp": "What is a Curb Ramp?",
@@ -136,7 +136,9 @@
         "info-title-surface-problem": "What is a Surface Problem?",
         "info-title-no-sidewalk": "What is a \"No Sidewalk\"",
         "info-title-crosswalk": "What is a Crosswalk?",
-        "info-title-signal": "What is a Pedestrian Signal?"
+        "info-title-signal": "What is a Pedestrian Signal?",
+        "no-new-mission-body": "You can add more labels using a laptop/desktop computer, or you can validate labels in another city!",
+        "no-new-mission-button": "Validate in"
     },
     "mission-start-tutorial": {
         "mst-instruction-1": "YOUR MISSION",

--- a/public/locales/es/validate.json
+++ b/public/locales/es/validate.json
@@ -126,8 +126,8 @@
         "continue": "Continuar validando",
         "explore": "Comienza una misión de exploración",
         "no-new-mission-title": "No quedan más misiones de validación",
-        "no-new-mission-body": "¡Puede agregar más etiquetas usando una computadora portátil/de escritorio, o puede validar etiquetas en otra ciudad!",
-        "no-new-mission-button": "Validar en"
+        "no-new-mission-body": "Haga clic en el botón para comenzar a explorar.",
+        "no-new-mission-button": "Comience a explorar"
     },
     "mobile": {
         "info-title-curb-ramp": "¿Qué es una Rampa Peatonal?",
@@ -136,7 +136,9 @@
         "info-title-surface-problem": "¿Qué es un Problema en Superficie?",
         "info-title-no-sidewalk": "¿Qué es un \"No Hay Banqueta\"?",
         "info-title-crosswalk": "¿Qué es un Cruce Peatonal?",
-        "info-title-signal": "¿Qué es un Semáforo Peatonal?"
+        "info-title-signal": "¿Qué es un Semáforo Peatonal?",
+        "no-new-mission-body": "Puede agregar más etiquetas usando una computadora portátil / de escritorio, ¡o puede validar etiquetas en otra ciudad!",
+        "no-new-mission-button": "Validar en"
     },
     "mission-start-tutorial": {
         "mst-instruction-1": "TU MISIÓN",

--- a/public/locales/nl/validate.json
+++ b/public/locales/nl/validate.json
@@ -126,8 +126,8 @@
         "continue": "Ga door met valideren",
         "explore": "Start een ondtekkingsmissie",
         "no-new-mission-title": "Geen valideermissies meer te gaan",
-        "no-new-mission-body": "U kunt meer labels toevoegen met behulp van een laptop/desktopcomputer, of u kunt labels valideren in een andere stad!",
-        "no-new-mission-button": "Valideer in"
+        "no-new-mission-body": "Klik op de knop om te beginnen met verkennen.",
+        "no-new-mission-button": "Begin met verkennen"
     },
     "mobile": {
         "info-title-curb-ramp": "Wat is een Trottoir Oprit?",
@@ -136,7 +136,9 @@
         "info-title-surface-problem": "Wat is een Oppervlakte Probleem?",
         "info-title-no-sidewalk": "Wat is \"Geen Trottoir\"?",
         "info-title-crosswalk": "Wat is een Oversteekplaats?",
-        "info-title-signal": "Wat is een Verkeerslicht?"
+        "info-title-signal": "Wat is een Verkeerslicht?",
+        "no-new-mission-body": "U kunt meer labels toevoegen met behulp van een laptop / desktopcomputer, of u kunt labels valideren in een andere stad!",
+        "no-new-mission-button": "Valideren in"
     },
     "mission-start-tutorial": {
         "mst-instruction-1": "JOUW MISSIE",

--- a/public/locales/zh-TW/validate.json
+++ b/public/locales/zh-TW/validate.json
@@ -126,8 +126,8 @@
         "continue": "繼續檢核",
         "explore": "開始一個探索任務",
         "no-new-mission-title": "已無任何剩餘檢核任務",
-        "no-new-mission-body": "您可以使用筆記本型或桌上型電腦增添更多標記，也可以檢核另一個城市！",
-        "no-new-mission-button": "檢核於"
+        "no-new-mission-body": "按兩下按鈕開始探索。",
+        "no-new-mission-button": "開始探索"
     },
     "mobile": {
         "info-title-curb-ramp": "路緣斜坡是什麼？",
@@ -136,7 +136,9 @@
         "info-title-surface-problem": "鋪面問題是什麼？",
         "info-title-no-sidewalk": "\"無人行道\"是什麼 ",
         "info-title-crosswalk": "行人穿越道是什麼？",
-        "info-title-signal": "行人號誌是什麼？"
+        "info-title-signal": "行人號誌是什麼？",
+        "no-new-mission-body": "您可以使用筆記型電腦/台式計算機添加更多標籤，也可以在其他城市驗證標籤！",
+        "no-new-mission-button": "在中驗證"
     },
     "mission-start-tutorial": {
         "mst-instruction-1": "您的任務",


### PR DESCRIPTION
Resolves #3126

Fixes broken "no more validation missions left" screen when there are no more labels to validate. Adds different functionality for mobile, as well as translations.

##### Before/After screenshots (if applicable)
Before:
![3126-validate-no-new-mission_bug1](https://github.com/ProjectSidewalk/SidewalkWebpage/assets/106000281/b8105e0e-39d6-4a1b-a3bd-7e733ca6ccd6)

After:
![3126-validate-no-new-mission_fix1](https://github.com/ProjectSidewalk/SidewalkWebpage/assets/106000281/e29ac1b1-8508-48a8-98dd-f7133ef191f5)
![3126-validate-no-new-mission_fix2](https://github.com/ProjectSidewalk/SidewalkWebpage/assets/106000281/f540d9f5-4005-42e6-913c-ea308555d65f)

##### Testing instructions
1. Force else case in getDataForValidationPages() in ValidationController.scala by temporarily editing if statement to 'if (false)'
2. Navigate to Validate webpage
3. Use Dev Tools to test mobile version

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've included before/after screenshots above.
- [x] I've asked for and included translations for any user facing text that was added or modified.
- [x] I've tested on mobile (only needed for validation page).
