### PR TITLE
Renames "points into traffic" tag to "points into cross traffic"

### DIFF
--- a/app/views/apiDocs/rawLabels.scala.html
+++ b/app/views/apiDocs/rawLabels.scala.html
@@ -369,7 +369,7 @@
                     <tr>
                         <td><code>properties.tags</code></td>
                         <td><code>array[string]</code></td>
-                        <td>Array of string tags providing additional context about the label. Common tags include <code>grass</code>, <code>height difference</code>, <code>no alternate route</code>, <code>points into traffic</code>, among others.</td>
+                        <td>Array of string tags providing additional context about the label. Common tags include <code>grass</code>, <code>height difference</code>, <code>no alternate route</code>, <code>points into cross traffic</code>, among others.</td>
                     </tr>
                     <tr>
                         <td><code>properties.description</code></td>

--- a/app/views/labelingGuide/labelingGuideCurbRamps.scala.html
+++ b/app/views/labelingGuide/labelingGuideCurbRamps.scala.html
@@ -90,8 +90,8 @@
                                     <figcaption>
                                         A corner with only one curb ramp. The severity rating would be Low, since
                                         pedestrians are only minorly directed into traffic, and they are protected by a
-                                        parking lane; though the "points into traffic" tag should still be used. If the
-                                        visible lanes were not parking lanes, the severity rating would be Medium.
+                                        parking lane; though the "points into cross traffic" tag should still be used.
+                                        If the visible lanes were not parking lanes, the severity rating would be Medium.
                                     </figcaption>
                                 </figure>
                             </div>

