### PR TITLE
Per-city engagement funnels on the admin Contributors page (#4379)

### DIFF
--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -1040,6 +1040,16 @@ class AdminController @Inject() (
    *
    * @param window "30d", "90d", or "all"; anything else (or absent) falls back to "30d".
    */
+  /**
+   * Serializes one funnel segment to snake_case JSON (#288): its raw step counts plus the derived step-over-step and
+   * overall conversion ratios. Shared by the cross-city and single-city funnel endpoints so both emit the same shape.
+   */
+  private def funnelSegJson(seg: FunnelSegment): JsObject = Json.obj(
+    "steps"              -> seg.steps,
+    "step_conversion"    -> ConfigService.stepConversion(seg.steps),
+    "overall_conversion" -> ConfigService.overallConversion(seg.steps)
+  )
+
   def getCityFunnels(window: Option[String]) = cc.securityService.SecuredAction(WithOwner()) { implicit request =>
     cc.loggingService.insert(request.identity.userId, request.ipAddress, request.toString)
     // Only these three windows are precomputed in funnel_stat; reject anything else rather than 500 on a cache miss.
@@ -1048,11 +1058,6 @@ class AdminController @Inject() (
       configService.getAllCityInfo(request2Messages.lang).map(ci => ci.cityId -> ci).toMap
 
     configService.getCityFunnels(windowKey).map { funnelsByType =>
-      def segJson(seg: FunnelSegment): JsObject = Json.obj(
-        "steps"              -> seg.steps,
-        "step_conversion"    -> ConfigService.stepConversion(seg.steps),
-        "overall_conversion" -> ConfigService.overallConversion(seg.steps)
-      )
       def cityJson(f: CityFunnel): JsObject = {
         val info = cityInfoById.get(f.cityId)
         Json.obj(
@@ -1061,12 +1066,12 @@ class AdminController @Inject() (
           "city_name_formatted" -> info.map(_.cityNameFormatted),
           "url"                 -> info.map(_.URL),
           "visibility"          -> info.map(_.visibility),
-          "all"                 -> segJson(f.all),
-          "registered"          -> segJson(f.registered),
-          "anonymous"           -> segJson(f.anonymous),
-          "desktop"             -> segJson(f.desktop),
-          "mobile"              -> segJson(f.mobile),
-          "device_unknown"      -> segJson(f.deviceUnknown)
+          "all"                 -> funnelSegJson(f.all),
+          "registered"          -> funnelSegJson(f.registered),
+          "anonymous"           -> funnelSegJson(f.anonymous),
+          "desktop"             -> funnelSegJson(f.desktop),
+          "mobile"              -> funnelSegJson(f.mobile),
+          "device_unknown"      -> funnelSegJson(f.deviceUnknown)
         )
       }
       // One entry per funnel type ("mapping", "contribution"), each with its own step list and per-city rows. `steps`
@@ -1079,6 +1084,39 @@ class AdminController @Inject() (
       })
       Ok(Json.obj("window" -> windowKey, "funnels" -> funnels))
     }
+  }
+
+  /**
+   * Returns THIS deployment's own precomputed engagement funnels for one time window (#4379), for the per-city
+   * Contributors page. Admin-gated (per-city Administrators see their own city), unlike the Owner-gated cross-city
+   * [[getCityFunnels]]. Output is snake_case per the v3 convention; each funnel's `steps` array names its steps in
+   * order so the client never hardcodes them, and segments are keyed (not a `cities` array) since there is one city.
+   *
+   * @param window "30d", "90d", or "all"; anything else (or absent) falls back to "30d".
+   */
+  def getCurrentCityFunnels(window: Option[String]) = cc.securityService.SecuredAction(WithAdmin()) {
+    implicit request =>
+      cc.loggingService.insert(request.identity.userId, request.ipAddress, request.toString)
+      // Only these three windows are precomputed in funnel_stat; reject anything else rather than 500 on a cache miss.
+      val windowKey = window.filter(Set("30d", "90d", "all")).getOrElse("30d")
+
+      configService.getCurrentCityFunnels(windowKey).map { result =>
+        def segmentsJson(f: CityFunnel): JsObject = Json.obj(
+          "all"            -> funnelSegJson(f.all),
+          "registered"     -> funnelSegJson(f.registered),
+          "anonymous"      -> funnelSegJson(f.anonymous),
+          "desktop"        -> funnelSegJson(f.desktop),
+          "mobile"         -> funnelSegJson(f.mobile),
+          "device_unknown" -> funnelSegJson(f.deviceUnknown)
+        )
+        // One entry per funnel type the city has data for, each with its ordered step keys and this city's segments.
+        val funnels = JsObject(ConfigService.FunnelDefs.collect {
+          case (funnelType, stepKeys) if result.byType.contains(funnelType) =>
+            funnelType -> Json.obj("steps" -> stepKeys, "segments" -> segmentsJson(result.byType(funnelType)))
+        })
+        // ISO-8601 string (OffsetDateTime.toString) so the page can show a "data as of" label; null until precomputed.
+        Ok(Json.obj("window" -> windowKey, "computed_at" -> result.computedAt.map(_.toString), "funnels" -> funnels))
+      }
   }
 
   def getUserStats = cc.securityService.SecuredAction(WithAdmin()) { implicit request =>

--- a/app/service/AdminService.scala
+++ b/app/service/AdminService.scala
@@ -1093,8 +1093,10 @@ class AdminServiceImpl @Inject() (
       }
     }
     // Compute all windows, then atomically replace the table. replaceAll is itself transactional, so the reads plus the
-    // wholesale swap are all the consistency this precompute needs.
+    // wholesale swap are all the consistency this precompute needs. Then drop the cached funnel reads so the fresh rows
+    // show on the next page load rather than after the 10-minute TTL.
     db.run(DBIO.sequence(perWindow).flatMap(rows => funnelStatTable.replaceAll(rows.flatten)))
+      .flatMap(rowsWritten => configService.invalidateFunnelCaches().map(_ => rowsWritten))
   }
 
   /**

--- a/app/service/ConfigService.scala
+++ b/app/service/ConfigService.scala
@@ -235,6 +235,17 @@ case class CityFunnel(
 )
 
 /**
+ * The current deployment's own engagement funnels for a single time window, for the per-city Contributors page (#4379).
+ *
+ * This is the single-city counterpart of the cross-city read: one [[CityFunnel]] per funnel type for *this* schema
+ * only (no cross-schema fan-out), plus when the rows were last precomputed so the page can show a "data as of" label.
+ *
+ * @param computedAt When this city's `funnel_stat` was last recomputed; `None` if the table has no rows yet.
+ * @param byType     One [[CityFunnel]] per funnel type ("mapping", "contribution"); empty if there is no funnel data.
+ */
+case class CurrentCityFunnels(computedAt: Option[OffsetDateTime], byType: Map[String, CityFunnel])
+
+/**
  * Lifecycle thresholds, the data-quality anomaly thresholds, and the (pure) classification helpers for the cross-city
  * overview (#4329).
  *
@@ -319,6 +330,9 @@ object ConfigService {
     "contribution" -> Seq("visited", "contributed", "contribution_completed")
   )
 
+  /** The funnel time windows offered by the API and precomputed in `funnel_stat`; the source of truth for the set. */
+  val FunnelWindowKeys: Seq[String] = Seq("30d", "90d", "all")
+
   /** Step keys for one funnel type. */
   def funnelStepKeys(funnelType: String): Seq[String] = FunnelDefs.toMap.getOrElse(funnelType, Seq.empty)
 
@@ -352,6 +366,30 @@ object ConfigService {
    */
   def overallConversion(steps: Seq[Int]): Double =
     if (steps.nonEmpty && steps.head > 0) steps.last.toDouble / steps.head else 0.0
+
+  /**
+   * Builds a [[CityFunnel]] for one funnel type from a city's precomputed `funnel_stat` rows (#288), zero-filling any
+   * segment that has no row (e.g. a city with no mobile or no anonymous users) and trimming the stored six-slot steps
+   * to the funnel's actual step count.
+   *
+   * Pure (depends only on [[funnelStepKeys]]) so both the cross-city read ([[ConfigService.getCityFunnels]]) and the
+   * single-city read ([[ConfigService.getCurrentCityFunnels]]) share one assembly, and it can be unit-tested without a
+   * DB.
+   *
+   * @param cityId     The city id to stamp on the result.
+   * @param funnelType "mapping" or "contribution"; determines the step count the steps are trimmed to.
+   * @param rowsOfType The `funnel_stat` rows for that city and funnel type (any subset of the six segments).
+   * @return           One [[CityFunnel]] with every segment present (zero-filled when absent).
+   */
+  def assembleCityFunnel(cityId: String, funnelType: String, rowsOfType: Seq[FunnelStat]): CityFunnel = {
+    val numSteps                              = funnelStepKeys(funnelType).length
+    val stepsBySegment: Map[String, Seq[Int]] = rowsOfType.map(r => r.segment -> r.steps.take(numSteps)).toMap
+    def seg(key: String): FunnelSegment       = FunnelSegment(stepsBySegment.getOrElse(key, Seq.fill(numSteps)(0)))
+    CityFunnel(
+      cityId = cityId, all = seg("all"), registered = seg("role:registered"), anonymous = seg("role:anon"),
+      desktop = seg("device:desktop"), mobile = seg("device:mobile"), deviceUnknown = seg("device:unknown")
+    )
+  }
 }
 
 @ImplementedBy(classOf[ConfigServiceImpl])
@@ -403,6 +441,29 @@ trait ConfigService {
    * @return       Per funnel type ("mapping", "contribution"), one [[CityFunnel]] per available city with funnel data.
    */
   def getCityFunnels(window: String): Future[Map[String, Seq[CityFunnel]]]
+
+  /**
+   * Returns THIS deployment's own precomputed engagement funnels for a time window (#4379), for the per-city
+   * Contributors page.
+   *
+   * The single-city counterpart of [[getCityFunnels]]: reads only the current city's `funnel_stat` (no cross-schema
+   * fan-out), so per-city Administrators can see their own onboarding/contribution conversion without Owner access.
+   * Returns an empty result (no funnel types) when the table has not been populated yet.
+   *
+   * @param window The funnel window key: "30d", "90d", or "all".
+   * @return       One [[CityFunnel]] per funnel type for this city, plus when the rows were last recomputed.
+   */
+  def getCurrentCityFunnels(window: String): Future[CurrentCityFunnels]
+
+  /**
+   * Drops the cached funnel reads ([[getCityFunnels]] and [[getCurrentCityFunnels]]) for every window (#4379).
+   *
+   * Called after a funnel recompute so a manual `/adminapi/updateFunnelStats` (or the nightly job) is reflected on the
+   * next page load instead of after the 10-minute cache TTL.
+   *
+   * @return Completes when all entries have been removed.
+   */
+  def invalidateFunnelCaches(): Future[Unit]
 
   /**
    * Maps a city ID to its corresponding database user/schema.
@@ -786,7 +847,7 @@ class ConfigServiceImpl @Inject() (
           // Group into funnelType -> one CityFunnel per city, in the page's funnel order.
           ConfigService.FunnelDefs.map { case (funnelType, _) =>
             funnelType -> citiesWithRows.map { case (cityId, rows) =>
-              assembleCityFunnel(cityId, funnelType, rows.filter(_.funnelType == funnelType))
+              ConfigService.assembleCityFunnel(cityId, funnelType, rows.filter(_.funnelType == funnelType))
             }
           }.toMap
         }
@@ -794,19 +855,33 @@ class ConfigServiceImpl @Inject() (
     }
   }
 
-  /**
-   * Builds a [[CityFunnel]] for one funnel type from a city's precomputed `funnel_stat` rows, zero-filling any segment
-   * that has no row (e.g. a city with no mobile or no anonymous users) and trimming the stored six-slot steps to the
-   * funnel's actual step count (#288).
-   */
-  private def assembleCityFunnel(cityId: String, funnelType: String, rowsOfType: Seq[FunnelStat]): CityFunnel = {
-    val numSteps                              = ConfigService.funnelStepKeys(funnelType).length
-    val stepsBySegment: Map[String, Seq[Int]] = rowsOfType.map(r => r.segment -> r.steps.take(numSteps)).toMap
-    def seg(key: String): FunnelSegment       = FunnelSegment(stepsBySegment.getOrElse(key, Seq.fill(numSteps)(0)))
-    CityFunnel(
-      cityId = cityId, all = seg("all"), registered = seg("role:registered"), anonymous = seg("role:anon"),
-      desktop = seg("device:desktop"), mobile = seg("device:mobile"), deviceUnknown = seg("device:unknown")
-    )
+  def getCurrentCityFunnels(window: String): Future[CurrentCityFunnels] = {
+    // Reads only this deployment's own precomputed funnel_stat (no cross-schema fan-out), so it is cheap; the short
+    // cache just coalesces bursts of requests from the Contributors page.
+    cacheApi.getOrElseUpdate[CurrentCityFunnels](s"getCurrentCityFunnels_$window", Duration(10, "minutes")) {
+      val cityId = getCityId
+      db.run(funnelStatTable.getFunnelStatsBySchema(getCitySchema(cityId), window)).map { rows =>
+        // No rows yet (the nightly FunnelStatActor hasn't run, or /adminapi/updateFunnelStats hasn't been hit): return
+        // an empty result so the page can show its "no funnel data yet" state rather than zero-filled funnels.
+        if (rows.isEmpty) CurrentCityFunnels(None, Map.empty)
+        else {
+          val byType = ConfigService.FunnelDefs.map { case (funnelType, _) =>
+            funnelType -> ConfigService.assembleCityFunnel(cityId, funnelType, rows.filter(_.funnelType == funnelType))
+          }.toMap
+          CurrentCityFunnels(rows.headOption.map(_.computedAt), byType)
+        }
+      }
+    }
+  }
+
+  def invalidateFunnelCaches(): Future[Unit] = {
+    // Both reads cache per window for 10 min; drop every window's entry so a recompute is reflected immediately rather
+    // than after the TTL. Tiny, fixed key set — cheaper and clearer than a tagged/region cache.
+    Future
+      .sequence(ConfigService.FunnelWindowKeys.flatMap { w =>
+        Seq(cacheApi.remove(s"getCityFunnels_$w"), cacheApi.remove(s"getCurrentCityFunnels_$w"))
+      })
+      .map(_ => ())
   }
 
   /**

--- a/app/views/admin/dashboard/contributors.scala.html
+++ b/app/views/admin/dashboard/contributors.scala.html
@@ -22,6 +22,34 @@
         <div class="coverage-status" id="contrib-status" role="status" aria-live="polite">Loading contributor data…</div>
     </div>
 
+    <div class="api-section" id="funnel-section">
+        <h2 class="api-heading" id="funnels">Engagement funnels <a href="#funnels" class="permalink">#</a></h2>
+        <p>Of the people who arrive, how many make it through each step? Two funnels: the <strong>mapping</strong> funnel
+            follows the Explore onboarding (tutorial → first label → first mission), and the <strong>contribution</strong>
+            funnel is the broader “did they contribute anything (labeling or validation) and finish a mission”. Bars are
+            normalized to visitors (= 100%); the percentage on each step is its share of the step before it (the
+            drop-off).</p>
+        <p class="ac-note">Two caveats. <strong>Anonymous visitors are counted per browser</strong> (a new id each time
+            cookies are cleared), so the top of each funnel counts sessions, not unique people, and headline conversion
+            reads low. <strong>The mapping tool is desktop-only</strong> — mobile visitors are redirected to a landing
+            page and can’t proceed, so in the “Desktop vs mobile” view mobile drops off early by design. In the mapping
+            funnel, “took a step” means a user walked some distance in a real (non-tutorial) mission.</p>
+        <div class="ac-funnel-controls">
+            <div class="ac-toggle" id="funnel-window" role="group" aria-label="Funnel time window">
+                <button type="button" class="ac-toggle-btn active" data-window="30d">Last 30 days</button>
+                <button type="button" class="ac-toggle-btn" data-window="90d">Last 90 days</button>
+                <button type="button" class="ac-toggle-btn" data-window="all">All time</button>
+            </div>
+            <div class="ac-toggle" id="funnel-dim" role="group" aria-label="Funnel breakdown">
+                <button type="button" class="ac-toggle-btn active" data-dim="all">All users</button>
+                <button type="button" class="ac-toggle-btn" data-dim="role">Registered vs anonymous</button>
+                <button type="button" class="ac-toggle-btn" data-dim="device">Desktop vs mobile</button>
+            </div>
+        </div>
+        <div id="funnel-blocks"></div>
+        <div class="coverage-status" id="funnel-status" role="status" aria-live="polite"></div>
+    </div>
+
     <div class="api-section" id="contributor-quality-section">
         <h2 class="api-heading" id="contributor-quality">Contributors by quality <a href="#contributor-quality" class="permalink">#</a></h2>
         <p>How many contributors are flagged high- vs low-quality.</p>
@@ -70,11 +98,19 @@
     </div>
 
     <script src="@assets.path("javascripts/admin-dashboard/contributors.js")"></script>
+    <script src="@assets.path("javascripts/admin-dashboard/funnels-section.js")"></script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {
             new ContributorsPage({
                 userStatsUrl: '/adminapi/getUserStats',
                 leaderboardsUrl: '/adminapi/contributorLeaderboards'
+            }).init();
+            new FunnelsSection({
+                funnelsUrl: '/adminapi/funnels',
+                hostId: 'funnel-blocks',
+                statusId: 'funnel-status',
+                windowToggleId: 'funnel-window',
+                dimToggleId: 'funnel-dim'
             }).init();
         });
     </script>

--- a/conf/routes
+++ b/conf/routes
@@ -95,6 +95,7 @@ GET     /adminapi/recentActivity                        controllers.AdminControl
 GET     /adminapi/getRecentLabelMetadata                controllers.AdminController.getRecentLabelMetadata
 GET     /adminapi/getUserStats                          controllers.AdminController.getUserStats
 GET     /adminapi/contributorLeaderboards               controllers.AdminController.getContributorLeaderboards(n: Int ?= 15)
+GET     /adminapi/funnels                               controllers.AdminController.getCurrentCityFunnels(window: Option[String])
 GET     /adminapi/apiAnalytics                          controllers.AdminController.getApiAnalytics(excludeApiDocs: Boolean ?= true, days: Int ?= 30)
 GET     /adminapi/apiAnalyticsBySource                  controllers.AdminController.getApiAnalyticsBySource(days: Int ?= 30)
 GET     /adminapi/activityByDay                          controllers.AdminController.getActivityByDay

--- a/public/javascripts/admin-dashboard/funnels-section.js
+++ b/public/javascripts/admin-dashboard/funnels-section.js
@@ -1,0 +1,212 @@
+/**
+ * Renders this deployment's own engagement funnels on the single-city admin Contributors page (#4379).
+ *
+ * The per-city counterpart of the cross-city funnels on the Across Cities page (#288): it reads /adminapi/funnels
+ * (this schema only) and draws the two funnels — "mapping" (the Explore onboarding flow) and "contribution" (any
+ * labeling/validation contribution and finishing a mission) — as horizontal bar funnels, each step normalized to its
+ * segment's visitors (= 100%) and labeled with the count and per-step drop-off. A window selector refetches; a
+ * breakdown selector (all / registered-vs-anonymous / desktop-vs-mobile) re-renders from cached data. Reuses the
+ * shared `.ac-funnel-*` / `.ac-toggle` CSS; no charting library.
+ *
+ * The set and order of steps come from each funnel's `steps` array in the response — this class only supplies
+ * presentational labels — so the funnel shape stays defined by the backend (ConfigService.FunnelDefs).
+ */
+class FunnelsSection {
+    /**
+     * Display names for the funnel steps, keyed by the backend step keys. `full` labels the bar rows; `short` is unused
+     * here but kept parallel to the Across Cities page for consistency. Covers both funnels.
+     */
+    static #STEP_LABELS = {
+        visited:                { full: 'Visited site' },
+        tutorial_started:       { full: 'Started tutorial' },
+        tutorial_finished:      { full: 'Finished or skipped tutorial' },
+        took_step:              { full: 'Took a step' },
+        labeled:                { full: 'Placed a label' },
+        mission_completed:      { full: 'Completed a mapping mission' },
+        contributed:            { full: 'Labeled or validated' },
+        contribution_completed: { full: 'Completed a labeling/validation mission' }
+    };
+
+    /** Title + one-line description for each funnel, shown above its bars. Keyed by funnel type. */
+    static #FUNNEL_META = {
+        mapping:      { title: 'Mapping funnel',
+            desc: 'The Explore onboarding flow: tutorial, then walking, labeling, and completing an audit mission.' },
+        contribution: { title: 'Contribution funnel',
+            desc: 'The broad view: any contribution (labeling or validation) and finishing a mission.' }
+    };
+
+    /** Funnel display order on the page. The endpoint may include any subset of these. */
+    static #FUNNEL_ORDER = ['mapping', 'contribution'];
+
+    /** Which segment keys (matching the endpoint's per-funnel `segments` object) each breakdown dimension shows. */
+    static #DIMS = {
+        all:    [{ key: 'all',        label: 'All users' }],
+        role:   [{ key: 'registered', label: 'Registered' }, { key: 'anonymous', label: 'Anonymous' }],
+        device: [{ key: 'desktop',    label: 'Desktop' }, { key: 'mobile', label: 'Mobile' },
+            { key: 'device_unknown', label: 'Unknown' }]
+    };
+
+    /** Bar colors by segment position within the active dimension. */
+    static #SEG_COLORS = ['#4a90d9', '#e0a800', '#b3b3b3'];
+
+    #funnelsUrl;
+    #hostId;
+    #statusId;
+    #windowToggleId;
+    #dimToggleId;
+
+    #funnels = {};          // { mapping: {steps, segments}, contribution: {steps, segments} } for the current window.
+    #computedAt = null;     // ISO string of when this city's funnel_stat was last recomputed, or null.
+    #window = '30d';        // '30d' | '90d' | 'all'.
+    #dim = 'all';           // 'all' | 'role' | 'device'.
+
+    /**
+     * @param {{funnelsUrl: string, hostId: string, statusId: string, windowToggleId: string, dimToggleId: string}} opts
+     */
+    constructor(opts = {}) {
+        this.#funnelsUrl = opts.funnelsUrl;
+        this.#hostId = opts.hostId;
+        this.#statusId = opts.statusId;
+        this.#windowToggleId = opts.windowToggleId;
+        this.#dimToggleId = opts.dimToggleId;
+    }
+
+    async init() {
+        this.#wireControls();
+        await this.#load();
+    }
+
+    /** Wires the window selector (refetches) and the breakdown toggle (re-renders from cached data). */
+    #wireControls() {
+        const win = document.getElementById(this.#windowToggleId);
+        if (win) win.querySelectorAll('.ac-toggle-btn').forEach(btn => btn.addEventListener('click', () => {
+            if (this.#window === btn.dataset.window) return;
+            this.#window = btn.dataset.window;
+            win.querySelectorAll('.ac-toggle-btn').forEach(b => b.classList.toggle('active', b === btn));
+            this.#load();
+        }));
+        const dim = document.getElementById(this.#dimToggleId);
+        if (dim) dim.querySelectorAll('.ac-toggle-btn').forEach(btn => btn.addEventListener('click', () => {
+            if (this.#dim === btn.dataset.dim) return;
+            this.#dim = btn.dataset.dim;
+            dim.querySelectorAll('.ac-toggle-btn').forEach(b => b.classList.toggle('active', b === btn));
+            this.#render();
+        }));
+    }
+
+    /** Fetches the funnels for the current window and renders them; a failure shows a message but leaves the page intact. */
+    async #load() {
+        this.#setText(this.#statusId, 'Loading funnels…');
+        try {
+            const data = await this.#fetchJson(`${this.#funnelsUrl}?window=${encodeURIComponent(this.#window)}`);
+            this.#funnels = (data && data.funnels) || {};
+            this.#computedAt = (data && data.computed_at) || null;
+            this.#render();
+        } catch (err) {
+            console.error('Funnel load failed:', err);
+            this.#setText(this.#statusId, 'Could not load funnel data.');
+        }
+    }
+
+    /** Renders each available funnel (mapping, contribution) for the active breakdown dimension. */
+    #render() {
+        const host = document.getElementById(this.#hostId);
+        if (!host) return;
+        const segs = FunnelsSection.#DIMS[this.#dim] || FunnelsSection.#DIMS.all;
+        const types = FunnelsSection.#FUNNEL_ORDER.filter(t => this.#funnels[t]);
+        if (!types.length) {
+            host.innerHTML = '';
+            // No funnel_stat rows yet: the nightly job hasn't run for this deployment, or it was never triggered.
+            this.#setText(this.#statusId,
+                'No funnel data yet — an admin can recompute it via /adminapi/updateFunnelStats.');
+            return;
+        }
+        host.innerHTML = types.map(t => this.#funnelBlock(t, this.#funnels[t], segs)).join('');
+        this.#setText(this.#statusId, this.#computedAt
+            ? `Data as of ${this.#formatDate(this.#computedAt)}.`
+            : '');
+    }
+
+    /**
+     * One funnel block: heading, description, optional legend, and the step bars for the active dimension.
+     * @param {string} funnelType 'mapping' | 'contribution'.
+     * @param {{steps: string[], segments: object}} funnel The funnel's step keys and per-segment data.
+     * @param {{key: string, label: string}[]} segs Segments to show for the active dimension.
+     * @returns {string} The block's HTML.
+     */
+    #funnelBlock(funnelType, funnel, segs) {
+        const meta = FunnelsSection.#FUNNEL_META[funnelType] || { title: funnelType, desc: '' };
+        const steps = funnel.steps || [];
+        const segments = funnel.segments || {};
+        const palette = FunnelsSection.#SEG_COLORS;
+
+        const legend = segs.length > 1
+            ? '<div class="ac-funnel-legend">' + segs.map((s, i) =>
+                `<span class="ac-funnel-legend-item"><span class="ac-funnel-swatch" ` +
+                `style="background:${palette[i] || palette[0]}"></span>${FunnelsSection.#esc(s.label)}</span>`).join('') +
+                '</div>'
+            : '';
+
+        const stepRows = steps.map((k, i) => {
+            const full = (FunnelsSection.#STEP_LABELS[k] || { full: k }).full;
+            const bars = segs.map((s, si) => {
+                const d = segments[s.key];
+                const v = d ? d.steps[i] : 0;
+                const base = d && d.steps[0] > 0 ? d.steps[0] : 0;
+                const width = base > 0 ? (v / base) * 100 : 0;
+                const conv = d ? d.step_conversion[i] : 0;
+                const valText = i === 0 ? this.#compact(v) : `${this.#compact(v)} · ${this.#pct(conv)}`;
+                const title = i === 0
+                    ? `${FunnelsSection.#esc(full)}: ${this.#num(v)} visitors`
+                    : `${FunnelsSection.#esc(full)}: ${this.#num(v)} — ${this.#pct(conv)} of previous step`;
+                return `<div class="ac-funnel-bar" title="${title}">` +
+                    `<span class="ac-funnel-bar-fill" style="width:${width.toFixed(1)}%;` +
+                    `background:${palette[si] || palette[0]}"></span>` +
+                    `<span class="ac-funnel-bar-val">${valText}</span></div>`;
+            }).join('');
+            return `<div class="ac-funnel-step"><div class="ac-funnel-step-label">${FunnelsSection.#esc(full)}</div>` +
+                `<div class="ac-funnel-bars">${bars}</div></div>`;
+        }).join('');
+
+        return '<div class="ac-funnel-block">' +
+            `<h3 class="ac-funnel-block-title">${FunnelsSection.#esc(meta.title)}</h3>` +
+            `<p class="ac-note">${FunnelsSection.#esc(meta.desc)}</p>` +
+            `<div class="ac-funnel-panel">${legend}${stepRows}</div>` +
+            '</div>';
+    }
+
+    async #fetchJson(url) {
+        const resp = await fetch(url, { headers: { Accept: 'application/json' } });
+        if (!resp.ok) throw new Error(`Request failed (${resp.status}): ${url}`);
+        return resp.json();
+    }
+
+    #setText(id, text) {
+        const el = document.getElementById(id);
+        if (el) el.textContent = text;
+    }
+
+    /** Full count with thousands separators, for tooltips. */
+    #num(v) { return (v || 0).toLocaleString(); }
+
+    /** Compact count for the on-bar label (e.g. 1.2k), to keep narrow bars legible. */
+    #compact(v) {
+        const n = v || 0;
+        if (n >= 1000) return `${(n / 1000).toFixed(n >= 10000 ? 0 : 1)}k`;
+        return `${n}`;
+    }
+
+    /** A 0–1 fraction as a rounded percent. */
+    #pct(frac) { return `${Math.round((frac || 0) * 100)}%`; }
+
+    /** ISO timestamp → a short local date string; falls back to the raw value if unparseable. */
+    #formatDate(iso) {
+        const d = new Date(iso);
+        return isNaN(d) ? iso : d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+    }
+
+    static #esc(s) {
+        return String(s == null ? '' : s)
+            .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+    }
+}

