### PR TITLE
Adds tag counts to /v3/api/labelClusters API

### DIFF
--- a/app/controllers/helper/ShapefilesCreatorHelper.scala
+++ b/app/controllers/helper/ShapefilesCreatorHelper.scala
@@ -368,7 +368,8 @@ class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: M
       + "nDisagree:Integer,"      // Disagree count
       + "nUnsure:Integer,"        // Unsure count
       + "clusterSze:Integer,"     // Cluster size
-      + "userIds:String"          // User IDs
+      + "userIds:String,"         // User IDs
+      + "tagCounts:String"        // Tag counts as JSON
     )
 
     val geometryFactory: GeometryFactory = JTSFactoryFinder.getGeometryFactory
@@ -391,7 +392,8 @@ class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: M
       featureBuilder.add(cluster.disagreeCount)
       featureBuilder.add(cluster.unsureCount)
       featureBuilder.add(cluster.clusterSize)
-      featureBuilder.add(cluster.userIds.mkString("[", ",", "]"))
+      featureBuilder.add(Json.stringify(Json.toJson(cluster.userIds)))
+      featureBuilder.add(Json.stringify(Json.toJson(cluster.tagCounts)))
 
       featureBuilder.buildFeature(null)
     }
@@ -741,6 +743,7 @@ class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: M
       + "unsure_count:Integer,"    // Unsure count
       + "cluster_size:Integer,"    // Cluster size
       + "user_ids:String,"         // User IDs as JSON array string
+      + "tag_counts:String,"       // Tag counts as JSON object string
       + "labels:String"            // Raw labels (if included) as JSON string
     )
 
@@ -763,10 +766,8 @@ class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: M
       featureBuilder.add(cluster.disagreeCount)
       featureBuilder.add(cluster.unsureCount)
       featureBuilder.add(cluster.clusterSize)
