### PR TITLE
Including Anon Users With Validations in Admin Dashboard

### DIFF
--- a/app/models/daos/slick/UserDAOSlick.scala
+++ b/app/models/daos/slick/UserDAOSlick.scala
@@ -156,7 +156,7 @@ object UserDAOSlick {
    * Get all users, excluding anonymous users who haven't placed any labels or have done validations 
    * (so admin user table isn't too big).
    */
-  def usersMinusAnonUsersWithNoLabels: Query[UserTable, DBUser, Seq] = { 
+  def usersMinusAnonUsersWithNoLabelsAndNoValidations: Query[UserTable, DBUser, Seq] = { 
     val anonUsersWithLabels = (for {
       _user <- userTable
       _userRole <- userRoleTable if _user.userId === _userRole.userId
@@ -515,7 +515,7 @@ object UserDAOSlick {
       UserStatTable.userStats.map { x => (x.userId, x.highQuality) }.list.toMap
 
     // Now left join them all together and put into UserStatsForAdminPage objects.
-    usersMinusAnonUsersWithNoLabels.list.map { u =>
+    usersMinusAnonUsersWithNoLabelsAndNoValidations.list.map { u =>
       val ownValidatedCounts = validatedCounts.getOrElse(u.userId, ("", 0, 0, 0, 0))
       val ownValidatedTotal = ownValidatedCounts._2
       val ownValidatedAgreed = ownValidatedCounts._3

--- a/app/models/daos/slick/UserDAOSlick.scala
+++ b/app/models/daos/slick/UserDAOSlick.scala
@@ -13,6 +13,7 @@ import models.user.OrganizationTable.organizations
 import models.user.UserOrgTable.userOrgs
 import models.user.{RoleTable, UserStatTable, WebpageActivityTable}
 import models.user.{User, UserRoleTable}
+import models.label.{LabelValidation, LabelValidationTable}
 import play.api.db.slick._
 import play.api.db.slick.Config.driver.simple._
 import play.api.Play.current
@@ -152,14 +153,23 @@ object UserDAOSlick {
   val auditTaskTable = TableQuery[AuditTaskTable]
 
   /**
-   * Get all users, excluding anonymous users who haven't placed any labels (so admin user table isn't too big).
+   * Get all users, excluding anonymous users who haven't placed any labels or have done validations 
+   * (so admin user table isn't too big).
    */
-  def usersMinusAnonUsersWithNoLabels: Query[UserTable, DBUser, Seq] = {
-    val anonUsers = (for {
+  def usersMinusAnonUsersWithNoLabels: Query[UserTable, DBUser, Seq] = { 
+    val anonUsersWithLabels = (for {
       _user <- userTable
       _userRole <- userRoleTable if _user.userId === _userRole.userId
       _role <- roleTable if _userRole.roleId === _role.roleId
       _label <- LabelTable.labelsWithTutorialAndExcludedUsers if _user.userId === _label.userId
+      if _role.role === "Anonymous"
+    } yield _user).groupBy(x => x).map(_._1)
+
+    val anonUsersWithValidations = (for {
+      _user <- userTable
+      _userRole <- userRoleTable if _user.userId === _userRole.userId
+      _role <- roleTable if _userRole.roleId === _role.roleId
+      _labelValidation <- LabelValidationTable.validationLabels if _user.userId === _labelValidation.userId
       if _role.role === "Anonymous"
     } yield _user).groupBy(x => x).map(_._1)
 
@@ -170,7 +180,7 @@ object UserDAOSlick {
       if _role.role =!= "Anonymous"
     } yield _user
 
-    anonUsers ++ otherUsers
+    anonUsersWithLabels.union(anonUsersWithValidations) ++ otherUsers
   }
 
   /**


### PR DESCRIPTION
Resolves #3419 

In this PR, I edited the UserDAOSlick file in the backend to send anonymous users that have validated data to the admin dashboard frontend, which it did not do previously (only anon users that had done labels and non-anonymous users were sent). This took adding one subquery to the usersMinusAnonUsersWithNoLabels method to include those new anonymous users. 

##### Testing instructions
1. Make a new user
2. Go into the database and change their role to id = 6 (anon)
3. log into an admin user and go to the admin dashboard. Here you can check that that new user you just made does NOT come up.
4. log back into the new user you made & do one validation mission
5. log back into the admin user again and go to the admin dashboard. This time, the new user we just made should be visible in the dashboard! 

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->