### PR TITLE
Code to ensure keyboard isn't incorrectly enabled during the Mission Start screen

### DIFF
--- a/public/javascripts/SVValidate/src/modal/ModalMissionComplete.js
+++ b/public/javascripts/SVValidate/src/modal/ModalMissionComplete.js
@@ -34,7 +34,8 @@ function ModalMissionComplete (uiModalMissionComplete, user, language = 'en') {
         // Have to remove the effect since keyup event did not go through (but no keyboard use on mobile).
         if (svv.keyboard) {
             svv.keyboard.removeAllKeyPressVisualEffect();
-            svv.keyboard.enableKeyboard();
+            // Commenting this out to fix bug 3670
+            // svv.keyboard.enableKeyboard();
         }
 
         uiModalMissionComplete.closeButtonPrimary.off('click');

--- a/public/javascripts/SVValidate/src/modal/ModalMissionComplete.js
+++ b/public/javascripts/SVValidate/src/modal/ModalMissionComplete.js
@@ -34,8 +34,6 @@ function ModalMissionComplete (uiModalMissionComplete, user, language = 'en') {
         // Have to remove the effect since keyup event did not go through (but no keyboard use on mobile).
         if (svv.keyboard) {
             svv.keyboard.removeAllKeyPressVisualEffect();
-            // Commenting this out to fix bug 3670
-            // svv.keyboard.enableKeyboard();
         }
 
         uiModalMissionComplete.closeButtonPrimary.off('click');


### PR DESCRIPTION
Resolves #3704

The keyboard was being incorrectly enabling during the screen right before the Validation missions and increasing the count even before the mission started. I commented out the extra keyboard enabling. 

##### Before/After screenshots (if applicable)

##### Testing instructions
1. 

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
- [x] I've asked for and included translations for any user facing text that was added or modified.
- [x] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure the documentation on [this wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Descriptions-of-Logged-Events) is up to date for the logs you added/updated.
- [x] I've tested on mobile (only needed for validation page).
