### PR TITLE
Migrate core developer docs from wiki into repo (#4252)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,7 +236,7 @@ Good targets for inline comments:
 - Do not add a header just because a function was touched; only add one if it is missing
   and the function is non-trivial.
 
-## Linting Rules (will be enforced by `make lint` some day, but not being run now)
+## Linting Rules (frontend lint deferred to #2487; Scala `scalafmt` is checked in CI — see Continuous integration)
 - ESLint: ES6+, `const`/`let` only (no `var`), arrow functions, template literals, semicolons required, 120-char line limit
 - Stylelint: 4-space indentation, stylelint-config-standard
 - HTMLHint: lowercase tags/attrs, double quotes, no inline scripts/styles, alt text required
@@ -253,11 +253,15 @@ make docker-stop    # stop and remove containers
 make ssh target=db  # exec into a running container (projectsidewalk-db / -web)
 ```
 
+> Human-facing companions to this section: [`docs/dev-environment.md`](docs/dev-environment.md) (full setup —
+> prerequisites, WSL2, city switching, troubleshooting) and [`CONTRIBUTING.md`](CONTRIBUTING.md) (workflow + coding
+> standards). This file stays the AI-facing reference; those are written for contributors.
+
 Inside the web container shell, the developer starts the app with `npm start` (runs Grunt concat + watch in the background, then `sbt run` — i.e. `sbt ~ run`, continuous recompile; `npm run debug` adds a JVM debug port). It serves on **http://localhost:9000** using `conf/application.local.conf`. First compile is slow (sbt resolves dependencies); sbt keeps its caches inside the project dir (`.coursier`, `.sbt`).
 
 ### Verifying backend (Scala) changes compile
 
-There is **no Scala/backend test suite** — validate backend changes by compiling. The clean way is the **sbt thin client**, which runs against its own dedicated server and so does *not* fight the developer's running `sbt ~ run` (a plain second `sbt compile` collides with it over build/target locks and hangs):
+For a quick pass/fail without running tests, validate backend changes by compiling. The clean way is the **sbt thin client**, which runs against its own dedicated server and so does *not* fight the developer's running `sbt ~ run` (a plain second `sbt compile` collides with it over build/target locks and hangs):
 
 ```bash
 docker exec projectsidewalk-web bash -lc "cd /home && sbt --client compile"
@@ -268,6 +272,23 @@ docker exec projectsidewalk-web bash -lc "cd /home && sbt --client compile"
 - It only needs the web container up — the app itself (`npm start`) does not have to be running.
 
 Alternatively, since the developer's `sbt ~ run` recompiles on save, hitting any route over HTTP (see below) also forces a compile; errors surface as a 500 page rather than clean output, so prefer the thin client when you just want a pass/fail.
+
+### Running tests
+
+There **is** a backend test suite (ScalaTest via `scalatestplus-play`), under `test/` — mostly public-API functional specs in `test/controllers/api/`, plus `test/models/api/` and `test/formats/json/`. Run it with the thin client:
+
+```bash
+docker exec projectsidewalk-web bash -lc "cd /home && sbt --client test"                                # whole suite
+docker exec projectsidewalk-web bash -lc "cd /home && sbt --client \"testOnly controllers.api.PublicApiSpec\""
+```
+
+The API specs **boot the real app against Postgres+PostGIS**, so the `db` container must be up; they assert response contract/shape, not data values. There is no `make` target — invoke sbt directly. The phased testing strategy and rationale live in [`docs/testing-and-ci.md`](docs/testing-and-ci.md).
+
+A prototype **JS** test layer (jsdom) lives under `test/js/` — run `npm run test:js`. It is opt-in and not wired into CI yet (sequenced with the ES5→ES6 migration, #2487); see `test/js/README.md`.
+
+### Continuous integration
+
+`.github/workflows/ci.yml` runs on PRs and pushes to `develop`/`master`: backend **`sbt compile`** (blocking gate), **`scalafmtCheckAll`** (advisory — format Scala you touch with scalafmt, `.scalafmt.conf`), the **frontend grunt build**, and the **DB-backed API tests** (advisory while the suite stabilizes). "Advisory" steps report findings but don't block merges yet.
 
 ### Building frontend assets
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,7 @@ feature code; use `getLabelColors()` so colors stay in sync automatically.
 - Ensure WCAG 2.1/2.2 Level AA accessibility standards are met
 - When adding or refactoring code, use the fonts, colors, button styling, etc. defined in main.css :root. These are pulled from our "Design System Tokens" Figma, and we are pushing to use these going forward.
 - Max line length of 120 characters, with long line exceptions where appropriate. For multi-line comments, TARGET line length is 120 characters
+- **Keep docs in sync.** When you change architecture, framework versions, supported languages, label types, or other conventions, update the affected docs in the *same* change: [`docs/architecture.md`](docs/architecture.md) mirrors this file's architecture (and the README's tech-stack summary), and [`CONTRIBUTING.md`](CONTRIBUTING.md) holds the workflow/standards. To avoid drift, keep exact dependency/patch versions in **one** place — the dependency-version inventory (currently the [Upgrading libraries](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Upgrading-libraries) wiki page; planned `docs/upgrading-libraries.md`) — rather than copying them across docs. README/architecture mention only stable major versions (e.g. Scala 2.13, Play 3.0, Java 17).
 
 ## Code Commenting Standards
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,10 @@ Project Sidewalk is a web-based crowdsourcing tool for mapping and assessing sid
 
 ## Backend architecture
 
+> Human-facing companion: [`docs/architecture.md`](docs/architecture.md) covers this same architecture as narrative
+> contributor docs (and is what the README links to). Keep the two in sync when architecture changes; this file
+> stays the AI-facing reference and adds the operational/tooling notes below.
+
 Request flow: **routes → Controller → Service → Table (DAO)**.
 
 - **`conf/routes`** — single routes file mapping URLs to controller methods. The public data API lives under `/v3/api/...` (handlers in `app/controllers/api/`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,7 @@ feature code; use `getLabelColors()` so colors stay in sync automatically.
 - Update said code to use the native `fetch` API rather than jQuery, and to make use of Promises. But if said refactor would impact many other functions that use it, then wait for a dedicated refactor.
 - Replace uses of Bootstrap with native JS alternatives as you come across them
 - When writing SQL, avoid table aliases
+- User interactions are logged (clicks, key presses, mode switches, pano changes, mission/task events, etc.) to the activity/interaction tables. When you **add or change an interaction**, add or adjust the corresponding logging so analytics stay complete; keep event names consistent with the existing ones.
 - Ensure WCAG 2.1/2.2 Level AA accessibility standards are met
 - When adding or refactoring code, use the fonts, colors, button styling, etc. defined in main.css :root. These are pulled from our "Design System Tokens" Figma, and we are pushing to use these going forward.
 - Max line length of 120 characters, with long line exceptions where appropriate. For multi-line comments, TARGET line length is 120 characters

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**jonf@cs.uw.edu**.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,182 @@
+# Contributing to Project Sidewalk
+
+Thanks for your interest in contributing! Project Sidewalk is an open-source tool for mapping and assessing sidewalk
+accessibility, and we welcome bug reports, fixes, features, translations, and documentation improvements.
+
+By participating, you agree to abide by our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Ways to contribute
+
+- **Report a bug or request a feature** — open a [GitHub issue](https://github.com/ProjectSidewalk/SidewalkWebpage/issues).
+  Search first to avoid duplicates, and include steps to reproduce, your environment, and screenshots where helpful.
+- **Report a security vulnerability** — *don't* open a public issue; follow [`SECURITY.md`](SECURITY.md).
+- **Fix a bug or build a feature** — see the [workflow](#development-workflow) below.
+- **Improve translations** — Project Sidewalk runs in many languages; see [Internationalization](#internationalization).
+
+## Before you start
+
+1. Set up your local environment by following [`docs/dev-environment.md`](docs/dev-environment.md).
+2. Skim [`CLAUDE.md`](CLAUDE.md) — it's written for an AI assistant but is the most complete, current tour of the
+   architecture, conventions, and build/test commands.
+3. **Claim an issue.** Pick an [open issue](https://github.com/ProjectSidewalk/SidewalkWebpage/issues) and comment
+   that you're working on it. For anything non-trivial, agree on the approach in the issue thread *before* you write
+   code — and for UI changes, post before/after mockups there first (the PR thread is for implementation details).
+
+## Development workflow
+
+We use a branch-and-pull-request model. **Always branch off `develop`**, never `master`.
+
+- **`develop`** — the active development branch and the target for every pull request.
+- **`master`** — the release branch, deployed to production ([projectsidewalk.io](https://projectsidewalk.io)).
+  Don't branch from it or target it.
+
+### 1. Create a branch
+
+Name it `<issue-number>-<brief-description>` — e.g. for issue #474, `474-admin-update-activities-table`. **Don't**
+prefix with `#` (it breaks command-line autocomplete).
+
+```bash
+git checkout develop
+git pull                                   # get the latest develop
+git checkout -b 474-admin-update-activities-table
+git push --set-upstream origin 474-admin-update-activities-table
+```
+
+### 2. Write code
+
+Follow the [coding standards](#coding-standards). As you work:
+
+- **Review changes file by file before committing.** Don't `git commit -a` or `git commit .` — it's the easiest way
+  to commit debugging scaffolding by accident. Instead:
+
+  ```bash
+  git status                 # what changed?
+  git diff path/to/file      # confirm each file contains only intended changes
+  git add path/to/file       # stage it
+  git commit -m "Add severity filter to the admin activities table"
+  git push
+  ```
+
+- **Write descriptive commit messages** that say what actually changed. Avoid vague messages like `Fixes #880`,
+  `Addresses PR feedback`, or `Update ModalMissionComplete.js`.
+
+### 3. Keep your branch current
+
+Before opening a PR — and before re-requesting review after changes — merge the latest `develop` and re-test:
+
+```bash
+git pull origin develop
+```
+
+## Coding standards
+
+The full conventions live in [`CLAUDE.md`](CLAUDE.md) (architecture + ScalaDoc/JSDoc comment standards); a dedicated
+`docs/style-guide.md` is planned. The essentials:
+
+**General**
+- Max line length **120 characters** (with sensible exceptions for readability).
+- Indent with **spaces**, not tabs; end every file with a newline.
+- Comments start with a capital letter and end with a period, and explain **why**, not what.
+- Meet **WCAG 2.1/2.2 Level AA** for any UI work, and use the design-system tokens in `main.css` `:root` for fonts,
+  colors, and buttons.
+
+**JavaScript** (vanilla JS, concatenated by Grunt — no module system)
+- Write **ES6+** for new and modernized code: `const`/`let` (never `var`), arrow functions, template literals,
+  semicolons. When editing an old all-ES5 file, you may match its style, but prefer modernizing.
+- Use single quotes for strings (backticks for interpolation/multiline).
+- Prefer native **`fetch`** + Promises over jQuery, and native JS/CSS over Bootstrap, as you touch that code.
+- When refactoring an old constructor-function module, convert it to an ES6 `class` with `#private` fields.
+
+**Scala** (Play 3.0, Scala 2.13)
+- Follow the request flow **routes → Controller → Service → Table (DAO)**; keep controllers thin.
+- Declare value types where it aids clarity (e.g. `val x: Int = 5`), using discretion for long/obvious library
+  types.
+- Use **Slick** for queries rather than raw SQL; when you do write SQL, avoid table aliases. Format with
+  **scalafmt** (`.scalafmt.conf`).
+- Two performance gotchas: count rows with `.size.result` (a `COUNT(*)`), **not** `.length.result` (loads all rows
+  into memory); for CPU-heavy work, use the `cpu-intensive` `ExecutionContext` (see existing examples) rather than
+  the default.
+
+**Public API (`/v3`)** — output field names are **snake_case**; query/REST parameters are **camelCase**. New API
+DTOs go in `app/models/api/`. See the API sections of [`CLAUDE.md`](CLAUDE.md).
+
+## Internationalization
+
+User-facing text must be translatable. There are two systems:
+
+- **Backend (server-rendered):** Play message files `conf/messages.<lang>` (`messages.en`, `messages.es`, …).
+  Add a key to each language file and reference it in `.scala.html` with `@Messages("your.key")`.
+- **Frontend (client-side):** JSON under `public/locales/<lang>/` (e.g. `common.json`). Reference it with
+  `i18next.t('your-key')`, or prefer `data-i18n="ns:key"` directly in HTML to avoid duplicate strings.
+
+Supported languages: **en, es, de, nl, zh-TW, pt-BR**, plus the regional English variants **en-US** and **en-NZ**.
+
+**When you add or change user-facing text:**
+
+1. Add **temporary translations** for Spanish, Dutch, German, and Mandarin (`zh-TW`, traditional). Google Translate
+   is fine for these — a maintainer periodically sends the accumulated machine translations to our partners for
+   official ones.
+2. Add to the generic **`en`** files by default. Also add **regional overrides** only where the wording differs:
+   - **en-US** — distances use feet/miles (`ft`/`mi`) where generic `en` uses meters/kilometers (`m`/`km`); your
+     code should respect the unit system too (see existing examples).
+   - **en-NZ** — e.g. curb ramp → *drop kerb*, sidewalk → *footpath*, crosswalk → *pedestrian crossing*,
+     neighborhood → *neighbourhood*, organization → *organisation*, meter/kilometer → *metre/kilometre*,
+     trash/recycling can → *trash/recycling bin*.
+
+**When you remove translated text,** check it isn't used elsewhere; if not, remove the key from every language file.
+
+## Testing your changes
+
+There is no automated backend test suite yet (see [`docs/testing-and-ci.md`](docs/testing-and-ci.md)) — validate
+backend changes by compiling (`sbt --client compile`; see [`docs/dev-environment.md`](docs/dev-environment.md)), and
+exercise behavior in the running app.
+
+**Update logging.** User interactions (clicks, key presses, etc.) should be logged. If you add or change
+interactions, update the logging accordingly.
+
+**Test as the relevant user types.** Behavior often differs by role:
+
+- **Anonymous** — the default on first visit; an incognito/private window gives you a fresh anon account.
+- **Registered** — create an account and sign in.
+- **Administrator** — promote an account locally by setting its role to Administrator (role `4`):
+
+  ```sql
+  -- find your user_id, then promote it
+  SELECT user_id FROM sidewalk_login.sidewalk_user WHERE username = '<your-username>';
+  UPDATE sidewalk_login.user_role SET role_id = 4 WHERE user_id = '<your-user-id>';
+  ```
+
+- **Mechanical Turk worker** — visit
+  `localhost:9000/?referrer=mturk&hitId=h1&workerId=worker1&assignmentId=a1&minutes=60`. To start a fresh turker,
+  change `workerId`/`hitId`/`assignmentId`.
+
+**Test on mobile if you touched the Validate page** (the only page served on mobile). Start with Chrome DevTools
+[device mode](https://developer.chrome.com/docs/devtools/device-mode/); if it looks good, test on a real device by
+visiting `<your-computer-ip>:9000` (phone and computer on the same Wi-Fi; this often fails on public/café networks).
+
+## Submitting a pull request
+
+1. Merge the latest `develop` (`git pull origin develop`) and test one more time.
+2. **Run scalafmt** on any Scala files you changed (IntelliJ: `Ctrl`+`Alt`+`L`; VS Code via the Metals/Scalafmt
+   formatter — both can format-on-save). CI also checks formatting.
+3. Push your branch and [open a PR](https://github.com/ProjectSidewalk/SidewalkWebpage/compare) with **base
+   `develop`** ← your branch. Fill out the [PR template](.github/PULL_REQUEST_TEMPLATE.md): clear title, description,
+   before/after screenshots for UI, testing instructions, translations, and logging updates. Link the issue
+   (`Resolves #474`).
+4. **Keep PRs small** and scoped to one issue.
+5. A maintainer (usually Mikey) will review. Address feedback in follow-up commits, then leave a comment letting us
+   know it's ready for another look. Once approved, we merge to `develop` (and eventually `master`).
+
+## Where documentation lives
+
+- **In this repo:** [`README.md`](README.md), [`CONTRIBUTING.md`](CONTRIBUTING.md), [`SECURITY.md`](SECURITY.md),
+  [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md), [`CLAUDE.md`](CLAUDE.md), and guides under [`docs/`](docs/).
+- **In the [wiki](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki):** operational runbooks, city-deployment
+  guidance, and visual/GIS tutorials.
+
+If you change behavior a doc describes, update the doc in the same PR.
+
+## Questions
+
+Open an issue, ask in the team Slack (**#core** / **#interns**), or email **sidewalk@cs.uw.edu**. We're glad you're
+here. 🎉

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,9 +127,11 @@ Supported languages: **en, es, de, nl, zh-TW, pt-BR**, plus the regional English
 
 ## Testing your changes
 
-There is no automated backend test suite yet (see [`docs/testing-and-ci.md`](docs/testing-and-ci.md)) — validate
-backend changes by compiling (`sbt --client compile`; see [`docs/dev-environment.md`](docs/dev-environment.md)), and
-exercise behavior in the running app.
+There's a backend test suite (ScalaTest) under `test/` — mainly public-API functional specs. Run it with
+`sbt --client test` (the DB-backed API specs boot the app against Postgres+PostGIS, so the `db` container must be
+up); the overall strategy and phased rollout are in [`docs/testing-and-ci.md`](docs/testing-and-ci.md). The suite is
+still growing and CI runs it as advisory for now, so also compile (`sbt --client compile`) and exercise behavior in
+the running app. See [`docs/dev-environment.md`](docs/dev-environment.md) for the exact commands.
 
 **Update logging.** User interactions (clicks, key presses, etc.) should be logged. If you add or change
 interactions, update the logging accordingly.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ world, using remote crowdsourcing, machine learning, and online satellite & stre
 virtually through cities and label accessibility features and problems — curb ramps, obstacles, surface problems,
 missing sidewalks, and more.
 
-Project Sidewalk has run in **45+ cities across 10 countries** (the US, Canada, Chile, India, Mexico, Ecuador, the
+Project Sidewalk has run in **50+ cities across 10 countries** (the US, Canada, Chile, India, Mexico, Ecuador, the
 Netherlands, Switzerland, and New Zealand), is natively translated into **six languages** (English, Spanish, German,
 Mandarin, Portuguese, and Dutch), and has collected **3.4M+ contributor-labeled data points**. See the
 [live data dashboard](https://jonfroehlich.github.io/ps-label-vis/ps-dashboard.html).
@@ -27,7 +27,7 @@ If you use or reference Project Sidewalk in your research, please cite:
   Bootstrap).
 - **Dev environment:** Docker.
 
-For a full architecture overview, see [`CLAUDE.md`](CLAUDE.md).
+For a full architecture overview, see [`docs/architecture.md`](docs/architecture.md).
 
 ## Quickstart for developers
 
@@ -48,8 +48,9 @@ guide: **[`docs/dev-environment.md`](docs/dev-environment.md)**.
 | Doc | What's in it |
 |-----|--------------|
 | [`docs/dev-environment.md`](docs/dev-environment.md) | Set up and run the app locally. |
+| [`docs/architecture.md`](docs/architecture.md) | How the backend, frontend, and data fit together. |
 | [`CONTRIBUTING.md`](CONTRIBUTING.md) | Branch/PR workflow, coding standards, i18n. |
-| [`CLAUDE.md`](CLAUDE.md) | Full architecture, conventions, and build/test commands. |
+| [`CLAUDE.md`](CLAUDE.md) | Conventions + operational notes, used as AI-assistant context. |
 | [`docs/testing-and-ci.md`](docs/testing-and-ci.md) | Testing strategy and CI rollout plan. |
 | [`SECURITY.md`](SECURITY.md) | How to report a vulnerability. |
 | [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) | Community standards. |

--- a/README.md
+++ b/README.md
@@ -1,17 +1,91 @@
 <img src="https://github.com/ProjectSidewalk/SidewalkWebpage/assets/1621749/0e838038-14fe-48cf-a849-1025e688ae68" width="200">
 
-Welcome to Project Sidewalk! Project Sidewalk is an open source project aimed at mapping and assessing every sidewalk in the world using remote crowdsourcing, artificial intelligence, and online satellite & streetscape imagery.
+# Project Sidewalk
+
+Project Sidewalk is an open-source web tool for mapping and assessing the accessibility of every sidewalk in the
+world, using remote crowdsourcing, machine learning, and online satellite & streetscape imagery. Contributors walk
+virtually through cities and label accessibility features and problems — curb ramps, obstacles, surface problems,
+missing sidewalks, and more.
+
+Project Sidewalk has run in **45+ cities across 10 countries** (the US, Canada, Chile, India, Mexico, Ecuador, the
+Netherlands, Switzerland, and New Zealand), is natively translated into **six languages** (English, Spanish, German,
+Mandarin, Portuguese, and Dutch), and has collected **3.4M+ contributor-labeled data points**. See the
+[live data dashboard](https://jonfroehlich.github.io/ps-label-vis/ps-dashboard.html).
 
 If you use or reference Project Sidewalk in your research, please cite:
 
-> Manaswi Saha, Michael Saugstad, Hanuma Teja Maddali, Aileen Zeng, Ryan Holland, Steven Bower, Aditya Dash, Sage Chen, Anthony Li, Kotaro Hara, and Jon Froehlich. 2019. Project Sidewalk: A Web-based Crowdsourcing Tool for Collecting Sidewalk Accessibility Data At Scale. In Proceedings of the 2019 CHI Conference on Human Factors in Computing Systems (CHI '19). Association for Computing Machinery, New York, NY, USA, Paper 62, 1–14. https://doi.org/10.1145/3290605.3300292
+> Manaswi Saha, Michael Saugstad, Hanuma Teja Maddali, Aileen Zeng, Ryan Holland, Steven Bower, Aditya Dash, Sage
+> Chen, Anthony Li, Kotaro Hara, and Jon Froehlich. 2019. Project Sidewalk: A Web-based Crowdsourcing Tool for
+> Collecting Sidewalk Accessibility Data At Scale. In Proceedings of the 2019 CHI Conference on Human Factors in
+> Computing Systems (CHI '19). Association for Computing Machinery, New York, NY, USA, Paper 62, 1–14.
+> https://doi.org/10.1145/3290605.3300292
 
-## Want Project Sidewalk in Your City?
-Want a Project Sidewalk server set up for your city/municipality? Read our ["Considerations for Deploying Project Sidewalk into a New City" wiki](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Considerations-when-Preparing-for-and-Deploying-to-New-Cities) and then email us at sidewalk@cs.uw.edu!
+## Tech stack
 
-## Development Environment Instructions
-Project Sidewalk's frontend is built on JavaScript, jQuery, and Bootstrap. The backend is built on Scala and the Play framework.
+- **Backend:** Scala 2.13 + Play Framework 3.0 (Java 17), Postgres + PostGIS via Slick.
+- **Frontend:** vanilla JavaScript, organized as independent apps bundled with Grunt (we're migrating off jQuery and
+  Bootstrap).
+- **Dev environment:** Docker.
 
-Instructions for setting up a development environment for Project Sidewalk can be found [on our wiki](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Dev-Environment-Setup). 
+For a full architecture overview, see [`CLAUDE.md`](CLAUDE.md).
 
-These instructions are geared towards internal team members. If you're outside the team and hoping to set up your own server with data for a city that we don't currently support, then you'll want to start with our [Creating a new database wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Creating-database-for-a-new-city). Note that setting up a db for your city is a non-trivial amount of work the first time through, especially for those without experience with GIS software. Feel free to email our lead engineer, Mikey (saugstad@cs.washington.edu) with questions.
+## Quickstart for developers
+
+Everything runs in Docker. In brief:
+
+```bash
+git clone https://github.com/ProjectSidewalk/SidewalkWebpage.git
+cd SidewalkWebpage
+make dev      # build + start containers, open a shell in the web container
+npm start     # (inside that shell) build assets and run the app
+```
+
+Then open http://localhost:9000. You'll need a secrets file and database dump from a maintainer first — see the full
+guide: **[`docs/dev-environment.md`](docs/dev-environment.md)**.
+
+## Documentation
+
+| Doc | What's in it |
+|-----|--------------|
+| [`docs/dev-environment.md`](docs/dev-environment.md) | Set up and run the app locally. |
+| [`CONTRIBUTING.md`](CONTRIBUTING.md) | Branch/PR workflow, coding standards, i18n. |
+| [`CLAUDE.md`](CLAUDE.md) | Full architecture, conventions, and build/test commands. |
+| [`docs/testing-and-ci.md`](docs/testing-and-ci.md) | Testing strategy and CI rollout plan. |
+| [`SECURITY.md`](SECURITY.md) | How to report a vulnerability. |
+| [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) | Community standards. |
+
+Operational runbooks, city-deployment guidance, and visual/GIS tutorials live in the
+[**wiki**](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki).
+
+## Contributing
+
+We welcome bug reports, fixes, features, translations, and docs from contributors of all experience levels. Start by
+picking an [open issue](https://github.com/ProjectSidewalk/SidewalkWebpage/issues), then follow the workflow and
+coding standards in [`CONTRIBUTING.md`](CONTRIBUTING.md). Project Sidewalk has been built by
+[160+ contributors](https://makeabilitylab.cs.washington.edu/projects/sidewalk/) — high schoolers, undergraduate and
+graduate students, researchers, and partner organizations.
+
+## Want Project Sidewalk in your city?
+
+Want a Project Sidewalk server set up for your city or municipality? Read our
+[Considerations for Deploying Project Sidewalk into a New City](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Considerations-when-Preparing-for-and-Deploying-to-New-Cities)
+wiki page, then email us at **sidewalk@cs.uw.edu**.
+
+If you're outside the team and want to set up your own server for a city we don't currently support, start with the
+[Creating a database for a new city](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Creating-database-for-a-new-city)
+wiki page. This is a non-trivial amount of work the first time through, especially without prior GIS experience —
+email our lead engineer, Mikey (saugstad@cs.washington.edu), with questions.
+
+## Project history & funding
+
+Project Sidewalk began in 2012 with a Google Faculty Research Award and NSF Award
+[#1302338](https://www.nsf.gov/awardsearch/showAward?AWD_ID=1302338), led by Prof. Jon E. Froehlich and then–PhD
+student Kotaro Hara. The first deployment launched in Washington, DC, around 2017 (CHI 2019 Best Paper, above). The
+work is currently supported by NSF Awards [#2125087](https://www.nsf.gov/awardsearch/showAward?AWD_ID=2125087)
+(UI Chicago) and [#2236277](https://www.nsf.gov/awardsearch/showAward?AWD_ID=2236277) (Utah State University). See
+the [wiki](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki) for the fuller history, deployments, and
+mapathon materials.
+
+## License
+
+Project Sidewalk is released under the MIT License — see [`LICENSE.md`](LICENSE.md).

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 <img src="https://github.com/ProjectSidewalk/SidewalkWebpage/assets/1621749/0e838038-14fe-48cf-a849-1025e688ae68" width="200">
 
+# Project Sidewalk
+
 <p align="center">
   <video src="https://github.com/user-attachments/assets/a0181dac-4cce-4674-85b1-403f4e24c3f8" width="760" controls muted loop playsinline></video>
 </p>
 <p align="center"><em>▶ <a href="https://github.com/ProjectSidewalk/SidewalkWebpage/raw/develop/public/videos/ProjectSidewalk_LabelingFromSeattle_KerryPark4_optimized1.5x.mp4">Labeling sidewalk accessibility from Kerry Park, Seattle</a></em></p>
-
-# Project Sidewalk
 
 Project Sidewalk is an open-source web tool for mapping and assessing the accessibility of every sidewalk in the
 world, using remote crowdsourcing, machine learning, and online satellite & streetscape imagery. Contributors walk
 virtually through cities and label accessibility features and problems — curb ramps, obstacles, surface problems,
 missing sidewalks, and more.
 
-Project Sidewalk has run in **50+ cities across 10 countries** (the US, Canada, Chile, India, Mexico, Ecuador, the
+Project Sidewalk is deployed in **50+ cities across 10 countries** (the US, Canada, Chile, India, Mexico, Ecuador, the
 Netherlands, Switzerland, and New Zealand), is natively translated into **six languages** (English, Spanish, German,
 Mandarin, Portuguese, and Dutch), and has collected **3.4M+ contributor-labeled data points**. See the
 [live data dashboard](https://jonfroehlich.github.io/ps-label-vis/ps-dashboard.html).

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@
 Project Sidewalk is an open-source web tool for mapping and assessing the accessibility of every sidewalk in the
 world, using remote crowdsourcing, machine learning, and online satellite & streetscape imagery. Contributors walk
 virtually through cities and label accessibility features and problems — curb ramps, obstacles, surface problems,
-missing sidewalks, and more.
+missing sidewalks, and more. And all collected data is fully open and downloadable in standard formats like GeoJSON and CSV, 
+so it's easy to integrate into your own systems and research! See [https://projectsidewalk.org/api](https://projectsidewalk.org/api).
 
 Project Sidewalk is deployed in **50+ cities across 10 countries** (the US, Canada, Chile, India, Mexico, Ecuador, the
 Netherlands, Switzerland, and New Zealand), is natively translated into **six languages** (English, Spanish, German,

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <img src="https://github.com/ProjectSidewalk/SidewalkWebpage/assets/1621749/0e838038-14fe-48cf-a849-1025e688ae68" width="200">
 
 <p align="center">
-  <video src="https://github.com/ProjectSidewalk/SidewalkWebpage/raw/develop/public/videos/ProjectSidewalk_LabelingFromSeattle_KerryPark4_optimized1.5x.mp4" width="760" autoplay loop muted playsinline controls></video>
+  <video src="https://github.com/user-attachments/assets/a0181dac-4cce-4674-85b1-403f4e24c3f8" width="760" controls muted loop playsinline></video>
 </p>
-<p align="center"><em>▶ <a href="https://github.com/ProjectSidewalk/SidewalkWebpage/raw/develop/public/videos/ProjectSidewalk_LabelingFromSeattle_KerryPark4_optimized1.5x.mp4">Watch a short demo — labeling sidewalk accessibility from Kerry Park, Seattle</a></em></p>
+<p align="center"><em>▶ <a href="https://github.com/ProjectSidewalk/SidewalkWebpage/raw/develop/public/videos/ProjectSidewalk_LabelingFromSeattle_KerryPark4_optimized1.5x.mp4">Labeling sidewalk accessibility from Kerry Park, Seattle</a></em></p>
 
 # Project Sidewalk
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 <img src="https://github.com/ProjectSidewalk/SidewalkWebpage/assets/1621749/0e838038-14fe-48cf-a849-1025e688ae68" width="200">
 
+<p align="center">
+  <video src="https://github.com/ProjectSidewalk/SidewalkWebpage/raw/develop/public/videos/ProjectSidewalk_LabelingFromSeattle_KerryPark4_optimized1.5x.mp4" width="760" autoplay loop muted playsinline controls></video>
+</p>
+<p align="center"><em>▶ <a href="https://github.com/ProjectSidewalk/SidewalkWebpage/raw/develop/public/videos/ProjectSidewalk_LabelingFromSeattle_KerryPark4_optimized1.5x.mp4">Watch a short demo — labeling sidewalk accessibility from Kerry Park, Seattle</a></em></p>
+
 # Project Sidewalk
 
 Project Sidewalk is an open-source web tool for mapping and assessing the accessibility of every sidewalk in the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,45 @@
+# Security Policy
+
+Project Sidewalk collects accessibility data from contributors around the world, and we take the security of the
+application and that data seriously. Thank you for helping keep it safe.
+
+## Supported versions
+
+Project Sidewalk is a continuously deployed web application rather than a versioned download. We support and patch:
+
+- **`master`** — the code running on production deployments.
+- **`develop`** — the active development branch.
+
+Fixes land on `develop` and roll out to deployments from `master`; there are no separately maintained older
+releases.
+
+## Reporting a vulnerability
+
+**Please do not open a public issue, pull request, or discussion for security problems**, and don't disclose them
+publicly until we've had a chance to fix them.
+
+Instead, report privately through GitHub's vulnerability reporting:
+
+➡️ **[Report a vulnerability](https://github.com/ProjectSidewalk/SidewalkWebpage/security/advisories/new)**
+(repository **Security** tab → **Report a vulnerability**)
+
+This opens a private advisory visible only to you and the maintainers. If you can't use GitHub for any reason, email
+**sidewalk@cs.uw.edu** with `SECURITY` in the subject line.
+
+### What to include
+
+A good report helps us reproduce and fix the issue quickly:
+
+- A description of the vulnerability and its potential impact.
+- Step-by-step instructions to reproduce it (proof-of-concept, affected URL/endpoint, payload).
+- The affected component or area (e.g. a `/v3/api/...` route, the Explore tool, authentication).
+- Any relevant logs, screenshots, or suggested remediation.
+
+### What to expect
+
+- **Acknowledgement** of your report, typically within a few business days.
+- An assessment and, where confirmed, a fix coordinated with you before public disclosure.
+- Credit for the discovery if you'd like it (let us know how you'd like to be named).
+
+We're a small academic/civic-tech team, so timelines depend on severity and capacity — we appreciate your patience
+and your discretion in giving us time to remediate before any public disclosure.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,147 @@
+# Architecture
+
+A tour of how Project Sidewalk is put together, for contributors getting oriented. For setup see
+[`docs/dev-environment.md`](dev-environment.md); for the contribution workflow and coding standards see
+[`CONTRIBUTING.md`](../CONTRIBUTING.md). [`CLAUDE.md`](../CLAUDE.md) is the AI-assistant-facing companion to this
+document — same architecture, plus tool/operational notes for coding agents.
+
+## Overview
+
+Project Sidewalk is a web-based crowdsourcing tool for mapping and assessing sidewalk accessibility. Contributors
+move through panoramic street imagery and label accessibility features and problems; that data is validated,
+aggregated, scored, and served back out through a public API and a set of dashboards.
+
+**Stack:**
+- **Backend** — Scala 2.13 + Play Framework 3.0 (Java 17).
+- **Database** — Postgres + PostGIS, accessed via Slick (with slick-pg for spatial/JSON types).
+- **Frontend** — vanilla JavaScript, organized as several independent apps bundled by Grunt (concatenation only —
+  no transpilation/module system). Migrating off jQuery and Bootstrap.
+- **Dev/runtime** — everything runs in Docker.
+
+## System at a glance
+
+```
+Browser (vanilla-JS apps: Explore, Validate, Gallery, Admin, Progress, PSMap)
+        │  HTTP
+        ▼
+Play backend ── routes → Controller → Service → Table (DAO/Slick)
+        │                                   │
+        │                                   ▼
+        │                         Postgres + PostGIS  (one schema per city: sidewalk_<city>;
+        │                                              auth in sidewalk_login)
+        ▼
+External imagery providers (Google Street View / Mapillary / Infra3d / Pannellum)
+
+Out-of-band Python utilities: label_clustering.py, check_streets_for_imagery.py
+```
+
+## Backend
+
+### Request flow
+
+The backend follows a consistent layering: **routes → Controller → Service → Table (DAO)**.
+
+- **`conf/routes`** — a single file mapping URLs to controller methods. The public data API lives under
+  `/v3/api/...`.
+- **`app/controllers/`** — a thin HTTP layer. Controllers parse/validate requests and delegate; they should not
+  touch tables directly. Auth-protected actions use **Silhouette** (`app/models/auth/`, `SilhouetteModule`).
+  Versioned public-API controllers live in `app/controllers/api/`.
+- **`app/service/`** — business logic (e.g. `LabelService`, `ValidationService`, `ExploreService`,
+  `AccessScoreService`, `ApiService`). This is where most non-trivial logic belongs.
+- **`app/models/`** — Slick table definitions and queries, grouped by domain (`label/`, `validation/`, `mission/`,
+  `region/`, `street/`, `route/`, `user/`, `cluster/`, `gallery/`, `api/`, …). Files named `*Table.scala` define
+  schema + queries (the DAO pattern).
+
+### Database access
+
+- **`app/models/utils/MyPostgresProfile.scala`** — a custom Slick Postgres profile wiring in PostGIS geometry,
+  JSON, and other slick-pg extensions. Spatial query helpers live in `SpatialQueryDefs.scala`.
+- **Per-city schemas** — each city is its own schema (`sidewalk_<city>`); they're essentially identical.
+  Authentication lives in `sidewalk_login`.
+- **Evolutions** — schema changes are Play evolutions: numbered SQL files in `conf/evolutions/default/`, each with
+  `# --- !Ups` / `# --- !Downs`. The dev DB is seeded from a dump rather than built up from evolutions.
+
+### Dependency injection & runtime
+
+DI is Guice. The app bootstraps via `app/CustomApplicationLoader.scala`; modules are registered in
+`conf/application.conf` and defined in `app/modules/` (`CustomControllerModule`, `ActorModule`, `ExecutorsModule`,
+`SilhouetteModule`). Custom execution contexts live in `app/executors/`; background actors in `app/actor/`.
+
+**Views** are Twirl templates (`app/views/*.scala.html`).
+
+### The public API (`/v3`)
+
+The `/v3` API is the canonical public surface (handlers in `app/controllers/api/`). Conventions (issue #3871):
+
+- **Query/REST parameters are camelCase** (`minSeverity`, `regionId`, `validationStatus`).
+- **All output field names are snake_case** — JSON bodies, GeoJSON `properties`, CSV headers, and
+  shapefile/geopackage fields (`label_id`, `region_name`, `city_id`) — one canonical field name across every export
+  format.
+- v3 is a **preview** surface: breaking changes are made in place rather than minting a new version.
+
+The response/filter data structures (DTOs) live in **`app/models/api/`** (`package models.api`), in per-domain
+`*ApiModels.scala` files (issue #3885). Response types are named `*ForApi`; parsed query filters are
+`*FiltersForApi`. Response DTOs extend `StreamingApiType` and implement `toJson`/`toCsvRow` inline so the
+`BaseApiController` helpers can serialize a stream of them uniformly. (The older `/v2` access-score DTOs remain in
+`models/computation/` and `models/cluster/` pending the v3 access-score rewrite.)
+
+## Frontend
+
+Each major UI is a self-contained app under `public/javascripts/`, bundled separately by Grunt and loaded by the
+corresponding Twirl view:
+
+- **`SVLabel/`** — the Explore/Audit tool (label accessibility issues on street-view panoramas). The largest app.
+- **`SVValidate/`** — the Validate tool (confirm/reject others' labels).
+- **`Gallery/`** — browsable, filterable gallery of labels.
+- **`Admin/`** — admin dashboards and maps.
+- **`Progress/`** — user dashboards.
+- **`PSMap/`** — shared map component used across pages.
+- **`Help/`** — help/FAQ page.
+- **`common/`** — modules shared across bundles: `pano-viewer/` (an abstraction over the GSV / Mapillary / Infra3d /
+  Pannellum imagery providers), `label-detail/` (label popups), and various utilities.
+
+There is **no module system**: files are concatenated in a hand-specified order (see `Gruntfile.js`); external
+libraries live in `public/javascripts/lib/`. Edit `src/` files only — bundles are generated into
+`public/javascripts/*/build/`.
+
+## Internationalization
+
+Two separate i18n systems:
+
+1. **Backend** (server-rendered) — Play message files `conf/messages.<lang>`, referenced in Twirl with
+   `@Messages("key")`.
+2. **Frontend** (client-side) — JSON under `public/locales/<lang>/` (e.g. `common.json`), referenced with
+   `i18next.t('key')` or, preferably, `data-i18n="ns:key"` in HTML.
+
+Supported languages: en, es, de, nl, zh-TW, pt-BR, plus regional English variants en-US and en-NZ.
+
+## Configuration & deployment
+
+- `conf/application.conf` is the base; environment overlays are `application.local.conf`, `application.staging.conf`,
+  `application.test.conf`. Local dev runs with `application.local.conf`.
+- Per-city settings live in `conf/cityparams.conf`, selected via the `SIDEWALK_CITY_ID` env var.
+- Secrets/keys (Mapbox, Google Maps, Gemini, Mapillary, Infra3d, Silhouette signer/crypter, DB credentials) come
+  from environment variables; local values live in a `docker-compose.override.yml`.
+
+## Python utilities
+
+Two standalone scripts (run out-of-band, not from the web app):
+
+- `label_clustering.py` — clusters nearby labels (used by the clustering flow; see `ClusterController` /
+  `app/models/cluster/`).
+- `check_streets_for_imagery.py` — checks streets for available street-view imagery.
+
+## Label types
+
+Every label type (CurbRamp, NoCurbRamp, Obstacle, SurfaceProblem, NoSidewalk, Crosswalk, Signal, Other, …) has a
+canonical color and icon set. The source of truth is the **`/v3/api/labelTypes`** endpoint; in frontend code use
+`util.misc.getLabelColors(labelType)` rather than hardcoding hex values. See [`CLAUDE.md`](../CLAUDE.md) for the
+canonical color table and icon locations.
+
+## Where to go next
+
+- [`docs/dev-environment.md`](dev-environment.md) — get it running locally.
+- [`CONTRIBUTING.md`](../CONTRIBUTING.md) — workflow, coding standards, i18n, testing.
+- [`docs/testing-and-ci.md`](testing-and-ci.md) — testing strategy and CI.
+- [`CLAUDE.md`](../CLAUDE.md) — the same architecture plus conventions and operational notes, used as AI-assistant
+  context.

--- a/docs/dev-environment.md
+++ b/docs/dev-environment.md
@@ -1,0 +1,319 @@
+# Development Environment Setup
+
+This guide gets a local copy of Project Sidewalk running on your machine. Everything runs in **Docker**, so you do
+not install Scala, Node, or Postgres directly — you only need Docker, Git, and a terminal.
+
+> **New contributor?** Read [`CONTRIBUTING.md`](../CONTRIBUTING.md) first for the branch/PR workflow and coding
+> standards. For a deeper tour of the architecture, see [`CLAUDE.md`](../CLAUDE.md).
+>
+> **Stuck?** Jump to [Troubleshooting](#troubleshooting) or [Getting help](#getting-help).
+
+---
+
+## What you'll need
+
+- **Docker** (Docker Desktop on macOS/Windows, Docker Engine + Compose on Linux) — installed and running.
+- **Git** and terminal/shell access.
+- **From a maintainer** (the app will not start without these): a `docker-compose.override.yml` with local secrets
+  and one or more **database dumps** to seed Postgres. Email the lead engineer, Mikey
+  (**saugstad@cs.washington.edu**), to request them.
+- **API keys** — the override file from a maintainer includes our keys. If you're *outside the team*, you'll need to
+  create your own [Google Maps](https://developers.google.com/maps/documentation/javascript/get-api-key) and
+  [Mapbox](https://docs.mapbox.com/help/getting-started/access-tokens/) keys and add them to the override file.
+
+The dev setup is geared toward team members. If you're outside the team and want to stand up a server for a city we
+don't support, start with the [Creating a database for a new city](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Creating-database-for-a-new-city)
+wiki page — that's a substantial GIS task on its own.
+
+---
+
+## Platform setup
+
+Install Docker and Git for your platform, then clone the repo. The workflow after that is identical everywhere.
+
+```bash
+git clone https://github.com/ProjectSidewalk/SidewalkWebpage.git
+cd SidewalkWebpage
+```
+
+### Linux (Ubuntu)
+
+1. Install Docker. Consider [rootless Docker](https://docs.docker.com/engine/security/rootless/) — a bit more setup
+   now, but smoother development later.
+2. [Install Docker Compose](https://docs.docker.com/compose/install/) (bundled on Mac/Windows, separate on Linux).
+3. Clone the repo (above).
+
+### macOS
+
+1. [Install Docker Desktop](https://www.docker.com/get-started) — pick **Apple Chip** for M-series Macs or **Intel
+   Chip** for older models.
+2. Clone the repo (above).
+
+### Windows (WSL2)
+
+We recommend and only support the **WSL2** path — it runs a real Linux kernel in a lightweight VM, giving faster
+compiles and better Docker support than legacy WSL.
+
+1. [Install Docker Desktop](https://docs.docker.com/desktop/windows/install/). When prompted, select **Use WSL 2**
+   (not Hyper-V).
+2. Install WSL2 with the default Ubuntu distro: open PowerShell **as administrator** and run `wsl --install`.
+   (Pin Ubuntu to your taskbar for easy access.)
+3. Update WSL: `wsl --update`.
+4. In Docker Desktop → **Settings → General**, check **Use the WSL 2 based engine**. Then under
+   **Resources → WSL Integration**, enable integration with your default distro and check **Ubuntu**.
+5. **From inside the Ubuntu (Linux) shell** — not `/mnt/c` — clone the repo into your Linux home (e.g.
+   `~/projects/`). Running from the Linux filesystem is required for acceptable performance.
+
+You'll need `make` inside Ubuntu: `sudo apt install make`.
+
+<details>
+<summary><strong>Moving files (e.g. database dumps) into the Linux VM</strong></summary>
+
+- **File Explorer:** in the left sidebar open `Linux → Ubuntu → home → <username> → SidewalkWebpage` and drag files
+  in. (Right-click the folder → "Pin to Quick access" to find it easily later.) Copied files often get a companion
+  `:Zone.Identifier` file — it's safe to delete those.
+- **Command line:** your Windows drives are mounted under `/mnt` (e.g. `/mnt/c`), so you can
+  `cp /mnt/c/path/to/dump ~/SidewalkWebpage/db/`.
+</details>
+
+<details>
+<summary><strong>Starting / shutting down WSL2 + Docker</strong></summary>
+
+WSL and Docker use significant memory in the background. When you're not working on Project Sidewalk:
+
+- **Shut down:** close anything using Docker/WSL, quit Docker Desktop from the tray, then run `wsl --shutdown`.
+- **Start back up:** run `wsl -d Ubuntu` (or just open your IDE in WSL), then launch Docker Desktop.
+</details>
+
+---
+
+## First-time setup
+
+Make sure Docker is running (you'll see the whale icon in your tray; you can set Docker to start on login).
+
+1. **Add the secrets file.** Place the `docker-compose.override.yml` from your maintainer in the repo root, then
+   edit it for the city you want to run:
+   - **`SIDEWALK_CITY_ID`** — the city to run (e.g. `seattle-wa`); see the [City IDs table](#city-ids).
+   - **`DATABASE_USER`** — that city's database user, replacing the default `sidewalk` (e.g. `sidewalk_seattle`).
+   - **`platform`** — *Apple Silicon (M-series) only:* uncomment this line.
+
+2. **Stage the database dumps.** Put the dump files from your maintainer in the **`db/`** directory and rename them
+   to the exact names the import scripts expect:
+   - City data dump → **`<database_user>-dump`** (e.g. `sidewalk_seattle-dump`).
+   - Users dump → **`sidewalk_users-dump`** (same name regardless of city).
+
+3. **Build and start the containers**, dropping into a shell in the web container:
+
+   ```bash
+   make dev
+   ```
+
+   `make dev` starts the `db` container and then opens an interactive shell in the `web` container. The **first**
+   build downloads images, spins up containers, and initializes (but does not yet populate) the database — expect
+   ~5–30+ minutes depending on your connection. Success ends with a `root@<container-id>:/home#` prompt.
+
+4. **Import users and data** from a *second* terminal on your host (outside the web-container shell):
+
+   ```bash
+   make import-users                   # load sidewalk_users-dump (the login schema); ~1–2 min
+   make import-dump db=<database_user> # load <database_user>-dump; db= defaults to "sidewalk"
+   ```
+
+   `import-dump` can take a while for large dumps. Read its output carefully — if it errors, **don't** continue;
+   check [Troubleshooting](#troubleshooting) and ask. (A `schema "public" already exists` notice is the one error
+   you can safely ignore.)
+
+5. **Start the app** from inside the web-container shell opened by `make dev`:
+
+   ```bash
+   npm start
+   ```
+
+   `npm start` runs Grunt (JS/CSS concatenation + watch) in the background, then `sbt ~ run` for continuous
+   recompile. The first compile takes 5+ minutes; later ones are seconds. Use `npm run debug` if you want a JVM
+   debug port attached. It's ready when you see `Listening for HTTP on .../9000`.
+
+6. **Open the app:** http://localhost:9000 (or `127.0.0.1:9000`). The first load is slow while Play applies
+   evolutions and compiles on demand.
+
+---
+
+## Daily workflow
+
+After a restart you don't repeat the import — just:
+
+```bash
+cd SidewalkWebpage
+make dev          # start db + open the web-container shell
+npm start         # (inside that shell) build assets + run the app
+```
+
+Then visit http://localhost:9000. To stop everything: `make docker-stop`.
+
+Other handy targets:
+
+| Command | What it does |
+|---------|--------------|
+| `make docker-up` | Start all services detached (no shell). |
+| `make ssh target=web` | Open a shell in a running container (`target=web` or `target=db`). |
+
+---
+
+## Switching / adding another city
+
+Each city is a separate database. To switch:
+
+1. Put the new dump in `db/`, renamed to `<database_user>-dump` (see the [City IDs table](#city-ids)).
+2. If that dump is newer than your existing ones, also re-import users with a fresh `sidewalk_users-dump`
+   (ask a maintainer if unsure — the creation date is in the original filename).
+3. `make import-dump db=<database_user>` (from the host, outside the Docker shell).
+4. Update **`DATABASE_USER`** and **`SIDEWALK_CITY_ID`** in `docker-compose.override.yml` to match.
+5. `make dev` again.
+
+To switch back and forth later: `exit` the Docker shell, change the two override values, and re-run `make dev`.
+
+### City IDs
+
+The `SIDEWALK_CITY_ID` and `DATABASE_USER` must correspond. In the repo, **`conf/cityparams.conf` is the source of
+truth**; the snapshot below is a convenience copy (it may lag as new cities are added).
+
+| City ID | Database User | | City ID | Database User |
+| --- | --- | --- | --- | --- |
+| seattle-wa | sidewalk_seattle | | madison-wi | sidewalk_madison |
+| columbus-oh | sidewalk_columbus | | tainan-nj | sidewalk_tainan |
+| cdmx | sidewalk_cdmx | | niagara-falls-nj | sidewalk_niagara_falls |
+| spgg | sidewalk_spgg | | chandigarh-india | sidewalk_chandigarh |
+| pittsburgh-pa | sidewalk_pittsburgh | | vancouver-wa | sidewalk_vancouver |
+| newberg-or | sidewalk_newberg | | rancagua-chile | sidewalk_rancagua |
+| washington-dc | sidewalk | | santiago-chile | sidewalk_santiago |
+| chicago-il | sidewalk_chicago | | tucson-az | sidewalk_tucson |
+| amsterdam | sidewalk_amsterdam | | paterson-nj | sidewalk_paterson |
+| la-piedad | sidewalk_la_piedad | | richmond-va | sidewalk_richmond |
+| oradell-nj | sidewalk_oradell | | fort-wayne-in | sidewalk_fort_wayne |
+| validation-study | sidewalk_validation | | virden-il | sidewalk_virden |
+| zurich | sidewalk_zurich | | gainesville-fl | sidewalk_gainesville |
+| taipei | sidewalk_taipei | | sao-paulo-brazil | sidewalk_sao_paulo |
+| new-taipei-tw | sidewalk_new_taipei | | winterthur-infra3d | sidewalk_winterthur_infra3d |
+| keelung-tw | sidewalk_keelung | | waltham-ma | sidewalk_waltham |
+| auckland | sidewalk_auckland | | knox-oh | sidewalk_knox |
+| cuenca | sidewalk_cuenca | | kaohsiung-tw | sidewalk_kaohsiung |
+| crowdstudy | sidewalk_crowdstudy | | taichung-tw | sidewalk_taichung |
+| burnaby | sidewalk_burnaby | | cliffside-park-nj | sidewalk_cliffside_park |
+| teaneck-nj | sidewalk_teaneck | | blackhawk-hills-il | sidewalk_blackhawk_hills |
+| walla-walla-wa | sidewalk_walla_walla | | columbia-sc | sidewalk_columbia |
+| st-louis-mo | sidewalk_st_louis | | west-chester-pa | sidewalk_west_chester |
+| la-ca | sidewalk_la | | danville-il | sidewalk_danville |
+| mendota-il | sidewalk_mendota | | detroit-mi | sidewalk_detroit |
+| hackensack-nj | sidewalk_hackensack | | clifton-nj | sidewalk_clifton |
+| maywood-nj | sidewalk_maywood | | | |
+
+---
+
+## Editor and database tools
+
+**Editor:** use whatever you're productive in — the team uses both, and the codebase has two halves with different
+sweet spots:
+
+- **[IntelliJ IDEA](https://www.jetbrains.com/idea/)** (free [student license](https://www.jetbrains.com/student/)
+  for Ultimate) has the most turnkey **Scala/Play** support. The
+  [Developing with IntelliJ IDEA](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Developing-with-IntelliJ-IDEA)
+  wiki page has full setup (marking source/excluded folders, plugins).
+- **[VS Code](https://code.visualstudio.com/)** is excellent for the **vanilla-JS frontend**; add the
+  [Metals](https://scalameta.org/metals/docs/editors/vscode/) extension for Scala.
+
+A combined `docs/editor-setup.md` covering both is planned. Whichever you use, configure it to run **scalafmt** on
+Scala files (see [`CONTRIBUTING.md`](../CONTRIBUTING.md)).
+
+**Database client:** [Valentina Studio](https://www.valentina-db.com/en/valentina-studio-overview) (cross-platform),
+[Postico](https://eggerapps.at/postico/) (Mac), or [pgAdmin](https://www.pgadmin.org/download/) (Windows/Mac).
+Connect with:
+
+```
+Host:     localhost
+Port:     5432
+Database: sidewalk
+User:     postgres
+Password: sidewalk
+```
+
+---
+
+## Making changes
+
+The dev server hot-reloads, so you rarely restart it.
+
+- **Scala / Twirl views** — `sbt ~ run` recompiles on save; reload the browser once compilation finishes.
+- **JavaScript / CSS** — Grunt's `watch` re-concatenates your `src/` edits into `public/javascripts/*/build/`
+  automatically. **Edit `src/` files only; never edit `build/` output**, and don't run `grunt` by hand. If a new
+  `src/` file isn't picked up, check that its path matches a glob in `Gruntfile.js`.
+- **`build.sbt` or config changes** — these aren't hot-reloaded. In the Docker shell press `Ctrl+D`, then run
+  `sbt clean`, then `npm start` again.
+
+### Checking that backend changes compile
+
+There's no backend test suite — validate Scala changes by compiling. The sbt **thin client** uses its own server,
+so it won't collide with a running `sbt ~ run`:
+
+```bash
+docker exec projectsidewalk-web bash -lc "cd /home && sbt --client compile"
+```
+
+The first call after a container boot starts the compile server (~30s); later calls are near-instant. `build.sbt`
+sets `-Xfatal-warnings`, so a `[success]` is also warning-clean.
+
+### Exercising authenticated routes
+
+Most routes need a session. Grab an anonymous cookie once, then reuse the jar:
+
+```bash
+curl -s -c /tmp/sidewalk_cookies.txt "http://localhost:9000/anonSignUp?url=%2F"
+curl -s -b /tmp/sidewalk_cookies.txt "http://localhost:9000/v3/api/labelTypes"
+```
+
+### Inspecting the database
+
+Each city lives in its own schema (`sidewalk_<city>`); authentication lives in `sidewalk_login`. For ad-hoc
+queries, prefer the **read-only** role so you can't accidentally write:
+
+```bash
+docker exec projectsidewalk-db psql -U readonly_user -d sidewalk -c "\dt sidewalk_seattle.*"
+```
+
+---
+
+## Troubleshooting
+
+Roughly ordered by when you'd hit them during setup.
+
+| Symptom | Fix |
+|---------|-----|
+| `make: docker-compose: No such file or directory` | Newer Docker uses `docker compose` (no hyphen). Edit the `Makefile` to replace `docker-compose` with `docker compose`. |
+| `Docker-Compose` command fails on Mac | Recreate the symlink per the [Compose install docs](https://docs.docker.com/compose/install/). |
+| `gpg: keyserver receive failed` during build (Windows) | Add `ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1` near the top of the `Dockerfile`. |
+| `pg_restore: ... schema "public" already exists` | Safe to ignore — no effect. |
+| `import-dump` otherwise errors | Don't skip ahead. Re-check the dump filename and `db=` value, then see the [Troubleshooting wiki](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Troubleshooting-Dev-Environment) and ask. |
+| `Execution exception [NoSuchElementException: None.get]` at runtime | The data wasn't imported — run `make import-dump` (the init only creates the schema, not the data). |
+| `Cannot create container for service web: Conflict ... name "/projectsidewalk-web" already in use` | A prior `web` container wasn't shut down cleanly: `docker container rm /projectsidewalk-web`. |
+| Errors after the computer was shut off mid-run (WSL) | Run `wsl --shutdown`; when Docker offers to restart WSL, accept. Otherwise restart Docker manually. |
+| Can't connect to the database | The db container may not be listening on all addresses. `make ssh target=db`, edit `/var/lib/postgresql/data/postgresql.conf`, set `listen_addresses = '*'`. |
+| `make` commands "just don't work" | Reinstall `make`. As a fallback, run the underlying command from the `Makefile` directly (e.g. `make ssh target=web` ≈ `docker exec -it projectsidewalk-web /bin/bash`). |
+| A new `src/` JS file isn't bundled | Make sure its path matches a glob in `Gruntfile.js`. |
+| First compile seems stuck | It isn't — initial dependency resolution is genuinely slow. Watch the container logs. |
+
+**Slick query errors while developing:**
+
+- `value transactionally is not a member of slick.dbio.DBIOAction...` → add `import models.utils.MyPostgresProfile.api._`.
+- `type mismatch ... NoStream,Nothing ...` (often misleading) → try wrapping the queries in `.transactionally`, or
+  use `DBIO.seq().andThen()`.
+
+---
+
+## Getting help
+
+- **Team members:** ask in the **#core** or **#interns** Slack channels (we prefer channels over DMs so everyone
+  can learn and help).
+- **Anyone:** search the [issues tagged "Dev Environment"](https://github.com/ProjectSidewalk/SidewalkWebpage/issues?q=is%3Aissue+label%3A%22Dev+Environment%22),
+  check the [Troubleshooting wiki](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Troubleshooting-Dev-Environment),
+  or email **sidewalk@cs.uw.edu**.
+
+If you solve something not covered here, please add it.


### PR DESCRIPTION
Resolves part of #4252 — foundational pass moving core developer docs off the wiki into versioned Markdown, plus the missing GitHub-standard community files (SECURITY/CONTRIBUTING/CODE_OF_CONDUCT). Adds docs/dev-environment.md and an expanded README. Rewritten to a high OSS-docs standard, not ported verbatim. Follow-up PRs migrate the remaining wiki pages; migrated wiki pages become redirect stubs after this lands. Action: enable Private Vulnerability Reporting so the SECURITY.md link is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)