### PR TITLE
Prep for v11.7.0 release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import com.typesafe.sbt.packager.MappingsHelper.directory
 
 name := """sidewalk-webpage"""
 
-version := "11.6.1"
+version := "11.7.0"
 
 scalaVersion := "2.13.18"
 

--- a/conf/evolutions/default/340.sql
+++ b/conf/evolutions/default/340.sql
@@ -1,0 +1,5 @@
+# --- !Ups
+INSERT INTO version VALUES ('11.7.0', now(), 'Adds Lived Experience Stories, redesigns the navbar, label detail card, and Explore tutorial intro/outro screens, and improves database integrity.');
+
+# --- !Downs
+DELETE FROM version WHERE version_id = '11.7.0';


### PR DESCRIPTION
Prep for the v11.7.0 release (#4614): bumps `build.sbt` to 11.7.0 and adds evolution 340 with the release summary for the version table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)