### PR TITLE
CSS zoom disabled on Chrome temporarily

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/Main.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Main.js
@@ -381,7 +381,7 @@ function Main (params) {
 
             // Use CSS zoom to scale the UI for users with high resolution screens.
             // Has only been tested on Chrome and Safari. Firefox doesn't support CSS zoom.
-            if (bowser.chrome || bowser.safari) {
+            if (bowser.safari) {
                 svl.cssZoom = util.scaleUI();
                 window.addEventListener('resize', (e) => { svl.cssZoom = util.scaleUI(); });
             }

--- a/public/javascripts/SVValidate/src/Main.js
+++ b/public/javascripts/SVValidate/src/Main.js
@@ -270,7 +270,7 @@ function Main (param) {
 
         // Use CSS zoom to scale the UI for users with high resolution screens.
         // Has only been tested on Chrome and Safari. Firefox doesn't support CSS zoom.
-        if (!isMobile() && (bowser.chrome || bowser.safari)) {
+        if (!isMobile() && bowser.safari) {
             svv.cssZoom = util.scaleUI();
             window.addEventListener('resize', (e) => { svv.cssZoom = util.scaleUI(); });
         }

--- a/public/javascripts/common/Utilities.js
+++ b/public/javascripts/common/Utilities.js
@@ -171,7 +171,7 @@ util.camelToKebab = camelToKebab;
  */
 function scaleUI() {
     var toolCSSZoom = 100;
-    if (!bowser.chrome && !bowser.safari) return toolCSSZoom; // Only tested for Chrome/Safari so far.
+    if (!bowser.safari) return toolCSSZoom; // Only tested for Chrome/Safari so far.
 
     var toolUI = document.querySelector('.tool-ui');
     var mst = document.querySelector('.mst-content');


### PR DESCRIPTION
#3626 (HOTFIX)

Removes automatic CSS zoom from Explore/Validate on Chrome. Remains enabled on Safari for now.

The way that CSS zoom works has been changed in the latest version of Chrome, breaking our Explore/Validate pages. I have made a bit of progress on getting it working again, but it needs tweaking and then very thorough testing. Given that the Explore page will be essentially broken as users update their browsers, I think it's best to just remove the automatic zoom from Chrome users until we have a fix ready.
