### PR TITLE
Add admin-only "not validated by an admin" LabelMap filter (#4243)

### DIFF
--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -134,13 +134,19 @@ class AdminController @Inject() (
               "coordinates" -> Json.arr(label.lng, label.lat)
             ),
             "properties" -> Json.obj(
-              "audit_task_id"     -> label.auditTaskId,
-              "label_id"          -> label.labelId,
-              "label_type"        -> label.labelType,
-              "severity"          -> label.severity,
-              "correct"           -> label.correct,
-              "high_quality_user" -> label.highQualityUser,
-              "ai_generated"      -> label.aiGenerated
+              "audit_task_id"        -> label.auditTaskId,
+              "label_id"             -> label.labelId,
+              "label_type"           -> label.labelType,
+              "severity"             -> label.severity,
+              "correct"              -> label.correct,
+              "has_validations"      -> label.hasValidations,
+              "has_admin_validation" -> label.hasAdminValidation,
+              "ai_validation"        -> label.aiValidation.map(_.toString),
+              "expired"              -> label.expired,
+              "has_backup"           -> label.hasBackup,
+              "high_quality_user"    -> label.highQualityUser,
+              "ai_generated"         -> label.aiGenerated,
+              "tags"                 -> label.tags
             )
           )
         }.seq
@@ -688,15 +694,19 @@ class AdminController @Inject() (
   def getApiAnalytics(excludeApiDocs: Boolean, days: Int) = cc.securityService.SecuredAction(WithAdmin()) {
     implicit request =>
       logger.debug(request.toString) // Added bc scalafmt doesn't like "implicit _" & compiler needs us to use request.
-      adminService.getApiAnalytics(excludeApiDocs, days).map { case (endpointCounts, dailyCounts, uniqueIps, formatCounts) =>
-        val totalCalls = endpointCounts.map(_.count).sum
-        Ok(Json.obj(
-          "endpoint_counts" -> endpointCounts.map(c => Json.obj("endpoint" -> c.endpoint, "count" -> c.count)),
-          "daily_counts"    -> dailyCounts.map(c => Json.obj("date" -> c.date, "count" -> c.count)),
-          "unique_ips"      -> uniqueIps,
-          "format_counts"   -> formatCounts.map(c => Json.obj("endpoint" -> c.endpoint, "format" -> c.format, "count" -> c.count)),
-          "total_calls"     -> totalCalls
-        ))
+      adminService.getApiAnalytics(excludeApiDocs, days).map {
+        case (endpointCounts, dailyCounts, uniqueIps, formatCounts) =>
+          val totalCalls = endpointCounts.map(_.count).sum
+          Ok(
+            Json.obj(
+              "endpoint_counts" -> endpointCounts.map(c => Json.obj("endpoint" -> c.endpoint, "count" -> c.count)),
+              "daily_counts"    -> dailyCounts.map(c => Json.obj("date" -> c.date, "count" -> c.count)),
+              "unique_ips"      -> uniqueIps,
+              "format_counts"   -> formatCounts
+                .map(c => Json.obj("endpoint" -> c.endpoint, "format" -> c.format, "count" -> c.count)),
+              "total_calls" -> totalCalls
+            )
+          )
       }
   }
 

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -81,6 +81,7 @@ case class LabelForLabelMap(
     lng: Double,
     correct: Option[Boolean],
     hasValidations: Boolean,
+    hasAdminValidation: Boolean,
     aiValidation: Option[ValidationOption.Value],
     expired: Boolean,
     hasBackup: Boolean,
@@ -1326,6 +1327,13 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
       routeIds: Seq[Int],
       aiValOptions: Seq[String]
   ): DBIO[Seq[LabelForLabelMap]] = {
+    // Label IDs with at least one validation from an Administrator or Owner.
+    val _adminValidatedLabelIds = for {
+      _lv <- labelValidations
+      _ur <- userRoles if _lv.userId === _ur.userId
+      _r  <- roleTable if _ur.roleId === _r.roleId && (_r.role === "Administrator" || _r.role === "Owner")
+    } yield _lv.labelId
+
     val _labels = for {
       (_l, _at, _us) <- labelsWithAuditTasksAndUserStats
       _lt            <- labelTypes if _l.labelTypeId === _lt.labelTypeId
@@ -1369,9 +1377,11 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
 
       // Grab the columns that we need for the LabelForLabelMap case class.
       query.map { case (l, lp, highQuality, labelType, expired, hasBackup, isAiUser, aiv) =>
-        val hasValidations = l.agreeCount > 0 || l.disagreeCount > 0 || l.unsureCount > 0
+        val hasValidations     = l.agreeCount > 0 || l.disagreeCount > 0 || l.unsureCount > 0
+        val hasAdminValidation = l.labelId.in(_adminValidatedLabelIds)
         (l.labelId, l.streetEdgeId, l.auditTaskId, labelType, lp.lat, lp.lng, l.correct, hasValidations,
-          aiv.map(_.validationResult), expired, hasBackup.getOrElse(false), highQuality, l.severity, l.tags, isAiUser)
+          hasAdminValidation, aiv.map(_.validationResult), expired, hasBackup.getOrElse(false), highQuality, l.severity,
+          l.tags, isAiUser)
       }
     }
 
@@ -1391,10 +1401,10 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
     // error, which is why we couldn't use `.tupled` here. This was the error message:
     // SlickException: Expected an option type, found Float/REAL
     _labelsNearRoute.result.map(_.map {
-      case (id, streetId, taskId, lType, lat, lng, correct, hasVals, aiVal, expired, hasBackup, highQual, sev, tags,
-            ai) =>
-        LabelForLabelMap(id, taskId, lType, lat.get, lng.get, correct, hasVals, aiVal, expired, hasBackup, highQual,
-          sev, tags, ai)
+      case (id, streetId, taskId, lType, lat, lng, correct, hasVals, hasAdminVals, aiVal, expired, hasBackup, highQual,
+            sev, tags, ai) =>
+        LabelForLabelMap(id, taskId, lType, lat.get, lng.get, correct, hasVals, hasAdminVals, aiVal, expired, hasBackup,
+          highQual, sev, tags, ai)
     })
   }
 

--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -458,7 +458,7 @@
                         <div class="col-lg-12">
                             <div id="admin-labelmap-choropleth-holder" class="choropleth-holder">
                                 <div id="admin-labelmap-choropleth" class="choropleth"></div>
-                                @common.mapSidebar(tags = tags)
+                                @common.mapSidebar(tags = tags, adminVersion = true)
                             </div>
                         </div>
                     </div>

--- a/app/views/common/mapSidebar.scala.html
+++ b/app/views/common/mapSidebar.scala.html
@@ -1,5 +1,5 @@
 @import models.label.{LabelTypeEnum, Tag}
-@(tags: Seq[Tag] = Seq.empty, streetsShownByDefault: Boolean = false)(implicit messages: Messages, assets: AssetsFinder)
+@(tags: Seq[Tag] = Seq.empty, streetsShownByDefault: Boolean = false, adminVersion: Boolean = false)(implicit messages: Messages, assets: AssetsFinder)
 
 @tagsByLabelType = @{tags.groupBy(t => LabelTypeEnum.labelTypeIdToLabelType.getOrElse(t.labelTypeId, ""))}
 
@@ -142,6 +142,21 @@
             </li>
         </ul>
     </section>
+
+    @* ---- Admin-only filters section (#4243). Only rendered inside the admin dashboard's Map tab. ---- *@
+    @if(adminVersion) {
+        <section class="map-sidebar__section">
+            <div class="map-sidebar__heading-row">
+                <h3 class="map-sidebar__heading" data-i18n="labelmap:admin-only">Admin only</h3>
+            </div>
+            <ul class="map-sidebar__list">
+                <li class="map-sidebar__item">
+                    <input type="checkbox" id="not-admin-validated" data-filter-type="admin-validation" disabled>
+                    <label for="not-admin-validated" data-i18n="labelmap:not-admin-validated">Not validated by an admin</label>
+                </li>
+            </ul>
+        </section>
+    }
 
     @* ---- Streets section ---- *@
     <section class="map-sidebar__section">

--- a/public/javascripts/Admin/src/Admin.js
+++ b/public/javascripts/Admin/src/Admin.js
@@ -28,7 +28,7 @@ async function Admin($, mapboxApiKey, viewerType, viewerAccessToken, currentUser
         neighborhoodsURL: '/neighborhoods',
         completionRatesURL: '/adminapi/neighborhoodCompletionRate',
         streetsURL: '/contribution/streets/all?filterLowQuality=true',
-        labelsURL: '/labels/all',
+        labelsURL: '/adminapi/labels/all',
         neighborhoodFillMode: 'singleColor',
         neighborhoodFillColor: '#808080',
         neighborhoodFillOpacity: 0.1,

--- a/public/javascripts/PSMap/MapSidebarFilter.js
+++ b/public/javascripts/PSMap/MapSidebarFilter.js
@@ -27,6 +27,7 @@ class MapSidebarFilter {
         this.#initSeverityToggles();
         this.#initLabelTypeCheckboxes();
         this.#initValidationCheckboxes();
+        this.#initAdminValidationCheckbox();
         this.#initStreetCheckboxes();
         this.#initDeselectAllButtons();
         this.#initTagToggles();
@@ -82,6 +83,18 @@ class MapSidebarFilter {
                 filterLabelLayers(cb, this.#map, this.#mapData, this.#highQualityFilter);
                 this.#updateDeselectAllButton('label-validations');
             });
+        });
+    }
+
+    /**
+     * Binds the admin-only "not validated by an admin" checkbox. No-op on /labelMap, where the checkbox isn't rendered.
+     */
+    #initAdminValidationCheckbox() {
+        const cb = this.#sidebar.querySelector('#not-admin-validated');
+        if (!cb) return;
+        cb.addEventListener('click', () => {
+            this.#mapData.notAdminValidated = cb.checked;
+            filterLabelLayers(null, this.#map, this.#mapData, this.#highQualityFilter);
         });
     }
 

--- a/public/javascripts/PSMap/PSMapUtilities.js
+++ b/public/javascripts/PSMap/PSMapUtilities.js
@@ -61,6 +61,10 @@ function filterLabelLayers(checkbox, map, mapData, highQualityFilter) {
     if (highQualityFilter) {
         baseFilter.push(['any', mapData.lowQualityUsers, ['==', ['get', 'high_quality_user'], true]]);
     }
+    // Admin-only: restrict to labels with no Administrator/Owner validation when the toggle is on (#4243).
+    if (mapData.notAdminValidated) {
+        baseFilter.push(['==', ['get', 'has_admin_validation'], false]);
+    }
 
     // Apply per-layer, appending a tag sub-filter when that label type has active tags.
     for (const [labelType, layerName] of Object.entries(mapData.layerNames)) {
@@ -110,6 +114,9 @@ function CreateMapLayerTracker() {
     mapData.unsure = true;
     mapData.unvalidated = true;
     mapData.lowQualityUsers = false;
+    // Admin-only filter (#4243): when true, restrict to labels not yet validated by an Administrator/Owner. Defaults
+    // to off so the shared filter logic is a no-op on the public LabelMap, where the control isn't rendered.
+    mapData.notAdminValidated = false;
 
     // Severity filter state (all enabled by default).
     mapData.severities = { 0: true, 1: true, 2: true, 3: true };

--- a/public/locales/de/labelmap.json
+++ b/public/locales/de/labelmap.json
@@ -18,5 +18,7 @@
     "comment": "Kommentar",
     "comments": "Kommentare",
     "comment-submitted": "Kommentar gesendet",
-    "own-label-disabled": "Sie können Ihre eigene Beschriftung nicht validieren oder kommentieren"
+    "own-label-disabled": "Sie können Ihre eigene Beschriftung nicht validieren oder kommentieren",
+    "admin-only": "Nur Admin",
+    "not-admin-validated": "Nicht von einem Administrator validiert"
 }

--- a/public/locales/en/labelmap.json
+++ b/public/locales/en/labelmap.json
@@ -18,5 +18,7 @@
     "comment": "Comment",
     "comments": "Comments",
     "comment-submitted": "Comment Submitted",
-    "own-label-disabled": "You cannot validate or comment on your own label"
+    "own-label-disabled": "You cannot validate or comment on your own label",
+    "admin-only": "Admin only",
+    "not-admin-validated": "Not validated by an admin"
 }

--- a/public/locales/es/labelmap.json
+++ b/public/locales/es/labelmap.json
@@ -18,5 +18,7 @@
     "comment": "Comentario",
     "comments": "Comentarios",
     "comment-submitted": "Comentario enviado",
-    "own-label-disabled": "No puedes validar ni comentar tu propia etiqueta"
+    "own-label-disabled": "No puedes validar ni comentar tu propia etiqueta",
+    "admin-only": "Solo administradores",
+    "not-admin-validated": "No validado por un administrador"
 }

--- a/public/locales/nl/labelmap.json
+++ b/public/locales/nl/labelmap.json
@@ -18,5 +18,7 @@
     "comment": "Opmerking",
     "comments": "Opmerkingen",
     "comment-submitted": "Commentaar ingediend",
-    "own-label-disabled": "Je kunt je eigen etiket niet valideren of becommentariëren"
+    "own-label-disabled": "Je kunt je eigen etiket niet valideren of becommentariëren",
+    "admin-only": "Alleen beheerders",
+    "not-admin-validated": "Niet gevalideerd door een beheerder"
 }

