### PR TITLE
Updating the vertical position of the zoom-in text box to have its arrow point to the center of the zoom-in button

### DIFF
--- a/public/javascripts/SVLabel/css/svl-onboarding.css
+++ b/public/javascripts/SVLabel/css/svl-onboarding.css
@@ -7,6 +7,24 @@
     }
 }
 
+@keyframes fadeInLeftCustom {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+}
+
+@keyframes fadeInDownCustom {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+}
+
 #tracker-holder {
     position: absolute;
     top: 0;

--- a/public/javascripts/SVLabel/css/svl-onboarding.css
+++ b/public/javascripts/SVLabel/css/svl-onboarding.css
@@ -1,3 +1,12 @@
+@keyframes fadeInRightCustom {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+}
+
 #tracker-holder {
     position: absolute;
     top: 0;
@@ -28,6 +37,7 @@
     left: 0;
     z-index: 3;
     font-size: 14pt;
+    transform: None;
 
     border-radius: 3px 3px 3px 3px;
     -webkit-border-radius: 3px 3px 3px 3px;

--- a/public/javascripts/SVLabel/css/svl-onboarding.css
+++ b/public/javascripts/SVLabel/css/svl-onboarding.css
@@ -1,30 +1,3 @@
-@keyframes fadeInRightCustom {
-    from {
-      opacity: 0;
-    }
-    to {
-      opacity: 1;
-    }
-}
-
-@keyframes fadeInLeftCustom {
-    from {
-      opacity: 0;
-    }
-    to {
-      opacity: 1;
-    }
-}
-
-@keyframes fadeInDownCustom {
-    from {
-      opacity: 0;
-    }
-    to {
-      opacity: 1;
-    }
-}
-
 #tracker-holder {
     position: absolute;
     top: 0;

