### PR TITLE
Severity smileys colors adjusted to be less subtle

### DIFF
--- a/public/images/icons/smileys/sev-1-negative-filled.svg
+++ b/public/images/icons/smileys/sev-1-negative-filled.svg
@@ -1,5 +1,5 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" fill="#FDF0D1" stroke="#242424" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" fill="#FCE1A3" stroke="#242424" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M8 15C10.6358 14.6705 13.3642 14.6705 16 15" stroke="#242424" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M9 9H9.01" stroke="#242424" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M15 9H15.01" stroke="#242424" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>

--- a/public/images/icons/smileys/sev-1-positive-filled.svg
+++ b/public/images/icons/smileys/sev-1-positive-filled.svg
@@ -1,5 +1,5 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" fill="#FDF0D1" stroke="#242424" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" fill="#FCE1A3" stroke="#242424" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M7 14C7 14 8.5 17 12 17C15.5 17 17 14 17 14L14.25 14.25C12.7542 14.4162 11.245 14.4245 9.74739 14.2747L7 14Z" stroke="#242424" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M9 9V9.49994" stroke="#242424" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M15 9.5L15 9" stroke="#242424" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>

--- a/public/images/icons/smileys/sev-2-negative-filled.svg
+++ b/public/images/icons/smileys/sev-2-negative-filled.svg
@@ -1,5 +1,5 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" fill="#FBD98C" stroke="#242424" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" fill="#F1B12A" stroke="#242424" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M16 16C16 16 14.5 14 12 14C9.5 14 8 16 8 16" stroke="#242424" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M9 9H9.01" stroke="#242424" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M15 9H15.01" stroke="#242424" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>

--- a/public/images/icons/smileys/sev-2-positive-filled.svg
+++ b/public/images/icons/smileys/sev-2-positive-filled.svg
@@ -1,5 +1,5 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" fill="#FBD98C" stroke="#242424" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" fill="#F1B12A" stroke="#242424" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M8 15C10.6358 15.3295 13.3642 15.3295 16 15" stroke="#242424" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M9 9H9.01" stroke="#242424" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M15 9H15.01" stroke="#242424" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>

--- a/public/images/icons/smileys/sev-3-negative-filled.svg
+++ b/public/images/icons/smileys/sev-3-negative-filled.svg
@@ -1,5 +1,5 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" fill="#F1B12A" stroke="#242424" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" fill="#F29173" stroke="#242424" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M16 16.5C16 16.5 14.5 14 12 14C9.5 14 8 16.5 8 16.5" stroke="#242424" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M7.5 8.5L10 9.5L7.5 11" stroke="#242424" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M16.5 11L14 9.5L16.5 8.5" stroke="#242424" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>

--- a/public/images/icons/smileys/sev-3-positive-filled.svg
+++ b/public/images/icons/smileys/sev-3-positive-filled.svg
@@ -1,5 +1,5 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" fill="#F1B12A" stroke="#242424" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" fill="#F29173" stroke="#242424" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M16 16C16 16 14.5 14 12 14C9.5 14 8 16 8 16" stroke="#242424" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M9 9H9.01" stroke="#242424" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M15 9H15.01" stroke="#242424" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>


### PR DESCRIPTION
Resolves #4189

Updates the colors on the smiley faces for severity/quality ratings to be less subtle on the lower end. We no go all the way to a red for high severity.

##### Before/After screenshots (if applicable)
Before/after
<img width="217" height="89" alt="image" src="https://github.com/user-attachments/assets/e6c90252-439c-4829-98d4-9bdd93171e30" />
<img width="217" height="89" alt="image" src="https://github.com/user-attachments/assets/26099ceb-1cda-4541-96f2-2a5361900d90" />
