### PR TITLE
Adds a dedicated page to view a label and search for them

### DIFF
--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -91,6 +91,15 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
   }
 
   /**
+   * Loads the page that shows a single label.
+   */
+  def label(labelId: Int) = UserAwareAction.async { implicit request =>
+    val admin: Boolean = isAdmin(request.identity)
+    // TODO check if the label ID exists.
+    Future.successful(Ok(views.html.admin.label("Sidewalk LabelView", request.identity, admin, labelId)))
+  }
+
+  /**
    * Loads the page that replays an audit task.
    */
   def task(taskId: Int) = UserAwareAction.async { implicit request =>

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -95,7 +95,6 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
    */
   def label(labelId: Int) = UserAwareAction.async { implicit request =>
     val admin: Boolean = isAdmin(request.identity)
-    // TODO check if the label ID exists.
     Future.successful(Ok(views.html.admin.label("Sidewalk LabelView", request.identity, admin, labelId)))
   }
 
@@ -380,7 +379,7 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
           val labelMetadata: LabelMetadata = LabelTable.getSingleLabelMetadata(labelId, userId)
           val labelMetadataJson: JsObject = LabelFormat.labelMetadataWithValidationToJsonAdmin(labelMetadata)
           Future.successful(Ok(labelMetadataJson))
-        case _ => Future.successful(Ok(Json.obj("error" -> "no such label")))
+        case _ => Future.failed(new NotFoundException("No label found with that ID"))
       }
     } else {
       Future.failed(new AuthenticationException("User is not an administrator"))
@@ -397,7 +396,7 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
         val labelMetadata: LabelMetadata = LabelTable.getSingleLabelMetadata(labelId, userId)
         val labelMetadataJson: JsObject = LabelFormat.labelMetadataWithValidationToJson(labelMetadata)
         Future.successful(Ok(labelMetadataJson))
-      case _ => Future.successful(Ok(Json.obj("error" -> "no such label")))
+      case _ => Future.failed(new NotFoundException("No label found with that ID"))
     }
   }
 

--- a/app/views/admin/label.scala.html
+++ b/app/views/admin/label.scala.html
@@ -1,0 +1,45 @@
+@import models.user.User
+@(title: String, user: Option[User], isAdmin: Boolean, labelId: Int)(implicit lang: Lang)
+
+@main(title) {
+    @navbar(user, Some(s"/admin/label/$labelId"))
+    <div class="container">
+        <h1>Label Search</h1>
+        <form onSubmit="return false;">
+            <div class="form-group">
+                <label for="form-control-input">Label ID</label>
+                <input type="text" class="form-control" id="form-control-input" placeholder="Enter Label ID here...">
+            </div>
+        </form>
+        <button type="submit" id="submit" class="btn btn-primary">Submit</button>
+        <div style="height: 237px;"></div> <!-- Just included to fill the page by default at usual zoom. -->
+    </div>
+
+    <script type="text/javascript" src='@routes.Assets.at("javascripts/lib/i18next-21.9.1.min.js")'></script>
+    <script type="text/javascript" src='@routes.Assets.at("javascripts/lib/i18nextXHRBackend.min.js")'></script>
+    <script type="text/javascript" src='@routes.Assets.at("javascripts/common/timestampLocalization.js")'></script>
+    <script type="text/javascript" src='@routes.Assets.at("javascripts/Admin/build/Admin.js")'></script>
+    <script type="text/javascript" src='@routes.Assets.at("javascripts/SVValidate/src/util/PanoProperties.js")'></script>
+    <script type="text/javascript" src='@routes.Assets.at("javascripts/common/Utilities.js")'></script>
+    <script type="text/javascript">
+        updateTimestamps("@lang.code");
+    </script>
+
+    <link href='@routes.Assets.at("stylesheets/admin.css")' rel="stylesheet"/>
+    <script>
+        $(document).ready(function () {
+            i18next.use(i18nextXHRBackend);
+            i18next.init({
+                backend: { loadPath: '/assets/locales/{{lng}}/{{ns}}.json' },
+                fallbackLng: 'en',
+                ns: ['common', 'labelmap'],
+                defaultNS: 'common',
+                lng: "@lang.code",
+                debug: false
+            }, function(err, t) {
+                let labelSearch = AdminLabelSearch(@isAdmin, 'LabelSearchPage');
+                labelSearch.adminGSVLabelView.showLabel(parseInt("@labelId"));
+            });
+        });
+    </script>
+}

