### PR TITLE
Observability: 500s at ERROR, drop hot-path println, surface swallowed pano errors (#4415)

### DIFF
--- a/app/executors/CustomExecutionContexts.scala
+++ b/app/executors/CustomExecutionContexts.scala
@@ -25,11 +25,5 @@ object CpuIntensiveExecutionContext {
   @Singleton
   class PekkoBased @Inject() (system: ActorSystem)
       extends CustomExecutionContext(system, "cpu-intensive")
-      with CpuIntensiveExecutionContext {
-
-    override def execute(runnable: Runnable): Unit = {
-      println(s"CpuIntensiveExecutionContext executing: ${Thread.currentThread().getName}")
-      super.execute(runnable)
-    }
-  }
+      with CpuIntensiveExecutionContext
 }

--- a/app/modules/CustomErrorHandler.scala
+++ b/app/modules/CustomErrorHandler.scala
@@ -66,7 +66,7 @@ class CustomErrorHandler @Inject() (
   }
 
   override def onServerError(request: RequestHeader, exception: Throwable): Future[Result] = {
-    logger.info("Server error occurred: " + exception.getMessage, exception)
+    logger.error("Server error occurred: " + exception.getMessage, exception)
     logUserInfo(request)
     // API requests get a problem+json 500 (without leaking exception internals); other routes keep Play's default
     // (dev error page / generic HTML) error handling.

--- a/app/service/PanoDataService.scala
+++ b/app/service/PanoDataService.scala
@@ -275,10 +275,14 @@ class PanoDataServiceImpl @Inject() (
           Future.successful(None)
         }
       }
-      .recover { // If there was an exception, don't assume it means a lack of imagery.
+      .recover {
+        // Transient network errors don't mean the imagery is gone; treat as inconclusive.
         case _: SocketTimeoutException => None
         case _: IOException            => None
-        case _: Exception              => None
+        // Anything else is unexpected: still inconclusive, but log it so the swallow is visible.
+        case e: Exception =>
+          logger.warn(s"Unexpected error checking GSV imagery for $panoId; treating as inconclusive.", e)
+          None
       }
   }
 
@@ -315,10 +319,14 @@ class PanoDataServiceImpl @Inject() (
                 Future.successful(None)
             }
           }
-          .recover { // A network error doesn't mean the image is gone.
+          .recover {
+            // A transient network error doesn't mean the image is gone; treat as inconclusive.
             case _: SocketTimeoutException => None
             case _: IOException            => None
-            case _: Exception              => None
+            // Anything else is unexpected: still inconclusive, but log it so the swallow is visible.
+            case e: Exception =>
+              logger.warn(s"Unexpected error checking Mapillary imagery for $panoId; treating as inconclusive.", e)
+              None
           }
     }
   }


### PR DESCRIPTION
Part of #4415. Three low-risk observability fixes; **behavior is unchanged** (same 500 responses, still returns `None` on pano-check errors) — only logging level/visibility improves.

- **`CustomErrorHandler.onServerError`** logs at **ERROR** (was INFO), so genuine 500s reach monitoring that filters on WARN/ERROR. The exception + stack were already passed; only the level changes.
- **`CustomExecutionContexts`** — remove the `println` that ran on **every** task dispatched to the cpu-intensive pool (System.out contention + log noise on a hot path). The `execute` override existed only for that debug line, so it's dropped and the pool uses the parent's `execute`.
- **`PanoDataService`** — the GSV/Mapillary existence checks had a catch-all `case _: Exception => None` that made the `SocketTimeoutException`/`IOException` cases dead and swallowed **all** failures silently. Still returns `None` (inconclusive), but now logs unexpected exceptions at WARN before defaulting.

**Verification:** `scalafmtAll` clean, `compile` warning-clean, full suite **141 tests green** (incl. `ApiErrorHandlerSpec`, which still confirms 500 responses don't leak internals).

Remaining #4415 items (separate, need more design): `ImageController` image work → `cpuEc`, `AiService` `Await.result` removal, `ClusteringActor` → `ClusteringService`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)