### PR TITLE
3778 fixed user dashboard teams list not displaying special characters correctly for team name and description

### DIFF
--- a/app/views/userProfile.scala.html
+++ b/app/views/userProfile.scala.html
@@ -268,7 +268,7 @@
                 </div>
             </div>
         </div>
-        
+
         <div id="mistakes-row" class="row">
             <h2 id="recent-mistakes">@Messages("dashboard.mistakes.header")</h2>
             <span id="mistakes-subheader-display"></span>

--- a/app/views/userProfile.scala.html
+++ b/app/views/userProfile.scala.html
@@ -268,7 +268,7 @@
                 </div>
             </div>
         </div>
-
+        
         <div id="mistakes-row" class="row">
             <h2 id="recent-mistakes">@Messages("dashboard.mistakes.header")</h2>
             <span id="mistakes-subheader-display"></span>
@@ -288,44 +288,7 @@
     <link href='@routes.Assets.at("stylesheets/userProfile.css")' rel="stylesheet"/>
     <link href='@routes.Assets.at("stylesheets/choropleth.css")' rel="stylesheet"/>
     <script>
-        function unescapeHTML(str) {
-            return str.replace(/&amp;/g, '&')
-                .replace(/&lt;/g, '<')
-                .replace(/&gt;/g, '>')
-                .replace(/&quot;/g, '"')
-                .replace(/&#039;/g, "'");
-        }
         $(document).ready(function () {
-            $('.put-user-team').each(function () {
-                var teamName = $(this).text();
-                var unescapedName = unescapeHTML(teamName);
-                $(this).text(unescapedName);
-            });
-
-            $('[data-toggle="dropdown"] .caret').each(function() {
-                var teamGreetingText = $(this).prev('span').text();
-                var unescapedText = unescapeHTML(teamGreetingText);
-                $(this).prev('span').text(unescapedText);
-            });
-
-            $('[data-toggle="tooltip"]').each(function() {
-                var tooltipText = $(this).attr('title');
-                var unescapedTooltip = unescapeHTML(tooltipText);
-                $(this).attr('title', unescapedTooltip);
-            });
-
-            $('#edit-team-button').each(function() {
-                var buttonText = $(this).html();
-                var unescapedButtonText = unescapeHTML(buttonText);
-                $(this).html(unescapedButtonText);
-            });
-
-            $('.put-team-container').each(function() {
-                var teamDescription = $(this).attr('data-content');
-                var unescapedDescription = unescapeHTML(teamDescription);
-                $(this).attr('data-content', unescapedDescription);
-            });
-
             // Gets all translations before loading the choropleth.
             i18next.use(i18nextHttpBackend).init({
                 backend: { loadPath: '/assets/locales/{{lng}}/{{ns}}.json' },

--- a/app/views/userProfile.scala.html
+++ b/app/views/userProfile.scala.html
@@ -288,7 +288,44 @@
     <link href='@routes.Assets.at("stylesheets/userProfile.css")' rel="stylesheet"/>
     <link href='@routes.Assets.at("stylesheets/choropleth.css")' rel="stylesheet"/>
     <script>
+        function unescapeHTML(str) {
+            return str.replace(/&amp;/g, '&')
+                .replace(/&lt;/g, '<')
+                .replace(/&gt;/g, '>')
+                .replace(/&quot;/g, '"')
+                .replace(/&#039;/g, "'");
+    }
         $(document).ready(function () {
+            $('.put-user-team').each(function () {
+            var teamName = $(this).text();
+            var unescapedName = unescapeHTML(teamName);
+            $(this).text(unescapedName);
+            });
+
+            $('[data-toggle="dropdown"] .caret').each(function() {
+                var teamGreetingText = $(this).prev('span').text();
+                var unescapedText = unescapeHTML(teamGreetingText);
+                $(this).prev('span').text(unescapedText);
+            });
+
+            $('[data-toggle="tooltip"]').each(function() {
+                var tooltipText = $(this).attr('title');
+                var unescapedTooltip = unescapeHTML(tooltipText);
+                $(this).attr('title', unescapedTooltip);
+            });
+
+            $('#edit-team-button').each(function() {
+                var buttonText = $(this).html();
+                var unescapedButtonText = unescapeHTML(buttonText);
+                $(this).html(unescapedButtonText);
+            });
+
+            $('.put-team-container').each(function() {
+                var teamDescription = $(this).attr('data-content');
+                var unescapedDescription = unescapeHTML(teamDescription);
+                $(this).attr('data-content', unescapedDescription);
+            });
+
             // Gets all translations before loading the choropleth.
             i18next.use(i18nextHttpBackend).init({
                 backend: { loadPath: '/assets/locales/{{lng}}/{{ns}}.json' },

--- a/app/views/userProfile.scala.html
+++ b/app/views/userProfile.scala.html
@@ -294,12 +294,12 @@
                 .replace(/&gt;/g, '>')
                 .replace(/&quot;/g, '"')
                 .replace(/&#039;/g, "'");
-    }
+        }
         $(document).ready(function () {
             $('.put-user-team').each(function () {
-            var teamName = $(this).text();
-            var unescapedName = unescapeHTML(teamName);
-            $(this).text(unescapedName);
+                var teamName = $(this).text();
+                var unescapedName = unescapeHTML(teamName);
+                $(this).text(unescapedName);
             });
 
             $('[data-toggle="dropdown"] .caret').each(function() {

--- a/public/javascripts/Progress/src/Progress.js
+++ b/public/javascripts/Progress/src/Progress.js
@@ -86,8 +86,8 @@ function Progress (_, $, userRole) {
         // Check for special characters in teamName and teamDescription.
         var specialCharRegex = /[&<>"']/;
         if (specialCharRegex.test(teamName) || specialCharRegex.test(teamDescription)) {
-            alert(`Team name or description contains special characters like &, <, >, ", or '. Please remove them and try again.`);
-            return;  
+            alert(i18next.t('characters-not-allowed'));
+            return;
         }
 
         // If no special characters, proceed with AJAX request
@@ -111,7 +111,6 @@ function Progress (_, $, userRole) {
             }
         });
     }
-
 
     function addLegendListeners(map, mapData) {
         // Add listeners on the checkboxes.

--- a/public/javascripts/Progress/src/Progress.js
+++ b/public/javascripts/Progress/src/Progress.js
@@ -80,9 +80,17 @@ function Progress (_, $, userRole) {
 
     // function to call endpoint and create team
     function createTeam() {
-        var teamName = util.escapeHTML($('#team-name-input').val());
+        var teamName = $('#team-name-input').val();
         var teamDescription = util.escapeHTML($('#team-description-input').val());
         
+        // Check for special characters in teamName and teamDescription.
+        var specialCharRegex = /[&<>"']/;
+        if (specialCharRegex.test(teamName) || specialCharRegex.test(teamDescription)) {
+            alert(`Team name or description contains special characters like &, <, >, ", or '. Please remove them and try again.`);
+            return;  
+        }
+
+        // If no special characters, proceed with AJAX request
         $.ajax({
             async: true,
             url: '/userapi/createTeam', 
@@ -103,6 +111,7 @@ function Progress (_, $, userRole) {
             }
         });
     }
+
 
     function addLegendListeners(map, mapData) {
         // Add listeners on the checkboxes.

--- a/public/javascripts/Progress/src/Progress.js
+++ b/public/javascripts/Progress/src/Progress.js
@@ -80,7 +80,7 @@ function Progress (_, $, userRole) {
 
     // function to call endpoint and create team
     function createTeam() {
-        var teamName = $('#team-name-input').val();
+        var teamName = util.escapeHTML($('#team-name-input').val());
         var teamDescription = util.escapeHTML($('#team-description-input').val());
         
         // Check for special characters in teamName and teamDescription.

--- a/public/locales/de/dashboard.json
+++ b/public/locales/de/dashboard.json
@@ -36,5 +36,6 @@
     "mistakes-subheader": "Untenstehend werden Beschriftungen angezeigt, welche von anderen “Project Sidewalk“-Nutzenden als falsch bewertet wurden.",
     "no-mistakes-subheader": "Keine Beschriftungen wurden bis jetzt als falsch bewertet, gute Arbeit! <a href=\"/audit\">Starten Sie die Erkundung</a>, um die gute Arbeit fortzusetzen! ",
     "validator-comment": "Kommentar von Validierer:in: {{c}}",
-    "validator-no-comment": "Kein Kommentar von Validierer:in vorhanden."
+    "validator-no-comment": "Kein Kommentar von Validierer:in vorhanden.",
+    "characters-not-allowed": "Der Teamname oder die Beschreibung enthält Sonderzeichen wie &, <, >, \" oder '. Bitte entfernen Sie diese und versuchen Sie es erneut."
 }

--- a/public/locales/en/dashboard.json
+++ b/public/locales/en/dashboard.json
@@ -36,5 +36,6 @@
     "mistakes-subheader": "Below, we are showing labels that have been marked as incorrect by other Project Sidewalk users.",
     "no-mistakes-subheader": "No labels have been reported as incorrect so far, good job! <a href=\"/explore\">Start exploring</a> to keep up the good work! ",
     "validator-comment": "Comment from validator: {{c}}",
-    "validator-no-comment": "No comment supplied by validator."
+    "validator-no-comment": "No comment supplied by validator.",
+    "characters-not-allowed": "Team name or description contains special characters like &, <, >, \", or '. Please remove them and try again."
 }

--- a/public/locales/es/dashboard.json
+++ b/public/locales/es/dashboard.json
@@ -36,5 +36,6 @@
     "mistakes-subheader": "A continuación, mostramos las etiquetas que otros usuarios de Project Sidewalk han marcado como incorrectas.",
     "no-mistakes-subheader": "Hasta el momento no se han informado etiquetas incorrectas, ¡buen trabajo! <a href=\"/explore\">¡Empieza a explorar</a> para continuar con el buen trabajo!",
     "validator-comment": "Comentario del validador: {{c}}",
-    "validator-no-comment": "Ningún comentario proporcionado por el validador."
+    "validator-no-comment": "Ningún comentario proporcionado por el validador.",
+    "characters-not-allowed": "El nombre o la descripción del equipo contienen caracteres especiales como &, <, >, \"o '. Elimínelos e inténtelo de nuevo."
 }

--- a/public/locales/nl/dashboard.json
+++ b/public/locales/nl/dashboard.json
@@ -36,5 +36,6 @@
     "mistakes-subheader": "Hieronder tonen we labels die door andere Project Sidewalk-gebruikers als onjuist zijn gemarkeerd.",
     "no-mistakes-subheader": "Er zijn tot nu toe geen labels als onjuist gerapporteerd, goed gedaan! <a href=\"/explore\">Begin met verkennen</a> om het goede werk voort te zetten!",
     "validator-comment": "Commentaar van validator: {{c}}",
-    "validator-no-comment": "Geen commentaar geleverd door validator."
+    "validator-no-comment": "Geen commentaar geleverd door validator.",
+    "characters-not-allowed": "De teamnaam of -beschrijving bevat speciale tekens zoals &, <, >, \", of '. Verwijder deze en probeer het opnieuw."
 }

--- a/public/locales/zh-TW/dashboard.json
+++ b/public/locales/zh-TW/dashboard.json
@@ -36,5 +36,6 @@
     "mistakes-subheader": "以下為其他使用者標示為不正確的標記。",
     "no-mistakes-subheader": "到目前為止，沒有任何標籤被通報為不正確，做得好！<a href=\"/explore\">開始探索</a> 以持續做優質的工作！",
     "validator-comment": "其他檢核者評論：{{c}}",
-    "validator-no-comment": "無其他檢核者評論。"
+    "validator-no-comment": "無其他檢核者評論。",
+    "characters-not-allowed": "團隊名稱或描述包含特殊字符，例如 &、<、>、\" 或 '。請刪除它們並重試。"
 }


### PR DESCRIPTION
Resolves #3778

I added an unescape HTML method so that special characters like & can be displayed correctly in the teams list.

##### Before/After screenshots (if applicable)

##### Testing instructions
1. 

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [ ] I've added/updated comments for large or confusing blocks of code.
- [ ] I've included before/after screenshots above.
- [ ] I've asked for and included translations for any user facing text that was added or modified.
- [ ] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure the documentation on [this wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Descriptions-of-Logged-Events) is up to date for the logs you added/updated.
- [ ] I've tested on mobile (only needed for validation page).
