### PR TITLE
Validate prioritizes label types based on need, other Validate fixes

### DIFF
--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -19,7 +19,7 @@ import models.attribute.{GlobalAttribute, GlobalAttributeTable}
 import models.audit.{AuditTaskInteractionTable, AuditTaskTable, AuditedStreetWithTimestamp, InteractionWithLabel}
 import models.daos.slick.DBTableDefinitions.UserTable
 import models.gsv.{GSVDataSlim, GSVDataTable}
-import models.label.LabelTable.LabelMetadata
+import models.label.LabelTable.{AdminValidationData, LabelMetadata}
 import models.label.{LabelLocationWithSeverity, LabelPointTable, LabelTable, LabelTypeTable, LabelValidationTable}
 import models.mission.MissionTable
 import models.region.RegionCompletionTable
@@ -368,7 +368,8 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
         case Some(labelPointObj) =>
           val userId: String = request.identity.get.userId.toString
           val labelMetadata: LabelMetadata = LabelTable.getSingleLabelMetadata(labelId, userId)
-          val labelMetadataJson: JsObject = LabelFormat.labelMetadataWithValidationToJsonAdmin(labelMetadata)
+          val adminData: AdminValidationData = LabelTable.getExtraAdminValidateData(List(labelId)).head
+          val labelMetadataJson: JsObject = LabelFormat.labelMetadataWithValidationToJsonAdmin(labelMetadata, adminData)
           Future.successful(Ok(labelMetadataJson))
         case _ => Future.failed(new NotFoundException("No label found with that ID"))
       }

