### PR TITLE
Removing Extra labels on LabelMap panoramas

### DIFF
--- a/public/javascripts/Admin/src/Admin.GSVLabelView.js
+++ b/public/javascripts/Admin/src/Admin.GSVLabelView.js
@@ -498,6 +498,7 @@ function AdminGSVLabelView(admin, source) {
             _resetModal();
         }
         _resetButtonStates();
+        self.panorama.clearLabels();
 
         self.modal.modal({
             'show': true

--- a/public/javascripts/Admin/src/Admin.Panorama.js
+++ b/public/javascripts/Admin/src/Admin.Panorama.js
@@ -108,6 +108,10 @@ function AdminPanorama(svHolder, buttonHolder, admin) {
 
         return this;
     }
+
+    /**
+     * Clears all labels from the panorama.
+     */
     function clearLabels() {
         for (var marker of self.labelMarkers) {
             marker.marker.setMap(null);

--- a/public/javascripts/Admin/src/Admin.Panorama.js
+++ b/public/javascripts/Admin/src/Admin.Panorama.js
@@ -108,6 +108,13 @@ function AdminPanorama(svHolder, buttonHolder, admin) {
 
         return this;
     }
+    function clearLabels() {
+        for (var marker of self.labelMarkers) {
+            marker.marker.setMap(null);
+        }
+        self.labelMarkers = [];
+    }
+
 
     function setPov(heading, pitch, zoom) {
         self.panorama.setPov({ heading: heading, pitch: pitch, zoom: zoomLevel[zoom] });
@@ -382,6 +389,7 @@ function AdminPanorama(svHolder, buttonHolder, admin) {
     self.getPanoId = getPanoId;
     self.getPosition = getPos;
     self.getPov = getPov;
+    self.clearLabels= clearLabels;
 
     return self;
 }


### PR DESCRIPTION
Resolves #3564

Added method to clear labels extra labels when showing a new label pop up. 

##### Before/After screenshots (if applicable)

##### Testing instructions
1. 

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [ ] I've included before/after screenshots above.
- [ ] I've asked for and included translations for any user facing text that was added or modified.
- [ ] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure the documentation on [this wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Descriptions-of-Logged-Events) is up to date for the logs you added/updated.
- [ ] I've tested on mobile (only needed for validation page).
