### PR TITLE
Normalize compass heading calculation

### DIFF
--- a/public/javascripts/SVLabel/src/navigation/Compass.js
+++ b/public/javascripts/SVLabel/src/navigation/Compass.js
@@ -169,10 +169,10 @@ class Compass {
 
   /**
    * Get the compass angle.
-   * @returns {number}
+   * @returns {number} Degrees the user needs to rotate to face the correct direction, normalized [0,360].
    */
   #getCompassAngle() {
-    const heading = svl.panoViewer.getPov().heading;
+    const heading = ((svl.panoViewer.getPov().heading % 360) + 360) % 360;
     const targetAngle = this.getTargetAngle();
     return ((heading - targetAngle + 360) % 360);
   }


### PR DESCRIPTION
Fixes #4465

Normalizes compass heading to ensure it stays within [0,360] degrees, fixing issues where it would suggest going straight at odd angles.
