### PR TITLE
Showing scraped image as backup in Gallery/LabelMap

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -95,6 +95,7 @@ module.exports = function(grunt) {
                     'public/javascripts/common/pano-viewer/src/PanoUtilities.js',
                     'public/javascripts/common/pano-viewer/src/PanoViewer.js',
                     'public/javascripts/common/pano-viewer/src/GsvViewer.js',
+                    'public/javascripts/common/pano-viewer/src/MapillaryChunkedDataProvider.js',
                     'public/javascripts/common/pano-viewer/src/MapillaryViewer.js',
                     'public/javascripts/common/pano-viewer/src/Infra3dViewer.js'
                 ],

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -7,7 +7,7 @@ import formats.json.AdminFormats._
 import formats.json.LabelFormats._
 import formats.json.UserFormats._
 import models.auth.{DefaultEnv, WithAdmin}
-import models.label.{LabelMetadata, LabelTypeEnum}
+import models.label.LabelMetadata
 import models.user.{RoleTable, SidewalkUserWithRole}
 import models.validation.LabelValidationTable
 import org.apache.pekko.actor.ActorSystem
@@ -54,9 +54,10 @@ class AdminController @Inject() (
 
   /** Returns a JsObject with "crop_url" set to the crop image path if the crop exists, or null otherwise. */
   private def cropUrlJson(metadata: LabelMetadata): JsObject = {
-    val cropUrl: Option[String] = LabelTypeEnum.byName.get(metadata.labelType).collect {
-      case lt if panoDataService.cropExists(metadata.labelId, lt) => s"/cropImage/${lt.name}/${metadata.labelId}"
-    }
+    val cropUrl: Option[String] =
+      if (panoDataService.cropExists(metadata.labelId, metadata.labelType))
+        Some(s"/cropImage/${metadata.labelType.name}/${metadata.labelId}")
+      else None
     Json.obj("crop_url" -> cropUrl)
   }
 

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -7,6 +7,7 @@ import formats.json.AdminFormats._
 import formats.json.LabelFormats._
 import formats.json.UserFormats._
 import models.auth.{DefaultEnv, WithAdmin}
+import models.label.{LabelMetadata, LabelTypeEnum}
 import models.user.{RoleTable, SidewalkUserWithRole}
 import models.validation.LabelValidationTable
 import org.apache.pekko.actor.ActorSystem
@@ -50,6 +51,14 @@ class AdminController @Inject() (
   implicit val implicitConfig: Configuration = config
   val dateFormatter: DateTimeFormatter       = DateTimeFormatter.ofPattern("yyyy-MM-dd")
   private val logger                         = Logger(this.getClass)
+
+  /** Returns a JsObject with "crop_url" set to the crop image path if the crop exists, or null otherwise. */
+  private def cropUrlJson(metadata: LabelMetadata): JsObject = {
+    val cropUrl: Option[String] = LabelTypeEnum.byName.get(metadata.labelType).collect {
+      case lt if panoDataService.cropExists(metadata.labelId, lt) => s"/cropImage/${lt.name}/${metadata.labelId}"
+    }
+    Json.obj("crop_url" -> cropUrl)
+  }
 
   /**
    * Loads the admin page.
@@ -284,7 +293,7 @@ class AdminController @Inject() (
         labelService
           .getExtraAdminValidateData(Seq(labelId))
           .map(adminData => {
-            Ok(labelMetadataWithValidationToJsonAdmin(metadata, adminData.head))
+            Ok(labelMetadataWithValidationToJsonAdmin(metadata, adminData.head) ++ cropUrlJson(metadata))
           })
       case None => Future.successful(NotFound(s"No label found with ID: $labelId"))
     }
@@ -295,7 +304,7 @@ class AdminController @Inject() (
    */
   def getLabelData(labelId: Int) = cc.securityService.SecuredAction { implicit request =>
     labelService.getSingleLabelMetadata(labelId, request.identity.userId).map {
-      case Some(metadata) => Ok(labelMetadataWithValidationToJson(metadata))
+      case Some(metadata) => Ok(labelMetadataWithValidationToJson(metadata) ++ cropUrlJson(metadata))
       case None           => NotFound(s"No label found with ID: $labelId")
     }
   }

--- a/app/controllers/AiController.scala
+++ b/app/controllers/AiController.scala
@@ -83,8 +83,8 @@ class AiController @Inject() (
     val prompt = generatePrompt(wayType, cityName)
 
     for {
-      gsvImageUrls   <- panoDataService.getImageUrlsForStreet(streetEdgeId) // Get image URLs for the street
-      imageObjects   <- fetchAndEncodeImages(gsvImageUrls)                  // Fetch and encode images
+      gsvImageUrls   <- panoDataService.getGsvImageUrlsForStreet(streetEdgeId) // Get image URLs for the street
+      imageObjects   <- fetchAndEncodeImages(gsvImageUrls) // Fetch and encode images
       geminiResponse <- sendToGeminiApi(prompt, imageObjects)               // Send to Gemini API
     } yield {
       val activity = s"Analyzing street $streetEdgeId with URLs: ${gsvImageUrls.mkString(", ")}"

--- a/app/controllers/GalleryController.scala
+++ b/app/controllers/GalleryController.scala
@@ -29,7 +29,6 @@ class GalleryController @Inject() (
     configService: ConfigService,
     labelService: LabelService,
     panoDataService: PanoDataService,
-    imageController: ImageController,
     galleryTaskInteractionTable: GalleryTaskInteractionTable,
     galleryTaskEnvironmentTable: GalleryTaskEnvironmentTable,
     regionService: RegionService

--- a/app/controllers/GalleryController.scala
+++ b/app/controllers/GalleryController.scala
@@ -118,7 +118,7 @@ class GalleryController @Inject() (
             val jsonList: Seq[JsObject] = labels.map { l =>
               val cropUrl: Option[String] =
                 if (imageController.cropExists(l.labelId, l.labelType))
-                  Some(s"/cropImage/${l.labelType}/${l.labelId}")
+                  Some(s"/cropImage/${l.labelType.name}/${l.labelId}")
                 else None
               Json.obj(
                 "label"       -> LabelFormats.validationLabelMetadataToJson(l),

--- a/app/controllers/GalleryController.scala
+++ b/app/controllers/GalleryController.scala
@@ -117,7 +117,7 @@ class GalleryController @Inject() (
           .map { labels =>
             val jsonList: Seq[JsObject] = labels.map { l =>
               val cropUrl: Option[String] =
-                if (imageController.cropExists(l.labelId, l.labelType))
+                if (panoDataService.cropExists(l.labelId, l.labelType))
                   Some(s"/cropImage/${l.labelType.name}/${l.labelId}")
                 else None
               Json.obj(

--- a/app/controllers/GalleryController.scala
+++ b/app/controllers/GalleryController.scala
@@ -29,6 +29,7 @@ class GalleryController @Inject() (
     configService: ConfigService,
     labelService: LabelService,
     panoDataService: PanoDataService,
+    imageController: ImageController,
     galleryTaskInteractionTable: GalleryTaskInteractionTable,
     galleryTaskEnvironmentTable: GalleryTaskEnvironmentTable,
     regionService: RegionService
@@ -114,12 +115,18 @@ class GalleryController @Inject() (
         labelService
           .getGalleryLabels(n, labelType, loadedLabels, valOptions, regionIds, severities, tags, aiValOptions, userId)
           .map { labels =>
-            val jsonList: Seq[JsObject] = labels.map(l =>
+            val jsonList: Seq[JsObject] = labels.map { l =>
+              val cropUrl: Option[String] =
+                if (imageController.cropExists(l.labelId, l.labelType))
+                  Some(s"/cropImage/${l.labelType}/${l.labelId}")
+                else None
               Json.obj(
-                "label"    -> LabelFormats.validationLabelMetadataToJson(l),
-                "imageUrl" -> panoDataService.getImageUrl(l.panoId, l.pov.heading, l.pov.pitch, l.pov.zoom)
+                "label"       -> LabelFormats.validationLabelMetadataToJson(l),
+                "cropUrl"     -> cropUrl,
+                "gsvImageUrl" -> panoDataService.getImageUrl(l.panoId, l.panoSource, l.pov.heading, l.pov.pitch,
+                  l.pov.zoom)
               )
-            )
+            }
             val labelList: JsObject = Json.obj("labelsOfType" -> jsonList)
             Ok(labelList)
           }

--- a/app/controllers/ImageController.scala
+++ b/app/controllers/ImageController.scala
@@ -63,7 +63,7 @@ class ImageController @Inject() (cc: CustomControllerComponents, config: Configu
   }
 
   // Creates the base directory for the crops if it doesn't exist. Uses subdirectories /<city-id>/<label-type>.
-  def initializeDirIfNeeded(labelType: String): Unit = {
+  private def initializeDirIfNeeded(labelType: String): Unit = {
     val file = new File(CROPS_DIR_NAME + File.separator + labelType)
     if (!file.exists()) {
       val result = file.mkdirs()
@@ -74,15 +74,17 @@ class ImageController @Inject() (cc: CustomControllerComponents, config: Configu
   }
 
   /** Checks whether a crop image file exists for the given label. */
-  def cropExists(labelId: Int, labelType: String): Boolean = {
-    val file = new File(CROPS_DIR_NAME + File.separator + labelType + File.separator + "crop_" + labelId + ".png")
+  def cropExists(labelId: Int, labelType: LabelTypeEnum.Base): Boolean = {
+    val file = new File(CROPS_DIR_NAME + File.separator + labelType.name + File.separator + "crop_" + labelId + ".png")
     file.exists()
   }
 
   /** Serves a previously-saved crop image for a label. */
   def serveCropImage(labelType: String, labelId: Int) = cc.securityService.SecuredAction { _ =>
     if (!LabelTypeEnum.validLabelTypes.contains(labelType)) {
-      Future.successful(BadRequest("Invalid label type"))
+      Future.successful(
+        BadRequest(s"Invalid label type provided: $labelType. Valid label types are: ${LabelTypeEnum.validLabelTypes.mkString(", ")}.")
+      )
     } else {
       val file = new File(CROPS_DIR_NAME + File.separator + labelType + File.separator + "crop_" + labelId + ".png")
       if (file.exists()) {

--- a/app/controllers/ImageController.scala
+++ b/app/controllers/ImageController.scala
@@ -15,13 +15,13 @@ import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class ImageController @Inject() (cc: CustomControllerComponents, configService: service.ConfigService)(implicit
+class ImageController @Inject() (cc: CustomControllerComponents, panoDataService: service.PanoDataService)(implicit
     ec: ExecutionContext
 ) extends CustomBaseController(cc) {
   private val logger = Logger(this.getClass)
 
   // This is the name of the directory in which all the crops are saved. Subdirectory by city ID.
-  private val CROPS_DIR_NAME = configService.getCropDirectory
+  private val CROPS_DIR_NAME = panoDataService.getCropDirectory
 
   // 2x the actual size of the pano window as retina screen can give us 2x the pixel density.
   val CROP_WIDTH  = 1440

--- a/app/controllers/ImageController.scala
+++ b/app/controllers/ImageController.scala
@@ -2,9 +2,9 @@ package controllers
 
 import controllers.base._
 import models.label.LabelTypeEnum
+import play.api.Logger
 import play.api.libs.json._
 import play.api.mvc.{AnyContent, Request}
-import play.api.{Configuration, Logger}
 
 import java.awt.Image
 import java.awt.image.BufferedImage
@@ -15,12 +15,13 @@ import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class ImageController @Inject() (cc: CustomControllerComponents, config: Configuration)(implicit ec: ExecutionContext)
-    extends CustomBaseController(cc) {
+class ImageController @Inject() (cc: CustomControllerComponents, configService: service.ConfigService)(implicit
+    ec: ExecutionContext
+) extends CustomBaseController(cc) {
   private val logger = Logger(this.getClass)
 
   // This is the name of the directory in which all the crops are saved. Subdirectory by city ID.
-  val CROPS_DIR_NAME = config.get[String]("cropped.image.directory") + File.separator + config.get[String]("city-id")
+  private val CROPS_DIR_NAME = configService.getCropDirectory
 
   // 2x the actual size of the pano window as retina screen can give us 2x the pixel density.
   val CROP_WIDTH  = 1440
@@ -71,12 +72,6 @@ class ImageController @Inject() (cc: CustomControllerComponents, config: Configu
         logger.error("Error creating directory: " + CROPS_DIR_NAME)
       }
     }
-  }
-
-  /** Checks whether a crop image file exists for the given label. */
-  def cropExists(labelId: Int, labelType: LabelTypeEnum.Base): Boolean = {
-    val file = new File(CROPS_DIR_NAME + File.separator + labelType.name + File.separator + "crop_" + labelId + ".png")
-    file.exists()
   }
 
   /** Serves a previously-saved crop image for a label. */

--- a/app/controllers/ImageController.scala
+++ b/app/controllers/ImageController.scala
@@ -1,6 +1,7 @@
 package controllers
 
 import controllers.base._
+import models.label.LabelTypeEnum
 import play.api.libs.json._
 import play.api.mvc.{AnyContent, Request}
 import play.api.{Configuration, Logger}
@@ -11,10 +12,10 @@ import java.io._
 import java.util.Base64
 import javax.imageio.ImageIO
 import javax.inject.{Inject, Singleton}
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class ImageController @Inject() (cc: CustomControllerComponents, config: Configuration)
+class ImageController @Inject() (cc: CustomControllerComponents, config: Configuration)(implicit ec: ExecutionContext)
     extends CustomBaseController(cc) {
   private val logger = Logger(this.getClass)
 
@@ -68,6 +69,26 @@ class ImageController @Inject() (cc: CustomControllerComponents, config: Configu
       val result = file.mkdirs()
       if (!result) {
         logger.error("Error creating directory: " + CROPS_DIR_NAME)
+      }
+    }
+  }
+
+  /** Checks whether a crop image file exists for the given label. */
+  def cropExists(labelId: Int, labelType: String): Boolean = {
+    val file = new File(CROPS_DIR_NAME + File.separator + labelType + File.separator + "crop_" + labelId + ".png")
+    file.exists()
+  }
+
+  /** Serves a previously-saved crop image for a label. */
+  def serveCropImage(labelType: String, labelId: Int) = cc.securityService.SecuredAction { _ =>
+    if (!LabelTypeEnum.validLabelTypes.contains(labelType)) {
+      Future.successful(BadRequest("Invalid label type"))
+    } else {
+      val file = new File(CROPS_DIR_NAME + File.separator + labelType + File.separator + "crop_" + labelId + ".png")
+      if (file.exists()) {
+        Future.successful(Ok.sendFile(file, inline = true).as("image/png"))
+      } else {
+        Future.successful(NotFound("Crop image not found"))
       }
     }
   }

--- a/app/controllers/UserProfileController.scala
+++ b/app/controllers/UserProfileController.scala
@@ -150,9 +150,9 @@ class UserProfileController @Inject() (
           labelService.getRecentValidatedLabelsForUser(userId, labelTypes, n).map { validations =>
             val validationJson = Json.toJson(labelTypes.map { labelType =>
               labelType.name -> validations(labelType).map { l =>
-                val imageUrl: String =
-                  panoDataService.getImageUrl(l.panoId, l.pov.heading, l.pov.pitch, l.pov.zoom)
-                labelMetadataUserDashToJson(l, imageUrl)
+                val gsvImageUrl: Option[String] =
+                  panoDataService.getImageUrl(l.panoId, l.panoSource, l.pov.heading, l.pov.pitch, l.pov.zoom)
+                labelMetadataUserDashToJson(l, gsvImageUrl)
               }
             }.toMap)
             Ok(validationJson)

--- a/app/formats/json/LabelFormats.scala
+++ b/app/formats/json/LabelFormats.scala
@@ -8,6 +8,8 @@ import play.api.libs.json._
 import java.time.OffsetDateTime
 
 object LabelFormats {
+  implicit val labelTypeEnumWrites: Writes[LabelTypeEnum.Base] = Writes(lt => JsString(lt.name))
+
   implicit val labelWrites: Writes[Label] = (
     (__ \ "label_id").write[Int] and
       (__ \ "audit_task_id").write[Int] and
@@ -62,30 +64,33 @@ object LabelFormats {
     }
   }
 
-  implicit val labelMetadataWrites: Writes[LabelMetadata] = (
-    (__ \ "label_id").write[Int] and
-      (__ \ "pano_id").write[String] and
-      (__ \ "tutorial").write[Boolean] and
-      (__ \ "image_capture_date").write[String] and
-      (__ \ "pov").write[POV] and
-      (__ \ "canvas_location").write[LocationXY] and
-      (__ \ "audit_task_id").write[Int] and
-      (__ \ "street_edge_id").write[Int] and
-      (__ \ "region_id").write[Int] and
-      (__ \ "user_id").write[String] and
-      (__ \ "username").write[String] and
-      (__ \ "timestamp").write[OffsetDateTime] and
-      (__ \ "label_type").write[String] and
-      (__ \ "severity").write[Option[Int]] and
-      (__ \ "description").write[Option[String]] and
-      (__ \ "user_validation").write[Option[Int]] and
-      (__ \ "ai_validation").write[Option[Int]] and
-      (__ \ "validations").write[Map[String, Int]] and
-      (__ \ "tags").write[List[String]] and
-      (__ \ "low_quality_incomplete_stale_flags").write[(Boolean, Boolean, Boolean)] and
-      (__ \ "comments").write[Option[Seq[String]]] and
-      (__ \ "ai_generated").write[Boolean]
-  )(unlift(LabelMetadata.unapply))
+  implicit val labelMetadataWrites: Writes[LabelMetadata] = Writes { m =>
+    Json.obj(
+      "label_id"                           -> m.labelId,
+      "pano_id"                            -> m.panoId,
+      "tutorial"                           -> m.tutorial,
+      "image_capture_date"                 -> m.imageCaptureDate,
+      "pov"                                -> m.pov,
+      "canvas_location"                    -> m.canvasXY,
+      "audit_task_id"                      -> m.auditTaskId,
+      "street_edge_id"                     -> m.streetEdgeId,
+      "region_id"                          -> m.regionId,
+      "user_id"                            -> m.userId,
+      "username"                           -> m.username,
+      "timestamp"                          -> m.timestamp,
+      "label_type"                         -> m.labelType,
+      "severity"                           -> m.severity,
+      "description"                        -> m.description,
+      "user_validation"                    -> m.userValidation,
+      "ai_validation"                      -> m.aiValidation,
+      "validations"                        -> m.validations,
+      "tags"                               -> m.tags,
+      "low_quality_incomplete_stale_flags" -> m.lowQualityIncompleteStaleFlags,
+      "comments"                           -> m.comments,
+      "ai_generated"                       -> m.aiGenerated,
+      "expired"                            -> m.expired
+    )
+  }
 
   def validationLabelMetadataToJson(
       labelMetadata: LabelValidationMetadata,
@@ -148,7 +153,7 @@ object LabelFormats {
       "street_edge_id"     -> labelMetadata.streetEdgeId,
       "region_id"          -> labelMetadata.regionId,
       "timestamp"          -> labelMetadata.timestamp,
-      "label_type"         -> labelMetadata.labelType,
+      "label_type"         -> labelMetadata.labelType.name,
       "severity"           -> labelMetadata.severity,
       "description"        -> labelMetadata.description,
       "user_validation"    -> labelMetadata.userValidation.map(LabelValidationTable.validationOptions.get),
@@ -158,7 +163,8 @@ object LabelFormats {
       "num_unsure"         -> labelMetadata.validations("unsure"),
       "comments"           -> labelMetadata.comments,
       "tags"               -> labelMetadata.tags,
-      "ai_generated"       -> labelMetadata.aiGenerated
+      "ai_generated"       -> labelMetadata.aiGenerated,
+      "expired"            -> labelMetadata.expired
     )
   }
 

--- a/app/formats/json/LabelFormats.scala
+++ b/app/formats/json/LabelFormats.scala
@@ -93,7 +93,7 @@ object LabelFormats {
   ): JsObject = {
     Json.obj(
       "label_id"           -> labelMetadata.labelId,
-      "label_type"         -> labelMetadata.labelType,
+      "label_type"         -> labelMetadata.labelType.name,
       "pano_id"            -> labelMetadata.panoId,
       "image_capture_date" -> labelMetadata.imageCaptureDate,
       "label_timestamp"    -> labelMetadata.timestamp,
@@ -193,7 +193,7 @@ object LabelFormats {
       "zoom"              -> label.pov.zoom,
       "canvas_x"          -> label.canvasX,
       "canvas_y"          -> label.canvasY,
-      "label_type"        -> label.labelType,
+      "label_type"        -> label.labelType.name,
       "time_validated"    -> label.timeValidated,
       "validator_comment" -> label.validatorComment,
       "image_url"         -> imageUrl

--- a/app/formats/json/LabelFormats.scala
+++ b/app/formats/json/LabelFormats.scala
@@ -184,7 +184,7 @@ object LabelFormats {
     )
   }
 
-  def labelMetadataUserDashToJson(label: LabelMetadataUserDash, imageUrl: String): JsObject = {
+  def labelMetadataUserDashToJson(label: LabelMetadataUserDash, imageUrl: Option[String]): JsObject = {
     Json.obj(
       "label_id"          -> label.labelId,
       "pano_id"           -> label.panoId,

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -135,7 +135,7 @@ case class LabelMetadata(
     userId: String,
     username: String,
     timestamp: OffsetDateTime,
-    labelType: String,
+    labelType: LabelTypeEnum.Base,
     severity: Option[Int],
     description: Option[String],
     userValidation: Option[Int],
@@ -144,7 +144,8 @@ case class LabelMetadata(
     tags: List[String],
     lowQualityIncompleteStaleFlags: (Boolean, Boolean, Boolean),
     comments: Option[Seq[String]],
-    aiGenerated: Boolean
+    aiGenerated: Boolean,
+    expired: Boolean
 )
 
 // Extra data to include with validations for Expert Validate. Includes usernames and previous validators.
@@ -555,7 +556,7 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
       r.nextString(),
       r.nextString(),
       OffsetDateTime.ofInstant(r.nextTimestamp().toInstant, ZoneOffset.UTC),
-      r.nextString(),
+      LabelTypeEnum.byName(r.nextString()),
       r.nextIntOption(),
       r.nextStringOption(),
       r.nextIntOption(), // userValidation
@@ -564,6 +565,7 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
       r.nextString().split(",").filter(_.nonEmpty).toList,
       (r.nextBoolean(), r.nextBoolean(), r.nextBoolean()),
       r.nextStringOption().filter(_.nonEmpty).map(_.split(":").filter(_.nonEmpty).toSeq),
+      r.nextBoolean(),
       r.nextBoolean()
     )
   }
@@ -756,7 +758,8 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
              at.incomplete,
              at.stale,
              comment.comments,
-             r.role = 'AI' AS ai_generated
+             r.role = 'AI' AS ai_generated,
+             pano_data.expired
       FROM label AS lb1
       INNER JOIN pano_data ON lb1.pano_id = pano_data.pano_id
       INNER JOIN audit_task AS at ON lb1.audit_task_id = at.audit_task_id

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -116,7 +116,7 @@ case class LabelCount(count: Int, timeInterval: TimeInterval, labelType: String)
 // Defines some common fields for a label metadata, which allows us to create generic functions using these fields.
 trait BasicLabelMetadata {
   val labelId: Int
-  val labelType: String
+  val labelType: LabelTypeEnum.Base
   val panoId: String
   val panoSource: PanoSource
   val pov: POV
@@ -202,7 +202,7 @@ case class LabelMetadataUserDash(
     pov: POV,
     canvasX: Int,
     canvasY: Int,
-    labelType: String,
+    labelType: LabelTypeEnum.Base,
     timeValidated: OffsetDateTime,
     validatorComment: Option[String]
 ) extends BasicLabelMetadata
@@ -210,7 +210,7 @@ case class LabelMetadataUserDash(
 // NOTE: canvas_x and canvas_y are null when the label is not visible when validation occurs.
 case class LabelValidationMetadata(
     labelId: Int,
-    labelType: String,
+    labelType: LabelTypeEnum.Base,
     panoId: String,
     panoSource: PanoSource,
     imageCaptureDate: String,
@@ -301,7 +301,7 @@ object LabelTable {
   implicit val labelMetadataUserDashConverter: TupleConverter[LabelMetadataUserDashTuple, LabelMetadataUserDash] =
     new TupleConverter[LabelMetadataUserDashTuple, LabelMetadataUserDash] {
       def fromTuple(t: LabelMetadataUserDashTuple): LabelMetadataUserDash =
-        LabelMetadataUserDash(t._1, t._2, t._3, POV.tupled(t._4), t._5, t._6, t._7, t._8, t._9)
+        LabelMetadataUserDash(t._1, t._2, t._3, POV.tupled(t._4), t._5, t._6, LabelTypeEnum.byName(t._7), t._8, t._9)
     }
 
   // Type aliases for the tuple representation of LabelValidationMetadata and queries for them.
@@ -359,8 +359,9 @@ object LabelTable {
   implicit val labelValidationMetadataConverter: TupleConverter[LabelValidationMetadataTuple, LabelValidationMetadata] =
     new TupleConverter[LabelValidationMetadataTuple, LabelValidationMetadata] {
       def fromTuple(t: LabelValidationMetadataTuple): LabelValidationMetadata = LabelValidationMetadata(
-        t._1, t._2, t._3, t._4, t._5, t._6, t._7.get, t._8.get, POV.tupled(t._9), LocationXY.tupled(t._10), t._11,
-        t._12, t._13, t._14, LabelValidationInfo.tupled(t._15), t._16, t._17, t._18, t._19, t._20, t._21, t._22
+        t._1, LabelTypeEnum.byName(t._2), t._3, t._4, t._5, t._6, t._7.get, t._8.get, POV.tupled(t._9),
+        LocationXY.tupled(t._10), t._11, t._12, t._13, t._14, LabelValidationInfo.tupled(t._15), t._16, t._17, t._18,
+        t._19, t._20, t._21, t._22
       )
     }
 

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -118,6 +118,7 @@ trait BasicLabelMetadata {
   val labelId: Int
   val labelType: String
   val panoId: String
+  val panoSource: PanoSource
   val pov: POV
 }
 
@@ -197,6 +198,7 @@ case class LabelDataForAi(labelId: Int, labelTypeId: Int, labelPoint: LabelPoint
 case class LabelMetadataUserDash(
     labelId: Int,
     panoId: String,
+    panoSource: PanoSource,
     pov: POV,
     canvasX: Int,
     canvasY: Int,
@@ -210,6 +212,7 @@ case class LabelValidationMetadata(
     labelId: Int,
     labelType: String,
     panoId: String,
+    panoSource: PanoSource,
     imageCaptureDate: String,
     timestamp: OffsetDateTime,
     lat: Double,
@@ -281,10 +284,11 @@ object LabelTable {
   // Type aliases for the tuple representation of LabelMetadataUserDash and queries for them.
   // TODO in Scala 3 I think that we can make these top-level like we do for the case class version.
   type LabelMetadataUserDashTuple =
-    (Int, String, (Double, Double, Double), Int, Int, String, OffsetDateTime, Option[String])
+    (Int, String, PanoSource, (Double, Double, Double), Int, Int, String, OffsetDateTime, Option[String])
   type LabelMetadataUserDashTupleRep = (
       Rep[Int],                                // labelId
       Rep[String],                             // panoId
+      Rep[PanoSource],                         // panoSource
       (Rep[Double], Rep[Double], Rep[Double]), // pov (heading, pitch, zoom)
       Rep[Int],                                // canvasX
       Rep[Int],                                // canvasY
@@ -297,7 +301,7 @@ object LabelTable {
   implicit val labelMetadataUserDashConverter: TupleConverter[LabelMetadataUserDashTuple, LabelMetadataUserDash] =
     new TupleConverter[LabelMetadataUserDashTuple, LabelMetadataUserDash] {
       def fromTuple(t: LabelMetadataUserDashTuple): LabelMetadataUserDash =
-        LabelMetadataUserDash(t._1, t._2, POV.tupled(t._3), t._4, t._5, t._6, t._7, t._8)
+        LabelMetadataUserDash(t._1, t._2, t._3, POV.tupled(t._4), t._5, t._6, t._7, t._8, t._9)
     }
 
   // Type aliases for the tuple representation of LabelValidationMetadata and queries for them.
@@ -306,6 +310,7 @@ object LabelTable {
       Int,                              // labelId
       String,                           // labelType
       String,                           // panoId
+      PanoSource,                       // panoSource
       String,                           // imageCaptureDate
       OffsetDateTime,                   // timestamp
       Option[Double],                   // lat
@@ -329,6 +334,7 @@ object LabelTable {
       Rep[Int],                                             // labelId
       Rep[String],                                          // labelType
       Rep[String],                                          // panoId
+      Rep[PanoSource],                                      // panoSource
       Rep[String],                                          // imageCaptureDate
       Rep[OffsetDateTime],                                  // timestamp
       Rep[Option[Double]],                                  // lat
@@ -353,8 +359,8 @@ object LabelTable {
   implicit val labelValidationMetadataConverter: TupleConverter[LabelValidationMetadataTuple, LabelValidationMetadata] =
     new TupleConverter[LabelValidationMetadataTuple, LabelValidationMetadata] {
       def fromTuple(t: LabelValidationMetadataTuple): LabelValidationMetadata = LabelValidationMetadata(
-        t._1, t._2, t._3, t._4, t._5, t._6.get, t._7.get, POV.tupled(t._8), LocationXY.tupled(t._9), t._10, t._11,
-        t._12, t._13, LabelValidationInfo.tupled(t._14), t._15, t._16, t._17, t._18, t._19, t._20, t._21
+        t._1, t._2, t._3, t._4, t._5, t._6, t._7.get, t._8.get, POV.tupled(t._9), LocationXY.tupled(t._10), t._11,
+        t._12, t._13, t._14, LabelValidationInfo.tupled(t._15), t._16, t._17, t._18, t._19, t._20, t._21, t._22
       )
     }
 
@@ -920,6 +926,7 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
           l.labelId,
           labelType,
           l.panoId,
+          pd.source,
           pd.captureDate,
           l.timeCreated,
           lp.lat,
@@ -1062,6 +1069,7 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
       lb.labelId,
       labelType,
       lb.panoId,
+      pd.source,
       pd.captureDate,
       lb.timeCreated,
       lp.lat,
@@ -1131,6 +1139,7 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
     } yield (
       _lb.labelId,
       _lb.panoId,
+      _pd.source,
       (_lp.heading.asColumnOf[Double], _lp.pitch.asColumnOf[Double], _lp.zoom.asColumnOf[Double]),
       _lp.canvasX,
       _lp.canvasY,

--- a/app/service/AiService.scala
+++ b/app/service/AiService.scala
@@ -213,7 +213,7 @@ class AiServiceImpl @Inject() (
           } else {
             logger.warn(s"AI API for label $labelId returned error status: ${response.status} - ${response.statusText}")
             // Most common failure is for expired imagery, so do that check and mark it as expired here.
-            Await.result(panoDataService.panoExists(labelData.panoData.panoId), 5.seconds)
+            Await.result(panoDataService.panoExists(labelData.panoData.panoId, labelData.panoData.source), 5.seconds)
             None
           }
         } catch {

--- a/app/service/ConfigService.scala
+++ b/app/service/ConfigService.scala
@@ -14,7 +14,6 @@ import play.api.libs.ws.WSClient
 import play.api.{Configuration, Logger}
 import slick.dbio.DBIO
 
-import java.io.File
 import java.time.OffsetDateTime
 import javax.inject._
 import scala.concurrent.duration.Duration
@@ -128,7 +127,6 @@ trait ConfigService {
   def getCityName(lang: Lang): String
   def getAiTagSuggestionsEnabled: Boolean
   def getPanoSource: PanoSource
-  def getCropDirectory: String
   def sendSciStarterContributions(email: String, contributions: Int, timeSpent: Double): Future[Int]
   def cachedDBIO[T: ClassTag](key: String, duration: Duration = Duration.Inf)(dbOperation: => DBIO[T]): DBIO[T]
   def getCommonPageData(lang: Lang): Future[CommonPageData]
@@ -583,9 +581,6 @@ class ConfigServiceImpl @Inject() (
   def getAiTagSuggestionsEnabled: Boolean = config.get[Boolean](s"city-params.ai-tag-suggestions-enabled.$getCityId")
 
   def getPanoSource: PanoSource = PanoSource.withName(config.get[String](s"city-params.pano-viewer-type.$getCityId"))
-
-  def getCropDirectory: String =
-    config.get[String]("cropped.image.directory") + File.separator + config.get[String]("city-id")
 
   // Uses Play's cache API to cache the result of a DBIO.
   def cachedDBIO[T: ClassTag](key: String, duration: Duration = Duration.Inf)(dbOperation: => DBIO[T]): DBIO[T] = {

--- a/app/service/ConfigService.scala
+++ b/app/service/ConfigService.scala
@@ -14,6 +14,7 @@ import play.api.libs.ws.WSClient
 import play.api.{Configuration, Logger}
 import slick.dbio.DBIO
 
+import java.io.File
 import java.time.OffsetDateTime
 import javax.inject._
 import scala.concurrent.duration.Duration
@@ -127,6 +128,7 @@ trait ConfigService {
   def getCityName(lang: Lang): String
   def getAiTagSuggestionsEnabled: Boolean
   def getPanoSource: PanoSource
+  def getCropDirectory: String
   def sendSciStarterContributions(email: String, contributions: Int, timeSpent: Double): Future[Int]
   def cachedDBIO[T: ClassTag](key: String, duration: Duration = Duration.Inf)(dbOperation: => DBIO[T]): DBIO[T]
   def getCommonPageData(lang: Lang): Future[CommonPageData]
@@ -581,6 +583,9 @@ class ConfigServiceImpl @Inject() (
   def getAiTagSuggestionsEnabled: Boolean = config.get[Boolean](s"city-params.ai-tag-suggestions-enabled.$getCityId")
 
   def getPanoSource: PanoSource = PanoSource.withName(config.get[String](s"city-params.pano-viewer-type.$getCityId"))
+
+  def getCropDirectory: String =
+    config.get[String]("cropped.image.directory") + File.separator + config.get[String]("city-id")
 
   // Uses Play's cache API to cache the result of a DBIO.
   def cachedDBIO[T: ClassTag](key: String, duration: Duration = Duration.Inf)(dbOperation: => DBIO[T]): DBIO[T] = {

--- a/app/service/LabelService.scala
+++ b/app/service/LabelService.scala
@@ -113,9 +113,9 @@ class LabelServiceImpl @Inject() (
   private val cropsDirName: String =
     config.get[String]("cropped.image.directory") + java.io.File.separator + config.get[String]("city-id")
 
-  private def cropExists(labelId: Int, labelType: String): Boolean = {
+  private def cropExists(labelId: Int, labelType: LabelTypeEnum.Base): Boolean = {
     val file = new java.io.File(
-      cropsDirName + java.io.File.separator + labelType + java.io.File.separator + "crop_" + labelId + ".png"
+      cropsDirName + java.io.File.separator + labelType.name + java.io.File.separator + "crop_" + labelId + ".png"
     )
     file.exists()
   }

--- a/app/service/LabelService.scala
+++ b/app/service/LabelService.scala
@@ -96,7 +96,6 @@ trait LabelService {
 @Singleton
 class LabelServiceImpl @Inject() (
     protected val dbConfigProvider: DatabaseConfigProvider,
-    config: play.api.Configuration,
     configService: ConfigService,
     panoDataService: PanoDataService,
     labelTable: LabelTable,
@@ -109,16 +108,6 @@ class LabelServiceImpl @Inject() (
     with HasDatabaseConfigProvider[MyPostgresProfile] {
 
   private val logger = Logger(this.getClass)
-
-  private val cropsDirName: String =
-    config.get[String]("cropped.image.directory") + java.io.File.separator + config.get[String]("city-id")
-
-  private def cropExists(labelId: Int, labelType: LabelTypeEnum.Base): Boolean = {
-    val file = new java.io.File(
-      cropsDirName + java.io.File.separator + labelType.name + java.io.File.separator + "crop_" + labelId + ".png"
-    )
-    file.exists()
-  }
 
   def countLabels: Future[Int] = db.run(labelTable.countLabels)
 
@@ -330,7 +319,7 @@ class LabelServiceImpl @Inject() (
   private def checkImageryBatch[A <: BasicLabelMetadata](labels: Seq[A], useCrops: Boolean): Future[Seq[A]] = {
     if (useCrops) {
       // Partition: labels with local crops pass immediately; the rest are checked via panoExists().
-      val (withCrop, withoutCrop) = labels.partition(l => cropExists(l.labelId, l.labelType))
+      val (withCrop, withoutCrop) = labels.partition(l => panoDataService.cropExists(l.labelId, l.labelType))
       Future
         .traverse(withoutCrop) { label =>
           panoDataService.panoExists(label.panoId, label.panoSource).map {

--- a/app/service/LabelService.scala
+++ b/app/service/LabelService.scala
@@ -7,7 +7,6 @@ import models.label.LabelTable._
 import models.label.LabelTypeEnum.labelTypeToId
 import models.label.{Tag, _}
 import models.mission.{Mission, MissionTable}
-import models.pano.PanoSource
 import models.pano.PanoSource.PanoSource
 import models.user.SidewalkUserWithRole
 import models.utils.CommonUtils.UiSource
@@ -97,6 +96,7 @@ trait LabelService {
 @Singleton
 class LabelServiceImpl @Inject() (
     protected val dbConfigProvider: DatabaseConfigProvider,
+    config: play.api.Configuration,
     configService: ConfigService,
     panoDataService: PanoDataService,
     labelTable: LabelTable,
@@ -109,6 +109,16 @@ class LabelServiceImpl @Inject() (
     with HasDatabaseConfigProvider[MyPostgresProfile] {
 
   private val logger = Logger(this.getClass)
+
+  private val cropsDirName: String =
+    config.get[String]("cropped.image.directory") + java.io.File.separator + config.get[String]("city-id")
+
+  private def cropExists(labelId: Int, labelType: String): Boolean = {
+    val file = new java.io.File(
+      cropsDirName + java.io.File.separator + labelType + java.io.File.separator + "crop_" + labelId + ".png"
+    )
+    file.exists()
+  }
 
   def countLabels: Future[Int] = db.run(labelTable.countLabels)
 
@@ -202,13 +212,14 @@ class LabelServiceImpl @Inject() (
   ): Future[Seq[LabelValidationMetadata]] = {
     val viewer: PanoSource = configService.getPanoSource
 
-    // If a label type is specified, get labels for that type. Otherwise, get labels for all types.
+    // If a label type is specified, get labels for that type. Otherwise, get labels for all types. Include useCrops so
+    // that labels with expired or non-Google imagery are still included if a local crop exists.
     if (labelType.isDefined) {
       findValidLabelsForType(
-        viewer,
         labelTable.getGalleryLabelsQuery(viewer, labelType.get, loadedLabelIds, valOptions, regionIds, severity, tags,
           aiValOptions, userId),
         randomize = true,
+        useCrops = true,
         n
       )
     } else {
@@ -217,10 +228,10 @@ class LabelServiceImpl @Inject() (
       Future
         .sequence(LabelTypeEnum.primaryLabelTypes.map { labelType =>
           findValidLabelsForType(
-            viewer,
             labelTable.getGalleryLabelsQuery(viewer, labelType, loadedLabelIds, valOptions, regionIds, severity, tags,
               aiValOptions, userId),
             randomize = true,
+            useCrops = true,
             nPerType
           )
         })
@@ -254,28 +265,28 @@ class LabelServiceImpl @Inject() (
   ): Future[Seq[LabelValidationMetadata]] = {
     // TODO can we make this and the Gallery queries transactions to prevent label dupes?
     findValidLabelsForType(
-      viewer,
       labelTable.retrieveLabelListForValidationQuery(userId, viewer, labelTypeId,
         configService.getAiTagSuggestionsEnabled, userIds, regionIds, unvalidatedOnly, skippedLabelId),
       randomize = true,
+      useCrops = false,
       n
     )
   }
 
   /**
    * Query labels from the db in batches until we have enough labels that have imagery available. Works recursively.
-   * @param viewer The type of pano viewer the labels must have been added on (GSV, Mapillary, etc).
    * @param labelQuery Query to get labels from the db.
    * @param randomize Whether to randomize the label order or not.
+   * @param useCrops If true, local static crop of pano around the label also works as well as an API call.
    * @param remaining Number of labels remaining to get.
    * @param batchNumber Batch number we're on, used to paginate the query.
    * @param accumulator Accumulator of labels we've found so far.
    * @param tupleConverter Implicit converter to convert the tuple from the db to the appropriate case class.
    */
   private def findValidLabelsForType[A <: BasicLabelMetadata, TupleRep, Tuple](
-      viewer: PanoSource,
       labelQuery: Query[TupleRep, Tuple, Seq],
       randomize: Boolean,
+      useCrops: Boolean,
       remaining: Int,
       batchNumber: Int = 0,
       accumulator: Seq[A] = Seq.empty
@@ -292,20 +303,17 @@ class LabelServiceImpl @Inject() (
           // Randomize the labels to prevent similar labels in a mission.
           val shuffledLabels: Seq[A] = if (randomize) scala.util.Random.shuffle(labels) else labels
 
-          // Check each of those labels for GSV imagery in parallel. Only doing the check for GSV imagery for now.
-          // TODO maybe we include viewer in BasicLabelMetadata and sort it out in checkImageryBatch() instead?
-          val imageryCheck: Future[Seq[A]] =
-            if (viewer == PanoSource.Gsv) checkImageryBatch(shuffledLabels) else Future.successful(shuffledLabels)
-          imageryCheck.flatMap { validLabels =>
+          // Check for valid imagery in parallel.
+          checkImageryBatch(shuffledLabels, useCrops).flatMap { validLabels =>
             if (validLabels.isEmpty) {
               Future.successful(accumulator) // No more valid labels found.
             } else {
               // Add the valid labels to the accumulator and recurse.
               val newValidLabels = validLabels.take(remaining)
               findValidLabelsForType(
-                viewer,
                 labelQuery,
                 randomize,
+                useCrops,
                 remaining - newValidLabels.size,
                 batchNumber + 1,
                 accumulator ++ newValidLabels
@@ -316,16 +324,31 @@ class LabelServiceImpl @Inject() (
     }
   }
 
-  // Checks each label in a batch for GSV imagery in parallel.
-  private def checkImageryBatch[A <: BasicLabelMetadata](labels: Seq[A]): Future[Seq[A]] = {
-    Future
-      .traverse(labels) { label =>
-        panoDataService.panoExists(label.panoId).map {
-          case Some(true) => Some(label)
-          case _          => None
+  // Checks each label in a batch for imagery availability. When useCrops is true, labels with a locally-saved crop
+  // image are accepted without querying the API; only labels lacking a crop are checked. When useCrops is false, all
+  // labels are checked via panoExists(), which returns Some(false) for non-GSV labels.
+  private def checkImageryBatch[A <: BasicLabelMetadata](labels: Seq[A], useCrops: Boolean): Future[Seq[A]] = {
+    if (useCrops) {
+      // Partition: labels with local crops pass immediately; the rest are checked via panoExists().
+      val (withCrop, withoutCrop) = labels.partition(l => cropExists(l.labelId, l.labelType))
+      Future
+        .traverse(withoutCrop) { label =>
+          panoDataService.panoExists(label.panoId, label.panoSource).map {
+            case Some(true) => Some(label)
+            case _          => None
+          }
         }
-      }
-      .map(_.flatten)
+        .map(results => withCrop ++ results.flatten)
+    } else {
+      Future
+        .traverse(labels) { label =>
+          panoDataService.panoExists(label.panoId, label.panoSource).map {
+            case Some(true) => Some(label)
+            case _          => None
+          }
+        }
+        .map(_.flatten)
+    }
   }
 
   /**
@@ -503,9 +526,9 @@ class LabelServiceImpl @Inject() (
     Future
       .sequence(labelTypes.map { labelType =>
         findValidLabelsForType(
-          PanoSource.Gsv,
           labelTable.getValidatedLabelsForUserQuery(userId, labelType),
           randomize = false,
+          useCrops = false,
           nPerType
         )
           .map(labels => (labelType, labels))

--- a/app/service/PanoDataService.scala
+++ b/app/service/PanoDataService.scala
@@ -17,7 +17,7 @@ import play.api.{Configuration, Logger}
 import service.PanoDataService.getFov
 import slick.dbio.DBIO
 
-import java.io.IOException
+import java.io.{File, IOException}
 import java.net.{SocketTimeoutException, URL}
 import java.time.OffsetDateTime
 import java.util.Base64
@@ -155,6 +155,7 @@ trait PanoDataService {
   def insertPanoHistories(histories: Seq[PanoHistorySubmission]): Future[Unit]
   def getAllPanos: Future[Seq[PanoDataSlim]]
   def checkForImagery: Future[String]
+  def getCropDirectory: String
   def cropExists(labelId: Int, labelType: LabelTypeEnum.Base): Boolean
 }
 
@@ -165,7 +166,6 @@ class PanoDataServiceImpl @Inject() (
     cacheApi: AsyncCacheApi,
     ws: WSClient,
     implicit val ec: ExecutionContext,
-    configService: ConfigService,
     panoDataTable: PanoDataTable,
     panoHistoryTable: PanoHistoryTable,
     streetEdgeTable: models.street.StreetEdgeTable
@@ -184,7 +184,7 @@ class PanoDataServiceImpl @Inject() (
   // Get an HMAC-SHA1 signing key from the raw key bytes.
   val sha1Key: SecretKeySpec = new SecretKeySpec(secretKey, "HmacSHA1")
 
-  private val cropsDirName: String = configService.getCropDirectory
+  private val cropsDirName: String = getCropDirectory
 
   def getInfra3dToken: Future[String] = {
     // Token expires after 60 minutes, so we don't need to get a new token every time.
@@ -394,6 +394,9 @@ class PanoDataServiceImpl @Inject() (
       }
     ).flatten
   }
+
+  def getCropDirectory: String =
+    config.get[String]("cropped.image.directory") + File.separator + config.get[String]("city-id")
 
   /** Checks whether a crop image file exists for the given label. */
   def cropExists(labelId: Int, labelType: LabelTypeEnum.Base): Boolean = {

--- a/app/service/PanoDataService.scala
+++ b/app/service/PanoDataService.scala
@@ -3,7 +3,8 @@ package service
 import com.google.inject.ImplementedBy
 import formats.json.PanoFormats.PanoHistorySubmission
 import models.label.{LabelPointTable, POV}
-import models.pano.{PanoDataSlim, PanoDataTable, PanoHistory, PanoHistoryTable}
+import models.pano.PanoSource.PanoSource
+import models.pano._
 import models.street.StreetEdge
 import models.utils.{CommonUtils, MyPostgresProfile}
 import org.locationtech.jts.geom.Point
@@ -148,9 +149,9 @@ object PanoDataService {
 @ImplementedBy(classOf[PanoDataServiceImpl])
 trait PanoDataService {
   def getInfra3dToken: Future[String]
-  def panoExists(panoId: String): Future[Option[Boolean]]
-  def getImageUrl(panoId: String, heading: Double, pitch: Double, zoom: Double): String
-  def getImageUrlsForStreet(streetEdgeId: Int): Future[Seq[String]]
+  def panoExists(panoId: String, panoSource: PanoSource): Future[Option[Boolean]]
+  def getImageUrl(panoId: String, panoSrc: PanoSource, heading: Double, pitch: Double, zoom: Double): Option[String]
+  def getGsvImageUrlsForStreet(streetEdgeId: Int): Future[Seq[String]]
   def insertPanoHistories(histories: Seq[PanoHistorySubmission]): Future[Unit]
   def getAllPanos: Future[Seq[PanoDataSlim]]
   def checkForImagery: Future[String]
@@ -171,7 +172,8 @@ class PanoDataServiceImpl @Inject() (
 
   private val logger = Logger(this.getClass)
 
-  // Grab secret from ENV variable.
+  // Grab API key and secret from ENV variable.
+  val googleApiKey: String    = config.get[String]("google-maps-api-key")
   val secretKeyString: String = config.get[String]("google-maps-secret")
 
   // Decode secret key as Byte[].
@@ -212,12 +214,11 @@ class PanoDataServiceImpl @Inject() (
    * @param panoId  Panorama ID
    * @return        True if the panorama exists, false otherwise
    */
-  def panoExists(panoId: String): Future[Option[Boolean]] = {
-    val url =
-      s"https://maps.googleapis.com/maps/api/streetview/metadata?pano=$panoId&key=${config.get[String]("google-maps-api-key")}"
-    val signedUrl = signUrl(url)
+  def panoExists(panoId: String, panoSource: PanoSource): Future[Option[Boolean]] = {
+    if (panoSource != PanoSource.Gsv) return Future.successful(Some(false))
 
-    ws.url(signedUrl)
+    val url = signUrl(s"https://maps.googleapis.com/maps/api/streetview/metadata?pano=$panoId&key=$googleApiKey")
+    ws.url(url)
       .withRequestTimeout(5.seconds)
       .get()
       .flatMap { response =>
@@ -273,20 +274,23 @@ class PanoDataServiceImpl @Inject() (
    * More information here: https://developers.google.com/maps/documentation/streetview/intro
    *
    * @param panoId Id of gsv pano.
+   * @param panoSrc The type of pano viewer the labels must have been added on (GSV, Mapillary, etc).
    * @param heading Compass heading of the camera.
    * @param pitch Up or down angle of the camera relative to the vehicle.
    * @param zoom Zoom level of the canvas (for fov calculation).
    * @return Image URL that represents the background of the label.
    */
-  def getImageUrl(panoId: String, heading: Double, pitch: Double, zoom: Double): String = {
+  def getImageUrl(panoId: String, panoSrc: PanoSource, heading: Double, pitch: Double, zoom: Double): Option[String] = {
+    if (panoSrc != PanoSource.Gsv) return None
+
     val url = "https://maps.googleapis.com/maps/api/streetview?" +
       "pano=" + panoId +
       "&size=" + LabelPointTable.canvasWidth + "x" + LabelPointTable.canvasHeight +
       "&heading=" + heading +
       "&pitch=" + pitch +
       "&fov=" + getFov(zoom) +
-      "&key=" + config.get[String]("google-maps-api-key")
-    signUrl(url)
+      "&key=" + googleApiKey
+    Some(signUrl(url))
   }
 
   /**
@@ -299,7 +303,7 @@ class PanoDataServiceImpl @Inject() (
    * @param heading Compass heading of the camera
    * @return GSV Static API URL for the given location and heading
    */
-  def getImageUrlFromLatLng(lat: Double, lng: Double, heading: Double): String = {
+  def getGsvImageUrlFromLatLng(lat: Double, lng: Double, heading: Double): String = {
     val url = "https://maps.googleapis.com/maps/api/streetview?" +
       "location=" + lat + "," + lng +
       "&radius=40" + // Search as far as 40 meters from the given lat/lng, same as we use on the frontend
@@ -309,7 +313,7 @@ class PanoDataServiceImpl @Inject() (
       "&pitch=-10" + // Default pitch of -10 degrees, facing slightly downwards towards the ground
       "&fov=90" +
       "&return_error_code=true" +
-      "&key=" + config.get[String]("google-maps-api-key")
+      "&key=" + googleApiKey
     signUrl(url)
   }
 
@@ -318,7 +322,7 @@ class PanoDataServiceImpl @Inject() (
    * @param streetEdgeId ID of the street edge to get image URLs for
    * @return A sequence of image URLs for the start and end points of the street edge
    */
-  def getImageUrlsForStreet(streetEdgeId: Int): Future[Seq[String]] = {
+  def getGsvImageUrlsForStreet(streetEdgeId: Int): Future[Seq[String]] = {
     db.run(for {
       streetOption: Option[StreetEdge] <- streetEdgeTable.getStreet(streetEdgeId)
       startDir: Option[Double]         <- streetEdgeTable.directionFromStart(streetEdgeId)
@@ -328,8 +332,8 @@ class PanoDataServiceImpl @Inject() (
         val startPoint: Point = street.geom.getStartPoint
         val endPoint: Point   = street.geom.getEndPoint
         Seq(
-          startDir.map(sd => getImageUrlFromLatLng(startPoint.getY, startPoint.getX, Math.toDegrees(sd))),
-          endDir.map(ed => getImageUrlFromLatLng(endPoint.getY, endPoint.getX, Math.toDegrees(ed)))
+          startDir.map(sd => getGsvImageUrlFromLatLng(startPoint.getY, startPoint.getX, Math.toDegrees(sd))),
+          endDir.map(ed => getGsvImageUrlFromLatLng(endPoint.getY, endPoint.getX, Math.toDegrees(ed)))
         ).flatten
       }
     })
@@ -379,8 +383,9 @@ class PanoDataServiceImpl @Inject() (
         logger.info(s"Checking ${expiredPanoIdsToCheck.length} expired panos.")
 
         // Run the panoExists function to check for imagery, then log some stats.
-        Future.traverse(panoIdsToCheck ++ expiredPanoIdsToCheck) { panoId => panoExists(panoId) }.map { responses =>
-          s"Not expired: ${responses.count(_ == Some(true))}. Expired: ${responses.count(_ == Some(false))}. Errors: ${responses.count(_.isEmpty)}."
+        Future.traverse(panoIdsToCheck ++ expiredPanoIdsToCheck) { panoId => panoExists(panoId, PanoSource.Gsv) }.map {
+          responses =>
+            s"Not expired: ${responses.count(_ == Some(true))}. Expired: ${responses.count(_ == Some(false))}. Errors: ${responses.count(_.isEmpty)}."
         }
       }
     ).flatten

--- a/app/service/PanoDataService.scala
+++ b/app/service/PanoDataService.scala
@@ -2,7 +2,7 @@ package service
 
 import com.google.inject.ImplementedBy
 import formats.json.PanoFormats.PanoHistorySubmission
-import models.label.{LabelPointTable, POV}
+import models.label.{LabelPointTable, LabelTypeEnum, POV}
 import models.pano.PanoSource.PanoSource
 import models.pano._
 import models.street.StreetEdge
@@ -155,6 +155,7 @@ trait PanoDataService {
   def insertPanoHistories(histories: Seq[PanoHistorySubmission]): Future[Unit]
   def getAllPanos: Future[Seq[PanoDataSlim]]
   def checkForImagery: Future[String]
+  def cropExists(labelId: Int, labelType: LabelTypeEnum.Base): Boolean
 }
 
 @Singleton
@@ -164,6 +165,7 @@ class PanoDataServiceImpl @Inject() (
     cacheApi: AsyncCacheApi,
     ws: WSClient,
     implicit val ec: ExecutionContext,
+    configService: ConfigService,
     panoDataTable: PanoDataTable,
     panoHistoryTable: PanoHistoryTable,
     streetEdgeTable: models.street.StreetEdgeTable
@@ -181,6 +183,8 @@ class PanoDataServiceImpl @Inject() (
 
   // Get an HMAC-SHA1 signing key from the raw key bytes.
   val sha1Key: SecretKeySpec = new SecretKeySpec(secretKey, "HmacSHA1")
+
+  private val cropsDirName: String = configService.getCropDirectory
 
   def getInfra3dToken: Future[String] = {
     // Token expires after 60 minutes, so we don't need to get a new token every time.
@@ -389,5 +393,13 @@ class PanoDataServiceImpl @Inject() (
         }
       }
     ).flatten
+  }
+
+  /** Checks whether a crop image file exists for the given label. */
+  def cropExists(labelId: Int, labelType: LabelTypeEnum.Base): Boolean = {
+    val file = new java.io.File(
+      cropsDirName + java.io.File.separator + labelType.name + java.io.File.separator + "crop_" + labelId + ".png"
+    )
+    file.exists()
   }
 }

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -965,7 +965,6 @@
         </div>
     </div>
     <script src='@assets.path("javascripts/lib/d3-3.5.6.js")'></script>
-    <script src='@assets.path("javascripts/common/pano-viewer/build/pano-viewer.js")'></script>
     @if(commonData.imagerySource == PanoSource.Infra3d) {
         <script src='@assets.path("javascripts/lib/proj4-2.19.10.js")'></script>
         <script src='@assets.path("javascripts/lib/infra3dapi-1.7.0.js")'></script>
@@ -974,6 +973,7 @@
         <script src='@assets.path("javascripts/lib/mapillary-4.1.2.min.js")'></script>
         <link href='@assets.path("javascripts/lib/mapillary-4.1.2.css")' rel="stylesheet"/>
     }
+    <script src='@assets.path("javascripts/common/pano-viewer/build/pano-viewer.js")'></script>
     <script src='@assets.path("javascripts/Admin/build/Admin.js")'></script>
     <script src='@assets.path("javascripts/PSMap/build/PSMap.js")'></script>
     <script src='@assets.path("javascripts/lib/turf-7.3.4.min.js")'></script>

--- a/app/views/admin/label.scala.html
+++ b/app/views/admin/label.scala.html
@@ -24,7 +24,6 @@
     <script src='@assets.path("javascripts/lib/i18next-23.16.8.min.js")'></script>
     <script src='@assets.path("javascripts/lib/i18nextHttpBackend-3.0.2.min.js")'></script>
     <script src='@assets.path("javascripts/common/timestampLocalization.js")'></script>
-    <script src='@assets.path("javascripts/common/pano-viewer/build/pano-viewer.js")'></script>
     @if(commonData.imagerySource == PanoSource.Infra3d) {
         <script src='@assets.path("javascripts/lib/proj4-2.19.10.js")'></script>
         <script src='@assets.path("javascripts/lib/infra3dapi-1.7.0.js")'></script>
@@ -33,6 +32,7 @@
         <script src='@assets.path("javascripts/lib/mapillary-4.1.2.min.js")'></script>
         <link href='@assets.path("javascripts/lib/mapillary-4.1.2.css")' rel="stylesheet"/>
     }
+    <script src='@assets.path("javascripts/common/pano-viewer/build/pano-viewer.js")'></script>
     <script src='@assets.path("javascripts/Admin/build/Admin.js")'></script>
     <script>updateTimestamps("@messages.lang.code");</script>
 

--- a/app/views/admin/task.scala.html
+++ b/app/views/admin/task.scala.html
@@ -51,7 +51,6 @@
             </div>
         </div>
     </div>
-    <script src='@assets.path("javascripts/common/pano-viewer/build/pano-viewer.js")'></script>
     @if(commonData.imagerySource == PanoSource.Infra3d) {
         <script src='@assets.path("javascripts/lib/proj4-2.19.10.js")'></script>
         <script src='@assets.path("javascripts/lib/infra3dapi-1.7.0.js")'></script>
@@ -60,6 +59,7 @@
         <script src='@assets.path("javascripts/lib/mapillary-4.1.2.min.js")'></script>
         <link href='@assets.path("javascripts/lib/mapillary-4.1.2.css")' rel="stylesheet"/>
     }
+    <script src='@assets.path("javascripts/common/pano-viewer/build/pano-viewer.js")'></script>
     <script src='@assets.path("javascripts/Admin/build/Admin.js")'></script>
     <script src='@assets.path("javascripts/common/UtilitiesSidewalk.js")'></script>
     <script src='@assets.path("javascripts/lib/bootstrap-3.3.5/js/bootstrap-slider.min.js")'></script>

--- a/app/views/apps/explore.scala.html
+++ b/app/views/apps/explore.scala.html
@@ -663,7 +663,6 @@
             </div>
         </div>
     </template>
-    <script src='@assets.path("javascripts/common/pano-viewer/build/pano-viewer.js")'></script>
     @if(commonData.imagerySource == PanoSource.Infra3d) {
         <script src='@assets.path("javascripts/lib/proj4-2.19.10.js")'></script>
         <script src='@assets.path("javascripts/lib/infra3dapi-1.7.0.js")'></script>
@@ -672,6 +671,7 @@
         <script src='@assets.path("javascripts/lib/mapillary-4.1.2.min.js")'></script>
         <link href='@assets.path("javascripts/lib/mapillary-4.1.2.css")' rel="stylesheet"/>
     }
+    <script src='@assets.path("javascripts/common/pano-viewer/build/pano-viewer.js")'></script>
     <script src='@assets.path("javascripts/SVLabel/build/SVLabel.js")'></script>
     <script src='@assets.path("javascripts/lib/kinetic-v4.4.3.min.js")'></script>
     <script src='@assets.path("javascripts/common/detectMobileBrowser.js")'></script>

--- a/app/views/apps/gallery.scala.html
+++ b/app/views/apps/gallery.scala.html
@@ -9,7 +9,6 @@
 @currentCity = @{commonData.allCityInfo.filter(_.cityId == commonData.cityId).head}
 
 @common.main(commonData, title, i18Namespaces = Seq("common", "gallery")) {
-    <script src='@assets.path("javascripts/common/pano-viewer/build/pano-viewer.js")'></script>
     @if(commonData.imagerySource == PanoSource.Infra3d) {
         <script src='@assets.path("javascripts/lib/proj4-2.19.10.js")'></script>
         <script src='@assets.path("javascripts/lib/infra3dapi-1.7.0.js")'></script>
@@ -18,6 +17,7 @@
         <script src='@assets.path("javascripts/lib/mapillary-4.1.2.min.js")'></script>
         <link href='@assets.path("javascripts/lib/mapillary-4.1.2.css")' rel="stylesheet"/>
     }
+    <script src='@assets.path("javascripts/common/pano-viewer/build/pano-viewer.js")'></script>
     <script src='@assets.path("javascripts/Gallery/build/Gallery.js")'></script>
     <script src='@assets.path("javascripts/lib/i18next-23.16.8.min.js")'></script>
     <script src='@assets.path("javascripts/lib/i18nextHttpBackend-3.0.2.min.js")'></script>

--- a/app/views/apps/labelMap.scala.html
+++ b/app/views/apps/labelMap.scala.html
@@ -124,7 +124,6 @@
     <script src='@assets.path("javascripts/lib/jquery.dataTables.min.js")'></script>
     <script src='@assets.path("javascripts/lib/dataTables.bootstrap.min.js")'></script>
     <script src='@assets.path("javascripts/common/UtilitiesSidewalk.js")'></script>
-    <script src='@assets.path("javascripts/common/pano-viewer/build/pano-viewer.js")'></script>
     @if(commonData.imagerySource == PanoSource.Infra3d) {
         <script src='@assets.path("javascripts/lib/proj4-2.19.10.js")'></script>
         <script src='@assets.path("javascripts/lib/infra3dapi-1.7.0.js")'></script>
@@ -133,6 +132,7 @@
         <script src='@assets.path("javascripts/lib/mapillary-4.1.2.min.js")'></script>
         <link href='@assets.path("javascripts/lib/mapillary-4.1.2.css")' rel="stylesheet"/>
     }
+    <script src='@assets.path("javascripts/common/pano-viewer/build/pano-viewer.js")'></script>
     <script src='@assets.path("javascripts/common/timestampLocalization.js")'></script>
     <script>updateTimestamps("@messages.lang.code");</script>
 

--- a/app/views/apps/mobileValidate.scala.html
+++ b/app/views/apps/mobileValidate.scala.html
@@ -17,7 +17,6 @@
 
     <script src='@assets.path("javascripts/lib/i18next-23.16.8.min.js")'></script>
     <script src='@assets.path("javascripts/lib/i18nextHttpBackend-3.0.2.min.js")'></script>
-    <script src='@assets.path("javascripts/common/pano-viewer/build/pano-viewer.js")'></script>
     @if(commonData.imagerySource == PanoSource.Infra3d) {
         <script src='@assets.path("javascripts/lib/proj4-2.19.10.js")'></script>
         <script src='@assets.path("javascripts/lib/infra3dapi-1.7.0.js")'></script>
@@ -26,6 +25,7 @@
         <script src='@assets.path("javascripts/lib/mapillary-4.1.2.min.js")'></script>
         <link href='@assets.path("javascripts/lib/mapillary-4.1.2.css")' rel="stylesheet"/>
     }
+    <script src='@assets.path("javascripts/common/pano-viewer/build/pano-viewer.js")'></script>
     <script src='@assets.path("javascripts/SVValidate/build/SVValidate.js")'></script>
     <link rel="stylesheet" href='@assets.path("javascripts/SVValidate/build/SVValidate.css")'/>
 

--- a/app/views/apps/validate.scala.html
+++ b/app/views/apps/validate.scala.html
@@ -22,7 +22,6 @@
     <script src='@assets.path("javascripts/lib/turf-7.3.4.min.js")'></script>
     <script src='@assets.path("javascripts/lib/selectize-0.15.2.min.js")'></script>
     <link rel="stylesheet" href='@assets.path("javascripts/lib/selectize-0.15.2.min.css")'/>
-    <script src='@assets.path("javascripts/common/pano-viewer/build/pano-viewer.js")'></script>
     @if(commonData.imagerySource == PanoSource.Infra3d) {
         <script src='@assets.path("javascripts/lib/proj4-2.19.10.js")'></script>
         <script src='@assets.path("javascripts/lib/infra3dapi-1.7.0.js")'></script>
@@ -31,6 +30,7 @@
         <script src='@assets.path("javascripts/lib/mapillary-4.1.2.min.js")'></script>
         <link href='@assets.path("javascripts/lib/mapillary-4.1.2.css")' rel="stylesheet"/>
     }
+    <script src='@assets.path("javascripts/common/pano-viewer/build/pano-viewer.js")'></script>
     <script src='@assets.path("javascripts/SVValidate/build/SVValidate.js")'></script>
     <link rel="stylesheet" href='@assets.path("javascripts/SVValidate/build/SVValidate.css")'/>
 

--- a/app/views/userProfile.scala.html
+++ b/app/views/userProfile.scala.html
@@ -401,7 +401,6 @@
         }
     </div>
 
-    <script src='@assets.path("javascripts/common/pano-viewer/build/pano-viewer.js")'></script>
     @if(commonData.imagerySource == PanoSource.Infra3d) {
         <script src='@assets.path("javascripts/lib/proj4-2.19.10.js")'></script>
         <script src='@assets.path("javascripts/lib/infra3dapi-1.7.0.js")'></script>
@@ -410,6 +409,7 @@
         <script src='@assets.path("javascripts/lib/mapillary-4.1.2.min.js")'></script>
         <link href='@assets.path("javascripts/lib/mapillary-4.1.2.css")' rel="stylesheet"/>
     }
+    <script src='@assets.path("javascripts/common/pano-viewer/build/pano-viewer.js")'></script>
     <script src='@assets.path("javascripts/PSMap/build/PSMap.js")'></script>
     <script src='@assets.path("javascripts/Progress/build/Progress.js")'></script>
     <script src='@assets.path("javascripts/lib/mapbox-gl-3.20.0.js")'></script>

--- a/conf/routes
+++ b/conf/routes
@@ -161,6 +161,7 @@ POST    /saveRoute                                      controllers.RouteBuilder
 
 # Images
 POST    /saveImage                                      controllers.ImageController.saveImage
+GET     /cropImage/:labelType/:labelId                  controllers.ImageController.serveCropImage(labelType: String, labelId: Int)
 
 # AI
 POST    /ai/analyzeScene                                controllers.AiController.analyzeScene()

--- a/public/javascripts/Admin/src/Admin.GSVLabelView.js
+++ b/public/javascripts/Admin/src/Admin.GSVLabelView.js
@@ -24,6 +24,10 @@ async function AdminGSVLabelView(admin, viewerType, viewerAccessToken, userMap) 
     };
 
     async function _resetModal() {
+        let viewerTypeHeader;
+        if (viewerType === GsvViewer) viewerTypeHeader = i18next.t('common:gsv-info.google-street-view');
+        else if (viewerType === MapillaryViewer) viewerTypeHeader = i18next.t('common:gsv-info.mapillary');
+        else if (viewerType === Infra3dViewer) viewerTypeHeader = i18next.t('common:gsv-info.infra3d');
         let modalText =
             '<div class="modal fade" id="label-modal" tabindex="-1" role="dialog" aria-labelledby="modal-label">' +
                 '<div class="modal-dialog" role="document" style="width: 570px">' +
@@ -97,8 +101,8 @@ async function AdminGSVLabelView(admin, viewerType, viewerAccessToken, userMap) 
                                         '<td id="pano-id" colspan="3"></td>' +
                                     '</tr>' +
                                     '<tr>' +
-                                        `<th>${i18next.t('common:gsv-info.google-street-view')}</th>` +
-                                        '<td id="view-in-gsv" colspan="3"></td>' +
+                                        `<th>${viewerTypeHeader}</th>` +
+                                        '<td id="use-external-viewer" colspan="3"></td>' +
                                     '</tr>' +
                                     '<tr>' +
                                         `<th>${i18next.t('common:gsv-info.latitude')}</th>` +
@@ -274,7 +278,7 @@ async function AdminGSVLabelView(admin, viewerType, viewerAccessToken, userMap) 
         self.modalTask = self.modal.find("#task");
         self.modalPrevValidations = self.modal.find("#prev-validations");
         self.modalPanoId = self.modal.find('#pano-id');
-        self.modalPanoLink = self.modal.find('#view-in-gsv');
+        self.modalPanoLink = self.modal.find('#use-external-viewer');
         self.modalLat = self.modal.find('#lat');
         self.modalLng = self.modal.find('#lng');
         self.modalLabelId = self.modal.find("#label-id");
@@ -590,6 +594,7 @@ async function AdminGSVLabelView(admin, viewerType, viewerAccessToken, userMap) 
 
         // Pass a callback function that fills in the pano lat/lng.
         // TODO we're going to replace this in a future redesign, including in the same place as on all other UIs.
+        self.modalPanoLink.parent().hide();
         const panoCallback = function () {
             const lat = self.panoManager.panoViewer.getPosition().lat;
             const lng = self.panoManager.panoViewer.getPosition().lng;
@@ -600,12 +605,20 @@ async function AdminGSVLabelView(admin, viewerType, viewerAccessToken, userMap) 
             if (self.panoManager.panoViewer.getViewerType() === 'gsv') {
                 const href = `https://www.google.com/maps/@?api=1&map_action=pano&pano=${labelMetadata.pano_id}&heading=${labelPov.heading}&pitch=${labelPov.pitch}`;
                 self.modalPanoLink.html(`<a target="_blank">${i18next.t('common:gsv-info.view-in-gsv')}</a>`);
-                self.modalPanoLink.children(":first").attr('href', href);
-            } else {
-                self.modalPanoLink.parent().hide();
+                self.modalPanoLink.children(':first').attr('href', href);
+                self.modalPanoLink.parent().show();
+            } else if (self.panoManager.panoViewer.getViewerType() === 'mapillary') {
+                self.modalPanoLink.parent().show();
+                // TODO would like to include zoom parameter too, but we would get that info async from the viewer.
+                const center = self.panoManager.panoViewer.currCenter;
+                const href = `https://www.mapillary.com/app/?pKey=${labelMetadata.pano_id}&focus=photo&x=${center[0]}&y=${center[1]}`;
+                self.modalPanoLink.html(`<a target="_blank">${i18next.t(`common:gsv-info.view-in-mapillary`)}</a>`);
+                self.modalPanoLink.children(':first').attr('href', href);
             }
         };
-        self.panoManager.setPano(labelMetadata.pano_id, labelPov).then(panoCallback);
+        self.panoManager.setPano(labelMetadata.pano_id, labelPov, labelMetadata.crop_url).then((panoLoaded) => {
+            if (panoLoaded) panoCallback();
+        });
 
         self.validationCounts['Agree'] = labelMetadata['num_agree'];
         self.validationCounts['Disagree'] = labelMetadata['num_disagree'];

--- a/public/javascripts/Admin/src/Admin.GSVLabelView.js
+++ b/public/javascripts/Admin/src/Admin.GSVLabelView.js
@@ -616,7 +616,7 @@ async function AdminGSVLabelView(admin, viewerType, viewerAccessToken, userMap) 
                 self.modalPanoLink.children(':first').attr('href', href);
             }
         };
-        self.panoManager.setPano(labelMetadata.pano_id, labelPov, labelMetadata.crop_url).then((panoLoaded) => {
+        self.panoManager.setPano(labelMetadata.pano_id, labelPov, labelMetadata.crop_url, labelMetadata.expired).then((panoLoaded) => {
             if (panoLoaded) panoCallback();
         });
 

--- a/public/javascripts/Admin/src/Admin.Panorama.js
+++ b/public/javascripts/Admin/src/Admin.Panorama.js
@@ -77,7 +77,7 @@ async function AdminPanorama(svHolder, buttonHolder, admin, viewerType, viewerAc
             height: '100%',
             'object-fit': 'cover'
         })[0];
-        self.fallbackMarker = $('<img id="pano-fallback-marker">').css({
+        self.fallbackMarker = $('<img id="pano-fallback-marker">').addClass('icon-outline').css({
             position: 'absolute',
             width: '20px',
             height: '20px',
@@ -129,18 +129,23 @@ async function AdminPanorama(svHolder, buttonHolder, admin, viewerType, viewerAc
      * @param panoId
      * @param {{heading: number, pitch: number, zoom: number}} pov
      * @param {string|null} cropUrl URL for the screenshot fallback image, if available.
+     * @param {boolean} expired Whether the panorama imagery is known to be expired.
      */
-    async function setPano(panoId, pov, cropUrl) {
+    async function setPano(panoId, pov, cropUrl, expired = false) {
         self.cropUrl = typeof cropUrl === 'string' ? cropUrl : null;
         self.svHolder.css('visibility', 'hidden'); // Hide until we've finished rendering.
         let panoLoaded = false;
-        return self.panoViewer.setPano(panoId).then(
-            () => { panoLoaded = true; return _panoSuccessCallback(pov); },
-            _panoFailureCallback
-        ).then(() => {
-            self.svHolder.css('visibility', 'visible');
-            return panoLoaded;
-        });
+        // If the imagery is expired and we have a fallback image, skip the pano API call.
+        if (expired && self.cropUrl) {
+            await _panoFailureCallback();
+        } else {
+            await self.panoViewer.setPano(panoId).then(
+                () => { panoLoaded = true; return _panoSuccessCallback(pov); },
+                _panoFailureCallback
+            );
+        }
+        self.svHolder.css('visibility', 'visible');
+        return panoLoaded;
     }
 
     /**

--- a/public/javascripts/Admin/src/Admin.Panorama.js
+++ b/public/javascripts/Admin/src/Admin.Panorama.js
@@ -66,7 +66,28 @@ async function AdminPanorama(svHolder, buttonHolder, admin, viewerType, viewerAc
             'padding-bottom': '15px'
         })[0];
 
+        self.fallbackContainer = $('<div id="pano-fallback-container">').css({
+            position: 'relative',
+            width: '100%',
+            height: '100%',
+            display: 'none'
+        })[0];
+        self.fallbackImage = $('<img id="pano-fallback-image">').css({
+            width: '100%',
+            height: '100%',
+            'object-fit': 'cover'
+        })[0];
+        self.fallbackMarker = $('<img id="pano-fallback-marker">').css({
+            position: 'absolute',
+            width: '20px',
+            height: '20px',
+            transform: 'translate(-50%, -50%)',
+            display: 'none'
+        })[0];
+        $(self.fallbackContainer).append(self.fallbackImage, self.fallbackMarker);
+
         self.svHolder.append($(self.panoCanvas));
+        self.svHolder.append($(self.fallbackContainer));
         self.svHolder.append($(self.panoNotAvailable));
         self.svHolder.append($(self.panoNotAvailableDetails));
         self.svHolder.append($(self.panoNotAvailableAuditSuggestion));
@@ -107,11 +128,18 @@ async function AdminPanorama(svHolder, buttonHolder, admin, viewerType, viewerAc
      * Sets the panorama ID and POV from label metadata.
      * @param panoId
      * @param {{heading: number, pitch: number, zoom: number}} pov
+     * @param {string|null} cropUrl URL for the screenshot fallback image, if available.
      */
-    async function setPano(panoId, pov) {
+    async function setPano(panoId, pov, cropUrl) {
+        self.cropUrl = typeof cropUrl === 'string' ? cropUrl : null;
         self.svHolder.css('visibility', 'hidden'); // Hide until we've finished rendering.
-        return self.panoViewer.setPano(panoId).then(() => _panoSuccessCallback(pov), _panoFailureCallback).then(() => {
+        let panoLoaded = false;
+        return self.panoViewer.setPano(panoId).then(
+            () => { panoLoaded = true; return _panoSuccessCallback(pov); },
+            _panoFailureCallback
+        ).then(() => {
             self.svHolder.css('visibility', 'visible');
+            return panoLoaded;
         });
     }
 
@@ -122,8 +150,9 @@ async function AdminPanorama(svHolder, buttonHolder, admin, viewerType, viewerAc
      * @private
      */
     async function _panoSuccessCallback(targetPov) {
-        // Show the pano, hide the error messages.
+        // Show the pano, hide the fallback image and error messages.
         $(self.panoCanvas).css('display', 'block');
+        $(self.fallbackContainer).css('display', 'none');
         $(self.panoNotAvailable).css('display', 'none');
         $(self.panoNotAvailableDetails).css('display', 'none');
         $(self.panoNotAvailableAuditSuggestion).css('display', 'none');
@@ -149,14 +178,37 @@ async function AdminPanorama(svHolder, buttonHolder, admin, viewerType, viewerAc
      * @private
      */
     async function _panoFailureCallback(error) {
-        $(self.svHolder).css('height', '');
-        $(self.panoNotAvailable).text(i18next.t("common:errors.title"));
         $(self.panoCanvas).css('display', 'none');
-        $(self.panoNotAvailable).css('display', 'block');
-        $(self.panoNotAvailableDetails).css('display', 'block');
-        if (self.label) $("#explore-street").attr('href', '/explore?streetEdgeId=' + self.label['streetEdgeId']);
-        $(self.panoNotAvailableAuditSuggestion).css('display', 'block');
-        $(self.buttonHolder).css('display', 'none');
+        if (self.cropUrl) {
+            // Show the screenshot as a fallback instead of the error message.
+            $(self.fallbackImage).attr('src', self.cropUrl);
+            $(self.fallbackContainer).css('display', 'block');
+            // Position the label icon on the fallback image.
+            if (self.label && icons[self.label.label_type]) {
+                const leftPercent = 100 * self.label.canvasX / self.label.originalCanvasWidth;
+                const topPercent = 100 * self.label.canvasY / self.label.originalCanvasHeight;
+                $(self.fallbackMarker).attr('src', icons[self.label.label_type]).css({
+                    left: `${leftPercent}%`,
+                    top: `${topPercent}%`,
+                    display: 'block'
+                });
+            } else {
+                $(self.fallbackMarker).css('display', 'none');
+            }
+            $(self.panoNotAvailable).css('display', 'none');
+            $(self.panoNotAvailableDetails).css('display', 'none');
+            $(self.panoNotAvailableAuditSuggestion).css('display', 'none');
+            $(self.buttonHolder).css('display', 'block');
+        } else {
+            $(self.svHolder).css('height', '');
+            $(self.fallbackContainer).css('display', 'none');
+            $(self.panoNotAvailable).text(i18next.t("common:errors.title"));
+            $(self.panoNotAvailable).css('display', 'block');
+            $(self.panoNotAvailableDetails).css('display', 'block');
+            if (self.label) $("#explore-street").attr('href', '/explore?streetEdgeId=' + self.label['streetEdgeId']);
+            $(self.panoNotAvailableAuditSuggestion).css('display', 'block');
+            $(self.buttonHolder).css('display', 'none');
+        }
         return Promise.resolve();
     }
 

--- a/public/javascripts/Gallery/css/cards.css
+++ b/public/javascripts/Gallery/css/cards.css
@@ -31,6 +31,7 @@ with respect to the image holder. This allows the validation menu to be placed o
     cursor: pointer;
     position: relative;
     overflow: hidden;
+    aspect-ratio: 3 / 2; /* Match the Explore canvas ratio (720x480). */
     --gallery-marker-size: clamp(16px, 1.1vw, 22px);
 }
 
@@ -40,7 +41,8 @@ with respect to the image holder. This allows the validation menu to be placed o
 
 .static-gallery-image {
     width: 100%;
-    height: auto;
+    height: 100%;
+    object-fit: cover; /* Fills 3:2 container; crops excess from Google's 4:3 images. */
     border-top-left-radius: 20px;
     border-top-right-radius: 20px;
 }

--- a/public/javascripts/Gallery/src/cards/Card.js
+++ b/public/javascripts/Gallery/src/cards/Card.js
@@ -1,12 +1,13 @@
 /**
  * A Card module.
  * @param params properties of the associated label.
- * @param imageUrl google maps static image url for label.
+ * @param cropUrl Locally-saved crop image url, or null if no crop exists.
+ * @param gsvImageUrl Google Street View static image url, or null if non-GSV imagery.
  * @param expandedView ExpandedView object; used to update the expanded view when modifying a card.
  * @returns {Card}
  * @constructor
  */
-function Card(params, imageUrl, expandedView) {
+function Card(params, cropUrl, gsvImageUrl, expandedView) {
     const self = this;
 
     // UI card element.
@@ -56,7 +57,8 @@ function Card(params, imageUrl, expandedView) {
 
     // Status to determine if static imagery has been loaded.
     let status = {
-        imageFetched: false
+        imageFetched: false,
+        imageSource: cropUrl ? 'crop' : 'api'
     };
 
     // The label icon to be placed on the static pano image.
@@ -167,6 +169,7 @@ function Card(params, imageUrl, expandedView) {
         }
         imageHolder.appendChild(markerWrapper);
         imageHolder.appendChild(panoImage);
+
         card.appendChild(cardInfo);
         validationMenu = new ValidationMenu(self, $(imageHolder), expandedView, false);
     }
@@ -212,17 +215,29 @@ function Card(params, imageUrl, expandedView) {
     }
 
     /**
-     * Loads the pano image from url.
+     * Loads the image, preferring the crop. Falls back to GSV if the crop fails.
      */
     function loadImage() {
         return new Promise(resolve => {
             if (!status.imageFetched) {
-                let img = panoImage;
+                const img = panoImage;
+                const primaryUrl = cropUrl || gsvImageUrl;
+                const fallbackUrl = cropUrl ? gsvImageUrl : null;
                 img.onload = () => {
                     status.imageFetched = true;
                     resolve(true);
                 };
-                img.src = imageUrl;
+                img.onerror = () => {
+                    if (fallbackUrl) {
+                        // Primary failed; try the other source.
+                        status.imageSource = cropUrl ? 'api' : 'crop';
+                        img.onerror = () => resolve(false); // Prevent infinite loop.
+                        img.src = fallbackUrl;
+                    } else {
+                        resolve(false);
+                    }
+                };
+                img.src = primaryUrl;
             } else {
                 resolve(true);
             }
@@ -313,11 +328,19 @@ function Card(params, imageUrl, expandedView) {
         return imageId
     }
 
+    /**
+     * Returns the current image source: 'api' or 'crop'.
+     */
+    function getImageSource() {
+        return status.imageSource;
+    }
+
     self.getLabelId = getLabelId;
     self.getLabelType = getLabelType;
     self.getProperties = getProperties;
     self.getProperty = getProperty;
     self.getStatus = getStatus;
+    self.getImageSource = getImageSource;
     self.loadImage = loadImage;
     self.render = render;
     self.setProperty = setProperty;

--- a/public/javascripts/Gallery/src/cards/Card.js
+++ b/public/javascripts/Gallery/src/cards/Card.js
@@ -335,6 +335,7 @@ function Card(params, cropUrl, gsvImageUrl, expandedView) {
         return status.imageSource;
     }
 
+    self.getCropUrl = function() { return cropUrl; };
     self.getLabelId = getLabelId;
     self.getLabelType = getLabelType;
     self.getProperties = getProperties;

--- a/public/javascripts/Gallery/src/cards/CardContainer.js
+++ b/public/javascripts/Gallery/src/cards/CardContainer.js
@@ -210,7 +210,7 @@ async function CardContainer(uiCardContainer, initialFilters, panoViewerType, vi
      * @param {*} callback Function to be called when labels arrive.
      */
     function fetchLabels(labelTypeId, n, validationOptions, loadedLabels, neighborhoods, severities, tags, aiValidationOptions, callback) {
-        var url = "/label/labels";
+        const url = "/label/labels";
         let data = {
             label_type_id: labelTypeId,
             n: n,
@@ -230,15 +230,12 @@ async function CardContainer(uiCardContainer, initialFilters, panoViewerType, vi
             dataType: "json",
             success: function(data) {
                 if ("labelsOfType" in data) {
-                    let labels = data.labelsOfType
-                    let card;
+                    const labels = data.labelsOfType;
                     for (let i = 0; i < labels.length; i++) {
-                        let labelProp = labels[i];
-                        if ("label" in labelProp && "imageUrl" in labelProp) {
-                            card = new Card(labelProp.label, labelProp.imageUrl, expandedView);
-                            self.push(card);
-                            loadedLabelIds.add(card.getLabelId());
-                        }
+                    const labelProp = labels[i];
+                        const card = new Card(labelProp.label, labelProp.cropUrl, labelProp.gsvImageUrl, expandedView);
+                        self.push(card);
+                        loadedLabelIds.add(card.getLabelId());
                     }
                     if (callback) callback();
                 }

--- a/public/javascripts/Gallery/src/expandedview/ExpandedView.js
+++ b/public/javascripts/Gallery/src/expandedview/ExpandedView.js
@@ -172,9 +172,11 @@ async function ExpandedView(uiModal, panoViewerType, viewerAccessToken) {
      * Performs the actions needed to open the expanded view.
      */
     function openExpandedView() {
-        // Load the pano and then render the label.
-        self.panoManager.setPano(self.refCard.getProperty('pano_id'), self.refCard.getProperty('pov'))
-            .then(() => { self.panoManager.renderLabel(self.label) });
+        // Load the pano and then render the label. Pass crop URL and label for fallback if pano fails.
+        self.panoManager.setPano(
+            self.refCard.getProperty('pano_id'), self.refCard.getProperty('pov'),
+            self.refCard.getCropUrl(), self.label
+        ).then((panoData) => { if (panoData) self.panoManager.renderLabel(self.label); });
 
         // Update the text various fields shown below the pano.
         resetExpandedView();

--- a/public/javascripts/Gallery/src/expandedview/PanoManager.js
+++ b/public/javascripts/Gallery/src/expandedview/PanoManager.js
@@ -112,6 +112,7 @@ class PanoManager {
 
         // Show the pano, hide the error messages.
         $(this.panoCanvas).css('display', 'block');
+        this.svHolder.find('#gallery-validation-button-holder').css('display', 'flex');
         $(this.panoNotAvailable).css('display', 'none');
         $(this.panoNotAvailableDetails).css('display', 'none');
         return Promise.resolve(panoData);
@@ -128,6 +129,7 @@ class PanoManager {
         $(this.svHolder).css('height', '');
         $(this.panoNotAvailable).text(i18next.t('common:errors.title'));
         $(this.panoCanvas).css('display', 'none');
+        this.svHolder.find('#gallery-validation-button-holder').css('display', 'none');
         $(this.panoNotAvailable).css('display', 'block');
         $(this.panoNotAvailableDetails).css('display', 'block');
         return Promise.resolve();

--- a/public/javascripts/Gallery/src/expandedview/PanoManager.js
+++ b/public/javascripts/Gallery/src/expandedview/PanoManager.js
@@ -30,7 +30,8 @@ class PanoManager {
             this.svHolder.css('position', 'relative');
         }
 
-        // Pano will be added to panoCanvas.
+        // TODO all this stuff below is following what we did in GsvLabelView.js, but we shouldn't be creating all of
+        //      this in JS. Needs to be rewritten using better coding practices.
         this.panoCanvas = $("<div id='pano'>").css({
             position: 'relative',
             top: '0px',
@@ -48,7 +49,28 @@ class PanoManager {
                 'padding-bottom': '15px'
             })[0];
 
+        this.fallbackContainer = $('<div id="pano-fallback-container">').css({
+            position: 'relative',
+            width: '100%',
+            height: '60vh',
+            display: 'none'
+        })[0];
+        this.fallbackImage = $('<img id="pano-fallback-image">').css({
+            width: '100%',
+            height: '100%',
+            'object-fit': 'cover'
+        })[0];
+        this.fallbackMarker = $('<img id="pano-fallback-marker">').addClass('icon-outline').css({
+            position: 'absolute',
+            width: '20px',
+            height: '20px',
+            transform: 'translate(-50%, -50%)',
+            display: 'none'
+        })[0];
+        $(this.fallbackContainer).append(this.fallbackImage, this.fallbackMarker);
+
         this.svHolder.append($(this.panoCanvas));
+        this.svHolder.append($(this.fallbackContainer));
         this.svHolder.append($(this.panoNotAvailable));
         this.svHolder.append($(this.panoNotAvailableDetails));
     }
@@ -88,12 +110,16 @@ class PanoManager {
      * Sets the panorama ID and POV from label metadata.
      * @param {string} panoId
      * @param {{heading: number, pitch: number, zoom: number}} pov
+     * @param {string} [cropUrl] URL for the screenshot fallback image, if available.
+     * @param {AdminPanoramaLabel} [label] Label info for positioning the marker on the fallback image.
      * @returns {Promise<PanoData>}
      */
-    async setPano(panoId, pov) {
+    async setPano(panoId, pov, cropUrl, label) {
+        this.cropUrl = typeof cropUrl === 'string' ? cropUrl : null;
+        this.fallbackLabel = label || null;
         this.svHolder.css('visibility', 'hidden');
         return sg.panoViewer.setPano(panoId).then(this.#panoSuccessCallback, this.#panoFailureCallback).then((panoData) => {
-            sg.panoViewer.setPov(pov);
+            if (panoData) sg.panoViewer.setPov(pov);
             this.svHolder.css('visibility', 'visible');
             return panoData;
         });
@@ -110,8 +136,9 @@ class PanoManager {
         const panoId = panoData.getPanoId();
         sg.panoStore.addPanoMetadata(panoId, panoData);
 
-        // Show the pano, hide the error messages.
+        // Show the pano, hide the fallback image and error messages.
         $(this.panoCanvas).css('display', 'block');
+        $(this.fallbackContainer).css('display', 'none');
         this.svHolder.find('#gallery-validation-button-holder').css('display', 'flex');
         $(this.panoNotAvailable).css('display', 'none');
         $(this.panoNotAvailableDetails).css('display', 'none');
@@ -119,19 +146,42 @@ class PanoManager {
     }
 
     /**
-     * Shows an error message if the pano fails to load.
+     * Show local cropped image if pano fails to load, or an error message if neither is available.
      * @param {Error} error
      * @returns {Promise<void>}
      * @private
      */
     #panoFailureCallback = async (error) => {
         console.error('failed to load pano!', error);
-        $(this.svHolder).css('height', '');
-        $(this.panoNotAvailable).text(i18next.t('common:errors.title'));
         $(this.panoCanvas).css('display', 'none');
-        this.svHolder.find('#gallery-validation-button-holder').css('display', 'none');
-        $(this.panoNotAvailable).css('display', 'block');
-        $(this.panoNotAvailableDetails).css('display', 'block');
+        if (this.cropUrl) {
+            // Show the screenshot as a fallback instead of the error message.
+            $(this.fallbackImage).attr('src', this.cropUrl);
+            $(this.fallbackContainer).css('display', 'block');
+            // Position the label icon on the fallback image.
+            if (this.fallbackLabel && PanoManager.icons[this.fallbackLabel.label_type]) {
+                const label = this.fallbackLabel;
+                const leftPercent = 100 * label.canvasX / label.originalCanvasWidth;
+                const topPercent = 100 * label.canvasY / label.originalCanvasHeight;
+                $(this.fallbackMarker).attr('src', PanoManager.icons[label.label_type]).css({
+                    left: `${leftPercent}%`,
+                    top: `${topPercent}%`,
+                    display: 'block'
+                });
+            } else {
+                $(this.fallbackMarker).css('display', 'none');
+            }
+            this.svHolder.find('#gallery-validation-button-holder').css('display', 'flex');
+            $(this.panoNotAvailable).css('display', 'none');
+            $(this.panoNotAvailableDetails).css('display', 'none');
+        } else {
+            $(this.svHolder).css('height', '');
+            $(this.fallbackContainer).css('display', 'none');
+            $(this.panoNotAvailable).text(i18next.t('common:errors.title'));
+            this.svHolder.find('#gallery-validation-button-holder').css('display', 'none');
+            $(this.panoNotAvailable).css('display', 'block');
+            $(this.panoNotAvailableDetails).css('display', 'block');
+        }
         return Promise.resolve();
     }
 

--- a/public/javascripts/common/pano-viewer/src/MapillaryChunkedDataProvider.js
+++ b/public/javascripts/common/pano-viewer/src/MapillaryChunkedDataProvider.js
@@ -1,0 +1,16 @@
+/**
+ * Workaround: Mapillary's GraphDataProvider fails when getSpatialImages is called with more than 30 image IDs at once.
+ * This subclass chunks requests into batches of 30 to avoid that limit.
+ */
+const { GraphDataProvider } = mapillary;
+class MapillaryChunkedDataProvider extends GraphDataProvider {
+    async getSpatialImages(imageIds) {
+        const CHUNK_SIZE = 30;
+        const chunks = [];
+        for (let i = 0; i < imageIds.length; i += CHUNK_SIZE) {
+            chunks.push(imageIds.slice(i, i + CHUNK_SIZE));
+        }
+        const results = await Promise.all(chunks.map(chunk => super.getSpatialImages(chunk)));
+        return results.flat();
+    }
+}

--- a/public/javascripts/common/pano-viewer/src/MapillaryChunkedDataProvider.js
+++ b/public/javascripts/common/pano-viewer/src/MapillaryChunkedDataProvider.js
@@ -1,16 +1,22 @@
 /**
  * Workaround: Mapillary's GraphDataProvider fails when getSpatialImages is called with more than 30 image IDs at once.
  * This subclass chunks requests into batches of 30 to avoid that limit.
+ *
+ * Implemented as a factory function so that the `mapillary` global is not accessed at bundle-load time — it's only
+ * needed when actually using Mapillary, and other imagery providers don't load that library at all.
  */
-const { GraphDataProvider } = mapillary;
-class MapillaryChunkedDataProvider extends GraphDataProvider {
-    async getSpatialImages(imageIds) {
-        const CHUNK_SIZE = 30;
-        const chunks = [];
-        for (let i = 0; i < imageIds.length; i += CHUNK_SIZE) {
-            chunks.push(imageIds.slice(i, i + CHUNK_SIZE));
+function createMapillaryChunkedDataProvider(options) {
+    const { GraphDataProvider } = mapillary;
+    class MapillaryChunkedDataProvider extends GraphDataProvider {
+        async getSpatialImages(imageIds) {
+            const CHUNK_SIZE = 30;
+            const chunks = [];
+            for (let i = 0; i < imageIds.length; i += CHUNK_SIZE) {
+                chunks.push(imageIds.slice(i, i + CHUNK_SIZE));
+            }
+            const results = await Promise.all(chunks.map(chunk => super.getSpatialImages(chunk)));
+            return results.flat();
         }
-        const results = await Promise.all(chunks.map(chunk => super.getSpatialImages(chunk)));
-        return results.flat();
     }
+    return new MapillaryChunkedDataProvider(options);
 }

--- a/public/javascripts/common/pano-viewer/src/MapillaryViewer.js
+++ b/public/javascripts/common/pano-viewer/src/MapillaryViewer.js
@@ -26,7 +26,7 @@ class MapillaryViewer extends PanoViewer {
         let disableDefaultUi = 'disableDefaultUi' in panoOptions ? panoOptions.disableDefaultUi : true;
         let defaultNavigation = 'defaultNavigation' in panoOptions ? panoOptions.defaultNavigation : false;
         let panoOpts = {
-            dataProvider: new MapillaryChunkedDataProvider({ accessToken: panoOptions.accessToken }),
+            dataProvider: createMapillaryChunkedDataProvider({ accessToken: panoOptions.accessToken }),
             container: canvasElem.id,
             component: {
                 bearing: !disableDefaultUi, // Shows heading viewer orb thing

--- a/public/javascripts/common/pano-viewer/src/MapillaryViewer.js
+++ b/public/javascripts/common/pano-viewer/src/MapillaryViewer.js
@@ -26,7 +26,7 @@ class MapillaryViewer extends PanoViewer {
         let disableDefaultUi = 'disableDefaultUi' in panoOptions ? panoOptions.disableDefaultUi : true;
         let defaultNavigation = 'defaultNavigation' in panoOptions ? panoOptions.defaultNavigation : false;
         let panoOpts = {
-            accessToken: panoOptions.accessToken,
+            dataProvider: new MapillaryChunkedDataProvider({ accessToken: panoOptions.accessToken }),
             container: canvasElem.id,
             component: {
                 bearing: !disableDefaultUi, // Shows heading viewer orb thing
@@ -314,14 +314,7 @@ class MapillaryViewer extends PanoViewer {
                 // Load the pano. Say that it failed if it doesn't work after 10 seconds.
                 // TODO If the pano fails to load, we should try the next closest pano. Getting an issue where the pano
                 //      with ID 859880776211217 never loads, but there are plenty of others at that location.
-                this.changingPanoOurselves = true;
-                return await Promise.race([
-                    this.viewer.moveTo(closestPano.id).then(this._getPanoramaCallback),
-                    new Promise((_, reject) => setTimeout(() => reject(new Error('Timed out')), 10000))
-                ]).catch(() => {
-                    console.error('Failed to load pano: ', closestPano.id);
-                    throw new Error('Failed to load pano: ', closestPano.id);
-                });
+                return await this.setPano(closestPano.id);
             } else {
                 throw new Error(JSON.stringify(data));
             }
@@ -333,7 +326,13 @@ class MapillaryViewer extends PanoViewer {
 
     setPano = async (panoId) => {
         this.changingPanoOurselves = true;
-        return this.viewer.moveTo(panoId).then(this._getPanoramaCallback);
+        return Promise.race([
+            this.viewer.moveTo(panoId).then(this._getPanoramaCallback),
+            new Promise((_, reject) => setTimeout(() => reject(new Error('Timed out')), 8000))
+        ]).catch(() => {
+            console.error('Failed to load pano: ', closestPano.id);
+            throw new Error('Failed to load pano: ', closestPano.id);
+        });
     }
 
     getLinkedPanos = () => {

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -147,6 +147,8 @@
         "panorama-id": "Panorama ID",
         "street-id": "Strasse ID",
         "google-street-view": "“Google Street View”",
+        "mapillary": "“Mapillary”",
+        "infra3d": "“infra3D”",
         "region-id": "Region ID",
         "label-id": "Beschriftung ID",
         "label-date": "$t(common:labeled)",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -147,6 +147,8 @@
         "panorama-id": "Panorama ID",
         "street-id": "Street ID",
         "google-street-view": "Google Street View",
+        "mapillary": "Mapillary",
+        "infra3d": "infra3D",
         "region-id": "Region ID",
         "label-id": "Label ID",
         "label-date": "$t(common:labeled)",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -147,6 +147,8 @@
         "panorama-id": "ID de panorama",
         "street-id": "ID de calle",
         "google-street-view": "Google Street View",
+        "mapillary": "Mapillary",
+        "infra3d": "infra3D",
         "region-id": "ID de región",
         "label-id": "ID de etiqueta",
         "label-date": "$t(common:labeled)",

--- a/public/locales/nl/common.json
+++ b/public/locales/nl/common.json
@@ -146,6 +146,8 @@
         "longitude": "Lengtegraad",
         "panorama-id": "Panorama-ID",
         "google-street-view": "Google Street View",
+        "mapillary": "Mapillary",
+        "infra3d": "infra3D",
         "street-id": "Straat-ID",
         "region-id": "Regio-ID",
         "label-id": "Etiket-ID",

--- a/public/locales/pt-BR/common.json
+++ b/public/locales/pt-BR/common.json
@@ -147,6 +147,8 @@
         "panorama-id": "ID do Panorama",
         "street-id": "ID da Rua",
         "google-street-view": "Google Street View",
+        "mapillary": "Mapillary",
+        "infra3d": "infra3D",
         "region-id": "ID da Região",
         "label-id": "ID do Rótulo",
         "label-date": "$t(common:labeled)",

--- a/public/locales/zh-TW/common.json
+++ b/public/locales/zh-TW/common.json
@@ -146,6 +146,8 @@
         "longitude": "經度",
         "panorama-id": "全景圖編號",
         "google-street-view": "Google街景",
+        "mapillary": "Mapillary",
+        "infra3d": "infra3D",
         "street-id": "街道編號",
         "region-id": "區域編號",
         "label-id": "標籤編號",


### PR DESCRIPTION
Working towards #3025 

We are now using our local screenshot "crops" as backups in Gallery and LabelMap! Some details:
* In LabelMap, we try to show the dynamic pano first. If that fails (or if we already marked in the db that the imagery has expired), then we show the static crop that we created. If we don't have one, then we show the usual error message. This applies anywhere that has the LabelMap-style label popup (/admin, /admin/user, /admin/label, etc)
* In Gallery's expanded view, we treat this the same way as LabelMap (dynamic -> static crop).
* In Gallery's smaller images, we actually default to our local crop. If we don't have one, then we show the image from the static API.
* In Gallery, if we don't have a local crop _and_ the image isn't available from Google, then we don't try to show the image. But in Mapillary/infra3D we still do for now (since we haven't added a process to check if imagery has expired for those imagery sources yet)

While testing with our various imagery sources, I also managed to track down and fix a bug that would sometimes prevent images from loading in Mapillary in high traffic areas. When we try to load an image using it's image ID in Mapillary, it kicks off a request to get info on the nearby images. The number of images that can be requested is capped at 30, but sometimes these streets would have 60+ nearby images to query. We had to extend Mapillary's `GraphDataProvider` class with our own that would make this request in chunks.

##### Before/After screenshots (if applicable)
Before (infra3D example)
<img width="1899" height="948" alt="image" src="https://github.com/user-attachments/assets/e52c1613-6068-4875-a5e4-0e5ad3979737" />

After
<img width="1899" height="948" alt="image" src="https://github.com/user-attachments/assets/6298dcbc-b349-413c-bca0-9bf5c7cb8c46" />


##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
