### PR TITLE
Start mission button in validate page recognized by audio control

### DIFF
--- a/app/views/missionStartTutorial.scala.html
+++ b/app/views/missionStartTutorial.scala.html
@@ -129,7 +129,7 @@
                     <div class="label-type-description"></div>
 
 
-                    <div class="mission-start-tutorial-done-btn">Start mission</div>
+                    <div class="mission-start-tutorial-done-btn" role="button">Start mission</div>
                 </div>
             </div>
             <div class="next-slide-button">


### PR DESCRIPTION
Resolves #3743

Start mission button in validate page recognized by audio control by setting div attribute role="button", which allows the audio control to recognize it as a button rather than just a div text element.

##### Before/After screenshots (if applicable)
![IMG_7919](https://github.com/user-attachments/assets/2dafbd8b-8e11-4f10-8f93-674898de67a2)
![IMG_7918](https://github.com/user-attachments/assets/a6e6975e-6d72-47b8-92c1-4e42e357630a)
##### Testing instructions
1. If on mac, turn on voice control in accessability with overlay set to item numbers. 
2. See that a number pops up for the start mission button in validate page.

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No nee

d to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
- [x] I've asked for and included translations for any user facing text that was added or modified.
- [x] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure the documentation on [this wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Descriptions-of-Logged-Events) is up to date for the logs you added/updated.

- [ ] I've tested on mobile (only needed for validation page).
