### PR TITLE
Fixes various issues with account creation

### DIFF
--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -397,7 +397,7 @@ class AdminController @Inject() (
               Future.successful(BadRequest("Invalid role"))
             } else {
               authenticationService
-                .setRole(userId, newRole)
+                .updateRole(userId, newRole)
                 .map(_ => {
                   val logText = s"UpdateRole_User=${userId}_Old=${user.role}_New=$newRole"
                   cc.loggingService.insert(request.identity.userId, request.remoteAddress, logText)

--- a/app/models/user/LoginInfoTable.scala
+++ b/app/models/user/LoginInfoTable.scala
@@ -27,8 +27,18 @@ class LoginInfoTable @Inject() (protected val dbConfigProvider: DatabaseConfigPr
 
   val passwordInfo = TableQuery[LoginInfoTableDef]
 
-  def find(email: String): Future[Option[Long]] = {
+  def findByEmail(email: String): Future[Option[Long]] = {
     db.run(passwordInfo.filter(_.providerKey === email).map(_.loginInfoId).result.headOption)
+  }
+
+  /**
+   * Updates the provider key (which is just the user's email address) for a given login info ID.
+   * @param loginInfoId the ID of the login info to update
+   * @param newProviderKey the new provider key (email address) to set
+   * @return A DBIO action that returns the number of rows updated
+   */
+  def updateProviderKey(loginInfoId: Long, newProviderKey: String): DBIO[Int] = {
+    passwordInfo.filter(_.loginInfoId === loginInfoId).map(_.providerKey).update(newProviderKey)
   }
 
   def insert(loginInfo: DBLoginInfo): DBIO[Long] = {

--- a/app/models/user/SidewalkUserTable.scala
+++ b/app/models/user/SidewalkUserTable.scala
@@ -60,7 +60,27 @@ class SidewalkUserTable @Inject() (protected val dbConfigProvider: DatabaseConfi
     db.run(sidewalkUserWithRole.filter(_._3 === email).result.headOption).map(_.map(SidewalkUserWithRole.tupled))
   }
 
-  def insertOrUpdate(newUser: SidewalkUser): DBIO[String] = {
-    (sidewalkUser returning sidewalkUser.map(_.userId)).insertOrUpdate(newUser).map(_.getOrElse(newUser.userId))
+  /**
+   * Updates the username of a user.
+   * @param userId The user ID of the user whose username is to be updated
+   * @param newUsername The new username to set for the user
+   * @return A DBIO action that returns the number of rows updated
+   */
+  def updateUsername(userId: String, newUsername: String): DBIO[Int] = {
+    sidewalkUser.filter(_.userId === userId).map(_.username).update(newUsername)
+  }
+
+  /**
+   * Updates the email of a user. NOTE: MUST be accompanied by updating login_info, handled by AuthenticationService.
+   * @param userId The user ID of the user whose email is to be updated
+   * @param newEmail The new email address to set for the user
+   * @return A DBIO action that returns the number of rows updated
+   */
+  def updateEmail(userId: String, newEmail: String): DBIO[Int] = {
+    sidewalkUser.filter(_.userId === userId).map(_.email).update(newEmail)
+  }
+
+  def insert(newUser: SidewalkUser): DBIO[String] = {
+    (sidewalkUser returning sidewalkUser.map(_.userId)) += newUser
   }
 }

--- a/app/models/user/UserStatTable.scala
+++ b/app/models/user/UserStatTable.scala
@@ -881,7 +881,7 @@ class UserStatTable @Inject() (
   }
 
   /**
-   * Get the entry in the user_stat table fro the given userId if it exists.
+   * Get the entry in the user_stat table for the given userId if it exists.
    *
    * @param userId The userId to look up.
    * @return An optional UserStat object if it exists, otherwise None.
@@ -890,6 +890,11 @@ class UserStatTable @Inject() (
     userStats.filter(_.userId === userId).result.headOption
   }
 
+  /**
+   * Insert a new user_stat entry for the given userId.
+   * @param userId The userId to insert a user_stat entry for
+   * @return DBIO action that returns the number of rows inserted (should be 1)
+   */
   def insert(userId: String): DBIO[Int] = {
     userStats += UserStat(0, userId, 0f, None, highQuality = true, None, 0, None, excluded = false)
   }


### PR DESCRIPTION
Resolves #3939 

Fixes two main issues with account creation.

The first is that we were creating duplicate entries in the `user_login_info` and `user_stat` tables. This is due to the way that we "create" accounts for users when they register. What we actually do is to transfer the anonymous user account that we automatically created for them over to their new login credentials that they provided. This way we can keep the contributions that they made anonymously in that session associated with the new account that they created.

I've fixed this by creating separate flows when creating new accounts vs transferring accounts. New accounts get db inserts, transferred accounts get db updates.

The second problem was, although entries to the `user_role` table were being inserted and then updated (or so it seemed), the entries in those tables were later on vanishing from the table! I don't fully understand the exact mechanisms at play, but I believe that the issue stems from slick's `insertOrUpdate` function not working with auto incrementing keys in the way that I expect. If you do an insert and you provide something for the primary key, the value is ignored (it's standard to just include a 0 or None or something). If you're doing an update, then the primary key is necessary (as you'd expect). If doing `insertOrUpdate`, it turns out that it (silently) fails in very odd ways if you just provide a default value like 0 (I was assuming that the `update` would fail, and it would then do the `insert` as usual.

So the fix was just to rewrite the method that we had for setting the user's role. I had a one-stop shop function that would add a role for the user if they didn't have one, or update their existing entry if one existed. I separated these out into insert and update methods, and they are now called in the appropriate place.

The last thing that I'm going to do is to fix the users in the db that have this issue once this code has been merged. Tested this locally and it works well. Here are the queries, with some explanation for what they do:
```
-- Delete duplicate entries in the user_login_info table. Deleting the older entry, since the newer one would hold
-- the login info provided by the user. The old one would have our fake credentials for anonymous users.
-- Only need to run this once, since it's in the centralized sidewalk_login schema.
DELETE FROM user_login_info 
WHERE user_login_info_id IN (
    SELECT user_login_info_id
    FROM (
        SELECT user_login_info_id,
               ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY user_login_info_id DESC) as rn
        FROM user_login_info
    ) ranked
    WHERE rn > 1
);

-- Delete duplicate entries in the user_stat table. Deleting the older entry for the same reason as above.
-- Need to run this in every city, since the user_stat table exists in every city.
DELETE FROM user_stat 
WHERE user_stat_id IN (
    SELECT user_stat_id
    FROM (
        SELECT user_stat_id,
               ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY user_stat_id DESC) as rn
        FROM user_stat
    ) ranked
    WHERE rn > 1
);

-- Insert missing user_role entries for users that don't have them. Checking the email column tell us 
-- whether they are an anonymous or registered user.
INSERT INTO user_role (user_id, role_id, community_service)
SELECT su.user_id, CASE WHEN su.email LIKE 'anonymous@%' THEN 6 ELSE 1 END, false
FROM sidewalk_user su
LEFT JOIN user_role ur ON su.user_id = ur.user_id
WHERE ur.user_id IS NULL;
```

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure the documentation on [this wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Descriptions-of-Logged-Events) is up to date for the logs you added/updated.
