### PR TITLE
Require internal API key for AI label ingest (submitAiLabel)

### DIFF
--- a/app/controllers/AiController.scala
+++ b/app/controllers/AiController.scala
@@ -1,6 +1,7 @@
 package controllers
 
 import controllers.base.{CustomBaseController, CustomControllerComponents}
+import controllers.helper.ControllerUtils.internalKeyValid
 import formats.json.ExploreFormats.AiLabelsSubmission
 import play.api.libs.json._
 import play.api.libs.ws._
@@ -36,19 +37,27 @@ class AiController @Inject() (
    * Parse and process the submitted AI-generated label.
    */
   def submitAiLabel = Action.async(parse.json) { implicit request =>
-    val submission = request.body.validate[AiLabelsSubmission]
-    submission.fold(
-      errors => { Future.successful(BadRequest(Json.obj("status" -> "Error", "message" -> JsError.toJson(errors)))) },
-      submission => {
-        if (configService.getCityId == "vancouver-wa") {
-          exploreService.savePanoInfo(Seq(submission.pano)).flatMap { _ =>
-            exploreService.submitAiLabelData(submission).map(_ => Ok("success!"))
+    // Server-to-server write: authenticate the trusted caller (the auto-labeler) with the internal API key before
+    // persisting anything. Without this, anyone could POST labels into the dataset (the city check below is not auth).
+    if (!internalKeyValid(request, config.getOptional[String]("internal-api-key").getOrElse(""))) {
+      Future.successful(
+        Unauthorized(Json.obj("status" -> "Error", "message" -> "Invalid or missing internal API key."))
+      )
+    } else {
+      val submission = request.body.validate[AiLabelsSubmission]
+      submission.fold(
+        errors => { Future.successful(BadRequest(Json.obj("status" -> "Error", "message" -> JsError.toJson(errors)))) },
+        submission => {
+          if (configService.getCityId == "vancouver-wa") {
+            exploreService.savePanoInfo(Seq(submission.pano)).flatMap { _ =>
+              exploreService.submitAiLabelData(submission).map(_ => Ok("success!"))
+            }
+          } else {
+            Future.successful(BadRequest("AI label submission beta is only supported in Vancouver, WA at the moment."))
           }
-        } else {
-          Future.successful(BadRequest("AI label submission beta is only supported in Vancouver, WA at the moment."))
         }
-      }
-    )
+      )
+    }
   }
 
   private def generatePrompt(wayType: String, cityName: String): String = {

--- a/app/controllers/helper/ControllerUtils.scala
+++ b/app/controllers/helper/ControllerUtils.scala
@@ -5,6 +5,8 @@ import models.user.{RoleTable, SidewalkUserWithRole}
 import play.api.mvc.Results.Redirect
 import play.api.mvc.{Request, RequestHeader, Result}
 
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
 import scala.util.Try
 import scala.util.matching.Regex
 
@@ -34,6 +36,37 @@ object ControllerUtils {
   }
   def isAdmin(user: Option[SidewalkUserWithRole]): Boolean = {
     user.map(isAdmin).getOrElse(false)
+  }
+
+  /**
+   * Extracts a bearer token from the request's `Authorization` header, if present.
+   *
+   * @param request The incoming request.
+   * @return The token following a case-insensitive `Bearer ` prefix (trimmed), or None if there is no such header.
+   */
+  def bearerToken(request: RequestHeader): Option[String] =
+    request.headers.get("Authorization").collect {
+      case header if header.regionMatches(true, 0, "Bearer ", 0, 7) => header.substring(7).trim
+    }
+
+  /**
+   * Constant-time check that the request carries the configured internal API key as a bearer token.
+   *
+   * Authenticates trusted server-to-server callers (e.g. the AI label ingest) that have no Silhouette session. Fails
+   * closed: returns false if the configured key is blank or the header is absent/mismatched. The comparison is
+   * constant-time so a caller cannot recover the key byte-by-byte via response timing.
+   *
+   * @param request       The incoming request.
+   * @param configuredKey The server's configured `internal-api-key` (pass "" when unset).
+   * @return              True iff a bearer token is present and equals the configured key.
+   */
+  def internalKeyValid(request: RequestHeader, configuredKey: String): Boolean = {
+    if (configuredKey.isEmpty) {
+      false
+    } else {
+      val provided = bearerToken(request).getOrElse("")
+      MessageDigest.isEqual(provided.getBytes(StandardCharsets.UTF_8), configuredKey.getBytes(StandardCharsets.UTF_8))
+    }
   }
 
   def parseIntegerSeq(listOfInts: String): Seq[Int] = {

--- a/test/controllers/helper/ControllerUtilsSpec.scala
+++ b/test/controllers/helper/ControllerUtilsSpec.scala
@@ -1,0 +1,38 @@
+package controllers.helper
+
+import org.scalatestplus.play.PlaySpec
+import play.api.test.FakeRequest
+
+/**
+ * Unit tests for pure helpers in ControllerUtils. No application/DB boot required.
+ */
+class ControllerUtilsSpec extends PlaySpec {
+
+  "ControllerUtils.internalKeyValid" should {
+    val key = "s3cr3t-internal-key"
+
+    "accept a request whose bearer token equals the configured key" in {
+      ControllerUtils.internalKeyValid(FakeRequest().withHeaders("Authorization" -> s"Bearer $key"), key) mustBe true
+    }
+
+    "accept a case-insensitive Bearer prefix and trim the token" in {
+      ControllerUtils.internalKeyValid(FakeRequest().withHeaders("Authorization" -> s"bearer $key  "), key) mustBe true
+    }
+
+    "reject a wrong token" in {
+      ControllerUtils.internalKeyValid(FakeRequest().withHeaders("Authorization" -> "Bearer wrong"), key) mustBe false
+    }
+
+    "reject when the Authorization header is absent" in {
+      ControllerUtils.internalKeyValid(FakeRequest(), key) mustBe false
+    }
+
+    "reject a non-bearer Authorization scheme" in {
+      ControllerUtils.internalKeyValid(FakeRequest().withHeaders("Authorization" -> s"Basic $key"), key) mustBe false
+    }
+
+    "fail closed when the configured key is blank, even with a matching-looking header" in {
+      ControllerUtils.internalKeyValid(FakeRequest().withHeaders("Authorization" -> "Bearer "), "") mustBe false
+    }
+  }
+}


### PR DESCRIPTION
Closes a security gap: `POST /ai/submitLabelsOnPano` (`AiController.submitAiLabel`) persisted AI labels with **no authentication** — the `vancouver-wa` city check is not auth — so any client could write into the labeling dataset.

## Fix
Require the shared internal API key as an `Authorization: Bearer` header, verified **constant-time** (`MessageDigest.isEqual`) and **failing closed** via a new reusable `ControllerUtils.internalKeyValid` (+ `bearerToken`). `INTERNAL_API_KEY` is already provisioned on the servers, so no new secret is needed server-side. New `ControllerUtilsSpec` covers valid / case-insensitive+trim / wrong / missing / non-bearer / blank-key.

## Deploy coordination
The auto-labeler client (`sidewalk-auto-labeler` → `send_to_ps.py`) must send the same key as `PS_INTERNAL_API_KEY`; deploy together or Vancouver ingest returns 401 (fails safe — no data written).

**This PR targets `develop` (→ test).** A sibling hotfix branch `hotfix-v11.5.1-gate-ai-ingest` carries the identical change off `master` for a `v11.5.1` prod release (Vancouver is prod; releasing from develop would ship 141 unreleased commits).

Verified: `scalafmtAll` clean, `compile` warning-clean (`-Xfatal-warnings`), full suite green.