### PR TITLE
Full-window LabelMap + in-city address search (#4370)

### DIFF
--- a/app/views/apps/labelMap.scala.html
+++ b/app/views/apps/labelMap.scala.html
@@ -9,7 +9,7 @@
 
 @currentCity = @{commonData.allCityInfo.filter(_.cityId == commonData.cityId).head}
 
-@common.main(commonData, title, i18Namespaces = Seq("common", "labelmap")) {
+@common.main(commonData, title, i18Namespaces = Seq("common", "labelmap"), url = "/labelMap") {
     @common.navbar(commonData, Some(user))
     <div id="page-loading">
         <img id="loading-animation" src='@assets.path("videos/ProjectSidewalk_LoadingAnimation_WithArmMovement_Medium.webp")' alt='@Messages("loading")'/>
@@ -17,7 +17,7 @@
     <div id="labelmap-choropleth-container" class="container choropleth-container">
         <div id="labelmap-choropleth-holder" class="choropleth-holder">
             <div id="labelmap-choropleth" class="choropleth"></div>
-            @common.mapSidebar(tags = tags)
+            @common.mapSidebar(tags = tags, showSearch = true)
         </div>
     </div>
 
@@ -50,9 +50,11 @@
 
     <script src='@assets.path("javascripts/lib/mapbox-gl-3.21.0.js")'></script>
     <script src='@assets.path("javascripts/lib/mapbox-gl-language-1.0.1.js")'></script>
+    <script src='@assets.path("javascripts/lib/mapbox-gl-search-1.5.0.js")'></script>
     <link href='@assets.path("javascripts/lib/mapbox-gl-3.21.0.css")' rel="stylesheet"/>
     <script src='@assets.path("javascripts/common/detectMobileBrowser.js")'></script>
     <script src='@assets.path("javascripts/PSMap/build/PSMap.js")'></script>
+    <script src='@assets.path("javascripts/labelMapLocationSearch.js")'></script>
     <link href='@assets.path("stylesheets/choropleth.css")' rel="stylesheet"/>
     <link href='@assets.path("stylesheets/admin.css")' rel="stylesheet"/>
 
@@ -108,6 +110,7 @@
                 self.map = m[0];
                 self.mapData = m[4];
                 new MapSidebarFilter(self.map, self.mapData, { highQualityFilter: true });
+                initLabelMapLocationSearch(self.map, params.mapboxApiKey);
             });
             window.map = self;
         });

--- a/app/views/apps/labelMap.scala.html
+++ b/app/views/apps/labelMap.scala.html
@@ -18,6 +18,15 @@
         <div id="labelmap-choropleth-holder" class="choropleth-holder">
             <div id="labelmap-choropleth" class="choropleth"></div>
             @common.mapSidebar(tags = tags, showSearch = true)
+            @* Feedback while the (large) label layer streams in — the map itself loads in ~1s but labels
+               can be tens of MB, during which the sidebar sits greyed with no cue that work is happening. *@
+            <div id="labelmap-loading" class="labelmap-loading" hidden role="status" aria-live="polite" aria-busy="true">
+                <div class="labelmap-loading__card">
+                    <div class="labelmap-loading__spinner" aria-hidden="true"></div>
+                    <p class="labelmap-loading__message" data-i18n="labelmap:loading-labels">Loading sidewalk labels…</p>
+                    <p id="labelmap-loading-elapsed" class="labelmap-loading__elapsed"></p>
+                </div>
+            </div>
         </div>
     </div>
 
@@ -63,6 +72,33 @@
         const viewerType = imagerySrc === 'mapillary' ? MapillaryViewer : imagerySrc === 'infra3d' ? Infra3dViewer : GsvViewer;
         const accessToken = "@commonData.imageryAccessToken";
 
