### PR TITLE
Ensures that zoom is always set to an integer value on Explore page

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/keyboard/Keyboard.js
+++ b/public/javascripts/SVLabel/src/SVLabel/keyboard/Keyboard.js
@@ -94,11 +94,11 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
 
     /**
      * Change the heading of the current panorama point of view by a particular degree value.
-     * TODO Change the method name so it is more descriptive.
+     *
      * @param degree
      */
-    this._rotatePov = function (degree){
-        if (!svl.map.getStatus("disablePanning")){
+    this._rotatePovByDegree = function(degree) {
+        if (!svl.map.getStatus("disablePanning")) {
             svl.contextMenu.hide();
             // Panning hide label tag and delete icon.
             var labels = svl.labelContainer.getCanvasLabels(),
@@ -116,7 +116,7 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
                 pitch: pitch,
                 zoom: zoom
             });
-            svl.panorama.setPov({heading: pov.heading, pitch: pov.pitch, zoom: pov.zoom});
+            svl.map.setPov({heading: pov.heading, pitch: pov.pitch, zoom: pov.zoom});
         }
     };
 
@@ -157,10 +157,10 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
             } else {
                 switch (e.keyCode) {
                     case 37:  // "ArrowLeft"
-                        self._rotatePov(-2);
+                        self._rotatePovByDegree(-2);
                         break;
                     case 39:  // "ArrowRight"
-                        self._rotatePov(2);
+                        self._rotatePovByDegree(2);
                         break;
                 }
                 if (!status.disableMovement) {

--- a/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
+++ b/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
@@ -459,7 +459,7 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
             var pov = svl.panorama.getPov();
 
             // Make sure that zoom is set to an integer.
-            // pov.zoom = Math.round(pov.zoom);
+            pov.zoom = Math.round(pov.zoom);
 
             // Adjust heading to be between 0 and 360 instead of -180 to 180.
             while (pov.heading < 0) {

--- a/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
+++ b/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
@@ -458,12 +458,13 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
         if ("panorama" in svl) {
             var pov = svl.panorama.getPov();
 
-            // Pov can be less than 0. So adjust it.
+            // Make sure that zoom is set to an integer.
+            // pov.zoom = Math.round(pov.zoom);
+
+            // Adjust heading to be between 0 and 360 instead of -180 to 180.
             while (pov.heading < 0) {
                 pov.heading += 360;
             }
-
-            // Pov can be more than 360. Adjust it.
             while (pov.heading > 360) {
                 pov.heading -= 360;
             }
@@ -1212,7 +1213,7 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
      */
     function updatePov(dx, dy) {
         if (svl.panorama) {
-            var pov = svl.panorama.getPov();
+            var pov = getPov();
             var alpha = 0.25;
             pov.heading -= alpha * dx;
             pov.pitch += alpha * dy;
@@ -1251,8 +1252,11 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
      */
     function setPov(pov, durationMs, callback) {
         if (('panorama' in svl) && svl.panorama) {
-            var currentPov = svl.panorama.getPov();
+            var currentPov = getPov();
             var interval;
+
+            // Make sure that zoom is set to an integer value.
+            if (pov.zoom) pov.zoom = Math.round(pov.zoom);
 
             // Pov restriction.
             restrictViewPort(pov);
@@ -1445,7 +1449,7 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
     }
 
     function setZoom(zoomLevel) {
-        svl.panorama.setZoom(zoomLevel);
+        svl.panorama.setZoom(Math.round(zoomLevel));
     }
 
     // Set a flag that triggers the POV being reset into the route direction upon the position changing.
@@ -1455,9 +1459,9 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
 
     // Set the POV in the same direction as the route.
     function setPovToRouteDirection(durationMs) {
-        var pov = svl.panorama.getPov();
+        var pov = getPov();
         var newPov = {
-            heading: parseInt(svl.compass.getTargetAngle() + 360, 10) % 360,
+            heading: Math.round(svl.compass.getTargetAngle() + 360) % 360,
             pitch: pov.pitch,
             zoom: pov.zoom
         }


### PR DESCRIPTION
Partially addresses #2478 

Ensures that the zoom level is always recorded as integer value, and the _correct_integer value on the Explore page. Zoom values like 1.999 and 0.999 were being used on the front end, then were being automatically truncated to values of 1 or 0 when being sent to the back end. We now make sure to round those values consistently!

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
