### PR TITLE
Upgrade postgres JDBC driver to 42.7.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ libraryDependencies ++= Seq(
   "com.typesafe.slick" %% "slick" % "2.1.0",
   "com.typesafe.play" %% "play-slick" % "0.8.1",
   "com.typesafe.play" %% "play-mailer" % "2.4.1",
-  "org.postgresql" % "postgresql" % "9.4.1212",
+  "org.postgresql" % "postgresql" % "42.7.1",
   "com.mohiva" %% "play-silhouette" % "2.0.2",
   "net.codingwell" %% "scala-guice" % "4.1.1",
   "com.typesafe.play.extras" %% "play-geojson" % "1.3.1",


### PR DESCRIPTION
Upgrade the PostgreSQL JDBC driver from 9.4.1212 to 42.7.1, the latest stable version.
Since the primary test and prod databases have been upgraded to PostgreSQL 16.1, this change brings the client driver in line, and is needed for full compatibility (e.g., support for scram-sha-256 password encryption).

- [x] I've written a descriptive PR title.