### PR TITLE
Adds city subdirectories for crops

### DIFF
--- a/app/controllers/ImageController.scala
+++ b/app/controllers/ImageController.scala
@@ -22,7 +22,7 @@ class ImageController @Inject() (implicit val env: Environment[User, SessionAuth
   extends Silhouette[User, SessionAuthenticator] with ProvidesHeader {
 
   // This is the name of the directory in which all the crops are saved.
-  val CROPS_DIR_NAME = Play.configuration.getString("cropped.image.directory").get
+  val CROPS_DIR_NAME = Play.configuration.getString("cropped.image.directory").get + File.separator + Play.configuration.getString("city-id").get
 
   // 2x the actual size of the GSV window as retina screen can give us 2x the pixel density.
   val CROP_WIDTH = 1440
@@ -62,7 +62,7 @@ class ImageController @Inject() (implicit val env: Environment[User, SessionAuth
   def initializeDirIfNeeded(): Unit = {
     val file = new File(CROPS_DIR_NAME)
     if (!file.exists()) {
-      val result = file.mkdir()
+      val result = file.mkdirs()
       if (!result) {
         Logger.error("Error creating directory: " + CROPS_DIR_NAME)
       }

--- a/app/controllers/ImageController.scala
+++ b/app/controllers/ImageController.scala
@@ -21,7 +21,7 @@ import javax.imageio.ImageIO
 class ImageController @Inject() (implicit val env: Environment[User, SessionAuthenticator])
   extends Silhouette[User, SessionAuthenticator] with ProvidesHeader {
 
-  // This is the name of the directory in which all the crops are saved.
+  // This is the name of the directory in which all the crops are saved. Subdirectory by city ID.
   val CROPS_DIR_NAME = Play.configuration.getString("cropped.image.directory").get + File.separator + Play.configuration.getString("city-id").get
 
   // 2x the actual size of the GSV window as retina screen can give us 2x the pixel density.
@@ -58,7 +58,7 @@ class ImageController @Inject() (implicit val env: Environment[User, SessionAuth
     }
   }
 
-  // Creates the base directory for the crops if it doesn't exist.
+  // Creates the base directory for the crops if it doesn't exist. Uses subdirectories /<city-id>/<label-type>.
   def initializeDirIfNeeded(labelType: String): Unit = {
     val file = new File(CROPS_DIR_NAME + File.separator + labelType)
     if (!file.exists()) {

--- a/app/controllers/ImageController.scala
+++ b/app/controllers/ImageController.scala
@@ -59,8 +59,8 @@ class ImageController @Inject() (implicit val env: Environment[User, SessionAuth
   }
 
   // Creates the base directory for the crops if it doesn't exist.
-  def initializeDirIfNeeded(): Unit = {
-    val file = new File(CROPS_DIR_NAME)
+  def initializeDirIfNeeded(labelType: String): Unit = {
+    val file = new File(CROPS_DIR_NAME + File.separator + labelType)
     if (!file.exists()) {
       val result = file.mkdirs()
       if (!result) {
@@ -75,9 +75,10 @@ class ImageController @Inject() (implicit val env: Environment[User, SessionAuth
 
     jsonBody
       .map { json =>
-        initializeDirIfNeeded()
+        val labelType: String = (json \ "label_type").as[String]
+        initializeDirIfNeeded(labelType)
         val b64String: String = (json \ "b64").as[String].split(",")(1)
-        val filename: String = CROPS_DIR_NAME + File.separator + (json \ "name").as[String] + ".png"
+        val filename: String = CROPS_DIR_NAME + File.separator + labelType + File.separator + (json \ "name").as[String] + ".png"
         try {
           writeImageFile(filename, b64String)
           Ok("Got: " + (json \ "name").as[String])

--- a/public/javascripts/SVLabel/src/SVLabel/canvas/Canvas.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/Canvas.js
@@ -368,7 +368,8 @@ function Canvas(ribbon) {
         const labelTempID = label.getProperty('temporaryLabelId');
         const labelType = label.getProperty('labelType');
         const newCrop = {
-            'name': `crop_temp_${userId}_${labelTempID}_${labelType}`,
+            'name': `crop_temp_${userId}_${labelTempID}`,
+            'label_type': labelType
         };
 
         // Save a high-res version of the image.

--- a/public/javascripts/SVLabel/src/SVLabel/canvas/Canvas.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/Canvas.js
@@ -368,7 +368,7 @@ function Canvas(ribbon) {
         const labelTempID = label.getProperty('temporaryLabelId');
         const labelType = label.getProperty('labelType');
         const newCrop = {
-            'name': `crop_temp_${svl.cityId}_${userId}_${labelTempID}_${labelType}`,
+            'name': `crop_temp_${userId}_${labelTempID}_${labelType}`,
         };
 
         // Save a high-res version of the image.

--- a/public/javascripts/SVLabel/src/SVLabel/canvas/Canvas.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/Canvas.js
@@ -360,10 +360,9 @@ function Canvas(ribbon) {
             return;
         }
 
-        // Save a screenshot of the GSV named crop_temp_<cityId>_<userId>_<temporaryLabelId>_<labelType>.jpg. 'temp'
-        // denotes that this crop should be renamed with the actual label id (which can be derived using userID and
-        // labelTempId). labelType is included for convenience in case we want to filter crops by label type manually
-        // without having to rely on the DB.
+        // Save a screenshot of the GSV named crop_temp_<userId>_<temporaryLabelId>.png. The 'temp' denotes that this
+        // crop should be renamed with the actual label id (which can be derived using userID and labelTempId). The
+        // crops are stored in subdirectories /<city-id>/<label-type> for ease of viewing/filtering.
         const userId = svl.user.getProperty('userId');
         const labelTempID = label.getProperty('temporaryLabelId');
         const labelType = label.getProperty('labelType');


### PR DESCRIPTION
Resolves #3502 

Crops will now be split into subdirectories based on their city and label type. Instead of
`crop_temp_<city-id>_<user-id>_<temp-label-id>_<label-type>.png`, they will be stored as
`<city-id>/<label-type>/crop_temp_<user-id>_<temp-label-id>.png`.

Once this is on the servers, I will just need to run the following script to update all past data:
```
#!/bin/bash

# Prevents errors when no files are found.
shopt -s nullglob

# Loop over all cities.
for city in seattle-wa columbus-oh cdmx spgg pittsburgh-pa newberg-or chicago-il amsterdam la-piedad oradell-nj validation-study zurich taipei new-taipei-tw keelung-tw auckland cuenca crowdstudy burnaby teaneck-nj walla-walla-wa; do
    # Loop over all label types.
    for label_type in CurbRamp NoCurbRamp Obstacle SurfaceProblem NoSidewalk Crosswalk Signal Occlusion Other; do
        # Create the necessary dir.
        mkdir -p "${city}/${label_type}"

        # Loop over all files matching the pattern if any exist.
        for file in crop_temp_${city}_*_${label_type}.png; do
            # Extract the piece of the filename that we keep.
            user_and_temp_id=$(basename "$file" | sed "s/crop_temp_${city}_\(.*\)_${label_type}\.png/\1/")

            # Construct the destination path.
            dest_path="${city}/${label_type}/crop_temp_${user_and_temp_id}.png"

            # Move the file.
            mv "$file" "$dest_path"
        done
    done
done
```

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
