### PR TITLE
No longer showing tutorial street during normal Explore missions

### DIFF
--- a/app/models/audit/AuditTaskTable.scala
+++ b/app/models/audit/AuditTaskTable.scala
@@ -104,12 +104,14 @@ class AuditTaskTableDef(tag: slick.lifted.Tag) extends Table[AuditTask](tag, "au
 @ImplementedBy(classOf[AuditTaskTable])
 trait AuditTaskTableRepository {}
 
-class AuditTaskTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvider)(implicit ec: ExecutionContext)
+class AuditTaskTable @Inject() (
+    protected val dbConfigProvider: DatabaseConfigProvider,
+    streetEdgeTable: StreetEdgeTable
+)(implicit ec: ExecutionContext)
     extends AuditTaskTableRepository
     with HasDatabaseConfigProvider[MyPostgresProfile] {
 
   val auditTasks            = TableQuery[AuditTaskTableDef]
-  val streetEdges           = TableQuery[StreetEdgeTableDef]
   val regions               = TableQuery[RegionTableDef]
   val streetEdgeRegionTable = TableQuery[StreetEdgeRegionTableDef]
   val configTable           = TableQuery[ConfigTableDef]
@@ -121,13 +123,13 @@ class AuditTaskTable @Inject() (protected val dbConfigProvider: DatabaseConfigPr
   val userRoutes            = TableQuery[UserRouteTableDef]
   val auditTaskUserRoutes   = TableQuery[AuditTaskUserRouteTableDef]
 
-  val activeTasks                 = auditTasks.filterNot(_.completed)
-  val completedTasks              = auditTasks.filter(_.completed)
-  val streetEdgesWithoutDeleted   = streetEdges.filterNot(_.deleted)
+  val activeTasks    = auditTasks.filterNot(_.completed)
+  val completedTasks = auditTasks.filter(_.completed)
+
   val regionsWithoutDeleted       = regions.filterNot(_.deleted)
   val nonDeletedStreetEdgeRegions = for {
     _ser <- streetEdgeRegionTable
-    _se  <- streetEdgesWithoutDeleted if _ser.streetEdgeId === _se.streetEdgeId
+    _se  <- streetEdgeTable.streets if _ser.streetEdgeId === _se.streetEdgeId
     _r   <- regionsWithoutDeleted if _ser.regionId === _r.regionId
   } yield _ser
 
@@ -138,7 +140,7 @@ class AuditTaskTable @Inject() (protected val dbConfigProvider: DatabaseConfigPr
     val completionCnt = completedTasks.groupBy(_.streetEdgeId).map { case (_street, group) => (_street, group.length) }
 
     // Gets completion count of 0 for unaudited streets w/ a left join, then checks if completion count is > 0.
-    streetEdgesWithoutDeleted.joinLeft(completionCnt).on(_.streetEdgeId === _._1).map { case (_edge, _cnt) =>
+    streetEdgeTable.streetsWithTutorial.joinLeft(completionCnt).on(_.streetEdgeId === _._1).map { case (_edge, _cnt) =>
       (_edge.streetEdgeId, _cnt.map(_._2).ifNull(0.asColumnOf[Int]) > 0)
     }
   }
@@ -264,7 +266,7 @@ class AuditTaskTable @Inject() (protected val dbConfigProvider: DatabaseConfigPr
     val _distinctCompleted = _filteredTasks.groupBy(_.streetEdgeId).map(_._1)
 
     // Left join list of streets with list of audited streets to record whether each street has been audited.
-    val streetsWithAuditedStatus = streetEdgesWithoutDeleted
+    val streetsWithAuditedStatus = streetEdgeTable.streets
       .join(streetEdgeRegionTable)
       .on(_.streetEdgeId === _.streetEdgeId)
       .filter(x => (x._2.regionId inSetBind regionIds) || regionIds.isEmpty)
@@ -292,7 +294,7 @@ class AuditTaskTable @Inject() (protected val dbConfigProvider: DatabaseConfigPr
   def getAuditedStreetsWithTimestamps: DBIO[Seq[AuditedStreetWithTimestamp]] = {
     val auditedStreets = for {
       _at <- completedTasks
-      _se <- streetEdges if _at.streetEdgeId === _se.streetEdgeId
+      _se <- streetEdgeTable.streets if _at.streetEdgeId === _se.streetEdgeId
       _ut <- userStats if _at.userId === _ut.userId
       _ur <- userRoleTable if _ut.userId === _ur.userId
       _r  <- roleTable if _ur.roleId === _r.roleId
@@ -306,7 +308,7 @@ class AuditTaskTable @Inject() (protected val dbConfigProvider: DatabaseConfigPr
    */
   def getAuditedStreets(userId: String): DBIO[Seq[StreetEdge]] = {
     completedTasks
-      .join(streetEdgesWithoutDeleted)
+      .join(streetEdgeTable.streets)
       .on(_.streetEdgeId === _.streetEdgeId)
       .filter(_._1.userId === userId)
       .map(_._2)
@@ -320,7 +322,7 @@ class AuditTaskTable @Inject() (protected val dbConfigProvider: DatabaseConfigPr
   def getDistanceAudited(userId: String): DBIO[Double] = {
     completedTasks
       .filter(_.userId === userId)
-      .join(streetEdges)
+      .join(streetEdgeTable.streets)
       .on(_.streetEdgeId === _.streetEdgeId)
       .map(_._2.geom.transform(26918).lengthD)
       .sum
@@ -333,7 +335,7 @@ class AuditTaskTable @Inject() (protected val dbConfigProvider: DatabaseConfigPr
    */
   def getUnauditedDistance(userId: String, regionId: Int): DBIO[Double] = {
     getStreetEdgeRegionsNotAuditedQuery(userId, regionId)
-      .join(streetEdgesWithoutDeleted)
+      .join(streetEdgeTable.streets)
       .on(_.streetEdgeId === _.streetEdgeId)
       .map(_._2.geom.transform(26918).lengthD)
       .sum
@@ -354,7 +356,7 @@ class AuditTaskTable @Inject() (protected val dbConfigProvider: DatabaseConfigPr
 
     // Join with other queries to get completion count and priority for each of the street edges.
     val edges = for {
-      se   <- streetEdgesWithoutDeleted if se.streetEdgeId === streetEdgeId
+      se   <- streetEdgeTable.streets if se.streetEdgeId === streetEdgeId
       scau <- streetCompletedByAnyUser if se.streetEdgeId === scau._1
       sep  <- streetEdgePriorities if scau._1 === sep.streetEdgeId
     } yield (
@@ -382,7 +384,7 @@ class AuditTaskTable @Inject() (protected val dbConfigProvider: DatabaseConfigPr
    */
   def getATutorialTask(missionId: Int): DBIO[NewTask] = {
     val timestamp: OffsetDateTime = OffsetDateTime.now
-    streetEdges
+    streetEdgeTable.streetsUnfiltered
       .join(configTable)
       .on(_.streetEdgeId === _.tutorialStreetEdgeID)
       .map { case (e, c) =>
@@ -415,7 +417,7 @@ class AuditTaskTable @Inject() (protected val dbConfigProvider: DatabaseConfigPr
     // Get streets the user hasn't completed. Then join w/ other queries to get completion count and priority.
     val possibleTasks = for {
       ser <- getStreetEdgeRegionsNotAuditedQuery(userId, regionId)
-      se  <- streetEdgesWithoutDeleted if ser.streetEdgeId === se.streetEdgeId
+      se  <- streetEdgeTable.streets if ser.streetEdgeId === se.streetEdgeId
       sp  <- streetEdgePriorities if se.streetEdgeId === sp.streetEdgeId
       sc  <- streetCompletedByAnyUser if se.streetEdgeId === sc._1
     } yield (
@@ -452,7 +454,7 @@ class AuditTaskTable @Inject() (protected val dbConfigProvider: DatabaseConfigPr
   def selectTaskFromTaskId(taskId: Int, routeStreetId: Option[Int] = None): DBIO[Option[NewTask]] = {
     val newTask = for {
       at <- activeTasks if at.auditTaskId === taskId
-      se <- streetEdges if at.streetEdgeId === se.streetEdgeId
+      se <- streetEdgeTable.streetsWithTutorial if at.streetEdgeId === se.streetEdgeId
       sp <- streetEdgePriorities if se.streetEdgeId === sp.streetEdgeId
       sc <- streetCompletedByAnyUser if sp.streetEdgeId === sc._1
     } yield (
@@ -480,7 +482,7 @@ class AuditTaskTable @Inject() (protected val dbConfigProvider: DatabaseConfigPr
     val edgesInRegion = nonDeletedStreetEdgeRegions.filter(_.regionId === regionId)
     val tasks         = for {
       (ser, ucs) <- edgesInRegion.joinLeft(userCompletedStreets).on(_.streetEdgeId === _._1)
-      se         <- streetEdges if ser.streetEdgeId === se.streetEdgeId
+      se         <- streetEdgeTable.streets if ser.streetEdgeId === se.streetEdgeId
       sep        <- streetEdgePriorities if se.streetEdgeId === sep.streetEdgeId
       scau       <- streetCompletedByAnyUser if sep.streetEdgeId === scau._1
     } yield (
@@ -514,7 +516,7 @@ class AuditTaskTable @Inject() (protected val dbConfigProvider: DatabaseConfigPr
       .filter(_.userRouteId === userRouteId)
       .join(routeStreets)
       .on(_.routeId === _.routeId)
-      .join(streetEdgesWithoutDeleted)
+      .join(streetEdgeTable.streets)
       .on(_._2.streetEdgeId === _.streetEdgeId)
       .map { case ((_userRoute, _routeStreet), _streetEdge) => (_streetEdge, _routeStreet) }
 
@@ -532,7 +534,7 @@ class AuditTaskTable @Inject() (protected val dbConfigProvider: DatabaseConfigPr
 
     val tasks = for {
       ((_se1, _rs), ucs) <- edgesInRoute.joinLeft(userCompletedStreets).on(_._1.streetEdgeId === _._1)
-      _se2               <- streetEdges if _se1.streetEdgeId === _se2.streetEdgeId
+      _se2               <- streetEdgeTable.streets if _se1.streetEdgeId === _se2.streetEdgeId
       _sep               <- streetEdgePriorities if _se2.streetEdgeId === _sep.streetEdgeId
       _scau              <- streetCompletedByAnyUser if _sep.streetEdgeId === _scau._1
     } yield (

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -12,7 +12,7 @@ import models.pano.PanoSource.PanoSource
 import models.pano.{PanoData, PanoDataTableDef, PanoSource}
 import models.region.RegionTableDef
 import models.route.RouteStreetTableDef
-import models.street.{StreetEdgeRegionTableDef, StreetEdgeTableDef}
+import models.street.{StreetEdgeRegionTableDef, StreetEdgeTable}
 import models.user._
 import models.utils.MyPostgresProfile.api._
 import models.utils.{ConfigTableDef, MyPostgresProfile}
@@ -505,8 +505,9 @@ object LabelTable {
 trait LabelTableRepository {}
 
 @Singleton
-class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvider)(implicit ec: ExecutionContext)
-    extends LabelTableRepository
+class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvider, streetEdgeTable: StreetEdgeTable)(
+    implicit ec: ExecutionContext
+) extends LabelTableRepository
     with HasDatabaseConfigProvider[MyPostgresProfile] {
 
   val gf: GeometryFactory = JTSFactoryFinder.getGeometryFactory
@@ -530,7 +531,6 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
   val labelValidations       = TableQuery[LabelValidationTableDef]
   val labelAiAssessments     = TableQuery[LabelAiAssessmentTableDef]
   val missions               = TableQuery[MissionTableDef]
-  val streets                = TableQuery[StreetEdgeTableDef]
   val regions                = TableQuery[RegionTableDef]
   val usersUnfiltered        = TableQuery[SidewalkUserTableDef]
   val userStats              = TableQuery[UserStatTableDef]
@@ -1292,7 +1292,7 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
     val _labelsNearRoute = if (routeIds.nonEmpty) {
       (for {
         _rs <- routeStreets if _rs.routeId inSetBind routeIds
-        _se <- streets if _rs.streetEdgeId === _se.streetEdgeId
+        _se <- streetEdgeTable.streetsUnfiltered if _rs.streetEdgeId === _se.streetEdgeId
         _l  <- _labelsFilteredByAiValidation if _se.streetEdgeId === _l._2 ||
           _se.geom.distanceSphereD(makePoint(_l._6.asColumnOf[Double], _l._5.asColumnOf[Double]).setSRID(4326)) < 30d
       } yield _l).distinct
@@ -1389,8 +1389,7 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
    * Select street_edge_id of street closest to lat/lng position.
    */
   def getStreetEdgeIdClosestToLatLng(lat: Double, lng: Double): DBIO[Int] = {
-    streets
-      .filterNot(_.deleted)
+    streetEdgeTable.streetsWithTutorial
       .map(s => (s.streetEdgeId, s.geom.distanceSphereD(makePoint(lng.bind, lat.bind).setSRID(4326))))
       .sortBy(_._2)
       .map(_._1)

--- a/app/models/region/RegionCompletionTable.scala
+++ b/app/models/region/RegionCompletionTable.scala
@@ -1,8 +1,8 @@
 package models.region
 
 import com.google.inject.ImplementedBy
-import models.street.{StreetEdgePriorityTableDef, StreetEdgeRegionTableDef, StreetEdgeTableDef}
-import models.utils.MyPostgresProfile
+import models.street.{StreetEdgePriorityTableDef, StreetEdgeRegionTableDef, StreetEdgeTable}
+import models.utils.{ConfigTableDef, MyPostgresProfile}
 import models.utils.MyPostgresProfile.api._
 import play.api.db.slick.{DatabaseConfigProvider, HasDatabaseConfigProvider}
 
@@ -24,7 +24,10 @@ class RegionCompletionTableDef(tag: Tag) extends Table[RegionCompletion](tag, "r
 trait RegionCompletionTableRepository {}
 
 @Singleton
-class RegionCompletionTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvider)(implicit
+class RegionCompletionTable @Inject() (
+    protected val dbConfigProvider: DatabaseConfigProvider,
+    streetEdgeTable: StreetEdgeTable
+)(implicit
     ec: ExecutionContext
 ) extends RegionCompletionTableRepository
     with HasDatabaseConfigProvider[MyPostgresProfile] {
@@ -32,10 +35,11 @@ class RegionCompletionTable @Inject() (protected val dbConfigProvider: DatabaseC
   val regionCompletions       = TableQuery[RegionCompletionTableDef]
   val regions                 = TableQuery[RegionTableDef]
   val streetEdgeRegion        = TableQuery[StreetEdgeRegionTableDef]
-  val streetEdgeTable         = TableQuery[StreetEdgeTableDef]
   val streetEdgePriorityTable = TableQuery[StreetEdgePriorityTableDef]
-  val streetsWithoutDeleted   = streetEdgeTable.filter(_.deleted === false)
+  val configTable             = TableQuery[ConfigTableDef]
   val regionsWithoutDeleted   = regions.filter(_.deleted === false)
+
+  val tutorialStreetId: Query[Rep[Int], Int, Seq] = configTable.map(_.tutorialStreetEdgeID)
 
   def count: DBIO[Int] = regionCompletions.length.result
 
@@ -54,10 +58,19 @@ class RegionCompletionTable @Inject() (protected val dbConfigProvider: DatabaseC
 
   /**
    * Increase the `audited_distance` column of the corresponding region by the length of the specified street edge.
+   * Short-circuits for the tutorial street — it's excluded from region completion totals entirely, so crediting its
+   * distance here would overshoot `total_distance`.
    */
   def updateAuditedDistance(streetEdgeId: Int): DBIO[Int] = {
+    tutorialStreetId.filter(_ === streetEdgeId).exists.result.flatMap { isTutorial =>
+      if (isTutorial) DBIO.successful(0)
+      else doUpdateAuditedDistance(streetEdgeId)
+    }
+  }
+
+  private def doUpdateAuditedDistance(streetEdgeId: Int): DBIO[Int] = {
     for {
-      distToAdd: Double <- streetsWithoutDeleted
+      distToAdd: Double <- streetEdgeTable.streets
         .filter(_.streetEdgeId === streetEdgeId)
         .map(_.geom.transform(26918).lengthD)
         .result
@@ -70,11 +83,16 @@ class RegionCompletionTable @Inject() (protected val dbConfigProvider: DatabaseC
         .result
         .head
 
-      // Check if neighborhood is fully audited.
+      // Check if neighborhood is fully audited. Exclude the tutorial street (permanent priority=1.0) and the street
+      // currently being audited (its priority update runs separately in partiallyUpdatePriority — if we don't exclude
+      // it here, the last street in a region always appears un-audited at this point, so regionIncomplete is always
+      // true and the floating-point equalization never fires).
       regionIncomplete: Boolean <- streetEdgeRegion
         .join(streetEdgePriorityTable)
         .on(_.streetEdgeId === _.streetEdgeId)
         .filter(x => x._1.regionId === regionId && x._2.priority === 1.0)
+        .filterNot(_._1.streetEdgeId in tutorialStreetId)
+        .filterNot(_._1.streetEdgeId === streetEdgeId)
         .exists
         .result
 

--- a/app/models/street/StreetEdgePriorityTable.scala
+++ b/app/models/street/StreetEdgePriorityTable.scala
@@ -33,17 +33,16 @@ trait StreetEdgePriorityTableRepository {}
 @Singleton
 class StreetEdgePriorityTable @Inject() (
     protected val dbConfigProvider: DatabaseConfigProvider,
+    streetEdgeTable: StreetEdgeTable,
     implicit val ec: ExecutionContext
 ) extends StreetEdgePriorityTableRepository
     with HasDatabaseConfigProvider[MyPostgresProfile] {
 
-  val userStats                 = TableQuery[UserStatTableDef]
-  val streetEdgePriorities      = TableQuery[StreetEdgePriorityTableDef]
-  val streetEdges               = TableQuery[StreetEdgeTableDef]
-  val streetEdgesWithoutDeleted = streetEdges.filter(_.deleted === false)
-  val streetEdgeRegionTable     = TableQuery[StreetEdgeRegionTableDef]
-  val auditTaskTable            = TableQuery[AuditTaskTableDef]
-  val completedTasks            = auditTaskTable.filter(_.completed === true)
+  val userStats             = TableQuery[UserStatTableDef]
+  val streetEdgePriorities  = TableQuery[StreetEdgePriorityTableDef]
+  val streetEdgeRegionTable = TableQuery[StreetEdgeRegionTableDef]
+  val auditTaskTable        = TableQuery[AuditTaskTableDef]
+  val completedTasks        = auditTaskTable.filter(_.completed === true)
 
   def insert(streetEdgePriority: StreetEdgePriority): DBIO[Int] = {
     (streetEdgePriorities returning streetEdgePriorities.map(_.streetEdgePriorityId)) += streetEdgePriority
@@ -52,7 +51,7 @@ class StreetEdgePriorityTable @Inject() (
   def auditedStreetDistanceUsingPriority: DBIO[Double] = {
     // Get the lengths of all the audited street edges.
     val edgeLengths = for {
-      se  <- streetEdgesWithoutDeleted
+      se  <- streetEdgeTable.streets
       sep <- streetEdgePriorities if se.streetEdgeId === sep.streetEdgeId
       if sep.priority < 1.0d
     } yield se.geom.transform(26918).lengthD
@@ -200,9 +199,10 @@ class StreetEdgePriorityTable @Inject() (
       completions.filterNot(_._2).groupBy(_._1).map { case (edge, group) => (edge, group.length) }
 
     // Join the good and bad user audit counts with street_edge table, filling in any counts not present as 0. We now
-    // have a table with three columns: street_edge_id, good_user_audit_count, bad_user_audit_count.
+    // have a table with three columns: street_edge_id, good_user_audit_count, bad_user_audit_count. We keep tutorial
+    // street in the set so its street_edge_priority row stays at priority=1.0 (it's never a regular audit target).
     val allAuditCounts =
-      streetEdgesWithoutDeleted
+      streetEdgeTable.streetsWithTutorial
         .joinLeft(goodUserAuditCounts)
         .on(_.streetEdgeId === _._1)
         .map { case (_edge, _goodCount) => (_edge.streetEdgeId, _goodCount.map(_._2).getOrElse(0)) }

--- a/app/models/street/StreetEdgeRegionTable.scala
+++ b/app/models/street/StreetEdgeRegionTable.scala
@@ -39,7 +39,7 @@ class StreetEdgeRegionTable @Inject() (
   val regionsWithoutDeleted       = regionTable.filter(_.deleted === false)
   val nonDeletedStreetEdgeRegions = for {
     _ser <- streetEdgeRegionTable
-    _se  <- streetEdgeTable.streetEdgesWithoutDeleted if _ser.streetEdgeId === _se.streetEdgeId
+    _se  <- streetEdgeTable.streets if _ser.streetEdgeId === _se.streetEdgeId
     _r   <- regionsWithoutDeleted if _ser.regionId === _r.regionId
   } yield _ser
 

--- a/app/models/street/StreetEdgeTable.scala
+++ b/app/models/street/StreetEdgeTable.scala
@@ -8,7 +8,7 @@ import models.user.RoleTable.RESEARCHER_ROLES
 import models.user.{RoleTableDef, UserRoleTableDef, UserStatTableDef}
 import models.utils.MyPostgresProfile.api._
 import models.utils.SpatialQueryType.SpatialQueryType
-import models.utils.{LatLngBBox, MyPostgresProfile, SpatialQueryType}
+import models.utils.{ConfigTableDef, LatLngBBox, MyPostgresProfile, SpatialQueryType}
 import org.locationtech.jts.geom.LineString
 import org.postgresql.jdbc.PgArray
 import play.api.db.slick.{DatabaseConfigProvider, HasDatabaseConfigProvider}
@@ -101,14 +101,23 @@ class StreetEdgeTable @Inject() (
     )
   })
 
-  val auditTasks       = TableQuery[AuditTaskTableDef]
-  val streetEdges      = TableQuery[StreetEdgeTableDef]
-  val streetEdgeRegion = TableQuery[StreetEdgeRegionTableDef]
-  val osmWayStreetEdge = TableQuery[OsmWayStreetEdgeTableDef]
-  val regions          = TableQuery[RegionTableDef]
-  val userStats        = TableQuery[UserStatTableDef]
-  val userRoles        = TableQuery[UserRoleTableDef]
-  val roleTable        = TableQuery[RoleTableDef]
+  val auditTasks        = TableQuery[AuditTaskTableDef]
+  val streetsUnfiltered = TableQuery[StreetEdgeTableDef]
+  val streetEdgeRegion  = TableQuery[StreetEdgeRegionTableDef]
+  val osmWayStreetEdge  = TableQuery[OsmWayStreetEdgeTableDef]
+  val regions           = TableQuery[RegionTableDef]
+  val userStats         = TableQuery[UserStatTableDef]
+  val userRoles         = TableQuery[UserRoleTableDef]
+  val roleTable         = TableQuery[RoleTableDef]
+  val configTable       = TableQuery[ConfigTableDef]
+
+  val tutorialStreetId: Query[Rep[Int], Int, Seq] = configTable.map(_.tutorialStreetEdgeID)
+
+  // `streetsWithTutorial` drops deleted streets only. `streets` is the default set: drops deleted AND the tutorial
+  // street, which is randomly assigned to a region at db init but should not be user-routable outside the tutorial.
+  // Use `streetsUnfiltered` only when you specifically need access to the tutorial or deleted streets.
+  val streetsWithTutorial = streetsUnfiltered.filterNot(_.deleted)
+  val streets             = streetsWithTutorial.filterNot(_.streetEdgeId in tutorialStreetId)
 
   val roleTableWithResearchersCollapsed = roleTable.map(_roles =>
     (
@@ -120,27 +129,25 @@ class StreetEdgeTable @Inject() (
   val completedAuditTasksWithUsers = auditTasks
     .join(userStats)
     .on(_.userId === _.userId)
-    .join(streetEdges)
+    .join(streets)
     .on(_._1.streetEdgeId === _.streetEdgeId)
-    .filter { case ((t, u), s) => t.completed && !u.excluded && !s.deleted }
+    .filter { case ((t, u), _) => t.completed && !u.excluded }
   val completedAuditTasks       = completedAuditTasksWithUsers.map(_._1._1)
   val highQualityCompletedTasks = completedAuditTasksWithUsers.filter(_._1._2.highQuality).map(_._1._1)
 
-  val streetEdgesWithoutDeleted = streetEdges.filter(_.deleted === false)
-
   def getStreet(streetEdgeId: Int): DBIO[Option[StreetEdge]] = {
-    streetEdgesWithoutDeleted.filter(_.streetEdgeId === streetEdgeId).result.headOption
+    streetsWithTutorial.filter(_.streetEdgeId === streetEdgeId).result.headOption
   }
 
   def streetCount: DBIO[Int] = {
-    streetEdgesWithoutDeleted.length.result
+    streets.length.result
   }
 
   /**
    * Get the total street distance in meters.
    */
   def totalStreetDistance: DBIO[Double] = {
-    streetEdgesWithoutDeleted.map(_.geom.transform(26918).lengthD).sum.result.map(x => x.getOrElse(0.0d))
+    streets.map(_.geom.transform(26918).lengthD).sum.result.map(x => x.getOrElse(0.0d))
   }
 
   /**
@@ -153,7 +160,7 @@ class StreetEdgeTable @Inject() (
     // Get the street edges that have been audited.
     val edges = for {
       _tasks <- filteredTasks
-      _edges <- streetEdgesWithoutDeleted if _tasks.streetEdgeId === _edges.streetEdgeId
+      _edges <- streets if _tasks.streetEdgeId === _edges.streetEdgeId
     } yield _edges
 
     // Get length of each street segment, sum the lengths, and convert from meters to miles.
@@ -170,7 +177,7 @@ class StreetEdgeTable @Inject() (
     // Group by role and sum distance of distinct street edges.
     (for {
       _tasks    <- filteredTasks
-      _edges    <- streetEdges if _tasks.streetEdgeId === _edges.streetEdgeId
+      _edges    <- streets if _tasks.streetEdgeId === _edges.streetEdgeId
       _userRole <- userRoles if _userRole.userId === _tasks.userId
       _role     <- roleTableWithResearchersCollapsed if _role._1 === _userRole.roleId
     } yield (_role._2, _edges.streetEdgeId, _edges.geom))
@@ -195,11 +202,11 @@ class StreetEdgeTable @Inject() (
       case _                  => auditTasks
     }
 
-    streetEdges
+    streets
       .join(tasksEndedInTimeInterval)
       .on(_.streetEdgeId === _.streetEdgeId)
-      .filter { case (street, task) => street.deleted === false && task.completed === true }
-      .map { case (street, task) => street.geom.transform(26918).lengthD }
+      .filter { case (_, task) => task.completed === true }
+      .map { case (street, _) => street.geom.transform(26918).lengthD }
       .sum
       .result
       .map(_.getOrElse(0.0d))
@@ -215,7 +222,7 @@ class StreetEdgeTable @Inject() (
       .groupBy(_.streetEdgeId)
       .map { case (streetId, rows) => (streetId, rows.map(_.taskEnd).min.trunc("day")) }
       // Join with street edges to get the geometry.
-      .join(streetEdgesWithoutDeleted)
+      .join(streets)
       .on(_._1 === _.streetEdgeId)
       // Group by date and sum the distances.
       .groupBy(_._1._2)
@@ -262,7 +269,7 @@ class StreetEdgeTable @Inject() (
     require(spatialQueryType != SpatialQueryType.LabelCluster, "This method is not supported for the Clusters API.")
 
     // Do all the necessary joins to get all the data we need.
-    val baseQuery = streetEdgesWithoutDeleted
+    val baseQuery = streets
       .join(osmWayStreetEdge)
       .on(_.streetEdgeId === _.streetEdgeId)
       .join(streetEdgeRegion)
@@ -347,10 +354,11 @@ class StreetEdgeTable @Inject() (
         JOIN street_edge_region r ON s.street_edge_id = r.street_edge_id
         JOIN region reg ON r.region_id = reg.region_id
         WHERE s.deleted = false
-        $bboxFilter
-        $wayTypeFilter
-        $regionIdFilter
-        $regionNameFilter
+            AND s.street_edge_id <> (SELECT tutorial_street_edge_id FROM config)
+            $bboxFilter
+            $wayTypeFilter
+            $regionIdFilter
+            $regionNameFilter
       ),
       -- Get audit counts.
       audit_counts AS (
@@ -362,10 +370,10 @@ class StreetEdgeTable @Inject() (
       -- Get label counts, users, and timestamps.
       label_stats AS (
         SELECT s.street_edge_id,
-              COUNT(l.label_id) as label_count,
-              array_agg(DISTINCT l.user_id) as user_ids,
-              MIN(l.time_created) as first_label_date,
-              MAX(l.time_created) as last_label_date
+               COUNT(l.label_id) as label_count,
+               array_agg(DISTINCT l.user_id) as user_ids,
+               MIN(l.time_created) as first_label_date,
+               MAX(l.time_created) as last_label_date
         FROM filtered_streets s
         LEFT JOIN label l ON s.street_edge_id = l.street_edge_id
             AND l.deleted = false
@@ -376,19 +384,19 @@ class StreetEdgeTable @Inject() (
       )
       -- Final selection with all filters applied.
       SELECT s.street_edge_id, s.osm_way_id, s.region_id, s.region_name, s.way_type,
-            COALESCE(l.user_ids, ARRAY[]::text[]) as user_ids,
-            COALESCE(l.label_count, 0) as label_count,
-            COALESCE(a.audit_count, 0) as audit_count,
-            l.first_label_date,
-            l.last_label_date,
-            s.geom
+             COALESCE(l.user_ids, ARRAY[]::text[]) as user_ids,
+             COALESCE(l.label_count, 0) as label_count,
+             COALESCE(a.audit_count, 0) as audit_count,
+             l.first_label_date,
+             l.last_label_date,
+             s.geom
       FROM filtered_streets s
       LEFT JOIN audit_counts a ON s.street_edge_id = a.street_edge_id
       LEFT JOIN label_stats l ON s.street_edge_id = l.street_edge_id
       WHERE 1=1
-      $minLabelCountFilter
-      $minAuditCountFilter
-      $minUserCountFilter
+        $minLabelCountFilter
+        $minAuditCountFilter
+        $minUserCountFilter
     """
 
     // Use the plainSQL function with GetResult implicit for StreetDataForApi.
@@ -423,7 +431,7 @@ class StreetEdgeTable @Inject() (
    * @return A database action that yields a sequence of (wayType, count) tuples.
    */
   def getStreetTypes: DBIO[Seq[(String, Int)]] = {
-    streetEdgesWithoutDeleted
+    streets
       .groupBy(_.wayType)
       .map { case (wayType, group) => (wayType, group.length) }
       .result
@@ -435,7 +443,7 @@ class StreetEdgeTable @Inject() (
    * @return A DBIO action that returns an Option containing the azimuth in radians
    */
   def directionFromStart(streetEdgeId: Int): DBIO[Option[Double]] = {
-    streetEdgesWithoutDeleted
+    streetsWithTutorial
       .filter(_.streetEdgeId === streetEdgeId)
       .map { street => street.geom.startPoint.azimuthD(street.geom.pointN(2)) }
       .result
@@ -448,7 +456,7 @@ class StreetEdgeTable @Inject() (
    * @return A DBIO action that returns an Option containing the azimuth in radians
    */
   def directionFromEnd(streetEdgeId: Int): DBIO[Option[Double]] = {
-    streetEdgesWithoutDeleted
+    streetsWithTutorial
       .filter(_.streetEdgeId === streetEdgeId)
       .map { street => street.geom.endPoint.azimuthD(street.geom.pointN(street.geom.nPoints - 1)) }
       .result

--- a/app/models/user/UserStatTable.scala
+++ b/app/models/user/UserStatTable.scala
@@ -4,7 +4,7 @@ import com.google.inject.ImplementedBy
 import models.audit.AuditTaskTableDef
 import models.label.{LabelTable, LabelTypeEnum}
 import models.mission.{MissionTableDef, MissionTypeTable}
-import models.street.StreetEdgeTableDef
+import models.street.StreetEdgeTable
 import models.user.RoleTable.{RESEARCHER_ROLES, ROLES_RESEARCHER_COLLAPSED}
 import models.utils.MyPostgresProfile
 import models.utils.MyPostgresProfile.api._
@@ -126,6 +126,7 @@ trait UserStatTableRepository {}
 class UserStatTable @Inject() (
     protected val dbConfigProvider: DatabaseConfigProvider,
     sidewalkUserTable: SidewalkUserTable,
+    streetEdgeTable: StreetEdgeTable,
     labelTable: LabelTable
 )(implicit ec: ExecutionContext)
     extends UserStatTableRepository
@@ -134,7 +135,6 @@ class UserStatTable @Inject() (
   private val userStats            = TableQuery[UserStatTableDef]
   private val userRoleTable        = TableQuery[UserRoleTableDef]
   private val auditTaskTable       = TableQuery[AuditTaskTableDef]
-  private val streetEdgeTable      = TableQuery[StreetEdgeTableDef]
   private val missionTable         = TableQuery[MissionTableDef]
   private val labelValidationTable = TableQuery[LabelValidationTableDef]
 
@@ -236,7 +236,7 @@ class UserStatTable @Inject() (
       .filter(_.completed === true)
       .join(usersToUpdate)
       .on(_.userId === _)
-      .join(streetEdgeTable)
+      .join(streetEdgeTable.streets)
       .on(_._1.streetEdgeId === _.streetEdgeId)
       .groupBy(_._1._1.userId)
       .map(x => (x._1, x._2.map(_._2.geom.transform(26918).lengthD).sum))

--- a/app/service/RegionService.scala
+++ b/app/service/RegionService.scala
@@ -61,8 +61,8 @@ class RegionServiceImpl @Inject() (
       numInserted: Int <-
         if (count == 0) {
           val streetsInRegion = for {
-            _edgeRegion <- streetEdgeRegion
-            _edges      <- streetEdgeTable.streetEdgesWithoutDeleted if _edges.streetEdgeId === _edgeRegion.streetEdgeId
+            _edgeRegion   <- streetEdgeRegion
+            _edges        <- streetEdgeTable.streets if _edges.streetEdgeId === _edgeRegion.streetEdgeId
             _edgePriority <- streetEdgePriorities if _edges.streetEdgeId === _edgePriority.streetEdgeId
           } yield (_edgeRegion.regionId, _edges.geom.transform(26918), _edgePriority.priority < 1.0)
 

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -1011,7 +1011,7 @@
             const imagerySrc = "@commonData.imagerySource.toString";
             const viewerType = imagerySrc === 'mapillary' ? MapillaryViewer : imagerySrc === 'infra3d' ? Infra3dViewer : GsvViewer;
             const accessToken = "@commonData.imageryAccessToken";
-            window.admin = await Admin(_, $, '@commonData.mapboxApiKey', viewerType, accessToken, "@currentCity.cityNameShort", "@user.username");
+            window.admin = await Admin($, '@commonData.mapboxApiKey', viewerType, accessToken, "@currentCity.cityNameShort", "@user.username");
             // Initialize the sliders in the legend. We add the "change" functionality after the map loads.
             $("*[id*='slider']").each(function() {
                 $(this).slider({ range: true, min : 0, max : 3, step: 1, values: [0,3], disabled: true });

--- a/app/views/userProfile.scala.html
+++ b/app/views/userProfile.scala.html
@@ -442,7 +442,7 @@
             const imagerySrc = "@commonData.imagerySource.toString";
             const viewerType = imagerySrc === 'mapillary' ? MapillaryViewer : imagerySrc === 'infra3d' ? Infra3dViewer : GsvViewer;
             const accessToken = "@commonData.imageryAccessToken";
-            await Progress(_, $, '@commonData.mapboxApiKey', viewerType, accessToken, '@profileUser.userId', @admin, "@currentCity.cityNameShort", "@user.username");
+            await Progress($, '@commonData.mapboxApiKey', viewerType, accessToken, '@profileUser.userId', @admin, "@currentCity.cityNameShort", "@user.username");
             @if(admin) {
                 AdminUser('@profileUser.username', '@profileUser.userId', @profileUser.communityService, @profileUser.infra3dAccess);
                 $('#label-table').dataTable();

--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -1,4 +1,4 @@
-async function Admin(_, $, mapboxApiKey, viewerType, viewerAccessToken, cityName, currentUsername) {
+async function Admin($, mapboxApiKey, viewerType, viewerAccessToken, cityName, currentUsername) {
     const self = {};
     const $loadingGif = $('#page-loading');
     const legendTable = document.getElementById('legend-table');

--- a/public/javascripts/Progress/src/Progress.js
+++ b/public/javascripts/Progress/src/Progress.js
@@ -1,4 +1,4 @@
-async function Progress (_, $, mapboxApiKey, viewerType, viewerAccessToken, userId, admin, cityName, currentUsername) {
+async function Progress ($, mapboxApiKey, viewerType, viewerAccessToken, userId, admin, cityName, currentUsername) {
     var params = {
         mapName: 'user-dashboard-choropleth',
         mapStyle: 'mapbox://styles/mapbox/streets-v12?optimize=true',

--- a/public/javascripts/SVLabel/src/task/TaskContainer.js
+++ b/public/javascripts/SVLabel/src/task/TaskContainer.js
@@ -43,6 +43,10 @@ function TaskContainer (neighborhoodModel, svl, tracker) {
         // Updates the segments that the user has already explored.
         self.updateCurrentTask();
 
+        // Check if finishing this task completes the neighborhood across all users. Must run after task.complete() so
+        // the just-finished task is filtered out of getIncompleteTasksAcrossAllUsersUsingPriority() naturally.
+        updateNeighborhoodCompleteAcrossAllUsersStatus();
+
         return task;
     }
 
@@ -253,32 +257,17 @@ function TaskContainer (neighborhoodModel, svl, tracker) {
     };
 
     /**
-     * Checks if finishedTask makes the neighborhood complete across all users; if so, it displays the relevant overlay.
-     *
-     * @param {Task} finishedTask
+     * Checks if the neighborhood is complete across all users; if so, displays the relevant overlay.
      */
-    function updateNeighborhoodCompleteAcrossAllUsersStatus(finishedTask) {
+    function updateNeighborhoodCompleteAcrossAllUsersStatus() {
         // Only run this code if the neighborhood was set as incomplete and user is not on a designated route.
         if (!neighborhoodModel.isRoute && !neighborhoodModel.getNeighborhoodCompleteAcrossAllUsers()) {
-            const candidateTasks = self.getIncompleteTasksAcrossAllUsersUsingPriority().filter(function (t) {
-                return (t.getStreetEdgeId() !== (finishedTask ? finishedTask.getStreetEdgeId() : null));
-            });
             // Indicates neighborhood is complete.
-            if (candidateTasks.length === 0) {
-                // TODO: Remove the console.log statements if issue #1449 has been resolved.
-                console.error('finished neighborhood screen has appeared, logging debug info');
-                console.trace();
-                console.log('incompleteTasks.length:' +
-                    self.getIncompleteTasksAcrossAllUsersUsingPriority().length);
-                console.log('finishedTask streetEdgeId: ' + finishedTask.getStreetEdgeId());
-
+            if (self.getIncompleteTasksAcrossAllUsersUsingPriority().length === 0) {
                 neighborhoodModel.setNeighborhoodCompleteAcrossAllUsers();
                 svl.ui.areaComplete.overlay.show();
                 const currentNeighborhood = svl.neighborhoodModel.currentNeighborhood();
                 const currentNeighborhoodId = currentNeighborhood.getRegionId();
-
-                console.log('neighborhood: ' + currentNeighborhoodId + ": " + currentNeighborhood);
-
                 tracker.push("NeighborhoodComplete_AcrossAllUsers", { 'RegionId': currentNeighborhoodId });
             }
         }
@@ -299,9 +288,6 @@ function TaskContainer (neighborhoodModel, svl, tracker) {
      */
     this.nextTask = function(finishedTask) {
         let newTask;
-
-        // Check if this task finishes the neighborhood across all users, if so, shows neighborhood complete overlay.
-        updateNeighborhoodCompleteAcrossAllUsersStatus(finishedTask);
 
         // Check if user has audited entire region or route.
         let tasksNotCompletedByUser = self.getTasks().filter(function (t) {


### PR DESCRIPTION
Resolves #2782 
Fixes #3680 

The tutorial street from DC will no longer be shown on the Explore page during normal missions. This was especially jarring in international deployments! Doing this just required some care in making sure that all of the edge cases have been ironed out: the tutorial street still needs to be assigned to a region so that db columns aren't made nullable specifically for the tutorial, but we are now filtering it out in nearly all queries.

While testing, I ended up fixing another issue: the "Neighborhood complete" screen was showing up before users were able to finish labeling their last intersection. This both prevented users from finishing their labeling, but it also made it so that their last street was never marked as complete, and neither was the neighborhood! 

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
