### PR TITLE
Fix issue in gallery when there's not enough labels to display more than 1 page

### DIFF
--- a/public/javascripts/Gallery/src/cards/CardContainer.js
+++ b/public/javascripts/Gallery/src/cards/CardContainer.js
@@ -84,6 +84,7 @@ function CardContainer(uiCardContainer, initialFilters) {
         // Grab first batch of labels to show.
         fetchLabels(labelTypeIds[currentLabelType], initialLoad, initialFilters.validationOptions, Array.from(loadedLabelIds), initialFilters.neighborhoods, initialFilters.severities, initialFilters.tags, function() {
             currentCards = cardsByType[currentLabelType].copy();
+            lastPage = currentCards.getCards().length <= currentPage * cardsPerPage;
             render();
         });
         // Creates the Modal object in the DOM element currently present.


### PR DESCRIPTION
Resolves #3621

In gallery queries with not enough entries to form more than one page, the gallery system was falsely enabling the next label button and next page button. They should be disabled because there is no next page, and no next label at the end. The issue was that the system did not check if there was enough labels until `updateCardsNewPage` was called. This was fixed by adding a check in the `_init` function.

##### Before/After screenshots (if applicable)

Before:
![image](https://github.com/user-attachments/assets/d44c748e-b0f4-4687-bc5d-ae71c246c67d)
![image](https://github.com/user-attachments/assets/8b8f2653-1b1a-4f5c-96ce-9dbbc35f23b9)

After:
![image](https://github.com/user-attachments/assets/bec46c7f-589a-44b8-af65-b9e1924ecece)
![image](https://github.com/user-attachments/assets/fd651990-6253-42e7-a7e5-c2044b67cc41)

##### Testing instructions
1. Find a query that doesn't have enough entries to make a page
2. Verify that the next page and next label (for the last label on the first page) buttons are disabled.

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've included before/after screenshots above.