--- a/public/locales/de/audit.json
+++ b/public/locales/de/audit.json
@@ -115,7 +115,7 @@
             "label-popup-shortcuts": "Drücken Sie <tag-underline>{{c}}</tag-underline>, um einen Tag hinzuzufügen",
             "tag": {
                 "narrow": "schm<tag-underline>a</tag-underline>l",
-                "points-into-traffic": "auf den Verkehr ausger<tag-underline>i</tag-underline>chtet",
+                "points-into-traffic": "auf Querverkehr ausger<tag-underline>i</tag-underline>chtet",
                 "missing-tactile-warning": "fehlende taktil<tag-underline>e</tag-underline> Orientierungshilfe",
                 "tactile-warning": "taktile Orientierungs<tag-underline>h</tag-underline>ilfe",
                 "steep": "s<tag-underline>t</tag-underline>eil",

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -59,7 +59,7 @@
     "ai-disclaimer": "Die KI hat dieses Label analysiert und mit „$t({{aiVal}})“ bewertet. KI kann jedoch Fehler machen. Bitte bilden Sie sich Ihre eigene Meinung.",
     "tag": {
         "narrow": "schmal",
-        "points into traffic": "auf den Verkehr ausgerichtet",
+        "points into traffic": "auf Querverkehr ausgerichtet",
         "missing tactile warning": "fehlende taktile Orientierungshilfe",
         "tactile warning": "taktile Orientierungshilfe",
         "steep": "steil",

--- a/public/locales/en/audit.json
+++ b/public/locales/en/audit.json
@@ -115,7 +115,7 @@
             "label-popup-shortcuts": "Press <tag-underline>{{c}}</tag-underline> to add tag",
             "tag": {
                 "narrow": "n<tag-underline>a</tag-underline>rrow",
-                "points-into-traffic": "points <tag-underline>i</tag-underline>nto traffic",
+                "points-into-traffic": "points <tag-underline>i</tag-underline>nto cross traffic",
                 "missing-tactile-warning": "missing tactil<tag-underline>e</tag-underline> warning",
                 "tactile-warning": "tactile warning (<tag-underline>h</tag-underline>)",
                 "steep": "s<tag-underline>t</tag-underline>eep",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -59,7 +59,7 @@
     "ai-disclaimer": "AI analyzed this label and voted \"$t({{aiVal}})\"; however, AI can make mistakes. Please make your own assessment.",
     "tag": {
         "narrow": "narrow",
-        "points into traffic": "points into traffic",
+        "points into traffic": "points into cross traffic",
         "missing tactile warning": "missing tactile warning",
         "tactile warning": "tactile warning",
         "steep": "steep",

--- a/public/locales/es/audit.json
+++ b/public/locales/es/audit.json
@@ -115,7 +115,7 @@
             "label-popup-shortcuts": "Presiona <tag-underline>{{c}}</tag-underline> para agregar la etiqueta",
             "tag": {
                 "narrow": "muy <tag-underline>a</tag-underline>ngosta",
-                "points-into-traffic": "orientada hac<tag-underline>i</tag-underline>a el tráfico",
+                "points-into-traffic": "orientado hacia el tráf<tag-underline>i</tag-underline>co transversal",
                 "missing-tactile-warning": "pavim<tag-underline>e</tag-underline>nto de advertencia táctil ausente",
                 "tactile-warning": "advertencia táctil (<tag-underline>h</tag-underline>)",
                 "steep": "empinada (mucha pendien<tag-underline>t</tag-underline>e)",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -59,7 +59,7 @@
     "ai-disclaimer": "La IA analizó esta etiqueta y votó \"$t({{aiVal}})\"; sin embargo, la IA puede cometer errores. Por favor, haga su propia evaluación.",
     "tag": {
         "narrow": "muy angosta",
-        "points into traffic": "orientada hacia el tráfico",
+        "points into traffic": "orientado hacia el tráfico transversal",
         "missing tactile warning": "pavimento de advertencia táctil ausente",
         "tactile warning": "advertencia táctil",
         "steep": "empinada (mucha pendiente)",

--- a/public/locales/nl/audit.json
+++ b/public/locales/nl/audit.json
@@ -115,7 +115,7 @@
             "label-popup-shortcuts": "Druk <tag-underline>{{c}}</tag-underline> om een tag toe te voegen",
             "tag": {
                 "narrow": "sm<tag-underline>a</tag-underline>l",
-                "points-into-traffic": "het verkeer <tag-underline>i</tag-underline>n gericht",
+                "points-into-traffic": "punten <tag-underline>i</tag-underline>n het kruisende verkeer",
                 "missing-tactile-warning": "tacti<tag-underline>e</tag-underline>le waarschuwing ontbreekt",
                 "tactile-warning": "tactile waarsc<tag-underline>h</tag-underline>uwing",
                 "steep": "s<tag-underline>t</tag-underline>eil",

--- a/public/locales/nl/common.json
+++ b/public/locales/nl/common.json
@@ -58,7 +58,7 @@
     "ai-disclaimer": "AI heeft dit label geanalyseerd en gestemd op \"$t({{aiVal}})\". AI kan echter fouten maken. Maak uw eigen beoordeling.",
     "tag": {
         "narrow": "smal",
-        "points into traffic": "het verkeer in gericht",
+        "points into traffic": "punten in het kruisende verkeer",
         "missing tactile warning": "tactiele waarschuwing ontbreekt",
         "tactile warning": "tactiele waarschuwing",
         "steep": "steil",

--- a/public/locales/zh-TW/audit.json
+++ b/public/locales/zh-TW/audit.json
@@ -115,7 +115,7 @@
             "label-popup-shortcuts": "點選<tag-underline>{{c}}</tag-underline>以增加標籤",
             "tag": {
                 "narrow": "狹窄(<tag-underline>a</tag-underline>)",
-                "points-into-traffic": "對著交通車流(<tag-underline>i</tag-underline>)",
+                "points-into-traffic": "指向橫向交通(<tag-underline>i</tag-underline>)",
                 "missing-tactile-warning": "缺導盲警示帶(<tag-underline>e</tag-underline>)",
                 "tactile-warning": "導盲警示帶(<tag-underline>h</tag-underline>)",
                 "steep": "陡峭(<tag-underline>t</tag-underline>)",

--- a/public/locales/zh-TW/common.json
+++ b/public/locales/zh-TW/common.json
@@ -59,7 +59,7 @@
     "ai-disclaimer": "AI 分析了此標籤並投票「$t({{aiVal}})」；然而，AI 難免會犯錯。請自行判斷。",
     "tag": {
         "narrow": "狹窄",
-        "points into traffic": "面向交通車流",
+        "points into traffic": "指向橫向交通",
         "missing tactile warning": "缺導盲警示帶",
         "tactile warning": "導盲警示帶",
         "steep": "陡峭",


### PR DESCRIPTION
Resolves #4043

Renames "points into traffic" tag to "points into cross traffic". Though we still don't feel like this is the perfect name, as "cross traffic" is on the more technical side of verbiage, I think that this is an improvement in that it's a more accurate representation of what the tag's meaning. So an improvement for now! 