-
-      // Format user IDs as a JSON array string.
-      val userIdsStr = cluster.userIds.map(id => s""""$id"""").mkString(",")
-      featureBuilder.add(s"[$userIdsStr]")
+      featureBuilder.add(Json.stringify(Json.toJson(cluster.userIds)))
+      featureBuilder.add(Json.stringify(Json.toJson(cluster.tagCounts)))
 
       // Add raw labels if they exist, formatted as JSON string.
       val labelsStr = cluster.labels match {

--- a/app/models/api/LabelClustersApiModels.scala
+++ b/app/models/api/LabelClustersApiModels.scala
@@ -89,6 +89,7 @@ object RawLabelInClusterDataForApi {
  * @param unsureCount Total number of users who were unsure about labels in this cluster
  * @param clusterSize Number of labels in this cluster
  * @param userIds List of user IDs who contributed labels to this cluster
+ * @param tagCounts Map of tag names to the number of labels in the cluster with that tag
  * @param labels Optional list of raw labels in this cluster (only included if requested)
  * @param avgLatitude The geographic latitude coordinate of the cluster center (centroid)
  * @param avgLongitude The geographic longitude coordinate of the cluster center (centroid)
@@ -108,6 +109,7 @@ case class LabelClusterForApi(
     unsureCount: Int,
     clusterSize: Int,
     userIds: Seq[String],
+    tagCounts: Map[String, Int],
     labels: Option[Seq[RawLabelInClusterDataForApi]],
     avgLatitude: Double,
     avgLongitude: Double
@@ -137,7 +139,8 @@ case class LabelClusterForApi(
       "disagree_count"         -> disagreeCount,
       "unsure_count"           -> unsureCount,
       "cluster_size"           -> clusterSize,
-      "users"                  -> userIds
+      "users"                  -> userIds,
+      "tag_counts"             -> tagCounts
     )
 
     // Add labels to properties if they exist.
@@ -173,6 +176,7 @@ case class LabelClusterForApi(
       unsureCount.toString,
       clusterSize.toString,
       escapeCsvField(userIds.mkString("[", ",", "]")),
+      escapeCsvField(Json.stringify(Json.toJson(tagCounts))),
       // We don't include the raw labels in CSV format as it would be too complex.
       avgLatitude.toString,
       avgLongitude.toString
@@ -192,5 +196,5 @@ object LabelClusterForApi {
    */
   val csvHeader: String = "label_cluster_id,label_type,street_edge_id,osm_way_id,region_id,region_name," +
     "avg_image_capture_date,avg_label_date,median_severity,agree_count,disagree_count,unsure_count,cluster_size," +
-    "users,avg_latitude,avg_longitude\n"
+    "users,tag_counts,avg_latitude,avg_longitude\n"
 }

--- a/app/models/cluster/ClusterTable.scala
+++ b/app/models/cluster/ClusterTable.scala
@@ -150,6 +150,10 @@ class ClusterTable @Inject() (protected val dbConfigProvider: DatabaseConfigProv
     val avgLatitude  = r.nextDouble()
     val avgLongitude = r.nextDouble()
 
+    // Parse tag counts JSON object into a Map (e.g., {"narrow": 2} -> Map("narrow" -> 2)).
+    val tagCounts =
+      r.nextStringOption().map { tagCountsJson => Json.parse(tagCountsJson).as[Map[String, Int]] }.getOrElse(Map.empty)
+
     // Parse labels if included (only when includeRawLabels=true).
     val labels = if (r.hasMoreColumns) {
       r.nextStringOption().map { labelsJson =>
@@ -165,7 +169,7 @@ class ClusterTable @Inject() (protected val dbConfigProvider: DatabaseConfigProv
       regionId = regionId, regionName = regionName, avgImageCaptureDate = avgImageCaptureDate,
       avgLabelDate = avgLabelDate, medianSeverity = medianSeverity, agreeCount = agreeCount,
       disagreeCount = disagreeCount, unsureCount = unsureCount, clusterSize = clusterSize, userIds = userIds,
-      labels = labels, avgLatitude = avgLatitude, avgLongitude = avgLongitude
+      tagCounts = tagCounts, labels = labels, avgLatitude = avgLatitude, avgLongitude = avgLongitude
     )
   }
 
@@ -317,6 +321,21 @@ class ClusterTable @Inject() (protected val dbConfigProvider: DatabaseConfigProv
         |INNER JOIN label ON cluster_label.label_id = label.label_id
         |GROUP BY cluster.cluster_id""".stripMargin
 
+    // Aggregate tag counts for each cluster as a JSON object (e.g., {"missing tactile warning": 2, "narrow": 1}).
+    // Tags are stored as a TEXT[] array on the label table; unnest to count occurrences across labels in each cluster.
+    val tagCounts =
+      """SELECT cluster.cluster_id AS cluster_id,
+        |       COALESCE(jsonb_object_agg(tag_counts.tag, tag_counts.cnt) FILTER (WHERE tag_counts.tag IS NOT NULL), '{}') AS tag_counts
+        |FROM cluster
+        |LEFT JOIN (
+        |    SELECT cluster_label.cluster_id, t.tag, COUNT(*) AS cnt
+        |    FROM cluster_label
+        |    INNER JOIN label ON cluster_label.label_id = label.label_id
+        |    CROSS JOIN LATERAL unnest(label.tags) AS t(tag)
+        |    GROUP BY cluster_label.cluster_id, t.tag
+        |) tag_counts ON cluster.cluster_id = tag_counts.cluster_id
+        |GROUP BY cluster.cluster_id""".stripMargin
+
     // Select the average image date and number of images for each cluster.
     val imageCaptureDatesAndUserIds =
       """SELECT capture_dates.cluster_id AS cluster_id,
@@ -352,7 +371,8 @@ class ClusterTable @Inject() (protected val dbConfigProvider: DatabaseConfigProv
           validation_counts.label_count AS cluster_size,
           image_capture_dates.users_list,
           ST_Y(cluster.geom) AS lat,
-          ST_X(cluster.geom) AS lng
+          ST_X(cluster.geom) AS lng,
+          cluster_tag_counts.tag_counts
     FROM cluster
     INNER JOIN label_type ON cluster.label_type_id = label_type.label_type_id
     INNER JOIN street_edge ON cluster.street_edge_id = street_edge.street_edge_id
@@ -361,6 +381,7 @@ class ClusterTable @Inject() (protected val dbConfigProvider: DatabaseConfigProv
     INNER JOIN osm_way_street_edge ON cluster.street_edge_id = osm_way_street_edge.street_edge_id
     INNER JOIN (${validationCounts}) validation_counts ON cluster.cluster_id = validation_counts.cluster_id
     INNER JOIN (${imageCaptureDatesAndUserIds}) image_capture_dates ON cluster.cluster_id = image_capture_dates.cluster_id
+    INNER JOIN (${tagCounts}) cluster_tag_counts ON cluster.cluster_id = cluster_tag_counts.cluster_id
     WHERE ${whereClause}
     ORDER BY cluster.cluster_id
     """
@@ -406,7 +427,8 @@ class ClusterTable @Inject() (protected val dbConfigProvider: DatabaseConfigProv
             base_query.cluster_size,
             base_query.users_list,
             base_query.lat,
-            base_query.lng
+            base_query.lng,
+            base_query.tag_counts
       """
     }
 

--- a/app/views/apiDocs/labelClusters.scala.html
+++ b/app/views/apiDocs/labelClusters.scala.html
@@ -245,6 +245,10 @@
                     "18b26a38-24ab-402d-a64e-158fc0bb8a8a",
                     "53ad4d79-9a7b-4d3c-a753-63bbfca34c9b"
                 ],
+                "tag_counts": {
+                    "points into street": 2,
+                    "missing tactile warning": 1
+                },
                 "labels": [
                     {
                         "label_id": 8,
@@ -296,6 +300,7 @@
                     "be481045-4448-42ae-bbac-3455ce914202",
                     "549187e0-82c9-4014-a48d-31f18083d575"
                 ],
+                "tag_counts": {},
                 "labels": [
                     ...
                 ]
@@ -403,6 +408,13 @@
                         <td>Array of anonymized user identifiers (UUIDs) of the users who contributed labels to this cluster.</td>
                     </tr>
 
+                        <!-- Tag Counts -->
+                    <tr>
+                        <td><code>properties.tag_counts</code></td>
+                        <td><code>object</code></td>
+                        <td>A JSON object mapping tag names to the number of labels in the cluster with that tag. For example, <code>{"missing tactile warning": 2, "narrow": 1}</code> means two labels were tagged "missing tactile warning" and one was tagged "narrow". Empty object (<code>{}</code>) if no labels in the cluster have tags. See the <a href="@routes.ApiDocsController.labelTags">Label Tags API</a> for the full list of available tags.</td>
+                    </tr>
+
                         <!-- Raw Labels (optional) -->
                     <tr>
                         <td><code>properties.labels</code></td>
@@ -415,9 +427,9 @@
 
         <h4 id="response-csv">CSV Format <a href="#response-csv" class="permalink">#</a></h4>
         <p>If <code>filetype=csv</code> is specified, the response body will be CSV data. The first row contains the headers, corresponding to the fields in the GeoJSON properties object, plus <code>avg_latitude</code> and <code>avg_longitude</code> columns derived from the geometry. CRS is WGS84 (EPSG:4326).</p>
-        <pre tabindex="0"><code class="language-csv">label_cluster_id,label_type,street_edge_id,osm_way_id,region_id,region_name,avg_image_capture_date,avg_label_date,median_severity,agree_count,disagree_count,unsure_count,cluster_size,users,avg_latitude,avg_longitude
-124,CurbRamp,951,11584845,8,Teaneck Community Charter School,2012-08-15T00:00:00Z,2023-06-20T14:32:45Z,1,18,2,0,5,"[18b26a38-24ab-402d-a64e-158fc0bb8a8a,53ad4d79-9a7b-4d3c-a753-63bbfca34c9b]",40.8839912414551,-74.0243606567383
-125,NoCurbRamp,952,11566031,8,Teaneck Community Charter School,2012-08-15T00:00:00Z,2023-06-22T11:12:24Z,3,9,0,1,3,"[8af92eb8-fb84-4aa6-9539-abc95216dcd7,be481045-4448-42ae-bbac-3455ce914202,549187e0-82c9-4014-a48d-31f18083d575]",40.8839416503906,-74.0243835449219
+        <pre tabindex="0"><code class="language-csv">label_cluster_id,label_type,street_edge_id,osm_way_id,region_id,region_name,avg_image_capture_date,avg_label_date,median_severity,agree_count,disagree_count,unsure_count,cluster_size,users,tag_counts,avg_latitude,avg_longitude
+124,CurbRamp,951,11584845,8,Teaneck Community Charter School,2012-08-15T00:00:00Z,2023-06-20T14:32:45Z,1,18,2,0,5,"[18b26a38-24ab-402d-a64e-158fc0bb8a8a,53ad4d79-9a7b-4d3c-a753-63bbfca34c9b]","{""points into street"":2,""missing tactile warning"":1}",40.8839912414551,-74.0243606567383
+125,NoCurbRamp,952,11566031,8,Teaneck Community Charter School,2012-08-15T00:00:00Z,2023-06-22T11:12:24Z,3,9,0,1,3,"[8af92eb8-fb84-4aa6-9539-abc95216dcd7,be481045-4448-42ae-bbac-3455ce914202,549187e0-82c9-4014-a48d-31f18083d575]","{}",40.8839416503906,-74.0243835449219
 ...</code></pre>
 
         <p>Note: The <code>labels</code> array is not included in the CSV output even when <code>includeRawLabels=true</code> is specified, as the nested data structure is not suitable for the CSV format.</p>


### PR DESCRIPTION
Resolves #4131

Adds tag counts in JSON format to the /v3/api/labelClusters API. The JSON format is used for all output file types (GeoJSON, CSV, Shapefile, and GeoPackage).

##### Before/After screenshots (if applicable)
Before
<img width="466" height="409" alt="image" src="https://github.com/user-attachments/assets/ff458ca4-1850-41e2-88c0-fabd1c94abf1" />

After
<img width="466" height="516" alt="image" src="https://github.com/user-attachments/assets/527e2269-ff48-419a-90ab-fe219f1d5c48" />

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
