### PR TITLE
Title-case Houston's ALL-CAPS neighborhood names (#4596)

### DIFF
--- a/conf/evolutions/default/341.sql
+++ b/conf/evolutions/default/341.sql
@@ -7,13 +7,17 @@
 -- to a per-city review rather than swept here.
 --
 -- Rule (identical to the importer): title-case a name that is entirely uppercase AND is either multi-word or a single
--- token of 5+ characters -- shorter single tokens are treated as acronyms and left alone. COLLATE "default" makes
--- initcap use the database's UTF-8 collation instead of the name column's POSIX collation, under which initcap treats
--- accented letters as word boundaries and corrupts them. Houston is all-ASCII, but this keeps the statement identical
--- to the importer and correct for any accented data.
+-- token of 5+ characters, EXCEPT names that look like abbreviations -- single tokens of 4 chars or fewer, names with an
+-- "&" ("PSE&G"), and dotted initialisms ("P.I.C.O.") are left alone. (Houston has none of the abbreviation cases, but
+-- the guards keep this statement identical to the importer.) COLLATE "default" makes initcap use the database's UTF-8
+-- collation instead of the name column's POSIX collation, under which initcap treats accented letters as word
+-- boundaries and corrupts them -- Houston is all-ASCII, but this keeps the rule correct for any accented data.
 UPDATE region SET name = initcap(name COLLATE "default")
 WHERE current_schema() = 'sidewalk_houston'
-  AND name = upper(name) AND name ~ '[[:alpha:]]' AND (name LIKE '% %' OR char_length(name) >= 5);
+  AND name = upper(name) AND name ~ '[[:alpha:]]'
+  AND name NOT LIKE '%&%'
+  AND (char_length(name) - char_length(replace(name, '.', ''))) < 2
+  AND (name LIKE '% %' OR char_length(name) >= 5);
 
 # --- !Downs
 -- One-way data normalization: the original casing is not stored, so there is nothing to restore automatically.

