### PR TITLE
Now only importing onnxruntime on crowdstudy server

### DIFF
--- a/app/views/explore.scala.html
+++ b/app/views/explore.scala.html
@@ -20,7 +20,9 @@
     <link rel="stylesheet" href='@routes.Assets.at("javascripts/SVLabel/build/SVLabel.css")'/>
     <link rel="stylesheet" href='@routes.Assets.at("stylesheets/animate.css")'/>
 
-    <script src="https://cdn.jsdelivr.net/npm/onnxruntime-web/dist/ort.min.js"></script>
+    @if(currentCity.cityId == "crowdstudy") {
+        <script src="https://cdn.jsdelivr.net/npm/onnxruntime-web/dist/ort.min.js"></script>
+    }
 
     <script>
         // Setup necessary for saving crops of GSV. We don't want to cause issues if this fails.


### PR DESCRIPTION
I recently noticed that we are importing the onnxruntime lib that we used for LabelAId through a CDN no matter what. It's a pretty big lib and was taking like 100ms to load. No need to do this anywhere but the crowdstudy server right now. Should speed up page load slightly.
