### PR TITLE
Updated Admin sign in statistics to account for new sign up/sign in logging values

### DIFF
--- a/app/models/daos/slick/UserDAOSlick.scala
+++ b/app/models/daos/slick/UserDAOSlick.scala
@@ -493,7 +493,7 @@ object UserDAOSlick {
 
     // Map(user_id: String -> (most_recent_sign_in_time: Option[Timestamp], sign_in_count: Int)).
     val signInTimesAndCounts =
-      WebpageActivityTable.activities.filter(_.activity inSet List("AnonAutoSignUp", "SignIn"))
+      WebpageActivityTable.activities.filter(row => row.activity === "AnonAutoSignUp" || (row.activity like "SignIn%"))
         .groupBy(_.userId).map{ case (_userId, group) => (_userId, group.map(_.timestamp).max, group.length) }
         .list.map{ case (_userId, _time, _count) => (_userId, (_time, _count)) }.toMap
 

--- a/app/models/user/WebpageActivityTable.scala
+++ b/app/models/user/WebpageActivityTable.scala
@@ -46,7 +46,7 @@ object WebpageActivityTable {
     */
   def selectAllSignInCounts: List[(String, String, Int)] = db.withTransaction { implicit session =>
     val signIns = for {
-      _activity <- activities if _activity.activity === "SignIn"
+      _activity <- activities if _activity.activity like "SignIn%"
       _userRole <- userRoles if _activity.userId === _userRole.userId
       _role <- roles if _userRole.roleId === _role.roleId
       if _role.role =!= "Anonymous"


### PR DESCRIPTION
Resolves #3664

Updated queries in admin view statistics (last login date in Users tab, logins per user in Analytics) to account for "SignInSuccessEmail=" which was introduced as new logging values. 

##### Before/After screenshots
Before
<img width="1118" alt="image" src="https://github.com/user-attachments/assets/5e4abf3d-1663-40d8-8997-bd7f40580ff6">

<img width="781" alt="image" src="https://github.com/user-attachments/assets/b85bec6f-c409-45e6-9bb0-613904e99f9c">

After
<img width="1077" alt="image" src="https://github.com/user-attachments/assets/5e6904c8-47d8-452e-a490-98400bb0ced2">

<img width="787" alt="image" src="https://github.com/user-attachments/assets/acb9fe7b-50ed-4d4e-b6a8-92163c8065ee">


##### Testing instructions
1. Login to your account
2. Sign out of your account
3. Login to your account
4. Go to Admin view and check "last login" date of your alias in "Users" tab
5. Go to Admin view and check "logins per user" graph in "Analytics" tab

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [ ] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [ ] I've added/updated comments for large or confusing blocks of code.
- [ ] I've included before/after screenshots above.

