### PR TITLE
Showing only validated users on admin page #3802

### DIFF
--- a/app/models/daos/slick/UserDAOSlick.scala
+++ b/app/models/daos/slick/UserDAOSlick.scala
@@ -154,21 +154,21 @@ object UserDAOSlick {
    * (so admin user table isn't too big).
    */
   def usersMinusAnonUsersWithNoLabelsAndNoValidations: Query[UserTable, DBUser, Seq] = { 
-    val anonUsersWithLabels = (for {
-      _user <- userTable
-      _userRole <- userRoleTable if _user.userId === _userRole.userId
-      _role <- roleTable if _userRole.roleId === _role.roleId
-      _label <- LabelTable.labelsWithTutorialAndExcludedUsers if _user.userId === _label.userId
-      if _role.role === "Anonymous"
-    } yield _user).groupBy(x => x).map(_._1)
-
-    val anonUsersWithValidations = (for {
-      _user <- userTable
-      _userRole <- userRoleTable if _user.userId === _userRole.userId
-      _role <- roleTable if _userRole.roleId === _role.roleId
-      _labelValidation <- LabelValidationTable.validationLabels if _user.userId === _labelValidation.userId
-      if _role.role === "Anonymous"
-    } yield _user).groupBy(x => x).map(_._1)
+//    val anonUsersWithLabels = (for {
+//      _user <- userTable
+//      _userRole <- userRoleTable if _user.userId === _userRole.userId
+//      _role <- roleTable if _userRole.roleId === _role.roleId
+//      _label <- LabelTable.labelsWithTutorialAndExcludedUsers if _user.userId === _label.userId
+//      if _role.role === "Anonymous"
+//    } yield _user).groupBy(x => x).map(_._1)
+//
+//    val anonUsersWithValidations = (for {
+//      _user <- userTable
+//      _userRole <- userRoleTable if _user.userId === _userRole.userId
+//      _role <- roleTable if _userRole.roleId === _role.roleId
+//      _labelValidation <- LabelValidationTable.validationLabels if _user.userId === _labelValidation.userId
+//      if _role.role === "Anonymous"
+//    } yield _user).groupBy(x => x).map(_._1)
 
     val otherUsers = for {
       _user <- userTable
@@ -177,7 +177,10 @@ object UserDAOSlick {
       if _role.role =!= "Anonymous"
     } yield _user
 
-    anonUsersWithLabels.union(anonUsersWithValidations) ++ otherUsers
+    // Only returning non-anonymous users:
+    otherUsers
+
+//    anonUsersWithLabels.union(anonUsersWithValidations)// ++ otherUsers
   }
 
   /**


### PR DESCRIPTION
Resolves #3802

Users tab on admin page having issues since merging authentication info into a centralized schema. Quick fix was commenting out code that showed anonymous users, only displaying validated ones.

##### Before/After screenshots (if applicable)
![Before](https://github.com/user-attachments/assets/1a2b1dd0-44a3-45b7-a423-0f09374fb3c2)
![after](https://github.com/user-attachments/assets/c5fca5cd-5d1c-4ea2-8b48-290591a6b319)

##### Testing instructions
1. Sign in as admin
2. Profile -> Admin -> Users
3. See if only verified users are being displayed.

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [X] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [X] I've added/updated comments for large or confusing blocks of code.
- [X] I've included before/after screenshots above.
- [X] I've asked for and included translations for any user facing text that was added or modified.
- [X] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure the documentation on [this wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Descriptions-of-Logged-Events) is up to date for the logs you added/updated.
- [X] I've tested on mobile (only needed for validation page).
