### PR TITLE
Add /v3/api/overallStatsByDay and /v3/api/aggregateStatsByDay endpoints (#4274)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,32 @@ Two standalone scripts (run via the Python deps in `requirements.txt`, installed
 - `label_clustering.py` — clusters nearby labels (used by the clustering flow; see `ClusterController.scala` / `app/models/cluster/`).
 - `check_streets_for_imagery.py` — checks streets for available street-view imagery (related: `make hide-streets-without-imagery`).
 
+## Label Type Colors and Icons
+
+Every label type has a **canonical color** and a set of **icon images**. Always use these — never invent substitute colors.
+
+| Label Type     | Color     |
+|----------------|-----------|
+| CurbRamp       | `#90C31F` |
+| NoCurbRamp     | `#E679B6` |
+| Obstacle       | `#78B0EA` |
+| SurfaceProblem | `#F68D3E` |
+| NoSidewalk     | `#BE87D8` |
+| Crosswalk      | `#FABF1C` |
+| Signal         | `#63C0AB` |
+| Other          | `#B3B3B3` |
+| Occlusion      | `#B3B3B3` |
+| Problem        | `#B3B3B3` |
+
+**Icons** live in `public/images/icons/label_type_icons/` in three sizes: `{LabelType}.png` (large),
+`{LabelType}_small.png`, and `{LabelType}_tiny.png`. The canonical source of truth for both colors and icon URLs
+is the `/v3/api/labelTypes` endpoint.
+
+**In JavaScript:** call `util.misc.getLabelColors(labelType)` — defined in
+`public/javascripts/common/UtilitiesSidewalk.js` and loaded on every page that includes
+`app/views/apiDocs/layout.scala.html` or the main app bundles. Do **not** hardcode the hex values in
+feature code; use `getLabelColors()` so colors stay in sync automatically.
+
 ## Development Guidelines
 - Main development branch is **develop**; **master** is the release branch. PRs target `develop`.
 - If there is an associated Github issue, beging the branch name with the issue number (e.g. `1234-fix-label-popup`).

--- a/app/controllers/ApiDocsController.scala
+++ b/app/controllers/ApiDocsController.scala
@@ -159,4 +159,24 @@ class ApiDocsController @Inject() (
       Ok(views.html.apiDocs.aggregateStats(commonData, request.identity))
     }
   }
+
+  /**
+   * Displays API documentation for the overall stats by day (time series).
+   */
+  def overallStatsByDay = cc.securityService.SecuredAction { implicit request =>
+    configService.getCommonPageData(request2Messages.lang).map { commonData =>
+      cc.loggingService.insert(request.identity.userId, request.ipAddress, "Visit_APIDocs_OverallStatsByDay")
+      Ok(views.html.apiDocs.overallStatsByDay(commonData, request.identity))
+    }
+  }
+
+  /**
+   * Displays API documentation for the aggregate stats by day (time series).
+   */
+  def aggregateStatsByDay = cc.securityService.SecuredAction { implicit request =>
+    configService.getCommonPageData(request2Messages.lang).map { commonData =>
+      cc.loggingService.insert(request.identity.userId, request.ipAddress, "Visit_APIDocs_AggregateStatsByDay")
+      Ok(views.html.apiDocs.aggregateStatsByDay(commonData, request.identity))
+    }
+  }
 }

--- a/app/controllers/api/StatsApiController.scala
+++ b/app/controllers/api/StatsApiController.scala
@@ -3,17 +3,18 @@ package controllers.api
 import controllers.base.CustomControllerComponents
 import controllers.helper.ControllerUtils.labelTypeOrdering
 import formats.json.ApiFormats._
-import models.api.ApiError
+import models.api.{ApiError, DailyStatRecord}
 import models.label.ProjectSidewalkStats
 import models.user.UserStatApi
 import play.api.Logger
 import play.api.libs.json.{JsObject, Json}
+import play.api.mvc.Result
 import play.silhouette.api.Silhouette
 import service.{AggregateStats, ApiService, ConfigService}
 
-import java.time.OffsetDateTime
+import java.time.{LocalDate, OffsetDateTime}
 import javax.inject.{Inject, Singleton}
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class StatsApiController @Inject() (
@@ -273,5 +274,116 @@ class StatsApiController @Inject() (
     // Combine all statistics
     val allStats = basicStats ++ labelTypeStats
     header + allStats.mkString("\n")
+  }
+
+  /**
+   * Parses a pair of optional YYYY-MM-DD date strings into Option[LocalDate] values.
+   *
+   * @param startDateStr Optional start date in YYYY-MM-DD format.
+   * @param endDateStr   Optional end date in YYYY-MM-DD format.
+   * @return             Right((startDate, endDate)) on success, Left(ApiError) on bad input.
+   */
+  private def parseDateParams(
+      startDateStr: Option[String],
+      endDateStr: Option[String]
+  ): Either[ApiError, (Option[LocalDate], Option[LocalDate])] = {
+    def parseOpt(opt: Option[String], paramName: String): Either[ApiError, Option[LocalDate]] =
+      opt match {
+        case None => Right(None)
+        case Some(s) =>
+          try Right(Some(LocalDate.parse(s)))
+          catch {
+            case _: Exception =>
+              Left(ApiError.invalidParameter(s"Invalid date '$s': expected YYYY-MM-DD format.", paramName))
+          }
+      }
+    for {
+      start <- parseOpt(startDateStr, "startDate")
+      end   <- parseOpt(endDateStr, "endDate")
+      _ <- (start, end) match {
+        case (Some(s), Some(e)) if s.isAfter(e) =>
+          Left(ApiError.invalidParameter("startDate must not be after endDate.", "startDate"))
+        case _ => Right(())
+      }
+    } yield (start, end)
+  }
+
+  /**
+   * Renders a sequence of DailyStatRecord as JSON or as a downloadable CSV file.
+   *
+   * @param stats    The daily stats to render.
+   * @param filetype Optional "csv" to trigger CSV output; defaults to JSON.
+   * @param baseName Base filename stem for the CSV download (timestamp appended automatically).
+   * @return         Play Result with appropriate content type.
+   */
+  private def renderDailyStats(stats: Seq[DailyStatRecord], filetype: Option[String], baseName: String): Result = {
+    filetype match {
+      case Some("csv") =>
+        val file   = new java.io.File(s"${baseName}_${OffsetDateTime.now()}.csv")
+        val writer = new java.io.PrintStream(file, "UTF-8")
+        writer.print(DailyStatRecord.csvHeader)
+        stats.foreach { r =>
+          writer.println(
+            s"${r.date},${r.labelType},${r.humanLabels},${r.aiLabels}," +
+              s"${r.humanValidationsAgree},${r.humanValidationsDisagree},${r.humanValidationsUnsure}," +
+              s"${r.aiValidationsAgree},${r.aiValidationsDisagree},${r.aiValidationsUnsure}"
+          )
+        }
+        writer.close()
+        Ok.sendFile(content = file, onClose = () => { file.delete(); () })
+      case _ =>
+        Ok(Json.obj("status" -> "OK", "data" -> stats))
+    }
+  }
+
+  /**
+   * Returns daily label and validation counts for the current city split by human vs AI and label type.
+   *
+   * @param startDate        Optional start date (YYYY-MM-DD); no lower bound if absent.
+   * @param endDate          Optional end date (YYYY-MM-DD); no upper bound if absent.
+   * @param filterLowQuality If true, exclude low-quality users. Defaults to false.
+   * @param filetype         Output format: "json" (default) or "csv".
+   * @return                 Daily stats in the requested format.
+   */
+  def getOverallStatsByDay(
+      startDate: Option[String],
+      endDate: Option[String],
+      filterLowQuality: Boolean,
+      filetype: Option[String]
+  ) = silhouette.UserAwareAction.async { implicit request =>
+    parseDateParams(startDate, endDate) match {
+      case Left(err) => Future.successful(BadRequest(Json.toJson(err)))
+      case Right((start, end)) =>
+        apiService.getOverallStatsByDay(start, end, filterLowQuality).map { stats =>
+          cc.loggingService.insert(request.identity.map(_.userId), request.ipAddress, request.toString)
+          renderDailyStats(stats, filetype, "overallStatsByDay")
+        }
+    }
+  }
+
+  /**
+   * Returns daily label and validation counts aggregated across all configured cities, split by human
+   * vs AI and label type.
+   *
+   * @param startDate        Optional start date (YYYY-MM-DD); no lower bound if absent.
+   * @param endDate          Optional end date (YYYY-MM-DD); no upper bound if absent.
+   * @param filterLowQuality If true, exclude low-quality users. Defaults to false.
+   * @param filetype         Output format: "json" (default) or "csv".
+   * @return                 Daily aggregate stats in the requested format.
+   */
+  def getAggregateStatsByDay(
+      startDate: Option[String],
+      endDate: Option[String],
+      filterLowQuality: Boolean,
+      filetype: Option[String]
+  ) = silhouette.UserAwareAction.async { implicit request =>
+    parseDateParams(startDate, endDate) match {
+      case Left(err) => Future.successful(BadRequest(Json.toJson(err)))
+      case Right((start, end)) =>
+        configService.getAggregateStatsByDay(start, end, filterLowQuality).map { stats =>
+          cc.loggingService.insert(request.identity.map(_.userId), request.ipAddress, request.toString)
+          renderDailyStats(stats, filetype, "aggregateStatsByDay")
+        }
+    }
   }
 }

--- a/app/models/api/DailyStatsApiModels.scala
+++ b/app/models/api/DailyStatsApiModels.scala
@@ -1,0 +1,76 @@
+/**
+ * Models for the Project Sidewalk Daily Stats API endpoints
+ * (/v3/api/overallStatsByDay and /v3/api/aggregateStatsByDay). (#4274)
+ */
+package models.api
+
+import play.api.libs.json.{Json, JsonConfiguration, JsonNaming, OWrites}
+
+import java.time.LocalDate
+
+/**
+ * A single record in the daily label-and-validation time series.
+ *
+ * Each record covers one calendar day (in US/Pacific time) and one label type. Label counts are
+ * bucketed by label.time_created; validation counts are bucketed by label_validation.end_timestamp.
+ * The two date dimensions are independent: on a given day a city may place many labels and also
+ * validate labels that were placed on earlier days.
+ *
+ * @param date                       The calendar date (Pacific time).
+ * @param labelType                  Label type name (e.g. "CurbRamp", "NoCurbRamp").
+ * @param humanLabels                Labels placed by human users on this date.
+ * @param aiLabels                   Labels placed by AI users on this date.
+ * @param humanValidationsAgree      Human validations with result "agree" completed on this date.
+ * @param humanValidationsDisagree   Human validations with result "disagree" completed on this date.
+ * @param humanValidationsUnsure     Human validations with result "unsure" completed on this date.
+ * @param aiValidationsAgree         AI validations with result "agree" completed on this date.
+ * @param aiValidationsDisagree      AI validations with result "disagree" completed on this date.
+ * @param aiValidationsUnsure        AI validations with result "unsure" completed on this date.
+ */
+case class DailyStatRecord(
+    date: LocalDate,
+    labelType: String,
+    humanLabels: Int,
+    aiLabels: Int,
+    humanValidationsAgree: Int,
+    humanValidationsDisagree: Int,
+    humanValidationsUnsure: Int,
+    aiValidationsAgree: Int,
+    aiValidationsDisagree: Int,
+    aiValidationsUnsure: Int
+)
+
+object DailyStatRecord {
+  // snake_case JSON output per the v3 API convention (#3871).
+  private implicit val config: JsonConfiguration = JsonConfiguration(JsonNaming.SnakeCase)
+  implicit val writes: OWrites[DailyStatRecord]  = Json.writes[DailyStatRecord]
+
+  val csvHeader: String =
+    "date,label_type,human_labels,ai_labels," +
+      "human_validations_agree,human_validations_disagree,human_validations_unsure," +
+      "ai_validations_agree,ai_validations_disagree,ai_validations_unsure\n"
+
+  /**
+   * Merges label-stat and validation-stat rows (each keyed by date + label_type) into one unified
+   * sequence of DailyStatRecord. Either sequence may have keys the other lacks; missing entries are
+   * filled with zeros.
+   *
+   * @param labels      Rows from the labels-by-day query: (date, labelType, humanLabels, aiLabels).
+   * @param validations Rows from the validations-by-day query: (date, labelType, humanAgree,
+   *                    humanDisagree, humanUnsure, aiAgree, aiDisagree, aiUnsure).
+   * @return            Merged sequence sorted by date then label type.
+   */
+  def merge(
+      labels: Seq[(LocalDate, String, Int, Int)],
+      validations: Seq[(LocalDate, String, Int, Int, Int, Int, Int, Int)]
+  ): Seq[DailyStatRecord] = {
+    val labelMap      = labels.map(r => (r._1, r._2) -> (r._3, r._4)).toMap
+    val validationMap = validations.map(r => (r._1, r._2) -> (r._3, r._4, r._5, r._6, r._7, r._8)).toMap
+    (labelMap.keySet ++ validationMap.keySet).toSeq.sortBy(k => (k._1, k._2)).map { key =>
+      val (date, labelType)         = key
+      val (humanLabels, aiLabels)   = labelMap.getOrElse(key, (0, 0))
+      val (ha, hd, hu, aa, ad, au) = validationMap.getOrElse(key, (0, 0, 0, 0, 0, 0))
+      DailyStatRecord(date, labelType, humanLabels, aiLabels, ha, hd, hu, aa, ad, au)
+    }
+  }
+}

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -26,7 +26,7 @@ import service.TimeInterval.TimeInterval
 import slick.jdbc.GetResult
 import slick.sql.SqlStreamingAction
 
