### PR TITLE
AI user now has its own role

### DIFF
--- a/app/models/mission/MissionTable.scala
+++ b/app/models/mission/MissionTable.scala
@@ -246,7 +246,7 @@ class MissionTable @Inject() (protected val dbConfigProvider: DatabaseConfigProv
    */
   def selectMissionCountsPerUser: DBIO[Seq[(String, String, Int)]] = {
     val userMissions = for {
-      _user        <- users if _user.username =!= "anonymous"
+      _user        <- users
       _userRole    <- userRoles if _user.userId === _userRole.userId
       _role        <- roles if _userRole.roleId === _role.roleId
       _mission     <- missions if _user.userId === _mission.userId

--- a/app/models/user/RoleTable.scala
+++ b/app/models/user/RoleTable.scala
@@ -4,7 +4,6 @@ import com.google.inject.ImplementedBy
 import models.utils.MyPostgresProfile
 import models.utils.MyPostgresProfile.api._
 import play.api.db.slick.{DatabaseConfigProvider, HasDatabaseConfigProvider}
-
 import javax.inject.{Inject, Singleton}
 
 case class Role(roleId: Int, role: String)
@@ -23,8 +22,8 @@ object RoleTable {
   val SCISTARTER_ROLES: Seq[String] = Seq("Registered", "Researcher", "Administrator", "Owner")
   val RESEARCHER_ROLES: Seq[String] = Seq("Researcher", "Administrator", "Owner")
   val ADMIN_ROLES: Seq[String]      = Seq("Administrator", "Owner")
-  val VALID_ROLES: Seq[String]      = Seq("Registered", "Turker", "Researcher", "Administrator", "Owner", "Anonymous")
-  val ROLES_RESEARCHER_COLLAPSED: Seq[String] = Seq("Registered", "Turker", "Researcher", "Anonymous")
+  val VALID_ROLES: Seq[String] = Seq("Registered", "Turker", "Researcher", "Administrator", "Owner", "Anonymous", "AI")
+  val ROLES_RESEARCHER_COLLAPSED: Seq[String] = Seq("Registered", "Turker", "Researcher", "Anonymous", "AI")
 }
 
 @ImplementedBy(classOf[RoleTable])

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -683,9 +683,6 @@
                                 <span>Standard Deviation (turker users): </span><span id="turker-labels-std"></span><br>
                                 <span>Standard Deviation (registered users): </span><span id="reg-labels-std"></span><br>
                                 <span>Standard Deviation (anon users): </span><span id="anon-labels-std"></span><br>
-                                <span>
-                                    Note: We only consider anonymous users who have completed at least one audit task.
-                                </span>
                             </p>
                         </div>
                         <div class="col-lg-12">
@@ -704,7 +701,7 @@
                         </div>
                         <label><input type="checkbox" id="login-count-include-researchers-checkbox"> Include researchers</label>
 
-                        <h2 class="d-block">User Performance (validation agreement)</h2>
+                        <h2 class="d-block">User Accuracy</h2>
                         <div class="col-lg-12">
                             <p>
                                 <span>Standard Deviation: </span><span id="validation-agreed-std"></span><br>

--- a/conf/evolutions/default/295.sql
+++ b/conf/evolutions/default/295.sql
@@ -1,0 +1,12 @@
+# --- !Ups
+-- Add a new role for the dummy SidewalkAI user.
+INSERT INTO sidewalk_login.role (role_id, role)
+SELECT 7, 'AI'
+WHERE NOT EXISTS (SELECT 1 FROM sidewalk_login.role WHERE role = 'AI');
+
+UPDATE sidewalk_login.user_role SET role_id = 7 WHERE user_id = '51b0b927-3c8a-45b2-93de-bd878d1e5cf4';
+
+# --- !Downs
+UPDATE sidewalk_login.user_role SET role_id = 1 WHERE role_id = 7;
+
+DELETE FROM sidewalk_login.role WHERE role = 'AI';

--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -605,27 +605,16 @@ function Admin(_, $, mapboxApiKey) {
 
             });
             $.getJSON('/adminapi/validationCounts', function (data) {
-                var filteredData = data.map(function(x) {
-                    return {
-                        role: x.role,
-                        total: x.count,
-                        agreed: x.agreed,
-                    }
-                });
+                // Must have 50+ labels validated. Also removing AI user.
+                var filteredData = data.filter(function(x) { return x.count >= 50 && x.role !== 'AI'; })
 
-                var pcts = filteredData.filter(function(x) { // Must have 10+ labels validated
-                    return x.total >= 10;
-                }).map(function (x) { // Convert to percentages
-                    return {
-                        count: (x.agreed / x.total) * 100,
-                        role: x.role
-                    };
-                });
+                // Convert to percentages.
+                var pcts = filteredData.map(function (x) { return { count: (x.agreed / x.count) * 100 }; });
 
                 var stats = getSummaryStats(pcts, "count");
                 $("#validation-agreed-std").html((stats.std).toFixed(2) + " %");
 
-                var histOpts = {xAxisTitle:"Validations Placed Agreed With (%)", xDomain:[0, 100], binStep:5};
+                var histOpts = { xAxisTitle:"User Accuracy (%)", xDomain:[0, 100], binStep:5 };
                 var coverageRateHist = getVegaLiteHistogram(pcts, stats.mean, stats.median, histOpts);
                 vega.embed("#validation-agreed", coverageRateHist, opt, function(error, results) {});
 
@@ -757,7 +746,7 @@ function Admin(_, $, mapboxApiKey) {
                         }
                     }
                 };
-                vega.embed("#label-count-chart", chart, opt, function(error, results) {});
+                vega.embed("#label-count-chart", chart, opt, function(error, results) { });
             });
             $.getJSON("/userapi/validationCounts/all", function (data) {
                 var stats = getSummaryStats(data, "count");
@@ -823,7 +812,8 @@ function Admin(_, $, mapboxApiKey) {
                 };
                 vega.embed("#validation-count-chart", chart, opt, function(error, results) {});
             });
