### PR TITLE
User Dashboard map now has a streets filter like LabelMap

### DIFF
--- a/app/views/common/mapSidebar.scala.html
+++ b/app/views/common/mapSidebar.scala.html
@@ -1,5 +1,5 @@
 @import models.label.{LabelTypeEnum, Tag}
-@(showStreets: Boolean = true, tags: Seq[Tag] = Seq.empty)(implicit messages: Messages, assets: AssetsFinder)
+@(tags: Seq[Tag] = Seq.empty)(implicit messages: Messages, assets: AssetsFinder)
 
 @tagsByLabelType = @{tags.groupBy(t => LabelTypeEnum.labelTypeIdToLabelType.getOrElse(t.labelTypeId, ""))}
 
@@ -138,34 +138,32 @@
         </ul>
     </section>
 
-    @* ---- Streets section (optional) ---- *@
-    @if(showStreets) {
-        <section class="map-sidebar__section">
-            <div class="map-sidebar__heading-row">
-                <h3 class="map-sidebar__heading" data-i18n="labelmap:streets">Streets</h3>
-                <button class="map-sidebar__deselect-all" data-section="streets"
-                        data-i18n="labelmap:select-all">Select all</button>
-            </div>
-            <ul class="map-sidebar__list">
-                <li class="map-sidebar__item">
-                    <input type="checkbox" id="audited-street" data-filter-type="streets" disabled>
-                    <svg class="map-sidebar__street-icon map-sidebar__street-icon--audited"
-                         width="17" height="14" viewBox="0 0 20 20">
-                        <path d="M 2 10 L 18 10 z"></path>
-                    </svg>
-                    <label for="audited-street" data-i18n="labelmap:audited-street">Audited Street</label>
-                </li>
-                <li class="map-sidebar__item">
-                    <input type="checkbox" id="unaudited-street" data-filter-type="streets" disabled>
-                    <svg class="map-sidebar__street-icon map-sidebar__street-icon--unaudited"
-                         width="17" height="14" viewBox="0 0 20 20">
-                        <path d="M 2 10 L 18 10 z"></path>
-                    </svg>
-                    <label for="unaudited-street" data-i18n="labelmap:unaudited-street">Unaudited Street</label>
-                </li>
-            </ul>
-        </section>
-    }
+    @* ---- Streets section ---- *@
+    <section class="map-sidebar__section">
+        <div class="map-sidebar__heading-row">
+            <h3 class="map-sidebar__heading" data-i18n="labelmap:streets">Streets</h3>
+            <button class="map-sidebar__deselect-all" data-section="streets"
+                    data-i18n="labelmap:select-all">Select all</button>
+        </div>
+        <ul class="map-sidebar__list">
+            <li class="map-sidebar__item">
+                <input type="checkbox" id="audited-street" data-filter-type="streets" disabled>
+                <svg class="map-sidebar__street-icon map-sidebar__street-icon--audited"
+                     width="17" height="14" viewBox="0 0 20 20">
+                    <path d="M 2 10 L 18 10 z"></path>
+                </svg>
+                <label for="audited-street" data-i18n="labelmap:audited-street">Audited Street</label>
+            </li>
+            <li class="map-sidebar__item">
+                <input type="checkbox" id="unaudited-street" data-filter-type="streets" disabled>
+                <svg class="map-sidebar__street-icon map-sidebar__street-icon--unaudited"
+                     width="17" height="14" viewBox="0 0 20 20">
+                    <path d="M 2 10 L 18 10 z"></path>
+                </svg>
+                <label for="unaudited-street" data-i18n="labelmap:unaudited-street">Unaudited Street</label>
+            </li>
+        </ul>
+    </section>
 </div>
 
 @* Drag handle on the right edge of the sidebar for resizing. *@

--- a/app/views/common/mapSidebar.scala.html
+++ b/app/views/common/mapSidebar.scala.html
@@ -1,5 +1,5 @@
 @import models.label.{LabelTypeEnum, Tag}
