### PR TITLE
Rate limiting for auth + AI-ingest endpoints (disabled by default)

### DIFF
--- a/app/controllers/AiController.scala
+++ b/app/controllers/AiController.scala
@@ -22,7 +22,8 @@ class AiController @Inject() (
     config: Configuration,
     configService: service.ConfigService,
     exploreService: service.ExploreService,
-    panoDataService: service.PanoDataService
+    panoDataService: service.PanoDataService,
+    rateLimiter: service.RateLimiter
 )(implicit ec: ExecutionContext)
     extends CustomBaseController(cc) {
   private val logger = Logger(this.getClass)
@@ -37,9 +38,17 @@ class AiController @Inject() (
    * Parse and process the submitted AI-generated label.
    */
   def submitAiLabel = Action.async(parse.json) { implicit request =>
+    // Defense-in-depth cap on the write volume from any single source, independent of the auth check below.
+    val aiLimit = rateLimiter.limit("ai-ingest")
+    if (!rateLimiter.allow(s"ai-ingest:${request.ipAddress}", aiLimit.maxAttempts, aiLimit.window)) {
+      Future.successful(
+        TooManyRequests(Json.obj("status" -> "Error", "message" -> "Rate limit exceeded."))
+          .withHeaders("Retry-After" -> aiLimit.window.toSeconds.toString)
+      )
+    }
     // Server-to-server write: authenticate the trusted caller (the auto-labeler) with the internal API key before
     // persisting anything. Without this, anyone could POST labels into the dataset (the city check below is not auth).
-    if (!internalKeyValid(request, config.getOptional[String]("internal-api-key").getOrElse(""))) {
+    else if (!internalKeyValid(request, config.getOptional[String]("internal-api-key").getOrElse(""))) {
       Future.successful(
         Unauthorized(Json.obj("status" -> "Error", "message" -> "Invalid or missing internal API key."))
       )

--- a/app/controllers/UserController.scala
+++ b/app/controllers/UserController.scala
@@ -34,7 +34,8 @@ class UserController @Inject() (
     userService: service.UserService,
     passwordHasher: PasswordHasher,
     clock: Clock,
-    mailerClient: MailerClient
+    mailerClient: MailerClient,
+    rateLimiter: service.RateLimiter
 )(implicit ec: ExecutionContext, assets: AssetsFinder)
     extends CustomBaseController(cc) {
   implicit val implicitConfig: Configuration = config
@@ -159,87 +160,98 @@ class UserController @Inject() (
     val ipAddress: String          = request.ipAddress
     val currUserId: Option[String] = request.identity.map(_.userId)
 
-    SignInForm.form
-      .bindFromRequest()
-      .fold(
-        formWithErrors => {
-          configService
-            .getCommonPageData(request2Messages.lang)
-            .map(commonData => {
-              BadRequest(views.html.authentication.signIn(formWithErrors, commonData, request.identity))
-            })
-        },
-        data => {
-          // Logs sign-in attempt.
-          val email: String    = data.email.toLowerCase
-          val activity: String = s"""SignInAttempt_Email="$email""""
-          cc.loggingService.insert(currUserId, ipAddress, activity)
-
-          // Grab the URL we want to redirect to that was passed as a hidden field in the form.
-          val returnUrl = request.body.asFormUrlEncoded
-            .flatMap(_.get("returnUrl"))
-            .flatMap(_.headOption)
-            .getOrElse("/") // Default redirect path if no returnUrl.
-          val (returnUrlPath, returnUrlQuery) = parseURL(returnUrl)
-          // Constrain to a same-origin path so a crafted returnUrl can't open-redirect a signed-in user off-site.
-          val result = Redirect(safeLocalPath(returnUrl))
-
-          // Try to authenticate the user.
-          authenticationService
-            .authenticate(email, data.password)
-            .flatMap { loginInfo =>
-              authenticationService.retrieve(loginInfo).flatMap {
-                case Some(user) =>
-                  val c = config.underlying
-                  silhouette.env.authenticatorService
-                    .create(loginInfo)
-                    .map {
-                      case authenticator if data.rememberMe =>
-                        // Set up the remember me cookie.
-                        authenticator.copy(
-                          expirationDateTime =
-                            clock.now + c.as[FiniteDuration]("silhouette.authenticator.rememberMe.authenticatorExpiry"),
-                          idleTimeout =
-                            c.getAs[FiniteDuration]("silhouette.authenticator.rememberMe.authenticatorIdleTimeout"),
-                          cookieMaxAge = c.getAs[FiniteDuration]("silhouette.authenticator.rememberMe.cookieMaxAge")
-                        )
-                      case authenticator => authenticator
-                    }
-                    .flatMap { authenticator =>
-                      // Log successful sign in attempt.
-                      val activity: String = s"""SignInSuccess_Email="${user.email}""""
-                      cc.loggingService.insert(user.userId, ipAddress, activity)
-
-                      // Sign in the user.
-                      silhouette.env.eventBus.publish(LoginEvent(user, request))
-                      silhouette.env.authenticatorService.init(authenticator).flatMap { v =>
-                        silhouette.env.authenticatorService.embed(v, result)
-                      }
-                    }
-                case None =>
-                  // Log failed sign-in due to a database issue.
-                  val activity: String = s"""SignInFailed_Email="$email"_Reason="user not found in db""""
-                  cc.loggingService.insert(currUserId, ipAddress, activity)
-                  Future.failed(new IdentityNotFoundException("Couldn't find the user in db"))
-              }
-            }
-            .recover {
-              case e: ProviderException =>
-                // Log failed sign-in due to invalid credentials. Should be the only reason for failed sign-in.
-                val activity: String = s"""SignInFailed_Email="$email"_Reason="invalid credentials""""
-                cc.loggingService.insert(currUserId, ipAddress, activity)
-
-                Redirect("/signIn", returnUrlQuery + ("url" -> Seq(returnUrlPath)))
-                  .flashing("error" -> Messages("authenticate.error.invalid.credentials"))
-              case e: Exception =>
-                val activity: String = s"""SignInFailed_Email="$email"_Reason="unexpected""""
-                cc.loggingService.insert(currUserId, ipAddress, activity)
-
-                Redirect("/signIn", returnUrlQuery + ("url" -> Seq(returnUrlPath)))
-                  .flashing("error" -> "Unexpected error")
-            }
-        }
+    // Per-IP login rate limit. Inert unless rate-limit.enabled; enable only after confirming the prod proxy forwards
+    // the real client IP (see CustomBaseController.ipAddress). A per-email key can be added identically inside the fold
+    // once the email is parsed — proxy-independent and stops per-account credential stuffing.
+    val loginLimit = rateLimiter.limit("login")
+    if (!rateLimiter.allow(s"login:ip:$ipAddress", loginLimit.maxAttempts, loginLimit.window)) {
+      Future.successful(
+        TooManyRequests("Too many login attempts. Please wait and try again.")
+          .withHeaders("Retry-After" -> loginLimit.window.toSeconds.toString)
       )
+    } else {
+      SignInForm.form
+        .bindFromRequest()
+        .fold(
+          formWithErrors => {
+            configService
+              .getCommonPageData(request2Messages.lang)
+              .map(commonData => {
+                BadRequest(views.html.authentication.signIn(formWithErrors, commonData, request.identity))
+              })
+          },
+          data => {
+            // Logs sign-in attempt.
+            val email: String    = data.email.toLowerCase
+            val activity: String = s"""SignInAttempt_Email="$email""""
+            cc.loggingService.insert(currUserId, ipAddress, activity)
+
+            // Grab the URL we want to redirect to that was passed as a hidden field in the form.
+            val returnUrl = request.body.asFormUrlEncoded
+              .flatMap(_.get("returnUrl"))
+              .flatMap(_.headOption)
+              .getOrElse("/") // Default redirect path if no returnUrl.
+            val (returnUrlPath, returnUrlQuery) = parseURL(returnUrl)
+            // Constrain to a same-origin path so a crafted returnUrl can't open-redirect a signed-in user off-site.
+            val result = Redirect(safeLocalPath(returnUrl))
+
+            // Try to authenticate the user.
+            authenticationService
+              .authenticate(email, data.password)
+              .flatMap { loginInfo =>
+                authenticationService.retrieve(loginInfo).flatMap {
+                  case Some(user) =>
+                    val c = config.underlying
+                    silhouette.env.authenticatorService
+                      .create(loginInfo)
+                      .map {
+                        case authenticator if data.rememberMe =>
+                          // Set up the remember me cookie.
+                          authenticator.copy(
+                            expirationDateTime = clock.now + c
+                              .as[FiniteDuration]("silhouette.authenticator.rememberMe.authenticatorExpiry"),
+                            idleTimeout =
+                              c.getAs[FiniteDuration]("silhouette.authenticator.rememberMe.authenticatorIdleTimeout"),
+                            cookieMaxAge = c.getAs[FiniteDuration]("silhouette.authenticator.rememberMe.cookieMaxAge")
+                          )
+                        case authenticator => authenticator
+                      }
+                      .flatMap { authenticator =>
+                        // Log successful sign in attempt.
+                        val activity: String = s"""SignInSuccess_Email="${user.email}""""
+                        cc.loggingService.insert(user.userId, ipAddress, activity)
+
+                        // Sign in the user.
+                        silhouette.env.eventBus.publish(LoginEvent(user, request))
+                        silhouette.env.authenticatorService.init(authenticator).flatMap { v =>
+                          silhouette.env.authenticatorService.embed(v, result)
+                        }
+                      }
+                  case None =>
+                    // Log failed sign-in due to a database issue.
+                    val activity: String = s"""SignInFailed_Email="$email"_Reason="user not found in db""""
+                    cc.loggingService.insert(currUserId, ipAddress, activity)
+                    Future.failed(new IdentityNotFoundException("Couldn't find the user in db"))
+                }
+              }
+              .recover {
+                case e: ProviderException =>
+                  // Log failed sign-in due to invalid credentials. Should be the only reason for failed sign-in.
+                  val activity: String = s"""SignInFailed_Email="$email"_Reason="invalid credentials""""
+                  cc.loggingService.insert(currUserId, ipAddress, activity)
+
+                  Redirect("/signIn", returnUrlQuery + ("url" -> Seq(returnUrlPath)))
+                    .flashing("error" -> Messages("authenticate.error.invalid.credentials"))
+                case e: Exception =>
+                  val activity: String = s"""SignInFailed_Email="$email"_Reason="unexpected""""
+                  cc.loggingService.insert(currUserId, ipAddress, activity)
+
+                  Redirect("/signIn", returnUrlQuery + ("url" -> Seq(returnUrlPath)))
+                    .flashing("error" -> "Unexpected error")
+              }
+          }
+        )
+    }
   }
 
   /**

--- a/app/service/RateLimiter.scala
+++ b/app/service/RateLimiter.scala
@@ -1,0 +1,94 @@
+package service
+
+import play.api.Configuration
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.function.BiFunction
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
+
+/**
+ * In-memory, fixed-window rate limiter for a single application instance.
+ *
+ * Tracks a per-key attempt count within a sliding fixed window. It is a no-op when `rate-limit.enabled` is false, so it
+ * can be wired into endpoints and shipped inert, then enabled by config once the deployment's proxy client-IP handling
+ * is confirmed (see `CustomBaseController.ipAddress`). State is per-instance and resets on restart, which fits the
+ * current single-instance deployment; a multi-instance future would need a shared store (e.g. Redis).
+ *
+ * @param config Application configuration; supplies `rate-limit.enabled` and the per-endpoint limit blocks.
+ */
+@Singleton
+class RateLimiter @Inject() (config: Configuration) {
+
+  private val enabled: Boolean = config.getOptional[Boolean]("rate-limit.enabled").getOrElse(false)
+
+  // Above this many distinct tracked keys, sweep expired windows so a flood of unique keys can't grow the map without
+  // bound. Chosen well above any legitimate per-window key count for a single instance.
+  private val MaxTrackedKeys: Int = 100000
+
+  /** A fixed window: when it started, how long it lasts, and how many attempts have landed in it. */
+  private case class Window(startMs: Long, windowMs: Long, count: Int)
+
+  private val windows = new ConcurrentHashMap[String, Window]()
+
+  /** Current time in milliseconds. `protected` so tests can override it to drive window expiry deterministically. */
+  protected def nowMs: Long = System.currentTimeMillis()
+
+  /**
+   * Records an attempt against `key` and reports whether it is within the limit.
+   *
+   * Always returns true when rate limiting is disabled. Otherwise increments the current window's counter (starting a
+   * fresh window if none is active or the previous one has elapsed) and returns whether the running count is still at or
+   * below `maxAttempts`. Counting is atomic per key via `ConcurrentHashMap.compute`.
+   *
+   * @param key         Identifies the thing being limited (e.g. `s"login:ip:$ip"`). Callers namespace their own keys.
+   * @param maxAttempts Attempts allowed within one window before this returns false.
+   * @param window      Length of the fixed window.
+   * @return            True if the attempt is allowed, false if `maxAttempts` has been exceeded within the window.
+   */
+  def allow(key: String, maxAttempts: Int, window: FiniteDuration): Boolean = {
+    if (!enabled) {
+      true
+    } else {
+      val now      = nowMs
+      val windowMs = window.toMillis
+      if (windows.size > MaxTrackedKeys) evictExpired(now)
+
+      val remap: BiFunction[String, Window, Window] = (_, existing) =>
+        if (existing == null || now - existing.startMs >= windowMs) Window(now, windowMs, 1)
+        else existing.copy(count = existing.count + 1)
+      windows.compute(key, remap).count <= maxAttempts
+    }
+  }
+
+  /**
+   * Looks up a named limit from the `rate-limit.<name>` config block.
+   *
+   * @param name The limit's config key (e.g. "login", "signup", "ai-ingest").
+   * @return     The configured max-attempts and window.
+   */
+  def limit(name: String): RateLimiter.Limit = {
+    val block = config.get[Configuration](s"rate-limit.$name")
+    RateLimiter.Limit(block.get[Int]("max-attempts"), block.get[Int]("window-seconds").seconds)
+  }
+
+  /** Drops windows that have fully elapsed as of `now`, freeing memory. The CHM iterator supports safe live removal. */
+  private def evictExpired(now: Long): Unit = {
+    val it = windows.entrySet().iterator()
+    while (it.hasNext) {
+      val w = it.next().getValue
+      if (now - w.startMs >= w.windowMs) it.remove()
+    }
+  }
+}
+
+object RateLimiter {
+
+  /**
+   * A configured rate limit.
+   *
+   * @param maxAttempts Attempts allowed within one window.
+   * @param window      Length of the fixed window.
+   */
+  case class Limit(maxAttempts: Int, window: FiniteDuration)
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -156,6 +156,22 @@ infra3d-client-secret-zurich = ${?INFRA3D_CLIENT_SECRET_ZURICH}
 infra3d-client-secret-winterthur = ${?INFRA3D_CLIENT_SECRET_WINTERTHUR}
 internal-api-key = ${?INTERNAL_API_KEY}
 
+# In-memory, per-endpoint rate limiting for the auth and AI-ingest endpoints. Fixed-window counters keyed by endpoint +
+# client IP and/or account. DISABLED by default and a no-op until enabled: turn it on only after confirming the prod
+# reverse proxy forwards the real client IP via X-Forwarded-For (see CustomBaseController.ipAddress), otherwise every
+# request behind the proxy shares one per-IP bucket and legitimate users get throttled. Limits are per-instance (reset
+# on restart), which is fine for the current single-instance deployment; a multi-instance future would need a shared
+# store (Redis). Defaults are deliberately generous — tune before enabling.
+rate-limit {
+  enabled = false
+  enabled = ${?RATE_LIMIT_ENABLED}
+  login {         max-attempts = 10,  window-seconds = 60 }   # per IP and per email
+  signup {        max-attempts = 5,   window-seconds = 3600 } # per IP
+  forgot {        max-attempts = 5,   window-seconds = 3600 } # per email+IP
+  anon-signup {   max-attempts = 30,  window-seconds = 3600 } # per IP
+  ai-ingest {     max-attempts = 120, window-seconds = 60 }   # per IP (bulk caller; caps requests, not labels)
+}
+
 # Sidewalk AI API settings. The ai-enabled flag is only used so that we can disable AI requests in the dev env.
 ai-enabled = true
 sidewalk-ai-api-hostname = "sidewalk-ai-api.cs.washington.edu"

--- a/test/service/RateLimiterSpec.scala
+++ b/test/service/RateLimiterSpec.scala
@@ -1,0 +1,74 @@
+package service
+
+import com.typesafe.config.ConfigFactory
+import org.scalatestplus.play.PlaySpec
+import play.api.Configuration
+
+import scala.concurrent.duration.DurationInt
+
+/**
+ * Unit tests for RateLimiter's fixed-window counting. No application/DB boot required; the clock is driven manually so
+ * window expiry is deterministic.
+ */
+class RateLimiterSpec extends PlaySpec {
+
+  /** A RateLimiter whose clock is a mutable field, so tests can advance time across window boundaries. */
+  private class TestRateLimiter(config: Configuration) extends RateLimiter(config) {
+    var currentMs: Long                = 0L
+    override protected def nowMs: Long = currentMs
+  }
+
+  private def limiter(enabled: Boolean): TestRateLimiter =
+    new TestRateLimiter(Configuration(ConfigFactory.parseString(s"""
+      rate-limit {
+        enabled = $enabled
+        login { max-attempts = 3, window-seconds = 60 }
+      }
+    """)))
+
+  "RateLimiter.allow" should {
+    "allow up to maxAttempts within a window, then deny" in {
+      val rl = limiter(enabled = true)
+      rl.allow("k", 3, 60.seconds) mustBe true
+      rl.allow("k", 3, 60.seconds) mustBe true
+      rl.allow("k", 3, 60.seconds) mustBe true
+      rl.allow("k", 3, 60.seconds) mustBe false
+    }
+
+    "reset the counter once the window elapses" in {
+      val rl = limiter(enabled = true)
+      rl.allow("k", 2, 60.seconds) mustBe true
+      rl.allow("k", 2, 60.seconds) mustBe true
+      rl.allow("k", 2, 60.seconds) mustBe false
+      rl.currentMs = 60000 // advance exactly one window
+      rl.allow("k", 2, 60.seconds) mustBe true
+    }
+
+    "not reset until the full window has elapsed" in {
+      val rl = limiter(enabled = true)
+      rl.allow("k", 1, 60.seconds) mustBe true
+      rl.currentMs = 59999 // one ms short of the window
+      rl.allow("k", 1, 60.seconds) mustBe false
+    }
+
+    "track keys independently" in {
+      val rl = limiter(enabled = true)
+      rl.allow("a", 1, 60.seconds) mustBe true
+      rl.allow("a", 1, 60.seconds) mustBe false
+      rl.allow("b", 1, 60.seconds) mustBe true
+    }
+
+    "be a no-op (always allow) when disabled" in {
+      val rl = limiter(enabled = false)
+      (1 to 100).foreach(_ => rl.allow("k", 1, 60.seconds) mustBe true)
+    }
+  }
+
+  "RateLimiter.limit" should {
+    "read max-attempts and window from the named config block" in {
+      val lim = limiter(enabled = true).limit("login")
+      lim.maxAttempts mustBe 3
+      lim.window mustBe 60.seconds
+    }
+  }
+}


### PR DESCRIPTION
Adds an in-memory rate limiter and wires it into the login and AI-ingest endpoints. **Ships disabled (`rate-limit.enabled=false`) — a no-op until deliberately turned on**, so merging changes no behavior.

> **Stacked on #4428** (base branch is `security-hardening-auth-crypto`). GitHub will retarget this to `develop` automatically once #4428 merges. Review the incremental diff here.

### What's in here
- **`service.RateLimiter`** — per-key fixed-window counter, atomic via `ConcurrentHashMap.compute`, with a bounded-memory eviction sweep. Clock is overridable for deterministic tests. No-op when disabled.
- **Config block** (`rate-limit.*`) — per-endpoint limits, `enabled=false` by default, `RATE_LIMIT_ENABLED` env override.
- **Wiring** — `AiController.submitAiLabel` (per-IP write cap, defense-in-depth over the existing internal-key gate) and `UserController.authenticate` (per-IP login cap).
- **`RateLimiterSpec`** — 6 cases (window counting, reset, isolation, disabled no-op, config read).

### ⚠️ Do not enable until this is confirmed
Turn it on **only after** verifying the prod reverse proxy forwards the real client IP via `X-Forwarded-For` (see `CustomBaseController.ipAddress`). Otherwise every request behind the proxy shares one per-IP bucket and real users get throttled. State is per-instance (resets on restart) — fine for the current single-instance deployment; multi-instance would need a shared store (Redis).

### Follow-up (not here)
Same one-line guard for `signUpPost` / `submitForgottenPassword` / `signUpAnon`, plus optional per-email login keys (proxy-independent, stops per-account credential stuffing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)