### PR TITLE
Admin dashboard: Street Status page (#4331)

### DIFF
--- a/app/controllers/AdminDashboardController.scala
+++ b/app/controllers/AdminDashboardController.scala
@@ -56,6 +56,20 @@ class AdminDashboardController @Inject() (
   }
 
   /**
+   * Renders the Street Status page: a per-segment map colored by street availability plus a per-region breakdown.
+   *
+   * Answers "which streets are auditable, and where is imagery missing or are streets disabled?" — the operational
+   * counterpart to Coverage's "how much is audited". Driven client-side from `/v3/api/streets`, which returns every
+   * street (regardless of status) tagged with its `street_edge_status` (#3888).
+   */
+  def streetStatus = cc.securityService.SecuredAction(WithAdmin()) { implicit request =>
+    configService.getCommonPageData(request2Messages.lang).map { commonData =>
+      cc.loggingService.insert(request.identity.userId, request.ipAddress, "Visit_Admin_StreetStatus")
+      Ok(views.html.admin.dashboard.streetStatus(commonData, request.identity))
+    }
+  }
+
+  /**
    * Renders the Data Quality page: per-label-type label counts, severity, validation agreement, and tag usage.
    *
    * Answers "how good is the data?" for the current deployment. Driven client-side from the per-city v3 overallStats

--- a/app/views/admin/dashboard/_sidebar.scala.html
+++ b/app/views/admin/dashboard/_sidebar.scala.html
@@ -30,6 +30,9 @@
         <a href="@routes.AdminDashboardController.coverage"
            class="api-nav-item @if(activePage == "coverage"){active}"
            @if(activePage == "coverage"){aria-current="page"}>Coverage</a>
+        <a href="@routes.AdminDashboardController.streetStatus"
+           class="api-nav-item @if(activePage == "street-status"){active}"
+           @if(activePage == "street-status"){aria-current="page"}>Street Status</a>
         <a href="@routes.AdminDashboardController.labelMap"
            class="api-nav-item @if(activePage == "label-map"){active}"
            @if(activePage == "label-map"){aria-current="page"}>Label Map</a>

--- a/app/views/admin/dashboard/streetStatus.scala.html
+++ b/app/views/admin/dashboard/streetStatus.scala.html
@@ -1,0 +1,72 @@
+@import service.CommonPageData
+@import models.user.SidewalkUserWithRole
+@import play.api.Configuration
+@(commonData: CommonPageData, user: SidewalkUserWithRole
+)(implicit request: RequestHeader, messages: Messages, assets: AssetsFinder, config: Configuration)
+
+@content = {
+    <div class="api-section" id="street-status-intro-section">
+        <h1 class="api-heading" id="street-status">Street status <a href="#street-status" class="permalink">#</a></h1>
+        <p>
+            Which streets are actually available for auditing, and where are they unavailable? Every street carries a
+            status: <strong>open</strong> (usable), <strong>no imagery</strong> (no street-view available),
+            <strong>closed</strong> (in a region not yet opened to the public), or <strong>disabled</strong> (manually
+            hidden, e.g. an OSM miscategorization). Use this to spot neighborhoods with lots of missing imagery or
+            disabled streets.
+        </p>
+        <div class="coverage-kpis" id="street-status-kpis">
+            <div class="coverage-kpi"><span class="coverage-kpi-value" id="kpi-total-streets">—</span><span class="coverage-kpi-label">Total streets</span></div>
+            <div class="coverage-kpi"><span class="coverage-kpi-value" id="kpi-no-imagery">—</span><span class="coverage-kpi-label">No imagery</span></div>
+            <div class="coverage-kpi"><span class="coverage-kpi-value" id="kpi-closed">—</span><span class="coverage-kpi-label">Closed</span></div>
+            <div class="coverage-kpi"><span class="coverage-kpi-value" id="kpi-disabled">—</span><span class="coverage-kpi-label">Disabled</span></div>
+        </div>
+        <div class="coverage-status" id="street-status-status" role="status" aria-live="polite">Loading street data…</div>
+    </div>
+
+    <div class="api-section" id="street-status-map-section">
+        <h2 class="api-heading" id="street-status-map">Status map <a href="#street-status-map" class="permalink">#</a></h2>
+        <p>
+            Each street segment is colored by its status. Hover for details; click a segment to highlight its region's
+            streets here and in the table below.
+        </p>
+        <div id="street-status-choropleth" class="coverage-map"
+             role="img" aria-label="Map of street segments colored by availability status"></div>
+        <div class="street-status-legend" id="street-status-legend"></div>
+    </div>
+
+    <div class="api-section" id="street-status-by-region-section">
+        <h2 class="api-heading" id="street-status-by-region">Status by region <a href="#street-status-by-region" class="permalink">#</a></h2>
+        <p>
+            Streets per status for each region, sorted to surface the regions with the most missing imagery first. Hover
+            or click a row to highlight that region's streets on the map above (and vice-versa).
+        </p>
+        <div class="coverage-table-controls">
+            <input type="search" id="street-status-table-search" class="coverage-table-search"
+                   placeholder="Search regions…" aria-label="Search regions">
+        </div>
+        <div class="coverage-table-wrap">
+            <table id="street-status-table" class="coverage-table street-status-table"></table>
+        </div>
+    </div>
+
+    <!-- Page-specific library: Mapbox for the segment map (Vega isn't needed here). Loaded only on this page. -->
+    <link rel="stylesheet" href="@assets.path("javascripts/lib/mapbox-gl-3.21.0.css")">
+    <script src="@assets.path("javascripts/lib/mapbox-gl-3.21.0.js")"></script>
+
+    <script src="@assets.path("javascripts/admin-dashboard/street-status-map.js")"></script>
+    <script src="@assets.path("javascripts/admin-dashboard/street-status-table.js")"></script>
+    <script src="@assets.path("javascripts/admin-dashboard/street-status-page.js")"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            new StreetStatusPage({
+                mapboxToken: '@commonData.mapboxApiKey',
+                streetsUrl: '/v3/api/streets?filetype=geojson'
+            }).init();
+        });
+    </script>
+}
+
+@common.main(commonData, "Sidewalk - Admin Street Status") {
+    @common.navbar(commonData, Some(user))
+    @admin.dashboard.adminLayout("street-status")(content)
+}

--- a/conf/routes
+++ b/conf/routes
@@ -55,6 +55,7 @@ GET     /admin                                          controllers.AdminDashboa
 GET     /admin/classic                                  controllers.AdminController.index
 GET     /admin/overview                                 controllers.AdminDashboardController.overview
 GET     /admin/coverage                                 controllers.AdminDashboardController.coverage
+GET     /admin/street-status                             controllers.AdminDashboardController.streetStatus
 GET     /admin/label-map                                controllers.AdminDashboardController.labelMap
 GET     /admin/quality                                  controllers.AdminDashboardController.quality
 GET     /admin/contributors                             controllers.AdminDashboardController.contributors

--- a/public/javascripts/admin-dashboard/street-status-map.js
+++ b/public/javascripts/admin-dashboard/street-status-map.js
@@ -1,0 +1,210 @@
+/**
+ * Categorical palette + labels for the four street_edge_status values (#3888, #4331). This is the presentational
+ * source of truth for the Street Status page: the map line colors, the legend, the per-region table columns, and the
+ * stacked-bar cells all read STATUSES so they can never disagree. The status *values* mirror the backend enum
+ * `app/models/street/StreetEdgeStatus.scala` (and are documented on /v3/api/streets); only the display order, labels,
+ * and colors live here, since there is no canonical backend color for street status. Colors are design-system tokens
+ * from main.css, chosen for lightness separation so the four stay distinguishable under deuteranopia/protanopia.
+ */
+class StreetStatusColors {
+    /** @type {Array<{key: string, label: string, color: string}>} ordered open → no_imagery → closed → disabled. */
+    static STATUSES = [
+        { key: 'open',       label: 'Open',       color: '#60A189' }, // --color-pine-600   (healthy/auditable)
+        { key: 'no_imagery', label: 'No imagery', color: '#EB724E' }, // --color-orange-500 (the headline problem)
+        { key: 'closed',     label: 'Closed',     color: '#B3B3B3' }, // --color-neutral-500 (region not opened)
+        { key: 'disabled',   label: 'Disabled',   color: '#424055' }  // --color-asphalt-400 (manually hidden)
+    ];
+
+    /** Fallback color for any status value not in STATUSES (shouldn't happen, but keeps unknown data visible). */
+    static FALLBACK = '#d0d0d0';
+
+    /** High-contrast color for the currently selected region's segments (distinct from all four status colors). */
+    static SELECTED = '#0566f5'; // --color-accent-link
+
+    /** @param {string} status @returns {string} the hex color for a status, or the fallback if unrecognized. */
+    static colorFor(status) {
+        const match = StreetStatusColors.STATUSES.find(s => s.key === status);
+        return match ? match.color : StreetStatusColors.FALLBACK;
+    }
+
+    /** @param {string} status @returns {string} the human-readable label for a status, or the raw value if unknown. */
+    static labelFor(status) {
+        const match = StreetStatusColors.STATUSES.find(s => s.key === status);
+        return match ? match.label : status;
+    }
+
+    /** Builds a Mapbox 'match' expression coloring each segment by its status property, with a fallback color. */
+    static mapboxExpression() {
+        const expr = ['match', ['get', 'status']];
+        for (const s of StreetStatusColors.STATUSES) expr.push(s.key, s.color);
+        expr.push(StreetStatusColors.FALLBACK);
+        return expr;
+    }
+}
+
+/**
+ * Renders the per-segment street-status map with Mapbox GL and exposes hooks so a coordinator can keep it in sync with
+ * the linked per-region table: hover shows a tooltip and brushes the segment's region, clicking fires onRegionClick,
+ * and highlightSegments()/clearHighlight() drive the selected outline from the outside. Segments are keyed by
+ * street_edge_id, so region-level highlighting is done by passing the set of street_edge_ids that belong to a region.
+ */
+class StreetStatusMap {
+    static #SOURCE = 'street-status-streets';
+
+    #map;
+    #mapboxToken;
+    #onRegionClick;
+    #onRegionHover;
+    #onRegionHoverEnd;
+    #popup;
+    #selectedIds = new Set();
+    #hoverId = null;
+
+    /**
+     * @param {string} containerId - id of the map container element.
+     * @param {{mapboxToken: string, onRegionClick?: function(number): void, onRegionHover?: function(number): void,
+     *          onRegionHoverEnd?: function(): void}} [opts]
+     */
+    constructor(containerId, opts = {}) {
+        this.containerId = containerId;
+        this.#mapboxToken = opts.mapboxToken;
+        this.#onRegionClick = opts.onRegionClick || (() => {});
+        this.#onRegionHover = opts.onRegionHover || (() => {});
+        this.#onRegionHoverEnd = opts.onRegionHoverEnd || (() => {});
+    }
+
+    /**
+     * Initializes the map and draws the street segments.
+     * @param {object} geojson - A GeoJSON FeatureCollection of streets with status + region_id in properties.
+     * @returns {Promise<void>} resolves once the map's first render is ready.
+     */
+    init(geojson) {
+        if (!this.#mapboxToken) throw new Error('StreetStatusMap: missing Mapbox access token');
+        mapboxgl.accessToken = this.#mapboxToken;
+
+        this.#map = new mapboxgl.Map({
+            container: this.containerId,
+            style: 'mapbox://styles/mapbox/light-v11',
+            bounds: StreetStatusMap.#bounds(geojson),
+            fitBoundsOptions: { padding: 24 }
+        });
+        this.#map.addControl(new mapboxgl.NavigationControl({ showCompass: false }), 'top-right');
+        this.#popup = new mapboxgl.Popup({ closeButton: false, closeOnClick: false, className: 'coverage-popup' });
+
+        return new Promise(resolve => {
+            this.#map.on('load', () => {
+                this.#addLayers(geojson);
+                this.#wireInteractions();
+                resolve();
+            });
+        });
+    }
+
+    #addLayers(geojson) {
+        this.#map.addSource(StreetStatusMap.#SOURCE, { type: 'geojson', data: geojson, promoteId: 'street_edge_id' });
+
+        // Base segment line colored by status; thickens on hover.
+        this.#map.addLayer({
+            id: 'street-status-line', type: 'line', source: StreetStatusMap.#SOURCE,
+            layout: { 'line-cap': 'round' },
+            paint: {
+                'line-color': StreetStatusColors.mapboxExpression(),
+                'line-width': ['case', ['boolean', ['feature-state', 'hover'], false], 4, 1.6]
+            }
+        });
+        // Separate selected outline (a region's segments) in the high-contrast highlight color, drawn on top.
+        this.#map.addLayer({
+            id: 'street-status-selected', type: 'line', source: StreetStatusMap.#SOURCE,
+            layout: { 'line-cap': 'round' },
+            paint: {
+                'line-color': StreetStatusColors.SELECTED,
+                'line-width': ['case', ['boolean', ['feature-state', 'selected'], false], 5, 0]
+            }
+        });
+    }
+
+    #wireInteractions() {
+        this.#map.on('mousemove', 'street-status-line', e => {
+            if (!e.features.length) return;
+            this.#map.getCanvas().style.cursor = 'pointer';
+            const f = e.features[0];
+            this.#setHover(f.id, Number(f.properties.region_id));
+            this.#popup.setLngLat(e.lngLat).setHTML(StreetStatusMap.#popupHtml(f.properties)).addTo(this.#map);
+        });
+        this.#map.on('mouseleave', 'street-status-line', () => {
+            this.#map.getCanvas().style.cursor = '';
+            this.#setHover(null, null);
+            this.#popup.remove();
+        });
+        this.#map.on('click', 'street-status-line', e => {
+            if (e.features.length) this.#onRegionClick(Number(e.features[0].properties.region_id));
+        });
+    }
+
+    /** Tracks the hovered segment (for the line-thicken feature-state) and brushes its region via the coordinator. */
+    #setHover(segmentId, regionId) {
+        if (this.#hoverId === segmentId) return;
+        const src = StreetStatusMap.#SOURCE;
+        if (this.#hoverId !== null) this.#map.setFeatureState({ source: src, id: this.#hoverId }, { hover: false });
+        this.#hoverId = segmentId;
+        if (segmentId !== null) {
+            this.#map.setFeatureState({ source: src, id: segmentId }, { hover: true });
+            this.#onRegionHover(regionId);
+        } else {
+            this.#onRegionHoverEnd();
+        }
+    }
+
+    /**
+     * Highlights exactly the given set of segments (e.g. all street_edge_ids in a region), replacing any prior
+     * highlight. The coordinator resolves region → segment ids and passes them here.
+     * @param {number[]} streetEdgeIds
+     */
+    highlightSegments(streetEdgeIds) {
+        const src = StreetStatusMap.#SOURCE;
+        const next = new Set(streetEdgeIds.map(Number));
+        for (const id of this.#selectedIds) {
+            if (!next.has(id)) this.#map.setFeatureState({ source: src, id }, { selected: false });
+        }
+        for (const id of next) {
+            if (!this.#selectedIds.has(id)) this.#map.setFeatureState({ source: src, id }, { selected: true });
+        }
+        this.#selectedIds = next;
+    }
+
+    /** Clears any selected-segment highlight. */
+    clearHighlight() {
+        this.highlightSegments([]);
+    }
+
+    /** Builds the hover-popup HTML showing a segment's status and activity. */
+    static #popupHtml(p) {
+        const row = (label, value) => `<dt>${label}</dt><dd>${value}</dd>`;
+        const swatch = `<span class="street-status-swatch" style="background:${StreetStatusColors.colorFor(p.status)}"` +
+            ' aria-hidden="true"></span>';
+        return `<div class="coverage-popup-name">Street ${p.street_edge_id}</div>` +
+            '<dl class="coverage-popup-dl">' +
+            row('Status', `${swatch}${StreetStatusColors.labelFor(p.status)}`) +
+            row('Region', p.region_name) +
+            row('Way type', p.way_type) +
+            row('Audits', (p.audit_count || 0).toLocaleString()) +
+            row('Labels', (p.label_count || 0).toLocaleString()) +
+            row('Contributors', (p.user_count || 0).toLocaleString()) +
+            '</dl>';
+    }
+
+    /** Computes a [[minLng,minLat],[maxLng,maxLat]] bounds box covering all features. */
+    static #bounds(geojson) {
+        let minLng = Infinity, minLat = Infinity, maxLng = -Infinity, maxLat = -Infinity;
+        const visit = coords => {
+            if (typeof coords[0] === 'number') {
+                minLng = Math.min(minLng, coords[0]); maxLng = Math.max(maxLng, coords[0]);
+                minLat = Math.min(minLat, coords[1]); maxLat = Math.max(maxLat, coords[1]);
+            } else {
+                coords.forEach(visit);
+            }
+        };
+        for (const f of geojson.features) if (f.geometry) visit(f.geometry.coordinates);
+        return [[minLng, minLat], [maxLng, maxLat]];
+    }
+}

