### PR TITLE
Open share-via-email in a new tab like the other share actions

### DIFF
--- a/public/js/common/share/ShareWidget.js
+++ b/public/js/common/share/ShareWidget.js
@@ -235,7 +235,7 @@ class ShareWidget {
     this.#log('Share_Platform=Email');
     const subject = encodeURIComponent(this.#target.title);
     const body = encodeURIComponent(`${this.#target.text}\n\n${this.#target.url}`);
-    window.location.href = `mailto:?subject=${subject}&body=${body}`;
+    window.open(`mailto:?subject=${subject}&body=${body}`, '_blank', 'noopener');
     this.#closePopover();
   }
 


### PR DESCRIPTION
## Summary
The **Email** action in the label share popover navigated the current tab via `window.location.href`, unlike the **X** and **Facebook** actions which use `window.open(..., '_blank')`. This switches Email to the same `window.open` pattern, so the `mailto:` hands off to the mail client without navigating away from the label detail view.

## Testing
- `make eslint dir=public/js/common/share` passes.
- Manual: clicking **Email** in the share popover launches the mail client while leaving the current page intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)