### PR TITLE
3495 results map

### DIFF
--- a/public/javascripts/PSMap/AddNeighborhoodsToMap.js
+++ b/public/javascripts/PSMap/AddNeighborhoodsToMap.js
@@ -225,9 +225,9 @@ function AddNeighborhoodsToMap(map, neighborhoodGeoJSON, completionRates, labelC
      * Finds the color for a neighborhood based on issue counts and completion rate (used for Results map).
      */
     function getRegionStyleFromIssueCount(polygonData) {
-        const significantData = polygonData.completionRate >= 30;
         const totalIssues = polygonData.NoSidewalk + polygonData.NoCurbRamp + polygonData.SurfaceProblem + polygonData.Obstacle;
         const severityVal = Math.min(100, 1000.0 * totalIssues / polygonData.completed_distance_m);
+        const significantData = isNaN(severityVal) ? false : polygonData.completionRate >= 30;
         const neighborhoodColorGradient = {
             10: '#ff99a0',
             20: '#ff8088',
@@ -240,8 +240,9 @@ function AddNeighborhoodsToMap(map, neighborhoodGeoJSON, completionRates, labelC
             90: '#b3000c',
             100: '#99000a'
         }
+
         return {
-            fillColor: significantData ? getColorFromGradient(severityVal || 100, neighborhoodColorGradient) : '#888',
+            fillColor: significantData ? getColorFromGradient(severityVal, neighborhoodColorGradient) : '#888',
             fillOpacity: significantData ? 0.4 + (totalIssues / polygonData.completed_distance_m) : .25
         }
     }

--- a/public/javascripts/PSMap/AddNeighborhoodsToMap.js
+++ b/public/javascripts/PSMap/AddNeighborhoodsToMap.js
@@ -241,7 +241,7 @@ function AddNeighborhoodsToMap(map, neighborhoodGeoJSON, completionRates, labelC
             100: '#99000a'
         }
         return {
-            fillColor: significantData ? getColorFromGradient(severityVal, neighborhoodColorGradient) : '#888',
+            fillColor: significantData ? getColorFromGradient(severityVal || 100, neighborhoodColorGradient) : '#888',
             fillOpacity: significantData ? 0.4 + (totalIssues / polygonData.completed_distance_m) : .25
         }
     }

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -191,7 +191,7 @@ footer {
     padding: 0px 10px 0px;
 }
 
-.navbar-default .navbar-nav > .active > a {
+.navbar-default .navbar-nav > .active > a.navbar-button {
     background-color: #ffffff;
 }
 

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -191,7 +191,7 @@ footer {
     padding: 0px 10px 0px;
 }
 
-.navbar-default .navbar-nav > .active > a.navbar-button {
+.navbar-default .navbar-nav > .active > a {
     background-color: #ffffff;
 }
 


### PR DESCRIPTION
Resolves #3495 

For many neighborhoods, the value severityVal was undefined. This variable is passed into getColorFromGradient and is supposed to be an int used to determine the color in a loop. Since this variable was undefined, the loop didn't work and there was no resulting color to load. This fix sets severityVal to 100 (the default value) whenever it is undefined.  

### Before
![image](https://github.com/ProjectSidewalk/SidewalkWebpage/assets/88812001/7211f21f-603c-4198-a130-0252bfa1279b)
![image](https://github.com/ProjectSidewalk/SidewalkWebpage/assets/88812001/938c870c-135f-4155-b42b-587bbab3622d)

### After
<img width="660" alt="Screenshot 2024-06-05 at 5 39 13 PM" src="https://github.com/ProjectSidewalk/SidewalkWebpage/assets/88812001/cfbd1967-a19f-4b23-a965-e589b813a469">
<img width="599" alt="Screenshot 2024-06-05 at 5 48 50 PM" src="https://github.com/ProjectSidewalk/SidewalkWebpage/assets/88812001/a08e5fcb-d175-43d0-844b-b974881ff496">


##### Testing instructions
1. Load the results map before and after the fix.

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've included before/after screenshots above.
- [ ] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure the documentation on [this wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Descriptions-of-Logged-Events) is up to date for the logs you added/updated.
- [x] I've tested on mobile (only needed for validation page).
