### PR TITLE
Disabled scroll wheel zoom on all API Docs map previews 

### DIFF
--- a/public/javascripts/api-docs/cities-preview.js
+++ b/public/javascripts/api-docs/cities-preview.js
@@ -102,16 +102,7 @@
             container.appendChild(mapElement);
 
             // Create the map, centered on the world.
-            const map = L.map('cities-map', {
-                // prevent accidental zoom while scrolling the page
-                scrollWheelZoom: false,
-                // keep intentional zoom methods
-                touchZoom: true,
-                zoomControl: true
-            }).setView([20, 0], 2);
-
-            // (Defensive) ensure it stays off even if defaults change elsewhere
-            map.scrollWheelZoom.disable();
+            const map = L.map('cities-map', { scrollWheelZoom: false }).setView([20, 0], 2);
 
             // Add the OpenStreetMap tile layer.
             L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {

--- a/public/javascripts/api-docs/label-clusters-preview.js
+++ b/public/javascripts/api-docs/label-clusters-preview.js
@@ -203,14 +203,7 @@
             const center = this.getCenterFromRegion(regionData);
 
             // Create the map.
-            const map = L.map('label-clusters-map', {
-                scrollWheelZoom: false, // disable zooming with scroll wheel
-                touchZoom: true,
-                zoomControl: true
-            }).setView(center, 16);
-
-            // Defensive: ensure scroll wheel zoom remains disabled.
-            map.scrollWheelZoom.disable();
+            const map = L.map('label-clusters-map', { scrollWheelZoom: false }).setView(center, 16);
 
             // Add the OpenStreetMap tile layer with darkened overlay.
             L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {

--- a/public/javascripts/api-docs/raw-labels-preview.js
+++ b/public/javascripts/api-docs/raw-labels-preview.js
@@ -203,14 +203,7 @@
             const center = this.getCenterFromRegion(regionData);
 
             // Create the map.
-            const map = L.map('raw-labels-map', {
-                scrollWheelZoom: false, // disable wheel zoom so page scroll works
-                touchZoom: true,
-                zoomControl: true
-            }).setView(center, 16);
-
-            // Defensive: keep it off even if defaults change elsewhere.
-            map.scrollWheelZoom.disable();
+            const map = L.map('raw-labels-map', { scrollWheelZoom: false }).setView(center, 16);
 
             L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
                 attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'

--- a/public/javascripts/api-docs/streets-preview.js
+++ b/public/javascripts/api-docs/streets-preview.js
@@ -312,15 +312,7 @@
 
             const center = this.getCenterFromRegion(regionData);
 
-            // Create the map with scroll wheel zoom disabled.
-            const map = L.map(`streets-${mapType}-map`, {
-                scrollWheelZoom: false, // prevent accidental zoom while scrolling page
-                touchZoom: true,
-                zoomControl: true
-            }).setView(center, 16);
-
-            // Defensive: ensure it stays off.
-            map.scrollWheelZoom.disable();
+            const map = L.map(`streets-${mapType}-map`, { scrollWheelZoom: false }).setView(center, 16);
 
             // Add CartoDB Dark Matter tile layer for better line visibility.
             L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {


### PR DESCRIPTION
Resolves #4029 

Disabled scroll wheel zoom on all API Docs Leaflet maps to prevent accidental zooming while scrolling the page. Implemented by setting scrollWheelZoom: false in each map initialization.

<img width="1078" height="687" alt="Screenshot 2025-10-24 at 12 28 02 AM" src="https://github.com/user-attachments/assets/4737d0e3-1abc-4d1b-a5c7-6677a3bb2eee" />

##### Testing instructions
1. Scroll past the maps in the API docs and you will see it won't zoom anymore.

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->

- [x] I've added/updated comments for large or confusing blocks of code.
- [X] I've included before/after screenshots above.
- [X] I've asked for and included translations for any user facing text that was added or modified.
- [X] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure the documentation on [this wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Descriptions-of-Logged-Events) is up to date for the logs you added/updated.
- [ ] I've tested on mobile (only needed for validation page).
