### PR TITLE
Adds neighborhood filter URL parameter to Gallery

### DIFF
--- a/app/controllers/ApplicationController.scala
+++ b/app/controllers/ApplicationController.scala
@@ -367,7 +367,7 @@ class ApplicationController @Inject() (implicit val env: Environment[User, Sessi
   /**
    * Returns the Gallery page.
    */
-  def gallery(labelType: String, severities: String, tags: String, validationOptions: String) = UserAwareAction.async { implicit request =>
+  def gallery(labelType: String, neighborhoods: String, severities: String, tags: String, validationOptions: String) = UserAwareAction.async { implicit request =>
     request.identity match {
       case Some(user) =>
         val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
@@ -393,20 +393,23 @@ class ApplicationController @Inject() (implicit val env: Environment[User, Sessi
           if (labelTypes.exists(x => { x._1 == labelType })) (labelType, selectTagsByLabelType(labelType).map(_.tag))
           else ("Assorted", List())
 
-        // Make sure that list of severities and validation options are formatted correctly.
+        // TODO maybe remove neighborhoods that aren't in the city?
+
+        // Make sure that list of region IDs, severities, and validation options are formatted correctly.
+        val regionIdsList: List[Int] = parseIntegerList(neighborhoods)
         val severityList: List[Int] = parseIntegerList(severities).filter(s => s > 0 && s < 6)
         val tagList: List[String] = tags.split(",").filter(possibleTags.contains).toList
         val valOptions: List[String] = validationOptions.split(",").filter(List("correct", "incorrect", "notsure", "unvalidated").contains(_)).toList
 
         // Log visit to Gallery.
-        val activityStr: String = s"Visit_Gallery_LabelType=${labType}_Severity=${severityList}_Tags=${tagList}_Validations=$valOptions"
+        val activityStr: String = s"Visit_Gallery_LabelType=${labType}_RegionIDs=${regionIdsList}_Severity=${severityList}_Tags=${tagList}_Validations=$valOptions"
         WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, activityStr, timestamp))
 
-        Future.successful(Ok(views.html.gallery("Sidewalk - Gallery", Some(user), cityInfo, labType, labelTypes, severityList, tagList, valOptions)))
+        Future.successful(Ok(views.html.gallery("Sidewalk - Gallery", Some(user), cityInfo, labType, labelTypes, regionIdsList, severityList, tagList, valOptions)))
       case None =>
         // Send them through anon signup so that there activities on sidewalk gallery are logged as anon.
         // UTF-8 codes needed to pass a URL that contains parameters: ? is %3F, & is %26
-        Future.successful(Redirect(s"/anonSignUp?url=/gallery%3FlabelType=$labelType%26severities=$severities%26tags=$tags%26validationOptions=$validationOptions"))
+        Future.successful(Redirect(s"/anonSignUp?url=/gallery%3FlabelType=$labelType%26neighborhoods=$neighborhoods%26severities=$severities%26tags=$tags%26validationOptions=$validationOptions"))
     }
   }
 

--- a/app/controllers/ApplicationController.scala
+++ b/app/controllers/ApplicationController.scala
@@ -17,11 +17,14 @@ import models.label.TagTable.selectTagsByLabelType
 import models.street.StreetEdgePriorityTable
 import models.utils.{CityInfo, Configs}
 import models.attribute.ConfigTable
+import models.region.RegionTable
 import play.api.Play
 import play.api.Play.current
 import play.api.i18n.{Lang, Messages}
+
 import java.util.Calendar
 import play.api.mvc._
+
 import scala.concurrent.Future
 import scala.util.Random
 
@@ -389,14 +392,13 @@ class ApplicationController @Inject() (implicit val env: Environment[User, Sessi
           ("Signal", Messages("signal")),
           ("Other", Messages("other"))
         )
+        val possibleRegions: List[Int] = RegionTable.getAllRegions.map(_.regionId)
         val (labType, possibleTags): (String, List[String]) =
           if (labelTypes.exists(x => { x._1 == labelType })) (labelType, selectTagsByLabelType(labelType).map(_.tag))
           else ("Assorted", List())
 
-        // TODO maybe remove neighborhoods that aren't in the city?
-
         // Make sure that list of region IDs, severities, and validation options are formatted correctly.
-        val regionIdsList: List[Int] = parseIntegerList(neighborhoods)
+        val regionIdsList: List[Int] = parseIntegerList(neighborhoods).filter(possibleRegions.contains)
         val severityList: List[Int] = parseIntegerList(severities).filter(s => s > 0 && s < 6)
         val tagList: List[String] = tags.split(",").filter(possibleTags.contains).toList
         val valOptions: List[String] = validationOptions.split(",").filter(List("correct", "incorrect", "notsure", "unvalidated").contains(_)).toList

--- a/app/controllers/GalleryController.scala
+++ b/app/controllers/GalleryController.scala
@@ -41,12 +41,13 @@ class GalleryController @Inject() (implicit val env: Environment[User, SessionAu
             val labelTypeId: Option[Int] = submission.labelTypeId
             val loadedLabelIds: Set[Int] = submission.loadedLabels.toSet
             val valOptions: Set[String] = submission.validationOptions.getOrElse(Seq()).toSet
+            val regionIds: Set[Int] = submission.regionIds.getOrElse(Seq()).toSet
             val severities: Set[Int] = submission.severities.getOrElse(Seq()).toSet
             val tags: Set[String] = submission.tags.getOrElse(Seq()).toSet
 
             // Get labels from LabelTable.
             val labels: Seq[LabelValidationMetadata] =
-              LabelTable.getGalleryLabels(n, labelTypeId, loadedLabelIds, valOptions, severities, tags, user.userId)
+              LabelTable.getGalleryLabels(n, labelTypeId, loadedLabelIds, valOptions, regionIds, severities, tags, user.userId)
 
             val jsonList: Seq[JsObject] = labels.map(l => Json.obj(
                 "label" -> LabelFormat.validationLabelMetadataToJson(l),

--- a/app/formats/json/GalleryFormats.scala
+++ b/app/formats/json/GalleryFormats.scala
@@ -8,7 +8,7 @@ object GalleryFormats {
   case class GalleryEnvironmentSubmission(browser: Option[String], browserVersion: Option[String], browserWidth: Option[Int], browserHeight: Option[Int], screenWidth: Option[Int], screenHeight: Option[Int], availWidth: Option[Int], availHeight: Option[Int], operatingSystem: Option[String], language: String)
   case class GalleryInteractionSubmission(action: String, panoId: Option[String], note: Option[String], timestamp: Long)
   case class GalleryTaskSubmission(environment: GalleryEnvironmentSubmission, interactions: Seq[GalleryInteractionSubmission])
-  case class GalleryLabelsRequest(n: Int, labelTypeId: Option[Int], validationOptions: Option[Seq[String]], severities: Option[Seq[Int]], tags: Option[Seq[String]], loadedLabels: Seq[Int])
+  case class GalleryLabelsRequest(n: Int, labelTypeId: Option[Int], validationOptions: Option[Seq[String]], regionIds: Option[Seq[Int]], severities: Option[Seq[Int]], tags: Option[Seq[String]], loadedLabels: Seq[Int])
 
   implicit val galleryEnvironmentSubmissionReads: Reads[GalleryEnvironmentSubmission] = (
     (JsPath \ "browser").readNullable[String] and
@@ -39,6 +39,7 @@ object GalleryFormats {
     (JsPath \ "n").read[Int] and
       (JsPath \ "label_type_id").readNullable[Int] and
       (JsPath \ "validation_options").readNullable[Seq[String]] and
+      (JsPath \ "neighborhoods").readNullable[Seq[Int]] and
       (JsPath \ "severities").readNullable[Seq[Int]] and
       (JsPath \ "tags").readNullable[Seq[String]] and
       (JsPath \ "loaded_labels").read[Seq[Int]]

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -640,11 +640,12 @@ object LabelTable {
    * @param labelTypeId       Label type specifying what type of labels to grab. None will give a mix.
    * @param loadedLabelIds    Set of labelIds already grabbed as to not grab them again.
    * @param valOptions        Set of correctness values to filter for: correct, incorrect, notsure, and/or unvalidated.
+   * @param regionIds         Set of neighborhoods to get labels from. All neighborhoods if empty.
    * @param severity          Set of severities the labels grabbed can have.
    * @param tags              Set of tags the labels grabbed can have.
    * @return Seq[LabelValidationMetadata]
    */
-  def getGalleryLabels(n: Int, labelTypeId: Option[Int], loadedLabelIds: Set[Int], valOptions: Set[String], severity: Set[Int], tags: Set[String], userId: UUID): Seq[LabelValidationMetadata] = db.withSession { implicit session =>
+  def getGalleryLabels(n: Int, labelTypeId: Option[Int], loadedLabelIds: Set[Int], valOptions: Set[String], regionIds: Set[Int], severity: Set[Int], tags: Set[String], userId: UUID): Seq[LabelValidationMetadata] = db.withSession { implicit session =>
     // Filter labels based on correctness.
     val _l1 = if (!valOptions.contains("correct")) labels.filter(l => l.correct.isEmpty || !l.correct) else labels
     val _l2 = if (!valOptions.contains("incorrect")) _l1.filter(l => l.correct.isEmpty || l.correct) else _l1
@@ -673,6 +674,7 @@ object LabelTable {
       _ser <- StreetEdgeRegionTable.streetEdgeRegionTable if _lb.streetEdgeId === _ser.streetEdgeId
       if _gd.expired === false
       if _lb.labelTypeId === labelTypeId || labelTypeId.isEmpty
+      if (_ser.regionId inSet regionIds) || regionIds.isEmpty
       if (_lb.severity inSet severity) || severity.isEmpty
       if _us.highQuality || (_lb.correct.isDefined && _lb.correct === true)
       if _lb.disagreeCount < 3 || _lb.disagreeCount < _lb.agreeCount * 2

--- a/app/views/gallery.scala.html
+++ b/app/views/gallery.scala.html
@@ -2,7 +2,7 @@
 @import models.utils.CityInfo
 @import play.api.Play
 @import play.api.Play.current
-@(title: String, user: Option[User] = None, cityInfo: List[CityInfo], labelType: String, labels: List[(String, String)], severities: List[Int], tags: List[String], valOptions: List[String])(implicit lang: Lang)
+@(title: String, user: Option[User] = None, cityInfo: List[CityInfo], labelType: String, labels: List[(String, String)], regionIds: List[Int], severities: List[Int], tags: List[String], valOptions: List[String])(implicit lang: Lang)
 @currentCity = @{cityInfo.filter(c => c.cityId == Play.configuration.getString("city-id").get).head}
 
 @main(title) {
@@ -128,6 +128,7 @@
             // Initial set of sidebar filters.
             params.initialFilters = {
                 labelType: '@labelType',
+                neighborhoods: @{regionIds.mkString("[", ",", "]")},
                 severities: @{severities.mkString("[", ",", "]")},
                 validationOptions: @{if (valOptions.isEmpty) "[]" else Html(valOptions.mkString("['", "','", "']"))},
                 tags: @{if (tags.isEmpty) "[]" else Html(tags.mkString("['", "','", "']"))}

--- a/app/views/navbar.scala.html
+++ b/app/views/navbar.scala.html
@@ -129,7 +129,7 @@
                         </a>
                         <ul id="nav-data-menu" class="dropdown-menu" role="menu" aria-label="Data Options">
                             <li>
-                                <a id="navbar-gallery-btn" role="menuitem" href="@routes.ApplicationController.gallery("Assorted", "", "", "correct,unvalidated")">@Messages("gallery")</a>
+                                <a id="navbar-gallery-btn" role="menuitem" href="@routes.ApplicationController.gallery("Assorted", "", "", "", "correct,unvalidated")">@Messages("gallery")</a>
                             </li>
                             <li>
                                 <a id="navbar-leaderboard-btn" role="menuitem" href='@routes.ApplicationController.leaderboard'>@Messages("navbar.leaderboard")</a>

--- a/conf/routes
+++ b/conf/routes
@@ -13,7 +13,7 @@ GET     /demo                                                @controllers.Applic
 GET     /results                                             @controllers.ApplicationController.results
 GET     /labelMap                                            @controllers.ApplicationController.labelMap(regions: Option[String] ?= None)
 GET     /labelmap                                            @controllers.ApplicationController.labelMap(regions: Option[String] ?= None)
-GET     /gallery                                             @controllers.ApplicationController.gallery(labelType: String ?= "Assorted", severities: String ?= "", tags: String ?= "", validationOptions: String ?= "correct,unvalidated")
+GET     /gallery                                             @controllers.ApplicationController.gallery(labelType: String ?= "Assorted", neighborhoods: String ?= "", severities: String ?= "", tags: String ?= "", validationOptions: String ?= "correct,unvalidated")
 GET     /help                                                @controllers.ApplicationController.help
 GET     /labelingGuide                                       @controllers.ApplicationController.labelingGuide
 GET     /labelingguide                                       @controllers.ApplicationController.labelingGuide

--- a/public/javascripts/Gallery/src/cards/CardContainer.js
+++ b/public/javascripts/Gallery/src/cards/CardContainer.js
@@ -81,7 +81,7 @@ function CardContainer(uiCardContainer, initialFilters) {
         cardsByType[currentLabelType] = new CardBucket();
 
         // Grab first batch of labels to show.
-        fetchLabels(labelTypeIds[currentLabelType], initialLoad, initialFilters.validationOptions, Array.from(loadedLabelIds), initialFilters.severities, initialFilters.tags, function() {
+        fetchLabels(labelTypeIds[currentLabelType], initialLoad, initialFilters.validationOptions, Array.from(loadedLabelIds), initialFilters.neighborhoods, initialFilters.severities, initialFilters.tags, function() {
             currentCards = cardsByType[currentLabelType].copy();
             render();
         });
@@ -170,18 +170,20 @@ function CardContainer(uiCardContainer, initialFilters) {
      * @param {*} n Number of labels to grab.
      * @param validationOptions List of validation options for fetched labels: correct, incorrect, and/or unvalidated.
      * @param {*} loadedLabels Label Ids of labels already grabbed.
-     * @param {*} severities Severities the labels to be grabbed can have. (Set to undefined if N/A)
-     * @param {*} tags Tags the labels to be grabbed can have. (Set to undefined if N/A)
+     * @param {*} neighborhoods Region IDs the labels to be grabbed can be from (Set to undefined if N/A).
+     * @param {*} severities Severities the labels to be grabbed can have (Set to undefined if N/A).
+     * @param {*} tags Tags the labels to be grabbed can have (Set to undefined if N/A).
      * @param {*} callback Function to be called when labels arrive.
      */
-    function fetchLabels(labelTypeId, n, validationOptions, loadedLabels, severities, tags, callback) {
+    function fetchLabels(labelTypeId, n, validationOptions, loadedLabels, neighborhoods, severities, tags, callback) {
         var url = "/label/labels";
         let data = {
             label_type_id: labelTypeId,
             n: n,
             validation_options: validationOptions,
-            ...(severities !== undefined && {severities: severities}),
-            ...(tags !== undefined && {tags: tags}),
+            ...(neighborhoods !== undefined && { neighborhoods: neighborhoods }),
+            ...(severities !== undefined && { severities: severities }),
+            ...(tags !== undefined && { tags: tags }),
             loaded_labels: loadedLabels
         }
         $.ajax({
@@ -253,7 +255,7 @@ function CardContainer(uiCardContainer, initialFilters) {
 
         if (currentCards.getSize() < cardsPerPage * currentPage + 1) {
             // When we don't have enough cards of specific query to show on one page, see if more can be grabbed.
-            fetchLabels(labelTypeIds[currentLabelType], cardsPerPage * 2, appliedValOptions, Array.from(loadedLabelIds), appliedSeverities, appliedTags, function() {
+            fetchLabels(labelTypeIds[currentLabelType], cardsPerPage * 2, appliedValOptions, Array.from(loadedLabelIds), initialFilters.neighborhoods, appliedSeverities, appliedTags, function() {
                 currentCards = cardsByType[currentLabelType].copy();
                 currentCards.filterOnTags(appliedTags);
                 currentCards.filterOnSeverities(appliedSeverities);

--- a/public/javascripts/Gallery/src/cards/CardContainer.js
+++ b/public/javascripts/Gallery/src/cards/CardContainer.js
@@ -37,6 +37,7 @@ function CardContainer(uiCardContainer, initialFilters) {
 
     // Current label type of cards being shown.
     let currentLabelType = initialFilters.labelType;
+    sg.neighborhoodIds = initialFilters.neighborhoods; // TODO remove this when we add a UI for filtering neighborhoods.
     let currentPage = 1;
     let lastPage = false;
     let pageNumberDisplay = null;

--- a/public/javascripts/Gallery/src/data/Tracker.js
+++ b/public/javascripts/Gallery/src/data/Tracker.js
@@ -89,7 +89,7 @@ function Tracker() {
      * 
      * @param action (required) Action name.
      * @param suppData (optional) Supplementary data to be logged about action.
-     * @param notes (optional) Notes to be logged into the notes fieldin database.
+     * @param notes (optional) Notes to be logged into the notes field in database.
      */
     function push(action, suppData, notes) {
         let item = _createAction(action, suppData, notes);

--- a/public/javascripts/Gallery/src/filter/CardFilter.js
+++ b/public/javascripts/Gallery/src/filter/CardFilter.js
@@ -124,6 +124,11 @@ function CardFilter(uiCardFilter, labelTypeMenu, cityMenu, initialFilters) {
             }
             firstQueryParam = false;
         }
+        // TODO once we add a UI for neighborhood filtering, have that process mirror what we have for other filters.
+        if (sg.neighborhoodIds.length > 0) {
+            newUrl += firstQueryParam ? `?neighborhoods=${sg.neighborhoodIds.join()}` : `&neighborhoods=${sg.neighborhoodIds.join()}`;
+            firstQueryParam = false;
+        }
         if (currSeverities.length > 0) {
             uiCardFilter.clearFilters.show();
             newUrl += firstQueryParam ? `?severities=${currSeverities}` : `&severities=${currSeverities}`;


### PR DESCRIPTION
Partially resolves #3206 

Adds a neighborhood filter to Gallery. I didn't add any UI, but I've added it as a URL parameter that anyone can use. It should look like `neighborhoods=<comma-separated list of region IDs>`.  For example, in Newberg, the Oak Knoll neighborhood's region ID is 6, so you could search for all labels in that neighborhood using:
https://sidewalk-newberg.cs.washington.edu/gallery?neighborhoods=6.
If you wanted to search in both Oak Knoll and Jaquith Park, you could use:
https://sidewalk-newberg.cs.washington.edu/gallery?neighborhoods=4,6.

You can find the region ID using the /v2/access/score/neighborhoods API.

In the future, we will add a UI to select neighborhoods for filtering. But we are setting up just the URL parameters for internal use, and to send direct links to our partners quickly. Sacrificing some usability for now!

But if you filter for a neighborhood, you can continue to add other types of filters to Gallery through the UI (severity, tags, etc) without any issue. It will continue to look only at the set of neighborhoods you specified. If you want to go back to searching in any neighborhood, just remove that parameter from the URL.

##### Before/After screenshots (if applicable)
Searching through all neighborhoods
<img width="1426" alt="Screenshot 2024-01-26 at 4 04 23 PM" src="https://github.com/ProjectSidewalk/SidewalkWebpage/assets/6518824/bd325c3b-2991-4c08-b8a8-0551116f69fe">

Searching through one neighborhood (with very little data). You can see the filter in the URL.
<img width="1426" alt="Screenshot 2024-01-26 at 4 04 05 PM" src="https://github.com/ProjectSidewalk/SidewalkWebpage/assets/6518824/599dae39-cc88-4e37-8f5c-8179ece93b0b">

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
- [x] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure the documentation on [this wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Descriptions-of-Logged-Events) is up to date for the logs you added/updated.
