### PR TITLE
Fixes neighborhood complete message after every street

### DIFF
--- a/app/controllers/ExploreController.scala
+++ b/app/controllers/ExploreController.scala
@@ -172,7 +172,9 @@ class ExploreController @Inject() (
 
   def getTasksInARoute(userRouteId: Int) = Action.async { implicit request =>
     logger.debug(request.toString) // Added bc scalafmt doesn't like "implicit _" & compiler needs us to use request.
-    exploreService.selectTasksInRoute(userRouteId).map(tasks => Ok(JsArray(tasks.map(Json.toJson(_)))))
+    exploreService
+      .selectTasksInRoute(userRouteId)
+      .map(tasks => Ok(Json.obj("type" -> "FeatureCollection", "features" -> JsArray(tasks.map(Json.toJson(_))))))
   }
 
   /**

--- a/public/javascripts/SVLabel/src/SVLabel/task/TaskContainer.js
+++ b/public/javascripts/SVLabel/src/SVLabel/task/TaskContainer.js
@@ -124,11 +124,11 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
             success: function (result) {
                 var task;
                 var currStreetId = getCurrentTaskStreetEdgeId();
-                for (var i = 0; i < result.length; i++) {
+                for (var i = 0; i < result.features.length; i++) {
                     // Skip the task that we were given to start with so that we don't add a duplicate.
-                    if (result[i].properties.street_edge_id !== currStreetId) {
-                        task = new Task(result[i], false);
-                        if ((result[i].properties.completed)) task.complete();
+                    if (result.features[i].properties.street_edge_id !== currStreetId) {
+                        task = new Task(result.features[i], false);
+                        if ((result.features[i].properties.completed)) task.complete();
                         self._tasks.push(task);
 
                         // If the street was part of the curr mission, add it to the list!
@@ -154,7 +154,7 @@ function TaskContainer (navigationModel, neighborhoodModel, streetViewService, s
     function updateTaskPriorities(updatedPriorities) {
         // Loop through all updatedPriorities and update self._tasks with the new priorities.
         updatedPriorities.forEach(function (newPriority) {
-            const index = self._tasks.findIndex((s) => { return s.getStreetEdgeId() === newPriority.streetEdgeId; });
+            const index = self._tasks.findIndex((s) => { return s.getStreetEdgeId() === newPriority.street_edge_id; });
             self._tasks[index].setProperty('priority', newPriority.priority);
         });
     }


### PR DESCRIPTION
Fixes #3937

Fixes the issue where the Neighborhood Complete screen would show up after every street that you audit, forcing a page refresh each time.

It seems that I updated the /tasks endpoint to produce correctly formatted GeoJSON at some point, but didn't catch the place we use it on the Explore page that assumes that it's in the wrong format :upside_down_face: Fixed this to assume the correct format (and then updated the /routeTasks endpoint to return correctly formatted GeoJSON as well).
