### PR TITLE
Cross-city engagement funnels on the Across Cities admin page (#288)

### DIFF
--- a/app/actor/FunnelStatActor.scala
+++ b/app/actor/FunnelStatActor.scala
@@ -1,0 +1,71 @@
+package actor
+
+import actor.ActorUtils.{dateFormatter, getTimeToNextUpdate}
+import org.apache.pekko.actor.{Actor, Cancellable, Props}
+import play.api.Logger
+import service.{AdminService, ConfigService}
+
+import java.time.Instant
+import javax.inject._
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+import scala.util.{Failure, Success}
+
+object FunnelStatActor {
+  val Name  = "funnel-stat-actor"
+  def props = Props[FunnelStatActor]()
+  case object Tick
+}
+
+/**
+ * Nightly recompute of this deployment's engagement funnel into the local `funnel_stat` table (#288).
+ *
+ * Mirrors [[UserStatActor]]: each deployment precomputes only its own city's funnel; the cross-city Across Cities page
+ * reads every schema's precomputed table. Scheduled at 3:15 am Pacific plus the per-deployment offset (which staggers
+ * co-hosted cities), in an empty slot between the user-stat (1:30) and clustering (4:00) jobs.
+ *
+ * @param adminService Recompute entry point ([[AdminService.updateFunnelStatTable]]).
+ */
+@Singleton
+class FunnelStatActor @Inject() (adminService: AdminService)(implicit
+    ec: ExecutionContext,
+    configService: ConfigService
+) extends Actor {
+
+  private var cancellable: Option[Cancellable] = None
+  private val logger                           = Logger(this.getClass)
+
+  override def preStart(): Unit = {
+    super.preStart()
+    // Per-city offset staggers computation/resource use across co-hosted deployments.
+    configService.getOffsetHours.foreach { hoursOffset =>
+      // Target time is 3:15 am Pacific + offset.
+      cancellable = Some(
+        context.system.scheduler.scheduleAtFixedRate(
+          getTimeToNextUpdate(3, 15, hoursOffset).toMillis.millis,
+          24.hours,
+          self,
+          FunnelStatActor.Tick
+        )(context.dispatcher)
+      )
+      logger.info("FunnelStatActor created")
+    }
+  }
+
+  override def postStop(): Unit = {
+    cancellable.foreach(_.cancel())
+    cancellable = None
+    super.postStop()
+  }
+
+  def receive: Receive = { case FunnelStatActor.Tick =>
+    val currentTimeStart: String = dateFormatter.format(Instant.now())
+    logger.info(s"Auto-scheduled computation of engagement funnel starting at: $currentTimeStart")
+    adminService.updateFunnelStatTable().onComplete {
+      case Success(nRows) =>
+        val currentEndTime: String = dateFormatter.format(Instant.now())
+        logger.info(s"Funnel stats updated ($nRows rows) completed at: $currentEndTime")
+      case Failure(e) => logger.error(s"Error updating funnel stats: ${e.getMessage}")
+    }
+  }
+}

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -551,6 +551,15 @@ class AdminController @Inject() (
   }
 
   /**
+   * Forces an immediate recompute of this deployment's engagement funnel (#288) into `funnel_stat` — the same work the
+   * nightly FunnelStatActor does. Handy after a deploy so the Across Cities page shows this city without waiting a day.
+   */
+  def updateFunnelStats = cc.securityService.SecuredAction(WithAdmin()) { implicit request =>
+    cc.loggingService.insert(request.identity.userId, request.ipAddress, request.toString)
+    adminService.updateFunnelStatTable().map { rowsUpdated => Ok(s"Funnel stats updated ($rowsUpdated rows)!") }
+  }
+
+  /**
    * Updates a single flag for a single audit task specified by the audit task id.
    */
   def setTaskFlag() = cc.securityService.SecuredAction(WithAdmin(), parse.json) { implicit request =>
@@ -1021,6 +1030,54 @@ class AdminController @Inject() (
           )
         )
       )
+    }
+  }
+
+  /**
+   * Returns every available city's precomputed engagement funnel for one time window (#288), for the Across Cities
+   * page's funnel comparison. Owner-only (cross-deployment data). Output is snake_case per the v3 convention; the
+   * `steps` array names the eight funnel steps in order so the client never hardcodes them.
+   *
+   * @param window "30d", "90d", or "all"; anything else (or absent) falls back to "30d".
+   */
+  def getCityFunnels(window: Option[String]) = cc.securityService.SecuredAction(WithOwner()) { implicit request =>
+    cc.loggingService.insert(request.identity.userId, request.ipAddress, request.toString)
+    // Only these three windows are precomputed in funnel_stat; reject anything else rather than 500 on a cache miss.
+    val windowKey                           = window.filter(Set("30d", "90d", "all")).getOrElse("30d")
+    val cityInfoById: Map[String, CityInfo] =
+      configService.getAllCityInfo(request2Messages.lang).map(ci => ci.cityId -> ci).toMap
+
+    configService.getCityFunnels(windowKey).map { funnelsByType =>
+      def segJson(seg: FunnelSegment): JsObject = Json.obj(
+        "steps"              -> seg.steps,
+        "step_conversion"    -> ConfigService.stepConversion(seg.steps),
+        "overall_conversion" -> ConfigService.overallConversion(seg.steps)
+      )
+      def cityJson(f: CityFunnel): JsObject = {
+        val info = cityInfoById.get(f.cityId)
+        Json.obj(
+          "city_id"             -> f.cityId,
+          "city_name"           -> info.map(_.cityNameShort),
+          "city_name_formatted" -> info.map(_.cityNameFormatted),
+          "url"                 -> info.map(_.URL),
+          "visibility"          -> info.map(_.visibility),
+          "all"                 -> segJson(f.all),
+          "registered"          -> segJson(f.registered),
+          "anonymous"           -> segJson(f.anonymous),
+          "desktop"             -> segJson(f.desktop),
+          "mobile"              -> segJson(f.mobile),
+          "device_unknown"      -> segJson(f.deviceUnknown)
+        )
+      }
+      // One entry per funnel type ("mapping", "contribution"), each with its own step list and per-city rows. `steps`
+      // names the steps in order so the client never hardcodes them.
+      val funnels = JsObject(ConfigService.FunnelDefs.map { case (funnelType, stepKeys) =>
+        funnelType -> Json.obj(
+          "steps"  -> stepKeys,
+          "cities" -> JsArray(funnelsByType.getOrElse(funnelType, Seq.empty).map(cityJson))
+        )
+      })
+      Ok(Json.obj("window" -> windowKey, "funnels" -> funnels))
     }
   }
 

--- a/app/models/utils/ConfigTable.scala
+++ b/app/models/utils/ConfigTable.scala
@@ -79,6 +79,21 @@ class ConfigTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvi
 
   val config = TableQuery[ConfigTableDef]
 
+  /**
+   * Runs `action` in a transaction with JIT disabled for the duration of that transaction.
+   *
+   * Interim workaround for #4376: the projectsidewalk/db image ships a broken Postgres JIT (PostGIS bitcode built with
+   * LLVM 16, runtime llvmjit linked against LLVM 11). An expensive query that JIT-inlines PostGIS function bitcode
+   * (ST_TRANSFORM/ST_LENGTH) segfaults the backend, surfacing as a dropped connection (SQLSTATE 08006). The cross-city
+   * scorecard and labeling-speed queries cross the JIT cost thresholds and call those functions, so they trip it.
+   * `SET LOCAL` scopes the setting to this one transaction. Remove once #4376 disables JIT at the DB config level.
+   *
+   * @param action The DBIO to run with JIT off.
+   * @return       The same action, wrapped so JIT is disabled for its transaction.
+   */
+  private def withJitOff[T](action: DBIO[T]): DBIO[T] =
+    (sqlu"SET LOCAL jit = off" >> action).transactionally
+
   def getCityMapParams: DBIO[MapParams] = {
     config.result.head.map(_.cityMapParams)
   }
@@ -499,8 +514,9 @@ class ConfigTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvi
 
     // Fold in the per-label-type breakdown, the weekly trend, and the (cheap) per-user output/speed stats (same
     // connection), then assemble the full scorecard. The expensive labeling-speed query is NOT here — it is computed on
