### PR TITLE
Fixes team assignments being overwritten

### DIFF
--- a/app/models/user/UserTeamTable.scala
+++ b/app/models/user/UserTeamTable.scala
@@ -52,7 +52,7 @@ class UserTeamTable @Inject() (
    */
   def save(userId: String, teamId: Int): DBIO[Int] = {
     teams.filter(_.teamId === teamId).result.headOption.flatMap {
-      case Some(_) => userTeams.insertOrUpdate(UserTeam(0, userId, teamId))
+      case Some(_) => (userTeams returning userTeams.map(_.userTeamId)) += UserTeam(0, userId, teamId)
       case _       => DBIO.successful(0)
     }
   }

--- a/conf/evolutions/default/317.sql
+++ b/conf/evolutions/default/317.sql
@@ -1,0 +1,9 @@
+# --- !Ups
+-- Fix user_team rows with user_team_id = 0 created by using Slick's insertOrUpdate in UserTeamTable.save(). Slick's
+-- PostgresUpsertBuilder treated the literal 0 (the default for an Int auto-inc PK) as the upsert key, so once such a
+-- row existed, every subsequent setUserTeam call silently overwrote it instead of inserting a new row. Reassign the bad
+-- row to a fresh sequence id so the team membership is preserved. No-op for schemas with no such row.
+SELECT setval('user_org_user_org_id_seq', GREATEST(COALESCE((SELECT MAX(user_team_id) FROM user_team), 0), 1));
+UPDATE user_team SET user_team_id = nextval('user_org_user_org_id_seq') WHERE user_team_id = 0;
+
+# --- !Downs


### PR DESCRIPTION
Fixes #4207

Fixes an issue where team assignments were being overwritten.

I had mistakenly been used Slick's `insertOrUpdate` function on the `user_team` table to add entries when users joined a team.
```
userTeams.insertOrUpdate(UserTeam(0, userId, teamId))
```

But including 0 as the primary key (`user_team_id`) only works when inserting normally, filling in the 0 using the auto incrementing primary key. The `insertOrUpdate function was treating the 0 as a literal 0, so every time someone tried to join a team, it was giving their entry the same ID (0) and was just updating the same entry every time!

I switched to the normal insert function and it's now working again!
```
userTeams += UserTeam(0, userId, teamId)
```

I've also looked through to make sure that we're not making the same mistake anywhere else (and we're not!).

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
