### PR TITLE
Make rawLabels pano_url provider-aware (#3853)

### DIFF
--- a/app/controllers/helper/ShapefilesCreatorHelper.scala
+++ b/app/controllers/helper/ShapefilesCreatorHelper.scala
@@ -282,7 +282,7 @@ class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: M
       + "cameraHdng:Double,"      // Camera heading
       + "cameraPtch:Double,"      // Camera pitch
       + "cameraRoll:Double,"      // Camera roll
-      + "imageUrl:String"         // Pano URL
+      + "panoUrl:String"          // Provider viewer URL (empty for providers without one)
     )
 
     val geometryFactory: GeometryFactory = JTSFactoryFinder.getGeometryFactory
@@ -335,7 +335,7 @@ class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: M
       featureBuilder.add(label.cameraHeading.orNull)
       featureBuilder.add(label.cameraPitch.orNull)
       featureBuilder.add(label.cameraRoll.orNull)
-      featureBuilder.add(label.imageUrl)
+      featureBuilder.add(label.panoUrl.getOrElse(""))
 
       featureBuilder.buildFeature(null)
     }
@@ -734,7 +734,7 @@ class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: M
       + "camera_heading:Double,"  // Camera heading
       + "camera_pitch:Double,"    // Camera pitch
       + "camera_roll:Double,"     // Camera pitch
-      + "image_url:String"        // Pano URL
+      + "pano_url:String"         // Provider viewer URL (empty for providers without one)
     )
 
     val geometryFactory: GeometryFactory = JTSFactoryFinder.getGeometryFactory
@@ -779,7 +779,7 @@ class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: M
       featureBuilder.add(label.cameraHeading.orNull)
       featureBuilder.add(label.cameraPitch.orNull)
       featureBuilder.add(label.cameraRoll.orNull)
-      featureBuilder.add(label.imageUrl)
+      featureBuilder.add(label.panoUrl.getOrElse(""))
       featureBuilder.buildFeature(null)
     }
 

--- a/app/models/api/LabelApiModels.scala
+++ b/app/models/api/LabelApiModels.scala
@@ -7,6 +7,8 @@
 package models.api
 
 import models.api.ApiModelUtils.{createGeoJsonPointGeometry, escapeCsvField}
+import models.pano.PanoSource
+import models.pano.PanoSource.PanoSource
 import models.utils.LatLngBBox
 import play.api.libs.json.{JsObject, JsValue, Json, JsonConfiguration, JsonNaming, OFormat, Writes}
 
