### PR TITLE
Split overallStats validation stats by source: combined / human / AI (#4223)

### DIFF
--- a/app/controllers/api/StatsApiController.scala
+++ b/app/controllers/api/StatsApiController.scala
@@ -106,13 +106,21 @@ class StatsApiController @Inject() (
               writer.println(s"$labType Severity Mean,${sevStats.severityMean.map(_.toString).getOrElse("NA")}")
               writer.println(s"$labType Severity SD,${sevStats.severitySD.map(_.toString).getOrElse("NA")}")
             }
-            writer.println(s"Total Validations,${stats.nValidations}")
-            for ((labType, accStats) <- stats.accuracyByLabelType.toSeq.sorted(labelTypeOrdering)) {
-              writer.println(s"$labType Labels Validated,${accStats.n}")
-              writer.println(s"$labType Agreed Count,${accStats.nAgree}")
-              writer.println(s"$labType Disagreed Count,${accStats.nDisagree}")
-              writer.println(s"$labType Accuracy,${accStats.accuracy.map(_.toString).getOrElse("NA")}")
-              writer.println(s"$labType Labels With a Validation,${accStats.nWithValidation}")
+            // Validation stats split three ways: combined (all votes), human (non-AI votes), and AI (AI votes).
+            val validationSources = Seq(
+              ("Combined", stats.validations.combined),
+              ("Human", stats.validations.human),
+              ("AI", stats.validations.ai)
+            )
+            for ((srcLabel, srcStats) <- validationSources) {
+              writer.println(s"$srcLabel Total Validations,${srcStats.nValidations}")
+              for ((labType, accStats) <- srcStats.accuracyByLabelType.toSeq.sorted(labelTypeOrdering)) {
+                writer.println(s"$srcLabel $labType Labels Validated,${accStats.n}")
+                writer.println(s"$srcLabel $labType Agreed Count,${accStats.nAgree}")
+                writer.println(s"$srcLabel $labType Disagreed Count,${accStats.nDisagree}")
+                writer.println(s"$srcLabel $labType Accuracy,${accStats.accuracy.map(_.toString).getOrElse("NA")}")
+                writer.println(s"$srcLabel $labType Labels With a Validation,${accStats.nWithValidation}")
+              }
             }
             for ((labelType, aiStatsMap) <- stats.aiPerformance.toSeq.sorted(labelTypeOrdering)) {
               for ((voteType, aiStats) <- aiStatsMap) {

--- a/app/formats/json/ApiFormats.scala
+++ b/app/formats/json/ApiFormats.scala
@@ -185,6 +185,13 @@ object ApiFormats {
       s"""${a.agreeCount},${a.disagreeCount},${a.unsureCount},${a.labelCount},"[${a.usersList.mkString(",")}]""""
   }
 
+  /** Serializes one validation-vote source (combined/human/ai): a total count plus a per-label-type accuracy block. */
+  private def validationSourceToJson(src: ValidationSourceStats): JsObject = JsObject(
+    Seq("total_validations" -> JsNumber(src.nValidations.toDouble)) ++
+      // Turns into { "Overall" -> { "validated" -> ###, ... }, "CurbRamp" -> { "validated" -> ###, ... }, ... }.
+      src.accuracyByLabelType.toSeq.sorted(labelTypeOrdering).map(s => s._1 -> Json.toJson(s._2))
+  )
+
   def projectSidewalkStatsToJson(stats: ProjectSidewalkStats): JsObject = {
     Json.obj(
       "launch_date"                   -> stats.launchDate,
@@ -213,10 +220,12 @@ object ApiFormats {
           // Turns into { "CurbRamp" -> { "count" -> ###, ... }, ... }.
           stats.severityByLabelType.toSeq.sorted(labelTypeOrdering).map(stats => stats._1 -> Json.toJson(stats._2))
       ),
-      "validations" -> JsObject(
-        Seq("total_validations" -> JsNumber(stats.nValidations.toDouble)) ++
-          // Turns into { "Overall" -> { "validated" -> ###, ... }, "CurbRamp" -> { "validated" -> ###, ... }, ... }.
-          stats.accuracyByLabelType.toSeq.sorted(labelTypeOrdering).map(stats => stats._1 -> Json.toJson(stats._2))
+      // Validation stats are split three ways. "combined" includes both human and AI votes (AI votes are baked into
+      // the label table's agree/disagree/correct counts); "human" and "ai" isolate each source via the validator role.
+      "validations" -> Json.obj(
+        "combined" -> validationSourceToJson(stats.validations.combined),
+        "human"    -> validationSourceToJson(stats.validations.human),
+        "ai"       -> validationSourceToJson(stats.validations.ai)
       ),
       "ai_stats" -> JsObject(
         // { "Overall" -> "human_maj_vote" -> { "ai_yes_human_concurs": ###, ... }, ... }, "CurbRamp" -> { ... }, ... }.

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -97,6 +97,16 @@ case class TagCount(labelType: String, tag: String, count: Int)
 case class LabelSevStats(n: Int, nWithSeverity: Option[Int], severityMean: Option[Double], severitySD: Option[Double])
 case class LabelAccuracy(n: Int, nAgree: Int, nDisagree: Int, accuracy: Option[Double], nWithValidation: Int)
 case class AiConcurrence(aiYesHumanConcurs: Int, aiYesHumanDiffers: Int, aiNoHumanDiffers: Int, aiNoHumanConcurs: Int)
+
+// Validation stats for a single source of votes (combined = all votes, human = non-AI votes, ai = AI votes). Each
+// source has a raw count of validations (label_validation rows) plus a per-label-type majority-vote breakdown.
+case class ValidationSourceStats(nValidations: Int, accuracyByLabelType: Map[String, LabelAccuracy])
+case class ValidationStats(
+    combined: ValidationSourceStats,
+    human: ValidationSourceStats,
+    ai: ValidationSourceStats
+)
+
 case class ProjectSidewalkStats(
     launchDate: String,
     avgTimestampLast100Labels: Option[OffsetDateTime],
@@ -114,8 +124,7 @@ case class ProjectSidewalkStats(
     avgLabelTimestamp: Option[OffsetDateTime],
     avgImageAgeByLabel: Option[Duration],
     severityByLabelType: Map[String, LabelSevStats],
-    nValidations: Int,
-    accuracyByLabelType: Map[String, LabelAccuracy],
+    validations: ValidationStats,
     aiPerformance: Map[String, Map[String, AiConcurrence]]
 )
 case class LabelTypeValidationsLeft(labelType: LabelTypeEnum.Base, validationsAvailable: Int, validationsNeeded: Int)
@@ -298,6 +307,31 @@ object LabelTable {
   trait TupleConverter[Tuple, A] {
     def fromTuple(tuple: Tuple): A
   }
+
+  // Ordered list of (columnPrefix, labelTypeName) groups used by the validation-stats portion of
+  // getOverallStatsForApi and its result parser (projectSidewalkStatsConverter). "overall" applies no label_type
+  // filter (i.e., all types). ORDER MATTERS: the SQL emits columns in this order and the parser reads them in the same
+  // order, so the two stay in lockstep.
+  val validationStatLabelTypes: Seq[(String, String)] = Seq(
+    "overall"    -> "Overall",
+    "ramp"       -> CurbRamp.name,
+    "noramp"     -> NoCurbRamp.name,
+    "obs"        -> Obstacle.name,
+    "surf"       -> SurfaceProblem.name,
+    "nosidewalk" -> NoSidewalk.name,
+    "crswlk"     -> Crosswalk.name,
+    "signal"     -> Signal.name,
+    "occlusion"  -> Occlusion.name,
+    "other"      -> Other.name
+  )
+
+  // Ordered list of (columnPrefix, SQL role filter) for the three validation-vote sources: combined (all votes),
+  // human (non-AI votes), and ai (AI votes). ORDER MATTERS (see validationStatLabelTypes).
+  val validationStatSources: Seq[(String, String)] = Seq(
+    "comb"  -> "TRUE",
+    "human" -> "role <> 'AI'",
+    "ai"    -> "role = 'AI'"
+  )
 
   // Type aliases for the tuple representation of LabelMetadataUserDash and queries for them.
   // TODO in Scala 3 I think that we can make these top-level like we do for the case class version.
@@ -699,19 +733,23 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
         Occlusion.name  -> LabelSevStats(r.nextInt(), r.nextIntOption(), r.nextDoubleOption(), r.nextDoubleOption()),
         Other.name      -> LabelSevStats(r.nextInt(), r.nextIntOption(), r.nextDoubleOption(), r.nextDoubleOption())
       ),
-      r.nextInt(),
-      Map(
-        "Overall"           -> LabelAccuracy(r.nextInt(), r.nextInt(), r.nextInt(), r.nextDoubleOption(), r.nextInt()),
-        CurbRamp.name       -> LabelAccuracy(r.nextInt(), r.nextInt(), r.nextInt(), r.nextDoubleOption(), r.nextInt()),
-        NoCurbRamp.name     -> LabelAccuracy(r.nextInt(), r.nextInt(), r.nextInt(), r.nextDoubleOption(), r.nextInt()),
-        Obstacle.name       -> LabelAccuracy(r.nextInt(), r.nextInt(), r.nextInt(), r.nextDoubleOption(), r.nextInt()),
-        SurfaceProblem.name -> LabelAccuracy(r.nextInt(), r.nextInt(), r.nextInt(), r.nextDoubleOption(), r.nextInt()),
-        NoSidewalk.name     -> LabelAccuracy(r.nextInt(), r.nextInt(), r.nextInt(), r.nextDoubleOption(), r.nextInt()),
-        Crosswalk.name      -> LabelAccuracy(r.nextInt(), r.nextInt(), r.nextInt(), r.nextDoubleOption(), r.nextInt()),
-        Signal.name         -> LabelAccuracy(r.nextInt(), r.nextInt(), r.nextInt(), r.nextDoubleOption(), r.nextInt()),
-        Occlusion.name      -> LabelAccuracy(r.nextInt(), r.nextInt(), r.nextInt(), r.nextDoubleOption(), r.nextInt()),
-        Other.name          -> LabelAccuracy(r.nextInt(), r.nextInt(), r.nextInt(), r.nextDoubleOption(), r.nextInt())
-      ),
+      {
+        // Read the combined/human/ai validation breakdowns in the exact order getOverallStatsForApi emits them: for
+        // each source, the total validation count followed by one LabelAccuracy per validationStatLabelTypes entry.
+        // Seq.map is strict and left-to-right, so this reads columns positionally in sync with the SELECT.
+        def readSource(): ValidationSourceStats =
+          ValidationSourceStats(
+            r.nextInt(),
+            validationStatLabelTypes.map { case (_, labelType) =>
+              labelType -> LabelAccuracy(r.nextInt(), r.nextInt(), r.nextInt(), r.nextDoubleOption(), r.nextInt())
+            }.toMap
+          )
+        // validationStatSources order is (comb, human, ai); read in that exact order.
+        val combined = readSource()
+        val human    = readSource()
+        val ai       = readSource()
+        ValidationStats(combined, human, ai)
+      },
       Map(
         "Overall" -> Map(
           "human_majority_vote" -> AiConcurrence(r.nextInt(), r.nextInt(), r.nextInt(), r.nextInt()),
@@ -1673,6 +1711,74 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
       if (filterLowQuality) "user_stat.high_quality"
       else "NOT user_stat.excluded"
 
+    // Same as `userFilter`, but applied to the LABELER's user_stat (aliased `labeler_stat`) in the per-label
+    // validation-verdict subquery. There, `user_stat` is reused for the validator, so the labeler needs its own alias.
+    val labelerFilter: String =
+      if (filterLowQuality) "labeler_stat.high_quality"
+      else "NOT labeler_stat.excluded"
+
+    // The validation stats are reported three ways: combined (all votes), human (non-AI votes), and ai (AI votes).
+    // Rather than hand-write ~150 nearly-identical SQL columns (and risk drift from projectSidewalkStatsConverter), we
+    // generate the repetitive column lists from the shared, ordered LabelTable.validationStatSources and
+    // LabelTable.validationStatLabelTypes. The parser reads columns in the same order, keeping the two in lockstep.
+    val valSources: Seq[(String, String)]  = LabelTable.validationStatSources
+    val valTypes: Seq[(String, String)]    = LabelTable.validationStatLabelTypes
+    // Per-label-type filter used in the outer aggregation; "overall" matches all label types.
+    def ltCond(prefix: String, labelType: String): String =
+      if (prefix == "overall") "" else s"label_type = '$labelType' AND "
+
+    // (a) Top-level SELECT: for each source, the total validation count then validated/agreed/disagreed/accuracy/
+    // has-a-validation per label type, in the exact order projectSidewalkStatsConverter reads them.
+    val validationSelectCols: String = valSources
+      .map { case (src, _) =>
+        val perType = valTypes
+          .map { case (pfx, _) =>
+            s"""val_counts.${src}_${pfx}_validated,
+               |             val_counts.${src}_${pfx}_agree,
+               |             val_counts.${src}_${pfx}_disagree,
+               |             1.0 * val_counts.${src}_${pfx}_agree / NULLIF(val_counts.${src}_${pfx}_validated, 0) AS ${src}_${pfx}_accuracy,
+               |             val_counts.${src}_${pfx}_with_val""".stripMargin
+          }
+          .mkString(",\n             ")
+        s"total_val_count.${src}_total,\n             $perType"
+      }
+      .mkString(",\n             ")
+
+    // (b) Totals subquery: raw label_validation row counts split by source.
+    val validationTotalsCols: String = valSources
+      .map { case (src, filter) => s"COUNT(CASE WHEN $filter THEN 1 END) AS ${src}_total" }
+      .mkString(",\n                 ")
+
+    // (c) Inner per-label verdict subquery: for each source, the majority vote (1=agree, 2=disagree, 3=tie/none) and a
+    // raw vote count (>0 means this source weighed in, used for has_a_validation).
+    val validationVerdictCols: String = valSources
+      .map { case (src, filter) =>
+        s"""CASE
+           |                         WHEN COUNT(CASE WHEN $filter AND validation_result = 1 THEN 1 END)
+           |                             > COUNT(CASE WHEN $filter AND validation_result = 2 THEN 1 END) THEN 1
+           |                         WHEN COUNT(CASE WHEN $filter AND validation_result = 2 THEN 1 END)
+           |                             > COUNT(CASE WHEN $filter AND validation_result = 1 THEN 1 END) THEN 2
+           |                         ELSE 3
+           |                         END AS ${src}_mv,
+           |                     COUNT(CASE WHEN $filter THEN 1 END) AS ${src}_votes""".stripMargin
+      }
+      .mkString(",\n                     ")
+
+    // (d) Outer aggregation: per source and label type, count labels by their majority verdict.
+    val validationAggCols: String = valSources
+      .map { case (src, _) =>
+        valTypes
+          .map { case (pfx, labelType) =>
+            val cond = ltCond(pfx, labelType)
+            s"""COUNT(CASE WHEN ${cond}${src}_mv IN (1, 2) THEN 1 END) AS ${src}_${pfx}_validated,
+               |                 COUNT(CASE WHEN ${cond}${src}_mv = 1 THEN 1 END) AS ${src}_${pfx}_agree,
+               |                 COUNT(CASE WHEN ${cond}${src}_mv = 2 THEN 1 END) AS ${src}_${pfx}_disagree,
+               |                 COUNT(CASE WHEN ${cond}${src}_votes > 0 THEN 1 END) AS ${src}_${pfx}_with_val""".stripMargin
+          }
+          .mkString(",\n                 ")
+      }
+      .mkString(",\n                 ")
+
     sql"""
       SELECT '#$launchDate' AS launch_date,
              #${avgRecentLabels.map(avg => s"'$avg'").getOrElse("NULL")} AS avg_timestamp_last_100_labels,
@@ -1725,57 +1831,7 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
              label_counts_and_severity.n_other_with_sev,
              label_counts_and_severity.other_sev_mean,
              label_counts_and_severity.other_sev_sd,
-             total_val_count.validation_count,
-             val_counts.n_validated,
-             val_counts.n_agree,
-             val_counts.n_disagree,
-             1.0 * val_counts.n_agree / NULLIF(val_counts.n_validated, 0) AS overall_accuracy,
-             n_with_validation,
-             val_counts.n_ramp_total,
-             val_counts.n_ramp_agree,
-             val_counts.n_ramp_disagree,
-             1.0 * val_counts.n_ramp_agree / NULLIF(val_counts.n_ramp_total, 0) AS ramp_accuracy,
-             n_ramp_with_validation,
-             val_counts.n_noramp_total,
-             val_counts.n_noramp_agree,
-             val_counts.n_noramp_disagree,
-             1.0 * val_counts.n_noramp_agree / NULLIF(val_counts.n_noramp_total, 0) AS noramp_accuracy,
-             n_noramp_with_validation,
-             val_counts.n_obs_total,
-             val_counts.n_obs_agree,
-             val_counts.n_obs_disagree,
-             1.0 * val_counts.n_obs_agree / NULLIF(val_counts.n_obs_total, 0) AS obs_accuracy,
-             n_obs_with_validation,
-             val_counts.n_surf_total,
-             val_counts.n_surf_agree,
-             val_counts.n_surf_disagree,
-             1.0 * val_counts.n_surf_agree / NULLIF(val_counts.n_surf_total, 0) AS surf_accuracy,
-             n_surf_with_validation,
-             val_counts.n_nosidewalk_total,
-             val_counts.n_nosidewalk_agree,
-             val_counts.n_nosidewalk_disagree,
-             1.0 * val_counts.n_nosidewalk_agree / NULLIF(val_counts.n_nosidewalk_total, 0) AS nosidewalk_accuracy,
-             n_nosidewalk_with_validation,
-             val_counts.n_crswlk_total,
-             val_counts.n_crswlk_agree,
-             val_counts.n_crswlk_disagree,
-             1.0 * val_counts.n_crswlk_agree / NULLIF(val_counts.n_crswlk_total, 0) AS crswlk_accuracy,
-             n_crswlk_with_validation,
-             val_counts.n_signal_total,
-             val_counts.n_signal_agree,
-             val_counts.n_signal_disagree,
-             1.0 * val_counts.n_signal_agree / NULLIF(val_counts.n_signal_total, 0) AS signal_accuracy,
-             n_signal_with_validation,
-             val_counts.n_occlusion_total,
-             val_counts.n_occlusion_agree,
-             val_counts.n_occlusion_disagree,
-             1.0 * val_counts.n_occlusion_agree / NULLIF(val_counts.n_occlusion_total, 0) AS occlusion_accuracy,
-             n_occlusion_with_validation,
-             val_counts.n_other_total,
-             val_counts.n_other_agree,
-             val_counts.n_other_disagree,
-             1.0 * val_counts.n_other_agree / NULLIF(val_counts.n_other_total, 0) AS other_accuracy,
-             n_other_with_validation,
+             #$validationSelectCols,
              ai_stats.ai_yes_mv_yes,
              ai_stats.ai_yes_mv_no,
              ai_stats.ai_no_mv_yes,
@@ -1910,60 +1966,37 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
               AND label.street_edge_id <> (SELECT tutorial_street_edge_id FROM config)
               AND audit_task.street_edge_id <> (SELECT tutorial_street_edge_id FROM config)
       ) AS label_counts_and_severity, (
-          SELECT COUNT(*) AS validation_count
+          SELECT #$validationTotalsCols
           FROM label_validation
           INNER JOIN user_stat ON label_validation.user_id = user_stat.user_id
+          INNER JOIN user_role ON user_stat.user_id = user_role.user_id
+          INNER JOIN role ON user_role.role_id = role.role_id
           WHERE #$userFilter
       ) AS total_val_count, (
-          SELECT COUNT(CASE WHEN correct THEN 1 END) AS n_agree,
-                 COUNT(CASE WHEN NOT correct THEN 1 END) AS n_disagree,
-                 COUNT(CASE WHEN correct IS NOT NULL THEN 1 END) AS n_validated,
-                 COUNT(CASE WHEN agree_count + disagree_count + unsure_count > 0 THEN 1 END) AS n_with_validation,
-                 COUNT(CASE WHEN label_type = 'CurbRamp' AND correct THEN 1 END) AS n_ramp_agree,
-                 COUNT(CASE WHEN label_type = 'CurbRamp' AND NOT correct THEN 1 END) AS n_ramp_disagree,
-                 COUNT(CASE WHEN label_type = 'CurbRamp' AND correct IS NOT NULL THEN 1 END) AS n_ramp_total,
-                 COUNT(CASE WHEN label_type = 'CurbRamp' AND agree_count + disagree_count + unsure_count > 0 THEN 1 END) AS n_ramp_with_validation,
-                 COUNT(CASE WHEN label_type = 'NoCurbRamp' AND correct THEN 1 END) AS n_noramp_agree,
-                 COUNT(CASE WHEN label_type = 'NoCurbRamp' AND NOT correct THEN 1 END) AS n_noramp_disagree,
-                 COUNT(CASE WHEN label_type = 'NoCurbRamp' AND correct IS NOT NULL THEN 1 END) AS n_noramp_total,
-                 COUNT(CASE WHEN label_type = 'NoCurbRamp' AND agree_count + disagree_count + unsure_count > 0 THEN 1 END) AS n_noramp_with_validation,
-                 COUNT(CASE WHEN label_type = 'Obstacle' AND correct THEN 1 END) AS n_obs_agree,
-                 COUNT(CASE WHEN label_type = 'Obstacle' AND NOT correct THEN 1 END) AS n_obs_disagree,
-                 COUNT(CASE WHEN label_type = 'Obstacle' AND correct IS NOT NULL THEN 1 END) AS n_obs_total,
-                 COUNT(CASE WHEN label_type = 'Obstacle' AND agree_count + disagree_count + unsure_count > 0 THEN 1 END) AS n_obs_with_validation,
-                 COUNT(CASE WHEN label_type = 'SurfaceProblem' AND correct THEN 1 END) AS n_surf_agree,
-                 COUNT(CASE WHEN label_type = 'SurfaceProblem' AND NOT correct THEN 1 END) AS n_surf_disagree,
-                 COUNT(CASE WHEN label_type = 'SurfaceProblem' AND correct IS NOT NULL THEN 1 END) AS n_surf_total,
-                 COUNT(CASE WHEN label_type = 'SurfaceProblem' AND agree_count + disagree_count + unsure_count > 0 THEN 1 END) AS n_surf_with_validation,
-                 COUNT(CASE WHEN label_type = 'NoSidewalk' AND correct THEN 1 END) AS n_nosidewalk_agree,
-                 COUNT(CASE WHEN label_type = 'NoSidewalk' AND NOT correct THEN 1 END) AS n_nosidewalk_disagree,
-                 COUNT(CASE WHEN label_type = 'NoSidewalk' AND correct IS NOT NULL THEN 1 END) AS n_nosidewalk_total,
-                 COUNT(CASE WHEN label_type = 'NoSidewalk' AND agree_count + disagree_count + unsure_count > 0 THEN 1 END) AS n_nosidewalk_with_validation,
-                 COUNT(CASE WHEN label_type = 'Crosswalk' AND correct THEN 1 END) AS n_crswlk_agree,
-                 COUNT(CASE WHEN label_type = 'Crosswalk' AND NOT correct THEN 1 END) AS n_crswlk_disagree,
-                 COUNT(CASE WHEN label_type = 'Crosswalk' AND correct IS NOT NULL THEN 1 END) AS n_crswlk_total,
-                 COUNT(CASE WHEN label_type = 'Crosswalk' AND agree_count + disagree_count + unsure_count > 0 THEN 1 END) AS n_crswlk_with_validation,
-                 COUNT(CASE WHEN label_type = 'Signal' AND correct THEN 1 END) AS n_signal_agree,
-                 COUNT(CASE WHEN label_type = 'Signal' AND NOT correct THEN 1 END) AS n_signal_disagree,
-                 COUNT(CASE WHEN label_type = 'Signal' AND correct IS NOT NULL THEN 1 END) AS n_signal_total,
-                 COUNT(CASE WHEN label_type = 'Signal' AND agree_count + disagree_count + unsure_count > 0 THEN 1 END) AS n_signal_with_validation,
-                 COUNT(CASE WHEN label_type = 'Occlusion' AND correct THEN 1 END) AS n_occlusion_agree,
-                 COUNT(CASE WHEN label_type = 'Occlusion' AND NOT correct THEN 1 END) AS n_occlusion_disagree,
-                 COUNT(CASE WHEN label_type = 'Occlusion' AND correct IS NOT NULL THEN 1 END) AS n_occlusion_total,
-                 COUNT(CASE WHEN label_type = 'Occlusion' AND agree_count + disagree_count + unsure_count > 0 THEN 1 END) AS n_occlusion_with_validation,
-                 COUNT(CASE WHEN label_type = 'Other' AND correct THEN 1 END) AS n_other_agree,
-                 COUNT(CASE WHEN label_type = 'Other' AND NOT correct THEN 1 END) AS n_other_disagree,
-                 COUNT(CASE WHEN label_type = 'Other' AND correct IS NOT NULL THEN 1 END) AS n_other_total,
-                 COUNT(CASE WHEN label_type = 'Other' AND agree_count + disagree_count + unsure_count > 0 THEN 1 END) AS n_other_with_validation
-          FROM label
-          INNER JOIN label_type ON label.label_type_id = label_type.label_type_id
-          INNER JOIN user_stat ON label.user_id = user_stat.user_id
-          INNER JOIN audit_task ON label.audit_task_id = audit_task.audit_task_id
-          WHERE #$userFilter
-              AND deleted = FALSE
-              AND tutorial = FALSE
-              AND label.street_edge_id <> (SELECT tutorial_street_edge_id FROM config)
-              AND audit_task.street_edge_id <> (SELECT tutorial_street_edge_id FROM config)
+          SELECT #$validationAggCols
+          FROM (
+              -- One row per validated label: the majority verdict from each vote source plus that source's vote count.
+              -- AI votes are baked into the label table's agree/disagree/correct columns, so we recompute from
+              -- label_validation joined to role to separate human (role <> 'AI') from AI (role = 'AI') from combined.
+              SELECT label.label_id, label_type.label_type,
+                     #$validationVerdictCols
+              FROM label
+              INNER JOIN label_type ON label.label_type_id = label_type.label_type_id
+              INNER JOIN audit_task ON label.audit_task_id = audit_task.audit_task_id
+              INNER JOIN user_stat AS labeler_stat ON label.user_id = labeler_stat.user_id
+              INNER JOIN label_validation ON label.label_id = label_validation.label_id
+              INNER JOIN user_stat AS validator_stat ON label_validation.user_id = validator_stat.user_id
+              INNER JOIN user_role ON validator_stat.user_id = user_role.user_id
+              INNER JOIN role ON user_role.role_id = role.role_id
+              WHERE #$labelerFilter
+                  AND validator_stat.excluded = FALSE
+                  AND label.user_id <> label_validation.user_id -- Exclude users validating their own labels.
+                  AND label.deleted = FALSE
+                  AND label.tutorial = FALSE
+                  AND label.street_edge_id <> (SELECT tutorial_street_edge_id FROM config)
+                  AND audit_task.street_edge_id <> (SELECT tutorial_street_edge_id FROM config)
+              GROUP BY label.label_id, label_type.label_type
+          ) AS label_verdicts
       ) AS val_counts, (
           SELECT COUNT(CASE WHEN ai_mv = 1 AND human_mv = 1 THEN 1 END) AS ai_yes_mv_yes,
                  COUNT(CASE WHEN ai_mv = 1 AND human_mv = 2 THEN 1 END) AS ai_yes_mv_no,

--- a/app/views/apiDocs/overallStats.scala.html
+++ b/app/views/apiDocs/overallStats.scala.html
@@ -161,30 +161,49 @@
         },
         ... // Remaining label types
     },
+    // Validation stats are split into three parallel blocks: "combined" (all votes), "human" (non-AI votes only),
+    // and "ai" (AI votes only). Each block has the same structure. AI votes are included in "combined".
     "validations": {
-        "total_validations": 125834,
-        "Overall": {
-            "validated": 151196,
-            "agreed": 127564,
-            "disagreed": 23632,
-            "accuracy": 0.84,
-            "has_a_validation": 162974
+        "combined": {
+            "total_validations": 125834,
+            "Overall": {
+                "validated": 151196,
+                "agreed": 127564,
+                "disagreed": 23632,
+                "accuracy": 0.84,
+                "has_a_validation": 162974
+            },
+            "CurbRamp": {
+                "validated": 54321,
+                "agreed": 48923,
+                "disagreed": 5398,
+                "accuracy": 0.90,
+                "has_a_validation": 59422
+            },
+            ... // Remaining label types
         },
-        "CurbRamp": {
-            "validated": 54321,
-            "agreed": 48923,
-            "disagreed": 5398,
-            "accuracy": 0.90,
-            "has_a_validation": 59422
+        "human": {
+            "total_validations": 119032,
+            "Overall": {
+                "validated": 142880,
+                "agreed": 120115,
+                "disagreed": 22765,
+                "accuracy": 0.84,
+                "has_a_validation": 154219
+            },
+            ... // Same label-type structure as "combined"
         },
-        "NoCurbRamp": {
-            "validated": 21456,
-            "agreed": 18237,
-            "disagreed": 3219,
-            "accuracy": 0.85,
-            "has_a_validation": 26100
-        },
-        ... // Remaining label types
+        "ai": {
+            "total_validations": 6802,
+            "Overall": {
+                "validated": 8316,
+                "agreed": 7449,
+                "disagreed": 867,
+                "accuracy": 0.90,
+                "has_a_validation": 8755
+            },
+            ... // Same label-type structure as "combined"
+        }
     },
     "ai_stats": {
         "Overall": {
@@ -252,13 +271,14 @@
                     <tr><td><code>labels.[type].count_with_severity</code></td><td><code>integer | null</code></td><td>Number of labels of this type that have severity ratings, or null if no severity ratings exist.</td></tr>
                     <tr><td><code>labels.[type].severity_mean</code></td><td><code>number | null</code></td><td>Mean severity rating for this label type, or null if no severity ratings exist.</td></tr>
                     <tr><td><code>labels.[type].severity_sd</code></td><td><code>number | null</code></td><td>Standard deviation of severity ratings for this label type, or null if insufficient data.</td></tr>
-                    <tr><td><code>validations</code></td><td><code>object</code></td><td>Statistics about validation accuracy by label type.</td></tr>
-                    <tr><td><code>validations.total_validations</code></td><td><code>integer</code></td><td>Total number of validation judgments made across all labels.</td></tr>
-                    <tr><td><code>validations.[type].validated</code></td><td><code>integer</code></td><td>Number of labels of this type that have been validated as either "correct" or "incorrect" through majority vote; a label is not included if the number of agree and disagree votes are equal.</td></tr>
-                    <tr><td><code>validations.[type].agreed</code></td><td><code>integer</code></td><td>Number of labels of this type that have been validated as "correct" through majority vote.</td></tr>
-                    <tr><td><code>validations.[type].disagreed</code></td><td><code>integer</code></td><td>Number of labels of this type that have been validated as "incorrect" through majority vote</td></tr>
-                    <tr><td><code>validations.[type].accuracy</code></td><td><code>number | null</code></td><td>Calculated accuracy rate (agreed / validated) for this label type, or null if no validations.</td></tr>
-                    <tr><td><code>validations.[type].validated</code></td><td><code>integer</code></td><td>Number of labels of this type that have received any validation votes.</td></tr>
+                    <tr><td><code>validations</code></td><td><code>object</code></td><td>Validation statistics split into three parallel blocks by vote source: <code>combined</code> (all votes), <code>human</code> (votes cast by people), and <code>ai</code> (votes cast by Project Sidewalk's AI). Each block has the identical structure described below. Note that <code>combined</code> includes AI votes, so it is not the same as <code>human</code>.</td></tr>
+                    <tr><td><code>validations.[source]</code></td><td><code>object</code></td><td>One of <code>combined</code>, <code>human</code>, or <code>ai</code>. Holds the validation breakdown computed using only that source's votes.</td></tr>
+                    <tr><td><code>validations.[source].total_validations</code></td><td><code>integer</code></td><td>Total number of individual validation judgments made by this source across all labels.</td></tr>
+                    <tr><td><code>validations.[source].[type].validated</code></td><td><code>integer</code></td><td>Number of labels of this type that this source has validated as either "correct" or "incorrect" through majority vote; a label is not included if the number of agree and disagree votes are equal.</td></tr>
+                    <tr><td><code>validations.[source].[type].agreed</code></td><td><code>integer</code></td><td>Number of labels of this type that this source has validated as "correct" through majority vote.</td></tr>
+                    <tr><td><code>validations.[source].[type].disagreed</code></td><td><code>integer</code></td><td>Number of labels of this type that this source has validated as "incorrect" through majority vote.</td></tr>
+                    <tr><td><code>validations.[source].[type].accuracy</code></td><td><code>number | null</code></td><td>Calculated accuracy rate (agreed / validated) for this label type and source, or null if no validations. Note that for the <code>ai</code> source this measures how often AI's own majority verdict was "agree", which is distinct from <code>ai_stats</code> (AI vs. human agreement).</td></tr>
+                    <tr><td><code>validations.[source].[type].has_a_validation</code></td><td><code>integer</code></td><td>Number of labels of this type that have received at least one validation vote from this source.</td></tr>
                     <tr><td><code>ai_stats</code></td><td><code>object</code></td><td>Statistics human agreement with AI validations.</td></tr>
                     <tr><td><code>ai_stats.[type].[vote]</code></td><td><code>object</code></td><td>Vote can be either "human" for majority vote across all users, or "admin" for majority vote across admin users.</td></tr>
                     <tr><td><code>ai_stats.[type].[vote].ai_yes_human_concurs</code></td><td><code>object</code></td><td>Number of labels where AI voted yes and human users voted yes more often than no.</td></tr>
@@ -291,17 +311,19 @@ CurbRamp Count With Severity,61837
 CurbRamp Severity Mean,1.2
 CurbRamp Severity SD,0.5
 ...
-Total Validations,125834
-Overall Labels Validated,151196
-Overall Agreed Count,127564
-Overall Disagreed Count,23632
-Overall Accuracy,0.84
-Overall Labels With a Validation,162974
-CurbRamp Labels Validated,54321
-CurbRamp Agreed Count,48923
-CurbRamp Disagreed Count,5398
-CurbRamp Accuracy,0.90
-CurbRamp Labels With a Validation,59422
+Combined Total Validations,125834
+Combined Overall Labels Validated,151196
+Combined Overall Agreed Count,127564
+Combined Overall Disagreed Count,23632
+Combined Overall Accuracy,0.84
+Combined Overall Labels With a Validation,162974
+Combined CurbRamp Labels Validated,54321
+...
+Human Total Validations,119032
+Human Overall Labels Validated,142880
+...
+AI Total Validations,6802
+AI Overall Labels Validated,8316
 ...
 Overall AI Yes and Human Majority Vote Concurs,37
 Overall AI Yes but Human Majority Vote Differs,3

--- a/test/formats/json/ApiFormatsSpec.scala
+++ b/test/formats/json/ApiFormatsSpec.scala
@@ -1,0 +1,94 @@
+package formats.json
+
+import models.label.{LabelAccuracy, ProjectSidewalkStats, ValidationSourceStats, ValidationStats}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.{JsObject, JsValue}
+
+/**
+ * Pure (no DB, no app boot) contract test for the `/v3/api/overallStats` JSON shape.
+ *
+ * Guards the breaking response-shape change from #4223: the `validations` block splits into combined/human/ai. This
+ * is the kind of regression the compiler cannot catch — a JSON-shape change is invisible to the type system.
+ */
+class ApiFormatsSpec extends AnyFunSuite with Matchers {
+
+  /** Builds a ProjectSidewalkStats with distinct combined/human/ai values so the test can tell the blocks apart. */
+  private def sampleStats: ProjectSidewalkStats = {
+    def source(total: Int, overall: LabelAccuracy, curbRamp: LabelAccuracy, other: LabelAccuracy): ValidationSourceStats =
+      ValidationSourceStats(
+        nValidations = total,
+        accuracyByLabelType = Map("Overall" -> overall, "CurbRamp" -> curbRamp, "Other" -> other)
+      )
+
+    ProjectSidewalkStats(
+      launchDate = "2021-06-15",
+      avgTimestampLast100Labels = None,
+      kmExplored = 10.0,
+      kmExploreNoOverlap = 8.0,
+      nUsers = 5,
+      nExplorers = 4,
+      nValidators = 3,
+      nRegistered = 2,
+      nAnon = 1,
+      nTurker = 0,
+      nResearcher = 1,
+      nLabels = 50,
+      nLabelsWithSeverity = 40,
+      avgLabelTimestamp = None,
+      avgImageAgeByLabel = None,
+      severityByLabelType = Map.empty,
+      validations = ValidationStats(
+        // "Other" has accuracy = None on purpose, to assert the null-accuracy key is omitted (writeNullable behavior).
+        combined =
+          source(100, LabelAccuracy(80, 70, 10, Some(0.875), 90), LabelAccuracy(40, 38, 2, Some(0.95), 45),
+            LabelAccuracy(0, 0, 0, None, 0)),
+        human =
+          source(90, LabelAccuracy(72, 63, 9, Some(0.875), 81), LabelAccuracy(36, 34, 2, Some(0.944), 40),
+            LabelAccuracy(0, 0, 0, None, 0)),
+        ai =
+          source(10, LabelAccuracy(8, 7, 1, Some(0.875), 9), LabelAccuracy(4, 4, 0, Some(1.0), 5),
+            LabelAccuracy(0, 0, 0, None, 0))
+      ),
+      aiPerformance = Map.empty
+    )
+  }
+
+  test("overallStats validations block splits into combined/human/ai, each with total + per-type accuracy") {
+    val json: JsValue        = ApiFormats.projectSidewalkStatsToJson(sampleStats)
+    val validations: JsValue = (json \ "validations").get
+
+    (validations.as[JsObject].keys) shouldBe Set("combined", "human", "ai")
+
+    (validations \ "combined" \ "total_validations").as[Int] shouldBe 100
+    (validations \ "human" \ "total_validations").as[Int] shouldBe 90
+    (validations \ "ai" \ "total_validations").as[Int] shouldBe 10
+
+    // Combined Overall block carries the full LabelAccuracy field set.
+    val combinedOverall = validations \ "combined" \ "Overall"
+    (combinedOverall \ "validated").as[Int] shouldBe 80
+    (combinedOverall \ "agreed").as[Int] shouldBe 70
+    (combinedOverall \ "disagreed").as[Int] shouldBe 10
+    (combinedOverall \ "accuracy").as[Double] shouldBe 0.875
+    (combinedOverall \ "has_a_validation").as[Int] shouldBe 90
+
+    // Sources are genuinely distinct (the whole point of #4223).
+    (validations \ "ai" \ "CurbRamp" \ "accuracy").as[Double] shouldBe 1.0
+    (validations \ "human" \ "CurbRamp" \ "agreed").as[Int] shouldBe 34
+  }
+
+  test("old flat validations shape is gone (breaking-change guard)") {
+    val json = ApiFormats.projectSidewalkStatsToJson(sampleStats)
+    // Pre-#4223 these lived directly under `validations`; they must now only exist under a source block.
+    (json \ "validations" \ "Overall").toOption shouldBe None
+    (json \ "validations" \ "total_validations").toOption shouldBe None
+  }
+
+  test("null accuracy is omitted, but the other fields remain") {
+    val json  = ApiFormats.projectSidewalkStatsToJson(sampleStats)
+    val other = json \ "validations" \ "combined" \ "Other"
+    (other \ "accuracy").toOption shouldBe None
+    (other \ "validated").as[Int] shouldBe 0
+    (other \ "has_a_validation").as[Int] shouldBe 0
+  }
+}


### PR DESCRIPTION
Closes #4223.

## Why
AI validations flow through the normal validation path (`AiService` → `ValidationService.insert` → `updateValidationCounts`), and the AI user is neither excluded nor the labeler — so **AI votes are baked into `label.agree_count` / `disagree_count` / `correct`**. As a result, the `validations` block in `/v3/api/overallStats` silently combined human + AI, making it impossible for consumers (incl. the dashboard) to tell them apart.

## What
Restructure the `validations` block into three parallel, internally-consistent breakdowns — **`combined`** (all votes), **`human`** (non-AI), **`ai`** (AI) — each with a `total_validations` count and the full per-label-type accuracy block (`validated` / `agreed` / `disagreed` / `accuracy` / `has_a_validation`).

```jsonc
"validations": {
  "combined": { "total_validations": …, "Overall": { … }, "CurbRamp": { … }, … },
  "human":    { "total_validations": …, "Overall": { … }, … },
  "ai":       { "total_validations": …, "Overall": { … }, … }
}
```

Because the denormalized `label` columns can't be split by source, the per-type stats are recomputed from `label_validation` joined to `role` via a per-label majority-vote subquery (the same role-based technique the existing `ai_stats` subquery already uses). The ~150 repetitive SQL columns and the positional `GetResult` parser are generated from shared ordered lists (`validationStatSources` × `validationStatLabelTypes`) so they stay in lockstep.

Touches: `LabelTable` (SQL + model + parser), `ApiFormats` (JSON), `StatsApiController` (CSV), `apiDocs/overallStats.scala.html` (docs), plus a contract test.

## ⚠️ Breaking change
The response shape changes: `validations.Overall` → `validations.combined.Overall`, etc. The dashboard will need the corresponding update.

## Semantics note
Within each source, `agreed`/`disagreed` mean "the majority of *that source's* votes." So `ai.accuracy` = "how often AI's own majority verdict was 'agree'," which is distinct from `ai_stats` (AI-vs-human concordance) — both are kept. Documented in the field table.

## Verification
- Against the live dev DB: `combined` reproduces the **old** per-type numbers **exactly** (regression check), and `human.total + ai.total == combined.total`.
- New `test/formats/json/ApiFormatsSpec.scala` locks the combined/human/ai JSON shape, guards against the old flat shape returning, and pins null-accuracy omission (3/3 green). The merged DB-backed `backend-tests` CI job also boots the app and exercises `/v3/api/overallStats` end-to-end.

## Follow-ups (filed)
- #4244 — docs wording ("users and/or AI") for rawLabels/labelClusters.
- #4245 — `ai_stats` ignores `filterLowQuality`; raw-SQL maintainability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)