### PR TITLE
Adds 'unsure' reasons buttons to new Validate beta

### DIFF
--- a/app/views/newValidateBeta.scala.html
+++ b/app/views/newValidateBeta.scala.html
@@ -208,7 +208,7 @@
                         <button id="unsure-button-2" class="validation-reason-button"></button>
                         <button id="unsure-button-3" class="validation-reason-button"></button>
                         <div class="input-group input-group-sm validate-text-input">
-                            <input type="text" class="form-control" placeholder="Add your reason (optional)" id="add-unsure-comment" size="36" aria-label="Add unsure reason input">
+                            <input type="text" class="form-control" placeholder="Or add your own reason" id="add-unsure-comment" size="36" aria-label="Add unsure reason input">
                         </div>
                     </div>
                 </div>

--- a/app/views/newValidateBeta.scala.html
+++ b/app/views/newValidateBeta.scala.html
@@ -193,9 +193,9 @@
                 <div id="validate-why-no-section" class="right-ui-section">
                     <div id="validate-why-not-header" class="right-ui-header">Why not?</div>
                     <div id="no-reason-options">
-                        <button id="no-button-1" class="disagree-reason-button"></button>
-                        <button id="no-button-2" class="disagree-reason-button"></button>
-                        <button id="no-button-3" class="disagree-reason-button"></button>
+                        <button id="no-button-1" class="validation-reason-button"></button>
+                        <button id="no-button-2" class="validation-reason-button"></button>
+                        <button id="no-button-3" class="validation-reason-button"></button>
                         <div class="input-group input-group-sm validate-text-input">
                             <input type="text" class="form-control" placeholder="Or add your own reason" id="add-disagree-comment" size="36" aria-label="Add no reason input">
                         </div>
@@ -203,8 +203,13 @@
                 </div>
                 <div id="validate-why-unsure-section" class="right-ui-section validate-why-unsure-section">
                     <div id="validate-why-unsure-header" class="right-ui-header">Why 'Unsure'?</div>
-                    <div class="input-group input-group-sm validate-text-input">
-                        <input type="text" class="form-control" placeholder="Add your reason (optional)" id="add-unsure-comment" size="36" aria-label="Add unsure reason input">
+                    <div id="unsure-reason-options">
+                        <button id="unsure-button-1" class="validation-reason-button"></button>
+                        <button id="unsure-button-2" class="validation-reason-button"></button>
+                        <button id="unsure-button-3" class="validation-reason-button"></button>
+                        <div class="input-group input-group-sm validate-text-input">
+                            <input type="text" class="form-control" placeholder="Add your reason (optional)" id="add-unsure-comment" size="36" aria-label="Add unsure reason input">
+                        </div>
                     </div>
                 </div>
                 <div id="validate-submit-section" class="right-ui-section button-section validate-submit-section">

