### PR TITLE
#3413 Shapefile format doesn't allow integers longer than 9 digits 

### DIFF
--- a/app/controllers/ProjectSidewalkAPIController.scala
+++ b/app/controllers/ProjectSidewalkAPIController.scala
@@ -41,7 +41,7 @@ case class NeighborhoodAttributeSignificance (val name: String,
 
 case class StreetAttributeSignificance (val geometry: Array[JTSCoordinate],
                                         val streetID: Int,
-                                        val osmID: Int,
+                                        val osmID: Long,
                                         val regionID: Int,
                                         val score: Double,
                                         val auditCount: Int,
@@ -61,7 +61,7 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
 
   case class AttributeForAccessScore(lat: Float, lng: Float, labelType: String, avgImageCaptureDate: Timestamp,
                                      avgLabelDate: Timestamp, imageCount: Int, labelCount: Int)
-  case class AccessScoreStreet(streetEdge: StreetEdge, osmId: Int, regionId: Int, score: Double, auditCount: Int,
+  case class AccessScoreStreet(streetEdge: StreetEdge, osmId: Long, regionId: Int, score: Double, auditCount: Int,
                                attributes: Array[Double], significance: Array[Double],
                                avgImageCaptureDate: Option[Timestamp], avgLabelDate: Option[Timestamp], imageCount: Int,
                                labelCount: Int) {
@@ -156,8 +156,6 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
     } else if (filetype.isDefined && filetype.get == "shapefile") {
 
       val attributeList: Buffer[GlobalAttributeForAPI] = GlobalAttributeTable.getGlobalAttributesInBoundingBox(minLat, minLng, maxLat, maxLng, severity).to[ArrayBuffer]
-
-     // attributeList.filter(attr => attr.osmStreetId > 99999999).foreach(attr => println(s"OSM ID (Attributes): ${attr.osmStreetId}"))
 
       ShapefilesCreatorHelper.createAttributeShapeFile("attributes", attributeList)
 

--- a/app/controllers/ProjectSidewalkAPIController.scala
+++ b/app/controllers/ProjectSidewalkAPIController.scala
@@ -157,6 +157,8 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
 
       val attributeList: Buffer[GlobalAttributeForAPI] = GlobalAttributeTable.getGlobalAttributesInBoundingBox(minLat, minLng, maxLat, maxLng, severity).to[ArrayBuffer]
 
+     // attributeList.filter(attr => attr.osmStreetId > 99999999).foreach(attr => println(s"OSM ID (Attributes): ${attr.osmStreetId}"))
+
       ShapefilesCreatorHelper.createAttributeShapeFile("attributes", attributeList)
 
       val labelList: Buffer[GlobalAttributeWithLabelForAPI] = GlobalAttributeTable.getGlobalAttributesWithLabelsInBoundingBox(minLat, minLng, maxLat, maxLng, severity).to[ArrayBuffer]
@@ -164,6 +166,7 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
       ShapefilesCreatorHelper.createLabelShapeFile("labels", labelList)
 
       val shapefile: java.io.File = ShapefilesCreatorHelper.zipShapeFiles("attributeWithLabels", Array("attributes", "labels"))
+
 
       Future.successful(Ok.sendFile(content = shapefile, onClose = () => shapefile.delete()))
     } else {

--- a/app/controllers/helper/ShapefilesCreatorHelper.java
+++ b/app/controllers/helper/ShapefilesCreatorHelper.java
@@ -31,6 +31,16 @@ import controllers.StreetAttributeSignificance;
  */
 public class ShapefilesCreatorHelper {
 
+ /* This class handles the creation of Shapefile archives to be used by the SidewalkAPIController.
+            *
+            * Code was started and modified from the Geotools feature tutorial:
+            * https://docs.geotools.org/stable/tutorials/feature/csv2shp.html
+            *
+            */
+
+        public static void createGeneralShapeFile(String outputFile, SimpleFeatureType TYPE, List<SimpleFeature> features) throws Exception {
+        /*
+         * Get an output
     public static void createGeneralShapeFile(String outputFile, SimpleFeatureType TYPE, List<SimpleFeature> features) throws Exception {
         /*
          * Get an output file name and create the new shapefile
@@ -100,7 +110,7 @@ public class ShapefilesCreatorHelper {
                         + "id:Integer," // a attribute ID
                         + "labelType:String," // Label type
                         + "streetId:Integer," // Street edge ID of the nearest street
-                        + "osmWayId:Integer," // Street OSM ID of the nearest street
+                        + "osmWayId:String," // Street OSM ID of the nearest street
                         + "neighborhd:String," // Neighborhood Name
                         + "avgImgDate:String," // Image date
                         + "avgLblDate:String," // Label date
@@ -131,7 +141,8 @@ public class ShapefilesCreatorHelper {
             featureBuilder.add(a.globalAttributeId());
             featureBuilder.add(a.labelType());
             featureBuilder.add(a.streetEdgeId());
-            featureBuilder.add(a.osmStreetId());
+            featureBuilder.add(String.valueOf(a.osmStreetId()));
+
             featureBuilder.add(a.neighborhoodName());
             featureBuilder.add(a.avgImageCaptureDate());
             featureBuilder.add(a.avgLabelDate());
@@ -168,7 +179,7 @@ public class ShapefilesCreatorHelper {
                         + "attribId:Integer," // attribute ID
                         + "labelType:String," // Label type
                         + "streetId:Integer," // Street edge ID of the nearest street
-                        + "osmWayId:Integer," // Street OSM ID of the nearest street (10 char max)
+                        + "osmWayId:String," // Street OSM ID of the nearest street (10 char max)
                         + "neighborhd:String," // Neighborhood Name
                         + "severity:Integer," // Severity
                         + "temporary:Boolean," // Temporary flag
@@ -212,7 +223,8 @@ public class ShapefilesCreatorHelper {
             featureBuilder.add(l.globalAttributeId());
             featureBuilder.add(l.labelType());
             featureBuilder.add(l.streetEdgeId());
-            featureBuilder.add(l.osmStreetId());
+//          //featureBuilder.add(l.osmStreetId());
+            featureBuilder.add(String.valueOf(l.osmStreetId()));
             featureBuilder.add(l.neighborhoodName());
             featureBuilder.add(l.labelSeverity().getOrElse(new AbstractFunction0<Integer>() {
                 @Override
@@ -261,7 +273,7 @@ public class ShapefilesCreatorHelper {
                         "Location",
                         "the_geom:LineString:srid=4326," // the geometry attribute: Line type
                         + "streetId:Integer," // StreetId
-                        + "osmWayId:Integer," // osmWayId
+                        + "osmWayId:String," // osmWayId
                         + "nghborhdId:String," // Region ID
                         + "score:Double," // street score
                         + "auditCount:Integer," // boolean representing whether the street is audited
@@ -293,7 +305,8 @@ public class ShapefilesCreatorHelper {
         for (StreetAttributeSignificance s : streets) {
             featureBuilder.add(geometryFactory.createLineString(s.geometry()));
             featureBuilder.add(s.streetID());
-            featureBuilder.add(s.osmID());
+            featureBuilder.add(String.valueOf(s.osmID()));
+            //featureBuilder.add(s.osmID());
             featureBuilder.add(s.regionID());
             featureBuilder.add(s.score());
             featureBuilder.add(s.auditCount());

--- a/app/controllers/helper/ShapefilesCreatorHelper.java
+++ b/app/controllers/helper/ShapefilesCreatorHelper.java
@@ -142,7 +142,6 @@ public class ShapefilesCreatorHelper {
             featureBuilder.add(a.labelType());
             featureBuilder.add(a.streetEdgeId());
             featureBuilder.add(String.valueOf(a.osmStreetId()));
-
             featureBuilder.add(a.neighborhoodName());
             featureBuilder.add(a.avgImageCaptureDate());
             featureBuilder.add(a.avgLabelDate());
@@ -223,7 +222,6 @@ public class ShapefilesCreatorHelper {
             featureBuilder.add(l.globalAttributeId());
             featureBuilder.add(l.labelType());
             featureBuilder.add(l.streetEdgeId());
-//          //featureBuilder.add(l.osmStreetId());
             featureBuilder.add(String.valueOf(l.osmStreetId()));
             featureBuilder.add(l.neighborhoodName());
             featureBuilder.add(l.labelSeverity().getOrElse(new AbstractFunction0<Integer>() {
@@ -306,7 +304,6 @@ public class ShapefilesCreatorHelper {
             featureBuilder.add(geometryFactory.createLineString(s.geometry()));
             featureBuilder.add(s.streetID());
             featureBuilder.add(String.valueOf(s.osmID()));
-            //featureBuilder.add(s.osmID());
             featureBuilder.add(s.regionID());
             featureBuilder.add(s.score());
             featureBuilder.add(s.auditCount());

--- a/app/controllers/helper/ShapefilesCreatorHelper.java
+++ b/app/controllers/helper/ShapefilesCreatorHelper.java
@@ -66,25 +66,28 @@ public class ShapefilesCreatorHelper {
          *
          * Each data store has different limitations so check the resulting SimpleFeatureType.
          */
-        if (featureSource instanceof SimpleFeatureStore) {
-            SimpleFeatureStore featureStore = (SimpleFeatureStore) featureSource;
-            /*
-             * SimpleFeatureStore has a method to add features from a
-             * SimpleFeatureCollection object, so we use the ListFeatureCollection
-             * class to wrap our list of features.
-             */
-            SimpleFeatureCollection collection = new ListFeatureCollection(TYPE, features);
-            featureStore.setTransaction(transaction);
-            try {
-                featureStore.addFeatures(collection);
-                transaction.commit();
-            } catch (Exception problem) {
-                problem.printStackTrace();
-                transaction.rollback();
-            } finally {
-                transaction.close();
+//        // Implementing Batch processing to send features in batchsize of 20k
+            final int batchSize = 20000;
+            if (featureSource instanceof SimpleFeatureStore) {
+                SimpleFeatureStore featureStore = (SimpleFeatureStore) featureSource;
+                try {
+
+                    for (int i = 0; i < features.size(); i += batchSize) {
+                        int endIdx = Math.min(i + batchSize, features.size());
+                        List<SimpleFeature> batchFeatures = features.subList(i, endIdx);
+
+                        SimpleFeatureCollection collection = new ListFeatureCollection(TYPE, batchFeatures);
+                        featureStore.setTransaction(transaction);
+                        featureStore.addFeatures(collection);
+                    }
+                    transaction.commit();
+                } catch (Exception problem) {
+                    problem.printStackTrace();
+                    transaction.rollback();
+                } finally {
+                    transaction.close();
+                }
             }
-        }
     }
 
     public static void createAttributeShapeFile(String outputFile, List<GlobalAttributeForAPI> attributes) throws Exception {

--- a/app/controllers/helper/ShapefilesCreatorHelper.java
+++ b/app/controllers/helper/ShapefilesCreatorHelper.java
@@ -31,16 +31,7 @@ import controllers.StreetAttributeSignificance;
  */
 public class ShapefilesCreatorHelper {
 
- /* This class handles the creation of Shapefile archives to be used by the SidewalkAPIController.
-            *
-            * Code was started and modified from the Geotools feature tutorial:
-            * https://docs.geotools.org/stable/tutorials/feature/csv2shp.html
-            *
-            */
 
-        public static void createGeneralShapeFile(String outputFile, SimpleFeatureType TYPE, List<SimpleFeature> features) throws Exception {
-        /*
-         * Get an output
     public static void createGeneralShapeFile(String outputFile, SimpleFeatureType TYPE, List<SimpleFeature> features) throws Exception {
         /*
          * Get an output file name and create the new shapefile

--- a/app/controllers/helper/ShapefilesCreatorHelper.java
+++ b/app/controllers/helper/ShapefilesCreatorHelper.java
@@ -66,28 +66,25 @@ public class ShapefilesCreatorHelper {
          *
          * Each data store has different limitations so check the resulting SimpleFeatureType.
          */
-//        // Implementing Batch processing to send features in batchsize of 20k
-            final int batchSize = 20000;
-            if (featureSource instanceof SimpleFeatureStore) {
-                SimpleFeatureStore featureStore = (SimpleFeatureStore) featureSource;
-                try {
-
-                    for (int i = 0; i < features.size(); i += batchSize) {
-                        int endIdx = Math.min(i + batchSize, features.size());
-                        List<SimpleFeature> batchFeatures = features.subList(i, endIdx);
-
-                        SimpleFeatureCollection collection = new ListFeatureCollection(TYPE, batchFeatures);
-                        featureStore.setTransaction(transaction);
-                        featureStore.addFeatures(collection);
-                    }
-                    transaction.commit();
-                } catch (Exception problem) {
-                    problem.printStackTrace();
-                    transaction.rollback();
-                } finally {
-                    transaction.close();
-                }
+        if (featureSource instanceof SimpleFeatureStore) {
+            SimpleFeatureStore featureStore = (SimpleFeatureStore) featureSource;
+            /*
+             * SimpleFeatureStore has a method to add features from a
+             * SimpleFeatureCollection object, so we use the ListFeatureCollection
+             * class to wrap our list of features.
+             */
+            SimpleFeatureCollection collection = new ListFeatureCollection(TYPE, features);
+            featureStore.setTransaction(transaction);
+            try {
+                featureStore.addFeatures(collection);
+                transaction.commit();
+            } catch (Exception problem) {
+                problem.printStackTrace();
+                transaction.rollback();
+            } finally {
+                transaction.close();
             }
+        }
     }
 
     public static void createAttributeShapeFile(String outputFile, List<GlobalAttributeForAPI> attributes) throws Exception {

--- a/app/models/attribute/GlobalAttributeTable.scala
+++ b/app/models/attribute/GlobalAttributeTable.scala
@@ -32,7 +32,7 @@ case class GlobalAttributeForAPI(val globalAttributeId: Int,
                                  val disagreeCount: Int,
                                  val notsureCount: Int,
                                  val streetEdgeId: Int,
-                                 val osmStreetId: Int,
+                                 val osmStreetId: Long,
                                  val neighborhoodName: String,
                                  val avgImageCaptureDate: Timestamp,
                                  val avgLabelDate: Timestamp,
@@ -74,7 +74,7 @@ case class GlobalAttributeWithLabelForAPI(val globalAttributeId: Int,
                                           val attributeSeverity: Option[Int],
                                           val attributeTemporary: Boolean,
                                           val streetEdgeId: Int,
-                                          val osmStreetId: Int,
+                                          val osmStreetId: Long,
                                           val neighborhoodName: String,
                                           val labelId: Int,
                                           val labelLatLng: (Float, Float),
@@ -188,14 +188,14 @@ object GlobalAttributeTable {
   implicit val GlobalAttributeForAPIConverter = GetResult[GlobalAttributeForAPI](r =>
     GlobalAttributeForAPI(
       r.nextInt, r.nextString, r.nextFloat, r.nextFloat, r.nextIntOption, r.nextBoolean, r.nextInt, r.nextInt,
-      r.nextInt, r.nextInt, r.nextInt, r.nextString, r.nextTimestamp, r.nextTimestamp, r.nextInt, r.nextInt,
+      r.nextInt, r.nextInt, r.nextLong, r.nextString, r.nextTimestamp, r.nextTimestamp, r.nextInt, r.nextInt,
       r.nextString.split(",").toList.distinct
     )
   )
 
   implicit val GlobalAttributeWithLabelForAPIConverter = GetResult[GlobalAttributeWithLabelForAPI](r =>
     GlobalAttributeWithLabelForAPI(
-      r.nextInt, r.nextString, (r.nextFloat, r.nextFloat), r.nextIntOption, r.nextBoolean, r.nextInt, r.nextInt, r.nextString,
+      r.nextInt, r.nextString, (r.nextFloat, r.nextFloat), r.nextIntOption, r.nextBoolean, r.nextInt, r.nextLong, r.nextString,
       r.nextInt, (r.nextFloat, r.nextFloat), r.nextString, (r.nextFloat, r.nextFloat, r.nextInt),
       (r.nextInt, r.nextInt), (r.nextInt, r.nextInt, r.nextInt), r.nextIntOption, r.nextBoolean,
       (r.nextString, r.nextTimestamp), r.nextStringOption.map(tags => tags.split(",").toList).getOrElse(List()),

--- a/app/models/street/OsmWayStreetEdgeTable.scala
+++ b/app/models/street/OsmWayStreetEdgeTable.scala
@@ -5,11 +5,11 @@ import play.api.Play.current
 import play.api.db.slick
 import scala.slick.lifted.{Tag}
 
-case class OsmWayStreetEdge(osmWayStreetEdgeId: Int, osmWayId: Int, streetEdgeId: Int)
+case class OsmWayStreetEdge(osmWayStreetEdgeId: Int, osmWayId: Long, streetEdgeId: Int)
 
 class OsmWayStreetEdgeTable(tag: Tag) extends Table[OsmWayStreetEdge](tag, "osm_way_street_edge") {
   def osmWayStreetEdgeId = column[Int]("osm_way_street_edge_id", O.NotNull, O.PrimaryKey, O.AutoInc)
-  def osmWayId = column[Int]("osm_way_id", O.NotNull)
+  def osmWayId = column[Long]("osm_way_id", O.NotNull)
   def streetEdgeId = column[Int]("street_edge_id", O.NotNull)
 
   def * = (osmWayStreetEdgeId, osmWayId, streetEdgeId) <> ((OsmWayStreetEdge.apply _).tupled, OsmWayStreetEdge.unapply)

--- a/app/models/street/StreetEdgeTable.scala
+++ b/app/models/street/StreetEdgeTable.scala
@@ -17,7 +17,7 @@ import scala.slick.jdbc.{GetResult, StaticQuery => Q}
 
 case class StreetEdge(streetEdgeId: Int, geom: LineString, x1: Float, y1: Float, x2: Float, y2: Float, wayType: String, deleted: Boolean, timestamp: Option[Timestamp])
 
-case class StreetEdgeInfo(val street: StreetEdge, osmId: Int, regionId: Int, val auditCount: Int)
+case class StreetEdgeInfo(val street: StreetEdge, osmId: Long, regionId: Int, val auditCount: Int)
 
 class StreetEdgeTable(tag: Tag) extends Table[StreetEdge](tag, "street_edge") {
   def streetEdgeId = column[Int]("street_edge_id", O.PrimaryKey)
@@ -64,7 +64,7 @@ object StreetEdgeTable {
     val wayType = r.nextString
     val deleted = r.nextBoolean
     val timestamp = r.nextTimestampOption
-    val osmId = r.nextInt
+    val osmId = r.nextLong
     val regionId = r.nextInt
     val auditCount = r.nextInt
     StreetEdgeInfo(StreetEdge(streetEdgeId, geometry, x1, y1, x2, y2, wayType, deleted, timestamp), osmId, regionId, auditCount)

--- a/conf/evolutions/default/211.sql
+++ b/conf/evolutions/default/211.sql
@@ -1,0 +1,14 @@
+# --- !Ups
+
+ALTER TABLE osm_way_street_edge
+ALTER COLUMN osm_way_id TYPE BIGINT;
+
+# --- !Downs
+
+
+ALTER TABLE osm_way_street_edge ADD COLUMN osm_way_id_temp INT;
+UPDATE osm_way_street_edge SET osm_way_id_temp = CAST(LEFT(osm_way_id::TEXT, 9) AS INT);
+
+ALTER TABLE osm_way_street_edge DROP COLUMN osm_way_id;
+
+ALTER TABLE osm_way_street_edge RENAME COLUMN osm_way_id_temp TO osm_way_id;

--- a/conf/evolutions/default/211.sql
+++ b/conf/evolutions/default/211.sql
@@ -5,10 +5,11 @@ ALTER COLUMN osm_way_id TYPE BIGINT;
 
 # --- !Downs
 
-
-ALTER TABLE osm_way_street_edge ADD COLUMN osm_way_id_temp INT;
-UPDATE osm_way_street_edge SET osm_way_id_temp = CAST(LEFT(osm_way_id::TEXT, 9) AS INT);
-
-ALTER TABLE osm_way_street_edge DROP COLUMN osm_way_id;
-
-ALTER TABLE osm_way_street_edge RENAME COLUMN osm_way_id_temp TO osm_way_id;
+ALTER TABLE osm_way_street_edge
+    ADD COLUMN osm_way_id_temp INT;
+UPDATE osm_way_street_edge
+    SET osm_way_id_temp = CAST(LEFT(osm_way_id::TEXT, 9) AS INT);
+ALTER TABLE osm_way_street_edge
+    DROP COLUMN osm_way_id;
+ALTER TABLE osm_way_street_edge
+    RENAME COLUMN osm_way_id_temp TO osm_way_id;


### PR DESCRIPTION
Resolves #3413

Shapefile format doesn't allow integers longer than 9 digits 

Fixed the bug!
Also changed the data type for "osmWayId" to BIGINT as INT data type does not take more than 9 digits.
Added Evolutions file for Database migration.

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