--- a/test/controllers/AdminCurrentCityFunnelsSpec.scala
+++ b/test/controllers/AdminCurrentCityFunnelsSpec.scala
@@ -1,0 +1,42 @@
+package controllers
+
+import org.apache.pekko.stream.Materializer
+import org.scalatestplus.play.PlaySpec
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+
+/**
+ * Smoke tests for the single-city engagement-funnel endpoint (#4379): GET /adminapi/funnels (Admin).
+ *
+ * Verifies the route is wired (not 404) and the auth guard is in place — unauthenticated requests are redirected to
+ * sign-in rather than served data — across the optional window param. Boots the full application with a real DB.
+ *
+ * Requires a Postgres+PostGIS database (via DATABASE_URL / DATABASE_USER / DATABASE_PASSWORD env).
+ */
+class AdminCurrentCityFunnelsSpec extends PlaySpec with GuiceOneAppPerSuite {
+
+  override def fakeApplication(): Application =
+    new GuiceApplicationBuilder()
+      .disable[modules.ActorModule]
+      .build()
+
+  implicit lazy val mat: Materializer = app.materializer
+
+  "GET /adminapi/funnels" should {
+    "redirect unauthenticated users to the sign-in page (not 404)" in {
+      val resp = route(app, FakeRequest(GET, "/adminapi/funnels")).get
+      // Must be a redirect (3xx) to sign-in — never a 404, which would indicate a missing route.
+      status(resp) must (be >= 300 and be < 400)
+    }
+
+    "also redirect for each supported window (route accepts the optional window param)" in {
+      Seq("30d", "90d", "all").foreach { w =>
+        val resp = route(app, FakeRequest(GET, s"/adminapi/funnels?window=$w")).get
+        status(resp) must (be >= 300 and be < 400)
+      }
+    }
+  }
+}

