### PR TITLE
Added extra null checking for next mission to solve navigation system error for custom routes

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
+++ b/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
@@ -704,7 +704,6 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
      * Callback to track when user moves away from their current location.
      */
     function trackBeforeJumpActions() {
-        console.log('in trackBeforeJA')
         if (status.labelBeforeJumpListenerSet) {
             var currentLatLng = getPosition(),
                 currentPosition = turf.point([currentLatLng.lng, currentLatLng.lat]),

--- a/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
+++ b/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
@@ -690,7 +690,7 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
                 } catch (err) {}
             } else {
                 finishCurrentTaskBeforeJumping(missionJump, nextTask);
-            
+
                 // Move to the new task if the route/neighborhood has not finished.
                 if (nextTask) {
                     svl.taskContainer.setCurrentTask(nextTask);
@@ -716,7 +716,7 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
                 svl.compass.showLabelBeforeJumpMessage();
                 status.jumpMsgShown = true
 
-            } else if (distance > 0.07) {
+            } else if (distance > 0.07 && !svl.neighborhoodModel.isRouteOrNeighborhoodComplete()) {
                 // Jump to the new location if it's really far away from their location.
                 svl.tracker.push('LabelBeforeJump_AutoJump');
 
@@ -728,12 +728,8 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
 
                 // Jump to the new task
                 var newTask = svl.taskContainer.getAfterJumpNewTask();
-                if (newTask) {
-                    _jumpToNewTask(newTask);
-                    svl.jumpModel.triggerTooFarFromJumpLocation();
-                } else {
-                    console.log("next task is null, the if statement is successfully catching the case where the system attempts to move to a null next task")
-                }
+                _jumpToNewTask(newTask);
+                svl.jumpModel.triggerTooFarFromJumpLocation();
             }
         }
     }

--- a/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
+++ b/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
@@ -690,7 +690,7 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
                 } catch (err) {}
             } else {
                 finishCurrentTaskBeforeJumping(missionJump, nextTask);
-
+            
                 // Move to the new task if the route/neighborhood has not finished.
                 if (nextTask) {
                     svl.taskContainer.setCurrentTask(nextTask);
@@ -728,8 +728,10 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
 
                 // Jump to the new task
                 var newTask = svl.taskContainer.getAfterJumpNewTask();
-                _jumpToNewTask(newTask);
-                svl.jumpModel.triggerTooFarFromJumpLocation();
+                if (newTask) {
+                    _jumpToNewTask(newTask);
+                    svl.jumpModel.triggerTooFarFromJumpLocation();
+                }
             }
         }
     }

--- a/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
+++ b/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
@@ -704,6 +704,7 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
      * Callback to track when user moves away from their current location.
      */
     function trackBeforeJumpActions() {
+        console.log('in trackBeforeJA')
         if (status.labelBeforeJumpListenerSet) {
             var currentLatLng = getPosition(),
                 currentPosition = turf.point([currentLatLng.lng, currentLatLng.lat]),
@@ -731,6 +732,8 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
                 if (newTask) {
                     _jumpToNewTask(newTask);
                     svl.jumpModel.triggerTooFarFromJumpLocation();
+                } else {
+                    console.log("next task is null, the if statement is successfully catching the case where the system attempts to move to a null next task")
                 }
             }
         }


### PR DESCRIPTION
Resolves #3341: navigation system (arrows) spinning at the end of custom routes

In this PR, I fixed the issue of the navigation system spinning randomly at the end of a custom route. I found that the cause of the error was the fact that the nextTask is null at the end of a custom route, which was causing various errors on the console and throwing everything out of whack. So, to combat this, before switching to the next task, I simply added and if statement to check if it was null, and only allowed moving to the next task in the case that it is not null. In the null case, nothing happens, which I think is appropriate since the user is prompted to click to finish their route anyway.

##### Before/After screenshots (if applicable)
Before:
<img width="1709" alt="image" src="https://github.com/ProjectSidewalk/SidewalkWebpage/assets/86600946/307ce015-0ccf-40bd-aebc-056332e7e602">

After:
<img width="1709" alt="image" src="https://github.com/ProjectSidewalk/SidewalkWebpage/assets/86600946/f7a2420b-0682-4577-9f76-647d7688740b">


##### Testing instructions
Watching this video may help to show how to recreate the error (you can see it in the final quarter of the video): https://www.youtube.com/watch?v=oONCCEaH4lM
1. Go to routeBuilder 
2. Go to a custom route
3. Finish traversing across it
4. Now keep labeling and using the navigation, especially when it tells you to 'finish labeling the intersection and click here'
5. Keep repeating step 5 until a print statement appears saying that "next task is null, the if statement is catching the case where the system attempts to move to a null next task". If the navigation system starts spinning here, the fix did not work, but if no related errors pop up and everything is fine in the UI, we should be good!

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.