### PR TITLE
Increased tooltip timeout for small neighborhoods

### DIFF
--- a/public/javascripts/PSMap/AddNeighborhoodsToMap.js
+++ b/public/javascripts/PSMap/AddNeighborhoodsToMap.js
@@ -201,7 +201,7 @@ function AddNeighborhoodsToMap(map, neighborhoodGeoJSON, completionRates, labelC
                     map.setFeatureState({ source: NEIGHBORHOOD_LAYER_NAME, id: hoveredRegionId }, { hover: false });
                     neighborhoodTooltip.remove();
                     hoveredRegionId = null;
-                }, 200);
+                }, 500);
             }
         });
 


### PR DESCRIPTION
Resolves #3755 

Simply increased tooltip timeout for users to have enough time to hover over the tooltip before it timesout for small cities when zoomed out.

##### Before/After screenshots (if applicable)
After screenshot:

https://github.com/user-attachments/assets/220d9422-0fc6-4a25-885d-dadb357b5300



##### Testing instructions
1. Go to black hawk hills to hover over a small city while being fully zoomed out.

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [X] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [X] I've added/updated comments for large or confusing blocks of code.
- [X] I've included before/after screenshots above.
- [ ] I've asked for and included translations for any user facing text that was added or modified.
- [ ] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure the documentation on [this wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Descriptions-of-Logged-Events) is up to date for the logs you added/updated.
- [ ] I've tested on mobile (only needed for validation page).