--- a/test/service/FunnelAssemblySpec.scala
+++ b/test/service/FunnelAssemblySpec.scala
@@ -1,0 +1,66 @@
+package service
+
+import models.utils.FunnelStat
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import java.time.{OffsetDateTime, ZoneOffset}
+
+/**
+ * Pure (no DB, no app boot) unit test for [[ConfigService.assembleCityFunnel]], the shared per-city funnel assembly
+ * used by both the cross-city (#288) and single-city (#4379) reads.
+ *
+ * Pins the three behaviors the read paths rely on: segment keys map to the right [[CityFunnel]] fields, missing
+ * segments zero-fill to the funnel's step count, and the stored six-slot steps are trimmed to the funnel's actual
+ * length (so the 3-step contribution funnel never leaks the padding zeros of the 6-slot row).
+ */
+class FunnelAssemblySpec extends AnyFunSuite with Matchers {
+
+  private val computedAt: OffsetDateTime = OffsetDateTime.of(2026, 6, 30, 12, 0, 0, 0, ZoneOffset.UTC)
+
+  /** A funnel_stat row, padded to the stored six slots like the real table. */
+  private def row(funnelType: String, segment: String, steps: Int*): FunnelStat =
+    FunnelStat(funnelType, "30d", segment, steps.toSeq.padTo(6, 0), computedAt)
+
+  test("maps each segment key to the matching CityFunnel field") {
+    val rows = Seq(
+      row("mapping", "all", 100, 80, 60, 40, 20, 10),
+      row("mapping", "role:registered", 30, 28, 26, 24, 22, 20),
+      row("mapping", "role:anon", 70, 52, 34, 16, 8, 4),
+      row("mapping", "device:desktop", 60, 50, 40, 30, 20, 10),
+      row("mapping", "device:mobile", 35, 25, 15, 5, 0, 0),
+      row("mapping", "device:unknown", 5, 5, 5, 5, 0, 0)
+    )
+    val funnel = ConfigService.assembleCityFunnel("seattle-wa", "mapping", rows)
+
+    funnel.cityId shouldBe "seattle-wa"
+    funnel.all.steps shouldBe Seq(100, 80, 60, 40, 20, 10)
+    funnel.registered.steps shouldBe Seq(30, 28, 26, 24, 22, 20)
+    funnel.anonymous.steps shouldBe Seq(70, 52, 34, 16, 8, 4)
+    funnel.desktop.steps shouldBe Seq(60, 50, 40, 30, 20, 10)
+    funnel.mobile.steps shouldBe Seq(35, 25, 15, 5, 0, 0)
+    funnel.deviceUnknown.steps shouldBe Seq(5, 5, 5, 5, 0, 0)
+  }
+
+  test("zero-fills every segment that has no row, to the funnel's step count") {
+    // Only the "all" segment is present (e.g. a city with no anonymous or mobile users).
+    val funnel = ConfigService.assembleCityFunnel("x", "mapping", Seq(row("mapping", "all", 10, 8, 6, 4, 2, 1)))
+
+    val zeros = Seq(0, 0, 0, 0, 0, 0)
+    funnel.registered.steps shouldBe zeros
+    funnel.anonymous.steps shouldBe zeros
+    funnel.desktop.steps shouldBe zeros
+    funnel.mobile.steps shouldBe zeros
+    funnel.deviceUnknown.steps shouldBe zeros
+  }
+
+  test("trims the stored six-slot steps to the contribution funnel's three steps") {
+    // The contribution row is still stored padded to six slots; only the first three are real.
+    val funnel =
+      ConfigService.assembleCityFunnel("x", "contribution", Seq(row("contribution", "all", 100, 40, 12)))
+
+    funnel.all.steps shouldBe Seq(100, 40, 12)
+    funnel.all.steps.length shouldBe 3
+    funnel.registered.steps shouldBe Seq(0, 0, 0) // zero-filled, also at the funnel's length, not six.
+  }
+}


