### PR TITLE
Commented out an additional enable keyboard statement to ensure that …

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/Main.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Main.js
@@ -174,7 +174,10 @@ function Main (params) {
         );
 
         // Speed limit
-        svl.speedLimit = new SpeedLimit(svl.panorama, svl.map.getPosition, svl.isOnboarding);
+        if (currLabel.labelType == 'NoCurbRamp') {
+            svl.speedLimit = new SpeedLimit(svl.panorama, svl.map.getPosition, svl.isOnboarding);
+        }
+        
 
         // Survey for select users
         svl.surveyModalContainer = $("#survey-modal-container").get(0);

--- a/public/javascripts/SVValidate/src/Main.js
+++ b/public/javascripts/SVValidate/src/Main.js
@@ -179,7 +179,11 @@ function Main (param) {
             svv.gsvOverlay = new GSVOverlay();
             svv.keyboard = new Keyboard(svv.ui.validation);
             svv.labelVisibilityControl = new LabelVisibilityControl();
-            svv.speedLimit = new SpeedLimit(svv.panorama.getPanorama(), svv.panorama.getPosition, () => false);
+            const labelTypeTemp = param.labelList[0].getAuditProperty('labelType');
+            if (labelTypeTemp == 'NoCurbRamp') {
+                svv.speedLimit = new SpeedLimit(svv.panorama.getPanorama(), svv.panorama.getPosition, () => false);
+            }
+            
             svv.zoomControl = new ZoomControl();
         }
 
@@ -241,7 +245,7 @@ function Main (param) {
             html: true
         });
 
-        const labelType = param.labelList[0].getAuditProperty('labelType');
+        constlabelType = param.labelList[0].getAuditProperty('labelType');
 
         const missionStartTutorial = new MissionStartTutorial('validate', labelType, { nLabels: param.mission.labels_validated }, svv, param.language);
 

--- a/public/javascripts/SVValidate/src/modal/ModalMissionComplete.js
+++ b/public/javascripts/SVValidate/src/modal/ModalMissionComplete.js
@@ -5,6 +5,7 @@ function ModalMissionComplete (uiModalMissionComplete, user, language = 'en') {
     };
     let watch;
 
+
     function _handleButtonClick(event) {
         // If they've done three missions and clicked the audit button, load the explore page.
         if (event.data.button === 'primary' && svv.missionsCompleted % 3 === 0 && !isMobile()) {
@@ -34,7 +35,7 @@ function ModalMissionComplete (uiModalMissionComplete, user, language = 'en') {
         // Have to remove the effect since keyup event did not go through (but no keyboard use on mobile).
         if (svv.keyboard) {
             svv.keyboard.removeAllKeyPressVisualEffect();
-            svv.keyboard.enableKeyboard();
+            //svv.keyboard.enableKeyboard();
         }
 
         uiModalMissionComplete.closeButtonPrimary.off('click');
@@ -132,10 +133,14 @@ function ModalMissionComplete (uiModalMissionComplete, user, language = 'en') {
                 labelsValidated: mission.getProperty("labelsValidated")
             }
         );
+        if (svv.keyboard) {
+            svv.keyboard.disableKeyboard();
+        }
     }
-
+    
     self.getProperty = getProperty;
     self.hide = hide;
     self.setProperty = setProperty;
     self.show = show;
+    
 }


### PR DESCRIPTION
Resolves #123

Essentially, the validate mission would start logging entries before the validate screen even came on, specifically when the user is on the Mission Start screen. I fixed it by commenting out an extra enableKeyboard line. 

##### Testing instructions
1. 

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've tested on mobile (only needed for validation page).
