### PR TITLE
Wrap long compass messages instead of overflowing the box (#4383)

### DIFF
--- a/public/css/explore/svl-compass.css
+++ b/public/css/explore/svl-compass.css
@@ -5,7 +5,8 @@
   z-index: 2;
   padding: calc(5px * var(--ui-scale));
   min-width: calc(120px * var(--ui-scale));
-  white-space: nowrap;
+  max-width: calc(320px * var(--ui-scale));
+  overflow-wrap: break-word;
   border-radius: calc(3px * var(--ui-scale));
   transition: background-color 150ms ease, transform 150ms ease;
   background-color: rgb(from var(--color-neutral-white) r g b / 75%);

--- a/public/js/explore/src/navigation/Compass.js
+++ b/public/js/explore/src/navigation/Compass.js
@@ -224,11 +224,11 @@ class Compass {
 
   #setLabelBeforeJumpMessage() {
     if (svl.neighborhoodModel.isRouteComplete) {
-      this.#uiCompass.message.html(`<div style="width: 20%">${i18next.t('center-ui.compass.end-route')}</div>`);
+      this.#uiCompass.message.html(`<div>${i18next.t('center-ui.compass.end-route')}</div>`);
     } else if (svl.neighborhoodModel.isNeighborhoodComplete) {
-      this.#uiCompass.message.html(`<div style="width: 20%">${i18next.t('center-ui.compass.end-neighborhood')}</div>`);
+      this.#uiCompass.message.html(`<div>${i18next.t('center-ui.compass.end-neighborhood')}</div>`);
     } else {
-      this.#uiCompass.message.html(`<div style="width: 20%">${i18next.t('center-ui.compass.end-street')}</div>`);
+      this.#uiCompass.message.html(`<div>${i18next.t('center-ui.compass.end-street')}</div>`);
     }
   }
 

--- a/public/locales/de/audit.json
+++ b/public/locales/de/audit.json
@@ -229,10 +229,10 @@
       "slight-left": "Biegen Sie leicht links ab",
       "slight-right": "Biegen Sie leicht rechts ab",
       "u-turn": "Kehrtwende",
-      "end-route": "Sie sind am Ende Ihrer Route! Beenden Sie das Beschriften dieser Kreuzung. Anschliessend <br><span class='bold'>klicken Sie hier, um die Route zu beenden.</span>",
-      "end-neighborhood": "Sie haben das gesamte Quartier erkundet! Beenden Sie das Beschriften dieser Kreuzung. Anschliessend <br><span class='bold'>klicken Sie hier, um das Quartier zu beenden.</span>",
-      "end-street": "Wir werden Sie an einen neuen Ort bewegen. Beenden sie das Beschriften dieser Kreuzung. Anschliessend <br><span class='bold'>klicken Sie hier um zu einem neuen Ort gebracht zu werden.</span>",
-      "far-away": "Ups, Sie sind ziemlich weit von der Route entfernt. <br><span class='bold'>Klicken Sie hier, um zurückzukehren.</span>"
+      "end-route": "Sie sind am Ende Ihrer Route! Beenden Sie das Beschriften dieser Kreuzung. Anschliessend <b>klicken Sie hier, um die Route zu beenden.</b>",
+      "end-neighborhood": "Sie haben das gesamte Quartier erkundet! Beenden Sie das Beschriften dieser Kreuzung. Anschliessend <b>klicken Sie hier, um das Quartier zu beenden.</b>",
+      "end-street": "Wir werden Sie an einen neuen Ort bewegen. Beenden sie das Beschriften dieser Kreuzung. Anschliessend <b>klicken Sie hier um zu einem neuen Ort gebracht zu werden.</b>",
+      "far-away": "Ups, Sie sind ziemlich weit von der Route entfernt. <b>Klicken Sie hier, um zurückzukehren.</b>"
     }
   },
   "popup": {

--- a/public/locales/en-NZ/audit.json
+++ b/public/locales/en-NZ/audit.json
@@ -60,7 +60,7 @@
       }
     },
     "compass": {
-      "end-neighborhood": "You've explored this entire neighbourhood! Finish labeling this intersection, then <br><span class='bold'>click here to complete the neighbourhood.</span>"
+      "end-neighborhood": "You've explored this entire neighbourhood! Finish labeling this intersection, then <b>click here to complete the neighbourhood.</b>"
     }
   },
   "popup": {

--- a/public/locales/en/audit.json
+++ b/public/locales/en/audit.json
@@ -229,10 +229,10 @@
       "slight-left": "Turn slightly left",
       "slight-right": "Turn slightly right",
       "u-turn": "U turn",
-      "end-route": "You're at the end of your route! Finish labeling this intersection, then <br><span class='bold'>click here to complete the route.</span>",
-      "end-neighborhood": "You've explored this entire neighborhood! Finish labeling this intersection, then <br><span class='bold'>click here to complete the neighborhood.</span>",
-      "end-street": "We need to move you to a new location. Finish labeling this intersection, then <br><span class='bold'>click here to move to a new location.</span>",
-      "far-away": "Uh-oh, you're quite far away from the route. <br><span class='bold'>Click here to jump back.</span>"
+      "end-route": "You're at the end of your route! Finish labeling this intersection, then <b>click here to complete the route.</b>",
+      "end-neighborhood": "You've explored this entire neighborhood! Finish labeling this intersection, then <b>click here to complete the neighborhood.</b>",
+      "end-street": "We need to move you to a new location. Finish labeling this intersection, then <b>click here to move to a new location.</b>",
+      "far-away": "Uh-oh, you're quite far away from the route. <b>Click here to jump back.</b>"
     }
   },
   "popup": {

--- a/public/locales/es/audit.json
+++ b/public/locales/es/audit.json
@@ -229,10 +229,10 @@
       "slight-left": "Gira ligeramente a la izquierda",
       "slight-right": "Gira ligeramente a la derecha",
       "u-turn": "Da la vuelta",
-      "end-route": "¡Estás al final de tu ruta! Termina de etiquetar esta intersección, luego <br><span class='bold'>haz clic aquí para completar la ruta.</span>",
-      "end-neighborhood": "¡Has explorado todo este vecindario! Termine de etiquetar esta intersección, luego <br><span class='bold'>haga clic aquí para completar el vecindario.</span>",
-      "end-street": "Necesitamos trasladarte a una nueva ubicación. Termine de etiquetar esta intersección, luego <br><span class='bold'>haga clic aquí para moverse a una nueva ubicación.</span>",
-      "far-away": "Oh-oh, estás bastante lejos de la ruta. <br><span class='bold'>Haz clic aquí para volver atrás.</span>"
+      "end-route": "¡Estás al final de tu ruta! Termina de etiquetar esta intersección, luego <b>haz clic aquí para completar la ruta.</b>",
+      "end-neighborhood": "¡Has explorado todo este vecindario! Termine de etiquetar esta intersección, luego <b>haga clic aquí para completar el vecindario.</b>",
+      "end-street": "Necesitamos trasladarte a una nueva ubicación. Termine de etiquetar esta intersección, luego <b>haga clic aquí para moverse a una nueva ubicación.</b>",
+      "far-away": "Oh-oh, estás bastante lejos de la ruta. <b>Haz clic aquí para volver atrás.</b>"
     }
   },
   "popup": {

--- a/public/locales/nl/audit.json
+++ b/public/locales/nl/audit.json
@@ -229,10 +229,10 @@
       "slight-left": "Sla flauw links af",
       "slight-right": "Sla flauw rechts af",
       "u-turn": "Keer om",
-      "end-route": "Je bent aan het einde van je route! Voltooi het labelen van dit kruispunt en <br><span class='bold'>klik hier om de route te voltooien.</span>",
-      "end-neighborhood": "Je hebt deze hele buurt verkend! Voltooi het labelen van dit kruispunt en <br><span class='bold'>klik hier om de buurt te voltooien.</span>",
-      "end-street": "We moeten u verhuizen naar een nieuwe locatie. Voltooi het labelen van dit kruispunt en <br><span class='bold'>klik hier om naar een nieuwe locatie te gaan.</span>",
-      "far-away": "Oh oh, je bent nogal ver weg van de route. <br><span class='bold'>Klik hier om terug te gaan.</span>"
+      "end-route": "Je bent aan het einde van je route! Voltooi het labelen van dit kruispunt en <b>klik hier om de route te voltooien.</b>",
+      "end-neighborhood": "Je hebt deze hele buurt verkend! Voltooi het labelen van dit kruispunt en <b>klik hier om de buurt te voltooien.</b>",
+      "end-street": "We moeten u verhuizen naar een nieuwe locatie. Voltooi het labelen van dit kruispunt en <b>klik hier om naar een nieuwe locatie te gaan.</b>",
+      "far-away": "Oh oh, je bent nogal ver weg van de route. <b>Klik hier om terug te gaan.</b>"
     }
   },
   "popup": {

--- a/public/locales/pt-BR/audit.json
+++ b/public/locales/pt-BR/audit.json
@@ -229,10 +229,10 @@
       "slight-left": "Vire ligeiramente à esquerda",
       "slight-right": "Vire ligeiramente à direita",
       "u-turn": "Retorne",
-      "end-route": "Você está no final da sua rota! Termine de rotular este cruzamento e, em seguida, <br><span class='bold'>clique aqui para completar a rota.</span>",
-      "end-neighborhood": "Você explorou todo este bairro! Termine de rotular este cruzamento e, em seguida, <br><span class='bold'>clique aqui para completar o bairro.</span>",
-      "end-street": "Precisamos movê-lo para um novo local. Termine de rotular este cruzamento e, em seguida, <br><span class='bold'>clique aqui para ir para um novo local.</span>",
-      "far-away": "Opa, você está bem longe da rota. <br><span class='bold'>Clique aqui para voltar.</span>"
+      "end-route": "Você está no final da sua rota! Termine de rotular este cruzamento e, em seguida, <b>clique aqui para completar a rota.</b>",
+      "end-neighborhood": "Você explorou todo este bairro! Termine de rotular este cruzamento e, em seguida, <b>clique aqui para completar o bairro.</b>",
+      "end-street": "Precisamos movê-lo para um novo local. Termine de rotular este cruzamento e, em seguida, <b>clique aqui para ir para um novo local.</b>",
+      "far-away": "Opa, você está bem longe da rota. <b>Clique aqui para voltar.</b>"
     }
   },
   "popup": {

--- a/public/locales/zh-TW/audit.json
+++ b/public/locales/zh-TW/audit.json
@@ -228,10 +228,10 @@
       "slight-left": "稍微向左轉",
       "slight-right": "稍微向右轉",
       "u-turn": "迴轉",
-      "end-route": "您已到達路線的盡頭！ 完成標記此路口，然後<br><span class='bold'>點選這裡完成路線。</span>",
-      "end-neighborhood": "您已探索了整個鄰里！ 完成標記此路口，然後<br><span class='bold'>點選這裡完成此鄰里。</span>",
-      "end-street": "我們需要將您轉移到新的位置。 完成標記此路口，然後<br><span class='bold'>點選這裡來移動到新的位置。</span>",
-      "far-away": "不妙了！ 您已經離開路線很遠了。<br><span class='bold'>點選這裡以回到路線。</span>"
+      "end-route": "您已到達路線的盡頭！ 完成標記此路口，然後 <b>點選這裡完成路線。</b>",
+      "end-neighborhood": "您已探索了整個鄰里！ 完成標記此路口，然後<b>點選這裡完成此鄰里。</b>",
+      "end-street": "我們需要將您轉移到新的位置。 完成標記此路口，然後<b>點選這裡來移動到新的位置。</b>",
+      "far-away": "不妙了！ 您已經離開路線很遠了。<b>點選這裡以回到路線。</b>"
     }
   },
   "popup": {


### PR DESCRIPTION
Fixes #4383

## Problem

The compass message holder in Explore (bottom-right of the pano viewer) used `white-space: nowrap` with only a `min-width`. A long message — e.g. the end-of-route / end-neighborhood / "far away" instructions — couldn't wrap, so the box grew until the text spilled outside the pano viewer.

## Fix

- **`svl-compass.css`**: replace `white-space: nowrap` with a `max-width` (`calc(320px * var(--ui-scale))`) plus `overflow-wrap: break-word`, so the box caps its width and the message wraps inside it.
- **`Compass.js`**: drop the now-unneeded inline `width: 20%` hacks on the jump messages (`end-route` / `end-neighborhood` / `end-street`), which were compensating for the nowrap behavior.
- **`locales/*/audit.json`**: replace the `<br>` + `<span class='bold'>` markup in the compass strings with `<b>` so the text reflows naturally within the box rather than forcing a hard break.

## Testing

Verify in Explore at a few UI scales that the long compass messages wrap inside the box, and that the turn-direction prompts (arrow icon + "Turn left/right") still read on a single line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)