### PR TITLE
Banner: align wrapped mobile pill with the text column

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1079,9 +1079,14 @@ kbd {
     margin-top: 1px;
   }
 
-  /* Actions drop to their own row: pill anchored left, close anchored right, spanning the full width. */
+  /*
+   * Actions drop to their own full-width row: indent the pill to the message's text column (icon width + row gap)
+   * so it lines up under the text rather than the icon, while the close stays anchored at the right edge.
+   */
   .test-server-banner-actions {
+    box-sizing: border-box;
     width: 100%;
+    padding-inline-start: 30px;
     justify-content: space-between;
   }
 


### PR DESCRIPTION
Small follow-up to #4611.

On narrow viewports the test-server banner's actions row wraps below the message. It was anchored to the content's left edge (under the warning icon); this indents it to the message's text column (icon width + row gap, via `box-sizing: border-box` + `padding-inline-start`) so the "Don't show again" pill lines up under the text. The close (×) button stays anchored at the right edge.

CSS-only, mobile media query only (`width <= 600px`). Stylelint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)