### PR TITLE
Switches google maps to weekly release, adds cameraControl opts

### DIFF
--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -34,7 +34,7 @@
     <script type="text/javascript" src='@routes.Assets.at("javascripts/lib/backbone-1.4.0-min.js")'></script>
     <script src='@routes.Assets.at("javascripts/lib/js-cookie-3.0.5-min.js")'></script>
     <script type="text/javascript"
-        src="https://maps.googleapis.com/maps/api/js?v=quarterly&key=@Play.configuration.getString("google-maps-api-key").get&language=@lang.code&callback=Function.prototype">
+        src="https://maps.googleapis.com/maps/api/js?v=weekly&key=@Play.configuration.getString("google-maps-api-key").get&language=@lang.code&callback=Function.prototype">
     </script>
     <link href='@routes.Assets.at("stylesheets/fonts.css")' rel="stylesheet"/>
     <link rel="stylesheet" href='@routes.Assets.at("stylesheets/main.css")'>

--- a/public/javascripts/Admin/src/Admin.Panorama.js
+++ b/public/javascripts/Admin/src/Admin.Panorama.js
@@ -95,6 +95,7 @@ function AdminPanorama(svHolder, buttonHolder, admin) {
             self.panorama.set('linksControl', false);
             self.panorama.set('navigationControl', false);
             self.panorama.set('panControl', false);
+            self.panorama.set('cameraControl', false);
             self.panorama.set('zoomControl', false);
             self.panorama.set('keyboardShortcuts', false);
             self.panorama.set('motionTracking', false);

--- a/public/javascripts/Gallery/src/expandedview/GalleryPanorama.js
+++ b/public/javascripts/Gallery/src/expandedview/GalleryPanorama.js
@@ -74,6 +74,7 @@
             linksControl: false,
             navigationControl: false,
             panControl: false,
+            cameraControl: false,
             zoomControl: false,
             keyboardShortcuts: false
         };

--- a/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
+++ b/public/javascripts/SVLabel/src/SVLabel/navigation/MapService.js
@@ -110,6 +110,7 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
         rotateControl:false,
         scaleControl:false,
         streetViewControl:true,
+        cameraControl: false,
         zoomControl:false,
         zoom: 18,
         backgroundColor: "none",
@@ -190,6 +191,7 @@ function MapService (canvas, neighborhoodModel, uiMap, params) {
             svl.panorama.set('showRoadLabels', true);
             svl.panorama.set('panControl', false);
             svl.panorama.set('scrollwheel', false);
+            svl.panorama.set('cameraControl', false);
             svl.panorama.set('zoomControl', false);
             svl.panorama.set('keyboardShortcuts', true);
         }

--- a/public/javascripts/SVValidate/src/panorama/Panorama.js
+++ b/public/javascripts/SVValidate/src/panorama/Panorama.js
@@ -62,6 +62,7 @@ function Panorama (label) {
             panorama.set('navigationControl', false);
             panorama.set('panControl', false); 
             panorama.set('showRoadLabels', false);
+            panorama.set('cameraControl', false);
             panorama.set('zoomControl', false);
             if (!isMobile()) {
                 panorama.set('scrollwheel', false);


### PR DESCRIPTION
Resolves #3620 

I am _hoping_ that this update will prepare us for the upcoming changes to the Google Maps controls. Unfortunately, I had to do a bit of guesswork because their documentation says to test on the beta channel, but there's a bug in the beta channel that prevents the zoom UI from ever closing. Once the new API update comes out, we'll just make a new ticket of UI elements appear that shouldn't be there.

I also updated from the "quarterly" release cycle to "weekly" from Google Maps. After reading through the documentation, it was clear that the weekly cycle is the one that we want to be on.
