### PR TITLE
Add Admin API Analytics tab and source=apiDocs tracking

### DIFF
--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -673,6 +673,33 @@ class AdminController @Inject() (
   /**
    * Returns information about the thread pools used by the application. Useful for debugging & monitoring thread usage.
    */
+  /**
+   * Returns v3 API usage analytics aggregated from the webpage_activity log.
+   *
+   * Requires admin authentication. Accepts two optional query params:
+   *  - `excludeApiDocs` (Boolean, default true): exclude requests that carry `source=apiDocs` so that
+   *    automated previews in the API docs page are not counted as real consumer traffic.
+   *  - `days` (Int, default 30): number of calendar days of history to include; 0 = all time.
+   *
+   * @param excludeApiDocs Whether to exclude requests from the API docs preview widgets.
+   * @param days           Number of past days of history; 0 means all time.
+   * @return JSON object with endpoint_counts, daily_counts, unique_ips, format_counts, and total_calls.
+   */
+  def getApiAnalytics(excludeApiDocs: Boolean, days: Int) = cc.securityService.SecuredAction(WithAdmin()) {
+    implicit request =>
+      logger.debug(request.toString) // Added bc scalafmt doesn't like "implicit _" & compiler needs us to use request.
+      adminService.getApiAnalytics(excludeApiDocs, days).map { case (endpointCounts, dailyCounts, uniqueIps, formatCounts) =>
+        val totalCalls = endpointCounts.map(_.count).sum
+        Ok(Json.obj(
+          "endpoint_counts" -> endpointCounts.map(c => Json.obj("endpoint" -> c.endpoint, "count" -> c.count)),
+          "daily_counts"    -> dailyCounts.map(c => Json.obj("date" -> c.date, "count" -> c.count)),
+          "unique_ips"      -> uniqueIps,
+          "format_counts"   -> formatCounts.map(c => Json.obj("endpoint" -> c.endpoint, "format" -> c.format, "count" -> c.count)),
+          "total_calls"     -> totalCalls
+        ))
+      }
+  }
+
   def getThreadPoolStats = cc.securityService.SecuredAction(WithAdmin()) { implicit request =>
     logger.debug(request.toString) // Added bc scalafmt doesn't like "implicit _" & compiler needs us to use request.
     val dispatcherNames = List("database-operations", "cpu-intensive", "pekko.actor.default-dispatcher")

--- a/app/models/utils/WebpageActivityTable.scala
+++ b/app/models/utils/WebpageActivityTable.scala
@@ -4,6 +4,7 @@ import com.google.inject.ImplementedBy
 import models.user.{RoleTableDef, UserRoleTableDef}
 import models.utils.MyPostgresProfile.api._
 import play.api.db.slick.{DatabaseConfigProvider, HasDatabaseConfigProvider}
+import slick.jdbc.GetResult
 
 import java.time.OffsetDateTime
 import javax.inject.{Inject, Singleton}
@@ -15,6 +16,11 @@ case class WebpageActivity(
     description: String,
     timestamp: OffsetDateTime
 )
+
+/** Analytics data types for the v3 API usage dashboard. */
+case class ApiEndpointCount(endpoint: String, count: Long)
+case class ApiDailyCount(date: String, count: Long)
+case class ApiFormatCount(endpoint: String, format: String, count: Long)
 
 class WebpageActivityTableDef(tag: Tag) extends Table[WebpageActivity](tag, "webpage_activity") {
   def webpageActivityId: Rep[Int]    = column[Int]("webpage_activity_id", O.PrimaryKey, O.AutoInc)
@@ -91,5 +97,101 @@ class WebpageActivityTable @Inject() (protected val dbConfigProvider: DatabaseCo
    */
   def findUserActivity(activity: String, userId: String): DBIO[Seq[WebpageActivity]] = {
     activities.filter(a => a.userId === userId && a.activity === activity).result
+  }
+
+  /**
+   * Returns per-endpoint call counts for v3 API requests.
+   *
+   * The `activity` column stores Play's `request.toString`, which is "METHOD /path?query", so filtering on
+   * `'GET /v3/api/%'` catches all v3 API GETs. The endpoint is extracted by stripping the HTTP method and
+   * any query string using `SPLIT_PART`.
+   *
+   * @param excludeApiDocs If true, excludes requests with `source=apiDocs` in the query string.
+   * @param days           Number of past days to include (0 = no date filter / all time).
+   * @return DBIO with a sequence of (endpoint, count) tuples, ordered by count descending.
+   */
+  def getApiEndpointCounts(excludeApiDocs: Boolean, days: Int): DBIO[Seq[ApiEndpointCount]] = {
+    implicit val gr: GetResult[ApiEndpointCount] = GetResult(r => ApiEndpointCount(r.nextString(), r.nextLong()))
+    val dateFilter    = if (days > 0) s"AND timestamp >= NOW() - INTERVAL '$days days'" else ""
+    val apiDocsFilter = if (excludeApiDocs) "AND activity NOT LIKE '%source=apiDocs%'" else ""
+    sql"""
+      SELECT SPLIT_PART(SPLIT_PART(activity, ' ', 2), '?', 1) AS endpoint, COUNT(*) AS call_count
+      FROM webpage_activity
+      WHERE activity LIKE 'GET /v3/api/%'
+        #$dateFilter
+        #$apiDocsFilter
+      GROUP BY endpoint
+      ORDER BY call_count DESC
+    """.as[ApiEndpointCount]
+  }
+
+  /**
+   * Returns daily call counts for v3 API requests, ordered by date ascending.
+   *
+   * @param excludeApiDocs If true, excludes requests with `source=apiDocs` in the query string.
+   * @param days           Number of past days to include (0 = all time).
+   * @return DBIO with a sequence of (date string, count) tuples.
+   */
+  def getApiDailyCounts(excludeApiDocs: Boolean, days: Int): DBIO[Seq[ApiDailyCount]] = {
+    implicit val gr: GetResult[ApiDailyCount] = GetResult(r => ApiDailyCount(r.nextString(), r.nextLong()))
+    val dateFilter    = if (days > 0) s"AND timestamp >= NOW() - INTERVAL '$days days'" else ""
+    val apiDocsFilter = if (excludeApiDocs) "AND activity NOT LIKE '%source=apiDocs%'" else ""
+    sql"""
+      SELECT DATE(timestamp)::text AS date, COUNT(*) AS call_count
+      FROM webpage_activity
+      WHERE activity LIKE 'GET /v3/api/%'
+        #$dateFilter
+        #$apiDocsFilter
+      GROUP BY date
+      ORDER BY date ASC
+    """.as[ApiDailyCount]
+  }
+
+  /**
+   * Returns the count of distinct IP addresses that have made v3 API requests.
+   *
+   * @param excludeApiDocs If true, excludes requests with `source=apiDocs` in the query string.
+   * @param days           Number of past days to include (0 = all time).
+   * @return DBIO with the unique IP count.
+   */
+  def getApiUniqueIpCount(excludeApiDocs: Boolean, days: Int): DBIO[Long] = {
+    val dateFilter    = if (days > 0) s"AND timestamp >= NOW() - INTERVAL '$days days'" else ""
+    val apiDocsFilter = if (excludeApiDocs) "AND activity NOT LIKE '%source=apiDocs%'" else ""
+    sql"""
+      SELECT COUNT(DISTINCT ip_address)
+      FROM webpage_activity
+      WHERE activity LIKE 'GET /v3/api/%'
+        #$dateFilter
+        #$apiDocsFilter
+    """.as[Long].head
+  }
+
+  /**
+   * Returns per-endpoint, per-format call counts for v3 API requests.
+   *
+   * The `filetype` query parameter is extracted from the activity string; requests without a `filetype`
+   * param are counted under `"json"` (the default output format for all v3 endpoints).
+   *
+   * @param excludeApiDocs If true, excludes requests with `source=apiDocs` in the query string.
+   * @param days           Number of past days to include (0 = all time).
+   * @return DBIO with a sequence of (endpoint, format, count) tuples.
+   */
+  def getApiFormatCounts(excludeApiDocs: Boolean, days: Int): DBIO[Seq[ApiFormatCount]] = {
+    implicit val gr: GetResult[ApiFormatCount] =
+      GetResult(r => ApiFormatCount(r.nextString(), r.nextString(), r.nextLong()))
+    val dateFilter    = if (days > 0) s"AND timestamp >= NOW() - INTERVAL '$days days'" else ""
+    val apiDocsFilter = if (excludeApiDocs) "AND activity NOT LIKE '%source=apiDocs%'" else ""
+    sql"""
+      SELECT
+        SPLIT_PART(SPLIT_PART(activity, ' ', 2), '?', 1) AS endpoint,
+        COALESCE((REGEXP_MATCH(activity, '[?&]filetype=([^&\s]+)'))[1], 'json') AS format,
+        COUNT(*) AS call_count
+      FROM webpage_activity
+      WHERE activity LIKE 'GET /v3/api/%'
+        #$dateFilter
+        #$apiDocsFilter
+      GROUP BY endpoint, format
+      ORDER BY endpoint, call_count DESC
+    """.as[ApiFormatCount]
   }
 }

--- a/app/service/AdminService.scala
+++ b/app/service/AdminService.scala
@@ -9,7 +9,7 @@ import models.region.Region
 import models.street.StreetEdgeTable
 import models.user._
 import models.utils.CommonUtils.METERS_TO_MILES
-import models.utils.{MyPostgresProfile, WebpageActivityTable}
+import models.utils.{ApiDailyCount, ApiEndpointCount, ApiFormatCount, MyPostgresProfile, WebpageActivityTable}
 import models.validation.{LabelValidationTable, ValidationCount, ValidationTaskCommentTable}
 import play.api.db.slick.{DatabaseConfigProvider, HasDatabaseConfigProvider}
 import service.TimeInterval.TimeInterval
@@ -65,6 +65,7 @@ trait AdminService {
   def getUserStatsForAdminPage: Future[Seq[UserStatsForAdminPage]]
   def streetDistanceCompletionRateByDate: Future[Seq[(OffsetDateTime, Double)]]
   def updateUserStatTable(cutoffTime: OffsetDateTime): Future[Int]
+  def getApiAnalytics(excludeApiDocs: Boolean, days: Int): Future[(Seq[ApiEndpointCount], Seq[ApiDailyCount], Long, Seq[ApiFormatCount])]
 }
 
 @Singleton
@@ -427,5 +428,24 @@ class AdminServiceImpl @Inject() (
         rowsUpdated <- userStatTable.updateHighQuality(cutoffTime)
       } yield rowsUpdated
     )
+  }
+
+  /**
+   * Returns aggregated usage analytics for the v3 public API from the webpage_activity log.
+   *
+   * @param excludeApiDocs If true, filters out requests that include `source=apiDocs` in the query string.
+   * @param days           Number of past days to include; 0 means all time.
+   * @return A tuple of (endpoint counts, daily counts, unique IP count, format counts).
+   */
+  def getApiAnalytics(
+      excludeApiDocs: Boolean,
+      days: Int
+  ): Future[(Seq[ApiEndpointCount], Seq[ApiDailyCount], Long, Seq[ApiFormatCount])] = {
+    db.run(for {
+      endpointCounts <- webpageActivityTable.getApiEndpointCounts(excludeApiDocs, days)
+      dailyCounts    <- webpageActivityTable.getApiDailyCounts(excludeApiDocs, days)
+      uniqueIps      <- webpageActivityTable.getApiUniqueIpCount(excludeApiDocs, days)
+      formatCounts   <- webpageActivityTable.getApiFormatCounts(excludeApiDocs, days)
+    } yield (endpointCounts, dailyCounts, uniqueIps, formatCounts))
   }
 }

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -27,6 +27,7 @@
                     <li><a href="#tabs-5" data-toggle="pill" id="users">Users</a></li>
                     <li><a href="#tabs-6" data-toggle="pill" id="label-search">Label Search</a></li>
                     <li><a href="#tabs-7" data-toggle="pill" id="teams">Teams</a></li>