--- a/public/javascripts/SVLabel/src/SVLabel/onboarding/Onboarding.js
+++ b/public/javascripts/SVLabel/src/SVLabel/onboarding/Onboarding.js
@@ -397,11 +397,7 @@ function Onboarding(svl, audioEffect, compass, form, handAnimation, mapService, 
             }
 
             if ("top" in parameters) {
-                if (i18next.language === "zh-TW" && "arrow" in parameters && parameters.arrow === "left") {
-                    uiOnboarding.messageHolder.css("top", parameters.top - 6);
-                } else {
-                    uiOnboarding.messageHolder.css("top", parameters.top);
-                }
+                uiOnboarding.messageHolder.css("top", parameters.top);
             }
 
             if ("background" in parameters && parameters.background) {

--- a/public/javascripts/SVLabel/src/SVLabel/onboarding/Onboarding.js
+++ b/public/javascripts/SVLabel/src/SVLabel/onboarding/Onboarding.js
@@ -397,7 +397,11 @@ function Onboarding(svl, audioEffect, compass, form, handAnimation, mapService, 
             }
 
             if ("top" in parameters) {
-                uiOnboarding.messageHolder.css("top", parameters.top);
+                if (i18next.language === "zh-TW" && "arrow" in parameters && parameters.arrow === "left") {
+                    uiOnboarding.messageHolder.css("top", parameters.top - 6);
+                } else {
+                    uiOnboarding.messageHolder.css("top", parameters.top);
+                }
             }
 
             if ("background" in parameters && parameters.background) {

--- a/public/javascripts/SVLabel/src/SVLabel/onboarding/Onboarding.js
+++ b/public/javascripts/SVLabel/src/SVLabel/onboarding/Onboarding.js
@@ -413,7 +413,7 @@ function Onboarding(svl, audioEffect, compass, form, handAnimation, mapService, 
             }
 
             if ("transform" in parameters) {
-                uiOnboarding.messageHolder.css("transform", "translateY(-50%)");
+                uiOnboarding.messageHolder.css("transform", parameters.transform);
             } else {
                 uiOnboarding.messageHolder.css("transform", "None");
             }

--- a/public/javascripts/SVLabel/src/SVLabel/onboarding/Onboarding.js
+++ b/public/javascripts/SVLabel/src/SVLabel/onboarding/Onboarding.js
@@ -369,7 +369,6 @@ function Onboarding(svl, audioEffect, compass, form, handAnimation, mapService, 
      */
     function showMessage(parameters) {
         var message = parameters.message;
-
         // Make the message flash yellow once to catch your attention.
         uiOnboarding.messageHolder.toggleClass("yellow-background");
         setTimeout(function () {
@@ -411,6 +410,12 @@ function Onboarding(svl, audioEffect, compass, form, handAnimation, mapService, 
 
             if ("fade-direction" in parameters) {
                 uiOnboarding.messageHolder.addClass("animated " + parameters["fade-direction"]);
+            }
+
+            if ("transform" in parameters) {
+                uiOnboarding.messageHolder.css("transform", "translateY(-50%)");
+            } else {
+                uiOnboarding.messageHolder.css("transform", "None");
             }
         }
 

--- a/public/javascripts/SVLabel/src/SVLabel/onboarding/OnboardingStates.js
+++ b/public/javascripts/SVLabel/src/SVLabel/onboarding/OnboardingStates.js
@@ -34,7 +34,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
                     return dom ? dom.innerHTML : "";
                 },
                 "width": 1000,
-                "top": -50,
+                "top": -105,
                 "left": -70,
                 "padding": "100px 10px 100px 10px",
                 "background": true
@@ -2040,7 +2040,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
                     return document.getElementById("onboarding-outro").innerHTML;
                 },
                 "width": 1000,
-                "top": -50,
+                "top": -105,
                 "left": -70,
                 "padding": "100px 10px 100px 10px",
                 "background": true

--- a/public/javascripts/SVLabel/src/SVLabel/onboarding/OnboardingStates.js
+++ b/public/javascripts/SVLabel/src/SVLabel/onboarding/OnboardingStates.js
@@ -976,9 +976,10 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             },
             "message": {
                 "message": i18next.t('tutorial.zoom-out'),
-                "fade-direction": "fadeInRight",
+                "fade-direction": "fadeInRightCustom",
                 "arrow": "left",
-                "top": 30
+                "top": 80,
+                "transform": "translateY(-50%)"
             },
             "panoId": panoId,
             "annotations": null,
@@ -1795,10 +1796,11 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             },
             "message": {
                 "message": i18next.t('tutorial.walk-1'),
-                "fade-direction": "fadeInLeft",
+                "fade-direction": "fadeInLeftCustom",
                 "arrow": "right",
-                "top": 310,
-                "left": 405
+                "top": 365,
+                "left": 405,
+                "transform": "translateY(-50%)"
             },
             "panoId": panoId,
             "transition": function () {
@@ -1824,10 +1826,11 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             },
             "message": {
                 "message": i18next.t('tutorial.walk-2'),
-                "fade-direction": "fadeInDown",
+                "fade-direction": "fadeInDownCustom",
                 "arrow": "bottom",
-                "top": 225,
-                "left": 405
+                "top": 385,
+                "left": 590,
+                "transform": "translate(-50%, -100%)"
             },
             "panoId": panoId,
             "annotations": null,
@@ -1868,9 +1871,10 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
                 "message": i18next.t('tutorial.walk-4'),
                 "width": 350,
                 "arrow": "right",
-                "fade-direction": "fadeInLeft",
-                "top": 254,
-                "left": 350
+                "fade-direction": "fadeInLeftCustom",
+                "top": 330,
+                "left": 350,
+                "transform": "translateY(-50%)"
             },
             "panoId": afterWalkPanoId,
             "annotations": null,
@@ -1988,9 +1992,10 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "message": {
                 "message": i18next.t('tutorial.instruction-1'),
                 "arrow": "right",
-                "fade-direction": "fadeInLeft",
-                "top": 270,
-                "left": 405
+                "fade-direction": "fadeInLeftCustom",
+                "top": 330,
+                "left": 405,
+                "transform": "translateY(-50%)"
             },
             "panoId": afterWalkPanoId,
             "annotations": null,
@@ -2007,10 +2012,11 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             },
             "message": {
                 "message": i18next.t('tutorial.instruction-2'),
-                "fade-direction": "fadeInRight",
+                "fade-direction": "fadeInRightCustom",
                 "arrow": "left",
-                "top": 265,
-                "left": 5
+                "top": 340,
+                "left": 5,
+                "transform": "translateY(-50%)"
             },
             "panoId": afterWalkPanoId,
             "annotations": null,

