### PR TITLE
Fixes &shy; showing in German when hovering over label

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/label/Label.js
+++ b/public/javascripts/SVLabel/src/SVLabel/label/Label.js
@@ -251,8 +251,7 @@ function Label(params) {
             severityImage = new Image(),
             severitySVGElement,
             severityMessage = i18next.t('center-ui.context-menu.severity'),
-            msg = i18next.t('common:' + util.camelToKebab(properties.labelType)),
-            messages = msg.split('\n'),
+            labelTypeText = i18next.t('common:' + util.camelToKebab(properties.labelType)).replace('&shy;', ''),
             padding = { left: 12, right: 5, bottom: 0, top: 18 };
 
         if (hasSeverity) {
@@ -268,25 +267,23 @@ function Label(params) {
         ctx.font = '13px Open Sans';
         var height = HOVER_INFO_HEIGHT * labelRows;
 
-        for (var i = 0; i < messages.length; i += 1) {
-            // Width of the hover info is determined by the width of the longest row.
-            var firstRow = ctx.measureText(messages[i]).width;
-            var secondRow = -1;
+        // Width of the hover info is determined by the width of the longest row.
+        var firstRow = ctx.measureText(labelTypeText).width;
+        var secondRow = -1;
 
-            // Do additional adjustments on the width to make room for smiley icon.
-            if (hasSeverity) {
-                secondRow = ctx.measureText(severityMessage).width;
-                if (severitySVGElement !== undefined) {
-                    if (firstRow - secondRow > 0 && firstRow - secondRow < 15) {
-                        width += 15 - firstRow + secondRow;
-                    } else if (firstRow - secondRow < 0) {
-                        width += 20;
-                    }
+        // Do additional adjustments on the width to make room for smiley icon.
+        if (hasSeverity) {
+            secondRow = ctx.measureText(severityMessage).width;
+            if (severitySVGElement !== undefined) {
+                if (firstRow - secondRow > 0 && firstRow - secondRow < 15) {
+                    width += 15 - firstRow + secondRow;
+                } else if (firstRow - secondRow < 0) {
+                    width += 20;
                 }
             }
-
-            width += Math.max(firstRow, secondRow) + 5;
         }
+
+        width += Math.max(firstRow, secondRow) + 5;
 
         ctx.lineCap = 'square';
         ctx.lineWidth = 2;
@@ -310,7 +307,7 @@ function Label(params) {
 
         // Hover info text and image.
         ctx.fillStyle = '#ffffff';
-        ctx.fillText(messages[0], labelCoordinate.x + padding.left, labelCoordinate.y + padding.top);
+        ctx.fillText(labelTypeText, labelCoordinate.x + padding.left, labelCoordinate.y + padding.top);
         if (hasSeverity) {
             ctx.fillText(severityMessage, labelCoordinate.x + padding.left, labelCoordinate.y + HOVER_INFO_HEIGHT + padding.top);
             if (properties.severity !== null) {


### PR DESCRIPTION
Resolves #3508

Fixes the issue where &shy; was showing when hovering over most labels in German. Solved it by filtering that text out of translations when displaying in this location. It works differently here bc we're drawing the text instead of it being in HTML.

##### Before/After screenshots (if applicable)
Before
![Screenshot from 2024-02-27 15-52-55](https://github.com/ProjectSidewalk/SidewalkWebpage/assets/6518824/e3683a75-5834-4a96-8b13-2c64c9ec91c7)
![Screenshot from 2024-02-27 15-53-01](https://github.com/ProjectSidewalk/SidewalkWebpage/assets/6518824/20722896-09db-40d9-adcc-1b3a82ca9616)

After
![Screenshot from 2024-02-27 17-07-16](https://github.com/ProjectSidewalk/SidewalkWebpage/assets/6518824/c3300fce-e635-4b6b-b31e-910bf894903d)
![Screenshot from 2024-02-27 17-07-53](https://github.com/ProjectSidewalk/SidewalkWebpage/assets/6518824/b7d3c7ad-58e6-42c9-a595-89de6cf5b206)

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've included before/after screenshots above.
