### PR TITLE
Log API streaming failures so large-export empty-200s aren't silent (#4161, #4133)

### DIFF
--- a/app/controllers/api/BaseApiController.scala
+++ b/app/controllers/api/BaseApiController.scala
@@ -4,6 +4,7 @@ import controllers.base.{CustomBaseController, CustomControllerComponents}
 import controllers.helper.ShapefilesCreatorHelper
 import models.api.{ApiError, StreamingApiType}
 import models.utils.{LatLngBBox, MapParams}
+import org.apache.pekko.Done
 import org.apache.pekko.stream.scaladsl.{Source, StreamConverters}
 import org.apache.pekko.util.ByteString
 import play.api.Logger
@@ -19,6 +20,7 @@ import java.util.zip.{ZipEntry, ZipOutputStream}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.math._
 import scala.util.control.NonFatal
+import scala.util.{Failure, Success}
 
 /**
  * Base controller for API endpoints with common utility methods.
@@ -28,6 +30,34 @@ abstract class BaseApiController(cc: CustomControllerComponents)(implicit ec: Ex
 
   private val logger                    = Logger(this.getClass)
   protected val DEFAULT_BATCH_SIZE: Int = 50000
+
+  /**
+   * Attaches failure logging to a streaming response body.
+   *
+   * Chunked API responses (`Ok.chunked`) commit a 200 status and headers *before* the underlying database stream
+   * runs. So if the stream fails mid-flight — e.g. a query timeout or dropped connection while serializing a very
+   * large city's labels — the body simply ends, and Play cannot retract the status it already sent. Without this hook
+   * such failures are completely silent: exactly the #4161 symptom, where large-city `/v3/api/rawLabels` returns a
+   * 200 with an empty/truncated body and no server-side trace. This logs the failure so it is at least diagnosable;
+   * it does not (and cannot) change the status already sent to the client.
+   *
+   * @param source The streaming body to monitor.
+   * @param label  A short identifier (e.g. the download filename) included in the log line to locate the failure.
+   * @return       The same source, with termination-failure logging attached (success behavior is unchanged).
+   */
+  private def logStreamFailures(source: Source[String, _], label: String): Source[String, _] =
+    source.watchTermination() { (mat, done) =>
+      done.onComplete {
+        case Failure(e) =>
+          logger.error(
+            s"API streaming response failed mid-flight for '$label'; the client received a truncated/empty body " +
+              s"after a 200 status was already sent (see #4161).",
+            e
+          )
+        case Success(_: Done) => // Stream completed normally; nothing to log.
+      }
+      mat
+    }
 
   /**
    * Creates a bounding box (BBox) using the provided latitude and longitude values.
@@ -142,7 +172,7 @@ abstract class BaseApiController(cc: CustomControllerComponents)(implicit ec: Ex
       .intersperse(csvHeader, "\n", "\n")
 
     Future.successful(
-      Ok.chunked(csvSource, inline.getOrElse(false), Some(filename))
+      Ok.chunked(logStreamFailures(csvSource, filename), inline.getOrElse(false), Some(filename))
         .as("text/csv")
         .withHeaders(CONTENT_DISPOSITION -> s"attachment; filename=$filename")
     )
@@ -207,7 +237,7 @@ abstract class BaseApiController(cc: CustomControllerComponents)(implicit ec: Ex
       .intersperse("""{"type":"FeatureCollection","features":[""", ",", "]}")
 
     Future.successful(
-      Ok.chunked(jsonSource, inline.getOrElse(false), Some(filename))
+      Ok.chunked(logStreamFailures(jsonSource, filename), inline.getOrElse(false), Some(filename))
         .as(ContentTypes.JSON)
     )
   }
@@ -230,7 +260,7 @@ abstract class BaseApiController(cc: CustomControllerComponents)(implicit ec: Ex
       .intersperse("[", ",", "]")
 
     Future.successful(
-      Ok.chunked(jsonSource, inline.getOrElse(false), Some(filename))
+      Ok.chunked(logStreamFailures(jsonSource, filename), inline.getOrElse(false), Some(filename))
         .as(ContentTypes.JSON)
     )
   }


### PR DESCRIPTION
Addresses the silent-failure half of #4161 (and likely a contributor to #4133).

## Problem
The v3 API streams CSV/JSON/GeoJSON via `Ok.chunked`, which commits a **200 status and headers before** the underlying DB stream runs. If the stream then fails mid-flight — e.g. a query timeout or dropped connection while serializing a very large city's labels — the body just ends, and Play cannot retract the status it already sent. Today that failure is **completely silent**: the client gets a 200 with an empty/truncated body and there is *no server-side trace*. That's the reported #4161 symptom (Seattle `rawLabels` returns a 200 + 0-byte body after ~26s), and a plausible contributor to the #4133 shapefile failures.

## What this PR does
Adds `logStreamFailures()` — a `watchTermination` hook on the CSV/JSON/GeoJSON sources — that logs (with the download filename) whenever a streaming body terminates with a failure. Success behavior is unchanged.

## What this PR does NOT do
This is **observability, not the root-cause fix**. It makes the real failure diagnosable so we can pin the underlying cause on the largest deployments. Suggested follow-up diagnostics:
- Deploy, hit Seattle `/v3/api/rawLabels`, read the new error log line.
- Check `SHOW statement_timeout;` for the API's DB role on prod.
- `EXPLAIN ANALYZE` `getLabelDataWithFilters` for Seattle to see if it's slow vs. failing.

Longer term, the most reliable fix for the very largest exports is to move them off the synchronous chunked path (pre-generated files + progress), which would also cover #4133, #3861, and #3847.

## Verification
`sbt --client compile` clean; `StreetsApiSpec`, `BaseApiControllerSpec`, `RawLabelsApiSpec` (which consume real chunked bodies via a live Materializer) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
