### PR TITLE
11.6.1 — hotfix: /leaderboard 502 (broken-JIT PostGIS segfault, #4545)

### DIFF
--- a/app/models/user/UserStatTable.scala
+++ b/app/models/user/UserStatTable.scala
@@ -499,6 +499,23 @@ class UserStatTable @Inject() (
   }
 
   /**
+   * Runs `action` in a transaction with JIT disabled for the duration of that transaction.
+   *
+   * Interim workaround for #4376 (mirrors `ConfigTable.withJitOff`): the projectsidewalk/db image ships a broken
+   * Postgres JIT (PostGIS bitcode built with LLVM 16, runtime llvmjit linked against LLVM 11). A query expensive enough
+   * to cross the JIT inline-cost threshold and inline PostGIS bitcode (ST_TRANSFORM/ST_LENGTH) segfaults the backend,
+   * dropping the connection (SQLSTATE 08006) and forcing Postgres crash-recovery — which surfaces as a site-wide 502.
+   * `getLeaderboardStats` computes audited distance with ST_LENGTH(ST_TRANSFORM(...)) and is expensive enough to trip
+   * this (#4545), so it must run with JIT off. `SET LOCAL` scopes the setting to this one transaction. Remove once #4376
+   * disables JIT at the DB config level.
+   *
+   * @param action The DBIO to run with JIT off.
+   * @return       The same action, wrapped so JIT is disabled for its transaction.
+   */
+  private def withJitOff[T](action: DBIO[T]): DBIO[T] =
+    (sqlu"SET LOCAL jit = off" >> action).transactionally
+
+  /**
    * Gets leaderboard stats for the top `n` users in the given time period.
    *
    * Top users are calculated using: score = sqrt(# labels) * (0.5 * distance_audited / city_distance + 0.5 * accuracy).
@@ -547,7 +564,8 @@ class UserStatTable @Inject() (
         "INNER JOIN (SELECT user_id, username FROM sidewalk_user) \"usernames\" ON label_counts.user_id = usernames.user_id"
       }
     }
-    sql"""
+    withJitOff(
+      sql"""
       SELECT usernames.username,
              label_counts.label_count,
              mission_count,
@@ -606,13 +624,14 @@ class UserStatTable @Inject() (
       ) "accuracy" ON label_counts.#$groupingColName = accuracy.#$groupingColName
       ORDER BY score DESC;
     """
-      .as[(String, Int, Int, Double, Option[Double], Double)]
-      .map(_.map { stat =>
-        // Run the query and, if it's not a team name, remove the "@X.Y" from usernames that are just email addresses.
-        if (!byTeam && isValidEmail(stat._1))
-          LeaderboardStat(stat._1.slice(0, stat._1.lastIndexOf('@')), stat._2, stat._3, stat._4, stat._5, stat._6)
-        else LeaderboardStat.tupled(stat)
-      })
+        .as[(String, Int, Int, Double, Option[Double], Double)]
+        .map(_.map { stat =>
+          // Run the query and, if it's not a team name, remove the "@X.Y" from usernames that are just email addresses.
+          if (!byTeam && isValidEmail(stat._1))
+            LeaderboardStat(stat._1.slice(0, stat._1.lastIndexOf('@')), stat._2, stat._3, stat._4, stat._5, stat._6)
+          else LeaderboardStat.tupled(stat)
+        })
+    )
   }
 
   /**

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import com.typesafe.sbt.packager.MappingsHelper.directory
 
 name := """sidewalk-webpage"""
 
-version := "11.6.0"
+version := "11.6.1"
 
 scalaVersion := "2.13.18"
 


### PR DESCRIPTION
Patch release **11.6.1** — hotfix for the production `/leaderboard` outage (#4545).

## What's in it
- **#4545 / PR #4546:** `getLeaderboardStats` computes audited distance with `SUM(ST_LENGTH(ST_TRANSFORM(geom, 26918)))`, which segfaults the broken `projectsidewalk/db` JIT (#4376) on cities large enough to cross the JIT inline-cost threshold (Seattle/Teaneck/Newberg). The backend crash drops the connection (`SQLSTATE 08006`) → 502 Proxy Error. Fixed by wrapping the query in the same `SET LOCAL jit = off` guard `ConfigTable` already uses.
- Version bump `11.6.0 → 11.6.1`.

## Verified
Reproduced and fixed end-to-end on **real Seattle data with the DB set to `jit=on`** (matching production): pre-fix `/leaderboard` → HTTP 500 (`SQLSTATE 08006`); with the guard → HTTP 200 (~1.6s warm). Required CI checks green on the develop PR.

## Follow-ups (tracked separately)
Latent same-class risks (not crashing now, under threshold): unguarded PostGIS in `LabelTable.getOverallStatsForApi` (`/v3/api/overallStats`) and `ConfigTable.getCityAggregateDataBySchema` (`getAggregateStats`). The durable fixes are #4376 (rebuild the db image so the JIT isn't broken) and/or disabling JIT at the DB config level in all environments — issues to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)