### PR TITLE
Fixes tooltip staying open on Expert Validate

### DIFF
--- a/public/javascripts/SVValidate/src/menu/RightMenu.js
+++ b/public/javascripts/SVValidate/src/menu/RightMenu.js
@@ -397,6 +397,7 @@ function RightMenu(menuUI) {
 
                 // Add onclick to the tag to add or remove it if the user clicks to accept the AI suggestion.
                 template.on('click', e => {
+                    template.tooltip('destroy'); // Fix for the tooltip showing up on later labels, #4071.
                     if (tag.action === 'add') {
                         _addTag(tag.tag_name, true);
                     } else {


### PR DESCRIPTION
Fixes #4071

This should fix the issue where the tooltip on AI-suggested tags would stay open on subsequent labels, blocking your view! Just a one-line change to destroy the tooltip we created when you click on the AI-suggested tag to add it.