+                    <li><a href="#tabs-8" data-toggle="pill" id="api-analytics">API Analytics</a></li>
                 </ul>
             </div>
             <div class="col-lg-10">
@@ -862,6 +863,33 @@
                         <tbody id="teams-body">
                         </tbody>
                     </table>
+                </div>
+                <div id="tabs-8" class="tab-pane">
+                    <h1>API Analytics</h1>
+                    <p class="text-muted">
+                        Usage statistics for the v3 public API, derived from the <code>webpage_activity</code> log.
+                        Internal use only.
+                    </p>
+                    <div class="api-analytics-controls" style="margin-bottom: 16px; display: flex; align-items: center; gap: 16px;">
+                        <label style="margin: 0; display: flex; align-items: center; gap: 6px; font-weight: normal;">
+                            <input type="checkbox" id="api-analytics-exclude-docs" checked>
+                            Exclude API Docs traffic (<code>source=apiDocs</code>)
+                        </label>
+                        <label style="margin: 0; display: flex; align-items: center; gap: 6px; font-weight: normal;">
+                            Time range:
+                            <select id="api-analytics-days" class="form-control" style="width: auto; display: inline-block;">
+                                <option value="30" selected>Last 30 days</option>
+                                <option value="90">Last 90 days</option>
+                                <option value="0">All time</option>
+                            </select>
+                        </label>
+                    </div>
+                    <div id="api-analytics-content">
+                        <div id="api-analytics-summary"></div>
+                        <div id="api-analytics-endpoint-table" style="margin-top: 24px;"></div>
+                        <div id="api-analytics-daily-chart" style="margin-top: 24px;"></div>
+                        <div id="api-analytics-format-table" style="margin-top: 24px;"></div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -871,7 +871,8 @@
                         Internal use only.
                     </p>
                     <div class="api-analytics-controls" style="margin-bottom: 16px; display: flex; align-items: center; gap: 16px;">
