### PR TITLE
Spacebar to advance one step along the route (#1041)

### DIFF
--- a/app/views/help.scala.html
+++ b/app/views/help.scala.html
@@ -343,6 +343,11 @@
                                     </tr>
                                     <tr>
                                         <th></th>
+                                        <th><kbd>Space</kbd></th>
+                                        <td>Move forward along your route (works even when no arrow points the way)</td>
+                                    </tr>
+                                    <tr>
+                                        <th></th>
                                         <th><kbd>Down</kbd></th>
                                         <td>Move Back</td>
                                     </tr>

--- a/docs/logged-events.md
+++ b/docs/logged-events.md
@@ -69,6 +69,7 @@ ones whose meaning, parameters, or history aren't obvious:
 | `NeighborhoodComplete_ByUser` vs `NeighborhoodComplete_AcrossAllUsers` | One user finishing their work vs. a neighborhood hitting 100% across *all* users. |
 | `Viewer_Primary` / `Viewer_Pannellum` | Which imagery viewer is active — the primary provider vs. the Pannellum fallback. |
 | `KeyboardShortcut_DisagreeReason_Option` / `KeyboardShortcut_UnsureReason_Option` | Validate: a reason chosen for a disagree/unsure verdict. |
+| `KeyboardShortcut_MoveForwardAlongRoute` | Explore: the spacebar route-advance shortcut. The `usedRoute` note is `false` when it stepped to a GSV-linked pano and `true` when it fell back to the same route-aware engine as the Stuck button (so heavy `usedRoute:true` volume overlaps with `ModalStuck_*`). |
 | `ValidationOptionApply` / `ValidationOptionUnapply` (Gallery) | A validation-status **filter** in the Gallery — *not* a validation of a label. |
 
 ## Finding the current list

--- a/public/javascripts/SVLabel/src/Main.js
+++ b/public/javascripts/SVLabel/src/Main.js
@@ -147,7 +147,8 @@ function Main (params) {
         svl.modalMissionComplete.hide();
 
         svl.feedbackModal = new FeedbackModal(svl, svl.tracker, svl.ribbon, svl.taskContainer);
-        svl.panoOverlayControls = new PanoOverlayControls(svl.tracker, svl.navigationService, svl.stuckAlert);
+        svl.panoOverlayControls = new PanoOverlayControls(svl.tracker, svl.navigationService, svl.stuckAlert,
+            svl.keyboardShortcutAlert);
 
         svl.infoPopover = new PanoInfoPopover(svl.ui.streetview.dateHolder, svl.panoViewer, svl.panoViewer.getPosition,
             svl.panoViewer.getPanoId, svl.taskContainer.getCurrentTaskStreetEdgeId,

--- a/public/javascripts/SVLabel/src/alert/KeyboardShortcutAlert.js
+++ b/public/javascripts/SVLabel/src/alert/KeyboardShortcutAlert.js
@@ -3,6 +3,8 @@ function KeyboardShortcutAlert(alertHandler) {
         'clickCount': {}
     };
     var MINIMUM_CLICKS_BEFORE_ALERT = 10;
+    // Stuck is clicked far less often than the mode buttons, so nudge after fewer clicks.
+    var MINIMUM_STUCK_CLICKS_BEFORE_ALERT = 5;
 
     function modeSwitchButtonClicked(labelType) {
         if(labelType === 'Walk')
@@ -25,6 +27,23 @@ function KeyboardShortcutAlert(alertHandler) {
         }
     }
 
+    /**
+     * Nudges the user toward the spacebar shortcut after they've clicked the Stuck button several times. The
+     * spacebar runs the same route-aware "move forward" the Stuck button does (see Keyboard._advanceForwardAlongRoute).
+     */
+    function stuckButtonClicked() {
+        if ('Stuck' in self['clickCount'])
+            self['clickCount']['Stuck']++;
+        else
+            self['clickCount']['Stuck'] = 1;
+
+        if (self['clickCount']['Stuck'] >= MINIMUM_STUCK_CLICKS_BEFORE_ALERT && (svl.isOnboarding() === false)) {
+            alertHandler.showAlert(i18next.t('popup.move-forward-shortcut'), 'MoveForwardShortcut', true);
+            self['clickCount']['Stuck'] = 0;
+        }
+    }
+
     self.modeSwitchButtonClicked = modeSwitchButtonClicked;
+    self.stuckButtonClicked = stuckButtonClicked;
     return self;
 }

--- a/public/javascripts/SVLabel/src/alert/KeyboardShortcutAlert.js
+++ b/public/javascripts/SVLabel/src/alert/KeyboardShortcutAlert.js
@@ -28,8 +28,9 @@ function KeyboardShortcutAlert(alertHandler) {
     }
 
     /**
-     * Nudges the user toward the spacebar shortcut after they've clicked the Stuck button several times. The
-     * spacebar runs the same route-aware "move forward" the Stuck button does (see Keyboard._advanceForwardAlongRoute).
+     * Nudges the user toward the spacebar shortcut after they've clicked the Stuck button several times. The spacebar
+     * first tries a routed linked-pano step and only falls back to the Stuck button's route-aware moveForward() when
+     * no such link exists (see Keyboard._advanceForwardAlongRoute).
      */
     function stuckButtonClicked() {
         if ('Stuck' in self['clickCount'])

--- a/public/javascripts/SVLabel/src/controls/PanoOverlayControls.js
+++ b/public/javascripts/SVLabel/src/controls/PanoOverlayControls.js
@@ -15,11 +15,13 @@ class PanoOverlayControls {
      * @param {Tracker} tracker
      * @param {NavigationService} navigationService
      * @param {StuckAlert} stuckAlert
+     * @param {KeyboardShortcutAlert} keyboardShortcutAlert
      */
-    constructor(tracker, navigationService, stuckAlert) {
+    constructor(tracker, navigationService, stuckAlert, keyboardShortcutAlert) {
         this.tracker = tracker;
         this.navigationService = navigationService;
         this.stuckAlert = stuckAlert;
+        this.keyboardShortcutAlert = keyboardShortcutAlert;
 
         this.#stuck = document.getElementById('explore-control-stuck');
         this.#controlButtonsHolder = document.getElementById('explore-control-buttons-holder');
@@ -55,6 +57,7 @@ class PanoOverlayControls {
         e.preventDefault();
         if (!this.#stuckEnabled) return;
         this.stuckAlert.compassOrStuckClicked();
+        this.keyboardShortcutAlert.stuckButtonClicked();
         this.tracker.push('ModalStuck_ClickStuck');
         this.navigationService.moveForward()
             .then(() => {

--- a/public/javascripts/SVLabel/src/keyboard/Keyboard.js
+++ b/public/javascripts/SVLabel/src/keyboard/Keyboard.js
@@ -64,15 +64,24 @@ function Keyboard (svl, canvas, contextMenu, navigationService, ribbon, zoomCont
      * the spacebar shortcut for the "routed where there's no forward arrow" case from #619/#1041.
      */
     this._advanceForwardAlongRoute = async function() {
-        // Bias the forward step toward the route direction rather than wherever the camera is currently pointed.
-        // moveToLinkedPano() takes a heading offset relative to the current heading, so subtract the current one.
-        const routeHeading = svl.compass.getTargetAngle();
-        const currHeading = svl.panoViewer.getPov().heading;
-        const moved = await navigationService.moveToLinkedPano(routeHeading - currHeading);
-        if (!moved) {
-            await navigationService.moveForward();
+        // No-op while walking is disabled (e.g. mid-load), matching the arrow keys — otherwise moveToLinkedPano()
+        // resolves false and we'd both fall through to a no-op moveForward() and log a move that never happened.
+        if (navigationService.getStatus('disableWalking')) return;
+
+        try {
+            // Bias the forward step toward the route direction rather than wherever the camera is currently pointed.
+            // moveToLinkedPano() takes a heading offset relative to the current heading, so subtract the current one.
+            const routeHeading = svl.compass.getTargetAngle();
+            const currHeading = svl.panoViewer.getPov().heading;
+            const moved = await navigationService.moveToLinkedPano(routeHeading - currHeading);
+            if (!moved) {
+                await navigationService.moveForward();
+            }
+            svl.tracker.push('KeyboardShortcut_MoveForwardAlongRoute', { usedRoute: !moved });
+        } catch (e) {
+            // Keep a failed forward step from surfacing as an unhandled promise rejection out of a key event.
+            console.error('Spacebar route-advance failed:', e);
         }
-        svl.tracker.push('KeyboardShortcut_MoveForwardAlongRoute', { usedRoute: !moved });
     };
 
     /**

--- a/public/javascripts/SVLabel/src/keyboard/Keyboard.js
+++ b/public/javascripts/SVLabel/src/keyboard/Keyboard.js
@@ -56,6 +56,26 @@ function Keyboard (svl, canvas, contextMenu, navigationService, ribbon, zoomCont
     };
 
     /**
+     * Advance one step forward along the user's assigned route, keeping their current POV (heading/pitch/zoom).
+     *
+     * First tries to step to the GSV-linked pano in the route direction (not just wherever the camera happens to
+     * face); if there's no such link — e.g. GSV shows no navigation arrow that way — falls back to the route-aware
+     * moveForward() engine that probes along the assigned street geometry for the next available imagery. This is
+     * the spacebar shortcut for the "routed where there's no forward arrow" case from #619/#1041.
+     */
+    this._advanceForwardAlongRoute = async function() {
+        // Bias the forward step toward the route direction rather than wherever the camera is currently pointed.
+        // moveToLinkedPano() takes a heading offset relative to the current heading, so subtract the current one.
+        const routeHeading = svl.compass.getTargetAngle();
+        const currHeading = svl.panoViewer.getPov().heading;
+        const moved = await navigationService.moveToLinkedPano(routeHeading - currHeading);
+        if (!moved) {
+            await navigationService.moveForward();
+        }
+        svl.tracker.push('KeyboardShortcut_MoveForwardAlongRoute', { usedRoute: !moved });
+    };
+
+    /**
      * This is a callback for a key down event
      * @param {object} e An event object
      * @private
@@ -76,6 +96,12 @@ function Keyboard (svl, canvas, contextMenu, navigationService, ribbon, zoomCont
                         break;
                     case "ArrowDown":
                         navigationService.moveToLinkedPano(180);
+                        break;
+                    case " ":
+                        // preventDefault stops the page from scrolling and stops space from re-activating a
+                        // focused button (e.g. the Stuck/ribbon button right after a mouse click).
+                        e.preventDefault();
+                        self._advanceForwardAlongRoute();
                         break;
                 }
             }

--- a/public/locales/de/audit.json
+++ b/public/locales/de/audit.json
@@ -95,7 +95,7 @@
     },
     "controls": {
         "stuck": "Verlaufen",
-        "stuck-tooltip": "Wir werden versuchen, Sie zurück zu Ihrer Mission zu bringen",
+        "stuck-tooltip": "Wir werden versuchen, Sie zurück zu Ihrer Mission zu bringen – oder drücken Sie die Leertaste",
         "sound": "Ton",
         "feedback": "Rück­meldung",
         "feedback-tooltip": "Teilen Sie uns Ihre Gedanken mit",
@@ -250,6 +250,7 @@
         "signup-body": "Möchten Sie einen Account erstellen, um Ihren Fortschritt zu verfolgen?",
         "severity-shortcuts": "Bitte geben Sie einen Schweregrad für jede Beschriftung an, indem Sie <kbd>1</kbd> bis <kbd>3</kbd> drücken.",
         "zoom-shortcuts": "Sie können auch die Taste <kbd>Z</kbd> drücken um hineinzuzoomen und die Tasten <kbd>Shift</kbd> + <kbd>Z</kbd> um hinauszuzoomen.",
+        "move-forward-shortcut": "Sie können auch die <kbd>Leertaste</kbd> drücken, um sich entlang Ihrer Route vorwärtszubewegen.",
         "label-shortcuts-curb-ramp": "Sie können auch die Taste <kbd>{{key}}</kbd> drücken, um die Beschriftung für eine Trottoirabsenkung zu wählen.",
         "label-shortcuts-no-curb-ramp": "Sie können auch die Taste the <kbd>{{key}}</kbd> drücken, um die Beschriftung für eine fehlende Trottoirabsenkung zu wählen.",
         "label-shortcuts-obstacle": "Sie können auch die Taste <kbd>{{key}}</kbd> drücken, um die Beschriftung für ein Hindernis zu wählen.",

--- a/public/locales/en/audit.json
+++ b/public/locales/en/audit.json
@@ -95,7 +95,7 @@
     },
     "controls": {
         "stuck": "Stuck",
-        "stuck-tooltip": "We'll try to move you back to your mission",
+        "stuck-tooltip": "We'll try to move you back to your mission — or press the spacebar",
         "sound": "Sound",
         "feedback": "Feedback",
         "feedback-tooltip": "Share your thoughts with us",
@@ -250,6 +250,7 @@
         "signup-body": "Do you want to create an account to keep track of your progress?",
         "severity-shortcuts": "Please provide severity ratings for each label by pressing keys <kbd>1</kbd> through <kbd>3</kbd>",
         "zoom-shortcuts": "You can also press the <kbd>Z</kbd> key to zoom in and the <kbd>Shift</kbd> + <kbd>Z</kbd> keys to zoom out.",
+        "move-forward-shortcut": "You can also press the <kbd>Space</kbd> bar to move forward along your route.",
         "label-shortcuts-curb-ramp": "You can also press the <kbd>{{key}}</kbd> key for selecting the Curb Ramp label.",
         "label-shortcuts-no-curb-ramp": "You can also press the <kbd>{{key}}</kbd> key for selecting the Missing Curb Ramp label.",
         "label-shortcuts-obstacle": "You can also press the <kbd>{{key}}</kbd> key for selecting the Obstacle label.",

--- a/public/locales/es/audit.json
+++ b/public/locales/es/audit.json
@@ -95,7 +95,7 @@
     },
     "controls": {
         "stuck": "Atorado",
-        "stuck-tooltip": "Intentaremos llevarte de regreso a tu misión",
+        "stuck-tooltip": "Intentaremos llevarte de regreso a tu misión, o presiona la barra espaciadora",
         "sound": "Sonido",
         "feedback": "Retroalimentación",
         "feedback-tooltip": "Comparte tus pensamientos con nosotros",
@@ -250,6 +250,7 @@
         "signup-body": "¿Deseas crear una cuenta para tener un seguimiento de tu progreso?",
         "severity-shortcuts": "Por favor proporciona clasificaciones de gravedad para cada etiqueta presionando las teclas <kbd>1</kbd> a <kbd>3</kbd>",
         "zoom-shortcuts": "También puedes presionar la tecla <kbd>Z</kbd> para acercar y las teclas <kbd>Shift</kbd> + <kbd>Z</kbd> para alejar.",
+        "move-forward-shortcut": "También puedes presionar la <kbd>barra espaciadora</kbd> para avanzar a lo largo de tu ruta.",
         "label-shortcuts-curb-ramp": "También puedes presionar la tecla <kbd>{{key}}</kbd> para seleccionar la etiqueta de la Rampa Peatonal.",
         "label-shortcuts-no-curb-ramp": "También puedes presionar la tecla <kbd>{{key}}</kbd> para seleccionar la etiqueta de la Rampa Peatonal Ausente.",
         "label-shortcuts-obstacle": "También puedes presionar la tecla <kbd>{{key}}</kbd> para seleccionar la etiqueta del Obstáculo.",

--- a/public/locales/nl/audit.json
+++ b/public/locales/nl/audit.json
@@ -95,7 +95,7 @@
     },
     "controls": {
         "stuck": "Vastgelopen",
-        "stuck-tooltip": "We zullen proberen u terug te brengen naar uw missie",
+        "stuck-tooltip": "We zullen proberen u terug te brengen naar uw missie – of druk op de spatiebalk",
         "sound": "Geluid",
         "feedback": "Feedback",
         "feedback-tooltip": "Deel uw mening met ons",
@@ -250,6 +250,7 @@
         "signup-body": "Wil je een account maken om je voortgang bij te houden?",
         "severity-shortcuts": "Beoordeel de ernst van elk label door tussen <kbd>1</kbd> en <kbd>3</kbd> in te drukken",
         "zoom-shortcuts": "Je kunt ook de <kbd>Z</kbd> toets gebruiken om in te zoomen en <kbd>Shift</kbd> + <kbd>Z</kbd> toetsen om uit te zoomen.",
+        "move-forward-shortcut": "Je kunt ook op de <kbd>spatiebalk</kbd> drukken om vooruit te gaan langs je route.",
         "label-shortcuts-curb-ramp": "Je kunt ook de <kbd>{{key}}</kbd> toets gebruiken voor het selecteren van het trottoir oprit label.",
         "label-shortcuts-no-curb-ramp": "Je kunt ook de <kbd>{{key}}</kbd> toets gebruiken voor het selecteren van het ontbrekende trottoir oprit label.",
         "label-shortcuts-obstacle": "Je kunt ook de <kbd>{{key}}</kbd> toets gebruiken voor het selecteren van het obstakel label.",

--- a/public/locales/pt-BR/audit.json
+++ b/public/locales/pt-BR/audit.json
@@ -95,7 +95,7 @@
     },
     "controls": {
         "stuck": "Travado",
-        "stuck-tooltip": "Vamos tentar fazê-lo voltar à sua missão",
+        "stuck-tooltip": "Vamos tentar fazê-lo voltar à sua missão — ou pressione a barra de espaço",
         "sound": "Som",
         "feedback": "Opinião",
         "feedback-tooltip": "Compartilhe suas ideias conosco",
@@ -250,6 +250,7 @@
         "signup-body": "Você quer criar uma conta para acompanhar seu progresso?",
         "severity-shortcuts": "Por favor, forneça classificações de gravidade para cada rótulo pressionando as teclas <kbd>1</kbd> a <kbd>3</kbd>",
         "zoom-shortcuts": "Você também pode pressionar a tecla <kbd>Z</kbd> para ampliar e as teclas <kbd>Shift</kbd> + <kbd>Z</kbd> para reduzir.",
+        "move-forward-shortcut": "Você também pode pressionar a <kbd>barra de espaço</kbd> para avançar ao longo da sua rota.",
         "label-shortcuts-curb-ramp": "Você também pode pressionar a tecla <kbd>{{key}}</kbd> para selecionar o rótulo Rampa de Meio-Fio.",
         "label-shortcuts-no-curb-ramp": "Você também pode pressionar a tecla <kbd>{{key}}</kbd> para selecionar o rótulo Rampa de Meio-Fio Ausente.",
         "label-shortcuts-obstacle": "Você também pode pressionar a tecla <kbd>{{key}}</kbd> para selecionar o rótulo Obstáculo.",

--- a/public/locales/zh-TW/audit.json
+++ b/public/locales/zh-TW/audit.json
@@ -95,7 +95,7 @@
     },
     "controls": {
         "stuck": "卡住",
-        "stuck-tooltip": "我們會盡力讓您回到您的使命",
+        "stuck-tooltip": "我們會盡力讓您回到您的使命，或按空白鍵",
         "sound": "音效",
         "feedback": "回饋",
         "feedback-tooltip": "和我們分享一下你的想法",
@@ -249,6 +249,7 @@
         "signup-body": "您想要設立一個帳號以便持續追蹤進度嗎？",
         "severity-shortcuts": "請為每個標記紀錄品質評分，請點選<kbd>1</kbd>至<kbd>3</kbd>",
         "zoom-shortcuts": "您也可按下<kbd>Z</kbd>鍵來放大視窗或<kbd>Shift</kbd> + <kbd>Z</kbd>鍵來縮小視窗。",
+        "move-forward-shortcut": "您也可按下<kbd>空白鍵</kbd>沿著您的路線向前移動。",
         "label-shortcuts-curb-ramp": "您也可按下<kbd>{{key}}</kbd>鍵以選擇「路緣斜坡」標記。",
         "label-shortcuts-no-curb-ramp": "您也可按下<kbd>{{key}}</kbd>鍵以選擇「缺路緣斜坡」標記。",
         "label-shortcuts-obstacle": "您也可按下<kbd>{{key}}</kbd>鍵以選擇「有障礙物」標記。",


### PR DESCRIPTION
Closes #1041.

## What & why
In Explore, the only forward keys are **ArrowUp** (step to the GSV-linked pano you're *facing*) and the **Stuck** button (route-aware `moveForward`). When GSV shows **no navigation arrow in the routed direction**, ArrowUp does nothing and users get stuck — the problem raised back in #619. This binds the **spacebar** to advance one step along the assigned route while keeping POV unchanged, as @manaswis suggested.

## Behavior (route-biased hybrid)
On spacebar:
1. Try `moveToLinkedPano` toward the **compass route heading** (not just where the camera faces).
2. If there's no such link, fall back to the route-aware `moveForward()` engine — the same one the Stuck button uses.

Both paths leave heading/pitch/zoom untouched, so POV is preserved. Gated by the same guards as the arrow keys (keyboard enabled, not in a text field, context menu closed), and `preventDefault` stops page-scroll / re-activating a focused button.

Spacebar was verified **unbound** everywhere (Explore, Validate, modals, all locale/message files), so no overloading.

## Discoverability
- **Toast nudge** after ~5 Stuck-button clicks (extends `KeyboardShortcutAlert`).
- **Help-page** shortcuts table gains a `Space` row.
- **Stuck-button tooltip** gains a spacebar hint.

New i18n key `popup.move-forward-shortcut` + a tooltip hint added to all maintained `audit.json` locales (en/de/es/nl/pt-BR/zh-TW); others fall back to en.

## Logging
Adds `KeyboardShortcut_MoveForwardAlongRoute` (with a `usedRoute` flag for which path fired); documented in `docs/logged-events.md`.

## Testing
Manually tested in Explore on freshly-imported **Teaneck** data (continuous un-audited streets): Space advances one pano with POV unchanged where an arrow exists, and falls back to the route-aware step where no forward arrow points along the route. Backend (Twirl) change compiles clean; all edited locale JSON validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)