### PR TITLE
Fixes fog of war not updating correctly on Explore minimap

### DIFF
--- a/public/javascripts/SVLabel/src/navigation/ObservedArea.js
+++ b/public/javascripts/SVLabel/src/navigation/ObservedArea.js
@@ -83,17 +83,36 @@ function ObservedArea(uiMinimap) {
     }
 
     /**
+     * Converts a latitude and longitude to pixel xy-coordinates.
+     * @param {{lat: number, lng: number}} latLng
+     * @returns {{x: number, y: number}}
+     */
+    function latLngToPixel(latLng) {
+        const projection = svl.minimap.getMap().getProjection();
+        const bounds = svl.minimap.getMap().getBounds();
+        const topRight = projection.fromLatLngToPoint(bounds.getNorthEast());
+        const bottomLeft = projection.fromLatLngToPoint(bounds.getSouthWest());
+        const scale = Math.pow(2, svl.minimap.getMap().getZoom());
+        const worldPoint = projection.fromLatLngToPoint(latLng);
+        return {
+            x: Math.floor((worldPoint.x - bottomLeft.x) * scale),
+            y: Math.floor((worldPoint.y - topRight.y) * scale)
+        };
+    }
+
+    /**
      * Renders the fog of war.
      */
     function renderFogOfWar() {
         fogOfWarCtx.fillRect(0, 0, width, height);
         fogOfWarCtx.globalCompositeOperation = 'destination-out';
         for (const observedArea of observedAreas) {
+            const center = latLngToPixel(observedArea.latLng);
             fogOfWarCtx.beginPath();
             if (observedArea.maxAngle - observedArea.minAngle < 360) {
-                fogOfWarCtx.moveTo(width / 2, height / 2);
+                fogOfWarCtx.moveTo(center.x, center.y);
             }
-            fogOfWarCtx.arc(width / 2, height / 2, radius,
+            fogOfWarCtx.arc(center.x, center.y, radius,
                 toRadians(observedArea.minAngle - 90), toRadians(observedArea.maxAngle - 90));
                 fogOfWarCtx.fill();
         }

--- a/public/javascripts/SVLabel/src/navigation/Peg.js
+++ b/public/javascripts/SVLabel/src/navigation/Peg.js
@@ -78,7 +78,6 @@ class Peg {
      */
     setLocation(location) {
         this.marker.position = new this.LatLng(location.lat, location.lng);
-        this.marker.position = this.marker.map.getCenter();
     }
 
     /**


### PR DESCRIPTION
Fixes #4150

Fixes the fog of war visualization on the Explore page minimap. It wasn't updating correctly when you moved between panos.

You can see in the "before" screenshot below, that even though I had moved multiple times, the fog of war viz made it look like I hadn't moved at all. Whereas in the "after" pic you can see the history of where you had looked before moving.

##### Before/After screenshots (if applicable)
Before
<img width="222" height="220" alt="image" src="https://github.com/user-attachments/assets/296586bf-c0ea-4170-9c67-d7727bde943c" />

After
<img width="222" height="220" alt="image" src="https://github.com/user-attachments/assets/f527abb6-6cb0-4f31-9dd0-3bee32761764" />


##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
