### PR TITLE
Navbar menu polish: dropdown icons, account grouping, single-line responsive bar (#4567)

### DIFF
--- a/app/views/common/navbar.scala.html
+++ b/app/views/common/navbar.scala.html
@@ -39,40 +39,40 @@
         @* Explore is the single dominant call to action. It stays visible and is marked active on /explore (rather
            than being hidden), so the link set is stable page to page. *@
         <li class="navbar-lnk">
-          <a class="navbar-button@if(isExplore){ is-active}" id="navbar-start-btn" href="@routes.ExploreController.explore()"@if(isExplore){ aria-current="page"}>@Messages("navbar.explore")</a>
+          <a class="navbar-button@if(isExplore){ is-active}" id="navbar-start-btn" href="@routes.ExploreController.explore()"@if(isExplore){ aria-current="page"}>@common.navbarLnkIcon("compass")@Messages("navbar.explore")</a>
         </li>
         <li class="navbar-lnk">
-          <a class="navbar-button@if(request.path == "/validate"){ is-active}" id="navbar-validate-btn" href="@routes.ValidateController.validate()"@if(request.path == "/validate"){ aria-current="page"}>@Messages("navbar.validate")</a>
+          <a class="navbar-button@if(request.path == "/validate"){ is-active}" id="navbar-validate-btn" href="@routes.ValidateController.validate()"@if(request.path == "/validate"){ aria-current="page"}>@common.navbarLnkIcon("check-circle")@Messages("navbar.validate")</a>
         </li>
         @* Label Map is the results/output view — a top-level peer of the Explore (contribute) + Validate (verify) loop.
            `data-nav-shed` marks it droppable when the bar runs out of room (it stays reachable under Tools ▸ Analyze);
            see the shed order in Navbar.js. *@
         <li class="navbar-lnk" data-nav-shed="4">
-          <a class="navbar-button@if(request.path.toLowerCase == "/labelmap"){ is-active}" id="navbar-labelmap-btn" href="@routes.ApplicationController.labelMap(None)"@if(request.path.toLowerCase == "/labelmap"){ aria-current="page"}>@Messages("navbar.labelmap")</a>
+          <a class="navbar-button@if(request.path.toLowerCase == "/labelmap"){ is-active}" id="navbar-labelmap-btn" href="@routes.ApplicationController.labelMap(None)"@if(request.path.toLowerCase == "/labelmap"){ aria-current="page"}>@common.navbarLnkIcon("map")@Messages("navbar.labelmap")</a>
         </li>
         @* Retake Tutorial and Help are genuine /explore-only features, not the current page hidden. *@
         @if(isExplore) {
           <li class="navbar-lnk">
-            <a class="navbar-button" href="#" id="navbar-retake-tutorial-btn">@Messages("navbar.retake.tutorial")</a>
+            <a class="navbar-button" href="#" id="navbar-retake-tutorial-btn">@common.navbarLnkIcon("play-circle")@Messages("navbar.retake.tutorial")</a>
           </li>
         }
         <li class="navbar-lnk" data-nav-shed="1">
         @if(currentCityInfo.countryId == "taiwan") {
-          <a class="navbar-button" id="navbar-guide-btn" href="@assets.path("documents/labeling-guide-Taiwan.pdf")" target="_blank" rel="noopener">@Messages("navbar.howto")</a>
+          <a class="navbar-button" id="navbar-guide-btn" href="@assets.path("documents/labeling-guide-Taiwan.pdf")" target="_blank" rel="noopener">@common.navbarLnkIcon("book-open")@Messages("navbar.howto")</a>
         } else {
-          <a class="navbar-button" id="navbar-guide-btn" href="@routes.ApplicationController.labelingGuide" target="_blank" rel="noopener">@Messages("navbar.howto")</a>
+          <a class="navbar-button" id="navbar-guide-btn" href="@routes.ApplicationController.labelingGuide" target="_blank" rel="noopener">@common.navbarLnkIcon("book-open")@Messages("navbar.howto")</a>
         }
         </li>
         @if(isExplore) {
           <li class="navbar-lnk" data-nav-shed="3">
-            <a class="navbar-button" id="navbar-help-btn" href='@routes.ApplicationController.help' target="_blank" rel="noopener">@Messages("navbar.help")</a>
+            <a class="navbar-button" id="navbar-help-btn" href='@routes.ApplicationController.help' target="_blank" rel="noopener">@common.navbarLnkIcon("help-circle")@Messages("navbar.help")</a>
           </li>
         }
 
         @* Tools: grouped into labeled sections so the menu stays scannable as tools are added. *@
         <li class="dropdown navbar-lnk" id="navbar-tools-dropdown-list">
           <button type="button" id="nav-tools-dropdown" class="navbar-button navbar-dropdown-toggle@if(toolsToggleActive){ is-active}" data-nav-dropdown aria-haspopup="true" aria-expanded="false" aria-controls="nav-tools-menu">
-            @Messages("navbar.tools")<b class="caret" aria-hidden="true"></b>
+            @common.navbarLnkIcon("tool")@Messages("navbar.tools")<b class="caret" aria-hidden="true"></b>
           </button>
           <ul id="nav-tools-menu" class="dropdown-menu" aria-label="@Messages("navbar.tools")">
             <li class="dropdown-section">@Messages("navbar.tools.analyze")</li>
@@ -90,7 +90,7 @@
         </li>
 
         <li class="navbar-lnk" data-nav-shed="2">
-          <a class="navbar-button" id="navbar-api-btn" href="@routes.ApiDocsController.index" aria-label="Developer API">@Messages("navbar.api")</a>
+          <a class="navbar-button" id="navbar-api-btn" href="@routes.ApiDocsController.index" aria-label="Developer API">@common.navbarLnkIcon("code")@Messages("navbar.api")</a>
         </li>
       </ul>
 
@@ -177,7 +177,7 @@
         } else {
           @* Real href so it works on pages without the dialog (e.g. /signIn itself); AuthModal intercepts the
              click to open the dialog everywhere else. *@
-          <a id="navbar-sign-in-btn" href="@routes.UserController.signIn()" data-au-open="signIn" class="navbar-button">@Messages("navbar.signin")</a>
+          <a id="navbar-sign-in-btn" href="@routes.UserController.signIn()" data-au-open="signIn" class="navbar-button">@common.navbarLnkIcon("log-in")@Messages("navbar.signin")</a>
         }
         </li>
 

