### PR TITLE
updates unsure reasoning text on Expert Validate

### DIFF
--- a/public/javascripts/SVValidate/src/menu/RightMenu.js
+++ b/public/javascripts/SVValidate/src/menu/RightMenu.js
@@ -161,7 +161,7 @@ function RightMenu(menuUI) {
                 const $reasonButton = $(reasonButton);
                 const buttonInfo = svv.reasonButtonInfo[labelType][$reasonButton.attr('id')];
                 if (buttonInfo) {
-                    $reasonButton.text(buttonInfo.buttonText);
+                    $reasonButton.html(buttonInfo.buttonText);
 
                     // Remove any old tooltip (from a previous label type) and add a new tooltip.
                     $reasonButton.tooltip('destroy');
@@ -495,14 +495,14 @@ function RightMenu(menuUI) {
             if (disagreeReason === 'other') {
                 comment = currLabel.getProperty('disagreeReasonTextBox');
             } else {
-                comment = menuUI.disagreeReasonOptions.find(`#${disagreeReason}`).text();
+                comment = menuUI.disagreeReasonOptions.find(`#${disagreeReason}`).html().replace('<br>', ' ');
             }
         } else if (action === 'Unsure') {
             let unsureReason = currLabel.getProperty('unsureOption');
             if (unsureReason === 'other') {
                 comment = currLabel.getProperty('unsureReasonTextBox');
             } else {
-                comment = menuUI.unsureReasonOptions.find(`#${unsureReason}`).text();
+                comment = menuUI.unsureReasonOptions.find(`#${unsureReason}`).html().replace('<br>', ' ');
             }
         }
         currLabel.setProperty('comment', comment);

--- a/public/locales/en/validate.json
+++ b/public/locales/en/validate.json
@@ -161,8 +161,8 @@
                 "unsure-button-3-tooltip": "It may be unclear whether pedestrians should be able to cross at an intersection with a busier road"
             },
             "obstacle": {
-                "unsure-button-3": "Not sure if sidewalk is wide enough to avoid the obstacle",
-                "unsure-button-3-tooltip": "The width of the sidewalk may be difficult to judge from an image"
+                "unsure-button-3": "There might be enough space<br>to avoid the object",
+                "unsure-button-3-tooltip": "The width of the sidewalk may be difficult to judge from a picture"
             },
             "surface-problem": {
                 "unsure-button-3": "Might be too minor to label",


### PR DESCRIPTION
Resolves #4026 

Renames the third "Unsure" reason in Expert Validate. I also added a line break at a more aesthetically pleasing place.

Before
<img width="411" height="585" alt="Screenshot from 2025-11-20 14-55-38" src="https://github.com/user-attachments/assets/6800cffc-5b92-41e3-8223-adb6a1756383" />

After
<img width="411" height="585" alt="Screenshot from 2025-11-20 15-13-17" src="https://github.com/user-attachments/assets/344c865c-8b9a-4b05-9302-1ef19fb91d9a" />
