### PR TITLE
Fix stale fetch-URL assertions in api-docs preview JS tests

### DIFF
--- a/test/js/aggregate-stats-preview.test.js
+++ b/test/js/aggregate-stats-preview.test.js
@@ -113,10 +113,11 @@ describe('AggregateStatsPreview', () => {
         expect(container.textContent).toContain('Obstacle');
     });
 
-    test('fetch is called against the expected endpoint', async () => {
+    test('fetch is called against the expected endpoint, tagged source=apiDocs', async () => {
         stubFetch(GOOD_FIXTURE);
         await window.AggregateStatsPreview.setup({}).init();
-        expect(global.fetch).toHaveBeenCalledWith('/v3/api/aggregateStats');
+        // The preview tags its request with source=apiDocs so the API analytics can attribute doc-page traffic.
+        expect(global.fetch).toHaveBeenCalledWith('/v3/api/aggregateStats?source=apiDocs');
     });
 
     // The renderer is null-safe (every field goes through `fmt()`), so a missing top-level `total_validations` does

--- a/test/js/validation-result-types-preview.test.js
+++ b/test/js/validation-result-types-preview.test.js
@@ -89,10 +89,11 @@ describe('ValidationResultTypesPreview', () => {
         expect(container.textContent).toContain('10');
     });
 
-    test('fetch is called against the expected endpoint', async () => {
+    test('fetch is called against the expected endpoint, tagged source=apiDocs', async () => {
         stubFetch(GOOD_FIXTURE);
         await window.ValidationResultTypesPreview.setup({}).init();
-        expect(global.fetch).toHaveBeenCalledWith('/v3/api/validationResultTypes');
+        // The preview tags its request with source=apiDocs so the API analytics can attribute doc-page traffic.
+        expect(global.fetch).toHaveBeenCalledWith('/v3/api/validationResultTypes?source=apiDocs');
     });
 
     // Documents the drift-detection value of this layer: the wrong (camelCase) shape does not throw — the module is


### PR DESCRIPTION
## What
Two suites in the prototype frontend test layer (`npm run test:js`) were failing on `develop`:
`aggregate-stats-preview.test.js` and `validation-result-types-preview.test.js`.

Both modules append `?source=apiDocs` to their fetch URL (added with the API analytics source-tagging work) so that doc-page traffic can be attributed. The two `"fetch is called against the expected endpoint"` tests still asserted the **bare** URL:

```
Expected: "/v3/api/aggregateStats"
Received: "/v3/api/aggregateStats?source=apiDocs"
```

The modules are correct; the assertions were stale.

## Change
- Update both assertions to the tagged URL (`…?source=apiDocs`).
- Rename the tests and add a comment so the `source=apiDocs` analytics contract is explicit (so a future drift fails loudly with context).

## Verification
`npm run test:js` — both suites now pass (10/10 across the two files; full suite green aside from anything unrelated).

No production code changed; tests only.