--- a/public/javascripts/admin-dashboard/street-status-page.js
+++ b/public/javascripts/admin-dashboard/street-status-page.js
@@ -1,0 +1,162 @@
+/**
+ * Coordinator for the admin Street Status page (#4331). Fetches every street once from the v3 streets API as GeoJSON,
+ * then drives the per-segment status map (StreetStatusMap) and the per-region breakdown table (StreetStatusTable) from
+ * a single selection state. A single pass over the features builds both the per-region status counts (for the table +
+ * KPIs) and a region → segment-id index (so a region selection in the table can brush all of that region's segments on
+ * the map, and vice-versa). Selection mirrors the Coverage page: hovering brushes transiently, clicking pins (click
+ * again to unpin), and the effective highlight is the hovered region if any, else the pinned region.
+ */
+class StreetStatusPage {
+    #mapboxToken;
+    #streetsUrl;
+    #map;
+    #table = null;
+
+    #rows = [];                      // Per-region aggregation rows, in API order.
+    #segmentsByRegion = new Map();   // region_id -> number[] of street_edge_ids.
+
+    #pinnedIds = [];
+    #hoverIds = null; // null = no active hover.
+
+    /**
+     * @param {{mapboxToken: string, streetsUrl: string}} opts - Mapbox access token and the v3 streets endpoint URL,
+     *   both injected from the Twirl template so the JS has no server-config coupling.
+     */
+    constructor(opts = {}) {
+        this.#mapboxToken = opts.mapboxToken;
+        this.#streetsUrl = opts.streetsUrl;
+    }
+
+    async init() {
+        try {
+            const geojson = await this.#fetchStreets(this.#streetsUrl);
+            const features = geojson.features || [];
+
+            if (features.length === 0) {
+                this.#setStatus('No street data available for this city yet.', false);
+                return;
+            }
+
+            this.#aggregate(features);
+            this.#renderKpis();
+            this.#renderLegend();
+
+            this.#map = new StreetStatusMap('street-status-choropleth', {
+                mapboxToken: this.#mapboxToken,
+                onRegionClick: id => this.#pin([id]),
+                onRegionHover: id => this.#hover([id]),
+                onRegionHoverEnd: () => this.#hoverEnd()
+            });
+            await this.#map.init(geojson);
+
+            this.#table = new StreetStatusTable('street-status-table', 'street-status-table-search', {
+                onRowClick: id => this.#pin([id]),
+                onRowHover: id => this.#hover([id]),
+                onRowHoverEnd: () => this.#hoverEnd()
+            });
+            this.#table.render(this.#rows);
+
+            this.#setStatus('', false, true);
+        } catch (err) {
+            console.error('Street status page failed to load:', err);
+            this.#setStatus('Could not load street data. Please try again.', true);
+        }
+    }
+
+    async #fetchStreets(url) {
+        const resp = await fetch(url, { headers: { Accept: 'application/json' } });
+        if (!resp.ok) throw new Error(`Streets request failed: ${resp.status}`);
+        return resp.json();
+    }
+
+    /**
+     * Single pass over the GeoJSON features building both outputs the page needs: per-region status counts (table +
+     * KPIs) and a region → segment-id index (map↔table highlight sync). Only statuses actually present are counted, so
+     * a city missing a status still renders cleanly.
+     */
+    #aggregate(features) {
+        const byRegion = new Map();
+        for (const f of features) {
+            const p = f.properties;
+            const regionId = Number(p.region_id);
+            let row = byRegion.get(regionId);
+            if (!row) {
+                row = { region_id: regionId, name: p.region_name, open: 0, no_imagery: 0, closed: 0, disabled: 0, total: 0 };
+                byRegion.set(regionId, row);
+                this.#segmentsByRegion.set(regionId, []);
+            }
+            if (row[p.status] !== undefined) row[p.status] += 1;
+            row.total += 1;
+            this.#segmentsByRegion.get(regionId).push(Number(p.street_edge_id));
+        }
+        this.#rows = Array.from(byRegion.values());
+    }
+
+    /** Click handler: toggles the pinned set (clicking the same selection again clears it). */
+    #pin(ids) {
+        this.#pinnedIds = StreetStatusPage.#sameSet(this.#pinnedIds, ids) ? [] : ids;
+        this.#applyHighlight();
+    }
+
+    /** Hover handler: transiently brushes a set without disturbing the pinned selection. */
+    #hover(ids) {
+        this.#hoverIds = ids;
+        this.#applyHighlight();
+    }
+
+    /** Hover-end handler: drops the transient brush, reverting to the pinned selection (if any). */
+    #hoverEnd() {
+        this.#hoverIds = null;
+        this.#applyHighlight();
+    }
+
+    /** Applies the effective highlight (hovered region, else pinned region, else none) to the map and the table. */
+    #applyHighlight() {
+        const regionIds = this.#hoverIds !== null ? this.#hoverIds : this.#pinnedIds;
+        if (regionIds.length === 0) {
+            this.#map.clearHighlight();
+            this.#table?.clearHighlight();
+            return;
+        }
+        const segmentIds = regionIds.flatMap(id => this.#segmentsByRegion.get(Number(id)) || []);
+        this.#map.highlightSegments(segmentIds);
+        this.#table?.highlightRows(regionIds);
+    }
+
+    #renderKpis() {
+        const totals = { open: 0, no_imagery: 0, closed: 0, disabled: 0, total: 0 };
+        for (const r of this.#rows) {
+            totals.open += r.open; totals.no_imagery += r.no_imagery;
+            totals.closed += r.closed; totals.disabled += r.disabled; totals.total += r.total;
+        }
+        const pct = n => `${Math.round((totals.total ? n / totals.total : 0) * 100)}%`;
+        document.getElementById('kpi-total-streets').textContent = totals.total.toLocaleString();
+        document.getElementById('kpi-no-imagery').textContent = pct(totals.no_imagery);
+        document.getElementById('kpi-disabled').textContent = pct(totals.disabled);
+        document.getElementById('kpi-closed').textContent = pct(totals.closed);
+    }
+
+    /** Renders the categorical legend: one swatch + label per status, from the shared palette. */
+    #renderLegend() {
+        document.getElementById('street-status-legend').innerHTML = StreetStatusColors.STATUSES.map(s =>
+            `<span class="street-status-legend-item"><span class="street-status-swatch" ` +
+            `style="background:${s.color}" aria-hidden="true"></span>${s.label}</span>`
+        ).join('');
+    }
+
+    /** Updates the status line; pass hide=true to remove it once data has loaded. */
+    #setStatus(message, isError, hide = false) {
+        const status = document.getElementById('street-status-status');
+        if (!status) return;
+        status.textContent = message;
+        status.classList.toggle('error', !!isError);
+        status.classList.toggle('hidden', hide);
+    }
+
+    /** True if two id lists contain the same set of ids (order-independent). */
+    static #sameSet(a, b) {
+        if (a.length !== b.length) return false;
+        const set = new Set(a);
+        return b.every(id => set.has(id));
+    }
+}

