### PR TITLE
Adds S keyboard shortcut to submit validation in new UI

### DIFF
--- a/public/javascripts/SVValidate/src/keyboard/Keyboard.js
+++ b/public/javascripts/SVValidate/src/keyboard/Keyboard.js
@@ -125,7 +125,7 @@ function Keyboard(menuUI) {
                         });
                     }
                     break;
-                // "n" key
+                // "u" key
                 case 85:
                     if (svv.newValidateBeta) {
                         svv.ui.newValidateBeta.unsureButton.click();
@@ -134,6 +134,12 @@ function Keyboard(menuUI) {
                         validateLabel(menuUI.unsureButton, "Unsure", comment);
                         menuUI.yesButton.removeClass("validate");
                         menuUI.noButton.removeClass("validate");
+                    }
+                    break;
+                // "s" key
+                case 83:
+                    if (svv.newValidateBeta) {
+                        svv.ui.newValidateBeta.submitButton.click();
                     }
                     break;
                 // "z" key

--- a/public/javascripts/SVValidate/src/menu/RightMenu.js
+++ b/public/javascripts/SVValidate/src/menu/RightMenu.js
@@ -83,8 +83,10 @@ function RightMenu(menuUI) {
         });
 
         // Add onclick for submit button.
-        menuUI.submitButton.click(function() {
-            _validateLabel(svv.validationOptions[svv.panorama.getCurrentLabel().getProperty('validationResult')]);
+        menuUI.submitButton.click(function(e) {
+            if (!e.target.disabled) {
+                _validateLabel(svv.validationOptions[svv.panorama.getCurrentLabel().getProperty('validationResult')], e.isTrigger);
+            }
         });
     }
 
@@ -108,7 +110,7 @@ function RightMenu(menuUI) {
             $disagreeReasonTextbox.val('');
             menuUI.unsureMenu.css('display', 'none');
             menuUI.unsureComment.val('');
-            menuUI.submitButton.attr('disabled', 'disabled');
+            menuUI.submitButton.prop('disabled', true);
         } else {
             // This is a validation that they are going back to, so update all the views to match what they had before.
             menuUI.unsureComment.val(label.getProperty('unsureReasonTextBox'));
@@ -142,7 +144,7 @@ function RightMenu(menuUI) {
         }
         menuUI.noMenu.css('display', 'none');
         menuUI.unsureMenu.css('display', 'none');
-        menuUI.submitButton.removeAttr('disabled');
+        menuUI.submitButton.prop('disabled', false);
     }
 
     function _setNoView() {
@@ -153,7 +155,7 @@ function RightMenu(menuUI) {
         menuUI.severityMenu.css('display', 'none');
         menuUI.noMenu.css('display', 'block');
         menuUI.unsureMenu.css('display', 'none');
-        menuUI.submitButton.removeAttr('disabled');
+        menuUI.submitButton.prop('disabled', false);
     }
 
     function _setUnsureView() {
@@ -164,7 +166,7 @@ function RightMenu(menuUI) {
         menuUI.severityMenu.css('display', 'none');
         menuUI.noMenu.css('display', 'none');
         menuUI.unsureMenu.css('display', 'block');
-        menuUI.submitButton.removeAttr('disabled');
+        menuUI.submitButton.prop('disabled', false);
     }
 
 
@@ -243,11 +245,13 @@ function RightMenu(menuUI) {
 
     /**
      * Validates a single label from a button click.
-     * @param action    {String} Validation action - must be one of Agree, Disagree, or Unsure.
+     * @param action           {String} Validation action - must be one of Agree, Disagree, or Unsure.
+     * @param keyboardShortcut {boolean} Whether or not the validation was triggered by a keyboard shortcut.
      */
-    function _validateLabel(action) {
+    function _validateLabel(action, keyboardShortcut) {
+        const actionStr = keyboardShortcut ? 'ValidationKeyboardShortcut_Submit_Validation=' : 'Click=Submit_Validation=';
         let timestamp = new Date().getTime();
-        svv.tracker.push('Click=Submit_Validation=' + action);
+        svv.tracker.push(actionStr + action);
         let currLabel = svv.panorama.getCurrentLabel();
 
         // Resets CSS elements for all buttons to their default states.


### PR DESCRIPTION
Resolves #3596

Adds a keyboard shortcut (S) to submit a validation to reduce mouse travel on new Validate UI.

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure the documentation on [this wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Descriptions-of-Logged-Events) is up to date for the logs you added/updated.
