### PR TITLE
Explain Explore badges on hover/focus (#4258)

### DIFF
--- a/app/views/apps/explore.scala.html
+++ b/app/views/apps/explore.scala.html
@@ -250,7 +250,7 @@
                     <h1 class="explore-sidebar__heading" data-i18n="audit:right-ui.badges.title">Badges</h1>
                     <div class="explore-sidebar__badge-list">
                         <div class="explore-sidebar__badge" id="explore-sidebar__badge-labels">
-                            <div class="explore-sidebar__badge-icon">
+                            <div class="explore-sidebar__badge-icon" tabindex="0" role="img">
                                 <img class="explore-sidebar__badge-icon-base" alt="">
                                 <img class="explore-sidebar__badge-icon-fill" alt="">
                             </div>
@@ -260,7 +260,7 @@
                             </div>
                         </div>
                         <div class="explore-sidebar__badge" id="explore-sidebar__badge-distance">
-                            <div class="explore-sidebar__badge-icon">
+                            <div class="explore-sidebar__badge-icon" tabindex="0" role="img">
                                 <img class="explore-sidebar__badge-icon-base" alt="">
                                 <img class="explore-sidebar__badge-icon-fill" alt="">
                             </div>

--- a/public/javascripts/SVLabel/css/svl-minimap.css
+++ b/public/javascripts/SVLabel/css/svl-minimap.css
@@ -48,7 +48,6 @@
 
 #minimap-message {
     font: var(--text-tiny-regular);
-    line-height: 125%;
     inset: auto;
     left: calc(3px * var(--ui-scale));
     top: calc(3px * var(--ui-scale));

--- a/public/javascripts/SVLabel/css/svl-sidebar.css
+++ b/public/javascripts/SVLabel/css/svl-sidebar.css
@@ -111,7 +111,13 @@
     flex: 0 0 auto;
     width: calc(36px * var(--ui-scale));
     height: calc(36px * var(--ui-scale));
-    cursor: zoom-in;
+    cursor: help;
+    border-radius: calc(4px * var(--ui-scale));
+}
+
+.explore-sidebar__badge-icon:focus-visible {
+    outline: 2px solid var(--color-link-200);
+    outline-offset: calc(2px * var(--ui-scale));
 }
 
 .explore-sidebar__badge-icon img {
@@ -134,25 +140,56 @@
     transition: clip-path 0.3s ease;
 }
 
