### PR TITLE
resolved issues with labelmap in firefox due to circle css

### DIFF
--- a/public/stylesheets/choropleth.css
+++ b/public/stylesheets/choropleth.css
@@ -84,8 +84,8 @@
 }
 
 .map-legend-circle-icon circle {
-    cx: 10;
-    cy: 10;
+    cx: 50%;
+    cy: 50%;
 }
 
 #map-legend-curb-ramp circle {


### PR DESCRIPTION
Resolves #3776 

Updated cx and cy presentation attributes to the circle as mentioned here. 
https://stackoverflow.com/questions/51551729/styling-of-svg-circle-doesn%C2%B4t-work-in-firefox-browser-removes-radius-property


##### Before/After screenshots (if applicable)
<img width="1624" alt="Screenshot 2025-01-27 at 4 21 33 PM" src="https://github.com/user-attachments/assets/23ffab28-a9e7-40c6-bbb7-a7df95c5c185" />
<img width="1624" alt="Screenshot 2025-01-27 at 4 21 18 PM" src="https://github.com/user-attachments/assets/b47f2779-ab67-4321-98da-7edae0011a41" />


##### Testing instructions
1. Run locally on firefox and go to labelmap page. http://localhost:9000/labelMap

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x ] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [ x] I've added/updated comments for large or confusing blocks of code.
- [ x] I've included before/after screenshots above.
- [ x] I've asked for and included translations for any user facing text that was added or modified.
- [ x] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure the documentation on [this wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Descriptions-of-Logged-Events) is up to date for the logs you added/updated.
- [ x] I've tested on mobile (only needed for validation page).