### PR TITLE
Fix Explore page occasionally refreshing from mission-complete map crash (#4204)

### DIFF
--- a/public/javascripts/SVLabel/src/modal/ModalMissionComplete.js
+++ b/public/javascripts/SVLabel/src/modal/ModalMissionComplete.js
@@ -200,8 +200,11 @@ class ModalMissionComplete {
                 if (task.isComplete()) {
                     end = task.getEndCoordinate();
                 } else {
-                    const furthest = task.getFurthestPointReached().geometry.coordinates;
-                    end = { lat: furthest[1], lng: furthest[0] };
+                    // The furthest point is only recorded once the user advances along a street; without it (e.g. a
+                    // street reached via a jump that the user never moved along) there's nothing to draw here. (#4204)
+                    const furthest = task.getFurthestPointReached();
+                    if (!furthest) return null;
+                    end = { lat: furthest.geometry.coordinates[1], lng: furthest.geometry.coordinates[0] };
                 }
                 coordinates = task.getSubsetOfCoordinates(start, end);
             } else {
@@ -243,10 +246,28 @@ class ModalMissionComplete {
             : this.#taskContainer.getCompletedTasksAllUsersUsingPriority();
 
         return {
-            thisMission: { type: 'FeatureCollection', features: thisMissionFeatures },
-            previous: { type: 'FeatureCollection', features: previousFeatures },
-            community: { type: 'FeatureCollection', features: communityTasks.map(task => task.getFeature()) }
+            thisMission: { type: 'FeatureCollection', features: thisMissionFeatures.filter(this.#isDrawableLine) },
+            previous: { type: 'FeatureCollection', features: previousFeatures.filter(this.#isDrawableLine) },
+            community: {
+                type: 'FeatureCollection',
+                features: communityTasks.map(task => task.getFeature()).filter(this.#isDrawableLine)
+            }
         };
+    }
+
+    /**
+     * Reports whether a LineString feature has enough real coordinates to hand to Mapbox. A mission can cover ~zero
+     * usable length of a street (it ended at a street boundary, the street was reached via a jump, etc.), in which case
+     * turf.lineSlice/cleanCoords collapses the segment to a single point or nothing. Mapbox then throws deep in its
+     * tiler ("Cannot read properties of null (reading 'x')") and the failure bubbles up into a page reload; filtering
+     * those degenerate features out here keeps them out of the source entirely. (#4204)
+     * @param {object} feature A GeoJSON Feature, or null/undefined.
+     * @returns {boolean} True if the feature is a LineString with at least two finite [lng, lat] coordinates.
+     */
+    #isDrawableLine(feature) {
+        const coords = feature?.geometry?.coordinates;
+        if (!Array.isArray(coords) || coords.length < 2) return false;
+        return coords.every(c => Array.isArray(c) && Number.isFinite(c[0]) && Number.isFinite(c[1]));
     }
 
     /**


### PR DESCRIPTION
Fixes #4204.

## Problem
The Explore page occasionally refreshed itself. The trigger was the mission-complete modal map throwing `TypeError: Cannot read properties of null (reading 'x')` from inside Mapbox's tiler (on the old `getSource('mission-tasks').setData(...)`, now `addSource` in the rewritten map). Because `#buildStreetTiers` runs *synchronously* as an argument to `this.#map.update(...)` — before the `.catch` is attached — the throw escaped the modal and bubbled up into `Form.js`'s reload `.catch`, masquerading as a server-down refresh.

The size-race theory (map created while the modal is hidden) was ruled out by experiment: delaying `resize()` did not reproduce the crash. The real cause is **data-dependent degenerate geometry** reaching the map source, which matches the "occasional" reports.

## Fix
In `ModalMissionComplete.#buildStreetTiers`:

- **Missing furthest point:** `getFurthestPointReached()` is `undefined` until the user advances along a street, so a street reached via a jump (and never moved along) threw on `.geometry`. That task is now skipped (returns `null`, filtered out).
- **Single-point LineStrings:** when a mission covers ~zero usable length of a street, `turf.lineSlice`/`cleanCoords` collapses the segment to one coordinate (or none). A new `#isDrawableLine` guard filters every tier (`thisMission`, `previous`, `community`) to features with at least two finite `[lng, lat]` coordinates before they reach `addSource`.

## Risk / testing
Low. `#isDrawableLine` is a pass-through for valid lines, so well-formed missions render identically — it only removes geometry that would otherwise crash Mapbox. Hard to reproduce on demand; the most reliable trigger is finishing a mission on a street reached via a jump that you never moved along.

🤖 Generated with [Claude Code](https://claude.com/claude-code)