### PR TITLE
Add missing table ownership for street_imagery/funnel_stat evolutions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,10 @@ convention above.
 
 Schema changes are **Play evolutions**: numbered SQL files in `conf/evolutions/default/`. Add the next-numbered file for schema changes; each has `# --- !Ups` and `# --- !Downs` sections. The dev DB is seeded from a dump — see [`db/scripts/README.md`](db/scripts/README.md) for the full DB lifecycle/maintenance scripts (`import-dump`, `create-new-schema`, etc., exposed as `make` targets). Connection config is env-driven (`DATABASE_URL`, `DATABASE_USER`, `DATABASE_PASSWORD`) in `conf/application.conf`.
 
+**Every `CREATE TABLE` must be followed by `ALTER TABLE <name> OWNER TO sidewalk;`** in the same evolution (see 309.sql for the pattern). On the prod server, evolutions run as an admin role, so a new table would otherwise be owned by that role and the `sidewalk` app role would lack permissions on it. This applies to **tables only** — it's easy to forget, and a missed one has to be patched by a later evolution (e.g. 321.sql fixed 314.sql; 329.sql fixed 326.sql/327.sql). Note:
+- **SERIAL / identity sequences** are covered automatically: `ALTER TABLE … OWNER TO` recursively reassigns any sequence a column owns, so no separate statement is needed for them.
+- **Enum types, views, and standalone (non-column-owned) sequences do *not* get an owner change** — the app only needs default `USAGE`/`SELECT` on those, which it already has, and they're never altered at runtime. Don't add `OWNER TO` for them.
+
 ## Frontend architecture
 
 Each major UI is a self-contained app under `public/javascripts/`, bundled separately by Grunt and loaded by the corresponding Twirl view:

--- a/app/service/ClusterService.scala
+++ b/app/service/ClusterService.scala
@@ -7,7 +7,7 @@ import play.api.{Configuration, Logger}
 import java.util.concurrent.atomic.AtomicReference
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
-import scala.sys.process.Process
+import scala.sys.process.{Process, ProcessLogger}
 
 /**
  * Final counts from a clustering run: how many labels were grouped into how many clusters.
@@ -67,13 +67,27 @@ class ClusterServiceImpl @Inject() (
 
         // Run the clustering script for this region. Pass the internal key via the subprocess environment rather than
         // an argv flag so it can't leak into the process table / `ps` output.
-        val clusteringOutput =
-          Process(
-            Seq("/usr/bin/python3", "scripts/label_clustering.py", "--region_id", regionId.toString),
-            None,
-            "INTERNAL_API_KEY" -> key
-          ).!!
-        logger.debug(clusteringOutput)
+        val process = Process(
+          Seq("/usr/bin/python3", "scripts/label_clustering.py", "--region_id", regionId.toString),
+          None,
+          "INTERNAL_API_KEY" -> key
+        )
+
+        // Capture stdout/stderr separately so a subprocess failure surfaces the Python error to Play's logger.
+        val stdout   = new StringBuilder
+        val stderr   = new StringBuilder
+        val exitCode = process.!(
+          ProcessLogger(
+            line => { stdout.append(line).append('\n'); () },
+            line => { stderr.append(line).append('\n'); () }
+          )
+        )
+
+        if (exitCode != 0) {
+          logger.error(s"Clustering script failed for region $regionId (exit $exitCode):\n${stderr.toString.trim}")
+          throw new RuntimeException(s"Clustering failed for region $regionId (exit $exitCode)")
+        }
+        logger.debug(stdout.toString)
       }
       logger.info("Finished 100% of regions!!\n\n")
     }(cpuEc)

--- a/conf/evolutions/default/329.sql
+++ b/conf/evolutions/default/329.sql
@@ -1,0 +1,7 @@
+# --- !Ups
+-- Set the owner of tables added in 326.sql and 327.sql, which were created without it. Every new table needs its owner
+-- reassigned to sidewalk so the app role has the correct permissions on the prod server (see 309.sql for the pattern).
+ALTER TABLE street_imagery OWNER TO sidewalk;
+ALTER TABLE funnel_stat OWNER TO sidewalk;
+
+# --- !Downs

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,7 +60,10 @@ The backend follows a consistent layering: **routes → Controller → Service �
   Authentication lives in `sidewalk_login`.
 - **Evolutions** — schema changes are Play evolutions: numbered SQL files in `conf/evolutions/default/`, each with
   `# --- !Ups` / `# --- !Downs`. The dev DB is seeded from a dump rather than built up from evolutions; the scripts that
-  do that seeding (and other DB lifecycle/maintenance tasks) live in [`db/scripts/`](../db/scripts/README.md).
+  do that seeding (and other DB lifecycle/maintenance tasks) live in [`db/scripts/`](../db/scripts/README.md). Every new
+  table must be followed by `ALTER TABLE <name> OWNER TO sidewalk;` (see 309.sql) — on prod, evolutions run as an admin
+  role, so without it the `sidewalk` app role lacks permissions on the table. This applies to tables only; SERIAL
+  sequences follow the table owner automatically, and enum types/views don't need it.
 
 ### Dependency injection & runtime
 


### PR DESCRIPTION
## Problem

New tables in evolutions must be followed by `ALTER TABLE <name> OWNER TO sidewalk;` (see 309.sql). On the prod server, evolutions run as an admin role, so without the owner change the table is owned by that role and the `sidewalk` app role lacks permissions on it.

Two recently-added tables missed this:
- **326.sql** — `street_imagery` (#4348)
- **327.sql** — `funnel_stat` (#288)

(314.sql had the same bug for `label_ai_failure`, but it was already patched by 321.sql — this is the same remediation pattern.)

## Fix

- **329.sql** reassigns ownership of both tables to `sidewalk`, mirroring the 321.sql fix.
- Documents the requirement in **CLAUDE.md** and **docs/architecture.md** so future tables (including ones Claude writes) get an owner change from the start.

## Scope note

The owner change applies to **tables only**:
- SERIAL / identity sequences follow the table owner automatically (`ALTER TABLE … OWNER TO` recursively reassigns column-owned sequences).
- Enum types and views don't need it — the app only needs default `USAGE`/`SELECT`, which it already has.

I audited every object-creating statement from 310–328; `street_imagery` and `funnel_stat` were the only outstanding cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)