### PR TITLE
Fix API-docs stats failing to load when aggregateStats is slow (#4600)

### DIFF
--- a/app/models/utils/ConfigTable.scala
+++ b/app/models/utils/ConfigTable.scala
@@ -741,30 +741,20 @@ class ConfigTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvi
   /**
    * Returns daily label counts split by human vs AI creator and label type for a specific city schema.
    *
-   * This is the cross-schema variant of LabelTable.getDailyLabelStats, used by the aggregate
-   * endpoint to query each city schema in turn.
+   * This is the cross-schema variant of LabelTable.getDailyLabelStats, used by the aggregate endpoint to query each
+   * city schema in turn. Always covers the full date range; the service slices requested windows from its cached
+   * copy of the result (#4600).
    *
    * @param schema           Database schema to query (e.g. "sidewalk_seattle").
-   * @param startDate        Inclusive lower bound on label.time_created; no bound if None.
-   * @param endDate          Inclusive upper bound; no bound if None.
    * @param filterLowQuality If true, restrict to user_stat.high_quality; otherwise exclude excluded users.
    * @return                 Sequence of (date, labelType, humanLabels, aiLabels).
    */
   def getCityDailyLabelStatsBySchema(
       schema: String,
-      startDate: Option[LocalDate],
-      endDate: Option[LocalDate],
       filterLowQuality: Boolean
   ): DBIO[Seq[(LocalDate, String, Int, Int)]] = {
-    val userFilter   = if (filterLowQuality) "user_stat.high_quality" else "NOT user_stat.excluded"
-    val whereClauses = scala.collection.mutable.ListBuffer(
-      "label.deleted = FALSE",
-      "label.tutorial = FALSE",
-      userFilter
-    )
-    startDate.foreach(d => whereClauses += s"label.time_created >= '$d'::date")
-    endDate.foreach(d => whereClauses += s"label.time_created < ('$d'::date + INTERVAL '1 day')")
-    val where = whereClauses.mkString(" AND ")
+    val userFilter = if (filterLowQuality) "user_stat.high_quality" else "NOT user_stat.excluded"
+    val where      = s"label.deleted = FALSE AND label.tutorial = FALSE AND $userFilter"
 
     implicit val getResult: GetResult[(LocalDate, String, Int, Int)] =
       GetResult(r => (LocalDate.parse(r.nextString()), r.nextString(), r.nextInt(), r.nextInt()))
@@ -789,31 +779,22 @@ class ConfigTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvi
    * Returns daily validation counts split by human vs AI validator, result, and label type for a
    * specific city schema.
    *
-   * This is the cross-schema variant of LabelValidationTable.getDailyValidationStats.
+   * This is the cross-schema variant of LabelValidationTable.getDailyValidationStats. Always covers the full date
+   * range; the service slices requested windows from its cached copy of the result (#4600).
    *
    * validation_result integers: 1 = agree, 2 = disagree, 3 = unsure.
    *
    * @param schema           Database schema to query.
-   * @param startDate        Inclusive lower bound on end_timestamp (Pacific date); no bound if None.
-   * @param endDate          Inclusive upper bound; no bound if None.
    * @param filterLowQuality If true, restrict to user_stat.high_quality; otherwise exclude excluded users.
    * @return                 Sequence of (date, labelType, humanAgree, humanDisagree, humanUnsure,
    *                         aiAgree, aiDisagree, aiUnsure).
    */
   def getCityDailyValidationStatsBySchema(
       schema: String,
-      startDate: Option[LocalDate],
-      endDate: Option[LocalDate],
       filterLowQuality: Boolean
   ): DBIO[Seq[(LocalDate, String, Int, Int, Int, Int, Int, Int)]] = {
-    val userFilter   = if (filterLowQuality) "user_stat.high_quality" else "NOT user_stat.excluded"
-    val whereClauses = scala.collection.mutable.ListBuffer(
-      "label.deleted = FALSE",
-      userFilter
-    )
-    startDate.foreach(d => whereClauses += s"label_validation.end_timestamp >= '$d'::date")
-    endDate.foreach(d => whereClauses += s"label_validation.end_timestamp < ('$d'::date + INTERVAL '1 day')")
-    val where = whereClauses.mkString(" AND ")
+    val userFilter = if (filterLowQuality) "user_stat.high_quality" else "NOT user_stat.excluded"
+    val where      = s"label.deleted = FALSE AND $userFilter"
 
     implicit val getResult: GetResult[(LocalDate, String, Int, Int, Int, Int, Int, Int)] =
       GetResult(r =>

--- a/app/service/ConfigService.scala
+++ b/app/service/ConfigService.scala
@@ -964,7 +964,10 @@ class ConfigServiceImpl @Inject() (
         // The cast is safe because a given key is only ever refreshed with one result type.
         case Some(inFlight) => inFlight.asInstanceOf[Future[T]]
         case None           =>
-          val computation = compute.flatMap { value =>
+          // Future.delegate guards against `compute` throwing synchronously (before producing a Future): the throw
+          // becomes a failed Future handled by the onComplete logging below, instead of escaping to a caller that
+          // could have been served stale data.
+          val computation = Future.delegate(compute).flatMap { value =>
             cacheApi.set(key, Timestamped(value, OffsetDateTime.now()), maxAge).map(_ => value)
           }
           computation.onComplete { result =>

--- a/app/service/ConfigService.scala
+++ b/app/service/ConfigService.scala
@@ -18,7 +18,7 @@ import slick.dbio.DBIO
 import java.time.{LocalDate, OffsetDateTime}
 import java.time.temporal.ChronoUnit
 import javax.inject._
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration.{Duration, FiniteDuration}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.reflect.ClassTag
 
@@ -253,6 +253,12 @@ case class CurrentCityFunnels(computedAt: Option[OffsetDateTime], byType: Map[St
  * its summary block) read the same values.
  */
 object ConfigService {
+
+  /** Cached aggregate stats older than this trigger a background recompute when served (#4600). */
+  val AggregateStatsFreshFor: FiniteDuration = Duration(5, "minutes")
+
+  /** How long cached aggregate stats may be served at all; past this, a request blocks on recomputing them. */
+  val AggregateStatsMaxAge: FiniteDuration = Duration(24, "hours")
 
   /** A city with activity within this many days is "active". */
   val ActiveWithinDays: Long = 30
@@ -490,6 +496,8 @@ trait ConfigService {
    * Calculates aggregate statistics across all Project Sidewalk deployments.
    *
    * Fetches statistics from all configured cities by querying their respective db schemas and aggregating the results.
+   * Results are cached and may lag reality by roughly [[ConfigService.AggregateStatsFreshFor]]; stale data is served
+   * immediately while a background recompute refreshes it (#4600).
    *
    * @return A Future containing aggregated statistics across all cities
    */
@@ -911,88 +919,138 @@ class ConfigServiceImpl @Inject() (
     }
   }
 
+  /** Cached aggregate stats plus when they were computed, so stale data can be served while a refresh runs (#4600). */
+  private case class TimestampedAggregateStats(stats: AggregateStats, computedAt: OffsetDateTime)
+
+  private val aggregateStatsCacheKey = "getAggregateStats"
+
+  /** The in-flight aggregate-stats computation, if any; concurrent refreshes share it instead of re-querying. */
+  private var aggregateStatsRefresh: Option[Future[AggregateStats]] = None
+
   /**
-   * Calculates aggregate statistics across all Project Sidewalk deployments.
+   * Calculates aggregate statistics across all Project Sidewalk deployments, serving cached results when available.
    *
-   * This method uses direct database queries with cross-schema access to efficiently gather only the essential
-   * statistics from all configured cities. It filters out cities whose schemas don't exist in the current environment
-   * (so plays nice with localhost dev setups). Additionally, calculates deployment counts for cities, countries, and
-   * supported languages.
+   * The computation fans out several aggregate queries to every configured city schema, which can take well over 10s
+   * on a loaded database — long enough that a request hitting an expired cache would time out client-side (#4600). So
+   * cached stats are served immediately for up to [[ConfigService.AggregateStatsMaxAge]], with a single background
+   * recompute triggered once they are older than [[ConfigService.AggregateStatsFreshFor]]. Only the first request
+   * after a JVM start (nothing cached yet) waits for the full computation.
    *
    * @return A Future containing aggregated statistics across all cities
    */
   def getAggregateStats(): Future[AggregateStats] = {
-    // Use cache to avoid repeated expensive calculations.
-    cacheApi.getOrElseUpdate[AggregateStats]("getAggregateStats", Duration(5, "minutes")) {
-      // Get all configured city IDs.
-      val configuredCityIds = config.get[Seq[String]]("city-params.city-ids")
+    cacheApi.get[TimestampedAggregateStats](aggregateStatsCacheKey).flatMap {
+      case Some(cached) =>
+        val ageSeconds = ChronoUnit.SECONDS.between(cached.computedAt, OffsetDateTime.now())
+        if (ageSeconds >= ConfigService.AggregateStatsFreshFor.toSeconds) { val _ = refreshAggregateStats() }
+        Future.successful(cached.stats)
+      case None => refreshAggregateStats() // Nothing cached yet (first call since JVM start): wait for the compute.
+    }
+  }
 
-      // Filter to only include cities whose schemas actually exist in the database.
-      val schemaExistenceChecks: Seq[Future[(String, Boolean)]] = configuredCityIds.map { cityId =>
-        try {
-          val schema = getCitySchema(cityId)
-          // Check if the schema actually exists in the database.
-          checkSchemaExists(schema).map(cityId -> _).recover { case _ => cityId -> false }
-        } catch {
-          case _: Exception =>
-            Future.successful(cityId -> false)
-        }
+  /**
+   * Recomputes aggregate stats and caches the result, coalescing concurrent calls into one shared computation.
+   *
+   * @return The freshly computed stats, or the computation's failure (already-cached data is left untouched).
+   */
+  private def refreshAggregateStats(): Future[AggregateStats] = synchronized {
+    aggregateStatsRefresh.getOrElse {
+      val computation = computeAggregateStats().flatMap { stats =>
+        cacheApi
+          .set(
+            aggregateStatsCacheKey,
+            TimestampedAggregateStats(stats, OffsetDateTime.now()),
+            ConfigService.AggregateStatsMaxAge
+          )
+          .map(_ => stats)
       }
+      computation.onComplete { result =>
+        synchronized { aggregateStatsRefresh = None }
+        result.failed.foreach(e => logger.warn(s"Aggregate stats recompute failed: ${e.getMessage}", e))
+      }
+      aggregateStatsRefresh = Some(computation)
+      computation
+    }
+  }
 
-      // Wait for all schema checks to complete.
-      Future.sequence(schemaExistenceChecks).flatMap { schemaResults =>
-        val availableCities = schemaResults.filter(_._2).map(_._1)
+  /**
+   * Runs the full cross-schema fan-out that computes aggregate statistics.
+   *
+   * Uses direct database queries with cross-schema access to gather only the essential statistics from all configured
+   * cities. Filters out cities whose schemas don't exist in the current environment (so plays nice with localhost dev
+   * setups). Additionally, calculates deployment counts for cities, countries, and supported languages.
+   *
+   * @return A Future containing freshly computed aggregate statistics across all cities
+   */
+  private def computeAggregateStats(): Future[AggregateStats] = {
+    // Get all configured city IDs.
+    val configuredCityIds = config.get[Seq[String]]("city-params.city-ids")
 
-        if (availableCities.isEmpty) {
-          logger.warn("No cities with valid schemas found")
-          Future.successful(
+    // Filter to only include cities whose schemas actually exist in the database.
+    val schemaExistenceChecks: Seq[Future[(String, Boolean)]] = configuredCityIds.map { cityId =>
+      try {
+        val schema = getCitySchema(cityId)
+        // Check if the schema actually exists in the database.
+        checkSchemaExists(schema).map(cityId -> _).recover { case _ => cityId -> false }
+      } catch {
+        case _: Exception =>
+          Future.successful(cityId -> false)
+      }
+    }
+
+    // Wait for all schema checks to complete.
+    Future.sequence(schemaExistenceChecks).flatMap { schemaResults =>
+      val availableCities = schemaResults.filter(_._2).map(_._1)
+
+      if (availableCities.isEmpty) {
+        logger.warn("No cities with valid schemas found")
+        Future.successful(
+          AggregateStats(
+            kmExplored = 0.0, kmExploredNoOverlap = 0.0, totalLabels = 0, tutorialLabels = 0, totalValidations = 0,
+            totalUsers = 0, numCities = 0, numCountries = 0, numLanguages = 0, byLabelType = Map.empty
+          )
+        )
+      } else {
+        // Calculate deployment statistics.
+        val numCities    = availableCities.length + 1 // +1 for legacy DC city
+        val numCountries = calculateNumCountries(availableCities)
+        val numLanguages = calculateNumLanguages()
+
+        // Fetch essential statistics from available cities in parallel.
+        val cityStatsFutures: Seq[Future[Option[AggregateStats]]] = availableCities.map { cityId =>
+          getCityAggregateData(cityId)
+        }
+
+        // Distinct contributors across all live cities, deduped by the global `user_id` then DC added on top (#3976).
+        // Computed by unioning per-city contributor-id sets rather than summing per-city counts, so a user active in
+        // multiple cities is counted once. Each city recovers to an empty set so one bad schema can't sink the count.
+        val distinctUsersFut: Future[Int] = Future
+          .sequence(availableCities.map { cityId =>
+            db.run(configTable.getContributorUserIdsBySchema(getCitySchema(cityId)))
+              .map(_.toSet)
+              .recover { case e: Exception =>
+                logger.warn(s"Failed to retrieve contributor ids for city $cityId: ${e.getMessage}")
+                Set.empty[String]
+              }
+          })
+          .map(perCity => perCity.foldLeft(Set.empty[String])(_ ++ _).size + legacyDCUserCount)
+
+        // Wait for all futures to complete and aggregate results.
+        Future.sequence(cityStatsFutures).zip(distinctUsersFut).map { case (cityStatsOptions, totalUsers) =>
+          // Filter out failed requests and aggregate the successful ones.
+          val validCityStats = cityStatsOptions.flatten
+
+          if (validCityStats.isEmpty) {
+            logger.warn("No valid city statistics found for aggregate calculation")
+            // Return empty aggregate stats if no cities provided data.
             AggregateStats(
               kmExplored = 0.0, kmExploredNoOverlap = 0.0, totalLabels = 0, tutorialLabels = 0, totalValidations = 0,
-              totalUsers = 0, numCities = 0, numCountries = 0, numLanguages = 0, byLabelType = Map.empty
+              totalUsers = 0, numCities = numCities, numCountries = numCountries, numLanguages = numLanguages,
+              byLabelType = Map.empty
             )
-          )
-        } else {
-          // Calculate deployment statistics.
-          val numCities    = availableCities.length + 1 // +1 for legacy DC city
-          val numCountries = calculateNumCountries(availableCities)
-          val numLanguages = calculateNumLanguages()
-
-          // Fetch essential statistics from available cities in parallel.
-          val cityStatsFutures: Seq[Future[Option[AggregateStats]]] = availableCities.map { cityId =>
-            getCityAggregateData(cityId)
-          }
-
-          // Distinct contributors across all live cities, deduped by the global `user_id` then DC added on top (#3976).
-          // Computed by unioning per-city contributor-id sets rather than summing per-city counts, so a user active in
-          // multiple cities is counted once. Each city recovers to an empty set so one bad schema can't sink the count.
-          val distinctUsersFut: Future[Int] = Future
-            .sequence(availableCities.map { cityId =>
-              db.run(configTable.getContributorUserIdsBySchema(getCitySchema(cityId)))
-                .map(_.toSet)
-                .recover { case e: Exception =>
-                  logger.warn(s"Failed to retrieve contributor ids for city $cityId: ${e.getMessage}")
-                  Set.empty[String]
-                }
-            })
-            .map(perCity => perCity.foldLeft(Set.empty[String])(_ ++ _).size + legacyDCUserCount)
-
-          // Wait for all futures to complete and aggregate results.
-          Future.sequence(cityStatsFutures).zip(distinctUsersFut).map { case (cityStatsOptions, totalUsers) =>
-            // Filter out failed requests and aggregate the successful ones.
-            val validCityStats = cityStatsOptions.flatten
-
-            if (validCityStats.isEmpty) {
-              logger.warn("No valid city statistics found for aggregate calculation")
-              // Return empty aggregate stats if no cities provided data.
-              AggregateStats(
-                kmExplored = 0.0, kmExploredNoOverlap = 0.0, totalLabels = 0, tutorialLabels = 0, totalValidations = 0,
-                totalUsers = 0, numCities = numCities, numCountries = numCountries, numLanguages = numLanguages,
-                byLabelType = Map.empty
-              )
-            } else {
-              // Add legacy DC data to the valid city stats before aggregating.
-              aggregateCityData(validCityStats :+ legacyDCData, numCities, numCountries, numLanguages, totalUsers)
-            }
+          } else {
+            // Add legacy DC data to the valid city stats before aggregating.
+            aggregateCityData(validCityStats :+ legacyDCData, numCities, numCountries, numLanguages, totalUsers)
           }
         }
       }

--- a/app/service/ConfigService.scala
+++ b/app/service/ConfigService.scala
@@ -509,7 +509,9 @@ trait ConfigService {
    * Queries each city schema in parallel and sums counts by (date, labelType) across cities.
    * Cities whose schemas do not exist in the current environment are silently skipped (same
    * guard as getAggregateStats). The legacy DC dataset is omitted because its schema predates
-   * the label_validation table format used here.
+   * the label_validation table format used here. The full-range result is cached like
+   * getAggregateStats (stale data served immediately, background refresh — #4600), and the
+   * requested date window is sliced from the cached per-day rows.
    *
    * @param startDate        Inclusive start date (Pacific time); no lower bound if None.
    * @param endDate          Inclusive end date; no upper bound if None.
@@ -919,13 +921,60 @@ class ConfigServiceImpl @Inject() (
     }
   }
 
-  /** Cached aggregate stats plus when they were computed, so stale data can be served while a refresh runs (#4600). */
-  private case class TimestampedAggregateStats(stats: AggregateStats, computedAt: OffsetDateTime)
+  /** A cached value plus when it was computed, so stale data can be served while a refresh runs (#4600). */
+  private case class Timestamped[T](value: T, computedAt: OffsetDateTime)
 
-  private val aggregateStatsCacheKey = "getAggregateStats"
+  /** In-flight cache recomputes by cache key, so concurrent refreshes of a key share one computation (#4600). */
+  private val refreshesInFlight = scala.collection.mutable.Map.empty[String, Future[_]]
 
-  /** The in-flight aggregate-stats computation, if any; concurrent refreshes share it instead of re-querying. */
-  private var aggregateStatsRefresh: Option[Future[AggregateStats]] = None
+  /**
+   * Serves the cached value for `key` immediately — even when stale — while keeping it fresh in the background.
+   *
+   * When the cached copy is older than `freshFor`, a single background recompute is kicked off and the stale copy is
+   * returned right away; requests arriving while a recompute runs share it rather than piling more load on the
+   * database. Only a request that finds nothing cached at all (first call since JVM start, or the value aged past
+   * `maxAge`) blocks on `compute`.
+   *
+   * @param key      Cache key; must uniquely identify the computation, including any parameters.
+   * @param freshFor Age beyond which serving the cached value also triggers a background recompute.
+   * @param maxAge   Hard cache-eviction bound; past this, a request blocks on recomputing.
+   * @param compute  The expensive computation producing a fresh value.
+   * @return         The cached (possibly stale) value, or the result of `compute` when nothing is cached.
+   */
+  private def staleWhileRevalidate[T: ClassTag](key: String, freshFor: FiniteDuration, maxAge: FiniteDuration)(
+      compute: => Future[T]
+  ): Future[T] = {
+    cacheApi.get[Timestamped[T]](key).flatMap {
+      case Some(cached) =>
+        val ageSeconds = ChronoUnit.SECONDS.between(cached.computedAt, OffsetDateTime.now())
+        if (ageSeconds >= freshFor.toSeconds) { val _ = refreshCachedValue(key, maxAge)(compute) }
+        Future.successful(cached.value)
+      case None => refreshCachedValue(key, maxAge)(compute) // Nothing cached yet: wait for the compute.
+    }
+  }
+
+  /**
+   * Recomputes the value behind `key` and caches it, coalescing concurrent calls into one shared computation.
+   *
+   * @return The freshly computed value, or the computation's failure (already-cached data is left untouched).
+   */
+  private def refreshCachedValue[T](key: String, maxAge: FiniteDuration)(compute: => Future[T]): Future[T] =
+    synchronized {
+      refreshesInFlight.get(key) match {
+        // The cast is safe because a given key is only ever refreshed with one result type.
+        case Some(inFlight) => inFlight.asInstanceOf[Future[T]]
+        case None           =>
+          val computation = compute.flatMap { value =>
+            cacheApi.set(key, Timestamped(value, OffsetDateTime.now()), maxAge).map(_ => value)
+          }
+          computation.onComplete { result =>
+            synchronized { val _ = refreshesInFlight.remove(key) }
+            result.failed.foreach(e => logger.warn(s"Recompute of cached '$key' failed: ${e.getMessage}", e))
+          }
+          refreshesInFlight(key) = computation
+          computation
+      }
+    }
 
   /**
    * Calculates aggregate statistics across all Project Sidewalk deployments, serving cached results when available.
@@ -938,40 +987,10 @@ class ConfigServiceImpl @Inject() (
    *
    * @return A Future containing aggregated statistics across all cities
    */
-  def getAggregateStats(): Future[AggregateStats] = {
-    cacheApi.get[TimestampedAggregateStats](aggregateStatsCacheKey).flatMap {
-      case Some(cached) =>
-        val ageSeconds = ChronoUnit.SECONDS.between(cached.computedAt, OffsetDateTime.now())
-        if (ageSeconds >= ConfigService.AggregateStatsFreshFor.toSeconds) { val _ = refreshAggregateStats() }
-        Future.successful(cached.stats)
-      case None => refreshAggregateStats() // Nothing cached yet (first call since JVM start): wait for the compute.
-    }
-  }
-
-  /**
-   * Recomputes aggregate stats and caches the result, coalescing concurrent calls into one shared computation.
-   *
-   * @return The freshly computed stats, or the computation's failure (already-cached data is left untouched).
-   */
-  private def refreshAggregateStats(): Future[AggregateStats] = synchronized {
-    aggregateStatsRefresh.getOrElse {
-      val computation = computeAggregateStats().flatMap { stats =>
-        cacheApi
-          .set(
-            aggregateStatsCacheKey,
-            TimestampedAggregateStats(stats, OffsetDateTime.now()),
-            ConfigService.AggregateStatsMaxAge
-          )
-          .map(_ => stats)
-      }
-      computation.onComplete { result =>
-        synchronized { aggregateStatsRefresh = None }
-        result.failed.foreach(e => logger.warn(s"Aggregate stats recompute failed: ${e.getMessage}", e))
-      }
-      aggregateStatsRefresh = Some(computation)
-      computation
-    }
-  }
+  def getAggregateStats(): Future[AggregateStats] =
+    staleWhileRevalidate("getAggregateStats", ConfigService.AggregateStatsFreshFor, ConfigService.AggregateStatsMaxAge)(
+      computeAggregateStats()
+    )
 
   /**
    * Runs the full cross-schema fan-out that computes aggregate statistics.
@@ -1062,6 +1081,30 @@ class ConfigServiceImpl @Inject() (
       endDate: Option[LocalDate],
       filterLowQuality: Boolean
   ): Future[Seq[DailyStatRecord]] = {
+    // Cache the full date range once per filterLowQuality variant — a bounded key space, where caching per requested
+    // date range would let arbitrary query params mint unbounded cache entries — and slice the requested window out
+    // of it. A per-day row depends only on its own day's data, so slicing cached rows is equivalent to querying with
+    // bounds; and because rows are keyed by Pacific date, the slice honors the documented inclusive-Pacific-date
+    // window exactly, where the raw-timestamp WHERE it replaced could emit partial edge days outside it.
+    staleWhileRevalidate(
+      s"getAggregateStatsByDay:filterLowQuality=$filterLowQuality",
+      ConfigService.AggregateStatsFreshFor,
+      ConfigService.AggregateStatsMaxAge
+    )(computeAggregateStatsByDay(filterLowQuality)).map { allDays =>
+      allDays.filter(r => startDate.forall(!r.date.isBefore(_)) && endDate.forall(!r.date.isAfter(_)))
+    }
+  }
+
+  /**
+   * Runs the full cross-schema fan-out that computes daily stats over the entire date range.
+   *
+   * Queries each city schema in parallel and sums counts by (date, labelType) across cities. Cities whose schemas do
+   * not exist in the current environment are silently skipped (same guard as computeAggregateStats).
+   *
+   * @param filterLowQuality If true, restrict to high-quality users.
+   * @return                 Merged, sorted sequence of DailyStatRecord summed across all cities.
+   */
+  private def computeAggregateStatsByDay(filterLowQuality: Boolean): Future[Seq[DailyStatRecord]] = {
     val configuredCityIds = config.get[Seq[String]]("city-params.city-ids")
 
     val schemaChecks = configuredCityIds.map { cityId =>
@@ -1082,13 +1125,13 @@ class ConfigServiceImpl @Inject() (
         val cityDataFutures = availableCities.map { cityId =>
           val schema       = getCitySchema(cityId)
           val labelsFuture = db
-            .run(configTable.getCityDailyLabelStatsBySchema(schema, startDate, endDate, filterLowQuality))
+            .run(configTable.getCityDailyLabelStatsBySchema(schema, filterLowQuality))
             .recover { case e: Exception =>
               logger.warn(s"Failed daily label stats for city $cityId: ${e.getMessage}")
               Seq.empty[(LocalDate, String, Int, Int)]
             }
           val valsFuture = db
-            .run(configTable.getCityDailyValidationStatsBySchema(schema, startDate, endDate, filterLowQuality))
+            .run(configTable.getCityDailyValidationStatsBySchema(schema, filterLowQuality))
             .recover { case e: Exception =>
               logger.warn(s"Failed daily validation stats for city $cityId: ${e.getMessage}")
               Seq.empty[(LocalDate, String, Int, Int, Int, Int, Int, Int)]

--- a/public/js/common/aggregateStats.js
+++ b/public/js/common/aggregateStats.js
@@ -10,7 +10,7 @@
  */
 const CONFIG = {
   AGGREGATE_STATS_ENDPOINT: '/v3/api/aggregateStats',
-  REQUEST_TIMEOUT: 10000, // 10 seconds
+  REQUEST_TIMEOUT: 15000, // 15 seconds
   RETRY_ATTEMPTS: 2,
   RETRY_DELAY: 1000, // 1 second
 };
@@ -32,29 +32,26 @@ const CONFIG = {
 /**
  * Fetches data from a URL with timeout and retry logic.
  *
+ * Timeouts are retried like any other failure: the server finishes computing an aborted request and caches the
+ * result, so a follow-up attempt typically succeeds quickly even when the first one timed out (#4600).
+ *
  * @param {string} url - The URL to fetch data from
  * @param {number} [timeout=CONFIG.REQUEST_TIMEOUT] - Request timeout in milliseconds
  * @param {number} [retries=CONFIG.RETRY_ATTEMPTS] - Number of retry attempts
- * @returns {Promise<Object>} The parsed JSON response
+ * @returns {Promise<object>} The parsed JSON response
  * @throws {Error} When the request fails after all retries
  *
  * @example
  * const data = await fetchWithRetry('/v3/api/aggregateStats');
  */
 async function fetchWithRetry(url, timeout = CONFIG.REQUEST_TIMEOUT, retries = CONFIG.RETRY_ATTEMPTS) {
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), timeout);
-
   try {
     const response = await fetch(url, {
-      signal: controller.signal,
+      signal: AbortSignal.timeout(timeout),
       headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json',
+        Accept: 'application/json',
       },
     });
-
-    clearTimeout(timeoutId);
 
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}: ${response.statusText}`);
@@ -62,15 +59,17 @@ async function fetchWithRetry(url, timeout = CONFIG.REQUEST_TIMEOUT, retries = C
 
     return await response.json();
   } catch (error) {
-    clearTimeout(timeoutId);
+    // Aborts surface as "signal is aborted without reason" — rewrap them into something a reader can act on.
+    const isTimeout = error.name === 'TimeoutError' || error.name === 'AbortError';
+    const friendlyError = isTimeout ? new Error(`Request timed out after ${timeout / 1000} seconds`) : error;
 
-    if (retries > 0 && error.name !== 'AbortError') {
-      console.warn(`Request failed, retrying... (${retries} attempts left)`, error.message);
+    if (retries > 0) {
+      console.warn(`Request failed, retrying... (${retries} attempts left)`, friendlyError.message);
       await new Promise((resolve) => setTimeout(resolve, CONFIG.RETRY_DELAY));
       return fetchWithRetry(url, timeout, retries - 1);
     }
 
-    throw error;
+    throw friendlyError;
   }
 }
 

--- a/test/controllers/api/StatsApiSpec.scala
+++ b/test/controllers/api/StatsApiSpec.scala
@@ -138,20 +138,20 @@ class StatsApiSpec extends PlaySpec with GuiceOneAppPerSuite {
 
     // The requested window is sliced from the cached full-range rows (#4600), so the sliced result must equal the
     // matching subset of the unbounded result — inclusive of both endpoint days, with no dates outside the window.
+    // Robust to an empty test DB: with no rows at all, any window must slice to empty (still a 200).
     "honor an inclusive startDate/endDate window consistently with the unbounded result" in {
       val allData = (contentAsJson(route(app, FakeRequest(GET, "/v3/api/aggregateStatsByDay")).get) \ "data")
         .as[Seq[JsObject]]
-      assume(allData.nonEmpty, "test DB has no daily stats to slice")
 
       // Pick a middle date so both bounds actually cut something when more than one day exists.
       val dates      = allData.map(row => (row \ "date").as[String]).distinct
-      val windowDate = dates(dates.size / 2)
+      val windowDate = if (dates.nonEmpty) dates(dates.size / 2) else "2026-01-01"
 
       val windowed = (contentAsJson(
         route(app, FakeRequest(GET, s"/v3/api/aggregateStatsByDay?startDate=$windowDate&endDate=$windowDate")).get
       ) \ "data").as[Seq[JsObject]]
 
-      windowed.map(row => (row \ "date").as[String]).distinct mustBe Seq(windowDate)
+      windowed.map(row => (row \ "date").as[String]).distinct mustBe dates.filter(_ == windowDate)
       windowed mustBe allData.filter(row => (row \ "date").as[String] == windowDate)
     }
 

--- a/test/controllers/api/StatsApiSpec.scala
+++ b/test/controllers/api/StatsApiSpec.scala
@@ -113,4 +113,57 @@ class StatsApiSpec extends PlaySpec with GuiceOneAppPerSuite {
       ).foreach(key => body must include(key))
     }
   }
+
+  "GET /v3/api/aggregateStatsByDay" should {
+    "return 200 JSON with snake_case per-day rows sorted by date" in {
+      val resp = route(app, FakeRequest(GET, "/v3/api/aggregateStatsByDay")).get
+      status(resp) mustBe OK
+      contentType(resp) mustBe Some("application/json")
+
+      val json = contentAsJson(resp)
+      (json \ "status").as[String] mustBe "OK"
+      val data = (json \ "data").as[Seq[JsObject]]
+
+      data.headOption.foreach { row =>
+        (row \ "date").asOpt[String] mustBe defined
+        (row \ "label_type").asOpt[String] mustBe defined
+        (row \ "human_labels").asOpt[Long] mustBe defined
+        (row \ "ai_labels").asOpt[Long] mustBe defined
+        (row \ "human_validations_agree").asOpt[Long] mustBe defined
+        (row \ "ai_validations_unsure").asOpt[Long] mustBe defined
+      }
+      val dates = data.map(row => (row \ "date").as[String])
+      dates mustBe dates.sorted
+    }
+
+    // The requested window is sliced from the cached full-range rows (#4600), so the sliced result must equal the
+    // matching subset of the unbounded result — inclusive of both endpoint days, with no dates outside the window.
+    "honor an inclusive startDate/endDate window consistently with the unbounded result" in {
+      val allData = (contentAsJson(route(app, FakeRequest(GET, "/v3/api/aggregateStatsByDay")).get) \ "data")
+        .as[Seq[JsObject]]
+      assume(allData.nonEmpty, "test DB has no daily stats to slice")
+
+      // Pick a middle date so both bounds actually cut something when more than one day exists.
+      val dates      = allData.map(row => (row \ "date").as[String]).distinct
+      val windowDate = dates(dates.size / 2)
+
+      val windowed = (contentAsJson(
+        route(app, FakeRequest(GET, s"/v3/api/aggregateStatsByDay?startDate=$windowDate&endDate=$windowDate")).get
+      ) \ "data").as[Seq[JsObject]]
+
+      windowed.map(row => (row \ "date").as[String]).distinct mustBe Seq(windowDate)
+      windowed mustBe allData.filter(row => (row \ "date").as[String] == windowDate)
+    }
+
+    "reject a malformed date with a 400" in {
+      val resp = route(app, FakeRequest(GET, "/v3/api/aggregateStatsByDay?startDate=07-17-2026")).get
+      status(resp) mustBe BAD_REQUEST
+    }
+
+    "reject startDate after endDate with a 400" in {
+      val resp =
+        route(app, FakeRequest(GET, "/v3/api/aggregateStatsByDay?startDate=2026-02-01&endDate=2026-01-01")).get
+      status(resp) mustBe BAD_REQUEST
+    }
+  }
 }

--- a/test/js/aggregateStatsRetry.test.js
+++ b/test/js/aggregateStatsRetry.test.js
@@ -1,0 +1,135 @@
+/**
+ * Behavior tests for public/js/common/aggregateStats.js (#4600).
+ *
+ * The API-docs landing page fell back to its error state whenever /v3/api/aggregateStats took longer than the fetch
+ * timeout, because timeout aborts were exempted from the retry logic. These tests pin the fixed contract: a timed-out
+ * attempt is retried (the server keeps computing the aborted request and caches its result, so retries converge), and
+ * the error shown after all retries fail is human-readable rather than "signal is aborted without reason".
+ *
+ * Runs under jsdom (set in jest.config.js via testEnvironment) so `window`/`document` are available.
+ */
+
+const { loadGlobalScript } = require('./loadGlobalScript');
+
+// jsdom (as bundled with this Jest version) implements AbortSignal but not the static AbortSignal.timeout()
+// (Baseline 2022, present in all supported browsers). Shim it for these tests; fetch is stubbed anyway, so the
+// signal's actual timing behavior never matters here.
+if (typeof AbortSignal.timeout !== 'function') {
+    AbortSignal.timeout = () => new AbortController().signal;
+}
+
+const MODULE_PATH = 'public/js/common/aggregateStats.js';
+const STATS_PARAGRAPH_ID = 'project-sidewalk-aggregate-stats';
+
+// Minimal snake_case /v3/api/aggregateStats response (v3 naming convention, issue #3871).
+const GOOD_FIXTURE = {
+    status: 'OK',
+    km_explored: 1234,
+    km_explored_no_overlap: 1000,
+    total_labels: 50000,
+    total_validations: 30000,
+    num_cities: 18,
+    num_countries: 9,
+    num_languages: 7,
+    by_label_type: {}
+};
+
+/**
+ * Builds the error a fetch rejects with when its AbortSignal.timeout() fires.
+ * @returns {Error} An error whose name matches the DOMException browsers raise on fetch timeout.
+ */
+function timeoutError() {
+    return Object.assign(new Error('signal timed out'), { name: 'TimeoutError' });
+}
+
+/**
+ * Polls an expectation until it passes, failing with its last error after timeoutMs. The script kicks off
+ * loadProjectSidewalkStats() fire-and-forget from the appManager.ready callback, so tests can't await it directly —
+ * they wait for its DOM effects instead.
+ * @param {Function} expectation - Function that throws (e.g. contains Jest expects) until the condition holds.
+ * @param {number} [timeoutMs=8000] - How long to keep polling before giving up.
+ */
+async function waitFor(expectation, timeoutMs = 8000) {
+    const deadline = Date.now() + timeoutMs;
+    for (;;) {
+        try {
+            expectation();
+            return;
+        } catch (error) {
+            if (Date.now() > deadline) throw error;
+            await new Promise((resolve) => setTimeout(resolve, 25));
+        }
+    }
+}
+
+describe('aggregateStats fetch resilience', () => {
+    let readyCallback;
+
+    beforeEach(() => {
+        document.body.innerHTML = `<p id="${STATS_PARAGRAPH_ID}"></p>`;
+
+        // The script auto-registers via window.appManager.ready() at load; capture the callback to trigger manually.
+        readyCallback = undefined;
+        window.appManager = { ready: (cb) => { readyCallback = cb; } };
+
+        // Globals the renderer reaches for (provided by other bundles in production).
+        global.i18next = { t: (key, opts) => Number(opts.val).toLocaleString('en-US') };
+        global.util = { math: { kmsToMiles: (km) => km * 0.621371 } };
+
+        // Keep the retry/error logging out of Jest's output.
+        jest.spyOn(console, 'warn').mockImplementation(() => {});
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        loadGlobalScript(MODULE_PATH);
+    });
+
+    afterEach(() => {
+        delete global.fetch;
+        delete global.i18next;
+        delete global.util;
+        delete window.appManager;
+        jest.restoreAllMocks();
+    });
+
+    test('registers with appManager and passes a timeout signal to fetch', async () => {
+        global.fetch = jest.fn(() =>
+            Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(GOOD_FIXTURE) })
+        );
+
+        expect(readyCallback).toBeDefined();
+        readyCallback();
+
+        await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+        const options = global.fetch.mock.calls[0][1];
+        expect(options.signal).toBeInstanceOf(AbortSignal);
+    });
+
+    test('retries after a timeout and renders stats from the second attempt', async () => {
+        global.fetch = jest.fn()
+            .mockRejectedValueOnce(timeoutError())
+            .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve(GOOD_FIXTURE) });
+
+        readyCallback();
+
+        await waitFor(() => {
+            const html = document.getElementById(STATS_PARAGRAPH_ID).innerHTML;
+            expect(html).toContain('18 cities');
+        });
+        expect(global.fetch).toHaveBeenCalledTimes(2);
+        expect(document.getElementById(STATS_PARAGRAPH_ID).innerHTML).not.toContain('Unable to load');
+    }, 15000);
+
+    test('shows a readable timeout message after every attempt times out', async () => {
+        global.fetch = jest.fn(() => Promise.reject(timeoutError()));
+
+        readyCallback();
+
+        await waitFor(() => {
+            const html = document.getElementById(STATS_PARAGRAPH_ID).innerHTML;
+            expect(html).toContain('Request timed out after 15 seconds');
+        });
+        // Initial attempt + CONFIG.RETRY_ATTEMPTS retries.
+        expect(global.fetch).toHaveBeenCalledTimes(3);
+        expect(document.getElementById(STATS_PARAGRAPH_ID).innerHTML).not.toContain('signal is aborted');
+    }, 15000);
+});

--- a/test/models/utils/CityScorecardSpec.scala
+++ b/test/models/utils/CityScorecardSpec.scala
@@ -88,13 +88,11 @@ class CityScorecardSpec extends PlaySpec with GuiceOneAppPerSuite {
       run(configTable.getCityLabelingSpeedBySchema(schema)) mustBe a[Product] // (Double, Double)
     }
     "execute getCityDailyLabelStatsBySchema (both quality filters)" in {
-      run(configTable.getCityDailyLabelStatsBySchema(schema, None, None, filterLowQuality = false)) mustBe a[Seq[_]]
-      run(configTable.getCityDailyLabelStatsBySchema(schema, None, None, filterLowQuality = true)) mustBe a[Seq[_]]
+      run(configTable.getCityDailyLabelStatsBySchema(schema, filterLowQuality = false)) mustBe a[Seq[_]]
+      run(configTable.getCityDailyLabelStatsBySchema(schema, filterLowQuality = true)) mustBe a[Seq[_]]
     }
     "execute getCityDailyValidationStatsBySchema" in {
-      run(configTable.getCityDailyValidationStatsBySchema(schema, None, None, filterLowQuality = false)) mustBe a[Seq[
-        _
-      ]]
+      run(configTable.getCityDailyValidationStatsBySchema(schema, filterLowQuality = false)) mustBe a[Seq[_]]
     }
   }
 }


### PR DESCRIPTION
Resolves #4600.

## Root cause

`/v3/api/aggregateStats` fans out several heavy aggregate queries to every configured city schema (~56). With a 5-minute expiring cache and one JVM cache per city instance, low-traffic deployments (like Houston's API docs page) hit a cold cache almost every visit. Measured on prod: warm = 0.15s, cold = ~2.2s under light load — under DB contention that exceeds the frontend's 10s fetch timeout, and `aggregateStats.js` explicitly refused to retry aborted requests, so the page fell into its error state showing `signal is aborted without reason`.

`/v3/api/aggregateStatsByDay` (the by-day docs preview) was worse: the same fan-out on **every** request, with no caching at all.

## Backend

- New reusable `staleWhileRevalidate` helper in `ConfigService` (per-key coalescing: concurrent refreshes share one computation). Cached stats are served instantly for up to 24h; once older than 5 minutes, a single background recompute refreshes them. Only the first request after a JVM start blocks on the full computation.
- `getAggregateStats` and `getAggregateStatsByDay` both use it. For by-day, the **full date range** is cached once per `filterLowQuality` variant (a bounded key space — caching per requested range would let arbitrary query params mint unbounded cache entries) and the requested window is sliced from the cached per-day rows.
- The slice is exact (a per-day row depends only on its own day's data) and fixes a latent edge-day bug: the old SQL grouped by Pacific date but range-filtered raw timestamps in server timezone, so a windowed request could return partial days dated outside the requested window. The slice honors the documented inclusive-Pacific-date contract exactly. The now-dead date params are dropped from the two `ConfigTable` by-day queries.

## Frontend (`aggregateStats.js`)

- Timeouts are retried like any other failure — the server finishes computing an aborted request and caches it, so a retry lands on the warm cache.
- Timeout raised 10s → 15s, modernized to `AbortSignal.timeout()`.
- Readable error (`Request timed out after 15 seconds`) instead of the abort message.

## Testing

- New jest suite `test/js/aggregateStatsRetry.test.js` pinning the retry-on-timeout contract (fails against the old code).
- First `StatsApiSpec` coverage of `/v3/api/aggregateStatsByDay`: snake_case row contract, window-slice consistency against the unbounded result, 400s for malformed/inverted dates.
- Full backend suite 297/297 (boots with evolution 338 applied), jest 74/74, eslint/scalafmt clean. Rebased on latest `develop`; scanned #4588/#4603 conventions — no schema/table-def changes here, so nothing applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)