### PR TITLE
3464 truncate gallery tags

### DIFF
--- a/public/javascripts/Gallery/css/cards.css
+++ b/public/javascripts/Gallery/css/cards.css
@@ -137,6 +137,7 @@ with respect to the image holder. This allows the validation menu to be placed o
     height: 100%;
     flex-direction: row;
     right: 0px;
+    overflow: hidden;
 }
 
 .label-tags-header {
@@ -149,11 +150,18 @@ with respect to the image holder. This allows the validation menu to be placed o
     width: 100%;
     flex-direction: row;
     flex-wrap: wrap;
+    flex-wrap: nowrap; /* Prevent wrapping */
+    overflow: hidden; /*new*/
 }
 
 .label-tags-content {
-    text-overflow: ellipsis;
+    /* text-overflow: ellipsis;
     width:fit-content;
+    color: black; */
+    text-overflow: ellipsis; /* Add ellipsis to truncated text */
+    white-space: nowrap; /* Prevent text from wrapping */
+    overflow: hidden; /* Ensure the overflow is hidden */
+    width: fit-content; /* Ensure the width is set to 100% of its container */
     color: black;
 }
 

--- a/public/javascripts/Gallery/css/cards.css
+++ b/public/javascripts/Gallery/css/cards.css
@@ -150,18 +150,15 @@ with respect to the image holder. This allows the validation menu to be placed o
     width: 100%;
     flex-direction: row;
     flex-wrap: wrap;
-    flex-wrap: nowrap; /* Prevent wrapping */
-    overflow: hidden; /*new*/
+    flex-wrap: nowrap;
+    overflow: hidden;
 }
 
 .label-tags-content {
-    /* text-overflow: ellipsis;
-    width:fit-content;
-    color: black; */
-    text-overflow: ellipsis; /* Add ellipsis to truncated text */
-    white-space: nowrap; /* Prevent text from wrapping */
-    overflow: hidden; /* Ensure the overflow is hidden */
-    width: fit-content; /* Ensure the width is set to 100% of its container */
+    text-overflow: ellipsis; 
+    white-space: nowrap;
+    overflow: hidden;
+    width: fit-content;
     color: black;
 }
 

--- a/public/javascripts/Gallery/src/displays/TagDisplay.js
+++ b/public/javascripts/Gallery/src/displays/TagDisplay.js
@@ -51,7 +51,7 @@ function TagDisplay(container, tags, isModal=false) {
             for (let i = 0; i < tagsText.length; i++) {
                 let tagEl = document.createElement('div');
                 // We may want to rename the thumbnail-tag class if we every choose to make tags editable in modal mode.
-                tagEl.className = 'gallery-tag thumbnail-tag';
+                tagEl.className = 'gallery-tag';
                 tagEl.innerText = tagsText[i];
                 $(tagContainer).append(tagEl);
 
@@ -61,17 +61,23 @@ function TagDisplay(container, tags, isModal=false) {
                 // can't fit the tag at all, will need to add to the hidden tags in the '+n' popover.
                 let isLastTag = i === tagsText.length - 1;
                 let tagWidth = parseFloat($(tagEl).css('width'));
+                let isOnlyTag = tagsText.length === 1;
+                let hasHiddenTags = false;
 
                 // If this is the last tag and there are hidden tags, then we need to account for the PLUS_N indicator
                 // in addition to the margin between tags in the extra space needed. Otherwise, we just need to account
                 // for the margin between tags.
-                let extraSpaceNeeded = (isLastTag && hiddenTags.length === 0) ? MARGIN_BW_TAGS : MARGIN_BW_TAGS + WIDTH_FOR_PLUS_N;
-                let spaceForShortenedTag = (isLastTag && hiddenTags.length === 0) ? MIN_TAG_WIDTH : MIN_TAG_WIDTH + WIDTH_FOR_PLUS_N;
+                // let extraSpaceNeeded = (isLastTag && hiddenTags.length === 0) ? MARGIN_BW_TAGS : MARGIN_BW_TAGS + WIDTH_FOR_PLUS_N;
+                let extraSpaceNeeded = MARGIN_BW_TAGS + (isOnlyTag || isLastTag ? 0 : WIDTH_FOR_PLUS_N);
+                // let spaceForShortenedTag = (isLastTag && hiddenTags.length === 0) ? MIN_TAG_WIDTH : MIN_TAG_WIDTH + WIDTH_FOR_PLUS_N;
+                let spaceForShortenedTag = MIN_TAG_WIDTH + (isLastTag ? 0 : WIDTH_FOR_PLUS_N) + MARGIN_BW_TAGS;
 
-                if (isModal || (remainingWidth > tagWidth + extraSpaceNeeded)) {
+
+                if (isModal || (remainingWidth > tagWidth + extraSpaceNeeded) || isOnlyTag) {
                     // Show the entire tag if there is enough space. Always show in modal bc we have a scrollbar.
                     remainingWidth -= (tagWidth + MARGIN_BW_TAGS);
-                } else if (remainingWidth > spaceForShortenedTag) {
+                } else if (remainingWidth > MIN_TAG_WIDTH + extraSpaceNeeded) {
+                    //spaceForShortenedTag
                     // Show a tag abbreviated with an ellipsis if there's some space, just not enough for the full tag.
                     $(tagEl).css('maxWidth', remainingWidth - extraSpaceNeeded);
                     tagWidth = parseFloat($(tagEl).css('width'));


### PR DESCRIPTION
Resolves #3464 
Before:
<img width="785" alt="after 3464" src="https://github.com/ProjectSidewalk/SidewalkWebpage/assets/132852508/696afd77-918b-40de-aeaa-99bfd4e95596">
After:
<img width="784" alt="before 3464" src="https://github.com/ProjectSidewalk/SidewalkWebpage/assets/132852508/ab36e2d1-0023-433c-9a80-2a199d018de8">

Looked in the gallery/Cards class to see how the Cards worked and then made changes in public/javascripts/Gallery/css/cards.css to make it so that the tags of the cards were properly truncated. Difference can be seen in the before and after pictures with the before overflowing out of the card and the after picture having ellipses instead of overflowing in the tag. 



