### PR TITLE
Disable validating/commenting on labels with no available imagery (#4446)

### DIFF
--- a/public/css/label-detail.css
+++ b/public/css/label-detail.css
@@ -246,7 +246,7 @@ dialog.label-detail[open]::backdrop {
 
 .label-detail__pano-overlay-button.is-selected { opacity: 1; }
 
-/* Read-only mode: viewer is looking at their own labels, so we don't allow validating or commenting.
+/* Read-only mode: validating/commenting is blocked (the viewer's own label, or no imagery is available for it).
    Elements remain visible but appear disabled. */
 .label-detail--readonly .label-detail__pano-overlay-button {
   opacity: 0.8;

--- a/public/js/common/label-detail/LabelDetail.js
+++ b/public/js/common/label-detail/LabelDetail.js
@@ -31,6 +31,7 @@ class LabelDetail {
 
   #source = undefined; // Set in showLabel().
   #readonly = false;   // Set per-label in #handleData() based on meta.from_current_user.
+  #noImagery = false;  // Set per-label once setPano() resolves; true when no navigable imagery could be loaded.
   #validationCounts = { Agree: null, Disagree: null, Unsure: null };
   #flags = { low_quality: null, incomplete: null, stale: null };
   #prevAction = null;
@@ -228,7 +229,7 @@ class LabelDetail {
     const els = this.#els;
     // buttonSource overrides #source for this specific button group; falls back to #source if null.
     const voteHandler = (action, buttonSource) => () => {
-      if (this.#readonly) return;
+      if (this.#locked) return;
       if (this.#prevAction !== action) {
         this.#setVoteButtonsDisabled(true);
         this.#validateLabel(action, buttonSource || this.#source);
@@ -242,12 +243,12 @@ class LabelDetail {
       const btn = els.voteButtons[action];
       const img = els.voteIcons[action];
       btn.addEventListener('mouseenter', () => {
-        if (this.#readonly) return;
+        if (this.#locked) return;
         const ai = this.#aiValidation === action ? '-ai' : '';
         img.src = `${this.#iconBase}${action.toLowerCase()}-filled${ai}.svg`;
       });
       btn.addEventListener('mouseleave', () => {
-        if (this.#readonly) return;
+        if (this.#locked) return;
         this.#renderVoteIcons();
       });
     }
@@ -258,7 +259,7 @@ class LabelDetail {
     els.commentInput.addEventListener('keydown', (e) => {
       if (e.key === 'Enter') {
         e.preventDefault();
-        if (this.#readonly) return;
+        if (this.#locked) return;
         const comment = els.commentInput.value.trim();
         if (comment) this.#submitComment(comment);
       } else if (e.key === 'Escape') {
@@ -275,7 +276,7 @@ class LabelDetail {
       }
     });
     els.commentButton.addEventListener('click', () => {
-      if (this.#readonly) return;
+      if (this.#locked) return;
       const comment = els.commentInput.value.trim();
       if (comment) this.#submitComment(comment);
     });
@@ -329,10 +330,11 @@ class LabelDetail {
     const els = this.#els;
     this.#currentLabelMeta = meta;
 
-    // Read-only mode for the user's own labels — no validating/commenting.
+    // Read-only mode for the user's own labels — no validating/commenting. Imagery availability is unknown until
+    // setPano() resolves below, so assume it's present for now and re-apply the lock once we know.
     this.#readonly = !!meta.from_current_user;
-    this.#root.classList.toggle('label-detail--readonly', this.#readonly);
-    this.#setReadonlyState(this.#readonly);
+    this.#noImagery = false;
+    this.#applyInteractionLock();
 
     const labelPov = { heading: meta.heading, pitch: meta.pitch, zoom: meta.zoom };
 
@@ -356,7 +358,16 @@ class LabelDetail {
     this.panoManager.setLabel(popupLabel);
     // Accept a pre-constructed backup_image object (Gallery path) or build from server fields (API path).
     const backupImage = meta.backup_image || buildBackupImageData(meta);
-    this.panoManager.setPano(meta.pano_id, labelPov, meta.crop_url, meta.expired, backupImage);
+    // setPano() resolves to whether a viewable image of the label was shown — live/Pannellum imagery or the static
+    // crop. It's only false for the "imagery not available" panel, i.e. nothing to look at. Lock validating/
+    // commenting only in that case: if the user can see the label in an image (crop included), they can validate it.
+    this.panoManager.setPano(meta.pano_id, labelPov, meta.crop_url, meta.expired, backupImage)
+      .then((imageShown) => {
+        // Guard against a newer label having been opened while this resolved.
+        if (this.#currentLabelMeta !== meta) return;
+        this.#noImagery = !imageShown;
+        this.#applyInteractionLock();
+      });
 
     // Validation counts + AI validation.
     this.#validationCounts.Agree = meta.num_agree;
@@ -606,7 +617,7 @@ class LabelDetail {
   #resetVoteButtonStyles() {
     for (const btn of Object.values(this.#els.panoOverlayButtons)) {
       btn.classList.remove('is-selected');
-      if (!this.#readonly) btn.disabled = false;
+      if (!this.#locked) btn.disabled = false;
     }
     if (this.#els.panoWrap) {
       this.#els.panoWrap.classList.remove('is-agree', 'is-disagree', 'is-unsure');
@@ -614,29 +625,43 @@ class LabelDetail {
   }
 
   /**
-   * Toggles the disabled state + tooltip on interactive elements when viewing your own label.
-   * @param {boolean} readonly
+   * Whether validating/commenting is blocked for the current label — the viewer's own label or no available imagery.
+   * navigable imagery is available for it.
+   * @returns {boolean}
    */
-  #setReadonlyState(readonly) {
+  get #locked() {
+    return this.#readonly || this.#noImagery;
+  }
+
+  /**
+   * Toggles the disabled state + tooltip on interactive elements based on the current lock reasons. The viewer's
+   * own label and no-imagery both disable validating/commenting; own-label wins the tooltip since it's the more
+   * specific reason to surface.
+   */
+  #applyInteractionLock() {
     const els = this.#els;
-    const tip = readonly ? i18next.t('labelmap:own-label-disabled') : '';
+    const locked = this.#locked;
+    this.#root.classList.toggle('label-detail--readonly', locked);
+    const tip = this.#readonly
+      ? i18next.t('labelmap:own-label-disabled')
+      : this.#noImagery ? i18next.t('labelmap:no-imagery-disabled') : '';
 
     // Pano overlay buttons.
     for (const btn of Object.values(els.panoOverlayButtons)) {
-      btn.disabled = readonly;
+      btn.disabled = locked;
       btn.title = tip;
     }
 
     // Validation column buttons.
     for (const btn of Object.values(els.voteButtons)) {
-      btn.disabled = readonly;
+      btn.disabled = locked;
       btn.title = tip;
     }
 
     // Comment input and submit button.
-    els.commentInput.disabled = readonly;
+    els.commentInput.disabled = locked;
     els.commentInput.title = tip;
-    els.commentButton.disabled = readonly;
+    els.commentButton.disabled = locked;
     els.commentButton.title = tip;
   }
 

--- a/public/js/common/label-detail/PopupPanoManager.js
+++ b/public/js/common/label-detail/PopupPanoManager.js
@@ -212,7 +212,8 @@ class PopupPanoManager {
    * @param {?string} cropUrl - URL for the screenshot fallback image, if available.
    * @param {boolean} [expired=false] - When true, skips the live attempt (imagery known to be expired).
    * @param {?Object} [backupImage=null] - Self-hosted pano metadata; fetched lazily from the backend if null.
-   * @returns {Promise<boolean>} Whether live/Pannellum imagery was shown (false if it fell back to a crop/error).
+   * @returns {Promise<boolean>} Whether a viewable image of the label was shown — live/Pannellum imagery or the
+   *                             static crop (step 1–3). Only `false` for step 4, the "imagery not available" panel.
    */
   async setPano(panoId, pov, cropUrl, expired = false, backupImage = null) {
     this.#cropUrl = typeof cropUrl === 'string' ? cropUrl : null;
@@ -254,11 +255,11 @@ class PopupPanoManager {
     }
 
     // Step 3 & 4: hand off to the existing failure callback, which shows the crop if cropUrl is set
-    // and a generic "imagery not available" message otherwise.
+    // and a generic "imagery not available" message otherwise. Its return distinguishes those two outcomes.
     this.activeViewerName = 'StaticCrop';
-    await this.#panoFailureCallback();
+    const cropShown = await this.#panoFailureCallback();
     if (!this.svHolder[0].dataset.closedDuringLoad) this.svHolder.css('visibility', 'visible');
-    return false;
+    return cropShown;
   }
 
   /**
@@ -328,7 +329,7 @@ class PopupPanoManager {
 
   /**
    * Shows an error message (or the crop fallback) if the pano fails to load.
-   * @returns {Promise<void>}
+   * @returns {Promise<boolean>} Whether the crop fallback was shown (false only when no imagery is available at all).
    */
   #panoFailureCallback() {
     $(this.#panoCanvas).css('display', 'none');
@@ -354,7 +355,7 @@ class PopupPanoManager {
       $(this.#panoNotAvailable).css('display', 'flex');
       this.#buttonHolder.css('display', 'none');
     }
-    return Promise.resolve();
+    return Promise.resolve(Boolean(this.#cropUrl));
   }
 
   /**

--- a/public/locales/de/labelmap.json
+++ b/public/locales/de/labelmap.json
@@ -22,6 +22,7 @@
   "comments": "Kommentare",
   "comment-submitted": "Kommentar gesendet",
   "own-label-disabled": "Sie können Ihre eigene Beschriftung nicht validieren oder kommentieren",
+  "no-imagery-disabled": "Sie können nicht validieren oder kommentieren, wenn für diese Beschriftung keine Bilddaten verfügbar sind",
   "admin-only": "Nur Admin",
   "not-admin-validated": "Nicht von einem Administrator validiert"
 }

--- a/public/locales/en/labelmap.json
+++ b/public/locales/en/labelmap.json
@@ -22,6 +22,7 @@
   "comments": "Comments",
   "comment-submitted": "Comment Submitted",
   "own-label-disabled": "You cannot validate or comment on your own label",
+  "no-imagery-disabled": "You cannot validate or comment when no imagery is available for this label",
   "admin-only": "Admin only",
   "not-admin-validated": "Not validated by an admin"
 }

--- a/public/locales/es/labelmap.json
+++ b/public/locales/es/labelmap.json
@@ -22,6 +22,7 @@
   "comments": "Comentarios",
   "comment-submitted": "Comentario enviado",
   "own-label-disabled": "No puedes validar ni comentar tu propia etiqueta",
+  "no-imagery-disabled": "No puedes validar ni comentar cuando no hay imágenes disponibles para esta etiqueta",
   "admin-only": "Solo administradores",
   "not-admin-validated": "No validado por un administrador"
 }

--- a/public/locales/nl/labelmap.json
+++ b/public/locales/nl/labelmap.json
@@ -22,6 +22,7 @@
   "comments": "Opmerkingen",
   "comment-submitted": "Commentaar ingediend",
   "own-label-disabled": "Je kunt je eigen etiket niet valideren of becommentariëren",
+  "no-imagery-disabled": "Je kunt niet valideren of becommentariëren wanneer er geen beeldmateriaal beschikbaar is voor dit etiket",
   "admin-only": "Alleen beheerders",
   "not-admin-validated": "Niet gevalideerd door een beheerder"
 }

--- a/public/locales/pt-BR/labelmap.json
+++ b/public/locales/pt-BR/labelmap.json
@@ -22,6 +22,7 @@
   "comments": "Comentários",
   "comment-submitted": "Comentários Enviados",
   "own-label-disabled": "Você não pode validar nem comentar seu próprio rótulo",
+  "no-imagery-disabled": "Você não pode validar nem comentar quando não há imagens disponíveis para este rótulo",
   "admin-only": "Apenas administradores",
   "not-admin-validated": "Não validado por um administrador"
 }

--- a/public/locales/zh-TW/labelmap.json
+++ b/public/locales/zh-TW/labelmap.json
@@ -22,6 +22,7 @@
   "comments": "評論",
   "comment-submitted": "已上傳評論",
   "own-label-disabled": "您無法驗證或評論自己的標記",
+  "no-imagery-disabled": "當此標記沒有可用的影像時，您無法驗證或評論",
   "admin-only": "僅限管理員",
   "not-admin-validated": "未經管理員驗證"
 }


### PR DESCRIPTION
## Summary

Fixes #4446.

The label detail popup already disables validating/commenting when you're viewing your **own** label. This extends that same lock to labels with **no available imagery**: when the pano can't be loaded and there's no static crop to fall back on (i.e. only the "imagery not available" panel is shown), the vote buttons and comment box are disabled with an explanatory tooltip.

If a static crop **is** available, the label stays fully validatable — if the user can see the label in an image, they can validate it.

## Changes

- **`PopupPanoManager.js`** — `setPano()` now resolves to whether any *viewable* image was shown (live/Pannellum imagery **or** the static crop). It's `false` only for the true "imagery not available" panel. `#panoFailureCallback()` reports whether it rendered the crop vs. the error panel.
- **`LabelDetail.js`** — added a `#noImagery` state (set once `setPano()` resolves) and a `#locked` getter combining it with the existing `#readonly` (own-label) state. `#setReadonlyState` → `#applyInteractionLock`, which disables the controls and picks the tooltip (own-label reason takes precedence). A stale-result guard drops the async `setPano` result if a newer label was opened in the meantime.
- **`label-detail.css`** — generalized the read-only mode comment (now covers both reasons).
- **Translations** — added `no-imagery-disabled` to all full locales (en, es, nl, de, pt-BR, zh-TW); en-US/en-NZ fall back to en.

## Testing

ESLint / Stylelint / locale key-parity all pass. Pano/crop rendering can't be automated, so manual verification:
- No-imagery label (not your own) → vote buttons + comment box disabled, new tooltip shown.
- Crop-only label → stays validatable.
- Live/Pannellum imagery → unchanged.
- Your own label → unchanged (own-label tooltip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)