### PR TITLE
Fixes divide by zero error in overallStats API when there are no labels

### DIFF
--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -1181,11 +1181,13 @@ object LabelTable {
     val launchDate: String = Play.configuration.getString(s"city-params.launch-date.$cityId").get
 
     val recentLabelDates: List[Timestamp] = labels.sortBy(_.timeCreated.desc).take(100).list.map(_.timeCreated)
-    val avgRecentLabels: Timestamp = new Timestamp(recentLabelDates.map(_.getTime).sum / recentLabelDates.length)
+    val avgRecentLabels: Option[Timestamp] =
+      if (recentLabelDates.nonEmpty) Some(new Timestamp(recentLabelDates.map(_.getTime).sum / recentLabelDates.length))
+      else None
 
     val overallStatsQuery = Q.queryNA[ProjectSidewalkStats](
       s"""SELECT '$launchDate' AS launch_date,
-         |       '$avgRecentLabels' AS avg_timestamp_last_100_labels,
+         |       '${avgRecentLabels.map(_.toString).getOrElse("N/A")}' AS avg_timestamp_last_100_labels,
          |       km_audited.km_audited AS km_audited,
          |       km_audited_no_overlap.km_audited_no_overlap AS km_audited_no_overlap,
          |       users.total_users,


### PR DESCRIPTION
Fixes #3745

Fixed the divide by zero error in the /overallStats API when the city has no labels! We now deal with this case and output "N/A" for the `avg_timestamp_last_100_labels` attribute if there are no labels.

@jonfroehlich you may have to take this into account in your dashboard!

##### Before/After screenshots (if applicable)
Here's a look at the output if there are no labels.
![Screenshot from 2024-11-22 17-03-23](https://github.com/user-attachments/assets/1f5280ef-9563-47eb-9d19-af73a10dc701)
