### PR TITLE
Added recent labels average timestamp to overall stats API

### DIFF
--- a/app/controllers/ProjectSidewalkAPIController.scala
+++ b/app/controllers/ProjectSidewalkAPIController.scala
@@ -867,6 +867,7 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
 
       val stats: ProjectSidewalkStats = LabelTable.getOverallStatsForAPI(filterLowQuality)
       writer.println(s"Launch Date, ${stats.launchDate}")
+      writer.println(s"Recent Labels Average Timestamp, ${stats.avgTimestampLast100Labels}")
       writer.println(s"KM Explored,${stats.kmExplored}")
       writer.println(s"KM Explored Without Overlap,${stats.kmExploreNoOverlap}")
       writer.println(s"Total User Count,${stats.nUsers}")

--- a/app/formats/json/APIFormats.scala
+++ b/app/formats/json/APIFormats.scala
@@ -22,6 +22,7 @@ object APIFormats {
   def projectSidewalkStatsToJson(stats: ProjectSidewalkStats): JsObject = {
     Json.obj(
       "launch_date" -> stats.launchDate,
+      "avg_timestamp_last_100_labels" -> stats.avgTimestampLast100Labels,
       "km_explored" -> stats.kmExplored,
       "km_explored_no_overlap" -> stats.kmExploreNoOverlap,
       "user_counts" -> Json.obj(

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -39,9 +39,10 @@ case class LabelLocationWithSeverity(labelId: Int, auditTaskId: Int, gsvPanorama
 
 case class LabelSeverityStats(n: Int, nWithSeverity: Int, severityMean: Option[Float], severitySD: Option[Float])
 case class LabelAccuracy(n: Int, nAgree: Int, nDisagree: Int, accuracy: Option[Float])
-case class ProjectSidewalkStats(launchDate: String, kmExplored: Float, kmExploreNoOverlap: Float, nUsers: Int, nExplorers: Int,
-                                nValidators: Int, nRegistered: Int, nAnon: Int, nTurker: Int, nResearcher: Int,
-                                nLabels: Int, severityByLabelType: Map[String, LabelSeverityStats], nValidations: Int,
+case class ProjectSidewalkStats(launchDate: String, avgTimestampLast100Labels: String, kmExplored: Float,
+                                kmExploreNoOverlap: Float, nUsers: Int, nExplorers: Int, nValidators: Int,
+                                nRegistered: Int, nAnon: Int, nTurker: Int, nResearcher: Int, nLabels: Int,
+                                severityByLabelType: Map[String, LabelSeverityStats], nValidations: Int,
                                 accuracyByLabelType: Map[String, LabelAccuracy])
 
 class LabelTable(tag: slick.lifted.Tag) extends Table[Label](tag, "label") {
@@ -228,7 +229,7 @@ object LabelTable {
   )
 
   implicit val projectSidewalkStatsConverter = GetResult[ProjectSidewalkStats](r => ProjectSidewalkStats(
-    r.nextString, r.nextFloat, r.nextFloat, r.nextInt, r.nextInt, r.nextInt, r.nextInt, r.nextInt, r.nextInt, r.nextInt,
+    r.nextString, r.nextString, r.nextFloat, r.nextFloat, r.nextInt, r.nextInt, r.nextInt, r.nextInt, r.nextInt, r.nextInt, r.nextInt,
     r.nextInt,
     Map(
       "CurbRamp" -> LabelSeverityStats(r.nextInt, r.nextInt, r.nextFloatOption, r.nextFloatOption),
@@ -1104,8 +1105,13 @@ object LabelTable {
     val cityId: String = Play.configuration.getString("city-id").get
     val launchDate: String = Play.configuration.getString(s"city-params.launch-date.$cityId").get
 
+    val recentLabelDates = labels.sortBy(_.timeCreated.desc).take(10).list.map(label => label.timeCreated)
+    val avgRecentLabels = new Timestamp(recentLabelDates.map(date => date.getTime).sum / recentLabelDates.length)
+    println(avgRecentLabels)
+
     val overallStatsQuery = Q.queryNA[ProjectSidewalkStats](
       s"""SELECT '$launchDate' AS launch_date,
+         |       '$avgRecentLabels' AS avg_timestamp_last_100_labels,
          |       km_audited.km_audited AS km_audited,
          |       km_audited_no_overlap.km_audited_no_overlap AS km_audited_no_overlap,
          |       users.total_users,

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -1105,9 +1105,8 @@ object LabelTable {
     val cityId: String = Play.configuration.getString("city-id").get
     val launchDate: String = Play.configuration.getString(s"city-params.launch-date.$cityId").get
 
-    val recentLabelDates = labels.sortBy(_.timeCreated.desc).take(10).list.map(label => label.timeCreated)
-    val avgRecentLabels = new Timestamp(recentLabelDates.map(date => date.getTime).sum / recentLabelDates.length)
-    println(avgRecentLabels)
+    val recentLabelDates: List[Timestamp] = labels.sortBy(_.timeCreated.desc).take(100).list.map(_.timeCreated)
+    val avgRecentLabels: Timestamp = new Timestamp(recentLabelDates.map(_.getTime).sum / recentLabelDates.length)
 
     val overallStatsQuery = Q.queryNA[ProjectSidewalkStats](
       s"""SELECT '$launchDate' AS launch_date,


### PR DESCRIPTION
Resolves #3430 

Takes the 100 most recent labels in the city, takes the average of those dates, and adds it to the Overall Stats API. 
Field is called "Recent Labels Average Timestamp" in csv format for readability, but "avg_timestamp_last_100_labels" for detail in JSON format and the case class fields.

##### Before/After screenshots (if applicable)
![image](https://github.com/ProjectSidewalk/SidewalkWebpage/assets/77756028/30ee0ee3-989b-4ab1-9af1-3f3cd460bcfe)

##### Testing instructions
1. Call the OverallStats API (http://localhost:9000/v2/overallStats)
2. Check that the "Recent Labels Average Timestamp"/"avg_timestamp_last_100_labels" field and ensure that the date makes sense with the current labels in the database.
3. Check all filetype formats (CSV, JSON) to make sure field comes through on all formats.

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.