### PR TITLE
Adds human readable text for "remember me" functionality

### DIFF
--- a/app/views/authentication/signIn.scala.html
+++ b/app/views/authentication/signIn.scala.html
@@ -26,7 +26,7 @@
             <input type="hidden" name="returnUrl" value="@buildUrlFromQueryString(request.queryString)">
             @b3.email(signInForm("email"), '_hiddenLabel -> Messages("authenticate.email"), 'placeholder -> Messages("authenticate.email"))
             @b3.password(signInForm("password"), '_hiddenLabel -> Messages("authenticate.password"), 'placeholder -> Messages("authenticate.password"), 'pattern -> "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d).*$", 'title -> "Password must contain at least one uppercase letter, one lowercase letter, and one number")
-            @b3.checkbox(signInForm("rememberMe"), '_text -> Messages("remember.me"), 'checked -> true)
+            @b3.checkbox(signInForm("rememberMe"), '_text -> Messages("authenticate.remember.me"), 'checked -> true)
             @b3.submit('class -> "btn btn-lg btn-primary btn-block") { @Messages("navbar.signin") }
         }
         <div>

--- a/app/views/authentication/signInMobile.scala.html
+++ b/app/views/authentication/signInMobile.scala.html
@@ -25,7 +25,7 @@
             <input type="hidden" name="returnUrl" value="@buildUrlFromQueryString(request.queryString)">
             @b3.email(signInForm("email"), '_hiddenLabel -> Messages("authenticate.email"), 'placeholder -> Messages("authenticate.email"))
             @b3.password(signInForm("password"), '_hiddenLabel -> Messages("authenticate.password"), 'placeholder -> Messages("authenticate.password"), 'pattern -> "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d).*$", 'title -> "Password must contain at least one uppercase letter, one lowercase letter, and one number")
-            @b3.checkbox(signInForm("rememberMe"), '_text -> Messages("remember.me"), 'checked -> true)
+            @b3.checkbox(signInForm("rememberMe"), '_text -> Messages("authenticate.remember.me"), 'checked -> true)
             @b3.submit('class -> "btn btn-lg btn-primary btn-block") { @Messages("navbar.signin") }
         }
         <div>

--- a/app/views/common/navbar.scala.html
+++ b/app/views/common/navbar.scala.html
@@ -324,7 +324,7 @@ $(document).ready(function () {
                         <input type="hidden" name="returnUrl" value="@request.uri">
                         @b3.email(forms.SignInForm.form("email"), '_hiddenLabel -> Messages("authenticate.email"), 'placeholder -> Messages("authenticate.email"))
                         @b3.password(forms.SignInForm.form("password"), '_hiddenLabel -> Messages("authenticate.password"), 'placeholder -> Messages("authenticate.password"), 'pattern -> "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d).*$", 'title -> "Password must contain at least one uppercase letter, one lowercase letter, and one number")
-                        @b3.checkbox(forms.SignInForm.form("rememberMe"), '_text -> Messages("remember.me"), 'checked -> true)
+                        @b3.checkbox(forms.SignInForm.form("rememberMe"), '_text -> Messages("authenticate.remember.me"), 'checked -> true)
                         @b3.submit('class -> "btn btn-sm btn-primary btn-block") { @Messages("navbar.signin") }
                     }
                 </div>

--- a/conf/messages/messages.de
+++ b/conf/messages/messages.de
@@ -249,6 +249,7 @@ mobile.validate.leave.feedback = Rückmeldung verfassen
 authenticate.email = E-Mail-Adresse
 authenticate.password = Passwort
 authenticate.submit = Übermitteln
+authenticate.remember.me = Ich möchte angemeldet bleiben
 authenticate.new = Neu dabei? <a href="#" id="form-open-sign-up">Registrieren!</a>
 authenticate.non.member = Kein Mitglied? <a href="{0}">Registrieren Sie sich jetzt</a>
 authenticate.confirm.password = Passwort wiederholen

--- a/conf/messages/messages.en
+++ b/conf/messages/messages.en
@@ -244,6 +244,7 @@ mobile.validate.leave.feedback = Leave Feedback
 authenticate.email = Email address
 authenticate.password = Password
 authenticate.submit = Submit
+authenticate.remember.me = Keep me signed in
 authenticate.new = Are you new? <a href="#" id="form-open-sign-up">Sign up!</a>
 authenticate.non.member = Not a member? <a href="{0}">Sign up now</a>
 authenticate.confirm.password = Confirm password

--- a/conf/messages/messages.es
+++ b/conf/messages/messages.es
@@ -256,6 +256,7 @@ mobile.validate.leave.feedback = Retroalimentación
 authenticate.email = Correo electrónico
 authenticate.password = Contraseña
 authenticate.submit = Enviar
+authenticate.remember.me = Mantenerme conectado
 authenticate.new = ¿Eres nuevo/a? <a href="#" id="form-open-sign-up">¡Regístrate!</a>
 authenticate.non.member = ¿No eres un miembro? <a href="{0}">Regístrate ahora</a>
 authenticate.confirm.password = Confirmar contraseña

--- a/conf/messages/messages.nl
+++ b/conf/messages/messages.nl
@@ -245,6 +245,7 @@ mobile.validate.leave.feedback = Geef feedback
 authenticate.email = Email-adres
 authenticate.password = Wachtwoord
 authenticate.submit = Dien in
+authenticate.remember.me = Houd mij aangemeld
 authenticate.new = Ben je nieuw? <a href="#" id="form-open-sign-up">Nieuw account maken!</a>
 authenticate.non.member = Nog geen account? <a href="{0}">Maak er een</a>
 authenticate.confirm.password = Bevestig wachtwoord

--- a/conf/messages/messages.zh-TW
+++ b/conf/messages/messages.zh-TW
@@ -297,6 +297,7 @@ mobile.validate.leave.feedback = 請給予意見回饋
 authenticate.email = 電子郵件地址
 authenticate.password = 密碼
 authenticate.submit = 送出
+authenticate.remember.me = 保持登入狀態
 authenticate.new = 您是新使用者嗎？ <a href="#" id="form-open-sign-up">請註冊！</a>
 authenticate.non.member = 還不是會員嗎？ <a href="{0}">請註冊</a>
 authenticate.confirm.password = 確認密碼


### PR DESCRIPTION
Resolves #3951

Adds human readable text for the "remember me" functionality. It now reads "Keep me signed in". Added translations for this in every supported language.

##### Before/After screenshots (if applicable)
Before
<img width="497" height="413" alt="image" src="https://github.com/user-attachments/assets/3176bae9-55e9-4fb5-bed5-4d1c675296da" />

After
<img width="497" height="413" alt="image" src="https://github.com/user-attachments/assets/18170019-6160-456f-9e8c-3f4d9b58948f" />

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've included before/after screenshots above.
- [x] I've asked for and included translations for any user facing text that was added or modified.
