### PR TITLE
Fixes Explore page refreshing near end of street

### DIFF
--- a/app/formats/json/ExploreFormats.scala
+++ b/app/formats/json/ExploreFormats.scala
@@ -54,7 +54,6 @@ object ExploreFormats {
   case class LabelSubmission(
       panoId: String,
       panoSource: PanoSource,
-      auditTaskId: Int,
       labelType: String,
       deleted: Boolean,
       severity: Option[Int],
@@ -251,7 +250,6 @@ object ExploreFormats {
   implicit val labelSubmissionReads: Reads[LabelSubmission] = (
     (JsPath \ "pano_id").read[String] and
       (JsPath \ "pano_source").read[PanoSource.Value] and
-      (JsPath \ "audit_task_id").read[Int] and
       (JsPath \ "label_type").read[String] and
       (JsPath \ "deleted").read[Boolean] and
       (JsPath \ "severity").readNullable[Int] and

--- a/app/service/ExploreService.scala
+++ b/app/service/ExploreService.scala
@@ -570,7 +570,6 @@ class ExploreServiceImpl @Inject() (
           labelSubmission: LabelSubmission = LabelSubmission(
             panoId = pano.panoId,
             panoSource = pano.source,
-            auditTaskId = auditTaskId,
             labelType = data.labelType,
             deleted = false,
             temporaryLabelId = tempLabelId,

--- a/public/javascripts/SVLabel/src/data/Form.js
+++ b/public/javascripts/SVLabel/src/data/Form.js
@@ -85,21 +85,18 @@ function Form (labelContainer, missionModel, missionContainer, panoStore, taskCo
             let prop = label.getProperties();
             const labelLatLng = label.toLatLng();
             const tempLabelId = label.getProperty('temporaryLabelId');
-            const auditTaskId = label.getProperty('auditTaskId');
             const panoData = panoStore.getPanoData(prop.panoId);
 
             // If this label is a new label, get the timestamp of its creation from the corresponding interaction.
             const associatedInteraction = data.interactions.find(interaction =>
                 interaction.action === 'LabelingCanvas_FinishLabeling'
-                && interaction.temporary_label_id === tempLabelId
-                && interaction.audit_task_id === auditTaskId);
+                && interaction.temporary_label_id === tempLabelId);
             const timeCreated = associatedInteraction ? associatedInteraction.timestamp : null;
 
             let temp = {
                 deleted : label.isDeleted(),
                 label_type : label.getLabelType(),
                 temporary_label_id: tempLabelId,
-                audit_task_id: auditTaskId,
                 pano_id: prop.panoId,
                 pano_source: panoData.getProperty('source'),
                 severity: label.getProperty('severity'),


### PR DESCRIPTION
Fixes #4149 

Fixes a bug where the Explore page would refresh when you placed a label and then moved close to the end of a street segment.

Getting to the end of a street segment would trigger a process to prepare the next street to audit, and it can cause us to try to send a label to the back end with a null `audit_task_id`. But it turns out that we don't even use the `audit_task_id` that was associated with the label on the back end anyway, so it's safe to just remove that from being a required field in the POST request. 

Easy enough fix!
