### PR TITLE
API docs: AI-inclusive validation counts (#4244) + labelTags anchors (#3992)

### DIFF
--- a/app/views/apiDocs/labelClusters.scala.html
+++ b/app/views/apiDocs/labelClusters.scala.html
@@ -395,17 +395,17 @@
                     <tr>
                         <td><code>properties.agree_count</code></td>
                         <td><code>integer</code></td>
-                        <td>Total number of users who agreed with (confirmed) the labels in this cluster during validation tasks.</td>
+                        <td>Total number of users and/or AI who agreed with (confirmed) the labels in this cluster during validation tasks. To separate human vs. AI validations, use the <a href="@routes.ApiDocsController.validations">validations endpoint</a> (its <code>validator_type</code> field).</td>
                     </tr>
                     <tr>
                         <td><code>properties.disagree_count</code></td>
                         <td><code>integer</code></td>
-                        <td>Total number of users who disagreed with (disputed) the labels in this cluster during validation tasks.</td>
+                        <td>Total number of users and/or AI who disagreed with (disputed) the labels in this cluster during validation tasks. To separate human vs. AI validations, use the <a href="@routes.ApiDocsController.validations">validations endpoint</a> (its <code>validator_type</code> field).</td>
                     </tr>
                     <tr>
                         <td><code>properties.unsure_count</code></td>
                         <td><code>integer</code></td>
-                        <td>Total number of users who marked "unsure" for the labels in this cluster during validation tasks.</td>
+                        <td>Total number of users and/or AI who marked "unsure" for the labels in this cluster during validation tasks. To separate human vs. AI validations, use the <a href="@routes.ApiDocsController.validations">validations endpoint</a> (its <code>validator_type</code> field).</td>
                     </tr>
 
                         <!-- User Information -->

--- a/app/views/apiDocs/rawLabels.scala.html
+++ b/app/views/apiDocs/rawLabels.scala.html
@@ -422,17 +422,17 @@
                     <tr>
                         <td><code>properties.agree_count</code></td>
                         <td><code>integer</code></td>
-                        <td>Number of users who agreed with (confirmed) this label during validation tasks.</td>
+                        <td>Number of users and/or AI who agreed with (confirmed) this label during validation tasks. To separate human vs. AI validations, use the <a href="@routes.ApiDocsController.validations">validations endpoint</a> (its <code>validator_type</code> field).</td>
                     </tr>
                     <tr>
                         <td><code>properties.disagree_count</code></td>
                         <td><code>integer</code></td>
-                        <td>Number of users who disagreed with (disputed) this label during validation tasks.</td>
+                        <td>Number of users and/or AI who disagreed with (disputed) this label during validation tasks. To separate human vs. AI validations, use the <a href="@routes.ApiDocsController.validations">validations endpoint</a> (its <code>validator_type</code> field).</td>
                     </tr>
                     <tr>
                         <td><code>properties.unsure_count</code></td>
                         <td><code>integer</code></td>
-                        <td>Number of users who marked "unsure" for this label during validation tasks.</td>
+                        <td>Number of users and/or AI who marked "unsure" for this label during validation tasks. To separate human vs. AI validations, use the <a href="@routes.ApiDocsController.validations">validations endpoint</a> (its <code>validator_type</code> field).</td>
                     </tr>
                     <tr>
                         <td><code>properties.validations</code></td>

--- a/public/javascripts/api-docs/label-tags-preview.js
+++ b/public/javascripts/api-docs/label-tags-preview.js
@@ -141,14 +141,24 @@
                 const section = document.createElement('div');
                 section.className = 'label-tags-section';
 
-                // Add heading for the label type.
+                // Add heading for the label type. Use the same `api-heading` + child `.permalink` markup as the
+                // static headings so these JS-rendered sub-headers get TOC entries and the hover/copy "#" anchor that
+                // the rest of the API docs link to (e.g. the index page's summary table links here via
+                // #label-type-<type>).
                 const heading = document.createElement('h3');
-                heading.className = 'section-subheading';
-                heading.textContent = labelType;
+                heading.className = 'api-heading section-subheading';
                 const headingId = 'label-type-' + labelType.toLowerCase()
                     .replace(/\s+/g, '-')     // Replace spaces with hyphens
                     .replace(/[^a-z0-9-]/g, ''); // Remove non-alphanumeric characters except hyphens
                 heading.id = headingId;
+                heading.appendChild(document.createTextNode(labelType + ' '));
+
+                const permalink = document.createElement('a');
+                permalink.href = '#' + headingId;
+                permalink.className = 'permalink';
+                permalink.textContent = '#';
+                heading.appendChild(permalink);
+
                 section.appendChild(heading);
 
                 // Create table for tags.


### PR DESCRIPTION
Two small, self-contained API-docs fixes.

## #4244 — clarify validation counts include AI ("users and/or AI")
AI votes now flow through the normal validation insert path and are baked into the label table's `agree_count`/`disagree_count`/`unsure_count`. The `rawLabels` and `labelClusters` field docs described these as coming from "users", which understated AI's contribution.

- `rawLabels.scala.html` and `labelClusters.scala.html`: "users" → **"users and/or AI"** for `agree_count` / `disagree_count` / `unsure_count`.
- Each blended count now also points to the **[validations endpoint](../api-docs/validations)** (`validator_type` = Human/AI) so consumers can always recover the human-vs-AI split — `rawLabels`/`labelClusters` themselves only expose the blended totals.

Per @misaugstad's note on #4223, this is wording-only; we are **not** splitting these endpoints. No code or query changes.

## #3992 — labelTags label-type headers missing anchor links
The JS-rendered label-type sub-headers in the Label Tags preview (`label-tags-preview.js`) already got an `id`, but used `class="section-subheading"` with no permalink anchor — unlike every static heading (`class="api-heading"` + child `.permalink` `#`). So the index page's summary table, which links to `#label-type-<type>`, pointed at headers that lacked the shared heading affordances.

- The generated headings now use `api-heading section-subheading` and append a `.permalink` `#` anchor matching the static markup, so they get TOC entries and the copyable hover anchor. The clipboard handler is already delegated on `.api-content`, so dynamically-added anchors work without re-init.

## Testing
- `sbt --client compile` clean (Twirl templates + `@routes.ApiDocsController.validations` resolve).
- `label-tags-preview.js` is served directly (not Grunt-bundled), so no build step.

Closes #4244
Closes #3992

🤖 Generated with [Claude Code](https://claude.com/claude-code)