### PR TITLE
Added ESC keyboard shortcut to escape out of expanded view in Gallery.

### DIFF
--- a/public/javascripts/Gallery/src/expandedview/ExpandedView.js
+++ b/public/javascripts/Gallery/src/expandedview/ExpandedView.js
@@ -423,6 +423,7 @@ function ExpandedView(uiModal) {
     self.previousLabel = previousLabel;
     self.zoomIn = zoomIn;
     self.zoomOut = zoomOut;
+    self.closeExpandedViewAndRemoveCardTransparency = closeExpandedViewAndRemoveCardTransparency;
 
 
     return self;

--- a/public/javascripts/Gallery/src/keyboard/Keyboard.js
+++ b/public/javascripts/Gallery/src/keyboard/Keyboard.js
@@ -62,6 +62,11 @@ function Keyboard(expandedView) {
                         }
                     }
                     break;
+                case "ESCAPE":
+                    if (expandedView.open) {
+                        expandedView.closeExpandedViewAndRemoveCardTransparency();
+                    }
+                    break;
                 default:
                     break;
             }


### PR DESCRIPTION
Resolves #3923 

Added esc keyboard shortcut to escape out of expanded view in Gallery mode. Added a new ESCAPE shortcut in Keyboard.js.
##### Before/After screenshots (if applicable)
<img width="1353" height="765" alt="Screenshot 2025-10-31 at 10 39 47 AM" src="https://github.com/user-attachments/assets/82955045-6ea3-4fa4-95ea-bdff1405a5f4" />

##### Testing instructions
1. Enter Gallery mode and click on an image.
2. Use the ESC key to exit out of expanded view.

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
- [x] I've asked for and included translations for any user facing text that was added or modified.
- [x] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure the documentation on [this wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Descriptions-of-Logged-Events) is up to date for the logs you added/updated.
- [ ] I've tested on mobile (only needed for validation page).
