### PR TITLE
Fix ClusteringThreshold JSON key mismatch: label_type_id → label_type (#4364)

### DIFF
--- a/app/models/utils/MyPostgresProfile.scala
+++ b/app/models/utils/MyPostgresProfile.scala
@@ -190,7 +190,7 @@ object ClusteringThreshold {
     )(ClusteringThreshold.apply _)
 
     val writes: Writes[ClusteringThreshold] = (
-      (__ \ "label_type_id").write[String] and
+      (__ \ "label_type").write[String] and
         (__ \ "threshold").write[Double]
     )(unlift(ClusteringThreshold.unapply))
 

--- a/conf/evolutions/default/328.sql
+++ b/conf/evolutions/default/328.sql
@@ -1,0 +1,20 @@
+# --- !Ups
+-- Rename the JSONB key label_type_id to label_type inside clustering_session.thresholds so the Slick reader and writer
+-- agree on one key name (#4364). Before this fix the writer emitted label_type_id while the reader expected label_type,
+-- so any read path threw JsResultException on existing rows. The stored value was always a label-type name string
+-- (CurbRamp, Obstacle, ...), never a numeric id, so label_type_id was a misnomer -- this aligns on the correct name.
+-- Each array element gets the key renamed in place with its value preserved.
+UPDATE clustering_session
+SET thresholds = (
+    SELECT jsonb_agg((elem - 'label_type_id') || jsonb_build_object('label_type', elem -> 'label_type_id'))
+    FROM jsonb_array_elements(thresholds) AS elem
+)
+WHERE EXISTS (SELECT 1 FROM jsonb_array_elements(thresholds) AS elem WHERE elem ? 'label_type_id');
+
+# --- !Downs
+UPDATE clustering_session
+SET thresholds = (
+    SELECT jsonb_agg((elem - 'label_type') || jsonb_build_object('label_type_id', elem -> 'label_type'))
+    FROM jsonb_array_elements(thresholds) AS elem
+)
+WHERE EXISTS (SELECT 1 FROM jsonb_array_elements(thresholds) AS elem WHERE elem ? 'label_type');


### PR DESCRIPTION
Fixes #4364.

## Problem
The Slick serializer for `clustering_session.thresholds` (in `MyPostgresProfile.scala`) used **mismatched keys**: the writer emitted `label_type_id` but the reader expected `label_type`. So a stored `thresholds` value could not be deserialized back through Slick — any read path would throw `JsResultException(error.path.missing /label_type)` on existing rows.

Latent today (the column is only ever written, never read back), but a landmine for the first read path anyone adds (analytics, a debug view, an export). It surfaced while writing the DB-backed test for #2507 (PR #4363).

## Fix
Per @misaugstad's call on the issue, align on the **correct name** rather than papering over it on the reader side:

- **Writer** now emits `label_type` (matching the reader). The stored value was always a label-type *name* string (`CurbRamp`, `Obstacle`, …), never a numeric id, so `label_type_id` was a misnomer.
- **Evolution 328** migrates existing rows: renames the key in place inside each element of the `thresholds` JSONB array, value preserved. Idempotent-guarded with a `WHERE EXISTS` so it only touches rows still carrying the old key. `!Downs` reverses it.

## Verification
- Transform validated read-only against real Seattle `clustering_session` rows — `label_type_id` → `label_type`, values intact.
- `sbt --client compile` clean (warning-clean under `-Xfatal-warnings`).
- `scalafmtAll` applied; `make lint-evolutions` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)