### PR TITLE
Added check for 404 bug, and removed labelmap breaking code

### DIFF
--- a/app/views/labelMap.scala.html
+++ b/app/views/labelMap.scala.html
@@ -238,17 +238,5 @@
             });
         });
     }
-
-    // Fully destroy label modal when it's closed to prevent weird behavior when opening another.
-    $(window).on('click', function(e) {
-        var modal = $("#labelModal");
-        if (modal != null && !(modal.hasClass('in'))) {
-            modal.modal('hide');
-            setTimeout(function() {
-                modal.remove();
-                $('.modal-backdrop').remove();
-            }, 200)
-        }
-    });
     </script>
 }

--- a/public/javascripts/Admin/src/Admin.GSVLabelView.js
+++ b/public/javascripts/Admin/src/Admin.GSVLabelView.js
@@ -481,7 +481,10 @@ function AdminGSVLabelView(admin, source) {
     }
 
     function showLabel(labelId) {
-        _resetModal();
+        // Reset modal when gsv panorama is not found.gi
+        if (self.panorama.panorama.getStatus() === "ZERO_RESULTS") {
+            _resetModal();
+        }
 
         self.modal.modal({
             'show': true


### PR DESCRIPTION
Resolves #3542

I removed the modal clean up code in the labelmap file and I added a check when resetting the panorama in the gsv label view file. When I removed the _resetModal call in the showLabel method the code works fine for all four of the locations(labelMap, admin dashboard, contributions, adminmap). However, I found a bug on the contributions tab which occurs when a gsv is deleted by google. 

The steps to reproduce this bug(with screenshots below), is to go to the admin contributions tab and go to the very last page and click on a gsv that is deleted(NoCurbRamp severity 3 on the last page), then click on another gsv that is not deleted(any of the top curb ramps) and these should log a 404 error to the console. After I click on a few other gsv's that are not deleted the issue fixes itself. I solved this issue by calling _resetModal everytime a user clicks on a deleted gsv. If deleted labels are removed the contributions tab, this issue will also fix itself. 

##### Before/After screenshots (if applicable)

##### Testing instructions
1. 
<img width="888" alt="Screen Shot 2024-05-15 at 2 22 41 PM" src="https://github.com/ProjectSidewalk/SidewalkWebpage/assets/96550063/876f0a67-806e-4afb-8a6a-08ed0e197356">
<img width="434" alt="Screen Shot 2024-05-15 at 2 22 11 PM" src="https://github.com/ProjectSidewalk/SidewalkWebpage/assets/96550063/20f7e4ce-6993-4ae7-b157-9acd1c5f4e4d">


##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [ ] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
- [ ] I've asked for and included translations for any user facing text that was added or modified.
- [ ] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure the documentation on [this wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Descriptions-of-Logged-Events) is up to date for the logs you added/updated.
- [ ] I've tested on mobile (only needed for validation page).
