### PR TITLE
Make /welcome page cards clickable links (#4530)

### DIFF
--- a/app/views/authentication/welcome.scala.html
+++ b/app/views/authentication/welcome.scala.html
@@ -25,28 +25,29 @@
       <p class="wl-sub">@Messages("welcome.subtitle")</p>
     </div>
     <div class="wl-main">
+      @* Each card is a link into the section it previews — users reach for the card itself before the CTA below (#4530). *@
       <div class="wl-cards">
-        <div class="wl-card">
+        <a class="wl-card" href="@routes.UserDashboardController.dashboard">
           <div class="wl-icon">
             <svg viewBox="0 0 38 38" fill="none" aria-hidden="true"><rect x="3" y="21" width="7" height="13" rx="1.5" fill="var(--color-pine-400)"></rect><rect x="15.5" y="12" width="7" height="22" rx="1.5" fill="var(--color-pine-600)"></rect><rect x="28" y="4" width="7" height="30" rx="1.5" fill="var(--color-pine-700)"></rect></svg>
           </div>
           <h2>@Messages("welcome.card.dashboard.title")</h2>
           <p>@Messages("welcome.card.dashboard.body")</p>
-        </div>
-        <div class="wl-card">
+        </a>
+        <a class="wl-card" href="@{routes.UserDashboardController.dashboard.url}#achievements">
           <div class="wl-icon">
             <img src='@assets.path("images/badges/badge_missions_badge1.png")' alt="" width="42" height="42">
           </div>
           <h2>@Messages("welcome.card.badges.title")</h2>
           <p>@Messages("welcome.card.badges.body")</p>
-        </div>
-        <div class="wl-card">
+        </a>
+        <a class="wl-card" href="@routes.UserDashboardController.leaderboard">
           <div class="wl-icon">
             <svg viewBox="0 0 38 38" fill="none" aria-hidden="true"><rect x="2" y="18" width="10" height="16" rx="1.5" fill="var(--color-banana-500)"></rect><rect x="14" y="10" width="10" height="24" rx="1.5" fill="var(--color-banana-600)"></rect><rect x="26" y="22" width="10" height="12" rx="1.5" fill="var(--color-banana-300)"></rect><circle cx="19" cy="5" r="3" fill="var(--color-banana-800)"></circle></svg>
           </div>
           <h2>@Messages("welcome.card.leaderboard.title")</h2>
           <p>@Messages("welcome.card.leaderboard.body")</p>
-        </div>
+        </a>
       </div>
       <div class="wl-ctas">
         <a class="button-ps button--primary button--large" id="welcome-explore-btn" href="@resumeUrl">@Messages("landing.start.exploring")</a>

--- a/public/css/auth.css
+++ b/public/css/auth.css
@@ -715,11 +715,32 @@ dialog.au-dialog::backdrop {
 }
 
 .wl-card {
+  display: block;
   border: 1px solid var(--color-neutral-200);
   border-radius: 12px;
   padding: 20px;
   background: var(--color-neutral-white);
   text-align: left;
+  color: inherit;
+  text-decoration: none;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
+}
+
+.wl-card:hover {
+  border-color: var(--color-pine-600);
+  box-shadow: 0 8px 28px rgb(9 8 13 / 8%);
+}
+
+.wl-card:focus-visible {
+  outline: 2px solid var(--color-pine-700);
+  outline-offset: 2px;
+}
+
+/* Lift on hover only when motion is welcome; reduced-motion users still get the border/shadow cue. */
+@media (prefers-reduced-motion: no-preference) {
+  .wl-card:hover {
+    transform: translateY(-2px);
+  }
 }
 
 .wl-card .wl-icon {


### PR DESCRIPTION
Closes #4530. Follow-up to the sign-up UX redesign (#4495), which introduced the post-registration `/welcome` page.

## What & why
On `/welcome`, the **Your dashboard / Badges / The leaderboard** cards were plain `<div>`s. Both @misaugstad and @jonfroehlich reported the same instinct: click the card itself, not the "See my dashboard" CTA below it. This makes each card a link into the section it previews.

- **Your dashboard** → `/dashboard`
- **Badges** → `/dashboard#achievements` (the dashboard's badges/trophies section — there's no standalone badges page)
- **The leaderboard** → `/leaderboard`

All three use reverse-routing (`routes.UserDashboardController.*`), so no hardcoded paths. The existing "Start Exploring" / "See my dashboard" CTAs are unchanged (the dashboard card intentionally duplicates the CTA target, per the issue).

## Accessibility
- Each card is a single `<a>` (one tab stop, activatable with Enter); the icons stay `aria-hidden`, and the card's heading + body text serve as the accessible name.
- Added `.wl-card:hover` (border + shadow) and `.wl-card:focus-visible` (2px pine-700 outline) so the cards read as interactive and are keyboard-navigable.
- The hover lift (`translateY(-2px)`) is gated behind `prefers-reduced-motion: no-preference`; reduced-motion users still get the border/shadow cue.
- Colors use existing `--color-pine-*` design tokens.

## Notes
- No new user-facing strings, so no translation changes.
- Frontend linters (Stylelint, HTMLHint) pass on both touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)