--- a/public/javascripts/SVLabel/src/SVLabel/onboarding/OnboardingStates.js
+++ b/public/javascripts/SVLabel/src/SVLabel/onboarding/OnboardingStates.js
@@ -400,7 +400,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
                 "arrow": "left",
                 "fade-direction": "fadeInRightCustom",
                 "top": 30,
-                "transform": "true"
+                "transform": "translateY(-50%)"
             },
             "panoId": panoId,
             "annotations": null,

--- a/public/javascripts/SVLabel/src/SVLabel/onboarding/OnboardingStates.js
+++ b/public/javascripts/SVLabel/src/SVLabel/onboarding/OnboardingStates.js
@@ -398,7 +398,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "message": {
                 "message": i18next.t('tutorial.zoom-in'),
                 "arrow": "left",
-                "fade-direction": "fadeInRightCustom",
+                "fade-direction": "fadeIn",
                 "top": 30,
                 "transform": "translateY(-50%)"
             },
@@ -976,7 +976,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             },
             "message": {
                 "message": i18next.t('tutorial.zoom-out'),
-                "fade-direction": "fadeInRightCustom",
+                "fade-direction": "fadeIn",
                 "arrow": "left",
                 "top": 80,
                 "transform": "translateY(-50%)"
@@ -1796,7 +1796,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             },
             "message": {
                 "message": i18next.t('tutorial.walk-1'),
-                "fade-direction": "fadeInLeftCustom",
+                "fade-direction": "fadeIn",
                 "arrow": "right",
                 "top": 365,
                 "left": 405,
@@ -1826,7 +1826,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             },
             "message": {
                 "message": i18next.t('tutorial.walk-2'),
-                "fade-direction": "fadeInDownCustom",
+                "fade-direction": "fadeIn",
                 "arrow": "bottom",
                 "top": 385,
                 "left": 590,
@@ -1871,7 +1871,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
                 "message": i18next.t('tutorial.walk-4'),
                 "width": 350,
                 "arrow": "right",
-                "fade-direction": "fadeInLeftCustom",
+                "fade-direction": "fadeIn",
                 "top": 330,
                 "left": 350,
                 "transform": "translateY(-50%)"
@@ -1992,7 +1992,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "message": {
                 "message": i18next.t('tutorial.instruction-1'),
                 "arrow": "right",
-                "fade-direction": "fadeInLeftCustom",
+                "fade-direction": "fadeIn",
                 "top": 330,
                 "left": 405,
                 "transform": "translateY(-50%)"
@@ -2012,7 +2012,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             },
             "message": {
                 "message": i18next.t('tutorial.instruction-2'),
-                "fade-direction": "fadeInRightCustom",
+                "fade-direction": "fadeIn",
                 "arrow": "left",
                 "top": 340,
                 "left": 5,

--- a/public/javascripts/SVLabel/src/SVLabel/onboarding/OnboardingStates.js
+++ b/public/javascripts/SVLabel/src/SVLabel/onboarding/OnboardingStates.js
@@ -225,7 +225,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
                 "maxHeading": headingRanges["stage-1"][1]
             },
             "message": {
-                "message": i18next.t('tutorial.select-label-type-2'),
+                "message": i18next.t('tutorial.select-label-type-2')
             },
             "panoId": panoId,
             "annotations": [
@@ -397,9 +397,10 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             },
             "message": {
                 "message": i18next.t('tutorial.zoom-in'),
-                "fade-direction": "fadeInRight",
                 "arrow": "left",
-                "top": -44
+                "fade-direction": "fadeInRightCustom",
+                "top": 30,
+                "transform": "true"
             },
             "panoId": panoId,
             "annotations": null,

--- a/public/javascripts/SVLabel/src/SVLabel/onboarding/OnboardingStates.js
+++ b/public/javascripts/SVLabel/src/SVLabel/onboarding/OnboardingStates.js
@@ -400,6 +400,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
                 "arrow": "left",
                 "fade-direction": "fadeIn",
                 "top": 30,
+                "left": 5,
                 "transform": "translateY(-50%)"
             },
             "panoId": panoId,