-            $.getJSON("/adminapi/userMissionCounts", function (allData) {
+            $.getJSON("/adminapi/userMissionCounts", function (data) {
+                var allData = data.filter(user => user.role !== 'AI');
                 var regData = allData.filter(user => user.role === 'Registered' || isResearcherRole(user.role));
                 var anonData = allData.filter(user => user.role === 'Anonymous');
                 var turkerData = allData.filter(user => user.role === 'Turker');
@@ -888,8 +878,7 @@ function Admin(_, $, mapboxApiKey) {
                     }
                 });
 
-                vega.embed("#mission-count-chart", combinedChartFiltered, opt, function (error, results) {
-                });
+                vega.embed("#mission-count-chart", combinedChartFiltered, opt, function (error, results) { });
 
                 var checkbox = document.getElementById("mission-count-include-researchers-checkbox").addEventListener("click", function (cb) {
                     if (cb.srcElement.checked) {
@@ -905,15 +894,16 @@ function Admin(_, $, mapboxApiKey) {
                     }
                 });
             });
-            $.getJSON("/adminapi/labelCounts", function (allData) {
+            $.getJSON("/adminapi/labelCounts", function (data) {
+                var allData = data.filter(user => user.role !== 'AI');
                 var regData = allData.filter(user => user.role === 'Registered' || isResearcherRole(user.role));
                 var turkerData = allData.filter(user => user.role === 'Turker');
                 var anonData = allData.filter(user => user.role === 'Anonymous');
 
                 var allStats = getSummaryStats(allData, "count");
-                var allFilteredStats = getSummaryStats(allData, "count", {excludeResearchers: true});
+                var allFilteredStats = getSummaryStats(allData, "count", { excludeResearchers: true });
                 var regStats = getSummaryStats(regData, "count");
-                var regFilteredStats = getSummaryStats(regData, "count", {excludeResearchers: true});
+                var regFilteredStats = getSummaryStats(regData, "count", { excludeResearchers: true });
                 var turkerStats = getSummaryStats(turkerData, "count");
                 var anonStats = getSummaryStats(anonData, "count");
 
@@ -970,8 +960,7 @@ function Admin(_, $, mapboxApiKey) {
                     }
                 });
 
-                vega.embed("#label-count-hist", combinedChartFiltered, opt, function (error, results) {
-                });
+                vega.embed("#label-count-hist", combinedChartFiltered, opt, function (error, results) { });
 
                 var checkbox = document.getElementById("label-count-include-researchers-checkbox").addEventListener("click", function (cb) {
                     if (cb.srcElement.checked) {
@@ -987,7 +976,8 @@ function Admin(_, $, mapboxApiKey) {
                     }
                 });
             });
-            $.getJSON("/adminapi/validationCounts", function (allData) {
+            $.getJSON("/adminapi/validationCounts", function (data) {
+                var allData = data.filter(user => user.role !== 'AI');
                 var regData = allData.filter(user => user.role === 'Registered' || isResearcherRole(user.role));
                 var turkerData = allData.filter(user => user.role === 'Turker');
                 var anonData = allData.filter(user => user.role === 'Anonymous');
@@ -1052,8 +1042,7 @@ function Admin(_, $, mapboxApiKey) {
                     }
                 });
 
-                vega.embed("#validation-count-hist", combinedChartFiltered, opt, function (error, results) {
-                });
+                vega.embed("#validation-count-hist", combinedChartFiltered, opt, function (error, results) { });
 
                 var checkbox = document.getElementById("validation-count-include-researchers-checkbox").addEventListener("click", function (cb) {
                     if (cb.srcElement.checked) {


### PR DESCRIPTION
Resolves #4074 

Adds a "role" in the database for the AI user (similar to the separate roles for registered users, anon users, admins, etc).

This is a more robust way to differentiate between AI and human users in our system, rather than relying on the hard coded `user_id` for the AI user as we had been doing.

This PR goes back through all of our code and updates to make use of the role for filtering and such.

Nothing really changed, aside from a few places where our count of users went down by one since we're now filtering out the AI user appropriately. I also fixed a couple tiny problems with charts on the Admin page as I saw them, but nothing major.

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
