### PR TITLE
Fixes bug where you could not validate on Expert Validate without a reason

### DIFF
--- a/public/javascripts/SVValidate/src/menu/RightMenu.js
+++ b/public/javascripts/SVValidate/src/menu/RightMenu.js
@@ -494,15 +494,19 @@ function RightMenu(menuUI) {
             let disagreeReason = currLabel.getProperty('disagreeOption');
             if (disagreeReason === 'other') {
                 comment = currLabel.getProperty('disagreeReasonTextBox');
-            } else {
+            } else if (disagreeReason) {
                 comment = menuUI.disagreeReasonOptions.find(`#${disagreeReason}`).html().replace('<br>', ' ');
+            } else {
+                comment = '';
             }
         } else if (action === 'Unsure') {
             let unsureReason = currLabel.getProperty('unsureOption');
             if (unsureReason === 'other') {
                 comment = currLabel.getProperty('unsureReasonTextBox');
-            } else {
+            } else if (unsureReason) {
                 comment = menuUI.unsureReasonOptions.find(`#${unsureReason}`).html().replace('<br>', ' ');
+            } else {
+                comment = '';
             }
         }
         currLabel.setProperty('comment', comment);


### PR DESCRIPTION
Resolves #4076 

Fixes a bug introduced in #4065, where failing to provide a rationale when disagreeing or being unsure silently prevented you from moving to the next label.