--- a/public/javascripts/SVValidate/src/Main.js
+++ b/public/javascripts/SVValidate/src/Main.js
@@ -79,7 +79,8 @@ function Main (param) {
             svv.ui.newValidateBeta.disagreeReasonOptions = $("#no-reason-options");
             svv.ui.newValidateBeta.disagreeReasonTextBox = $("#add-disagree-comment")
             svv.ui.newValidateBeta.unsureMenu = $("#validate-why-unsure-section");
-            svv.ui.newValidateBeta.unsureComment = $("#add-unsure-comment");
+            svv.ui.newValidateBeta.unsureReasonOptions = $("#unsure-reason-options");
+            svv.ui.newValidateBeta.unsureReasonTextBox = $("#add-unsure-comment");
 
             svv.ui.newValidateBeta.currentTags = $('#current-tags-list')
 

--- a/public/javascripts/SVValidate/src/keyboard/Keyboard.js
+++ b/public/javascripts/SVValidate/src/keyboard/Keyboard.js
@@ -20,7 +20,7 @@ function Keyboard(menuUI) {
     function checkIfTextAreaSelected() {
         if (document.activeElement === menuUI.comment[0] ||
             (svv.newValidateBeta && document.activeElement === svv.ui.newValidateBeta.disagreeReasonTextBox[0]) ||
-            (svv.newValidateBeta && document.activeElement === svv.ui.newValidateBeta.unsureComment[0]) ||
+            (svv.newValidateBeta && document.activeElement === svv.ui.newValidateBeta.unsureReasonTextBox[0]) ||
             (svv.newValidateBeta && document.activeElement === document.getElementById('select-tag-selectized'))) {
             status.addingComment = true
         } else {

--- a/public/javascripts/SVValidate/src/label/Label.js
+++ b/public/javascripts/SVValidate/src/label/Label.js
@@ -46,6 +46,7 @@ function Label(params) {
         newTags: undefined,
         disagreeOption: undefined,
         disagreeReasonTextBox: '',
+        unsureOption: undefined,
         unsureReasonTextBox: '',
         comment: undefined,
         zoom: undefined,

--- a/public/javascripts/SVValidate/src/menu/RightMenu.js
+++ b/public/javascripts/SVValidate/src/menu/RightMenu.js
@@ -141,6 +141,16 @@ function RightMenu(menuUI) {
                 } else {
                     $(reasonButton).css('display', 'none');
                 }
+
+                // Add tooltip if one exists.
+                const tooltipText = i18next.t(`right-ui.unsure-reason.${labelType}.${$(reasonButton).attr('id')}-tooltip`, { defaultValue: null });
+                if (tooltipText) {
+                    $(reasonButton).tooltip(({
+                        placement: 'top',
+                        delay: {"show": 500, "hide": 10},
+                        title: tooltipText
+                    })).tooltip("show").tooltip("hide");
+                }
             }
             menuUI.unsureReasonTextBox.removeClass('chosen');
             menuUI.unsureReasonTextBox.val('');

--- a/public/locales/en/validate.json
+++ b/public/locales/en/validate.json
@@ -141,6 +141,45 @@
                 "no-button-2": "This is a sign with no light to indicate safe crossing",
                 "no-button-3": "This is a pole with no pedestrian signal or button"
             }
+        },
+        "unsure-reason": {
+            "common": {
+                "reason-1": "Need a better image",
+                "reason-2": "Label placement looks incorrect"
+            },
+            "curb-ramp": {
+                "unsure-button-1": "$t(validate:right-ui.unsure-reason.common.reason-1)",
+                "unsure-button-2": "$t(validate:right-ui.unsure-reason.common.reason-2)",
+                "unsure-button-3": "Alley or parking lot entrance"
+            },
+            "no-curb-ramp": {
+                "unsure-button-1": "$t(validate:right-ui.unsure-reason.common.reason-1)",
+                "unsure-button-2": "$t(validate:right-ui.unsure-reason.common.reason-2)",
+                "unsure-button-3": "Not sure if a curb ramp is required"
+            },
+            "obstacle": {
+                "unsure-button-1": "$t(validate:right-ui.unsure-reason.common.reason-1)",
+                "unsure-button-2": "$t(validate:right-ui.unsure-reason.common.reason-2)",
+                "unsure-button-3": "Not sure if sidewalk is wide enough to avoid the obstacle"
+            },
+            "surface-problem": {
+                "unsure-button-1": "$t(validate:right-ui.unsure-reason.common.reason-1)",
+                "unsure-button-2": "$t(validate:right-ui.unsure-reason.common.reason-2)",
+                "unsure-button-3": "Might be too minor to label"
+            },
+            "no-sidewalk": {
+                "unsure-button-1": "$t(validate:right-ui.unsure-reason.common.reason-1)",
+                "unsure-button-2": "$t(validate:right-ui.unsure-reason.common.reason-2)",
+                "unsure-button-3": "Not sure if there should be a sidewalk here"
+            },
+            "crosswalk": {
+                "unsure-button-1": "$t(validate:right-ui.unsure-reason.common.reason-1)",
+                "unsure-button-2": "$t(validate:right-ui.unsure-reason.common.reason-2)"
+            },
+            "signal": {
+                "unsure-button-1": "$t(validate:right-ui.unsure-reason.common.reason-1)",
+                "unsure-button-2": "$t(validate:right-ui.unsure-reason.common.reason-2)"
+            }
         }
     },
     "center-ui": {

--- a/public/locales/en/validate.json
+++ b/public/locales/en/validate.json
@@ -145,39 +145,47 @@
         "unsure-reason": {
             "common": {
                 "reason-1": "Need a better image",
+                "reason-1-tooltip": "This could be because the image is blurry, what's being labeled is too far away, or a different angle is needed",
                 "reason-2": "Label placement looks incorrect"
             },
             "curb-ramp": {
                 "unsure-button-1": "$t(validate:right-ui.unsure-reason.common.reason-1)",
+                "unsure-button-1-tooltip": "$t(validate:right-ui.unsure-reason.common.reason-1-tooltip)",
                 "unsure-button-2": "$t(validate:right-ui.unsure-reason.common.reason-2)",
                 "unsure-button-3": "Alley or parking lot entrance"
             },
             "no-curb-ramp": {
                 "unsure-button-1": "$t(validate:right-ui.unsure-reason.common.reason-1)",
+                "unsure-button-1-tooltip": "$t(validate:right-ui.unsure-reason.common.reason-1-tooltip)",
                 "unsure-button-2": "$t(validate:right-ui.unsure-reason.common.reason-2)",
                 "unsure-button-3": "Not sure if a curb ramp is required"
             },
             "obstacle": {
                 "unsure-button-1": "$t(validate:right-ui.unsure-reason.common.reason-1)",
+                "unsure-button-1-tooltip": "$t(validate:right-ui.unsure-reason.common.reason-1-tooltip)",
                 "unsure-button-2": "$t(validate:right-ui.unsure-reason.common.reason-2)",
                 "unsure-button-3": "Not sure if sidewalk is wide enough to avoid the obstacle"
             },
             "surface-problem": {
                 "unsure-button-1": "$t(validate:right-ui.unsure-reason.common.reason-1)",
+                "unsure-button-1-tooltip": "$t(validate:right-ui.unsure-reason.common.reason-1-tooltip)",
                 "unsure-button-2": "$t(validate:right-ui.unsure-reason.common.reason-2)",
                 "unsure-button-3": "Might be too minor to label"
             },
             "no-sidewalk": {
                 "unsure-button-1": "$t(validate:right-ui.unsure-reason.common.reason-1)",
+                "unsure-button-1-tooltip": "$t(validate:right-ui.unsure-reason.common.reason-1-tooltip)",
                 "unsure-button-2": "$t(validate:right-ui.unsure-reason.common.reason-2)",
                 "unsure-button-3": "Not sure if there should be a sidewalk here"
             },
             "crosswalk": {
                 "unsure-button-1": "$t(validate:right-ui.unsure-reason.common.reason-1)",
+                "unsure-button-1-tooltip": "$t(validate:right-ui.unsure-reason.common.reason-1-tooltip)",
                 "unsure-button-2": "$t(validate:right-ui.unsure-reason.common.reason-2)"
             },
             "signal": {
                 "unsure-button-1": "$t(validate:right-ui.unsure-reason.common.reason-1)",
+                "unsure-button-1-tooltip": "$t(validate:right-ui.unsure-reason.common.reason-1-tooltip)",
                 "unsure-button-2": "$t(validate:right-ui.unsure-reason.common.reason-2)"
             }
         }

--- a/public/stylesheets/newValidateBeta.css
+++ b/public/stylesheets/newValidateBeta.css
@@ -424,14 +424,14 @@
     gap: 20px;  /* This can be used to control the distance between the severity icons. */
 }
 
-#no-reason-options {
+#no-reason-options, #unsure-reason-options {
     display: flex;
     flex-direction: column;
     gap: 10px;
 
 }
 
