### PR TITLE
Reduce Admin Page Initial Load Time by ~10s (Seattle) by Moving Coverage Data to new API Route

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -49,6 +49,7 @@ module.exports = function(grunt) {
                 src: [
                     'public/javascripts/Admin/src/*.js',
                     'public/javascripts/common/Utilities.js',
+                    'public/javascripts/common/UtilitiesMath.js',
                     'public/javascripts/common/UtilitiesSidewalk.js',
                     'public/javascripts/common/Panomarker.js',
                     'public/javascripts/common/UtilitiesPanomarker.js'

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -672,7 +672,6 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
 
   /**
    * Gets street edge data for the coverage section of the admin page.
-   * @return
    */
   def getStreetEdgeData = UserAwareAction.async { implicit request =>
     if (isAdmin(request.identity)) {

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -669,4 +669,140 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
       }
     )
   }
+
+  /**
+   * Gets street edge data for the coverage section of the admin page.
+   * @return
+   */
+  def getStreetEdgeData = UserAwareAction.async { implicit request =>
+    if (isAdmin(request.identity)) {
+      val auditedStreetDistanceOverTimeData = Json.obj(
+        "all_time" -> StreetEdgeTable.auditedStreetDistanceOverTime("all time"),
+        "today" -> StreetEdgeTable.auditedStreetDistanceOverTime("today"),
+        "week" -> StreetEdgeTable.auditedStreetDistanceOverTime("week")
+      )
+      
+      val auditedStreetsData = Json.obj(
+        "total_streets" -> StreetEdgeTable.countTotalStreets(),
+
+        "total_audited_streets" -> Json.obj(
+          "all_users" -> Json.obj(
+            "total" -> StreetEdgeTable.countAuditedStreets(),
+            "percentage" -> StreetEdgeTable.auditCompletionRate(1) * 100
+          ),
+          "high_quality" -> Json.obj(
+            "total" -> StreetEdgeTable.countAuditedStreets(1, "All", true),
+            "percentage" -> StreetEdgeTable.auditCompletionRate(1, "All", true) * 100
+          )
+        ),
+
+        "registered" -> Json.obj(
+          "all_users" -> Json.obj(
+            "total" -> StreetEdgeTable.countAuditedStreets(1, "Registered"),
+            "percentage" -> StreetEdgeTable.auditCompletionRate(1, "Registered") * 100
+          ),
+          "high_quality" -> Json.obj(
+            "total" -> StreetEdgeTable.countAuditedStreets(1, "Registered", true),
+            "percentage" -> StreetEdgeTable.auditCompletionRate(1, "Registered", true) * 100
+          )
+        ),
+
+        "anonymous" -> Json.obj(
+          "all_users" -> Json.obj(
+            "total" -> StreetEdgeTable.countAuditedStreets(1, "Anonymous"),
+            "percentage" -> StreetEdgeTable.auditCompletionRate(1, "Anonymous") * 100
+          ),
+          "high_quality" -> Json.obj(
+            "total" -> StreetEdgeTable.countAuditedStreets(1, "Anonymous", true),
+            "percentage" -> StreetEdgeTable.auditCompletionRate(1, "Anonymous", true) * 100
+          )
+        ),
+
+        "turker" -> Json.obj(
+          "all_users" -> Json.obj(
+            "total" -> StreetEdgeTable.countAuditedStreets(1, "Turker"),
+            "percentage" -> StreetEdgeTable.auditCompletionRate(1, "Turker") * 100
+          ),
+          "high_quality" -> Json.obj(
+            "total" -> StreetEdgeTable.countAuditedStreets(1, "Turker", true),
+            "percentage" -> StreetEdgeTable.auditCompletionRate(1, "Turker", true) * 100
+          )
+        ),
+
+        "researcher" -> Json.obj(
+          "all_users" -> Json.obj(
+            "total" -> StreetEdgeTable.countAuditedStreets(1, "Researcher"),
+            "percentage" -> StreetEdgeTable.auditCompletionRate(1, "Researcher") * 100
+          ),
+          "high_quality" -> Json.obj(
+            "total" -> StreetEdgeTable.countAuditedStreets(1, "Researcher", true),
+            "percentage" -> StreetEdgeTable.auditCompletionRate(1, "Researcher", true) * 100
+          )
+        )
+      )
+
+      val distanceData = Json.obj(
+        "total_distance" -> StreetEdgeTable.totalStreetDistance(),
+
+        "total_audited_streets" -> Json.obj(
+          "all_users" -> Json.obj(
+            "total" -> StreetEdgeTable.auditedStreetDistance(1),
+            "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1) * 100
+          ),
+          "high_quality" -> Json.obj(
+            "total" -> StreetEdgeTable.auditedStreetDistance(1, "All", true),
+            "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "All", true) * 100
+          )
+        ),
+
+        "registered" -> Json.obj(
+          "all_users" -> Json.obj(
+            "total" -> StreetEdgeTable.auditedStreetDistance(1, "Registered"),
+            "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "Registered") * 100
+          ),
+          "high_quality" -> Json.obj(
+            "total" -> StreetEdgeTable.auditedStreetDistance(1, "Registered", true),
+            "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "Registered", true) * 100
+          )
+        ),
+
+        "anonymous" -> Json.obj(
+          "all_users" -> Json.obj(
+            "total" -> StreetEdgeTable.auditedStreetDistance(1, "Anonymous"),
+            "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "Anonymous") * 100
+          ),
+          "high_quality" -> Json.obj(
+            "total" -> StreetEdgeTable.auditedStreetDistance(1, "Anonymous", true),
+            "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "Anonymous", true) * 100
+          )
+        ),
+
+        "turker" -> Json.obj(
+          "all_users" -> Json.obj(
+            "total" -> StreetEdgeTable.auditedStreetDistance(1, "Turker"),
+            "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "Turker") * 100
+          ),
+          "high_quality" -> Json.obj(
+            "total" -> StreetEdgeTable.auditedStreetDistance(1, "Turker", true),
+            "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "Turker", true) * 100
+          )
+        ),
+
+        "researcher" -> Json.obj(
+          "all_users" -> Json.obj(
+            "total" -> StreetEdgeTable.auditedStreetDistance(1, "Researcher"),
+            "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "Researcher") * 100
+          ),
+          "high_quality" -> Json.obj(
+            "total" -> StreetEdgeTable.auditedStreetDistance(1, "Researcher", true),
+            "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "Researcher", true) * 100
+          )
+        )
+      )
+      val data = Json.obj("audited_street_distance_over_time" -> auditedStreetDistanceOverTimeData, "audited_streets" -> auditedStreetsData, "distance" -> distanceData)
+      Future.successful(Ok(data))
+    } else {
+      Future.failed(new AuthenticationException("User is not an administrator"))
+    }
+  }
 }

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -678,52 +678,24 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
       "total" -> StreetEdgeTable.countTotalStreets(),
       "audited" -> Json.obj(
         "all_users" -> Json.obj(
-          "total" -> StreetEdgeTable.countAuditedStreets(),
-          "percentage" -> StreetEdgeTable.auditCompletionRate(1) * 100
-        ),
-        "high_quality" -> Json.obj(
-          "total" -> StreetEdgeTable.countAuditedStreets(1, "All", true),
-          "percentage" -> StreetEdgeTable.auditCompletionRate(1, "All", true) * 100
+          "all" -> StreetEdgeTable.countAuditedStreets(),
+          "high_quality" -> StreetEdgeTable.countAuditedStreets(1, "All", true)
         ),
         "registered" -> Json.obj(
-          "all" -> Json.obj(
-            "total" -> StreetEdgeTable.countAuditedStreets(1, "Registered"),
-            "percentage" -> StreetEdgeTable.auditCompletionRate(1, "Registered") * 100
-          ),
-          "high_quality" -> Json.obj(
-            "total" -> StreetEdgeTable.countAuditedStreets(1, "Registered", true),
-            "percentage" -> StreetEdgeTable.auditCompletionRate(1, "Registered", true) * 100
-          )
+          "all" -> StreetEdgeTable.countAuditedStreets(1, "Registered"),
+          "high_quality" -> StreetEdgeTable.countAuditedStreets(1, "Registered", true)
         ),
         "anonymous" -> Json.obj(
-          "all" -> Json.obj(
-            "total" -> StreetEdgeTable.countAuditedStreets(1, "Anonymous"),
-            "percentage" -> StreetEdgeTable.auditCompletionRate(1, "Anonymous") * 100
-          ),
-          "high_quality" -> Json.obj(
-            "total" -> StreetEdgeTable.countAuditedStreets(1, "Anonymous", true),
-            "percentage" -> StreetEdgeTable.auditCompletionRate(1, "Anonymous", true) * 100
-          )
+          "all" -> StreetEdgeTable.countAuditedStreets(1, "Anonymous"),
+          "high_quality" -> StreetEdgeTable.countAuditedStreets(1, "Anonymous", true)
         ),
         "turker" -> Json.obj(
-          "all" -> Json.obj(
-            "total" -> StreetEdgeTable.countAuditedStreets(1, "Turker"),
-            "percentage" -> StreetEdgeTable.auditCompletionRate(1, "Turker") * 100
-          ),
-          "high_quality" -> Json.obj(
-            "total" -> StreetEdgeTable.countAuditedStreets(1, "Turker", true),
-            "percentage" -> StreetEdgeTable.auditCompletionRate(1, "Turker", true) * 100
-          )
+          "all" -> StreetEdgeTable.countAuditedStreets(1, "Turker"),
+          "high_quality" -> StreetEdgeTable.countAuditedStreets(1, "Turker", true)
         ),
         "researcher" -> Json.obj(
-          "all" -> Json.obj(
-            "total" -> StreetEdgeTable.countAuditedStreets(1, "Researcher"),
-            "percentage" -> StreetEdgeTable.auditCompletionRate(1, "Researcher") * 100
-          ),
-          "high_quality" -> Json.obj(
-            "total" -> StreetEdgeTable.countAuditedStreets(1, "Researcher", true),
-            "percentage" -> StreetEdgeTable.auditCompletionRate(1, "Researcher", true) * 100
-          )
+          "all" -> StreetEdgeTable.countAuditedStreets(1, "Researcher"),
+          "high_quality" -> StreetEdgeTable.countAuditedStreets(1, "Researcher", true)
         )
       )
     )
@@ -732,52 +704,24 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
       "total" -> StreetEdgeTable.totalStreetDistance(),
       "audited" -> Json.obj(
         "all_users" -> Json.obj(
-          "total" -> StreetEdgeTable.auditedStreetDistance(1),
-          "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1) * 100
-        ),
-        "high_quality" -> Json.obj(
-          "total" -> StreetEdgeTable.auditedStreetDistance(1, "All", true),
-          "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "All", true) * 100
+          "all" -> StreetEdgeTable.auditedStreetDistance(1),
+          "high_quality" -> StreetEdgeTable.auditedStreetDistance(1, "All", true)
         ),
         "registered" -> Json.obj(
-          "all" -> Json.obj(
-            "total" -> StreetEdgeTable.auditedStreetDistance(1, "Registered"),
-            "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "Registered") * 100
-          ),
-          "high_quality" -> Json.obj(
-            "total" -> StreetEdgeTable.auditedStreetDistance(1, "Registered", true),
-            "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "Registered", true) * 100
-          )
+          "all" -> StreetEdgeTable.auditedStreetDistance(1, "Registered"),
+          "high_quality" -> StreetEdgeTable.auditedStreetDistance(1, "Registered", true)
         ),
         "anonymous" -> Json.obj(
-          "all" -> Json.obj(
-            "total" -> StreetEdgeTable.auditedStreetDistance(1, "Anonymous"),
-            "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "Anonymous") * 100
-          ),
-          "high_quality" -> Json.obj(
-            "total" -> StreetEdgeTable.auditedStreetDistance(1, "Anonymous", true),
-            "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "Anonymous", true) * 100
-          )
+          "all" -> StreetEdgeTable.auditedStreetDistance(1, "Anonymous"),
+          "high_quality" -> StreetEdgeTable.auditedStreetDistance(1, "Anonymous", true)
         ),
         "turker" -> Json.obj(
-          "all" -> Json.obj(
-            "total" -> StreetEdgeTable.auditedStreetDistance(1, "Turker"),
-            "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "Turker") * 100
-          ),
-          "high_quality" -> Json.obj(
-            "total" -> StreetEdgeTable.auditedStreetDistance(1, "Turker", true),
-            "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "Turker", true) * 100
-          )
+          "all" -> StreetEdgeTable.auditedStreetDistance(1, "Turker"),
+          "high_quality" -> StreetEdgeTable.auditedStreetDistance(1, "Turker", true)
         ),
         "researcher" -> Json.obj(
-          "all" -> Json.obj(
-            "total" -> StreetEdgeTable.auditedStreetDistance(1, "Researcher"),
-            "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "Researcher") * 100
-          ),
-          "high_quality" -> Json.obj(
-            "total" -> StreetEdgeTable.auditedStreetDistance(1, "Researcher", true),
-            "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "Researcher", true) * 100
-          )
+          "all" -> StreetEdgeTable.auditedStreetDistance(1, "Researcher"),
+          "high_quality" -> StreetEdgeTable.auditedStreetDistance(1, "Researcher", true)
         ),
 
         // Audited distance over time is related, but included in a separate table on the Admin page.
@@ -792,7 +736,7 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
     val data = Json.obj(
       "street_counts" -> streetCountsData,
       "street_distance" -> streetDistanceData
-      )
+    )
     Future.successful(Ok(data))
   }
 }

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -673,135 +673,134 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
   /**
    * Gets street edge data for the coverage section of the admin page.
    */
