### PR TITLE
removed angle overlap in angleToDirection and normalized targetAngle

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/navigation/Compass.js
+++ b/public/javascripts/SVLabel/src/SVLabel/navigation/Compass.js
@@ -52,7 +52,7 @@ function Compass (svl, mapService, taskContainer, uiCompass) {
         var argTarget;
         argTarget = (argmin < (coordinates.length - 1)) ? argmin + 1 : geometry.coordinates.length - 1;
 
-        return util.math.toDegrees(Math.atan2(coordinates[argTarget][0] - latlng.lng, coordinates[argTarget][1] - latlng.lat));
+        return ((util.math.toDegrees(Math.atan2(coordinates[argTarget][0] - latlng.lng, coordinates[argTarget][1] - latlng.lat)) + 360) % 360);
     }
 
     /**
@@ -159,7 +159,7 @@ function Compass (svl, mapService, taskContainer, uiCompass) {
     function _getCompassAngle () {
         var heading = mapService.getPov().heading;
         var targetAngle = getTargetAngle();
-        return (heading - targetAngle) % 360;
+        return ((heading - targetAngle + 360) % 360);
     }
 
     /**
@@ -262,14 +262,13 @@ function Compass (svl, mapService, taskContainer, uiCompass) {
      * @returns {*}
      */
     function _angleToDirection (angle) {
-        angle = (angle + 360) % 360;
         if (angle < 20 || angle > 340)
             return "straight";
         else if (angle >= 20 && angle < 45)
             return "slight-left";
         else if (angle <= 340 && angle > 315)
             return "slight-right";
-        else if (angle >= 35 && angle < 150)
+        else if (angle >= 45 && angle < 150)
             return "left";
         else if (angle <= 315 && angle > 210)
             return "right";


### PR DESCRIPTION
Resolves #3773

To fix the compass message inconsistency, I normalized the targetAngle and removed any overlap with the angle for "slightly left" and "left"

##### Before/After screenshots (if applicable)
Before:
![Screenshot 2025-04-07 at 10 50 22 PM](https://github.com/user-attachments/assets/347b54a8-13fa-489a-8687-e8eb5f48f554)

After:
![Screenshot 2025-04-07 at 10 48 46 PM](https://github.com/user-attachments/assets/e6fc60c5-62ec-42b9-b759-05a236c8c62a)

##### Testing instructions
1. Revert all changes in this PR to original state except changes in _angleToDirection function (remove my edits)
2. Add console.log for heading angle and target angle in the function _getCompassAngle after the respective variables are declared
3. Some streets where you can see this error: http://localhost:9000/explore/street/44336 , http://localhost:9000/explore/street/62878 , http://localhost:9000/explore/street/62877
5. Look to the left relative to the direction you are trying to go (left of the red line)
6. Compass message should be "Go Straight"
7. Add my changes and messages should say Turn Right or Turn Slightly Right
##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've included before/after screenshots above.