--- a/app/views/common/navbar.scala.html
+++ b/app/views/common/navbar.scala.html
@@ -44,8 +44,10 @@
         <li class="navbar-lnk">
           <a class="navbar-button@if(request.path == "/validate"){ is-active}" id="navbar-validate-btn" href="@routes.ValidateController.validate()"@if(request.path == "/validate"){ aria-current="page"}>@Messages("navbar.validate")</a>
         </li>
-        @* Label Map is the results/output view — a top-level peer of the Explore (contribute) + Validate (verify) loop. *@
-        <li class="navbar-lnk">
+        @* Label Map is the results/output view — a top-level peer of the Explore (contribute) + Validate (verify) loop.
+           `data-nav-shed` marks it droppable when the bar runs out of room (it stays reachable under Tools ▸ Analyze);
+           see the shed order in Navbar.js. *@
+        <li class="navbar-lnk" data-nav-shed="4">
           <a class="navbar-button@if(request.path.toLowerCase == "/labelmap"){ is-active}" id="navbar-labelmap-btn" href="@routes.ApplicationController.labelMap(None)"@if(request.path.toLowerCase == "/labelmap"){ aria-current="page"}>@Messages("navbar.labelmap")</a>
         </li>
         @* Retake Tutorial and Help are genuine /explore-only features, not the current page hidden. *@
@@ -54,7 +56,7 @@
             <a class="navbar-button" href="#" id="navbar-retake-tutorial-btn">@Messages("navbar.retake.tutorial")</a>
           </li>
         }
-        <li class="navbar-lnk nav-shed-1">
+        <li class="navbar-lnk" data-nav-shed="1">
         @if(currentCityInfo.countryId == "taiwan") {
           <a class="navbar-button" id="navbar-guide-btn" href="@assets.path("documents/labeling-guide-Taiwan.pdf")" target="_blank" rel="noopener">@Messages("navbar.howto")</a>
         } else {
@@ -62,7 +64,7 @@
         }
         </li>
         @if(isExplore) {
-          <li class="navbar-lnk">
+          <li class="navbar-lnk" data-nav-shed="3">
             <a class="navbar-button" id="navbar-help-btn" href='@routes.ApplicationController.help' target="_blank" rel="noopener">@Messages("navbar.help")</a>
           </li>
         }
@@ -74,20 +76,20 @@
           </button>
           <ul id="nav-tools-menu" class="dropdown-menu" aria-label="@Messages("navbar.tools")">
             <li class="dropdown-section">@Messages("navbar.tools.analyze")</li>
-            <li><a id="navbar-gallery-btn" href="@routes.GalleryController.gallery()"@if(curPath == "/gallery"){ class="is-active" aria-current="page"}>@Messages("gallery")</a></li>
-            <li><a id="navbar-labelmap-btn-tools" href="@routes.ApplicationController.labelMap(None)"@if(curPath == "/labelmap"){ class="is-active" aria-current="page"}>@Messages("navbar.labelmap")</a></li>
+            <li><a id="navbar-gallery-btn" href="@routes.GalleryController.gallery()"@if(curPath == "/gallery"){ class="is-active" aria-current="page"}>@common.navbarMenuIcon("grid")@Messages("gallery")</a></li>
+            <li><a id="navbar-labelmap-btn-tools" href="@routes.ApplicationController.labelMap(None)"@if(curPath == "/labelmap"){ class="is-active" aria-current="page"}>@common.navbarMenuIcon("map")@Messages("navbar.labelmap")</a></li>
             <li class="dropdown-section">@Messages("navbar.tools.community")</li>
