### PR TITLE
Added launch date to overallStats API call

### DIFF
--- a/app/controllers/ProjectSidewalkAPIController.scala
+++ b/app/controllers/ProjectSidewalkAPIController.scala
@@ -17,7 +17,6 @@ import models.daos.slick.DBTableDefinitions.{DBUser, UserTable}
 import models.label.{LabelLocation, LabelTable, ProjectSidewalkStats}
 import models.street.{StreetEdge, StreetEdgeInfo, StreetEdgeTable}
 import models.user.{User, UserStatTable, WebpageActivity, WebpageActivityTable}
-import play.api.Play
 import play.api.Play.current
 import play.api.libs.json._
 import play.api.libs.json.Json._

--- a/app/formats/json/APIFormats.scala
+++ b/app/formats/json/APIFormats.scala
@@ -21,6 +21,7 @@ object APIFormats {
 
   def projectSidewalkStatsToJson(stats: ProjectSidewalkStats): JsObject = {
     Json.obj(
+      "launch_date" -> stats.launchDate,
       "km_explored" -> stats.kmExplored,
       "km_explored_no_overlap" -> stats.kmExploreNoOverlap,
       "user_counts" -> Json.obj(

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -1101,8 +1101,8 @@ object LabelTable {
       if (filterLowQuality) "user_stat.high_quality"
       else "NOT user_stat.excluded"
 
-    val cityId = Play.configuration.getString("city-id").get
-    val launchDate = Play.configuration.getString(s"city-params.launch-date.$cityId").get
+    val cityId: String = Play.configuration.getString("city-id").get
+    val launchDate: String = Play.configuration.getString(s"city-params.launch-date.$cityId").get
 
     val overallStatsQuery = Q.queryNA[ProjectSidewalkStats](
       s"""SELECT '$launchDate' AS launch_date,

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -39,7 +39,7 @@ case class LabelLocationWithSeverity(labelId: Int, auditTaskId: Int, gsvPanorama
 
 case class LabelSeverityStats(n: Int, nWithSeverity: Int, severityMean: Option[Float], severitySD: Option[Float])
 case class LabelAccuracy(n: Int, nAgree: Int, nDisagree: Int, accuracy: Option[Float])
-case class ProjectSidewalkStats(kmExplored: Float, kmExploreNoOverlap: Float, nUsers: Int, nExplorers: Int,
+case class ProjectSidewalkStats(launchDate: String, kmExplored: Float, kmExploreNoOverlap: Float, nUsers: Int, nExplorers: Int,
                                 nValidators: Int, nRegistered: Int, nAnon: Int, nTurker: Int, nResearcher: Int,
                                 nLabels: Int, severityByLabelType: Map[String, LabelSeverityStats], nValidations: Int,
                                 accuracyByLabelType: Map[String, LabelAccuracy])
@@ -228,7 +228,8 @@ object LabelTable {
   )
 
   implicit val projectSidewalkStatsConverter = GetResult[ProjectSidewalkStats](r => ProjectSidewalkStats(
-    r.nextFloat, r.nextFloat, r.nextInt, r.nextInt, r.nextInt, r.nextInt, r.nextInt, r.nextInt, r.nextInt, r.nextInt,
+    r.nextString, r.nextFloat, r.nextFloat, r.nextInt, r.nextInt, r.nextInt, r.nextInt, r.nextInt, r.nextInt, r.nextInt,
+    r.nextInt,
     Map(
       "CurbRamp" -> LabelSeverityStats(r.nextInt, r.nextInt, r.nextFloatOption, r.nextFloatOption),
       "NoCurbRamp" -> LabelSeverityStats(r.nextInt, r.nextInt, r.nextFloatOption, r.nextFloatOption),
@@ -1100,8 +1101,12 @@ object LabelTable {
       if (filterLowQuality) "user_stat.high_quality"
       else "NOT user_stat.excluded"
 
+    val cityId = Play.configuration.getString("city-id").get
+    val launchDate = Play.configuration.getString(s"city-params.launch-date.$cityId").get
+
     val overallStatsQuery = Q.queryNA[ProjectSidewalkStats](
-      s"""SELECT km_audited.km_audited AS km_audited,
+      s"""SELECT '$launchDate' AS launch_date,
+         |       km_audited.km_audited AS km_audited,
          |       km_audited_no_overlap.km_audited_no_overlap AS km_audited_no_overlap,
          |       users.total_users,
          |       users.audit_users,

--- a/conf/cityparams.conf
+++ b/conf/cityparams.conf
@@ -90,6 +90,28 @@ city-params {
     burnaby = "private"
     teaneck-nj = "public"
   }
+  launch-date {
+    newberg-or = "2019-01-31"
+    washington-dc = "2015-10-17"
+    seattle-wa = "2019-03-12"
+    columbus-oh = "2019-11-12"
+    cdmx = "2020-01-09"
+    spgg = "2020-05-30"
+    pittsburgh-pa = "2020-07-30"
+    chicago-il = "2021-09-03"
+    amsterdam = "2022-03-17"
+    la-piedad = "2022-03-17"
+    oradell-nj = "2022-03-17"
+    validation-study = "2022-05-10"
+    zurich = "2022-11-08"
+    taipei = "2023-01-24"
+    new-taipei-tw = "2023-08-06"
+    keelung-tw = "2023-08-10"
+    auckland = "2023-02-14"
+    cuenca = "2023-04-02"
+    burnaby = "2023-08-09"
+    teaneck-nj = "2023-08-24"
+  }
   skyline-img = {
     newberg-or = "skyline1.png"
     washington-dc = "skyline-dc.png"

--- a/conf/cityparams.conf
+++ b/conf/cityparams.conf
@@ -115,6 +115,7 @@ city-params {
     cuenca = "2023-04-02"
     burnaby = "2023-08-09"
     teaneck-nj = "2023-08-24"
+    walla-walla-wa = "2023-10-05"
   }
   skyline-img = {
     newberg-or = "skyline1.png"


### PR DESCRIPTION
Resolves #3375 

Launch date of a city is currently not available. To show this information, the date of the first label in each city was found and added to the city params config file. The info is then drawn from the config file to the API call.

##### Before/After screenshots (if applicable)
Before:
No info displayed for city launch date.

After:
CSV format:
![image](https://github.com/ProjectSidewalk/SidewalkWebpage/assets/77756028/0a6b61d7-f7df-4eda-84ca-ed15173a5767)

JSON format:
![image](https://github.com/ProjectSidewalk/SidewalkWebpage/assets/77756028/3000ca08-8a46-4d6a-8d8b-a0287dec98b8)


##### Testing instructions
1. Use the `/v2/overallStats` and `/v2/overallStats?filetype=csv` API calls.
2. Check that the `launch_date`/Launch Date fields are displayed correctly.

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [ ] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.