### PR TITLE
Detach PanoMarker resize/pov_changed listeners on removal (#4231)

### DIFF
--- a/public/javascripts/common/PanoMarker.js
+++ b/public/javascripts/common/PanoMarker.js
@@ -127,9 +127,13 @@ class PanoMarker {
         this.marker_ = marker;
         this.markerContainer_.appendChild(marker);
 
-        // Attach to some global events.
-        window.addEventListener('resize', this.draw.bind(this));
-        this.panoViewer_.addListener('pov_changed', this.draw.bind(this));
+        // Attach to some global events. Keep a single bound reference (and the viewer it was registered on) so
+        // removeMarker can detach both listeners — otherwise each recreated marker leaks a window + pov_changed
+        // handler that keeps re-running draw() on a dead marker. See issue #4231.
+        this.boundDraw_ = this.draw.bind(this);
+        this.listenerViewer_ = this.panoViewer_;
+        window.addEventListener('resize', this.boundDraw_);
+        this.listenerViewer_.addListener('pov_changed', this.boundDraw_);
 
         // If this is a validation label, we want to add mouse-hovering event for popped up hide/show label.
         if (this.id_ === "validate-pano-marker") {
@@ -168,6 +172,9 @@ class PanoMarker {
      * Removes the marker.
      */
     removeMarker = function() {
+        // Detach the listeners registered in createMarker, by reference, so they don't accumulate (#4231).
+        window.removeEventListener('resize', this.boundDraw_);
+        this.listenerViewer_.removeListener('pov_changed', this.boundDraw_);
         this.marker_.parentNode.removeChild(this.marker_);
         this.marker_ = null;
     };


### PR DESCRIPTION
## Problem
Fixes #4231. `PanoMarker.createMarker` registered a `window` `resize` handler and a viewer `pov_changed` handler, each using a fresh `this.draw.bind(this)` reference, but `removeMarker` only tore down the DOM node. Because every `.bind()` produces a new function reference, the handlers were also unremovable by reference. Over a long validation session these accumulated, holding references to detached markers and re-running `draw()` on each dead marker on every resize / POV change.

## Fix
- In `createMarker`, store a single bound draw handler (`this.boundDraw_`) and the viewer it was attached to (`this.listenerViewer_`), and register both listeners with that reference.
- In `removeMarker`, detach both via `window.removeEventListener('resize', this.boundDraw_)` and `this.listenerViewer_.removeListener('pov_changed', this.boundDraw_)` before removing the DOM node.

The viewer's `removeListener` API already existed (`PanoViewer.js`) and matches by reference, so no new API was needed. Capturing `listenerViewer_` at registration (rather than reading `this.panoViewer_` at removal) keeps cleanup correct even if `setPanoViewer` is wired up later.

## Notes
- Both `removeMarker` call sites — `PanoManager.renderPanoMarker` (on a primary↔Pannellum viewer switch) and `PopupPanoManager.clearLabels` — are legitimate cleanup points, so listeners are now torn down wherever a marker is discarded.
- Went with the issue's primary recommendation (per-marker teardown) rather than the "shared handler per viewer" alternative: consumers hold very few simultaneous markers (Validate reuses a single `labelMarker`), so the structural-zero-listeners variant would add coupling to a widely-shared class for negligible real-world gain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)