### PR TITLE
Neighborhood hover not working on our maps in Firefox #3777

### DIFF
--- a/public/javascripts/PSMap/AddNeighborhoodsToMap.js
+++ b/public/javascripts/PSMap/AddNeighborhoodsToMap.js
@@ -173,13 +173,13 @@ function AddNeighborhoodsToMap(map, neighborhoodGeoJSON, completionRates, labelC
                 // Clear timeout when entering a tooltip.
                 neighborhoodTooltip._content.onmouseenter = function () { clearTimeout(tooltipTimeout); };
 
-                // Remove the tooltip after a delay when the mouse leaves the tooltip
+                // Remove the tooltip after a delay when the mouse leaves the tooltip.
                 neighborhoodTooltip._content.onmouseleave = function () {
                     tooltipTimeout = setTimeout(() => {
                         map.setFeatureState({ source: NEIGHBORHOOD_LAYER_NAME, id: hoveredRegionId }, { hover: false });
                         neighborhoodTooltip.remove();
                         hoveredRegionId = null;
-                    }, 200); // 200ms delay
+                    }, 200);
                 };
 
                 // Make sure the region outline is removed when the popup close button is clicked.
@@ -197,7 +197,6 @@ function AddNeighborhoodsToMap(map, neighborhoodGeoJSON, completionRates, labelC
             const isOverTooltip = e.originalEvent && e.originalEvent.toElement && e.originalEvent.toElement.closest('.mapboxgl-popup');
 
             if (hoveredRegionId !== null && (pageLostFocus || !isOverTooltip)) {
-                // Delay tooltip removal by 200ms
                 tooltipTimeout = setTimeout(() => {
                     map.setFeatureState({ source: NEIGHBORHOOD_LAYER_NAME, id: hoveredRegionId }, { hover: false });
                     neighborhoodTooltip.remove();
@@ -206,11 +205,9 @@ function AddNeighborhoodsToMap(map, neighborhoodGeoJSON, completionRates, labelC
             }
         });
 
-        // Clear the timeout if the mouse re-enters the neighborhood polygon
+        // Clear the timeout if the mouse re-enters the neighborhood polygon.
         map.on('mouseenter', NEIGHBORHOOD_LAYER_NAME, () => {
-            if (tooltipTimeout) {
                 clearTimeout(tooltipTimeout);
-            }
         });
 
         if (params.logClicks) {

--- a/public/javascripts/PSMap/AddNeighborhoodsToMap.js
+++ b/public/javascripts/PSMap/AddNeighborhoodsToMap.js
@@ -170,12 +170,8 @@ function AddNeighborhoodsToMap(map, neighborhoodGeoJSON, completionRates, labelC
                 const regionCenter = turf.centerOfMass(currRegion).geometry.coordinates;
                 neighborhoodTooltip.setLngLat({ lng: regionCenter[0], lat: regionCenter[1] }).addTo(map);
 
-                // Clear timeout when entering new toolTip
-                neighborhoodTooltip._content.onmouseenter = function () {
-                    if (tooltipTimeout) {
-                        clearTimeout(tooltipTimeout); // Clear the timeout if the mouse enters the tooltip
-                    }
-                };
+                // Clear timeout when entering a tooltip.
+                neighborhoodTooltip._content.onmouseenter = function () { clearTimeout(tooltipTimeout); };
 
                 // Remove the tooltip after a delay when the mouse leaves the tooltip
                 neighborhoodTooltip._content.onmouseleave = function () {

--- a/public/javascripts/PSMap/AddNeighborhoodsToMap.js
+++ b/public/javascripts/PSMap/AddNeighborhoodsToMap.js
@@ -206,9 +206,7 @@ function AddNeighborhoodsToMap(map, neighborhoodGeoJSON, completionRates, labelC
         });
 
         // Clear the timeout if the mouse re-enters the neighborhood polygon.
-        map.on('mouseenter', NEIGHBORHOOD_LAYER_NAME, () => {
-                clearTimeout(tooltipTimeout);
-        });
+        map.on('mouseenter', NEIGHBORHOOD_LAYER_NAME, () => { clearTimeout(tooltipTimeout); });
 
         if (params.logClicks) {
             // Logs to the webpage_activity table when a region is selected from the map and 'Click here' is clicked.


### PR DESCRIPTION
Resolves #3777 

Configured tooltopTimout variable to handle flickering on toolbox when hovered by adding slight delay when removing tool tip which gives the user time to move their mouse onto the tooltip.

##### Before/After screenshots (if applicable)

https://github.com/user-attachments/assets/4bb58cc7-68e9-4445-97af-ea614b63a8fa


https://github.com/user-attachments/assets/9bdae156-b64e-4f8d-bf05-353244bf01c4


##### Testing instructions
1. Open up firefox and hover over label map and check whether there is flickering.

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
- [x] I've asked for and included translations for any user facing text that was added or modified.
- [x] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure the documentation on [this wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Descriptions-of-Logged-Events) is up to date for the logs you added/updated.
- [ ] I've tested on mobile (only needed for validation page).
