### PR TITLE
Add speed limit relevant check for validation

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/Main.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Main.js
@@ -174,7 +174,7 @@ function Main (params) {
         );
 
         // Speed limit
-        svl.speedLimit = new SpeedLimit(svl.panorama, svl.map.getPosition, svl.isOnboarding, null, 'AlwaysDisplay');
+        svl.speedLimit = new SpeedLimit(svl.panorama, svl.map.getPosition, svl.isOnboarding, null, null);
 
         // Survey for select users
         svl.surveyModalContainer = $("#survey-modal-container").get(0);

--- a/public/javascripts/SVLabel/src/SVLabel/Main.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Main.js
@@ -174,7 +174,7 @@ function Main (params) {
         );
 
         // Speed limit
-        svl.speedLimit = new SpeedLimit(svl.panorama, svl.map.getPosition, svl.isOnboarding, null, null);
+        svl.speedLimit = new SpeedLimit(svl.panorama, svl.map.getPosition, svl.isOnboarding, null, 'AlwaysDisplay');
 
         // Survey for select users
         svl.surveyModalContainer = $("#survey-modal-container").get(0);

--- a/public/javascripts/SVLabel/src/SVLabel/Main.js
+++ b/public/javascripts/SVLabel/src/SVLabel/Main.js
@@ -174,7 +174,7 @@ function Main (params) {
         );
 
         // Speed limit
-        svl.speedLimit = new SpeedLimit(svl.panorama, svl.map.getPosition, svl.isOnboarding, null);
+        svl.speedLimit = new SpeedLimit(svl.panorama, svl.map.getPosition, svl.isOnboarding, null, null);
 
         // Survey for select users
         svl.surveyModalContainer = $("#survey-modal-container").get(0);

--- a/public/javascripts/SVValidate/src/Main.js
+++ b/public/javascripts/SVValidate/src/Main.js
@@ -159,6 +159,9 @@ function Main (param) {
     function _init() {
         svv.util = {};
         svv.util.properties = {};
+
+        const labelType = param.labelList[0].getAuditProperty('labelType');
+
         if (svv.newValidateBeta) svv.rightMenu = new RightMenu(svv.ui.newValidateBeta);
         svv.util.properties.panorama = new PanoProperties();
 
@@ -183,7 +186,7 @@ function Main (param) {
                 svv.keyboard = new Keyboard(svv.ui.validation);
             }
             svv.labelVisibilityControl = new LabelVisibilityControl();
-            svv.speedLimit = new SpeedLimit(svv.panorama.getPanorama(), svv.panorama.getPosition, () => false, svv.panoramaContainer);
+            svv.speedLimit = new SpeedLimit(svv.panorama.getPanorama(), svv.panorama.getPosition, () => false, svv.panoramaContainer, labelType);
             svv.zoomControl = new ZoomControl();
         }
 
@@ -244,8 +247,6 @@ function Main (param) {
             delay: { "show": 500, "hide": 100 },
             html: true
         });
-
-        const labelType = param.labelList[0].getAuditProperty('labelType');
 
         const missionStartTutorial = new MissionStartTutorial('validate', labelType, { nLabels: param.mission.labels_validated }, svv, param.language);
 

