### PR TITLE
Fixes tooltip never closing on Expert Validate

### DIFF
--- a/public/javascripts/SVValidate/src/menu/DesktopValidationMenu.js
+++ b/public/javascripts/SVValidate/src/menu/DesktopValidationMenu.js
@@ -315,14 +315,16 @@ function DesktopValidationMenu(menuUI) {
     }
 
     function _removeTagListener(e, label) {
-        let allTagOptions = structuredClone(svv.tagsByLabelType[label.getAuditProperty('labelType')]);
-        let tagIdToRemove = $(e.target).parents('.current-tag').data('tag-id');
-        let tagToRemove = allTagOptions.find(t => t.tag_id === tagIdToRemove).tag_name;
+        const allTagOptions = structuredClone(svv.tagsByLabelType[label.getAuditProperty('labelType')]);
+        const tagElem = $(e.target).parents('.current-tag');
+        tagElem.tooltip('destroy');
+        const tagIdToRemove = tagElem.data('tag-id');
+        const tagToRemove = allTagOptions.find(t => t.tag_id === tagIdToRemove).tag_name;
         _removeTag(tagToRemove, label, false);
     }
 
     function _renderTags() {
-        let label = svv.labelContainer.getCurrentLabel();
+        const label = svv.labelContainer.getCurrentLabel();
         let allTagOptions = structuredClone(svv.tagsByLabelType[label.getAuditProperty('labelType')]);
         const allTagOptionsPermanent = structuredClone(allTagOptions);
 


### PR DESCRIPTION
Fixes #4127

Fixes an issue where tooltips would never close when you removed a tag on Expert Validate. The tag element was being removed before the tooltip had a chance to be removed on it's own. We're now manually removing the tooltip before removing the tag!