### PR TITLE
Fixes some minimap text showing on top of context menu

### DIFF
--- a/public/javascripts/SVLabel/css/svl-context-menu.css
+++ b/public/javascripts/SVLabel/css/svl-context-menu.css
@@ -1,6 +1,6 @@
 #context-menu-holder {
     position: absolute;
-    z-index: 1;
+    z-index: 2;
     display: flex;
     flex-direction: column;
     align-items: flex-start;


### PR DESCRIPTION
Fixes #4126 

Fixes a z-index issue where text on the minimap would show up on top of the context menu.

##### Before/After screenshots (if applicable)
Before
<img width="676" height="414" alt="Screenshot from 2026-02-24 12-22-40" src="https://github.com/user-attachments/assets/62978300-4bbc-4c80-b99b-64414dfd93c9" />

After
<img width="676" height="414" alt="Screenshot from 2026-02-24 12-23-53" src="https://github.com/user-attachments/assets/27c650bb-8f16-4e79-9d14-439b7565b097" />

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've included before/after screenshots above.