### PR TITLE
Hotfix: evolution 325 fails to apply (semicolons inside SQL comments)

### DIFF
--- a/conf/evolutions/default/325.sql
+++ b/conf/evolutions/default/325.sql
@@ -1,7 +1,7 @@
 # --- !Ups
 -- Replace the overloaded boolean street_edge.deleted with a first-class status enum (#3888). The old flag conflated
 -- several unrelated things: no imagery, manually disabled (e.g. OSM miscategorization), and "region not opened yet".
--- The new status makes each of those explicit. region.deleted is kept; street status 'closed' mirrors it and is the
+-- The new status makes each of those explicit. region.deleted is kept, and street status 'closed' mirrors it as the
 -- authoritative per-street availability flag (so we can also mark individual streets closed during partial reveals).
 CREATE TYPE street_edge_status AS ENUM ('open', 'no_imagery', 'closed', 'disabled');
 
@@ -11,7 +11,7 @@ ALTER TABLE street_edge ALTER COLUMN status DROP DEFAULT;
 -- Backfill from the overloaded flag joined to region state (per #3888 discussion with @misaugstad):
 --   deleted = FALSE                       -> 'open'
 --   deleted = TRUE, region closed/deleted -> 'closed'      (the whole neighborhood is hidden)
---   deleted = TRUE, region open           -> 'no_imagery'  (true for nearly all of these; a small number are actually
+--   deleted = TRUE, region open           -> 'no_imagery'  (true for nearly all of these, though a small number are
 --                                                            miscategorizations that an admin can later flip to 'disabled')
 UPDATE street_edge
 SET status = (CASE


### PR DESCRIPTION
Follow-up to #4335, which merged at `e57d94252` — one commit **before** the evolution fix (`5ffd94215`) landed, so develop currently ships a broken evolution 325.

## The bug
Play's evolutions parser splits statements on every `;`, **including semicolons inside `--` comments**. Two comment lines in 325 contain a literal `;`:

- line 4: `...region.deleted is kept; street status 'closed'...`
- line 14: `...nearly all of these; a small number...`

The applier splits mid-comment, the leading `--` goes to the prior chunk, and the comment remainder (`street status 'closed' ...`) is executed as SQL → `ERROR: syntax error at or near "street"` (SQLSTATE 42601), aborting evolutions and leaving the DB inconsistent. This is what failed the **Backend tests (API, PostGIS)** job on #4335.

## The fix
Reword both comments to drop the semicolons. **No schema change.**

Safe to edit 325 in place rather than add a new evolution: it never applied successfully anywhere (held back locally, failed in CI), so there's no risk of a Play hash mismatch against already-migrated data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)