-    // a separate long-cached path (getCrossCityLabelingSpeed).
-    for {
+    // a separate long-cached path (getCrossCityLabelingSpeed). Wrapped in withJitOff because coreQuery's km calc uses
+    // PostGIS (#4376).
+    withJitOff(for {
       core        <- coreQuery
       byLabelType <- getLabelTypeStatsBySchema(schema)
       weeklyTrend <- getCityWeeklyTrendBySchema(schema, Some(ScorecardTrendWeeks))
@@ -544,7 +560,7 @@ class ConfigTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvi
         numValidators = nValidators,
         validationSecondsMedian = valSecMedian
       )
-    }
+    })
   }
 
   /**
@@ -670,7 +686,8 @@ class ConfigTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvi
   def getCityLabelingSpeedBySchema(schema: String): DBIO[(Double, Double)] = {
     implicit val getResult: GetResult[(Double, Double)] = GetResult(r => (r.nextDouble(), r.nextDouble()))
 
-    sql"""
+    // Wrapped in withJitOff because the audited-km subquery uses PostGIS (#4376).
+    withJitOff(sql"""
       SELECT COALESCE(audit_time.hours, 0) AS hours,
              COALESCE(audited.km, 0)       AS km
       FROM (
@@ -688,7 +705,7 @@ class ConfigTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvi
           INNER JOIN "#$schema".user_stat ON audit_task.user_id = user_stat.user_id
           WHERE completed = TRUE AND NOT user_stat.excluded AND street_edge.deleted = FALSE
       ) AS audited;
-    """.as[(Double, Double)].head
+    """.as[(Double, Double)].head)
   }
 
   def getTutorialStreetId: DBIO[Int] = {

--- a/app/models/utils/FunnelStatTable.scala
+++ b/app/models/utils/FunnelStatTable.scala
@@ -1,0 +1,263 @@
+package models.utils
+
+import models.utils.MyPostgresProfile.api._
+import play.api.db.slick.{DatabaseConfigProvider, HasDatabaseConfigProvider}
+import slick.jdbc.GetResult
+
+import java.time.{OffsetDateTime, ZoneOffset}
+import javax.inject._
+import scala.concurrent.ExecutionContext
+
+/**
+ * One precomputed funnel row: the (up to six) monotonic step counts for a single funnel type, window, and segment (#288).
+ *
+ * @param funnelType "mapping" (6 steps) or "contribution" (3 steps; step4..6 are 0).
+ * @param window     The funnel time window: "30d", "90d", or "all".
+ * @param segment    The population slice: "all", "role:registered", "role:anon", "device:desktop", "device:mobile",
+ *                   or "device:unknown".
+ * @param steps      Six funnel counts (distinct users reaching each step), index 0 = step 1; trailing entries are 0 for
+ *                   funnels with fewer than six steps.
+ * @param computedAt When this row was last recomputed (for the page's "data as of" freshness label).
+ */
+case class FunnelStat(funnelType: String, window: String, segment: String, steps: Seq[Int], computedAt: OffsetDateTime)
+
+/**
+ * The raw per-segment output of a funnel computation, before it is stamped with a funnel type, window, and recompute
+ * time (#288).
+ *
+ * @param segment One of the segment keys (see [[FunnelStat]]).
+ * @param steps   The monotonic step counts for that segment (length matches the funnel's step count).
+ */
+case class FunnelSegmentCounts(segment: String, steps: Seq[Int])
+
+class FunnelStatTableDef(tag: Tag) extends Table[FunnelStat](tag, "funnel_stat") {
+  def funnelType: Rep[String]         = column[String]("funnel_type")
+  def timeWindow: Rep[String]         = column[String]("time_window")
+  def segment: Rep[String]            = column[String]("segment")
+  def step1: Rep[Int]                 = column[Int]("step1")
+  def step2: Rep[Int]                 = column[Int]("step2")
+  def step3: Rep[Int]                 = column[Int]("step3")
+  def step4: Rep[Int]                 = column[Int]("step4")
+  def step5: Rep[Int]                 = column[Int]("step5")
+  def step6: Rep[Int]                 = column[Int]("step6")
+  def computedAt: Rep[OffsetDateTime] = column[OffsetDateTime]("computed_at")
+
+  // steps is a fixed six-slot Seq, so the projection maps the six step columns to/from it explicitly.
+  override def * = (funnelType, timeWindow, segment, step1, step2, step3, step4, step5, step6, computedAt) <> (
+    { case (funnelType, window, segment, s1, s2, s3, s4, s5, s6, computedAt) =>
+      FunnelStat(funnelType, window, segment, Seq(s1, s2, s3, s4, s5, s6), computedAt)
+    },
+    (f: FunnelStat) => {
+      val s = f.steps.padTo(6, 0) // contribution funnel has 3 steps; pad the unused slots with 0.
+      Some((f.funnelType, f.window, f.segment, s(0), s(1), s(2), s(3), s(4), s(5), f.computedAt))
+    }
+  )
+}
+
+/**
+ * DAO for the per-deployment precomputed engagement funnels (#288): a "mapping" funnel (the Explore onboarding flow)
+ * and a "contribution" funnel (any labeling-or-validation contribution).
+ *
+ * The funnels are too heavy to compute live across every city schema on each Across Cities page load (they scan the
+ * large `webpage_activity` log), so each deployment recomputes ITS OWN funnels nightly into the local `funnel_stat`
+ * table (mirroring the user_stat precompute), and the cross-city page reads each schema's tiny precomputed table
+ * cheaply. Hence the split: [[computeMappingFunnelBySchema]] / [[computeContributionFunnelBySchema]] + [[replaceAll]]
+ * write the local table; [[getFunnelStatsBySchema]] reads any schema's precomputed table.
+ */
+@Singleton
+class FunnelStatTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvider)(implicit ec: ExecutionContext)
+    extends HasDatabaseConfigProvider[MyPostgresProfile] {
+
+  private val funnelStats = TableQuery[FunnelStatTableDef]
+
+  /**
+   * Replaces the entire local `funnel_stat` table with a fresh set of rows, transactionally (#288).
+   *
+   * The table is tiny (<= 36 rows) and recomputed wholesale, so a delete-then-insert is simpler and safer than an
+   * upsert and avoids leaving stale (funnel_type, window, segment) combinations behind.
+   *
+   * @param stats The full set of rows to persist.
+   * @return      The number of rows written.
+   */
+  def replaceAll(stats: Seq[FunnelStat]): DBIO[Int] = {
+    (for {
+      _ <- funnelStats.delete
+      _ <- funnelStats ++= stats
+    } yield stats.size).transactionally
+  }
+
+  /**
+   * Reads one window's precomputed funnel rows (all funnel types) from an arbitrary city schema (#288).
+   *
+   * Used by the cross-city Across Cities page, which reads every available schema's `funnel_stat`. The schema name is
+   * interpolated (it comes from trusted config, not user input); the window is a bound parameter.
+   *
+   * @param schema The database schema to read from.
+   * @param window The funnel window key ("30d", "90d", or "all").
+   * @return       The rows for that window across all funnel types; empty if the schema has no funnel_stat yet.
+   */
+  def getFunnelStatsBySchema(schema: String, window: String): DBIO[Seq[FunnelStat]] = {
+    implicit val getResult: GetResult[FunnelStat] = GetResult { r =>
+      FunnelStat(
+        r.nextString(),
+        r.nextString(),
+        r.nextString(),
+        Seq(r.nextInt(), r.nextInt(), r.nextInt(), r.nextInt(), r.nextInt(), r.nextInt()),
+        r.nextTimestamp().toInstant.atOffset(ZoneOffset.UTC)
+      )
+    }
+    sql"""SELECT funnel_type, time_window, segment, step1, step2, step3, step4, step5, step6, computed_at
+          FROM "#$schema".funnel_stat
+          WHERE time_window = $window""".as[FunnelStat]
+  }
+
+  /**
+   * The Explore/mapping funnel for a city schema (#288): visited, started the tutorial, finished OR skipped the
+   * tutorial (skipping sets completed = true), took a step (walked some distance in a real audit mission via
+   * `distance_progress`), placed a real label, completed an audit mission. Validation is deliberately excluded — it is
+   * a separate activity and belongs to the contribution funnel. The redundant "clicked Start Mapping" and "started a
+   * mission" signals are omitted because they duplicate the tutorial-start and tutorial-finish steps (the missions are
+   * auto-created).
+   *
+   * @param schema     The database schema to compute over.
+   * @param windowDays The trailing window in days, or None for all-time.
+   * @return           One [[FunnelSegmentCounts]] (6 steps) per non-empty segment.
+   */
+  def computeMappingFunnelBySchema(schema: String, windowDays: Option[Int]): DBIO[Seq[FunnelSegmentCounts]] = {
+    val b      = bounds(windowDays)
+    val events =
+      s"""
+        SELECT user_id, 1 AS step FROM "$schema".webpage_activity
+            WHERE activity IN ('Visit_Index', 'Visit_MobileLanding') ${b.wa}
+        UNION ALL
+        SELECT user_id, 2 AS step FROM "$schema".mission WHERE mission_type_id = 1 ${b.mStart}
+        UNION ALL
+        SELECT user_id, 3 AS step FROM "$schema".mission WHERE mission_type_id = 1 AND completed = TRUE ${b.mEnd}
+        UNION ALL
+        SELECT user_id, 4 AS step FROM "$schema".mission
+            WHERE mission_type_id = 2 AND COALESCE(distance_progress, 0) > 0 ${b.mStart}
+        UNION ALL
+        SELECT user_id, 5 AS step FROM "$schema".label WHERE deleted = FALSE AND tutorial = FALSE ${b.label}
+        UNION ALL
+        SELECT user_id, 6 AS step FROM "$schema".mission WHERE mission_type_id = 2 AND completed = TRUE ${b.mEnd}
+      """
+    computeFunnel(schema, events, numSteps = 6)
+  }
+
+  /**
+   * The contribution funnel for a city schema (#288): visited, contributed (placed at least one real label OR cast at
+   * least one validation), completed a labeling (type 2) or validation (type 4) mission. This is the broad "did they
+   * contribute anything and finish something" view, complementing the mapping funnel.
+   *
+   * @param schema     The database schema to compute over.
+   * @param windowDays The trailing window in days, or None for all-time.
+   * @return           One [[FunnelSegmentCounts]] (3 steps) per non-empty segment.
+   */
+  def computeContributionFunnelBySchema(schema: String, windowDays: Option[Int]): DBIO[Seq[FunnelSegmentCounts]] = {
+    val b      = bounds(windowDays)
+    val events =
+      s"""
+        SELECT user_id, 1 AS step FROM "$schema".webpage_activity
+            WHERE activity IN ('Visit_Index', 'Visit_MobileLanding') ${b.wa}
+        UNION ALL
+        SELECT user_id, 2 AS step FROM "$schema".label WHERE deleted = FALSE AND tutorial = FALSE ${b.label}
+        UNION ALL
+        SELECT user_id, 2 AS step FROM "$schema".label_validation WHERE TRUE ${b.validation}
+        UNION ALL
+        SELECT user_id, 3 AS step FROM "$schema".mission
+            WHERE mission_type_id IN (2, 4) AND completed = TRUE ${b.mEnd}
+      """
+    computeFunnel(schema, events, numSteps = 3)
+  }
+
+  /** Per-source window-bound SQL fragments (empty for all-time). windowDays is an Int, so it is safe to interpolate. */
+  private case class Bounds(wa: String, mStart: String, mEnd: String, label: String, validation: String)
+  private def bounds(windowDays: Option[Int]): Bounds = {
+    def bound(col: String): String =
+      windowDays.map(d => s"AND $col >= NOW() - ($d * INTERVAL '1 day')").getOrElse("")
+    Bounds(
+      wa = bound("webpage_activity.timestamp"), mStart = bound("mission.mission_start"),
+      mEnd = bound("mission.mission_end"), label = bound("label.time_created"),
+      validation = bound("label_validation.end_timestamp")
+    )
+  }
+
+  /**
+   * Runs a funnel: from a per-step `events` body (each row is a (user_id, step) for a step the user reached), reduce to
+   * each user's DEEPEST step, classify role and device, then count per segment with `COUNT(*) FILTER (WHERE deepest >=
+   * k)`. The max-reached-step method guarantees a monotonic, nested funnel even though the source events are not
+   * naturally nested. Device is all-time (a user attribute), not windowed. The AI user is excluded; anonymous users are
+   * a real per-cookie population, kept and counted. The schema and events body are trusted (config + code), so they are
+   * spliced in literally.
+   *
+   * @param schema   The database schema (already validated as a configured city schema).
+   * @param events   The UNION ALL body producing (user_id, step) rows.
+   * @param numSteps How many step columns to aggregate (6 for mapping, 3 for contribution).
+   * @return         One [[FunnelSegmentCounts]] per non-empty segment.
+   */
+  private def computeFunnel(schema: String, events: String, numSteps: Int): DBIO[Seq[FunnelSegmentCounts]] = {
+    implicit val getResult: GetResult[FunnelSegmentCounts] =
+      GetResult(r => FunnelSegmentCounts(r.nextString(), Vector.fill(numSteps)(r.nextInt())))
+    val filterCols =
+      (1 to numSteps).map(k => s"COUNT(*) FILTER (WHERE deepest >= $k) AS s$k").mkString(",\n             ")
+    val query =
+      s"""
+        WITH events AS ( $events ),
+        device AS (
+            SELECT DISTINCT ON (user_id) user_id, dev
+            FROM (
+                SELECT mission.user_id AS user_id,
+                       CASE WHEN audit_task_environment.operating_system ~* 'android|iphone|ipad|ios|mobile'
+                                 OR COALESCE(audit_task_environment.screen_width, audit_task_environment.browser_width) < 768
+                                THEN 'mobile'
+                            WHEN audit_task_environment.operating_system IS NOT NULL
+                                 OR audit_task_environment.screen_width IS NOT NULL
+                                 OR audit_task_environment.browser_width IS NOT NULL
+                                THEN 'desktop'
+                            ELSE NULL END AS dev,
+                       2 AS prio
+                FROM "$schema".audit_task_environment
+                INNER JOIN "$schema".mission ON audit_task_environment.mission_id = mission.mission_id
+                UNION ALL
+                SELECT user_id,
+                       CASE WHEN activity = 'Visit_MobileLanding' THEN 'mobile'
+                            WHEN activity = 'Visit_Index' THEN 'desktop'
+                            ELSE NULL END AS dev,
+                       1 AS prio
+                FROM "$schema".webpage_activity
+                WHERE activity IN ('Visit_Index', 'Visit_MobileLanding')
+            ) hints
+            WHERE dev IS NOT NULL
+            ORDER BY user_id, prio DESC, (dev = 'desktop') DESC
+        ),
+        per_user AS (
+            SELECT events.user_id,
+                   MAX(events.step) AS deepest,
+                   CASE WHEN bool_or(role.role = 'Anonymous') THEN 'anon' ELSE 'registered' END AS role_class,
+                   COALESCE(MAX(device.dev), 'unknown') AS device_class
+            FROM events
+            LEFT JOIN sidewalk_login.user_role ON events.user_id = user_role.user_id
+            LEFT JOIN sidewalk_login.role ON user_role.role_id = role.role_id
+            LEFT JOIN device ON device.user_id = events.user_id
+            WHERE role.role IS DISTINCT FROM 'AI'
+            GROUP BY events.user_id
+            -- A funnel starts at step 1: only count users who actually have the step-1 (visit) event. Without this, a
+            -- user with downstream activity but no logged visit (e.g. an auto-created tutorial mission) would be counted
+            -- in step 1 via deepest >= 1, inflating "visited" and making it differ between funnels that draw from
+            -- different downstream tables. Anchoring on step 1 makes step 1 = distinct visitors, identical across funnels
+            -- and a true superset of every later step (#288).
+            HAVING bool_or(events.step = 1)
+        ),
+        segmented AS (
+            SELECT deepest, 'all' AS segment FROM per_user
+            UNION ALL SELECT deepest, 'role:' || role_class FROM per_user
+            UNION ALL SELECT deepest, 'device:' || device_class FROM per_user
+        )
+        SELECT segment,
+               $filterCols
+        FROM segmented
+        GROUP BY segment
+      """
+    sql"""#$query""".as[FunnelSegmentCounts]
+  }
+}

