### PR TITLE
Fix Explore ribbon "Other Accessibility Labels" oversized title (id vs class typo)

### DIFF
--- a/app/views/apps/explore.scala.html
+++ b/app/views/apps/explore.scala.html
@@ -177,7 +177,7 @@
           </div>
           <div class="ribbon-menu-group">
             <div id="ribbon-menu-title-holder-other" class="ribbon-menu-title-holder audit-selectable">
-              <span id="ribbon-menu-title">@Messages("audit.ribbon.other.labels")</span>
+              <span class="ribbon-menu-title">@Messages("audit.ribbon.other.labels")</span>
             </div>
             <div class="ribbon-menu-group-buttons">
               <span id="mode-switch-button-crosswalk" class="label-type-button-holder" val="Crosswalk">


### PR DESCRIPTION
## What

On Explore, the **"Other Accessibility Labels"** ribbon title renders much larger than "Curb Ramp Labels" and "Sidewalk Labels".

## Why

The three group titles are meant to share `.ribbon-menu-title`, but the third one used `id="ribbon-menu-title"` instead of `class="ribbon-menu-title"` (`app/views/apps/explore.scala.html:180`). A CSS **class** selector doesn't match an element that only has that string as its **id**, so `.ribbon-menu-title { font: var(--text-tiny-regular) }` never applied and the title fell back to the default `<span>` font size.

No `#ribbon-menu-title` CSS selector and no `getElementById('ribbon-menu-title')` exist, so the id was unused — switching it to the class has no side effects.

## Fix

`id=` → `class=` on that span, matching the other two titles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