-import java.time.{Duration, Instant, OffsetDateTime, ZoneOffset}
+import java.time.{Duration, Instant, LocalDate, OffsetDateTime, ZoneOffset}
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.ExecutionContext
 
@@ -2205,5 +2205,56 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
       _pd.cameraPitch.asColumnOf[Double],
       _pd.cameraRoll
     )).sortBy(_._1).result
+  }
+
+  /**
+   * Returns daily label counts split by human vs AI creator and label type.
+   *
+   * Labels are bucketed into US/Pacific calendar dates via label.time_created. Tutorial and deleted
+   * labels are always excluded. The quality filter mirrors the convention in getOverallStatsForApi:
+   * when filterLowQuality is false, only administratively excluded users (user_stat.excluded) are
+   * removed; when true, only high-quality users (user_stat.high_quality) are included.
+   *
+   * @param startDate        Inclusive lower bound on label.time_created (date cast to Pacific time);
+   *                         no lower bound if None.
+   * @param endDate          Inclusive upper bound on label.time_created; no upper bound if None.
+   * @param filterLowQuality If true, restrict to user_stat.high_quality users; otherwise exclude
+   *                         only user_stat.excluded users.
+   * @return                 Sequence of (date, labelType, humanLabels, aiLabels), sorted by date
+   *                         then label type.
+   */
+  def getDailyLabelStats(
+      startDate: Option[LocalDate],
+      endDate: Option[LocalDate],
+      filterLowQuality: Boolean
+  ): DBIO[Seq[(LocalDate, String, Int, Int)]] = {
+    // Mirrors the userFilter convention in getOverallStatsForApi.
+    val userFilter = if (filterLowQuality) "user_stat.high_quality" else "NOT user_stat.excluded"
+    val whereClauses = scala.collection.mutable.ListBuffer(
+      "label.deleted = FALSE",
+      "label.tutorial = FALSE",
+      userFilter
+    )
+    startDate.foreach(d => whereClauses += s"label.time_created >= '$d'::date")
+    endDate.foreach(d => whereClauses += s"label.time_created < ('$d'::date + INTERVAL '1 day')")
+    val where = whereClauses.mkString(" AND ")
+
+    implicit val getResult: GetResult[(LocalDate, String, Int, Int)] =
+      GetResult(r => (LocalDate.parse(r.nextString()), r.nextString(), r.nextInt(), r.nextInt()))
+
+    sql"""
+      SELECT CAST((label.time_created AT TIME ZONE 'US/Pacific')::date AS TEXT) AS date,
+             label_type.label_type,
+             COUNT(CASE WHEN role.role IS DISTINCT FROM 'AI' THEN label.label_id END) AS human_labels,
+             COUNT(CASE WHEN role.role = 'AI'               THEN label.label_id END) AS ai_labels
+      FROM label
+      INNER JOIN label_type ON label.label_type_id = label_type.label_type_id
+      INNER JOIN user_stat  ON label.user_id       = user_stat.user_id
+      LEFT  JOIN sidewalk_login.user_role ON label.user_id     = user_role.user_id
+      LEFT  JOIN sidewalk_login.role      ON user_role.role_id = role.role_id
+      WHERE #$where
+      GROUP BY (label.time_created AT TIME ZONE 'US/Pacific')::date, label_type.label_type
+      ORDER BY date ASC, label_type.label_type
+    """.as[(LocalDate, String, Int, Int)]
   }
 }

--- a/app/models/utils/ConfigTable.scala
+++ b/app/models/utils/ConfigTable.scala
@@ -4,7 +4,9 @@ import com.google.inject.ImplementedBy
 import models.utils.MyPostgresProfile.api._
 import play.api.db.slick.{DatabaseConfigProvider, HasDatabaseConfigProvider}
 import service.{AggregateStats, LabelTypeStats}
+import slick.jdbc.GetResult
 
+import java.time.LocalDate
 import javax.inject._
 import scala.concurrent.ExecutionContext
 
@@ -238,5 +240,110 @@ class ConfigTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvi
 
   def getExcludedTagsString: DBIO[Seq[ExcludedTag]] = {
     config.map(_.excludedTags).result.head
+  }
+
+  /**
+   * Returns daily label counts split by human vs AI creator and label type for a specific city schema.
+   *
+   * This is the cross-schema variant of LabelTable.getDailyLabelStats, used by the aggregate
+   * endpoint to query each city schema in turn.
+   *
+   * @param schema           Database schema to query (e.g. "sidewalk_seattle").
+   * @param startDate        Inclusive lower bound on label.time_created; no bound if None.
+   * @param endDate          Inclusive upper bound; no bound if None.
+   * @param filterLowQuality If true, restrict to user_stat.high_quality; otherwise exclude excluded users.
+   * @return                 Sequence of (date, labelType, humanLabels, aiLabels).
+   */
+  def getCityDailyLabelStatsBySchema(
+      schema: String,
+      startDate: Option[LocalDate],
+      endDate: Option[LocalDate],
+      filterLowQuality: Boolean
+  ): DBIO[Seq[(LocalDate, String, Int, Int)]] = {
+    val userFilter = if (filterLowQuality) "user_stat.high_quality" else "NOT user_stat.excluded"
+    val whereClauses = scala.collection.mutable.ListBuffer(
+      "label.deleted = FALSE",
+      "label.tutorial = FALSE",
+      userFilter
+    )
+    startDate.foreach(d => whereClauses += s"label.time_created >= '$d'::date")
+    endDate.foreach(d => whereClauses += s"label.time_created < ('$d'::date + INTERVAL '1 day')")
+    val where = whereClauses.mkString(" AND ")
+
+    implicit val getResult: GetResult[(LocalDate, String, Int, Int)] =
+      GetResult(r => (LocalDate.parse(r.nextString()), r.nextString(), r.nextInt(), r.nextInt()))
+
+    sql"""
+      SELECT CAST((label.time_created AT TIME ZONE 'US/Pacific')::date AS TEXT) AS date,
+             label_type.label_type,
+             COUNT(CASE WHEN role.role IS DISTINCT FROM 'AI' THEN label.label_id END) AS human_labels,
+             COUNT(CASE WHEN role.role = 'AI'               THEN label.label_id END) AS ai_labels
+      FROM "#$schema".label
+      INNER JOIN "#$schema".label_type ON label.label_type_id = label_type.label_type_id
+      INNER JOIN "#$schema".user_stat  ON label.user_id       = user_stat.user_id
+      LEFT  JOIN sidewalk_login.user_role ON label.user_id     = user_role.user_id
+      LEFT  JOIN sidewalk_login.role      ON user_role.role_id = role.role_id
+      WHERE #$where
+      GROUP BY (label.time_created AT TIME ZONE 'US/Pacific')::date, label_type.label_type
+      ORDER BY date ASC, label_type.label_type
+    """.as[(LocalDate, String, Int, Int)]
+  }
+
+  /**
+   * Returns daily validation counts split by human vs AI validator, result, and label type for a
+   * specific city schema.
+   *
+   * This is the cross-schema variant of LabelValidationTable.getDailyValidationStats.
+   *
+   * validation_result integers: 1 = agree, 2 = disagree, 3 = unsure.
+   *
+   * @param schema           Database schema to query.
+   * @param startDate        Inclusive lower bound on end_timestamp (Pacific date); no bound if None.
+   * @param endDate          Inclusive upper bound; no bound if None.
+   * @param filterLowQuality If true, restrict to user_stat.high_quality; otherwise exclude excluded users.
+   * @return                 Sequence of (date, labelType, humanAgree, humanDisagree, humanUnsure,
+   *                         aiAgree, aiDisagree, aiUnsure).
+   */
+  def getCityDailyValidationStatsBySchema(
+      schema: String,
+      startDate: Option[LocalDate],
+      endDate: Option[LocalDate],
+      filterLowQuality: Boolean
+  ): DBIO[Seq[(LocalDate, String, Int, Int, Int, Int, Int, Int)]] = {
+    val userFilter = if (filterLowQuality) "user_stat.high_quality" else "NOT user_stat.excluded"
+    val whereClauses = scala.collection.mutable.ListBuffer(
+      "label.deleted = FALSE",
+      userFilter
+    )
+    startDate.foreach(d => whereClauses += s"label_validation.end_timestamp >= '$d'::date")
+    endDate.foreach(d => whereClauses += s"label_validation.end_timestamp < ('$d'::date + INTERVAL '1 day')")
+    val where = whereClauses.mkString(" AND ")
+
+    implicit val getResult: GetResult[(LocalDate, String, Int, Int, Int, Int, Int, Int)] =
+      GetResult(r => (LocalDate.parse(r.nextString()), r.nextString(),
+        r.nextInt(), r.nextInt(), r.nextInt(), r.nextInt(), r.nextInt(), r.nextInt()))
+
+    sql"""
+      SELECT CAST((label_validation.end_timestamp AT TIME ZONE 'US/Pacific')::date AS TEXT) AS date,
+             label_type.label_type,
+             COUNT(CASE WHEN role.role IS DISTINCT FROM 'AI' AND label_validation.validation_result = 1 THEN 1 END)
+               AS human_agree,
+             COUNT(CASE WHEN role.role IS DISTINCT FROM 'AI' AND label_validation.validation_result = 2 THEN 1 END)
+               AS human_disagree,
+             COUNT(CASE WHEN role.role IS DISTINCT FROM 'AI' AND label_validation.validation_result = 3 THEN 1 END)
+               AS human_unsure,
+             COUNT(CASE WHEN role.role = 'AI' AND label_validation.validation_result = 1 THEN 1 END) AS ai_agree,
+             COUNT(CASE WHEN role.role = 'AI' AND label_validation.validation_result = 2 THEN 1 END) AS ai_disagree,
+             COUNT(CASE WHEN role.role = 'AI' AND label_validation.validation_result = 3 THEN 1 END) AS ai_unsure
+      FROM "#$schema".label_validation
+      INNER JOIN "#$schema".label      ON label_validation.label_id    = label.label_id
+      INNER JOIN "#$schema".label_type ON label.label_type_id          = label_type.label_type_id
+      INNER JOIN "#$schema".user_stat  ON label_validation.user_id     = user_stat.user_id
+      LEFT  JOIN sidewalk_login.user_role ON label_validation.user_id = user_role.user_id
+      LEFT  JOIN sidewalk_login.role      ON user_role.role_id        = role.role_id
+      WHERE #$where
+      GROUP BY (label_validation.end_timestamp AT TIME ZONE 'US/Pacific')::date, label_type.label_type
+      ORDER BY date ASC, label_type.label_type
+    """.as[(LocalDate, String, Int, Int, Int, Int, Int, Int)]
   }
 }

