### PR TITLE
AI suggests tags to remove; AI tag suggestions now more accurate

### DIFF
--- a/app/formats/json/LabelFormats.scala
+++ b/app/formats/json/LabelFormats.scala
@@ -125,11 +125,12 @@ object LabelFormats {
       "ai_validation"   -> labelMetadata.validationInfo.aiValidation.map(LabelValidationTable.validationOptions.get),
       "tags"            -> labelMetadata.tags,
       "ai_tags"         -> labelMetadata.aiTags,
-      "ai_generated"    -> labelMetadata.aiGenerated,
-      "expired"         -> labelMetadata.expired,
-      "comments"        -> labelMetadata.comments.map(_.comment),
-      "from_current_user" -> labelMetadata.fromCurrentUser,
-      "admin_data"        -> adminData.map(ad =>
+      "ai_tags_not_present" -> labelMetadata.aiTagsNotPresent,
+      "ai_generated"        -> labelMetadata.aiGenerated,
+      "expired"             -> labelMetadata.expired,
+      "comments"            -> labelMetadata.comments.map(_.comment),
+      "from_current_user"   -> labelMetadata.fromCurrentUser,
+      "admin_data"          -> adminData.map(ad =>
         Json.obj(
           "username"             -> ad.username,
           "previous_validations" -> ad.previousValidations.map(prevVal =>

--- a/app/models/label/LabelAiAssessmentTable.scala
+++ b/app/models/label/LabelAiAssessmentTable.scala
@@ -16,6 +16,7 @@ case class LabelAiAssessment(
     validationAccuracy: Double,
     validationConfidence: Double,
     tags: Option[List[String]],
+    tagsNotPresent: Option[List[String]],
     tagsConfidence: Option[Seq[AiTagConfidence]],
     apiVersion: String,
     validatorModelId: String,
@@ -33,6 +34,7 @@ class LabelAiAssessmentTableDef(tag: Tag) extends Table[LabelAiAssessment](tag, 
   def validationAccuracy: Rep[Double]                   = column[Double]("validation_accuracy")
   def validationConfidence: Rep[Double]                 = column[Double]("validation_confidence")
   def tags: Rep[Option[List[String]]]                   = column[Option[List[String]]]("tags")
+  def tagsNotPresent: Rep[Option[List[String]]]         = column[Option[List[String]]]("tags_not_present")
   def tagsConfidence: Rep[Option[Seq[AiTagConfidence]]] = column[Option[Seq[AiTagConfidence]]]("tags_confidence")
   def apiVersion: Rep[String]                           = column[String]("api_version")
   def validatorModelId: Rep[String]                     = column[String]("validator_model_id")
@@ -43,8 +45,8 @@ class LabelAiAssessmentTableDef(tag: Tag) extends Table[LabelAiAssessment](tag, 
   def labelValidationId: Rep[Option[Int]] = column[Option[Int]]("label_validation_id")
 
   def * =
-    (labelAiAssessmentId, labelId, validationResult, validationAccuracy, validationConfidence, tags, tagsConfidence,
-      apiVersion, validatorModelId, validatorTrainingDate, taggerModelId, taggerTrainingDate, timestamp,
+    (labelAiAssessmentId, labelId, validationResult, validationAccuracy, validationConfidence, tags, tagsNotPresent,
+      tagsConfidence, apiVersion, validatorModelId, validatorTrainingDate, taggerModelId, taggerTrainingDate, timestamp,
       labelValidationId) <> (
       (LabelAiAssessment.apply _).tupled,
       LabelAiAssessment.unapply

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -241,6 +241,7 @@ case class LabelValidationMetadata(
     tags: Seq[String],
     cameraLocation: Option[LatLng],
     aiTags: Option[Seq[String]],
+    aiTagsNotPresent: Option[Seq[String]],
     aiGenerated: Boolean,
     comments: Seq[LabelComment] = Seq.empty,
     fromCurrentUser: Boolean = false
@@ -338,6 +339,7 @@ object LabelTable {
       List[String],                     // tags
       (Option[Double], Option[Double]), // cameraLocation (lat, lng)
       Option[List[String]],             // aiTags
+      Option[List[String]],             // aiTagsNotPresent
       Boolean,                          // aiGenerated
       Option[String],                   // comments (JSON-aggregated)
       Boolean                           // fromCurrentUser
@@ -361,6 +363,7 @@ object LabelTable {
       Rep[List[String]],                                                                        // tags
       (Rep[Option[Double]], Rep[Option[Double]]), // cameraLocation (lat, lng)
       Rep[Option[List[String]]],                  // aiTags
+      Rep[Option[List[String]]],                  // aiTagsNotPresent
       Rep[Boolean],                               // aiGenerated
       Rep[Option[String]],                        // comments (JSON-aggregated)
       Rep[Boolean]                                // fromCurrentUser
@@ -391,15 +394,16 @@ object LabelTable {
           case _                      => None
         },
         aiTags = t._18,
-        aiGenerated = t._19,
-        comments = t._20
+        aiTagsNotPresent = t._19,
+        aiGenerated = t._20,
+        comments = t._21
           .map { json =>
             play.api.libs.json.Json.parse(json).as[Seq[play.api.libs.json.JsObject]].map { obj =>
               LabelComment((obj \ "username").as[String], (obj \ "comment").as[String])
             }
           }
           .getOrElse(Seq.empty),
-        fromCurrentUser = t._21
+        fromCurrentUser = t._22
       )
     }
 
@@ -1019,8 +1023,11 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
           ),
           l.tags,
           (pd.lat, pd.lng),
-          // Include AI tags if requested.
+          // Include AI tag suggestions (present and not present) if requested.
           if (includeAiTags) laa.flatMap(_.tags).getOrElse(List.empty[String].bind).asColumnOf[Option[List[String]]]
+          else None.asInstanceOf[Option[List[String]]].asColumnOf[Option[List[String]]],
+          if (includeAiTags)
+            laa.flatMap(_.tagsNotPresent).getOrElse(List.empty[String].bind).asColumnOf[Option[List[String]]]
           else None.asInstanceOf[Option[List[String]]].asColumnOf[Option[List[String]]],
           isAiUser,
           None.asInstanceOf[Option[String]].asColumnOf[Option[String]], // Comments not needed for validation rn.
@@ -1168,7 +1175,8 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
         aiv.map(_.validationResult)),
       lb.tags,
       (pd.lat, pd.lng),
-      // Placeholder for AI tags, since we don't show those on Gallery right now.
+      // Placeholder for AI tags (present and not present), since we don't show those on Gallery right now.
+      None.asInstanceOf[Option[List[String]]].asColumnOf[Option[List[String]]],
       None.asInstanceOf[Option[List[String]]].asColumnOf[Option[List[String]]],
       isAiUser,
       comments.flatMap(_.comments), // pre-aggregated comments string from VIEW

--- a/app/service/AiService.scala
+++ b/app/service/AiService.scala
@@ -191,10 +191,11 @@ class AiServiceImpl @Inject() (
             val tagsConfidence: Option[Seq[AiTagConfidence]] = (json \ "tag_scores")
               .asOpt[JsObject]
               .map(_.fields.map { case (tag, jsValue) => AiTagConfidence(tag, jsValue.as[Double]) }.toSeq)
-            val tags          = (json \ "tags").asOpt[List[String]].map(tags => tags.filter(tag => tag != "NULL"))
-            val apiVersion    = (json \ "api_version").as[String]
-            val valModelId    = (json \ "validator_model_id").as[String]
-            val taggerModelId = (json \ "tagger_model_id").asOpt[String]
+            val tags           = (json \ "tags").asOpt[List[String]]
+            val tagsNotPresent = (json \ "tags_not_present").asOpt[List[String]]
+            val apiVersion     = (json \ "api_version").as[String]
+            val valModelId     = (json \ "validator_model_id").as[String]
+            val taggerModelId  = (json \ "tagger_model_id").asOpt[String]
 
             // Read training dates.
             val dateFormatter   = DateTimeFormatter.ofPattern("MM-dd-yyyy")
@@ -207,8 +208,9 @@ class AiServiceImpl @Inject() (
               .map(dateStr => LocalDate.parse(dateStr, dateFormatter).atStartOfDay(ZoneOffset.UTC).toOffsetDateTime)
 
             Some(
-              LabelAiAssessment(0, labelData.labelId, valResult, valAccuracy, valConfidence, tags, tagsConfidence,
-                apiVersion, valModelId, valTrainingDate, taggerModelId, taggerTrainingDate, OffsetDateTime.now, None)
+              LabelAiAssessment(0, labelData.labelId, valResult, valAccuracy, valConfidence, tags, tagsNotPresent,
+                tagsConfidence, apiVersion, valModelId, valTrainingDate, taggerModelId, taggerTrainingDate,
+                OffsetDateTime.now, None)
             )
           } else {
             logger.warn(s"AI API for label $labelId returned error status: ${response.status} - ${response.statusText}")

--- a/conf/evolutions/default/312.sql
+++ b/conf/evolutions/default/312.sql
@@ -1,0 +1,5 @@
+# --- !Ups
+ALTER TABLE label_ai_assessment ADD COLUMN tags_not_present TEXT[] DEFAULT '{}';
+
+# --- !Downs
+ALTER TABLE label_ai_assessment DROP COLUMN tags_not_present;

--- a/conf/evolutions/default/312.sql
+++ b/conf/evolutions/default/312.sql
@@ -1,5 +1,82 @@
 # --- !Ups
 ALTER TABLE label_ai_assessment ADD COLUMN tags_not_present TEXT[] DEFAULT '{}';
 
+-- Backfill `tags` and `tags_not_present` for existing rows using the new per-tag thresholds. The AI models haven't
+-- changed, so the stored `tags_confidence` scores are still valid -- only the rules for promoting a score to a
+-- "present" or "not present" suggestion have changed. Thresholds are defined here:
+-- https://github.com/ProjectSidewalk/sidewalk-ai-api/commit/fe0652dc5fc0d01f565a5800fc0f12732f74dfc4#diff-b6c2623e405dd5ad8df81926b45fa6598fe31018a5f8d291267039ea44ab3467
+WITH
+add_thresholds(label_type_id, tag, threshold) AS (VALUES
+    -- CurbRamp.
+    (1, 'missing tactile warning', 0.999032616615295::DOUBLE PRECISION),
+    -- Obstacle.
+    (3, 'parked car',              0.99954742193222::DOUBLE PRECISION),
+    (3, 'trash/recycling can',     0.996601343154907::DOUBLE PRECISION),
+    -- SurfaceProblem.
+    (4, 'brick/cobblestone',       0.460518807172775::DOUBLE PRECISION),
+    (4, 'grass',                   0.878179550170898::DOUBLE PRECISION),
+    (4, 'height difference',       0.990894317626953::DOUBLE PRECISION)
+    -- Crosswalk: none.
+),
+remove_thresholds(label_type_id, tag, threshold) AS (VALUES
+    -- CurbRamp.
+    (1, 'missing tactile warning', 0.137371987104416::DOUBLE PRECISION),
+    (1, 'points into traffic',     0.0000236960186157376::DOUBLE PRECISION),
+    (1, 'surface problem',         0.0124074257910252::DOUBLE PRECISION),
+    -- Obstacle.
+    (3, 'construction',            0.00129300216212869::DOUBLE PRECISION),
+    (3, 'parked car',              0.415593057870865::DOUBLE PRECISION),
+    (3, 'pole',                    0.538854777812958::DOUBLE PRECISION),
+    (3, 'trash/recycling can',     0.99326080083847::DOUBLE PRECISION),
+    (3, 'vegetation',              0.999191462993622::DOUBLE PRECISION),
+    -- SurfaceProblem.
+    (4, 'brick/cobblestone',       0.000102744284959044::DOUBLE PRECISION),
+    (4, 'grass',                   0.512212753295898::DOUBLE PRECISION),
+    (4, 'height difference',       0.0114266304299235::DOUBLE PRECISION),
+    -- Crosswalk.
+    (9, 'broken surface',          0.997941434383392::DOUBLE PRECISION),
+    (9, 'bumpy',                   0.000261053384747356::DOUBLE PRECISION),
+    (9, 'paint fading',            0.000167091304319911::DOUBLE PRECISION)
+),
+-- Flatten tags_confidence (a JSONB array of {tag, confidence}) into one row per (assessment, tag).
+expanded AS (
+    SELECT label_ai_assessment.label_ai_assessment_id,
+           label.label_type_id,
+           tc.tag,
+           tc.confidence
+    FROM label_ai_assessment
+    JOIN label ON label.label_id = label_ai_assessment.label_id
+    CROSS JOIN LATERAL jsonb_to_recordset(label_ai_assessment.tags_confidence)
+        AS tc(tag TEXT, confidence DOUBLE PRECISION)
+    WHERE label_ai_assessment.tags_confidence IS NOT NULL
+),
+new_tags AS (
+    SELECT expanded.label_ai_assessment_id,
+           ARRAY_AGG(expanded.tag ORDER BY expanded.tag) AS tags
+    FROM expanded
+    JOIN add_thresholds
+        ON add_thresholds.label_type_id = expanded.label_type_id
+        AND add_thresholds.tag = expanded.tag
+    WHERE expanded.confidence > add_thresholds.threshold
+    GROUP BY expanded.label_ai_assessment_id
+),
+new_tags_not_present AS (
+    SELECT expanded.label_ai_assessment_id,
+           ARRAY_AGG(expanded.tag ORDER BY expanded.tag) AS tags_not_present
+    FROM expanded
+    JOIN remove_thresholds
+        ON remove_thresholds.label_type_id = expanded.label_type_id
+        AND remove_thresholds.tag = expanded.tag
+    WHERE expanded.confidence < remove_thresholds.threshold
+    GROUP BY expanded.label_ai_assessment_id
+)
+UPDATE label_ai_assessment
+SET tags = COALESCE(new_tags.tags, '{}'),
+    tags_not_present = COALESCE(new_tags_not_present.tags_not_present, '{}')
+FROM label_ai_assessment AS laa_self
+LEFT JOIN new_tags ON new_tags.label_ai_assessment_id = laa_self.label_ai_assessment_id
+LEFT JOIN new_tags_not_present ON new_tags_not_present.label_ai_assessment_id = laa_self.label_ai_assessment_id
+WHERE label_ai_assessment.label_ai_assessment_id = laa_self.label_ai_assessment_id;
+
 # --- !Downs
 ALTER TABLE label_ai_assessment DROP COLUMN tags_not_present;

--- a/public/javascripts/SVValidate/src/label/Label.js
+++ b/public/javascripts/SVValidate/src/label/Label.js
@@ -28,6 +28,7 @@ function Label(params) {
         regionId: undefined,
         tags: undefined,
         aiTags: undefined,
+        aiTagsNotPresent: undefined,
         isMobile: undefined,
         aiGenerated: false
     };
@@ -123,6 +124,7 @@ function Label(params) {
                 setProperty('newTags', [...params.tags]); // Copy tags to newTags.
             }
             if ('ai_tags' in params) setAuditProperty('aiTags', params.ai_tags);
+            if ('ai_tags_not_present' in params) setAuditProperty('aiTagsNotPresent', params.ai_tags_not_present);
             if ('ai_generated' in params) setAuditProperty('aiGenerated', params.ai_generated);
             // Properties only used on the Admin version of Validate.
             if ('admin_data' in params && params.admin_data !== null) {

--- a/public/javascripts/SVValidate/src/menu/DesktopValidationMenu.js
+++ b/public/javascripts/SVValidate/src/menu/DesktopValidationMenu.js
@@ -388,9 +388,15 @@ function DesktopValidationMenu(menuUI) {
         if (label.getAuditProperty('aiTags') !== null) {
             const aiTags = label.getAuditProperty('aiTags');
             aiAddTagOptions = allTagOptions.filter(t => aiTags.includes(t.tag_name));
-            // TODO we need to set up a threshold where we decide to remove tags: issue #3998.
-            // aiRemoveTagOptions = currTags.filter(t => !aiTags.includes(t)).filter(t => !tagsAddedByUser.includes(t))
-            //     .map(t => allTagOptionsPermanent.find(t2 => t2.tag_name === t));
+        }
+        if (label.getAuditProperty('aiTagsNotPresent') !== null) {
+            const aiTagsNotPresent = label.getAuditProperty('aiTagsNotPresent');
+            // Only suggest removing tags that are currently on the label and were not added by the user this session.
+            aiRemoveTagOptions = currTags
+                .filter(t => aiTagsNotPresent.includes(t))
+                .filter(t => !tagsAddedByUser.includes(t))
+                .map(t => allTagOptionsPermanent.find(t2 => t2.tag_name === t))
+                .filter(t => t !== undefined);
         }
 
         // If there are AI suggestions, show the section and add the tag suggestions.
@@ -412,7 +418,10 @@ function DesktopValidationMenu(menuUI) {
                 // Add the text to the tag.
                 const translatedTagName = i18next.t(`common:tag.${tag.tag_name.replace(/:/g, '-')}`);
                 const addRemoveTranslationKey = 'expert-validate.' + (tag.action === 'add' ? 'add-tag' : 'remove-tag');
-                template.text(i18next.t(addRemoveTranslationKey, { tag: translatedTagName }));
+                template.text(i18next.t(addRemoveTranslationKey, {
+                    tag: translatedTagName,
+                    interpolation: { escapeValue: false }
+                }));
                 menuUI.aiSuggestedTagTemplate.parent().append(template);
 
                 // Show tooltip with example image for the tag.


### PR DESCRIPTION
Resolves #3998

We've further analyzed our [AI tagger](https://github.com/ProjectSidewalk/sidewalk-tagger-ai) data to ensure more accurate tag suggestions, and to begin to suggest tags for removal on Expert Validate.

We were just using a blanket confidence threshold of 0.7 across all tags, and if the model scored above 0.7, we would suggest adding the tag. What we now do is that we look for a confidences threshold that gets us to a precision of 92% (matching the precision we require for the AI validator). We do this to find cases where the AI tagger thinks that a tag _shouldn't_ be there, by looking for labels below a certain threshold. The thresholds are different for adding/removing tags.

I also made it a bit more strict: requiring a 95% Wilson lower bound of 90% on precision (meaning, given the size of our dataset, 95% of the time we would expect the true precision to be at least 90%). This, along with a few other filters, allow us to weed out problematic cases like not having enough data to _actually_ expect there to be a precision of 92%, or cases when just predicting "no" for every example would give us a precision of 92% already.

The [Sidewalk AI API](https://github.com/ProjectSidewalk/sidewalk-ai-api) has been updated to use these new thresholds. And the new version is already running. It is backward compatible with the old version, which means no issues with the current production environments.

This PR adds a column to start tracking the list of tags that AI thinks are not present. It also goes through all of our old predictions from the AI tagger and updates those entries in the database match what the AI API would give us for that label now. This is a one-time update to the old db entries, which means that we can avoid rerunning the tagger on all those labels again. We can do this because we stored all the confidence ratings in the db; the confidence ratings remain the same, the thresholds that determine whether we predict add/remove are all that's changed.

From my local db that comes from a recent Seattle db dump, I found that the average number of tags that we now suggest is at 0.31 tags per label, down from 0.96 tags per label before. This makes sense, as we've restricted ourselves to being much more confident in our suggestions (and we had in fact noticed that the tagger was giving a lot of false predictions). Though we now recommend removing 2.02 tags per label!*

*Edit: This isn't quite right. The tagger is confident that 2.02 tags per label shouldn't be there. I didn't compare to what the user actually placed.

##### Before/After screenshots (if applicable)
Here's a look at it working in my test environment. Excuse the bad example image, it was the first thing I found quickly (we should probably deal with the AI section requiring a scroll, but I'll save that for a future PR)
<img width="1382" height="744" alt="image" src="https://github.com/user-attachments/assets/d0ac6797-df03-4c77-8885-6c79783009d2" />

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
- [x] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure the documentation on [this wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Descriptions-of-Logged-Events) is up to date for the logs you added/updated.
