### PR TITLE
Adopt RFC 7807 problem+json for API errors + handler integration (#3931)

### DIFF
--- a/app/controllers/api/BaseApiController.scala
+++ b/app/controllers/api/BaseApiController.scala
@@ -9,7 +9,6 @@ import org.apache.pekko.stream.scaladsl.{Source, StreamConverters}
 import org.apache.pekko.util.ByteString
 import play.api.Logger
 import play.api.http.ContentTypes
-import play.api.libs.json.Json
 import play.api.mvc.Result
 
 import java.io.{BufferedInputStream, File}
@@ -136,8 +135,8 @@ abstract class BaseApiController(cc: CustomControllerComponents)(implicit ec: Ex
       }
   }
 
-  /** Builds a 400 Bad Request response from an `ApiError`. */
-  protected def badRequest(error: ApiError): Result = BadRequest(Json.toJson(error))
+  /** Renders an `ApiError` as an RFC 7807 `application/problem+json` response with the error's HTTP status. */
+  protected def badRequest(error: ApiError): Result = ApiError.toResult(error)
 
   // Instance method wrappers — delegate to the companion object so the pure logic is unit-testable without DI.
   protected def validateBBoxParam(bbox: Option[String], parsed: Option[LatLngBBox]): Option[ApiError] =
@@ -294,7 +293,7 @@ abstract class BaseApiController(cc: CustomControllerComponents)(implicit ec: Ex
             .withHeaders(CONTENT_DISPOSITION -> s"attachment; filename=$baseFileName.zip")
 
         case None =>
-          InternalServerError("Failed to create shapefile")
+          ApiError.toResult(ApiError.internalServerError("Failed to create shapefile"))
       }
   }
 
@@ -336,21 +335,13 @@ abstract class BaseApiController(cc: CustomControllerComponents)(implicit ec: Ex
 
         case None =>
           logger.error("Failed to create GeoPackage file")
-          InternalServerError(
-            Json.toJson(
-              ApiError.internalServerError("Failed to create GeoPackage file")
-            )
-          )
+          ApiError.toResult(ApiError.internalServerError("Failed to create GeoPackage file"))
       }
     } catch {
       case e: Exception =>
         logger.error(s"Error creating GeoPackage output: ${e.getMessage}", e)
         Future.successful(
-          InternalServerError(
-            Json.toJson(
-              ApiError.internalServerError(s"Error creating GeoPackage: ${e.getMessage}")
-            )
-          )
+          ApiError.toResult(ApiError.internalServerError(s"Error creating GeoPackage: ${e.getMessage}"))
         )
     }
   }

--- a/app/controllers/api/CitiesApiController.scala
+++ b/app/controllers/api/CitiesApiController.scala
@@ -93,7 +93,7 @@ class CitiesApiController @Inject() (
       }
       .recover { case e: Exception =>
         logger.error(s"Failed to retrieve city information: ${e.getMessage}", e)
-        InternalServerError(Json.toJson(ApiError.internalServerError(s"Failed to retrieve city information: ${e.getMessage}")))
+        ApiError.toResult(ApiError.internalServerError(s"Failed to retrieve city information: ${e.getMessage}"))
       }
   }
 

--- a/app/controllers/api/LabelApiController.scala
+++ b/app/controllers/api/LabelApiController.scala
@@ -109,11 +109,7 @@ class LabelApiController @Inject() (
         Ok(Json.obj("status" -> "OK", "label_tags" -> formattedTags))
       }
       .recover { case e: Exception =>
-        InternalServerError(
-          Json.toJson(
-            ApiError.internalServerError(s"Failed to retrieve label tags: ${e.getMessage}")
-          )
-        )
+        ApiError.toResult(ApiError.internalServerError(s"Failed to retrieve label tags: ${e.getMessage}"))
       }
   }
 
@@ -173,41 +169,35 @@ class LabelApiController @Inject() (
 
     firstError match {
       case Some(error) => Future.successful(badRequest(error))
-      case None =>
+      case None        =>
         configService.getCityMapParams.flatMap { cityMapParams =>
-        val (finalBbox, finalRegionId, finalRegionName) = resolveGeoFilters(bbox, parsedBbox, regionId, regionName, cityMapParams)
+          val (finalBbox, finalRegionId, finalRegionName) =
+            resolveGeoFilters(bbox, parsedBbox, regionId, regionName, cityMapParams)
 
-        // Create filters object.
-        val filters = RawLabelFiltersForApi(
-          bbox = finalBbox,
-          labelTypes = parsedLabelTypes,
-          tags = parsedTags,
-          minSeverity = minSeverity,
-          maxSeverity = maxSeverity,
-          validationStatus = parsedValidationStatus.toOption.flatten,
-          highQualityUserOnly = highQualityUserOnly.getOrElse(false),
-          startDate = parsedStartDate.toOption.flatten,
-          endDate = parsedEndDate.toOption.flatten,
-          regionId = finalRegionId,
-          regionName = finalRegionName
-        )
+          // Create filters object.
+          val filters = RawLabelFiltersForApi(
+            bbox = finalBbox, labelTypes = parsedLabelTypes, tags = parsedTags, minSeverity = minSeverity,
+            maxSeverity = maxSeverity, validationStatus = parsedValidationStatus.toOption.flatten,
+            highQualityUserOnly = highQualityUserOnly.getOrElse(false), startDate = parsedStartDate.toOption.flatten,
+            endDate = parsedEndDate.toOption.flatten, regionId = finalRegionId, regionName = finalRegionName
+          )
 
-        // Get the data stream.
-        val dbDataStream: Source[LabelDataForApi, _] = apiService.getRawLabels(filters, DEFAULT_BATCH_SIZE)
-        val baseFileName: String                     = s"labels_${OffsetDateTime.now()}"
+          // Get the data stream.
+          val dbDataStream: Source[LabelDataForApi, _] = apiService.getRawLabels(filters, DEFAULT_BATCH_SIZE)
+          val baseFileName: String                     = s"labels_${OffsetDateTime.now()}"
 
-        // Output data in the appropriate file format.
-        filetype match {
-          case Some("csv") =>
-            outputCSV(dbDataStream, LabelDataForApi.csvHeader, inline, baseFileName + ".csv")
-          case Some("shapefile") =>
-            outputShapefile(dbDataStream, baseFileName, shapefileCreator.createRawLabelShapefile, shapefileCreator)
-          case Some("geopackage") =>
-            outputGeopackage(dbDataStream, baseFileName, shapefileCreator.createRawLabelDataGeopackage, inline)
-          case _ => // Default to GeoJSON.
-            outputGeoJSON(dbDataStream, inline, baseFileName + ".json")
+          // Output data in the appropriate file format.
+          filetype match {
+            case Some("csv") =>
+              outputCSV(dbDataStream, LabelDataForApi.csvHeader, inline, baseFileName + ".csv")
+            case Some("shapefile") =>
+              outputShapefile(dbDataStream, baseFileName, shapefileCreator.createRawLabelShapefile, shapefileCreator)
+            case Some("geopackage") =>
+              outputGeopackage(dbDataStream, baseFileName, shapefileCreator.createRawLabelDataGeopackage, inline)
+            case _ => // Default to GeoJSON.
+              outputGeoJSON(dbDataStream, inline, baseFileName + ".json")
+          }
         }
-      }
     }
   }
 
