### PR TITLE
Fixes minimap styling with Google's cloud-based maps styling

### DIFF
--- a/public/javascripts/SVLabel/src/navigation/Minimap.js
+++ b/public/javascripts/SVLabel/src/navigation/Minimap.js
@@ -28,42 +28,14 @@ class Minimap {
             fullscreenControl: false,
             gestureHandling: 'none',
             keyboardShortcuts: false,
-            mapId: 'DEMO_MAP_ID', // TODO use cloud-based map styling, to replace old way to style maps.
+            // Map style is changed via cloud-based maps styling in the Google Cloud Console.
+            mapId: '9c9a85114c815aa4d4dbd5d3',
             mapTypeControl: false,
             mapTypeId: MapTypeId.ROADMAP, // HYBRID is another option
             renderingType: RenderingType.RASTER,
-            // streetViewControl: true,
             zoom: 18
         };
         this.#map = new Map(document.getElementById('minimap'), mapOptions);
-
-        // TODO use cloud-based map styling, to replace old way to style maps.
-        // https://developers.google.com/maps/documentation/javascript/cloud-customization
-        // Styling google map.
-        // http://stackoverflow.com/questions/8406636/how-to-remove-all-from-google-map
-        // http://gmaps-samples-v3.googlecode.com/svn/trunk/styledmaps/wizard/index.html
-        // const mapStyleOptions = [
-        //     {
-        //         featureType: "all",
-        //         stylers: [
-        //             { visibility: "off" }
-        //         ]
-        //     },
-        //     {
-        //         featureType: "road",
-        //         stylers: [
-        //             { visibility: "on" }
-        //         ]
-        //     },
-        //     {
-        //         "elementType": "labels",
-        //         "stylers": [
-        //             { "visibility": "off" }
-        //         ]
-        //     }
-        // ];
-        //
-        // map.setOptions({ styles: mapStyleOptions });
 
         // Add listener to the PanoViewer to update observed area on the minimap when zoom changes.
         svl.panoViewer.addListener('zoom_changed', this.handlerZoomChange);


### PR DESCRIPTION
Resolves #4098 

Moves to Google's new cloud-based maps styling, fixing the styling in the minimap on the Explore page.

Here's what it looks like before the change (nothing is hidden)
<img width="253" height="252" alt="Screenshot from 2026-02-19 15-07-58" src="https://github.com/user-attachments/assets/2004633e-902c-4e60-8595-fea62a6443ce" />

And after the change (note that I hid the traffic signal icons, as I expect them to add too much noise to intersections when we add a bunch of labels to them).
<img width="255" height="250" alt="Screenshot from 2026-02-19 15-16-54" src="https://github.com/user-attachments/assets/7775b92b-628b-4117-8aeb-68b79aafa777" />

One thing I have hidden that we could consider showing is the sidewalks layer. Ultimately I found the visualization of the sidewalks to be more distracting than anything, with the polygons taking some funky shapes. Here's what it looked like in my little example intersection, where it doesn't look too bad (partially because we're adding some more gray on top of the minimap.
<img width="253" height="252" alt="Screenshot from 2026-02-19 15-12-26" src="https://github.com/user-attachments/assets/02d3a27a-f7d5-419c-8952-ee8faa8f4af0" />

But here's one case where it looked weird when I was looking at it in the map editor.
<img width="989" height="720" alt="Screenshot from 2026-02-19 15-14-36" src="https://github.com/user-attachments/assets/0372ca5f-cff9-4536-a02a-0a98f260e551" />

Thankfully we can make updates to the styling without changes to our code anymore, so it's easy to update if we want it!
