### PR TITLE
New Validate no longer breaks when trying to show excluded tags

### DIFF
--- a/public/javascripts/SVValidate/src/menu/RightMenu.js
+++ b/public/javascripts/SVValidate/src/menu/RightMenu.js
@@ -277,6 +277,10 @@ function RightMenu(menuUI) {
         const currTags = label.getProperty('newTags');
         // Clone the template tag element, remove the 'template' class, update the text, and add the removal onclick.
         for (let tag of currTags) {
+            if (!allTagOptions.some(t => t.tag_name === tag)) {
+                continue; // Skip tags that are now being excluded on this server. Don't want to show them.
+            }
+
             // Clone the template tag element, remove the 'template' class, and add a tag-id data attribute.
             let $tagDiv = $('.current-tag.template').clone().removeClass('template');
             $tagDiv.data('tag-id', allTagOptions.find(t => t.tag_name === tag).tag_id);


### PR DESCRIPTION
Fixes #3691

When we encountered an "excluded" tag on the new Validate page, the page would break since it didn't have all the necessary data to render it. Since we are trying to hide those tags in the UI anyway, I just added a condition to skip trying to render tags if we don't have the appropriate metadata.

An excluded tag would be one where we collected data on it, but subsequently removed it from the UI while keeping the old data in the db. The most notable example comes from our rework of the Pedestrian Signal tags (PR #3501), where we switched from "button waist height" to "hard to reach button". We kept the old data, but aren't showing it in the UI.

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
