### PR TITLE
Adds city and GSV URL to image info button when copied to clipboard

### DIFF
--- a/app/controllers/ApplicationController.scala
+++ b/app/controllers/ApplicationController.scala
@@ -377,8 +377,7 @@ class ApplicationController @Inject() (implicit val env: Environment[User, Sessi
         val ipAddress: String = request.remoteAddress
 
         // Get names and URLs for cities to display in Gallery dropdown.
-        val lang: Lang = request.cookies.get("PLAY_LANG").map(l => Lang(l.value))
-          .getOrElse(Lang.preferred(request.acceptLanguages))
+        val lang: Lang = Configs.getLangFromRequest(request)
         val cityInfo: List[CityInfo] = Configs.getAllCityInfo(lang)
         val labelTypes: List[(String, String)] = List(
           ("Assorted", Messages("gallery.all")),

--- a/app/controllers/AuditController.scala
+++ b/app/controllers/AuditController.scala
@@ -19,9 +19,11 @@ import models.region._
 import models.route.{Route, RouteTable, UserRoute, UserRouteTable}
 import models.street.StreetEdgeRegionTable
 import models.user._
+import models.utils.{CityInfo, Configs}
 import play.api.libs.json._
 import play.api.{Logger, Play}
 import play.api.Play.current
+import play.api.i18n.Lang
 import play.api.mvc._
 import scala.concurrent.Future
 
@@ -136,15 +138,16 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
         // mission, but only after every third explore mission after that.
         val completedMissions: Boolean = MissionTable.countCompletedMissions(user.userId, missionType = "audit") > 0
 
-        val cityId: String = Play.configuration.getString("city-id").get
         val tutorialStreetId: Int = ConfigTable.getTutorialStreetId
-        val cityNameShort: Option[String] = Play.configuration.getString("city-params.city-short-name." + cityId)
+        val lang: Lang = Configs.getLangFromRequest(request)
+        val cityInfo: List[CityInfo] = Configs.getAllCityInfo(lang)
+        val cityId: String = cityInfo.filter(_.current).head.cityId
         val makeCrops: Boolean = ConfigTable.getMakeCrops
         if (missionSetProgress.missionType != "audit") {
           Future.successful(Redirect("/validate"))
         } else {
           // On the crowdstudy server, we want to assign users to a study group.
-          val response = Ok(views.html.explore("Project Sidewalk - Audit", task, mission, region.get, userRoute, missionSetProgress.numComplete, completedMissions, nextTempLabelId, Some(user), cityId, cityNameShort, tutorialStreetId, makeCrops))
+          val response = Ok(views.html.explore("Project Sidewalk - Audit", task, mission, region.get, userRoute, missionSetProgress.numComplete, completedMissions, nextTempLabelId, Some(user), cityInfo, tutorialStreetId, makeCrops))
           if (cityId == "crowdstudy" && studyGroup.nonEmpty) Future.successful(response.withCookies(Cookie("SIDEWALK_STUDY_GROUP", studyGroup, httpOnly = false)))
           else Future.successful(response)
         }
@@ -202,14 +205,14 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
             // mission, but only after every third explore mission after that.
             val completedMission: Boolean = MissionTable.countCompletedMissions(user.userId, missionType = "audit") > 0
 
-            val cityId: String = Play.configuration.getString("city-id").get
+            val lang: Lang = Configs.getLangFromRequest(request)
+            val cityInfo: List[CityInfo] = Configs.getAllCityInfo(lang)
             val tutorialStreetId: Int = ConfigTable.getTutorialStreetId
-            val cityNameShort: Option[String] = Play.configuration.getString("city-params.city-short-name." + cityId)
             val makeCrops: Boolean = ConfigTable.getMakeCrops
             if (missionSetProgress.missionType != "audit") {
               Future.successful(Redirect("/validate"))
             } else {
-              Future.successful(Ok(views.html.explore("Project Sidewalk - Audit", task, mission, region, None, missionSetProgress.numComplete, completedMission, nextTempLabelId, Some(user), cityId, cityNameShort, tutorialStreetId, makeCrops)))
+              Future.successful(Ok(views.html.explore("Project Sidewalk - Audit", task, mission, region, None, missionSetProgress.numComplete, completedMission, nextTempLabelId, Some(user), cityInfo, tutorialStreetId, makeCrops)))
             }
           case None =>
             Logger.error(s"Tried to explore region $regionId, but there is no neighborhood with that id.")
@@ -269,9 +272,9 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
             mission = MissionTable.resumeOrCreateNewAuditMission(userId, regionId, payPerMeter, tutorialPay).get
           }
 
-          val cityId: String = Play.configuration.getString("city-id").get
+          val lang: Lang = Configs.getLangFromRequest(request)
+          val cityInfo: List[CityInfo] = Configs.getAllCityInfo(lang)
           val tutorialStreetId: Int = ConfigTable.getTutorialStreetId
-          val cityNameShort: Option[String] = Play.configuration.getString("city-params.city-short-name." + cityId)
           val makeCrops: Boolean = ConfigTable.getMakeCrops
           if (missionSetProgress.missionType != "audit") {
             Future.successful(Redirect("/validate"))
@@ -279,15 +282,15 @@ class AuditController @Inject() (implicit val env: Environment[User, SessionAuth
             // If user is an admin and a panoId or lat/lng are supplied, send to that location, o/w send to street.
             if (isAdmin(request.identity) && (startAtPano || startAtLatLng)) {
               panoId match {
-                case Some(panoId) => Future.successful(Ok(views.html.explore("Project Sidewalk - Audit", Some(task), mission, region, None, missionSetProgress.numComplete, completedMission, nextTempLabelId, Some(user), cityId, cityNameShort, tutorialStreetId, makeCrops, None, None, Some(panoId))))
+                case Some(panoId) => Future.successful(Ok(views.html.explore("Project Sidewalk - Audit", Some(task), mission, region, None, missionSetProgress.numComplete, completedMission, nextTempLabelId, Some(user), cityInfo, tutorialStreetId, makeCrops, None, None, Some(panoId))))
                 case None =>
                   (lat, lng) match {
-                    case (Some(lat), Some(lng)) => Future.successful(Ok(views.html.explore("Project Sidewalk - Audit", Some(task), mission, region, None, missionSetProgress.numComplete, completedMission, nextTempLabelId, Some(user), cityId, cityNameShort, tutorialStreetId, makeCrops, Some(lat), Some(lng))))
-                    case (_, _) => Future.successful(Ok(views.html.explore("Project Sidewalk - Audit", Some(task), mission, region, None, missionSetProgress.numComplete, completedMission, nextTempLabelId, None, cityId, cityNameShort, tutorialStreetId, makeCrops)))
+                    case (Some(lat), Some(lng)) => Future.successful(Ok(views.html.explore("Project Sidewalk - Audit", Some(task), mission, region, None, missionSetProgress.numComplete, completedMission, nextTempLabelId, Some(user), cityInfo, tutorialStreetId, makeCrops, Some(lat), Some(lng))))
+                    case (_, _) => Future.successful(Ok(views.html.explore("Project Sidewalk - Audit", Some(task), mission, region, None, missionSetProgress.numComplete, completedMission, nextTempLabelId, None, cityInfo, tutorialStreetId, makeCrops)))
                   }
               }
             } else {
-              Future.successful(Ok(views.html.explore("Project Sidewalk - Audit", Some(task), mission, region, None, missionSetProgress.numComplete, completedMission, nextTempLabelId, Some(user), cityId, cityNameShort, tutorialStreetId, makeCrops)))
+              Future.successful(Ok(views.html.explore("Project Sidewalk - Audit", Some(task), mission, region, None, missionSetProgress.numComplete, completedMission, nextTempLabelId, Some(user), cityInfo, tutorialStreetId, makeCrops)))
             }
           }
         }

--- a/app/controllers/ValidationController.scala
+++ b/app/controllers/ValidationController.scala
@@ -19,8 +19,10 @@ import models.mission.{Mission, MissionSetProgress, MissionTable}
 import models.region.{Region, RegionTable}
 import models.validation._
 import models.user._
+import models.utils.{CityInfo, Configs}
 import play.api.libs.json._
 import play.api.Logger
+import play.api.i18n.Lang
 import play.api.mvc._
 import javax.naming.AuthenticationException
 import scala.concurrent.Future
@@ -39,15 +41,15 @@ class ValidationController @Inject() (implicit val env: Environment[User, Sessio
     * Returns the validation page.
     */
   def validate = UserAwareAction.async { implicit request =>
-    val ipAddress: String = request.remoteAddress
     request.identity match {
       case Some(user) =>
         val adminParams = AdminValidateParams(adminVersion = false)
-        val validationData = getDataForValidationPages(user, ipAddress, labelCount = 10, "Visit_Validate", adminParams)
+        val r: UserAwareRequest[AnyContent] = request
+        val validationData = getDataForValidationPages(request, labelCount = 10, "Visit_Validate", adminParams)
         if (validationData._4.missionType != "validation") {
           Future.successful(Redirect("/explore"))
         } else {
-          Future.successful(Ok(views.html.validation("Sidewalk - Validate", Some(user), adminParams, validationData._1, validationData._2, validationData._3, validationData._4.numComplete, validationData._5, validationData._6)))
+          Future.successful(Ok(views.html.validation("Sidewalk - Validate", Some(user), adminParams, validationData._1, validationData._2, validationData._3, validationData._4.numComplete, validationData._5, validationData._6, validationData._7)))
         }
       case None =>
         Future.successful(Redirect(s"/anonSignUp?url=/validate"));
@@ -58,16 +60,14 @@ class ValidationController @Inject() (implicit val env: Environment[User, Sessio
     * Returns the validation page for mobile.
     */
   def mobileValidate = UserAwareAction.async { implicit request =>
-    val ipAddress: String = request.remoteAddress
-
     request.identity match {
       case Some(user) =>
         val adminParams = AdminValidateParams(adminVersion = false)
-        val validationData = getDataForValidationPages(user, ipAddress, labelCount = 10, "Visit_MobileValidate", adminParams)
+        val validationData = getDataForValidationPages(request, labelCount = 10, "Visit_MobileValidate", adminParams)
         if (validationData._4.missionType != "validation" || user.role.getOrElse("") == "Turker" || !isMobile(request)) {
           Future.successful(Redirect("/explore"))
         } else {
-          Future.successful(Ok(views.html.mobileValidate("Sidewalk - Validate", Some(user), adminParams, validationData._1, validationData._2, validationData._3, validationData._4.numComplete, validationData._5, validationData._6)))
+          Future.successful(Ok(views.html.mobileValidate("Sidewalk - Validate", Some(user), adminParams, validationData._1, validationData._2, validationData._3, validationData._4.numComplete, validationData._5, validationData._6, validationData._7)))
         }
       case None =>
         Future.successful(Redirect(s"/anonSignUp?url=/mobile"));
@@ -81,7 +81,6 @@ class ValidationController @Inject() (implicit val env: Environment[User, Sessio
    * @param neighborhoods   Comma-separated list of neighborhood names or region IDs to validate (could be mixed).
    */
   def adminValidate(labelType: Option[String], users: Option[String], neighborhoods: Option[String]) = UserAwareAction.async { implicit request =>
-    val ipAddress: String = request.remoteAddress
     if (isAdmin(request.identity)) {
       // If any inputs are invalid, send back error message. For each input, we check if the input is an integer
       // representing a valid ID (label_type_id, user_id, or region_id) or a String representing a valid name for that
@@ -118,8 +117,8 @@ class ValidationController @Inject() (implicit val env: Environment[User, Sessio
       } else {
         // If all went well, load the data for Admin Validate with the specified filters.
         val adminParams: AdminValidateParams = AdminValidateParams(adminVersion = true, parsedLabelTypeId.flatten, userIdsList.map(_.flatten), neighborhoodIdList.map(_.flatten))
-        val validationData = getDataForValidationPages(request.identity.get, ipAddress, labelCount=10, "Visit_AdminValidate", adminParams)
-        Future.successful(Ok(views.html.validation("Sidewalk - Admin Validate", request.identity, adminParams, validationData._1, validationData._2, validationData._3, validationData._4.numComplete, validationData._5, validationData._6)))
+        val validationData = getDataForValidationPages(request, labelCount=10, "Visit_AdminValidate", adminParams)
+        Future.successful(Ok(views.html.validation("Sidewalk - Admin Validate", request.identity, adminParams, validationData._1, validationData._2, validationData._3, validationData._4.numComplete, validationData._5, validationData._6, validationData._7)))
       }
     } else {
       Future.failed(new AuthenticationException("User is not an administrator"))
@@ -131,14 +130,19 @@ class ValidationController @Inject() (implicit val env: Environment[User, Sessio
     *
     * @return (mission, labelList, missionProgress, missionSetProgress, hasNextMission, completedValidations)
     */
-  def getDataForValidationPages(user: User, ipAddress: String, labelCount: Int, visitTypeStr: String, adminParams: AdminValidateParams): (Option[JsObject], Option[JsValue], Option[JsObject], MissionSetProgress, Boolean, Int) = {
+  def getDataForValidationPages(request: UserAwareRequest[AnyContent], labelCount: Int, visitTypeStr: String, adminParams: AdminValidateParams): (Option[JsObject], Option[JsValue], Option[JsObject], MissionSetProgress, Boolean, Int, List[CityInfo]) = {
     val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
+    val user: User = request.identity.get
+    val ipAddress: String = request.remoteAddress
 
     WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, visitTypeStr, timestamp))
 
     val missionSetProgress: MissionSetProgress =
       if (user.role.getOrElse("") == "Turker") MissionTable.getProgressOnMissionSet(user.username)
       else MissionTable.defaultValidationMissionSetProgress
+
+    val lang: Lang = Configs.getLangFromRequest(request)
+    val cityInfo: List[CityInfo] = Configs.getAllCityInfo(lang)
 
     val labelTypeId: Option[Int] = getLabelTypeIdToValidate(user.userId, labelCount, adminParams.labelTypeId)
 
@@ -154,11 +158,11 @@ class ValidationController @Inject() (implicit val env: Environment[User, Sessio
       val progressJsObject: JsObject = LabelValidationTable.getValidationProgress(mission.missionId)
       val hasDataForMission: Boolean = labelList.toString != "[]"
 
-      (Some(missionJsObject), Some(labelList), Some(progressJsObject), missionSetProgress, hasDataForMission, completedValidations)
+      (Some(missionJsObject), Some(labelList), Some(progressJsObject), missionSetProgress, hasDataForMission, completedValidations, cityInfo)
     } else {
       // TODO When fixing the mission sequence infrastructure (#1916), this should update that table since there are
       //      no validation missions that can be done.
-      (None, None, None, missionSetProgress, false, completedValidations)
+      (None, None, None, missionSetProgress, false, completedValidations, cityInfo)
     }
   }
 

--- a/app/models/utils/Configs.scala
+++ b/app/models/utils/Configs.scala
@@ -2,38 +2,45 @@ package models.utils
 
 import play.api.Play
 import play.api.Play.current
+import play.api.cache.Cache
 import scala.collection.JavaConverters._
 import play.api.i18n.{Lang, Messages}
 
-case class CityInfo(cityId: String, countryId: String, cityNameShort: String, cityNameFormatted: String, URL: String, visibility: String)
+case class CityInfo(cityId: String, countryId: String, cityNameShort: String, cityNameFormatted: String, URL: String, visibility: String, current: Boolean)
 
 object Configs {
   /**
    * Returns list of info for all cities, including formatted names (in current language), URL, visibility.
    */
   def getAllCityInfo(lang: Lang): List[CityInfo] = {
-    val currentCityId: String = Play.configuration.getString("city-id").get
-    val currentCountryId: String = Play.configuration.getString(s"city-params.country-id.$currentCityId").get
-    val envType: String = Play.configuration.getString("environment-type").get
+    Cache.getOrElse("getAllCityInfo()") {
+      val currentCityId: String = Play.configuration.getString("city-id").get
+      val currentCountryId: String = Play.configuration.getString(s"city-params.country-id.$currentCityId").get
+      val envType: String = Play.configuration.getString("environment-type").get
 
-    // Get names and URLs for cities to display in Gallery dropdown.
-    val cityIds: List[String] = Play.configuration.getStringList("city-params.city-ids").get.asScala.toList
-    val cityInfo: List[CityInfo] = cityIds.map { cityId =>
-      val stateId: Option[String] = Play.configuration.getString(s"city-params.state-id.$cityId")
-      val countryId: String = Play.configuration.getString(s"city-params.country-id.$cityId").get
-      val cityURL: String = Play.configuration.getString(s"city-params.landing-page-url.$envType.$cityId").get
-      val visibility: String = Play.configuration.getString(s"city-params.status.$cityId").get
+      // Get names and URLs for cities to display in Gallery dropdown.
+      val cityIds: List[String] = Play.configuration.getStringList("city-params.city-ids").get.asScala.toList
+      val cityInfo: List[CityInfo] = cityIds.map { cityId =>
+        val stateId: Option[String] = Play.configuration.getString(s"city-params.state-id.$cityId")
+        val countryId: String = Play.configuration.getString(s"city-params.country-id.$cityId").get
+        val cityURL: String = Play.configuration.getString(s"city-params.landing-page-url.$envType.$cityId").get
+        val visibility: String = Play.configuration.getString(s"city-params.status.$cityId").get
 
-      // Get the name of the city in frequently used formats in the current language.
-      val cityName: String = Messages(s"city.name.$cityId")(lang)
-      val cityNameShort: String = Play.configuration.getString(s"city-params.city-short-name.$cityId").getOrElse(cityName)
-      val cityNameFormatted: String = if (currentCountryId == "usa" && stateId.isDefined && countryId == "usa")
-        Messages("city.state", cityName, Messages(s"state.name.${stateId.get}")(lang))(lang)
-      else
-        Messages("city.state", cityName, Messages(s"country.name.$countryId")(lang))(lang)
-      CityInfo(cityId, countryId, cityNameShort, cityNameFormatted, cityURL, visibility)
+        // Get the name of the city in frequently used formats in the current language.
+        val cityName: String = Messages(s"city.name.$cityId")(lang)
+        val cityNameShort: String = Play.configuration.getString(s"city-params.city-short-name.$cityId").getOrElse(cityName)
+        val cityNameFormatted: String = if (currentCountryId == "usa" && stateId.isDefined && countryId == "usa")
+          Messages("city.state", cityName, Messages(s"state.name.${stateId.get}")(lang))(lang)
+        else
+          Messages("city.state", cityName, Messages(s"country.name.$countryId")(lang))(lang)
+        CityInfo(cityId, countryId, cityNameShort, cityNameFormatted, cityURL, visibility, cityId == currentCityId)
+      }
+      cityInfo
     }
-    cityInfo
+  }
+
+  def getLangFromRequest(request: play.api.mvc.RequestHeader): Lang = {
+    request.cookies.get("PLAY_LANG").map(l => Lang(l.value)).getOrElse(Lang.preferred(request.acceptLanguages))
   }
 
   def getCurrentCountryId(): String = {

--- a/app/views/explore.scala.html
+++ b/app/views/explore.scala.html
@@ -6,8 +6,9 @@
 @import models.route.UserRoute
 @import views.html.bootstrap._
 
-@(title: String, task: Option[models.audit.NewTask] = None, mission: Mission, region: Region, userRoute: Option[UserRoute], missionSetProgress: Int, hasCompletedMission: Boolean, nextTempLabelId: Int, user: Option[User] = None, cityId: String, cityNameShort: Option[String], tutorialStreetId: Int, makeCrops: Boolean, lat: Option[Double] = None, lng: Option[Double] = None, panoId: Option[String] = None)(implicit lang: Lang)
-@cityName = @{cityNameShort.getOrElse(Messages(s"city.name.$cityId"))}
+@import models.utils.CityInfo
+@(title: String, task: Option[models.audit.NewTask] = None, mission: Mission, region: Region, userRoute: Option[UserRoute], missionSetProgress: Int, hasCompletedMission: Boolean, nextTempLabelId: Int, user: Option[User] = None, cityInfo: List[CityInfo], tutorialStreetId: Int, makeCrops: Boolean, lat: Option[Double] = None, lng: Option[Double] = None, panoId: Option[String] = None)(implicit lang: Lang)
+@currentCity = @{cityInfo.filter(c => c.current).head}
 
 @main(title, Some("/explore")) {
     @if(userRoute.isDefined) {
@@ -388,7 +389,7 @@
                 </div>
                 <div id="neighborhood-stats-status-box" class="status-box">
                     <h1 class="status-holder-header-1">@Messages("audit.right.ui.current.neighborhood")</h1>
-                    <span id="status-neighborhood-name"><span id="status-holder-neighborhood-name"></span>@cityName</span>
+                    <span id="status-neighborhood-name"><span id="status-holder-neighborhood-name"></span>@currentCity.cityNameShort</span>
                     <div class="status-row" id="neighborhood-status-row">
                         <img src='@routes.Assets.at("images/icons/noun_distance_2587675_cropped.png")' class="status-icon" alt="@Messages("distance.icon.alt")" align="">
                         <span><strong id="status-audited-distance">0.00</strong> <small>@Messages("audit.right.ui.distance")</small></span>
@@ -1047,8 +1048,9 @@
             }
 
             mainParam.language = "@lang.code";
-            mainParam.cityId = "@cityId";
-            mainParam.cityName = "@cityName";
+            mainParam.cityId = "@currentCity.cityId";
+            mainParam.cityName = "@currentCity.cityNameFormatted";
+            mainParam.cityNameShort = "@currentCity.cityNameShort";
             mainParam.makeCrops = @makeCrops;
 
             svl.main = new Main(mainParam);

--- a/app/views/gallery.scala.html
+++ b/app/views/gallery.scala.html
@@ -1,9 +1,7 @@
 @import models.user.User
 @import models.utils.CityInfo
-@import play.api.Play
-@import play.api.Play.current
 @(title: String, user: Option[User] = None, cityInfo: List[CityInfo], labelType: String, labels: List[(String, String)], regionIds: List[Int], severities: List[Int], tags: List[String], valOptions: List[String])(implicit lang: Lang)
-@currentCity = @{cityInfo.filter(c => c.cityId == Play.configuration.getString("city-id").get).head}
+@currentCity = @{cityInfo.filter(c => c.current).head}
 
 @main(title) {
     <script type="text/javascript" src='@routes.Assets.at("javascripts/Gallery/build/Gallery.js")'></script>
@@ -41,8 +39,8 @@
                     <span id="city-type-holder">
                         <h4><b>@Messages("navbar.city")</b></h4>
                         <select id="city-select" class="gallery-filter" disabled>
-                            @for(city <- cityInfo.filter(c => c.visibility == "public" || c.cityId == currentCity.cityId).sortBy(c => (c.countryId, c.cityId))) {
-                                @if(currentCity.cityId == city.cityId) {
+                            @for(city <- cityInfo.filter(c => c.visibility == "public" || c.current).sortBy(c => (c.countryId, c.cityId))) {
+                                @if(city.current) {
                                     <option value="@city.URL" selected>@city.cityNameFormatted</option>
                                 } else {
                                     <option value="@city.URL">@city.cityNameFormatted</option>
@@ -135,6 +133,8 @@
             }
 
             params.language = "@lang.code";
+            params.cityId = "@currentCity.cityId";
+            params.cityName = "@currentCity.cityNameFormatted";
 
             sg.main = new Main(params);
     </script>

--- a/app/views/mobileValidate.scala.html
+++ b/app/views/mobileValidate.scala.html
@@ -5,9 +5,9 @@
 @import play.api.Play.current
 
 @import controllers.helper.ValidateHelper.AdminValidateParams
-@(title: String, user: Option[User] = None, adminParams: AdminValidateParams, mission: Option[JsValue], labelList: Option[JsValue], progress: Option[JsValue], missionSetProgress: Int, hasNextMission: Boolean, completedValidations: Int)(implicit lang: Lang)
-
-@currentCity =@{Play.configuration.getString("city-id").get}
+@import models.utils.CityInfo
+@(title: String, user: Option[User] = None, adminParams: AdminValidateParams, mission: Option[JsValue], labelList: Option[JsValue], progress: Option[JsValue], missionSetProgress: Int, hasNextMission: Boolean, completedValidations: Int, cityInfo: List[CityInfo])(implicit lang: Lang)
+@currentCity = @{cityInfo.filter(c => c.current).head}
 
 @main(title, Some("/mobile")) {
 
@@ -85,7 +85,7 @@
                 } else {
                     <button data-toggle="modal" data-target="#sign-in-modal-container" class="gray-button-mobile" onclick="location.href='@routes.UserController.signInMobile()'">@Messages("navbar.signin")</button>
                 }
-                <img src='@routes.Assets.at("assets/" + Play.configuration.getString("city-params.logo-img." + currentCity).get)' id="ps-logo-mission"></img>
+                <img src='@routes.Assets.at("assets/" + Play.configuration.getString("city-params.logo-img." + currentCity.cityId).get)' id="ps-logo-mission"></img>
                 <h1 id="modal-mission-header" class="text-center"></h1>
                 <div id="modal-mission-instruction"></div>
                 <button class="button" id="modal-mission-close-button">OK</button>
@@ -134,7 +134,7 @@
         <div id="modal-mission-complete-holder">
             <div id="modal-mission-complete-background" class="modal-background"></div>
             <div id="modal-mission-complete-foreground" class="modal-foreground">
-                <img src='@routes.Assets.at("assets/" + Play.configuration.getString("city-params.logo-img." + currentCity).get)' id="ps-logo-mission-complete"></img>
+                <img src='@routes.Assets.at("assets/" + Play.configuration.getString("city-params.logo-img." + currentCity.cityId).get)' id="ps-logo-mission-complete"></img>
                 <h1 class="normal" id="modal-mission-complete-title"></h1>
                 <p><div id="modal-mission-complete-message"></div></p>
                 <div id="modal-mission-complete-table">
@@ -167,7 +167,7 @@
         <div id="modal-landscape-holder">
             <div id="modal-landscape-background" class="modal-background"></div>
             <div id="modal-landscape-foreground" class="modal-foreground">
-                <img src='@routes.Assets.at("assets/" + Play.configuration.getString("city-params.logo-img." + currentCity).get)' id="ps-logo-landscape"></img>
+                <img src='@routes.Assets.at("assets/" + Play.configuration.getString("city-params.logo-img." + currentCity.cityId).get)' id="ps-logo-landscape"></img>
                 <div>
                     <p id="modal-landscape-header">
                         Welcome to Project Sidewalk!
@@ -218,6 +218,8 @@
             param.canvasHeight = window.innerHeight;
             param.canvasWidth = window.innerWidth;
             param.language = "@lang.code";
+            param.cityId = "@currentCity.cityId";
+            param.cityName = "@currentCity.cityNameFormatted";
             param.adminVersion = @adminParams.adminVersion;
             param.adminLabelTypeId = @Html(adminParams.labelTypeId.map(_.toString).getOrElse("null"));
             param.adminUserIds = @Html(adminParams.userIds.map(_.mkString("['", "','", "']")).getOrElse("null"));

--- a/app/views/validation.scala.html
+++ b/app/views/validation.scala.html
@@ -3,7 +3,9 @@
 @import play.api.libs.json.JsValue
 
 @import controllers.helper.ValidateHelper.AdminValidateParams
-@(title: String, user: Option[User] = None, adminParams: AdminValidateParams, mission: Option[JsValue], labelList: Option[JsValue], progress: Option[JsValue], missionSetProgress: Int, hasNextMission: Boolean, completedValidations: Int)(implicit lang: Lang)
+@import models.utils.CityInfo
+@(title: String, user: Option[User] = None, adminParams: AdminValidateParams, mission: Option[JsValue], labelList: Option[JsValue], progress: Option[JsValue], missionSetProgress: Int, hasNextMission: Boolean, completedValidations: Int, cityInfo: List[CityInfo])(implicit lang: Lang)
+@currentCity = @{cityInfo.filter(c => c.current).head}
 
 @main(title, Some("/validate")) {
     @navbar(user, Some("/validate"))
@@ -300,6 +302,8 @@
             param.canvasHeight = 440;
             param.canvasWidth = 720;
             param.language = "@lang.code";
+            param.cityId = "@currentCity.cityId";
+            param.cityName = "@currentCity.cityNameFormatted";
             param.adminVersion = @adminParams.adminVersion;
             param.adminLabelTypeId = @Html(adminParams.labelTypeId.map(_.toString).getOrElse("null"));
             param.adminUserIds = @Html(adminParams.userIds.map(_.mkString("['", "','", "']")).getOrElse("null"));

--- a/public/javascripts/Gallery/src/Main.js
+++ b/public/javascripts/Gallery/src/Main.js
@@ -67,6 +67,8 @@ function Main (params) {
 
     function _init() {
         sg.rootDirectory = ('rootDirectory' in params) ? params.rootDirectory : '/';
+        sg.cityId = params.cityId;
+        sg.cityName = params.cityName;
 
         // Initialize functional components of UI elements.
         sg.cityMenu = new CityMenu(sg.ui.cityMenu);

--- a/public/javascripts/Gallery/src/modal/Modal.js
+++ b/public/javascripts/Gallery/src/modal/Modal.js
@@ -148,7 +148,7 @@ function Modal(uiModal) {
         self.infoPopover = new GSVInfoPopover(self.labelTimestampData, sg.modal().pano.panorama,
             sg.modal().pano.getPosition, getPanoId,
             function () { return properties['street_edge_id']; }, function () { return properties['region_id']; },
-            sg.modal().pano.getPov, false,
+            sg.modal().pano.getPov, sg.cityName, false,
             function() { sg.tracker.push('GSVInfoButton_Click', { panoId: getPanoId() }); },
             function() { sg.tracker.push('GSVInfoCopyToClipboard_Click', { panoId: getPanoId() }); },
             function() { sg.tracker.push('GSVInfoViewInGSV_Click', { panoId: getPanoId() }); },

--- a/public/javascripts/SVLabel/src/SVLabel/Main.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Main.js
@@ -53,6 +53,7 @@ function Main (params) {
         svl.userRouteId = params.userRouteId;
         svl.cityId = params.cityId;
         svl.cityName = params.cityName;
+        svl.cityNameShort = params.cityNameShort;
         svl.makeCrops = params.makeCrops;
         if (svl.usingPredictionModel()) {
             svl.predictionModel = new PredictionModel();
@@ -167,7 +168,7 @@ function Main (params) {
 
         svl.infoPopover = new GSVInfoPopover(svl.ui.dateHolder, svl.panorama, svl.map.getPosition, svl.map.getPanoId,
             svl.taskContainer.getCurrentTaskStreetEdgeId, svl.neighborhoodContainer.getCurrentNeighborhood().getRegionId,
-            svl.map.getPov, true, function() { svl.tracker.push('GSVInfoButton_Click'); },
+            svl.map.getPov, svl.cityName, true, function() { svl.tracker.push('GSVInfoButton_Click'); },
             function() { svl.tracker.push('GSVInfoCopyToClipboard_Click'); },
             function() { svl.tracker.push('GSVInfoViewInGSV_Click'); }
         );

--- a/public/javascripts/SVLabel/src/SVLabel/onboarding/InitialMissionInstruction.js
+++ b/public/javascripts/SVLabel/src/SVLabel/onboarding/InitialMissionInstruction.js
@@ -122,7 +122,7 @@ function InitialMissionInstruction(compass, mapService, popUpMessage, taskContai
         if (!svl.isOnboarding()) {
             var title = i18next.t('popup.start-title');
             var message = i18next.t('popup.start-body',
-                { neighborhood: neighborhood.getProperty("name"), city: svl.cityName });
+                { neighborhood: neighborhood.getProperty("name"), city: svl.cityNameShort });
             tracker.push('PopUpShow_LetsGetStarted');
 
             popUpMessage.notify(title, message, self._finishedInstructionToStart);

--- a/public/javascripts/SVValidate/src/Main.js
+++ b/public/javascripts/SVValidate/src/Main.js
@@ -15,6 +15,8 @@ function Main (param) {
     svv.canvasHeight = param.canvasHeight;
     svv.canvasWidth = param.canvasWidth;
     svv.missionsCompleted = param.missionSetProgress;
+    svv.cityId = param.cityId;
+    svv.cityName = param.cityName;
 
     function _initUI() {
         // Maps label types to label names.
@@ -179,7 +181,7 @@ function Main (param) {
             svv.panorama.getPanoId,
             function() { return svv.panoramaContainer.getCurrentLabel().getAuditProperty('streetEdgeId'); },
             function() { return svv.panoramaContainer.getCurrentLabel().getAuditProperty('regionId'); },
-            svv.panorama.getPov, true, function() { svv.tracker.push('GSVInfoButton_Click'); },
+            svv.panorama.getPov, svv.cityName, true, function() { svv.tracker.push('GSVInfoButton_Click'); },
             function() { svv.tracker.push('GSVInfoCopyToClipboard_Click'); },
             function() { svv.tracker.push('GSVInfoViewInGSV_Click'); },
             function() { return svv.panoramaContainer.getCurrentLabel().getAuditProperty('labelId'); }

--- a/public/javascripts/common/GSVInfoPopover.js
+++ b/public/javascripts/common/GSVInfoPopover.js
@@ -8,6 +8,7 @@
  * @param {function} streetEdgeId Function that returns current Street Edge ID
  * @param {function} regionId Function that returns current Region ID
  * @param {function} pov Function that returns current POV
+ * @param {String} cityName Name of the current city
  * @param {Boolean} whiteIcon Set to true if using white icon, false if using blue icon.
  * @param {function} infoLogging Function that adds the info button click to the appropriate logs.
  * @param {function} clipboardLogging Function that adds the copy to clipboard click to the appropriate logs.
@@ -16,7 +17,7 @@
  * @returns {GSVInfoPopover} Popover object, which holds the popover title html, content html, info button html, and
  * update values method
  */
-function GSVInfoPopover (container, panorama, coords, panoId, streetEdgeId, regionId, pov, whiteIcon, infoLogging, clipboardLogging, viewGSVLogging, labelId) {
+function GSVInfoPopover (container, panorama, coords, panoId, streetEdgeId, regionId, pov, cityName, whiteIcon, infoLogging, clipboardLogging, viewGSVLogging, labelId) {
     let self = this;
 
     function _init() {
@@ -159,8 +160,10 @@ function GSVInfoPopover (container, panorama, coords, panoId, streetEdgeId, regi
                 `${i18next.t(`common:gsv-info.longitude`)}: ${currCoords.lng}°\n` +
                 `${i18next.t(`common:gsv-info.panorama-id`)}: ${currPanoId}\n` +
                 `${i18next.t(`common:gsv-info.street-id`)}: ${currStreetEdgeId}\n` +
-                `${i18next.t(`common:gsv-info.region-id`)}: ${currRegionId}\n`;
-            if (currLabelId) clipboardText += `${i18next.t(`common:gsv-info.label-id`)}: ${currLabelId}`;
+                `${i18next.t(`common:gsv-info.region-id`)}: ${currRegionId}\n` +
+                `${i18next.t(`common:gsv-info.city`)}: ${cityName}\n` +
+                `GSV URL: ${gsvLink.attr('href')}`;
+            if (currLabelId) clipboardText += `\n${i18next.t(`common:gsv-info.label-id`)}: ${currLabelId}`;
             navigator.clipboard.writeText(clipboardText);
 
             // The clipboard popover will only show one time until you close and reopen the info button popover. I have

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -128,6 +128,7 @@
         "region-id": "Region ID",
         "label-id": "Beschriftung ID",
         "view-in-gsv": "Ansicht in Google Street View",
+        "city": "Stadt",
         "copied-to-clipboard": "Daten wurden in Zwischenablage kopiert"
     },
     "mission-start-tutorial": {

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -128,6 +128,7 @@
         "region-id": "Region ID",
         "label-id": "Label ID",
         "view-in-gsv": "View in Google Street View",
+        "city": "City",
         "copied-to-clipboard": "Data copied to your clipboard!"
     },
     "mission-start-tutorial": {

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -128,6 +128,7 @@
         "region-id": "ID de región",
         "label-id": "ID de etiqueta",
         "view-in-gsv": "Ver en Google Street View",
+        "city": "Ciudad",
         "copied-to-clipboard": "¡Datos copiados a su portapapeles!"
     },
     "mission-start-tutorial": {

--- a/public/locales/nl/common.json
+++ b/public/locales/nl/common.json
@@ -127,6 +127,7 @@
         "region-id": "Regio-ID",
         "label-id": "Etiket-ID",
         "view-in-gsv": "Bekijken in Google Streetview",
+        "city": "Stad",
         "copied-to-clipboard": "Gegevens gekopieerd naar uw klembord!"
     },
     "mission-start-tutorial": {

--- a/public/locales/zh-TW/common.json
+++ b/public/locales/zh-TW/common.json
@@ -128,6 +128,7 @@
         "region-id": "區域編號",
         "label-id": "標籤編號",
         "view-in-gsv": "在Google街景圖裡查看",
+        "city": "城市",
         "copied-to-clipboard": "資訊已複製於您的剪貼簿！"
     },
     "mission-start-tutorial": {


### PR DESCRIPTION
Resolves #3568 

Adds the city name and the GSV URL to the data when copied to the clipboard on the GSV info button. This applies to the button as shown on Gallery, Validate, and Explore.

##### Before/After screenshots (if applicable)
Before
```
Latitude: 40.9007798662525°
Longitude: -74.02539685791724°
Panorama ID: CCNJnMDAiD2D_uHkgVGFWQ
Street ID: 1751
Region ID: 12
Label ID: 5790
```

After:
```
Latitude: 40.9007798662525°
Longitude: -74.02539685791724°
Panorama ID: CCNJnMDAiD2D_uHkgVGFWQ
Street ID: 1751
Region ID: 12
City: Teaneck, NJ
GSV URL: https://www.google.com/maps/@?api=1&map_action=pano&viewpoint=40.9007798662525%2C-74.02539685791724&heading=94.1875&pitch=-23
Label ID: 5790
```

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
- [x] I've asked for and included translations for any user facing text that was added or modified.
- [x] I've tested on mobile (only needed for validation page).
