### PR TITLE
docs(scripts): remove stale "imagery age is a future step" wording

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -86,9 +86,6 @@ from it on purpose, because the two tools answer different questions:
   under the limit; at that bounded concurrency, threads are simpler and sufficient and async's scale benefit is wasted.
 - **Providers — GSV *and* Mapillary.** GSV Tracker is GSV-only.
 
-A natural future step (issue #4347) is to also capture the imagery *capture date* from the same GSV responses — exactly
-the temporal angle GSV Tracker specializes in — to know not just whether a street has imagery but how old it is.
-
 ## Persisting imagery age to the database (#4348)
 
 The `street_imagery` table records, per street, the capture-date range of the panos observed on it (`oldest_capture`,
@@ -102,7 +99,7 @@ column:
   `data_source = 'pano_data'`.
 - **Feeder 2 — the imagery scan (manual).** For streets a scan reached but that have no labels yet (so Feeder 1 can't
   see them), run `make import-street-imagery` to ingest `db/street_imagery_summary.csv` — the per-street summary the
-  scan writes once the imagery-age work (#4347) lands. Rows are tagged `data_source = 'imagery_scan'`, and a scan
+  scan writes. Rows are tagged `data_source = 'imagery_scan'`, and a scan
   supersedes an existing `pano_data` row for the same street (it's a deliberate, fresher measurement).
 
 ## Testing


### PR DESCRIPTION
## What

`scripts/README.md` still described imagery-age capture as **"a natural future step (issue #4347)"** even though #4347 shipped — directly contradicting the **"Imagery age"** and **"Persisting imagery age to the database (#4348)"** sections in the same file that document it as done.

- Remove the leftover "A natural future step (issue #4347)…" paragraph from the *Design lineage* section.
- Drop "once the imagery-age work (#4347) lands" from the `make import-street-imagery` step (it landed).

Docs-only; no code changes. Spotted while addressing review on #4360.

🤖 Generated with [Claude Code](https://claude.com/claude-code)