### PR TITLE
Fix #4545: /leaderboard 502 — disable JIT for getLeaderboardStats (PostGIS segfault)

### DIFF
--- a/app/models/user/UserStatTable.scala
+++ b/app/models/user/UserStatTable.scala
@@ -499,6 +499,23 @@ class UserStatTable @Inject() (
   }
 
   /**
+   * Runs `action` in a transaction with JIT disabled for the duration of that transaction.
+   *
+   * Interim workaround for #4376 (mirrors `ConfigTable.withJitOff`): the projectsidewalk/db image ships a broken
+   * Postgres JIT (PostGIS bitcode built with LLVM 16, runtime llvmjit linked against LLVM 11). A query expensive enough
+   * to cross the JIT inline-cost threshold and inline PostGIS bitcode (ST_TRANSFORM/ST_LENGTH) segfaults the backend,
+   * dropping the connection (SQLSTATE 08006) and forcing Postgres crash-recovery — which surfaces as a site-wide 502.
+   * `getLeaderboardStats` computes audited distance with ST_LENGTH(ST_TRANSFORM(...)) and is expensive enough to trip
+   * this (#4545), so it must run with JIT off. `SET LOCAL` scopes the setting to this one transaction. Remove once #4376
+   * disables JIT at the DB config level.
+   *
+   * @param action The DBIO to run with JIT off.
+   * @return       The same action, wrapped so JIT is disabled for its transaction.
+   */
+  private def withJitOff[T](action: DBIO[T]): DBIO[T] =
+    (sqlu"SET LOCAL jit = off" >> action).transactionally
+
+  /**
    * Gets leaderboard stats for the top `n` users in the given time period.
    *
    * Top users are calculated using: score = sqrt(# labels) * (0.5 * distance_audited / city_distance + 0.5 * accuracy).
@@ -547,7 +564,8 @@ class UserStatTable @Inject() (
         "INNER JOIN (SELECT user_id, username FROM sidewalk_user) \"usernames\" ON label_counts.user_id = usernames.user_id"
       }
     }
-    sql"""
+    withJitOff(
+      sql"""
       SELECT usernames.username,
              label_counts.label_count,
              mission_count,
@@ -606,13 +624,14 @@ class UserStatTable @Inject() (
       ) "accuracy" ON label_counts.#$groupingColName = accuracy.#$groupingColName
       ORDER BY score DESC;
     """
-      .as[(String, Int, Int, Double, Option[Double], Double)]
-      .map(_.map { stat =>
-        // Run the query and, if it's not a team name, remove the "@X.Y" from usernames that are just email addresses.
-        if (!byTeam && isValidEmail(stat._1))
-          LeaderboardStat(stat._1.slice(0, stat._1.lastIndexOf('@')), stat._2, stat._3, stat._4, stat._5, stat._6)
-        else LeaderboardStat.tupled(stat)
-      })
+        .as[(String, Int, Int, Double, Option[Double], Double)]
+        .map(_.map { stat =>
+          // Run the query and, if it's not a team name, remove the "@X.Y" from usernames that are just email addresses.
+          if (!byTeam && isValidEmail(stat._1))
+            LeaderboardStat(stat._1.slice(0, stat._1.lastIndexOf('@')), stat._2, stat._3, stat._4, stat._5, stat._6)
+          else LeaderboardStat.tupled(stat)
+        })
+    )
   }
 
   /**


### PR DESCRIPTION
## Problem (#4545)
The redesigned `/leaderboard` fails to load on production — a **502 Proxy Error** ("Error reading from remote server") on Seattle, Teaneck, and Newberg.

## Root cause: the broken-JIT PostGIS segfault (#4376)
`UserStatTable.getLeaderboardStats` computes audited distance with `SUM(ST_LENGTH(ST_TRANSFORM(geom, 26918)))`. The `projectsidewalk/db` image ships a **broken Postgres JIT** (PostGIS bitcode built with LLVM 16, runtime `llvmjit` linked against LLVM 11 — #4376). When a query is expensive enough to cross the JIT **inline**-cost threshold and inline that PostGIS bitcode, the backend **segfaults**: the connection drops (`SQLSTATE 08006`) and Postgres crash-recovery briefly takes the whole app down → 502.

**Why now / why only some cities:** the crash is data-scale-dependent. Smaller cities (e.g. local Teaneck, ~21k labels) keep the query cost under the JIT inline threshold and run fine; Seattle (~269k labels / ~60k completed audit tasks) crosses it and segfaults. It surfaced as the dataset grew. In dev this was masked by a dev-only `ALTER DATABASE sidewalk SET jit = off`; production runs JIT on.

## Fix
Wrap the query in the same `SET LOCAL jit = off` transaction guard that `ConfigTable` already uses for its cross-city PostGIS aggregates. One-transaction scope; no behavior change other than avoiding the broken JIT path.

## Verification (real Seattle data, DB `jit = on` to match production)
End-to-end through the app, same request, only the guard toggled:

| Code | `/leaderboard` |
|------|----------------|
| pre-fix (current prod) | **HTTP 500**, `SQLSTATE(08006)` "connection marked as broken" → the 502 |
| with guard | **HTTP 200**, full render, ~1.6s warm (stable across repeated hits) |

Also confirmed at the SQL level: the exact query segfaults the backend under `jit=on`, and `SET LOCAL jit=off` in the transaction runs it in ~1.5s. Compiles clean (`-Xfatal-warnings`), scalafmt clean.

## Recommended immediate mitigation (no deploy)
This code guard is a targeted, durable fix. For the fastest unblock — and to cover any *other* expensive PostGIS query that could trip the same JIT bug (e.g. `getAggregateStats` if a city's data grows past the inline threshold) — apply the intended #4376 fix at the DB level on each production city DB:

```sql
ALTER DATABASE <db> SET jit = off;
```

(This is exactly what dev already does; it takes effect on new connections, no redeploy.)

## Follow-ups (not in this PR)
- Guard `ConfigTable.getCityAggregateDataBySchema` (also unguarded PostGIS; currently under threshold but latent).
- Optional leaderboard load/robustness: short-TTL cache of the three boards for high mapathon concurrency, and/or run the three board queries in parallel. Not needed to stop the crash; warm responses are ~1.6s.
- Remove all `withJitOff` guards once #4376 fixes the JIT at the image/DB-config level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)