### PR TITLE
Adds highQualityUserOnly param to rawLabels API

### DIFF
--- a/app/controllers/api/LabelApiController.scala
+++ b/app/controllers/api/LabelApiController.scala
@@ -130,6 +130,7 @@ class LabelApiController @Inject() (
    * @param minSeverity Minimum severity score (1-5 scale)
    * @param maxSeverity Maximum severity score (1-5 scale)
    * @param validationStatus Filter by validation status: "validated_correct", "validated_incorrect", "unvalidated"
+   * @param highQualityUserOnly Optional filter to include only labels from high quality users if true
    * @param startDate Start date for filtering (ISO 8601 format)
    * @param endDate End date for filtering (ISO 8601 format)
    * @param regionId Optional region ID to filter by geographic region
@@ -144,6 +145,7 @@ class LabelApiController @Inject() (
       minSeverity: Option[Int],
       maxSeverity: Option[Int],
       validationStatus: Option[String],
+      highQualityUserOnly: Option[Boolean],
       startDate: Option[String],
       endDate: Option[String],
       regionId: Option[Int],
@@ -244,6 +246,7 @@ class LabelApiController @Inject() (
           minSeverity = minSeverity,
           maxSeverity = maxSeverity,
           validationStatus = validationStatusMapped.filter(_ != null),
+          highQualityUserOnly = highQualityUserOnly.getOrElse(false),
           startDate = parsedStartDate,
           endDate = parsedEndDate,
           regionId = finalRegionId,

--- a/app/controllers/api/StatsApiController.scala
+++ b/app/controllers/api/StatsApiController.scala
@@ -46,7 +46,7 @@ class StatsApiController @Inject() (
       .getUserStats(
         minLabels = minLabels,
         minMetersExplored = minMetersExplored,
-        highQualityOnly = highQualityOnly,
+        highQualityOnly = highQualityOnly.getOrElse(false),
         minAccuracy = minAccuracy
       )
       .map { filteredStats: Seq[UserStatApi] =>

--- a/app/models/api/LabelApiModels.scala
+++ b/app/models/api/LabelApiModels.scala
@@ -34,6 +34,7 @@ case class RawLabelFiltersForApi(
     minSeverity: Option[Int] = None,
     maxSeverity: Option[Int] = None,
     validationStatus: Option[String] = None,
+    highQualityUserOnly: Boolean = false,
     startDate: Option[OffsetDateTime] = None,
     endDate: Option[OffsetDateTime] = None,
     regionId: Option[Int] = None,

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -1295,6 +1295,10 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
       }
     }
 
+    if (filters.highQualityUserOnly) {
+      whereConditions :+= "user_stat.high_quality = TRUE"
+    }
+
     if (filters.startDate.isDefined) {
       whereConditions :+= s"label.time_created >= '${filters.startDate.get.toString}'"
     }

--- a/app/models/user/UserStatTable.scala
+++ b/app/models/user/UserStatTable.scala
@@ -308,7 +308,8 @@ class UserStatTable @Inject() (
       .flatMap { usersToUpdate: Seq[(String, Int, Option[Float])] =>
         // Update the own_labels_validated and accuracy columns in the user_stat table.
         val updateActions = usersToUpdate.map { case (userId, validatedCount, accuracy) =>
-          val updateQuery = for { _us <- userStats if _us.userId === userId } yield (_us.ownLabelsValidated, _us.accuracy)
+          val updateQuery =
+            for { _us <- userStats if _us.userId === userId } yield (_us.ownLabelsValidated, _us.accuracy)
           updateQuery.update((validatedCount, accuracy))
         }
         DBIO.sequence(updateActions).map(_ => ())
@@ -719,20 +720,20 @@ class UserStatTable @Inject() (
    *
    * @param minLabels Optional minimum number of labels a user must have
    * @param minMetersExplored Optional minimum meters explored a user must have
-   * @param highQualityOnly Optional filter to include only high quality users if Some(true)
+   * @param highQualityOnly Optional filter to include only high quality users if true
    * @param minAccuracy Optional minimum label accuracy a user must have
    * @return DBIO action that retrieves filtered user statistics
    */
   def getStatsForApiWithFilters(
       minLabels: Option[Int] = None,
       minMetersExplored: Option[Float] = None,
-      highQualityOnly: Option[Boolean] = None,
+      highQualityOnly: Boolean = false,
       minAccuracy: Option[Float] = None
   ): DBIO[Seq[UserStatApi]] = {
     // Construct the SQL query with dynamic WHERE clauses based on filter parameters.
     val minLabelsClause   = minLabels.map(min => s"AND COALESCE(label_counts.labels, 0) >= $min").getOrElse("")
     val minMetersClause   = minMetersExplored.map(min => s"AND user_stat.meters_audited >= $min").getOrElse("")
-    val highQualityClause = highQualityOnly.map(hq => s"AND user_stat.high_quality = ${hq.toString}").getOrElse("")
+    val highQualityClause = if (highQualityOnly) "AND user_stat.high_quality = TRUE" else ""
     val minAccuracyClause =
       minAccuracy.map(min => s"AND user_stat.accuracy IS NOT NULL AND user_stat.accuracy >= $min").getOrElse("")
 

--- a/app/service/ApiService.scala
+++ b/app/service/ApiService.scala
@@ -83,7 +83,7 @@ trait ApiService {
   def getUserStats(
       minLabels: Option[Int] = None,
       minMetersExplored: Option[Float] = None,
-      highQualityOnly: Option[Boolean] = None,
+      highQualityOnly: Boolean = false,
       minAccuracy: Option[Float] = None
   ): Future[Seq[UserStatApi]]
 
@@ -228,14 +228,14 @@ class ApiServiceImpl @Inject() (
    *
    * @param minLabels Optional minimum number of labels a user must have.
    * @param minMetersExplored Optional minimum meters explored a user must have.
-   * @param highQualityOnly Optional filter to include only high quality users if Some(true).
+   * @param highQualityOnly Optional filter to include only high quality users if true.
    * @param minAccuracy Optional minimum label accuracy a user must have.
    * @return A Future containing a sequence of UserStatApi objects that match the filters.
    */
   def getUserStats(
       minLabels: Option[Int] = None,
       minMetersExplored: Option[Float] = None,
-      highQualityOnly: Option[Boolean] = None,
+      highQualityOnly: Boolean = false,
       minAccuracy: Option[Float] = None
   ): Future[Seq[UserStatApi]] = {
     // Uses the database-level filtering method for improved performance.

--- a/app/views/apiDocs/labelClusters.scala.html
+++ b/app/views/apiDocs/labelClusters.scala.html
@@ -29,6 +29,10 @@
             For access to individual, unclustered label data, use the <a href="/api-docs/rawLabels">Raw Labels API</a>
             instead.
         </p>
+        <p>
+            To ensure data quality, we apply some data cleaning before grouping labels into clusters. You can read more
+            about this in the <a href="#data-cleaning">Data Cleaning</a> section below.
+        </p>
     </div>
 
     <div class="api-section" id="label-clusters-preview-section">
@@ -440,6 +444,26 @@
     "message": "Invalid value for bbox parameter. Expected format: minLng,minLat,maxLng,maxLat.", // Human-readable description
     "parameter": "bbox" // Optional: The specific parameter causing the error
 }</code></pre>
+    </div>
+
+    <div class="api-section" id="data-cleaning-section">
+        <h2 class="api-heading" id="data-cleaning">Data Cleaning<a href="#data-cleaning" class="permalink">#</a></h2>
+        <p>
+            Before grouping labels into the cluster provided by this API, we apply a few filters to clean the data and
+            ensure data quality. We filter out labels that meet any of these criteria:
+        </p>
+        <ul>
+            <li>The label has been validated as incorrect. If a label has more "No" votes than "Yes" votes, it won't be included.</li>
+            <li>Through manual review, an Admin has flagged an entire street or more as being labeled incorrectly. If the label was validated as correct, however, it will still be included.</li>
+            <li>
+                The user who created the label has been flagged as a low-quality contributor, either through an algorithmic assessment or through manual review by an Admin. If the label was validated as correct, however, it will still be included. A user may be automatically flagged as providing low-quality data if they meet any of the following criteria:
+                <ul>
+                    <li>They have an accuracy rating below 60% based on validations from other users (min 50 of their labels validated).</li>
+                    <li>They have a "labeling frequency" below 37.5 labels per kilometer. This cutoff point was determined experimentally and helps to ensure full data coverage.</li>
+                    <li>They have been flagged by Admins as providing low quality data through manual review.</li>
+                </ul>
+            </li>
+        </ul>
     </div>
 
     <div class="api-section" id="best-practices-section">

--- a/app/views/apiDocs/rawLabels.scala.html
+++ b/app/views/apiDocs/rawLabels.scala.html
@@ -172,6 +172,11 @@
                         <td>Filter by validation status. Possible values: <code>validated_correct</code>, <code>validated_incorrect</code>, <code>unvalidated</code>. </td>
                     </tr>
                     <tr>
+                        <td><code>highQualityUserOnly</code></td>
+                        <td><code>boolean</code></td>
+                        <td>When set to <code>true</code>, only include labels from users flagged as high quality contributors. Default: <code>false</code>. </td>
+                    </tr>
+                    <tr>
                         <td><code>startDate</code></td>
                         <td><code>string</code></td>
                         <td>Filter labels created on or after this date/time. Format: ISO 8601 (e.g., <code>2024-01-01T00:00:00Z</code>). Filters based on the <code>time_created</code> field.</td>
@@ -226,6 +231,7 @@
                 "tags": [],
                 "description": null,
                 "time_created": 1692227245041,
+                "high_quality_user": true,
                 "street_edge_id": 951,
                 "osm_way_id": 11584845,
                 "neighborhood": "Teaneck Community Charter School",
@@ -374,6 +380,11 @@
                         <td><code>properties.time_created</code></td>
                         <td><code>long</code></td>
                         <td>Unix timestamp (milliseconds since epoch) when the label was created.</td>
+                    </tr>
+                    <tr>
+                        <td><code>properties.high_quality_user</code></td>
+                        <td><code>boolean</code></td>
+                        <td>Whether the user who created the label is flagged as a high-quality contributor based on algorithmic assessment.</td>
                     </tr>
 
                         <!-- Location Context -->

--- a/conf/routes
+++ b/conf/routes
@@ -165,7 +165,7 @@ POST    /saveImage                                      controllers.ImageControl
 POST    /api/gemini/analyze                             controllers.GeminiController.analyzeImage()
 
 # Public API (v3) for Project Sidewalk data and metadata.
-GET     /v3/api/rawLabels                               controllers.api.LabelApiController.getRawLabelsV3(bbox: Option[String], labelType: Option[String], tags: Option[String], minSeverity: Option[Int], maxSeverity: Option[Int], validationStatus: Option[String], startDate: Option[String], endDate: Option[String], regionId: Option[Int], regionName: Option[String], filetype: Option[String], inline: Option[Boolean])
+GET     /v3/api/rawLabels                               controllers.api.LabelApiController.getRawLabelsV3(bbox: Option[String], labelType: Option[String], tags: Option[String], minSeverity: Option[Int], maxSeverity: Option[Int], validationStatus: Option[String], highQualityUserOnly: Option[Boolean], startDate: Option[String], endDate: Option[String], regionId: Option[Int], regionName: Option[String], filetype: Option[String], inline: Option[Boolean])
 GET     /v3/api/labelTypes                              controllers.api.LabelApiController.getLabelTypes
 GET     /v3/api/labelTags                               controllers.api.LabelApiController.getLabelTags
 GET     /v3/api/regionWithMostLabels                    controllers.api.RegionApiController.getRegionWithMostLabels


### PR DESCRIPTION
Resolves #2967 

This PR consists of three small changes:
1. Adds a new `highQualityUserOnly` param to the `/v3/api/rawLabels` API. If set to `true`, it excludes labels from any user marked as low quality.
2. Fixes the behavior of the `highQualityOnly` param in the `/v3/api/userStats` API. The parameter name and documentation implied that it would exclude low quality users if set to `true`, and include all users otherwise. Setting it to `false` was actually filtering out high quality users. I've fixed the way it works to match the parameter name, documentation, and the way that the new `highQualityUserOnly` parameter works in the rawLabels API.
3. Adds a Data Cleaning section to the labelClusters API docs page, which outlines all the filtering that we do before clustering in detail. I also added one sentence about this to the top of that page, linking to the full section.

##### Before/After screenshots (if applicable)
Here's the new Data Cleaning section, located just above Best Practices
<img width="1231" height="595" alt="image" src="https://github.com/user-attachments/assets/dfa74f77-9ad5-4c78-b62e-c835160c763c" />

