### PR TITLE
Fix dependency security alerts: requests, grunt, tqdm (#4385)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "devDependencies": {
         "eslint": "^7.26.0",
-        "grunt": "^1.4.0",
+        "grunt": "^1.6.2",
         "grunt-concat-css": "*",
         "grunt-contrib-concat": "*",
         "grunt-contrib-watch": "*",

--- a/requirements-offline-tools.txt
+++ b/requirements-offline-tools.txt
@@ -6,4 +6,4 @@
 shapely==2.0.2
 geopy==2.4.1
 tenacity==8.2.3
-tqdm==4.66.1
+tqdm==4.68.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@
 pandas==2.0.3
 haversine==2.8.1
 scipy==1.10.1
-requests==2.34.2
+requests==2.32.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@
 pandas==2.0.3
 haversine==2.8.1
 scipy==1.10.1
-requests==2.31.0
+requests==2.34.2


### PR DESCRIPTION
Clears the immediate open Dependabot **security alerts** by bumping three deps out of their vulnerable ranges. Kept deliberately small and decoupled from the config/policy PR (#4403) so it can merge fast.

| Dep | From → To | Alerts cleared | Surface |
|---|---|---|---|
| `requests` | 2.31.0 → **2.34.2** | GHSA-9wx4-h78v-vm56, GHSA-9hjg-9r4m-mvj7, GHSA-gc5v-m9x4-r6x2 (3× MEDIUM) | offline `check_streets_for_imagery.py` |
| `grunt` | ^1.4.0 → **^1.6.2** | GHSA-rm36-94g8-835r, GHSA-m5pj-vjjf-4m3h (HIGH), GHSA-j383-35pm-c5h4 | build-time tooling (raises vulnerable floor) |
| `tqdm` | 4.66.1 → **4.68.3** | GHSA-g7vv-2v7x-gj9p (LOW) | offline imagery script |

All three are in dev/build/offline-script tooling, not the running app's request path — real-world risk is low, but the fixes are trivial and the alerts are noise otherwise.

**Not included:** `pytest` 7.4.4 → 9.x is a two-major jump that needs the test suite validated against it, so it's left for the new **pip Dependabot ecosystem** (added in #4403) to propose, where the advisory Python-tests CI will vet it.

Advisory Python-tests and frontend-build CI here will confirm nothing broke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)