--- a/app/controllers/ValidationController.scala
+++ b/app/controllers/ValidationController.scala
@@ -67,7 +67,7 @@ class ValidationController @Inject() (implicit val env: Environment[User, Sessio
         if (validationData._4.missionType != "validation" || user.role.getOrElse("") == "Turker" || !isMobile(request)) {
           Future.successful(Redirect("/explore"))
         } else {
-          Future.successful(Ok(views.html.mobileValidate("Sidewalk - Validate", Some(user), validationData._1, validationData._2, validationData._3, validationData._4.numComplete, validationData._5, validationData._6)))
+          Future.successful(Ok(views.html.mobileValidate("Sidewalk - Validate", Some(user), adminParams, validationData._1, validationData._2, validationData._3, validationData._4.numComplete, validationData._5, validationData._6)))
         }
       case None =>
         Future.successful(Redirect(s"/anonSignUp?url=/mobile"));

--- a/app/controllers/ValidationTaskController.scala
+++ b/app/controllers/ValidationTaskController.scala
@@ -7,7 +7,7 @@ import com.mohiva.play.silhouette.api.{Environment, Silhouette}
 import com.mohiva.play.silhouette.impl.authenticators.SessionAuthenticator
 import controllers.headers.ProvidesHeader
 import controllers.helper.ControllerUtils.{isAdmin, sendSciStarterContributions}
-import controllers.helper.ValidateHelper.AdminValidateParams
+import controllers.helper.ValidateHelper.{AdminValidateParams, getLabelTypeIdToValidate}
 import formats.json.ValidationTaskSubmissionFormats._
 import models.amt.AMTAssignmentTable
 import models.label._
@@ -79,8 +79,14 @@ class ValidationTaskController @Inject() (implicit val env: Environment[User, Se
     val returnValue: ValidationTaskPostReturnValue = data.missionProgress match {
       case Some(_) =>
         val missionProgress: ValidationMissionProgress = data.missionProgress.get
-        val currentMissionLabelTypeId: Int = missionProgress.labelTypeId
-        val nextMissionLabelTypeId: Option[Int] = getLabelTypeId(userOption, missionProgress, Some(currentMissionLabelTypeId), adminParams)
+        val nextMissionLabelTypeId: Option[Int] =
+          if (missionProgress.completed) {
+            val labelsToRetrieve: Int = MissionTable.validationMissionLabelsToRetrieve
+            getLabelTypeIdToValidate(userOption.get.userId, labelsToRetrieve, adminParams.labelTypeId)
+          } else {
+            None
+          }
+
         nextMissionLabelTypeId match {
           // Load new mission, generate label list for validation.
           case Some (nextMissionLabelTypeId) =>
@@ -218,34 +224,6 @@ class ValidationTaskController @Inject() (implicit val env: Environment[User, Se
         Future.successful(Ok(Json.obj("commend_id" -> commentId)))
       }
     )
-  }
-
-  /**
-    * Returns the label type id for the next validation mission.
-    *
-    * @param user               UserId of the current user.
-    * @param missionProgress    Progress of the current validation mission.
-    * @param currentLabelTypeId Label Type ID of the current mission
-    * @param adminParams        Parameters related to the admin version of the validate page.
-    */
-  def getLabelTypeId(user: Option[User], missionProgress: ValidationMissionProgress, currentLabelTypeId: Option[Int], adminParams: AdminValidateParams): Option[Int] = {
-    val userId: UUID = user.get.userId
-    if (missionProgress.completed) {
-      val labelsToRetrieve: Int = MissionTable.validationMissionLabelsToRetrieve
-      val possibleLabelTypeIds: List[Int] = LabelTable.retrievePossibleLabelTypeIds(userId, labelsToRetrieve, currentLabelTypeId)
-        .filter(labTypeId => adminParams.labelTypeId.isEmpty || adminParams.labelTypeId.get == labTypeId)
-      val hasNextMission: Boolean = possibleLabelTypeIds.nonEmpty
-
-      if (hasNextMission) {
-        // possibleLabTypeIds can contain [1, 2, 3, 4, 7, 9, 10]. Select 1, 2, 3, 4, 9, 10 if possible, o/w choose 7.
-        val possibleIds: List[Int] =
-          if (possibleLabelTypeIds.size > 1) possibleLabelTypeIds.filter(_ != 7)
-          else possibleLabelTypeIds
-        val index: Int = if (possibleIds.size > 1) scala.util.Random.nextInt(possibleIds.size - 1) else 0
-        return Some(possibleIds(index))
-      }
-    }
-    None
   }
 
   /**

--- a/app/controllers/helper/ValidateHelper.scala
+++ b/app/controllers/helper/ValidateHelper.scala
@@ -1,9 +1,58 @@
 package controllers.helper
 
+import models.label.{LabelTable, LabelTypeValidationsLeft}
+import models.label.LabelTable.getAvailableValidationLabelsByType
+import java.util.UUID
+import scala.util.Random
+
 object ValidateHelper {
   case class AdminValidateParams(adminVersion: Boolean, labelTypeId: Option[Int]=None, userIds: Option[List[String]]=None, neighborhoodIds: Option[List[Int]]=None) {
     require(labelTypeId.isEmpty || adminVersion, "labelTypeId can only be set if adminVersion is true")
     require(userIds.isEmpty || adminVersion, "userIds can only be set if adminVersion is true")
     require(neighborhoodIds.isEmpty || adminVersion, "neighborhoodIds can only be set if adminVersion is true")
+  }
+
+  /**
+   * Get the label_type_id to validate. Label types with fewer labels with validations have higher priority.
+   *
+   * We get the number of labels available to validate for each label type and the number of those that have no
+   * validations (or have agree=disagree). We then filter out label types with fewer than missionLength labels available
+   * to validate (the size of a Validate mission), and prioritize label types more labels w/ no validations.
+   *
+   * @param userId               User ID of the current user.
+   * @param missionLength        Number of labels for this mission.
+   * @param currentLabelTypeId   Label ID of the current mission
+   */
+  def getLabelTypeIdToValidate(userId: UUID, missionLength: Int, requiredLabelType: Option[Int]): Option[Int] = {
+    val availTypes: List[LabelTypeValidationsLeft] = getAvailableValidationLabelsByType(userId)
+      .filter(_.validationsAvailable >= missionLength)
+      .filter(x => requiredLabelType.isEmpty || x.labelTypeId == requiredLabelType.get)
+      .filter(x => LabelTable.valLabelTypeIds.contains(x.labelTypeId))
+
+    // Unless NoSidewalk (7) is the only available label type, remove it from the list of available types.
+    val typesFiltered: List[LabelTypeValidationsLeft] = availTypes.filter(_.labelTypeId != 7 || availTypes.length == 1)
+
+    if (typesFiltered.length < 2) {
+      typesFiltered.map(_.labelTypeId).headOption
+    } else {
+      // Each label type has at least a 3% chance of being selected. Remaining probability is divvied up proportionally
+      // based on the number of remaining labels requiring a validation for each label type.
+      val typeProbabilities: List[(Int, Double)] = if (typesFiltered.map(_.validationsNeeded).sum > 0) {
+        typesFiltered.map { t =>
+          (t.labelTypeId, 0.03 + (1 - typesFiltered.length * 0.03) * (t.validationsNeeded.toDouble / typesFiltered.map(_.validationsNeeded).sum))
+        }
+      } else {
+        typesFiltered.map(x => (x.labelTypeId, 1D / typesFiltered.length))
+      }
+      println(typeProbabilities)
+
+      // Get cumulative probabilities.
+      val cumulativeProbabilities: Seq[Double] = typeProbabilities.scanLeft(0.0) { case (acc, (_, prob)) => acc + prob }.tail
+
+      // Choose a label type proportionally based on the calculated probabilities.
+      val random = new Random()
+      val labelTypeId: Int = typeProbabilities(cumulativeProbabilities.indexWhere(_ > random.nextDouble()))._1
+      Some(labelTypeId)
+    }
   }
 }

--- a/app/formats/json/LabelFormat.scala
+++ b/app/formats/json/LabelFormat.scala
@@ -94,7 +94,7 @@ object LabelFormat {
     )
   }
 
-  def labelMetadataWithValidationToJsonAdmin(labelMetadata: LabelMetadata): JsObject = {
+  def labelMetadataWithValidationToJsonAdmin(labelMetadata: LabelMetadata, adminData: AdminValidationData): JsObject = {
     Json.obj(
       "label_id" -> labelMetadata.labelId,
       "gsv_panorama_id" -> labelMetadata.gsvPanoramaId,
@@ -120,7 +120,15 @@ object LabelFormat {
       "num_agree" -> labelMetadata.validations("agree"),
       "num_disagree" -> labelMetadata.validations("disagree"),
       "num_notsure" -> labelMetadata.validations("notsure"),
-      "tags" -> labelMetadata.tags
+      "tags" -> labelMetadata.tags,
+      // The part below is just lifted straight from Admin Validate without much care.
+      "admin_data" -> Json.obj(
+        "username" -> adminData.username,
+        "previous_validations" -> adminData.previousValidations.map(prevVal => Json.obj(
+          "username" -> prevVal._1,
+          "validation" -> LabelValidationTable.validationOptions.get(prevVal._2)
+        ))
+      )
     )
   }
 

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -44,6 +44,7 @@ case class ProjectSidewalkStats(launchDate: String, avgTimestampLast100Labels: S
                                 nRegistered: Int, nAnon: Int, nTurker: Int, nResearcher: Int, nLabels: Int,
                                 severityByLabelType: Map[String, LabelSeverityStats], nValidations: Int,
                                 accuracyByLabelType: Map[String, LabelAccuracy])
+case class LabelTypeValidationsLeft(labelTypeId: Int, validationsAvailable: Int, validationsNeeded: Int)
 
 class LabelTable(tag: slick.lifted.Tag) extends Table[Label](tag, "label") {
   def labelId = column[Int]("label_id", O.PrimaryKey, O.AutoInc)
@@ -507,11 +508,11 @@ object LabelTable {
   }
 
   /**
-    * Returns how many labels this user has available to validate for each label type.
+    * Returns how many labels this user has available to validate (& how many need validations) for each label type.
     *
-    * @return List[(label_type_id, label_count)]
+    * @return List[LabelTypeValidationsRemaining]
     */
-  def getAvailableValidationLabelsByType(userId: UUID): List[(Int, Int)] = db.withSession { implicit session =>
+  def getAvailableValidationLabelsByType(userId: UUID): List[LabelTypeValidationsLeft] = db.withSession { implicit session =>
     val userIdString: String = userId.toString
     val labelsValidatedByUser = labelValidations.filter(_.userId === userIdString)
 
@@ -522,7 +523,7 @@ object LabelTable {
       _ms <- missions if _ms.missionId === _lb.missionId
       _us <- UserStatTable.userStats if _ms.userId === _us.userId
       if _us.highQuality && _gd.expired === false && _ms.userId =!= userIdString
-    } yield (_lb.labelId, _lb.labelTypeId)
+    } yield (_lb.labelId, _lb.labelTypeId, _lb.correct)
 
     // Left join with the labels that the user has already validated, then filter those out.
     val filteredLabelsToValidate = for {
@@ -531,7 +532,11 @@ object LabelTable {
     } yield _lab
 
     // Group by the label_type_id and count.
-    filteredLabelsToValidate.groupBy(_._2).map{ case (labType, group) => (labType, group.length) }.list
+    // TODO when converting to Slick 3 we can use group.countDefined or something for the third column.
+    filteredLabelsToValidate
+      .groupBy(_._2).map{ case (labType, group) =>
+        (labType, group.length, group.map { x => Case.If(x._3.isEmpty).Then(1).Else(0) }.sum.getOrElse(0))
+      }.list.map(x => LabelTypeValidationsLeft(x._1, x._2, x._3))
   }
 
   /**
@@ -903,21 +908,6 @@ object LabelTable {
         label.streetEdgeId, label.regionId, label.correct, label.agreeCount, label.disagreeCount, label.notsureCount,
         label.userValidation, tags
       )
-  }
-
-  /**
-    * Retrieves a list of possible label types that the user can validate.
-    *
-    * We do this by getting the number of labels available to validate for each label type. We then filter out label
-    * types with less than 10 labels to validate (the size of a validation mission), and we filter for labels in our
-    * labelTypeIdList (the main label types that we ask users to validate).
-    *
-    * @param userId               User ID of the current user.
-    * @param count                Number of labels for this mission.
-    * @param currentLabelTypeId   Label ID of the current mission
-    */
-  def retrievePossibleLabelTypeIds(userId: UUID, count: Int, currentLabelTypeId: Option[Int]): List[Int] = {
-    getAvailableValidationLabelsByType(userId).filter(_._2 > count * 2).map(_._1).filter(valLabelTypeIds.contains(_))
   }
 
     /**

--- a/app/views/mobileValidate.scala.html
+++ b/app/views/mobileValidate.scala.html
@@ -4,7 +4,8 @@
 @import play.api.Play
 @import play.api.Play.current
 
-@(title: String, user: Option[User] = None, mission: Option[JsValue], labelList: Option[JsValue], progress: Option[JsValue], missionSetProgress: Int, hasNextMission: Boolean, completedValidations: Int)(implicit lang: Lang)
+@import controllers.helper.ValidateHelper.AdminValidateParams
+@(title: String, user: Option[User] = None, adminParams: AdminValidateParams, mission: Option[JsValue], labelList: Option[JsValue], progress: Option[JsValue], missionSetProgress: Int, hasNextMission: Boolean, completedValidations: Int)(implicit lang: Lang)
 
 @currentCity =@{Play.configuration.getString("city-id").get}
 
@@ -215,6 +216,10 @@
             param.canvasHeight = window.innerHeight;
             param.canvasWidth = window.innerWidth;
             param.language = "@lang.code";
+            param.adminVersion = @adminParams.adminVersion;
+            param.adminLabelTypeId = @Html(adminParams.labelTypeId.map(_.toString).getOrElse("null"));
+            param.adminUserIds = @Html(adminParams.userIds.map(_.mkString("['", "','", "']")).getOrElse("null"));
+            param.adminNeighborhoodIds = @Html(adminParams.neighborhoodIds.map(_.mkString("[", ",", "]")).getOrElse("null"));
             param.modalText = {
                 1: "@Messages("labeling.guide.curb.ramp.summary")",
                 2: "@Messages("labeling.guide.curb.ramp.summary")",

--- a/app/views/validation.scala.html
+++ b/app/views/validation.scala.html
@@ -232,8 +232,10 @@
                         For example:
                         <br><code>?users=User1,User2</code>
                     </p>
-                    <h2 id="">Labeler</h2>
+                    <h2>Labeler</h2>
                     <p id="curr-label-username"></p>
+                    <h2>Label ID</h2>
+                    <p id="curr-label-id"></p>
                     <h2 id="curr-label-prev-validations">Previous Validations</h2>
                 </div>
                 }

--- a/public/javascripts/Admin/src/Admin.GSVLabelView.js
+++ b/public/javascripts/Admin/src/Admin.GSVLabelView.js
@@ -112,8 +112,16 @@ function AdminGSVLabelView(admin, source) {
         if (self.admin) {
             modalText +=
                                     '<tr>' +
-                                        '<th>Task ID</th>' +
+                                        '<th>Username</th>' +
+                                        '<td id="admin-username"></td>' +
+                                    '</tr>' +
+                                    '<tr>' +
+                                        '<th>Audit Task ID</th>' +
                                         '<td id="task"></td>' +
+                                    '</tr>' +
+                                    '<tr>' +
+                                        '<th>Previous Validations</th>' +
+                                        '<td id="prev-validations"></td>' +
                                     '</tr>'
         }
         modalText +=
@@ -184,7 +192,9 @@ function AdminGSVLabelView(admin, source) {
         self.modalDescription = self.modal.find("#label-description");
         self.modalValidations = self.modal.find("#label-validations");
         self.modalImageDate = self.modal.find("#image-capture-date");
+        self.modalUsername = self.modal.find("#admin-username");
         self.modalTask = self.modal.find("#task");
+        self.modalPrevValidations = self.modal.find("#prev-validations");
         self.modalPanoId = self.modal.find('#pano-id');
         self.modalGsvLink = self.modal.find('#view-in-gsv');
         self.modalLat = self.modal.find('#lat');
@@ -438,9 +448,22 @@ function AdminGSVLabelView(admin, source) {
         self.modalStreetId.html(labelMetadata['street_edge_id']);
         self.modalRegionId.html(labelMetadata['region_id']);
         if (self.admin) {
-            self.modalTask.html("<a href='/admin/task/"+labelMetadata['audit_task_id']+"'>"+
-                labelMetadata['audit_task_id']+"</a> by <a href='/admin/user/" + encodeURI(labelMetadata['username']) + "'>" +
-                labelMetadata['username'] + "</a>");
+            self.modalUsername.html(`<a href='/admin/user/${encodeURI(labelMetadata['username'])}'>${labelMetadata['username']}</a>`);
+            self.modalTask.html(`<a href='/admin/task/${labelMetadata['audit_task_id']}'>${labelMetadata['audit_task_id']}</a>`);
+            var prevVals = labelMetadata['admin_data']['previous_validations'];
+            if (prevVals.length === 0) {
+                self.modalPrevValidations.html("None");
+            } else {
+                var prevValText = "";
+                for (var i = 0; i < prevVals.length; i++) {
+                    var prevVal = prevVals[i];
+                    prevValText += `<a href='/admin/user/${encodeURI(prevVal['username'])}'>${prevVal['username']}</a>: ${i18next.t('common:' + camelToKebab(prevVal['validation']))}`;
+                    if (i !== prevVals.length - 1) {
+                        prevValText += "<br>";
+                    }
+                }
+                self.modalPrevValidations.html(prevValText);
+            }
         }
         // If the signed in user has already validated this label, make the button look like it has been clicked.
         if (labelMetadata['user_validation']) _resetButtonColors(labelMetadata['user_validation']);

--- a/public/javascripts/SVValidate/mobile/mobileValidate.js
+++ b/public/javascripts/SVValidate/mobile/mobileValidate.js
@@ -32,10 +32,16 @@ $(document).ready(function() {
     let loadedScreenLandscape = false;
 
     if (orientation != 0) {
-        svv.modalLandscape.show();
-        loadedScreenLandscape = true;
+        // If we are in landscape, wait for the modal to load and then show it.
+        const landscapeInterval = setInterval(() => {
+            if (svv.modalLandscape) {
+                svv.modalLandscape.show();
+                loadedScreenLandscape = true;
+                clearInterval(landscapeInterval);
+            }
+        }, 20); // 20 ms.
     } else {
-        svv.modalLandscape.hide();
+        if (svv.modalLandscape) svv.modalLandscape.hide();
     }
 
     $(window).on('orientationchange', function (event) {

--- a/public/javascripts/SVValidate/src/Main.js
+++ b/public/javascripts/SVValidate/src/Main.js
@@ -126,6 +126,7 @@ function Main (param) {
 
         svv.ui.status.admin = {};
         svv.ui.status.admin.username = $('#curr-label-username');
+        svv.ui.status.admin.labelId = $('#curr-label-id');
         svv.ui.status.admin.prevValidations = $('#curr-label-prev-validations');
 
         svv.ui.dateHolder = $("#svv-panorama-date-holder");

--- a/public/javascripts/SVValidate/src/status/StatusField.js
+++ b/public/javascripts/SVValidate/src/status/StatusField.js
@@ -109,6 +109,7 @@ function StatusField(param) {
             // Update the status area with extra info if on Admin Validate.
             const user = svv.panorama.getCurrentLabel().getAdminProperty('username');
             statusUI.admin.username.html(`<a href="/admin/user/${user}" target="_blank">${user}</a>`);
+            statusUI.admin.labelId.html(svv.panorama.getCurrentLabel().getAuditProperty('labelId'));
 
             // Remove prior set of previous validations and add the new set.
             document.querySelectorAll('.prev-val').forEach(e => e.remove());


### PR DESCRIPTION
Resolves #2530
Fixes #3513 

This PR ends up doing a few related things since they came up while I was already working on this...
1. We now prioritize which label type to choose for a Validate mission based on need. Each of our 6 primary label types have at least a 3% chance of being selected (if there are any such labels left for the user to validate). The remaining probability of being chosen is split up proportionally based no the number of labels remaining of that label type that either has no validations or needs a tie breaking vote. As before, we only assign No Sidewalk missions if there is nothing available for the other label types.
    As an example, I tested on my Seattle db dump, and the probabilities for the various label types were: 48% Curb Ramp, 15% Missing Curb Ramp, 9% Obstacle, 21.5% Surface Problem, 3.5% Crosswalk, and 3% Pedestrian Signal. We'll be validating a lot of curb ramps for awhile here while we catch up!
2. I tweaked the label prioritization algorithm for choosing labels to validate as well, and you could even consider it fixing bugs in the algorithm. Both of these changes increased the frequency that I saw labels that actually needed validations in local testing:
    1. We have been giving a label higher priority if the user who labeled it has fewer than 50 labels validated... But I didn't add the condition that the label in question still required a validation itself! I've added that condition so we don't repeatedly validate a label just bc a user doesn't have 50 labels to validate.
    2. We were adding a weight that was proportional to the number of validations: `100 / (1 + validation_count)`. I've adjusted this to consider how far we are from consensus instead of how far we are from having no validations: `100 / (1 + abs(agree_count - disagree_count))`.
3. Fixed mobile validate not showing new mission after the first (#3513).
4. I added label ID to the Admin Validate page.
5. I added the Admin Validate info to the admin versions of the LabelMap popup. Visible on Admin page "Map" tab, admin user dashboard, etc... anywhere that shows the Label Map popup _except_ for LabelMap itself; I want to keep LabelMap looking clean for demos and such.
6. Fixes a bug where our mobile page's warning for being in landscape mode wasn't showing up on initial page load.

##### Before/After screenshots (if applicable)
Here are screenshots of the changes to Admin Validate. The others don't really have screenshots to show.
![Screenshot from 2024-03-11 12-29-39](https://github.com/ProjectSidewalk/SidewalkWebpage/assets/6518824/7da1da0f-8089-44dc-b12f-3962a6a45d7d)
![Screenshot from 2024-03-11 12-28-40](https://github.com/ProjectSidewalk/SidewalkWebpage/assets/6518824/bb26b9b1-5ca0-49d9-90bc-aac4091d465e)


##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
