### PR TITLE
Move blocking image work + AI-path Await off pool threads (#4415)

### DIFF
--- a/app/controllers/ImageController.scala
+++ b/app/controllers/ImageController.scala
@@ -1,6 +1,7 @@
 package controllers
 
 import controllers.base._
+import executors.CpuIntensiveExecutionContext
 import formats.json.LabelFormats
 import models.label.LabelTypeEnum
 import play.api.libs.json._
@@ -22,7 +23,8 @@ class ImageController @Inject() (
     cc: CustomControllerComponents,
     panoDataService: service.PanoDataService,
     signingService: ImageSigningService,
-    config: Configuration
+    config: Configuration,
+    cpuEc: CpuIntensiveExecutionContext
 )(implicit ec: ExecutionContext)
     extends CustomBaseController(cc) {
   private val logger = Logger(this.getClass)
@@ -232,14 +234,14 @@ class ImageController @Inject() (
           initializeDirIfNeeded(labelType)
           val b64String: String = (json \ "b64").as[String].split(",")(1)
           val filename: String  = panoDataService.cropFile(labelId, labelType).getPath
-          try {
-            writeImageFile(filename, b64String)
-            Future.successful(Ok("Got: crop_" + labelId))
-          } catch {
-            case e: Exception =>
+          // Base64 decode + ImageIO read/resize/write is CPU-bound; run it off the request EC so concurrent crop
+          // uploads can't starve the HTTP dispatcher (#4415).
+          Future(writeImageFile(filename, b64String))(cpuEc)
+            .map(_ => Ok("Got: crop_" + labelId))
+            .recover { case e: Exception =>
               logger.error("Exception when writing image file: " + filename + "\n\t" + e)
-              Future.successful(InternalServerError("Exception when writing image file: " + filename + "\n\t" + e))
-          }
+              InternalServerError("Exception when writing image file: " + filename + "\n\t" + e)
+            }
         }
       }
       .getOrElse {

--- a/app/service/AiService.scala
+++ b/app/service/AiService.scala
@@ -16,8 +16,7 @@ import slick.dbio.DBIO
 import java.time.format.DateTimeFormatter
 import java.time.{LocalDate, OffsetDateTime, ZoneOffset}
 import javax.inject._
-import scala.concurrent.duration.DurationInt
-import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.{ExecutionContext, Future}
 
 @ImplementedBy(classOf[AiServiceImpl])
 trait AiService {
@@ -222,15 +221,16 @@ class AiServiceImpl @Inject() (
             )
           } else if (response.status == 502) {
             // The AI API tried both its scraped cache and a fresh download from Google and got nothing back, so the
-            // imagery is likely expired. Check expiration & Record a failure row so we stop retrying this label.
+            // imagery is likely expired. Check expiration (panoExists records it) then record a failure row so we stop
+            // retrying this label. Sequenced with flatMap rather than Await so we don't block a pool thread on the call.
             val reason = response.body.trim.take(500)
-            Await.result(panoDataService.panoExists(labelData.panoData.panoId, labelData.panoData.source), 5.seconds)
-            logger.warn(s"AI API for label $labelId returned 502: $reason. Recording permanent failure.")
-            db.run(labelAiFailureTable.save(labelId, reason)).map(_ => None)
+            panoDataService.panoExists(labelData.panoData.panoId, labelData.panoData.source).flatMap { _ =>
+              logger.warn(s"AI API for label $labelId returned 502: $reason. Recording permanent failure.")
+              db.run(labelAiFailureTable.save(labelId, reason)).map(_ => None)
+            }
           } else {
             logger.warn(s"AI API for label $labelId returned error status: ${response.status} - ${response.statusText}")
-            Await.result(panoDataService.panoExists(labelData.panoData.panoId, labelData.panoData.source), 5.seconds)
-            Future.successful(None)
+            panoDataService.panoExists(labelData.panoData.panoId, labelData.panoData.source).map(_ => None)
           }
         } catch {
           case e: Exception =>


### PR DESCRIPTION
Part of the backend-reliability pass (#4415). Two fixes that stop blocking work from running on shared pool threads — the two items in the issue title ("image work off request EC, remove blocking Await"). The observability trio and the unguarded `.head` from that issue already shipped in #4421 / #4420.

### 1. Image encode/resize off the request EC
`ImageController.saveImage` did the Base64 decode + `ImageIO.read` + smooth `resize` + `ImageIO.write("png")` **synchronously on the default request EC**. Under concurrent crop uploads that can starve the HTTP dispatcher. Now it runs on the injected `CpuIntensiveExecutionContext` (the same pool `AdminController` / `AccessScoreService` already use), with the success/error handling moved to `.map`/`.recover`.

### 2. Remove blocking `Await` on the AI path
`AiService` blocked a pool thread with `Await.result(panoDataService.panoExists(...), 5.seconds)` **inside a WS `.flatMap` callback** on the 502 and error-status branches — up to 5s parked on an outbound HTTP call, and the awaited value was unused (`panoExists` runs for its expiration-recording side effect). Now sequenced asynchronously with `flatMap`/`map`; the unused `Await`/`DurationInt` imports are dropped.

### Not included (remaining #4415, tracked)
The actor→service extraction (`ClusteringActor` injecting `ClusterController`) and the last controller `db.run` (`GalleryController`) are a layering refactor of background scheduling — better as its own focused PR. Plus the lower-priority `.par` / scala-global-EC notes.

### Verification
`sbt compile` clean (`-Xfatal-warnings`), `scalafmtCheckAll` clean, full backend suite **158/158** (exercises the app booting with the new `cpuEc` injection on `ImageController`).
