### PR TITLE
Keyboard shortcuts for new validate page

### DIFF
--- a/public/javascripts/SVValidate/src/Main.js
+++ b/public/javascripts/SVValidate/src/Main.js
@@ -177,7 +177,11 @@ function Main (param) {
         // There are certain features that will only make sense on desktop.
         if (!isMobile()) {
             svv.gsvOverlay = new GSVOverlay();
-            svv.keyboard = new Keyboard(svv.ui.validation);
+            if (svv.newValidateBeta) {
+                svv.keyboard = new Keyboard(svv.ui.newValidateBeta);
+            } else {
+                svv.keyboard = new Keyboard(svv.ui.validation);
+            }
             svv.labelVisibilityControl = new LabelVisibilityControl();
             svv.speedLimit = new SpeedLimit(svv.panorama.getPanorama(), svv.panorama.getPosition, () => false, svv.panoramaContainer);
             svv.zoomControl = new ZoomControl();
@@ -269,7 +273,11 @@ function Main (param) {
             if (param.hasNextMission) {
                 _init();
             } else {
-                svv.keyboard = new Keyboard(svv.ui.validation);
+                if (svv.newValidateBeta) {
+                    svv.keyboard = new Keyboard(svv.ui.newValidateBeta);
+                } else {
+                    svv.keyboard = new Keyboard(svv.ui.validation);
+                }
                 svv.form = new Form(param.dataStoreUrl);
                 svv.tracker = new Tracker();
                 svv.modalNoNewMission = new ModalNoNewMission(svv.ui.modalMission);

--- a/public/javascripts/SVValidate/src/keyboard/Keyboard.js
+++ b/public/javascripts/SVValidate/src/keyboard/Keyboard.js
@@ -8,6 +8,24 @@ function Keyboard(menuUI) {
         addingComment: false
     };
 
+    // Add keydown listeners to the text boxes because escape
+    // key press is not being recognized when selected input text.
+    function handleEscapeKey(e) {
+        if (e.keyCode === 27) {
+            e.preventDefault();
+            e.stopImmediatePropagation();
+            this.blur();
+            svv.tracker.push("KeyboardShortcut_UnfocusComment", {
+                keyCode: e.keyCode
+            });
+        }
+    }
+
+    // Attach the same function to all three text boxes.
+    menuUI.optionalCommentTextBox.on('keydown', handleEscapeKey);
+    menuUI.disagreeReasonTextBox.on('keydown', handleEscapeKey);
+    menuUI.unsureReasonTextBox.on('keydown', handleEscapeKey);
+
     function disableKeyboard () {
         status.disableKeyboard = true;
     }
@@ -18,12 +36,23 @@ function Keyboard(menuUI) {
 
     // Set the addingComment status based on whether the user is currently typing in a validation comment text field.
     function checkIfTextAreaSelected() {
-        if (document.activeElement === menuUI.comment[0] ||
-            (svv.newValidateBeta && document.activeElement === svv.ui.newValidateBeta.optionalCommentTextBox[0]) ||
-            (svv.newValidateBeta && document.activeElement === svv.ui.newValidateBeta.disagreeReasonTextBox[0]) ||
-            (svv.newValidateBeta && document.activeElement === svv.ui.newValidateBeta.unsureReasonTextBox[0]) ||
-            (svv.newValidateBeta && document.activeElement === document.getElementById('select-tag-selectized'))) {
-            status.addingComment = true
+        // Check if menuUI.comment exists and has a valid element.
+        if (menuUI.comment && menuUI.comment[0] && document.activeElement === menuUI.comment[0]) {
+            status.addingComment = true;
+        }
+        // Check if newValidateBeta text boxes are focused.
+        else if (svv.newValidateBeta) {
+            if ((svv.ui.newValidateBeta.optionalCommentTextBox
+                    && document.activeElement === svv.ui.newValidateBeta.optionalCommentTextBox[0]) ||
+                (svv.ui.newValidateBeta.disagreeReasonTextBox
+                    && document.activeElement === svv.ui.newValidateBeta.disagreeReasonTextBox[0]) ||
+                (svv.ui.newValidateBeta.unsureReasonTextBox
+                    && document.activeElement === svv.ui.newValidateBeta.unsureReasonTextBox[0]) ||
+                (document.activeElement === document.getElementById('select-tag-selectized'))) {
+                status.addingComment = true;
+            } else {
+                status.addingComment = false;
+            }
         } else {
             status.addingComment = false
         }
@@ -80,6 +109,19 @@ function Keyboard(menuUI) {
             menuUI.yesButton.removeClass("validate");
             menuUI.unsureButton.removeClass("validate");
         }
+    }
+
+    // Handle severity and reason button clicks.
+    function handleButtonClick(buttonId, trackerEvent, keyCode) {
+        $(buttonId).click();
+        svv.tracker.push(trackerEvent, { keyCode: keyCode });
+    }
+
+    // Handle focusing on comment text boxes.
+    function focusCommentTextBox(textBox, trackerEvent, keyCode, e) {
+        textBox.focus();
+        svv.tracker.push(trackerEvent, { keyCode: keyCode });
+        e.preventDefault();
     }
 
     this._documentKeyDown = function (e) {
@@ -158,6 +200,52 @@ function Keyboard(menuUI) {
                         svv.tracker.push("KeyboardShortcut_ZoomIn", {
                             keyCode: e.keyCode
                         });
+                    }
+                    break;
+                // Severity shortcuts (1, 2, 3)
+                case 49: // "1"
+                case 97: // Numpad "1"
+                    if (menuUI.yesButton.hasClass('chosen')) {
+                        handleButtonClick('#severity-button-1', "KeyboardShortcut_Severity1", e.keyCode);
+                    } else if (menuUI.noButton.hasClass('chosen')) {
+                        handleButtonClick('#no-button-1', "KeyboardShortcut_DisagreeReason1", e.keyCode);
+                    } else if (menuUI.unsureButton.hasClass('chosen')) {
+                        handleButtonClick('#unsure-button-1', "KeyboardShortcut_UnsureReason1", e.keyCode);
+                    }
+                    break;
+
+                case 50: // "2"
+                case 98: // Numpad "2"
+                    if (menuUI.yesButton.hasClass('chosen')) {
+                        handleButtonClick('#severity-button-2', "KeyboardShortcut_Severity2", e.keyCode);
+                    } else if (menuUI.noButton.hasClass('chosen')) {
+                        handleButtonClick('#no-button-2', "KeyboardShortcut_DisagreeReason2", e.keyCode);
+                    } else if (menuUI.unsureButton.hasClass('chosen')) {
+                        handleButtonClick('#unsure-button-2', "KeyboardShortcut_UnsureReason2", e.keyCode);
+                    }
+                    break;
+
+                case 51: // "3"
+                case 99: // Numpad "3"
+                    if (menuUI.yesButton.hasClass('chosen')) {
+                        handleButtonClick('#severity-button-3', "KeyboardShortcut_Severity3", e.keyCode);
+                    } else if (menuUI.noButton.hasClass('chosen')) {
+                        handleButtonClick('#no-button-3', "KeyboardShortcut_DisagreeReason3", e.keyCode);
+                    } else if (menuUI.unsureButton.hasClass('chosen')) {
+                        handleButtonClick('#unsure-button-3', "KeyboardShortcut_UnsureReason3", e.keyCode);
+                    }
+                    break;
+
+                // "4" or "c" key (Focus comment box)
+                case 52: // "4"
+                case 100: // Numpad "4"
+                case 67: // "c"
+                    if (menuUI.yesButton.hasClass('chosen')) {
+                        focusCommentTextBox(menuUI.optionalCommentTextBox, "KeyboardShortcut_FocusAgreeComment", e.keyCode, e);
+                    } else if (menuUI.noButton.hasClass('chosen')) {
+                        focusCommentTextBox(menuUI.disagreeReasonTextBox, "KeyboardShortcut_FocusDisagreeComment", e.keyCode, e);
+                    } else if (menuUI.unsureButton.hasClass('chosen')) {
+                        focusCommentTextBox(menuUI.unsureReasonTextBox, "KeyboardShortcut_FocusUnsureComment", e.keyCode, e);
                     }
                     break;
             }

--- a/public/javascripts/SVValidate/src/keyboard/Keyboard.js
+++ b/public/javascripts/SVValidate/src/keyboard/Keyboard.js
@@ -11,20 +11,24 @@ function Keyboard(menuUI) {
     // Add keydown listeners to the text boxes because escape
     // key press is not being recognized when selected input text.
     function handleEscapeKey(e) {
-        if (e.keyCode === 27) {
-            e.preventDefault();
-            e.stopImmediatePropagation();
-            this.blur();
-            svv.tracker.push("KeyboardShortcut_UnfocusComment", {
-                keyCode: e.keyCode
-            });
+        if (svv.newValidateBeta) {
+            if (e.keyCode === 27) {
+                e.preventDefault();
+                e.stopImmediatePropagation();
+                this.blur();
+                svv.tracker.push("KeyboardShortcut_UnfocusComment", {
+                    keyCode: e.keyCode
+                });
+            }
         }
     }
 
     // Attach the same function to all three text boxes.
-    menuUI.optionalCommentTextBox.on('keydown', handleEscapeKey);
-    menuUI.disagreeReasonTextBox.on('keydown', handleEscapeKey);
-    menuUI.unsureReasonTextBox.on('keydown', handleEscapeKey);
+    if (svv.newValidateBeta) {
+        menuUI.optionalCommentTextBox.on('keydown', handleEscapeKey);
+        menuUI.disagreeReasonTextBox.on('keydown', handleEscapeKey);
+        menuUI.unsureReasonTextBox.on('keydown', handleEscapeKey);
+    }
 
     function disableKeyboard () {
         status.disableKeyboard = true;
@@ -119,9 +123,19 @@ function Keyboard(menuUI) {
 
     // Handle focusing on comment text boxes.
     function focusCommentTextBox(textBox, trackerEvent, keyCode, e) {
+        deselectDisagreeAndUnsureButtons();
+
         textBox.focus();
         svv.tracker.push(trackerEvent, { keyCode: keyCode });
         e.preventDefault();
+    }
+
+    function deselectDisagreeAndUnsureButtons() {
+        // Deselect disagree buttons
+        $('#no-button-1, #no-button-2, #no-button-3').removeClass('chosen');
+
+        // Deselect unsure buttons
+        $('#unsure-button-1, #unsure-button-2, #unsure-button-3').removeClass('chosen');
     }
 
     this._documentKeyDown = function (e) {
@@ -230,9 +244,19 @@ function Keyboard(menuUI) {
                     if (menuUI.yesButton.hasClass('chosen')) {
                         handleButtonClick('#severity-button-3', "KeyboardShortcut_Severity3", e.keyCode);
                     } else if (menuUI.noButton.hasClass('chosen')) {
-                        handleButtonClick('#no-button-3', "KeyboardShortcut_DisagreeReason3", e.keyCode);
+                        const button3 = document.getElementById('no-button-3');
+                        if (window.getComputedStyle(button3).display === 'none') {
+                            focusCommentTextBox(menuUI.disagreeReasonTextBox, "KeyboardShortcut_FocusDisagreeComment", e.keyCode, e);
+                        } else {
+                            handleButtonClick('#no-button-3', "KeyboardShortcut_DisagreeReason3", e.keyCode);
+                        }
                     } else if (menuUI.unsureButton.hasClass('chosen')) {
-                        handleButtonClick('#unsure-button-3', "KeyboardShortcut_UnsureReason3", e.keyCode);
+                        const button3 = document.getElementById('unsure-button-3');
+                        if (window.getComputedStyle(button3).display === 'none') {
+                            focusCommentTextBox(menuUI.unsureReasonTextBox, "KeyboardShortcut_FocusUnsureComment", e.keyCode, e);
+                        } else {
+                            handleButtonClick('#unsure-button-3', "KeyboardShortcut_UnsureReason3", e.keyCode);
+                        }
                     }
                     break;
 

--- a/public/javascripts/SVValidate/src/keyboard/Keyboard.js
+++ b/public/javascripts/SVValidate/src/keyboard/Keyboard.js
@@ -43,15 +43,11 @@ function Keyboard(menuUI) {
         // Check if menuUI.comment exists and has a valid element.
         if (menuUI.comment && menuUI.comment[0] && document.activeElement === menuUI.comment[0]) {
             status.addingComment = true;
-        }
-        // Check if newValidateBeta text boxes are focused.
-        else if (svv.newValidateBeta) {
-            if ((svv.ui.newValidateBeta.optionalCommentTextBox
-                    && document.activeElement === svv.ui.newValidateBeta.optionalCommentTextBox[0]) ||
-                (svv.ui.newValidateBeta.disagreeReasonTextBox
-                    && document.activeElement === svv.ui.newValidateBeta.disagreeReasonTextBox[0]) ||
-                (svv.ui.newValidateBeta.unsureReasonTextBox
-                    && document.activeElement === svv.ui.newValidateBeta.unsureReasonTextBox[0]) ||
+        } else if (svv.newValidateBeta) {
+            // Check if newValidateBeta text boxes are focused.
+            if (document.activeElement === svv.ui.newValidateBeta.optionalCommentTextBox[0] ||
+                document.activeElement === svv.ui.newValidateBeta.disagreeReasonTextBox[0] ||
+                document.activeElement === svv.ui.newValidateBeta.unsureReasonTextBox[0] ||
                 (document.activeElement === document.getElementById('select-tag-selectized'))) {
                 status.addingComment = true;
             } else {

--- a/public/javascripts/SVValidate/src/keyboard/Keyboard.js
+++ b/public/javascripts/SVValidate/src/keyboard/Keyboard.js
@@ -111,20 +111,6 @@ function Keyboard(menuUI) {
         }
     }
 
-    // Handle focusing on comment text boxes.
-    function focusCommentTextBox(textBox, trackerEvent, keyCode, e) {
-        deselectDisagreeAndUnsureButtons();
-
-        textBox.focus();
-        svv.tracker.push(trackerEvent, { keyCode: keyCode });
-        e.preventDefault();
-    }
-
-    function deselectDisagreeAndUnsureButtons() {
-        $('#no-button-1, #no-button-2, #no-button-3').removeClass('chosen');
-        $('#unsure-button-1, #unsure-button-2, #unsure-button-3').removeClass('chosen');
-    }
-
     //Handles the logic for the 1, 2, and 3 key shortcuts.
     function handleNumberKeyShortcut(n, e) {
         if (menuUI.yesButton.hasClass('chosen')) {

--- a/public/javascripts/SVValidate/src/keyboard/Keyboard.js
+++ b/public/javascripts/SVValidate/src/keyboard/Keyboard.js
@@ -111,12 +111,6 @@ function Keyboard(menuUI) {
         }
     }
 
-    // Handle severity and reason button clicks.
-    function handleButtonClick(buttonId, trackerEvent, keyCode) {
-        $(buttonId).click();
-        svv.tracker.push(trackerEvent, { keyCode: keyCode });
-    }
-
     // Handle focusing on comment text boxes.
     function focusCommentTextBox(textBox, trackerEvent, keyCode, e) {
         deselectDisagreeAndUnsureButtons();
@@ -134,31 +128,37 @@ function Keyboard(menuUI) {
     //Handles the logic for the 1, 2, and 3 key shortcuts.
     function handleNumberKeyShortcut(n, e) {
         if (menuUI.yesButton.hasClass('chosen')) {
-            handleButtonClick(`#severity-button-${n}`, `KeyboardShortcut_Severity${n}`, e.keyCode);
+            const buttonId = `#severity-button-${n}`;
+            $(buttonId).click();
         } else if (menuUI.noButton.hasClass('chosen')) {
-            if (!$(`#no-button-${n}`).hasClass('defaultOption')) {
+            const buttonId = `#no-button-${n}`;
+            if (!$(buttonId).hasClass('defaultOption')) {
                 // If there's no default disagree option for this key, focus on the comment box.
-                focusCommentTextBox(menuUI.disagreeReasonTextBox, "KeyboardShortcut_FocusDisagreeComment", e.keyCode, e);
+                e.preventDefault();
+                menuUI.disagreeReasonTextBox.click();
             } else {
-                handleButtonClick(`#no-button-${n}`, `KeyboardShortcut_DisagreeReason${n}`, e.keyCode);
+                $(buttonId).click();
             }
         } else if (menuUI.unsureButton.hasClass('chosen')) {
-            if (!$(`#unsure-button-${n}`).hasClass('defaultOption')) {
+            const buttonId = `#unsure-button-${n}`;
+            if (!$(buttonId).hasClass('defaultOption')) {
                 // If there's no default unsure option for key 2 or 3, focus on the comment box.
-                focusCommentTextBox(menuUI.unsureReasonTextBox, "KeyboardShortcut_FocusUnsureComment", e.keyCode, e);
+                e.preventDefault();
+                menuUI.unsureReasonTextBox.click();
             } else {
-                handleButtonClick(`#unsure-button-${n}`, `KeyboardShortcut_UnsureReason${n}`, e.keyCode);
+                $(buttonId).click();
             }
         }
     }
 
     function handleCommentBoxShortcut(e) {
+        e.preventDefault();
         if (menuUI.yesButton.hasClass('chosen')) {
-            focusCommentTextBox(menuUI.optionalCommentTextBox, "KeyboardShortcut_FocusAgreeComment", e.keyCode, e);
+            menuUI.optionalCommentTextBox.click();
         } else if (menuUI.noButton.hasClass('chosen')) {
-            focusCommentTextBox(menuUI.disagreeReasonTextBox, "KeyboardShortcut_FocusDisagreeComment", e.keyCode, e);
+            menuUI.disagreeReasonTextBox.click();
         } else if (menuUI.unsureButton.hasClass('chosen')) {
-            focusCommentTextBox(menuUI.unsureReasonTextBox, "KeyboardShortcut_FocusUnsureComment", e.keyCode, e);
+            menuUI.unsureReasonTextBox.click();
         }
     }
 

--- a/public/javascripts/SVValidate/src/keyboard/Keyboard.js
+++ b/public/javascripts/SVValidate/src/keyboard/Keyboard.js
@@ -131,10 +131,7 @@ function Keyboard(menuUI) {
     }
 
     function deselectDisagreeAndUnsureButtons() {
-        // Deselect disagree buttons
         $('#no-button-1, #no-button-2, #no-button-3').removeClass('chosen');
-
-        // Deselect unsure buttons
         $('#unsure-button-1, #unsure-button-2, #unsure-button-3').removeClass('chosen');
     }
 

--- a/public/javascripts/SVValidate/src/keyboard/Keyboard.js
+++ b/public/javascripts/SVValidate/src/keyboard/Keyboard.js
@@ -138,6 +138,40 @@ function Keyboard(menuUI) {
         $('#unsure-button-1, #unsure-button-2, #unsure-button-3').removeClass('chosen');
     }
 
+    //Handles the logic for the 1, 2, and 3 key shortcuts.
+    function handleNumberKeyShortcut(n, e) {
+        if (menuUI.yesButton.hasClass('chosen')) {
+            // Handle severity buttons for "agree"
+            handleButtonClick(`#severity-button-${n}`, `KeyboardShortcut_Severity${n}`, e.keyCode);
+        } else if (menuUI.noButton.hasClass('chosen')) {
+            // Handle disagree reason buttons
+            if (n === 3 && !menuUI.hasDefaultDisagreeOption) {
+                // If there's no default disagree option for key 3, focus on the comment box
+                focusCommentTextBox(menuUI.disagreeReasonTextBox, "KeyboardShortcut_FocusDisagreeComment", e.keyCode, e);
+            } else {
+                handleButtonClick(`#no-button-${n}`, `KeyboardShortcut_DisagreeReason${n}`, e.keyCode);
+            }
+        } else if (menuUI.unsureButton.hasClass('chosen')) {
+            // Handle unsure reason buttons
+            if (n === 3 && !menuUI.hasDefaultUnsureOption) {
+                // If there's no default unsure option for key 3, focus on the comment box
+                focusCommentTextBox(menuUI.unsureReasonTextBox, "KeyboardShortcut_FocusUnsureComment", e.keyCode, e);
+            } else {
+                handleButtonClick(`#unsure-button-${n}`, `KeyboardShortcut_UnsureReason${n}`, e.keyCode);
+            }
+        }
+    }
+
+    function handleCommentBoxShortcut(e) {
+        if (menuUI.yesButton.hasClass('chosen')) {
+            focusCommentTextBox(menuUI.optionalCommentTextBox, "KeyboardShortcut_FocusAgreeComment", e.keyCode, e);
+        } else if (menuUI.noButton.hasClass('chosen')) {
+            focusCommentTextBox(menuUI.disagreeReasonTextBox, "KeyboardShortcut_FocusDisagreeComment", e.keyCode, e);
+        } else if (menuUI.unsureButton.hasClass('chosen')) {
+            focusCommentTextBox(menuUI.unsureReasonTextBox, "KeyboardShortcut_FocusUnsureComment", e.keyCode, e);
+        }
+    }
+
     this._documentKeyDown = function (e) {
         // When the user is typing in the validation comment text field, temporarily disable keyboard
         // shortcuts that can be used to validate a label.
@@ -219,58 +253,24 @@ function Keyboard(menuUI) {
                 // Severity shortcuts (1, 2, 3)
                 case 49: // "1"
                 case 97: // Numpad "1"
-                    if (menuUI.yesButton.hasClass('chosen')) {
-                        handleButtonClick('#severity-button-1', "KeyboardShortcut_Severity1", e.keyCode);
-                    } else if (menuUI.noButton.hasClass('chosen')) {
-                        handleButtonClick('#no-button-1', "KeyboardShortcut_DisagreeReason1", e.keyCode);
-                    } else if (menuUI.unsureButton.hasClass('chosen')) {
-                        handleButtonClick('#unsure-button-1', "KeyboardShortcut_UnsureReason1", e.keyCode);
-                    }
+                    handleNumberKeyShortcut(1, e);
                     break;
 
                 case 50: // "2"
                 case 98: // Numpad "2"
-                    if (menuUI.yesButton.hasClass('chosen')) {
-                        handleButtonClick('#severity-button-2', "KeyboardShortcut_Severity2", e.keyCode);
-                    } else if (menuUI.noButton.hasClass('chosen')) {
-                        handleButtonClick('#no-button-2', "KeyboardShortcut_DisagreeReason2", e.keyCode);
-                    } else if (menuUI.unsureButton.hasClass('chosen')) {
-                        handleButtonClick('#unsure-button-2', "KeyboardShortcut_UnsureReason2", e.keyCode);
-                    }
+                    handleNumberKeyShortcut(2, e);
                     break;
 
                 case 51: // "3"
                 case 99: // Numpad "3"
-                    if (menuUI.yesButton.hasClass('chosen')) {
-                        handleButtonClick('#severity-button-3', "KeyboardShortcut_Severity3", e.keyCode);
-                    } else if (menuUI.noButton.hasClass('chosen')) {
-                        const button3 = document.getElementById('no-button-3');
-                        if (window.getComputedStyle(button3).display === 'none') {
-                            focusCommentTextBox(menuUI.disagreeReasonTextBox, "KeyboardShortcut_FocusDisagreeComment", e.keyCode, e);
-                        } else {
-                            handleButtonClick('#no-button-3', "KeyboardShortcut_DisagreeReason3", e.keyCode);
-                        }
-                    } else if (menuUI.unsureButton.hasClass('chosen')) {
-                        const button3 = document.getElementById('unsure-button-3');
-                        if (window.getComputedStyle(button3).display === 'none') {
-                            focusCommentTextBox(menuUI.unsureReasonTextBox, "KeyboardShortcut_FocusUnsureComment", e.keyCode, e);
-                        } else {
-                            handleButtonClick('#unsure-button-3', "KeyboardShortcut_UnsureReason3", e.keyCode);
-                        }
-                    }
+                    handleNumberKeyShortcut(3, e);
                     break;
 
                 // "4" or "c" key (Focus comment box)
                 case 52: // "4"
                 case 100: // Numpad "4"
                 case 67: // "c"
-                    if (menuUI.yesButton.hasClass('chosen')) {
-                        focusCommentTextBox(menuUI.optionalCommentTextBox, "KeyboardShortcut_FocusAgreeComment", e.keyCode, e);
-                    } else if (menuUI.noButton.hasClass('chosen')) {
-                        focusCommentTextBox(menuUI.disagreeReasonTextBox, "KeyboardShortcut_FocusDisagreeComment", e.keyCode, e);
-                    } else if (menuUI.unsureButton.hasClass('chosen')) {
-                        focusCommentTextBox(menuUI.unsureReasonTextBox, "KeyboardShortcut_FocusUnsureComment", e.keyCode, e);
-                    }
+                    handleCommentBoxShortcut(e);
                     break;
             }
         }

--- a/public/javascripts/SVValidate/src/keyboard/Keyboard.js
+++ b/public/javascripts/SVValidate/src/keyboard/Keyboard.js
@@ -11,15 +11,11 @@ function Keyboard(menuUI) {
     // Add keydown listeners to the text boxes because escape
     // key press is not being recognized when selected input text.
     function handleEscapeKey(e) {
-        if (svv.newValidateBeta) {
-            if (e.keyCode === 27) {
-                e.preventDefault();
-                e.stopImmediatePropagation();
-                this.blur();
-                svv.tracker.push("KeyboardShortcut_UnfocusComment", {
-                    keyCode: e.keyCode
-                });
-            }
+        if (e.keyCode === 27) {
+            e.preventDefault();
+            e.stopImmediatePropagation();
+            this.blur();
+            svv.tracker.push("KeyboardShortcut_UnfocusComment", { keyCode: e.keyCode });
         }
     }
 
@@ -28,6 +24,8 @@ function Keyboard(menuUI) {
         menuUI.optionalCommentTextBox.on('keydown', handleEscapeKey);
         menuUI.disagreeReasonTextBox.on('keydown', handleEscapeKey);
         menuUI.unsureReasonTextBox.on('keydown', handleEscapeKey);
+    } else {
+        menuUI.comment.on('keydown', handleEscapeKey);
     }
 
     function disableKeyboard () {
@@ -48,7 +46,7 @@ function Keyboard(menuUI) {
             if (document.activeElement === svv.ui.newValidateBeta.optionalCommentTextBox[0] ||
                 document.activeElement === svv.ui.newValidateBeta.disagreeReasonTextBox[0] ||
                 document.activeElement === svv.ui.newValidateBeta.unsureReasonTextBox[0] ||
-                (document.activeElement === document.getElementById('select-tag-selectized'))) {
+                document.activeElement === document.getElementById('select-tag-selectized')) {
                 status.addingComment = true;
             } else {
                 status.addingComment = false;
@@ -111,15 +109,14 @@ function Keyboard(menuUI) {
         }
     }
 
-    //Handles the logic for the 1, 2, and 3 key shortcuts.
+    // Handles the logic for the 1, 2, and 3 key shortcuts.
     function handleNumberKeyShortcut(n, e) {
         if (menuUI.yesButton.hasClass('chosen')) {
-            const buttonId = `#severity-button-${n}`;
-            $(buttonId).click();
+            $(`#severity-button-${n}`).click();
         } else if (menuUI.noButton.hasClass('chosen')) {
             const buttonId = `#no-button-${n}`;
+            // If there's no default disagree option for this key, focus on the comment box, otherwise click the button.
             if (!$(buttonId).hasClass('defaultOption')) {
-                // If there's no default disagree option for this key, focus on the comment box.
                 e.preventDefault();
                 menuUI.disagreeReasonTextBox.click();
             } else {
@@ -127,8 +124,8 @@ function Keyboard(menuUI) {
             }
         } else if (menuUI.unsureButton.hasClass('chosen')) {
             const buttonId = `#unsure-button-${n}`;
+            // If there's no default unsure option for key 2 or 3, focus on the comment box, otherwise click the button.
             if (!$(buttonId).hasClass('defaultOption')) {
-                // If there's no default unsure option for key 2 or 3, focus on the comment box.
                 e.preventDefault();
                 menuUI.unsureReasonTextBox.click();
             } else {
@@ -139,7 +136,9 @@ function Keyboard(menuUI) {
 
     function handleCommentBoxShortcut(e) {
         e.preventDefault();
-        if (menuUI.yesButton.hasClass('chosen')) {
+        if (!svv.newValidateBeta) {
+            menuUI.comment.focus();
+        } else if (menuUI.yesButton.hasClass('chosen')) {
             menuUI.optionalCommentTextBox.click();
         } else if (menuUI.noButton.hasClass('chosen')) {
             menuUI.disagreeReasonTextBox.click();

--- a/public/javascripts/SVValidate/src/keyboard/Keyboard.js
+++ b/public/javascripts/SVValidate/src/keyboard/Keyboard.js
@@ -141,20 +141,17 @@ function Keyboard(menuUI) {
     //Handles the logic for the 1, 2, and 3 key shortcuts.
     function handleNumberKeyShortcut(n, e) {
         if (menuUI.yesButton.hasClass('chosen')) {
-            // Handle severity buttons for "agree"
             handleButtonClick(`#severity-button-${n}`, `KeyboardShortcut_Severity${n}`, e.keyCode);
         } else if (menuUI.noButton.hasClass('chosen')) {
-            // Handle disagree reason buttons
-            if (n === 3 && !menuUI.hasDefaultDisagreeOption) {
-                // If there's no default disagree option for key 3, focus on the comment box
+            if (!$(`#no-button-${n}`).hasClass('defaultOption')) {
+                // If there's no default disagree option for this key, focus on the comment box.
                 focusCommentTextBox(menuUI.disagreeReasonTextBox, "KeyboardShortcut_FocusDisagreeComment", e.keyCode, e);
             } else {
                 handleButtonClick(`#no-button-${n}`, `KeyboardShortcut_DisagreeReason${n}`, e.keyCode);
             }
         } else if (menuUI.unsureButton.hasClass('chosen')) {
-            // Handle unsure reason buttons
-            if (n === 3 && !menuUI.hasDefaultUnsureOption) {
-                // If there's no default unsure option for key 3, focus on the comment box
+            if (!$(`#unsure-button-${n}`).hasClass('defaultOption')) {
+                // If there's no default unsure option for key 2 or 3, focus on the comment box.
                 focusCommentTextBox(menuUI.unsureReasonTextBox, "KeyboardShortcut_FocusUnsureComment", e.keyCode, e);
             } else {
                 handleButtonClick(`#unsure-button-${n}`, `KeyboardShortcut_UnsureReason${n}`, e.keyCode);

--- a/public/javascripts/SVValidate/src/menu/RightMenu.js
+++ b/public/javascripts/SVValidate/src/menu/RightMenu.js
@@ -82,22 +82,47 @@ function RightMenu(menuUI) {
 
         // Add onclick for disagree and unsure reason buttons.
         for (const reasonButton of $disagreeReasonButtons) {
-            reasonButton.onclick = function() {
-                svv.tracker.push('Click=DisagreeReason_Option=' + $(this).attr('id'));
+            reasonButton.onclick = function(e) {
+                const action = e.isTrigger ? 'KeyboardShortcut_DisagreeReason_Option=no-button-' + $(this).attr('id')
+                    : 'Click=DisagreeReason_Option=' + $(this).attr('id');
+                svv.tracker.push(action);
                 _setDisagreeReason($(this).attr('id'));
             };
         }
         for (const reasonButton of $unsureReasonButtons) {
-            reasonButton.onclick = function() {
-                svv.tracker.push('Click=UnsureReason_Option=' + $(this).attr('id'));
+            reasonButton.onclick = function(e) {
+                const action = e.isTrigger ? 'KeyboardShortcut_UnsureReason_Option=unsure-button-' + $(this).attr('id')
+                    : 'Click=UnsureReason_Option=' + $(this).attr('id');
+                svv.tracker.push(action);
                 _setUnsureReason($(this).attr('id'));
             };
         }
 
+        function deselectReasonButtons() {
+            $disagreeReasonButtons.removeClass('chosen');
+            $unsureReasonButtons.removeClass('chosen');
+            menuUI.disagreeReasonTextBox.removeClass('chosen');
+            menuUI.unsureReasonTextBox.removeClass('chosen');
+        }
+
         // Log clicks to the three text boxes.
-        menuUI.optionalCommentTextBox.click(function() { svv.tracker.push('Click=AgreeCommentTextbox'); });
-        menuUI.disagreeReasonTextBox.click(function() { svv.tracker.push('Click=DisagreeReasonTextbox'); });
-        menuUI.unsureReasonTextBox.click(function() { svv.tracker.push('Click=UnsureReasonTextbox'); });
+        menuUI.optionalCommentTextBox.click(function(e) {
+            menuUI.optionalCommentTextBox.focus();
+            const action = e.isTrigger ? 'Keyboard=AgreeCommentTextbox': 'Click=AgreeCommentTextbox';
+            svv.tracker.push(action);
+        });
+        menuUI.disagreeReasonTextBox.click(function(e) {
+            deselectReasonButtons();
+            menuUI.disagreeReasonTextBox.focus();
+            const action = e.isTrigger ? 'Keyboard=DisagreeReasonTextbox': 'Click=DisagreeReasonTextbox';
+            svv.tracker.push(action);
+        });
+        menuUI.unsureReasonTextBox.click(function(e) {
+            deselectReasonButtons();
+            menuUI.unsureReasonTextBox.focus();
+            const action = e.isTrigger ? 'Keyboard=UnsureReasonTextbox': 'Click=UnsureReasonTextbox';
+            svv.tracker.push(action);
+        });
 
         // Add oninput for disagree and unsure other reason text boxes.
         menuUI.disagreeReasonTextBox.on('input', function() {

--- a/public/javascripts/SVValidate/src/menu/RightMenu.js
+++ b/public/javascripts/SVValidate/src/menu/RightMenu.js
@@ -147,8 +147,6 @@ function RightMenu(menuUI) {
 
             // Update the text and tooltips on each disagree and unsure reason buttons.
             const labelType = util.camelToKebab(label.getAuditProperty('labelType'));
-            let hasDefaultDisagreeOption = false;
-            let hasDefaultUnsureOption = false;
             for (const reasonButton of $disagreeReasonButtons.add($unsureReasonButtons)) {
                 const $reasonButton = $(reasonButton);
                 const buttonInfo = svv.reasonButtonInfo[labelType][$reasonButton.attr('id')];
@@ -164,19 +162,17 @@ function RightMenu(menuUI) {
                     } else {
                         _addTooltip($reasonButton, buttonInfo.tooltipText);
                     }
-                    // Check if there is a default option for third option for disagree or unsure reasons.
-                    if ($reasonButton.attr('id').includes('no-button-3')) {
-                        hasDefaultDisagreeOption = true;
-                    } else if ($reasonButton.attr('id').includes('unsure-button-3')) {
-                        hasDefaultUnsureOption = true;
-                    }
+
                     $reasonButton.css('display', 'flex');
+                    // Check if there is a default option for disagree or unsure reasons.
+                    $reasonButton.addClass('defaultOption');
                 } else {
                     $reasonButton.css('display', 'none');
+                    if ($reasonButton.hasClass('defaultOption')) {
+                        $reasonButton.removeClass('defaultOption');
+                    }
                 }
             }
-            menuUI.hasDefaultDisagreeOption = hasDefaultDisagreeOption;
-            menuUI.hasDefaultUnsureOption = hasDefaultUnsureOption;
             menuUI.submitButton.prop('disabled', true);
         } else {
             // This is a validation that they are going back to, so update all the views to match what they had before.

--- a/public/javascripts/SVValidate/src/menu/RightMenu.js
+++ b/public/javascripts/SVValidate/src/menu/RightMenu.js
@@ -147,6 +147,8 @@ function RightMenu(menuUI) {
 
             // Update the text and tooltips on each disagree and unsure reason buttons.
             const labelType = util.camelToKebab(label.getAuditProperty('labelType'));
+            let hasDefaultDisagreeOption = false;
+            let hasDefaultUnsureOption = false;
             for (const reasonButton of $disagreeReasonButtons.add($unsureReasonButtons)) {
                 const $reasonButton = $(reasonButton);
                 const buttonInfo = svv.reasonButtonInfo[labelType][$reasonButton.attr('id')];
@@ -162,11 +164,19 @@ function RightMenu(menuUI) {
                     } else {
                         _addTooltip($reasonButton, buttonInfo.tooltipText);
                     }
+                    // Check if there is a default option for third option for disagree or unsure reasons.
+                    if ($reasonButton.attr('id').includes('no-button-3')) {
+                        hasDefaultDisagreeOption = true;
+                    } else if ($reasonButton.attr('id').includes('unsure-button-3')) {
+                        hasDefaultUnsureOption = true;
+                    }
                     $reasonButton.css('display', 'flex');
                 } else {
                     $reasonButton.css('display', 'none');
                 }
             }
+            menuUI.hasDefaultDisagreeOption = hasDefaultDisagreeOption;
+            menuUI.hasDefaultUnsureOption = hasDefaultUnsureOption;
             menuUI.submitButton.prop('disabled', true);
         } else {
             // This is a validation that they are going back to, so update all the views to match what they had before.

--- a/public/javascripts/SVValidate/src/menu/RightMenu.js
+++ b/public/javascripts/SVValidate/src/menu/RightMenu.js
@@ -163,9 +163,9 @@ function RightMenu(menuUI) {
                         _addTooltip($reasonButton, buttonInfo.tooltipText);
                     }
 
-                    $reasonButton.css('display', 'flex');
-                    // Check if there is a default option for disagree or unsure reasons.
+                    // Adds a class as a way to show that this button has associated text.
                     $reasonButton.addClass('defaultOption');
+                    $reasonButton.css('display', 'flex');
                 } else {
                     $reasonButton.css('display', 'none');
                     if ($reasonButton.hasClass('defaultOption')) {

--- a/public/javascripts/SVValidate/src/menu/RightMenu.js
+++ b/public/javascripts/SVValidate/src/menu/RightMenu.js
@@ -34,7 +34,8 @@ function RightMenu(menuUI) {
             let currLabel = svv.panorama.getCurrentLabel();
             const oldSeverity = currLabel.getProperty('newSeverity');
             const newSeverity = $(e.target).closest('.severity-level').data('severity');
-            if (oldSeverity !== newSeverity) {
+            const labelType = currLabel.getAuditProperty('labelType')
+            if (oldSeverity !== newSeverity && labelType !== 'Signal') {
                 svv.tracker.push(`Click=Severity_Old=${oldSeverity}_New=${newSeverity}`);
                 currLabel.setProperty('newSeverity', newSeverity);
                 _renderSeverity();
@@ -83,7 +84,7 @@ function RightMenu(menuUI) {
         // Add onclick for disagree and unsure reason buttons.
         for (const reasonButton of $disagreeReasonButtons) {
             reasonButton.onclick = function(e) {
-                const action = e.isTrigger ? 'KeyboardShortcut_DisagreeReason_Option=no-button-' + $(this).attr('id')
+                const action = e.isTrigger ? 'KeyboardShortcut_DisagreeReason_Option=' + $(this).attr('id')
                     : 'Click=DisagreeReason_Option=' + $(this).attr('id');
                 svv.tracker.push(action);
                 _setDisagreeReason($(this).attr('id'));
@@ -91,36 +92,27 @@ function RightMenu(menuUI) {
         }
         for (const reasonButton of $unsureReasonButtons) {
             reasonButton.onclick = function(e) {
-                const action = e.isTrigger ? 'KeyboardShortcut_UnsureReason_Option=unsure-button-' + $(this).attr('id')
+                const action = e.isTrigger ? 'KeyboardShortcut_UnsureReason_Option=' + $(this).attr('id')
                     : 'Click=UnsureReason_Option=' + $(this).attr('id');
                 svv.tracker.push(action);
                 _setUnsureReason($(this).attr('id'));
             };
         }
 
-        function deselectReasonButtons() {
-            $disagreeReasonButtons.removeClass('chosen');
-            $unsureReasonButtons.removeClass('chosen');
-            menuUI.disagreeReasonTextBox.removeClass('chosen');
-            menuUI.unsureReasonTextBox.removeClass('chosen');
-        }
-
         // Log clicks to the three text boxes.
         menuUI.optionalCommentTextBox.click(function(e) {
             menuUI.optionalCommentTextBox.focus();
-            const action = e.isTrigger ? 'Keyboard=AgreeCommentTextbox': 'Click=AgreeCommentTextbox';
+            const action = e.isTrigger ? 'KeyboardShortcut=AgreeCommentTextbox': 'Click=AgreeCommentTextbox';
             svv.tracker.push(action);
         });
         menuUI.disagreeReasonTextBox.click(function(e) {
-            deselectReasonButtons();
             menuUI.disagreeReasonTextBox.focus();
-            const action = e.isTrigger ? 'Keyboard=DisagreeReasonTextbox': 'Click=DisagreeReasonTextbox';
+            const action = e.isTrigger ? 'KeyboardShortcut=DisagreeReasonTextbox': 'Click=DisagreeReasonTextbox';
             svv.tracker.push(action);
         });
         menuUI.unsureReasonTextBox.click(function(e) {
-            deselectReasonButtons();
             menuUI.unsureReasonTextBox.focus();
-            const action = e.isTrigger ? 'Keyboard=UnsureReasonTextbox': 'Click=UnsureReasonTextbox';
+            const action = e.isTrigger ? 'KeyboardShortcut=UnsureReasonTextbox': 'Click=UnsureReasonTextbox';
             svv.tracker.push(action);
         });
 

--- a/public/javascripts/SVValidate/src/menu/RightMenu.js
+++ b/public/javascripts/SVValidate/src/menu/RightMenu.js
@@ -84,17 +84,21 @@ function RightMenu(menuUI) {
         // Add onclick for disagree and unsure reason buttons.
         for (const reasonButton of $disagreeReasonButtons) {
             reasonButton.onclick = function(e) {
-                const action = e.isTrigger ? 'KeyboardShortcut_DisagreeReason_Option=' + $(this).attr('id')
-                    : 'Click=DisagreeReason_Option=' + $(this).attr('id');
-                svv.tracker.push(action);
+                if (e.isTrigger) {
+                    svv.tracker.push('KeyboardShortcut_DisagreeReason_Option=' + $(this).attr('id'));
+                } else {
+                    svv.tracker.push('Click=DisagreeReason_Option=' + $(this).attr('id'));
+                }
                 _setDisagreeReason($(this).attr('id'));
             };
         }
         for (const reasonButton of $unsureReasonButtons) {
             reasonButton.onclick = function(e) {
-                const action = e.isTrigger ? 'KeyboardShortcut_UnsureReason_Option=' + $(this).attr('id')
-                    : 'Click=UnsureReason_Option=' + $(this).attr('id');
-                svv.tracker.push(action);
+                if (e.isTrigger) {
+                    svv.tracker.push('KeyboardShortcut_UnsureReason_Option=' + $(this).attr('id'));
+                } else {
+                    svv.tracker.push('Click=UnsureReason_Option=' + $(this).attr('id'));
+                }
                 _setUnsureReason($(this).attr('id'));
             };
         }

--- a/public/javascripts/SVValidate/src/util/ConstantsValidate.js
+++ b/public/javascripts/SVValidate/src/util/ConstantsValidate.js
@@ -237,5 +237,14 @@ function defineValidateConstants() {
                 }
             }
         }
+        // Append button numbers to tooltipText.
+        for (const labelType in svv.reasonButtonInfo) {
+            for (const buttonId in svv.reasonButtonInfo[labelType]) {
+                const buttonInfo = svv.reasonButtonInfo[labelType][buttonId];
+                // Extract the number from the button ID (e.g., "no-button-1" -> "1").
+                const buttonNumber = buttonId.split('-').pop();
+                buttonInfo.tooltipText += ` (${buttonNumber})`;
+            }
+        }
     }
 }


### PR DESCRIPTION
Resolves #3639 

- Added additional cases to handle (1,2,3) option choices for agree, disagree, unsure options under documentKeyDown function. if there are only 2 options, 3 will go to the comment box.
- c,4 key deselects the other options and go to the input box.
- Implemented keydownListener handlers for the escape key as it was not being recognized within input element.
- Added numbers to corresponding tooltips to help guide users to shortcuts.
- Added attributes to unsure disagree options button to keep track they have the defaultOption.

##### Before/After screenshots (if applicable)

https://github.com/user-attachments/assets/e1db2099-2609-49ec-b706-5d62482fc5d0


https://github.com/user-attachments/assets/4e9c0dc8-17f6-46d7-b631-f42cedbc8124


##### Testing instructions
1. Go to /newValidateBeta page with admin account
2. Go to /validate to make sure it did not affect regular validate page.
3. Click on start mission and then click on one of the agree, disagree, unsure options.
4. Press 1,2,3,4 to choose between options and press escape to see if it unfocuses when on textbox.

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [X] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [X] I've added/updated comments for large or confusing blocks of code.
- [X] I've included before/after screenshots above.
- [X] I've asked for and included translations for any user facing text that was added or modified.
- [X] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure the documentation on [this wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Descriptions-of-Logged-Events) is up to date for the logs you added/updated.
- [X] I've tested on mobile (only needed for validation page).
