### PR TITLE
Requesting AI validation/tags on older imagery

### DIFF
--- a/app/models/label/LabelAiAssessmentTable.scala
+++ b/app/models/label/LabelAiAssessmentTable.scala
@@ -1,6 +1,7 @@
 package models.label
 
 import com.google.inject.ImplementedBy
+import models.label.AiImageSource.AiImageSource
 import models.utils.MyPostgresProfile.api._
 import models.utils.{AiTagConfidence, MyPostgresProfile}
 import play.api.db.slick.{DatabaseConfigProvider, HasDatabaseConfigProvider}
@@ -8,6 +9,13 @@ import play.api.db.slick.{DatabaseConfigProvider, HasDatabaseConfigProvider}
 import java.time.OffsetDateTime
 import javax.inject._
 import scala.concurrent.ExecutionContext
+
+// NOTE need to update ai_image_source enum in postgres as well if changing this Enumeration.
+object AiImageSource extends Enumeration {
+  type AiImageSource = Value
+  val Download = Value("download")
+  val Cache    = Value("cache")
+}
 
 case class LabelAiAssessment(
     labelAiAssessmentId: Int,
@@ -24,7 +32,8 @@ case class LabelAiAssessment(
     taggerModelId: Option[String],
     taggerTrainingDate: Option[OffsetDateTime],
     timestamp: OffsetDateTime,
-    labelValidationId: Option[Int]
+    labelValidationId: Option[Int],
+    aiImageSource: AiImageSource
 )
 
 class LabelAiAssessmentTableDef(tag: Tag) extends Table[LabelAiAssessment](tag, "label_ai_assessment") {
@@ -43,11 +52,12 @@ class LabelAiAssessmentTableDef(tag: Tag) extends Table[LabelAiAssessment](tag, 
   def taggerTrainingDate: Rep[Option[OffsetDateTime]]   = column[Option[OffsetDateTime]]("tagger_training_date")
   def timestamp: Rep[OffsetDateTime]      = column[OffsetDateTime]("timestamp", O.Default(OffsetDateTime.now))
   def labelValidationId: Rep[Option[Int]] = column[Option[Int]]("label_validation_id")
+  def aiImageSource: Rep[AiImageSource]   = column[AiImageSource]("ai_image_source")
 
   def * =
     (labelAiAssessmentId, labelId, validationResult, validationAccuracy, validationConfidence, tags, tagsNotPresent,
       tagsConfidence, apiVersion, validatorModelId, validatorTrainingDate, taggerModelId, taggerTrainingDate, timestamp,
-      labelValidationId) <> (
+      labelValidationId, aiImageSource) <> (
       (LabelAiAssessment.apply _).tupled,
       LabelAiAssessment.unapply
     )

--- a/app/models/label/LabelAiFailureTable.scala
+++ b/app/models/label/LabelAiFailureTable.scala
@@ -1,0 +1,44 @@
+package models.label
+
+import com.google.inject.ImplementedBy
+import models.utils.MyPostgresProfile
+import models.utils.MyPostgresProfile.api._
+import play.api.db.slick.{DatabaseConfigProvider, HasDatabaseConfigProvider}
+
+import java.time.OffsetDateTime
+import javax.inject._
+import scala.concurrent.ExecutionContext
+
+case class LabelAiFailure(labelId: Int, reason: String, timestamp: OffsetDateTime)
+
+class LabelAiFailureTableDef(tag: Tag) extends Table[LabelAiFailure](tag, "label_ai_failure") {
+  def labelId: Rep[Int]              = column[Int]("label_id", O.PrimaryKey)
+  def reason: Rep[String]            = column[String]("reason")
+  def timestamp: Rep[OffsetDateTime] = column[OffsetDateTime]("timestamp", O.Default(OffsetDateTime.now))
+
+  def * = (labelId, reason, timestamp) <> (
+    (LabelAiFailure.apply _).tupled,
+    LabelAiFailure.unapply
+  )
+}
+
+@ImplementedBy(classOf[LabelAiFailureTable])
+trait LabelAiFailureTableRepository {}
+
+@Singleton
+class LabelAiFailureTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvider)(implicit
+    val ec: ExecutionContext
+) extends LabelAiFailureTableRepository
+    with HasDatabaseConfigProvider[MyPostgresProfile] {
+
+  val labelAiFailures = TableQuery[LabelAiFailureTableDef]
+
+  /**
+   * Records a permanent AI validation failure for the given label so it will be skipped in future runs.
+   * @param labelId The label that the AI API could not assess
+   * @param reason A short description of why the failure is permanent (e.g., "Failed to fetch")
+   */
+  def save(labelId: Int, reason: String): DBIO[Int] = {
+    labelAiFailures += LabelAiFailure(labelId, reason, OffsetDateTime.now)
+  }
+}

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -535,6 +535,7 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
   val labelPoints            = TableQuery[LabelPointTableDef]
   val labelValidations       = TableQuery[LabelValidationTableDef]
   val labelAiAssessments     = TableQuery[LabelAiAssessmentTableDef]
+  val labelAiFailures        = TableQuery[LabelAiFailureTableDef]
   val missions               = TableQuery[MissionTableDef]
   val regions                = TableQuery[RegionTableDef]
   val usersUnfiltered        = TableQuery[SidewalkUserTableDef]
@@ -2034,7 +2035,10 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
       .joinLeft(labelAiAssessments)
       .on(_._1._1.labelId === _.labelId)
       .filter { case (((l, ur), r), laa) => laa.map(_.labelId).isEmpty } // No labels that AI's already validated
-      .map(_._1._1._1)
+      .joinLeft(labelAiFailures)
+      .on(_._1._1._1.labelId === _.labelId)
+      .filter { case ((((l, ur), r), laa), laf) => laf.map(_.labelId).isEmpty } // No labels with a permanent failure
+      .map(_._1._1._1._1)
 
     possibleLabels
       .join(labelPoints)
@@ -2042,7 +2046,7 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
       .join(panoData)
       .on { case ((label, point), pd) => label.panoId === pd.panoId }
       .filter { case ((label, point), pd) =>
-        !pd.expired && pd.width.isDefined && pd.height.isDefined && pd.source === PanoSource.Gsv
+        pd.width.isDefined && pd.height.isDefined && pd.source === PanoSource.Gsv
       }
       .sortBy { case ((label, point), pd) =>
         (

--- a/app/models/utils/MyPostgresProfile.scala
+++ b/app/models/utils/MyPostgresProfile.scala
@@ -3,6 +3,7 @@ package models.utils
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.github.tminglei.slickpg._
 import com.github.tminglei.slickpg.geom.PgPostGISExtensions
+import models.label.AiImageSource
 import models.pano.PanoSource
 import models.utils.CommonUtils.UiSource
 import org.locationtech.jts.geom.{Geometry, LineString, MultiPolygon, Point}
@@ -106,9 +107,13 @@ trait MyPostgresProfile
     implicit val panoSourceMapper: BaseColumnType[PanoSource.Value] =
       createEnumJdbcType[PanoSource.Value]("pano_source", _.toString, PanoSource.withName, quoteName = false)
 
-    // Mapper for pano_source enum type.
+    // Mapper for ui_source enum type.
     implicit val uiSourceMapper: BaseColumnType[UiSource.Value] =
       createEnumJdbcType[UiSource.Value]("ui_source", _.toString, UiSource.withName, quoteName = false)
+
+    // Mapper for ai_image_source enum type.
+    implicit val aiImageSourceMapper: BaseColumnType[AiImageSource.Value] =
+      createEnumJdbcType[AiImageSource.Value]("ai_image_source", _.toString, AiImageSource.withName, quoteName = false)
   }
 }
 

--- a/app/service/AiService.scala
+++ b/app/service/AiService.scala
@@ -54,6 +54,8 @@ class AiServiceImpl @Inject() (
     with HasDatabaseConfigProvider[MyPostgresProfile] {
   private val logger                         = Logger(this.getClass)
   private val cityId: String                 = config.get[String]("city-id")
+  // Strip the "sidewalk_" prefix off DATABASE_USER so the AI API can look up this city's image cache.
+  private val cityForAiApi: String           = config.get[String]("slick.dbs.default.db.user").stripPrefix("sidewalk_")
   private val AI_ENABLED: Boolean            = config.get[Boolean]("ai-enabled")
   private val AI_VALIDATIONS_ON: Boolean     = config.get[Boolean](s"city-params.ai-validation-enabled.$cityId")
   private val AI_TAG_SUGGESTIONS_ON: Boolean = config.get[Boolean](s"city-params.ai-tag-suggestions-enabled.$cityId")
@@ -174,7 +176,8 @@ class AiServiceImpl @Inject() (
       "label_type"  -> LabelTypeEnum.labelTypeIdToLabelType(labelData.labelTypeId).toLowerCase,
       "panorama_id" -> labelData.panoData.panoId,
       "x"           -> (labelData.labelPoint.panoX.toDouble / labelData.panoData.width.get).toString,
-      "y"           -> (labelData.labelPoint.panoY.toDouble / labelData.panoData.height.get).toString
+      "y"           -> (labelData.labelPoint.panoY.toDouble / labelData.panoData.height.get).toString,
+      "city"        -> cityForAiApi
     )
 
     ws.url(url)
@@ -197,6 +200,7 @@ class AiServiceImpl @Inject() (
             val apiVersion     = (json \ "api_version").as[String]
             val valModelId     = (json \ "validator_model_id").as[String]
             val taggerModelId  = (json \ "tagger_model_id").asOpt[String]
+            val aiImageSource  = AiImageSource.withName((json \ "image_source").as[String])
 
             // Read training dates.
             val dateFormatter   = DateTimeFormatter.ofPattern("MM-dd-yyyy")
@@ -212,7 +216,7 @@ class AiServiceImpl @Inject() (
               Some(
                 LabelAiAssessment(0, labelData.labelId, valResult, valAccuracy, valConfidence, tags, tagsNotPresent,
                   tagsConfidence, apiVersion, valModelId, valTrainingDate, taggerModelId, taggerTrainingDate,
-                  OffsetDateTime.now, None)
+                  OffsetDateTime.now, None, aiImageSource)
               )
             )
           } else if (response.status == 502) {

--- a/app/service/AiService.scala
+++ b/app/service/AiService.scala
@@ -46,6 +46,7 @@ class AiServiceImpl @Inject() (
     labelTable: models.label.LabelTable,
     validationService: ValidationService,
     labelAiAssessmentTable: models.label.LabelAiAssessmentTable,
+    labelAiFailureTable: models.label.LabelAiFailureTable,
     missionTable: models.mission.MissionTable,
     panoDataService: PanoDataService
 )(implicit val ec: ExecutionContext)
@@ -178,7 +179,7 @@ class AiServiceImpl @Inject() (
 
     ws.url(url)
       .post(formData)
-      .map { response =>
+      .flatMap { response =>
         try {
           if (response.status >= 200 && response.status < 300) {
             val json: JsValue = response.json
@@ -207,21 +208,29 @@ class AiServiceImpl @Inject() (
               .asOpt[String]
               .map(dateStr => LocalDate.parse(dateStr, dateFormatter).atStartOfDay(ZoneOffset.UTC).toOffsetDateTime)
 
-            Some(
-              LabelAiAssessment(0, labelData.labelId, valResult, valAccuracy, valConfidence, tags, tagsNotPresent,
-                tagsConfidence, apiVersion, valModelId, valTrainingDate, taggerModelId, taggerTrainingDate,
-                OffsetDateTime.now, None)
+            Future.successful(
+              Some(
+                LabelAiAssessment(0, labelData.labelId, valResult, valAccuracy, valConfidence, tags, tagsNotPresent,
+                  tagsConfidence, apiVersion, valModelId, valTrainingDate, taggerModelId, taggerTrainingDate,
+                  OffsetDateTime.now, None)
+              )
             )
+          } else if (response.status == 502) {
+            // The AI API tried both its scraped cache and a fresh download from Google and got nothing back, so the
+            // imagery is permanently unavailable. Record a failure row so the daily actor stops retrying this label.
+            val reason = response.body.trim.take(500)
+            logger.warn(s"AI API for label $labelId returned 502: $reason. Recording permanent failure.")
+            db.run(labelAiFailureTable.save(labelId, reason)).map(_ => None)
           } else {
             logger.warn(s"AI API for label $labelId returned error status: ${response.status} - ${response.statusText}")
             // Most common failure is for expired imagery, so do that check and mark it as expired here.
             Await.result(panoDataService.panoExists(labelData.panoData.panoId, labelData.panoData.source), 5.seconds)
-            None
+            Future.successful(None)
           }
         } catch {
           case e: Exception =>
             logger.warn(s"Failed to parse AI API response for label $labelId: ${e.getMessage}")
-            None
+            Future.successful(None)
         }
       }
       .recover { case e: Exception =>

--- a/app/service/AiService.scala
+++ b/app/service/AiService.scala
@@ -221,13 +221,13 @@ class AiServiceImpl @Inject() (
             )
           } else if (response.status == 502) {
             // The AI API tried both its scraped cache and a fresh download from Google and got nothing back, so the
-            // imagery is permanently unavailable. Record a failure row so the daily actor stops retrying this label.
+            // imagery is likely expired. Check expiration & Record a failure row so we stop retrying this label.
             val reason = response.body.trim.take(500)
+            Await.result(panoDataService.panoExists(labelData.panoData.panoId, labelData.panoData.source), 5.seconds)
             logger.warn(s"AI API for label $labelId returned 502: $reason. Recording permanent failure.")
             db.run(labelAiFailureTable.save(labelId, reason)).map(_ => None)
           } else {
             logger.warn(s"AI API for label $labelId returned error status: ${response.status} - ${response.statusText}")
-            // Most common failure is for expired imagery, so do that check and mark it as expired here.
             Await.result(panoDataService.panoExists(labelData.panoData.panoId, labelData.panoData.source), 5.seconds)
             Future.successful(None)
           }

--- a/conf/evolutions/default/314.sql
+++ b/conf/evolutions/default/314.sql
@@ -1,0 +1,11 @@
+# --- !Ups
+-- Track labels that the SidewalkAI API has refused permanently (e.g., the imagery is no longer available from Google
+-- and we have no cached copy). Rows here cause getLabelsToValidateWithAi to skip the label, so we don't keep retrying.
+CREATE TABLE IF NOT EXISTS label_ai_failure (
+    label_id INT PRIMARY KEY REFERENCES label (label_id),
+    reason TEXT NOT NULL,
+    timestamp TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+# --- !Downs
+DROP TABLE IF EXISTS label_ai_failure;

--- a/conf/evolutions/default/314.sql
+++ b/conf/evolutions/default/314.sql
@@ -7,5 +7,14 @@ CREATE TABLE IF NOT EXISTS label_ai_failure (
     timestamp TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
+-- Record whether the AI API used a freshly-downloaded image or a cached one for each assessment. Older rows all
+-- predate the cache option, so they are backfilled to 'download'.
+CREATE TYPE ai_image_source AS ENUM ('download', 'cache');
+ALTER TABLE label_ai_assessment ADD COLUMN ai_image_source ai_image_source NOT NULL DEFAULT 'download';
+ALTER TABLE label_ai_assessment ALTER COLUMN ai_image_source DROP DEFAULT;
+
 # --- !Downs
+ALTER TABLE label_ai_assessment DROP COLUMN ai_image_source;
+DROP TYPE ai_image_source;
+
 DROP TABLE IF EXISTS label_ai_failure;


### PR DESCRIPTION
Working towards #3025

In https://github.com/ProjectSidewalk/sidewalk-ai-api/commit/98f18fd4dcefe970a111ec6a46c239a749e29681, we added the ability to run the AI validator/tagger on our cached images. This PR updates the Project Sidewalk side to make use of that feature. We no longer filter out images where we have the imagery marked as "expired" in our database. We instead make the request, and if it fails, we log that to a separate table that I've created. This way, we can avoid making requests for the same images repeatedly if we don't even have it available in the cache.

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure the documentation on [this wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Descriptions-of-Logged-Events) is up to date for the logs you added/updated.
