### PR TITLE
Adds button to view data for a route in LabelMap

### DIFF
--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -108,7 +108,7 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
    */
   def getAllLabels = UserAwareAction.async { implicit request =>
     if (isAdmin(request.identity)) {
-      val labels = LabelTable.selectLocationsAndSeveritiesOfLabels(List())
+      val labels = LabelTable.selectLocationsAndSeveritiesOfLabels(List(), List())
       val features: List[JsObject] = labels.par.map { label =>
         val point = geojson.Point(geojson.LatLng(label.lat.toDouble, label.lng.toDouble))
         val properties = Json.obj(
@@ -131,9 +131,10 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
   /**
    * Get a list of all labels with metadata needed for /labelMap.
    */
-  def getAllLabelsForLabelMap(regions: Option[String]) = UserAwareAction.async { implicit request =>
+  def getAllLabelsForLabelMap(regions: Option[String], routes: Option[String]) = UserAwareAction.async { implicit request =>
     val regionIds: List[Int] = regions.map(parseIntegerList).getOrElse(List())
-    val labels: List[LabelLocationWithSeverity] = LabelTable.selectLocationsAndSeveritiesOfLabels(regionIds)
+    val routeIds: List[Int] = routes.map(parseIntegerList).getOrElse(List())
+    val labels: List[LabelLocationWithSeverity] = LabelTable.selectLocationsAndSeveritiesOfLabels(regionIds, routeIds)
     val features: List[JsObject] = labels.par.map { label =>
       val point: Point[LatLng] = geojson.Point(geojson.LatLng(label.lat.toDouble, label.lng.toDouble))
       val properties: JsObject = Json.obj(

--- a/app/controllers/ApplicationController.scala
+++ b/app/controllers/ApplicationController.scala
@@ -348,10 +348,12 @@ class ApplicationController @Inject() (implicit val env: Environment[User, Sessi
   }
 
   /**
-   * Returns the labelmap page that contains a cool visualization.
+   * Returns the LabelMap page that contains a cool visualization.
    */
-  def labelMap(regions: Option[String]) = UserAwareAction.async { implicit request =>
+  def labelMap(regions: Option[String], routes: Option[String]) = UserAwareAction.async { implicit request =>
+    // TODO what do we do if the route doesn't exist?
     val regionIds: List[Int] = regions.map(parseIntegerList).getOrElse(List())
+    val routeIds: List[Int] = routes.map(parseIntegerList).getOrElse(List())
     request.identity match {
       case Some(user) =>
         val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
@@ -359,8 +361,9 @@ class ApplicationController @Inject() (implicit val env: Environment[User, Sessi
 
         val activityStr: String = if (regions.isEmpty) "Visit_LabelMap" else s"Visit_LabelMap_Regions=$regions"
         WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, activityStr, timestamp))
-        Future.successful(Ok(views.html.labelMap("Sidewalk - LabelMap", Some(user), regionIds)))
+        Future.successful(Ok(views.html.labelMap("Sidewalk - LabelMap", Some(user), regionIds, routeIds)))
       case None =>
+        // TODO include routeId query param in redirect for anon users.
         // UTF-8 codes needed to pass a URL that contains parameters: ? is %3F, & is %26
         val queryParams: String = regions.map(r => s"%3Fregions=$r").getOrElse("")
         Future.successful(Redirect("/anonSignUp?url=/labelmap" + queryParams))

--- a/app/controllers/ApplicationController.scala
+++ b/app/controllers/ApplicationController.scala
@@ -351,7 +351,6 @@ class ApplicationController @Inject() (implicit val env: Environment[User, Sessi
    * Returns the LabelMap page that contains a cool visualization.
    */
   def labelMap(regions: Option[String], routes: Option[String]) = UserAwareAction.async { implicit request =>
-    // TODO what do we do if the route doesn't exist?
     val regionIds: List[Int] = regions.map(parseIntegerList).getOrElse(List())
     val routeIds: List[Int] = routes.map(parseIntegerList).getOrElse(List())
     request.identity match {
@@ -363,9 +362,13 @@ class ApplicationController @Inject() (implicit val env: Environment[User, Sessi
         WebpageActivityTable.save(WebpageActivity(0, user.userId.toString, ipAddress, activityStr, timestamp))
         Future.successful(Ok(views.html.labelMap("Sidewalk - LabelMap", Some(user), regionIds, routeIds)))
       case None =>
-        // TODO include routeId query param in redirect for anon users.
         // UTF-8 codes needed to pass a URL that contains parameters: ? is %3F, & is %26
-        val queryParams: String = regions.map(r => s"%3Fregions=$r").getOrElse("")
+        val queryParams: String = (regionIds, routeIds) match {
+          case (Nil, Nil) => ""
+          case (r, Nil) => s"%3Fregions=${r.mkString(",")}"
+          case (Nil, r) => s"%3Froutes=${r.mkString(",")}"
+          case (r, s) => s"%3Fregions=${r.mkString(",")}%26routes=${s.mkString(",")}"
+        }
         Future.successful(Redirect("/anonSignUp?url=/labelmap" + queryParams))
     }
   }

--- a/app/controllers/UserProfileController.scala
+++ b/app/controllers/UserProfileController.scala
@@ -78,9 +78,10 @@ class UserProfileController @Inject() (implicit val env: Environment[User, Sessi
   /**
    * Get the list of all streets and whether they have been audited or not, regardless of user.
    */
-  def getAllStreets(filterLowQuality: Boolean, regions: Option[String]) = UserAwareAction.async { implicit request =>
+  def getAllStreets(filterLowQuality: Boolean, regions: Option[String], routes: Option[String]) = UserAwareAction.async { implicit request =>
     val regionIds: List[Int] = regions.map(parseIntegerList).getOrElse(List())
-    val streets: List[StreetEdgeWithAuditStatus] = AuditTaskTable.selectStreetsWithAuditStatus(filterLowQuality, regionIds)
+    val routeIds: List[Int] = routes.map(parseIntegerList).getOrElse(List())
+    val streets: List[StreetEdgeWithAuditStatus] = AuditTaskTable.selectStreetsWithAuditStatus(filterLowQuality, regionIds, routeIds)
     val features: List[JsObject] = streets.map { edge =>
       val coordinates: Array[Coordinate] = edge.geom.getCoordinates
       val latlngs: List[geojson.LatLng] = coordinates.map(coord => geojson.LatLng(coord.y, coord.x)).toList  // Map it to an immutable list

--- a/app/views/labelMap.scala.html
+++ b/app/views/labelMap.scala.html
@@ -1,7 +1,7 @@
 @import models.user.User
 @import play.api.Play
 @import play.api.Play.current
-@(title: String, user: Option[User] = None, regionIds: List[Int])(implicit lang: Lang)
+@(title: String, user: Option[User] = None, regionIds: List[Int], routeIds: List[Int])(implicit lang: Lang)
 
 @cityId = @{Play.configuration.getString("city-id").get}
 
@@ -170,17 +170,23 @@
                 popupLabelViewer: AdminGSVLabelView(false, "LabelMap"),
                 differentiateExpiredLabels: true
             };
+            params.neighborhoodsURL = new URL('/neighborhoods', window.location.origin);
+            params.completionRatesURL = new URL('/adminapi/neighborhoodCompletionRate', window.location.origin);
+            params.streetsURL = new URL('/contribution/streets/all?filterLowQuality=true', window.location.origin);
+            params.labelsURL = new URL('/labels/all', window.location.origin);
+
             let regionsParam = '@{regionIds.mkString(",")}';
             if (regionsParam) {
-                params.neighborhoodsURL = `/neighborhoods?regions=${regionsParam}`;
-                params.completionRatesURL = `/adminapi/neighborhoodCompletionRate?regions=${regionsParam}`;
-                params.streetsURL = `/contribution/streets/all?filterLowQuality=true&regions=${regionsParam}`;
-                params.labelsURL = `/labels/all?regions=${regionsParam}`;
-            } else {
-                params.neighborhoodsURL = '/neighborhoods';
-                params.completionRatesURL = '/adminapi/neighborhoodCompletionRate';
-                params.streetsURL = '/contribution/streets/all?filterLowQuality=true';
-                params.labelsURL = '/labels/all';
+                params.neighborhoodsURL.searchParams.append('regions', regionsParam);
+                params.completionRatesURL.searchParams.append('regions', regionsParam);
+                params.streetsURL.searchParams.append('regions', regionsParam);
+                params.labelsURL.searchParams.append('regions', regionsParam);
+            }
+
+            let routesParam = '@{routeIds.mkString(",")}';
+            if (routesParam) {
+                params.streetsURL.searchParams.append('routes', routesParam);
+                params.labelsURL.searchParams.append('routes', routesParam);
             }
             // Show polling locations for Chicago, IL as part of a pilot.
             if ('@cityId' === 'chicago-il') {

--- a/app/views/routeBuilder.scala.html
+++ b/app/views/routeBuilder.scala.html
@@ -82,6 +82,7 @@
             </div>
             <div id="route-saved-buttons" class="flex-div-row">
                 <button type="button" id="explore-button" class="routebuilder-button  blue-button">@Messages("routebuilder.explore.route")</button>
+                <button type="button" id="view-in-labelmap-button" class="routebuilder-button white-button">@Messages("routebuilder.view.in.labelmap")</button>
                 <button type="button" id="build-new-route-button" class="routebuilder-button white-button">@Messages("routebuilder.build.another.route")</button>
             </div>
         </div>

--- a/conf/messages.de
+++ b/conf/messages.de
@@ -388,6 +388,7 @@ routebuilder.delete.route = Route löschen
 routebuilder.saved.icon.alt = Ein grüner Kreis mit einem weißen Checkmark in der Mitte
 routebuilder.saved = Route gespeichert!
 routebuilder.explore.route = Erforschen Sie diese Route
+routebuilder.view.in.labelmap = In der Beschriftungskarte anzeigen
 routebuilder.build.another.route = Bauen Sie eine andere Route
 routebuilder.share.title = Speichern Sie diesen Link für den zukünftigen Zugriff:
 routebuilder.copy.link = Link kopieren

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -381,6 +381,7 @@ routebuilder.delete.route = Delete Route
 routebuilder.saved.icon.alt = A green circle with a white checkmark in the center
 routebuilder.saved = Route saved!
 routebuilder.explore.route = Explore This Route
+routebuilder.view.in.labelmap = View in Label Map
 routebuilder.build.another.route = Build Another Route
 routebuilder.share.title = Save this link for future access:
 routebuilder.copy.link = Copy Link

--- a/conf/messages.es
+++ b/conf/messages.es
@@ -391,6 +391,7 @@ routebuilder.delete.route = Eliminar ruta
 routebuilder.saved.icon.alt = Un círculo verde con una marca de verificación blanca en el centro
 routebuilder.saved = Ruta guardada!
 routebuilder.explore.route = Explore esta ruta
+routebuilder.view.in.labelmap = Ver en mapa de etiquetas
 routebuilder.build.another.route = Construir otra ruta
 routebuilder.share.title = Guarde este enlace para el acceso futuro:
 routebuilder.copy.link = Copiar link

--- a/conf/messages.nl
+++ b/conf/messages.nl
@@ -383,6 +383,7 @@ routebuilder.delete.route = Verwijder route
 routebuilder.saved.icon.alt = Een groene cirkel met een wit vinkje in het midden
 routebuilder.saved = Route opgeslagen!
 routebuilder.explore.route = Verken deze route
+routebuilder.view.in.labelmap = Bekijk in Label Kaart
 routebuilder.build.another.route = Bouw een andere route
 routebuilder.share.title = Sla deze link op voor toekomstige toegang:
 routebuilder.copy.link = Kopieer link

--- a/conf/messages.zh-TW
+++ b/conf/messages.zh-TW
@@ -418,6 +418,7 @@ routebuilder.delete.route = 刪除路線
 routebuilder.saved.icon.alt = 一個有白色勾號在中心的綠色圓圈
 routebuilder.saved = 路線已儲存！
 routebuilder.explore.route = 探索此路線
+routebuilder.view.in.labelmap = 標記地圖中查看
 routebuilder.build.another.route = 設立另一條路線
 routebuilder.share.title = 儲存此連結供未來使用：
 routebuilder.copy.link = 複製連結

--- a/conf/routes
+++ b/conf/routes
@@ -11,8 +11,8 @@ GET     /developer                                           @controllers.Applic
 GET     /terms                                               @controllers.ApplicationController.terms
 GET     /demo                                                @controllers.ApplicationController.demo
 GET     /results                                             @controllers.ApplicationController.results
-GET     /labelMap                                            @controllers.ApplicationController.labelMap(regions: Option[String] ?= None)
-GET     /labelmap                                            @controllers.ApplicationController.labelMap(regions: Option[String] ?= None)
+GET     /labelMap                                            @controllers.ApplicationController.labelMap(regions: Option[String] ?= None, routes: Option[String] ?= None)
+GET     /labelmap                                            @controllers.ApplicationController.labelMap(regions: Option[String] ?= None, routes: Option[String] ?= None)
 GET     /gallery                                             @controllers.ApplicationController.gallery(labelType: String ?= "Assorted", neighborhoods: String ?= "", severities: String ?= "", tags: String ?= "", validationOptions: String ?= "correct,unvalidated")
 GET     /help                                                @controllers.ApplicationController.help
 GET     /labelingGuide                                       @controllers.ApplicationController.labelingGuide
@@ -88,7 +88,7 @@ PUT     /adminapi/setOrg                                     @controllers.AdminC
 PUT     /adminapi/setTaskFlagsBeforeDate                     @controllers.AdminController.setTaskFlagsBeforeDate
 PUT     /adminapi/setTaskFlag                                @controllers.AdminController.setTaskFlag
 
-GET     /labels/all                                          @controllers.AdminController.getAllLabelsForLabelMap(regions: Option[String] ?= None)
+GET     /labels/all                                          @controllers.AdminController.getAllLabelsForLabelMap(regions: Option[String] ?= None, routes: Option[String] ?= None)
 GET     /label/id/:labelId                                   @controllers.AdminController.getLabelData(labelId: Int)
 
 # Auditing tasks

--- a/conf/routes
+++ b/conf/routes
@@ -137,7 +137,7 @@ GET     /neighborhoods                                       @controllers.Region
 # User status
 # /:username has to come last in the list. Otherwise it eats other urls.
 GET     /contribution/streets                                @controllers.UserProfileController.getAuditedStreets
-GET     /contribution/streets/all                            @controllers.UserProfileController.getAllStreets(filterLowQuality: Boolean ?= false, regions: Option[String] ?= None)
+GET     /contribution/streets/all                            @controllers.UserProfileController.getAllStreets(filterLowQuality: Boolean ?= false, regions: Option[String] ?= None, routes: Option[String] ?= None)
 GET     /contribution/auditCounts/all                        @controllers.UserProfileController.getAllAuditCounts
 GET     /dashboard                                           @controllers.UserProfileController.userProfile
 GET     /userapi/mistakes                                    @controllers.UserProfileController.getRecentMistakes(n: Int ?= 5)

--- a/public/javascripts/routeBuilder.js
+++ b/public/javascripts/routeBuilder.js
@@ -30,6 +30,7 @@ function RouteBuilder ($, mapParams) {
     let exploreButton = $('#explore-button');
     let linkTextEl = document.getElementById('share-route-link');
     let copyLinkButton = $('#copy-link-button');
+    let viewInLabelmapButton = $('#view-in-labelmap-button');
 
     // Add the click event for the clear route buttons.
     document.getElementById('cancel-button').addEventListener('click', clickCancelRoute);
@@ -691,6 +692,13 @@ function RouteBuilder ($, mapParams) {
                     navigator.clipboard.writeText(exploreURL);
                     setTemporaryTooltip(e.currentTarget, i18next.t('copied-to-clipboard'));
                     logActivity(`RouteBuilder_Click=Copy_RouteId=${data.route_id}`);
+                });
+
+                // Update link for the 'View in LabelMap' button.
+                viewInLabelmapButton.off('click');
+                viewInLabelmapButton.click(function () {
+                    logActivity(`RouteBuilder_Click=LabelMap_RouteId=${data.route_id}`);
+                    window.open(`/labelMap?routes=${data.route_id}`, '_blank');
                 });
 
                 logActivity(`RouteBuilder_Click=SaveSuccess_RouteId=${data.route_id}`);

--- a/public/stylesheets/routeBuilder.css
+++ b/public/stylesheets/routeBuilder.css
@@ -26,9 +26,9 @@
 }
 
 .routebuilder-centered-overlay {
-    width: 520px;
+    width: 590px;
     top: calc(4% + 85px); /* 2% + navbar height + map margin-top */
-    left: calc(50% - 260px); /* 50% - width/2 */
+    left: calc(50% - 295px); /* 50% - width/2 */
 }
 
 .routebuilder-h1 {


### PR DESCRIPTION
Resolves #3694

Adds a button after you finish creating a route in RouteBuilder to view the data for just that route in LabelMap. This is done via a URL parameter, so you view data for any route (or routes) at any time. The URL might look like `/labelMap?routes=12,8,44` or simply `/labelMap?routes=12`.

##### Before/After screenshots (if applicable)
Before
![Screenshot from 2024-10-22 11-16-07](https://github.com/user-attachments/assets/1b4b6ee5-ad4a-4dbc-8eec-c7f2632a483f)

After
![Screenshot from 2024-10-21 17-08-56](https://github.com/user-attachments/assets/e4bacfab-8107-4be4-b516-1dc9cfb8c269)

And in LabelMap
![Screenshot from 2024-10-21 17-09-16](https://github.com/user-attachments/assets/178465a9-1397-45ca-905d-1b6f714f0291)

And then in LabelMap if you selected multiple routes
![Screenshot from 2024-10-21 15-57-19](https://github.com/user-attachments/assets/aa2783dd-23b1-47c1-930e-ce0f5091108b)

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
- [x] I've asked for and included translations for any user facing text that was added or modified.
- [x] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure the documentation on [this wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Descriptions-of-Logged-Events) is up to date for the logs you added/updated.
