### PR TITLE
added reset set button function

### DIFF
--- a/public/javascripts/Admin/src/Admin.GSVLabelView.js
+++ b/public/javascripts/Admin/src/Admin.GSVLabelView.js
@@ -434,6 +434,18 @@ function AdminGSVLabelView(admin, source) {
     }
 
     /**
+     * Reset all buttons to their original state.
+     */
+    function _resetButtonStates() {
+        for (var button in self.resultButtons) {
+            if (self.resultButtons.hasOwnProperty(button)) {
+                self.resultButtons[button].css('background-color', 'white');
+                self.resultButtons[button].css('color', 'black');
+            }
+        }
+    }
+
+    /**
      * Sets the new state of a flag for the current label's audit task.
      * @param flag
      * @param state
@@ -481,10 +493,11 @@ function AdminGSVLabelView(admin, source) {
     }
 
     function showLabel(labelId) {
-        // Reset modal when gsv panorama is not found.gi
+        // Reset modal when gsv panorama is not found.
         if (self.panorama.panorama.getStatus() === "ZERO_RESULTS") {
             _resetModal();
         }
+        _resetButtonStates();
 
         self.modal.modal({
             'show': true


### PR DESCRIPTION
Resolves #3556

I added a method to reset the buttons when the user clicks on a new label, previous label clicks are kept. 

##### Before/After screenshots (if applicable)

##### Testing instructions
1. 

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [ ] I've included before/after screenshots above.
- [ ] I've asked for and included translations for any user facing text that was added or modified.
- [ ] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure the documentation on [this wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Descriptions-of-Logged-Events) is up to date for the logs you added/updated.
- [ ] I've tested on mobile (only needed for validation page).
