### PR TITLE
Fixed occasional zoom in/out in validate bug

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/zoom/ZoomControl.js
+++ b/public/javascripts/SVLabel/src/SVLabel/zoom/ZoomControl.js
@@ -256,7 +256,7 @@ function ZoomControl (canvas, mapService, tracker, uiZoomControl) {
 
         // Set the zoom level and change the panorama properties.
         var zoomLevel = undefined;
-        zoomLevelIn = parseInt(zoomLevelIn);
+        zoomLevelIn = Math.round(zoomLevelIn);
         if (zoomLevelIn <= properties.minZoomLevel) {
             zoomLevel = properties.minZoomLevel;
             enableZoomIn();

--- a/public/javascripts/SVValidate/src/zoom/ZoomControl.js
+++ b/public/javascripts/SVValidate/src/zoom/ZoomControl.js
@@ -1,6 +1,5 @@
 /**
- * Handles zooming for the Google StreetView panorama. This is also called by the
- * Keyboard class to deal with zooming via keyboard shortcuts.
+ * Handles zooming for the GSV pano. Also called by the Keyboard class to deal with zooming via keyboard shortcuts.
  * @returns {ZoomControl}
  * @constructor
  */
@@ -12,7 +11,7 @@ function ZoomControl () {
     /**
      * Logs interaction when the zoom in button is clicked.
      */
-    function clickZoomIn () {
+    function clickZoomIn() {
         svv.tracker.push("Click_ZoomIn");
         zoomIn();
     }
@@ -20,17 +19,16 @@ function ZoomControl () {
     /**
      * Logs interaction when the zoom out button is clicked.
      */
-    function clickZoomOut () {
+    function clickZoomOut() {
         svv.tracker.push("Click_ZoomOut");
         zoomOut();
     }
 
     /**
-     * Increases zoom for the Google StreetView Panorama and checks if 'Zoom In' button needs
-     * to be disabled.
+     * Increases zoom for the Google StreetView Panorama and checks if 'Zoom In' button needs to be disabled.
      * Zoom levels: {1, 2, 3}
      */
-    function zoomIn () {
+    function zoomIn() {
         const zoomLevel = Math.round(svv.panorama.getPov().zoom);
         if (zoomLevel <= 2) {
             svv.panorama.setZoom(zoomLevel + 1);
@@ -39,11 +37,10 @@ function ZoomControl () {
     }
 
     /**
-     * Decreases zoom for the Google StreetView Panorama and checks if 'Zoom Out' button needs
-     * to be disabled.
+     * Decreases zoom for the Google StreetView Panorama and checks if 'Zoom Out' button needs to be disabled.
      * Zoom levels: {1, 2, 3}
      */
-    function zoomOut () {
+    function zoomOut() {
         const zoomLevel = Math.round(svv.panorama.getPov().zoom);
         if (zoomLevel >= 2) {
             svv.panorama.setZoom(zoomLevel - 1);

--- a/public/javascripts/SVValidate/src/zoom/ZoomControl.js
+++ b/public/javascripts/SVValidate/src/zoom/ZoomControl.js
@@ -31,10 +31,9 @@ function ZoomControl () {
      * Zoom levels: {1, 2, 3}
      */
     function zoomIn () {
-        let zoomLevel = Math.round(svv.panorama.getPov().zoom);
+        const zoomLevel = Math.round(svv.panorama.getPov().zoom);
         if (zoomLevel <= 2) {
-            zoomLevel += 1;
-            svv.panorama.setZoom(zoomLevel);
+            svv.panorama.setZoom(zoomLevel + 1);
         }
         updateZoomAvailability();
     }
@@ -45,10 +44,9 @@ function ZoomControl () {
      * Zoom levels: {1, 2, 3}
      */
     function zoomOut () {
-        let zoomLevel = Math.round(svv.panorama.getPov().zoom);
+        const zoomLevel = Math.round(svv.panorama.getPov().zoom);
         if (zoomLevel >= 2) {
-            zoomLevel -= 1;
-            svv.panorama.setZoom(zoomLevel);
+            svv.panorama.setZoom(zoomLevel - 1);
         }
         updateZoomAvailability();
     }

--- a/public/javascripts/SVValidate/src/zoom/ZoomControl.js
+++ b/public/javascripts/SVValidate/src/zoom/ZoomControl.js
@@ -31,7 +31,7 @@ function ZoomControl () {
      * Zoom levels: {1, 2, 3}
      */
     function zoomIn () {
-        let zoomLevel = svv.panorama.getPov().zoom;
+        let zoomLevel = Math.round(svv.panorama.getPov().zoom);
         if (zoomLevel <= 2) {
             zoomLevel += 1;
             svv.panorama.setZoom(zoomLevel);
@@ -45,7 +45,7 @@ function ZoomControl () {
      * Zoom levels: {1, 2, 3}
      */
     function zoomOut () {
-        let zoomLevel = svv.panorama.getPov().zoom;
+        let zoomLevel = Math.round(svv.panorama.getPov().zoom);
         if (zoomLevel >= 2) {
             zoomLevel -= 1;
             svv.panorama.setZoom(zoomLevel);


### PR DESCRIPTION
Resolves #3646 

As suggested in the issue, I changed the zoomLevel variables in the zoomControl in validate to wrap them with Math.round() so that they were rounded to the appropriate decimal value. I also went into the zoomControl in explore and looked through the commit history to see why we were doing parseInt(zoomLevelIn), and I found that it's been like that since the very first commit where no reasoning was provided. So I went ahead and changed that to a Math.round as well. 

##### Before/After screenshots (if applicable)
Before (couldn't zoom sometimes even if the button wasn't grayed out)
![image](https://github.com/user-attachments/assets/f0e18e66-e5b1-4ec1-ba8a-6068d8038aa9)

After (can always zoom until the button is grayed out)
![image](https://github.com/user-attachments/assets/eca157f2-9657-4f67-9e13-9fc854be3aa9)

##### Testing instructions
I was able to reproduce this issue, albeit occasionally, whenever I went through validate and kept zooming in and zooming out. The exact way I tested this was by going through 4 different validate missions and for each new frame, zooming in and zooming out, making sure that the three zoom levels showed up & the buttons worked every time they were not grayed out.

I also added console.log() statements to print out the original svv.panorama.getPov().zoom & verified that whenever it printed out a decimal (like 1.99999996), we still were able to get the three zoom levels because of the rounding.

1. Go to validate 
2. Click through frames doing the process described above
3. Repeat for 4-5 missions

##### Things to check before submitting the PR
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
