### PR TITLE
Improvements to Label Clusters API when using includeRawLabels=true

### DIFF
--- a/app/controllers/api/BaseApiController.scala
+++ b/app/controllers/api/BaseApiController.scala
@@ -12,9 +12,10 @@ import play.api.http.ContentTypes
 import play.api.libs.json.Json
 import play.api.mvc.Result
 
-import java.io.BufferedInputStream
+import java.io.{BufferedInputStream, File}
 import java.nio.file.{Files, Path}
 import java.time.OffsetDateTime
+import java.util.zip.{ZipEntry, ZipOutputStream}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.math._
 
@@ -114,6 +115,36 @@ abstract class BaseApiController(cc: CustomControllerComponents)(implicit ec: Ex
       Ok.chunked(csvSource, inline.getOrElse(false), Some(filename))
         .as("text/csv")
         .withHeaders(CONTENT_DISPOSITION -> s"attachment; filename=$filename")
+    )
+  }
+
+  /**
+   * Zips multiple CSV files together and streams the resulting ZIP archive as a response.
+   *
+   * @param files A sequence of (file path, entry name) pairs for each CSV file to include in the ZIP.
+   * @param baseFileName The base name for the ZIP file (without extension).
+   * @return A Result containing the zipped CSV files as a downloadable response.
+   */
+  protected def zipAndStreamCsvFiles(files: Seq[(Path, String)], baseFileName: String): Future[Result] = {
+    val zipPath = new File(s"$baseFileName.zip").toPath
+    val zipOut  = new ZipOutputStream(Files.newOutputStream(zipPath))
+
+    files.foreach { case (filePath, entryName) =>
+      zipOut.putNextEntry(new ZipEntry(entryName))
+      Files.copy(filePath, zipOut)
+      zipOut.closeEntry()
+      Files.deleteIfExists(filePath)
+    }
+    zipOut.close()
+
+    val zipSource = StreamConverters
+      .fromInputStream(() => new BufferedInputStream(Files.newInputStream(zipPath)))
+      .mapMaterializedValue(_.map { _ => Files.deleteIfExists(zipPath) })
+
+    Future.successful(
+      Ok.chunked(zipSource)
+        .as("application/zip")
+        .withHeaders(CONTENT_DISPOSITION -> s"attachment; filename=$baseFileName.zip")
     )
   }
 

--- a/app/controllers/api/LabelClustersApiController.scala
+++ b/app/controllers/api/LabelClustersApiController.scala
@@ -5,6 +5,7 @@ import controllers.helper.ShapefilesCreatorHelper
 import models.api.{ApiError, LabelClusterFiltersForApi, LabelClusterForApi}
 import models.utils.LatLngBBox
 import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko.util.ByteString
 import play.api.i18n.Lang.logger
 import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent}
