### PR TITLE
Add total_users to /v3/api/aggregateStats (#3976)

### DIFF
--- a/app/controllers/api/StatsApiController.scala
+++ b/app/controllers/api/StatsApiController.scala
@@ -236,6 +236,7 @@ class StatsApiController @Inject() (
       "total_labels"           -> stats.totalLabels,
       "tutorial_labels"        -> stats.tutorialLabels,
       "total_validations"      -> stats.totalValidations,
+      "total_users"            -> stats.totalUsers,
       "num_cities"             -> stats.numCities,
       "num_countries"          -> stats.numCountries,
       "num_languages"          -> stats.numLanguages,
@@ -261,6 +262,7 @@ class StatsApiController @Inject() (
       s"${toSnakeKey("Total Labels")},${stats.totalLabels}",
       s"${toSnakeKey("Tutorial Labels")},${stats.tutorialLabels}",
       s"${toSnakeKey("Total Validations")},${stats.totalValidations}",
+      s"${toSnakeKey("Total Users")},${stats.totalUsers}",
       s"${toSnakeKey("Number of Cities")},${stats.numCities}",
       s"${toSnakeKey("Number of Countries")},${stats.numCountries}",
       s"${toSnakeKey("Number of Languages")},${stats.numLanguages}"

--- a/app/models/utils/ConfigTable.scala
+++ b/app/models/utils/ConfigTable.scala
@@ -173,6 +173,7 @@ class ConfigTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvi
           AggregateStats(
             kmExplored = kmExplored, kmExploredNoOverlap = kmExploredNoOverlap, totalLabels = totalLabels,
             tutorialLabels = tutorialLabels, totalValidations = totalValidations,
+            totalUsers = 0,   // Deduped across schemas in ConfigService (getContributorUserIdsBySchema); not a per-city sum
             numCities = 0,    // Individual cities don't have deployment counts
             numCountries = 0, // These are calculated at the service level
             numLanguages = 0, // when aggregating across all cities
@@ -181,6 +182,37 @@ class ConfigTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvi
         }
       }
       .flatten
+  }
+
+  /**
+   * Retrieves the distinct contributor user ids for a single city schema (#3976).
+   *
+   * A "contributor" is a non-excluded user who added at least one non-tutorial label OR validated at least one label.
+   * The two arms reuse the EXACT predicates of `getCityAggregateDataBySchema`'s `label_counts` and `total_val_count`
+   * subqueries, so the contributing set is consistent with `total_labels` / `total_validations`. The `UNION` dedupes
+   * within this city; cross-city dedup (by the global `user_id`) is done by the caller, which unions these id sets
+   * across schemas. Returns ids (not a count) precisely so that caller-side cross-schema dedup is possible.
+   *
+   * @param schema The database schema to query.
+   * @return DBIO action yielding the distinct contributor `user_id`s (a `text` column) for this schema.
+   */
+  def getContributorUserIdsBySchema(schema: String): DBIO[Seq[String]] = {
+    sql"""
+      SELECT label.user_id
+      FROM "#$schema".label
+      INNER JOIN "#$schema".user_stat ON label.user_id = user_stat.user_id
+      INNER JOIN "#$schema".audit_task ON label.audit_task_id = audit_task.audit_task_id
+      WHERE NOT user_stat.excluded
+          AND deleted = FALSE
+          AND tutorial = FALSE
+          AND label.street_edge_id <> (SELECT tutorial_street_edge_id FROM "#$schema".config)
+          AND audit_task.street_edge_id <> (SELECT tutorial_street_edge_id FROM "#$schema".config)
+      UNION
+      SELECT label_validation.user_id
+      FROM "#$schema".label_validation
+      INNER JOIN "#$schema".user_stat ON label_validation.user_id = user_stat.user_id
+      WHERE NOT user_stat.excluded;
+    """.as[String]
   }
 
   /**

--- a/app/service/ConfigService.scala
+++ b/app/service/ConfigService.scala
@@ -69,6 +69,11 @@ case class LabelTypeStats(
  * @param tutorialLabels Total number of practice/tutorial labels across all cities. Tracked separately because tutorial
  *                       labels are excluded from `totalLabels` and `byLabelType` (they would skew the per-type ratios).
  * @param totalValidations Total number of validations across all cities
+ * @param totalUsers Number of distinct contributors across all cities — users who added at least one (non-tutorial)
+ *                   label or validated at least one label. Counted as distinct people: because `user_id` is a global
+ *                   identifier shared across city schemas, a user active in multiple cities is counted once (the union
+ *                   of contributor ids, not the sum of per-city counts). The legacy DC deployment contributes a fixed
+ *                   historical estimate (`legacyDCUserCount`) since it has no per-user records.
  * @param numCities Number of cities where Project Sidewalk is deployed
  * @param numCountries Number of countries where Project Sidewalk is deployed
  * @param numLanguages Number of distinct languages supported
@@ -80,6 +85,7 @@ case class AggregateStats(
     totalLabels: Int,
     tutorialLabels: Int,
     totalValidations: Int,
+    totalUsers: Int,
     numCities: Int,
     numCountries: Int,
     numLanguages: Int,
@@ -241,6 +247,16 @@ class ConfigServiceImpl @Inject() (
   private val legacyDCUnfilteredLabelCount = 263403
 
   /**
+   * Distinct contributors from the legacy DC deployment, a fixed historical estimate (#3976).
+   *
+   * The archived DC dataset has no per-user records we can query, so unlike live cities its user count can't be derived
+   * from the union of contributor ids. This value (from the gid=963888605 tab of the DC spreadsheet linked above) is
+   * added on top of the live-city distinct-user union in getAggregateStats. DC user_ids don't exist in current schemas,
+   * so there is nothing to dedup against — the addition is exact.
+   */
+  private val legacyDCUserCount = 1395
+
+  /**
    * Legacy DC deployment rolled into an AggregateStats so getAggregateStats can sum it alongside live cities.
    *
    * `totalLabels` is derived from `legacyDCByLabelType` (249,905, the filtered count), NOT the unfiltered 263,403
@@ -252,6 +268,9 @@ class ConfigServiceImpl @Inject() (
    * value bundles both and is really an UPPER BOUND on DC's tutorial labels. Documented as such in the API docs.
    *
    * Validations were never implemented during the DC deployment, so `totalValidations` is 0.
+   *
+   * `totalUsers` is 0 here: DC's contributors are added separately via `legacyDCUserCount` (they can't be deduped by
+   * union like live-city users), so this field must NOT also contribute to the aggregate user count.
    */
   private val legacyDCData = AggregateStats(
     kmExplored = 5482.0,
@@ -259,6 +278,7 @@ class ConfigServiceImpl @Inject() (
     totalLabels = legacyDCByLabelType.values.map(_.labels).sum,
     tutorialLabels = legacyDCUnfilteredLabelCount - legacyDCByLabelType.values.map(_.labels).sum,
     totalValidations = 0,
+    totalUsers = 0,
     numCities = 0,
     numCountries = 0,
     numLanguages = 0,
@@ -362,7 +382,7 @@ class ConfigServiceImpl @Inject() (
           Future.successful(
             AggregateStats(
               kmExplored = 0.0, kmExploredNoOverlap = 0.0, totalLabels = 0, tutorialLabels = 0, totalValidations = 0,
-              numCities = 0, numCountries = 0, numLanguages = 0, byLabelType = Map.empty
+              totalUsers = 0, numCities = 0, numCountries = 0, numLanguages = 0, byLabelType = Map.empty
             )
           )
         } else {
@@ -376,8 +396,22 @@ class ConfigServiceImpl @Inject() (
             getCityAggregateData(cityId)
           }
 
+          // Distinct contributors across all live cities, deduped by the global `user_id` then DC added on top (#3976).
+          // Computed by unioning per-city contributor-id sets rather than summing per-city counts, so a user active in
+          // multiple cities is counted once. Each city recovers to an empty set so one bad schema can't sink the count.
+          val distinctUsersFut: Future[Int] = Future
+            .sequence(availableCities.map { cityId =>
+              db.run(configTable.getContributorUserIdsBySchema(getCitySchema(cityId)))
+                .map(_.toSet)
+                .recover { case e: Exception =>
+                  logger.warn(s"Failed to retrieve contributor ids for city $cityId: ${e.getMessage}")
+                  Set.empty[String]
+                }
+            })
+            .map(perCity => perCity.foldLeft(Set.empty[String])(_ ++ _).size + legacyDCUserCount)
+
           // Wait for all futures to complete and aggregate results.
-          Future.sequence(cityStatsFutures).map { cityStatsOptions =>
+          Future.sequence(cityStatsFutures).zip(distinctUsersFut).map { case (cityStatsOptions, totalUsers) =>
             // Filter out failed requests and aggregate the successful ones.
             val validCityStats = cityStatsOptions.flatten
 
@@ -386,11 +420,12 @@ class ConfigServiceImpl @Inject() (
               // Return empty aggregate stats if no cities provided data.
               AggregateStats(
                 kmExplored = 0.0, kmExploredNoOverlap = 0.0, totalLabels = 0, tutorialLabels = 0, totalValidations = 0,
-                numCities = numCities, numCountries = numCountries, numLanguages = numLanguages, byLabelType = Map.empty
+                totalUsers = 0, numCities = numCities, numCountries = numCountries, numLanguages = numLanguages,
+                byLabelType = Map.empty
               )
             } else {
               // Add legacy DC data to the valid city stats before aggregating.
-              aggregateCityData(validCityStats :+ legacyDCData, numCities, numCountries, numLanguages)
+              aggregateCityData(validCityStats :+ legacyDCData, numCities, numCountries, numLanguages, totalUsers)
             }
           }
         }
@@ -556,13 +591,16 @@ class ConfigServiceImpl @Inject() (
    * @param numCities Number of cities in deployment
    * @param numCountries Number of countries in deployment
    * @param numLanguages Number of languages supported
+   * @param totalUsers Distinct contributors across all deployments. Passed in (like numCountries/numLanguages) rather
+   *                   than summed from `cityData`, because it is a cross-schema deduped union, not a per-city sum (#3976).
    * @return Aggregated statistics across all provided cities
    */
   private def aggregateCityData(
       cityData: Seq[AggregateStats],
       numCities: Int,
       numCountries: Int,
-      numLanguages: Int
+      numLanguages: Int,
+      totalUsers: Int
   ): AggregateStats = {
     import scala.collection.mutable
 
@@ -592,8 +630,9 @@ class ConfigServiceImpl @Inject() (
 
     AggregateStats(
       kmExplored = totalKmExplored, kmExploredNoOverlap = totalKmExploredNoOverlap, totalLabels = totalLabelsCount,
-      tutorialLabels = tutorialLabelsCount, totalValidations = totalValidationsCount, numCities = numCities,
-      numCountries = numCountries, numLanguages = numLanguages, byLabelType = labelTypeStatsMap.toMap
+      tutorialLabels = tutorialLabelsCount, totalValidations = totalValidationsCount, totalUsers = totalUsers,
+      numCities = numCities, numCountries = numCountries, numLanguages = numLanguages,
+      byLabelType = labelTypeStatsMap.toMap
     )
   }
 

--- a/app/views/apiDocs/aggregateStats.scala.html
+++ b/app/views/apiDocs/aggregateStats.scala.html
@@ -106,6 +106,7 @@
     "total_labels": 4567890,
     "tutorial_labels": 123456,
     "total_validations": 2345678,
+    "total_users": 12345,
     "num_cities": 18,
     "num_countries": 5,
     "num_languages": 7,
@@ -133,6 +134,7 @@
                     <tr><td><code>total_labels</code></td><td><code>integer</code></td><td>Total number of labels across all deployments, excluding practice/tutorial labels. Equal to the sum of the <code>by_label_type.&lt;type&gt;.labels</code> counts.</td></tr>
                     <tr><td><code>tutorial_labels</code></td><td><code>integer</code></td><td>Number of practice/tutorial labels across all deployments. Reported separately because they are excluded from <code>total_labels</code> and <code>by_label_type</code> (they would skew the per-type ratios). Note: the count contributed by the legacy Washington, DC deployment also includes a small number of low-quality labels that its archived data cannot separate from tutorial labels.</td></tr>
                     <tr><td><code>total_validations</code></td><td><code>integer</code></td><td>Total number of validations across all deployments.</td></tr>
+                    <tr><td><code>total_users</code></td><td><code>integer</code></td><td>Number of distinct contributors across all deployments &mdash; users who added at least one (non-tutorial) label or validated at least one label. Counted as distinct people: a user active in multiple cities is counted once. Registered and anonymous users are counted the same; excluded low-quality users are omitted. The legacy Washington, DC deployment contributes a fixed historical estimate of 1,395 users (its archived data has no per-user records).</td></tr>
                     <tr><td><code>num_cities</code></td><td><code>integer</code></td><td>Number of deployment cities.</td></tr>
                     <tr><td><code>num_countries</code></td><td><code>integer</code></td><td>Number of countries with a deployment.</td></tr>
                     <tr><td><code>num_languages</code></td><td><code>integer</code></td><td>Number of natively translated languages.</td></tr>

--- a/public/javascripts/api-docs/aggregate-stats-preview.js
+++ b/public/javascripts/api-docs/aggregate-stats-preview.js
@@ -80,7 +80,8 @@
                 ['Languages', fmt(data.num_languages)],
                 ['Distance Explored', `${Number(data.km_explored || 0).toLocaleString(undefined, { maximumFractionDigits: 0 })} km`],
                 ['Total Labels', fmt(data.total_labels)],
-                ['Total Validations', fmt(data.total_validations)]
+                ['Total Validations', fmt(data.total_validations)],
+                ['Total Users', fmt(data.total_users)]
             ];
 
             const grid = document.createElement('div');

--- a/test/controllers/api/StatsApiSpec.scala
+++ b/test/controllers/api/StatsApiSpec.scala
@@ -34,6 +34,7 @@ class StatsApiSpec extends PlaySpec with GuiceOneAppPerSuite {
       (json \ "km_explored").asOpt[Double] mustBe defined
       (json \ "total_labels").asOpt[Long] mustBe defined
       (json \ "tutorial_labels").asOpt[Long] mustBe defined
+      (json \ "total_users").asOpt[Long] mustBe defined
       (json \ "num_cities").asOpt[Int] mustBe defined
       (json \ "by_label_type").asOpt[JsObject] mustBe defined
 
@@ -41,6 +42,16 @@ class StatsApiSpec extends PlaySpec with GuiceOneAppPerSuite {
       (json \ "kmExplored").toOption mustBe None
       (json \ "totalLabels").toOption mustBe None
       (json \ "byLabelType").toOption mustBe None
+    }
+
+    // The CSV export must expose total_users too (#3976) — field changes need coverage in every output format, not
+    // just JSON, since the formats are serialized independently.
+    "include a total_users row in the CSV export" in {
+      val resp = route(app, FakeRequest(GET, "/v3/api/aggregateStats?filetype=csv")).get
+      status(resp) mustBe OK
+      val body = contentAsString(resp)
+      body must include("metric,value")
+      body.linesIterator.exists(_.startsWith("total_users,")) mustBe true
     }
 
     // Regression guard for #3981: the per-label-type breakdown must reconcile with the headline total. This held only

--- a/test/js/aggregate-stats-preview.test.js
+++ b/test/js/aggregate-stats-preview.test.js
@@ -21,6 +21,7 @@ const GOOD_FIXTURE = {
     km_explored_no_overlap: 1000,
     total_labels: 50000,
     total_validations: 30000,
+    total_users: 12345,
     num_cities: 18,
     num_countries: 9,
     num_languages: 7,
@@ -103,6 +104,8 @@ describe('AggregateStatsPreview', () => {
         expect(container.textContent).toContain('18');
         expect(container.textContent).toContain('30,000'); // total_validations
         expect(container.textContent).toContain('50,000'); // total_labels
+        expect(container.textContent).toContain('Total Users');
+        expect(container.textContent).toContain('12,345'); // total_users
 
         // Per-label-type table rendered both rows.
         expect(container.querySelectorAll('tbody tr')).toHaveLength(2);


### PR DESCRIPTION
Closes #3976.

Adds a `total_users` field to `/v3/api/aggregateStats`: the number of distinct contributors across all deployments.

## Methodology (agreed by @jonfroehlich + @misaugstad in #3976)
A contributor is a non-excluded user who **added ≥1 non-tutorial label OR validated ≥1 label**. Registered and anonymous users are counted the same; excluded low-quality users are omitted — consistent with how `total_labels` and `total_validations` are already filtered in this same response.

## Distinct people, deduped across cities
`user_id` is a global identifier shared via the `sidewalk_login` schema, so the same person contributing in multiple cities carries the **same** id in each city schema. `total_users` is therefore the size of the **union** of per-city contributor id sets, not the sum of per-city counts (which would double-count cross-city contributors). On the local DB the gap is ~0.6% today (naive sum 6,573 vs true union 6,535) and grows as more cities come online.

- `ConfigTable.getContributorUserIdsBySchema` returns a schema's distinct contributor `user_id`s — its two arms reuse the exact predicates of the existing `label_counts` / `total_val_count` subqueries.
- `ConfigService.getAggregateStats` unions the per-city id sets (each recovers to empty so one bad schema can't sink the count) and passes the total into `aggregateCityData` like `numCountries`/`numLanguages`, rather than summing per-city rows.

## Legacy DC
The archived DC deployment has no per-user records, so it contributes a fixed historical estimate (`legacyDCUserCount = 1395`, from the DC spreadsheet) added on top of the live-city union. DC ids don't exist in current schemas, so there's nothing to dedup against.

## Surface
- `total_users` in both JSON and CSV output.
- Documented in `apiDocs/aggregateStats.scala.html` (example + response-fields row) and surfaced as a "Total Users" card in the docs preview.

## Tests
- `StatsApiSpec` asserts `total_users` is present in the JSON response and in the CSV export (DB-backed, boots the real app).
- JS preview fixture updated.

## Scope / follow-up
API + docs only. @misaugstad also suggested realigning the **Admin page** user stats to this same methodology — tracked as a separate follow-up issue.

## Verification
- `sbt --client compile` warning-clean; `StatsApiSpec` 3/3 green.
- Cross-city dedup confirmed via psql: live-city union 6,535 + DC 1,395 = **7,930** locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)