### PR TITLE
3618-Routebuilder-Calc Bug Fix

### DIFF
--- a/app/models/street/StreetEdgeTable.scala
+++ b/app/models/street/StreetEdgeTable.scala
@@ -16,6 +16,7 @@ import models.utils.MyPostgresDriver.simple._
 import play.api.cache.Cache
 import play.api.Play.current
 import scala.slick.jdbc.{GetResult, StaticQuery => Q}
+import com.vividsolutions.jts.geom.LineString
 
 case class StreetEdge(streetEdgeId: Int, geom: LineString, x1: Float, y1: Float, x2: Float, y2: Float, wayType: String, deleted: Boolean, timestamp: Option[Timestamp])
 
@@ -356,6 +357,16 @@ object StreetEdgeTable {
   /** Returns the distance of the given street edge. */
   def getStreetEdgeDistance(streetEdgeId: Int): Float = db.withSession { implicit session =>
     streetEdgesWithoutDeleted.filter(_.streetEdgeId === streetEdgeId).groupBy(x => x).map(_._1.geom.transform(26918).length).first
+  }
+
+  /** Returns the coordinates of the given street edge as a string. */
+  def getStreetGeomById(streetEdgeId: Int): String = db.withSession { implicit session =>
+    val geomOption: Option[LineString] = streetEdgesWithoutDeleted
+      .filter(_.streetEdgeId === streetEdgeId)
+      .map(_.geom)
+      .firstOption
+
+    geomOption.map(_.toText).getOrElse("")
   }
 
   def selectStreetsIntersecting(apiType: APIType, bbox: APIBBox): List[StreetEdgeInfo] = db.withSession { implicit session =>

--- a/conf/routes
+++ b/conf/routes
@@ -179,6 +179,7 @@ POST    /singleUserClusteringResults                         @controllers.Attrib
 POST    /multiUserClusteringResults                          @controllers.AttributeController.postMultiUserClusteringResults(key: String, regionId: Int)
 
 # RouteBuilder
+GET     /backendRoute                                        @controllers.RouteBuilderController.backendRoute(street_edge_id: Int)
 POST    /saveRoute                                           @controllers.RouteBuilderController.saveRoute
 
 # Images


### PR DESCRIPTION
Resolves #3618

When you zoom into a street, the coordinates for the selected street are limited to the zoom frame. To fix this, I created a new route which gets coordinates directly from the database and updates it remotely. 

##### Before/After screenshots (if applicable)
## Before
<img width="932" alt="Screenshot 2024-09-09 at 7 09 49 PM" src="https://github.com/user-attachments/assets/cc21a720-7078-489b-9628-69e0610bbc54">
## After
<img width="1321" alt="Screenshot 2024-09-09 at 7 31 04 PM" src="https://github.com/user-attachments/assets/061351ae-a87e-445e-a1de-613567121713">

##### Testing instructions
1. Load routebuilder
2. Find a long street (pref. over 0.3 miles)
3. Zoom in as far as you can and select the street
4. Cancel route
5. Zoom out so the full street is visible and select the street.

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
