### PR TITLE
Renames "pooled water" tag to "debris / pooled water"

### DIFF
--- a/conf/evolutions/default/223.sql
+++ b/conf/evolutions/default/223.sql
@@ -1,0 +1,21 @@
+# --- !Ups
+UPDATE tag SET tag = 'debris / pooled water' WHERE tag = 'pooled water';
+
+UPDATE label SET tags = ARRAY_REPLACE(tags, 'pooled water', 'debris / pooled water');
+
+UPDATE label_history SET tags = ARRAY_REPLACE(tags, 'pooled water', 'debris / pooled water');
+
+UPDATE label_validation
+SET old_tags = ARRAY_REPLACE(old_tags, 'pooled water', 'debris / pooled water'),
+    new_tags = ARRAY_REPLACE(new_tags, 'pooled water', 'debris / pooled water');
+
+# --- !Downs
+UPDATE label_validation
+SET old_tags = ARRAY_REPLACE(old_tags, 'debris / pooled water', 'pooled water'),
+    new_tags = ARRAY_REPLACE(new_tags, 'debris / pooled water', 'pooled water');
+
+UPDATE label_history SET tags = ARRAY_REPLACE(tags, 'debris / pooled water', 'pooled water');
+
+UPDATE label SET tags = ARRAY_REPLACE(tags, 'debris / pooled water', 'pooled water');
+
+UPDATE tag SET tag = 'pooled water' WHERE tag = 'debris / pooled water';

--- a/public/javascripts/common/UtilitiesSidewalk.js
+++ b/public/javascripts/common/UtilitiesSidewalk.js
@@ -105,9 +105,9 @@ function UtilitiesMisc (JSON) {
                         keyChar: 'R',
                         text: i18next.t('center-ui.context-menu.tag.surface-problem')
                     },