--- a/app/models/utils/ConfigTable.scala
+++ b/app/models/utils/ConfigTable.scala
@@ -326,15 +326,18 @@ class ConfigTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvi
     sql"""
       SELECT CAST((label_validation.end_timestamp AT TIME ZONE 'US/Pacific')::date AS TEXT) AS date,
              label_type.label_type,
-             COUNT(CASE WHEN role.role IS DISTINCT FROM 'AI' AND label_validation.validation_result = 1 THEN 1 END)
-               AS human_agree,
-             COUNT(CASE WHEN role.role IS DISTINCT FROM 'AI' AND label_validation.validation_result = 2 THEN 1 END)
-               AS human_disagree,
-             COUNT(CASE WHEN role.role IS DISTINCT FROM 'AI' AND label_validation.validation_result = 3 THEN 1 END)
-               AS human_unsure,
-             COUNT(CASE WHEN role.role = 'AI' AND label_validation.validation_result = 1 THEN 1 END) AS ai_agree,
-             COUNT(CASE WHEN role.role = 'AI' AND label_validation.validation_result = 2 THEN 1 END) AS ai_disagree,
-             COUNT(CASE WHEN role.role = 'AI' AND label_validation.validation_result = 3 THEN 1 END) AS ai_unsure
+             COUNT(CASE WHEN role.role IS DISTINCT FROM 'AI' AND label_validation.validation_result::text = 'Agree'
+                        THEN 1 END) AS human_agree,
+             COUNT(CASE WHEN role.role IS DISTINCT FROM 'AI' AND label_validation.validation_result::text = 'Disagree'
+                        THEN 1 END) AS human_disagree,
+             COUNT(CASE WHEN role.role IS DISTINCT FROM 'AI' AND label_validation.validation_result::text = 'Unsure'
+                        THEN 1 END) AS human_unsure,
+             COUNT(CASE WHEN role.role = 'AI' AND label_validation.validation_result::text = 'Agree'
+                        THEN 1 END) AS ai_agree,
+             COUNT(CASE WHEN role.role = 'AI' AND label_validation.validation_result::text = 'Disagree'
+                        THEN 1 END) AS ai_disagree,
+             COUNT(CASE WHEN role.role = 'AI' AND label_validation.validation_result::text = 'Unsure'
+                        THEN 1 END) AS ai_unsure
       FROM "#$schema".label_validation
       INNER JOIN "#$schema".label      ON label_validation.label_id    = label.label_id
       INNER JOIN "#$schema".label_type ON label.label_type_id          = label_type.label_type_id

--- a/app/models/validation/LabelValidationTable.scala
+++ b/app/models/validation/LabelValidationTable.scala
@@ -10,10 +10,11 @@ import models.utils.CommonUtils.ViewerType.ViewerType
 import models.utils.MyPostgresProfile
 import models.utils.MyPostgresProfile.api._
 import play.api.db.slick.{DatabaseConfigProvider, HasDatabaseConfigProvider}
+import slick.jdbc.GetResult
 import service.TimeInterval
 import service.TimeInterval.TimeInterval
 
-import java.time.OffsetDateTime
+import java.time.{LocalDate, OffsetDateTime}
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.ExecutionContext
 
@@ -401,5 +402,64 @@ class LabelValidationTable @Inject() (
             )
           }
       }
+  }
+
+  /**
+   * Returns daily validation counts split by human vs AI validator and validation result, per label type.
+   *
+   * Validations are bucketed by label_validation.end_timestamp cast to a US/Pacific calendar date —
+   * i.e. the day the validation was performed, not the day the label was placed. The quality filter
+   * mirrors the convention in getOverallStatsForApi: when filterLowQuality is false, only
+   * administratively excluded users are removed; when true, only high_quality users are included.
+   *
+   * validation_result integers: 1 = agree, 2 = disagree, 3 = unsure (see validation_options table).
+   *
+   * @param startDate        Inclusive lower bound on end_timestamp (Pacific date); no bound if None.
+   * @param endDate          Inclusive upper bound on end_timestamp; no bound if None.
+   * @param filterLowQuality If true, restrict to user_stat.high_quality users; otherwise exclude
+   *                         only user_stat.excluded users.
+   * @return                 Sequence of (date, labelType, humanAgree, humanDisagree, humanUnsure,
+   *                         aiAgree, aiDisagree, aiUnsure), sorted by date then label type.
+   */
+  def getDailyValidationStats(
+      startDate: Option[LocalDate],
+      endDate: Option[LocalDate],
+      filterLowQuality: Boolean
+  ): DBIO[Seq[(LocalDate, String, Int, Int, Int, Int, Int, Int)]] = {
+    val userFilter = if (filterLowQuality) "user_stat.high_quality" else "NOT user_stat.excluded"
+    val whereClauses = scala.collection.mutable.ListBuffer(
+      "label.deleted = FALSE",
+      userFilter
+    )
+    startDate.foreach(d => whereClauses += s"label_validation.end_timestamp >= '$d'::date")
+    endDate.foreach(d => whereClauses += s"label_validation.end_timestamp < ('$d'::date + INTERVAL '1 day')")
+    val where = whereClauses.mkString(" AND ")
+
+    implicit val getResult: GetResult[(LocalDate, String, Int, Int, Int, Int, Int, Int)] =
+      GetResult(r => (LocalDate.parse(r.nextString()), r.nextString(),
+        r.nextInt(), r.nextInt(), r.nextInt(), r.nextInt(), r.nextInt(), r.nextInt()))
+
+    sql"""
+      SELECT CAST((label_validation.end_timestamp AT TIME ZONE 'US/Pacific')::date AS TEXT) AS date,
+             label_type.label_type,
+             COUNT(CASE WHEN role.role IS DISTINCT FROM 'AI' AND label_validation.validation_result = 1 THEN 1 END)
+               AS human_agree,
+             COUNT(CASE WHEN role.role IS DISTINCT FROM 'AI' AND label_validation.validation_result = 2 THEN 1 END)
+               AS human_disagree,
+             COUNT(CASE WHEN role.role IS DISTINCT FROM 'AI' AND label_validation.validation_result = 3 THEN 1 END)
+               AS human_unsure,
+             COUNT(CASE WHEN role.role = 'AI' AND label_validation.validation_result = 1 THEN 1 END) AS ai_agree,
+             COUNT(CASE WHEN role.role = 'AI' AND label_validation.validation_result = 2 THEN 1 END) AS ai_disagree,
+             COUNT(CASE WHEN role.role = 'AI' AND label_validation.validation_result = 3 THEN 1 END) AS ai_unsure
+      FROM label_validation
+      INNER JOIN label      ON label_validation.label_id    = label.label_id
+      INNER JOIN label_type ON label.label_type_id          = label_type.label_type_id
+      INNER JOIN user_stat  ON label_validation.user_id     = user_stat.user_id
+      LEFT  JOIN sidewalk_login.user_role ON label_validation.user_id = user_role.user_id
+      LEFT  JOIN sidewalk_login.role      ON user_role.role_id        = role.role_id
+      WHERE #$where
+      GROUP BY (label_validation.end_timestamp AT TIME ZONE 'US/Pacific')::date, label_type.label_type
+      ORDER BY date ASC, label_type.label_type
+    """.as[(LocalDate, String, Int, Int, Int, Int, Int, Int)]
   }
 }

--- a/app/models/validation/LabelValidationTable.scala
+++ b/app/models/validation/LabelValidationTable.scala
@@ -412,7 +412,8 @@ class LabelValidationTable @Inject() (
    * mirrors the convention in getOverallStatsForApi: when filterLowQuality is false, only
    * administratively excluded users are removed; when true, only high_quality users are included.
    *
-   * validation_result integers: 1 = agree, 2 = disagree, 3 = unsure (see validation_options table).
+   * validation_result is compared via ::text cast to support both integer and validation_option enum
+   * schemas across different city deployments ('Agree', 'Disagree', 'Unsure').
    *
    * @param startDate        Inclusive lower bound on end_timestamp (Pacific date); no bound if None.
    * @param endDate          Inclusive upper bound on end_timestamp; no bound if None.
@@ -442,15 +443,18 @@ class LabelValidationTable @Inject() (
     sql"""
       SELECT CAST((label_validation.end_timestamp AT TIME ZONE 'US/Pacific')::date AS TEXT) AS date,
              label_type.label_type,
-             COUNT(CASE WHEN role.role IS DISTINCT FROM 'AI' AND label_validation.validation_result = 1 THEN 1 END)
-               AS human_agree,
-             COUNT(CASE WHEN role.role IS DISTINCT FROM 'AI' AND label_validation.validation_result = 2 THEN 1 END)
-               AS human_disagree,
-             COUNT(CASE WHEN role.role IS DISTINCT FROM 'AI' AND label_validation.validation_result = 3 THEN 1 END)
-               AS human_unsure,
-             COUNT(CASE WHEN role.role = 'AI' AND label_validation.validation_result = 1 THEN 1 END) AS ai_agree,
-             COUNT(CASE WHEN role.role = 'AI' AND label_validation.validation_result = 2 THEN 1 END) AS ai_disagree,
-             COUNT(CASE WHEN role.role = 'AI' AND label_validation.validation_result = 3 THEN 1 END) AS ai_unsure
+             COUNT(CASE WHEN role.role IS DISTINCT FROM 'AI' AND label_validation.validation_result::text = 'Agree'
+                        THEN 1 END) AS human_agree,
+             COUNT(CASE WHEN role.role IS DISTINCT FROM 'AI' AND label_validation.validation_result::text = 'Disagree'
+                        THEN 1 END) AS human_disagree,
+             COUNT(CASE WHEN role.role IS DISTINCT FROM 'AI' AND label_validation.validation_result::text = 'Unsure'
+                        THEN 1 END) AS human_unsure,
+             COUNT(CASE WHEN role.role = 'AI' AND label_validation.validation_result::text = 'Agree'
+                        THEN 1 END) AS ai_agree,
+             COUNT(CASE WHEN role.role = 'AI' AND label_validation.validation_result::text = 'Disagree'
+                        THEN 1 END) AS ai_disagree,
+             COUNT(CASE WHEN role.role = 'AI' AND label_validation.validation_result::text = 'Unsure'
+                        THEN 1 END) AS ai_unsure
       FROM label_validation
       INNER JOIN label      ON label_validation.label_id    = label.label_id
       INNER JOIN label_type ON label.label_type_id          = label_type.label_type_id

--- a/app/service/ApiService.scala
+++ b/app/service/ApiService.scala
@@ -2,7 +2,7 @@ package service
 
 import com.google.inject.ImplementedBy
 import formats.json.ClusterFormats.{ClusterSubmission, ClusteredLabelSubmission}
-import models.api._
+import models.api.{DailyStatRecord, _}
 import models.cluster._
 import models.label._
 import models.region.{Region, RegionTable}
@@ -20,7 +20,7 @@ import play.api.db.slick.{DatabaseConfigProvider, HasDatabaseConfigProvider}
 import play.api.i18n.{Lang, MessagesApi}
 import slick.sql.SqlStreamingAction
 
-import java.time.OffsetDateTime
+import java.time.{LocalDate, OffsetDateTime}
 import javax.inject._
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -143,6 +143,23 @@ trait ApiService {
   ): Future[Seq[UserStatApi]]
 
   def getOverallStats(filterLowQuality: Boolean): Future[ProjectSidewalkStats]
+
+  /**
+   * Returns daily label and validation counts for the current city, split by human vs AI and label type.
+   *
+   * Runs two DB queries concurrently (labels by time_created, validations by end_timestamp) then merges
+   * them into one sequence keyed by (date, labelType).
+   *
+   * @param startDate        Inclusive start date (Pacific time); no lower bound if None.
+   * @param endDate          Inclusive end date; no upper bound if None.
+   * @param filterLowQuality If true, restrict to high-quality users (mirrors overallStats).
+   * @return                 Merged sequence of DailyStatRecord, sorted by date then label type.
+   */
+  def getOverallStatsByDay(
+      startDate: Option[LocalDate],
+      endDate: Option[LocalDate],
+      filterLowQuality: Boolean
+  ): Future[Seq[DailyStatRecord]]
 
   /**
    * Retrieves validation data based on the provided filters and returns them as a reactive stream source.
@@ -338,6 +355,19 @@ class ApiServiceImpl @Inject() (
           StreetTypeForApi(wayType, description, count)
         }
     }
+  }
+
+  def getOverallStatsByDay(
+      startDate: Option[LocalDate],
+      endDate: Option[LocalDate],
+      filterLowQuality: Boolean
+  ): Future[Seq[DailyStatRecord]] = {
+    val labelsFuture      = db.run(labelTable.getDailyLabelStats(startDate, endDate, filterLowQuality))
+    val validationsFuture = db.run(labelValidationTable.getDailyValidationStats(startDate, endDate, filterLowQuality))
+    for {
+      labels      <- labelsFuture
+      validations <- validationsFuture
+    } yield DailyStatRecord.merge(labels, validations)
   }
 
   def getValidations(filters: ValidationFiltersForApi, batchSize: Int): Source[ValidationDataForApi, _] = {

--- a/app/service/ConfigService.scala
+++ b/app/service/ConfigService.scala
@@ -2,6 +2,7 @@ package service
 
 import com.google.inject.ImplementedBy
 import com.typesafe.config.ConfigException
+import models.api.DailyStatRecord
 import models.label.LabelTypeEnum
 import models.pano.PanoSource
 import models.pano.PanoSource.PanoSource
@@ -14,7 +15,7 @@ import play.api.libs.ws.WSClient
 import play.api.{Configuration, Logger}
 import slick.dbio.DBIO
 
-import java.time.OffsetDateTime
+import java.time.{LocalDate, OffsetDateTime}
 import javax.inject._
 import scala.concurrent.duration.Duration
 import scala.concurrent.{ExecutionContext, Future}
@@ -113,6 +114,25 @@ trait ConfigService {
    * @return A Future containing aggregated statistics across all cities
    */
   def getAggregateStats(): Future[AggregateStats]
+
+  /**
+   * Returns daily label and validation counts aggregated across all configured cities.
+   *
+   * Queries each city schema in parallel and sums counts by (date, labelType) across cities.
+   * Cities whose schemas do not exist in the current environment are silently skipped (same
+   * guard as getAggregateStats). The legacy DC dataset is omitted because its schema predates
+   * the label_validation table format used here.
+   *
+   * @param startDate        Inclusive start date (Pacific time); no lower bound if None.
+   * @param endDate          Inclusive end date; no upper bound if None.
+   * @param filterLowQuality If true, restrict to high-quality users.
+   * @return                 Merged, sorted sequence of DailyStatRecord summed across all cities.
+   */
+  def getAggregateStatsByDay(
+      startDate: Option[LocalDate],
+      endDate: Option[LocalDate],
+      filterLowQuality: Boolean
+  ): Future[Seq[DailyStatRecord]]
 
   def getCityMapParams: Future[MapParams]
   def getTutorialStreetId: Future[Int]
@@ -341,6 +361,72 @@ class ConfigServiceImpl @Inject() (
               aggregateCityData(validCityStats :+ legacyDCData, numCities, numCountries, numLanguages)
             }
           }
