### PR TITLE
Use `docker compose` (v2) in Makefile instead of deprecated `docker-compose`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,17 +24,17 @@ lint-fix:
 	@make lint-fix-eslint; make lint-fix-stylelint
 
 docker-up:
-	@docker-compose up -d
+	@docker compose up -d
 
 docker-up-db:
-	@docker-compose up -d db
+	@docker compose up -d db
 
 docker-stop:
-	@docker-compose stop
-	@docker-compose rm -f
+	@docker compose stop
+	@docker compose rm -f
 
 docker-run:
-	@docker-compose run --rm --service-ports --name projectsidewalk-web web /bin/bash
+	@docker compose run --rm --service-ports --name projectsidewalk-web web /bin/bash
 
 ssh:
 	@docker exec -it projectsidewalk-$${target} /bin/bash


### PR DESCRIPTION
Resolves #3623. Supersedes #3669.

### What
Replaces every `docker-compose` (hyphen) invocation in the `Makefile` with `docker compose` (space).

### Why
Compose v1 — the standalone hyphenated `docker-compose` binary — has been removed from current Docker releases across macOS, Linux, and Windows in favor of the `docker compose` subcommand (the Compose V2 plugin). On up-to-date installs the old command no longer exists, breaking `make dev`, `make docker-up`, `make docker-stop`, and `make docker-run`.

### Approach
This is the minimal single-command fix discussed on #3669. Rather than duplicating each target into an OS-specific `-mac` variant, we switch to the one canonical command that works cross-platform, which is simpler to maintain and doesn't require developers to remember which target to run. Thanks to @aslassi777 for the original investigation and the Docker Troubleshooting wiki note that came out of that thread.

### Testing
`make docker-up-db` / `make docker-run` work as before against a current Docker install.