### PR TITLE
Adds Validate URL param: unvalidatedOnly

### DIFF
--- a/app/controllers/ValidateController.scala
+++ b/app/controllers/ValidateController.scala
@@ -2,7 +2,7 @@ package controllers
 
 import controllers.base._
 import controllers.helper.ControllerUtils.{isAdmin, isMobile}
-import controllers.helper.ValidateHelper.AdminValidateParams
+import controllers.helper.ValidateHelper.ValidateParams
 import formats.json.CommentSubmissionFormats.{LabelMapValidationCommentSubmission, ValidationCommentSubmission}
 import formats.json.LabelFormats
 import formats.json.LabelFormats.validationLabelMetadataToJson
@@ -42,27 +42,29 @@ class ValidateController @Inject() (
 
   /**
    * Returns the validation page.
-   * @param neighborhoods   Comma-separated list of neighborhood names or region IDs to validate (could be mixed).
+   * @param neighborhoods Comma-separated list of neighborhood names or region IDs to validate (could be mixed).
    */
-  def validate(neighborhoods: Option[String]) = cc.securityService.SecuredAction { implicit request =>
-    checkParams(adminVersion = false, None, None, neighborhoods).flatMap { case (adminParams, response) =>
-      if (response.header.status == 200) {
-        val user: SidewalkUserWithRole = request.identity
-        for {
-          (mission, labelList, missionProgress, hasNextMission, completedVals) <-
-            getDataForValidatePages(user, labelCount = 10, adminParams)
-          commonPageData <- configService.getCommonPageData(request2Messages.lang)
-        } yield {
-          cc.loggingService.insert(user.userId, request.ipAddress, "Visit_Validate")
-          Ok(
-            views.html.apps.validate(commonPageData, "Sidewalk - Validate", user, adminParams, mission, labelList,
-              missionProgress, hasNextMission, completedVals)
-          )
-        }
-      } else {
-        Future.successful(response)
+  def validate(neighborhoods: Option[String], unvalidatedOnly: Option[Boolean]) = cc.securityService.SecuredAction {
+    implicit request =>
+      checkParams(adminVersion = false, None, None, neighborhoods, unvalidatedOnly).flatMap {
+        case (validateParams, response) =>
+          if (response.header.status == 200) {
+            val user: SidewalkUserWithRole = request.identity
+            for {
+              (mission, labelList, missionProgress, hasNextMission, completedVals) <-
+                getDataForValidatePages(user, labelCount = 10, validateParams)
+              commonPageData <- configService.getCommonPageData(request2Messages.lang)
+            } yield {
+              cc.loggingService.insert(user.userId, request.ipAddress, "Visit_Validate")
+              Ok(
+                views.html.apps.validate(commonPageData, "Sidewalk - Validate", user, validateParams, mission,
+                  labelList, missionProgress, hasNextMission, completedVals)
+              )
+            }
+          } else {
+            Future.successful(response)
+          }
       }
-    }
   }
 
   /**
@@ -71,26 +73,32 @@ class ValidateController @Inject() (
    * @param users           Comma-separated list of usernames or user IDs to validate (could be mixed).
    * @param neighborhoods   Comma-separated list of neighborhood names or region IDs to validate (could be mixed).
    */
-  def expertValidate(labelType: Option[String], users: Option[String], neighborhoods: Option[String]) =
+  def expertValidate(
+      labelType: Option[String],
+      users: Option[String],
+      neighborhoods: Option[String],
+      unvalidatedOnly: Option[Boolean]
+  ) =
     cc.securityService.SecuredAction(WithAdmin()) { implicit request =>
-      checkParams(adminVersion = true, labelType, users, neighborhoods).flatMap { case (adminParams, response) =>
-        if (response.header.status == 200) {
-          val user: SidewalkUserWithRole = request.identity
-          for {
-            (mission, labelList, missionProgress, hasNextMission, completedVals) <-
-              getDataForValidatePages(user, labelCount = 10, adminParams)
-            commonPageData <- configService.getCommonPageData(request2Messages.lang)
-            tags: Seq[Tag] <- labelService.getTagsForCurrentCity
-          } yield {
-            cc.loggingService.insert(user.userId, request.ipAddress, "Visit_ExpertValidate")
-            Ok(
-              views.html.apps.expertValidate(commonPageData, "Sidewalk - Expert Validate", user, adminParams, mission,
-                labelList, missionProgress, hasNextMission, completedVals, tags)
-            )
+      checkParams(adminVersion = true, labelType, users, neighborhoods, unvalidatedOnly).flatMap {
+        case (validateParams, response) =>
+          if (response.header.status == 200) {
+            val user: SidewalkUserWithRole = request.identity
+            for {
+              (mission, labelList, missionProgress, hasNextMission, completedVals) <-
+                getDataForValidatePages(user, labelCount = 10, validateParams)
+              commonPageData <- configService.getCommonPageData(request2Messages.lang)
+              tags: Seq[Tag] <- labelService.getTagsForCurrentCity
+            } yield {
+              cc.loggingService.insert(user.userId, request.ipAddress, "Visit_ExpertValidate")
+              Ok(
+                views.html.apps.expertValidate(commonPageData, "Sidewalk - Expert Validate", user, validateParams,
+                  mission, labelList, missionProgress, hasNextMission, completedVals, tags)
+              )
+            }
+          } else {
+            Future.successful(response)
           }
-        } else {
-          Future.successful(response)
-        }
       }
     }
 
@@ -98,39 +106,41 @@ class ValidateController @Inject() (
    * Returns the validation page for mobile.
    * @param neighborhoods   Comma-separated list of neighborhood names or region IDs to validate (could be mixed).
    */
-  def mobileValidate(neighborhoods: Option[String]) = cc.securityService.SecuredAction { implicit request =>
-    checkParams(adminVersion = false, None, None, neighborhoods).flatMap { case (adminParams, response) =>
-      if (response.header.status == 200) {
-        val user: SidewalkUserWithRole = request.identity
-        for {
-          (mission, labelList, missionProgress, hasNextMission, completedVals) <- getDataForValidatePages(
-            user,
-            labelCount = 10,
-            adminParams
-          )
-          commonPageData <- configService.getCommonPageData(request2Messages.lang)
-        } yield {
-          if (!isMobile(request)) {
-            cc.loggingService.insert(user.userId, request.ipAddress, "Visit_MobileValidate_RedirectHome")
-            Redirect("/")
+  def mobileValidate(neighborhoods: Option[String], unvalidatedOnly: Option[Boolean]) =
+    cc.securityService.SecuredAction { implicit request =>
+      checkParams(adminVersion = false, None, None, neighborhoods, unvalidatedOnly).flatMap {
+        case (validateParams, response) =>
+          if (response.header.status == 200) {
+            val user: SidewalkUserWithRole = request.identity
+            for {
+              (mission, labelList, missionProgress, hasNextMission, completedVals) <- getDataForValidatePages(
+                user,
+                labelCount = 10,
+                validateParams
+              )
+              commonPageData <- configService.getCommonPageData(request2Messages.lang)
+            } yield {
+              if (!isMobile(request)) {
+                cc.loggingService.insert(user.userId, request.ipAddress, "Visit_MobileValidate_RedirectHome")
+                Redirect("/")
+              } else {
+                cc.loggingService.insert(user.userId, request.ipAddress, "Visit_MobileValidate")
+                Ok(
+                  views.html.apps.mobileValidate(commonPageData, "Sidewalk - Validate", user, validateParams, mission,
+                    labelList, missionProgress, hasNextMission, completedVals)
+                )
+              }
+              cc.loggingService.insert(user.userId, request.ipAddress, "Visit_MobileValidate")
+              Ok(
+                views.html.apps.mobileValidate(commonPageData, "Sidewalk - Validate", user, validateParams, mission,
+                  labelList, missionProgress, hasNextMission, completedVals)
+              )
+            }
           } else {
-            cc.loggingService.insert(user.userId, request.ipAddress, "Visit_MobileValidate")
-            Ok(
-              views.html.apps.mobileValidate(commonPageData, "Sidewalk - Validate", user, adminParams, mission,
-                labelList, missionProgress, hasNextMission, completedVals)
-            )
+            Future.successful(response)
           }
-          cc.loggingService.insert(user.userId, request.ipAddress, "Visit_MobileValidate")
-          Ok(
-            views.html.apps.mobileValidate(commonPageData, "Sidewalk - Validate", user, adminParams, mission, labelList,
-              missionProgress, hasNextMission, completedVals)
-          )
-        }
-      } else {
-        Future.successful(response)
       }
     }
-  }
 
   /**
    * Returns an admin version of the validation page.
@@ -138,25 +148,31 @@ class ValidateController @Inject() (
    * @param users           Comma-separated list of usernames or user IDs to validate (could be mixed).
    * @param neighborhoods   Comma-separated list of neighborhood names or region IDs to validate (could be mixed).
    */
-  def adminValidate(labelType: Option[String], users: Option[String], neighborhoods: Option[String]) =
+  def adminValidate(
+      labelType: Option[String],
+      users: Option[String],
+      neighborhoods: Option[String],
+      unvalidatedOnly: Option[Boolean]
+  ) =
     cc.securityService.SecuredAction(WithAdmin()) { implicit request =>
-      checkParams(adminVersion = true, labelType, users, neighborhoods).flatMap { case (adminParams, response) =>
-        if (response.header.status == 200) {
-          val user: SidewalkUserWithRole = request.identity
-          for {
-            (mission, labelList, missionProgress, hasNextMission, completedVals) <-
-              getDataForValidatePages(user, labelCount = 10, adminParams)
-            commonPageData <- configService.getCommonPageData(request2Messages.lang)
-          } yield {
-            cc.loggingService.insert(user.userId, request.ipAddress, "Visit_AdminValidate")
-            Ok(
-              views.html.apps.validate(commonPageData, "Sidewalk - AdminValidate", user, adminParams, mission,
-                labelList, missionProgress, hasNextMission, completedVals)
-            )
+      checkParams(adminVersion = true, labelType, users, neighborhoods, unvalidatedOnly).flatMap {
+        case (validateParams, response) =>
+          if (response.header.status == 200) {
+            val user: SidewalkUserWithRole = request.identity
+            for {
+              (mission, labelList, missionProgress, hasNextMission, completedVals) <-
+                getDataForValidatePages(user, labelCount = 10, validateParams)
+              commonPageData <- configService.getCommonPageData(request2Messages.lang)
+            } yield {
+              cc.loggingService.insert(user.userId, request.ipAddress, "Visit_AdminValidate")
+              Ok(
+                views.html.apps.validate(commonPageData, "Sidewalk - AdminValidate", user, validateParams, mission,
+                  labelList, missionProgress, hasNextMission, completedVals)
+              )
+            }
+          } else {
+            Future.successful(response)
           }
-        } else {
-          Future.successful(response)
-        }
       }
     }
 
@@ -171,8 +187,9 @@ class ValidateController @Inject() (
       adminVersion: Boolean,
       labelType: Option[String],
       users: Option[String],
-      neighborhoods: Option[String]
-  ): Future[(AdminValidateParams, Result)] = {
+      neighborhoods: Option[String],
+      unvalidatedOnly: Option[Boolean]
+  ): Future[(ValidateParams, Result)] = {
     // If any inputs are invalid, send back error message. For each input, we check if the input is an integer
     // representing a valid ID (label_type_id, user_id, or region_id) or a String representing a valid name for that
     // parameter (label_type, username, or region_name).
@@ -224,29 +241,27 @@ class ValidateController @Inject() (
         case None            => Future.successful(None)
       }
     } yield {
-      // Return a BadRequest if anything is wrong, or the AdminValidateParams if everything looks good.
+      // Return a BadRequest if anything is wrong, or the ValidateParams if everything looks good.
       if (parsedLabelTypeId.isDefined && parsedLabelTypeId.get.isEmpty) {
         (
-          AdminValidateParams(adminVersion),
+          ValidateParams(adminVersion),
           BadRequest(s"Invalid label type provided: ${labelType.get}. Valid label types are: ${LabelTypeEnum.primaryLabelTypes.mkString(", ")}. Or you can use their IDs: ${LabelTypeEnum.primaryLabelTypeIds.mkString(", ")}.")
         )
       } else if (userIds.isDefined && userIds.get.length != userIds.get.flatten.length) {
         (
-          AdminValidateParams(adminVersion),
+          ValidateParams(adminVersion),
           BadRequest(s"One or more of the users provided were not found; please double check your list of users! You can use either their usernames or user IDs. You provided: ${users.get}")
         )
       } else if (regionIds.isDefined && regionIds.get.length != regionIds.get.flatten.length) {
         (
-          AdminValidateParams(adminVersion),
+          ValidateParams(adminVersion),
           BadRequest(s"One or more of the neighborhoods provided were not found; please double check your list of neighborhoods! You can use either their names or IDs. You provided: ${neighborhoods.get}")
         )
       } else {
         (
-          AdminValidateParams(
-            adminVersion,
-            parsedLabelTypeId.flatten,
-            userIds.map(_.flatten),
-            regionIds.map(_.flatten)
+          ValidateParams(
+            adminVersion, parsedLabelTypeId.flatten, userIds.map(_.flatten), regionIds.map(_.flatten),
+            unvalidatedOnly.getOrElse(false)
           ),
           Ok("")
         )
@@ -262,11 +277,11 @@ class ValidateController @Inject() (
   def getDataForValidatePages(
       user: SidewalkUserWithRole,
       labelCount: Int,
-      adminParams: AdminValidateParams
+      validateParams: ValidateParams
   ): Future[(Option[JsValue], Option[JsValue], Option[JsObject], Boolean, Int)] = {
     for {
       (mission, missionProgress, labels, adminData) <-
-        labelService.getDataForValidationPages(user, labelCount, adminParams)
+        labelService.getDataForValidationPages(user, labelCount, validateParams)
       completedValidations <- validationService.countValidations(user.userId)
     } yield {
       val missionJsObject: Option[JsValue] = mission.map(m => Json.toJson(m))
@@ -278,7 +293,7 @@ class ValidateController @Inject() (
         )
       )
       val hasDataForMission: Boolean          = labels.nonEmpty
-      val labelMetadataJsonSeq: Seq[JsObject] = if (adminParams.adminVersion) {
+      val labelMetadataJsonSeq: Seq[JsObject] = if (validateParams.adminVersion) {
         labels
           .sortBy(_.labelId)
           .zip(adminData.sortBy(_.labelId))
@@ -323,10 +338,10 @@ class ValidateController @Inject() (
       })
 
       // Get data to return in POST response. Not much unless the mission is over and we need the next batch of labels.
-      returnValue <- labelService.getDataForValidatePostRequest(user, data.missionProgress, data.adminParams)
+      returnValue <- labelService.getDataForValidatePostRequest(user, data.missionProgress, data.validateParams)
     } yield {
       // Put label metadata into JSON format.
-      val labelMetadataJsonSeq: Seq[JsObject] = if (data.adminParams.adminVersion) {
+      val labelMetadataJsonSeq: Seq[JsObject] = if (data.validateParams.adminVersion) {
         returnValue.labels
           .sortBy(_.labelId)
           .zip(returnValue.adminData.sortBy(_.labelId))
@@ -500,19 +515,20 @@ class ValidateController @Inject() (
       submission.fold(
         errors => { Future.successful(BadRequest(Json.obj("status" -> "Error", "message" -> JsError.toJson(errors)))) },
         submission => {
-          val adminParams: AdminValidateParams =
-            if (submission.adminParams.adminVersion && isAdmin(request.identity)) submission.adminParams
-            else AdminValidateParams(adminVersion = false)
+          val validateParams: ValidateParams =
+            if (submission.validateParams.adminVersion && isAdmin(request.identity)) submission.validateParams
+            else ValidateParams(adminVersion = false)
           val userId: String = request.identity.userId
 
           // Get metadata for one new label to replace the skipped one.
           // TODO should really exclude all remaining labels in the mission, not just the skipped one. Not bothering now
           //      because it isn't a heavily used feature, and it's a rare edge case.
           labelService
-            .retrieveLabelListForValidation(userId, n = 1, labelTypeId, adminParams.userIds.map(_.toSet),
-              adminParams.neighborhoodIds.map(_.toSet), skippedLabelId = Some(skippedLabelId))
+            .retrieveLabelListForValidation(userId, n = 1, labelTypeId, validateParams.userIds.map(_.toSet),
+              validateParams.neighborhoodIds.map(_.toSet), validateParams.unvalidatedOnly,
+              skippedLabelId = Some(skippedLabelId))
             .flatMap { labelMetadata =>
-              if (adminParams.adminVersion) {
+              if (validateParams.adminVersion) {
                 labelService
                   .getExtraAdminValidateData(Seq(labelMetadata.head.labelId))
                   .map(adminData =>

--- a/app/controllers/helper/ValidateHelper.scala
+++ b/app/controllers/helper/ValidateHelper.scala
@@ -1,11 +1,12 @@
 package controllers.helper
 
 object ValidateHelper {
-  case class AdminValidateParams(
+  case class ValidateParams(
       adminVersion: Boolean,
       labelTypeId: Option[Int] = None,
       userIds: Option[Seq[String]] = None,
-      neighborhoodIds: Option[Seq[Int]] = None
+      neighborhoodIds: Option[Seq[Int]] = None,
+      unvalidatedOnly: Boolean = false
   ) {
     require(labelTypeId.isEmpty || adminVersion, "labelTypeId can only be set if adminVersion is true")
     require(userIds.isEmpty || adminVersion, "userIds can only be set if adminVersion is true")

--- a/app/formats/json/ValidateFormats.scala
+++ b/app/formats/json/ValidateFormats.scala
@@ -1,6 +1,6 @@
 package formats.json
 
-import controllers.helper.ValidateHelper.AdminValidateParams
+import controllers.helper.ValidateHelper.ValidateParams
 import formats.json.CommentSubmissionFormats.ValidationCommentSubmission
 import formats.json.PanoHistoryFormats._
 import play.api.libs.functional.syntax._
@@ -57,7 +57,7 @@ object ValidateFormats {
       undone: Boolean,
       redone: Boolean
   )
-  case class SkipLabelSubmission(labels: Seq[LabelValidationSubmission], adminParams: AdminValidateParams)
+  case class SkipLabelSubmission(labels: Seq[LabelValidationSubmission], validateParams: ValidateParams)
   case class ValidationMissionProgress(
       missionId: Int,
       missionType: String,
@@ -72,7 +72,7 @@ object ValidateFormats {
       environment: EnvironmentSubmission,
       validations: Seq[LabelValidationSubmission],
       missionProgress: Option[ValidationMissionProgress],
-      adminParams: AdminValidateParams,
+      validateParams: ValidateParams,
       panoHistories: Seq[PanoHistorySubmission],
       source: String,
       timestamp: OffsetDateTime
@@ -160,19 +160,20 @@ object ValidateFormats {
       (JsPath \ "skipped").read[Boolean]
   )(ValidationMissionProgress.apply _)
 
-  implicit val adminValidateParamsReads: Reads[AdminValidateParams] = (
+  implicit val adminValidateParamsReads: Reads[ValidateParams] = (
     (JsPath \ "admin_version").read[Boolean] and
       (JsPath \ "label_type_id").readNullable[Int] and
       (JsPath \ "user_ids").readNullable[Seq[String]] and
-      (JsPath \ "neighborhood_ids").readNullable[Seq[Int]]
-  )(AdminValidateParams.apply _)
+      (JsPath \ "neighborhood_ids").readNullable[Seq[Int]] and
+      (JsPath \ "unvalidated_only").read[Boolean]
+  )(ValidateParams.apply _)
 
   implicit val validationTaskSubmissionReads: Reads[ValidationTaskSubmission] = (
     (JsPath \ "interactions").read[Seq[InteractionSubmission]] and
       (JsPath \ "environment").read[EnvironmentSubmission] and
       (JsPath \ "validations").read[Seq[LabelValidationSubmission]] and
       (JsPath \ "mission_progress").readNullable[ValidationMissionProgress] and
-      (JsPath \ "admin_params").read[AdminValidateParams] and
+      (JsPath \ "validate_params").read[ValidateParams] and
       (JsPath \ "pano_histories").read[Seq[PanoHistorySubmission]] and
       (JsPath \ "source").read[String] and
       (JsPath \ "timestamp").read[OffsetDateTime]
@@ -202,6 +203,6 @@ object ValidateFormats {
 
   implicit val skipLabelReads: Reads[SkipLabelSubmission] = (
     (JsPath \ "labels").read[Seq[LabelValidationSubmission]] and
-      (JsPath \ "admin_params").read[AdminValidateParams]
+      (JsPath \ "validate_params").read[ValidateParams]
   )(SkipLabelSubmission.apply _)
 }

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -796,6 +796,7 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
       labelTypeId: Int,
       userIds: Option[Set[String]] = None,
       regionIds: Option[Set[Int]] = None,
+      unvalidatedOnly: Boolean = false,
       skippedLabelId: Option[Int] = None
   ): Query[LabelValidationMetadataTupleRep, LabelValidationMetadataTuple, Seq] = {
 
@@ -807,6 +808,7 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
       _gd             <- gsvData if _lb.gsvPanoramaId === _gd.gsvPanoramaId
       _ser            <- streetEdgeRegions if _lb.streetEdgeId === _ser.streetEdgeId
       if _lt.labelTypeId === labelTypeId && !_gd.expired && _lp.lat.isDefined && _lp.lng.isDefined && _lb.userId =!= userId
+      if !unvalidatedOnly.asColumnOf[Boolean] || _lb.correct.isEmpty                     // Filter out validated labels.
       if skippedLabelId.map(_lb.labelId =!= _).getOrElse(true: Rep[Boolean])             // Filter out skipped label.
       if regionIds.map(ids => _ser.regionId inSetBind ids).getOrElse(true: Rep[Boolean]) // Filter by region IDs.
       if userIds.map(ids => _lb.userId inSetBind ids).getOrElse(true: Rep[Boolean])      // Filter by user IDs.

--- a/app/views/apps/expertValidate.scala.html
+++ b/app/views/apps/expertValidate.scala.html
@@ -1,11 +1,11 @@
-@import controllers.helper.ValidateHelper.AdminValidateParams
+@import controllers.helper.ValidateHelper.ValidateParams
 @import formats.json.LabelFormats.tagWrites
 @import models.label.Tag
 @import models.user.SidewalkUserWithRole
 @import play.api.Configuration
 @import play.api.libs.json.{JsArray, JsValue, Json}
 @import service.CommonPageData
-@(commonData: CommonPageData, title: String, user: SidewalkUserWithRole, adminParams: AdminValidateParams,
+@(commonData: CommonPageData, title: String, user: SidewalkUserWithRole, validateParams: ValidateParams,
         mission: Option[JsValue], labelList: Option[JsValue], progress: Option[JsValue], hasNextMission: Boolean,
         completedValidations: Int, tagList: Seq[Tag]
 )(implicit request: RequestHeader, messages: Messages, assets: AssetsFinder, config: Configuration)
@@ -239,10 +239,13 @@
             param.canvasWidth = 720;
             param.language = "@messages.lang.code";
             param.cityName = "@currentCity.cityNameFormatted";
-            param.adminVersion = @adminParams.adminVersion;
-            param.adminLabelTypeId = @Html(adminParams.labelTypeId.map(_.toString).getOrElse("null"));
-            param.adminUserIds = @Html(adminParams.userIds.map(_.mkString("['", "','", "']")).getOrElse("null"));
-            param.adminNeighborhoodIds = @Html(adminParams.neighborhoodIds.map(_.mkString("[", ",", "]")).getOrElse("null"));
+            param.validateParams = {
+                adminVersion: @validateParams.adminVersion,
+                labelTypeId: @Html(validateParams.labelTypeId.map(_.toString).getOrElse("null")),
+                userIds: @Html(validateParams.userIds.map(_.mkString("['", "','", "']")).getOrElse("null")),
+                regionIds: @Html(validateParams.neighborhoodIds.map(_.mkString("[", ",", "]")).getOrElse("null")),
+                unvalidatedOnly: @validateParams.unvalidatedOnly
+            }
             param.tagList = @Html(JsArray(tagList.map(t => Json.toJson(t))).toString);
             param.modalText = {
                 1: "@Messages("labeling.guide.curb.ramp.summary")",

--- a/app/views/apps/mobileValidate.scala.html
+++ b/app/views/apps/mobileValidate.scala.html
@@ -1,9 +1,9 @@
-@import controllers.helper.ValidateHelper.AdminValidateParams
+@import controllers.helper.ValidateHelper.ValidateParams
 @import models.user.SidewalkUserWithRole
 @import play.api.Configuration
 @import play.api.libs.json.JsValue
 @import service.CommonPageData
-@(commonData: CommonPageData, title: String, user: SidewalkUserWithRole, adminParams: AdminValidateParams,
+@(commonData: CommonPageData, title: String, user: SidewalkUserWithRole, validateParams: ValidateParams,
         mission: Option[JsValue], labelList: Option[JsValue], progress: Option[JsValue], hasNextMission: Boolean,
         completedValidations: Int
 )(implicit request: RequestHeader, messages: Messages, assets: AssetsFinder, config: Configuration)
@@ -200,10 +200,13 @@
             param.language = "@messages.lang.code";
             param.cityId = "@commonData.cityId";
             param.cityName = "@currentCity.cityNameFormatted";
-            param.adminVersion = @adminParams.adminVersion;
-            param.adminLabelTypeId = @Html(adminParams.labelTypeId.map(_.toString).getOrElse("null"));
-            param.adminUserIds = @Html(adminParams.userIds.map(_.mkString("['", "','", "']")).getOrElse("null"));
-            param.adminNeighborhoodIds = @Html(adminParams.neighborhoodIds.map(_.mkString("[", ",", "]")).getOrElse("null"));
+            param.validateParams = {
+                adminVersion: @validateParams.adminVersion,
+                labelTypeId: @Html(validateParams.labelTypeId.map(_.toString).getOrElse("null")),
+                userIds: @Html(validateParams.userIds.map(_.mkString("['", "','", "']")).getOrElse("null")),
+                regionIds: @Html(validateParams.neighborhoodIds.map(_.mkString("[", ",", "]")).getOrElse("null")),
+                unvalidatedOnly: @validateParams.unvalidatedOnly
+            }
             param.modalText = {
                 1: "@Messages("labeling.guide.curb.ramp.summary")",
                 2: "@Messages("labeling.guide.curb.ramp.summary")",

--- a/app/views/apps/validate.scala.html
+++ b/app/views/apps/validate.scala.html
@@ -1,9 +1,9 @@
-@import controllers.helper.ValidateHelper.AdminValidateParams
+@import controllers.helper.ValidateHelper.ValidateParams
 @import models.user.SidewalkUserWithRole
 @import play.api.Configuration
 @import play.api.libs.json.JsValue
 @import service.CommonPageData
-@(commonData: CommonPageData, title: String, user: SidewalkUserWithRole, adminParams: AdminValidateParams,
+@(commonData: CommonPageData, title: String, user: SidewalkUserWithRole, validateParams: ValidateParams,
         mission: Option[JsValue], labelList: Option[JsValue], progress: Option[JsValue], hasNextMission: Boolean,
         completedValidations: Int
 )(implicit request: RequestHeader, messages: Messages, assets: AssetsFinder, config: Configuration)
@@ -190,7 +190,7 @@
                     </div>
                     <br class="clear">
                 </div>
-                @if(!adminParams.adminVersion) {
+                @if(!validateParams.adminVersion) {
                 <div class="status-box">
                     <h1 class="status-holder-header-1" id="label-type-example">
                         @Html(Messages("validate.right.ui.correct.examples"))
@@ -267,10 +267,13 @@
             param.language = "@messages.lang.code";
             param.cityId = "@commonData.cityId";
             param.cityName = "@currentCity.cityNameFormatted";
-            param.adminVersion = @adminParams.adminVersion;
-            param.adminLabelTypeId = @Html(adminParams.labelTypeId.map(_.toString).getOrElse("null"));
-            param.adminUserIds = @Html(adminParams.userIds.map(_.mkString("['", "','", "']")).getOrElse("null"));
-            param.adminNeighborhoodIds = @Html(adminParams.neighborhoodIds.map(_.mkString("[", ",", "]")).getOrElse("null"));
+            param.validateParams = {
+                adminVersion: @validateParams.adminVersion,
+                labelTypeId: @Html(validateParams.labelTypeId.map(_.toString).getOrElse("null")),
+                userIds: @Html(validateParams.userIds.map(_.mkString("['", "','", "']")).getOrElse("null")),
+                regionIds: @Html(validateParams.neighborhoodIds.map(_.mkString("[", ",", "]")).getOrElse("null")),
+                unvalidatedOnly: @validateParams.unvalidatedOnly
+            }
             param.modalText = {
                 1: "@Messages("labeling.guide.curb.ramp.summary")",
                 2: "@Messages("labeling.guide.curb.ramp.summary")",

--- a/conf/routes
+++ b/conf/routes
@@ -15,7 +15,7 @@ GET     /labelingGuide/surfaceProblems                  controllers.ApplicationC
 GET     /labelingGuide/obstacles                        controllers.ApplicationController.labelingGuideObstacles
 GET     /labelingGuide/noSidewalk                       controllers.ApplicationController.labelingGuideNoSidewalk
 GET     /labelingGuide/occlusion                        controllers.ApplicationController.labelingGuideOcclusion
-GET     /mobile                                         controllers.ValidateController.mobileValidate(neighborhoods: Option[String] ?= None)
+GET     /mobile                                         controllers.ValidateController.mobileValidate(neighborhoods: Option[String] ?= None, unvalidatedOnly: Option[Boolean] ?= None)
 GET     /leaderboard                                    controllers.ApplicationController.leaderboard
 GET     /serviceHoursInstructions                       controllers.ApplicationController.serviceHoursInstructions
 GET     /timeCheck                                      controllers.ApplicationController.timeCheck
@@ -100,10 +100,10 @@ GET     /neighborhoodMissions                           controllers.ExploreContr
 GET     /audit                                          controllers.ExploreController.explore(newRegion: Boolean ?= false, retakeTutorial: Option[Boolean] ?= None, routeId: Option[Int] ?= None, resumeRoute: Boolean ?= true, regionId: Option[Int] ?= None, streetEdgeId: Option[Int] ?= None, lat: Option[Double] ?= None, lng: Option[Double] ?= None, panoId: Option[String] ?= None)
 
 # Label validation tasks
-GET     /validate                                       controllers.ValidateController.validate(neighborhoods: Option[String] ?= None)
-GET     /expertValidate                                 controllers.ValidateController.expertValidate(labelType: Option[String] ?= None, users: Option[String] ?= None, neighborhoods: Option[String] ?= None)
-GET     /newValidateBeta                                controllers.ValidateController.expertValidate(labelType: Option[String] ?= None, users: Option[String] ?= None, neighborhoods: Option[String] ?= None)
-GET     /adminValidate                                  controllers.ValidateController.adminValidate(labelType: Option[String] ?= None, users: Option[String] ?= None, neighborhoods: Option[String] ?= None)
+GET     /validate                                       controllers.ValidateController.validate(neighborhoods: Option[String] ?= None, unvalidatedOnly: Option[Boolean] ?= None)
+GET     /expertValidate                                 controllers.ValidateController.expertValidate(labelType: Option[String] ?= None, users: Option[String] ?= None, neighborhoods: Option[String] ?= None, unvalidatedOnly: Option[Boolean] ?= None)
+GET     /newValidateBeta                                controllers.ValidateController.expertValidate(labelType: Option[String] ?= None, users: Option[String] ?= None, neighborhoods: Option[String] ?= None, unvalidatedOnly: Option[Boolean] ?= None)
+GET     /adminValidate                                  controllers.ValidateController.adminValidate(labelType: Option[String] ?= None, users: Option[String] ?= None, neighborhoods: Option[String] ?= None, unvalidatedOnly: Option[Boolean] ?= None)
 
 # Task API
 GET     /tasks                                          controllers.ExploreController.getTasksInARegion(regionId: Int)

--- a/public/javascripts/SVValidate/src/Main.js
+++ b/public/javascripts/SVValidate/src/Main.js
@@ -9,10 +9,8 @@ var svv = svv || {};
  */
 function Main (param) {
     svv.expertValidate = param.expertValidate;
-    svv.adminVersion = param.adminVersion;
-    svv.adminLabelTypeId = param.adminLabelTypeId;
-    svv.adminUserIds = param.adminUserIds;
-    svv.adminNeighborhoodIds = param.adminNeighborhoodIds;
+    svv.adminVersion = param.validateParams.adminVersion;
+    svv.validateParams = param.validateParams;
     svv.missionLength = param.mission?.labels_validated ?? 0;
     svv.canvasHeight = param.canvasHeight;
     svv.canvasWidth = param.canvasWidth;

--- a/public/javascripts/SVValidate/src/data/Form.js
+++ b/public/javascripts/SVValidate/src/data/Form.js
@@ -65,11 +65,12 @@ function Form(url, beaconUrl) {
             css_zoom: svv.cssZoom ? svv.cssZoom : 100
         };
 
-        data.admin_params = {
+        data.validate_params = {
             admin_version: svv.adminVersion,
-            label_type_id: svv.adminLabelTypeId,
-            user_ids: svv.adminUserIds,
-            neighborhood_ids: svv.adminNeighborhoodIds
+            label_type_id: svv.validateParams.labelTypeId,
+            user_ids: svv.validateParams.userIds,
+            neighborhood_ids: svv.validateParams.regionIds,
+            unvalidated_only: svv.validateParams.unvalidatedOnly
         };
 
         data.interactions = svv.tracker.getActions();

--- a/public/javascripts/SVValidate/src/panorama/PanoramaContainer.js
+++ b/public/javascripts/SVValidate/src/panorama/PanoramaContainer.js
@@ -39,11 +39,12 @@ function PanoramaContainer (labelList) {
 
         let data = {};
         data.labels = svv.labelContainer.getCurrentLabels();
-        data.admin_params = {
+        data.validate_params = {
             admin_version: svv.adminVersion,
-            label_type_id: svv.adminLabelTypeId,
-            user_ids: svv.adminUserIds,
-            neighborhood_ids: svv.adminNeighborhoodIds
+            label_type_id: svv.validateParams.labelTypeId,
+            user_ids: svv.validateParams.userIds,
+            neighborhood_ids: svv.validateParams.regionIds,
+            unvalidated_only: svv.validateParams.unvalidatedOnly
         };
 
         $.ajax({


### PR DESCRIPTION
Resolves #3774 

Adds a new URL parameter to all Validate pages, `unvalidatedOnly`. You can set it to `unvalidatedOnly=true` to only see labels that have no validations, or an even number of agree and disagree validations. This works on Validate, Admin Validate, and Expert Validate! An example URL:
https://sidewalk-chicago.cs.washington.edu/adminValidate?labelType=Obstacle&unvalidatedOnly=true

Note that the `labelType` and `users` parameters are admin-only, while the `unvalidatedOnly` and `neighborhoods` parameters can be used by anyone. Not committed to that setup, but that's what we have at the moment!

