### PR TITLE
Use sbt default JVM memory allocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ On Windows, we recommend [Windows Powershell](https://docs.microsoft.com/en-us/p
 
 1. Email Mikey (michaelssaugstad@gmail.com) and ask for a database dump, a Mapbox API key, and a Google Maps API key & secret (if you are not part of our team, you'll have to [create a Google Maps API key](https://developers.google.com/maps/documentation/javascript/get-api-key) yourself).
 1. If your computer has an Apple Silicon (M1 or M2) chip, then you should modify the `platform` line in the `docker-compose.yml`, changing it to `linux/arm64`.
-1. If your computer has less than 16 GB of RAM, I'd recommend modifying `-mem 12288` to `-mem 8192` or lower in the `package.json` file so that you don't fill up your computer's memory.
 1. Modify the `MAPBOX_API_KEY`, `GOOGLE_MAPS_API_KEY`, and `GOOGLE_MAPS_SECRET` lines in the `docker-compose.yml` using the keys and secret you've acquired.
 1. Modify the `SIDEWALK_CITY_ID` line in the `docker-compose.yml` to use the ID of the appropriate city, listed [here](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Docker-Troubleshooting#first-heres-a-table-that-youll-reference-when-setting-up-your-dev-env).
 1. Modify the `DATABASE_URL` line in the `docker-compose.yml`, replacing "sidewalk" with the database name from the table [linked above](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Docker-Troubleshooting#first-heres-a-table-that-youll-reference-when-setting-up-your-dev-env).

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
         "grunt-concat": "grunt concat && grunt concat_css",
         "build": "npm install && grunt",
         "debug": "npm run grunt-concat && grunt watch & sbt -jvm-debug 9998 run",
-        "start": "npm run grunt-concat && grunt watch & sbt -Dsbt.ivy.home='.ivy2' -Dsbt.global.base='.sbt' -Dsbt.repository.config='.sbt/repositories' -mem 12288 compile \"~ run\" shell",
-        "start-no-docker": "npm run grunt-concat && grunt watch & sbt -Dhttp.port=$SIDEWALK_HTTP_PORT -Dsbt.ivy.home='.ivy2' -Dsbt.global.base='.sbt' -Dsbt.repository.config='.sbt/repositories' -mem 12288 compile \"~ run\" shell",
+        "start": "npm run grunt-concat && grunt watch & sbt -Dsbt.ivy.home='.ivy2' -Dsbt.global.base='.sbt' -Dsbt.repository.config='.sbt/repositories' compile \"~ run\" shell",
+        "start-no-docker": "npm run grunt-concat && grunt watch & sbt -Dhttp.port=$SIDEWALK_HTTP_PORT -Dsbt.ivy.home='.ivy2' -Dsbt.global.base='.sbt' -Dsbt.repository.config='.sbt/repositories' compile \"~ run\" shell",
         "test": "grunt && grunt test"
     }
 }


### PR DESCRIPTION
An investigation revealed that the test and prod servers are invoking sbt without a -mem argument (they don't use npm start, so don't use the command-line in package.json).  That means that they have been using sbt's default JVM memory allocation (which currently is 1GB), instead of the 12GB (!) specified in package.json.  Some (anecdotal) testing of servers running with 12GB vs 1GB showed no obvious performance difference, and apparently the servers have been stable at 1GB for years in prod, so it was recommended that the package.json command-line be modified to put dev instances in line with test and prod.

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
