### PR TITLE
Add /v3/api/regions endpoint with docs and live preview (#4017)

### DIFF
--- a/app/controllers/ApiDocsController.scala
+++ b/app/controllers/ApiDocsController.scala
@@ -81,6 +81,16 @@ class ApiDocsController @Inject() (
   }
 
   /**
+   * Displays API documentation for the regions.
+   */
+  def regions = cc.securityService.SecuredAction { implicit request =>
+    configService.getCommonPageData(request2Messages.lang).map { commonData =>
+      cc.loggingService.insert(request.identity.userId, request.ipAddress, "Visit_APIDocs_Regions")
+      Ok(views.html.apiDocs.regions(commonData, request.identity))
+    }
+  }
+
+  /**
    * Displays API documentation for the street types.
    */
   def streetTypes = cc.securityService.SecuredAction { implicit request =>

--- a/app/controllers/api/RegionApiController.scala
+++ b/app/controllers/api/RegionApiController.scala
@@ -1,21 +1,120 @@
 package controllers.api
 
 import controllers.base.CustomControllerComponents
+import controllers.helper.ShapefilesCreatorHelper
 import formats.json.ApiFormats._
+import models.api.{ApiError, RegionDataForApi, RegionFiltersForApi}
+import models.utils.LatLngBBox
+import org.apache.pekko.stream.scaladsl.Source
 import play.api.libs.json.Json
 import play.silhouette.api.Silhouette
-import service.ApiService
+import service.{ApiService, ConfigService}
 
+import java.time.OffsetDateTime
 import javax.inject.{Inject, Singleton}
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class RegionApiController @Inject() (
     cc: CustomControllerComponents,
     val silhouette: Silhouette[models.auth.DefaultEnv],
-    apiService: ApiService
+    apiService: ApiService,
+    configService: ConfigService,
+    shapefileCreator: ShapefilesCreatorHelper
 )(implicit ec: ExecutionContext)
     extends BaseApiController(cc) {
+
+  /**
+   * Gets regions (neighborhoods) with filters applied.
+   *
+   * @param bbox Bounding box in format "minLng,minLat,maxLng,maxLat"
+   * @param regionId Optional region ID to filter for a single region
+   * @param regionName Optional region name to filter for a single region
+   * @param minLabelCount Optional minimum number of labels within the region
+   * @param filetype Output format: "geojson" (default), "csv", "shapefile", "geopackage"
+   * @param inline Whether to display the file inline or as an attachment
+   */
+  def getRegions(
+      bbox: Option[String],
+      regionId: Option[Int],
+      regionName: Option[String],
+      minLabelCount: Option[Int],
+      filetype: Option[String],
+      inline: Option[Boolean]
+  ) = silhouette.UserAwareAction.async { implicit request =>
+    // Parse the bbox parameter.
+    val parsedBbox: Option[LatLngBBox] = parseBBoxString(bbox)
+
+    // Handle input parameter error cases.
+    if (bbox.isDefined && parsedBbox.isEmpty) {
+      Future.successful(
+        BadRequest(
+          Json.toJson(
+            ApiError.invalidParameter(
+              "Invalid value for bbox parameter. Expected format: minLng,minLat,maxLng,maxLat.",
+              "bbox"
+            )
+          )
+        )
+      )
+    } else if (regionId.isDefined && regionId.get <= 0) {
+      Future.successful(
+        BadRequest(
+          Json.toJson(
+            ApiError.invalidParameter("Invalid regionId value. Must be a positive integer.", "regionId")
+          )
+        )
+      )
+    } else {
+      configService.getCityMapParams.flatMap { cityMapParams =>
+        // If bbox isn't provided, use city defaults.
+        val apiBox: LatLngBBox = parsedBbox.getOrElse(
+          LatLngBBox(
+            minLng = Math.min(cityMapParams.lng1, cityMapParams.lng2),
+            minLat = Math.min(cityMapParams.lat1, cityMapParams.lat2),
+            maxLng = Math.max(cityMapParams.lng1, cityMapParams.lng2),
+            maxLat = Math.max(cityMapParams.lat1, cityMapParams.lat2)
+          )
+        )
+
+        // Apply filter precedence logic. If bbox is defined, it takes precedence over region filters.
+        val finalBbox: Option[LatLngBBox] = if (bbox.isDefined && parsedBbox.isDefined) {
+          parsedBbox
+        } else if (regionId.isDefined || regionName.isDefined) {
+          None // If region filters are used, bbox should be None.
+        } else {
+          Some(apiBox) // Default city bbox.
+        }
+
+        // If bbox is defined, ignore region filters; regionId takes precedence over regionName.
+        val finalRegionId = if (bbox.isDefined && parsedBbox.isDefined) None else regionId
+        val finalRegionName =
+          if (bbox.isDefined && parsedBbox.isDefined || regionId.isDefined) None else regionName
+
+        // Create filters object.
+        val filters = RegionFiltersForApi(
+          bbox = finalBbox, regionId = finalRegionId, regionName = finalRegionName, minLabelCount = minLabelCount
+        )
+
+        // Get the data stream.
+        val dbDataStream: Source[RegionDataForApi, _] = apiService.getRegions(filters, DEFAULT_BATCH_SIZE)
+        val baseFileName: String                      = s"regions_${OffsetDateTime.now()}"
+        cc.loggingService.insert(request.identity.map(_.userId), request.ipAddress, request.toString)
+
+        // Output data in the appropriate file format.
+        filetype match {
+          case Some("csv") =>
+            outputCSV(dbDataStream, RegionDataForApi.csvHeader, inline, baseFileName + ".csv")
+          case Some("shapefile") =>
+            outputShapefile(dbDataStream, baseFileName, shapefileCreator.createRegionDataShapefile, shapefileCreator)
+          case Some("geopackage") =>
+            outputGeopackage(dbDataStream, baseFileName, shapefileCreator.createRegionDataGeopackage, inline)
+          case _ => // Default to GeoJSON.
+            outputGeoJSON(dbDataStream, inline, baseFileName + ".json")
+        }
+      }
+    }
+  }
 
   /**
    * Returns the region with the highest number of labels.

--- a/app/controllers/helper/ShapefilesCreatorHelper.scala
+++ b/app/controllers/helper/ShapefilesCreatorHelper.scala
@@ -1,6 +1,6 @@
 package controllers.helper
 
-import models.api.{LabelClusterForApi, LabelDataForApi, RawLabelInClusterDataForApi, StreetDataForApi}
+import models.api.{LabelClusterForApi, LabelDataForApi, RawLabelInClusterDataForApi, RegionDataForApi, StreetDataForApi}
 import models.computation.{RegionScore, StreetScore}
 import org.apache.pekko.stream.Materializer
 import org.apache.pekko.stream.scaladsl.{Source, StreamConverters}
@@ -987,6 +987,92 @@ class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: M
       featureBuilder.add(street.firstLabelDate.map(_.toString).orNull)
       featureBuilder.add(street.lastLabelDate.map(_.toString).orNull)
 
+      featureBuilder.buildFeature(null)
+    }
+
+    createGeneralGeoPackage(source, outputFile, batchSize, featureType, buildFeature)
+  }
+
+  /**
+   * Creates a shapefile from RegionDataForApi objects.
+   *
+   * @param source Stream of RegionDataForApi objects
+   * @param outputFile Base filename for the output file (without extension)
+   * @param batchSize Number of features to process in each batch
+   * @return Path to the created shapefile, or None if creation failed
+   */
+  def createRegionDataShapefile(
+      source: Source[RegionDataForApi, _],
+      outputFile: String,
+      batchSize: Int
+  ): Future[Option[Path]] = {
+    // Define the feature type schema for RegionDataForApi.
+    val featureType: SimpleFeatureType = DataUtilities.createType(
+      "Region",
+      "the_geom:MultiPolygon:srid=4326," // the geometry attribute: MultiPolygon type
+      + "regionId:Integer,"              // Region ID
+      + "name:String,"                   // Region name
+      + "labelCount:Integer,"            // Number of labels in this region
+      + "streetCount:Integer,"           // Number of streets in this region
+      + "userCount:Integer,"             // Number of unique users who labeled in this region
+      + "auditCount:Integer,"            // Number of completed audits in this region
+      + "firstLabel:String,"             // First label date
+      + "lastLabel:String"               // Last label date
+    )
+
+    def buildFeature(region: RegionDataForApi, featureBuilder: SimpleFeatureBuilder): SimpleFeature = {
+      featureBuilder.add(region.geometry)
+      featureBuilder.add(region.regionId)
+      featureBuilder.add(region.name)
+      featureBuilder.add(region.labelCount)
+      featureBuilder.add(region.streetCount)
+      featureBuilder.add(region.userCount)
+      featureBuilder.add(region.auditCount)
+      featureBuilder.add(region.firstLabelDate.map(_.toString).orNull)
+      featureBuilder.add(region.lastLabelDate.map(_.toString).orNull)
+      featureBuilder.buildFeature(null)
+    }
+
+    createGeneralShapefile(source, outputFile, batchSize, featureType, buildFeature)
+  }
+
+  /**
+   * Creates a GeoPackage file from RegionDataForApi objects.
+   *
+   * @param source Stream of RegionDataForApi objects
+   * @param outputFile Base filename for the output file (without extension)
+   * @param batchSize Number of features to process in each batch
+   * @return Path to the created GeoPackage file, or None if creation failed
+   */
+  def createRegionDataGeopackage(
+      source: Source[RegionDataForApi, _],
+      outputFile: String,
+      batchSize: Int
+  ): Future[Option[Path]] = {
+    // Define the feature type schema.
+    val featureType: SimpleFeatureType = DataUtilities.createType(
+      "regions",
+      "the_geom:MultiPolygon:srid=4326," // MultiPolygon geometry
+      + "region_id:Integer,"             // Region ID
+      + "name:String,"                   // Region name
+      + "label_count:Integer,"           // Number of labels in this region
+      + "street_count:Integer,"          // Number of streets in this region
+      + "user_count:Integer,"            // Number of unique users who labeled in this region
+      + "audit_count:Integer,"           // Number of completed audits in this region
+      + "first_label_time:String,"       // First label date
+      + "last_label_time:String"         // Last label date
+    )
+
+    def buildFeature(region: RegionDataForApi, featureBuilder: SimpleFeatureBuilder): SimpleFeature = {
+      featureBuilder.add(region.geometry)
+      featureBuilder.add(region.regionId)
+      featureBuilder.add(region.name)
+      featureBuilder.add(region.labelCount)
+      featureBuilder.add(region.streetCount)
+      featureBuilder.add(region.userCount)
+      featureBuilder.add(region.auditCount)
+      featureBuilder.add(region.firstLabelDate.map(_.toString).orNull)
+      featureBuilder.add(region.lastLabelDate.map(_.toString).orNull)
       featureBuilder.buildFeature(null)
     }
 

--- a/app/models/api/RegionsApiModels.scala
+++ b/app/models/api/RegionsApiModels.scala
@@ -1,0 +1,125 @@
+/**
+ * Models for the Project Sidewalk Regions API.
+ *
+ * This file contains the data structures used for API requests, responses, and error handling related to regions
+ * (neighborhoods).
+ */
+package models.api
+
+import models.api.ApiModelUtils.escapeCsvField
+import models.computation.StreamingApiType
+import models.utils.LatLngBBox
+import models.utils.MyPostgresProfile.api._
+import org.locationtech.jts.geom.MultiPolygon
+import play.api.libs.json.{JsObject, Json, Writes}
+
+import java.time.OffsetDateTime
+
+/**
+ * Represents a region (neighborhood) with associated metadata for the Regions API.
+ * Implements StreamingApiType to support streaming output formats like GeoJSON and CSV.
+ *
+ * @param regionId Project Sidewalk's region identifier
+ * @param name Name of the region
+ * @param labelCount Number of (non-tutorial, non-deleted) labels placed within this region
+ * @param streetCount Number of (non-deleted) streets that belong to this region
+ * @param userCount Number of unique users who have placed labels within this region
+ * @param auditCount Number of completed audits of streets within this region
+ * @param firstLabelDate Timestamp of the first label placed within this region (if any)
+ * @param lastLabelDate Timestamp of the most recent label placed within this region (if any)
+ * @param geometry The MultiPolygon geometry representing the region's boundary
+ */
+case class RegionDataForApi(
+    regionId: Int,
+    name: String,
+    labelCount: Int,
+    streetCount: Int,
+    userCount: Int,
+    auditCount: Int,
+    firstLabelDate: Option[OffsetDateTime] = None,
+    lastLabelDate: Option[OffsetDateTime] = None,
+    geometry: MultiPolygon
+) extends StreamingApiType {
+
+  /**
+   * Converts this RegionData object to a GeoJSON Feature object.
+   *
+   * The GeoJSON structure follows RFC 7946 and includes:
+   * - A MultiPolygon geometry
+   * - Properties containing all region metadata
+   *
+   * @return A JsObject containing the GeoJSON Feature representation
+   */
+  override def toJson: JsObject = {
+    Json.obj(
+      "type"       -> "Feature",
+      "geometry"   -> geometry,
+      "properties" -> Json.obj(
+        "region_id"        -> regionId,
+        "name"             -> name,
+        "label_count"      -> labelCount,
+        "street_count"     -> streetCount,
+        "user_count"       -> userCount,
+        "audit_count"      -> auditCount,
+        "first_label_date" -> firstLabelDate.map(_.toString),
+        "last_label_date"  -> lastLabelDate.map(_.toString)
+      )
+    )
+  }
+
+  /**
+   * Converts this RegionData object to a CSV row string, ordered to match the header defined in the companion object.
+   *
+   * @return A comma-separated string representing this region's data
+   */
+  override def toCsvRow: String = {
+    // The full polygon geometry is too complex for the tabular CSV format, so we provide the centroid as a simplified
+    // representation. Use the GeoJSON format for the complete geometry.
+    val centroid = geometry.getCentroid
+    val fields   = Seq(
+      regionId.toString,
+      escapeCsvField(name),
+      labelCount.toString,
+      streetCount.toString,
+      userCount.toString,
+      auditCount.toString,
+      firstLabelDate.map(_.toString).getOrElse(""),
+      lastLabelDate.map(_.toString).getOrElse(""),
+      escapeCsvField(s"${centroid.getX},${centroid.getY}")
+    )
+    fields.mkString(",")
+  }
+}
+
+/**
+ * Companion object for RegionDataForApi containing CSV header definition.
+ */
+object RegionDataForApi {
+
+  /**
+   * CSV header string with field names in the same order as the toCsvRow output.
+   * This should be included as the first line when generating CSV output.
+   */
+  val csvHeader: String = "region_id,name,label_count,street_count,user_count,audit_count,first_label_date," +
+    "last_label_date,center_point\n"
+
+  /**
+   * Implicit JSON writer for RegionDataForApi that uses the toJson method.
+   */
+  implicit val regionDataWrites: Writes[RegionDataForApi] = (region: RegionDataForApi) => region.toJson
+}
+
+/**
+ * Represents filter criteria for the Regions API (v3).
+ *
+ * @param bbox Optional bounding box to filter regions by geographic location
+ * @param regionId Optional region ID to filter for a single region
+ * @param regionName Optional region name to filter for a single region
+ * @param minLabelCount Optional minimum number of labels within the region
+ */
+case class RegionFiltersForApi(
+    bbox: Option[LatLngBBox] = None,
+    regionId: Option[Int] = None,
+    regionName: Option[String] = None,
+    minLabelCount: Option[Int] = None
+)

--- a/app/models/region/RegionTable.scala
+++ b/app/models/region/RegionTable.scala
@@ -1,6 +1,7 @@
 package models.region
 
 import com.google.inject.ImplementedBy
+import models.api.{RegionDataForApi, RegionFiltersForApi}
 import models.audit.AuditTaskTableDef
 import models.label.LabelTable
 import models.street.{StreetEdgePriorityTableDef, StreetEdgeRegionTable}
@@ -8,7 +9,11 @@ import models.utils.MyPostgresProfile.api._
 import models.utils.{LatLngBBox, MyPostgresProfile}
 import org.locationtech.jts.geom.MultiPolygon
 import play.api.db.slick.{DatabaseConfigProvider, HasDatabaseConfigProvider}
+import slick.dbio.Effect
+import slick.jdbc.GetResult
+import slick.sql.SqlStreamingAction
 
+import java.time.{OffsetDateTime, ZoneOffset}
 import javax.inject._
 import scala.concurrent.ExecutionContext
 
@@ -131,6 +136,118 @@ class RegionTable @Inject() (
       .map(_._2)
       .result
       .headOption // Output first region.
+  }
+
+  /**
+   * Gets all region (neighborhood) data for the API with filters applied, designed for streaming.
+   *
+   * @param filters The filters to apply when retrieving regions.
+   * @return        A streaming database action that yields RegionDataForApi objects.
+   */
+  def getRegionsForApi(
+      filters: RegionFiltersForApi
+  ): SqlStreamingAction[Vector[RegionDataForApi], RegionDataForApi, Effect.Read] = {
+    // Set up query filters. User-supplied string values (regionName) are single-quote-escaped and numeric filters are
+    // safe; see #2756 for migrating these raw builders to bound parameters.
+    val bboxFilter = filters.bbox
+      .map { bbox =>
+        s"AND ST_Intersects(region.geom, " +
+          s"ST_MakeEnvelope(${bbox.minLng}, ${bbox.minLat}, ${bbox.maxLng}, ${bbox.maxLat}, 4326))"
+      }
+      .getOrElse("")
+
+    val regionIdFilter = filters.regionId.map { regionId => s"AND region.region_id = $regionId" }.getOrElse("")
+
+    val regionNameFilter =
+      filters.regionName.map { regionName => s"AND LOWER(region.name) = LOWER('${regionName.replace("'", "''")}')" }
+        .getOrElse("")
+
+    val minLabelCountFilter =
+      filters.minLabelCount.map { count => s"AND COALESCE(region_labels.label_count, 0) >= $count" }.getOrElse("")
+
+    val queryStr = s"""
+      WITH filtered_regions AS (
+        SELECT region.region_id, region.name, region.geom
+        FROM region
+        WHERE region.deleted = FALSE
+            $bboxFilter
+            $regionIdFilter
+            $regionNameFilter
+      ),
+      -- Get the number of (non-deleted, non-tutorial) streets in each region.
+      region_streets AS (
+        SELECT street_edge_region.region_id, COUNT(DISTINCT street_edge.street_edge_id) AS street_count
+        FROM street_edge_region
+        JOIN street_edge ON street_edge_region.street_edge_id = street_edge.street_edge_id
+        WHERE street_edge.deleted = FALSE
+            AND street_edge.street_edge_id <> (SELECT tutorial_street_edge_id FROM config)
+            AND street_edge_region.region_id IN (SELECT region_id FROM filtered_regions)
+        GROUP BY street_edge_region.region_id
+      ),
+      -- Get the number of completed audits of streets in each region.
+      region_audits AS (
+        SELECT street_edge_region.region_id, COUNT(audit_task.audit_task_id) AS audit_count
+        FROM street_edge_region
+        JOIN street_edge ON street_edge_region.street_edge_id = street_edge.street_edge_id
+            AND street_edge.deleted = FALSE
+            AND street_edge.street_edge_id <> (SELECT tutorial_street_edge_id FROM config)
+        JOIN audit_task ON street_edge_region.street_edge_id = audit_task.street_edge_id
+            AND audit_task.completed = TRUE
+        WHERE street_edge_region.region_id IN (SELECT region_id FROM filtered_regions)
+        GROUP BY street_edge_region.region_id
+      ),
+      -- Get label counts, distinct user counts, and label timestamps for each region.
+      region_labels AS (
+        SELECT street_edge_region.region_id,
+               COUNT(label.label_id) AS label_count,
+               COUNT(DISTINCT label.user_id) AS user_count,
+               MIN(label.time_created) AS first_label_date,
+               MAX(label.time_created) AS last_label_date
+        FROM street_edge_region
+        JOIN street_edge ON street_edge_region.street_edge_id = street_edge.street_edge_id
+            AND street_edge.deleted = FALSE
+            AND street_edge.street_edge_id <> (SELECT tutorial_street_edge_id FROM config)
+        JOIN label ON street_edge_region.street_edge_id = label.street_edge_id
+            AND label.deleted = FALSE
+            AND label.tutorial = FALSE
+        JOIN user_stat ON label.user_id = user_stat.user_id
+            AND user_stat.excluded = FALSE
+        WHERE street_edge_region.region_id IN (SELECT region_id FROM filtered_regions)
+        GROUP BY street_edge_region.region_id
+      )
+      -- Final selection with all aggregates joined back to the filtered regions.
+      SELECT filtered_regions.region_id, filtered_regions.name,
+             COALESCE(region_labels.label_count, 0) AS label_count,
+             COALESCE(region_streets.street_count, 0) AS street_count,
+             COALESCE(region_labels.user_count, 0) AS user_count,
+             COALESCE(region_audits.audit_count, 0) AS audit_count,
+             region_labels.first_label_date,
+             region_labels.last_label_date,
+             filtered_regions.geom
+      FROM filtered_regions
+      LEFT JOIN region_streets ON filtered_regions.region_id = region_streets.region_id
+      LEFT JOIN region_audits ON filtered_regions.region_id = region_audits.region_id
+      LEFT JOIN region_labels ON filtered_regions.region_id = region_labels.region_id
+      WHERE 1=1
+        $minLabelCountFilter
+      ORDER BY filtered_regions.region_id
+    """
+
+    implicit val getRegionDataForApi: GetResult[RegionDataForApi] = GetResult { r =>
+      RegionDataForApi(
+        regionId = r.nextInt(),
+        name = r.nextString(),
+        labelCount = r.nextInt(),
+        streetCount = r.nextInt(),
+        userCount = r.nextInt(),
+        auditCount = r.nextInt(),
+        firstLabelDate = r.nextTimestampOption().map(t => OffsetDateTime.ofInstant(t.toInstant, ZoneOffset.UTC)),
+        lastLabelDate = r.nextTimestampOption().map(t => OffsetDateTime.ofInstant(t.toInstant, ZoneOffset.UTC)),
+        geometry = r.nextGeometry[MultiPolygon]()
+      )
+    }
+
+    sql"""#$queryStr""".as[RegionDataForApi]
   }
 
   /**

--- a/app/service/ApiService.scala
+++ b/app/service/ApiService.scala
@@ -83,6 +83,15 @@ trait ApiService {
   def getStreets(filters: StreetFiltersForApi, batchSize: Int): Source[StreetDataForApi, _]
 
   /**
+   * Retrieves regions (neighborhoods) based on the provided filters and returns them as a reactive stream source.
+   *
+   * @param filters   The filters to apply when retrieving regions.
+   * @param batchSize The number of records to fetch in each batch from the database.
+   * @return          A reactive stream source that emits RegionDataForApi objects.
+   */
+  def getRegions(filters: RegionFiltersForApi, batchSize: Int): Source[RegionDataForApi, _]
+
+  /**
    * Retrieves the region with the most labels from the database.
    *
    * @return A `Future` containing an `Option` of `Region`. The `Option` will be:
@@ -186,6 +195,10 @@ class ApiServiceImpl @Inject() (
 
   def getStreets(filters: StreetFiltersForApi, batchSize: Int): Source[StreetDataForApi, _] = {
     setUpStreamFromDb(streetEdgeTable.getStreetsForApi(filters), batchSize)
+  }
+
+  def getRegions(filters: RegionFiltersForApi, batchSize: Int): Source[RegionDataForApi, _] = {
+    setUpStreamFromDb(regionTable.getRegionsForApi(filters), batchSize)
   }
 
   def getLabelClusters(filters: LabelClusterFiltersForApi, batchSize: Int): Source[LabelClusterForApi, _] = {

--- a/app/views/apiDocs/_sidebar.scala.html
+++ b/app/views/apiDocs/_sidebar.scala.html
@@ -16,6 +16,7 @@
         <a href="@routes.ApiDocsController.rawLabels" class="api-nav-item @if(activePage == "raw-labels"){active}">Raw Labels</a>
         <a href="@routes.ApiDocsController.labelClusters" class="api-nav-item @if(activePage == "label-clusters"){active}">Label Clusters</a>
         <a href="@routes.ApiDocsController.streets" class="api-nav-item @if(activePage == "streets"){active}">Streets</a>
+        <a href="@routes.ApiDocsController.regions" class="api-nav-item @if(activePage == "regions"){active}">Regions</a>
         <a href="@routes.ApiDocsController.validations" class="api-nav-item @if(activePage == "validations"){active}">Validations</a>
 
 

--- a/app/views/apiDocs/regions.scala.html
+++ b/app/views/apiDocs/regions.scala.html
@@ -1,0 +1,324 @@
+@import service.CommonPageData
+@import models.user.SidewalkUserWithRole
+@import play.api.Configuration
+@(commonData: CommonPageData, user: SidewalkUserWithRole)(implicit request: RequestHeader, messages: Messages, assets: AssetsFinder, config: Configuration)
+@cityName = @{commonData.allCityInfo.filter(c => c.cityId == commonData.cityId).head.cityNameFormatted}
+
+@content = {
+    <script>
+        // Set data attributes for API information. This is used by our JavaScripts to configure API calls,
+        // including the download buttons in api-docs.js
+        document.documentElement.setAttribute('data-api-base-url', '/v3/api');
+        document.documentElement.setAttribute('data-api-endpoint', 'regions');
+    </script>
+
+    <div class="api-section" id="regions-intro-section">
+        <h1 class="api-heading" id="regions-api">Regions API <a href="#regions-api" class="permalink">#</a></h1>
+        <p>
+            The Regions API provides access to Project Sidewalk's region (neighborhood) data, including each region's
+            boundary geometry and summary statistics such as the number of accessibility labels, streets, contributing
+            users, and completed audits. Project Sidewalk divides each city into regions to organize exploration and
+            track progress.
+        </p>
+    </div>
+
+    <div class="api-section" id="regions-preview-section">
+        <h2 class="api-heading" id="visual-example">Regions API Preview <a href="#visual-example" class="permalink">#</a></h2>
+        <p>
+            Below is a live preview of region data from @cityName retrieved directly from the API. Each neighborhood is
+            color-coded by a statistic of your choice—use the <em>Color by</em> dropdown to switch between label count,
+            completed audit count, and contributing user count. Hover and click on a region to view more information.
+        </p>
+
+        <div id="regions-preview">
+            <!-- To be replaced by JavaScript with actual map rendering -->
+        </div>
+
+        <link rel="stylesheet" href="https://unpkg.com/leaflet@@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+        <script src="https://unpkg.com/leaflet@@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+        <link rel="stylesheet" href="@assets.path("stylesheets/api-docs/regions.css")">
+        <script src="@routes.Assets.versioned("javascripts/api-docs/regions-preview.js")"></script>
+        <script>
+            // Initialize the regions preview map.
+            document.addEventListener('DOMContentLoaded', function() {
+                RegionsPreview.setup({
+                    mapHeight: 500
+                }).init();
+            });
+        </script>
+    </div>
+
+    <div class="api-section" id="endpoint-section">
+        <h2 class="api-heading" id="endpoint">Endpoint<a href="#endpoint" class="permalink">#</a></h2>
+        <p>Retrieves a list of regions, optionally filtered by the <a href="#query-parameters">Query Parameters</a> below.</p>
+        <p><code>GET /v3/api/regions</code></p>
+        <div class="api-subsection" id="endpoint-example-section">
+            <h3 class="api-heading" id="endpoint-examples">Examples<a href="#endpoint-examples" class="permalink">#</a></h3>
+            <p><code><a href="/v3/api/regions?filetype=geojson">/v3/api/regions?filetype=geojson</a></code> Get all regions in GeoJSON format (default)</p>
+            <p><code><a target="_blank" href="/v3/api/regions?filetype=geojson&inline=true">/v3/api/regions?filetype=geojson&inline=true</a></code> Get all regions in GeoJSON but opened in the browser</p>
+            <p><code><a href="/v3/api/regions?filetype=csv">/v3/api/regions?filetype=csv</a></code> Get all regions in CSV format</p>
+            <p><code><a href="/v3/api/regions?minLabelCount=100">/v3/api/regions?minLabelCount=100</a></code> Get regions with at least 100 accessibility labels</p>
+            <p><code><a href="/v3/api/regions?regionId=8">/v3/api/regions?regionId=8</a></code> Get a single region by ID</p>
+        </div>
+    </div>
+
+    <div class="api-section" id="quick-download-section">
+        <h2 class="api-heading" id="quick-download">Quick Download <a href="#quick-download" class="permalink">#</a></h2>
+        <p>
+            Download region data directly in your preferred format:
+        </p>
+
+        <div class="download-buttons">
+            <button class="download-btn" data-format="geojson">
+                <span class="format-icon">📝</span> GeoJSON
+                <span class="format-hint">Web mapping standard</span>
+            </button>
+            <button class="download-btn" data-format="csv">
+                <span class="format-icon">📊</span> CSV
+                <span class="format-hint">For Excel, Google Sheets</span>
+            </button>
+            <button class="download-btn" data-format="shapefile">
+                <span class="format-icon">🗺️</span> Shapefile
+                <span class="format-hint">For ArcGIS, QGIS</span>
+            </button>
+            <button class="download-btn" data-format="geopackage">
+                <span class="format-icon">📦</span> GeoPackage
+                <span class="format-hint">Open GIS format</span>
+            </button>
+        </div>
+
+        <div id="download-status" class="status-container status-loading" style="display: none;">
+            <div class="loading-spinner"></div>
+            <div class="status-message">Generating your download...</div>
+            <div class="status-progress">This may take anywhere from a few seconds to a few minutes depending on the data size.</div>
+        </div>
+
+        <p class="download-note">
+            Note: This downloads all region data. For filtered data, use the
+            <a href="#query-parameters">API Query Parameters</a> described below.
+        </p>
+    </div>
+
+    <div class="api-section" id="query-parameters-section">
+        <h2 class="api-heading" id="query-parameters">Query Parameters<a href="#query-parameters" class="permalink">#</a></h2>
+        <p>
+            Filter the regions returned by this endpoint using the following query parameters. All parameters are
+            optional. Combine multiple filter parameters to narrow down results (filters are applied using AND logic).
+        </p>
+        <p>
+            Note: When multiple location filters are provided (<code>bbox</code>, <code>regionId</code>,
+            and <code>regionName</code>), <code>bbox</code> takes precedence over region filters, and
+            <code>regionId</code> takes precedence over <code>regionName</code>.
+        </p>
+
+        <div class="api-table-wrapper">
+            <table class="api-table">
+                <thead>
+                    <tr>
+                        <th>Parameter</th>
+                        <th>Type</th>
+                        <th>Description</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td><code>bbox</code></td>
+                        <td><code>string</code></td>
+                        <td>Filter regions by bounding box. Coordinates should be provided as a comma-separated string in the format: <code>minLongitude,minLatitude,maxLongitude,maxLatitude</code> (e.g., <code>-74.01,40.71,-74.00,40.72</code>). Uses WGS84 (EPSG:4326) coordinates. Returns regions whose boundary intersects the box. If omitted, results are not spatially filtered.</td>
+                    </tr>
+                    <tr>
+                        <td><code>regionId</code></td>
+                        <td><code>integer</code></td>
+                        <td>Filter for a single region by its ID. Note: If both <code>bbox</code> and <code>regionId</code> are provided, <code>bbox</code> takes precedence.</td>
+                    </tr>
+                    <tr>
+                        <td><code>regionName</code></td>
+                        <td><code>string</code></td>
+                        <td>Filter for a single region by its name. Note: If <code>bbox</code> or <code>regionId</code> are provided, they take precedence over <code>regionName</code>.</td>
+                    </tr>
+                    <tr>
+                        <td><code>minLabelCount</code></td>
+                        <td><code>integer</code></td>
+                        <td>Filter for regions with at least this many accessibility labels. Useful for focusing on well-documented regions.</td>
+                    </tr>
+                    <tr>
+                        <td><code>filetype</code></td>
+                        <td><code>string</code></td>
+                        <td>Specify the output format. Options: <code>geojson</code> (default), <code>csv</code>, <code>shapefile</code>, <code>geopackage</code>.</td>
+                    </tr>
+                    <tr>
+                        <td><code>inline</code></td>
+                        <td><code>boolean</code></td>
+                        <td>Whether to display the file inline or as an attachment. Default: <code>false</code> (attachment). Set to <code>true</code> to view data in the browser instead of downloading.</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <div class="api-section" id="responses-section">
+        <h2 class="api-heading" id="responses">Responses<a href="#responses" class="permalink">#</a></h2>
+
+        <h3 class="api-heading" id="success-response-200-ok">Success Response (200 OK)<a href="#success-response-200-ok" class="permalink">#</a></h3>
+        <p>
+            On success, the API returns an HTTP <code>200 OK</code> status code and the requested data in the specified <code>filetype</code> format.
+        </p>
+
+        <h4 id="response-geojson">GeoJSON Format (Default) <a href="#response-geojson" class="permalink">#</a></h4>
+        <p>Returns a GeoJSON FeatureCollection where each feature represents a single region. Coordinate Reference System (CRS) is WGS84 (EPSG:4326).</p>
+        <pre><code class="language-json">{
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "MultiPolygon",
+                "coordinates": [
+                    [
+                        [
+                            [-74.0243606567383, 40.8839912414551],
+                            [-74.0244835449219, 40.8838416503906],
+                            [-74.0245123456789, 40.8836789012345],
+                            [-74.0243606567383, 40.8839912414551]
+                        ]
+                    ]
+                ]
+            },
+            "properties": {
+                "region_id": 8,
+                "name": "Teaneck Community Charter School",
+                "label_count": 423,
+                "street_count": 36,
+                "user_count": 12,
+                "audit_count": 58,
+                "first_label_date": "2023-06-20T14:32:45Z",
+                "last_label_date": "2023-08-15T10:22:18Z"
+            }
+        },
+        ...
+    ]
+}</code></pre>
+
+        <h5 id="geojson-fields">GeoJSON Field Descriptions <a href="#geojson-fields" class="permalink">#</a></h5>
+        <p>Each feature in the GeoJSON response represents a single region with MultiPolygon geometry and detailed properties:</p>
+
+        <div class="api-table-wrapper">
+            <table class="api-table">
+                <thead>
+                    <tr>
+                        <th style="width:30%">Field Path</th>
+                        <th style="width:15%">Type</th>
+                        <th style="width:55%">Description</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td><code>geometry.coordinates</code></td>
+                        <td><code>array[number]</code></td>
+                        <td>Nested arrays of coordinate pairs forming the region's boundary polygon(s), in <code>[longitude, latitude]</code> format using WGS84 (EPSG:4326).</td>
+                    </tr>
+                    <tr>
+                        <td><code>properties.region_id</code></td>
+                        <td><code>integer</code></td>
+                        <td>Project Sidewalk's unique identifier for this region.</td>
+                    </tr>
+                    <tr>
+                        <td><code>properties.name</code></td>
+                        <td><code>string</code></td>
+                        <td>Name of the region, as defined in Project Sidewalk's regions.</td>
+                    </tr>
+                    <tr>
+                        <td><code>properties.label_count</code></td>
+                        <td><code>integer</code></td>
+                        <td>Total number of accessibility labels placed within this region by all users.</td>
+                    </tr>
+                    <tr>
+                        <td><code>properties.street_count</code></td>
+                        <td><code>integer</code></td>
+                        <td>Number of streets that belong to this region.</td>
+                    </tr>
+                    <tr>
+                        <td><code>properties.user_count</code></td>
+                        <td><code>integer</code></td>
+                        <td>Number of unique users who have placed labels within this region.</td>
+                    </tr>
+                    <tr>
+                        <td><code>properties.audit_count</code></td>
+                        <td><code>integer</code></td>
+                        <td>Number of completed audits (virtual walks) of streets within this region.</td>
+                    </tr>
+                    <tr>
+                        <td><code>properties.first_label_date</code></td>
+                        <td><code>string</code></td>
+                        <td>Timestamp when the first accessibility label was placed within this region, in ISO 8601 format. May be <code>null</code> if no labels exist.</td>
+                    </tr>
+                    <tr>
+                        <td><code>properties.last_label_date</code></td>
+                        <td><code>string</code></td>
+                        <td>Timestamp when the most recent accessibility label was placed within this region, in ISO 8601 format. May be <code>null</code> if no labels exist.</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+
+        <h4 id="response-csv">CSV Format <a href="#response-csv" class="permalink">#</a></h4>
+        <p>If <code>filetype=csv</code> is specified, the response body will be CSV data. The first row contains the headers, corresponding to the fields in the GeoJSON properties object, plus a geometry representation. CRS is WGS84 (EPSG:4326).</p>
+        <pre tabindex="0"><code class="language-csv">region_id,name,label_count,street_count,user_count,audit_count,first_label_date,last_label_date,center_point
+8,Teaneck Community Charter School,423,36,12,58,2023-06-20T14:32:45Z,2023-08-15T10:22:18Z,"-74.0244835449219,40.8838416503906"
+...</code></pre>
+
+        <p>
+            Note: The complete MultiPolygon geometry is simplified to a single center point in the CSV format due to the
+            tabular nature of CSV. For full geometry data, use the GeoJSON format.
+        </p>
+
+        <h4 id="response-shapefile">Shapefile Format <a href="#response-shapefile" class="permalink">#</a></h4>
+        <p>
+            If <code>filetype=shapefile</code> is specified, the response body will be a ZIP archive containing the
+            Shapefile components (.shp, .shx, .dbf, .prj). The attribute table (.dbf) contains fields corresponding to
+            the GeoJSON properties object (field names may be truncated due to Shapefile limitations). The included
+            <code>.prj</code> file defines the Coordinate Reference System (CRS), typically WGS84 (EPSG:4326).
+        </p>
+
+        <h4 id="response-geopackage">GeoPackage Format <a href="#response-geopackage" class="permalink">#</a></h4>
+        <p>
+            If <code>filetype=geopackage</code> is specified, the response body will be a GeoPackage (.gpkg) file
+            containing the region data with full geometry and attributes. GeoPackage is a modern, open standard
+            geospatial format that supports complex geometries and is widely supported by GIS software.
+        </p>
+
+        <h3 class="api-heading" id="error-responses">Error Responses<a href="#error-responses" class="permalink">#</a></h3>
+        <p>
+            If an error occurs, the API will return an appropriate HTTP status code and a JSON response body containing
+            details about the error.
+        </p>
+        <ul>
+            <li><strong><code>400 Bad Request</code>:</strong> Invalid parameter values (e.g., malformed bounding box, invalid region ID).</li>
+            <li><strong><code>404 Not Found</code>:</strong> The requested resource does not exist (e.g., incorrect base URL path).</li>
+            <li><strong><code>500 Internal Server Error</code>:</strong> An unexpected error occurred on the server.</li>
+        </ul>
+
+        <h4 id="error-body">Error Response Body <a href="#error-body" class="permalink">#</a></h4>
+        <p>Error responses include a JSON body with the following structure:</p>
+        <pre><code class="language-json">{
+    "status": 400, // HTTP Status Code repeated
+    "code": "INVALID_PARAMETER", // Machine-readable error code
+    "message": "Invalid value for bbox parameter. Expected format: minLng,minLat,maxLng,maxLat.", // Human-readable description
+    "parameter": "bbox" // Optional: The specific parameter causing the error
+}</code></pre>
+    </div>
+
+    <div class="api-section" id="best-practices-section">
+        <h2 class="api-heading" id="best-practices">Best Practices<a href="#best-practices" class="permalink">#</a></h2>
+        <p>When working with the Regions API, consider these recommendations:</p>
+        <ul>
+            <li><strong>Choose the right format:</strong> Use <code>geojson</code> for web mapping applications, <code>csv</code> for basic data analysis, <code>shapefile</code> for traditional GIS software, and <code>geopackage</code> for modern GIS workflows.</li>
+            <li><strong>Combine with other APIs:</strong> Use the Regions API alongside the <a href="/api-docs/streets">Streets API</a>, <a href="/api-docs/labelClusters">Label Clusters API</a>, and <a href="/api-docs/rawLabels">Raw Labels API</a> to drill down from regions to individual streets and labels.</li>
+        </ul>
+    </div>
+}
+
+@common.main(commonData, "API Docs") {
+    @common.navbar(commonData, Some(user))
+    @apiDocs.layout("regions")(content)
+}

--- a/conf/routes
+++ b/conf/routes
@@ -182,6 +182,7 @@ GET     /v3/api/aggregateStats                          controllers.api.StatsApi
 GET     /v3/api/labelClusters                           controllers.api.LabelClustersApiController.getLabelClustersV3(bbox: Option[String], labelType: Option[String], regionId: Option[Int], regionName: Option[String], includeRawLabels: Option[Boolean], clusterSize: Option[Int], avgImageCaptureDate: Option[String], avgLabelDate: Option[String], minSeverity: Option[Int], maxSeverity: Option[Int], filetype: Option[String], inline: Option[Boolean])
 GET     /v3/api/streets                                 controllers.api.StreetsApiController.getStreets(bbox: Option[String], regionId: Option[Int], regionName: Option[String], minLabelCount: Option[Int], minAuditCount: Option[Int], minUserCount: Option[Int], wayType: Option[String], filetype: Option[String], inline: Option[Boolean])
 GET     /v3/api/streetTypes                             controllers.api.StreetsApiController.getStreetTypes
+GET     /v3/api/regions                                 controllers.api.RegionApiController.getRegions(bbox: Option[String], regionId: Option[Int], regionName: Option[String], minLabelCount: Option[Int], filetype: Option[String], inline: Option[Boolean])
 GET     /v3/api/validations                             controllers.api.ValidationApiController.getValidations(labelId: Option[Int], userId: Option[String], validationResult: Option[Int], labelTypeId: Option[Int], validationTimestamp: Option[String], changedTags: Option[Boolean], changedSeverityLevels: Option[Boolean], filetype: Option[String], inline: Option[Boolean])
 GET     /v3/api/validationResultTypes                   controllers.api.ValidationApiController.getValidationResultTypes
 
@@ -194,6 +195,7 @@ GET     /v3/api-docs/rawLabels                          controllers.ApiDocsContr
 GET     /v3/api-docs/labelClusters                      controllers.ApiDocsController.labelClusters
 GET     /v3/api-docs/streets                            controllers.ApiDocsController.streets
 GET     /v3/api-docs/streetTypes                        controllers.ApiDocsController.streetTypes
+GET     /v3/api-docs/regions                            controllers.ApiDocsController.regions
 GET     /v3/api-docs/validations                        controllers.ApiDocsController.validations
 GET     /v3/api-docs/user-stats                         controllers.ApiDocsController.userStats
 GET     /v3/api-docs/overall-stats                      controllers.ApiDocsController.overallStats

--- a/public/javascripts/api-docs/regions-preview.js
+++ b/public/javascripts/api-docs/regions-preview.js
@@ -1,0 +1,291 @@
+/**
+ * Regions Map Preview Generator.
+ *
+ * Renders a single live choropleth map of all of a city's regions (neighborhoods), fed directly from the
+ * /v3/api/regions endpoint. A metric toggle recolors the same polygons by label count, completed-audit count, or
+ * contributing-user count. Hover/click a region to see its full statistics.
+ *
+ * @requires A DOM element with id 'regions-preview'
+ * @requires Leaflet.js library
+ */
+
+(function() {
+    // Configuration options - can be overridden by calling setup().
+    let config = {
+        apiBaseUrl: "/v3/api",
+        mainContainerId: "regions-preview",
+        regionsEndpoint: "/regions",
+        mapHeight: 500
+    };
+
+    // The metrics that can be visualized, keyed by the GeoJSON property name. Each defines the color ramp endpoints
+    // (dark-background optimized), a "none" color for regions with a value of zero, and human-readable labels.
+    const METRICS = {
+        label_count: {
+            label: "Label count", legendTitle: "Labels per region",
+            none: "#3d3d3d", low: "#440154", high: "#f0f921"
+        },
+        audit_count: {
+            label: "Audit count", legendTitle: "Completed audits per region",
+            none: "#3d3d3d", low: "#0d3b2e", high: "#44ff88"
+        },
+        user_count: {
+            label: "User count", legendTitle: "Contributors per region",
+            none: "#3d3d3d", low: "#472c7a", high: "#ffffff"
+        }
+    };
+
+    /**
+     * Interpolate between two hex colors.
+     * @param {string} color1 - First color in hex format
+     * @param {string} color2 - Second color in hex format
+     * @param {number} factor - Interpolation factor (0-1)
+     * @returns {string} Interpolated color in hex format
+     */
+    function interpolateColor(color1, color2, factor) {
+        const c1 = { r: parseInt(color1.slice(1, 3), 16), g: parseInt(color1.slice(3, 5), 16), b: parseInt(color1.slice(5, 7), 16) };
+        const c2 = { r: parseInt(color2.slice(1, 3), 16), g: parseInt(color2.slice(3, 5), 16), b: parseInt(color2.slice(5, 7), 16) };
+        const r = Math.round(c1.r + (c2.r - c1.r) * factor);
+        const g = Math.round(c1.g + (c2.g - c1.g) * factor);
+        const b = Math.round(c1.b + (c2.b - c1.b) * factor);
+        return `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${b.toString(16).padStart(2, '0')}`;
+    }
+
+    window.RegionsPreview = {
+        // Internal state, populated during init().
+        _map: null,
+        _layer: null,
+        _legend: null,
+        _metric: "label_count",
+        _maxByMetric: {},
+
+        /**
+         * Configure the regions preview.
+         * @param {object} options - Configuration options
+         * @returns {object} The RegionsPreview object for chaining
+         */
+        setup: function(options) {
+            config = Object.assign(config, options);
+            return this;
+        },
+
+        /**
+         * Initialize the regions preview map.
+         * @returns {Promise} A promise that resolves when the preview is rendered
+         */
+        init: function() {
+            const container = document.getElementById(config.mainContainerId);
+            if (!container) {
+                console.error("Regions preview container element not found.");
+                return Promise.reject(new Error("Regions preview container element not found"));
+            }
+
+            container.style.height = `${config.mapHeight}px`;
+            const loading = document.createElement('div');
+            loading.className = 'loading-message';
+            loading.textContent = "Loading region data...";
+            container.appendChild(loading);
+
+            return this.fetchRegions()
+                .then(regions => {
+                    container.innerHTML = "";
+                    this.renderMap(container, regions);
+                })
+                .catch(error => {
+                    console.error("Error rendering regions preview:", error);
+                    container.innerHTML = "";
+                    const message = document.createElement('div');
+                    message.className = 'no-regions-message';
+                    message.textContent = "Unable to load region data for the preview.";
+                    container.appendChild(message);
+                });
+        },
+
+        /**
+         * Fetch all regions for the current city as a GeoJSON FeatureCollection.
+         * @returns {Promise} A promise that resolves with the GeoJSON FeatureCollection
+         */
+        fetchRegions: function() {
+            return fetch(`${config.apiBaseUrl}${config.regionsEndpoint}?inline=true`)
+                .then(response => {
+                    if (!response.ok) {
+                        throw new Error(`HTTP error! Status: ${response.status}`);
+                    }
+                    return response.json();
+                });
+        },
+
+        /**
+         * Build the Leaflet map, draw the region polygons, and wire up the metric toggle and legend.
+         * @param {HTMLElement} container - Container element for the map
+         * @param {object} regions - GeoJSON FeatureCollection of regions
+         */
+        renderMap: function(container, regions) {
+            const features = regions.features || [];
+
+            // Precompute the maximum value of each metric across all regions, used to scale the color ramp.
+            Object.keys(METRICS).forEach(metric => {
+                this._maxByMetric[metric] = features.reduce((max, f) => Math.max(max, f.properties[metric] || 0), 0);
+            });
+
+            // Build the toolbar (with the metric selector) above the map. Keeping it out of the map means region
+            // popups can never render behind it.
+            const toolbar = document.createElement('div');
+            toolbar.className = 'regions-toolbar';
+            const optionsHtml = Object.keys(METRICS)
+                .map(metric => `<option value="${metric}">${METRICS[metric].label}</option>`)
+                .join('');
+            toolbar.innerHTML = `<label for="region-metric-select">Color by</label>
+                <select id="region-metric-select">${optionsHtml}</select>`;
+            container.appendChild(toolbar);
+
+            const mapElement = document.createElement('div');
+            mapElement.id = 'regions-map';
+            container.appendChild(mapElement);
+
+            const map = L.map('regions-map', { scrollWheelZoom: false });
+            this._map = map;
+
+            // CartoDB Dark Matter tiles, matching the other API doc previews.
+            L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
+                attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
+                subdomains: 'abcd',
+                maxZoom: 19
+            }).addTo(map);
+
+            if (features.length === 0) {
+                map.setView([0, 0], 2);
+                this.addNoRegionsMessage(map);
+                return;
+            }
+
+            this._layer = L.geoJSON(regions, {
+                style: (feature) => this.styleForFeature(feature),
+                onEachFeature: (feature, layer) => this.bindRegionInteractions(feature, layer)
+            }).addTo(map);
+
+            map.fitBounds(this._layer.getBounds(), { padding: [10, 10] });
+
+            // Region counter badge.
+            const countDiv = document.createElement('div');
+            countDiv.className = 'counter-badge';
+            countDiv.textContent = `${features.length} region${features.length === 1 ? '' : 's'}`;
+            map.getContainer().appendChild(countDiv);
+
+            // Wire the metric selector to recolor the regions and update the legend.
+            const select = document.getElementById('region-metric-select');
+            select.value = this._metric;
+            select.addEventListener('change', (event) => {
+                this._metric = event.target.value;
+                this._layer.setStyle((feature) => this.styleForFeature(feature));
+                this.updateLegend();
+            });
+
+            this.updateLegend();
+        },
+
+        /**
+         * Compute the Leaflet style for a region feature based on the currently selected metric.
+         * @param {object} feature - GeoJSON feature for a region
+         * @returns {object} A Leaflet path style object
+         */
+        styleForFeature: function(feature) {
+            const metricCfg = METRICS[this._metric];
+            const value = feature.properties[this._metric] || 0;
+            const max = this._maxByMetric[this._metric];
+            let fillColor;
+            if (value <= 0) {
+                fillColor = metricCfg.none;
+            } else if (max <= 0) {
+                fillColor = metricCfg.low;
+            } else {
+                fillColor = interpolateColor(metricCfg.low, metricCfg.high, value / max);
+            }
+            return { color: "#ffffff", weight: 1, opacity: 0.7, fillColor: fillColor, fillOpacity: 0.7 };
+        },
+
+        /**
+         * Attach the popup and hover behavior for a single region.
+         * @param {object} feature - GeoJSON feature for a region
+         * @param {object} layer - The Leaflet layer for the feature
+         */
+        bindRegionInteractions: function(feature, layer) {
+            const props = feature.properties;
+            const firstLabelDate = props.first_label_date ? new Date(props.first_label_date).toLocaleDateString() : "No labels";
+            const lastLabelDate = props.last_label_date ? new Date(props.last_label_date).toLocaleDateString() : "No labels";
+
+            layer.bindPopup(`
+                <div class="region-popup">
+                    <h4>${props.name || 'Region ' + props.region_id}</h4>
+                    <p><strong>Region ID:</strong> ${props.region_id}</p>
+                    <p><strong>Labels:</strong> ${props.label_count}</p>
+                    <p><strong>Streets:</strong> ${props.street_count}</p>
+                    <p><strong>Contributors:</strong> ${props.user_count}</p>
+                    <p><strong>Completed audits:</strong> ${props.audit_count}</p>
+                    <p><strong>First Label:</strong> ${firstLabelDate}</p>
+                    <p><strong>Last Label:</strong> ${lastLabelDate}</p>
+                    <a href="/labelmap?regions=${props.region_id}" class="explore-region-btn" target="_blank">
+                        View region on the label map
+                    </a>
+                </div>
+            `, {
+                // Pad the auto-pan so an opened popup is nudged clear of the bottom-right legend.
+                autoPanPaddingTopLeft: L.point(10, 10),
+                autoPanPaddingBottomRight: L.point(260, 130)
+            });
+
+            layer.on('mouseover', function() {
+                this.setStyle({ weight: 3, opacity: 1, fillOpacity: 0.85 });
+                this.bringToFront();
+            });
+            layer.on('mouseout', () => this._layer.resetStyle(layer));
+        },
+
+        /**
+         * (Re)build the continuous gradient legend for the currently selected metric.
+         */
+        updateLegend: function() {
+            const map = this._map;
+            const metricCfg = METRICS[this._metric];
+            const max = this._maxByMetric[this._metric];
+
+            if (this._legend) {
+                map.removeControl(this._legend);
+            }
+
+            const legend = L.control({ position: 'bottomright' });
+            legend.onAdd = function() {
+                const div = L.DomUtil.create('div', 'info legend continuous-legend');
+                div.innerHTML = `<h4>${metricCfg.legendTitle}</h4>`;
+
+                const gradientContainer = L.DomUtil.create('div', 'gradient-container', div);
+                gradientContainer.style.cssText = "width: 200px; height: 20px; position: relative; margin: 5px 0;";
+                const gradientBar = L.DomUtil.create('div', 'gradient-bar', gradientContainer);
+                gradientBar.style.cssText =
+                    `width: 100%; height: 100%; background: linear-gradient(to right, ${metricCfg.low}, ${metricCfg.high});`;
+
+                const labelsContainer = L.DomUtil.create('div', 'legend-labels', div);
+                labelsContainer.style.cssText = "display: flex; justify-content: space-between; width: 200px;";
+                const minTick = L.DomUtil.create('div', 'legend-tick', labelsContainer);
+                minTick.textContent = "0";
+                const maxTick = L.DomUtil.create('div', 'legend-tick', labelsContainer);
+                maxTick.textContent = max.toLocaleString();
+
+                return div;
+            };
+            legend.addTo(map);
+            this._legend = legend;
+        },
+
+        /**
+         * Show a message when there are no regions to display.
+         * @param {object} map - The Leaflet map object
+         */
+        addNoRegionsMessage: function(map) {
+            const div = document.createElement('div');
+            div.className = 'no-regions-message';
+            div.textContent = "No regions found for this city.";
+            map.getContainer().appendChild(div);
+        }
+    };
+})();

--- a/public/stylesheets/api-docs/regions.css
+++ b/public/stylesheets/api-docs/regions.css
@@ -1,0 +1,231 @@
+/**
+ * Regions API Documentation - Specific Styles.
+ *
+ * This stylesheet contains styles specific to the Regions API documentation page, including the choropleth map preview
+ * and its metric toggle, legend, and popups.
+ */
+
+/* ==========================================================================
+   REGIONS API SPECIFIC STYLES
+   ========================================================================== */
+
+/* ---- Regions Preview Container ---- */
+
+#regions-preview {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    border: 1px solid var(--color-border-light, #e0e0e0);
+    border-radius: var(--border-radius, 4px);
+    background-color: white;
+    overflow: hidden;
+}
+
+/* The metric selector lives in a toolbar above the map (rather than as an on-map Leaflet control) so it can never be
+   overlapped by region popups: Leaflet control corners sit at z-index 1000 while the popup pane is trapped at 700
+   inside the transformed map pane, so on-map controls always cover popups. */
+.regions-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 12px;
+    border-bottom: 1px solid var(--color-border-light, #e0e0e0);
+    background-color: #fafafa;
+    font-family: var(--font-sans);
+    font-size: 13px;
+    color: #222;
+}
+
+.regions-toolbar label {
+    font-weight: 600;
+}
+
+.regions-toolbar select {
+    font-family: var(--font-sans);
+    font-size: 13px;
+    padding: 2px 4px;
+    border: 1px solid #ccc;
+    border-radius: 3px;
+}
+
+#regions-map {
+    flex: 1 1 auto;
+    min-height: 0;
+    width: 100%;
+}
+
+/* ---- Loading Message ---- */
+
+.loading-message {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    color: #666;
+    font-style: italic;
+    background-color: #f8f9fa;
+}
+
+.loading-message::before {
+    content: '';
+    width: 20px;
+    height: 20px;
+    border: 2px solid #e0e0e0;
+    border-top: 2px solid var(--color-accent-link, #007bff);
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+    margin-right: 10px;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}
+
+/* ---- Counter Badge ---- */
+
+.counter-badge {
+    position: absolute;
+    bottom: 10px;
+    left: 10px;
+    right: auto; /* Override the shared api-docs.css rule's `right`, which would otherwise stretch the badge full width. */
+    background-color: white;
+    padding: 5px 10px;
+    border-radius: 4px;
+    box-shadow: 0 1px 5px rgba(0,0,0,0.4);
+    font-size: 12px;
+    font-weight: 500;
+    color: #222;
+    z-index: 1000;
+}
+
+/* ---- Continuous Legend ---- */
+
+.continuous-legend {
+    background-color: white;
+    padding: 8px 10px;
+    border-radius: 4px;
+    box-shadow: 0 1px 5px rgba(0,0,0,0.4);
+    line-height: 1.4;
+    color: #555;
+    font-family: var(--font-sans);
+    max-width: 250px;
+}
+
+.continuous-legend h4 {
+    margin: 0 0 8px;
+    font-size: 14px;
+    font-weight: 600;
+    color: #222;
+}
+
+.gradient-container {
+    border: 1px solid #ccc;
+    border-radius: 3px;
+    overflow: hidden;
+}
+
+.legend-tick {
+    font-size: 10px;
+    color: #666;
+    font-weight: 500;
+}
+
+/* ---- Region Popup ---- */
+
+.region-popup {
+    font-family: var(--font-sans);
+    max-width: 250px;
+    line-height: 1.4;
+}
+
+.region-popup h4 {
+    margin: 0 0 8px 0;
+    font-size: 16px;
+    font-weight: 600;
+    color: #222;
+    border-bottom: 1px solid #e0e0e0;
+    padding-bottom: 4px;
+}
+
+.region-popup p {
+    margin: 4px 0;
+    font-size: 13px;
+    color: #555;
+}
+
+.region-popup strong {
+    color: #222;
+    font-weight: 500;
+}
+
+/* ---- View Region Button ---- */
+
+.explore-region-btn {
+    display: inline-block;
+    margin-top: 8px;
+    padding: 6px 12px;
+    background-color: var(--color-accent-link, #007bff);
+    color: white !important;
+    text-decoration: none;
+    border-radius: 4px;
+    font-size: 12px;
+    font-weight: 500;
+    text-align: center;
+    border: 1px solid var(--color-accent-link, #007bff);
+    transition: background-color 0.2s ease;
+}
+
+.explore-region-btn:hover {
+    background-color: #0056b3;
+    border-color: #0056b3;
+    text-decoration: none;
+}
+
+.explore-region-btn:focus {
+    outline: 2px solid rgba(0, 123, 255, 0.5);
+    outline-offset: 2px;
+}
+
+/* ---- No Regions Message ---- */
+
+.no-regions-message {
+    position: absolute;
+    top: 10px;
+    left: 50%;
+    transform: translateX(-50%);
+    background-color: white;
+    padding: 8px 12px;
+    border-radius: 4px;
+    box-shadow: 0 1px 5px rgba(0,0,0,0.4);
+    font-size: 14px;
+    color: #666;
+    z-index: 1000;
+    white-space: nowrap;
+}
+
+/* ---- Responsive Adjustments ---- */
+
+@media (max-width: 768px) {
+    .continuous-legend {
+        max-width: 180px;
+        padding: 6px 8px;
+    }
+
+    .gradient-container,
+    .legend-labels {
+        width: 160px !important;
+    }
+
+    .continuous-legend h4 {
+        font-size: 13px;
+    }
+
+    .legend-tick {
+        font-size: 9px;
+    }
+
+    .region-popup {
+        max-width: 200px;
+    }
+}

--- a/test/controllers/api/PublicApiSpec.scala
+++ b/test/controllers/api/PublicApiSpec.scala
@@ -52,6 +52,38 @@ class PublicApiSpec extends PlaySpec with GuiceOneAppPerSuite {
     }
   }
 
+  "GET /v3/api/regions" should {
+    "return 200 GeoJSON FeatureCollection by default" in {
+      val resp = route(app, FakeRequest(GET, "/v3/api/regions")).get
+      status(resp) mustBe OK
+      contentType(resp) mustBe Some("application/json")
+
+      val json = contentAsJson(resp)
+      (json \ "type").as[String] mustBe "FeatureCollection"
+      (json \ "features").asOpt[Seq[JsObject]] mustBe defined
+    }
+
+    "return CSV with the documented header when filetype=csv" in {
+      val resp = route(app, FakeRequest(GET, "/v3/api/regions?filetype=csv")).get
+      status(resp) mustBe OK
+      contentAsString(resp) must include(
+        "region_id,name,label_count,street_count,user_count,audit_count,first_label_date,last_label_date,center_point"
+      )
+    }
+
+    "return 400 for a malformed bbox" in {
+      val resp = route(app, FakeRequest(GET, "/v3/api/regions?bbox=not-a-bbox")).get
+      status(resp) mustBe BAD_REQUEST
+      (contentAsJson(resp) \ "parameter").as[String] mustBe "bbox"
+    }
+
+    "return 400 for a non-positive regionId" in {
+      val resp = route(app, FakeRequest(GET, "/v3/api/regions?regionId=0")).get
+      status(resp) mustBe BAD_REQUEST
+      (contentAsJson(resp) \ "parameter").as[String] mustBe "regionId"
+    }
+  }
+
   "GET /v3/api/cities" should {
     "return 200 JSON" in {
       val resp = route(app, FakeRequest(GET, "/v3/api/cities")).get


### PR DESCRIPTION
Closes #4017.

Adds a public `GET /v3/api/regions` endpoint, analogous to `/v3/api/streets`, returning per-neighborhood (region) info with polygon geometry. Based on the existing internal `/neighborhoods` endpoint, given a public name plus filters and richer output fields.

## Endpoint
`GET /v3/api/regions?bbox=&regionId=&regionName=&minLabelCount=&filetype=&inline=`

Each region returns its MultiPolygon boundary plus:
`region_id`, `name`, `label_count`, `street_count`, `user_count`, `audit_count`, `first_label_date`, `last_label_date`.

- **Formats:** GeoJSON (default), CSV (geometry simplified to a center point), Shapefile, GeoPackage.
- **Filters:** `bbox`, `regionId`, `regionName`, `minLabelCount`, with the same `bbox` > `regionId` > `regionName` precedence as `/v3/api/streets`; `400` for a malformed `bbox` or non-positive `regionId`.
- The label/street/audit aggregates consistently exclude deleted + tutorial streets and excluded users.

## Docs + preview
- New API docs page at `/v3/api-docs/regions` (added to the sidebar under Data APIs), mirroring the Streets page.
- A live choropleth preview of the city's regions fed from the API, with a **"Color by"** toolbar dropdown (label / audit / user count), a gradient legend, and per-region popups. The selector sits in a toolbar above the map (not an on-map Leaflet control) so popups can't render behind it.

## Files
- `models/api/RegionsApiModels.scala` (new) — `RegionDataForApi` (`StreamingApiType`) + `RegionFiltersForApi`.
- `models/region/RegionTable.scala` — `getRegionsForApi` streaming raw-SQL builder.
- `service/ApiService.scala` — `getRegions`.
- `controllers/api/RegionApiController.scala` — `getRegions` action (all four formats).
- `controllers/helper/ShapefilesCreatorHelper.scala` — `createRegionDataShapefile` / `createRegionDataGeopackage`.
- `conf/routes`, `ApiDocsController.regions`, `apiDocs/_sidebar`, new `apiDocs/regions.scala.html`.
- `public/javascripts/api-docs/regions-preview.js`, `public/stylesheets/api-docs/regions.css`.
- `test/controllers/api/PublicApiSpec.scala` — 4 contract cases (GeoJSON shape, CSV header, two `400` paths).

## Verification
- `sbt --client compile` clean (warning-clean under `-Xfatal-warnings`).
- `PublicApiSpec` 7/7 green against the dev PostGIS DB; the advisory `backend-tests` CI job will exercise it.
- Manually exercised against live Teaneck data: all four formats (valid Zip + valid OGC GeoPackage), each filter, and both `400` error paths; docs page and interactive preview verified in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)