### PR TITLE
Add km-by-status and redundant-coverage km to /v3/api/overallStats (#3080)

### DIFF
--- a/app/controllers/api/StatsApiController.scala
+++ b/app/controllers/api/StatsApiController.scala
@@ -104,6 +104,13 @@ class StatsApiController @Inject() (
             row("Recent Labels Average Timestamp", stats.avgTimestampLast100Labels.getOrElse("NA"))
             row("KM Explored", stats.kmExplored)
             row("KM Explored Without Overlap", stats.kmExploreNoOverlap)
+            row("KM Explored Multiple Users", stats.kmExploredMultipleUsers)
+            row("KM Explored Single User", stats.kmExploredSingleUser)
+            row("KM Explorable", stats.kmOpen) // Auditable-now network (status = open); alias of KM Open below.
+            row("KM Open", stats.kmOpen)
+            row("KM No Imagery", stats.kmNoImagery)
+            row("KM Closed", stats.kmClosed)
+            row("KM Disabled", stats.kmDisabled)
             row("Total User Count", stats.nUsers)
             row("Explore User Count", stats.nExplorers)
             row("Validate User Count", stats.nValidators)

--- a/app/formats/json/ApiFormats.scala
+++ b/app/formats/json/ApiFormats.scala
@@ -68,6 +68,17 @@ object ApiFormats {
       "avg_timestamp_last_100_labels" -> stats.avgTimestampLast100Labels.map(_.toString),
       "km_explored"                   -> stats.kmExplored,
       "km_explored_no_overlap"        -> stats.kmExploreNoOverlap,
+      "km_explored_multiple_users"    -> stats.kmExploredMultipleUsers,
+      "km_explored_single_user"       -> stats.kmExploredSingleUser,
+      // `km_explorable` is the auditable-now network (status = open). A street can be audited and later become
+      // closed/no_imagery, so km_explored_no_overlap is NOT bounded by km_explorable.
+      "km_explorable"                 -> stats.kmOpen,
+      "km_by_status"                  -> Json.obj(
+        "open"       -> stats.kmOpen,
+        "no_imagery" -> stats.kmNoImagery,
+        "closed"     -> stats.kmClosed,
+        "disabled"   -> stats.kmDisabled
+      ),
       "user_counts"                   -> Json.obj(
         "all_users"  -> stats.nUsers,
         "labelers"   -> stats.nExplorers,

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -110,6 +110,12 @@ case class ProjectSidewalkStats(
     avgTimestampLast100Labels: Option[OffsetDateTime],
     kmExplored: Double,
     kmExploreNoOverlap: Double,
+    kmExploredMultipleUsers: Double,
+    kmExploredSingleUser: Double,
+    kmOpen: Double,
+    kmNoImagery: Double,
+    kmClosed: Double,
+    kmDisabled: Double,
     nUsers: Int,
     nExplorers: Int,
     nValidators: Int,
@@ -686,12 +692,32 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
     )
   }
 
-  implicit val projectSidewalkStatsConverter: GetResult[ProjectSidewalkStats] = GetResult[ProjectSidewalkStats](r =>
+  implicit val projectSidewalkStatsConverter: GetResult[ProjectSidewalkStats] = GetResult[ProjectSidewalkStats] { r =>
+    // Read the leading scalar columns into locals (rather than inline constructor args) so we can derive
+    // kmExploredSingleUser. Reads must stay in SELECT order; GetResult is positional. km_explored_no_overlap counts
+    // streets with ≥1 completed audit and km_explored_multiple_users counts streets with ≥2 distinct auditors, so
+    // single-user = no_overlap − multiple_users by construction.
+    val launchDate                = r.nextString()
+    val avgTimestampLast100Labels = r.nextOffsetDateTimeOption()
+    val kmExplored                = r.nextDouble()
+    val kmExploreNoOverlap        = r.nextDouble()
+    val kmExploredMultipleUsers   = r.nextDouble()
+    val kmExploredSingleUser      = kmExploreNoOverlap - kmExploredMultipleUsers
+    val kmOpen                    = r.nextDouble()
+    val kmNoImagery               = r.nextDouble()
+    val kmClosed                  = r.nextDouble()
+    val kmDisabled                = r.nextDouble()
     ProjectSidewalkStats(
-      r.nextString(),
-      r.nextOffsetDateTimeOption(),
-      r.nextDouble(),
-      r.nextDouble(),
+      launchDate,
+      avgTimestampLast100Labels,
+      kmExplored,
+      kmExploreNoOverlap,
+      kmExploredMultipleUsers,
+      kmExploredSingleUser,
+      kmOpen,
+      kmNoImagery,
+      kmClosed,
+      kmDisabled,
       r.nextInt(),
       r.nextInt(),
       r.nextInt(),
@@ -760,7 +786,7 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
         )
       )
     )
-  )
+  }
 
   def find(labelId: Int): DBIO[Option[Label]] = {
     labelsUnfiltered.filter(_.labelId === labelId).result.headOption
@@ -1962,6 +1988,11 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
              #${avgRecentLabels.map(avg => s"'$avg'").getOrElse("NULL")} AS avg_timestamp_last_100_labels,
              km_audited.km_audited AS km_audited,
              km_audited_no_overlap.km_audited_no_overlap AS km_audited_no_overlap,
+             km_explored_multiple_users.km_explored_multiple_users AS km_explored_multiple_users,
+             km_by_status.km_open,
+             km_by_status.km_no_imagery,
+             km_by_status.km_closed,
+             km_by_status.km_disabled,
              users.total_users,
              users.audit_users,
              users.validation_users,
@@ -2076,6 +2107,33 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
               WHERE completed = TRUE AND #$userFilter
           ) distinct_streets
       ) AS km_audited_no_overlap, (
+          -- Redundant-coverage km: streets with a completed audit by ≥2 distinct (non-excluded) users. Mirrors the
+          -- km_audited_no_overlap subquery but groups per street and keeps only those audited by 2+ people. Single-user
+          -- km is derived (no_overlap − multiple_users) in projectSidewalkStatsConverter, so it is not selected here.
+          SELECT COALESCE(SUM(ST_LENGTH(ST_TRANSFORM(geom, 26918))) / 1000, 0) AS km_explored_multiple_users
+          FROM (
+              SELECT street_edge.street_edge_id, geom
+              FROM street_edge
+              INNER JOIN audit_task ON street_edge.street_edge_id = audit_task.street_edge_id
+              INNER JOIN user_stat ON audit_task.user_id = user_stat.user_id
+              WHERE completed = TRUE AND #$userFilter
+              GROUP BY street_edge.street_edge_id, geom
+              HAVING COUNT(DISTINCT audit_task.user_id) >= 2
+          ) multi_user_streets
+      ) AS km_explored_multiple_users, (
+          -- Total street km by availability status (#3888 enum). The `open` bucket is the auditable-now network and is
+          -- surfaced as `km_explorable`. The tutorial street is excluded from every bucket. COALESCE guards buckets a
+          -- given city may have none of (e.g. no `disabled` streets), since the converter reads non-Option Doubles.
+          SELECT COALESCE(SUM(len) FILTER (WHERE status = 'open'), 0)       AS km_open,
+                 COALESCE(SUM(len) FILTER (WHERE status = 'no_imagery'), 0) AS km_no_imagery,
+                 COALESCE(SUM(len) FILTER (WHERE status = 'closed'), 0)     AS km_closed,
+                 COALESCE(SUM(len) FILTER (WHERE status = 'disabled'), 0)   AS km_disabled
+          FROM (
+              SELECT status, ST_LENGTH(ST_TRANSFORM(geom, 26918)) / 1000 AS len
+              FROM street_edge
+              WHERE street_edge_id <> (SELECT tutorial_street_edge_id FROM config)
+          ) street_lengths
+      ) AS km_by_status, (
           SELECT COUNT(DISTINCT(users.user_id)) AS total_users,
                  COUNT(CASE WHEN mission_type = 'validation' THEN 1 END) AS validation_users,
                  COUNT(CASE WHEN mission_type = 'audit' THEN 1 END) AS audit_users,

--- a/app/views/apiDocs/overallStats.scala.html
+++ b/app/views/apiDocs/overallStats.scala.html
@@ -126,6 +126,15 @@
     "avg_timestamp_last_100_labels": "2023-09-25T14:32:47Z",
     "km_explored": 1834.26,
     "km_explored_no_overlap": 1523.75,
+    "km_explored_multiple_users": 412.08,
+    "km_explored_single_user": 1111.67,
+    "km_explorable": 1987.40,
+    "km_by_status": {
+        "open": 1987.40,
+        "no_imagery": 142.13,
+        "closed": 38.55,
+        "disabled": 6.20
+    },
     "user_counts": {
         "all_users": 4287,
         "labelers": 3892,
@@ -255,8 +264,12 @@
                 <tbody>
                     <tr><td><code>launch_date</code></td><td><code>string</code></td><td>ISO 8601 formatted date when Project Sidewalk was launched in this city.</td></tr>
                     <tr><td><code>avg_timestamp_last_100_labels</code></td><td><code>string</code></td><td>ISO 8601 formatted average timestamp of the 100 most recent labels, indicating data recency.</td></tr>
-                    <tr><td><code>km_explored</code></td><td><code>number</code></td><td>Total kilometers of streets explored by all users, including overlapping streets.</td></tr>
-                    <tr><td><code>km_explored_no_overlap</code></td><td><code>number</code></td><td>Total kilometers of unique streets explored, excluding overlapping streets.</td></tr>
+                    <tr><td><code>km_explored</code></td><td><code>number</code></td><td>Total kilometers of streets explored by all users, counting a street once per user who completed it (i.e. with overlap — the total auditing work done).</td></tr>
+                    <tr><td><code>km_explored_no_overlap</code></td><td><code>number</code></td><td>Total kilometers of unique streets with at least one completed audit (each street counted once, regardless of how many users explored it).</td></tr>
+                    <tr><td><code>km_explored_multiple_users</code></td><td><code>number</code></td><td>Kilometers of unique streets that have been completely audited by two or more distinct (non-excluded) users — i.e. redundantly covered. A street counts here only if each of the ≥2 users completed the whole street.</td></tr>
+                    <tr><td><code>km_explored_single_user</code></td><td><code>number</code></td><td>Kilometers of unique streets audited by exactly one user. Equals <code>km_explored_no_overlap − km_explored_multiple_users</code>.</td></tr>
+                    <tr><td><code>km_explorable</code></td><td><code>number</code></td><td>Kilometers of streets that are auditable right now (status <code>open</code>). This is the natural denominator for "percent of the city audited" (<code>km_explored_no_overlap / km_explorable</code>). Alias of <code>km_by_status.open</code>. Note: a street can be audited and later marked closed/no-imagery, so <code>km_explored_no_overlap</code> is not strictly bounded by this value.</td></tr>
+                    <tr><td><code>km_by_status</code></td><td><code>object</code></td><td>Total street kilometers broken down by availability status (see the <code>/v3/api/streets</code> <code>status</code> field). Lets you choose your own denominator. Keys: <code>open</code> (auditable now), <code>no_imagery</code> (a real street with no street-view imagery), <code>closed</code> (a real street whose region is not yet open to the public), <code>disabled</code> (not a genuine auditable street, e.g. an OSM miscategorization). The tutorial street is excluded from every bucket.</td></tr>
                     <tr><td><code>user_counts.all_users</code></td><td><code>integer</code></td><td>Total number of users who have contributed to Project Sidewalk.</td></tr>
                     <tr><td><code>user_counts.labelers</code></td><td><code>integer</code></td><td>Number of users who have participated in explore/labeling tasks.</td></tr>
                     <tr><td><code>user_counts.validators</code></td><td><code>integer</code></td><td>Number of users who have participated in validation tasks.</td></tr>
@@ -278,6 +291,7 @@
                     <tr><td><code>validations</code></td><td><code>object</code></td><td>Validation statistics split into three parallel blocks by vote source: <code>combined</code> (all votes), <code>human</code> (votes cast by people), and <code>ai</code> (votes cast by Project Sidewalk's AI). Each block has the identical structure described below. Note that <code>combined</code> includes AI votes, so it is not the same as <code>human</code>.</td></tr>
                     <tr><td><code>validations.[source]</code></td><td><code>object</code></td><td>One of <code>combined</code>, <code>human</code>, or <code>ai</code>. Holds the validation breakdown computed using only that source's votes.</td></tr>
                     <tr><td><code>validations.[source].total_validations</code></td><td><code>integer</code></td><td>Total number of individual validation judgments made by this source across all labels.</td></tr>
+                    <tr><td><code>validations.[source].[type]</code></td><td><code>object</code></td><td>Per-label-type breakdown for this source. The special key <code>Overall</code> aggregates across all label types; in particular <code>validations.[source].Overall.has_a_validation</code> is the total number of labels with at least one validation from this source.</td></tr>
                     <tr><td><code>validations.[source].[type].validated</code></td><td><code>integer</code></td><td>Number of labels of this type that this source has validated as either "correct" or "incorrect" through majority vote; a label is not included if the number of agree and disagree votes are equal.</td></tr>
                     <tr><td><code>validations.[source].[type].agreed</code></td><td><code>integer</code></td><td>Number of labels of this type that this source has validated as "correct" through majority vote.</td></tr>
                     <tr><td><code>validations.[source].[type].disagreed</code></td><td><code>integer</code></td><td>Number of labels of this type that this source has validated as "incorrect" through majority vote.</td></tr>

--- a/test/controllers/api/StatsApiSpec.scala
+++ b/test/controllers/api/StatsApiSpec.scala
@@ -66,4 +66,56 @@ class StatsApiSpec extends PlaySpec with GuiceOneAppPerSuite {
       perTypeLabels mustBe totalLabels
     }
   }
+
+  "GET /v3/api/overallStats" should {
+    "return 200 JSON exposing the km-by-status and redundant-coverage fields (#3080)" in {
+      val resp = route(app, FakeRequest(GET, "/v3/api/overallStats")).get
+      status(resp) mustBe OK
+      contentType(resp) mustBe Some("application/json")
+
+      val json = contentAsJson(resp)
+      (json \ "km_explored_multiple_users").asOpt[Double] mustBe defined
+      (json \ "km_explored_single_user").asOpt[Double] mustBe defined
+      (json \ "km_explorable").asOpt[Double] mustBe defined
+      (json \ "km_by_status" \ "open").asOpt[Double] mustBe defined
+      (json \ "km_by_status" \ "no_imagery").asOpt[Double] mustBe defined
+      (json \ "km_by_status" \ "closed").asOpt[Double] mustBe defined
+      (json \ "km_by_status" \ "disabled").asOpt[Double] mustBe defined
+
+      // #3080 ask #1 ("labels with at least one validation") is surfaced as the Overall rollup of has_a_validation.
+      (json \ "validations" \ "combined" \ "Overall" \ "has_a_validation").asOpt[Long] mustBe defined
+    }
+
+    // Data-independent invariants: hold for any test DB contents.
+    "reconcile single + multiple user km with no-overlap km, and alias km_explorable to km_by_status.open" in {
+      val json        = contentAsJson(route(app, FakeRequest(GET, "/v3/api/overallStats")).get)
+      val noOverlap   = (json \ "km_explored_no_overlap").as[Double]
+      val multiple    = (json \ "km_explored_multiple_users").as[Double]
+      val single      = (json \ "km_explored_single_user").as[Double]
+      val explorable  = (json \ "km_explorable").as[Double]
+      val open        = (json \ "km_by_status" \ "open").as[Double]
+
+      // single + multiple == no_overlap (single is derived as no_overlap − multiple), and multiple ≤ no_overlap.
+      (single + multiple) mustBe (noOverlap +- 0.001)
+      multiple must be <= (noOverlap + 0.001)
+      // km_explorable is an alias of the open bucket. NOTE: we deliberately do NOT assert noOverlap ≤ explorable —
+      // a street can be audited and later become closed/no_imagery, so explored can exceed the auditable-now network.
+      explorable mustBe (open +- 0.001)
+    }
+
+    "return 200 CSV containing the new km rows" in {
+      val resp = route(app, FakeRequest(GET, "/v3/api/overallStats?filetype=csv")).get
+      status(resp) mustBe OK
+      val body = contentAsString(resp)
+      Seq(
+        "km_explored_multiple_users",
+        "km_explored_single_user",
+        "km_explorable",
+        "km_open",
+        "km_no_imagery",
+        "km_closed",
+        "km_disabled"
+      ).foreach(key => body must include(key))
+    }
+  }
 }

--- a/test/formats/json/ApiFormatsSpec.scala
+++ b/test/formats/json/ApiFormatsSpec.scala
@@ -33,6 +33,12 @@ class ApiFormatsSpec extends AnyFunSuite with Matchers {
       avgTimestampLast100Labels = None,
       kmExplored = 10.0,
       kmExploreNoOverlap = 8.0,
+      kmExploredMultipleUsers = 3.0,
+      kmExploredSingleUser = 5.0, // 8.0 no-overlap − 3.0 multiple
+      kmOpen = 12.0,
+      kmNoImagery = 1.0,
+      kmClosed = 0.5,
+      kmDisabled = 0.2,
       nUsers = 5,
       nExplorers = 4,
       nValidators = 3,
@@ -100,6 +106,17 @@ class ApiFormatsSpec extends AnyFunSuite with Matchers {
     // Pre-#4223 these lived directly under `validations`; they must now only exist under a source block.
     (json \ "validations" \ "Overall").toOption shouldBe None
     (json \ "validations" \ "total_validations").toOption shouldBe None
+  }
+
+  test("km-by-status + redundant-coverage km serialize, with km_explorable aliasing the open bucket (#3080)") {
+    val json = ApiFormats.projectSidewalkStatsToJson(sampleStats)
+    (json \ "km_explored_multiple_users").as[Double] shouldBe 3.0
+    (json \ "km_explored_single_user").as[Double] shouldBe 5.0
+    (json \ "km_explorable").as[Double] shouldBe 12.0
+    (json \ "km_by_status" \ "open").as[Double] shouldBe 12.0
+    (json \ "km_by_status" \ "no_imagery").as[Double] shouldBe 1.0
+    (json \ "km_by_status" \ "closed").as[Double] shouldBe 0.5
+    (json \ "km_by_status" \ "disabled").as[Double] shouldBe 0.2
   }
 
   test("stddev of label/image dates serialize as day-valued durations (#3031)") {


### PR DESCRIPTION
Closes #3080.

Adds the remaining additions requested in #3080 to `/v3/api/overallStats`, building on the `street_edge_status` enum from #3888/#4335 (a street is auditable iff `status = 'open'`).

## What's new (JSON + CSV)

- **`km_by_status`** = `{open, no_imagery, closed, disabled}` — total street km per availability status (tutorial excluded), so consumers can pick their own denominator for "percent of city audited."
- **`km_explorable`** = alias of the `open` bucket (the auditable-now network) — the natural denominator for `km_explored_no_overlap / km_explorable`.
- **`km_explored_multiple_users`** / **`km_explored_single_user`** — redundant-coverage split. *Multiple* = streets with a completed audit by ≥2 distinct non-excluded users (Mikey's "each person completed 100% of the street"); *single* is derived as `no_overlap − multiple`.

## The third #3080 ask was already shipped

"Labels with at least one validation" already exists as `validations.<source>.Overall.has_a_validation` (the `Overall` rollup applies no label-type filter). Rather than add a duplicate top-level field, this PR just documents it clearly in the apiDocs.

## Implementation notes

- Two new sub-SELECTs in `LabelTable.getOverallStatsForApi` (`km_by_status`, `km_explored_multiple_users`); 6 new `ProjectSidewalkStats` fields; the positional `GetResult` converter reads them in SELECT order and derives `km_explored_single_user`.
- Wired through `ApiFormats.projectSidewalkStatsToJson`, the CSV writer in `StatsApiController`, and `overallStats.scala.html`.
- **Note:** because a street can be audited and *later* become closed/no-imagery, `km_explored_no_overlap` is **not** bounded by `km_explorable` — documented, and the tests deliberately don't assert that.

## Testing

- `StatsApiSpec` (DB-backed): new data-independent invariants — `single + multiple == no_overlap`, `multiple <= no_overlap`, `km_explorable == km_by_status.open`, the new keys present in JSON **and** CSV. 6/6 green against real data.
- `ApiFormatsSpec` (pure unit): new km/`km_by_status` serializer assertion. Green.
- `sbt compile` / `Test/compile` warning-clean (`-Xfatal-warnings`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)