### PR TITLE
Add quotation marks around commas in API CSV calls.

### DIFF
--- a/app/formats/json/APIFormats.scala
+++ b/app/formats/json/APIFormats.scala
@@ -76,12 +76,12 @@ object APIFormats {
     val coordinates: Array[Coordinate] = n.geom.getCoordinates
     val coordStr: String = s""""[${coordinates.map(c => s"(${c.x},${c.y})").mkString(",")}]""""
     if (n.coverage > 0.0D) {
-      s"""${n.name.replace(",", "\",\"")},${n.regionID},${n.score},$n.coordStr,${n.coverage},${n.attributeScores(0)},""" +
+      s""""${n.name}",${n.regionID},${n.score},$n.coordStr,${n.coverage},${n.attributeScores(0)},""" +
         s"${n.attributeScores(1)},${n.attributeScores(2)},${n.attributeScores(3)},${n.significanceScores(0)}," +
         s"${n.significanceScores(1)},${n.significanceScores(2)},${n.significanceScores(3)}," +
         s"${n.avgImageCaptureDate.map(_.toString).getOrElse("NA")},${n.avgLabelDate.map(_.toString).getOrElse("NA")}"
     } else {
-      s"""${n.name.replace(",", "\",\"")},${n.regionID},NA,$coordStr,0.0,NA,NA,NA,NA,${n.significanceScores(0)},""" +
+      s""""${n.name}",${n.regionID},NA,$coordStr,0.0,NA,NA,NA,NA,${n.significanceScores(0)},""" +
         s"${n.significanceScores(1)},${n.significanceScores(2)},${n.significanceScores(3)},NA,NA"
     }
   }
@@ -145,7 +145,7 @@ object APIFormats {
   }
 
   def globalAttributeToCSVRow(a: GlobalAttributeForAPI): String = {
-    s"""${a.globalAttributeId},${a.labelType},${a.streetEdgeId},${a.osmStreetId},""" + s"""${a.neighborhoodName.replace(",", "\",\"")}""" + s""",""" +
+    s"""${a.globalAttributeId},${a.labelType},${a.streetEdgeId},${a.osmStreetId},"${a.neighborhoodName}",""" +
       s"${a.lat},${a.lng},${a.avgImageCaptureDate},${a.avgLabelDate},${a.severity.getOrElse("NA")},${a.temporary}," +
       s"""${a.agreeCount},${a.disagreeCount},${a.unsureCount},${a.labelCount},"[${a.usersList.mkString(",")}]""""
   }
