### PR TITLE
Fix broken openhand cursor link on Explore page

### DIFF
--- a/public/css/explore/svl.css
+++ b/public/css/explore/svl.css
@@ -86,7 +86,7 @@ input[type="radio"] {
 #view-control-layer {
   -webkit-user-select: none;
   user-select: none;
-  cursor: url("../../images/icons/openhand.cur") 4 4, move;
+  cursor: url("/assets/images/icons/openhand.cur") 4 4, move;
   z-index: 1;
 }
 


### PR DESCRIPTION
## Problem

The `#view-control-layer` cursor on the Explore page fails to load `openhand.cur`, producing a "can't find" error in the browser.

The `url()` was written relative to the CSS **source** location (`public/css/explore/svl.css`), where `../../images/icons/openhand.cur` correctly resolves to `public/images/icons/openhand.cur`. But CSS `url()` paths resolve against the **served** stylesheet, and Grunt concatenates this source into `public/js/explore/build/explore.css` — one directory level deeper. From there, `../../` only reaches `public/js/`, so the browser requests `public/js/images/icons/openhand.cur`, which doesn't exist (404).

This is fallout from the #2292 asset reorg: source and bundle output now sit at different directory depths, so the relative `url()` no longer resolves once bundled.

## Fix

Use a root-relative path (`/assets/images/icons/openhand.cur`). Play serves `public/` at `/assets/`, so this resolves correctly regardless of whether it's loaded from the source or the concatenated bundle — location-independent, unlike a `../` count tied to bundle depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)