### PR TITLE
Tame dependency-bot noise: monthly cadence, freeze pins, auto-merge (#4385)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,18 @@
 version: 2
 # Dependabot has no native sbt/Scala updater — those are handled by the hosted Scala Steward instance
-# (this repo is registered with VirtusLab's public instance). Dependabot here covers npm, GitHub Actions, and Docker.
+# (this repo is registered with VirtusLab's public instance; config in `.scala-steward.conf`). Dependabot
+# here covers npm, GitHub Actions, and Docker.
+#
+# Cadence is monthly so version-currency PRs arrive as one predictable batch for a two-person team, rather
+# than a weekly trickle. This throttles *version* noise only — Dependabot *security* updates (GHSA/CVE-driven)
+# are a separate channel and still fire immediately (enable them in Settings → Code security). Green patch &
+# minor bumps auto-merge via `.github/workflows/dependency-auto-merge.yml`; majors and deliberate freezes need
+# a human. See issue #4385 for the standing dependency/platform maintenance strategy.
 updates:
   - package-ecosystem: npm
     directory: "/"
     schedule:
-      interval: weekly
+      interval: monthly
     open-pull-requests-limit: 5
     groups:
       npm-dependencies:
@@ -14,7 +21,7 @@ updates:
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: weekly
+      interval: monthly
     groups:
       github-actions:
         patterns: ["*"]
@@ -22,7 +29,13 @@ updates:
   - package-ecosystem: docker
     directory: "/"
     schedule:
-      interval: weekly
+      interval: monthly
     groups:
       docker:
         patterns: ["*"]
+    ignore:
+      # Stay on JDK 17 (an LTS). Dependabot keeps re-proposing odd, non-LTS temurin majors (19, 21-preview…);
+      # 19 was already rejected as EOL (#4247). The Java 17→21 LTS move is a deliberate, tracked migration
+      # (#4385, #3936), not a bot bump. Minor/OS bumps within 17 (e.g. focal→jammy) are still allowed.
+      - dependency-name: "eclipse-temurin"
+        update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 # Dependabot has no native sbt/Scala updater — those are handled by the hosted Scala Steward instance
 # (this repo is registered with VirtusLab's public instance; config in `.scala-steward.conf`). Dependabot
-# here covers npm, GitHub Actions, and Docker.
+# here covers npm, GitHub Actions, Docker, and Python (pip).
 #
 # Cadence is monthly so version-currency PRs arrive as one predictable batch for a two-person team, rather
 # than a weekly trickle. This throttles *version* noise only — Dependabot *security* updates (GHSA/CVE-driven)
@@ -17,6 +17,16 @@ updates:
     groups:
       npm-dependencies:
         patterns: ["*"]
+    ignore:
+      # Frontend lint/test toolchain is owned by #2487 (sequenced with the ES5→ES6 migration) and not yet wired
+      # into CI, so major bumps here (eslint 7→10 flat-config, stylelint 13→17, jest 29→30, htmlhint 0.14→1.9)
+      # would break `make lint` the moment #2487 revives it. Un-ignore these as part of that work.
+      - dependency-name: "eslint"
+      - dependency-name: "htmlhint"
+      - dependency-name: "jest"
+      - dependency-name: "jest-environment-jsdom"
+      - dependency-name: "stylelint"
+      - dependency-name: "stylelint-config-standard"
 
   - package-ecosystem: github-actions
     directory: "/"
@@ -39,3 +49,13 @@ updates:
       # (#4385, #3936), not a bot bump. Minor/OS bumps within 17 (e.g. focal→jammy) are still allowed.
       - dependency-name: "eclipse-temurin"
         update-types: ["version-update:semver-major"]
+
+  # Watch the Python deps in requirements*.txt so their security alerts (requests, pytest, tqdm) get auto-fix
+  # PRs like the other ecosystems (#4385, workstream A).
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: monthly
+    groups:
+      pip-dependencies:
+        patterns: ["*"]

--- a/.github/workflows/dependency-auto-merge.yml
+++ b/.github/workflows/dependency-auto-merge.yml
@@ -1,0 +1,52 @@
+name: Dependency auto-merge
+
+# Enable GitHub auto-merge for green patch & minor dependency bumps so they clear the review queue on their
+# own once the required checks pass. Majors, and anything a required check fails, still wait for a human.
+# Security is unaffected: this only decides *when to merge*, never *what to merge* — branch protection's
+# required checks (compile + scalafmt, frontend build) are the gate. See issue #4385, workstream B.
+#
+# `pull_request_target` runs in the base-repo context (needed for the token to enable auto-merge on bot PRs),
+# so this workflow file must never checkout or execute PR-authored code.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, labeled, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    # Dependabot: derive the semver bump from official metadata (reliable), auto-merge patch & minor.
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Enable auto-merge for patch & minor
+        if: >-
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  scala-steward:
+    # Scala Steward has no metadata action, so key off the semver labels it attaches to its PRs.
+    # If a Steward PR arrives unlabeled it simply won't auto-merge (falls back to the monthly manual sweep).
+    if: >-
+      github.actor == 'scala-steward' &&
+      (contains(github.event.pull_request.labels.*.name, 'semver-patch') ||
+       contains(github.event.pull_request.labels.*.name, 'semver-minor'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge for patch & minor
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,13 @@
+# Scala Steward config for the hosted VirtusLab public instance (sbt/Scala deps only).
+# Companion to `.github/dependabot.yml` (npm/Actions/Docker) and issue #4385 (maintenance strategy).
+
+# One predictable batch per month rather than a weekly trickle — matches the Dependabot cadence and suits a
+# two-person team. Security-relevant bumps still surface here; the throttle is about grouping, not suppressing.
+pullRequests.frequency = "@monthly"
+
+updates.ignore = [
+  # GeoTools is deliberately frozen at 29.6 (build.sbt) on a compat issue — jai_core phase-out + our
+  # export/reprojection paths. Moving to a current major (35.x) is a tracked migration (#4385), not a bot
+  # bump, so silence the recurring gt-* PRs (e.g. the 35.0 bump in #4280) until that migration is scheduled.
+  { groupId = "org.geotools" }
+]

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -11,3 +11,10 @@ updates.ignore = [
   # bump, so silence the recurring gt-* PRs (e.g. the 35.0 bump in #4280) until that migration is scheduled.
   { groupId = "org.geotools" }
 ]
+
+# Keep jackson-datatype-jts on its 1.x line. The 3.x line targets Jackson 3 (package rename
+# com.fasterxml.jackson → tools.jackson), but Play 3.0 runs on Jackson 2 — so 3.x is incompatible until a
+# framework-wide Jackson 3 move. Still allow 1.x patch/minor updates.
+updates.pin = [
+  { groupId = "org.n52.jackson", artifactId = "jackson-datatype-jts", version = "1." }
+]


### PR DESCRIPTION
Relieves the piled-up Dependabot / Scala Steward PR queue by encoding our constraints into the bots and auto-clearing the safe bumps. This is workstream **B** of the maintenance strategy in #4385 — a concrete down-payment that doesn't front-run the parts still awaiting @misaugstad's input (EOL runtimes, migration cadence, DB parity).

## The problem
The bots aren't wrong — nothing told them our constraints, and nothing merged the safe stuff. So the queue grew, and PRs we'd already rejected kept coming back (e.g. Dependabot re-offering the temurin **Java 19** bump #4254, an EOL odd release closed once as #4247).

## Changes
1. **Monthly cadence** for all Dependabot ecosystems (npm/Actions/Docker) and Scala Steward (`.scala-steward.conf`), so version-currency PRs arrive as one predictable batch instead of a weekly trickle.
2. **Encode deliberate freezes** so the bots stop re-proposing rejected bumps:
   - Dependabot: ignore `eclipse-temurin` **semver-major** — stay on JDK 17 LTS; the 17→21 move is tracked (#4385/#3936), not a bot bump. Minor/OS bumps within 17 (focal→jammy) still allowed.
   - Scala Steward: ignore `org.geotools` — frozen at 29.6 pending the tracked GeoTools migration (silences the 35.0 bump in #4280).
3. **Auto-merge** (`.github/workflows/dependency-auto-merge.yml`): enables GitHub auto-merge for **green patch & minor** bumps from both bots, gated entirely on the existing required checks. Majors and any check failure still wait for a human.

## Security is unaffected
This throttles *version-currency* noise only. Dependabot **security** updates (GHSA/CVE-driven) are a separate channel and still fire immediately — confirm "Dependabot security updates" is on in Settings → Code security.

## Notes / follow-ups
- Adds `semver-{patch,minor,major}` + `library-update` labels for Steward keying. The Steward auto-merge job keys on `semver-patch`/`semver-minor` labels; **our existing Steward PRs are unlabeled**, so this arms on Steward's *next* run — worth confirming it actually attaches semver labels on the hosted instance, else that job never fires (safe fallback: monthly manual merge).
- Once merged, close the now-blocked bot PRs: **#4254** (Java 19) and **#4280** (GeoTools 35.0). The ignore rules prevent the re-offer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)