### PR TITLE
Consolidate API data structures into models.api (#3885)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,29 @@ Request flow: **routes → Controller → Service → Table (DAO)**.
 - **DI**: Guice. App bootstraps via `app/CustomApplicationLoader.scala`; modules registered in `conf/application.conf` and defined in `app/modules/` (`CustomControllerModule`, `ActorModule`, `ExecutorsModule`, `SilhouetteModule`). Custom execution contexts are in `app/executors/`; background actors in `app/actor/`.
 - **Views**: Twirl templates (`app/views/*.scala.html`). The sbt build silences warnings in `views/` and the routes file specifically.
 
+### API data structures (`app/models/api/`)
+
+The data structures (DTOs) returned by the public `/v3` API live in **`app/models/api/`** (`package models.api`), in
+per-domain files named `*ApiModels.scala` (`LabelApiModels.scala`, `StreetsApiModels.scala`, `UserStatsApiModels.scala`,
+...). This is the canonical home — do **not** define new API DTOs inside `*Table.scala` DAO files (issue #3885). Each DAO
+file produces its DTOs but the DTO *definitions* belong in `models.api`. The convention:
+
+- **Naming**: response types are `*ForApi` (e.g. `LabelDataForApi`, `UserStatForApi`); parsed query filters are
+  `*FiltersForApi` (e.g. `RawLabelFiltersForApi`).
+- **Streaming**: response DTOs extend **`StreamingApiType`** (`app/models/api/StreamingApiType.scala`) and implement
+  `toJson` / `toCsvRow` **inline** on the case class, so `BaseApiController`'s `outputJSON`/`outputCSV`/`outputGeoJSON`
+  helpers can serialize a stream of them uniformly. Serialization lives *on the DTO*, not as free functions elsewhere.
+- **Companion object** holds the `csvHeader` string (keep it next to `toCsvRow` so columns can't drift) and JSON writers.
+- **snake_case JSON** per #3871: derive writers with a scoped `JsonConfiguration(JsonNaming.SnakeCase)` +
+  `Json.format`/`Json.writes`, or hand-build the `JsObject` with snake_case keys for nested/custom shapes.
+- **Shared helpers**: reuse `ApiModelUtils` (`escapeCsvField`, `createGeoJsonPointGeometry`, ...) rather than re-rolling
+  CSV/GeoJSON logic.
+
+**Known exception**: the older `/v2` access-score DTOs (`StreetScore`, `RegionScore` in `models/computation/`,
+`ClusterForApi` in `models/cluster/`) intentionally remain in place pending the v3 access-score rewrite (#3855) and v2
+removal (#3864). `app/formats/json/ApiFormats.scala` holds their serializers plus other non-DTO writes; new API DTOs
+should not add to it.
+
 ### Database & evolutions
 
 Schema changes are **Play evolutions**: numbered SQL files in `conf/evolutions/default/`. Add the next-numbered file for schema changes; each has `# --- !Ups` and `# --- !Downs` sections. The dev DB is seeded from a dump — see the wiki and `db/scripts/` (`import-dump`, `create-new-schema`, etc., exposed as `make` targets). Connection config is env-driven (`DATABASE_URL`, `DATABASE_USER`, `DATABASE_PASSWORD`) in `conf/application.conf`.

--- a/app/controllers/api/BaseApiController.scala
+++ b/app/controllers/api/BaseApiController.scala
@@ -2,8 +2,7 @@ package controllers.api
 
 import controllers.base.{CustomBaseController, CustomControllerComponents}
 import controllers.helper.ShapefilesCreatorHelper
-import models.api.ApiError
-import models.computation.StreamingApiType
+import models.api.{ApiError, StreamingApiType}
 import models.utils.{LatLngBBox, MapParams}
 import org.apache.pekko.stream.scaladsl.{Source, StreamConverters}
 import org.apache.pekko.util.ByteString

--- a/app/controllers/api/LabelApiController.scala
+++ b/app/controllers/api/LabelApiController.scala
@@ -4,7 +4,7 @@ import controllers.base.CustomControllerComponents
 import controllers.helper.ShapefilesCreatorHelper
 import formats.json.ApiFormats._
 import models.api._
-import models.label.{LabelCVMetadata, LabelTypeEnum}
+import models.label.LabelTypeEnum
 import org.apache.pekko.stream.scaladsl.Source
 import play.api.libs.json.Json
 import play.silhouette.api.Silhouette

--- a/app/controllers/api/StatsApiController.scala
+++ b/app/controllers/api/StatsApiController.scala
@@ -3,9 +3,8 @@ package controllers.api
 import controllers.base.CustomControllerComponents
 import controllers.helper.ControllerUtils.labelTypeOrdering
 import formats.json.ApiFormats._
-import models.api.{ApiError, DailyStatRecord}
+import models.api.{ApiError, DailyStatRecord, UserStatForApi}
 import models.label.ProjectSidewalkStats
-import models.user.UserStatApi
 import play.api.Logger
 import play.api.libs.json.{JsObject, Json}
 import play.api.mvc.Result
@@ -64,7 +63,7 @@ class StatsApiController @Inject() (
         highQualityOnly = highQualityOnly.getOrElse(false),
         minAccuracy = minAccuracy
       )
-      .map { filteredStats: Seq[UserStatApi] =>
+      .map { filteredStats: Seq[UserStatForApi] =>
         val baseFileName: String = s"userStats_${OffsetDateTime.now()}"
         cc.loggingService.insert(request.identity.map(_.userId), request.ipAddress, request.toString)
 
@@ -73,12 +72,12 @@ class StatsApiController @Inject() (
           case Some("csv") =>
             val userStatsFile = new java.io.File(s"$baseFileName.csv")
             val writer        = new java.io.PrintStream(userStatsFile)
-            writer.println(UserStatApi.csvHeader)
-            filteredStats.foreach(userStat => writer.println(userStatToCSVRow(userStat)))
+            writer.println(UserStatForApi.csvHeader)
+            filteredStats.foreach(userStat => writer.println(userStat.toCsvRow))
             writer.close()
             Ok.sendFile(content = userStatsFile, onClose = () => { userStatsFile.delete(); () })
           case _ =>
-            Ok(Json.toJson(filteredStats.map(userStatToJson)))
+            Ok(Json.toJson(filteredStats.map(_.toJson)))
         }
       }
   }

--- a/app/formats/json/ApiFormats.scala
+++ b/app/formats/json/ApiFormats.scala
@@ -6,7 +6,6 @@ import models.computation.{RegionScore, StreetScore}
 import models.label._
 import models.pano.{PanoDataSlim, PanoSource}
 import models.region.Region
-import models.user.{LabelTypeStat, UserStatApi}
 import models.utils.MapParams
 import models.utils.MyPostgresProfile.api._
 import org.locationtech.jts.geom.MultiPolygon
@@ -16,7 +15,6 @@ import play.api.libs.json._
 import java.time.OffsetDateTime
 
 object ApiFormats {
-  private def formatOptionForCSV(x: Option[Any]): String = { x.map(_.toString).getOrElse("NA").replace("\"", "\"\"") }
 
   /**
    * Converts a Region object to JSON format
@@ -60,13 +58,6 @@ object ApiFormats {
       (__ \ "lat2").write[Double] and
       (__ \ "lng2").write[Double]
   )(unlift(MapParams.unapply))
-
-  implicit val labelTypeStatWrites: Writes[LabelTypeStat] = (
-    (__ \ "labels").write[Int] and
-      (__ \ "validated_correct").write[Int] and
-      (__ \ "validated_incorrect").write[Int] and
-      (__ \ "not_validated").write[Int]
-  )(unlift(LabelTypeStat.unapply))
 
   def regionScoreToJson(n: RegionScore): JsObject = {
     if (n.coverage > 0.0d) {
@@ -234,93 +225,6 @@ object ApiFormats {
         }
       )
     )
-  }
-
-  def userStatToJson(u: UserStatApi): JsObject = {
-    Json.obj(
-      "user_id"                      -> u.userId,
-      "labels"                       -> u.labels,
-      "meters_explored"              -> u.metersExplored,
-      "labels_per_meter"             -> u.labelsPerMeter,
-      "high_quality"                 -> u.highQuality,
-      "high_quality_manual"          -> u.highQualityManual,
-      "label_accuracy"               -> u.labelAccuracy,
-      "validated_labels"             -> u.validatedLabels,
-      "validations_received"         -> u.validationsReceived,
-      "labels_validated_correct"     -> u.labelsValidatedCorrect,
-      "labels_validated_incorrect"   -> u.labelsValidatedIncorrect,
-      "labels_not_validated"         -> u.labelsNotValidated,
-      "validations_given"            -> u.validationsGiven,
-      "dissenting_validations_given" -> u.dissentingValidationsGiven,
-      "agree_validations_given"      -> u.agreeValidationsGiven,
-      "disagree_validations_given"   -> u.disagreeValidationsGiven,
-      "unsure_validations_given"     -> u.unsureValidationsGiven,
-      "stats_by_label_type"          -> Json.obj(
-        "curb_ramp"         -> Json.toJson(u.statsByLabelType(LabelTypeEnum.CurbRamp.name)),
-        "no_curb_ramp"      -> Json.toJson(u.statsByLabelType(LabelTypeEnum.NoCurbRamp.name)),
-        "obstacle"          -> Json.toJson(u.statsByLabelType(LabelTypeEnum.Obstacle.name)),
-        "surface_problem"   -> Json.toJson(u.statsByLabelType(LabelTypeEnum.SurfaceProblem.name)),
-        "no_sidewalk"       -> Json.toJson(u.statsByLabelType(LabelTypeEnum.NoSidewalk.name)),
-        "marked_crosswalk"  -> Json.toJson(u.statsByLabelType(LabelTypeEnum.Crosswalk.name)),
-        "pedestrian_signal" -> Json.toJson(u.statsByLabelType(LabelTypeEnum.Signal.name)),
-        "cant_see_sidewalk" -> Json.toJson(u.statsByLabelType(LabelTypeEnum.Occlusion.name)),
-        "other"             -> Json.toJson(u.statsByLabelType(LabelTypeEnum.Other.name))
-      )
-    )
-  }
-
-  def userStatToCSVRow(s: UserStatApi): String = {
-    s"${s.userId},${s.labels},${s.metersExplored},${formatOptionForCSV(s.labelsPerMeter)},${s.highQuality}," +
-      s"${formatOptionForCSV(s.highQualityManual)},${formatOptionForCSV(s.labelAccuracy)},${s.validatedLabels}," +
-      s"${s.validationsReceived},${s.labelsValidatedCorrect},${s.labelsValidatedIncorrect},${s.labelsNotValidated}," +
-      s"${s.validationsGiven},${s.dissentingValidationsGiven},${s.agreeValidationsGiven}," +
-      s"${s.disagreeValidationsGiven},${s.unsureValidationsGiven}," +
-      s"${labelTypeStatToCSVRow(s.statsByLabelType(LabelTypeEnum.CurbRamp.name))}," +
-      s"${labelTypeStatToCSVRow(s.statsByLabelType(LabelTypeEnum.NoCurbRamp.name))}," +
-      s"${labelTypeStatToCSVRow(s.statsByLabelType(LabelTypeEnum.Obstacle.name))}," +
-      s"${labelTypeStatToCSVRow(s.statsByLabelType(LabelTypeEnum.SurfaceProblem.name))}," +
-      s"${labelTypeStatToCSVRow(s.statsByLabelType(LabelTypeEnum.NoSidewalk.name))}," +
-      s"${labelTypeStatToCSVRow(s.statsByLabelType(LabelTypeEnum.Crosswalk.name))}," +
-      s"${labelTypeStatToCSVRow(s.statsByLabelType(LabelTypeEnum.Signal.name))}," +
-      s"${labelTypeStatToCSVRow(s.statsByLabelType(LabelTypeEnum.Occlusion.name))}," +
-      s"${labelTypeStatToCSVRow(s.statsByLabelType(LabelTypeEnum.Other.name))}"
-  }
-
-  def labelCVMetadataToCSVRow(l: LabelCVMetadata): String = {
-    s"${l.labelId},${l.panoId},${l.labelTypeId},${l.agreeCount},${l.disagreeCount},${l.unsureCount}," +
-      s"${formatOptionForCSV(l.panoWidth)},${formatOptionForCSV(l.panoHeight)},${l.panoX},${l.panoY}," +
-      s"${l.canvasWidth},${l.canvasHeight},${l.canvasX},${l.canvasY},${l.zoom},${l.heading},${l.pitch}," +
-      s"${l.cameraHeading},${l.cameraPitch},${l.cameraRoll.map(_.toString).getOrElse("NA")}"
-  }
-
-  // Just uses implicit convert defined below.
-  def labelCVMetadataToJSON(l: LabelCVMetadata): JsValue = { Json.toJson(l) }
-
-  implicit val labelCVMetadataWrites: Writes[LabelCVMetadata] = (
-    (__ \ "label_id").write[Int] and
-      (__ \ "pano_id").write[String] and
-      (__ \ "label_type_id").write[Int] and
-      (__ \ "agree_count").write[Int] and
-      (__ \ "disagree_count").write[Int] and
-      (__ \ "unsure_count").write[Int] and
-      (__ \ "pano_width").writeNullable[Int] and
-      (__ \ "pano_height").writeNullable[Int] and
-      (__ \ "pano_x").write[Int] and
-      (__ \ "pano_y").write[Int] and
-      (__ \ "canvas_width").write[Int] and
-      (__ \ "canvas_height").write[Int] and
-      (__ \ "canvas_x").write[Int] and
-      (__ \ "canvas_y").write[Int] and
-      (__ \ "zoom").write[Double] and
-      (__ \ "heading").write[Double] and
-      (__ \ "pitch").write[Double] and
-      (__ \ "camera_heading").write[Double] and
-      (__ \ "camera_pitch").write[Double] and
-      (__ \ "camera_roll").writeNullable[Double]
-  )(unlift(LabelCVMetadata.unapply))
-
-  private def labelTypeStatToCSVRow(l: LabelTypeStat): String = {
-    s"${l.labels},${l.validatedCorrect},${l.validatedIncorrect},${l.notValidated}"
   }
 
   implicit val panoDataSlimWrites: Writes[PanoDataSlim] = (

--- a/app/models/api/LabelApiModels.scala
+++ b/app/models/api/LabelApiModels.scala
@@ -7,9 +7,8 @@
 package models.api
 
 import models.api.ApiModelUtils.{createGeoJsonPointGeometry, escapeCsvField}
-import models.computation.StreamingApiType
 import models.utils.LatLngBBox
-import play.api.libs.json.{JsObject, Json, JsonConfiguration, JsonNaming, OFormat, Writes}
+import play.api.libs.json.{JsObject, JsValue, Json, JsonConfiguration, JsonNaming, OFormat, Writes}
 
 import java.time.OffsetDateTime
 
@@ -307,4 +306,86 @@ object LabelDataForApi {
    * Implicit JSON writer for LabelData that uses the toJson method.
    */
   implicit val labelDataWrites: Writes[LabelDataForApi] = (label: LabelDataForApi) => label.toJson
+}
+
+/**
+ * Computer-vision metadata for a single label, used by the CV/ML export (`/adminapi/labels/cvMetadata`).
+ *
+ * Implements StreamingApiType to support streaming output formats like JSON and CSV. Holds the panorama
+ * and canvas geometry needed to locate the label within its Street View image.
+ *
+ * @param labelId Unique identifier for the label
+ * @param panoId Identifier of the panorama the label was placed on
+ * @param labelTypeId Numeric label type identifier
+ * @param agreeCount Number of "agree" validations the label received
+ * @param disagreeCount Number of "disagree" validations the label received
+ * @param unsureCount Number of "unsure" validations the label received
+ * @param panoWidth Panorama width in pixels, if known
+ * @param panoHeight Panorama height in pixels, if known
+ * @param panoX X coordinate of the label within the panorama
+ * @param panoY Y coordinate of the label within the panorama
+ * @param canvasWidth Width of the canvas the label was placed on
+ * @param canvasHeight Height of the canvas the label was placed on
+ * @param canvasX X coordinate of the label on the canvas
+ * @param canvasY Y coordinate of the label on the canvas
+ * @param zoom Zoom level when the label was placed
+ * @param heading Viewport heading when the label was placed
+ * @param pitch Viewport pitch when the label was placed
+ * @param cameraHeading Camera heading of the panorama
+ * @param cameraPitch Camera pitch of the panorama
+ * @param cameraRoll Camera roll of the panorama, if known
+ */
+case class LabelCVMetadata(
+    labelId: Int,
+    panoId: String,
+    labelTypeId: Int,
+    agreeCount: Int,
+    disagreeCount: Int,
+    unsureCount: Int,
+    panoWidth: Option[Int],
+    panoHeight: Option[Int],
+    panoX: Int,
+    panoY: Int,
+    canvasWidth: Int,
+    canvasHeight: Int,
+    canvasX: Int,
+    canvasY: Int,
+    zoom: Double,
+    heading: Double,
+    pitch: Double,
+    cameraHeading: Double,
+    cameraPitch: Double,
+    cameraRoll: Option[Double]
+) extends StreamingApiType {
+
+  /** Serializes to a JSON object with snake_case keys (#3871), via the companion's implicit Writes. */
+  override def toJson: JsValue = Json.toJson(this)
+
+  /**
+   * Serializes to a CSV row matching the companion object's `csvHeader`.
+   *
+   * @return A comma-separated row; `None` options render as "NA".
+   */
+  override def toCsvRow: String = {
+    s"${labelId},${panoId},${labelTypeId},${agreeCount},${disagreeCount},${unsureCount}," +
+      s"${formatOptionForCsv(panoWidth)},${formatOptionForCsv(panoHeight)},${panoX},${panoY}," +
+      s"${canvasWidth},${canvasHeight},${canvasX},${canvasY},${zoom},${heading},${pitch}," +
+      s"${cameraHeading},${cameraPitch},${cameraRoll.map(_.toString).getOrElse("NA")}"
+  }
+
+  /** Renders an option for CSV, using "NA" for `None` (matches the historical CV-metadata CSV format). */
+  private def formatOptionForCsv(x: Option[Any]): String = x.map(_.toString).getOrElse("NA").replace("\"", "\"\"")
+}
+
+/**
+ * Companion object for LabelCVMetadata containing the CSV header and JSON writer.
+ */
+object LabelCVMetadata {
+  val csvHeader: String = "Label ID,Panorama ID,Label Type ID,Agree Count,Disagree Count,Unsure Count,Panorama Width," +
+    "Panorama Height,Panorama X,Panorama Y,Canvas Width,Canvas Height,Canvas X,Canvas Y,Zoom,Heading,Pitch," +
+    "Camera Heading,Camera Pitch,Camera Roll\n"
+
+  // snake_case JSON output per the v3 API convention (#3871).
+  private implicit val config: JsonConfiguration = JsonConfiguration(JsonNaming.SnakeCase)
+  implicit val writes: Writes[LabelCVMetadata]   = Json.writes[LabelCVMetadata]
 }

--- a/app/models/api/LabelClustersApiModels.scala
+++ b/app/models/api/LabelClustersApiModels.scala
@@ -7,7 +7,6 @@
 package models.api
 
 import models.api.ApiModelUtils.{createGeoJsonPoint, escapeCsvField}
-import models.computation.StreamingApiType
 import models.utils.LatLngBBox
 import play.api.libs.json.{JsObject, Json, JsonConfiguration, JsonNaming, Writes}
 

--- a/app/models/api/RegionsApiModels.scala
+++ b/app/models/api/RegionsApiModels.scala
@@ -7,7 +7,6 @@
 package models.api
 
 import models.api.ApiModelUtils.escapeCsvField
-import models.computation.StreamingApiType
 import models.utils.LatLngBBox
 import models.utils.MyPostgresProfile.api._
 import org.locationtech.jts.geom.MultiPolygon

--- a/app/models/api/StreamingApiType.scala
+++ b/app/models/api/StreamingApiType.scala
@@ -1,0 +1,20 @@
+package models.api
+
+import play.api.libs.json.JsValue
+
+/**
+ * Common interface for public-API data structures (DTOs) that are streamed to clients.
+ *
+ * Every type returned by a `/v3` API endpoint implements this so `BaseApiController`'s output helpers
+ * (`outputJSON`, `outputCSV`, `outputGeoJSON`, ...) can serialize a heterogeneous stream uniformly. By
+ * convention each implementer defines these inline and pairs them with a companion `csvHeader` so the
+ * header and row columns stay in sync.
+ */
+trait StreamingApiType {
+
+  /** Serializes this record to JSON (a GeoJSON `Feature` for geospatial types, a plain object otherwise). */
+  def toJson: JsValue
+
+  /** Serializes this record to a single CSV row matching the companion object's `csvHeader`. */
+  def toCsvRow: String
+}

--- a/app/models/api/StreetsApiModels.scala
+++ b/app/models/api/StreetsApiModels.scala
@@ -6,7 +6,6 @@
 package models.api
 
 import models.api.ApiModelUtils.escapeCsvField
-import models.computation.StreamingApiType
 import models.utils.LatLngBBox
 import models.utils.MyPostgresProfile.api._
 import org.locationtech.jts.geom.LineString

--- a/app/models/api/UserStatsApiModels.scala
+++ b/app/models/api/UserStatsApiModels.scala
@@ -1,0 +1,152 @@
+/**
+ * Models for the Project Sidewalk User Stats API.
+ *
+ * This file contains the data structure returned by the `/v3/api/userStats` endpoint, summarizing each
+ * registered user's labeling and validation activity.
+ */
+package models.api
+
+import models.label.LabelTypeEnum
+import models.user.LabelTypeStat
+import play.api.libs.json.{JsObject, Json, Writes}
+
+/**
+ * Per-user labeling and validation statistics for the User Stats API.
+ *
+ * Implements StreamingApiType to support streaming output formats like JSON and CSV. `statsByLabelType`
+ * is keyed by `LabelTypeEnum` name and is expected to contain an entry for every label type.
+ *
+ * @param userId Anonymized user identifier
+ * @param labels Total number of labels the user has placed
+ * @param metersExplored Distance explored by the user, in meters
+ * @param labelsPerMeter Labels placed per meter explored, if computable
+ * @param highQuality Whether the user is currently considered high quality
+ * @param highQualityManual Manual high-quality override, if set
+ * @param labelAccuracy The user's label accuracy, if they have validated labels
+ * @param validatedLabels Number of the user's labels that have been validated
+ * @param validationsReceived Number of validations the user's labels have received
+ * @param labelsValidatedCorrect Number of the user's labels validated as correct
+ * @param labelsValidatedIncorrect Number of the user's labels validated as incorrect
+ * @param labelsNotValidated Number of the user's labels not yet validated
+ * @param validationsGiven Number of validations the user has given to others
+ * @param dissentingValidationsGiven Validations the user gave that disagreed with the majority
+ * @param agreeValidationsGiven Number of "agree" validations the user gave
+ * @param disagreeValidationsGiven Number of "disagree" validations the user gave
+ * @param unsureValidationsGiven Number of "unsure" validations the user gave
+ * @param statsByLabelType Per-label-type breakdown of label and validation counts
+ */
+case class UserStatForApi(
+    userId: String,
+    labels: Int,
+    metersExplored: Double,
+    labelsPerMeter: Option[Double],
+    highQuality: Boolean,
+    highQualityManual: Option[Boolean],
+    labelAccuracy: Option[Double],
+    validatedLabels: Int,
+    validationsReceived: Int,
+    labelsValidatedCorrect: Int,
+    labelsValidatedIncorrect: Int,
+    labelsNotValidated: Int,
+    validationsGiven: Int,
+    dissentingValidationsGiven: Int,
+    agreeValidationsGiven: Int,
+    disagreeValidationsGiven: Int,
+    unsureValidationsGiven: Int,
+    statsByLabelType: Map[String, LabelTypeStat]
+) extends StreamingApiType {
+
+  /**
+   * Converts this UserStatForApi object to a JSON object with snake_case field names (#3871).
+   *
+   * @return A JsObject representing the user's stats, with a nested `stats_by_label_type` breakdown.
+   */
+  override def toJson: JsObject = {
+    Json.obj(
+      "user_id"                      -> userId,
+      "labels"                       -> labels,
+      "meters_explored"              -> metersExplored,
+      "labels_per_meter"             -> labelsPerMeter,
+      "high_quality"                 -> highQuality,
+      "high_quality_manual"          -> highQualityManual,
+      "label_accuracy"               -> labelAccuracy,
+      "validated_labels"             -> validatedLabels,
+      "validations_received"         -> validationsReceived,
+      "labels_validated_correct"     -> labelsValidatedCorrect,
+      "labels_validated_incorrect"   -> labelsValidatedIncorrect,
+      "labels_not_validated"         -> labelsNotValidated,
+      "validations_given"            -> validationsGiven,
+      "dissenting_validations_given" -> dissentingValidationsGiven,
+      "agree_validations_given"      -> agreeValidationsGiven,
+      "disagree_validations_given"   -> disagreeValidationsGiven,
+      "unsure_validations_given"     -> unsureValidationsGiven,
+      "stats_by_label_type"          -> Json.obj(
+        "curb_ramp"         -> Json.toJson(statsByLabelType(LabelTypeEnum.CurbRamp.name)),
+        "no_curb_ramp"      -> Json.toJson(statsByLabelType(LabelTypeEnum.NoCurbRamp.name)),
+        "obstacle"          -> Json.toJson(statsByLabelType(LabelTypeEnum.Obstacle.name)),
+        "surface_problem"   -> Json.toJson(statsByLabelType(LabelTypeEnum.SurfaceProblem.name)),
+        "no_sidewalk"       -> Json.toJson(statsByLabelType(LabelTypeEnum.NoSidewalk.name)),
+        "marked_crosswalk"  -> Json.toJson(statsByLabelType(LabelTypeEnum.Crosswalk.name)),
+        "pedestrian_signal" -> Json.toJson(statsByLabelType(LabelTypeEnum.Signal.name)),
+        "cant_see_sidewalk" -> Json.toJson(statsByLabelType(LabelTypeEnum.Occlusion.name)),
+        "other"             -> Json.toJson(statsByLabelType(LabelTypeEnum.Other.name))
+      )
+    )
+  }
+
+  /**
+   * Converts this UserStatForApi object to a CSV row matching the companion object's `csvHeader`.
+   *
+   * The per-label-type stats are flattened into four columns each, in the same label-type order as the
+   * header. `None` options are rendered as "NA".
+   *
+   * @return A comma-separated string representing this user's stats.
+   */
+  override def toCsvRow: String = {
+    s"${userId},${labels},${metersExplored},${formatOptionForCsv(labelsPerMeter)},${highQuality}," +
+      s"${formatOptionForCsv(highQualityManual)},${formatOptionForCsv(labelAccuracy)},${validatedLabels}," +
+      s"${validationsReceived},${labelsValidatedCorrect},${labelsValidatedIncorrect},${labelsNotValidated}," +
+      s"${validationsGiven},${dissentingValidationsGiven},${agreeValidationsGiven}," +
+      s"${disagreeValidationsGiven},${unsureValidationsGiven}," +
+      s"${labelTypeStatToCsvRow(statsByLabelType(LabelTypeEnum.CurbRamp.name))}," +
+      s"${labelTypeStatToCsvRow(statsByLabelType(LabelTypeEnum.NoCurbRamp.name))}," +
+      s"${labelTypeStatToCsvRow(statsByLabelType(LabelTypeEnum.Obstacle.name))}," +
+      s"${labelTypeStatToCsvRow(statsByLabelType(LabelTypeEnum.SurfaceProblem.name))}," +
+      s"${labelTypeStatToCsvRow(statsByLabelType(LabelTypeEnum.NoSidewalk.name))}," +
+      s"${labelTypeStatToCsvRow(statsByLabelType(LabelTypeEnum.Crosswalk.name))}," +
+      s"${labelTypeStatToCsvRow(statsByLabelType(LabelTypeEnum.Signal.name))}," +
+      s"${labelTypeStatToCsvRow(statsByLabelType(LabelTypeEnum.Occlusion.name))}," +
+      s"${labelTypeStatToCsvRow(statsByLabelType(LabelTypeEnum.Other.name))}"
+  }
+
+  /** Renders an option for CSV, using "NA" for `None` (matches the historical userStats CSV format). */
+  private def formatOptionForCsv(x: Option[Any]): String = x.map(_.toString).getOrElse("NA").replace("\"", "\"\"")
+
+  /** Flattens one label type's stats into the four CSV columns: labels, correct, incorrect, not-validated. */
+  private def labelTypeStatToCsvRow(l: LabelTypeStat): String =
+    s"${l.labels},${l.validatedCorrect},${l.validatedIncorrect},${l.notValidated}"
+}
+
+/**
+ * Companion object for UserStatForApi containing the CSV header and JSON writer.
+ */
+object UserStatForApi {
+
+  // Historical Title-Case header; preserved verbatim for output compatibility with existing API consumers.
+  val csvHeader: String = "User ID,Labels,Meters Explored,Labels per Meter,High Quality,High Quality Manual," +
+    "Label Accuracy,Validated Labels,Validations Received,Labels Validated Correct,Labels Validated Incorrect," +
+    "Labels Not Validated,Validations Given,Dissenting Validations Given,Agree Validations Given," +
+    "Disagree Validations Given,Unsure Validations Given,Curb Ramp Labels,Curb Ramps Validated Correct," +
+    "Curb Ramps Validated Incorrect,Curb Ramps Not Validated,No Curb Ramp Labels,No Curb Ramps Validated Correct," +
+    "No Curb Ramps Validated Incorrect,No Curb Ramps Not Validated,Obstacle Labels,Obstacles Validated Correct," +
+    "Obstacles Validated Incorrect,Obstacles Not Validated,Surface Problem Labels,Surface Problems Validated Correct," +
+    "Surface Problems Validated Incorrect,Surface Problems Not Validated,No Sidewalk Labels," +
+    "No Sidewalks Validated Correct,No Sidewalks Validated Incorrect,No Sidewalks Not Validated," +
+    "Marked Crosswalk Labels,Marked Crosswalks Validated Correct,Marked Crosswalks Validated Incorrect," +
+    "Marked Crosswalks Not Validated,Pedestrian Signal Labels,Pedestrian Signals Validated Correct," +
+    "Pedestrian Signals Validated Incorrect,Pedestrian Signals Not Validated,Cant See Sidewalk Labels," +
+    "Cant See Sidewalks Validated Correct,Cant See Sidewalks Validated Incorrect,Cant See Sidewalks Not Validated," +
+    "Other Labels,Others Validated Correct,Others Validated Incorrect,Others Not Validated\n"
+
+  implicit val userStatWrites: Writes[UserStatForApi] = (userStat: UserStatForApi) => userStat.toJson
+}

--- a/app/models/api/ValidationApiModels.scala
+++ b/app/models/api/ValidationApiModels.scala
@@ -6,7 +6,6 @@
 package models.api
 
 import models.api.ApiModelUtils.escapeCsvField
-import models.computation.StreamingApiType
 import models.label.LocationXY
 import models.utils.CommonUtils.UiSource.UiSource
 import models.validation.ValidationOption

--- a/app/models/cluster/ClusterTable.scala
+++ b/app/models/cluster/ClusterTable.scala
@@ -2,8 +2,7 @@ package models.cluster
 
 import com.google.inject.ImplementedBy
 import formats.json.ApiFormats
-import models.api.{LabelClusterFiltersForApi, LabelClusterForApi, RawLabelInClusterDataForApi}
-import models.computation.StreamingApiType
+import models.api.{LabelClusterFiltersForApi, LabelClusterForApi, RawLabelInClusterDataForApi, StreamingApiType}
 import models.utils.MyPostgresProfile.api._
 import models.utils.SpatialQueryType.SpatialQueryType
 import models.utils.{LatLngBBox, MyPostgresProfile, SpatialQueryType}

--- a/app/models/computation/AccessScoreModels.scala
+++ b/app/models/computation/AccessScoreModels.scala
@@ -1,9 +1,10 @@
 package models.computation
 
 import formats.json.ApiFormats._
+import models.api.StreamingApiType
 import models.street.StreetEdge
 import org.locationtech.jts.geom.MultiPolygon
-import play.api.libs.json.{JsObject, JsValue}
+import play.api.libs.json.JsObject
 
 import java.time.OffsetDateTime
 import scala.collection.mutable
@@ -19,14 +20,6 @@ case class StreetLabelCounter(
     var imageAgeSum: Long,
     labelCounter: mutable.Map[String, Int]
 )
-
-/**
- * Trait for streaming API types that can be converted to JSON and CSV
- */
-trait StreamingApiType {
-  def toJson: JsValue
-  def toCsvRow: String
-}
 
 /**
  * Access score information for a street

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -1,10 +1,8 @@
 package models.label
 
 import com.google.inject.ImplementedBy
-import formats.json.ApiFormats
 import models.api.{LabelDataForApi, LabelValidationSummaryForApi, RawLabelFiltersForApi}
 import models.audit.AuditTaskTableDef
-import models.computation.StreamingApiType
 import models.label.LabelTable._
 import models.label.LabelTypeEnum._
 import models.mission.MissionTableDef
@@ -20,7 +18,6 @@ import models.validation.{LabelValidationTableDef, ValidationOption, ValidationT
 import org.geotools.geometry.jts.JTSFactoryFinder
 import org.locationtech.jts.geom.GeometryFactory
 import play.api.db.slick.{DatabaseConfigProvider, HasDatabaseConfigProvider}
-import play.api.libs.json.JsValue
 import service.TimeInterval
 import service.TimeInterval.TimeInterval
 import slick.jdbc.GetResult
@@ -191,37 +188,6 @@ case class ResumeLabelMetadata(
     panoWidth: Option[Int],
     panoHeight: Option[Int]
 )
-
-case class LabelCVMetadata(
-    labelId: Int,
-    panoId: String,
-    labelTypeId: Int,
-    agreeCount: Int,
-    disagreeCount: Int,
-    unsureCount: Int,
-    panoWidth: Option[Int],
-    panoHeight: Option[Int],
-    panoX: Int,
-    panoY: Int,
-    canvasWidth: Int,
-    canvasHeight: Int,
-    canvasX: Int,
-    canvasY: Int,
-    zoom: Double,
-    heading: Double,
-    pitch: Double,
-    cameraHeading: Double,
-    cameraPitch: Double,
-    cameraRoll: Option[Double]
-) extends StreamingApiType {
-  def toJson: JsValue  = ApiFormats.labelCVMetadataToJSON(this)
-  def toCsvRow: String = ApiFormats.labelCVMetadataToCSVRow(this)
-}
-object LabelCVMetadata {
-  val csvHeader: String = "Label ID,Panorama ID,Label Type ID,Agree Count,Disagree Count,Unsure Count,Panorama Width," +
-    "Panorama Height,Panorama X,Panorama Y,Canvas Width,Canvas Height,Canvas X,Canvas Y,Zoom,Heading,Pitch," +
-    "Camera Heading,Camera Pitch,Camera Roll\n"
-}
 
 case class LabelDataForAi(labelId: Int, labelTypeId: Int, labelPoint: LabelPoint, panoData: PanoData)
 

--- a/app/models/user/UserStatTable.scala
+++ b/app/models/user/UserStatTable.scala
@@ -1,6 +1,7 @@
 package models.user
 
 import com.google.inject.ImplementedBy
+import models.api.UserStatForApi
 import models.audit.AuditTaskTableDef
 import models.label.{LabelTable, LabelTypeEnum}
 import models.mission.{MissionTableDef, MissionTypeTable}
@@ -10,6 +11,8 @@ import models.utils.MyPostgresProfile
 import models.utils.MyPostgresProfile.api._
 import models.validation.LabelValidationTableDef
 import play.api.db.slick.{DatabaseConfigProvider, HasDatabaseConfigProvider}
+import play.api.libs.functional.syntax._
+import play.api.libs.json.{Writes, __}
 import service.TimeInterval
 import service.TimeInterval.TimeInterval
 import slick.jdbc.GetResult
@@ -31,6 +34,16 @@ case class UserStat(
 )
 
 case class LabelTypeStat(labels: Int, validatedCorrect: Int, validatedIncorrect: Int, notValidated: Int)
+object LabelTypeStat {
+  // snake_case JSON output per the v3 API convention (#3871). Lives in the companion so it is in implicit
+  // scope wherever a LabelTypeStat is serialized (e.g. UserStatForApi).
+  implicit val writes: Writes[LabelTypeStat] = (
+    (__ \ "labels").write[Int] and
+      (__ \ "validated_correct").write[Int] and
+      (__ \ "validated_incorrect").write[Int] and
+      (__ \ "not_validated").write[Int]
+  )(unlift(LabelTypeStat.unapply))
+}
 case class UserStatsForAdminPage(
     userId: String,
     username: String,
@@ -47,42 +60,6 @@ case class UserStatsForAdminPage(
     othersValidatedAgreedPct: Double,
     highQuality: Boolean
 )
-case class UserStatApi(
-    userId: String,
-    labels: Int,
-    metersExplored: Double,
-    labelsPerMeter: Option[Double],
-    highQuality: Boolean,
-    highQualityManual: Option[Boolean],
-    labelAccuracy: Option[Double],
-    validatedLabels: Int,
-    validationsReceived: Int,
-    labelsValidatedCorrect: Int,
-    labelsValidatedIncorrect: Int,
-    labelsNotValidated: Int,
-    validationsGiven: Int,
-    dissentingValidationsGiven: Int,
-    agreeValidationsGiven: Int,
-    disagreeValidationsGiven: Int,
-    unsureValidationsGiven: Int,
-    statsByLabelType: Map[String, LabelTypeStat]
-)
-object UserStatApi {
-  val csvHeader: String = "User ID,Labels,Meters Explored,Labels per Meter,High Quality,High Quality Manual," +
-    "Label Accuracy,Validated Labels,Validations Received,Labels Validated Correct,Labels Validated Incorrect," +
-    "Labels Not Validated,Validations Given,Dissenting Validations Given,Agree Validations Given," +
-    "Disagree Validations Given,Unsure Validations Given,Curb Ramp Labels,Curb Ramps Validated Correct," +
-    "Curb Ramps Validated Incorrect,Curb Ramps Not Validated,No Curb Ramp Labels,No Curb Ramps Validated Correct," +
-    "No Curb Ramps Validated Incorrect,No Curb Ramps Not Validated,Obstacle Labels,Obstacles Validated Correct," +
-    "Obstacles Validated Incorrect,Obstacles Not Validated,Surface Problem Labels,Surface Problems Validated Correct," +
-    "Surface Problems Validated Incorrect,Surface Problems Not Validated,No Sidewalk Labels," +
-    "No Sidewalks Validated Correct,No Sidewalks Validated Incorrect,No Sidewalks Not Validated," +
-    "Marked Crosswalk Labels,Marked Crosswalks Validated Correct,Marked Crosswalks Validated Incorrect," +
-    "Marked Crosswalks Not Validated,Pedestrian Signal Labels,Pedestrian Signals Validated Correct," +
-    "Pedestrian Signals Validated Incorrect,Pedestrian Signals Not Validated,Cant See Sidewalk Labels," +
-    "Cant See Sidewalks Validated Correct,Cant See Sidewalks Validated Incorrect,Cant See Sidewalks Not Validated," +
-    "Other Labels,Others Validated Correct,Others Validated Incorrect,Others Not Validated\n"
-}
 case class UserCount(
     count: Int,
     toolUsed: String,
@@ -142,8 +119,8 @@ class UserStatTable @Inject() (
 
   private val LABEL_PER_METER_THRESHOLD: Double = 0.0375
 
-  implicit val userStatApiConverter: GetResult[UserStatApi] = GetResult[UserStatApi](r =>
-    UserStatApi(
+  implicit val userStatApiConverter: GetResult[UserStatForApi] = GetResult[UserStatForApi](r =>
+    UserStatForApi(
       r.nextString(),
       r.nextInt(),
       r.nextDouble(),
@@ -791,7 +768,7 @@ class UserStatTable @Inject() (
       minMetersExplored: Option[Double] = None,
       highQualityOnly: Boolean = false,
       minAccuracy: Option[Double] = None
-  ): DBIO[Seq[UserStatApi]] = {
+  ): DBIO[Seq[UserStatForApi]] = {
     // Construct the SQL query with dynamic WHERE clauses based on filter parameters.
     val minLabelsClause   = minLabels.map(min => s"AND COALESCE(label_counts.labels, 0) >= $min").getOrElse("")
     val minMetersClause   = minMetersExplored.map(min => s"AND user_stat.meters_audited >= $min").getOrElse("")
@@ -928,7 +905,7 @@ class UserStatTable @Inject() (
           #$minLabelsClause
           #$minMetersClause
           #$highQualityClause
-          #$minAccuracyClause;""".as[UserStatApi]
+          #$minAccuracyClause;""".as[UserStatForApi]
   }
 
   /**

--- a/app/service/ApiService.scala
+++ b/app/service/ApiService.scala
@@ -7,7 +7,7 @@ import models.cluster._
 import models.label._
 import models.region.{Region, RegionTable}
 import models.street.{StreetEdgeInfo, StreetEdgeTable}
-import models.user.{UserStatApi, UserStatTable}
+import models.user.UserStatTable
 import models.utils.MyPostgresProfile.api._
 import models.utils.SpatialQueryType.SpatialQueryType
 import models.utils.{ClusteringThreshold, LatLngBBox, MyPostgresProfile}
@@ -133,14 +133,14 @@ trait ApiService {
    * @param minMetersExplored Optional minimum meters explored a user must have.
    * @param highQualityOnly Optional filter to include only high quality users if true.
    * @param minAccuracy Optional minimum label accuracy a user must have.
-   * @return A Future containing a sequence of UserStatApi objects that match the filters.
+   * @return A Future containing a sequence of UserStatForApi objects that match the filters.
    */
   def getUserStats(
       minLabels: Option[Int] = None,
       minMetersExplored: Option[Double] = None,
       highQualityOnly: Boolean = false,
       minAccuracy: Option[Double] = None
-  ): Future[Seq[UserStatApi]]
+  ): Future[Seq[UserStatForApi]]
 
   def getOverallStats(filterLowQuality: Boolean): Future[ProjectSidewalkStats]
 
@@ -274,7 +274,7 @@ class ApiServiceImpl @Inject() (
       minMetersExplored: Option[Double] = None,
       highQualityOnly: Boolean = false,
       minAccuracy: Option[Double] = None
-  ): Future[Seq[UserStatApi]] = {
+  ): Future[Seq[UserStatForApi]] = {
     // Uses the database-level filtering method for improved performance.
     db.run(userStatTable.getStatsForApiWithFilters(minLabels, minMetersExplored, highQualityOnly, minAccuracy))
   }

--- a/test/models/api/UserStatsApiModelsSpec.scala
+++ b/test/models/api/UserStatsApiModelsSpec.scala
@@ -1,0 +1,118 @@
+package models.api
+
+import models.label.LabelTypeEnum
+import models.user.LabelTypeStat
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.JsObject
+
+/**
+ * Pure (no DB, no app boot) serialization contract tests for the API DTOs moved out of `*Table.scala` files in #3885.
+ *
+ * These lock the JSON shape and the CSV header/row alignment so the move (and the switch to inline serialization)
+ * stays byte-for-byte compatible with the previous `ApiFormats` free-function output.
+ */
+class UserStatsApiModelsSpec extends AnyFunSuite with Matchers {
+
+  /** Every label type mapped to a distinct stat block so column ordering regressions are visible. */
+  private def sampleStatsByLabelType: Map[String, LabelTypeStat] = Map(
+    LabelTypeEnum.CurbRamp.name       -> LabelTypeStat(10, 1, 2, 7),
+    LabelTypeEnum.NoCurbRamp.name     -> LabelTypeStat(11, 1, 2, 8),
+    LabelTypeEnum.Obstacle.name       -> LabelTypeStat(12, 1, 2, 9),
+    LabelTypeEnum.SurfaceProblem.name -> LabelTypeStat(13, 1, 2, 10),
+    LabelTypeEnum.NoSidewalk.name     -> LabelTypeStat(14, 1, 2, 11),
+    LabelTypeEnum.Crosswalk.name      -> LabelTypeStat(15, 1, 2, 12),
+    LabelTypeEnum.Signal.name         -> LabelTypeStat(16, 1, 2, 13),
+    LabelTypeEnum.Occlusion.name      -> LabelTypeStat(17, 1, 2, 14),
+    LabelTypeEnum.Other.name          -> LabelTypeStat(18, 1, 2, 15)
+  )
+
+  private def sampleUserStat: UserStatForApi = UserStatForApi(
+    userId = "user-1",
+    labels = 100,
+    metersExplored = 1234.5,
+    labelsPerMeter = Some(0.081),
+    highQuality = true,
+    highQualityManual = None,
+    labelAccuracy = Some(0.95),
+    validatedLabels = 50,
+    validationsReceived = 60,
+    labelsValidatedCorrect = 40,
+    labelsValidatedIncorrect = 10,
+    labelsNotValidated = 50,
+    validationsGiven = 20,
+    dissentingValidationsGiven = 2,
+    agreeValidationsGiven = 15,
+    disagreeValidationsGiven = 3,
+    unsureValidationsGiven = 2,
+    statsByLabelType = sampleStatsByLabelType
+  )
+
+  test("UserStatForApi JSON uses snake_case keys and a nested per-label-type breakdown") {
+    val json = sampleUserStat.toJson
+
+    (json \ "user_id").as[String] shouldBe "user-1"
+    (json \ "meters_explored").as[Double] shouldBe 1234.5
+    (json \ "high_quality_manual").asOpt[Boolean] shouldBe None // None serializes as JSON null, key present
+    json.keys.filter(k => k != k.toLowerCase) shouldBe empty
+
+    val byType = (json \ "stats_by_label_type").as[JsObject]
+    byType.keys should contain allOf ("curb_ramp", "no_curb_ramp", "marked_crosswalk", "pedestrian_signal", "cant_see_sidewalk")
+    (byType \ "curb_ramp" \ "validated_correct").as[Int] shouldBe 1
+    (byType \ "curb_ramp" \ "not_validated").as[Int] shouldBe 7
+  }
+
+  test("UserStatForApi CSV row column count matches the header, with NA for None") {
+    val headerCols = UserStatForApi.csvHeader.trim.split(",", -1).length
+    val rowCols    = sampleUserStat.toCsvRow.split(",", -1).length
+    rowCols shouldBe headerCols
+
+    val cols = sampleUserStat.toCsvRow.split(",", -1)
+    cols(0) shouldBe "user-1"
+    cols(5) shouldBe "NA" // highQualityManual = None
+  }
+
+  private def sampleCVMetadata: LabelCVMetadata = LabelCVMetadata(
+    labelId = 1,
+    panoId = "pano-1",
+    labelTypeId = 2,
+    agreeCount = 3,
+    disagreeCount = 1,
+    unsureCount = 0,
+    panoWidth = None,
+    panoHeight = Some(8192),
+    panoX = 100,
+    panoY = 200,
+    canvasWidth = 720,
+    canvasHeight = 480,
+    canvasX = 50,
+    canvasY = 60,
+    zoom = 1.0,
+    heading = 90.0,
+    pitch = -10.0,
+    cameraHeading = 95.0,
+    cameraPitch = 0.0,
+    cameraRoll = None
+  )
+
+  test("LabelCVMetadata JSON uses snake_case keys and omits None-valued optional fields") {
+    val json = sampleCVMetadata.toJson
+
+    (json \ "label_id").as[Int] shouldBe 1
+    (json \ "pano_height").as[Int] shouldBe 8192
+    // writeNullable semantics: absent (not null) when None — matches the previous explicit Writes.
+    (json \ "pano_width").toOption shouldBe None
+    (json \ "camera_roll").toOption shouldBe None
+    json.as[JsObject].keys.filter(k => k != k.toLowerCase) shouldBe empty
+  }
+
+  test("LabelCVMetadata CSV row column count matches the header, with NA for None") {
+    val headerCols = LabelCVMetadata.csvHeader.trim.split(",", -1).length
+    val rowCols    = sampleCVMetadata.toCsvRow.split(",", -1).length
+    rowCols shouldBe headerCols
+
+    val cols = sampleCVMetadata.toCsvRow.split(",", -1)
+    cols(6) shouldBe "NA"   // panoWidth = None
+    cols.last shouldBe "NA" // cameraRoll = None
+  }
+}


### PR DESCRIPTION
Closes #3885.

## What & why

API-facing DTOs for the `/v3` API were inconsistently located: most live in the dedicated `app/models/api/` package (`LabelDataForApi`, `StreetDataForApi`, …), but a few stragglers still lived inside `*Table.scala` DAO files with their serialization stranded as free functions in `app/formats/json/ApiFormats.scala`. This PR moves the stragglers into `models.api` and **documents the convention** so future API additions stay consistent.

The established convention (now codified in `CLAUDE.md`): response DTOs are named `*ForApi` / filters `*FiltersForApi`, extend `StreamingApiType`, implement `toJson`/`toCsvRow` **inline**, and define `csvHeader` + a scoped `JsonConfiguration(JsonNaming.SnakeCase)` in the companion, reusing `ApiModelUtils` helpers.

## Changes

- **`UserStatApi` → `models.api.UserStatForApi`** (new `UserStatsApiModels.scala`). Renamed to the `*ForApi` convention; `toJson`/`toCsvRow` ported inline from the `ApiFormats` free functions.
- **`LabelCVMetadata` → `models.api`** (into `LabelApiModels.scala`). Inline serialization; JSON derived via a scoped `JsonConfiguration(JsonNaming.SnakeCase)` macro.
- **`StreamingApiType` trait → `models.api`** (own file). It's the core abstraction of the entire `/v3` API yet lived in the v2 `AccessScoreModels.scala`; relocating it decouples the v3 API from that file.
- **`LabelTypeStat` JSON `Writes`** moved to its companion object so it stays in implicit scope for the relocated serializer.
- **Trimmed `ApiFormats.scala`** of the migrated serializers (−96 lines); it retains only the v2 access-score serializers and other non-DTO writes.

### Intentionally left alone

The older **v2 access-score** DTOs (`StreetScore`, `RegionScore` in `models/computation/`, `ClusterForApi` in `models/cluster/`) stay put. They feed `/v2/access/score/*`, which the v3 access-score rewrite (#3855) will replace and #3864 will remove — migrating them now would be churn on code slated for replacement. Noted as the documented exception in `CLAUDE.md`.

## Verification — output is byte-identical

This is a pure relocation/refactor: **no API output should change.** Verified at three levels.

**1. Compile** — `sbt compile` clean under `-Xfatal-warnings` (no unused imports / dead code).

**2. Tests** — new `test/models/api/UserStatsApiModelsSpec.scala` (4 cases: snake_case keys, nested `stats_by_label_type`, `None`-omission, CSV header↔row column alignment) plus the existing 61-test API + `ApiFormats` suites — all green.

**3. End-to-end before/after byte-diff** — ran the *old* code (this branch's base, no consolidation) and the *new* code against the **same dev database on the same running server**, captured both affected endpoints in JSON and CSV, and diffed. Record ordering is nondeterministic in both (no `ORDER BY`), so outputs were normalized by sorting records before comparison; everything else compared byte-for-byte:

| Output | Records | Result |
|---|---|---|
| `/v3/api/userStats` JSON | 82 | **0** value diffs, **0** key-order/set diffs — identical incl. key order |
| `/v3/api/userStats` CSV | 82 rows | header byte-identical; sorted data rows **identical md5** |
| `/adminapi/labels/cvMetadata` JSON | 21,647 | **0** value diffs, **0** key-order/set diffs — identical incl. key order |
| `/adminapi/labels/cvMetadata` CSV | 21,647 rows | header byte-identical; sorted data rows **identical md5** |

Raw byte sizes matched exactly too. This confirms the relocation, the inline-serialization rewrite, the `Json.writes`+SnakeCase swap for cvMetadata, and the `LabelTypeStat` companion move changed nothing observable — same keys, key order, values, number formatting, and `None`→omission/`NA` handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)