### PR TITLE
Prevent conflicting tags being added in new Validate

### DIFF
--- a/app/controllers/LabelController.scala
+++ b/app/controllers/LabelController.scala
@@ -47,7 +47,6 @@ class LabelController @Inject() (implicit val env: Environment[User, SessionAuth
             "cameraPitch" -> label.cameraPitch,
             "panoWidth" -> label.panoWidth,
             "panoHeight" -> label.panoHeight,
-            // TODO Simplify this after removing the `tag` table.
             "tagIds" -> label.labelData.tags.flatMap(t => allTags.filter(at => at.tag == t && Some(at.labelTypeId) == LabelTypeTable.labelTypeToId(label.labelType)).map(_.tagId).headOption),
             "severity" -> label.labelData.severity,
             "tutorial" -> label.labelData.tutorial,
@@ -79,7 +78,8 @@ class LabelController @Inject() (implicit val env: Environment[User, SessionAuth
     Future.successful(Ok(JsArray(tags.map { tag => Json.obj(
       "tag_id" -> tag.tagId,
       "label_type" -> LabelTypeTable.labelTypeIdToLabelType(tag.labelTypeId).get,
-      "tag" -> tag.tag
+      "tag" -> tag.tag,
+      "mutually_exclusive_with" -> tag.mutuallyExclusiveWith
     )})))
   }
 }

--- a/app/controllers/TaskController.scala
+++ b/app/controllers/TaskController.scala
@@ -298,7 +298,7 @@ class TaskController @Inject() (implicit val env: Environment[User, SessionAuthe
               // Map tag IDs to their string representations.
               val tagStrings: List[String] = label.tagIds.distinct.flatMap(t => TagTable.selectAllTags.filter(_.tagId == t).map(_.tag).headOption).toList
 
-              LabelTable.update(existingLab.labelId, label.deleted, label.severity, label.temporary, label.description, tagStrings)
+              LabelTable.updateFromExplore(existingLab.labelId, label.deleted, label.severity, label.temporary, label.description, tagStrings)
               existingLab.labelId
             }
           case None =>

--- a/app/formats/json/LabelFormat.scala
+++ b/app/formats/json/LabelFormat.scala
@@ -187,6 +187,7 @@ object LabelFormat {
   implicit val tagWrites: Writes[Tag] = (
     (__ \ "tag_id").write[Int] and
       (__ \ "label_type_id").write[Int] and
-      (__ \ "tag_name").write[String]
+      (__ \ "tag_name").write[String] and
+      (__ \ "mutually_exclusive_with").writeNullable[String]
     )(unlift(Tag.unapply))
 }

--- a/app/models/label/TagTable.scala
+++ b/app/models/label/TagTable.scala
@@ -18,6 +18,8 @@ class TagTable(tagParam: slick.lifted.Tag) extends Table[Tag](tagParam, "tag") {
 
   def labelType: ForeignKeyQuery[LabelTypeTable, LabelType] =
     foreignKey("tag_label_type_id_fkey", labelTypeId, TableQuery[LabelTypeTable])(_.labelTypeId)
+
+  def labelTypeTagUnique: Index = index("tag_label_type_id_tag_unique", (labelTypeId, tag), unique = true)
 }
 
 object TagTable {

--- a/app/models/label/TagTable.scala
+++ b/app/models/label/TagTable.scala
@@ -5,16 +5,17 @@ import models.utils.MyPostgresDriver.simple._
 import play.api.Play.current
 import play.api.cache.Cache
 import scala.concurrent.duration.DurationInt
-import scala.slick.lifted.ForeignKeyQuery
+import scala.slick.lifted.{ForeignKeyQuery, Index}
 
-case class Tag(tagId: Int, labelTypeId: Int, tag: String)
+case class Tag(tagId: Int, labelTypeId: Int, tag: String, mutuallyExclusiveWith: Option[String])
 
 class TagTable(tagParam: slick.lifted.Tag) extends Table[Tag](tagParam, "tag") {
   def tagId: Column[Int] = column[Int]("tag_id", O.PrimaryKey, O.AutoInc)
   def labelTypeId: Column[Int] = column[Int]("label_type_id")
   def tag: Column[String] = column[String]("tag")
+  def mutuallyExclusiveWith: Column[Option[String]] = column[Option[String]]("mutually_exclusive_with")
 
-  def * = (tagId, labelTypeId, tag) <> ((Tag.apply _).tupled, Tag.unapply)
+  def * = (tagId, labelTypeId, tag, mutuallyExclusiveWith) <> ((Tag.apply _).tupled, Tag.unapply)
 
   def labelType: ForeignKeyQuery[LabelTypeTable, LabelType] =
     foreignKey("tag_label_type_id_fkey", labelTypeId, TableQuery[LabelTypeTable])(_.labelTypeId)

--- a/conf/evolutions/default/245.sql
+++ b/conf/evolutions/default/245.sql
@@ -4,6 +4,15 @@ ALTER TABLE tag
     ADD COLUMN mutually_exclusive_with TEXT,
     ADD CONSTRAINT tag_mutually_exclusive_with_self_reference_check CHECK (mutually_exclusive_with IS DISTINCT FROM tag);
 
+UPDATE tag SET mutually_exclusive_with = 'tactile warning' WHERE tag = 'missing tactile warning';
+UPDATE tag SET mutually_exclusive_with = 'missing tactile warning' WHERE tag = 'tactile warning';
+UPDATE tag SET mutually_exclusive_with = 'no alternate route' WHERE tag = 'alternate route present';
+UPDATE tag SET mutually_exclusive_with = 'alternate route present' WHERE tag = 'no alternate route';
+UPDATE tag SET mutually_exclusive_with = 'street has no sidewalks' WHERE tag = 'street has a sidewalk';
+UPDATE tag SET mutually_exclusive_with = 'street has a sidewalk' WHERE tag = 'street has no sidewalks';
+UPDATE tag SET mutually_exclusive_with = 'two buttons' WHERE tag = 'one button';
+UPDATE tag SET mutually_exclusive_with = 'one button' WHERE tag = 'two buttons';
+
 # --- !Downs
 ALTER TABLE tag
     DROP CONSTRAINT IF EXISTS tag_mutually_exclusive_with_self_reference_check,

--- a/conf/evolutions/default/245.sql
+++ b/conf/evolutions/default/245.sql
@@ -1,0 +1,5 @@
+# --- !Ups
+ALTER TABLE tag ADD CONSTRAINT tag_label_type_id_tag_unique UNIQUE (label_type_id, tag);
+
+# --- !Downs
+ALTER TABLE tag DROP CONSTRAINT IF EXISTS tag_label_type_id_tag_unique;

--- a/conf/evolutions/default/245.sql
+++ b/conf/evolutions/default/245.sql
@@ -1,4 +1,5 @@
 # --- !Ups
+-- No mutually exclusive tags exist together in a prod database, so we don't need to clean existing data.
 ALTER TABLE tag
     ADD CONSTRAINT tag_label_type_id_tag_unique UNIQUE (label_type_id, tag),
     ADD COLUMN mutually_exclusive_with TEXT,

--- a/conf/evolutions/default/245.sql
+++ b/conf/evolutions/default/245.sql
@@ -1,5 +1,11 @@
 # --- !Ups
-ALTER TABLE tag ADD CONSTRAINT tag_label_type_id_tag_unique UNIQUE (label_type_id, tag);
+ALTER TABLE tag
+    ADD CONSTRAINT tag_label_type_id_tag_unique UNIQUE (label_type_id, tag),
+    ADD COLUMN mutually_exclusive_with TEXT,
+    ADD CONSTRAINT tag_mutually_exclusive_with_self_reference_check CHECK (mutually_exclusive_with IS DISTINCT FROM tag);
 
 # --- !Downs
-ALTER TABLE tag DROP CONSTRAINT IF EXISTS tag_label_type_id_tag_unique;
+ALTER TABLE tag
+    DROP CONSTRAINT IF EXISTS tag_mutually_exclusive_with_self_reference_check,
+    DROP COLUMN mutually_exclusive_with,
+    DROP CONSTRAINT IF EXISTS tag_label_type_id_tag_unique;

--- a/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
@@ -193,6 +193,7 @@ function ContextMenu (uiContextMenu) {
                 // Adds or removes tag from the label's current list of tags.
                 if (!labelTags.includes(tag.tag_id)) {
                     // Deals with 'no alternate route' and 'alternate route present' being mutually exclusive.
+                    // TODO when redoing context menu, make use of new `mutually_exclusive_with` field in `tag` table.
                     var alternateRoutePresentId = self.labelTags.filter(tag => tag.tag === 'alternate route present')[0].tag_id;
                     var noAlternateRouteId = self.labelTags.filter(tag => tag.tag === 'no alternate route')[0].tag_id;
                     // Automatically deselect one of the tags above if the other one is selected.

--- a/public/javascripts/SVValidate/src/label/Label.js
+++ b/public/javascripts/SVValidate/src/label/Label.js
@@ -130,7 +130,7 @@ function Label(params) {
             if ("tags" in params) {
                 setAuditProperty("tags", params.tags);
                 setProperty("oldTags", params.tags);
-                setProperty("newTags", params.tags);
+                setProperty("newTags", [...params.tags]); // Copy tags to newTags.
             }
             // Properties only used on the Admin version of Validate.
             if ("admin_data" in params && params.admin_data !== null) {

--- a/public/javascripts/SVValidate/src/menu/RightMenu.js
+++ b/public/javascripts/SVValidate/src/menu/RightMenu.js
@@ -51,9 +51,19 @@ function RightMenu(menuUI) {
             sortField: 'popularity', // TODO include data abt frequency of use on this server.
             onFocus: function() { svv.tracker.push('Click=TagSearch'); },
             onItemAdd: function (value, $item) {
+                let currLabel = svv.panorama.getCurrentLabel();
+
+                // If the tag is mutually exclusive with another tag that's been added, remove the other tag.
+                const allTags = svv.tagsByLabelType[currLabel.getAuditProperty('labelType')];
+                const mutuallyExclusiveWith = allTags.find(t => t.tag_name === value).mutually_exclusive_with;
+                const currTags = currLabel.getProperty('newTags');
+                if (currTags.some(t => t === mutuallyExclusiveWith)) {
+                    svv.tracker.push(`TagAutoRemove_Tag="${mutuallyExclusiveWith}"`);
+                    currLabel.setProperty('newTags', currTags.filter(t => t !== mutuallyExclusiveWith));
+                }
                 // New tag added, add to list and rerender.
                 svv.tracker.push(`TagAdd_Tag="${value}"`);
-                svv.panorama.getCurrentLabel().getProperty('newTags').push(value);
+                currLabel.getProperty('newTags').push(value);
                 $tagSelect[0].selectize.clear();
                 $tagSelect[0].selectize.removeOption(value);
                 _renderTags();


### PR DESCRIPTION
Fixes #3635 

Fixes a bug where conflicting tags (like "no alternate route" and "alternate route present") could both be added to a label through the new Validate page. Some more specifics:
* I added a new `mutually_exclusive_with` column to the`tag` table, so that these mutual exclusivity relationships are recorded in the db. This helps us deal with the more programmatically, and I'm hoping that it makes it easier to remember to address them when this comes up again.
* I'm using this new column to check for mutual exclusivity before inserting/updating on the `label` or `label_history` table. If we fail to prevent this issue on the front-end, we'll now log a warning on the back-end and remove both of the mutually exclusive tags before inserting/updating. This way we'll never have conflicting tags in the db, even if we mess up on the front-end.
* Added the front-end fix for the new Validate page so that it works like it does in Explore (choosing 'no alternate route' will now automatically remove 'alternate route present' if it was selected).
* I ran a query on our live databases, and no one has tried to add conflicting tags using the tool, so we don't need to fix any live data. Here's the query I used to check for this:
    ```
    SELECT COUNT(*)
    FROM label
    WHERE ('alternate route present' = ANY(tags) AND 'no alternate route' = ANY(tags))
        OR ('missing tactile warning' = ANY(tags) AND 'tactile warning' = ANY(tags))
        OR ('street has a sidewalk' = ANY(tags) AND 'street has no sidewalks' = ANY(tags))
        OR ('one button' = ANY(tags) AND 'two buttons' = ANY(tags))
    ```
* I also added a `UNIQUE(label_type_id, tag)` constraint to the `tag` table. This wasn't an issue, but it's technically a constraint we had, so figured it was worth updating the db since I was already fixing up this table. Doesn't impact anything right now.


##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure the documentation on [this wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Descriptions-of-Logged-Events) is up to date for the logs you added/updated.
