### PR TITLE
Bug Fix for expanded view going out of view when current expanded card is clicked again

### DIFF
--- a/public/javascripts/Gallery/src/cards/CardContainer.js
+++ b/public/javascripts/Gallery/src/cards/CardContainer.js
@@ -91,7 +91,7 @@ function CardContainer(uiCardContainer, initialFilters) {
         expandedView = new ExpandedView($('.gallery-expanded-view'));
         // Add the click event for opening the ExpandedView when a card is clicked.
         sg.ui.cardContainer.holder.on('click', '.static-gallery-image, .additional-count', (event) => {
-            $('.gallery-expanded-view').attr('style', 'display: flex');
+            $('.gallery-expanded-view').css('display', 'flex');
             $('.grid-container').css("grid-template-columns", "1fr 5fr");
             // If the user clicks on the image body in the card, just use the provided id.
             // Otherwise, the user will have clicked on an existing "+n" icon on the card, meaning we need to acquire


### PR DESCRIPTION
Resolves #3674

Fixed bug that caused the expanded view of a card to go out of view in Gallery view when the currently expanded card is clicked on again. 

##### Before:

You click once on the card you want the expanded view of to get the following display.

<img width="1224" alt="image" src="https://github.com/user-attachments/assets/2faf7834-a54c-455e-8ce7-5879e32a8eca">

If you click on the same card again through the side bar in expanded view, the expanded view shifts up the page so it is out of view. The higher the index of the card on the current page, the more the expanded view shifts. Image 1 is card 2 on the page and image 2 is card 3 on the page.

<img width="1259" alt="image" src="https://github.com/user-attachments/assets/1ca92118-ed6b-4a91-9d7f-54b9d70aeecf">
<img width="1234" alt="image" src="https://github.com/user-attachments/assets/865565ad-a6bd-4de0-8fdb-93d525311935">

##### After:

You click once on the card you want the expanded view of to get the following display.

<img width="1225" alt="image" src="https://github.com/user-attachments/assets/4d243459-ee5a-464f-8c27-3aff4a714ea4">

If you click on the currently expanded card again, the expanded view remains unaffected.

<img width="1225" alt="image" src="https://github.com/user-attachments/assets/2aa6f417-8628-4d23-a877-0c10614babe4">

##### Testing instructions
1. Start local instance
2. Click into Gallery view
3. Click on any card on the page to open expanded view
4. Click on the currently expanded card in the left side bar. Its expanded view shouldn't move on the page.

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've included before/after screenshots above.