-.disagree-reason-button {
+.validation-reason-button {
     display: flex;
     width: 295px;
     height: 36px;
@@ -451,10 +451,15 @@
     line-height: normal;
 }
 
-/* Matching style of 'No' button for now. */
-.disagree-reason-button:hover, .disagree-reason-button.chosen {
+/* Matching style of 'No' and 'Unsure' button for now. */
+#no-reason-options .validation-reason-button:hover, #no-reason-options .validation-reason-button.chosen {
     background: #F29173;
     border-color: #F29173;
+    color: white;
+}
+#unsure-reason-options .validation-reason-button:hover, #unsure-reason-options .validation-reason-button.chosen {
+    background: #1A1A1A;
+    border-color: #1A1A1A;
     color: white;
 }
 

--- a/public/stylesheets/newValidateBeta.css
+++ b/public/stylesheets/newValidateBeta.css
@@ -463,6 +463,10 @@
     color: white;
 }
 
+.tooltip {
+    font-size: 11px;
+}
+
 #add-disagree-comment:hover, #add-disagree-comment.chosen {
     border-color: #F29173 !important;
 }


### PR DESCRIPTION
Resolves #3581 

Adds buttons with 'Unsure' reasons to the new Validate page. We can and should iterate on the options that I've added in for now. The options came from Jon and I brainstorming, and looking through reasons that users have manually entered during previous Unsure validations. I'm starting with the following showing up for all label types:
* Need a better image
    * This has an associated tooltip with the text: "This could be because the image is blurry, what's being labeled is too far away, or a different angle is needed"
