### PR TITLE
Fixes APS tag not being recorded

### DIFF
--- a/app/service/LabelService.scala
+++ b/app/service/LabelService.scala
@@ -142,7 +142,7 @@ class LabelServiceImpl @Inject() (
   def cleanTagList(tags: Seq[String], labelTypeId: Int): DBIO[Seq[String]] = {
     for {
       validTags: Seq[String] <- selectTagsByLabelTypeId(labelTypeId).map(_.map(_.tag))
-      cleanedTags: Seq[String] = tags.map(_.toLowerCase).distinct.filter(t => validTags.contains(t))
+      cleanedTags: Seq[String] = tags.distinct.filter(t => validTags.contains(t))
       conflictingTags: Seq[String] <- findConflictingTags(cleanedTags.toSet, labelTypeId)
     } yield {
       if (conflictingTags.nonEmpty) {


### PR DESCRIPTION
Fixes #3927

Fixes an issue where the APS (now called tactile-audible button) tag was not being added.

The issue stemmed from code I added in [v7.19.1](https://github.com/ProjectSidewalk/SidewalkWebpage/pull/3530) where I added some checks on the back end to clean tag names before inserting them into the db. What I was trying to solve there were edge cases where the same tag was being added multiple times. But as part of it, I added something I didn't need to: converting the tags to lowercase. Seemed like a good idea at the time, but I forgot that we had one tag that _wasn't_ lowercase in the db: APS.

There's nowhere where we're inputting the wrong case for the tags, so I just removed the call to convert the tags to lowercase. Now we have to strictly match the case in order to add tags, which is probably for the best!

It's rather complicated to update a label to add missing tags like this for a number of reasons:
1. We have to look through the `audit_task_interaction` table for logs indicating that the tag was added (it's a very large table that takes awhile to query on)
2. A user may have added the tag _and then removed it afterwards_, so we'd want to look at the same table again so that we don't add the tags in a place where a user undid the addition themselves
3. We would want to do the same two steps for the ExpertValidate page using the `validation_task_interaction` table
4. Now that we keep track of a label's history, it's more complicated to update the history of the label so that it's coherent if we have to update the label to add the APS tag somewhere in the history

I ran a query on the db to look for how many labels could have been impacted by the tag not being added in the past. It looks like there are a total of 206 logged additions of the APS tag since this bug was introduced (not taking into account situations where the tag was subsequently removed). The cities with more than just a handful of these logs:
- Columbia: 64
- St. Louis: 23
- Burnaby: 34
- Chicago: 56

I'm wondering if it's easier for me to just manually try to validate a number of these labels using ExpertValidate so that I can add missing APS tags after merging the fix? We don't actually have an option to validate individual labels like that, but I can use some workarounds to get to most of them... Thoughts @jonfroehlich?