-            <li><a id="navbar-leaderboard-btn" href='@routes.UserDashboardController.leaderboard'@if(curPath == "/leaderboard"){ class="is-active" aria-current="page"}>@Messages("navbar.leaderboard")</a></li>
+            <li><a id="navbar-leaderboard-btn" href='@routes.UserDashboardController.leaderboard'@if(curPath == "/leaderboard"){ class="is-active" aria-current="page"}>@common.navbarMenuIcon("award")@Messages("navbar.leaderboard")</a></li>
             <li class="dropdown-section">@Messages("navbar.tools.build")</li>
-            <li><a id="navbar-route-builder-btn" href='@routes.ApplicationController.routeBuilder'@if(curPath == "/routebuilder"){ class="is-active" aria-current="page"}>@Messages("routebuilder.name")</a></li>
+            <li><a id="navbar-route-builder-btn" href='@routes.ApplicationController.routeBuilder'@if(curPath == "/routebuilder"){ class="is-active" aria-current="page"}>@common.navbarMenuIcon("navigation")@Messages("routebuilder.name")</a></li>
             @if(isAdmin) {
               <li class="dropdown-section">@Messages("navbar.tools.admin")</li>
-              <li><a id="navbar-expert-validate-btn-tools" href='@routes.ValidateController.expertValidate()'@if(curPath == "/expertvalidate" || curPath == "/adminvalidate"){ class="is-active" aria-current="page"}>@Messages("navbar.expert.validate")</a></li>
+              <li><a id="navbar-expert-validate-btn-tools" href='@routes.ValidateController.expertValidate()'@if(curPath == "/expertvalidate" || curPath == "/adminvalidate"){ class="is-active" aria-current="page"}>@common.navbarMenuIcon("check-square")@Messages("navbar.expert.validate")</a></li>
             }
           </ul>
         </li>
 
-        <li class="navbar-lnk nav-shed-2">
+        <li class="navbar-lnk" data-nav-shed="2">
           <a class="navbar-button" id="navbar-api-btn" href="@routes.ApiDocsController.index" aria-label="Developer API">@Messages("navbar.api")</a>
         </li>
       </ul>
