### PR TITLE
Polish navbar layout: flush on wide screens, centered/longer divider on landing (#3892)

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -327,8 +327,6 @@ a {
   display: flex;
   align-items: center;
   flex: 1;
-  max-width: 1440px; /* Cap the content column so the two nav groups don't sprawl to the edges on wide screens. */
-  margin: 0 auto;
   padding: 0 4.5%;
 }
 
@@ -485,11 +483,11 @@ a {
   height: 50px;
 }
 
-/* Sit the nav text on the logo wordmark's baseline by bottom-aligning the row. At this height the 5px bottom pad
-   also balances the ~5px above the 40px logo, so the whitespace reads even. */
-#header.header--tall .navbar-container {
-  align-items: flex-end;
-  padding-bottom: 5px;
+/* In the taller landing bar the row inherits the base .navbar-container centering, so brand + nav + divider sit
+   vertically centered in the 50px bar. The divider is lengthened to suit the taller bar; the compact scrolled bar
+   keeps the base 22px. */
+#header.header--tall .navbar-nav--primary::before {
+  height: 30px;
 }
 
 #header.header--tall #navbar-brand img {


### PR DESCRIPTION
Follow-up polish to the merged navbar redesign (#3892). CSS-only, all in `.navbar-container` and the `header--tall` landing variant.

### Changes
- **Flush layout on wide screens.** Drop the `max-width: 1440px` cap and `margin: 0 auto`. Past 1440px the bar collapsed into a centered band, floating the logo in from the left edge and the city/account/language nav in from the right against a full-width white bar. Now the logo is pinned 4.5% from the left and the utility nav 4.5% from the right at every width (the pre-redesign behavior).
- **Vertically centered landing bar.** On the taller landing navbar (`header--tall`), drop the `align-items: flex-end` / `padding-bottom: 5px` override so the brand + nav row inherits the base `.navbar-container` centering instead of bottom-aligning to the wordmark baseline.
- **Longer divider on the landing bar.** Lengthen the brand/nav divider to `30px` in the large state to suit the taller bar; the compact scrolled bar keeps the base `22px`.

### Testing
Each change verified visually in the browser at multiple window widths (including >1440px) and in both the tall landing state and the compact scrolled state. `make stylelint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)