### PR TITLE
Adds a tool to /admin/user to update high_quality_manual for a user

### DIFF
--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -392,6 +392,46 @@ class AdminController @Inject() (
     )
   }
 
+  /**
+   * Updates high_quality_manual and high_quality in the database for the given user.
+   */
+  def setUserQualityManual = cc.securityService.SecuredAction(WithAdmin(), parse.json) { implicit request =>
+    val submission = request.body.validate[UserQualitySubmission]
+    submission.fold(
+      errors => { Future.successful(BadRequest(Json.obj("status" -> "Error", "message" -> JsError.toJson(errors)))) },
+      submission => {
+        val userId: String                  = submission.userId
+        val newUserQuality: Option[Boolean] = submission.userQualityManual
+
+        authenticationService.findByUserId(userId) flatMap {
+          case Some(user) =>
+            if (user.role == "Owner") {
+              Future.successful(
+                BadRequest(Json.obj("status" -> "Error", "message" -> "Owner's quality cannot be changed"))
+              )
+            } else if (user.role == "Administrator" && request.identity.role != "Owner") {
+              Future.successful(
+                BadRequest(Json.obj("status" -> "Error", "message" -> "Admin's quality can only be set by an Owner"))
+              )
+            } else {
+              // Update the high_quality_manual and high_quality columns. Recomputes high_quality if input is None.
+              userService
+                .setManualUserQuality(userId, newUserQuality)
+                .map {
+                  case Some(newQuality) =>
+                    val logText = s"UpdateUserManualQuality_User=${userId}_Manual=${newUserQuality}_New=$newQuality"
+                    cc.loggingService.insert(request.identity.userId, request.ipAddress, logText)
+                    Ok(Json.obj("new_user_quality" -> newQuality))
+                  case None => BadRequest(Json.obj("status" -> "Error", "message" -> "Likely an excluded user"))
+                }
+            }
+          case None =>
+            Future.successful(BadRequest(Json.obj("status" -> "Error", "message" -> "No user has this user_id")))
+        }
+      }
+    )
+  }
+
   /* Clears all cached values. Should only be called from the Admin page. */
   def clearPlayCache() = cc.securityService.SecuredAction(WithAdmin()) { implicit request =>
     logger.debug(request.toString) // Added bc scalafmt doesn't like "implicit _" & compiler needs us to use request.

--- a/app/formats/json/AdminFormats.scala
+++ b/app/formats/json/AdminFormats.scala
@@ -13,6 +13,7 @@ import java.time.OffsetDateTime
 
 object AdminFormats {
   case class UserRoleSubmission(userId: String, roleId: String)
+  case class UserQualitySubmission(userId: String, userQualityManual: Option[Boolean])
   case class TaskFlagsByDateSubmission(userId: String, date: OffsetDateTime, flag: String, state: Boolean)
   case class TaskFlagSubmission(auditTaskId: Int, flag: String, state: Boolean) {
     require(flag == "low_quality" || flag == "incomplete" || flag == "stale")
@@ -22,6 +23,11 @@ object AdminFormats {
     (JsPath \ "user_id").read[String] and
       (JsPath \ "role_id").read[String]
   )(UserRoleSubmission.apply _)
+
+  implicit val userQualitySubmissionReads: Reads[UserQualitySubmission] = (
+    (JsPath \ "user_id").read[String] and
+      (JsPath \ "quality").readNullable[Boolean]
+  )(UserQualitySubmission.apply _)
 
   implicit val taskFlagsByDateSubmissionReads: Reads[TaskFlagsByDateSubmission] = (
     (JsPath \ "userId").read[String] and

--- a/app/models/user/UserStatTable.scala
+++ b/app/models/user/UserStatTable.scala
@@ -13,6 +13,7 @@ import play.api.db.slick.{DatabaseConfigProvider, HasDatabaseConfigProvider}
 import service.TimeInterval
 import service.TimeInterval.TimeInterval
 import slick.jdbc.GetResult
+
 import java.time.OffsetDateTime
 import javax.inject._
 import scala.concurrent.ExecutionContext
@@ -179,6 +180,37 @@ class UserStatTable @Inject() (
   }
 
   /**
+   * Updates the high_quality_manual column for the given user.
+   * @param userId The user whose data quality is being set
+   * @param newHighQualityManual The new value for the high_quality_manual column
+   * @return Number of rows updated; should be 1, or 0 if user is excluded or no user is found
+   */
+  def updateHighQualityManual(userId: String, newHighQualityManual: Option[Boolean]): DBIO[Int] = {
+    userStats.filter(u => u.userId === userId && !u.excluded).map(_.highQualityManual).update(newHighQualityManual)
+  }
+
+  /**
+   * Updates the high_quality column for a single user.
+   * @param userId The user whose data quality is being set
+   * @param newHighQuality The new value for the high_quality column
+   * @return Number of rows updated; should be 1, or 0 if user is excluded or no user is found
+   */
+  def updateHighQuality(userId: String, newHighQuality: Boolean): DBIO[Int] = {
+    userStats.filter(u => u.userId === userId && !u.excluded).map(_.highQuality).update(newHighQuality)
+  }
+
+  /**
+   * Update the meters_audited column in the user_stat table for the given user.
+   * @param userId The user whose audited distance is being calculated
+   */
+  def updateAuditedDistance(userId: String): DBIO[Unit] = {
+    val userQuery: Query[Rep[String], String, Seq] = userStats.filter(_.userId === userId).map(_.userId)
+
+    // Computes the audited distance in meters for each user using the audit_task and street_edge tables.
+    updateAuditedDistanceHelper(userQuery)
+  }
+
+  /**
    * Update meters_audited column in the user_stat table for users who have done any auditing since `cutoffTime`.
    */
   def updateAuditedDistance(cutoffTime: OffsetDateTime): DBIO[Unit] = {
@@ -186,6 +218,19 @@ class UserStatTable @Inject() (
     val usersToUpdate: Query[Rep[String], String, Seq] =
       auditMissions.filter(_.missionEnd > cutoffTime).groupBy(_.userId).map(_._1)
 
+    // Computes the audited distance in meters for each user using the audit_task and street_edge tables.
+    updateAuditedDistanceHelper(usersToUpdate)
+  }
+
+  /**
+   * Update the meters_audited column in the user_stat table for users who have done any auditing since `cutoffTime`.
+   */
+
+  /**
+   * Updates the meters_audited column in the user_stat table for the given users.
+   * @param usersToUpdate A query for the users whose audited distance is being calculated
+   */
+  def updateAuditedDistanceHelper(usersToUpdate: Query[Rep[String], String, Seq]): DBIO[Unit] = {
     // Computes the audited distance in meters for each user using the audit_task and street_edge tables.
     auditTaskTable
       .filter(_.completed === true)
@@ -204,17 +249,29 @@ class UserStatTable @Inject() (
         }
         DBIO.sequence(updateActions).map(_ => ())
       }
-      .transactionally
+  }.transactionally
+
+  /**
+   * Update the labels_per_meter column in the user_stat table for the given user.
+   * @param userId The user whose labeling frequency is being calculated
+   */
+  def updateLabelsPerMeter(userId: String): DBIO[Unit] = {
+    val userQuery: Query[Rep[String], String, Seq] = userStats.filter(_.userId === userId).map(_.userId)
+    updateLabelsPerMeterHelper(userQuery)
   }
 
   /**
    * Update labels_per_meter column in the user_stat table for all users who have done any auditing since `cutoffTime`.
    */
   def updateLabelsPerMeter(cutoffTime: OffsetDateTime): DBIO[Unit] = {
+    val usersToUpdate: Query[Rep[String], String, Seq] = usersThatAuditedSinceCutoffTime(cutoffTime)
+    updateLabelsPerMeterHelper(usersToUpdate)
+  }
 
-    // Get the list of users who have done any auditing since the cutoff time.
-    val usersToUpdate = usersThatAuditedSinceCutoffTime(cutoffTime)
-
+  /**
+   * Update labels_per_meter column in the user_stat table for all users who have done any auditing since `cutoffTime`.
+   */
+  def updateLabelsPerMeterHelper(usersToUpdate: Query[Rep[String], String, Seq]): DBIO[Unit] = {
     // Compute label counts for each of those users.
     val labelCounts = (for {
       _mission       <- auditMissions
@@ -229,19 +286,24 @@ class UserStatTable @Inject() (
       .joinLeft(labelCounts)
       .on(_._1.userId === _._1)
       .map { case ((_stat, _userId), _count) =>
-        (_userId, _count.map(_._2).ifNull(0.asColumnOf[Int]).asColumnOf[Float] / _stat.metersAudited)
+        // Calculate labels_per_meter. If no meters audited, just set to NULL.
+        val newLabelsPerMeter = Case
+          .If(_stat.metersAudited > 0f)
+          .Then(_count.map(_._2).ifNull(0.asColumnOf[Int]).asColumnOf[Option[Float]] / _stat.metersAudited)
+          .Else(Option.empty[Float].bind)
+
+        (_userId, newLabelsPerMeter)
       }
       .result
-      .flatMap { labelFreqs: Seq[(String, Float)] =>
+      .flatMap { labelFreqs: Seq[(String, Option[Float])] =>
         // Update the labels_per_meter column in the user_stat table.
         val updateActions = labelFreqs.map { case (userId, labelingFreq) =>
           val updateQuery = for { _userStat <- userStats if _userStat.userId === userId } yield _userStat.labelsPerMeter
-          updateQuery.update(Some(labelingFreq))
+          updateQuery.update(labelingFreq)
         }
         DBIO.sequence(updateActions).map(_ => ())
       }
-      .transactionally
-  }
+  }.transactionally
 
   /**
    * Update the accuracy column in the user_stat table for the given users, or every user if the list is empty.
@@ -281,8 +343,43 @@ class UserStatTable @Inject() (
         }
         DBIO.sequence(updateActions).map(_ => ())
       }
-      .transactionally
-  }
+  }.transactionally
+
+  /**
+   * Update the high_quality column for the given user based on labeling freq and accuracy (or use manual setting).
+   *
+   * Users are considered low quality if they either:
+   * 1. have been manually marked as high_quality_manual = FALSE in the user_stat table,
+   * 2. have a labeling frequency below `LABEL_PER_METER_THRESHOLD`, or
+   * 3. have an accuracy rating below 60% (with at least 50 of their labels validated).
+   *
+   * @param userId The user whose high_quality column should be updated
+   * @return The number of rows updated; should be 1, or 0 if no user is found
+   */
+  def updateUserQuality(userId: String): DBIO[Int] = {
+    // Decide if each user is high quality. Conditions in the method comment. Users manually marked for exclusion or
+    // low quality are filtered out later (using results from the previous query).
+    val userQualQuery: DBIO[Seq[Boolean]] = {
+      userStats
+        .filter(_.userId === userId)
+        .map { x =>
+          !x.excluded &&                              // false if excluded=true
+          x.highQualityManual.getOrElse(true) && (    // false if high_quality_manual=false
+            x.highQualityManual.getOrElse(false) || ( // true if high_quality_manual set to true
+              (x.metersAudited === 0f || x.labelsPerMeter.getOrElse(5f) > LABEL_PER_METER_THRESHOLD)
+                && (x.accuracy.getOrElse(1.0f) > 0.6f.asColumnOf[Float] || x.ownLabelsValidated < 50.asColumnOf[Int])
+            )
+          )
+        }
+        .result
+    }
+    for {
+      newUserQuality <- userQualQuery
+      rowsUpdated    <-
+        if (newUserQuality.nonEmpty) updateHighQuality(userId, newUserQuality.head)
+        else DBIO.successful(0)
+    } yield rowsUpdated
+  }.transactionally
 
   /**
    * Update high_quality col in user_stat table, run after updateAuditedDistance, updateLabelsPerMeter, updateAccuracy.
@@ -318,8 +415,7 @@ class UserStatTable @Inject() (
           )
         }
         .result
-        .transactionally
-    }
+    }.transactionally
 
     // Get the list of users who have done any auditing or have had any of their labels validated since the cutoff time.
     // Will only update these users.

--- a/app/service/AdminService.scala
+++ b/app/service/AdminService.scala
@@ -120,8 +120,7 @@ class AdminServiceImpl @Inject() (
       completedMissions: Seq[RegionalMission] <- missionTable.selectCompletedRegionalMission(userId)
       comments: Seq[AuditTaskComment]         <- auditTaskCommentTable.all(userId)
     } yield {
-      val labelsPerMeter = userStats.flatMap(_.labelsPerMeter)
-      AdminUserProfileData(currRegion, completedAudits, hoursWorked, labelsPerMeter, completedMissions, comments)
+      AdminUserProfileData(currRegion, completedAudits, hoursWorked, userStats.get, completedMissions, comments)
     })
   }
 
@@ -410,18 +409,17 @@ class AdminServiceImpl @Inject() (
 
   /**
    * Calls functions to update all columns in user_stat table. Only updates users who have audited since cutoff time.
+   * @param cutoffTime Only update users who have done any auditing since this cutoff time
+   * @return The number of users whose stats were updated
    */
   def updateUserStatTable(cutoffTime: OffsetDateTime): Future[Int] = {
     db.run(
-      DBIO
-        .seq(
-          userStatTable.updateAuditedDistance(cutoffTime),
-          userStatTable.updateLabelsPerMeter(cutoffTime),
-          userStatTable.updateAccuracy(Seq())
-        )
-        .andThen(
-          userStatTable.updateHighQuality(cutoffTime)
-        )
+      for {
+        _ad         <- userStatTable.updateAuditedDistance(cutoffTime)
+        _lpm        <- userStatTable.updateLabelsPerMeter(cutoffTime)
+        _a          <- userStatTable.updateAccuracy(Seq())
+        rowsUpdated <- userStatTable.updateHighQuality(cutoffTime)
+      } yield rowsUpdated
     )
   }
 }

--- a/app/service/UserService.scala
+++ b/app/service/UserService.scala
@@ -31,7 +31,7 @@ case class AdminUserProfileData(
     currentRegion: Option[Region],
     numCompletedAudits: Int,
     hoursWorked: Float,
-    labelsPerMeter: Option[Float],
+    userStats: UserStat,
     completedMissions: Seq[RegionalMission],
     exploreComments: Seq[AuditTaskComment]
 )
@@ -42,6 +42,14 @@ trait UserService {
   def getDistanceAudited(userId: String): Future[Float]
   def countLabelsFromUser(userId: String): Future[Int]
   def getUserAccuracy(userId: String): Future[Option[Float]]
+
+  /**
+   * Updates the high_quality_manual column for the given user. If None, recalculates stats and updates high_quality.
+   * @param userId The user whose stats should be updated
+   * @param highQualityManual The new value to set in the high_quality_manual column
+   * @return The user's new value in the high_quality column; None if user marked excluded or no user found
+   */
+  def setManualUserQuality(userId: String, highQualityManual: Option[Boolean]): Future[Option[Boolean]]
   def getUserTeam(userId: String): Future[Option[Team]]
   def setUserTeam(userId: String, newTeamId: Int): Future[Int]
   def getAllTeams: Future[Seq[Team]]
@@ -97,6 +105,38 @@ class UserServiceImpl @Inject() (
       }
       UserProfileData(userId, userTeam, teams, missionCount, auditedDistance, labelCount, valCount, accuracy)
     })
+  }
+
+  def setManualUserQuality(userId: String, highQualityManual: Option[Boolean]): Future[Option[Boolean]] = {
+    db.run(for {
+      hqmRowsUpdated <- userStatTable.updateHighQualityManual(userId, highQualityManual)
+
+      // If high_quality_manual set to None, recalculate stats to update high_quality column.
+      hqRowsUpdated <- {
+        if (highQualityManual.isDefined) userStatTable.updateHighQuality(userId, highQualityManual.get)
+        else updateStatsForUser(userId)
+      }
+
+      // If rows weren't actually updated, return None, otherwise return the user's new high_quality value.
+      currUserStats <- {
+        if (hqmRowsUpdated > 0 && hqRowsUpdated > 0) userStatTable.getStatsFromUserId(userId)
+        else DBIO.successful(None)
+      }
+    } yield currUserStats.map(_.highQuality))
+  }
+
+  /**
+   * Calls functions to update all columns in user_stat table for the given user.
+   * @param userId The user whose stats should be updated
+   * @return The number of users whose stats were updated; should be 1, or 0 if user marked excluded or no user found
+   */
+  private def updateStatsForUser(userId: String): DBIO[Int] = {
+    for {
+      _           <- userStatTable.updateAuditedDistance(userId)
+      _           <- userStatTable.updateLabelsPerMeter(userId)
+      _           <- userStatTable.updateAccuracy(Seq(userId))
+      rowsUpdated <- userStatTable.updateUserQuality(userId)
+    } yield rowsUpdated
   }
 
   def getDistanceAudited(userId: String): Future[Float] = db.run(auditTaskTable.getDistanceAudited(userId))

--- a/app/views/userProfile.scala.html
+++ b/app/views/userProfile.scala.html
@@ -250,12 +250,28 @@
                             <th class="col-md">Username</th>
                             <th class="col-md">User Id</th>
                             <th class="col-md">Email</th>
+                            <th class="col-md">High quality</th>
+                            <th class="col-md">High quality manual</th>
                             <th class="col-md">Volunteer</th>
                         </tr>
                         <tr>
                             <td>@profileUser.username</td>
                             <td>@profileUser.userId</td>
                             <td>@profileUser.email</td>
+                            <td id="stat-high-quality">@adminData.get.userStats.highQuality</td>
+                            <td>
+                                <div id="user-quality-dropdown" class="dropdown">
+                                    <button class="btn btn-default dropdown-toggle" type="button" id="user-quality-button" data-toggle="dropdown">
+                                        @adminData.get.userStats.highQualityManual.map(_.toString).getOrElse("Not set")
+                                        <span class="caret"></span>
+                                    </button>
+                                    <ul class="dropdown-menu" role="menu" aria-labelledby="user-quality-button">
+                                        <li><a href="#!" class="change-role">true</a></li>
+                                        <li><a href="#!" class="change-role">false</a></li>
+                                        <li><a href="#!" class="change-role">Not set</a></li>
+                                    </ul>
+                                </div>
+                            </td>
                             <td><input type="checkbox" id="check-volunteer"></td>
                         </tr>
                     </table>
@@ -278,7 +294,7 @@
                             </td>
                             <td>@adminData.get.numCompletedAudits</td>
                             <td>@{"%.2f".format(adminData.get.hoursWorked)} hours</td>
-                            <td>@{adminData.get.labelsPerMeter.map(f => "%.2f labels per km".format(f * 1000)).getOrElse("NA")}</td>
+                            <td>@{adminData.get.userStats.labelsPerMeter.map(f => "%.2f labels per km".format(f * 1000)).getOrElse("NA")}</td>
                         </tr>
                     </table>
                 </div>

--- a/conf/routes
+++ b/conf/routes
@@ -78,6 +78,7 @@ GET     /adminapi/getRecentLabelMetadata                controllers.AdminControl
 GET     /adminapi/getUserStats                          controllers.AdminController.getUserStats
 
 PUT     /adminapi/setRole                               controllers.AdminController.setUserRole
+PUT     /adminapi/setUserQualityManual                  controllers.AdminController.setUserQualityManual
 PUT     /adminapi/setTaskFlagsBeforeDate                controllers.AdminController.setTaskFlagsBeforeDate()
 PUT     /adminapi/setTaskFlag                           controllers.AdminController.setTaskFlag()
 PUT     /adminapi/updateTeamStatus/:teamId              controllers.AdminController.updateTeamStatus(teamId: Int)

--- a/public/javascripts/Admin/src/Admin.User.js
+++ b/public/javascripts/Admin/src/Admin.User.js
@@ -8,6 +8,42 @@ function AdminUser(username, userId, serviceHoursUser) {
     }).datepicker('update', d);
 
     /**
+     * Used to send a request to update a user's high_quality_manual column in the database through a dropdown click.
+     * @param {Event} e
+     * @returns {Promise<void>}
+     */
+    async function updateUserQuality(e) {
+        const choice = e.target.innerText;
+        const data = {
+            'user_id': userId,
+            'quality': choice === 'true' ? true : (choice === 'false' ? false : null)
+        };
+        return fetch('/adminapi/setUserQualityManual', {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(data),
+        })
+            .then((response) => response.json())
+            .then(result => {
+                // Owners and 'excluded' users can't have their quality set, so back end might give an error.
+                if (result.status === 'Error') throw(result.message);
+
+                // Change the adjacent 'High quality' column to the correct value.
+                $('#stat-high-quality').text(result.new_user_quality);
+
+                // Change dropdown button to reflect new quality selection.
+                const button = $('#user-quality-button')[0];
+                button.childNodes[0].nodeValue = ` ${choice} `;
+            })
+            .catch(error => {
+                console.error(error);
+                alert('Error updating user quality: ' + error);
+                return undefined;
+            });
+    }
+    $('#user-quality-dropdown').on('click', 'a', updateUserQuality);
+
+    /**
      * Perform an AJAX call (PUT request) to modify all of a specified flag for the user before a specified date.
      * @param date
      * @param flag One of "low_quality", "incomplete", or "stale".
@@ -81,7 +117,7 @@ function AdminUser(username, userId, serviceHoursUser) {
 
     // Updates user's volunteer status when the checkbox is clicked.
     $("#check-volunteer").click(function() {
-        var isChecked = $(this).is(":checked");
+        const isChecked = $(this).is(":checked");
         updateVolunteerStatus(isChecked);
     });
 

--- a/public/stylesheets/admin.css
+++ b/public/stylesheets/admin.css
@@ -147,3 +147,7 @@
     max-height: 700px;
     overflow-y: auto;
 }
+
+#user-quality-button {
+    margin-top: unset; /* Remove default styling from main.css since this isn't in a table. */
+}


### PR DESCRIPTION
Resolves #4122

Adds a drop down menu to /admin/user/\<username\> that allows admins to manually set a user's quality. Some notes on the feature
1. You can change it back to "Not set" and it reset the `high_quality` field based on the user's labeling frequency and accuracy as usual
2. Admins can't set this for other admins

##### Before/After screenshots (if applicable)
Before
<img width="887" height="283" alt="image" src="https://github.com/user-attachments/assets/02f6255f-a14e-49e6-ac43-2b379e0963e9" />

After
<img width="887" height="283" alt="Screenshot from 2026-02-23 16-30-22" src="https://github.com/user-attachments/assets/08293d75-34d5-4007-a060-f01740a973d4" />

Then if you choose "true" from the drop down
<img width="887" height="283" alt="Screenshot from 2026-02-23 16-30-35" src="https://github.com/user-attachments/assets/d50f187d-ab26-458b-a742-0c03c172db22" />

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
- [x] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure the documentation on [this wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Descriptions-of-Logged-Events) is up to date for the logs you added/updated.