--- a/conf/evolutions/default/341.sql
+++ b/conf/evolutions/default/341.sql
@@ -1,0 +1,19 @@
+# --- !Ups
+-- One-time backfill: title-case Houston's neighborhood names, which were imported ALL CAPS before fill-new-schema.sh
+-- learned to normalize them (issue #4596). Scoped to Houston via current_schema() -- during evolution application the
+-- city's own schema is on the search_path, so this is a plain no-op for every other deployment. A read-only dry-run
+-- across all sites showed the other all-caps cities (CDMX, La Piedad, Rancagua, ...) carry local conventions -- Spanish
+-- connector words, "Unidad Vecinal" (UV) codes, dotted org acronyms -- that initcap would mangle, so they are deferred
+-- to a per-city review rather than swept here.
+--
+-- Rule (identical to the importer): title-case a name that is entirely uppercase AND is either multi-word or a single
+-- token of 5+ characters -- shorter single tokens are treated as acronyms and left alone. COLLATE "default" makes
+-- initcap use the database's UTF-8 collation instead of the name column's POSIX collation, under which initcap treats
+-- accented letters as word boundaries and corrupts them. Houston is all-ASCII, but this keeps the statement identical
+-- to the importer and correct for any accented data.
+UPDATE region SET name = initcap(name COLLATE "default")
+WHERE current_schema() = 'sidewalk_houston'
+  AND name = upper(name) AND name ~ '[[:alpha:]]' AND (name LIKE '% %' OR char_length(name) >= 5);
+
+# --- !Downs
+-- One-way data normalization: the original casing is not stored, so there is nothing to restore automatically.

--- a/db/scripts/fill-new-schema.sh
+++ b/db/scripts/fill-new-schema.sh
@@ -120,9 +120,21 @@ psql -v ON_ERROR_STOP=1 -d sidewalk -U "$SCHEMA_NAME" <<-EOSQL
     INSERT INTO osm_way_street_edge (osm_way_id, street_edge_id)
         SELECT CAST(osm_id AS INT), road_id FROM qgis_road;
 
-    -- Fill in the region table using the qgis_region table.
+    -- Fill in the region table using the qgis_region table. Names imported from QGIS/OSM are sometimes ALL CAPS
+    -- (issue #4596), so title-case any name that is entirely uppercase and is not a short standalone acronym: the
+    -- acronym guard leaves single-token names of 4 chars or fewer as-is ("VCU"/"RAI"/"NASA"), while multi-word names
+    -- and longer single words ("SUNNYSIDE") are title-cased. COLLATE "default" makes initcap use the DB's UTF-8
+    -- collation so accented names title-case correctly; a name that already carries a lowercase letter is left as
+    -- provided. Evolution 341 back-fills Houston, the one existing site imported before this was added.
     INSERT INTO region (region_id, data_source, name, geom, deleted)
-        SELECT region_id, '$REGION_DATA_SOURCE', $REGION_NAME_COL, geom, $REGION_DELETED_Q
+        SELECT region_id, '$REGION_DATA_SOURCE',
+               CASE WHEN $REGION_NAME_COL = upper($REGION_NAME_COL)
+                         AND $REGION_NAME_COL ~ '[[:alpha:]]'
+                         AND ($REGION_NAME_COL LIKE '% %' OR char_length($REGION_NAME_COL) >= 5)
+                    THEN initcap($REGION_NAME_COL COLLATE "default")
+                    ELSE $REGION_NAME_COL
+               END,
+               geom, $REGION_DELETED_Q
         FROM qgis_region;
 
     -- Fill in the street_edge_region table. First streets for the city, then the tutorial street.

--- a/db/scripts/fill-new-schema.sh
+++ b/db/scripts/fill-new-schema.sh
@@ -121,15 +121,18 @@ psql -v ON_ERROR_STOP=1 -d sidewalk -U "$SCHEMA_NAME" <<-EOSQL
         SELECT CAST(osm_id AS INT), road_id FROM qgis_road;
 
     -- Fill in the region table using the qgis_region table. Names imported from QGIS/OSM are sometimes ALL CAPS
-    -- (issue #4596), so title-case any name that is entirely uppercase and is not a short standalone acronym: the
-    -- acronym guard leaves single-token names of 4 chars or fewer as-is ("VCU"/"RAI"/"NASA"), while multi-word names
-    -- and longer single words ("SUNNYSIDE") are title-cased. COLLATE "default" makes initcap use the DB's UTF-8
-    -- collation so accented names title-case correctly; a name that already carries a lowercase letter is left as
-    -- provided. Evolution 341 back-fills Houston, the one existing site imported before this was added.
+    -- (issue #4596), so title-case any name that is entirely uppercase and does not look like an acronym. Guards keep
+    -- abbreviations intact: single tokens of 4 chars or fewer ("VCU"/"NASA"), names containing an "&" ("PSE&G"), and
+    -- dotted initialisms ("P.I.C.O.") are left as-is; multi-word names and longer single words ("SUNNYSIDE") are
+    -- title-cased. COLLATE "default" makes initcap use the DB's UTF-8 collation so accented names title-case correctly;
+    -- a name that already carries a lowercase letter is left as provided. Evolution 341 back-fills Houston, the one
+    -- existing site imported before this was added.
     INSERT INTO region (region_id, data_source, name, geom, deleted)
         SELECT region_id, '$REGION_DATA_SOURCE',
                CASE WHEN $REGION_NAME_COL = upper($REGION_NAME_COL)
                          AND $REGION_NAME_COL ~ '[[:alpha:]]'
+                         AND $REGION_NAME_COL NOT LIKE '%&%'
+                         AND (char_length($REGION_NAME_COL) - char_length(replace($REGION_NAME_COL, '.', ''))) < 2
                          AND ($REGION_NAME_COL LIKE '% %' OR char_length($REGION_NAME_COL) >= 5)
                     THEN initcap($REGION_NAME_COL COLLATE "default")
                     ELSE $REGION_NAME_COL


### PR DESCRIPTION
Closes #4596.

Houston's neighborhood (`region.name`) values were imported ALL CAPS. This normalizes them to title case and stops future imports from reintroducing the problem.

## What changed
- **`db/scripts/fill-new-schema.sh`** — the region import now title-cases names at insert time, so **new cities self-standardize**. Guarded so it only touches ALL-CAPS names and never mangles acronyms or already-cased names.
- **`conf/evolutions/default/341.sql`** — a one-time backfill that title-cases **Houston's** existing names on deploy. Scoped to Houston via `current_schema()`, so it's a plain no-op for every other city.

## The rule
Title-case a name only when it is entirely uppercase **AND** is either multi-word **or** a single token of 5+ characters. Single tokens of ≤4 chars are kept as acronyms; names that already carry a lowercase letter are left as-is. `COLLATE "default"` makes `initcap` use the DB's UTF-8 collation — the `name` column is POSIX-collated, under which a bare `initcap` corrupts accented letters (`MÉXICO`→`MÉXico`).

## Why Houston-only (dry-run across all prod sites)
I ran a **read-only** preview of this exact rule against every production city schema. Rather than blindly sweep everyone, the results showed the other ALL-CAPS cities need a human pass first:

| City | Would change | Notes |
|---|---|---|
| **houston** | 88 / 88 | ✅ all clean — the target |
| cdmx | 1685 / 1811 | deferred — Spanish `de`/`del` capitalization, 93% of the city |
| la_piedad | 55 / 62 | deferred — Spanish conventions |
| rancagua / la / clifton | 7 / 3 / 1 | deferred — local abbreviations (`UV`, `PSE&G`, `P.I.C.O.`) `initcap` would mangle |
| everyone else (Seattle, Taiwan cities, Zurich, Amsterdam, São Paulo…) | 0 | untouched |

Those local conventions (Spanish connector words, "Unidad Vecinal" codes, dotted org acronyms) can't be handled by a blind `initcap`, so they're deferred to per-city review. The importer fix still future-proofs all new cities.

## Verification
- Read-only dry-run across all prod city schemas (+ the legacy DC db) — table above.
- `COLLATE "default"` fix verified on the real POSIX column (`El Malecón`, `Juárez`, `Lázaro Cárdenas`).
- Evolution parses and is a clean no-op locally (`current_schema()` guard); `make lint-evolutions` clean; importer `CASE` exercised end-to-end.
- `region.name` is the sole store, and the v3 API name filter is case-insensitive (`LOWER(...) = LOWER(...)`), so lookups are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