@@ -189,7 +189,7 @@ object APIFormats {
 
   def globalAttributeWithLabelToCSVRow(l: GlobalAttributeWithLabelForAPI): String = {
     s"${l.globalAttributeId},${l.labelType},${l.attributeSeverity.getOrElse("NA")},${l.attributeTemporary}," +
-      s"""${l.streetEdgeId},${l.osmStreetId},""" + s"""${l.neighborhoodName.replace(",", "\",\"")},""" + s"""${l.labelId},${l.gsvPanoramaId},""" +
+      s"""${l.streetEdgeId},${l.osmStreetId},"${l.neighborhoodName}",${l.labelId},${l.gsvPanoramaId},""" +
       s"${l.attributeLatLng._1},${l.attributeLatLng._2},${l.labelLatLng._1},${l.labelLatLng._2}," +
       s"${l.pov.heading},${l.pov.pitch},${l.pov.zoom},${l.canvasXY.x},${l.canvasXY.y}," +
       s"""${LabelPointTable.canvasWidth},${LabelPointTable.canvasHeight},"${l.gsvUrl}",${l.imageLabelDates._1},""" +
@@ -246,7 +246,7 @@ object APIFormats {
   def rawLabelMetadataToCSVRow(l: LabelAllMetadata): String = {
     s"${l.labelId},${l.geom.lat},${l.geom.lng},${l.userId},${l.panoId},${l.labelType},${l.severity.getOrElse("NA")}," +
       s""""[${l.tags.mkString(",")}]",${l.temporary},"${l.description.getOrElse("NA").replace("\"", "\"\"")}",""" +
-      s"${l.timeCreated},${l.streetEdgeId},${l.osmStreetId},${l.neighborhoodName.replace(",", "\",\"")},${l.validationInfo.correct.getOrElse("NA")}," +
+      s"${l.timeCreated},${l.streetEdgeId},${l.osmStreetId}," + s""""${l.neighborhoodName}"""" + s",${l.validationInfo.correct.getOrElse("NA")}," +
       s"${l.validationInfo.agreeCount},${l.validationInfo.disagreeCount},${l.validationInfo.unsureCount}," +
       s""""[${l.validations.map(v => s"{user_id: ${v._1}, validation: ${LabelValidationTable.validationOptions(v._2)}")}]",""" +
       s"${l.auditTaskId},${l.missionId},${l.imageCaptureDate},${l.pov.heading},${l.pov.pitch},${l.pov.zoom}," +

--- a/app/formats/json/APIFormats.scala
+++ b/app/formats/json/APIFormats.scala
@@ -246,7 +246,7 @@ object APIFormats {
   def rawLabelMetadataToCSVRow(l: LabelAllMetadata): String = {
     s"${l.labelId},${l.geom.lat},${l.geom.lng},${l.userId},${l.panoId},${l.labelType},${l.severity.getOrElse("NA")}," +
       s""""[${l.tags.mkString(",")}]",${l.temporary},"${l.description.getOrElse("NA").replace("\"", "\"\"")}",""" +
-      s"${l.timeCreated},${l.streetEdgeId},${l.osmStreetId},${l.neighborhoodName},${l.validationInfo.correct.getOrElse("NA")}," +
+      s"${l.timeCreated},${l.streetEdgeId},${l.osmStreetId},${l.neighborhoodName.replace(",", "\",\"")},${l.validationInfo.correct.getOrElse("NA")}," +
       s"${l.validationInfo.agreeCount},${l.validationInfo.disagreeCount},${l.validationInfo.unsureCount}," +
       s""""[${l.validations.map(v => s"{user_id: ${v._1}, validation: ${LabelValidationTable.validationOptions(v._2)}")}]",""" +
       s"${l.auditTaskId},${l.missionId},${l.imageCaptureDate},${l.pov.heading},${l.pov.pitch},${l.pov.zoom}," +

--- a/app/formats/json/APIFormats.scala
+++ b/app/formats/json/APIFormats.scala
@@ -76,12 +76,12 @@ object APIFormats {
     val coordinates: Array[Coordinate] = n.geom.getCoordinates
     val coordStr: String = s""""[${coordinates.map(c => s"(${c.x},${c.y})").mkString(",")}]""""
     if (n.coverage > 0.0D) {
-      s""""${n.name}",${n.regionID},${n.score},$n.coordStr,${n.coverage},${n.attributeScores(0)},""" +
+      s"""${n.name.replace(",", "\",\"")},${n.regionID},${n.score},$n.coordStr,${n.coverage},${n.attributeScores(0)},""" +
         s"${n.attributeScores(1)},${n.attributeScores(2)},${n.attributeScores(3)},${n.significanceScores(0)}," +
         s"${n.significanceScores(1)},${n.significanceScores(2)},${n.significanceScores(3)}," +
         s"${n.avgImageCaptureDate.map(_.toString).getOrElse("NA")},${n.avgLabelDate.map(_.toString).getOrElse("NA")}"
     } else {
-      s""""${n.name}",${n.regionID},NA,$coordStr,0.0,NA,NA,NA,NA,${n.significanceScores(0)},""" +
+      s"""${n.name.replace(",", "\",\"")},${n.regionID},NA,$coordStr,0.0,NA,NA,NA,NA,${n.significanceScores(0)},""" +
         s"${n.significanceScores(1)},${n.significanceScores(2)},${n.significanceScores(3)},NA,NA"
     }
   }
@@ -145,7 +145,7 @@ object APIFormats {
   }
 
   def globalAttributeToCSVRow(a: GlobalAttributeForAPI): String = {
-    s"""${a.globalAttributeId},${a.labelType},${a.streetEdgeId},${a.osmStreetId},"${a.neighborhoodName}",""" +
+    s"""${a.globalAttributeId},${a.labelType},${a.streetEdgeId},${a.osmStreetId},""" + s"""${a.neighborhoodName.replace(",", "\",\"")}""" + s""",""" +
       s"${a.lat},${a.lng},${a.avgImageCaptureDate},${a.avgLabelDate},${a.severity.getOrElse("NA")},${a.temporary}," +
       s"""${a.agreeCount},${a.disagreeCount},${a.unsureCount},${a.labelCount},"[${a.usersList.mkString(",")}]""""
   }
@@ -189,7 +189,7 @@ object APIFormats {
 
   def globalAttributeWithLabelToCSVRow(l: GlobalAttributeWithLabelForAPI): String = {
     s"${l.globalAttributeId},${l.labelType},${l.attributeSeverity.getOrElse("NA")},${l.attributeTemporary}," +
-      s"""${l.streetEdgeId},${l.osmStreetId},"${l.neighborhoodName}",${l.labelId},${l.gsvPanoramaId},""" +
+      s"""${l.streetEdgeId},${l.osmStreetId},""" + s"""${l.neighborhoodName.replace(",", "\",\"")},""" + s"""${l.labelId},${l.gsvPanoramaId},""" +
       s"${l.attributeLatLng._1},${l.attributeLatLng._2},${l.labelLatLng._1},${l.labelLatLng._2}," +
       s"${l.pov.heading},${l.pov.pitch},${l.pov.zoom},${l.canvasXY.x},${l.canvasXY.y}," +
       s"""${LabelPointTable.canvasWidth},${LabelPointTable.canvasHeight},"${l.gsvUrl}",${l.imageLabelDates._1},""" +


### PR DESCRIPTION
Resolves #3756 

Added quotation marks around name field in the rawData to CSV API call.

##### Before/After screenshots (if applicable)
Before (The neighborhood is called School , 5):
<img width="957" alt="image" src="https://github.com/user-attachments/assets/32bd86e7-9012-4a37-869f-cd163a12da12" />
After:
<img width="959" alt="image" src="https://github.com/user-attachments/assets/5ac5bc64-a669-43bc-90e2-8d0ff0aa18a9" />



##### Testing instructions
1. Check the Label Map to find the coordinates of an area populated with labels. Choose a min/max lat and min/max long.
2. Use this URL to fetch the csv file from the API:
localhost:9000/v2/rawLabels?lat1=<x1>&lng1=<y1>&lat2=<x2>&lng2=<y2>&filetype=csv
3. check that the CSV file matches with correct formatting for any row with neighborhood name that contains ,

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've included before/after screenshots above.