### PR TITLE
Fixes /admin/user page issues when viewing label popup

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -19,6 +19,7 @@ module.exports = function(grunt) {
             },
             dist_progress: {
                 src: [
+                    'public/javascripts/common/AiLabelIndicator.js',
                     'public/javascripts/Admin/src/*.js',
                     'public/javascripts/SVValidate/src/util/*.js',
                     'public/javascripts/common/PanoMarker.js',

--- a/app/views/userProfile.scala.html
+++ b/app/views/userProfile.scala.html
@@ -424,7 +424,6 @@
 
     <!-- Add extra imports for admin version. -->
     @if(admin) {
-        <script src='@assets.path("javascripts/Admin/build/Admin.js")'></script>
         <script src='@assets.path("javascripts/lib/jquery.dataTables.min.js")'></script>
         <script src='@assets.path("javascripts/common/timestampLocalization.js")'></script>
         <script src='@assets.path("javascripts/lib/bootstrap-datepicker-1.9.0.min.js")'></script>


### PR DESCRIPTION
Fixes #4163 

Fixes an issue where the label popup on the /admin/user pages wouldn't work if the label had an AI validation. There was just a missing import!

##### Before/After screenshots (if applicable)
Before
<img width="625" height="918" alt="image" src="https://github.com/user-attachments/assets/a784c5ea-1648-4f77-83fa-be12ba4ceea8" />

After
<img width="625" height="918" alt="image" src="https://github.com/user-attachments/assets/dc5cb2f8-04e1-4975-9396-6dbb163d0add" />

