### PR TITLE
Crops now saved as .png instead of .jpg.png

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/canvas/Canvas.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/Canvas.js
@@ -368,7 +368,7 @@ function Canvas(ribbon) {
         const labelTempID = label.getProperty('temporaryLabelId');
         const labelType = label.getProperty('labelType');
         const newCrop = {
-            'name': `crop_temp_${svl.cityId}_${userId}_${labelTempID}_${labelType}.jpg`,
+            'name': `crop_temp_${svl.cityId}_${userId}_${labelTempID}_${labelType}`,
         };
 
         // Save a high-res version of the image.


### PR DESCRIPTION
Fixes #3506 

Fixes naming of our crops from .jpg.png to .png. They were being successfully being saved as PNG files, just not without the correct filename. Once this is up on servers, we'll just need to run this bash command to fix all existing files:
```
for f in *.jpg.png; do
    mv "$f" "${f%.jpg.png}.png"
done
```

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
