### PR TITLE
Adds configs for LA & Mendota, fixes internationalization bug in navbar

### DIFF
--- a/app/models/utils/Configs.scala
+++ b/app/models/utils/Configs.scala
@@ -13,7 +13,7 @@ object Configs {
    * Returns list of info for all cities, including formatted names (in current language), URL, visibility.
    */
   def getAllCityInfo(lang: Lang): List[CityInfo] = {
-    Cache.getOrElse("getAllCityInfo()") {
+    Cache.getOrElse(s"getAllCityInfo($lang)") {
       val currentCityId: String = Play.configuration.getString("city-id").get
       val currentCountryId: String = Play.configuration.getString(s"city-params.country-id.$currentCityId").get
       val envType: String = Play.configuration.getString("environment-type").get

--- a/conf/cityparams.conf
+++ b/conf/cityparams.conf
@@ -27,12 +27,14 @@ city-params {
     "teaneck-nj"
     "walla-walla-wa"
     "st-louis-mo"
+    "la-ca"
   ]
   city-short-name {
     washington-dc = "DC"
     cdmx = "CDMX"
     spgg = "SPGG"
     validation-study = "Val Study"
+    la-ca = "LA"
   }
   state-id {
     newberg-or = "oregon"
@@ -47,6 +49,7 @@ city-params {
     teaneck-nj = "new-jersey"
     walla-walla-wa = "washington"
     st-louis-mo = "missouri"
+    la-ca = "california"
   }
   country-id {
     newberg-or = "usa"
@@ -72,6 +75,7 @@ city-params {
     teaneck-nj = "usa"
     walla-walla-wa = "usa"
     st-louis-mo = "usa"
+    la-ca = "usa"
   }
   status {
     newberg-or = "public"
@@ -97,6 +101,7 @@ city-params {
     teaneck-nj = "public"
     walla-walla-wa = "private"
     st-louis-mo = "public"
+    la-ca = "private"
   }
   launch-date {
     newberg-or = "2019-01-31"
@@ -121,6 +126,7 @@ city-params {
     teaneck-nj = "2023-08-24"
     walla-walla-wa = "2023-10-05"
     st-louis-mo = "2024-4-10"
+    la-ca = "2024-9-16"
   }
   skyline-img = {
     newberg-or = "skyline1.png"
@@ -146,6 +152,7 @@ city-params {
     teaneck-nj = "skyline1.png"
     walla-walla-wa = "skyline1.png"
     st-louis-mo = "skyline1.png"
+    la-ca = "skyline1.png"
   }
   logo-img = {
     newberg-or = "sidewalk-logo.png"
@@ -171,6 +178,7 @@ city-params {
     teaneck-nj = "sidewalk-logo.png"
     walla-walla-wa = "sidewalk-logo.png"
     st-louis-mo = "sidewalk-logo.png"
+    la-ca = "sidewalk-logo.png"
   }
   landing-page-url {
     prod {
@@ -197,6 +205,7 @@ city-params {
       teaneck-nj = "https://sidewalk-teaneck.cs.washington.edu"
       walla-walla-wa = "https://sidewalk-walla-walla.cs.washington.edu"
       st-louis-mo = "https://sidewalk-st-louis.cs.washington.edu"
+      la-ca = "https://sidewalk-la.cs.washington.edu"
     }
     test {
       newberg-or = "https://sidewalk-newberg-test.cs.washington.edu"
@@ -222,6 +231,7 @@ city-params {
       teaneck-nj = "https://sidewalk-teaneck-test.cs.washington.edu"
       walla-walla-wa = "https://sidewalk-walla-walla-test.cs.washington.edu"
       st-louis-mo = "https://sidewalk-st-louis-test.cs.washington.edu"
+      la-ca = "https://sidewalk-la-test.cs.washington.edu"
     }
   }
   google-analytics-4-id {
@@ -249,6 +259,7 @@ city-params {
       teaneck-nj = "G-2RZB03K3HW"
       walla-walla-wa = "G-RGCXF4KYED"
       st-louis-mo = "G-3HL22FM4BS"
+      la-ca = "G-815WLSJ888"
     }
     test {
       newberg-or = "G-P2JPSFFN3H"
@@ -273,6 +284,7 @@ city-params {
       teaneck-nj = "G-611R79E2SJ"
       walla-walla-wa = "G-7BWV5VRENW"
       st-louis-mo = "G-DJMP9QBM0M"
+      la-ca = "G-LJKNZP9DYK"
     }
   }
   // New cities have ony GA 4. Old cities also retain the old GA tracking.

--- a/conf/cityparams.conf
+++ b/conf/cityparams.conf
@@ -28,6 +28,7 @@ city-params {
     "walla-walla-wa"
     "st-louis-mo"
     "la-ca"
+    "mendota-il"
   ]
   city-short-name {
     washington-dc = "DC"
@@ -50,6 +51,7 @@ city-params {
     walla-walla-wa = "washington"
     st-louis-mo = "missouri"
     la-ca = "california"
+    mendota-il = "illinois"
   }
   country-id {
     newberg-or = "usa"
@@ -76,6 +78,7 @@ city-params {
     walla-walla-wa = "usa"
     st-louis-mo = "usa"
     la-ca = "usa"
+    mendota-il = "usa"
   }
   status {
     newberg-or = "public"
@@ -102,6 +105,7 @@ city-params {
     walla-walla-wa = "private"
     st-louis-mo = "public"
     la-ca = "private"
+    mendota-il = "public"
   }
   launch-date {
     newberg-or = "2019-01-31"
@@ -127,6 +131,7 @@ city-params {
     walla-walla-wa = "2023-10-05"
     st-louis-mo = "2024-4-10"
     la-ca = "2024-9-16"
+    mendota-il = "2024-9-16"
   }
   skyline-img = {
     newberg-or = "skyline1.png"
@@ -153,6 +158,7 @@ city-params {
     walla-walla-wa = "skyline1.png"
     st-louis-mo = "skyline1.png"
     la-ca = "skyline1.png"
+    mendota-il = "skyline1.png"
   }
   logo-img = {
     newberg-or = "sidewalk-logo.png"
@@ -179,6 +185,7 @@ city-params {
     walla-walla-wa = "sidewalk-logo.png"
     st-louis-mo = "sidewalk-logo.png"
     la-ca = "sidewalk-logo.png"
+    mendota-il = "sidewalk-logo.png"
   }
   landing-page-url {
     prod {
@@ -206,6 +213,7 @@ city-params {
       walla-walla-wa = "https://sidewalk-walla-walla.cs.washington.edu"
       st-louis-mo = "https://sidewalk-st-louis.cs.washington.edu"
       la-ca = "https://sidewalk-la.cs.washington.edu"
+      mendota-il = "https://sidewalk-mendota.cs.washington.edu"
     }
     test {
       newberg-or = "https://sidewalk-newberg-test.cs.washington.edu"
@@ -232,6 +240,7 @@ city-params {
       walla-walla-wa = "https://sidewalk-walla-walla-test.cs.washington.edu"
       st-louis-mo = "https://sidewalk-st-louis-test.cs.washington.edu"
       la-ca = "https://sidewalk-la-test.cs.washington.edu"
+      mendota-il = "https://sidewalk-mendota-test.cs.washington.edu"
     }
   }
   google-analytics-4-id {
@@ -260,6 +269,7 @@ city-params {
       walla-walla-wa = "G-RGCXF4KYED"
       st-louis-mo = "G-3HL22FM4BS"
       la-ca = "G-815WLSJ888"
+      mendota-il = "G-1CYXWS6195"
     }
     test {
       newberg-or = "G-P2JPSFFN3H"
@@ -285,6 +295,7 @@ city-params {
       walla-walla-wa = "G-7BWV5VRENW"
       st-louis-mo = "G-DJMP9QBM0M"
       la-ca = "G-LJKNZP9DYK"
+      mendota-il = "G-2V84GVCHV4"
     }
   }
   // New cities have ony GA 4. Old cities also retain the old GA tracking.

--- a/conf/evolutions/default/244.sql
+++ b/conf/evolutions/default/244.sql
@@ -1,0 +1,4 @@
+# --- !Ups
+UPDATE mission_type SET mission_type_id = 7 WHERE mission_type = 'labelmapValidation';
+
+# --- !Downs

--- a/conf/messages
+++ b/conf/messages
@@ -29,6 +29,7 @@ city.name.teaneck-nj = Teaneck
 city.name.walla-walla-wa = Walla Walla
 city.name.st-louis-mo = St. Louis
 city.name.la-ca = Los Angeles
+city.name.mendota-il = Mendota
 
 state.name.oregon = Oregon
 state.name.dc = DC

--- a/conf/messages
+++ b/conf/messages
@@ -28,6 +28,7 @@ city.name.burnaby = Burnaby
 city.name.teaneck-nj = Teaneck
 city.name.walla-walla-wa = Walla Walla
 city.name.st-louis-mo = St. Louis
+city.name.la-ca = Los Angeles
 
 state.name.oregon = Oregon
 state.name.dc = DC
@@ -37,6 +38,7 @@ state.name.pennsylvania = Pennsylvania
 state.name.illinois = Illinois
 state.name.new-jersey = New Jersey
 state.name.missouri = Missouri
+state.name.california = California
 
 country.name.usa = USA
 country.name.mexico = Mexico

--- a/conf/messages.de
+++ b/conf/messages.de
@@ -60,6 +60,8 @@ city.name.zurich = Zürich
 city.name.taipei = Taipeh
 city.name.new-taipei-tw = Neu-Taipeh
 
+state.name.california = Kalifornien
+
 country.name.usa = USA
 country.name.mexico = Mexiko
 country.name.netherlands = Niederlande

--- a/conf/messages.es
+++ b/conf/messages.es
@@ -58,7 +58,8 @@ city.state = {0}, {1}
 city.name.cdmx = Ciudad de México
 city.name.zurich = Zúrich
 city.name.new-taipei-tw = Nuevo Taipei
-city.name.st-louis = San Luis
+city.name.st-louis-mo = San Luis
+city.name.la-ca = Los Ángeles
 
 state.name.oregon = Oregón
 state.name.pennsylvania = Pensilvania

--- a/conf/messages.nl
+++ b/conf/messages.nl
@@ -58,12 +58,7 @@ city.state = {0}, {1}
 city.name.cdmx = Mexico Stad
 city.name.new-taipei-tw = Nieuw Taipei
 
-state.name.oregon = Oregon
-state.name.washington = Washington
-state.name.ohio = Ohio
-state.name.pennsylvania = Pennsylvania
-state.name.illinois = Illinois
-state.name.new-jersey = New Jersey
+state.name.california = Californië
 
 country.name.usa = USA
 country.name.netherlands = Nederland

--- a/conf/messages.zh-TW
+++ b/conf/messages.zh-TW
@@ -77,6 +77,7 @@ city.name.teaneck-nj = 提内克
 city.name.walla-walla-wa = 瓦拉瓦拉
 city.name.st-louis-mo = 聖路易
 city.name.la-ca = 洛杉磯
+city.name.mendota-il = 門多塔
 
 state.name.oregon = 奧勒岡州
 state.name.dc = 特區

--- a/conf/messages.zh-TW
+++ b/conf/messages.zh-TW
@@ -75,7 +75,8 @@ city.name.cuenca = 昆卡
 city.name.burnaby = 本拿比
 city.name.teaneck-nj = 提内克
 city.name.walla-walla-wa = 瓦拉瓦拉
-city.name.st-louis = 聖路易
+city.name.st-louis-mo = 聖路易
+city.name.la-ca = 洛杉磯
 
 state.name.oregon = 奧勒岡州
 state.name.dc = 特區
@@ -85,6 +86,7 @@ state.name.pennsylvania = 賓夕法尼亞州
 state.name.illinois = 伊利諾州
 state.name.new-jersey = 紐澤西州
 state.name.missouri = 密蘇裡州
+state.name.california = 加州
 
 country.name.usa = 美國
 country.name.mexico = 墨西哥


### PR DESCRIPTION
Resolves #3644 
Resolves #3648 

Adds configs for the new LA and Mendota, IL servers. I also fixed a bug where city/state/country names weren't being translated correctly due to a caching issue.

I also added a database evolution to fix the `mission_type_id` in our db. This was an issue because of how we wrote our evolutions in the past. It had no impact on any of the code running on our servers, but it would cause problems when trying to manually run queries on the dbs because IDs weren't consistent between cities.