--- a/conf/routes
+++ b/conf/routes
@@ -54,6 +54,7 @@ GET     /cityAPIDemoParams                                   @controllers.Config
 GET     /admin                                               @controllers.AdminController.index
 GET     /admin/user/:username                                @controllers.AdminController.userProfile(username: String)
 GET     /admin/task/:taskId                                  @controllers.AdminController.task(taskId: Int)
+GET     /admin/label/:labelId                                @controllers.AdminController.label(labelId: Int)
 
 GET     /adminapi/neighborhoodCompletionRate                 @controllers.AdminController.getNeighborhoodCompletionRate(regions: Option[String] ?= None)
 GET     /adminapi/userMissionCounts                          @controllers.AdminController.getAllUserCompletedMissionCounts

--- a/public/javascripts/Admin/src/Admin.GSVLabelView.js
+++ b/public/javascripts/Admin/src/Admin.GSVLabelView.js
@@ -385,8 +385,15 @@ function AdminGSVLabelView(admin, source) {
             'show': true
         });
         var adminLabelUrl = admin ? "/adminapi/label/id/" + labelId : "/label/id/" + labelId;
-        $.getJSON(adminLabelUrl, function (data) {
-            _handleData(data, admin);
+        $.ajax({
+            dataType: 'json',
+            url: adminLabelUrl,
+            success: function (data) {
+                _handleData(data);
+            },
+            error: function (xhr, textStatus, error) {
+                alert('Server error. Most likely a label with this ID did not exist.');
+            }
         });
     }
 

--- a/public/javascripts/Admin/src/Admin.LabelSearch.js
+++ b/public/javascripts/Admin/src/Admin.LabelSearch.js
@@ -1,16 +1,13 @@
-function AdminLabelSearch() {
-    var adminGSVLabelView;
-
-
+function AdminLabelSearch(isAdmin, source) {
     function _init() {
-        adminGSVLabelView = AdminGSVLabelView(true, "AdminLabelSearchTab");
+        self.adminGSVLabelView = AdminGSVLabelView(isAdmin, source);
     }
 
     // Prevents the page from refreshing when the enter key is pressed.
     $('#form-control-input').keypress(function(e) {
         if (e.keyCode === 13) {
             var labelId = $('#form-control-input').val();
-            adminGSVLabelView.showLabel(labelId);
+            self.adminGSVLabelView.showLabel(labelId);
             return false;
         }
     });
@@ -20,7 +17,7 @@ function AdminLabelSearch() {
      */
     $('#submit').on('click', function(e) {
         var labelId = $('#form-control-input').val();
-        adminGSVLabelView.showLabel(labelId);
+        self.adminGSVLabelView.showLabel(labelId);
     });
 
     _init();

--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -52,7 +52,7 @@ function Admin(_, $) {
     }
 
     function initializeAdminLabelSearch() {
-        self.adminLabelSearch = AdminLabelSearch();
+        self.adminLabelSearch = AdminLabelSearch(true, 'AdminLabelSearchTab');
     }
 
     function initializeLabelTable() {


### PR DESCRIPTION
Resolves #3469 

Adds a page that will show you a label if you include the label ID in the URL. I also included a search box so it's basically a copy of the Label Search tab on the Admin page that doesn't require the whole Admin page to use :) And it defaults to showing the label in the URL.

I used the url `/admin/label/<label-id>`.

Though it can be viewed even if you aren't an admin! There are just a few rows in the table that only show up for admins.

##### Example screenshot
![Screenshot from 2024-01-30 16-25-28](https://github.com/ProjectSidewalk/SidewalkWebpage/assets/6518824/b5a459ba-079f-4829-92d9-d7d53bfa1493)

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
