### PR TITLE
Adds small version of audit_task_interaction table for faster select queries

### DIFF
--- a/app/controllers/TaskController.scala
+++ b/app/controllers/TaskController.scala
@@ -10,7 +10,6 @@ import com.vividsolutions.jts.geom._
 import controllers.headers.ProvidesHeader
 import controllers.helper.ControllerUtils.sendSciStarterContributions
 import formats.json.TaskSubmissionFormats._
-import formats.json.PanoHistoryFormats._
 import models.amt.AMTAssignmentTable
 import models.audit.AuditTaskInteractionTable.secondsAudited
 import models.audit._

--- a/app/formats/json/TaskFormats.scala
+++ b/app/formats/json/TaskFormats.scala
@@ -36,7 +36,7 @@ object TaskFormats {
     )(unlift(AuditTask.unapply _))
 
   implicit val auditTaskInteractionWrites: Writes[AuditTaskInteraction] = (
-    (__ \ "audit_task_interaction_id").write[Int] and
+    (__ \ "audit_task_interaction_id").write[Long] and
       (__ \ "audit_task_id").write[Int] and
       (__ \ "mission_id").write[Int] and
       (__ \ "action").write[String] and

--- a/app/models/audit/AuditTaskInteractionTable.scala
+++ b/app/models/audit/AuditTaskInteractionTable.scala
@@ -10,7 +10,7 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.slick.jdbc.{GetResult, StaticQuery => Q}
 import scala.slick.lifted.ForeignKeyQuery
 
-case class AuditTaskInteraction(auditTaskInteractionId: Int,
+case class AuditTaskInteraction(auditTaskInteractionId: Long,
                                 auditTaskId: Int,
                                 missionId: Int,
                                 action: String,
@@ -24,7 +24,7 @@ case class AuditTaskInteraction(auditTaskInteractionId: Int,
                                 temporaryLabelId: Option[Int],
                                 timestamp: java.sql.Timestamp)
 
-case class InteractionWithLabel(auditTaskInteractionId: Int, auditTaskId: Int, missionId: Int, action: String,
+case class InteractionWithLabel(auditTaskInteractionId: Long, auditTaskId: Int, missionId: Int, action: String,
                                 gsvPanoramaId: Option[String], lat: Option[Float], lng: Option[Float],
                                 heading: Option[Float], pitch: Option[Float], zoom: Option[Int],
                                 note: Option[String], timestamp: java.sql.Timestamp, labelId: Option[Int],
@@ -33,7 +33,7 @@ case class InteractionWithLabel(auditTaskInteractionId: Int, auditTaskId: Int, m
 
 
 class AuditTaskInteractionTable(tag: slick.lifted.Tag) extends Table[AuditTaskInteraction](tag, "audit_task_interaction") {
-  def auditTaskInteractionId = column[Int]("audit_task_interaction_id", O.PrimaryKey, O.AutoInc)
+  def auditTaskInteractionId = column[Long]("audit_task_interaction_id", O.PrimaryKey, O.AutoInc)
   def auditTaskId = column[Int]("audit_task_id", O.NotNull)
   def missionId = column[Int]("mission_id", O.NotNull)
   def action = column[String]("action", O.NotNull)
@@ -46,10 +46,35 @@ class AuditTaskInteractionTable(tag: slick.lifted.Tag) extends Table[AuditTaskIn
   def note = column[Option[String]]("note", O.Nullable)
   def temporaryLabelId = column[Option[Int]]("temporary_label_id", O.Nullable)
   def timestamp = column[java.sql.Timestamp]("timestamp", O.NotNull)
-
   def * = (auditTaskInteractionId, auditTaskId, missionId, action, gsvPanoramaId, lat, lng, heading, pitch, zoom, note,
     temporaryLabelId, timestamp) <> ((AuditTaskInteraction.apply _).tupled, AuditTaskInteraction.unapply)
+  def auditTask: ForeignKeyQuery[AuditTaskTable, AuditTask] =
+    foreignKey("audit_task_interaction_audit_task_id_fkey", auditTaskId, TableQuery[AuditTaskTable])(_.auditTaskId)
+  def mission: ForeignKeyQuery[MissionTable, Mission] =
+    foreignKey("audit_task_interaction_mission_id_fkey", missionId, TableQuery[MissionTable])(_.missionId)
+}
 
+// A copy of the audit_task_interaction table that holds only a subset of the records for fast SELECT queries.
+class AuditTaskInteractionTableSmall(tag: slick.lifted.Tag) extends Table[AuditTaskInteraction](tag, "audit_task_interaction_small") {
+  def auditTaskInteractionId = column[Long]("audit_task_interaction_id", O.PrimaryKey)
+  def auditTaskId = column[Int]("audit_task_id", O.NotNull)
+  def missionId = column[Int]("mission_id", O.NotNull)
+  def action = column[String]("action", O.NotNull)
+  def gsvPanoramaId = column[Option[String]]("gsv_panorama_id", O.Nullable)
+  def lat = column[Option[Float]]("lat", O.Nullable)
+  def lng = column[Option[Float]]("lng", O.Nullable)
+  def heading = column[Option[Float]]("heading", O.Nullable)
+  def pitch = column[Option[Float]]("pitch", O.Nullable)
+  def zoom = column[Option[Int]]("zoom", O.Nullable)
+  def note = column[Option[String]]("note", O.Nullable)
+  def temporaryLabelId = column[Option[Int]]("temporary_label_id", O.Nullable)
+  def timestamp = column[java.sql.Timestamp]("timestamp", O.NotNull)
+  def * = (auditTaskInteractionId, auditTaskId, missionId, action, gsvPanoramaId, lat, lng, heading, pitch, zoom, note,
+    temporaryLabelId, timestamp) <> ((AuditTaskInteraction.apply _).tupled, AuditTaskInteraction.unapply)
+  def auditTaskInteraction: ForeignKeyQuery[AuditTaskInteractionTable, AuditTaskInteraction] =
+    foreignKey("audit_task_interaction_small_audit_task_interaction_id_fkey", auditTaskInteractionId, TableQuery[AuditTaskInteractionTable])(_.auditTaskInteractionId)
+  def auditTask: ForeignKeyQuery[AuditTaskTable, AuditTask] =
+    foreignKey("audit_task_interaction_audit_task_id_fkey", auditTaskId, TableQuery[AuditTaskTable])(_.auditTaskId)
   def mission: ForeignKeyQuery[MissionTable, Mission] =
     foreignKey("audit_task_interaction_mission_id_fkey", missionId, TableQuery[MissionTable])(_.missionId)
 }
@@ -61,7 +86,7 @@ object AuditTaskInteractionTable {
   implicit val context: ExecutionContext = play.api.libs.concurrent.Execution.Implicits.defaultContext
   implicit val interactionWithLabelConverter = GetResult[InteractionWithLabel](r => {
     InteractionWithLabel(
-      r.nextInt, // audit_task_interaction_id
+      r.nextLong, // audit_task_interaction_id
       r.nextInt, // audit_task_id
       r.nextInt, // mission_id
       r.nextString, // action
@@ -84,7 +109,7 @@ object AuditTaskInteractionTable {
 
   implicit val auditTaskInteraction = GetResult[AuditTaskInteraction](r => {
     AuditTaskInteraction(
-      r.nextInt, // audit_task_interaction_id
+      r.nextLong, // audit_task_interaction_id
       r.nextInt, // audit_task_id
       r.nextInt, // mission_id
       r.nextString, // action
@@ -102,12 +127,18 @@ object AuditTaskInteractionTable {
 
   val db = play.api.db.slick.DB
   val auditTaskInteractions = TableQuery[AuditTaskInteractionTable]
+  val auditTaskInteractionsSmall = TableQuery[AuditTaskInteractionTableSmall]
+  val actionSubsetForSmallTable: List[String] = List("ViewControl_MouseDown", "LabelingCanvas_MouseDown", "NextSlideButton_Click", "PreviousSlideButton_Click")
 
   /**
-    * Inserts a sequence of interactions into the audit_task_interaction table.
+    * Inserts a sequence of interactions into the audit_task_interaction and audit_task_interaction_small tables.
     */
-  def saveMultiple(interactions: Seq[AuditTaskInteraction]): Seq[Int] = db.withTransaction { implicit session =>
-    (auditTaskInteractions returning auditTaskInteractions.map(_.auditTaskInteractionId)) ++= interactions
+  def saveMultiple(interactions: Seq[AuditTaskInteraction]): Seq[Long] = db.withTransaction { implicit session =>
+    val savedActions: Seq[AuditTaskInteraction] = (auditTaskInteractions returning auditTaskInteractions) ++= interactions
+
+    // Insert copies of a subset of those interactions in audit_task_interaction_small for faster SELECT queries.
+    val subsetToSave: Seq[AuditTaskInteraction] = savedActions.filter(action =>  actionSubsetForSmallTable.contains(action.action))
+    (auditTaskInteractionsSmall returning auditTaskInteractionsSmall.map(_.auditTaskInteractionId)) ++= subsetToSave
   }
 
   /**
@@ -210,10 +241,9 @@ object AuditTaskInteractionTable {
          |            AND user_id = '$userId'
          |        UNION
          |        SELECT user_id, timestamp
-         |        FROM audit_task_interaction
-         |        INNER JOIN audit_task ON audit_task.audit_task_id = audit_task_interaction.audit_task_id
-         |        WHERE action IN ('ViewControl_MouseDown', 'LabelingCanvas_MouseDown', 'NextSlideButton_Click', 'PreviousSlideButton_Click')
-         |            AND audit_task.user_id = '$userId'
+         |        FROM audit_task_interaction_small
+         |        INNER JOIN audit_task ON audit_task.audit_task_id = audit_task_interaction_small.audit_task_id
+         |        WHERE audit_task.user_id = '$userId'
          |        UNION
          |        SELECT user_id, timestamp
          |        FROM webpage_activity
@@ -249,12 +279,11 @@ object AuditTaskInteractionTable {
         s"""SELECT extract( epoch FROM SUM(diff) ) AS seconds_contributed
            |FROM (
            |    SELECT (timestamp - LAG(timestamp, 1) OVER(PARTITION BY user_id ORDER BY timestamp)) AS diff
-           |    FROM audit_task_interaction
-           |    INNER JOIN audit_task ON audit_task.audit_task_id = audit_task_interaction.audit_task_id
-           |    WHERE action IN ('ViewControl_MouseDown', 'LabelingCanvas_MouseDown', 'NextSlideButton_Click', 'PreviousSlideButton_Click')
-           |        AND audit_task.user_id = '$userId'
-           |        AND audit_task_interaction.timestamp < '$timeRangeEnd'
-           |        AND audit_task_interaction.timestamp > (
+           |    FROM audit_task_interaction_small
+           |    INNER JOIN audit_task ON audit_task.audit_task_id = audit_task_interaction_small.audit_task_id
+           |    WHERE audit_task.user_id = '$userId'
+           |        AND audit_task_interaction_small.timestamp < '$timeRangeEnd'
+           |        AND audit_task_interaction_small.timestamp > (
            |            SELECT COALESCE(MAX(time_created), TIMESTAMP 'epoch')
            |            FROM label
            |            WHERE label.user_id = '$userId'

--- a/conf/evolutions/default/229.sql
+++ b/conf/evolutions/default/229.sql
@@ -1,0 +1,33 @@
+# --- !Ups
+-- Create a copy of the audit_task_interaction table that has just a subset of the records for easy retrieval.
+CREATE TABLE audit_task_interaction_small (
+    audit_task_interaction_id BIGINT NOT NULL,
+    audit_task_id INT NOT NULL,
+    action TEXT NOT NULL,
+    gsv_panorama_id TEXT,
+    lat DOUBLE PRECISION,
+    lng DOUBLE PRECISION,
+    heading DOUBLE PRECISION,
+    pitch DOUBLE PRECISION,
+    zoom INT,
+    note TEXT,
+    timestamp TIMESTAMPTZ NOT NULL,
+    temporary_label_id INT,
+    mission_id INT,
+    PRIMARY KEY (audit_task_interaction_id),
+    FOREIGN KEY (audit_task_interaction_id) REFERENCES audit_task_interaction(audit_task_interaction_id),
+    FOREIGN KEY (audit_task_id) REFERENCES audit_task(audit_task_id),
+    FOREIGN KEY (mission_id) REFERENCES mission(mission_id)
+);
+ALTER TABLE audit_task_interaction_small OWNER TO sidewalk;
+
+-- Below is being run on servers manually due to how long the query takes.
+-- NOTE if adding more actions to this list in the future, make sure to update `actionSubsetForSmallTable` variable.
+-- INSERT INTO audit_task_interaction_small
+-- SELECT *
+-- FROM audit_task_interaction
+-- WHERE action IN ('ViewControl_MouseDown', 'LabelingCanvas_MouseDown', 'NextSlideButton_Click', 'PreviousSlideButton_Click')
+-- ON CONFLICT DO NOTHING;
+
+# --- !Downs
+DROP TABLE audit_task_interaction_small;


### PR DESCRIPTION
Resolves #1245 

Adds a copy of the `audit_task_interaction` table that holds only a subset of the records (~0.9%), which makes our queries that use records in that table much faster. I used a db dump from Seattle (around 250 million records in the table; 2 million in small version), and the relevant queries went from a runtime of 1 minute 15 seconds to less than 1 second.

Hopefully this will help to reduce load on the db when people use the Explore page! And it should drastically speed up the loading time for the /admin/user pages and the /timeCheck page.

One note is that the evolutions file creates the table, but I am going to manually run the query to copy data into that table. It took 6 minutes to run on my local environment, and I'm worried about what might happen if we do that on the prod servers. The query I'm using is commented out in the evolutions file.

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
