### PR TITLE
Fixes completed validation missions not being marked as such

### DIFF
--- a/app/controllers/ValidationTaskController.scala
+++ b/app/controllers/ValidationTaskController.scala
@@ -358,7 +358,7 @@ class ValidationTaskController @Inject() (implicit val env: Environment[User, Se
       val payPerLabel: Double = AMTAssignmentTable.TURKER_PAY_PER_LABEL_VALIDATION
       MissionTable.updateCompleteAndGetNextValidationMission(userId, payPerLabel, missionId, missionProgress.missionType, labelsProgress, nextMissionLabelTypeId, skipped)
     } else {
-      MissionTable.updateValidationProgressOnly(userId, missionId, labelsProgress)
+      MissionTable.updateValidationProgressOnly(userId, missionId, labelsProgress, missionProgress.labelsTotal)
     }
   }
 }

--- a/app/formats/json/ValidationTaskSubmissionFormats.scala
+++ b/app/formats/json/ValidationTaskSubmissionFormats.scala
@@ -10,7 +10,7 @@ object ValidationTaskSubmissionFormats {
   case class InteractionSubmission(action: String, missionId: Option[Int], gsvPanoramaId: Option[String], lat: Option[Float], lng: Option[Float], heading: Option[Float], pitch: Option[Float], zoom: Option[Float], note: Option[String], timestamp: Long)
   case class LabelValidationSubmission(labelId: Int, missionId: Int, validationResult: Int, oldSeverity: Option[Int], newSeverity: Option[Int], oldTags: List[String], newTags: List[String], canvasX: Option[Int], canvasY: Option[Int], heading: Float, pitch: Float, zoom: Float, canvasHeight: Int, canvasWidth: Int, startTimestamp: Long, endTimestamp: Long, source: String, undone: Boolean, redone: Boolean)
   case class SkipLabelSubmission(labels: Seq[LabelValidationSubmission], adminParams: AdminValidateParams)
-  case class ValidationMissionProgress(missionId: Int, missionType: String, labelsProgress: Int, labelTypeId: Int, completed: Boolean, skipped: Boolean)
+  case class ValidationMissionProgress(missionId: Int, missionType: String, labelsProgress: Int, labelsTotal: Int, labelTypeId: Int, completed: Boolean, skipped: Boolean)
   case class ValidationTaskSubmission(interactions: Seq[InteractionSubmission], environment: EnvironmentSubmission, validations: Seq[LabelValidationSubmission], missionProgress: Option[ValidationMissionProgress], adminParams: AdminValidateParams, panoHistories: Seq[PanoHistorySubmission], source: String, timestamp: Long)
   case class LabelMapValidationSubmission(labelId: Int, labelType: String, validationResult: Int, oldSeverity: Option[Int], newSeverity: Option[Int], oldTags: List[String], newTags: List[String], canvasX: Option[Int], canvasY: Option[Int], heading: Float, pitch: Float, zoom: Float, canvasHeight: Int, canvasWidth: Int, startTimestamp: Long, endTimestamp: Long, source: String)
 
@@ -68,6 +68,7 @@ object ValidationTaskSubmissionFormats {
     (JsPath \ "mission_id").read[Int] and
       (JsPath \ "mission_type").read[String] and
       (JsPath \ "labels_progress").read[Int] and
+      (JsPath \ "labels_total").read[Int] and
       (JsPath \ "label_type_id").read[Int] and
       (JsPath \ "completed").read[Boolean] and
       (JsPath \ "skipped").read[Boolean]

--- a/app/models/mission/MissionTable.scala
+++ b/app/models/mission/MissionTable.scala
@@ -488,8 +488,16 @@ object MissionTable {
      queryMissionTable(actions, userId, None, None, None, None, Some(missionId), Some(distanceProgress), auditTaskId, None)
    }
 
-  def updateValidationProgressOnly(userId: UUID, missionId: Int, labelsProgress: Int): Option[Mission] = {
-    val actions: List[String] = List("updateProgress")
+  /**
+   * Updates labels_progress column of a mission using the helper method to prevent race conditions.
+   *
+   * Also marks the mission as complete if the user has validated all the labels. Added this to try and prevent a bug
+   * where missions would have 10 out of 10 labels validated but still be marked as incomplete.
+   * https://github.com/ProjectSidewalk/SidewalkWebpage/issues/3789
+   */
+  def updateValidationProgressOnly(userId: UUID, missionId: Int, labelsProgress: Int, labelsTotal: Int): Option[Mission] = {
+    val actions: List[String] =
+      if (labelsProgress >= labelsTotal) List("updateProgress", "updateComplete") else List("updateProgress")
     queryMissionTableValidationMissions(actions, userId, None, None, None, Some(missionId), None, Some(labelsProgress), None, None)
   }
 

--- a/public/javascripts/SVValidate/src/data/Form.js
+++ b/public/javascripts/SVValidate/src/data/Form.js
@@ -35,6 +35,7 @@ function Form(url, beaconUrl) {
                 mission_id: mission.getProperty("missionId"),
                 mission_type: mission.getProperty("missionType"),
                 labels_progress: mission.getProperty("labelsProgress"),
+                labels_total: mission.getProperty("labelsValidated"),
                 label_type_id: mission.getProperty("labelTypeId"),
                 completed: missionComplete ? missionComplete : false,
                 skipped: mission.getProperty("skipped")


### PR DESCRIPTION
Fixes #3789 

##### The problem
We were having some issues where the Validate page would say that there were no more labels available to validate, when users could confirm that there were.

##### The underlying cause
I was able to track the issue to our `mission` table, which would have a mission that was marked as `completed = false` even though the mission was marked as having 10 out of 10 labels validated.

There are very few ways that this could happen, but the way that I could figure is if one of the post requests sent from the Validate page ended up being lost. We send data through this post endpoint whenever we have 200 logs to save, _or_ when the user completes a mission.

There is stuff that we do on the back end only when a mission is finished, and we only want to do it once per mission. So the "mission complete" post request is sent with a special flag set to let us know that that's the one time to do those operations. And it made sense to mark the mission complete as one of those things that we do on the "mission complete" post request.

If the request to mark the mission as complete was lost, but the user proceeded to move their mouse around and create logs which prompted a new request to save those logs that managed to go through, then it would mark the mission progress as 10 out of 10 labels complete without ever having been marked as "complete". An entry should never be in that state, and it was causing problems when trying to load a new mission.

##### The solution
Although there are operations that we want to make sure to only do once, marking the mission as complete is not one of them. It logically made sense to only do it once under the assumption that all API calls eventually went through, but if they don't then we need the redundancy. I just made sure that a missions is now marked as complete if we ever set it to have all it's validations finished. This worked in my test cases where I manually prevented the "mission complete" specific API call from being sent.

I'm also just going to run the following query on all the dbs once to fix the current instances of this problem:
```
UPDATE mission
SET completed = TRUE
WHERE labels_validated = 10 AND labels_progress = 10 AND completed = FALSE;
```

##### Caveat
I didn't actually reproduce the issue in the wild. There were only 6 missions marked incorrectly in this way in the Chicago database, indicating that it's very rare. I believe that my change will fix the issue whether it's a network issue or some sort of very difficult to reproduce race condition. But I ultimately don't 100% know what the root cause was, so I'll keep my eyes peeled in case this starts to happen again.

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
