### PR TITLE
Apply safe Scala Steward patch/minor bumps on current base (#4385)

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = "3.9.7"
+version = "3.9.10"
 runner.dialect = scala213 // Or scala3, scala212, etc., matching your project
 
 docstrings.style = Asterisk // JavaDoc style.

--- a/build.sbt
+++ b/build.sbt
@@ -17,10 +17,10 @@ resolvers ++= Seq(
 // Play: https://mvnrepository.com/artifact/com.typesafe.play/play?repo=central
 libraryDependencies ++= Seq(
   // General Play stuff.
-  "org.playframework" %% "play-guice"          % "3.0.10",
-  "org.playframework" %% "play-cache"          % "3.0.10",
-  "org.playframework" %% "play-ws"             % "3.0.10",
-  "org.playframework" %% "play-caffeine-cache" % "3.0.10",
+  "org.playframework" %% "play-guice"          % "3.0.11",
+  "org.playframework" %% "play-cache"          % "3.0.11",
+  "org.playframework" %% "play-ws"             % "3.0.11",
+  "org.playframework" %% "play-caffeine-cache" % "3.0.11",
   "org.playframework" %% "play-mailer" % "10.1.0", // play-mailer is on a different versioning scheme than Play itself.
   "org.playframework" %% "play-mailer-guice" % "10.1.0", // play-mailer is on a different versioning scheme than Play itself.
   "org.playframework" %% "play-json" % "3.0.6", // play-json is on a different versioning scheme than Play itself.
@@ -62,7 +62,7 @@ libraryDependencies ++= Seq(
   "org.geotools" % "gt-geopkg"    % "29.6" exclude ("javax.media", "jai_core"),
 
   // Testing. scalatestplus-play pulls in ScalaTest + Play's test helpers (FakeRequest, route, etc.).
-  "org.scalatestplus.play" %% "scalatestplus-play" % "7.0.1" % Test
+  "org.scalatestplus.play" %% "scalatestplus-play" % "7.0.2" % Test
 )
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.9
+sbt.version=1.12.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,9 +10,9 @@ resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releas
 // Use the Play sbt plugin for Play projects
 addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.10")
 
-// Code formatting check (scalafmtCheckAll). The scalafmt version itself is pinned in .scalafmt.conf (3.9.7); this
+// Code formatting check (scalafmtCheckAll). The scalafmt version itself is pinned in .scalafmt.conf (3.9.10); this
 // plugin fetches it dynamically. Wired into CI as advisory-only for now (no repo-wide reformat pass yet).
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.4")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.6")
 
 // Test coverage (scoverage). Used in a later CI phase with a low, ratcheting threshold.
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.3.1")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.4.4")


### PR DESCRIPTION
Re-applies six low-risk Scala Steward bumps whose original fork PRs sit on a **pre-admin-redesign base** (06-24) that no longer compiles against current `develop` and can't be rebased (they live on scala-steward's fork). Batched onto current `develop` so CI actually validates them.

| Bump | From → To | Level | Replaces |
|---|---|---|---|
| Play modules (guice/cache/ws/caffeine-cache) | 3.0.10 → 3.0.11 | patch | #4282 |
| scalatestplus-play | 7.0.1 → 7.0.2 | patch | #4287 |
| sbt | 1.12.9 → 1.12.13 | patch | #4284 |
| sbt-scalafmt | 2.5.4 → 2.5.6 | patch | #4285 |
| scalafmt-core | 3.9.7 → 3.9.10 | patch | #4286 |
| sbt-scoverage | 2.3.1 → 2.4.4 | minor | #4288 |

Notes:
- Play modules move as a set (Play releases all `play-*` at one version); the original PR only named a couple, but leaving the rest at 3.0.10 would be an inconsistent split.
- `scalafmt-core` 3.9.10 was already proven format-clean on the tree by #4286's CI; no reformat needed. `plugins.sbt`'s inline version reference is updated to match.
- No `.scala` source files changed — only build definitions. The blocking compile + `scalafmtCheckAll` gates and advisory API/Python tests validate here.

Once green, the six replaced Steward PRs get closed pointing here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)