### PR TITLE
Fixes severity buttons erroneously being selected in Expert Validate

### DIFF
--- a/public/javascripts/SVLabel/src/Main.js
+++ b/public/javascripts/SVLabel/src/Main.js
@@ -224,7 +224,8 @@ function Main (params) {
 
         $('[data-toggle="tooltip"]').tooltip({
             delay: { "show": 500, "hide": 100 },
-            html: true
+            html: true,
+            container: 'body'
         });
 
         // Clean up the URL in the address bar.

--- a/public/javascripts/SVLabel/src/canvas/ContextMenu.js
+++ b/public/javascripts/SVLabel/src/canvas/ContextMenu.js
@@ -443,7 +443,8 @@ function ContextMenu (uiContextMenu) {
                 const tooltipFooter = `<i>${i18next.t('center-ui.context-menu.severity-shortcuts')}</i>`
                 $(`#severity-${sev}`).tooltip({
                     placement: "top", html: true, delay: {"show": 300, "hide": 10},
-                    title: `${tooltipHeader}<br/><img src=${img} height="110"/><br/>${tooltipFooter}`
+                    title: `${tooltipHeader}<br/><img src=${img} height="110"/><br/>${tooltipFooter}`,
+                    container: 'body'
                 });
             });
         }

--- a/public/javascripts/SVValidate/src/Main.js
+++ b/public/javascripts/SVValidate/src/Main.js
@@ -251,7 +251,8 @@ function Main (param) {
         });
         $('[data-toggle="tooltip"]').tooltip({
             delay: { "show": 500, "hide": 100 },
-            html: true
+            html: true,
+            container: 'body'
         });
 
         const missionStartTutorial = new MissionStartTutorial('validate', labelType, { nLabels: param.mission.labels_validated }, svv, param.language);

--- a/public/javascripts/SVValidate/src/menu/RightMenu.js
+++ b/public/javascripts/SVValidate/src/menu/RightMenu.js
@@ -135,7 +135,7 @@ function RightMenu(menuUI) {
     }
 
     function resetMenu(label) {
-        tagsAddedByUser = []
+        tagsAddedByUser = [];
         const prevValResult = label.getProperty('validationResult');
         if (prevValResult === undefined) {
             // This is a new label (not returning from an undo), so reset everything.
@@ -271,6 +271,7 @@ function RightMenu(menuUI) {
         $elem.tooltip(({
             placement: 'top',
             html: true,
+            container: 'body',
             delay: { show: 500, hide: 10 },
             title: tooltipHtml
         })).tooltip('show').tooltip('hide');


### PR DESCRIPTION
Fixes #4088

Fixes a bug where the severity buttons were being selected in Expert Validate when double clicking on the 'Yes' button.

It seems that it was an issue with our tooltips... With Bootstrap tooltips, we need to set the container to be the body element of the page, rather than the default. This was missed on Expert Validate, so the click was somehow being sent through the tooltip (I hardly understand how it works tbh, but the fix did work, and it's what we've done on other parts of the site as well).

I made that same change in a few other places in case it were to ever be an issue in the future, and confirmed that those tooltips still work as expected.

