### PR TITLE
Phase 3: extract shared geo-filter helpers into BaseApiController (#3871)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,10 +73,119 @@ Two standalone scripts (run via the Python deps in `requirements.txt`, installed
 - Ensure WCAG 2.1/2.2 Level AA accessibility standards are met
 - When adding or refactoring code, use the fonts, colors, button styling, etc. defined in main.css :root. These are pulled from our "Design System Tokens" Figma, and we are pushing to use these going forward.
 - Max line length of 120 characters, with long line exceptions where appropriate. For multi-line comments, TARGET line length is 120 characters
-- Functions should have comments, even if they are private. Incredibly trivial functions are okay to leave without a comment.
-    - They should include @param lines as well (including their type in JS), and those should almost always be restricted to a single line
-    - Function comments should start with a one-line summary. If more detail is necessary, then longer details can be added with an empty comment line between one-line summary and the further details. But those details can also just be added throughout the function's code instead, where appropriate.
-- When writing comments, DO NOT waste time describing how something has changed from how it used to work. Just because something was edited doesn't mean that a comment even needs to be added.
+
+## Code Commenting Standards
+
+Comments communicate **why** code makes a choice — not **what** it does (well-named identifiers handle that). Follow the
+language-specific conventions below so that IDEs, documentation generators, and the next developer can consume them.
+
+### Scala (ScalaDoc)
+
+Use `/** ... */` for all ScalaDoc. Every class, trait, object, and non-trivial method gets one — including `private`
+methods. Private methods are read by the next developer, not just public API consumers.
+
+**Method / function:**
+```scala
+/**
+ * One-line summary of what this does or returns.
+ *
+ * Longer description when the contract, preconditions, or edge cases need more room.
+ * Separate from the summary with a blank line; keep each line under 120 chars.
+ *
+ * @param name  Description. Don't repeat the type — it is already in the signature.
+ * @param other Description. Align multi-param descriptions for readability.
+ * @return      What is returned and meaningful edge cases (e.g. `None` if absent,
+ *              `Left(ApiError)` if malformed, `Right(Some(...))` if valid).
+ */
+```
+
+**Class / trait / object / companion:**
+```scala
+/**
+ * One-line description of this type's single responsibility.
+ *
+ * Longer description if construction semantics, lifecycle, or thread-safety matter.
+ *
+ * @param cc  Description of constructor param (omit implicit/DI-only params).
+ */
+```
+
+Rules:
+- Use `@return` (not `@returns`) — that is the ScalaDoc standard.
+- Align `@param` descriptions when there are multiple — consistent with Play/Slick/Scala stdlib style.
+- Omit `@throws` unless the exception is part of the intentional public contract.
+- Do not document implicit params that are pure DI plumbing details.
+- Trivial one-line helpers (simple delegators, obvious getters) may omit the header.
+
+### JavaScript (JSDoc)
+
+Use `/** ... */` for all JSDoc. Every ES6 class and every non-trivial method gets one — including `#private` methods.
+Type annotations in `@param` are especially important in JS because there is no static type checker.
+
+**Method / function:**
+```javascript
+/**
+ * One-line summary.
+ *
+ * Longer description when needed. Keep lines under 120 chars.
+ *
+ * @param {string} name - Description. Mark optional params as {string} [name] = defaultValue.
+ * @param {number} count - Description.
+ * @returns {boolean} What is returned; include edge cases (null if not found, etc.).
+ */
+```
+
+**ES6 class:**
+```javascript
+/**
+ * One-line description of the class's single responsibility.
+ */
+class Foo {
+    /**
+     * @param {string} name - Description.
+     */
+    constructor(name) { ... }
+}
+```
+
+Rules:
+- Use `@returns` (not `@return`) — that is the JSDoc standard (opposite of ScalaDoc).
+- Always include `{Type}` in `@param` and `@returns`.
+- Use `{Type} [paramName]` (square brackets) for optional parameters.
+- Use `{Type} [paramName=default]` when a default exists and is non-obvious.
+- Trivial one-line helpers may omit the header.
+
+### Inline comments
+
+Use `//` for inline comments within a body. Write the **why**, never the what:
+
+```scala
+// bbox takes precedence over region filters per the v3 API contract (#3871).
+val finalBbox = if (bboxActive) parsedBbox else ...
+```
+
+not:
+
+```scala
+// check if bbox is active   ← restates the code; adds no value
+val finalBbox = if (bboxActive) parsedBbox else ...
+```
+
+Good targets for inline comments:
+- Non-obvious algorithmic choices or ordering constraints that must be preserved.
+- Business rules and domain invariants that aren't apparent from identifiers alone.
+- Workarounds for external bugs, framework quirks, or surprising behavior.
+- Why a specific constant or threshold was chosen (link to issue/spec if possible).
+- Branches where the "looks-wrong" path is actually correct.
+- `firstError`-style validation sequences where the order of checks matters.
+
+### What not to comment
+
+- Do not restate what the code obviously does.
+- Do not describe what the code *used to* do — use git history for that.
+- Do not leave `TODO`/`FIXME` in committed code without a linked tracking issue.
+- Do not add a header just because a function was touched; only add one if it is missing
+  and the function is non-trivial.
 
 ## Linting Rules (will be enforced by `make lint` some day, but not being run now)
 - ESLint: ES6+, `const`/`let` only (no `var`), arrow functions, template literals, semicolons required, 120-char line limit

--- a/app/controllers/api/BaseApiController.scala
+++ b/app/controllers/api/BaseApiController.scala
@@ -110,69 +110,18 @@ abstract class BaseApiController(cc: CustomControllerComponents)(implicit ec: Ex
   /** Builds a 400 Bad Request response from an `ApiError`. */
   protected def badRequest(error: ApiError): Result = BadRequest(Json.toJson(error))
 
-  /**
-   * Returns an ApiError if `bbox` was supplied but could not be parsed.
-   *
-   * @param bbox    The raw bbox query parameter value.
-   * @param parsed  The result of running `parseBBoxString(bbox)`.
-   */
+  // Instance method wrappers — delegate to the companion object so the pure logic is unit-testable without DI.
   protected def validateBBoxParam(bbox: Option[String], parsed: Option[LatLngBBox]): Option[ApiError] =
-    if (bbox.isDefined && parsed.isEmpty)
-      Some(ApiError.invalidParameter(
-        "Invalid value for bbox parameter. Expected format: minLng,minLat,maxLng,maxLat.", "bbox"))
-    else None
-
-  /**
-   * Returns an ApiError if `regionId` is defined but not a positive integer.
-   *
-   * @param regionId The optional regionId query parameter.
-   */
+    BaseApiController.validateBBoxParam(bbox, parsed)
   protected def validateRegionId(regionId: Option[Int]): Option[ApiError] =
-    if (regionId.exists(_ <= 0))
-      Some(ApiError.invalidParameter("Invalid regionId value. Must be a positive integer.", "regionId"))
-    else None
-
-  /**
-   * Resolves the effective bbox/regionId/regionName filters, applying the standard v3 precedence rules:
-   * - An explicit valid bbox takes precedence over region filters.
-   * - regionId takes precedence over regionName.
-   * - If neither a bbox nor a region filter is provided, the city default bbox is used.
-   *
-   * @param bbox          The raw bbox query parameter.
-   * @param parsedBbox    The result of running `parseBBoxString(bbox)`.
-   * @param regionId      The optional regionId query parameter.
-   * @param regionName    The optional regionName query parameter.
-   * @param cityMapParams Default map parameters for the current city.
-   * @return A triple of (finalBbox, finalRegionId, finalRegionName) after applying precedence.
-   */
+    BaseApiController.validateRegionId(regionId)
   protected def resolveGeoFilters(
-      bbox: Option[String],
-      parsedBbox: Option[LatLngBBox],
-      regionId: Option[Int],
-      regionName: Option[String],
-      cityMapParams: MapParams
-  ): (Option[LatLngBBox], Option[Int], Option[String]) = {
-    val defaultBox = LatLngBBox(
-      minLng = Math.min(cityMapParams.lng1, cityMapParams.lng2),
-      minLat = Math.min(cityMapParams.lat1, cityMapParams.lat2),
-      maxLng = Math.max(cityMapParams.lng1, cityMapParams.lng2),
-      maxLat = Math.max(cityMapParams.lat1, cityMapParams.lat2)
-    )
-    val bboxActive  = bbox.isDefined && parsedBbox.isDefined
-    val finalBbox   = if (bboxActive) parsedBbox else if (regionId.isDefined || regionName.isDefined) None else Some(defaultBox)
-    val finalRegId  = if (bboxActive) None else regionId
-    val finalRegName = if (bboxActive || regionId.isDefined) None else regionName
-    (finalBbox, finalRegId, finalRegName)
-  }
-
-  /**
-   * Parses a comma-separated query parameter into a sequence of trimmed strings.
-   *
-   * @param raw The optional raw query parameter string.
-   * @return `None` if the parameter was absent; otherwise a non-empty `Some(Seq(...))`.
-   */
+      bbox: Option[String], parsedBbox: Option[LatLngBBox], regionId: Option[Int],
+      regionName: Option[String], cityMapParams: MapParams
+  ): (Option[LatLngBBox], Option[Int], Option[String]) =
+    BaseApiController.resolveGeoFilters(bbox, parsedBbox, regionId, regionName, cityMapParams)
   protected def parseCommaSeparated(raw: Option[String]): Option[Seq[String]] =
-    raw.map(_.split(",").map(_.trim).toSeq)
+    BaseApiController.parseCommaSeparated(raw)
 
   /**
    * Outputs a CSV stream from the provided database data stream.
@@ -376,4 +325,77 @@ abstract class BaseApiController(cc: CustomControllerComponents)(implicit ec: Ex
         )
     }
   }
+}
+
+/**
+ * Pure geo-filter helpers shared across v3 API controllers.
+ *
+ * Extracted to a companion object so they can be unit-tested directly without any DI wiring.
+ * The controller instance methods in [[BaseApiController]] delegate here.
+ */
+object BaseApiController {
+
+  /**
+   * Returns an ApiError if `bbox` was supplied but could not be parsed.
+   *
+   * @param bbox   The raw bbox query parameter value.
+   * @param parsed The result of running `parseBBoxString(bbox)`.
+   */
+  def validateBBoxParam(bbox: Option[String], parsed: Option[LatLngBBox]): Option[ApiError] =
+    if (bbox.isDefined && parsed.isEmpty)
+      Some(ApiError.invalidParameter(
+        "Invalid value for bbox parameter. Expected format: minLng,minLat,maxLng,maxLat.", "bbox"))
+    else None
+
+  /**
+   * Returns an ApiError if `regionId` is defined but not a positive integer.
+   *
+   * @param regionId The optional regionId query parameter.
+   */
+  def validateRegionId(regionId: Option[Int]): Option[ApiError] =
+    if (regionId.exists(_ <= 0))
+      Some(ApiError.invalidParameter("Invalid regionId value. Must be a positive integer.", "regionId"))
+    else None
+
+  /**
+   * Resolves the effective bbox/regionId/regionName filters, applying the standard v3 precedence rules:
+   * - An explicit valid bbox takes precedence over region filters.
+   * - regionId takes precedence over regionName.
+   * - If neither a bbox nor a region filter is provided, the city default bbox is used.
+   *
+   * @param bbox          The raw bbox query parameter (pre-parse string, used only to detect "was it supplied").
+   * @param parsedBbox    The result of running `parseBBoxString(bbox)`.
+   * @param regionId      The optional regionId query parameter.
+   * @param regionName    The optional regionName query parameter.
+   * @param cityMapParams Default map parameters for the current city.
+   * @return A triple of (finalBbox, finalRegionId, finalRegionName) after applying precedence.
+   */
+  def resolveGeoFilters(
+      bbox: Option[String],
+      parsedBbox: Option[LatLngBBox],
+      regionId: Option[Int],
+      regionName: Option[String],
+      cityMapParams: MapParams
+  ): (Option[LatLngBBox], Option[Int], Option[String]) = {
+    val defaultBox = LatLngBBox(
+      minLng = Math.min(cityMapParams.lng1, cityMapParams.lng2),
+      minLat = Math.min(cityMapParams.lat1, cityMapParams.lat2),
+      maxLng = Math.max(cityMapParams.lng1, cityMapParams.lng2),
+      maxLat = Math.max(cityMapParams.lat1, cityMapParams.lat2)
+    )
+    val bboxActive   = bbox.isDefined && parsedBbox.isDefined
+    val finalBbox    = if (bboxActive) parsedBbox else if (regionId.isDefined || regionName.isDefined) None else Some(defaultBox)
+    val finalRegId   = if (bboxActive) None else regionId
+    val finalRegName = if (bboxActive || regionId.isDefined) None else regionName
+    (finalBbox, finalRegId, finalRegName)
+  }
+
+  /**
+   * Parses a comma-separated query parameter into a sequence of trimmed strings.
+   *
+   * @param raw The optional raw query parameter string.
+   * @return `None` if the parameter was absent; a `Some(Seq(...))` of trimmed tokens otherwise.
+   */
+  def parseCommaSeparated(raw: Option[String]): Option[Seq[String]] =
+    raw.map(_.split(",").map(_.trim).toSeq)
 }

--- a/app/controllers/api/BaseApiController.scala
+++ b/app/controllers/api/BaseApiController.scala
@@ -111,6 +111,70 @@ abstract class BaseApiController(cc: CustomControllerComponents)(implicit ec: Ex
   protected def badRequest(error: ApiError): Result = BadRequest(Json.toJson(error))
 
   /**
+   * Returns an ApiError if `bbox` was supplied but could not be parsed.
+   *
+   * @param bbox    The raw bbox query parameter value.
+   * @param parsed  The result of running `parseBBoxString(bbox)`.
+   */
+  protected def validateBBoxParam(bbox: Option[String], parsed: Option[LatLngBBox]): Option[ApiError] =
+    if (bbox.isDefined && parsed.isEmpty)
+      Some(ApiError.invalidParameter(
+        "Invalid value for bbox parameter. Expected format: minLng,minLat,maxLng,maxLat.", "bbox"))
+    else None
+
+  /**
+   * Returns an ApiError if `regionId` is defined but not a positive integer.
+   *
+   * @param regionId The optional regionId query parameter.
+   */
+  protected def validateRegionId(regionId: Option[Int]): Option[ApiError] =
+    if (regionId.exists(_ <= 0))
+      Some(ApiError.invalidParameter("Invalid regionId value. Must be a positive integer.", "regionId"))
+    else None
+
+  /**
+   * Resolves the effective bbox/regionId/regionName filters, applying the standard v3 precedence rules:
+   * - An explicit valid bbox takes precedence over region filters.
+   * - regionId takes precedence over regionName.
+   * - If neither a bbox nor a region filter is provided, the city default bbox is used.
+   *
+   * @param bbox          The raw bbox query parameter.
+   * @param parsedBbox    The result of running `parseBBoxString(bbox)`.
+   * @param regionId      The optional regionId query parameter.
+   * @param regionName    The optional regionName query parameter.
+   * @param cityMapParams Default map parameters for the current city.
+   * @return A triple of (finalBbox, finalRegionId, finalRegionName) after applying precedence.
+   */
+  protected def resolveGeoFilters(
+      bbox: Option[String],
+      parsedBbox: Option[LatLngBBox],
+      regionId: Option[Int],
+      regionName: Option[String],
+      cityMapParams: MapParams
+  ): (Option[LatLngBBox], Option[Int], Option[String]) = {
+    val defaultBox = LatLngBBox(
+      minLng = Math.min(cityMapParams.lng1, cityMapParams.lng2),
+      minLat = Math.min(cityMapParams.lat1, cityMapParams.lat2),
+      maxLng = Math.max(cityMapParams.lng1, cityMapParams.lng2),
+      maxLat = Math.max(cityMapParams.lat1, cityMapParams.lat2)
+    )
+    val bboxActive  = bbox.isDefined && parsedBbox.isDefined
+    val finalBbox   = if (bboxActive) parsedBbox else if (regionId.isDefined || regionName.isDefined) None else Some(defaultBox)
+    val finalRegId  = if (bboxActive) None else regionId
+    val finalRegName = if (bboxActive || regionId.isDefined) None else regionName
+    (finalBbox, finalRegId, finalRegName)
+  }
+
+  /**
+   * Parses a comma-separated query parameter into a sequence of trimmed strings.
+   *
+   * @param raw The optional raw query parameter string.
+   * @return `None` if the parameter was absent; otherwise a non-empty `Some(Seq(...))`.
+   */
+  protected def parseCommaSeparated(raw: Option[String]): Option[Seq[String]] =
+    raw.map(_.split(",").map(_.trim).toSeq)
+
+  /**
    * Outputs a CSV stream from the provided database data stream.
    *
    * @tparam A The type of data in the stream, which must extend `StreamingApiType`.

--- a/app/controllers/api/LabelApiController.scala
+++ b/app/controllers/api/LabelApiController.scala
@@ -5,7 +5,6 @@ import controllers.helper.ShapefilesCreatorHelper
 import formats.json.ApiFormats._
 import models.api._
 import models.label.{LabelCVMetadata, LabelTypeEnum}
-import models.utils.LatLngBBox
 import org.apache.pekko.stream.scaladsl.Source
 import play.api.libs.json.Json
 import play.silhouette.api.Silhouette
@@ -155,67 +154,28 @@ class LabelApiController @Inject() (
   ) = silhouette.UserAwareAction.async { implicit request =>
     cc.loggingService.insert(request.identity.map(_.userId), request.ipAddress, request.toString)
 
-    // Parse bbox parameter.
-    val parsedBbox: Option[LatLngBBox] = parseBBoxString(bbox)
-
-    // Parse and validate date filters (malformed values are reported rather than silently dropped).
-    val parsedStartDate = parseDateTimeParam(startDate, "startDate")
-    val parsedEndDate   = parseDateTimeParam(endDate, "endDate")
-
-    // Validate and map validation status to its internal representation.
+    // Parse bbox and date/validation params.
+    val parsedBbox             = parseBBoxString(bbox)
+    val parsedStartDate        = parseDateTimeParam(startDate, "startDate")
+    val parsedEndDate          = parseDateTimeParam(endDate, "endDate")
     val parsedValidationStatus = parseValidationStatus(validationStatus)
-
-    // Parse comma-separated lists into sequences.
-    val parsedLabelTypes = labelType.map(_.split(",").map(_.trim).toSeq)
-    val parsedTags       = tags.map(_.split(",").map(_.trim).toSeq)
+    val parsedLabelTypes       = parseCommaSeparated(labelType)
+    val parsedTags             = parseCommaSeparated(tags)
 
     // Collect the first invalid-parameter error, if any.
     val firstError: Option[ApiError] = Seq(
-      if (bbox.isDefined && parsedBbox.isEmpty)
-        Some(ApiError.invalidParameter(
-          "Invalid value for bbox parameter. Expected format: minLng,minLat,maxLng,maxLat.", "bbox"))
-      else None,
+      validateBBoxParam(bbox, parsedBbox),
       parsedValidationStatus.left.toOption,
       parsedStartDate.left.toOption,
       parsedEndDate.left.toOption,
-      if (regionId.exists(_ <= 0))
-        Some(ApiError.invalidParameter("Invalid regionId value. Must be a positive integer.", "regionId"))
-      else None
+      validateRegionId(regionId)
     ).flatten.headOption
 
     firstError match {
       case Some(error) => Future.successful(badRequest(error))
       case None =>
         configService.getCityMapParams.flatMap { cityMapParams =>
-        // If bbox isn't provided, use city defaults.
-        val apiBox = parsedBbox.getOrElse(
-          LatLngBBox(
-            minLng = Math.min(cityMapParams.lng1, cityMapParams.lng2),
-            minLat = Math.min(cityMapParams.lat1, cityMapParams.lat2),
-            maxLng = Math.max(cityMapParams.lng1, cityMapParams.lng2),
-            maxLat = Math.max(cityMapParams.lat1, cityMapParams.lat2)
-          )
-        )
-
-        // Apply filter precedence logic.
-        // If bbox is defined, it takes precedence over region filters.
-        val finalBbox = if (bbox.isDefined && parsedBbox.isDefined) {
-          parsedBbox
-        } else if (regionId.isDefined || regionName.isDefined) {
-          None // If region filters are used, bbox should be None.
-        } else {
-          Some(apiBox) // Default city bbox.
-        }
-
-        // Apply region filter precedence logic.
-        // If bbox is defined, ignore region filters. If regionId is defined, it takes precedence over regionName.
-        val finalRegionId =
-          if (bbox.isDefined && parsedBbox.isDefined) None
-          else regionId
-
-        val finalRegionName =
-          if (bbox.isDefined && parsedBbox.isDefined || regionId.isDefined) None
-          else regionName
+        val (finalBbox, finalRegionId, finalRegionName) = resolveGeoFilters(bbox, parsedBbox, regionId, regionName, cityMapParams)
 
         // Create filters object.
         val filters = RawLabelFiltersForApi(

--- a/app/controllers/api/LabelClustersApiController.scala
+++ b/app/controllers/api/LabelClustersApiController.scala
@@ -3,7 +3,6 @@ package controllers.api
 import controllers.base.CustomControllerComponents
 import controllers.helper.ShapefilesCreatorHelper
 import models.api.{ApiError, LabelClusterFiltersForApi, LabelClusterForApi, RawLabelInClusterDataForApi}
-import models.utils.LatLngBBox
 import org.apache.pekko.stream.Materializer
 import org.apache.pekko.stream.scaladsl.Source
 import org.apache.pekko.util.ByteString
@@ -74,185 +73,127 @@ class LabelClustersApiController @Inject() (
       inline: Option[Boolean]
   ): Action[AnyContent] = silhouette.UserAwareAction.async { implicit request =>
     cc.loggingService.insert(request.identity.map(_.userId), request.ipAddress, request.toString)
-    try {
-      // Parse bbox parameter.
-      val parsedBbox: Option[LatLngBBox] = parseBBoxString(bbox)
 
-      // Parse and validate date filters (malformed values are reported rather than silently dropped).
-      val parsedAvgImageCaptureDate = parseDateTimeParam(avgImageCaptureDate, "avgImageCaptureDate")
-      val parsedAvgLabelDate        = parseDateTimeParam(avgLabelDate, "avgLabelDate")
+    // Parse bbox and date params.
+    val parsedBbox                = parseBBoxString(bbox)
+    val parsedAvgImageCaptureDate = parseDateTimeParam(avgImageCaptureDate, "avgImageCaptureDate")
+    val parsedAvgLabelDate        = parseDateTimeParam(avgLabelDate, "avgLabelDate")
+    val parsedLabelTypes          = parseCommaSeparated(labelType)
 
-      // Parse comma-separated lists into sequences.
-      val parsedLabelTypes = labelType.map(_.split(",").map(_.trim).toSeq)
+    // Collect the first invalid-parameter error, if any.
+    val firstError: Option[ApiError] = Seq(
+      validateBBoxParam(bbox, parsedBbox),
+      validateRegionId(regionId),
+      if (minSeverity.exists(s => s < 1 || s > 3))
+        Some(ApiError.invalidParameter("Invalid minSeverity value. Must be between 1-3.", "minSeverity"))
+      else None,
+      if (maxSeverity.exists(s => s < 1 || s > 3))
+        Some(ApiError.invalidParameter("Invalid maxSeverity value. Must be between 1-3.", "maxSeverity"))
+      else None,
+      if (clusterSize.exists(_ <= 0))
+        Some(ApiError.invalidParameter("Invalid clusterSize value. Must be a positive integer.", "clusterSize"))
+      else None,
+      parsedAvgImageCaptureDate.left.toOption,
+      parsedAvgLabelDate.left.toOption
+    ).flatten.headOption
 
-      // Collect the first invalid-parameter error, if any.
-      val firstError: Option[ApiError] = Seq(
-        if (bbox.isDefined && parsedBbox.isEmpty)
-          Some(ApiError.invalidParameter(
-            "Invalid value for bbox parameter. Expected format: minLng,minLat,maxLng,maxLat.", "bbox"))
-        else None,
-        if (regionId.exists(_ <= 0))
-          Some(ApiError.invalidParameter("Invalid regionId value. Must be a positive integer.", "regionId"))
-        else None,
-        if (minSeverity.exists(s => s < 1 || s > 3))
-          Some(ApiError.invalidParameter("Invalid minSeverity value. Must be between 1-3.", "minSeverity"))
-        else None,
-        if (maxSeverity.exists(s => s < 1 || s > 3))
-          Some(ApiError.invalidParameter("Invalid maxSeverity value. Must be between 1-3.", "maxSeverity"))
-        else None,
-        if (clusterSize.exists(_ <= 0))
-          Some(ApiError.invalidParameter("Invalid clusterSize value. Must be a positive integer.", "clusterSize"))
-        else None,
-        parsedAvgImageCaptureDate.left.toOption,
-        parsedAvgLabelDate.left.toOption
-      ).flatten.headOption
+    firstError match {
+      case Some(error) => Future.successful(badRequest(error))
+      case None =>
+        configService.getCityMapParams.flatMap { cityMapParams =>
+        val (finalBbox, finalRegionId, finalRegionName) = resolveGeoFilters(bbox, parsedBbox, regionId, regionName, cityMapParams)
 
-      firstError match {
-        case Some(error) => Future.successful(badRequest(error))
-        case None =>
-          configService.getCityMapParams.flatMap { cityMapParams =>
-          // If bbox isn't provided, use city defaults.
-          val apiBox: LatLngBBox = parsedBbox.getOrElse {
-            logger.info("Using default city bounding box")
-            LatLngBBox(
-              minLng = Math.min(cityMapParams.lng1, cityMapParams.lng2),
-              minLat = Math.min(cityMapParams.lat1, cityMapParams.lat2),
-              maxLng = Math.max(cityMapParams.lng1, cityMapParams.lng2),
-              maxLat = Math.max(cityMapParams.lat1, cityMapParams.lat2)
-            )
-          }
+        // Create filters object.
+        val filters = LabelClusterFiltersForApi(
+          bbox = finalBbox, labelTypes = parsedLabelTypes, regionId = finalRegionId, regionName = finalRegionName,
+          includeRawLabels = includeRawLabels.getOrElse(false), minClusterSize = clusterSize,
+          minAvgImageCaptureDate = parsedAvgImageCaptureDate.toOption.flatten,
+          minAvgLabelDate = parsedAvgLabelDate.toOption.flatten,
+          minSeverity = minSeverity, maxSeverity = maxSeverity
+        )
 
-          // Apply filter precedence logic.
-          // If bbox is defined, it takes precedence over region filters.
-          val finalBbox = if (bbox.isDefined && parsedBbox.isDefined) {
-            parsedBbox
-          } else if (regionId.isDefined || regionName.isDefined) {
-            None // If region filters are used, bbox should be None.
-          } else {
-            Some(apiBox) // Default city bbox.
-          }
+        // Get the data stream.
+        val dbDataStream: Source[LabelClusterForApi, _] = apiService.getLabelClusters(filters, DEFAULT_BATCH_SIZE)
+        val baseFileName: String                        = s"labelClusters_${OffsetDateTime.now()}"
 
-          // Apply region filter precedence logic.
-          // If bbox is defined, ignore region filters. If regionId is defined, it takes precedence over regionName.
-          val finalRegionId: Option[Int] = if (bbox.isDefined && parsedBbox.isDefined) None else regionId
+        // Output data in the appropriate file format.
+        filetype match {
+          case Some("csv") if filters.includeRawLabels =>
+            // When raw labels are included, create two CSVs (clusters + labels) zipped together.
+            val clusterCsvPath = Files.createTempFile(baseFileName + "_clusters", ".csv")
+            val labelCsvPath   = Files.createTempFile(baseFileName + "_labels", ".csv")
+            val clusterWriter  = Files.newBufferedWriter(clusterCsvPath)
+            val labelWriter    = Files.newBufferedWriter(labelCsvPath)
 
-          val finalRegionName: Option[String] =
-            if (bbox.isDefined && parsedBbox.isDefined || regionId.isDefined) None else regionName
+            clusterWriter.write(LabelClusterForApi.csvHeader)
+            labelWriter.write(RawLabelInClusterDataForApi.csvHeader)
 
-          // Create filters object.
-          val filters = LabelClusterFiltersForApi(
-            bbox = finalBbox, labelTypes = parsedLabelTypes, regionId = finalRegionId, regionName = finalRegionName,
-            includeRawLabels = includeRawLabels.getOrElse(false), minClusterSize = clusterSize,
-            minAvgImageCaptureDate = parsedAvgImageCaptureDate.toOption.flatten,
-            minAvgLabelDate = parsedAvgLabelDate.toOption.flatten,
-            minSeverity = minSeverity, maxSeverity = maxSeverity
-          )
-
-          try {
-            // Get the data stream.
-            val dbDataStream: Source[LabelClusterForApi, _] = apiService.getLabelClusters(filters, DEFAULT_BATCH_SIZE)
-            val baseFileName: String                        = s"labelClusters_${OffsetDateTime.now()}"
-
-            // Output data in the appropriate file format.
-            filetype match {
-              case Some("csv") if filters.includeRawLabels =>
-                // When raw labels are included, create two CSVs (clusters + labels) zipped together.
-                val clusterCsvPath = Files.createTempFile(baseFileName + "_clusters", ".csv")
-                val labelCsvPath   = Files.createTempFile(baseFileName + "_labels", ".csv")
-                val clusterWriter  = Files.newBufferedWriter(clusterCsvPath)
-                val labelWriter    = Files.newBufferedWriter(labelCsvPath)
-
-                clusterWriter.write(LabelClusterForApi.csvHeader)
-                labelWriter.write(RawLabelInClusterDataForApi.csvHeader)
-
-                dbDataStream
-                  .grouped(DEFAULT_BATCH_SIZE)
-                  .runForeach { batch =>
-                    batch.foreach { cluster =>
-                      clusterWriter.write(cluster.toCsvRow)
-                      clusterWriter.write("\n")
-                      cluster.labels.foreach { labelsList =>
-                        labelsList.foreach { label =>
-                          labelWriter.write(RawLabelInClusterDataForApi.toCsvRow(cluster.labelClusterId, label))
-                          labelWriter.write("\n")
-                        }
-                      }
+            dbDataStream
+              .grouped(DEFAULT_BATCH_SIZE)
+              .runForeach { batch =>
+                batch.foreach { cluster =>
+                  clusterWriter.write(cluster.toCsvRow)
+                  clusterWriter.write("\n")
+                  cluster.labels.foreach { labelsList =>
+                    labelsList.foreach { label =>
+                      labelWriter.write(RawLabelInClusterDataForApi.toCsvRow(cluster.labelClusterId, label))
+                      labelWriter.write("\n")
                     }
                   }
-                  .flatMap { _ =>
-                    clusterWriter.close()
-                    labelWriter.close()
-                    zipAndStreamCsvFiles(
-                      Seq(
-                        (clusterCsvPath, baseFileName + "_clusters.csv"),
-                        (labelCsvPath, baseFileName + "_labels.csv")
-                      ),
-                      baseFileName
-                    )
-                  }
-                  .recoverWith { case NonFatal(e) =>
-                    // Ensure writers are closed and temp files removed if streaming or zipping failed.
-                    scala.util.Try(clusterWriter.close())
-                    scala.util.Try(labelWriter.close())
-                    Files.deleteIfExists(clusterCsvPath)
-                    Files.deleteIfExists(labelCsvPath)
-                    logger.error(s"Error generating label clusters CSV: ${e.getMessage}", e)
-                    Future.successful(
-                      InternalServerError(
-                        Json.toJson(ApiError.internalServerError(s"Error processing request: ${e.getMessage}"))
-                      )
-                    )
-                  }
-              case Some("csv") =>
-                outputCSV(dbDataStream, LabelClusterForApi.csvHeader, inline, baseFileName + ".csv")
-              case Some("shapefile") if filters.includeRawLabels =>
-                // When raw labels are included, create both clusters and labels shapefiles in the ZIP.
-                shapefileCreator
-                  .createLabelClusterShapefileWithLabels(dbDataStream, baseFileName, DEFAULT_BATCH_SIZE)
-                  .map {
-                    case Some(p) =>
-                      val zipSrc: Source[ByteString, Future[Boolean]] = shapefileCreator.zipShapefile(p, baseFileName)
-                      Ok.chunked(zipSrc)
-                        .as("application/zip")
-                        .withHeaders(CONTENT_DISPOSITION -> s"attachment; filename=$baseFileName.zip")
-                    case None =>
-                      InternalServerError("Failed to create shapefile")
-                  }
-              case Some("shapefile") =>
-                outputShapefile(
-                  dbDataStream,
-                  baseFileName,
-                  shapefileCreator.createLabelClusterShapefile,
-                  shapefileCreator
+                }
+              }
+              .flatMap { _ =>
+                clusterWriter.close()
+                labelWriter.close()
+                zipAndStreamCsvFiles(
+                  Seq(
+                    (clusterCsvPath, baseFileName + "_clusters.csv"),
+                    (labelCsvPath, baseFileName + "_labels.csv")
+                  ),
+                  baseFileName
                 )
-              case Some("geopackage") =>
-                outputGeopackage(dbDataStream, baseFileName, shapefileCreator.createLabelClusterGeopackage, inline)
-              case _ => // Default to GeoJSON.
-                outputGeoJSON(dbDataStream, inline, baseFileName + ".json")
-            }
-          } catch {
-            case e: Exception =>
-              logger.error(s"Error processing request: ${e.getMessage}", e)
-              Future.successful(
-                InternalServerError(
-                  Json.toJson(
-                    ApiError.internalServerError(s"Error processing request: ${e.getMessage}")
+              }
+              .recoverWith { case NonFatal(e) =>
+                // Ensure writers are closed and temp files removed if streaming or zipping failed.
+                scala.util.Try(clusterWriter.close())
+                scala.util.Try(labelWriter.close())
+                Files.deleteIfExists(clusterCsvPath)
+                Files.deleteIfExists(labelCsvPath)
+                logger.error(s"Error generating label clusters CSV: ${e.getMessage}", e)
+                Future.successful(
+                  InternalServerError(
+                    Json.toJson(ApiError.internalServerError(s"Error processing request: ${e.getMessage}"))
                   )
                 )
-              )
-          }
+              }
+          case Some("csv") =>
+            outputCSV(dbDataStream, LabelClusterForApi.csvHeader, inline, baseFileName + ".csv")
+          case Some("shapefile") if filters.includeRawLabels =>
+            // When raw labels are included, create both clusters and labels shapefiles in the ZIP.
+            shapefileCreator
+              .createLabelClusterShapefileWithLabels(dbDataStream, baseFileName, DEFAULT_BATCH_SIZE)
+              .map {
+                case Some(p) =>
+                  val zipSrc: Source[ByteString, Future[Boolean]] = shapefileCreator.zipShapefile(p, baseFileName)
+                  Ok.chunked(zipSrc)
+                    .as("application/zip")
+                    .withHeaders(CONTENT_DISPOSITION -> s"attachment; filename=$baseFileName.zip")
+                case None =>
+                  InternalServerError("Failed to create shapefile")
+              }
+          case Some("shapefile") =>
+            outputShapefile(
+              dbDataStream,
+              baseFileName,
+              shapefileCreator.createLabelClusterShapefile,
+              shapefileCreator
+            )
+          case Some("geopackage") =>
+            outputGeopackage(dbDataStream, baseFileName, shapefileCreator.createLabelClusterGeopackage, inline)
+          case _ => // Default to GeoJSON.
+            outputGeoJSON(dbDataStream, inline, baseFileName + ".json")
         }
       }
-    } catch {
-      case e: Exception =>
-        logger.error(s"Unexpected error in getLabelClusters: ${e.getMessage}", e)
-        Future.successful(
-          InternalServerError(
-            Json.toJson(
-              ApiError.internalServerError(s"Unexpected error: ${e.getMessage}")
-            )
-          )
-        )
     }
   }
 }

--- a/app/controllers/api/StreetsApiController.scala
+++ b/app/controllers/api/StreetsApiController.scala
@@ -3,7 +3,6 @@ package controllers.api
 import controllers.base.CustomControllerComponents
 import controllers.helper.ShapefilesCreatorHelper
 import models.api.{ApiError, StreetDataForApi, StreetFiltersForApi}
-import models.utils.LatLngBBox
 import org.apache.pekko.stream.scaladsl.Source
 import play.api.libs.json.Json
 import play.silhouette.api.Silhouette
@@ -50,69 +49,21 @@ class StreetsApiController @Inject() (
       filetype: Option[String],
       inline: Option[Boolean]
   ) = silhouette.UserAwareAction.async { implicit request =>
-    // Parse the bbox parameter.
-    val parsedBbox: Option[LatLngBBox] = parseBBoxString(bbox)
+    // Parse bbox and way types.
+    val parsedBbox     = parseBBoxString(bbox)
+    val parsedWayTypes = parseCommaSeparated(wayType)
 
-    // Parse way types (comma-separated).
-    val parsedWayTypes: Option[Seq[String]] = wayType.map(_.split(",").map(_.trim).toSeq)
+    // Collect the first invalid-parameter error, if any.
+    val firstError: Option[ApiError] = Seq(
+      validateBBoxParam(bbox, parsedBbox),
+      validateRegionId(regionId)
+    ).flatten.headOption
 
-    // Handle input parameter error cases.
-    if (bbox.isDefined && parsedBbox.isEmpty) {
-      Future.successful(
-        BadRequest(
-          Json.toJson(
-            ApiError.invalidParameter(
-              "Invalid value for bbox parameter. Expected format: minLng,minLat,maxLng,maxLat.",
-              "bbox"
-            )
-          )
-        )
-      )
-    } else if (regionId.isDefined && regionId.get <= 0) {
-      Future.successful(
-        BadRequest(
-          Json.toJson(
-            ApiError.invalidParameter(
-              "Invalid regionId value. Must be a positive integer.",
-              "regionId"
-            )
-          )
-        )
-      )
-    } else {
-
-      configService.getCityMapParams.flatMap { cityMapParams =>
-        // If bbox isn't provided, use city defaults.
-        val apiBox: LatLngBBox = parsedBbox.getOrElse(
-          LatLngBBox(
-            minLng = Math.min(cityMapParams.lng1, cityMapParams.lng2),
-            minLat = Math.min(cityMapParams.lat1, cityMapParams.lat2),
-            maxLng = Math.max(cityMapParams.lng1, cityMapParams.lng2),
-            maxLat = Math.max(cityMapParams.lat1, cityMapParams.lat2)
-          )
-        )
-
-        // Apply filter precedence logic. If bbox is defined, it takes precedence over region filters.
-        val finalBbox: Option[LatLngBBox] = if (bbox.isDefined && parsedBbox.isDefined) {
-          parsedBbox
-        } else if (regionId.isDefined || regionName.isDefined) {
-          None // If region filters are used, bbox should be None.
-        } else {
-          Some(apiBox) // Default city bbox.
-        }
-
-        // Apply region filter precedence logic. If bbox is defined, ignore region filters.
-        val finalRegionId = if (bbox.isDefined && parsedBbox.isDefined) {
-          None // If regionId is defined, it takes precedence over regionName.
-        } else {
-          regionId
-        }
-
-        val finalRegionName = if (bbox.isDefined && parsedBbox.isDefined || regionId.isDefined) {
-          None
-        } else {
-          regionName
-        }
+    firstError match {
+      case Some(error) => Future.successful(badRequest(error))
+      case None =>
+        configService.getCityMapParams.flatMap { cityMapParams =>
+        val (finalBbox, finalRegionId, finalRegionName) = resolveGeoFilters(bbox, parsedBbox, regionId, regionName, cityMapParams)
 
         // Create filters object.
         val filters = StreetFiltersForApi(

--- a/app/controllers/api/ValidationApiController.scala
+++ b/app/controllers/api/ValidationApiController.scala
@@ -4,7 +4,6 @@ import controllers.base.CustomControllerComponents
 import models.api.{ApiError, ValidationDataForApi, ValidationFiltersForApi}
 import models.validation.ValidationOption
 import org.apache.pekko.stream.scaladsl.Source
-import play.api.i18n.Lang.logger
 import play.api.libs.json.Json
 import play.silhouette.api.Silhouette
 import service.ApiService
@@ -60,72 +59,47 @@ class ValidationApiController @Inject() (
       inline: Option[Boolean]
   ) = silhouette.UserAwareAction.async { implicit request =>
     cc.loggingService.insert(request.identity.map(_.userId), request.ipAddress, request.toString)
-    try {
-      // Parse and validate the timestamp (malformed values are reported rather than silently dropped).
-      val parsedTimestamp = parseDateTimeParam(validationTimestamp, "validationTimestamp")
 
-      // Parse the validation result string into the enum (None if absent or invalid; invalid is rejected below).
-      val parsedValidationResult: Option[ValidationOption.Value] = validationResult.flatMap(ValidationOption.fromString)
+    // Parse and validate the timestamp (malformed values are reported rather than silently dropped).
+    val parsedTimestamp = parseDateTimeParam(validationTimestamp, "validationTimestamp")
 
-      // Create filters object.
-      val filters = ValidationFiltersForApi(
-        labelId = labelId, userId = userId, validationResult = parsedValidationResult, labelTypeId = labelTypeId,
-        validationTimestamp = parsedTimestamp.toOption.flatten, changedTags = changedTags,
-        changedSeverityLevels = changedSeverityLevels
-      )
+    // Parse the validation result string into the enum (None if absent or invalid; invalid is rejected below).
+    val parsedValidationResult: Option[ValidationOption.Value] = validationResult.flatMap(ValidationOption.fromString)
 
-      // Collect the first invalid-parameter error, if any.
-      val firstError: Option[ApiError] = Seq(
-        parsedTimestamp.left.toOption,
-        if (validationResult.isDefined && parsedValidationResult.isEmpty)
-          Some(ApiError.invalidParameter(
-            "Invalid validationResult value. Must be Agree, Disagree, or Unsure.", "validationResult"))
-        else None,
-        // Shapefiles are unsupported because validations have no geographic coordinates.
-        if (filetype.contains("shapefile"))
-          Some(ApiError.invalidParameter(
-            "Shapefile format is not supported for validation data. Validations do not contain geographic " +
-              "coordinates. Use 'json' or 'csv' format instead.", "filetype"))
-        else None
-      ).flatten.headOption
+    // Collect the first invalid-parameter error, if any.
+    val firstError: Option[ApiError] = Seq(
+      parsedTimestamp.left.toOption,
+      if (validationResult.isDefined && parsedValidationResult.isEmpty)
+        Some(ApiError.invalidParameter(
+          "Invalid validationResult value. Must be Agree, Disagree, or Unsure.", "validationResult"))
+      else None,
+      // Shapefiles are unsupported because validations have no geographic coordinates.
+      if (filetype.contains("shapefile"))
+        Some(ApiError.invalidParameter(
+          "Shapefile format is not supported for validation data. Validations do not contain geographic " +
+            "coordinates. Use 'json' or 'csv' format instead.", "filetype"))
+      else None
+    ).flatten.headOption
 
-      firstError match {
-        case Some(error) => Future.successful(badRequest(error))
-        case None =>
-          try {
-            // Get the data stream.
-            val dbDataStream: Source[ValidationDataForApi, _] = apiService.getValidations(filters, DEFAULT_BATCH_SIZE)
-            val baseFileName: String                          = s"validations_${OffsetDateTime.now()}"
-
-            // Output data in the appropriate file format.
-            filetype match {
-              case Some("csv") =>
-                outputCSV(dbDataStream, ValidationDataForApi.csvHeader, inline, baseFileName + ".csv")
-              case _ => // Default to JSON
-                outputJSON(dbDataStream, inline, baseFileName + ".json")
-            }
-          } catch {
-            case e: Exception =>
-              logger.error(s"Error processing request: ${e.getMessage}", e)
-              Future.successful(
-                InternalServerError(
-                  Json.toJson(
-                    ApiError.internalServerError(s"Error processing request: ${e.getMessage}")
-                  )
-                )
-              )
-          }
-      }
-    } catch {
-      case e: Exception =>
-        logger.error(s"Unexpected error in getValidations: ${e.getMessage}", e)
-        Future.successful(
-          InternalServerError(
-            Json.toJson(
-              ApiError.internalServerError(s"Unexpected error: ${e.getMessage}")
-            )
-          )
+    firstError match {
+      case Some(error) => Future.successful(badRequest(error))
+      case None =>
+        // Create filters object and get the data stream.
+        val filters = ValidationFiltersForApi(
+          labelId = labelId, userId = userId, validationResult = parsedValidationResult, labelTypeId = labelTypeId,
+          validationTimestamp = parsedTimestamp.toOption.flatten, changedTags = changedTags,
+          changedSeverityLevels = changedSeverityLevels
         )
+        val dbDataStream: Source[ValidationDataForApi, _] = apiService.getValidations(filters, DEFAULT_BATCH_SIZE)
+        val baseFileName: String                          = s"validations_${OffsetDateTime.now()}"
+
+        // Output data in the appropriate file format.
+        filetype match {
+          case Some("csv") =>
+            outputCSV(dbDataStream, ValidationDataForApi.csvHeader, inline, baseFileName + ".csv")
+          case _ => // Default to JSON
+            outputJSON(dbDataStream, inline, baseFileName + ".json")
+        }
     }
   }
 
@@ -139,28 +113,13 @@ class ValidationApiController @Inject() (
    * @return JSON response containing validation result type information
    */
   def getValidationResultTypes = silhouette.UserAwareAction.async { implicit request =>
-    try {
-      apiService.getValidationResultTypes
-        .map { validationTypes =>
-          cc.loggingService.insert(request.identity.map(_.userId), request.ipAddress, request.toString)
-          Ok(Json.obj("status" -> "OK", "validation_result_types" -> validationTypes))
-        }
-        .recover { case e: Exception =>
-          logger.error(s"Error retrieving validation result types: ${e.getMessage}", e)
-          InternalServerError(
-            Json.toJson(
-              ApiError.internalServerError(s"Error retrieving validation result types: ${e.getMessage}")
-            )
-          )
-        }
-    } catch {
-      case e: Exception =>
-        logger.error(s"Unexpected error in getValidationResultTypes: ${e.getMessage}", e)
-        Future.successful(
-          InternalServerError(
-            Json.toJson(ApiError.internalServerError(s"Unexpected error: ${e.getMessage}"))
-          )
-        )
-    }
+    apiService.getValidationResultTypes
+      .map { validationTypes =>
+        cc.loggingService.insert(request.identity.map(_.userId), request.ipAddress, request.toString)
+        Ok(Json.obj("status" -> "OK", "validation_result_types" -> validationTypes))
+      }
+      .recover { case e: Exception =>
+        InternalServerError(Json.toJson(ApiError.internalServerError(s"Error retrieving validation result types: ${e.getMessage}")))
+      }
   }
 }

--- a/test/controllers/api/BaseApiControllerSpec.scala
+++ b/test/controllers/api/BaseApiControllerSpec.scala
@@ -1,0 +1,104 @@
+package controllers.api
+
+import models.utils.{LatLngBBox, MapParams}
+import org.scalatestplus.play.PlaySpec
+
+/**
+ * Unit tests for the pure geo-filter helpers on the BaseApiController companion object.
+ *
+ * These functions contain the shared precedence logic used by LabelApiController,
+ * LabelClustersApiController, and StreetsApiController. Testing them directly (without any DI or DB)
+ * keeps the tests fast and makes regressions easy to pinpoint.
+ */
+class BaseApiControllerSpec extends PlaySpec {
+
+  private val cityParams = MapParams(centerLat = 47.6, centerLng = -122.35, zoom = 12,
+                                     lat1 = 47.5, lng1 = -122.45, lat2 = 47.7, lng2 = -122.25)
+  private val explicitBox = LatLngBBox(minLng = -1.0, minLat = -1.0, maxLng = 1.0, maxLat = 1.0)
+
+  "BaseApiController.validateBBoxParam" should {
+    "return None when bbox is absent" in {
+      BaseApiController.validateBBoxParam(None, None) mustBe None
+    }
+    "return None when bbox is present and successfully parsed" in {
+      BaseApiController.validateBBoxParam(Some("0,0,1,1"), Some(explicitBox)) mustBe None
+    }
+    "return an ApiError(parameter=bbox) when bbox is present but failed to parse" in {
+      val err = BaseApiController.validateBBoxParam(Some("not-a-bbox"), None)
+      err mustBe defined
+      err.get.parameter mustBe Some("bbox")
+    }
+  }
+
+  "BaseApiController.validateRegionId" should {
+    "return None when regionId is absent" in {
+      BaseApiController.validateRegionId(None) mustBe None
+    }
+    "return None when regionId is a positive integer" in {
+      BaseApiController.validateRegionId(Some(1)) mustBe None
+      BaseApiController.validateRegionId(Some(99999)) mustBe None
+    }
+    "return an ApiError(parameter=regionId) when regionId is zero" in {
+      val err = BaseApiController.validateRegionId(Some(0))
+      err mustBe defined
+      err.get.parameter mustBe Some("regionId")
+    }
+    "return an ApiError(parameter=regionId) when regionId is negative" in {
+      val err = BaseApiController.validateRegionId(Some(-5))
+      err mustBe defined
+      err.get.parameter mustBe Some("regionId")
+    }
+  }
+
+  "BaseApiController.resolveGeoFilters" should {
+    "use the explicit bbox and ignore region filters when bbox is valid" in {
+      val (bbox, rid, rname) = BaseApiController.resolveGeoFilters(
+        Some("..."), Some(explicitBox), Some(1), Some("Seattle"), cityParams)
+      bbox mustBe Some(explicitBox)
+      rid mustBe None   // regionId discarded: bbox wins
+      rname mustBe None // regionName discarded: bbox wins
+    }
+
+    "pass regionId through and clear regionName when only regionId is supplied" in {
+      val (bbox, rid, rname) = BaseApiController.resolveGeoFilters(
+        None, None, Some(5), Some("Seattle"), cityParams)
+      bbox mustBe None
+      rid mustBe Some(5)
+      rname mustBe None // regionId takes precedence over regionName
+    }
+
+    "pass regionName through when only regionName is supplied" in {
+      val (bbox, rid, rname) = BaseApiController.resolveGeoFilters(
+        None, None, None, Some("Seattle"), cityParams)
+      bbox mustBe None
+      rid mustBe None
+      rname mustBe Some("Seattle")
+    }
+
+    "fall back to the city-default bbox when no filter is provided" in {
+      val (bbox, rid, rname) = BaseApiController.resolveGeoFilters(
+        None, None, None, None, cityParams)
+      rid mustBe None
+      rname mustBe None
+      bbox mustBe defined
+      // Default box uses min/max of the two city corner params.
+      bbox.get.minLng mustBe Math.min(cityParams.lng1, cityParams.lng2)
+      bbox.get.maxLng mustBe Math.max(cityParams.lng1, cityParams.lng2)
+      bbox.get.minLat mustBe Math.min(cityParams.lat1, cityParams.lat2)
+      bbox.get.maxLat mustBe Math.max(cityParams.lat1, cityParams.lat2)
+    }
+  }
+
+  "BaseApiController.parseCommaSeparated" should {
+    "return None when the parameter is absent" in {
+      BaseApiController.parseCommaSeparated(None) mustBe None
+    }
+    "split a single value into a one-element Seq" in {
+      BaseApiController.parseCommaSeparated(Some("CurbRamp")) mustBe Some(Seq("CurbRamp"))
+    }
+    "split and trim a comma-separated list" in {
+      BaseApiController.parseCommaSeparated(Some("CurbRamp, NoCurbRamp , Obstacle")) mustBe
+        Some(Seq("CurbRamp", "NoCurbRamp", "Obstacle"))
+    }
+  }
+}

--- a/test/controllers/api/PublicApiSpec.scala
+++ b/test/controllers/api/PublicApiSpec.scala
@@ -104,6 +104,12 @@ class PublicApiSpec extends PlaySpec with GuiceOneAppPerSuite {
     // A tiny bbox far from any city keeps the streamed success body cheap while still exercising the happy path.
     val emptyBbox = "0,0,0.001,0.001"
 
+    "reject a non-positive regionId with 400 (parameter=regionId)" in {
+      val resp = route(app, FakeRequest(GET, "/v3/api/rawLabels?regionId=-1")).get
+      status(resp) mustBe BAD_REQUEST
+      (contentAsJson(resp) \ "parameter").as[String] mustBe "regionId"
+    }
+
     "reject an invalid validationStatus with 400 (parameter=validationStatus)" in {
       val resp = route(app, FakeRequest(GET, "/v3/api/rawLabels?validationStatus=not-a-status")).get
       status(resp) mustBe BAD_REQUEST
@@ -157,6 +163,18 @@ class PublicApiSpec extends PlaySpec with GuiceOneAppPerSuite {
   }
 
   "GET /v3/api/labelClusters parameter validation" should {
+    "reject a malformed bbox with 400 (parameter=bbox)" in {
+      val resp = route(app, FakeRequest(GET, "/v3/api/labelClusters?bbox=not-a-bbox")).get
+      status(resp) mustBe BAD_REQUEST
+      (contentAsJson(resp) \ "parameter").as[String] mustBe "bbox"
+    }
+
+    "reject a non-positive regionId with 400 (parameter=regionId)" in {
+      val resp = route(app, FakeRequest(GET, "/v3/api/labelClusters?regionId=0")).get
+      status(resp) mustBe BAD_REQUEST
+      (contentAsJson(resp) \ "parameter").as[String] mustBe "regionId"
+    }
+
     "reject a malformed avgLabelDate with 400 (parameter=avgLabelDate)" in {
       val resp = route(app, FakeRequest(GET, "/v3/api/labelClusters?avgLabelDate=nope")).get
       status(resp) mustBe BAD_REQUEST

--- a/test/controllers/api/StreetsApiSpec.scala
+++ b/test/controllers/api/StreetsApiSpec.scala
@@ -65,6 +65,12 @@ class StreetsApiSpec extends PlaySpec with GuiceOneAppPerSuite {
       status(resp) mustBe BAD_REQUEST
       (contentAsJson(resp) \ "parameter").as[String] mustBe "bbox"
     }
+
+    "return 400 INVALID_PARAMETER for a non-positive regionId" in {
+      val resp = route(app, FakeRequest(GET, "/v3/api/streets?regionId=0")).get
+      status(resp) mustBe BAD_REQUEST
+      (contentAsJson(resp) \ "parameter").as[String] mustBe "regionId"
+    }
   }
 
   "GET /v3/api/streetTypes" should {


### PR DESCRIPTION
## Summary

Eliminates copy-pasted logic that appeared identically in `LabelApiController`, `LabelClustersApiController`, and `StreetsApiController` by extracting four helpers into `BaseApiController`:

- **`validateBBoxParam`** — returns `Option[ApiError]` if bbox was supplied but couldn't be parsed
- **`validateRegionId`** — returns `Option[ApiError]` if regionId is not a positive integer
- **`resolveGeoFilters`** — bbox/regionId/regionName precedence logic + city-default bbox construction (was duplicated verbatim in all three controllers)
- **`parseCommaSeparated`** — parses a comma-separated query parameter into `Option[Seq[String]]`

Additional cleanups:
- `StreetsApiController` converted from an ad-hoc `if/else if` chain to the same `firstError`-Seq + `badRequest(error)` pattern the other controllers use
- Superfluous `try/catch` blocks removed from `ValidationApiController` and `LabelClustersApiController` — those blocks wrapped async `Future`-returning code where they couldn't catch async failures, and `LabelApiController` correctly has none

**Net: −125 lines. All 38 tests green, warning-clean. All error-path 400s verified live.**

## Test plan

- [x] `sbt --client compile` — warning-clean
- [x] `sbt --client test` — 38/38 passed
- [x] Live curl: `?bbox=bad`, `?regionId=-1`, `?validationStatus=garbage`, `?startDate=notadate` all return `400` with correct `parameter` field on rawLabels, streets, labelClusters, and validations endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)