### PR TITLE
Fixes various bugs in the Explore tutorial

### DIFF
--- a/public/javascripts/SVLabel/src/SVLabel/canvas/Canvas.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/Canvas.js
@@ -100,6 +100,14 @@ function Canvas(ribbon) {
             svl.audioEffect.play('drip');
         }
 
+        // If in the tutorial, send an event to the onboarding module.
+        if (svl.onboarding) {
+            const customEvent = new CustomEvent('addTutorialLabel', {
+                detail: { label: status.currentLabel }
+            });
+            document.dispatchEvent(customEvent);
+        }
+
         // Wait for the crop to be saved before switching back to walk mode.
         // We are hiding the 'road labels' in the labeling mode as we don't want them to show in the crop.
         // So we need to ensure we don't switch back to explore mode until the crop is saved.

--- a/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
@@ -10,6 +10,7 @@ function ContextMenu (uiContextMenu) {
         status = {
             targetLabel: null,
             visibility: 'hidden',
+            disableRatingSeverity: false,
             disableTagging: false
         };
     var $menuWindow = uiContextMenu.holder;
@@ -247,6 +248,15 @@ function ContextMenu (uiContextMenu) {
     }
 
     /**
+     * Disable rating severity. Adds the disabled visual effects to the severity buttons on current context menu.
+     */
+    function disableRatingSeverity() {
+        setStatus('disableRatingSeverity', true);
+        // $severityButtons.prop('disabled', true);
+        $radioButtonLabels.addClass('disabled');
+    }
+
+    /**
      * Disable tagging. Adds the disabled visual effects to the tags on current context menu.
      */
     function disableTagging() {
@@ -257,6 +267,15 @@ function ContextMenu (uiContextMenu) {
     }
 
     /**
+     * Enable rating severity. Removes the disabled visual effects to the severity buttons on current context menu.
+     */
+    function enableRatingSeverity() {
+        setStatus('disableRatingSeverity', false);
+        // $severityButtons.prop('disabled', false);
+        $radioButtonLabels.removeClass('disabled');
+    }
+
+    /**
      * Enable tagging. Removes the disabled visual effects to the tags on current context menu.
      */
     function enableTagging() {
@@ -264,6 +283,13 @@ function ContextMenu (uiContextMenu) {
         $("body").find("button[name=tag]").each(function(t) {
             $(this).removeClass('disabled');
         });
+    }
+
+    /**
+     * Returns true if rating severity is currently disabled.
+     */
+    function isRatingSeverityDisabled() {
+        return getStatus('disableRatingSeverity');
     }
 
     /**
@@ -448,7 +474,6 @@ function ContextMenu (uiContextMenu) {
         $descriptionTextBox.val(null);
 
         var labelType = targetLabel.getLabelType();
-        var labelColor = util.misc.getLabelColors()[labelType].fillStyle;
         var labelCoord = targetLabel.getCanvasXY();
 
         if (labelType !== 'Occlusion') {
@@ -530,8 +555,11 @@ function ContextMenu (uiContextMenu) {
     self.hide = hide;
     self.isOpen = isOpen;
     self.show = show;
+    self.disableRatingSeverity = disableRatingSeverity;
     self.disableTagging = disableTagging;
+    self.enableRatingSeverity = enableRatingSeverity;
     self.enableTagging = enableTagging;
+    self.isRatingSeverityDisabled = isRatingSeverityDisabled;
     self.isTaggingDisabled = isTaggingDisabled;
     return self;
 }

--- a/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
+++ b/public/javascripts/SVLabel/src/SVLabel/canvas/ContextMenu.js
@@ -10,8 +10,8 @@ function ContextMenu (uiContextMenu) {
         status = {
             targetLabel: null,
             visibility: 'hidden',
-            disableRatingSeverity: false,
-            disableTagging: false
+            ratingSeverityEnabledForTutorialLabel: null, // During tutorial, disabled except for specific steps
+            taggingEnabledForTutorialLabel: null, // During tutorial, disabled except for specific steps
         };
     var $menuWindow = uiContextMenu.holder;
     var $severityMenu = uiContextMenu.severityMenu;
@@ -247,41 +247,49 @@ function ContextMenu (uiContextMenu) {
         return getStatus('visibility') === 'visible';
     }
 
-    /**
-     * Disable rating severity. Adds the disabled visual effects to the severity buttons on current context menu.
-     */
+    // Disable rating severity.
     function disableRatingSeverity() {
-        setStatus('disableRatingSeverity', true);
-        // $severityButtons.prop('disabled', true);
-        $radioButtonLabels.addClass('disabled');
+        setStatus('ratingSeverityEnabledForTutorialLabel', null);
+        _showRatingSeverityDisabled();
     }
 
-    /**
-     * Disable tagging. Adds the disabled visual effects to the tags on current context menu.
-     */
+    // Disable tagging.
     function disableTagging() {
-        setStatus('disableTagging', true);
-        $("body").find("button[name=tag]").each(function(t) {
-            $(this).addClass('disabled');
-        });
+        setStatus('taggingEnabledForTutorialLabel', null);
+        _showTaggingDisabled();
     }
 
-    /**
-     * Enable rating severity. Removes the disabled visual effects to the severity buttons on current context menu.
-     */
-    function enableRatingSeverity() {
-        setStatus('disableRatingSeverity', false);
-        // $severityButtons.prop('disabled', false);
+    // Enable rating severity for a given tutorial label.
+    function enableRatingSeverityForTutorialLabel(tutorialLabelNumber) {
+        setStatus('ratingSeverityEnabledForTutorialLabel', tutorialLabelNumber);
+        if (svl.isOnboarding() && !isRatingSeverityDisabled()) _showRatingSeverityEnabled();
+    }
+
+    // Enable tagging for a given tutorial label.
+    function enableTaggingForTutorialLabel(tutorialLabelNumber) {
+        setStatus('taggingEnabledForTutorialLabel', tutorialLabelNumber);
+        if (svl.isOnboarding() && !isTaggingDisabled()) _showTaggingEnabled();
+    }
+
+    // Adds the disabled visual effects to the severity buttons on current context menu.
+    function _showRatingSeverityEnabled() {
         $radioButtonLabels.removeClass('disabled');
     }
 
-    /**
-     * Enable tagging. Removes the disabled visual effects to the tags on current context menu.
-     */
-    function enableTagging() {
-        setStatus('disableTagging', false);
+    // Adds the disabled visual effects to the tags on current context menu.
+    function _showRatingSeverityDisabled() {
+        $radioButtonLabels.addClass('disabled');
+    }
+
+    function _showTaggingEnabled() {
         $("body").find("button[name=tag]").each(function(t) {
             $(this).removeClass('disabled');
+        });
+    }
+
+    function _showTaggingDisabled() {
+        $("body").find("button[name=tag]").each(function(t) {
+            $(this).addClass('disabled');
         });
     }
 
@@ -289,14 +297,14 @@ function ContextMenu (uiContextMenu) {
      * Returns true if rating severity is currently disabled.
      */
     function isRatingSeverityDisabled() {
-        return getStatus('disableRatingSeverity');
+        return status.ratingSeverityEnabledForTutorialLabel !== status.targetLabel.getProperty('tutorialLabelNumber');
     }
 
     /**
      * Returns true if tagging is currently disabled.
      */
     function isTaggingDisabled() {
-        return getStatus('disableTagging');
+        return status.taggingEnabledForTutorialLabel !== status.targetLabel.getProperty('tutorialLabelNumber');
     }
 
     /**
@@ -508,6 +516,14 @@ function ContextMenu (uiContextMenu) {
                 });
             }
 
+            // Enable rating severity and tagging on tutorial labels if appropriate.
+            if (svl.isOnboarding()) {
+                if (!isRatingSeverityDisabled()) _showRatingSeverityEnabled();
+                else _showRatingSeverityDisabled();
+                if (!isTaggingDisabled()) _showTaggingEnabled();
+                else _showTaggingDisabled();
+            }
+
             $menuWindow.css({
                 visibility: 'visible',
                 left: labelCoord.x - windowWidth / 2,
@@ -557,8 +573,8 @@ function ContextMenu (uiContextMenu) {
     self.show = show;
     self.disableRatingSeverity = disableRatingSeverity;
     self.disableTagging = disableTagging;
-    self.enableRatingSeverity = enableRatingSeverity;
-    self.enableTagging = enableTagging;
+    self.enableRatingSeverityForTutorialLabel = enableRatingSeverityForTutorialLabel;
+    self.enableTaggingForTutorialLabel = enableTaggingForTutorialLabel;
     self.isRatingSeverityDisabled = isRatingSeverityDisabled;
     self.isTaggingDisabled = isTaggingDisabled;
     return self;

--- a/public/javascripts/SVLabel/src/SVLabel/keyboard/Keyboard.js
+++ b/public/javascripts/SVLabel/src/SVLabel/keyboard/Keyboard.js
@@ -142,7 +142,8 @@ function Keyboard (svl, canvas, contextMenu, googleMap, ribbon, zoomControl) {
         if (!status.disableKeyboard && !status.focusOnTextField) {
             if (contextMenu.isOpen()) {
                 var label;
-                if (e.keyCode >= 49 && e.keyCode <= 51) {
+                // Rating severity.
+                if (e.keyCode >= 49 && e.keyCode <= 51 && !contextMenu.isRatingSeverityDisabled()) {
                     const severity = e.keyCode - 48; // "1" - "3"
                     contextMenu.checkRadioButton(severity);
                     label = contextMenu.getTargetLabel();

--- a/public/javascripts/SVLabel/src/SVLabel/label/Label.js
+++ b/public/javascripts/SVLabel/src/SVLabel/label/Label.js
@@ -61,6 +61,7 @@ function Label(params) {
         tagIds: [],
         severity: null,
         tutorial: null,
+        tutorialLabelNumber: undefined,
         temporaryLabelId: null,
         description: null,
         crop: undefined

--- a/public/javascripts/SVLabel/src/SVLabel/onboarding/Onboarding.js
+++ b/public/javascripts/SVLabel/src/SVLabel/onboarding/Onboarding.js
@@ -80,6 +80,9 @@ function Onboarding(svl, audioEffect, compass, form, handAnimation, mapService, 
         compass.hideMessage();
         compass.disableCompassClick();
 
+        contextMenu.disableRatingSeverity();
+        contextMenu.disableTagging();
+
         // Make sure that the context menu covers instructions when hovering over the context menu.
         svl.ui.contextMenu.holder.on('mouseover', function() {
             uiOnboarding.messageHolder.css('z-index', 2);
@@ -700,23 +703,23 @@ function Onboarding(svl, audioEffect, compass, form, handAnimation, mapService, 
     }
 
     function _visitRateSeverity(state, listener) {
-        contextMenu.disableTagging();
+        contextMenu.enableRatingSeverity();
         var $target = svl.ui.contextMenu.radioButtons;
         var callback = function () {
             if (listener) google.maps.event.removeListener(listener);
             $target.off("click", callback);
-            contextMenu.enableTagging();
+            contextMenu.disableRatingSeverity();
             next.call(this, state.transition);
         };
         $target.on("click", callback);
     }
     function _visitAddTag(state, listener) {
+        contextMenu.enableTagging();
         var $target = svl.ui.contextMenu.tagHolder; // Grab tag holder so we can add an event listener.
         var callback = function () {
-            if (listener) {
-                google.maps.event.removeListener(listener);
-            }
+            if (listener) google.maps.event.removeListener(listener);
             $target.off("tagIds-updated", callback);
+            contextMenu.disableTagging();
             next.call(contextMenu.getTargetLabel(), state.transition);
         };
         // We use a custom event here to ensure that this is triggered after the tags have been updated.

--- a/public/javascripts/SVLabel/src/SVLabel/onboarding/OnboardingStates.js
+++ b/public/javascripts/SVLabel/src/SVLabel/onboarding/OnboardingStates.js
@@ -1,4 +1,4 @@
-function OnboardingStates (contextMenu, compass, mapService, statusModel, tracker) {
+function OnboardingStates (contextMenu, compass, mapService) {
     var panoId = "tutorial";
     var afterWalkPanoId = "afterWalkTutorial";
     var headingRanges = {
@@ -86,6 +86,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": true,
             "properties": [{
                 "action": "LabelAccessibilityAttribute",
+                "labelNumber": 1,
                 "labelType": "CurbRamp",
                 "imageX": 1170,
                 "imageY": 3800,
@@ -120,6 +121,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": false,
             "properties": {
                 "action": "DeleteAccessibilityAttribute",
+                "labelNumber": 1,
                 "labelType": "CurbRamp",
                 "minHeading": headingRanges["stage-1"][0],
                 "maxHeading": headingRanges["stage-1"][1],
@@ -144,6 +146,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": false,
             "properties": {
                 "action": "RedoSelectLabelType",
+                "labelNumber": 1,
                 "labelType": "CurbRamp",
                 "minHeading": headingRanges["stage-1"][0],
                 "maxHeading": headingRanges["stage-1"][1],
@@ -168,6 +171,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": true,
             "properties": {
                 "action": "RateSeverity",
+                "labelNumber": 1,
                 "labelType": "CurbRamp",
                 "minHeading": headingRanges["stage-1"][0],
                 "maxHeading": headingRanges["stage-1"][1]
@@ -194,6 +198,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": false,
             "properties": {
                 "action": "RedoRateSeverity",
+                "labelNumber": 1,
                 "labelType": "CurbRamp",
                 "minHeading": headingRanges["stage-1"][0],
                 "maxHeading": headingRanges["stage-1"][1]
@@ -220,6 +225,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": true,
             "properties": {
                 "action": "SelectLabelType",
+                "labelNumber": 2,
                 "labelType": "Crosswalk",
                 "minHeading": headingRanges["stage-1"][0],
                 "maxHeading": headingRanges["stage-1"][1]
@@ -244,6 +250,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": true,
             "properties": [{
                 "action": "LabelAccessibilityAttribute",
+                "labelNumber": 2,
                 "labelType": "Crosswalk",
                 "imageX": 420,
                 "imageY": 3800,
@@ -278,6 +285,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": false,
             "properties": {
                 "action": "DeleteAccessibilityAttribute",
+                "labelNumber": 2,
                 "labelType": "Crosswalk",
                 "minHeading": headingRanges["stage-1"][0],
                 "maxHeading": headingRanges["stage-1"][1],
@@ -302,6 +310,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": false,
             "properties": {
                 "action": "RedoSelectLabelType",
+                "labelNumber": 2,
                 "labelType": "Crosswalk",
                 "minHeading": headingRanges["stage-1"][0],
                 "maxHeading": headingRanges["stage-1"][1],
@@ -326,6 +335,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": true,
             "properties": {
                 "action": "RateSeverity",
+                "labelNumber": 2,
                 "labelType": "Crosswalk",
                 "minHeading": headingRanges["stage-1"][0],
                 "maxHeading": headingRanges["stage-1"][1]
@@ -350,6 +360,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": false,
             "properties": {
                 "action": "RedoRateSeverity",
+                "labelNumber": 2,
                 "labelType": "Crosswalk",
                 "minHeading": headingRanges["stage-1"][0],
                 "maxHeading": headingRanges["stage-1"][1]
@@ -412,6 +423,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": true,
             "properties": {
                 "action": "SelectLabelType",
+                "labelNumber": 3,
                 "labelType": "CurbRamp",
                 "minHeading": headingRanges["stage-2"][0],
                 "maxHeading": headingRanges["stage-2"][1]
@@ -437,6 +449,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": true,
             "properties": [{
                 "action": "LabelAccessibilityAttribute",
+                "labelNumber": 3,
                 "labelType": "CurbRamp",
                 "imageX": 12950,
                 "imageY": 3720,
@@ -471,6 +484,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": false,
             "properties": {
                 "action": "DeleteAccessibilityAttribute",
+                "labelNumber": 3,
                 "labelType": "CurbRamp",
                 "minHeading": headingRanges["stage-2"][0],
                 "maxHeading": headingRanges["stage-2"][1],
@@ -496,6 +510,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": false,
             "properties": {
                 "action": "RedoSelectLabelType",
+                "labelNumber": 3,
                 "labelType": "CurbRamp",
                 "minHeading": headingRanges["stage-2"][0],
                 "maxHeading": headingRanges["stage-2"][1],
@@ -521,6 +536,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": true,
             "properties": {
                 "action": "RateSeverity",
+                "labelNumber": 3,
                 "labelType": "CurbRamp",
                 "minHeading": headingRanges["stage-2"][0],
                 "maxHeading": headingRanges["stage-2"][1]
@@ -547,6 +563,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": false,
             "properties": {
                 "action": "RedoRateSeverity",
+                "labelNumber": 3,
                 "labelType": "CurbRamp",
                 "minHeading": headingRanges["stage-2"][0],
                 "maxHeading": headingRanges["stage-2"][1]
@@ -573,6 +590,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": true,
             "properties": {
                 "action": "AddTag",
+                "labelNumber": 3,
                 "labelType": "CurbRamp",
                 "minHeading": headingRanges["stage-2"][0],
                 "maxHeading": headingRanges["stage-2"][1]
@@ -598,6 +616,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": false,
             "properties": {
                 "action": "RedoAddTag",
+                "labelNumber": 3,
                 "labelType": "CurbRamp",
                 "minHeading": headingRanges["stage-2"][0],
                 "maxHeading": headingRanges["stage-2"][1]
@@ -623,6 +642,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": true,
             "properties": {
                 "action": "SelectLabelType",
+                "labelNumber": 4,
                 "labelType": "NoCurbRamp",
                 "minHeading": headingRanges["stage-2"][0],
                 "maxHeading": headingRanges["stage-2"][1]
@@ -648,6 +668,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": true,
             "properties": [{
                 "action": "LabelAccessibilityAttribute",
+                "labelNumber": 4,
                 "labelType": "NoCurbRamp",
                 "imageX": 12560,
                 "imageY": 3720,
@@ -682,6 +703,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": false,
             "properties": {
                 "action": "DeleteAccessibilityAttribute",
+                "labelNumber": 4,
                 "labelType": "NoCurbRamp",
                 "minHeading": headingRanges["stage-2"][0],
                 "maxHeading": headingRanges["stage-2"][1],
@@ -707,6 +729,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": false,
             "properties": {
                 "action": "RedoSelectLabelType",
+                "labelNumber": 4,
                 "labelType": "NoCurbRamp",
                 "minHeading": headingRanges["stage-2"][0],
                 "maxHeading": headingRanges["stage-2"][1],
@@ -732,6 +755,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": true,
             "properties": {
                 "action": "RateSeverity",
+                "labelNumber": 4,
                 "labelType": "NoCurbRamp",
                 "minHeading": headingRanges["stage-2"][0],
                 "maxHeading": headingRanges["stage-2"][1]
@@ -758,6 +782,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": false,
             "properties": {
                 "action": "RedoRateSeverity",
+                "labelNumber": 4,
                 "labelType": "NoCurbRamp",
                 "minHeading": headingRanges["stage-2"][0],
                 "maxHeading": headingRanges["stage-2"][1]
@@ -784,6 +809,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": true,
             "properties": {
                 "action": "AddTag",
+                "labelNumber": 4,
                 "labelType": "NoCurbRamp",
                 "minHeading": headingRanges["stage-2"][0],
                 "maxHeading": headingRanges["stage-2"][1]
@@ -809,6 +835,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": false,
             "properties": {
                 "action": "RedoAddTag",
+                "labelNumber": 4,
                 "labelType": "NoCurbRamp",
                 "minHeading": headingRanges["stage-2"][0],
                 "maxHeading": headingRanges["stage-2"][1]
@@ -834,6 +861,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": true,
             "properties": {
                 "action": "SelectLabelType",
+                "labelNumber": 5,
                 "labelType": "Signal",
                 "minHeading": headingRanges["stage-2"][0],
                 "maxHeading": headingRanges["stage-2"][1]
@@ -865,6 +893,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": true,
             "properties": [{
                 "action": "LabelAccessibilityAttribute",
+                "labelNumber": 5,
                 "labelType": "Signal",
                 "imageX": 12500,
                 "imageY": 3690,
@@ -907,6 +936,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": false,
             "properties": {
                 "action": "DeleteAccessibilityAttribute",
+                "labelNumber": 5,
                 "labelType": "Signal",
                 "minHeading": headingRanges["stage-2"][0],
                 "maxHeading": headingRanges["stage-2"][1],
@@ -939,6 +969,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": false,
             "properties": {
                 "action": "RedoSelectLabelType",
+                "labelNumber": 5,
                 "labelType": "Signal",
                 "minHeading": headingRanges["stage-2"][0],
                 "maxHeading": headingRanges["stage-2"][1],
@@ -1009,6 +1040,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": true,
             "properties": {
                 "action": "SelectLabelType",
+                "labelNumber": 6,
                 "labelType": "Crosswalk",
                 "minHeading": headingRanges["stage-3"][0],
                 "maxHeading": headingRanges["stage-3"][1]
@@ -1033,6 +1065,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": true,
             "properties": [{
                 "action": "LabelAccessibilityAttribute",
+                "labelNumber": 6,
                 "labelType": "Crosswalk",
                 "imageX": 11850,
                 "imageY": 3980,
@@ -1067,6 +1100,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": false,
             "properties": {
                 "action": "DeleteAccessibilityAttribute",
+                "labelNumber": 6,
                 "labelType": "Crosswalk",
                 "minHeading": headingRanges["stage-3"][0],
                 "maxHeading": headingRanges["stage-3"][1],
@@ -1092,6 +1126,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": false,
             "properties": {
                 "action": "RedoSelectLabelType",
+                "labelNumber": 6,
                 "labelType": "Crosswalk",
                 "minHeading": headingRanges["stage-3"][0],
                 "maxHeading": headingRanges["stage-3"][1],
@@ -1117,6 +1152,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": true,
             "properties": {
                 "action": "RateSeverity",
+                "labelNumber": 6,
                 "labelType": "Crosswalk",
                 "minHeading": headingRanges["stage-3"][0],
                 "maxHeading": headingRanges["stage-3"][1]
@@ -1141,6 +1177,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": false,
             "properties": {
                 "action": "RedoRateSeverity",
+                "labelNumber": 6,
                 "labelType": "Crosswalk",
                 "minHeading": headingRanges["stage-3"][0],
                 "maxHeading": headingRanges["stage-3"][1]
@@ -1235,6 +1272,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": true,
             "properties": {
                 "action": "SelectLabelType",
+                "labelNumber": 7,
                 "labelType": "NoSidewalk",
                 "minHeading": headingRanges["stage-4"][0],
                 "maxHeading": headingRanges["stage-4"][1]
@@ -1260,6 +1298,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": true,
             "properties": [{
                 "action": "LabelAccessibilityAttribute",
+                "labelNumber": 7,
                 "labelType": "NoSidewalk",
                 "imageX": 7550,
                 "imageY": 3900,
@@ -1294,6 +1333,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": false,
             "properties": {
                 "action": "DeleteAccessibilityAttribute",
+                "labelNumber": 7,
                 "labelType": "NoSidewalk",
                 "minHeading": headingRanges["stage-4"][0],
                 "maxHeading": headingRanges["stage-4"][1],
@@ -1319,6 +1359,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": false,
             "properties": {
                 "action": "RedoSelectLabelType",
+                "labelNumber": 7,
                 "labelType": "NoSidewalk",
                 "minHeading": headingRanges["stage-4"][0],
                 "maxHeading": headingRanges["stage-4"][1],
@@ -1344,6 +1385,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": true,
             "properties": {
                 "action": "RateSeverity",
+                "labelNumber": 7,
                 "labelType": "NoSidewalk",
                 "minHeading": headingRanges["stage-4"][0],
                 "maxHeading": headingRanges["stage-4"][1]
@@ -1371,6 +1413,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": false,
             "properties": {
                 "action": "RedoRateSeverity",
+                "labelNumber": 7,
                 "labelType": "NoSidewalk",
                 "minHeading": headingRanges["stage-4"][0],
                 "maxHeading": headingRanges["stage-4"][1]
@@ -1398,6 +1441,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": true,
             "properties": {
                 "action": "AddTag",
+                "labelNumber": 7,
                 "labelType": "NoSidewalk",
                 "minHeading": headingRanges["stage-4"][0],
                 "maxHeading": headingRanges["stage-4"][1]
@@ -1429,6 +1473,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": false,
             "properties": {
                 "action": "RedoAddTag",
+                "labelNumber": 7,
                 "labelType": "NoSidewalk",
                 "minHeading": headingRanges["stage-4"][0],
                 "maxHeading": headingRanges["stage-4"][1]
@@ -1477,6 +1522,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": true,
             "properties": {
                 "action": "SelectLabelType",
+                "labelNumber": 8,
                 "labelType": "CurbRamp",
                 "minHeading": headingRanges["stage-5"][0],
                 "maxHeading": headingRanges["stage-5"][1]
@@ -1502,6 +1548,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": true,
             "properties": [{
                 "action": "LabelAccessibilityAttribute",
+                "labelNumber": 8,
                 "labelType": "CurbRamp",
                 "imageX": 5550,
                 "imageY": 4080,
@@ -1536,6 +1583,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": false,
             "properties": {
                 "action": "DeleteAccessibilityAttribute",
+                "labelNumber": 8,
                 "labelType": "CurbRamp",
                 "minHeading": headingRanges["stage-5"][0],
                 "maxHeading": headingRanges["stage-5"][1],
@@ -1561,6 +1609,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": false,
             "properties": {
                 "action": "RedoSelectLabelType",
+                "labelNumber": 8,
                 "labelType": "CurbRamp",
                 "minHeading": headingRanges["stage-5"][0],
                 "maxHeading": headingRanges["stage-5"][1],
@@ -1586,6 +1635,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": true,
             "properties": {
                 "action": "RateSeverity",
+                "labelNumber": 8,
                 "labelType": "CurbRamp",
                 "minHeading": headingRanges["stage-5"][0],
                 "maxHeading": headingRanges["stage-5"][1]
@@ -1612,6 +1662,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": false,
             "properties": {
                 "action": "RedoRateSeverity",
+                "labelNumber": 8,
                 "labelType": "CurbRamp",
                 "minHeading": headingRanges["stage-5"][0],
                 "maxHeading": headingRanges["stage-5"][1]
@@ -1638,6 +1689,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": true,
             "properties": {
                 "action": "SelectLabelType",
+                "labelNumber": 9,
                 "labelType": "Signal",
                 "minHeading": headingRanges["stage-5"][0],
                 "maxHeading": headingRanges["stage-5"][1]
@@ -1669,6 +1721,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": true,
             "properties": [{
                 "action": "LabelAccessibilityAttribute",
+                "labelNumber": 9,
                 "labelType": "Signal",
                 "imageX": 5015,
                 "imageY": 4260,
@@ -1711,6 +1764,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": false,
             "properties": {
                 "action": "DeleteAccessibilityAttribute",
+                "labelNumber": 9,
                 "labelType": "Signal",
                 "minHeading": headingRanges["stage-5"][0],
                 "maxHeading": headingRanges["stage-5"][1],
@@ -1743,6 +1797,7 @@ function OnboardingStates (contextMenu, compass, mapService, statusModel, tracke
             "progression": false,
             "properties": {
                 "action": "RedoSelectLabelType",
+                "labelNumber": 9,
                 "labelType": "Signal",
                 "minHeading": headingRanges["stage-5"][0],
                 "maxHeading": headingRanges["stage-5"][1],


### PR DESCRIPTION
Fixes #4021

Here are a few of the bugs that were fixed
* Rating severity wasn't disabled during that tagging step, allowing you to complete steps out of order (this was introduced in PR #3845)
* You could edit labels from earlier in the tutorial when you were supposed to edit the current one (because "enabling tagging" wasn't tied to a specific label). This also meant that editing the severity for a prior label could progress the tutorial as if you had rated the current one correctly

I made a few other improvements to keyboard shortcuts while I was looking at the relevant code:
* The `enter` and `esc` keys now close the context menu even if you're focused on the description text box
* 1/2/3 on the number pad will now add severity ratings as it does for the typical 1/2/3 keys
* zooming in/out should be a bit less finicky as well

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