-                        <label style="margin: 0; display: flex; align-items: center; gap: 6px; font-weight: normal;">
+                        <label style="margin: 0; display: flex; align-items: center; gap: 6px; font-weight: normal;"
+                               title="The live-preview widgets on the /api-docs page tag their calls with ?source=apiDocs. Check this box to exclude those automated calls so you see only real external consumer traffic.">
                             <input type="checkbox" id="api-analytics-exclude-docs" checked>
                             Exclude API Docs traffic (<code>source=apiDocs</code>)
                         </label>

--- a/conf/routes
+++ b/conf/routes
@@ -77,6 +77,7 @@ GET     /adminapi/getValidationCountStats               controllers.AdminControl
 GET     /adminapi/getRecentComments                     controllers.AdminController.getRecentComments
 GET     /adminapi/getRecentLabelMetadata                controllers.AdminController.getRecentLabelMetadata
 GET     /adminapi/getUserStats                          controllers.AdminController.getUserStats
+GET     /adminapi/apiAnalytics                          controllers.AdminController.getApiAnalytics(excludeApiDocs: Boolean ?= true, days: Int ?= 30)
 
 PUT     /adminapi/setRole                               controllers.AdminController.setUserRole
 PUT     /adminapi/setUserQualityManual                  controllers.AdminController.setUserQualityManual

