### PR TITLE
Fixed blank screen issue when there are no missions to validate initially

### DIFF
--- a/public/javascripts/SVValidate/src/Main.js
+++ b/public/javascripts/SVValidate/src/Main.js
@@ -13,7 +13,7 @@ function Main (param) {
     svv.adminLabelTypeId = param.adminLabelTypeId;
     svv.adminUserIds = param.adminUserIds;
     svv.adminNeighborhoodIds = param.adminNeighborhoodIds;
-    svv.missionLength = param.mission.labels_validated;
+    svv.missionLength = param.mission?.labels_validated ?? 0;
     svv.canvasHeight = param.canvasHeight;
     svv.canvasWidth = param.canvasWidth;
     svv.missionsCompleted = param.missionSetProgress;
@@ -262,13 +262,13 @@ function Main (param) {
         lng: param.language,
         debug: false
     }, function(err, t) {
-        if(param.init !== "noInit") {
+        if (param.init !== "noInit") {
             defineValidateConstants();
             _initUI();
-
+  
             if (param.hasNextMission) {
                 _init();
-            } else {
+            } else if (!param.hasNextMission || svv.missionLength === 0) {
                 svv.keyboard = new Keyboard(svv.ui.validation);
                 svv.form = new Form(param.dataStoreUrl);
                 svv.tracker = new Tracker();
@@ -276,5 +276,5 @@ function Main (param) {
                 svv.modalNoNewMission.show();
             }
         }
-    });
+    });    
 }

--- a/public/javascripts/SVValidate/src/Main.js
+++ b/public/javascripts/SVValidate/src/Main.js
@@ -268,7 +268,7 @@ function Main (param) {
 
             if (param.hasNextMission) {
                 _init();
-            } else if (!param.hasNextMission || svv.missionLength === 0) {
+            } else {
                 svv.keyboard = new Keyboard(svv.ui.validation);
                 svv.form = new Form(param.dataStoreUrl);
                 svv.tracker = new Tracker();

--- a/public/javascripts/SVValidate/src/Main.js
+++ b/public/javascripts/SVValidate/src/Main.js
@@ -265,7 +265,7 @@ function Main (param) {
         if (param.init !== "noInit") {
             defineValidateConstants();
             _initUI();
-  
+
             if (param.hasNextMission) {
                 _init();
             } else if (!param.hasNextMission || svv.missionLength === 0) {
@@ -276,5 +276,5 @@ function Main (param) {
                 svv.modalNoNewMission.show();
             }
         }
-    });    
+    });
 }


### PR DESCRIPTION
Resolves #3746

The problem was that when the validate page is reloaded and there are no missions to start with, the screen is blank. To fix this, I added ternary operation to ensure that if the initial length of missions is 0, it will display the no new mission modal.

##### Before/After screenshots (if applicable)
Before:
Web Browser-
<img width="1713" alt="Screenshot 2025-02-06 at 6 46 44 PM" src="https://github.com/user-attachments/assets/f6b845e8-91fe-45e3-aac2-db1eb9c0b266" />

Mobile-
![Screenshot 2025-02-10 at 10 57 15 AM](https://github.com/user-attachments/assets/80329f7d-6797-40bb-9502-2714eaedbe3b)

After:
Web Browser-
![Screenshot 2025-02-10 at 10 21 36 AM](https://github.com/user-attachments/assets/95792550-e79f-45ca-90ce-b96f56641f21)

Mobile-
![Screenshot 2025-02-10 at 10 57 39 AM](https://github.com/user-attachments/assets/96dd60dd-54f4-497c-9061-35b0954607f5)

##### Testing instructions
1. Force else case in getDataForValidationPages() in ValidationController.scala by replacing labelTypeId.isDefined && missionSetProgress.missionType == "validation" with false.
2. Navigate to validation page and reload the screen.

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've included before/after screenshots above.
- [x] I've tested on mobile (only needed for validation page).