### PR DESCRIPTION
Closes #4379. Follow-up to #288 / #4378.

## What

Surfaces this deployment's own **mapping** and **contribution** engagement funnels on the single-city admin **Contributors** page (`/admin/contributors`), so per-city Administrators can see their onboarding/contribution conversion **without Owner access** to the cross-city Across Cities page. The funnel data already exists per city (`funnel_stat`, precomputed nightly by `FunnelStatActor`); this reads the current schema and renders it.

Placement on **Contributors** follows the issue's recommendation (a funnel is a per-user conversion view).

## How

**Backend**
- `ConfigService`: relocated `assembleCityFunnel` to the companion object as a **pure** function — now shared by the cross-city and single-city reads and unit-testable. Added `getCurrentCityFunnels(window)`, a single-schema read of the current city's `funnel_stat` (no cross-schema fan-out).
- `AdminController`: new **`WithAdmin()`-gated** `getCurrentCityFunnels` emitting segment-keyed snake_case JSON (vs. the Owner-gated cross-city `getCityFunnels`); lifted the shared `funnelSegJson` helper so both endpoints serialize identically.
- Route: `GET /adminapi/funnels`.
- `updateFunnelStatTable` now calls a new `ConfigService.invalidateFunnelCaches()` after writing, so a manual `/adminapi/updateFunnelStats` (or the nightly job) is reflected on the next page load instead of after the 10-minute cache TTL.

**Frontend**
- New "Engagement funnels" section on the Contributors page with window (30d/90d/all) and breakdown (all / registered-vs-anonymous / desktop-vs-mobile) toggles.
- Self-contained `funnels-section.js` (`FunnelsSection`) renderer reusing the shared `.ac-funnel-*` CSS; the step set/order comes from the endpoint's `steps` array (no hardcoded steps). Includes empty-state and a "data as of" freshness label.

## Tests
- `test/service/FunnelAssemblySpec.scala` (pure): segment-key mapping, zero-fill, 6→3 step trimming.
- `test/controllers/AdminCurrentCityFunnelsSpec.scala` (DB-backed): route wiring + auth gate, mirroring `AdminCityFunnelsSpec`.

## Notes
- **No new evolution** — `funnel_stat` already exists from evolution 327 (#4378).
- No new logged events (page visit already logs `Visit_Admin_Contributors`; toggles are client-side, consistent with Across Cities). Admin-only page, so English-only (no i18n).
- Verified locally against real Seattle data: empty-state → `updateFunnelStats` → both funnels render; window/breakdown toggles work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)