### PR TITLE
Move speed limit sign to top-right; align zoom/Hide Label across Explore and Validate

### DIFF
--- a/app/views/apps/validate.scala.html
+++ b/app/views/apps/validate.scala.html
@@ -100,7 +100,7 @@
                     <div id="label-description-box"></div>
                 </div>
                 <div id="pano-border-frame"></div>
-                <div id="speed-limit-sign" class="speed-limit-sign speed-limit-sign-left" data-design-style="us-canada">
+                <div id="speed-limit-sign" class="speed-limit-sign" data-design-style="us-canada">
                     <div class="speed-limit-holder">
                         <span class="speed-limit-text"><span id="speed-limit">N/A</span><span id="speed-limit-sub">N/A</span></span>
                     </div>

--- a/public/javascripts/SVLabel/css/svl-canvas.css
+++ b/public/javascripts/SVLabel/css/svl-canvas.css
@@ -141,19 +141,21 @@
     height: calc(16px * var(--ui-scale));
 }
 
+/* Sits in the top-right just left of the stacked zoom control, scaled down to match its height. transform-origin keeps
+   the top-right corner pinned so the scaled sign still lines up with the zoom buttons. */
 .speed-limit-sign {
     display: none;
     width: calc(60px * var(--ui-scale));
     height: calc(70px * var(--ui-scale));
     padding: calc(3px * var(--ui-scale));
-    margin-left: calc(2px * var(--ui-scale));
-    left: 0;
-    bottom: calc((25px + var(--bottom-left-links-clearance, 0px)) * var(--ui-scale));
+    top: calc(7px * var(--ui-scale));
+    right: calc(36px * var(--ui-scale));
     border-radius: calc(5px * var(--ui-scale));
     position: absolute;
-    z-index: 1;
+    z-index: 2;
     pointer-events: none;
-    transform: scale(0.75);
+    transform: scale(0.657);
+    transform-origin: top right;
     background: rgb(from var(--color-neutral-white) r g b / 75%);
 }
 
@@ -161,10 +163,8 @@
     width: calc(75px * var(--ui-scale));
     height: calc(75px * var(--ui-scale));
     padding: 0px;
-    margin-left: calc(-5px * var(--ui-scale));
-    margin-bottom: calc(-10px * var(--ui-scale));
     border-radius: 100%;
-    transform: scale(0.6);
+    transform: scale(0.613);
 }
 
 .speed-limit-holder {

--- a/public/javascripts/SVLabel/css/svl.css
+++ b/public/javascripts/SVLabel/css/svl.css
@@ -112,7 +112,7 @@ input[type="radio"] {
 
 /* Scale Google's terms / report-a-problem links (bottom-left; moved here from the pano) with the UI. They're Google's
    own elements with no scale hooks, so we scale them visually, anchored to the bottom-left corner they sit in. The
-   other bottom-left overlays (date/info button, speed-limit sign, imagery-source logo) are lifted above these via
+   other bottom-left overlays (date/info button, imagery-source logo) are lifted above these via
    --bottom-left-links-clearance, which PanoManager sets to the links' height for whichever imagery source provides
    a bottom-left links/attribution bar (GSV's terms/report-a-problem links, Mapillary's attribution links). */
 #view-control-layer div:has(> .gmnoprint) {

--- a/public/javascripts/SVValidate/css/svv-panorama.css
+++ b/public/javascripts/SVValidate/css/svv-panorama.css
@@ -54,36 +54,30 @@
     background-size: 100% 100%;
 }
 
+/* Sits in the top-right just left of the stacked zoom control, scaled down to match its height. transform-origin keeps
+   the top-right corner pinned so the scaled sign still lines up with the zoom buttons. */
 .speed-limit-sign {
     display: none;
     width: calc(60px * var(--ui-scale));
     height: calc(70px * var(--ui-scale));
     padding: calc(3px * var(--ui-scale));
-    margin-top: calc(-5px * var(--ui-scale));
-    margin-left: calc(-4px * var(--ui-scale));
-    margin-right: calc(-4px * var(--ui-scale));
-    top: 0;
-    right: 0;
+    top: calc(7px * var(--ui-scale));
+    right: calc(36px * var(--ui-scale));
     border-radius: calc(5px * var(--ui-scale));
     position: absolute;
     z-index: 3;
     pointer-events: none;
-    transform: scale(0.75);
+    transform: scale(0.657);
+    transform-origin: top right;
     background: rgb(from var(--color-neutral-white) r g b / 75%);
-}
-
-.speed-limit-sign-left {
-    left: 0;
 }
 
 .speed-limit-sign[data-design-style="non-us-canada"] {
     width: calc(75px * var(--ui-scale));
     height: calc(75px * var(--ui-scale));
     padding: 0px;
-    margin-top: calc(-10px * var(--ui-scale));
-    margin-left: calc(-10px * var(--ui-scale));
     border-radius: 100%;
-    transform: scale(0.6);
+    transform: scale(0.613);
 }
 
 .speed-limit-holder {
@@ -112,12 +106,12 @@
     font-size: calc(30px * var(--ui-scale));
 }
 
-/* Shared button look in pano-overlay-buttons.css; this rule only positions the holder in the bottom-right of pano. */
+/* Shared button look in pano-overlay-buttons.css; this rule only positions the holder in the top-right of the pano. */
 #zoom-buttons-holder {
     position: absolute;
     z-index: 3;
+    top: calc(7px * var(--ui-scale));
     right: calc(7px * var(--ui-scale));
-    bottom: calc(19px * var(--ui-scale));
 }
 
 #svv-panorama-date-holder {
@@ -191,9 +185,10 @@
     outline: none;
 }
 
+/* Top-left of the pano, where Explore keeps its stuck/sound/feedback controls. */
 #label-visibility-control-button {
     top: calc(7px * var(--ui-scale));
-    right: calc(7px * var(--ui-scale));
+    left: calc(7px * var(--ui-scale));
 }
 
 .hide-label-button-icon {


### PR DESCRIPTION
## Summary

Repositions the panorama overlay controls so the speed limit sign and zoom controls sit in the same place on both Explore and Validate.

- **Speed limit sign → top-right**, immediately left of the stacked zoom control, on both Explore and Validate. It's scaled down (`transform: scale(...)` with `transform-origin: top right`) so its height matches the zoom control while staying proportional.
- **Validate zoom buttons → top-right** (was bottom-right), matching Explore so the zoom control is in the same spot on both UIs.
- **Validate Hide Label button → top-left**, where Explore keeps its stuck/sound/feedback controls.
- Removed the now-unused `speed-limit-sign-left` class and dropped the speed-limit sign from the "bottom-left overlays" comment in `svl.css`.

## Screenshot

_Validate, showing the speed limit sign left of the zoom buttons in the top-right and the Hide Label button in the top-left:_
<img width="1754" height="911" alt="Screenshot from 2026-06-29 11-42-01" src="https://github.com/user-attachments/assets/82c9d0e9-7740-4888-a6b2-1dab636fae99" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)