### PR TITLE
11.6.1 version evolution + release runbook (#4545 follow-up)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,7 @@ When you catch yourself writing a frontend constant that mirrors a backend value
 
 ## Development Guidelines
 - Main development branch is **develop**; **master** is the release branch. PRs target `develop`.
+- **Deploying to production is tag-triggered, not branch-triggered:** pushing `develop` redeploys the **test** stage, but prod only deploys when a **`vX.Y.Z` GitHub Release/tag** is cut on `master`. Cutting a release also requires bumping `build.sbt` **and** adding a `version`-table evolution (the two are separate: the tag deploys the code, the evolution updates the displayed version). Full step-by-step runbook: [`docs/deployment-and-stages.md`](docs/deployment-and-stages.md) ("Cutting a release").
 - **Maintainers / GitHub @-mentions:** Project Sidewalk is maintained by **@jonfroehlich** (Professor Jon Froehlich) and
   **@misaugstad** (Mikey / Michael Saugstad).
 - If there is an associated Github issue, beging the branch name with the issue number (e.g. `1234-fix-label-popup`).

--- a/conf/evolutions/default/335.sql
+++ b/conf/evolutions/default/335.sql
@@ -1,0 +1,5 @@
+# --- !Ups
+INSERT INTO version VALUES ('11.6.1', now(), 'Fixes a bug where the leaderboard failed to load.');
+
+# --- !Downs
+DELETE FROM version WHERE version_id = '11.6.1';

--- a/docs/deployment-and-stages.md
+++ b/docs/deployment-and-stages.md
@@ -50,6 +50,42 @@ Practical implications for contributors:
 - A redeploy re-runs the full build (below) and restarts the affected city instances, so it is not instantaneous and
   briefly interrupts the sites on that stage.
 
+## Cutting a release (runbook)
+
+Production is deployed by **creating a GitHub Release with a `vX.Y.Z` tag on `master`** — per the table above, only a
+semver tag deploys to prod. A release is more than the tag, though. Do these steps **in order**:
+
+1. **Bump the app version** — edit `version := "X.Y.Z"` in [`build.sbt`](../build.sbt) (patch bump for a hotfix, e.g.
+   `11.6.0` → `11.6.1`).
+2. **Add a version-table evolution** — create the next-numbered `conf/evolutions/default/NNN.sql` that records the
+   release in the `version` table. This row is what the site footer / `commonData.versionId` displays (the app shows
+   the row with the latest `version_start_time`, so `now()` is correct and no manual date is needed):
+   ```sql
+   # --- !Ups
+   INSERT INTO version VALUES ('X.Y.Z', now(), 'One-line, user-facing summary of the release.');
+
+   # --- !Downs
+   DELETE FROM version WHERE version_id = 'X.Y.Z';
+   ```
+3. **Land it on `develop` first** (PR) — merging to `develop` redeploys the **test** stage; verify there.
+4. **Merge `develop` → `master`** (PR).
+5. **Create the GitHub Release** with tag `vX.Y.Z` targeting `master`. That tag/release triggers the **prod** build and
+   the rolling per-city restart. Match the existing tag format exactly (`v11.6.0`, `v11.5.1`, …).
+6. **Verify prod** — the build isn't instant and city instances come up one-by-one. Confirm the *new code* is live, not
+   just that the server responds. Until an explicit version endpoint exists (**#4548**), the reliable check is
+   **behavioral**: load a page whose behavior only the new code produces. (The `/anonSignUp` liveness probe is not
+   sufficient — it passes even when a page like `/leaderboard` is crashing.)
+
+**Two independent gotchas, both learned from #4545:**
+- Merging to `master` alone does **not** deploy to prod — the **tag** (step 5) does.
+- Bumping `build.sbt` alone does **not** change the version the site shows — the **evolution** (step 2) does.
+A hotfix that changes no schema *still* needs step 2 for the displayed version to update.
+
+> **Design note:** routing release-versioning through schema evolutions couples two unrelated concerns and duplicates
+> the version string across `build.sbt`, an evolution, and the git tag. Making the git tag / build metadata the single
+> source of truth (an `sbt-buildinfo`-backed `/version` endpoint) is tracked in **#4548**; follow that convention if it
+> lands.
+
 ## Runtime shape
 
 Each stage hosts **many cities at once**, and each city runs as its **own independent instance of this app** —


### PR DESCRIPTION
Two things surfaced by the #4545 hotfix deploy:

1. **Evolution 335** records `11.6.1` in the `version` table (site footer / `commonData.versionId` reads the latest row). A release needs this even with no schema change — bumping `build.sbt` alone doesn't update the displayed version. Pairs with the `build.sbt` `11.6.0`→`11.6.1` bump already on `master` (#4547).
2. **Release runbook** added to `docs/deployment-and-stages.md` ("Cutting a release") + a pointer in `CLAUDE.md`, documenting that prod deploys are **tag-triggered** (a `vX.Y.Z` GitHub Release on `master`), not branch-triggered — and that the version evolution is a required, separate step. Both facts bit us in #4545. Includes a design note that coupling release-versioning to schema evolutions isn't ideal (→ #4548).

Path to prod: merge here → `develop`, then `develop`→`master`, then cut the `v11.6.1` Release.