### PR TITLE
Prevent short gallery tags from taking up too much space

### DIFF
--- a/public/javascripts/Gallery/css/tags.css
+++ b/public/javascripts/Gallery/css/tags.css
@@ -10,10 +10,6 @@
     color: #2d2a3f;
 }
 
-.card-tags .thumbnail-tag {
-    flex: 1;
-}
-
 .not-added {
     background-color: white;
     font-size: .6vw;


### PR DESCRIPTION
Resolves #3636

Short gallery tags were not being displayed properly, and they were taking up too much space. This was fixed by removing the `flex: 1` css property which was never necessary in the first place (I accidently added this in my first PR which fixed long gallery tags). I tested both short and long gallery tags this time.

##### Before/After screenshots (if applicable)
**Before**
![image](https://github.com/user-attachments/assets/87877b68-629c-486e-9697-051e0c96fac2)
**After**
![image](https://github.com/user-attachments/assets/a1ef48f2-17b7-42db-b7cf-fbabe6148973)
##### Testing instructions
1. Go to gallery
2. Find a label with short tags
3. Verify that the short tag is not filling up the whole space, as seen in the before screenshot

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've included before/after screenshots above.