* Label placement looks incorrect

And then a third option for a few label types:
* Curb Ramp: Alley or parking lot entrance
* Missing Curb Ramp: Not sure if a curb ramp is required
* Obstacle: Not sure if sidewalk is wide enough to avoid the obstacle
* Surface Problem: Might be too minor to label
* No Sidewalk: Not sure if there should be a sidewalk here
* Crosswalk & Pedestrian Signal: None, I couldn't think of any good ones yet!

##### Before/After screenshots (if applicable)
Before
![Screenshot from 2024-07-31 13-47-43](https://github.com/user-attachments/assets/c1f048b5-d708-4d5a-a5fa-cc071e457dba)

After:
Curb Ramp
![Screenshot from 2024-07-31 13-40-15](https://github.com/user-attachments/assets/14aa4cef-0985-4d07-b9fd-3dd77cdd5982)

Tooltip:
![Screenshot from 2024-07-31 13-41-28](https://github.com/user-attachments/assets/b8547b68-84ce-4312-9cda-fc8b43eb85cd)

Missing Curb Ramp
![Screenshot from 2024-07-31 13-41-19](https://github.com/user-attachments/assets/e3ef139a-9430-4979-b761-a8109b744a0b)

Obstacle
![Screenshot from 2024-07-31 13-41-39](https://github.com/user-attachments/assets/9c8ad2e8-1368-4fb5-b0ca-98089993a0b9)

Surface Problem
![Screenshot from 2024-07-31 13-41-56](https://github.com/user-attachments/assets/efa7e563-89d0-4dff-843e-11a6f9e71e56)

No Sidewalk
![Screenshot from 2024-07-31 13-42-13](https://github.com/user-attachments/assets/af2332e8-f79a-4f5f-b666-23fc4194769d)

Crosswalk & Pedestrian Signal
![Screenshot from 2024-07-31 13-39-47](https://github.com/user-attachments/assets/317096b8-31f9-43a7-a3c9-5b6d7fa604ac)

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
- [ ] I've asked for and included translations for any user facing text that was added or modified.
- [x] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure the documentation on [this wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Descriptions-of-Logged-Events) is up to date for the logs you added/updated.