+        // Loading overlay for the label layer. Indeterminate spinner + a live elapsed-time counter: the
+        // response is gzipped (Content-Length is the compressed size), so a byte-percentage bar isn't
+        // meaningful, and the exact count isn't known until the payload has fully parsed.
+        let labelMapLoadingTimer = null;
+        function showLabelMapLoading() {
+            const overlay = document.getElementById('labelmap-loading');
+            if (!overlay) return;
+            const elapsedEl = document.getElementById('labelmap-loading-elapsed');
+            const start = performance.now();
+            const renderElapsed = () => {
+                if (!elapsedEl) return;
+                const seconds = ((performance.now() - start) / 1000).toFixed(1);
+                elapsedEl.textContent = i18next.t('labelmap:loading-elapsed', { seconds: seconds });
+            };
+            renderElapsed();
+            overlay.hidden = false;
+            labelMapLoadingTimer = setInterval(renderElapsed, 100);
+        }
+        function hideLabelMapLoading() {
+            const overlay = document.getElementById('labelmap-loading');
+            if (overlay) overlay.hidden = true;
+            if (labelMapLoadingTimer) {
+                clearInterval(labelMapLoadingTimer);
+                labelMapLoadingTimer = null;
+            }
+        }
+
         // Gets all translations before loading the choropleth.
         window.appManager.ready(async function () {
             let params = {
@@ -105,12 +141,23 @@
                 params.labelsURL.searchParams.append('aiValidationOptions', aiValidationOptionsParam);
             }
 
+            // Mount the address search and reveal the loading indicator as soon as the map is ready, not
+            // after the (large) label layer finishes loading, so they appear with the sidebar rather than
+            // popping in late (#4370/#4447).
+            params.onMapReady = (map) => {
+                initLabelMapLocationSearch(map, params.mapboxApiKey);
+                showLabelMapLoading();
+            };
+
             const self = {};
             CreatePSMap($, params).then(m => {
                 self.map = m[0];
                 self.mapData = m[4];
                 new MapSidebarFilter(self.map, self.mapData, { highQualityFilter: true });
-                initLabelMapLocationSearch(self.map, params.mapboxApiKey);
+                hideLabelMapLoading();
+            }).catch(e => {
+                console.error('LabelMap failed to load', e);
+                hideLabelMapLoading();
             });
             window.map = self;
         });

--- a/app/views/common/main.scala.html
+++ b/app/views/common/main.scala.html
@@ -72,7 +72,7 @@
             window.appManager.init(csrfToken, i18nextParams, globals);
         });
     </script>
-    <div id="wrap">
+    <div id="wrap" class='@if(url == "/labelMap"){wrap--full-window}'>
             <!-- Banner is only visible if user is on local/test server-->
         @if(commonData.environmentType != "prod") {
             <div class="test-server-banner">
@@ -111,15 +111,15 @@
             <meta name="viewport" content="width=device-width, initial-scale=1">
         </head>
     }
