### PR TITLE
2499 - Speeding up nightly label clustering with bulk processing

### DIFF
--- a/app/controllers/AttributeController.scala
+++ b/app/controllers/AttributeController.scala
@@ -18,6 +18,10 @@ import models.label.{LabelTable, LabelTypeTable}
 import models.region.RegionTable
 import play.api.Play.current
 import play.api.{Logger, Play}
+import anorm._
+import anorm.SqlParser._
+import play.api.db.DB
+
 
 /**
  * Holds the HTTP requests associated with accessibility attributes and the label clustering used to create them.
@@ -108,124 +112,261 @@ class AttributeController @Inject() (implicit val env: Environment[User, Session
     * Takes in results of single-user clustering, and adds the data to the relevant tables.
     *
     * @param key A key used for authentication.
-    * @param userId The user_id address of the user who's labels were clustered.
+    * @param userId The user_id address of the user whose labels were clustered.
     */
-  def postSingleUserClusteringResults(key: String, userId: String) = UserAwareAction.async(BodyParsers.parse.json(maxLength = 1024 * 1024 * 100)) { implicit request =>
-    // The maxLength argument above allows a 100MB max load size for the POST request.
-    if (authenticate(key)) {
-      // Validation https://www.playframework.com/documentation /2.3.x/ScalaJson
-      val submission = request.body.validate[AttributeFormats.ClusteringSubmission]
-      submission.fold(
-        errors => {
-          Logger.warn("Failed to parse JSON POST request for single-user clustering results.")
-          Logger.info(Json.prettyPrint(request.body))
-          Future.successful(BadRequest(Json.obj("status" -> "Error", "message" -> JsError.toFlatJson(errors))))
-        },
-        submission => {
-          // Extract the thresholds, clusters, and labels, and put them into separate variables.
-          val thresholds: Map[String, Float] = submission.thresholds.map(t => (t.labelType, t.threshold)).toMap
-          val clusters: List[AttributeFormats.ClusterSubmission] = submission.clusters
-          val labels: List[AttributeFormats.ClusteredLabelSubmission] = submission.labels
+  def postSingleUserClusteringResults(key: String, userId: String) =
+    UserAwareAction.async(BodyParsers.parse.json(maxLength = 1024 * 1024 * 100)) { implicit request =>
+      // The maxLength argument above allows a 100MB max load size for  the POST request.
+      if (authenticate(key)) {
+        // Validation https://www.playframework.com/documentation/2.3.x/ScalaJson
+        val submission = request.body.validate[AttributeFormats.ClusteringSubmission]
+        submission.fold(
+          errors => {
+            Logger.warn("Failed to parse JSON POST request for single-user clustering results.")
+            Logger.info(Json.prettyPrint(request.body))
+            Future.successful(BadRequest(Json.obj("status" -> "Error", "message" -> JsError.toFlatJson(errors))))
+          },
+          submission => {
+            // Extract the thresholds, clusters, and labels, and put them into seperate variables.
+            val thresholds: Map[String, Float] = submission.thresholds.map(t => (t.labelType, t.threshold)).toMap
+            val clusters: List[AttributeFormats.ClusterSubmission] = submission.clusters
+            val labels: List[AttributeFormats.ClusteredLabelSubmission] = submission.labels
 
-          // Group the labels by the cluster they were put into.
-          val groupedLabels: Map[Int, List[AttributeFormats.ClusteredLabelSubmission]] = labels.groupBy(_.clusterNum)
-          val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
+            // Group the labels by the cluster they were put into
+            val groupedLabels: Map[Int, List[AttributeFormats.ClusteredLabelSubmission]] = labels.groupBy(_.clusterNum)
+            val timestamp = new Timestamp(Instant.now.toEpochMilli)
 
-          // Add corresponding entry to the user_clustering_session table
-          val userSessionId: Int = UserClusteringSessionTable.save(UserClusteringSession(0, userId, timestamp))
-          // Add the clusters to user_attribute table, and the associated user_attribute_labels after each cluster.
-          for (cluster <- clusters) yield {
-            val attributeId: Int =
-              UserAttributeTable.save(
-                UserAttribute(0,
-                  userSessionId,
-                  thresholds(cluster.labelType),
-                  LabelTypeTable.labelTypeToId(cluster.labelType).get,
-                  RegionTable.selectRegionIdOfClosestNeighborhood(cluster.lng, cluster.lat),
-                  cluster.lat,
-                  cluster.lng,
-                  cluster.severity,
-                  cluster.temporary
-                )
-              )
-            // Add all the labels associated with that user_attribute to the user_attribute_label table.
-            groupedLabels get cluster.clusterNum match {
-              case Some(group) =>
-                for (label <- group) yield {
-                  UserAttributeLabelTable.save(UserAttributeLabel(0, attributeId, label.labelId))
+            // This is the new user_clustering_session entry
+            val userSessionId: Int = UserClusteringSessionTable.save(UserClusteringSession(0, userId, timestamp))
+
+            // Gotta insert all the user_attributes in one pass to speed things up
+            DB.withConnection { implicit conn =>
+              val rowPlaceholder = "(?,?,?,?,?,?,?,?)"
+              val allPlaceholders = clusters.map(_ => rowPlaceholder).mkString(", ")
+
+              val insertSql =
+                s"""
+                   INSERT INTO user_attribute (
+                     user_clustering_session_id,
+                     clustering_threshold,
+                     label_type_id,
+                     region_id,
+                     lat,
+                     lng,
+                     severity,
+                     temporary
+                   )
+                   VALUES $allPlaceholders
+                   RETURNING user_attribute_id
+                 """
+
+              val stmt = conn.prepareStatement(insertSql)
+              var paramIndex = 1
+
+              // Fill placeholders with cluster data
+              clusters.foreach { c =>
+                stmt.setInt(paramIndex, userSessionId)
+                paramIndex += 1
+                stmt.setFloat(paramIndex, thresholds(c.labelType))
+                paramIndex += 1
+                val labelTypeId = LabelTypeTable.labelTypeToId(c.labelType).get
+                stmt.setInt(paramIndex, labelTypeId)
+                paramIndex += 1
+                val regionId = RegionTable.selectRegionIdOfClosestNeighborhood(c.lng, c.lat)
+                stmt.setInt(paramIndex, regionId)
+                paramIndex += 1
+                stmt.setDouble(paramIndex, c.lat.toDouble)
+                paramIndex += 1
+                stmt.setDouble(paramIndex, c.lng.toDouble)
+                paramIndex += 1
+                c.severity match {
+                  case Some(sv) => stmt.setInt(paramIndex, sv)
+                  case None     => stmt.setNull(paramIndex, java.sql.Types.INTEGER)
                 }
-              case None =>
-                Logger.warn("Cluster sent with no accompanying labels. Seems wrong!")
+                paramIndex += 1
+                stmt.setBoolean(paramIndex, c.temporary)
+                paramIndex += 1
+              }
+
+              val rs = stmt.executeQuery()
+              val newUserAttrIds = collection.mutable.ArrayBuffer[Int]()
+              while (rs.next()) {
+                newUserAttrIds.append(rs.getInt("user_attribute_id"))
+              }
+              rs.close()
+              stmt.close()
+
+              // Pair up each cluster with its labels
+              val labelTuples = clusters.zip(newUserAttrIds).flatMap { case (c, attrId) =>
+                groupedLabels.getOrElse(c.clusterNum, Nil).map { lbl =>
+                  (attrId, lbl.labelId)
+                }
+              }
+
+              // Insert all user_attribute_label rows at once
+              if (labelTuples.nonEmpty) {
+                val rowPlaceholder2 = "(?,?)"
+                val all2 = labelTuples.map(_ => rowPlaceholder2).mkString(", ")
+                val insertLabelSql =
+                  s"""
+                     INSERT INTO user_attribute_label (
+                       user_attribute_id,
+                       label_id
+                     )
+                     VALUES $all2
+                   """
+                val stmt2 = conn.prepareStatement(insertLabelSql)
+                var i2 = 1
+
+                labelTuples.foreach { case (attrId, lblId) =>
+                  stmt2.setInt(i2, attrId)
+                  i2 += 1
+                  stmt2.setInt(i2, lblId)
+                  i2 += 1
+                }
+
+                stmt2.executeUpdate()
+                stmt2.close()
+              }
             }
+
+            Future.successful(Ok(Json.obj("session" -> userSessionId)))
           }
-          Future.successful(Ok(Json.obj("session" -> userSessionId)))
-        }
-      )
-    } else {
-      Future.successful(Ok(Json.obj("error_msg" -> "Could not authenticate.")))
+        )
+      } else {
+        Future.successful(Ok(Json.obj("error_msg" -> "Could not authenticate.")))
+      }
     }
-  }
 
   /**
     * Takes in results of multi-user clustering, and adds the data to the relevant tables.
     *
     * @param key A key used for authentication.
-    * @param regionId The region who's labels were clustered.
+    * @param regionId The region whose labels were clustered.
     */
-  def postMultiUserClusteringResults(key: String, regionId: Int) = UserAwareAction.async(BodyParsers.parse.json(maxLength = 1024 * 1024 * 100)) {implicit request =>
-    // The maxLength argument above allows a 100MB max load size for the POST request.
-    if (authenticate(key)) {
-      // Validation https://www.playframework.com/documentation /2.3.x/ScalaJson
-      val submission = request.body.validate[AttributeFormats.ClusteringSubmission]
-      submission.fold(
-        errors => {
-          Logger.error("Failed to parse JSON POST request for multi-user clustering results.")
-          Logger.info(Json.prettyPrint(request.body))
-          Future.successful(BadRequest(Json.obj("status" -> "Error", "message" -> JsError.toFlatJson(errors))))
-        },
-        submission => {
-          // Extract the thresholds, clusters, and labels, and put them into separate variables.
-          val thresholds: Map[String, Float] = submission.thresholds.map(t => (t.labelType, t.threshold)).toMap
-          val clusters: List[AttributeFormats.ClusterSubmission] = submission.clusters
-          val labels: List[AttributeFormats.ClusteredLabelSubmission] = submission.labels
+  def postMultiUserClusteringResults(key: String, regionId: Int) =
+    UserAwareAction.async(BodyParsers.parse.json(maxLength = 1024 * 1024 * 100)) { implicit request =>
+      // We keep the 100MB note: The maxLength argument above allows a 100MB max load size for the POST request.
+      if (authenticate(key)) {
+        val submission = request.body.validate[AttributeFormats.ClusteringSubmission]
+        submission.fold(
+          errors => {
+            Logger.error("Failed to parse JSON POST request for multi-user clustering results.")
+            Logger.info(Json.prettyPrint(request.body))
+            Future.successful(BadRequest(Json.obj("status" -> "Error", "message" -> JsError.toFlatJson(errors))))
+          },
+          submission => {
+            val thresholds: Map[String, Float] = submission.thresholds.map(t => (t.labelType, t.threshold)).toMap
+            val clusters: List[AttributeFormats.ClusterSubmission] = submission.clusters
+            val labels: List[AttributeFormats.ClusteredLabelSubmission] = submission.labels
 
-          // Group the labels by the cluster they were put into.
-          val groupedLabels: Map[Int, List[AttributeFormats.ClusteredLabelSubmission]] = labels.groupBy(_.clusterNum)
-          val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
+            val groupedLabels: Map[Int, List[AttributeFormats.ClusteredLabelSubmission]] = labels.groupBy(_.clusterNum)
+            val timestamp = new Timestamp(Instant.now.toEpochMilli)
 
-          // Add corresponding entry to the global_clustering_session table
-          val globalSessionId: Int = GlobalClusteringSessionTable.save(GlobalClusteringSession(0, regionId, timestamp))
+            // This new approach also creates an entry in global_clustering_session
+            val globalSessionId: Int =
+              GlobalClusteringSessionTable.save(GlobalClusteringSession(0, regionId, timestamp))
 
-          // Add the clusters to global_attribute table, and the associated user_attributes after each cluster.
-          for (cluster <- clusters) yield {
-            val attributeId: Int =
-              GlobalAttributeTable.save(
-                GlobalAttribute(0,
-                  globalSessionId,
-                  thresholds(cluster.labelType),
-                  LabelTypeTable.labelTypeToId(cluster.labelType).get,
-                  LabelTable.getStreetEdgeIdClosestToLatLng(cluster.lat, cluster.lng).get,
-                  RegionTable.selectRegionIdOfClosestNeighborhood(cluster.lng, cluster.lat),
-                  cluster.lat,
-                  cluster.lng,
-                  cluster.severity,
-                  cluster.temporary)
-              )
-            // Add all the associated labels to the global_attribute_user_attribute table.
-            groupedLabels get cluster.clusterNum match {
-              case Some(group) =>
-                for (label <- group) yield {
-                  GlobalAttributeUserAttributeTable.save(GlobalAttributeUserAttribute(0, attributeId, label.labelId))
+            // Do all the inserts for global_attribute in a single statement
+            DB.withConnection { implicit conn =>
+              val rowPlaceholder = "(?,?,?,?,?,?,?,?,?)"
+              val allPlaceholders = clusters.map(_ => rowPlaceholder).mkString(", ")
+
+              val insertSql =
+                s"""
+                   INSERT INTO global_attribute (
+                     global_clustering_session_id,
+                     clustering_threshold,
+                     label_type_id,
+                     street_edge_id,
+                     region_id,
+                     lat,
+                     lng,
+                     severity,
+                     temporary
+                   )
+                   VALUES $allPlaceholders
+                   RETURNING global_attribute_id
+                 """
+
+              val stmt = conn.prepareStatement(insertSql)
+              var idx = 1
+
+              clusters.foreach { c =>
+                stmt.setInt(idx, globalSessionId)
+                idx += 1
+                stmt.setFloat(idx, thresholds(c.labelType))
+                idx += 1
+                val labelTypeId = LabelTypeTable.labelTypeToId(c.labelType).get
+                stmt.setInt(idx, labelTypeId)
+                idx += 1
+                val streetEdgeId = LabelTable.getStreetEdgeIdClosestToLatLng(c.lat, c.lng).get
+                stmt.setInt(idx, streetEdgeId)
+                idx += 1
+                val regionVal = RegionTable.selectRegionIdOfClosestNeighborhood(c.lng, c.lat)
+                stmt.setInt(idx, regionVal)
+                idx += 1
+                stmt.setDouble(idx, c.lat.toDouble)
+                idx += 1
+                stmt.setDouble(idx, c.lng.toDouble)
+                idx += 1
+                c.severity match {
+                  case Some(sv) => stmt.setInt(idx, sv)
+                  case None     => stmt.setNull(idx, java.sql.Types.INTEGER)
                 }
-              case None =>
-                Logger.warn("Cluster sent with no accompanying labels. Seems wrong!")
+                idx += 1
+                stmt.setBoolean(idx, c.temporary)
+                idx += 1
+              }
+
+              val rs = stmt.executeQuery()
+              val newGlobalAttrIds = collection.mutable.ArrayBuffer[Int]()
+              while (rs.next()) {
+                newGlobalAttrIds.append(rs.getInt("global_attribute_id"))
+              }
+              rs.close()
+              stmt.close()
+
+              // Link global_attribute IDs to user_attributes
+              val linkTuples = clusters.zip(newGlobalAttrIds).flatMap { case (c, globAttrId) =>
+                groupedLabels.getOrElse(c.clusterNum, Nil).map { lbl =>
+                  (globAttrId, lbl.labelId)
+                }
+              }
+
+              // Insert all global_attribute_user_attribute rows in bulk
+              if (linkTuples.nonEmpty) {
+                val rowPlaceholder2 = "(?,?)"
+                val all2 = linkTuples.map(_ => rowPlaceholder2).mkString(", ")
+                val insertLinkSql =
+                  s"""
+                     INSERT INTO global_attribute_user_attribute (
+                       global_attribute_id,
+                       user_attribute_id
+                     )
+                     VALUES $all2
+                   """
+                val stmt2 = conn.prepareStatement(insertLinkSql)
+                var i2 = 1
+
+                linkTuples.foreach { case (gAttrId, userAttrId) =>
+                  stmt2.setInt(i2, gAttrId)
+                  i2 += 1
+                  stmt2.setInt(i2, userAttrId)
+                  i2 += 1
+                }
+
+                stmt2.executeUpdate()
+                stmt2.close()
+              }
             }
+
+            Future.successful(Ok(Json.obj("session" -> globalSessionId)))
           }
-          Future.successful(Ok(Json.obj("session" -> globalSessionId)))
-        }
-      )
-    } else {
-      Future.successful(Ok(Json.obj("error_msg" -> "Could not authenticate.")))
+        )
+      } else {
+        Future.successful(Ok(Json.obj("error_msg" -> "Could not authenticate.")))
+      }
     }
-  }
+
 }

--- a/app/controllers/AttributeController.scala
+++ b/app/controllers/AttributeController.scala
@@ -17,10 +17,11 @@ import models.attribute._
 import models.label.{LabelTable, LabelTypeTable}
 import models.region.RegionTable
 import play.api.Play.current
+import play.api.db.DB
 import play.api.{Logger, Play}
 import anorm._
 import anorm.SqlParser._
-import play.api.db.DB
+
 
 
 /**

--- a/app/controllers/AttributeController.scala
+++ b/app/controllers/AttributeController.scala
@@ -17,12 +17,7 @@ import models.attribute._
 import models.label.{LabelTable, LabelTypeTable}
 import models.region.RegionTable
 import play.api.Play.current
-import play.api.db.DB
 import play.api.{Logger, Play}
-import anorm._
-import anorm.SqlParser._
-
-
 
 /**
  * Holds the HTTP requests associated with accessibility attributes and the label clustering used to create them.
@@ -33,8 +28,8 @@ class AttributeController @Inject() (implicit val env: Environment[User, Session
   extends Silhouette[User, SessionAuthenticator] with ProvidesHeader {
 
   /**
-    * Returns the clustering webpage with GUI if the user is an admin, otherwise redirects to the landing page.
-    */
+   * Returns the clustering webpage with GUI if the user is an admin, otherwise redirects to the landing page.
+   */
   def index = UserAwareAction.async { implicit request =>
     if (isAdmin(request.identity)) {
       Future.successful(Ok(views.html.clustering("Project Sidewalk", request.identity)))
@@ -44,9 +39,9 @@ class AttributeController @Inject() (implicit val env: Environment[User, Session
   }
 
   /**
-    * Checks if the user is an administrator.
-    *
-    * @return Boolean indicating if the user is an admin.
+   * Checks if the user is an administrator.
+   *
+   * @return Boolean indicating if the user is an admin.
    */
   def isAdmin(user: Option[User]): Boolean = user match {
     case Some(user) =>
@@ -55,19 +50,19 @@ class AttributeController @Inject() (implicit val env: Environment[User, Session
   }
 
   /**
-    * Reads a key from env variable and compares against input key, returning true if they match.
-    *
-    * @return Boolean indicating whether the input key matches the true key.
-    */
+   * Reads a key from env variable and compares against input key, returning true if they match.
+   *
+   * @return Boolean indicating whether the input key matches the true key.
+   */
   def authenticate(key: String): Boolean = {
     key == Play.configuration.getString("internal-api-key").get
   }
 
   /**
-    * Calls the appropriate clustering function(s); either single-user clustering, multi-user clustering, or both.
-    *
-    * @param clusteringType One of "singleUser", "multiUser", or "both".
-    */
+   * Calls the appropriate clustering function(s); either single-user clustering, multi-user clustering, or both.
+   *
+   * @param clusteringType One of "singleUser", "multiUser", or "both".
+   */
   def runClustering(clusteringType: String) = UserAwareAction.async { implicit request =>
     if (isAdmin(request.identity)) {
       val json = AttributeControllerHelper.runClustering(clusteringType)
@@ -78,11 +73,11 @@ class AttributeController @Inject() (implicit val env: Environment[User, Session
   }
 
   /**
-    * Returns the set of all labels associated with the given user, in the format needed for clustering.
-    *
-    * @param key A key used for authentication.
-    * @param userId The user_id of the user who's labels should be retrieved.
-    */
+   * Returns the set of all labels associated with the given user, in the format needed for clustering.
+   *
+   * @param key A key used for authentication.
+   * @param userId The user_id of the user who's labels should be retrieved.
+   */
   def getUserLabelsToCluster(key: String, userId: String) = UserAwareAction.async { implicit request =>
 
     val json = if (authenticate(key)) {
@@ -94,11 +89,11 @@ class AttributeController @Inject() (implicit val env: Environment[User, Session
   }
 
   /**
-    * Returns the set of clusters from single-user clustering that are in this region as JSON.
-    *
-    * @param key A key used for authentication.
-    * @param regionId The region who's labels should be retrieved.
-    */
+   * Returns the set of clusters from single-user clustering that are in this region as JSON.
+   *
+   * @param key A key used for authentication.
+   * @param regionId The region who's labels should be retrieved.
+   */
   def getClusteredLabelsInRegion(key: String, regionId: Int) = UserAwareAction.async { implicit request =>
     val json = if (authenticate(key)) {
       val labelsToCluster: List[LabelToCluster] = UserClusteringSessionTable.getClusteredLabelsInRegion(regionId)
@@ -110,264 +105,147 @@ class AttributeController @Inject() (implicit val env: Environment[User, Session
   }
 
   /**
-    * Takes in results of single-user clustering, and adds the data to the relevant tables.
-    *
-    * @param key A key used for authentication.
-    * @param userId The user_id address of the user whose labels were clustered.
-    */
-  def postSingleUserClusteringResults(key: String, userId: String) =
-    UserAwareAction.async(BodyParsers.parse.json(maxLength = 1024 * 1024 * 100)) { implicit request =>
-      // The maxLength argument above allows a 100MB max load size for  the POST request.
-      if (authenticate(key)) {
-        // Validation https://www.playframework.com/documentation/2.3.x/ScalaJson
-        val submission = request.body.validate[AttributeFormats.ClusteringSubmission]
-        submission.fold(
-          errors => {
-            Logger.warn("Failed to parse JSON POST request for single-user clustering results.")
-            Logger.info(Json.prettyPrint(request.body))
-            Future.successful(BadRequest(Json.obj("status" -> "Error", "message" -> JsError.toFlatJson(errors))))
-          },
-          submission => {
-            // Extract the thresholds, clusters, and labels, and put them into seperate variables.
-            val thresholds: Map[String, Float] = submission.thresholds.map(t => (t.labelType, t.threshold)).toMap
-            val clusters: List[AttributeFormats.ClusterSubmission] = submission.clusters
-            val labels: List[AttributeFormats.ClusteredLabelSubmission] = submission.labels
+   * Takes in results of single-user clustering, and adds the data in bulk to the relevant tables.
+   *
+   * @param key A key used for authentication.
+   * @param userId The user_id address of the user who's labels were clustered.
+   */
+  def postSingleUserClusteringResults(key: String, userId: String) = UserAwareAction.async(BodyParsers.parse.json(maxLength = 1024 * 1024 * 100)) { implicit request =>
+    if (authenticate(key)) {
+      val submission = request.body.validate[AttributeFormats.ClusteringSubmission]
+      submission.fold(
+        errors => {
+          Logger.warn("Failed to parse JSON POST request for bulk user clustering results.")
+          Logger.info(Json.prettyPrint(request.body))
+          Future.successful(BadRequest(Json.obj("status" -> "Error", "message" -> JsError.toFlatJson(errors))))
+        },
+        submission => {
+          // Extract everything from the request.
+          val thresholds: Map[String, Float] = submission.thresholds.map(t => (t.labelType, t.threshold)).toMap
+          val clusters: List[AttributeFormats.ClusterSubmission] = submission.clusters
+          val labels: List[AttributeFormats.ClusteredLabelSubmission] = submission.labels
 
-            // Group the labels by the cluster they were put into
-            val groupedLabels: Map[Int, List[AttributeFormats.ClusteredLabelSubmission]] = labels.groupBy(_.clusterNum)
-            val timestamp = new Timestamp(Instant.now.toEpochMilli)
+          // Group labels by cluster
+          val groupedLabels = labels.groupBy(_.clusterNum)
+          // Insert a user clustering session row with userId
+          val timestamp = new Timestamp(Instant.now.toEpochMilli)
+          val userSessionId = UserClusteringSessionTable.save(UserClusteringSession(0, userId, timestamp))
+          Logger.info(s"User session ID: $userSessionId")
 
-            // This is the new user_clustering_session entry
-            val userSessionId: Int = UserClusteringSessionTable.save(UserClusteringSession(0, userId, timestamp))
+          // Build a list of UserAttribute objects for all clusters
+          val userAttributes = clusters.map { c =>
+            UserAttribute(
+              userAttributeId = 0,
+              userClusteringSessionId = userSessionId,
+              clusteringThreshold = thresholds(c.labelType),
+              labelTypeId = LabelTypeTable.labelTypeToId(c.labelType).get,
+              regionId = RegionTable.selectRegionIdOfClosestNeighborhood(c.lng, c.lat),
+              lat = c.lat,
+              lng = c.lng,
+              severity = c.severity,
+              temporary = c.temporary
+            )
+          }
 
-            // Gotta insert all the user_attributes in one pass to speed things up
-            DB.withConnection { implicit conn =>
-              val rowPlaceholder = "(?,?,?,?,?,?,?,?)"
-              val allPlaceholders = clusters.map(_ => rowPlaceholder).mkString(", ")
+          // Bulk insert them, returning newly created IDs in the same order
+          val userAttrIds = UserAttributeTable.saveMultiple(userAttributes)
 
-              val insertSql =
-                s"""
-                   INSERT INTO user_attribute (
-                     user_clustering_session_id,
-                     clustering_threshold,
-                     label_type_id,
-                     region_id,
-                     lat,
-                     lng,
-                     severity,
-                     temporary
-                   )
-                   VALUES $allPlaceholders
-                   RETURNING user_attribute_id
-                 """
-
-              val stmt = conn.prepareStatement(insertSql)
-              var paramIndex = 1
-
-              // Fill placeholders with cluster data
-              clusters.foreach { c =>
-                stmt.setInt(paramIndex, userSessionId)
-                paramIndex += 1
-                stmt.setFloat(paramIndex, thresholds(c.labelType))
-                paramIndex += 1
-                val labelTypeId = LabelTypeTable.labelTypeToId(c.labelType).get
-                stmt.setInt(paramIndex, labelTypeId)
-                paramIndex += 1
-                val regionId = RegionTable.selectRegionIdOfClosestNeighborhood(c.lng, c.lat)
-                stmt.setInt(paramIndex, regionId)
-                paramIndex += 1
-                stmt.setDouble(paramIndex, c.lat.toDouble)
-                paramIndex += 1
-                stmt.setDouble(paramIndex, c.lng.toDouble)
-                paramIndex += 1
-                c.severity match {
-                  case Some(sv) => stmt.setInt(paramIndex, sv)
-                  case None     => stmt.setNull(paramIndex, java.sql.Types.INTEGER)
-                }
-                paramIndex += 1
-                stmt.setBoolean(paramIndex, c.temporary)
-                paramIndex += 1
-              }
-
-              val rs = stmt.executeQuery()
-              val newUserAttrIds = collection.mutable.ArrayBuffer[Int]()
-              while (rs.next()) {
-                newUserAttrIds.append(rs.getInt("user_attribute_id"))
-              }
-              rs.close()
-              stmt.close()
-
-              // Pair up each cluster with its labels
-              val labelTuples = clusters.zip(newUserAttrIds).flatMap { case (c, attrId) =>
-                groupedLabels.getOrElse(c.clusterNum, Nil).map { lbl =>
-                  (attrId, lbl.labelId)
-                }
-              }
-
-              // Insert all user_attribute_label rows at once
-              if (labelTuples.nonEmpty) {
-                val rowPlaceholder2 = "(?,?)"
-                val all2 = labelTuples.map(_ => rowPlaceholder2).mkString(", ")
-                val insertLabelSql =
-                  s"""
-                     INSERT INTO user_attribute_label (
-                       user_attribute_id,
-                       label_id
-                     )
-                     VALUES $all2
-                   """
-                val stmt2 = conn.prepareStatement(insertLabelSql)
-                var i2 = 1
-
-                labelTuples.foreach { case (attrId, lblId) =>
-                  stmt2.setInt(i2, attrId)
-                  i2 += 1
-                  stmt2.setInt(i2, lblId)
-                  i2 += 1
-                }
-
-                stmt2.executeUpdate()
-                stmt2.close()
+          // Build a list of UserAttributeLabel objects for all label mappings
+          // We match each cluster to the new userAttributeId
+          val userAttributeLabels =
+            clusters.zip(userAttrIds).flatMap { case (c, attrId) =>
+              groupedLabels.getOrElse(c.clusterNum, Nil).map { lbl =>
+                UserAttributeLabel(
+                  userAttributeLabelId = 0,
+                  userAttributeId = attrId,
+                  labelId = lbl.labelId
+                )
               }
             }
 
-            Future.successful(Ok(Json.obj("session" -> userSessionId)))
-          }
-        )
-      } else {
-        Future.successful(Ok(Json.obj("error_msg" -> "Could not authenticate.")))
-      }
+          // Bulk insert the label mappings
+          if (userAttributeLabels.nonEmpty)
+            UserAttributeLabelTable.saveMultiple(userAttributeLabels)
+
+          Future.successful(Ok(Json.obj("session" -> userSessionId)))
+        }
+      )
+    } else {
+      Future.successful(Ok(Json.obj("error_msg" -> "Could not authenticate.")))
     }
+  }
 
   /**
-    * Takes in results of multi-user clustering, and adds the data to the relevant tables.
-    *
-    * @param key A key used for authentication.
-    * @param regionId The region whose labels were clustered.
-    */
-  def postMultiUserClusteringResults(key: String, regionId: Int) =
-    UserAwareAction.async(BodyParsers.parse.json(maxLength = 1024 * 1024 * 100)) { implicit request =>
-      // We keep the 100MB note: The maxLength argument above allows a 100MB max load size for the POST request.
-      if (authenticate(key)) {
-        val submission = request.body.validate[AttributeFormats.ClusteringSubmission]
-        submission.fold(
-          errors => {
-            Logger.error("Failed to parse JSON POST request for multi-user clustering results.")
-            Logger.info(Json.prettyPrint(request.body))
-            Future.successful(BadRequest(Json.obj("status" -> "Error", "message" -> JsError.toFlatJson(errors))))
-          },
-          submission => {
-            val thresholds: Map[String, Float] = submission.thresholds.map(t => (t.labelType, t.threshold)).toMap
-            val clusters: List[AttributeFormats.ClusterSubmission] = submission.clusters
-            val labels: List[AttributeFormats.ClusteredLabelSubmission] = submission.labels
+   * Takes in results of multi-user clustering, and adds the data in bulk to the relevant tables.
+   *
+   * @param key A key used for authentication.
+   * @param regionId The region who's labels were clustered.
+   */
+  def postMultiUserClusteringResults(key: String, regionId: Int) = UserAwareAction.async(BodyParsers.parse.json(maxLength = 1024 * 1024 * 100)) { implicit request =>
+    // The maxLength argument above allows a 100MB max load size for the POST request.
+    if (authenticate(key)) {
+      // Validation https://www.playframework.com/documentation/2.3.x/ScalaJson
+      val submission = request.body.validate[AttributeFormats.ClusteringSubmission]
+      submission.fold(
+        errors => {
+          Logger.error("Failed to parse JSON POST request for multi-user clustering results.")
+          Logger.info(Json.prettyPrint(request.body))
+          Future.successful(BadRequest(Json.obj("status" -> "Error", "message" -> JsError.toFlatJson(errors))))
+        },
+        submission => {
+          // Extract the thresholds, clusters, and labels, and put them into separate variables.
+          val thresholds: Map[String, Float] = submission.thresholds.map(t => (t.labelType, t.threshold)).toMap
+          val clusters: List[AttributeFormats.ClusterSubmission] = submission.clusters
+          val labels: List[AttributeFormats.ClusteredLabelSubmission] = submission.labels
 
-            val groupedLabels: Map[Int, List[AttributeFormats.ClusteredLabelSubmission]] = labels.groupBy(_.clusterNum)
-            val timestamp = new Timestamp(Instant.now.toEpochMilli)
+          // Group the labels by the cluster they were put into.
+          val groupedLabels: Map[Int, List[AttributeFormats.ClusteredLabelSubmission]] = labels.groupBy(_.clusterNum)
+          val timestamp: Timestamp = new Timestamp(Instant.now.toEpochMilli)
 
-            // This new approach also creates an entry in global_clustering_session
-            val globalSessionId: Int =
-              GlobalClusteringSessionTable.save(GlobalClusteringSession(0, regionId, timestamp))
+          // Add corresponding entry to the global_clustering_session table
+          val globalSessionId: Int = GlobalClusteringSessionTable.save(GlobalClusteringSession(0, regionId, timestamp))
 
-            // Do all the inserts for global_attribute in a single statement
-            DB.withConnection { implicit conn =>
-              val rowPlaceholder = "(?,?,?,?,?,?,?,?,?)"
-              val allPlaceholders = clusters.map(_ => rowPlaceholder).mkString(", ")
+          // Add the clusters to global_attribute table
+          val globalAttributes: Seq[GlobalAttribute] = clusters.map { cluster =>
+            GlobalAttribute(
+              globalAttributeId = 0,
+              globalClusteringSessionId = globalSessionId,
+              clusteringThreshold = thresholds(cluster.labelType),
+              labelTypeId = LabelTypeTable.labelTypeToId(cluster.labelType).get,
+              streetEdgeId = LabelTable.getStreetEdgeIdClosestToLatLng(cluster.lat, cluster.lng).get,
+              regionId = RegionTable.selectRegionIdOfClosestNeighborhood(cluster.lng, cluster.lat),
+              lat = cluster.lat,
+              lng = cluster.lng,
+              severity = cluster.severity,
+              temporary = cluster.temporary
+            )
+          }
 
-              val insertSql =
-                s"""
-                   INSERT INTO global_attribute (
-                     global_clustering_session_id,
-                     clustering_threshold,
-                     label_type_id,
-                     street_edge_id,
-                     region_id,
-                     lat,
-                     lng,
-                     severity,
-                     temporary
-                   )
-                   VALUES $allPlaceholders
-                   RETURNING global_attribute_id
-                 """
+          // Bulk insert global attributes and return their newly created IDs in the same order
+          val globalAttrIds: Seq[Int] = GlobalAttributeTable.saveMultiple(globalAttributes)
 
-              val stmt = conn.prepareStatement(insertSql)
-              var idx = 1
-
-              clusters.foreach { c =>
-                stmt.setInt(idx, globalSessionId)
-                idx += 1
-                stmt.setFloat(idx, thresholds(c.labelType))
-                idx += 1
-                val labelTypeId = LabelTypeTable.labelTypeToId(c.labelType).get
-                stmt.setInt(idx, labelTypeId)
-                idx += 1
-                val streetEdgeId = LabelTable.getStreetEdgeIdClosestToLatLng(c.lat, c.lng).get
-                stmt.setInt(idx, streetEdgeId)
-                idx += 1
-                val regionVal = RegionTable.selectRegionIdOfClosestNeighborhood(c.lng, c.lat)
-                stmt.setInt(idx, regionVal)
-                idx += 1
-                stmt.setDouble(idx, c.lat.toDouble)
-                idx += 1
-                stmt.setDouble(idx, c.lng.toDouble)
-                idx += 1
-                c.severity match {
-                  case Some(sv) => stmt.setInt(idx, sv)
-                  case None     => stmt.setNull(idx, java.sql.Types.INTEGER)
-                }
-                idx += 1
-                stmt.setBoolean(idx, c.temporary)
-                idx += 1
-              }
-
-              val rs = stmt.executeQuery()
-              val newGlobalAttrIds = collection.mutable.ArrayBuffer[Int]()
-              while (rs.next()) {
-                newGlobalAttrIds.append(rs.getInt("global_attribute_id"))
-              }
-              rs.close()
-              stmt.close()
-
-              // Link global_attribute IDs to user_attributes
-              val linkTuples = clusters.zip(newGlobalAttrIds).flatMap { case (c, globAttrId) =>
-                groupedLabels.getOrElse(c.clusterNum, Nil).map { lbl =>
-                  (globAttrId, lbl.labelId)
-                }
-              }
-
-              // Insert all global_attribute_user_attribute rows in bulk
-              if (linkTuples.nonEmpty) {
-                val rowPlaceholder2 = "(?,?)"
-                val all2 = linkTuples.map(_ => rowPlaceholder2).mkString(", ")
-                val insertLinkSql =
-                  s"""
-                     INSERT INTO global_attribute_user_attribute (
-                       global_attribute_id,
-                       user_attribute_id
-                     )
-                     VALUES $all2
-                   """
-                val stmt2 = conn.prepareStatement(insertLinkSql)
-                var i2 = 1
-
-                linkTuples.foreach { case (gAttrId, userAttrId) =>
-                  stmt2.setInt(i2, gAttrId)
-                  i2 += 1
-                  stmt2.setInt(i2, userAttrId)
-                  i2 += 1
-                }
-
-                stmt2.executeUpdate()
-                stmt2.close()
+          // Add all the associated labels to the global_attribute_user_attribute table.
+          val globalAttributeLabels: Seq[GlobalAttributeUserAttribute] =
+            clusters.zip(globalAttrIds).flatMap { case (cluster, attrId) =>
+              groupedLabels.getOrElse(cluster.clusterNum, Nil).map { label =>
+                GlobalAttributeUserAttribute(
+                  globalAttributeUserAttributeId = 0,
+                  globalAttributeId = attrId,
+                  userAttributeId = label.labelId
+                )
               }
             }
 
-            Future.successful(Ok(Json.obj("session" -> globalSessionId)))
-          }
-        )
-      } else {
-        Future.successful(Ok(Json.obj("error_msg" -> "Could not authenticate.")))
-      }
+          if (globalAttributeLabels.nonEmpty)
+            // Bulk insert global attribute user attributes and return their newly created IDs in the same order
+            GlobalAttributeUserAttributeTable.saveMultiple(globalAttributeLabels)
+
+          Future.successful(Ok(Json.obj("session" -> globalSessionId)))
+        }
+      )
+    } else {
+      Future.successful(Ok(Json.obj("error_msg" -> "Could not authenticate.")))
     }
+  }
 
 }

--- a/app/models/attribute/GlobalAttributeTable.scala
+++ b/app/models/attribute/GlobalAttributeTable.scala
@@ -293,4 +293,8 @@ object GlobalAttributeTable {
     val newId: Int = (globalAttributes returning globalAttributes.map(_.globalAttributeId)) += newSess
     newId
   }
+
+  def saveMultiple(attributes: Seq[GlobalAttribute]): Seq[Int] = db.withSession { implicit session =>
+    (globalAttributes returning globalAttributes.map(_.globalAttributeId)) ++= attributes
+  }
 }

--- a/app/models/attribute/GlobalAttributeUserAttributeTable.scala
+++ b/app/models/attribute/GlobalAttributeUserAttributeTable.scala
@@ -34,4 +34,8 @@ object GlobalAttributeUserAttributeTable {
     val newId: Int = (globalAttributeUserAttributes returning globalAttributeUserAttributes.map(_.globalAttributeUserAttributeId)) += newSess
     newId
   }
+
+  def saveMultiple(attributes: Seq[GlobalAttributeUserAttribute]): Seq[Int] = db.withSession { implicit session =>
+    (globalAttributeUserAttributes returning globalAttributeUserAttributes.map(_.globalAttributeUserAttributeId)) ++= attributes
+  }
 }

--- a/app/models/attribute/UserAttributeLabelTable.scala
+++ b/app/models/attribute/UserAttributeLabelTable.scala
@@ -39,4 +39,8 @@ object UserAttributeLabelTable {
     val newId: Int = (userAttributeLabels returning userAttributeLabels.map(_.userAttributeLabelId)) += newSess
     newId
   }
+
+  def saveMultiple(labels: Seq[UserAttributeLabel]): Seq[Int] = db.withSession { implicit session =>
+    (userAttributeLabels returning userAttributeLabels.map(_.userAttributeLabelId)) ++= labels
+  }
 }

--- a/app/models/attribute/UserAttributeTable.scala
+++ b/app/models/attribute/UserAttributeTable.scala
@@ -64,4 +64,9 @@ object UserAttributeTable {
     val newId: Int = (userAttributes returning userAttributes.map(_.userAttributeId)) += newSess
     newId
   }
+
+  def saveMultiple(attributes: Seq[UserAttribute]): Seq[Int] = db.withSession { implicit session =>
+    (userAttributes returning userAttributes.map(_.userAttributeId)) ++= attributes
+  }
+
 }


### PR DESCRIPTION
Resolves #2499 

Replaced individual row inserts with a single bulk insert call that returns all newly inserted IDs, vastly reducing the number of queries and ~doubling the speed of nightly clustering.  

TODO: Implement bulk region clustering.

##### Testing instructions
1. Run nightly clustering, and check time compared to original code

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [ ] I've included before/after screenshots above.
- [x] I've asked for and included translations for any user facing text that was added or modified.
- [x] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure the documentation on [this wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Descriptions-of-Logged-Events) is up to date for the logs you added/updated.
- [x] I've tested on mobile (only needed for validation page).
