### PR TITLE
Persist per-street imagery age in a street_imagery table (#4348)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,9 @@ fill-new-schema:
 hide-streets-without-imagery:
 	@docker exec -it projectsidewalk-db sh -c "/opt/scripts/hide-streets-without-imagery.sh"
 
+import-street-imagery:
+	@docker exec -it projectsidewalk-db sh -c "/opt/scripts/import-street-imagery.sh"
+
 # Run the Python utility test suite (test/python/) inside the running web container. Pass extra pytest flags via args=,
 # e.g. `make test-python args="-k bbox -v"`.
 test-python:

--- a/app/models/street/StreetImageryTable.scala
+++ b/app/models/street/StreetImageryTable.scala
@@ -1,0 +1,75 @@
+package models.street
+
+import com.google.inject.ImplementedBy
+import models.utils.MyPostgresProfile
+import models.utils.MyPostgresProfile.api._
+import play.api.db.slick.{DatabaseConfigProvider, HasDatabaseConfigProvider}
+
+import java.time.{LocalDate, OffsetDateTime}
+import javax.inject.{Inject, Singleton}
+
+/**
+ * Per-street imagery age (#4348): the capture-date range of the street-view panos observed on one street.
+ *
+ * Complements street_edge_status (#3888): status says whether a street has imagery; this says how old it is (a street
+ * can be `open` yet years out of date). One row per street, aggregated across providers.
+ *
+ * @param streetEdgeId  The street this imagery summary is for.
+ * @param oldestCapture Earliest observed capture date, standardized to a date (`None` if none were parseable).
+ * @param newestCapture Latest observed capture date, standardized to a date (`None` if none were parseable).
+ * @param nPanos        Number of distinct dated panos observed on the street.
+ * @param dataSource    Which feeder produced this row: `pano_data` (in-app backfill) or `imagery_scan` (the
+ *                      check_streets_for_imagery.py summary).
+ * @param updatedAt     When this row was last written.
+ */
+case class StreetImagery(
+    streetEdgeId: Int,
+    oldestCapture: Option[LocalDate],
+    newestCapture: Option[LocalDate],
+    nPanos: Int,
+    dataSource: String,
+    updatedAt: OffsetDateTime
+)
+
+class StreetImageryTableDef(tag: Tag) extends Table[StreetImagery](tag, "street_imagery") {
+  def streetEdgeId: Rep[Int]                = column[Int]("street_edge_id", O.PrimaryKey)
+  def oldestCapture: Rep[Option[LocalDate]] = column[Option[LocalDate]]("oldest_capture")
+  def newestCapture: Rep[Option[LocalDate]] = column[Option[LocalDate]]("newest_capture")
+  def nPanos: Rep[Int]                      = column[Int]("n_panos")
+  def dataSource: Rep[String]               = column[String]("data_source")
+  def updatedAt: Rep[OffsetDateTime]        = column[OffsetDateTime]("updated_at")
+
+  def * = (streetEdgeId, oldestCapture, newestCapture, nPanos, dataSource, updatedAt) <>
+    ((StreetImagery.apply _).tupled, StreetImagery.unapply)
+}
+
+@ImplementedBy(classOf[StreetImageryTable]) trait StreetImageryTableRepository {}
+
+/**
+ * Read-only DAO for the street_imagery table. The table is populated out-of-band by the two feeders (the evolution-326
+ * pano_data backfill and db/scripts/import-street-imagery.sh); this DAO exists so app code can read imagery age. Exposure
+ * (admin viz, a /v3 field) is a separate follow-up.
+ */
+@Singleton
+class StreetImageryTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvider)
+    extends StreetImageryTableRepository
+    with HasDatabaseConfigProvider[MyPostgresProfile] {
+
+  import profile.api._
+  val streetImageryRecords = TableQuery[StreetImageryTableDef]
+
+  /**
+   * Imagery age for a single street.
+   *
+   * @param streetEdgeId The street to look up.
+   * @return The street's imagery summary, or `None` if no imagery has been recorded for it.
+   */
+  def getForStreet(streetEdgeId: Int): DBIO[Option[StreetImagery]] = {
+    streetImageryRecords.filter(_.streetEdgeId === streetEdgeId).result.headOption
+  }
+
+  /**
+   * Number of streets that have a recorded imagery summary.
+   */
+  def count: DBIO[Int] = streetImageryRecords.length.result
+}

