### PR TITLE
Fixes bug preventing validating NoSidewalk labels

### DIFF
--- a/public/javascripts/common/MissionStartTutorial.js
+++ b/public/javascripts/common/MissionStartTutorial.js
@@ -257,7 +257,7 @@ function MissionStartTutorial(missionType, labelType, data, svvOrsvl, language =
                 }
             ]
         },
-        'NoSideWalk': {
+        'NoSidewalk': {
             'missionInstruction1': i18next.t('validate:mission-start-tutorial.mst-instruction-1'),
             'missionInstruction2': i18next.t('validate:mission-start-tutorial.mst-instruction-2',
                 {'nLabels': data.labelCount, 'labelType': i18next.t('common:no-sidewalk')}),


### PR DESCRIPTION
Resolves #3401 

Fixes a bug that broke the "Validate more labels" button when the only labels left to validate are No Sidewalk labels.

The issue is that in the Mission Start Tutorial code, "NoSidewalk" was written as "NoSideWalk". Not sure how I missed that when testing the Mission Start Tutorial when it was first added, but this bug has been there from the beginning!

Since we only show No Sidewalk labels if all our main label types have already been fully validated by a user, this is only showing up on servers with very little data (like our new Walla Walla deployment).

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [ ] I've tested on mobile (only needed for validation page).