--- a/public/javascripts/admin-dashboard/street-status-table.js
+++ b/public/javascripts/admin-dashboard/street-status-table.js
@@ -1,0 +1,152 @@
+/**
+ * Searchable, sortable per-region street-status table for the Street Status page (#4331). Each row breaks a region's
+ * streets down by status (open / no_imagery / closed / disabled) with a total and an inline 100%-stacked bar, so an
+ * admin can eyeball which neighborhoods have lots of missing imagery or disabled streets. Defaults to most-missing-
+ * imagery first — the actionable end. Hover/click a row to brush that region's segments on the map; highlightRows()
+ * reflects a selection coming from the map.
+ */
+class StreetStatusTable {
+    /** Status columns (key/label/color) come from the shared palette so table + map + legend agree. */
+    static #STATUS_COLS = StreetStatusColors.STATUSES;
+
+    #tableId;
+    #searchId;
+    #onRowClick;
+    #onRowHover;
+    #onRowHoverEnd;
+    #rows = [];
+    #sortKey = 'no_imagery'; // Default: surface the regions with the most missing imagery first.
+    #sortDir = -1;           // -1 = descending.
+    #filter = '';
+    #hoverId = null;
+
+    /**
+     * @param {string} tableId - id of the <table> element.
+     * @param {string} searchId - id of the search <input> element.
+     * @param {{onRowClick?: function(number): void, onRowHover?: function(number): void,
+     *          onRowHoverEnd?: function(): void}} [opts]
+     */
+    constructor(tableId, searchId, opts = {}) {
+        this.#tableId = tableId;
+        this.#searchId = searchId;
+        this.#onRowClick = opts.onRowClick || (() => {});
+        this.#onRowHover = opts.onRowHover || (() => {});
+        this.#onRowHoverEnd = opts.onRowHoverEnd || (() => {});
+    }
+
+    /**
+     * Renders the table and wires search, sort, and row interactions (once).
+     * @param {Array<object>} rows - Per-region rows (region_id, name, open, no_imagery, closed, disabled, total).
+     */
+    render(rows) {
+        this.#rows = rows;
+        const table = document.getElementById(this.#tableId);
+        table.innerHTML = this.#headerHtml();
+        const tbody = document.createElement('tbody');
+        table.appendChild(tbody);
+        this.#renderBody();
+        this.#wireEvents(table, tbody);
+    }
+
+    #headerHtml() {
+        const arrowFor = key => (key === this.#sortKey ? (this.#sortDir === 1 ? ' ▲' : ' ▼') : '');
+        const th = (key, label) =>
+            `<th data-key="${key}" role="button" tabindex="0" scope="col">${label}${arrowFor(key)}</th>`;
+        const statusThs = StreetStatusTable.#STATUS_COLS.map(c => th(c.key, c.label)).join('');
+        // The distribution (stacked-bar) column is purely visual, so it is not a sortable header.
+        return `<thead><tr>${th('name', 'Region')}${statusThs}${th('total', 'Total')}` +
+            '<th scope="col">Distribution</th></tr></thead>';
+    }
+
+    #renderBody() {
+        const tbody = document.getElementById(this.#tableId).querySelector('tbody');
+        const filter = this.#filter.toLowerCase();
+        const visible = this.#rows
+            .filter(r => !filter || r.name.toLowerCase().includes(filter))
+            .sort((a, b) => {
+                const av = a[this.#sortKey];
+                const bv = b[this.#sortKey];
+                if (typeof av === 'string') return av.localeCompare(bv) * this.#sortDir;
+                return ((av || 0) - (bv || 0)) * this.#sortDir;
+            });
+
+        tbody.innerHTML = visible.map(r => {
+            const statusCells = StreetStatusTable.#STATUS_COLS
+                .map(c => `<td>${(r[c.key] || 0).toLocaleString()}</td>`).join('');
+            return `<tr data-region-id="${r.region_id}">` +
+                `<td>${r.name}</td>${statusCells}<td>${(r.total || 0).toLocaleString()}</td>` +
+                `<td>${StreetStatusTable.#barHtml(r)}</td></tr>`;
+        }).join('');
+    }
+
+    /** Builds an inline 100%-stacked bar (one span per status, sized by share) for a region row. */
+    static #barHtml(r) {
+        const total = r.total || 0;
+        if (!total) return '<div class="street-status-bar" aria-hidden="true"></div>';
+        const segments = StreetStatusTable.#STATUS_COLS
+            .filter(c => (r[c.key] || 0) > 0)
+            .map(c => {
+                const pct = ((r[c.key] / total) * 100).toFixed(2);
+                const title = `${c.label}: ${(r[c.key] || 0).toLocaleString()}`;
+                return `<span style="width:${pct}%;background:${c.color}" title="${title}"></span>`;
+            }).join('');
+        return `<div class="street-status-bar" aria-hidden="true">${segments}</div>`;
+    }
+
+    #wireEvents(table, tbody) {
+        const refreshHeader = () => { table.querySelector('thead').outerHTML = this.#headerHtml(); };
+
+        table.querySelector('thead').addEventListener('click', e => {
+            const th = e.target.closest('th[data-key]');
+            if (th) this.#sortBy(th.dataset.key, refreshHeader);
+        });
+        table.querySelector('thead').addEventListener('keydown', e => {
+            const th = e.target.closest('th[data-key]');
+            if (th && (e.key === 'Enter' || e.key === ' ')) { e.preventDefault(); this.#sortBy(th.dataset.key, refreshHeader); }
+        });
+
+        const search = document.getElementById(this.#searchId);
+        if (search) search.addEventListener('input', () => { this.#filter = search.value; this.#renderBody(); });
+
+        tbody.addEventListener('pointerover', e => {
+            const tr = e.target.closest('tr[data-region-id]');
+            const id = tr ? Number(tr.dataset.regionId) : null;
+            if (id === this.#hoverId) return;
+            this.#hoverId = id;
+            if (id != null) this.#onRowHover(id);
+            else this.#onRowHoverEnd();
+        });
+        tbody.addEventListener('pointerleave', () => {
+            if (this.#hoverId === null) return;
+            this.#hoverId = null;
+            this.#onRowHoverEnd();
+        });
+        tbody.addEventListener('click', e => {
+            const tr = e.target.closest('tr[data-region-id]');
+            if (tr) this.#onRowClick(Number(tr.dataset.regionId));
+        });
+    }
+
+    #sortBy(key, refreshHeader) {
+        // New numeric column starts descending (most-first); the name column starts ascending (A→Z).
+        if (this.#sortKey === key) this.#sortDir *= -1;
+        else { this.#sortKey = key; this.#sortDir = key === 'name' ? 1 : -1; }
+        refreshHeader();
+        this.#renderBody();
+    }
+
+    /** Highlights the rows for the given region ids. @param {number[]} ids */
+    highlightRows(ids) {
+        const set = new Set(ids.map(Number));
+        const tbody = document.getElementById(this.#tableId).querySelector('tbody');
+        tbody.querySelectorAll('tr[data-region-id]').forEach(tr => {
+            tr.classList.toggle('highlighted', set.has(Number(tr.dataset.regionId)));
+        });
+    }
+
+    /** Clears all row highlights. */
+    clearHighlight() {
+        const tbody = document.getElementById(this.#tableId).querySelector('tbody');
+        tbody.querySelectorAll('tr.highlighted').forEach(tr => tr.classList.remove('highlighted'));
+    }
+}

--- a/public/stylesheets/admin-dashboard/admin-dashboard.css
+++ b/public/stylesheets/admin-dashboard/admin-dashboard.css
@@ -1499,3 +1499,44 @@ img.activity-feed-thumb:hover { box-shadow: 0 2px 6px rgba(0, 0, 0, 0.18); }
 
 /* --- Across Cities: effort-table sub-header (#4329) -------------------------------------------------------------- */
 .ac-th-sub { font-weight: 400; font-size: var(--font-size-xs, 0.8125rem); color: var(--color-text-secondary, #5a7785); }
+
+/* --- Street Status page (#4331) -------------------------------------------------------------------------------
+ * Reuses the Coverage page's map / KPI / table / status classes; this block only adds the categorical status
+ * legend, the small status swatch (legend + popup), and the per-region 100%-stacked-bar cell. The status colors
+ * are owned by StreetStatusColors.STATUSES in street-status-map.js (no canonical backend color); these tokens
+ * mirror them for the CSS-only swatch borders and must be kept in sync there. */
+.street-status-legend {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--space-sm, 12px);
+    margin-top: var(--space-sm, 12px);
+    font-size: var(--font-size-xs, 0.8125rem);
+    color: var(--color-text-secondary, #5a7785);
+}
+.street-status-legend-item { display: inline-flex; align-items: center; gap: 6px; }
+
+/* Small color chip shared by the legend and the map popup. */
+.street-status-swatch {
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    border-radius: 3px;
+    border: 1px solid rgba(0, 0, 0, 0.15);
+    vertical-align: middle;
+    margin-right: 4px;
+}
+
+/* Per-region 100%-stacked bar: one span per status, sized by share, colored inline from the JS palette. */
+.street-status-bar {
+    display: flex;
+    width: 120px;
+    height: 12px;
+    border-radius: 3px;
+    overflow: hidden;
+    background: var(--color-neutral-100, #f0f0f0);
+}
+.street-status-bar span { display: block; height: 100%; }
+
+/* The distribution cell is decorative, so keep it left-aligned and let the count columns stay right-aligned. */
+.street-status-table td:last-child, .street-status-table th:last-child { text-align: left; }


### PR DESCRIPTION
## What

Adds a new admin-dashboard page at **`/admin/street-status`** that visualizes the `street_edge_status` enum from
#3888. Closes #4331.

- **Status map** — every street segment on a Mapbox line layer colored by status (open / no_imagery / closed /
  disabled). Hover for a details popup; click a segment to highlight its region's streets.
- **Status by region** — a sortable, searchable table breaking each region's streets down by status, with an
  inline 100%-stacked bar and city-wide KPIs. Defaults to most-missing-imagery first (the actionable end).
- Map ⇄ table are linked: hover brushes transiently, click pins (mirrors the Coverage page's selection model).

## How

Read-only and purely additive — no new backend endpoint. The page is driven client-side from the existing
`/v3/api/streets?filetype=geojson`, which already returns per-segment `status`, `user_count`, `label_count`,
`region_id/name`, `way_type`, and LineString geometry. The map and table share a single fetch and one pass that
builds both the per-region counts and a region→segment index for highlight sync. The new JS mirrors the existing
`coverage-*.js` components; admin-dashboard JS is served via `<script>` tags (not Grunt-bundled), so no Gruntfile
change.

**Status palette** (categorical, from main.css design tokens; no canonical backend color exists for status, so
the palette lives in `street-status-map.js` with a comment pointing at `StreetEdgeStatus.scala`): open =
pine-600, no_imagery = orange-500, closed = neutral-500, disabled = asphalt-400 — chosen for lightness
separation so they survive deuteranopia/protanopia.

## Files

New: `streetStatus.scala.html`, `street-status-map.js`, `street-status-table.js`, `street-status-page.js`.
Modified: `conf/routes`, `AdminDashboardController.scala` (new `streetStatus` action, logs
`Visit_Admin_StreetStatus`), `_sidebar.scala.html` (nav entry), `admin-dashboard.css` (legend/swatch/stacked-bar).

## Screenshots
<img width="2428" height="1647" alt="image" src="https://github.com/user-attachments/assets/7266fa32-573b-40b5-a6e7-fbe5fdea8369" />

<img width="1650" height="890" alt="image" src="https://github.com/user-attachments/assets/009314ad-ac18-493c-b99f-cf9dee44b0c4" />

## Verification

Backend compiles (`sbt --client compile` → success); the three new JS files pass `node --check`. Confirmed against
the running dev app that `/v3/api/streets?filetype=geojson` carries the `status` field across all segments
(open / no_imagery / closed). UI confirmed rendering in the admin dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