--- a/conf/evolutions/default/326.sql
+++ b/conf/evolutions/default/326.sql
@@ -1,0 +1,44 @@
+# --- !Ups
+-- Per-street imagery age (#4348). One row per street, aggregating the capture dates of the panos observed on it, so the
+-- app can surface a "stale imagery" signal alongside street_edge_status (#3888) -- a street can have imagery and still be
+-- years out of date. data_source records which feeder produced the row: 'pano_data' (this in-app backfill) or
+-- 'imagery_scan' (the check_streets_for_imagery.py summary, ingested by db/scripts/import-street-imagery.sh).
+CREATE TABLE street_imagery (
+    street_edge_id INTEGER PRIMARY KEY REFERENCES street_edge (street_edge_id),
+    oldest_capture DATE,
+    newest_capture DATE,
+    n_panos INTEGER NOT NULL,
+    data_source TEXT NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL
+);
+
+-- Feeder 1 backfill: every audited street gets imagery age for free from pano_data, joined to streets via label (which
+-- carries both pano_id and street_edge_id, so no spatial join is needed) -- at zero API cost, and covering Mapillary and
+-- Infra3d panos too. pano_data.capture_date is a varying-precision string (YYYY, YYYY-MM, or YYYY-MM-DD), so we
+-- standardize each to a date exactly the way the script's standardize_capture_date does: a year-only value becomes
+-- January 1st, a year-month becomes the 1st, and anything unparseable is dropped. The tutorial pano is excluded so the
+-- tutorial street gets no bogus row.
+INSERT INTO street_imagery (street_edge_id, oldest_capture, newest_capture, n_panos, data_source, updated_at)
+SELECT dated.street_edge_id,
+       MIN(dated.capture),
+       MAX(dated.capture),
+       COUNT(DISTINCT dated.pano_id),
+       'pano_data',
+       now()
+FROM (
+    SELECT label.street_edge_id AS street_edge_id,
+           pano_data.pano_id    AS pano_id,
+           CASE
+               WHEN pano_data.capture_date ~ '^[0-9]{4}$'             THEN to_date(pano_data.capture_date, 'YYYY')
+               WHEN pano_data.capture_date ~ '^[0-9]{4}-[0-9]{2}$'    THEN to_date(pano_data.capture_date, 'YYYY-MM')
+               WHEN pano_data.capture_date ~ '^[0-9]{4}-[0-9]{2}-[0-9]{2}$' THEN to_date(pano_data.capture_date, 'YYYY-MM-DD')
+           END AS capture
+    FROM label
+    JOIN pano_data ON label.pano_id = pano_data.pano_id
+    WHERE pano_data.pano_id <> 'tutorial'
+) AS dated
+WHERE dated.capture IS NOT NULL
+GROUP BY dated.street_edge_id;
+
+# --- !Downs
+DROP TABLE street_imagery;

--- a/db/scripts/import-street-imagery.sh
+++ b/db/scripts/import-street-imagery.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -e  # Exit on any error
+
+# Feeder 2 for the street_imagery table (#4348): ingest the per-street imagery summary produced by
+# check_streets_for_imagery.py (db/street_imagery_summary.csv) into street_imagery with data_source = 'imagery_scan'.
+# This covers streets a scan reached but that have no labels yet, so Feeder 1 (the evolution-326 pano_data backfill)
+# could not see them. A deliberate scan is treated as authoritative for the streets it covers, so on a key collision the
+# scan row supersedes an existing pano_data row.
+
+source /opt/scripts/helpers.sh
+
+SCHEMA_NAME=$(prompt_with_default "Schema name")
+
+# Prompt user for path to CSV file and prepend working dir.
+CSV_FILENAME=$(prompt_with_default "Path to CSV file (relative to db dir)" "street_imagery_summary.csv")
+CSV_FILENAME=/opt/$CSV_FILENAME
+
+# Stage the CSV in a temp table (all text so empty date fields survive as ''), then upsert only the streets that have
+# imagery. Empty oldest/newest fields become NULL; a street with imagery but no parseable capture date still gets a row
+# (NULL dates) so it is distinguishable from a street that was never scanned.
+psql -v ON_ERROR_STOP=1 -d sidewalk -U "$SCHEMA_NAME" <<EOSQL
+    BEGIN;
+
+    CREATE TEMP TABLE street_imagery_import (
+        street_edge_id INTEGER,
+        region_id      INTEGER,
+        has_imagery    TEXT,
+        oldest_capture TEXT,
+        newest_capture TEXT,
+        n_panos        INTEGER
+    ) ON COMMIT DROP;
+
+    \copy street_imagery_import FROM '$CSV_FILENAME' WITH (FORMAT csv, HEADER true)
+
+    INSERT INTO street_imagery (street_edge_id, oldest_capture, newest_capture, n_panos, data_source, updated_at)
+    SELECT street_edge_id,
+           NULLIF(oldest_capture, '')::date,
+           NULLIF(newest_capture, '')::date,
+           n_panos,
+           'imagery_scan',
+           now()
+    FROM street_imagery_import
+    WHERE has_imagery = 'True'
+    ON CONFLICT (street_edge_id) DO UPDATE
+    SET oldest_capture = EXCLUDED.oldest_capture,
+        newest_capture = EXCLUDED.newest_capture,
+        n_panos        = EXCLUDED.n_panos,
+        data_source    = EXCLUDED.data_source,
+        updated_at     = EXCLUDED.updated_at;
+
+    COMMIT;
+EOSQL
+
+echo "Done! Ingested $CSV_FILENAME into street_imagery (data_source = 'imagery_scan')."

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -79,6 +79,22 @@ from it on purpose, because the two tools answer different questions:
 A natural future step (issue #4347) is to also capture the imagery *capture date* from the same GSV responses — exactly
 the temporal angle GSV Tracker specializes in — to know not just whether a street has imagery but how old it is.
 
+## Persisting imagery age to the database (#4348)
+
+The `street_imagery` table records, per street, the capture-date range of the panos observed on it (`oldest_capture`,
+`newest_capture`, `n_panos`) so the app can flag streets whose imagery is stale — complementing `street_edge_status`
+(#3888), which only says *whether* a street has imagery. The table has two feeders, distinguished by its `data_source`
+column:
+
+- **Feeder 1 — `pano_data` (automatic).** Evolution `326.sql` creates the table and backfills it from `pano_data`
+  (joined to streets via `label`, which carries both `pano_id` and `street_edge_id`). This runs per-city on deploy at
+  zero API cost and covers every **audited** street, including Mapillary/Infra3d panos. Rows are tagged
+  `data_source = 'pano_data'`.
+- **Feeder 2 — the imagery scan (manual).** For streets a scan reached but that have no labels yet (so Feeder 1 can't
+  see them), run `make import-street-imagery` to ingest `db/street_imagery_summary.csv` — the per-street summary the
+  scan writes once the imagery-age work (#4347) lands. Rows are tagged `data_source = 'imagery_scan'`, and a scan
+  supersedes an existing `pano_data` row for the same street (it's a deliberate, fresher measurement).
+
 ## Testing
 
 ```bash

--- a/test/models/street/StreetImageryTableSpec.scala
+++ b/test/models/street/StreetImageryTableSpec.scala
@@ -1,0 +1,64 @@
+package models.street
+
+import models.utils.MyPostgresProfile
+import models.utils.MyPostgresProfile.api._
+import org.scalatestplus.play.PlaySpec
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
+import play.api.db.slick.DatabaseConfigProvider
+import play.api.inject.guice.GuiceApplicationBuilder
+import slick.dbio.DBIO
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+/**
+ * DB-backed contract test for the street_imagery table (#4348) and its read-only DAO.
+ *
+ * Booting the app applies evolution 326, which creates street_imagery and backfills it from pano_data (Feeder 1). This
+ * spec asserts the table exists and is queryable through StreetImageryTable, and that the backfill's invariants hold for
+ * whatever rows the connected DB produced (oldest <= newest, a recognized data_source, a non-negative pano count). It
+ * asserts shape/invariants, not data values, so it passes against an empty DB too.
+ *
+ * Requires a Postgres+PostGIS database (via DATABASE_URL / DATABASE_USER / DATABASE_PASSWORD env, as in dev/CI). The
+ * eager scheduling actors are disabled so they don't fire background work during the test.
+ */
+class StreetImageryTableSpec extends PlaySpec with GuiceOneAppPerSuite {
+
+  override def fakeApplication(): Application =
+    new GuiceApplicationBuilder().disable[modules.ActorModule].build()
+
+  private val streetImageryTable = app.injector.instanceOf[StreetImageryTable]
+  // Keep the DatabaseConfig as a stable val and call .db.run inline; binding .db to its own val would infer a
+  // path-dependent existential type that needs -language:existentials.
+  private val dbConfig                   = app.injector.instanceOf[DatabaseConfigProvider].get[MyPostgresProfile]
+  private def run[T](action: DBIO[T]): T = Await.result(dbConfig.db.run(action), 60.seconds)
+
+  private val validSources = Set("pano_data", "imagery_scan")
+
+  "street_imagery (evolution 326) + StreetImageryTable" should {
+    "exist and be countable through the DAO" in {
+      run(streetImageryTable.count) must be >= 0
+    }
+
+    "hold the backfill invariants for every row" in {
+      val rows: Seq[StreetImagery] = run(streetImageryTable.streetImageryRecords.result)
+      rows.foreach { row =>
+        row.nPanos must be >= 0
+        validSources must contain(row.dataSource)
+        // Where both endpoints of the capture-date range are known, oldest must not be after newest.
+        (row.oldestCapture, row.newestCapture) match {
+          case (Some(oldest), Some(newest)) => oldest.isAfter(newest) mustBe false
+          case _                            => // a one-sided or absent range has nothing to compare
+        }
+      }
+    }
+
+    "round-trip an existing street through getForStreet" in {
+      run(streetImageryTable.streetImageryRecords.result.headOption) match {
+        case Some(expected) => run(streetImageryTable.getForStreet(expected.streetEdgeId)) mustBe Some(expected)
+        case None           => succeed // No imagery rows in this DB; nothing to round-trip.
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #4348.

## What

Adds a `street_imagery` table recording, per street, the capture-date range of the panos observed on it (`oldest_capture`, `newest_capture`, `n_panos`), so the app can flag streets whose imagery is **stale** — complementing `street_edge_status` (#3888), which only says *whether* a street has imagery, not *how old* it is. One row per street, aggregated across providers.

```
street_imagery
  street_edge_id  int          PK, FK -> street_edge
  oldest_capture  date         standardized (YYYY-MM -> -01, YYYY -> -01-01)
  newest_capture  date
  n_panos         int          distinct dated panos observed
  data_source     text         provenance: 'pano_data' | 'imagery_scan'
  updated_at      timestamptz
```

## Two feeders (by `data_source`)

- **Feeder 1 — `pano_data` (automatic).** Evolution `326.sql` creates the table and backfills it from `pano_data` joined to streets via `label` (which carries both `pano_id` and `street_edge_id`, so no spatial join). Standardizes `capture_date` (`YYYY` / `YYYY-MM` / `YYYY-MM-DD`) to a `date` the same way the imagery script's `standardize_capture_date` does. Runs **per-city on deploy at zero API cost**, covering every audited street incl. Mapillary/Infra3d. This mirrors how evolution 325 (#3888) backfilled street status inline.
- **Feeder 2 — `imagery_scan` (manual).** `db/scripts/import-street-imagery.sh` (+ `make import-street-imagery`) ingests the per-street summary `db/street_imagery_summary.csv` written by `check_streets_for_imagery.py`, covering streets a scan reached but that have no labels yet (so Feeder 1 can't see them). A scan **supersedes** an existing `pano_data` row (`ON CONFLICT (street_edge_id) DO UPDATE`).

Also adds a read-only `StreetImageryTable` DAO and a DB-backed contract test. **Exposure** (admin viz, a `/v3` field) is intentionally a separate follow-up — this PR just lands and populates the table.

## Verification

- `sbt --client Test/compile` — green, warning-clean (`-Xfatal-warnings`).
- `StreetImageryTableSpec` — 3/3 pass (boots the app → applies evolution 326 → asserts the table is queryable through the DAO + backfill invariants: `nPanos >= 0`, recognized `data_source`, `oldest <= newest`, `getForStreet` round-trip). Asserts shape/invariants, not data values, so it passes on an empty DB too.
- The in-app evolution-326 backfill produced **1,726 rows** in the test schema (Teaneck; 2007-10..2024-10, all `pano_data`) — i.e. Feeder 1 works end-to-end through the real evolution, not just a standalone query. On Seattle the backfill SELECT yields 22,537 streets (2007-08..2025-10).
- Feeder-2 upsert SQL validated against the DB (rolled back): conflict row updated to `imagery_scan` with new dates, undated-imagery row inserted with `NULL` dates, `has_imagery='False'` row skipped.

## Notes for review

- ⚠️ **Evolution number collision:** this uses `326.sql`, but the in-flight engagement-funnel (#288) work also plans evolution 326. Whichever merges first keeps 326; the other rebases to 327.
- **Feeder 2's input CSV** (`street_imagery_summary.csv`) is produced by the imagery-age scan (#4347 / PR #4352, still open), so Feeder 2 is fully exercisable once that lands. **Feeder 1 stands alone** and is what populates the ~50 existing cities.
- No semicolons inside SQL comments in the evolution (the bug that broke evolution 325 / hotfix #4351).

## Open decisions (defaulted per the issue; easy to revisit)

- One row per street (v1) — not `(street_edge_id, provider)`.
- `date` columns — not raw `YYYY-MM` strings.
- Precedence: a scan supersedes `pano_data` on conflict.
- Feeder-1 **refresh** (evolutions run once) is a deliberate later follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)