### PR TITLE
Updated make file to deal with Docker Compose Compatibility Issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,18 +23,28 @@ lint:
 lint-fix:
 	@make lint-fix-eslint; make lint-fix-stylelint
 
+#Duplicating compose commands to deal with compability issues for Mac users.
 docker-up:
 	@docker-compose up -d
+docker-up-mac:
+	@docker compose up -d
 
 docker-up-db:
 	@docker-compose up -d db
+docker-up-db-mac:
+	@docker compose up -d db
 
 docker-stop:
 	@docker-compose stop
 	@docker-compose rm -f
+docker-stop-mac:
+	@docker compose stop
+	@docker compose rm -f
 
 docker-run:
 	@docker-compose run --rm --service-ports --name projectsidewalk-web web /bin/bash
+docker-run-mac:
+	@docker compose run --rm --service-ports --name projectsidewalk-web web /bin/bash
 
 ssh:
 	@docker exec -it projectsidewalk-$${target} /bin/bash


### PR DESCRIPTION
Resolves #3623 

Docker compose command (with the dash) has been depreciated for mac users. To fix, per Mikey's proposed solution, I simply added a 2nd version of docker compose files to the make file to address mac users and correct the compose command used. 

##### Before/After screenshots (if applicable)
N/A

##### Testing instructions
N/A

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
- [x] I've asked for and included translations for any user facing text that was added or modified.
- [x] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure the documentation on [this wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Descriptions-of-Logged-Events) is up to date for the logs you added/updated.
- [x] I've tested on mobile (only needed for validation page).
