### PR TITLE
Fix #4464: pano info button crashes on Explore (unbound getRegionId accessor)

### DIFF
--- a/public/js/explore/src/Main.js
+++ b/public/js/explore/src/Main.js
@@ -162,7 +162,7 @@ class Main {
 
     svl.infoPopover = new PanoInfoPopover(svl.ui.streetview.dateHolder, svl.panoViewer, svl.panoViewer.getPosition,
       svl.panoViewer.getPanoId, () => svl.taskContainer.getCurrentTaskStreetEdgeId(),
-      svl.neighborhoodModel.currentNeighborhood().getRegionId,
+      () => svl.neighborhoodModel.currentNeighborhood().getRegionId(),
       () => svl.panoStore.getPanoData(svl.panoViewer.getPanoId()).getProperty('captureDate'),
       () => svl.panoStore.getPanoData(svl.panoViewer.getPanoId()).getProperty('address'),
       svl.panoViewer.getPov, true,


### PR DESCRIPTION
Fixes #4464 — the pano info button does nothing on Explore (works in Validate/Gallery/LabelMap).

## Root cause

`PanoInfoPopover` (shared component) takes each field as an accessor function and later calls them, e.g. `this.#regionId()`. Explore passed the region accessor as a **bare, unbound method reference**:

```js
svl.neighborhoodModel.currentNeighborhood().getRegionId
```

When `PanoInfoPopover` invokes it, the `this` binding is lost, so `getRegionId`'s `this.getProperty('regionId')` throws `this.getProperty is not a function` on the first info-button click. The other three viewers pass arrow-function accessors, which is why the bug is Explore-only.

## Fix

Wrap it in an arrow function — matching the `streetEdgeId` / `panoDate` / `panoAddress` accessors immediately around it:

```js
() => svl.neighborhoodModel.currentNeighborhood().getRegionId()
```

This binds `this` correctly and also defers `currentNeighborhood()` to click time (so the popover reflects the region you're actually in).

## Verification

Rebuilt the explore bundle from this change and served it on a local dev server: the served bundle carries the arrow-wrapped accessor (buggy unbound form gone), and the change mirrors the three working call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
