### PR TITLE
[hotfix] Require internal API key for AI label ingest → v11.5.1

### DIFF
--- a/app/controllers/AiController.scala
+++ b/app/controllers/AiController.scala
@@ -1,6 +1,7 @@
 package controllers
 
 import controllers.base.{CustomBaseController, CustomControllerComponents}
+import controllers.helper.ControllerUtils.internalKeyValid
 import formats.json.ExploreFormats.AiLabelsSubmission
 import play.api.libs.json._
 import play.api.libs.ws._
@@ -36,19 +37,27 @@ class AiController @Inject() (
    * Parse and process the submitted AI-generated label.
    */
   def submitAiLabel = Action.async(parse.json) { implicit request =>
-    val submission = request.body.validate[AiLabelsSubmission]
-    submission.fold(
-      errors => { Future.successful(BadRequest(Json.obj("status" -> "Error", "message" -> JsError.toJson(errors)))) },
-      submission => {
-        if (configService.getCityId == "vancouver-wa") {
-          exploreService.savePanoInfo(Seq(submission.pano)).flatMap { _ =>
-            exploreService.submitAiLabelData(submission).map(_ => Ok("success!"))
+    // Server-to-server write: authenticate the trusted caller (the auto-labeler) with the internal API key before
+    // persisting anything. Without this, anyone could POST labels into the dataset (the city check below is not auth).
+    if (!internalKeyValid(request, config.getOptional[String]("internal-api-key").getOrElse(""))) {
+      Future.successful(
+        Unauthorized(Json.obj("status" -> "Error", "message" -> "Invalid or missing internal API key."))
+      )
+    } else {
+      val submission = request.body.validate[AiLabelsSubmission]
+      submission.fold(
+        errors => { Future.successful(BadRequest(Json.obj("status" -> "Error", "message" -> JsError.toJson(errors)))) },
+        submission => {
+          if (configService.getCityId == "vancouver-wa") {
+            exploreService.savePanoInfo(Seq(submission.pano)).flatMap { _ =>
+              exploreService.submitAiLabelData(submission).map(_ => Ok("success!"))
+            }
+          } else {
+            Future.successful(BadRequest("AI label submission beta is only supported in Vancouver, WA at the moment."))
           }
-        } else {
-          Future.successful(BadRequest("AI label submission beta is only supported in Vancouver, WA at the moment."))
         }
-      }
-    )
+      )
+    }
   }
 
   private def generatePrompt(wayType: String, cityName: String): String = {
@@ -84,8 +93,8 @@ class AiController @Inject() (
 
     for {
       gsvImageUrls   <- panoDataService.getGsvImageUrlsForStreet(streetEdgeId) // Get image URLs for the street
-      imageObjects   <- fetchAndEncodeImages(gsvImageUrls) // Fetch and encode images
-      geminiResponse <- sendToGeminiApi(prompt, imageObjects)               // Send to Gemini API
+      imageObjects   <- fetchAndEncodeImages(gsvImageUrls)                     // Fetch and encode images
+      geminiResponse <- sendToGeminiApi(prompt, imageObjects)                  // Send to Gemini API
     } yield {
       val activity = s"Analyzing street $streetEdgeId with URLs: ${gsvImageUrls.mkString(", ")}"
       cc.loggingService.insert(request.identity.userId, request.ipAddress, activity)

--- a/app/controllers/helper/ControllerUtils.scala
+++ b/app/controllers/helper/ControllerUtils.scala
@@ -5,6 +5,8 @@ import models.user.{RoleTable, SidewalkUserWithRole}
 import play.api.mvc.Results.Redirect
 import play.api.mvc.{Request, RequestHeader, Result}
 
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
 import scala.util.Try
 import scala.util.matching.Regex
 
@@ -34,6 +36,37 @@ object ControllerUtils {
   }
   def isAdmin(user: Option[SidewalkUserWithRole]): Boolean = {
     user.map(isAdmin).getOrElse(false)
+  }
+
+  /**
+   * Extracts a bearer token from the request's `Authorization` header, if present.
+   *
+   * @param request The incoming request.
+   * @return The token following a case-insensitive `Bearer ` prefix (trimmed), or None if there is no such header.
+   */
+  def bearerToken(request: RequestHeader): Option[String] =
+    request.headers.get("Authorization").collect {
+      case header if header.regionMatches(true, 0, "Bearer ", 0, 7) => header.substring(7).trim
+    }
+
+  /**
+   * Constant-time check that the request carries the configured internal API key as a bearer token.
+   *
+   * Authenticates trusted server-to-server callers (e.g. the AI label ingest) that have no Silhouette session. Fails
+   * closed: returns false if the configured key is blank or the header is absent/mismatched. The comparison is
+   * constant-time so a caller cannot recover the key byte-by-byte via response timing.
+   *
+   * @param request       The incoming request.
+   * @param configuredKey The server's configured `internal-api-key` (pass "" when unset).
+   * @return              True iff a bearer token is present and equals the configured key.
+   */
+  def internalKeyValid(request: RequestHeader, configuredKey: String): Boolean = {
+    if (configuredKey.isEmpty) {
+      false
+    } else {
+      val provided = bearerToken(request).getOrElse("")
+      MessageDigest.isEqual(provided.getBytes(StandardCharsets.UTF_8), configuredKey.getBytes(StandardCharsets.UTF_8))
+    }
   }
 
   def parseIntegerSeq(listOfInts: String): Seq[Int] = {

--- a/test/controllers/helper/ControllerUtilsSpec.scala
+++ b/test/controllers/helper/ControllerUtilsSpec.scala
@@ -1,0 +1,38 @@
+package controllers.helper
+
+import org.scalatestplus.play.PlaySpec
+import play.api.test.FakeRequest
+
+/**
+ * Unit tests for pure helpers in ControllerUtils. No application/DB boot required.
+ */
+class ControllerUtilsSpec extends PlaySpec {
+
+  "ControllerUtils.internalKeyValid" should {
+    val key = "s3cr3t-internal-key"
+
+    "accept a request whose bearer token equals the configured key" in {
+      ControllerUtils.internalKeyValid(FakeRequest().withHeaders("Authorization" -> s"Bearer $key"), key) mustBe true
+    }
+
+    "accept a case-insensitive Bearer prefix and trim the token" in {
+      ControllerUtils.internalKeyValid(FakeRequest().withHeaders("Authorization" -> s"bearer $key  "), key) mustBe true
+    }
+
+    "reject a wrong token" in {
+      ControllerUtils.internalKeyValid(FakeRequest().withHeaders("Authorization" -> "Bearer wrong"), key) mustBe false
+    }
+
+    "reject when the Authorization header is absent" in {
+      ControllerUtils.internalKeyValid(FakeRequest(), key) mustBe false
+    }
+
+    "reject a non-bearer Authorization scheme" in {
+      ControllerUtils.internalKeyValid(FakeRequest().withHeaders("Authorization" -> s"Basic $key"), key) mustBe false
+    }
+
+    "fail closed when the configured key is blank, even with a matching-looking header" in {
+      ControllerUtils.internalKeyValid(FakeRequest().withHeaders("Authorization" -> "Bearer "), "") mustBe false
+    }
+  }
+}


### PR DESCRIPTION
**Hotfix release to prod.** Identical change to the develop PR, cut from `master` so tagging `v11.5.1` deploys **only** this fix to production (Vancouver is a prod city; `develop` is 141 commits ahead, so releasing from develop is not an option for a targeted hotfix).

## Fix
`POST /ai/submitLabelsOnPano` persisted AI labels with no authentication. Now requires the shared internal API key as an `Authorization: Bearer` header, verified constant-time and failing closed (`ControllerUtils.internalKeyValid`). `INTERNAL_API_KEY` is already on the servers. Adds `ControllerUtilsSpec`.

## Release steps
1. Merge to `master`.
2. Tag `v11.5.1` on master → auto-deploys to prod.
3. Verify: external `POST` to `/ai/submitLabelsOnPano` returns **401** (was reaching the app unauthenticated).
4. Set `PS_INTERNAL_API_KEY` wherever the auto-labeler runs (= server's `INTERNAL_API_KEY`) so ingest keeps working.

Verified on the master baseline: `scalafmtAll` clean, `compile` warning-clean, full suite green (101 tests).