### PR TITLE
Migrate logged-events, tutorial & data-notes docs from wiki (#4252)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,5 +13,5 @@ Replace this with a brief description of the problem solved or feature implement
 - [ ] I've added/updated comments for large or confusing blocks of code.
 - [ ] I've included before/after screenshots above.
 - [ ] I've asked for and included translations for any user facing text that was added or modified.
-- [ ] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure the documentation on [this wiki page](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Descriptions-of-Logged-Events) is up to date for the logs you added/updated.
+- [ ] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure [`docs/logged-events.md`](../docs/logged-events.md) is up to date for the logs you added/updated.
 - [ ] I've tested on mobile (only needed for validation page).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,7 +123,7 @@ feature code; use `getLabelColors()` so colors stay in sync automatically.
 - Update said code to use the native `fetch` API rather than jQuery, and to make use of Promises. But if said refactor would impact many other functions that use it, then wait for a dedicated refactor.
 - Replace uses of Bootstrap with native JS alternatives as you come across them
 - When writing SQL, avoid table aliases
-- User interactions are logged (clicks, key presses, mode switches, pano changes, mission/task events, etc.) to the activity/interaction tables. When you **add or change an interaction**, add or adjust the corresponding logging so analytics stay complete; keep event names consistent with the existing ones.
+- User interactions are logged (clicks, key presses, mode switches, pano changes, mission/task events, etc.) to the activity/interaction tables. When you **add or change an interaction**, add or adjust the corresponding logging so analytics stay complete; keep event names consistent with the existing ones, and update [`docs/logged-events.md`](docs/logged-events.md) (how logging works + the event reference).
 - Ensure WCAG 2.1/2.2 Level AA accessibility standards are met
 - When adding or refactoring code, use the fonts, colors, button styling, etc. defined in main.css :root. These are pulled from our "Design System Tokens" Figma, and we are pushing to use these going forward.
 - Max line length of 120 characters, with long line exceptions where appropriate. For multi-line comments, TARGET line length is 120 characters

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ guide: **[`docs/dev-environment.md`](docs/dev-environment.md)**.
 | [`CLAUDE.md`](CLAUDE.md) | Conventions + operational notes, used as AI-assistant context. |
 | [`docs/testing-and-ci.md`](docs/testing-and-ci.md) | Testing strategy and CI rollout plan. |
 | [`docs/upgrading-libraries.md`](docs/upgrading-libraries.md) | Dependency-version inventory and how to update each. |
+| [`docs/logged-events.md`](docs/logged-events.md) | How user-interaction logging works + the event reference. |
+| [`docs/data-notes.md`](docs/data-notes.md) | Release-specific caveats for analyzing Project Sidewalk data. |
 | [`SECURITY.md`](SECURITY.md) | How to report a vulnerability. |
 | [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) | Community standards. |
 

--- a/docs/data-notes.md
+++ b/docs/data-notes.md
@@ -1,0 +1,47 @@
+# Data notes for analysis
+
+Caveats and gotchas to keep in mind when **analyzing Project Sidewalk data** — historical conditions in specific
+releases that affect how certain columns should be interpreted. If you're working with a database dump or the public
+[data API](https://projectsidewalk.org/api), check whether any of these apply to the time range you're analyzing.
+
+This is an **append-only log**: when a release changes data semantics or fixes a data bug with lasting analytical
+impact, add a dated, version-tagged entry here (newest first) so future analysts aren't caught out.
+
+## Data caveats by release
+
+### v7.8.5 — `audit_task.task_start` corrected
+
+Before v7.8.5, the `task_start` column in `audit_task` was incorrectly set to the **session** start time rather than
+that individual task's start time. It's correct going forward. Existing rows were back-filled to a close
+approximation using the timestamp of the `TaskStart` event in `audit_task_interaction` — but only ~90% of
+`audit_task` rows have a corresponding `TaskStart` event, so the remaining ~10% are still approximate. The same fix
+was applied to the DC database (which is no longer collecting new data).
+
+### v7.5.0 (May 2022) — gallery interaction tables gained `user_id`
+
+Before v7.5.0, the `gallery_task_interaction` and `gallery_task_environment` tables had **no `user_id` column**, so
+rows from before then can't be tied to a specific user. Added in
+[#2895](https://github.com/ProjectSidewalk/SidewalkWebpage/pull/2895).
+
+Separately, a small number of labels have a `temporary_label_id` that doesn't match any such ID in the
+`audit_task_interaction` logs — most do match. Background in
+[#2154 (comment)](https://github.com/ProjectSidewalk/SidewalkWebpage/pull/2154#issuecomment-1128257211).
+
+### v2 — anonymous users and `audit_task.completed`
+
+Up to the v2 release, records for **anonymous users weren't marked as `complete`**, so the `completed` column of
+`audit_task` is unreliable for anonymous contributions from that era. Discussion in
+[#403](https://github.com/ProjectSidewalk/SidewalkWebpage/issues/403).
+
+## Gallery screenshot tips
+
+Console snippets for staging clean label screenshots in the Gallery's expanded card view:
+
+```js
+// Hide the label icon/marker in the expanded view.
+sg.cardContainer.getModal().pano.labelMarker.marker.setVisible(false);
+
+// Inspect the marker's current heading/pitch, then reposition it.
+sg.cardContainer.getModal().pano.labelMarker.marker.getPosition();           // current { heading, pitch }
+sg.cardContainer.getModal().pano.labelMarker.marker.setPosition({ heading: newH, pitch: newP });
+```

--- a/docs/logged-events.md
+++ b/docs/logged-events.md
@@ -1,0 +1,98 @@
+# Logged interaction events
+
+Project Sidewalk records fine-grained **user-interaction events** (clicks, key presses, mode switches, pano changes,
+mission/task events, …) so we can analyze how people use the tools and debug sessions. This page explains how that
+logging works and documents the events whose meaning isn't obvious from their name — then points you at the code for
+the authoritative, always-current list.
+
+> **Why this page is deliberately not an exhaustive table.** The authoritative list of events *is the code* — events
+> are emitted by `push(...)` calls across the frontend, and some names are assembled at runtime. A hand-maintained
+> mirror of every event drifts (the previous wiki version did: it still listed `GSVInfo*` events that were renamed,
+> and events that no longer fire). So this page documents the *system* and the *non-obvious* events, and defers
+> completeness to [Finding the current list](#finding-the-current-list). When you add or change an interaction, update
+> the relevant section here in the **same PR** — the [PR template](../.github/PULL_REQUEST_TEMPLATE.md) reminds you.
+
+## How logging works
+
+Each interactive tool has its own `Tracker` that buffers events and periodically flushes them to a backend table:
+
+| Tool | Tracker (frontend) | Backend table | Table model (Slick) |
+|------|--------------------|---------------|---------------------|
+| **Explore / Audit** (`SVLabel`) | `public/javascripts/SVLabel/src/data/Tracker.js` | `audit_task_interaction` | `app/models/audit/AuditTaskInteractionTable.scala` |
+| **Validate** (`SVValidate`, incl. mobile) | `public/javascripts/SVValidate/src/Tracker.js` | `validation_task_interaction` | `app/models/validation/ValidationTaskInteractionTable.scala` |
+| **Gallery** (`Gallery`) | `public/javascripts/Gallery/src/data/Tracker.js` | `gallery_task_interaction` | `app/models/gallery/GalleryTaskInteractionTable.scala` |
+
+The core call is **`tracker.push(action, note)`** (see `Tracker.push` in each Tracker file):
+
+- `action` — the event name (a string; see [naming](#event-naming)).
+- `note` — an optional object of extra fields (e.g. `{labelType}`, `{cursorX, cursorY}`, `{keyCode}`) stored with the
+  event.
+
+Each pushed event is buffered with a timestamp and context (pano, task, lat/lng, …) and flushed to the backend
+periodically — on mission complete or after enough interactions accumulate — which is itself recorded as a
+`RefreshTracker` event.
+
+## Event naming
+
+Most events are fixed, transparently-named strings (`ContextMenu_Open`, `Onboarding_Start`, `Click_ZoomIn`). The ones
+worth knowing about are the **families assembled at runtime**, which you won't find as full string literals:
+
+- **`LowLevelEvent_<domType>`** — raw DOM events. `Tracker.trackWindowEvents()` (in
+  `SVLabel/src/data/Tracker.js`) binds `mousedown`, `mouseup`, `mouseover`, `mouseout`, `mousemove`, `click`,
+  `contextmenu`, `dblclick`, `keydown`, `keyup` and pushes `"LowLevelEvent_" + e.type`, with `cursorX`/`cursorY` or
+  `keyCode` in the note.
+- **`ModeSwitch_<LabelType>`**, **`Click_ModeSwitch_<LabelType>`**, **`KeyboardShortcut_ModeSwitch_<LabelType>`** —
+  labeling-mode changes; suffix is the label type (`CurbRamp`, `NoSidewalk`, …) or `Walk`. The prefix encodes *how*
+  the switch happened: programmatic vs. a mouse click (emitted in `SVLabel/src/menu/RibbonMenu.js`) vs. a keyboard
+  shortcut (`SVLabel/src/keyboard/Keyboard.js`).
+- **`Click_Subcategory_<Subcategory>`**, **`KeyboardShortcut_Severity_<n>`** — suffix is the chosen subcategory /
+  severity value (also `RibbonMenu.js` / `Keyboard.js`).
+
+Conventions for new events: `PascalCase_WithUnderscores`, prefixed by UI area or mechanism (`ContextMenu_…`,
+`KeyboardShortcut_…`, `PopUpShow_…`, `Modal…_…`). Keep `Click_…` for mouse and `KeyboardShortcut_…` for the keyboard
+equivalent so the two input paths stay distinguishable in analysis.
+
+## Notable events
+
+Most event names are self-explanatory; for the full set, [read the code](#finding-the-current-list). These are the
+ones whose meaning, parameters, or history aren't obvious:
+
+| Event | Why it's worth noting |
+|-------|------------------------|
+| `RefreshTracker` | Not a user action — it marks the buffer being flushed to the backend (on mission complete or after N interactions). |
+| `LowLevelEvent_<domType>` | A runtime family, not a single event (see [naming](#event-naming)); these are by far the highest-volume rows. |
+| `ModeSwitch_<…>` vs `Click_ModeSwitch_<…>` vs `KeyboardShortcut_ModeSwitch_<…>` | Same logical action via three input paths; don't double-count them as separate behaviors. |
+| `LabelingCanvas_FinishLabeling` | A label was *placed* (severity/tags not yet set, and it can still be removed) — not a finalized label. |
+| `ContextMenu_Close` + `ContextMenu_CloseButtonClick` / `CloseClickOut` / `CloseKeyboardShortcut` / `ClosePressEnter` | The menu close is logged generically *and* by mechanism; pick the granularity your analysis needs. |
+| `ContextMenu_TagAutoRemoved` | A tag the system removed automatically (e.g. incompatible with a changed label), distinct from a user-removed tag. |
+| `PanoInfoButton_Click` / `PanoInfoCopyToClipboard_Click` / `PanoInfoViewInPano_Click` | **Renamed from `GSVInfo*`** with the pano-viewer abstraction — older data uses the `GSVInfo*` names, so query both across time ranges. |
+| `NeighborhoodComplete_ByUser` vs `NeighborhoodComplete_AcrossAllUsers` | One user finishing their work vs. a neighborhood hitting 100% across *all* users. |
+| `Viewer_Primary` / `Viewer_Pannellum` | Which imagery viewer is active — the primary provider vs. the Pannellum fallback. |
+| `KeyboardShortcut_DisagreeReason_Option` / `KeyboardShortcut_UnsureReason_Option` | Validate: a reason chosen for a disagree/unsure verdict. |
+| `ValidationOptionApply` / `ValidationOptionUnapply` (Gallery) | A validation-status **filter** in the Gallery — *not* a validation of a label. |
+
+## Finding the current list
+
+The reference above is intentionally partial. To get the **authoritative, current** set for a tool, search its
+`src/` for `push(` and read the surrounding code (remember the [runtime families](#event-naming) won't appear as full
+literals):
+
+```bash
+# Literal event names emitted by the Explore tool (swap in SVValidate/src or Gallery/src for the others):
+grep -rhoE "push\(\s*['\"][A-Za-z0-9_]+" public/javascripts/SVLabel/src --include=*.js | sort -u
+```
+
+Then read each tool's `Tracker.js` for the generated families (start with `trackWindowEvents()` in
+`SVLabel/src/data/Tracker.js`), and `SVLabel/src/menu/RibbonMenu.js` + `SVLabel/src/keyboard/Keyboard.js` for the
+`ModeSwitch_`/`Severity_`/`Subcategory_` suffixes. The backend table models (table above) define the columns each
+event is stored in.
+
+## Keeping this up to date
+
+- **Add or change an interaction → update the relevant section here in the same PR.** The
+  [PR template](../.github/PULL_REQUEST_TEMPLATE.md) includes this step.
+- Follow the [naming conventions](#event-naming); if you add a keyboard path for an existing click (or vice versa),
+  mirror the existing `Click_…` / `KeyboardShortcut_…` pair so the input paths stay distinguishable.
+- Only document a *new* event here if its meaning isn't obvious from its name — keep this page the curated layer over
+  the code, not a mirror of it.
+- Unsure whether or how something should be logged? Ask Mikey.

--- a/public/javascripts/SVLabel/src/onboarding/README.md
+++ b/public/javascripts/SVLabel/src/onboarding/README.md
@@ -1,0 +1,56 @@
+# Explore onboarding tutorial
+
+This directory implements the **interactive onboarding tutorial** that new users go through on the Explore/Audit page
+before labeling for real. It walks them through a scripted Google Street View pano, prompting them to pan, zoom, and
+place each label type. This README orients you for editing that flow; the behavior lives in the files here, so keep
+this doc in sync when you change them.
+
+## Files
+
+| File | Responsibility |
+|------|----------------|
+| `OnboardingStates.js` | **The script.** An ordered list of tutorial *states* (steps) and how each advances to the next. This is what you edit most. |
+| `Onboarding.js` | **The engine.** Reads the current state, renders its message/annotations, wires up the listeners that detect the user's action, and transitions to the next state. |
+| `HandAnimation.js` | The animated hand hint shown during some steps. |
+| `InitialMissionInstruction.js` | The instructional messaging shown for the first real mission, just after onboarding. |
+
+## How a state is shaped (`OnboardingStates.js`)
+
+Each entry in the states array describes one step. The common fields:
+
+- **`id`** — the state's unique name (e.g. `"select-label-type-1"`); `transition` functions return these to move
+  between states.
+- **`progression`** — `true` if this state counts toward the tutorial **progress bar**. (This replaced the older
+  manual `completedRate`/`numStates` bookkeeping — you no longer hand-maintain counts; just set `progression`
+  correctly on each state and the bar is derived from it.)
+- **`properties`** — drives the step's behavior. Watch especially:
+  - `action` — what the user must do (e.g. `"SelectLabelType"`, `"WalkTowards"`); `Onboarding.js` branches on this.
+  - `labelType` — the label type involved, when relevant.
+  - `minHeading` / `maxHeading` — the allowed pano heading range for this step (from `headingRanges`).
+- **`message`** — the text shown in the tutorial speech bubble. Use `i18next.t('tutorial.<key>')` — **tutorial text is
+  internationalized**, so add the corresponding key to the `tutorial` namespace for every supported language rather
+  than hardcoding a string (see [`CONTRIBUTING.md`](../../../../../CONTRIBUTING.md) → Internationalization).
+- **`panoId`** — the GSV pano used for the tutorial. It's the same shared value (`"tutorial"`) for all states.
+- **`annotations`** — optional visual overlays (arrows, etc.) with pixel `x`/`y` positions on the pano. Easiest to
+  copy and tweak from a nearby state.
+- **`transition`** — a function called when the state's action is completed. It returns the **`id` of the next
+  state** (it can branch on what the user did). Some terminal states use special keys like `end-onboarding`
+  instead.
+
+## How the engine runs them (`Onboarding.js`)
+
+The control flow centers on `_visit(state)`: it renders the state, then (based on `properties.action`) attaches the
+listeners that wait for the user to do the right thing. When they do, the state's `transition` runs and its return
+value is passed back into `_visit(getState(nextState))` to advance.
+
+To add a step of an **existing** action type, add a new state object and point the previous state's `transition` at
+it. To add a **new** action type, you'll also add a handler in `Onboarding.js` that knows how to set up and detect
+that interaction.
+
+## Tips
+
+- Edit `src/` files only — Grunt rebuilds the `build/` bundle (see [`CONTRIBUTING.md`](../../../../../CONTRIBUTING.md)).
+- The tutorial can't be exercised by automated GSV testing; step through it manually in the browser after changes.
+- For worked examples of tutorial-flow changes, see PRs
+  [#1493](https://github.com/ProjectSidewalk/SidewalkWebpage/pull/1493) and
+  [#1485](https://github.com/ProjectSidewalk/SidewalkWebpage/pull/1485).


### PR DESCRIPTION
Third batch of the wiki→repo developer-docs migration (#4252), after #4294 and #4296. Each doc is **rewritten to current code**, and deliberately scoped to **minimize ongoing maintenance**: document what the code can't tell you (intent, non-obvious meaning, history), and point to code for the regenerable rest.

## Docs

### `docs/logged-events.md` (98 lines)
- Explains how interaction logging works: the three `Tracker`s → `push(action, note)` → `audit_task_interaction` / `validation_task_interaction` / `gallery_task_interaction` (with links to each Tracker file **and** Slick table model).
- Documents the **runtime-assembled event-name families** (`LowLevelEvent_<domType>`, `ModeSwitch_<labelType>`, …) that a literal grep can't enumerate, citing the exact emitting files (`RibbonMenu.js`, `Keyboard.js`, `trackWindowEvents()`).
- Lists **only the non-obvious events**, then a `grep` recipe + code pointers for the authoritative, always-current list — instead of a fragile ~80-row mirror that drifts.
- Reconciling against code caught real drift the wiki had missed: **`GSVInfo*` → `PanoInfo*`** (renamed with the pano-viewer abstraction), and `WalkTowards`/`MissionComplete` **no longer fire as `push()` events**.
- Repoints the **PR-template** logging checklist from the wiki page to this doc.

### `public/javascripts/SVLabel/src/onboarding/README.md` (56 lines)
Tutorial internals, placed **beside the code** so it surfaces when you edit the tutorial. Corrects the wiki's **stale path** (`SVLabel/src/SVLabel/onboarding` → `SVLabel/src/onboarding`) and its **dead `completedRate`/`numStates`** progress instructions (now a per-state `progression` flag), and notes tutorial text is now **i18n'd** via `i18next.t('tutorial.…')`.

### `docs/data-notes.md` (47 lines)
Release-specific data-analysis caveats (v7.8.5 `task_start`, v7.5.0 gallery `user_id`, v2 anonymous `completed`). Historical facts → migrated faithfully; framed as an append-only log.

## Wiring (no duplication)
`README.md` doc index + `CLAUDE.md` logging guideline point at the new docs.

## Scope note
The logged-events doc is intentionally **not** an exhaustive event table. The previous wiki table had drifted (above); the durable, low-maintenance core is the system explanation + non-obvious events + a recipe to regenerate the full list from code.

## Verification
- All relative links + code pointers verified against real files.
- The new `onboarding/README.md` won't be bundled (Grunt globs are `src/**/*.js`).
- Docs-only change — no code touched.

## Follow-up (not in this PR)
Wiki redirect stubs for these three pages (+ sidebar repoint, and the PR-template link is already handled here) will be pushed once this merges, same repo-first sequencing as #4294/#4296.

🤖 Generated with [Claude Code](https://claude.com/claude-code)