### PR TITLE
Across Cities: cross-deployment admin overview (#4329)

### DIFF
--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -6,7 +6,7 @@ import executors.CpuIntensiveExecutionContext
 import formats.json.AdminFormats._
 import formats.json.LabelFormats._
 import formats.json.UserFormats._
-import models.auth.{DefaultEnv, WithAdmin}
+import models.auth.{DefaultEnv, WithAdmin, WithOwner}
 import models.label.LabelTypeEnum
 import models.user.{RoleTable, SidewalkUserWithRole}
 import org.apache.pekko.actor.ActorSystem
@@ -20,6 +20,7 @@ import play.silhouette.impl.exceptions.IdentityNotFoundException
 import service._
 
 import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
 import java.time.{Instant, OffsetDateTime, ZoneOffset}
 import java.util.concurrent.ThreadPoolExecutor
 import javax.inject.{Inject, Singleton}
@@ -850,6 +851,167 @@ class AdminController @Inject() (
           "labels_awaiting_validation" -> s.labelsAwaitingValidation,
           "low_quality_users"     -> s.lowQualityUsers,
           "last_activity"         -> lastActivity
+        )
+      )
+    }
+  }
+
+  /**
+   * Returns a per-city summary scorecard for every deployment, for the cross-city "Across Cities" overview (#4329).
+   *
+   * Owner-gated: all cities share one database, so per-city Administrators must not see other cities' detail. Merges the
+   * computed metrics ([[service.ConfigService.getCityScorecards]]) with each city's display name / URL / visibility
+   * (from config, so they stay language-aware) and echoes the anomaly thresholds + cross-city median in the summary
+   * block so the page can label the "needs attention" items. All field names are snake_case (v3 API convention).
+   */
+  def getCityScorecards = cc.securityService.SecuredAction(WithOwner()) { implicit request =>
+    cc.loggingService.insert(request.identity.userId, request.ipAddress, request.toString)
+    val cityInfoById: Map[String, CityInfo] =
+      configService.getAllCityInfo(request2Messages.lang).map(ci => ci.cityId -> ci).toMap
+
+    // Fetch the per-city scorecards and the all-time cross-city weekly series in parallel; the page's "over time" charts
+    // default to the last 12 weeks (derived client-side from each city's weekly_trend) and toggle to this all-time set.
+    val scorecardsF    = configService.getCityScorecards()
+    val allTimeF       = configService.getCrossCityWeeklyTrend(None)
+    val labelingSpeedF = configService.getCrossCityLabelingSpeed()
+
+    for {
+      withFlags     <- scorecardsF
+      allTimeTrend  <- allTimeF
+      labelingSpeed <- labelingSpeedF
+    } yield {
+      val now        = OffsetDateTime.now()
+      val scorecards = withFlags.map(_.scorecard)
+
+      val cities = withFlags.map { case CityScorecardWithFlags(sc, anomalies) =>
+        val info = cityInfoById.get(sc.cityId)
+        // Per-label-type breakdown (the data-pattern lens), keyed by label type with snake_case stat names.
+        val byLabelType = JsObject(sc.byLabelType.toSeq.map { case (labelType, s) =>
+          labelType -> Json.obj(
+            "labels"    -> s.labels,
+            "validated" -> s.labelsValidated,
+            "agree"     -> s.labelsValidatedAgree,
+            "disagree"  -> s.labelsValidatedDisagree
+          )
+        })
+        // Trailing weekly activity (oldest first) — drives per-city sparklines and the aggregate overview line charts.
+        val weeklyTrend = JsArray(sc.weeklyTrend.map { w =>
+          Json.obj(
+            "week_start"   -> w.weekStart.toString,
+            "labels"       -> w.labels,
+            "validations"  -> w.validations,
+            "active_users" -> w.activeUsers
+          )
+        })
+        Json.obj(
+          "city_id"                      -> sc.cityId,
+          "city_name"                    -> info.map(_.cityNameShort),
+          "city_name_formatted"          -> info.map(_.cityNameFormatted),
+          "url"                          -> info.map(_.URL),
+          "visibility"                   -> info.map(_.visibility),
+          // Coverage lens.
+          "coverage"                     -> sc.coverage,
+          "total_streets"                -> sc.totalStreets,
+          "audited_streets"              -> sc.auditedStreets,
+          "streets_remaining"            -> (sc.totalStreets - sc.auditedStreets),
+          "total_km"                     -> sc.totalKm,
+          "audited_km"                   -> sc.auditedKm,
+          "km_remaining"                 -> math.max(0.0, sc.totalKm - sc.auditedKm),
+          // Data + quality lens.
+          "total_labels"                 -> sc.totalLabels,
+          "ai_labels"                    -> sc.aiLabels,
+          "ai_label_share"               -> (if (sc.totalLabels > 0) sc.aiLabels.toDouble / sc.totalLabels else 0.0),
+          "labels_validated"             -> sc.labelsValidated,
+          "labels_validated_share"       -> (if (sc.totalLabels > 0) sc.labelsValidated.toDouble / sc.totalLabels else 0.0),
+          "labels_with_severity"         -> sc.labelsWithSeverity,
+          "labels_severity_eligible"     -> sc.labelsSeverityEligible,
+          // Share computed only over types that CAN have a severity (NoSidewalk/Signal/Occlusion excluded).
+          "severity_share"               -> (if (sc.labelsSeverityEligible > 0) sc.labelsWithSeverity.toDouble / sc.labelsSeverityEligible else 0.0),
+          "labels_with_tags"             -> sc.labelsWithTags,
+          "labels_tag_eligible"          -> sc.labelsTagEligible,
+          // Share computed only over types that CAN have tags (types present in the deployment's tag table).
+          "tags_share"                   -> (if (sc.labelsTagEligible > 0) sc.labelsWithTags.toDouble / sc.labelsTagEligible else 0.0),
+          "validations_per_label"        -> (if (sc.totalLabels > 0) sc.totalValidations.toDouble / sc.totalLabels else 0.0),
+          "total_validations"            -> sc.totalValidations,
+          "validations_agree"            -> sc.validationsAgree,
+          "validations_disagree"         -> sc.validationsDisagree,
+          "validation_disagreement_rate" -> ConfigService.disagreementRate(sc),
+          "ai_validations"               -> sc.aiValidations,
+          "ai_validation_share"          -> (if (sc.totalValidations > 0) sc.aiValidations.toDouble / sc.totalValidations else 0.0),
+          "by_label_type"                -> byLabelType,
+          // People lens.
+          "active_contributors"          -> sc.activeContributors,
+          "low_quality_contributors"     -> sc.lowQualityContributors,
+          // Activity lens.
+          "labels_7d"                    -> sc.labels7d,
+          "labels_30d"                   -> sc.labels30d,
+          "validations_7d"               -> sc.validations7d,
+          "validations_30d"              -> sc.validations30d,
+          "audits_7d"                    -> sc.audits7d,
+          "audits_30d"                   -> sc.audits30d,
+          "last_activity"                -> sc.lastActivity,
+          "days_since_activity"          -> sc.lastActivity.map(ts => ChronoUnit.DAYS.between(ts, now)),
+          "weekly_trend"                 -> weeklyTrend,
+          // Contributors & effort (per-user output is median/p90, not mean±SD — the distribution is power-law).
+          "labels_per_user_median"       -> sc.labelsPerUserMedian,
+          "labels_per_user_p90"          -> sc.labelsPerUserP90,
+          "num_labelers"                 -> sc.numLabelers,
+          "validations_per_user_median"  -> sc.validationsPerUserMedian,
+          "validations_per_user_p90"     -> sc.validationsPerUserP90,
+          "num_validators"               -> sc.numValidators,
+          "seconds_per_validation"       -> sc.validationSecondsMedian,
+          "seconds_to_validate_10"       -> (sc.validationSecondsMedian * 10),
+          // Labeling speed (seconds of active auditing per 100 m) from the daily-cached heavy path; None if no data.
+          "seconds_per_100m"             -> labelingSpeed.get(sc.cityId),
+          // Lifecycle/health state: active | wrapped_up | stalled | low_traction (#4329).
+          "lifecycle"                    -> ConfigService.lifecycle(sc, now),
+          "anomalies"                    -> anomalies
+        )
+      }
+
+      // Cross-city weekly series for the full project history (the "All time" toggle on the over-time charts).
+      val overTimeAllTime = JsArray(allTimeTrend.map { w =>
+        Json.obj(
+          "week_start"   -> w.weekStart.toString,
+          "labels"       -> w.labels,
+          "validations"  -> w.validations,
+          "active_users" -> w.activeUsers
+        )
+      })
+
+      // Project-wide "hero" totals, summed from the cities shown above so they reconcile with the table. Distinct
+      // countries come from city config; languages from the app's supported set. global_agreement is the share of
+      // agree/disagree validations that agreed. total_users is the sum of per-city contributors (a person who
+      // contributes in two cities counts in each — there is no cross-city dedup here).
+      val numCountries     = scorecards.flatMap(sc => cityInfoById.get(sc.cityId).map(_.countryId)).distinct.size
+      val numLanguages     = config.get[Seq[String]]("play.i18n.langs").size
+      val totalContributors = scorecards.map(_.activeContributors).sum
+      val totalKm          = scorecards.map(_.auditedKm).sum
+      val totalLabels      = scorecards.map(_.totalLabels).sum
+      val totalValidations = scorecards.map(_.totalValidations).sum
+      val sumAgree         = scorecards.map(_.validationsAgree).sum
+      val sumDisagree      = scorecards.map(_.validationsDisagree).sum
+      val globalAgreement  = if (sumAgree + sumDisagree > 0) sumAgree.toDouble / (sumAgree + sumDisagree) else 0.0
+
+      Ok(
+        Json.obj(
+          "cities"             -> cities,
+          "over_time_all_time" -> overTimeAllTime,
+          "summary" -> Json.obj(
+            "num_cities"               -> scorecards.length,
+            "num_countries"            -> numCountries,
+            "num_languages"            -> numLanguages,
+            "total_users"              -> totalContributors,
+            "total_km"                 -> totalKm,
+            "total_labels"             -> totalLabels,
+            "total_validations"        -> totalValidations,
+            "total_datapoints"         -> (totalLabels.toLong + totalValidations.toLong),
+            "global_agreement"         -> globalAgreement,
+            "median_disagreement_rate" -> ConfigService.medianDisagreementRate(scorecards),
+            "active_within_days"       -> ConfigService.ActiveWithinDays,
+            "wrapped_up_coverage"      -> ConfigService.WrappedUpCoverage,
+            "low_traction_contributors" -> ConfigService.LowTractionContributors
+          )
         )
       )
     }

--- a/app/controllers/AdminDashboardController.scala
+++ b/app/controllers/AdminDashboardController.scala
@@ -1,7 +1,7 @@
 package controllers
 
 import controllers.base.{CustomBaseController, CustomControllerComponents}
-import models.auth.WithAdmin
+import models.auth.{WithAdmin, WithOwner}
 import play.api.Configuration
 import service.{ConfigService, LabelService}
 
@@ -157,6 +157,21 @@ class AdminDashboardController @Inject() (
     configService.getCommonPageData(request2Messages.lang).map { commonData =>
       cc.loggingService.insert(request.identity.userId, request.ipAddress, "Visit_Admin_Management")
       Ok(views.html.admin.dashboard.management(commonData, request.identity))
+    }
+  }
+
+  /**
+   * Renders the Across Cities page: a cross-deployment overview comparing every Project Sidewalk city at once (#4329).
+   *
+   * Answers "how is the whole project doing, and which deployments need attention?" — a per-city scorecard (coverage,
+   * labels, validations, contributors, AI share, last activity) plus server-computed anomaly flags (stalled, low
+   * coverage, outlier validation disagreement). Owner-gated rather than admin-gated: every city lives in one database,
+   * so per-city Administrators must not see other cities' detail. Driven client-side from `/adminapi/cityScorecards`.
+   */
+  def acrossCities = cc.securityService.SecuredAction(WithOwner()) { implicit request =>
+    configService.getCommonPageData(request2Messages.lang).map { commonData =>
+      cc.loggingService.insert(request.identity.userId, request.ipAddress, "Visit_Admin_AcrossCities")
+      Ok(views.html.admin.dashboard.acrossCities(commonData, request.identity))
     }
   }
 }

--- a/app/models/auth/WithRole.scala
+++ b/app/models/auth/WithRole.scala
@@ -16,6 +16,20 @@ case class WithAdmin() extends RoleBasedAuthorization[SidewalkUserWithRole, Defa
   }
 }
 