-/* Enlarged badge shown on hover so the small icon's detail is legible. */
-.explore-sidebar__badge-preview {
+/* Tooltip shown on hover/focus: an enlarged, full-color badge alongside its name and how-to-earn text. */
+.explore-sidebar__badge-tooltip {
     position: fixed;
-    width: calc(100px * var(--ui-scale));
-    height: calc(100px * var(--ui-scale));
-    object-fit: contain;
+    left: -9999px; /* Off-screen until JS positions it. */
+    top: -9999px;
+    display: flex;
+    align-items: center;
+    gap: calc(12px * var(--ui-scale));
+    width: calc(280px * var(--ui-scale));
+    padding: calc(12px * var(--ui-scale));
+    background: var(--color-neutral-white);
+    border: 1px solid var(--color-neutral-600);
+    border-radius: calc(12px * var(--ui-scale));
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
     pointer-events: none;
     opacity: 0;
     visibility: hidden;
-    transform: scale(0.85);
-    transform-origin: center bottom;
+    transform: scale(0.95);
     transition: opacity 0.12s ease, transform 0.12s ease;
     z-index: calc(var(--navbar-z-index) - 1);
 }
 
-.explore-sidebar__badge-preview--visible {
+.explore-sidebar__badge-tooltip--visible {
     opacity: 1;
     visibility: visible;
     transform: scale(1);
+}
+
+.explore-sidebar__badge-tooltip-icon {
+    flex: 0 0 auto;
+    width: calc(72px * var(--ui-scale));
+    height: calc(72px * var(--ui-scale));
+    object-fit: contain;
+}
+
+.explore-sidebar__badge-tooltip-body {
+    display: flex;
+    flex-direction: column;
+    gap: calc(4px * var(--ui-scale));
+}
+
+.explore-sidebar__badge-tooltip-name {
+    font: var(--text-small-medium);
+    color: var(--color-neutral-black);
+}
+
+.explore-sidebar__badge-tooltip-desc {
+    margin: 0;
+    font: var(--text-tiny-regular);
+    color: var(--color-neutral-black);
 }
 
 .explore-sidebar__badge-info {

--- a/public/javascripts/SVLabel/src/sidebar/BadgeProgress.js
+++ b/public/javascripts/SVLabel/src/sidebar/BadgeProgress.js
@@ -5,25 +5,44 @@
  * and converted to kilometers for metric users so the displayed values and badge level match the user's unit system.
  */
 class BadgeProgress {
-    // Gap (px, before --ui-scale) between the cursor and the enlarged preview floating above it.
-    static #PREVIEW_GAP = 16;
-    // Minimum distance (px) the preview keeps from the viewport edges when clamped.
-    static #PREVIEW_MARGIN = 8;
+    // Gap (px, before --ui-scale) between the badge icon and the tooltip beside it.
+    static #TOOLTIP_GAP = 12;
+    // Minimum distance (px) the tooltip keeps from the viewport edges when clamped.
+    static #TOOLTIP_MARGIN = 8;
 
     #labelsRow;
     #distanceRow;
-    #preview;
+    #tooltip;
+    #tooltipIcon;
+    #tooltipName;
+    #tooltipDesc;
 
     constructor() {
         this.#labelsRow = this.#cacheRow('explore-sidebar__badge-labels', 'explore-sidebar__badge-labels-count');
         this.#distanceRow = this.#cacheRow('explore-sidebar__badge-distance', 'explore-sidebar__badge-distance-count');
 
-        // The sidebar clips its overflow, so the enlarged preview lives on <body> and is positioned on hover.
-        this.#preview = document.createElement('img');
-        this.#preview.className = 'explore-sidebar__badge-preview';
-        this.#preview.alt = '';
-        this.#preview.setAttribute('aria-hidden', 'true');
-        document.body.appendChild(this.#preview);
+        // The sidebar clips its overflow, so the tooltip lives on <body> and is positioned next to the hovered badge.
+        this.#tooltip = document.createElement('div');
+        this.#tooltip.className = 'explore-sidebar__badge-tooltip';
+        this.#tooltip.setAttribute('role', 'presentation');
+        this.#tooltip.setAttribute('aria-hidden', 'true');
+
+        this.#tooltipIcon = document.createElement('img');
+        this.#tooltipIcon.className = 'explore-sidebar__badge-tooltip-icon';
+        this.#tooltipIcon.alt = '';
+
+        const body = document.createElement('div');
+        body.className = 'explore-sidebar__badge-tooltip-body';
+        this.#tooltipName = document.createElement('span');
+        this.#tooltipName.className = 'explore-sidebar__badge-tooltip-name';
+        this.#tooltipDesc = document.createElement('p');
+        this.#tooltipDesc.className = 'explore-sidebar__badge-tooltip-desc';
+        body.appendChild(this.#tooltipName);
+        body.appendChild(this.#tooltipDesc);
+
+        this.#tooltip.appendChild(this.#tooltipIcon);
+        this.#tooltip.appendChild(body);
+        document.body.appendChild(this.#tooltip);
 
         this.#attachHover(this.#labelsRow);
         this.#attachHover(this.#distanceRow);
@@ -42,51 +61,60 @@ class BadgeProgress {
             iconFill: container.querySelector('.explore-sidebar__badge-icon-fill'),
             name: container.querySelector('.explore-sidebar__badge-name'),
             bar: new ProgressBar(container.querySelector('.ps-progress-bar__fill'), countId),
-            // The next-badge image source, set during render and shown enlarged on hover.
-            iconSrc: null
+            // Tooltip content for this row, set during render and shown on hover/focus.
+            iconSrc: null,
+            tooltipName: '',
+            tooltipDesc: ''
         };
     }
 
-    /** Wires a badge row's icon to show, follow, and hide the enlarged preview on hover. */
+    /**
+     * Wires a badge row's icon to show/hide its tooltip. The icon is focusable, so the tooltip is keyboard-reachable as
+     * well as hoverable; the descriptive text is mirrored onto the icon's aria-label in #renderRow.
+     */
     #attachHover(row) {
-        row.icon.addEventListener('mouseenter', (event) => this.#showPreview(row, event));
-        row.icon.addEventListener('mousemove', (event) => this.#positionPreview(event));
-        row.icon.addEventListener('mouseleave', () => this.#hidePreview());
+        row.icon.addEventListener('mouseenter', () => this.#showTooltip(row));
+        row.icon.addEventListener('mouseleave', () => this.#hideTooltip());
+        row.icon.addEventListener('focusin', () => this.#showTooltip(row));
+        row.icon.addEventListener('focusout', () => this.#hideTooltip());
     }
 
     /**
-     * Shows the enlarged, full-color preview of a row's next-badge icon, floating above the cursor.
+     * Shows the tooltip for a row, populated with the next badge's enlarged icon, name, and how-to-earn text.
      * @param row Cached row elements.
-     * @param {MouseEvent} event The triggering pointer event, used for initial placement.
      */
-    #showPreview(row, event) {
+    #showTooltip(row) {
         if (!row.iconSrc) return;
-        if (this.#preview.getAttribute('src') !== row.iconSrc) this.#preview.src = row.iconSrc;
-        this.#positionPreview(event);
-        this.#preview.classList.add('explore-sidebar__badge-preview--visible');
+        if (this.#tooltipIcon.getAttribute('src') !== row.iconSrc) this.#tooltipIcon.src = row.iconSrc;
+        this.#tooltipName.textContent = row.tooltipName;
+        this.#tooltipDesc.textContent = row.tooltipDesc;
+        this.#tooltip.classList.add('explore-sidebar__badge-tooltip--visible');
+        this.#positionTooltip(row);
     }
 
     /**
-     * Positions the preview centered just above the cursor, clamped within the viewport.
-     * @param {MouseEvent} event The pointer event providing the cursor position.
+     * Positions the tooltip just to the left of the badge icon.
+     * @param row Cached row elements.
      */
-    #positionPreview(event) {
-        const previewRect = this.#preview.getBoundingClientRect();
-        const gap = BadgeProgress.#PREVIEW_GAP * util.uiScale();
-        const margin = BadgeProgress.#PREVIEW_MARGIN;
+    #positionTooltip(row) {
+        const iconRect = row.icon.getBoundingClientRect();
+        const tipRect = this.#tooltip.getBoundingClientRect();
+        const gap = BadgeProgress.#TOOLTIP_GAP * util.uiScale();
+        const margin = BadgeProgress.#TOOLTIP_MARGIN;
 
-        let left = event.clientX - previewRect.width / 2;
-        left = Math.max(margin, Math.min(left, window.innerWidth - previewRect.width - margin));
-        let top = event.clientY - previewRect.height - gap;
-        if (top < margin) top = event.clientY + gap;
+        let left = iconRect.left - gap - tipRect.width;
+        if (left < margin) left = iconRect.right + gap;
 
-        this.#preview.style.left = `${left}px`;
-        this.#preview.style.top = `${top}px`;
+        let top = iconRect.top + iconRect.height / 2 - tipRect.height / 2;
+        top = Math.max(margin, Math.min(top, window.innerHeight - tipRect.height - margin));
+
+        this.#tooltip.style.left = `${left}px`;
+        this.#tooltip.style.top = `${top}px`;
     }
 
-    /** Hides the enlarged badge preview. */
-    #hidePreview() {
-        this.#preview.classList.remove('explore-sidebar__badge-preview--visible');
+    /** Hides the badge tooltip. */
+    #hideTooltip() {
+        this.#tooltip.classList.remove('explore-sidebar__badge-tooltip--visible');
     }
 
     /** Formats a number using the locale-aware i18next number formatter. */
@@ -105,7 +133,9 @@ class BadgeProgress {
             value: labelCount,
             thresholds: BadgeAchievements.THRESHOLDS.labels,
             nameKey: 'common:badges.labeler-name',
+            goalKey: 'audit:right-ui.badges.labeler-goal',
             iconFor: (level) => `/assets/images/badges/badge_labels_badge${level}.png`,
+            nextText: (target) => i18next.t('audit:right-ui.badges.next-labels', { count: target }),
             unit: '',
             decimals: 0
         });
@@ -113,25 +143,32 @@ class BadgeProgress {
         const distanceThresholds = isMetric
             ? BadgeAchievements.THRESHOLDS.distance.map(util.math.milesToKms)
             : BadgeAchievements.THRESHOLDS.distance;
+        const distanceUnit = i18next.t('common:unit-distance-abbreviation');
         this.#renderRow(this.#distanceRow, {
             value: distance,
             thresholds: distanceThresholds,
             nameKey: 'common:badges.explorer-name',
+            goalKey: 'audit:right-ui.badges.explorer-goal',
             iconFor: (level) => isMetric
                 ? `/assets/images/badges/badge_distance_km_badge${level}.png`
                 : `/assets/images/badges/badge_distance_badge${level}.png`,
-            unit: i18next.t('common:unit-distance-abbreviation'),
+            // The badge's total distance goal, shown to one decimal place.
+            nextText: (target) => i18next.t('audit:right-ui.badges.next-distance', {
+                distance: `${this.#formatNumber(Number(target.toFixed(1)))} ${distanceUnit}`
+            }),
+            unit: distanceUnit,
             decimals: 1
         });
     }
 
     /**
-     * Renders a single badge row: next-badge icon + fill, tiered name, progress bar, and "current / target" text.
+     * Renders a single badge row: next-badge icon + fill, tiered name, progress bar, "current / target" text, and the
+     * tooltip content (name + goal + how-to-earn) shown on hover/focus.
      * @param row Cached row elements.
-     * @param config Row config: value, thresholds, nameKey, iconFor, unit, decimals.
+     * @param config Row config: value, thresholds, nameKey, goalKey, iconFor, nextText, unit, decimals.
      */
     #renderRow(row, config) {
-        const { value, thresholds, nameKey, iconFor, unit, decimals } = config;
+        const { value, thresholds, nameKey, goalKey, iconFor, nextText, unit, decimals } = config;
 
         // The next badge is the lowest level the user hasn't reached yet; if they've earned them all, show the top one.
         let nextIndex = thresholds.findIndex(threshold => value < threshold);
@@ -151,8 +188,15 @@ class BadgeProgress {
         row.iconSrc = iconSrc;
         row.iconFill.style.setProperty('--badge-fill', fraction);
 
-        row.name.textContent = `${i18next.t(nameKey)} ${BadgeAchievements.ROMAN[nextIndex]}`;
+        const badgeName = `${i18next.t(nameKey)} ${BadgeAchievements.ROMAN[nextIndex]}`;
+        row.name.textContent = badgeName;
         row.bar.setFraction(fraction);
+
+        // Tooltip: the badge's goal, plus the total it takes to earn it (or a congrats line once it's maxed out).
+        const howTo = maxed ? i18next.t('audit:right-ui.badges.earned-all') : nextText(target);
+        row.tooltipName = badgeName;
+        row.tooltipDesc = `${i18next.t(goalKey)} ${howTo}`;
+        row.icon.setAttribute('aria-label', `${badgeName}. ${row.tooltipDesc}`);
 
         // Floor (don't round) the displayed value so it never shows the target before the bar is actually full.
         const factor = 10 ** decimals;

--- a/public/javascripts/SVValidate/css/svv-panorama.css
+++ b/public/javascripts/SVValidate/css/svv-panorama.css
@@ -199,7 +199,7 @@
 .label-visibility-button-on-label {
     position: absolute;
     visibility: hidden;
-    padding: calc(2px * var(--ui-scale)) calc(5px * var(--ui-scale));
+    padding: calc(4px * var(--ui-scale)) calc(6px * var(--ui-scale));
     border: calc(1px * var(--ui-scale)) solid var(--color-neutral-black);
     border-radius: calc(3px * var(--ui-scale));
     font: var(--text-tiny-regular);

--- a/public/javascripts/SVValidate/css/svv-validation-menu.css
+++ b/public/javascripts/SVValidate/css/svv-validation-menu.css
@@ -224,7 +224,7 @@
 /* Selectize renders its own .option nodes; DesktopValidationMenu adds the tag-pill classes so they pick up the
    shared pill look. These rules out-rank selectize's own stylesheet, which is more specific than .tag-pill. */
 .selectize-dropdown .option.tag-pill {
-    padding: calc(3px * var(--ui-scale)) calc(10px * var(--ui-scale));
+    padding: calc(5px * var(--ui-scale)) calc(10px * var(--ui-scale));
     font: var(--text-tiny-semibold);
     text-align: center;
     transition: all 0.3s;

--- a/public/locales/de/audit.json
+++ b/public/locales/de/audit.json
@@ -116,7 +116,13 @@
         },
         "badges": {
             "title": "Abzeichen",
-            "see-all": "Alle Abzeichen anzeigen"
+            "see-all": "Alle Abzeichen anzeigen",
+            "labeler-goal": "Verdienen Sie Beschrifter-Abzeichen, indem Sie beim Erkunden Barrierefreiheits-Markierungen setzen.",
+            "explorer-goal": "Verdienen Sie Erkunder-Abzeichen, indem Sie auf der Erkunden-Seite Strassen bewerten.",
+            "next-labels_one": "Setzen Sie {{count, number}} Markierung, um das nächste zu erhalten.",
+            "next-labels_other": "Setzen Sie {{count, number}} Markierungen, um das nächste zu erhalten.",
+            "next-distance": "Erkunden Sie {{distance}}, um das nächste zu erhalten.",
+            "earned-all": "Sie haben die höchste Stufe dieses Abzeichens erreicht – großartige Arbeit!"
         },
         "neighborhood-progress": {
             "title": "Fortschritt im Quartier",

--- a/public/locales/en/audit.json
+++ b/public/locales/en/audit.json
@@ -116,7 +116,13 @@
         },
         "badges": {
             "title": "Badges",
-            "see-all": "See all badges"
+            "see-all": "See all badges",
+            "labeler-goal": "Earn Labeler badges by placing accessibility labels as you explore.",
+            "explorer-goal": "Earn Explorer badges by auditing streets on the Explore page.",
+            "next-labels_one": "Place {{count, number}} label to earn the next one.",
+            "next-labels_other": "Place {{count, number}} labels to earn the next one.",
+            "next-distance": "Explore {{distance}} to earn the next one.",
+            "earned-all": "You've reached the highest level for this badge — amazing work!"
         },
         "neighborhood-progress": {
             "title": "Neighborhood progress",

--- a/public/locales/es/audit.json
+++ b/public/locales/es/audit.json
@@ -116,7 +116,13 @@
         },
         "badges": {
             "title": "Insignias",
-            "see-all": "Ver todas las insignias"
+            "see-all": "Ver todas las insignias",
+            "labeler-goal": "Gana insignias de Etiquetador colocando etiquetas de accesibilidad mientras exploras.",
+            "explorer-goal": "Gana insignias de Explorador evaluando calles en la página Explorar.",
+            "next-labels_one": "Coloca {{count, number}} etiqueta para conseguir la siguiente.",
+            "next-labels_other": "Coloca {{count, number}} etiquetas para conseguir la siguiente.",
+            "next-distance": "Explora {{distance}} para conseguir la siguiente.",
+            "earned-all": "¡Has alcanzado el nivel máximo de esta insignia, excelente trabajo!"
         },
         "neighborhood-progress": {
             "title": "Progreso del barrio",

--- a/public/locales/nl/audit.json
+++ b/public/locales/nl/audit.json
@@ -116,7 +116,13 @@
         },
         "badges": {
             "title": "Badges",
-            "see-all": "Alle badges bekijken"
+            "see-all": "Alle badges bekijken",
+            "labeler-goal": "Verdien Labelaar-badges door toegankelijkheidslabels te plaatsen tijdens het verkennen.",
+            "explorer-goal": "Verdien Ontdekker-badges door straten te beoordelen op de Verkennen-pagina.",
+            "next-labels_one": "Plaats {{count, number}} label om de volgende te verdienen.",
+            "next-labels_other": "Plaats {{count, number}} labels om de volgende te verdienen.",
+            "next-distance": "Verken {{distance}} om de volgende te verdienen.",
+            "earned-all": "Je hebt het hoogste niveau van deze badge bereikt — geweldig gedaan!"
         },
         "neighborhood-progress": {
             "title": "Wijk voortgang",

--- a/public/locales/pt-BR/audit.json
+++ b/public/locales/pt-BR/audit.json
@@ -116,7 +116,13 @@
         },
         "badges": {
             "title": "Insígnias",
-            "see-all": "Ver todas as insígnias"
+            "see-all": "Ver todas as insígnias",
+            "labeler-goal": "Ganhe insígnias de Rotulador adicionando rótulos de acessibilidade enquanto explora.",
+            "explorer-goal": "Ganhe insígnias de Explorador avaliando ruas na página Explorar.",
+            "next-labels_one": "Adicione {{count, number}} rótulo para conquistar a próxima.",
+            "next-labels_other": "Adicione {{count, number}} rótulos para conquistar a próxima.",
+            "next-distance": "Explore {{distance}} para conquistar a próxima.",
+            "earned-all": "Você alcançou o nível máximo desta insígnia — excelente trabalho!"
         },
         "neighborhood-progress": {
             "title": "Progresso do bairro",

--- a/public/locales/zh-TW/audit.json
+++ b/public/locales/zh-TW/audit.json
@@ -116,7 +116,12 @@
         },
         "badges": {
             "title": "徽章",
-            "see-all": "查看所有徽章"
+            "see-all": "查看所有徽章",
+            "labeler-goal": "在探索時放置無障礙標記即可獲得標記者徽章。",
+            "explorer-goal": "在探索頁面評估街道即可獲得探索者徽章。",
+            "next-labels_other": "放置 {{count, number}} 個標記即可獲得下一個徽章。",
+            "next-distance": "探索 {{distance}} 即可獲得下一個徽章。",
+            "earned-all": "您已達到此徽章的最高等級 — 做得太棒了！"
         },
         "neighborhood-progress": {
             "title": "鄰里進度",

--- a/public/stylesheets/common/missionStartTutorial.css
+++ b/public/stylesheets/common/missionStartTutorial.css
@@ -328,7 +328,6 @@
     justify-content: center;
     align-items: center;
     font: var(--text-tiny-semibold);
-    line-height: 120%;
     text-align: left;
     border-bottom: calc(3px * var(--ui-scale, 1)) solid var(--color-neutral-200);
     padding: 0 calc(3px * var(--ui-scale, 1));

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -121,9 +121,9 @@
     --text-underline-medium: 500 calc(12px * var(--ui-scale, 1))/calc(18px * var(--ui-scale, 1)) var(--font-primary);
 
     /* Try to avoid using such tiny text!! */
-    --text-tiny-semibold: 600 calc(10px * var(--ui-scale, 1))/calc(18px * var(--ui-scale, 1)) var(--font-primary);
-    --text-tiny-medium:   500 calc(10px * var(--ui-scale, 1))/calc(18px * var(--ui-scale, 1)) var(--font-primary);
-    --text-tiny-regular:  400 calc(10px * var(--ui-scale, 1))/calc(18px * var(--ui-scale, 1)) var(--font-primary);
+    --text-tiny-semibold: 600 calc(10px * var(--ui-scale, 1))/calc(12px * var(--ui-scale, 1)) var(--font-primary);
+    --text-tiny-medium:   500 calc(10px * var(--ui-scale, 1))/calc(12px * var(--ui-scale, 1)) var(--font-primary);
+    --text-tiny-regular:  400 calc(10px * var(--ui-scale, 1))/calc(12px * var(--ui-scale, 1)) var(--font-primary);
 
     /* Other globals. */
     --navbar-height: 38px;

--- a/public/stylesheets/tag-pills.css
+++ b/public/stylesheets/tag-pills.css
@@ -4,7 +4,7 @@
     justify-content: center;
     align-items: center;
     gap: calc(8px * var(--ui-scale, 1));
-    padding: calc(3px * var(--ui-scale, 1)) calc(10px * var(--ui-scale, 1));
+    padding: calc(5px * var(--ui-scale, 1)) calc(10px * var(--ui-scale, 1));
     outline: 1px solid var(--color-neutral-900);
     border: none;
     border-radius: 200px;


### PR DESCRIPTION
Fixes #4258.

## What & why
Hovering a badge in the Explore right sidebar previously just showed a bare, enlarged **translucent** badge image. That gave no explanation of what the badge is or how to get it, and because the image is translucent its expansion visually clashed with whatever was behind it in the panorama (see the screenshot in #4258).

This replaces that hover behavior with a **solid tooltip card** that:
- keeps the zoomed-in, full-color badge,
- adds the badge name (e.g. "Labeler II"), and
- explains the goal plus **what it takes to earn the next one** (e.g. "Place 2,000 labels to earn the next one." / "Explore 5 km to earn the next one."), or a congrats line once the badge is maxed out.

The card has a solid background (DS card styling) so it reads clearly over the pano, and is positioned beside the badge rather than floating over the cursor.

## Accessibility
- Badge icons are now keyboard-focusable (`tabindex="0"`, `role="img"`); the tooltip shows on focus as well as hover.
- The full description is mirrored onto each icon's `aria-label` so screen readers announce it without reading the decorative tooltip.

## i18n
New `right-ui.badges` keys (`labeler-goal`, `explorer-goal`, `next-labels` with plural, `next-distance`, `earned-all`) added and translated for en, de, es, nl, pt-BR, zh-TW. en-US/en-NZ inherit from en. The label count uses i18next's `{{count, number}}` formatter so large totals get locale-aware separators, and pluralization uses i18next's native `_one`/`_other` suffixes.

## Also included
A small typography pass staged alongside this work: tighten the `--text-tiny-*` line-height (18px → 12px) in `main.css` and adjust dependent component padding / drop now-redundant `line-height` overrides (minimap message, validate label-visibility button, validation-menu pills, tag-pills, mission-start tutorial).

## Testing
Verified by visual inspection in Explore (can't browser-test pano interactions). Suggested checks: hover/tab each badge in the right sidebar in a few languages; confirm the solid card no longer clashes with the pano; check a low-progress vs. maxed-out account; toggle metric/imperial.