--- a/app/modules/ActorModule.scala
+++ b/app/modules/ActorModule.scala
@@ -9,6 +9,7 @@ class ActorModule extends AbstractModule with PekkoGuiceSupport {
     bindActor[CheckImageExpiryActor]("check-image-expiry-actor")
     bindActor[GetAiValidationsActor]("get-ai-validations-actor")
     bindActor[UserStatActor]("user-stats-actor")
+    bindActor[FunnelStatActor]("funnel-stat-actor")
     bindActor[RecalculateStreetPriorityActor]("recalculate-street-priority-actor")
     bindActor[AuthTokenCleanerActor]("auth-token-cleaner-actor")
     bindActor[ClusteringActor]("clustering-actor")

--- a/app/service/AdminService.scala
+++ b/app/service/AdminService.scala
@@ -18,6 +18,8 @@ import models.utils.{
   ApiFormatCount,
   ApiFormatSourceCount,
   ApiSourceIpCount,
+  FunnelStat,
+  FunnelStatTable,
   MyPostgresProfile,
   WebpageActivityTable
 }
@@ -316,6 +318,16 @@ trait AdminService {
   def getUserStatsForAdminPage: Future[Seq[UserStatsForAdminPage]]
   def streetDistanceCompletionRateByDate: Future[Seq[(OffsetDateTime, Double)]]
   def updateUserStatTable(cutoffTime: OffsetDateTime): Future[Int]
+
+  /**
+   * Recomputes this deployment's engagement funnels (#288) for all three windows and replaces the local `funnel_stat`.
+   *
+   * Each deployment precomputes only its own city's funnels; the cross-city Across Cities page reads every schema's
+   * `funnel_stat`. Runs nightly via `FunnelStatActor` and on demand via `/adminapi/updateFunnelStats`.
+   *
+   * @return The number of rows written to `funnel_stat`.
+   */
+  def updateFunnelStatTable(): Future[Int]
   def getApiAnalytics(
       excludeApiDocs: Boolean,
       days: Int
@@ -342,6 +354,8 @@ class AdminServiceImpl @Inject() (
     userTeamTable: UserTeamTable,
     webpageActivityTable: WebpageActivityTable,
     teamTable: TeamTable,
+    funnelStatTable: FunnelStatTable,
+    configService: ConfigService,
     implicit val ec: ExecutionContext,
     cpuEc: CpuIntensiveExecutionContext
 ) extends AdminService
@@ -1059,6 +1073,28 @@ class AdminServiceImpl @Inject() (
         rowsUpdated <- userStatTable.updateHighQuality(cutoffTime)
       } yield rowsUpdated
     )
+  }
+
+  // The three funnel windows the page offers, as (stored key, trailing days); None days = all-time. Kept here next to
+  // the recompute so the precomputed set and the read path (ConfigService.getCityFunnels) agree on the window keys.
+  private val funnelWindows: Seq[(String, Option[Int])] = Seq("30d" -> Some(30), "90d" -> Some(90), "all" -> None)
+
+  def updateFunnelStatTable(): Future[Int] = {
+    val schema     = configService.getCitySchema(configService.getCityId)
+    val computedAt = OffsetDateTime.now()
+    // For each window, compute both the mapping and contribution funnels, tagging each row with its funnel type.
+    val perWindow: Seq[DBIO[Seq[FunnelStat]]] = funnelWindows.map { case (windowKey, windowDays) =>
+      for {
+        mapping <- funnelStatTable.computeMappingFunnelBySchema(schema, windowDays)
+        contrib <- funnelStatTable.computeContributionFunnelBySchema(schema, windowDays)
+      } yield {
+        mapping.map(seg => FunnelStat("mapping", windowKey, seg.segment, seg.steps, computedAt)) ++
+          contrib.map(seg => FunnelStat("contribution", windowKey, seg.segment, seg.steps, computedAt))
+      }
+    }
+    // Compute all windows, then atomically replace the table. replaceAll is itself transactional, so the reads plus the
+    // wholesale swap are all the consistency this precompute needs.
+    db.run(DBIO.sequence(perWindow).flatMap(rows => funnelStatTable.replaceAll(rows.flatten)))
   }
 
   /**

--- a/app/service/ConfigService.scala
+++ b/app/service/ConfigService.scala
@@ -203,6 +203,38 @@ case class CityScorecard(
 case class CityScorecardWithFlags(scorecard: CityScorecard, anomalies: Seq[String])
 
 /**
+ * One demographic slice of a city's engagement funnel: the eight monotonic step counts for that slice (#288).
+ *
+ * @param steps Distinct users reaching each step, index 0 = step 1 (see [[ConfigService.FunnelDefs]]), non-increasing.
+ */
+case class FunnelSegment(steps: Seq[Int])
+
+/**
+ * One city's engagement funnel for a single time window, split by the dimensions the Across Cities page toggles (#288).
+ *
+ * The `all` segment is the whole (human, non-AI) population; the role and device segments partition it two different
+ * ways. Device is only reliably known once a user enters the (desktop-only) audit tool, so `deviceUnknown` collects
+ * everyone whose device could not be determined — see the page's caveat.
+ *
+ * @param cityId        The city id (e.g. "seattle-wa").
+ * @param all           The funnel for every counted user.
+ * @param registered    Users with a non-anonymous role.
+ * @param anonymous     Users with the Anonymous role (a per-cookie identity, not necessarily a unique person).
+ * @param desktop       Users classified as desktop.
+ * @param mobile        Users classified as mobile.
+ * @param deviceUnknown Users whose device could not be determined.
+ */
+case class CityFunnel(
+    cityId: String,
+    all: FunnelSegment,
+    registered: FunnelSegment,
+    anonymous: FunnelSegment,
+    desktop: FunnelSegment,
+    mobile: FunnelSegment,
+    deviceUnknown: FunnelSegment
+)
+
+/**
  * Lifecycle thresholds, the data-quality anomaly thresholds, and the (pure) classification helpers for the cross-city
  * overview (#4329).
  *
@@ -274,6 +306,52 @@ object ConfigService {
     else if (rates.length % 2 == 1) rates(rates.length / 2)
     else (rates(rates.length / 2 - 1) + rates(rates.length / 2)) / 2.0
   }
+
+  /**
+   * The step keys for each engagement funnel (#288), in order. This is the source of truth for step identity and
+   * count; the API echoes the relevant list to the client so the frontend never hardcodes its own copy.
+   *   - "mapping":      the Explore onboarding flow (6 steps).
+   *   - "contribution": any labeling-or-validation contribution (3 steps).
+   * The iteration order here is the order the funnels are presented on the page.
+   */
+  val FunnelDefs: Seq[(String, Seq[String])] = Seq(
+    "mapping" -> Seq("visited", "tutorial_started", "tutorial_finished", "took_step", "labeled", "mission_completed"),
+    "contribution" -> Seq("visited", "contributed", "contribution_completed")
+  )
+
+  /** Step keys for one funnel type. */
+  def funnelStepKeys(funnelType: String): Seq[String] = FunnelDefs.toMap.getOrElse(funnelType, Seq.empty)
+
+  /** The longest funnel's step count (the mapping funnel), derived from [[FunnelDefs]] rather than hardcoded. */
+  val MaxFunnelSteps: Int = FunnelDefs.map(_._2.length).max
+
+  /** An all-zero funnel of the maximum length — the empty/identity input for the conversion helpers. */
+  val ZeroFunnelSteps: Seq[Int] = Seq.fill(MaxFunnelSteps)(0)
+
+  /**
+   * Step-over-step conversion for a funnel: `stepConversion(i)` = `steps(i) / steps(i-1)` (#288).
+   *
+   * The first element is 1.0 (the entry step converts from itself). A ratio is 0.0 when the previous step had no users
+   * (avoids divide-by-zero).
+   *
+   * @param steps The eight monotonic step counts.
+   * @return      One conversion ratio per step, same length as `steps`.
+   */
+  def stepConversion(steps: Seq[Int]): Seq[Double] = steps.zipWithIndex.map {
+    case (_, 0)     => 1.0
+    case (count, i) =>
+      val prev = steps(i - 1)
+      if (prev > 0) count.toDouble / prev else 0.0
+  }
+
+  /**
+   * Overall funnel conversion: last step / first step (#288).
+   *
+   * @param steps The eight monotonic step counts.
+   * @return      Fraction of entrants who reached the final step; 0.0 when there were no entrants.
+   */
+  def overallConversion(steps: Seq[Int]): Double =
+    if (steps.nonEmpty && steps.head > 0) steps.last.toDouble / steps.head else 0.0
 }
 
 @ImplementedBy(classOf[ConfigServiceImpl])
