### PR TITLE
Decreased minZoom for Maps

### DIFF
--- a/public/javascripts/Admin/src/Admin.Task.js
+++ b/public/javascripts/Admin/src/Admin.Task.js
@@ -6,7 +6,7 @@ function AdminTask(params) {
         container: 'admin-task-choropleth',
         style: 'mapbox://styles/mapbox/streets-v12?optimize=true',
         maxZoom: 19,
-        minZoom: 9,
+        minZoom: 8.5,
         scrollZoom: false,
         doubleClickZoom: true
     }).addControl(new MapboxLanguage({ defaultLanguage: i18next.t('common:mapbox-language-code') }));

--- a/public/javascripts/PSMap/CreatePSMap.js
+++ b/public/javascripts/PSMap/CreatePSMap.js
@@ -88,7 +88,7 @@ function CreatePSMap($, params) {
             style: params.mapStyle,
             center: [mapParamData.city_center.lng, mapParamData.city_center.lat],
             zoom: mapParamData.default_zoom,
-            minZoom: 9,
+            minZoom: 8.5,
             maxZoom: 19,
             maxBounds: [
                 [mapParamData.southwest_boundary.lng, mapParamData.southwest_boundary.lat],

--- a/public/javascripts/accessScoreDemo.js
+++ b/public/javascripts/accessScoreDemo.js
@@ -5,7 +5,7 @@ function AccessScoreDemo () {
         L.mapbox.accessToken = data.mapbox_api_key;
         map = L.mapbox.map('access-score-choropleth', null, {
             maxZoom: 19,
-            minZoom: 9,
+            minZoom: 8.5,
             zoomSnap: 0.25
         }).addLayer(L.mapbox.styleLayer('mapbox://styles/mapbox/streets-v11'));
 

--- a/public/javascripts/api.js
+++ b/public/javascripts/api.js
@@ -20,7 +20,7 @@ function SidewalkAPI () {
             center: [data.attribute.center_lng, data.attribute.center_lat],
             zoom: data.attribute.zoom,
             maxZoom: 19,
-            minZoom: 9,
+            minZoom: 8.5,
             maxBounds: maxBounds
         }).addControl(new MapboxLanguage({ defaultLanguage: i18next.t('common:mapbox-language-code') }))
             .addControl(new mapboxgl.NavigationControl(), 'top-left');
@@ -30,7 +30,7 @@ function SidewalkAPI () {
             center: [data.street.center_lng, data.street.center_lat],
             zoom: data.street.zoom,
             maxZoom: 19,
-            minZoom: 9,
+            minZoom: 8.5,
             maxBounds: maxBounds
         }).addControl(new MapboxLanguage({ defaultLanguage: i18next.t('common:mapbox-language-code') }))
             .addControl(new mapboxgl.NavigationControl(), 'top-left');
@@ -40,7 +40,7 @@ function SidewalkAPI () {
             center: [data.region.center_lng, data.region.center_lat],
             zoom: data.region.zoom,
             maxZoom: 19,
-            minZoom: 9,
+            minZoom: 8.5,
             maxBounds: maxBounds
         }).addControl(new MapboxLanguage({ defaultLanguage: i18next.t('common:mapbox-language-code') }))
             .addControl(new mapboxgl.NavigationControl(), 'top-left');

--- a/public/javascripts/routeBuilder.js
+++ b/public/javascripts/routeBuilder.js
@@ -42,7 +42,7 @@ function RouteBuilder ($, mapParams) {
         style: 'mapbox://styles/projectsidewalk/cloov4big002801rc0qw75w5g',
         center: [mapParams.city_center.lng, mapParams.city_center.lat],
         zoom: mapParams.default_zoom,
-        minZoom: 9,
+        minZoom: 8.5,
         maxZoom: 19,
         maxBounds: [
             [mapParams.southwest_boundary.lng, mapParams.southwest_boundary.lat],


### PR DESCRIPTION
Resolves #3558 

Changed minZoom from 9 to 8.5 on files relevant to the maps.

##### Before/After screenshots (if applicable)
Before:
<img width="1487" alt="Screenshot 2024-06-13 at 6 51 13 PM" src="https://github.com/ProjectSidewalk/SidewalkWebpage/assets/92408438/605a290c-d10b-48e9-b30f-3850c5bc8705">
After:
<img width="1481" alt="Screenshot 2024-06-13 at 6 52 05 PM" src="https://github.com/ProjectSidewalk/SidewalkWebpage/assets/92408438/307d3a0c-eda2-4280-9ce6-c25f32c7c3e8">

##### Testing instructions
1. Test maps on signUp page, Result Map, Label Map, etc..

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [ ] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [ ] I've added/updated comments for large or confusing blocks of code.
- [ ] I've included before/after screenshots above.
- [ ] I've asked for and included translations for any user facing text that was added or modified.
- [ ] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure the documentation on [this wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Descriptions-of-Logged-Events) is up to date for the logs you added/updated.
- [ ] I've tested on mobile (only needed for validation page).