+        }
+      }
+    }
+  }
+
+  def getAggregateStatsByDay(
+      startDate: Option[LocalDate],
+      endDate: Option[LocalDate],
+      filterLowQuality: Boolean
+  ): Future[Seq[DailyStatRecord]] = {
+    val configuredCityIds = config.get[Seq[String]]("city-params.city-ids")
+
+    val schemaChecks = configuredCityIds.map { cityId =>
+      try {
+        val schema = getCitySchema(cityId)
+        checkSchemaExists(schema).map(cityId -> _).recover { case _ => cityId -> false }
+      } catch {
+        case _: Exception => Future.successful(cityId -> false)
+      }
+    }
+
+    Future.sequence(schemaChecks).flatMap { results =>
+      val availableCities = results.filter(_._2).map(_._1)
+
+      if (availableCities.isEmpty) {
+        Future.successful(Seq.empty)
+      } else {
+        val cityDataFutures = availableCities.map { cityId =>
+          val schema = getCitySchema(cityId)
+          val labelsFuture = db.run(configTable.getCityDailyLabelStatsBySchema(schema, startDate, endDate,
+            filterLowQuality))
+            .recover { case e: Exception =>
+              logger.warn(s"Failed daily label stats for city $cityId: ${e.getMessage}")
+              Seq.empty[(LocalDate, String, Int, Int)]
+            }
+          val valsFuture = db.run(configTable.getCityDailyValidationStatsBySchema(schema, startDate, endDate,
+            filterLowQuality))
+            .recover { case e: Exception =>
+              logger.warn(s"Failed daily validation stats for city $cityId: ${e.getMessage}")
+              Seq.empty[(LocalDate, String, Int, Int, Int, Int, Int, Int)]
+            }
+          for {
+            labels      <- labelsFuture
+            validations <- valsFuture
+          } yield DailyStatRecord.merge(labels, validations)
+        }
+
+        Future.sequence(cityDataFutures).map { cityResults =>
+          // Sum all numeric fields across cities, grouped by (date, labelType).
+          cityResults.flatten
+            .groupBy(r => (r.date, r.labelType))
+            .map { case ((date, labelType), records) =>
+              DailyStatRecord(
+                date                     = date,
+                labelType                = labelType,
+                humanLabels              = records.map(_.humanLabels).sum,
+                aiLabels                 = records.map(_.aiLabels).sum,
+                humanValidationsAgree    = records.map(_.humanValidationsAgree).sum,
+                humanValidationsDisagree = records.map(_.humanValidationsDisagree).sum,
+                humanValidationsUnsure   = records.map(_.humanValidationsUnsure).sum,
+                aiValidationsAgree       = records.map(_.aiValidationsAgree).sum,
+                aiValidationsDisagree    = records.map(_.aiValidationsDisagree).sum,
+                aiValidationsUnsure      = records.map(_.aiValidationsUnsure).sum
+              )
+            }
+            .toSeq.sortBy(r => (r.date, r.labelType))
         }
       }
     }

--- a/app/views/apiDocs/_sidebar.scala.html
+++ b/app/views/apiDocs/_sidebar.scala.html
@@ -28,6 +28,8 @@
         <div class="api-nav-header">Stat APIs</div>
         <a href="@routes.ApiDocsController.userStats" class="api-nav-item @if(activePage == "user-stats"){active}">User Stats</a>
         <a href="@routes.ApiDocsController.overallStats" class="api-nav-item @if(activePage == "overall-stats"){active}">Overall Stats</a>
+        <a href="@routes.ApiDocsController.overallStatsByDay" class="api-nav-item @if(activePage == "overall-stats-by-day"){active}">Overall Stats by Day</a>
         <a href="@routes.ApiDocsController.aggregateStats" class="api-nav-item @if(activePage == "aggregate-stats"){active}">Aggregate Stats</a>
+        <a href="@routes.ApiDocsController.aggregateStatsByDay" class="api-nav-item @if(activePage == "aggregate-stats-by-day"){active}">Aggregate Stats by Day</a>
     </div>
 </div>

--- a/app/views/apiDocs/aggregateStatsByDay.scala.html
+++ b/app/views/apiDocs/aggregateStatsByDay.scala.html
@@ -31,6 +31,26 @@
         </p>
     </div>
 
+    <div class="api-section" id="aggregate-stats-by-day-preview-section">
+        <h2 class="api-heading" id="visual-example">
+            Aggregate Stats by Day API Preview <a href="#visual-example" class="permalink">#</a>
+        </h2>
+        <p>Live preview of the last 90 days of label and validation activity summed across all Project Sidewalk deployments:</p>
+
+        <div id="aggregate-stats-by-day-preview">Loading…</div>
+
+        <script src='@assets.path("javascripts/lib/chart-4.5.1.min.js")'></script>
+        <link rel="stylesheet" href="@assets.path("stylesheets/api-docs/stats-by-day.css")">
+        <script src="@routes.Assets.versioned("javascripts/api-docs/aggregate-stats-by-day-preview.js")"></script>
+        <script>
+            document.addEventListener('DOMContentLoaded', function() {
+                AggregateStatsByDayPreview.setup({
+                    apiBaseUrl: document.documentElement.getAttribute('data-api-base-url') || '/v3/api'
+                }).init();
+            });
+        </script>
+    </div>
+
     <div class="api-section" id="endpoint-section">
         <h2 class="api-heading" id="endpoint">Endpoint <a href="#endpoint" class="permalink">#</a></h2>
         <p>Returns daily label and validation counts summed across all Project Sidewalk deployments.</p>

--- a/app/views/apiDocs/aggregateStatsByDay.scala.html
+++ b/app/views/apiDocs/aggregateStatsByDay.scala.html
@@ -1,0 +1,180 @@
+@import service.CommonPageData
+@import models.user.SidewalkUserWithRole
+@import play.api.Configuration
+@(commonData: CommonPageData, user: SidewalkUserWithRole)(implicit request: RequestHeader, messages: Messages, assets: AssetsFinder, config: Configuration)
+
+@content = {
+    <script>
+        document.documentElement.setAttribute('data-api-base-url', '/v3/api');
+        document.documentElement.setAttribute('data-api-endpoint', 'aggregateStatsByDay');
+    </script>
+
+    <div class="api-section" id="aggregate-stats-by-day-intro-section">
+        <h1 class="api-heading" id="aggregate-stats-by-day-api">
+            Aggregate Stats by Day API <a href="#aggregate-stats-by-day-api" class="permalink">#</a>
+        </h1>
+        <p>
+            The Aggregate Stats by Day API provides a <strong>daily time series</strong> of label and
+            validation activity <strong>summed across every Project Sidewalk deployment</strong>, broken down
+            by label type and by whether the actor was a human user or an AI.
+        </p>
+        <p>
+            Each record covers one calendar day (US/Pacific time) and one label type. Counts from all
+            configured city deployments are summed together. Days with no activity for a label type across
+            any city are omitted.
+        </p>
+        <p>
+            For per-city daily data, see the
+            <a href="@routes.ApiDocsController.overallStatsByDay">Overall Stats by Day API</a>. For a
+            project-wide snapshot (not a time series), see the
+            <a href="@routes.ApiDocsController.aggregateStats">Aggregate Stats API</a>.
+        </p>
+    </div>
+
+    <div class="api-section" id="endpoint-section">
+        <h2 class="api-heading" id="endpoint">Endpoint <a href="#endpoint" class="permalink">#</a></h2>
+        <p>Returns daily label and validation counts summed across all Project Sidewalk deployments.</p>
+        <p><code>GET /v3/api/aggregateStatsByDay</code></p>
+        <div class="api-subsection" id="endpoint-example-section">
+            <h3 class="api-heading" id="endpoint-examples">Examples <a href="#endpoint-examples" class="permalink">#</a></h3>
+            <p>
+                <code><a target="_blank" href="/v3/api/aggregateStatsByDay">/v3/api/aggregateStatsByDay</a></code>
+                All-time aggregate data in JSON
+            </p>
+            <p>
+                <code><a target="_blank" href="/v3/api/aggregateStatsByDay?startDate=2025-01-01&amp;endDate=2025-03-31">/v3/api/aggregateStatsByDay?startDate=2025-01-01&amp;endDate=2025-03-31</a></code>
+                First quarter of 2025 in JSON
+            </p>
+            <p>
+                <code><a href="/v3/api/aggregateStatsByDay?filetype=csv">/v3/api/aggregateStatsByDay?filetype=csv</a></code>
+                All-time aggregate data as CSV
+            </p>
+        </div>
+    </div>
+
+    <div class="api-section" id="query-parameters-section">
+        <h2 class="api-heading" id="query-parameters">Query Parameters <a href="#query-parameters" class="permalink">#</a></h2>
+        <div class="api-table-wrapper">
+            <table class="api-table">
+                <thead>
+                    <tr><th>Parameter</th><th>Type</th><th>Default</th><th>Description</th></tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td><code>startDate</code></td>
+                        <td><code>string</code></td>
+                        <td><em>none</em></td>
+                        <td>
+                            Inclusive lower bound on the activity date in <code>YYYY-MM-DD</code> format
+                            (US/Pacific calendar date). If omitted, all data from the beginning of the
+                            earliest deployment is returned.
+                        </td>
+                    </tr>
+                    <tr>
+                        <td><code>endDate</code></td>
+                        <td><code>string</code></td>
+                        <td><em>none</em></td>
+                        <td>
+                            Inclusive upper bound on the activity date in <code>YYYY-MM-DD</code> format.
+                            If omitted, data up to and including today is returned.
+                        </td>
+                    </tr>
+                    <tr>
+                        <td><code>filterLowQuality</code></td>
+                        <td><code>boolean</code></td>
+                        <td><code>false</code></td>
+                        <td>
+                            If <code>true</code>, only include activity from users whose
+                            <code>high_quality</code> flag is set. Applied independently within
+                            each city schema before summing.
+                        </td>
+                    </tr>
+                    <tr>
+                        <td><code>filetype</code></td>
+                        <td><code>string</code></td>
+                        <td><code>json</code></td>
+                        <td>Output format: <code>json</code> (default) or <code>csv</code>.</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <div class="api-section" id="response-format-section">
+        <h2 class="api-heading" id="response-format">Response Format <a href="#response-format" class="permalink">#</a></h2>
+        <p>
+            Identical structure to the
+            <a href="@routes.ApiDocsController.overallStatsByDay">Overall Stats by Day</a> response,
+            with counts summed across all city deployments.
+        </p>
+        <pre><code>{
+  "status": "OK",
+  "data": [
+    {
+      "date": "2025-01-15",
+      "label_type": "CurbRamp",
+      "human_labels": 2340,
+      "ai_labels": 0,
+      "human_validations_agree": 1870,
+      "human_validations_disagree": 280,
+      "human_validations_unsure": 95,
+      "ai_validations_agree": 0,
+      "ai_validations_disagree": 0,
+      "ai_validations_unsure": 0
+    }
+  ]
+}</code></pre>
+
+        <h3 class="api-heading" id="response-fields">Response Fields <a href="#response-fields" class="permalink">#</a></h3>
+        <p>All fields are identical to the <a href="@routes.ApiDocsController.overallStatsByDay">Overall Stats by Day API</a>.</p>
+        <div class="api-table-wrapper">
+            <table class="api-table">
+                <thead>
+                    <tr><th>Field</th><th>Type</th><th>Description</th></tr>
+                </thead>
+                <tbody>
+                    <tr><td><code>date</code></td><td><code>string</code></td>
+                        <td>Calendar date in <code>YYYY-MM-DD</code> format (US/Pacific time).</td></tr>
+                    <tr><td><code>label_type</code></td><td><code>string</code></td>
+                        <td>Label type name (e.g. <code>CurbRamp</code>, <code>NoCurbRamp</code>).</td></tr>
+                    <tr><td><code>human_labels</code></td><td><code>integer</code></td>
+                        <td>Labels placed by human users across all cities on this date.</td></tr>
+                    <tr><td><code>ai_labels</code></td><td><code>integer</code></td>
+                        <td>Labels placed by AI across all cities on this date.</td></tr>
+                    <tr><td><code>human_validations_agree</code></td><td><code>integer</code></td>
+                        <td>Human agree validations across all cities on this date.</td></tr>
+                    <tr><td><code>human_validations_disagree</code></td><td><code>integer</code></td>
+                        <td>Human disagree validations across all cities on this date.</td></tr>
+                    <tr><td><code>human_validations_unsure</code></td><td><code>integer</code></td>
+                        <td>Human unsure validations across all cities on this date.</td></tr>
+                    <tr><td><code>ai_validations_agree</code></td><td><code>integer</code></td>
+                        <td>AI agree validations across all cities on this date.</td></tr>
+                    <tr><td><code>ai_validations_disagree</code></td><td><code>integer</code></td>
+                        <td>AI disagree validations across all cities on this date.</td></tr>
+                    <tr><td><code>ai_validations_unsure</code></td><td><code>integer</code></td>
+                        <td>AI unsure validations across all cities on this date.</td></tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <div class="api-section" id="quick-download-section">
+        <h2 class="api-heading" id="quick-download">Quick Download <a href="#quick-download" class="permalink">#</a></h2>
+        <p>Download the project-wide daily stats time series in your preferred format:</p>
+        <div class="download-buttons">
+            <button class="download-btn" data-format="json">
+                <span class="format-icon">📄</span> JSON
+                <span class="format-hint">Standard format</span>
+            </button>
+            <button class="download-btn" data-format="csv">
+                <span class="format-icon">📊</span> CSV
+                <span class="format-hint">Spreadsheet friendly</span>
+            </button>
+        </div>
+    </div>
+}
+
+@common.main(commonData, "API Docs") {
+    @common.navbar(commonData, Some(user))
+    @apiDocs.layout("aggregate-stats-by-day")(content)
+}

--- a/app/views/apiDocs/aggregateStatsByDay.scala.html
+++ b/app/views/apiDocs/aggregateStatsByDay.scala.html
@@ -35,7 +35,7 @@
         <h2 class="api-heading" id="visual-example">
             Aggregate Stats by Day API Preview <a href="#visual-example" class="permalink">#</a>
         </h2>
-        <p>Live preview of the last 90 days of label and validation activity summed across all Project Sidewalk deployments:</p>
+        <p>Live preview of the most recent 90 days of activity summed across all Project Sidewalk deployments:</p>
 
         <div id="aggregate-stats-by-day-preview">Loading…</div>
 

--- a/app/views/apiDocs/overallStatsByDay.scala.html
+++ b/app/views/apiDocs/overallStatsByDay.scala.html
@@ -1,0 +1,195 @@
+@import service.CommonPageData
+@import models.user.SidewalkUserWithRole
+@import play.api.Configuration
+@(commonData: CommonPageData, user: SidewalkUserWithRole)(implicit request: RequestHeader, messages: Messages, assets: AssetsFinder, config: Configuration)
+@cityName = @{commonData.allCityInfo.filter(c => c.cityId == commonData.cityId).head.cityNameFormatted}
+
+@content = {
+    <script>
+        document.documentElement.setAttribute('data-api-base-url', '/v3/api');
+        document.documentElement.setAttribute('data-api-endpoint', 'overallStatsByDay');
+    </script>
+
+    <div class="api-section" id="overall-stats-by-day-intro-section">
+        <h1 class="api-heading" id="overall-stats-by-day-api">
+            Overall Stats by Day API <a href="#overall-stats-by-day-api" class="permalink">#</a>
+        </h1>
+        <p>
+            The Overall Stats by Day API provides a <strong>daily time series</strong> of label and validation
+            activity for <strong>@cityName</strong>, broken down by label type and by whether the actor was a
+            human user or an AI. This lets you track productivity trends over time.
+        </p>
+        <p>
+            Each record covers one calendar day (US/Pacific time) and one label type. Label counts reflect
+            labels <em>created</em> on that day; validation counts reflect validations <em>completed</em> on
+            that day (on any label, not just ones created that day).
+        </p>
+        <p>
+            For aggregate counts across all Project Sidewalk deployments, see the
+            <a href="@routes.ApiDocsController.aggregateStatsByDay">Aggregate Stats by Day API</a>. For a
+            single-number snapshot, see the <a href="@routes.ApiDocsController.overallStats">Overall Stats API</a>.
+        </p>
+    </div>
+
+    <div class="api-section" id="endpoint-section">
+        <h2 class="api-heading" id="endpoint">Endpoint <a href="#endpoint" class="permalink">#</a></h2>
+        <p>Returns daily label and validation counts for @cityName.</p>
+        <p><code>GET /v3/api/overallStatsByDay</code></p>
+        <div class="api-subsection" id="endpoint-example-section">
+            <h3 class="api-heading" id="endpoint-examples">Examples <a href="#endpoint-examples" class="permalink">#</a></h3>
+            <p>
+                <code><a target="_blank" href="/v3/api/overallStatsByDay">/v3/api/overallStatsByDay</a></code>
+                All-time data for @cityName in JSON
+            </p>
+            <p>
+                <code><a target="_blank" href="/v3/api/overallStatsByDay?startDate=2025-01-01&amp;endDate=2025-03-31">/v3/api/overallStatsByDay?startDate=2025-01-01&amp;endDate=2025-03-31</a></code>
+                First quarter of 2025 in JSON
+            </p>
+            <p>
+                <code><a href="/v3/api/overallStatsByDay?filetype=csv">/v3/api/overallStatsByDay?filetype=csv</a></code>
+                All-time data as CSV
+            </p>
+            <p>
+                <code><a href="/v3/api/overallStatsByDay?filterLowQuality=true">/v3/api/overallStatsByDay?filterLowQuality=true</a></code>
+                Restrict to high-quality users
+            </p>
+        </div>
+    </div>
+
+    <div class="api-section" id="query-parameters-section">
+        <h2 class="api-heading" id="query-parameters">Query Parameters <a href="#query-parameters" class="permalink">#</a></h2>
+        <div class="api-table-wrapper">
+            <table class="api-table">
+                <thead>
+                    <tr><th>Parameter</th><th>Type</th><th>Default</th><th>Description</th></tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td><code>startDate</code></td>
+                        <td><code>string</code></td>
+                        <td><em>none</em></td>
+                        <td>
+                            Inclusive lower bound on the activity date in <code>YYYY-MM-DD</code> format
+                            (US/Pacific calendar date). If omitted, all data from the beginning of the
+                            deployment is returned.
+                        </td>
+                    </tr>
+                    <tr>
+                        <td><code>endDate</code></td>
+                        <td><code>string</code></td>
+                        <td><em>none</em></td>
+                        <td>
+                            Inclusive upper bound on the activity date in <code>YYYY-MM-DD</code> format.
+                            If omitted, data up to and including today is returned.
+                        </td>
+                    </tr>
+                    <tr>
+                        <td><code>filterLowQuality</code></td>
+                        <td><code>boolean</code></td>
+                        <td><code>false</code></td>
+                        <td>
+                            If <code>true</code>, only include activity from users whose
+                            <code>high_quality</code> flag is set. If <code>false</code> (default),
+                            only users explicitly marked as <code>excluded</code> are omitted.
+                            Mirrors the same parameter on <a href="@routes.ApiDocsController.overallStats">Overall Stats</a>.
+                        </td>
+                    </tr>
+                    <tr>
+                        <td><code>filetype</code></td>
+                        <td><code>string</code></td>
+                        <td><code>json</code></td>
+                        <td>Output format: <code>json</code> (default) or <code>csv</code>.</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <div class="api-section" id="response-format-section">
+        <h2 class="api-heading" id="response-format">Response Format <a href="#response-format" class="permalink">#</a></h2>
+        <p>
+            The response is a JSON object with a <code>data</code> array. Each element covers one
+            (date, label_type) combination. Days with no activity for a label type are omitted.
+        </p>
+        <pre><code>{
+  "status": "OK",
+  "data": [
+    {
+      "date": "2025-01-15",
+      "label_type": "CurbRamp",
+      "human_labels": 150,
+      "ai_labels": 0,
+      "human_validations_agree": 120,
+      "human_validations_disagree": 18,
+      "human_validations_unsure": 6,
+      "ai_validations_agree": 0,
+      "ai_validations_disagree": 0,
+      "ai_validations_unsure": 0
+    },
+    {
+      "date": "2025-01-15",
+      "label_type": "NoCurbRamp",
+      "human_labels": 85,
+      "ai_labels": 0,
+      "human_validations_agree": 72,
+      "human_validations_disagree": 9,
+      "human_validations_unsure": 3,
+      "ai_validations_agree": 0,
+      "ai_validations_disagree": 0,
+      "ai_validations_unsure": 0
+    }
+  ]
+}</code></pre>
+
+        <h3 class="api-heading" id="response-fields">Response Fields <a href="#response-fields" class="permalink">#</a></h3>
+        <div class="api-table-wrapper">
+            <table class="api-table">
+                <thead>
+                    <tr><th>Field</th><th>Type</th><th>Description</th></tr>
+                </thead>
+                <tbody>
+                    <tr><td><code>date</code></td><td><code>string</code></td>
+                        <td>Calendar date in <code>YYYY-MM-DD</code> format (US/Pacific time).</td></tr>
+                    <tr><td><code>label_type</code></td><td><code>string</code></td>
+                        <td>Label type name (e.g. <code>CurbRamp</code>, <code>NoCurbRamp</code>, <code>Obstacle</code>).</td></tr>
+                    <tr><td><code>human_labels</code></td><td><code>integer</code></td>
+                        <td>Number of labels of this type placed by human users on this date.</td></tr>
+                    <tr><td><code>ai_labels</code></td><td><code>integer</code></td>
+                        <td>Number of labels of this type placed by AI on this date.</td></tr>
+                    <tr><td><code>human_validations_agree</code></td><td><code>integer</code></td>
+                        <td>Human validations with result <em>agree</em> completed on this date.</td></tr>
+                    <tr><td><code>human_validations_disagree</code></td><td><code>integer</code></td>
+                        <td>Human validations with result <em>disagree</em> completed on this date.</td></tr>
+                    <tr><td><code>human_validations_unsure</code></td><td><code>integer</code></td>
+                        <td>Human validations with result <em>unsure</em> completed on this date.</td></tr>
+                    <tr><td><code>ai_validations_agree</code></td><td><code>integer</code></td>
+                        <td>AI validations with result <em>agree</em> completed on this date.</td></tr>
+                    <tr><td><code>ai_validations_disagree</code></td><td><code>integer</code></td>
+                        <td>AI validations with result <em>disagree</em> completed on this date.</td></tr>
+                    <tr><td><code>ai_validations_unsure</code></td><td><code>integer</code></td>
+                        <td>AI validations with result <em>unsure</em> completed on this date.</td></tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <div class="api-section" id="quick-download-section">
+        <h2 class="api-heading" id="quick-download">Quick Download <a href="#quick-download" class="permalink">#</a></h2>
+        <p>Download the full @cityName daily stats time series in your preferred format:</p>
+        <div class="download-buttons">
+            <button class="download-btn" data-format="json">
+                <span class="format-icon">📄</span> JSON
+                <span class="format-hint">Standard format</span>
+            </button>
+            <button class="download-btn" data-format="csv">
+                <span class="format-icon">📊</span> CSV
+                <span class="format-hint">Spreadsheet friendly</span>
+            </button>
+        </div>
+    </div>
+}
+
+@common.main(commonData, "API Docs") {
+    @common.navbar(commonData, Some(user))
+    @apiDocs.layout("overall-stats-by-day")(content)
+}

--- a/app/views/apiDocs/overallStatsByDay.scala.html
+++ b/app/views/apiDocs/overallStatsByDay.scala.html
@@ -35,7 +35,7 @@
         <h2 class="api-heading" id="visual-example">
             Overall Stats by Day API Preview <a href="#visual-example" class="permalink">#</a>
         </h2>
-        <p>Live preview of the last 90 days of label and validation activity for <strong>@cityName</strong>:</p>
+        <p>Live preview of the most recent 90 days of activity for <strong>@cityName</strong>:</p>
 
         <div id="overall-stats-by-day-preview">Loading…</div>
 

--- a/app/views/apiDocs/overallStatsByDay.scala.html
+++ b/app/views/apiDocs/overallStatsByDay.scala.html
@@ -31,6 +31,27 @@
         </p>
     </div>
 
+    <div class="api-section" id="overall-stats-by-day-preview-section">
+        <h2 class="api-heading" id="visual-example">
+            Overall Stats by Day API Preview <a href="#visual-example" class="permalink">#</a>
+        </h2>
+        <p>Live preview of the last 90 days of label and validation activity for <strong>@cityName</strong>:</p>
+
+        <div id="overall-stats-by-day-preview">Loading…</div>
+
+        <script src='@assets.path("javascripts/lib/chart-4.5.1.min.js")'></script>
+        <link rel="stylesheet" href="@assets.path("stylesheets/api-docs/stats-by-day.css")">
+        <script src="@routes.Assets.versioned("javascripts/api-docs/overall-stats-by-day-preview.js")"></script>
+        <script>
+            document.addEventListener('DOMContentLoaded', function() {
+                OverallStatsByDayPreview.setup({
+                    apiBaseUrl: document.documentElement.getAttribute('data-api-base-url') || '/v3/api',
+                    cityName: '@cityName'
+                }).init();
+            });
+        </script>
+    </div>
+
     <div class="api-section" id="endpoint-section">
         <h2 class="api-heading" id="endpoint">Endpoint <a href="#endpoint" class="permalink">#</a></h2>
         <p>Returns daily label and validation counts for @cityName.</p>

--- a/conf/routes
+++ b/conf/routes
@@ -50,6 +50,14 @@ GET     /cityMapParams                                  controllers.ConfigContro
 
 # Admin
 GET     /admin                                          controllers.AdminController.index
+GET     /admin/overview                                 controllers.AdminController.overview
+GET     /admin/map                                      controllers.AdminController.adminMap
+GET     /admin/analytics                                controllers.AdminController.adminAnalytics
+GET     /admin/labels                                   controllers.AdminController.adminLabels
+GET     /admin/users                                    controllers.AdminController.adminUsers
+GET     /admin/label-search                             controllers.AdminController.adminLabelSearch
+GET     /admin/teams                                    controllers.AdminController.adminTeams
+GET     /admin/api-analytics                            controllers.AdminController.adminApiAnalytics
 GET     /admin/user/:username                           controllers.AdminController.userProfile(username: String)
 GET     /admin/task/:taskId                             controllers.AdminController.task(taskId: Int)
 GET     /admin/label/:labelId                           controllers.AdminController.label(labelId: Int)
@@ -181,7 +189,9 @@ GET     /v3/api/regionWithMostLabels                    controllers.api.RegionAp
 GET     /v3/api/cities                                  controllers.api.CitiesApiController.getCities(filetype: String ?= "json")
 GET     /v3/api/userStats                               controllers.api.StatsApiController.getUserApiStats(minLabels: Option[Int], minMetersExplored: Option[Double], highQualityOnly: Option[Boolean], minAccuracy: Option[Double], filetype: Option[String])
 GET     /v3/api/overallStats                            controllers.api.StatsApiController.getOverallSidewalkStats(filterLowQuality: Boolean ?= false, filetype: Option[String])
+GET     /v3/api/overallStatsByDay                       controllers.api.StatsApiController.getOverallStatsByDay(startDate: Option[String] ?= None, endDate: Option[String] ?= None, filterLowQuality: Boolean ?= false, filetype: Option[String] ?= None)
 GET     /v3/api/aggregateStats                          controllers.api.StatsApiController.getAggregateStats(filetype: Option[String])
+GET     /v3/api/aggregateStatsByDay                     controllers.api.StatsApiController.getAggregateStatsByDay(startDate: Option[String] ?= None, endDate: Option[String] ?= None, filterLowQuality: Boolean ?= false, filetype: Option[String] ?= None)
 GET     /v3/api/labelClusters                           controllers.api.LabelClustersApiController.getLabelClustersV3(bbox: Option[String], labelType: Option[String], regionId: Option[Int], regionName: Option[String], includeRawLabels: Option[Boolean], clusterSize: Option[Int], avgImageCaptureDate: Option[String], avgLabelDate: Option[String], minSeverity: Option[Int], maxSeverity: Option[Int], filetype: Option[String], inline: Option[Boolean])
 GET     /v3/api/streets                                 controllers.api.StreetsApiController.getStreets(bbox: Option[String], regionId: Option[Int], regionName: Option[String], minLabelCount: Option[Int], minAuditCount: Option[Int], minUserCount: Option[Int], wayType: Option[String], filetype: Option[String], inline: Option[Boolean])
 GET     /v3/api/streetTypes                             controllers.api.StreetsApiController.getStreetTypes
@@ -203,7 +213,9 @@ GET     /v3/api-docs/validations                        controllers.ApiDocsContr
 GET     /v3/api-docs/validation-result-types            controllers.ApiDocsController.validationResultTypes
 GET     /v3/api-docs/user-stats                         controllers.ApiDocsController.userStats
 GET     /v3/api-docs/overall-stats                      controllers.ApiDocsController.overallStats
+GET     /v3/api-docs/overall-stats-by-day               controllers.ApiDocsController.overallStatsByDay
 GET     /v3/api-docs/aggregate-stats                    controllers.ApiDocsController.aggregateStats
+GET     /v3/api-docs/aggregate-stats-by-day             controllers.ApiDocsController.aggregateStatsByDay
 
 # Old Public API (v2).
 GET     /v2/access/score/streets                        controllers.api.AccessScoreApiController.getAccessScoreStreetsV2(lat1: Option[Double], lng1: Option[Double], lat2: Option[Double], lng2: Option[Double], filetype: Option[String])

--- a/public/javascripts/api-docs/aggregate-stats-by-day-preview.js
+++ b/public/javascripts/api-docs/aggregate-stats-by-day-preview.js
@@ -3,7 +3,7 @@
  *
  * Renders a live time-series visualization for the Aggregate Stats by Day API endpoint, showing
  * daily label and validation activity summed across all Project Sidewalk deployments over the
- * last 90 days.
+ * most recent 90 days with data.
  *
  * @requires DOM element with id 'aggregate-stats-by-day-preview'
  * @requires Chart.js library (chart-4.5.1.min.js)
@@ -27,20 +27,21 @@
         containerId: 'aggregate-stats-by-day-preview'
     };
 