-@(tags: Seq[Tag] = Seq.empty)(implicit messages: Messages, assets: AssetsFinder)
+@(tags: Seq[Tag] = Seq.empty, streetsShownByDefault: Boolean = false)(implicit messages: Messages, assets: AssetsFinder)
 
 @tagsByLabelType = @{tags.groupBy(t => LabelTypeEnum.labelTypeIdToLabelType.getOrElse(t.labelTypeId, ""))}
 
@@ -142,12 +142,18 @@
     <section class="map-sidebar__section">
         <div class="map-sidebar__heading-row">
             <h3 class="map-sidebar__heading" data-i18n="labelmap:streets">Streets</h3>
-            <button class="map-sidebar__deselect-all" data-section="streets"
-                    data-i18n="labelmap:select-all">Select all</button>
+            @if(streetsShownByDefault) {
+                <button class="map-sidebar__deselect-all" data-section="streets"
+                        data-i18n="labelmap:deselect-all">Deselect all</button>
+            } else {
+                <button class="map-sidebar__deselect-all" data-section="streets"
+                        data-i18n="labelmap:select-all">Select all</button>
+            }
         </div>
         <ul class="map-sidebar__list">
             <li class="map-sidebar__item">
-                <input type="checkbox" id="audited-street" data-filter-type="streets" disabled>
+                <input type="checkbox" id="audited-street" data-filter-type="streets"
+                       @if(streetsShownByDefault){checked} disabled>
                 <svg class="map-sidebar__street-icon map-sidebar__street-icon--audited"
                      width="17" height="14" viewBox="0 0 20 20">
                     <path d="M 2 10 L 18 10 z"></path>
@@ -155,7 +161,8 @@
                 <label for="audited-street" data-i18n="labelmap:audited-street">Audited Street</label>
             </li>
             <li class="map-sidebar__item">
-                <input type="checkbox" id="unaudited-street" data-filter-type="streets" disabled>
+                <input type="checkbox" id="unaudited-street" data-filter-type="streets"
+                       @if(streetsShownByDefault){checked} disabled>
                 <svg class="map-sidebar__street-icon map-sidebar__street-icon--unaudited"
                      width="17" height="14" viewBox="0 0 20 20">
                     <path d="M 2 10 L 18 10 z"></path>

--- a/app/views/userProfile.scala.html
+++ b/app/views/userProfile.scala.html
@@ -86,7 +86,7 @@
             <div class="col-lg-12" id="map-column">
                 <div id="user-dashboard-choropleth-holder" class="choropleth-holder">
                     <div id="user-dashboard-choropleth" class="choropleth"></div>
-                    @common.mapSidebar(tags = tags)
+                    @common.mapSidebar(tags = tags, streetsShownByDefault = true)
                 </div>
             </div>
         </div>

--- a/app/views/userProfile.scala.html
+++ b/app/views/userProfile.scala.html
@@ -86,7 +86,7 @@
             <div class="col-lg-12" id="map-column">
                 <div id="user-dashboard-choropleth-holder" class="choropleth-holder">
                     <div id="user-dashboard-choropleth" class="choropleth"></div>
-                    @common.mapSidebar(showStreets = false, tags = tags)
+                    @common.mapSidebar(tags = tags)
                 </div>
             </div>
         </div>

--- a/public/javascripts/PSMap/MapSidebarFilter.js
+++ b/public/javascripts/PSMap/MapSidebarFilter.js
@@ -34,6 +34,9 @@ class MapSidebarFilter {
         this.#initSidebarOpenClose();
         this.#initResizeHandle();
         this.#enableAllControls();
+
+        // Sync the streets layer visibility with the initial checkbox state (the streets layer starts hidden).
+        filterStreetLayer(this.#map);
     }
 
     /** Binds click handlers to the severity toggle buttons. */


### PR DESCRIPTION
Fixes #4196 

The map on the User Dashboard now has the streets filter section that it was missing. We now also show the streets by default on the user dashboard, unlike LabelMap.

##### Before/After screenshots (if applicable)
Before
<img width="1777" height="943" alt="image" src="https://github.com/user-attachments/assets/0eedf17c-b09e-478c-999f-5df500b8deb1" />


After
<img width="1777" height="943" alt="image" src="https://github.com/user-attachments/assets/ab321392-f85c-4bab-b664-07456feeeb10" />

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
