### PR TITLE
3420 leaderboard lableing guide link update

### DIFF
--- a/app/models/utils/Configs.scala
+++ b/app/models/utils/Configs.scala
@@ -35,4 +35,11 @@ object Configs {
     }
     cityInfo
   }
+
+  def getCurrentCountryId(): String = {
+    val cityId: String = Play.configuration.getString("city-id").get
+    val currentCountryId: String = Play.configuration.getString(s"city-params.country-id.$cityId").get
+    currentCountryId
+  }
+
 }

--- a/app/views/leaderboard.scala.html
+++ b/app/views/leaderboard.scala.html
@@ -330,11 +330,10 @@
     } else {
         @if(UserOrgTable.getAllOrgs(user.get.userId).isEmpty) {
             @if(currentCityInfo.countryId == "taiwan") {
-                Want to improve your accuracy? Read our <a id="encouragement-link" href="@routes.Assets.at("documents/labeling-guide-Taiwan.pdf")"><u>labeling guide</u></a> and view your recent incorrect labels on <a id="encouragement-link" href="/dashboard#recent-mistakes"><u>your dashboard</u></a>
+                @Html(Messages("leaderboard.encouragement.no.org", routes.Assets.at("documents/labeling-guide-Taiwan.pdf").url))
             } else {
-                @Html(Messages("leaderboard.encouragement.no.org"))
+                @Html(Messages("leaderboard.encouragement.no.org", "/labelingGuide"))
             }
-            
         } else {
             @Html(Messages("leaderboard.encouragement"))
         }

--- a/app/views/leaderboard.scala.html
+++ b/app/views/leaderboard.scala.html
@@ -330,7 +330,7 @@
     } else {
         @if(UserOrgTable.getAllOrgs(user.get.userId).isEmpty) {
             @if(currentCityInfo.countryId == "taiwan") {
-                <a class="navbar-button" id="navbar-guide-btn" href="@routes.Assets.at("documents/labeling-guide-Taiwan.pdf")" target="_blank">@Messages("navbar.howto")</a>
+                Want to improve your accuracy? Read our <a id="encouragement-link" href="@routes.Assets.at("documents/labeling-guide-Taiwan.pdf")"><u>labeling guide</u></a> and view your recent incorrect labels on <a id="encouragement-link" href="/dashboard#recent-mistakes"><u>your dashboard</u></a>
             } else {
                 @Html(Messages("leaderboard.encouragement.no.org"))
             }

--- a/app/views/leaderboard.scala.html
+++ b/app/views/leaderboard.scala.html
@@ -1,4 +1,7 @@
 @import models.user._
+@import play.api.Play
+@import play.api.Play.current
+@import models.utils.Configs
 
 @(min: Int = 1, user: Option[User] = None, url: Option[String] = Some("/"))(implicit lang: Lang)
 
@@ -6,13 +9,7 @@
 @leaderboardStatsThisWeek = @{UserStatTable.getLeaderboardStats(10, "weekly")}
 @leaderboardStatsByOrg = @{UserStatTable.getLeaderboardStats(10, "overall", true)}
 @leaderboardStatsOrg = @{UserStatTable.getLeaderboardStats(10, "overall", false, UserOrgTable.getAllOrgs(user.get.userId).headOption)}
-@import play.api.Play
-@import play.api.Play.current
-@import models.utils.Configs
-
-@currentCityId =@{Play.configuration.getString("city-id").get}
-@cityInfo = @{Configs.getAllCityInfo(lang).filter(c => c.cityId == currentCityId || c.visibility == "public" || (List("taipei", "new-taipei-tw", "keelung-tw").contains(currentCityId) && List("taipei", "new-taipei-tw", "keelung-tw").contains(c.cityId)))}
-@currentCityInfo = @{cityInfo.filter(c => c.cityId == currentCityId).head}
+@currentCountryId =@{Configs.getCurrentCountryId()}
 
 <div class="leaderboard-container">
     <div class="item leaderboard-table">
@@ -329,7 +326,7 @@
         @Html(Messages("leaderboard.encouragement.no.user"))
     } else {
         @if(UserOrgTable.getAllOrgs(user.get.userId).isEmpty) {
-            @if(currentCityInfo.countryId == "taiwan") {
+            @if(currentCountryId == "taiwan") {
                 @Html(Messages("leaderboard.encouragement.no.org", routes.Assets.at("documents/labeling-guide-Taiwan.pdf").url))
             } else {
                 @Html(Messages("leaderboard.encouragement.no.org", "/labelingGuide"))

--- a/app/views/leaderboard.scala.html
+++ b/app/views/leaderboard.scala.html
@@ -6,7 +6,13 @@
 @leaderboardStatsThisWeek = @{UserStatTable.getLeaderboardStats(10, "weekly")}
 @leaderboardStatsByOrg = @{UserStatTable.getLeaderboardStats(10, "overall", true)}
 @leaderboardStatsOrg = @{UserStatTable.getLeaderboardStats(10, "overall", false, UserOrgTable.getAllOrgs(user.get.userId).headOption)}
+@import play.api.Play
+@import play.api.Play.current
+@import models.utils.Configs
 
+@currentCityId =@{Play.configuration.getString("city-id").get}
+@cityInfo = @{Configs.getAllCityInfo(lang).filter(c => c.cityId == currentCityId || c.visibility == "public" || (List("taipei", "new-taipei-tw", "keelung-tw").contains(currentCityId) && List("taipei", "new-taipei-tw", "keelung-tw").contains(c.cityId)))}
+@currentCityInfo = @{cityInfo.filter(c => c.cityId == currentCityId).head}
 
 <div class="leaderboard-container">
     <div class="item leaderboard-table">
@@ -323,7 +329,12 @@
         @Html(Messages("leaderboard.encouragement.no.user"))
     } else {
         @if(UserOrgTable.getAllOrgs(user.get.userId).isEmpty) {
-            @Html(Messages("leaderboard.encouragement.no.org"))
+            @if(currentCityInfo.countryId == "taiwan") {
+                <a class="navbar-button" id="navbar-guide-btn" href="@routes.Assets.at("documents/labeling-guide-Taiwan.pdf")" target="_blank">@Messages("navbar.howto")</a>
+            } else {
+                @Html(Messages("leaderboard.encouragement.no.org"))
+            }
+            
         } else {
             @Html(Messages("leaderboard.encouragement"))
         }

--- a/conf/messages.de
+++ b/conf/messages.de
@@ -349,7 +349,7 @@ leaderboard.tooltip.accuracy = Die Genauigkeit wird nur angezeigt, wenn mindeste
 leaderboard.tooltip.weekly.reset = Die Statistik wird jeden Sonntag Morgen um 0:00 Uhr PT zurückgesetzt.
 leaderboard.encouragement = Wollen Sie es unter die Top 10 schaffen? <a id="encouragement-link" href="/explore"><u>Erkundung starten!</u></a>
 leaderboard.encouragement.no.user = <a id="encouragement-link" href="/signUp"><u>Registrieren</u></a> Sie sich, um Ihren Fortschritt zu verfolgen!
-leaderboard.encouragement.no.org = Möchten Sie Ihre Genauigkeit verbessern? Lesen Sie unseren <a id="encouragement-link" href="/labelingGuide"><u>Etikettierungsleitfaden</u></a> und sehen Sie sich Ihre letzten falschen Etiketten auf <a id="encouragement-link" href="/dashboard#recent-mistakes"><u>Ihrem Dashboard</u></a> an
+leaderboard.encouragement.no.org = Möchten Sie Ihre Genauigkeit verbessern? Lesen Sie unseren <a id="encouragement-link" href="{0}" target="_blank"><u>Etikettierungsleitfaden</u></a> und sehen Sie sich Ihre letzten falschen Etiketten auf <a id="encouragement-link" href="/dashboard#recent-mistakes"><u>Ihrem Dashboard</u></a> an
 
 gallery = Galerie
 gallery.filter.by = Filtern nach

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -344,7 +344,7 @@ leaderboard.tooltip.accuracy = Accuracy is only shown if at least 10 of your lab
 leaderboard.tooltip.weekly.reset = Stats reset every Sunday morning at 12 AM Pacific
 leaderboard.encouragement = Want to make it into the Top 10? <a id="encouragement-link" href="/explore"><u>Start exploring!</u></a>
 leaderboard.encouragement.no.user = <a id="encouragement-link" href="/signUp"><u>Sign up</u></a> to track your progress!
-leaderboard.encouragement.no.org = Want to improve your accuracy? Read our <a id="encouragement-link" href="{0}"><u>labeling guide</u></a> and view your recent incorrect labels on <a id="encouragement-link" href="/dashboard#recent-mistakes"><u>your dashboard</u></a>
+leaderboard.encouragement.no.org = Want to improve your accuracy? Read our <a id="encouragement-link" href="{0}" target="_blank"><u>labeling guide</u></a> and view your recent incorrect labels on <a id="encouragement-link" href="/dashboard#recent-mistakes"><u>your dashboard</u></a>
 
 gallery = Gallery
 gallery.filter.by = Filter By

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -344,7 +344,7 @@ leaderboard.tooltip.accuracy = Accuracy is only shown if at least 10 of your lab
 leaderboard.tooltip.weekly.reset = Stats reset every Sunday morning at 12 AM Pacific
 leaderboard.encouragement = Want to make it into the Top 10? <a id="encouragement-link" href="/explore"><u>Start exploring!</u></a>
 leaderboard.encouragement.no.user = <a id="encouragement-link" href="/signUp"><u>Sign up</u></a> to track your progress!
-leaderboard.encouragement.no.org = Want to improve your accuracy? Read our <a id="encouragement-link" href="/labelingGuide"><u>labeling guide</u></a> and view your recent incorrect labels on <a id="encouragement-link" href="/dashboard#recent-mistakes"><u>your dashboard</u></a>
+leaderboard.encouragement.no.org = Want to improve your accuracy? Read our <a id="encouragement-link" href="{0}"><u>labeling guide</u></a> and view your recent incorrect labels on <a id="encouragement-link" href="/dashboard#recent-mistakes"><u>your dashboard</u></a>
 
 gallery = Gallery
 gallery.filter.by = Filter By

--- a/conf/messages.en-NZ
+++ b/conf/messages.en-NZ
@@ -43,5 +43,3 @@ dashboard.no.org = No Organisation
 dashboard.edit.info = If you don''t see your organisation, please email <a id="email-link" href="mailto:sidewalk@cs.uw.edu" target="_blank">sidewalk@cs.uw.edu</a> and include your organisation name and description.
 dashboard.orgs.unavailable = There are no available organisations!
 dashboard.leave.org = Leave Organisation
-
-leaderboard.encouragement.no.org = <a id="encouragement-link" href="/dashboard"><u>Join an organisation</u></a> and work together as a team to map and assess footpaths!

--- a/conf/messages.es
+++ b/conf/messages.es
@@ -351,7 +351,7 @@ leaderboard.tooltip.accuracy = La precisión sólo se muestra si al menos 10 de 
 leaderboard.tooltip.weekly.reset = Las estadísticas se restablecen todos los domingos por la mañana a las 12:00 a.m. (PT)
 leaderboard.encouragement = ¿Quieres entrar en el Top 10? <a id="encouragement-link" href="/explore"><u>¡Empieza a explorar!</u></a>
 leaderboard.encouragement.no.user = ¡<a id="encouragement-link" href="/signUp"><u>Regístrate</u></a> para seguir tu progreso!
-leaderboard.encouragement.no.org = ¿Quieres mejorar tu precisión? Lea nuestra <a id="encouragement-link" href="/labelingGuide"><u>guía de etiquetado</u></a> y vea sus etiquetas incorrectas recientes en <a id="encouragement-link" href="/dashboard#recent-mistakes"><u>su tablero</u></a>
+leaderboard.encouragement.no.org = ¿Quieres mejorar tu precisión? Lea nuestra <a id="encouragement-link" href="{0}"><u>guía de etiquetado</u></a> y vea sus etiquetas incorrectas recientes en <a id="encouragement-link" href="/dashboard#recent-mistakes"><u>su tablero</u></a>
 
 gallery = Galería
 gallery.filter.by = Filtrar por

--- a/conf/messages.es
+++ b/conf/messages.es
@@ -351,7 +351,7 @@ leaderboard.tooltip.accuracy = La precisión sólo se muestra si al menos 10 de 
 leaderboard.tooltip.weekly.reset = Las estadísticas se restablecen todos los domingos por la mañana a las 12:00 a.m. (PT)
 leaderboard.encouragement = ¿Quieres entrar en el Top 10? <a id="encouragement-link" href="/explore"><u>¡Empieza a explorar!</u></a>
 leaderboard.encouragement.no.user = ¡<a id="encouragement-link" href="/signUp"><u>Regístrate</u></a> para seguir tu progreso!
-leaderboard.encouragement.no.org = ¿Quieres mejorar tu precisión? Lea nuestra <a id="encouragement-link" href="{0}"><u>guía de etiquetado</u></a> y vea sus etiquetas incorrectas recientes en <a id="encouragement-link" href="/dashboard#recent-mistakes"><u>su tablero</u></a>
+leaderboard.encouragement.no.org = ¿Quieres mejorar tu precisión? Lea nuestra <a id="encouragement-link" href="{0}" target="_blank"><u>guía de etiquetado</u></a> y vea sus etiquetas incorrectas recientes en <a id="encouragement-link" href="/dashboard#recent-mistakes"><u>su tablero</u></a>
 
 gallery = Galería
 gallery.filter.by = Filtrar por

--- a/conf/messages.nl
+++ b/conf/messages.nl
@@ -351,7 +351,7 @@ leaderboard.tooltip.accuracy = Nauwkeurigheid wordt alleen weergegeven als ten m
 leaderboard.tooltip.weekly.reset = Statistieken worden elke zondagochtend om 12.00 uur Pacific Time gereset
 leaderboard.encouragement = Wil je in de Top 10 komen? <a id="encouragement-link" href="/explore"><u>Begin met verkennen!</u></a>
 leaderboard.encouragement.no.user = <a id="encouragement-link" href="/signUp"><u>Meld je aan</u></a> om je voortgang bij te houden!
-leaderboard.encouragement.no.org = Wilt u uw nauwkeurigheid verbeteren? Lees onze <a id="encouragement-link" href="{0}"><u>labelgids</u></a> en bekijk uw recente onjuiste labels op <a id="encouragement-link" href="/dashboard#recent-mistakes"><u>uw dashboard</u></a>
+leaderboard.encouragement.no.org = Wilt u uw nauwkeurigheid verbeteren? Lees onze <a id="encouragement-link" href="{0}" target="_blank"><u>labelgids</u></a> en bekijk uw recente onjuiste labels op <a id="encouragement-link" href="/dashboard#recent-mistakes"><u>uw dashboard</u></a>
 
 gallery = Galerij
 gallery.filter.by = Filteren op

--- a/conf/messages.nl
+++ b/conf/messages.nl
@@ -351,7 +351,7 @@ leaderboard.tooltip.accuracy = Nauwkeurigheid wordt alleen weergegeven als ten m
 leaderboard.tooltip.weekly.reset = Statistieken worden elke zondagochtend om 12.00 uur Pacific Time gereset
 leaderboard.encouragement = Wil je in de Top 10 komen? <a id="encouragement-link" href="/explore"><u>Begin met verkennen!</u></a>
 leaderboard.encouragement.no.user = <a id="encouragement-link" href="/signUp"><u>Meld je aan</u></a> om je voortgang bij te houden!
-leaderboard.encouragement.no.org = Wilt u uw nauwkeurigheid verbeteren? Lees onze <a id="encouragement-link" href="/labelingGuide"><u>labelgids</u></a> en bekijk uw recente onjuiste labels op <a id="encouragement-link" href="/dashboard#recent-mistakes"><u>uw dashboard</u></a>
+leaderboard.encouragement.no.org = Wilt u uw nauwkeurigheid verbeteren? Lees onze <a id="encouragement-link" href="{0}"><u>labelgids</u></a> en bekijk uw recente onjuiste labels op <a id="encouragement-link" href="/dashboard#recent-mistakes"><u>uw dashboard</u></a>
 
 gallery = Galerij
 gallery.filter.by = Filteren op

--- a/conf/messages.zh-TW
+++ b/conf/messages.zh-TW
@@ -375,7 +375,7 @@ leaderboard.tooltip.accuracy = 僅當至少您的10個標記獲得檢核時才�
 leaderboard.tooltip.weekly.reset = 每週日上午12點重置統計數據
 leaderboard.encouragement = 想進入排行榜前10名嗎？ <a id="encouragement-link" href="/explore"><u>開始探索這張地圖吧！</u></a>
 leaderboard.encouragement.no.user = <a id="encouragement-link" href="/signUp"><u>註冊</u></a>以開始追蹤您的參與進度！
-leaderboard.encouragement.no.org = 想提高你的準確性嗎？閱讀我們的<a id="encouragement-link" href="/labelingGuide"><u>標記指南</u></a>並在<a id="encouragement-link" href="/dashboard#recent-mistakes"><u>儀表板</u></a>上查看最近的錯誤標籤
+leaderboard.encouragement.no.org = 想提高你的準確性嗎？閱讀我們的<a id="encouragement-link" href="{0}"><u>標記指南</u></a>並在<a id="encouragement-link" href="/dashboard#recent-mistakes"><u>儀表板</u></a>上查看最近的錯誤標籤
 
 gallery = 標記彙整
 gallery.filter.by = 篩選

--- a/conf/messages.zh-TW
+++ b/conf/messages.zh-TW
@@ -375,7 +375,7 @@ leaderboard.tooltip.accuracy = 僅當至少您的10個標記獲得檢核時才�
 leaderboard.tooltip.weekly.reset = 每週日上午12點重置統計數據
 leaderboard.encouragement = 想進入排行榜前10名嗎？ <a id="encouragement-link" href="/explore"><u>開始探索這張地圖吧！</u></a>
 leaderboard.encouragement.no.user = <a id="encouragement-link" href="/signUp"><u>註冊</u></a>以開始追蹤您的參與進度！
-leaderboard.encouragement.no.org = 想提高你的準確性嗎？閱讀我們的<a id="encouragement-link" href="{0}"><u>標記指南</u></a>並在<a id="encouragement-link" href="/dashboard#recent-mistakes"><u>儀表板</u></a>上查看最近的錯誤標籤
+leaderboard.encouragement.no.org = 想提高你的準確性嗎？閱讀我們的<a id="encouragement-link" href="{0}" target="_blank"><u>標記指南</u></a>並在<a id="encouragement-link" href="/dashboard#recent-mistakes"><u>儀表板</u></a>上查看最近的錯誤標籤
 
 gallery = 標記彙整
 gallery.filter.by = 篩選


### PR DESCRIPTION
Resolves labeling guide links point to different places https://github.com/ProjectSidewalk/SidewalkWebpage/issues/3420

This fix was made by writing a parameter into the text for the links to the labeling guide on the leaderboard, and inserting the proper link in as the argument.

##### Before/After screenshots (if applicable)
The following screenshots are for the taiwan country id: 
BEFORE: We go from the first screen to the second after clicking the labeling guide link:
<img width="1150" alt="image" src="https://github.com/ProjectSidewalk/SidewalkWebpage/assets/86600946/f3eee797-1caa-4d26-91e7-70006eb512ae">
to
<img width="1185" alt="image" src="https://github.com/ProjectSidewalk/SidewalkWebpage/assets/86600946/3f8c67f3-b6a8-4e9a-ba9d-3bd9fda4bdab">

AFTER: This is the new flow (for taiwan):
<img width="1185" alt="image" src="https://github.com/ProjectSidewalk/SidewalkWebpage/assets/86600946/83f08dea-e528-463b-81f9-21ff5e4c8418">
to 
<img width="1185" alt="image" src="https://github.com/ProjectSidewalk/SidewalkWebpage/assets/86600946/ed25aa34-af35-4ac0-93f5-a2e804a7bde5">


##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've included before/after screenshots above.
