### PR TITLE
Unsure reason selection isn't being kept when undoing a validation

### DIFF
--- a/public/javascripts/SVValidate/src/menu/RightMenu.js
+++ b/public/javascripts/SVValidate/src/menu/RightMenu.js
@@ -183,7 +183,7 @@ function RightMenu(menuUI) {
                 menuUI.disagreeReasonOptions.find(`#${disagreeOption}`).addClass('chosen');
             }
 
-            let unsureOption = label.getProperty('disagreeOption');
+            let unsureOption = label.getProperty('unsureOption');
             $unsureReasonButtons.removeClass('chosen');
             if (unsureOption === 'other') {
                 menuUI.unsureReasonTextBox.addClass('chosen');


### PR DESCRIPTION
Resolves #3801

- Small typo in fetching unsureOption

##### Before/After screenshots (if applicable)

https://github.com/user-attachments/assets/38b7027f-60b8-423d-a4eb-53014a349ab9


https://github.com/user-attachments/assets/cc0e7dcb-3d41-4a02-8499-91bc1913571d


##### Testing instructions
1. Go on newValidateBeta and go to unsure tab and choose an option and click submit
2. Go back and check there is the previous chosen option.

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [X] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [X] I've added/updated comments for large or confusing blocks of code.
- [X] I've included before/after screenshots above.
- [X] I've asked for and included translations for any user facing text that was added or modified.
- [X] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure the documentation on [this wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Descriptions-of-Logged-Events) is up to date for the logs you added/updated.
- [X] I've tested on mobile (only needed for validation page).