-                    'pooled water': {
+                    'debris / pooled water': {
                         keyChar: 'D',
-                        text: i18next.t('center-ui.context-menu.tag.pooled-water')
+                        text: i18next.t('center-ui.context-menu.tag.debris-pooled-water')
                     },
                     'parallel lines': {
                         keyChar: 'J',

--- a/public/locales/de/audit.json
+++ b/public/locales/de/audit.json
@@ -124,7 +124,7 @@
                 "not-enough-landing-space": "nicht genug P<tag-underline>l</tag-underline>atz",
                 "not-level-with-street": "nicht auf dem selben Ni<tag-underline>v</tag-underline>eau wie Strasse",
                 "surface-problem": "Obe<tag-underline>r</tag-underline>flächenproblem",
-                "pooled-water": "Wasserpfütze (<tag-underline>d</tag-underline>)",
+                "debris-pooled-water": "Schmutz/Wasserpfütze (<tag-underline>d</tag-underline>)",
                 "parallel-lines": "parallele Linien (<tag-underline>j</tag-underline>)",
                 "alternate-route-present": "<tag-underline>a</tag-underline>lternative Route vorhanden",
                 "no-alternate-route": "keine a<tag-underline>l</tag-underline>ternative Route vorhanden",

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -64,7 +64,7 @@
         "not enough landing space": "nicht genug Platz",
         "not level with street": "nicht auf dem selben Niveau wie Strasse",
         "surface problem": "Oberflächenproblem",
-        "pooled water": "Wasserpfütze",
+        "debris / pooled water": "Schmutz/Wasserpfütze",
         "parallel lines": "parallele Linien",
         "alternate route present": "alternative Route vorhanden",
         "no alternate route": "keine alternative Route vorhanden",

--- a/public/locales/en/audit.json
+++ b/public/locales/en/audit.json
@@ -124,7 +124,7 @@
                 "not-enough-landing-space": "not enough <tag-underline>l</tag-underline>anding space",
                 "not-level-with-street": "not le<tag-underline>v</tag-underline>el with street",
                 "surface-problem": "su<tag-underline>r</tag-underline>face problem",
-                "pooled-water": "poole<tag-underline>d</tag-underline> water",
+                "debris-pooled-water": "<tag-underline>d</tag-underline>ebris / pooled water",
                 "parallel-lines": "parallel lines (<tag-underline>j</tag-underline>)",
                 "alternate-route-present": "<tag-underline>a</tag-underline>lternate route present",
                 "no-alternate-route": "no a<tag-underline>l</tag-underline>ternate route",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -64,7 +64,7 @@
         "not enough landing space": "not enough landing space",
         "not level with street": "not level with street",
         "surface problem": "surface problem",
-        "pooled water": "pooled water",
+        "debris / pooled water": "debris / pooled water",
         "parallel lines": "parallel lines",
         "alternate route present": "alternate route present",
         "no alternate route": "no alternate route",

--- a/public/locales/es/audit.json
+++ b/public/locales/es/audit.json
@@ -124,7 +124,7 @@
                 "not-enough-landing-space": "área de aproximación insuficiente (<tag-underline>l</tag-underline>)",
                 "not-level-with-street": "con desni<tag-underline>v</tag-underline>el",
                 "surface-problem": "problema en supe<tag-underline>r</tag-underline>ficie",
-                "pooled-water": "encharca<tag-underline>d</tag-underline>a",
+                "debris-pooled-water": "escombros/encharca<tag-underline>d</tag-underline>a",
                 "parallel-lines": "lineas paralelas (<tag-underline>j</tag-underline>)",
                 "alternate-route-present": "hay una ruta <tag-underline>a</tag-underline>lternativa segura para cruzar",
                 "no-alternate-route": "no hay una ruta a<tag-underline>l</tag-underline>ternativa para cruzar",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -64,7 +64,7 @@
         "not enough landing space": "área de aproximación insuficiente",
         "not level with street": "con desnivel",
         "surface-problem": "problema en superficie",
-        "pooled water": "encharcada",
+        "debris / pooled water": "escombros/encharcada",
         "parallel lines": "lineas paralelas",
         "alternate route present": "hay una ruta alternativa segura para cruzar",
         "no alternate route": "no hay una ruta alternativa para cruzar",

--- a/public/locales/nl/audit.json
+++ b/public/locales/nl/audit.json
@@ -124,7 +124,7 @@
                 "not-enough-landing-space": "bovenaan niet genoeg ruimte (<tag-underline>l</tag-underline>)",
                 "not-level-with-street": "niet zelfde ni<tag-underline>v</tag-underline>eau met straat",
                 "surface-problem": "oppervlakte p<tag-underline>r</tag-underline>obleem",
-                "pooled-water": "gepool<tag-underline>d</tag-underline> water",
+                "debris-pooled-water": "brokstukken / gepool<tag-underline>d</tag-underline> water",
                 "parallel-lines": "parallelle li<tag-underline>j</tag-underline>nen",
                 "alternate-route-present": "<tag-underline>a</tag-underline>lternatieve route aanwezig",
                 "no-alternate-route": "geen a<tag-underline>l</tag-underline>ternatieve route",

--- a/public/locales/nl/common.json
+++ b/public/locales/nl/common.json
@@ -63,7 +63,7 @@
         "not enough landing space": "bovenaan niet genoeg ruimte",
         "not level with street": "niet zelfde niveau met straat",
         "surface-problem": "oppervlakte probleem",
-        "pooled water": "gepoold water",
+        "debris / pooled water": "brokstukken / gepoold water",
         "parallel lines": "parallelle lijnen",
         "alternate route present": "alternatieve route aanwezig",
         "no alternate route": "geen alternatieve route",

--- a/public/locales/zh-TW/audit.json
+++ b/public/locales/zh-TW/audit.json
@@ -124,7 +124,7 @@
                 "not-enough-landing-space": "坡頂平臺空間不足(<tag-underline>l</tag-underline>)",
                 "not-level-with-street": "與街道不齊平(<tag-underline>v</tag-underline>)",
                 "surface-problem": "鋪面問題(<tag-underline>r</tag-underline>)",
-                "pooled-water": "積水(<tag-underline>d</tag-underline>)",
+                "debris-pooled-water": "碎片/積水(<tag-underline>d</tag-underline>)",
                 "parallel-lines": "平行線(<tag-underline>j</tag-underline>)",
                 "alternate-route-present": "有替代路徑(<tag-underline>a</tag-underline>)",
                 "no-alternate-route": "無替代路徑(<tag-underline>l</tag-underline>)",

--- a/public/locales/zh-TW/common.json
+++ b/public/locales/zh-TW/common.json
@@ -64,7 +64,7 @@
         "not enough landing space": "坡頂平臺上空間不足",
         "not level with street": "與街道路面不平齊",
         "surface problem": "鋪面問題",
-        "pooled water": "積水",
+        "debris / pooled water": "碎片/積水",
         "parallel lines": "平行線",
         "alternate route present": "有替代路徑",
         "no alternate route": "無替代路徑",


### PR DESCRIPTION
Resolves #3518 

Renames "pooled water" tag to "debris / pooled water". Made sure to update in all languages.

##### Before/After screenshots (if applicable)
Before
![Screenshot from 2024-04-15 15-27-28](https://github.com/ProjectSidewalk/SidewalkWebpage/assets/6518824/81864164-cd3c-4ff2-8d7d-e601715ef794)

After
![Screenshot from 2024-04-15 15-27-06](https://github.com/ProjectSidewalk/SidewalkWebpage/assets/6518824/fe442a52-dd0a-4742-b401-994e8f75f769)

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've included before/after screenshots above.
- [x] I've asked for and included translations for any user facing text that was added or modified.
