### PR TITLE
Hide severity section in Gallery/LabelMap for label types that don't support severity

### DIFF
--- a/public/javascripts/Gallery/css/cards.css
+++ b/public/javascripts/Gallery/css/cards.css
@@ -140,6 +140,7 @@ with respect to the image holder. This allows the validation menu to be placed o
     flex-direction: row;
     flex: 1; /* Takes all remaining space */
     right: 0px;
+    padding-left: 7px;
 }
 
 .label-tags-header {

--- a/public/javascripts/Gallery/src/cards/Card.js
+++ b/public/javascripts/Gallery/src/cards/Card.js
@@ -118,11 +118,13 @@ function Card(params, cropUrl, gsvImageUrl) {
         cardData.className = 'card-data';
         cardInfo.appendChild(cardData);
 
-        // Create the div to store the severity of the label.
-        let cardSeverity = document.createElement('div');
-        cardSeverity.className = 'card-severity';
-        new SeverityDisplay(cardSeverity, properties.severity, getLabelType());
-        cardData.appendChild(cardSeverity);
+        // Create the div to store the severity of the label (if the label type supports severity/quality ratings).
+        if (util.misc.labelTypeHasSeverity(getLabelType())) {
+            let cardSeverity = document.createElement('div');
+            cardSeverity.className = 'card-severity';
+            new SeverityDisplay(cardSeverity, properties.severity, getLabelType());
+            cardData.appendChild(cardSeverity);
+        }
 
         // Create the div to store the validation info of the label.
         let cardValidationInfo = document.createElement('div');

--- a/public/javascripts/Gallery/src/cards/CardContainer.js
+++ b/public/javascripts/Gallery/src/cards/CardContainer.js
@@ -277,7 +277,7 @@ async function CardContainer(uiCardContainer, initialFilters, panoViewerType, vi
         let appliedValOptions = sg.cardFilter.getAppliedValidationOptions();
 
         // NoSidewalk, Occlusion, and Signal don't have severity, Occlusion does not have tags.
-        if (['NoSidewalk', 'Signal', 'Occlusion'].includes(currentLabelType)) appliedSeverities = undefined;
+        if (!util.misc.labelTypeHasSeverity(currentLabelType)) appliedSeverities = undefined;
         if ('Occlusion' === currentLabelType) appliedTags = undefined;
 
         currentCards = cardsByType[currentLabelType].copy();

--- a/public/javascripts/Gallery/src/displays/SeverityDisplay.js
+++ b/public/javascripts/Gallery/src/displays/SeverityDisplay.js
@@ -12,11 +12,7 @@ function SeverityDisplay(container, severity, labelType) {
     self.severity = severity;
     self.severityContainer = container;
 
-    // List of label types where severity ratings are not supported.
-    // If more unsupported label types are made, add them here!
-    const unsupportedLabels = ['NoSidewalk', 'Signal', 'Occlusion'];
-
-    let unsupported = unsupportedLabels.includes(labelType);
+    let unsupported = !util.misc.labelTypeHasSeverity(labelType);
     const positive = util.misc.isPositiveLabelType(labelType);
 
     let circles = [];

--- a/public/javascripts/Gallery/src/displays/SeverityDisplay.js
+++ b/public/javascripts/Gallery/src/displays/SeverityDisplay.js
@@ -12,7 +12,6 @@ function SeverityDisplay(container, severity, labelType) {
     self.severity = severity;
     self.severityContainer = container;
 
-    let unsupported = !util.misc.labelTypeHasSeverity(labelType);
     const positive = util.misc.isPositiveLabelType(labelType);
 
     let circles = [];
@@ -25,7 +24,7 @@ function SeverityDisplay(container, severity, labelType) {
 
         title.innerText = i18next.t(positive ? 'quality' : 'severity');
         // If no severity rating, gray out title.
-        if (unsupported || severity == null) {
+        if (severity == null) {
             title.classList.add('no-severity-header');
         }
         container.append(title);
@@ -37,7 +36,7 @@ function SeverityDisplay(container, severity, labelType) {
             let $severityCircle = $('<div></div>');
             $severityCircle.addClass('severity-circle');
 
-            if (unsupported || severity == null) {
+            if (severity == null) {
                 // Create grayed out empty circles.
                 $severityCircle.addClass('no-severity-circle');
                 circles.push($severityCircle);
@@ -51,16 +50,10 @@ function SeverityDisplay(container, severity, labelType) {
         }
 
         if (severity == null) {
-            // Add tooltip if no severity level.
+            // Add tooltip indicating the user didn't add a severity rating for this label.
             holder.setAttribute('data-toggle', 'tooltip');
             holder.setAttribute('data-placement', 'top');
-
-            // Change tooltip message depending on if the label is unsupported or user did not add severity rating.
-            if (unsupported) {
-                holder.setAttribute('title', `${i18next.t("unsupported")}`);
-            } else {
-                holder.setAttribute('title', i18next.t(positive ? 'no-quality' : 'no-severity'));
-            }
+            holder.setAttribute('title', i18next.t(positive ? 'no-quality' : 'no-severity'));
             $(holder).tooltip('hide');
         }
 

--- a/public/javascripts/Gallery/src/filter/CardFilter.js
+++ b/public/javascripts/Gallery/src/filter/CardFilter.js
@@ -156,14 +156,14 @@ function CardFilter(uiCardFilter, labelTypeMenu, cityMenu, initialFilters) {
      * Render tags and severities in sidebar.
      */
     function render() {
-        if (['NoSidewalk', 'Signal', 'Occlusion'].includes(status.currentLabelType)) {
-            $('#severity-header').hide();
-            $('#severity-select').hide();
-        } else {
+        if (util.misc.labelTypeHasSeverity(status.currentLabelType)) {
             // Swap the filter header between "Severity" and "Quality" based on the current label type.
             const headerKey = util.misc.isPositiveLabelType(status.currentLabelType) ? 'quality' : 'severity';
             $('#severity-header').text(i18next.t(headerKey)).show();
             $('#severity-select').show();
+        } else {
+            $('#severity-header').hide();
+            $('#severity-select').hide();
         }
         if (currentTags.getTags().length > 0) {
             $("#tags-header").show();

--- a/public/javascripts/SVLabel/src/canvas/ContextMenu.js
+++ b/public/javascripts/SVLabel/src/canvas/ContextMenu.js
@@ -111,8 +111,8 @@ function ContextMenu (uiContextMenu) {
         const labels = svl.labelContainer.getAllLabels();
         if (labels.length > 0) {
             const lastLabelProps = labels[labels.length - 1].getProperties();
-            // If the label is No Sidewalk or Pedestrian Signal, do not call ratingReminderAlert().
-            if (!['NoSidewalk', 'Signal'].includes(lastLabelProps.labelType)) {
+            // Only call ratingReminderAlert() for label types that have a severity rating.
+            if (util.misc.labelTypeHasSeverity(lastLabelProps.labelType)) {
                 svl.ratingReminderAlert.ratingClicked(lastLabelProps.severity);
             }
         }
@@ -515,11 +515,11 @@ function ContextMenu (uiContextMenu) {
             _setTagColor(targetLabel);
             if (getStatus('disableTagging')) { disableTagging(); }
 
-            // Hide the severity menu for the No Sidewalk and Pedestrian Signal label types.
-            if (['NoSidewalk', 'Signal'].includes(labelType)) {
-                $severityMenu.addClass('hidden');
-            } else {
+            // Hide the severity menu for label types that don't have a severity rating.
+            if (util.misc.labelTypeHasSeverity(labelType)) {
                 $severityMenu.removeClass('hidden');
+            } else {
+                $severityMenu.addClass('hidden');
             }
             var menuHeight = $menuWindow.outerHeight();
 
@@ -565,7 +565,7 @@ function ContextMenu (uiContextMenu) {
             // Don't push event on Occlusion labels; they don't open ContextMenus.
             svl.tracker.push('ContextMenu_Open', {'auditTaskId': labelProps.auditTaskId}, {'temporaryLabelId': labelProps.temporaryLabelId});
         }
-        if (!['NoSidewalk', 'Signal', 'Occlusion'].includes(labelType)) {
+        if (util.misc.labelTypeHasSeverity(labelType)) {
             self.updateRadioButtonImages();
             _updateRatingText();
             _removePrevSeverityTooltips();

--- a/public/javascripts/SVLabel/src/label/Label.js
+++ b/public/javascripts/SVLabel/src/label/Label.js
@@ -214,7 +214,7 @@ function Label(params) {
                 Label.renderLabelIcon(ctx, properties.labelType, properties.currCanvasXY.x, properties.currCanvasXY.y);
 
                 // Only render severity warning if there's a severity option.
-                if (!['NoSidewalk', 'Occlusion', 'Signal'].includes(properties.labelType) && properties.severity === null) {
+                if (util.misc.labelTypeHasSeverity(properties.labelType) && properties.severity === null) {
                     showSeverityAlert(ctx);
                 }
             }
@@ -246,7 +246,7 @@ function Label(params) {
         // labelCoordinate represents the upper left corner of the hover info.
         var labelCoordinate = getCanvasXY(),
             cornerRadius = 3,
-            hasSeverity = (!['NoSidewalk', 'Occlusion', 'Signal'].includes(properties.labelType)),
+            hasSeverity = util.misc.labelTypeHasSeverity(properties.labelType),
             width = 0,
             labelRows = 1,
             severityImage = new Image(),

--- a/public/javascripts/SVValidate/src/menu/DesktopValidationMenu.js
+++ b/public/javascripts/SVValidate/src/menu/DesktopValidationMenu.js
@@ -40,7 +40,7 @@ function DesktopValidationMenu(menuUI) {
                 const oldSeverity = currLabel.getProperty('newSeverity');
                 const newSeverity = $(e.target).closest('.severity-button').data('severity');
                 const labelType = currLabel.getAuditProperty('labelType')
-                if (oldSeverity !== newSeverity && !['NoSidewalk', 'Signal'].includes(labelType)) {
+                if (oldSeverity !== newSeverity && util.misc.labelTypeHasSeverity(labelType)) {
                     svv.tracker.push(`Click=Severity_Old=${oldSeverity}_New=${newSeverity}`);
                     currLabel.setProperty('newSeverity', newSeverity);
                     _renderSeverity();
@@ -232,9 +232,9 @@ function DesktopValidationMenu(menuUI) {
             _renderTags();
             menuUI.tagsMenu.css('display', 'block');
 
-            // Pedestrian Signal and No Sidewalk label types don't have severity ratings.
+            // Some label types (Pedestrian Signal, No Sidewalk) don't have severity ratings.
             let currLabelType = svv.labelContainer.getCurrentLabel().getAuditProperty('labelType');
-            if (!['Signal', 'NoSidewalk'].includes(currLabelType)) {
+            if (util.misc.labelTypeHasSeverity(currLabelType)) {
                 _renderSeverity();
                 menuUI.severityMenu.css('display', 'block');
             }

--- a/public/javascripts/common/UtilitiesSidewalk.js
+++ b/public/javascripts/common/UtilitiesSidewalk.js
@@ -484,6 +484,7 @@ function UtilitiesMisc (JSON) {
 
     const SMILEY_ICON_BASE = '/assets/images/icons/smileys/';
     const POSITIVE_LABEL_TYPES = ['CurbRamp', 'Crosswalk'];
+    const LABEL_TYPES_WITHOUT_SEVERITY = ['NoSidewalk', 'Signal', 'Occlusion'];
 
     /**
      * Returns true if label type uses the "positive" rating scheme (Good/Okay/Bad) vs the "negative" (Low/Medium/High).
@@ -492,6 +493,15 @@ function UtilitiesMisc (JSON) {
      */
     function isPositiveLabelType(labelType) {
         return POSITIVE_LABEL_TYPES.includes(labelType);
+    }
+
+    /**
+     * Returns true if label type supports a severity/quality rating.
+     * @param {string} labelType
+     * @returns {boolean}
+     */
+    function labelTypeHasSeverity(labelType) {
+        return !LABEL_TYPES_WITHOUT_SEVERITY.includes(labelType);
     }
 
     /**
@@ -611,6 +621,8 @@ function UtilitiesMisc (JSON) {
     self.getSeverityDescription = getSeverityDescription;
     self.isPositiveLabelType = isPositiveLabelType;
     self.POSITIVE_LABEL_TYPES = POSITIVE_LABEL_TYPES;
+    self.labelTypeHasSeverity = labelTypeHasSeverity;
+    self.LABEL_TYPES_WITHOUT_SEVERITY = LABEL_TYPES_WITHOUT_SEVERITY;
     self.getSmileyIconPath = getSmileyIconPath;
     self.getRatingLevelKeys = getRatingLevelKeys;
     self.getLabelColors = getLabelColors;

--- a/public/javascripts/common/label-detail/LabelDetail.js
+++ b/public/javascripts/common/label-detail/LabelDetail.js
@@ -113,6 +113,7 @@ async function LabelDetail(root, opts) {
         els.title              = $('.label-detail__title');
         els.timestamp          = $('.label-detail__timestamp');
         els.imageDate          = $('.label-detail__image-capture-date');
+        els.severitySection    = $('.label-detail__col--severity');
         els.severity           = $('.label-detail__severity-faces');
         els.severityTitle      = $('.label-detail__severity-title');
         els.tags               = $('.label-detail__tags');
@@ -563,6 +564,10 @@ async function LabelDetail(root, opts) {
      * @private
      */
     function _renderSeverity(severity, labelType) {
+        // Hide entire section if the label type doesn't support severity ratings.
+        if (els.severitySection) els.severitySection.hidden = !util.misc.labelTypeHasSeverity(labelType);
+        if (!util.misc.labelTypeHasSeverity(labelType)) return;
+
         const positive = util.misc.isPositiveLabelType(labelType);
         const titleKey = positive ? 'quality' : 'severity';
         const levelKeys = util.misc.getRatingLevelKeys(labelType);

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -62,7 +62,6 @@
     "quality-example-tooltip-3": "Beispiel für schlechte Qualität",
     "no-severity": "Bei dieser Beschriftung wurde kein Schweregrad angegeben",
     "no-quality": "Bei dieser Beschriftung wurde keine Qualitätsbewertung angegeben",
-    "unsupported": "Diese Beschriftungkategorie hat keinen bedeutenden Schweregrad",
     "tags": "Tags",
     "description": "Beschreibung",
     "no-description": "keine Beschreibung",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -62,7 +62,6 @@
     "quality-example-tooltip-3": "Bad quality example",
     "no-severity": "A severity rating was not provided for this label",
     "no-quality": "A quality rating was not provided for this label",
-    "unsupported": "This label type does not have meaningful severity levels",
     "tags": "Tags",
     "description": "Description",
     "no-description": "No description",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -62,7 +62,6 @@
     "quality-example-tooltip-3": "Ejemplo de mala calidad",
     "no-severity": "No se proporcionó una calificación de gravedad para esta etiqueta",
     "no-quality": "No se proporcionó una calificación de calidad para esta etiqueta",
-    "unsupported": "Este tipo de etiqueta no tiene niveles de gravedad significativos",
     "tags": "Etiquetas ",
     "description": "Descripción",
     "no-description": "Sin descripción",

--- a/public/locales/nl/common.json
+++ b/public/locales/nl/common.json
@@ -62,7 +62,6 @@
     "quality-example-tooltip-3": "Voorbeeld van slechte kwaliteit",
     "no-severity": "Er is geen ernstclassificatie opgegeven voor dit label",
     "no-quality": "Er is geen kwaliteitsbeoordeling opgegeven voor dit label",
-    "unsupported": "Dit labeltype heeft geen betekenisvolle ernstniveaus",
     "tags": "Tags",
     "description": "Beschrijving",
     "no-description": "Geen beschrijving",

--- a/public/locales/pt-BR/common.json
+++ b/public/locales/pt-BR/common.json
@@ -62,7 +62,6 @@
     "quality-example-tooltip-3": "Exemplo de má qualidade",
     "no-severity": "Uma classificação de gravidade não foi fornecida para este rótulo",
     "no-quality": "Uma classificação de qualidade não foi fornecida para este rótulo",
-    "unsupported": "Este tipo de rótulo não possui níveis de gravidade significativos",
     "tags": "Etiquetas",
     "description": "Descrição",
     "no-description": "Sem descrição",

--- a/public/locales/zh-TW/common.json
+++ b/public/locales/zh-TW/common.json
@@ -62,7 +62,6 @@
     "quality-example-tooltip-3": "不良品質範例",
     "no-severity": "該標記無嚴重度評分",
     "no-quality": "該標記無品質評分",
-    "unsupported": "此類標記不適用嚴重度區別",
     "tags": "標籤",
     "description": "描述",
     "no-description": "無描述",


### PR DESCRIPTION
Resolves #4213

For label types that don't support severity, this PR removes the severity/quality sections in LabelMap/Gallery. This fits with Explore/Validate, which don't show the severity sections if they don't apply, and it leaves more space to show tags!

While doing this, I've also moved the list of label types where severity rating is included to a central place on the front-end, and refactored all other places (Explore/Validate) to use the consolidated list.

### Before/After screenshots (if applicable)
##### LabelMap popup before/after (Gallery expanded view shares code and thus looks similar)
<img width="707" height="837" alt="image" src="https://github.com/user-attachments/assets/aad572ad-2f65-4605-9b26-9567f356783f" />

<img width="707" height="821" alt="image" src="https://github.com/user-attachments/assets/82913f26-5dbe-43ef-b910-38fcb8f24b0c" />

##### Gallery cards before/after
<img width="484" height="392" alt="image" src="https://github.com/user-attachments/assets/753b9f6a-4bf4-4122-ab26-ae8fbda85236" />
<img width="484" height="392" alt="image" src="https://github.com/user-attachments/assets/5d6cb310-5877-4d15-ac23-ec7a0bfa7b99" />

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->
<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->
- [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
