### PR TITLE
Adds admin params for /newValidateBeta

### DIFF
--- a/app/controllers/ValidationController.scala
+++ b/app/controllers/ValidationController.scala
@@ -57,22 +57,52 @@ class ValidationController @Inject() (implicit val env: Environment[User, Sessio
   }
 
   /**
-   * Returns the new validation that includes severity and tags page.
-   */
-  def newValidateBeta = UserAwareAction.async { implicit request =>
+    * Returns the new validate beta page, optionally with some admin filters.
+    *
+    * @param labelType       Label type or label type ID to validate.
+    * @param users           Comma-separated list of usernames or user IDs to validate (could be mixed).
+    * @param neighborhoods   Comma-separated list of neighborhood names or region IDs to validate (could be mixed).
+    */
+  def newValidateBeta(labelType: Option[String], users: Option[String], neighborhoods: Option[String]) = UserAwareAction.async { implicit request =>
     if (isAdmin(request.identity)) {
-      request.identity match {
-        case Some(user) =>
-          val adminParams = AdminValidateParams(adminVersion = false)
-          val validationData = getDataForValidationPages(request, labelCount = 10, "Visit_NewValidateBeta", adminParams)
-          if (validationData._4.missionType != "validation") {
-            Future.successful(Redirect("/explore"))
-          } else {
-            val tags: List[Tag] = TagTable.getTagsForCurrentCity
-            Future.successful(Ok(views.html.newValidateBeta("Sidewalk - NewValidateBeta", Some(user), adminParams, validationData._1, validationData._2, validationData._3, validationData._4.numComplete, validationData._5, validationData._6, tags)))
-          }
-        case None =>
-          Future.successful(Redirect(s"/anonSignUp?url=/newValidateBeta"));
+      // If any inputs are invalid, send back error message. For each input, we check if the input is an integer
+      // representing a valid ID (label_type_id, user_id, or region_id) or a String representing a valid name for that
+      // parameter (label_type, username, or region_name).
+      val possibleLabTypeIds: List[Int] = LabelTable.valLabelTypeIds
+      val parsedLabelTypeId: Option[Option[Int]] = labelType.map { lType =>
+        val parsedId: Try[Int] = Try(lType.toInt)
+        val lTypeIdFromName: Option[Int] = LabelTypeTable.labelTypeToId(lType)
+        if (parsedId.isSuccess && possibleLabTypeIds.contains(parsedId.get)) parsedId.toOption
+        else if (lTypeIdFromName.isDefined) lTypeIdFromName
+        else None
+      }
+      val userIdsList: Option[List[Option[String]]] = users.map(_.split(',').map(_.trim).map { userStr =>
+        val parsedUserId: Option[UUID] = Try(UUID.fromString(userStr)).toOption
+        val user: Option[DBUser] = parsedUserId.flatMap(u => UserTable.findById(u))
+        val userId: Option[String] = UserTable.find(userStr).map(_.userId)
+        if (user.isDefined) Some(userStr) else if (userId.isDefined) Some(userId.get) else None
+      }.toList)
+      val neighborhoodIdList: Option[List[Option[Int]]] = neighborhoods.map(_.split(",").map { regionStr =>
+        val parsedRegionId: Try[Int] = Try(regionStr.toInt)
+        val regionFromName: Option[Region] = RegionTable.getRegionByName(regionStr)
+        if (parsedRegionId.isSuccess && RegionTable.getRegion(parsedRegionId.get).isDefined) parsedRegionId.toOption
+        else if (regionFromName.isDefined) regionFromName.map(_.regionId)
+        else None
+      }.toList)
+
+      // If any inputs are invalid (even any item in the list of users/regions), send back error message.
+      if (parsedLabelTypeId.isDefined && parsedLabelTypeId.get.isEmpty) {
+        Future.successful(BadRequest(s"Invalid label type provided: ${labelType.get}. Valid label types are: ${LabelTypeTable.getAllLabelTypes.filter(l => possibleLabTypeIds.contains(l.labelTypeId)).map(_.labelType).toList.reverse.mkString(", ")}. Or you can use their IDs: ${possibleLabTypeIds.mkString(", ")}."))
+      } else if (userIdsList.isDefined && userIdsList.get.length != userIdsList.get.flatten.length) {
+        Future.successful(BadRequest(s"One or more of the users provided were not found; please double check your list of users! You can use either their usernames or user IDs. You provided: ${users.get}"))
+      } else if (neighborhoodIdList.isDefined && neighborhoodIdList.get.length != neighborhoodIdList.get.flatten.length) {
+        Future.successful(BadRequest(s"One or more of the neighborhoods provided were not found; please double check your list of neighborhoods! You can use either their names or IDs. You provided: ${neighborhoods.get}"))
+      } else {
+        // If all went well, load the data for Admin NewValidateBeta with the specified filters.
+        val adminParams: AdminValidateParams = AdminValidateParams(adminVersion=true, parsedLabelTypeId.flatten, userIdsList.map(_.flatten), neighborhoodIdList.map(_.flatten))
+        val validationData = getDataForValidationPages(request, labelCount=10, "Visit_NewValidateBeta", adminParams)
+        val tags: List[Tag] = TagTable.getTagsForCurrentCity
+        Future.successful(Ok(views.html.newValidateBeta("Sidewalk - NewValidateBeta", request.identity, adminParams, validationData._1, validationData._2, validationData._3, validationData._4.numComplete, validationData._5, validationData._6, tags)))
       }
     } else {
       Future.failed(new AuthenticationException("This is a beta currently only open to Admins."))
@@ -144,7 +174,7 @@ class ValidationController @Inject() (implicit val env: Environment[User, Sessio
         Future.successful(Ok(views.html.validation("Sidewalk - Admin Validate", request.identity, adminParams, validationData._1, validationData._2, validationData._3, validationData._4.numComplete, validationData._5, validationData._6, validationData._7)))
       }
     } else {
-      Future.failed(new AuthenticationException("User is not an administrator"))
+      Future.failed(new AuthenticationException("This is a beta currently only open to Admins."))
     }
   }
 

--- a/conf/routes
+++ b/conf/routes
@@ -107,7 +107,7 @@ GET     /audit/street/:id                                    @controllers.AuditC
 
 # Label validation tasks
 GET     /validate                                            @controllers.ValidationController.validate
-GET     /newValidateBeta                                     @controllers.ValidationController.newValidateBeta
+GET     /newValidateBeta                                     @controllers.ValidationController.newValidateBeta(labelType: Option[String] ?= None, users: Option[String] ?= None, neighborhoods: Option[String] ?= None)
 GET     /adminValidate                                       @controllers.ValidationController.adminValidate(labelType: Option[String] ?= None, users: Option[String] ?= None, neighborhoods: Option[String] ?= None)
 POST    /validate/comment                                    @controllers.ValidationController.postComment
 


### PR DESCRIPTION
Working towards #3584 

Adds URL parameters matching those for /adminValidate, allowing admins to specify which label type, users, and neighborhoods for the labels they're validating. I'm adding these quickly so that our partners can make use of them over the next couple of weeks, so I didn't include anything in the UI to show that extra info like we're doing for /adminValidate. For reference, here's an example 
```
/newValidateBeta?labelType=CurbRamp&users=user1,user2&neighborhoods=3,Downtown,6
```

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