@@ -222,10 +212,13 @@ class LabelApiController @Inject() (
     case Some("validated_correct")   => Right(Some("Agreed"))
     case Some("validated_incorrect") => Right(Some("Disagreed"))
     case Some("unvalidated")         => Right(Some("Unvalidated"))
-    case Some(_) =>
-      Left(ApiError.invalidParameter(
-        "Invalid validationStatus value. Must be one of: validated_correct, validated_incorrect, unvalidated",
-        "validationStatus"))
+    case Some(_)                     =>
+      Left(
+        ApiError.invalidParameter(
+          "Invalid validationStatus value. Must be one of: validated_correct, validated_incorrect, unvalidated",
+          "validationStatus"
+        )
+      )
   }
 
   /**

--- a/app/controllers/api/LabelClustersApiController.scala
+++ b/app/controllers/api/LabelClustersApiController.scala
@@ -7,7 +7,6 @@ import org.apache.pekko.stream.Materializer
 import org.apache.pekko.stream.scaladsl.Source
 import org.apache.pekko.util.ByteString
 import play.api.i18n.Lang.logger
-import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent}
 import play.silhouette.api.Silhouette
 import service.{ApiService, ConfigService}
@@ -161,9 +160,7 @@ class LabelClustersApiController @Inject() (
                 Files.deleteIfExists(labelCsvPath)
                 logger.error(s"Error generating label clusters CSV: ${e.getMessage}", e)
                 Future.successful(
-                  InternalServerError(
-                    Json.toJson(ApiError.internalServerError(s"Error processing request: ${e.getMessage}"))
-                  )
+                  ApiError.toResult(ApiError.internalServerError(s"Error processing request: ${e.getMessage}"))
                 )
               }
           case Some("csv") =>
@@ -179,7 +176,7 @@ class LabelClustersApiController @Inject() (
                     .as("application/zip")
                     .withHeaders(CONTENT_DISPOSITION -> s"attachment; filename=$baseFileName.zip")
                 case None =>
-                  InternalServerError("Failed to create shapefile")
+                  ApiError.toResult(ApiError.internalServerError("Failed to create shapefile"))
               }
           case Some("shapefile") =>
             outputShapefile(

--- a/app/controllers/api/RegionApiController.scala
+++ b/app/controllers/api/RegionApiController.scala
@@ -102,7 +102,7 @@ class RegionApiController @Inject() (
         cc.loggingService.insert(request.identity.map(_.userId), request.ipAddress, request.toString)
         Ok(Json.toJson(region))
       case None =>
-        NotFound(Json.toJson(ApiError.notFound("No region found with labels")))
+        ApiError.toResult(ApiError.notFound("No region found with labels"))
     }
   }
 }

--- a/app/controllers/api/StatsApiController.scala
+++ b/app/controllers/api/StatsApiController.scala
@@ -199,7 +199,7 @@ class StatsApiController @Inject() (
       }
       .recover { case e: Exception =>
         logger.error(s"Failed to retrieve aggregate statistics: ${e.getMessage}", e)
-        InternalServerError(Json.toJson(ApiError.internalServerError(s"Failed to retrieve aggregate statistics: ${e.getMessage}")))
+        ApiError.toResult(ApiError.internalServerError(s"Failed to retrieve aggregate statistics: ${e.getMessage}"))
       }
   }
 
@@ -353,7 +353,7 @@ class StatsApiController @Inject() (
       filetype: Option[String]
   ) = silhouette.UserAwareAction.async { implicit request =>
     parseDateParams(startDate, endDate) match {
-      case Left(err) => Future.successful(BadRequest(Json.toJson(err)))
+      case Left(err) => Future.successful(ApiError.toResult(err))
       case Right((start, end)) =>
         apiService.getOverallStatsByDay(start, end, filterLowQuality).map { stats =>
           cc.loggingService.insert(request.identity.map(_.userId), request.ipAddress, request.toString)
@@ -379,7 +379,7 @@ class StatsApiController @Inject() (
       filetype: Option[String]
   ) = silhouette.UserAwareAction.async { implicit request =>
     parseDateParams(startDate, endDate) match {
-      case Left(err) => Future.successful(BadRequest(Json.toJson(err)))
+      case Left(err) => Future.successful(ApiError.toResult(err))
       case Right((start, end)) =>
         configService.getAggregateStatsByDay(start, end, filterLowQuality).map { stats =>
           cc.loggingService.insert(request.identity.map(_.userId), request.ipAddress, request.toString)

--- a/app/controllers/api/StreetsApiController.scala
+++ b/app/controllers/api/StreetsApiController.scala
@@ -107,11 +107,7 @@ class StreetsApiController @Inject() (
         Ok(Json.obj("status" -> "OK", "street_types" -> types))
       }
       .recover { case e: Exception =>
-        InternalServerError(
-          Json.toJson(
-            ApiError.internalServerError(s"Failed to retrieve street types: ${e.getMessage}")
-          )
-        )
+        ApiError.toResult(ApiError.internalServerError(s"Failed to retrieve street types: ${e.getMessage}"))
       }
   }
 }

--- a/app/controllers/api/ValidationApiController.scala
+++ b/app/controllers/api/ValidationApiController.scala
@@ -70,20 +70,26 @@ class ValidationApiController @Inject() (
     val firstError: Option[ApiError] = Seq(
       parsedTimestamp.left.toOption,
       if (validationResult.isDefined && parsedValidationResult.isEmpty)
-        Some(ApiError.invalidParameter(
-          "Invalid validationResult value. Must be Agree, Disagree, or Unsure.", "validationResult"))
+        Some(
+          ApiError
+            .invalidParameter("Invalid validationResult value. Must be Agree, Disagree, or Unsure.", "validationResult")
+        )
       else None,
       // Shapefiles are unsupported because validations have no geographic coordinates.
       if (filetype.contains("shapefile"))
-        Some(ApiError.invalidParameter(
-          "Shapefile format is not supported for validation data. Validations do not contain geographic " +
-            "coordinates. Use 'json' or 'csv' format instead.", "filetype"))
+        Some(
+          ApiError.invalidParameter(
+            "Shapefile format is not supported for validation data. Validations do not contain geographic " +
+              "coordinates. Use 'json' or 'csv' format instead.",
+            "filetype"
+          )
+        )
       else None
     ).flatten.headOption
 
     firstError match {
       case Some(error) => Future.successful(badRequest(error))
-      case None =>
+      case None        =>
         // Create filters object and get the data stream.
         val filters = ValidationFiltersForApi(
           labelId = labelId, userId = userId, validationResult = parsedValidationResult, labelTypeId = labelTypeId,
@@ -119,7 +125,7 @@ class ValidationApiController @Inject() (
         Ok(Json.obj("status" -> "OK", "validation_result_types" -> validationTypes))
       }
       .recover { case e: Exception =>
-        InternalServerError(Json.toJson(ApiError.internalServerError(s"Error retrieving validation result types: ${e.getMessage}")))
+        ApiError.toResult(ApiError.internalServerError(s"Error retrieving validation result types: ${e.getMessage}"))
       }
   }
 }

--- a/app/models/api/ApiErrorModels.scala
+++ b/app/models/api/ApiErrorModels.scala
@@ -1,72 +1,115 @@
 /**
- * Error models for the Project Sidewalk API.
- * TODO replace this with Play's built-in error handling.
+ * RFC 7807 "Problem Details for HTTP APIs" error model for the Project Sidewalk API.
+ *
+ * Every error the `/v3/api` surface returns — whether raised by a controller (e.g. an invalid query
+ * parameter) or by the framework via `CustomErrorHandler` (an unknown route, an unhandled exception) — is
+ * serialized as an RFC 7807 problem detail with the `application/problem+json` content type, so consumers
+ * get one consistent, machine-readable error schema across the whole API (#3931).
  */
 package models.api
 
