### PR TITLE
/admin/user page now loads if the user has not visited a given city

### DIFF
--- a/app/service/AdminService.scala
+++ b/app/service/AdminService.scala
@@ -116,11 +116,17 @@ class AdminServiceImpl @Inject() (
       currRegion: Option[Region]              <- userCurrentRegionTable.getCurrentRegion(userId)
       completedAudits: Int                    <- auditTaskTable.countCompletedAuditsForUser(userId)
       hoursWorked: Double                     <- auditTaskInteractionTable.getHoursAuditingAndValidating(userId)
-      userStats: Option[UserStat]             <- userStatTable.getStatsFromUserId(userId)
+      existingStats: Option[UserStat]         <- userStatTable.getStatsFromUserId(userId)
+      // Insert a user_stat if the user hasn't visited this server before, allowing this page to load.
+      userStats: UserStat <- existingStats match {
+        case Some(stats) => DBIO.successful(stats)
+        case None        =>
+          userStatTable.insert(userId).flatMap(_ => userStatTable.getStatsFromUserId(userId).map(_.get))
+      }
       completedMissions: Seq[RegionalMission] <- missionTable.selectCompletedRegionalMission(userId)
       comments: Seq[AuditTaskComment]         <- auditTaskCommentTable.all(userId)
     } yield {
-      AdminUserProfileData(currRegion, completedAudits, hoursWorked, userStats.get, completedMissions, comments)
+      AdminUserProfileData(currRegion, completedAudits, hoursWorked, userStats, completedMissions, comments)
     })
   }
 


### PR DESCRIPTION
Fixes #4195

When visiting /admin/user/\<username\>, the page will now load even if the user has not visited the site for this particular city before.

##### Before/After screenshots (if applicable)
<img width="578" height="155" alt="image" src="https://github.com/user-attachments/assets/db5b09b0-2071-4f8d-99c0-a5c8c04da4cf" />
<img width="1777" height="943" alt="image" src="https://github.com/user-attachments/assets/a401d65e-8078-4081-892f-3bd5b2f0b495" />

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
