### PR TITLE
Adds Org column to Admin User table

### DIFF
--- a/app/controllers/UserProfileController.scala
+++ b/app/controllers/UserProfileController.scala
@@ -182,7 +182,7 @@ class UserProfileController @Inject() (implicit val env: Environment[User, Sessi
       case Some(user) =>
         val userId: UUID = user.userId
         if (user.role.getOrElse("") != "Anonymous") {
-          val allUserOrgs: List[Int] = UserOrgTable.getAllOrgs(userId);
+          val allUserOrgs: List[Int] = UserOrgTable.getAllOrgs(userId)
           if (allUserOrgs.headOption.isEmpty) {
             UserOrgTable.save(userId, orgId)
           } else if (allUserOrgs.head != orgId) {

--- a/app/formats/AdminUpdateSubmissionFormats.scala
+++ b/app/formats/AdminUpdateSubmissionFormats.scala
@@ -5,11 +5,17 @@ import java.util.UUID
 import play.api.libs.json.{Reads, JsPath}
 import play.api.libs.functional.syntax._
 
-object UserRoleSubmissionFormats {
+object AdminUpdateSubmissionFormats {
   case class UserRoleSubmission(userId: String, roleId: String)
+  case class UserOrgSubmission(userId: String, orgId: Int)
 
   implicit val userRoleSubmissionReads: Reads[UserRoleSubmission] = (
     (JsPath \ "user_id").read[String] and
       (JsPath \ "role_id").read[String]
     )(UserRoleSubmission.apply _)
+
+  implicit val userOrgSubmissionReads: Reads[UserOrgSubmission] = (
+    (JsPath \ "user_id").read[String] and
+      (JsPath \ "org_id").read[Int]
+    )(UserOrgSubmission.apply _)
 }

--- a/app/models/daos/slick/UserDAOSlick.scala
+++ b/app/models/daos/slick/UserDAOSlick.scala
@@ -20,8 +20,7 @@ import scala.slick.jdbc.{StaticQuery => Q}
 
 case class UserStatsForAdminPage(userId: String, username: String, email: String, role: String,
                                  signUpTime: Option[Timestamp], lastSignInTime: Option[Timestamp], signInCount: Int,
-                                 completedMissions: Int, completedAudits: Int, labels: Int, ownValidated: Int,
-                                 ownValidatedAgreedPct: Double, ownValidatedDisagreedPct: Double, ownValidatedNotsurePct: Double,
+                                 labels: Int, ownValidated: Int, ownValidatedAgreedPct: Double,
                                  othersValidated: Int, othersValidatedAgreedPct: Double, highQuality: Boolean)
 
 class UserDAOSlick extends UserDAO {
@@ -485,15 +484,6 @@ object UserDAOSlick {
         .groupBy(_.userId).map{ case (_userId, group) => (_userId, group.map(_.timestamp).max, group.length) }
         .list.map{ case (_userId, _time, _count) => (_userId, (_time, _count)) }.toMap
 
-    // Map(user_id: String -> mission_count: Int).
-    val missionCounts =
-      MissionTable.missions.filter(_.completed)
-        .groupBy(_.userId).map { case (_userId, group) => (_userId, group.length) }.list.toMap
-
-    // Map(user_id: String -> audit_count: Int).
-    val auditCounts =
-      AuditTaskTable.completedTasks.groupBy(_.userId).map { case (_uId, group) => (_uId, group.length) }.list.toMap
-
     // Map(user_id: String -> label_count: Int).
     val labelCounts =
       AuditTaskTable.auditTasks.innerJoin(LabelTable.labelsWithTutorialAndExcludedUsers).on(_.auditTaskId === _.auditTaskId)
@@ -504,9 +494,9 @@ object UserDAOSlick {
       (valCount._1, (valCount._2, valCount._3, valCount._4, valCount._5, valCount._6))
     }.toMap
 
-    // Map(user_id: String -> (count: Int, agreed: Int)).
+    // Map(user_id: String -> (count: Int, agreed: Int, disagreed: Int)).
     val othersValidatedCounts = LabelValidationTable.getValidatedCountsPerUser.map { valCount =>
-      (valCount._1, (valCount._2, valCount._3))
+      (valCount._1, (valCount._2, valCount._3, valCount._4))
     }.toMap
 
     val userHighQuality =
@@ -518,40 +508,28 @@ object UserDAOSlick {
       val ownValidatedTotal = ownValidatedCounts._2
       val ownValidatedAgreed = ownValidatedCounts._3
       val ownValidatedDisagreed = ownValidatedCounts._4
-      val ownValidatedNotsure = ownValidatedCounts._5
 
-      val otherValidatedCounts = othersValidatedCounts.getOrElse(u.userId, (0, 0))
+      val otherValidatedCounts = othersValidatedCounts.getOrElse(u.userId, (0, 0, 0))
       val otherValidatedTotal = otherValidatedCounts._1
       val otherValidatedAgreed = otherValidatedCounts._2
+      val otherValidatedDisagreed = otherValidatedCounts._3
 
       val ownValidatedAgreedPct =
         if (ownValidatedTotal == 0) 0f
-        else ownValidatedAgreed * 1.0 / ownValidatedTotal
-
-      val ownValidatedDisagreedPct =
-        if (ownValidatedTotal == 0) 0f
-        else ownValidatedDisagreed * 1.0 / ownValidatedTotal
-
-      val ownValidatedNotsurePct =
-        if (ownValidatedTotal == 0) 0f
-        else ownValidatedNotsure * 1.0 / ownValidatedTotal
+        else ownValidatedAgreed * 1.0 / (ownValidatedAgreed + ownValidatedDisagreed)
 
       val otherValidatedAgreedPct =
         if (otherValidatedTotal == 0) 0f
-        else otherValidatedAgreed * 1.0 / otherValidatedTotal
+        else otherValidatedAgreed * 1.0 / (otherValidatedAgreed + otherValidatedDisagreed)
 
       UserStatsForAdminPage(
         u.userId, u.username, u.email,
         roles.getOrElse(u.userId, ""),
         signUpTimes.get(u.userId).flatten,
         signInTimesAndCounts.get(u.userId).flatMap(_._1), signInTimesAndCounts.get(u.userId).map(_._2).getOrElse(0),
-        missionCounts.getOrElse(u.userId, 0),
-        auditCounts.getOrElse(u.userId, 0),
         labelCounts.getOrElse(u.userId, 0),
         ownValidatedTotal,
         ownValidatedAgreedPct,
-        ownValidatedDisagreedPct,
-        ownValidatedNotsurePct,
         otherValidatedTotal,
         otherValidatedAgreedPct,
         userHighQuality.getOrElse(u.userId, true)

--- a/app/models/user/UserOrgTable.scala
+++ b/app/models/user/UserOrgTable.scala
@@ -53,7 +53,7 @@ object UserOrgTable {
     if (OrganizationTable.containsId(orgId)) {
       userOrgs.insertOrUpdate(UserOrg(0, userId.toString, orgId))
     } else {
-      0
+      -1
     }
   }
 

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -857,6 +857,7 @@
                                                 @OrganizationTable.getAllOrganizations.map { org =>
                                                     <li role="presentation"><a role="menuitem" tabindex="-1" href="#!" class="change-org" data-org-id="@org.orgId">@org.orgName</a></li>
                                                 }
+                                                <li role="presentation"><a role="menuitem" tabindex="-1" href="#!" class="change-org" data-org-id="-1">None</a></li>
                                             </ul>
                                         </div>
                                     </td>

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -803,7 +803,7 @@
                     <div class="row">
                         <h1>Users</h1>
                         <div id="user-table-container" class="col-lg-12">
-                            <table id="user-table" data-order='[[ 5, "desc" ]]' class="table table-striped table-condensed">
+                            <table id="user-table" data-order='[[ 6, "desc" ]]' class="table table-striped table-condensed">
                                 <thead>
                                     <tr>
                                         <th class="col-md-1">Username</th>

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -810,13 +810,9 @@
                                         <th class="col-md-1">Email</th>
                                         <th class="col-md-1">Role</th>
                                         <th class="col-md-1">High Quality</th>
-                                        <th class="col-md-1">Mission Count</th>
-                                        <th class="col-md-1">Audit Count</th>
                                         <th class="col-md-1">Label Count</th>
                                         <th class="col-md-1">Own Labels Validated</th>
                                         <th class="col-md-1">%Own Labels Agree</th>
-                                        <th class="col-md-1">%Own Labels Disagree</th>
-                                        <th class="col-md-1">%Own Labels Notsure</th>
                                         <th class="col-md-1">Others' Labels Validated</th>
                                         <th class="col-md-1">%Others' Labels Agreed</th>
                                         <th class="col-md-2">Date Registered</th>
@@ -849,13 +845,9 @@
                                             @u.role
                                         }</td>
                                     <td>@u.highQuality</td>
-                                    <td>@u.completedMissions</td>
-                                    <td>@u.completedAudits</td>
                                     <td>@u.labels</td>
                                     <td>@u.ownValidated</td>
                                     <td>@("%.0f".format(u.ownValidatedAgreedPct * 100))%</td>
-                                    <td>@("%.0f".format(u.ownValidatedDisagreedPct * 100))%</td>
-                                    <td>@("%.0f".format(u.ownValidatedNotsurePct * 100))%</td>
                                     <td>@u.othersValidated</td>
                                     <td>@("%.0f".format(u.othersValidatedAgreedPct * 100))%</td>
                                     <td class = 'timestamp'>@u.signUpTime</td>

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -6,6 +6,7 @@
 @import models.audit.AuditTaskCommentTable
 @import models.utils.DataFormatter
 
+@import models.user.OrganizationTable
 @(title: String, user: Option[User] = None)(implicit lang: Lang)
 @convertDistance(distance: Float) = @{
     if (Messages("measurement.system") == "metric") distance * 1.60934.toDouble
@@ -809,6 +810,7 @@
                                         <th class="col-md-2">User Id</th>
                                         <th class="col-md-1">Email</th>
                                         <th class="col-md-1">Role</th>
+                                        <th class="col-md-1">Org</th>
                                         <th class="col-md-1">High Quality</th>
                                         <th class="col-md-1">Label Count</th>
                                         <th class="col-md-1">Own Labels Validated</th>
@@ -843,7 +845,21 @@
                                             </div>
                                         } else {
                                             @u.role
-                                        }</td>
+                                        }
+                                    </td>
+                                    <td>
+                                        <div class="dropdown">
+                                            <button class="btn btn-default dropdown-toggle org-dropdown" type="button" id="userOrgDropdown@u.userId" data-toggle="dropdown">
+                                                @u.org.getOrElse("None")
+                                                <span class="caret"></span>
+                                            </button>
+                                            <ul class="dropdown-menu" role="menu" aria-labelledby="userOrgDropdown@u.userId">
+                                                @OrganizationTable.getAllOrganizations.map { org =>
+                                                    <li role="presentation"><a role="menuitem" tabindex="-1" href="#!" class="change-org" data-org-id="@org.orgId">@org.orgName</a></li>
+                                                }
+                                            </ul>
+                                        </div>
+                                    </td>
                                     <td>@u.highQuality</td>
                                     <td>@u.labels</td>
                                     <td>@u.ownValidated</td>

--- a/conf/routes
+++ b/conf/routes
@@ -83,6 +83,7 @@ GET     /adminapi/numWebpageActivity/:activity               @controllers.AdminC
 GET     /adminapi/numWebpageActivity/:activity/*keyValPairs  @controllers.AdminController.getNumWebpageActivitiesKeyVal(activity: String, keyValPairs: String)
 GET     /adminapi/choroplethCounts                           @controllers.AdminController.getRegionNegativeLabelCounts
 PUT     /adminapi/setRole                                    @controllers.AdminController.setUserRole
+PUT     /adminapi/setOrg                                     @controllers.AdminController.setUserOrg
 
 GET     /labels/all                                          @controllers.AdminController.getAllLabelsForLabelMap(regions: Option[String] ?= None)
 GET     /label/id/:labelId                                   @controllers.AdminController.getLabelData(labelId: Int)

--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -1110,7 +1110,7 @@ function Admin(_, $) {
             .attr('id')
             .substring("userRoleDropdown".length); // userId is stored in id of dropdown
         var newRole = this.innerText;
-        
+
         data = {
             'user_id': userId,
             'role_id': newRole
@@ -1128,6 +1128,35 @@ function Admin(_, $) {
                 var buttonContents = button.html();
                 var newRole = result.role;
                 button.html(buttonContents.replace(/Registered|Turker|Researcher|Administrator|Anonymous/g, newRole));
+            },
+            error: function (result) {
+                console.error(result);
+            }
+        });
+    }
+
+    function changeOrg(e) {
+        console.log(this);
+        var userId = $(this).parent() // <li>
+            .parent() // <ul>
+            .siblings('button')
+            .attr('id')
+            .substring("userOrgDropdown".length); // userId is stored in id of dropdown
+        var orgId = parseInt(this.getAttribute('data-org-id'));
+        var orgName = this.innerText;
+
+        $.ajax({
+            async: true,
+            contentType: 'application/json; charset=utf-8',
+            url: '/adminapi/setOrg',
+            type: 'put',
+            data: JSON.stringify({ 'user_id': userId, 'org_id': orgId }),
+            dataType: 'json',
+            success: function (result) {
+                // Change dropdown button to reflect new org.
+                var newOrg = result.org_id;
+                var button = document.getElementById(`userOrgDropdown${result.user_id}`);
+                button.childNodes[0].nodeValue = ` ${orgName} `;
             },
             error: function (result) {
                 console.error(result);
@@ -1158,6 +1187,7 @@ function Admin(_, $) {
     self.toggleUnauditedStreetLayer = toggleUnauditedStreetLayerAdmin;
 
     $('.change-role').on('click', changeRole);
+    $('.change-org').on('click', changeOrg);
 
     return self;
 }

--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -1136,7 +1136,6 @@ function Admin(_, $) {
     }
 
     function changeOrg(e) {
-        console.log(this);
         var userId = $(this).parent() // <li>
             .parent() // <ul>
             .siblings('button')
@@ -1154,7 +1153,6 @@ function Admin(_, $) {
             dataType: 'json',
             success: function (result) {
                 // Change dropdown button to reflect new org.
-                var newOrg = result.org_id;
                 var button = document.getElementById(`userOrgDropdown${result.user_id}`);
                 button.childNodes[0].nodeValue = ` ${orgName} `;
             },

--- a/public/stylesheets/admin.css
+++ b/public/stylesheets/admin.css
@@ -21,11 +21,11 @@
 }
 #user-table_wrapper {
     -webkit-transform: rotateX(180deg); /* Adding scrollbar flips all text, this flips it back. */
-    font-size: 12px;
+    font-size: 11px;
     min-height: 290px;
 }
 
-.stats-grid{
+.stats-grid {
     display: flex;
 }
 
@@ -33,12 +33,12 @@
     flex: 1;
 }
 
-.role-dropdown {
-    font-size: 12px;
+.role-dropdown, .org-dropdown {
+    font-size: 11px;
 }
 
-.change-role {
-    font-size: 12px;
+.change-role, .change-org {
+    font-size: 11px;
 }
 
 #admin-percentage-legend {


### PR DESCRIPTION
Resolves #3398 

Adds an Org column to the Admin User table. Also removes the audit_count, mission_count, % Own Labels Notsure, and % Own Labels Disagree columns to make space. I also decreased the font size from 12px to 11px to fit even more on screen.

The org column functions the same way as the role column, so we can now set users' org from the Admin page! I included the ability to fully remove a user's org as well.

##### Before/After screenshots (if applicable)
Before
![Screenshot from 2023-10-26 12-47-23](https://github.com/ProjectSidewalk/SidewalkWebpage/assets/6518824/2cf54147-c1d9-4c09-ad8c-e60935ee459a)

After
![Screenshot from 2023-10-26 12-46-19](https://github.com/ProjectSidewalk/SidewalkWebpage/assets/6518824/6f891942-deb3-467e-a576-afa1d310d8bf)

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