-import play.api.libs.json.{Json, OFormat}
+import play.api.libs.json.{JsString, Json, Writes}
+import play.api.mvc.{Result, Results}
 
 /**
- * Represents an API error response with standard HTTP status codes and error details.
+ * An RFC 7807 problem detail describing a single API error.
  *
- * @param status HTTP status code (e.g., 400, 404, 500)
- * @param code Machine-readable error code (e.g., "BAD_REQUEST", "NOT_FOUND")
- * @param message Human-readable error message
- * @param parameter Optional parameter name that caused the error
+ * The first four fields are the standard RFC 7807 members; `code` and `parameter` are Project Sidewalk
+ * extension members (allowed by the spec). `code` is a stable machine-readable discriminator that consumers
+ * can branch on without dereferencing `problemType`; `parameter` names the offending query/REST parameter
+ * for validation errors.
+ *
+ * @param status      HTTP status code (also echoed in the body per RFC 7807).
+ * @param code        Stable machine-readable error code (e.g. "INVALID_PARAMETER", "NOT_FOUND").
+ * @param title       Short, human-readable summary of the problem type; stable for a given `code`.
+ * @param detail      Human-readable explanation specific to this occurrence.
+ * @param parameter   Name of the query/REST parameter that caused the error, if applicable.
+ * @param problemType RFC 7807 `type` URI. Defaults to "about:blank" (no type beyond the status code).
  */