@@ -979,6 +980,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
                 "fade-direction": "fadeIn",
                 "arrow": "left",
                 "top": 80,
+                "left": 5,
                 "transform": "translateY(-50%)"
             },
             "panoId": panoId,
@@ -1798,8 +1800,8 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
                 "message": i18next.t('tutorial.walk-1'),
                 "fade-direction": "fadeIn",
                 "arrow": "right",
-                "top": 365,
-                "left": 405,
+                "top": 377,
+                "left": 403,
                 "transform": "translateY(-50%)"
             },
             "panoId": panoId,
@@ -1828,7 +1830,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
                 "message": i18next.t('tutorial.walk-2'),
                 "fade-direction": "fadeIn",
                 "arrow": "bottom",
-                "top": 385,
+                "top": 391,
                 "left": 590,
                 "transform": "translate(-50%, -100%)"
             },
@@ -1872,8 +1874,8 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
                 "width": 350,
                 "arrow": "right",
                 "fade-direction": "fadeIn",
-                "top": 330,
-                "left": 350,
+                "top": 377,
+                "left": 353,
                 "transform": "translateY(-50%)"
             },
             "panoId": afterWalkPanoId,
@@ -1993,8 +1995,8 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
                 "message": i18next.t('tutorial.instruction-1'),
                 "arrow": "right",
                 "fade-direction": "fadeIn",
-                "top": 330,
-                "left": 405,
+                "top": 377,
+                "left": 403,
                 "transform": "translateY(-50%)"
             },
             "panoId": afterWalkPanoId,

--- a/public/stylesheets/animate.css
+++ b/public/stylesheets/animate.css
@@ -1350,7 +1350,7 @@ Copyright (c) 2015 Daniel Eden
 
 .fadeInRight {
   -webkit-animation-name: fadeInRight;
-  animation-name: fadeInRight; 
+  animation-name: fadeInRight;
 }
 
 @-webkit-keyframes fadeInRightBig {

--- a/public/stylesheets/animate.css
+++ b/public/stylesheets/animate.css
@@ -1350,7 +1350,7 @@ Copyright (c) 2015 Daniel Eden
 
 .fadeInRight {
   -webkit-animation-name: fadeInRight;
-  animation-name: fadeInRight;
+  animation-name: fadeInRight; 
 }
 
 @-webkit-keyframes fadeInRightBig {


### PR DESCRIPTION
Resolves #3378

In this PR I align the arrow of the text box that prompts the user to zoom in in the tutorial to the center of the zoom in button. I did this by setting the top of the box to be where the center should be, and adding another parameter in OnboardingStates that translated up the box by 50% of it's height. I also had to replace the fadeInDown/Left/Right animation settings for each arrowed text box with a simple fadeIn animation, since the transformation component of the fadeInDown/Left/Right was overwriting the base transform needed to position each box properly.

##### Before/After screenshots (if applicable)
Before: 
![image](https://github.com/ProjectSidewalk/SidewalkWebpage/assets/86600946/45d5ee0e-50f3-4ee3-b74f-338e8587fc80)

After:
<img width="806" alt="image" src="https://github.com/ProjectSidewalk/SidewalkWebpage/assets/86600946/af340c25-442d-47b6-9c72-a80e81ff8964">

##### Testing instructions
1. Choose a language
2. Step through the tutorial until you get to the point where the text box pops up telling the user to zoom in and observe if it points to the center of the button.

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.