### PR TITLE
Fix extra space around highlighted text in Expert Validate tag search

### DIFF
--- a/public/css/validate/svv-validation-menu.css
+++ b/public/css/validate/svv-validation-menu.css
@@ -230,6 +230,11 @@
   font: var(--text-tiny-semibold);
   text-align: center;
   transition: all 0.3s;
+
+  /* Selectize wraps the matched search substring in a <span class="highlight">, splitting the option's text into
+     separate children. The shared .tag-pill class is an inline-flex container with a gap, which would then insert a
+     visible space around the highlight span (#4523). Zero the gap here to fix the issue. */
+  gap: 0;
 }
 
 /* Removing default styling for "active" options in dropdown. Would be left over after hover. */


### PR DESCRIPTION
Fixes #4523.

## Problem

When searching the tag picker in Expert Validate, a large extra space was inserted after the matched portion of the tag name (see screenshots in #4523).

## Cause

Selectize highlights the matched search substring by wrapping it in a `<span class="highlight">`, which splits the option's text into multiple child nodes. The dropdown options carry the shared `.tag-pill` class (`public/css/tag-pills.css`), which is an `inline-flex` container with `gap: 8px`. In a flex container each text run and the highlight span become separate flex items, so the gap rendered as visible space around the highlighted text.

This reintroduced a bug previously fixed in 80ca16b5f. The #2292 asset reorg extracted the shared `.tag-pill` class (which legitimately needs the gap for icon+label pills elsewhere), and the dropdown options re-inherited its flex gap.

## Fix

Add `gap: 0` to the `.selectize-dropdown .option.tag-pill` override so the dropdown's text-only pills lose the gap, while every other pill using the shared class keeps it. Stylelint passes.

## Testing

Manual: open Expert Validate, type a partial tag name in the picker, and confirm the match is still highlighted with no extra space after it, while the current-tags list and AI-suggested tags remain correctly spaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)