-case class ApiError(status: Int, code: String, message: String, parameter: Option[String] = None)
+case class ApiError(
+    status: Int,
+    code: String,
+    title: String,
+    detail: String,
+    parameter: Option[String] = None,
+    problemType: String = "about:blank"
+)
 
 /**
- * Companion object for ApiError containing JSON formatter and factory methods
- * for common error types.
+ * Companion object for ApiError: JSON serialization, the `application/problem+json` renderer, and factory
+ * methods for the error types the API raises.
  */
 object ApiError {
-  implicit val apiErrorFormat: OFormat[ApiError] = Json.format[ApiError]
+
+  /** RFC 7807 media type for problem detail responses. */
+  val ContentType: String = "application/problem+json"
 
   /**
-   * Creates a generic Bad Request (400) error.
-   *
-   * @param message Human-readable error message
-   * @param parameter Optional parameter name that caused the error
-   * @return An ApiError instance with status 400
+   * Serializes an ApiError as an RFC 7807 problem object. Standard members (`type`, `title`, `status`,
+   * `detail`) are emitted first, followed by the extension members (`code`, and `parameter` when present).
    */
-  def badRequest(message: String, parameter: Option[String] = None): ApiError =
-    ApiError(400, "BAD_REQUEST", message, parameter)
+  implicit val writes: Writes[ApiError] = (e: ApiError) => {
+    val base = Json.obj(
+      "type"   -> e.problemType,
+      "title"  -> e.title,
+      "status" -> e.status,
+      "detail" -> e.detail,
+      "code"   -> e.code
+    )
+    e.parameter.fold(base)(p => base + ("parameter" -> JsString(p)))
+  }
 
   /**
-   * Creates an Invalid Parameter (400) error with a specific parameter name.
-   *
-   * @param message Human-readable error message
-   * @param parameter Name of the parameter that was invalid
-   * @return An ApiError instance with status 400 and code INVALID_PARAMETER
+   * Renders an ApiError as a Play `Result` with its HTTP status and the `application/problem+json` content
+   * type. Centralizing rendering here keeps every error site — controllers and the error handler — emitting
+   * the identical envelope and media type.
    */
-  def invalidParameter(message: String, parameter: String): ApiError =
-    ApiError(400, "INVALID_PARAMETER", message, Some(parameter))
+  def toResult(error: ApiError): Result = Results.Status(error.status)(Json.toJson(error)).as(ContentType)
 
   /**
-   * Creates an Internal Server Error (500) response.
+   * Creates a 400 problem detail for an invalid query/REST parameter.
    *
-   * @param message Human-readable error message
-   * @return An ApiError instance with status 500
+   * @param detail    Human-readable explanation of why the value was rejected.
+   * @param parameter Name of the offending parameter.
    */
-  def internalServerError(message: String): ApiError =
-    ApiError(500, "INTERNAL_SERVER_ERROR", message, None)
+  def invalidParameter(detail: String, parameter: String): ApiError =
+    ApiError(400, "INVALID_PARAMETER", "Invalid Parameter", detail, Some(parameter))
 
   /**
-   * Creates a Not Implemented (501) error response.
+   * Creates a 500 problem detail for an unexpected server-side failure.
    *
-   * @param message Human-readable error message
-   * @return An ApiError instance with status 501
+   * @param detail Human-readable explanation (avoid leaking internal exception details to clients).
    */
-  def notImplemented(message: String): ApiError =
-    ApiError(501, "NOT_IMPLEMENTED", message, None)
+  def internalServerError(detail: String): ApiError =
+    ApiError(500, "INTERNAL_SERVER_ERROR", "Internal Server Error", detail)
 
   /**
-   * Creates a Not Found (404) error response.
+   * Creates a 404 problem detail for a missing resource.
    *
-   * @param message Human-readable error message
-   * @return An ApiError instance with status 404
+   * @param detail Human-readable explanation of what was not found.
    */
-  def notFound(message: String): ApiError =
-    ApiError(404, "NOT_FOUND", message, None)
+  def notFound(detail: String): ApiError =
+    ApiError(404, "NOT_FOUND", "Not Found", detail)
+
+  /**
+   * Builds a problem detail for a framework-level error from a raw HTTP status code, mapping it to a stable
+   * `code`/`title`. Used by `CustomErrorHandler` to render Play's automatic client/server errors (unknown
+   * route, malformed typed route param, unhandled exception) in the same RFC 7807 envelope.
+   *
+   * @param status HTTP status code Play produced for the error.
+   * @param detail Human-readable explanation for this occurrence.
+   */
+  def forStatus(status: Int, detail: String): ApiError = {
+    val (code, title) = status match {
+      case 400               => ("BAD_REQUEST", "Bad Request")
+      case 401               => ("UNAUTHORIZED", "Unauthorized")
+      case 403               => ("FORBIDDEN", "Forbidden")
+      case 404               => ("NOT_FOUND", "Not Found")
+      case 405               => ("METHOD_NOT_ALLOWED", "Method Not Allowed")
+      case 415               => ("UNSUPPORTED_MEDIA_TYPE", "Unsupported Media Type")
+      case s if s >= 500     => ("INTERNAL_SERVER_ERROR", "Internal Server Error")
+      case _                 => ("CLIENT_ERROR", "Client Error")
+    }
+    ApiError(status, code, title, detail)
+  }
 }

--- a/app/modules/CustomErrorHandler.scala
+++ b/app/modules/CustomErrorHandler.scala
@@ -1,5 +1,6 @@
 package modules
 
+import models.api.ApiError
 import play.api.http.DefaultHttpErrorHandler
 import play.api.http.Status.{FORBIDDEN, NOT_FOUND}
 import play.api.libs.typedmap.TypedMap