-    /**
-     * Returns a date string YYYY-MM-DD for `daysAgo` days before today.
-     * @param {number} daysAgo
-     * @returns {string}
-     */
-    function dateString(daysAgo) {
-        const d = new Date();
-        d.setDate(d.getDate() - daysAgo);
-        return d.toISOString().slice(0, 10);
-    }
-
     /** @param {string} msg */
     function showError(container, msg) {
         container.innerHTML = `<p style="color:var(--color-danger,#d9534f);text-align:center;padding:40px 0">${msg}</p>`;
+    }
+
+    /**
+     * Keeps only rows from the most recent `maxDays` unique dates in the data.
+     * @param {Array<object>} data
+     * @param {number} maxDays
+     * @returns {Array<object>}
+     */
+    function trimToRecentDays(data, maxDays) {
+        const dates = Array.from(new Set(data.map(r => r.date))).sort();
+        const cutoff = dates.length > maxDays ? dates[dates.length - maxDays] : dates[0];
+        return data.filter(r => r.date >= cutoff);
     }
 
     /**
@@ -115,7 +116,7 @@
         // ── Chart 1: Human + AI labels per day ─────────────────────────────────
         container.appendChild(makeChart(
             'Labels per Day (All Deployments)',
-            'Daily new labels placed across all Project Sidewalk cities (last 90 days)',
+            'Daily new labels placed across all Project Sidewalk cities',
             chartContainer => {
                 const canvas = document.createElement('canvas');
                 chartContainer.appendChild(canvas);
@@ -152,7 +153,7 @@
         // ── Chart 2: Validations per day (stacked agree/disagree/unsure) ───────
         container.appendChild(makeChart(
             'Human Validations per Day (All Deployments)',
-            'Daily validation activity breakdown across all cities (last 90 days)',
+            'Daily validation activity breakdown across all cities',
             chartContainer => {
                 const canvas = document.createElement('canvas');
                 chartContainer.appendChild(canvas);
@@ -281,8 +282,7 @@
 
             container.innerHTML = '<p style="text-align:center;color:#888;padding:40px 0">Loading…</p>';
 
-            const startDate = dateString(90);
-            const url = `${config.apiBaseUrl}/aggregateStatsByDay?startDate=${startDate}&source=apiDocs`;
+            const url = `${config.apiBaseUrl}/aggregateStatsByDay?source=apiDocs`;
 
             return fetch(url)
                 .then(r => {
@@ -291,7 +291,8 @@
                 })
                 .then(json => {
                     container.innerHTML = '';
-                    render(container, json.data || []);
+                    // Trim to the most recent 90 days that have data for readability.
+                    render(container, trimToRecentDays(json.data || [], 90));
                 })
                 .catch(err => {
                     showError(container, `Failed to load preview: ${err.message}`);

--- a/public/javascripts/api-docs/aggregate-stats-by-day-preview.js
+++ b/public/javascripts/api-docs/aggregate-stats-by-day-preview.js
@@ -1,0 +1,302 @@
+/**
+ * Project Sidewalk Aggregate Stats by Day Preview Generator.
+ *
+ * Renders a live time-series visualization for the Aggregate Stats by Day API endpoint, showing
+ * daily label and validation activity summed across all Project Sidewalk deployments over the
+ * last 90 days.
+ *
+ * @requires DOM element with id 'aggregate-stats-by-day-preview'
+ * @requires Chart.js library (chart-4.5.1.min.js)
+ */
+(function() {
+    const LABEL_TYPE_COLORS = {
+        CurbRamp: '#5cb85c',
+        NoCurbRamp: '#d9534f',
+        Obstacle: '#f0ad4e',
+        SurfaceProblem: '#9b59b6',
+        NoSidewalk: '#d35400',
+        Crosswalk: '#3498db',
+        Signal: '#1abc9c',
+        Occlusion: '#95a5a6',
+        Other: '#7f8c8d'
+    };
+
+    /** @type {{apiBaseUrl: string, containerId: string}} */
+    let config = {
+        apiBaseUrl: '/v3/api',
+        containerId: 'aggregate-stats-by-day-preview'
+    };
+
+    /**
+     * Returns a date string YYYY-MM-DD for `daysAgo` days before today.
+     * @param {number} daysAgo
+     * @returns {string}
+     */
+    function dateString(daysAgo) {
+        const d = new Date();
+        d.setDate(d.getDate() - daysAgo);
+        return d.toISOString().slice(0, 10);
+    }
+
+    /** @param {string} msg */
+    function showError(container, msg) {
+        container.innerHTML = `<p style="color:var(--color-danger,#d9534f);text-align:center;padding:40px 0">${msg}</p>`;
+    }
+
+    /**
+     * Builds a lookup: date → { labelType → record } from the flat data array.
+     * @param {Array<object>} data
+     * @returns {Map<string, Map<string, object>>}
+     */
+    function buildDailyMap(data) {
+        const map = new Map();
+        data.forEach(row => {
+            if (!map.has(row.date)) map.set(row.date, new Map());
+            map.get(row.date).set(row.label_type, row);
+        });
+        return map;
+    }
+
+    /**
+     * Aggregates daily totals (summed across all label types) for a field.
+     * @param {string[]} dates - Sorted date strings
+     * @param {Map<string, Map<string, object>>} byDay
+     * @param {string} field
+     * @returns {number[]}
+     */
+    function dailyTotals(dates, byDay, field) {
+        return dates.map(d => {
+            let total = 0;
+            (byDay.get(d) || new Map()).forEach(row => { total += (row[field] || 0); });
+            return total;
+        });
+    }
+
+    /**
+     * Renders the summary stats bar and charts.
+     * @param {HTMLElement} container
+     * @param {Array<object>} data
+     */
+    function render(container, data) {
+        if (!data.length) {
+            container.innerHTML = '<p style="text-align:center;color:#888;padding:40px 0">No data available for this period.</p>';
+            return;
+        }
+
+        const byDay = buildDailyMap(data);
+        const dates = Array.from(byDay.keys()).sort();
+
+        // ── Summary stats ──────────────────────────────────────────────────────
+        const totalHumanLabels = data.reduce((s, r) => s + r.human_labels, 0);
+        const totalAiLabels    = data.reduce((s, r) => s + r.ai_labels, 0);
+        const totalAgree       = data.reduce((s, r) => s + r.human_validations_agree, 0);
+        const totalDisagree    = data.reduce((s, r) => s + r.human_validations_disagree, 0);
+        const totalUnsure      = data.reduce((s, r) => s + r.human_validations_unsure, 0);
+        const totalAiAgree     = data.reduce((s, r) => s + r.ai_validations_agree, 0);
+        const totalAiDisagree  = data.reduce((s, r) => s + r.ai_validations_disagree, 0);
+        const totalValidations = totalAgree + totalDisagree + totalUnsure + totalAiAgree + totalAiDisagree
+            + data.reduce((s, r) => s + r.ai_validations_unsure, 0);
+        const humanValidations = totalAgree + totalDisagree + totalUnsure;
+        const accuracy         = humanValidations > 0
+            ? ((totalAgree / humanValidations) * 100).toFixed(1)
+            : 'N/A';
+
+        const summaryEl = document.createElement('div');
+        summaryEl.className = 'preview-summary-grid';
+        summaryEl.innerHTML = `
+            <div class="preview-stat"><span class="preview-stat-value">${dates.length}</span><span class="preview-stat-label">Days shown</span></div>
+            <div class="preview-stat"><span class="preview-stat-value">${totalHumanLabels.toLocaleString()}</span><span class="preview-stat-label">Human labels</span></div>
+            <div class="preview-stat"><span class="preview-stat-value">${totalAiLabels.toLocaleString()}</span><span class="preview-stat-label">AI labels</span></div>
+            <div class="preview-stat"><span class="preview-stat-value">${totalValidations.toLocaleString()}</span><span class="preview-stat-label">Total validations</span></div>
+            <div class="preview-stat"><span class="preview-stat-value">${accuracy}%</span><span class="preview-stat-label">Human agreement rate</span></div>
+        `;
+        container.appendChild(summaryEl);
+
+        // ── Chart 1: Human + AI labels per day ─────────────────────────────────
+        container.appendChild(makeChart(
+            'Labels per Day (All Deployments)',
+            'Daily new labels placed across all Project Sidewalk cities (last 90 days)',
+            chartContainer => {
+                const canvas = document.createElement('canvas');
+                chartContainer.appendChild(canvas);
+                new Chart(canvas.getContext('2d'), {
+                    type: 'line',
+                    data: {
+                        labels: dates,
+                        datasets: [
+                            {
+                                label: 'Human Labels',
+                                data: dailyTotals(dates, byDay, 'human_labels'),
+                                borderColor: 'var(--color-primary, #2c77b1)',
+                                backgroundColor: 'rgba(44,119,177,0.12)',
+                                fill: true,
+                                tension: 0.3,
+                                pointRadius: dates.length > 60 ? 0 : 3
+                            },
+                            {
+                                label: 'AI Labels',
+                                data: dailyTotals(dates, byDay, 'ai_labels'),
+                                borderColor: 'rgba(153,102,255,0.9)',
+                                backgroundColor: 'rgba(153,102,255,0.08)',
+                                fill: true,
+                                tension: 0.3,
+                                pointRadius: dates.length > 60 ? 0 : 3
+                            }
+                        ]
+                    },
+                    options: chartOptions('Labels placed')
+                });
+            }
+        ));
+
+        // ── Chart 2: Validations per day (stacked agree/disagree/unsure) ───────
+        container.appendChild(makeChart(
+            'Human Validations per Day (All Deployments)',
+            'Daily validation activity breakdown across all cities (last 90 days)',
+            chartContainer => {
+                const canvas = document.createElement('canvas');
+                chartContainer.appendChild(canvas);
+                new Chart(canvas.getContext('2d'), {
+                    type: 'bar',
+                    data: {
+                        labels: dates,
+                        datasets: [
+                            {
+                                label: 'Agree',
+                                data: dailyTotals(dates, byDay, 'human_validations_agree'),
+                                backgroundColor: 'rgba(92,184,92,0.8)',
+                                stack: 'val'
+                            },
+                            {
+                                label: 'Disagree',
+                                data: dailyTotals(dates, byDay, 'human_validations_disagree'),
+                                backgroundColor: 'rgba(217,83,79,0.8)',
+                                stack: 'val'
+                            },
+                            {
+                                label: 'Unsure',
+                                data: dailyTotals(dates, byDay, 'human_validations_unsure'),
+                                backgroundColor: 'rgba(240,173,78,0.8)',
+                                stack: 'val'
+                            }
+                        ]
+                    },
+                    options: chartOptions('Validations', { stacked: true })
+                });
+            }
+        ));
+
+        // ── Chart 3: Labels per day by type (all cities, human only) ───────────
+        const labelTypes = Array.from(
+            new Set(data.map(r => r.label_type))
+        ).sort();
+        container.appendChild(makeChart(
+            'Human Labels per Day by Label Type (All Deployments)',
+            'Each line represents one label type summed across all cities',
+            chartContainer => {
+                const canvas = document.createElement('canvas');
+                chartContainer.appendChild(canvas);
+                new Chart(canvas.getContext('2d'), {
+                    type: 'line',
+                    data: {
+                        labels: dates,
+                        datasets: labelTypes.map(lt => ({
+                            label: lt,
+                            data: dates.map(d => ((byDay.get(d) || new Map()).get(lt) || {}).human_labels || 0),
+                            borderColor: LABEL_TYPE_COLORS[lt] || '#999',
+                            backgroundColor: 'transparent',
+                            tension: 0.3,
+                            pointRadius: dates.length > 60 ? 0 : 2
+                        }))
+                    },
+                    options: chartOptions('Labels placed')
+                });
+            }
+        ));
+    }
+
+    /**
+     * Builds a standard Chart.js options object.
+     * @param {string} yLabel
+     * @param {{stacked?: boolean}} [opts]
+     * @returns {object}
+     */
+    function chartOptions(yLabel, opts = {}) {
+        return {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: { legend: { position: 'bottom' } },
+            scales: {
+                x: {
+                    ticks: { maxTicksLimit: 10, maxRotation: 45 },
+                    stacked: !!opts.stacked
+                },
+                y: {
+                    beginAtZero: true,
+                    stacked: !!opts.stacked,
+                    title: { display: true, text: yLabel }
+                }
+            }
+        };
+    }
+
+    /**
+     * Creates a labelled chart wrapper div.
+     * @param {string} title
+     * @param {string} description
+     * @param {Function} builder - Receives the inner div and should append a canvas.
+     * @returns {HTMLElement}
+     */
+    function makeChart(title, description, builder) {
+        const wrap = document.createElement('div');
+        wrap.className = 'preview-chart-section';
+        wrap.innerHTML = `
+            <h3 class="preview-chart-title">${title}</h3>
+            <p class="preview-chart-desc">${description}</p>
+        `;
+        const inner = document.createElement('div');
+        inner.style.cssText = 'position:relative;height:280px;width:100%';
+        wrap.appendChild(inner);
+        builder(inner);
+        return wrap;
+    }
+
+    window.AggregateStatsByDayPreview = {
+        /**
+         * @param {object} options
+         * @returns {object} this
+         */
+        setup: function(options) {
+            config = Object.assign(config, options);
+            return this;
+        },
+
+        /**
+         * Fetch data and render charts.
+         * @returns {Promise}
+         */
+        init: function() {
+            const container = document.getElementById(config.containerId);
+            if (!container) return Promise.reject(new Error('Container not found'));
+
+            container.innerHTML = '<p style="text-align:center;color:#888;padding:40px 0">Loading…</p>';
+
+            const startDate = dateString(90);
+            const url = `${config.apiBaseUrl}/aggregateStatsByDay?startDate=${startDate}&source=apiDocs`;
+
+            return fetch(url)
+                .then(r => {
+                    if (!r.ok) throw new Error(`HTTP ${r.status}`);
+                    return r.json();
+                })
+                .then(json => {
+                    container.innerHTML = '';
+                    render(container, json.data || []);
+                })
+                .catch(err => {
+                    showError(container, `Failed to load preview: ${err.message}`);
+                    console.error('AggregateStatsByDayPreview error:', err);
+                });
+        }
+    };
+})();