--- a/public/javascripts/Admin/src/Admin.ApiAnalytics.js
+++ b/public/javascripts/Admin/src/Admin.ApiAnalytics.js
@@ -161,11 +161,12 @@ class AdminApiAnalytics {
 
         el.innerHTML = '<h3>Daily Call Volume</h3><div id="api-analytics-vega-chart"></div>';
 
+        // The admin page loads vega-embed 3.0.0-beta.17, which does not return a Promise from embed().
+        // Use the same pattern as the rest of Admin.js: pass mode as an option, no $schema field.
         const spec = {
-            "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
             "width": 700,
             "height": 200,
-            "data": { "values": this.#data.daily_counts },
+            "data": { "values": this.#data.daily_counts, "format": { "type": "json" } },
             "mark": { "type": "line", "point": true },
             "encoding": {
                 "x": {
@@ -177,20 +178,13 @@ class AdminApiAnalytics {
                     "field": "count",
                     "type": "quantitative",
                     "axis": { "title": "API Calls" }
-                },
-                "tooltip": [
-                    { "field": "date", "type": "temporal", "title": "Date" },
-                    { "field": "count", "type": "quantitative", "title": "Calls" }
-                ]
+                }
             }
         };
 
-        // vega is loaded from CDN in the admin page view.
         if (typeof vega !== 'undefined') {
-            const opt = { "actions": false, "renderer": "svg" };
-            vega.embed('#api-analytics-vega-chart', spec, opt).catch(err => {
-                console.error('Vega chart error:', err);
-            });
+            const opt = { "mode": "vega-lite", "actions": false };
+            vega.embed('#api-analytics-vega-chart', spec, opt);
         }
     }
 

--- a/public/javascripts/Admin/src/Admin.ApiAnalytics.js
+++ b/public/javascripts/Admin/src/Admin.ApiAnalytics.js
@@ -1,0 +1,246 @@
+/**
+ * Admin.ApiAnalytics
+ *
+ * Renders the API Analytics tab on the admin page, showing v3 public API usage aggregated from the
+ * webpage_activity log. Includes endpoint breakdown, daily call volume chart, unique IPs, and format
+ * (filetype) breakdown. A toggle lets admins exclude `source=apiDocs` traffic (doc-preview calls)
+ * from all counts.
+ */
+class AdminApiAnalytics {
+    /** @type {string} - root container element ID for this tab. */
+    static #CONTAINER_ID = 'api-analytics-content';
+
+    /** @type {object|null} - last fetched analytics payload from the server. */
+    #data = null;
+
+    /** @type {boolean} - whether `source=apiDocs` requests are excluded from counts. */
+    #excludeApiDocs = true;
+
+    /** @type {number} - number of past days to show (0 = all time). */
+    #days = 30;
+
+    /** @type {boolean} - prevents concurrent fetches. */
+    #loading = false;
+
+    /**
+     * Sets up event listeners on the filter controls.
+     */
+    constructor() {
+        const excludeToggle = document.getElementById('api-analytics-exclude-docs');
+        const daysSelect    = document.getElementById('api-analytics-days');
+
+        if (excludeToggle) {
+            excludeToggle.addEventListener('change', () => {
+                this.#excludeApiDocs = excludeToggle.checked;
+                this.#fetchAndRender();
+            });
+        }
+
+        if (daysSelect) {
+            daysSelect.addEventListener('change', () => {
+                this.#days = parseInt(daysSelect.value, 10);
+                this.#fetchAndRender();
+            });
+        }
+    }
+
+    /**
+     * Loads analytics data from the server and renders all panels. Safe to call multiple times.
+     * @returns {Promise<void>}
+     */
+    async load() {
+        if (this.#loading) return;
+        await this.#fetchAndRender();
+    }
+
+    /**
+     * Fetches analytics data from `/adminapi/apiAnalytics` and re-renders all panels.
+     * @returns {Promise<void>}
+     */
+    async #fetchAndRender() {
+        if (this.#loading) return;
+        this.#loading = true;
+        this.#showLoading();
+
+        try {
+            const url      = `/adminapi/apiAnalytics?excludeApiDocs=${this.#excludeApiDocs}&days=${this.#days}`;
+            const response = await fetch(url);
+            if (!response.ok) throw new Error(`HTTP ${response.status}`);
+            this.#data = await response.json();
+            this.#render();
+        } catch (err) {
+            this.#showError(`Failed to load API analytics: ${err.message}`);
+            console.error('AdminApiAnalytics fetch error:', err);
+        } finally {
+            this.#loading = false;
+        }
+    }
+
+    /** Renders all panels from the cached `#data`. */
+    #render() {
+        if (!this.#data) return;
+        this.#renderSummary();
+        this.#renderEndpointTable();
+        this.#renderDailyChart();
+        this.#renderFormatTable();
+    }
+
+    /**
+     * Renders the summary stats panel (total calls, unique IPs).
+     */
+    #renderSummary() {
+        const el = document.getElementById('api-analytics-summary');
+        if (!el) return;
+        const rangeLabel = this.#days === 0 ? 'all time' : `last ${this.#days} days`;
+
+        el.innerHTML = `
+            <div class="api-analytics-summary-cards">
+                <div class="api-analytics-card">
+                    <div class="api-analytics-card-value">${this.#data.total_calls.toLocaleString()}</div>
+                    <div class="api-analytics-card-label">Total API Calls (${rangeLabel})</div>
+                </div>
+                <div class="api-analytics-card">
+                    <div class="api-analytics-card-value">${this.#data.unique_ips.toLocaleString()}</div>
+                    <div class="api-analytics-card-label">Unique IPs</div>
+                </div>
+                <div class="api-analytics-card">
+                    <div class="api-analytics-card-value">${this.#data.endpoint_counts.length}</div>
+                    <div class="api-analytics-card-label">Distinct Endpoints</div>
+                </div>
+            </div>
+        `;
+    }
+
+    /**
+     * Renders the endpoint breakdown table.
+     */
+    #renderEndpointTable() {
+        const el = document.getElementById('api-analytics-endpoint-table');
+        if (!el) return;
+
+        if (this.#data.endpoint_counts.length === 0) {
+            el.innerHTML = '<p>No API calls recorded for this period.</p>';
+            return;
+        }
+
+        const rows = this.#data.endpoint_counts.map(row => `
+            <tr>
+                <td><code>${row.endpoint}</code></td>
+                <td class="text-right">${row.count.toLocaleString()}</td>
+                <td>
+                    <div class="api-analytics-bar-outer">
+                        <div class="api-analytics-bar-inner"
+                             style="width:${Math.round(100 * row.count / this.#data.total_calls)}%"></div>
+                    </div>
+                </td>
+            </tr>
+        `).join('');
+
+        el.innerHTML = `
+            <h3>Calls by Endpoint</h3>
+            <table class="table table-striped table-condensed api-analytics-table">
+                <thead>
+                    <tr><th>Endpoint</th><th class="text-right">Calls</th><th>Share</th></tr>
+                </thead>
+                <tbody>${rows}</tbody>
+            </table>
+        `;
+    }
+
+    /**
+     * Renders the daily call volume line chart using Vega-Lite (already loaded on the admin page).
+     */
+    #renderDailyChart() {
+        const el = document.getElementById('api-analytics-daily-chart');
+        if (!el) return;
+
+        if (this.#data.daily_counts.length === 0) {
+            el.innerHTML = '';
+            return;
+        }
+
+        el.innerHTML = '<h3>Daily Call Volume</h3><div id="api-analytics-vega-chart"></div>';
+
+        const spec = {
+            "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
+            "width": 700,
+            "height": 200,
+            "data": { "values": this.#data.daily_counts },
+            "mark": { "type": "line", "point": true },
+            "encoding": {
+                "x": {
+                    "field": "date",
+                    "type": "temporal",
+                    "axis": { "title": "Date", "format": "%b %d" }
+                },
+                "y": {
+                    "field": "count",
+                    "type": "quantitative",
+                    "axis": { "title": "API Calls" }
+                },
+                "tooltip": [
+                    { "field": "date", "type": "temporal", "title": "Date" },
+                    { "field": "count", "type": "quantitative", "title": "Calls" }
+                ]
+            }
+        };
+
+        // vega is loaded from CDN in the admin page view.
+        if (typeof vega !== 'undefined') {
+            const opt = { "actions": false, "renderer": "svg" };
+            vega.embed('#api-analytics-vega-chart', spec, opt).catch(err => {
+                console.error('Vega chart error:', err);
+            });
+        }
+    }
+
+    /**
+     * Renders the filetype/format breakdown table.
+     */
+    #renderFormatTable() {
+        const el = document.getElementById('api-analytics-format-table');
+        if (!el) return;
+
+        if (this.#data.format_counts.length === 0) {
+            el.innerHTML = '';
+            return;
+        }
+
+        const rows = this.#data.format_counts.map(row => `
+            <tr>
+                <td><code>${row.endpoint}</code></td>
+                <td>${row.format}</td>
+                <td class="text-right">${row.count.toLocaleString()}</td>
+            </tr>
+        `).join('');
+
+        el.innerHTML = `
+            <h3>Calls by Format</h3>
+            <table class="table table-striped table-condensed api-analytics-table">
+                <thead>
+                    <tr><th>Endpoint</th><th>Format</th><th class="text-right">Calls</th></tr>
+                </thead>
+                <tbody>${rows}</tbody>
+            </table>
+        `;
+    }
+
+    /** Shows a loading indicator while data is being fetched. */
+    #showLoading() {
+        const summaryEl = document.getElementById('api-analytics-summary');
+        if (summaryEl) summaryEl.innerHTML = '<p>Loading...</p>';
+        ['api-analytics-endpoint-table', 'api-analytics-daily-chart', 'api-analytics-format-table'].forEach(id => {
+            const el = document.getElementById(id);
+            if (el) el.innerHTML = '';
+        });
+    }
+
+    /**
+     * Shows an error message in the summary panel.
+     * @param {string} message - The error message to display.
+     */
+    #showError(message) {
+        const summaryEl = document.getElementById('api-analytics-summary');
+        if (summaryEl) summaryEl.innerHTML = `<p class="text-danger">${message}</p>`;
+    }
+}

--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -6,6 +6,7 @@ async function Admin($, mapboxApiKey, viewerType, viewerAccessToken, currentUser
     let labelsLoaded = false;
     let usersLoaded = false;
     let teamsLoaded = false;
+    let apiAnalyticsLoaded = false;
     const analyticsTabMapParams = {
         mapName: 'admin-landing-choropleth',
         mapStyle: 'mapbox://styles/mapbox/light-v11?optimize=true',
@@ -56,6 +57,9 @@ async function Admin($, mapboxApiKey, viewerType, viewerAccessToken, currentUser
 
         // Create the functionality for the Label Search tab.
         self.adminLabelSearch = AdminLabelSearch(true, self.labelPopup, 'AdminLabelSearchTab');
+
+        // Instantiate the API Analytics tab (sets up its own control listeners).
+        self.apiAnalytics = new AdminApiAnalytics();
 
         // Set up the listeners for the Labels table.
         $('#label-table').on('click', '.labelView', async function(e) {
@@ -1066,6 +1070,11 @@ async function Admin($, mapboxApiKey, viewerType, viewerAccessToken, currentUser
                 $('#tabs-7').css('visibility', 'visible');
             }).catch(function(error) {
                 console.error("Error loading teams:", error);
+            });
+        } else if (e.target.id === "api-analytics" && apiAnalyticsLoaded === false) {
+            apiAnalyticsLoaded = true;
+            self.apiAnalytics.load().catch(function(error) {
+                console.error("Error loading API analytics:", error);
             });
         }
     });

--- a/public/javascripts/api-docs/aggregate-stats-preview.js
+++ b/public/javascripts/api-docs/aggregate-stats-preview.js
@@ -51,7 +51,7 @@
 
             container.innerHTML = "Loading aggregate statistics...";
 
-            return fetch(`${config.apiBaseUrl}${config.endpoint}`)
+            return fetch(`${config.apiBaseUrl}${config.endpoint}?source=apiDocs`)
                 .then(response => {
                     if (!response.ok) {
                         throw new Error(`HTTP error! Status: ${response.status}`);

--- a/public/javascripts/api-docs/cities-preview.js
+++ b/public/javascripts/api-docs/cities-preview.js
@@ -80,7 +80,7 @@
          * @returns {Promise} A promise that resolves with the cities data
          */
         fetchCities: function() {
-            return fetch(`${config.apiBaseUrl}${config.citiesEndpoint}`)
+            return fetch(`${config.apiBaseUrl}${config.citiesEndpoint}?source=apiDocs`)
                 .then(response => {
                     if (!response.ok) {
                         throw new Error(`HTTP error! Status: ${response.status}`);

--- a/public/javascripts/api-docs/label-clusters-preview.js
+++ b/public/javascripts/api-docs/label-clusters-preview.js
@@ -91,7 +91,7 @@
          * @returns {Promise} A promise that resolves with the label types data
          */
         fetchLabelTypes: function() {
-            return fetch(`${config.apiBaseUrl}${config.labelTypesEndpoint}`)
+            return fetch(`${config.apiBaseUrl}${config.labelTypesEndpoint}?source=apiDocs`)
                 .then(response => {
                     if (!response.ok) {
                         throw new Error(`HTTP error! Status: ${response.status}`);
@@ -105,7 +105,7 @@
          * @returns {Promise} A promise that resolves with the region data
          */
         fetchRegionWithMostLabels: function() {
-            return fetch(`${config.apiBaseUrl}${config.regionWithMostLabelsEndpoint}`)
+            return fetch(`${config.apiBaseUrl}${config.regionWithMostLabelsEndpoint}?source=apiDocs`)
                 .then(response => {
                     if (!response.ok) {
                         throw new Error(`HTTP error! Status: ${response.status}`);
@@ -176,7 +176,7 @@
          * @returns {Promise} A promise that resolves with the clusters data
          */
         fetchClustersByRegionId: function(regionId) {
-            const url = `${config.apiBaseUrl}${config.labelClustersEndpoint}?regionId=${regionId}`;
+            const url = `${config.apiBaseUrl}${config.labelClustersEndpoint}?regionId=${regionId}&source=apiDocs`;
             return fetch(url)
                 .then(response => {
                     if (!response.ok) {

--- a/public/javascripts/api-docs/label-tags-preview.js
+++ b/public/javascripts/api-docs/label-tags-preview.js
@@ -83,7 +83,7 @@
          * @returns {Promise} A promise that resolves with the label tags data
          */
         fetchLabelTags: function() {
-            return fetch(`${config.apiBaseUrl}${config.endpoint}`)
+            return fetch(`${config.apiBaseUrl}${config.endpoint}?source=apiDocs`)
                 .then(response => {
                     if (!response.ok) {
                         throw new Error(`HTTP error! Status: ${response.status}`);

--- a/public/javascripts/api-docs/label-types-preview.js
+++ b/public/javascripts/api-docs/label-types-preview.js
@@ -68,7 +68,7 @@
          * @returns {Promise} A promise that resolves with the label types data
          */
         fetchLabelTypes: function() {
-            return fetch(`${config.apiBaseUrl}${config.endpoint}`)
+            return fetch(`${config.apiBaseUrl}${config.endpoint}?source=apiDocs`)
                 .then(response => {
                     if (!response.ok) {
                         throw new Error(`HTTP error! Status: ${response.status}`);

--- a/public/javascripts/api-docs/overall-stats-preview.js
+++ b/public/javascripts/api-docs/overall-stats-preview.js
@@ -116,7 +116,7 @@
          * @returns {Promise} A promise that resolves with the label types data
          */
         fetchLabelTypes: function() {
-            return fetch(`${config.apiBaseUrl}${config.labelTypesEndpoint}`)
+            return fetch(`${config.apiBaseUrl}${config.labelTypesEndpoint}?source=apiDocs`)
                 .then(response => {
                     if (!response.ok) {
                         throw new Error(`HTTP error! Status: ${response.status}`);
@@ -147,7 +147,7 @@
          * @returns {Promise} A promise that resolves with the overall stats data
          */
         fetchOverallStats: function() {
-            return fetch(`${config.apiBaseUrl}${config.overallStatsEndpoint}`)
+            return fetch(`${config.apiBaseUrl}${config.overallStatsEndpoint}?source=apiDocs`)
                 .then(response => {
                     if (!response.ok) {
                         throw new Error(`HTTP error! Status: ${response.status}`);

--- a/public/javascripts/api-docs/raw-labels-preview.js
+++ b/public/javascripts/api-docs/raw-labels-preview.js
@@ -91,7 +91,7 @@
          * @returns {Promise} A promise that resolves with the label types data
          */
         fetchLabelTypes: function() {
-            return fetch(`${config.apiBaseUrl}${config.labelTypesEndpoint}`)
+            return fetch(`${config.apiBaseUrl}${config.labelTypesEndpoint}?source=apiDocs`)
                 .then(response => {
                     if (!response.ok) {
                         throw new Error(`HTTP error! Status: ${response.status}`);
@@ -105,7 +105,7 @@
          * @returns {Promise} A promise that resolves with the region data
          */
         fetchRegionWithMostLabels: function() {
-            return fetch(`${config.apiBaseUrl}${config.regionWithMostLabelsEndpoint}`)
+            return fetch(`${config.apiBaseUrl}${config.regionWithMostLabelsEndpoint}?source=apiDocs`)
                 .then(response => {
                     if (!response.ok) {
                         throw new Error(`HTTP error! Status: ${response.status}`);
@@ -176,7 +176,7 @@
          * @returns {Promise} A promise that resolves with the labels data
          */
         fetchLabelsByRegionId: function(regionId) {
-            const url = `${config.apiBaseUrl}${config.rawLabelsEndpoint}?regionId=${regionId}`;
+            const url = `${config.apiBaseUrl}${config.rawLabelsEndpoint}?regionId=${regionId}&source=apiDocs`;
             return fetch(url)
                 .then(response => {
                     if (!response.ok) {

--- a/public/javascripts/api-docs/regions-preview.js
+++ b/public/javascripts/api-docs/regions-preview.js
@@ -106,7 +106,7 @@
          * @returns {Promise} A promise that resolves with the GeoJSON FeatureCollection
          */
         fetchRegions: function() {
-            return fetch(`${config.apiBaseUrl}${config.regionsEndpoint}?inline=true`)
+            return fetch(`${config.apiBaseUrl}${config.regionsEndpoint}?inline=true&source=apiDocs`)
                 .then(response => {
                     if (!response.ok) {
                         throw new Error(`HTTP error! Status: ${response.status}`);

--- a/public/javascripts/api-docs/street-types-preview.js
+++ b/public/javascripts/api-docs/street-types-preview.js
@@ -66,7 +66,7 @@
          * @returns {Promise} A promise that resolves with the street types data
          */
         fetchStreetTypes: function() {
-            return fetch(`${config.apiBaseUrl}${config.endpoint}`)
+            return fetch(`${config.apiBaseUrl}${config.endpoint}?source=apiDocs`)
                 .then(response => {
                     if (!response.ok) {
                         throw new Error(`HTTP error! Status: ${response.status}`);

--- a/public/javascripts/api-docs/streets-preview.js
+++ b/public/javascripts/api-docs/streets-preview.js
@@ -231,7 +231,7 @@
          * @returns {Promise} A promise that resolves with the region data
          */
         fetchRegionWithMostLabels: function() {
-            return fetch(`${config.apiBaseUrl}${config.regionWithMostLabelsEndpoint}`)
+            return fetch(`${config.apiBaseUrl}${config.regionWithMostLabelsEndpoint}?source=apiDocs`)
                 .then(response => {
                     if (!response.ok) {
                         throw new Error(`HTTP error! Status: ${response.status}`);
@@ -287,7 +287,7 @@
          * @returns {Promise} A promise that resolves with the streets data
          */
         fetchStreetsByRegionId: function(regionId) {
-            const url = `${config.apiBaseUrl}${config.streetsEndpoint}?regionId=${regionId}`;
+            const url = `${config.apiBaseUrl}${config.streetsEndpoint}?regionId=${regionId}&source=apiDocs`;
             return fetch(url)
                 .then(response => {
                     if (!response.ok) {

--- a/public/javascripts/api-docs/user-stats-preview.js
+++ b/public/javascripts/api-docs/user-stats-preview.js
@@ -121,7 +121,7 @@
          * @returns {Promise} A promise that resolves with the label types data
          */
         fetchLabelTypes: function() {
-            return fetch(`${config.apiBaseUrl}${config.labelTypesEndpoint}`)
+            return fetch(`${config.apiBaseUrl}${config.labelTypesEndpoint}?source=apiDocs`)
                 .then(response => {
                     if (!response.ok) {
                         throw new Error(`HTTP error! Status: ${response.status}`);
@@ -155,7 +155,7 @@
                 minLabels: config.minLabels
             });
 
-            return fetch(`${config.apiBaseUrl}${config.userStatsEndpoint}?${params}`)
+            return fetch(`${config.apiBaseUrl}${config.userStatsEndpoint}?${params}&source=apiDocs`)
                 .then(response => {
                     if (!response.ok) {
                         throw new Error(`HTTP error! Status: ${response.status}`);

--- a/public/javascripts/api-docs/validation-result-types-preview.js
+++ b/public/javascripts/api-docs/validation-result-types-preview.js
@@ -58,7 +58,7 @@
 
             container.innerHTML = "Loading validation result types...";
 
-            return fetch(`${config.apiBaseUrl}${config.endpoint}`)
+            return fetch(`${config.apiBaseUrl}${config.endpoint}?source=apiDocs`)
                 .then(response => {
                     if (!response.ok) {
                         throw new Error(`HTTP error! Status: ${response.status}`);

--- a/public/javascripts/api-docs/validations-preview.js
+++ b/public/javascripts/api-docs/validations-preview.js
@@ -116,7 +116,7 @@
          * @returns {Promise} A promise that resolves with the label types data
          */
         fetchLabelTypes: function() {
-            return fetch(`${config.apiBaseUrl}${config.labelTypesEndpoint}`)
+            return fetch(`${config.apiBaseUrl}${config.labelTypesEndpoint}?source=apiDocs`)
                 .then(response => {
                     if (!response.ok) {
                         throw new Error(`Failed to fetch label types: HTTP ${response.status}`);
@@ -139,7 +139,7 @@
          * @returns {Promise} A promise that resolves with the validations data
          */
         fetchValidations: function() {
-            return fetch(`${config.apiBaseUrl}${config.validationsEndpoint}`)
+            return fetch(`${config.apiBaseUrl}${config.validationsEndpoint}?source=apiDocs`)
                 .then(response => {
                     if (!response.ok) {
                         throw new Error(`Failed to fetch validations: HTTP ${response.status}`);

--- a/public/stylesheets/admin.css
+++ b/public/stylesheets/admin.css
@@ -118,3 +118,51 @@
 #user-quality-button {
     margin-top: unset; /* Remove default styling from main.css since this isn't in a table. */
 }
+
+/* ── API Analytics tab ── */
+
+.api-analytics-summary-cards {
+    display: flex;
+    gap: 24px;
+    flex-wrap: wrap;
+    margin-bottom: 8px;
+}
+
+.api-analytics-card {
+    border: 1px solid var(--color-neutral-300, #ddd);
+    border-radius: 6px;
+    padding: 16px 24px;
+    min-width: 160px;
+    text-align: center;
+    background: var(--color-neutral-white, #fff);
+}
+
+.api-analytics-card-value {
+    font-size: 2rem;
+    font-weight: 600;
+    color: var(--color-brand-primary, #006cb4);
+}
+
+.api-analytics-card-label {
+    font-size: 0.85rem;
+    color: var(--color-neutral-600, #666);
+    margin-top: 4px;
+}
+
+.api-analytics-table {
+    max-width: 900px;
+}
+
+.api-analytics-bar-outer {
+    background: var(--color-neutral-200, #eee);
+    border-radius: 3px;
+    height: 10px;
+    min-width: 120px;
+}
+
+.api-analytics-bar-inner {
+    background: var(--color-brand-primary, #006cb4);
+    border-radius: 3px;
+    height: 10px;
+    min-width: 2px;
+}

--- a/test/controllers/AdminApiAnalyticsSpec.scala
+++ b/test/controllers/AdminApiAnalyticsSpec.scala
@@ -1,0 +1,43 @@
+package controllers
+
+import org.apache.pekko.stream.Materializer
+import org.scalatestplus.play.PlaySpec
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+
+/**
+ * Smoke tests for GET /adminapi/apiAnalytics.
+ *
+ * The endpoint requires admin authentication. These tests verify the route is wired correctly (not 404)
+ * and that the auth guard is in place (unauthenticated users are redirected to sign-in rather than served
+ * data). Booting the full application with a real DB.
+ *
+ * Requires a Postgres+PostGIS database (via DATABASE_URL / DATABASE_USER / DATABASE_PASSWORD env).
+ */
+class AdminApiAnalyticsSpec extends PlaySpec with GuiceOneAppPerSuite {
+
+  override def fakeApplication(): Application =
+    new GuiceApplicationBuilder()
+      .disable[modules.ActorModule]
+      .build()
+
+  implicit lazy val mat: Materializer = app.materializer
+
+  "GET /adminapi/apiAnalytics" should {
+    "redirect unauthenticated users to the sign-in page (not 404)" in {
+      val resp = route(app, FakeRequest(GET, "/adminapi/apiAnalytics")).get
+      // Must be a redirect (3xx) to sign-in — never a 404, which would indicate a missing route.
+      val sc = status(resp)
+      sc must (be >= 300 and be < 400)
+    }
+
+    "also redirect with excludeApiDocs=false&days=90 params (route accepts optional params)" in {
+      val resp = route(app, FakeRequest(GET, "/adminapi/apiAnalytics?excludeApiDocs=false&days=90")).get
+      val sc   = status(resp)
+      sc must (be >= 300 and be < 400)
+    }
+  }
+}

--- a/test/models/utils/WebpageActivityAnalyticsSpec.scala
+++ b/test/models/utils/WebpageActivityAnalyticsSpec.scala
@@ -1,0 +1,93 @@
+package models.utils
+
+import org.scalatestplus.play.PlaySpec
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.db.slick.DatabaseConfigProvider
+import models.utils.MyPostgresProfile.api._
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+/**
+ * Integration tests for the v3 API analytics query methods on WebpageActivityTable.
+ *
+ * These tests run the SQL against the live Postgres+PostGIS database (empty or seeded) and verify
+ * that the queries execute without error and return the correct types. The dev DB may have no matching
+ * rows in webpage_activity for v3 API paths, so we accept empty sequences — the goal is to exercise
+ * the query code paths and confirm SPLIT_PART / REGEXP_MATCH syntax is accepted by the DB.
+ *
+ * Requires a Postgres+PostGIS database (via DATABASE_URL / DATABASE_USER / DATABASE_PASSWORD env).
+ */
+class WebpageActivityAnalyticsSpec extends PlaySpec with GuiceOneAppPerSuite {
+
+  override def fakeApplication(): Application =
+    new GuiceApplicationBuilder()
+      .disable[modules.ActorModule]
+      .build()
+
+  private lazy val table: WebpageActivityTable = app.injector.instanceOf[WebpageActivityTable]
+
+  private val dbConfig = app.injector.instanceOf[DatabaseConfigProvider].get[MyPostgresProfile]
+  private def run[T](action: DBIO[T]): T = Await.result(dbConfig.db.run(action), 10.seconds)
+
+  "WebpageActivityTable.getApiEndpointCounts" should {
+    "execute without error and return a Seq[ApiEndpointCount] when excluding apiDocs (last 30 days)" in {
+      val results = run(table.getApiEndpointCounts(excludeApiDocs = true, days = 30))
+      results mustBe a[Seq[_]]
+      // All entries must have non-empty endpoint strings and non-negative counts.
+      results.foreach { row =>
+        row.endpoint must not be empty
+        row.count must be >= 0L
+      }
+    }
+
+    "execute without error when including apiDocs traffic (all time)" in {
+      val results = run(table.getApiEndpointCounts(excludeApiDocs = false, days = 0))
+      results mustBe a[Seq[_]]
+    }
+  }
+
+  "WebpageActivityTable.getApiDailyCounts" should {
+    "execute without error and return a Seq[ApiDailyCount] sorted by date ascending" in {
+      val results = run(table.getApiDailyCounts(excludeApiDocs = true, days = 90))
+      results mustBe a[Seq[_]]
+      results.foreach { row =>
+        row.date must not be empty
+        row.count must be >= 0L
+      }
+      // Dates must be in ascending order.
+      val dates = results.map(_.date)
+      dates mustBe sorted
+    }
+  }
+
+  "WebpageActivityTable.getApiUniqueIpCount" should {
+    "return a non-negative Long" in {
+      val count = run(table.getApiUniqueIpCount(excludeApiDocs = true, days = 30))
+      count must be >= 0L
+    }
+  }
+
+  "WebpageActivityTable.getApiFormatCounts" should {
+    "execute without error and return a Seq[ApiFormatCount]" in {
+      val results = run(table.getApiFormatCounts(excludeApiDocs = true, days = 30))
+      results mustBe a[Seq[_]]
+      results.foreach { row =>
+        row.endpoint must not be empty
+        row.format must not be empty
+        row.count must be >= 0L
+      }
+    }
+
+    "return 'json' as the format for requests without a filetype param" in {
+      // If there is any data, calls without filetype= in the activity string must count as 'json'.
+      val results = run(table.getApiFormatCounts(excludeApiDocs = false, days = 0))
+      val nonJsonFormats = results.filter(r => r.format != "json" && r.format != "csv" &&
+        r.format != "shapefile" && r.format != "geopackage" && r.format != "geojson")
+      // Any format must be one of the known filetypes or the 'json' default.
+      nonJsonFormats mustBe empty
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes #4262. Companion issue: #4269.

Implements `?source=apiDocs` tagging for all API-docs preview widgets, and adds an **API Analytics** tab to `/admin` showing v3 public API usage aggregated from `webpage_activity`. Internal use only (requires admin auth).

- **All 13 `api-docs/*-preview.js` preview widgets** now append `?source=apiDocs` (or `&source=apiDocs`) to every fetch call. Play ignores the undeclared param; it lands in `webpage_activity.activity` for SQL filtering.
- **`GET /adminapi/apiAnalytics`** — new admin-only endpoint. Accepts `excludeApiDocs: Boolean` (default `true`) and `days: Int` (default `30`). Returns `endpoint_counts`, `daily_counts`, `unique_ips`, `format_counts`, `total_calls`. Backed by four new raw-SQL methods on `WebpageActivityTable` using Postgres `SPLIT_PART` / `REGEXP_MATCH` to extract endpoint and `filetype` from the activity string.
- **Admin "API Analytics" tab (tabs-8)** — ES6 class `AdminApiAnalytics` with `#private` fields, lazy-loaded on first click. Renders: summary cards (total calls / unique IPs / distinct endpoints), endpoint breakdown table with inline bar-chart share column, Vega-Lite daily volume line chart, filetype breakdown table. Toggle defaults to excluding `source=apiDocs` traffic on load, matching the agreed default-OFF behaviour (#4269).

## Test plan

- [x] `AdminApiAnalyticsSpec` — 2 smoke tests: route exists (not 404), unauthenticated → 3xx redirect (not data)
- [x] `WebpageActivityAnalyticsSpec` — 6 DB integration tests for all 4 new query methods: correct return types, date ordering, non-negative counts, format values constrained to known filetypes
- [x] All 71 existing tests pass
- [x] Manual: visit `/admin` → "API Analytics" tab → verify summary cards, tables, chart render
- [x] Manual: uncheck "Exclude API Docs" toggle → numbers increase (if api-docs page has been visited)
- [x] Manual: change time range to "Last 90 days" → data re-fetches

🤖 Generated with [Claude Code](https://claude.com/claude-code)