### PR TITLE
Add v3 AccessScore API endpoints with severity- and tag-aware scoring (#3855)

### DIFF
--- a/app/controllers/ApiDocsController.scala
+++ b/app/controllers/ApiDocsController.scala
@@ -91,6 +91,26 @@ class ApiDocsController @Inject() (
   }
 
   /**
+   * Displays API documentation for the street-level AccessScore.
+   */
+  def accessScoreStreets = cc.securityService.SecuredAction { implicit request =>
+    configService.getCommonPageData(request2Messages.lang).map { commonData =>
+      cc.loggingService.insert(request.identity.userId, request.ipAddress, "Visit_APIDocs_AccessScoreStreets")
+      Ok(views.html.apiDocs.accessScoreStreets(commonData, request.identity))
+    }
+  }
+
+  /**
+   * Displays API documentation for the region-level AccessScore.
+   */
+  def accessScoreRegions = cc.securityService.SecuredAction { implicit request =>
+    configService.getCommonPageData(request2Messages.lang).map { commonData =>
+      cc.loggingService.insert(request.identity.userId, request.ipAddress, "Visit_APIDocs_AccessScoreRegions")
+      Ok(views.html.apiDocs.accessScoreRegions(commonData, request.identity))
+    }
+  }
+
+  /**
    * Displays API documentation for the street types.
    */
   def streetTypes = cc.securityService.SecuredAction { implicit request =>

--- a/app/controllers/api/AccessScoreApiController.scala
+++ b/app/controllers/api/AccessScoreApiController.scala
@@ -2,15 +2,16 @@ package controllers.api
 
 import controllers.base.CustomControllerComponents
 import controllers.helper.ShapefilesCreatorHelper
+import models.api.{ApiError, RegionAccessScoreForApi, StreetAccessScoreForApi}
 import models.computation.{RegionScore, StreetScore}
 import models.utils.{LatLngBBox, MapParams, SpatialQueryType}
 import org.apache.pekko.stream.scaladsl.Source
 import play.silhouette.api.Silhouette
-import service.{AccessScoreService, ConfigService}
+import service.{AccessScoreService, ApiService, ConfigService}
 
 import java.time.OffsetDateTime
 import javax.inject.{Inject, Singleton}
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 
 /**
  * AccessScoreController handles API endpoints related to access scores for streets and neighborhoods.
@@ -30,7 +31,8 @@ class AccessScoreApiController @Inject() (
     val silhouette: Silhouette[models.auth.DefaultEnv],
     configService: ConfigService,
     shapefileCreator: ShapefilesCreatorHelper,
-    accessScoreService: AccessScoreService
+    accessScoreService: AccessScoreService,
+    apiService: ApiService
 )(implicit ec: ExecutionContext)
     extends BaseApiController(cc) {
 
@@ -110,5 +112,142 @@ class AccessScoreApiController @Inject() (
           outputGeoJSON(regionStream, inline = Some(true), baseFileName + ".json")
       }
     }).flatMap(identity) // Flatten the Future[Result] to return a Future[Result].
+  }
+
+  /**
+   * AccessScore for streets (v3, #3855).
+   *
+   * Returns the severity/quality- and tag-aware AccessScore for each street in the queried area. Supports the standard
+   * v3 geo-filters (bbox / regionId / regionName) and output formats (geojson, csv, shapefile, geopackage).
+   *
+   * @param bbox       Optional bounding box "minLng,minLat,maxLng,maxLat".
+   * @param regionId   Optional region id to score (resolved to the region's bbox; streets are filtered back to it).
+   * @param regionName Optional region name (used only when regionId is absent).
+   * @param filetype   Output format: "csv", "shapefile", "geopackage", or GeoJSON by default.
+   * @param inline     Whether to display the response inline rather than as an attachment.
+   */
+  def getAccessScoreStreets(
+      bbox: Option[String],
+      regionId: Option[Int],
+      regionName: Option[String],
+      filetype: Option[String],
+      inline: Option[Boolean]
+  ) = silhouette.UserAwareAction.async { implicit request =>
+    resolveAccessScoreArea(bbox, regionId, regionName).flatMap {
+      case Left(error) => Future.successful(badRequest(error))
+      case Right((resolvedBbox, regionFilterId)) =>
+        accessScoreService.computeStreetScoresV3(SpatialQueryType.Street, resolvedBbox, DEFAULT_BATCH_SIZE).flatMap {
+          allStreets =>
+            // A region's bbox can overlap neighbors, so restrict to the requested region when one was given.
+            val streets: Seq[StreetAccessScoreForApi] =
+              regionFilterId.fold(allStreets)(id => allStreets.filter(_.regionId == id))
+            val baseFileName: String                  = s"accessScoreStreets_${OffsetDateTime.now()}"
+            val streetStream: Source[StreetAccessScoreForApi, _] = Source.fromIterator(() => streets.iterator)
+            cc.loggingService.insert(request.identity.map(_.userId), request.ipAddress, request.toString)
+
+            filetype match {
+              case Some("csv") =>
+                outputCSV(streetStream, StreetAccessScoreForApi.csvHeader, inline, baseFileName + ".csv")
+              case Some("shapefile") =>
+                outputShapefile(
+                  streetStream, baseFileName, shapefileCreator.createStreetAccessScoreShapefile, shapefileCreator)
+              case Some("geopackage") =>
+                outputGeopackage(
+                  streetStream, baseFileName, shapefileCreator.createStreetAccessScoreGeopackage, inline)
+              case _ =>
+                outputGeoJSON(streetStream, inline, baseFileName + ".json")
+            }
+        }
+    }
+  }
+
+  /**
+   * AccessScore for regions/neighborhoods (v3, #3855).
+   *
+   * Returns each region's street-length-weighted AccessScore plus audit coverage. Supports the standard v3 geo-filters
+   * (bbox / regionId / regionName) and output formats (geojson, csv, shapefile, geopackage).
+   *
+   * @param bbox       Optional bounding box "minLng,minLat,maxLng,maxLat".
+   * @param regionId   Optional region id to score (resolved to the region's bbox; results are filtered back to it).
+   * @param regionName Optional region name (used only when regionId is absent).
+   * @param filetype   Output format: "csv", "shapefile", "geopackage", or GeoJSON by default.
+   * @param inline     Whether to display the response inline rather than as an attachment.
+   */
+  def getAccessScoreRegions(
+      bbox: Option[String],
+      regionId: Option[Int],
+      regionName: Option[String],
+      filetype: Option[String],
+      inline: Option[Boolean]
+  ) = silhouette.UserAwareAction.async { implicit request =>
+    resolveAccessScoreArea(bbox, regionId, regionName).flatMap {
+      case Left(error) => Future.successful(badRequest(error))
+      case Right((resolvedBbox, regionFilterId)) =>
+        accessScoreService.computeRegionScoresV3(resolvedBbox, DEFAULT_BATCH_SIZE).flatMap { allRegions =>
+          val regions: Seq[RegionAccessScoreForApi] =
+            regionFilterId.fold(allRegions)(id => allRegions.filter(_.regionId == id))
+          val baseFileName: String                  = s"accessScoreRegions_${OffsetDateTime.now()}"
+          val regionStream: Source[RegionAccessScoreForApi, _] = Source.fromIterator(() => regions.iterator)
+          cc.loggingService.insert(request.identity.map(_.userId), request.ipAddress, request.toString)
+
+          filetype match {
+            case Some("csv") =>
+              outputCSV(regionStream, RegionAccessScoreForApi.csvHeader, inline, baseFileName + ".csv")
+            case Some("shapefile") =>
+              outputShapefile(
+                regionStream, baseFileName, shapefileCreator.createRegionAccessScoreShapefile, shapefileCreator)
+            case Some("geopackage") =>
+              outputGeopackage(
+                regionStream, baseFileName, shapefileCreator.createRegionAccessScoreGeopackage, inline)
+            case _ =>
+              outputGeoJSON(regionStream, inline, baseFileName + ".json")
+          }
+        }
+    }
+  }
+
+  /**
+   * Resolves the v3 geo-filters to a single bounding box to score within, plus the region id to post-filter results by.
+   *
+   * AccessScore is computed over a bbox, so a region filter is resolved to that region's bounding box; the region id is
+   * retained so the (rectangular) bbox can be trimmed back to the region. Applies the standard v3 precedence via
+   * `resolveGeoFilters`, and reports an unknown region id/name as a 400.
+   *
+   * @return `Right((bbox, regionIdToPostFilterBy))`, or `Left(ApiError)` for an invalid or unknown parameter.
+   */
+  private def resolveAccessScoreArea(
+      bbox: Option[String],
+      regionId: Option[Int],
+      regionName: Option[String]
+  ): Future[Either[ApiError, (LatLngBBox, Option[Int])]] = {
+    val parsedBbox: Option[LatLngBBox] = parseBBoxString(bbox)
+    val firstError: Option[ApiError]   =
+      Seq(validateBBoxParam(bbox, parsedBbox), validateRegionId(regionId)).flatten.headOption
+
+    firstError match {
+      case Some(error) => Future.successful(Left(error))
+      case None =>
+        configService.getCityMapParams.flatMap { cityMapParams =>
+          val (finalBbox, finalRegionId, finalRegionName) =
+            resolveGeoFilters(bbox, parsedBbox, regionId, regionName, cityMapParams)
+          (finalBbox, finalRegionId, finalRegionName) match {
+            case (Some(resolvedBbox), _, _) =>
+              Future.successful(Right((resolvedBbox, None)))
+            case (None, Some(id), _) =>
+              apiService.getRegionBBox(id).map {
+                case Some(regionBbox) => Right((regionBbox, Some(id)))
+                case None => Left(ApiError.invalidParameter(s"No region found with regionId $id.", "regionId"))
+              }
+            case (None, None, Some(name)) =>
+              apiService.resolveRegionByName(name).map {
+                case Some((id, regionBbox)) => Right((regionBbox, Some(id)))
+                case None => Left(ApiError.invalidParameter(s"No region found with regionName '$name'.", "regionName"))
+              }
+            case _ =>
+              // resolveGeoFilters always yields a default bbox when no filter is supplied, so this is unreachable.
+              Future.successful(Left(ApiError.invalidParameter("A bbox or region filter is required.", "bbox")))
+          }
+        }
+    }
   }
 }

--- a/app/controllers/helper/ShapefilesCreatorHelper.scala
+++ b/app/controllers/helper/ShapefilesCreatorHelper.scala
@@ -1,6 +1,6 @@
 package controllers.helper
 
-import models.api.{LabelClusterForApi, LabelDataForApi, RawLabelInClusterDataForApi, RegionDataForApi, StreetDataForApi}
+import models.api.{AccessScoreApiModels, LabelClusterForApi, LabelDataForApi, RawLabelInClusterDataForApi, RegionAccessScoreForApi, RegionDataForApi, StreetAccessScoreForApi, StreetDataForApi}
 import models.computation.{RegionScore, StreetScore}
 import org.apache.pekko.stream.Materializer
 import org.apache.pekko.stream.scaladsl.{Source, StreamConverters}
@@ -1074,6 +1074,152 @@ class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: M
       featureBuilder.add(region.firstLabelDate.map(_.toString).orNull)
       featureBuilder.add(region.lastLabelDate.map(_.toString).orNull)
       featureBuilder.buildFeature(null)
+    }
+
+    createGeneralGeoPackage(source, outputFile, batchSize, featureType, buildFeature)
+  }
+
+  /**
+   * Creates a shapefile from StreetAccessScoreForApi objects (v3, #3855).
+   *
+   * The per-label-type count/sub-score columns use short codes (e.g. nCRamp, sCRamp) because the DBF format truncates
+   * column names at 10 characters; GeoJSON/CSV/GeoPackage keep the full snake_case names.
+   */
+  def createStreetAccessScoreShapefile(
+      source: Source[StreetAccessScoreForApi, _],
+      outputFile: String,
+      batchSize: Int
+  ): Future[Option[Path]] = {
+    val perTypeSpec: String = AccessScoreApiModels.orderedTypes
+      .map { t => val c = AccessScoreApiModels.shapefileTypeCode(t); s"n$c:Integer,s$c:Double" }
+      .mkString(",")
+    val featureType: SimpleFeatureType = DataUtilities.createType(
+      "AccessScoreStreet",
+      "the_geom:LineString:srid=4326," // LineString geometry
+      + "streetId:Integer,"            // Street edge ID
+      + "osmWayId:String,"             // OSM way ID as String (shapefiles don't handle Long well)
+      + "regionId:Integer,"            // Region ID
+      + "score:Double,"                // Access score (null if unaudited)
+      + "auditCount:Integer,"          // Number of completed audits
+      + "lengthM:Double,"              // Street length in meters
+      + "labelCount:Integer,"          // Number of labels contributing to the score
+      + perTypeSpec                    // Per-type cluster count (n<code>) and sub-score (s<code>)
+    )
+
+    def buildFeature(s: StreetAccessScoreForApi, fb: SimpleFeatureBuilder): SimpleFeature = {
+      fb.add(s.geometry)
+      fb.add(s.streetEdgeId)
+      fb.add(s.osmWayId.toString)
+      fb.add(s.regionId)
+      fb.add(s.score.map(Double.box).orNull)
+      fb.add(s.auditCount)
+      fb.add(s.lengthMeters)
+      fb.add(s.labelCount)
+      AccessScoreApiModels.orderedTypes.foreach { t =>
+        fb.add(s.clusterCounts.getOrElse(t, 0))
+        fb.add(s.subScores.getOrElse(t, 0.0))
+      }
+      fb.buildFeature(null)
+    }
+
+    createGeneralShapefile(source, outputFile, batchSize, featureType, buildFeature)
+  }
+
+  /** Creates a GeoPackage from StreetAccessScoreForApi objects (v3, #3855). Full snake_case column names (no 10-char limit). */
+  def createStreetAccessScoreGeopackage(
+      source: Source[StreetAccessScoreForApi, _],
+      outputFile: String,
+      batchSize: Int
+  ): Future[Option[Path]] = {
+    val perTypeSpec: String = AccessScoreApiModels.orderedTypes
+      .flatMap { t => val n = AccessScoreApiModels.snakeType(t); Seq(s"n_$n:Integer", s"score_$n:Double") }
+      .mkString(",")
+    val featureType: SimpleFeatureType = DataUtilities.createType(
+      "access_score_streets",
+      "the_geom:LineString:srid=4326,street_id:Integer,osm_way_id:String,region_id:Integer,score:Double," +
+        "audit_count:Integer,length_meters:Double,label_count:Integer," + perTypeSpec
+    )
+
+    def buildFeature(s: StreetAccessScoreForApi, fb: SimpleFeatureBuilder): SimpleFeature = {
+      fb.add(s.geometry)
+      fb.add(s.streetEdgeId)
+      fb.add(s.osmWayId.toString)
+      fb.add(s.regionId)
+      fb.add(s.score.map(Double.box).orNull)
+      fb.add(s.auditCount)
+      fb.add(s.lengthMeters)
+      fb.add(s.labelCount)
+      AccessScoreApiModels.orderedTypes.foreach { t =>
+        fb.add(s.clusterCounts.getOrElse(t, 0))
+        fb.add(s.subScores.getOrElse(t, 0.0))
+      }
+      fb.buildFeature(null)
+    }
+
+    createGeneralGeoPackage(source, outputFile, batchSize, featureType, buildFeature)
+  }
+
+  /** Creates a shapefile from RegionAccessScoreForApi objects (v3, #3855). Per-type avg-count columns use short codes. */
+  def createRegionAccessScoreShapefile(
+      source: Source[RegionAccessScoreForApi, _],
+      outputFile: String,
+      batchSize: Int
+  ): Future[Option[Path]] = {
+    val perTypeSpec: String = AccessScoreApiModels.orderedTypes
+      .map { t => s"a${AccessScoreApiModels.shapefileTypeCode(t)}:Double" }
+      .mkString(",")
+    val featureType: SimpleFeatureType = DataUtilities.createType(
+      "AccessScoreRegion",
+      "the_geom:MultiPolygon:srid=4326," // MultiPolygon geometry
+      + "regionId:Integer,"              // Region ID
+      + "name:String,"                   // Region name
+      + "score:Double,"                  // Length-weighted region score (null if no audited streets)
+      + "coverage:Double,"               // Fraction of streets audited
+      + "audited:Integer,"               // Audited street count
+      + "total:Integer,"                 // Total street count
+      + perTypeSpec                      // Per-type mean cluster count (a<code>)
+    )
+
+    def buildFeature(r: RegionAccessScoreForApi, fb: SimpleFeatureBuilder): SimpleFeature = {
+      fb.add(r.geometry)
+      fb.add(r.regionId)
+      fb.add(r.name)
+      fb.add(r.score.map(Double.box).orNull)
+      fb.add(r.coverage)
+      fb.add(r.auditedStreetCount)
+      fb.add(r.totalStreetCount)
+      AccessScoreApiModels.orderedTypes.foreach { t => fb.add(r.avgClusterCounts.getOrElse(t, 0.0)) }
+      fb.buildFeature(null)
+    }
+
+    createGeneralShapefile(source, outputFile, batchSize, featureType, buildFeature)
+  }
+
+  /** Creates a GeoPackage from RegionAccessScoreForApi objects (v3, #3855). Full snake_case column names. */
+  def createRegionAccessScoreGeopackage(
+      source: Source[RegionAccessScoreForApi, _],
+      outputFile: String,
+      batchSize: Int
+  ): Future[Option[Path]] = {
+    val perTypeSpec: String = AccessScoreApiModels.orderedTypes
+      .map { t => s"avg_n_${AccessScoreApiModels.snakeType(t)}:Double" }
+      .mkString(",")
+    val featureType: SimpleFeatureType = DataUtilities.createType(
+      "access_score_regions",
+      "the_geom:MultiPolygon:srid=4326,region_id:Integer,name:String,score:Double,coverage:Double," +
+        "audited_street_count:Integer,total_street_count:Integer," + perTypeSpec
+    )
+
+    def buildFeature(r: RegionAccessScoreForApi, fb: SimpleFeatureBuilder): SimpleFeature = {
+      fb.add(r.geometry)
+      fb.add(r.regionId)
+      fb.add(r.name)
+      fb.add(r.score.map(Double.box).orNull)
+      fb.add(r.coverage)
+      fb.add(r.auditedStreetCount)
+      fb.add(r.totalStreetCount)
+      AccessScoreApiModels.orderedTypes.foreach { t => fb.add(r.avgClusterCounts.getOrElse(t, 0.0)) }
+      fb.buildFeature(null)
     }
 
     createGeneralGeoPackage(source, outputFile, batchSize, featureType, buildFeature)

--- a/app/models/api/AccessScoreApiModels.scala
+++ b/app/models/api/AccessScoreApiModels.scala
@@ -1,0 +1,205 @@
+/**
+ * Models for the Project Sidewalk AccessScore API (v3, #3855).
+ *
+ * Holds the streaming DTOs returned by `/v3/api/accessScoreStreets` and `/v3/api/accessScoreRegions`, plus the parsed
+ * filter object. The scoring math itself lives in `service.AccessScoreCalculator`; these types only carry and serialize
+ * the computed results. Per the v3 conventions (#3871) all output field names are snake_case; the dynamic per-type
+ * breakdown objects are keyed by the canonical label-type names (e.g. "CurbRamp"), matching `/v3/api/labelTypes`.
+ */
+package models.api
+
+import models.api.ApiModelUtils.escapeCsvField
+import models.utils.LatLngBBox
+import models.utils.MyPostgresProfile.api._
+import org.locationtech.jts.geom.{LineString, MultiPolygon}
+import play.api.libs.json.{JsObject, Json, Writes}
+import service.AccessScoreCalculator
+
+/**
+ * Shared helpers for the AccessScore DTOs: the per-label-type column names used across CSV, GeoJSON, and shapefile
+ * output. Centralized so the street and region DTOs (and the shapefile creator) stay in lockstep with the set of scored
+ * types defined in [[service.AccessScoreCalculator]].
+ */
+object AccessScoreApiModels {
+
+  /** The scored label types in stable column order (by label-type id). */
+  val orderedTypes: Seq[String] = AccessScoreCalculator.orderedScoredTypes
+
+  /** Converts a CamelCase label-type name to snake_case for flat CSV column names (e.g. "NoCurbRamp" → "no_curb_ramp"). */
+  def snakeType(labelType: String): String =
+    labelType.replaceAll("([a-z0-9])([A-Z])", "$1_$2").toLowerCase
+
+  /**
+   * Short (<= 10 char) column codes for the per-type fields in shapefile output, where the DBF format truncates column
+   * names at 10 characters. GeoJSON/CSV/GeoPackage use the full names instead.
+   */
+  val shapefileTypeCode: Map[String, String] = Map(
+    "CurbRamp" -> "CRamp", "NoCurbRamp" -> "NoCRamp", "Obstacle" -> "Obst", "SurfaceProblem" -> "Surf",
+    "NoSidewalk" -> "NoSwk", "Crosswalk" -> "Xwalk", "Signal" -> "Signal"
+  )
+
+  /** Builds a JSON object keyed by canonical label-type name from a (possibly sparse) per-type map, defaulting to 0. */
+  private[api] def perTypeJson[T](values: Map[String, T], default: T)(implicit w: Writes[T]): JsObject =
+    JsObject(orderedTypes.map(t => t -> Json.toJson(values.getOrElse(t, default))))
+}
+
+/**
+ * AccessScore for a single street segment, for the v3 API.
+ *
+ * @param streetEdgeId        Project Sidewalk street segment identifier.
+ * @param osmWayId            OpenStreetMap way identifier.
+ * @param regionId            Region (neighborhood) the street belongs to.
+ * @param score               Access score in (0, 1), or None if the street has not been audited.
+ * @param auditCount          Number of completed (high-quality) audits of this street.
+ * @param lengthMeters        Street length in meters (UTM-projected; used to length-weight region scores).
+ * @param labelCount          Number of labels contributing to this street's clusters.
+ * @param clusterCounts       Per-label-type count of scored clusters on the street.
+ * @param subScores           Per-label-type summed contribution to the pre-sigmoid score (explains the score).
+ * @param geometry            The LineString geometry of the street.
+ */
+case class StreetAccessScoreForApi(
+    streetEdgeId: Int,
+    osmWayId: Long,
+    regionId: Int,
+    score: Option[Double],
+    auditCount: Int,
+    lengthMeters: Double,
+    labelCount: Int,
+    clusterCounts: Map[String, Int],
+    subScores: Map[String, Double],
+    geometry: LineString
+) extends StreamingApiType {
+
+  /** Converts this street access score to a GeoJSON Feature with a LineString geometry. */
+  override def toJson: JsObject = {
+    Json.obj(
+      "type"       -> "Feature",
+      "geometry"   -> geometry,
+      "properties" -> Json.obj(
+        "street_edge_id" -> streetEdgeId,
+        "osm_way_id"     -> osmWayId,
+        "region_id"      -> regionId,
+        "score"          -> score,
+        "audit_count"    -> auditCount,
+        "length_meters"  -> lengthMeters,
+        "label_count"    -> labelCount,
+        "cluster_counts" -> AccessScoreApiModels.perTypeJson(clusterCounts, 0),
+        "sub_scores"     -> AccessScoreApiModels.perTypeJson(subScores, 0.0)
+      )
+    )
+  }
+
+  /** Converts this street access score to a CSV row matching [[StreetAccessScoreForApi.csvHeader]]. */
+  override def toCsvRow: String = {
+    val baseFields = Seq(
+      streetEdgeId.toString,
+      osmWayId.toString,
+      regionId.toString,
+      score.map(_.toString).getOrElse(""),
+      auditCount.toString,
+      lengthMeters.toString,
+      labelCount.toString
+    )
+    val countFields    = AccessScoreApiModels.orderedTypes.map(t => clusterCounts.getOrElse(t, 0).toString)
+    val subScoreFields = AccessScoreApiModels.orderedTypes.map(t => subScores.getOrElse(t, 0.0).toString)
+    val tailFields     = Seq(
+      escapeCsvField(s"${geometry.getStartPoint.getX},${geometry.getStartPoint.getY}"),
+      escapeCsvField(s"${geometry.getEndPoint.getX},${geometry.getEndPoint.getY}")
+    )
+    (baseFields ++ countFields ++ subScoreFields ++ tailFields).mkString(",")
+  }
+}
+
+/** Companion holding the CSV header for [[StreetAccessScoreForApi]], generated from the scored-type set. */
+object StreetAccessScoreForApi {
+  val csvHeader: String = {
+    val countCols    = AccessScoreApiModels.orderedTypes.map(t => s"n_${AccessScoreApiModels.snakeType(t)}")
+    val subScoreCols = AccessScoreApiModels.orderedTypes.map(t => s"score_${AccessScoreApiModels.snakeType(t)}")
+    (Seq("street_edge_id", "osm_way_id", "region_id", "score", "audit_count", "length_meters", "label_count") ++
+      countCols ++ subScoreCols ++ Seq("start_point", "end_point")).mkString(",") + "\n"
+  }
+
+  implicit val writes: Writes[StreetAccessScoreForApi] = (s: StreetAccessScoreForApi) => s.toJson
+}
+
+/**
+ * AccessScore for a region (neighborhood), for the v3 API.
+ *
+ * @param regionId            Project Sidewalk region identifier.
+ * @param name                Region name.
+ * @param score               Street-length-weighted mean of audited street scores in (0, 1), or None if none audited.
+ * @param coverage            Fraction of the region's streets that have been audited, in [0, 1].
+ * @param auditedStreetCount  Number of audited streets in the region.
+ * @param totalStreetCount    Total number of streets in the region.
+ * @param avgClusterCounts    Per-label-type mean cluster count across the region's audited streets.
+ * @param geometry            The MultiPolygon geometry of the region.
+ */
+case class RegionAccessScoreForApi(
+    regionId: Int,
+    name: String,
+    score: Option[Double],
+    coverage: Double,
+    auditedStreetCount: Int,
+    totalStreetCount: Int,
+    avgClusterCounts: Map[String, Double],
+    geometry: MultiPolygon
+) extends StreamingApiType {
+
+  /** Converts this region access score to a GeoJSON Feature with a MultiPolygon geometry. */
+  override def toJson: JsObject = {
+    Json.obj(
+      "type"       -> "Feature",
+      "geometry"   -> geometry,
+      "properties" -> Json.obj(
+        "region_id"            -> regionId,
+        "name"                 -> name,
+        "score"                -> score,
+        "coverage"             -> coverage,
+        "audited_street_count" -> auditedStreetCount,
+        "total_street_count"   -> totalStreetCount,
+        "avg_cluster_counts"   -> AccessScoreApiModels.perTypeJson(avgClusterCounts, 0.0)
+      )
+    )
+  }
+
+  /** Converts this region access score to a CSV row matching [[RegionAccessScoreForApi.csvHeader]]. */
+  override def toCsvRow: String = {
+    val centroid = geometry.getCentroid
+    val baseFields = Seq(
+      regionId.toString,
+      escapeCsvField(name),
+      score.map(_.toString).getOrElse(""),
+      coverage.toString,
+      auditedStreetCount.toString,
+      totalStreetCount.toString
+    )
+    val countFields = AccessScoreApiModels.orderedTypes.map(t => avgClusterCounts.getOrElse(t, 0.0).toString)
+    val tailFields  = Seq(escapeCsvField(s"${centroid.getX},${centroid.getY}"))
+    (baseFields ++ countFields ++ tailFields).mkString(",")
+  }
+}
+
+/** Companion holding the CSV header for [[RegionAccessScoreForApi]], generated from the scored-type set. */
+object RegionAccessScoreForApi {
+  val csvHeader: String = {
+    val countCols = AccessScoreApiModels.orderedTypes.map(t => s"avg_n_${AccessScoreApiModels.snakeType(t)}")
+    (Seq("region_id", "name", "score", "coverage", "audited_street_count", "total_street_count") ++
+      countCols ++ Seq("center_point")).mkString(",") + "\n"
+  }
+
+  implicit val writes: Writes[RegionAccessScoreForApi] = (r: RegionAccessScoreForApi) => r.toJson
+}
+
+/**
+ * Parsed geo-filters for the AccessScore endpoints. AccessScore is computed over a bbox; a region filter is resolved to
+ * the region's bounding box upstream, with the resolved id retained to post-filter streets back to that region.
+ *
+ * @param bbox       Optional bounding box to score within.
+ * @param regionId   Optional region id to score (resolved to its bbox by the controller).
+ * @param regionName Optional region name to score (resolved to its bbox by the controller).
+ */
+case class AccessScoreFiltersForApi(
+    bbox: Option[LatLngBBox] = None,
+    regionId: Option[Int] = None,
+    regionName: Option[String] = None
+)

--- a/app/models/cluster/ClusterTable.scala
+++ b/app/models/cluster/ClusterTable.scala
@@ -52,6 +52,26 @@ object ClusterForApi {
     "Cluster Size,User IDs\n"
 }
 
+/**
+ * Lean per-cluster inputs for the v3 AccessScore computation (#3855).
+ *
+ * Deliberately minimal — only what the scoring engine needs — so the query can skip the expensive validation/image-date/
+ * user-list aggregation that the general cluster query computes.
+ *
+ * @param streetEdgeId The street the cluster sits on (clusters are grouped by street to score it).
+ * @param labelType    The cluster's label type name (e.g. "CurbRamp").
+ * @param severity     Median severity 1..3 of the cluster's labels, or None for presence-only/unrated clusters.
+ * @param labelCount   Number of member labels (denominator for the tag-active threshold).
+ * @param tagCounts    Map of tag name → number of member labels carrying that tag.
+ */
+case class ClusterScoreRow(
+    streetEdgeId: Int,
+    labelType: String,
+    severity: Option[Int],
+    labelCount: Int,
+    tagCounts: Map[String, Int]
+)
+
 class ClusterTableDef(tag: slick.lifted.Tag) extends Table[Cluster](tag, "cluster") {
   def clusterId: Rep[Int]           = column[Int]("cluster_id", O.PrimaryKey, O.AutoInc)
   def clusteringSessionId: Rep[Int] = column[Int]("clustering_session_id")
@@ -92,6 +112,20 @@ class ClusterTableDef(tag: slick.lifted.Tag) extends Table[Cluster](tag, "cluste
       bbox: LatLngBBox,
       severity: Option[String]
   ): SqlStreamingAction[Vector[ClusterForApi], ClusterForApi, Effect]
+
+  /**
+   * Streams lean per-cluster scoring inputs for the v3 AccessScore endpoints.
+   *
+   * @param spatialQueryType Whether the bbox filters on region geometry or street geometry.
+   * @param bbox             The bounding box to score within.
+   * @param labelTypes       The label type names to include (the scoring engine's scored-type set).
+   * @return                 A streaming action yielding one [[ClusterScoreRow]] per in-scope cluster.
+   */
+  def getClusterScoreRows(
+      spatialQueryType: SpatialQueryType,
+      bbox: LatLngBBox,
+      labelTypes: Set[String]
+  ): SqlStreamingAction[Vector[ClusterScoreRow], ClusterScoreRow, Effect]
 
   def countClusters: DBIO[Int]
 
@@ -170,6 +204,16 @@ class ClusterTable @Inject() (protected val dbConfigProvider: DatabaseConfigProv
       avgLabelDate = avgLabelDate, medianSeverity = medianSeverity, agreeCount = agreeCount,
       disagreeCount = disagreeCount, unsureCount = unsureCount, clusterSize = clusterSize, labelIds = labelIds,
       userIds = userIds, tagCounts = tagCounts, labels = labels, avgLatitude = avgLatitude, avgLongitude = avgLongitude
+    )
+  }
+
+  implicit val clusterScoreRowConverter: GetResult[ClusterScoreRow] = GetResult[ClusterScoreRow] { r =>
+    ClusterScoreRow(
+      streetEdgeId = r.nextInt(),
+      labelType = r.nextString(),
+      severity = r.nextIntOption(),
+      labelCount = r.nextInt(),
+      tagCounts = r.nextStringOption().map(json => Json.parse(json).as[Map[String, Int]]).getOrElse(Map.empty)
     )
   }
 
@@ -257,6 +301,63 @@ class ClusterTable @Inject() (protected val dbConfigProvider: DatabaseConfigProv
                   OR cluster.severity = #${toInt(severity).getOrElse(-1)}
               );
     """.as[ClusterForApi]
+  }
+
+  def getClusterScoreRows(
+      spatialQueryType: SpatialQueryType,
+      bbox: LatLngBBox,
+      labelTypes: Set[String]
+  ): SqlStreamingAction[Vector[ClusterScoreRow], ClusterScoreRow, Effect] = {
+    val locationFilter: String = if (spatialQueryType == SpatialQueryType.Region) {
+      s"ST_Within(region.geom, ST_MakeEnvelope(${bbox.minLng}, ${bbox.minLat}, ${bbox.maxLng}, ${bbox.maxLat}, 4326))"
+    } else {
+      s"ST_Intersects(street_edge.geom, ST_MakeEnvelope(${bbox.minLng}, ${bbox.minLat}, ${bbox.maxLng}, ${bbox.maxLat}, 4326))"
+    }
+
+    // Restrict to the scored label types. Single-quote-escaped; empty set short-circuits to no rows.
+    val labelTypeFilter: String =
+      if (labelTypes.isEmpty) "FALSE"
+      else s"label_type.label_type IN (${labelTypes.map(lt => s"'${lt.replace("'", "''")}'").mkString(", ")})"
+
+    // Number of member labels per cluster (the denominator for the tag-active threshold).
+    val labelCounts =
+      """SELECT cluster_label.cluster_id AS cluster_id,
+        |       COUNT(label.label_id) AS label_count
+        |FROM cluster_label
+        |INNER JOIN label ON cluster_label.label_id = label.label_id
+        |GROUP BY cluster_label.cluster_id""".stripMargin
+
+    // Per-cluster tag counts as a JSON object (e.g. {"steep": 2, "narrow": 1}), unnesting the label.tags TEXT[] array.
+    // Same technique as getLabelClustersV3, kept separate so the access-score query carries only what scoring needs.
+    val tagCounts =
+      """SELECT cluster.cluster_id AS cluster_id,
+        |       COALESCE(jsonb_object_agg(tag_counts.tag, tag_counts.cnt) FILTER (WHERE tag_counts.tag IS NOT NULL), '{}') AS tag_counts
+        |FROM cluster
+        |LEFT JOIN (
+        |    SELECT cluster_label.cluster_id, t.tag, COUNT(*) AS cnt
+        |    FROM cluster_label
+        |    INNER JOIN label ON cluster_label.label_id = label.label_id
+        |    CROSS JOIN LATERAL unnest(label.tags) AS t(tag)
+        |    GROUP BY cluster_label.cluster_id, t.tag
+        |) tag_counts ON cluster.cluster_id = tag_counts.cluster_id
+        |GROUP BY cluster.cluster_id""".stripMargin
+
+    sql"""
+      SELECT cluster.street_edge_id,
+             label_type.label_type,
+             cluster.severity,
+             label_counts.label_count,
+             cluster_tag_counts.tag_counts
+      FROM cluster
+      INNER JOIN label_type ON cluster.label_type_id = label_type.label_type_id
+      INNER JOIN street_edge ON cluster.street_edge_id = street_edge.street_edge_id
+      INNER JOIN street_edge_region ON street_edge.street_edge_id = street_edge_region.street_edge_id
+      INNER JOIN region ON street_edge_region.region_id = region.region_id
+      INNER JOIN (#$labelCounts) label_counts ON cluster.cluster_id = label_counts.cluster_id
+      INNER JOIN (#$tagCounts) cluster_tag_counts ON cluster.cluster_id = cluster_tag_counts.cluster_id
+      WHERE #$labelTypeFilter
+          AND #$locationFilter;
+    """.as[ClusterScoreRow]
   }
 
   def getLabelClustersV3(

--- a/app/models/street/StreetEdgeTable.scala
+++ b/app/models/street/StreetEdgeTable.scala
@@ -314,6 +314,26 @@ class StreetEdgeTable @Inject() (
   }
 
   /**
+   * Gets the length in meters of each of the given street edges.
+   *
+   * Lengths are computed by projecting the geometry to UTM zone 18N (EPSG:26918) so the result is in meters rather than
+   * degrees — the same projection used by the distance methods above. Used to length-weight region AccessScores (#3855).
+   * `inSet` inlines the ids (rather than binding them) to avoid the bound-parameter limit on whole-city id lists.
+   *
+   * @param streetEdgeIds The street edge ids to measure.
+   * @return A map from street edge id to its length in meters (empty for an empty input).
+   */
+  def getStreetLengths(streetEdgeIds: Seq[Int]): DBIO[Map[Int, Double]] = {
+    if (streetEdgeIds.isEmpty) DBIO.successful(Map.empty[Int, Double])
+    else
+      streetsUnfiltered
+        .filter(_.streetEdgeId inSet streetEdgeIds)
+        .map(s => (s.streetEdgeId, s.geom.transform(26918).lengthD))
+        .result
+        .map(_.toMap)
+  }
+
+  /**
    * Gets all street data for the API with filters applied, designed for streaming.
    *
    * @param filters   The filters to apply when retrieving streets.

--- a/app/service/AccessScoreCalculator.scala
+++ b/app/service/AccessScoreCalculator.scala
@@ -1,0 +1,166 @@
+package service
+
+import models.label.LabelTypeEnum
+
+/**
+ * Pure, DB-free scoring engine for the v3 AccessScore API (#3855).
+ *
+ * Implements the severity/quality- and tag-aware extension of Chu Li's Urban Access 2022 AccessScore. All weighting
+ * lives here as tunable constants so the math can be unit-tested in isolation and adjusted without touching the DB layer
+ * ([[AccessScoreService]]) or the controller. Nothing in this object performs IO.
+ *
+ * The model, per label type:
+ *   - A street's pre-sigmoid sum is the sum of each cluster's `contribution = base(type) * multiplier + tagAdjustments`.
+ *   - The street score is `sigmoid(sum)`, mapped to (0, 1).
+ *   - A region's score is the street-length-weighted mean of its audited streets' scores (the paper's normalization).
+ *
+ * Severity semantics differ by type and are the crux of the model (the same DB `severity` column means different things):
+ *   - Positive **quality**-rated types (CurbRamp, Crosswalk): Good(1) / Okay(2) / Bad(3). A Bad one flips negative.
+ *   - Negative **severity**-rated types (NoCurbRamp, Obstacle, SurfaceProblem): Low(1) / Med(2) / High(3).
+ *   - **Presence-only** types (Signal, NoSidewalk): no severity; a fixed weight for mere presence.
+ */
+object AccessScoreCalculator {
+
+  /** How a label type's severity column is interpreted when scoring. */
+  sealed trait Scoring
+
+  /** Severity ignored; presence alone contributes `baseWeight` (e.g. Signal, NoSidewalk). */
+  case object PresenceOnly extends Scoring
+
+  /** Quality-rated positive feature: severity 1=Good, 2=Okay, 3=Bad (a Bad one contributes negatively). */
+  case object PositiveQuality extends Scoring
+
+  /** Severity-rated negative feature: severity 1=Low, 2=Med, 3=High (magnitude grows with severity). */
+  case object NegativeSeverity extends Scoring
+
+  /**
+   * Per-type scoring configuration.
+   *
+   * @param baseWeight Signed base weight (positive features positive, negative features negative). The severity/quality
+   *                   multiplier scales this; for `PositiveQuality` the multiplier may flip the sign (Bad → negative).
+   * @param scoring    How this type's severity column is interpreted.
+   */
+  case class TypeWeight(baseWeight: Double, scoring: Scoring)
+
+  // --- TUNABLE: base weight + scoring mode per scored label type. Types absent here are excluded from scoring. ---
+  val typeWeights: Map[String, TypeWeight] = Map(
+    LabelTypeEnum.CurbRamp.name       -> TypeWeight(+0.75, PositiveQuality),
+    LabelTypeEnum.Crosswalk.name      -> TypeWeight(+0.75, PositiveQuality),
+    LabelTypeEnum.Signal.name         -> TypeWeight(+0.50, PresenceOnly),
+    LabelTypeEnum.NoCurbRamp.name     -> TypeWeight(-1.00, NegativeSeverity),
+    LabelTypeEnum.Obstacle.name       -> TypeWeight(-1.00, NegativeSeverity),
+    LabelTypeEnum.SurfaceProblem.name -> TypeWeight(-1.00, NegativeSeverity),
+    LabelTypeEnum.NoSidewalk.name     -> TypeWeight(-1.00, PresenceOnly)
+  )
+
+  /** Names of the label types that contribute to the score. Single source of truth for the DB query's type filter. */
+  val scoredTypeNames: Set[String] = typeWeights.keySet
+
+  /** Scored types in a stable order (by label-type id) so CSV/shapefile columns never drift from the header. */
+  val orderedScoredTypes: Seq[String] = scoredTypeNames.toSeq.sortBy(LabelTypeEnum.labelTypeToId)
+
+  // --- TUNABLE: quality multiplier for PositiveQuality types. Signed: Bad(3) flips a positive base to a penalty. ---
+  private val qualityMultiplier: Map[Int, Double] = Map(1 -> 1.0, 2 -> 0.5, 3 -> -1.0)
+  // Null quality on a positive type → treat as Okay (credit an unknown weakly but still positively).
+  private val qualityNullMultiplier: Double = qualityMultiplier(2)
+
+  // --- TUNABLE: severity magnitude for NegativeSeverity types (unsigned; the negative base carries the sign). ---
+  private val severityMultiplier: Map[Int, Double] = Map(1 -> 0.33, 2 -> 0.67, 3 -> 1.0)
+  // Null severity on a negative type → treat as Low (penalize an unknown conservatively). Highest-impact tuning knob:
+  // v2 effectively used magnitude 1.0 for every negative cluster, so scores shift relative to v2 by design (#3855).
+  private val severityNullMultiplier: Double = severityMultiplier(1)
+
+  // --- TUNABLE: additive weight adjustments for impactful tags. (labelType, tag) -> delta; unlisted tags contribute 0.
+  // Sign is absolute (added directly to the cluster's contribution), independent of the base weight's sign. ---
+  val tagAdjustments: Map[(String, String), Double] = Map(
+    (LabelTypeEnum.Signal.name, "hard to reach buttons")    -> -0.25,
+    (LabelTypeEnum.Signal.name, "button waist height")      -> +0.15,
+    (LabelTypeEnum.Signal.name, "APS")                      -> +0.25,
+    (LabelTypeEnum.CurbRamp.name, "steep")                  -> -0.25,
+    (LabelTypeEnum.CurbRamp.name, "narrow")                 -> -0.25,
+    (LabelTypeEnum.CurbRamp.name, "missing tactile warning")-> -0.25,
+    (LabelTypeEnum.CurbRamp.name, "points into traffic")    -> -0.25,
+    (LabelTypeEnum.Crosswalk.name, "level with sidewalk")   -> +0.25,
+    (LabelTypeEnum.Crosswalk.name, "paint fading")          -> -0.25,
+    (LabelTypeEnum.Crosswalk.name, "no pedestrian priority")-> -0.25,
+    (LabelTypeEnum.NoCurbRamp.name, "no alternate route")   -> -0.50,
+    (LabelTypeEnum.NoCurbRamp.name, "alternate route present") -> +0.25
+  )
+
+  // --- TUNABLE: a tag counts toward scoring when it appears on at least this fraction of a cluster's member labels. ---
+  val tagActiveThreshold: Double = 0.5
+
+  /**
+   * The per-cluster inputs the calculator needs. Severity is the cluster's median member severity (None if unrated).
+   *
+   * @param labelType  The cluster's label type name (e.g. "CurbRamp").
+   * @param severity   Median severity 1..3 of the cluster's labels, or None for presence-only/unrated clusters.
+   * @param labelCount Number of member labels (the denominator for the tag-active threshold).
+   * @param tagCounts  Map of tag name → how many member labels carry that tag.
+   */
+  case class ClusterScoreInput(
+      labelType: String,
+      severity: Option[Int],
+      labelCount: Int,
+      tagCounts: Map[String, Int]
+  )
+
+  /**
+   * Computes a single cluster's signed contribution to its street's pre-sigmoid sum.
+   *
+   * @param c The cluster inputs.
+   * @return  The contribution, or 0.0 if the cluster's label type is not scored (e.g. Occlusion/Other/Problem).
+   */
+  def scoreCluster(c: ClusterScoreInput): Double = {
+    typeWeights.get(c.labelType) match {
+      case None => 0.0 // Not a scored type.
+      case Some(TypeWeight(base, scoring)) =>
+        val typeContribution: Double = scoring match {
+          case PresenceOnly     => base
+          case PositiveQuality  => base * c.severity.flatMap(qualityMultiplier.get).getOrElse(qualityNullMultiplier)
+          case NegativeSeverity => base * c.severity.flatMap(severityMultiplier.get).getOrElse(severityNullMultiplier)
+        }
+        typeContribution + activeTagAdjustment(c)
+    }
+  }
+
+  /**
+   * Sums the adjustments for tags that are "active" on this cluster (present on >= [[tagActiveThreshold]] of its labels).
+   *
+   * @param c The cluster inputs.
+   * @return  The summed tag adjustment (0.0 when the cluster has no labels or no active, mapped tags).
+   */
+  private def activeTagAdjustment(c: ClusterScoreInput): Double = {
+    if (c.labelCount <= 0) 0.0
+    else
+      c.tagCounts.iterator.collect {
+        case (tag, count)
+            if count.toDouble / c.labelCount >= tagActiveThreshold && tagAdjustments.contains((c.labelType, tag)) =>
+          tagAdjustments((c.labelType, tag))
+      }.sum
+  }
+
+  /** The logistic squashing function mapping the unbounded weighted sum to (0, 1). */
+  private def sigmoid(t: Double): Double = 1.0 / (1.0 + math.exp(-t))
+
+  /**
+   * Computes a street's access score: the sigmoid of the summed cluster contributions. No length normalization at the
+   * street level (faithful to the paper) — this is a saturating "how accessible is this street" signal in (0, 1).
+   *
+   * @param clusters The street's scored clusters (empty yields the neutral 0.5).
+   * @return         The access score in (0, 1).
+   */
+  def scoreStreet(clusters: Seq[ClusterScoreInput]): Double = sigmoid(clusters.iterator.map(scoreCluster).sum)
+
+  /**
+   * Computes a region's access score as the street-length-weighted mean of its audited streets' scores.
+   *
+   * @param auditedStreets (streetScore, lengthMeters) pairs for streets in the region with >= 1 completed audit.
+   * @return               The weighted-mean score, or None when there are no audited streets / zero total length.
+   */
+  def scoreRegion(auditedStreets: Seq[(Double, Double)]): Option[Double] = {
+    val totalLength: Double = auditedStreets.iterator.map(_._2).sum
+    if (totalLength <= 0.0) None
+    else Some(auditedStreets.iterator.map { case (score, length) => score * length }.sum / totalLength)
+  }
+}

--- a/app/service/AccessScoreService.scala
+++ b/app/service/AccessScoreService.scala
@@ -1,6 +1,8 @@
 package service
 
 import executors.CpuIntensiveExecutionContext
+import models.api.{RegionAccessScoreForApi, StreetAccessScoreForApi}
+import models.cluster.ClusterScoreRow
 import models.computation.{RegionScore, StreetLabelCounter, StreetScore}
 import models.label.LabelTypeEnum
 import models.region.Region
@@ -9,6 +11,7 @@ import models.utils.SpatialQueryType.SpatialQueryType
 import models.utils.{LatLngBBox, SpatialQueryType}
 import org.apache.pekko.stream.Materializer
 import org.apache.pekko.stream.scaladsl.Sink
+import service.AccessScoreCalculator.ClusterScoreInput
 
 import java.time.{Instant, OffsetDateTime, ZoneOffset}
 import javax.inject.{Inject, Singleton}
@@ -242,6 +245,121 @@ class AccessScoreService @Inject() (
             streetAccessScores
           }
       }(cpuEc)
+  }
+
+  /**
+   * Computes v3 AccessScores for every street intersecting the bbox (#3855).
+   *
+   * Loads the streets and their lengths, streams the lean per-cluster scoring rows, groups them by street, and delegates
+   * the weighting to the pure [[AccessScoreCalculator]]. A street's score is exposed only when it has been audited.
+   *
+   * @param spatialQueryType Whether the bbox filters on street geometry (streets endpoint) or region geometry.
+   * @param bbox             The bounding box to score within.
+   * @param batchSize        DB fetch size for the cluster stream.
+   * @return                 One [[StreetAccessScoreForApi]] per intersecting street.
+   */
+  def computeStreetScoresV3(
+      spatialQueryType: SpatialQueryType,
+      bbox: LatLngBBox,
+      batchSize: Int
+  ): Future[Seq[StreetAccessScoreForApi]] = {
+    apiService.selectStreetsIntersecting(spatialQueryType, bbox).flatMap { streets: Seq[StreetEdgeInfo] =>
+      val streetIds: Seq[Int]     = streets.map(_.street.streetEdgeId)
+      val lengthsFuture           = apiService.getStreetLengths(streetIds)
+
+      // Accumulate the streamed cluster rows by street. The sink runs single-threaded, so the mutable map is safe.
+      val rowsByStreet: mutable.Map[Int, mutable.Buffer[ClusterScoreRow]] = mutable.Map.empty
+      val streamFuture = apiService
+        .getClusterScoreRows(spatialQueryType, bbox, AccessScoreCalculator.scoredTypeNames, batchSize)
+        .runWith(Sink.foreach { row =>
+          rowsByStreet.getOrElseUpdate(row.streetEdgeId, mutable.Buffer.empty) += row
+        })
+
+      // Join the concurrent length lookup and cluster stream, then do the (CPU-bound) scoring off the default pool.
+      lengthsFuture.zip(streamFuture).map { case (lengths, _) =>
+        streets.map { s =>
+          val streetId: Int              = s.street.streetEdgeId
+          val rows: Seq[ClusterScoreRow] = rowsByStreet.getOrElse(streetId, mutable.Buffer.empty).toSeq
+          buildStreetScore(s, rows, lengths.getOrElse(streetId, 0.0))
+        }
+      }(cpuEc)
+    }
+  }
+
+  /**
+   * Builds a single street's AccessScore DTO from its cluster rows.
+   *
+   * @param s            The street (carries geometry, region, and audit count).
+   * @param rows         The street's scored cluster rows.
+   * @param lengthMeters The street's length in meters.
+   * @return             The populated [[StreetAccessScoreForApi]].
+   */
+  private def buildStreetScore(
+      s: StreetEdgeInfo,
+      rows: Seq[ClusterScoreRow],
+      lengthMeters: Double
+  ): StreetAccessScoreForApi = {
+    val inputs: Seq[ClusterScoreInput] =
+      rows.map(r => ClusterScoreInput(r.labelType, r.severity, r.labelCount, r.tagCounts))
+    val rawScore: Double               = AccessScoreCalculator.scoreStreet(inputs)
+    val byType: Map[String, Seq[ClusterScoreInput]] = inputs.groupBy(_.labelType)
+    val clusterCounts: Map[String, Int]    = byType.map { case (lt, cs) => lt -> cs.size }
+    val subScores: Map[String, Double]     = byType.map { case (lt, cs) => lt -> cs.map(AccessScoreCalculator.scoreCluster).sum }
+
+    StreetAccessScoreForApi(
+      streetEdgeId = s.street.streetEdgeId,
+      osmWayId = s.osmId,
+      regionId = s.regionId,
+      score = if (s.auditCount > 0) Some(rawScore) else None,
+      auditCount = s.auditCount,
+      lengthMeters = lengthMeters,
+      labelCount = rows.map(_.labelCount).sum,
+      clusterCounts = clusterCounts,
+      subScores = subScores,
+      geometry = s.street.geom
+    )
+  }
+
+  /**
+   * Computes v3 AccessScores for every region (neighborhood) within the bbox (#3855).
+   *
+   * Each region's score is the street-length-weighted mean of its audited streets' scores — the paper's normalization
+   * that the v2 endpoint lacked. Coverage is the fraction of the region's streets that have been audited.
+   *
+   * @param bbox      The bounding box to score within.
+   * @param batchSize DB fetch size for the cluster stream.
+   * @return          One [[RegionAccessScoreForApi]] per region within the bbox.
+   */
+  def computeRegionScoresV3(bbox: LatLngBBox, batchSize: Int): Future[Seq[RegionAccessScoreForApi]] = {
+    for {
+      regions: Seq[Region]                       <- apiService.getNeighborhoodsWithin(bbox)
+      streetScores: Seq[StreetAccessScoreForApi] <- computeStreetScoresV3(SpatialQueryType.Region, bbox, batchSize)
+    } yield {
+      val streetsByRegion: Map[Int, Seq[StreetAccessScoreForApi]] = streetScores.groupBy(_.regionId)
+      regions.map { region =>
+        val streetsInRegion: Seq[StreetAccessScoreForApi] = streetsByRegion.getOrElse(region.regionId, Seq.empty)
+        val auditedStreets: Seq[StreetAccessScoreForApi]  = streetsInRegion.filter(_.auditCount > 0)
+
+        val score: Option[Double] =
+          AccessScoreCalculator.scoreRegion(auditedStreets.flatMap(s => s.score.map(sc => (sc, s.lengthMeters))))
+        val coverage: Double =
+          if (streetsInRegion.nonEmpty) auditedStreets.size.toDouble / streetsInRegion.size else 0.0
+
+        // Mean cluster count per audited street, per label type (parity with v2's avg_attribute_count).
+        val avgClusterCounts: Map[String, Double] =
+          if (auditedStreets.isEmpty) Map.empty
+          else
+            AccessScoreCalculator.orderedScoredTypes.map { t =>
+              t -> auditedStreets.map(_.clusterCounts.getOrElse(t, 0)).sum.toDouble / auditedStreets.size
+            }.toMap
+
+        RegionAccessScoreForApi(
+          regionId = region.regionId, name = region.name, score = score, coverage = coverage,
+          auditedStreetCount = auditedStreets.size, totalStreetCount = streetsInRegion.size,
+          avgClusterCounts = avgClusterCounts, geometry = region.geom
+        )
+      }
+    }
   }
 
   /**

--- a/app/service/ApiService.scala
+++ b/app/service/ApiService.scala
@@ -39,6 +39,23 @@ trait ApiService {
 
   def getNeighborhoodsWithin(bbox: LatLngBBox): Future[Seq[Region]]
 
+  /** Streams lean per-cluster scoring inputs for the v3 AccessScore endpoints (#3855). */
+  def getClusterScoreRows(
+      spatialQueryType: SpatialQueryType,
+      bbox: LatLngBBox,
+      labelTypes: Set[String],
+      batchSize: Int
+  ): Source[ClusterScoreRow, _]
+
+  /** Returns the length in meters of each given street edge, used to length-weight region AccessScores (#3855). */
+  def getStreetLengths(streetEdgeIds: Seq[Int]): Future[Map[Int, Double]]
+
+  /** Resolves a region id to its bounding box, or None if no such (non-deleted) region exists. */
+  def getRegionBBox(regionId: Int): Future[Option[LatLngBBox]]
+
+  /** Resolves a region name to its (region id, bounding box), or None if no such (non-deleted) region exists. */
+  def resolveRegionByName(regionName: String): Future[Option[(Int, LatLngBBox)]]
+
   def getLabelCVMetadata(batchSize: Int): Source[LabelCVMetadata, _]
 
   def getLabelsToClusterInRegion(regionId: Int): Future[Seq[LabelToCluster]]
@@ -258,6 +275,30 @@ class ApiServiceImpl @Inject() (
 
   def getNeighborhoodsWithin(bbox: LatLngBBox): Future[Seq[Region]] =
     db.run(regionTable.getNeighborhoodsWithin(bbox))
+
+  def getClusterScoreRows(
+      spatialQueryType: SpatialQueryType,
+      bbox: LatLngBBox,
+      labelTypes: Set[String],
+      batchSize: Int
+  ): Source[ClusterScoreRow, _] = {
+    setUpStreamFromDb(clusterTable.getClusterScoreRows(spatialQueryType, bbox, labelTypes), batchSize)
+  }
+
+  def getStreetLengths(streetEdgeIds: Seq[Int]): Future[Map[Int, Double]] =
+    db.run(streetEdgeTable.getStreetLengths(streetEdgeIds))
+
+  /** Derives a lat/lng bounding box from a region's MultiPolygon envelope (geometry is stored in EPSG:4326). */
+  private def regionToBBox(region: Region): LatLngBBox = {
+    val env = region.geom.getEnvelopeInternal
+    LatLngBBox(minLat = env.getMinY, minLng = env.getMinX, maxLat = env.getMaxY, maxLng = env.getMaxX)
+  }
+
+  def getRegionBBox(regionId: Int): Future[Option[LatLngBBox]] =
+    db.run(regionTable.getRegion(regionId)).map(_.map(regionToBBox))
+
+  def resolveRegionByName(regionName: String): Future[Option[(Int, LatLngBBox)]] =
+    db.run(regionTable.getRegionByName(regionName)).map(_.map(r => (r.regionId, regionToBBox(r))))
 
   def getLabelCVMetadata(batchSize: Int): Source[LabelCVMetadata, _] = {
     // NOTE can't use `setUpStreamFromDb` here bc we need to call `mapResult` to convert tuples to `LabelCVMetadata`.

--- a/app/views/apiDocs/_sidebar.scala.html
+++ b/app/views/apiDocs/_sidebar.scala.html
@@ -21,9 +21,9 @@
         <a href="@routes.ApiDocsController.validationResultTypes" class="api-nav-item @if(activePage == "validation-result-types"){active}">Validation Result Types</a>
 
 
-        <!-- <div class="api-nav-header">Analysis APIs</div>
-        <a href="" class="api-nav-item @if(activePage == "street-score"){active}">Street Score</a>
-        <a href="" class="api-nav-item @if(activePage == "region-score"){active}">Region Score</a> -->
+        <div class="api-nav-header">Accessibility Score APIs</div>
+        <a href="@routes.ApiDocsController.accessScoreStreets" class="api-nav-item @if(activePage == "access-score-streets"){active}">AccessScore: Streets</a>
+        <a href="@routes.ApiDocsController.accessScoreRegions" class="api-nav-item @if(activePage == "access-score-regions"){active}">AccessScore: Regions</a>
 
         <div class="api-nav-header">Stat APIs</div>
         <a href="@routes.ApiDocsController.userStats" class="api-nav-item @if(activePage == "user-stats"){active}">User Stats</a>

--- a/app/views/apiDocs/_sidebar.scala.html
+++ b/app/views/apiDocs/_sidebar.scala.html
@@ -21,7 +21,7 @@
         <a href="@routes.ApiDocsController.validationResultTypes" class="api-nav-item @if(activePage == "validation-result-types"){active}">Validation Result Types</a>
 
 
-        <div class="api-nav-header">Accessibility Score APIs</div>
+        <div class="api-nav-header">Access Score APIs</div>
         <a href="@routes.ApiDocsController.accessScoreStreets" class="api-nav-item @if(activePage == "access-score-streets"){active}">AccessScore: Streets</a>
         <a href="@routes.ApiDocsController.accessScoreRegions" class="api-nav-item @if(activePage == "access-score-regions"){active}">AccessScore: Regions</a>
 

--- a/app/views/apiDocs/accessScoreRegions.scala.html
+++ b/app/views/apiDocs/accessScoreRegions.scala.html
@@ -1,0 +1,222 @@
+@import service.CommonPageData
+@import models.user.SidewalkUserWithRole
+@import play.api.Configuration
+@(commonData: CommonPageData, user: SidewalkUserWithRole)(implicit request: RequestHeader, messages: Messages, assets: AssetsFinder, config: Configuration)
+
+@content = {
+    <script>
+        // Set data attributes for API information. Used by api-docs.js (e.g. the download buttons) to build API calls.
+        document.documentElement.setAttribute('data-api-base-url', '/v3/api');
+        document.documentElement.setAttribute('data-api-endpoint', 'accessScoreRegions');
+    </script>
+
+    <div class="api-section" id="access-score-regions-intro-section">
+        <h1 class="api-heading" id="access-score-regions-api">AccessScore: Regions API <a href="#access-score-regions-api" class="permalink">#</a></h1>
+        <p>
+            The AccessScore: Regions API returns an accessibility score in the range <code>(0,&nbsp;1)</code> for each
+            region (neighborhood) — higher is more accessible. A region's score is the
+            <strong>street-length-weighted mean</strong> of the AccessScores of its audited streets, so long streets
+            count proportionally more than short ones.
+        </p>
+        <p>
+            AccessScore extends the method introduced in
+            <a href="https://makeabilitylab.cs.washington.edu/media/publications/Li_APilotStudyOfSidewalkEquityInSeattleUsingCrowdsourcedSidewalkAssessmentData_UrbanAccess2022.pdf">Li et&nbsp;al., <i>A Pilot Study of Sidewalk Equity in Seattle</i> (Urban Access 2022)</a>.
+            It is <strong>experimental</strong> and the weights are subject to change. See the
+            <a href="@routes.ApiDocsController.accessScoreStreets">AccessScore: Streets API</a> for how individual street
+            scores are computed.
+        </p>
+    </div>
+
+    <div class="api-section" id="endpoint-section">
+        <h2 class="api-heading" id="endpoint">Endpoint<a href="#endpoint" class="permalink">#</a></h2>
+        <p>Returns a region boundary and its AccessScore for each region in the queried area, optionally filtered by the <a href="#query-parameters">Query Parameters</a> below.</p>
+        <p><code>GET /v3/api/accessScoreRegions</code></p>
+        <div class="api-subsection" id="endpoint-example-section">
+            <h3 class="api-heading" id="endpoint-examples">Examples<a href="#endpoint-examples" class="permalink">#</a></h3>
+            <p><code><a href="/v3/api/accessScoreRegions?filetype=geojson">/v3/api/accessScoreRegions?filetype=geojson</a></code> Get AccessScores for all regions in GeoJSON (default)</p>
+            <p><code><a target="_blank" href="/v3/api/accessScoreRegions?filetype=geojson&inline=true">/v3/api/accessScoreRegions?filetype=geojson&inline=true</a></code> Same, but opened in the browser</p>
+            <p><code><a href="/v3/api/accessScoreRegions?filetype=csv">/v3/api/accessScoreRegions?filetype=csv</a></code> Get AccessScores for all regions in CSV</p>
+            <p><code><a href="/v3/api/accessScoreRegions?regionId=8">/v3/api/accessScoreRegions?regionId=8</a></code> Get the score for a single region</p>
+        </div>
+    </div>
+
+    <div class="api-section" id="scoring-model-section">
+        <h2 class="api-heading" id="scoring-model">How the score is computed<a href="#scoring-model" class="permalink">#</a></h2>
+        <p>
+            Each of the region's audited streets is scored as described in the
+            <a href="@routes.ApiDocsController.accessScoreStreets">AccessScore: Streets API</a>. The region's
+            <code>score</code> is the mean of those street scores weighted by street length:
+            <code>Σ(score × length) / Σ(length)</code>. Unaudited streets are excluded. When a region has no audited
+            streets, its <code>score</code> is <code>null</code>.
+        </p>
+        <p>
+            <code>coverage</code> reports the fraction of the region's streets that have been audited, so you can judge
+            how complete a region's score is.
+        </p>
+    </div>
+
+    <div class="api-section" id="quick-download-section">
+        <h2 class="api-heading" id="quick-download">Quick Download <a href="#quick-download" class="permalink">#</a></h2>
+        <p>Download region AccessScore data directly in your preferred format:</p>
+        <div class="download-buttons">
+            <button class="download-btn" data-format="geojson">
+                <span class="format-icon">📝</span> GeoJSON
+                <span class="format-hint">Web mapping standard</span>
+            </button>
+            <button class="download-btn" data-format="csv">
+                <span class="format-icon">📊</span> CSV
+                <span class="format-hint">For Excel, Google Sheets</span>
+            </button>
+            <button class="download-btn" data-format="shapefile">
+                <span class="format-icon">🗺️</span> Shapefile
+                <span class="format-hint">For ArcGIS, QGIS</span>
+            </button>
+            <button class="download-btn" data-format="geopackage">
+                <span class="format-icon">📦</span> GeoPackage
+                <span class="format-hint">Open GIS format</span>
+            </button>
+        </div>
+        <div id="download-status" class="status-container status-loading" style="display: none;">
+            <div class="loading-spinner"></div>
+            <div class="status-message">Generating your download...</div>
+            <div class="status-progress">This may take anywhere from a few seconds to a few minutes depending on the data size.</div>
+        </div>
+        <p class="download-note">
+            Note: This downloads scores for all regions. For filtered data, use the
+            <a href="#query-parameters">API Query Parameters</a> described below.
+        </p>
+    </div>
+
+    <div class="api-section" id="query-parameters-section">
+        <h2 class="api-heading" id="query-parameters">Query Parameters<a href="#query-parameters" class="permalink">#</a></h2>
+        <p>All parameters are optional.</p>
+        <p>
+            Note: When multiple location filters are provided (<code>bbox</code>, <code>regionId</code>,
+            and <code>regionName</code>), <code>bbox</code> takes precedence over region filters, and
+            <code>regionId</code> takes precedence over <code>regionName</code>.
+        </p>
+        <div class="api-table-wrapper">
+            <table class="api-table">
+                <thead>
+                    <tr><th>Parameter</th><th>Type</th><th>Description</th></tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td><code>bbox</code></td>
+                        <td><code>string</code></td>
+                        <td>Filter by bounding box, as <code>minLongitude,minLatitude,maxLongitude,maxLatitude</code> (e.g., <code>-74.04,40.88,-74.00,40.91</code>), WGS84 (EPSG:4326). Returns regions within the box. If omitted, the city's default bounding box is used.</td>
+                    </tr>
+                    <tr>
+                        <td><code>regionId</code></td>
+                        <td><code>integer</code></td>
+                        <td>Return only the region with this id. Takes precedence over <code>regionName</code>; <code>bbox</code> takes precedence over both.</td>
+                    </tr>
+                    <tr>
+                        <td><code>regionName</code></td>
+                        <td><code>string</code></td>
+                        <td>Return only the region with this name. Used only when <code>bbox</code> and <code>regionId</code> are absent.</td>
+                    </tr>
+                    <tr>
+                        <td><code>filetype</code></td>
+                        <td><code>string</code></td>
+                        <td>Output format. Options: <code>geojson</code> (default), <code>csv</code>, <code>shapefile</code>, <code>geopackage</code>.</td>
+                    </tr>
+                    <tr>
+                        <td><code>inline</code></td>
+                        <td><code>boolean</code></td>
+                        <td>Whether to display the file inline rather than as an attachment. Default: <code>false</code>.</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <div class="api-section" id="responses-section">
+        <h2 class="api-heading" id="responses">Responses<a href="#responses" class="permalink">#</a></h2>
+
+        <h3 class="api-heading" id="success-response-200-ok">Success Response (200 OK)<a href="#success-response-200-ok" class="permalink">#</a></h3>
+        <p>On success, the API returns <code>200 OK</code> and the requested data in the specified <code>filetype</code> format.</p>
+
+        <h4 id="response-geojson">GeoJSON Format (Default) <a href="#response-geojson" class="permalink">#</a></h4>
+        <p>Returns a GeoJSON FeatureCollection where each feature is a region (MultiPolygon, WGS84 / EPSG:4326).</p>
+        <pre><code class="language-json">{
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "geometry": { "type": "MultiPolygon", "coordinates": [...] },
+            "properties": {
+                "region_id": 8,
+                "name": "Terhune Park",
+                "score": 0.5623,
+                "coverage": 1.0,
+                "audited_street_count": 52,
+                "total_street_count": 52,
+                "avg_cluster_counts": {
+                    "CurbRamp": 2.1, "NoCurbRamp": 0.3, "Obstacle": 0.4, "SurfaceProblem": 0.6,
+                    "NoSidewalk": 0.5, "Crosswalk": 0.9, "Signal": 0.1
+                }
+            }
+        },
+        ...
+    ]
+}</code></pre>
+
+        <h5 id="geojson-fields">GeoJSON Field Descriptions <a href="#geojson-fields" class="permalink">#</a></h5>
+        <div class="api-table-wrapper">
+            <table class="api-table">
+                <thead>
+                    <tr><th style="width:34%">Field Path</th><th style="width:16%">Type</th><th style="width:50%">Description</th></tr>
+                </thead>
+                <tbody>
+                    <tr><td><code>geometry</code></td><td><code>MultiPolygon</code></td><td>The region's boundary polygon(s), in <code>[longitude, latitude]</code> (WGS84 / EPSG:4326).</td></tr>
+                    <tr><td><code>properties.region_id</code></td><td><code>integer</code></td><td>Project Sidewalk's unique identifier for this region.</td></tr>
+                    <tr><td><code>properties.name</code></td><td><code>string</code></td><td>The region (neighborhood) name.</td></tr>
+                    <tr><td><code>properties.score</code></td><td><code>number</code></td><td>Length-weighted mean AccessScore of the region's audited streets, in <code>(0,&nbsp;1)</code>. <code>null</code> when no streets in the region have been audited.</td></tr>
+                    <tr><td><code>properties.coverage</code></td><td><code>number</code></td><td>Fraction of the region's streets that have been audited, in <code>[0,&nbsp;1]</code>.</td></tr>
+                    <tr><td><code>properties.audited_street_count</code></td><td><code>integer</code></td><td>Number of audited streets in the region.</td></tr>
+                    <tr><td><code>properties.total_street_count</code></td><td><code>integer</code></td><td>Total number of streets in the region.</td></tr>
+                    <tr><td><code>properties.avg_cluster_counts</code></td><td><code>object</code></td><td>Mean number of scored clusters of each label type across the region's audited streets, keyed by label-type name.</td></tr>
+                </tbody>
+            </table>
+        </div>
+
+        <h4 id="response-csv">CSV Format <a href="#response-csv" class="permalink">#</a></h4>
+        <p>If <code>filetype=csv</code>, the first row is the header. The per-type <code>avg_cluster_counts</code> are flattened into one <code>avg_n_*</code> column per label type, and the geometry is simplified to the region centroid.</p>
+        <pre tabindex="0"><code class="language-csv">region_id,name,score,coverage,audited_street_count,total_street_count,avg_n_curb_ramp,avg_n_no_curb_ramp,avg_n_obstacle,avg_n_surface_problem,avg_n_no_sidewalk,avg_n_crosswalk,avg_n_signal,center_point
+8,Terhune Park,0.5623,1.0,52,52,2.1,0.3,0.4,0.6,0.5,0.9,0.1,"-74.012,40.895"
+...</code></pre>
+
+        <h4 id="response-shapefile">Shapefile Format <a href="#response-shapefile" class="permalink">#</a></h4>
+        <p>If <code>filetype=shapefile</code>, the response is a ZIP archive of Shapefile components (.shp, .shx, .dbf, .prj). Because the DBF format truncates column names at 10 characters, the per-type columns use short codes (e.g. <code>aCRamp</code>); the GeoJSON, CSV, and GeoPackage formats keep the full names.</p>
+
+        <h4 id="response-geopackage">GeoPackage Format <a href="#response-geopackage" class="permalink">#</a></h4>
+        <p>If <code>filetype=geopackage</code>, the response is a GeoPackage (.gpkg) file with full geometry and attributes (full snake_case column names).</p>
+
+        <h3 class="api-heading" id="error-responses">Error Responses<a href="#error-responses" class="permalink">#</a></h3>
+        <ul>
+            <li><strong><code>400 Bad Request</code>:</strong> Invalid parameter values (e.g., malformed bounding box, non-positive or unknown region id).</li>
+            <li><strong><code>500 Internal Server Error</code>:</strong> An unexpected error occurred on the server.</li>
+        </ul>
+        <pre><code class="language-json">{
+    "status": 400,
+    "code": "INVALID_PARAMETER",
+    "message": "No region found with regionId 99999.",
+    "parameter": "regionId"
+}</code></pre>
+    </div>
+
+    <div class="api-section" id="best-practices-section">
+        <h2 class="api-heading" id="best-practices">Best Practices<a href="#best-practices" class="permalink">#</a></h2>
+        <ul>
+            <li><strong>Read <code>coverage</code> alongside <code>score</code>:</strong> a high score over low coverage reflects only the audited fraction of the region.</li>
+            <li><strong>Treat the score as relative, not absolute:</strong> the weights are experimental. Use scores to compare regions, not as a calibrated index.</li>
+            <li><strong>Drill down:</strong> use the <a href="@routes.ApiDocsController.accessScoreStreets">AccessScore: Streets API</a> to see which streets drive a region's score.</li>
+        </ul>
+    </div>
+}
+
+@common.main(commonData, "API Docs") {
+    @common.navbar(commonData, Some(user))
+    @apiDocs.layout("access-score-regions")(content)
+}

--- a/app/views/apiDocs/accessScoreRegions.scala.html
+++ b/app/views/apiDocs/accessScoreRegions.scala.html
@@ -2,6 +2,7 @@
 @import models.user.SidewalkUserWithRole
 @import play.api.Configuration
 @(commonData: CommonPageData, user: SidewalkUserWithRole)(implicit request: RequestHeader, messages: Messages, assets: AssetsFinder, config: Configuration)
+@cityName = @{commonData.allCityInfo.filter(c => c.cityId == commonData.cityId).head.cityNameFormatted}
 
 @content = {
     <script>
@@ -25,6 +26,26 @@
             <a href="@routes.ApiDocsController.accessScoreStreets">AccessScore: Streets API</a> for how individual street
             scores are computed.
         </p>
+    </div>
+
+    <div class="api-section" id="access-score-regions-preview-section">
+        <h2 class="api-heading" id="visual-example">AccessScore: Regions Preview <a href="#visual-example" class="permalink">#</a></h2>
+        <p>
+            Below is a live preview of region AccessScores in @cityName, retrieved directly from the API. Each region is
+            colored from red (low accessibility) to green (high); use the <em>Color by</em> dropdown to switch between
+            the AccessScore and audit coverage. Hover or click a region to see its score and coverage.
+        </p>
+        <div id="access-score-regions-preview"><!-- Replaced by JavaScript with the rendered map. --></div>
+
+        <link rel="stylesheet" href="https://unpkg.com/leaflet@@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+        <script src="https://unpkg.com/leaflet@@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+        <link rel="stylesheet" href="@assets.path("stylesheets/api-docs/access-score.css")">
+        <script src="@routes.Assets.versioned("javascripts/api-docs/access-score-regions-preview.js")"></script>
+        <script>
+            document.addEventListener('DOMContentLoaded', function() {
+                AccessScoreRegionsPreview.setup({ mapHeight: 500 }).init();
+            });
+        </script>
     </div>
 
     <div class="api-section" id="endpoint-section">

--- a/app/views/apiDocs/accessScoreRegions.scala.html
+++ b/app/views/apiDocs/accessScoreRegions.scala.html
@@ -35,6 +35,14 @@
             colored from red (low accessibility) to green (high); use the <em>Color by</em> dropdown to switch between
             the AccessScore and audit coverage. Hover or click a region to see its score and coverage.
         </p>
+        <p class="download-note">
+            <strong>One method, not the method.</strong> There is no single correct way to measure street- and
+            neighborhood-level accessibility—researchers and practitioners use many different approaches. AccessScore
+            implements just one such algorithm, and it is experimental: the weighting is deliberately simple and subject
+            to change. Treat these scores as one lens rather than a definitive measure, and compute your own index from
+            the <a href="@routes.ApiDocsController.labelClusters">Label Clusters API</a> if a different method suits your
+            needs better.
+        </p>
         <div id="access-score-regions-preview"><!-- Replaced by JavaScript with the rendered map. --></div>
 
         <link rel="stylesheet" href="https://unpkg.com/leaflet@@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>

--- a/app/views/apiDocs/accessScoreStreets.scala.html
+++ b/app/views/apiDocs/accessScoreStreets.scala.html
@@ -2,6 +2,7 @@
 @import models.user.SidewalkUserWithRole
 @import play.api.Configuration
 @(commonData: CommonPageData, user: SidewalkUserWithRole)(implicit request: RequestHeader, messages: Messages, assets: AssetsFinder, config: Configuration)
+@cityName = @{commonData.allCityInfo.filter(c => c.cityId == commonData.cityId).head.cityNameFormatted}
 
 @content = {
     <script>
@@ -23,6 +24,26 @@
             It is <strong>experimental</strong>: the weights are deliberately simple and subject to change. For full
             control you can compute your own index from the <a href="@routes.ApiDocsController.labelClusters">Label Clusters API</a>.
         </p>
+    </div>
+
+    <div class="api-section" id="access-score-streets-preview-section">
+        <h2 class="api-heading" id="visual-example">AccessScore: Streets Preview <a href="#visual-example" class="permalink">#</a></h2>
+        <p>
+            Below is a live preview of street AccessScores from a sample region in @cityName, retrieved directly from the
+            API. Streets are colored from red (low accessibility) to green (high); gray streets have not yet been
+            audited. Hover or click a street to see its score and the accessibility features that produced it.
+        </p>
+        <div id="access-score-streets-preview"><!-- Replaced by JavaScript with the rendered map. --></div>
+
+        <link rel="stylesheet" href="https://unpkg.com/leaflet@@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+        <script src="https://unpkg.com/leaflet@@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+        <link rel="stylesheet" href="@assets.path("stylesheets/api-docs/access-score.css")">
+        <script src="@routes.Assets.versioned("javascripts/api-docs/access-score-streets-preview.js")"></script>
+        <script>
+            document.addEventListener('DOMContentLoaded', function() {
+                AccessScoreStreetsPreview.setup({ mapHeight: 500 }).init();
+            });
+        </script>
     </div>
 
     <div class="api-section" id="endpoint-section">

--- a/app/views/apiDocs/accessScoreStreets.scala.html
+++ b/app/views/apiDocs/accessScoreStreets.scala.html
@@ -1,0 +1,238 @@
+@import service.CommonPageData
+@import models.user.SidewalkUserWithRole
+@import play.api.Configuration
+@(commonData: CommonPageData, user: SidewalkUserWithRole)(implicit request: RequestHeader, messages: Messages, assets: AssetsFinder, config: Configuration)
+
+@content = {
+    <script>
+        // Set data attributes for API information. Used by api-docs.js (e.g. the download buttons) to build API calls.
+        document.documentElement.setAttribute('data-api-base-url', '/v3/api');
+        document.documentElement.setAttribute('data-api-endpoint', 'accessScoreStreets');
+    </script>
+
+    <div class="api-section" id="access-score-streets-intro-section">
+        <h1 class="api-heading" id="access-score-streets-api">AccessScore: Streets API <a href="#access-score-streets-api" class="permalink">#</a></h1>
+        <p>
+            The AccessScore: Streets API returns an accessibility score in the range <code>(0,&nbsp;1)</code> for each
+            street segment — higher is more accessible. The score weights each clustered accessibility feature by its
+            type, its severity/quality rating, and its tags, then squashes the total with a logistic function.
+        </p>
+        <p>
+            AccessScore extends the method introduced in
+            <a href="https://makeabilitylab.cs.washington.edu/media/publications/Li_APilotStudyOfSidewalkEquityInSeattleUsingCrowdsourcedSidewalkAssessmentData_UrbanAccess2022.pdf">Li et&nbsp;al., <i>A Pilot Study of Sidewalk Equity in Seattle</i> (Urban Access 2022)</a>.
+            It is <strong>experimental</strong>: the weights are deliberately simple and subject to change. For full
+            control you can compute your own index from the <a href="@routes.ApiDocsController.labelClusters">Label Clusters API</a>.
+        </p>
+    </div>
+
+    <div class="api-section" id="endpoint-section">
+        <h2 class="api-heading" id="endpoint">Endpoint<a href="#endpoint" class="permalink">#</a></h2>
+        <p>Returns a street segment and its AccessScore for each street in the queried area, optionally filtered by the <a href="#query-parameters">Query Parameters</a> below.</p>
+        <p><code>GET /v3/api/accessScoreStreets</code></p>
+        <div class="api-subsection" id="endpoint-example-section">
+            <h3 class="api-heading" id="endpoint-examples">Examples<a href="#endpoint-examples" class="permalink">#</a></h3>
+            <p><code><a href="/v3/api/accessScoreStreets?filetype=geojson">/v3/api/accessScoreStreets?filetype=geojson</a></code> Get AccessScores for all streets in GeoJSON (default)</p>
+            <p><code><a target="_blank" href="/v3/api/accessScoreStreets?filetype=geojson&inline=true">/v3/api/accessScoreStreets?filetype=geojson&inline=true</a></code> Same, but opened in the browser</p>
+            <p><code><a href="/v3/api/accessScoreStreets?filetype=csv">/v3/api/accessScoreStreets?filetype=csv</a></code> Get AccessScores for all streets in CSV</p>
+            <p><code><a href="/v3/api/accessScoreStreets?regionId=8">/v3/api/accessScoreStreets?regionId=8</a></code> Get scores for streets in a single region</p>
+        </div>
+    </div>
+
+    <div class="api-section" id="scoring-model-section">
+        <h2 class="api-heading" id="scoring-model">How the score is computed<a href="#scoring-model" class="permalink">#</a></h2>
+        <p>
+            Project Sidewalk clusters proximal labels of the same type. Each scored cluster on a street contributes a
+            signed weight; the street's score is the logistic (sigmoid) of the sum of those weights, mapped to
+            <code>(0,&nbsp;1)</code>. An empty or unlabeled street scores the neutral <code>0.5</code>.
+        </p>
+        <p>Each cluster's contribution is <code>base(type) × ratingMultiplier + Σ tagAdjustments</code>:</p>
+        <ul class="api-list">
+            <li><strong>Positive, quality-rated</strong> (CurbRamp, Crosswalk): rated <em>Good&nbsp;/&nbsp;Okay&nbsp;/&nbsp;Bad</em> → multiplier <code>+1.0&nbsp;/&nbsp;+0.5&nbsp;/&nbsp;−1.0</code>. A <em>Bad</em> feature therefore <em>lowers</em> the score.</li>
+            <li><strong>Negative, severity-rated</strong> (NoCurbRamp, Obstacle, SurfaceProblem): rated <em>Low&nbsp;/&nbsp;Medium&nbsp;/&nbsp;High</em> → magnitude <code>0.33&nbsp;/&nbsp;0.67&nbsp;/&nbsp;1.0</code> of the (negative) base.</li>
+            <li><strong>Presence-only</strong> (no rating): a pedestrian Signal contributes a fixed positive weight; a missing sidewalk (NoSidewalk) a fixed negative weight.</li>
+            <li><strong>Tags</strong> adjust a cluster's weight when present on a majority of its labels — e.g. a Signal tagged <em>hard to reach buttons</em> counts negatively, while <em>APS</em> (accessible signal) counts positively.</li>
+        </ul>
+        <p>
+            The per-type <code>cluster_counts</code> and <code>sub_scores</code> in each response let you see exactly how
+            a street's score was composed. Other label types (Occlusion, Other) do not affect the score.
+        </p>
+        <p class="download-note">Note: The score is not normalized by street length — a long street with many issues saturates toward 0. Region scores (see the <a href="@routes.ApiDocsController.accessScoreRegions">AccessScore: Regions API</a>) <em>are</em> length-weighted.</p>
+    </div>
+
+    <div class="api-section" id="quick-download-section">
+        <h2 class="api-heading" id="quick-download">Quick Download <a href="#quick-download" class="permalink">#</a></h2>
+        <p>Download street AccessScore data directly in your preferred format:</p>
+        <div class="download-buttons">
+            <button class="download-btn" data-format="geojson">
+                <span class="format-icon">📝</span> GeoJSON
+                <span class="format-hint">Web mapping standard</span>
+            </button>
+            <button class="download-btn" data-format="csv">
+                <span class="format-icon">📊</span> CSV
+                <span class="format-hint">For Excel, Google Sheets</span>
+            </button>
+            <button class="download-btn" data-format="shapefile">
+                <span class="format-icon">🗺️</span> Shapefile
+                <span class="format-hint">For ArcGIS, QGIS</span>
+            </button>
+            <button class="download-btn" data-format="geopackage">
+                <span class="format-icon">📦</span> GeoPackage
+                <span class="format-hint">Open GIS format</span>
+            </button>
+        </div>
+        <div id="download-status" class="status-container status-loading" style="display: none;">
+            <div class="loading-spinner"></div>
+            <div class="status-message">Generating your download...</div>
+            <div class="status-progress">This may take anywhere from a few seconds to a few minutes depending on the data size.</div>
+        </div>
+        <p class="download-note">
+            Note: This downloads scores for all streets. For filtered data, use the
+            <a href="#query-parameters">API Query Parameters</a> described below.
+        </p>
+    </div>
+
+    <div class="api-section" id="query-parameters-section">
+        <h2 class="api-heading" id="query-parameters">Query Parameters<a href="#query-parameters" class="permalink">#</a></h2>
+        <p>All parameters are optional.</p>
+        <p>
+            Note: When multiple location filters are provided (<code>bbox</code>, <code>regionId</code>,
+            and <code>regionName</code>), <code>bbox</code> takes precedence over region filters, and
+            <code>regionId</code> takes precedence over <code>regionName</code>. A region filter is resolved to the
+            region's bounding box, and the streets are then trimmed back to that region.
+        </p>
+        <div class="api-table-wrapper">
+            <table class="api-table">
+                <thead>
+                    <tr><th>Parameter</th><th>Type</th><th>Description</th></tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td><code>bbox</code></td>
+                        <td><code>string</code></td>
+                        <td>Filter by bounding box, as <code>minLongitude,minLatitude,maxLongitude,maxLatitude</code> (e.g., <code>-74.04,40.88,-74.00,40.91</code>), WGS84 (EPSG:4326). If omitted, the city's default bounding box is used.</td>
+                    </tr>
+                    <tr>
+                        <td><code>regionId</code></td>
+                        <td><code>integer</code></td>
+                        <td>Score only streets within the region with this id. Takes precedence over <code>regionName</code>; <code>bbox</code> takes precedence over both.</td>
+                    </tr>
+                    <tr>
+                        <td><code>regionName</code></td>
+                        <td><code>string</code></td>
+                        <td>Score only streets within the region with this name. Used only when <code>bbox</code> and <code>regionId</code> are absent.</td>
+                    </tr>
+                    <tr>
+                        <td><code>filetype</code></td>
+                        <td><code>string</code></td>
+                        <td>Output format. Options: <code>geojson</code> (default), <code>csv</code>, <code>shapefile</code>, <code>geopackage</code>.</td>
+                    </tr>
+                    <tr>
+                        <td><code>inline</code></td>
+                        <td><code>boolean</code></td>
+                        <td>Whether to display the file inline rather than as an attachment. Default: <code>false</code>.</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <div class="api-section" id="responses-section">
+        <h2 class="api-heading" id="responses">Responses<a href="#responses" class="permalink">#</a></h2>
+
+        <h3 class="api-heading" id="success-response-200-ok">Success Response (200 OK)<a href="#success-response-200-ok" class="permalink">#</a></h3>
+        <p>On success, the API returns <code>200 OK</code> and the requested data in the specified <code>filetype</code> format.</p>
+
+        <h4 id="response-geojson">GeoJSON Format (Default) <a href="#response-geojson" class="permalink">#</a></h4>
+        <p>Returns a GeoJSON FeatureCollection where each feature is a street segment (LineString, WGS84 / EPSG:4326).</p>
+        <pre><code class="language-json">{
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "LineString",
+                "coordinates": [[-74.0243, 40.8839], [-74.0245, 40.8836]]
+            },
+            "properties": {
+                "street_edge_id": 766,
+                "osm_way_id": 11584845,
+                "region_id": 8,
+                "score": 1.0,
+                "audit_count": 2,
+                "length_meters": 142.7,
+                "label_count": 29,
+                "cluster_counts": {
+                    "CurbRamp": 10, "NoCurbRamp": 0, "Obstacle": 0, "SurfaceProblem": 1,
+                    "NoSidewalk": 0, "Crosswalk": 6, "Signal": 0
+                },
+                "sub_scores": {
+                    "CurbRamp": 7.5, "NoCurbRamp": 0.0, "Obstacle": 0.0, "SurfaceProblem": -0.67,
+                    "NoSidewalk": 0.0, "Crosswalk": 4.25, "Signal": 0.0
+                }
+            }
+        },
+        ...
+    ]
+}</code></pre>
+
+        <h5 id="geojson-fields">GeoJSON Field Descriptions <a href="#geojson-fields" class="permalink">#</a></h5>
+        <div class="api-table-wrapper">
+            <table class="api-table">
+                <thead>
+                    <tr><th style="width:34%">Field Path</th><th style="width:16%">Type</th><th style="width:50%">Description</th></tr>
+                </thead>
+                <tbody>
+                    <tr><td><code>geometry.coordinates</code></td><td><code>array[number]</code></td><td>Coordinate pairs forming the street's path, in <code>[longitude, latitude]</code> (WGS84 / EPSG:4326).</td></tr>
+                    <tr><td><code>properties.street_edge_id</code></td><td><code>integer</code></td><td>Project Sidewalk's unique identifier for this street segment.</td></tr>
+                    <tr><td><code>properties.osm_way_id</code></td><td><code>integer</code></td><td><a href="https://wiki.openstreetmap.org/wiki/Way">OpenStreetMap Way ID</a> for the street, if available.</td></tr>
+                    <tr><td><code>properties.region_id</code></td><td><code>integer</code></td><td>Identifier for the region the street belongs to.</td></tr>
+                    <tr><td><code>properties.score</code></td><td><code>number</code></td><td>AccessScore in <code>(0,&nbsp;1)</code>; higher is more accessible. <code>null</code> when the street has not been audited.</td></tr>
+                    <tr><td><code>properties.audit_count</code></td><td><code>integer</code></td><td>Number of completed (high-quality) audits of this street.</td></tr>
+                    <tr><td><code>properties.length_meters</code></td><td><code>number</code></td><td>Street length in meters (used to length-weight region scores).</td></tr>
+                    <tr><td><code>properties.label_count</code></td><td><code>integer</code></td><td>Number of labels contributing to this street's scored clusters.</td></tr>
+                    <tr><td><code>properties.cluster_counts</code></td><td><code>object</code></td><td>Number of scored clusters of each label type on the street, keyed by label-type name.</td></tr>
+                    <tr><td><code>properties.sub_scores</code></td><td><code>object</code></td><td>Summed contribution of each label type to the pre-sigmoid total, keyed by label-type name. Explains how the <code>score</code> was composed.</td></tr>
+                </tbody>
+            </table>
+        </div>
+
+        <h4 id="response-csv">CSV Format <a href="#response-csv" class="permalink">#</a></h4>
+        <p>If <code>filetype=csv</code>, the first row is the header. The per-type <code>cluster_counts</code> and <code>sub_scores</code> are flattened into one column per label type (<code>n_*</code> and <code>score_*</code>), and the geometry is simplified to start/end points.</p>
+        <pre tabindex="0"><code class="language-csv">street_edge_id,osm_way_id,region_id,score,audit_count,length_meters,label_count,n_curb_ramp,n_no_curb_ramp,n_obstacle,n_surface_problem,n_no_sidewalk,n_crosswalk,n_signal,score_curb_ramp,score_no_curb_ramp,score_obstacle,score_surface_problem,score_no_sidewalk,score_crosswalk,score_signal,start_point,end_point
+766,11584845,8,1.0,2,142.7,29,10,0,0,1,0,6,0,7.5,0.0,0.0,-0.67,0.0,4.25,0.0,"-74.0243,40.8839","-74.0245,40.8836"
+...</code></pre>
+
+        <h4 id="response-shapefile">Shapefile Format <a href="#response-shapefile" class="permalink">#</a></h4>
+        <p>If <code>filetype=shapefile</code>, the response is a ZIP archive of Shapefile components (.shp, .shx, .dbf, .prj). Because the DBF format truncates column names at 10 characters, the per-type columns use short codes (e.g. <code>nCRamp</code>, <code>sCRamp</code>); the GeoJSON, CSV, and GeoPackage formats keep the full names.</p>
+
+        <h4 id="response-geopackage">GeoPackage Format <a href="#response-geopackage" class="permalink">#</a></h4>
+        <p>If <code>filetype=geopackage</code>, the response is a GeoPackage (.gpkg) file with full geometry and attributes (full snake_case column names).</p>
+
+        <h3 class="api-heading" id="error-responses">Error Responses<a href="#error-responses" class="permalink">#</a></h3>
+        <ul>
+            <li><strong><code>400 Bad Request</code>:</strong> Invalid parameter values (e.g., malformed bounding box, non-positive or unknown region id).</li>
+            <li><strong><code>500 Internal Server Error</code>:</strong> An unexpected error occurred on the server.</li>
+        </ul>
+        <pre><code class="language-json">{
+    "status": 400,
+    "code": "INVALID_PARAMETER",
+    "message": "Invalid value for bbox parameter. Expected format: minLng,minLat,maxLng,maxLat.",
+    "parameter": "bbox"
+}</code></pre>
+    </div>
+
+    <div class="api-section" id="best-practices-section">
+        <h2 class="api-heading" id="best-practices">Best Practices<a href="#best-practices" class="permalink">#</a></h2>
+        <ul>
+            <li><strong>Treat the score as relative, not absolute:</strong> the weights are experimental. Use scores to compare streets, not as a calibrated index.</li>
+            <li><strong>Read the breakdown:</strong> <code>cluster_counts</code> and <code>sub_scores</code> explain each score and help you sanity-check it.</li>
+            <li><strong>Mind audit coverage:</strong> a <code>null</code> score means the street has not been audited — absence of data, not poor accessibility.</li>
+            <li><strong>Roll up to neighborhoods:</strong> use the <a href="@routes.ApiDocsController.accessScoreRegions">AccessScore: Regions API</a> for length-weighted, region-level scores.</li>
+        </ul>
+    </div>
+}
+
+@common.main(commonData, "API Docs") {
+    @common.navbar(commonData, Some(user))
+    @apiDocs.layout("access-score-streets")(content)
+}

--- a/app/views/apiDocs/accessScoreStreets.scala.html
+++ b/app/views/apiDocs/accessScoreStreets.scala.html
@@ -33,6 +33,14 @@
             API. Streets are colored from red (low accessibility) to green (high); gray streets have not yet been
             audited. Hover or click a street to see its score and the accessibility features that produced it.
         </p>
+        <p class="download-note">
+            <strong>One method, not the method.</strong> There is no single correct way to measure street-level
+            accessibility—researchers and practitioners use many different approaches. AccessScore implements just one
+            such algorithm, and it is experimental: the weighting is deliberately simple and subject to change. Treat
+            these scores as one lens rather than a definitive measure, and compute your own index from the
+            <a href="@routes.ApiDocsController.labelClusters">Label Clusters API</a> if a different method suits your
+            needs better.
+        </p>
         <div id="access-score-streets-preview"><!-- Replaced by JavaScript with the rendered map. --></div>
 
         <link rel="stylesheet" href="https://unpkg.com/leaflet@@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>

--- a/app/views/apiDocs/index.scala.html
+++ b/app/views/apiDocs/index.scala.html
@@ -149,7 +149,7 @@
             <li><a href="@routes.ApiDocsController.validations"><b>Validations:</b></a> User judgments of label data.</li>
         </ul>
 
-        <h2 class="api-heading" id="accessibility-score-apis">Accessibility Score APIs<a href="#accessibility-score-apis" class="permalink">#</a></h2>
+        <h2 class="api-heading" id="accessibility-score-apis">Access Score APIs<a href="#accessibility-score-apis" class="permalink">#</a></h2>
         <p>
             Inspired by <a href="https://www.walkscore.com/">WalkScore</a>, we also compute an aggregate
             <b>AccessScore</b> based on Project Sidewalk data. AccessScore extends the method from

--- a/app/views/apiDocs/index.scala.html
+++ b/app/views/apiDocs/index.scala.html
@@ -151,16 +151,27 @@
 
         <h2 class="api-heading" id="accessibility-score-apis">Accessibility Score APIs<a href="#accessibility-score-apis" class="permalink">#</a></h2>
         <p>
-            Inspired by <a href="https://www.walkscore.com/">WalkScore</a>, we also compute an aggregate "accessibility"
-            index based on Project Sidewalk data. These scoring algorithms are experimental. You can compute your own
-            scoring indices by using our Labels API.
+            Inspired by <a href="https://www.walkscore.com/">WalkScore</a>, we also compute an aggregate
+            <b>AccessScore</b> based on Project Sidewalk data. AccessScore extends the method from
+            <a href="https://makeabilitylab.cs.washington.edu/media/publications/Li_APilotStudyOfSidewalkEquityInSeattleUsingCrowdsourcedSidewalkAssessmentData_UrbanAccess2022.pdf">Li et&nbsp;al. (Urban Access 2022)</a>
+            by weighting each feature by its severity/quality rating and its tags. These scoring algorithms are
+            experimental and the weights are subject to change; you can also compute your own indices via the Labels API.
         </p>
-        <p>We provide two different scoring approaches.</p>
-
-        <p><i>Note: The accessibility score version 3 APIs are not yet available.</i></p>
         <ul class="api-list">
-            <li><b>StreetScore:</b> A score that represents the accessibility of individual streets based on the presence of barriers and features.</li>
-            <li><b>NeighborhoodScore:</b> An aggregated score that represents the overall accessibility of neighborhoods.</li>
+            <li><b><code>GET /v3/api/accessScoreStreets</code>:</b> AccessScore for individual streets.</li>
+            <li><b><code>GET /v3/api/accessScoreRegions</code>:</b> AccessScore for regions (neighborhoods), length-weighted across their streets.</li>
+        </ul>
+        <p>
+            Both endpoints accept the standard geo-filters (<code>bbox</code>, <code>regionId</code>,
+            <code>regionName</code>) and output formats (<code>filetype=</code> geojson [default], <code>csv</code>,
+            <code>shapefile</code>, <code>geopackage</code>).
+        </p>
+        <p>How the score is computed:</p>
+        <ul class="api-list">
+            <li>Each clustered label contributes a weight: positive features (curb ramps, crosswalks) are rated on a Good/Okay/Bad quality scale (a <i>Bad</i> one counts <i>against</i> the score); negative features (missing curb ramps, obstacles, surface problems) are rated Low/Medium/High severity; pedestrian signals and missing sidewalks have no rating and contribute a fixed amount for their presence.</li>
+            <li>Certain tags adjust the weight further (e.g. a signal tagged <i>hard to reach buttons</i> counts negatively).</li>
+            <li>A <b>street's</b> score is the logistic (sigmoid) of the summed weights, mapped to (0,&nbsp;1) — higher is more accessible.</li>
+            <li>A <b>region's</b> score is the street-length-weighted mean of its audited streets' scores; <code>coverage</code> reports the fraction of the region's streets that have been audited.</li>
         </ul>
 
         <h2 class="api-heading" id="stats-apis">Stats API<a href="#stats-apis" class="permalink">#</a></h2>

--- a/app/views/apiDocs/index.scala.html
+++ b/app/views/apiDocs/index.scala.html
@@ -158,8 +158,8 @@
             experimental and the weights are subject to change; you can also compute your own indices via the Labels API.
         </p>
         <ul class="api-list">
-            <li><b><code>GET /v3/api/accessScoreStreets</code>:</b> AccessScore for individual streets.</li>
-            <li><b><code>GET /v3/api/accessScoreRegions</code>:</b> AccessScore for regions (neighborhoods), length-weighted across their streets.</li>
+            <li><b><a href="@routes.ApiDocsController.accessScoreStreets">AccessScore: Streets</a>:</b> AccessScore for individual streets (<code>GET /v3/api/accessScoreStreets</code>).</li>
+            <li><b><a href="@routes.ApiDocsController.accessScoreRegions">AccessScore: Regions</a>:</b> AccessScore for regions (neighborhoods), length-weighted across their streets (<code>GET /v3/api/accessScoreRegions</code>).</li>
         </ul>
         <p>
             Both endpoints accept the standard geo-filters (<code>bbox</code>, <code>regionId</code>,

--- a/conf/routes
+++ b/conf/routes
@@ -190,6 +190,8 @@ GET     /v3/api/streetTypes                             controllers.api.StreetsA
 GET     /v3/api/regions                                 controllers.api.RegionApiController.getRegions(bbox: Option[String], regionId: Option[Int], regionName: Option[String], minLabelCount: Option[Int], filetype: Option[String], inline: Option[Boolean])
 GET     /v3/api/validations                             controllers.api.ValidationApiController.getValidations(labelId: Option[Int], userId: Option[String], validationResult: Option[String], labelTypeId: Option[Int], validationTimestamp: Option[String], changedTags: Option[Boolean], changedSeverityLevels: Option[Boolean], filetype: Option[String], inline: Option[Boolean])
 GET     /v3/api/validationResultTypes                   controllers.api.ValidationApiController.getValidationResultTypes
+GET     /v3/api/accessScoreStreets                      controllers.api.AccessScoreApiController.getAccessScoreStreets(bbox: Option[String], regionId: Option[Int], regionName: Option[String], filetype: Option[String], inline: Option[Boolean])
+GET     /v3/api/accessScoreRegions                      controllers.api.AccessScoreApiController.getAccessScoreRegions(bbox: Option[String], regionId: Option[Int], regionName: Option[String], filetype: Option[String], inline: Option[Boolean])
 
 # API Documentation (v3) Routes.
 GET     /v3/api-docs                                    controllers.ApiDocsController.index

--- a/conf/routes
+++ b/conf/routes
@@ -203,6 +203,8 @@ GET     /v3/api-docs/labelClusters                      controllers.ApiDocsContr
 GET     /v3/api-docs/streets                            controllers.ApiDocsController.streets
 GET     /v3/api-docs/streetTypes                        controllers.ApiDocsController.streetTypes
 GET     /v3/api-docs/regions                            controllers.ApiDocsController.regions
+GET     /v3/api-docs/accessScoreStreets                 controllers.ApiDocsController.accessScoreStreets
+GET     /v3/api-docs/accessScoreRegions                 controllers.ApiDocsController.accessScoreRegions
 GET     /v3/api-docs/validations                        controllers.ApiDocsController.validations
 GET     /v3/api-docs/validation-result-types            controllers.ApiDocsController.validationResultTypes
 GET     /v3/api-docs/user-stats                         controllers.ApiDocsController.userStats

--- a/public/javascripts/api-docs/access-score-regions-preview.js
+++ b/public/javascripts/api-docs/access-score-regions-preview.js
@@ -1,0 +1,212 @@
+/**
+ * AccessScore: Regions Map Preview Generator.
+ *
+ * Renders a live choropleth of a city's regions, fed directly from /v3/api/accessScoreRegions. Regions are colored on a
+ * fixed red→yellow→green ramp by AccessScore (default) or audit coverage — both already in [0, 1], so no rescaling is
+ * needed. Hover/click a region to see its score, coverage, and audited-street counts.
+ *
+ * @requires A DOM element with id 'access-score-regions-preview'
+ * @requires Leaflet.js
+ */
+
+(function() {
+    let config = {
+        apiBaseUrl: "/v3/api",
+        mainContainerId: "access-score-regions-preview",
+        endpoint: "/accessScoreRegions",
+        mapHeight: 500
+    };
+
+    // Metrics that can be visualized. Both are already normalized to [0, 1], so the ramp domain is fixed.
+    const METRICS = {
+        score: { label: "AccessScore", legendTitle: "AccessScore (0 = low, 1 = high)" },
+        coverage: { label: "Audit coverage", legendTitle: "Fraction of streets audited" }
+    };
+
+    // A diverging red→yellow→green ramp (ColorBrewer RdYlGn): low accessibility is red, high is green (per the paper).
+    const RAMP = ["#d7191c", "#fdae61", "#ffffbf", "#a6d96a", "#1a9641"];
+    const NONE_COLOR = "#3d3d3d"; // Regions with no audited streets (null score).
+
+    /** Interpolates between two hex colors by a 0–1 factor. */
+    function interpolateColor(color1, color2, factor) {
+        const c1 = { r: parseInt(color1.slice(1, 3), 16), g: parseInt(color1.slice(3, 5), 16), b: parseInt(color1.slice(5, 7), 16) };
+        const c2 = { r: parseInt(color2.slice(1, 3), 16), g: parseInt(color2.slice(3, 5), 16), b: parseInt(color2.slice(5, 7), 16) };
+        const r = Math.round(c1.r + (c2.r - c1.r) * factor);
+        const g = Math.round(c1.g + (c2.g - c1.g) * factor);
+        const b = Math.round(c1.b + (c2.b - c1.b) * factor);
+        return `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${b.toString(16).padStart(2, '0')}`;
+    }
+
+    /** Maps a value in [0, 1] to a color along the multi-stop RAMP. */
+    function rampColor(value) {
+        const v = Math.max(0, Math.min(1, value));
+        const segments = RAMP.length - 1;
+        const scaled = v * segments;
+        const i = Math.min(Math.floor(scaled), segments - 1);
+        return interpolateColor(RAMP[i], RAMP[i + 1], scaled - i);
+    }
+
+    window.AccessScoreRegionsPreview = {
+        _map: null,
+        _layer: null,
+        _legend: null,
+        _metric: "score",
+
+        /** Apply caller config overrides. */
+        setup: function(options) {
+            config = Object.assign(config, options);
+            return this;
+        },
+
+        /** Fetch the data and render the map (or a friendly message on failure). */
+        init: function() {
+            const container = document.getElementById(config.mainContainerId);
+            if (!container) {
+                console.error("AccessScore regions preview container not found.");
+                return Promise.reject(new Error("container not found"));
+            }
+            container.style.height = `${config.mapHeight}px`;
+            const loading = document.createElement('div');
+            loading.className = 'loading-message';
+            loading.textContent = "Loading AccessScore data...";
+            container.appendChild(loading);
+
+            return this.fetchRegions()
+                .then(regions => {
+                    container.innerHTML = "";
+                    this.renderMap(container, regions);
+                })
+                .catch(error => {
+                    console.error("Error rendering AccessScore regions preview:", error);
+                    container.innerHTML = "";
+                    const message = document.createElement('div');
+                    message.className = 'no-data-message';
+                    message.textContent = "Unable to load AccessScore data for the preview.";
+                    container.appendChild(message);
+                });
+        },
+
+        /** Fetch region AccessScores as a GeoJSON FeatureCollection. */
+        fetchRegions: function() {
+            return fetch(`${config.apiBaseUrl}${config.endpoint}?inline=true&source=apiDocs`)
+                .then(response => {
+                    if (!response.ok) throw new Error(`HTTP error! Status: ${response.status}`);
+                    return response.json();
+                });
+        },
+
+        /** Build the map, draw region polygons, and wire the metric toggle and legend. */
+        renderMap: function(container, regions) {
+            const features = regions.features || [];
+
+            const toolbar = document.createElement('div');
+            toolbar.className = 'as-toolbar';
+            const optionsHtml = Object.keys(METRICS)
+                .map(metric => `<option value="${metric}">${METRICS[metric].label}</option>`).join('');
+            toolbar.innerHTML = `<label for="as-region-metric-select">Color by</label>
+                <select id="as-region-metric-select">${optionsHtml}</select>`;
+            container.appendChild(toolbar);
+
+            const mapElement = document.createElement('div');
+            mapElement.id = 'access-score-regions-map';
+            container.appendChild(mapElement);
+
+            const map = L.map('access-score-regions-map', { scrollWheelZoom: false });
+            this._map = map;
+            L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
+                attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
+                subdomains: 'abcd', maxZoom: 19
+            }).addTo(map);
+
+            if (features.length === 0) {
+                map.setView([0, 0], 2);
+                this.addNoDataMessage(map, "No regions found for this city.");
+                return;
+            }
+
+            this._layer = L.geoJSON(regions, {
+                style: (feature) => this.styleForFeature(feature),
+                onEachFeature: (feature, layer) => this.bindInteractions(feature, layer)
+            }).addTo(map);
+            map.fitBounds(this._layer.getBounds(), { padding: [10, 10] });
+
+            const countDiv = document.createElement('div');
+            countDiv.className = 'counter-badge';
+            countDiv.textContent = `${features.length} region${features.length === 1 ? '' : 's'}`;
+            map.getContainer().appendChild(countDiv);
+
+            const select = document.getElementById('as-region-metric-select');
+            select.value = this._metric;
+            select.addEventListener('change', (event) => {
+                this._metric = event.target.value;
+                this._layer.setStyle((feature) => this.styleForFeature(feature));
+                this.updateLegend();
+            });
+            this.updateLegend();
+        },
+
+        /** Leaflet style for a region based on the selected metric (gray when the value is null). */
+        styleForFeature: function(feature) {
+            const value = feature.properties[this._metric];
+            const fillColor = (value === null || value === undefined) ? NONE_COLOR : rampColor(value);
+            return { color: "#ffffff", weight: 1, opacity: 0.7, fillColor: fillColor, fillOpacity: 0.75 };
+        },
+
+        /** Popup + hover behavior for a region. */
+        bindInteractions: function(feature, layer) {
+            const p = feature.properties;
+            const score = (p.score === null || p.score === undefined) ? "N/A (no audited streets)" : p.score.toFixed(3);
+            const coverage = `${Math.round((p.coverage || 0) * 100)}%`;
+            layer.bindPopup(`
+                <div class="as-popup">
+                    <h4>${p.name || 'Region ' + p.region_id}</h4>
+                    <p><span class="as-score">${score}</span> AccessScore</p>
+                    <p><strong>Coverage:</strong> ${coverage} (${p.audited_street_count} of ${p.total_street_count} streets audited)</p>
+                    <p><strong>Region ID:</strong> ${p.region_id}</p>
+                    <a href="/v3/api/accessScoreRegions?regionId=${p.region_id}&inline=true" class="explore-region-btn" target="_blank">
+                        View this region's JSON
+                    </a>
+                </div>
+            `, { autoPanPaddingTopLeft: L.point(10, 10), autoPanPaddingBottomRight: L.point(260, 130) });
+
+            layer.on('mouseover', function() {
+                this.setStyle({ weight: 3, opacity: 1, fillOpacity: 0.9 });
+                this.bringToFront();
+            });
+            layer.on('mouseout', () => this._layer.resetStyle(layer));
+        },
+
+        /** (Re)build the fixed 0→1 gradient legend for the selected metric. */
+        updateLegend: function() {
+            const map = this._map;
+            const metricCfg = METRICS[this._metric];
+            if (this._legend) map.removeControl(this._legend);
+
+            const legend = L.control({ position: 'bottomright' });
+            legend.onAdd = function() {
+                const div = L.DomUtil.create('div', 'info legend continuous-legend');
+                div.innerHTML = `<h4>${metricCfg.legendTitle}</h4>`;
+                const gradientContainer = L.DomUtil.create('div', 'gradient-container', div);
+                gradientContainer.style.cssText = "width: 200px; height: 20px; position: relative; margin: 5px 0;";
+                const gradientBar = L.DomUtil.create('div', 'gradient-bar', gradientContainer);
+                gradientBar.style.cssText =
+                    `width: 100%; height: 100%; background: linear-gradient(to right, ${RAMP.join(', ')});`;
+                const labelsContainer = L.DomUtil.create('div', 'legend-labels', div);
+                labelsContainer.style.cssText = "display: flex; justify-content: space-between; width: 200px;";
+                L.DomUtil.create('div', 'legend-tick', labelsContainer).textContent = "0";
+                L.DomUtil.create('div', 'legend-tick', labelsContainer).textContent = "1";
+                return div;
+            };
+            legend.addTo(map);
+            this._legend = legend;
+        },
+
+        /** Show an on-map message (e.g. when there is no data). */
+        addNoDataMessage: function(map, text) {
+            const div = document.createElement('div');
+            div.className = 'no-data-message';
+            div.textContent = text;
+            map.getContainer().appendChild(div);
+        }
+    };
+})();

--- a/public/javascripts/api-docs/access-score-streets-preview.js
+++ b/public/javascripts/api-docs/access-score-streets-preview.js
@@ -1,0 +1,199 @@
+/**
+ * AccessScore: Streets Map Preview Generator.
+ *
+ * Renders a live map of a sample region's streets, fed directly from /v3/api/accessScoreStreets. Each street is colored
+ * on a fixed red→yellow→green ramp by its AccessScore (already in [0, 1]); unaudited streets (null score) are gray.
+ * Hover/click a street to see its score and per-type cluster breakdown.
+ *
+ * @requires A DOM element with id 'access-score-streets-preview'
+ * @requires Leaflet.js
+ */
+
+(function() {
+    let config = {
+        apiBaseUrl: "/v3/api",
+        mainContainerId: "access-score-streets-preview",
+        endpoint: "/accessScoreStreets",
+        regionsEndpoint: "/regions",
+        mapHeight: 500
+    };
+
+    // Diverging red→yellow→green ramp (ColorBrewer RdYlGn): low accessibility is red, high is green (per the paper).
+    const RAMP = ["#d7191c", "#fdae61", "#ffffbf", "#a6d96a", "#1a9641"];
+    const NONE_COLOR = "#888888"; // Unaudited streets (null score).
+
+    /** Interpolates between two hex colors by a 0–1 factor. */
+    function interpolateColor(color1, color2, factor) {
+        const c1 = { r: parseInt(color1.slice(1, 3), 16), g: parseInt(color1.slice(3, 5), 16), b: parseInt(color1.slice(5, 7), 16) };
+        const c2 = { r: parseInt(color2.slice(1, 3), 16), g: parseInt(color2.slice(3, 5), 16), b: parseInt(color2.slice(5, 7), 16) };
+        const r = Math.round(c1.r + (c2.r - c1.r) * factor);
+        const g = Math.round(c1.g + (c2.g - c1.g) * factor);
+        const b = Math.round(c1.b + (c2.b - c1.b) * factor);
+        return `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${b.toString(16).padStart(2, '0')}`;
+    }
+
+    /** Maps a value in [0, 1] to a color along the multi-stop RAMP. */
+    function rampColor(value) {
+        const v = Math.max(0, Math.min(1, value));
+        const segments = RAMP.length - 1;
+        const scaled = v * segments;
+        const i = Math.min(Math.floor(scaled), segments - 1);
+        return interpolateColor(RAMP[i], RAMP[i + 1], scaled - i);
+    }
+
+    window.AccessScoreStreetsPreview = {
+        _map: null,
+        _layer: null,
+        _legend: null,
+
+        /** Apply caller config overrides. */
+        setup: function(options) {
+            config = Object.assign(config, options);
+            return this;
+        },
+
+        /** Fetch the data and render the map (or a friendly message on failure). */
+        init: function() {
+            const container = document.getElementById(config.mainContainerId);
+            if (!container) {
+                console.error("AccessScore streets preview container not found.");
+                return Promise.reject(new Error("container not found"));
+            }
+            container.style.height = `${config.mapHeight}px`;
+            const loading = document.createElement('div');
+            loading.className = 'loading-message';
+            loading.textContent = "Loading AccessScore data...";
+            container.appendChild(loading);
+
+            // Limit the preview to a single region so it stays legible and the response stays small.
+            return this.fetchSampleRegionId()
+                .then(regionId => this.fetchStreets(regionId))
+                .then(streets => {
+                    container.innerHTML = "";
+                    this.renderMap(container, streets);
+                })
+                .catch(error => {
+                    console.error("Error rendering AccessScore streets preview:", error);
+                    container.innerHTML = "";
+                    const message = document.createElement('div');
+                    message.className = 'no-data-message';
+                    message.textContent = "Unable to load AccessScore data for the preview.";
+                    container.appendChild(message);
+                });
+        },
+
+        /** Pick a sample region (the one with the most labels) to keep the preview focused. Null = whole city. */
+        fetchSampleRegionId: function() {
+            // getRegionWithMostLabels returns a flat Region object (region_id at the top level), not a GeoJSON Feature.
+            return fetch(`${config.apiBaseUrl}/regionWithMostLabels?source=apiDocs`)
+                .then(response => (response.ok ? response.json() : null))
+                .then(region => (region ? region.region_id : null))
+                .catch(() => null);
+        },
+
+        /** Fetch street AccessScores (optionally scoped to a region) as a GeoJSON FeatureCollection. */
+        fetchStreets: function(regionId) {
+            const regionParam = regionId ? `&regionId=${regionId}` : "";
+            return fetch(`${config.apiBaseUrl}${config.endpoint}?inline=true&source=apiDocs${regionParam}`)
+                .then(response => {
+                    if (!response.ok) throw new Error(`HTTP error! Status: ${response.status}`);
+                    return response.json();
+                });
+        },
+
+        /** Build the map, draw the street polylines, and add the legend. */
+        renderMap: function(container, streets) {
+            const features = streets.features || [];
+
+            const mapElement = document.createElement('div');
+            mapElement.id = 'access-score-streets-map';
+            container.appendChild(mapElement);
+
+            const map = L.map('access-score-streets-map', { scrollWheelZoom: false });
+            this._map = map;
+            L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
+                attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
+                subdomains: 'abcd', maxZoom: 19
+            }).addTo(map);
+
+            if (features.length === 0) {
+                map.setView([0, 0], 2);
+                this.addNoDataMessage(map, "No streets found for this city.");
+                return;
+            }
+
+            this._layer = L.geoJSON(streets, {
+                style: (feature) => this.styleForFeature(feature),
+                onEachFeature: (feature, layer) => this.bindInteractions(feature, layer)
+            }).addTo(map);
+            map.fitBounds(this._layer.getBounds(), { padding: [10, 10] });
+
+            const countDiv = document.createElement('div');
+            countDiv.className = 'counter-badge';
+            countDiv.textContent = `${features.length} street${features.length === 1 ? '' : 's'}`;
+            map.getContainer().appendChild(countDiv);
+
+            this.updateLegend();
+        },
+
+        /** Leaflet style for a street: stroke colored by score, gray and thinner when unaudited (null). */
+        styleForFeature: function(feature) {
+            const score = feature.properties.score;
+            if (score === null || score === undefined) {
+                return { color: NONE_COLOR, weight: 2, opacity: 0.5 };
+            }
+            return { color: rampColor(score), weight: 4, opacity: 0.9 };
+        },
+
+        /** Popup + hover behavior for a street, including a compact per-type cluster breakdown. */
+        bindInteractions: function(feature, layer) {
+            const p = feature.properties;
+            const score = (p.score === null || p.score === undefined) ? "N/A (unaudited)" : p.score.toFixed(3);
+            const counts = p.cluster_counts || {};
+            const breakdown = Object.keys(counts).filter(k => counts[k] > 0).map(k => `${k}: ${counts[k]}`).join(", ")
+                || "no scored features";
+            layer.bindPopup(`
+                <div class="as-popup">
+                    <h4>Street ${p.street_edge_id}</h4>
+                    <p><span class="as-score">${score}</span> AccessScore</p>
+                    <p><strong>Audits:</strong> ${p.audit_count} &nbsp; <strong>Labels:</strong> ${p.label_count}</p>
+                    <p class="as-breakdown"><strong>Clusters:</strong> ${breakdown}</p>
+                </div>
+            `, { autoPanPaddingTopLeft: L.point(10, 10), autoPanPaddingBottomRight: L.point(260, 130) });
+
+            layer.on('mouseover', function() { this.setStyle({ weight: 7, opacity: 1 }); this.bringToFront(); });
+            layer.on('mouseout', () => this._layer.resetStyle(layer));
+        },
+
+        /** Build the fixed 0→1 AccessScore gradient legend. */
+        updateLegend: function() {
+            const map = this._map;
+            if (this._legend) map.removeControl(this._legend);
+            const legend = L.control({ position: 'bottomright' });
+            legend.onAdd = function() {
+                const div = L.DomUtil.create('div', 'info legend continuous-legend');
+                div.innerHTML = `<h4>AccessScore (0 = low, 1 = high)</h4>`;
+                const gradientContainer = L.DomUtil.create('div', 'gradient-container', div);
+                gradientContainer.style.cssText = "width: 200px; height: 20px; position: relative; margin: 5px 0;";
+                const gradientBar = L.DomUtil.create('div', 'gradient-bar', gradientContainer);
+                gradientBar.style.cssText =
+                    `width: 100%; height: 100%; background: linear-gradient(to right, ${RAMP.join(', ')});`;
+                const labelsContainer = L.DomUtil.create('div', 'legend-labels', div);
+                labelsContainer.style.cssText = "display: flex; justify-content: space-between; width: 200px;";
+                L.DomUtil.create('div', 'legend-tick', labelsContainer).textContent = "0";
+                L.DomUtil.create('div', 'legend-tick', labelsContainer).textContent = "1";
+                return div;
+            };
+            legend.addTo(map);
+            this._legend = legend;
+        },
+
+        /** Show an on-map message (e.g. when there is no data). */
+        addNoDataMessage: function(map, text) {
+            const div = document.createElement('div');
+            div.className = 'no-data-message';
+            div.textContent = text;
+            map.getContainer().appendChild(div);
+        }
+    };
+})();

--- a/public/stylesheets/api-docs/access-score.css
+++ b/public/stylesheets/api-docs/access-score.css
@@ -1,0 +1,212 @@
+/**
+ * AccessScore API Documentation - Specific Styles.
+ *
+ * Styles for the AccessScore (streets + regions) doc-page map previews: the metric toolbar, the continuous
+ * red→yellow→green score legend, popups, and status messages. Mirrors regions.css so the AccessScore previews match the
+ * other API doc previews.
+ */
+
+/* ---- Preview Container ---- */
+
+#access-score-streets-preview,
+#access-score-regions-preview {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    border: 1px solid var(--color-border-light, #e0e0e0);
+    border-radius: var(--border-radius, 4px);
+    background-color: white;
+    overflow: hidden;
+}
+
+/* The metric selector lives in a toolbar above the map (not as an on-map Leaflet control) so it can never be overlapped
+   by feature popups (on-map controls sit above the popup pane). */
+.as-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 12px;
+    border-bottom: 1px solid var(--color-border-light, #e0e0e0);
+    background-color: #fafafa;
+    font-family: var(--font-sans);
+    font-size: 13px;
+    color: #222;
+}
+
+.as-toolbar label {
+    font-weight: 600;
+}
+
+.as-toolbar select {
+    font-family: var(--font-sans);
+    font-size: 13px;
+    padding: 2px 4px;
+    border: 1px solid #ccc;
+    border-radius: 3px;
+}
+
+#access-score-streets-map,
+#access-score-regions-map {
+    flex: 1 1 auto;
+    min-height: 0;
+    width: 100%;
+}
+
+/* ---- Loading Message ---- */
+
+.loading-message {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    color: #666;
+    font-style: italic;
+    background-color: #f8f9fa;
+}
+
+.loading-message::before {
+    content: '';
+    width: 20px;
+    height: 20px;
+    border: 2px solid #e0e0e0;
+    border-top: 2px solid var(--color-accent-link, #007bff);
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+    margin-right: 10px;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}
+
+/* ---- Counter Badge ---- */
+
+.counter-badge {
+    position: absolute;
+    bottom: 10px;
+    left: 10px;
+    right: auto;
+    background-color: white;
+    padding: 5px 10px;
+    border-radius: 4px;
+    box-shadow: 0 1px 5px rgba(0,0,0,0.4);
+    font-size: 12px;
+    font-weight: 500;
+    color: #222;
+    z-index: 1000;
+}
+
+/* ---- Continuous Legend ---- */
+
+.continuous-legend {
+    background-color: white;
+    padding: 8px 10px;
+    border-radius: 4px;
+    box-shadow: 0 1px 5px rgba(0,0,0,0.4);
+    line-height: 1.4;
+    color: #555;
+    font-family: var(--font-sans);
+    max-width: 250px;
+}
+
+.continuous-legend h4 {
+    margin: 0 0 8px;
+    font-size: 14px;
+    font-weight: 600;
+    color: #222;
+}
+
+.gradient-container {
+    border: 1px solid #ccc;
+    border-radius: 3px;
+    overflow: hidden;
+}
+
+.legend-tick {
+    font-size: 10px;
+    color: #666;
+    font-weight: 500;
+}
+
+/* ---- Feature Popup ---- */
+
+.as-popup {
+    font-family: var(--font-sans);
+    max-width: 260px;
+    line-height: 1.4;
+}
+
+.as-popup h4 {
+    margin: 0 0 8px 0;
+    font-size: 16px;
+    font-weight: 600;
+    color: #222;
+    border-bottom: 1px solid #e0e0e0;
+    padding-bottom: 4px;
+}
+
+.as-popup p {
+    margin: 4px 0;
+    font-size: 13px;
+    color: #555;
+}
+
+.as-popup strong {
+    color: #222;
+    font-weight: 500;
+}
+
+.as-popup .as-score {
+    font-size: 20px;
+    font-weight: 700;
+}
+
+.as-popup .as-breakdown {
+    margin: 6px 0 0;
+    font-size: 12px;
+    color: #555;
+}
+
+/* ---- No Data Message ---- */
+
+.no-data-message {
+    position: absolute;
+    top: 10px;
+    left: 50%;
+    transform: translateX(-50%);
+    background-color: white;
+    padding: 8px 12px;
+    border-radius: 4px;
+    box-shadow: 0 1px 5px rgba(0,0,0,0.4);
+    font-size: 14px;
+    color: #666;
+    z-index: 1000;
+    white-space: nowrap;
+}
+
+/* ---- Responsive Adjustments ---- */
+
+@media (max-width: 768px) {
+    .continuous-legend {
+        max-width: 180px;
+        padding: 6px 8px;
+    }
+
+    .gradient-container,
+    .legend-labels {
+        width: 160px !important;
+    }
+
+    .continuous-legend h4 {
+        font-size: 13px;
+    }
+
+    .legend-tick {
+        font-size: 9px;
+    }
+
+    .as-popup {
+        max-width: 200px;
+    }
+}

--- a/test/controllers/api/AccessScoreApiSpec.scala
+++ b/test/controllers/api/AccessScoreApiSpec.scala
@@ -1,0 +1,104 @@
+package controllers.api
+
+import org.apache.pekko.stream.Materializer
+import org.scalatestplus.play.PlaySpec
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.json.JsObject
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+
+/**
+ * Locks the response contract of the v3 AccessScore API (#3855): GET /v3/api/accessScoreStreets and
+ * /v3/api/accessScoreRegions return a GeoJSON FeatureCollection by default and a snake_case CSV header for filetype=csv,
+ * and reject a malformed bbox / non-positive regionId with 400 INVALID_PARAMETER. Asserts shape, not data.
+ *
+ * Boots the real application (real Slick/PostGIS) and exercises the routes end to end. The endpoints are
+ * `UserAwareAction` (no auth needed); the eager scheduling actors are disabled so they don't fire background work.
+ *
+ * Requires a Postgres+PostGIS database whose city schema uses the new `cluster`/`cluster_label` model.
+ */
+class AccessScoreApiSpec extends PlaySpec with GuiceOneAppPerSuite {
+
+  override def fakeApplication(): Application =
+    new GuiceApplicationBuilder()
+      .disable[modules.ActorModule] // No eager background actors during tests.
+      .build()
+
+  // Chunked GeoJSON/CSV bodies need a real Materializer to consume (the test default NoMaterializer only does strict).
+  implicit lazy val mat: Materializer = app.materializer
+
+  // A tiny near-empty bbox keeps the streamed body cheap regardless of how much data the connected DB holds.
+  private val tinyBbox = "bbox=0,0,0.001,0.001"
+
+  "GET /v3/api/accessScoreStreets" should {
+    "return 200 GeoJSON FeatureCollection by default" in {
+      val resp = route(app, FakeRequest(GET, s"/v3/api/accessScoreStreets?$tinyBbox")).get
+      status(resp) mustBe OK
+      contentType(resp) mustBe Some("application/json")
+
+      val json = contentAsJson(resp)
+      (json \ "type").as[String] mustBe "FeatureCollection"
+      (json \ "features").asOpt[Seq[JsObject]] mustBe defined
+    }
+
+    "return CSV with the documented snake_case header when filetype=csv" in {
+      val resp = route(app, FakeRequest(GET, s"/v3/api/accessScoreStreets?$tinyBbox&filetype=csv")).get
+      status(resp) mustBe OK
+      contentType(resp) mustBe Some("text/csv")
+
+      val body = contentAsString(resp)
+      // Per-type columns are generated from AccessScoreCalculator.orderedScoredTypes; assert the leading + trailing run.
+      body must include(
+        "street_edge_id,osm_way_id,region_id,score,audit_count,length_meters,label_count,n_curb_ramp"
+      )
+      body must include("score_signal,start_point,end_point")
+      body must not include "streetEdgeId"
+      body must not include "lengthMeters"
+    }
+
+    "return 400 INVALID_PARAMETER for a malformed bbox" in {
+      val resp = route(app, FakeRequest(GET, "/v3/api/accessScoreStreets?bbox=not-a-bbox")).get
+      status(resp) mustBe BAD_REQUEST
+      (contentAsJson(resp) \ "parameter").as[String] mustBe "bbox"
+    }
+
+    "return 400 INVALID_PARAMETER for a non-positive regionId" in {
+      val resp = route(app, FakeRequest(GET, "/v3/api/accessScoreStreets?regionId=0")).get
+      status(resp) mustBe BAD_REQUEST
+      (contentAsJson(resp) \ "parameter").as[String] mustBe "regionId"
+    }
+  }
+
+  "GET /v3/api/accessScoreRegions" should {
+    "return 200 GeoJSON FeatureCollection by default" in {
+      val resp = route(app, FakeRequest(GET, s"/v3/api/accessScoreRegions?$tinyBbox")).get
+      status(resp) mustBe OK
+      contentType(resp) mustBe Some("application/json")
+
+      val json = contentAsJson(resp)
+      (json \ "type").as[String] mustBe "FeatureCollection"
+      (json \ "features").asOpt[Seq[JsObject]] mustBe defined
+    }
+
+    "return CSV with the documented snake_case header when filetype=csv" in {
+      val resp = route(app, FakeRequest(GET, s"/v3/api/accessScoreRegions?$tinyBbox&filetype=csv")).get
+      status(resp) mustBe OK
+      contentType(resp) mustBe Some("text/csv")
+
+      val body = contentAsString(resp)
+      body must include(
+        "region_id,name,score,coverage,audited_street_count,total_street_count,avg_n_curb_ramp"
+      )
+      body must include("center_point")
+      body must not include "regionId"
+    }
+
+    "return 400 INVALID_PARAMETER for a malformed bbox" in {
+      val resp = route(app, FakeRequest(GET, "/v3/api/accessScoreRegions?bbox=not-a-bbox")).get
+      status(resp) mustBe BAD_REQUEST
+      (contentAsJson(resp) \ "parameter").as[String] mustBe "bbox"
+    }
+  }
+}

--- a/test/service/AccessScoreCalculatorSpec.scala
+++ b/test/service/AccessScoreCalculatorSpec.scala
@@ -1,0 +1,109 @@
+package service
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import service.AccessScoreCalculator.ClusterScoreInput
+
+/**
+ * Pure (no DB, no app boot) unit test for the v3 AccessScore math (#3855).
+ *
+ * Pins the consequential weighting decisions so they can't silently drift: the Good/Okay/Bad sign-flip for positive
+ * types, the Low/Med/High magnitude scaling for negative types, presence-only handling for Signal/NoSidewalk, the
+ * null-severity fallbacks, tag activation, and the street/region aggregation.
+ */
+class AccessScoreCalculatorSpec extends AnyFunSuite with Matchers {
+
+  private val eps = 1e-9
+
+  /** Builds a cluster input; severity/labelCount/tagCounts default to the common "no tags" case. */
+  private def cluster(
+      labelType: String,
+      severity: Option[Int] = None,
+      labelCount: Int = 1,
+      tagCounts: Map[String, Int] = Map.empty
+  ): ClusterScoreInput = ClusterScoreInput(labelType, severity, labelCount, tagCounts)
+
+  test("positive quality maps Good→full+, Okay→half+, Bad→full− (the sign-flip, CurbRamp base 0.75)") {
+    AccessScoreCalculator.scoreCluster(cluster("CurbRamp", Some(1))) shouldBe (0.75 +- eps)
+    AccessScoreCalculator.scoreCluster(cluster("CurbRamp", Some(2))) shouldBe (0.375 +- eps)
+    AccessScoreCalculator.scoreCluster(cluster("CurbRamp", Some(3))) shouldBe (-0.75 +- eps)
+  }
+
+  test("Crosswalk (also a positive quality type) follows the same sign-flipping mapping") {
+    AccessScoreCalculator.scoreCluster(cluster("Crosswalk", Some(1))) shouldBe (0.75 +- eps)
+    AccessScoreCalculator.scoreCluster(cluster("Crosswalk", Some(3))) shouldBe (-0.75 +- eps)
+  }
+
+  test("negative severity scales magnitude Low→Med→High, staying negative (Obstacle base −1.0)") {
+    AccessScoreCalculator.scoreCluster(cluster("Obstacle", Some(1))) shouldBe (-0.33 +- eps)
+    AccessScoreCalculator.scoreCluster(cluster("Obstacle", Some(2))) shouldBe (-0.67 +- eps)
+    AccessScoreCalculator.scoreCluster(cluster("Obstacle", Some(3))) shouldBe (-1.0 +- eps)
+  }
+
+  test("presence-only types ignore severity entirely") {
+    // Signal is +0.5 for mere presence; a (spurious) severity value must not change it.
+    AccessScoreCalculator.scoreCluster(cluster("Signal", None)) shouldBe (0.5 +- eps)
+    AccessScoreCalculator.scoreCluster(cluster("Signal", Some(3))) shouldBe (0.5 +- eps)
+    // NoSidewalk is a strong fixed negative.
+    AccessScoreCalculator.scoreCluster(cluster("NoSidewalk", None)) shouldBe (-1.0 +- eps)
+  }
+
+  test("null severity falls back to Okay for positives and Low for negatives") {
+    AccessScoreCalculator.scoreCluster(cluster("CurbRamp", None)) shouldBe (0.375 +- eps) // Okay
+    AccessScoreCalculator.scoreCluster(cluster("SurfaceProblem", None)) shouldBe (-0.33 +- eps) // Low
+  }
+
+  test("unscored label types contribute exactly zero") {
+    Seq("Occlusion", "Other", "Problem", "NotARealType").foreach { lt =>
+      AccessScoreCalculator.scoreCluster(cluster(lt, Some(3))) shouldBe (0.0 +- eps)
+    }
+  }
+
+  test("a tag is active only when present on at least half the cluster's labels") {
+    // 1 of 2 labels tagged == 0.5 threshold → active → Signal penalty applies on top of the +0.5 presence base.
+    AccessScoreCalculator.scoreCluster(
+      cluster("Signal", labelCount = 2, tagCounts = Map("hard to reach buttons" -> 1))
+    ) shouldBe (0.25 +- eps)
+
+    // 1 of 3 labels tagged < 0.5 → inactive → only the presence base remains.
+    AccessScoreCalculator.scoreCluster(
+      cluster("Signal", labelCount = 3, tagCounts = Map("hard to reach buttons" -> 1))
+    ) shouldBe (0.5 +- eps)
+  }
+
+  test("unmapped tags add nothing, and a zero label count never divides by zero") {
+    AccessScoreCalculator.scoreCluster(
+      cluster("CurbRamp", Some(1), labelCount = 1, tagCounts = Map("some unmapped tag" -> 1))
+    ) shouldBe (0.75 +- eps)
+    AccessScoreCalculator.scoreCluster(
+      cluster("Signal", labelCount = 0, tagCounts = Map("hard to reach buttons" -> 1))
+    ) shouldBe (0.5 +- eps)
+  }
+
+  test("tag adjustments add independently of the base sign (Crosswalk 'level with sidewalk' helps a Bad crosswalk)") {
+    // Bad crosswalk base −0.75, plus +0.25 for the positive tag.
+    AccessScoreCalculator.scoreCluster(
+      cluster("Crosswalk", Some(3), labelCount = 1, tagCounts = Map("level with sidewalk" -> 1))
+    ) shouldBe (-0.5 +- eps)
+  }
+
+  test("scoreStreet sigmoids the summed contributions; empty street is the neutral 0.5") {
+    AccessScoreCalculator.scoreStreet(Seq.empty) shouldBe (0.5 +- eps)
+    // A strongly negative street trends toward 0; a strongly positive one toward 1.
+    AccessScoreCalculator.scoreStreet(Seq.fill(10)(cluster("NoSidewalk"))) should be < 0.01
+    AccessScoreCalculator.scoreStreet(Seq.fill(10)(cluster("CurbRamp", Some(1)))) should be > 0.99
+  }
+
+  test("scoreRegion is the street-length-weighted mean of scores, or None when nothing is audited") {
+    AccessScoreCalculator.scoreRegion(Seq((0.2, 100.0), (0.8, 300.0))).get shouldBe (0.65 +- eps)
+    AccessScoreCalculator.scoreRegion(Seq.empty) shouldBe None
+    AccessScoreCalculator.scoreRegion(Seq((0.5, 0.0))) shouldBe None // zero total length
+    AccessScoreCalculator.scoreRegion(Seq((0.42, 50.0))).get shouldBe (0.42 +- eps) // single street
+  }
+
+  test("the scored-type set is exactly the seven expected types, in id order") {
+    AccessScoreCalculator.orderedScoredTypes shouldBe Seq(
+      "CurbRamp", "NoCurbRamp", "Obstacle", "SurfaceProblem", "NoSidewalk", "Crosswalk", "Signal"
+    )
+  }
+}


### PR DESCRIPTION
## What & why

Brings AccessScore to the v3 API with a severity/quality- and tag-aware algorithm, replacing the dated v2 model. Based on Chu Li's *A Pilot Study of Sidewalk Equity in Seattle* (Urban Access 2022) and extended per #3855 to incorporate the 3-point rating scale, the Crosswalk/Signal/NoSidewalk label types, and tags.

Two new endpoints (standard v3 geo-filters `bbox`/`regionId`/`regionName`; formats `geojson`/`csv`/`shapefile`/`geopackage`):

- `GET /v3/api/accessScoreStreets`
- `GET /v3/api/accessScoreRegions`

This is **PR1**. Removing the old v2 AccessScore stack is tracked separately in #3864 (PR2), after these scores are sanity-checked in review.

## The scoring model

All weights are **tunable constants** in `AccessScoreCalculator` (one place to adjust).

- **3-point ratings (stored 1/2/3).** Positive *quality* types (CurbRamp, Crosswalk): Good/Okay/Bad → `+1.0 / +0.5 / -1.0 × base` — a **Bad** feature *lowers* the score. Negative *severity* types (NoCurbRamp, Obstacle, SurfaceProblem): Low/Med/High → `0.33 / 0.67 / 1.0 × base`. **Presence-only** (no rating): Signal `+0.5`, NoSidewalk `-1.0`.
- **Tags** layer additively when present on ≥50% of a cluster's labels — e.g. Signal `hard to reach buttons` `-0.25`, `APS` / `button waist height` positive; Crosswalk `level with sidewalk` `+0.25`; NoCurbRamp `no alternate route` `-0.50`. ~12 of the 69 tags carry nonzero weight; the rest are 0.
- **Street score** = `sigmoid(Σ contributions)` in (0,1). **Region score** = street-**length-weighted** mean of audited streets' scores (the normalization v2 lacked). `coverage` = audited / total streets.
- Null-severity fallback: positives → Okay, negatives → Low (conservative; v2 used 1.0 for every negative, so scores shift by design).

## Implementation notes

- **`AccessScoreCalculator`** — pure, DB-free engine; its `scoredTypeNames` set is the single source of truth that also generates the SQL type filter and the CSV/shapefile per-type columns, so they can't drift.
- **`AccessScoreApiModels`** — `StreetAccessScoreForApi` / `RegionAccessScoreForApi` (snake_case GeoJSON + CSV, #3871) + filters in `models.api` (#3885).
- **DB** — new lean `ClusterTable.getClusterScoreRows` (per-cluster severity + `tag_counts` via `unnest`), `StreetEdgeTable.getStreetLengths`, region-bbox/length helpers in `ApiService`. v2 service/controller paths left untouched.
- Shapefile uses short DBF-safe column codes (`nCRamp`, `sNoCRamp`, …); geopackage/CSV/GeoJSON keep full snake_case.
- apiDocs overview documents the endpoints + model.

## Testing

- **12** calculator unit tests (sign-flip, severity scaling, presence-only, null fallbacks, tag activation/composition) + **7** DB-backed endpoint tests. 74 touched-area tests green.
- **Verified end-to-end on real Teaneck data** (the dev DB on the new clustering model): 1267 street features, mean score **0.456** (matches the paper's ~0.49); region/CSV/shapefile/geopackage outputs and all 400 error paths confirmed over HTTP.

## Reviewer notes

- The starter **weight tables are judgment-based, not empirically derived** — the most likely thing to tune. All isolated in `AccessScoreCalculator`.
- **Verify against a new-model city (e.g. Teaneck), not Seattle** — the Seattle dev dump is still on the old clustering schema and pre-3-point severity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)