### PR TITLE
Fixes keyboard shortcuts in Validate

### DIFF
--- a/public/javascripts/SVValidate/src/keyboard/Keyboard.js
+++ b/public/javascripts/SVValidate/src/keyboard/Keyboard.js
@@ -165,8 +165,18 @@ function Keyboard(menuUI) {
                     menuUI.yesButton.removeClass("validate");
                     status.keyPressed = false;
                     break;
+                // "a" key
+                case 65:
+                    menuUI.yesButton.removeClass("validate");
+                    status.keyPressed = false;
+                    break;
                 // "n" key
                 case 78:
+                    menuUI.noButton.removeClass("validate");
+                    status.keyPressed = false;
+                    break;
+                // "d" key
+                case 68:
                     menuUI.noButton.removeClass("validate");
                     status.keyPressed = false;
                     break;


### PR DESCRIPTION
Resolves #3592 

Fixes broken keyboard shortcuts in Validate (not the new one) when using the old A/D keys to validate.

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
