### PR TITLE
Small query performance improvements

### DIFF
--- a/app/models/amt/AMTAssignmentTable.scala
+++ b/app/models/amt/AMTAssignmentTable.scala
@@ -38,21 +38,21 @@ object AMTAssignmentTable {
   val TURKER_PAY_PER_LABEL_VALIDATION = 0.012D
   val VOLUNTEER_PAY: Double = 0.0D
 
-  def save(asg: AMTAssignment): Int = db.withTransaction { implicit session =>
+  def save(asg: AMTAssignment): Int = db.withSession { implicit session =>
     val asgId: Int =
       (amtAssignments returning amtAssignments.map(_.amtAssignmentId)) += asg
     asgId
   }
 
-  def getConfirmationCode(workerId: String, assignmentId: String): String = db.withTransaction { implicit session =>
+  def getConfirmationCode(workerId: String, assignmentId: String): String = db.withSession { implicit session =>
     amtAssignments.filter(a => a.workerId === workerId && a.assignmentId === assignmentId).sortBy(_.assignmentStart.desc).map(_.confirmationCode).first
   }
 
-  def getMostRecentAssignmentId(workerId: String): String = db.withTransaction { implicit session =>
+  def getMostRecentAssignmentId(workerId: String): String = db.withSession { implicit session =>
     amtAssignments.filter(_.workerId === workerId).sortBy(_.assignmentStart.desc).map(_.assignmentId).first
   }
 
-  def getMostRecentAMTAssignmentId(workerId: String): Int = db.withTransaction { implicit session =>
+  def getMostRecentAMTAssignmentId(workerId: String): Int = db.withSession { implicit session =>
     amtAssignments.filter(_.workerId === workerId).sortBy(_.assignmentStart.desc).map(_.amtAssignmentId).first
   }
 
@@ -84,7 +84,7 @@ object AMTAssignmentTable {
   /**
     * Update the `completed` column of the specified amt_assignment row.
     */
-  def updateCompleted(amtAssignmentId: Int, completed: Boolean): Int = db.withTransaction { implicit session =>
+  def updateCompleted(amtAssignmentId: Int, completed: Boolean): Int = db.withSession { implicit session =>
     val q = for { asg <- amtAssignments if asg.amtAssignmentId === amtAssignmentId } yield asg.completed
     q.update(completed)
   }

--- a/app/models/attribute/GlobalAttributeTable.scala
+++ b/app/models/attribute/GlobalAttributeTable.scala
@@ -121,7 +121,7 @@ object GlobalAttributeTable {
     )
   )
 
-  def getAllGlobalAttributes: List[GlobalAttribute] = db.withTransaction { implicit session =>
+  def getAllGlobalAttributes: List[GlobalAttribute] = db.withSession { implicit session =>
     globalAttributes.list
   }
 
@@ -285,11 +285,11 @@ object GlobalAttributeTable {
       .list.map{ case (rId, typeId, count) => (rId, LabelTypeTable.labelTypeIdToLabelType(typeId).get, count) }
   }
 
-  def countGlobalAttributes: Int = db.withTransaction { implicit session =>
-    globalAttributes.length.run
+  def countGlobalAttributes: Int = db.withSession { implicit session =>
+    globalAttributes.size.run
   }
 
-  def save(newSess: GlobalAttribute): Int = db.withTransaction { implicit session =>
+  def save(newSess: GlobalAttribute): Int = db.withSession { implicit session =>
     val newId: Int = (globalAttributes returning globalAttributes.map(_.globalAttributeId)) += newSess
     newId
   }

--- a/app/models/attribute/GlobalAttributeUserAttributeTable.scala
+++ b/app/models/attribute/GlobalAttributeUserAttributeTable.scala
@@ -30,7 +30,7 @@ object GlobalAttributeUserAttributeTable {
   val db: slick.Database = play.api.db.slick.DB
   val globalAttributeUserAttributes: TableQuery[GlobalAttributeUserAttributeTable] = TableQuery[GlobalAttributeUserAttributeTable]
 
-  def save(newSess: GlobalAttributeUserAttribute): Int = db.withTransaction { implicit session =>
+  def save(newSess: GlobalAttributeUserAttribute): Int = db.withSession { implicit session =>
     val newId: Int = (globalAttributeUserAttributes returning globalAttributeUserAttributes.map(_.globalAttributeUserAttributeId)) += newSess
     newId
   }

--- a/app/models/attribute/GlobalClusteringSessionTable.scala
+++ b/app/models/attribute/GlobalClusteringSessionTable.scala
@@ -57,7 +57,7 @@ object GlobalClusteringSessionTable {
   /**
     * Truncates global_clustering_session, global_attribute, and global_attribute_user_attribute.
     */
-  def truncateTables(): Unit = db.withTransaction { implicit session =>
+  def truncateTables(): Unit = db.withSession { implicit session =>
     Q.updateNA("TRUNCATE TABLE global_clustering_session CASCADE").execute
   }
 
@@ -67,11 +67,11 @@ object GlobalClusteringSessionTable {
    * We run the delete on the `global_clustering_session` table, and it cascades to the `global_attribute` and
    * `global_attribute_user_attribute` tables.
    */
-  def deleteGlobalClusteringSessions(regionIds: List[Int]): Int = db.withTransaction { implicit session =>
+  def deleteGlobalClusteringSessions(regionIds: List[Int]): Int = db.withSession { implicit session =>
     globalClusteringSessions.filter(_.regionId inSet regionIds).delete
   }
 
-  def save(newSess: GlobalClusteringSession): Int = db.withTransaction { implicit session =>
+  def save(newSess: GlobalClusteringSession): Int = db.withSession { implicit session =>
     val newId: Int = (globalClusteringSessions returning globalClusteringSessions.map(_.globalClusteringSessionId)) += newSess
     newId
   }

--- a/app/models/attribute/UserAttributeLabelTable.scala
+++ b/app/models/attribute/UserAttributeLabelTable.scala
@@ -31,11 +31,11 @@ object UserAttributeLabelTable {
   val db: slick.Database = play.api.db.slick.DB
   val userAttributeLabels: TableQuery[UserAttributeLabelTable] = TableQuery[UserAttributeLabelTable]
 
-  def countUserAttributeLabels: Int = db.withTransaction { implicit session =>
-    userAttributeLabels.length.run
+  def countUserAttributeLabels: Int = db.withSession { implicit session =>
+    userAttributeLabels.size.run
   }
 
-  def save(newSess: UserAttributeLabel): Int = db.withTransaction { implicit session =>
+  def save(newSess: UserAttributeLabel): Int = db.withSession { implicit session =>
     val newId: Int = (userAttributeLabels returning userAttributeLabels.map(_.userAttributeLabelId)) += newSess
     newId
   }

--- a/app/models/attribute/UserAttributeTable.scala
+++ b/app/models/attribute/UserAttributeTable.scala
@@ -56,11 +56,11 @@ object UserAttributeTable {
   val db: slick.Database = play.api.db.slick.DB
   val userAttributes: TableQuery[UserAttributeTable] = TableQuery[UserAttributeTable]
 
-  def countUserAttributes: Int = db.withTransaction { implicit session =>
-    userAttributes.length.run
+  def countUserAttributes: Int = db.withSession { implicit session =>
+    userAttributes.size.run
   }
 
-  def save(newSess: UserAttribute): Int = db.withTransaction { implicit session =>
+  def save(newSess: UserAttribute): Int = db.withSession { implicit session =>
     val newId: Int = (userAttributes returning userAttributes.map(_.userAttributeId)) += newSess
     newId
   }

--- a/app/models/attribute/UserClusteringSessionTable.scala
+++ b/app/models/attribute/UserClusteringSessionTable.scala
@@ -89,7 +89,7 @@ object UserClusteringSessionTable {
   /**
     * Gets all clusters from single-user clustering that are in this region, outputs in format needed for clustering.
     */
-  def getClusteredLabelsInRegion(regionId: Int): List[LabelToCluster] = db.withTransaction { implicit session =>
+  def getClusteredLabelsInRegion(regionId: Int): List[LabelToCluster] = db.withSession { implicit session =>
     val labelsInRegion = for {
       _sess <- userClusteringSessions
       _att <- UserAttributeTable.userAttributes if _sess.userClusteringSessionId === _att.userClusteringSessionId
@@ -111,7 +111,7 @@ object UserClusteringSessionTable {
   /**
     * Truncates user_clustering_session, user_attribute, user_attribute_label, and global_attribute_user_attribute.
     */
-  def truncateTables(): Unit = db.withTransaction { implicit session =>
+  def truncateTables(): Unit = db.withSession { implicit session =>
     Q.updateNA("TRUNCATE TABLE user_clustering_session CASCADE").execute
   }
 
@@ -139,7 +139,7 @@ object UserClusteringSessionTable {
     userClusteringSessions.filter(_.userId inSet usersToDelete).delete
   }
 
-  def save(newSess: UserClusteringSession): Int = db.withTransaction { implicit session =>
+  def save(newSess: UserClusteringSession): Int = db.withSession { implicit session =>
     val newId: Int = (userClusteringSessions returning userClusteringSessions.map(_.userClusteringSessionId)) += newSess
     newId
   }

--- a/app/models/audit/AuditTaskCommentTable.scala
+++ b/app/models/audit/AuditTaskCommentTable.scala
@@ -49,7 +49,7 @@ object AuditTaskCommentTable {
   /**
     * Get all task records of the given user.
     */
-  def all(username: String): Option[List[AuditTaskComment]] = db.withTransaction { implicit session =>
+  def all(username: String): Option[List[AuditTaskComment]] = db.withSession { implicit session =>
     val comments = (for {
       (c, u) <- auditTaskComments.innerJoin(users).on(_.userId === _.userId).sortBy(_._1.timestamp.desc) if u.username === username
     } yield (c.auditTaskCommentId, c.auditTaskId, c.missionId, c.edgeId, u.username, c.ipAddress, c.gsvPanoramaId,
@@ -61,10 +61,8 @@ object AuditTaskCommentTable {
   /**
     * Insert an audit_task_comment record.
     */
-  def save(comment: AuditTaskComment): Int = db.withTransaction { implicit session =>
-    val auditTaskCommentId: Int =
-      (auditTaskComments returning auditTaskComments.map(_.auditTaskCommentId)) += comment
-    auditTaskCommentId
+  def save(comment: AuditTaskComment): Int = db.withSession { implicit session =>
+    (auditTaskComments returning auditTaskComments.map(_.auditTaskCommentId)) += comment
   }
 
   /**

--- a/app/models/audit/AuditTaskEnvironmentTable.scala
+++ b/app/models/audit/AuditTaskEnvironmentTable.scala
@@ -49,9 +49,7 @@ object AuditTaskEnvironmentTable {
   /**
    * Saves a new audit task environment.
    */
-  def save(env: AuditTaskEnvironment): Int = db.withTransaction { implicit session =>
-    val auditTaskEnvironmentId: Int =
-      (auditTaskEnvironments returning auditTaskEnvironments.map(_.auditTaskEnvironmentId)) += env
-    auditTaskEnvironmentId
+  def save(env: AuditTaskEnvironment): Int = db.withSession { implicit session =>
+    (auditTaskEnvironments returning auditTaskEnvironments.map(_.auditTaskEnvironmentId)) += env
   }
 }

--- a/app/models/audit/AuditTaskIncompleteTable.scala
+++ b/app/models/audit/AuditTaskIncompleteTable.scala
@@ -34,9 +34,7 @@ object AuditTaskIncompleteTable {
   /**
    * Saves a new audit task environment.
    */
-  def save(incomplete: AuditTaskIncomplete): Int = db.withTransaction { implicit session =>
-    val auditTaskIncompleteId: Int =
-      (incompletes returning incompletes.map(_.auditTaskIncompleteId)) += incomplete
-    auditTaskIncompleteId
+  def save(incomplete: AuditTaskIncomplete): Int = db.withSession { implicit session =>
+    (incompletes returning incompletes.map(_.auditTaskIncompleteId)) += incomplete
   }
 }

--- a/app/models/audit/AuditTaskInteractionTable.scala
+++ b/app/models/audit/AuditTaskInteractionTable.scala
@@ -133,7 +133,7 @@ object AuditTaskInteractionTable {
   /**
     * Inserts a sequence of interactions into the audit_task_interaction and audit_task_interaction_small tables.
     */
-  def saveMultiple(interactions: Seq[AuditTaskInteraction]): Seq[Long] = db.withTransaction { implicit session =>
+  def saveMultiple(interactions: Seq[AuditTaskInteraction]): Seq[Long] = db.withSession { implicit session =>
     val savedActions: Seq[AuditTaskInteraction] = (auditTaskInteractions returning auditTaskInteractions) ++= interactions
 
     // Insert copies of a subset of those interactions in audit_task_interaction_small for faster SELECT queries.

--- a/app/models/audit/AuditTaskTable.scala
+++ b/app/models/audit/AuditTaskTable.scala
@@ -182,7 +182,7 @@ object AuditTaskTable {
     * Returns the number of tasks completed.
     */
   def countCompletedAudits: Int = db.withSession { implicit session =>
-    completedTasks.length.run
+    completedTasks.size.run
   }
 
   /**
@@ -215,7 +215,7 @@ object AuditTaskTable {
     * Returns the number of tasks completed by the given user.
     */
   def countCompletedAudits(userId: UUID): Int = db.withSession { implicit session =>
-    completedTasks.filter(_.userId === userId.toString).length.run
+    completedTasks.filter(_.userId === userId.toString).size.run
   }
 
   /**

--- a/app/models/daos/slick/DBTableDefinitions.scala
+++ b/app/models/daos/slick/DBTableDefinitions.scala
@@ -63,28 +63,18 @@ object DBTableDefinitions {
 
     val db = play.api.db.slick.DB
 
-    def find(username: String): Option[DBUser] = db.withTransaction { implicit session =>
-      slickUsers.filter(_.username === username).firstOption match {
-        case Some(user) => Some(user)
-        case None => None
-      }
+    def find(username: String): Option[DBUser] = db.withSession { implicit session =>
+      slickUsers.filter(_.username === username).firstOption
     }
-    def findEmail(email: String): Option[DBUser] = db.withTransaction { implicit session =>
-      slickUsers.filter(_.email === email).firstOption match {
-        case Some(user) => Some(user)
-        case None => None
-      }
+    def findEmail(email: String): Option[DBUser] = db.withSession { implicit session =>
+      slickUsers.filter(_.email === email).firstOption
     }
-    def findById(userId: UUID): Option[DBUser] = db.withTransaction { implicit session =>
-      slickUsers.filter(_.userId === userId.toString).firstOption match {
-        case Some(user) => Some(user)
-        case None => None
-      }
+    def findById(userId: UUID): Option[DBUser] = db.withSession { implicit session =>
+      slickUsers.filter(_.userId === userId.toString).firstOption
     }
 
-    def count: Int = db.withTransaction { implicit session =>
-      val users = slickUsers.list
-      users.length
+    def count: Int = db.withSession { implicit session =>
+      slickUsers.size.run
     }
   }
 }

--- a/app/models/daos/slick/UserDAOSlick.scala
+++ b/app/models/daos/slick/UserDAOSlick.scala
@@ -256,7 +256,7 @@ object UserDAOSlick {
     } yield _userTable.userId
 
     // The group by and map does a SELECT DISTINCT, and the list.length does the COUNT.
-    filteredUsers.groupBy(x => x).map(_._1).length.run
+    filteredUsers.groupBy(x => x).map(_._1).size.run
   }
 
   /**
@@ -368,7 +368,7 @@ object UserDAOSlick {
     } yield _user.userId
 
     // The group by and map does a SELECT DISTINCT, and the list.length does the COUNT.
-    users.groupBy(x => x).map(_._1).length.run
+    users.groupBy(x => x).map(_._1).size.run
   }
 
   /**

--- a/app/models/gallery/GalleryTaskEnvironmentTable.scala
+++ b/app/models/gallery/GalleryTaskEnvironmentTable.scala
@@ -46,9 +46,7 @@ object GalleryTaskEnvironmentTable {
    * @param env Data concerning the environment a gallery interaction was done in.
    * @return
    */
-  def save(env: GalleryTaskEnvironment): Int = db.withTransaction { implicit session =>
-    val galleryTaskEnvironmentId: Int =
-      (galleryTaskEnvironments returning galleryTaskEnvironments.map(_.galleryTaskEnvironmentId)) += env
-    galleryTaskEnvironmentId
+  def save(env: GalleryTaskEnvironment): Int = db.withSession { implicit session =>
+    (galleryTaskEnvironments returning galleryTaskEnvironments.map(_.galleryTaskEnvironmentId)) += env
   }
 }

--- a/app/models/gallery/GalleryTaskInteractionTable.scala
+++ b/app/models/gallery/GalleryTaskInteractionTable.scala
@@ -32,10 +32,8 @@ object GalleryTaskInteractionTable {
     * @param interaction The interaction to be saved.
     * @return
     */
-  def save(interaction: GalleryTaskInteraction): Int = db.withTransaction { implicit session =>
-    val interactionId: Int =
-      (galleryTaskInteractions returning galleryTaskInteractions.map(_.galleryTaskInteractionId)).insert(interaction)
-    interactionId
+  def save(interaction: GalleryTaskInteraction): Int = db.withSession { implicit session =>
+    (galleryTaskInteractions returning galleryTaskInteractions.map(_.galleryTaskInteractionId)).insert(interaction)
   }
 
   /**
@@ -44,7 +42,7 @@ object GalleryTaskInteractionTable {
     * @param interactions The interactions to be saved.
     * @return
     */
-  def saveMultiple(interactions: Seq[GalleryTaskInteraction]): Seq[Int] = db.withTransaction { implicit session =>
+  def saveMultiple(interactions: Seq[GalleryTaskInteraction]): Seq[Int] = db.withSession { implicit session =>
     (galleryTaskInteractions returning galleryTaskInteractions.map(_.galleryTaskInteractionId)) ++= interactions
   }
 }

--- a/app/models/gsv/GSVDataTable.scala
+++ b/app/models/gsv/GSVDataTable.scala
@@ -60,7 +60,7 @@ object GSVDataTable {
     LabelTable.labelsUnfiltered
       .filter(_.gsvPanoramaId =!= "tutorial")
       .groupBy(_.gsvPanoramaId).map(_._1)
-      .length.run
+      .size.run
   }
 
   /**

--- a/app/models/gsv/GSVLinkTable.scala
+++ b/app/models/gsv/GSVLinkTable.scala
@@ -23,7 +23,7 @@ object GSVLinkTable {
     *
     * @param panoramaId Google Street View panorama id
     */
-  def linkExists(panoramaId: String, targetPanoramaId: String): Boolean = db.withTransaction { implicit session =>
+  def linkExists(panoramaId: String, targetPanoramaId: String): Boolean = db.withSession { implicit session =>
     gsvLinks.filter(x => x.gsvPanoramaId === panoramaId && x.targetGsvPanoramaId === targetPanoramaId).list.nonEmpty
   }
 
@@ -32,7 +32,7 @@ object GSVLinkTable {
     *
     * @param link GSVLink object
     */
-  def save(link: GSVLink): String = db.withTransaction { implicit session =>
+  def save(link: GSVLink): String = db.withSession { implicit session =>
     gsvLinks += link
     link.gsvPanoramaId
   }

--- a/app/models/label/LabelPointTable.scala
+++ b/app/models/label/LabelPointTable.scala
@@ -55,9 +55,7 @@ object LabelPointTable {
   /**
    * Stores a label point into the label_point table.
    */
-  def save(point: LabelPoint): Int = db.withTransaction { implicit session =>
-    val labelPointId: Int =
-      (labelPoints returning labelPoints.map(_.labelPointId)) += point
-    labelPointId
+  def save(point: LabelPoint): Int = db.withSession { implicit session =>
+    (labelPoints returning labelPoints.map(_.labelPointId)) += point
   }
 }

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -296,11 +296,11 @@ object LabelTable {
   }
 
   def countLabels: Int = db.withSession(implicit session =>
-    labelsWithTutorial.length.run
+    labelsWithTutorial.size.run
   )
 
   def countLabels(labelType: String): Int = db.withSession { implicit session =>
-    labelsWithTutorial.filter(_.labelTypeId === LabelTypeTable.labelTypeToId(labelType)).length.run
+    labelsWithTutorial.filter(_.labelTypeId === LabelTypeTable.labelTypeToId(labelType)).size.run
   }
 
   /*
@@ -337,7 +337,7 @@ object LabelTable {
   /*
   * Counts the number of labels added during the last week.
   */
-  def countPastWeekLabels: Int = db.withTransaction { implicit session =>
+  def countPastWeekLabels: Int = db.withSession { implicit session =>
     val countQuery = Q.queryNA[Int](
       """SELECT COUNT(label_id)
         |FROM label
@@ -350,13 +350,14 @@ object LabelTable {
   /*
   * Counts the number of specific label types added during the last week.
   */
-  def countPastWeekLabels(labelType: String): Int = db.withTransaction { implicit session =>
+  def countPastWeekLabels(labelType: String): Int = db.withSession { implicit session =>
     val countQuery = Q.queryNA[Int](
       s"""SELECT COUNT(label.label_id)
          |FROM label
+         |INNER JOIN label_type ON label.label_type_id = label_type.label_type_id
          |WHERE (time_created AT TIME ZONE 'US/Pacific') > (now() AT TIME ZONE 'US/Pacific') - interval '168 hours'
          |    AND label.deleted = false
-         |    AND label.label_type_id = ${LabelTypeTable.labelTypeToId(labelType).get};""".stripMargin
+         |    AND label_type.label_type = $labelType;""".stripMargin
     )
     countQuery.first
   }
@@ -368,7 +369,7 @@ object LabelTable {
     * @return A number of labels submitted by the user
     */
   def countLabels(userId: UUID): Int = db.withSession { implicit session =>
-    labelsWithExcludedUsers.filter(_.userId === userId.toString).length.run
+    labelsWithExcludedUsers.filter(_.userId === userId.toString).size.run
   }
 
   /**
@@ -391,7 +392,7 @@ object LabelTable {
     if (labelToUpdate.severity != severity || labelToUpdate.tags.toSet != cleanedTags.toSet) {
       // If there are multiple entries in the label_history table, then the label has been edited before and we need to
       // add an entirely new entry to the table. Otherwise we can just update the existing entry.
-      val labelHistoryCount: Int = LabelHistoryTable.labelHistory.filter(_.labelId === labelId).length.run
+      val labelHistoryCount: Int = LabelHistoryTable.labelHistory.filter(_.labelId === labelId).size.run
       if (labelHistoryCount > 1) {
         LabelHistoryTable.save(LabelHistory(0, labelId, severity, cleanedTags, labelToUpdate.userId, new Timestamp(Instant.now.toEpochMilli), "Explore", None))
       } else {

--- a/app/models/label/LabelValidationTable.scala
+++ b/app/models/label/LabelValidationTable.scala
@@ -98,7 +98,7 @@ object LabelValidationTable {
    * @return An integer with the count
    */
   def countValidationsFromUserAndLabel(userId: UUID, labelId: Int): Int = db.withSession { implicit session =>
-    validationLabels.filter(v => v.userId === userId.toString && v.labelId === labelId).length.run
+    validationLabels.filter(v => v.userId === userId.toString && v.labelId === labelId).size.run
   }
   
   /**
@@ -109,7 +109,7 @@ object LabelValidationTable {
     * @return           Number of labels that were
     */
   def countResultsFromValidationMission(missionId: Int, result: Int): Int = db.withSession { implicit session =>
-    validationLabels.filter(_.missionId === missionId).filter(_.validationResult === result).length.run
+    validationLabels.filter(_.missionId === missionId).filter(_.validationResult === result).size.run
   }
 
   /**
@@ -153,6 +153,7 @@ object LabelValidationTable {
     val userThatAppliedLabel: String = labelsUnfiltered.filter(_.labelId === labelVal.labelId).map(_.userId).list.head
 
     // Update val counts in label table if they're not validating their own label and aren't an excluded user.
+    // TODO pass in session here, I believe that we have nested transactions right now.
     if (userThatAppliedLabel != labelVal.userId & !isExcludedUser)
       updateValidationCounts(labelVal.labelId, Some(labelVal.validationResult), None)
 
@@ -303,7 +304,7 @@ object LabelValidationTable {
 
     validationLabels.innerJoin(labelsWithoutDeleted).on(_.labelId === _.labelId)
       .filter(_._2.labelTypeId === typeID)
-      .length.run
+      .size.run
   }
 
   /**
@@ -315,7 +316,7 @@ object LabelValidationTable {
     validationLabels.innerJoin(labelsWithoutDeleted).on(_.labelId === _.labelId)
       .filter(_._2.labelTypeId === typeID)
       .filter(_._1.validationResult === result)
-      .length.run
+      .size.run
   }
 
   /**
@@ -324,21 +325,21 @@ object LabelValidationTable {
    * @returns the number of validations performed by this user
    */
   def countValidations(userId: UUID): Int = db.withSession { implicit session =>
-    validationLabels.filter(_.userId === userId.toString).length.run
+    validationLabels.filter(_.userId === userId.toString).size.run
   }
 
   /**
     * @return total number of validations
     */
-  def countValidations: Int = db.withTransaction(implicit session =>
-    validationLabels.length.run
+  def countValidations: Int = db.withSession(implicit session =>
+    validationLabels.size.run
   )
 
   /**
     * @return total number of validations with a given result
     */
-  def countValidationsByResult(result: Int): Int = db.withTransaction(implicit session =>
-    validationLabels.filter(_.validationResult === result).length.run
+  def countValidationsByResult(result: Int): Int = db.withSession(implicit session =>
+    validationLabels.filter(_.validationResult === result).size.run
   )
 
   /**

--- a/app/models/mission/MissionTable.scala
+++ b/app/models/mission/MissionTable.scala
@@ -139,7 +139,7 @@ object MissionTable {
     * @param includeOnboarding should any onboarding missions be included in this count
     * @return
     */
-  def countCompletedMissions(userId: UUID, includeOnboarding: Boolean, includeSkipped: Boolean): Int = db.withTransaction { implicit session =>
+  def countCompletedMissions(userId: UUID, includeOnboarding: Boolean, includeSkipped: Boolean): Int = {
     selectCompletedMissions(userId, includeOnboarding, includeSkipped).size
   }
 
@@ -151,7 +151,7 @@ object MissionTable {
       _missionType <- missionTypes
       _mission <- missions if _missionType.missionTypeId === _mission.missionTypeId
       if _missionType.missionType === missionType && _mission.userId === userId.toString && _mission.completed === true
-    } yield _mission.missionId).length.run
+    } yield _mission.missionId).size.run
   }
 
   /**

--- a/app/models/mission/MissionTypeTable.scala
+++ b/app/models/mission/MissionTypeTable.scala
@@ -30,7 +30,7 @@ object MissionTypeTable {
     * @param missionType    Name field for this mission type
     * @return               ID associated with this mission type
     */
-  def missionTypeToId(missionType: String): Int = db.withTransaction { implicit session =>
+  def missionTypeToId(missionType: String): Int = db.withSession { implicit session =>
     missionTypes.filter(_.missionType === missionType).map(_.missionTypeId).first
   }
 
@@ -40,15 +40,7 @@ object MissionTypeTable {
     * @param missionTypeId  ID associated with this mission type
     * @return               Name field for this mission type
     */
-  def missionTypeIdToMissionType(missionTypeId: Int): String = db.withTransaction { implicit session =>
+  def missionTypeIdToMissionType(missionTypeId: Int): String = db.withSession { implicit session =>
     missionTypes.filter(_.missionTypeId === missionTypeId).map(_.missionType).first
-  }
-
-  /**
-    * Saves a new mission type in the table.
-    */
-  def save(missionType: MissionType): Int = db.withTransaction { implicit session =>
-    val missionTypeId: Int = (missionTypes returning missionTypes.map(_.missionTypeId)) += missionType
-    missionTypeId
   }
 }

--- a/app/models/region/RegionCompletionTable.scala
+++ b/app/models/region/RegionCompletionTable.scala
@@ -88,7 +88,7 @@ object RegionCompletionTable {
 
   def initializeRegionCompletionTable() = db.withTransaction { implicit session =>
 
-    if (regionCompletions.length.run == 0) {
+    if (regionCompletions.size.run == 0) {
 
       val neighborhoods: List[Region] = RegionTable.getAllRegions
       for (neighborhood <- neighborhoods) yield {
@@ -109,7 +109,7 @@ object RegionCompletionTable {
     }
   }
 
-  def truncateTable(): Unit = db.withTransaction { implicit session =>
+  def truncateTable(): Unit = db.withSession { implicit session =>
     Q.updateNA("TRUNCATE TABLE region_completion").execute
   }
 }

--- a/app/models/route/RouteStreetTable.scala
+++ b/app/models/route/RouteStreetTable.scala
@@ -36,7 +36,7 @@ object RouteStreetTable {
   /**
    * Inserts a sequence of new route_streets, presumably representing a complete route.
    */
-  def saveMultiple(newRouteStreets: Seq[RouteStreet]): Seq[Int] = db.withTransaction { implicit session =>
+  def saveMultiple(newRouteStreets: Seq[RouteStreet]): Seq[Int] = db.withSession { implicit session =>
     (routeStreets returning routeStreets.map(_.routeStreetId)) ++= newRouteStreets
   }
 }

--- a/app/models/street/StreetEdgeIssueTable.scala
+++ b/app/models/street/StreetEdgeIssueTable.scala
@@ -27,7 +27,7 @@ object StreetEdgeIssueTable {
     * @param issue A StreetEdgeIssue object
     * @return
     */
-  def save(issue: StreetEdgeIssue): Int = db.withTransaction { implicit session =>
+  def save(issue: StreetEdgeIssue): Int = db.withSession { implicit session =>
     streetEdgeIssues += issue
     0
   }

--- a/app/models/street/StreetEdgePriorityTable.scala
+++ b/app/models/street/StreetEdgePriorityTable.scala
@@ -47,10 +47,8 @@ object StreetEdgePriorityTable {
     * @param streetEdgePriority
     * @return
     */
-  def save(streetEdgePriority: StreetEdgePriority): Int = db.withTransaction { implicit session =>
-    val streetEdgePriorityId: Int =
-      (streetEdgePriorities returning streetEdgePriorities.map(_.streetEdgePriorityId)) += streetEdgePriority
-    streetEdgePriorityId
+  def save(streetEdgePriority: StreetEdgePriority): Int = db.withSession { implicit session =>
+    (streetEdgePriorities returning streetEdgePriorities.map(_.streetEdgePriorityId)) += streetEdgePriority
   }
 
   def auditedStreetDistanceUsingPriority: Float = db.withSession { implicit session =>
@@ -81,7 +79,7 @@ object StreetEdgePriorityTable {
       if ser.regionId === regionId
       if sep.priority === 1.0
     } yield sep
-    streetsToAudit.length.run == 0
+    streetsToAudit.size.run == 0
   }
 
   def streetDistanceCompletionRateUsingPriority: Float = db.withSession { implicit session =>
@@ -109,12 +107,12 @@ object StreetEdgePriorityTable {
     * and 1. This returns the reciprocal for each street edge's parameter value. The reciprocal is calculated after
     * adding some prior to the value to prevent divide by zero errors.
     *
-    * @param priorityParamTable
+    * @param priorityParams
     * @return
     */
-  def normalizePriorityReciprocal(priorityParamTable: List[StreetEdgePriorityParameter]): List[StreetEdgePriorityParameter] = db.withTransaction { implicit session =>
+  def normalizePriorityReciprocal(priorityParams: List[StreetEdgePriorityParameter]): List[StreetEdgePriorityParameter] = {
     val prior = 1
-    priorityParamTable.map{x => x.copy(priorityParameter = 1 / (x.priorityParameter + prior))}
+    priorityParams.map{x => x.copy(priorityParameter = 1 / (x.priorityParameter + prior))}
   }
 
   /**
@@ -161,8 +159,7 @@ object StreetEdgePriorityTable {
     * @param weightVector List of positive numbers b/w 0 and 1 that sum to 1; used to weight the generated parameters.
     * @return
     */
-  def updateAllStreetEdgePriorities(rankParameterGeneratorList: List[()=>List[StreetEdgePriorityParameter]],
-                                    weightVector: List[Double]) = db.withTransaction { implicit session =>
+  def updateAllStreetEdgePriorities(rankParameterGeneratorList: List[()=>List[StreetEdgePriorityParameter]], weightVector: List[Double]) = db.withSession { implicit session =>
 
     // Create a map from each street edge to a default priority value of 0.
     val edgePriorityMap = collection.mutable.Map[Int, Double]().withDefaultValue(0.0)
@@ -175,6 +172,7 @@ object StreetEdgePriorityTable {
     }
 
     // Set priority values in the table.
+    // TODO update this to use a batch update after upgrading Slick, there should be easier syntax to do it in future.
     for ((edgeId, newPriority) <- edgePriorityMap) {
       val q = for { edge <- streetEdgePriorities if edge.streetEdgeId === edgeId } yield edge.priority
       val rowsUpdated: Int = q.update(newPriority)
@@ -255,7 +253,7 @@ object StreetEdgePriorityTable {
     * @param streetEdgeId
     * @return success boolean
     */
-  def partiallyUpdatePriority(streetEdgeId: Int, userId: UUID): Boolean = db.withTransaction { implicit session =>
+  def partiallyUpdatePriority(streetEdgeId: Int, userId: UUID): Boolean = db.withSession { implicit session =>
     // Check if the user that audited is high quality. Make sure they have an entry in user_stat table first.
     UserStatTable.addUserStatIfNew(userId)
     val userHighQuality: Boolean = UserStatTable.userStats.filter(_.userId === userId.toString).map(_.highQuality).first

--- a/app/models/street/StreetEdgeTable.scala
+++ b/app/models/street/StreetEdgeTable.scala
@@ -121,7 +121,7 @@ object StreetEdgeTable {
     * @return
     */
   def countTotalStreets(): Int = db.withSession { implicit session =>
-    streetEdgesWithoutDeleted.length.run
+    streetEdgesWithoutDeleted.size.run
   }
 
   /**

--- a/app/models/survey/SurveyQuestionTable.scala
+++ b/app/models/survey/SurveyQuestionTable.scala
@@ -22,21 +22,15 @@ object SurveyQuestionTable{
   val surveyQuestions = TableQuery[SurveyQuestionTable]
   val surveyOptions = TableQuery[SurveyOptionTable]
 
-  def getQuestionById(surveyQuestionId: Int): Option[SurveyQuestion] = db.withTransaction { implicit session =>
+  def getQuestionById(surveyQuestionId: Int): Option[SurveyQuestion] = db.withSession { implicit session =>
     surveyQuestions.filter(_.surveyQuestionId === surveyQuestionId).firstOption
   }
 
-  def listOptionsByQuestion(surveyQuestionId: Int): Option[List[SurveyOption]] = db.withTransaction { implicit session =>
-    val question: Option[SurveyQuestion] = getQuestionById(surveyQuestionId)
-    question match{
-      case Some(q) =>
-        Some(surveyOptions.filter(_.surveyQuestionId === surveyQuestionId).list)
-      case None =>
-        None
-    }
+  def listOptionsByQuestion(surveyQuestionId: Int): List[SurveyOption] = db.withSession { implicit session =>
+    surveyOptions.filter(_.surveyQuestionId === surveyQuestionId).list
   }
 
-  def listAll: List[SurveyQuestion] = db.withTransaction { implicit session =>
+  def listAll: List[SurveyQuestion] = db.withSession { implicit session =>
     surveyQuestions.filter(_.deleted === false).list
   }
 }

--- a/app/models/user/OrganizationTable.scala
+++ b/app/models/user/OrganizationTable.scala
@@ -45,7 +45,7 @@ object OrganizationTable {
    * @param orgId The id of the organization.
    * @return The name of the organization.
    */
-  def getOrganizationName(orgId: Int): Option[String] = db.withTransaction { implicit session =>
+  def getOrganizationName(orgId: Int): Option[String] = db.withSession { implicit session =>
     organizations.filter(_.orgId === orgId).map(_.orgName).firstOption
   }
 
@@ -55,7 +55,7 @@ object OrganizationTable {
    * @param orgId The id of the organization.
    * @return The description of the organization.
    */
-  def getOrganizationDescription(orgId: Int): Option[String] = db.withTransaction { implicit session =>
+  def getOrganizationDescription(orgId: Int): Option[String] = db.withSession { implicit session =>
     organizations.filter(_.orgId === orgId).map(_.orgDescription).firstOption
   }
   

--- a/app/models/user/RoleTable.scala
+++ b/app/models/user/RoleTable.scala
@@ -16,7 +16,7 @@ object RoleTable {
   val db = play.api.db.slick.DB
   val roles = TableQuery[RoleTable]
 
-  def getRoleNames: List[String] = db.withTransaction { implicit session =>
+  def getRoleNames: List[String] = db.withSession { implicit session =>
     roles.map(_.role).list
   }
 }

--- a/app/models/user/UserCurrentRegionTable.scala
+++ b/app/models/user/UserCurrentRegionTable.scala
@@ -24,11 +24,8 @@ object UserCurrentRegionTable {
 
   val regionsWithoutDeleted = RegionTable.regionsWithoutDeleted
 
-  def save(userId: UUID, regionId: Int): Int = db.withTransaction { implicit session =>
-    val userCurrentRegion = UserCurrentRegion(0, userId.toString, regionId)
-    val userCurrentRegionId: Int =
-      (userCurrentRegions returning userCurrentRegions.map(_.userCurrentRegionId)) += userCurrentRegion
-    userCurrentRegionId
+  def save(userId: UUID, regionId: Int): Int = db.withSession { implicit session =>
+    (userCurrentRegions returning userCurrentRegions.map(_.userCurrentRegionId)) += UserCurrentRegion(0, userId.toString, regionId)
   }
 
   /**

--- a/app/models/user/UserRoleTable.scala
+++ b/app/models/user/UserRoleTable.scala
@@ -46,7 +46,7 @@ object UserRoleTable {
     setRole(userId, roleMapping(newRole), communityService)
   }
 
-  def setRole(userId: UUID, newRole: Int, communityService: Option[Boolean]): Int = db.withTransaction { implicit session =>
+  def setRole(userId: UUID, newRole: Int, communityService: Option[Boolean]): Int = db.withSession { implicit session =>
     val currRole: Option[UserRole] = userRoles.filter(_.userId === userId.toString).firstOption
     val commServ: Boolean = communityService.getOrElse(currRole.map(_.communityService).getOrElse(false))
     userRoles.insertOrUpdate(UserRole(currRole.map(_.userRoleId).getOrElse(0), userId.toString, newRole, commServ))

--- a/app/models/user/UserStatTable.scala
+++ b/app/models/user/UserStatTable.scala
@@ -542,7 +542,7 @@ object UserStatTable {
     * @return Number of rows updated
     */
   def addUserStatIfNew(userId: UUID): Int = db.withTransaction { implicit session =>
-    if (userStats.filter(_.userId === userId.toString).length.run == 0)
+    if (userStats.filter(_.userId === userId.toString).size.run == 0)
       userStats.insert(UserStat(0, userId.toString, 0F, None, true, None, 0, None, false))
     else
       0

--- a/app/models/user/UserSurveyOptionSubmission.scala
+++ b/app/models/user/UserSurveyOptionSubmission.scala
@@ -29,9 +29,7 @@ object UserSurveyOptionSubmissionTable{
   val db = play.api.db.slick.DB
   val userSurveyOptionSubmissions = TableQuery[UserSurveyOptionSubmissionTable]
 
-  def save(userSurveyOptionSubmission: UserSurveyOptionSubmission): Int = db.withTransaction { implicit session =>
-    val userSurveyOptionSubmissionId: Int =
-      (userSurveyOptionSubmissions returning userSurveyOptionSubmissions.map(_.userSurveyOptionSubmissionId)) += userSurveyOptionSubmission
-    userSurveyOptionSubmissionId
+  def save(optionSubmission: UserSurveyOptionSubmission): Int = db.withSession { implicit session =>
+    (userSurveyOptionSubmissions returning userSurveyOptionSubmissions.map(_.userSurveyOptionSubmissionId)) += optionSubmission
   }
 }

--- a/app/models/user/UserSurveyTextSubmission.scala
+++ b/app/models/user/UserSurveyTextSubmission.scala
@@ -29,9 +29,7 @@ object UserSurveyTextSubmissionTable{
   val db = play.api.db.slick.DB
   val userSurveyTextSubmissions = TableQuery[UserSurveyTextSubmissionTable]
 
-  def save(userSurveyTextSubmission: UserSurveyTextSubmission): Int = db.withTransaction { implicit session =>
-    val userSurveyTextSubmissionId: Int =
-      (userSurveyTextSubmissions returning userSurveyTextSubmissions.map(_.userSurveyTextSubmissionId)) += userSurveyTextSubmission
-    userSurveyTextSubmissionId
+  def save(textSubmission: UserSurveyTextSubmission): Int = db.withSession { implicit session =>
+    (userSurveyTextSubmissions returning userSurveyTextSubmissions.map(_.userSurveyTextSubmissionId)) += textSubmission
   }
 }

--- a/app/models/user/WebpageActivityTable.scala
+++ b/app/models/user/WebpageActivityTable.scala
@@ -28,14 +28,13 @@ object WebpageActivityTable {
   val userRoles = TableQuery[UserRoleTable]
   val roles = TableQuery[RoleTable]
 
-  def save(activity: WebpageActivity): Int = db.withTransaction { implicit session =>
+  def save(activity: WebpageActivity): Int = db.withSession { implicit session =>
     if (activity.ipAddress == "128.8.132.187") {
       // Don't save data if the activity is from the remote proxy.
       // TODO The IP address of the remote proxy server should be stored somewhere
       0
     } else {
-      val webpageActivityId: Int = (activities returning activities.map(_.webpageActivityId)) += activity
-      webpageActivityId
+      (activities returning activities.map(_.webpageActivityId)) += activity
     }
   }
 
@@ -44,7 +43,7 @@ object WebpageActivityTable {
     *
     * @return List[(userId: String, role: String, count: Int)]
     */
-  def selectAllSignInCounts: List[(String, String, Int)] = db.withTransaction { implicit session =>
+  def selectAllSignInCounts: List[(String, String, Int)] = db.withSession { implicit session =>
     val signIns = for {
       _activity <- activities if _activity.activity like "SignIn%"
       _userRole <- userRoles if _activity.userId === _userRole.userId

--- a/app/models/validation/ValidationTaskCommentTable.scala
+++ b/app/models/validation/ValidationTaskCommentTable.scala
@@ -36,19 +36,14 @@ object ValidationTaskCommentTable {
   /**
     * Insert an validation_task_comment record.
     */
-  def save(comment: ValidationTaskComment): Int = db.withTransaction { implicit session =>
-    val validationTaskCommentId: Int =
-      (validationTaskComments returning validationTaskComments.map(_.validationTaskCommentId)) += comment
-    validationTaskCommentId
+  def save(comment: ValidationTaskComment): Int = db.withSession { implicit session =>
+    (validationTaskComments returning validationTaskComments.map(_.validationTaskCommentId)) += comment
   }
 
   /**
     * Delete a validation_task_comment record.
     */
-  def deleteIfExists(labelId: Int, missionId: Int): Int = db.withTransaction { implicit session =>
-    val query = validationTaskComments
-      .filter(comment => comment.labelId === labelId && comment.missionId === missionId)
-    val rowsAffected = query.delete
-    rowsAffected
+  def deleteIfExists(labelId: Int, missionId: Int): Int = db.withSession { implicit session =>
+    validationTaskComments.filter(comment => comment.labelId === labelId && comment.missionId === missionId).delete
   }
 }

--- a/app/models/validation/ValidationTaskEnvironmentTable.scala
+++ b/app/models/validation/ValidationTaskEnvironmentTable.scala
@@ -45,9 +45,7 @@ object ValidationTaskEnvironmentTable {
   /**
    * Saves a new validation task environment.
    */
-  def save(env: ValidationTaskEnvironment): Int = db.withTransaction { implicit session =>
-    val validationTaskEnvironmentId: Int =
-      (validationTaskEnvironments returning validationTaskEnvironments.map(_.validationTaskEnvironmentId)) += env
-    validationTaskEnvironmentId
+  def save(env: ValidationTaskEnvironment): Int = db.withSession { implicit session =>
+    (validationTaskEnvironments returning validationTaskEnvironments.map(_.validationTaskEnvironmentId)) += env
   }
 }

--- a/app/views/explore.scala.html
+++ b/app/views/explore.scala.html
@@ -133,7 +133,7 @@
                                 }
                                 @if(surveyQuestion.surveyInputType == "radio") {
                                     <ul class="survey-option-holder">
-                                    @for(surveyOption <- SurveyQuestionTable.listOptionsByQuestion(surveyQuestion.surveyQuestionId).get) {
+                                    @for(surveyOption <- SurveyQuestionTable.listOptionsByQuestion(surveyQuestion.surveyQuestionId)) {
                                         <li class="survey-option">
                                             @if(surveyQuestion.required == true) {
                                                 <input type="@surveyQuestion.surveyInputType" name="@surveyQuestion.surveyQuestionId" value="@surveyOption.surveyOptionId" required>
@@ -147,7 +147,7 @@
                                 } else {
                                     @if(surveyQuestion.surveyInputType == "checkbox") {
                                         <ul class="survey-option-holder">
-                                        @for(surveyOption <- SurveyQuestionTable.listOptionsByQuestion(surveyQuestion.surveyQuestionId).get) {
+                                        @for(surveyOption <- SurveyQuestionTable.listOptionsByQuestion(surveyQuestion.surveyQuestionId)) {
                                             <li class="survey-option">
                                                 <input type="@surveyQuestion.surveyInputType" name="@surveyQuestion.surveyQuestionId" value="@surveyOption.surveyOptionId">
                                                 <label>@Messages("audit.survey." + surveyQuestion.surveyQuestionTextId + ".option." + surveyOption.surveyDisplayRank.get)</label>


### PR DESCRIPTION
Working on #3726 

We've had some back end db issues since switching to unified login. I was looking at some logs today as Teaneck is currently down. I'm seeing a lot of errors about not being able to find free/available db connections.

One small thing I'm trying here is to change a bunch of instances where we're using `withTransaction` and switching it to `withSession`. I think that in some cases this may result in essentially a lock being taken out on a table, preventing it from being used by other processes, which could be slowing down the system.

It looked like Teaneck may have gone down while running nightly clustering, and I took a quick peek at the code and noticed that we were using `withTransaction` often there unnecessarily, which is why I started making this change. I'm honestly not expecting it to really help, but you never know! And it's something that we've needed to do anyway.

Other small updates:
* Updated instance of `.length.run` to `.size.run`. Both of these get a count of rows in the db, but the former will be deprecated in the future, and we should keep things consistent!
* A few functions were simplified, mostly for clarity. Primarily in `DBTableDefinitions.scala` and `SurveyQuestionTable.scala`
* Fixed a couple instances of nested transactions (#3550) in `LabelTable.scala` and `MissionTable.scala`

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
