### PR TITLE
Fix page-unload log submissions rejected by the CSRF filter (#3935)

### DIFF
--- a/app/controllers/ExploreController.scala
+++ b/app/controllers/ExploreController.scala
@@ -183,18 +183,6 @@ class ExploreController @Inject() (
   }
 
   /**
-   * Parse JSON data sent as plain text, convert it to JSON, and process it as JSON.
-   */
-  def postBeacon = cc.securityService.SecuredAction(parse.text) { implicit request =>
-    val json: JsValue = Json.parse(request.body)
-    val submission    = json.validate[AuditTaskSubmission]
-    submission.fold(
-      errors => { Future.successful(BadRequest(Json.obj("status" -> "Error", "message" -> JsError.toJson(errors)))) },
-      submission => { processAuditTaskSubmissions(submission, request.ipAddress, request.identity) }
-    )
-  }
-
-  /**
    * Parse the submitted data and insert them into tables.
    */
   def post = cc.securityService.SecuredAction(parse.json) { implicit request =>
@@ -208,7 +196,7 @@ class ExploreController @Inject() (
   /**
    * Helper function that updates database with all data submitted through the explore page.
    */
-  def processAuditTaskSubmissions(
+  private def processAuditTaskSubmissions(
       data: AuditTaskSubmission,
       ipAddress: String,
       user: SidewalkUserWithRole

--- a/app/controllers/GalleryController.scala
+++ b/app/controllers/GalleryController.scala
@@ -11,7 +11,7 @@ import play.api.Configuration
 import play.api.db.slick.{DatabaseConfigProvider, HasDatabaseConfigProvider}
 import play.api.i18n.Messages
 import play.api.libs.json.{JsError, JsValue, Json}
-import play.api.mvc.{Action, AnyContent, Result}
+import play.api.mvc.{Action, AnyContent}
 import play.silhouette.api.Silhouette
 import service._
 
@@ -132,36 +132,17 @@ class GalleryController @Inject() (
   }
 
   /**
-   * Take parsed JSON data and insert it into the database, only responding once the writes have committed.
-   */
-  def processGalleryTaskSubmissions(
-      submission: Seq[GalleryTaskSubmission],
-      ipAddress: String,
-      userId: String
-  ): Future[Result] = {
-    galleryService.submitGalleryTasks(submission, ipAddress, userId).map(_ => Ok("Got request"))
-  }
-
-  /**
-   * Parse JSON data sent as plain text, convert it to JSON, and process it as JSON.
-   */
-  def postBeacon = cc.securityService.SecuredAction(parse.text) { implicit request =>
-    val json       = Json.parse(request.body)
-    val submission = json.validate[Seq[GalleryTaskSubmission]]
-    submission.fold(
-      errors => { Future.successful(BadRequest(Json.obj("status" -> "Error", "message" -> JsError.toJson(errors)))) },
-      submission => { processGalleryTaskSubmissions(submission, request.ipAddress, request.identity.userId) }
-    )
-  }
-
-  /**
-   * Parse submitted gallery data and submit to tables.
+   * Parse submitted gallery data and insert it into the database, only responding once the writes have committed.
    */
   def post = cc.securityService.SecuredAction(parse.json) { implicit request =>
     val submission = request.body.validate[Seq[GalleryTaskSubmission]]
     submission.fold(
       errors => { Future.successful(BadRequest(Json.obj("status" -> "Error", "message" -> JsError.toJson(errors)))) },
-      submission => { processGalleryTaskSubmissions(submission, request.ipAddress, request.identity.userId) }
+      submission => {
+        galleryService
+          .submitGalleryTasks(submission, request.ipAddress, request.identity.userId)
+          .map(_ => Ok("Got request"))
+      }
     )
   }
 }

--- a/app/controllers/ValidateController.scala
+++ b/app/controllers/ValidateController.scala
@@ -273,7 +273,7 @@ class ValidateController @Inject() (
   /**
    * Helper function that updates database with all data submitted through the validation page.
    */
-  def processValidationTaskSubmissions(
+  private def processValidationTaskSubmissions(
       data: ValidationTaskSubmission,
       ipAddress: String,
       user: SidewalkUserWithRole
@@ -353,18 +353,6 @@ class ValidateController @Inject() (
     }
 
     response
-  }
-
-  /**
-   * Parse JSON data sent as plain text, convert it to JSON, and process it as JSON.
-   */
-  def postBeacon = cc.securityService.SecuredAction(parse.text) { implicit request =>
-    val json       = Json.parse(request.body)
-    val submission = json.validate[ValidationTaskSubmission]
-    submission.fold(
-      errors => { Future.successful(BadRequest(Json.obj("status" -> "Error", "message" -> JsError.toJson(errors)))) },
-      submission => { processValidationTaskSubmissions(submission, request.ipAddress, request.identity) }
-    )
   }
 
   /**

--- a/app/modules/CustomErrorHandler.scala
+++ b/app/modules/CustomErrorHandler.scala
@@ -2,7 +2,7 @@ package modules
 
 import models.api.ApiError
 import play.api.http.DefaultHttpErrorHandler
-import play.api.http.Status.{FORBIDDEN, NOT_FOUND}
+import play.api.http.Status.NOT_FOUND
 import play.api.libs.typedmap.TypedMap
 import play.api.mvc.Results._
 import play.api.mvc._
@@ -36,15 +36,13 @@ class CustomErrorHandler @Inject() (
 
   override def onClientError(request: RequestHeader, statusCode: Int, message: String): Future[Result] = {
     // Don't log common, harmless 404s
-    val shouldSkipLogging = (
+    val shouldSkipLogging =
       statusCode == NOT_FOUND && (
         request.path.endsWith(".map") ||              // Source maps
           request.path.startsWith("/.well-known/") || // Well-known URLs
           request.path == "/favicon.ico" ||           // Common favicon requests
           request.path.endsWith("-india.json")        // We only added the India files for en so far so we expect these.
       )
-    ) || // Beacon requests that we need to fix, but they happen constantly so we don't need this extra logging.
-      (statusCode == FORBIDDEN && request.path.contains("Beacon"))
 
     if (!shouldSkipLogging) {
       logger.warn(s"Client error occurred: ${request.uri} - $statusCode - $message")

--- a/app/views/apps/gallery.scala.html
+++ b/app/views/apps/gallery.scala.html
@@ -101,9 +101,8 @@
             // Path to assets
             params.rootDirectory = "/assets/javascripts/SVLabel/";
 
-            // URLs for where to send interaction data
+            // URL for where to send interaction data
             params.dataStoreUrl = '@routes.GalleryController.post';
-            params.beaconDataStoreUrl = params.dataStoreUrl + "Beacon";
 
             // Initial set of sidebar filters.
             params.initialFilters = {

--- a/app/views/apps/mobileValidate.scala.html
+++ b/app/views/apps/mobileValidate.scala.html
@@ -180,7 +180,6 @@
             svv.user = new User(userParam);
 
             param.dataStoreUrl = '@routes.ValidateController.post';
-            param.beaconDataStoreUrl = param.dataStoreUrl + "Beacon";
             param.hasNextMission = @validatePageData.hasNextMission;
             param.completedValidations = @validatePageData.completedValidations;
             param.language = "@messages.lang.code";

--- a/app/views/apps/validate.scala.html
+++ b/app/views/apps/validate.scala.html
@@ -261,7 +261,6 @@
             svv.user = new User(userParam);
 
             param.dataStoreUrl = '@routes.ValidateController.post';
-            param.beaconDataStoreUrl = param.dataStoreUrl + "Beacon";
             param.hasNextMission = @validatePageData.hasNextMission;
             param.completedValidations = @validatePageData.completedValidations;
             param.language = "@messages.lang.code";

--- a/conf/routes
+++ b/conf/routes
@@ -113,11 +113,8 @@ GET     /adminValidate                                  controllers.ValidateCont
 GET     /tasks                                          controllers.ExploreController.getTasksInARegion(regionId: Int)
 GET     /routeTasks                                     controllers.ExploreController.getTasksInARoute(userRouteId: Int)
 POST    /task                                           controllers.ExploreController.post
-POST    /taskBeacon                                     controllers.ExploreController.postBeacon
 POST    /validationTask                                 controllers.ValidateController.post
-POST    /validationTaskBeacon                           controllers.ValidateController.postBeacon
 POST    /galleryTask                                    controllers.GalleryController.post
-POST    /galleryTaskBeacon                              controllers.GalleryController.postBeacon
 POST    /labelmap/validate                              controllers.ValidateController.postLabelMapValidation
 POST    /labelmap/comment                               controllers.ValidateController.postLabelMapComment
 

--- a/public/javascripts/Gallery/src/Main.js
+++ b/public/javascripts/Gallery/src/Main.js
@@ -89,7 +89,7 @@ async function Main (params) {
         sg.keyboard = new Keyboard(sg.expandedView());
 
         // Initialize data collection.
-        sg.form = new Form(params.dataStoreUrl, params.beaconDataStoreUrl);
+        sg.form = new Form(params.dataStoreUrl);
         sg.tracker = new Tracker();
 
         let sidebarWrapper = sg.ui.cardFilter.wrapper;

--- a/public/javascripts/Gallery/src/data/Form.js
+++ b/public/javascripts/Gallery/src/data/Form.js
@@ -1,19 +1,36 @@
 /**
- * Compiles and submits log data from Gallery.
- *
- * @param {*} url URL to send interaction data to.
- * @returns {Form}
- * @constructor
+ * Compiles and submits Gallery interaction log data to the back end.
  */
-function Form(url) {
-    const dataStoreUrl = url;
+class Form {
+    #dataStoreUrl;
 
     /**
-     * Compiles data into a format that can be parsed by our backend.
-     * @returns {{}}
+     * @param {string} url - URL to send interaction data to.
      */
-    function compileSubmissionData() {
-        let data = {};
+    constructor(url) {
+        this.#dataStoreUrl = url;
+
+        // Flush any remaining logs when the page is being dismissed. `pagehide` is the reliable, bfcache-compatible
+        // unload signal; `keepalive` lets the POST outlive the page while still routing through AppManager's fetch
+        // wrapper, which attaches the `Csrf-Token` header Play's CSRF filter requires (#3935).
+        window.addEventListener('pagehide', () => {
+            sg.tracker.push("Unload");
+            const data = [this.compileSubmissionData()];
+            fetch(this.#dataStoreUrl, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json; charset=utf-8' },
+                body: JSON.stringify(data),
+                keepalive: true
+            });
+        });
+    }
+
+    /**
+     * Compiles the buffered interaction data into a format that can be parsed by our back end.
+     * @returns {Object} The log data to submit.
+     */
+    compileSubmissionData() {
+        const data = {};
 
         data.environment = {
             browser: util.getBrowser(),
@@ -34,53 +51,28 @@ function Form(url) {
     }
 
     /**
-     * Submits all front-end data to the backend.
+     * Submits front-end log data to the back end.
      *
-     * @param data  Data object containing interactions.
-     * @param async Whether to submit asynchronously or not.
-     * @returns {*}
+     * @param {Object|Object[]} data - A single submission object, or an array of them.
+     * @returns {Promise<void>}
      */
-    function submit(data, async) {
-        if (typeof async === "undefined") {
-            async = false;
-        }
-
+    submit(data) {
         if (data.constructor !== Array) {
             data = [data];
         }
 
-        $.ajax({
-            async: async,
-            contentType: 'application/json; charset=utf-8',
-            url: dataStoreUrl,
-            method: 'POST',
-            data: JSON.stringify(data),
-            success: function () {
-                console.log("Data logged successfully");
-            },
-            error: function (xhr, status, result) {
-                console.error(xhr.responseText);
-                console.error(result);
-            }
-        });
-    }
-
-    // Flush any remaining logs when the page is being dismissed. `pagehide` is the reliable, bfcache-compatible
-    // unload signal; `keepalive` lets the POST outlive the page while still routing through AppManager's fetch
-    // wrapper, which attaches the `Csrf-Token` header Play's CSRF filter requires (#3935).
-    window.addEventListener('pagehide', function () {
-        sg.tracker.push("Unload");
-        let data = [compileSubmissionData()];
-        fetch(dataStoreUrl, {
+        return fetch(this.#dataStoreUrl, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json; charset=utf-8' },
-            body: JSON.stringify(data),
-            keepalive: true
-        });
-    });
-
-    self.compileSubmissionData = compileSubmissionData;
-    self.submit = submit;
-
-    return self;
+            body: JSON.stringify(data)
+        })
+            .then((response) => {
+                if (response.ok) {
+                    console.log("Data logged successfully");
+                } else {
+                    console.error(`Failed to log data: ${response.status}`);
+                }
+            })
+            .catch((error) => { console.error(error); });
+    }
 }

--- a/public/javascripts/Gallery/src/data/Form.js
+++ b/public/javascripts/Gallery/src/data/Form.js
@@ -2,15 +2,11 @@
  * Compiles and submits log data from Gallery.
  *
  * @param {*} url URL to send interaction data to.
- * @param {*} beaconUrl URL to send interaction data to on page unload.
  * @returns {Form}
  * @constructor
  */
-function Form(url, beaconUrl) {
-    let properties = {
-        dataStoreUrl : url,
-        beaconDataStoreUrl : beaconUrl
-    };
+function Form(url) {
+    const dataStoreUrl = url;
 
     /**
      * Compiles data into a format that can be parsed by our backend.
@@ -56,7 +52,7 @@ function Form(url, beaconUrl) {
         $.ajax({
             async: async,
             contentType: 'application/json; charset=utf-8',
-            url: properties.dataStoreUrl,
+            url: dataStoreUrl,
             method: 'POST',
             data: JSON.stringify(data),
             success: function () {
@@ -69,21 +65,18 @@ function Form(url, beaconUrl) {
         });
     }
 
-    // On page unload, we compile stored interaction data and send it over.
-    $(window).on('beforeunload', function () {
+    // Flush any remaining logs when the page is being dismissed. `pagehide` is the reliable, bfcache-compatible
+    // unload signal; `keepalive` lets the POST outlive the page while still routing through AppManager's fetch
+    // wrapper, which attaches the `Csrf-Token` header Play's CSRF filter requires (#3935).
+    window.addEventListener('pagehide', function () {
         sg.tracker.push("Unload");
-
-        // April 17, 2019
-        // What we want here is type: 'application/json'. Can't do that quite yet because the
-        // feature has been disabled, but we should switch back when we can.
-        //
-        // // For now, we send plaintext and the server converts it to actual JSON
-        //
-        // Source for fix and ongoing discussion is here:
-        // https://bugs.chromium.org/p/chromium/issues/detail?id=490015
         let data = [compileSubmissionData()];
-        let jsonData = JSON.stringify(data);
-        navigator.sendBeacon(properties.beaconDataStoreUrl, jsonData);
+        fetch(dataStoreUrl, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json; charset=utf-8' },
+            body: JSON.stringify(data),
+            keepalive: true
+        });
     });
 
     self.compileSubmissionData = compileSubmissionData;

--- a/public/javascripts/Gallery/src/data/Tracker.js
+++ b/public/javascripts/Gallery/src/data/Tracker.js
@@ -98,7 +98,7 @@ function Tracker() {
         // TODO: change action buffer size limit
         if (actions.length > 10) {
             let data = sg.form.compileSubmissionData();
-            sg.form.submit(data, true);
+            sg.form.submit(data);
         }
         return this;
     }

--- a/public/javascripts/SVLabel/src/Main.js
+++ b/public/javascripts/SVLabel/src/Main.js
@@ -113,7 +113,7 @@ function Main (params) {
 
         svl.missionModel.trigger("MissionFactory:create", params.mission); // create current mission and set as current
         svl.form = new Form(svl.labelContainer, svl.missionModel, svl.missionContainer, svl.panoStore,
-            svl.taskContainer, svl.navigationService, svl.compass, svl.tracker, params.dataStoreUrl);
+            svl.taskContainer, svl.tracker, params.dataStoreUrl);
         if (params.mission.current_audit_task_id) {
             const currTask = svl.taskContainer.getCurrentTask();
             const currTaskId = currTask.getProperty('auditTaskId');

--- a/public/javascripts/SVLabel/src/data/Form.js
+++ b/public/javascripts/SVLabel/src/data/Form.js
@@ -17,7 +17,6 @@ function Form (labelContainer, missionModel, missionContainer, panoStore, taskCo
     const self = this;
     let properties = {
         dataStoreUrl : undefined,
-        beaconDataStoreUrl : undefined,
         lastPriorityUpdateTime : new Date() // Assumes that priorities are up-to-date when the page loads.
     };
     const compileDataLock = new AsyncLock();
@@ -216,23 +215,20 @@ function Form (labelContainer, missionModel, missionContainer, panoStore, taskCo
     };
 
     properties.dataStoreUrl = dataStoreUrl;
-    properties.beaconDataStoreUrl = dataStoreUrl + 'Beacon';
 
-    $(window).on('beforeunload', function () {
+    // Flush any remaining logs when the page is being dismissed. `pagehide` is the reliable, bfcache-compatible
+    // unload signal; `keepalive` lets the POST outlive the page while still routing through AppManager's fetch
+    // wrapper, which attaches the `Csrf-Token` header Play's CSRF filter requires (#3935).
+    window.addEventListener('pagehide', function () {
         tracker.push("Unload");
-
-        // April 17, 2019
-        // What we want here is type: 'application/json'. Can't do that quite yet because the
-        // feature has been disabled, but we should switch back when we can.
-
-        // For now, we send plaintext and the server converts it to actual JSON
-
-        // Source for fix and ongoing discussion is here:
-        // https://bugs.chromium.org/p/chromium/issues/detail?id=490015
         const task = taskContainer.getCurrentTask();
         const data = _compileSubmissionData(task);
-        const jsonData = JSON.stringify(data);
-        navigator.sendBeacon(properties.beaconDataStoreUrl, jsonData);
+        fetch(properties.dataStoreUrl, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json; charset=utf-8' },
+            body: JSON.stringify(data),
+            keepalive: true
+        });
     });
 
     /**

--- a/public/javascripts/SVLabel/src/data/Form.js
+++ b/public/javascripts/SVLabel/src/data/Form.js
@@ -1,37 +1,65 @@
 /**
- * Handles submitting interaction data to the back end.
- *
- * @param {LabelContainer} labelContainer
- * @param {MissionModel} missionModel
- * @param {MissionContainer} missionContainer
- * @param {PanoStore} panoStore
- * @param {TaskContainer} taskContainer
- * @param {NavigationService} navigationService
- * @param {Compass} compass
- * @param {Tracker} tracker
- * @param {string} dataStoreUrl
- * @returns {{className: string}}
- * @constructor
+ * Handles compiling and submitting Explore/Audit interaction data to the back end.
  */
-function Form (labelContainer, missionModel, missionContainer, panoStore, taskContainer, navigationService, compass, tracker, dataStoreUrl) {
-    const self = this;
-    let properties = {
-        dataStoreUrl : undefined,
-        lastPriorityUpdateTime : new Date() // Assumes that priorities are up-to-date when the page loads.
-    };
-    const compileDataLock = new AsyncLock();
-
-    missionModel.on("MissionProgress:complete", () => {
-        self.submitData(taskContainer.getCurrentTask());
-    });
+class Form {
+    #labelContainer;
+    #missionModel;
+    #missionContainer;
+    #panoStore;
+    #taskContainer;
+    #tracker;
+    #dataStoreUrl;
+    #lastPriorityUpdateTime;
+    #compileDataLock;
 
     /**
-     * Gathers all the data needed to submit logs to back end. Uses a lock to prevent duplicate logging.
-     * @param task
-     * @returns {object} The JSON data to submit to the back end.
+     * @param {LabelContainer} labelContainer - Holds the labels placed during the current session.
+     * @param {MissionModel} missionModel - Emits mission lifecycle events (e.g. progress completion).
+     * @param {MissionContainer} missionContainer - Tracks the current mission and its progress.
+     * @param {PanoStore} panoStore - Holds metadata for the panoramas seen this session.
+     * @param {TaskContainer} taskContainer - Tracks the current audit task.
+     * @param {Tracker} tracker - Buffers the interaction log to be flushed to the back end.
+     * @param {string} dataStoreUrl - URL to POST submission data to.
      */
-    const _compileSubmissionData = (task) => {
-        const mission = missionContainer.getCurrentMission();
+    constructor(labelContainer, missionModel, missionContainer, panoStore, taskContainer, tracker, dataStoreUrl) {
+        this.#labelContainer = labelContainer;
+        this.#missionModel = missionModel;
+        this.#missionContainer = missionContainer;
+        this.#panoStore = panoStore;
+        this.#taskContainer = taskContainer;
+        this.#tracker = tracker;
+        this.#dataStoreUrl = dataStoreUrl;
+        this.#lastPriorityUpdateTime = new Date(); // Assumes that priorities are up-to-date when the page loads.
+        this.#compileDataLock = new AsyncLock();
+
+        this.#missionModel.on("MissionProgress:complete", () => {
+            this.submitData(this.#taskContainer.getCurrentTask());
+        });
+
+        // Flush any remaining logs when the page is being dismissed. `pagehide` is the reliable, bfcache-compatible
+        // unload signal; `keepalive` lets the POST outlive the page while still routing through AppManager's fetch
+        // wrapper, which attaches the `Csrf-Token` header Play's CSRF filter requires (#3935).
+        window.addEventListener('pagehide', () => {
+            this.#tracker.push("Unload");
+            const task = this.#taskContainer.getCurrentTask();
+            const data = this.#compileSubmissionData(task);
+            fetch(this.#dataStoreUrl, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json; charset=utf-8' },
+                body: JSON.stringify(data),
+                keepalive: true
+            });
+        });
+    }
+
+    /**
+     * Gathers all the data needed to submit logs to the back end.
+     *
+     * @param {Task} task - The audit task to compile submission data for.
+     * @returns {Object} The JSON data to submit to the back end.
+     */
+    #compileSubmissionData(task) {
+        const mission = this.#missionContainer.getCurrentMission();
         const missionId = mission.getProperty("missionId");
         mission.updateDistanceProgress();
 
@@ -55,7 +83,7 @@ function Form (labelContainer, missionModel, missionContainer, panoStore, taskCo
                 current_lng: svl.panoViewer.getPosition().lng,
                 start_point_reversed: task.getProperty("startPointReversed"),
                 current_mission_start: task.getMissionStart(missionId),
-                last_priority_update_time: properties.lastPriorityUpdateTime,
+                last_priority_update_time: this.#lastPriorityUpdateTime,
                 // Request updated street priorities if we are at least 60% of the way through the current street.
                 request_updated_street_priority: !svl.isOnboarding() && (task.getAuditedDistance() / task.lineDistance()) > 0.6
             },
@@ -67,24 +95,24 @@ function Form (labelContainer, missionModel, missionContainer, panoStore, taskCo
                 screen_width: screen.width,
                 screen_height: screen.height,
                 avail_width: screen.availWidth,              // total width - interface (taskbar)
-                avail_height: screen.availHeight,            // total height - interface };
+                avail_height: screen.availHeight,            // total height - interface
                 operating_system: util.getOperatingSystem(),
                 language: i18next.language,
-                css_zoom: 100 // The UI no longer uses CSS zoom; scaling is done via real layout sizes (--ui-scale).
+                css_zoom: 100 // Sent for back-end compatibility; UI scaling is done via real layout sizes (--ui-scale).
             }
         };
 
-        data.interactions = tracker.getActions();
-        tracker.refresh();
+        data.interactions = this.#tracker.getActions();
+        this.#tracker.refresh();
 
         data.labels = [];
-        const labels = labelContainer.getLabelsToLog();
+        const labels = this.#labelContainer.getLabelsToLog();
         for (let i = 0, labelLen = labels.length; i < labelLen; i += 1) {
             let label = labels[i];
             let prop = label.getProperties();
             const labelLatLng = label.toLatLng();
             const tempLabelId = label.getProperty('temporaryLabelId');
-            const panoData = panoStore.getPanoData(prop.panoId);
+            const panoData = this.#panoStore.getPanoData(prop.panoId);
 
             // If this label is a new label, get the timestamp of its creation from the corresponding interaction.
             const associatedInteraction = data.interactions.find(interaction =>
@@ -129,7 +157,7 @@ function Form (labelContainer, missionModel, missionContainer, panoStore, taskCo
         data.panos = [];
 
         let temp;
-        const panoramas = panoStore.getStagedPanoData();
+        const panoramas = this.#panoStore.getStagedPanoData();
         for (let i = 0; i < panoramas.length; i++) {
             const panoData = panoramas[i].getProperties();
             const links = panoData.linkedPanos.map(function(link) {
@@ -168,17 +196,19 @@ function Form (labelContainer, missionModel, missionContainer, panoStore, taskCo
             panoramas[i].setProperty('submitted', true);
         }
         return data;
-    };
+    }
 
     /**
-     * Submit the data via an AJAX post request.
-     * @param data
-     * @param task
+     * Submit the compiled data to the back end and apply the server's response.
+     *
+     * @param {Object} data - The compiled submission data.
+     * @param {Task} task - The audit task the data belongs to.
+     * @returns {Promise<void>}
      */
-    this._submit = function (data, task) {
-        labelContainer.clearLabelsToLog();
+    #submit(data, task) {
+        this.#labelContainer.clearLabelsToLog();
 
-        return fetch(properties.dataStoreUrl, {
+        return fetch(this.#dataStoreUrl, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json; charset=utf-8' },
             body: JSON.stringify(data)
@@ -192,18 +222,18 @@ function Form (labelContainer, missionModel, missionContainer, panoStore, taskCo
                 if (result.refresh_page) window.location.reload();
 
                 // If a new mission was sent and we aren't in onboarding, create an object for it on the front-end.
-                if (result.mission && !svl.isOnboarding()) missionModel.createAMission(result.mission);
+                if (result.mission && !svl.isOnboarding()) this.#missionModel.createAMission(result.mission);
 
                 // Update the priority of streets audited by other users that are auditing at the same time.
                 if (result.updated_streets) {
-                    properties.lastPriorityUpdateTime = result.updated_streets.last_priority_update_time;
-                    taskContainer.updateTaskPriorities(result.updated_streets.updated_street_priorities);
+                    this.#lastPriorityUpdateTime = result.updated_streets.last_priority_update_time;
+                    this.#taskContainer.updateTaskPriorities(result.updated_streets.updated_street_priorities);
                 }
 
                 // Update labels with their official label_id from the server.
                 if (!svl.isOnboarding()) {
                     for (const lab of result.label_ids) {
-                        labelContainer.getAllLabels()
+                        this.#labelContainer.getAllLabels()
                             .find(l => l.getProperty('temporaryLabelId') === lab.temporary_label_id)
                             .updateLabelIdAndUploadCrop(lab.label_id);
                     }
@@ -212,36 +242,21 @@ function Form (labelContainer, missionModel, missionContainer, panoStore, taskCo
             .catch(error => {
                 window.location.reload(); // Refresh the page in case the server has gone down.
             });
-    };
-
-    properties.dataStoreUrl = dataStoreUrl;
-
-    // Flush any remaining logs when the page is being dismissed. `pagehide` is the reliable, bfcache-compatible
-    // unload signal; `keepalive` lets the POST outlive the page while still routing through AppManager's fetch
-    // wrapper, which attaches the `Csrf-Token` header Play's CSRF filter requires (#3935).
-    window.addEventListener('pagehide', function () {
-        tracker.push("Unload");
-        const task = taskContainer.getCurrentTask();
-        const data = _compileSubmissionData(task);
-        fetch(properties.dataStoreUrl, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json; charset=utf-8' },
-            body: JSON.stringify(data),
-            keepalive: true
-        });
-    });
+    }
 
     /**
-     * Compile and submit existing logs to the server.
-     * @param {Task} [task] The task to submit data for. If not provided, the current task is used.
+     * Compile and submit existing logs to the server. Uses a lock to prevent duplicate logging.
+     *
+     * @param {Task} [task] - The task to submit data for. If not provided, the current task is used.
+     * @returns {Promise<void>}
      */
-    this.submitData = async function(task) {
-        return await compileDataLock.acquire('submitData', async () => {
+    async submitData(task) {
+        return await this.#compileDataLock.acquire('submitData', async () => {
             if (typeof task === "undefined") {
-                task = taskContainer.getCurrentTask();
+                task = this.#taskContainer.getCurrentTask();
             }
-            const data = _compileSubmissionData(task);
-            await self._submit(data, task);
+            const data = this.#compileSubmissionData(task);
+            await this.#submit(data, task);
         });
     }
 }

--- a/public/javascripts/SVValidate/src/Main.js
+++ b/public/javascripts/SVValidate/src/Main.js
@@ -113,7 +113,7 @@ function Main (param) {
 
         svv.validationMenu = isMobile() ? new MobileValidationMenu(svv.ui.validationMenu) : new DesktopValidationMenu(svv.ui.validationMenu);
 
-        svv.form = new Form(param.dataStoreUrl, param.beaconDataStoreUrl);
+        svv.form = new Form(param.dataStoreUrl);
 
         if (svv.adminVersion) svv.adminInfo = new AdminInfo(svv.ui.status.admin);
 

--- a/public/javascripts/SVValidate/src/data/Form.js
+++ b/public/javascripts/SVValidate/src/data/Form.js
@@ -1,9 +1,35 @@
-function Form(url) {
-    let properties = {
-        dataStoreUrl : url
-    };
+/**
+ * Compiles and submits Validate interaction and validation data to the back end.
+ */
+class Form {
+    #dataStoreUrl;
 
-    function getSource() {
+    /**
+     * @param {string} url - URL to send validation/interaction data to.
+     */
+    constructor(url) {
+        this.#dataStoreUrl = url;
+
+        // Flush any remaining logs when the page is being dismissed. `pagehide` is the reliable, bfcache-compatible
+        // unload signal; `keepalive` lets the POST outlive the page while still routing through AppManager's fetch
+        // wrapper, which attaches the `Csrf-Token` header Play's CSRF filter requires (#3935).
+        window.addEventListener('pagehide', () => {
+            svv.tracker.push('Unload');
+            const data = this.compileSubmissionData(false);
+            fetch(this.#dataStoreUrl, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json; charset=utf-8' },
+                body: JSON.stringify(data),
+                keepalive: true
+            });
+        });
+    }
+
+    /**
+     * Returns the source label identifying which Validate UI produced the data.
+     * @returns {string} One of 'ValidateMobile', 'ExpertValidate', or 'Validate'.
+     */
+    getSource() {
         if (isMobile()) {
             return 'ValidateMobile';
         } else if (svv.adminVersion) {
@@ -14,12 +40,13 @@ function Form(url) {
     }
 
     /**
-     * Compiles data into a format that can be parsed by our backend.
-     * @returns {{}}
-     * @param {boolean} missionComplete Whether or not the mission is complete. To ensure we only send once per mission.
+     * Compiles data into a format that can be parsed by our back end.
+     *
+     * @param {boolean} missionComplete - Whether the mission is complete. Ensures we only send once per mission.
+     * @returns {Object} The log data to submit.
      */
-    function compileSubmissionData(missionComplete) {
-        let data = { timestamp: new Date(), source: getSource() };
+    compileSubmissionData(missionComplete) {
+        let data = { timestamp: new Date(), source: this.getSource() };
         let missionContainer = svv.missionContainer;
         let mission = missionContainer ? missionContainer.getCurrentMission() : null;
 
@@ -56,10 +83,10 @@ function Form(url) {
             screen_width: screen.width,
             screen_height: screen.height,
             avail_width: screen.availWidth,              // total width - interface (taskbar)
-            avail_height: screen.availHeight,            // total height - interface };
+            avail_height: screen.availHeight,            // total height - interface ;
             operating_system: util.getOperatingSystem(),
             language: i18next.language,
-            css_zoom: 100 // The UI no longer uses CSS zoom; scaling is done via real layout sizes (--ui-scale).
+            css_zoom: 100 // Sent for back-end compatibility; UI scaling is done via real layout sizes (--ui-scale).
         };
 
         data.validate_params = {
@@ -98,12 +125,13 @@ function Form(url) {
     }
 
     /**
-     * Submits all front-end data to the backend.
-     * @param data  Data object (containing Interactions, Missions, etc...)
+     * Submits all front-end data to the back end.
+     *
+     * @param {Object} data - Data object (containing interactions, missions, etc.).
      * @returns {Promise<void>}
      */
-    function submit(data) {
-        return fetch(properties.dataStoreUrl, {
+    submit(data) {
+        return fetch(this.#dataStoreUrl, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json; charset=utf-8' },
             body: JSON.stringify(data)
@@ -128,24 +156,4 @@ function Form(url) {
                 window.location.reload(); // Refresh the page in case the server has gone down.
             });
     }
-
-    // Flush any remaining logs when the page is being dismissed. `pagehide` is the reliable, bfcache-compatible
-    // unload signal; `keepalive` lets the POST outlive the page while still routing through AppManager's fetch
-    // wrapper, which attaches the `Csrf-Token` header Play's CSRF filter requires (#3935).
-    window.addEventListener('pagehide', function () {
-        svv.tracker.push('Unload');
-        let data = compileSubmissionData(false);
-        fetch(properties.dataStoreUrl, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json; charset=utf-8' },
-            body: JSON.stringify(data),
-            keepalive: true
-        });
-    });
-
-    self.getSource = getSource;
-    self.compileSubmissionData = compileSubmissionData;
-    self.submit = submit;
-
-    return self;
 }

--- a/public/javascripts/SVValidate/src/data/Form.js
+++ b/public/javascripts/SVValidate/src/data/Form.js
@@ -1,7 +1,6 @@
-function Form(url, beaconUrl) {
+function Form(url) {
     let properties = {
-        dataStoreUrl : url,
-        beaconDataStoreUrl : beaconUrl
+        dataStoreUrl : url
     };
 
     function getSource() {
@@ -130,20 +129,18 @@ function Form(url, beaconUrl) {
             });
     }
 
-    $(window).on('beforeunload', function () {
+    // Flush any remaining logs when the page is being dismissed. `pagehide` is the reliable, bfcache-compatible
+    // unload signal; `keepalive` lets the POST outlive the page while still routing through AppManager's fetch
+    // wrapper, which attaches the `Csrf-Token` header Play's CSRF filter requires (#3935).
+    window.addEventListener('pagehide', function () {
         svv.tracker.push('Unload');
-
-        // April 17, 2019
-        // What we want here is type: 'application/json'. Can't do that quite yet because the
-        // feature has been disabled, but we should switch back when we can.
-        //
-        // // For now, we send plaintext and the server converts it to actual JSON
-        //
-        // Source for fix and ongoing discussion is here:
-        // https://bugs.chromium.org/p/chromium/issues/detail?id=490015
         let data = compileSubmissionData(false);
-        let jsonData = JSON.stringify(data);
-        navigator.sendBeacon(properties.beaconDataStoreUrl, jsonData);
+        fetch(properties.dataStoreUrl, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json; charset=utf-8' },
+            body: JSON.stringify(data),
+            keepalive: true
+        });
     });
 
     self.getSource = getSource;


### PR DESCRIPTION
Fixes #3935.

## Problem

On Explore, Validate, and Gallery, remaining logs were flushed on `beforeunload` via `navigator.sendBeacon` to dedicated `*Beacon` endpoints. `sendBeacon` can't set request headers, so it never carried the `Csrf-Token` that AppManager's `fetch` wrapper attaches — and Play's CSRF filter rejected every one of these submissions, silently losing the data. The whole `parse.text`/"send plaintext, server re-parses as JSON" design was a 2019 workaround for a long-since-fixed Chromium bug.

## Fix

Send the unload flush with `fetch(..., { keepalive: true })` instead:

- `keepalive` lets the POST outlive the page (the spec-sanctioned replacement for `sendBeacon`) while routing through the global `fetch` wrapper, so it carries the CSRF token.
- It posts real `application/json`, so it can hit the **normal** data-store endpoints — letting us delete the parallel beacon plumbing entirely: the three `postBeacon` controller actions, their routes, and the `beaconDataStoreUrl` bindings/params across the views and JS.
- Switched the trigger from the deprecated `beforeunload` to **`pagehide`** (reliable, bfcache-compatible terminal unload signal). Deliberately *not* `visibilitychange→hidden`: SVLabel's unload path sends `getLabelsToLog()` without clearing it, so firing on every tab-switch would duplicate labels server-side and preempt crop upload. `pagehide` fires once on actual dismissal — a safe 1:1 swap. (Tradeoff: like `beforeunload`, neither fires when a mobile OS silently kills a backgrounded tab. Closing that gap needs a larger refactor — noted as a follow-up.)
- Removed the now-dead `CustomErrorHandler` clause that muted `FORBIDDEN` logging on `*Beacon` paths, so any future genuine 403 on an unload POST surfaces in the logs.

## Cleanup carried in this branch

- The single-caller `processAuditTaskSubmissions`/`processValidationTaskSubmissions` helpers (originally extracted to share with the beacon endpoints) are now `private`; Gallery's one-liner was inlined. The larger move of pushing that orchestration into the service layer is filed as #4325.
- Converted all three `Form.js` files from `function Foo(){…}` constructors to ES6 `class`es (`#private` fields/methods, JSDoc, arrow-bound `pagehide` listeners), converted Gallery's normal-submit path from `$.ajax` to `fetch`, and dropped the unused `navigationService`/`compass` params from the SVLabel `Form` constructor.

## Testing

- Backend compiles warning-clean under `-Xfatal-warnings` (sbt thin client); `node --check` passes on all touched JS.
- Needs manual verification of the panorama flows (can't be automated): normal mid-session submits on all three tools, mission-complete → next-mission load on Validate, Explore audit-task creation on load, and that the `pagehide` unload POST 200s with the `Csrf-Token` header present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)