### PR TITLE
Fix Streets API user_ids=[null] and user_count off-by-one (#3887)

### DIFF
--- a/app/models/street/StreetEdgeTable.scala
+++ b/app/models/street/StreetEdgeTable.scala
@@ -393,7 +393,12 @@ class StreetEdgeTable @Inject() (
       label_stats AS (
         SELECT s.street_edge_id,
                COUNT(l.label_id) as label_count,
-               array_agg(DISTINCT l.user_id) as user_ids,
+               -- The FILTER is essential: the LEFT JOIN to `label` yields a NULL user_id for streets that have been
+               -- audited but carry no labels, and `array_agg(DISTINCT l.user_id)` over that produces `{NULL}` (a
+               -- one-element array containing null) rather than an empty array. Without the FILTER, such streets report
+               -- `user_ids: [null]` and `user_count: 1`, and the `minUserCount` filter (which counts array_length)
+               -- treats them as having one user. See #3887.
+               array_agg(DISTINCT l.user_id) FILTER (WHERE l.user_id IS NOT NULL) as user_ids,
                MIN(l.time_created) as first_label_date,
                MAX(l.time_created) as last_label_date
         FROM filtered_streets s


### PR DESCRIPTION
Fixes #3887.

## Problem
`/v3/api/streets` returns `user_ids: [null]` with `user_count: 1` for streets that have been **audited but carry no labels** (e.g. someone audited the segment and placed nothing). The counts then "disagree in weird ways": `audit_count ≥ 1`, `label_count: 0`, but `user_count: 1` over a single `null`.

## Root cause
In `StreetEdgeTable.getStreetsForApi`, the `label_stats` CTE `LEFT JOIN`s `street_edge → label`, so an unlabeled street yields a `NULL` `l.user_id`. `array_agg(DISTINCT l.user_id)` over that produces `{NULL}` — a one-element array containing null — rather than an empty array. Two consequences:
- the response emits `user_ids: [null]` / `user_count: 1`, and
- the `minUserCount` filter (`array_length(user_ids, 1) >= n`) counts the null, so `?minUserCount=1` wrongly includes streets with **zero** real users.

(The app-side `GetResult` did `.filter(_ != null)`, which masked the JSON symptom in some paths but left the SQL-level array and the `minUserCount` filter still wrong.)

## Fix
Add `FILTER (WHERE l.user_id IS NOT NULL)` to the aggregate. It then returns `NULL` when there are no real labelers, which the existing `COALESCE(..., ARRAY[]::text[])` turns into an empty array (`user_count: 0`), and `array_length(empty, 1)` is `NULL` so `minUserCount` correctly excludes them.

## Verification
- **Real data (SELECT-only):** cleans up **418** audited-but-unlabeled streets in Teaneck and **3,231** in Seattle; **zero** resulting arrays still contain null.
- `sbt --client compile` clean; `StreetsApiSpec`, `BaseApiControllerSpec`, `RawLabelsApiSpec` all green (22 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
