### PR TITLE
Fixes tooltips being hidden behind context menu on Explore page

### DIFF
--- a/app/views/apps/explore.scala.html
+++ b/app/views/apps/explore.scala.html
@@ -400,7 +400,7 @@
                                     data-toggle="tooltip" data-placement="top"
                                 />
                             </div>
-                            <div id="context-menu-tag-holder">
+                            <div id="context-menu-tag-holder" class="context-menu-section">
                                 <button class="context-menu-tag" name='tag' id="0"></button>
                                 <button class="context-menu-tag" name='tag' id="1"></button>
                                 <button class="context-menu-tag" name='tag' id="2"></button>
@@ -430,7 +430,7 @@
                                     data-toggle="tooltip" data-placement="top"
                                 />
                             </div>
-                            <div id="severity-radio-holder">
+                            <div id="severity-radio-holder" class="context-menu-section">
                                 <div class="severity-level" id="severity-1" data-toggle="tooltip">
                                     <label>
                                         <input type="radio" name="label-severity" value="1">

--- a/public/javascripts/SVLabel/css/svl-context-menu.css
+++ b/public/javascripts/SVLabel/css/svl-context-menu.css
@@ -9,7 +9,6 @@
     border-radius: 8.1px;
     border: solid 1px lightgray;
     visibility: hidden;
-    z-index: 1050; /* so that tooltips will show up on top of the navbar */
     box-sizing: border-box;
 }
 
@@ -38,12 +37,12 @@
     width: 15px;
 }
 
-.context-menu-header .tooltip {
+.context-menu-tooltip {
     font-size: 10px;
+    z-index: 1050; /* so that tooltips will show up on top of the navbar */
 }
 
 #context-menu-tag-holder {
-    width: 100%;
     margin: 0;
     display: flex;
     flex-direction: row;
@@ -51,7 +50,6 @@
     align-items: center;
     gap: 5px 4px;
     padding: 0;
-    box-sizing: border-box;
     white-space: pre;
 }
 
@@ -92,8 +90,6 @@
 }
 
 #severity-menu {
-    width: 100%;
-    height: auto;
     min-height: fit-content;
     margin-top: 1px;
     display: flex;

--- a/public/javascripts/SVLabel/src/canvas/ContextMenu.js
+++ b/public/javascripts/SVLabel/src/canvas/ContextMenu.js
@@ -107,9 +107,9 @@ function ContextMenu (uiContextMenu) {
     }
 
     function handleSeverityPopup() {
-        var labels = svl.labelContainer.getAllLabels();
+        const labels = svl.labelContainer.getAllLabels();
         if (labels.length > 0) {
-            var lastLabelProps = labels[labels.length - 1].getProperties();
+            const lastLabelProps = labels[labels.length - 1].getProperties();
             // If the label is No Sidewalk or Pedestrian Signal, do not call ratingReminderAlert().
             if (!['NoSidewalk', 'Signal'].includes(lastLabelProps.labelType)) {
                 svl.ratingReminderAlert.ratingClicked(lastLabelProps.severity);
@@ -118,8 +118,8 @@ function ContextMenu (uiContextMenu) {
     }
 
     function _handleSeverityChange(e) {
-        var severity = parseInt($(this).val(), 10);
-        var label = status.targetLabel;
+        const severity = parseInt($(this).val(), 10);
+        const label = status.targetLabel;
         svl.tracker.push('ContextMenu_RadioChange', { LabelType: label.getLabelType(), RadioValue: severity });
 
         self.updateRadioButtonImages();
@@ -406,10 +406,13 @@ function ContextMenu (uiContextMenu) {
                             $tagHolder.find("button[id=" + buttonIndex + "]").tooltip(({
                                 placement: 'top',
                                 html: true,
-                                delay: {"show": 300, "hide": 10},
+                                delay: { 'show': 300, 'hide': 10 },
                                 height: '130',
-                                title: `${tooltipHeader}<br/>${tooltipImage}<br/> <i>${tooltipFooter}</i>`
-                            })).tooltip("show").tooltip("hide");
+                                title: `${tooltipHeader}<br/>${tooltipImage}<br/> <i>${tooltipFooter}</i>`,
+                                container: 'body',
+                                // Add template so we can attach a custom CSS class.
+                                template: '<div class="tooltip context-menu-tooltip" role="tooltip"><div class="tooltip-arrow"></div><div class="tooltip-inner"></div></div>'
+                            })).tooltip('show').tooltip('hide');
                         });
 
                         count += 1;
@@ -442,9 +445,11 @@ function ContextMenu (uiContextMenu) {
                 const tooltipHeader = i18next.t(`common:severity-example-tooltip-${sev}`);
                 const tooltipFooter = `<i>${i18next.t('center-ui.context-menu.severity-shortcuts')}</i>`
                 $(`#severity-${sev}`).tooltip({
-                    placement: "top", html: true, delay: {"show": 300, "hide": 10},
+                    placement: 'top', html: true, delay: { 'show': 300, 'hide': 10 },
                     title: `${tooltipHeader}<br/><img src=${img} height="110"/><br/>${tooltipFooter}`,
-                    container: 'body'
+                    container: 'body',
+                    // Add template so we can attach a custom CSS class.
+                    template: '<div class="tooltip context-menu-tooltip" role="tooltip"><div class="tooltip-arrow"></div><div class="tooltip-inner"></div></div>'
                 });
             });
         }


### PR DESCRIPTION
Fixes #4116 

Fixes an issue where our bootstrap tooltips were being hidden behind the context menu on the Explore page. The font size styling was also being lost there.

##### Before/After screenshots (if applicable)
Before
<img width="672" height="680" alt="Screenshot from 2026-02-19 13-18-58" src="https://github.com/user-attachments/assets/3474db6c-c47a-456a-90fb-910512d6f0b9" />

After
<img width="672" height="680" alt="Screenshot from 2026-02-19 13-51-23" src="https://github.com/user-attachments/assets/c93e0b9d-f502-4eaf-a32e-f721eede781f" />

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
