### PR TITLE
Fix Mapillary "far away from route" flash and stale peg/observed-area on move (#4174)

### DIFF
--- a/public/javascripts/SVLabel/src/navigation/Compass.js
+++ b/public/javascripts/SVLabel/src/navigation/Compass.js
@@ -246,7 +246,8 @@ function Compass (svl, navigationService, taskContainer) {
             if (_checkEnRoute()) {
                 self.stopBlinking();
                 self.setTurnMessage();
-            } else {
+            } else if (!navigationService.getStatus('movingToNewLocation')) {
+                // Only warn that the user is off-route if they're not mid-move. (#4174)
                 self.blink();
                 _setBackToRouteMessage();
             }

--- a/public/javascripts/SVLabel/src/navigation/NavigationService.js
+++ b/public/javascripts/SVLabel/src/navigation/NavigationService.js
@@ -14,7 +14,11 @@ function NavigationService (neighborhoodModel, uiStreetview) {
         disableWalking: false,
         lockDisableWalking: false,
         labelBeforeJumpState: false,
-        contextMenuWasOpen: false
+        contextMenuWasOpen: false,
+        // True during a move until getPosition() is final; gates position-dependent views like the off-route warning.
+        movingToNewLocation: false,
+        // True from a move's start until getPov() stops settling; we hold their pre-move heading until then. (#4174)
+        headingSettling: false
     };
 
     /**
@@ -24,6 +28,7 @@ function NavigationService (neighborhoodModel, uiStreetview) {
     let missionJump = undefined;
     let _stuckPanos = new Set([]);
     let positionUpdateCallbacks = [];
+    let _povSettlePoll = null; // Interval id; see _refreshHeadingViewsAfterPovSettles.
 
     const END_OF_STREET_THRESHOLD = 25; // Distance from the endpoint of the street when we consider it complete (meters).
     const moveDelay = 800; // Move delay prevents users from spamming through a mission.
@@ -133,7 +138,9 @@ function NavigationService (neighborhoodModel, uiStreetview) {
                 svl.stuckAlert.stuckSkippedStreet();
                 return moveForward();
             } else {
-                // Complete current neighborhood if no new task is available.
+                // No new task: complete the neighborhood. This path skips _updateUiAfterMove(), so clear the flags here.
+                status.movingToNewLocation = false;
+                status.headingSettling = false;
                 svl.neighborhoodModel.setComplete();
                 svl.missionController.wrapUpRouteOrNeighborhood();
                 return Promise.resolve(null);
@@ -155,6 +162,11 @@ function NavigationService (neighborhoodModel, uiStreetview) {
     }
 
     async function jumpToANewTask() {
+        // Flag the move before setCurrentTask() below, which synchronously calls compass.update() while still at the
+        // old location — otherwise it would flash the off-route warning before moveForward() sets these. (#4174)
+        status.movingToNewLocation = true;
+        status.headingSettling = true;
+
         // Finish the current task.
         const mission = missionJump || svl.missionContainer.getCurrentMission()
         finishCurrentTaskBeforeJumping(mission);
@@ -246,6 +258,8 @@ function NavigationService (neighborhoodModel, uiStreetview) {
      * @private
      */
     function _updateUiBeforeMove() {
+        status.movingToNewLocation = true;
+        status.headingSettling = true;
         svl.feedbackModal.hide();
         if (svl.contextMenu.isOpen()) {
             svl.contextMenu.hide();
@@ -294,15 +308,13 @@ function NavigationService (neighborhoodModel, uiStreetview) {
         }
         svl.missionModel.updateMissionProgress(currentMission, neighborhood);
 
-        // Update the minimap location and observed area viz.
-        svl.minimap.setMinimapLocation(newLatLng);
-        svl.peg.setHeading(svl.panoViewer.getPov().heading);
-        svl.observedArea.panoChanged();
-        svl.observedArea.update();
+        // Position is final, so position-dependent checks can run again; heading is still settling (handled below).
+        status.movingToNewLocation = false;
 
-        // Update the compass navigation messages.
-        svl.compass.update();
+        // Update position-dependent views now; heading-dependent ones wait for the pov to settle.
+        svl.minimap.setMinimapLocation(newLatLng);
         svl.compass.enableCompassClick();
+        _refreshHeadingViewsAfterPovSettles();
 
         // Re-enable the keyboard.
         svl.keyboard.setStatus("disableKeyboard", false);
@@ -317,6 +329,45 @@ function NavigationService (neighborhoodModel, uiStreetview) {
 
         // Enable moving again after a timeout.
         setTimeout(resetWalking, moveDelay);
+    }
+
+    /**
+     * Once the viewer's heading stops changing after a move (Mapillary keeps animating it briefly), refreshes the
+     * heading-dependent views — peg, observed-area FOV, compass — with the settled pov. Until then those views keep
+     * their pre-move orientation. Aborts if a new move begins (it runs its own refresh); GSV, whose pov is final
+     * immediately, settles after the first couple of ticks.
+     */
+    function _refreshHeadingViewsAfterPovSettles() {
+        if (_povSettlePoll) window.clearInterval(_povSettlePoll); // Replace any in-flight poll from a prior move.
+
+        let prevHeading = svl.panoViewer.getPov().heading;
+        let stableTicks = 0;
+        const startTime = performance.now();
+        const pollMs = 80;
+        const maxSettleMs = 1500; // Stop polling even if the heading never fully stabilizes.
+
+        _povSettlePoll = window.setInterval(() => {
+            if (status.movingToNewLocation) { // A new move took over.
+                window.clearInterval(_povSettlePoll);
+                _povSettlePoll = null;
+                return;
+            }
+
+            const heading = svl.panoViewer.getPov().heading;
+            const headingDelta = Math.abs(((heading - prevHeading + 540) % 360) - 180); // Shortest angular distance.
+            prevHeading = heading;
+            stableTicks = headingDelta < 0.5 ? stableTicks + 1 : 0;
+
+            if (stableTicks >= 2 || performance.now() - startTime > maxSettleMs) {
+                window.clearInterval(_povSettlePoll);
+                _povSettlePoll = null;
+                status.headingSettling = false; // Clear first so observedArea.update() recomputes from the settled pov.
+                svl.peg.setHeading(heading);
+                svl.observedArea.panoChanged();
+                svl.observedArea.update();
+                svl.compass.update();
+            }
+        }, pollMs);
     }
 
     /**

--- a/public/javascripts/SVLabel/src/navigation/ObservedArea.js
+++ b/public/javascripts/SVLabel/src/navigation/ObservedArea.js
@@ -212,7 +212,11 @@ class ObservedArea {
     update() {
         if (this.#observedAreas.length > 0) {
             this.#syncCanvasSize();
-            this.#updateAngles();
+            // While the heading is settling after a move, hold the FOV at its pre-move angles rather than recomputing
+            // from the mid-animation heading; the settle poll recomputes once it's final. (#4174)
+            if (!svl.navigationService || !svl.navigationService.getStatus('headingSettling')) {
+                this.#updateAngles();
+            }
             this.#renderFogOfWar();
             this.#renderFov();
             this.#renderProgressCircle();

--- a/public/javascripts/SVLabel/src/panorama/PanoManager.js
+++ b/public/javascripts/SVLabel/src/panorama/PanoManager.js
@@ -350,8 +350,13 @@ class PanoManager {
         const heading = svl.panoViewer.getPov().heading;
         if (svl.canvas) this.updateCanvas();
         if (svl.compass) svl.compass.update();
-        if (svl.observedArea) svl.observedArea.update();
-        if (svl.peg) svl.peg.setHeading(heading);
+
+        // Skip the heading-dependent viz while the heading is still settling; NavigationService's settle poll handles
+        // the final update so these don't swing through the mid-animation heading. (#4174)
+        if (!svl.navigationService || !svl.navigationService.getStatus('headingSettling')) {
+            if (svl.observedArea) svl.observedArea.update();
+            if (svl.peg) svl.peg.setHeading(heading);
+        }
 
         const arrowGroup = svl.ui.streetview.navArrows[0];
         arrowGroup.setAttribute('transform', `rotate(${-heading})`);


### PR DESCRIPTION
Fixes #4174.

## Problem

With Mapillary imagery, moving/jumping between streets caused two glitches:
- The **"Uh-oh, you're quite far away from the route"** warning flashed mid-move, even though it couldn't be interacted with.
- The **peg** and **observed-area FOV** briefly pointed the wrong direction before settling on the correct heading.

## Root causes & fixes

**1. Off-route warning flash.** During a jump, `setCurrentTask()` switches the current task to the new street and synchronously calls `compass.update()` — while `getPosition()` still reports the old location, so the route-proximity check sees the user as "far away." A `movingToNewLocation` flag now brackets the move (set up front in `jumpToANewTask()` and `_updateUiBeforeMove()`, cleared once the position is final), and the off-route warning is suppressed while it's set.

**2. Stale peg/observed-area heading.** Mapillary keeps animating the heading for a few hundred ms *after* the move resolves (overshooting, then drifting to the settled heading), and the heading-dependent views were being read from that mid-animation pov. The peg and observed-area FOV now **hold their pre-move orientation** during the move (`headingSettling` flag; `ObservedArea.update()` skips the angle recompute so the minimap's `idle` listener can't reintroduce the flash) and refresh **once** when the heading stops drifting, via a short settle poll.

The two flags cover deliberately different windows: `movingToNewLocation` ends when *position* is final (off-route checks can resume); `headingSettling` spans until the *heading* settles.

## Files
- `navigation/NavigationService.js` — flags, `_refreshHeadingViewsAfterPovSettles()` settle poll, deferred heading updates.
- `navigation/Compass.js` — gate off-route warning on `movingToNewLocation`.
- `navigation/ObservedArea.js` — skip FOV angle recompute while heading is settling.
- `panorama/PanoManager.js` — skip heading-dependent viz in `#handlePovChange` while settling.

## Testing
Verified manually on a Mapillary city (Richmond): far jumps no longer flash the off-route warning, and the peg/observed-area hold the previous orientation during the move and snap once to the correct heading on settle. GSV settles immediately (provider-agnostic poll). Frontend `src` changes only — bundled by `grunt watch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)