### PR TITLE
Removed redudant call and dom modal clean up

### DIFF
--- a/app/views/labelMap.scala.html
+++ b/app/views/labelMap.scala.html
@@ -238,17 +238,5 @@
             });
         });
     }
-
-    // Fully destroy label modal when it's closed to prevent weird behavior when opening another.
-    $(window).on('click', function(e) {
-        var modal = $("#labelModal");
-        if (modal != null && !(modal.hasClass('in'))) {
-            modal.modal('hide');
-            setTimeout(function() {
-                modal.remove();
-                $('.modal-backdrop').remove();
-            }, 200)
-        }
-    });
     </script>
 }

--- a/public/javascripts/Admin/src/Admin.GSVLabelView.js
+++ b/public/javascripts/Admin/src/Admin.GSVLabelView.js
@@ -393,7 +393,6 @@ function AdminGSVLabelView(admin, source) {
     }
 
     function showLabel(labelId) {
-        _resetModal();
 
         self.modal.modal({
             'show': true


### PR DESCRIPTION
Resolves #3512 

The problem was opening a modal on the label map reinitialized the panorama every time creating too many web gl elements. I also have to remove the code to remove the modal because I think it is interfering with bootstraps garbage collection/reusing modals. 

##### Before/After screenshots (if applicable)

##### Testing instructions
1. I tested pretty thoroughly, for each label type, validation type, and other data imported to make sure that it is the panorama that is creating too many webgl elements. When I only remove the reset call the problem still occurs. 

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [ ] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x ] I've added/updated comments for large or confusing blocks of code.
- [ ] I've included before/after screenshots above.
- [ ] I've asked for and included translations for any user facing text that was added or modified.
- [ x] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure the documentation on [this wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Descriptions-of-Logged-Events) is up to date for the logs you added/updated.
- [ ] I've tested on mobile (only needed for validation page).
