### PR TITLE
Add stddev of label/image dates to /v3/api/overallStats (#3031)

### DIFF
--- a/app/controllers/api/StatsApiController.scala
+++ b/app/controllers/api/StatsApiController.scala
@@ -116,6 +116,10 @@ class StatsApiController @Inject() (
             row("Average Label Timestamp", stats.avgLabelTimestamp.getOrElse("NA"))
             val avgImgAge: String = stats.avgImageAgeByLabel.map(avg => s"${avg.toDays} Days").getOrElse("NA")
             row("Average Age of Image When Labeled", avgImgAge)
+            val stddevLabelTs: String = stats.stddevLabelTimestamp.map(sd => s"${sd.toDays} Days").getOrElse("NA")
+            row("Stddev Label Timestamp", stddevLabelTs)
+            val stddevImgAge: String = stats.stddevImageAgeByLabel.map(sd => s"${sd.toDays} Days").getOrElse("NA")
+            row("Stddev Age of Image When Labeled", stddevImgAge)
             for ((labType, sevStats) <- stats.severityByLabelType.toSeq.sorted(labelTypeOrdering)) {
               row(s"$labType Count", sevStats.n)
               row(s"$labType Count With Severity", sevStats.nWithSeverity.getOrElse("NA"))

--- a/app/formats/json/ApiFormats.scala
+++ b/app/formats/json/ApiFormats.scala
@@ -85,6 +85,14 @@ object ApiFormats {
           (
             "avg_age_of_image_when_labeled",
             stats.avgImageAgeByLabel.map(avgImgAge => JsString(s"${avgImgAge.toDays} days")).getOrElse(JsNull)
+          ),
+          (
+            "stddev_label_timestamp",
+            stats.stddevLabelTimestamp.map(sd => JsString(s"${sd.toDays} days")).getOrElse(JsNull)
+          ),
+          (
+            "stddev_age_of_image_when_labeled",
+            stats.stddevImageAgeByLabel.map(sd => JsString(s"${sd.toDays} days")).getOrElse(JsNull)
           )
         ) ++
           // Turns into { "CurbRamp" -> { "count" -> ###, ... }, ... }.

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -121,6 +121,8 @@ case class ProjectSidewalkStats(
     nLabelsWithSeverity: Int,
     avgLabelTimestamp: Option[OffsetDateTime],
     avgImageAgeByLabel: Option[Duration],
+    stddevLabelTimestamp: Option[Duration],
+    stddevImageAgeByLabel: Option[Duration],
     severityByLabelType: Map[String, LabelSevStats],
     validations: ValidationStats,
     aiPerformance: Map[String, Map[String, AiConcurrence]]
@@ -699,6 +701,8 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
       r.nextInt(),
       r.nextInt(),
       r.nextOffsetDateTimeOption(),
+      r.nextDurationOption(),
+      r.nextDurationOption(),
       r.nextDurationOption(),
       Map(
         CurbRamp.name   -> LabelSevStats(r.nextInt(), r.nextIntOption(), r.nextDoubleOption(), r.nextDoubleOption()),
@@ -1795,6 +1799,8 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
              label_counts_and_severity.n_with_sev,
              label_counts_and_severity.avg_label_timestamp,
              label_counts_and_severity.avg_age_when_labeled,
+             label_counts_and_severity.stddev_label_timestamp,
+             label_counts_and_severity.stddev_age_when_labeled,
              label_counts_and_severity.n_ramp,
              label_counts_and_severity.n_ramp_with_sev,
              label_counts_and_severity.ramp_sev_mean,
@@ -1928,6 +1934,17 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
                          THEN time_created - TO_TIMESTAMP(EXTRACT(epoch from CAST(pano_data.capture_date || '-01' AS DATE)))
                      END
                  ) AS avg_age_when_labeled,
+                 -- STDDEV operates on seconds, then `* INTERVAL '1 second'` yields an interval so the spread is read as
+                 -- a Duration (a standard deviation of dates is a duration/spread, not itself a date).
+                 STDDEV(EXTRACT(EPOCH FROM time_created)) * INTERVAL '1 second' AS stddev_label_timestamp,
+                 STDDEV(
+                     EXTRACT(EPOCH FROM (
+                         CASE
+                             WHEN pano_data.capture_date IS NOT NULL AND pano_data.capture_date <> ''
+                             THEN time_created - TO_TIMESTAMP(EXTRACT(epoch from CAST(pano_data.capture_date || '-01' AS DATE)))
+                         END
+                     ))
+                 ) * INTERVAL '1 second' AS stddev_age_when_labeled,
                  COUNT(CASE WHEN label_type.label_type = 'CurbRamp' THEN 1 END) AS n_ramp,
                  COUNT(CASE WHEN label_type.label_type = 'CurbRamp' AND severity IS NOT NULL THEN 1 END) AS n_ramp_with_sev,
                  avg(CASE WHEN label_type.label_type = 'CurbRamp' THEN severity END) AS ramp_sev_mean,

--- a/app/views/apiDocs/overallStats.scala.html
+++ b/app/views/apiDocs/overallStats.scala.html
@@ -140,6 +140,8 @@
         "label_count_with_severity": 162320,
         "avg_label_timestamp": "2021-05-10T20:20:25.147504Z",
         "avg_age_of_image_when_labeled": "672 days",
+        "stddev_label_timestamp": "188 days",
+        "stddev_age_of_image_when_labeled": "543 days",
         "CurbRamp": {
             "count": 72964,
             "count_with_severity": 61837,
@@ -267,6 +269,8 @@
                     <tr><td><code>labels.label_count_with_severity</code></td><td><code>integer</code></td><td>Total number of labels placed by all users with an associated severity rating.</td></tr>
                     <tr><td><code>avg_label_timestamp</code></td><td><code>string</code></td><td>ISO 8601 formatted average timestamp when labels were created.</td></tr>
                     <tr><td><code>labels.avg_age_of_image_when_labeled</code></td><td><code>string</code></td><td>The average, across all labels, of the age of the image when the label was placed (in days).</td></tr>
+                    <tr><td><code>labels.stddev_label_timestamp</code></td><td><code>string</code></td><td>Standard deviation (spread) of label creation timestamps, expressed as a duration in days. A standard deviation of dates is a duration, not a date.</td></tr>
+                    <tr><td><code>labels.stddev_age_of_image_when_labeled</code></td><td><code>string</code></td><td>Standard deviation (spread), in days, of the age of the image when each label was placed.</td></tr>
                     <tr><td><code>labels.[type].count</code></td><td><code>integer</code></td><td>Total number of labels of this type.</td></tr>
                     <tr><td><code>labels.[type].count_with_severity</code></td><td><code>integer | null</code></td><td>Number of labels of this type that have severity ratings, or null if no severity ratings exist.</td></tr>
                     <tr><td><code>labels.[type].severity_mean</code></td><td><code>number | null</code></td><td>Mean severity rating for this label type, or null if no severity ratings exist.</td></tr>

--- a/test/controllers/api/PublicApiSpec.scala
+++ b/test/controllers/api/PublicApiSpec.scala
@@ -45,6 +45,24 @@ class PublicApiSpec extends PlaySpec with GuiceOneAppPerSuite {
       (json \ "validations").asOpt[JsObject] mustBe defined
     }
 
+    "expose the label/image date metrics, including the standard deviations (#3031)" in {
+      val resp = route(app, FakeRequest(GET, "/v3/api/overallStats")).get
+      status(resp) mustBe OK
+
+      // Driving these through the real query also exercises the positional GetResult converter: a column-order drift
+      // between the SELECT and the converter would surface here as a missing key or a parse failure.
+      val labels = (contentAsJson(resp) \ "labels").as[JsObject]
+      labels.keys must contain("avg_label_timestamp")
+      labels.keys must contain("avg_age_of_image_when_labeled")
+      labels.keys must contain("stddev_label_timestamp")
+      labels.keys must contain("stddev_age_of_image_when_labeled")
+
+      // A standard deviation of dates is a duration: when the dataset has enough labels to compute one, it renders as
+      // a day-valued string (e.g. "188 days"). Tolerate null so the contract holds on a sparse test DB.
+      (labels \ "stddev_label_timestamp").asOpt[String].foreach(_ must fullyMatch regex """-?\d+ days""")
+      (labels \ "stddev_age_of_image_when_labeled").asOpt[String].foreach(_ must fullyMatch regex """-?\d+ days""")
+    }
+
     "return CSV with snake_case keys when filetype=csv" in {
       val resp = route(app, FakeRequest(GET, "/v3/api/overallStats?filetype=csv")).get
       status(resp) mustBe OK
@@ -52,6 +70,9 @@ class PublicApiSpec extends PlaySpec with GuiceOneAppPerSuite {
       body must include("launch_date")
       body must include("km_explored")
       body must not include "Launch Date" // old Title-Case key gone
+      // The #3031 standard-deviation date metrics appear in the CSV with the same snake_case keys as the JSON.
+      body must include("stddev_label_timestamp")
+      body must include("stddev_age_of_image_when_labeled")
     }
   }
 

--- a/test/formats/json/ApiFormatsSpec.scala
+++ b/test/formats/json/ApiFormatsSpec.scala
@@ -5,6 +5,8 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.{JsObject, JsValue}
 
+import java.time.Duration
+
 /**
  * Pure (no DB, no app boot) contract test for the `/v3/api/overallStats` JSON shape.
  *
@@ -15,7 +17,12 @@ class ApiFormatsSpec extends AnyFunSuite with Matchers {
 
   /** Builds a ProjectSidewalkStats with distinct combined/human/ai values so the test can tell the blocks apart. */
   private def sampleStats: ProjectSidewalkStats = {
-    def source(total: Int, overall: LabelAccuracy, curbRamp: LabelAccuracy, other: LabelAccuracy): ValidationSourceStats =
+    def source(
+        total: Int,
+        overall: LabelAccuracy,
+        curbRamp: LabelAccuracy,
+        other: LabelAccuracy
+    ): ValidationSourceStats =
       ValidationSourceStats(
         nValidations = total,
         accuracyByLabelType = Map("Overall" -> overall, "CurbRamp" -> curbRamp, "Other" -> other)
@@ -37,18 +44,29 @@ class ApiFormatsSpec extends AnyFunSuite with Matchers {
       nLabelsWithSeverity = 40,
       avgLabelTimestamp = None,
       avgImageAgeByLabel = None,
+      stddevLabelTimestamp = Some(Duration.ofDays(120)),
+      stddevImageAgeByLabel = Some(Duration.ofDays(365)),
       severityByLabelType = Map.empty,
       validations = ValidationStats(
         // "Other" has accuracy = None on purpose, to assert the null-accuracy key is omitted (writeNullable behavior).
-        combined =
-          source(100, LabelAccuracy(80, 70, 10, Some(0.875), 90), LabelAccuracy(40, 38, 2, Some(0.95), 45),
-            LabelAccuracy(0, 0, 0, None, 0)),
-        human =
-          source(90, LabelAccuracy(72, 63, 9, Some(0.875), 81), LabelAccuracy(36, 34, 2, Some(0.944), 40),
-            LabelAccuracy(0, 0, 0, None, 0)),
-        ai =
-          source(10, LabelAccuracy(8, 7, 1, Some(0.875), 9), LabelAccuracy(4, 4, 0, Some(1.0), 5),
-            LabelAccuracy(0, 0, 0, None, 0))
+        combined = source(
+          100,
+          LabelAccuracy(80, 70, 10, Some(0.875), 90),
+          LabelAccuracy(40, 38, 2, Some(0.95), 45),
+          LabelAccuracy(0, 0, 0, None, 0)
+        ),
+        human = source(
+          90,
+          LabelAccuracy(72, 63, 9, Some(0.875), 81),
+          LabelAccuracy(36, 34, 2, Some(0.944), 40),
+          LabelAccuracy(0, 0, 0, None, 0)
+        ),
+        ai = source(
+          10,
+          LabelAccuracy(8, 7, 1, Some(0.875), 9),
+          LabelAccuracy(4, 4, 0, Some(1.0), 5),
+          LabelAccuracy(0, 0, 0, None, 0)
+        )
       ),
       aiPerformance = Map.empty
     )
@@ -82,6 +100,12 @@ class ApiFormatsSpec extends AnyFunSuite with Matchers {
     // Pre-#4223 these lived directly under `validations`; they must now only exist under a source block.
     (json \ "validations" \ "Overall").toOption shouldBe None
     (json \ "validations" \ "total_validations").toOption shouldBe None
+  }
+
+  test("stddev of label/image dates serialize as day-valued durations (#3031)") {
+    val labels = ApiFormats.projectSidewalkStatsToJson(sampleStats) \ "labels"
+    (labels \ "stddev_label_timestamp").as[String] shouldBe "120 days"
+    (labels \ "stddev_age_of_image_when_labeled").as[String] shouldBe "365 days"
   }
 
   test("null accuracy is omitted, but the other fields remain") {


### PR DESCRIPTION
Closes #3031.

#2928 added the **average** label timestamp and **average** image age when labeled to `/v3/api/overallStats`. This adds the **standard-deviation (spread)** counterpart of each — the part the issue noted was missing.

## Approach
A standard deviation of dates is a **duration**, not a date. So both are computed in SQL as `STDDEV` over epoch seconds, then `* INTERVAL '1 second'` to yield a Postgres `interval`, read back as a `java.time.Duration` via the same `nextDurationOption` path the existing `avg_age_when_labeled` column already uses, and serialized as a day-valued string (e.g. `"188 days"`) to match `avg_age_of_image_when_labeled`.

New fields in **both JSON and CSV**:
- `labels.stddev_label_timestamp`
- `labels.stddev_age_of_image_when_labeled`

The five edit sites stay positionally aligned: SQL subquery, top-level `SELECT`, the `ProjectSidewalkStats` case class, the positional `GetResult` converter, and the `ApiFormats` JSON writer — plus the `StatsApiController` CSV path and the docs.

## Testing
- **`PublicApiSpec` (DB-backed, boots the app against Postgres+PostGIS):** new case drives the real `/v3/api/overallStats` query and asserts all four date metrics (avg + stddev) are present in JSON, with a day-valued-duration format check; the CSV case asserts the new keys. This exercises the SQL **and the positional converter end-to-end** — a `SELECT`/converter column-order drift would surface here. Locally: 23/23 green.
- **`ApiFormatsSpec` (pure, no DB):** locks the day-valued JSON serialization. 4/4 green. (scalafmt reformatted the file.)
- Validated `double × INTERVAL → interval` directly in Postgres.

## Notes
- Follow-up filed as **#4320**: the overallStats **CSV** emits `average_label_timestamp` while the JSON emits `avg_label_timestamp` — a pre-existing JSON↔CSV key mismatch (#3871). Out of scope here; the new stddev fields were named so their CSV and JSON keys already match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)