### PR TITLE
Reverts using centralized auth_token tables, now separate by city again

### DIFF
--- a/app/models/daos/slick/DBTableDefinitions.scala
+++ b/app/models/daos/slick/DBTableDefinitions.scala
@@ -44,7 +44,7 @@ object DBTableDefinitions {
 
   case class DBAuthToken (id: Array[Byte], userID: String, expirationTimestamp: Timestamp)
 
-  class AuthTokenTable(tag: Tag) extends Table[DBAuthToken](tag, Some("sidewalk_login"), "auth_tokens") {
+  class AuthTokenTable(tag: Tag) extends Table[DBAuthToken](tag, "auth_tokens") {
     def id = column[Array[Byte]]("id")
     def userID = column[String]("user_id", O.PrimaryKey)
     def expirationTimestamp = column[Timestamp]("expiration_timestamp")


### PR DESCRIPTION
Resolves #3715 

The `auth_tokens` table was centralized along with the rest of authentication in PR #3712, but it wasn't actually useful for this specific table. This PR just reverts that change. Once I verify that password resets are still working as expected on test/prod, I'll delete the `auth_tokens` table that's part of the centralized `sidewalk_login` schema.