--- a/public/locales/pt-BR/labelmap.json
+++ b/public/locales/pt-BR/labelmap.json
@@ -18,5 +18,7 @@
     "comment": "Comentário",
     "comments": "Comentários",
     "comment-submitted": "Comentários Enviados",
-    "own-label-disabled": "Você não pode validar nem comentar seu próprio rótulo"
+    "own-label-disabled": "Você não pode validar nem comentar seu próprio rótulo",
+    "admin-only": "Apenas administradores",
+    "not-admin-validated": "Não validado por um administrador"
 }

--- a/public/locales/zh-TW/labelmap.json
+++ b/public/locales/zh-TW/labelmap.json
@@ -18,5 +18,7 @@
     "comment": "評論",
     "comments": "評論",
     "comment-submitted": "已上傳評論",
-    "own-label-disabled": "您無法驗證或評論自己的標記"
+    "own-label-disabled": "您無法驗證或評論自己的標記",
+    "admin-only": "僅限管理員",
+    "not-admin-validated": "未經管理員驗證"
 }


### PR DESCRIPTION
## Summary

Adds a filter on the **admin dashboard's Map tab** to show only labels that have **not been validated by an Administrator or Owner**. Requested by partners in Zurich, who aim to have every label reviewed by one of their two admins and need a way to track the remaining gaps. Closes #4243.

