### PR TITLE
Cleans up the API docs

### DIFF
--- a/app/controllers/api/CitiesApiController.scala
+++ b/app/controllers/api/CitiesApiController.scala
@@ -55,10 +55,7 @@ class CitiesApiController @Inject() (
    *
    * @return Response in requested format containing city information.
    */
-  def getCities = silhouette.UserAwareAction.async { implicit request =>
-    // Get filetype parameter from request, defaulting to JSON.
-    val filetype: String = request.getQueryString("filetype").getOrElse("json").toLowerCase
-
+  def getCities(filetype: String) = silhouette.UserAwareAction.async { implicit request =>
     // Get city information from ConfigService.
     val cityInfos: Seq[CityInfo] = configService.getAllCityInfo(request.lang)
 
@@ -89,7 +86,7 @@ class CitiesApiController @Inject() (
             Ok(generateGeoJson(cityDetails))
               .withHeaders(
                 "Content-Type"        -> "application/geo+json",
-                "Content-Disposition" -> "attachment; filename=cities.geojson"
+                "Content-Disposition" -> "inline; filename=cities.geojson"
               )
           case _ => // Default to JSON
             Ok(Json.obj("status" -> "OK", "cities" -> cityDetails))

--- a/app/controllers/api/LabelApiController.scala
+++ b/app/controllers/api/LabelApiController.scala
@@ -126,7 +126,7 @@ class LabelApiController @Inject() (
    *
    * @param bbox Bounding box in format "minLng,minLat,maxLng,maxLat"
    * @param labelType Comma-separated list of label types to include
-   * @param tag Comma-separated list of tags to filter by
+   * @param tags Comma-separated list of tags to filter by
    * @param minSeverity Minimum severity score (1-5 scale)
    * @param maxSeverity Maximum severity score (1-5 scale)
    * @param validationStatus Filter by validation status: "validated_correct", "validated_incorrect", "unvalidated"
@@ -140,7 +140,7 @@ class LabelApiController @Inject() (
   def getRawLabelsV3(
       bbox: Option[String],
       labelType: Option[String],
-      tag: Option[String],
+      tags: Option[String],
       minSeverity: Option[Int],
       maxSeverity: Option[Int],
       validationStatus: Option[String],
@@ -162,7 +162,7 @@ class LabelApiController @Inject() (
 
     // Parse comma-separated lists into sequences.
     val parsedLabelTypes = labelType.map(_.split(",").map(_.trim).toSeq)
-    val parsedTags       = tag.map(_.split(",").map(_.trim).toSeq)
+    val parsedTags       = tags.map(_.split(",").map(_.trim).toSeq)
 
     // Map validation status to internal representation.
     val validationStatusMapped = validationStatus.map {

--- a/app/controllers/api/StatsApiController.scala
+++ b/app/controllers/api/StatsApiController.scala
@@ -26,7 +26,7 @@ class StatsApiController @Inject() (
    * @param minLabels Optional minimum number of labels a user must have to be included
    * @param minMetersExplored Optional minimum meters explored a user must have to be included
    * @param highQualityOnly Optional filter to include only high quality users if true
-   * @param minLabelAccuracy Optional minimum label accuracy a user must have to be included
+   * @param minAccuracy Optional minimum label accuracy a user must have to be included
    * @param filetype Optional file type (e.g., "csv" for CSV format, defaults to JSON if not specified)
    * @return User statistics in the requested format with applied filters
    */
@@ -34,7 +34,7 @@ class StatsApiController @Inject() (
       minLabels: Option[Int],
       minMetersExplored: Option[Float],
       highQualityOnly: Option[Boolean],
-      minLabelAccuracy: Option[Float],
+      minAccuracy: Option[Float],
       filetype: Option[String]
   ) = silhouette.UserAwareAction.async { implicit request =>
     // Use the updated service method that applies filters at the service level.
@@ -43,7 +43,7 @@ class StatsApiController @Inject() (
         minLabels = minLabels,
         minMetersExplored = minMetersExplored,
         highQualityOnly = highQualityOnly,
-        minLabelAccuracy = minLabelAccuracy
+        minAccuracy = minAccuracy
       )
       .map { filteredStats: Seq[UserStatApi] =>
         val baseFileName: String = s"userStats_${OffsetDateTime.now()}"

--- a/app/models/user/UserStatTable.scala
+++ b/app/models/user/UserStatTable.scala
@@ -717,21 +717,21 @@ class UserStatTable @Inject() (
    * @param minLabels Optional minimum number of labels a user must have
    * @param minMetersExplored Optional minimum meters explored a user must have
    * @param highQualityOnly Optional filter to include only high quality users if Some(true)
-   * @param minLabelAccuracy Optional minimum label accuracy a user must have
+   * @param minAccuracy Optional minimum label accuracy a user must have
    * @return DBIO action that retrieves filtered user statistics
    */
   def getStatsForApiWithFilters(
       minLabels: Option[Int] = None,
       minMetersExplored: Option[Float] = None,
       highQualityOnly: Option[Boolean] = None,
-      minLabelAccuracy: Option[Float] = None
+      minAccuracy: Option[Float] = None
   ): DBIO[Seq[UserStatApi]] = {
     // Construct the SQL query with dynamic WHERE clauses based on filter parameters.
     val minLabelsClause   = minLabels.map(min => s"AND COALESCE(label_counts.labels, 0) >= $min").getOrElse("")
     val minMetersClause   = minMetersExplored.map(min => s"AND user_stat.meters_audited >= $min").getOrElse("")
     val highQualityClause = highQualityOnly.map(hq => s"AND user_stat.high_quality = ${hq.toString}").getOrElse("")
     val minAccuracyClause =
-      minLabelAccuracy.map(min => s"AND user_stat.accuracy IS NOT NULL AND user_stat.accuracy >= $min").getOrElse("")
+      minAccuracy.map(min => s"AND user_stat.accuracy IS NOT NULL AND user_stat.accuracy >= $min").getOrElse("")
 
     sql"""
       SELECT user_stat.user_id,

--- a/app/service/ApiService.scala
+++ b/app/service/ApiService.scala
@@ -84,7 +84,7 @@ trait ApiService {
       minLabels: Option[Int] = None,
       minMetersExplored: Option[Float] = None,
       highQualityOnly: Option[Boolean] = None,
-      minLabelAccuracy: Option[Float] = None
+      minAccuracy: Option[Float] = None
   ): Future[Seq[UserStatApi]]
 
   def getOverallStats(filterLowQuality: Boolean): Future[ProjectSidewalkStats]
@@ -229,17 +229,17 @@ class ApiServiceImpl @Inject() (
    * @param minLabels Optional minimum number of labels a user must have.
    * @param minMetersExplored Optional minimum meters explored a user must have.
    * @param highQualityOnly Optional filter to include only high quality users if Some(true).
-   * @param minLabelAccuracy Optional minimum label accuracy a user must have.
+   * @param minAccuracy Optional minimum label accuracy a user must have.
    * @return A Future containing a sequence of UserStatApi objects that match the filters.
    */
   def getUserStats(
       minLabels: Option[Int] = None,
       minMetersExplored: Option[Float] = None,
       highQualityOnly: Option[Boolean] = None,
-      minLabelAccuracy: Option[Float] = None
+      minAccuracy: Option[Float] = None
   ): Future[Seq[UserStatApi]] = {
     // Uses the database-level filtering method for improved performance.
-    db.run(userStatTable.getStatsForApiWithFilters(minLabels, minMetersExplored, highQualityOnly, minLabelAccuracy))
+    db.run(userStatTable.getStatsForApiWithFilters(minLabels, minMetersExplored, highQualityOnly, minAccuracy))
   }
 
   def getOverallStats(filterLowQuality: Boolean): Future[ProjectSidewalkStats] = {

--- a/app/views/apiDocs/cities.scala.html
+++ b/app/views/apiDocs/cities.scala.html
@@ -53,9 +53,9 @@
         <p><code>GET /v3/api/cities</code></p>
         <div class="api-subsection" id="endpoint-example-section">
             <h3 class="api-heading" id="endpoint-examples">Examples<a href="#endpoint-examples" class="permalink">#</a></h3>
-            <p><code><a href="/v3/api/cities?filetype=json">/v3/api/cities?filetype=json</a></code> Get all cities in JSON (default)</p>
+            <p><code><a target="_blank" href="/v3/api/cities?filetype=json">/v3/api/cities?filetype=json</a></code> Get all cities in JSON (default)</p>
             <p><code><a href="/v3/api/cities?filetype=csv">/v3/api/cities?filetype=csv</a></code> Get all cities in csv</p>
-            <p><code><a href="/v3/api/cities?filetype=geojson">/v3/api/cities?filetype=geojson</a></code> Get all cities in geojson</p>
+            <p><code><a target="_blank" href="/v3/api/cities?filetype=geojson">/v3/api/cities?filetype=geojson</a></code> Get all cities in geojson</p>
         </div>
     </div>
 

--- a/app/views/apiDocs/labelClusters.scala.html
+++ b/app/views/apiDocs/labelClusters.scala.html
@@ -73,9 +73,9 @@
         <p><code>GET /v3/api/labelClusters</code></p>
         <div class="api-subsection" id="endpoint-example-section">
             <h3 class="api-heading" id="endpoint-examples">Examples<a href="#endpoint-examples" class="permalink">#</a></h3>
-            <p><code><a href="/v3/api/labelClusters?filetype=json">/v3/api/labelClusters?filetype=json</a></code> Get all label clusters in JSON (default)</p>
-            <p><code><a href="/v3/api/labelClusters?filetype=json&inline=true">/v3/api/labelClusters?filetype=json&inline=true</a></code> Get all label clusters in JSON but opened in the browser</p>
-            <p><code><a href="/v3/api/labelClusters?filetype=csv">/v3/api/labelClusters?filetype=csv</a></code> Get all label clusters in CSV</p>
+            <p><code><a href="/v3/api/labelClusters?filetype=geojson">/v3/api/labelClusters?filetype=geojson</a></code> Get all label clusters in GeoJSON (default)</p>
+            <p><code><a target="_blank" href="/v3/api/labelClusters?filetype=geojson&inline=true">/v3/api/labelClusters?filetype=geojson&inline=true</a></code> Get all label clusters in GeoJSON but opened in the browser</p>
+            <p><code><a href="/v3/api/labelClusters?filetype=csv">/v3/api/labelClusters?filetype=csv</a></code> Get all label clusters in a CSV</p>
             <p><code><a href="/v3/api/labelClusters?includeRawLabels=true">/v3/api/labelClusters&includeRawLabels=true</a></code> Get all label clusters and the raw labels within each cluster.</p>
             <p><code><a href="/v3/api/labelClusters?labelType=CurbRamp">/v3/api/labelClusters?labelType=CurbRamp</a></code> Get all label clusters of type <code>CurbRamp</code>. The available label types match those in the <a href="@routes.ApiDocsController.labelTypes">Label Types API</a></p>
             <p><code><a href="/v3/api/labelClusters?labelType=SurfaceProblem&minSeverity=4">/v3/api/labelClusters?labelType=SurfaceProblem&minSeverity=4</a></code> Get all label clusters of type <code>SurfaceProblem</code> with a minimum median severity of 4.</p>
@@ -420,6 +420,9 @@
 
         <h4 id="response-shapefile">Shapefile Format <a href="#response-shapefile" class="permalink">#</a></h4>
         <p>If <code>filetype=shapefile</code> is specified, the response body will be a ZIP archive containing the Shapefile components (.shp, .shx, .dbf, .prj). The attribute table (.dbf) contains fields corresponding to the GeoJSON properties object (field names may be truncated due to Shapefile limitations). The included <code>.prj</code> file defines the Coordinate Reference System (CRS), typically WGS84 (EPSG:4326). </p>
+
+        <h4 id="response-geopackage">GeoPackage Format <a href="#response-geopackage" class="permalink">#</a></h4>
+        <p>If <code>filetype=geopackage</code> is specified, the response body will be a GeoPackage file (<code>.gpkg</code>). This is an open standard format based on SQLite that contains both geometry and attributes in a single file, generally without the field name limitations of Shapefiles. CRS is typically WGS84 (EPSG:4326). </p>
 
         <h3 class="api-heading" id="error-responses">Error Responses<a href="#error-responses" class="permalink">#</a></h3>
         <p>If an error occurs, the API will return an appropriate HTTP status code and a JSON response body containing details about the error.</p>

--- a/app/views/apiDocs/labelTags.scala.html
+++ b/app/views/apiDocs/labelTags.scala.html
@@ -70,7 +70,7 @@
         <p><code>GET /v3/api/labelTags</code></p>
         <div class="api-subsection" id="endpoint-example-section">
             <h3 class="api-heading" id="endpoint-examples">Examples<a href="#endpoint-examples" class="permalink">#</a></h3>
-            <p><code><a href="/v3/api/labelTags">/v3/api/labelTags</a></code> Get all label tags available for @cityName (in JSON)</p>
+            <p><code><a target="_blank" href="/v3/api/labelTags">/v3/api/labelTags</a></code> Get all label tags available for @cityName (in JSON)</p>
         </div>
     </div>
 

--- a/app/views/apiDocs/labelTypes.scala.html
+++ b/app/views/apiDocs/labelTypes.scala.html
@@ -55,7 +55,7 @@
         <p><code>GET /v3/api/labelTypes</code></p>
         <div class="api-subsection" id="endpoint-example-section">
             <h3 class="api-heading" id="endpoint-examples">Examples<a href="#endpoint-examples" class="permalink">#</a></h3>
-            <p><code><a href="/v3/api/labelTypes">/v3/api/labelTypes</a></code> Get all label types in JSON</p>
+            <p><code><a target="_blank" href="/v3/api/labelTypes">/v3/api/labelTypes</a></code> Get all label types in JSON</p>
         </div>
     </div>
 

--- a/app/views/apiDocs/overallStats.scala.html
+++ b/app/views/apiDocs/overallStats.scala.html
@@ -53,7 +53,7 @@
         <p><code>GET /v3/api/overallStats</code></p>
         <div class="api-subsection" id="endpoint-example-section">
             <h3 class="api-heading" id="endpoint-examples">Examples<a href="#endpoint-examples" class="permalink">#</a></h3>
-            <p><code><a href="/v3/api/overallStats?filetype=json">/v3/api/overallStats?filetype=json</a></code> Get overall stats for @cityName in JSON (default)</p>
+            <p><code><a target="_blank" href="/v3/api/overallStats?filetype=json">/v3/api/overallStats?filetype=json</a></code> Get overall stats for @cityName in JSON (default)</p>
             <p><code><a href="/v3/api/overallStats?filetype=csv">/v3/api/overallStats?filetype=csv</a></code> Get overall stats for @cityName in CSV</p>
         </div>
     </div>
@@ -95,15 +95,15 @@
                 </thead>
                 <tbody>
                     <tr>
-                        <td><code>filetype</code></td>
-                        <td><code>string</code></td>
-                        <td>Specify the output format. Options: <code>json</code> (default), <code>csv</code>.</td>
-                    </tr>
-                    <tr>
                         <td><code>filterLowQuality</code></td>
                         <td><code>boolean</code></td>
                         <td>When set to <code>true</code>, excludes data from low-quality contributors to provide
                             more reliable statistics. Default: <code>false</code> (includes all data).</td>
+                    </tr>
+                    <tr>
+                        <td><code>filetype</code></td>
+                        <td><code>string</code></td>
+                        <td>Specify the output format. Options: <code>json</code> (default), <code>csv</code>.</td>
                     </tr>
                 </tbody>
             </table>

--- a/app/views/apiDocs/rawLabels.scala.html
+++ b/app/views/apiDocs/rawLabels.scala.html
@@ -67,6 +67,14 @@
         <h2 class="api-heading" id="endpoint">Endpoint <a href="#endpoint" class="permalink">#</a></h2>
         <p>Retrieve a list of raw labels, optionally filtered by various criteria.</p>
         <p><code>GET /v3/api/rawLabels</code></p>
+        <div class="api-subsection" id="endpoint-example-section">
+            <h3 class="api-heading" id="endpoint-examples">Examples<a href="#endpoint-examples" class="permalink">#</a></h3>
+            <p><code><a href="/v3/api/rawLabels?filetype=geojson">/v3/api/rawLabels?filetype=geojson</a></code> Get all raw labels in GeoJSON (default)</p>
+            <p><code><a target="_blank" href="/v3/api/rawLabels?filetype=geojson&inline=true">/v3/api/rawLabels?filetype=geojson&inline=true</a></code> Get all raw labels in GeoJSON but opened in the browser</p>
+            <p><code><a href="/v3/api/rawLabels?filetype=csv">/v3/api/rawLabels?filetype=csv</a></code> Get all raw labels in a CSV</p>
+            <p><code><a href="/v3/api/rawLabels?labelType=CurbRamp">/v3/api/rawLabels?labelType=CurbRamp</a></code> Get all raw labels of type <code>CurbRamp</code>. The available label types match those in the <a href="@routes.ApiDocsController.labelTypes">Label Types API</a></p>
+            <p><code><a href="/v3/api/rawLabels?labelType=SurfaceProblem&minSeverity=4">/v3/api/rawLabels?labelType=SurfaceProblem&minSeverity=4</a></code> Get all raw labels of type <code>SurfaceProblem</code> with a minimum severity of 4.</p>
+        </div>
     </div>
 
     <div class="api-section" id="quick-download-section">
@@ -144,9 +152,9 @@
                         <td>Filter by one or more label types. Provide comma-separated values (e.g., <code>labelType=CurbRamp,Obstacle</code>). See <a href="@routes.ApiDocsController.labelTypes">Label Types Reference</a> for available types. </td>
                     </tr>
                     <tr>
-                        <td><code>tag</code></td>
+                        <td><code>tags</code></td>
                         <td><code>string</code></td>
-                        <td>Filter by one or more tags associated with labels. Provide comma-separated values (e.g., <code>tag=missing_tactile_warning,uneven_surface</code>). Matches labels containing *any* of the specified tags. See <a href="#tags-reference">Tags Reference</a> for available tags. </td>
+                        <td>Filter by one or more tags associated with labels. Provide comma-separated values (e.g., <code>tags=missing tactile warning,uneven surface</code>). Matches labels containing *any* of the specified tags. See <a href="#tags-reference">Tags Reference</a> for available tags. </td>
                     </tr>
                     <tr>
                         <td><code>minSeverity</code></td>
@@ -177,6 +185,11 @@
                         <td><code>filetype</code></td>
                         <td><code>string</code></td>
                         <td>Specify the output format. Options: <code>geojson</code> (default), <code>csv</code>, <code>shapefile</code>.</td>
+                    </tr>
+                    <tr>
+                        <td><code>inline</code></td>
+                        <td><code>boolean</code></td>
+                        <td>Whether to display the file inline or as an attachment. Default: <code>false</code> (attachment). Set to <code>true</code> to view data in the browser instead of downloading.</td>
                     </tr>
                 </tbody>
             </table>

--- a/app/views/apiDocs/streetTypes.scala.html
+++ b/app/views/apiDocs/streetTypes.scala.html
@@ -60,7 +60,7 @@
         <p><code>GET /v3/api/streetTypes</code></p>
         <div class="api-subsection" id="endpoint-example-section">
             <h3 class="api-heading" id="endpoint-examples">Examples<a href="#endpoint-examples" class="permalink">#</a></h3>
-            <p><code><a href="/v3/api/streetTypes">/v3/api/streetTypes</a></code> Get all street types in JSON</p>
+            <p><code><a target="_blank" href="/v3/api/streetTypes">/v3/api/streetTypes</a></code> Get all street types in JSON</p>
         </div>
     </div>
 

--- a/app/views/apiDocs/streets.scala.html
+++ b/app/views/apiDocs/streets.scala.html
@@ -67,7 +67,7 @@
         <div class="api-subsection" id="endpoint-example-section">
             <h3 class="api-heading" id="endpoint-examples">Examples<a href="#endpoint-examples" class="permalink">#</a></h3>
             <p><code><a href="/v3/api/streets?filetype=geojson">/v3/api/streets?filetype=geojson</a></code> Get all streets in GeoJSON format (default)</p>
-            <p><code><a href="/v3/api/streets?filetype=geojson&inline=true">/v3/api/streets?filetype=geojson&inline=true</a></code> Get all streets in GeoJSON but opened in the browser</p>
+            <p><code><a target="_blank" href="/v3/api/streets?filetype=geojson&inline=true">/v3/api/streets?filetype=geojson&inline=true</a></code> Get all streets in GeoJSON but opened in the browser</p>
             <p><code><a href="/v3/api/streets?filetype=csv">/v3/api/streets?filetype=csv</a></code> Get all streets in CSV format</p>
             <p><code><a href="/v3/api/streets?minLabelCount=5">/v3/api/streets?minLabelCount=5</a></code> Get streets with at least 5 accessibility labels</p>
             <p><code><a href="/v3/api/streets?wayType=residential,primary">/v3/api/streets?wayType=residential,primary</a></code> Get only residential and primary roads</p>

--- a/app/views/apiDocs/userStats.scala.html
+++ b/app/views/apiDocs/userStats.scala.html
@@ -56,11 +56,11 @@
         <p><code>GET /v3/api/userStats</code></p>
         <div class="api-subsection" id="endpoint-example-section">
             <h3 class="api-heading" id="endpoint-examples">Examples<a href="#endpoint-examples" class="permalink">#</a></h3>
-            <p><code><a href="/v3/api/userStats?filetype=json">/v3/api/userStats?filetype=json</a></code> Get all user stats for @cityName in JSON (default)</p>
+            <p><code><a target="_blank" href="/v3/api/userStats?filetype=json">/v3/api/userStats?filetype=json</a></code> Get all user stats for @cityName in JSON (default)</p>
             <p><code><a href="/v3/api/userStats?filetype=csv">/v3/api/userStats?filetype=csv</a></code> Get all user stats for @cityName in CSV</p>
-            <p><code><a href="/v3/api/userStats?filetype=csv&highQualityOnly=True">/v3/api/userStats?filetype=csv&highQualityOnly=true</a></code> Get all user stats for users marked as high_quality (in CSV)</p>
-            <p><code><a href="/v3/api/userStats?filetype=json&minLabels=10">/v3/api/userStats?filetype=json&minLabels=10</a></code> Get all user stats for users with 10 labels or more (in JSON)</p>
-            <p><code><a href="/v3/api/userStats?filetype=json&minLabels=10&min_accuracy=0.9">/v3/api/userStats?filetype=json&minLabels=10&min_accuracy=0.9</a></code> Get all user stats for users with 10 labels or more and a 90% accuracy or better (in JSON)</p>
+            <p><code><a href="/v3/api/userStats?filetype=csv&highQualityOnly=true">/v3/api/userStats?filetype=csv&highQualityOnly=true</a></code> Get all user stats for users marked as high_quality (in CSV)</p>
+            <p><code><a target="_blank" href="/v3/api/userStats?filetype=json&minLabels=10">/v3/api/userStats?filetype=json&minLabels=10</a></code> Get all user stats for users with 10 labels or more (in JSON)</p>
+            <p><code><a target="_blank" href="/v3/api/userStats?filetype=json&minLabels=10&min_accuracy=0.9">/v3/api/userStats?filetype=json&minLabels=10&min_accuracy=0.9</a></code> Get all user stats for users with 10 labels or more and a 90% accuracy or better (in JSON)</p>
         </div>
     </div>
 
@@ -105,23 +105,17 @@
                 </thead>
                 <tbody>
                     <tr>
-                        <td><code>filetype</code></td>
-                        <td><code>string</code></td>
-                        <td>Specify the output format. Options: <code>json</code> (default), <code>csv</code>.</td>
-                    </tr>
-
-                    <tr>
                         <td><code>minLabels</code></td>
                         <td><code>integer</code></td>
                         <td>Filter users with at least this many total labels. Default: 0 (no minimum).</td>
                     </tr>
                     <tr>
-                        <td><code>min_meters</code></td>
+                        <td><code>minMetersExplored</code></td>
                         <td><code>number</code></td>
                         <td>Filter users who have explored at least this many meters. Default: 0 (no minimum).</td>
                     </tr>
                     <tr>
-                        <td><code>min_accuracy</code></td>
+                        <td><code>minAccuracy</code></td>
                         <td><code>number</code></td>
                         <td>Filter users with at least this label accuracy (0.0-1.0). Users without validation data will be excluded.</td>
                     </tr>
@@ -129,6 +123,11 @@
                         <td><code>highQualityOnly</code></td>
                         <td><code>boolean</code></td>
                         <td>When set to <code>true</code>, only include users flagged as high quality contributors. Default: <code>false</code>.</td>
+                    </tr>
+                    <tr>
+                        <td><code>filetype</code></td>
+                        <td><code>string</code></td>
+                        <td>Specify the output format. Options: <code>json</code> (default), <code>csv</code>.</td>
                     </tr>
 
                         <!--

--- a/conf/routes
+++ b/conf/routes
@@ -161,12 +161,12 @@ POST    /saveImage                                      controllers.ImageControl
 POST    /api/gemini/analyze                             controllers.GeminiController.analyzeImage()
 
 # Public API (v3) for Project Sidewalk data and metadata.
-GET     /v3/api/rawLabels                               controllers.api.LabelApiController.getRawLabelsV3(bbox: Option[String], labelType: Option[String], tag: Option[String], minSeverity: Option[Int], maxSeverity: Option[Int], validationStatus: Option[String], startDate: Option[String], endDate: Option[String], regionId: Option[Int], regionName: Option[String], filetype: Option[String], inline: Option[Boolean])
+GET     /v3/api/rawLabels                               controllers.api.LabelApiController.getRawLabelsV3(bbox: Option[String], labelType: Option[String], tags: Option[String], minSeverity: Option[Int], maxSeverity: Option[Int], validationStatus: Option[String], startDate: Option[String], endDate: Option[String], regionId: Option[Int], regionName: Option[String], filetype: Option[String], inline: Option[Boolean])
 GET     /v3/api/labelTypes                              controllers.api.LabelApiController.getLabelTypes
 GET     /v3/api/labelTags                               controllers.api.LabelApiController.getLabelTags
 GET     /v3/api/regionWithMostLabels                    controllers.api.RegionApiController.getRegionWithMostLabels
-GET     /v3/api/cities                                  controllers.api.CitiesApiController.getCities
-GET     /v3/api/userStats                               controllers.api.StatsApiController.getUserApiStats(minLabels: Option[Int], minMetersExplored: Option[Float], highQualityOnly: Option[Boolean], minLabelAccuracy: Option[Float], filetype: Option[String])
+GET     /v3/api/cities                                  controllers.api.CitiesApiController.getCities(filetype: String ?= "json")
+GET     /v3/api/userStats                               controllers.api.StatsApiController.getUserApiStats(minLabels: Option[Int], minMetersExplored: Option[Float], highQualityOnly: Option[Boolean], minAccuracy: Option[Float], filetype: Option[String])
 GET     /v3/api/overallStats                            controllers.api.StatsApiController.getOverallSidewalkStats(filterLowQuality: Boolean ?= false, filetype: Option[String])
 GET     /v3/api/labelClusters                           controllers.api.LabelClustersApiController.getLabelClustersV3(bbox: Option[String], labelType: Option[String], regionId: Option[Int], regionName: Option[String], includeRawLabels: Option[Boolean], clusterSize: Option[Int], avgImageCaptureDate: Option[String], avgLabelDate: Option[String], minSeverity: Option[Int], maxSeverity: Option[Int], filetype: Option[String], inline: Option[Boolean])
 GET     /v3/api/streets                                 controllers.api.StreetsApiController.getStreets(bbox: Option[String], regionId: Option[Int], regionName: Option[String], minLabelCount: Option[Int], minAuditCount: Option[Int], minUserCount: Option[Int], wayType: Option[String], filetype: Option[String], inline: Option[Boolean])


### PR DESCRIPTION
Resolves #3930

Cleans up a few small issues with the API docs. Changes outlined below:
* User Stats: Fixes a few params that were documented with the wrong names. For example, `minMetersExplored` param was listed as `min_meters` in the docs
* Raw Labels: adds missing Examples section
* Raw Labels: adds documentation of `inline` parameter
* Label Clusters: adds missing GeoPackage subsection in the Success Response section
* Cities: GeoJSON output in Examples section is now shown inline like the JSON example
* All: Links in the Examples sections that open data inline now open in a new tab
* Other misc issues I noticed while fixing the issues above
