### PR TITLE
Consolidate i18n docs + clarify repo-vs-wiki doc split (#4252)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,8 @@ User-facing text changes require translations for all supported languages
 
 Lean towards using `data-i18n="ns:key"` in HTML so that we can keep the translations in the i18next JS library and reduce duplicate translations.
 
+Full details (both systems, regional `en-US`/`en-NZ` rules, adding a new language): [`docs/internationalization.md`](docs/internationalization.md).
+
 ## Configuration
 
 - `conf/application.conf` is the base; environment overlays are `application.local.conf`, `application.staging.conf`, `application.test.conf`. `npm start` runs with `application.local.conf`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,28 +88,13 @@ conventions.
 
 ## Internationalization
 
-User-facing text must be translatable. There are two systems:
+**All user-facing text must be translatable** — never hardcode display strings. Project Sidewalk has two i18n systems
+(backend Play messages in `conf/messages/`, and frontend i18next JSON in `public/locales/`), supports several
+languages, and has specific rules for temporary translations and the `en-US`/`en-NZ` regional variants.
 
-- **Backend (server-rendered):** Play message files `conf/messages.<lang>` (`messages.en`, `messages.es`, …).
-  Add a key to each language file and reference it in `.scala.html` with `@Messages("your.key")`.
-- **Frontend (client-side):** JSON under `public/locales/<lang>/` (e.g. `common.json`). Reference it with
-  `i18next.t('your-key')`, or prefer `data-i18n="ns:key"` directly in HTML to avoid duplicate strings.
-
-Supported languages: **en, es, de, nl, zh-TW, pt-BR**, plus the regional English variants **en-US** and **en-NZ**.
-
-**When you add or change user-facing text:**
-
-1. Add **temporary translations** for Spanish, Dutch, German, and Mandarin (`zh-TW`, traditional). Google Translate
-   is fine for these — a maintainer periodically sends the accumulated machine translations to our partners for
-   official ones.
-2. Add to the generic **`en`** files by default. Also add **regional overrides** only where the wording differs:
-   - **en-US** — distances use feet/miles (`ft`/`mi`) where generic `en` uses meters/kilometers (`m`/`km`); your
-     code should respect the unit system too (see existing examples).
-   - **en-NZ** — e.g. curb ramp → *drop kerb*, sidewalk → *footpath*, crosswalk → *pedestrian crossing*,
-     neighborhood → *neighbourhood*, organization → *organisation*, meter/kilometer → *metre/kilometre*,
-     trash/recycling can → *trash/recycling bin*.
-
-**When you remove translated text,** check it isn't used elsewhere; if not, remove the key from every language file.
+The full details — both systems, adding/changing/removing text, and adding a whole new language — are in
+**[`docs/internationalization.md`](docs/internationalization.md)**. The one thing to remember: when you add or change
+user-facing text, add at least temporary (machine) translations for the other languages in the same PR.
 
 ## Testing your changes
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ guide: **[`docs/dev-environment.md`](docs/dev-environment.md)**.
 | [`docs/architecture.md`](docs/architecture.md) | How the backend, frontend, and data fit together. |
 | [`CONTRIBUTING.md`](CONTRIBUTING.md) | Branch/PR workflow, coding standards, i18n. |
 | [`docs/style-guide.md`](docs/style-guide.md) | Detailed code-style conventions (JS, Scala, HTML/CSS). |
+| [`docs/internationalization.md`](docs/internationalization.md) | How translations work + adding a new language. |
 | [`CLAUDE.md`](CLAUDE.md) | Conventions + operational notes, used as AI-assistant context. |
 | [`docs/testing-and-ci.md`](docs/testing-and-ci.md) | Testing strategy and CI rollout plan. |
 | [`docs/upgrading-libraries.md`](docs/upgrading-libraries.md) | Dependency-version inventory and how to update each. |
@@ -68,8 +69,17 @@ guide: **[`docs/dev-environment.md`](docs/dev-environment.md)**.
 | [`SECURITY.md`](SECURITY.md) | How to report a vulnerability. |
 | [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) | Community standards. |
 
-Operational runbooks, city-deployment guidance, and visual/GIS tutorials live in the
-[**wiki**](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki).
+### Where documentation lives
+
+**Developer documentation lives in this repository** — versioned with the code, reviewed in pull requests, and
+searchable by tooling (and AI assistants). The
+[**wiki**](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki) holds **operational runbooks** (e.g. deploying to
+a live server), **city-deployment and GIS data preparation**, and **visual tutorials** — content that changes
+independently of the code or is maintained by non-developers.
+
+Rule of thumb: *if it describes the code or how to contribute, it's in the repo; if it's a runbook for operating a
+server or onboarding a new city's data, it's in the wiki.* We keep one source of truth per topic and cross-link rather
+than duplicate.
 
 ## Contributing
 

--- a/docs/internationalization.md
+++ b/docs/internationalization.md
@@ -1,0 +1,81 @@
+# Internationalization (i18n)
+
+Project Sidewalk is translated into several languages, and **all user-facing text must be translatable** — never
+hardcode display strings. This page is the single home for how i18n works, how to add or change translated text, and
+how to add a whole new language.
+
+## Supported languages
+
+`en` (default), `es`, `nl`, `de`, `pt-BR`, `zh-TW`, plus the regional English variants `en-US` and `en-NZ`. The
+authoritative list is **`play.i18n.langs`** in [`conf/application.conf`](../conf/application.conf) — that's what
+determines the languages the app offers.
+
+## The two i18n systems
+
+Project Sidewalk has two separate translation systems; which one you use depends on where the string is rendered.
+
+### Backend — Play i18n (server-rendered Twirl templates)
+
+- Message files live in **`conf/messages/`**: `messages` (default) and `messages.<lang>` per language
+  (`messages.en`, `messages.es`, `messages.de`, `messages.zh-TW`, …). City-specific overrides exist too
+  (e.g. `messages-india.en`). The directory is wired via `play.i18n.path = "messages"` in `conf/application.conf`.
+- Add a key to the relevant message file(s) and reference it in a `.scala.html` template with `@Messages("your.key")`
+  (or the injected `messagesApi`).
+
+### Frontend — i18next (client-side JavaScript)
+
+- Translations live in **`public/locales/<lang>/<namespace>.json`**, split into namespaces such as `common.json`,
+  `audit.json`, `gallery.json`, `dashboard.json`, `routebuilder.json`, and `labelmap.json` (plus city-specific
+  variants like `common-india.json`, `audit-zurich.json`).
+- Reference a string with `i18next.t('namespace:your-key')`, **or prefer `data-i18n="namespace:key"` directly in the
+  HTML** — that keeps the translation in i18next and avoids duplicating strings across JS and markup.
+
+> Most user-facing text in the apps is in the **frontend** system. Reach for the backend message files only for
+> server-rendered Twirl pages.
+
+## Adding or changing user-facing text
+
+1. **Add the key** to the appropriate backend message file or frontend namespace JSON, for the languages you can.
+2. **Add temporary machine translations** for Spanish, Dutch, German, and Mandarin (`zh-TW`, traditional) — Google
+   Translate is fine. A maintainer periodically sends the accumulated machine translations to our partners for proper
+   ones, so don't block on official translations.
+3. **Default to the generic `en`** files, and add **regional English overrides only where the wording actually
+   differs**:
+   - **`en-US`** — imperial units: feet/miles (`ft`/`mi`) where generic `en` uses metric (`m`/`km`). Your code must
+     respect the unit system too (see existing examples).
+   - **`en-NZ`** — dialect: curb ramp → *drop kerb*, sidewalk → *footpath*, crosswalk → *pedestrian crossing*,
+     neighborhood → *neighbourhood*, organization → *organisation*, meter/kilometre → *metre/kilometre*,
+     trash/recycling can → *trash/recycling bin*.
+4. **Prefer `data-i18n` in HTML** over duplicating a string in both a template and JS.
+
+**Removing translated text:** confirm the key isn't used elsewhere, then remove it from **every** language file so no
+orphans remain.
+
+## Adding a whole new language
+
+1. **Get translations.** Hand the translator the English source as the starting point: `conf/messages/messages.en`
+   (backend) and `public/locales/en/*.json` (frontend).
+   - Ask them **not to edit the keys** — only the values. (Especially important for non-technical partners.)
+   - For a **regional variant** of a language we already have (as with `en-NZ` over `en`), it's cleaner to ask them
+     to keep only the lines that actually change.
+2. **Register the locale** by adding it to `play.i18n.langs` in [`conf/application.conf`](../conf/application.conf).
+3. **Add the translated files:** backend as `conf/messages/messages.<lang>`, frontend as
+   `public/locales/<lang>/<namespace>.json` (mirror the namespaces in `public/locales/en/`).
+4. **Add the moment.js locale** (for localized dates) if one exists for the language: drop the locale file into
+   `public/javascripts/lib/moment/` and add a `<script>` import in
+   [`app/views/common/main.scala.html`](../app/views/common/main.scala.html) alongside the existing per-locale imports
+   (`es.js`, `nl.js`, `zh-tw.js`, `en-nz.js`). We import locales individually to keep the bundle small. (There's an
+   open ticket, [#1258](https://github.com/ProjectSidewalk/SidewalkWebpage/issues/1258), about moving off moment.js —
+   don't take that on as part of adding a language.)
+5. **Mind the `unit-distance` key.** In `common.json`, `unit-distance` (e.g. `"kilometers"` / `"miles"`) is **not**
+   display text — it's a unit-*system* selector consumed by turf.js. For a new non-US language, leave it as
+   `"kilometers"` (metric) rather than translating the word.
+6. **Test thoroughly.** Compare each main page against the English version (open them in adjacent tabs and flip
+   between them) to catch layout breakage from differing text lengths. On Explore, place a label of each type and
+   open the various sub-menus. Then open a PR and deploy to the test servers so the requesting partner can review the
+   live result.
+
+## See also
+
+- [`CONTRIBUTING.md`](../CONTRIBUTING.md) — the contribution workflow this fits into.
+- [`CLAUDE.md`](../CLAUDE.md) — AI-assistant context (terse i18n summary).


### PR DESCRIPTION
Folds Project Sidewalk's internationalization docs into one home and documents where docs live. **Stacked on #4301** — base will auto-retarget to `develop` once #4301 merges; the diff here is just the i18n commit.

## i18n consolidation
- **`docs/internationalization.md`** (new) — the single i18n home: both systems (backend Play messages in `conf/messages/`, frontend i18next JSON in `public/locales/`), adding/changing/removing translated text, the `en-US`/`en-NZ` regional rules, and the full **add-a-new-language** checklist (folded in from the wiki's "Adding a new language" page).
- Reconciling against the code fixed inaccuracies **both** existing docs carried — the payoff of one authoritative home:
  - backend messages are `conf/messages/messages.<lang>` (a directory), **not** `conf/messages.<lang>`;
  - the moment.js locales import in `app/views/common/main.scala.html`, not a top-level `main.scala.html`;
  - `unit-distance` lives in `common.json` and is a unit-*system* selector (`kilometers`/`miles`), not display text.
  - Dropped the wiki's stale `common.js` / `'zh'` references.
- **`CONTRIBUTING.md`** — i18n section trimmed to a pointer (net de-dup, −15 lines).
- **`CLAUDE.md`** — one-line pointer added (stays the terse AI reference).
- **`README.md`** — adds the i18n doc to the index.

## Repo-vs-wiki distinction
Adds a **"Where documentation lives"** section to `README.md`, stating the split **once**, authoritatively:
> *if it describes the code or how to contribute, it's in the repo; if it's a runbook for operating a server or onboarding a new city's data, it's in the wiki.*

(The wiki side gets a short *pointer* to this section rather than a restatement — staged for the post-merge wiki update.)

## Verification
- All relative links + code pointers verified against real files.
- Docs-only change — no code touched.

## Follow-up (not in this PR)
The `Adding-a-new-language` wiki redirect stub, sidebar repoint, and the Home "where docs live" pointer are staged to push after this merges (same repo-first sequencing as the earlier batches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)