### PR TITLE
Fixes list of IP addresses being logged

### DIFF
--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -54,7 +54,7 @@ class AdminController @Inject() (
    */
   def index = cc.securityService.SecuredAction(WithAdmin()) { implicit request =>
     configService.getCommonPageData(request2Messages.lang).map { commonData =>
-      cc.loggingService.insert(request.identity.userId, request.remoteAddress, "Visit_Admin")
+      cc.loggingService.insert(request.identity.userId, request.ipAddress, "Visit_Admin")
       Ok(views.html.admin.index(commonData, "Sidewalk - Admin", request.identity))
     }
   }
@@ -71,7 +71,7 @@ class AdminController @Inject() (
           adminData                        <- adminService.getAdminUserProfileData(user.userId)
           commonData                       <- configService.getCommonPageData(request2Messages.lang)
         } yield {
-          cc.loggingService.insert(user.userId, request.remoteAddress, s"Visit_AdminUserDashboard_User=$username")
+          cc.loggingService.insert(user.userId, request.ipAddress, s"Visit_AdminUserDashboard_User=$username")
           Ok(
             views.html.userProfile(commonData, "Sidewalk - Dashboard", request.identity, user, userProfileData,
               Some(adminData))
@@ -88,7 +88,7 @@ class AdminController @Inject() (
     configService.getCommonPageData(request2Messages.lang).map { commonData =>
       val user: SidewalkUserWithRole = request.identity
       val admin: Boolean             = isAdmin(request.identity)
-      cc.loggingService.insert(user.userId, request.remoteAddress, s"Visit_LabelView_Label=${labelId}_Admin=$admin")
+      cc.loggingService.insert(user.userId, request.ipAddress, s"Visit_LabelView_Label=${labelId}_Admin=$admin")
       Ok(views.html.admin.label(commonData, "Sidewalk - LabelView", user, admin, labelId))
     }
   }
@@ -104,10 +104,10 @@ class AdminController @Inject() (
       val user: SidewalkUserWithRole = request.identity
       maybeTask match {
         case Some(task) =>
-          cc.loggingService.insert(user.userId, request.remoteAddress, s"Visit_AdminTask_TaskId=$taskId")
+          cc.loggingService.insert(user.userId, request.ipAddress, s"Visit_AdminTask_TaskId=$taskId")
           Ok(views.html.admin.task(commonData, "Sidewalk - TaskView", user, task))
         case None =>
-          cc.loggingService.insert(user.userId, request.remoteAddress, s"Visit_AdminTask_TaskId=${taskId}_NotFound")
+          cc.loggingService.insert(user.userId, request.ipAddress, s"Visit_AdminTask_TaskId=${taskId}_NotFound")
           NotFound(s"Task with ID $taskId not found.")
       }
     }
@@ -374,7 +374,7 @@ class AdminController @Inject() (
                 .updateRole(userId, newRole)
                 .map(_ => {
                   val logText = s"UpdateRole_User=${userId}_Old=${user.role}_New=$newRole"
-                  cc.loggingService.insert(request.identity.userId, request.remoteAddress, logText)
+                  cc.loggingService.insert(request.identity.userId, request.ipAddress, logText)
                   Ok(Json.obj("username" -> user.username, "user_id" -> userId, "role" -> newRole))
                 })
             }
@@ -548,7 +548,7 @@ class AdminController @Inject() (
     val open: Boolean = (request.body \ "open").as[Boolean]
     adminService.updateTeamStatus(teamId, open).map { _ =>
       val logText = s"UpdateTeamStatus_Team=${teamId}_Open=$open"
-      cc.loggingService.insert(request.identity.userId, request.remoteAddress, logText)
+      cc.loggingService.insert(request.identity.userId, request.ipAddress, logText)
       Ok(Json.obj("status" -> "success", "team_id" -> teamId, "open" -> open))
     }
   }
@@ -561,7 +561,7 @@ class AdminController @Inject() (
     val visible: Boolean = (request.body \ "visible").as[Boolean]
     adminService.updateTeamVisibility(teamId, visible).map { _ =>
       val logText = s"UpdateTeamVisibility_Team=${teamId}_Visible=$visible"
-      cc.loggingService.insert(request.identity.userId, request.remoteAddress, logText)
+      cc.loggingService.insert(request.identity.userId, request.ipAddress, logText)
       Ok(Json.obj("status" -> "success", "team_id" -> teamId, "visible" -> visible))
     }
   }

--- a/app/controllers/ApiDocsController.scala
+++ b/app/controllers/ApiDocsController.scala
@@ -25,7 +25,7 @@ class ApiDocsController @Inject() (
    */
   def index = cc.securityService.SecuredAction { implicit request =>
     configService.getCommonPageData(request2Messages.lang).map { commonData =>
-      cc.loggingService.insert(request.identity.userId, request.remoteAddress, "Visit_APIDocs_Introduction")
+      cc.loggingService.insert(request.identity.userId, request.ipAddress, "Visit_APIDocs_Introduction")
       Ok(views.html.apiDocs.index(commonData, request.identity))
     }
   }
@@ -35,7 +35,7 @@ class ApiDocsController @Inject() (
    */
   def labelTypes = cc.securityService.SecuredAction { implicit request =>
     configService.getCommonPageData(request2Messages.lang).map { commonData =>
-      cc.loggingService.insert(request.identity.userId, request.remoteAddress, "Visit_APIDocs_LabelTypes")
+      cc.loggingService.insert(request.identity.userId, request.ipAddress, "Visit_APIDocs_LabelTypes")
       Ok(views.html.apiDocs.labelTypes(commonData, request.identity))
     }
   }
@@ -45,7 +45,7 @@ class ApiDocsController @Inject() (
    */
   def labelTags = cc.securityService.SecuredAction { implicit request =>
     configService.getCommonPageData(request2Messages.lang).map { commonData =>
-      cc.loggingService.insert(request.identity.userId, request.remoteAddress, "Visit_APIDocs_LabelTags")
+      cc.loggingService.insert(request.identity.userId, request.ipAddress, "Visit_APIDocs_LabelTags")
       Ok(views.html.apiDocs.labelTags(commonData, request.identity))
     }
   }
@@ -55,7 +55,7 @@ class ApiDocsController @Inject() (
    */
   def rawLabels = cc.securityService.SecuredAction { implicit request =>
     configService.getCommonPageData(request2Messages.lang).map { commonData =>
-      cc.loggingService.insert(request.identity.userId, request.remoteAddress, "Visit_APIDocs_RawLabels")
+      cc.loggingService.insert(request.identity.userId, request.ipAddress, "Visit_APIDocs_RawLabels")
       Ok(views.html.apiDocs.rawLabels(commonData, request.identity))
     }
   }
@@ -65,7 +65,7 @@ class ApiDocsController @Inject() (
    */
   def labelClusters = cc.securityService.SecuredAction { implicit request =>
     configService.getCommonPageData(request2Messages.lang).map { commonData =>
-      cc.loggingService.insert(request.identity.userId, request.remoteAddress, "Visit_APIDocs_LabelClusters")
+      cc.loggingService.insert(request.identity.userId, request.ipAddress, "Visit_APIDocs_LabelClusters")
       Ok(views.html.apiDocs.labelClusters(commonData, request.identity))
     }
   }
@@ -75,7 +75,7 @@ class ApiDocsController @Inject() (
    */
   def streets = cc.securityService.SecuredAction { implicit request =>
     configService.getCommonPageData(request2Messages.lang).map { commonData =>
-      cc.loggingService.insert(request.identity.userId, request.remoteAddress, "Visit_APIDocs_Streets")
+      cc.loggingService.insert(request.identity.userId, request.ipAddress, "Visit_APIDocs_Streets")
       Ok(views.html.apiDocs.streets(commonData, request.identity))
     }
   }
@@ -85,7 +85,7 @@ class ApiDocsController @Inject() (
    */
   def streetTypes = cc.securityService.SecuredAction { implicit request =>
     configService.getCommonPageData(request2Messages.lang).map { commonData =>
-      cc.loggingService.insert(request.identity.userId, request.remoteAddress, "Visit_APIDocs_StreetTypes")
+      cc.loggingService.insert(request.identity.userId, request.ipAddress, "Visit_APIDocs_StreetTypes")
       Ok(views.html.apiDocs.streetTypes(commonData, request.identity))
     }
   }
@@ -95,7 +95,7 @@ class ApiDocsController @Inject() (
    */
   def cities = cc.securityService.SecuredAction { implicit request =>
     configService.getCommonPageData(request2Messages.lang).map { commonData =>
-      cc.loggingService.insert(request.identity.userId, request.remoteAddress, "Visit_APIDocs_Cities")
+      cc.loggingService.insert(request.identity.userId, request.ipAddress, "Visit_APIDocs_Cities")
       Ok(views.html.apiDocs.cities(commonData, request.identity))
     }
   }
@@ -105,7 +105,7 @@ class ApiDocsController @Inject() (
    */
   def userStats = cc.securityService.SecuredAction { implicit request =>
     configService.getCommonPageData(request2Messages.lang).map { commonData =>
-      cc.loggingService.insert(request.identity.userId, request.remoteAddress, "Visit_APIDocs_UserStats")
+      cc.loggingService.insert(request.identity.userId, request.ipAddress, "Visit_APIDocs_UserStats")
       Ok(views.html.apiDocs.userStats(commonData, request.identity))
     }
   }
@@ -115,7 +115,7 @@ class ApiDocsController @Inject() (
    */
   def overallStats = cc.securityService.SecuredAction { implicit request =>
     configService.getCommonPageData(request2Messages.lang).map { commonData =>
-      cc.loggingService.insert(request.identity.userId, request.remoteAddress, "Visit_APIDocs_OverallStats")
+      cc.loggingService.insert(request.identity.userId, request.ipAddress, "Visit_APIDocs_OverallStats")
       Ok(views.html.apiDocs.overallStats(commonData, request.identity))
     }
   }
@@ -125,7 +125,7 @@ class ApiDocsController @Inject() (
    */
   def validations = cc.securityService.SecuredAction { implicit request =>
     configService.getCommonPageData(request2Messages.lang).map { commonData =>
-      cc.loggingService.insert(request.identity.userId, request.remoteAddress, "Visit_APIDocs_Validations")
+      cc.loggingService.insert(request.identity.userId, request.ipAddress, "Visit_APIDocs_Validations")
       Ok(views.html.apiDocs.validations(commonData, request.identity))
     }
   }

--- a/app/controllers/ApplicationController.scala
+++ b/app/controllers/ApplicationController.scala
@@ -39,7 +39,7 @@ class ApplicationController @Inject() (
   def index = cc.securityService.SecuredAction { implicit request =>
     val user: SidewalkUserWithRole   = request.identity
     val timestamp: OffsetDateTime    = OffsetDateTime.now
-    val ipAddress: String            = request.remoteAddress
+    val ipAddress: String            = request.ipAddress
     val isMobile: Boolean            = ControllerUtils.isMobile(request)
     val qString: Map[String, String] = request.queryString.map { case (k, v) => k.mkString -> v.mkString }
 
@@ -95,7 +95,7 @@ class ApplicationController @Inject() (
       currTeamLeaders <- userService.getLeaderboardStats(10, "overall", byTeam = false, Some(request.identity.userId))
       userTeam        <- userService.getUserTeam(request.identity.userId)
     } yield {
-      cc.loggingService.insert(request.identity.userId, request.remoteAddress, "Visit_Leaderboard")
+      cc.loggingService.insert(request.identity.userId, request.ipAddress, "Visit_Leaderboard")
       Ok(
         views.html.leaderboard("Sidewalk - Leaderboard", commonData, request.identity, overallLeaders, teamLeaders,
           weeklyLeaders, currTeamLeaders, userTeam, countryId)
@@ -114,7 +114,7 @@ class ApplicationController @Inject() (
       val logText: String = s"Click_module=ChangeLanguage_from=${oldLang}_to=${newLang}_location=${clickLoc}_route=$url"
 
       // Log the interaction. Moved the logging here from navbar.scala.html b/c the redirect was happening too fast.
-      cc.loggingService.insert(request.identity.userId, request.remoteAddress, logText)
+      cc.loggingService.insert(request.identity.userId, request.ipAddress, logText)
 
       // Update the cookie and redirect.
       Future.successful(Redirect(url).withLang(Lang(newLang)))
@@ -125,7 +125,7 @@ class ApplicationController @Inject() (
    */
   def help = cc.securityService.SecuredAction { implicit request =>
     configService.getCommonPageData(request2Messages.lang).map { commonData =>
-      cc.loggingService.insert(request.identity.userId, request.remoteAddress, "Visit_Help")
+      cc.loggingService.insert(request.identity.userId, request.ipAddress, "Visit_Help")
       Ok(views.html.help(commonData, "Sidewalk - Help", request.identity))
     }
   }
@@ -135,21 +135,21 @@ class ApplicationController @Inject() (
    */
   def labelingGuide = cc.securityService.SecuredAction { implicit request =>
     configService.getCommonPageData(request2Messages.lang).map { commonData =>
-      cc.loggingService.insert(request.identity.userId, request.remoteAddress, "Visit_Labeling_Guide")
+      cc.loggingService.insert(request.identity.userId, request.ipAddress, "Visit_Labeling_Guide")
       Ok(views.html.labelingGuide.labelingGuide(commonData, "Sidewalk - Labeling Guide", request.identity))
     }
   }
 
   def labelingGuideCurbRamps = cc.securityService.SecuredAction { implicit request =>
     configService.getCommonPageData(request2Messages.lang).map { commonData =>
-      cc.loggingService.insert(request.identity.userId, request.remoteAddress, "Visit_Labeling_Guide_Curb_Ramps")
+      cc.loggingService.insert(request.identity.userId, request.ipAddress, "Visit_Labeling_Guide_Curb_Ramps")
       Ok(views.html.labelingGuide.labelingGuideCurbRamps(commonData, "Sidewalk - Labeling Guide", request.identity))
     }
   }
 
   def labelingGuideSurfaceProblems = cc.securityService.SecuredAction { implicit request =>
     configService.getCommonPageData(request2Messages.lang).map { commonData =>
-      cc.loggingService.insert(request.identity.userId, request.remoteAddress, "Visit_Labeling_Guide_Surface_Problems")
+      cc.loggingService.insert(request.identity.userId, request.ipAddress, "Visit_Labeling_Guide_Surface_Problems")
       Ok(
         views.html.labelingGuide.labelingGuideSurfaceProblems(commonData, "Sidewalk - Labeling Guide", request.identity)
       )
@@ -158,21 +158,21 @@ class ApplicationController @Inject() (
 
   def labelingGuideObstacles = cc.securityService.SecuredAction { implicit request =>
     configService.getCommonPageData(request2Messages.lang).map { commonData =>
-      cc.loggingService.insert(request.identity.userId, request.remoteAddress, "Visit_Labeling_Guide_Obstacles")
+      cc.loggingService.insert(request.identity.userId, request.ipAddress, "Visit_Labeling_Guide_Obstacles")
       Ok(views.html.labelingGuide.labelingGuideObstacles(commonData, "Sidewalk - Labeling Guide", request.identity))
     }
   }
 
   def labelingGuideNoSidewalk = cc.securityService.SecuredAction { implicit request =>
     configService.getCommonPageData(request2Messages.lang).map { commonData =>
-      cc.loggingService.insert(request.identity.userId, request.remoteAddress, "Visit_Labeling_Guide_No_Sidewalk")
+      cc.loggingService.insert(request.identity.userId, request.ipAddress, "Visit_Labeling_Guide_No_Sidewalk")
       Ok(views.html.labelingGuide.labelingGuideNoSidewalk(commonData, "Sidewalk - Labeling Guide", request.identity))
     }
   }
 
   def labelingGuideOcclusion = cc.securityService.SecuredAction { implicit request =>
     configService.getCommonPageData(request2Messages.lang).map { commonData =>
-      cc.loggingService.insert(request.identity.userId, request.remoteAddress, "Visit_Labeling_Guide_Occlusion")
+      cc.loggingService.insert(request.identity.userId, request.ipAddress, "Visit_Labeling_Guide_Occlusion")
       Ok(views.html.labelingGuide.labelingGuideOcclusion(commonData, "Sidewalk - Labeling Guide", request.identity))
     }
   }
@@ -182,7 +182,7 @@ class ApplicationController @Inject() (
    */
   def terms = cc.securityService.SecuredAction { implicit request =>
     configService.getCommonPageData(request2Messages.lang).map { commonData =>
-      cc.loggingService.insert(request.identity.userId, request.remoteAddress, "Visit_Terms")
+      cc.loggingService.insert(request.identity.userId, request.ipAddress, "Visit_Terms")
       Ok(views.html.terms(commonData, "Sidewalk - Terms", request.identity))
     }
   }
@@ -196,7 +196,7 @@ class ApplicationController @Inject() (
     val activityStr: String = if (regions.isEmpty) "Visit_LabelMap" else s"Visit_LabelMap_Regions=$regions"
 
     configService.getCommonPageData(request2Messages.lang).map { commonData =>
-      cc.loggingService.insert(request.identity.userId, request.remoteAddress, activityStr)
+      cc.loggingService.insert(request.identity.userId, request.ipAddress, activityStr)
       Ok(views.html.apps.labelMap(commonData, "Sidewalk - LabelMap", request.identity, regionIds, routeIds))
     }
   }
@@ -238,7 +238,7 @@ class ApplicationController @Inject() (
         // Log visit to Gallery async.
         val activityStr: String =
           s"Visit_Gallery_LabelType=${labType}_RegionIDs=${regionIdsList}_Severity=${severityList}_Tags=${tagList}_Validations=$valOptions"
-        cc.loggingService.insert(request.identity.userId, request.remoteAddress, activityStr)
+        cc.loggingService.insert(request.identity.userId, request.ipAddress, activityStr)
 
         Ok(
           views.html.apps.gallery(commonData, "Sidewalk - Gallery", request.identity, labType, labelTypes,
@@ -253,7 +253,7 @@ class ApplicationController @Inject() (
   def serviceHoursInstructions = cc.securityService.SecuredAction { implicit request =>
     val isMobile: Boolean = ControllerUtils.isMobile(request)
     configService.getCommonPageData(request2Messages.lang).map { commonData =>
-      cc.loggingService.insert(request.identity.userId, request.remoteAddress, "Visit_ServiceHourInstructions")
+      cc.loggingService.insert(request.identity.userId, request.ipAddress, "Visit_ServiceHourInstructions")
       Ok(views.html.serviceHoursInstructions(commonData, request.identity, isMobile))
     }
   }
@@ -268,14 +268,14 @@ class ApplicationController @Inject() (
         commonData       <- configService.getCommonPageData(request2Messages.lang)
         timeSpent: Float <- userService.getHoursAuditingAndValidating(request.identity.userId)
       } yield {
-        cc.loggingService.insert(request.identity.userId, request.remoteAddress, "Visit_TimeCheck")
+        cc.loggingService.insert(request.identity.userId, request.ipAddress, "Visit_TimeCheck")
         Ok(views.html.timeCheck(commonData, request.identity, isMobile, timeSpent))
       }
   }
 
   def routeBuilder = cc.securityService.SecuredAction { implicit request =>
     configService.getCommonPageData(request2Messages.lang).map { commonData =>
-      cc.loggingService.insert(request.identity.userId, request.remoteAddress, "Visit_RouteBuilder")
+      cc.loggingService.insert(request.identity.userId, request.ipAddress, "Visit_RouteBuilder")
       Ok(views.html.apps.routeBuilder(commonData, request.identity))
     }
   }
@@ -285,7 +285,7 @@ class ApplicationController @Inject() (
    */
   def cities = cc.securityService.SecuredAction { implicit request =>
     configService.getCommonPageData(request2Messages.lang).map { commonData =>
-      cc.loggingService.insert(request.identity.userId, request.remoteAddress, "Visit_Deployment_Cities_Dashboard")
+      cc.loggingService.insert(request.identity.userId, request.ipAddress, "Visit_Deployment_Cities_Dashboard")
       Ok(views.html.deploymentSitesDashboard("Project Sidewalk - Cities", commonData, request.identity))
     }
   }

--- a/app/controllers/ApplicationController.scala
+++ b/app/controllers/ApplicationController.scala
@@ -6,7 +6,7 @@ import controllers.helper.ControllerUtils.parseIntegerSeq
 import models.auth.{DefaultEnv, WithSignedIn}
 import models.label.LabelTypeEnum
 import models.user.SidewalkUserWithRole
-import models.utils.{MyPostgresProfile, WebpageActivity}
+import models.utils.MyPostgresProfile
 import play.api.Configuration
 import play.api.db.slick.{DatabaseConfigProvider, HasDatabaseConfigProvider}
 import play.api.i18n.{Lang, Messages}
@@ -53,18 +53,18 @@ class ApplicationController @Inject() (
       case Some(ref) =>
         val redirectTo: String      = qString.getOrElse("to", "/")
         val activityLogText: String = s"Referrer=${ref}_SendTo=$redirectTo"
-        cc.loggingService.insert(WebpageActivity(0, user.userId, ipAddress, activityLogText, timestamp))
+        cc.loggingService.insert(user.userId, ipAddress, activityLogText, timestamp)
         Future.successful(Redirect(redirectTo))
       case None =>
         // When there are no referrers, load the landing page but store the query parameters that were passed anyway.
         if (qString.nonEmpty) {
           // Log the query string parameters if they exist, but do a redirect to hide them.
-          cc.loggingService.insert(WebpageActivity(0, user.userId, ipAddress, request.uri, timestamp))
+          cc.loggingService.insert(user.userId, ipAddress, request.uri, timestamp)
           Future.successful(Redirect("/"))
         } else if (isMobile) {
           Future.successful(Redirect("/mobile"))
         } else {
-          cc.loggingService.insert(WebpageActivity(0, user.userId, ipAddress, "Visit_Index", timestamp))
+          cc.loggingService.insert(user.userId, ipAddress, "Visit_Index", timestamp)
           // Get names and URLs for other cities so we can link to them on landing page.
           val metric: Boolean = Messages("measurement.system") == "metric"
           for {

--- a/app/controllers/ClusterController.scala
+++ b/app/controllers/ClusterController.scala
@@ -32,7 +32,7 @@ class ClusterController @Inject() (
    * Returns the clustering webpage with GUI if the user is an admin, otherwise redirects to the landing page.
    */
   def index = cc.securityService.SecuredAction(WithAdmin()) { implicit request =>
-    cc.loggingService.insert(request.identity.userId, request.remoteAddress, "Visit_Clustering")
+    cc.loggingService.insert(request.identity.userId, request.ipAddress, "Visit_Clustering")
     configService
       .getCommonPageData(request2Messages.lang)
       .map(commonData => Ok(views.html.clustering(commonData, "Sidewalk - Clustering", request.identity)))
@@ -51,7 +51,7 @@ class ClusterController @Inject() (
    * @param clusteringType One of "singleUser", "multiUser", or "both".
    */
   def runClustering(clusteringType: String) = cc.securityService.SecuredAction(WithAdmin()) { implicit request =>
-    cc.loggingService.insert(request.identity.userId, request.remoteAddress, request.toString)
+    cc.loggingService.insert(request.identity.userId, request.ipAddress, request.toString)
 
     // Create a shared status object for clustering progress updates.
     val statusRef = new AtomicReference[String]("Starting")

--- a/app/controllers/ExploreController.scala
+++ b/app/controllers/ExploreController.scala
@@ -75,7 +75,7 @@ class ExploreController @Inject() (
         else if (regionId.isDefined) s"Visit_Audit_RegionId=${regionId.get}"
         else if (newRegion) "Visit_Audit_NewRegionSelected"
         else "Visit_Audit"
-      cc.loggingService.insert(user.userId, request.remoteAddress, activityStr)
+      cc.loggingService.insert(user.userId, request.ipAddress, activityStr)
 
       // Load the Explore page. The match statement below just passes along any extra params when using `streetEdgeId`.
       // If user is an admin and a panoId or lat/lng are supplied, send to that location, o/w send to street.
@@ -100,7 +100,7 @@ class ExploreController @Inject() (
         exploreService
           .insertComment(
             AuditTaskComment(0, data.auditTaskId, data.missionId, data.streetEdgeId, request.identity.userId,
-              request.remoteAddress, data.gsvPanoramaId, data.heading, data.pitch, data.zoom, data.lat, data.lng,
+              request.ipAddress, data.gsvPanoramaId, data.heading, data.pitch, data.zoom, data.lat, data.lng,
               OffsetDateTime.now, data.comment)
           )
           .map { commentId: Int => Ok(Json.obj("comment_id" -> commentId)) }
@@ -125,8 +125,8 @@ class ExploreController @Inject() (
     submission.fold(
       errors => { Future.successful(BadRequest(Json.obj("status" -> "Error", "message" -> JsError.toJson(errors)))) },
       data => {
-        exploreService.submitSurvey(request.identity.userId, request.remoteAddress, data).map { _ =>
-          cc.loggingService.insert(request.identity.userId, request.remoteAddress, "SurveySubmit")
+        exploreService.submitSurvey(request.identity.userId, request.ipAddress, data).map { _ =>
+          cc.loggingService.insert(request.identity.userId, request.ipAddress, "SurveySubmit")
           Ok(Json.obj("survey_success" -> "True"))
         }
       }
@@ -153,7 +153,7 @@ class ExploreController @Inject() (
         exploreService
           .insertNoGsv(
             StreetEdgeIssue(
-              0, streetEdgeId, "GSVNotAvailable", request.identity.userId, request.remoteAddress, OffsetDateTime.now
+              0, streetEdgeId, "GSVNotAvailable", request.identity.userId, request.ipAddress, OffsetDateTime.now
             )
           )
           .map(_ => Ok)
@@ -185,7 +185,7 @@ class ExploreController @Inject() (
     val submission    = json.validate[AuditTaskSubmission]
     submission.fold(
       errors => { Future.successful(BadRequest(Json.obj("status" -> "Error", "message" -> JsError.toJson(errors)))) },
-      submission => { processAuditTaskSubmissions(submission, request.remoteAddress, request.identity) }
+      submission => { processAuditTaskSubmissions(submission, request.ipAddress, request.identity) }
     )
   }
 
@@ -196,7 +196,7 @@ class ExploreController @Inject() (
     val submission = request.body.validate[AuditTaskSubmission]
     submission.fold(
       errors => { Future.successful(BadRequest(Json.obj("status" -> "Error", "message" -> JsError.toJson(errors)))) },
-      submission => { processAuditTaskSubmissions(submission, request.remoteAddress, request.identity) }
+      submission => { processAuditTaskSubmissions(submission, request.ipAddress, request.identity) }
     )
   }
 

--- a/app/controllers/GalleryController.scala
+++ b/app/controllers/GalleryController.scala
@@ -67,7 +67,7 @@ class GalleryController @Inject() (
    */
   def processGalleryTaskSubmissions(
       submission: Seq[GalleryTaskSubmission],
-      remoteAddress: String,
+      ipAddress: String,
       userId: String
   ): Future[Result] = {
     for (data <- submission) yield {
@@ -79,8 +79,8 @@ class GalleryController @Inject() (
         })
         _ <- galleryTaskEnvironmentTable.insert(
           GalleryTaskEnvironment(0, env.browser, env.browserVersion, env.browserWidth, env.browserHeight,
-            env.availWidth, env.availHeight, env.screenWidth, env.screenHeight, env.operatingSystem,
-            Some(remoteAddress), env.language, Some(userId))
+            env.availWidth, env.availHeight, env.screenWidth, env.screenHeight, env.operatingSystem, Some(ipAddress),
+            env.language, Some(userId))
         )
       } yield nInteractionSubmitted)
     }
@@ -95,7 +95,7 @@ class GalleryController @Inject() (
     val submission = json.validate[Seq[GalleryTaskSubmission]]
     submission.fold(
       errors => { Future.successful(BadRequest(Json.obj("status" -> "Error", "message" -> JsError.toJson(errors)))) },
-      submission => { processGalleryTaskSubmissions(submission, request.remoteAddress, request.identity.userId) }
+      submission => { processGalleryTaskSubmissions(submission, request.ipAddress, request.identity.userId) }
     )
   }
 
@@ -106,7 +106,7 @@ class GalleryController @Inject() (
     val submission = request.body.validate[Seq[GalleryTaskSubmission]]
     submission.fold(
       errors => { Future.successful(BadRequest(Json.obj("status" -> "Error", "message" -> JsError.toJson(errors)))) },
-      submission => { processGalleryTaskSubmissions(submission, request.remoteAddress, request.identity.userId) }
+      submission => { processGalleryTaskSubmissions(submission, request.ipAddress, request.identity.userId) }
     )
   }
 }

--- a/app/controllers/GeminiController.scala
+++ b/app/controllers/GeminiController.scala
@@ -67,7 +67,7 @@ class GeminiController @Inject() (
       geminiResponse <- sendToGeminiApi(prompt, imageObjects)              // Send to Gemini API
     } yield {
       val activity = s"Analyzing street $streetEdgeId with URLs: ${gsvImageUrls.mkString(", ")}"
-      cc.loggingService.insert(request.identity.userId, request.remoteAddress, activity)
+      cc.loggingService.insert(request.identity.userId, request.ipAddress, activity)
       geminiResponse
     }
   }

--- a/app/controllers/UserProfileController.scala
+++ b/app/controllers/UserProfileController.scala
@@ -48,7 +48,7 @@ class UserProfileController @Inject() (
       userProfileData <- userService.getUserProfileData(user.userId, metricSystem)
       commonData      <- configService.getCommonPageData(request2Messages.lang)
     } yield {
-      cc.loggingService.insert(user.userId, request.remoteAddress, "Visit_UserDashboard")
+      cc.loggingService.insert(user.userId, request.ipAddress, "Visit_UserDashboard")
       Ok(views.html.userProfile(commonData, "Sidewalk - Dashboard", user, user, userProfileData, adminData = None))
     }
   }
@@ -165,7 +165,7 @@ class UserProfileController @Inject() (
    */
   def setUserTeam(userId: String, teamId: Int) =
     cc.securityService.SecuredAction(WithAdminOrRegisteredAndIsUser(userId)) { implicit request =>
-      cc.loggingService.insert(request.identity.userId, request.remoteAddress, request.toString)
+      cc.loggingService.insert(request.identity.userId, request.ipAddress, request.toString)
       userService
         .setUserTeam(userId, teamId)
         .map(_ => Ok(Json.obj("user_id" -> userId, "team_id" -> teamId)))

--- a/app/controllers/ValidateController.scala
+++ b/app/controllers/ValidateController.scala
@@ -53,7 +53,7 @@ class ValidateController @Inject() (
             getDataForValidatePages(user, labelCount = 10, adminParams)
           commonPageData <- configService.getCommonPageData(request2Messages.lang)
         } yield {
-          cc.loggingService.insert(user.userId, request.remoteAddress, "Visit_Validate")
+          cc.loggingService.insert(user.userId, request.ipAddress, "Visit_Validate")
           Ok(
             views.html.apps.validate(commonPageData, "Sidewalk - Validate", user, adminParams, mission, labelList,
               missionProgress, hasNextMission, completedVals)
@@ -82,7 +82,7 @@ class ValidateController @Inject() (
             commonPageData <- configService.getCommonPageData(request2Messages.lang)
             tags: Seq[Tag] <- labelService.getTagsForCurrentCity
           } yield {
-            cc.loggingService.insert(user.userId, request.remoteAddress, "Visit_NewValidateBeta")
+            cc.loggingService.insert(user.userId, request.ipAddress, "Visit_NewValidateBeta")
             Ok(
               views.html.apps.newValidateBeta(commonPageData, "Sidewalk - NewValidateBeta", user, adminParams, mission,
                 labelList, missionProgress, hasNextMission, completedVals, tags)
@@ -111,16 +111,16 @@ class ValidateController @Inject() (
           commonPageData <- configService.getCommonPageData(request2Messages.lang)
         } yield {
           if (!isMobile(request)) {
-            cc.loggingService.insert(user.userId, request.remoteAddress, "Visit_MobileValidate_RedirectHome")
+            cc.loggingService.insert(user.userId, request.ipAddress, "Visit_MobileValidate_RedirectHome")
             Redirect("/")
           } else {
-            cc.loggingService.insert(user.userId, request.remoteAddress, "Visit_MobileValidate")
+            cc.loggingService.insert(user.userId, request.ipAddress, "Visit_MobileValidate")
             Ok(
               views.html.apps.mobileValidate(commonPageData, "Sidewalk - Validate", user, adminParams, mission,
                 labelList, missionProgress, hasNextMission, completedVals)
             )
           }
-          cc.loggingService.insert(user.userId, request.remoteAddress, "Visit_MobileValidate")
+          cc.loggingService.insert(user.userId, request.ipAddress, "Visit_MobileValidate")
           Ok(
             views.html.apps.mobileValidate(commonPageData, "Sidewalk - Validate", user, adminParams, mission, labelList,
               missionProgress, hasNextMission, completedVals)
@@ -148,7 +148,7 @@ class ValidateController @Inject() (
               getDataForValidatePages(user, labelCount = 10, adminParams)
             commonPageData <- configService.getCommonPageData(request2Messages.lang)
           } yield {
-            cc.loggingService.insert(user.userId, request.remoteAddress, "Visit_AdminValidate")
+            cc.loggingService.insert(user.userId, request.ipAddress, "Visit_AdminValidate")
             Ok(
               views.html.apps.validate(commonPageData, "Sidewalk - AdminValidate", user, adminParams, mission,
                 labelList, missionProgress, hasNextMission, completedVals)
@@ -391,7 +391,7 @@ class ValidateController @Inject() (
     val submission = json.validate[ValidationTaskSubmission]
     submission.fold(
       errors => { Future.successful(BadRequest(Json.obj("status" -> "Error", "message" -> JsError.toJson(errors)))) },
-      submission => { processValidationTaskSubmissions(submission, request.remoteAddress, request.identity) }
+      submission => { processValidationTaskSubmissions(submission, request.ipAddress, request.identity) }
     )
   }
 
@@ -402,7 +402,7 @@ class ValidateController @Inject() (
     val submission = request.body.validate[ValidationTaskSubmission]
     submission.fold(
       errors => { Future.successful(BadRequest(Json.obj("status" -> "Error", "message" -> JsError.toJson(errors)))) },
-      submission => { processValidationTaskSubmissions(submission, request.remoteAddress, request.identity) }
+      submission => { processValidationTaskSubmissions(submission, request.ipAddress, request.identity) }
     )
   }
 
@@ -450,7 +450,7 @@ class ValidateController @Inject() (
           _              <- validationService.deleteCommentIfExists(submission.labelId, submission.missionId)
           commentId: Int <- validationService.insertComment(
             ValidationTaskComment(0, submission.missionId, submission.labelId, request.identity.userId,
-              request.remoteAddress, submission.gsvPanoramaId, submission.heading, submission.pitch,
+              request.ipAddress, submission.gsvPanoramaId, submission.heading, submission.pitch,
               Math.round(submission.zoom), submission.lat, submission.lng, OffsetDateTime.now, submission.comment)
           )
         } yield {
@@ -475,7 +475,7 @@ class ValidateController @Inject() (
           mission        <- missionService.resumeOrCreateNewValidationMission(userId, "labelmapValidation", labelTypeId)
           _              <- validationService.deleteCommentIfExists(submission.labelId, mission.get.missionId)
           commentId: Int <- validationService.insertComment(
-            ValidationTaskComment(0, mission.get.missionId, submission.labelId, userId, request.remoteAddress,
+            ValidationTaskComment(0, mission.get.missionId, submission.labelId, userId, request.ipAddress,
               submission.gsvPanoramaId, submission.heading, submission.pitch, Math.round(submission.zoom),
               submission.lat, submission.lng, OffsetDateTime.now, submission.comment)
           )

--- a/app/controllers/api/AccessScoreApiController.scala
+++ b/app/controllers/api/AccessScoreApiController.scala
@@ -61,7 +61,7 @@ class AccessScoreApiController @Inject() (
     } yield {
       val baseFileName: String                  = s"accessScoreStreet_${OffsetDateTime.now()}"
       val streetsStream: Source[StreetScore, _] = Source.fromIterator(() => streetAccessScores.iterator)
-      cc.loggingService.insert(request.identity.map(_.userId), request.remoteAddress, request.toString)
+      cc.loggingService.insert(request.identity.map(_.userId), request.ipAddress, request.toString)
 
       // Output data in the appropriate file format.
       filetype match {
@@ -98,7 +98,7 @@ class AccessScoreApiController @Inject() (
     } yield {
       val baseFileName: String                 = s"accessScoreNeighborhood_${OffsetDateTime.now()}"
       val regionStream: Source[RegionScore, _] = Source.fromIterator(() => neighborhoodAccessScores.iterator)
-      cc.loggingService.insert(request.identity.map(_.userId), request.remoteAddress, request.toString)
+      cc.loggingService.insert(request.identity.map(_.userId), request.ipAddress, request.toString)
 
       // Output data in the appropriate file format.
       filetype match {

--- a/app/controllers/api/CitiesApiController.scala
+++ b/app/controllers/api/CitiesApiController.scala
@@ -72,7 +72,7 @@ class CitiesApiController @Inject() (
     cityDetailsWithMapParams
       .map { cityDetails =>
         // Log the API request.
-        cc.loggingService.insert(request.identity.map(_.userId), request.remoteAddress, request.toString)
+        cc.loggingService.insert(request.identity.map(_.userId), request.ipAddress, request.toString)
 
         // Return response in the requested format.
         filetype match {

--- a/app/controllers/api/LabelApiController.scala
+++ b/app/controllers/api/LabelApiController.scala
@@ -58,7 +58,7 @@ class LabelApiController @Inject() (
     // Set up streaming data from the database.
     val dbDataStream: Source[LabelCVMetadata, _] = apiService.getLabelCVMetadata(DEFAULT_BATCH_SIZE)
     val baseFileName: String                     = s"labelsWithCVMetadata_${OffsetDateTime.now()}"
-    cc.loggingService.insert(request.identity.map(_.userId), request.remoteAddress, request.toString)
+    cc.loggingService.insert(request.identity.map(_.userId), request.ipAddress, request.toString)
 
     // Output data in the appropriate file format: CSV or JSON (default).
     filetype match {
@@ -75,7 +75,7 @@ class LabelApiController @Inject() (
    * @return JSON response containing label type information
    */
   def getLabelTypes = silhouette.UserAwareAction.async { request =>
-    cc.loggingService.insert(request.identity.map(_.userId), request.remoteAddress, request.toString)
+    cc.loggingService.insert(request.identity.map(_.userId), request.ipAddress, request.toString)
     val labelTypeDetailsList: Seq[LabelTypeForApi] = apiService.getLabelTypes(request.lang).toList.sortBy(_.id)
     Future.successful(Ok(Json.obj("status" -> "OK", "labelTypes" -> labelTypeDetailsList)))
   }
@@ -89,7 +89,7 @@ class LabelApiController @Inject() (
    * @return JSON response containing label tag information.
    */
   def getLabelTags = silhouette.UserAwareAction.async { request =>
-    cc.loggingService.insert(request.identity.map(_.userId), request.remoteAddress, request.toString)
+    cc.loggingService.insert(request.identity.map(_.userId), request.ipAddress, request.toString)
     labelService.getTagsForCurrentCity
       .map { tags =>
         val formattedTags = tags.map { tag =>
@@ -151,7 +151,7 @@ class LabelApiController @Inject() (
       filetype: Option[String],
       inline: Option[Boolean]
   ) = silhouette.UserAwareAction.async { implicit request =>
-    cc.loggingService.insert(request.identity.map(_.userId), request.remoteAddress, request.toString)
+    cc.loggingService.insert(request.identity.map(_.userId), request.ipAddress, request.toString)
 
     // Parse bbox parameter.
     val parsedBbox: Option[LatLngBBox] = parseBBoxString(bbox)

--- a/app/controllers/api/LabelClustersApiController.scala
+++ b/app/controllers/api/LabelClustersApiController.scala
@@ -72,7 +72,7 @@ class LabelClustersApiController @Inject() (
       filetype: Option[String],
       inline: Option[Boolean]
   ) = silhouette.UserAwareAction.async { implicit request =>
-    cc.loggingService.insert(request.identity.map(_.userId), request.remoteAddress, request.toString)
+    cc.loggingService.insert(request.identity.map(_.userId), request.ipAddress, request.toString)
     try {
       // Parse bbox parameter.
       val parsedBbox: Option[LatLngBBox] = parseBBoxString(bbox)
@@ -241,7 +241,7 @@ class LabelClustersApiController @Inject() (
       filetype: Option[String],
       inline: Option[Boolean]
   ) = silhouette.UserAwareAction.async { implicit request =>
-    cc.loggingService.insert(request.identity.map(_.userId), request.remoteAddress, request.toString)
+    cc.loggingService.insert(request.identity.map(_.userId), request.ipAddress, request.toString)
 
     configService.getCityMapParams.flatMap { cityMapParams =>
       val bbox: LatLngBBox = LatLngBBox(
@@ -328,7 +328,7 @@ class LabelClustersApiController @Inject() (
       filetype: Option[String],
       inline: Option[Boolean]
   ) = silhouette.UserAwareAction.async { implicit request =>
-    cc.loggingService.insert(request.identity.map(_.userId), request.remoteAddress, request.toString)
+    cc.loggingService.insert(request.identity.map(_.userId), request.ipAddress, request.toString)
 
     configService.getCityMapParams.flatMap { cityMapParams =>
       val bbox: LatLngBBox     = createBBox(lat1, lng1, lat2, lng2, cityMapParams)

--- a/app/controllers/api/RegionApiController.scala
+++ b/app/controllers/api/RegionApiController.scala
@@ -25,7 +25,7 @@ class RegionApiController @Inject() (
   def getRegionWithMostLabels = silhouette.UserAwareAction.async { implicit request =>
     apiService.getRegionWithMostLabels.map {
       case Some(region) =>
-        cc.loggingService.insert(request.identity.map(_.userId), request.remoteAddress, request.toString)
+        cc.loggingService.insert(request.identity.map(_.userId), request.ipAddress, request.toString)
         Ok(Json.toJson(region))
       case None =>
         NotFound(Json.obj("status" -> "NOT_FOUND", "message" -> "No region found with labels"))

--- a/app/controllers/api/StatsApiController.scala
+++ b/app/controllers/api/StatsApiController.scala
@@ -51,7 +51,7 @@ class StatsApiController @Inject() (
       )
       .map { filteredStats: Seq[UserStatApi] =>
         val baseFileName: String = s"userStats_${OffsetDateTime.now()}"
-        cc.loggingService.insert(request.identity.map(_.userId), request.remoteAddress, request.toString)
+        cc.loggingService.insert(request.identity.map(_.userId), request.ipAddress, request.toString)
 
         // Output data in the appropriate file format: CSV or JSON (default).
         filetype match {
@@ -75,7 +75,7 @@ class StatsApiController @Inject() (
     implicit request =>
       apiService.getOverallStats(filterLowQuality).map { stats: ProjectSidewalkStats =>
         val baseFileName: String = s"projectSidewalkStats_${OffsetDateTime.now()}"
-        cc.loggingService.insert(request.identity.map(_.userId), request.remoteAddress, request.toString)
+        cc.loggingService.insert(request.identity.map(_.userId), request.ipAddress, request.toString)
 
         // Output data in the appropriate file format: CSV or JSON (default).
         filetype match {
@@ -136,7 +136,7 @@ class StatsApiController @Inject() (
     configService
       .getAggregateStats()
       .map { aggregateStats =>
-        cc.loggingService.insert(request.identity.map(_.userId), request.remoteAddress, request.toString)
+        cc.loggingService.insert(request.identity.map(_.userId), request.ipAddress, request.toString)
 
         // Generate response in the requested format.
         filetype match {

--- a/app/controllers/api/StreetsApiController.scala
+++ b/app/controllers/api/StreetsApiController.scala
@@ -123,7 +123,7 @@ class StreetsApiController @Inject() (
         // Get the data stream.
         val dbDataStream: Source[StreetDataForApi, _] = apiService.getStreets(filters, DEFAULT_BATCH_SIZE)
         val baseFileName: String                      = s"streets_${OffsetDateTime.now()}"
-        cc.loggingService.insert(request.identity.map(_.userId), request.remoteAddress, request.toString)
+        cc.loggingService.insert(request.identity.map(_.userId), request.ipAddress, request.toString)
 
         // Output data in the appropriate file format.
         filetype match {
@@ -152,7 +152,7 @@ class StreetsApiController @Inject() (
     apiService
       .getStreetTypes(request.lang)
       .map { types =>
-        cc.loggingService.insert(request.identity.map(_.userId), request.remoteAddress, request.toString)
+        cc.loggingService.insert(request.identity.map(_.userId), request.ipAddress, request.toString)
         Ok(Json.obj("status" -> "OK", "streetTypes" -> types))
       }
       .recover { case e: Exception =>

--- a/app/controllers/api/ValidationApiController.scala
+++ b/app/controllers/api/ValidationApiController.scala
@@ -58,7 +58,7 @@ class ValidationApiController @Inject() (
       filetype: Option[String],
       inline: Option[Boolean]
   ) = silhouette.UserAwareAction.async { implicit request =>
-    cc.loggingService.insert(request.identity.map(_.userId), request.remoteAddress, request.toString)
+    cc.loggingService.insert(request.identity.map(_.userId), request.ipAddress, request.toString)
     try {
       // Parse timestamp if provided.
       val parsedTimestamp: Option[OffsetDateTime] = parseDateTimeString(validationTimestamp)
@@ -145,7 +145,7 @@ class ValidationApiController @Inject() (
     try {
       apiService.getValidationResultTypes
         .map { validationTypes =>
-          cc.loggingService.insert(request.identity.map(_.userId), request.remoteAddress, request.toString)
+          cc.loggingService.insert(request.identity.map(_.userId), request.ipAddress, request.toString)
           Ok(Json.obj("status" -> "OK", "validation_result_types" -> validationTypes))
         }
         .recover { case e: Exception =>

--- a/app/controllers/base/CustomBaseController.scala
+++ b/app/controllers/base/CustomBaseController.scala
@@ -15,5 +15,17 @@ abstract class CustomBaseController(cc: CustomControllerComponents)
   //  protected def loggingService: LoggingService = cc.loggingService
   //  protected def securityService: CustomControllerComponents = cc.securityService
 
+  // Adds a ipAddress method to RequestHeader for easy access to the client's IP address (cleaner than remoteAddress).
+  // See: https://github.com/ProjectSidewalk/SidewalkWebpage/issues/465
+  implicit class RequestHeaderExtensions(request: RequestHeader) {
+    def ipAddress: String = {
+      request.headers.get("X-Forwarded-For")
+        .map(_.split(",").head.trim)
+        .filter(_.nonEmpty)
+        .orElse(request.headers.get("X-Real-IP"))
+        .getOrElse(request.remoteAddress.split(",").head.trim)
+    }
+  }
+
   // Could add other common controller utilities here. Not sure if they should be here or in ControllerUtils.scala.
 }

--- a/conf/evolutions/default/278.sql
+++ b/conf/evolutions/default/278.sql
@@ -1,0 +1,12 @@
+# --- !Ups
+-- Fixes IP addresses that have multiple values separated by commas to only show the first.
+UPDATE audit_task_comment SET ip_address = TRIM(SPLIT_PART(ip_address, ',', 1)) WHERE ip_address LIKE '%,%';
+UPDATE audit_task_environment SET ip_address = TRIM(SPLIT_PART(ip_address, ',', 1)) WHERE ip_address LIKE '%,%';
+UPDATE gallery_task_environment SET ip_address = TRIM(SPLIT_PART(ip_address, ',', 1)) WHERE ip_address LIKE '%,%';
+UPDATE street_edge_issue SET ip_address = TRIM(SPLIT_PART(ip_address, ',', 1)) WHERE ip_address LIKE '%,%';
+UPDATE validation_task_comment SET ip_address = TRIM(SPLIT_PART(ip_address, ',', 1)) WHERE ip_address LIKE '%,%';
+UPDATE validation_task_environment SET ip_address = TRIM(SPLIT_PART(ip_address, ',', 1)) WHERE ip_address LIKE '%,%';
+UPDATE webpage_activity SET ip_address = TRIM(SPLIT_PART(ip_address, ',', 1)) WHERE ip_address LIKE '%,%';
+
+# --- !Downs
+-- No way to revert this change as the old data is lost. Would need to restore from a backup if necessary.


### PR DESCRIPTION
Resolves #465

Instead of logging the full IP address list that includes proxies, we're now just logging the first IP address in the list (which should be the correct one). I also added a database evolution that fixes this for all past entries in every table that stores IP addresses.

To enable these changes, I added a new method to the `RequestHeader` object called `ipAddress`, which does all of this cleaning automatically. So wherever we used to use `request.remoteAddress`, we should just use `request.ipAddress` instead! I've changed this everywhere in the code, and I'm hoping that it's pretty easy to remember going forward.