--- a/public/javascripts/common/SpeedLimit.js
+++ b/public/javascripts/common/SpeedLimit.js
@@ -139,7 +139,7 @@ function SpeedLimit(panorama, coords, isOnboarding, panoContainer, labelType) {
             const overpassResp = await fetch(
                 `https://overpass-api.de/api/interpreter?data=${encodeURIComponent(overpassQuery)}`
             );
-    
+
             const overpassRespJson = await overpassResp.json();
             const closestRoad = findClosestRoad(overpassRespJson, lat, lng);
             const result = {

--- a/public/javascripts/common/SpeedLimit.js
+++ b/public/javascripts/common/SpeedLimit.js
@@ -169,7 +169,7 @@ function SpeedLimit(panorama, coords, isOnboarding, panoContainer, labelType) {
 
         // Labels in which speed limit is necessary context for validation.
         // Speed limit will not display for other labels.
-        const speedLimitRelevantLabels = ['NoCurbRamp']
+        const speedLimitRelevantLabels = ['AlwaysDisplay', 'NoCurbRamp']
 
         const speedLimitRelevant = speedLimitRelevantLabels.includes(labelType)
 

--- a/public/javascripts/common/SpeedLimit.js
+++ b/public/javascripts/common/SpeedLimit.js
@@ -169,10 +169,10 @@ function SpeedLimit(panorama, coords, isOnboarding, panoContainer, labelType) {
 
         // Labels in which speed limit is necessary context for validation.
         // Speed limit will not display for other labels.
-        // 'AlwaysDisplay' is a placeholder for when we want to display the speed limit, regardless of label.
-        const speedLimitRelevantLabels = ['AlwaysDisplay', 'NoCurbRamp']
+        const speedLimitRelevantLabels = ['NoCurbRamp']
 
-        const speedLimitRelevant = speedLimitRelevantLabels.includes(labelType)
+        // If labelType is null/undefined (not provided), the speed limit will be displayed by default.
+        const speedLimitRelevant = !labelType || speedLimitRelevantLabels.includes(labelType)
 
         // If user is validating a label that doesn't require speed limit context, hide the speed limit.
         if (!speedLimitRelevant) {

--- a/public/javascripts/common/SpeedLimit.js
+++ b/public/javascripts/common/SpeedLimit.js
@@ -8,7 +8,7 @@
  * @returns {SpeedLimit} SpeedLimit object with updateSpeedLimit function, container, speedLimit object with
  * number and sub (units, e.g. 'mph'), speedLimitVisible boolean.
  */
-function SpeedLimit(panorama, coords, isOnboarding, panoContainer) {
+function SpeedLimit(panorama, coords, isOnboarding, panoContainer, labelType) {
     const ROAD_HIGHWAY_TYPES = [
         'motorway',
         'trunk',
@@ -171,8 +171,7 @@ function SpeedLimit(panorama, coords, isOnboarding, panoContainer) {
         // Speed limit will not display for other labels.
         const speedLimitRelevantLabels = ['NoCurbRamp']
 
-        const currentLabel = svl.ribbon.getStatus('mode')
-        const speedLimitRelevant = speedLimitRelevantLabels.includes(currentLabel)
+        const speedLimitRelevant = speedLimitRelevantLabels.includes(labelType)
 
         if (!speedLimitRelevant) {
             self.speedLimitVisible = false

--- a/public/javascripts/common/SpeedLimit.js
+++ b/public/javascripts/common/SpeedLimit.js
@@ -32,8 +32,8 @@ function SpeedLimit(panorama, coords, isOnboarding, panoContainer, labelType) {
 
     function _init() {
         if (typeof(panoContainer) !== "undefined" && panoContainer !== null) {
-            prefetchLabels()
-            panoContainer.setLabelsUpdateCallback(prefetchLabels)
+            prefetchLabels();
+            panoContainer.setLabelsUpdateCallback(prefetchLabels);
         }
 
         self.container = document.getElementById('speed-limit-sign');
@@ -41,7 +41,7 @@ function SpeedLimit(panorama, coords, isOnboarding, panoContainer, labelType) {
             number: '',
             sub: ''
         };
-        self.speedLimitVisible = false
+        self.speedLimitVisible = false;
         updateSpeedLimit();
 
         // Listen for position changes.
@@ -70,7 +70,7 @@ function SpeedLimit(panorama, coords, isOnboarding, panoContainer, labelType) {
             el.type === 'way' && el.tags && el.tags.highway && ROAD_HIGHWAY_TYPES.includes(el.tags.highway)
         );
 
-        const point = turf.point([lat, lon])
+        const point = turf.point([lat, lon]);
         let closestRoad = null;
         let minDistance = Infinity;
 
@@ -96,7 +96,7 @@ function SpeedLimit(panorama, coords, isOnboarding, panoContainer, labelType) {
         cache = {};
 
         // Get the labels from the pano container and prefetch them.
-        const labelsToPrefetch = panoContainer.getLabels()
+        const labelsToPrefetch = panoContainer.getLabels();
         for (const label of labelsToPrefetch) {
             const cameraLat = label.getAuditProperty("cameraLat");
             const cameraLng = label.getAuditProperty("cameraLng");
@@ -116,9 +116,9 @@ function SpeedLimit(panorama, coords, isOnboarding, panoContainer, labelType) {
      * @returns Object that contains json response and calculated closest road
      */
     async function queryClosestRoadForCoords(lat, lng, shouldCache, label) {
-        const cacheKey = label === null ? (panoContainer === null ? "" : panoContainer.getCurrentLabel().getAuditProperty("gsvPanoramaId")) : label.getAuditProperty("gsvPanoramaId")
+        const cacheKey = label === null ? (panoContainer === null ? "" : panoContainer.getCurrentLabel().getAuditProperty("gsvPanoramaId")) : label.getAuditProperty("gsvPanoramaId");
         if (cacheKey in cache) {
-            return await cache[cacheKey]
+            return await cache[cacheKey];
         }
 
         // Get nearby roads and their respective information from the overpass API.
@@ -134,7 +134,7 @@ function SpeedLimit(panorama, coords, isOnboarding, panoContainer, labelType) {
             ::id = id(),
             code = t['ISO3166-1'];
         out tags;
-        `
+        `;
         const promise = (async () => {
             const overpassResp = await fetch(
                 `https://overpass-api.de/api/interpreter?data=${encodeURIComponent(overpassQuery)}`
@@ -147,7 +147,7 @@ function SpeedLimit(panorama, coords, isOnboarding, panoContainer, labelType) {
                 closestRoad
             };
             return result;
-        })()
+        })();
 
         if (shouldCache) {
             cache[cacheKey] = promise;
@@ -162,60 +162,60 @@ function SpeedLimit(panorama, coords, isOnboarding, panoContainer, labelType) {
     async function positionChange() {
         // If user is in the onboarding/tutorial mission, we can skip getting the speed limit and hide the sign.
         if (isOnboarding()) {
-            self.speedLimitVisible = false
-            updateSpeedLimit()
-            return
+            self.speedLimitVisible = false;
+            updateSpeedLimit();
+            return;
         }
 
         // Labels in which speed limit is necessary context for validation.
         // Speed limit will not display for other labels.
-        const speedLimitRelevantLabels = ['NoCurbRamp']
+        const speedLimitRelevantLabels = ['NoCurbRamp'];
 
         // If labelType is null/undefined (not provided), the speed limit will be displayed by default.
-        const speedLimitRelevant = !labelType || speedLimitRelevantLabels.includes(labelType)
+        const speedLimitRelevant = !labelType || speedLimitRelevantLabels.includes(labelType);
 
         // If user is validating a label that doesn't require speed limit context, hide the speed limit.
         if (!speedLimitRelevant) {
-            self.speedLimitVisible = false
-            updateSpeedLimit()
-            return
+            self.speedLimitVisible = false;
+            updateSpeedLimit();
+            return;
         }
 
         // Get the current position.
-        const { lat, lng } = coords()
+        const { lat, lng } = coords();
         // Test coords here if someone finds them useful.
-        // const lat = 47.6271486
-        // const lng = -122.3423263
+        // const lat = 47.6271486;
+        // const lng = -122.3423263;
 
-        const queryResp = await queryClosestRoadForCoords(lat, lng, false, null)
-        const closestRoad = queryResp.closestRoad
+        const queryResp = await queryClosestRoadForCoords(lat, lng, false, null);
+        const closestRoad = queryResp.closestRoad;
 
         // Fallback units should be kilometers per hour by default.
-        let fallbackUnits = 'km/h'
+        let fallbackUnits = 'km/h';
 
         // Get the country code of the current location to set the speed limit indicator design and fallback units.
-        const countryElements = queryResp.json.elements.filter((el) => el.type === 'country')
+        const countryElements = queryResp.json.elements.filter((el) => el.type === 'country');
         if (countryElements.length > 0) {
-            const countryCode = countryElements[0].tags.code
+            const countryCode = countryElements[0].tags.code;
 
             // Set proper design.
             if (countryCode === 'US' || countryCode === 'CA') {
-                self.container.setAttribute('data-design-style', 'us-canada')
+                self.container.setAttribute('data-design-style', 'us-canada');
             } else {
-                self.container.setAttribute('data-design-style', 'non-us-canada')
+                self.container.setAttribute('data-design-style', 'non-us-canada');
             }
 
             // Set mph for fallback units if US or UK.
             if (countryCode === 'US' || countryCode === 'UK') {
-                fallbackUnits = 'mph'
+                fallbackUnits = 'mph';
             }
         }
 
         // Extract speed limit info from closest road.
         if (closestRoad !== null && closestRoad.tags['maxspeed']) {
-            const splitMaxspeed = closestRoad.tags['maxspeed'].split(' ')
-            const number = splitMaxspeed.shift()
-            let sub = splitMaxspeed.join(' ')
+            const splitMaxspeed = closestRoad.tags['maxspeed'].split(' ');
+            const number = splitMaxspeed.shift();
+            let sub = splitMaxspeed.join(' ');
             if (sub.trim().length === 0) {
                 sub = fallbackUnits;
             }
@@ -223,11 +223,11 @@ function SpeedLimit(panorama, coords, isOnboarding, panoContainer, labelType) {
                 number,
                 sub
             };
-            self.speedLimitVisible = true
+            self.speedLimitVisible = true;
         } else {
-            self.speedLimitVisible = false
+            self.speedLimitVisible = false;
         }
-        updateSpeedLimit()
+        updateSpeedLimit();
     }
 
     _init();

--- a/public/javascripts/common/SpeedLimit.js
+++ b/public/javascripts/common/SpeedLimit.js
@@ -169,10 +169,12 @@ function SpeedLimit(panorama, coords, isOnboarding, panoContainer, labelType) {
 
         // Labels in which speed limit is necessary context for validation.
         // Speed limit will not display for other labels.
+        // 'AlwaysDisplay' is a placeholder for when we want to display the speed limit, regardless of label.
         const speedLimitRelevantLabels = ['AlwaysDisplay', 'NoCurbRamp']
 
         const speedLimitRelevant = speedLimitRelevantLabels.includes(labelType)
 
+        // If user is validating a label that doesn't require speed limit context, hide the speed limit.
         if (!speedLimitRelevant) {
             self.speedLimitVisible = false
             updateSpeedLimit()

--- a/public/javascripts/common/SpeedLimit.js
+++ b/public/javascripts/common/SpeedLimit.js
@@ -167,6 +167,19 @@ function SpeedLimit(panorama, coords, isOnboarding, panoContainer) {
             return
         }
 
+        // Labels in which speed limit is necessary context for validation.
+        // Speed limit will not display for other labels.
+        const speedLimitRelevantLabels = ['NoCurbRamp']
+
+        const currentLabel = svl.ribbon.getStatus('mode')
+        const speedLimitRelevant = speedLimitRelevantLabels.includes(currentLabel)
+
+        if (!speedLimitRelevant) {
+            self.speedLimitVisible = false
+            updateSpeedLimit()
+            return
+        }
+
         // Get the current position.
         const { lat, lng } = coords()
         // Test coords here if someone finds them useful.


### PR DESCRIPTION
Resolves #3670 

Problem: The speed limit display in the validation view is irrelevant for some labels. We want to make it only display for certain labels (as of now, only `NoCurbRamp`).

Fix: Pass in label type to `SpeedLimit.js`, which now has a list of speed limit-relevant labels. It will hide the speed limit for all labels not included in this list. 
For the 'label' view, since we always want to display the speed limit, I have added the tag `AlwaysDisplay` as a label type, and the SVLabel/main will just pass in `AlwaysDisplay` as its label type. 
Question: Is there a more elegant way to do this? Instead of `AlwaysDisplay`, should it just be `null`?

Note - Since this is an edit to the "Validation" page, normally it would also apply to mobile. However, speed limit is, by default, hidden on mobile. See `if (!isMobile()) {` block on line 181 of `public/javascripts/SVValidate/src/Main.js`

##### Before/After screenshots (if applicable)
Before:
![image](https://github.com/user-attachments/assets/f22609f7-32dc-418a-a9bb-f2f7aa427da4)
![image](https://github.com/user-attachments/assets/519b3c68-7aac-4cfe-b5ea-2aaa276e5467)

After:
![image](https://github.com/user-attachments/assets/6dff6c6c-08b4-47b9-8855-c62a56a1b5bb)
![image](https://github.com/user-attachments/assets/1d85b517-6a9f-4750-af44-df082316e8f2)


##### Testing instructions
1. Testing this is tricky, since (in my experience), very few roads have speed limits that get retrieved successfully. Because of this, they do not display speed limit by default. 
2. To make them always display a speed limit, we need to change the `else` in line 225 of `SpeedLimit.js`
3. Set the field `self.speedLimitVisible = true`. This will make it display an empty speed limit box by default. 
4. If you want to get fancy like I did in my screenshots, you can add in 
`self.speedLimit = {
         number: 'TEST'
  };`
  To display a speed limit in the box. 
5. Boot up localhost and head to the validate page.
6. Observe a non-"Missing curb ramp" label. The speed limit box that says 'TEST' should **not** be there. 
7. Refresh the page until you encounter a "Missing curb ramp" label type. The speed limit box that says 'TEST' **should** be there. 


##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
- [NA] I've asked for and included translations for any user facing text that was added or modified.
- [NA] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure the documentation on [this wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Descriptions-of-Logged-Events) is up to date for the logs you added/updated.
- [NA - see note] I've tested on mobile (only needed for validation page).
