### PR TITLE
Clear auth errors once the user starts fixing them (#4532)

### DIFF
--- a/public/js/common/AuthModal.js
+++ b/public/js/common/AuthModal.js
@@ -100,6 +100,8 @@ function clearAuthErrors(form) {
 
 /**
  * Renders the async error contract: `_summary` becomes a banner above the form, any other key attaches to its field.
+ * Each error dismisses itself once the user starts fixing it — a field error clears when its own field is edited, and
+ * the `_summary` banner clears on the next edit to any field (#4532), so a stale error can't linger after it's fixed.
  *
  * @param {HTMLFormElement} form - The form the errors belong to.
  * @param {Object<string, string>} errors - Field name (or `_summary`) to localized message.
@@ -113,6 +115,7 @@ function renderAuthErrors(form, errors) {
       banner.innerHTML = `${AU_ALERT_ICON}<p></p>`;
       banner.querySelector('p').textContent = message;
       form.parentElement.insertBefore(banner, form);
+      form.addEventListener('input', () => banner.remove(), { once: true });
       return;
     }
     const input = form.querySelector(`[name="${field}"]`);
@@ -125,6 +128,11 @@ function renderAuthErrors(form, errors) {
     msg.innerHTML = AU_ALERT_ICON;
     msg.appendChild(document.createTextNode(` ${message}`));
     (input.closest('.au-input-wrap') || input).insertAdjacentElement('afterend', msg);
+    input.addEventListener('input', () => {
+      input.classList.remove('au-input--error');
+      input.removeAttribute('aria-invalid');
+      msg.remove();
+    }, { once: true });
   });
   const firstBad = form.querySelector('.au-input--error');
   if (firstBad) firstBad.focus();


### PR DESCRIPTION
Fixes #4532.

## Problem
Inline sign-in / sign-up errors persisted until the next submit. If you tried to sign up with a username that already existed, got the "username already exists" error, then typed a new username, the error message stayed up until you resubmitted.

## Fix
In `AuthModal.js`, `renderAuthErrors()` now attaches a one-shot `input` listener to each error it renders:
- **Field errors** (e.g. "username already exists", which comes back as a `username` field error) clear — red border, `aria-invalid`, and the message line — as soon as the user edits that specific field.
- **`_summary` banner** (e.g. invalid sign-in credentials) clears on the next edit to any field in the form.

Because `renderAuthErrors` runs fresh on every submit, the listeners re-attach if the user resubmits and hits a new error, so it stays correct across repeated attempts.

## Testing
Frontend-only, no backend changes. Verified manually:
1. Sign-up modal, submit with an existing username → error appears under the username field; typing into the field clears it immediately.
2. Sign-in modal, submit wrong credentials → summary banner appears; editing any field clears it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)