### PR TITLE
Fixes unified login when logging into a new city

### DIFF
--- a/app/controllers/CredentialsAuthController.scala
+++ b/app/controllers/CredentialsAuthController.scala
@@ -92,6 +92,8 @@ class CredentialsAuthController @Inject() (
     val expirationDate = authenticator.expirationDate.minusSeconds(defaultExpiry).plusSeconds(rememberMeExpiry)
     val updatedAuthenticator = authenticator.copy(expirationDate=expirationDate, idleTimeout = Some(2592000))
 
+    // Add to user_stat or user_current_region if user hasn't logged in in this city before.
+    UserStatTable.addUserStatIfNew(user.userId)
     if (!UserCurrentRegionTable.isAssigned(user.userId)) {
       UserCurrentRegionTable.assignRegion(user.userId)
     }

--- a/app/controllers/SignUpController.scala
+++ b/app/controllers/SignUpController.scala
@@ -75,14 +75,12 @@ class SignUpController @Inject() (
           UserTable.find(data.username) match {
             case Some(user) =>
               WebpageActivityTable.save(WebpageActivity(0, oldUserId, ipAddress, "Duplicate_Username_Error", timestamp))
-  //            Future.successful(Redirect(routes.UserController.signUp()).flashing("error" -> Messages("authenticate.error.username.exists")))
               Future.successful(Status(409)(Messages("authenticate.error.username.exists")))
             case None =>
               // Check presence of user by email.
               UserTable.findEmail(data.email.toLowerCase) match {
                 case Some(user) =>
                   WebpageActivityTable.save(WebpageActivity(0, oldUserId, ipAddress, "Duplicate_Email_Error", timestamp))
-  //                Future.successful(Redirect(routes.UserController.signUp()).flashing("error" -> Messages("authenticate.error.email.exists")))
                   Future.successful(Status(409)(Messages("authenticate.error.email.exists")))
                 case None =>
                   // Check if passwords match and are at least 6 characters.
@@ -107,8 +105,8 @@ class SignUpController @Inject() (
                     } yield {
                       // Set the user role, assign the neighborhood to audit, and add to the user_stat table.
                       UserRoleTable.setRole(user.userId, "Registered", Some(serviceHoursUser))
-                      UserCurrentRegionTable.assignRegion(user.userId)
                       UserStatTable.addUserStatIfNew(user.userId)
+                      UserCurrentRegionTable.assignRegion(user.userId)
 
                       // Log the sign up/in.
                       val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
@@ -124,9 +122,9 @@ class SignUpController @Inject() (
                         // If someone was already authenticated (i.e., they were signed into an anon user account), Play
                         // doesn't let us sign one account out and the other back in in one response header. So we start
                         // by redirecting to the "/finishSignUp" endpoint, discarding the old authenticator info and
-                        // sending the new authenticator info in a temp element in the session cookie. The "/finishSignUp"
-                        // endpoint will then move authenticator we put in "temp-authenticator" over to "authenticator"
-                        // where it belongs, finally completing the sign up.
+                        // sending the new authenticator info in a temp element in the session cookie. The
+                        // "/finishSignUp" endpoint will then move authenticator we put in "temp-authenticator" over to
+                        // "authenticator" where it belongs, finally completing the sign up.
                         val redirectURL: String = nextUrl match {
                           case Some(u) => "/finishSignUp?url=" + u
                           case None => "/finishSignUp"
@@ -236,6 +234,7 @@ class SignUpController @Inject() (
           // Set the user role and add to the user_stat table.
           UserRoleTable.setRole(user.userId, "Anonymous", Some(false))
           UserStatTable.addUserStatIfNew(user.userId)
+          UserCurrentRegionTable.assignRegion(user.userId)
 
           // Add Timestamp
           val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
@@ -303,8 +302,8 @@ class SignUpController @Inject() (
         } yield {
           // Set the user role, assign the neighborhood to audit, and add to the user_stat table.
           UserRoleTable.setRole(user.userId, "Turker", Some(false))
-          UserCurrentRegionTable.assignRegion(user.userId)
           UserStatTable.addUserStatIfNew(user.userId)
+          UserCurrentRegionTable.assignRegion(user.userId)
 
           // Log the sign up/in.
           val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)

--- a/app/controllers/ValidationTaskController.scala
+++ b/app/controllers/ValidationTaskController.scala
@@ -212,7 +212,7 @@ class ValidationTaskController @Inject() (implicit val env: Environment[User, Se
           MissionTable.resumeOrCreateNewValidationMission(userId, 0.0D, 0.0D, "labelmapValidation", labelTypeId).get
 
         // Check if user already has a validation for this label.
-        if(LabelValidationTable.countValidationsFromUserAndLabel(userId, submission.labelId) != 0) {
+        if (LabelValidationTable.countValidationsFromUserAndLabel(userId, submission.labelId) != 0) {
           // Delete the user's old label.
           LabelValidationTable.deleteLabelValidation(submission.labelId, userId.toString)
         }

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -601,6 +601,9 @@ object LabelTable {
     val userIdString: String = userId.toString
     val labelsValidatedByUser = labelValidations.filter(_.userId === userIdString)
 
+    // Make sure there is a user_stat entry for the given user.
+    UserStatTable.addUserStatIfNew(userId)
+
     // Get labels the given user has not placed that have non-expired GSV imagery.
     val labelsToValidate =  for {
       _lb <- labels

--- a/app/models/label/LabelValidationTable.scala
+++ b/app/models/label/LabelValidationTable.scala
@@ -148,6 +148,7 @@ object LabelValidationTable {
    * @return The label_validation_id of the inserted/updated validation.
    */
   def insert(labelVal: LabelValidation): Int = db.withTransaction { implicit session =>
+    UserStatTable.addUserStatIfNew(UUID.fromString(labelVal.userId))
     val isExcludedUser: Boolean = UserStatTable.userStats.filter(_.userId === labelVal.userId).map(_.excluded).first
     val userThatAppliedLabel: String = labelsUnfiltered.filter(_.labelId === labelVal.labelId).map(_.userId).list.head
 


### PR DESCRIPTION
Fixes #3728 

Fixes an issue where Exploring and Validating didn't work correctly if you were logged into a city that you had never logged into before. I added checks in a bunch of places to make sure that an entry exists for the current user in the `user_stat` table. We now do this check when signing in, when adding a label, when validating a label, etc.

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
