### PR TITLE
Fix gallery sidebar scroll bug

### DIFF
--- a/public/javascripts/Gallery/css/gallery.css
+++ b/public/javascripts/Gallery/css/gallery.css
@@ -46,7 +46,7 @@
 .sidebar {
     padding-left: 10px;
     min-height: calc(100vh - 610px);
-    height: 100%;
+    height: 620px;
     width: 239px;
     grid-row: 1/2;
 }

--- a/public/javascripts/Gallery/src/Main.js
+++ b/public/javascripts/Gallery/src/Main.js
@@ -111,6 +111,9 @@ function Main (params) {
                         // Compute the new location for the top of the sidebar, just above the paging arrows.
                         let navbarHeight = sg.ui.navbar.outerHeight(false);
                         let newTop = cardContainerBottomOffset - sidebarHeightBeforeRelative - navbarHeight;
+                        if(newTop < 0) {
+                            newTop = 0;
+                        }
                         sidebarWrapper.css('top', newTop);
 
                         // Adjust card container margin.


### PR DESCRIPTION
Resolves #123

The issue was before than when calculating the fixed position, at certain moments its relative position to the top was negative. I gave this a min so it could not be negative.

##### Before/After screenshots (if applicable)
Before:
![image](https://github.com/user-attachments/assets/ad0f5cbc-a8e5-4ec2-b02c-f614af1856f2)
If you then scroll up and down you get this bug:
![image](https://github.com/user-attachments/assets/7cd420fe-28ec-41ec-b0e7-6ec1e9afbdd8)

After fix (appearance throughout):
![image](https://github.com/user-attachments/assets/365f2079-1d02-4392-8942-e27007ce04dd)


##### Testing instructions
1. Go to http://localhost:9000/gallery?labelType=CurbRamp&severities=4 (or any other gallery view with limited # of cards)
2. Mess around with the page, make sure that it looks correct throughout many different circumstances

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've included before/after screenshots above.
