### PR TITLE
Allow sbt -mem arg to be configured in start-no-docker

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "build": "npm install && grunt",
         "debug": "npm run grunt-concat && grunt watch & sbt -jvm-debug 9998 run",
         "start": "npm run grunt-concat && grunt watch & sbt -Dsbt.ivy.home='.ivy2' -Dsbt.global.base='.sbt' -Dsbt.repository.config='.sbt/repositories' -mem 1536 compile \"~ run\" shell",
-        "start-no-docker": "npm run grunt-concat && grunt watch & sbt -Dhttp.port=$SIDEWALK_HTTP_PORT -Dsbt.ivy.home='.ivy2' -Dsbt.global.base='.sbt' -Dsbt.repository.config='.sbt/repositories' -mem 1536 compile \"~ run\" shell",
+        "start-no-docker": "npm run grunt-concat && grunt watch & sbt -Dhttp.port=$SIDEWALK_HTTP_PORT -Dsbt.ivy.home='.ivy2' -Dsbt.global.base='.sbt' -Dsbt.repository.config='.sbt/repositories' $SBT_MEM_ARG compile \"~ run\" shell",
         "test": "grunt && grunt test"
     }
 }


### PR DESCRIPTION
A previous change upped the JVM memory allocation to 1536MB to temporarily mitigate issues with API calls.  However, these issues were only being encountered on the largest of the city sites (Seattle), while the change upped the memory allocation for all sites, both in test and prod.  We are currently in the process of moving all of the test and prod servers to a single host, and with 24 of the 40 sites moved, it is starting to bump up against its total RAM, and use swap.
This change allows us to configure JVM memory allocations for individual server instances.  Thus, we can raise the allocation only for Seattle, and save ~20GB of resident memory, which will help keep us from heavily using swap as we move the rest of the sites over.

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
