### PR TITLE
Improves query performance for Admin page Users tab

### DIFF
--- a/app/models/daos/slick/UserDAOSlick.scala
+++ b/app/models/daos/slick/UserDAOSlick.scala
@@ -10,7 +10,7 @@ import models.label.LabelValidationTable
 import models.label.LabelTable
 import models.mission.MissionTable
 import models.user.UserTeamTable.userTeams
-import models.user.{RoleTable, TeamTable, User, UserRoleTable, UserStatTable, WebpageActivityTable}
+import models.user.{Role, RoleTable, TeamTable, User, UserRoleTable, UserStatTable, WebpageActivityTable}
 import play.api.db.slick._
 import play.api.db.slick.Config.driver.simple._
 import play.api.Play.current
@@ -150,17 +150,16 @@ object UserDAOSlick {
   val auditTaskTable = TableQuery[AuditTaskTable]
 
   /**
-   * Get all users, excluding anonymous users who haven't placed any labels or have done validations 
-   * (so admin user table isn't too big).
+   * Get all users, excluding anon users who haven't placed any labels or done any validations (to limit table size).
    */
-  def usersMinusAnonUsersWithNoLabelsAndNoValidations: Query[UserTable, DBUser, Seq] = { 
+  def usersMinusAnonUsersWithNoLabelsAndNoValidations: Query[(UserTable, RoleTable), (DBUser, Role), Seq] = {
     val anonUsersWithLabels = (for {
       _user <- userTable
       _userRole <- userRoleTable if _user.userId === _userRole.userId
       _role <- roleTable if _userRole.roleId === _role.roleId
       _label <- LabelTable.labelsWithTutorialAndExcludedUsers if _user.userId === _label.userId
       if _role.role === "Anonymous"
-    } yield _user).groupBy(x => x).map(_._1)
+    } yield (_user, _role)).groupBy(x => x).map(_._1)
 
     val anonUsersWithValidations = (for {
       _user <- userTable
@@ -168,14 +167,14 @@ object UserDAOSlick {
       _role <- roleTable if _userRole.roleId === _role.roleId
       _labelValidation <- LabelValidationTable.validationLabels if _user.userId === _labelValidation.userId
       if _role.role === "Anonymous"
-    } yield _user).groupBy(x => x).map(_._1)
+    } yield (_user, _role)).groupBy(x => x).map(_._1)
 
     val otherUsers = for {
       _user <- userTable
       _userRole <- userRoleTable if _user.userId === _userRole.userId
       _role <- roleTable if _userRole.roleId === _role.roleId
       if _role.role =!= "Anonymous"
-    } yield _user
+    } yield (_user, _role)
 
     anonUsersWithLabels.union(anonUsersWithValidations) ++ otherUsers
   }
@@ -475,10 +474,6 @@ object UserDAOSlick {
     // queries. We are using Scala Map objects instead of Slick b/c Slick doesn't create very efficient queries for this
     // use-case (at least in the old version of Slick that we are using right now).
 
-    // Map(user_id: String -> role: String).
-    val roles =
-      userRoleTable.innerJoin(roleTable).on(_.roleId === _.roleId).map(x => (x._1.userId, x._2.role)).list.toMap
-
     // Map(user_id: String -> team: String).
     val teams =
       userTeams.innerJoin(TeamTable.teams).on(_.teamId === _.teamId).map(x => (x._1.userId, x._2.name)).list.toMap
@@ -512,12 +507,12 @@ object UserDAOSlick {
       UserStatTable.userStats.map { x => (x.userId, x.highQuality) }.list.toMap
 
     // Now left join them all together and put into UserStatsForAdminPage objects.
-    usersMinusAnonUsersWithNoLabelsAndNoValidations.list.map { u =>
-      val ownValidatedCounts = validatedCounts.getOrElse(u.userId, ("", 0, 0))
+    usersMinusAnonUsersWithNoLabelsAndNoValidations.list.map { case (user, role) =>
+      val ownValidatedCounts = validatedCounts.getOrElse(user.userId, ("", 0, 0))
       val ownValidatedTotal = ownValidatedCounts._2
       val ownValidatedAgreed = ownValidatedCounts._3
 
-      val otherValidatedCounts = othersValidatedCounts.getOrElse(u.userId, (0, 0))
+      val otherValidatedCounts = othersValidatedCounts.getOrElse(user.userId, (0, 0))
       val otherValidatedTotal = otherValidatedCounts._1
       val otherValidatedAgreed = otherValidatedCounts._2
 
@@ -530,17 +525,17 @@ object UserDAOSlick {
         else otherValidatedAgreed * 1.0 / otherValidatedTotal
 
       UserStatsForAdminPage(
-        u.userId, u.username, u.email,
-        roles.getOrElse(u.userId, ""),
-        teams.get(u.userId),
-        signUpTimes.get(u.userId).flatten,
-        signInTimesAndCounts.get(u.userId).flatMap(_._1), signInTimesAndCounts.get(u.userId).map(_._2).getOrElse(0),
-        labelCounts.getOrElse(u.userId, 0),
+        user.userId, user.username, user.email,
+        role.role,
+        teams.get(user.userId),
+        signUpTimes.get(user.userId).flatten,
+        signInTimesAndCounts.get(user.userId).flatMap(_._1), signInTimesAndCounts.get(user.userId).map(_._2).getOrElse(0),
+        labelCounts.getOrElse(user.userId, 0),
         ownValidatedTotal,
         ownValidatedAgreedPct,
         otherValidatedTotal,
         otherValidatedAgreedPct,
-        userHighQuality.getOrElse(u.userId, true)
+        userHighQuality.getOrElse(user.userId, true)
       )
     }
   }


### PR DESCRIPTION
Resolves #3726 

I believe that I've found the problematic query that's been slowing down the Users tab on the Admin page. I combined it with another query in order to filter it down, since it was grabbing a row for every user account, instead of just those that we want to show. Took the query time locally from 25 seconds to 5 seconds.

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