-    @if(url == "/explore") {
+    @if(url == "/explore" || url == "/labelMap") {
         <script>
                 // Prevents extra whitespace at the bottom of the page, not sure why that's an issue.
                 document.getElementsByTagName("body")[0].style.overflow = "hidden";
         </script>
     }
         <!-- Trying out no footer on Explore or Validate. Mini footer on mobile sign in/up. Code is weird bc "else if" doesn't work in template scala rn. -->
-    @if(url == "/explore" || url == "/validate" || url == "/expertValidate" || url == "/mobile" || url == "/signInMobile" || url == "/signUpMobile" || url == "/mobileLanding") {
-        @if(url == "/explore" || url == "/validate" || url == "/expertValidate" || url == "/mobile" || url == "/mobileLanding") {
+    @if(url == "/explore" || url == "/validate" || url == "/expertValidate" || url == "/mobile" || url == "/signInMobile" || url == "/signUpMobile" || url == "/mobileLanding" || url == "/labelMap") {
+        @if(url == "/explore" || url == "/validate" || url == "/expertValidate" || url == "/mobile" || url == "/mobileLanding" || url == "/labelMap") {
         } else {
             <!-- footer code found in app/views/footer.scala.html -->
             @common.miniFooter(commonData)

--- a/app/views/common/mapSidebar.scala.html
+++ b/app/views/common/mapSidebar.scala.html
@@ -1,5 +1,5 @@
 @import models.label.{LabelTypeEnum, Tag}
-@(tags: Seq[Tag] = Seq.empty, streetsShownByDefault: Boolean = false, adminVersion: Boolean = false)(implicit messages: Messages, assets: AssetsFinder)
+@(tags: Seq[Tag] = Seq.empty, streetsShownByDefault: Boolean = false, adminVersion: Boolean = false, showSearch: Boolean = false)(implicit messages: Messages, assets: AssetsFinder)
 
 @tagsByLabelType = @{tags.groupBy(t => LabelTypeEnum.labelTypeIdToLabelType.getOrElse(t.labelTypeId, ""))}
 
@@ -39,6 +39,15 @@
             data-i18n-aria-label="common:close">
         <img src="@assets.path("images/icons/chevrons-left-feather.svg")" alt="">
     </button>
+
+    @* ---- Address/place search section (public LabelMap only, #4370) ---- *@
+    @if(showSearch) {
+        @* The Mapbox Search JS control is mounted into #labelmap-search-box by labelMapLocationSearch.js. *@
+        <section class="map-sidebar__section" id="labelmap-search-section" role="search"
+                 aria-label="Search for an address or place" data-i18n-aria-label="labelmap:search-placeholder">
+            <div id="labelmap-search-box"></div>
+        </section>
+    }
 
     @* ---- Severity section ---- *@
     <section class="map-sidebar__section">

--- a/public/javascripts/PSMap/CreatePSMap.js
+++ b/public/javascripts/PSMap/CreatePSMap.js
@@ -23,8 +23,11 @@
  * @param {boolean} [params.interactiveStreets=false] - Whether to include hover/click interactions on the streets.
  * @param {boolean} [params.includeLabelCounts=false] - Whether to include label counts for each type in the legend.
  * @param {string} [params.navigationControlPosition='top-left'] - Position of the zoom/pitch controls on the map.
- * @param {string} [params.uiSource] - Used to record the UI used when submitting a validation through the popup.
+ * @param {string} [params.uiSource] - Records the UI used when submitting a validation through the popup.
  * @param {object} [params.popupLabelViewer] - Shows a validation popup on labels on the map.
+ * @param {function} [params.onMapReady] - Called with the map as soon as it has loaded, BEFORE the
+ *     (potentially large) neighborhoods/streets/labels layers render. Use this to mount map-bound UI
+ *     early (e.g. the LabelMap search box) instead of waiting on the returned all-loaded promise.
  * @return {Promise} - Promise that resolves all components of map have loaded.
  */
 function CreatePSMap($, params) {
@@ -50,6 +53,20 @@ function CreatePSMap($, params) {
             sidebar.classList.add('map-sidebar--loading');
             map.setPadding({ left: sidebar.offsetWidth, top: 0, right: 0, bottom: 0 });
         }
+
+        // Mount map-bound UI (e.g. the LabelMap search box) now, while the map is ready but the data
+        // layers are still loading. Labels alone can be tens of MB (Seattle ~87 MB), so deferring this
+        // to the all-loaded promise leaves the control missing for many seconds and then shoves the
+        // sidebar down when it finally appears — worse over the network than on localhost (#4370/#4447).
+        // Guarded so a failure in the page's callback can't reject this promise and break the data layers.
+        if (params.onMapReady) {
+            try {
+                params.onMapReady(map);
+            } catch (e) {
+                console.error('onMapReady callback failed', e);
+            }
+        }
+
         return map;
     });
 

--- a/public/javascripts/labelMapLocationSearch.js
+++ b/public/javascripts/labelMapLocationSearch.js
@@ -1,0 +1,83 @@
+/**
+ * Address/place search for the public LabelMap (issue #4370).
+ *
+ * Mounts a Mapbox Search JS `MapboxSearchBox` at the top of the map's left filter sidebar and
+ * hard-limits suggestions to the deployment city's actual extent, so this stays a within-city finder
+ * (hospitals, schools, libraries, ...) rather than a general-purpose geocoder. Selecting a result flies
+ * the map to the place and drops a marker. Mirrors the setup in `routeBuilder.js` (`#setUpSearchBox`),
+ * except the control is mounted inside the sidebar (per #4370) rather than added as a floating control.
+ *
+ * The follow-up "Explore the sidewalks here" action (a separate ticket) will hook into the selection.
+ */
+
+// Fraction of the region's own span to pad the search bbox by on each edge, so places just outside the
+// audited footprint (e.g. a hospital across a boundary road) still surface, without opening the search up
+// to the surrounding metro. A small buffer — the DB config pan-bounds are far too loose to use here (e.g.
+// Seattle's spans ~300 km).
+const CITY_BBOX_BUFFER_FRACTION = 0.1;
+
+/**
+ * Compute a slightly-buffered bounding box of a GeoJSON FeatureCollection (or single Feature).
+ *
+ * @param {object} geojson - GeoJSON FeatureCollection or Feature with Polygon/MultiPolygon geometry.
+ * @returns {number[][]|null} bbox as [[minLng, minLat], [maxLng, maxLat]] (Mapbox LngLatBounds order),
+ *                            padded by CITY_BBOX_BUFFER_FRACTION per edge, or null if no coordinates found.
+ */
+function cityBoundingBox(geojson) {
+    let minLng = Infinity, minLat = Infinity, maxLng = -Infinity, maxLat = -Infinity;
+    const visit = (coords) => {
+        if (typeof coords[0] === 'number') {
+            const [lng, lat] = coords;
+            if (lng < minLng) minLng = lng;
+            if (lat < minLat) minLat = lat;
+            if (lng > maxLng) maxLng = lng;
+            if (lat > maxLat) maxLat = lat;
+        } else {
+            coords.forEach(visit);
+        }
+    };
+    const features = geojson.features || (geojson.geometry ? [geojson] : []);
+    for (const feature of features) {
+        if (feature.geometry && feature.geometry.coordinates) visit(feature.geometry.coordinates);
+    }
+    if (minLng === Infinity) return null;
+    const padLng = (maxLng - minLng) * CITY_BBOX_BUFFER_FRACTION;
+    const padLat = (maxLat - minLat) * CITY_BBOX_BUFFER_FRACTION;
+    return [[minLng - padLng, minLat - padLat], [maxLng + padLng, maxLat + padLat]];
+}
+
+/**
+ * Initialize the LabelMap address search box.
+ *
+ * @param {mapboxgl.Map} map - The Mapbox GL map created by CreatePSMap.
+ * @param {string} mapboxApiKey - Mapbox access token (the same token that initialized the map).
+ * @returns {void} No-op if the sidebar container or the Search SDK is unavailable.
+ */
+function initLabelMapLocationSearch(map, mapboxApiKey) {
+    const container = document.getElementById('labelmap-search-box');
+    if (!container || typeof MapboxSearchBox === 'undefined') return;
+
+    const searchBox = new MapboxSearchBox();
+    searchBox.accessToken = mapboxApiKey;
+    searchBox.options = { language: i18next.t('common:mapbox-language-code') };
+    searchBox.placeholder = i18next.t('labelmap:search-placeholder');
+
+    // Let the component fly the map to, and drop a marker on, the selected result for free.
+    searchBox.mapboxgl = mapboxgl;
+    searchBox.marker = true;
+
+    // onAdd(map) binds the map (enabling the auto-flyTo and a map-center proximity bias) and returns the
+    // control's DOM element, which we place inside the sidebar instead of handing to map.addControl().
+    container.appendChild(searchBox.onAdd(map));
+
+    // Hard-limit suggestions to the deployment city's actual footprint (the bounding box of its
+    // neighborhoods), NOT the map's deliberately-generous pan-bounds (which can span a whole metro area).
+    // Merge onto the existing options so we don't clobber a proximity the map binding may have added.
+    fetch('/neighborhoods')
+        .then(response => response.json())
+        .then(geojson => {
+            const bbox = cityBoundingBox(geojson);
+            if (bbox) searchBox.options = Object.assign({}, searchBox.options, { bbox });
+        })
+        .catch(() => { /* If the city extent can't be loaded, leave the search unbounded. */ });
+}

--- a/public/locales/de/labelmap.json
+++ b/public/locales/de/labelmap.json
@@ -1,5 +1,7 @@
 {
     "search-placeholder": "Nach Adresse oder Ort suchen",
+    "loading-labels": "Beschriftungen werden geladen…",
+    "loading-elapsed": "{{seconds}} s vergangen",
     "is-correct": "Ist diese Beschriftung richtig?",
     "label-type": "Beschriftungskategorie",
     "validations": "Validierungen",

--- a/public/locales/de/labelmap.json
+++ b/public/locales/de/labelmap.json
@@ -1,4 +1,5 @@
 {
+    "search-placeholder": "Nach Adresse oder Ort suchen",
     "is-correct": "Ist diese Beschriftung richtig?",
     "label-type": "Beschriftungskategorie",
     "validations": "Validierungen",

--- a/public/locales/en/labelmap.json
+++ b/public/locales/en/labelmap.json
@@ -1,4 +1,5 @@
 {
+    "search-placeholder": "Search for an address or place",
     "is-correct": "Is this label correct?",
     "label-type": "Label Type",
     "validations": "Validations",

--- a/public/locales/en/labelmap.json
+++ b/public/locales/en/labelmap.json
@@ -1,5 +1,7 @@
 {
     "search-placeholder": "Search for an address or place",
+    "loading-labels": "Loading sidewalk labels…",
+    "loading-elapsed": "{{seconds}}s elapsed",
     "is-correct": "Is this label correct?",
     "label-type": "Label Type",
     "validations": "Validations",

--- a/public/locales/es/labelmap.json
+++ b/public/locales/es/labelmap.json
@@ -1,5 +1,7 @@
 {
     "search-placeholder": "Busca una dirección o lugar",
+    "loading-labels": "Cargando etiquetas…",
+    "loading-elapsed": "{{seconds}} s transcurridos",
     "is-correct": "Esta etiqueta es correcta?",
     "label-type": "Tipo de etiqueta",
     "validations": "Validaciones",

--- a/public/locales/es/labelmap.json
+++ b/public/locales/es/labelmap.json
@@ -1,4 +1,5 @@
 {
+    "search-placeholder": "Busca una dirección o lugar",
     "is-correct": "Esta etiqueta es correcta?",
     "label-type": "Tipo de etiqueta",
     "validations": "Validaciones",

--- a/public/locales/nl/labelmap.json
+++ b/public/locales/nl/labelmap.json
@@ -1,4 +1,5 @@
 {
+    "search-placeholder": "Zoek een adres of plaats",
     "is-correct": "Klopt dit etiket?",
     "label-type": "Etikettype",
     "validations": "Validations",

--- a/public/locales/nl/labelmap.json
+++ b/public/locales/nl/labelmap.json
@@ -1,5 +1,7 @@
 {
     "search-placeholder": "Zoek een adres of plaats",
+    "loading-labels": "Etiketten laden…",
+    "loading-elapsed": "{{seconds}} s verstreken",
     "is-correct": "Klopt dit etiket?",
     "label-type": "Etikettype",
     "validations": "Validations",

--- a/public/locales/pt-BR/labelmap.json
+++ b/public/locales/pt-BR/labelmap.json
@@ -1,5 +1,7 @@
 {
     "search-placeholder": "Pesquise um endereço ou local",
+    "loading-labels": "Carregando rótulos…",
+    "loading-elapsed": "{{seconds}} s decorridos",
     "is-correct": "Esse rótulo esta correto?",
     "label-type": "Tipo de Rótulo",
     "validations": "Validação",

--- a/public/locales/pt-BR/labelmap.json
+++ b/public/locales/pt-BR/labelmap.json
@@ -1,4 +1,5 @@
 {
+    "search-placeholder": "Pesquise um endereço ou local",
     "is-correct": "Esse rótulo esta correto?",
     "label-type": "Tipo de Rótulo",
     "validations": "Validação",

--- a/public/locales/zh-TW/labelmap.json
+++ b/public/locales/zh-TW/labelmap.json
@@ -1,4 +1,5 @@
 {
+    "search-placeholder": "搜尋地址或地點",
     "is-correct": "這個標記是否正確?",
     "label-type": "標記類型",
     "validations": "檢核",

--- a/public/locales/zh-TW/labelmap.json
+++ b/public/locales/zh-TW/labelmap.json
@@ -1,5 +1,7 @@
 {
     "search-placeholder": "搜尋地址或地點",
+    "loading-labels": "正在載入標記…",
+    "loading-elapsed": "已經過 {{seconds}} 秒",
     "is-correct": "這個標記是否正確?",
     "label-type": "標記類型",
     "validations": "檢核",

--- a/public/stylesheets/choropleth.css
+++ b/public/stylesheets/choropleth.css
@@ -36,6 +36,35 @@
     margin-top: 15px;
 }
 
+/*
+ * Public LabelMap (/labelMap) renders full-window. The page's #wrap becomes a fixed-height flex column
+ * (.wrap--full-window in main.css); this container is the flex-growing child that fills whatever space
+ * is left below the navbar and the in-flow (dev-only) test-server banner. Scoped to the public
+ * #labelmap-* ids so the admin Map tab (#admin-labelmap-*), which shares this file, stays boxed.
+ */
+#labelmap-choropleth-container {
+    max-width: none; /* Override the Bootstrap .container max-width so the map spans the window. */
+    width: 100%;
+    flex: 1 1 auto; /* Fill the space #wrap leaves below the navbar and any test-server banner. */
+    min-height: 0; /* Let the flex child shrink to fit instead of overflowing the column. */
+    margin: 0;
+    padding: 0;
+}
+#labelmap-choropleth {
+    height: 100%; /* Fill the container rather than the shared .choropleth fixed 800px. */
+    margin-top: 0; /* Sit flush under the navbar (overrides the shared 15px above). */
+}
+/* Drop the top gap the shared sidebar chrome leaves, so it too sits flush in full-window mode. */
+#labelmap-choropleth-holder .map-sidebar {
+    margin-top: 0;
+}
+#labelmap-choropleth-holder .map-sidebar__resize-handle {
+    top: 0;
+}
+#labelmap-choropleth-holder .map-sidebar-open-btn {
+    margin-top: 0;
+}
+
 #admin-task-choropleth {
     width: 360px;
     height: 360px;

--- a/public/stylesheets/choropleth.css
+++ b/public/stylesheets/choropleth.css
@@ -65,6 +65,61 @@
     margin-top: 0;
 }
 
+/*
+ * Loading indicator shown over the map while the label layer streams in (#4370/#4447). A centered
+ * floating card (not a full-map scrim) so it reads over the light basemap without blacking it out, and
+ * pointer-events: none so it stays purely informational and never blocks panning while labels load.
+ */
+#labelmap-loading {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 20; /* Above the map and sidebar chrome. */
+    pointer-events: none;
+}
+#labelmap-loading[hidden] {
+    display: none;
+}
+.labelmap-loading__card {
+    text-align: center;
+    color: #fff;
+    background: rgba(0, 0, 0, 0.72);
+    padding: 24px 32px;
+    border-radius: 10px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+    font-family: 'Raleway', sans-serif;
+}
+.labelmap-loading__spinner {
+    width: 40px;
+    height: 40px;
+    margin: 0 auto 14px;
+    border: 3px solid rgba(255, 255, 255, 0.25);
+    border-top-color: #fff;
+    border-radius: 50%;
+    animation: labelmap-spin 0.8s linear infinite;
+}
+@keyframes labelmap-spin {
+    to { transform: rotate(360deg); }
+}
+.labelmap-loading__message {
+    font-size: 1rem;
+    font-weight: 600;
+    margin: 0;
+}
+.labelmap-loading__elapsed {
+    font-size: 0.8rem;
+    color: #bbb;
+    margin: 6px 0 0;
+}
+/* Respect reduced-motion: keep the spinner as a feedback cue but slow it well down. */
+@media (prefers-reduced-motion: reduce) {
+    .labelmap-loading__spinner {
+        animation-duration: 2.4s;
+    }
+}
+
 #admin-task-choropleth {
     width: 360px;
     height: 360px;

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -409,6 +409,20 @@ a {
     height: auto;
 }
 
+/*
+ * Full-window app pages (e.g. /labelMap) opt in via this class: #wrap becomes a fixed-height flex
+ * column so a flex-growing content area (the map) fills the viewport below the navbar, while the
+ * in-flow test-server banner (dev only) keeps its natural height rather than being covered. Robust to
+ * the banner wrapping or being dismissed; no effect on other pages, which don't get the class.
+ */
+#wrap.wrap--full-window {
+    display: flex;
+    flex-direction: column;
+    height: calc(100vh - var(--navbar-height));
+    min-height: 0;
+    overflow: hidden;
+}
+
 #mini-footer {
     position: relative;
     width: 100%;

--- a/public/stylesheets/mapSidebar.css
+++ b/public/stylesheets/mapSidebar.css
@@ -52,6 +52,23 @@
     height: 24px;
 }
 
+/* Address/place search box mounted at the top of the LabelMap sidebar (#4370). */
+#labelmap-search-section {
+    /*
+     * Raise the section (and its overflowing autocomplete dropdown) above the sibling filter sections
+     * below it. Those sections' controls (e.g. .severity-button) are position: relative, so without this
+     * they'd paint over the earlier-in-DOM dropdown.
+     */
+    position: relative;
+    z-index: 100;
+    margin-top: 18px; /* Breathing room below the collapse-drawer (close) button. */
+    margin-bottom: 28px; /* A bit more space above the Severity section than the standard 25px. */
+}
+
+#labelmap-search-box {
+    width: 100%;
+}
+
 /* Drag handle for resizing the sidebar width. Sits on the right edge of the sidebar. */
 .map-sidebar__resize-handle {
     position: absolute;

--- a/public/stylesheets/mapSidebar.css
+++ b/public/stylesheets/mapSidebar.css
@@ -67,6 +67,21 @@
 
 #labelmap-search-box {
     width: 100%;
+    /*
+     * Reserve the control's height (the Mapbox search input is 36px) so mounting it never nudges the
+     * filter sections below — even in the sub-frame before the search web component finishes upgrading.
+     */
+    min-height: 36px;
+}
+
+/*
+ * The control wraps itself in a .mapboxgl-ctrl div with an inline width: 300px (sized for a floating
+ * map control). Override it so the box fills the sidebar column instead of overflowing its ~290px of
+ * content width. !important is required because 300px is set as an inline style.
+ */
+#labelmap-search-box > .mapboxgl-ctrl {
+    width: 100% !important;
+    margin: 0;
 }
 
 /* Drag handle for resizing the sidebar width. Sits on the right edge of the sidebar. */


### PR DESCRIPTION
## What & why

The public LabelMap (`/labelMap`) rendered as a fixed 800px map inside a normal scrolling document with the full footer — out of step with our other interactive-map pages (Explore, Validate), which are chromeless and viewport-filling. It also had no way to search for a location, the most-requested navigation affordance (#4370).

This makes `/labelMap` full-window and adds an in-city address/place search.

## Changes

**Full-window layout**
- `/labelMap` drops the footer and page scroll via the existing `url`-based mechanism in `main.scala.html` (same path `/explore` and `/validate` use).
- `#wrap` becomes a fixed-height flex column (`.wrap--full-window`) so the map fills the space below the navbar while the in-flow dev test-server banner keeps its natural height (no overlap; robust to dismissal/resize).
- All map-sizing CSS is scoped to `#labelmap-*`, so the admin Map tab (which shares `choropleth.css`) stays boxed.

**Address/place search (#4370)**
- Mounts a Mapbox Search JS `MapboxSearchBox` at the top of the filter sidebar (`labelMapLocationSearch.js`), bound to the map for fly-to + marker + dynamic map-center proximity.
- Suggestions are hard-limited to the **deployment city's footprint** — the bounding box of `/neighborhoods` plus a small 10% buffer — rather than the DB config pan-bounds, which are metro/state-wide (Teaneck 84×111 km, Seattle 300×111 km). Keeps it a within-city finder (hospitals, schools, libraries, …) rather than a general-purpose geocoder.
- i18n: `search-placeholder` added for `en` + `es/de/nl/pt-BR/zh-TW` (regional `en-US/en-NZ` inherit from `en`; `pt/zh` are empty overlays that fall back).

## Screenshots
Here's an example looking for Teaneck HIgh school. The search is focused on the regional geography.

<img width="2712" height="1577" alt="image" src="https://github.com/user-attachments/assets/32dccdff-c798-4bc6-9d8d-debc97774d09" />

<img width="2291" height="1368" alt="image" src="https://github.com/user-attachments/assets/b112e5ae-67d7-44be-8d54-62d64fe8a7b4" />

<img width="2704" height="1579" alt="image" src="https://github.com/user-attachments/assets/9f8fc3ce-5d4b-479b-8113-9e4816c4a505" />


## Scope

Frontend-only — no backend, DB, or routes changes. This is **deliverable 1 of 2** for #4370; the **"Explore the sidewalks here"** action (drop into Explore at a searched address via a new `exploreAddress` mission type) is a deliberate follow-up, since it involves the mission model + SVLabel flow.

## Testing

- `sbt --client compile` clean (Twirl templates included; `-Xfatal-warnings`).
- Verified over HTTP on a local Teaneck run: `/labelMap` renders full-window (no footer, no page scroll), search box present, all new CSS/JS served.
- Admin Map tab and user-profile map unaffected (CSS scoping held).
- Search behavior visually verified: city-scoped suggestions, fly-to + marker, dropdown z-index above the filter sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