@@ -312,6 +390,19 @@ trait ConfigService {
    * @return A Future of cityId → seconds per 100 m (lower is faster).
    */
   def getCrossCityLabelingSpeed(): Future[Map[String, Double]]
+
+  /**
+   * Returns each available city's precomputed engagement funnels for a time window (#288).
+   *
+   * Reads each schema's nightly-precomputed `funnel_stat` table (cheap) and assembles one [[CityFunnel]] per city,
+   * using the same available-schema fan-out as [[getCityScorecards]]. Cities whose deployment has not yet created or
+   * populated `funnel_stat` are omitted (they appear once their nightly job has run). Segments absent from a city's
+   * rows (e.g. no mobile users) are zero-filled.
+   *
+   * @param window The funnel window key: "30d", "90d", or "all".
+   * @return       Per funnel type ("mapping", "contribution"), one [[CityFunnel]] per available city with funnel data.
+   */
+  def getCityFunnels(window: String): Future[Map[String, Seq[CityFunnel]]]
 
   /**
    * Maps a city ID to its corresponding database user/schema.
@@ -388,6 +479,7 @@ class ConfigServiceImpl @Inject() (
     cacheApi: AsyncCacheApi,
     ws: WSClient,
     configTable: ConfigTable,
+    funnelStatTable: FunnelStatTable,
     versionTable: VersionTable,
     panoDataService: PanoDataService
 )(implicit val ec: ExecutionContext)
@@ -663,6 +755,58 @@ class ConfigServiceImpl @Inject() (
         Future.sequence(perCityFutures).map(_.flatten.toMap)
       }
     }
+  }
+
+  def getCityFunnels(window: String): Future[Map[String, Seq[CityFunnel]]] = {
+    // Reads the precomputed funnel_stat per schema, so it is cheap; the short cache just coalesces bursts of requests.
+    cacheApi.getOrElseUpdate[Map[String, Seq[CityFunnel]]](s"getCityFunnels_$window", Duration(10, "minutes")) {
+      val configuredCityIds = config.get[Seq[String]]("city-params.city-ids").filter(_ != "staging")
+
+      val schemaExistenceChecks: Seq[Future[(String, Boolean)]] = configuredCityIds.map { cityId =>
+        try {
+          checkSchemaExists(getCitySchema(cityId)).map(cityId -> _).recover { case _ => cityId -> false }
+        } catch {
+          case _: Exception => Future.successful(cityId -> false)
+        }
+      }
+
+      Future.sequence(schemaExistenceChecks).flatMap { schemaResults =>
+        val availableCities = schemaResults.filter(_._2).map(_._1)
+        // Each city's rows cover all funnel types for this window; None ⇒ no funnel_stat yet, so omit the city.
+        val perCityFutures: Seq[Future[Option[(String, Seq[FunnelStat])]]] = availableCities.map { cityId =>
+          db.run(funnelStatTable.getFunnelStatsBySchema(getCitySchema(cityId), window))
+            .map(rows => if (rows.isEmpty) None else Some(cityId -> rows))
+            .recover { case e: Exception =>
+              logger.warn(s"Failed to read funnel for city $cityId (window $window): ${e.getMessage}")
+              None
+            }
+        }
+        Future.sequence(perCityFutures).map { results =>
+          val citiesWithRows = results.flatten
+          // Group into funnelType -> one CityFunnel per city, in the page's funnel order.
+          ConfigService.FunnelDefs.map { case (funnelType, _) =>
+            funnelType -> citiesWithRows.map { case (cityId, rows) =>
+              assembleCityFunnel(cityId, funnelType, rows.filter(_.funnelType == funnelType))
+            }
+          }.toMap
+        }
+      }
+    }
+  }
+
+  /**
+   * Builds a [[CityFunnel]] for one funnel type from a city's precomputed `funnel_stat` rows, zero-filling any segment
+   * that has no row (e.g. a city with no mobile or no anonymous users) and trimming the stored six-slot steps to the
+   * funnel's actual step count (#288).
+   */
+  private def assembleCityFunnel(cityId: String, funnelType: String, rowsOfType: Seq[FunnelStat]): CityFunnel = {
+    val numSteps                              = ConfigService.funnelStepKeys(funnelType).length
+    val stepsBySegment: Map[String, Seq[Int]] = rowsOfType.map(r => r.segment -> r.steps.take(numSteps)).toMap
+    def seg(key: String): FunnelSegment       = FunnelSegment(stepsBySegment.getOrElse(key, Seq.fill(numSteps)(0)))
+    CityFunnel(
+      cityId = cityId, all = seg("all"), registered = seg("role:registered"), anonymous = seg("role:anon"),
+      desktop = seg("device:desktop"), mobile = seg("device:mobile"), deviceUnknown = seg("device:unknown")
+    )
   }
 
   /**

--- a/app/views/admin/dashboard/acrossCities.scala.html
+++ b/app/views/admin/dashboard/acrossCities.scala.html
@@ -151,6 +151,34 @@
         </div>
     </div>
 
+    <div class="api-section" id="ac-funnel-section">
+        <h2 class="api-heading" id="funnel">Engagement funnels <a href="#funnel" class="permalink">#</a></h2>
+        <p>Of the people who arrive, how many make it through each step, for each city. Two funnels: the
+            <strong>mapping</strong> funnel follows the Explore onboarding (tutorial → first label → first mission), and
+            the <strong>contribution</strong> funnel is the broader “did they contribute anything (labeling or
+            validation) and finish a mission”. Bars are normalized to visitors (= 100%); the percentage on each step is
+            its share of the step before it (the drop-off).</p>
+        <p class="ac-note">Two caveats. <strong>Anonymous visitors are counted per browser</strong> (a new id each time
+            cookies are cleared), so the top of each funnel counts sessions, not unique people, and headline conversion
+            reads low. <strong>The mapping tool is desktop-only</strong> — mobile visitors are redirected to a landing
+            page and can't proceed, so in the “Desktop vs mobile” view mobile drops off early by design. In the mapping
+            funnel, “took a step” means a user walked some distance in a real (non-tutorial) mission.</p>
+        <div class="ac-funnel-controls">
+            <div class="ac-toggle" id="ac-funnel-window" role="group" aria-label="Funnel time window">
+                <button type="button" class="ac-toggle-btn active" data-window="30d">Last 30 days</button>
+                <button type="button" class="ac-toggle-btn" data-window="90d">Last 90 days</button>
+                <button type="button" class="ac-toggle-btn" data-window="all">All time</button>
+            </div>
+            <div class="ac-toggle" id="ac-funnel-dim" role="group" aria-label="Funnel breakdown">
+                <button type="button" class="ac-toggle-btn active" data-dim="all">All users</button>
+                <button type="button" class="ac-toggle-btn" data-dim="role">Registered vs anonymous</button>
+                <button type="button" class="ac-toggle-btn" data-dim="device">Desktop vs mobile</button>
+            </div>
+        </div>
+        <div id="ac-funnels"></div>
+        <div class="coverage-status" id="ac-funnel-status" role="status" aria-live="polite"></div>
+    </div>
+
     <div class="api-section" id="ac-effort-section">
         <h2 class="api-heading" id="effort">Contributors &amp; effort <a href="#effort" class="permalink">#</a></h2>
         <p>How much each contributor produces and how fast they work. Per-user output is shown as <strong>median</strong>
@@ -223,6 +251,7 @@
             new AcrossCitiesPage({
                 scorecardsUrl: '/adminapi/cityScorecards',
                 citiesUrl: '/v3/api/cities',
+                funnelsUrl: '/adminapi/cityFunnels',
                 mapboxToken: '@commonData.mapboxApiKey'
             }).init();
         });

--- a/conf/evolutions/default/327.sql
+++ b/conf/evolutions/default/327.sql
@@ -1,0 +1,24 @@
+# --- !Ups
+-- Per-deployment nightly-precomputed engagement funnels (#288), read cross-schema by the Across Cities admin page.
+-- One row per (funnel_type, time_window, segment). funnel_type is mapping (6 steps) or contribution (3 steps, leaving
+-- step4..step6 at 0). time_window is 30d, 90d, or all. segment is all, role:registered, role:anon, device:desktop,
+-- device:mobile, or device:unknown. step1..step6 hold the monotonic funnel counts (distinct users reaching each step).
+-- Small table (at most 36 rows), fully replaced each night by FunnelStatActor.
+-- NOTE keep comments free of the semicolon character and quotes, because Play splits evolution SQL on that character
+-- even inside comments (see #4351).
+CREATE TABLE funnel_stat (
+    funnel_type TEXT NOT NULL,
+    time_window TEXT NOT NULL,
+    segment TEXT NOT NULL,
+    step1 INT NOT NULL DEFAULT 0,
+    step2 INT NOT NULL DEFAULT 0,
+    step3 INT NOT NULL DEFAULT 0,
+    step4 INT NOT NULL DEFAULT 0,
+    step5 INT NOT NULL DEFAULT 0,
+    step6 INT NOT NULL DEFAULT 0,
+    computed_at TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (funnel_type, time_window, segment)
+);
+
+# --- !Downs
+DROP TABLE funnel_stat;

--- a/conf/routes
+++ b/conf/routes
@@ -83,6 +83,7 @@ GET     /adminapi/labels/cvMetadata                     controllers.api.LabelApi
 GET     /adminapi/validationCounts                      controllers.AdminController.getAllUserValidationCounts
 PUT     /adminapi/clearPlayCache                        controllers.AdminController.clearPlayCache()
 GET     /adminapi/updateUserStats                       controllers.AdminController.updateUserStats(hoursCutoff: Option[Int])
+GET     /adminapi/updateFunnelStats                     controllers.AdminController.updateFunnelStats
 GET     /adminapi/getCoverageData                       controllers.AdminController.getCoverageData
 GET     /adminapi/getNumUsersContributed                controllers.AdminController.getNumUsersContributed
 GET     /adminapi/getContributionTimeStats              controllers.AdminController.getContributionTimeStats
@@ -99,6 +100,7 @@ GET     /adminapi/activityByDay                          controllers.AdminContro
 GET     /adminapi/humanVsAi                              controllers.AdminController.getHumanVsAiStats
 GET     /adminapi/overviewSummary                       controllers.AdminController.getOverviewSummary
 GET     /adminapi/cityScorecards                        controllers.AdminController.getCityScorecards
+GET     /adminapi/cityFunnels                           controllers.AdminController.getCityFunnels(window: Option[String])
 
 PUT     /adminapi/setRole                               controllers.AdminController.setUserRole
 PUT     /adminapi/setUserQualityManual                  controllers.AdminController.setUserQualityManual

--- a/public/javascripts/admin-dashboard/across-cities-page.js
+++ b/public/javascripts/admin-dashboard/across-cities-page.js
@@ -37,6 +37,44 @@ class AcrossCitiesPage {
         active: '#4a90d9', wrapped_up: '#1f7a4d', stalled: '#e0a800', low_traction: '#c0392b'
     };
 
+    /**
+     * Display names for the funnel steps, keyed by the backend step keys (each funnel's `steps` array is the source of
+     * truth for the set and order; this map only supplies presentational labels). `full` is for the bar rows; `short`
+     * for the comparison-table column headers. Covers both the mapping and contribution funnels.
+     */
+    static #FUNNEL_STEP_LABELS = {
+        visited:                { full: 'Visited site',                     short: 'Visited' },
+        tutorial_started:       { full: 'Started tutorial',                short: 'Tutorial start' },
+        tutorial_finished:      { full: 'Finished or skipped tutorial',    short: 'Tutorial done' },
+        took_step:              { full: 'Took a step',                     short: 'Took a step' },
+        labeled:                { full: 'Placed a label',                  short: 'Labeled' },
+        mission_completed:      { full: 'Completed a mapping mission',     short: 'Mission done' },
+        contributed:            { full: 'Labeled or validated',           short: 'Contributed' },
+        contribution_completed: { full: 'Completed a labeling/validation mission', short: 'Mission done' }
+    };
+
+    /** Title + one-line description for each funnel, shown above its table/bars. Keyed by funnel type. */
+    static #FUNNEL_META = {
+        mapping:      { title: 'Mapping funnel',
+            desc: 'The Explore onboarding flow: tutorial, then walking, labeling, and completing an audit mission.' },
+        contribution: { title: 'Contribution funnel',
+            desc: 'The broad view: any contribution (labeling or validation) and finishing a mission.' }
+    };
+
+    /** Funnel display order on the page. The endpoint may include any subset of these. */
+    static #FUNNEL_ORDER = ['mapping', 'contribution'];
+
+    /** Which segment keys (matching the endpoint's per-city objects) each breakdown dimension shows, with labels. */
+    static #FUNNEL_DIMS = {
+        all:    [{ key: 'all',        label: 'All users' }],
+        role:   [{ key: 'registered', label: 'Registered' }, { key: 'anonymous', label: 'Anonymous' }],
+        device: [{ key: 'desktop',    label: 'Desktop' }, { key: 'mobile', label: 'Mobile' },
+            { key: 'device_unknown', label: 'Unknown' }]
+    };
+
+    /** Bar colors per segment, by position within the active dimension. */
+    static #FUNNEL_SEG_COLORS = ['#4a90d9', '#e0a800', '#b3b3b3'];
+
     #scorecardsUrl;
     #citiesUrl;
     #mapboxToken;
