### PR TITLE
Properly truncate long gallery tags in flexbox

### DIFF
--- a/public/javascripts/Gallery/css/cards.css
+++ b/public/javascripts/Gallery/css/cards.css
@@ -149,6 +149,8 @@ with respect to the image holder. This allows the validation menu to be placed o
     width: 100%;
     flex-direction: row;
     flex-wrap: wrap;
+    flex: 1;
+    min-width: 0;
 }
 
 .label-tags-content {

--- a/public/javascripts/Gallery/css/tags.css
+++ b/public/javascripts/Gallery/css/tags.css
@@ -8,6 +8,7 @@
     font-weight: bold;
     padding: 1px 5px;
     color: #2d2a3f;
+    flex: 1;
 }
 
 .not-added {

--- a/public/javascripts/Gallery/css/tags.css
+++ b/public/javascripts/Gallery/css/tags.css
@@ -8,6 +8,9 @@
     font-weight: bold;
     padding: 1px 5px;
     color: #2d2a3f;
+}
+
+.card-tags .thumbnail-tag {
     flex: 1;
 }
 


### PR DESCRIPTION
Resolves #3464

Previously, on the gallery page, long tags were not limited and could overflow out of the card container. Adding CSS to limit the tags to only fill up the rest of the flexbox space fixed this.

##### Before/After screenshots (if applicable)

**Before**
![image](https://github.com/user-attachments/assets/702e77ba-b94b-472b-b894-f23dada7b855)
**After**
![image](https://github.com/user-attachments/assets/48c10ef9-4a31-4eb8-8052-9bdb5228c471)

##### Testing instructions
1. Go to the gallery page
2. Find labels with long tag names
3. Confirm that they're being limited properly

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've included before/after screenshots above.