### PR TITLE
Replace validation_options table with a validation_option enum type

### DIFF
--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -8,7 +8,6 @@ import formats.json.LabelFormats._
 import formats.json.UserFormats._
 import models.auth.{DefaultEnv, WithAdmin}
 import models.user.{RoleTable, SidewalkUserWithRole}
-import models.validation.LabelValidationTable
 import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.dispatch.Dispatcher
 import play.api.cache.AsyncCacheApi
@@ -191,7 +190,7 @@ class AdminController @Inject() (
                 "severity"          -> label.severity,
                 "correct"           -> label.correct,
                 "has_validations"   -> label.hasValidations,
-                "ai_validation"     -> label.aiValidation.map(LabelValidationTable.validationOptions.get),
+                "ai_validation"     -> label.aiValidation.map(_.toString),
                 "expired"           -> label.expired,
                 "has_backup"        -> label.hasBackup,
                 "high_quality_user" -> label.highQualityUser,

--- a/app/controllers/api/ValidationApiController.scala
+++ b/app/controllers/api/ValidationApiController.scala
@@ -2,6 +2,7 @@ package controllers.api
 
 import controllers.base.CustomControllerComponents
 import models.api.{ApiError, ValidationDataForApi, ValidationFiltersForApi}
+import models.validation.ValidationOption
 import org.apache.pekko.stream.scaladsl.Source
 import play.api.i18n.Lang.logger
 import play.api.libs.json.Json
@@ -39,7 +40,7 @@ class ValidationApiController @Inject() (
    *
    * @param labelId Optional label ID to filter by specific label
    * @param userId Optional user ID to filter by specific validator
-   * @param validationResult Optional validation result (1=Agree, 2=Disagree, 3=Unsure)
+   * @param validationResult Optional validation result (Agree, Disagree, or Unsure)
    * @param labelTypeId Optional label type ID to filter by type of validated label
    * @param validationTimestamp Optional ISO 8601 timestamp to filter validations after this time
    * @param changedTags Optional boolean to filter validations where tags were changed (true) or not changed (false)
@@ -50,7 +51,7 @@ class ValidationApiController @Inject() (
   def getValidations(
       labelId: Option[Int],
       userId: Option[String],
-      validationResult: Option[Int],
+      validationResult: Option[String],
       labelTypeId: Option[Int],
       validationTimestamp: Option[String],
       changedTags: Option[Boolean],
@@ -63,19 +64,22 @@ class ValidationApiController @Inject() (
       // Parse timestamp if provided.
       val parsedTimestamp: Option[OffsetDateTime] = parseDateTimeString(validationTimestamp)
 
+      // Parse the validation result string into the enum (None if absent or invalid; invalid is rejected below).
+      val parsedValidationResult: Option[ValidationOption.Value] = validationResult.flatMap(ValidationOption.fromString)
+
       // Create filters object.
       val filters = ValidationFiltersForApi(
-        labelId = labelId, userId = userId, validationResult = validationResult, labelTypeId = labelTypeId,
+        labelId = labelId, userId = userId, validationResult = parsedValidationResult, labelTypeId = labelTypeId,
         validationTimestamp = parsedTimestamp, changedTags = changedTags, changedSeverityLevels = changedSeverityLevels
       )
 
       // Handle error cases for invalid parameters.
-      if (validationResult.isDefined && !Seq(1, 2, 3).contains(validationResult.get)) {
+      if (validationResult.isDefined && parsedValidationResult.isEmpty) {
         Future.successful(
           BadRequest(
             Json.toJson(
               ApiError.invalidParameter(
-                "Invalid validationResult value. Must be 1 (Agree), 2 (Disagree), or 3 (Unsure).",
+                "Invalid validationResult value. Must be Agree, Disagree, or Unsure.",
                 "validationResult"
               )
             )
@@ -135,7 +139,6 @@ class ValidationApiController @Inject() (
    * Returns information about validation result types (Agree, Disagree, Unsure).
    *
    * This endpoint provides details about each validation result type including:
-   * - ID (1, 2, 3)
    * - Name (Agree, Disagree, Unsure)
    * - Count (number of validations of this type)
    *

--- a/app/formats/json/AdminFormats.scala
+++ b/app/formats/json/AdminFormats.scala
@@ -4,7 +4,7 @@ import models.audit.{AuditedStreetWithTimestamp, ContributionTimeStat, GenericCo
 import models.label.LabelCount
 import models.user.UserCount
 import models.utils.MyPostgresProfile.api._
-import models.validation.ValidationCount
+import models.validation.{ValidationCount, ValidationOption}
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 import service.TimeInterval.TimeInterval
@@ -80,7 +80,8 @@ object AdminFormats {
     (__ \ "count").write[Int] and
       (__ \ "time_interval").write[TimeInterval] and
       (__ \ "label_type").write[String] and
-      (__ \ "result").write[String] and
+      // None represents the "All" results subtotal.
+      (__ \ "result").write[String].contramap[Option[ValidationOption.Value]](_.map(_.toString).getOrElse("All")) and
       (__ \ "validator").write[String]
   )(unlift(ValidationCount.unapply))
 

--- a/app/formats/json/LabelFormats.scala
+++ b/app/formats/json/LabelFormats.scala
@@ -2,7 +2,6 @@ package formats.json
 
 import models.label._
 import models.pano.{PanoData, PanoViewerMetadata}
-import models.validation.LabelValidationTable
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 
@@ -82,8 +81,8 @@ object LabelFormats {
       "label_type"                         -> m.labelType,
       "severity"                           -> m.severity,
       "description"                        -> m.description,
-      "user_validation"                    -> m.userValidation,
-      "ai_validation"                      -> m.aiValidation,
+      "user_validation"                    -> m.userValidation.map(_.toString),
+      "ai_validation"                      -> m.aiValidation.map(_.toString),
       "validations"                        -> m.validations,
       "tags"                               -> m.tags,
       "low_quality_incomplete_stale_flags" -> m.lowQualityIncompleteStaleFlags,
@@ -101,32 +100,32 @@ object LabelFormats {
       adminData: Option[AdminValidationData] = None
   ): JsObject = {
     Json.obj(
-      "label_id"           -> labelMetadata.labelId,
-      "label_type"         -> labelMetadata.labelType.name,
-      "pano_id"            -> labelMetadata.panoId,
-      "image_capture_date" -> labelMetadata.imageCaptureDate,
-      "label_timestamp"    -> labelMetadata.timestamp,
-      "lat"                -> labelMetadata.location.lat,
-      "lng"                -> labelMetadata.location.lng,
-      "camera_lat"         -> labelMetadata.cameraLocation.map(_.lat),
-      "camera_lng"         -> labelMetadata.cameraLocation.map(_.lng),
-      "heading"            -> labelMetadata.pov.heading,
-      "pitch"              -> labelMetadata.pov.pitch,
-      "zoom"               -> labelMetadata.pov.zoom,
-      "canvas_x"           -> labelMetadata.canvasXY.x,
-      "canvas_y"           -> labelMetadata.canvasXY.y,
-      "severity"           -> labelMetadata.severity,
-      "description"        -> labelMetadata.description,
-      "street_edge_id"     -> labelMetadata.streetEdgeId,
-      "region_id"          -> labelMetadata.regionId,
-      "correct"            -> labelMetadata.validationInfo.correct,
-      "agree_count"        -> labelMetadata.validationInfo.agreeCount,
-      "disagree_count"     -> labelMetadata.validationInfo.disagreeCount,
-      "unsure_count"       -> labelMetadata.validationInfo.unsureCount,
-      "user_validation" -> labelMetadata.validationInfo.userValidation.map(LabelValidationTable.validationOptions.get),
-      "ai_validation"   -> labelMetadata.validationInfo.aiValidation.map(LabelValidationTable.validationOptions.get),
-      "tags"            -> labelMetadata.tags,
-      "ai_tags"         -> labelMetadata.aiTags,
+      "label_id"            -> labelMetadata.labelId,
+      "label_type"          -> labelMetadata.labelType.name,
+      "pano_id"             -> labelMetadata.panoId,
+      "image_capture_date"  -> labelMetadata.imageCaptureDate,
+      "label_timestamp"     -> labelMetadata.timestamp,
+      "lat"                 -> labelMetadata.location.lat,
+      "lng"                 -> labelMetadata.location.lng,
+      "camera_lat"          -> labelMetadata.cameraLocation.map(_.lat),
+      "camera_lng"          -> labelMetadata.cameraLocation.map(_.lng),
+      "heading"             -> labelMetadata.pov.heading,
+      "pitch"               -> labelMetadata.pov.pitch,
+      "zoom"                -> labelMetadata.pov.zoom,
+      "canvas_x"            -> labelMetadata.canvasXY.x,
+      "canvas_y"            -> labelMetadata.canvasXY.y,
+      "severity"            -> labelMetadata.severity,
+      "description"         -> labelMetadata.description,
+      "street_edge_id"      -> labelMetadata.streetEdgeId,
+      "region_id"           -> labelMetadata.regionId,
+      "correct"             -> labelMetadata.validationInfo.correct,
+      "agree_count"         -> labelMetadata.validationInfo.agreeCount,
+      "disagree_count"      -> labelMetadata.validationInfo.disagreeCount,
+      "unsure_count"        -> labelMetadata.validationInfo.unsureCount,
+      "user_validation"     -> labelMetadata.validationInfo.userValidation.map(_.toString),
+      "ai_validation"       -> labelMetadata.validationInfo.aiValidation.map(_.toString),
+      "tags"                -> labelMetadata.tags,
+      "ai_tags"             -> labelMetadata.aiTags,
       "ai_tags_not_present" -> labelMetadata.aiTagsNotPresent,
       "ai_generated"        -> labelMetadata.aiGenerated,
       "expired"             -> labelMetadata.expired,
@@ -140,7 +139,7 @@ object LabelFormats {
           "previous_validations" -> ad.previousValidations.map(prevVal =>
             Json.obj(
               "username"   -> prevVal._1,
-              "validation" -> LabelValidationTable.validationOptions.get(prevVal._2)
+              "validation" -> prevVal._2.toString
             )
           )
         )
@@ -168,8 +167,8 @@ object LabelFormats {
       "label_type"         -> labelMetadata.labelType.name,
       "severity"           -> labelMetadata.severity,
       "description"        -> labelMetadata.description,
-      "user_validation"    -> labelMetadata.userValidation.map(LabelValidationTable.validationOptions.get),
-      "ai_validation"      -> labelMetadata.aiValidation.map(LabelValidationTable.validationOptions.get),
+      "user_validation"    -> labelMetadata.userValidation.map(_.toString),
+      "ai_validation"      -> labelMetadata.aiValidation.map(_.toString),
       "num_agree"          -> labelMetadata.validations("agree"),
       "num_disagree"       -> labelMetadata.validations("disagree"),
       "num_unsure"         -> labelMetadata.validations("unsure"),
@@ -201,7 +200,7 @@ object LabelFormats {
         "previous_validations" -> adminData.previousValidations.map(prevVal =>
           Json.obj(
             "username"   -> prevVal._1,
-            "validation" -> LabelValidationTable.validationOptions.get(prevVal._2)
+            "validation" -> prevVal._2.toString
           )
         )
       )

--- a/app/formats/json/ValidateFormats.scala
+++ b/app/formats/json/ValidateFormats.scala
@@ -8,6 +8,7 @@ import models.label.LabelTypeEnum
 import models.utils.CommonUtils.UiSource.UiSource
 import models.utils.CommonUtils.ViewerType.ViewerType
 import models.utils.CommonUtils.{UiSource, ViewerType}
+import models.validation.ValidationOption
 import play.api.libs.functional.syntax._
 import play.api.libs.json.{JsError, JsPath, JsSuccess, Reads}
 
@@ -44,7 +45,7 @@ object ValidateFormats {
   case class LabelValidationSubmission(
       labelId: Int,
       missionId: Int,
-      validationResult: Int,
+      validationResult: ValidationOption.Value,
       oldSeverity: Option[Int],
       newSeverity: Option[Int],
       oldTags: List[String],
@@ -87,7 +88,7 @@ object ValidateFormats {
   case class LabelMapValidationSubmission(
       labelId: Int,
       labelType: LabelTypeEnum.Base,
-      validationResult: Int,
+      validationResult: ValidationOption.Value,
       oldSeverity: Option[Int],
       newSeverity: Option[Int],
       oldTags: List[String],
@@ -127,6 +128,19 @@ object ValidateFormats {
     }
   }
 
+  implicit val validationOptionReads: Reads[ValidationOption.Value] = Reads { json =>
+    json.validate[String].flatMap { validationResult =>
+      ValidationOption.fromString(validationResult) match {
+        case Some(result) => JsSuccess(result)
+        case None         =>
+          JsError(
+            s"Invalid validation_result: $validationResult. Valid values are: " +
+              s"${ValidationOption.values.mkString(", ")}."
+          )
+      }
+    }
+  }
+
   implicit val environmentSubmissionReads: Reads[EnvironmentSubmission] = (
     (JsPath \ "mission_id").readNullable[Int] and
       (JsPath \ "browser").readNullable[String] and
@@ -158,7 +172,7 @@ object ValidateFormats {
   implicit val labelValidationSubmissionReads: Reads[LabelValidationSubmission] = (
     (JsPath \ "label_id").read[Int] and
       (JsPath \ "mission_id").read[Int] and
-      (JsPath \ "validation_result").read[Int] and
+      (JsPath \ "validation_result").read[ValidationOption.Value] and
       (JsPath \ "old_severity").readNullable[Int] and
       (JsPath \ "new_severity").readNullable[Int] and
       (JsPath \ "old_tags").read[List[String]] and
@@ -211,7 +225,7 @@ object ValidateFormats {
   implicit val labelMapValidationSubmissionReads: Reads[LabelMapValidationSubmission] = (
     (JsPath \ "label_id").read[Int] and
       (JsPath \ "label_type").read[LabelTypeEnum.Base] and
-      (JsPath \ "validation_result").read[Int] and
+      (JsPath \ "validation_result").read[ValidationOption.Value] and
       (JsPath \ "old_severity").readNullable[Int] and
       (JsPath \ "new_severity").readNullable[Int] and
       (JsPath \ "old_tags").read[List[String]] and

--- a/app/models/api/ValidationApiModels.scala
+++ b/app/models/api/ValidationApiModels.scala
@@ -9,6 +9,7 @@ import models.api.ApiModelUtils.escapeCsvField
 import models.computation.StreamingApiType
 import models.label.LocationXY
 import models.utils.CommonUtils.UiSource.UiSource
+import models.validation.ValidationOption
 import play.api.libs.json.{JsObject, Json, OFormat}
 
 import java.time.OffsetDateTime
@@ -18,7 +19,7 @@ import java.time.OffsetDateTime
  *
  * @param labelId Optional label ID to filter validations by the validated label
  * @param userId Optional user ID to filter validations by the user who performed the validation
- * @param validationResult Optional validation result to filter by (1 = Agree, 2 = Disagree, 3 = Unsure)
+ * @param validationResult Optional validation result to filter by (Agree, Disagree, or Unsure)
  * @param labelTypeId Optional label type ID to filter by the type of the validated label
  * @param validationTimestamp Optional timestamp to filter validations by when they occurred (using startTimestamp)
  * @param changedTags Optional boolean to filter validations where tags were changed (oldTags != newTags)
@@ -28,7 +29,7 @@ import java.time.OffsetDateTime
 case class ValidationFiltersForApi(
     labelId: Option[Int] = None,
     userId: Option[String] = None,
-    validationResult: Option[Int] = None,
+    validationResult: Option[ValidationOption.Value] = None,
     labelTypeId: Option[Int] = None,
     validationTimestamp: Option[OffsetDateTime] = None,
     changedTags: Option[Boolean] = None,
@@ -44,8 +45,7 @@ case class ValidationFiltersForApi(
  * @param labelId ID of the validated label
  * @param labelTypeId Type ID of the validated label
  * @param labelType String representation of the label type
- * @param validationResult Numeric result of validation (1 = Agree, 2 = Disagree, 3 = Unsure)
- * @param validationResultString String representation of the validation result
+ * @param validationResult Result of the validation (Agree, Disagree, or Unsure)
  * @param oldSeverity Previous severity assigned to the label
  * @param newSeverity New severity assigned during validation
  * @param oldTags Previous tags assigned to the label
@@ -68,8 +68,7 @@ case class ValidationDataForApi(
     labelId: Int,
     labelTypeId: Int,
     labelType: String,
-    validationResult: Int,
-    validationResultString: String,
+    validationResult: ValidationOption.Value,
     oldSeverity: Option[Int],
     newSeverity: Option[Int],
     oldTags: List[String],
@@ -96,29 +95,28 @@ case class ValidationDataForApi(
    */
   override def toJson: JsObject = {
     Json.obj(
-      "label_validation_id"      -> labelValidationId,
-      "label_id"                 -> labelId,
-      "label_type_id"            -> labelTypeId,
-      "label_type"               -> labelType,
-      "validation_result"        -> validationResult,
-      "validation_result_string" -> validationResultString,
-      "old_severity"             -> oldSeverity,
-      "new_severity"             -> newSeverity,
-      "old_tags"                 -> oldTags,
-      "new_tags"                 -> newTags,
-      "user_id"                  -> userId,
-      "validator_type"           -> validatorType,
-      "mission_id"               -> missionId,
-      "canvas_x"                 -> canvasXY.map(_.x),
-      "canvas_y"                 -> canvasXY.map(_.y),
-      "heading"                  -> heading,
-      "pitch"                    -> pitch,
-      "zoom"                     -> zoom,
-      "canvas_height"            -> canvasHeight,
-      "canvas_width"             -> canvasWidth,
-      "start_timestamp"          -> startTimestamp.toString,
-      "end_timestamp"            -> endTimestamp.toString,
-      "source"                   -> source
+      "label_validation_id" -> labelValidationId,
+      "label_id"            -> labelId,
+      "label_type_id"       -> labelTypeId,
+      "label_type"          -> labelType,
+      "validation_result"   -> validationResult,
+      "old_severity"        -> oldSeverity,
+      "new_severity"        -> newSeverity,
+      "old_tags"            -> oldTags,
+      "new_tags"            -> newTags,
+      "user_id"             -> userId,
+      "validator_type"      -> validatorType,
+      "mission_id"          -> missionId,
+      "canvas_x"            -> canvasXY.map(_.x),
+      "canvas_y"            -> canvasXY.map(_.y),
+      "heading"             -> heading,
+      "pitch"               -> pitch,
+      "zoom"                -> zoom,
+      "canvas_height"       -> canvasHeight,
+      "canvas_width"        -> canvasWidth,
+      "start_timestamp"     -> startTimestamp.toString,
+      "end_timestamp"       -> endTimestamp.toString,
+      "source"              -> source
     )
   }
 
@@ -137,7 +135,6 @@ case class ValidationDataForApi(
       labelTypeId.toString,
       escapeCsvField(labelType),
       validationResult.toString,
-      escapeCsvField(validationResultString),
       oldSeverity.map(_.toString).getOrElse(""),
       newSeverity.map(_.toString).getOrElse(""),
       escapeCsvField(oldTags.mkString("[", ",", "]")),
@@ -170,21 +167,19 @@ object ValidationDataForApi {
    * This should be included as the first line when generating CSV output.
    */
   val csvHeader: String = "label_validation_id,label_id,label_type_id,label_type,validation_result," +
-    "validation_result_string,old_severity,new_severity,old_tags,new_tags,user_id,validator_type,mission_id,canvas_x," +
-    "canvas_y,heading,pitch,zoom,canvas_height,canvas_width,start_timestamp,end_timestamp,source\n"
+    "old_severity,new_severity,old_tags,new_tags,user_id,validator_type,mission_id,canvas_x,canvas_y," +
+    "heading,pitch,zoom,canvas_height,canvas_width,start_timestamp,end_timestamp,source\n"
 }
 
 /**
  * Represents a validation result type for API responses.
  *
- * @param id The numeric identifier for the validation result (1-3)
  * @param name The string representation of the result ("Agree", "Disagree", "Unsure")
  * @param count Number of validations with this result in the database
  * @param countHuman Number of validations with this result performed by human users
  * @param countAi Number of validations with this result performed by AI
  */
 case class ValidationResultTypeForApi(
-    id: Int,
     name: String,
     count: Int,
     countHuman: Int,

--- a/app/models/label/LabelAiAssessmentTable.scala
+++ b/app/models/label/LabelAiAssessmentTable.scala
@@ -4,6 +4,7 @@ import com.google.inject.ImplementedBy
 import models.label.AiImageSource.AiImageSource
 import models.utils.MyPostgresProfile.api._
 import models.utils.{AiTagConfidence, MyPostgresProfile}
+import models.validation.ValidationOption
 import play.api.db.slick.{DatabaseConfigProvider, HasDatabaseConfigProvider}
 
 import java.time.OffsetDateTime
@@ -20,7 +21,7 @@ object AiImageSource extends Enumeration {
 case class LabelAiAssessment(
     labelAiAssessmentId: Int,
     labelId: Int,
-    validationResult: Int,
+    validationResult: ValidationOption.Value,
     validationAccuracy: Double,
     validationConfidence: Double,
     tags: Option[List[String]],
@@ -39,7 +40,7 @@ case class LabelAiAssessment(
 class LabelAiAssessmentTableDef(tag: Tag) extends Table[LabelAiAssessment](tag, "label_ai_assessment") {
   def labelAiAssessmentId: Rep[Int]                     = column[Int]("label_ai_assessment_id", O.PrimaryKey, O.AutoInc)
   def labelId: Rep[Int]                                 = column[Int]("label_id")
-  def validationResult: Rep[Int]                        = column[Int]("validation_result")
+  def validationResult: Rep[ValidationOption.Value]     = column[ValidationOption.Value]("validation_result")
   def validationAccuracy: Rep[Double]                   = column[Double]("validation_accuracy")
   def validationConfidence: Rep[Double]                 = column[Double]("validation_confidence")
   def tags: Rep[Option[List[String]]]                   = column[Option[List[String]]]("tags")

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -16,7 +16,7 @@ import models.street.{StreetEdgeRegionTableDef, StreetEdgeTable}
 import models.user._
 import models.utils.MyPostgresProfile.api._
 import models.utils.{ConfigTableDef, MyPostgresProfile}
-import models.validation.{LabelValidationTableDef, ValidationTaskCommentTableDef}
+import models.validation.{LabelValidationTableDef, ValidationOption, ValidationTaskCommentTableDef}
 import org.geotools.geometry.jts.JTSFactoryFinder
 import org.locationtech.jts.geom.GeometryFactory
 import play.api.db.slick.{DatabaseConfigProvider, HasDatabaseConfigProvider}
@@ -56,8 +56,8 @@ case class LabelValidationInfo(
     disagreeCount: Int,
     unsureCount: Int,
     correct: Option[Boolean],
-    userValidation: Option[Int],
-    aiValidation: Option[Int]
+    userValidation: Option[ValidationOption.Value],
+    aiValidation: Option[ValidationOption.Value]
 )
 case class POV(heading: Double, pitch: Double, zoom: Double)
 case class Dimensions(width: Int, height: Int)
@@ -84,7 +84,7 @@ case class LabelForLabelMap(
     lng: Double,
     correct: Option[Boolean],
     hasValidations: Boolean,
-    aiValidation: Option[Int],
+    aiValidation: Option[ValidationOption.Value],
     expired: Boolean,
     hasBackup: Boolean,
     highQualityUser: Boolean,
@@ -158,8 +158,8 @@ case class LabelMetadata(
     labelType: LabelTypeEnum.Base,
     severity: Option[Int],
     description: Option[String],
-    userValidation: Option[Int],
-    aiValidation: Option[Int],
+    userValidation: Option[ValidationOption.Value],
+    aiValidation: Option[ValidationOption.Value],
     validations: Map[String, Int],
     tags: List[String],
     lowQualityIncompleteStaleFlags: (Boolean, Boolean, Boolean),
@@ -174,7 +174,11 @@ case class LabelMetadata(
 case class LabelComment(username: String, comment: String)
 
 // Extra data to include with validations for Expert Validate. Includes usernames and previous validators.
-case class AdminValidationData(labelId: Int, username: String, previousValidations: Seq[(String, Int)])
+case class AdminValidationData(
+    labelId: Int,
+    username: String,
+    previousValidations: Seq[(String, ValidationOption.Value)]
+)
 
 case class ResumeLabelMetadata(
     labelData: Label,
@@ -359,27 +363,27 @@ object LabelTable {
   // Type aliases for the tuple representation of LabelValidationMetadata and queries for them.
   // TODO in Scala 3 I think that we can make these top-level like we do for the case class version.
   type LabelValidationMetadataTuple = (
-      Int,                                                        // 1.  labelId
-      String,                                                     // 2.  labelType
-      String,                                                     // 3.  panoId
-      PanoSource,                                                 // 4.  panoSource
-      Boolean,                                                    // 5.  expired
-      String,                                                     // 6.  imageCaptureDate
-      OffsetDateTime,                                             // 7.  timestamp
-      (Option[Double], Option[Double]),                           // 8.  location (lat, lng)
-      (Double, Double, Double),                                   // 9.  pov (heading, pitch, zoom)
-      (Int, Int),                                                 // 10. canvasXY (x, y)
-      Option[Int],                                                // 11. severity
-      Option[String],                                             // 12. description
-      (Int, Int),                                                 // 13. (streetEdgeId, regionId)
-      (Int, Int, Int, Option[Boolean], Option[Int], Option[Int]), // 14. validationInfo
-      List[String],                                               // 15. tags
-      (Option[Double], Option[Double]),                           // 16. cameraLocation (lat, lng)
-      Option[List[String]],                                       // 17. aiTags
-      Option[List[String]],                                       // 18. aiTagsNotPresent
-      Boolean,                                                    // 19. aiGenerated
-      Option[String],                                             // 20. comments (JSON-aggregated)
-      Boolean,                                                    // 21. fromCurrentUser
+      Int,                              // 1.  labelId
+      String,                           // 2.  labelType
+      String,                           // 3.  panoId
+      PanoSource,                       // 4.  panoSource
+      Boolean,                          // 5.  expired
+      String,                           // 6.  imageCaptureDate
+      OffsetDateTime,                   // 7.  timestamp
+      (Option[Double], Option[Double]), // 8.  location (lat, lng)
+      (Double, Double, Double),         // 9.  pov (heading, pitch, zoom)
+      (Int, Int),                       // 10. canvasXY (x, y)
+      Option[Int],                      // 11. severity
+      Option[String],                   // 12. description
+      (Int, Int),                       // 13. (streetEdgeId, regionId)
+      (Int, Int, Int, Option[Boolean], Option[ValidationOption.Value], Option[ValidationOption.Value]), // 14. validationInfo
+      List[String],                     // 15. tags
+      (Option[Double], Option[Double]), // 16. cameraLocation (lat, lng)
+      Option[List[String]],             // 17. aiTags
+      Option[List[String]],             // 18. aiTagsNotPresent
+      Boolean,                          // 19. aiGenerated
+      Option[String],                   // 20. comments (JSON-aggregated)
+      Boolean,                          // 21. fromCurrentUser
       (
           Option[Int],
           Option[Int],
@@ -405,8 +409,15 @@ object LabelTable {
       Rep[Option[Int]],                           // 11. severity
       Rep[Option[String]],                        // 12. description
       (Rep[Int], Rep[Int]),                       // 13. (streetEdgeId, regionId)
-      (Rep[Int], Rep[Int], Rep[Int], Rep[Option[Boolean]], Rep[Option[Int]], Rep[Option[Int]]), // 14. validationInfo
-      Rep[List[String]],                                                                        // 15. tags
+      (
+          Rep[Int],
+          Rep[Int],
+          Rep[Int],
+          Rep[Option[Boolean]],
+          Rep[Option[ValidationOption.Value]],
+          Rep[Option[ValidationOption.Value]]
+      ),                                          // 14. validationInfo
+      Rep[List[String]],                          // 15. tags
       (Rep[Option[Double]], Rep[Option[Double]]), // 16. cameraLocation (lat, lng)
       Rep[Option[List[String]]],                  // 17. aiTags
       Rep[Option[List[String]]],                  // 18. aiTagsNotPresent
@@ -670,8 +681,8 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
       LabelTypeEnum.byName(r.nextString()),
       r.nextIntOption(),
       r.nextStringOption(),
-      r.nextIntOption(), // userValidation
-      r.nextIntOption(), // aiValidation
+      r.nextStringOption().map(ValidationOption.withName), // userValidation
+      r.nextStringOption().map(ValidationOption.withName), // aiValidation
       r.nextString().split(',').map(x => x.split(':')).map { y => (y(0), y(1).toInt) }.toMap,
       r.nextString().split(",").filter(_.nonEmpty).toList,
       (r.nextBoolean(), r.nextBoolean(), r.nextBoolean()),
@@ -732,8 +743,7 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
         Signal.name     -> LabelSevStats(r.nextInt(), r.nextIntOption(), r.nextDoubleOption(), r.nextDoubleOption()),
         Occlusion.name  -> LabelSevStats(r.nextInt(), r.nextIntOption(), r.nextDoubleOption(), r.nextDoubleOption()),
         Other.name      -> LabelSevStats(r.nextInt(), r.nextIntOption(), r.nextDoubleOption(), r.nextDoubleOption())
-      ),
-      {
+      ), {
         // Read the combined/human/ai validation breakdowns in the exact order getOverallStatsForApi emits them: for
         // each source, the total validation count followed by one LabelAccuracy per validationStatLabelTypes entry.
         // Seq.map is strict and left-to-right, so this reads columns positionally in sync with the SELECT.
@@ -1113,7 +1123,7 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
             l.disagreeCount,
             l.unsureCount,
             l.correct,
-            Option.empty[Int].bind,
+            Option.empty[ValidationOption.Value].bind,
             aiv.map(_.validationResult)
           ),
           l.tags,
@@ -1233,12 +1243,13 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
     val _labelsFilteredByAiValidation = {
       var query = _labelInfoWithAIValidation
       if (aiValOptions.nonEmpty) {
+        // Remove labels whose AI validation matches a result that wasn't requested (keeping unvalidated labels).
         if (!aiValOptions.contains("correct"))
-          query = query.filter(l => l._7.isEmpty || l._7.map(_.validationResult) =!= 1.asColumnOf[Option[Int]])
+          query = query.filterNot(l => l._7.map(_.validationResult === ValidationOption.Agree).getOrElse(false))
         if (!aiValOptions.contains("incorrect"))
-          query = query.filter(l => l._7.isEmpty || l._7.map(_.validationResult) =!= 2.asColumnOf[Option[Int]])
+          query = query.filterNot(l => l._7.map(_.validationResult === ValidationOption.Disagree).getOrElse(false))
         if (!aiValOptions.contains("unsure"))
-          query = query.filter(l => l._7.isEmpty || l._7.map(_.validationResult) =!= 3.asColumnOf[Option[Int]])
+          query = query.filterNot(l => l._7.map(_.validationResult === ValidationOption.Unsure).getOrElse(false))
         if (!aiValOptions.contains("unvalidated")) query = query.filter(l => l._7.isDefined)
       }
       query
@@ -1317,12 +1328,12 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
       _pd <- panoData if _lb.panoId === _pd.panoId
       _vc <- _validationsWithComments if _lb.labelId === _vc._1
       _us <- userStats if _vc._3 === _us.userId
-      if _lb.userId === userId &&   // Only include the given user's labels.
-        _vc._3 =!= userId &&        // Exclude any cases where the user may have validated their own label.
-        _vc._2 === 2 &&             // Only times when users validated as incorrect.
-        _us.excluded === false &&   // Don't use validations from excluded users
-        _us.highQuality === true && // For now, we only include validations from high quality users.
-        _pd.expired === false &&    // Only include those with non-expired imagery.
+      if _lb.userId === userId &&               // Only include the given user's labels.
+        _vc._3 =!= userId &&                    // Exclude any cases where the user may have validated their own label.
+        _vc._2 === ValidationOption.Disagree && // Only times when users validated as incorrect.
+        _us.excluded === false &&               // Don't use validations from excluded users
+        _us.highQuality === true &&             // For now, we only include validations from high quality users.
+        _pd.expired === false &&                // Only include those with non-expired imagery.
         _lb.correct.isDefined && _lb.correct === false && // Exclude outlier validations on a correct label.
         _lt.labelType === labelType.name                  // Only include given label types.
     } yield (
@@ -1373,17 +1384,18 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
     val _labelsFilteredByAiValidation = {
       var query = _labelInfoWithAIValidation
       if (aiValOptions.nonEmpty) {
+        // Remove labels whose AI validation matches a result that wasn't requested (keeping unvalidated labels).
         if (!aiValOptions.contains("correct"))
-          query = query.filter { case (_, _, _, _, _, _, _, aiv) =>
-            aiv.isEmpty || aiv.map(_.validationResult) =!= 1.asColumnOf[Option[Int]]
+          query = query.filterNot { case (_, _, _, _, _, _, _, aiv) =>
+            aiv.map(_.validationResult === ValidationOption.Agree).getOrElse(false)
           }
         if (!aiValOptions.contains("incorrect"))
-          query = query.filter { case (_, _, _, _, _, _, _, aiv) =>
-            aiv.isEmpty || aiv.map(_.validationResult) =!= 2.asColumnOf[Option[Int]]
+          query = query.filterNot { case (_, _, _, _, _, _, _, aiv) =>
+            aiv.map(_.validationResult === ValidationOption.Disagree).getOrElse(false)
           }
         if (!aiValOptions.contains("unsure"))
-          query = query.filter { case (_, _, _, _, _, _, _, aiv) =>
-            aiv.isEmpty || aiv.map(_.validationResult) =!= 3.asColumnOf[Option[Int]]
+          query = query.filterNot { case (_, _, _, _, _, _, _, aiv) =>
+            aiv.map(_.validationResult === ValidationOption.Unsure).getOrElse(false)
           }
         if (!aiValOptions.contains("unvalidated"))
           query = query.filter { case (_, _, _, _, _, _, _, aiv) => aiv.isDefined }
@@ -1692,10 +1704,9 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
       INNER JOIN user_stat ON label.user_id = user_stat.user_id
       LEFT JOIN (
           SELECT label.label_id,
-          array_to_string(array_agg(CONCAT(label_validation.user_id, ':', validation_options.text)), ',') AS validations
+          array_to_string(array_agg(CONCAT(label_validation.user_id, ':', label_validation.validation_result)), ',') AS validations
           FROM label
           INNER JOIN label_validation ON label.label_id = label_validation.label_id
-          INNER JOIN validation_options ON label_validation.validation_result = validation_options.validation_option_id
           GROUP BY label.label_id
       ) AS "vals" ON label.label_id = vals.label_id
       WHERE #$whereClause
@@ -1734,8 +1745,8 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
     // Rather than hand-write ~150 nearly-identical SQL columns (and risk drift from projectSidewalkStatsConverter), we
     // generate the repetitive column lists from the shared, ordered LabelTable.validationStatSources and
     // LabelTable.validationStatLabelTypes. The parser reads columns in the same order, keeping the two in lockstep.
-    val valSources: Seq[(String, String)]  = LabelTable.validationStatSources
-    val valTypes: Seq[(String, String)]    = LabelTable.validationStatLabelTypes
+    val valSources: Seq[(String, String)] = LabelTable.validationStatSources
+    val valTypes: Seq[(String, String)]   = LabelTable.validationStatLabelTypes
     // Per-label-type filter used in the outer aggregation; "overall" matches all label types.
     def ltCond(prefix: String, labelType: String): String =
       if (prefix == "overall") "" else s"label_type = '$labelType' AND "
@@ -1767,10 +1778,10 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
     val validationVerdictCols: String = valSources
       .map { case (src, filter) =>
         s"""CASE
-           |                         WHEN COUNT(CASE WHEN $filter AND validation_result = 1 THEN 1 END)
-           |                             > COUNT(CASE WHEN $filter AND validation_result = 2 THEN 1 END) THEN 1
-           |                         WHEN COUNT(CASE WHEN $filter AND validation_result = 2 THEN 1 END)
-           |                             > COUNT(CASE WHEN $filter AND validation_result = 1 THEN 1 END) THEN 2
+           |                         WHEN COUNT(CASE WHEN $filter AND validation_result = 'Agree' THEN 1 END)
+           |                             > COUNT(CASE WHEN $filter AND validation_result = 'Disagree' THEN 1 END) THEN 1
+           |                         WHEN COUNT(CASE WHEN $filter AND validation_result = 'Disagree' THEN 1 END)
+           |                             > COUNT(CASE WHEN $filter AND validation_result = 'Agree' THEN 1 END) THEN 2
            |                         ELSE 3
            |                         END AS ${src}_mv,
            |                     COUNT(CASE WHEN $filter THEN 1 END) AS ${src}_votes""".stripMargin
@@ -2063,24 +2074,24 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
               SELECT label.label_id, label_type.label_type,
                      -- Note that we're doing majority vote with AI for simplicity. Should only be one vote from AI.
                      CASE
-                         WHEN COUNT(CASE WHEN role = 'AI' AND validation_result = 1 THEN 1 END)
-                             > COUNT(CASE WHEN role = 'AI' AND validation_result = 2 THEN 1 END) THEN 1
-                         WHEN COUNT(CASE WHEN role = 'AI' AND validation_result = 2 THEN 1 END)
-                             > COUNT(CASE WHEN role = 'AI' AND validation_result = 1 THEN 1 END) THEN 2
+                         WHEN COUNT(CASE WHEN role = 'AI' AND validation_result = 'Agree' THEN 1 END)
+                             > COUNT(CASE WHEN role = 'AI' AND validation_result = 'Disagree' THEN 1 END) THEN 1
+                         WHEN COUNT(CASE WHEN role = 'AI' AND validation_result = 'Disagree' THEN 1 END)
+                             > COUNT(CASE WHEN role = 'AI' AND validation_result = 'Agree' THEN 1 END) THEN 2
                          ELSE 3
                          END AS ai_mv,
                      CASE
-                         WHEN COUNT(CASE WHEN role <> 'AI' AND validation_result = 1 THEN 1 END)
-                             > COUNT(CASE WHEN role <> 'AI' AND validation_result = 2 THEN 1 END) THEN 1
-                         WHEN COUNT(CASE WHEN role <> 'AI' AND validation_result = 2 THEN 1 END)
-                             > COUNT(CASE WHEN role <> 'AI' AND validation_result = 1 THEN 1 END) THEN 2
+                         WHEN COUNT(CASE WHEN role <> 'AI' AND validation_result = 'Agree' THEN 1 END)
+                             > COUNT(CASE WHEN role <> 'AI' AND validation_result = 'Disagree' THEN 1 END) THEN 1
+                         WHEN COUNT(CASE WHEN role <> 'AI' AND validation_result = 'Disagree' THEN 1 END)
+                             > COUNT(CASE WHEN role <> 'AI' AND validation_result = 'Agree' THEN 1 END) THEN 2
                          ELSE 3
                          END AS human_mv,
                      CASE
-                         WHEN COUNT(CASE WHEN role IN ('Administrator', 'Owner') AND validation_result = 1 THEN 1 END)
-                             > COUNT(CASE WHEN role IN ('Administrator', 'Owner') AND validation_result = 2 THEN 1 END) THEN 1
-                         WHEN COUNT(CASE WHEN role IN ('Administrator', 'Owner') AND validation_result = 2 THEN 1 END)
-                             > COUNT(CASE WHEN role IN ('Administrator', 'Owner') AND validation_result = 1 THEN 1 END) THEN 2
+                         WHEN COUNT(CASE WHEN role IN ('Administrator', 'Owner') AND validation_result = 'Agree' THEN 1 END)
+                             > COUNT(CASE WHEN role IN ('Administrator', 'Owner') AND validation_result = 'Disagree' THEN 1 END) THEN 1
+                         WHEN COUNT(CASE WHEN role IN ('Administrator', 'Owner') AND validation_result = 'Disagree' THEN 1 END)
+                             > COUNT(CASE WHEN role IN ('Administrator', 'Owner') AND validation_result = 'Agree' THEN 1 END) THEN 2
                          ELSE 3
                          END AS admin_mv
               FROM label

--- a/app/models/user/UserStatTable.scala
+++ b/app/models/user/UserStatTable.scala
@@ -860,11 +860,11 @@ class UserStatTable @Inject() (
       LEFT JOIN (
           SELECT label_validation.user_id,
                  COUNT(*) AS validations_given,
-                 COUNT(CASE WHEN (validation_result = 1 AND correct = FALSE)
-                                 OR (validation_result = 2 AND correct = TRUE) THEN 1 END) AS dissenting_validations_given,
-                 COUNT(CASE WHEN validation_result = 1 THEN 1 END) AS agree_validations_given,
-                 COUNT(CASE WHEN validation_result = 2 THEN 1 END) AS disagree_validations_given,
-                 COUNT(CASE WHEN validation_result = 3 THEN 1 END) AS unsure_validations_given
+                 COUNT(CASE WHEN (validation_result = 'Agree' AND correct = FALSE)
+                                 OR (validation_result = 'Disagree' AND correct = TRUE) THEN 1 END) AS dissenting_validations_given,
+                 COUNT(CASE WHEN validation_result = 'Agree' THEN 1 END) AS agree_validations_given,
+                 COUNT(CASE WHEN validation_result = 'Disagree' THEN 1 END) AS disagree_validations_given,
+                 COUNT(CASE WHEN validation_result = 'Unsure' THEN 1 END) AS unsure_validations_given
           FROM label_validation
           INNER JOIN label ON label_validation.label_id = label.label_id
           GROUP BY label_validation.user_id

--- a/app/models/utils/MyPostgresProfile.scala
+++ b/app/models/utils/MyPostgresProfile.scala
@@ -6,6 +6,7 @@ import com.github.tminglei.slickpg.geom.PgPostGISExtensions
 import models.label.AiImageSource
 import models.pano.PanoSource
 import models.utils.CommonUtils.{UiSource, ViewerType}
+import models.validation.ValidationOption
 import org.locationtech.jts.geom.{Geometry, LineString, MultiPolygon, Point}
 import org.n52.jackson.datatype.jts.JtsModule
 import play.api.libs.functional.syntax.{toFunctionalBuilderOps, unlift}
@@ -118,6 +119,15 @@ trait MyPostgresProfile
     // Mapper for viewer_type enum type.
     implicit val viewerTypeMapper: BaseColumnType[ViewerType.Value] =
       createEnumJdbcType[ViewerType.Value]("viewer_type", _.toString, ViewerType.withName, quoteName = false)
+
+    // Mapper for validation_option enum type.
+    implicit val validationOptionMapper: BaseColumnType[ValidationOption.Value] =
+      createEnumJdbcType[ValidationOption.Value](
+        "validation_option",
+        _.toString,
+        ValidationOption.withName,
+        quoteName = false
+      )
   }
 }
 

--- a/app/models/validation/LabelValidationTable.scala
+++ b/app/models/validation/LabelValidationTable.scala
@@ -221,7 +221,7 @@ class LabelValidationTable @Inject() (
    */
   def getValidatedCountsPerUser: DBIO[Seq[(String, (Int, Int))]] = {
     humanValidations
-      .filter(_.labelValidationId =!= 3) // Exclude "unsure" validations.
+      .filter(_.validationResult =!= 3) // Exclude "unsure" validations.
       .groupBy(_.userId)
       .map { case (userId, group) =>
         // Sum up the agreed validations and total validations (just agreed + disagreed).

--- a/app/models/validation/LabelValidationTable.scala
+++ b/app/models/validation/LabelValidationTable.scala
@@ -9,7 +9,6 @@ import models.utils.CommonUtils.UiSource.UiSource
 import models.utils.CommonUtils.ViewerType.ViewerType
 import models.utils.MyPostgresProfile
 import models.utils.MyPostgresProfile.api._
-import models.validation.LabelValidationTable.validationOptions
 import play.api.db.slick.{DatabaseConfigProvider, HasDatabaseConfigProvider}
 import service.TimeInterval
 import service.TimeInterval.TimeInterval
@@ -21,7 +20,7 @@ import scala.concurrent.ExecutionContext
 case class LabelValidation(
     labelValidationId: Int,
     labelId: Int,
-    validationResult: Int,
+    validationResult: ValidationOption.Value,
     oldSeverity: Option[Int],
     newSeverity: Option[Int],
     oldTags: List[String],
@@ -46,11 +45,10 @@ case class ValidationCount(
     count: Int,
     timeInterval: TimeInterval,
     labelType: String,
-    validationResult: String,
+    validationResult: Option[ValidationOption.Value], // None represents the "All" results subtotal.
     validatorType: String
 ) {
   require((validLabelTypes ++ Seq("All")).contains(labelType))
-  require((validationOptions.values.toSeq ++ Seq("All")).contains(validationResult))
   require(Seq("AI", "Human", "Both").contains(validatorType))
 }
 
@@ -60,26 +58,26 @@ case class ValidationCount(
  * @param tag
  */
 class LabelValidationTableDef(tag: slick.lifted.Tag) extends Table[LabelValidation](tag, "label_validation") {
-  def labelValidationId: Rep[Int]         = column[Int]("label_validation_id", O.AutoInc)
-  def labelId: Rep[Int]                   = column[Int]("label_id")
-  def validationResult: Rep[Int]          = column[Int]("validation_result") // 1 = Agree, 2 = Disagree, 3 = Unsure
-  def oldSeverity: Rep[Option[Int]]       = column[Option[Int]]("old_severity")
-  def newSeverity: Rep[Option[Int]]       = column[Option[Int]]("new_severity")
-  def oldTags: Rep[List[String]]          = column[List[String]]("old_tags")
-  def newTags: Rep[List[String]]          = column[List[String]]("new_tags")
-  def userId: Rep[String]                 = column[String]("user_id")
-  def missionId: Rep[Int]                 = column[Int]("mission_id")
-  def canvasX: Rep[Option[Int]]           = column[Option[Int]]("canvas_x")
-  def canvasY: Rep[Option[Int]]           = column[Option[Int]]("canvas_y")
-  def heading: Rep[Double]                = column[Double]("heading")
-  def pitch: Rep[Double]                  = column[Double]("pitch")
-  def zoom: Rep[Double]                   = column[Double]("zoom")
-  def canvasHeight: Rep[Int]              = column[Int]("canvas_height")
-  def canvasWidth: Rep[Int]               = column[Int]("canvas_width")
-  def startTimestamp: Rep[OffsetDateTime] = column[OffsetDateTime]("start_timestamp")
-  def endTimestamp: Rep[OffsetDateTime]   = column[OffsetDateTime]("end_timestamp")
-  def source: Rep[UiSource]               = column[UiSource]("source")
-  def viewerType: Rep[ViewerType]         = column[ViewerType]("viewer_type")
+  def labelValidationId: Rep[Int]                   = column[Int]("label_validation_id", O.AutoInc)
+  def labelId: Rep[Int]                             = column[Int]("label_id")
+  def validationResult: Rep[ValidationOption.Value] = column[ValidationOption.Value]("validation_result")
+  def oldSeverity: Rep[Option[Int]]                 = column[Option[Int]]("old_severity")
+  def newSeverity: Rep[Option[Int]]                 = column[Option[Int]]("new_severity")
+  def oldTags: Rep[List[String]]                    = column[List[String]]("old_tags")
+  def newTags: Rep[List[String]]                    = column[List[String]]("new_tags")
+  def userId: Rep[String]                           = column[String]("user_id")
+  def missionId: Rep[Int]                           = column[Int]("mission_id")
+  def canvasX: Rep[Option[Int]]                     = column[Option[Int]]("canvas_x")
+  def canvasY: Rep[Option[Int]]                     = column[Option[Int]]("canvas_y")
+  def heading: Rep[Double]                          = column[Double]("heading")
+  def pitch: Rep[Double]                            = column[Double]("pitch")
+  def zoom: Rep[Double]                             = column[Double]("zoom")
+  def canvasHeight: Rep[Int]                        = column[Int]("canvas_height")
+  def canvasWidth: Rep[Int]                         = column[Int]("canvas_width")
+  def startTimestamp: Rep[OffsetDateTime]           = column[OffsetDateTime]("start_timestamp")
+  def endTimestamp: Rep[OffsetDateTime]             = column[OffsetDateTime]("end_timestamp")
+  def source: Rep[UiSource]                         = column[UiSource]("source")
+  def viewerType: Rep[ViewerType]                   = column[ViewerType]("viewer_type")
 
   def * = (labelValidationId, labelId, validationResult, oldSeverity, newSeverity, oldTags, newTags, userId, missionId,
     canvasX, canvasY, heading, pitch, zoom, canvasHeight, canvasWidth, startTimestamp, endTimestamp, source,
@@ -95,13 +93,6 @@ class LabelValidationTableDef(tag: slick.lifted.Tag) extends Table[LabelValidati
 //    foreignKey("label_validation_mission_id_fkey", missionId, TableQuery[MissionTableDef])(_.missionId)
 
 //  def userLabelUnique: Index = index("label_validation_user_id_label_id_unique", (userId, labelId), unique = true)
-}
-
-/**
- * Companion object with constants that are shared throughout codebase.
- */
-object LabelValidationTable {
-  val validationOptions: Map[Int, String] = Map(1 -> "Agree", 2 -> "Disagree", 3 -> "Unsure")
 }
 
 @ImplementedBy(classOf[LabelValidationTable])
@@ -148,9 +139,9 @@ class LabelValidationTable @Inject() (
       .map { case (result, group) => (result, group.length) }
       .result
       .map { results =>
-        val agreeCount    = results.find(_._1 == 1).map(_._2).getOrElse(0)
-        val disagreeCount = results.find(_._1 == 2).map(_._2).getOrElse(0)
-        val unsureCount   = results.find(_._1 == 3).map(_._2).getOrElse(0)
+        val agreeCount    = results.find(_._1 == ValidationOption.Agree).map(_._2).getOrElse(0)
+        val disagreeCount = results.find(_._1 == ValidationOption.Disagree).map(_._2).getOrElse(0)
+        val unsureCount   = results.find(_._1 == ValidationOption.Unsure).map(_._2).getOrElse(0)
         (agreeCount, disagreeCount, unsureCount)
       }
   }
@@ -221,11 +212,12 @@ class LabelValidationTable @Inject() (
    */
   def getValidatedCountsPerUser: DBIO[Seq[(String, (Int, Int))]] = {
     humanValidations
-      .filter(_.validationResult =!= 3) // Exclude "unsure" validations.
+      .filter(_.validationResult =!= ValidationOption.Unsure) // Exclude "unsure" validations.
       .groupBy(_.userId)
       .map { case (userId, group) =>
         // Sum up the agreed validations and total validations (just agreed + disagreed).
-        val agreed = group.map { r => Case.If(r.validationResult === 1).Then(1).Else(0) }.sum.getOrElse(0)
+        val agreed =
+          group.map { r => Case.If(r.validationResult === ValidationOption.Agree).Then(1).Else(0) }.sum.getOrElse(0)
         (userId, (group.length, agreed))
       }
       .result
@@ -273,9 +265,9 @@ class LabelValidationTable @Inject() (
         // We want to also calculate a sum for every possible subgroup b/w label_type, validation_result and validator.
         // Let's start by enumerating every subgroup combination. We include None for each of the three fields to
         // allow for "All" entries.
-        val subgroupCombinations: Set[(Option[Int], Option[Int], Option[Boolean])] = for {
+        val subgroupCombinations: Set[(Option[Int], Option[ValidationOption.Value], Option[Boolean])] = for {
           labelType <- validLabelTypeIds.map(Some(_)) ++ Seq(None)
-          valResult <- validationOptions.keys.map(Some(_)) ++ Seq(None)
+          valResult <- ValidationOption.values.toSeq.map(Some(_)) ++ Seq(None)
           validator <- Seq(Some(true), Some(false), None)
         } yield (labelType, valResult, validator)
 
@@ -291,9 +283,8 @@ class LabelValidationTable @Inject() (
 
           // Create the ValidationCount object for this subgroup.
           val labelType = labTypeFilter.map(labelTypeIdToLabelType).getOrElse("All")
-          val valOption = valResultFilter.map(validationOptions).getOrElse("All")
           val validator = validatorFilter.map(isAi => if (isAi) "AI" else "Human").getOrElse("Both")
-          ValidationCount(subgroupCount, timeInterval, labelType, valOption, validator)
+          ValidationCount(subgroupCount, timeInterval, labelType, valResultFilter, validator)
         }.toSeq
       }
   }
@@ -364,8 +355,6 @@ class LabelValidationTable @Inject() (
       labelTypeId = label.labelTypeId,
       labelType = labelType.labelType,
       validationResult = validation.validationResult,
-      // Convert validation result to string using the companion object mapping.
-      validationResultString = LabelValidationTable.validationOptions.getOrElse(validation.validationResult, "Unknown"),
       oldSeverity = validation.oldSeverity,
       newSeverity = validation.newSeverity,
       oldTags = validation.oldTags,
@@ -397,23 +386,20 @@ class LabelValidationTable @Inject() (
       .groupBy { case (v, (u, ur, r)) => (v.validationResult, r.role === "AI") }
       .map { case ((valResult, isAi), group) => (valResult, isAi, group.length) }
       .result
-      .map { results: Seq[(Int, Boolean, Int)] =>
+      .map { results: Seq[(ValidationOption.Value, Boolean, Int)] =>
         // Create a ValidationResultTypeForApi object for each validation result type.
-        validationOptions.keys
+        ValidationOption.values.toSeq
           .map { valResult =>
             val currValCounts   = results.filter(_._1 == valResult)
             val humanCount: Int = currValCounts.find(_._2 == false).map(_._3).getOrElse(0)
             val aiCount: Int    = currValCounts.find(_._2 == true).map(_._3).getOrElse(0)
             ValidationResultTypeForApi(
-              id = valResult,
-              name = validationOptions.getOrElse(valResult, "Unknown"),
+              name = valResult.toString,
               count = humanCount + aiCount,
               countHuman = humanCount,
               countAi = aiCount
             )
           }
-          .toSeq
-          .sortBy(_.id)
       }
   }
 }

--- a/app/models/validation/ValidationOption.scala
+++ b/app/models/validation/ValidationOption.scala
@@ -1,0 +1,17 @@
+package models.validation
+
+/**
+ * Enumeration of the possible results of a validation, backing the `validation_option` Postgres enum type.
+ *
+ * NOTE: if changing these values, update the `validation_option` Postgres enum type as well (see 322.sql). The string
+ * values are emitted directly in API responses and consumed by the frontend.
+ */
+object ValidationOption extends Enumeration {
+  type ValidationOption = Value
+  val Agree: Value    = Value("Agree")
+  val Disagree: Value = Value("Disagree")
+  val Unsure: Value   = Value("Unsure")
+
+  /** Parses a string into a validation option, returning None if it doesn't match a known value. */
+  def fromString(name: String): Option[Value] = values.find(_.toString == name)
+}

--- a/app/service/AiService.scala
+++ b/app/service/AiService.scala
@@ -6,7 +6,7 @@ import models.user.SidewalkUserTable
 import models.utils.CommonUtils.{UiSource, ViewerType}
 import models.utils.MyPostgresProfile.api._
 import models.utils._
-import models.validation.LabelValidation
+import models.validation.{LabelValidation, ValidationOption}
 import play.api.db.slick.{DatabaseConfigProvider, HasDatabaseConfigProvider}
 import play.api.libs.json.{JsObject, JsValue}
 import play.api.libs.ws.WSClient
@@ -119,8 +119,9 @@ class AiServiceImpl @Inject() (
             val labelPoint = labelData.labelPoint
 
             // If confidence is below the threshold, submit an Unsure validation instead.
-            val aiValResult: Int =
-              if (aiResults.validationAccuracy >= AI_VALIDATION_MIN_ACCURACY) aiResults.validationResult else 3
+            val aiValResult: ValidationOption.Value =
+              if (aiResults.validationAccuracy >= AI_VALIDATION_MIN_ACCURACY) aiResults.validationResult
+              else ValidationOption.Unsure
 
             // Get the AI's mission_id and the label's current info, then create and submit the validation.
             for {
@@ -187,9 +188,11 @@ class AiServiceImpl @Inject() (
             logger.debug(json.toString)
 
             // Parse the output. Filter out "NULL" values from the tags list.
-            val valResult     = if ((json \ "validation_result").as[String] == "correct") 1 else 2
-            val valAccuracy   = (json \ "validation_estimated_accuracy").as[Double]
-            val valConfidence = (json \ "validation_score").as[Double]
+            val valResult =
+              if ((json \ "validation_result").as[String] == "correct") ValidationOption.Agree
+              else ValidationOption.Disagree
+            val valAccuracy                                  = (json \ "validation_estimated_accuracy").as[Double]
+            val valConfidence                                = (json \ "validation_score").as[Double]
             val tagsConfidence: Option[Seq[AiTagConfidence]] = (json \ "tag_scores")
               .asOpt[JsObject]
               .map(_.fields.map { case (tag, jsValue) => AiTagConfidence(tag, jsValue.as[Double]) }.toSeq)

--- a/app/service/ValidationService.scala
+++ b/app/service/ValidationService.scala
@@ -59,13 +59,14 @@ class ValidationServiceImpl @Inject() (
   /**
    * Updates the validation counts and correctness columns in the label table given a new incoming validation.
    * @param labelId label_id of the label with a new validation
-   * @param newResult the new validation: 1 meaning agree, 2 meaning disagree, and 3 meaning unsure
+   * @param newResult the new validation if there is one (Agree, Disagree, or Unsure)
    * @param oldResult the old validation if the user had validated this label in the past
    */
-  def updateValidationCounts(labelId: Int, newResult: Option[Int], oldResult: Option[Int]): DBIO[Int] = {
-    require(newResult.isEmpty || Seq(1, 2, 3).contains(newResult.get), "New validation results can only be 1, 2, or 3.")
-    require(oldResult.isEmpty || Seq(1, 2, 3).contains(oldResult.get), "Old validation results can only be 1, 2, or 3.")
-
+  def updateValidationCounts(
+      labelId: Int,
+      newResult: Option[ValidationOption.Value],
+      oldResult: Option[ValidationOption.Value]
+  ): DBIO[Int] = {
     labelTable
       .find(labelId)
       .flatMap {
@@ -75,18 +76,18 @@ class ValidationServiceImpl @Inject() (
 
           // Add 1 to the correct count for the new validation. In case of delete, no match is found.
           val countsWithNewVal: (Int, Int, Int) = newResult match {
-            case Some(1) => (oldCounts._1 + 1, oldCounts._2, oldCounts._3)
-            case Some(2) => (oldCounts._1, oldCounts._2 + 1, oldCounts._3)
-            case Some(3) => (oldCounts._1, oldCounts._2, oldCounts._3 + 1)
-            case _       => oldCounts
+            case Some(ValidationOption.Agree)    => (oldCounts._1 + 1, oldCounts._2, oldCounts._3)
+            case Some(ValidationOption.Disagree) => (oldCounts._1, oldCounts._2 + 1, oldCounts._3)
+            case Some(ValidationOption.Unsure)   => (oldCounts._1, oldCounts._2, oldCounts._3 + 1)
+            case _                               => oldCounts
           }
 
           // If there was a previous validation from this user, subtract 1 for that old validation. O/w use previous result.
           val countsWithoutOldVal: (Int, Int, Int) = oldResult match {
-            case Some(1) => (countsWithNewVal._1 - 1, countsWithNewVal._2, countsWithNewVal._3)
-            case Some(2) => (countsWithNewVal._1, countsWithNewVal._2 - 1, countsWithNewVal._3)
-            case Some(3) => (countsWithNewVal._1, countsWithNewVal._2, countsWithNewVal._3 - 1)
-            case _       => countsWithNewVal
+            case Some(ValidationOption.Agree)    => (countsWithNewVal._1 - 1, countsWithNewVal._2, countsWithNewVal._3)
+            case Some(ValidationOption.Disagree) => (countsWithNewVal._1, countsWithNewVal._2 - 1, countsWithNewVal._3)
+            case Some(ValidationOption.Unsure)   => (countsWithNewVal._1, countsWithNewVal._2, countsWithNewVal._3 - 1)
+            case _                               => countsWithNewVal
           }
 
           // Determine whether the label is correct. Agree > disagree = correct; disagree > agree = incorrect; o/w null.
@@ -121,7 +122,8 @@ class ValidationServiceImpl @Inject() (
         case Some(oldVal) =>
           for {
             historyEntryDeleted <- {
-              if (oldVal.validationResult == 1) removeLabelHistoryForValidation(oldVal.labelValidationId)
+              if (oldVal.validationResult == ValidationOption.Agree)
+                removeLabelHistoryForValidation(oldVal.labelValidationId)
               else DBIO.successful(false)
             }
             excludedUser <- userStatTable.isExcludedUser(userId)
@@ -291,7 +293,7 @@ class ValidationServiceImpl @Inject() (
           newValId: Int <- insert(validation)
           // Update the severity and tags in the label table if something changed (only applies if they marked Agree).
           _ <- {
-            if (validation.validationResult == 1) {
+            if (validation.validationResult == ValidationOption.Agree) {
               updateAndSaveLabelHistory(validation.labelId, validation.newSeverity, validation.newTags,
                 validation.userId, validation.source, newValId)
             } else DBIO.successful(0)

--- a/app/views/apiDocs/validations.scala.html
+++ b/app/views/apiDocs/validations.scala.html
@@ -59,7 +59,7 @@
             <h3 class="api-heading" id="endpoint-examples">Examples<a href="#endpoint-examples" class="permalink">#</a></h3>
             <p><code><a href="/v3/api/validations">/v3/api/validations</a></code> Get all validations in JSON (default)</p>
             <p><code><a href="/v3/api/validations?filetype=csv">/v3/api/validations?filetype=csv</a></code> Get all validations in CSV format</p>
-            <p><code><a href="/v3/api/validations?validationResult=1">/v3/api/validations?validationResult=1</a></code> Get only "Agree" validations</p>
+            <p><code><a href="/v3/api/validations?validationResult=Agree">/v3/api/validations?validationResult=Agree</a></code> Get only "Agree" validations</p>
             <p><code><a href="/v3/api/validations?labelTypeId=2&changedTags=true">/v3/api/validations?labelTypeId=2&changedTags=true</a></code> Get validations for label type 2 where tags were changed</p>
         </div>
     </div>
@@ -106,8 +106,8 @@
                     </tr>
                     <tr>
                         <td><code>validationResult</code></td>
-                        <td><code>integer</code></td>
-                        <td>Filter by validation result: <code>1</code> (Agree), <code>2</code> (Disagree), <code>3</code> (Unsure).</td>
+                        <td><code>string</code></td>
+                        <td>Filter by validation result: <code>Agree</code>, <code>Disagree</code>, or <code>Unsure</code>.</td>
                     </tr>
                     <tr>
                         <td><code>labelTypeId</code></td>
@@ -158,8 +158,7 @@
         "label_id": 67890,
         "label_type_id": 2,
         "label_type": "NoCurbRamp",
-        "validation_result": 1,
-        "validation_result_string": "Agree",
+        "validation_result": "Agree",
         "old_severity": 2,
         "new_severity": 3,
         "old_tags": ["narrow"],
@@ -183,8 +182,7 @@
         "label_id": 67891,
         "label_type_id": 1,
         "label_type": "CurbRamp",
-        "validation_result": 2,
-        "validation_result_string": "Disagree",
+        "validation_result": "Disagree",
         "old_severity": 2,
         "new_severity": 2,
         "old_tags": ["wide"],
@@ -220,8 +218,7 @@
                     <tr><td><code>label_id</code></td><td><code>integer</code></td><td>ID of the label that was validated.</td></tr>
                     <tr><td><code>label_type_id</code></td><td><code>integer</code></td><td>ID of the label type (e.g., 1 for CurbRamp, 2 for NoCurbRamp).</td></tr>
                     <tr><td><code>label_type</code></td><td><code>string</code></td><td>Name of the label type (e.g., "CurbRamp", "Obstacle").</td></tr>
-                    <tr><td><code>validation_result</code></td><td><code>integer</code></td><td>Validation judgment: 1 (Agree), 2 (Disagree), 3 (Unsure).</td></tr>
-                    <tr><td><code>validation_result_string</code></td><td><code>string</code></td><td>Validation judgment: Agree, Disagree, Unsure.</td></tr>
+                    <tr><td><code>validation_result</code></td><td><code>string</code></td><td>Validation judgment: Agree, Disagree, Unsure.</td></tr>
                     <tr><td><code>old_severity</code></td><td><code>integer | null</code></td><td>Severity rating before validation (1-3 scale), or null if not applicable.</td></tr>
                     <tr><td><code>new_severity</code></td><td><code>integer | null</code></td><td>Severity rating after validation (1-3 scale), or null if not applicable.</td></tr>
                     <tr><td><code>old_tags</code></td><td><code>array[string]</code></td><td>Array of tag names before validation.</td></tr>
@@ -263,7 +260,7 @@
         <pre><code class="language-json">{
     "status": 400,
     "code": "INVALID_PARAMETER",
-    "message": "Invalid validationResult value. Must be 1 (Agree), 2 (Disagree), or 3 (Unsure).",
+    "message": "Invalid validationResult value. Must be Agree, Disagree, or Unsure.",
     "parameter": "validationResult"
 }</code></pre>
     </div>
@@ -275,25 +272,21 @@
             <table class="api-table">
                 <thead>
                     <tr>
-                        <th>ID</th>
                         <th>Name</th>
                         <th>Description</th>
                     </tr>
                 </thead>
                 <tbody>
                     <tr>
-                        <td><code>1</code></td>
-                        <td>Agree</td>
+                        <td><code>Agree</code></td>
                         <td>The validator agrees with the original label placement and classification.</td>
                     </tr>
                     <tr>
-                        <td><code>2</code></td>
-                        <td>Disagree</td>
+                        <td><code>Disagree</code></td>
                         <td>The validator disagrees with the original label placement or classification.</td>
                     </tr>
                     <tr>
-                        <td><code>3</code></td>
-                        <td>Unsure</td>
+                        <td><code>Unsure</code></td>
                         <td>The validator is uncertain about the label's accuracy (e.g., due to image quality).</td>
                     </tr>
                 </tbody>

--- a/conf/evolutions/default/322.sql
+++ b/conf/evolutions/default/322.sql
@@ -1,0 +1,53 @@
+# --- !Ups
+-- Replace the integer-keyed validation_options lookup table with a proper Postgres enum type.
+CREATE TYPE validation_option AS ENUM ('Agree', 'Disagree', 'Unsure');
+
+-- Convert label_validation.validation_result from an integer FK into the enum.
+ALTER TABLE label_validation DROP CONSTRAINT label_validation_validation_result_fkey;
+ALTER TABLE label_validation
+    ALTER COLUMN validation_result TYPE validation_option
+    USING (CASE validation_result
+               WHEN 1 THEN 'Agree'
+               WHEN 2 THEN 'Disagree'
+               WHEN 3 THEN 'Unsure'
+           END)::validation_option;
+
+-- Convert label_ai_assessment.validation_result (same 1/2/3 semantics, but never had an FK) into the enum.
+ALTER TABLE label_ai_assessment
+    ALTER COLUMN validation_result TYPE validation_option
+    USING (CASE validation_result
+               WHEN 1 THEN 'Agree'
+               WHEN 2 THEN 'Disagree'
+               WHEN 3 THEN 'Unsure'
+           END)::validation_option;
+
+DROP TABLE validation_options;
+
+# --- !Downs
+CREATE TABLE validation_options (
+    validation_option_id INTEGER PRIMARY KEY,
+    text TEXT NOT NULL
+);
+INSERT INTO validation_options (validation_option_id, text)
+VALUES (1, 'agree'), (2, 'disagree'), (3, 'unsure');
+
+ALTER TABLE label_ai_assessment
+    ALTER COLUMN validation_result TYPE INTEGER
+    USING (CASE validation_result
+               WHEN 'Agree' THEN 1
+               WHEN 'Disagree' THEN 2
+               WHEN 'Unsure' THEN 3
+           END);
+
+ALTER TABLE label_validation
+    ALTER COLUMN validation_result TYPE INTEGER
+    USING (CASE validation_result
+               WHEN 'Agree' THEN 1
+               WHEN 'Disagree' THEN 2
+               WHEN 'Unsure' THEN 3
+           END);
+ALTER TABLE label_validation
+    ADD CONSTRAINT label_validation_validation_result_fkey
+    FOREIGN KEY (validation_result) REFERENCES validation_options(validation_option_id);
+
+DROP TYPE validation_option;

--- a/conf/routes
+++ b/conf/routes
@@ -185,7 +185,7 @@ GET     /v3/api/labelClusters                           controllers.api.LabelClu
 GET     /v3/api/streets                                 controllers.api.StreetsApiController.getStreets(bbox: Option[String], regionId: Option[Int], regionName: Option[String], minLabelCount: Option[Int], minAuditCount: Option[Int], minUserCount: Option[Int], wayType: Option[String], filetype: Option[String], inline: Option[Boolean])
 GET     /v3/api/streetTypes                             controllers.api.StreetsApiController.getStreetTypes
 GET     /v3/api/regions                                 controllers.api.RegionApiController.getRegions(bbox: Option[String], regionId: Option[Int], regionName: Option[String], minLabelCount: Option[Int], filetype: Option[String], inline: Option[Boolean])
-GET     /v3/api/validations                             controllers.api.ValidationApiController.getValidations(labelId: Option[Int], userId: Option[String], validationResult: Option[Int], labelTypeId: Option[Int], validationTimestamp: Option[String], changedTags: Option[Boolean], changedSeverityLevels: Option[Boolean], filetype: Option[String], inline: Option[Boolean])
+GET     /v3/api/validations                             controllers.api.ValidationApiController.getValidations(labelId: Option[Int], userId: Option[String], validationResult: Option[String], labelTypeId: Option[Int], validationTimestamp: Option[String], changedTags: Option[Boolean], changedSeverityLevels: Option[Boolean], filetype: Option[String], inline: Option[Boolean])
 GET     /v3/api/validationResultTypes                   controllers.api.ValidationApiController.getValidationResultTypes
 
 # API Documentation (v3) Routes.

--- a/public/javascripts/Gallery/src/validation/ValidationMenu.js
+++ b/public/javascripts/Gallery/src/validation/ValidationMenu.js
@@ -11,11 +11,6 @@ function ValidationMenu(referenceCard, gsvImage) {
     const refCard = referenceCard;
     let currSelected = null;
 
-    const resultOptions = {
-        'Agree': 1,
-        'Disagree': 2,
-        'Unsure': 3
-    };
     const classToValidationOption = {
         'validate-agree': 'Agree',
         'validate-disagree': 'Disagree',
@@ -182,7 +177,7 @@ function ValidationMenu(referenceCard, gsvImage) {
         const data = {
             label_id: refCard.getProperty('label_id'),
             label_type: refCard.getProperty('label_type'),
-            validation_result: resultOptions[action],
+            validation_result: action,
             old_severity: refCard.getProperty('severity'),
             new_severity: refCard.getProperty('severity'),
             old_tags: refCard.getProperty('tags'),

--- a/public/javascripts/SVValidate/src/label/Label.js
+++ b/public/javascripts/SVValidate/src/label/Label.js
@@ -263,28 +263,11 @@ function Label(params) {
             svv.tracker.push('ValidationTextField_DataEntered', { validation: validationResult, text: comment });
         }
 
-        switch (validationResult) {
-            // Agree option selected.
-            case 'Agree':
-                setProperty('validationResult', 1);
-                svv.missionContainer.getCurrentMission().updateValidationResult(1, false);
-                svv.labelContainer.pushToLabelsToSubmit(getAuditProperty('labelId'), getProperties(), prepareCommentData());
-                svv.missionContainer.updateAMission();
-                break;
-            // Disagree option selected.
-            case 'Disagree':
-                setProperty('validationResult', 2);
-                svv.missionContainer.getCurrentMission().updateValidationResult(2, false);
-                svv.labelContainer.pushToLabelsToSubmit(getAuditProperty('labelId'), getProperties(), prepareCommentData());
-                svv.missionContainer.updateAMission();
-                break;
-            // Unsure option selected.
-            case 'Unsure':
-                setProperty('validationResult', 3);
-                svv.missionContainer.getCurrentMission().updateValidationResult(3, false);
-                svv.labelContainer.pushToLabelsToSubmit(getAuditProperty('labelId'), getProperties(), prepareCommentData());
-                svv.missionContainer.updateAMission();
-                break;
+        if (['Agree', 'Disagree', 'Unsure'].includes(validationResult)) {
+            setProperty('validationResult', validationResult);
+            svv.missionContainer.getCurrentMission().updateValidationResult(validationResult, false);
+            svv.labelContainer.pushToLabelsToSubmit(getAuditProperty('labelId'), getProperties(), prepareCommentData());
+            svv.missionContainer.updateAMission();
         }
 
         // If there are more labels left to validate, add a new label to the panorama. Otherwise, we will load a new

--- a/public/javascripts/SVValidate/src/menu/DesktopValidationMenu.js
+++ b/public/javascripts/SVValidate/src/menu/DesktopValidationMenu.js
@@ -16,19 +16,19 @@ function DesktopValidationMenu(menuUI) {
             const action = e.isTrigger ? 'ValidationKeyboardShortcut_Agree' : 'ValidationButtonClick_Agree';
             svv.tracker.push(action);
             _setYesView();
-            svv.labelContainer.getCurrentLabel().setProperty('validationResult', 1);
+            svv.labelContainer.getCurrentLabel().setProperty('validationResult', 'Agree');
         });
         menuUI.noButton.click(function(e) {
             const action = e.isTrigger ? 'ValidationKeyboardShortcut_Disagree' : 'ValidationButtonClick_Disagree';
             svv.tracker.push(action);
             _setNoView();
-            svv.labelContainer.getCurrentLabel().setProperty('validationResult', 2);
+            svv.labelContainer.getCurrentLabel().setProperty('validationResult', 'Disagree');
         });
         menuUI.unsureButton.click(function(e) {
             const action = e.isTrigger ? 'ValidationKeyboardShortcut_Unsure' : 'ValidationButtonClick_Unsure';
             svv.tracker.push(action);
             _setUnsureView();
-            svv.labelContainer.getCurrentLabel().setProperty('validationResult', 3);
+            svv.labelContainer.getCurrentLabel().setProperty('validationResult', 'Unsure');
         });
 
         // Tag and severity sections only available with Expert Validate.
@@ -135,7 +135,7 @@ function DesktopValidationMenu(menuUI) {
         // Add onclick for submit button.
         menuUI.submitButton.click(function(e) {
             if (!e.target.disabled) {
-                _validateLabel(svv.validationOptions[svv.labelContainer.getCurrentLabel().getProperty('validationResult')], e.isTrigger);
+                _validateLabel(svv.labelContainer.getCurrentLabel().getProperty('validationResult'), e.isTrigger);
             }
         });
     }
@@ -216,9 +216,9 @@ function DesktopValidationMenu(menuUI) {
                 menuUI.unsureReasonOptions.find(`#${unsureOption}`).addClass('chosen');
             }
 
-            if (prevValResult === 1)      _setYesView();
-            else if (prevValResult === 2) _setNoView();
-            else if (prevValResult === 3) _setUnsureView();
+            if (prevValResult === 'Agree')         _setYesView();
+            else if (prevValResult === 'Disagree') _setNoView();
+            else if (prevValResult === 'Unsure')   _setUnsureView();
         }
     }
 

--- a/public/javascripts/SVValidate/src/menu/MobileValidationMenu.js
+++ b/public/javascripts/SVValidate/src/menu/MobileValidationMenu.js
@@ -14,22 +14,22 @@ function MobileValidationMenu(menuUI) {
             const action = e.isTrigger ? 'ValidationKeyboardShortcut_Agree' : 'ValidationButtonClick_Agree';
             svv.tracker.push(action);
             _setYesView();
-            svv.labelContainer.getCurrentLabel().setProperty('validationResult', 1);
+            svv.labelContainer.getCurrentLabel().setProperty('validationResult', 'Agree');
 
             // Not adding comments on mobile when voting yes, just submit the validation.
-            _validateLabel(svv.validationOptions[svv.labelContainer.getCurrentLabel().getProperty('validationResult')], e.isTrigger);
+            _validateLabel(svv.labelContainer.getCurrentLabel().getProperty('validationResult'), e.isTrigger);
         });
         menuUI.noButton.click(function(e) {
             const action = e.isTrigger ? 'ValidationKeyboardShortcut_Disagree' : 'ValidationButtonClick_Disagree';
             svv.tracker.push(action);
             _setNoView();
-            svv.labelContainer.getCurrentLabel().setProperty('validationResult', 2);
+            svv.labelContainer.getCurrentLabel().setProperty('validationResult', 'Disagree');
         });
         menuUI.unsureButton.click(function(e) {
             const action = e.isTrigger ? 'ValidationKeyboardShortcut_Unsure' : 'ValidationButtonClick_Unsure';
             svv.tracker.push(action);
             _setUnsureView();
-            svv.labelContainer.getCurrentLabel().setProperty('validationResult', 3);
+            svv.labelContainer.getCurrentLabel().setProperty('validationResult', 'Unsure');
         });
 
         // Add onclick for disagree and unsure reason buttons.
@@ -175,9 +175,9 @@ function MobileValidationMenu(menuUI) {
                 menuUI.unsureReasonOptions.find(`#${unsureOption}`).addClass('chosen');
             }
 
-            if (prevValResult === 1)      _setYesView();
-            else if (prevValResult === 2) _setNoView();
-            else if (prevValResult === 3) _setUnsureView();
+            if (prevValResult === 'Agree')         _setYesView();
+            else if (prevValResult === 'Disagree') _setNoView();
+            else if (prevValResult === 'Unsure')   _setUnsureView();
         }
     }
 

--- a/public/javascripts/SVValidate/src/mission/Mission.js
+++ b/public/javascripts/SVValidate/src/mission/Mission.js
@@ -113,19 +113,19 @@ function Mission(params) {
     /**
      * Updates the validation result for this mission by incrementing agree, disagree and unsure
      * counts collected in this mission. (Only persists for current session)
-     * @param result Validation result - Can either be 1, 2, or 3 for agree, disagree, or unsure.
+     * @param result Validation result - Can either be 'Agree', 'Disagree', or 'Unsure'.
      * @param removeValidation (bool)  - Whether user clicked "undo", meaning we would decrement the count.
      */
     function updateValidationResult(result, removeValidation) {
         const change = removeValidation ? -1 : 1;
         switch (result) {
-            case 1:
+            case 'Agree':
                 setProperty("agreeCount", getProperty("agreeCount") + change);
                 break;
-            case 2:
+            case 'Disagree':
                 setProperty("disagreeCount", getProperty("disagreeCount") + change);
                 break;
-            case 3:
+            case 'Unsure':
                 setProperty("unsureCount", getProperty("unsureCount") + change);
                 break;
         }

--- a/public/javascripts/SVValidate/src/util/ConstantsValidate.js
+++ b/public/javascripts/SVValidate/src/util/ConstantsValidate.js
@@ -19,12 +19,6 @@ function defineValidateConstants() {
         10: i18next.t('common:signal')
     };
 
-    svv.validationOptions = {
-        1: 'Agree',
-        2: 'Disagree',
-        3: 'Unsure'
-    };
-
     svv.reasonButtonInfo = {
         'curb-ramp': {
             'no-button-1': {

--- a/public/javascripts/api-docs/validations-preview.js
+++ b/public/javascripts/api-docs/validations-preview.js
@@ -205,13 +205,13 @@
 
                 // Count validation results.
                 switch (validation.validation_result) {
-                    case 1:
+                    case 'Agree':
                         validationsByType[typeId].agree++;
                         break;
-                    case 2:
+                    case 'Disagree':
                         validationsByType[typeId].disagree++;
                         break;
-                    case 3:
+                    case 'Unsure':
                         validationsByType[typeId].unsure++;
                         break;
                 }
@@ -263,9 +263,9 @@
 
             // Calculate overall statistics.
             const totalValidations = validationsData.length;
-            const totalAgree = validationsData.filter(v => v.validation_result === 1).length;
-            const totalDisagree = validationsData.filter(v => v.validation_result === 2).length;
-            const totalUnsure = validationsData.filter(v => v.validation_result === 3).length;
+            const totalAgree = validationsData.filter(v => v.validation_result === 'Agree').length;
+            const totalDisagree = validationsData.filter(v => v.validation_result === 'Disagree').length;
+            const totalUnsure = validationsData.filter(v => v.validation_result === 'Unsure').length;
 
             const statsGrid = document.createElement('div');
             statsGrid.className = 'summary-stats-grid';

--- a/public/javascripts/common/label-detail/LabelDetail.js
+++ b/public/javascripts/common/label-detail/LabelDetail.js
@@ -36,8 +36,6 @@ async function LabelDetail(root, opts) {
     // Updated in each showLabel() call so PanoInfoPopover's accessor closures see the current label.
     let currentLabelMeta = null;
 
-    // Result codes accepted by /labelmap/validate.
-    const RESULT_OPTIONS = { Agree: 1, Disagree: 2, Unsure: 3 };
     const FLAG_NAMES = ['low_quality', 'incomplete', 'stale'];
 
     // Field references — populated in _init().
@@ -432,7 +430,7 @@ async function LabelDetail(root, opts) {
         const data = {
             label_id: self.panoManager.label.labelId,
             label_type: self.panoManager.label.label_type,
-            validation_result: RESULT_OPTIONS[action],
+            validation_result: action,
             old_severity: self.panoManager.label.oldSeverity,
             new_severity: self.panoManager.label.newSeverity,
             old_tags: self.panoManager.label.oldTags,


### PR DESCRIPTION
Closes #4230
Working towards #4103

### The bug (#4230)
`getValidatedCountsPerUser` filtered `labelValidationId =!= 3` (the primary key) instead of `validationResult =!= 3`, so "unsure" validations were never excluded from per-user validated counts. Fixed, and made impossible to reintroduce by giving the result a real type.

### The change
Models validation results as a native Postgres enum `validation_option` ('Agree','Disagree','Unsure') with a Scala `ValidationOption` enum, mirroring the `ui_source`/`viewer_type` pattern. Drops the integer representation entirely.

- **DB (evolution 322):** new `validation_option` type; converts `label_validation.validation_result` and `label_ai_assessment.validation_result` from int → enum; drops the `validation_options` lookup table.
- **Backend:** columns/case classes/queries use `ValidationOption.Value`; raw SQL compares against `'Agree'`/`'Disagree'`/`'Unsure'`; the int `1/2/3` is gone.
- **Frontend:** Validate, Gallery, and label-detail send/consume the strings.

### Breaking API changes (intentional)
- `/v3/api/validations`: single `"validation_result": "Agree"` string; `validation_result_string` removed; CSV column dropped. Filter param is now `?validationResult=Agree` (400 on invalid).
- `/v3/api/validationResultTypes`: `id` field removed.
- `/adminapi/getRecentLabelMetadata`: `user_validation`/`ai_validation` now strings.
- labels-API `validations` aggregate casing changes (`user:agree` → `user:Agree`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
