### PR TITLE
Adds a /cropImage/:labelType/:labelId/metadata endpoint

### DIFF
--- a/app/controllers/ImageController.scala
+++ b/app/controllers/ImageController.scala
@@ -3,9 +3,9 @@ package controllers
 import controllers.base._
 import formats.json.LabelFormats
 import models.label.LabelTypeEnum
-import play.api.{Configuration, Logger}
 import play.api.libs.json._
 import play.api.mvc.{AnyContent, Request, RequestHeader}
+import play.api.{Configuration, Logger}
 import service.ImageSigningService
 
 import java.awt.Image
@@ -165,6 +165,26 @@ class ImageController @Inject() (
           case None =>
             Future.successful(NotFound(s"Pano image not found: $panoId"))
         }
+    }
+  }
+
+  /**
+   * Returns the crop image metadata (a signed serving URL) for a label as JSON, used to lazily fetch a  /cropImage URL.
+   */
+  def getCropImageMetadata(labelType: String, labelId: Int) = cc.securityService.SecuredAction { implicit request =>
+    if (!refererAllowed(request)) {
+      Future.successful(Forbidden("Request origin not allowed."))
+    } else if (!LabelTypeEnum.validLabelTypes.contains(labelType)) {
+      Future.successful(
+        BadRequest(
+          s"Invalid label type provided: $labelType. Valid label types are: ${LabelTypeEnum.validLabelTypes.mkString(", ")}."
+        )
+      )
+    } else {
+      panoDataService.cropUrl(labelId, LabelTypeEnum.byName(labelType)) match {
+        case Some(url) => Future.successful(Ok(LabelFormats.cropImagePayload(labelId, labelType, url)))
+        case None      => Future.successful(NotFound(s"No crop image found for label: $labelId"))
+      }
     }
   }
 

--- a/app/formats/json/LabelFormats.scala
+++ b/app/formats/json/LabelFormats.scala
@@ -266,6 +266,20 @@ object LabelFormats {
     )
   }
 
+  /**
+   * Builds the JSON payload for the /cropImage/:labelType/:labelId/metadata endpoint.
+   * @param labelId The label ID.
+   * @param labelType The label type name.
+   * @param url The signed serving URL (e.g. /cropImage/<labelType>/<labelId>?exp=...&sig=...).
+   */
+  def cropImagePayload(labelId: Int, labelType: String, url: String): JsObject = {
+    Json.obj(
+      "labelId"   -> labelId,
+      "labelType" -> labelType,
+      "imageUrl"  -> url
+    )
+  }
+
   def resumeLabelMetadatatoJson(label: ResumeLabelMetadata, allTags: Seq[Tag]): JsObject = {
     Json.obj(
       "labelId"     -> label.labelData.labelId,

--- a/conf/routes
+++ b/conf/routes
@@ -163,6 +163,7 @@ POST    /saveRoute                                      controllers.RouteBuilder
 
 # Images
 POST    /saveImage                                      controllers.ImageController.saveImage
+GET     /cropImage/:labelType/:labelId/metadata         controllers.ImageController.getCropImageMetadata(labelType: String, labelId: Int)
 GET     /cropImage/:labelType/:labelId                  controllers.ImageController.serveCropImage(labelType: String, labelId: Int)
 GET     /backupImage/:panoId/metadata                   controllers.ImageController.getBackupImageMetadata(panoId: String)
 GET     /backupImage/:panoId                            controllers.ImageController.serveBackupImage(panoId: String)

--- a/public/javascripts/Admin/src/Admin.CommentPopup.js
+++ b/public/javascripts/Admin/src/Admin.CommentPopup.js
@@ -76,14 +76,22 @@ async function AdminCommentPopup(admin, viewerType, viewerAccessToken) {
             return;
         }
 
-        await self.panoManager.setPano(panoId, pov);
-
+        // Fetch the label's metadata first (when there is one) so its crop/backup-image fallbacks are available to
+        // setPano() from the start, instead of arriving only after the popup has already given up on live imagery.
+        let labelMetadata = null;
         if (labelId) {
             const adminLabelUrl = admin ? '/adminapi/label/id/' + labelId : '/label/id/' + labelId;
-            $.getJSON(adminLabelUrl, function (data) {
-                setLabel(data);
-            });
-         }
+            const response = await fetch(adminLabelUrl);
+            if (response.ok) labelMetadata = await response.json();
+        }
+
+        if (labelMetadata) {
+            const backupImage = buildBackupImageData(labelMetadata);
+            await self.panoManager.setPano(panoId, pov, labelMetadata.crop_url, labelMetadata.expired, backupImage);
+            setLabel(labelMetadata);
+        } else {
+            await self.panoManager.setPano(panoId, pov);
+        }
     }
 
     function setLabel(labelMetadata) {


### PR DESCRIPTION
Resolves #4226

Adds a /cropImage/:labelType/:labelId/metadata endpoint, mirroring the one for /backupImage.