### PR TITLE
3612 Add keyboard shortcuts to gallery expanded view

### DIFF
--- a/public/javascripts/Gallery/src/cards/CardContainer.js
+++ b/public/javascripts/Gallery/src/cards/CardContainer.js
@@ -92,6 +92,7 @@ function CardContainer(uiCardContainer, initialFilters) {
         sg.ui.cardContainer.holder.on('click', '.static-gallery-image, .additional-count',  (event) => {
             $('.gallery-modal').attr('style', 'display: flex');
             $('.grid-container').css("grid-template-columns", "1fr 5fr");
+            modal.open = true;
             // If the user clicks on the image body in the card, just use the provided id.
             // Otherwise, the user will have clicked on an existing "+n" icon on the card, meaning we need to acquire
             // the cardId from the card-tags DOM element (as well as perform an additional prepend to put the ID in

--- a/public/javascripts/Gallery/src/modal/Modal.js
+++ b/public/javascripts/Gallery/src/modal/Modal.js
@@ -24,6 +24,8 @@ function Modal(uiModal) {
                 $('.gallery-modal').attr('style', 'display: flex');
                 $('.grid-container').css("grid-template-columns", "1fr 5fr");
 
+                self.open = true;
+
                 // Sets/Updates the label being displayed in the expanded modal.
                 updateModalCardByIndex(self.cardIndex);
 
@@ -62,6 +64,7 @@ function Modal(uiModal) {
      * access when populating the fields. It also instantiates the GSV panorama in the specified location of the Modal.
      */
     function _init() {
+        self.open = false;
         self.panoHolder = $('.actual-pano');
         self.tags = $('.gallery-modal-info-tags');
         self.timestamps = $('.gallery-modal-info-timestamps');
@@ -80,7 +83,6 @@ function Modal(uiModal) {
         self.closeButton.click(closeModalAndRemoveCardTransparency);
         self.rightArrow.click(nextLabel);
         self.leftArrow.click(previousLabel);
-        document.addEventListener('keydown', keydownListener, { capture: true });
         self.cardIndex = -1;
         self.validationMenu = new ValidationMenu(null, self.panoHolder, null, self, true);
 
@@ -98,7 +100,7 @@ function Modal(uiModal) {
         }
 
         // Proceed only when the gallery modal is open.
-        if (document.getElementsByClassName("gallery-modal")[0].style.display !== "none") {
+        if (self.open) {
             if (event.code === "ArrowLeft" && !self.leftArrowDisabled) {
                 previousLabel()
             } else if (event.code === "ArrowRight" && !self.rightArrowDisabled) {
@@ -118,6 +120,7 @@ function Modal(uiModal) {
         // Disclaimer: I could be totally wrong lol.
         $('.grid-container').css("grid-template-columns", "none");
         uiModal.hide();
+        self.open = false;
     }
 
     /**
@@ -371,6 +374,8 @@ function Modal(uiModal) {
      * Attach any specific event handlers for modal contents.
       */
     function attachEventHandlers() {
+        // Add key down event listener for keyboard shortcuts.
+        document.addEventListener('keydown', keydownListener, { capture: true });
 
         // GSV custom handles cursor on '.widget-scene' element. We need to be more specific than that to override.
         function handlerViewControlLayerMouseDown(e) {

--- a/public/javascripts/Gallery/src/validation/ValidationMenu.js
+++ b/public/javascripts/Gallery/src/validation/ValidationMenu.js
@@ -135,7 +135,7 @@ function ValidationMenu(refCard, gsvImage, cardProperties, modal, onExpandedView
      */
     function validateOnClickOrKeyPress(newValKey, thumbsClick) {
         return function (e) {
-            // If we aren't just doing what's already been selected, and we have the card properties and modal is open (this last predicate is only necessary if this is the expanded view validation menu).
+            // If we aren't just doing what's already been selected, we have the card properties, and modal is open (this last predicate is only necessary if this is the validation menu for the expanded view).
             if (currSelected !== newValKey && currCardProperties && (!onExpandedView || document.getElementsByClassName("gallery-modal")[0].style.display !== "none")) {
                 let validationOption = classToValidationOption[newValKey];
 

--- a/public/javascripts/Gallery/src/validation/ValidationMenu.js
+++ b/public/javascripts/Gallery/src/validation/ValidationMenu.js
@@ -86,11 +86,18 @@ function ValidationMenu(refCard, gsvImage, cardProperties, modal, onExpandedView
             }
 
             document.addEventListener('keydown', (event) => {
+                // Prevent Google's default panning and moving using arrow keys and WASD.
+                // https://stackoverflow.com/a/66069717/9409728
+                if (['ArrowUp', 'ArrowLeft', 'ArrowDown', 'ArrowRight', 'KeyW', 'KeyA', 'KeyS', 'KeyD'].indexOf(event.code) > -1) {
+                    event.stopPropagation();
+                }
+
                 const action = keyToActionMap[event.key.toLowerCase()];
                 if (action) {
                     action();
                 }
-            });
+            },
+            { capture: true });
         }
 
         validationButtons = {

--- a/public/javascripts/Gallery/src/validation/ValidationMenu.js
+++ b/public/javascripts/Gallery/src/validation/ValidationMenu.js
@@ -143,7 +143,7 @@ function ValidationMenu(refCard, gsvImage, cardProperties, modal, onExpandedView
     function validateOnClickOrKeyPress(newValKey, thumbsClick) {
         return function (e) {
             // If we aren't just doing what's already been selected, we have the card properties, and modal is open (this last predicate is only necessary if this is the validation menu for the expanded view).
-            if (currSelected !== newValKey && currCardProperties && (!onExpandedView || document.getElementsByClassName("gallery-modal")[0].style.display !== "none")) {
+            if (currSelected !== newValKey && currCardProperties && (!onExpandedView || modal.open)) {
                 let validationOption = classToValidationOption[newValKey];
 
                 // Change the look of the card/expanded view to match the new validation.


### PR DESCRIPTION
Resolves #3612

I added keyboard shortcuts to the gallery expanded view (the view when one of the gallery cards/labels is clicked).

Here are the shortcuts I added:

- Left arrow = previous label
- Right arrow = next label
- A or Y = Agree with label
- D or N = Disagree with label
- U = Unsure about label

I also made sure the keybindings for google street view (examples: W, A, S, D, arrow keys) were properly deactivated to avoid interference with the new keyboard shortcuts.

Please don't hesitate to let me know if something needs to be corrected!

##### Video

https://github.com/user-attachments/assets/f2f970fd-fbfb-4526-98fd-f871f66fcb39

##### Testing instructions
1. Go to the gallery. Click any label and this will open the expanded view.
2. Try pressing some keyboard shortcuts (the shortcuts added can be seen in the description of this PR)
3. You can also see that after exiting the expanded view, the keyboard shortcuts shouldn't perform any actions

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.