### PR TITLE
Fix discarded DBIO in validation-undo (#4228)

### DIFF
--- a/app/models/validation/LabelValidationTable.scala
+++ b/app/models/validation/LabelValidationTable.scala
@@ -10,9 +10,9 @@ import models.utils.CommonUtils.ViewerType.ViewerType
 import models.utils.MyPostgresProfile
 import models.utils.MyPostgresProfile.api._
 import play.api.db.slick.{DatabaseConfigProvider, HasDatabaseConfigProvider}
-import slick.jdbc.GetResult
 import service.TimeInterval
 import service.TimeInterval.TimeInterval
+import slick.jdbc.GetResult
 
 import java.time.{LocalDate, OffsetDateTime}
 import javax.inject.{Inject, Singleton}
@@ -427,7 +427,7 @@ class LabelValidationTable @Inject() (
       endDate: Option[LocalDate],
       filterLowQuality: Boolean
   ): DBIO[Seq[(LocalDate, String, Int, Int, Int, Int, Int, Int)]] = {
-    val userFilter = if (filterLowQuality) "user_stat.high_quality" else "NOT user_stat.excluded"
+    val userFilter   = if (filterLowQuality) "user_stat.high_quality" else "NOT user_stat.excluded"
     val whereClauses = scala.collection.mutable.ListBuffer(
       "label.deleted = FALSE",
       userFilter
@@ -437,8 +437,10 @@ class LabelValidationTable @Inject() (
     val where = whereClauses.mkString(" AND ")
 
     implicit val getResult: GetResult[(LocalDate, String, Int, Int, Int, Int, Int, Int)] =
-      GetResult(r => (LocalDate.parse(r.nextString()), r.nextString(),
-        r.nextInt(), r.nextInt(), r.nextInt(), r.nextInt(), r.nextInt(), r.nextInt()))
+      GetResult(r =>
+        (LocalDate.parse(r.nextString()), r.nextString(), r.nextInt(), r.nextInt(), r.nextInt(), r.nextInt(),
+          r.nextInt(), r.nextInt())
+      )
 
     sql"""
       SELECT CAST((label_validation.end_timestamp AT TIME ZONE 'US/Pacific')::date AS TEXT) AS date,

--- a/app/service/ValidationService.scala
+++ b/app/service/ValidationService.scala
@@ -166,8 +166,12 @@ class ValidationServiceImpl @Inject() (
             if (fullHistory.indexWhere(_.labelHistoryId == historyEntry.labelHistoryId) == fullHistory.length - 1) {
               val correctData: LabelHistory = fullHistory(fullHistory.length - 2)
               val labelToUpdateQuery        = labelsUnfiltered.filter(_.labelId === historyEntry.labelId)
-              labelToUpdateQuery.map(l => (l.severity, l.tags)).update((correctData.severity, correctData.tags.toList))
-              labelHistories.filter(_.labelValidationId === labelValidationId).delete.map(_ > 0)
+              for {
+                _ <- labelToUpdateQuery
+                  .map(l => (l.severity, l.tags))
+                  .update((correctData.severity, correctData.tags.toList))
+                deleted <- labelHistories.filter(_.labelValidationId === labelValidationId).delete
+              } yield deleted > 0
             } else {
               // If the next history entry reverses this one, we can update the label table and delete both entries.
               val thisEntryIdx: Int = fullHistory.indexWhere(_.labelValidationId == Some(labelValidationId))


### PR DESCRIPTION
## Problem
Fixes #4228.

When undoing the most-recent validation, `removeLabelHistoryForValidation` (`app/service/ValidationService.scala`) intended to roll the label's `severity`/`tags` back to the prior history entry **and** delete the history row. But the `update` DBIO was constructed on its own line and never sequenced into the returned action, so only the `delete` ran. Slick DBIOs are values — building one without combining it is a no-op. The result was a silent data-integrity defect: labels kept stale `severity`/`tags` after an undo.

## Fix
Sequence both actions in a `for`-comprehension so the `update` and the `delete` both run inside the existing `.transactionally` block:

```scala
for {
  _       <- labelToUpdateQuery.map(l => (l.severity, l.tags)).update((correctData.severity, correctData.tags.toList))
  deleted <- labelHistories.filter(_.labelValidationId === labelValidationId).delete
} yield deleted > 0
```

## Testing
Verified the change compiles cleanly via the sbt thin client (`sbt --client compile` → `[success]`, which with `-Xfatal-warnings` is also warning-clean). There is no Scala/backend test suite in this repo, so no regression test was added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)