+// Authorized only for the global "Owner" super-role. Used by cross-deployment views (e.g. the Across Cities admin
+// overview, #4329): every city's data lives in one database, so per-city Administrators must NOT see other cities'
+// detail — only Owners, who operate across deployments, may.
+case class WithOwner() extends RoleBasedAuthorization[SidewalkUserWithRole, DefaultEnv#A] {
+  override def checkAuthorization[B](identity: SidewalkUserWithRole, authenticator: DefaultEnv#A)(implicit
+      request: Request[B]
+  ): Future[AuthorizationResult] = {
+    Future.successful {
+      if (identity.role == "Owner") Authorized
+      else NotAuthorized(currRole = identity.role, requiredRole = "Owner")
+    }
+  }
+}
+
 case class WithSignedIn() extends RoleBasedAuthorization[SidewalkUserWithRole, DefaultEnv#A] {
   override def checkAuthorization[B](identity: SidewalkUserWithRole, authenticator: DefaultEnv#A)(implicit
       request: Request[B]

--- a/app/models/utils/ConfigTable.scala
+++ b/app/models/utils/ConfigTable.scala
@@ -3,10 +3,10 @@ package models.utils
 import com.google.inject.ImplementedBy
 import models.utils.MyPostgresProfile.api._
 import play.api.db.slick.{DatabaseConfigProvider, HasDatabaseConfigProvider}
-import service.{AggregateStats, LabelTypeStats}
+import service.{AggregateStats, CityScorecard, LabelTypeStats, WeeklyPoint}
 import slick.jdbc.GetResult
 
-import java.time.LocalDate
+import java.time.{LocalDate, OffsetDateTime, ZoneOffset}
 import javax.inject._
 import scala.concurrent.ExecutionContext
 
@@ -189,7 +189,7 @@ class ConfigTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvi
    * @param schema The database schema to query
    * @return DBIO action that yields a map of label type to LabelTypeStats
    */
-  private def getLabelTypeStatsBySchema(schema: String): DBIO[Map[String, LabelTypeStats]] = {
+  def getLabelTypeStatsBySchema(schema: String): DBIO[Map[String, LabelTypeStats]] = {
     sql"""
       SELECT
         lt.label_type,
@@ -234,6 +234,428 @@ class ConfigTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvi
           )
         }.toMap
       }
+  }
+
+  /**
+   * Internal single-row result of the scorecard core query, before the per-label-type and weekly-trend queries are
+   * folded in by [[getCityScorecardBySchema]].
+   */
+  private case class ScorecardCore(
+      totalStreets: Int,
+      auditedStreets: Int,
+      totalKm: Double,
+      auditedKm: Double,
+      totalLabels: Int,
+      aiLabels: Int,
+      labelsWithSeverity: Int,
+      labelsSeverityEligible: Int,
+      labelsWithTags: Int,
+      labelsTagEligible: Int,
+      totalValidations: Int,
+      validationsAgree: Int,
+      validationsDisagree: Int,
+      aiValidations: Int,
+      activeContributors: Int,
+      lowQualityContributors: Int,
+      labels7d: Int,
+      labels30d: Int,
+      validations7d: Int,
+      validations30d: Int,
+      audits7d: Int,
+      audits30d: Int,
+      lastActivity: Option[OffsetDateTime]
+  )
+
+  /** Number of trailing weeks of activity trend the scorecard fetches per city. */
+  private val ScorecardTrendWeeks: Int = 12
+
+  /**
+   * Computes a rich per-city summary scorecard for a specific city schema (#4329).
+   *
+   * Powers the cross-city "Across Cities" admin overview across four lenses — coverage (streets/km audited vs total),
+   * activity (7-day and 30-day volume plus a weekly trend), data patterns (the per-label-type mix), and data quality
+   * (validated/agreement counts plus low-quality contributors). Each configured city's schema is queried in parallel at
+   * the service layer and the rows are rendered as a comparison page. Exclusion predicates mirror
+   * `getCityAggregateDataBySchema` (`NOT user_stat.excluded`, `deleted = FALSE`, `tutorial = FALSE`, the tutorial-street
+   * guard) so a city's totals here reconcile with its single-city stats.
+   *
+   * Composed from three queries on the same connection: the single-row core metrics, the per-label-type breakdown
+   * (reusing [[getLabelTypeStatsBySchema]]), and the weekly trend (`getCityWeeklyTrendBySchema`).
+   *
+   * AI is determined by the shared `sidewalk_login` role (`role.role = 'AI'`), not anything in the city schema — so
+   * those joins are intentionally not schema-qualified, matching `getCityDailyLabelStatsBySchema`. `COUNT(DISTINCT
+   * label_id)` is used for label counts so the AI-role LEFT JOINs can never fan a label out if a user carries more than
+   * one role row.
+   *
+   * @param schema The database schema name for the target city (e.g. "sidewalk_seattle").
+   * @return       DBIO yielding a complete CityScorecard. `lastActivity` is None for a schema with no activity;
+   *               `coverage` is 0.0 when the city has no streets loaded.
+   */
+  def getCityScorecardBySchema(schema: String): DBIO[CityScorecard] = {
+    // The nullable last-activity timestamp can be NULL on an empty schema, so it is read as an Option and normalized to
+    // UTC (we only need the instant, for "days since last activity").
+    implicit val getResult: GetResult[ScorecardCore] = GetResult { r =>
+      ScorecardCore(
+        totalStreets = r.nextInt(),
+        auditedStreets = r.nextInt(),
+        totalKm = r.nextDouble(),
+        auditedKm = r.nextDouble(),
+        totalLabels = r.nextInt(),
+        aiLabels = r.nextInt(),
+        labelsWithSeverity = r.nextInt(),
+        labelsSeverityEligible = r.nextInt(),
+        labelsWithTags = r.nextInt(),
+        labelsTagEligible = r.nextInt(),
+        totalValidations = r.nextInt(),
+        validationsAgree = r.nextInt(),
+        validationsDisagree = r.nextInt(),
+        aiValidations = r.nextInt(),
+        activeContributors = r.nextInt(),
+        lowQualityContributors = r.nextInt(),
+        labels7d = r.nextInt(),
+        labels30d = r.nextInt(),
+        validations7d = r.nextInt(),
+        validations30d = r.nextInt(),
+        audits7d = r.nextInt(),
+        audits30d = r.nextInt(),
+        lastActivity = r.nextTimestampOption().map(_.toInstant.atOffset(ZoneOffset.UTC))
+      )
+    }
+
+    val coreQuery =
+      sql"""
+      SELECT total_streets.cnt          AS total_streets,
+             audited_streets.cnt        AS audited_streets,
+             COALESCE(street_km.km, 0)  AS total_km,
+             COALESCE(audited_km.km, 0) AS audited_km,
+             label_counts.label_count    AS total_labels,
+             label_counts.ai_count       AS ai_labels,
+             label_counts.with_severity     AS labels_with_severity,
+             label_counts.severity_eligible AS labels_severity_eligible,
+             label_counts.with_tags         AS labels_with_tags,
+             label_counts.tag_eligible      AS labels_tag_eligible,
+             val_counts.val_count           AS total_validations,
+             val_counts.agree_count     AS validations_agree,
+             val_counts.disagree_count  AS validations_disagree,
+             ai_val_counts.ai_count     AS ai_validations,
+             active_contributors.cnt    AS active_contributors,
+             low_quality.cnt            AS low_quality_contributors,
+             label_counts.labels_7d     AS labels_7d,
+             label_counts.labels_30d    AS labels_30d,
+             val_counts.val_7d          AS validations_7d,
+             val_counts.val_30d         AS validations_30d,
+             audit_windows.audits_7d    AS audits_7d,
+             audit_windows.audits_30d   AS audits_30d,
+             last_activity.ts           AS last_activity
+      FROM (
+          SELECT COUNT(*) AS cnt FROM "#$schema".street_edge WHERE deleted = FALSE
+      ) AS total_streets, (
+          -- Filter audited streets to non-deleted so the numerator can't exceed total_streets (deleted streets can
+          -- still have audit_task rows, which would push coverage above 100% and make "streets left" negative). #4329
+          SELECT COUNT(DISTINCT street_edge.street_edge_id) AS cnt
+          FROM "#$schema".street_edge
+          INNER JOIN "#$schema".audit_task ON street_edge.street_edge_id = audit_task.street_edge_id
+          INNER JOIN "#$schema".user_stat ON audit_task.user_id = user_stat.user_id
+          WHERE completed = TRUE AND NOT user_stat.excluded AND street_edge.deleted = FALSE
+      ) AS audited_streets, (
+          SELECT SUM(ST_LENGTH(ST_TRANSFORM(geom, 26918))) / 1000 AS km
+          FROM "#$schema".street_edge WHERE deleted = FALSE
+      ) AS street_km, (
+          -- Distinct audited length (no double-counting overlapping audits), non-deleted only (see audited_streets).
+          SELECT SUM(ST_LENGTH(ST_TRANSFORM(geom, 26918))) / 1000 AS km
+          FROM (
+              SELECT DISTINCT street_edge.street_edge_id, geom
+              FROM "#$schema".street_edge
+              INNER JOIN "#$schema".audit_task ON street_edge.street_edge_id = audit_task.street_edge_id
+              INNER JOIN "#$schema".user_stat ON audit_task.user_id = user_stat.user_id
+              WHERE completed = TRUE AND NOT user_stat.excluded AND street_edge.deleted = FALSE
+          ) AS distinct_audited
+      ) AS audited_km, (
+          SELECT COUNT(DISTINCT label.label_id) AS label_count,
+                 COUNT(DISTINCT label.label_id) FILTER (WHERE role.role = 'AI') AS ai_count,
+                 COUNT(DISTINCT label.label_id) FILTER (WHERE label.severity IS NOT NULL) AS with_severity,
+                 -- Denominator for "% with severity": only types that CAN take a severity. The three excluded here
+                 -- mirror UtilitiesSidewalk.js LABEL_TYPES_WITHOUT_SEVERITY (NoSidewalk, Signal, Occlusion).
+                 COUNT(DISTINCT label.label_id) FILTER (
+                     WHERE label.label_type_id NOT IN (
+                         SELECT label_type_id FROM "#$schema".label_type
+                         WHERE label_type IN ('NoSidewalk', 'Signal', 'Occlusion')
+                     )
+                 ) AS severity_eligible,
+                 COUNT(DISTINCT label.label_id) FILTER (WHERE cardinality(label.tags) > 0) AS with_tags,
+                 -- Denominator for "% with tags": only types that CAN take tags, i.e. types that have any tag defined
+                 -- in this deployment's tag table (self-adapting per city; typically all types except Occlusion).
+                 COUNT(DISTINCT label.label_id) FILTER (
+                     WHERE label.label_type_id IN (SELECT DISTINCT label_type_id FROM "#$schema".tag)
+                 ) AS tag_eligible,
+                 COUNT(DISTINCT label.label_id) FILTER (WHERE label.time_created >= NOW() - INTERVAL '7 days') AS labels_7d,
+                 COUNT(DISTINCT label.label_id) FILTER (WHERE label.time_created >= NOW() - INTERVAL '30 days') AS labels_30d
+          FROM "#$schema".label
+          INNER JOIN "#$schema".user_stat ON label.user_id = user_stat.user_id
+          INNER JOIN "#$schema".audit_task ON label.audit_task_id = audit_task.audit_task_id
+          LEFT  JOIN sidewalk_login.user_role ON label.user_id     = user_role.user_id
+          LEFT  JOIN sidewalk_login.role      ON user_role.role_id = role.role_id
+          WHERE NOT user_stat.excluded
+              AND label.deleted = FALSE
+              AND label.tutorial = FALSE
+              AND label.street_edge_id <> (SELECT tutorial_street_edge_id FROM "#$schema".config)
+              AND audit_task.street_edge_id <> (SELECT tutorial_street_edge_id FROM "#$schema".config)
+      ) AS label_counts, (
+          -- val_count / val_7d / val_30d are ALL validations (the activity volume, incl. AI). agree_count and
+          -- disagree_count are HUMAN-only (role != 'AI'): the agreement/disagreement quality signal is about whether
+          -- people concur; AI verdicts are reported separately (ai_val_counts). COUNT(DISTINCT ...) guards against the
+          -- role LEFT JOIN fanning a validation out if a user carries more than one role row.
+          SELECT COUNT(DISTINCT label_validation.label_validation_id) AS val_count,
+                 COUNT(DISTINCT label_validation.label_validation_id)
+                     FILTER (WHERE validation_result::text = 'Agree'    AND role.role IS DISTINCT FROM 'AI') AS agree_count,
+                 COUNT(DISTINCT label_validation.label_validation_id)
+                     FILTER (WHERE validation_result::text = 'Disagree' AND role.role IS DISTINCT FROM 'AI') AS disagree_count,
+                 COUNT(DISTINCT label_validation.label_validation_id)
+                     FILTER (WHERE end_timestamp >= NOW() - INTERVAL '7 days')  AS val_7d,
+                 COUNT(DISTINCT label_validation.label_validation_id)
+                     FILTER (WHERE end_timestamp >= NOW() - INTERVAL '30 days') AS val_30d
+          FROM "#$schema".label_validation
+          INNER JOIN "#$schema".user_stat ON label_validation.user_id = user_stat.user_id
+          LEFT  JOIN sidewalk_login.user_role ON label_validation.user_id = user_role.user_id
+          LEFT  JOIN sidewalk_login.role      ON user_role.role_id        = role.role_id
+          WHERE NOT user_stat.excluded
+      ) AS val_counts, (
+          -- AI-authored validations, counted separately from val_counts so the AI-role join can't fan out the totals.
+          SELECT COUNT(DISTINCT label_validation.label_validation_id) AS ai_count
+          FROM "#$schema".label_validation
+          INNER JOIN "#$schema".user_stat ON label_validation.user_id = user_stat.user_id
+          LEFT  JOIN sidewalk_login.user_role ON label_validation.user_id = user_role.user_id
+          LEFT  JOIN sidewalk_login.role      ON user_role.role_id        = role.role_id
+          WHERE NOT user_stat.excluded AND role.role = 'AI'
+      ) AS ai_val_counts, (
+          SELECT COUNT(DISTINCT street_edge_id) FILTER (WHERE task_end >= NOW() - INTERVAL '7 days')  AS audits_7d,
+                 COUNT(DISTINCT street_edge_id) FILTER (WHERE task_end >= NOW() - INTERVAL '30 days') AS audits_30d
+          FROM "#$schema".audit_task
+          INNER JOIN "#$schema".user_stat ON audit_task.user_id = user_stat.user_id
+          WHERE completed = TRUE AND NOT user_stat.excluded
+      ) AS audit_windows, (
+          -- Distinct PEOPLE who labeled or validated: union of non-excluded, non-AI label authors and validators.
+          SELECT COUNT(DISTINCT contributor_id) AS cnt FROM (
+              SELECT label.user_id AS contributor_id
+              FROM "#$schema".label
+              INNER JOIN "#$schema".user_stat ON label.user_id = user_stat.user_id
+              LEFT  JOIN sidewalk_login.user_role ON label.user_id     = user_role.user_id
+              LEFT  JOIN sidewalk_login.role      ON user_role.role_id = role.role_id
+              WHERE NOT user_stat.excluded AND label.deleted = FALSE AND label.tutorial = FALSE
+                  AND role.role IS DISTINCT FROM 'AI'
+              UNION
+              SELECT label_validation.user_id AS contributor_id
+              FROM "#$schema".label_validation
+              INNER JOIN "#$schema".user_stat ON label_validation.user_id = user_stat.user_id
+              LEFT  JOIN sidewalk_login.user_role ON label_validation.user_id = user_role.user_id
+              LEFT  JOIN sidewalk_login.role      ON user_role.role_id        = role.role_id
+              WHERE NOT user_stat.excluded AND role.role IS DISTINCT FROM 'AI'
+          ) AS contributor_union
+      ) AS active_contributors, (
+          -- Distinct EXCLUDED (low-quality) users who placed a label — the data-quality "how much got filtered" signal.
+          SELECT COUNT(DISTINCT label.user_id) AS cnt
+          FROM "#$schema".label
+          INNER JOIN "#$schema".user_stat ON label.user_id = user_stat.user_id
+          WHERE user_stat.excluded AND label.deleted = FALSE AND label.tutorial = FALSE
+      ) AS low_quality, (
+          SELECT GREATEST(
+              (SELECT MAX(time_created)  FROM "#$schema".label),
+              (SELECT MAX(end_timestamp) FROM "#$schema".label_validation),
+              (SELECT MAX(task_end)      FROM "#$schema".audit_task)
+          ) AS ts
+      ) AS last_activity;
+    """.as[ScorecardCore].head
+
+    // Fold in the per-label-type breakdown, the weekly trend, and the (cheap) per-user output/speed stats (same
+    // connection), then assemble the full scorecard. The expensive labeling-speed query is NOT here — it is computed on
+    // a separate long-cached path (getCrossCityLabelingSpeed).
+    for {
+      core        <- coreQuery
+      byLabelType <- getLabelTypeStatsBySchema(schema)
+      weeklyTrend <- getCityWeeklyTrendBySchema(schema, Some(ScorecardTrendWeeks))
+      output      <- getCityContributorOutputBySchema(schema)
+    } yield {
+      val (lblMedian, lblP90, nLabelers, valMedian, valP90, nValidators, valSecMedian) = output
+      CityScorecard(
+        cityId = schema, // Replaced with the real cityId at the service layer; schema is the only id known here.
+        totalStreets = core.totalStreets,
+        auditedStreets = core.auditedStreets,
+        coverage = if (core.totalStreets > 0) core.auditedStreets.toDouble / core.totalStreets else 0.0,
+        totalKm = core.totalKm,
+        auditedKm = core.auditedKm,
+        totalLabels = core.totalLabels,
+        aiLabels = core.aiLabels,
+        labelsWithSeverity = core.labelsWithSeverity,
+        labelsSeverityEligible = core.labelsSeverityEligible,
+        labelsWithTags = core.labelsWithTags,
+        labelsTagEligible = core.labelsTagEligible,
+        labelsValidated = byLabelType.values.map(_.labelsValidated).sum,
+        totalValidations = core.totalValidations,
+        validationsAgree = core.validationsAgree,
+        validationsDisagree = core.validationsDisagree,
+        aiValidations = core.aiValidations,
+        byLabelType = byLabelType,
+        activeContributors = core.activeContributors,
+        lowQualityContributors = core.lowQualityContributors,
+        labels7d = core.labels7d,
+        labels30d = core.labels30d,
+        validations7d = core.validations7d,
+        validations30d = core.validations30d,
+        audits7d = core.audits7d,
+        audits30d = core.audits30d,
+        lastActivity = core.lastActivity,
+        weeklyTrend = weeklyTrend,
+        labelsPerUserMedian = lblMedian,
+        labelsPerUserP90 = lblP90,
+        numLabelers = nLabelers,
+        validationsPerUserMedian = valMedian,
+        validationsPerUserP90 = valP90,
+        numValidators = nValidators,
+        validationSecondsMedian = valSecMedian
+      )
+    }
+  }
+
+  /**
+   * Returns weekly label/validation/active-user volume for a city schema, oldest week first (#4329).
+   *
+   * Buckets by ISO week (Monday) in Pacific time so the weeks line up with the rest of the daily/weekly stats. Weeks
+   * with no activity are absent (the page fills gaps with zeros).
+   *
+   * @param schema The database schema to query.
+   * @param weeks  Trailing weeks to include, or None for the city's full history (the "All time" toggle).
+   * @return       DBIO yielding (weekStart, labels, validations, activeUsers), ascending by week.
+   */
+  def getCityWeeklyTrendBySchema(schema: String, weeks: Option[Int]): DBIO[Seq[WeeklyPoint]] = {
+    implicit val getResult: GetResult[WeeklyPoint] =
+      GetResult(r => WeeklyPoint(LocalDate.parse(r.nextString()), r.nextInt(), r.nextInt(), r.nextInt()))
+
+    // weeks is an Int (safe to interpolate); None drops the lower bound to return the city's full history.
+    val labelBound = weeks.map(w => s"AND label.time_created >= NOW() - ($w * INTERVAL '1 week')").getOrElse("")
+    val valBound   =
+      weeks.map(w => s"AND label_validation.end_timestamp >= NOW() - ($w * INTERVAL '1 week')").getOrElse("")
+
+    sql"""
+      SELECT CAST(DATE_TRUNC('week', activity_ts AT TIME ZONE 'US/Pacific')::date AS TEXT) AS week_start,
+             COUNT(*) FILTER (WHERE kind = 'label')      AS labels,
+             COUNT(*) FILTER (WHERE kind = 'validation') AS validations,
+             COUNT(DISTINCT activity_user_id)            AS active_users
+      FROM (
+          SELECT label.time_created AS activity_ts, label.user_id AS activity_user_id, 'label' AS kind
+          FROM "#$schema".label
+          INNER JOIN "#$schema".user_stat ON label.user_id = user_stat.user_id
+          WHERE NOT user_stat.excluded AND label.deleted = FALSE AND label.tutorial = FALSE
+              #$labelBound
+          UNION ALL
+          SELECT label_validation.end_timestamp AS activity_ts, label_validation.user_id AS activity_user_id, 'validation' AS kind
+          FROM "#$schema".label_validation
+          INNER JOIN "#$schema".user_stat ON label_validation.user_id = user_stat.user_id
+          WHERE NOT user_stat.excluded
+              #$valBound
+      ) AS activity
+      GROUP BY week_start
+      ORDER BY week_start ASC;
+    """.as[WeeklyPoint]
+  }
+
+  /**
+   * Per-contributor output and validation speed for a city schema (#4329), all cheap aggregates (no interaction scan).
+   *
+   * Per-user label and validation counts are extremely right-skewed (a few power users), so this returns MEDIAN and p90
+   * rather than mean ± SD, which would be misleading. AI and excluded users are left out so these describe real people.
+   * Validation speed is the MEDIAN per-validation duration (seconds), clamped to <= 5 min to drop "left-the-tab-open"
+   * outliers (mirrors the 5-minute idle cap used by the contribution-time stats).
+   *
+   * @param schema The database schema to query.
+   * @return       (labelMedian, labelP90, numLabelers, valMedian, valP90, numValidators, validationSecondsMedian);
+   *               zeros when a population is empty.
+   */
+  def getCityContributorOutputBySchema(schema: String): DBIO[(Double, Double, Int, Double, Double, Int, Double)] = {
+    implicit val getResult: GetResult[(Double, Double, Int, Double, Double, Int, Double)] =
+      GetResult(r => (r.nextDouble(), r.nextDouble(), r.nextInt(), r.nextDouble(), r.nextDouble(), r.nextInt(), r.nextDouble()))
+
+    sql"""
+      SELECT COALESCE(lbl.median, 0), COALESCE(lbl.p90, 0), COALESCE(lbl.n, 0),
+             COALESCE(val.median, 0), COALESCE(val.p90, 0), COALESCE(val.n, 0),
+             COALESCE(vdur.median_secs, 0)
+      FROM (
+          SELECT percentile_cont(0.5) WITHIN GROUP (ORDER BY cnt) AS median,
+                 percentile_cont(0.9) WITHIN GROUP (ORDER BY cnt) AS p90,
+                 count(*)::int AS n
+          FROM (
+              SELECT count(*) AS cnt
+              FROM "#$schema".label
+              INNER JOIN "#$schema".user_stat ON label.user_id = user_stat.user_id
+              LEFT  JOIN sidewalk_login.user_role ON label.user_id     = user_role.user_id
+              LEFT  JOIN sidewalk_login.role      ON user_role.role_id = role.role_id
+              WHERE NOT user_stat.excluded AND label.deleted = FALSE AND label.tutorial = FALSE
+                  AND role.role IS DISTINCT FROM 'AI'
+              GROUP BY label.user_id
+          ) lc
+      ) lbl, (
+          SELECT percentile_cont(0.5) WITHIN GROUP (ORDER BY cnt) AS median,
+                 percentile_cont(0.9) WITHIN GROUP (ORDER BY cnt) AS p90,
+                 count(*)::int AS n
+          FROM (
+              SELECT count(*) AS cnt
+              FROM "#$schema".label_validation
+              INNER JOIN "#$schema".user_stat ON label_validation.user_id = user_stat.user_id
+              LEFT  JOIN sidewalk_login.user_role ON label_validation.user_id = user_role.user_id
+              LEFT  JOIN sidewalk_login.role      ON user_role.role_id        = role.role_id
+              WHERE NOT user_stat.excluded AND role.role IS DISTINCT FROM 'AI'
+              GROUP BY label_validation.user_id
+          ) vc
+      ) val, (
+          SELECT percentile_cont(0.5) WITHIN GROUP (ORDER BY secs) AS median_secs
+          FROM (
+              SELECT EXTRACT(EPOCH FROM (label_validation.end_timestamp - label_validation.start_timestamp)) AS secs
+              FROM "#$schema".label_validation
+              INNER JOIN "#$schema".user_stat ON label_validation.user_id = user_stat.user_id
+              LEFT  JOIN sidewalk_login.user_role ON label_validation.user_id = user_role.user_id
+              LEFT  JOIN sidewalk_login.role      ON user_role.role_id        = role.role_id
+              WHERE NOT user_stat.excluded AND role.role IS DISTINCT FROM 'AI'
+                  AND label_validation.start_timestamp IS NOT NULL
+                  AND label_validation.end_timestamp > label_validation.start_timestamp
+                  AND EXTRACT(EPOCH FROM (label_validation.end_timestamp - label_validation.start_timestamp)) <= 300
+          ) vd
+      ) vdur;
+    """.as[(Double, Double, Int, Double, Double, Int, Double)].head
+  }
+
+  /**
+   * Inputs for a city's labeling-speed metric (#4329): idle-capped active auditing time and audited distance.
+   *
+   * This is the EXPENSIVE query — a window function over `audit_task_interaction_small` — so it is called from a
+   * separately, long-cached service path rather than on every scorecard load. The active-time logic mirrors
+   * `AuditTaskInteractionTable.calculateTimeExploring`: sum the gaps between a user's consecutive interactions,
+   * dropping gaps over 5 minutes (idle). Distance is the audited length WITH overlap (total ground covered), the right
+   * denominator for "time to cover 100 m".
+   *
+   * @param schema The database schema to query.
+   * @return       (activeAuditHours, auditedKmWithOverlap); hours is 0 when there is no interaction data.
+   */
+  def getCityLabelingSpeedBySchema(schema: String): DBIO[(Double, Double)] = {
+    implicit val getResult: GetResult[(Double, Double)] = GetResult(r => (r.nextDouble(), r.nextDouble()))
+
+    sql"""
+      SELECT COALESCE(audit_time.hours, 0) AS hours,
+             COALESCE(audited.km, 0)       AS km
+      FROM (
+          SELECT extract(epoch from SUM(diff)) / 3600.0 AS hours
+          FROM (
+              SELECT (timestamp - LAG(timestamp, 1) OVER (PARTITION BY user_id ORDER BY timestamp)) AS diff
+              FROM "#$schema".audit_task_interaction_small
+              INNER JOIN "#$schema".mission ON audit_task_interaction_small.mission_id = mission.mission_id
+          ) time_diffs
+          WHERE diff < '00:05:00' AND diff > '00:00:00'
+      ) AS audit_time, (
+          SELECT SUM(ST_LENGTH(ST_TRANSFORM(geom, 26918))) / 1000 AS km
+          FROM "#$schema".street_edge
+          INNER JOIN "#$schema".audit_task ON street_edge.street_edge_id = audit_task.street_edge_id
+          INNER JOIN "#$schema".user_stat ON audit_task.user_id = user_stat.user_id
+          WHERE completed = TRUE AND NOT user_stat.excluded AND street_edge.deleted = FALSE
+      ) AS audited;
+    """.as[(Double, Double)].head
   }
 
   def getTutorialStreetId: DBIO[Int] = {

--- a/app/service/ConfigService.scala
+++ b/app/service/ConfigService.scala
@@ -16,6 +16,7 @@ import play.api.{Configuration, Logger}
 import slick.dbio.DBIO
 
 import java.time.{LocalDate, OffsetDateTime}
+import java.time.temporal.ChronoUnit
 import javax.inject._
 import scala.concurrent.duration.Duration
 import scala.concurrent.{ExecutionContext, Future}
@@ -86,8 +87,226 @@ case class AggregateStats(
     byLabelType: Map[String, LabelTypeStats]
 )
 
+/**
+ * One week's contribution volume for a city, for the Across Cities activity trends (#4329).
+ *
+ * @param weekStart    Monday (Pacific) of the week.
+ * @param labels       Non-tutorial, non-excluded labels created that week.
+ * @param validations  Validations by non-excluded users that week.
+ * @param activeUsers  Distinct non-excluded users who labeled or validated that week. Summed across cities for the
+ *                     "active users over time" overview line, this slightly over-counts users active in multiple cities.
+ */
+case class WeeklyPoint(weekStart: LocalDate, labels: Int, validations: Int, activeUsers: Int)
+
+/**
+ * One city's summary row for the cross-city "Across Cities" admin overview (#4329).
+ *
+ * Unlike [[AggregateStats]], which sums every city into one total, this keeps each deployment separate so they can be
+ * compared side by side across four lenses: coverage (how much is left), activity (what's happening and when), data
+ * patterns (the label-type mix), and data quality (how trustworthy the data is). Display name / URL / visibility are
+ * intentionally NOT here — they come from `getAllCityInfo(lang)` and are merged at the controller layer, so this
+ * (cached) value stays language-agnostic.
+ *
+ * Counts use the same exclusions as the rest of the stats code (`NOT user_stat.excluded`, non-deleted, non-tutorial).
+ *
+ * @param cityId                  The city id (e.g. "seattle-wa").
+ * @param totalStreets            Non-deleted streets in the city.
+ * @param auditedStreets          Distinct streets with a completed audit by a non-excluded user.
+ * @param coverage                auditedStreets / totalStreets in [0, 1]; 0.0 when the city has no streets.
+ * @param totalKm                 Total length of the non-deleted street network, in km.
+ * @param auditedKm               Distinct audited length (no double-counting overlapping audits), in km.
+ * @param totalLabels             Non-tutorial, non-excluded labels (reconciles with the city's single-city total).
+ * @param aiLabels                Subset of totalLabels authored by the AI role.
+ * @param labelsWithSeverity      Subset of totalLabels that have a severity rating (a data-completeness signal).
+ * @param labelsSeverityEligible  Labels whose type CAN take a severity (excludes NoSidewalk/Signal/Occlusion) — the
+ *                                correct denominator for "% with severity".
+ * @param labelsWithTags          Subset of totalLabels that have at least one tag applied.
+ * @param labelsTagEligible       Labels whose type CAN take tags (types present in this deployment's tag table) — the
+ *                                correct denominator for "% with tags".
+ * @param labelsValidated         Labels that have at least one validation.
+ * @param totalValidations        All validations by non-excluded users (the volume, including AI).
+ * @param validationsAgree        HUMAN (non-AI) validations with an "Agree" result.
+ * @param validationsDisagree     HUMAN (non-AI) validations with a "Disagree" result. (Agreement/disagreement is a
+ *                                human-consensus signal; AI verdicts are reported separately via `aiValidations`.)
+ * @param aiValidations           Subset of totalValidations cast by the AI role (distinct from AI-authored labels).
+ * @param byLabelType             Per-label-type counts (labels, validated, agree, disagree) — the data-pattern lens.
+ * @param activeContributors      Distinct non-excluded, non-AI users who placed a label or a validation.
+ * @param lowQualityContributors  Distinct EXCLUDED (low-quality) users who placed a label — the quality lens.
+ * @param labels7d                Labels created in the last 7 days.
+ * @param labels30d               Labels created in the last 30 days.
+ * @param validations7d           Validations in the last 7 days.
+ * @param validations30d          Validations in the last 30 days.
+ * @param audits7d                Streets completed in the last 7 days.
+ * @param audits30d               Streets completed in the last 30 days.
+ * @param lastActivity            Most recent label/validation/audit timestamp; None if the city has no activity.
+ * @param weeklyTrend             Trailing weekly label/validation volume (oldest first) for the activity sparkline.
+ * @param labelsPerUserMedian     Median labels per labeler (robust to the power-law skew; mean would mislead).
+ * @param labelsPerUserP90        90th-percentile labels per labeler (the engaged tail).
+ * @param numLabelers             Distinct non-AI, non-excluded users who placed a label.
+ * @param validationsPerUserMedian Median validations per validator.
+ * @param validationsPerUserP90   90th-percentile validations per validator.
+ * @param numValidators           Distinct non-AI, non-excluded users who validated.
+ * @param validationSecondsMedian Median seconds per validation (clamped to <= 5 min); 0 if unknown. ×10 = "time to
+ *                                validate 10".
+ */
+case class CityScorecard(
+    cityId: String,
+    totalStreets: Int,
+    auditedStreets: Int,
+    coverage: Double,
+    totalKm: Double,
+    auditedKm: Double,
+    totalLabels: Int,
+    aiLabels: Int,
+    labelsWithSeverity: Int,
+    labelsSeverityEligible: Int,
+    labelsWithTags: Int,
+    labelsTagEligible: Int,
+    labelsValidated: Int,
+    totalValidations: Int,
+    validationsAgree: Int,
+    validationsDisagree: Int,
+    aiValidations: Int,
+    byLabelType: Map[String, LabelTypeStats],
+    activeContributors: Int,
+    lowQualityContributors: Int,
+    labels7d: Int,
+    labels30d: Int,
+    validations7d: Int,
+    validations30d: Int,
+    audits7d: Int,
+    audits30d: Int,
+    lastActivity: Option[OffsetDateTime],
+    weeklyTrend: Seq[WeeklyPoint],
+    labelsPerUserMedian: Double,
+    labelsPerUserP90: Double,
+    numLabelers: Int,
+    validationsPerUserMedian: Double,
+    validationsPerUserP90: Double,
+    numValidators: Int,
+    validationSecondsMedian: Double
+)
+
+/**
+ * A [[CityScorecard]] paired with the anomaly flags computed for it across the full cross-city set (#4329).
+ *
+ * @param scorecard The per-city metrics.
+ * @param anomalies Zero or more flag keys: "stalled", "low_coverage", "high_disagreement". The page turns these into a
+ *                  "needs attention" panel.
+ */
+case class CityScorecardWithFlags(scorecard: CityScorecard, anomalies: Seq[String])
+
+/**
+ * Lifecycle thresholds, the data-quality anomaly thresholds, and the (pure) classification helpers for the cross-city
+ * overview (#4329).
+ *
+ * Centralized here so the thresholds are defined once and both the service and the controller (which echoes them back in
+ * its summary block) read the same values.
+ */
+object ConfigService {
+
+  /** A city with activity within this many days is "active". */
+  val ActiveWithinDays: Long = 30
+
+  /**
+   * Coverage at or above this means a quiet city is treated as having reached its milestone ("wrapped up") rather than
+   * having failed — the Oradell case (#4329). Success is judged by street coverage.
+   */
+  val WrappedUpCoverage: Double = 0.80
+
+  /**
+   * A quiet, under-covered city with fewer than this many distinct contributors "never took off" (low traction) — the
+   * LA case — versus "stalled" (it had a real community and lost momentum before finishing).
+   */
+  val LowTractionContributors: Int = 15
+
+  /** A city with fewer than this many validations is never flagged "high_disagreement" (too small a sample). */
+  val MinValidationsForDisagreement: Int = 100
+
+  /** A disagreement rate above the cross-city median times this multiple flags "high_disagreement". */
+  val DisagreementMedianMultiple: Double = 1.5
+
+  /**
+   * Classifies a city's lifecycle/health into one of four states (#4329), so a quiet-but-finished deployment reads
+   * very differently from one that never took off:
+   *   - "active"       — activity within [[ActiveWithinDays]].
+   *   - "wrapped_up"   — quiet, but coverage >= [[WrappedUpCoverage]] (reached its milestone; celebrate, don't alarm).
+   *   - "low_traction" — quiet, under-covered, and fewer than [[LowTractionContributors]] contributors (never took off).
+   *   - "stalled"      — quiet, under-covered, but had a real community (had momentum, lost it before finishing).
+   *
+   * @param sc  The city scorecard.
+   * @param now Reference time for the recency comparison.
+   * @return    The lifecycle state key.
+   */
+  def lifecycle(sc: CityScorecard, now: OffsetDateTime): String = {
+    val active = sc.lastActivity.exists(ts => ChronoUnit.DAYS.between(ts, now) <= ActiveWithinDays)
+    if (active) "active"
+    else if (sc.coverage >= WrappedUpCoverage) "wrapped_up"
+    else if (sc.activeContributors < LowTractionContributors) "low_traction"
+    else "stalled"
+  }
+
+  /** True if a city's lifecycle is one that warrants attention (stalled or never-took-off). */
+  def lifecycleNeedsAttention(state: String): Boolean = state == "stalled" || state == "low_traction"
+
+  /** Share of a city's HUMAN agree/disagree validations that are disagreements; 0.0 when it has none (AI excluded). */
+  def disagreementRate(sc: CityScorecard): Double = {
+    val denom = sc.validationsAgree + sc.validationsDisagree
+    if (denom > 0) sc.validationsDisagree.toDouble / denom else 0.0
+  }
+
+  /**
+   * Median disagreement rate across cities with enough validations to be meaningful — the baseline the
+   * "high_disagreement" flag compares against.
+   *
+   * @param scorecards All gathered per-city scorecards.
+   * @return           The median rate among cities clearing [[MinValidationsForDisagreement]]; 0.0 if none do.
+   */
+  def medianDisagreementRate(scorecards: Seq[CityScorecard]): Double = {
+    val rates = scorecards.filter(_.totalValidations >= MinValidationsForDisagreement).map(disagreementRate).sorted
+    if (rates.isEmpty) 0.0
+    else if (rates.length % 2 == 1) rates(rates.length / 2)
+    else (rates(rates.length / 2 - 1) + rates(rates.length / 2)) / 2.0
+  }
+}
+
 @ImplementedBy(classOf[ConfigServiceImpl])
 trait ConfigService {
+
+  /**
+   * Computes a per-city summary scorecard for every configured city whose schema exists (#4329).
+   *
+   * Reuses the same cross-schema fan-out as [[getAggregateStats]] — read the configured city ids, keep the ones whose
+   * schema actually exists, query each in parallel with per-city recovery, cache the merged result — but keeps cities
+   * separate rather than summing them. Anomaly flags ("stalled", "low_coverage", "high_disagreement") are computed
+   * across the whole set (the disagreement flag is relative to the cross-city median), so they are returned together.
+   *
+   * @return A Future of one [[CityScorecardWithFlags]] per available city (legacy DC and "staging" excluded).
+   */
+  def getCityScorecards(): Future[Seq[CityScorecardWithFlags]]
+
+  /**
+   * Returns the weekly label/validation/active-user volume summed across all available cities (#4329), for the
+   * "over time" overview charts. Active users are summed per city, so a person active in multiple cities is counted in
+   * each (documented on the page).
+   *
+   * @param weeks Trailing weeks to include, or None for full history (the page's "All time" toggle).
+   * @return      Merged weekly series, ascending by week.
+   */
+  def getCrossCityWeeklyTrend(weeks: Option[Int]): Future[Seq[WeeklyPoint]]
+
+  /**
+   * Returns each city's labeling speed as seconds of active auditing per 100 m covered (#4329).
+   *
+   * This is the project's one EXPENSIVE cross-city metric (a window-function scan of each schema's
+   * `audit_task_interaction_small`), so it is computed on its own long (daily) cache rather than on every scorecard
+   * load — the "nightly precompute" half of the hybrid delivery. Cities with no interaction data are omitted from the
+   * map (the page shows them as unknown).
+   *
+   * @return A Future of cityId → seconds per 100 m (lower is faster).
+   */
+  def getCrossCityLabelingSpeed(): Future[Map[String, Double]]
+
 
   /**
    * Maps a city ID to its corresponding database user/schema.
@@ -322,6 +541,132 @@ class ConfigServiceImpl @Inject() (
             Future.successful(None)
         }
       }
+    }
+  }
+
+  def getCityScorecards(): Future[Seq[CityScorecardWithFlags]] = {
+    // Heavier than getAggregateStats (a multi-subquery per city) and only viewed by Owners, so cache a bit longer.
+    cacheApi.getOrElseUpdate[Seq[CityScorecardWithFlags]]("getCityScorecards", Duration(10, "minutes")) {
+      // Same available-schema guard as getAggregateStats. "staging" is skipped (not a real deployment), as in
+      // CitiesApiController; legacy DC is skipped because it predates the modern label_validation schema.
+      val configuredCityIds = config.get[Seq[String]]("city-params.city-ids").filter(_ != "staging")
+
+      val schemaExistenceChecks: Seq[Future[(String, Boolean)]] = configuredCityIds.map { cityId =>
+        try {
+          val schema = getCitySchema(cityId)
+          checkSchemaExists(schema).map(cityId -> _).recover { case _ => cityId -> false }
+        } catch {
+          case _: Exception => Future.successful(cityId -> false)
+        }
+      }
+
+      Future.sequence(schemaExistenceChecks).flatMap { schemaResults =>
+        val availableCities = schemaResults.filter(_._2).map(_._1)
+
+        // Query each available city in parallel; one failing schema yields None rather than sinking the whole page.
+        val scorecardFutures: Seq[Future[Option[CityScorecard]]] = availableCities.map { cityId =>
+          val schema = getCitySchema(cityId)
+          db.run(configTable.getCityScorecardBySchema(schema))
+            .map(sc => Some(sc.copy(cityId = cityId))) // The DAO only knows the schema; restore the real cityId here.
+            .recover { case e: Exception =>
+              logger.warn(s"Failed to compute scorecard for city $cityId (schema $schema): ${e.getMessage}")
+              None
+            }
+        }
+
+        Future.sequence(scorecardFutures).map(opts => flagAnomalies(opts.flatten))
+      }
+    }
+  }
+
+  def getCrossCityWeeklyTrend(weeks: Option[Int]): Future[Seq[WeeklyPoint]] = {
+    val cacheKey = s"getCrossCityWeeklyTrend_${weeks.map(_.toString).getOrElse("all")}"
+    cacheApi.getOrElseUpdate[Seq[WeeklyPoint]](cacheKey, Duration(10, "minutes")) {
+      val configuredCityIds = config.get[Seq[String]]("city-params.city-ids").filter(_ != "staging")
+
+      val schemaExistenceChecks: Seq[Future[(String, Boolean)]] = configuredCityIds.map { cityId =>
+        try {
+          checkSchemaExists(getCitySchema(cityId)).map(cityId -> _).recover { case _ => cityId -> false }
+        } catch {
+          case _: Exception => Future.successful(cityId -> false)
+        }
+      }
+
+      Future.sequence(schemaExistenceChecks).flatMap { schemaResults =>
+        val availableCities = schemaResults.filter(_._2).map(_._1)
+        val perCityFutures = availableCities.map { cityId =>
+          db.run(configTable.getCityWeeklyTrendBySchema(getCitySchema(cityId), weeks))
+            .recover { case e: Exception =>
+              logger.warn(s"Failed to fetch weekly trend for city $cityId: ${e.getMessage}")
+              Seq.empty[WeeklyPoint]
+            }
+        }
+        Future.sequence(perCityFutures).map { perCity =>
+          // Sum each city's weekly points into one cross-city series, week by week.
+          perCity.flatten
+            .groupBy(_.weekStart)
+            .toSeq
+            .sortBy(_._1)
+            .map { case (week, pts) =>
+              WeeklyPoint(week, pts.map(_.labels).sum, pts.map(_.validations).sum, pts.map(_.activeUsers).sum)
+            }
+        }
+      }
+    }
+  }
+
+  def getCrossCityLabelingSpeed(): Future[Map[String, Double]] = {
+    // Daily cache: this is the heavy interaction-table scan, and labeling speed barely moves day to day.
+    cacheApi.getOrElseUpdate[Map[String, Double]]("getCrossCityLabelingSpeed", Duration(24, "hours")) {
+      val configuredCityIds = config.get[Seq[String]]("city-params.city-ids").filter(_ != "staging")
+
+      val schemaExistenceChecks: Seq[Future[(String, Boolean)]] = configuredCityIds.map { cityId =>
+        try {
+          checkSchemaExists(getCitySchema(cityId)).map(cityId -> _).recover { case _ => cityId -> false }
+        } catch {
+          case _: Exception => Future.successful(cityId -> false)
+        }
+      }
+
+      Future.sequence(schemaExistenceChecks).flatMap { schemaResults =>
+        val availableCities = schemaResults.filter(_._2).map(_._1)
+        val perCityFutures: Seq[Future[Option[(String, Double)]]] = availableCities.map { cityId =>
+          db.run(configTable.getCityLabelingSpeedBySchema(getCitySchema(cityId)))
+            .map { case (hours, km) =>
+              // Only report cities with both interaction data and audited distance; otherwise speed is unknowable.
+              if (hours > 0 && km > 0) Some(cityId -> (hours * 3600.0) / (km * 10.0)) else None
+            }
+            .recover { case e: Exception =>
+              logger.warn(s"Failed to compute labeling speed for city $cityId: ${e.getMessage}")
+              None
+            }
+        }
+        Future.sequence(perCityFutures).map(_.flatten.toMap)
+      }
+    }
+  }
+
+  /**
+   * Attaches data-quality anomaly flags to each scorecard, using the full set for the relative (median-based) check
+   * (#4329). The activity/coverage story is carried separately by the lifecycle classification
+   * ([[ConfigService.lifecycle]]), not here, so this only surfaces "high_disagreement".
+   *
+   * @param scorecards All gathered per-city scorecards.
+   * @return           Each scorecard paired with its data-quality flags.
+   */
+  private def flagAnomalies(scorecards: Seq[CityScorecard]): Seq[CityScorecardWithFlags] = {
+    val medianDisagreement = ConfigService.medianDisagreementRate(scorecards)
+
+    scorecards.map { sc =>
+      val flags = scala.collection.mutable.ListBuffer.empty[String]
+
+      // Outlier disagreement, but only among cities with a meaningful validation volume.
+      if (sc.totalValidations >= ConfigService.MinValidationsForDisagreement &&
+        ConfigService.disagreementRate(sc) > medianDisagreement * ConfigService.DisagreementMedianMultiple) {
+        flags += "high_disagreement"
+      }
+
+      CityScorecardWithFlags(sc, flags.toSeq)
     }
   }
 

--- a/app/views/admin/dashboard/_sidebar.scala.html
+++ b/app/views/admin/dashboard/_sidebar.scala.html
@@ -1,9 +1,12 @@
-@(activePage: String)
+@(activePage: String, isOwner: Boolean = false)
 
 @*
  * Left navigation for the redesigned admin dashboard. Mirrors the API-docs sidebar markup/classes so the two
  * share a look. Pages that are not built yet are rendered as disabled "soon" items rather than dead links, so the
  * intended information architecture is visible as the dashboard grows page-by-page (#4272).
+ *
+ * The "Across Cities" cross-deployment overview (#4329) is Owner-only, so its link is shown only when `isOwner` is
+ * true — a per-city Administrator would only get a 403, so we don't surface a link they can't use.
  *@
 
 <div class="api-sidebar">
@@ -12,6 +15,11 @@
         <a href="@routes.AdminDashboardController.overview"
            class="api-nav-item @if(activePage == "overview"){active}"
            @if(activePage == "overview"){aria-current="page"}>Overview</a>
+        @if(isOwner) {
+            <a href="@routes.AdminDashboardController.acrossCities"
+               class="api-nav-item @if(activePage == "across-cities"){active}"
+               @if(activePage == "across-cities"){aria-current="page"}>Across Cities</a>
+        }
 
         <div class="api-nav-header">Manage</div>
         <a href="@routes.AdminDashboardController.management"

--- a/app/views/admin/dashboard/acrossCities.scala.html
+++ b/app/views/admin/dashboard/acrossCities.scala.html
@@ -1,0 +1,235 @@
+@import service.CommonPageData
+@import models.user.SidewalkUserWithRole
+@import play.api.Configuration
+@(commonData: CommonPageData, user: SidewalkUserWithRole
+)(implicit request: RequestHeader, messages: Messages, assets: AssetsFinder, config: Configuration)
+
+@*
+ * Across Cities page for the redesigned admin dashboard (#4329). A cross-deployment overview comparing every Project
+ * Sidewalk city across four lenses — coverage (how much is left), activity (what's happening and when), data patterns
+ * (the label-type mix, city vs city), and data quality (how trustworthy the data is) — plus a "needs attention" panel
+ * of server-computed anomalies and overview line charts of labels / validations / active users over time. Owner-only.
+ * Driven entirely client-side from /adminapi/cityScorecards.
+ *@
+
+@content = {
+    <div class="api-section" id="ac-intro-section">
+        <h1 class="api-heading" id="across-cities">Across Cities <a href="#across-cities" class="permalink">#</a></h1>
+        <p>
+            Every Project Sidewalk deployment at a glance — how each city is doing on coverage, activity, data patterns,
+            and data quality, and which ones need a look right now. Numbers are summarized across all city databases and
+            cached for a few minutes, so they may lag live activity slightly.
+        </p>
+        <div class="ac-pulse" id="ac-pulse" role="status" aria-live="polite">Loading cities…</div>
+
+        <div class="ac-hero">
+            <div class="ac-hero-row">
+                <div class="ac-hero-stat"><span class="ac-hero-value" id="hero-cities">—</span><span class="ac-hero-label">Cities</span></div>
+                <div class="ac-hero-stat"><span class="ac-hero-value" id="hero-countries">—</span><span class="ac-hero-label">Countries</span></div>
+                <div class="ac-hero-stat"><span class="ac-hero-value" id="hero-languages">—</span><span class="ac-hero-label">Languages</span></div>
+                <div class="ac-hero-stat"><span class="ac-hero-value" id="hero-users">—</span><span class="ac-hero-label">Contributors</span></div>
+            </div>
+            <div class="ac-hero-row">
+                <div class="ac-hero-stat"><span class="ac-hero-value" id="hero-distance">—</span><span class="ac-hero-label">Distance explored</span></div>
+                <div class="ac-hero-stat"><span class="ac-hero-value" id="hero-labels">—</span><span class="ac-hero-label">Total labels</span></div>
+                <div class="ac-hero-stat"><span class="ac-hero-value" id="hero-validations">—</span><span class="ac-hero-label">Total validations</span></div>
+                <div class="ac-hero-stat"><span class="ac-hero-value" id="hero-datapoints">—</span><span class="ac-hero-label">Total datapoints</span></div>
+                <div class="ac-hero-stat"><span class="ac-hero-value" id="hero-agreement">—</span><span class="ac-hero-label">Validation agreement</span></div>
+            </div>
+        </div>
+    </div>
+
+    <div class="api-section" id="ac-map-section">
+        <h2 class="api-heading" id="deployment-map">Deployment cities <a href="#deployment-map" class="permalink">#</a></h2>
+        <p>Every deployment on the map — circle area is proportional to label count, color shows lifecycle status.
+            Click a city for its stats.</p>
+        <div id="ac-cities-map" class="ac-map"></div>
+        <div class="ac-map-legend" aria-label="Map legend">
+            <span class="ac-legend-item"><span class="ac-legend-dot" style="background:#4a90d9"></span>Active</span>
+            <span class="ac-legend-item"><span class="ac-legend-dot" style="background:#1f7a4d"></span>Wrapped up</span>
+            <span class="ac-legend-item"><span class="ac-legend-dot" style="background:#e0a800"></span>Stalled</span>
+            <span class="ac-legend-item"><span class="ac-legend-dot" style="background:#c0392b"></span>Low traction</span>
+            <span class="ac-legend-item"><span class="ac-legend-dot ac-legend-dot--nostats"></span>No local stats</span>
+            <span class="ac-legend-sep" aria-hidden="true"></span>
+            <span class="ac-legend-item"><span class="ac-legend-dot ac-legend-dot--private"></span>Private deployment (ring)</span>
+            <span class="ac-legend-item"><span class="ac-legend-size" aria-hidden="true"></span>Circle area ∝ labels</span>
+        </div>
+        <div class="coverage-status" id="ac-map-status" role="status" aria-live="polite"></div>
+    </div>
+
+    <div class="api-section" id="ac-attention-section">
+        <h2 class="api-heading" id="needs-attention">Needs attention <a href="#needs-attention" class="permalink">#</a></h2>
+        <p>Deployments flagged by an automatic check. Each links out to that city's site.</p>
+        <div class="ov-attention" id="ac-attention"></div>
+    </div>
+
+    <div class="api-section" id="ac-trends-section">
+        <h2 class="api-heading" id="over-time">Over time <a href="#over-time" class="permalink">#</a></h2>
+        <p>Weekly totals across all cities.</p>
+        <div class="ac-toggle" id="ac-trend-toggle" role="group" aria-label="Trend range">
+            <button type="button" class="ac-toggle-btn active" data-range="recent">12 weeks</button>
+            <button type="button" class="ac-toggle-btn" data-range="all">All time</button>
+        </div>
+        <div class="ac-charts">
+            <div class="ac-chart">
+                <h3 class="ac-chart-title">Labels per week</h3>
+                <div class="mini-chart" id="ac-chart-labels"></div>
+            </div>
+            <div class="ac-chart">
+                <h3 class="ac-chart-title">Validations per week</h3>
+                <div class="mini-chart" id="ac-chart-validations"></div>
+            </div>
+            <div class="ac-chart">
+                <h3 class="ac-chart-title">Active users per week</h3>
+                <div class="mini-chart" id="ac-chart-users"></div>
+            </div>
+        </div>
+        <p class="ac-note">“Active users” counts distinct people who labeled or validated that week, summed across
+            cities (a person active in two cities is counted in each).</p>
+    </div>
+
+    <div class="api-section" id="ac-scorecard-section">
+        <h2 class="api-heading" id="scorecard">Scorecard <a href="#scorecard" class="permalink">#</a></h2>
+        <p>One row per city — the at-a-glance index. Click a column header to sort; click a city to open its site.</p>
+        <div class="ac-table-wrap">
+            <table class="ac-table" id="ac-table">
+                <thead>
+                    <tr>
+                        <th data-sort="city_name" class="ac-th-text">City</th>
+                        <th data-sort="lifecycle" class="ac-th-text">Status</th>
+                        <th data-sort="coverage" class="ac-th-text">Coverage</th>
+                        <th data-sort="total_labels">Labels</th>
+                        <th data-sort="total_validations">Validations</th>
+                        <th data-sort="active_contributors">Contributors</th>
+                        <th data-sort="ai_label_share">AI labels</th>
+                        <th data-sort="days_since_activity">Last activity</th>
+                    </tr>
+                </thead>
+                <tbody id="ac-tbody"></tbody>
+            </table>
+        </div>
+        <div class="coverage-status" id="ac-status" role="status" aria-live="polite"></div>
+    </div>
+
+    <div class="api-section" id="ac-coverage-section">
+        <h2 class="api-heading" id="coverage">Coverage — how much is left <a href="#coverage" class="permalink">#</a></h2>
+        <p>Audited vs. total street network, and what remains, per city.</p>
+        <div class="ac-table-wrap">
+            <table class="ac-table">
+                <thead>
+                    <tr>
+                        <th class="ac-th-text">City</th>
+                        <th class="ac-th-text">Progress</th>
+                        <th>Streets audited</th>
+                        <th>Streets left</th>
+                        <th>km audited</th>
+                        <th>km left</th>
+                    </tr>
+                </thead>
+                <tbody id="ac-coverage-tbody"></tbody>
+            </table>
+        </div>
+    </div>
+
+    <div class="api-section" id="ac-activity-section">
+        <h2 class="api-heading" id="activity">Activity — what &amp; when <a href="#activity" class="permalink">#</a></h2>
+        <p>Recent volume (last 7 and 30 days), most recent activity, and a 12-week trend per city.</p>
+        <div class="ac-table-wrap">
+            <table class="ac-table">
+                <thead>
+                    <tr>
+                        <th class="ac-th-text">City</th>
+                        <th>Labels 7d / 30d</th>
+                        <th>Validations 7d / 30d</th>
+                        <th>Streets 7d / 30d</th>
+                        <th>Last activity</th>
+                        <th>Trend (labels)</th>
+                    </tr>
+                </thead>
+                <tbody id="ac-activity-tbody"></tbody>
+            </table>
+        </div>
+    </div>
+
+    <div class="api-section" id="ac-effort-section">
+        <h2 class="api-heading" id="effort">Contributors &amp; effort <a href="#effort" class="permalink">#</a></h2>
+        <p>How much each contributor produces and how fast they work. Per-user output is shown as <strong>median</strong>
+            and <strong>p90</strong> (90th percentile), because a handful of power users make the average misleading.</p>
+        <div class="ac-table-wrap">
+            <table class="ac-table">
+                <thead>
+                    <tr>
+                        <th class="ac-th-text">City</th>
+                        <th>Labelers</th>
+                        <th>Labels / labeler<br><span class="ac-th-sub">median · p90</span></th>
+                        <th>Validators</th>
+                        <th>Validations / validator<br><span class="ac-th-sub">median · p90</span></th>
+                        <th>Time to validate 10</th>
+                        <th title="Active auditing time per 100 m (idle gaps over 5 min excluded), refreshed about once a day.">Time to label 100 m <span class="ac-fn">†</span></th>
+                    </tr>
+                </thead>
+                <tbody id="ac-effort-tbody"></tbody>
+            </table>
+        </div>
+        <p class="ac-note"><span class="ac-fn">†</span> <strong>Time to label 100&nbsp;m</strong> is active auditing
+            time (idle gaps over 5&nbsp;minutes excluded) per 100&nbsp;m of street covered, and <strong>time to validate
+            10</strong> is the median per-validation time ×10. The labeling-speed figure is recomputed about once a day
+            and is blank where a deployment's interaction data isn't available.</p>
+    </div>
+
+    <div class="api-section" id="ac-patterns-section">
+        <h2 class="api-heading" id="patterns">Data patterns — city vs city <a href="#patterns" class="permalink">#</a></h2>
+        <p>The mix of accessibility problems each city has found, as a share of its labels. Comparable across cities.</p>
+        <div id="ac-patterns-legend" class="ac-legend"></div>
+        <div id="ac-patterns"></div>
+    </div>
+
+    <div class="api-section" id="ac-quality-section">
+        <h2 class="api-heading" id="quality">Data quality — how good <a href="#quality" class="permalink">#</a></h2>
+        <p>How much of each city's data has been validated, how often validators agree, and how much was AI-generated or
+            came from users later flagged low-quality.</p>
+        <div class="ac-table-wrap">
+            <table class="ac-table">
+                <thead>
+                    <tr>
+                        <th class="ac-th-text">City</th>
+                        <th>% validated</th>
+                        <th>Validations / label</th>
+                        <th title="Share of HUMAN agree/disagree validations that agreed. AI verdicts are excluded here and shown in the AI validations column.">Agreement <span class="ac-fn">†</span></th>
+                        <th title="Calculated only over label types that can have a severity (excludes No Sidewalk, Signal, Occlusion).">% w/ severity <span class="ac-fn">†</span></th>
+                        <th title="Calculated only over label types that have tags defined for this deployment (e.g. excludes Occlusion).">% w/ tags <span class="ac-fn">†</span></th>
+                        <th>AI labels</th>
+                        <th>AI validations</th>
+                        <th>Low-quality share</th>
+                    </tr>
+                </thead>
+                <tbody id="ac-quality-tbody"></tbody>
+            </table>
+        </div>
+        <p class="ac-note"><span class="ac-fn">†</span> <strong>% w/ severity</strong> and <strong>% w/ tags</strong> are
+            calculated only over the labels whose type <em>can</em> have them, not all labels. Severity excludes
+            No&nbsp;Sidewalk, Signal, and Occlusion; tags exclude types with no tags defined for the deployment
+            (e.g. Occlusion). So a city can reach 100% even though some label types never carry a severity or tag.
+            <strong>Agreement</strong> (and the High-disagreement flag) counts only <strong>human</strong> validators —
+            AI verdicts are excluded and shown separately in <strong>AI validations</strong>.</p>
+    </div>
+
+    <link rel="stylesheet" href="@assets.path("javascripts/lib/mapbox-gl-3.21.0.css")">
+    <script src="@assets.path("javascripts/lib/mapbox-gl-3.21.0.js")"></script>
+    <script src="@assets.path("javascripts/admin-dashboard/mini-line-chart.js")"></script>
+    <script src="@assets.path("javascripts/admin-dashboard/across-cities-page.js")"></script>
+    <script>
+        window.addEventListener('DOMContentLoaded', function () {
+            new AcrossCitiesPage({
+                scorecardsUrl: '/adminapi/cityScorecards',
+                citiesUrl: '/v3/api/cities',
+                mapboxToken: '@commonData.mapboxApiKey'
+            }).init();
+        });
+    </script>
+}
+
+@common.main(commonData, "Sidewalk - Across Cities") {
+    @common.navbar(commonData, Some(user))
+    @admin.dashboard.adminLayout("across-cities", user.role == "Owner")(content)
+}

--- a/app/views/admin/dashboard/activity.scala.html
+++ b/app/views/admin/dashboard/activity.scala.html
@@ -139,5 +139,5 @@
 
 @common.main(commonData, "Sidewalk - Admin Activity") {
     @common.navbar(commonData, Some(user))
-    @admin.dashboard.adminLayout("activity")(content)
+    @admin.dashboard.adminLayout("activity", user.role == "Owner")(content)
 }

--- a/app/views/admin/dashboard/adminLayout.scala.html
+++ b/app/views/admin/dashboard/adminLayout.scala.html
@@ -1,4 +1,4 @@
-@(activePage: String)(content: Html)(implicit request: RequestHeader, assets: AssetsFinder)
+@(activePage: String, isOwner: Boolean = false)(content: Html)(implicit request: RequestHeader, assets: AssetsFinder)
 
 @*
  * Shared shell for the redesigned admin dashboard (#4272): left nav + main content + right "On this page" TOC.
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="@assets.path("stylesheets/admin-dashboard/admin-dashboard.css")">
 
 <div class="api-container">
-    @admin.dashboard._sidebar(activePage)
+    @admin.dashboard._sidebar(activePage, isOwner)
 
     <main class="api-content">
         @content

--- a/app/views/admin/dashboard/apiAnalytics.scala.html
+++ b/app/views/admin/dashboard/apiAnalytics.scala.html
@@ -83,5 +83,5 @@
 
 @common.main(commonData, "Sidewalk - Admin API Analytics") {
     @common.navbar(commonData, Some(user))
-    @admin.dashboard.adminLayout("api-analytics")(content)
+    @admin.dashboard.adminLayout("api-analytics", user.role == "Owner")(content)
 }

--- a/app/views/admin/dashboard/contributors.scala.html
+++ b/app/views/admin/dashboard/contributors.scala.html
@@ -82,5 +82,5 @@
 
 @common.main(commonData, "Sidewalk - Admin Contributors") {
     @common.navbar(commonData, Some(user))
-    @admin.dashboard.adminLayout("contributors")(content)
+    @admin.dashboard.adminLayout("contributors", user.role == "Owner")(content)
 }

--- a/app/views/admin/dashboard/coverage.scala.html
+++ b/app/views/admin/dashboard/coverage.scala.html
@@ -91,5 +91,5 @@
 
 @common.main(commonData, "Sidewalk - Admin Coverage") {
     @common.navbar(commonData, Some(user))
-    @admin.dashboard.adminLayout("coverage")(content)
+    @admin.dashboard.adminLayout("coverage", user.role == "Owner")(content)
 }

--- a/app/views/admin/dashboard/humansVsAi.scala.html
+++ b/app/views/admin/dashboard/humansVsAi.scala.html
@@ -99,5 +99,5 @@
 
 @common.main(commonData, "Sidewalk - Humans vs AI") {
     @common.navbar(commonData, Some(user))
-    @admin.dashboard.adminLayout("humans-vs-ai")(content)
+    @admin.dashboard.adminLayout("humans-vs-ai", user.role == "Owner")(content)
 }

--- a/app/views/admin/dashboard/labelMap.scala.html
+++ b/app/views/admin/dashboard/labelMap.scala.html
@@ -94,5 +94,5 @@
 
 @common.main(commonData, "Sidewalk - Admin Label Map", i18Namespaces = Seq("common", "labelmap")) {
     @common.navbar(commonData, Some(user))
-    @admin.dashboard.adminLayout("label-map")(content)
+    @admin.dashboard.adminLayout("label-map", user.role == "Owner")(content)
 }

--- a/app/views/admin/dashboard/management.scala.html
+++ b/app/views/admin/dashboard/management.scala.html
@@ -106,5 +106,5 @@
 
 @common.main(commonData, "Sidewalk - Admin Management") {
     @common.navbar(commonData, Some(user))
-    @admin.dashboard.adminLayout("management")(content)
+    @admin.dashboard.adminLayout("management", user.role == "Owner")(content)
 }

--- a/app/views/admin/dashboard/overview.scala.html
+++ b/app/views/admin/dashboard/overview.scala.html
@@ -108,5 +108,5 @@
 
 @common.main(commonData, "Sidewalk - Admin Overview") {
     @common.navbar(commonData, Some(user))
-    @admin.dashboard.adminLayout("overview")(content)
+    @admin.dashboard.adminLayout("overview", user.role == "Owner")(content)
 }

--- a/app/views/admin/dashboard/quality.scala.html
+++ b/app/views/admin/dashboard/quality.scala.html
@@ -111,5 +111,5 @@
 
 @common.main(commonData, "Sidewalk - Admin Data Quality") {
     @common.navbar(commonData, Some(user))
-    @admin.dashboard.adminLayout("quality")(content)
+    @admin.dashboard.adminLayout("quality", user.role == "Owner")(content)
 }

--- a/conf/routes
+++ b/conf/routes
@@ -62,6 +62,7 @@ GET     /admin/activity                                 controllers.AdminDashboa
 GET     /admin/humans-vs-ai                             controllers.AdminDashboardController.humansVsAi
 GET     /admin/api-analytics                            controllers.AdminDashboardController.apiAnalytics
 GET     /admin/management                               controllers.AdminDashboardController.management
+GET     /admin/across-cities                            controllers.AdminDashboardController.acrossCities
 GET     /admin/user/:username                           controllers.AdminController.userProfile(username: String)
 GET     /admin/task/:taskId                             controllers.AdminController.task(taskId: Int)
 GET     /admin/label/:labelId                           controllers.AdminController.label(labelId: Int)
@@ -97,6 +98,7 @@ GET     /adminapi/apiAnalyticsBySource                  controllers.AdminControl
 GET     /adminapi/activityByDay                          controllers.AdminController.getActivityByDay
 GET     /adminapi/humanVsAi                              controllers.AdminController.getHumanVsAiStats
 GET     /adminapi/overviewSummary                       controllers.AdminController.getOverviewSummary
+GET     /adminapi/cityScorecards                        controllers.AdminController.getCityScorecards
 
 PUT     /adminapi/setRole                               controllers.AdminController.setUserRole
 PUT     /adminapi/setUserQualityManual                  controllers.AdminController.setUserQualityManual

--- a/public/javascripts/admin-dashboard/across-cities-page.js
+++ b/public/javascripts/admin-dashboard/across-cities-page.js
@@ -1,0 +1,682 @@
+/**
+ * Renders the admin "Across Cities" page (#4329): a cross-deployment overview of every Project Sidewalk city across
+ * four lenses — coverage (how much is left), activity (what's happening and when), data patterns (the label-type mix,
+ * city vs city), and data quality (how trustworthy the data is). Adds a "needs attention" panel from server-computed
+ * anomaly flags and three overview line charts (labels / validations / active users per week, summed across cities).
+ *
+ * Plain HTML/CSS plus the shared MiniLineChart for the over-time charts and small inline-SVG sparklines for the
+ * per-city activity trend. Owner-only; driven entirely from /adminapi/cityScorecards.
+ */
+class AcrossCitiesPage {
+
+    /** Human-friendly label + severity for each data-quality anomaly flag key the endpoint can emit. */
+    static #ANOMALY = {
+        high_disagreement: { label: 'High disagreement', sev: 'warn' }
+    };
+
+    /**
+     * Lifecycle/health states (#4329): label, badge tone, and whether the state warrants attention. `tone` maps to a
+     * `.ac-badge--<tone>` CSS class. Ordered active → wrapped_up → stalled → low_traction for the Status sort.
+     */
+    static #LIFECYCLE = {
+        active:       { label: 'Active',       tone: 'ok',    rank: 0, attention: false },
+        wrapped_up:   { label: 'Wrapped up',   tone: 'good',  rank: 1, attention: false },
+        stalled:      { label: 'Stalled',      tone: 'warn',  rank: 2, attention: true },
+        low_traction: { label: 'Low traction', tone: 'bad',   rank: 3, attention: true }
+    };
+
+    /** Canonical label-type order + short display names for the data-patterns bars. */
+    static #LABEL_TYPES = [
+        ['CurbRamp', 'Curb ramp'], ['NoCurbRamp', 'Missing curb ramp'], ['Obstacle', 'Obstacle'],
+        ['SurfaceProblem', 'Surface problem'], ['NoSidewalk', 'No sidewalk'], ['Crosswalk', 'Crosswalk'],
+        ['Signal', 'Signal'], ['Occlusion', 'Occlusion'], ['Other', 'Other']
+    ];
+
+    /** Lifecycle → map circle color (matches the badge tones). */
+    static #LIFECYCLE_COLOR = {
+        active: '#4a90d9', wrapped_up: '#1f7a4d', stalled: '#e0a800', low_traction: '#c0392b'
+    };
+
+    #scorecardsUrl;
+    #citiesUrl;
+    #mapboxToken;
+    #map = null;           // Mapbox map instance for the deployment-cities map.
+    #cities = [];          // The latest scorecard rows, as returned by the endpoint.
+    #summary = {};         // The summary block (thresholds + cross-city median + hero totals).
+    #allTimeTrend = [];    // Cross-city weekly series for the full project history (the "All time" toggle).
+    #trendSeries = {};     // { recent: [...], all: [...] } weekly aggregates for the over-time charts.
+    #trendRange = 'recent';// Which over-time range is shown: 'recent' (12 wks) | 'all'.
+    #sortKey = 'coverage'; // Current sort column.
+    #sortDir = 'desc';     // 'asc' | 'desc'.
+
+    /** @param {{scorecardsUrl: string, citiesUrl?: string, mapboxToken?: string}} opts */
+    constructor(opts = {}) {
+        this.#scorecardsUrl = opts.scorecardsUrl;
+        this.#citiesUrl = opts.citiesUrl;
+        this.#mapboxToken = opts.mapboxToken;
+    }
+
+    async init() {
+        try {
+            // Scorecards are required; the cities geo (for the map) is an enhancement, so it degrades gracefully.
+            const [data, citiesGeo] = await Promise.all([
+                this.#fetchJson(this.#scorecardsUrl),
+                this.#citiesUrl ? this.#fetchJson(this.#citiesUrl).catch(() => null) : Promise.resolve(null)
+            ]);
+            this.#cities = (data && data.cities) || [];
+            this.#summary = (data && data.summary) || {};
+            this.#allTimeTrend = (data && data.over_time_all_time) || [];
+            this.#renderHero();
+            this.#renderMap(citiesGeo);
+            this.#renderPulse();
+            this.#renderAttention();
+            this.#renderTrends();
+            this.#wireSorting();
+            this.#renderTable();
+            this.#renderCoverage();
+            this.#renderActivity();
+            this.#renderEffort();
+            this.#renderPatterns();
+            this.#renderQuality();
+        } catch (err) {
+            console.error('Across Cities page failed to load:', err);
+            this.#setText('ac-pulse', 'Could not load city data. Please try again.');
+            this.#setText('ac-status', 'Could not load city data. Please try again.');
+        }
+    }
+
+    async #fetchJson(url) {
+        const resp = await fetch(url, { headers: { Accept: 'application/json' } });
+        if (!resp.ok) throw new Error(`Request failed (${resp.status}): ${url}`);
+        return resp.json();
+    }
+
+    // --- Pulse ------------------------------------------------------------------------------------------------------
+
+    /** One-line summary: how many cities, broken down by lifecycle state. */
+    #renderPulse() {
+        const n = this.#cities.length;
+        const counts = {};
+        for (const c of this.#cities) counts[c.lifecycle] = (counts[c.lifecycle] || 0) + 1;
+        const order = ['active', 'wrapped_up', 'stalled', 'low_traction'];
+        const parts = order.filter(k => counts[k]).map(k =>
+            `<strong>${counts[k]}</strong> ${AcrossCitiesPage.#LIFECYCLE[k].label.toLowerCase()}`);
+        const breakdown = parts.length ? ` · ${parts.join(' · ')}` : '';
+        this.#setHtml('ac-pulse', `Comparing <strong>${n}</strong> ${n === 1 ? 'city' : 'cities'}${breakdown}.`);
+    }
+
+    // --- Hero stats -------------------------------------------------------------------------------------------------
+
+    /** Fills the project-wide "hero" stat band from the summary block. */
+    #renderHero() {
+        const s = this.#summary;
+        this.#setText('hero-cities', this.#num(s.num_cities));
+        this.#setText('hero-countries', this.#num(s.num_countries));
+        this.#setText('hero-languages', this.#num(s.num_languages));
+        this.#setText('hero-users', this.#compact(s.total_users));
+        this.#setText('hero-distance', `${this.#num(Math.round(s.total_km || 0))} km`);
+        this.#setText('hero-labels', this.#compact(s.total_labels));
+        this.#setText('hero-validations', this.#compact(s.total_validations));
+        this.#setText('hero-datapoints', this.#compact(s.total_datapoints));
+        this.#setText('hero-agreement', s.global_agreement ? this.#pct(s.global_agreement) : '—');
+    }
+
+    // --- Deployment cities map --------------------------------------------------------------------------------------
+
+    /**
+     * Renders the deployment-cities Mapbox map: one circle per city, area ∝ label count, colored by lifecycle, with a
+     * stats popup. Joins the cities geo (lat/lng from /v3/api/cities) to the scorecards by city_id. Degrades to a note
+     * if Mapbox, the token, or the geo are unavailable.
+     *
+     * @param {?object} citiesGeo - The /v3/api/cities response, or null.
+     */
+    #renderMap(citiesGeo) {
+        const host = document.getElementById('ac-cities-map');
+        if (!host) return;
+        if (typeof mapboxgl === 'undefined' || !this.#mapboxToken || !citiesGeo || !Array.isArray(citiesGeo.cities)) {
+            this.#setText('ac-map-status', 'Map unavailable.');
+            host.style.display = 'none';
+            return;
+        }
+
+        const byId = new Map(this.#cities.map(c => [c.city_id, c]));
+        const features = [];
+        let maxLabels = 1;
+        for (const geo of citiesGeo.cities) {
+            if (geo.center_lat == null || geo.center_lng == null) continue;
+            const sc = byId.get(geo.city_id);
+            const labelCount = sc ? (sc.total_labels || 0) : 0;
+            maxLabels = Math.max(maxLabels, labelCount);
+            features.push({
+                type: 'Feature',
+                geometry: { type: 'Point', coordinates: [geo.center_lng, geo.center_lat] },
+                properties: {
+                    name: geo.city_name_formatted || geo.city_name_short || geo.city_id,
+                    url: geo.url || (sc && sc.url) || '',
+                    lifecycle: sc ? sc.lifecycle : null,
+                    color: AcrossCitiesPage.#LIFECYCLE_COLOR[sc && sc.lifecycle] || '#9aa7b0',
+                    visibility: geo.visibility || (sc && sc.visibility) || 'public',
+                    labelCount,
+                    popup: this.#mapPopupHtml(geo, sc)
+                }
+            });
+        }
+        if (!features.length) {
+            this.#setText('ac-map-status', 'No city locations available.');
+            host.style.display = 'none';
+            return;
+        }
+        // sqrt scaling so circle AREA (not radius) tracks label count — perceptually honest.
+        for (const f of features) {
+            const n = f.properties.labelCount;
+            f.properties.radius = n > 0 ? 5 + (Math.sqrt(n) / Math.sqrt(maxLabels)) * 19 : 5;
+        }
+
+        mapboxgl.accessToken = this.#mapboxToken;
+        this.#map = new mapboxgl.Map({
+            container: 'ac-cities-map',
+            style: 'mapbox://styles/mapbox/light-v11',
+            center: [-30, 28],
+            zoom: 1.2,
+            minZoom: 1,
+            projection: 'mercator'
+        });
+        this.#map.addControl(new mapboxgl.NavigationControl({ showCompass: false }), 'top-right');
+        const popup = new mapboxgl.Popup({ closeButton: false, closeOnClick: false, className: 'coverage-popup' });
+
+        this.#map.on('load', () => {
+            this.#map.addSource('ac-cities', { type: 'geojson', data: { type: 'FeatureCollection', features } });
+            this.#map.addLayer({
+                id: 'ac-cities-circles',
+                type: 'circle',
+                source: 'ac-cities',
+                paint: {
+                    'circle-radius': ['get', 'radius'],
+                    'circle-color': ['get', 'color'],
+                    'circle-opacity': 0.75,
+                    // Private deployments get a thicker dark ring; public get a thin white stroke.
+                    'circle-stroke-width': ['case', ['==', ['get', 'visibility'], 'public'], 1, 3],
+                    'circle-stroke-color': ['case', ['==', ['get', 'visibility'], 'public'], '#ffffff', '#33373a']
+                }
+            });
+            const showPopup = e => {
+                const f = e.features[0];
+                this.#map.getCanvas().style.cursor = 'pointer';
+                popup.setLngLat(f.geometry.coordinates).setHTML(f.properties.popup).addTo(this.#map);
+            };
+            this.#map.on('mouseenter', 'ac-cities-circles', showPopup);
+            this.#map.on('mousemove', 'ac-cities-circles', showPopup);
+            this.#map.on('mouseleave', 'ac-cities-circles', () => {
+                this.#map.getCanvas().style.cursor = '';
+                popup.remove();
+            });
+            this.#map.on('click', 'ac-cities-circles', e => {
+                const url = e.features[0].properties.url;
+                if (url) window.open(url, '_blank', 'noopener');
+            });
+        });
+    }
+
+    /** Popup HTML for one city on the map. */
+    #mapPopupHtml(geo, sc) {
+        const name = AcrossCitiesPage.#esc(geo.city_name_formatted || geo.city_name_short || geo.city_id);
+        if (!sc) {
+            return `<div class="coverage-popup-name">${name}</div><div>No stats available.</div>`;
+        }
+        const lc = AcrossCitiesPage.#LIFECYCLE[sc.lifecycle];
+        const rows = [
+            ['Status', lc ? lc.label : '—'],
+            ['Coverage', this.#pct(sc.coverage)],
+            ['Labels', this.#num(sc.total_labels)],
+            ['Validations', this.#num(sc.total_validations)],
+            ['Contributors', this.#num(sc.active_contributors)],
+            ['Last activity', sc.last_activity ? AcrossCitiesPage.#relativeTime(sc.last_activity) : 'never']
+        ].map(([k, v]) => `<tr><td>${k}</td><td>${AcrossCitiesPage.#esc(v)}</td></tr>`).join('');
+        return `<div class="coverage-popup-name">${name}</div>` +
+            `<table class="coverage-popup-dl">${rows}</table>`;
+    }
+
+    // --- Needs attention --------------------------------------------------------------------------------------------
+
+    /**
+     * Builds the attention panel: cities whose lifecycle warrants attention (stalled / low traction) plus any
+     * data-quality anomaly (high disagreement). "Wrapped up" cities are deliberately NOT flagged — they succeeded.
+     * Shows an "all clear" note when nothing needs attention.
+     */
+    #renderAttention() {
+        const el = document.getElementById('ac-attention');
+        if (!el) return;
+
+        const items = [];
+        for (const c of this.#cities) {
+            const lc = AcrossCitiesPage.#LIFECYCLE[c.lifecycle];
+            if (lc && lc.attention) {
+                items.push({ sev: c.lifecycle === 'low_traction' ? 'bad' : 'warn', city: c,
+                    label: lc.label, reason: this.#lifecycleReason(c) });
+            }
+            for (const flag of (c.anomalies || [])) {
+                const meta = AcrossCitiesPage.#ANOMALY[flag] || { label: flag, sev: 'info' };
+                items.push({ sev: meta.sev, city: c, label: meta.label, reason: this.#anomalyReason(flag, c) });
+            }
+        }
+        const order = { bad: 0, warn: 1, info: 2 };
+        items.sort((a, b) => (order[a.sev] - order[b.sev]));
+
+        if (!items.length) {
+            el.innerHTML = '<p class="ov-attention-clear">All clear — no city needs attention right now. ✅</p>';
+            return;
+        }
+        el.innerHTML = items.map(it => {
+            const name = AcrossCitiesPage.#esc(it.city.city_name || it.city.city_id);
+            const href = it.city.url ? AcrossCitiesPage.#esc(it.city.url) : '#';
+            return `<a class="ov-attention-item ov-attention--${it.sev === 'bad' ? 'warn' : it.sev}" href="${href}"` +
+                (it.city.url ? ' target="_blank" rel="noopener"' : '') + '>' +
+                '<span class="ov-attention-dot" aria-hidden="true"></span>' +
+                `<span class="ov-attention-text"><strong>${name}</strong> — ${AcrossCitiesPage.#esc(it.reason)}</span>` +
+                `<span class="ov-attention-go">${AcrossCitiesPage.#esc(it.label)} →</span>` +
+                '</a>';
+        }).join('');
+    }
+
+    /** Explanation for a lifecycle state that needs attention, using the city's own numbers. */
+    #lifecycleReason(c) {
+        const quiet = c.days_since_activity == null ? 'no recorded activity'
+            : `quiet for ${c.days_since_activity} days`;
+        if (c.lifecycle === 'low_traction') {
+            return `never took off — ${quiet}, ${this.#pct(c.coverage)} coverage, ` +
+                `${this.#num(c.active_contributors)} contributors`;
+        }
+        // Stalled: had a community, lost momentum before finishing.
+        return `stalled at ${this.#pct(c.coverage)} coverage — ${quiet} ` +
+            `(${this.#num(c.active_contributors)} contributors)`;
+    }
+
+    /** Human-readable explanation for one data-quality anomaly flag on one city, using the city's own numbers. */
+    #anomalyReason(flag, c) {
+        switch (flag) {
+            case 'high_disagreement':
+                return `${this.#pct(c.validation_disagreement_rate)} of human validations disagree ` +
+                    `(median ${this.#pct(this.#summary.median_disagreement_rate)})`;
+            default:
+                return flag;
+        }
+    }
+
+    /** A colored lifecycle badge. */
+    #lifecycleBadge(state) {
+        const lc = AcrossCitiesPage.#LIFECYCLE[state] || { label: state, tone: 'ok' };
+        return `<span class="ac-badge ac-badge--${lc.tone}">${AcrossCitiesPage.#esc(lc.label)}</span>`;
+    }
+
+    // --- Over-time charts -------------------------------------------------------------------------------------------
+
+    /**
+     * Prepares the two over-time datasets (last 12 weeks, summed from each city's trend; and all-time, from the
+     * server-aggregated series), wires the range toggle, and draws the current range.
+     */
+    #renderTrends() {
+        this.#trendSeries = {
+            recent: this.#aggregateWeekly(this.#cities.flatMap(c => c.weekly_trend || [])),
+            all: this.#allTimeTrend.slice()
+        };
+
+        const toggle = document.getElementById('ac-trend-toggle');
+        if (toggle) {
+            toggle.querySelectorAll('.ac-toggle-btn').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    this.#trendRange = btn.dataset.range;
+                    toggle.querySelectorAll('.ac-toggle-btn').forEach(b => b.classList.toggle('active', b === btn));
+                    this.#drawTrends();
+                });
+            });
+        }
+        this.#drawTrends();
+    }
+
+    /** Sums a flat list of weekly points into one cross-city series, ascending by week. */
+    #aggregateWeekly(points) {
+        const m = new Map();
+        for (const w of points) {
+            const e = m.get(w.week_start) || { week_start: w.week_start, labels: 0, validations: 0, active_users: 0 };
+            e.labels += w.labels || 0;
+            e.validations += w.validations || 0;
+            e.active_users += w.active_users || 0;
+            m.set(w.week_start, e);
+        }
+        return [...m.values()].sort((a, b) => (a.week_start < b.week_start ? -1 : a.week_start > b.week_start ? 1 : 0));
+    }
+
+    /** Draws the three over-time line charts for the currently selected range. */
+    #drawTrends() {
+        const series = this.#trendSeries[this.#trendRange] || [];
+        const cats = series.map(w => AcrossCitiesPage.#shortDate(w.week_start));
+        // Small dots on the short (12-week) view where they aid hover tooltips; none on the dense all-time view, where
+        // hundreds of points would just be noise.
+        const dotRadius = series.length > 30 ? 0 : 2;
+        const draw = (id, key, name, values) => {
+            const host = document.getElementById(id);
+            if (host) MiniLineChart.renderInto(host, cats, [{ name, key, values }], { ariaLabel: name, dotRadius });
+        };
+        draw('ac-chart-labels', 'aclabels', 'Labels', series.map(w => w.labels));
+        draw('ac-chart-validations', 'acvals', 'Validations', series.map(w => w.validations));
+        draw('ac-chart-users', 'acusers', 'Active users', series.map(w => w.active_users));
+    }
+
+    // --- Scorecard table --------------------------------------------------------------------------------------------
+
+    #wireSorting() {
+        const ths = document.querySelectorAll('#ac-table thead th[data-sort]');
+        ths.forEach(th => {
+            th.addEventListener('click', () => {
+                const key = th.getAttribute('data-sort');
+                if (this.#sortKey === key) {
+                    this.#sortDir = this.#sortDir === 'asc' ? 'desc' : 'asc';
+                } else {
+                    this.#sortKey = key;
+                    this.#sortDir = key === 'city_name' ? 'asc' : 'desc';
+                }
+                this.#renderTable();
+            });
+        });
+    }
+
+    #renderTable() {
+        const tbody = document.getElementById('ac-tbody');
+        if (!tbody) return;
+        if (!this.#cities.length) {
+            tbody.innerHTML = '<tr><td colspan="8" class="dq-empty">No cities to show.</td></tr>';
+            this.#setText('ac-status', '');
+            return;
+        }
+        const rows = this.#sortedCities(this.#sortKey, this.#sortDir);
+        tbody.innerHTML = rows.map(c => {
+            const lc = AcrossCitiesPage.#LIFECYCLE[c.lifecycle];
+            const needsAttention = (lc && lc.attention) || (c.anomalies || []).length > 0;
+            const chips = (c.anomalies || []).map(f => {
+                const meta = AcrossCitiesPage.#ANOMALY[f] || { label: f, sev: 'info' };
+                return `<span class="ac-chip ac-chip--${meta.sev}">${AcrossCitiesPage.#esc(meta.label)}</span>`;
+            }).join('');
+            const lastActivity = c.last_activity
+                ? AcrossCitiesPage.#esc(AcrossCitiesPage.#relativeTime(c.last_activity))
+                : '<span class="ac-muted">never</span>';
+            return `<tr class="${needsAttention ? 'ac-row--flagged' : ''}">` +
+                `<td class="ac-td-city">${this.#cityLink(c)}${chips ? ` <span class="ac-chips">${chips}</span>` : ''}</td>` +
+                `<td>${this.#lifecycleBadge(c.lifecycle)}</td>` +
+                `<td>${this.#coverageBar(c.coverage)}</td>` +
+                `<td class="ac-num" title="${this.#num(c.total_labels)}">${this.#compact(c.total_labels)}</td>` +
+                `<td class="ac-num" title="${this.#num(c.total_validations)}">${this.#compact(c.total_validations)}</td>` +
+                `<td class="ac-num" title="${this.#num(c.active_contributors)}">${this.#compact(c.active_contributors)}</td>` +
+                `<td class="ac-num">${this.#pct(c.ai_label_share)}</td>` +
+                `<td class="ac-num">${lastActivity}</td>` +
+                '</tr>';
+        }).join('');
+        this.#markSortedHeader();
+        this.#setText('ac-status', `${rows.length} ${rows.length === 1 ? 'city' : 'cities'}.`);
+    }
+
+    #sortedCities(key, dirStr) {
+        const dir = dirStr === 'asc' ? 1 : -1;
+        const val = c => {
+            if (key === 'city_name') return (c.city_name || c.city_id || '').toLowerCase();
+            if (key === 'lifecycle') {
+                const lc = AcrossCitiesPage.#LIFECYCLE[c.lifecycle];
+                return lc ? lc.rank : 99;
+            }
+            if (key === 'days_since_activity') return c.days_since_activity == null ? Number.MAX_SAFE_INTEGER : c.days_since_activity;
+            return c[key] == null ? 0 : c[key];
+        };
+        return this.#cities.slice().sort((a, b) => {
+            const va = val(a), vb = val(b);
+            if (va < vb) return -1 * dir;
+            if (va > vb) return 1 * dir;
+            return 0;
+        });
+    }
+
+    #markSortedHeader() {
+        document.querySelectorAll('#ac-table thead th[data-sort]').forEach(th => {
+            const key = th.getAttribute('data-sort');
+            th.classList.toggle('ac-sorted', key === this.#sortKey);
+            if (key === this.#sortKey) {
+                th.setAttribute('aria-sort', this.#sortDir === 'asc' ? 'ascending' : 'descending');
+                th.dataset.dir = this.#sortDir;
+            } else {
+                th.removeAttribute('aria-sort');
+                delete th.dataset.dir;
+            }
+        });
+    }
+
+    // --- Coverage section -------------------------------------------------------------------------------------------
+
+    #renderCoverage() {
+        const tbody = document.getElementById('ac-coverage-tbody');
+        if (!tbody) return;
+        const rows = this.#sortedCities('coverage', 'desc');
+        tbody.innerHTML = rows.map(c =>
+            `<tr class="${(c.lifecycle === 'stalled' || c.lifecycle === 'low_traction') ? 'ac-row--flagged' : ''}">` +
+            `<td class="ac-td-city">${this.#cityLink(c)}</td>` +
+            `<td>${this.#coverageBar(c.coverage)}</td>` +
+            `<td class="ac-num" title="${this.#num(c.audited_streets)} of ${this.#num(c.total_streets)}">` +
+                `${this.#compact(c.audited_streets)} / ${this.#compact(c.total_streets)}</td>` +
+            `<td class="ac-num" title="${this.#num(c.streets_remaining)}">${this.#compact(c.streets_remaining)}</td>` +
+            `<td class="ac-num">${this.#km(c.audited_km)} / ${this.#km(c.total_km)}</td>` +
+            `<td class="ac-num">${this.#km(c.km_remaining)}</td>` +
+            '</tr>'
+        ).join('');
+    }
+
+    // --- Activity section -------------------------------------------------------------------------------------------
+
+    #renderActivity() {
+        const tbody = document.getElementById('ac-activity-tbody');
+        if (!tbody) return;
+        // Sort by most-recent activity (freshest first; never-active last).
+        const rows = this.#sortedCities('days_since_activity', 'asc');
+        tbody.innerHTML = rows.map(c => {
+            const last = c.last_activity
+                ? AcrossCitiesPage.#esc(AcrossCitiesPage.#relativeTime(c.last_activity))
+                : '<span class="ac-muted">never</span>';
+            const spark = this.#sparkline((c.weekly_trend || []).map(w => w.labels || 0));
+            const flagged = c.lifecycle === 'stalled' || c.lifecycle === 'low_traction';
+            return `<tr class="${flagged ? 'ac-row--flagged' : ''}">` +
+                `<td class="ac-td-city">${this.#cityLink(c)}</td>` +
+                `<td class="ac-num">${this.#num(c.labels_7d)} / ${this.#num(c.labels_30d)}</td>` +
+                `<td class="ac-num">${this.#num(c.validations_7d)} / ${this.#num(c.validations_30d)}</td>` +
+                `<td class="ac-num">${this.#num(c.audits_7d)} / ${this.#num(c.audits_30d)}</td>` +
+                `<td class="ac-num">${last}</td>` +
+                `<td class="ac-spark-cell">${spark}</td>` +
+                '</tr>';
+        }).join('');
+    }
+
+    // --- Contributors & effort section ------------------------------------------------------------------------------
+
+    #renderEffort() {
+        const tbody = document.getElementById('ac-effort-tbody');
+        if (!tbody) return;
+        const rows = this.#cities.slice().sort((a, b) => (b.num_labelers || 0) - (a.num_labelers || 0));
+        tbody.innerHTML = rows.map(c => {
+            const out = (med, p90) => `${this.#num(Math.round(med || 0))} <span class="ac-muted">· ${this.#num(Math.round(p90 || 0))}</span>`;
+            const v10 = c.seconds_to_validate_10 > 0
+                ? this.#duration(c.seconds_to_validate_10) : '<span class="ac-muted">—</span>';
+            const l100 = c.seconds_per_100m != null
+                ? this.#duration(c.seconds_per_100m) : '<span class="ac-muted">—</span>';
+            return '<tr>' +
+                `<td class="ac-td-city">${this.#cityLink(c)}</td>` +
+                `<td class="ac-num">${this.#num(c.num_labelers)}</td>` +
+                `<td class="ac-num">${out(c.labels_per_user_median, c.labels_per_user_p90)}</td>` +
+                `<td class="ac-num">${this.#num(c.num_validators)}</td>` +
+                `<td class="ac-num">${out(c.validations_per_user_median, c.validations_per_user_p90)}</td>` +
+                `<td class="ac-num">${v10}</td>` +
+                `<td class="ac-num">${l100}</td>` +
+                '</tr>';
+        }).join('');
+    }
+
+    // --- Data patterns section --------------------------------------------------------------------------------------
+
+    /** Renders the label-type legend + one normalized stacked bar per city, so problem mixes compare directly. */
+    #renderPatterns() {
+        const host = document.getElementById('ac-patterns');
+        const legendEl = document.getElementById('ac-patterns-legend');
+        if (!host) return;
+
+        // Only show label types that actually appear in at least one city, in canonical order.
+        const present = AcrossCitiesPage.#LABEL_TYPES.filter(([key]) =>
+            this.#cities.some(c => c.by_label_type && c.by_label_type[key] && c.by_label_type[key].labels > 0));
+
+        if (legendEl) {
+            legendEl.innerHTML = present.map(([key, name]) =>
+                `<span class="ac-legend-item"><span class="ac-legend-swatch" style="background:${this.#color(key)}"></span>` +
+                `${AcrossCitiesPage.#esc(name)}</span>`).join('');
+        }
+
+        const rows = this.#cities.slice().sort((a, b) => (b.total_labels || 0) - (a.total_labels || 0));
+        host.innerHTML = rows.map(c => {
+            const total = present.reduce((sum, [key]) =>
+                sum + ((c.by_label_type && c.by_label_type[key] && c.by_label_type[key].labels) || 0), 0);
+            let segments;
+            if (total === 0) {
+                segments = '<span class="ac-stack-empty">no labels</span>';
+            } else {
+                segments = present.map(([key, name]) => {
+                    const n = (c.by_label_type && c.by_label_type[key] && c.by_label_type[key].labels) || 0;
+                    if (n === 0) return '';
+                    const share = n / total;
+                    const tip = `${name}: ${this.#num(n)} (${this.#pct(share)})`;
+                    return `<span class="ac-stack-seg" style="width:${(share * 100).toFixed(2)}%;background:${this.#color(key)}" title="${AcrossCitiesPage.#esc(tip)}"></span>`;
+                }).join('');
+            }
+            return '<div class="ac-pattern-row">' +
+                `<div class="ac-pattern-city">${this.#cityLink(c)} <span class="ac-muted">${this.#compact(c.total_labels)}</span></div>` +
+                `<div class="ac-stack">${segments}</div>` +
+                '</div>';
+        }).join('');
+    }
+
+    // --- Data quality section ---------------------------------------------------------------------------------------
+
+    #renderQuality() {
+        const tbody = document.getElementById('ac-quality-tbody');
+        if (!tbody) return;
+        const rows = this.#sortedCities('labels_validated_share', 'desc');
+        tbody.innerHTML = rows.map(c => {
+            const agreeDenom = (c.validations_agree || 0) + (c.validations_disagree || 0);
+            const agreeRate = agreeDenom > 0 ? c.validations_agree / agreeDenom : null;
+            const contribDenom = (c.active_contributors || 0) + (c.low_quality_contributors || 0);
+            const lowQShare = contribDenom > 0 ? c.low_quality_contributors / contribDenom : 0;
+            const flagged = (c.anomalies || []).includes('high_disagreement');
+            const vpl = c.validations_per_label || 0;
+            return `<tr class="${flagged ? 'ac-row--flagged' : ''}">` +
+                `<td class="ac-td-city">${this.#cityLink(c)}</td>` +
+                `<td class="ac-num" title="${this.#num(c.labels_validated)} of ${this.#num(c.total_labels)}">${this.#pct(c.labels_validated_share)}</td>` +
+                `<td class="ac-num" title="${this.#num(c.total_validations)} validations / ${this.#num(c.total_labels)} labels">${vpl.toFixed(1)}</td>` +
+                `<td class="ac-num">${agreeRate == null ? '<span class="ac-muted">—</span>' : this.#pct(agreeRate)}</td>` +
+                `<td class="ac-num" title="${this.#num(c.labels_with_severity)} of ${this.#num(c.labels_severity_eligible)} severity-eligible labels">${this.#pct(c.severity_share)}</td>` +
+                `<td class="ac-num" title="${this.#num(c.labels_with_tags)} of ${this.#num(c.labels_tag_eligible)} tag-eligible labels">${this.#pct(c.tags_share)}</td>` +
+                `<td class="ac-num" title="${this.#num(c.ai_labels)} of ${this.#num(c.total_labels)} labels">${this.#pct(c.ai_label_share)}</td>` +
+                `<td class="ac-num" title="${this.#num(c.ai_validations)} of ${this.#num(c.total_validations)} validations">${this.#pct(c.ai_validation_share)}</td>` +
+                `<td class="ac-num" title="${this.#num(c.low_quality_contributors)} of ${this.#num(contribDenom)} contributors">${this.#pct(lowQShare)}</td>` +
+                '</tr>';
+        }).join('');
+    }
+
+    // --- Shared cell builders ---------------------------------------------------------------------------------------
+
+    #cityLink(c) {
+        const name = AcrossCitiesPage.#esc(c.city_name || c.city_id);
+        return c.url ? `<a href="${AcrossCitiesPage.#esc(c.url)}" target="_blank" rel="noopener">${name}</a>` : name;
+    }
+
+    #coverageBar(coverage) {
+        const pct = Math.round((coverage || 0) * 100);
+        return '<div class="ac-bar" title="' + pct + '% audited">' +
+            `<span class="ac-bar-fill" style="width:${pct}%"></span>` +
+            `<span class="ac-bar-label">${pct}%</span></div>`;
+    }
+
+    /** A tiny inline-SVG sparkline for a row cell (no axes/labels). */
+    #sparkline(values) {
+        if (!values || !values.length) return '';
+        const W = 90, H = 22, pad = 2;
+        const max = Math.max(1, ...values);
+        const n = values.length;
+        const x = i => pad + (n === 1 ? (W - 2 * pad) / 2 : (i / (n - 1)) * (W - 2 * pad));
+        const y = v => pad + (1 - v / max) * (H - 2 * pad);
+        const d = values.map((v, i) => `${i === 0 ? 'M' : 'L'}${x(i).toFixed(1)},${y(v).toFixed(1)}`).join(' ');
+        return `<svg class="ac-spark" viewBox="0 0 ${W} ${H}" preserveAspectRatio="none" aria-hidden="true">` +
+            `<path d="${d}" fill="none" stroke="currentColor" stroke-width="1.5"/></svg>`;
+    }
+
+    /** Canonical label-type color via the shared helper, with a gray fallback. */
+    #color(labelType) {
+        try {
+            if (window.util && util.misc && util.misc.getLabelColors) {
+                const c = util.misc.getLabelColors(labelType);
+                if (c) return c;
+            }
+        } catch (e) { /* fall through to default */ }
+        return '#b3b3b3';
+    }
+
+    // --- Helpers ----------------------------------------------------------------------------------------------------
+
+    #setText(id, text) { const el = document.getElementById(id); if (el) el.textContent = text; }
+    #setHtml(id, html) { const el = document.getElementById(id); if (el) el.innerHTML = html; }
+
+    /** Full number with thousands separators ("1,234,567"). */
+    #num(n) { return (n == null ? 0 : n).toLocaleString(); }
+
+    /** Compact number ("1.2M", "317k", "842"). */
+    #compact(n) {
+        const v = n == null ? 0 : n;
+        if (v >= 1e6) return `${(v / 1e6).toFixed(1).replace(/\.0$/, '')}M`;
+        if (v >= 1e4) return `${Math.round(v / 1e3)}k`;
+        return v.toLocaleString();
+    }
+
+    /** Kilometers with one decimal under 100, else whole ("0.4", "12.7", "1,240"). */
+    #km(n) {
+        const v = n == null ? 0 : n;
+        return v < 100 ? v.toFixed(1) : Math.round(v).toLocaleString();
+    }
+
+    /** Percentage with no decimals ("47%"). */
+    #pct(fraction) { return `${Math.round((fraction || 0) * 100)}%`; }
+
+    /** Human duration from seconds ("8s", "2.4 min", "1.3 h"). */
+    #duration(seconds) {
+        const s = seconds || 0;
+        if (s < 60) return `${Math.round(s)}s`;
+        if (s < 3600) return `${(s / 60).toFixed(1)} min`;
+        return `${(s / 3600).toFixed(1)} h`;
+    }
+
+    static #esc(s) {
+        return String(s).replace(/[&<>"']/g, c =>
+            ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+    }
+
+    /** "Jun 9"-style short date from an ISO date string. */
+    static #shortDate(iso) {
+        const d = new Date(iso + 'T00:00:00');
+        if (isNaN(d)) return iso;
+        return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+    }
+
+    /** Compact relative time ("just now", "5m ago", "3h ago", "2d ago", or a date for older items). */
+    static #relativeTime(ts) {
+        const d = new Date(ts);
+        if (isNaN(d)) return String(ts);
+        const secs = Math.floor((Date.now() - d.getTime()) / 1000);
+        if (secs < 60) return 'just now';
+        const mins = Math.floor(secs / 60);
+        if (mins < 60) return `${mins}m ago`;
+        const hrs = Math.floor(mins / 60);
+        if (hrs < 24) return `${hrs}h ago`;
+        const days = Math.floor(hrs / 24);
+        if (days < 7) return `${days}d ago`;
+        return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+    }
+}

--- a/public/stylesheets/admin-dashboard/admin-dashboard.css
+++ b/public/stylesheets/admin-dashboard/admin-dashboard.css
@@ -1253,3 +1253,249 @@ img.activity-feed-thumb:hover { box-shadow: 0 2px 6px rgba(0, 0, 0, 0.18); }
 .label-map-search .mgmt-search { flex: 0 1 160px; }
 .label-map-search-msg { margin-left: var(--space-xs, 8px); }
 .label-map-search-msg.error { color: #a32020; }
+
+/* --- Across Cities page (#4329) -------------------------------------------------------------------------------------
+ * Per-city scorecard table + anomaly chips. Reuses .ov-attention* for the "needs attention" panel and .dq-empty for
+ * empty states; only the table, coverage mini-bar, and chips are new here. */
+.ac-pulse {
+    font-size: var(--font-size-sm, 0.875rem);
+    color: var(--color-text-secondary, #5a7785);
+    margin-top: var(--space-sm, 12px);
+}
+.ac-pulse strong { color: var(--color-text-heading, #263238); }
+
+.ac-table-wrap { overflow-x: auto; margin: var(--space-md, 16px) 0; }
+.ac-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: var(--font-size-sm, 0.875rem);
+}
+.ac-table thead th {
+    text-align: right;
+    padding: var(--space-xs, 8px) var(--space-sm, 12px);
+    border-bottom: 2px solid var(--color-neutral-200, #e1e1e1);
+    color: var(--color-text-secondary, #5a7785);
+    font-weight: 600;
+    white-space: nowrap;
+    cursor: pointer;
+    user-select: none;
+}
+.ac-table thead th.ac-th-text { text-align: left; }
+.ac-table thead th:hover { color: var(--color-text-heading, #263238); }
+.ac-table thead th.ac-sorted { color: var(--color-text-heading, #263238); }
+/* Sort-direction caret on the active column. */
+.ac-table thead th.ac-sorted[data-dir="asc"]::after { content: " \25B2"; font-size: 0.7em; }
+.ac-table thead th.ac-sorted[data-dir="desc"]::after { content: " \25BC"; font-size: 0.7em; }
+
+.ac-table tbody td {
+    padding: var(--space-xs, 8px) var(--space-sm, 12px);
+    border-bottom: 1px solid var(--color-neutral-100, #f0f0f0);
+    vertical-align: middle;
+}
+.ac-table tbody tr:hover { background: var(--color-neutral-100, #f0f0f0); }
+.ac-num { text-align: right; white-space: nowrap; color: var(--color-text-primary, #222); }
+.ac-muted { color: var(--color-text-secondary, #5a7785); }
+.ac-td-city a { color: var(--color-accent-link, #0566f5); text-decoration: none; }
+.ac-td-city a:hover { text-decoration: underline; }
+
+/* Flagged rows get a subtle warning tint + left accent so they stand out in a long table. */
+.ac-row--flagged { background: #fffaf0; }
+.ac-row--flagged:hover { background: #fff4e0; }
+.ac-row--flagged .ac-td-city { box-shadow: inset 3px 0 0 #e0a800; }
+
+/* Coverage mini-bar: a thin track with a filled portion and the percentage overlaid. */
+.ac-bar {
+    position: relative;
+    width: 120px;
+    height: 16px;
+    background: var(--color-neutral-200, #e1e1e1);
+    border-radius: 3px;
+    overflow: hidden;
+}
+.ac-bar-fill {
+    position: absolute;
+    top: 0; left: 0; bottom: 0;
+    background: var(--color-primary, #4a90d9);
+    border-radius: 3px;
+}
+.ac-bar-label {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: var(--font-size-xs, 0.8125rem);
+    color: var(--color-text-heading, #263238);
+}
+
+/* Anomaly chips shown inline next to a city's name. */
+.ac-chips { display: inline-flex; gap: 4px; flex-wrap: wrap; }
+.ac-chip {
+    display: inline-block;
+    padding: 1px 6px;
+    border-radius: 10px;
+    font-size: var(--font-size-xs, 0.8125rem);
+    font-weight: 600;
+    white-space: nowrap;
+}
+.ac-chip--warn { background: #fff3cd; color: #8a6d00; }
+.ac-chip--info { background: #e3f0fb; color: #1c5a91; }
+
+/* --- Across Cities: over-time charts, sparklines, patterns (#4329) ------------------------------------------------- */
+.ac-charts {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: var(--space-lg, 24px);
+    margin: var(--space-md, 16px) 0;
+}
+.ac-chart { min-width: 0; }
+.ac-chart-title {
+    font-size: var(--font-size-sm, 0.875rem);
+    color: var(--color-text-heading, #263238);
+    margin: 0 0 var(--space-xs, 8px);
+}
+.ac-note { font-size: var(--font-size-xs, 0.8125rem); color: var(--color-text-secondary, #5a7785); }
+
+/* MiniLineChart series colors for the three overview charts (one series each). */
+.mini-line--aclabels { stroke: var(--color-primary, #4a90d9); fill: none; stroke-width: 2; }
+.mini-pt--aclabels   { fill: var(--color-primary, #4a90d9); }
+.mini-line--acvals   { stroke: #63c0ab; fill: none; stroke-width: 2; }
+.mini-pt--acvals     { fill: #63c0ab; }
+.mini-line--acusers  { stroke: #be87d8; fill: none; stroke-width: 2; }
+.mini-pt--acusers    { fill: #be87d8; }
+
+/* Per-city activity sparkline. */
+.ac-spark-cell { width: 100px; color: var(--color-primary, #4a90d9); }
+.ac-spark { display: block; width: 90px; height: 22px; }
+
+/* Data-patterns: legend + normalized stacked bars. */
+.ac-legend { display: flex; flex-wrap: wrap; gap: var(--space-sm, 12px); margin: var(--space-sm, 12px) 0; }
+.ac-legend-item {
+    display: inline-flex; align-items: center; gap: 5px;
+    font-size: var(--font-size-xs, 0.8125rem); color: var(--color-text-secondary, #5a7785);
+}
+.ac-legend-swatch { width: 11px; height: 11px; border-radius: 2px; display: inline-block; }
+
+.ac-pattern-row { display: flex; align-items: center; gap: var(--space-md, 16px); margin: 6px 0; }
+.ac-pattern-city {
+    flex: 0 0 200px; font-size: var(--font-size-sm, 0.875rem);
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.ac-pattern-city a { color: var(--color-accent-link, #0566f5); text-decoration: none; }
+.ac-pattern-city a:hover { text-decoration: underline; }
+.ac-stack {
+    flex: 1 1 auto; display: flex; height: 18px; border-radius: 3px; overflow: hidden;
+    background: var(--color-neutral-100, #f0f0f0);
+}
+.ac-stack-seg { height: 100%; }
+.ac-stack-empty { font-size: var(--font-size-xs, 0.8125rem); color: var(--color-text-secondary, #5a7785); padding-left: 6px; }
+
+/* --- Across Cities: lifecycle status badges (#4329) -------------------------------------------------------------- */
+.ac-badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 10px;
+    font-size: var(--font-size-xs, 0.8125rem);
+    font-weight: 600;
+    white-space: nowrap;
+}
+.ac-badge--ok   { background: #e3f0fb; color: #1c5a91; }  /* Active */
+.ac-badge--good { background: #e4f4ec; color: #1f7a4d; }  /* Wrapped up (success) */
+.ac-badge--warn { background: #fff3cd; color: #8a6d00; }  /* Stalled */
+.ac-badge--bad  { background: #fbe3e3; color: #a32020; }  /* Low traction */
+
+/* --- Across Cities: over-time range toggle (#4329) --------------------------------------------------------------- */
+.ac-toggle { display: inline-flex; gap: 0; margin: 0 0 var(--space-sm, 12px); }
+.ac-toggle-btn {
+    font-size: var(--font-size-sm, 0.875rem);
+    padding: 4px 12px;
+    border: 1px solid var(--color-neutral-400, #c2c2c2);
+    background: var(--color-neutral-white, #fff);
+    color: var(--color-text-primary, #222);
+    cursor: pointer;
+}
+.ac-toggle-btn:first-child { border-radius: 4px 0 0 4px; }
+.ac-toggle-btn:last-child { border-radius: 0 4px 4px 0; border-left: none; }
+.ac-toggle-btn:hover { background: var(--color-neutral-100, #f0f0f0); }
+.ac-toggle-btn.active {
+    background: var(--color-asphalt-500, #263238);
+    border-color: var(--color-asphalt-500, #263238);
+    color: #fff;
+}
+
+/* --- Across Cities: hero stat band + deployment map (#4329) ------------------------------------------------------ */
+.ac-hero { margin-top: var(--space-lg, 24px); }
+.ac-hero-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-md, 16px);
+    margin-bottom: var(--space-md, 16px);
+}
+.ac-hero-stat {
+    flex: 1 1 120px;
+    border: 1px solid var(--color-neutral-200, #e1e1e1);
+    border-radius: 8px;
+    padding: var(--space-md, 16px);
+    background: var(--color-neutral-white, #fff);
+}
+.ac-hero-value {
+    display: block;
+    font-size: var(--font-size-xxl, 1.5rem);
+    font-weight: 700;
+    color: var(--color-text-heading, #263238);
+    line-height: 1.1;
+}
+.ac-hero-label {
+    display: block;
+    margin-top: 4px;
+    font-size: var(--font-size-sm, 0.875rem);
+    color: var(--color-text-secondary, #5a7785);
+}
+.ac-map {
+    width: 100%;
+    height: 460px;
+    border: 1px solid var(--color-neutral-200, #e1e1e1);
+    border-radius: 8px;
+    overflow: hidden;
+}
+
+/* --- Across Cities: deployment map legend (#4329) ---------------------------------------------------------------- */
+.ac-map-legend {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--space-sm, 12px) var(--space-md, 16px);
+    margin-top: var(--space-sm, 12px);
+    font-size: var(--font-size-xs, 0.8125rem);
+    color: var(--color-text-secondary, #5a7785);
+}
+.ac-legend-dot {
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    margin-right: 5px;
+    vertical-align: -2px;
+    border: 1px solid #ffffff;
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.12);
+}
+.ac-legend-dot--nostats { background: #9aa7b0; }
+/* Private marker: neutral fill with the thick dark ring used on the map. */
+.ac-legend-dot--private { background: #9aa7b0; border: 2px solid #33373a; box-shadow: none; }
+.ac-legend-size {
+    display: inline-block;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    margin-right: 5px;
+    vertical-align: -3px;
+    background: rgba(74, 144, 217, 0.35);
+    border: 1px solid rgba(74, 144, 217, 0.7);
+}
+.ac-legend-sep { width: 1px; height: 16px; background: var(--color-neutral-200, #e1e1e1); }
+
+/* --- Across Cities: footnote marker (#4329) --------------------------------------------------------------------- */
+.ac-fn { color: var(--color-accent-link, #0566f5); cursor: help; font-weight: 600; }
+
+/* --- Across Cities: effort-table sub-header (#4329) -------------------------------------------------------------- */
+.ac-th-sub { font-weight: 400; font-size: var(--font-size-xs, 0.8125rem); color: var(--color-text-secondary, #5a7785); }


### PR DESCRIPTION
Closes #4329. Owner-only cross-deployment dashboard at **/admin/across-cities** — the last big piece of the admin dashboard redesign (#4272 / #4328), which deliberately scoped that work to per-city pages.

## What it adds
A single page comparing **all** Project Sidewalk cities at once, across these lenses:

- **Hero stats + deployment map** — project-wide totals, and a Mapbox map of every deployment (circle area ∝ labels, color = lifecycle, private deployments get a ring; legend included).
- **Lifecycle / health** — a 4-state classification (**Active / Wrapped up / Stalled / Low traction**) that distinguishes "succeeded then went quiet" (e.g. Oradell — high coverage, celebrated, not flagged) from "never took off" (e.g. LA — few contributors). Drives a "needs attention" panel.
- **Coverage** — streets & km audited vs total, and how much is left.
- **Activity** — last 7/30-day volume, last-activity recency, per-city sparklines, and **labels / validations / active-users over time** line charts with a **12-week / All-time** toggle.
- **Data patterns** — each city's label-type mix as a normalized stacked bar (canonical colors), for city-vs-city comparison.
- **Data quality** — % validated, validations/label, **human-only** agreement, **% with severity** and **% with tags** (each over the *eligible* label types only), **AI labels vs AI validations** (split, since they differ), and low-quality-contributor share.
- **Contributors & effort** — per-user output as **median + p90** (the distribution is power-law, so mean±SD would mislead), **time to validate 10**, and **time to label 100 m**.

## How it works
Reuses the established cross-schema fan-out (`ConfigService.getAggregateStats` pattern): per-schema queries run in parallel with per-city recovery and caching, merged with per-city display info from config. **Hybrid delivery** — cheap metrics compute on-demand (~10-min cache); the one heavy metric, idle-capped **labeling speed** (a window scan of `audit_task_interaction_small`, mirroring `calculateTimeExploring`'s 5-min idle cap), is on a **24-hour cache**. A scheduled actor (like `UserStatActor`) could replace that cache later for zero user-facing cost.

Access is gated by a new **`WithOwner()`** authorization (all cities live in one DB, so per-city admins must not see other cities' detail); the sidebar link is shown to owners only, directly under Overview.

## Backend
- `app/models/utils/ConfigTable.scala` — per-schema scorecard, weekly-trend, contributor-output, and labeling-speed queries (raw SQL, `"#$schema".table` pattern).
- `app/service/ConfigService.scala` — `CityScorecard` DTOs, `getCityScorecards`, `getCrossCityWeeklyTrend`, `getCrossCityLabelingSpeed`, lifecycle + anomaly logic.
- `app/controllers/AdminController.scala` — Owner-gated `/adminapi/cityScorecards` (snake_case JSON); `AdminDashboardController.acrossCities`; `WithOwner()` in `app/models/auth/WithRole.scala`.

## Frontend
- `app/views/admin/dashboard/acrossCities.scala.html`, `public/javascripts/admin-dashboard/across-cities-page.js`, additions to `admin-dashboard.css`; sidebar/layout threaded with an `isOwner` flag.

## Testing / notes
- Backend compiles; new SQL validated via `EXPLAIN` against a real schema and sanity-checked on Seattle data.
- **Verify on staging/prod:** labeling-speed (`audit_task_interaction_small`) and AI-label metrics aren't in the local DB dump, so those can only be confirmed on a real deployment. Their SQL is adapted from existing, proven queries.
- User-facing strings still need translations for the supported locales (follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)