@@ -26,6 +27,13 @@ class CustomErrorHandler @Inject() (
 
   private val logger = Logger(this.getClass)
 
+  /**
+   * True for requests to the public data API. Framework-level errors on these paths are rendered as RFC 7807
+   * `application/problem+json` (matching what the API controllers emit) instead of the HTML/plain-text used for
+   * the rest of the site. Note `/v3/api-docs/...` does NOT match (those are HTML doc pages).
+   */
+  private def isApiRequest(request: RequestHeader): Boolean = request.path.startsWith("/v3/api/")
+
   override def onClientError(request: RequestHeader, statusCode: Int, message: String): Future[Result] = {
     // Don't log common, harmless 404s
     val shouldSkipLogging = (
@@ -33,7 +41,7 @@ class CustomErrorHandler @Inject() (
         request.path.endsWith(".map") ||              // Source maps
           request.path.startsWith("/.well-known/") || // Well-known URLs
           request.path == "/favicon.ico" ||           // Common favicon requests
-          request.path.endsWith("-india.json") // We only added the India files for en so far so we expect these.
+          request.path.endsWith("-india.json")        // We only added the India files for en so far so we expect these.
       )
     ) || // Beacon requests that we need to fix, but they happen constantly so we don't need this extra logging.
       (statusCode == FORBIDDEN && request.path.contains("Beacon"))
@@ -42,16 +50,35 @@ class CustomErrorHandler @Inject() (
       logger.warn(s"Client error occurred: ${request.uri} - $statusCode - $message")
       logUserInfo(request)
     }
-    statusCode match {
-      case NOT_FOUND => Future.successful(NotFound(views.html.errors.onHandlerNotFound(request)))
-      case _         => Future.successful(Status(statusCode)("A client error occurred: " + message))
+    // API requests get the same RFC 7807 problem+json envelope the controllers use, so framework-level errors
+    // (unknown route, malformed typed route param, etc.) are consistent with handler-level errors (#3931).
+    if (isApiRequest(request)) {
+      val detail = statusCode match {
+        case NOT_FOUND             => s"No API endpoint matches ${request.method} ${request.path}."
+        case _ if message.nonEmpty => message
+        case _                     => "The request could not be processed."
+      }
+      Future.successful(ApiError.toResult(ApiError.forStatus(statusCode, detail)))
+    } else {
+      statusCode match {
+        case NOT_FOUND => Future.successful(NotFound(views.html.errors.onHandlerNotFound(request)))
+        case _         => Future.successful(Status(statusCode)("A client error occurred: " + message))
+      }
     }
   }
 
   override def onServerError(request: RequestHeader, exception: Throwable): Future[Result] = {
     logger.info("Server error occurred: " + exception.getMessage, exception)
     logUserInfo(request)
-    super.onServerError(request, exception) // Continue with default error handling.
+    // API requests get a problem+json 500 (without leaking exception internals); other routes keep Play's default
+    // (dev error page / generic HTML) error handling.
+    if (isApiRequest(request)) {
+      Future.successful(
+        ApiError.toResult(ApiError.internalServerError("An internal error occurred while processing the request."))
+      )
+    } else {
+      super.onServerError(request, exception)
+    }
   }
 
   /**

--- a/app/views/apiDocs/accessScoreRegions.scala.html
+++ b/app/views/apiDocs/accessScoreRegions.scala.html
@@ -227,12 +227,7 @@
             <li><strong><code>400 Bad Request</code>:</strong> Invalid parameter values (e.g., malformed bounding box, non-positive or unknown region id).</li>
             <li><strong><code>500 Internal Server Error</code>:</strong> An unexpected error occurred on the server.</li>
         </ul>
-        <pre><code class="language-json">{
-    "status": 400,
-    "code": "INVALID_PARAMETER",
-    "message": "No region found with regionId 99999.",
-    "parameter": "regionId"
-}</code></pre>
+        @apiDocs.errorResponseBody()
     </div>
 
     <div class="api-section" id="best-practices-section">

--- a/app/views/apiDocs/accessScoreStreets.scala.html
+++ b/app/views/apiDocs/accessScoreStreets.scala.html
@@ -242,12 +242,7 @@
             <li><strong><code>400 Bad Request</code>:</strong> Invalid parameter values (e.g., malformed bounding box, non-positive or unknown region id).</li>
             <li><strong><code>500 Internal Server Error</code>:</strong> An unexpected error occurred on the server.</li>
         </ul>
-        <pre><code class="language-json">{
-    "status": 400,
-    "code": "INVALID_PARAMETER",
-    "message": "Invalid value for bbox parameter. Expected format: minLng,minLat,maxLng,maxLat.",
-    "parameter": "bbox"
-}</code></pre>
+        @apiDocs.errorResponseBody()
     </div>
 
     <div class="api-section" id="best-practices-section">

--- a/app/views/apiDocs/aggregateStats.scala.html
+++ b/app/views/apiDocs/aggregateStats.scala.html
@@ -151,13 +151,7 @@
             <li><strong><code>500 Internal Server Error</code>:</strong> An unexpected error occurred on the server.</li>
         </ul>
 
-        <h4 id="error-body">Error Response Body <a href="#error-body" class="permalink">#</a></h4>
-        <p>Error responses include a JSON body with the following structure:</p>
-        <pre><code class="language-json">{
-    "status": 500, // HTTP Status Code
-    "code": "INTERNAL_SERVER_ERROR", // Machine-readable error code
-    "message": "Failed to retrieve aggregate statistics: Database connection error" // Human-readable description
-}</code></pre>
+        @apiDocs.errorResponseBody()
     </div>
 }
 

--- a/app/views/apiDocs/cities.scala.html
+++ b/app/views/apiDocs/cities.scala.html
@@ -250,14 +250,7 @@ pittsburgh-pa,usa,Pittsburgh,"Pittsburgh, PA",https://sidewalk-pittsburgh-test.c
             <li><strong><code>503 Service Unavailable</code>:</strong> The server is temporarily unable to handle the request.</li>
         </ul>
 
-        <h4 id="error-body">Error Response Body <a href="#error-body" class="permalink">#</a></h4>
-        <p>Error responses include a JSON body with the following structure:</p>
-        <pre><code class="language-json">{
-    "status": 400, // HTTP Status Code
-    "code": "INVALID_PARAMETER", // Machine-readable error code
-    "message": "Invalid value for visibility parameter. Expected 'public' or 'private'.", // Human-readable description
-    "parameter": "visibility" // Optional: The specific parameter causing the error
-}</code></pre>
+        @apiDocs.errorResponseBody()
     </div>
 }
 

--- a/app/views/apiDocs/errorResponseBody.scala.html
+++ b/app/views/apiDocs/errorResponseBody.scala.html
@@ -1,0 +1,20 @@
+@**
+ * Shared documentation of the RFC 7807 (`application/problem+json`) error envelope returned by every v3 API
+ * endpoint. Rendered via `@@apiDocs.errorResponseBody()` so the error schema is documented in exactly one place
+ * (#3931) rather than copy-pasted (and drifting) across each endpoint page.
+ *@
+@()
+<h4 id="error-body">Error Response Body <a href="#error-body" class="permalink">#</a></h4>
+<p>
+    All errors are returned as <a href="https://www.rfc-editor.org/rfc/rfc7807" target="_blank">RFC 7807</a>
+    &ldquo;problem details&rdquo; with the <code>application/problem+json</code> content type and the following
+    structure:
+</p>
+<pre><code class="language-json">{
+    "type": "about:blank",          // RFC 7807 problem-type URI ("about:blank" means no type beyond the status)
+    "title": "Invalid Parameter",   // Short, human-readable summary of the problem type (stable for a given code)
+    "status": 400,                  // HTTP status code (also repeated in the body)
+    "detail": "Invalid value for the bbox parameter. Expected format: minLng,minLat,maxLng,maxLat.", // This occurrence
+    "code": "INVALID_PARAMETER",    // Stable, machine-readable error code you can branch on
+    "parameter": "bbox"             // Extension member: the specific parameter at fault (omitted when not applicable)
+}</code></pre>

--- a/app/views/apiDocs/labelClusters.scala.html
+++ b/app/views/apiDocs/labelClusters.scala.html
@@ -459,14 +459,7 @@
             <li><strong><code>500 Internal Server Error</code>:</strong> An unexpected error occurred on the server.</li>
         </ul>
 
-        <h4 id="error-body">Error Response Body <a href="#error-body" class="permalink">#</a></h4>
-        <p>Error responses include a JSON body with the following structure:</p>
-        <pre><code class="language-json">{
-    "status": 400, // HTTP Status Code repeated
-    "code": "INVALID_PARAMETER", // Machine-readable error code
-    "message": "Invalid value for bbox parameter. Expected format: minLng,minLat,maxLng,maxLat.", // Human-readable description
-    "parameter": "bbox" // Optional: The specific parameter causing the error
-}</code></pre>
+        @apiDocs.errorResponseBody()
     </div>
 
     <div class="api-section" id="data-cleaning-section">

--- a/app/views/apiDocs/labelTags.scala.html
+++ b/app/views/apiDocs/labelTags.scala.html
@@ -183,13 +183,7 @@
             <li><strong><code>503 Service Unavailable</code>:</strong> The server is temporarily unable to handle the request (e.g., during maintenance).</li>
         </ul>
 
-        <h4 id="error-body">Error Response Body <a href="#error-body" class="permalink">#</a></h4>
-        <p>Error responses include a JSON body with the following structure:</p>
-        <pre><code class="language-json">{
-    "status": 500, // HTTP Status Code
-    "code": "INTERNAL_SERVER_ERROR", // Machine-readable error code
-    "message": "Failed to retrieve label tags: Database connection error" // Human-readable description
-}</code></pre>
+        @apiDocs.errorResponseBody()
     </div>
 }
 

--- a/app/views/apiDocs/labelTypes.scala.html
+++ b/app/views/apiDocs/labelTypes.scala.html
@@ -197,13 +197,7 @@
             <li><strong><code>503 Service Unavailable</code>:</strong> The server is temporarily unable to handle the request (e.g., during maintenance).</li>
         </ul>
 
-        <h4 id="error-body">Error Response Body <a href="#error-body" class="permalink">#</a></h4>
-        <p>Error responses include a JSON body with the following structure:</p>
-        <pre><code class="language-json">{
-    "status": 500, // HTTP Status Code
-    "code": "INTERNAL_SERVER_ERROR", // Machine-readable error code
-    "message": "Failed to retrieve label types: Database connection error" // Human-readable description
-}</code></pre>
+        @apiDocs.errorResponseBody()
     </div>
 }
 

--- a/app/views/apiDocs/overallStats.scala.html
+++ b/app/views/apiDocs/overallStats.scala.html
@@ -362,14 +362,7 @@ CurbRamp AI No and Admin Majority Vote Concurs,48
             <li><strong><code>503 Service Unavailable</code>:</strong> The server is temporarily unable to handle the request.</li>
         </ul>
 
-        <h4 id="error-body">Error Response Body <a href="#error-body" class="permalink">#</a></h4>
-        <p>Error responses include a JSON body with the following structure:</p>
-        <pre><code class="language-json">{
-    "status": 400, // HTTP Status Code
-    "code": "INVALID_PARAMETER", // Machine-readable error code
-    "message": "Invalid value for filetype parameter. Expected 'csv' or 'json'.", // Human-readable description
-    "parameter": "filetype" // Optional: The specific parameter causing the error
-}</code></pre>
+        @apiDocs.errorResponseBody()
     </div>
 
     <div class="api-section" id="best-practices-section">

--- a/app/views/apiDocs/rawLabels.scala.html
+++ b/app/views/apiDocs/rawLabels.scala.html
@@ -565,14 +565,7 @@
             <li><strong><code>503 Service Unavailable</code>:</strong> The server is temporarily unable to handle the request (e.g., during maintenance).</li>
         </ul>
 
-        <h4 id="error-body">Error Response Body <a href="#error-body" class="permalink">#</a></h4>
-        <p>Error responses include a JSON body with the following structure:</p>
-        <pre><code class="language-json">{
-    "status": 400, // HTTP Status Code repeated
-    "code": "INVALID_PARAMETER", // Machine-readable error code
-    "message": "Invalid value for bbox parameter. Expected format: minLng,minLat,maxLng,maxLat.", // Human-readable description
-    "parameter": "bbox" // Optional: The specific parameter causing the error
-}</code></pre>
+        @apiDocs.errorResponseBody()
     </div>
 }
 

--- a/app/views/apiDocs/regions.scala.html
+++ b/app/views/apiDocs/regions.scala.html
@@ -298,14 +298,7 @@
             <li><strong><code>500 Internal Server Error</code>:</strong> An unexpected error occurred on the server.</li>
         </ul>
 
-        <h4 id="error-body">Error Response Body <a href="#error-body" class="permalink">#</a></h4>
-        <p>Error responses include a JSON body with the following structure:</p>
-        <pre><code class="language-json">{
-    "status": 400, // HTTP Status Code repeated
-    "code": "INVALID_PARAMETER", // Machine-readable error code
-    "message": "Invalid value for bbox parameter. Expected format: minLng,minLat,maxLng,maxLat.", // Human-readable description
-    "parameter": "bbox" // Optional: The specific parameter causing the error
-}</code></pre>
+        @apiDocs.errorResponseBody()
     </div>
 
     <div class="api-section" id="best-practices-section">

--- a/app/views/apiDocs/streetTypes.scala.html
+++ b/app/views/apiDocs/streetTypes.scala.html
@@ -157,13 +157,7 @@
             <li><strong><code>503 Service Unavailable</code>:</strong> The server is temporarily unable to handle the request (e.g., during maintenance).</li>
         </ul>
 
-        <h4 id="error-body">Error Response Body <a href="#error-body" class="permalink">#</a></h4>
-        <p>Error responses include a JSON body with the following structure:</p>
-        <pre><code class="language-json">{
-    "status": 500, // HTTP Status Code
-    "code": "INTERNAL_SERVER_ERROR", // Machine-readable error code
-    "message": "Failed to retrieve street types: Database connection error" // Human-readable description
-}</code></pre>
+        @apiDocs.errorResponseBody()
     </div>
 }
 

--- a/app/views/apiDocs/streets.scala.html
+++ b/app/views/apiDocs/streets.scala.html
@@ -377,14 +377,7 @@
             <li><strong><code>500 Internal Server Error</code>:</strong> An unexpected error occurred on the server.</li>
         </ul>
 
-        <h4 id="error-body">Error Response Body <a href="#error-body" class="permalink">#</a></h4>
-        <p>Error responses include a JSON body with the following structure:</p>
-        <pre><code class="language-json">{
-    "status": 400, // HTTP Status Code repeated
-    "code": "INVALID_PARAMETER", // Machine-readable error code
-    "message": "Invalid value for bbox parameter. Expected format: minLng,minLat,maxLng,maxLat.", // Human-readable description
-    "parameter": "bbox" // Optional: The specific parameter causing the error
-}</code></pre>
+        @apiDocs.errorResponseBody()
     </div>
 
     <div class="api-section" id="best-practices-section">

--- a/app/views/apiDocs/userStats.scala.html
+++ b/app/views/apiDocs/userStats.scala.html
@@ -292,14 +292,7 @@ bfab6670-0955-440c-abe8-01c2d20696ba,27,154.8437957763672,0.17436927556991577,tr
             <li><strong><code>503 Service Unavailable</code>:</strong> The server is temporarily unable to handle the request.</li>
         </ul>
 
-        <h4 id="error-body">Error Response Body <a href="#error-body" class="permalink">#</a></h4>
-        <p>Error responses include a JSON body with the following structure:</p>
-        <pre><code class="language-json">{
-    "status": 400, // HTTP Status Code
-    "code": "INVALID_PARAMETER", // Machine-readable error code
-    "message": "Invalid value for filetype parameter. Expected 'csv' or 'json'.", // Human-readable description
-    "parameter": "filetype" // Optional: The specific parameter causing the error
-}</code></pre>
+        @apiDocs.errorResponseBody()
     </div>
 
     <div class="api-section" id="best-practices-section">

--- a/app/views/apiDocs/validationResultTypes.scala.html
+++ b/app/views/apiDocs/validationResultTypes.scala.html
@@ -132,13 +132,7 @@
             <li><strong><code>500 Internal Server Error</code>:</strong> An unexpected error occurred on the server.</li>
         </ul>
 
-        <h4 id="error-body">Error Response Body <a href="#error-body" class="permalink">#</a></h4>
-        <p>Error responses include a JSON body with the following structure:</p>
-        <pre><code class="language-json">{
-    "status": 500, // HTTP Status Code
-    "code": "INTERNAL_SERVER_ERROR", // Machine-readable error code
-    "message": "Error retrieving validation result types: Database connection error" // Human-readable description
-}</code></pre>
+        @apiDocs.errorResponseBody()
     </div>
 }
 

--- a/app/views/apiDocs/validations.scala.html
+++ b/app/views/apiDocs/validations.scala.html
@@ -255,14 +255,7 @@
             <li><strong><code>503 Service Unavailable</code>:</strong> The server is temporarily unable to handle the request.</li>
         </ul>
 
-        <h4 id="error-body">Error Response Body <a href="#error-body" class="permalink">#</a></h4>
-        <p>Error responses include a JSON body with the following structure:</p>
-        <pre><code class="language-json">{
-    "status": 400,
-    "code": "INVALID_PARAMETER",
-    "message": "Invalid validationResult value. Must be Agree, Disagree, or Unsure.",
-    "parameter": "validationResult"
-}</code></pre>
+        @apiDocs.errorResponseBody()
     </div>
 
     <div class="api-section" id="validation-result-types-section">

--- a/test/controllers/api/ApiErrorHandlerSpec.scala
+++ b/test/controllers/api/ApiErrorHandlerSpec.scala
@@ -1,0 +1,71 @@
+package controllers.api
+
+import modules.CustomErrorHandler
+import org.apache.pekko.stream.Materializer
+import org.scalatestplus.play.PlaySpec
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+
+/**
+ * Verifies that framework-level errors (unknown route, malformed typed param, unhandled exception) on the public
+ * `/v3/api` surface are rendered as RFC 7807 `application/problem+json` by `CustomErrorHandler` — consistent with
+ * the controller-level errors — while non-API routes keep the site's HTML error handling (#3931).
+ *
+ * These exercise the error handler directly: Play's `route()` test helper returns `None` for an unmatched path
+ * (it never invokes the error handler), so an unknown-route 404 can't be asserted through `route()`.
+ */
+class ApiErrorHandlerSpec extends PlaySpec with GuiceOneAppPerSuite {
+
+  override def fakeApplication(): Application =
+    new GuiceApplicationBuilder().disable[modules.ActorModule].build()
+
+  implicit lazy val mat: Materializer     = app.materializer
+  private def handler: CustomErrorHandler = app.injector.instanceOf[CustomErrorHandler]
+
+  "CustomErrorHandler.onClientError" should {
+    "render a 404 on an unknown /v3/api path as RFC 7807 problem+json" in {
+      val resp = handler.onClientError(FakeRequest(GET, "/v3/api/doesNotExist"), NOT_FOUND, "")
+      status(resp) mustBe NOT_FOUND
+      contentType(resp) mustBe Some("application/problem+json")
+      val json = contentAsJson(resp)
+      (json \ "type").as[String] mustBe "about:blank"
+      (json \ "title").as[String] mustBe "Not Found"
+      (json \ "status").as[Int] mustBe 404
+      (json \ "code").as[String] mustBe "NOT_FOUND"
+      (json \ "detail").asOpt[String] mustBe defined
+    }
+
+    "render a 400 on a /v3/api path (e.g. malformed typed route param) as problem+json" in {
+      val resp = handler.onClientError(FakeRequest(GET, "/v3/api/streets"), BAD_REQUEST, "Cannot parse parameter")
+      status(resp) mustBe BAD_REQUEST
+      contentType(resp) mustBe Some("application/problem+json")
+      (contentAsJson(resp) \ "code").as[String] mustBe "BAD_REQUEST"
+    }
+
+    "NOT match /v3/api-docs paths (those are HTML doc pages)" in {
+      val resp = handler.onClientError(FakeRequest(GET, "/v3/api-docs/nope"), NOT_FOUND, "")
+      contentType(resp) mustBe Some("text/html")
+    }
+
+    "keep HTML error handling for non-API paths" in {
+      val resp = handler.onClientError(FakeRequest(GET, "/some-web-page"), NOT_FOUND, "")
+      status(resp) mustBe NOT_FOUND
+      contentType(resp) mustBe Some("text/html")
+    }
+  }
+
+  "CustomErrorHandler.onServerError" should {
+    "render a 500 on a /v3/api path as problem+json without leaking the exception detail" in {
+      val resp =
+        handler.onServerError(FakeRequest(GET, "/v3/api/streets"), new RuntimeException("secret-internal-detail"))
+      status(resp) mustBe INTERNAL_SERVER_ERROR
+      contentType(resp) mustBe Some("application/problem+json")
+      val json = contentAsJson(resp)
+      (json \ "code").as[String] mustBe "INTERNAL_SERVER_ERROR"
+      (json \ "detail").as[String] must not include "secret-internal-detail"
+    }
+  }
+}

--- a/test/controllers/api/RegionApiSpec.scala
+++ b/test/controllers/api/RegionApiSpec.scala
@@ -61,12 +61,14 @@ class RegionApiSpec extends PlaySpec with GuiceOneAppPerSuite {
           (contentAsJson(resp) \ "region_id").asOpt[Int] mustBe defined
 
         case 404 =>
-          // Must use the standard ApiError envelope, NOT an ad-hoc Json.obj.
-          contentType(resp) mustBe Some("application/json")
+          // Must use the standard RFC 7807 problem+json envelope, NOT an ad-hoc Json.obj (#3931).
+          contentType(resp) mustBe Some("application/problem+json")
           val json = contentAsJson(resp)
           (json \ "status").as[Int] mustBe 404
           (json \ "code").as[String] mustBe "NOT_FOUND"
-          (json \ "message").asOpt[String] mustBe defined
+          (json \ "title").as[String] mustBe "Not Found"
+          (json \ "type").as[String] mustBe "about:blank"
+          (json \ "detail").asOpt[String] mustBe defined // RFC 7807 renamed `message` -> `detail`.
 
         case other =>
           fail(s"Expected 200 or 404 but got $other")

--- a/test/controllers/api/StreetsApiSpec.scala
+++ b/test/controllers/api/StreetsApiSpec.scala
@@ -60,10 +60,17 @@ class StreetsApiSpec extends PlaySpec with GuiceOneAppPerSuite {
       body must not include "labelCount"
     }
 
-    "return 400 INVALID_PARAMETER for a malformed bbox" in {
+    "return 400 INVALID_PARAMETER for a malformed bbox, as an RFC 7807 problem+json body" in {
       val resp = route(app, FakeRequest(GET, "/v3/api/streets?bbox=not-a-bbox")).get
       status(resp) mustBe BAD_REQUEST
-      (contentAsJson(resp) \ "parameter").as[String] mustBe "bbox"
+      contentType(resp) mustBe Some("application/problem+json") // RFC 7807 media type (#3931).
+      val json = contentAsJson(resp)
+      (json \ "type").as[String] mustBe "about:blank"
+      (json \ "title").as[String] mustBe "Invalid Parameter"
+      (json \ "status").as[Int] mustBe 400
+      (json \ "code").as[String] mustBe "INVALID_PARAMETER"
+      (json \ "detail").asOpt[String] mustBe defined
+      (json \ "parameter").as[String] mustBe "bbox"
     }
 
     "return 400 INVALID_PARAMETER for a non-positive regionId" in {


### PR DESCRIPTION
Fixes #3931.

## TL;DR
The issue proposed dropping `ApiErrorModels` in favor of Play's built-in error handling. On inspection that would **regress** the API — Play's built-ins return plain-text/HTML, whereas the structured error envelope is the *best-practice* part. The real problem was **inconsistency**: controller errors were structured JSON, but framework-level errors (unknown route, unhandled exception) on `/v3/api` fell through to `CustomErrorHandler` and returned **HTML**.

So this keeps the structured envelope, upgrades it to the **RFC 7807 "Problem Details for HTTP APIs"** standard, and routes **all** API errors through it.

## Changes
- **`ApiError` → RFC 7807 problem detail.** Standard members `type` / `title` / `status` / `detail`, plus `code` (machine-readable, retained for easy branching) and `parameter` extension members. Rendered via `ApiError.toResult` with the **`application/problem+json`** content type. `message` was renamed to `detail`; `type`/`title` are new. Removed 2 dead factory methods.
- **Centralized rendering.** Every controller error site now goes through `ApiError.toResult`, so the envelope and media type are identical everywhere — no more ad-hoc `Json.toJson(...)` or plain-text `"Failed to create shapefile"` responses.
- **Handler integration.** `CustomErrorHandler` now emits the same problem+json for `/v3/api/*` framework errors: `onClientError` (404 unknown route, 4xx) and `onServerError` (500, without leaking exception internals). Non-API routes keep the site's HTML handling; `/v3/api-docs/*` is intentionally excluded.

⚠️ **Breaking change** to the v3 error schema (`message` → `detail`, new media type), made in place per the v3 "preview" policy (precedent #4223).

## Example
```http
HTTP/1.1 400 Bad Request
Content-Type: application/problem+json
```
```json
{
  "type": "about:blank",
  "title": "Invalid Parameter",
  "status": 400,
  "detail": "Invalid value for the bbox parameter. Expected format: minLng,minLat,maxLng,maxLat.",
  "code": "INVALID_PARAMETER",
  "parameter": "bbox"
}
```

## Docs
The per-endpoint "Error Response Body" examples duplicated a (now-wrong) schema across 15 pages. Replaced them all with a single shared partial — `apiDocs.errorResponseBody` — documenting the RFC 7807 envelope once.

## Tests (test-first)
- **New `ApiErrorHandlerSpec`** exercises the handler directly (Play's `route()` returns `None` for unmatched paths, so it can't test the unknown-route 404): unknown `/v3/api` 404, `/v3/api` 400, non-API HTML fallthrough, and a 500 that does **not** leak the exception detail.
- `RegionApiSpec` and `StreetsApiSpec` updated to assert the `application/problem+json` media type and `type`/`title`/`detail`.
- Full API suite green (**71 tests, 11 suites**). Worktree compiles warning-clean; touched files scalafmt-formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
