### PR TITLE
Fixes Validate not working when adding a comment

### DIFF
--- a/public/javascripts/SVValidate/src/label/Label.js
+++ b/public/javascripts/SVValidate/src/label/Label.js
@@ -172,7 +172,7 @@ function Label(params) {
         return this;
     }
     
-    function prepareLabelCommentData(comment, position, pov, zoom) {
+    function prepareLabelCommentData(comment, position, pov) {
         let data = {
             comment: comment,
             label_id: svv.panorama.getCurrentLabel().getAuditProperty("labelId"),
@@ -182,7 +182,7 @@ function Label(params) {
             lng: position.lng,
             pitch: pov.pitch,
             mission_id: svv.missionContainer.getCurrentMission().getProperty('missionId'),
-            zoom: zoom
+            zoom: pov.zoom
         };
         return data;
     }
@@ -259,7 +259,7 @@ function Label(params) {
         if (comment) {
             document.getElementById('validation-label-comment').value = '';
             svv.tracker.push("ValidationTextField_DataEntered");
-            let data = prepareLabelCommentData(comment, svv.panorama.getPosition(), userPov, zoom);
+            let data = prepareLabelCommentData(comment, svv.panorama.getPosition(), userPov);
             submitComment(data);
         }
 


### PR DESCRIPTION
Resolves #3400

Fixes a bug where Validate wouldn't submit the validation when adding a comment. This _was_ my fault from a previous PR; I forgot to test validations with comments!

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
