### PR TITLE
Redirect mobile users away from RouteBuilder and Gallery (#4470)

### DIFF
--- a/app/controllers/ApplicationController.scala
+++ b/app/controllers/ApplicationController.scala
@@ -239,9 +239,14 @@ class ApplicationController @Inject() (
   }
 
   def routeBuilder = cc.securityService.SecuredAction { implicit request =>
-    configService.getCommonPageData(request2Messages.lang).map { commonData =>
-      cc.loggingService.insert(request.identity.userId, request.ipAddress, "Visit_RouteBuilder")
-      Ok(views.html.apps.routeBuilder(commonData, request.identity))
+    if (ControllerUtils.isMobile(request)) {
+      cc.loggingService.insert(request.identity.userId, request.ipAddress, "Visit_RouteBuilder_RedirectMobileLanding")
+      Future.successful(Redirect("/mobileLanding"))
+    } else {
+      configService.getCommonPageData(request2Messages.lang).map { commonData =>
+        cc.loggingService.insert(request.identity.userId, request.ipAddress, "Visit_RouteBuilder")
+        Ok(views.html.apps.routeBuilder(commonData, request.identity))
+      }
     }
   }
 

--- a/app/controllers/GalleryController.scala
+++ b/app/controllers/GalleryController.scala
@@ -1,7 +1,7 @@
 package controllers
 
 import controllers.base._
-import controllers.helper.ControllerUtils.parseIntegerSeq
+import controllers.helper.ControllerUtils.{isMobile, parseIntegerSeq}
 import formats.json.GalleryFormats._
 import formats.json.LabelFormats
 import models.auth.DefaultEnv
@@ -43,50 +43,58 @@ class GalleryController @Inject() (
       aiValidationOptions: String
   ): Action[AnyContent] =
     cc.securityService.SecuredAction { implicit request =>
-      val labelTypes: Seq[(String, String)] = Seq(
-        ("Assorted", Messages("gallery.all")),
-        (LabelTypeEnum.CurbRamp.name, Messages("curb.ramp")),
-        (LabelTypeEnum.NoCurbRamp.name, Messages("missing.ramp")),
-        (LabelTypeEnum.Obstacle.name, Messages("obstacle")),
-        (LabelTypeEnum.SurfaceProblem.name, Messages("surface.problem")),
-        (LabelTypeEnum.Occlusion.name, Messages("occlusion")),
-        (LabelTypeEnum.NoSidewalk.name, Messages("no.sidewalk")),
-        (LabelTypeEnum.Crosswalk.name, Messages("crosswalk")),
-        (LabelTypeEnum.Signal.name, Messages("signal")),
-        (LabelTypeEnum.Other.name, Messages("other"))
-      )
-      val labType: String = if (labelTypes.exists(x => { x._1 == labelType })) labelType else "Assorted"
-
-      for {
-        possibleRegions: Seq[Int] <- regionService.getAllRegions.map(_.map(_.regionId))
-        possibleTags: Seq[String] <- {
-          if (labType != "Assorted") labelService.selectTagsByLabelType(labelType).map(_.map(_.tag))
-          else Future.successful(Seq())
-        }
-        commonData <- configService.getCommonPageData(request2Messages.lang)
-      } yield {
-        // Make sure that list of region IDs, severities, and validation options are formatted correctly.
-        val regionIdsList: Seq[Int]      = parseIntegerSeq(neighborhoods).filter(possibleRegions.contains)
-        val validSeverities: Seq[String] = Seq("null", "1", "2", "3")
-        val severityList: Seq[String]    = {
-          val tokens = severities.split(",").filter(validSeverities.contains).distinct.toSeq
-          if (tokens.isEmpty) validSeverities else tokens
-        }
-        val tagList: List[String]   = tags.split(",").filter(possibleTags.contains).toList
-        val valOptions: Seq[String] =
-          validationOptions.split(",").filter(Seq("correct", "incorrect", "unsure", "unvalidated").contains(_)).toSeq
-        val aiValOptions: Seq[String] =
-          aiValidationOptions.split(",").filter(Seq("correct", "incorrect", "unsure", "unvalidated").contains(_)).toSeq
-
-        // Log visit to Gallery async.
-        val activityStr: String =
-          s"Visit_Gallery_LabelType=${labType}_RegionIDs=${regionIdsList}_Severity=${severityList}_Tags=${tagList}_Validations=$valOptions"
-        cc.loggingService.insert(request.identity.userId, request.ipAddress, activityStr)
-
-        Ok(
-          views.html.apps.gallery(commonData, "Sidewalk - Gallery", request.identity, labType, labelTypes,
-            regionIdsList, severityList, tagList, valOptions, aiValOptions)
+      if (isMobile(request)) {
+        cc.loggingService.insert(request.identity.userId, request.ipAddress, "Visit_Gallery_RedirectMobileLanding")
+        Future.successful(Redirect("/mobileLanding"))
+      } else {
+        val labelTypes: Seq[(String, String)] = Seq(
+          ("Assorted", Messages("gallery.all")),
+          (LabelTypeEnum.CurbRamp.name, Messages("curb.ramp")),
+          (LabelTypeEnum.NoCurbRamp.name, Messages("missing.ramp")),
+          (LabelTypeEnum.Obstacle.name, Messages("obstacle")),
+          (LabelTypeEnum.SurfaceProblem.name, Messages("surface.problem")),
+          (LabelTypeEnum.Occlusion.name, Messages("occlusion")),
+          (LabelTypeEnum.NoSidewalk.name, Messages("no.sidewalk")),
+          (LabelTypeEnum.Crosswalk.name, Messages("crosswalk")),
+          (LabelTypeEnum.Signal.name, Messages("signal")),
+          (LabelTypeEnum.Other.name, Messages("other"))
         )
+        val labType: String = if (labelTypes.exists(x => { x._1 == labelType })) labelType else "Assorted"
+
+        for {
+          possibleRegions: Seq[Int] <- regionService.getAllRegions.map(_.map(_.regionId))
+          possibleTags: Seq[String] <- {
+            if (labType != "Assorted") labelService.selectTagsByLabelType(labelType).map(_.map(_.tag))
+            else Future.successful(Seq())
+          }
+          commonData <- configService.getCommonPageData(request2Messages.lang)
+        } yield {
+          // Make sure that list of region IDs, severities, and validation options are formatted correctly.
+          val regionIdsList: Seq[Int]      = parseIntegerSeq(neighborhoods).filter(possibleRegions.contains)
+          val validSeverities: Seq[String] = Seq("null", "1", "2", "3")
+          val severityList: Seq[String]    = {
+            val tokens = severities.split(",").filter(validSeverities.contains).distinct.toSeq
+            if (tokens.isEmpty) validSeverities else tokens
+          }
+          val tagList: List[String]   = tags.split(",").filter(possibleTags.contains).toList
+          val valOptions: Seq[String] =
+            validationOptions.split(",").filter(Seq("correct", "incorrect", "unsure", "unvalidated").contains(_)).toSeq
+          val aiValOptions: Seq[String] =
+            aiValidationOptions
+              .split(",")
+              .filter(Seq("correct", "incorrect", "unsure", "unvalidated").contains(_))
+              .toSeq
+
+          // Log visit to Gallery async.
+          val activityStr: String =
+            s"Visit_Gallery_LabelType=${labType}_RegionIDs=${regionIdsList}_Severity=${severityList}_Tags=${tagList}_Validations=$valOptions"
+          cc.loggingService.insert(request.identity.userId, request.ipAddress, activityStr)
+
+          Ok(
+            views.html.apps.gallery(commonData, "Sidewalk - Gallery", request.identity, labType, labelTypes,
+              regionIdsList, severityList, tagList, valOptions, aiValOptions)
+          )
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

Mobile visitors to **RouteBuilder** and **Gallery** are now redirected to `/mobileLanding`, matching the existing behavior of LabelMap and Explore. Both are desktop-oriented tools — RouteBuilder is a full-screen Mapbox map-manipulation UI (a sibling of LabelMap, which already redirects), and the Gallery grid renders poorly on mobile.

Fixes the RouteBuilder issue raised in #4470.

## Changes

- **`/routeBuilder`** (`ApplicationController`): added an `isMobile` guard that logs `Visit_RouteBuilder_RedirectMobileLanding` and redirects to `/mobileLanding`.
- **`/gallery`** (`GalleryController`): same guard, logging `Visit_Gallery_RedirectMobileLanding`.

## Notes

- `/validate` already redirects mobile users to the dedicated `/mobile` (mobileValidate) page, so no change was needed there.
- New log events follow the existing `Visit_LabelMap_RedirectMobileLanding` naming.

## Testing

- `sbt --client compile` passes (warning-clean).
- `scalafmtAll` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)