### PR TITLE
Fix Across Cities scorecard querying dropped street_edge.deleted column (#4414)

### DIFF
--- a/app/models/utils/ConfigTable.scala
+++ b/app/models/utils/ConfigTable.scala
@@ -394,27 +394,27 @@ class ConfigTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvi
              audit_windows.audits_30d   AS audits_30d,
              last_activity.ts           AS last_activity
       FROM (
-          SELECT COUNT(*) AS cnt FROM "#$schema".street_edge WHERE deleted = FALSE
+          SELECT COUNT(*) AS cnt FROM "#$schema".street_edge WHERE status = 'open'
       ) AS total_streets, (
-          -- Filter audited streets to non-deleted so the numerator can't exceed total_streets (deleted streets can
+          -- Filter audited streets to open-only so the numerator can't exceed total_streets (non-open streets can
           -- still have audit_task rows, which would push coverage above 100% and make "streets left" negative). #4329
           SELECT COUNT(DISTINCT street_edge.street_edge_id) AS cnt
           FROM "#$schema".street_edge
           INNER JOIN "#$schema".audit_task ON street_edge.street_edge_id = audit_task.street_edge_id
           INNER JOIN "#$schema".user_stat ON audit_task.user_id = user_stat.user_id
-          WHERE completed = TRUE AND NOT user_stat.excluded AND street_edge.deleted = FALSE
+          WHERE completed = TRUE AND NOT user_stat.excluded AND street_edge.status = 'open'
       ) AS audited_streets, (
           SELECT SUM(ST_LENGTH(ST_TRANSFORM(geom, 26918))) / 1000 AS km
-          FROM "#$schema".street_edge WHERE deleted = FALSE
+          FROM "#$schema".street_edge WHERE status = 'open'
       ) AS street_km, (
-          -- Distinct audited length (no double-counting overlapping audits), non-deleted only (see audited_streets).
+          -- Distinct audited length (no double-counting overlapping audits), open-only (see audited_streets).
           SELECT SUM(ST_LENGTH(ST_TRANSFORM(geom, 26918))) / 1000 AS km
           FROM (
               SELECT DISTINCT street_edge.street_edge_id, geom
               FROM "#$schema".street_edge
               INNER JOIN "#$schema".audit_task ON street_edge.street_edge_id = audit_task.street_edge_id
               INNER JOIN "#$schema".user_stat ON audit_task.user_id = user_stat.user_id
-              WHERE completed = TRUE AND NOT user_stat.excluded AND street_edge.deleted = FALSE
+              WHERE completed = TRUE AND NOT user_stat.excluded AND street_edge.status = 'open'
           ) AS distinct_audited
       ) AS audited_km, (
           SELECT COUNT(DISTINCT label.label_id) AS label_count,
@@ -703,7 +703,7 @@ class ConfigTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvi
           FROM "#$schema".street_edge
           INNER JOIN "#$schema".audit_task ON street_edge.street_edge_id = audit_task.street_edge_id
           INNER JOIN "#$schema".user_stat ON audit_task.user_id = user_stat.user_id
-          WHERE completed = TRUE AND NOT user_stat.excluded AND street_edge.deleted = FALSE
+          WHERE completed = TRUE AND NOT user_stat.excluded AND street_edge.status = 'open'
       ) AS audited;
     """.as[(Double, Double)].head)
   }

--- a/test/models/utils/CityScorecardSpec.scala
+++ b/test/models/utils/CityScorecardSpec.scala
@@ -1,0 +1,63 @@
+package models.utils
+
+import org.scalatestplus.play.PlaySpec
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
+import play.api.db.slick.DatabaseConfigProvider
+import play.api.inject.guice.GuiceApplicationBuilder
+import models.utils.MyPostgresProfile.api._
+import service.CityScorecard
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+/**
+ * Integration test for the Across-Cities scorecard query on ConfigTable.
+ *
+ * `getCityScorecardBySchema` is a large per-city aggregate assembled as raw SQL against a `"#$schema".*`
+ * fan-out. Its street-availability filters must stay in sync with the `street_edge` schema — streets are
+ * filtered by the `street_edge_status` enum (`status = 'open'`, #3888), not by any scalar flag. Running the
+ * query against the live current-city schema (which has the enum applied) means a dropped or renamed column
+ * surfaces as a build failure here rather than as a silently-dropped city on the Owner-only page (where
+ * `ConfigService.getCityScorecards` swallows the per-city failure in a `.recover`).
+ *
+ * Requires a Postgres+PostGIS database (via DATABASE_URL / DATABASE_USER / DATABASE_PASSWORD env).
+ */
+class CityScorecardSpec extends PlaySpec with GuiceOneAppPerSuite {
+
+  override def fakeApplication(): Application =
+    new GuiceApplicationBuilder()
+      .disable[modules.ActorModule]
+      .build()
+
+  private lazy val configTable: ConfigTable = app.injector.instanceOf[ConfigTable]
+
+  private val dbConfig                   = app.injector.instanceOf[DatabaseConfigProvider].get[MyPostgresProfile]
+  private def run[T](action: DBIO[T]): T = Await.result(dbConfig.db.run(action), 30.seconds)
+
+  // Resolve the current city's schema the same way ConfigService.getCitySchema does; this schema has all
+  // evolutions applied, so it exercises the query against the current street_edge_status schema.
+  private val currentCityId = app.configuration.get[String]("city-id")
+  private val schema        = app.configuration.get[String](s"city-params.db-schema.$currentCityId")
+
+  "ConfigTable.getCityScorecardBySchema" should {
+    "execute against the live schema without referencing a nonexistent column" in {
+      // Pre-fix this threw `column "deleted" does not exist` on any schema migrated to the status enum.
+      val scorecard = run(configTable.getCityScorecardBySchema(schema))
+      scorecard mustBe a[CityScorecard]
+    }
+
+    "return internally-consistent street coverage counts" in {
+      val sc = run(configTable.getCityScorecardBySchema(schema))
+      sc.totalStreets must be >= 0
+      sc.auditedStreets must be >= 0
+      // The open-only filter on the numerator exists precisely so audited can't exceed total (coverage <= 100%).
+      sc.auditedStreets must be <= sc.totalStreets
+      sc.totalKm must be >= 0.0
+      sc.auditedKm must be >= 0.0
+      sc.auditedKm must be <= (sc.totalKm + 0.001) // Float tolerance; audited length can't exceed total length.
+      sc.coverage must be >= 0.0
+      sc.coverage must be <= 100.0
+    }
+  }
+}

--- a/test/models/utils/CityScorecardSpec.scala
+++ b/test/models/utils/CityScorecardSpec.scala
@@ -6,7 +6,7 @@ import play.api.Application
 import play.api.db.slick.DatabaseConfigProvider
 import play.api.inject.guice.GuiceApplicationBuilder
 import models.utils.MyPostgresProfile.api._
-import service.CityScorecard
+import service.{AggregateStats, CityScorecard}
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -58,6 +58,43 @@ class CityScorecardSpec extends PlaySpec with GuiceOneAppPerSuite {
       sc.auditedKm must be <= (sc.totalKm + 0.001) // Float tolerance; audited length can't exceed total length.
       sc.coverage must be >= 0.0
       sc.coverage must be <= 100.0
+    }
+  }
+
+  // The rest of the cross-city surface runs raw SQL against "#$schema".* and was otherwise untested — the same gap
+  // that let the dropped-column bug ship. Smoke-test each against the live current-city schema so a dropped/renamed
+  // column or enum-type mismatch fails the build here instead of silently blanking a city on the Across Cities page.
+  "ConfigTable cross-city BySchema queries" should {
+    "execute getCityMapParamsBySchema" in {
+      run(configTable.getCityMapParamsBySchema(schema)) mustBe a[MapParams]
+    }
+    "execute getCityAggregateDataBySchema" in {
+      run(configTable.getCityAggregateDataBySchema(schema)) mustBe a[AggregateStats]
+    }
+    "execute getContributorUserIdsBySchema" in {
+      run(configTable.getContributorUserIdsBySchema(schema)) mustBe a[Seq[_]]
+    }
+    "execute getLabelTypeStatsBySchema" in {
+      run(configTable.getLabelTypeStatsBySchema(schema)) mustBe a[Map[_, _]]
+    }
+    "execute getCityWeeklyTrendBySchema (all-time and windowed)" in {
+      run(configTable.getCityWeeklyTrendBySchema(schema, None)) mustBe a[Seq[_]]
+      run(configTable.getCityWeeklyTrendBySchema(schema, Some(4))) mustBe a[Seq[_]]
+    }
+    "execute getCityContributorOutputBySchema" in {
+      run(configTable.getCityContributorOutputBySchema(schema)) mustBe a[Product] // 7-tuple
+    }
+    "execute getCityLabelingSpeedBySchema" in {
+      run(configTable.getCityLabelingSpeedBySchema(schema)) mustBe a[Product] // (Double, Double)
+    }
+    "execute getCityDailyLabelStatsBySchema (both quality filters)" in {
+      run(configTable.getCityDailyLabelStatsBySchema(schema, None, None, filterLowQuality = false)) mustBe a[Seq[_]]
+      run(configTable.getCityDailyLabelStatsBySchema(schema, None, None, filterLowQuality = true)) mustBe a[Seq[_]]
+    }
+    "execute getCityDailyValidationStatsBySchema" in {
+      run(configTable.getCityDailyValidationStatsBySchema(schema, None, None, filterLowQuality = false)) mustBe a[Seq[
+        _
+      ]]
     }
   }
 }


### PR DESCRIPTION
Fixes #4414.

## Problem
The Across-Cities scorecard SQL in `ConfigTable.getCityScorecardBySchema` filtered streets on `street_edge.deleted = FALSE`, but evolution **325** (#3888) dropped that column in favor of the `street_edge_status` enum. On any city schema migrated to the enum, the query throws `column "deleted" does not exist`; `ConfigService.getCityScorecards` wraps each city in a `.recover`, so the failure is swallowed and the city **silently disappears** from the Owner-only Across Cities page.

Verified in the dev DB: `sidewalk_teaneck` (the current city) and `sidewalk_seattle` have `status` and no `deleted` column, so their scorecards currently fail. This is a second missed #3888 conversion after #4349.

## Fix
- Replace the five `street_edge` filters (`ConfigTable.scala` — total_streets, audited_streets, street_km, audited_km, labeling-speed) with `status = 'open'`, the enum value the old `deleted = FALSE` mapped to, matching the pattern already used in `LabelTable`/`RegionTable`.
- Update the accompanying comments (open-only, not "non-deleted").
- The many `label.deleted = FALSE` references in the same file are **correct** and left unchanged — only `street_edge` lost its `deleted` column.

## Test
Adds a DB-backed `CityScorecardSpec` that runs `getCityScorecardBySchema` against the live current-city schema (which has the status enum) and asserts internally-consistent coverage. Pre-fix this fails against `sidewalk_teaneck`; post-fix it passes. This path shipped without a test, which is why the miss went unnoticed.

## Verification
- `sbt scalafmtAll` clean
- `sbt compile` warning-clean (`-Xfatal-warnings`)
- `sbt "testOnly models.utils.CityScorecardSpec"` → 2/2 pass (confirmed non-vacuous: current schema has no `deleted` column)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