@@ -134,30 +136,42 @@
         <li class="dropdown navbar-lnk" id="navbar-user-dropdown-list">
         @if(user.isDefined && user.get.role != "Anonymous") {
           <button type="button" id="nav-user-dropdown" class="navbar-button navbar-dropdown-toggle@if(userToggleActive){ is-active}" data-nav-dropdown aria-haspopup="true" aria-expanded="false" aria-controls="nav-user-menu" aria-label="User options for @user.get.username">
-            <img class="navbar-select-icon" src='@assets.path("images/icons/user-feather.svg")' alt="" aria-hidden="true">@user.get.username<b class="caret" aria-hidden="true"></b>
+            <img class="navbar-select-icon" src='@assets.path("images/icons/user-feather.svg")' alt="" aria-hidden="true"><span class="navbar-user-name">@user.get.username</span><b class="caret" aria-hidden="true"></b>
           </button>
+          @* Section headers only appear for admins: their menu carries a second, unrelated group of links, while a
+             contributor's handful of account links reads better as one flat list. *@
           <ul id="nav-user-menu" class="dropdown-menu" aria-label="User options for @user.get.username">
-            <li>
-              <a id="navbar-dashboard-btn" href='@routes.UserDashboardController.dashboard'@if(curPath == "/dashboard"){ class="is-active" aria-current="page"}>@Messages("navbar.dashboard")</a>
-            </li>
-            @if(user.get.role == "Administrator" || user.get.role == "Owner") {
-              <li>
-                <a id="navbar-admin-btn" href='@routes.AdminDashboardController.overview'@if(curPath == "/admin" || curPath == "/admin/overview"){ class="is-active" aria-current="page"}>@Messages("navbar.admin")</a>
-              </li>
-              <li>
-                <a id="navbar-expert-validate-btn-user" href='@routes.ValidateController.expertValidate()'@if(curPath == "/expertvalidate" || curPath == "/adminvalidate"){ class="is-active" aria-current="page"}>@Messages("navbar.expert.validate")</a>
-              </li>
+            @if(isAdmin) {
+              <li class="dropdown-section">@Messages("navbar.user.account")</li>
             }
+            <li>
+              <a id="navbar-dashboard-btn" href='@routes.UserDashboardController.dashboard'@if(curPath == "/dashboard"){ class="is-active" aria-current="page"}>@common.navbarMenuIcon("bar-chart-2")@Messages("navbar.dashboard")</a>
+            </li>
+            @* Also lives under Tools ▸ Community; duplicated here because contributors look for their own standing
+               in their own menu. *@
+            <li>
+              <a id="navbar-leaderboard-btn-user" href='@routes.UserDashboardController.leaderboard'@if(curPath == "/leaderboard"){ class="is-active" aria-current="page"}>@common.navbarMenuIcon("award")@Messages("navbar.leaderboard")</a>
+            </li>
             @if(user.get.communityService) {
               <li>
-                <a id="navbar-service-hours-btn" href='@routes.ApplicationController.serviceHoursInstructions'@if(curPath == "/servicehoursinstructions"){ class="is-active" aria-current="page"}>@Messages("navbar.servicehours")</a>
+                <a id="navbar-service-hours-btn" href='@routes.ApplicationController.serviceHoursInstructions'@if(curPath == "/servicehoursinstructions"){ class="is-active" aria-current="page"}>@common.navbarMenuIcon("info")@Messages("navbar.servicehours")</a>
               </li>
               <li>
-                <a id="navbar-time-check-btn" href='@routes.ApplicationController.timeCheck'@if(curPath == "/timecheck"){ class="is-active" aria-current="page"}>@Messages("navbar.timecheck")</a>
+                <a id="navbar-time-check-btn" href='@routes.ApplicationController.timeCheck'@if(curPath == "/timecheck"){ class="is-active" aria-current="page"}>@common.navbarMenuIcon("clock")@Messages("navbar.timecheck")</a>
               </li>
             }
+            @if(isAdmin) {
+              <li class="dropdown-section">@Messages("navbar.tools.admin")</li>
+              <li>
+                <a id="navbar-admin-btn" href='@routes.AdminDashboardController.overview'@if(curPath == "/admin" || curPath == "/admin/overview"){ class="is-active" aria-current="page"}>@common.navbarMenuIcon("shield")@Messages("navbar.admin")</a>
+              </li>
+              <li>
+                <a id="navbar-expert-validate-btn-user" href='@routes.ValidateController.expertValidate()'@if(curPath == "/expertvalidate" || curPath == "/adminvalidate"){ class="is-active" aria-current="page"}>@common.navbarMenuIcon("check-square")@Messages("navbar.expert.validate")</a>
+              </li>
+            }
+            <li class="dropdown-divider" role="separator"></li>
             <li>
-              <a id="navbar-sign-out-btn" href='@routes.UserController.signOut(request.uri)'>@Messages("navbar.signout")</a>
+              <a id="navbar-sign-out-btn" href='@routes.UserController.signOut(request.uri)'>@common.navbarMenuIcon("log-out")@Messages("navbar.signout")</a>
             </li>
           </ul>
         } else {
@@ -170,7 +184,7 @@
         <li class="dropdown navbar-lnk" id="language-dropdown">
           <button type="button" class="navbar-button navbar-dropdown-toggle" id="language-button" data-nav-dropdown aria-haspopup="true" aria-expanded="false" aria-controls="nav-language-menu" aria-label="@Messages("navbar.lang.aria")">
             <img id="language-icon" src='@assets.path("images/icons/globe-feather.svg")' alt="@Messages("navbar.lang.icon.alt")">
-            @Messages(s"lang.name.${messages.lang.code}")<b class="caret" aria-hidden="true"></b>
+            <span class="navbar-lang-label">@Messages(s"lang.name.${messages.lang.code}")</span><b class="caret" aria-hidden="true"></b>
           </button>
           <ul id="nav-language-menu" class="dropdown-menu" aria-label="@Messages("navbar.lang.aria")">
           @for(language <- config.get[Seq[String]]("play.i18n.langs")) {

--- a/app/views/common/navbarLnkIcon.scala.html
+++ b/app/views/common/navbarLnkIcon.scala.html
@@ -1,0 +1,6 @@
+@(icon: String)(implicit assets: AssetsFinder)
+@* Leading icon for a top-level navbar destination. Hidden in the inline bar — where the destinations are deliberately
+   plain text links — and revealed in the stacked hamburger panel, so that menu reads as one icon column top to bottom
+   alongside the city/account/language selectors, which carry their icons at every width. Same shared feather set as
+   the dropdown items (docs/style-guide.md); the alt is empty because the item's own text is the accessible name. *@
+<img class="navbar-lnk-icon" src='@assets.path("images/icons/" + icon + "-feather.svg")' alt="" aria-hidden="true">

--- a/app/views/common/navbarMenuIcon.scala.html
+++ b/app/views/common/navbarMenuIcon.scala.html
@@ -1,0 +1,5 @@
+@(icon: String)(implicit assets: AssetsFinder)
+@* Leading icon for an item in a navbar dropdown. `icon` is the base name of a feather SVG in images/icons/, so the
+   menus stay on the shared icon set (docs/style-guide.md) rather than each item hand-rolling a path. The alt is empty
+   because the item's own text is the accessible name. *@
+<img class="dropdown-icon" src='@assets.path("images/icons/" + icon + "-feather.svg")' alt="" aria-hidden="true">

--- a/conf/messages/messages.de
+++ b/conf/messages/messages.de
@@ -98,6 +98,7 @@ navbar.tools.analyze = Analysieren
 navbar.tools.community = Community
 navbar.tools.build = Erstellen
 navbar.tools.admin = Verwaltung
+navbar.user.account = Konto
 navbar.city.search = Städte suchen…
 navbar.city.viewall = Alle Städte auf der Karte anzeigen
 navbar.city.none = Keine passenden Städte

--- a/conf/messages/messages.en
+++ b/conf/messages/messages.en
@@ -101,6 +101,7 @@ navbar.tools.analyze = Analyze
 navbar.tools.community = Community
 navbar.tools.build = Build
 navbar.tools.admin = Admin
+navbar.user.account = Account
 navbar.city.search = Search cities…
 navbar.city.viewall = View all cities on the map
 navbar.city.none = No matching cities

--- a/conf/messages/messages.es
+++ b/conf/messages/messages.es
@@ -107,6 +107,7 @@ navbar.tools.analyze = Analizar
 navbar.tools.community = Comunidad
 navbar.tools.build = Crear
 navbar.tools.admin = Administración
+navbar.user.account = Cuenta
 navbar.city.search = Buscar ciudades…
 navbar.city.viewall = Ver todas las ciudades en el mapa
 navbar.city.none = No hay ciudades que coincidan

--- a/conf/messages/messages.nl
+++ b/conf/messages/messages.nl
@@ -95,6 +95,7 @@ navbar.tools.analyze = Analyseren
 navbar.tools.community = Community
 navbar.tools.build = Bouwen
 navbar.tools.admin = Beheer
+navbar.user.account = Account
 navbar.city.search = Steden zoeken…
 navbar.city.viewall = Alle steden op de kaart bekijken
 navbar.city.none = Geen overeenkomende steden

--- a/conf/messages/messages.pt-BR
+++ b/conf/messages/messages.pt-BR
@@ -103,6 +103,7 @@ navbar.tools.analyze = Analisar
 navbar.tools.community = Comunidade
 navbar.tools.build = Criar
 navbar.tools.admin = Administração
+navbar.user.account = Conta
 navbar.city.search = Buscar cidades…
 navbar.city.viewall = Ver todas as cidades no mapa
 navbar.city.none = Nenhuma cidade correspondente

--- a/conf/messages/messages.zh-TW
+++ b/conf/messages/messages.zh-TW
@@ -166,6 +166,7 @@ navbar.tools.analyze = 分析
 navbar.tools.community = 社群
 navbar.tools.build = 建立
 navbar.tools.admin = 管理
+navbar.user.account = 帳戶
 navbar.city.search = 搜尋城市…
 navbar.city.viewall = 在地圖上檢視所有城市
 navbar.city.none = 沒有符合的城市

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -413,6 +413,10 @@ a {
   display: inline-flex;
   align-items: center;
   gap: 3px;
+
+  /* A navbar item never wraps: the bar is a fixed-height single line, so a wrapped label overflows it. Items are
+     shed instead when space runs short (see Navbar.js). */
+  white-space: nowrap;
   cursor: pointer;
   color: var(--color-asphalt-500);
   font-size: 13px;
@@ -1104,6 +1108,34 @@ kbd {
   list-style: none;
   margin: 0;
   padding: 0;
+
+  /* Neither group compresses: squeezing is what forced labels onto a second line. When the two groups no longer fit
+     side by side, Navbar.js sheds items instead. */
+  flex: none;
+}
+
+.navbar-nav > li {
+  flex: none;
+}
+
+/* Applied by Navbar.js to items dropped from the inline bar; each one stays reachable elsewhere (site footer, or
+   the Tools menu for Label Map), and all of them return in the stacked hamburger panel. */
+.navbar-nav > li.is-shed {
+  display: none;
+}
+
+/* Last step before the hamburger: the language selector keeps its globe icon and drops its label. The button's
+   aria-label still names the control, so this is visual only. */
+#language-dropdown.is-compact .navbar-lang-label {
+  display: none;
+}
+
+/* A long username can't be allowed to push the bar past its width. */
+.navbar-user-name {
+  display: block;
+  max-width: 14ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 /* Dropdown panels are hidden until Navbar.js adds .is-open to the wrapping .navbar-lnk. */
@@ -1135,12 +1167,35 @@ kbd {
 }
 
 .dropdown-menu li > a {
-  display: block;
+  display: flex;
+  align-items: center;
+  gap: 10px;
   padding: 5px 16px;
   font-size: 13px;
   color: var(--color-asphalt-600);
   text-decoration: none;
   white-space: nowrap;
+}
+
+/* Leading icon on a menu item; sized to the 13px item text, never shrinking as labels get long. */
+.dropdown-icon {
+  width: 16px;
+  height: 16px;
+  flex: none;
+  opacity: 0.75;
+}
+
+.dropdown-menu li > a:hover .dropdown-icon,
+.dropdown-menu li > a:focus .dropdown-icon,
+.dropdown-menu li > a.is-active .dropdown-icon {
+  opacity: 1;
+}
+
+/* Rule setting Sign out apart from the destinations above it. */
+.dropdown-divider {
+  height: 1px;
+  margin: 6px 0;
+  background-color: var(--color-neutral-200);
 }
 
 .dropdown-menu li > a:hover,
@@ -1162,9 +1217,9 @@ kbd {
   box-shadow: inset 3px 0 0 var(--color-banana-600);
 }
 
-/* Non-interactive section labels grouping the Tools menu. */
+/* Non-interactive section labels grouping a menu's items. */
 .dropdown-section {
-  padding: 8px 16px 2px;
+  padding: 12px 16px 2px;
   font-size: 10px;
   font-weight: 700;
   letter-spacing: 0.06em;
@@ -1477,21 +1532,10 @@ kbd {
 /*
 * Responsive navigation.
 *
-* As the window narrows, the lowest-priority items are shed from the inline bar (How to Label first, then API;
-* both stay reachable in the footer) before the whole nav collapses into the hamburger menu. Breakpoints below are a
-* first pass tuned for English label widths and are meant to be adjusted by eye.
+* Shedding lower-priority items as the window narrows is measured at runtime in Navbar.js rather than pinned to
+* breakpoints here, because the widths that matter depend on the active language's label lengths and on the
+* signed-in username. Only the collapse-to-hamburger step below is a fixed breakpoint.
 */
-@media only screen and (width >= 861px) and (width <= 1100px) {
-  .nav-shed-1 {
-    display: none;
-  }
-}
-
-@media only screen and (width >= 861px) and (width <= 1000px) {
-  .nav-shed-2 {
-    display: none;
-  }
-}
 
 /*
 * Hamburger menu: at the narrowest widths the whole nav collapses into a single stacked menu opened by the

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -471,6 +471,15 @@ a {
   background-color: var(--color-neutral-300);
 }
 
+/* Leading icon on a top-level destination. The inline bar keeps its destinations as plain text links, so this shows
+   only in the stacked hamburger panel (see the breakpoint below). */
+.navbar-lnk-icon {
+  display: none;
+  width: 16px;
+  height: 16px;
+  flex: none;
+}
+
 /* Leading icon on each selector pill (city / account / language); keeps the three the same height. */
 .navbar-select-icon {
   width: 16px;
@@ -1620,6 +1629,22 @@ kbd {
     width: 100%;
     display: flex;
     justify-content: flex-start;
+
+    /* One padding and one gap for every row — including the city/language pills, which carry different values in the
+       inline bar — so the icons form a single column and the labels start on a single edge. */
+    padding: 6px 16px;
+    gap: 10px;
+  }
+
+  /* Carries its own padding in the inline bar, at a higher specificity than the rule above. */
+  .navbar-nav > li > .navbar-button#language-button {
+    padding: 6px 16px;
+  }
+
+  /* Destination icons are the stacked menu's reason for existing: with them the panel reads as one icon column
+     top to bottom, matching the selector pills that show theirs at every width. */
+  .navbar-lnk-icon {
+    display: block;
   }
 
   .navbar-nav--primary::before {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1634,6 +1634,10 @@ kbd {
        inline bar — so the icons form a single column and the labels start on a single edge. */
     padding: 6px 16px;
     gap: 10px;
+
+    /* This vertical menu grows downward, so drop the bar's nowrap: a long translated label should wrap onto a second
+       line rather than be clipped by the panel's overflow: hidden. */
+    white-space: normal;
   }
 
   /* Carries its own padding in the inline bar, at a higher specificity than the rule above. */

--- a/public/images/icons/award-feather.svg
+++ b/public/images/icons/award-feather.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="12" cy="8" r="7" stroke="#242424" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<polyline points="8.21 13.89 7 23 12 20 17 23 15.79 13.88" stroke="#242424" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/images/icons/bar-chart-2-feather.svg
+++ b/public/images/icons/bar-chart-2-feather.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<line x1="18" y1="20" x2="18" y2="10" stroke="#242424" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<line x1="12" y1="20" x2="12" y2="4" stroke="#242424" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<line x1="6" y1="20" x2="6" y2="14" stroke="#242424" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/images/icons/book-open-feather.svg
+++ b/public/images/icons/book-open-feather.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z" stroke="#242424" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z" stroke="#242424" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/images/icons/check-circle-feather.svg
+++ b/public/images/icons/check-circle-feather.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" stroke="#242424" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<polyline points="22 4 12 14.01 9 11.01" stroke="#242424" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/images/icons/check-square-feather.svg
+++ b/public/images/icons/check-square-feather.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<polyline points="9 11 12 14 22 4" stroke="#242424" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11" stroke="#242424" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/images/icons/clock-feather.svg
+++ b/public/images/icons/clock-feather.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="12" cy="12" r="10" stroke="#242424" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<polyline points="12 6 12 12 16 14" stroke="#242424" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/images/icons/code-feather.svg
+++ b/public/images/icons/code-feather.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<polyline points="16 18 22 12 16 6" stroke="#242424" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<polyline points="8 6 2 12 8 18" stroke="#242424" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/images/icons/compass-feather.svg
+++ b/public/images/icons/compass-feather.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="12" cy="12" r="10" stroke="#242424" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<polygon points="16.24 7.76 14.12 14.12 7.76 16.24 9.88 9.88 16.24 7.76" stroke="#242424" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/images/icons/grid-feather.svg
+++ b/public/images/icons/grid-feather.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="3" y="3" width="7" height="7" stroke="#242424" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<rect x="14" y="3" width="7" height="7" stroke="#242424" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<rect x="14" y="14" width="7" height="7" stroke="#242424" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<rect x="3" y="14" width="7" height="7" stroke="#242424" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/images/icons/help-circle-feather.svg
+++ b/public/images/icons/help-circle-feather.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="12" cy="12" r="10" stroke="#242424" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" stroke="#242424" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<line x1="12" y1="17" x2="12.01" y2="17" stroke="#242424" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/images/icons/info-feather.svg
+++ b/public/images/icons/info-feather.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="12" cy="12" r="10" stroke="#242424" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<line x1="12" y1="16" x2="12" y2="12" stroke="#242424" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<line x1="12" y1="8" x2="12.01" y2="8" stroke="#242424" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/images/icons/log-in-feather.svg
+++ b/public/images/icons/log-in-feather.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4" stroke="#242424" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<polyline points="10 17 15 12 10 7" stroke="#242424" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<line x1="15" y1="12" x2="3" y2="12" stroke="#242424" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/images/icons/log-out-feather.svg
+++ b/public/images/icons/log-out-feather.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" stroke="#242424" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<polyline points="16 17 21 12 16 7" stroke="#242424" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<line x1="21" y1="12" x2="9" y2="12" stroke="#242424" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/images/icons/map-feather.svg
+++ b/public/images/icons/map-feather.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<polygon points="1 6 1 22 8 18 16 22 23 18 23 2 16 6 8 2 1 6" stroke="#242424" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<line x1="8" y1="2" x2="8" y2="18" stroke="#242424" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<line x1="16" y1="6" x2="16" y2="22" stroke="#242424" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/images/icons/navigation-feather.svg
+++ b/public/images/icons/navigation-feather.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<polygon points="3 11 22 2 13 21 11 13 3 11" stroke="#242424" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/images/icons/play-circle-feather.svg
+++ b/public/images/icons/play-circle-feather.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="12" cy="12" r="10" stroke="#242424" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<polygon points="10 8 16 12 10 16 10 8" stroke="#242424" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/images/icons/shield-feather.svg
+++ b/public/images/icons/shield-feather.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" stroke="#242424" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/images/icons/tool-feather.svg
+++ b/public/images/icons/tool-feather.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z" stroke="#242424" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/js/common/Navbar.js
+++ b/public/js/common/Navbar.js
@@ -22,6 +22,9 @@ class NavbarController {
   /** @type {?HTMLElement} The hamburger button; its visibility tells us the nav is in its stacked state. */
   #hamburger = null;
 
+  /** @type {HTMLElement[]} The two nav groups (primary, utility) whose combined width has to fit the bar. */
+  #navGroups = [];
+
   /**
    * Space-freeing steps for the inline bar, ordered lowest priority first. Each takes a boolean and applies or
    * clears its effect; #fitNav applies as few as will make the bar fit.
@@ -221,6 +224,7 @@ class NavbarController {
     this.#menu = document.getElementById('navbar');
     this.#hamburger = this.#nav.querySelector('[data-nav-toggle]');
     if (!this.#menu) return;
+    this.#navGroups = Array.from(this.#menu.querySelectorAll('.navbar-nav'));
 
     // Items opt in via data-nav-shed="<n>", n ascending from the first to be dropped.
     this.#shedSteps = Array.from(this.#menu.querySelectorAll('[data-nav-shed]'))
@@ -256,10 +260,22 @@ class NavbarController {
     for (const step of this.#shedSteps) step(false);
     if (stacked) return;
     for (const step of this.#shedSteps) {
-      // A few pixels of slack so items never sit flush against the edge of the available space.
-      if (this.#menu.scrollWidth <= this.#menu.clientWidth - 8) return;
+      if (this.#navFits()) return;
       step(true);
     }
+  }
+
+  /**
+   * @returns {boolean} Whether both nav groups currently fit side by side on one line.
+   */
+  #navFits() {
+    // #navbar is justify-content: space-between, so its children are spread to span the full width no matter how few
+    // remain — scrollWidth therefore reports the container's own width and can't reveal how much room is left. Sum the
+    // groups' own widths instead; they're flex: none, so each is already its intrinsic width.
+    const needed = this.#navGroups.reduce((sum, group) => sum + group.getBoundingClientRect().width, 0);
+
+    // Slack covers the gap between the groups plus a little breathing room, so items never sit flush together.
+    return needed <= this.#menu.clientWidth - 24;
   }
 
   /** Wires live client-side filtering of the city switcher, hiding empty country groups. */

--- a/public/js/common/Navbar.js
+++ b/public/js/common/Navbar.js
@@ -16,6 +16,19 @@ class NavbarController {
   /** @type {?{li: HTMLElement, btn: HTMLButtonElement}} The currently open dropdown, or null. */
   #current = null;
 
+  /** @type {?HTMLElement} The <div id="navbar"> holding both nav groups. */
+  #menu = null;
+
+  /** @type {?HTMLElement} The hamburger button; its visibility tells us the nav is in its stacked state. */
+  #hamburger = null;
+
+  /**
+   * Space-freeing steps for the inline bar, ordered lowest priority first. Each takes a boolean and applies or
+   * clears its effect; #fitNav applies as few as will make the bar fit.
+   * @type {Array<function(boolean): void>}
+   */
+  #shedSteps = [];
+
   /**
    * Click-target id → activity string logged for that navbar element.
    * @type {Object<string, string>}
@@ -33,6 +46,7 @@ class NavbarController {
     'navbar-gallery-btn': 'Click_module=Gallery',
     'navbar-expert-validate-btn-tools': 'Click_module=ExpertValidate_from=ToolsDropdown',
     'navbar-leaderboard-btn': 'Click_module=Leaderboard',
+    'navbar-leaderboard-btn-user': 'Click_module=Leaderboard_from=UserDropdown',
     'navbar-labelmap-btn': 'Click_module=LabelMap',
     'navbar-labelmap-btn-tools': 'Click_module=LabelMap_from=ToolsDropdown',
     'navbar-route-builder-btn': 'Click_module=RouteBuilder',
@@ -50,6 +64,7 @@ class NavbarController {
     this.#wireCitySearch();
     this.#wireGlobalHandlers();
     this.#wireLogging();
+    this.#wireResponsiveNav();
   }
 
   /**
@@ -196,6 +211,55 @@ class NavbarController {
       const open = menu.classList.toggle('is-open');
       toggle.setAttribute('aria-expanded', String(open));
     });
+  }
+
+  /**
+   * Sets up the progressive shedding that keeps the bar on one line, and re-runs it whenever the available width
+   * can have changed.
+   */
+  #wireResponsiveNav() {
+    this.#menu = document.getElementById('navbar');
+    this.#hamburger = this.#nav.querySelector('[data-nav-toggle]');
+    if (!this.#menu) return;
+
+    // Items opt in via data-nav-shed="<n>", n ascending from the first to be dropped.
+    this.#shedSteps = Array.from(this.#menu.querySelectorAll('[data-nav-shed]'))
+      .sort((a, b) => Number(a.dataset.navShed) - Number(b.dataset.navShed))
+      .map((li) => (on) => li.classList.toggle('is-shed', on));
+
+    const lang = document.getElementById('language-dropdown');
+    if (lang) this.#shedSteps.push((on) => lang.classList.toggle('is-compact', on));
+
+    let queued = false;
+    const update = () => {
+      if (queued) return;
+      queued = true;
+      requestAnimationFrame(() => {
+        queued = false;
+        this.#fitNav();
+      });
+    };
+    window.addEventListener('resize', update);
+    // Web fonts land after first paint and change every label's width, so re-fit once they're in.
+    if (document.fonts) document.fonts.ready.then(update);
+    this.#fitNav();
+  }
+
+  /**
+   * Keeps the inline bar on a single line: restores every item, then applies shed steps in priority order until the
+   * two nav groups fit. Measured at runtime rather than pinned to breakpoints, because the widths involved depend on
+   * the active language's labels and on the signed-in username.
+   */
+  #fitNav() {
+    // In the stacked hamburger panel each item has its own row, so everything is shown.
+    const stacked = this.#hamburger && this.#hamburger.offsetParent !== null;
+    for (const step of this.#shedSteps) step(false);
+    if (stacked) return;
+    for (const step of this.#shedSteps) {
+      // A few pixels of slack so items never sit flush against the edge of the available space.
+      if (this.#menu.scrollWidth <= this.#menu.clientWidth - 8) return;
+      step(true);
+    }
   }
 
   /** Wires live client-side filtering of the city switcher, hiding empty country groups. */


### PR DESCRIPTION
Polishes the navbar dropdowns and stops the top bar from wrapping. Closes #4567.

## What changed

**Dropdown polish**
- Tools and account menu items each carry a 16px feather icon, and dropdown sections get 12px of leading space so groups read as groups.
- The account menu gains Leaderboard, splits into Account/Admin sections for admins only, and separates Sign out with a rule.

**Single-line responsive bar**
- The inline bar can no longer wrap. Navbar buttons are `nowrap`, neither nav group shrinks, and `Navbar.js` measures the bar at runtime and sheds lower-priority items (How to Label → API → Help → Label Map → language label) until it fits. This replaces the fixed 1000/1100px breakpoints, which couldn't account for label lengths that vary by language or for long usernames.
- **Fix:** the first measurement pass compared `#navbar` `scrollWidth` vs `clientWidth`, but `#navbar` is `justify-content: space-between`, so its children always span the full width and the two are always equal — every shed step fired at any width (the bar showed only Explore/Validate/Tools even at 1400px+). Now it sums the two nav groups' own widths (each is `flex: none`, so its intrinsic width) and compares against the available width.

**Icons in the stacked hamburger menu**
- Every top-level destination now has a leading feather icon that shows **only** in the stacked hamburger panel, so that menu reads as one clean icon column top to bottom, aligned with the city/account/language selectors. The wide inline bar keeps its destinations as plain text links. New `navbarLnkIcon` Twirl template + eight feather SVGs; hamburger rows share one padding/gap so the icons form a single column.

## Testing
- Frontend linters clean (ESLint, Stylelint, HTMLHint).
- Visually QA'd locally across widths, in both the inline and hamburger states, signed out and signed-in-as-admin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)