### PR TITLE
Security hardening: constant-time signed-URL check, dedicated signing secret, open-redirect + splice guards

### DIFF
--- a/app/controllers/UserController.scala
+++ b/app/controllers/UserController.scala
@@ -2,7 +2,7 @@ package controllers
 
 import controllers.base._
 import controllers.helper.ControllerUtils
-import controllers.helper.ControllerUtils.parseURL
+import controllers.helper.ControllerUtils.{parseURL, safeLocalPath}
 import forms._
 import models.auth.{DefaultEnv, WithAdminOrIsUser}
 import models.user.{SidewalkUserWithRole, UserUtm}
@@ -181,7 +181,8 @@ class UserController @Inject() (
             .flatMap(_.headOption)
             .getOrElse("/") // Default redirect path if no returnUrl.
           val (returnUrlPath, returnUrlQuery) = parseURL(returnUrl)
-          val result                          = Redirect(returnUrl)
+          // Constrain to a same-origin path so a crafted returnUrl can't open-redirect a signed-in user off-site.
+          val result = Redirect(safeLocalPath(returnUrl))
 
           // Try to authenticate the user.
           authenticationService
@@ -270,7 +271,8 @@ class UserController @Inject() (
           val serviceHoursUser: Boolean = data.serviceHours == "YES"
 
           // Either redirect to the service hours instructions page or the returnUrl from the query params.
-          val redirectUrl: String = if (serviceHoursUser) "/serviceHoursInstructions" else returnUrl
+          // safeLocalPath constrains returnUrl to a same-origin path (open-redirect guard).
+          val redirectUrl: String = if (serviceHoursUser) "/serviceHoursInstructions" else safeLocalPath(returnUrl)
           val result              = Redirect(redirectUrl)
 
           (for {

--- a/app/controllers/helper/ControllerUtils.scala
+++ b/app/controllers/helper/ControllerUtils.scala
@@ -131,6 +131,22 @@ object ControllerUtils {
   }
 
   /**
+   * Restricts a post-auth redirect target to a same-origin path, guarding against open redirects.
+   *
+   * Only a single-slash-prefixed relative path is accepted (e.g. `/explore?foo=bar`). Absolute URLs, protocol-relative
+   * `//host` URLs, and backslash variants that browsers normalize to `//` fall back to `default`, so a caller-supplied
+   * `returnUrl` cannot bounce a freshly-authenticated user to an attacker-controlled site.
+   *
+   * @param url     The candidate redirect target (typically a `returnUrl` form field).
+   * @param default Where to send the user when `url` is not a safe same-origin path.
+   * @return        `url` (trimmed) if it is a same-origin relative path, otherwise `default`.
+   */
+  def safeLocalPath(url: String, default: String = "/"): String = {
+    val trimmed = url.trim
+    if (trimmed.startsWith("/") && !trimmed.startsWith("//") && !trimmed.startsWith("/\\")) trimmed else default
+  }
+
+  /**
    * Sets up a redirect to /anonSignUp while keeping track of the current URL and query string.
    */
   def anonSignupRedirect(request: RequestHeader): Result = {

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -1022,22 +1022,27 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
       validatorId: Option[String] = None,
       labelId: Option[Int] = None
   ): DBIO[Seq[LabelMetadata]] = {
-    // Optional filter to only get labels placed by the given user.
-    val labelerFilter: String = if (labelerId.isDefined) s"""u.user_id = '${labelerId.get}'""" else "TRUE"
+    // These user_ids are spliced into raw SQL below, so escape single quotes to keep the query injection-safe if a
+    // caller ever passes a request-derived id (today they are server-generated UUIDs).
+    val escapedLabelerId: Option[String]   = labelerId.map(_.replace("'", "''"))
+    val escapedValidatorId: Option[String] = validatorId.map(_.replace("'", "''"))
 
-    // Whether the label was placed by the current user (used to prevent self-validation).
-    val fromCurrentUserExpr: String = if (validatorId.isDefined) s"""u.user_id = '${validatorId.get}'""" else "FALSE"
+    // Optional filter to only get labels placed by the given user.
+    val labelerFilter: String = escapedLabelerId.map(id => s"""u.user_id = '$id'""").getOrElse("TRUE")
+
+    // Whether the label was placed by the current user (prevents self-validation).
+    val fromCurrentUserExpr: String = escapedValidatorId.map(id => s"""u.user_id = '$id'""").getOrElse("FALSE")
 
     // Optionally include the given user's validation info for each label in the userValidation field.
     val validatorJoin: String =
-      if (validatorId.isDefined) {
-        s"""LEFT JOIN (
-           |    SELECT label_id, validation_result
-           |    FROM label_validation WHERE user_id = '${validatorId.get}'
-           |) AS user_validation ON lb.label_id = user_validation.label_id""".stripMargin
-      } else {
-        "LEFT JOIN ( SELECT NULL AS validation_result ) AS user_validation ON lb.label_id = NULL"
-      }
+      escapedValidatorId
+        .map { id =>
+          s"""LEFT JOIN (
+             |    SELECT label_id, validation_result
+             |    FROM label_validation WHERE user_id = '$id'
+             |) AS user_validation ON lb.label_id = user_validation.label_id""".stripMargin
+        }
+        .getOrElse("LEFT JOIN ( SELECT NULL AS validation_result ) AS user_validation ON lb.label_id = NULL")
 
     // Either filter for the given labelId or filter out deleted and tutorial labels.
     val labelFilter: String = if (labelId.isDefined) {

--- a/app/service/ImageSigningService.scala
+++ b/app/service/ImageSigningService.scala
@@ -2,6 +2,8 @@ package service
 
 import play.api.Configuration
 
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
 import java.time.Instant
 import java.util.Base64
 import javax.crypto.Mac
@@ -40,6 +42,10 @@ class ImageSigningService @Inject() (config: Configuration) {
    * @param exp  The expiry epoch second from the query string.
    * @param sig  The HMAC signature from the query string.
    */
-  def verify(path: String, exp: Long, sig: String): Boolean =
-    Instant.now.getEpochSecond <= exp && sig == hmac(s"$path:$exp")
+  def verify(path: String, exp: Long, sig: String): Boolean = {
+    // Compare with a constant-time check so signature verification doesn't leak the HMAC via response timing.
+    val expected = hmac(s"$path:$exp").getBytes(StandardCharsets.UTF_8)
+    val provided = sig.getBytes(StandardCharsets.UTF_8)
+    Instant.now.getEpochSecond <= exp && MessageDigest.isEqual(expected, provided)
+  }
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -11,7 +11,10 @@ play.modules.enabled += "modules.ExecutorsModule"
 play.http.secret.key=${?SIDEWALK_APPLICATION_SECRET}
 
 # HMAC-SHA256 secret for signing time-limited image-serving URLs (/backupImage and /cropImage endpoints).
+# Defaults to the application secret so existing deployments keep working, but set IMAGE_SIGNING_SECRET in prod to a
+# distinct value so the image-signing key and the Play application secret can be rotated independently.
 image.signing.secret=${play.http.secret.key}
+image.signing.secret=${?IMAGE_SIGNING_SECRET}
 
 # Environment type: local, test, or prod.
 environment-type = "local"

--- a/test/controllers/helper/ControllerUtilsSpec.scala
+++ b/test/controllers/helper/ControllerUtilsSpec.scala
@@ -35,4 +35,30 @@ class ControllerUtilsSpec extends PlaySpec {
       ControllerUtils.internalKeyValid(FakeRequest().withHeaders("Authorization" -> "Bearer "), "") mustBe false
     }
   }
+
+  "ControllerUtils.safeLocalPath" should {
+    "pass through same-origin relative paths unchanged" in {
+      ControllerUtils.safeLocalPath("/explore") mustBe "/explore"
+      ControllerUtils.safeLocalPath("/validate?foo=bar&baz=1") mustBe "/validate?foo=bar&baz=1"
+      ControllerUtils.safeLocalPath("/") mustBe "/"
+    }
+
+    "reject absolute, scheme, and protocol-relative URLs (open-redirect guard)" in {
+      ControllerUtils.safeLocalPath("https://evil.example") mustBe "/"
+      ControllerUtils.safeLocalPath("http://evil.example/x") mustBe "/"
+      ControllerUtils.safeLocalPath("//evil.example") mustBe "/"
+      ControllerUtils.safeLocalPath("/\\evil.example") mustBe "/" // browsers normalize /\ to //
+      ControllerUtils.safeLocalPath("javascript:alert(1)") mustBe "/"
+      ControllerUtils.safeLocalPath("evil.example/path") mustBe "/"
+    }
+
+    "trim surrounding whitespace before classifying" in {
+      ControllerUtils.safeLocalPath("  //evil.example") mustBe "/"
+      ControllerUtils.safeLocalPath("  /explore") mustBe "/explore"
+    }
+
+    "fall back to the supplied default when the target is unsafe" in {
+      ControllerUtils.safeLocalPath("https://evil.example", "/signIn") mustBe "/signIn"
+    }
+  }
 }


### PR DESCRIPTION
Small, low-risk hardening changes to the auth/crypto surface. Each is a separate commit so they can be reviewed — or held — independently. **Inert/backward-compatible: no behavior changes for legitimate callers.**

### What's in here
1. **Constant-time signed-URL verification** — `ImageSigningService.verify` compares HMACs with `MessageDigest.isEqual` instead of `==`, closing a timing side-channel on signed image-URL checks.
2. **Dedicated image-signing secret** — `image.signing.secret` is now overridable via `IMAGE_SIGNING_SECRET`, soft-falling-back to the Play app secret so existing deploys are unaffected. Lets the signing key be rotated independently in prod.
3. **`user_id` splice escape (defense-in-depth)** — `LabelTable.getRecentLabelsMetadata` escapes single quotes in the spliced labeler/validator `user_id`. Not currently exploitable (callers pass server-generated UUIDs); removes the footgun.
4. **Open-redirect guard** — post-auth redirects (`authenticate` + `signUpPost`) route the caller-supplied `returnUrl` through a new `ControllerUtils.safeLocalPath`, accepting only same-origin relative paths.

### Tests
`ControllerUtilsSpec` gains 4 cases for `safeLocalPath` (10/10 in that spec). Compile clean under `-Xfatal-warnings`; scalafmt clean.

### Notes for reviewer
- The **open-redirect guard (commit 3)** is the only change with meaningful pre-deploy disclosure; it's isolated in its own commit if you'd prefer to sequence it separately.
- Follow-up (not in this PR): the same `safeLocalPath` guard applies to the sibling `signUpAnon` / `logout` / language-switch url-param sinks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)