### PR TITLE
Adds automatic CSS zoom for Explore/Validate pages

### DIFF
--- a/app/controllers/TaskController.scala
+++ b/app/controllers/TaskController.scala
@@ -220,7 +220,7 @@ class TaskController @Inject() (implicit val env: Environment[User, SessionAuthe
       val userOption: Option[User] = identity
       val streetEdgeId: Int = data.auditTask.streetEdgeId
       val missionId: Int = data.missionProgress.missionId
-      val currTime: Timestamp = new Timestamp(Instant.now.toEpochMilli)
+      val currTime: Timestamp = new Timestamp(data.timestamp)
 
       if (data.auditTask.auditTaskId.isDefined) {
         val priorityBefore: StreetEdgePriority = streetPrioritiesFromIds(List(streetEdgeId)).head
@@ -356,7 +356,7 @@ class TaskController @Inject() (implicit val env: Environment[User, SessionAuthe
       val env: EnvironmentSubmission = data.environment
       val taskEnv:AuditTaskEnvironment = AuditTaskEnvironment(0, auditTaskId, missionId, env.browser,
         env.browserVersion, env.browserWidth, env.browserHeight, env.availWidth, env.availHeight, env.screenWidth,
-        env.screenHeight, env.operatingSystem, Some(remoteAddress), env.language)
+        env.screenHeight, env.operatingSystem, Some(remoteAddress), env.language, env.cssZoom, Some(currTime))
       AuditTaskEnvironmentTable.save(taskEnv)
 
       // Insert Street View metadata.
@@ -364,7 +364,7 @@ class TaskController @Inject() (implicit val env: Environment[User, SessionAuthe
         // Insert new entry to gsv_data table, or update the last_viewed column if we've already recorded it.
         if (GSVDataTable.panoramaExists(pano.gsvPanoramaId)) {
           GSVDataTable.updateFromExplore(pano.gsvPanoramaId, pano.lat, pano.lng, pano.cameraHeading,
-            pano.cameraPitch, false, currTime)
+            pano.cameraPitch, expired = false, currTime)
         } else {
           val gsvData: GSVData = GSVData(pano.gsvPanoramaId, pano.width, pano.height, pano.tileWidth, pano.tileHeight,
             pano.captureDate, pano.copyright, pano.lat, pano.lng, pano.cameraHeading, pano.cameraPitch, expired = false,

--- a/app/controllers/ValidationTaskController.scala
+++ b/app/controllers/ValidationTaskController.scala
@@ -39,6 +39,7 @@ class ValidationTaskController @Inject() (implicit val env: Environment[User, Se
    */
   def processValidationTaskSubmissions(data: ValidationTaskSubmission, remoteAddress: String, identity: Option[User]) = {
     val userOption = identity
+    val currTime = new Timestamp(data.timestamp)
     ValidationTaskInteractionTable.saveMultiple(data.interactions.map { interaction =>
       ValidationTaskInteraction(0, interaction.missionId, interaction.action, interaction.gsvPanoramaId,
         interaction.lat, interaction.lng, interaction.heading, interaction.pitch, interaction.zoom, interaction.note,
@@ -49,7 +50,7 @@ class ValidationTaskController @Inject() (implicit val env: Environment[User, Se
     val env: EnvironmentSubmission = data.environment
     val taskEnv: ValidationTaskEnvironment = ValidationTaskEnvironment(0, env.missionId, env.browser,
       env.browserVersion, env.browserWidth, env.browserHeight, env.availWidth, env.availHeight, env.screenWidth,
-      env.screenHeight, env.operatingSystem, Some(remoteAddress), env.language)
+      env.screenHeight, env.operatingSystem, Some(remoteAddress), env.language, env.cssZoom, Some(currTime))
     ValidationTaskEnvironmentTable.save(taskEnv)
 
     // We aren't always submitting labels, so check if data.labels exists.

--- a/app/formats/json/TaskSubmissionFormats.scala
+++ b/app/formats/json/TaskSubmissionFormats.scala
@@ -7,7 +7,7 @@ import scala.collection.immutable.Seq
 import play.api.libs.functional.syntax._
 
 object TaskSubmissionFormats {
-  case class EnvironmentSubmission(browser: Option[String], browserVersion: Option[String], browserWidth: Option[Int], browserHeight: Option[Int], availWidth: Option[Int], availHeight: Option[Int], screenWidth: Option[Int], screenHeight: Option[Int], operatingSystem: Option[String], language: String)
+  case class EnvironmentSubmission(browser: Option[String], browserVersion: Option[String], browserWidth: Option[Int], browserHeight: Option[Int], availWidth: Option[Int], availHeight: Option[Int], screenWidth: Option[Int], screenHeight: Option[Int], operatingSystem: Option[String], language: String, cssZoom: Int)
   case class InteractionSubmission(action: String, gsvPanoramaId: Option[String], lat: Option[Float], lng: Option[Float], heading: Option[Float], pitch: Option[Float], zoom: Option[Int], note: Option[String], temporaryLabelId: Option[Int], timestamp: Long)
   case class LabelPointSubmission(panoX: Int, panoY: Int, canvasX: Int, canvasY: Int, heading: Float, pitch: Float, zoom: Int, lat: Option[Float], lng: Option[Float], computationMethod: Option[String])
   case class LabelSubmission(gsvPanoramaId: String, auditTaskId: Int, labelType: String, deleted: Boolean, severity: Option[Int], temporary: Boolean, description: Option[String], tagIds: Seq[Int], point: LabelPointSubmission, temporaryLabelId:Int, timeCreated: Option[Long], tutorial: Boolean)
@@ -16,7 +16,7 @@ object TaskSubmissionFormats {
   case class GSVLinkSubmission(targetGsvPanoramaId: String, yawDeg: Double, description: String)
   case class GSVPanoramaSubmission(gsvPanoramaId: String, captureDate: String, width: Option[Int], height: Option[Int], tileWidth: Option[Int], tileHeight: Option[Int], lat: Option[Float], lng: Option[Float], cameraHeading: Option[Float], cameraPitch: Option[Float], links: Seq[GSVLinkSubmission], copyright: String)
   case class AuditMissionProgress(missionId: Int, distanceProgress: Option[Float], completed: Boolean, auditTaskId: Option[Int], skipped: Boolean)
-  case class AuditTaskSubmission(missionProgress: AuditMissionProgress, auditTask: TaskSubmission, labels: Seq[LabelSubmission], interactions: Seq[InteractionSubmission], environment: EnvironmentSubmission, incomplete: Option[IncompleteTaskSubmission], gsvPanoramas: Seq[GSVPanoramaSubmission], amtAssignmentId: Option[Int], userRouteId: Option[Int])
+  case class AuditTaskSubmission(missionProgress: AuditMissionProgress, auditTask: TaskSubmission, labels: Seq[LabelSubmission], interactions: Seq[InteractionSubmission], environment: EnvironmentSubmission, incomplete: Option[IncompleteTaskSubmission], gsvPanoramas: Seq[GSVPanoramaSubmission], amtAssignmentId: Option[Int], userRouteId: Option[Int], timestamp: Long)
   case class AMTAssignmentCompletionSubmission(assignmentId: Int, completed: Option[Boolean])
 
   implicit val pointReads: Reads[Point] = (
@@ -40,7 +40,8 @@ object TaskSubmissionFormats {
       (JsPath \ "screen_width").readNullable[Int] and
       (JsPath \ "screen_height").readNullable[Int] and
       (JsPath \ "operating_system").readNullable[String] and
-      (JsPath \ "language").read[String]
+      (JsPath \ "language").read[String] and
+      (JsPath \ "css_zoom").read[Int]
     )(EnvironmentSubmission.apply _)
 
   implicit val interactionSubmissionReads: Reads[InteractionSubmission] = (
@@ -135,7 +136,8 @@ object TaskSubmissionFormats {
       (JsPath \ "incomplete").readNullable[IncompleteTaskSubmission] and
       (JsPath \ "gsv_panoramas").read[Seq[GSVPanoramaSubmission]] and
       (JsPath \ "amt_assignment_id").readNullable[Int] and
-      (JsPath \ "user_route_id").readNullable[Int]
+      (JsPath \ "user_route_id").readNullable[Int] and
+      (JsPath \ "timestamp").read[Long]
     )(AuditTaskSubmission.apply _)
 
   implicit val amtAssignmentCompletionReads: Reads[AMTAssignmentCompletionSubmission] = (

--- a/app/formats/json/ValidationTaskSubmissionFormats.scala
+++ b/app/formats/json/ValidationTaskSubmissionFormats.scala
@@ -7,12 +7,12 @@ import scala.collection.immutable.Seq
 import play.api.libs.functional.syntax._
 
 object ValidationTaskSubmissionFormats {
-  case class EnvironmentSubmission(missionId: Option[Int], browser: Option[String], browserVersion: Option[String], browserWidth: Option[Int], browserHeight: Option[Int], availWidth: Option[Int], availHeight: Option[Int], screenWidth: Option[Int], screenHeight: Option[Int], operatingSystem: Option[String], language: String)
+  case class EnvironmentSubmission(missionId: Option[Int], browser: Option[String], browserVersion: Option[String], browserWidth: Option[Int], browserHeight: Option[Int], availWidth: Option[Int], availHeight: Option[Int], screenWidth: Option[Int], screenHeight: Option[Int], operatingSystem: Option[String], language: String, cssZoom: Int)
   case class InteractionSubmission(action: String, missionId: Option[Int], gsvPanoramaId: Option[String], lat: Option[Float], lng: Option[Float], heading: Option[Float], pitch: Option[Float], zoom: Option[Float], note: Option[String], timestamp: Long, isMobile: Boolean)
   case class LabelValidationSubmission(labelId: Int, missionId: Int, validationResult: Int, canvasX: Option[Int], canvasY: Option[Int], heading: Float, pitch: Float, zoom: Float, canvasHeight: Int, canvasWidth: Int, startTimestamp: Long, endTimestamp: Long, source: String)
   case class SkipLabelSubmission(labels: Seq[LabelValidationSubmission])
   case class ValidationMissionProgress(missionId: Int, missionType: String, labelsProgress: Int, labelTypeId: Int, completed: Boolean, skipped: Boolean)
-  case class ValidationTaskSubmission(interactions: Seq[InteractionSubmission], environment: EnvironmentSubmission, labels: Seq[LabelValidationSubmission], missionProgress: Option[ValidationMissionProgress])
+  case class ValidationTaskSubmission(interactions: Seq[InteractionSubmission], environment: EnvironmentSubmission, labels: Seq[LabelValidationSubmission], missionProgress: Option[ValidationMissionProgress], timestamp: Long)
   case class LabelMapValidationSubmission(labelId: Int, labelType: String, validationResult: Int, canvasX: Option[Int], canvasY: Option[Int], heading: Float, pitch: Float, zoom: Float, canvasHeight: Int, canvasWidth: Int, startTimestamp: Long, endTimestamp: Long, source: String)
 
   implicit val environmentSubmissionReads: Reads[EnvironmentSubmission] = (
@@ -26,7 +26,8 @@ object ValidationTaskSubmissionFormats {
       (JsPath \ "screen_width").readNullable[Int] and
       (JsPath \ "screen_height").readNullable[Int] and
       (JsPath \ "operating_system").readNullable[String] and
-      (JsPath \ "language").read[String]
+      (JsPath \ "language").read[String] and
+      (JsPath \ "css_zoom").read[Int]
     )(EnvironmentSubmission.apply _)
 
   implicit val interactionSubmissionReads: Reads[InteractionSubmission] = (
@@ -72,8 +73,9 @@ object ValidationTaskSubmissionFormats {
     (JsPath \ "interactions").read[Seq[InteractionSubmission]] and
       (JsPath \ "environment").read[EnvironmentSubmission] and
       (JsPath \ "labels").read[Seq[LabelValidationSubmission]] and
-      (JsPath \ "missionProgress").readNullable[ValidationMissionProgress]
-    )(ValidationTaskSubmission.apply _) // .map(ValidationTaskSubmission(_))
+      (JsPath \ "missionProgress").readNullable[ValidationMissionProgress] and
+      (JsPath \ "timestamp").read[Long]
+    )(ValidationTaskSubmission.apply _)
 
   implicit val labelMapValidationSubmissionReads: Reads[LabelMapValidationSubmission] = (
     (JsPath \ "label_id").read[Int] and

--- a/app/models/audit/AuditTaskEnvironmentTable.scala
+++ b/app/models/audit/AuditTaskEnvironmentTable.scala
@@ -9,7 +9,7 @@ case class AuditTaskEnvironment(auditTaskEnvironmentId: Int, auditTaskId: Int, m
                                 browserVersion: Option[String], browserWidth: Option[Int], browserHeight: Option[Int],
                                 availWidth: Option[Int], availHeight: Option[Int], screenWidth: Option[Int],
                                 screenHeight: Option[Int], operatingSystem: Option[String], ipAddress: Option[String],
-                                language: String)
+                                language: String, cssZoom: Int, timestamp: Option[java.sql.Timestamp])
 
 class AuditTaskEnvironmentTable(tag: Tag) extends Table[AuditTaskEnvironment](tag, "audit_task_environment") {
   def auditTaskEnvironmentId = column[Int]("audit_task_environment_id", O.PrimaryKey, O.AutoInc)
@@ -26,9 +26,11 @@ class AuditTaskEnvironmentTable(tag: Tag) extends Table[AuditTaskEnvironment](ta
   def operatingSystem = column[Option[String]]("operating_system", O.Nullable)
   def ipAddress = column[Option[String]]("ip_address", O.Nullable)
   def language = column[String]("language", O.NotNull)
+  def cssZoom = column[Int]("css_zoom", O.NotNull)
+  def timestamp = column[Option[java.sql.Timestamp]]("timestamp", O.Nullable)
 
   def * = (auditTaskEnvironmentId, auditTaskId, missionId, browser, browserVersion, browserWidth, browserHeight,
-    availWidth, availHeight, screenWidth, screenHeight, operatingSystem, ipAddress, language) <> ((AuditTaskEnvironment.apply _).tupled, AuditTaskEnvironment.unapply)
+    availWidth, availHeight, screenWidth, screenHeight, operatingSystem, ipAddress, language, cssZoom, timestamp) <> ((AuditTaskEnvironment.apply _).tupled, AuditTaskEnvironment.unapply)
 
   def auditTask: ForeignKeyQuery[AuditTaskTable, AuditTask] =
     foreignKey("audit_task_environment_audit_task_id_fkey", auditTaskId, TableQuery[AuditTaskTable])(_.auditTaskId)

--- a/app/models/validation/ValidationTaskEnvironmentTable.scala
+++ b/app/models/validation/ValidationTaskEnvironmentTable.scala
@@ -9,7 +9,7 @@ case class ValidationTaskEnvironment(validationTaskEnvironmentId: Int, missionId
                                 browserVersion: Option[String], browserWidth: Option[Int], browserHeight: Option[Int],
                                 availWidth: Option[Int], availHeight: Option[Int], screenWidth: Option[Int],
                                 screenHeight: Option[Int], operatingSystem: Option[String], ipAddress: Option[String],
-                                language: String)
+                                language: String, cssZoom: Int, timestamp: Option[java.sql.Timestamp])
 
 class ValidationTaskEnvironmentTable(tag: Tag) extends Table[ValidationTaskEnvironment](tag, "validation_task_environment") {
   def validationTaskEnvironmentId = column[Int]("validation_task_environment_id", O.PrimaryKey, O.AutoInc)
@@ -25,9 +25,11 @@ class ValidationTaskEnvironmentTable(tag: Tag) extends Table[ValidationTaskEnvir
   def operatingSystem = column[Option[String]]("operating_system", O.Nullable)
   def ipAddress = column[Option[String]]("ip_address", O.Nullable)
   def language = column[String]("language", O.NotNull)
+  def cssZoom = column[Int]("css_zoom", O.NotNull)
+  def timestamp = column[Option[java.sql.Timestamp]]("timestamp", O.Nullable)
 
   def * = (validationTaskEnvironmentId, missionId, browser, browserVersion, browserWidth, browserHeight, availWidth,
-    availHeight, screenWidth, screenHeight, operatingSystem, ipAddress, language) <> ((ValidationTaskEnvironment.apply _).tupled, ValidationTaskEnvironment.unapply)
+    availHeight, screenWidth, screenHeight, operatingSystem, ipAddress, language, cssZoom, timestamp) <> ((ValidationTaskEnvironment.apply _).tupled, ValidationTaskEnvironment.unapply)
 
   def mission: ForeignKeyQuery[MissionTable, Mission] =
     foreignKey("validation_task_environment_mission_id_fkey", missionId, TableQuery[MissionTable])(_.missionId)

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -87,8 +87,8 @@
     }
     @if(url.get == "/explore") {
         <script type="text/javascript">
+            // Prevents extra whitespace at the bottom of the page, not sure why that's an issue.
             document.getElementsByTagName("body")[0].style.overflow = "hidden";
-            document.getElementById("wrap").style.padding = "0 0 35px";
         </script>
     }
     <!-- Trying out no footer on Explore or Validate. Mini footer on mobile sign in/up. Code is weird bc "else if" doesn't work in template scala rn. -->

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -91,9 +91,13 @@
             document.getElementById("wrap").style.padding = "0 0 35px";
         </script>
     }
-    @if(url.get == "/explore" || url.get == "/signInMobile" || url.get == "/signUpMobile") {
-        <!-- footer code found in app/views/footer.scala.html -->
-        @footer()
+    <!-- Trying out no footer on Explore or Validate. Mini footer on mobile sign in/up. Code is weird bc "else if" doesn't work in template scala rn. -->
+    @if(url.get == "/explore" || url.get == "/validate" || url.get == "/signInMobile" || url.get == "/signUpMobile") {
+        @if(url.get == "/explore" || url.get == "/validate") {
+        } else {
+            <!-- footer code found in app/views/footer.scala.html -->
+            @footer()
+        }
     } else {
         <div class="filler" style="position:relative;top: 0px;background-color:#fff; min-height:50px;"></div>
 

--- a/app/views/missionStartTutorial.scala.html
+++ b/app/views/missionStartTutorial.scala.html
@@ -115,7 +115,7 @@
                         <div class="label-on-image-description"></div>
                     </div>
                 </div>
-                <div class="mts-text-area">
+                <div class="mst-text-area">
                     <div class="example-type-area">
                         <div class="example-type-icon">
                             <svg viewBox="0 0 24 24">

--- a/conf/evolutions/default/209.sql
+++ b/conf/evolutions/default/209.sql
@@ -1,0 +1,17 @@
+# --- !Ups
+ALTER TABLE audit_task_environment
+    ADD COLUMN css_zoom INT NOT NULL DEFAULT 100,
+    ADD COLUMN timestamp TIMESTAMPTZ;
+
+ALTER TABLE validation_task_environment
+    ADD COLUMN css_zoom INT NOT NULL DEFAULT 100,
+    ADD COLUMN timestamp TIMESTAMPTZ;
+
+# --- !Downs
+ALTER TABLE validation_task_environment
+    DROP COLUMN css_zoom,
+    DROP COLUMN timestamp;
+
+ALTER TABLE audit_task_environment
+    DROP COLUMN css_zoom,
+    DROP COLUMN timestamp;

--- a/public/javascripts/SVLabel/css/svl.css
+++ b/public/javascripts/SVLabel/css/svl.css
@@ -91,7 +91,7 @@ input[type="radio"] {
     background: rgba(255,255,255,1);
     margin: 0 auto;
     position: relative;
-    height: 640px;
+    height: 610px;
     width: 960px;
 }
 

--- a/public/javascripts/SVLabel/css/svl.css
+++ b/public/javascripts/SVLabel/css/svl.css
@@ -83,6 +83,10 @@ input[type="radio"] {
     text-decoration: underline;
 }
 
+.tool-ui {
+    width: 1170px; /* Used to override bootstrap .container media queries. We want to keep a consistent width. */
+}
+
 #svl-application-holder {
     background: rgba(255,255,255,1);
     margin: 0 auto;

--- a/public/javascripts/SVLabel/src/SVLabel/Main.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Main.js
@@ -288,7 +288,7 @@ function Main (params) {
         //hide any alerts
         svl.alert.hideAlert();
         //hide footer
-        $("#mini-footer-audit").css("visibility", "hidden");
+        svl.ui.footer.css("visibility", "hidden");
 
         if (!onboardingHandAnimation) {
             onboardingHandAnimation = new HandAnimation(svl.rootDirectory, svl.ui.onboarding);
@@ -362,11 +362,11 @@ function Main (params) {
             $(".visible").css({"visibility": "visible"});
 
             if (mission.getProperty("missionType") === "auditOnboarding") {
-                $("#mini-footer-audit").css("visibility", "hidden");
+                svl.ui.footer.css("visibility", "hidden");
                 startOnboarding();
             } else {
                 _calculateAndSetTasksMissionsOffset();
-                $("#mini-footer-audit").css("visibility", "visible");
+                svl.ui.footer.css("visibility", "visible");
 
                 // Initialize explore mission screens focused on a randomized label type, though users can switch between them.
                 var currentNeighborhood = svl.neighborhoodContainer.getCurrentNeighborhood();
@@ -376,59 +376,57 @@ function Main (params) {
                     neighborhood: currentNeighborhood.getProperty('name')
                 }, svl, params.language);
 
-
-
-                // Use CSS zoom to scale the UI for users with high resolution screens.
-                var toolUI = document.querySelector('.tool-ui');
-                var mst = document.querySelector('.mst-content');
-                var footerHeight = 75; // 35px for #wrap padding, 40px for #mini-footer-audit height.
-                function isUIVisible(elem) {
-                    var zoomFactor = parseFloat(elem.style.zoom) / 100.0 || 1;
-                    var scaledRect = elem.getBoundingClientRect();
-                    if (zoomFactor !== 1) {
-                        scaledRect = {
-                            left: scaledRect.left * zoomFactor,
-                            bottom: scaledRect.bottom * zoomFactor,
-                            right: scaledRect.right * zoomFactor
-                        };
-                    }
-                    return scaledRect.left >= 0 &&
-                        scaledRect.bottom <= (window.innerHeight || document.documentElement.clientHeight) - footerHeight &&
-                        scaledRect.right <= (window.innerWidth || document.documentElement.clientWidth);
-                }
-                svl.scaleUI = function() {
-                    var zoomPercent = 50;
-                    if (!!toolUI.offsetParent) {
-                        console.log('toolUI');
-                        toolUI.style.zoom = zoomPercent + '%';
-                        while (isUIVisible(toolUI)) {
-                            zoomPercent += 5;
-                            toolUI.style.zoom = zoomPercent + '%';
-                        }
-                        toolUI.style.zoom = (zoomPercent - 5) + '%';
-                        svl.cssZoom = zoomPercent - 5;
-                        console.log(zoomPercent);
-                    }
-
-
-                    if (!!mst.offsetParent) {
-                        zoomPercent = 50;
-                        console.log('mst');
-                        mst.style.zoom = zoomPercent + '%';
-                        while (isUIVisible(mst)) {
-                            zoomPercent += 5;
-                            mst.style.zoom = zoomPercent + '%';
-                        }
-                        mst.style.zoom = (zoomPercent - 5) + '%';
-                        console.log(zoomPercent);
-                    }
-                }
-                svl.scaleUI();
-                window.addEventListener('resize', (e) => { svl.scaleUI(); });
-
-
                 startTheMission(mission, currentNeighborhood);
             }
+
+
+            // Use CSS zoom to scale the UI for users with high resolution screens.
+            var toolUI = document.querySelector('.tool-ui');
+            var mst = document.querySelector('.mst-content');
+            var footerHeight = svl.ui.footer.height() + parseInt($('#wrap').css('padding-bottom'));
+            function isUIVisible(elem) {
+                var zoomFactor = parseFloat(elem.style.zoom) / 100.0 || 1;
+                var scaledRect = elem.getBoundingClientRect();
+                if (zoomFactor !== 1) {
+                    scaledRect = {
+                        left: scaledRect.left * zoomFactor,
+                        bottom: scaledRect.bottom * zoomFactor,
+                        right: scaledRect.right * zoomFactor
+                    };
+                }
+                return scaledRect.left >= 0 &&
+                    scaledRect.bottom <= (window.innerHeight || document.documentElement.clientHeight) - footerHeight &&
+                    scaledRect.right <= (window.innerWidth || document.documentElement.clientWidth);
+            }
+            svl.scaleUI = function() {
+                var zoomPercent = 50;
+                if (!!toolUI.offsetParent) {
+                    console.log('toolUI');
+                    toolUI.style.zoom = zoomPercent + '%';
+                    while (isUIVisible(toolUI)) {
+                        zoomPercent += 5;
+                        toolUI.style.zoom = zoomPercent + '%';
+                    }
+                    toolUI.style.zoom = (zoomPercent - 5) + '%';
+                    svl.cssZoom = zoomPercent - 5;
+                    console.log(zoomPercent);
+                }
+
+                // If the Mission Start Tutorial is visible, scale it as well.
+                if (!!mst.offsetParent) {
+                    zoomPercent = 50;
+                    console.log('mst');
+                    mst.style.zoom = zoomPercent + '%';
+                    while (isUIVisible(mst)) {
+                        zoomPercent += 5;
+                        mst.style.zoom = zoomPercent + '%';
+                    }
+                    mst.style.zoom = (zoomPercent - 5) + '%';
+                    console.log(zoomPercent);
+                }
+            }
+            svl.scaleUI();
+            window.addEventListener('resize', (e) => { svl.scaleUI(); });
         }
     }
 
@@ -632,6 +630,8 @@ function Main (params) {
         svl.ui.areaComplete.overlay = $("#area-completion-overlay-wrapper");
         svl.ui.areaComplete.title = $("#area-completion-title");
         svl.ui.areaComplete.body = $("#area-completion-body");
+
+        svl.ui.footer = $("#mini-footer-audit");
     }
 
     // Gets all the text on the explore page for the correct language.

--- a/public/javascripts/SVLabel/src/SVLabel/Main.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Main.js
@@ -427,6 +427,7 @@ function Main (params) {
             }
             // Has only been tested on Chrome and Safari. Firefox doesn't support CSS zoom.
             if (bowser.chrome || bowser.safari) {
+                document.querySelector('.mission-start-tutorial-overlay').style.height = 'auto';
                 svl.scaleUI();
                 window.addEventListener('resize', (e) => { svl.scaleUI(); });
             }

--- a/public/javascripts/SVLabel/src/SVLabel/Main.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Main.js
@@ -379,62 +379,11 @@ function Main (params) {
                 startTheMission(mission, currentNeighborhood);
             }
 
-
             // Use CSS zoom to scale the UI for users with high resolution screens.
-            var toolUI = document.querySelector('.tool-ui');
-            var mst = document.querySelector('.mst-content');
-            function isUIVisible(elem) {
-                var zoomFactor = parseFloat(elem.style.zoom) / 100.0 || 1;
-                var scaledRect = elem.getBoundingClientRect();
-                if (zoomFactor !== 1) {
-                    scaledRect = {
-                        left: scaledRect.left * zoomFactor,
-                        bottom: scaledRect.bottom * zoomFactor,
-                        right: scaledRect.right * zoomFactor
-                    };
-                }
-                return scaledRect.left >= 0 &&
-                    scaledRect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
-                    scaledRect.right <= (window.innerWidth || document.documentElement.clientWidth);
-            }
-            svl.scaleUI = function() {
-                var zoomPercent = 50;
-                if (!!toolUI.offsetParent) {
-                    console.log('toolUI');
-                    toolUI.style.zoom = zoomPercent + '%';
-                    while (isUIVisible(toolUI)) {
-                        zoomPercent += 10;
-                        toolUI.style.zoom = zoomPercent + '%';
-                    }
-                    while (!isUIVisible(toolUI)) {
-                        zoomPercent -= 1;
-                        toolUI.style.zoom = zoomPercent + '%';
-                    }
-                    svl.cssZoom = zoomPercent;
-                    console.log(zoomPercent);
-                }
-
-                // If the Mission Start Tutorial is visible, scale it as well.
-                if (!!mst.offsetParent) {
-                    if (zoomPercent > 50) zoomPercent -= 20; // Should be similar as tool-ui, don't need to start at 50%.
-                    console.log('mst');
-                    mst.style.zoom = zoomPercent + '%';
-                    while (isUIVisible(mst)) {
-                        zoomPercent += 10;
-                        mst.style.zoom = zoomPercent + '%';
-                    }
-                    while (!isUIVisible(mst)) {
-                        zoomPercent -= 1;
-                        mst.style.zoom = zoomPercent + '%';
-                    }
-                    console.log(zoomPercent);
-                }
-            }
             // Has only been tested on Chrome and Safari. Firefox doesn't support CSS zoom.
             if (bowser.chrome || bowser.safari) {
-                document.querySelector('.mission-start-tutorial-overlay').style.height = 'auto';
-                svl.scaleUI();
-                window.addEventListener('resize', (e) => { svl.scaleUI(); });
+                svl.cssZoom = util.scaleUI();
+                window.addEventListener('resize', (e) => { svl.cssZoom = util.scaleUI(); });
             }
         }
     }

--- a/public/javascripts/SVLabel/src/SVLabel/Main.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Main.js
@@ -383,7 +383,6 @@ function Main (params) {
             // Use CSS zoom to scale the UI for users with high resolution screens.
             var toolUI = document.querySelector('.tool-ui');
             var mst = document.querySelector('.mst-content');
-            var footerHeight = svl.ui.footer.height() + parseInt($('#wrap').css('padding-bottom'));
             function isUIVisible(elem) {
                 var zoomFactor = parseFloat(elem.style.zoom) / 100.0 || 1;
                 var scaledRect = elem.getBoundingClientRect();
@@ -395,7 +394,7 @@ function Main (params) {
                     };
                 }
                 return scaledRect.left >= 0 &&
-                    scaledRect.bottom <= (window.innerHeight || document.documentElement.clientHeight) - footerHeight &&
+                    scaledRect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
                     scaledRect.right <= (window.innerWidth || document.documentElement.clientWidth);
             }
             svl.scaleUI = function() {
@@ -404,24 +403,30 @@ function Main (params) {
                     console.log('toolUI');
                     toolUI.style.zoom = zoomPercent + '%';
                     while (isUIVisible(toolUI)) {
-                        zoomPercent += 5;
+                        zoomPercent += 10;
                         toolUI.style.zoom = zoomPercent + '%';
                     }
-                    toolUI.style.zoom = (zoomPercent - 5) + '%';
-                    svl.cssZoom = zoomPercent - 5;
+                    while (!isUIVisible(toolUI)) {
+                        zoomPercent -= 1;
+                        toolUI.style.zoom = zoomPercent + '%';
+                    }
+                    svl.cssZoom = zoomPercent;
                     console.log(zoomPercent);
                 }
 
                 // If the Mission Start Tutorial is visible, scale it as well.
                 if (!!mst.offsetParent) {
-                    zoomPercent = 50;
+                    if (zoomPercent > 50) zoomPercent -= 20; // Should be similar as tool-ui, don't need to start at 50%.
                     console.log('mst');
                     mst.style.zoom = zoomPercent + '%';
                     while (isUIVisible(mst)) {
-                        zoomPercent += 5;
+                        zoomPercent += 10;
                         mst.style.zoom = zoomPercent + '%';
                     }
-                    mst.style.zoom = (zoomPercent - 5) + '%';
+                    while (!isUIVisible(mst)) {
+                        zoomPercent -= 1;
+                        mst.style.zoom = zoomPercent + '%';
+                    }
                     console.log(zoomPercent);
                 }
             }

--- a/public/javascripts/SVLabel/src/SVLabel/Main.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Main.js
@@ -376,6 +376,56 @@ function Main (params) {
                     neighborhood: currentNeighborhood.getProperty('name')
                 }, svl, params.language);
 
+
+
+                // Use CSS zoom to scale the UI for users with high resolution screens.
+                var toolUI = document.querySelector('.tool-ui');
+                var mst = document.querySelector('.mst-content');
+                var footerHeight = 75px; // 35px for #wrap padding, 40px for #mini-footer-audit height.
+                function isUIVisible(elem) {
+                    var zoomFactor = parseFloat(elem.style.zoom) / 100.0 || 1;
+                    var scaledRect = elem.getBoundingClientRect();
+                    if (zoomFactor !== 1) {
+                        scaledRect = {
+                            left: scaledRect.left * zoomFactor,
+                            bottom: scaledRect.bottom * zoomFactor,
+                            right: scaledRect.right * zoomFactor
+                        };
+                    }
+                    return scaledRect.left >= 0 &&
+                        scaledRect.bottom <= (window.innerHeight || document.documentElement.clientHeight) - footerHeight &&
+                        scaledRect.right <= (window.innerWidth || document.documentElement.clientWidth);
+                }
+                svl.scaleUI = function() {
+                    var zoomPercent = 50;
+                    if (!!toolUI.offsetParent) {
+                        console.log('toolUI');
+                        toolUI.style.zoom = zoomPercent + '%';
+                        while (isUIVisible(toolUI)) {
+                            zoomPercent += 5;
+                            toolUI.style.zoom = zoomPercent + '%';
+                        }
+                        toolUI.style.zoom = (zoomPercent - 5) + '%';
+                        console.log(zoomPercent);
+                    }
+
+
+                    if (!!mst.offsetParent) {
+                        zoomPercent = 50;
+                        console.log('mst');
+                        mst.style.zoom = zoomPercent + '%';
+                        while (isUIVisible(mst)) {
+                            zoomPercent += 5;
+                            mst.style.zoom = zoomPercent + '%';
+                        }
+                        mst.style.zoom = (zoomPercent - 5) + '%';
+                        console.log(zoomPercent);
+                    }
+                }
+                svl.scaleUI();
+                window.addEventListener('resize', (e) => { svl.scaleUI(); });
+
+
                 startTheMission(mission, currentNeighborhood);
             }
         }

--- a/public/javascripts/SVLabel/src/SVLabel/Main.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Main.js
@@ -381,7 +381,7 @@ function Main (params) {
                 // Use CSS zoom to scale the UI for users with high resolution screens.
                 var toolUI = document.querySelector('.tool-ui');
                 var mst = document.querySelector('.mst-content');
-                var footerHeight = 75px; // 35px for #wrap padding, 40px for #mini-footer-audit height.
+                var footerHeight = 75; // 35px for #wrap padding, 40px for #mini-footer-audit height.
                 function isUIVisible(elem) {
                     var zoomFactor = parseFloat(elem.style.zoom) / 100.0 || 1;
                     var scaledRect = elem.getBoundingClientRect();
@@ -406,6 +406,7 @@ function Main (params) {
                             toolUI.style.zoom = zoomPercent + '%';
                         }
                         toolUI.style.zoom = (zoomPercent - 5) + '%';
+                        svl.cssZoom = zoomPercent - 5;
                         console.log(zoomPercent);
                     }
 

--- a/public/javascripts/SVLabel/src/SVLabel/Main.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Main.js
@@ -425,8 +425,11 @@ function Main (params) {
                     console.log(zoomPercent);
                 }
             }
-            svl.scaleUI();
-            window.addEventListener('resize', (e) => { svl.scaleUI(); });
+            // Has only been tested on Chrome and Safari. Firefox doesn't support CSS zoom.
+            if (bowser.chrome || bowser.safari) {
+                svl.scaleUI();
+                window.addEventListener('resize', (e) => { svl.scaleUI(); });
+            }
         }
     }
 

--- a/public/javascripts/SVLabel/src/SVLabel/data/Form.js
+++ b/public/javascripts/SVLabel/src/SVLabel/data/Form.js
@@ -30,7 +30,7 @@ function Form (labelContainer, missionModel, missionContainer, navigationModel, 
      * @returns {{}}
      */
     this.compileSubmissionData = function (task) {
-        var data = {};
+        var data = { timestamp: new Date().getTime() };
 
         data.amt_assignment_id = svl.amtAssignmentId;
         data.user_route_id = svl.userRouteId;
@@ -70,7 +70,8 @@ function Form (labelContainer, missionModel, missionContainer, navigationModel, 
             avail_width: screen.availWidth,              // total width - interface (taskbar)
             avail_height: screen.availHeight,            // total height - interface };
             operating_system: util.getOperatingSystem(),
-            language: i18next.language
+            language: i18next.language,
+            css_zoom: svl.cssZoom ? svl.cssZoom : 100
         };
 
         data.interactions = tracker.getActions();

--- a/public/javascripts/SVValidate/css/svv.css
+++ b/public/javascripts/SVValidate/css/svv.css
@@ -6,6 +6,10 @@
     width: 960px;
 }
 
+.tool-ui {
+    width: 1170px; /* Used to override bootstrap .container media queries. We want to keep a consistent width. */
+}
+
 text {
     visibility: hidden;
 }

--- a/public/javascripts/SVValidate/src/Main.js
+++ b/public/javascripts/SVValidate/src/Main.js
@@ -204,64 +204,11 @@ function Main (param) {
 
         const missionStartTutorial = new MissionStartTutorial('validate', labelType, { nLabels: param.mission.labels_validated }, svv, param.language);
 
-
-
         // Use CSS zoom to scale the UI for users with high resolution screens.
-        var toolUI = document.querySelector('.tool-ui');
-        var mst = document.querySelector('.mst-content');
-        // var footerHeight = svv.ui.footer.height() + parseInt($('#wrap').css('padding-bottom'));
-        function isUIVisible(elem) {
-            var zoomFactor = parseFloat(elem.style.zoom) / 100.0 || 1;
-            var scaledRect = elem.getBoundingClientRect();
-            if (zoomFactor !== 1) {
-                scaledRect = {
-                    left: scaledRect.left * zoomFactor,
-                    bottom: scaledRect.bottom * zoomFactor,
-                    right: scaledRect.right * zoomFactor
-                };
-            }
-            return scaledRect.left >= 0 &&
-                scaledRect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&// - footerHeight &&
-                scaledRect.right <= (window.innerWidth || document.documentElement.clientWidth);
-        }
-        svv.scaleUI = function() {
-            var zoomPercent = 50;
-            if (!!toolUI.offsetParent) {
-                console.log('toolUI');
-                toolUI.style.zoom = zoomPercent + '%';
-                while (isUIVisible(toolUI)) {
-                    zoomPercent += 10;
-                    toolUI.style.zoom = zoomPercent + '%';
-                }
-                while (!isUIVisible(toolUI)) {
-                    zoomPercent -= 1;
-                    toolUI.style.zoom = zoomPercent + '%';
-                }
-                svv.cssZoom = zoomPercent;
-                console.log(svv.cssZoom);
-            }
-
-            // If the Mission Start Tutorial is visible, scale it as well.
-            if (!!mst.offsetParent) {
-                if (zoomPercent > 50) zoomPercent -= 20; // Should be similar as tool-ui, don't need to start at 50%.
-                console.log('mst');
-                mst.style.zoom = zoomPercent + '%';
-                while (isUIVisible(mst)) {
-                    zoomPercent += 10;
-                    mst.style.zoom = zoomPercent + '%';
-                }
-                while (!isUIVisible(mst)) {
-                    zoomPercent -= 1;
-                    mst.style.zoom = zoomPercent + '%';
-                }
-                console.log(zoomPercent);
-            }
-        }
         // Has only been tested on Chrome and Safari. Firefox doesn't support CSS zoom.
         if (!isMobile() && (bowser.chrome || bowser.safari)) {
-            document.querySelector('.mission-start-tutorial-overlay').style.height = 'auto';
-            svv.scaleUI();
-            window.addEventListener('resize', (e) => { svv.scaleUI(); });
+            svv.cssZoom = util.scaleUI();
+            window.addEventListener('resize', (e) => { svv.cssZoom = util.scaleUI(); });
         }
     }
 

--- a/public/javascripts/SVValidate/src/Main.js
+++ b/public/javascripts/SVValidate/src/Main.js
@@ -251,8 +251,10 @@ function Main (param) {
                 console.log(zoomPercent);
             }
         }
-        svv.scaleUI();
-        window.addEventListener('resize', (e) => { svv.scaleUI(); });
+        if (!isMobile()) {
+            svv.scaleUI();
+            window.addEventListener('resize', (e) => { svv.scaleUI(); });
+        }
     }
 
     // Gets all the text on the validation page for the correct language.

--- a/public/javascripts/SVValidate/src/Main.js
+++ b/public/javascripts/SVValidate/src/Main.js
@@ -253,6 +253,7 @@ function Main (param) {
         }
         // Has only been tested on Chrome and Safari. Firefox doesn't support CSS zoom.
         if (!isMobile() && (bowser.chrome || bowser.safari)) {
+            document.querySelector('.mission-start-tutorial-overlay').style.height = 'auto';
             svv.scaleUI();
             window.addEventListener('resize', (e) => { svv.scaleUI(); });
         }

--- a/public/javascripts/SVValidate/src/Main.js
+++ b/public/javascripts/SVValidate/src/Main.js
@@ -233,9 +233,9 @@ function Main (param) {
                     zoomPercent += 5;
                     toolUI.style.zoom = zoomPercent + '%';
                 }
-                toolUI.style.zoom = (zoomPercent - 5) + '%';
                 svv.cssZoom = zoomPercent - 5;
-                console.log(zoomPercent);
+                toolUI.style.zoom = svv.cssZoom + '%';
+                console.log(svv.cssZoom);
             }
 
             // If the Mission Start Tutorial is visible, scale it as well.
@@ -251,10 +251,8 @@ function Main (param) {
                 console.log(zoomPercent);
             }
         }
-        // svv.scaleUI();
-        // window.addEventListener('resize', (e) => { svv.scaleUI(); });
-
-
+        svv.scaleUI();
+        window.addEventListener('resize', (e) => { svv.scaleUI(); });
     }
 
     // Gets all the text on the validation page for the correct language.

--- a/public/javascripts/SVValidate/src/Main.js
+++ b/public/javascripts/SVValidate/src/Main.js
@@ -251,7 +251,8 @@ function Main (param) {
                 console.log(zoomPercent);
             }
         }
-        if (!isMobile()) {
+        // Has only been tested on Chrome and Safari. Firefox doesn't support CSS zoom.
+        if (!isMobile() && (bowser.chrome || bowser.safari)) {
             svv.scaleUI();
             window.addEventListener('resize', (e) => { svv.scaleUI(); });
         }

--- a/public/javascripts/SVValidate/src/Main.js
+++ b/public/javascripts/SVValidate/src/Main.js
@@ -203,6 +203,58 @@ function Main (param) {
         const labelType = param.labelList[0].getAuditProperty('labelType');
 
         const missionStartTutorial = new MissionStartTutorial('validate', labelType, { nLabels: param.mission.labels_validated }, svv, param.language);
+
+
+
+        // Use CSS zoom to scale the UI for users with high resolution screens.
+        var toolUI = document.querySelector('.tool-ui');
+        var mst = document.querySelector('.mst-content');
+        // var footerHeight = svv.ui.footer.height() + parseInt($('#wrap').css('padding-bottom'));
+        function isUIVisible(elem) {
+            var zoomFactor = parseFloat(elem.style.zoom) / 100.0 || 1;
+            var scaledRect = elem.getBoundingClientRect();
+            if (zoomFactor !== 1) {
+                scaledRect = {
+                    left: scaledRect.left * zoomFactor,
+                    bottom: scaledRect.bottom * zoomFactor,
+                    right: scaledRect.right * zoomFactor
+                };
+            }
+            return scaledRect.left >= 0 &&
+                scaledRect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&// - footerHeight &&
+                scaledRect.right <= (window.innerWidth || document.documentElement.clientWidth);
+        }
+        svv.scaleUI = function() {
+            var zoomPercent = 50;
+            if (!!toolUI.offsetParent) {
+                console.log('toolUI');
+                toolUI.style.zoom = zoomPercent + '%';
+                while (isUIVisible(toolUI)) {
+                    zoomPercent += 5;
+                    toolUI.style.zoom = zoomPercent + '%';
+                }
+                toolUI.style.zoom = (zoomPercent - 5) + '%';
+                svv.cssZoom = zoomPercent - 5;
+                console.log(zoomPercent);
+            }
+
+            // If the Mission Start Tutorial is visible, scale it as well.
+            if (!!mst.offsetParent) {
+                zoomPercent = 50;
+                console.log('mst');
+                mst.style.zoom = zoomPercent + '%';
+                while (isUIVisible(mst)) {
+                    zoomPercent += 5;
+                    mst.style.zoom = zoomPercent + '%';
+                }
+                mst.style.zoom = (zoomPercent - 10) + '%'; // Decrease zoom a bit extra for MST for aesthetics.
+                console.log(zoomPercent);
+            }
+        }
+        svv.scaleUI();
+        window.addEventListener('resize', (e) => { svv.scaleUI(); });
+
+
     }
 
     // Gets all the text on the validation page for the correct language.

--- a/public/javascripts/SVValidate/src/Main.js
+++ b/public/javascripts/SVValidate/src/Main.js
@@ -230,24 +230,30 @@ function Main (param) {
                 console.log('toolUI');
                 toolUI.style.zoom = zoomPercent + '%';
                 while (isUIVisible(toolUI)) {
-                    zoomPercent += 5;
+                    zoomPercent += 10;
                     toolUI.style.zoom = zoomPercent + '%';
                 }
-                svv.cssZoom = zoomPercent - 5;
-                toolUI.style.zoom = svv.cssZoom + '%';
+                while (!isUIVisible(toolUI)) {
+                    zoomPercent -= 1;
+                    toolUI.style.zoom = zoomPercent + '%';
+                }
+                svv.cssZoom = zoomPercent;
                 console.log(svv.cssZoom);
             }
 
             // If the Mission Start Tutorial is visible, scale it as well.
             if (!!mst.offsetParent) {
-                zoomPercent = 50;
+                if (zoomPercent > 50) zoomPercent -= 20; // Should be similar as tool-ui, don't need to start at 50%.
                 console.log('mst');
                 mst.style.zoom = zoomPercent + '%';
                 while (isUIVisible(mst)) {
-                    zoomPercent += 5;
+                    zoomPercent += 10;
                     mst.style.zoom = zoomPercent + '%';
                 }
-                mst.style.zoom = (zoomPercent - 10) + '%'; // Decrease zoom a bit extra for MST for aesthetics.
+                while (!isUIVisible(mst)) {
+                    zoomPercent -= 1;
+                    mst.style.zoom = zoomPercent + '%';
+                }
                 console.log(zoomPercent);
             }
         }

--- a/public/javascripts/SVValidate/src/Main.js
+++ b/public/javascripts/SVValidate/src/Main.js
@@ -251,8 +251,8 @@ function Main (param) {
                 console.log(zoomPercent);
             }
         }
-        svv.scaleUI();
-        window.addEventListener('resize', (e) => { svv.scaleUI(); });
+        // svv.scaleUI();
+        // window.addEventListener('resize', (e) => { svv.scaleUI(); });
 
 
     }

--- a/public/javascripts/SVValidate/src/data/Form.js
+++ b/public/javascripts/SVValidate/src/data/Form.js
@@ -10,7 +10,7 @@ function Form(url, beaconUrl) {
      * @param {boolean} missionComplete Whether or not the mission is complete. To ensure we only send once per mission.
      */
     function compileSubmissionData(missionComplete) {
-        let data = {};
+        let data = { timestamp: new Date().getTime() };
         let missionContainer = svv.missionContainer;
         let mission = missionContainer ? missionContainer.getCurrentMission() : null;
 
@@ -49,7 +49,8 @@ function Form(url, beaconUrl) {
             avail_width: screen.availWidth,              // total width - interface (taskbar)
             avail_height: screen.availHeight,            // total height - interface };
             operating_system: util.getOperatingSystem(),
-            language: i18next.language
+            language: i18next.language,
+            css_zoom: svv.cssZoom ? svv.cssZoom : 100
         };
 
         data.interactions = svv.tracker.getActions();

--- a/public/javascripts/SVValidate/src/panorama/GSVOverlay.js
+++ b/public/javascripts/SVValidate/src/panorama/GSVOverlay.js
@@ -114,22 +114,6 @@ function GSVOverlay () {
         }
     }
 
-    // A cross-browser function to capture mouse positions.
-    function mouseposition (e, dom) {
-        let mx;
-        let my;
-        //if(e.offsetX) {
-            // Chrome
-        //    mx = e.offsetX;
-        //    my = e.offsetY;
-        //} else {
-        // Firefox, Safari
-            mx = e.pageX - $(dom).offset().left;
-            my = e.pageY - $(dom).offset().top;
-        //}
-        return {'x': parseInt(mx, 10) , 'y': parseInt(my, 10) };
-    }
-
     viewControlLayer.bind('mousemove', handlerViewControlLayerMouseMove);
     viewControlLayer.bind('mousedown', handlerViewControlLayerMouseDown);
     viewControlLayer.bind('mouseup', handlerViewControlLayerMouseUp);

--- a/public/javascripts/common/GSVInfoPopover.js
+++ b/public/javascripts/common/GSVInfoPopover.js
@@ -60,6 +60,7 @@ function GSVInfoPopover (container, panorama, coords, panoId, streetEdgeId, regi
         self.popoverContent.appendChild(linkGSV);
 
         // Create info button and add popover attributes.
+        self.buttonHolder = document.createElement('div');
         self.infoButton = document.createElement('img');
         self.infoButton.classList.add('popover-element');
         self.infoButton.id = 'gsv-info-button';
@@ -67,13 +68,17 @@ function GSVInfoPopover (container, panorama, coords, panoId, streetEdgeId, regi
         else self.infoButton.src = '/assets/images/icons/gsv_info_btn.png';
         self.infoButton.setAttribute('data-toggle', 'popover');
 
+        // self.buttonHolder.append(self.infoButton);
+        // container.append(self.buttonHolder);
         container.append(self.infoButton);
 
         // Enable popovers/tooltips and set options.
         $('#gsv-info-button').popover({
             html: true,
             placement: 'top',
-            container: 'body',
+            // container: 'body',
+            // container: '#gsv-info-button',
+            // offset: '100,0',
             title: self.titleBox.innerHTML,
             content: self.popoverContent.innerHTML
         }).on('click', updateVals).on('shown.bs.popover', () => {
@@ -143,8 +148,10 @@ function GSVInfoPopover (container, panorama, coords, panoId, streetEdgeId, regi
         // Position popover.
         let infoPopover = $('.popover');
         let infoRect = self.infoButton.getBoundingClientRect();
+        console.log(infoRect);
         let xpos = infoRect.x + (infoRect.width / 2) - (infoPopover.width() / 2);
-        infoPopover.css('left', `${xpos}px`);
+        // infoPopover.css('left', `${xpos}px`);
+        //popover.css('left', (6 - popover[0].getBoundingClientRect().width / 2 + panoDate[0].getBoundingClientRect().width + infoButton[0].getBoundingClientRect().width / 2) + 'px')
 
         // Copy to clipboard.
         $('#clipboard').on('click', function(e) {

--- a/public/javascripts/common/GSVInfoPopover.js
+++ b/public/javascripts/common/GSVInfoPopover.js
@@ -60,7 +60,6 @@ function GSVInfoPopover (container, panorama, coords, panoId, streetEdgeId, regi
         self.popoverContent.appendChild(linkGSV);
 
         // Create info button and add popover attributes.
-        self.buttonHolder = document.createElement('div');
         self.infoButton = document.createElement('img');
         self.infoButton.classList.add('popover-element');
         self.infoButton.id = 'gsv-info-button';
@@ -68,17 +67,13 @@ function GSVInfoPopover (container, panorama, coords, panoId, streetEdgeId, regi
         else self.infoButton.src = '/assets/images/icons/gsv_info_btn.png';
         self.infoButton.setAttribute('data-toggle', 'popover');
 
-        // self.buttonHolder.append(self.infoButton);
-        // container.append(self.buttonHolder);
         container.append(self.infoButton);
 
         // Enable popovers/tooltips and set options.
         $('#gsv-info-button').popover({
             html: true,
             placement: 'top',
-            // container: 'body',
-            // container: '#gsv-info-button',
-            // offset: '100,0',
+            container: 'body',
             title: self.titleBox.innerHTML,
             content: self.popoverContent.innerHTML
         }).on('click', updateVals).on('shown.bs.popover', () => {
@@ -148,10 +143,12 @@ function GSVInfoPopover (container, panorama, coords, panoId, streetEdgeId, regi
         // Position popover.
         let infoPopover = $('.popover');
         let infoRect = self.infoButton.getBoundingClientRect();
-        console.log(infoRect);
         let xpos = infoRect.x + (infoRect.width / 2) - (infoPopover.width() / 2);
-        // infoPopover.css('left', `${xpos}px`);
-        //popover.css('left', (6 - popover[0].getBoundingClientRect().width / 2 + panoDate[0].getBoundingClientRect().width + infoButton[0].getBoundingClientRect().width / 2) + 'px')
+        infoPopover.css('left', `${xpos}px`);
+
+        // Set the popover zoom to the same zoom as the Explore/Validate page.
+        if (typeof svl !== 'undefined' && svl.cssZoom) infoPopover.css('zoom', `${svl.cssZoom}%`);
+        else if (typeof svv !== 'undefined' && svv.cssZoom) infoPopover.css('zoom', `${svv.cssZoom}%`);
 
         // Copy to clipboard.
         $('#clipboard').on('click', function(e) {

--- a/public/javascripts/common/Utilities.js
+++ b/public/javascripts/common/Utilities.js
@@ -173,37 +173,21 @@ function scaleUI() {
     var toolCSSZoom = 100;
     if (!bowser.chrome && !bowser.safari) return toolCSSZoom; // Only tested for Chrome/Safari so far.
 
-    document.querySelector('.mission-start-tutorial-overlay').style.height = 'calc(100% - 70px)';
     var toolUI = document.querySelector('.tool-ui');
     var mst = document.querySelector('.mst-content');
     var zoomPercent = 50;
+
+    // Start with the tool-ui at 50% zoom and find the maximum zoom level that is still visible.
     if (!!toolUI.offsetParent) {
-        toolUI.style.zoom = zoomPercent + '%';
-        while (_isVisible(toolUI)) {
-            zoomPercent += 10;
-            toolUI.style.zoom = zoomPercent + '%';
-        }
-        while (!_isVisible(toolUI)) {
-            zoomPercent -= 1;
-            toolUI.style.zoom = zoomPercent + '%';
-        }
+        zoomPercent = _findMaxZoomLevel(toolUI, zoomPercent);
         toolCSSZoom = zoomPercent;
-        console.log(`toolUI: ${zoomPercent}%`);
     }
 
     // If the Mission Start Tutorial is visible, scale it as well.
     if (!!mst.offsetParent) {
+        document.querySelector('.mission-start-tutorial-overlay').style.height = 'calc(100% - 70px)';
         if (zoomPercent > 50) zoomPercent -= 20; // Should be similar as tool-ui, don't need to start at 50%.
-        mst.style.zoom = zoomPercent + '%';
-        while (_isVisible(mst)) {
-            zoomPercent += 10;
-            mst.style.zoom = zoomPercent + '%';
-        }
-        while (!_isVisible(mst)) {
-            zoomPercent -= 1;
-            mst.style.zoom = zoomPercent + '%';
-        }
-        console.log(`mst: ${zoomPercent}%`);
+        zoomPercent = _findMaxZoomLevel(mst, zoomPercent);
     }
 
     return toolCSSZoom;
@@ -224,4 +208,19 @@ function _isVisible(elem) {
     return scaledRect.left >= 0 &&
         scaledRect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
         scaledRect.right <= (window.innerWidth || document.documentElement.clientWidth);
+}
+
+// Finds the maximum CSS zoom level for an element (tested on chrome/safari).
+function _findMaxZoomLevel(elem, startZoom) {
+    var zoomPercent = startZoom;
+    elem.style.zoom = zoomPercent + '%';
+    while (_isVisible(elem) && zoomPercent < 500) {
+        zoomPercent += 10;
+        elem.style.zoom = zoomPercent + '%';
+    }
+    while (!_isVisible(elem) && zoomPercent > 10) {
+        zoomPercent -= 1;
+        elem.style.zoom = zoomPercent + '%';
+    }
+    return zoomPercent;
 }

--- a/public/javascripts/common/Utilities.js
+++ b/public/javascripts/common/Utilities.js
@@ -6,9 +6,15 @@ util.EXPLORE_CANVAS_HEIGHT = 480;
 
 // A cross-browser function to capture a mouse position.
 function mouseposition(e, dom) {
-    var mx, my;
-    mx = e.pageX - $(dom).offset().left;
-    my = e.pageY - $(dom).offset().top;
+    var mx, my, zoomFactor;
+    var toolUIElem = dom.closest('.tool-ui')
+    if (toolUIElem && toolUIElem.style.zoom) {
+        zoomFactor = parseFloat(toolUIElem.style.zoom) / 100.0 || 1;
+    } else {
+        zoomFactor = 1;
+    }
+    mx = (e.pageX / zoomFactor) - $(dom).offset().left;
+    my = (e.pageY / zoomFactor) - $(dom).offset().top;
     return {'x': parseInt(mx, 10) , 'y': parseInt(my, 10) };
 }
 util.mouseposition = mouseposition;

--- a/public/stylesheets/common/missionStartTutorial.css
+++ b/public/stylesheets/common/missionStartTutorial.css
@@ -22,7 +22,7 @@
 
 .mission-start-tutorial-overlay {
     position: absolute;
-    height: 683px;
+    /*height: 683px;*/
     width: 100%;
     min-width: 1170px; /*  */
     background: white;

--- a/public/stylesheets/common/missionStartTutorial.css
+++ b/public/stylesheets/common/missionStartTutorial.css
@@ -107,7 +107,7 @@
     justify-content: space-between;
 }
 
-.mts-text-area {
+.mst-text-area {
     width: 290px;
     display: flex;
     flex-shrink: 0;
@@ -348,21 +348,6 @@
 
 .mst-carousel-location-indicator.current-location {
     background: #2C2A3D;
-}
-
-/* This block handles layout on browser zoom. */
-@media (max-width: 1170px) {
-    .mission-start-tutorial-overlay {
-        min-width: 1069px;
-    }
-    .mst-content {
-        width: 1020px;
-    }
-
-    /* We need to create space for the image at this zoom level. */
-    .mts-text-area {
-        width: 230px;
-    }
 }
 
 /* Explore mission screen tab bar styling */

--- a/public/stylesheets/common/missionStartTutorial.css
+++ b/public/stylesheets/common/missionStartTutorial.css
@@ -24,7 +24,6 @@
     position: absolute;
     height: 683px; /* We override this when using CSS zoom. */
     width: 100%;
-    min-width: 1170px;
     background: white;
     z-index: 10;
     display: none; /* Will be later set to flex by JS after rendering. */

--- a/public/stylesheets/common/missionStartTutorial.css
+++ b/public/stylesheets/common/missionStartTutorial.css
@@ -22,12 +22,12 @@
 
 .mission-start-tutorial-overlay {
     position: absolute;
-    /*height: 683px;*/
+    height: 683px; /* We override this when using CSS zoom. */
     width: 100%;
-    min-width: 1170px; /*  */
+    min-width: 1170px;
     background: white;
     z-index: 10;
-    display: none; /* will be later set to flex by JS after rendering */
+    display: none; /* Will be later set to flex by JS after rendering. */
     flex-shrink: 0;
     justify-content: flex-start;
     overflow: auto;

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -334,6 +334,11 @@ footer {
 
 .popover {
     max-width: 400px;
+    font-family: 'Open Sans', 'Noto Sans', sans-serif;
+    color: #333;
+    font-size: 14px;
+    text-shadow: none;
+    white-space: nowrap;
 }
 
 .popover-title {

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -334,11 +334,6 @@ footer {
 
 .popover {
     max-width: 400px;
-    font-family: 'Open Sans', 'Noto Sans', sans-serif;
-    color: #333;
-    font-size: 14px;
-    text-shadow: none;
-    white-space: nowrap;
 }
 
 .popover-title {


### PR DESCRIPTION
#303 is the issue we're working on here. This is a temporary fix because it doesn't work for Firefox.

Adds automatic zoom on the Explore and Validate pages using the CSS zoom property instead of browser zoom. This doesn't work on Firefox. I've tested that it works on Chrome and Safari thus far, so that's all I've enabled. I'll test it on Edge in the next couple of weeks and enable it there if it works well too. Everything below the navbar gets zoomed.

I also removed the footers on both of those pages, which makes the app take up basically the entire screen with no scrolling ever happening on the page. Easy enough to add the footers back in, but I really like how it looks/feels with no scrolling.

##### Before/After screenshots (if applicable)
Before (80% zoom)
<img width="1439" alt="Screenshot 2023-12-21 at 5 00 04 PM" src="https://github.com/ProjectSidewalk/SidewalkWebpage/assets/6518824/7258c490-830f-4a62-a877-6f36bd3e95e2">

After (80% zoom)
<img width="1439" alt="Screenshot 2023-12-21 at 5 01 59 PM" src="https://github.com/ProjectSidewalk/SidewalkWebpage/assets/6518824/39baf401-7546-400b-9f52-9ab0e8615803">


##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
- [x] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure the documentation on [this wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Descriptions-of-Logged-Events) is up to date for the logs you added/updated.
- [x] I've tested on mobile (only needed for validation page).