--- a/public/javascripts/api-docs/aggregate-stats-by-day-preview.js
+++ b/public/javascripts/api-docs/aggregate-stats-by-day-preview.js
@@ -9,18 +9,6 @@
  * @requires Chart.js library (chart-4.5.1.min.js)
  */
 (function() {
-    const LABEL_TYPE_COLORS = {
-        CurbRamp: '#5cb85c',
-        NoCurbRamp: '#d9534f',
-        Obstacle: '#f0ad4e',
-        SurfaceProblem: '#9b59b6',
-        NoSidewalk: '#d35400',
-        Crosswalk: '#3498db',
-        Signal: '#1abc9c',
-        Occlusion: '#95a5a6',
-        Other: '#7f8c8d'
-    };
-
     /** @type {{apiBaseUrl: string, containerId: string}} */
     let config = {
         apiBaseUrl: '/v3/api',
@@ -204,7 +192,7 @@
                         datasets: labelTypes.map(lt => ({
                             label: lt,
                             data: dates.map(d => ((byDay.get(d) || new Map()).get(lt) || {}).human_labels || 0),
-                            borderColor: LABEL_TYPE_COLORS[lt] || '#999',
+                            borderColor: util.misc.getLabelColors(lt) || '#B3B3B3',
                             backgroundColor: 'transparent',
                             tension: 0.3,
                             pointRadius: dates.length > 60 ? 0 : 2

--- a/public/javascripts/api-docs/overall-stats-by-day-preview.js
+++ b/public/javascripts/api-docs/overall-stats-by-day-preview.js
@@ -1,0 +1,287 @@
+/**
+ * Project Sidewalk Overall Stats by Day Preview Generator.
+ *
+ * Renders a live time-series visualization for the Overall Stats by Day API endpoint, showing
+ * daily label and validation activity for the current city over the last 90 days.
+ *
+ * @requires DOM element with id 'overall-stats-by-day-preview'
+ * @requires Chart.js library (chart-4.5.1.min.js)
+ */
+(function() {
+    const LABEL_TYPE_COLORS = {
+        CurbRamp: '#5cb85c',
+        NoCurbRamp: '#d9534f',
+        Obstacle: '#f0ad4e',
+        SurfaceProblem: '#9b59b6',
+        NoSidewalk: '#d35400',
+        Crosswalk: '#3498db',
+        Signal: '#1abc9c',
+        Occlusion: '#95a5a6',
+        Other: '#7f8c8d'
+    };
+
+    /** @type {{apiBaseUrl: string, containerId: string, cityName: string}} */
+    let config = {
+        apiBaseUrl: '/v3/api',
+        containerId: 'overall-stats-by-day-preview',
+        cityName: 'this city'
+    };
+
+    /**
+     * Returns a date string YYYY-MM-DD for `daysAgo` days before today.
+     * @param {number} daysAgo
+     * @returns {string}
+     */
+    function dateString(daysAgo) {
+        const d = new Date();
+        d.setDate(d.getDate() - daysAgo);
+        return d.toISOString().slice(0, 10);
+    }
+
+    /** @param {string} msg */
+    function showError(container, msg) {
+        container.innerHTML = `<p style="color:var(--color-danger,#d9534f);text-align:center;padding:40px 0">${msg}</p>`;
+    }
+
+    /**
+     * Builds a lookup: date → { labelType → record } from the flat data array.
+     * @param {Array<object>} data
+     * @returns {Map<string, Map<string, object>>}
+     */
+    function buildDailyMap(data) {
+        const map = new Map();
+        data.forEach(row => {
+            if (!map.has(row.date)) map.set(row.date, new Map());
+            map.get(row.date).set(row.label_type, row);
+        });
+        return map;
+    }
+
+    /**
+     * Aggregates daily totals (summed across all label types) for a field.
+     * @param {string[]} dates - Sorted date strings
+     * @param {Map<string, Map<string, object>>} byDay
+     * @param {string} field
+     * @returns {number[]}
+     */
+    function dailyTotals(dates, byDay, field) {
+        return dates.map(d => {
+            let total = 0;
+            (byDay.get(d) || new Map()).forEach(row => { total += (row[field] || 0); });
+            return total;
+        });
+    }
+
+    /**
+     * Renders the summary stats bar and two charts.
+     * @param {HTMLElement} container
+     * @param {Array<object>} data
+     */
+    function render(container, data) {
+        if (!data.length) {
+            container.innerHTML = '<p style="text-align:center;color:#888;padding:40px 0">No data available for this period.</p>';
+            return;
+        }
+
+        const byDay = buildDailyMap(data);
+        const dates = Array.from(byDay.keys()).sort();
+
+        // ── Summary stats ──────────────────────────────────────────────────────
+        const totalHumanLabels = data.reduce((s, r) => s + r.human_labels, 0);
+        const totalAiLabels    = data.reduce((s, r) => s + r.ai_labels, 0);
+        const totalAgree       = data.reduce((s, r) => s + r.human_validations_agree, 0);
+        const totalDisagree    = data.reduce((s, r) => s + r.human_validations_disagree, 0);
+        const totalUnsure      = data.reduce((s, r) => s + r.human_validations_unsure, 0);
+        const totalValidations = totalAgree + totalDisagree + totalUnsure;
+        const accuracy         = totalValidations > 0
+            ? ((totalAgree / totalValidations) * 100).toFixed(1)
+            : 'N/A';
+
+        const summaryEl = document.createElement('div');
+        summaryEl.className = 'preview-summary-grid';
+        summaryEl.innerHTML = `
+            <div class="preview-stat"><span class="preview-stat-value">${dates.length}</span><span class="preview-stat-label">Days shown</span></div>
+            <div class="preview-stat"><span class="preview-stat-value">${totalHumanLabels.toLocaleString()}</span><span class="preview-stat-label">Human labels</span></div>
+            <div class="preview-stat"><span class="preview-stat-value">${totalAiLabels.toLocaleString()}</span><span class="preview-stat-label">AI labels</span></div>
+            <div class="preview-stat"><span class="preview-stat-value">${totalValidations.toLocaleString()}</span><span class="preview-stat-label">Validations</span></div>
+            <div class="preview-stat"><span class="preview-stat-value">${accuracy}%</span><span class="preview-stat-label">Agreement rate</span></div>
+        `;
+        container.appendChild(summaryEl);
+
+        // ── Chart 1: Human labels per day ───────────────────────────────────────
+        container.appendChild(makeChart(
+            'Human Labels per Day',
+            `Daily new labels placed by human contributors in ${config.cityName} (last 90 days)`,
+            chartContainer => {
+                const canvas = document.createElement('canvas');
+                chartContainer.appendChild(canvas);
+                new Chart(canvas.getContext('2d'), {
+                    type: 'line',
+                    data: {
+                        labels: dates,
+                        datasets: [{
+                            label: 'Human Labels',
+                            data: dailyTotals(dates, byDay, 'human_labels'),
+                            borderColor: 'var(--color-primary, #2c77b1)',
+                            backgroundColor: 'rgba(44,119,177,0.12)',
+                            fill: true,
+                            tension: 0.3,
+                            pointRadius: dates.length > 60 ? 0 : 3
+                        }]
+                    },
+                    options: chartOptions('Labels placed')
+                });
+            }
+        ));
+
+        // ── Chart 2: Validations per day (agree / disagree / unsure) ───────────
+        container.appendChild(makeChart(
+            'Validations per Day',
+            `Daily validation activity breakdown in ${config.cityName} (last 90 days)`,
+            chartContainer => {
+                const canvas = document.createElement('canvas');
+                chartContainer.appendChild(canvas);
+                new Chart(canvas.getContext('2d'), {
+                    type: 'bar',
+                    data: {
+                        labels: dates,
+                        datasets: [
+                            {
+                                label: 'Agree',
+                                data: dailyTotals(dates, byDay, 'human_validations_agree'),
+                                backgroundColor: 'rgba(92,184,92,0.8)',
+                                stack: 'val'
+                            },
+                            {
+                                label: 'Disagree',
+                                data: dailyTotals(dates, byDay, 'human_validations_disagree'),
+                                backgroundColor: 'rgba(217,83,79,0.8)',
+                                stack: 'val'
+                            },
+                            {
+                                label: 'Unsure',
+                                data: dailyTotals(dates, byDay, 'human_validations_unsure'),
+                                backgroundColor: 'rgba(240,173,78,0.8)',
+                                stack: 'val'
+                            }
+                        ]
+                    },
+                    options: chartOptions('Validations', { stacked: true })
+                });
+            }
+        ));
+
+        // ── Chart 3: Labels per day by type ────────────────────────────────────
+        const labelTypes = Array.from(
+            new Set(data.map(r => r.label_type))
+        ).sort();
+        container.appendChild(makeChart(
+            'Human Labels per Day by Label Type',
+            'Each line represents one label type',
+            chartContainer => {
+                const canvas = document.createElement('canvas');
+                chartContainer.appendChild(canvas);
+                new Chart(canvas.getContext('2d'), {
+                    type: 'line',
+                    data: {
+                        labels: dates,
+                        datasets: labelTypes.map(lt => ({
+                            label: lt,
+                            data: dates.map(d => ((byDay.get(d) || new Map()).get(lt) || {}).human_labels || 0),
+                            borderColor: LABEL_TYPE_COLORS[lt] || '#999',
+                            backgroundColor: 'transparent',
+                            tension: 0.3,
+                            pointRadius: dates.length > 60 ? 0 : 2
+                        }))
+                    },
+                    options: chartOptions('Labels placed')
+                });
+            }
+        ));
+    }
+
+    /**
+     * Builds a standard Chart.js options object for these previews.
+     * @param {string} yLabel
+     * @param {{stacked?: boolean}} [opts]
+     * @returns {object}
+     */
+    function chartOptions(yLabel, opts = {}) {
+        return {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: { legend: { position: 'bottom' } },
+            scales: {
+                x: {
+                    ticks: { maxTicksLimit: 10, maxRotation: 45 },
+                    stacked: !!opts.stacked
+                },
+                y: {
+                    beginAtZero: true,
+                    stacked: !!opts.stacked,
+                    title: { display: true, text: yLabel }
+                }
+            }
+        };
+    }
+
+    /**
+     * Creates a labelled chart wrapper div.
+     * @param {string} title
+     * @param {string} description
+     * @param {Function} builder - Receives the inner div and should append a canvas.
+     * @returns {HTMLElement}
+     */
+    function makeChart(title, description, builder) {
+        const wrap = document.createElement('div');
+        wrap.className = 'preview-chart-section';
+        wrap.innerHTML = `
+            <h3 class="preview-chart-title">${title}</h3>
+            <p class="preview-chart-desc">${description}</p>
+        `;
+        const inner = document.createElement('div');
+        inner.style.cssText = 'position:relative;height:280px;width:100%';
+        wrap.appendChild(inner);
+        builder(inner);
+        return wrap;
+    }
+
+    window.OverallStatsByDayPreview = {
+        /**
+         * @param {object} options
+         * @returns {object} this
+         */
+        setup: function(options) {
+            config = Object.assign(config, options);
+            return this;
+        },
+
+        /**
+         * Fetch data and render charts.
+         * @returns {Promise}
+         */
+        init: function() {
+            const container = document.getElementById(config.containerId);
+            if (!container) return Promise.reject(new Error('Container not found'));
+
+            container.innerHTML = '<p style="text-align:center;color:#888;padding:40px 0">Loading…</p>';
+
+            const startDate = dateString(90);
+            const url = `${config.apiBaseUrl}/overallStatsByDay?startDate=${startDate}&source=apiDocs`;
+
+            return fetch(url)
+                .then(r => {
+                    if (!r.ok) throw new Error(`HTTP ${r.status}`);
+                    return r.json();
+                })
+                .then(json => {
+                    container.innerHTML = '';
+                    render(container, json.data || []);
+                })
+                .catch(err => {
+                    showError(container, `Failed to load preview: ${err.message}`);
+                    console.error('OverallStatsByDayPreview error:', err);
+                });
+        }
+    };
+})();

--- a/public/javascripts/api-docs/overall-stats-by-day-preview.js
+++ b/public/javascripts/api-docs/overall-stats-by-day-preview.js
@@ -2,7 +2,7 @@
  * Project Sidewalk Overall Stats by Day Preview Generator.
  *
  * Renders a live time-series visualization for the Overall Stats by Day API endpoint, showing
- * daily label and validation activity for the current city over the last 90 days.
+ * daily label and validation activity for the current city (most recent 90 days with data).
  *
  * @requires DOM element with id 'overall-stats-by-day-preview'
  * @requires Chart.js library (chart-4.5.1.min.js)
@@ -26,17 +26,6 @@
         containerId: 'overall-stats-by-day-preview',
         cityName: 'this city'
     };
-
-    /**
-     * Returns a date string YYYY-MM-DD for `daysAgo` days before today.
-     * @param {number} daysAgo
-     * @returns {string}
-     */
-    function dateString(daysAgo) {
-        const d = new Date();
-        d.setDate(d.getDate() - daysAgo);
-        return d.toISOString().slice(0, 10);
-    }
 
     /** @param {string} msg */
     function showError(container, msg) {
@@ -70,6 +59,18 @@
             (byDay.get(d) || new Map()).forEach(row => { total += (row[field] || 0); });
             return total;
         });
+    }
+
+    /**
+     * Keeps only rows from the most recent `maxDays` unique dates in the data.
+     * @param {Array<object>} data
+     * @param {number} maxDays
+     * @returns {Array<object>}
+     */
+    function trimToRecentDays(data, maxDays) {
+        const dates = Array.from(new Set(data.map(r => r.date))).sort();
+        const cutoff = dates.length > maxDays ? dates[dates.length - maxDays] : dates[0];
+        return data.filter(r => r.date >= cutoff);
     }
 
     /**
@@ -111,7 +112,7 @@
         // ── Chart 1: Human labels per day ───────────────────────────────────────
         container.appendChild(makeChart(
             'Human Labels per Day',
-            `Daily new labels placed by human contributors in ${config.cityName} (last 90 days)`,
+            `Daily new labels placed by human contributors in ${config.cityName}`,
             chartContainer => {
                 const canvas = document.createElement('canvas');
                 chartContainer.appendChild(canvas);
@@ -137,7 +138,7 @@
         // ── Chart 2: Validations per day (agree / disagree / unsure) ───────────
         container.appendChild(makeChart(
             'Validations per Day',
-            `Daily validation activity breakdown in ${config.cityName} (last 90 days)`,
+            `Daily validation activity breakdown in ${config.cityName}`,
             chartContainer => {
                 const canvas = document.createElement('canvas');
                 chartContainer.appendChild(canvas);
@@ -266,8 +267,7 @@
 
             container.innerHTML = '<p style="text-align:center;color:#888;padding:40px 0">Loading…</p>';
 
-            const startDate = dateString(90);
-            const url = `${config.apiBaseUrl}/overallStatsByDay?startDate=${startDate}&source=apiDocs`;
+            const url = `${config.apiBaseUrl}/overallStatsByDay?source=apiDocs`;
 
             return fetch(url)
                 .then(r => {
@@ -276,7 +276,8 @@
                 })
                 .then(json => {
                     container.innerHTML = '';
-                    render(container, json.data || []);
+                    // Trim to the most recent 90 days that have data for readability.
+                    render(container, trimToRecentDays(json.data || [], 90));
                 })
                 .catch(err => {
                     showError(container, `Failed to load preview: ${err.message}`);

--- a/public/javascripts/api-docs/overall-stats-by-day-preview.js
+++ b/public/javascripts/api-docs/overall-stats-by-day-preview.js
@@ -8,18 +8,6 @@
  * @requires Chart.js library (chart-4.5.1.min.js)
  */
 (function() {
-    const LABEL_TYPE_COLORS = {
-        CurbRamp: '#5cb85c',
-        NoCurbRamp: '#d9534f',
-        Obstacle: '#f0ad4e',
-        SurfaceProblem: '#9b59b6',
-        NoSidewalk: '#d35400',
-        Crosswalk: '#3498db',
-        Signal: '#1abc9c',
-        Occlusion: '#95a5a6',
-        Other: '#7f8c8d'
-    };
-
     /** @type {{apiBaseUrl: string, containerId: string, cityName: string}} */
     let config = {
         apiBaseUrl: '/v3/api',
@@ -189,7 +177,7 @@
                         datasets: labelTypes.map(lt => ({
                             label: lt,
                             data: dates.map(d => ((byDay.get(d) || new Map()).get(lt) || {}).human_labels || 0),
-                            borderColor: LABEL_TYPE_COLORS[lt] || '#999',
+                            borderColor: util.misc.getLabelColors(lt) || '#B3B3B3',
                             backgroundColor: 'transparent',
                             tension: 0.3,
                             pointRadius: dates.length > 60 ? 0 : 2

--- a/public/stylesheets/api-docs/stats-by-day.css
+++ b/public/stylesheets/api-docs/stats-by-day.css
@@ -1,0 +1,61 @@
+/**
+ * Shared styles for the Overall Stats by Day and Aggregate Stats by Day API preview visualizations.
+ */
+
+.preview-summary-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 12px;
+    margin-bottom: 24px;
+    padding: 16px;
+    background-color: var(--color-background-secondary, #f9f9f9);
+    border: 1px solid var(--color-border, #e0e0e0);
+    border-radius: 4px;
+}
+
+.preview-stat {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+}
+
+.preview-stat-value {
+    font-size: 1.5em;
+    font-weight: bold;
+    color: var(--color-text-primary, #222);
+    line-height: 1.2;
+}
+
+.preview-stat-label {
+    font-size: 0.8em;
+    color: var(--color-text-secondary, #666);
+    margin-top: 4px;
+}
+
+.preview-chart-section {
+    margin-bottom: 32px;
+    padding: 16px;
+    background-color: var(--color-background-secondary, #f9f9f9);
+    border: 1px solid var(--color-border, #e0e0e0);
+    border-radius: 4px;
+    transition: transform 0.15s, box-shadow 0.15s;
+}
+
+.preview-chart-section:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 8px rgba(0,0,0,0.08);
+}
+
+.preview-chart-title {
+    text-align: center;
+    font-size: 1.05em;
+    margin: 0 0 4px;
+}
+
+.preview-chart-desc {
+    text-align: center;
+    font-size: 0.85em;
+    color: var(--color-text-secondary, #666);
+    margin: 0 0 12px;
+}


### PR DESCRIPTION
## Summary

- Adds two new v3 API endpoints providing daily time-series of label and validation activity, broken down by label type and human vs AI actor
- `/v3/api/overallStatsByDay` — current city only (per-day, per-label-type counts)
- `/v3/api/aggregateStatsByDay` — project-wide, summing all configured city deployments

Both endpoints support:
- `startDate` / `endDate` (YYYY-MM-DD, US/Pacific bucketing) with 400 validation on bad/reversed dates
- `filterLowQuality` (mirrors the `overallStats` convention)
- `filetype=json|csv` output

Also includes full API docs pages for both endpoints with sidebar nav entries and **live interactive previews** — summary stats grid plus three Chart.js charts (labels per day, validations per day broken down by agree/disagree/unsure, and human labels per day by label type using canonical Project Sidewalk label colors via `util.misc.getLabelColors()`).

Closes #4274.

## Implementation notes

- Label dates are bucketed via `label.time_created AT TIME ZONE 'US/Pacific'`; validation dates via `label_validation.end_timestamp AT TIME ZONE 'US/Pacific'`
- `validation_result` is compared via `::text` cast to work across both integer (Seattle-style) and `validation_option` enum (Teaneck-style) city schemas — matches the existing pattern in the codebase
- Aggregate queries each city schema in parallel (same `checkSchemaExists` guard as `getAggregateStats`), then sums by `(date, labelType)` in Scala
- Legacy DC dataset omitted from aggregate (predates the current `label_validation` format)
- New model: `app/models/api/DailyStatsApiModels.scala` with `DailyStatRecord`, `merge()` helper, and snake_case JSON serialization via scoped `JsonConfiguration`
- Preview fetches all available data and trims client-side to the most recent 90 unique dates, so it works on dev instances with older data as well as production

## Test plan

- [x] `sbt --client compile` passes with `[success]` (warning-clean)
- [x] `GET /v3/api/overallStatsByDay` returns 200 with valid JSON
- [x] `GET /v3/api/overallStatsByDay?startDate=2024-01-01&endDate=2024-01-07` returns 200 with filtered data
- [x] `GET /v3/api/overallStatsByDay?filterLowQuality=true` returns 200
- [x] `GET /v3/api/overallStatsByDay?filetype=csv` returns 200 with correct CSV header
- [x] `GET /v3/api/aggregateStatsByDay?startDate=2024-01-01&endDate=2024-01-07` returns 200
- [x] `GET /v3/api/overallStatsByDay?startDate=not-a-date` returns 400 with `INVALID_PARAMETER`
- [x] `GET /v3/api/overallStatsByDay?startDate=2024-12-01&endDate=2024-01-01` returns 400 (startDate > endDate)
- [x] API docs pages load at `/v3/api-docs/overall-stats-by-day` and `/v3/api-docs/aggregate-stats-by-day`
- [x] Sidebar nav shows "Overall Stats by Day" and "Aggregate Stats by Day" under Stat APIs
- [x] Live preview charts render with correct Project Sidewalk label type colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)