### PR TITLE
Adds a hover effect to compass message on Explore page

### DIFF
--- a/public/javascripts/SVLabel/css/svl-compass.css
+++ b/public/javascripts/SVLabel/css/svl-compass.css
@@ -9,6 +9,13 @@
     border-radius: 3px 3px 3px 3px;
     -webkit-border-radius: 3px 3px 3px 3px;
     -moz-border-radius: 3px 3px 3px 3px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
+    transition: background-color 150ms ease, box-shadow 150ms ease, transform 150ms ease;
+}
+
+#compass-message-holder[style*="cursor: pointer"]:hover {
+    background: rgba(255, 255, 255, 0.95);
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
 }
 
 .compass-message-small {

--- a/public/javascripts/SVLabel/src/Main.js
+++ b/public/javascripts/SVLabel/src/Main.js
@@ -491,6 +491,7 @@ function Main (params) {
         svl.ui.contextMenu = {};
         svl.ui.contextMenu.holder = $("#context-menu-holder");
         svl.ui.contextMenu.severityMenu = $("#severity-menu");
+        svl.ui.contextMenu.severityRadioHolder = $("#severity-radio-holder");
         svl.ui.contextMenu.radioButtons = $("input[name='label-severity']");
         svl.ui.contextMenu.tagHolder = $("#context-menu-tag-holder");
         svl.ui.contextMenu.tags = $("button[name='tag']");

--- a/public/javascripts/SVLabel/src/canvas/ContextMenu.js
+++ b/public/javascripts/SVLabel/src/canvas/ContextMenu.js
@@ -15,6 +15,7 @@ function ContextMenu (uiContextMenu) {
         };
     var $menuWindow = uiContextMenu.holder;
     var $severityMenu = uiContextMenu.severityMenu;
+    const $severityRadioHolder = uiContextMenu.severityRadioHolder;
     var $severityRadios = uiContextMenu.radioButtons;
     let $descriptionHeaderNumber = $('#description-header-num');
     var $descriptionTextBox = uiContextMenu.textBox;
@@ -148,11 +149,10 @@ function ContextMenu (uiContextMenu) {
      * severity level is currently selected (filled vs outline variant).
      */
     function updateRadioButtonImages() {
-        const holder = document.getElementById('severity-radio-holder');
-        if (!holder) return;
+        if (!$severityRadioHolder[0]) return;
         const checkedSev = Number($severityRadios.filter(':checked').val());
         const labelType = status.targetLabel ? status.targetLabel.getLabelType() : null;
-        holder.querySelectorAll('.severity-button').forEach((button) => {
+        $severityRadioHolder[0].querySelectorAll('.severity-button').forEach((button) => {
             const sev = Number(button.dataset.severity);
             const img = button.querySelector('.severity-button__icon');
             if (img) img.src = util.misc.getSmileyIconPath(sev, labelType, sev === checkedSev);
@@ -305,12 +305,12 @@ function ContextMenu (uiContextMenu) {
 
     // Adds the disabled visual effects to the severity buttons on current context menu.
     function _showRatingSeverityEnabled() {
-        $radioButtonLabels.removeClass('disabled');
+        $severityRadioHolder.removeClass('disabled');
     }
 
     // Adds the disabled visual effects to the tags on current context menu.
     function _showRatingSeverityDisabled() {
-        $radioButtonLabels.addClass('disabled');
+        $severityRadioHolder.addClass('disabled');
     }
 
     function _showTaggingEnabled() {


### PR DESCRIPTION
Resolves #4203

Adds a hover effect to the compass message, making it more clear that it's interactive.

##### Before/After screenshots
Before/after
<img width="320" height="92" alt="image" src="https://github.com/user-attachments/assets/6dbd0751-1dd6-4b9e-b859-e7eeb1a2ab36" />
<img width="320" height="92" alt="image" src="https://github.com/user-attachments/assets/d32244d1-2e57-4c40-990b-dd826b13a473" />

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've included before/after screenshots above.
