### PR TITLE
Add zoom keyboard shortcuts to Gallery

### DIFF
--- a/public/javascripts/Gallery/src/expandedview/ExpandedView.js
+++ b/public/javascripts/Gallery/src/expandedview/ExpandedView.js
@@ -356,6 +356,32 @@ function ExpandedView(uiModal) {
         }
     }
 
+    // Increment zoom by 1 or to the maximum zoom level (3).
+    function zoomIn() {
+        if (self.open) {
+            sg.tracker.push("KeyboardShortcutZoomIn");
+            const panorama = self.pano.panorama;
+            if (panorama) {
+                const currentZoom = panorama.getZoom();
+                const newZoom = Math.min(3, currentZoom + 1);
+                panorama.setZoom(newZoom);
+            }
+        }
+    }
+
+    // Decrement zoom level by 1 or to the minimum zoom level (1).
+    function zoomOut() {
+        if (self.open) {
+            sg.tracker.push("KeyboardShortcutZoomOut");
+            const panorama = self.pano.panorama;
+            if (panorama) {
+                const currentZoom = panorama.getZoom();
+                const newZoom = Math.max(1, currentZoom - 1);
+                panorama.setZoom(newZoom);
+            }
+        }
+    }
+
     /**
      * Attach any specific event handlers for expanded view contents.
       */
@@ -405,6 +431,9 @@ function ExpandedView(uiModal) {
     self.getProperty = getProperty;
     self.nextLabel = nextLabel;
     self.previousLabel = previousLabel;
+    self.zoomIn = zoomIn;
+    self.zoomOut = zoomOut;
+
 
     return self;
 }

--- a/public/javascripts/Gallery/src/keyboard/Keyboard.js
+++ b/public/javascripts/Gallery/src/keyboard/Keyboard.js
@@ -56,10 +56,9 @@ function Keyboard(expandedView) {
                 case "Z":
                     if (expandedView.open) {
                         if (e.shiftKey) {
-                            zoomOut();
-
+                            expandedView.zoomOut();
                         } else {
-                            zoomIn();
+                            expandedView.zoomIn();
                         }
                     }
                     break;
@@ -69,31 +68,6 @@ function Keyboard(expandedView) {
         }
     }
 
-    // Increment zoom by 1 or to the maximum zoom level (3).
-    function zoomIn() {
-        if (expandedView.open) {
-            sg.tracker.push("KeyboardShortcutZoomIn");
-            const panorama = expandedView.pano.panorama;
-            if (panorama) {
-                const currentZoom = panorama.getZoom();
-                const newZoom = Math.min(3, currentZoom + 1);
-                panorama.setZoom(newZoom);
-            }
-        }
-    }
-
-    // Decrement zoom level  by 1 or to the minimum zoom level (1).
-    function zoomOut() {
-        if (expandedView.open) {
-            sg.tracker.push("KeyboardShortcutZoomOut");
-            const panorama = expandedView.pano.panorama;
-            if (panorama) {
-                const currentZoom = panorama.getZoom();
-                const newZoom = Math.max(1, currentZoom - 1);
-                panorama.setZoom(newZoom);
-            }
-        }
-    }
 
     _init();
 }

--- a/public/javascripts/Gallery/src/keyboard/Keyboard.js
+++ b/public/javascripts/Gallery/src/keyboard/Keyboard.js
@@ -53,8 +53,44 @@ function Keyboard(expandedView) {
                 case "U":
                     expandedView.validationMenu.validateOnClickOrKeyPress("validate-unsure", false, true)()
                     break;
+                case "Z":
+                    if (expandedView.open) {
+                        if (e.shiftKey) {
+                            zoomOut();
+
+                        } else {
+                            zoomIn();
+                        }
+                    }
+                    break;
                 default:
                     break;
+            }
+        }
+    }
+
+    // Increment zoom by 1 or to the maximum zoom level (3).
+    function zoomIn() {
+        if (expandedView.open) {
+            sg.tracker.push("KeyboardShortcutZoomIn");
+            const panorama = expandedView.pano.panorama;
+            if (panorama) {
+                const currentZoom = panorama.getZoom();
+                const newZoom = Math.min(3, currentZoom + 1);
+                panorama.setZoom(newZoom);
+            }
+        }
+    }
+
+    // Decrement zoom level  by 1 or to the minimum zoom level (1).
+    function zoomOut() {
+        if (expandedView.open) {
+            sg.tracker.push("KeyboardShortcutZoomOut");
+            const panorama = expandedView.pano.panorama;
+            if (panorama) {
+                const currentZoom = panorama.getZoom();
+                const newZoom = Math.max(1, currentZoom - 1);
+                panorama.setZoom(newZoom);
             }
         }
     }


### PR DESCRIPTION
Resolves #3798 

- Implemented zoomIn zoomOut functions.
- If the view is in expanded view, fetches current zoom and increment/decrement. 
- Min/Max functions so level stays between 1 and 3. 

##### Before/After screenshots (if applicable)

##### Testing instructions
1. Go to Gallery page and select one of the items.
2. Press Z and shiftZ to see if zoom works in the panorama. Also check it caps out at 3x zoom and does not go less than 1x.

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [X] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [X] I've added/updated comments for large or confusing blocks of code.
- [ ] I've included before/after screenshots above.
- [ ] I've asked for and included translations for any user facing text that was added or modified.
- [X] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure the documentation on [this wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Descriptions-of-Logged-Events) is up to date for the logs you added/updated.
- [ ] I've tested on mobile (only needed for validation page).
