### PR TITLE
Adds neighborhoods URL param to Validate and Mobile Validate

### DIFF
--- a/app/controllers/helper/ValidateHelper.scala
+++ b/app/controllers/helper/ValidateHelper.scala
@@ -9,7 +9,6 @@ object ValidateHelper {
   case class AdminValidateParams(adminVersion: Boolean, labelTypeId: Option[Int]=None, userIds: Option[List[String]]=None, neighborhoodIds: Option[List[Int]]=None) {
     require(labelTypeId.isEmpty || adminVersion, "labelTypeId can only be set if adminVersion is true")
     require(userIds.isEmpty || adminVersion, "userIds can only be set if adminVersion is true")
-    require(neighborhoodIds.isEmpty || adminVersion, "neighborhoodIds can only be set if adminVersion is true")
   }
 
   /**

--- a/conf/routes
+++ b/conf/routes
@@ -22,7 +22,7 @@ GET     /labelingGuide/surfaceProblems                       @controllers.Applic
 GET     /labelingGuide/obstacles                             @controllers.ApplicationController.labelingGuideObstacles
 GET     /labelingGuide/noSidewalk                            @controllers.ApplicationController.labelingGuideNoSidewalk
 GET     /labelingGuide/occlusion                             @controllers.ApplicationController.labelingGuideOcclusion
-GET     /mobile                                              @controllers.ValidationController.mobileValidate
+GET     /mobile                                              @controllers.ValidationController.mobileValidate(neighborhoods: Option[String] ?= None)
 GET     /turkerIdExists                                      @controllers.ApplicationController.turkerIdExists
 GET     /leaderboard                                         @controllers.ApplicationController.leaderboard
 GET     /serviceHoursInstructions                            @controllers.ApplicationController.serviceHoursInstructions
@@ -106,7 +106,7 @@ GET     /audit/region/:id                                    @controllers.AuditC
 GET     /audit/street/:id                                    @controllers.AuditController.exploreStreet(id: Int, lat: Option[Double], lng: Option[Double], panoId: Option[String])
 
 # Label validation tasks
-GET     /validate                                            @controllers.ValidationController.validate
+GET     /validate                                            @controllers.ValidationController.validate(neighborhoods: Option[String] ?= None)
 GET     /newValidateBeta                                     @controllers.ValidationController.newValidateBeta(labelType: Option[String] ?= None, users: Option[String] ?= None, neighborhoods: Option[String] ?= None)
 GET     /adminValidate                                       @controllers.ValidationController.adminValidate(labelType: Option[String] ?= None, users: Option[String] ?= None, neighborhoods: Option[String] ?= None)
 POST    /validate/comment                                    @controllers.ValidationController.postComment
@@ -155,8 +155,8 @@ POST    /userapi/logWebpageActivity                          @controllers.UserCo
 PUT    /userapi/setUserOrg/:orgId                            @controllers.UserProfileController.setUserOrg(orgId: Int)
 POST   /userapi/createTeam                                   @controllers.UserProfileController.createTeam
 GET    /userapi/getTeams                                     @controllers.UserProfileController.getTeams
-PUT   /userapi/updateStatus/:orgId                          @controllers.UserProfileController.updateStatus(orgId: Int)
-PUT   /userapi/updateVisibility/:orgId                      @controllers.UserProfileController.updateVisibility(orgId: Int)
+PUT    /userapi/updateStatus/:orgId                          @controllers.UserProfileController.updateStatus(orgId: Int)
+PUT    /userapi/updateVisibility/:orgId                      @controllers.UserProfileController.updateVisibility(orgId: Int)
 
 # Access Feature and Access Score APIs
 GET     /v2/access/attributes                                @controllers.ProjectSidewalkAPIController.getAccessAttributesV2(lat1: Option[Double], lng1: Option[Double], lat2: Option[Double], lng2: Option[Double], severity: Option[String], filetype: Option[String], inline: Option[Boolean])


### PR DESCRIPTION
Resolves #3784

Adds the ability to use the "neighborhoods" URL parameter on both Validate and Mobile Validate. Example uses:
```
/validate?neighborhoods=2
/validate?neighborhoods=North Oakland
/validate?neighborhoods=North Oakland,Central Business District
/mobile?neighborhoods=North Oakland
```

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've tested on mobile (only needed for validation page).
