### PR TITLE
Validate old labels using AI, nightly batch

### DIFF
--- a/app/actor/AuthTokenCleanerActor.scala
+++ b/app/actor/AuthTokenCleanerActor.scala
@@ -30,10 +30,10 @@ class AuthTokenCleanerActor @Inject() (authenticationService: service.Authentica
     super.preStart()
     // Get the number of hours later to run the code in this city. Used to stagger computation/resource use.
     configService.getOffsetHours.foreach { hoursOffset =>
-      // Target time is 2:00 am Pacific + offset.
+      // Target time is 2:30 am Pacific + offset.
       cancellable = Some(
         context.system.scheduler.scheduleAtFixedRate(
-          getTimeToNextUpdate(2, 0, hoursOffset).toMillis.millis,
+          getTimeToNextUpdate(2, 30, hoursOffset).toMillis.millis,
           24.hours,
           self,
           AuthTokenCleanerActor.Tick

--- a/app/actor/RecalculateStreetPriorityActor.scala
+++ b/app/actor/RecalculateStreetPriorityActor.scala
@@ -30,10 +30,10 @@ class RecalculateStreetPriorityActor @Inject() (streetService: StreetService, re
     super.preStart()
     // Get the number of hours later to run the code in this city. Used to stagger computation/resource use.
     configService.getOffsetHours.foreach { hoursOffset =>
-      // Target time is 12:45 am Pacific + offset.
+      // Target time is 1:45 am Pacific + offset.
       cancellable = Some(
         context.system.scheduler.scheduleAtFixedRate(
-          getTimeToNextUpdate(0, 45, hoursOffset).toMillis.millis,
+          getTimeToNextUpdate(1, 45, hoursOffset).toMillis.millis,
           24.hours,
           self,
           RecalculateStreetPriorityActor.Tick

--- a/app/actor/UserStatActor.scala
+++ b/app/actor/UserStatActor.scala
@@ -28,10 +28,10 @@ class UserStatActor @Inject() (adminService: AdminService)(implicit ec: Executio
     super.preStart()
     // Get the number of hours later to run the code in this city. Used to stagger computation/resource use.
     configService.getOffsetHours.foreach { hoursOffset =>
-      // Target time is 12:30 am Pacific + offset.
+      // Target time is 1:30 am Pacific + offset.
       cancellable = Some(
         context.system.scheduler.scheduleAtFixedRate(
-          getTimeToNextUpdate(0, 30, hoursOffset).toMillis.millis,
+          getTimeToNextUpdate(1, 30, hoursOffset).toMillis.millis,
           24.hours,
           self,
           UserStatActor.Tick

--- a/app/models/label/LabelTypeTable.scala
+++ b/app/models/label/LabelTypeTable.scala
@@ -87,7 +87,7 @@ object LabelTypeEnum {
 
   // Set of label types are accepted for validation using the Sidewalk AI API.
   lazy val aiLabelTypes: Set[String] = Set(
-    CurbRamp.name, NoCurbRamp.name, Obstacle.name, SurfaceProblem.name, NoSidewalk.name, Crosswalk.name
+    CurbRamp.name, NoCurbRamp.name, Obstacle.name, SurfaceProblem.name, Crosswalk.name
   )
   lazy val aiLabelTypeIds: Set[Int] = aiLabelTypes.map(labelTypeToId)
 }

--- a/app/models/mission/MissionTable.scala
+++ b/app/models/mission/MissionTable.scala
@@ -186,7 +186,6 @@ class MissionTable @Inject() (protected val dbConfigProvider: DatabaseConfigProv
    * @return DBIO[Int] - the mission ID for the AI validation mission of the given label type
    */
   def getAiValidateMissionId(labelTypeId: Int): DBIO[Int] = {
-    println("Getting AI validation mission ID for label type: " + labelTypeId)
     missions
       .filter(m => m.labelTypeId === labelTypeId && m.missionTypeId === missionTypeToId("aiValidation"))
       .map(_.missionId)

--- a/app/modules/ActorModule.scala
+++ b/app/modules/ActorModule.scala
@@ -7,6 +7,7 @@ import play.api.libs.concurrent.PekkoGuiceSupport
 class ActorModule extends AbstractModule with PekkoGuiceSupport {
   override def configure() = {
     bindActor[CheckImageExpiryActor]("check-image-expiry-actor")
+    bindActor[GetAiValidationsActor]("get-ai-validations-actor")
     bindActor[UserStatActor]("user-stats-actor")
     bindActor[RecalculateStreetPriorityActor]("recalculate-street-priority-actor")
     bindActor[AuthTokenCleanerActor]("auth-token-cleaner-actor")

--- a/app/service/GsvDataService.scala
+++ b/app/service/GsvDataService.scala
@@ -94,7 +94,7 @@ class GsvDataServiceImpl @Inject() (
         val imageStatus          = (Json.parse(response.body) \ "status").as[String]
         val imageExists: Boolean = imageStatus == "OK"
 
-        if (imageExists || imageStatus != "ZERO_RESULTS") {
+        if (imageExists || imageStatus == "ZERO_RESULTS") {
           // Mark the expired status, last_checked, and last_viewed columns in the db.
           val timestamp = OffsetDateTime.now
           db.run(gsvDataTable.updateExpiredStatus(gsvPanoId, !imageExists, timestamp)).map(_ => Some(imageExists))


### PR DESCRIPTION
Resolves #3997

Adds a nightly process that takes a batch of older labels that haven't yet been validated with AI and runs them through the Sidewalk AI API.

Also fixes a few bugs:
1. We weren't actually marking imagery as deleted (I had written `!=` instead of `==` in commit 75fdcacbf9e384846904d848147cbd5f189c53fb last month, oops!)
2. We were trying to ask AI to validate NoSidewalk labels, which we don't have the ability to do quite yet!

I started by trying to validate just 500 labels per city per day for now. I want to start with that and ensure that the process is actually completing in every city consistently, then I hope to move up to 1k labels per night. It looks like running a validation is taking ~3 seconds, which means 1.2k validations per hour. But we have more than 24 cities, so some of them will be running at the same time. Just need to monitor load. There are performance improvements that we could make to the validator as well (like using the panos that we've already downloaded for old labels) that would allow to validate more per hour.

I also set it validate 20 labels per night on test servers as a nominal amount that we can use to just make sure that the process is generally working. And we keep only a few of the test servers up at any given time, so this shouldn't be a particularly large load.

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure the documentation on [this wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Descriptions-of-Logged-Events) is up to date for the logs you added/updated.