@@ -172,6 +173,19 @@ class LabelClustersApiController @Inject() (
             filetype match {
               case Some("csv") =>
                 outputCSV(dbDataStream, LabelClusterForApi.csvHeader, inline, baseFileName + ".csv")
+              case Some("shapefile") if filters.includeRawLabels =>
+                // When raw labels are included, create both clusters and labels shapefiles in the ZIP.
+                shapefileCreator
+                  .createLabelClusterShapefileWithLabels(dbDataStream, baseFileName, DEFAULT_BATCH_SIZE)
+                  .map {
+                    case Some(p) =>
+                      val zipSrc: Source[ByteString, Future[Boolean]] = shapefileCreator.zipShapefile(p, baseFileName)
+                      Ok.chunked(zipSrc)
+                        .as("application/zip")
+                        .withHeaders(CONTENT_DISPOSITION -> s"attachment; filename=$baseFileName.zip")
+                    case None =>
+                      InternalServerError("Failed to create shapefile")
+                  }
               case Some("shapefile") =>
                 outputShapefile(
                   dbDataStream,

--- a/app/controllers/api/LabelClustersApiController.scala
+++ b/app/controllers/api/LabelClustersApiController.scala
@@ -2,8 +2,9 @@ package controllers.api
 
 import controllers.base.CustomControllerComponents
 import controllers.helper.ShapefilesCreatorHelper
-import models.api.{ApiError, LabelClusterFiltersForApi, LabelClusterForApi}
+import models.api.{ApiError, LabelClusterFiltersForApi, LabelClusterForApi, RawLabelInClusterDataForApi}
 import models.utils.LatLngBBox
+import org.apache.pekko.stream.Materializer
 import org.apache.pekko.stream.scaladsl.Source
 import org.apache.pekko.util.ByteString
 import play.api.i18n.Lang.logger
@@ -12,6 +13,7 @@ import play.api.mvc.{Action, AnyContent}
 import play.silhouette.api.Silhouette
 import service.{ApiService, ConfigService}
 
+import java.nio.file.Files
 import java.time.OffsetDateTime
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
@@ -37,7 +39,7 @@ class LabelClustersApiController @Inject() (
     apiService: ApiService,
     configService: ConfigService,
     shapefileCreator: ShapefilesCreatorHelper
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, mat: Materializer)
     extends BaseApiController(cc) {
 
   /**
@@ -171,6 +173,41 @@ class LabelClustersApiController @Inject() (
 
             // Output data in the appropriate file format.
             filetype match {
+              case Some("csv") if filters.includeRawLabels =>
+                // When raw labels are included, create two CSVs (clusters + labels) zipped together.
+                val clusterCsvPath = Files.createTempFile(baseFileName + "_clusters", ".csv")
+                val labelCsvPath   = Files.createTempFile(baseFileName + "_labels", ".csv")
+                val clusterWriter  = Files.newBufferedWriter(clusterCsvPath)
+                val labelWriter    = Files.newBufferedWriter(labelCsvPath)
+
+                clusterWriter.write(LabelClusterForApi.csvHeader)
+                labelWriter.write(RawLabelInClusterDataForApi.csvHeader)
+
+                dbDataStream
+                  .grouped(DEFAULT_BATCH_SIZE)
+                  .runForeach { batch =>
+                    batch.foreach { cluster =>
+                      clusterWriter.write(cluster.toCsvRow)
+                      clusterWriter.write("\n")
+                      cluster.labels.foreach { labelsList =>
+                        labelsList.foreach { label =>
+                          labelWriter.write(RawLabelInClusterDataForApi.toCsvRow(cluster.labelClusterId, label))
+                          labelWriter.write("\n")
+                        }
+                      }
+                    }
+                  }
+                  .flatMap { _ =>
+                    clusterWriter.close()
+                    labelWriter.close()
+                    zipAndStreamCsvFiles(
+                      Seq(
+                        (clusterCsvPath, baseFileName + "_clusters.csv"),
+                        (labelCsvPath, baseFileName + "_labels.csv")
+                      ),
+                      baseFileName
+                    )
+                  }
               case Some("csv") =>
                 outputCSV(dbDataStream, LabelClusterForApi.csvHeader, inline, baseFileName + ".csv")
               case Some("shapefile") if filters.includeRawLabels =>

--- a/app/controllers/helper/ShapefilesCreatorHelper.scala
+++ b/app/controllers/helper/ShapefilesCreatorHelper.scala
@@ -359,6 +359,7 @@ class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: M
     + "nDisagree:Integer,"      // Disagree count
     + "nUnsure:Integer,"        // Unsure count
     + "clusterSze:Integer,"     // Cluster size
+    + "labelIds:String,"        // Label IDs as comma-separated list
     + "userIds:String,"         // User IDs
     + "tagCounts:String"        // Tag counts as JSON
   )
@@ -383,6 +384,7 @@ class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: M
     featureBuilder.add(cluster.disagreeCount)
     featureBuilder.add(cluster.unsureCount)
     featureBuilder.add(cluster.clusterSize)
+    featureBuilder.add(Json.stringify(Json.toJson(cluster.labelIds)))
     featureBuilder.add(Json.stringify(Json.toJson(cluster.userIds)))
     featureBuilder.add(Json.stringify(Json.toJson(cluster.tagCounts)))
     featureBuilder.buildFeature(null)
@@ -537,41 +539,42 @@ class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: M
    * @return Path to the created GeoPackage file, or None if creation failed
    */
   def createLabelClusterGeopackage(
-                                    source: Source[LabelClusterForApi, _],
-                                    outputFile: String,
-                                    batchSize: Int
-                                  ): Future[Option[Path]] = {
+      source: Source[LabelClusterForApi, _],
+      outputFile: String,
+      batchSize: Int
+  ): Future[Option[Path]] = {
     val clusterFeatureType: SimpleFeatureType = DataUtilities.createType(
       "label_clusters",
       "the_geom:Point:srid=4326,"  // the geometry attribute: Point type
-        + "cluster_id:Integer,"      // Cluster ID
-        + "label_type:String,"       // Label type
-        + "street_edge_id:Integer,"  // Street edge ID
-        + "osm_way_id:String,"       // OSM way ID (as String to avoid Long issues)
-        + "region_id:Integer,"       // Region ID
-        + "region_name:String,"      // Region name
-        + "avg_image_date:String,"   // Average image capture date
-        + "avg_label_date:String,"   // Average label date
-        + "median_severity:Integer," // Median severity
-        + "agree_count:Integer,"     // Agree count
-        + "disagree_count:Integer,"  // Disagree count
-        + "unsure_count:Integer,"    // Unsure count
-        + "cluster_size:Integer,"    // Cluster size
-        + "user_ids:String,"         // User IDs as JSON array string
-        + "tag_counts:String"        // Tag counts as JSON object string
+      + "cluster_id:Integer,"      // Cluster ID
+      + "label_type:String,"       // Label type
+      + "street_edge_id:Integer,"  // Street edge ID
+      + "osm_way_id:String,"       // OSM way ID (as String to avoid Long issues)
+      + "region_id:Integer,"       // Region ID
+      + "region_name:String,"      // Region name
+      + "avg_image_date:String,"   // Average image capture date
+      + "avg_label_date:String,"   // Average label date
+      + "median_severity:Integer," // Median severity
+      + "agree_count:Integer,"     // Agree count
+      + "disagree_count:Integer,"  // Disagree count
+      + "unsure_count:Integer,"    // Unsure count
+      + "cluster_size:Integer,"    // Cluster size
+      + "label_ids:String,"        // Label IDs as comma-separated list
+      + "user_ids:String,"         // User IDs as JSON array string
+      + "tag_counts:String"        // Tag counts as JSON object string
     )
 
     val labelFeatureType: SimpleFeatureType = DataUtilities.createType(
       "raw_labels",
       "the_geom:Point:srid=4326," // the geometry attribute: Point type
-        + "label_id:Integer,"       // Label ID
-        + "cluster_id:Integer,"     // Parent cluster ID
-        + "user_id:String,"         // User ID
-        + "pano_id:String,"         // Panorama ID
-        + "severity:Integer,"       // Severity
-        + "time_created:String,"    // Creation timestamp
-        + "correct:String,"         // Validation correctness
-        + "image_date:String"       // Image capture date
+      + "label_id:Integer,"       // Label ID
+      + "cluster_id:Integer,"     // Parent cluster ID
+      + "user_id:String,"         // User ID
+      + "pano_id:String,"         // Panorama ID
+      + "severity:Integer,"       // Severity
+      + "time_created:String,"    // Creation timestamp
+      + "correct:String,"         // Validation correctness
+      + "image_date:String"       // Image capture date
     )
 
     val geopackagePath: Path = new File(outputFile + ".gpkg").toPath
@@ -616,6 +619,7 @@ class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: M
             clusterBuilder.add(cluster.disagreeCount)
             clusterBuilder.add(cluster.unsureCount)
             clusterBuilder.add(cluster.clusterSize)
+            clusterBuilder.add(Json.stringify(Json.toJson(cluster.labelIds)))
             clusterBuilder.add(Json.stringify(Json.toJson(cluster.userIds)))
             clusterBuilder.add(Json.stringify(Json.toJson(cluster.tagCounts)))
             clusterFeatures.add(clusterBuilder.buildFeature(null))

--- a/app/controllers/helper/ShapefilesCreatorHelper.scala
+++ b/app/controllers/helper/ShapefilesCreatorHelper.scala
@@ -1,6 +1,6 @@
 package controllers.helper
 
-import models.api.{LabelClusterForApi, LabelDataForApi, StreetDataForApi}
+import models.api.{LabelClusterForApi, LabelDataForApi, RawLabelInClusterDataForApi, StreetDataForApi}
 import models.computation.{RegionScore, StreetScore}
 import org.apache.pekko.stream.Materializer
 import org.apache.pekko.stream.scaladsl.{Source, StreamConverters}
@@ -32,6 +32,33 @@ import scala.jdk.CollectionConverters.MapHasAsJava
  */
 @Singleton
 class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: Materializer) {
+
+  /**
+   * Writes a batch of features to a feature store inside a transaction.
+   *
+   * @param featureStore The feature store to write to.
+   * @param features The list of features to write.
+   * @param rethrow If true, rethrows exceptions after rollback. If false, logs and swallows them.
+   */
+  private def writeFeatureBatch(
+      featureStore: SimpleFeatureStore,
+      features: java.util.ArrayList[SimpleFeature],
+      rethrow: Boolean = false
+  ): Unit = {
+    val transaction = new DefaultTransaction("create")
+    try {
+      featureStore.setTransaction(transaction)
+      featureStore.addFeatures(DataUtilities.collection(features))
+      transaction.commit()
+    } catch {
+      case e: Exception =>
+        transaction.rollback()
+        if (rethrow) throw e
+        else logger.error(s"Error writing features: ${e.getMessage}", e)
+    } finally {
+      transaction.close()
+    }
+  }
 
   /**
    * Creates a geopackage from the given source, saving it as outputFile.
@@ -82,19 +109,7 @@ class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: M
             features.add(feature)
           }
 
-          // Add this batch of features to the GeoPackage in a transaction.
-          val transaction = new DefaultTransaction("create")
-          try {
-            featureStore.setTransaction(transaction)
-            featureStore.addFeatures(DataUtilities.collection(features))
-            transaction.commit()
-          } catch {
-            case e: Exception =>
-              transaction.rollback()
-              logger.error(s"Error creating GeoPackage: ${e.getMessage}", e)
-          } finally {
-            transaction.close()
-          }
+          writeFeatureBatch(featureStore, features)
         }
         .map { _ =>
           // Return the file path for the GeoPackage.
@@ -154,28 +169,17 @@ class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: M
       source
         .grouped(batchSize)
         .runForeach { batch =>
-          val transaction = new DefaultTransaction("create")
-          try {
-            featureStore.setTransaction(transaction)
-            features.clear()
+          features.clear()
 
-            // Create a feature from each data point in this batch and add it to the ArrayList.
-            batch.foreach { x =>
-              featureBuilder.reset()
-              val feature: SimpleFeature = buildFeature(x, featureBuilder)
-              features.add(feature)
-            }
-
-            // Add this batch of features to the shapefile in a transaction.
-            featureStore.addFeatures(DataUtilities.collection(features))
-            transaction.commit()
-          } catch {
-            case e: Exception =>
-              transaction.rollback()
-              throw e
-          } finally {
-            transaction.close()
+          // Create a feature from each data point in this batch and add it to the ArrayList.
+          batch.foreach { x =>
+            featureBuilder.reset()
+            val feature: SimpleFeature = buildFeature(x, featureBuilder)
+            features.add(feature)
           }
+
+          // Add this batch of features to the shapefile in a transaction.
+          writeFeatureBatch(featureStore, features, rethrow = true)
         }
         .map { _ =>
           // Output the file path for the shapefile.
@@ -338,6 +342,52 @@ class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: M
     createGeneralShapefile(source, outputFile, batchSize, featureType, buildFeature)
   }
 
+  // Shared schema used by both createLabelClusterShapefile and createLabelClusterShapefileWithLabels.
+  private val clusterShapefileFeatureType: SimpleFeatureType = DataUtilities.createType(
+    "Location",
+    "the_geom:Point:srid=4326," // the geometry attribute: Point type
+    + "clusterId:Integer,"      // Cluster ID
+    + "labelType:String,"       // Label type
+    + "streetId:Integer,"       // Street edge ID
+    + "osmWayId:String,"        // OSM way ID
+    + "regionId:Integer,"       // Region ID
+    + "regionName:String,"      // Region name
+    + "avgImgDate:String,"      // Average image capture date
+    + "avgLblDate:String,"      // Average label date
+    + "severity:Integer,"       // Severity
+    + "nAgree:Integer,"         // Agree count
+    + "nDisagree:Integer,"      // Disagree count
+    + "nUnsure:Integer,"        // Unsure count
+    + "clusterSze:Integer,"     // Cluster size
+    + "userIds:String,"         // User IDs
+    + "tagCounts:String"        // Tag counts as JSON
+  )
+
+  // Shared builder used by both createLabelClusterShapefile and createLabelClusterShapefileWithLabels.
+  private def buildClusterShapefileFeature(
+      cluster: LabelClusterForApi,
+      featureBuilder: SimpleFeatureBuilder,
+      geometryFactory: GeometryFactory
+  ): SimpleFeature = {
+    featureBuilder.add(geometryFactory.createPoint(new Coordinate(cluster.avgLongitude, cluster.avgLatitude)))
+    featureBuilder.add(cluster.labelClusterId)
+    featureBuilder.add(cluster.labelType)
+    featureBuilder.add(cluster.streetEdgeId)
+    featureBuilder.add(cluster.osmWayId.toString)
+    featureBuilder.add(cluster.regionId)
+    featureBuilder.add(cluster.regionName)
+    featureBuilder.add(cluster.avgImageCaptureDate.map(_.toString).orNull)
+    featureBuilder.add(cluster.avgLabelDate.map(_.toString).orNull)
+    featureBuilder.add(cluster.medianSeverity.map(Integer.valueOf).orNull)
+    featureBuilder.add(cluster.agreeCount)
+    featureBuilder.add(cluster.disagreeCount)
+    featureBuilder.add(cluster.unsureCount)
+    featureBuilder.add(cluster.clusterSize)
+    featureBuilder.add(Json.stringify(Json.toJson(cluster.userIds)))
+    featureBuilder.add(Json.stringify(Json.toJson(cluster.tagCounts)))
+    featureBuilder.buildFeature(null)
+  }
+
   /**
    * Creates a shapefile from LabelClusterForApi objects.
    *
@@ -351,54 +401,281 @@ class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: M
       outputFile: String,
       batchSize: Int
   ): Future[Option[Path]] = {
-    // Define the feature type schema for LabelClusterForApi
-    val featureType: SimpleFeatureType = DataUtilities.createType(
+    val geometryFactory = JTSFactoryFinder.getGeometryFactory
+    createGeneralShapefile(
+      source,
+      outputFile,
+      batchSize,
+      clusterShapefileFeatureType,
+      (cluster, fb) => buildClusterShapefileFeature(cluster, fb, geometryFactory)
+    )
+  }
+
+  /**
+   * Creates shapefile(s) from LabelClusterForApi objects. When raw labels are included in the cluster data, a second
+   * shapefile for the raw labels is also created.
+   *
+   * @param source Stream of LabelClusterForApi objects
+   * @param outputFile Base filename for the output file (without extension)
+   * @param batchSize Number of features to process in each batch
+   * @return Paths to the created shapefile(s), or None if creation failed
+   */
+  def createLabelClusterShapefileWithLabels(
+      source: Source[LabelClusterForApi, _],
+      outputFile: String,
+      batchSize: Int
+  ): Future[Option[Seq[Path]]] = {
+    val labelFeatureType: SimpleFeatureType = DataUtilities.createType(
       "Location",
       "the_geom:Point:srid=4326," // the geometry attribute: Point type
-      + "clusterId:Integer,"      // Cluster ID
-      + "labelType:String,"       // Label type
-      + "streetId:Integer,"       // Street edge ID
-      + "osmWayId:String,"        // OSM way ID
-      + "regionId:Integer,"       // Region ID
-      + "regionName:String,"      // Region name
-      + "avgImgDate:String,"      // Average image capture date
-      + "avgLblDate:String,"      // Average label date
+      + "labelId:Integer,"        // Label ID
+      + "clusterId:Integer,"      // Parent cluster ID
+      + "userId:String,"          // User ID
+      + "panoId:String,"          // Panorama ID
       + "severity:Integer,"       // Severity
-      + "nAgree:Integer,"         // Agree count
-      + "nDisagree:Integer,"      // Disagree count
-      + "nUnsure:Integer,"        // Unsure count
-      + "clusterSze:Integer,"     // Cluster size
-      + "userIds:String,"         // User IDs
-      + "tagCounts:String"        // Tag counts as JSON
+      + "timeCreate:String,"      // Creation timestamp
+      + "correct:String,"         // Validation correctness
+      + "imageDate:String"        // Image capture date
     )
 
-    val geometryFactory: GeometryFactory = JTSFactoryFinder.getGeometryFactory
+    val clusterShapefilePath: Path = new File(outputFile + ".shp").toPath
+    val labelShapefilePath: Path   = new File(outputFile + "_labels.shp").toPath
+    val geometryFactory            = JTSFactoryFinder.getGeometryFactory
 
-    def buildFeature(cluster: LabelClusterForApi, featureBuilder: SimpleFeatureBuilder): SimpleFeature = {
-      // Add the geometry (Point)
-      featureBuilder.add(geometryFactory.createPoint(new Coordinate(cluster.avgLongitude, cluster.avgLatitude)))
+    try {
+      // Set up clusters shapefile.
+      val clusterDataStoreFactory = new ShapefileDataStoreFactory()
+      val clusterDataStore        = clusterDataStoreFactory.createNewDataStore(
+        Map("url" -> clusterShapefilePath.toUri.toURL, "create spatial index" -> java.lang.Boolean.FALSE).asJava
+      )
+      clusterDataStore.createSchema(clusterShapefileFeatureType)
+      val clusterStore =
+        clusterDataStore.getFeatureSource(clusterDataStore.getTypeNames()(0)).asInstanceOf[SimpleFeatureStore]
+      val clusterBuilder  = new SimpleFeatureBuilder(clusterShapefileFeatureType)
+      val clusterFeatures = new java.util.ArrayList[SimpleFeature](batchSize)
 
-      // Add all attributes
-      featureBuilder.add(cluster.labelClusterId)
-      featureBuilder.add(cluster.labelType)
-      featureBuilder.add(cluster.streetEdgeId)
-      featureBuilder.add(cluster.osmWayId.toString)
-      featureBuilder.add(cluster.regionId)
-      featureBuilder.add(cluster.regionName)
-      featureBuilder.add(cluster.avgImageCaptureDate.map(_.toString).orNull)
-      featureBuilder.add(cluster.avgLabelDate.map(_.toString).orNull)
-      featureBuilder.add(cluster.medianSeverity.map(Integer.valueOf).orNull)
-      featureBuilder.add(cluster.agreeCount)
-      featureBuilder.add(cluster.disagreeCount)
-      featureBuilder.add(cluster.unsureCount)
-      featureBuilder.add(cluster.clusterSize)
-      featureBuilder.add(Json.stringify(Json.toJson(cluster.userIds)))
-      featureBuilder.add(Json.stringify(Json.toJson(cluster.tagCounts)))
+      // Collect raw labels to write a second shapefile after processing clusters.
+      val allRawLabels = new java.util.ArrayList[(Int, RawLabelInClusterDataForApi)]()
+      var hasRawLabels = false
 
-      featureBuilder.buildFeature(null)
+      source
+        .grouped(batchSize)
+        .runForeach { batch =>
+          clusterFeatures.clear()
+          batch.foreach { cluster =>
+            clusterBuilder.reset()
+            clusterFeatures.add(buildClusterShapefileFeature(cluster, clusterBuilder, geometryFactory))
+
+            // Collect raw labels.
+            cluster.labels.foreach { labelsList =>
+              hasRawLabels = true
+              labelsList.foreach(label => allRawLabels.add((cluster.labelClusterId, label)))
+            }
+          }
+          writeFeatureBatch(clusterStore, clusterFeatures, rethrow = true)
+        }
+        .map { _ =>
+          clusterDataStore.dispose()
+
+          // Write the raw labels shapefile if any labels were collected.
+          if (hasRawLabels && !allRawLabels.isEmpty) {
+            val labelDataStoreFactory = new ShapefileDataStoreFactory()
+            val labelDataStore        = labelDataStoreFactory.createNewDataStore(
+              Map("url" -> labelShapefilePath.toUri.toURL, "create spatial index" -> java.lang.Boolean.FALSE).asJava
+            )
+            labelDataStore.createSchema(labelFeatureType)
+            val labelStore =
+              labelDataStore.getFeatureSource(labelDataStore.getTypeNames()(0)).asInstanceOf[SimpleFeatureStore]
+            val labelBuilder  = new SimpleFeatureBuilder(labelFeatureType)
+            val labelFeatures = new java.util.ArrayList[SimpleFeature](batchSize)
+
+            val labelIter = allRawLabels.iterator()
+            while (labelIter.hasNext) {
+              labelFeatures.clear()
+              var count = 0
+              while (labelIter.hasNext && count < batchSize) {
+                val (clusterId, label) = labelIter.next()
+                labelBuilder.reset()
+                labelBuilder.add(geometryFactory.createPoint(new Coordinate(label.longitude, label.latitude)))
+                labelBuilder.add(label.labelId)
+                labelBuilder.add(clusterId)
+                labelBuilder.add(label.userId)
+                labelBuilder.add(label.panoId)
+                labelBuilder.add(label.severity.map(Integer.valueOf).orNull)
+                labelBuilder.add(label.timeCreated.toString)
+                labelBuilder.add(label.correct.map(_.toString).orNull)
+                labelBuilder.add(label.imageCaptureDate.orNull)
+                labelFeatures.add(labelBuilder.buildFeature(null))
+                count += 1
+              }
+              writeFeatureBatch(labelStore, labelFeatures, rethrow = true)
+            }
+            labelDataStore.dispose()
+            Some(Seq(clusterShapefilePath, labelShapefilePath))
+          } else {
+            Some(Seq(clusterShapefilePath))
+          }
+        }
+        .recover { case e: Exception =>
+          clusterDataStore.dispose()
+          logger.error(s"Error creating shapefile: ${e.getMessage}", e)
+          None
+        }
+    } catch {
+      case e: Exception =>
+        logger.error(s"Error setting up shapefile: ${e.getMessage}", e)
+        Future.successful(None)
     }
+  }
 
-    createGeneralShapefile(source, outputFile, batchSize, featureType, buildFeature)
+  /**
+   * Creates a GeoPackage file from LabelClusterForApi objects.
+   *
+   * @param source Stream of LabelClusterForApi objects
+   * @param outputFile Base filename for the output file (without extension)
+   * @param batchSize Number of features to process in each batch
+   * @return Path to the created GeoPackage file, or None if creation failed
+   */
+  def createLabelClusterGeopackage(
+                                    source: Source[LabelClusterForApi, _],
+                                    outputFile: String,
+                                    batchSize: Int
+                                  ): Future[Option[Path]] = {
+    val clusterFeatureType: SimpleFeatureType = DataUtilities.createType(
+      "label_clusters",
+      "the_geom:Point:srid=4326,"  // the geometry attribute: Point type
+        + "cluster_id:Integer,"      // Cluster ID
+        + "label_type:String,"       // Label type
+        + "street_edge_id:Integer,"  // Street edge ID
+        + "osm_way_id:String,"       // OSM way ID (as String to avoid Long issues)
+        + "region_id:Integer,"       // Region ID
+        + "region_name:String,"      // Region name
+        + "avg_image_date:String,"   // Average image capture date
+        + "avg_label_date:String,"   // Average label date
+        + "median_severity:Integer," // Median severity
+        + "agree_count:Integer,"     // Agree count
+        + "disagree_count:Integer,"  // Disagree count
+        + "unsure_count:Integer,"    // Unsure count
+        + "cluster_size:Integer,"    // Cluster size
+        + "user_ids:String,"         // User IDs as JSON array string
+        + "tag_counts:String"        // Tag counts as JSON object string
+    )
+
+    val labelFeatureType: SimpleFeatureType = DataUtilities.createType(
+      "raw_labels",
+      "the_geom:Point:srid=4326," // the geometry attribute: Point type
+        + "label_id:Integer,"       // Label ID
+        + "cluster_id:Integer,"     // Parent cluster ID
+        + "user_id:String,"         // User ID
+        + "pano_id:String,"         // Panorama ID
+        + "severity:Integer,"       // Severity
+        + "time_created:String,"    // Creation timestamp
+        + "correct:String,"         // Validation correctness
+        + "image_date:String"       // Image capture date
+    )
+
+    val geopackagePath: Path = new File(outputFile + ".gpkg").toPath
+
+    try {
+      val params = Map(
+        GeoPkgDataStoreFactory.DBTYPE.key   -> "geopkg",
+        GeoPkgDataStoreFactory.DATABASE.key -> geopackagePath.toFile
+      ).asJava
+      val dataStore: DataStore = DataStoreFinder.getDataStore(params)
+
+      // Create both schemas.
+      dataStore.createSchema(clusterFeatureType)
+
+      val clusterTypeName = dataStore.getTypeNames()(0)
+      val clusterStore    = dataStore.getFeatureSource(clusterTypeName).asInstanceOf[SimpleFeatureStore]
+      val clusterBuilder  = new SimpleFeatureBuilder(clusterFeatureType)
+      val clusterFeatures = new java.util.ArrayList[SimpleFeature](batchSize)
+
+      // Collect raw labels to write as a second layer after the clusters.
+      val allRawLabels    = new java.util.ArrayList[(Int, RawLabelInClusterDataForApi)]()
+      val geometryFactory = JTSFactoryFinder.getGeometryFactory
+      var hasRawLabels    = false
+
+      source
+        .grouped(batchSize)
+        .runForeach { batch =>
+          clusterFeatures.clear()
+          batch.foreach { cluster =>
+            clusterBuilder.reset()
+            clusterBuilder.add(geometryFactory.createPoint(new Coordinate(cluster.avgLongitude, cluster.avgLatitude)))
+            clusterBuilder.add(cluster.labelClusterId)
+            clusterBuilder.add(cluster.labelType)
+            clusterBuilder.add(cluster.streetEdgeId)
+            clusterBuilder.add(cluster.osmWayId.toString)
+            clusterBuilder.add(cluster.regionId)
+            clusterBuilder.add(cluster.regionName)
+            clusterBuilder.add(cluster.avgImageCaptureDate.orNull)
+            clusterBuilder.add(cluster.avgLabelDate.orNull)
+            clusterBuilder.add(cluster.medianSeverity.map(Integer.valueOf).orNull)
+            clusterBuilder.add(cluster.agreeCount)
+            clusterBuilder.add(cluster.disagreeCount)
+            clusterBuilder.add(cluster.unsureCount)
+            clusterBuilder.add(cluster.clusterSize)
+            clusterBuilder.add(Json.stringify(Json.toJson(cluster.userIds)))
+            clusterBuilder.add(Json.stringify(Json.toJson(cluster.tagCounts)))
+            clusterFeatures.add(clusterBuilder.buildFeature(null))
+
+            // Collect raw labels for the second layer.
+            cluster.labels.foreach { labelsList =>
+              hasRawLabels = true
+              labelsList.foreach(label => allRawLabels.add((cluster.labelClusterId, label)))
+            }
+          }
+
+          writeFeatureBatch(clusterStore, clusterFeatures)
+        }
+        .flatMap { _ =>
+          // Write the raw labels layer if the raw labels were included.
+          if (hasRawLabels && !allRawLabels.isEmpty) {
+            dataStore.createSchema(labelFeatureType)
+            val labelTypeName = "raw_labels"
+            val labelStore    = dataStore.getFeatureSource(labelTypeName).asInstanceOf[SimpleFeatureStore]
+            val labelBuilder  = new SimpleFeatureBuilder(labelFeatureType)
+            val labelFeatures = new java.util.ArrayList[SimpleFeature](batchSize)
+
+            // Write raw labels in batches.
+            val labelIter = allRawLabels.iterator()
+            while (labelIter.hasNext) {
+              labelFeatures.clear()
+              var count = 0
+              while (labelIter.hasNext && count < batchSize) {
+                val (clusterId, label) = labelIter.next()
+                labelBuilder.reset()
+                labelBuilder.add(geometryFactory.createPoint(new Coordinate(label.longitude, label.latitude)))
+                labelBuilder.add(label.labelId)
+                labelBuilder.add(clusterId)
+                labelBuilder.add(label.userId)
+                labelBuilder.add(label.panoId)
+                labelBuilder.add(label.severity.map(Integer.valueOf).orNull)
+                labelBuilder.add(label.timeCreated.toString)
+                labelBuilder.add(label.correct.map(_.toString).orNull)
+                labelBuilder.add(label.imageCaptureDate.orNull)
+                labelFeatures.add(labelBuilder.buildFeature(null))
+                count += 1
+              }
+
+              writeFeatureBatch(labelStore, labelFeatures)
+            }
+          }
+
+          dataStore.dispose()
+          Future.successful(Some(geopackagePath))
+        }
+        .recover { case e: Exception =>
+          dataStore.dispose()
+          logger.error(s"Error creating GeoPackage: ${e.getMessage}", e)
+          None
+        }
+    } catch {
+      case e: Exception =>
+        logger.error(s"Error setting up GeoPackage: ${e.getMessage}", e)
+        Future.successful(None)
+    }
   }
 
   /**
@@ -705,76 +982,6 @@ class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: M
       featureBuilder.add(s"[$userIdsStr]")
       featureBuilder.add(street.firstLabelDate.map(_.toString).orNull)
       featureBuilder.add(street.lastLabelDate.map(_.toString).orNull)
-
-      featureBuilder.buildFeature(null)
-    }
-
-    createGeneralGeoPackage(source, outputFile, batchSize, featureType, buildFeature)
-  }
-
-  /**
-   * Creates a GeoPackage file from LabelClusterForApi objects.
-   *
-   * @param source Stream of LabelClusterForApi objects
-   * @param outputFile Base filename for the output file (without extension)
-   * @param batchSize Number of features to process in each batch
-   * @return Path to the created GeoPackage file, or None if creation failed
-   */
-  def createLabelClusterGeopackage(
-      source: Source[LabelClusterForApi, _],
-      outputFile: String,
-      batchSize: Int
-  ): Future[Option[Path]] = {
-    // Define the feature type schema.
-    val featureType: SimpleFeatureType = DataUtilities.createType(
-      "label_clusters",
-      "the_geom:Point:srid=4326,"  // the geometry attribute: Point type
-      + "cluster_id:Integer,"      // Cluster ID
-      + "label_type:String,"       // Label type
-      + "street_edge_id:Integer,"  // Street edge ID
-      + "osm_way_id:String,"       // OSM way ID (as String to avoid Long issues)
-      + "region_id:Integer,"       // Region ID
-      + "region_name:String,"      // Region name
-      + "avg_image_date:String,"   // Average image capture date
-      + "avg_label_date:String,"   // Average label date
-      + "median_severity:Integer," // Median severity
-      + "agree_count:Integer,"     // Agree count
-      + "disagree_count:Integer,"  // Disagree count
-      + "unsure_count:Integer,"    // Unsure count
-      + "cluster_size:Integer,"    // Cluster size
-      + "user_ids:String,"         // User IDs as JSON array string
-      + "tag_counts:String,"       // Tag counts as JSON object string
-      + "labels:String"            // Raw labels (if included) as JSON string
-    )
-
-    val geometryFactory = JTSFactoryFinder.getGeometryFactory
-    def buildFeature(cluster: LabelClusterForApi, featureBuilder: SimpleFeatureBuilder): SimpleFeature = {
-      // Add the geometry (Point).
-      featureBuilder.add(geometryFactory.createPoint(new Coordinate(cluster.avgLongitude, cluster.avgLatitude)))
-
-      // Add all attributes.
-      featureBuilder.add(cluster.labelClusterId)
-      featureBuilder.add(cluster.labelType)
-      featureBuilder.add(cluster.streetEdgeId)
-      featureBuilder.add(cluster.osmWayId.toString) // Convert Long to String.
-      featureBuilder.add(cluster.regionId)
-      featureBuilder.add(cluster.regionName)
-      featureBuilder.add(cluster.avgImageCaptureDate.orNull)
-      featureBuilder.add(cluster.avgLabelDate.orNull)
-      featureBuilder.add(cluster.medianSeverity.map(Integer.valueOf).orNull)
-      featureBuilder.add(cluster.agreeCount)
-      featureBuilder.add(cluster.disagreeCount)
-      featureBuilder.add(cluster.unsureCount)
-      featureBuilder.add(cluster.clusterSize)
-      featureBuilder.add(Json.stringify(Json.toJson(cluster.userIds)))
-      featureBuilder.add(Json.stringify(Json.toJson(cluster.tagCounts)))
-
-      // Add raw labels if they exist, formatted as JSON string.
-      val labelsStr = cluster.labels match {
-        case Some(labelsList) => Json.stringify(Json.toJson(labelsList))
-        case None             => null
-      }
-      featureBuilder.add(labelsStr)
 
       featureBuilder.buildFeature(null)
     }

--- a/app/models/api/LabelClustersApiModels.scala
+++ b/app/models/api/LabelClustersApiModels.scala
@@ -66,10 +66,39 @@ case class RawLabelInClusterDataForApi(
 )
 
 /**
- * Companion object for RawLabelInClusterDataForApi containing JSON formatter.
+ * Companion object for RawLabelInClusterDataForApi containing JSON formatter and CSV utilities.
  */
 object RawLabelInClusterDataForApi {
   implicit val clusterLabelDataWrites: Writes[RawLabelInClusterDataForApi] = Json.writes[RawLabelInClusterDataForApi]
+
+  /**
+   * CSV header for raw labels within clusters. Includes label_cluster_id to link back to the parent cluster.
+   */
+  val csvHeader: String = "label_cluster_id,label_id,user_id,pano_id,severity,time_created," +
+    "latitude,longitude,correct,image_capture_date\n"
+
+  /**
+   * Converts a raw label (the minimal version for cluster API) to a CSV row string, prefixed with parent cluster ID.
+   *
+   * @param clusterId The ID of the parent label cluster.
+   * @param label The raw label data to convert.
+   * @return A comma-separated string representing this label's data.
+   */
+  def toCsvRow(clusterId: Int, label: RawLabelInClusterDataForApi): String = {
+    val fields = Seq(
+      clusterId.toString,
+      label.labelId.toString,
+      escapeCsvField(label.userId),
+      escapeCsvField(label.panoId),
+      label.severity.map(_.toString).getOrElse(""),
+      label.timeCreated.toString,
+      label.latitude.toString,
+      label.longitude.toString,
+      label.correct.map(_.toString).getOrElse(""),
+      label.imageCaptureDate.getOrElse("")
+    )
+    fields.mkString(",")
+  }
 }
 
 /**

--- a/app/models/api/LabelClustersApiModels.scala
+++ b/app/models/api/LabelClustersApiModels.scala
@@ -88,6 +88,7 @@ object RawLabelInClusterDataForApi {
  * @param disagreeCount Total number of users who disagreed with labels in this cluster
  * @param unsureCount Total number of users who were unsure about labels in this cluster
  * @param clusterSize Number of labels in this cluster
+ * @param labelIds List of label IDs that make up this cluster
  * @param userIds List of user IDs who contributed labels to this cluster
  * @param tagCounts Map of tag names to the number of labels in the cluster with that tag
  * @param labels Optional list of raw labels in this cluster (only included if requested)
@@ -108,6 +109,7 @@ case class LabelClusterForApi(
     disagreeCount: Int,
     unsureCount: Int,
     clusterSize: Int,
+    labelIds: Seq[Int],
     userIds: Seq[String],
     tagCounts: Map[String, Int],
     labels: Option[Seq[RawLabelInClusterDataForApi]],
@@ -139,6 +141,7 @@ case class LabelClusterForApi(
       "disagree_count"         -> disagreeCount,
       "unsure_count"           -> unsureCount,
       "cluster_size"           -> clusterSize,
+      "label_ids"              -> labelIds,
       "users"                  -> userIds,
       "tag_counts"             -> tagCounts
     )
@@ -175,6 +178,7 @@ case class LabelClusterForApi(
       disagreeCount.toString,
       unsureCount.toString,
       clusterSize.toString,
+      escapeCsvField(labelIds.mkString("[", ",", "]")),
       escapeCsvField(userIds.mkString("[", ",", "]")),
       escapeCsvField(Json.stringify(Json.toJson(tagCounts))),
       // We don't include the raw labels in CSV format as it would be too complex.
@@ -196,5 +200,5 @@ object LabelClusterForApi {
    */
   val csvHeader: String = "label_cluster_id,label_type,street_edge_id,osm_way_id,region_id,region_name," +
     "avg_image_capture_date,avg_label_date,median_severity,agree_count,disagree_count,unsure_count,cluster_size," +
-    "users,tag_counts,avg_latitude,avg_longitude\n"
+    "label_ids,users,tag_counts,avg_latitude,avg_longitude\n"
 }

--- a/app/models/cluster/ClusterTable.scala
+++ b/app/models/cluster/ClusterTable.scala
@@ -144,8 +144,9 @@ class ClusterTable @Inject() (protected val dbConfigProvider: DatabaseConfigProv
     val unsureCount    = r.nextInt()
     val clusterSize    = r.nextInt()
 
-    // Parse user IDs and remove duplicates.
-    val userIds = r.nextString().split(",").toSeq.distinct
+    // Parse comma-separated label IDs and user IDs.
+    val labelIds = r.nextString().split(",").map(_.toInt).toSeq
+    val userIds  = r.nextString().split(",").toSeq
 
     val avgLatitude  = r.nextDouble()
     val avgLongitude = r.nextDouble()
@@ -168,8 +169,8 @@ class ClusterTable @Inject() (protected val dbConfigProvider: DatabaseConfigProv
       labelClusterId = labelClusterId, labelType = labelType, streetEdgeId = streetEdgeId, osmWayId = osmWayId,
       regionId = regionId, regionName = regionName, avgImageCaptureDate = avgImageCaptureDate,
       avgLabelDate = avgLabelDate, medianSeverity = medianSeverity, agreeCount = agreeCount,
-      disagreeCount = disagreeCount, unsureCount = unsureCount, clusterSize = clusterSize, userIds = userIds,
-      tagCounts = tagCounts, labels = labels, avgLatitude = avgLatitude, avgLongitude = avgLongitude
+      disagreeCount = disagreeCount, unsureCount = unsureCount, clusterSize = clusterSize, labelIds = labelIds,
+      userIds = userIds, tagCounts = tagCounts, labels = labels, avgLatitude = avgLatitude, avgLongitude = avgLongitude
     )
   }
 
@@ -308,14 +309,16 @@ class ClusterTable @Inject() (protected val dbConfigProvider: DatabaseConfigProv
     // Combine all conditions.
     val whereClause = whereConditions.mkString(" AND ")
 
-    // Sum the validations counts, average date, and the number of the labels that make up each cluster.
-    val validationCounts =
+    // Aggregate per-label data for each cluster: validation counts, dates, label IDs, and user IDs.
+    val labelAggregates =
       """SELECT cluster.cluster_id AS cluster_id,
         |       SUM(label.agree_count) AS agree_count,
         |       SUM(label.disagree_count) AS disagree_count,
         |       SUM(label.unsure_count) AS unsure_count,
         |       TO_TIMESTAMP(AVG(extract(epoch from label.time_created))) AS avg_label_date,
-        |       COUNT(label.label_id) AS label_count
+        |       COUNT(label.label_id) AS label_count,
+        |       array_to_string(array_agg(label.label_id ORDER BY label.label_id), ',') AS label_ids,
+        |       array_to_string(array_agg(DISTINCT label.user_id ORDER BY label.user_id), ',') AS users_list
         |FROM cluster
         |INNER JOIN cluster_label ON cluster.cluster_id = cluster_label.cluster_id
         |INNER JOIN label ON cluster_label.label_id = label.label_id
@@ -336,16 +339,13 @@ class ClusterTable @Inject() (protected val dbConfigProvider: DatabaseConfigProv
         |) tag_counts ON cluster.cluster_id = tag_counts.cluster_id
         |GROUP BY cluster.cluster_id""".stripMargin
 
-    // Select the average image date and number of images for each cluster.
-    val imageCaptureDatesAndUserIds =
+    // Compute the average image capture date per cluster by first averaging per pano, then averaging those.
+    val avgImageCaptureDates =
       """SELECT capture_dates.cluster_id AS cluster_id,
-        |       TO_TIMESTAMP(AVG(EXTRACT(epoch from capture_dates.capture_date))) AS avg_capture_date,
-        |       COUNT(capture_dates.capture_date) AS image_count,
-        |       string_agg(capture_dates.users_list, ',') AS users_list
+        |       TO_TIMESTAMP(AVG(EXTRACT(epoch from capture_dates.capture_date))) AS avg_capture_date
         |FROM (
         |    SELECT cluster.cluster_id,
-        |           TO_TIMESTAMP(AVG(EXTRACT(epoch from TO_DATE(pano_data.capture_date, 'YYYY-MM')))) AS capture_date,
-        |           array_to_string(array_agg(DISTINCT label.user_id), ',') AS users_list
+        |           TO_TIMESTAMP(AVG(EXTRACT(epoch from TO_DATE(pano_data.capture_date, 'YYYY-MM')))) AS capture_date
         |    FROM cluster
         |    INNER JOIN cluster_label ON cluster.cluster_id = cluster_label.cluster_id
         |    INNER JOIN label ON cluster_label.label_id = label.label_id
@@ -362,14 +362,15 @@ class ClusterTable @Inject() (protected val dbConfigProvider: DatabaseConfigProv
           osm_way_street_edge.osm_way_id,
           street_edge_region.region_id,
           region.name AS region_name,
-          image_capture_dates.avg_capture_date AS avg_image_capture_date,
-          validation_counts.avg_label_date,
+          avg_image_capture_dates.avg_capture_date AS avg_image_capture_date,
+          label_aggregates.avg_label_date,
           cluster.severity,
-          validation_counts.agree_count,
-          validation_counts.disagree_count,
-          validation_counts.unsure_count,
-          validation_counts.label_count AS cluster_size,
-          image_capture_dates.users_list,
+          label_aggregates.agree_count,
+          label_aggregates.disagree_count,
+          label_aggregates.unsure_count,
+          label_aggregates.label_count AS cluster_size,
+          label_aggregates.label_ids,
+          label_aggregates.users_list,
           ST_Y(cluster.geom) AS lat,
           ST_X(cluster.geom) AS lng,
           cluster_tag_counts.tag_counts
@@ -379,8 +380,8 @@ class ClusterTable @Inject() (protected val dbConfigProvider: DatabaseConfigProv
     INNER JOIN street_edge_region ON street_edge.street_edge_id = street_edge_region.street_edge_id
     INNER JOIN region ON street_edge_region.region_id = region.region_id
     INNER JOIN osm_way_street_edge ON cluster.street_edge_id = osm_way_street_edge.street_edge_id
-    INNER JOIN (${validationCounts}) validation_counts ON cluster.cluster_id = validation_counts.cluster_id
-    INNER JOIN (${imageCaptureDatesAndUserIds}) image_capture_dates ON cluster.cluster_id = image_capture_dates.cluster_id
+    INNER JOIN (${labelAggregates}) label_aggregates ON cluster.cluster_id = label_aggregates.cluster_id
+    INNER JOIN (${avgImageCaptureDates}) avg_image_capture_dates ON cluster.cluster_id = avg_image_capture_dates.cluster_id
     INNER JOIN (${tagCounts}) cluster_tag_counts ON cluster.cluster_id = cluster_tag_counts.cluster_id
     WHERE ${whereClause}
     ORDER BY cluster.cluster_id
@@ -425,6 +426,7 @@ class ClusterTable @Inject() (protected val dbConfigProvider: DatabaseConfigProv
             base_query.disagree_count,
             base_query.unsure_count,
             base_query.cluster_size,
+            base_query.label_ids,
             base_query.users_list,
             base_query.lat,
             base_query.lng,

--- a/app/views/apiDocs/labelClusters.scala.html
+++ b/app/views/apiDocs/labelClusters.scala.html
@@ -165,7 +165,7 @@
                     <tr>
                         <td><code>includeRawLabels</code></td>
                         <td><code>boolean</code></td>
-                        <td>Whether to include detailed information about the individual raw labels that make up each cluster. Default: <code>false</code>. Setting to <code>true</code> will increase response size substantially. Not available when using <code>filetype=csv</code></td>
+                        <td>Whether to include detailed information about the individual raw labels that make up each cluster. Default: <code>false</code>. Setting to <code>true</code> will increase response size substantially. To request all possible fields related to the raw labels, use the <a href="@routes.ApiDocsController.rawLabels">Raw Labels API</a>.
                     </tr>
                     <tr>
                         <td><code>clusterSize</code></td>
@@ -426,7 +426,7 @@
                     <tr>
                         <td><code>properties.labels</code></td>
                         <td><code>array</code></td>
-                        <td>Array of raw label objects that make up this cluster. Only included if <code>includeRawLabels=true</code> is specified in the request. Each object contains core information about the individual label including its ID, user ID, severity, coordinates, and validation status.</td>
+                        <td>Array of raw label objects that make up this cluster. Only included if <code>includeRawLabels=true</code> is specified in the request. Each object contains core information about the individual label including its ID, user ID, severity, coordinates, and validation status. To request all possible fields related to the raw labels, use the <a href="/api-docs/rawLabels">Raw Labels API</a></td>
                     </tr>
                 </tbody>
             </table>
@@ -439,7 +439,11 @@
 125,NoCurbRamp,952,11566031,8,Teaneck Community Charter School,2012-08-15T00:00:00Z,2023-06-22T11:12:24Z,3,9,0,1,3,"[31,35,42]","[8af92eb8-fb84-4aa6-9539-abc95216dcd7,be481045-4448-42ae-bbac-3455ce914202,549187e0-82c9-4014-a48d-31f18083d575]","{}",40.8839416503906,-74.0243835449219
 ...</code></pre>
 
-        <p>Note: The <code>labels</code> array is not included in the CSV output even when <code>includeRawLabels=true</code> is specified, as the nested data structure is not suitable for the CSV format.</p>
+        <p>When <code>includeRawLabels=true</code> is specified with <code>filetype=csv</code>, the response will be a ZIP archive containing two CSV files:</p>
+        <ul>
+            <li><code>*_clusters.csv</code> — The label clusters data (same format as above).</li>
+            <li><code>*_labels.csv</code> — The individual raw labels, with a <code>label_cluster_id</code> column to link each label back to its parent cluster. Columns: <code>label_cluster_id</code>, <code>label_id</code>, <code>user_id</code>, <code>pano_id</code>, <code>severity</code>, <code>time_created</code>, <code>latitude</code>, <code>longitude</code>, <code>correct</code>, <code>image_capture_date</code>.</li>
+        </ul>
 
         <h4 id="response-shapefile">Shapefile Format <a href="#response-shapefile" class="permalink">#</a></h4>
         <p>If <code>filetype=shapefile</code> is specified, the response body will be a ZIP archive containing the Shapefile components (.shp, .shx, .dbf, .prj). The attribute table (.dbf) contains fields corresponding to the GeoJSON properties object (field names may be truncated due to Shapefile limitations). The included <code>.prj</code> file defines the Coordinate Reference System (CRS), typically WGS84 (EPSG:4326). When <code>includeRawLabels=true</code> is specified, the ZIP will contain a second set of Shapefile components with a <code>_labels</code> suffix, representing the individual raw labels as a separate layer.</p>

--- a/app/views/apiDocs/labelClusters.scala.html
+++ b/app/views/apiDocs/labelClusters.scala.html
@@ -241,6 +241,7 @@
                 "disagree_count": 2,
                 "unsure_count": 0,
                 "cluster_size": 5,
+                "label_ids": [8, 12, 14, 19, 27],
                 "users": [
                     "18b26a38-24ab-402d-a64e-158fc0bb8a8a",
                     "53ad4d79-9a7b-4d3c-a753-63bbfca34c9b"
@@ -295,6 +296,7 @@
                 "disagree_count": 0,
                 "unsure_count": 1,
                 "cluster_size": 3,
+                "label_ids": [31, 35, 42],
                 "users": [
                     "8af92eb8-fb84-4aa6-9539-abc95216dcd7",
                     "be481045-4448-42ae-bbac-3455ce914202",
@@ -348,6 +350,11 @@
                         <td><code>properties.cluster_size</code></td>
                         <td><code>integer</code></td>
                         <td>Number of individual labels that make up this cluster. Higher numbers generally indicate higher confidence in the existence of the feature.</td>
+                    </tr>
+                    <tr>
+                        <td><code>properties.label_ids</code></td>
+                        <td><code>array[integer]</code></td>
+                        <td>Array of raw label IDs that make up this cluster. Can be used to cross-reference with the <a href="@routes.ApiDocsController.rawLabels">Raw Labels API</a>.</td>
                     </tr>
 
                         <!-- Location Context -->
@@ -427,18 +434,18 @@
 
         <h4 id="response-csv">CSV Format <a href="#response-csv" class="permalink">#</a></h4>
         <p>If <code>filetype=csv</code> is specified, the response body will be CSV data. The first row contains the headers, corresponding to the fields in the GeoJSON properties object, plus <code>avg_latitude</code> and <code>avg_longitude</code> columns derived from the geometry. CRS is WGS84 (EPSG:4326).</p>
-        <pre tabindex="0"><code class="language-csv">label_cluster_id,label_type,street_edge_id,osm_way_id,region_id,region_name,avg_image_capture_date,avg_label_date,median_severity,agree_count,disagree_count,unsure_count,cluster_size,users,tag_counts,avg_latitude,avg_longitude
-124,CurbRamp,951,11584845,8,Teaneck Community Charter School,2012-08-15T00:00:00Z,2023-06-20T14:32:45Z,1,18,2,0,5,"[18b26a38-24ab-402d-a64e-158fc0bb8a8a,53ad4d79-9a7b-4d3c-a753-63bbfca34c9b]","{""points into street"":2,""missing tactile warning"":1}",40.8839912414551,-74.0243606567383
-125,NoCurbRamp,952,11566031,8,Teaneck Community Charter School,2012-08-15T00:00:00Z,2023-06-22T11:12:24Z,3,9,0,1,3,"[8af92eb8-fb84-4aa6-9539-abc95216dcd7,be481045-4448-42ae-bbac-3455ce914202,549187e0-82c9-4014-a48d-31f18083d575]","{}",40.8839416503906,-74.0243835449219
+        <pre tabindex="0"><code class="language-csv">label_cluster_id,label_type,street_edge_id,osm_way_id,region_id,region_name,avg_image_capture_date,avg_label_date,median_severity,agree_count,disagree_count,unsure_count,cluster_size,label_ids,users,tag_counts,avg_latitude,avg_longitude
+124,CurbRamp,951,11584845,8,Teaneck Community Charter School,2012-08-15T00:00:00Z,2023-06-20T14:32:45Z,1,18,2,0,5,"[8,12,14,19,27]","[18b26a38-24ab-402d-a64e-158fc0bb8a8a,53ad4d79-9a7b-4d3c-a753-63bbfca34c9b]","{""points into street"":2,""missing tactile warning"":1}",40.8839912414551,-74.0243606567383
+125,NoCurbRamp,952,11566031,8,Teaneck Community Charter School,2012-08-15T00:00:00Z,2023-06-22T11:12:24Z,3,9,0,1,3,"[31,35,42]","[8af92eb8-fb84-4aa6-9539-abc95216dcd7,be481045-4448-42ae-bbac-3455ce914202,549187e0-82c9-4014-a48d-31f18083d575]","{}",40.8839416503906,-74.0243835449219
 ...</code></pre>
 
         <p>Note: The <code>labels</code> array is not included in the CSV output even when <code>includeRawLabels=true</code> is specified, as the nested data structure is not suitable for the CSV format.</p>
 
         <h4 id="response-shapefile">Shapefile Format <a href="#response-shapefile" class="permalink">#</a></h4>
-        <p>If <code>filetype=shapefile</code> is specified, the response body will be a ZIP archive containing the Shapefile components (.shp, .shx, .dbf, .prj). The attribute table (.dbf) contains fields corresponding to the GeoJSON properties object (field names may be truncated due to Shapefile limitations). The included <code>.prj</code> file defines the Coordinate Reference System (CRS), typically WGS84 (EPSG:4326). </p>
+        <p>If <code>filetype=shapefile</code> is specified, the response body will be a ZIP archive containing the Shapefile components (.shp, .shx, .dbf, .prj). The attribute table (.dbf) contains fields corresponding to the GeoJSON properties object (field names may be truncated due to Shapefile limitations). The included <code>.prj</code> file defines the Coordinate Reference System (CRS), typically WGS84 (EPSG:4326). When <code>includeRawLabels=true</code> is specified, the ZIP will contain a second set of Shapefile components with a <code>_labels</code> suffix, representing the individual raw labels as a separate layer.</p>
 
         <h4 id="response-geopackage">GeoPackage Format <a href="#response-geopackage" class="permalink">#</a></h4>
-        <p>If <code>filetype=geopackage</code> is specified, the response body will be a GeoPackage file (<code>.gpkg</code>). This is an open standard format based on SQLite that contains both geometry and attributes in a single file, generally without the field name limitations of Shapefiles. CRS is typically WGS84 (EPSG:4326). </p>
+        <p>If <code>filetype=geopackage</code> is specified, the response body will be a GeoPackage file (<code>.gpkg</code>). This is an open standard format based on SQLite that contains both geometry and attributes in a single file, generally without the field name limitations of Shapefiles. CRS is typically WGS84 (EPSG:4326). When <code>includeRawLabels=true</code> is specified, the GeoPackage will contain a second layer named <code>raw_labels</code> in addition to the <code>label_clusters</code> layer.</p>
 
         <h3 class="api-heading" id="error-responses">Error Responses<a href="#error-responses" class="permalink">#</a></h3>
         <p>If an error occurs, the API will return an appropriate HTTP status code and a JSON response body containing details about the error.</p>


### PR DESCRIPTION
Fixes #4157 
Resolves #4158 

There are various improvements to `/v3/api/labelClusters?includeRawLabels=true`:
1. Setting `includeRawLabels=true` now actually results in raw labels being returned for Shapefile, GeoPackage, and CSV file types
    * Shapefile: A separate Shapefile is created for clusters and labels, and they are zipped together
    * GeoPackage: The clusters and labels are added as separate layers to the GeoPackage file
    * CSV: The clusters and labels are written to their own CSVs, which are then zipped together
2. Regardless of `includeRawLabels`, a new `label_ids` field has been added, which includes a list of raw label IDs that make up the cluster.
3. All documentation has been updated appropriately