@@ -49,11 +87,17 @@ class AcrossCitiesPage {
     #sortKey = 'coverage'; // Current sort column.
     #sortDir = 'desc';     // 'asc' | 'desc'.
 
-    /** @param {{scorecardsUrl: string, citiesUrl?: string, mapboxToken?: string}} opts */
+    #funnelsUrl;
+    #funnels = {};         // { mapping: {steps, cities}, contribution: {steps, cities} } for the current window.
+    #funnelWindow = '30d'; // '30d' | '90d' | 'all'.
+    #funnelDim = 'all';    // 'all' | 'role' | 'device'.
+
+    /** @param {{scorecardsUrl: string, citiesUrl?: string, mapboxToken?: string, funnelsUrl?: string}} opts */
     constructor(opts = {}) {
         this.#scorecardsUrl = opts.scorecardsUrl;
         this.#citiesUrl = opts.citiesUrl;
         this.#mapboxToken = opts.mapboxToken;
+        this.#funnelsUrl = opts.funnelsUrl;
     }
 
     async init() {
@@ -78,6 +122,12 @@ class AcrossCitiesPage {
             this.#renderEffort();
             this.#renderPatterns();
             this.#renderQuality();
+            // Funnel data comes from its own endpoint and is refetched on window change, so load it separately; its
+            // internal error handling keeps a funnel failure from blanking the rest of the page.
+            if (this.#funnelsUrl) {
+                this.#wireFunnelControls();
+                await this.#loadFunnels();
+            }
         } catch (err) {
             console.error('Across Cities page failed to load:', err);
             this.#setText('ac-pulse', 'Could not load city data. Please try again.');
@@ -580,6 +630,161 @@ class AcrossCitiesPage {
                 `<td class="ac-num" title="${this.#num(c.low_quality_contributors)} of ${this.#num(contribDenom)} contributors">${this.#pct(lowQShare)}</td>` +
                 '</tr>';
         }).join('');
+    }
+
+    // --- Engagement funnel (#288) -----------------------------------------------------------------------------------
+
+    /** Wires the window selector (refetches) and the breakdown toggle (re-renders from cached data). */
+    #wireFunnelControls() {
+        const win = document.getElementById('ac-funnel-window');
+        if (win) win.querySelectorAll('.ac-toggle-btn').forEach(btn => btn.addEventListener('click', () => {
+            if (this.#funnelWindow === btn.dataset.window) return;
+            this.#funnelWindow = btn.dataset.window;
+            win.querySelectorAll('.ac-toggle-btn').forEach(b => b.classList.toggle('active', b === btn));
+            this.#loadFunnels();
+        }));
+        const dim = document.getElementById('ac-funnel-dim');
+        if (dim) dim.querySelectorAll('.ac-toggle-btn').forEach(btn => btn.addEventListener('click', () => {
+            if (this.#funnelDim === btn.dataset.dim) return;
+            this.#funnelDim = btn.dataset.dim;
+            dim.querySelectorAll('.ac-toggle-btn').forEach(b => b.classList.toggle('active', b === btn));
+            this.#renderFunnels();
+        }));
+    }
+
+    /** Fetches the funnels for the current window and renders them; a failure shows a message but leaves the page intact. */
+    async #loadFunnels() {
+        this.#setText('ac-funnel-status', 'Loading funnels…');
+        try {
+            const data = await this.#fetchJson(`${this.#funnelsUrl}?window=${encodeURIComponent(this.#funnelWindow)}`);
+            this.#funnels = (data && data.funnels) || {};
+            this.#renderFunnels();
+        } catch (err) {
+            console.error('Funnel load failed:', err);
+            this.#setText('ac-funnel-status', 'Could not load funnel data.');
+        }
+    }
+
+    /** Renders each funnel (mapping, contribution) as its own block for the active breakdown dimension. */
+    #renderFunnels() {
+        const host = document.getElementById('ac-funnels');
+        if (!host) return;
+        const segs = AcrossCitiesPage.#FUNNEL_DIMS[this.#funnelDim] || AcrossCitiesPage.#FUNNEL_DIMS.all;
+        const types = AcrossCitiesPage.#FUNNEL_ORDER.filter(t => this.#funnels[t]);
+        host.innerHTML = types.map(t => this.#funnelBlock(t, this.#funnels[t], segs)).join('');
+        const n = types.reduce((max, t) => Math.max(max, (this.#funnels[t].cities || []).length), 0);
+        this.#setText('ac-funnel-status', n ? `${n} ${n === 1 ? 'city' : 'cities'} with funnel data.` : 'No funnel data yet.');
+    }
+
+    /**
+     * One funnel block: heading + description, the comparison table, and the per-city small-multiples.
+     * @param {string} funnelType  'mapping' | 'contribution'.
+     * @param {{steps: string[], cities: object[]}} funnel  The funnel's step keys and per-city rows.
+     * @param {{key: string, label: string}[]} segs  Segments to show for the active dimension.
+     * @returns {string} The block's HTML.
+     */
+    #funnelBlock(funnelType, funnel, segs) {
+        const meta = AcrossCitiesPage.#FUNNEL_META[funnelType] || { title: funnelType, desc: '' };
+        const steps = funnel.steps || [];
+        const cities = funnel.cities || [];
+        return '<div class="ac-funnel-block">' +
+            `<h3 class="ac-funnel-block-title">${AcrossCitiesPage.#esc(meta.title)}</h3>` +
+            `<p class="ac-note">${AcrossCitiesPage.#esc(meta.desc)}</p>` +
+            `<div class="ac-table-wrap">${this.#funnelTableHtml(steps, cities, segs)}</div>` +
+            `<div class="ac-funnel-grid">${this.#funnelBarsHtml(steps, cities, segs)}</div>` +
+            '</div>';
+    }
+
+    /**
+     * The comparison table for one funnel: one row per (city, segment), sorted by overall conversion. Step columns are
+     * driven by the funnel's `steps` order; each cell carries the count and (past the first step) its drop-off.
+     * @returns {string} The `<table>` HTML.
+     */
+    #funnelTableHtml(steps, cities, segs) {
+        const labels = AcrossCitiesPage.#FUNNEL_STEP_LABELS;
+        const multi = segs.length > 1;
+        const head = '<tr>' +
+            '<th class="ac-th-text">City</th>' +
+            (multi ? '<th class="ac-th-text">Group</th>' : '') +
+            steps.map(k => {
+                const l = labels[k] || { full: k, short: k };
+                return `<th title="${AcrossCitiesPage.#esc(l.full)}">${AcrossCitiesPage.#esc(l.short)}</th>`;
+            }).join('') +
+            '<th title="Final step as a share of visitors">Overall</th></tr>';
+
+        const rows = [];
+        for (const c of cities) {
+            for (const seg of segs) {
+                const d = c[seg.key];
+                if (d) rows.push({ c, seg, d });
+            }
+        }
+        rows.sort((a, b) => (b.d.overall_conversion || 0) - (a.d.overall_conversion || 0));
+
+        let body;
+        if (!rows.length) {
+            const span = steps.length + (multi ? 3 : 2);
+            body = `<tr><td colspan="${span}" class="dq-empty">No funnel data to show.</td></tr>`;
+        } else {
+            body = rows.map(({ c, seg, d }) => {
+                const stepCells = d.steps.map((v, i) => {
+                    const title = i === 0
+                        ? `${this.#num(v)} visitors`
+                        : `${this.#num(v)} — ${this.#pct(d.step_conversion[i])} of previous step`;
+                    return `<td class="ac-num" title="${title}">${this.#compact(v)}</td>`;
+                }).join('');
+                return '<tr>' +
+                    `<td class="ac-td-city">${this.#cityLink(c)}</td>` +
+                    (multi ? `<td>${AcrossCitiesPage.#esc(seg.label)}</td>` : '') +
+                    stepCells +
+                    `<td class="ac-num">${this.#pct(d.overall_conversion)}</td>` +
+                    '</tr>';
+            }).join('');
+        }
+        return `<table class="ac-table"><thead>${head}</thead><tbody>${body}</tbody></table>`;
+    }
+
+    /**
+     * Per-city small-multiples for one funnel: a horizontal funnel of bars, each normalized to that segment's visitors
+     * (= 100%) and labeled with the count and (past the first step) the drop-off. Cities are ordered by overall traffic.
+     * @returns {string} The concatenated panel HTML.
+     */
+    #funnelBarsHtml(steps, cities, segs) {
+        if (!cities.length || !steps.length) return '';
+        const ordered = cities.slice()
+            .sort((a, b) => ((b.all && b.all.steps[0]) || 0) - ((a.all && a.all.steps[0]) || 0));
+        return ordered.map(c => this.#funnelPanel(steps, c, segs)).join('');
+    }
+
+    /** Builds one city's funnel panel for the given steps (title, optional legend, and the step bars). */
+    #funnelPanel(steps, c, segs) {
+        const labels = AcrossCitiesPage.#FUNNEL_STEP_LABELS;
+        const palette = AcrossCitiesPage.#FUNNEL_SEG_COLORS;
+        const legend = segs.length > 1
+            ? '<div class="ac-funnel-legend">' + segs.map((s, i) =>
+                `<span class="ac-funnel-legend-item"><span class="ac-funnel-swatch" style="background:${palette[i] || palette[0]}"></span>${AcrossCitiesPage.#esc(s.label)}</span>`).join('') + '</div>'
+            : '';
+        const stepRows = steps.map((k, i) => {
+            const full = (labels[k] || { full: k }).full;
+            const bars = segs.map((s, si) => {
+                const d = c[s.key];
+                const v = d ? d.steps[i] : 0;
+                const base = d && d.steps[0] > 0 ? d.steps[0] : 0;
+                const width = base > 0 ? (v / base) * 100 : 0;
+                const conv = d ? d.step_conversion[i] : 0;
+                const valText = i === 0 ? this.#compact(v) : `${this.#compact(v)} · ${this.#pct(conv)}`;
+                const title = i === 0
+                    ? `${AcrossCitiesPage.#esc(full)}: ${this.#num(v)} visitors`
+                    : `${AcrossCitiesPage.#esc(full)}: ${this.#num(v)} — ${this.#pct(conv)} of previous step`;
+                return `<div class="ac-funnel-bar" title="${title}">` +
+                    `<span class="ac-funnel-bar-fill" style="width:${width.toFixed(1)}%;background:${palette[si] || palette[0]}"></span>` +
+                    `<span class="ac-funnel-bar-val">${valText}</span></div>`;
+            }).join('');
+            return `<div class="ac-funnel-step"><div class="ac-funnel-step-label">${AcrossCitiesPage.#esc(full)}</div>` +
+                `<div class="ac-funnel-bars">${bars}</div></div>`;
+        }).join('');
+        return `<div class="ac-funnel-panel"><div class="ac-funnel-panel-title">${this.#cityLink(c)}</div>` +
+            `${legend}${stepRows}</div>`;
     }
 
     // --- Shared cell builders ---------------------------------------------------------------------------------------

--- a/public/stylesheets/admin-dashboard/admin-dashboard.css
+++ b/public/stylesheets/admin-dashboard/admin-dashboard.css
@@ -1499,3 +1499,66 @@ img.activity-feed-thumb:hover { box-shadow: 0 2px 6px rgba(0, 0, 0, 0.18); }
 
 /* --- Across Cities: effort-table sub-header (#4329) -------------------------------------------------------------- */
 .ac-th-sub { font-weight: 400; font-size: var(--font-size-xs, 0.8125rem); color: var(--color-text-secondary, #5a7785); }
+
+/* --- Across Cities: engagement funnels (#288) ------------------------------------------------------------------- */
+.ac-funnel-controls { display: flex; flex-wrap: wrap; gap: var(--space-md, 16px); margin: 0 0 var(--space-md, 16px); }
+
+/* Each funnel (mapping, contribution) is its own block with a heading, table, and small-multiples. */
+.ac-funnel-block { margin-bottom: var(--space-lg, 24px); }
+.ac-funnel-block-title {
+    font-size: var(--font-size-md, 1rem);
+    font-weight: 600;
+    color: var(--color-text-heading, #263238);
+    margin: var(--space-md, 16px) 0 var(--space-xs, 8px);
+}
+
+/* Responsive small-multiples: one compact funnel card per city. */
+.ac-funnel-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    gap: var(--space-md, 16px);
+    margin-top: var(--space-md, 16px);
+}
+.ac-funnel-panel {
+    border: 1px solid var(--color-neutral-200, #e1e1e1);
+    border-radius: 6px;
+    padding: var(--space-sm, 12px);
+    background: var(--color-surface, #fff);
+}
+.ac-funnel-panel-title { font-weight: 600; color: var(--color-text-heading, #263238); margin-bottom: var(--space-sm, 12px); }
+.ac-funnel-legend { display: flex; flex-wrap: wrap; gap: var(--space-sm, 12px); margin-bottom: var(--space-sm, 12px); }
+.ac-funnel-legend-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    font-size: var(--font-size-xs, 0.8125rem);
+    color: var(--color-text-secondary, #5a7785);
+}
+.ac-funnel-swatch { width: 11px; height: 11px; border-radius: 2px; display: inline-block; }
+
+.ac-funnel-step { margin-bottom: var(--space-xs, 8px); }
+.ac-funnel-step-label {
+    font-size: var(--font-size-xs, 0.8125rem);
+    color: var(--color-text-secondary, #5a7785);
+    margin-bottom: 2px;
+}
+.ac-funnel-bars { display: flex; flex-direction: column; gap: 2px; }
+
+/* A single bar: a full-width track with a left-anchored fill and a count/drop-off label that stays legible on top. */
+.ac-funnel-bar {
+    position: relative;
+    height: 16px;
+    background: var(--color-neutral-200, #e1e1e1);
+    border-radius: 3px;
+    overflow: hidden;
+}
+.ac-funnel-bar-fill { position: absolute; top: 0; left: 0; bottom: 0; border-radius: 3px; }
+.ac-funnel-bar-val {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    padding-left: 6px;
+    font-size: var(--font-size-xs, 0.8125rem);
+    color: var(--color-text-heading, #263238);
+}

--- a/test/controllers/AdminCityFunnelsSpec.scala
+++ b/test/controllers/AdminCityFunnelsSpec.scala
@@ -1,0 +1,50 @@
+package controllers
+
+import org.apache.pekko.stream.Materializer
+import org.scalatestplus.play.PlaySpec
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+
+/**
+ * Smoke tests for the cross-city engagement-funnel endpoints (#288): GET /adminapi/cityFunnels (Owner) and
+ * GET /adminapi/updateFunnelStats (Admin).
+ *
+ * Verifies the routes are wired (not 404) and the auth guards are in place — unauthenticated requests are redirected to
+ * sign-in rather than served data — across the optional window param. Boots the full application with a real DB.
+ *
+ * Requires a Postgres+PostGIS database (via DATABASE_URL / DATABASE_USER / DATABASE_PASSWORD env).
+ */
+class AdminCityFunnelsSpec extends PlaySpec with GuiceOneAppPerSuite {
+
+  override def fakeApplication(): Application =
+    new GuiceApplicationBuilder()
+      .disable[modules.ActorModule]
+      .build()
+
+  implicit lazy val mat: Materializer = app.materializer
+
+  "GET /adminapi/cityFunnels" should {
+    "redirect unauthenticated users to the sign-in page (not 404)" in {
+      val resp = route(app, FakeRequest(GET, "/adminapi/cityFunnels")).get
+      // Must be a redirect (3xx) to sign-in — never a 404, which would indicate a missing route.
+      status(resp) must (be >= 300 and be < 400)
+    }
+
+    "also redirect for each supported window (route accepts the optional window param)" in {
+      Seq("30d", "90d", "all").foreach { w =>
+        val resp = route(app, FakeRequest(GET, s"/adminapi/cityFunnels?window=$w")).get
+        status(resp) must (be >= 300 and be < 400)
+      }
+    }
+  }
+
+  "GET /adminapi/updateFunnelStats" should {
+    "redirect unauthenticated users to the sign-in page (not 404)" in {
+      val resp = route(app, FakeRequest(GET, "/adminapi/updateFunnelStats")).get
+      status(resp) must (be >= 300 and be < 400)
+    }
+  }
+}

--- a/test/service/FunnelMathSpec.scala
+++ b/test/service/FunnelMathSpec.scala
@@ -1,0 +1,54 @@
+package service
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+/**
+ * Pure (no DB, no app boot) unit test for the engagement-funnel conversion math (#288).
+ *
+ * Pins the step-over-step and overall conversion helpers, including the divide-by-zero behavior that keeps an empty
+ * funnel from producing NaN/Infinity, and the invariant that the step-key list and zero-fill stay the same length.
+ */
+class FunnelMathSpec extends AnyFunSuite with Matchers {
+
+  private val eps = 1e-9
+
+  test("FunnelDefs declares the mapping (6-step) and contribution (3-step) funnels, all starting with 'visited'") {
+    val defs = ConfigService.FunnelDefs.toMap
+    defs.keySet shouldBe Set("mapping", "contribution")
+    ConfigService.funnelStepKeys("mapping").length shouldBe 6
+    ConfigService.funnelStepKeys("contribution").length shouldBe 3
+    ConfigService.funnelStepKeys("mapping").head shouldBe "visited"
+    ConfigService.funnelStepKeys("contribution").head shouldBe "visited"
+    ConfigService.funnelStepKeys("nonexistent") shouldBe empty
+  }
+
+  test("stepConversion: first step is always 1.0; each later step is its share of the previous") {
+    val conv = ConfigService.stepConversion(Seq(100, 50, 25, 25, 5, 1))
+    conv.head shouldBe (1.0 +- eps)
+    conv(1) shouldBe (0.5 +- eps)
+    conv(2) shouldBe (0.5 +- eps)
+    conv(3) shouldBe (1.0 +- eps)
+    conv(4) shouldBe (0.2 +- eps)
+    conv.length shouldBe 6
+  }
+
+  test("stepConversion: a zero previous step yields 0.0, not NaN/Infinity") {
+    val conv = ConfigService.stepConversion(Seq(100, 0, 0, 0, 0, 0))
+    conv.head shouldBe (1.0 +- eps)
+    conv(1) shouldBe (0.0 +- eps)
+    conv.drop(1).forall(_ == 0.0) shouldBe true
+  }
+
+  test("stepConversion on an all-zero funnel is 1.0 then zeros (no division blowups)") {
+    val conv = ConfigService.stepConversion(ConfigService.ZeroFunnelSteps)
+    conv.head shouldBe (1.0 +- eps)
+    conv.drop(1).forall(_ == 0.0) shouldBe true
+  }
+
+  test("overallConversion is last/first, and 0.0 when there are no visitors or no steps") {
+    ConfigService.overallConversion(Seq(100, 50, 25, 25, 5, 10)) shouldBe (0.1 +- eps)
+    ConfigService.overallConversion(ConfigService.ZeroFunnelSteps) shouldBe (0.0 +- eps)
+    ConfigService.overallConversion(Seq.empty) shouldBe (0.0 +- eps)
+  }
+}


### PR DESCRIPTION
## What

Adds **two cross-city engagement funnels** to the Owner-only **Across Cities** admin page (#288), plus an interim fix for a Postgres-JIT crash that was blanking the page (#4376).

### Funnels
Two per-deployment funnels, precomputed nightly into each schema's `funnel_stat` (the cross-city page reads every schema's tiny table cheaply, rather than scanning `webpage_activity` live):

- **Mapping** (6 steps): visited → tutorial started → tutorial finished → took a step → labeled → completed an audit mission.
- **Contribution** (3 steps): visited → contributed (a label or a validation) → completed a labeling/validation mission.

Selected via a `funnel_type` column; both render as two blocks on the page with shared window (30d / 90d / all) and breakdown (role / device) toggles. Recompute on demand via `/adminapi/updateFunnelStats` and nightly via `FunnelStatActor`.

### Correctness fix — "Visited site" was over-counted
Step 1 previously counted **every** user appearing anywhere in the funnel (`deepest >= 1`), including users with downstream activity but no actual visit event. Because the two funnels draw from different downstream tables, they reported **different** "Visited site" totals (2,063 vs 2,006 on Seattle). Now each funnel is anchored on users who actually have a step-1 visit event (`HAVING bool_or(step = 1)`) — the standard funnel definition — so step 1 = distinct visitors (2,003), identical across funnels, and every later step is a true subset. Validated on live Seattle data.

### Interim JIT guard (#4376)
The `projectsidewalk/db` image ships a broken Postgres JIT (PostGIS bitcode built with LLVM 16, runtime `llvmjit` linked against LLVM 11). An expensive query that JIT-inlines PostGIS bitcode segfaults the backend (`SQLSTATE 08006`), which is what blanked the Across Cities scorecards/map. The cross-city scorecard and labeling-speed queries are wrapped in `SET LOCAL jit = off` as an interim guard. The real fix (disable JIT at the DB-config level) is tracked in **#4376**.

## Testing
- `sbt compile` + `scalafmtCheckAll`: clean.
- `FunnelMathSpec` (pure conversion math): 5/5 green.
- `AdminCityFunnelsSpec` (new, DB-backed smoke test: route wiring + auth redirects): exercised by the CI DB-backed job on a fresh DB. (Couldn't run locally — the dev DB's evolution state is mid-divergence and the running app held the shared build target.)
- Funnel SQL validated directly against live Seattle data (counts monotonic, segments reconcile, both funnels agree on step 1).

## Notes
- Evolution **327** creates `funnel_stat` (numbered after develop's 325/326).
- Follow-ups filed separately: per-city funnels on the single-city admin pages, and revisiting the "visited" event definition (direct-to-`/explore` entries never log `Visit_Index`, so "Visited site" undercounts real site entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
