### PR TITLE
Resizing crops before saving.

### DIFF
--- a/app/controllers/ImageController.scala
+++ b/app/controllers/ImageController.scala
@@ -11,6 +11,8 @@ import play.api.libs.json._
 import play.api.mvc.AnyContent
 import play.api.mvc.Action
 import play.api.mvc.Request
+
+import java.awt.Image
 import java.awt.image.BufferedImage
 import java.io._
 import java.util.Base64
@@ -22,14 +24,36 @@ class ImageController @Inject() (implicit val env: Environment[User, SessionAuth
   // This is the name of the directory in which all the crops are saved.
   val CROPS_DIR_NAME = Play.configuration.getString("cropped.image.directory").get
 
+
+  // 2x the actual size of the GSV window as retina screen can give us 2x the pixel density.
+  val CROP_WIDTH = 1440
+  val CROP_HEIGHT = 960
+
+
+  // Resize the image to the new width and height.
+  def resize(img: BufferedImage, newWidth: Int, newHeight: Int): BufferedImage = {
+      val tmp: Image = img.getScaledInstance(newWidth, newHeight, Image.SCALE_DEFAULT)
+      val dimg: BufferedImage = new BufferedImage(newWidth, newHeight, img.getType())
+      val g2d = dimg.createGraphics()
+      g2d.drawImage(tmp, 0, 0, null)
+      g2d.dispose()
+
+      dimg
+  }
+
   // Write the image to a file.
   def writeImageFile(filename: String, b64String: String): Unit = {
     val imageBytes: Array[Byte] = Base64.getDecoder.decode(b64String)
     val inputStream = new ByteArrayInputStream(imageBytes)
     val bufferedImage: BufferedImage = ImageIO.read(inputStream)
+
+      // resize the image right here as we might be getting different sizes for different browser zoom levels.
+      // the aspect ratio of the image should be preserved even if it is a different size so that should be okay.
+      val resizedImage: BufferedImage = resize(bufferedImage, CROP_WIDTH, CROP_HEIGHT)
+
     val f = new File(filename)
     try {
-      val result: Boolean = ImageIO.write(bufferedImage, "png", f)
+      val result: Boolean = ImageIO.write(resizedImage, "png", f)
       if (!result) {
         Logger.error("Failed to write image file: " + filename)
       }

--- a/app/controllers/ImageController.scala
+++ b/app/controllers/ImageController.scala
@@ -24,7 +24,6 @@ class ImageController @Inject() (implicit val env: Environment[User, SessionAuth
   // This is the name of the directory in which all the crops are saved.
   val CROPS_DIR_NAME = Play.configuration.getString("cropped.image.directory").get
 
-
   // 2x the actual size of the GSV window as retina screen can give us 2x the pixel density.
   val CROP_WIDTH = 1440
   val CROP_HEIGHT = 960
@@ -32,13 +31,12 @@ class ImageController @Inject() (implicit val env: Environment[User, SessionAuth
 
   // Resize the image to the new width and height.
   def resize(img: BufferedImage, newWidth: Int, newHeight: Int): BufferedImage = {
-      val tmp: Image = img.getScaledInstance(newWidth, newHeight, Image.SCALE_SMOOTH)
-      val dimg: BufferedImage = new BufferedImage(newWidth, newHeight, img.getType())
-      val g2d = dimg.createGraphics()
-      g2d.drawImage(tmp, 0, 0, null)
-      g2d.dispose()
-
-      dimg
+    val tmp: Image = img.getScaledInstance(newWidth, newHeight, Image.SCALE_SMOOTH)
+    val dimg: BufferedImage = new BufferedImage(newWidth, newHeight, img.getType())
+    val g2d = dimg.createGraphics()
+    g2d.drawImage(tmp, 0, 0, null)
+    g2d.dispose()
+    dimg
   }
 
   // Write the image to a file.
@@ -47,9 +45,9 @@ class ImageController @Inject() (implicit val env: Environment[User, SessionAuth
     val inputStream = new ByteArrayInputStream(imageBytes)
     val bufferedImage: BufferedImage = ImageIO.read(inputStream)
 
-      // resize the image right here as we might be getting different sizes for different browser zoom levels.
-      // the aspect ratio of the image should be preserved even if it is a different size so that should be okay.
-      val resizedImage: BufferedImage = resize(bufferedImage, CROP_WIDTH, CROP_HEIGHT)
+    // Resize the image as we might be getting different sizes for different browser zoom levels.
+    // The aspect ratio of the image should be preserved even if it is a different size so that should be okay.
+    val resizedImage: BufferedImage = resize(bufferedImage, CROP_WIDTH, CROP_HEIGHT)
 
     val f = new File(filename)
     try {

--- a/app/controllers/ImageController.scala
+++ b/app/controllers/ImageController.scala
@@ -32,7 +32,7 @@ class ImageController @Inject() (implicit val env: Environment[User, SessionAuth
 
   // Resize the image to the new width and height.
   def resize(img: BufferedImage, newWidth: Int, newHeight: Int): BufferedImage = {
-      val tmp: Image = img.getScaledInstance(newWidth, newHeight, Image.SCALE_DEFAULT)
+      val tmp: Image = img.getScaledInstance(newWidth, newHeight, Image.SCALE_SMOOTH)
       val dimg: BufferedImage = new BufferedImage(newWidth, newHeight, img.getType())
       val g2d = dimg.createGraphics()
       g2d.drawImage(tmp, 0, 0, null)


### PR DESCRIPTION
Resolves #3467 

To avoid saving images of different resolutions based on the user's browser zoom level, we are resizing the images on the server side right before saving it. This way we will have uniform size for all the crops saved. 

##### Testing instructions
1. Change the browser zoom to more than 100%. Place a label. Make sure that the crop saved is of size 1440x960.
2. Change the browser zoom to less than 100%. Place a label. Make sure that the crop saved is of size 1440x960. 

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
