### PR TITLE
Fixes route line not showing on minimap during tutorial

### DIFF
--- a/public/javascripts/SVLabel/css/svl-onboarding.css
+++ b/public/javascripts/SVLabel/css/svl-onboarding.css
@@ -1,9 +1,3 @@
-#tracker-holder {
-    position: absolute;
-    top: 0;
-    left: 935px;
-}
-
 #onboarding-holder {
     visibility: hidden;
 }

--- a/public/javascripts/SVLabel/src/onboarding/Onboarding.js
+++ b/public/javascripts/SVLabel/src/onboarding/Onboarding.js
@@ -98,8 +98,14 @@ function Onboarding(svl, audioEffect, compass, form, handAnimation, navigationSe
      * Sets the mini map to be transparent for everything except for yellow pin.
      */
     function adjustMap() {
-        map.setOptions({styles: [{ featureType: "all", stylers: [{ visibility: "off" }] }]});
         svl.ui.minimap.holder.css('backgroundImage', `url('${svl.rootDirectory}img/onboarding/TutorialMiniMap.jpg')`);
+        // TODO could use cloud-based maps styling for this potentially as well..? Hiding something in dom as workaround.
+        // map.setOptions({styles: [{ featureType: "all", stylers: [{ visibility: "off" }] }]});
+        setTimeout(() => {
+            // TODO extra hacky to set a timeout because the div wasn't ready even though map theoretically loaded.
+            const mapToHide = document.querySelector("#minimap")?.firstChild?.children[2]?.firstChild?.firstChild;
+            mapToHide.style.display = 'none';
+        }, 1000);
     }
 
     /**


### PR DESCRIPTION
Fixes #4107

You can now see the route line visible during the tutorial again.

The issue is that what we're actually doing is setting a background image to a screenshot of what the map would normally look like. We were then setting the map style to be transparent. But we have to use the new cloud-based maps styling (#4098) now, so our styling updates in the code weren't doing anything.

Hopefully we can use the new maps styling methods to make it transparent during the tutorial again, because the fix I have right now is very hacky. I have to search through the nameless div elements in a specific order to find the right element to hide, and the div isn't actually ready even though Google Maps says that the map has loaded, so I have to do a setTimeout...
```
setTimeout(() => {
    const mapToHide = document.querySelector("#minimap")?.firstChild?.children[2]?.firstChild?.firstChild;
    mapToHide.style.display = 'none';
}, 1000);
```

Would love to get rid of this code above in favor of something like what we had before.
```
map.setOptions({styles: [{ featureType: "all", stylers: [{ visibility: "off" }] }]});
```
