### PR TITLE
Remove admin dashboard redesign routes accidentally committed to develop

### DIFF
--- a/conf/routes
+++ b/conf/routes
@@ -50,14 +50,6 @@ GET     /cityMapParams                                  controllers.ConfigContro
 
 # Admin
 GET     /admin                                          controllers.AdminController.index
-GET     /admin/overview                                 controllers.AdminController.overview
-GET     /admin/map                                      controllers.AdminController.adminMap
-GET     /admin/analytics                                controllers.AdminController.adminAnalytics
-GET     /admin/labels                                   controllers.AdminController.adminLabels
-GET     /admin/users                                    controllers.AdminController.adminUsers
-GET     /admin/label-search                             controllers.AdminController.adminLabelSearch
-GET     /admin/teams                                    controllers.AdminController.adminTeams
-GET     /admin/api-analytics                            controllers.AdminController.adminApiAnalytics
 GET     /admin/user/:username                           controllers.AdminController.userProfile(username: String)
 GET     /admin/task/:taskId                             controllers.AdminController.task(taskId: Int)
 GET     /admin/label/:labelId                           controllers.AdminController.label(labelId: Int)


### PR DESCRIPTION
## Problem

`develop` does not compile. `conf/routes` references 8 `AdminController` page methods that don't exist on develop:

```
GET /admin/overview       controllers.AdminController.overview
GET /admin/map            controllers.AdminController.adminMap
GET /admin/analytics      controllers.AdminController.adminAnalytics
GET /admin/labels         controllers.AdminController.adminLabels
GET /admin/users          controllers.AdminController.adminUsers
GET /admin/label-search   controllers.AdminController.adminLabelSearch
GET /admin/teams          controllers.AdminController.adminTeams
GET /admin/api-analytics  controllers.AdminController.adminApiAnalytics
```

The compiler fails with `value overview is not a member of controllers.AdminController` (×8).

## Root cause

These routes are part of the **admin dashboard redesign (#4272)**, which splits the admin dashboard into separate pages. The redesign — including the `AdminController` methods and Twirl templates these routes point to — lives on the **`4272-admin-dashboard-redesign`** branch and has **not** been merged to develop.

The route lines leaked into develop via commit `dac9e9486` (*"Add /v3/api/overallStatsByDay and /v3/api/aggregateStatsByDay endpoints"*, #4274): they were present as uncommitted working-tree changes when that API commit was made, so `git commit` swept them in. Only the routes leaked — the controller methods and templates correctly stayed on #4272.

## Fix

Remove the 8 dangling route lines. Nothing else on develop references them, and removing them restores a clean compile. They will re-land **together with** their controller methods and templates when #4272 is merged.

## Verification

- Removing exactly these 8 lines makes the project compile cleanly (`sbt compile`, `-Xfatal-warnings`); with them present, compilation fails with the 8 errors above.
- No `AdminController` methods, templates, or other code are touched — this is a pure 8-line deletion in `conf/routes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)