### PR TITLE
Fix fire-and-forget DB writes in gallery and UTM paths (#4229)

### DIFF
--- a/app/controllers/ApplicationController.scala
+++ b/app/controllers/ApplicationController.scala
@@ -4,10 +4,8 @@ import controllers.base._
 import controllers.helper.ControllerUtils
 import controllers.helper.ControllerUtils.parseIntegerSeq
 import models.auth.{DefaultEnv, WithSignedIn}
-import models.user.{SidewalkUserWithRole, UserUtm, UserUtmTable}
-import models.utils.MyPostgresProfile
+import models.user.{SidewalkUserWithRole, UserUtm}
 import play.api.Configuration
-import play.api.db.slick.{DatabaseConfigProvider, HasDatabaseConfigProvider}
 import play.api.i18n.{Lang, Messages}
 import play.api.mvc._
 import play.silhouette.api.Silhouette
@@ -21,18 +19,15 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class ApplicationController @Inject() (
     cc: CustomControllerComponents,
-    protected val dbConfigProvider: DatabaseConfigProvider,
     val silhouette: Silhouette[DefaultEnv],
     val config: Configuration,
     configService: ConfigService,
     userService: UserService,
     streetService: StreetService,
     labelService: LabelService,
-    validationService: ValidationService,
-    userUtmTable: UserUtmTable
+    validationService: ValidationService
 )(implicit ec: ExecutionContext, assets: AssetsFinder)
-    extends CustomBaseController(cc)
-    with HasDatabaseConfigProvider[MyPostgresProfile] {
+    extends CustomBaseController(cc) {
   implicit val implicitConfig: Configuration = config
 
   def index = cc.securityService.SecuredAction { implicit request =>
@@ -59,16 +54,17 @@ class ApplicationController @Inject() (
         if (qString.nonEmpty) {
           // Log the query string parameters if they exist, but do a redirect to hide them.
           cc.loggingService.insert(user.userId, ipAddress, request.uri, timestamp)
-          // Save UTM parameters if present.
-          if (ControllerUtils.hasUtmParamsFlat(qString)) {
-            userUtmTable.insert(
-              UserUtm(
-                0, user.userId, qString.get("utm_source"), qString.get("utm_medium"), qString.get("utm_campaign"),
-                qString.get("utm_content"), qString.get("utm_term"), configService.getCityId, timestamp
+          // Save UTM parameters if present, awaiting the write so failures surface to the error handler (#4229).
+          val utmSaved: Future[_] =
+            if (ControllerUtils.hasUtmParamsFlat(qString)) {
+              userService.insertUserUtm(
+                UserUtm(
+                  0, user.userId, qString.get("utm_source"), qString.get("utm_medium"), qString.get("utm_campaign"),
+                  qString.get("utm_content"), qString.get("utm_term"), configService.getCityId, timestamp
+                )
               )
-            )
-          }
-          Future.successful(Redirect("/"))
+            } else Future.successful(())
+          utmSaved.map(_ => Redirect("/"))
         } else if (isMobile) {
           Future.successful(Redirect("/mobileLanding"))
         } else {

--- a/app/controllers/GalleryController.scala
+++ b/app/controllers/GalleryController.scala
@@ -5,7 +5,6 @@ import controllers.helper.ControllerUtils.parseIntegerSeq
 import formats.json.GalleryFormats._
 import formats.json.LabelFormats
 import models.auth.DefaultEnv
-import models.gallery.{GalleryTaskEnvironment, GalleryTaskEnvironmentTable, GalleryTaskInteraction, GalleryTaskInteractionTable}
 import models.label.LabelTypeEnum
 import models.utils.MyPostgresProfile
 import play.api.Configuration
@@ -14,7 +13,7 @@ import play.api.i18n.Messages
 import play.api.libs.json.{JsError, JsValue, Json}
 import play.api.mvc.{Action, AnyContent, Result}
 import play.silhouette.api.Silhouette
-import service.{ConfigService, LabelService, PanoDataService, RegionService}
+import service._
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
@@ -29,8 +28,7 @@ class GalleryController @Inject() (
     configService: ConfigService,
     labelService: LabelService,
     panoDataService: PanoDataService,
-    galleryTaskInteractionTable: GalleryTaskInteractionTable,
-    galleryTaskEnvironmentTable: GalleryTaskEnvironmentTable,
+    galleryService: GalleryService,
     regionService: RegionService
 )(implicit assets: AssetsFinder)
     extends CustomBaseController(cc)
@@ -134,28 +132,14 @@ class GalleryController @Inject() (
   }
 
   /**
-   * Take parsed JSON data and insert it into database.
+   * Take parsed JSON data and insert it into the database, only responding once the writes have committed.
    */
   def processGalleryTaskSubmissions(
       submission: Seq[GalleryTaskSubmission],
       ipAddress: String,
       userId: String
   ): Future[Result] = {
-    for (data <- submission) yield {
-      // Insert into interactions and environment tables.
-      val env: GalleryEnvironmentSubmission = data.environment
-      db.run(for {
-        nInteractionSubmitted <- galleryTaskInteractionTable.insertMultiple(data.interactions.map { action =>
-          GalleryTaskInteraction(0, action.action, action.panoId, action.note, action.timestamp, Some(userId))
-        })
-        _ <- galleryTaskEnvironmentTable.insert(
-          GalleryTaskEnvironment(0, env.browser, env.browserVersion, env.browserWidth, env.browserHeight,
-            env.availWidth, env.availHeight, env.screenWidth, env.screenHeight, env.operatingSystem, Some(ipAddress),
-            env.language, Some(userId))
-        )
-      } yield nInteractionSubmitted)
-    }
-    Future.successful(Ok("Got request"))
+    galleryService.submitGalleryTasks(submission, ipAddress, userId).map(_ => Ok("Got request"))
   }
 
   /**

--- a/app/controllers/UserController.scala
+++ b/app/controllers/UserController.scala
@@ -5,7 +5,7 @@ import controllers.helper.ControllerUtils
 import controllers.helper.ControllerUtils.parseURL
 import forms._
 import models.auth.{DefaultEnv, WithAdminOrIsUser}
-import models.user.{SidewalkUserWithRole, UserUtm, UserUtmTable}
+import models.user.{SidewalkUserWithRole, UserUtm}
 import net.ceedubs.ficus.Ficus._
 import play.api.i18n.Messages
 import play.api.libs.json.{JsError, Json}
@@ -31,7 +31,7 @@ class UserController @Inject() (
     val silhouette: Silhouette[DefaultEnv],
     configService: service.ConfigService,
     authenticationService: service.AuthenticationService,
-    userUtmTable: UserUtmTable,
+    userService: service.UserService,
     passwordHasher: PasswordHasher,
     clock: Clock,
     mailerClient: MailerClient
@@ -340,24 +340,27 @@ class UserController @Inject() (
           // Strip UTM params from redirect to avoid double-capture in index().
           qStringNoUtm = qString.filterNot { case (k, _) => k.startsWith("utm_") }
           result <- silhouette.env.authenticatorService.embed(value, Redirect(url, qStringNoUtm))
+
+          // Save UTM parameters if present, awaiting the write so failures surface to the error handler (#4229). UTM
+          // params are stripped from the redirect URL (above) to avoid double-capture when index() also checks for UTM
+          // params on returning users.
+          _ <- {
+            if (ControllerUtils.hasUtmParams(qString)) {
+              val flat = qString.map { case (k, v) => k -> v.mkString }
+              userService.insertUserUtm(
+                UserUtm(
+                  0, user.userId, flat.get("utm_source"), flat.get("utm_medium"), flat.get("utm_campaign"),
+                  flat.get("utm_content"), flat.get("utm_term"), configService.getCityId, java.time.OffsetDateTime.now
+                )
+              )
+            } else Future.successful(())
+          }
         } yield {
           // Log the anon sign-up along with url and query string of the page they came from.
           val activityStr =
             if (qString.isEmpty) s"""AnonAutoSignUp_url="$url""""
             else s"""AnonAutoSignUp_url="$url?${qString.map { case (k, v) => k + "=" + v.mkString }.mkString("&")}""""
           cc.loggingService.insert(user.userId, request.ipAddress, activityStr)
-
-          // Save UTM parameters if present. UTM params are stripped from the redirect URL (line above) to avoid
-          // double-capture when index() also checks for UTM params on returning users.
-          if (ControllerUtils.hasUtmParams(qString)) {
-            val flat = qString.map { case (k, v) => k -> v.mkString }
-            userUtmTable.insert(
-              UserUtm(
-                0, user.userId, flat.get("utm_source"), flat.get("utm_medium"), flat.get("utm_campaign"),
-                flat.get("utm_content"), flat.get("utm_term"), configService.getCityId, java.time.OffsetDateTime.now
-              )
-            )
-          }
 
           silhouette.env.eventBus.publish(SignUpEvent(user, request))
           silhouette.env.eventBus.publish(LoginEvent(user, request))

--- a/app/models/user/UserUtmTable.scala
+++ b/app/models/user/UserUtmTable.scala
@@ -7,7 +7,6 @@ import play.api.db.slick.{DatabaseConfigProvider, HasDatabaseConfigProvider}
 
 import java.time.OffsetDateTime
 import javax.inject._
-import scala.concurrent.Future
 
 case class UserUtm(
     userUtmId: Int,
@@ -54,7 +53,7 @@ class UserUtmTable @Inject() (protected val dbConfigProvider: DatabaseConfigProv
 
   val userUtms = TableQuery[UserUtmTableDef]
 
-  def insert(utm: UserUtm): Future[Int] = {
-    db.run((userUtms returning userUtms.map(_.userUtmId)) += utm)
+  def insert(utm: UserUtm): DBIO[Int] = {
+    (userUtms returning userUtms.map(_.userUtmId)) += utm
   }
 }

--- a/app/service/GalleryService.scala
+++ b/app/service/GalleryService.scala
@@ -1,0 +1,59 @@
+package service
+
+import com.google.inject.ImplementedBy
+import formats.json.GalleryFormats.GalleryTaskSubmission
+import models.gallery._
+import models.utils.MyPostgresProfile
+import models.utils.MyPostgresProfile.api._
+import play.api.db.slick.{DatabaseConfigProvider, HasDatabaseConfigProvider}
+
+import javax.inject._
+import scala.concurrent.{ExecutionContext, Future}
+
+@ImplementedBy(classOf[GalleryServiceImpl])
+trait GalleryService {
+  def submitGalleryTasks(
+      submissions: Seq[GalleryTaskSubmission],
+      ipAddress: String,
+      userId: String
+  ): Future[Seq[Int]]
+}
+
+@Singleton
+class GalleryServiceImpl @Inject() (
+    protected val dbConfigProvider: DatabaseConfigProvider,
+    galleryTaskInteractionTable: GalleryTaskInteractionTable,
+    galleryTaskEnvironmentTable: GalleryTaskEnvironmentTable,
+    implicit val ec: ExecutionContext
+) extends GalleryService
+    with HasDatabaseConfigProvider[MyPostgresProfile] {
+
+  /**
+   * Persists the interaction and environment data for a batch of Gallery task submissions.
+   *
+   * @param submissions Parsed Gallery task submissions, each carrying its interactions and environment.
+   * @param ipAddress   IP address of the submitting user, stored on the environment row.
+   * @param userId      ID of the submitting user, stored on both interaction and environment rows.
+   * @return            The number of interactions inserted per submission.
+   */
+  def submitGalleryTasks(
+      submissions: Seq[GalleryTaskSubmission],
+      ipAddress: String,
+      userId: String
+  ): Future[Seq[Int]] = {
+    val submissionActions: Seq[DBIO[Int]] = submissions.map { data =>
+      val env = data.environment
+      for {
+        nInteractionSubmitted <- galleryTaskInteractionTable.insertMultiple(data.interactions.map { action =>
+          GalleryTaskInteraction(0, action.action, action.panoId, action.note, action.timestamp, Some(userId))
+        })
+        _ <- galleryTaskEnvironmentTable.insert(
+          GalleryTaskEnvironment(0, env.browser, env.browserVersion, env.browserWidth, env.browserHeight,
+            env.availWidth, env.availHeight, env.screenWidth, env.screenHeight, env.operatingSystem, Some(ipAddress),
+            env.language, Some(userId))
+        )
+      } yield nInteractionSubmitted.length
+    }
+    db.run(DBIO.sequence(submissionActions).transactionally)
+  }
+}

--- a/app/service/UserService.scala
+++ b/app/service/UserService.scala
@@ -68,6 +68,7 @@ trait UserService {
   def getLabelLocations(userId: String, regionId: Option[Int] = None): Future[Seq[LabelLocation]]
   def updateTaskFlag(auditTaskId: Int, flag: String, state: Boolean): Future[Int]
   def updateTaskFlagsBeforeDate(userId: String, date: OffsetDateTime, flag: String, state: Boolean): Future[Int]
+  def insertUserUtm(utm: UserUtm): Future[Int]
 }
 
 @Singleton
@@ -82,6 +83,7 @@ class UserServiceImpl @Inject() (
     streetService: StreetService,
     userTeamTable: UserTeamTable,
     teamTable: TeamTable,
+    userUtmTable: UserUtmTable,
     implicit val ec: ExecutionContext
 ) extends UserService
     with HasDatabaseConfigProvider[MyPostgresProfile] {
@@ -206,4 +208,6 @@ class UserServiceImpl @Inject() (
     require(flag == "low_quality" || flag == "incomplete" || flag == "stale")
     db.run(auditTaskTable.updateTaskFlagsBeforeDate(userId, date, flag, state))
   }
+
+  def insertUserUtm(utm: UserUtm): Future[Int] = db.run(userUtmTable.insert(utm))
 }


### PR DESCRIPTION
Closes #4229.

## Problem
Several write paths returned an HTTP success **before** their DB writes were guaranteed to run, discarding both the result and any failure — so data could be silently lost (and was undiagnosable in production).

## Changes

### Gallery submissions
`GalleryController.processGalleryTaskSubmissions` previously built a discarded `Seq[Future[...]]` of `db.run(...)` calls and unconditionally returned `Ok("Got request")` — interaction/environment writes were never awaited and failures never observed.

- New **`GalleryService.submitGalleryTasks`** sequences each submission's interaction-inserts + environment-insert into a single **`DBIO.sequence(...).transactionally`** and runs it once.
- `GalleryController` now delegates to the service and maps the resulting `Future` to the `Result`, so failures reach the error handler. The controller no longer injects the gallery tables or calls `db.run` directly.

### UTM analytics inserts
`userUtmTable.insert(...)` returned a `Future[Int]` that was discarded in two places, so UTM writes failed silently.

- **`UserUtmTable.insert`** now returns a `DBIO[Int]` (DAO convention — services own `db.run`).
- New **`UserService.insertUserUtm`**.
- **`ApplicationController.index`** and **`UserController.signUpAnon`** now await the insert (chaining the redirect/result off it) so failures surface instead of being swallowed.

## Testing
- `sbt --client compile` passes clean (warning-clean under `-Xfatal-warnings`).
- No existing tests reference the changed signatures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)