-  def getStreetEdgeData = UserAwareAction.async { implicit request =>
-    if (isAdmin(request.identity)) {
-      val auditedStreetDistanceOverTimeData = Json.obj(
-        "all_time" -> StreetEdgeTable.auditedStreetDistanceOverTime("all time"),
-        "today" -> StreetEdgeTable.auditedStreetDistanceOverTime("today"),
-        "week" -> StreetEdgeTable.auditedStreetDistanceOverTime("week")
-      )
+  def getCoverageData = UserAwareAction.async { implicit request =>
+    val auditedStreetDistanceOverTimeData = Json.obj(
+      "all_time" -> StreetEdgeTable.auditedStreetDistanceOverTime("all time"),
+      "today" -> StreetEdgeTable.auditedStreetDistanceOverTime("today"),
+      "week" -> StreetEdgeTable.auditedStreetDistanceOverTime("week")
+    )
       
-      val auditedStreetsData = Json.obj(
-        "total_streets" -> StreetEdgeTable.countTotalStreets(),
-
-        "total_audited_streets" -> Json.obj(
-          "all_users" -> Json.obj(
-            "total" -> StreetEdgeTable.countAuditedStreets(),
-            "percentage" -> StreetEdgeTable.auditCompletionRate(1) * 100
-          ),
-          "high_quality" -> Json.obj(
-            "total" -> StreetEdgeTable.countAuditedStreets(1, "All", true),
-            "percentage" -> StreetEdgeTable.auditCompletionRate(1, "All", true) * 100
-          )
+    val auditedStreetsData = Json.obj(
+      "total_streets" -> StreetEdgeTable.countTotalStreets(),
+      "total_audited_streets" -> Json.obj(
+        "all_users" -> Json.obj(
+          "total" -> StreetEdgeTable.countAuditedStreets(),
+          "percentage" -> StreetEdgeTable.auditCompletionRate(1) * 100
         ),
+        "high_quality" -> Json.obj(
+          "total" -> StreetEdgeTable.countAuditedStreets(1, "All", true),
+          "percentage" -> StreetEdgeTable.auditCompletionRate(1, "All", true) * 100
+        )
+      ),
 
-        "registered" -> Json.obj(
-          "all_users" -> Json.obj(
-            "total" -> StreetEdgeTable.countAuditedStreets(1, "Registered"),
-            "percentage" -> StreetEdgeTable.auditCompletionRate(1, "Registered") * 100
-          ),
-          "high_quality" -> Json.obj(
-            "total" -> StreetEdgeTable.countAuditedStreets(1, "Registered", true),
-            "percentage" -> StreetEdgeTable.auditCompletionRate(1, "Registered", true) * 100
-          )
+      "registered" -> Json.obj(
+        "all_users" -> Json.obj(
+          "total" -> StreetEdgeTable.countAuditedStreets(1, "Registered"),
+          "percentage" -> StreetEdgeTable.auditCompletionRate(1, "Registered") * 100
         ),
+        "high_quality" -> Json.obj(
+          "total" -> StreetEdgeTable.countAuditedStreets(1, "Registered", true),
+          "percentage" -> StreetEdgeTable.auditCompletionRate(1, "Registered", true) * 100
+        )
+      ),
 
-        "anonymous" -> Json.obj(
-          "all_users" -> Json.obj(
-            "total" -> StreetEdgeTable.countAuditedStreets(1, "Anonymous"),
-            "percentage" -> StreetEdgeTable.auditCompletionRate(1, "Anonymous") * 100
-          ),
-          "high_quality" -> Json.obj(
-            "total" -> StreetEdgeTable.countAuditedStreets(1, "Anonymous", true),
-            "percentage" -> StreetEdgeTable.auditCompletionRate(1, "Anonymous", true) * 100
-          )
+      "anonymous" -> Json.obj(
+        "all_users" -> Json.obj(
+          "total" -> StreetEdgeTable.countAuditedStreets(1, "Anonymous"),
+          "percentage" -> StreetEdgeTable.auditCompletionRate(1, "Anonymous") * 100
         ),
+        "high_quality" -> Json.obj(
+          "total" -> StreetEdgeTable.countAuditedStreets(1, "Anonymous", true),
+          "percentage" -> StreetEdgeTable.auditCompletionRate(1, "Anonymous", true) * 100
+        )
+      ),
 
-        "turker" -> Json.obj(
-          "all_users" -> Json.obj(
-            "total" -> StreetEdgeTable.countAuditedStreets(1, "Turker"),
-            "percentage" -> StreetEdgeTable.auditCompletionRate(1, "Turker") * 100
-          ),
-          "high_quality" -> Json.obj(
-            "total" -> StreetEdgeTable.countAuditedStreets(1, "Turker", true),
-            "percentage" -> StreetEdgeTable.auditCompletionRate(1, "Turker", true) * 100
-          )
+      "turker" -> Json.obj(
+        "all_users" -> Json.obj(
+          "total" -> StreetEdgeTable.countAuditedStreets(1, "Turker"),
+          "percentage" -> StreetEdgeTable.auditCompletionRate(1, "Turker") * 100
         ),
+        "high_quality" -> Json.obj(
+          "total" -> StreetEdgeTable.countAuditedStreets(1, "Turker", true),
+          "percentage" -> StreetEdgeTable.auditCompletionRate(1, "Turker", true) * 100
+        )
+      ),
 
-        "researcher" -> Json.obj(
-          "all_users" -> Json.obj(
-            "total" -> StreetEdgeTable.countAuditedStreets(1, "Researcher"),
-            "percentage" -> StreetEdgeTable.auditCompletionRate(1, "Researcher") * 100
-          ),
-          "high_quality" -> Json.obj(
-            "total" -> StreetEdgeTable.countAuditedStreets(1, "Researcher", true),
-            "percentage" -> StreetEdgeTable.auditCompletionRate(1, "Researcher", true) * 100
-          )
+      "researcher" -> Json.obj(
+        "all_users" -> Json.obj(
+          "total" -> StreetEdgeTable.countAuditedStreets(1, "Researcher"),
+          "percentage" -> StreetEdgeTable.auditCompletionRate(1, "Researcher") * 100
+        ),
+        "high_quality" -> Json.obj(
+          "total" -> StreetEdgeTable.countAuditedStreets(1, "Researcher", true),
+          "percentage" -> StreetEdgeTable.auditCompletionRate(1, "Researcher", true) * 100
         )
       )
+    )
 
-      val distanceData = Json.obj(
-        "total_distance" -> StreetEdgeTable.totalStreetDistance(),
+    val distanceData = Json.obj(
+      "total_distance" -> StreetEdgeTable.totalStreetDistance(),
 
-        "total_audited_streets" -> Json.obj(
-          "all_users" -> Json.obj(
-            "total" -> StreetEdgeTable.auditedStreetDistance(1),
-            "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1) * 100
-          ),
-          "high_quality" -> Json.obj(
-            "total" -> StreetEdgeTable.auditedStreetDistance(1, "All", true),
-            "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "All", true) * 100
-          )
+      "total_audited_streets" -> Json.obj(
+        "all_users" -> Json.obj(
+          "total" -> StreetEdgeTable.auditedStreetDistance(1),
+          "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1) * 100
         ),
+        "high_quality" -> Json.obj(
+          "total" -> StreetEdgeTable.auditedStreetDistance(1, "All", true),
+          "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "All", true) * 100
+        )
+      ),
 
-        "registered" -> Json.obj(
-          "all_users" -> Json.obj(
-            "total" -> StreetEdgeTable.auditedStreetDistance(1, "Registered"),
-            "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "Registered") * 100
-          ),
-          "high_quality" -> Json.obj(
-            "total" -> StreetEdgeTable.auditedStreetDistance(1, "Registered", true),
-            "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "Registered", true) * 100
-          )
+      "registered" -> Json.obj(
+        "all_users" -> Json.obj(
+          "total" -> StreetEdgeTable.auditedStreetDistance(1, "Registered"),
+          "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "Registered") * 100
         ),
+        "high_quality" -> Json.obj(
+          "total" -> StreetEdgeTable.auditedStreetDistance(1, "Registered", true),
+          "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "Registered", true) * 100
+        )
+      ),
 
-        "anonymous" -> Json.obj(
-          "all_users" -> Json.obj(
-            "total" -> StreetEdgeTable.auditedStreetDistance(1, "Anonymous"),
-            "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "Anonymous") * 100
-          ),
-          "high_quality" -> Json.obj(
-            "total" -> StreetEdgeTable.auditedStreetDistance(1, "Anonymous", true),
-            "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "Anonymous", true) * 100
-          )
+      "anonymous" -> Json.obj(
+        "all_users" -> Json.obj(
+          "total" -> StreetEdgeTable.auditedStreetDistance(1, "Anonymous"),
+          "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "Anonymous") * 100
         ),
+        "high_quality" -> Json.obj(
+          "total" -> StreetEdgeTable.auditedStreetDistance(1, "Anonymous", true),
+          "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "Anonymous", true) * 100
+        )
+      ),
 
-        "turker" -> Json.obj(
-          "all_users" -> Json.obj(
-            "total" -> StreetEdgeTable.auditedStreetDistance(1, "Turker"),
-            "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "Turker") * 100
-          ),
-          "high_quality" -> Json.obj(
-            "total" -> StreetEdgeTable.auditedStreetDistance(1, "Turker", true),
-            "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "Turker", true) * 100
-          )
+      "turker" -> Json.obj(
+        "all_users" -> Json.obj(
+          "total" -> StreetEdgeTable.auditedStreetDistance(1, "Turker"),
+          "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "Turker") * 100
         ),
+        "high_quality" -> Json.obj(
+          "total" -> StreetEdgeTable.auditedStreetDistance(1, "Turker", true),
+          "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "Turker", true) * 100
+        )
+      ),
 
-        "researcher" -> Json.obj(
-          "all_users" -> Json.obj(
-            "total" -> StreetEdgeTable.auditedStreetDistance(1, "Researcher"),
-            "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "Researcher") * 100
-          ),
-          "high_quality" -> Json.obj(
-            "total" -> StreetEdgeTable.auditedStreetDistance(1, "Researcher", true),
-            "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "Researcher", true) * 100
-          )
+      "researcher" -> Json.obj(
+        "all_users" -> Json.obj(
+          "total" -> StreetEdgeTable.auditedStreetDistance(1, "Researcher"),
+          "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "Researcher") * 100
+        ),
+        "high_quality" -> Json.obj(
+          "total" -> StreetEdgeTable.auditedStreetDistance(1, "Researcher", true),
+          "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "Researcher", true) * 100
         )
       )
-      val data = Json.obj("audited_street_distance_over_time" -> auditedStreetDistanceOverTimeData, "audited_streets" -> auditedStreetsData, "distance" -> distanceData)
-      Future.successful(Ok(data))
-    } else {
-      Future.failed(new AuthenticationException("User is not an administrator"))
-    }
+    )
+    val data = Json.obj(
+      "audited_street_distance_over_time" -> auditedStreetDistanceOverTimeData,
+      "audited_streets" -> auditedStreetsData, 
+      "distance" -> distanceData
+      )
+    Future.successful(Ok(data))
   }
 }

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -674,15 +674,9 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
    * Gets street edge data for the coverage section of the admin page.
    */
   def getCoverageData = UserAwareAction.async { implicit request =>
-    val auditedStreetDistanceOverTimeData = Json.obj(
-      "all_time" -> StreetEdgeTable.auditedStreetDistanceOverTime("all time"),
-      "today" -> StreetEdgeTable.auditedStreetDistanceOverTime("today"),
-      "week" -> StreetEdgeTable.auditedStreetDistanceOverTime("week")
-    )
-      
-    val auditedStreetsData = Json.obj(
-      "total_streets" -> StreetEdgeTable.countTotalStreets(),
-      "total_audited_streets" -> Json.obj(
+    val streetCountsData = Json.obj(
+      "total" -> StreetEdgeTable.countTotalStreets(),
+      "audited" -> Json.obj(
         "all_users" -> Json.obj(
           "total" -> StreetEdgeTable.countAuditedStreets(),
           "percentage" -> StreetEdgeTable.auditCompletionRate(1) * 100
@@ -690,58 +684,53 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
         "high_quality" -> Json.obj(
           "total" -> StreetEdgeTable.countAuditedStreets(1, "All", true),
           "percentage" -> StreetEdgeTable.auditCompletionRate(1, "All", true) * 100
-        )
-      ),
-
-      "registered" -> Json.obj(
-        "all_users" -> Json.obj(
-          "total" -> StreetEdgeTable.countAuditedStreets(1, "Registered"),
-          "percentage" -> StreetEdgeTable.auditCompletionRate(1, "Registered") * 100
         ),
-        "high_quality" -> Json.obj(
-          "total" -> StreetEdgeTable.countAuditedStreets(1, "Registered", true),
-          "percentage" -> StreetEdgeTable.auditCompletionRate(1, "Registered", true) * 100
-        )
-      ),
-
-      "anonymous" -> Json.obj(
-        "all_users" -> Json.obj(
-          "total" -> StreetEdgeTable.countAuditedStreets(1, "Anonymous"),
-          "percentage" -> StreetEdgeTable.auditCompletionRate(1, "Anonymous") * 100
+        "registered" -> Json.obj(
+          "all" -> Json.obj(
+            "total" -> StreetEdgeTable.countAuditedStreets(1, "Registered"),
+            "percentage" -> StreetEdgeTable.auditCompletionRate(1, "Registered") * 100
+          ),
+          "high_quality" -> Json.obj(
+            "total" -> StreetEdgeTable.countAuditedStreets(1, "Registered", true),
+            "percentage" -> StreetEdgeTable.auditCompletionRate(1, "Registered", true) * 100
+          )
         ),
-        "high_quality" -> Json.obj(
-          "total" -> StreetEdgeTable.countAuditedStreets(1, "Anonymous", true),
-          "percentage" -> StreetEdgeTable.auditCompletionRate(1, "Anonymous", true) * 100
-        )
-      ),
-
-      "turker" -> Json.obj(
-        "all_users" -> Json.obj(
-          "total" -> StreetEdgeTable.countAuditedStreets(1, "Turker"),
-          "percentage" -> StreetEdgeTable.auditCompletionRate(1, "Turker") * 100
+        "anonymous" -> Json.obj(
+          "all" -> Json.obj(
+            "total" -> StreetEdgeTable.countAuditedStreets(1, "Anonymous"),
+            "percentage" -> StreetEdgeTable.auditCompletionRate(1, "Anonymous") * 100
+          ),
+          "high_quality" -> Json.obj(
+            "total" -> StreetEdgeTable.countAuditedStreets(1, "Anonymous", true),
+            "percentage" -> StreetEdgeTable.auditCompletionRate(1, "Anonymous", true) * 100
+          )
         ),
-        "high_quality" -> Json.obj(
-          "total" -> StreetEdgeTable.countAuditedStreets(1, "Turker", true),
-          "percentage" -> StreetEdgeTable.auditCompletionRate(1, "Turker", true) * 100
-        )
-      ),
-
-      "researcher" -> Json.obj(
-        "all_users" -> Json.obj(
-          "total" -> StreetEdgeTable.countAuditedStreets(1, "Researcher"),
-          "percentage" -> StreetEdgeTable.auditCompletionRate(1, "Researcher") * 100
+        "turker" -> Json.obj(
+          "all" -> Json.obj(
+            "total" -> StreetEdgeTable.countAuditedStreets(1, "Turker"),
+            "percentage" -> StreetEdgeTable.auditCompletionRate(1, "Turker") * 100
+          ),
+          "high_quality" -> Json.obj(
+            "total" -> StreetEdgeTable.countAuditedStreets(1, "Turker", true),
+            "percentage" -> StreetEdgeTable.auditCompletionRate(1, "Turker", true) * 100
+          )
         ),
-        "high_quality" -> Json.obj(
-          "total" -> StreetEdgeTable.countAuditedStreets(1, "Researcher", true),
-          "percentage" -> StreetEdgeTable.auditCompletionRate(1, "Researcher", true) * 100
+        "researcher" -> Json.obj(
+          "all" -> Json.obj(
+            "total" -> StreetEdgeTable.countAuditedStreets(1, "Researcher"),
+            "percentage" -> StreetEdgeTable.auditCompletionRate(1, "Researcher") * 100
+          ),
+          "high_quality" -> Json.obj(
+            "total" -> StreetEdgeTable.countAuditedStreets(1, "Researcher", true),
+            "percentage" -> StreetEdgeTable.auditCompletionRate(1, "Researcher", true) * 100
+          )
         )
       )
     )
 
-    val distanceData = Json.obj(
-      "total_distance" -> StreetEdgeTable.totalStreetDistance(),
-
-      "total_audited_streets" -> Json.obj(
+    val streetDistanceData = Json.obj(
+      "total" -> StreetEdgeTable.totalStreetDistance(),
+      "audited" -> Json.obj(
         "all_users" -> Json.obj(
           "total" -> StreetEdgeTable.auditedStreetDistance(1),
           "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1) * 100
@@ -749,57 +738,60 @@ class AdminController @Inject() (implicit val env: Environment[User, SessionAuth
         "high_quality" -> Json.obj(
           "total" -> StreetEdgeTable.auditedStreetDistance(1, "All", true),
           "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "All", true) * 100
-        )
-      ),
-
-      "registered" -> Json.obj(
-        "all_users" -> Json.obj(
-          "total" -> StreetEdgeTable.auditedStreetDistance(1, "Registered"),
-          "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "Registered") * 100
         ),
-        "high_quality" -> Json.obj(
-          "total" -> StreetEdgeTable.auditedStreetDistance(1, "Registered", true),
-          "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "Registered", true) * 100
-        )
-      ),
-
-      "anonymous" -> Json.obj(
-        "all_users" -> Json.obj(
-          "total" -> StreetEdgeTable.auditedStreetDistance(1, "Anonymous"),
-          "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "Anonymous") * 100
+        "registered" -> Json.obj(
+          "all" -> Json.obj(
+            "total" -> StreetEdgeTable.auditedStreetDistance(1, "Registered"),
+            "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "Registered") * 100
+          ),
+          "high_quality" -> Json.obj(
+            "total" -> StreetEdgeTable.auditedStreetDistance(1, "Registered", true),
+            "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "Registered", true) * 100
+          )
         ),
-        "high_quality" -> Json.obj(
-          "total" -> StreetEdgeTable.auditedStreetDistance(1, "Anonymous", true),
-          "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "Anonymous", true) * 100
-        )
-      ),
-
-      "turker" -> Json.obj(
-        "all_users" -> Json.obj(
-          "total" -> StreetEdgeTable.auditedStreetDistance(1, "Turker"),
-          "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "Turker") * 100
+        "anonymous" -> Json.obj(
+          "all" -> Json.obj(
+            "total" -> StreetEdgeTable.auditedStreetDistance(1, "Anonymous"),
+            "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "Anonymous") * 100
+          ),
+          "high_quality" -> Json.obj(
+            "total" -> StreetEdgeTable.auditedStreetDistance(1, "Anonymous", true),
+            "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "Anonymous", true) * 100
+          )
         ),
-        "high_quality" -> Json.obj(
-          "total" -> StreetEdgeTable.auditedStreetDistance(1, "Turker", true),
-          "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "Turker", true) * 100
-        )
-      ),
-
-      "researcher" -> Json.obj(
-        "all_users" -> Json.obj(
-          "total" -> StreetEdgeTable.auditedStreetDistance(1, "Researcher"),
-          "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "Researcher") * 100
+        "turker" -> Json.obj(
+          "all" -> Json.obj(
+            "total" -> StreetEdgeTable.auditedStreetDistance(1, "Turker"),
+            "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "Turker") * 100
+          ),
+          "high_quality" -> Json.obj(
+            "total" -> StreetEdgeTable.auditedStreetDistance(1, "Turker", true),
+            "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "Turker", true) * 100
+          )
         ),
-        "high_quality" -> Json.obj(
-          "total" -> StreetEdgeTable.auditedStreetDistance(1, "Researcher", true),
-          "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "Researcher", true) * 100
+        "researcher" -> Json.obj(
+          "all" -> Json.obj(
+            "total" -> StreetEdgeTable.auditedStreetDistance(1, "Researcher"),
+            "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "Researcher") * 100
+          ),
+          "high_quality" -> Json.obj(
+            "total" -> StreetEdgeTable.auditedStreetDistance(1, "Researcher", true),
+            "percentage" -> StreetEdgeTable.streetDistanceCompletionRate(1, "Researcher", true) * 100
+          )
+        ),
+
+        // Audited distance over time is related, but included in a separate table on the Admin page.
+        "with_overlap" -> Json.obj(
+          "all_time" -> StreetEdgeTable.auditedStreetDistanceOverTime("all time"),
+          "today" -> StreetEdgeTable.auditedStreetDistanceOverTime("today"),
+          "week" -> StreetEdgeTable.auditedStreetDistanceOverTime("week")
         )
       )
     )
+
     val data = Json.obj(
-      "audited_street_distance_over_time" -> auditedStreetDistanceOverTimeData,
-      "audited_streets" -> auditedStreetsData, 
-      "distance" -> distanceData
+      "street_counts" -> streetCountsData,
+      "street_distance" -> streetDistanceData
       )
     Future.successful(Ok(data))
   }

--- a/app/models/street/StreetEdgeTable.scala
+++ b/app/models/street/StreetEdgeTable.scala
@@ -125,31 +125,6 @@ object StreetEdgeTable {
   }
 
   /**
-    * Returns the audit completion rate for the specified group of users.
-    *
-    * @param auditCount
-    * @param userType
-    * @return
-    */
-  def auditCompletionRate(auditCount: Int, userType: String = "All", highQualityOnly: Boolean = false): Float = db.withSession { implicit session =>
-    val auditedStreetCount = countAuditedStreets(1, userType, highQualityOnly).toFloat
-    val allEdgesCount: Int = streetEdgesWithoutDeleted.length.run
-    auditedStreetCount / allEdgesCount
-  }
-
-  /**
-    * Calculate the proportion of the total miles of the city that have been audited at least auditCount times.
-    *
-    * @param auditCount
-    * @return Float between 0 and 1
-    */
-  def streetDistanceCompletionRate(auditCount: Int, userType: String = "All", highQualityOnly: Boolean = false): Float = db.withSession { implicit session =>
-    val auditedDistance: Float = auditedStreetDistance(auditCount, userType, highQualityOnly)
-    val totalDistance: Float = totalStreetDistance()
-    auditedDistance / totalDistance
-  }
-
-  /**
     * Get the total distance in miles.
     * Reference: http://gis.stackexchange.com/questions/143436/how-do-i-calculate-st-length-in-miles
     *

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -258,82 +258,62 @@
                                 </tr>
                                 <tr>
                                     <th>Audited Streets</th>
-                                    <td><span id="street-count-audited-all-users"></span>
-                                        <span id="street-count-audited-all-users-percentage"></span></td>
-                                    <td><span id="street-count-audited-high-quality-total"></span>
-                                        <span id="street-count-audited-high-quality-percentage"></span></td>
+                                    <td><span id="street-count-audited-all"></span></td>
+                                    <td><span id="street-count-audited-high-quality"></span></td>
                                     <td><span id="street-count-total"></span></td>
                                 </tr>
                                 <tr style="font-size: 90%;">
                                     <td style="padding-left: 30px">Registered</td>
-                                    <td><span id="street-count-audited-registered-all"></span>
-                                        <span id="street-count-audited-registered-all-percentage"></span></td>
-                                    <td><span id="street-count-audited-registered-high-quality"></span>
-                                        <span id="street-count-audited-registered-high-quality-percentage"></span></td>
+                                    <td><span id="street-count-audited-registered-all"></span></td>
+                                    <td><span id="street-count-audited-registered-high-quality"></span></td>
                                     <td></td>
                                 </tr>
                                 <tr style="font-size: 90%;">
                                     <td style="padding-left: 30px">Anonymous</td>
-                                    <td><span id="street-count-audited-anonymous-all"></span>
-                                        <span id="street-count-audited-anonymous-all-percentage"></span></td>
-                                    <td><span id="street-count-audited-anonymous-high-quality"></span>
-                                        <span id="street-count-audited-anonymous-high-quality-percentage"></span></td>
+                                    <td><span id="street-count-audited-anonymous-all"></span></td>
+                                    <td><span id="street-count-audited-anonymous-high-quality"></span></td>
                                     <td></td>
                                 </tr>
                                 <tr style="font-size: 90%;">
                                     <td style="padding-left: 30px">Turker</td>
-                                    <td><span id="street-count-audited-turker-all"></span>
-                                        <span id="street-count-audited-turker-all-percentage"></span></td>
-                                    <td><span id="street-count-audited-turker-high-quality"></span>
-                                        <span id="street-count-audited-turker-high-quality-percentage"></span></td>
+                                    <td><span id="street-count-audited-turker-all"></span></td>
+                                    <td><span id="street-count-audited-turker-high-quality"></span></td>
                                     <td></td>
                                 </tr>
                                 <tr style="font-size: 90%;">
                                     <td style="padding-left: 30px">Researcher</td>
-                                    <td><span id="street-count-audited-researcher-all"></span>
-                                        <span id="street-count-audited-researcher-all-percentage"></span></td>
-                                    <td><span id="street-count-audited-researcher-high-quality"></span>
-                                        <span id="street-count-audited-researcher-high-quality-percentage"></span></td>
+                                    <td><span id="street-count-audited-researcher-all"></span></td>
+                                    <td><span id="street-count-audited-researcher-high-quality"></span></td>
                                     <td></td>
                                 </tr>
                                 <tr>
                                     <th>Distance</th>
-                                    <td><span id="street-distance-audited-all-users"></span>
-                                        <span id="street-distance-audited-all-users-percentage"></span></td>
-                                    <td><span id="street-distance-audited-high-quality"></span>
-                                        <span id="street-distance-audited-high-quality-percentage"></span></td>
+                                    <td><span id="street-distance-audited-all"></span></td>
+                                    <td><span id="street-distance-audited-high-quality"></span></td>
                                     <td><span id="street-distance-total"></span></td>
                                 </tr>
                                 <tr style="font-size: 90%;">
                                     <td style="padding-left: 30px">Registered</td>
-                                    <td><span id="street-distance-registered-all"></span>
-                                        <span id="street-distance-registered-all-percentage"></span></td>
-                                    <td><span id="street-distance-registered-high-quality"></span>
-                                        <span id="street-distance-registered-high-quality-percentage"></span></td>
+                                    <td><span id="street-distance-registered-all"></span></td>
+                                    <td><span id="street-distance-registered-high-quality"></span></td>
                                     <td></td>
                                 </tr>
                                 <tr style="font-size: 90%;">
                                     <td style="padding-left: 30px">Anonymous</td>
-                                    <td><span id="street-distance-anonymous-all"></span>
-                                        <span id="street-distance-anonymous-all-percentage"></span></td>
-                                    <td><span id="street-distance-anonymous-high-quality"></span>
-                                        <span id="street-distance-anonymous-high-quality-percentage"></span></td>
+                                    <td><span id="street-distance-anonymous-all"></span></td>
+                                    <td><span id="street-distance-anonymous-high-quality"></span></td>
                                     <td></td>
                                 </tr>
                                 <tr style="font-size: 90%;">
                                     <td style="padding-left: 30px">Turker</td>
-                                    <td><span id="street-distance-turker-all"></span>
-                                        <span id="street-distance-turker-all-percentage"></span></td>
-                                    <td><span id="street-distance-turker-high-quality"></span>
-                                        <span id="street-distance-turker-high-quality-percentage"></span></td>
+                                    <td><span id="street-distance-turker-all"></span></td>
+                                    <td><span id="street-distance-turker-high-quality"></span></td>
                                     <td></td>
                                 </tr>
                                 <tr style="font-size: 90%;">
                                     <td style="padding-left: 30px">Researcher</td>
-                                    <td><span id="street-distance-researcher-all"></span>
-                                        <span id="street-distance-researcher-all-percentage"></span></td>
-                                    <td><span id="street-distance-researcher-high-quality"></span>
-                                        <span id="street-distance-researcher-high-quality-percentage"></span></td>
+                                    <td><span id="street-distance-researcher-all"></span></td>
+                                    <td><span id="street-distance-researcher-high-quality"></span></td>
                                     <td></td>
                                 </tr>
                             </table>

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -181,9 +181,9 @@
                                 </tr>
                                 <tr>
                                     <th>Audited Distance</th>
-                                    <th><span class="Audited-distance" id="all-time"></span></th>
-                                    <th><span class="Audited-distance" id="today"></span></th>
-                                    <th><span class="Audited-distance" id="week"></span></th>
+                                    <th><span id="audited-distance-all-time"></span></th>
+                                    <th><span id="audited-distance-today"></span></th>
+                                    <th><span id="audited-distance-week"></span></th>
                                 </tr>
                                 <tr>
                                     <th>Total Validation Users</th>
@@ -259,82 +259,82 @@
                                 </tr>
                                 <tr>
                                     <th>Audited Streets</th>
-                                    <td><span class="Coverage-audited-streets-totals" id="all-users-value"></span>
-                                        <span class="Coverage-audited-streets-totals" id="all-users-percentage"></span></td>
-                                    <td><span class="Coverage-audited-streets-totals" id="high-quality-value"></span>
-                                        <span class="Coverage-audited-streets-totals" id="high-quality-percentage"></span></td>
-                                    <td><span class="Coverage-audited-streets-totals" id="total-streets"></span></td>
+                                    <td><span id="audited-streets-totals-all-users-value"></span>
+                                        <span id="audited-streets-totals-all-users-percentage"></span></td>
+                                    <td><span id="audited-streets-totals-high-quality-value"></span>
+                                        <span id="audited-streets-totals-high-quality-percentage"></span></td>
+                                    <td><span id="audited-streets-totals-total-streets"></span></td>
                                 </tr>
                                 <tr style="font-size: 90%;">
                                     <td style="padding-left: 30px">Registered</td>
-                                    <td><span class="Coverage-audited-streets-registered" id="all-users-value"></span>
-                                        <span class="Coverage-audited-streets-registered" id="all-users-percentage"></span></td>
-                                    <td><span class="Coverage-audited-streets-registered" id="high-quality-value"></span>
-                                        <span class="Coverage-audited-streets-registered" id="high-quality-percentage"></span></td>
+                                    <td><span id="audited-streets-registered-all-users-value"></span>
+                                        <span id="audited-streets-registered-all-users-percentage"></span></td>
+                                    <td><span id="audited-streets-registered-high-quality-value"></span>
+                                        <span id="audited-streets-registered-high-quality-percentage"></span></td>
                                     <td></td>
                                 </tr>
                                 <tr style="font-size: 90%;">
                                     <td style="padding-left: 30px">Anonymous</td>
-                                    <td><span class="Coverage-audited-streets-anonymous" id="all-users-value"></span>
-                                        <span class="Coverage-audited-streets-anonymous" id="all-users-percentage"></span></td>
-                                    <td><span class="Coverage-audited-streets-anonymous" id="high-quality-value"></span>
-                                        <span class="Coverage-audited-streets-anonymous" id="high-quality-percentage"></span></td>
+                                    <td><span id="audited-streets-anonymous-all-users-value"></span>
+                                        <span id="audited-streets-anonymous-all-users-percentage"></span></td>
+                                    <td><span id="audited-streets-anonymous-high-quality-value"></span>
+                                        <span id="audited-streets-anonymous-high-quality-percentage"></span></td>
                                     <td></td>
                                 </tr>
                                 <tr style="font-size: 90%;">
                                     <td style="padding-left: 30px">Turker</td>
-                                    <td><span class="Coverage-audited-streets-turker" id="all-users-value"></span>
-                                        <span class="Coverage-audited-streets-turker" id="all-users-percentage"></span></td>
-                                    <td><span class="Coverage-audited-streets-turker" id="high-quality-value"></span>
-                                        <span class="Coverage-audited-streets-turker" id="high-quality-percentage"></span></td>
+                                    <td><span id="audited-streets-turker-all-users-value"></span>
+                                        <span id="audited-streets-turker-all-users-percentage"></span></td>
+                                    <td><span id="audited-streets-turker-high-quality-value"></span>
+                                        <span id="audited-streets-turker-high-quality-percentage"></span></td>
                                     <td></td>
                                 </tr>
                                 <tr style="font-size: 90%;">
                                     <td style="padding-left: 30px">Researcher</td>
-                                    <td><span class="Coverage-audited-streets-researcher" id="all-users-value"></span>
-                                        <span class="Coverage-audited-streets-researcher" id="all-users-percentage"></span></td>
-                                    <td><span class="Coverage-audited-streets-researcher" id="high-quality-value"></span>
-                                        <span class="Coverage-audited-streets-researcher" id="high-quality-percentage"></span></td>
+                                    <td><span id="audited-streets-researcher-all-users-value"></span>
+                                        <span id="audited-streets-researcher-all-users-percentage"></span></td>
+                                    <td><span id="audited-streets-researcher-high-quality-value"></span>
+                                        <span id="audited-streets-researcher-high-quality-percentage"></span></td>
                                     <td></td>
                                 </tr>
                                 <tr>
                                     <th>Distance</th>
-                                    <td><span class="Coverage-distance-totals" id="all-users-value"></span>
-                                        <span class="Coverage-distance-totals" id="all-users-percentage"></span></td>
-                                    <td><span class="Coverage-distance-totals" id="high-quality-value"></span> 
-                                        <span class="Coverage-distance-totals" id="high-quality-percentage"></span></td>
-                                    <td><span class="Coverage-distance-totals" id="total-distance"></span></td>
+                                    <td><span id="distance-totals-all-users-value"></span>
+                                        <span id="distance-totals-all-users-percentage"></span></td>
+                                    <td><span id="distance-totals-high-quality-value"></span> 
+                                        <span id="distance-totals-high-quality-percentage"></span></td>
+                                    <td><span id="distance-totals-total-distance"></span></td>
                                 </tr>
                                 <tr style="font-size: 90%;">
                                     <td style="padding-left: 30px">Registered</td>
-                                    <td><span class="Coverage-distance-registered" id="all-users-value"></span>
-                                        <span class="Coverage-distance-registered" id="all-users-percentage"></span></td>
-                                    <td><span class="Coverage-distance-registered" id="high-quality-value"></span>
-                                        <span class="Coverage-distance-registered" id="high-quality-percentage"></span></td>
+                                    <td><span id="distance-registered-all-users-value"></span>
+                                        <span id="distance-registered-all-users-percentage"></span></td>
+                                    <td><span id="distance-registered-high-quality-value"></span>
+                                        <span id="distance-registered-high-quality-percentage"></span></td>
                                     <td></td>
                                 </tr>
                                 <tr style="font-size: 90%;">
                                     <td style="padding-left: 30px">Anonymous</td>
-                                    <td><span class="Coverage-distance-anonymous" id="all-users-value"></span>
-                                        <span class="Coverage-distance-anonymous" id="all-users-percentage"></span></td>
-                                    <td><span class="Coverage-distance-anonymous" id="high-quality-value"></span>
-                                        <span class="Coverage-distance-anonymous" id="high-quality-percentage"></span></td>
+                                    <td><span id="distance-anonymous-all-users-value"></span>
+                                        <span id="distance-anonymous-all-users-percentage"></span></td>
+                                    <td><span id="distance-anonymous-high-quality-value"></span>
+                                        <span id="distance-anonymous-high-quality-percentage"></span></td>
                                     <td></td>
                                 </tr>
                                 <tr style="font-size: 90%;">
                                     <td style="padding-left: 30px">Turker</td>
-                                    <td><span class="Coverage-distance-turker" id="all-users-value"></span>
-                                        <span class="Coverage-distance-turker" id="all-users-percentage"></span></td>
-                                    <td><span class="Coverage-distance-turker" id="high-quality-value"></span>
-                                        <span class="Coverage-distance-turker" id="high-quality-percentage"></span></td>
+                                    <td><span id="distance-turker-all-users-value"></span>
+                                        <span id="distance-turker-all-users-percentage"></span></td>
+                                    <td><span id="distance-turker-high-quality-value"></span>
+                                        <span id="distance-turker-high-quality-percentage"></span></td>
                                     <td></td>
                                 </tr>
                                 <tr style="font-size: 90%;">
                                     <td style="padding-left: 30px">Researcher</td>
-                                    <td><span class="Coverage-distance-researcher" id="all-users-value"></span>
-                                        <span class="Coverage-distance-researcher" id="all-users-percentage"></span></td>
-                                    <td><span class="Coverage-distance-researcher" id="high-quality-value"></span>
-                                        <span class="Coverage-distance-researcher" id="high-quality-percentage"></span></td>
+                                    <td><span id="distance-researcher-all-users-value"></span>
+                                        <span id="distance-researcher-all-users-percentage"></span></td>
+                                    <td><span id="distance-researcher-high-quality-value"></span>
+                                        <span id="distance-researcher-high-quality-percentage"></span></td>
                                     <td></td>
                                 </tr>
                             </table>
@@ -946,13 +946,6 @@
                 debug: false
             }, function(err, t) {
                 window.admin = Admin(_, $);
-                
-                // Load street edge data from the backend & make the loader finish after that data loads.
-                window.admin.loadStreetEdgeData().then(function() {
-                    $('.loader').fadeOut('slow');
-                }).catch(function(error) {
-                    console.error("Error loading street edge data:", error);
-                });
 
                 $('#comments-table').dataTable();
                 $('#label-table').dataTable();

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -259,82 +259,82 @@
                                 </tr>
                                 <tr>
                                     <th>Audited Streets</th>
-                                    <td><span id="audited-streets-totals-all-users-value"></span>
-                                        <span id="audited-streets-totals-all-users-percentage"></span></td>
-                                    <td><span id="audited-streets-totals-high-quality-value"></span>
-                                        <span id="audited-streets-totals-high-quality-percentage"></span></td>
-                                    <td><span id="audited-streets-totals-total-streets"></span></td>
+                                    <td><span id="street-count-audited-all-users"></span>
+                                        <span id="street-count-audited-all-users-percentage"></span></td>
+                                    <td><span id="street-count-audited-high-quality-total"></span>
+                                        <span id="street-count-audited-high-quality-percentage"></span></td>
+                                    <td><span id="street-count-total"></span></td>
                                 </tr>
                                 <tr style="font-size: 90%;">
                                     <td style="padding-left: 30px">Registered</td>
-                                    <td><span id="audited-streets-registered-all-users-value"></span>
-                                        <span id="audited-streets-registered-all-users-percentage"></span></td>
-                                    <td><span id="audited-streets-registered-high-quality-value"></span>
-                                        <span id="audited-streets-registered-high-quality-percentage"></span></td>
+                                    <td><span id="street-count-audited-registered-all"></span>
+                                        <span id="street-count-audited-registered-all-percentage"></span></td>
+                                    <td><span id="street-count-audited-registered-high-quality"></span>
+                                        <span id="street-count-audited-registered-high-quality-percentage"></span></td>
                                     <td></td>
                                 </tr>
                                 <tr style="font-size: 90%;">
                                     <td style="padding-left: 30px">Anonymous</td>
-                                    <td><span id="audited-streets-anonymous-all-users-value"></span>
-                                        <span id="audited-streets-anonymous-all-users-percentage"></span></td>
-                                    <td><span id="audited-streets-anonymous-high-quality-value"></span>
-                                        <span id="audited-streets-anonymous-high-quality-percentage"></span></td>
+                                    <td><span id="street-count-audited-anonymous-all"></span>
+                                        <span id="street-count-audited-anonymous-all-percentage"></span></td>
+                                    <td><span id="street-count-audited-anonymous-high-quality"></span>
+                                        <span id="street-count-audited-anonymous-high-quality-percentage"></span></td>
                                     <td></td>
                                 </tr>
                                 <tr style="font-size: 90%;">
                                     <td style="padding-left: 30px">Turker</td>
-                                    <td><span id="audited-streets-turker-all-users-value"></span>
-                                        <span id="audited-streets-turker-all-users-percentage"></span></td>
-                                    <td><span id="audited-streets-turker-high-quality-value"></span>
-                                        <span id="audited-streets-turker-high-quality-percentage"></span></td>
+                                    <td><span id="street-count-audited-turker-all"></span>
+                                        <span id="street-count-audited-turker-all-percentage"></span></td>
+                                    <td><span id="street-count-audited-turker-high-quality"></span>
+                                        <span id="street-count-audited-turker-high-quality-percentage"></span></td>
                                     <td></td>
                                 </tr>
                                 <tr style="font-size: 90%;">
                                     <td style="padding-left: 30px">Researcher</td>
-                                    <td><span id="audited-streets-researcher-all-users-value"></span>
-                                        <span id="audited-streets-researcher-all-users-percentage"></span></td>
-                                    <td><span id="audited-streets-researcher-high-quality-value"></span>
-                                        <span id="audited-streets-researcher-high-quality-percentage"></span></td>
+                                    <td><span id="street-count-audited-researcher-all"></span>
+                                        <span id="street-count-audited-researcher-all-percentage"></span></td>
+                                    <td><span id="street-count-audited-researcher-high-quality"></span>
+                                        <span id="street-count-audited-researcher-high-quality-percentage"></span></td>
                                     <td></td>
                                 </tr>
                                 <tr>
                                     <th>Distance</th>
-                                    <td><span id="distance-totals-all-users-value"></span>
-                                        <span id="distance-totals-all-users-percentage"></span></td>
-                                    <td><span id="distance-totals-high-quality-value"></span> 
-                                        <span id="distance-totals-high-quality-percentage"></span></td>
-                                    <td><span id="distance-totals-total-distance"></span></td>
+                                    <td><span id="street-distance-audited-all-users"></span>
+                                        <span id="street-distance-audited-all-users-percentage"></span></td>
+                                    <td><span id="street-distance-audited-high-quality"></span>
+                                        <span id="street-distance-audited-high-quality-percentage"></span></td>
+                                    <td><span id="street-distance-total"></span></td>
                                 </tr>
                                 <tr style="font-size: 90%;">
                                     <td style="padding-left: 30px">Registered</td>
-                                    <td><span id="distance-registered-all-users-value"></span>
-                                        <span id="distance-registered-all-users-percentage"></span></td>
-                                    <td><span id="distance-registered-high-quality-value"></span>
-                                        <span id="distance-registered-high-quality-percentage"></span></td>
+                                    <td><span id="street-distance-registered-all"></span>
+                                        <span id="street-distance-registered-all-percentage"></span></td>
+                                    <td><span id="street-distance-registered-high-quality"></span>
+                                        <span id="street-distance-registered-high-quality-percentage"></span></td>
                                     <td></td>
                                 </tr>
                                 <tr style="font-size: 90%;">
                                     <td style="padding-left: 30px">Anonymous</td>
-                                    <td><span id="distance-anonymous-all-users-value"></span>
-                                        <span id="distance-anonymous-all-users-percentage"></span></td>
-                                    <td><span id="distance-anonymous-high-quality-value"></span>
-                                        <span id="distance-anonymous-high-quality-percentage"></span></td>
+                                    <td><span id="street-distance-anonymous-all"></span>
+                                        <span id="street-distance-anonymous-all-percentage"></span></td>
+                                    <td><span id="street-distance-anonymous-high-quality"></span>
+                                        <span id="street-distance-anonymous-high-quality-percentage"></span></td>
                                     <td></td>
                                 </tr>
                                 <tr style="font-size: 90%;">
                                     <td style="padding-left: 30px">Turker</td>
-                                    <td><span id="distance-turker-all-users-value"></span>
-                                        <span id="distance-turker-all-users-percentage"></span></td>
-                                    <td><span id="distance-turker-high-quality-value"></span>
-                                        <span id="distance-turker-high-quality-percentage"></span></td>
+                                    <td><span id="street-distance-turker-all"></span>
+                                        <span id="street-distance-turker-all-percentage"></span></td>
+                                    <td><span id="street-distance-turker-high-quality"></span>
+                                        <span id="street-distance-turker-high-quality-percentage"></span></td>
                                     <td></td>
                                 </tr>
                                 <tr style="font-size: 90%;">
                                     <td style="padding-left: 30px">Researcher</td>
-                                    <td><span id="distance-researcher-all-users-value"></span>
-                                        <span id="distance-researcher-all-users-percentage"></span></td>
-                                    <td><span id="distance-researcher-high-quality-value"></span>
-                                        <span id="distance-researcher-high-quality-percentage"></span></td>
+                                    <td><span id="street-distance-researcher-all"></span>
+                                        <span id="street-distance-researcher-all-percentage"></span></td>
+                                    <td><span id="street-distance-researcher-high-quality"></span>
+                                        <span id="street-distance-researcher-high-quality-percentage"></span></td>
                                     <td></td>
                                 </tr>
                             </table>

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -2,7 +2,6 @@
 @import models.daos.slick._
 @import models.audit._
 @import models.label._
-@import models.street.StreetEdgeTable
 @import models.audit.AuditTaskCommentTable
 @import models.utils.DataFormatter
 

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -8,10 +8,6 @@
 
 @import models.user.OrganizationTable
 @(title: String, user: Option[User] = None)(implicit lang: Lang)
-@convertDistance(distance: Float) = @{
-    if (Messages("measurement.system") == "metric") distance * 1.60934.toDouble
-    else distance.toDouble
-}
 @main(title) {
     @navbar(user, Some("/admin"))
     <style>
@@ -185,9 +181,9 @@
                                 </tr>
                                 <tr>
                                     <th>Audited Distance</th>
-                                    <th>@("%.1f".format(convertDistance(StreetEdgeTable.auditedStreetDistanceOverTime("all time")))) @Messages("dist.metric.abbr")</td>
-                                    <th>@("%.1f".format(convertDistance(StreetEdgeTable.auditedStreetDistanceOverTime("today")))) @Messages("dist.metric.abbr")</td>
-                                    <th>@("%.1f".format(convertDistance(StreetEdgeTable.auditedStreetDistanceOverTime("week")))) @Messages("dist.metric.abbr")</td>
+                                    <th><span class="Audited-distance" id="all-time"></span></th>
+                                    <th><span class="Audited-distance" id="today"></span></th>
+                                    <th><span class="Audited-distance" id="week"></span></th>
                                 </tr>
                                 <tr>
                                     <th>Total Validation Users</th>
@@ -263,82 +259,82 @@
                                 </tr>
                                 <tr>
                                     <th>Audited Streets</th>
-                                    <td>@StreetEdgeTable.countAuditedStreets()
-                                        (@("%.0f".format(StreetEdgeTable.auditCompletionRate(1) * 100))%)</td>
-                                    <td>@StreetEdgeTable.countAuditedStreets(1, "All", true)
-                                        (@("%.0f".format(StreetEdgeTable.auditCompletionRate(1, "All", true) * 100))%)</td>
-                                    <td>@StreetEdgeTable.countTotalStreets()</td>
+                                    <td><span class="Coverage-audited-streets-totals" id="all-users-value"></span>
+                                        <span class="Coverage-audited-streets-totals" id="all-users-percentage"></span></td>
+                                    <td><span class="Coverage-audited-streets-totals" id="high-quality-value"></span>
+                                        <span class="Coverage-audited-streets-totals" id="high-quality-percentage"></span></td>
+                                    <td><span class="Coverage-audited-streets-totals" id="total-streets"></span></td>
                                 </tr>
                                 <tr style="font-size: 90%;">
                                     <td style="padding-left: 30px">Registered</td>
-                                    <td>@StreetEdgeTable.countAuditedStreets(1, "Registered")
-                                        (@("%.0f".format(StreetEdgeTable.auditCompletionRate(1, "Registered") * 100))%)</td>
-                                    <td>@StreetEdgeTable.countAuditedStreets(1, "Registered", true)
-                                        (@("%.0f".format(StreetEdgeTable.auditCompletionRate(1, "Registered", true) * 100))%)</td>
+                                    <td><span class="Coverage-audited-streets-registered" id="all-users-value"></span>
+                                        <span class="Coverage-audited-streets-registered" id="all-users-percentage"></span></td>
+                                    <td><span class="Coverage-audited-streets-registered" id="high-quality-value"></span>
+                                        <span class="Coverage-audited-streets-registered" id="high-quality-percentage"></span></td>
                                     <td></td>
                                 </tr>
                                 <tr style="font-size: 90%;">
                                     <td style="padding-left: 30px">Anonymous</td>
-                                    <td>@StreetEdgeTable.countAuditedStreets(1, "Anonymous")
-                                        (@("%.0f".format(StreetEdgeTable.auditCompletionRate(1, "Anonymous") * 100))%)</td>
-                                    <td>@StreetEdgeTable.countAuditedStreets(1, "Anonymous", true)
-                                        (@("%.0f".format(StreetEdgeTable.auditCompletionRate(1, "Anonymous", true) * 100))%)</td>
+                                    <td><span class="Coverage-audited-streets-anonymous" id="all-users-value"></span>
+                                        <span class="Coverage-audited-streets-anonymous" id="all-users-percentage"></span></td>
+                                    <td><span class="Coverage-audited-streets-anonymous" id="high-quality-value"></span>
+                                        <span class="Coverage-audited-streets-anonymous" id="high-quality-percentage"></span></td>
                                     <td></td>
                                 </tr>
                                 <tr style="font-size: 90%;">
                                     <td style="padding-left: 30px">Turker</td>
-                                    <td>@StreetEdgeTable.countAuditedStreets(1, "Turker")
-                                        (@("%.0f".format(StreetEdgeTable.auditCompletionRate(1, "Turker") * 100))%)</td>
-                                    <td>@StreetEdgeTable.countAuditedStreets(1, "Turker", true)
-                                        (@("%.0f".format(StreetEdgeTable.auditCompletionRate(1, "Turker", true) * 100))%)</td>
+                                    <td><span class="Coverage-audited-streets-turker" id="all-users-value"></span>
+                                        <span class="Coverage-audited-streets-turker" id="all-users-percentage"></span></td>
+                                    <td><span class="Coverage-audited-streets-turker" id="high-quality-value"></span>
+                                        <span class="Coverage-audited-streets-turker" id="high-quality-percentage"></span></td>
                                     <td></td>
                                 </tr>
                                 <tr style="font-size: 90%;">
                                     <td style="padding-left: 30px">Researcher</td>
-                                    <td>@StreetEdgeTable.countAuditedStreets(1, "Researcher")
-                                        (@("%.0f".format(StreetEdgeTable.auditCompletionRate(1, "Researcher") * 100))%)</td>
-                                    <td>@StreetEdgeTable.countAuditedStreets(1, "Researcher", true)
-                                        (@("%.0f".format(StreetEdgeTable.auditCompletionRate(1, "Researcher", true) * 100))%)</td>
+                                    <td><span class="Coverage-audited-streets-researcher" id="all-users-value"></span>
+                                        <span class="Coverage-audited-streets-researcher" id="all-users-percentage"></span></td>
+                                    <td><span class="Coverage-audited-streets-researcher" id="high-quality-value"></span>
+                                        <span class="Coverage-audited-streets-researcher" id="high-quality-percentage"></span></td>
                                     <td></td>
                                 </tr>
                                 <tr>
                                     <th>Distance</th>
-                                    <td>@("%.1f".format(convertDistance(StreetEdgeTable.auditedStreetDistance(1)))) @Messages("dist.metric.abbr")
-                                        (@("%.0f".format(StreetEdgeTable.streetDistanceCompletionRate(1) * 100))%)</td>
-                                    <td>@("%.1f".format(convertDistance(StreetEdgeTable.auditedStreetDistance(1, "All", true)))) @Messages("dist.metric.abbr")
-                                        (@("%.0f".format(StreetEdgeTable.streetDistanceCompletionRate(1, "All", true) * 100))%)</td>
-                                    <td>@("%.1f".format(convertDistance(StreetEdgeTable.totalStreetDistance()))) @Messages("dist.metric.abbr")</td>
+                                    <td><span class="Coverage-distance-totals" id="all-users-value"></span>
+                                        <span class="Coverage-distance-totals" id="all-users-percentage"></span></td>
+                                    <td><span class="Coverage-distance-totals" id="high-quality-value"></span> 
+                                        <span class="Coverage-distance-totals" id="high-quality-percentage"></span></td>
+                                    <td><span class="Coverage-distance-totals" id="total-distance"></span></td>
                                 </tr>
                                 <tr style="font-size: 90%;">
                                     <td style="padding-left: 30px">Registered</td>
-                                    <td>@("%.1f".format(convertDistance(StreetEdgeTable.auditedStreetDistance(1, "Registered")))) @Messages("dist.metric.abbr")
-                                        (@("%.0f".format(StreetEdgeTable.streetDistanceCompletionRate(1, "Registered") * 100))%)</td>
-                                    <td>@("%.1f".format(convertDistance(StreetEdgeTable.auditedStreetDistance(1, "Registered", true)))) @Messages("dist.metric.abbr")
-                                        (@("%.0f".format(StreetEdgeTable.streetDistanceCompletionRate(1, "Registered", true) * 100))%)</td>
+                                    <td><span class="Coverage-distance-registered" id="all-users-value"></span>
+                                        <span class="Coverage-distance-registered" id="all-users-percentage"></span></td>
+                                    <td><span class="Coverage-distance-registered" id="high-quality-value"></span>
+                                        <span class="Coverage-distance-registered" id="high-quality-percentage"></span></td>
                                     <td></td>
                                 </tr>
                                 <tr style="font-size: 90%;">
                                     <td style="padding-left: 30px">Anonymous</td>
-                                    <td>@("%.1f".format(convertDistance(StreetEdgeTable.auditedStreetDistance(1, "Anonymous")))) @Messages("dist.metric.abbr")
-                                        (@("%.0f".format(StreetEdgeTable.streetDistanceCompletionRate(1, "Anonymous") * 100))%)</td>
-                                    <td>@("%.1f".format(convertDistance(StreetEdgeTable.auditedStreetDistance(1, "Anonymous", true)))) @Messages("dist.metric.abbr")
-                                        (@("%.0f".format(StreetEdgeTable.streetDistanceCompletionRate(1, "Anonymous", true) * 100))%)</td>
+                                    <td><span class="Coverage-distance-anonymous" id="all-users-value"></span>
+                                        <span class="Coverage-distance-anonymous" id="all-users-percentage"></span></td>
+                                    <td><span class="Coverage-distance-anonymous" id="high-quality-value"></span>
+                                        <span class="Coverage-distance-anonymous" id="high-quality-percentage"></span></td>
                                     <td></td>
                                 </tr>
                                 <tr style="font-size: 90%;">
                                     <td style="padding-left: 30px">Turker</td>
-                                    <td>@("%.1f".format(convertDistance(StreetEdgeTable.auditedStreetDistance(1, "Turker")))) @Messages("dist.metric.abbr")
-                                        (@("%.0f".format(StreetEdgeTable.streetDistanceCompletionRate(1, "Turker") * 100))%)</td>
-                                    <td>@("%.1f".format(convertDistance(StreetEdgeTable.auditedStreetDistance(1, "Turker", true)))) @Messages("dist.metric.abbr")
-                                        (@("%.0f".format(StreetEdgeTable.streetDistanceCompletionRate(1, "Turker", true) * 100))%)</td>
+                                    <td><span class="Coverage-distance-turker" id="all-users-value"></span>
+                                        <span class="Coverage-distance-turker" id="all-users-percentage"></span></td>
+                                    <td><span class="Coverage-distance-turker" id="high-quality-value"></span>
+                                        <span class="Coverage-distance-turker" id="high-quality-percentage"></span></td>
                                     <td></td>
                                 </tr>
                                 <tr style="font-size: 90%;">
                                     <td style="padding-left: 30px">Researcher</td>
-                                    <td>@("%.1f".format(convertDistance(StreetEdgeTable.auditedStreetDistance(1, "Researcher")))) @Messages("dist.metric.abbr")
-                                        (@("%.0f".format(StreetEdgeTable.streetDistanceCompletionRate(1, "Researcher") * 100))%)</td>
-                                    <td>@("%.1f".format(convertDistance(StreetEdgeTable.auditedStreetDistance(1, "Researcher", true)))) @Messages("dist.metric.abbr")
-                                        (@("%.0f".format(StreetEdgeTable.streetDistanceCompletionRate(1, "Researcher", true) * 100))%)</td>
+                                    <td><span class="Coverage-distance-researcher" id="all-users-value"></span>
+                                        <span class="Coverage-distance-researcher" id="all-users-percentage"></span></td>
+                                    <td><span class="Coverage-distance-researcher" id="high-quality-value"></span>
+                                        <span class="Coverage-distance-researcher" id="high-quality-percentage"></span></td>
                                     <td></td>
                                 </tr>
                             </table>
@@ -950,6 +946,14 @@
                 debug: false
             }, function(err, t) {
                 window.admin = Admin(_, $);
+                
+                // Load street edge data from the backend & make the loader finish after that data loads.
+                window.admin.loadStreetEdgeData().then(function() {
+                    $('.loader').fadeOut('slow');
+                }).catch(function(error) {
+                    console.error("Error loading street edge data:", error);
+                });
+
                 $('#comments-table').dataTable();
                 $('#label-table').dataTable();
                 $('#user-table').dataTable();
@@ -966,9 +970,6 @@
             console.log("To add data from users marked as 'low quality'', use the following commands. You can run them again with 'false' to remove.");
             console.log("admin.mapData.lowQualityUsers = true;");
             console.log("filterLabelLayers('', admin.map, admin.mapData);");
-        });
-        $(window).load(function() {
-            $('.loader').fadeOut('slow');
         });
     </script>
 }

--- a/conf/routes
+++ b/conf/routes
@@ -76,7 +76,7 @@ GET     /adminapi/attributes/all                             @controllers.AdminC
 GET     /adminapi/validationCounts                           @controllers.AdminController.getAllUserValidationCounts
 PUT     /adminapi/clearPlayCache                             @controllers.AdminController.clearPlayCache
 GET     /adminapi/updateUserStats                            @controllers.AdminController.updateUserStats(hoursCutoff: Option[Int])
-GET     /adminapi/getCoverageData                          @controllers.AdminController.getCoverageData
+GET     /adminapi/getCoverageData                            @controllers.AdminController.getCoverageData
 
 GET     /adminapi/webpageActivity                            @controllers.AdminController.getAllWebpageActivities
 GET     /adminapi/webpageActivity/:activity                  @controllers.AdminController.getWebpageActivities(activity: String)

--- a/conf/routes
+++ b/conf/routes
@@ -76,6 +76,7 @@ GET     /adminapi/attributes/all                             @controllers.AdminC
 GET     /adminapi/validationCounts                           @controllers.AdminController.getAllUserValidationCounts
 PUT     /adminapi/clearPlayCache                             @controllers.AdminController.clearPlayCache
 GET     /adminapi/updateUserStats                            @controllers.AdminController.updateUserStats(hoursCutoff: Option[Int])
+GET     /adminapi/getCoverageData                          @controllers.AdminController.getCoverageData
 
 GET     /adminapi/webpageActivity                            @controllers.AdminController.getAllWebpageActivities
 GET     /adminapi/webpageActivity/:activity                  @controllers.AdminController.getWebpageActivities(activity: String)

--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -39,7 +39,6 @@ function Admin(_, $) {
         }).catch(function(error) {
             console.error("Error loading street edge data:", error);
         });
-        return self;
     }
 
     function initializeAdminGSVLabelView() {
@@ -1170,68 +1169,65 @@ function Admin(_, $) {
         return `${distanceInCorrectUnits.toFixed(1)} ${distanceMetricAbbrev}`;
     }
 
-    function formatPercent(value) {
-        return `(${Math.round(value)}%)`;
+    function formatPercent(percent) {
+        return `(${Math.round(percent)}%)`;
+    }
+
+    function calculatePercent(value, total) {
+        return (value / total) * 100;
+    }
+
+    function formatCountWithPercent(count, total) {
+        const percent = calculatePercent(count, total);
+        return `${count} ${formatPercent(percent)}`;
+    }
+
+    function formatDistanceWithPercent(distance, total) {
+        const percent = calculatePercent(distance, total);
+        return `${formatDistance(distance)} ${formatPercent(percent)}`;
     }
 
     function loadStreetEdgeData() {
         return new Promise((resolve, reject) => {
             $.getJSON("/adminapi/getCoverageData", function (data) {
-                // Set Audited Streets section of the Street Edge Table.
-                $("#street-count-audited-all-users").text(data.street_counts.audited.all_users.total);
-                $("#street-count-audited-all-users-percentage").text(formatPercent(data.street_counts.audited.all_users.percentage));
-                $("#street-count-audited-high-quality-total").text(data.street_counts.audited.high_quality.total);
-                $("#street-count-audited-high-quality-percentage").text(formatPercent(data.street_counts.audited.high_quality.percentage));
-    
-                $("#street-count-total").text(data.street_counts.total);
+                const totalAuditedStreets = data.street_counts.total;
+                const totalAuditedDistance = data.street_distance.total;
 
-                $("#street-count-audited-registered-all").text(data.street_counts.audited.registered.all.total);
-                $("#street-count-audited-registered-all-percentage").text(formatPercent(data.street_counts.audited.registered.all.percentage));
-                $("#street-count-audited-registered-high-quality").text(data.street_counts.audited.registered.high_quality.total);
-                $("#street-count-audited-registered-high-quality-percentage").text(formatPercent(data.street_counts.audited.registered.high_quality.percentage));
+                // Set Audited Streets section of the Street Edge Table.
+                $("#street-count-audited-all").text(formatCountWithPercent(data.street_counts.audited.all_users.all, totalAuditedStreets));
+                $("#street-count-audited-high-quality").text(formatCountWithPercent(data.street_counts.audited.all_users.high_quality, totalAuditedStreets));
     
-                $("#street-count-audited-anonymous-all").text(data.street_counts.audited.anonymous.all.total);
-                $("#street-count-audited-anonymous-all-percentage").text(formatPercent(data.street_counts.audited.anonymous.all.percentage));
-                $("#street-count-audited-anonymous-high-quality").text(data.street_counts.audited.anonymous.high_quality.total);
-                $("#street-count-audited-anonymous-high-quality-percentage").text(formatPercent(data.street_counts.audited.anonymous.high_quality.percentage));
+                $("#street-count-total").text(totalAuditedStreets);
+
+                $("#street-count-audited-registered-all").text(formatCountWithPercent(data.street_counts.audited.registered.all, totalAuditedStreets));
+                $("#street-count-audited-registered-high-quality").text(formatCountWithPercent(data.street_counts.audited.registered.high_quality, totalAuditedStreets));
     
-                $("#street-count-audited-turker-all").text(data.street_counts.audited.turker.all.total);
-                $("#street-count-audited-turker-all-percentage").text(formatPercent(data.street_counts.audited.turker.all.percentage));
-                $("#street-count-audited-turker-high-quality").text(data.street_counts.audited.turker.high_quality.total);
-                $("#street-count-audited-turker-high-quality-percentage").text(formatPercent(data.street_counts.audited.turker.high_quality.percentage));
+                $("#street-count-audited-anonymous-all").text(formatCountWithPercent(data.street_counts.audited.anonymous.all, totalAuditedStreets));
+                $("#street-count-audited-anonymous-high-quality").text(formatCountWithPercent(data.street_counts.audited.anonymous.high_quality, totalAuditedStreets));
     
-                $("#street-count-audited-researcher-all").text(data.street_counts.audited.researcher.all.total);
-                $("#street-count-audited-researcher-all-percentage").text(formatPercent(data.street_counts.audited.researcher.all.percentage));
-                $("#street-count-audited-researcher-high-quality").text(data.street_counts.audited.researcher.high_quality.total);
-                $("#street-count-audited-researcher-high-quality-percentage").text(formatPercent(data.street_counts.audited.researcher.high_quality.percentage));
+                $("#street-count-audited-turker-all").text(formatCountWithPercent(data.street_counts.audited.turker.all, totalAuditedStreets));
+                $("#street-count-audited-turker-high-quality").text(formatCountWithPercent(data.street_counts.audited.turker.high_quality, totalAuditedStreets));
+    
+                $("#street-count-audited-researcher-all").text(formatCountWithPercent(data.street_counts.audited.researcher.all, totalAuditedStreets));
+                $("#street-count-audited-researcher-high-quality").text(formatCountWithPercent(data.street_counts.audited.researcher.high_quality, totalAuditedStreets));
     
                 // Set Distance section of the Street Edge Table.
-                $("#street-distance-audited-all-users").text(formatDistance(data.street_distance.audited.all_users.total));
-                $("#street-distance-audited-all-users-percentage").text(formatPercent(data.street_distance.audited.all_users.percentage));
-                $("#street-distance-audited-high-quality").text(formatDistance(data.street_distance.audited.high_quality.total));
-                $("#street-distance-audited-high-quality-percentage").text(formatPercent(data.street_distance.audited.high_quality.percentage));
+                $("#street-distance-audited-all").text(formatDistanceWithPercent(data.street_distance.audited.all_users.all, totalAuditedDistance));
+                $("#street-distance-audited-high-quality").text(formatDistanceWithPercent(data.street_distance.audited.all_users.high_quality, totalAuditedDistance));
     
-                $("#street-distance-total").text(formatDistance(data.street_distance.total));
+                $("#street-distance-total").text(formatDistance(totalAuditedDistance));
     
-                $("#street-distance-registered-all").text(formatDistance(data.street_distance.audited.registered.all.total));
-                $("#street-distance-registered-all-percentage").text(formatPercent(data.street_distance.audited.registered.all.percentage));
-                $("#street-distance-registered-high-quality").text(formatDistance(data.street_distance.audited.registered.high_quality.total));
-                $("#street-distance-registered-high-quality-percentage").text(formatPercent(data.street_distance.audited.registered.high_quality.percentage));
+                $("#street-distance-registered-all").text(formatDistanceWithPercent(data.street_distance.audited.registered.all, totalAuditedDistance));
+                $("#street-distance-registered-high-quality").text(formatDistanceWithPercent(data.street_distance.audited.registered.high_quality, totalAuditedDistance));
     
-                $("#street-distance-anonymous-all").text(formatDistance(data.street_distance.audited.anonymous.all.total));
-                $("#street-distance-anonymous-all-percentage").text(formatPercent(data.street_distance.audited.anonymous.all.percentage));
-                $("#street-distance-anonymous-high-quality").text(formatDistance(data.street_distance.audited.anonymous.high_quality.total));
-                $("#street-distance-anonymous-high-quality-percentage").text(formatPercent(data.street_distance.audited.anonymous.high_quality.percentage));
+                $("#street-distance-anonymous-all").text(formatDistanceWithPercent(data.street_distance.audited.anonymous.all, totalAuditedDistance));
+                $("#street-distance-anonymous-high-quality").text(formatDistanceWithPercent(data.street_distance.audited.anonymous.high_quality, totalAuditedDistance));
     
-                $("#street-distance-turker-all").text(formatDistance(data.street_distance.audited.turker.all.total));
-                $("#street-distance-turker-all-percentage").text(formatPercent(data.street_distance.audited.turker.all.percentage));
-                $("#street-distance-turker-high-quality").text(formatDistance(data.street_distance.audited.turker.high_quality.total));
-                $("#street-distance-turker-high-quality-percentage").text(formatPercent(data.street_distance.audited.turker.high_quality.percentage));
+                $("#street-distance-turker-all").text(formatDistanceWithPercent(data.street_distance.audited.turker.all, totalAuditedDistance));
+                $("#street-distance-turker-high-quality").text(formatDistanceWithPercent(data.street_distance.audited.turker.high_quality, totalAuditedDistance));
     
-                $("#street-distance-researcher-all").text(formatDistance(data.street_distance.audited.researcher.all.total));
-                $("#street-distance-researcher-all-percentage").text(formatPercent(data.street_distance.audited.researcher.all.percentage));
-                $("#street-distance-researcher-high-quality").text(formatDistance(data.street_distance.audited.researcher.high_quality.total));
-                $("#street-distance-researcher-high-quality-percentage").text(formatPercent(data.street_distance.audited.researcher.high_quality.percentage));
+                $("#street-distance-researcher-all").text(formatDistanceWithPercent(data.street_distance.audited.researcher.all, totalAuditedDistance));
+                $("#street-distance-researcher-high-quality").text(formatDistanceWithPercent(data.street_distance.audited.researcher.high_quality, totalAuditedDistance));
     
                 // Set the audited distance fields.
                 $("#audited-distance-all-time").text(formatDistance(data.street_distance.audited.with_overlap.all_time));
@@ -1257,4 +1253,5 @@ function Admin(_, $) {
     $('.change-org').on('click', changeOrg);
 
     _init();
+    return self;
 }

--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -32,6 +32,16 @@ function Admin(_, $) {
         logClicks: false
     };
 
+    // Constructor: load street edge data from the backend & make the loader finish after that data loads.
+    function _init() {
+        loadStreetEdgeData().then(function() {
+            $('.loader').fadeOut('slow');
+        }).catch(function(error) {
+            console.error("Error loading street edge data:", error);
+        });
+        return self;
+    }
+
     function initializeAdminGSVLabelView() {
         self.adminGSVLabelView = AdminGSVLabelView(true, "AdminContributionsTab");
     }
@@ -1152,76 +1162,76 @@ function Admin(_, $) {
 
     function convertDistance(distance) {
         if(i18next.t('common:measurement-system') === "metric") {
-            return distance * 1.60934;
+            return util.math.milesToKilometers(distance);
         }
         return distance;
     }
 
     function loadStreetEdgeData() {
         return new Promise((resolve, reject) => {
-            $.getJSON("/adminapi/getStreetEdgeData", function (data) {
+            $.getJSON("/adminapi/getCoverageData", function (data) {
                 // Set Audited Streets section of the Street Edge Table.
-                $(".Coverage-audited-streets-totals#all-users-value").html(data.audited_streets.total_audited_streets.all_users.total);
-                $(".Coverage-audited-streets-totals#all-users-percentage").html(`(${Math.round(data.audited_streets.total_audited_streets.all_users.percentage)}%)`);
-                $(".Coverage-audited-streets-totals#high-quality-value").html(data.audited_streets.total_audited_streets.high_quality.total);
-                $(".Coverage-audited-streets-totals#high-quality-percentage").html(`(${Math.round(data.audited_streets.total_audited_streets.high_quality.percentage)}%)`);
+                $("#audited-streets-totals-all-users-value").html(data.audited_streets.total_audited_streets.all_users.total);
+                $("#audited-streets-totals-all-users-percentage").html(`(${Math.round(data.audited_streets.total_audited_streets.all_users.percentage)}%)`);
+                $("#audited-streets-totals-high-quality-value").html(data.audited_streets.total_audited_streets.high_quality.total);
+                $("#audited-streets-totals-high-quality-percentage").html(`(${Math.round(data.audited_streets.total_audited_streets.high_quality.percentage)}%)`);
     
-                $(".Coverage-audited-streets-totals#total-streets").html(data.audited_streets.total_streets);
+                $("#audited-streets-totals-total-streets").html(data.audited_streets.total_streets);
 
-                $(".Coverage-audited-streets-registered#all-users-value").html(data.audited_streets.registered.all_users.total);
-                $(".Coverage-audited-streets-registered#all-users-percentage").html(`(${Math.round(data.audited_streets.registered.all_users.percentage)}%)`);
-                $(".Coverage-audited-streets-registered#high-quality-value").html(data.audited_streets.registered.high_quality.total);
-                $(".Coverage-audited-streets-registered#high-quality-percentage").html(`(${Math.round(data.audited_streets.registered.high_quality.percentage)}%)`);
+                $("#audited-streets-registered-all-users-value").html(data.audited_streets.registered.all_users.total);
+                $("#audited-streets-registered-all-users-percentage").html(`(${Math.round(data.audited_streets.registered.all_users.percentage)}%)`);
+                $("#audited-streets-registered-high-quality-value").html(data.audited_streets.registered.high_quality.total);
+                $("#audited-streets-registered-high-quality-percentage").html(`(${Math.round(data.audited_streets.registered.high_quality.percentage)}%)`);
     
-                $(".Coverage-audited-streets-anonymous#all-users-value").html(data.audited_streets.anonymous.all_users.total);
-                $(".Coverage-audited-streets-anonymous#all-users-percentage").html(`(${Math.round(data.audited_streets.anonymous.all_users.percentage)}%)`);
-                $(".Coverage-audited-streets-anonymous#high-quality-value").html(data.audited_streets.anonymous.high_quality.total);
-                $(".Coverage-audited-streets-anonymous#high-quality-percentage").html(`(${Math.round(data.audited_streets.anonymous.high_quality.percentage)}%)`);
+                $("#audited-streets-anonymous-all-users-value").html(data.audited_streets.anonymous.all_users.total);
+                $("#audited-streets-anonymous-all-users-percentage").html(`(${Math.round(data.audited_streets.anonymous.all_users.percentage)}%)`);
+                $("#audited-streets-anonymous-high-quality-value").html(data.audited_streets.anonymous.high_quality.total);
+                $("#audited-streets-anonymous-high-quality-percentage").html(`(${Math.round(data.audited_streets.anonymous.high_quality.percentage)}%)`);
     
-                $(".Coverage-audited-streets-turker#all-users-value").html(data.audited_streets.turker.all_users.total);
-                $(".Coverage-audited-streets-turker#all-users-percentage").html(`(${Math.round(data.audited_streets.turker.all_users.percentage)}%)`);
-                $(".Coverage-audited-streets-turker#high-quality-value").html(data.audited_streets.turker.high_quality.total);
-                $(".Coverage-audited-streets-turker#high-quality-percentage").html(`(${Math.round(data.audited_streets.turker.high_quality.percentage)}%)`);
+                $("#audited-streets-turker-all-users-value").html(data.audited_streets.turker.all_users.total);
+                $("#audited-streets-turker-all-users-percentage").html(`(${Math.round(data.audited_streets.turker.all_users.percentage)}%)`);
+                $("#audited-streets-turker-high-quality-value").html(data.audited_streets.turker.high_quality.total);
+                $("#audited-streets-turker-high-quality-percentage").html(`(${Math.round(data.audited_streets.turker.high_quality.percentage)}%)`);
     
-                $(".Coverage-audited-streets-researcher#all-users-value").html(data.audited_streets.researcher.all_users.total);
-                $(".Coverage-audited-streets-researcher#all-users-percentage").html(`(${Math.round(data.audited_streets.researcher.all_users.percentage)}%)`);
-                $(".Coverage-audited-streets-researcher#high-quality-value").html(data.audited_streets.researcher.high_quality.total);
-                $(".Coverage-audited-streets-researcher#high-quality-percentage").html(`(${Math.round(data.audited_streets.researcher.high_quality.percentage)}%)`);
+                $("#audited-streets-researcher-all-users-value").html(data.audited_streets.researcher.all_users.total);
+                $("#audited-streets-researcher-all-users-percentage").html(`(${Math.round(data.audited_streets.researcher.all_users.percentage)}%)`);
+                $("#audited-streets-researcher-high-quality-value").html(data.audited_streets.researcher.high_quality.total);
+                $("#audited-streets-researcher-high-quality-percentage").html(`(${Math.round(data.audited_streets.researcher.high_quality.percentage)}%)`);
     
                 // Set Distance section of the Street Edge Table.
                 const distanceMetricAbbrev = i18next.t('common:unit-distance-abbreviation');
 
-                $(".Coverage-distance-totals#all-users-value").html(`${convertDistance(data.distance.total_audited_streets.all_users.total).toFixed(1)} ${distanceMetricAbbrev}`);
-                $(".Coverage-distance-totals#all-users-percentage").html(`(${Math.round(data.distance.total_audited_streets.all_users.percentage)}%)`);
-                $(".Coverage-distance-totals#high-quality-value").html(`${convertDistance(data.distance.total_audited_streets.high_quality.total).toFixed(1)} ${distanceMetricAbbrev}`);
-                $(".Coverage-distance-totals#high-quality-percentage").html(`(${Math.round(data.distance.total_audited_streets.high_quality.percentage)}%)`);
+                $("#distance-totals-all-users-value").html(`${convertDistance(data.distance.total_audited_streets.all_users.total).toFixed(1)} ${distanceMetricAbbrev}`);
+                $("#distance-totals-all-users-percentage").html(`(${Math.round(data.distance.total_audited_streets.all_users.percentage)}%)`);
+                $("#distance-totals-high-quality-value").html(`${convertDistance(data.distance.total_audited_streets.high_quality.total).toFixed(1)} ${distanceMetricAbbrev}`);
+                $("#distance-totals-high-quality-percentage").html(`(${Math.round(data.distance.total_audited_streets.high_quality.percentage)}%)`);
     
-                $(".Coverage-distance-totals#total-distance").html(`${convertDistance(data.distance.total_distance).toFixed(1)} ${distanceMetricAbbrev}`);
+                $("#distance-totals-total-distance").html(`${convertDistance(data.distance.total_distance).toFixed(1)} ${distanceMetricAbbrev}`);
     
-                $(".Coverage-distance-registered#all-users-value").html(`${convertDistance(data.distance.registered.all_users.total).toFixed(1)} ${distanceMetricAbbrev}`);
-                $(".Coverage-distance-registered#all-users-percentage").html(`(${Math.round(data.distance.registered.all_users.percentage)}%)`);
-                $(".Coverage-distance-registered#high-quality-value").html(`${convertDistance(data.distance.registered.high_quality.total).toFixed(1)} ${distanceMetricAbbrev}`);
-                $(".Coverage-distance-registered#high-quality-percentage").html(`(${Math.round(data.distance.registered.high_quality.percentage)}%)`);
+                $("#distance-registered-all-users-value").html(`${convertDistance(data.distance.registered.all_users.total).toFixed(1)} ${distanceMetricAbbrev}`);
+                $("#distance-registered-all-users-percentage").html(`(${Math.round(data.distance.registered.all_users.percentage)}%)`);
+                $("#distance-registered-high-quality-value").html(`${convertDistance(data.distance.registered.high_quality.total).toFixed(1)} ${distanceMetricAbbrev}`);
+                $("#distance-registered-high-quality-percentage").html(`(${Math.round(data.distance.registered.high_quality.percentage)}%)`);
     
-                $(".Coverage-distance-anonymous#all-users-value").html(`${convertDistance(data.distance.anonymous.all_users.total).toFixed(1)} ${distanceMetricAbbrev}`);
-                $(".Coverage-distance-anonymous#all-users-percentage").html(`(${Math.round(data.distance.anonymous.all_users.percentage)}%)`);
-                $(".Coverage-distance-anonymous#high-quality-value").html(`${convertDistance(data.distance.anonymous.high_quality.total).toFixed(1)} ${distanceMetricAbbrev}`);
-                $(".Coverage-distance-anonymous#high-quality-percentage").html(`(${Math.round(data.distance.anonymous.high_quality.percentage)}%)`);
+                $("#distance-anonymous-all-users-value").html(`${convertDistance(data.distance.anonymous.all_users.total).toFixed(1)} ${distanceMetricAbbrev}`);
+                $("#distance-anonymous-all-users-percentage").html(`(${Math.round(data.distance.anonymous.all_users.percentage)}%)`);
+                $("#distance-anonymous-high-quality-value").html(`${convertDistance(data.distance.anonymous.high_quality.total).toFixed(1)} ${distanceMetricAbbrev}`);
+                $("#distance-anonymous-high-quality-percentage").html(`(${Math.round(data.distance.anonymous.high_quality.percentage)}%)`);
     
-                $(".Coverage-distance-turker#all-users-value").html(`${convertDistance(data.distance.turker.all_users.total).toFixed(1)} ${distanceMetricAbbrev}`);
-                $(".Coverage-distance-turker#all-users-percentage").html(`(${Math.round(data.distance.turker.all_users.percentage)}%)`);
-                $(".Coverage-distance-turker#high-quality-value").html(`${convertDistance(data.distance.turker.high_quality.total).toFixed(1)} ${distanceMetricAbbrev}`);
-                $(".Coverage-distance-turker#high-quality-percentage").html(`(${Math.round(data.distance.turker.high_quality.percentage)}%)`);
+                $("#distance-turker-all-users-value").html(`${convertDistance(data.distance.turker.all_users.total).toFixed(1)} ${distanceMetricAbbrev}`);
+                $("#distance-turker-all-users-percentage").html(`(${Math.round(data.distance.turker.all_users.percentage)}%)`);
+                $("#distance-turker-high-quality-value").html(`${convertDistance(data.distance.turker.high_quality.total).toFixed(1)} ${distanceMetricAbbrev}`);
+                $("#distance-turker-high-quality-percentage").html(`(${Math.round(data.distance.turker.high_quality.percentage)}%)`);
     
-                $(".Coverage-distance-researcher#all-users-value").html(`${convertDistance(data.distance.researcher.all_users.total).toFixed(1)} ${distanceMetricAbbrev}`);
-                $(".Coverage-distance-researcher#all-users-percentage").html(`(${Math.round(data.distance.researcher.all_users.percentage)}%)`);
-                $(".Coverage-distance-researcher#high-quality-value").html(`${convertDistance(data.distance.researcher.high_quality.total).toFixed(1)} ${distanceMetricAbbrev}`);
-                $(".Coverage-distance-researcher#high-quality-percentage").html(`(${Math.round(data.distance.researcher.high_quality.percentage)}%)`);
+                $("#distance-researcher-all-users-value").html(`${convertDistance(data.distance.researcher.all_users.total).toFixed(1)} ${distanceMetricAbbrev}`);
+                $("#distance-researcher-all-users-percentage").html(`(${Math.round(data.distance.researcher.all_users.percentage)}%)`);
+                $("#distance-researcher-high-quality-value").html(`${convertDistance(data.distance.researcher.high_quality.total).toFixed(1)} ${distanceMetricAbbrev}`);
+                $("#distance-researcher-high-quality-percentage").html(`(${Math.round(data.distance.researcher.high_quality.percentage)}%)`);
     
                 // Set the audited distance fields.
-                $(".Audited-distance#all-time").html(`${convertDistance(data.audited_street_distance_over_time.all_time).toFixed(1)} ${distanceMetricAbbrev}`);
-                $(".Audited-distance#today").html(`${convertDistance(data.audited_street_distance_over_time.today).toFixed(1)} ${distanceMetricAbbrev}`);
-                $(".Audited-distance#week").html(`${convertDistance(data.audited_street_distance_over_time.week).toFixed(1)} ${distanceMetricAbbrev}`);
+                $("#audited-distance-all-time").html(`${convertDistance(data.audited_street_distance_over_time.all_time).toFixed(1)} ${distanceMetricAbbrev}`);
+                $("#audited-distance-today").html(`${convertDistance(data.audited_street_distance_over_time.today).toFixed(1)} ${distanceMetricAbbrev}`);
+                $("#audited-distance-week").html(`${convertDistance(data.audited_street_distance_over_time.week).toFixed(1)} ${distanceMetricAbbrev}`);
 
                 resolve();
             })
@@ -1241,5 +1251,5 @@ function Admin(_, $) {
     $('.change-role').on('click', changeRole);
     $('.change-org').on('click', changeOrg);
 
-    return self;
+    _init();
 }

--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -1150,6 +1150,85 @@ function Admin(_, $) {
         } )
     }
 
+    function convertDistance(distance) {
+        if(i18next.t('common:measurement-system') === "metric") {
+            return distance * 1.60934;
+        }
+        return distance;
+    }
+
+    function loadStreetEdgeData() {
+        return new Promise((resolve, reject) => {
+            $.getJSON("/adminapi/getStreetEdgeData", function (data) {
+                // Set Audited Streets section of the Street Edge Table.
+                $(".Coverage-audited-streets-totals#all-users-value").html(data.audited_streets.total_audited_streets.all_users.total);
+                $(".Coverage-audited-streets-totals#all-users-percentage").html(`(${Math.round(data.audited_streets.total_audited_streets.all_users.percentage)}%)`);
+                $(".Coverage-audited-streets-totals#high-quality-value").html(data.audited_streets.total_audited_streets.high_quality.total);
+                $(".Coverage-audited-streets-totals#high-quality-percentage").html(`(${Math.round(data.audited_streets.total_audited_streets.high_quality.percentage)}%)`);
+    
+                $(".Coverage-audited-streets-totals#total-streets").html(data.audited_streets.total_streets);
+
+                $(".Coverage-audited-streets-registered#all-users-value").html(data.audited_streets.registered.all_users.total);
+                $(".Coverage-audited-streets-registered#all-users-percentage").html(`(${Math.round(data.audited_streets.registered.all_users.percentage)}%)`);
+                $(".Coverage-audited-streets-registered#high-quality-value").html(data.audited_streets.registered.high_quality.total);
+                $(".Coverage-audited-streets-registered#high-quality-percentage").html(`(${Math.round(data.audited_streets.registered.high_quality.percentage)}%)`);
+    
+                $(".Coverage-audited-streets-anonymous#all-users-value").html(data.audited_streets.anonymous.all_users.total);
+                $(".Coverage-audited-streets-anonymous#all-users-percentage").html(`(${Math.round(data.audited_streets.anonymous.all_users.percentage)}%)`);
+                $(".Coverage-audited-streets-anonymous#high-quality-value").html(data.audited_streets.anonymous.high_quality.total);
+                $(".Coverage-audited-streets-anonymous#high-quality-percentage").html(`(${Math.round(data.audited_streets.anonymous.high_quality.percentage)}%)`);
+    
+                $(".Coverage-audited-streets-turker#all-users-value").html(data.audited_streets.turker.all_users.total);
+                $(".Coverage-audited-streets-turker#all-users-percentage").html(`(${Math.round(data.audited_streets.turker.all_users.percentage)}%)`);
+                $(".Coverage-audited-streets-turker#high-quality-value").html(data.audited_streets.turker.high_quality.total);
+                $(".Coverage-audited-streets-turker#high-quality-percentage").html(`(${Math.round(data.audited_streets.turker.high_quality.percentage)}%)`);
+    
+                $(".Coverage-audited-streets-researcher#all-users-value").html(data.audited_streets.researcher.all_users.total);
+                $(".Coverage-audited-streets-researcher#all-users-percentage").html(`(${Math.round(data.audited_streets.researcher.all_users.percentage)}%)`);
+                $(".Coverage-audited-streets-researcher#high-quality-value").html(data.audited_streets.researcher.high_quality.total);
+                $(".Coverage-audited-streets-researcher#high-quality-percentage").html(`(${Math.round(data.audited_streets.researcher.high_quality.percentage)}%)`);
+    
+                // Set Distance section of the Street Edge Table.
+                const distanceMetricAbbrev = i18next.t('common:unit-distance-abbreviation');
+
+                $(".Coverage-distance-totals#all-users-value").html(`${convertDistance(data.distance.total_audited_streets.all_users.total).toFixed(1)} ${distanceMetricAbbrev}`);
+                $(".Coverage-distance-totals#all-users-percentage").html(`(${Math.round(data.distance.total_audited_streets.all_users.percentage)}%)`);
+                $(".Coverage-distance-totals#high-quality-value").html(`${convertDistance(data.distance.total_audited_streets.high_quality.total).toFixed(1)} ${distanceMetricAbbrev}`);
+                $(".Coverage-distance-totals#high-quality-percentage").html(`(${Math.round(data.distance.total_audited_streets.high_quality.percentage)}%)`);
+    
+                $(".Coverage-distance-totals#total-distance").html(`${convertDistance(data.distance.total_distance).toFixed(1)} ${distanceMetricAbbrev}`);
+    
+                $(".Coverage-distance-registered#all-users-value").html(`${convertDistance(data.distance.registered.all_users.total).toFixed(1)} ${distanceMetricAbbrev}`);
+                $(".Coverage-distance-registered#all-users-percentage").html(`(${Math.round(data.distance.registered.all_users.percentage)}%)`);
+                $(".Coverage-distance-registered#high-quality-value").html(`${convertDistance(data.distance.registered.high_quality.total).toFixed(1)} ${distanceMetricAbbrev}`);
+                $(".Coverage-distance-registered#high-quality-percentage").html(`(${Math.round(data.distance.registered.high_quality.percentage)}%)`);
+    
+                $(".Coverage-distance-anonymous#all-users-value").html(`${convertDistance(data.distance.anonymous.all_users.total).toFixed(1)} ${distanceMetricAbbrev}`);
+                $(".Coverage-distance-anonymous#all-users-percentage").html(`(${Math.round(data.distance.anonymous.all_users.percentage)}%)`);
+                $(".Coverage-distance-anonymous#high-quality-value").html(`${convertDistance(data.distance.anonymous.high_quality.total).toFixed(1)} ${distanceMetricAbbrev}`);
+                $(".Coverage-distance-anonymous#high-quality-percentage").html(`(${Math.round(data.distance.anonymous.high_quality.percentage)}%)`);
+    
+                $(".Coverage-distance-turker#all-users-value").html(`${convertDistance(data.distance.turker.all_users.total).toFixed(1)} ${distanceMetricAbbrev}`);
+                $(".Coverage-distance-turker#all-users-percentage").html(`(${Math.round(data.distance.turker.all_users.percentage)}%)`);
+                $(".Coverage-distance-turker#high-quality-value").html(`${convertDistance(data.distance.turker.high_quality.total).toFixed(1)} ${distanceMetricAbbrev}`);
+                $(".Coverage-distance-turker#high-quality-percentage").html(`(${Math.round(data.distance.turker.high_quality.percentage)}%)`);
+    
+                $(".Coverage-distance-researcher#all-users-value").html(`${convertDistance(data.distance.researcher.all_users.total).toFixed(1)} ${distanceMetricAbbrev}`);
+                $(".Coverage-distance-researcher#all-users-percentage").html(`(${Math.round(data.distance.researcher.all_users.percentage)}%)`);
+                $(".Coverage-distance-researcher#high-quality-value").html(`${convertDistance(data.distance.researcher.high_quality.total).toFixed(1)} ${distanceMetricAbbrev}`);
+                $(".Coverage-distance-researcher#high-quality-percentage").html(`(${Math.round(data.distance.researcher.high_quality.percentage)}%)`);
+    
+                // Set the audited distance fields.
+                $(".Audited-distance#all-time").html(`${convertDistance(data.audited_street_distance_over_time.all_time).toFixed(1)} ${distanceMetricAbbrev}`);
+                $(".Audited-distance#today").html(`${convertDistance(data.audited_street_distance_over_time.today).toFixed(1)} ${distanceMetricAbbrev}`);
+                $(".Audited-distance#week").html(`${convertDistance(data.audited_street_distance_over_time.week).toFixed(1)} ${distanceMetricAbbrev}`);
+
+                resolve();
+            })
+        });
+    }
+    
+
     initializeLabelTable();
     initializeAdminGSVLabelView();
     initializeAdminLabelSearch();
@@ -1157,6 +1236,7 @@ function Admin(_, $) {
     initializeAdminGSVCommentWindow();
     
     self.clearPlayCache = clearPlayCache;
+    self.loadStreetEdgeData = loadStreetEdgeData;
 
     $('.change-role').on('click', changeRole);
     $('.change-org').on('click', changeOrg);

--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -1160,78 +1160,83 @@ function Admin(_, $) {
         } )
     }
 
-    function convertDistance(distance) {
-        if(i18next.t('common:measurement-system') === "metric") {
-            return util.math.milesToKilometers(distance);
+    function formatDistance(distance) {
+        const distanceMetricAbbrev = i18next.t('common:unit-distance-abbreviation');
+
+        let distanceInCorrectUnits = distance;
+        if (i18next.t('common:measurement-system') === "metric") {
+            distanceInCorrectUnits = util.math.milesToKilometers(distance);
         }
-        return distance;
+        return `${distanceInCorrectUnits.toFixed(1)} ${distanceMetricAbbrev}`;
+    }
+
+    function formatPercent(value) {
+        return `(${Math.round(value)}%)`;
     }
 
     function loadStreetEdgeData() {
         return new Promise((resolve, reject) => {
             $.getJSON("/adminapi/getCoverageData", function (data) {
                 // Set Audited Streets section of the Street Edge Table.
-                $("#audited-streets-totals-all-users-value").html(data.audited_streets.total_audited_streets.all_users.total);
-                $("#audited-streets-totals-all-users-percentage").html(`(${Math.round(data.audited_streets.total_audited_streets.all_users.percentage)}%)`);
-                $("#audited-streets-totals-high-quality-value").html(data.audited_streets.total_audited_streets.high_quality.total);
-                $("#audited-streets-totals-high-quality-percentage").html(`(${Math.round(data.audited_streets.total_audited_streets.high_quality.percentage)}%)`);
+                $("#street-count-audited-all-users").html(data.street_counts.audited.all_users.total);
+                $("#street-count-audited-all-users-percentage").html(formatPercent(data.street_counts.audited.all_users.percentage));
+                $("#street-count-audited-high-quality-total").html(data.street_counts.audited.high_quality.total);
+                $("#street-count-audited-high-quality-percentage").html(formatPercent(data.street_counts.audited.high_quality.percentage));
     
-                $("#audited-streets-totals-total-streets").html(data.audited_streets.total_streets);
+                $("#street-count-total").html(data.street_counts.total);
 
-                $("#audited-streets-registered-all-users-value").html(data.audited_streets.registered.all_users.total);
-                $("#audited-streets-registered-all-users-percentage").html(`(${Math.round(data.audited_streets.registered.all_users.percentage)}%)`);
-                $("#audited-streets-registered-high-quality-value").html(data.audited_streets.registered.high_quality.total);
-                $("#audited-streets-registered-high-quality-percentage").html(`(${Math.round(data.audited_streets.registered.high_quality.percentage)}%)`);
+                $("#street-count-audited-registered-all").html(data.street_counts.audited.registered.all.total);
+                $("#street-count-audited-registered-all-percentage").html(formatPercent(data.street_counts.audited.registered.all.percentage));
+                $("#street-count-audited-registered-high-quality").html(data.street_counts.audited.registered.high_quality.total);
+                $("#street-count-audited-registered-high-quality-percentage").html(formatPercent(data.street_counts.audited.registered.high_quality.percentage));
     
-                $("#audited-streets-anonymous-all-users-value").html(data.audited_streets.anonymous.all_users.total);
-                $("#audited-streets-anonymous-all-users-percentage").html(`(${Math.round(data.audited_streets.anonymous.all_users.percentage)}%)`);
-                $("#audited-streets-anonymous-high-quality-value").html(data.audited_streets.anonymous.high_quality.total);
-                $("#audited-streets-anonymous-high-quality-percentage").html(`(${Math.round(data.audited_streets.anonymous.high_quality.percentage)}%)`);
+                $("#street-count-audited-anonymous-all").html(data.street_counts.audited.anonymous.all.total);
+                $("#street-count-audited-anonymous-all-percentage").html(formatPercent(data.street_counts.audited.anonymous.all.percentage));
+                $("#street-count-audited-anonymous-high-quality").html(data.street_counts.audited.anonymous.high_quality.total);
+                $("#street-count-audited-anonymous-high-quality-percentage").html(formatPercent(data.street_counts.audited.anonymous.high_quality.percentage));
     
-                $("#audited-streets-turker-all-users-value").html(data.audited_streets.turker.all_users.total);
-                $("#audited-streets-turker-all-users-percentage").html(`(${Math.round(data.audited_streets.turker.all_users.percentage)}%)`);
-                $("#audited-streets-turker-high-quality-value").html(data.audited_streets.turker.high_quality.total);
-                $("#audited-streets-turker-high-quality-percentage").html(`(${Math.round(data.audited_streets.turker.high_quality.percentage)}%)`);
+                $("#street-count-audited-turker-all").html(data.street_counts.audited.turker.all.total);
+                $("#street-count-audited-turker-all-percentage").html(formatPercent(data.street_counts.audited.turker.all.percentage));
+                $("#street-count-audited-turker-high-quality").html(data.street_counts.audited.turker.high_quality.total);
+                $("#street-count-audited-turker-high-quality-percentage").html(formatPercent(data.street_counts.audited.turker.high_quality.percentage));
     
-                $("#audited-streets-researcher-all-users-value").html(data.audited_streets.researcher.all_users.total);
-                $("#audited-streets-researcher-all-users-percentage").html(`(${Math.round(data.audited_streets.researcher.all_users.percentage)}%)`);
-                $("#audited-streets-researcher-high-quality-value").html(data.audited_streets.researcher.high_quality.total);
-                $("#audited-streets-researcher-high-quality-percentage").html(`(${Math.round(data.audited_streets.researcher.high_quality.percentage)}%)`);
+                $("#street-count-audited-researcher-all").html(data.street_counts.audited.researcher.all.total);
+                $("#street-count-audited-researcher-all-percentage").html(formatPercent(data.street_counts.audited.researcher.all.percentage));
+                $("#street-count-audited-researcher-high-quality").html(data.street_counts.audited.researcher.high_quality.total);
+                $("#street-count-audited-researcher-high-quality-percentage").text(formatPercent(data.street_counts.audited.researcher.high_quality.percentage));
     
                 // Set Distance section of the Street Edge Table.
-                const distanceMetricAbbrev = i18next.t('common:unit-distance-abbreviation');
-
-                $("#distance-totals-all-users-value").html(`${convertDistance(data.distance.total_audited_streets.all_users.total).toFixed(1)} ${distanceMetricAbbrev}`);
-                $("#distance-totals-all-users-percentage").html(`(${Math.round(data.distance.total_audited_streets.all_users.percentage)}%)`);
-                $("#distance-totals-high-quality-value").html(`${convertDistance(data.distance.total_audited_streets.high_quality.total).toFixed(1)} ${distanceMetricAbbrev}`);
-                $("#distance-totals-high-quality-percentage").html(`(${Math.round(data.distance.total_audited_streets.high_quality.percentage)}%)`);
+                $("#street-distance-audited-all-users").html(formatDistance(data.street_distance.audited.all_users.total));
+                $("#street-distance-audited-all-users-percentage").html(formatPercent(data.street_distance.audited.all_users.percentage));
+                $("#street-distance-audited-high-quality").html(formatDistance(data.street_distance.audited.high_quality.total));
+                $("#street-distance-audited-high-quality-percentage").html(formatPercent(data.street_distance.audited.high_quality.percentage));
     
-                $("#distance-totals-total-distance").html(`${convertDistance(data.distance.total_distance).toFixed(1)} ${distanceMetricAbbrev}`);
+                $("#street-distance-total").html(formatDistance(data.street_distance.total));
     
-                $("#distance-registered-all-users-value").html(`${convertDistance(data.distance.registered.all_users.total).toFixed(1)} ${distanceMetricAbbrev}`);
-                $("#distance-registered-all-users-percentage").html(`(${Math.round(data.distance.registered.all_users.percentage)}%)`);
-                $("#distance-registered-high-quality-value").html(`${convertDistance(data.distance.registered.high_quality.total).toFixed(1)} ${distanceMetricAbbrev}`);
-                $("#distance-registered-high-quality-percentage").html(`(${Math.round(data.distance.registered.high_quality.percentage)}%)`);
+                $("#street-distance-registered-all").html(formatDistance(data.street_distance.audited.registered.all.total));
+                $("#street-distance-registered-all-percentage").html(formatPercent(data.street_distance.audited.registered.all.percentage));
+                $("#street-distance-registered-high-quality").html(formatDistance(data.street_distance.audited.registered.high_quality.total));
+                $("#street-distance-registered-high-quality-percentage").html(formatPercent(data.street_distance.audited.registered.high_quality.percentage));
     
-                $("#distance-anonymous-all-users-value").html(`${convertDistance(data.distance.anonymous.all_users.total).toFixed(1)} ${distanceMetricAbbrev}`);
-                $("#distance-anonymous-all-users-percentage").html(`(${Math.round(data.distance.anonymous.all_users.percentage)}%)`);
-                $("#distance-anonymous-high-quality-value").html(`${convertDistance(data.distance.anonymous.high_quality.total).toFixed(1)} ${distanceMetricAbbrev}`);
-                $("#distance-anonymous-high-quality-percentage").html(`(${Math.round(data.distance.anonymous.high_quality.percentage)}%)`);
+                $("#street-distance-anonymous-all").html(formatDistance(data.street_distance.audited.anonymous.all.total));
+                $("#street-distance-anonymous-all-percentage").html(formatPercent(data.street_distance.audited.anonymous.all.percentage));
+                $("#street-distance-anonymous-high-quality").html(formatDistance(data.street_distance.audited.anonymous.high_quality.total));
+                $("#street-distance-anonymous-high-quality-percentage").html(formatPercent(data.street_distance.audited.anonymous.high_quality.percentage));
     
-                $("#distance-turker-all-users-value").html(`${convertDistance(data.distance.turker.all_users.total).toFixed(1)} ${distanceMetricAbbrev}`);
-                $("#distance-turker-all-users-percentage").html(`(${Math.round(data.distance.turker.all_users.percentage)}%)`);
-                $("#distance-turker-high-quality-value").html(`${convertDistance(data.distance.turker.high_quality.total).toFixed(1)} ${distanceMetricAbbrev}`);
-                $("#distance-turker-high-quality-percentage").html(`(${Math.round(data.distance.turker.high_quality.percentage)}%)`);
+                $("#street-distance-turker-all").html(formatDistance(data.street_distance.audited.turker.all.total));
+                $("#street-distance-turker-all-percentage").html(formatPercent(data.street_distance.audited.turker.all.percentage));
+                $("#street-distance-turker-high-quality").html(formatDistance(data.street_distance.audited.turker.high_quality.total));
+                $("#street-distance-turker-high-quality-percentage").html(formatPercent(data.street_distance.audited.turker.high_quality.percentage));
     
-                $("#distance-researcher-all-users-value").html(`${convertDistance(data.distance.researcher.all_users.total).toFixed(1)} ${distanceMetricAbbrev}`);
-                $("#distance-researcher-all-users-percentage").html(`(${Math.round(data.distance.researcher.all_users.percentage)}%)`);
-                $("#distance-researcher-high-quality-value").html(`${convertDistance(data.distance.researcher.high_quality.total).toFixed(1)} ${distanceMetricAbbrev}`);
-                $("#distance-researcher-high-quality-percentage").html(`(${Math.round(data.distance.researcher.high_quality.percentage)}%)`);
+                $("#street-distance-researcher-all").html(formatDistance(data.street_distance.audited.researcher.all.total));
+                $("#street-distance-researcher-all-percentage").html(formatPercent(data.street_distance.audited.researcher.all.percentage));
+                $("#street-distance-researcher-high-quality").html(formatDistance(data.street_distance.audited.researcher.high_quality.total));
+                $("#street-distance-researcher-high-quality-percentage").html(formatPercent(data.street_distance.audited.researcher.high_quality.percentage));
     
                 // Set the audited distance fields.
-                $("#audited-distance-all-time").html(`${convertDistance(data.audited_street_distance_over_time.all_time).toFixed(1)} ${distanceMetricAbbrev}`);
-                $("#audited-distance-today").html(`${convertDistance(data.audited_street_distance_over_time.today).toFixed(1)} ${distanceMetricAbbrev}`);
-                $("#audited-distance-week").html(`${convertDistance(data.audited_street_distance_over_time.week).toFixed(1)} ${distanceMetricAbbrev}`);
+                $("#audited-distance-all-time").html(formatDistance(data.street_distance.audited.with_overlap.all_time));
+                $("#audited-distance-today").html(formatDistance(data.street_distance.audited.with_overlap.today));
+                $("#audited-distance-week").html(formatDistance(data.street_distance.audited.with_overlap.week));
 
                 resolve();
             })

--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -1178,65 +1178,65 @@ function Admin(_, $) {
         return new Promise((resolve, reject) => {
             $.getJSON("/adminapi/getCoverageData", function (data) {
                 // Set Audited Streets section of the Street Edge Table.
-                $("#street-count-audited-all-users").html(data.street_counts.audited.all_users.total);
-                $("#street-count-audited-all-users-percentage").html(formatPercent(data.street_counts.audited.all_users.percentage));
-                $("#street-count-audited-high-quality-total").html(data.street_counts.audited.high_quality.total);
-                $("#street-count-audited-high-quality-percentage").html(formatPercent(data.street_counts.audited.high_quality.percentage));
+                $("#street-count-audited-all-users").text(data.street_counts.audited.all_users.total);
+                $("#street-count-audited-all-users-percentage").text(formatPercent(data.street_counts.audited.all_users.percentage));
+                $("#street-count-audited-high-quality-total").text(data.street_counts.audited.high_quality.total);
+                $("#street-count-audited-high-quality-percentage").text(formatPercent(data.street_counts.audited.high_quality.percentage));
     
-                $("#street-count-total").html(data.street_counts.total);
+                $("#street-count-total").text(data.street_counts.total);
 
-                $("#street-count-audited-registered-all").html(data.street_counts.audited.registered.all.total);
-                $("#street-count-audited-registered-all-percentage").html(formatPercent(data.street_counts.audited.registered.all.percentage));
-                $("#street-count-audited-registered-high-quality").html(data.street_counts.audited.registered.high_quality.total);
-                $("#street-count-audited-registered-high-quality-percentage").html(formatPercent(data.street_counts.audited.registered.high_quality.percentage));
+                $("#street-count-audited-registered-all").text(data.street_counts.audited.registered.all.total);
+                $("#street-count-audited-registered-all-percentage").text(formatPercent(data.street_counts.audited.registered.all.percentage));
+                $("#street-count-audited-registered-high-quality").text(data.street_counts.audited.registered.high_quality.total);
+                $("#street-count-audited-registered-high-quality-percentage").text(formatPercent(data.street_counts.audited.registered.high_quality.percentage));
     
-                $("#street-count-audited-anonymous-all").html(data.street_counts.audited.anonymous.all.total);
-                $("#street-count-audited-anonymous-all-percentage").html(formatPercent(data.street_counts.audited.anonymous.all.percentage));
-                $("#street-count-audited-anonymous-high-quality").html(data.street_counts.audited.anonymous.high_quality.total);
-                $("#street-count-audited-anonymous-high-quality-percentage").html(formatPercent(data.street_counts.audited.anonymous.high_quality.percentage));
+                $("#street-count-audited-anonymous-all").text(data.street_counts.audited.anonymous.all.total);
+                $("#street-count-audited-anonymous-all-percentage").text(formatPercent(data.street_counts.audited.anonymous.all.percentage));
+                $("#street-count-audited-anonymous-high-quality").text(data.street_counts.audited.anonymous.high_quality.total);
+                $("#street-count-audited-anonymous-high-quality-percentage").text(formatPercent(data.street_counts.audited.anonymous.high_quality.percentage));
     
-                $("#street-count-audited-turker-all").html(data.street_counts.audited.turker.all.total);
-                $("#street-count-audited-turker-all-percentage").html(formatPercent(data.street_counts.audited.turker.all.percentage));
-                $("#street-count-audited-turker-high-quality").html(data.street_counts.audited.turker.high_quality.total);
-                $("#street-count-audited-turker-high-quality-percentage").html(formatPercent(data.street_counts.audited.turker.high_quality.percentage));
+                $("#street-count-audited-turker-all").text(data.street_counts.audited.turker.all.total);
+                $("#street-count-audited-turker-all-percentage").text(formatPercent(data.street_counts.audited.turker.all.percentage));
+                $("#street-count-audited-turker-high-quality").text(data.street_counts.audited.turker.high_quality.total);
+                $("#street-count-audited-turker-high-quality-percentage").text(formatPercent(data.street_counts.audited.turker.high_quality.percentage));
     
-                $("#street-count-audited-researcher-all").html(data.street_counts.audited.researcher.all.total);
-                $("#street-count-audited-researcher-all-percentage").html(formatPercent(data.street_counts.audited.researcher.all.percentage));
-                $("#street-count-audited-researcher-high-quality").html(data.street_counts.audited.researcher.high_quality.total);
+                $("#street-count-audited-researcher-all").text(data.street_counts.audited.researcher.all.total);
+                $("#street-count-audited-researcher-all-percentage").text(formatPercent(data.street_counts.audited.researcher.all.percentage));
+                $("#street-count-audited-researcher-high-quality").text(data.street_counts.audited.researcher.high_quality.total);
                 $("#street-count-audited-researcher-high-quality-percentage").text(formatPercent(data.street_counts.audited.researcher.high_quality.percentage));
     
                 // Set Distance section of the Street Edge Table.
-                $("#street-distance-audited-all-users").html(formatDistance(data.street_distance.audited.all_users.total));
-                $("#street-distance-audited-all-users-percentage").html(formatPercent(data.street_distance.audited.all_users.percentage));
-                $("#street-distance-audited-high-quality").html(formatDistance(data.street_distance.audited.high_quality.total));
-                $("#street-distance-audited-high-quality-percentage").html(formatPercent(data.street_distance.audited.high_quality.percentage));
+                $("#street-distance-audited-all-users").text(formatDistance(data.street_distance.audited.all_users.total));
+                $("#street-distance-audited-all-users-percentage").text(formatPercent(data.street_distance.audited.all_users.percentage));
+                $("#street-distance-audited-high-quality").text(formatDistance(data.street_distance.audited.high_quality.total));
+                $("#street-distance-audited-high-quality-percentage").text(formatPercent(data.street_distance.audited.high_quality.percentage));
     
-                $("#street-distance-total").html(formatDistance(data.street_distance.total));
+                $("#street-distance-total").text(formatDistance(data.street_distance.total));
     
-                $("#street-distance-registered-all").html(formatDistance(data.street_distance.audited.registered.all.total));
-                $("#street-distance-registered-all-percentage").html(formatPercent(data.street_distance.audited.registered.all.percentage));
-                $("#street-distance-registered-high-quality").html(formatDistance(data.street_distance.audited.registered.high_quality.total));
-                $("#street-distance-registered-high-quality-percentage").html(formatPercent(data.street_distance.audited.registered.high_quality.percentage));
+                $("#street-distance-registered-all").text(formatDistance(data.street_distance.audited.registered.all.total));
+                $("#street-distance-registered-all-percentage").text(formatPercent(data.street_distance.audited.registered.all.percentage));
+                $("#street-distance-registered-high-quality").text(formatDistance(data.street_distance.audited.registered.high_quality.total));
+                $("#street-distance-registered-high-quality-percentage").text(formatPercent(data.street_distance.audited.registered.high_quality.percentage));
     
-                $("#street-distance-anonymous-all").html(formatDistance(data.street_distance.audited.anonymous.all.total));
-                $("#street-distance-anonymous-all-percentage").html(formatPercent(data.street_distance.audited.anonymous.all.percentage));
-                $("#street-distance-anonymous-high-quality").html(formatDistance(data.street_distance.audited.anonymous.high_quality.total));
-                $("#street-distance-anonymous-high-quality-percentage").html(formatPercent(data.street_distance.audited.anonymous.high_quality.percentage));
+                $("#street-distance-anonymous-all").text(formatDistance(data.street_distance.audited.anonymous.all.total));
+                $("#street-distance-anonymous-all-percentage").text(formatPercent(data.street_distance.audited.anonymous.all.percentage));
+                $("#street-distance-anonymous-high-quality").text(formatDistance(data.street_distance.audited.anonymous.high_quality.total));
+                $("#street-distance-anonymous-high-quality-percentage").text(formatPercent(data.street_distance.audited.anonymous.high_quality.percentage));
     
-                $("#street-distance-turker-all").html(formatDistance(data.street_distance.audited.turker.all.total));
-                $("#street-distance-turker-all-percentage").html(formatPercent(data.street_distance.audited.turker.all.percentage));
-                $("#street-distance-turker-high-quality").html(formatDistance(data.street_distance.audited.turker.high_quality.total));
-                $("#street-distance-turker-high-quality-percentage").html(formatPercent(data.street_distance.audited.turker.high_quality.percentage));
+                $("#street-distance-turker-all").text(formatDistance(data.street_distance.audited.turker.all.total));
+                $("#street-distance-turker-all-percentage").text(formatPercent(data.street_distance.audited.turker.all.percentage));
+                $("#street-distance-turker-high-quality").text(formatDistance(data.street_distance.audited.turker.high_quality.total));
+                $("#street-distance-turker-high-quality-percentage").text(formatPercent(data.street_distance.audited.turker.high_quality.percentage));
     
-                $("#street-distance-researcher-all").html(formatDistance(data.street_distance.audited.researcher.all.total));
-                $("#street-distance-researcher-all-percentage").html(formatPercent(data.street_distance.audited.researcher.all.percentage));
-                $("#street-distance-researcher-high-quality").html(formatDistance(data.street_distance.audited.researcher.high_quality.total));
-                $("#street-distance-researcher-high-quality-percentage").html(formatPercent(data.street_distance.audited.researcher.high_quality.percentage));
+                $("#street-distance-researcher-all").text(formatDistance(data.street_distance.audited.researcher.all.total));
+                $("#street-distance-researcher-all-percentage").text(formatPercent(data.street_distance.audited.researcher.all.percentage));
+                $("#street-distance-researcher-high-quality").text(formatDistance(data.street_distance.audited.researcher.high_quality.total));
+                $("#street-distance-researcher-high-quality-percentage").text(formatPercent(data.street_distance.audited.researcher.high_quality.percentage));
     
                 // Set the audited distance fields.
-                $("#audited-distance-all-time").html(formatDistance(data.street_distance.audited.with_overlap.all_time));
-                $("#audited-distance-today").html(formatDistance(data.street_distance.audited.with_overlap.today));
-                $("#audited-distance-week").html(formatDistance(data.street_distance.audited.with_overlap.week));
+                $("#audited-distance-all-time").text(formatDistance(data.street_distance.audited.with_overlap.all_time));
+                $("#audited-distance-today").text(formatDistance(data.street_distance.audited.with_overlap.today));
+                $("#audited-distance-week").text(formatDistance(data.street_distance.audited.with_overlap.week));
 
                 resolve();
             })


### PR DESCRIPTION
Working towards #380 

I called that API route in Admin.js and loaded that data onto the Admin page after its initial load from the server. I also made it so that the spinner stops the loading animation only after that API call happens so we won't get any proxy errors, but everything will still be loaded once the spinner stops.

This reduces the initial load time of the page by ~10 seconds, but the total load time remains the same since that data is queried after the initial page load. I have the Seattle database, but this change should induce speedups in every city's Admin page.

##### Before/After screenshots (if applicable)

##### Testing instructions
1. Load the admin page and verify that everything looks good! Additionally, you can time the amount of time it takes 

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
