### PR TITLE
Fix Hide Label button click being swallowed as a pan in Validate

### DIFF
--- a/public/js/validate/src/panorama/PanoOverlay.js
+++ b/public/js/validate/src/panorama/PanoOverlay.js
@@ -42,6 +42,11 @@ class PanoOverlay {
    * @param {Event} e
    */
   #handlerViewControlLayerMouseDown = (e) => {
+    // The hide-label button lives inside the control layer, so its mousedown bubbles here. Bail before starting a pan
+    // (and before hiding the hover info) so the button isn't hidden out from under the click, which would swallow it
+    // and leave the label untoggled (#4521).
+    if (e.target.closest('#label-visibility-button-on-label')) return;
+
     this.#mouseStatus.isLeftDown = true;
     this.#viewControlLayer.css('cursor', 'url(/assets/images/icons/closedhand.cur) 4 4, move');
 


### PR DESCRIPTION
Fixes #4521

## Problem

Clicking the floating "Hide Label" button over a label in Validate just made the button (and the severity/tags hover box) disappear instead of toggling label visibility.

## Cause

The on-label button (`#label-visibility-button-on-label`) is a child of `#view-control-layer`, and that layer has a `mousedown` handler that starts a pano pan and calls `hideTagsAndDeleteButton()`. A press on the button bubbled up to that handler, which hid the button (`visibility: hidden`) before `mouseup` — so the `click` never landed on the button and its toggle handler never ran.

## Fix

Bail out of the pan handler early when the `mousedown` originates on the hide-label button, so a press on it neither starts a pan nor hides the overlay. The button stays put and the `click` toggles the label; pressing anywhere else on the pano still pans and hides the hover info as before.

## Testing

Verified by the maintainer in-app (GSV pano interactions can't be automated):
- Hover a label → click the button toggles hidden/shown, button stays.
- Click-drag elsewhere on the pano still pans and hides the hover overlay.
- Keyboard `H` still toggles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)