### PR TITLE
Revert "Bump requests from 2.32.4 to 2.33.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@
 pandas==2.0.3
 haversine==2.8.1
 scipy==1.10.1
-requests==2.33.0
+requests==2.32.4


### PR DESCRIPTION
Reverts ProjectSidewalk/SidewalkWebpage#4513

Not sure why the github actions bot merged this in when it was failing a test?
<img width="919" height="439" alt="image" src="https://github.com/user-attachments/assets/343f340c-9d1d-4a8f-a7e7-18279c1b4cf8" />