@@ -70,6 +72,7 @@ object LabelValidationSummaryForApi {
  * @param labelId Unique identifier for the label
  * @param userId Anonymized identifier of the user who created the label
  * @param panoId Panorama identifier where the label was placed
+ * @param panoSource Imagery provider the panorama came from (GSV, Mapillary, or infra3d); drives `panoUrl`
  * @param labelType Type of accessibility issue (e.g., "CurbRamp", "SurfaceProblem")
  * @param severity Optional severity rating (1-3 scale)
  * @param tags List of descriptive tags applied to the label
@@ -108,6 +111,7 @@ case class LabelDataForApi(
     labelId: Int,
     userId: String,
     panoId: String,
+    panoSource: PanoSource,
     labelType: String,
     severity: Option[Int],
     tags: List[String],
@@ -144,39 +148,28 @@ case class LabelDataForApi(
 ) extends StreamingApiType {
 
   /**
-   * Generates a direct panorama URL for this label location.
+   * Builds a browser-openable link to view this label's panorama in the provider's own viewer, positioned at the
+   * label's heading/pitch. The format is provider-specific, mirroring the in-app "view in pano" links in
+   * `PanoInfoPopover.js` so the API and frontend stay on one canonical URL shape per provider:
    *
-   * This URL can be opened in a browser to view the Street View at the label position.
-   * The URL format follows Google's standard Street View URL structure:
-   * https://www.google.com/maps/@{lat},{lng},3a,75y,{heading}h,{pitch}t/data=!3m4!1e1!3m2!1s{panoId}!2e0
+   *  - GSV: Google's officially documented Maps URLs API for Street View (`map_action=pano`), which needs no API key.
+   *    See https://developers.google.com/maps/documentation/urls/get-started#street-view-action. `heading` (-180..360)
+   *    and `pitch` (-90..90) match Project Sidewalk's own conventions, so they pass through unchanged.
+   *  - Mapillary: the web app's image-permalink form (`pKey`).
+   *  - infra3d: no public, shareable viewer URL exists, so this is `None`.
    *
-   * URL components:
-   * - @{lat},{lng}: The geographic coordinates
-   * - 3a: Specifies Street View mode
-   * - 75y: Default field of view (75 degrees)
-   * - {heading}h: Horizontal view direction in degrees followed by 'h'
-   * - {pitch}t: Vertical view angle in degrees followed by 't'
-   * - !3m4!1e1!3m2!1s{panoId}!2e0: Data parameter specifying panorama ID
-   *
-   * @return A complete panorama URL pointing to this label's location
+   * @return The provider's viewer URL for this label, or `None` when the provider has no shareable external viewer.
    */
-  def imageUrl: String = {
-    // Base URL for Google Maps.
-    val baseUrl = "https://www.google.com/maps/@"
-
-    // Format latitude and longitude with default Street View settings.
-    val latLng = s"$latitude,$longitude,3a,75y" // '75y' is FOV
-
-    // Handle optional parameters with defaults where needed.
-    val headingStr = s"${heading.getOrElse(0)}h"
-    val pitchStr   = s"${90.0 + pitch.getOrElse(0.0)}t"
-
-    // The data parameter contains the panorama ID information.
-    // Format is: !3m4!1e1!3m2!1s{PANORAMA_ID}!2e0
-    val panoParam = s"data=!3m4!1e1!3m2!1s$panoId!2e0"
-
-    // Assemble all components into the final URL
-    s"$baseUrl$latLng,$headingStr,$pitchStr/$panoParam"
+  def panoUrl: Option[String] = panoSource match {
+    case PanoSource.Gsv =>
+      Some(
+        s"https://www.google.com/maps/@?api=1&map_action=pano&pano=$panoId" +
+          s"&heading=${heading.getOrElse(0.0)}&pitch=${pitch.getOrElse(0.0)}"
+      )
+    case PanoSource.Mapillary =>
+      Some(s"https://www.mapillary.com/app/?pKey=$panoId&focus=photo")
+    case _ =>
+      None
   }
 
   /**
@@ -232,7 +225,7 @@ case class LabelDataForApi(
         "camera_heading"     -> cameraHeading,
         "camera_pitch"       -> cameraPitch,
         "camera_roll"        -> cameraRoll,
-        "image_url"          -> imageUrl // Include the direct pano URL
+        "pano_url"           -> panoUrl // Provider-specific viewer link; null for providers without one (infra3d)
       )
     )
   }
@@ -284,7 +277,7 @@ case class LabelDataForApi(
       cameraHeading.map(_.toString).getOrElse(""),
       cameraPitch.map(_.toString).getOrElse(""),
       cameraRoll.map(_.toString).getOrElse(""),
-      escapeCsvField(imageUrl),
+      escapeCsvField(panoUrl.getOrElse("")),
       latitude.toString,
       longitude.toString
     )
@@ -304,7 +297,7 @@ object LabelDataForApi {
   val csvHeader: String = "label_id,user_id,pano_id,label_type,severity,tags,description,time_created,street_edge_id," +
     "osm_way_id,region_id,region_name,correct,agree_count,disagree_count,unsure_count,validations,audit_task_id,mission_id," +
     "image_capture_date,heading,pitch,zoom,canvas_x,canvas_y,canvas_width,canvas_height,pano_x,pano_y,pano_width," +
-    "pano_height,camera_heading,camera_pitch,camera_roll,image_url,latitude,longitude\n"
+    "pano_height,camera_heading,camera_pitch,camera_roll,pano_url,latitude,longitude\n"
 
   /**
    * Implicit JSON writer for LabelData that uses the toJson method.

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -478,6 +478,7 @@ object LabelTable {
       labelId = r.nextInt(),
       userId = r.nextString(),
       panoId = r.nextString(),
+      panoSource = PanoSource.withName(r.nextString()),
       labelType = r.nextString(),
       severity = r.nextIntOption(),
       tags = {
@@ -1642,6 +1643,7 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
       SELECT label.label_id,
              label.user_id,
              label.pano_id,
+             pano_data.source::text,
              label_type.label_type,
              label.severity,
              array_to_string(label.tags, ','),

--- a/app/views/apiDocs/rawLabels.scala.html
+++ b/app/views/apiDocs/rawLabels.scala.html
@@ -267,7 +267,7 @@
                 "camera_heading": 228.928619384766,
                 "camera_pitch": -0.998329997062683,
                 "camera_roll": 0.888324597068312,
-                "image_url": "https://www.google.com/maps/@@40.88399124145508,-74.02436065673828,3a,75y,94.31143188476562h,65.3222501t/data=!3m4!1e1!3m2!1sDsCvWstZYz9JL81V9NloOQ!2e0"
+                "pano_url": "https://www.google.com/maps/@@?api=1&map_action=pano&pano=DsCvWstZYz9JL81V9NloOQ&heading=94.3114318847656&pitch=-24.6774997711182"
             }
         },
         {
@@ -324,7 +324,7 @@
                 "camera_heading": 228.928619384766,
                 "camera_pitch": -0.998329997062683,
                 "camera_roll": 0.888324597068312,
-                "image_url": "https://www.google.com/maps/@@40.883941650390625,-74.02438354492188,3a,75y,140.74000549316406h,71.84035682679t/data=!3m4!1e1!3m2!1sDsCvWstZYz9JL81V9NloOQ!2e0"
+                "pano_url": "https://www.google.com/maps/@@?api=1&map_action=pano&pano=DsCvWstZYz9JL81V9NloOQ&heading=140.740005493164&pitch=-18.1596431732178"
             }
         },
         ...
@@ -464,9 +464,9 @@
                         <td>Date when the imagery was captured, typically in "YYYY-MM" format (e.g., "2012-08").</td>
                     </tr>
                     <tr>
-                        <td><code>properties.image_url</code></td>
-                        <td><code>string</code></td>
-                        <td>URL to the panorama where this label was placed, including parameters to position the view at the correct heading and pitch.</td>
+                        <td><code>properties.pano_url</code></td>
+                        <td><code>string | null</code></td>
+                        <td>Link to view the panorama where this label was placed in its imagery provider's viewer, positioned at the label's heading and pitch. For Google Street View panoramas this uses Google's <a target="_blank" href="https://developers.google.com/maps/documentation/urls/get-started#street-view-action">Maps URLs</a> format (no API key required); for Mapillary it links to the Mapillary web app. <code>null</code> for providers without a shareable public viewer (e.g., infra3d).</td>
                     </tr>
 
                         <!-- Camera and View Position Information -->

--- a/public/javascripts/api-docs/raw-labels-preview.js
+++ b/public/javascripts/api-docs/raw-labels-preview.js
@@ -322,9 +322,9 @@
                         validationStatus = `Invalidated (${props.agree_count} agree, ${props.disagree_count} disagree)`;
                     }
 
-                    // Add the image URL link to the popup content.
-                    const panoLink = props.image_url ?
-                        `<p><a href="${props.image_url}" target="_blank" rel="noopener noreferrer">View in Google Street View</a></p>` :
+                    // Add the panorama viewer link to the popup content (absent for providers without one, e.g. infra3d).
+                    const panoLink = props.pano_url ?
+                        `<p><a href="${props.pano_url}" target="_blank" rel="noopener noreferrer">View panorama</a></p>` :
                         '';
 
                     layer.bindPopup(`

--- a/test/controllers/api/RawLabelsApiSpec.scala
+++ b/test/controllers/api/RawLabelsApiSpec.scala
@@ -54,7 +54,7 @@ class RawLabelsApiSpec extends PlaySpec with GuiceOneAppPerSuite {
         "label_id,user_id,pano_id,label_type,severity,tags,description,time_created,street_edge_id,osm_way_id," +
           "region_id,region_name,correct,agree_count,disagree_count,unsure_count,validations,audit_task_id,mission_id," +
           "image_capture_date,heading,pitch,zoom,canvas_x,canvas_y,canvas_width,canvas_height,pano_x,pano_y," +
-          "pano_width,pano_height,camera_heading,camera_pitch,camera_roll,image_url,latitude,longitude"
+          "pano_width,pano_height,camera_heading,camera_pitch,camera_roll,pano_url,latitude,longitude"
       )
       body must not include "labelId"
       body must not include "streetEdgeId"

--- a/test/models/api/LabelApiModelsSpec.scala
+++ b/test/models/api/LabelApiModelsSpec.scala
@@ -1,0 +1,105 @@
+package models.api
+
+import models.pano.PanoSource
+import models.pano.PanoSource.PanoSource
+import org.scalatest.OptionValues
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.JsObject
+
+import java.time.{OffsetDateTime, ZoneOffset}
+
+/**
+ * Pure (no DB, no app boot) contract test for the `/v3/api/rawLabels` `pano_url` field (#3853).
+ *
+ * Locks the provider-aware behavior the compiler can't see: GSV labels get Google's documented Maps URLs link,
+ * Mapillary labels get a Mapillary web-app link, and providers with no shareable viewer (infra3d) get `null` in JSON
+ * and an empty CSV column. Also guards that the GSV URL carries no API key and matches the in-app `PanoInfoPopover.js`
+ * shape (`map_action=pano`, label heading/pitch passed through unchanged).
+ */
+class LabelApiModelsSpec extends AnyFunSuite with Matchers with OptionValues {
+
+  /** A label fixture parameterized by imagery provider and view angles; all other fields are arbitrary but valid. */
+  private def sampleLabel(
+      source: PanoSource,
+      heading: Option[Double] = Some(94.3114318847656),
+      pitch: Option[Double] = Some(-24.6774997711182)
+  ): LabelDataForApi = LabelDataForApi(
+    labelId = 8,
+    userId = "user-uuid",
+    panoId = "DsCvWstZYz9JL81V9NloOQ",
+    panoSource = source,
+    labelType = "CurbRamp",
+    severity = Some(1),
+    tags = List.empty,
+    description = None,
+    timeCreated = OffsetDateTime.of(2023, 8, 16, 0, 0, 0, 0, ZoneOffset.UTC),
+    streetEdgeId = 951,
+    osmWayId = 11584845L,
+    regionId = 1,
+    regionName = "Teaneck",
+    latitude = 40.8839912414551,
+    longitude = -74.0243606567383,
+    correct = Some(true),
+    agreeCount = 2,
+    disagreeCount = 0,
+    unsureCount = 0,
+    validations = Seq.empty,
+    auditTaskId = Some(6),
+    missionId = Some(3),
+    imageCaptureDate = Some("2012-08"),
+    heading = heading,
+    pitch = pitch,
+    zoom = Some(2.0),
+    canvasX = Some(395),
+    canvasY = Some(151),
+    canvasWidth = Some(480),
+    canvasHeight = Some(720),
+    panoX = Some(1781),
+    panoY = Some(3980),
+    panoWidth = Some(13312),
+    panoHeight = Some(6656),
+    cameraHeading = Some(228.928619384766),
+    cameraPitch = Some(-0.998329997062683),
+    cameraRoll = Some(0.888324597068312)
+  )
+
+  test("GSV pano_url uses Google's documented Maps URLs format with label heading/pitch and no API key") {
+    val url = sampleLabel(PanoSource.Gsv).panoUrl.value
+
+    url shouldBe "https://www.google.com/maps/@?api=1&map_action=pano&pano=DsCvWstZYz9JL81V9NloOQ" +
+      "&heading=94.3114318847656&pitch=-24.6774997711182"
+    url should not include "key="
+    url should not include "signature="
+  }
+
+  test("GSV pano_url defaults missing heading/pitch to 0.0") {
+    val url = sampleLabel(PanoSource.Gsv, heading = None, pitch = None).panoUrl.value
+    url should endWith("&heading=0.0&pitch=0.0")
+  }
+
+  test("Mapillary pano_url links to the Mapillary web app by pKey") {
+    sampleLabel(PanoSource.Mapillary).panoUrl.value shouldBe
+      "https://www.mapillary.com/app/?pKey=DsCvWstZYz9JL81V9NloOQ&focus=photo"
+  }
+
+  test("infra3d has no shareable viewer URL (None)") {
+    sampleLabel(PanoSource.Infra3d).panoUrl shouldBe None
+  }
+
+  test("GeoJSON properties carry pano_url for GSV and null for infra3d") {
+    val gsvProps = (sampleLabel(PanoSource.Gsv).toJson \ "properties").as[JsObject]
+    (gsvProps \ "pano_url").as[String] should startWith("https://www.google.com/maps/@?api=1")
+    (gsvProps \ "image_url").toOption shouldBe None // renamed; old key must not leak
+
+    val infraProps = (sampleLabel(PanoSource.Infra3d).toJson \ "properties").as[JsObject]
+    (infraProps \ "pano_url").toOption.map(_.toString) shouldBe Some("null")
+  }
+
+  test("CSV row renders the GSV pano_url and an empty column for infra3d") {
+    sampleLabel(PanoSource.Gsv).toCsvRow should include("https://www.google.com/maps/@?api=1")
+
+    // pano_url is the antepenultimate column (followed by latitude,longitude); for infra3d it is empty.
+    sampleLabel(PanoSource.Infra3d).toCsvRow should endWith(",,40.8839912414551,-74.0243606567383")
+  }
+}


### PR DESCRIPTION
Closes #3853.

### Background
The Raw Labels API returned an `image_url` field that **unconditionally** built a Google Street View link from an *undocumented*, reverse-engineered URL (`https://www.google.com/maps/@{lat},{lng},3a,.../data=!3m...`). Two problems:

1. **Wrong for non-GSV labels.** Labels also come from **Mapillary** and **infra3d**, yet every label got a Google Maps URL.
2. **Brittle + misleading.** The `/maps/@.../data=!3m...` form is reverse-engineered (can silently break), and the name `image_url` implies an image when it's actually a viewer link.

(The original issue noticed an API-key placeholder; that had already been removed in an earlier rename, but the deeper problems remained.)

### Change
Replace `image_url` with a provider-aware **`pano_url`**, derived from the panorama's imagery source (`pano_data.source`, threaded through the query → `GetResult` converter → `LabelDataForApi`). The URLs mirror the canonical in-app "view in pano" links in `PanoInfoPopover.js`, so the API and frontend share one shape per provider:

| Provider | `pano_url` |
|----------|-----------|
| **GSV** | `https://www.google.com/maps/@?api=1&map_action=pano&pano={id}&heading={h}&pitch={p}` — Google's [officially documented Maps URLs API](https://developers.google.com/maps/documentation/urls/get-started#street-view-action), no key required (cited in code) |
| **Mapillary** | `https://www.mapillary.com/app/?pKey={id}&focus=photo` |
| **infra3d** | `null` (JSON) / empty (CSV, shapefile, GeoPackage) — no public shareable viewer exists |

Field renamed `image_url` → `pano_url` across **GeoJSON, CSV, shapefile (`panoUrl`), and GeoPackage**. v3 is a preview surface, so the rename is made in place (precedent: #4223).

### Tests
- New pure unit spec `LabelApiModelsSpec` (6 tests): all three providers, GSV no-API-key + heading/pitch passthrough, JSON `null` + CSV-empty for infra3d, old `image_url` key absent.
- Updated `RawLabelsApiSpec` CSV-header assertion.
- **9/9 green** via `sbt --client testOnly`.
- Manually validated the new SQL column position/`::text` cast/joins against real Teaneck data (positional-converter risk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)