### PR TITLE
Removes text on forgot password page post unified login

### DIFF
--- a/app/views/forgotPassword.scala.html
+++ b/app/views/forgotPassword.scala.html
@@ -22,7 +22,6 @@
     <fieldset class="col-md-6 col-md-offset-3" style="margin-top:51px">
         <legend>@Messages("reset.pw.forgot.title")</legend>
         @helper.form(action = routes.ForgotPasswordController.submit()) {
-            <p class = "info">@Messages("reset.pw.forgot.suggest")</p>
             <p class="info">@Messages("reset.pw.forgot.submit.email")</p>
             @text(forgotPasswordForm("emailForgotPassword"), Messages("authenticate.email"), icon = "at")
             <div class="form-group">

--- a/conf/messages.de
+++ b/conf/messages.de
@@ -282,7 +282,6 @@ authenticate.error.generic = Bei der Beantwortung Ihrer Anfrage ist ein Fehler a
 
 reset.pw.forgot.title = Passwort vergessen?
 reset.pw.forgot.submit.email = Geben Sie bitte Ihre E-Mail-Adresse an. Wir werden Ihnen einen Link zum Zurücksetzen Ihres Passworts senden.
-reset.pw.forgot.suggest = Wenn Sie Probleme beim Anmelden oder dem Zurücksetzens Ihres Passworts haben, vergewissern Sie sich, dass die richtige Stadt rechts oben auf der Navigationsleiste angezeigt wird. Der erstellte Account ist nicht auf andere Städte übertragbar, Sie müssen also für jede Stadt einen neuen Account anlegen (Sie können aber denselben Benutzername/dasselbe Passwort wiederverwenden).
 
 reset.pw.email.hello = Hallo {0},
 reset.pw.email.reset.title = Passwort für den Project Sidewalk-Account zurücksetzen.

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -275,7 +275,6 @@ authenticate.error.generic = Something went wrong processing your request. Pleas
 
 reset.pw.forgot.title = Forgot your password?
 reset.pw.forgot.submit.email = Type in your email and we’ll send you a link to reset your password.
-reset.pw.forgot.suggest = If you are having trouble logging in or resetting your password, check that you are looking at the city where you made your account by checking the navbar on the top-right of the page. Accounts are not interchangeable between different cities, so you'll need to make a new account for each city (you can use the same username/password).
 
 reset.pw.email.hello = Hi {0},
 reset.pw.email.reset.title = Reset Your Project Sidewalk Account Password

--- a/conf/messages.es
+++ b/conf/messages.es
@@ -287,7 +287,6 @@ authenticate.error.generic = Algo salió mal al procesar su solicitud. Por favor
 
 reset.pw.forgot.title = Olvidaste tu contraseña
 reset.pw.forgot.submit.email = Escribe tu correo electrónico y te enviaremos un enlace para restablecer tu contraseña.
-reset.pw.forgot.suggest = Si tiene problemas para iniciar sesión o restablecer su contraseña, compruebe que está mirando la ciudad donde creó su cuenta consultando la barra de navegación en la parte superior derecha de la página. Las cuentas no son intercambiables entre diferentes ciudades, por lo que deberá crear una nueva cuenta para cada ciudad (puede usar el mismo nombre de usuario/contraseña).
 
 reset.pw.email.hello = Hola {0},
 reset.pw.email.reset.title = Restablecer la contraseña de tu cuenta de Project Sidewalk

--- a/conf/messages.nl
+++ b/conf/messages.nl
@@ -278,7 +278,6 @@ authenticate.error.generic = Er is iets misgegaan bij het verwerken van uw verzo
 
 reset.pw.forgot.title = Wachtwoord vergeten?
 reset.pw.forgot.submit.email = Typ je e-mail in en we sturen je een link om je wachtwoord opnieuw in te stellen.
-reset.pw.forgot.suggest = Als je problemen hebt met inloggen of het resetten van je wachtwoord, controleer dan of je naar de stad kijkt waar je je account hebt aangemaakt door naar de navigatiebalk rechtsboven op de pagina te kijken. Accounts zijn niet uitwisselbaar tussen verschillende steden, dus je moet voor elke stad een nieuw account aanmaken (je kunt dezelfde gebruikersnaam en hetzelfde wachtwoord gebruiken).
 
 reset.pw.email.hello = Hi {0},
 reset.pw.email.reset.title = Reset het wachtwoord van je Project Sidewalk-account

--- a/conf/messages.zh-TW
+++ b/conf/messages.zh-TW
@@ -315,7 +315,6 @@ authenticate.error.generic = 處理您的要求時發生了錯誤。請確認您
 
 reset.pw.forgot.title = 忘記密碼了嗎？
 reset.pw.forgot.submit.email = 別擔心，輸入您的電子郵件，我們將寄送重設密碼的連結給您。
-reset.pw.forgot.suggest = 如果您在登錄或重設密碼時遇到問題，請查看頁面右上角的導航欄，來確認您是否正在檢視您設立帳戶的城市。不同城市之間的帳戶並不相通，因此您需要為每個城市設立一個新帳戶（您可以使用相同的用戶名/密碼）。
 
 reset.pw.email.hello = {0}您好,
 reset.pw.email.reset.title = 請重設您的Project Sidewalk密碼


### PR DESCRIPTION
Resolves #3717 

Removes some text on the forgot password page that is no longer relevant after implementing unified login.

##### Before/After screenshots (if applicable)
Before
<img width="706" alt="Screenshot 2024-11-11 at 3 01 32 PM" src="https://github.com/user-attachments/assets/005b39d5-622f-4edd-9c97-0c40597cccd0">

After
<img width="715" alt="Screenshot 2024-11-11 at 3 03 58 PM" src="https://github.com/user-attachments/assets/470e4dfc-46af-442d-932e-93b75d4c10c5">

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've included before/after screenshots above.
- [x] I've tested on mobile (only needed for validation page).