The new "Not validated by an admin" checkbox lives in an **Admin only** section of the map sidebar and is rendered exclusively inside the admin dashboard — it does not appear on the public `/labelmap`.

## How it works

This is a new, orthogonal filter axis: existing validation filters key off the *result* of the aggregate vote (`correct` / `incorrect` / `unsure` / `unvalidated`), while this one keys off *who* validated. It ANDs with everything else, so combinations like "incorrect **and** not admin-validated" work as expected.

## Changes

**Backend**
- `LabelTable.scala`: added `hasAdminValidation` to `LabelForLabelMap`, computed in `getLabelsForLabelMap` via a subquery of `label_validation` rows from `Administrator`/`Owner` users.
- `AdminController.scala`: emit `has_admin_validation` only on the secured `/adminapi/labels/all` feed (also brought it to property parity with the public feed). The public `/labels/all` feed is unchanged, so this internal admin-workflow signal isn't exposed publicly.

**Frontend**
- `Admin.js`: the Map tab now reads the secured `/adminapi/labels/all`.
- `mapSidebar.scala.html` / `admin/index.scala.html`: new `adminVersion` flag renders the admin-only checkbox; the public `labelMap.scala.html` keeps the default (`false`).
- `PSMapUtilities.js` / `MapSidebarFilter.js`: the shared Mapbox filter gains a `notAdminValidated` clause, defaulting off so it's a no-op on the public map where the control is absent.

**i18n**
- Added `admin-only` and `not-admin-validated` to the six populated `labelmap` locales (en, es, nl, de, zh-TW, pt-BR); empty regional files inherit.

## Notes / decisions
- "Validated by an admin" counts **any** admin/owner validation (agree, disagree, or unsure). It does not apply the `excluded`-user / self-validation exclusions used by `admin_mv`, since those edge cases are negligible here and the simpler subquery is safer in Slick.
- Backend compiles clean (`sbt --client compile`, warning-free under `-Xfatal-warnings`).

## Test checklist (admin dashboard → Map tab)
- [x] "Admin only → Not validated by an admin" checkbox appears (and is absent on public `/labelmap`).
- [x] Checking it hides labels with an admin/owner validation; unchecking restores them.
- [x] Combines correctly with severity / label-type / validation-result / tag filters.
- [x] `/adminapi/labels/all` returns `has_admin_validation`; `/labels/all` does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)