### PR TITLE
Added an escape sequence to add double quotes after each double quote in the description field of AttributesWithLabels CSV files. 

### DIFF
--- a/app/formats/json/APIFormats.scala
+++ b/app/formats/json/APIFormats.scala
@@ -195,7 +195,7 @@ object APIFormats {
       s"""${LabelPointTable.canvasWidth},${LabelPointTable.canvasHeight},"${l.gsvUrl}",${l.imageLabelDates._1},""" +
       s"${l.imageLabelDates._2},${l.labelSeverity.getOrElse("NA")},${l.labelTemporary}," +
       s"${l.agreeDisagreeUnsureCount._1},${l.agreeDisagreeUnsureCount._2},${l.agreeDisagreeUnsureCount._3}," +
-      s""""[${l.labelTags.mkString(",")}]","${l.labelDescription.getOrElse("NA")}",${l.userId}"""
+      s""""[${l.labelTags.mkString(",")}]","${l.labelDescription.getOrElse("NA").replace("\"", "\"\"")}",${l.userId}"""
   }
 
   def rawLabelMetadataToJSON(l: LabelAllMetadata): JsObject = {


### PR DESCRIPTION
Resolves #3630 

An issue where double quotes in the field description of attributes with labels were not properly escaped, this causes CSV rows to break/extra rows. To solve this I added an escape sequence to add another quote following each double quote. This was suggested by [RFC-4180](https://www.ietf.org/rfc/rfc4180.txt), to test this I used Valentina studio to reproduce the bug by adding a " in a description and then compared the code before and after. 

##### Before/After screenshots (if applicable)
![Screenshot 2024-08-30 at 10 18 07 AM](https://github.com/user-attachments/assets/257fd227-1c56-4ac1-8ac6-dbb03136e48a)
![Screenshot 2024-08-30 at 10 19 47 AM](https://github.com/user-attachments/assets/5e585691-2c01-4e4a-b118-e0bd7ae33f52)
##### Testing instructions
1. 

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [X] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [ ] I've added/updated comments for large or confusing blocks of code.
- [X] I've included before/after screenshots above.
- [ ] I've asked for and included translations for any user facing text that was added or modified.
- [ ] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure the documentation on [this wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Descriptions-of-Logged-Events) is up to date for the logs you added/updated.
- [ ] I've tested on mobile (only needed for validation page).
