### PR TITLE
Authentication cookie should now be shared across subdomains

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -145,5 +145,11 @@ custom.news.ribbon.link = ""
 cropped.image.directory = "/home/.crops"
 cropped.image.directory = ${?SIDEWALK_IMAGES_DIR}
 
+# Authentication cookie settings. Updated to share across subdomains (i.e., across cities).
+application.session.cookie.domain=".cs.washington.edu"
+session.domain=".cs.washington.edu"
+session.secure=false
+session.httpOnly=true
+
 include "silhouette.conf"
 include "cityparams.conf"


### PR DESCRIPTION
Resolves #3714

This should give us _real_ unified login, where you login in one city, and it keeps you logged in as you switch between cities.

It's now working correctly on my local environment, but I need to test it out on the test servers to know for sure, especially when it comes to using http vs https!

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
