### PR TITLE
Fixed Neighborhood Complete Screen Rendering Early

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/navigation/Compass.js
+++ b/public/javascripts/SVLabel/src/SVLabel/navigation/Compass.js
@@ -76,6 +76,7 @@ function Compass (svl, mapService, taskContainer, uiCompass) {
         mapService.preparePovReset();
         mapService.setPosition(coordinate.lat, coordinate.lng);
         mapService.setPovToRouteDirection();
+        svl.taskContainer.showNeighborhoodCompleteOverlayIfRequired();
     }
 
     function enableCompassClick() {

--- a/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
+++ b/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
@@ -661,8 +661,7 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
      * @private
      */
     function _endTheCurrentTask(task, mission) {
-
-        if (!status.labelBeforeJumpListenerSet) {
+        if (!status.labelBeforeJumpListenerSet) { 
             missionJump = mission;
             var nextTask = svl.taskContainer.nextTask(task);
 
@@ -673,7 +672,8 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
 
             // Check if the user will jump to another discontinuous location or if this is the last street in their
             // route/neighborhood. If either is the case, let the user know to label the location before proceeding.
-            if (svl.neighborhoodModel.isRouteOrNeighborhoodComplete() || !task.isConnectedTo(nextTask)) {
+            if (svl.neighborhoodModel.isRouteOrNeighborhoodComplete() || (!task.isConnectedTo(nextTask) 
+                    && !svl.taskContainer.isLastIncompleteTaskInNeighborhood(task))) {
                 // If jumping to a new place, set the newTask before jumping.
                 if (nextTask && !task.isConnectedTo(nextTask)) {
                     nextTask.eraseFromMinimap();
@@ -690,6 +690,11 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
                         "pano_changed", trackBeforeJumpActions);
                 } catch (err) {}
             } else {
+                // As soon as we jump to the next task, we'll show the neighborhood complete overlay
+                if (svl.taskContainer.isLastIncompleteTaskInNeighborhood(task)) {
+                    svl.taskContainer.setShowNeighborhoodCompleteOverlayStatus(true);
+                }
+
                 finishCurrentTaskBeforeJumping(missionJump, nextTask);
 
                 // Move to the new task if the route/neighborhood has not finished.
@@ -794,7 +799,7 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
                 svl.compass.update();
             }
             if (!isOnboarding && "taskContainer" in svl && svl.taskContainer.tasksLoaded()) {
-
+                svl.taskContainer.showNeighborhoodCompleteOverlayIfRequired();
                 // End of the task if the user is close enough to the end point and we aren't in the tutorial.
                 var task = svl.taskContainer.getCurrentTask();
                 if (!isOnboarding && task && task.isAtEnd(position.lat(), position.lng(), END_OF_STREET_THRESHOLD)) {
@@ -1497,7 +1502,7 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
     self.restrictViewPort = restrictViewPort;
     self.setBeforeJumpLocation = setBeforeJumpLocation;
     self.setHeadingRange = setHeadingRange;
-    self.setLabelBeforeJumpListenerStatus = setLabelBeforeJumpListenerStatus;
+    self.setLabelBeforeJumpListenerStatus = setLabelBeforeJumpListenerStatus; 
     self.setPano = setPano;
     self.setPosition = setPosition;
     self.setPositionByIdAndLatLng = setPositionByIdAndLatLng;

--- a/public/javascripts/SVLabel/src/SVLabel/task/TaskContainer.js
+++ b/public/javascripts/SVLabel/src/SVLabel/task/TaskContainer.js
@@ -18,12 +18,14 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
     var tasksFinishedLoading = false;
 
     self._tasks = [];
+    self._showNeighborhoodCompleteOverlayStatus = false;
 
     self.tasksLoaded = function() {
         return tasksFinishedLoading;
     }
 
     self.getFinishedAndInitNextTask = function (finished) {
+        self.showNeighborhoodCompleteOverlayIfRequired();
         var newTask = self.nextTask(finished);
         if (!newTask) {
             svl.neighborhoodModel.setComplete();
@@ -335,6 +337,7 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
 
     /**
      * Checks if finishedTask makes the neighborhood complete across all users; if so, it displays the relevant overlay.
+     * UPDATE: THIS FUNCTION IS NOW UNUSED
      *
      * @param finishedTask
      */
@@ -378,10 +381,6 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
      */
     this.nextTask = function (finishedTask) {
         var newTask;
-
-        // Check if this task finishes the neighborhood across all users, if so, shows neighborhood complete overlay.
-        updateNeighborhoodCompleteAcrossAllUsersStatus(finishedTask);
-
         // Check if user has audited entire region or route.
         var tasksNotCompletedByUser = self.getTasks().filter(function (t) {
             return !t.isComplete() && t.getStreetEdgeId() !== (finishedTask ? finishedTask.getStreetEdgeId() : null);
@@ -451,6 +450,19 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
     };
 
     /**
+     * Check if a task is the last incomplete task in the neighborhood.
+     * @param task
+     */
+    function isLastIncompleteTaskInNeighborhood(task) { 
+        // If this is the last incomplete task in the neighborhood, it should be the only task in the 
+        // incompleteTasksAcrossAllUsers list and should have priority = 1.
+        var incompleteTasksAcrossAllUsers = self.getIncompleteTasksAcrossAllUsersUsingPriority();
+        return incompleteTasksAcrossAllUsers.length === 1 && 
+            incompleteTasksAcrossAllUsers[0].getStreetEdgeId() === task.getStreetEdgeId() && 
+            task.getProperty('priority') === 1; 
+    }
+
+    /**
      * Push a task to previousTasks
      * @param task
      */
@@ -490,6 +502,33 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
             svl.form.submitData(currentTask);
         }
     };
+
+    /**
+     * Display the neighborhood complete overlay if state permits it to be shown.
+     * Reset the corresponding state afterwards.
+     */
+    this.showNeighborhoodCompleteOverlayIfRequired = function () {
+        if (self.getShowNeighborhoodCompleteOverlayStatus()) {
+            neighborhoodModel.setNeighborhoodCompleteAcrossAllUsers();
+            svl.ui.areaComplete.overlay.show();
+        }
+        self.setShowNeighborhoodCompleteOverlayStatus(false);
+    }
+
+    /**
+     * Get the show neighborhood overlay status boolean.
+     */
+    this.getShowNeighborhoodCompleteOverlayStatus = function () {
+        return self._showNeighborhoodCompleteOverlayStatus;
+    }
+
+    /**
+     * Set the show neighborhood overlay status boolean to a given value.
+     * @param value
+     */
+    this.setShowNeighborhoodCompleteOverlayStatus = function (value) {
+        self._showNeighborhoodCompleteOverlayStatus = value;
+    }
 
     /**
      * Get the street id of the current task.
@@ -577,6 +616,7 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
     self.getAfterJumpNewTask = getAfterJumpNewTask;
     self.isFirstTask = isFirstTask;
     self.length = length;
+    self.isLastIncompleteTaskInNeighborhood = isLastIncompleteTaskInNeighborhood;
     self.push = pushATask;
     self.renderAllTasks = renderAllTasks;
     self.hasMaxPriorityTask = hasMaxPriorityTask;

--- a/public/javascripts/SVLabel/src/SVLabel/task/TaskContainer.js
+++ b/public/javascripts/SVLabel/src/SVLabel/task/TaskContainer.js
@@ -511,6 +511,7 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
         if (self.getShowNeighborhoodCompleteOverlayStatus()) {
             neighborhoodModel.setNeighborhoodCompleteAcrossAllUsers();
             svl.ui.areaComplete.overlay.show();
+            tracker.push("NeighborhoodComplete_AcrossAllUsers", { 'RegionId': currentNeighborhood.getRegionId() });
         }
         self.setShowNeighborhoodCompleteOverlayStatus(false);
     }


### PR DESCRIPTION
Resolves #3680 

In this PR, I added some logic to see if we were on the very last un-audited street in a neighborhood, and made sure to show the neighborhood complete screen after that street finishes. I also added logic to delay the display of that overlay to the point where the user jumps to a new street after completing a neighborhood. This necessitated a number of small changes in TaskContainer & MapService, including the addition of a new flag field (to log the fact that we need to display the overlay) that is toggled on when the neighborhood is finished, and turned back off when the overlay is displayed. 

Since the code for what jumps happen after a neighborhood is finished is pretty complex & there are a number of different methods that could handle it on a case-by case basis, I made sure to call the new function that conditionally renders the overlay in a few different places so we don't miss out on a case where a neighborhood is complete and the overlay needs to be rendered. 

Also, in order to do this, I had to make it so that the old function that was in charge of rendering the overlay is not used anymore, but as of now I left the code in there just because I'm a little iffy on deleting it without a review!

##### Testing instructions
1. Open up any 99% neighborhood from the landing page choropleth
2. Keep clicking through streets until you reach the very last one (can check if a street as previously been audited if it's priority != 1)
3. Verify that after that street is completed by the user, the overlay displays
4. Repeat steps 1 - 4 for any other neighborhood's you'd like (in my testing I went through all the 99% ones and called it good)


##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure the documentation on [this wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Descriptions-of-Logged-Events) is up to date for the logs you added/updated.