### PR TITLE
3437 geo json api file download

### DIFF
--- a/app/controllers/ProjectSidewalkAPIController.scala
+++ b/app/controllers/ProjectSidewalkAPIController.scala
@@ -126,7 +126,7 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
     * @return
     */
   def getAccessAttributesWithLabelsV2(lat1: Option[Double], lng1: Option[Double], lat2: Option[Double], lng2: Option[Double],
-                                      severity: Option[String], filetype: Option[String]) = UserAwareAction.async { implicit request =>
+                                      severity: Option[String], filetype: Option[String], inlineCheck: Boolean = false) = UserAwareAction.async { implicit request =>
     apiLogging(request.remoteAddress, request.identity, request.toString)
 
     val cityMapParams: MapParams = ConfigTable.getCityMapParams
@@ -185,7 +185,7 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
       writer.print("]}")
       writer.close()
 
-      Future.successful(Ok.sendFile(content = attributesJsonFile, inline = true, onClose = () => attributesJsonFile.delete()))
+      Future.successful(Ok.sendFile(content = attributesJsonFile, inline = inlineCheck, onClose = () => attributesJsonFile.delete()))
     }
   }
 
@@ -201,7 +201,7 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
     * @return
     */
   def getAccessAttributesV2(lat1: Option[Double], lng1: Option[Double], lat2: Option[Double], lng2: Option[Double],
-                            severity: Option[String], filetype: Option[String]) = UserAwareAction.async { implicit request =>
+                            severity: Option[String], filetype: Option[String], inlineCheck: Boolean = false) = UserAwareAction.async { implicit request =>
     apiLogging(request.remoteAddress, request.identity, request.toString)
 
     val cityMapParams: MapParams = ConfigTable.getCityMapParams
@@ -246,7 +246,7 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
       writer.print("]}")
       writer.close()
 
-      Future.successful(Ok.sendFile(content = attributesJsonFile, inline = true, onClose = () => attributesJsonFile.delete()))
+      Future.successful(Ok.sendFile(content = attributesJsonFile, inline = inlineCheck, onClose = () => attributesJsonFile.delete()))
     }
   }
 

--- a/app/controllers/ProjectSidewalkAPIController.scala
+++ b/app/controllers/ProjectSidewalkAPIController.scala
@@ -123,6 +123,7 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
     * @param lng2
     * @param severity
     * @param filetype
+    * @param inlineCheck
     * @return
     */
   def getAccessAttributesWithLabelsV2(lat1: Option[Double], lng1: Option[Double], lat2: Option[Double], lng2: Option[Double],
@@ -198,6 +199,7 @@ class ProjectSidewalkAPIController @Inject()(implicit val env: Environment[User,
     * @param lng2
     * @param severity
     * @param filetype
+    * @param inlineCheck
     * @return
     */
   def getAccessAttributesV2(lat1: Option[Double], lng1: Option[Double], lat2: Option[Double], lng2: Option[Double],

--- a/public/javascripts/developer.js
+++ b/public/javascripts/developer.js
@@ -31,11 +31,11 @@ function Developer () {
         // Assign URLs to download buttons to get citywide data.
         $('#city-attributes-csv').attr({ 'href': '/v2/access/attributes?filetype=csv' });
         $('#city-attributes-shapefile').attr({ 'href': '/v2/access/attributes?filetype=shapefile' });
-        $('#city-attributes-geojson').attr({ 'href': '/v2/access/attributes?filetype=geojson' });
+        $('#city-attributes-geojson').attr({ 'href': '/v2/access/attributes?filetype=geojson&inlineCheck=true' });
 
         $('#city-attributes-label-csv').attr({ 'href': '/v2/access/attributesWithLabels?filetype=csv' });
         $('#city-attributes-label-shapefile').attr({ 'href': '/v2/access/attributesWithLabels?filetype=shapefile' });
-        $('#city-attributes-label-geojson').attr({ 'href': '/v2/access/attributesWithLabels?filetype=geojson' });
+        $('#city-attributes-label-geojson').attr({ 'href': '/v2/access/attributesWithLabels?filetype=geojson&inlineCheck=true' });
 
         $('#city-streets-csv').attr({ 'href': '/v2/access/score/streets?filetype=csv' });
         $('#city-streets-shapefile').attr({ 'href': '/v2/access/score/streets?filetype=shapefile' });


### PR DESCRIPTION
…for API page

Resolves #3437

Creates optional parameter for /attributes and /attributesWithLabels API calls for geojson. Set inline parameter default to false and to true for maps on Project Sidewalk API webpage. 

##### Before/After screenshots (if applicable)

##### Testing instructions
1. 

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [X] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [X] I've added/updated comments for large or confusing blocks of code.
- [ ] I've included before/after screenshots above.
- [ ] I've asked for and included translations for any user facing text that was added or modified.
- [ ] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure the documentation on [this wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Descriptions-of-Logged-Events) is up to date for the logs you added/updated.
- [ ] I've tested on mobile (only needed for validation page).
