### PR TITLE
Explore: pano-ID seed falls back to street coordinates; clean abort when no imagery (#4635, #4636)

### DIFF
--- a/public/js/common/pano-viewer/src/PanoViewer.js
+++ b/public/js/common/pano-viewer/src/PanoViewer.js
@@ -27,6 +27,13 @@ class PanoViewer {
   povChangedListeners = [];
 
   /**
+   * Which initial seed successfully placed the viewer: 'pano' when startPanoId loaded, 'latLng' when a
+   * startLatLng/backupLatLngs candidate did. Undefined until _moveToInitialLocation() succeeds.
+   * @type {('pano'|'latLng'|undefined)}
+   */
+  initialSeed;
+
+  /**
    * Private constructor to prevent direct instantiation.
    */
   constructor() {
@@ -75,24 +82,35 @@ class PanoViewer {
   }
 
   /**
-   * Moves to the first initial location with usable imagery: startPanoId if given, otherwise startLatLng followed
-   * by each point in backupLatLngs. Called from subclasses' initialize() implementations.
+   * Moves to the first initial location with usable imagery: startPanoId if given, falling back to startLatLng
+   * followed by each point in backupLatLngs. Called from subclasses' initialize() implementations.
    * @param {object} panoOptions Object containing initialization options
-   * @param {string} [panoOptions.startPanoId] Pano to start at; used over the lat/lngs
+   * @param {string} [panoOptions.startPanoId] Pano to start at; tried before the lat/lngs
    * @param {{lat: number, lng: number}} [panoOptions.startLatLng] Preferred starting location
    * @param {Array<{lat: number, lng: number}>} [panoOptions.backupLatLngs=[]] Fallback locations, tried in order
-   * @returns {Promise<void>} Rejects with the last setLocation() error if every location fails
+   * @returns {Promise<void>} Rejects only when every given seed fails: with the last setLocation() error when
+   *     locations were given, otherwise with the setPano() error
    * @protected
    */
   async _moveToInitialLocation(panoOptions) {
     if (panoOptions.startPanoId) {
-      await this.setPano(panoOptions.startPanoId);
-    } else if (panoOptions.startLatLng) {
+      try {
+        await this.setPano(panoOptions.startPanoId);
+        this.initialSeed = 'pano';
+        return;
+      } catch (err) {
+        // A dead pano says nothing about the street (#4635), so fall through to the lat/lngs when we have them.
+        if (!panoOptions.startLatLng) throw err;
+      }
+    }
+    if (panoOptions.startLatLng) {
       const candidates = [panoOptions.startLatLng, ...(panoOptions.backupLatLngs ?? [])];
       let lastError;
       for (const latLng of candidates) {
         try {
-          return await this.setLocation(latLng);
+          await this.setLocation(latLng);
+          this.initialSeed = 'latLng';
+          return;
         } catch (err) {
           lastError = err;
         }

--- a/public/js/explore/src/Main.js
+++ b/public/js/explore/src/Main.js
@@ -65,8 +65,9 @@ class Main {
     svl.alertController = new AlertController();
     svl.stuckAlert = new StuckAlert(svl.alertController);
 
-    // The task's current position is the default start; an explicit pano seed (an admin auditing a street from a
-    // given pano/lat-lng, or an address drop-in per #4451) takes precedence.
+    // The task's current position is the default start; an explicit seed (an admin auditing a street from a given
+    // pano/lat-lng, or an address drop-in per #4451) takes precedence. A pano seed keeps the lat/lng alongside it as
+    // the fallback for a pano that fails to load (#4635).
     const startLat = params.startLat ?? params.task.properties.current_lat;
     const startLng = params.startLng ?? params.task.properties.current_lng;
     svl.panoStore = new PanoStore();
@@ -77,10 +78,12 @@ class Main {
     const newTask = new Task(params.task, isTutorialTask);
     let initParams;
     if (isTutorialTask) initParams = { startPanoId: 'tutorial' };
-    else if (params.startPanoId) initParams = { startPanoId: params.startPanoId };
-    else initParams = { startLat, startLng };
+    else initParams = { startPanoId: params.startPanoId, startLat, startLng };
     const errorParams = { task: newTask, missionId: params.mission.mission_id };
     svl.panoManager = await PanoManager.create(svl.viewerType, params.viewerAccessToken, initParams, errorParams);
+    // No viewer means PanoManager found no usable imagery and has already scheduled a redirect; stop initializing
+    // so nothing dereferences the missing viewer while the navigation lands.
+    if (!svl.panoViewer) return;
     const currLatLng = svl.panoViewer.getPosition();
     newTask.updateTheFurthestPointReached(currLatLng);
 

--- a/public/js/explore/src/panorama/PanoManager.js
+++ b/public/js/explore/src/panorama/PanoManager.js
@@ -28,9 +28,9 @@ class PanoManager {
    * @param {typeof PanoViewer} panoViewerType The type of pano viewer to initialize
    * @param {string} viewerAccessToken An access token used to request images for the pano viewer
    * @param {object} params Parameters that affect the initialization of the panorama viewer
-   * @param {string} [params.startPanoId] Optional starting pano, used over lat/lng
-   * @param {number} [params.startLat] Optional starting latitude, overridden by startPanoId
-   * @param {number} [params.startLng] Optional starting longitude, overridden by startPanoId
+   * @param {string} [params.startPanoId] Optional starting pano, tried before the lat/lng
+   * @param {number} [params.startLat] Optional starting latitude; the fallback if startPanoId fails to load
+   * @param {number} [params.startLng] Optional starting longitude; the fallback if startPanoId fails to load
    * @param {object} errorParams Params necessary in case loading the initial location fails
    * @param {Task} errorParams.task The assigned Task; used if no imagery is found to record the street
    * @param {number} errorParams.missionId The current mission ID; used if no imagery is found
@@ -73,25 +73,32 @@ class PanoManager {
       defaultNavigation: false, // We create our own navigation arrows.
     };
 
-    // Add the starting location to panoOptions.
+    // Add the starting location to panoOptions. A pano seed is tried first; the lat/lng (plus backups sampled along
+    // the street) doubles as its fallback, so a dead pano isn't misreported as a street with no imagery (#4635).
     if (params.startPanoId) {
       panoOptions.startPanoId = params.startPanoId;
-    } else if (params.startLat && params.startLng) {
+    }
+    if (params.startLat && params.startLng) {
       panoOptions.startLatLng = { lat: params.startLat, lng: params.startLng };
       panoOptions.backupLatLngs = PanoManager.#backupPointsAlongStreet(errorParams.task);
     }
 
     // Load the pano viewer.
-    svl.panoViewer = await panoViewerType.create(this.panoCanvas, panoOptions)
-      .catch(async () => {
-        // If no GSV at starting street, log it and refresh the page to get a new street.
-        await util.misc.reportNoImagery(errorParams.task, errorParams.missionId).then(() => {
-          window.location.replace('/explore');
-        });
-      });
+    try {
+      svl.panoViewer = await panoViewerType.create(this.panoCanvas, panoOptions);
+    } catch {
+      // No usable imagery anywhere on the street: record it and refresh the page to get a new street.
+      await util.misc.reportNoImagery(errorParams.task, errorParams.missionId);
+      // window.location.replace() doesn't halt execution, so bail out before the code below dereferences the
+      // missing viewer. Main.js sees the undefined svl.panoViewer and stops its own init the same way.
+      window.location.replace('/explore');
+      return;
+    }
 
-    // If we used a backup point closer to the end of the street, reverse the street direction.
-    if (panoOptions.startLatLng && panoOptions.backupLatLngs) {
+    // If we started from a lat/lng and used a backup point closer to the end of the street, reverse the street
+    // direction. An explicitly requested pano that loaded isn't a "couldn't start at the start" signal, so it
+    // doesn't reverse anything.
+    if (svl.panoViewer.initialSeed === 'latLng' && panoOptions.backupLatLngs) {
       const start = turf.point([params.startLng, params.startLat]);
       const end = turf.point([errorParams.task.getEndCoordinate().lng, errorParams.task.getEndCoordinate().lat]);
       const curr = turf.point([svl.panoViewer.getPosition().lng, svl.panoViewer.getPosition().lat]);

--- a/public/js/explore/src/panorama/PanoManager.js
+++ b/public/js/explore/src/panorama/PanoManager.js
@@ -78,7 +78,7 @@ class PanoManager {
     if (params.startPanoId) {
       panoOptions.startPanoId = params.startPanoId;
     }
-    if (params.startLat && params.startLng) {
+    if (Number.isFinite(params.startLat) && Number.isFinite(params.startLng)) {
       panoOptions.startLatLng = { lat: params.startLat, lng: params.startLng };
       panoOptions.backupLatLngs = PanoManager.#backupPointsAlongStreet(errorParams.task);
     }
@@ -86,8 +86,11 @@ class PanoManager {
     // Load the pano viewer.
     try {
       svl.panoViewer = await panoViewerType.create(this.panoCanvas, panoOptions);
-    } catch {
-      // No usable imagery anywhere on the street: record it and refresh the page to get a new street.
+    } catch (err) {
+      // Surface the error: creation can also fail for reasons beyond missing imagery (e.g. the maps library failing
+      // to load), and the redirect below would otherwise bury it.
+      console.error('Pano viewer creation failed at the starting location.', err);
+      // Record the street as having no usable imagery and refresh the page to get a new street.
       await util.misc.reportNoImagery(errorParams.task, errorParams.missionId);
       // window.location.replace() doesn't halt execution, so bail out before the code below dereferences the
       // missing viewer. Main.js sees the undefined svl.panoViewer and stops its own init the same way.

--- a/test/js/panoViewerSeedFallback.test.js
+++ b/test/js/panoViewerSeedFallback.test.js
@@ -1,0 +1,104 @@
+/**
+ * Tests for PanoViewer._moveToInitialLocation's seed ordering (issue #4635): a startPanoId seed is tried first, with
+ * startLatLng + backupLatLngs as its fallback, and a street is only declared imagery-less when every seed fails.
+ *
+ * PanoViewer is a top-level `class` declaration written for the Grunt-concatenation world, so we eval the source in
+ * the jsdom global scope. Its constructor compares `new.target` against the concrete viewer classes, so stub
+ * declarations for those names are eval'd ahead of the source.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const VIEWER_SRC = fs.readFileSync(
+    path.resolve(__dirname, '..', '..', 'public/js/common/pano-viewer/src/PanoViewer.js'), 'utf8'
+);
+
+/** Loads a fresh PanoViewer class into the jsdom global scope and returns it. */
+function loadPanoViewer() {
+    window.eval(`
+        class GsvViewer {}
+        class MapillaryViewer {}
+        class Infra3dViewer {}
+        class PannellumViewer {}
+        ${VIEWER_SRC}
+        window.PanoViewer = PanoViewer;
+    `);
+    return window.PanoViewer;
+}
+
+const START = { lat: 47.61, lng: -122.33 };
+const BACKUP_1 = { lat: 47.62, lng: -122.33 };
+const BACKUP_2 = { lat: 47.63, lng: -122.33 };
+
+describe('PanoViewer._moveToInitialLocation', () => {
+    /** A viewer whose setPano/setLocation record their calls and fail per the dead-set config. */
+    let TestViewer;
+
+    beforeEach(() => {
+        const PanoViewer = loadPanoViewer();
+        TestViewer = class extends PanoViewer {
+            calls = [];
+            deadPanoIds = new Set();
+            deadLatLngs = [];
+
+            setPano(panoId) {
+                this.calls.push(`pano:${panoId}`);
+                return this.deadPanoIds.has(panoId)
+                    ? Promise.reject(new Error(`dead pano: ${panoId}`))
+                    : Promise.resolve();
+            }
+
+            setLocation(latLng) {
+                this.calls.push(`loc:${latLng.lat}`);
+                return this.deadLatLngs.some((dead) => dead.lat === latLng.lat)
+                    ? Promise.reject(new Error(`no imagery at: ${latLng.lat}`))
+                    : Promise.resolve();
+            }
+        };
+    });
+
+    test('a loadable startPanoId wins and the lat/lngs are never consulted', async () => {
+        const viewer = new TestViewer();
+        await viewer._moveToInitialLocation({ startPanoId: 'abc', startLatLng: START, backupLatLngs: [BACKUP_1] });
+        expect(viewer.calls).toEqual(['pano:abc']);
+        expect(viewer.initialSeed).toBe('pano');
+    });
+
+    test('a dead startPanoId falls back to startLatLng, then each backup in order', async () => {
+        const viewer = new TestViewer();
+        viewer.deadPanoIds.add('abc');
+        viewer.deadLatLngs.push(START);
+        await viewer._moveToInitialLocation({
+            startPanoId: 'abc', startLatLng: START, backupLatLngs: [BACKUP_1, BACKUP_2],
+        });
+        expect(viewer.calls).toEqual(['pano:abc', `loc:${START.lat}`, `loc:${BACKUP_1.lat}`]);
+        expect(viewer.initialSeed).toBe('latLng');
+    });
+
+    test('a dead startPanoId with no lat/lng seed rejects with the setPano error', async () => {
+        const viewer = new TestViewer();
+        viewer.deadPanoIds.add('abc');
+        await expect(viewer._moveToInitialLocation({ startPanoId: 'abc' })).rejects.toThrow('dead pano: abc');
+        expect(viewer.calls).toEqual(['pano:abc']);
+        expect(viewer.initialSeed).toBeUndefined();
+    });
+
+    test('rejects with the last setLocation error when every seed fails', async () => {
+        const viewer = new TestViewer();
+        viewer.deadPanoIds.add('abc');
+        viewer.deadLatLngs.push(START, BACKUP_1);
+        await expect(viewer._moveToInitialLocation({
+            startPanoId: 'abc', startLatLng: START, backupLatLngs: [BACKUP_1],
+        })).rejects.toThrow(`no imagery at: ${BACKUP_1.lat}`);
+        expect(viewer.initialSeed).toBeUndefined();
+    });
+
+    test('lat/lng-only seeding tries the candidates in order', async () => {
+        const viewer = new TestViewer();
+        viewer.deadLatLngs.push(START);
+        await viewer._moveToInitialLocation({ startLatLng: START, backupLatLngs: [BACKUP_1] });
+        expect(viewer.calls).toEqual([`loc:${START.lat}`, `loc:${BACKUP_1.lat}`]);
+        expect(viewer.initialSeed).toBe('latLng');
+    });
+});

--- a/test/js/panoViewerSeedFallback.test.js
+++ b/test/js/panoViewerSeedFallback.test.js
@@ -35,7 +35,8 @@ describe('PanoViewer._moveToInitialLocation', () => {
     /** A viewer whose setPano/setLocation record their calls and fail per the dead-set config. */
     let TestViewer;
 
-    beforeEach(() => {
+    // The classes are stateless, so one eval serves every test (each test builds its own viewer instance).
+    beforeAll(() => {
         const PanoViewer = loadPanoViewer();
         TestViewer = class extends PanoViewer {
             calls = [];


### PR DESCRIPTION
## Summary

Fixes #4635. Fixes #4636.

**#4635 —** An Explore page seeded with a pano ID (`?panoId=`) had no fallback: when the pano couldn't load, the failure was treated as "street has no imagery", writing a bogus `street_edge_issue` row against a street that's usually fine and (for normal audit missions) completing the task off that false conclusion. Now `PanoViewer._moveToInitialLocation` tries the pano first and falls back to the seed lat/lng plus backup points sampled every 10 m along the street — the same candidate walk a coordinate seed already used — so `reportNoImagery` only fires when the whole street truly has no usable imagery. The logic lives in the shared `PanoViewer` base class, so GSV, Mapillary, and Infra3d all get the fallback; callers that seed a pano without coordinates (e.g. Validate) still get the rejection exactly as before.

**#4636 —** When viewer creation failed, the `.catch` scheduled a redirect but execution continued into `svl.panoViewer.getPosition()` / `#panoSuccessCallback(...)` on an undefined viewer — an unhandled TypeError racing the navigation. `PanoManager` now returns early after scheduling the redirect, and `Main.js` stops its own init when `svl.panoViewer` is missing (the same race would otherwise just move up one frame).

Details:

- A successful pano seed still skips the reverse-street-direction check (unchanged); the check now also runs when a pano seed fell back to coordinates, keyed off the new `PanoViewer.initialSeed` marker.
- New jsdom unit test pins the seed-fallback ordering: `test/js/panoViewerSeedFallback.test.js`.

## Testing

- `npx jest panoViewerSeedFallback` → 5/5 green (pano wins; dead pano → lat/lng → backups in order; pano-only rejection preserved; all-fail rejection; lat/lng-only ordering).
- ESLint clean on the three touched files.

### QA checklist (visual)

- [ ] Normal `/explore` load and the tutorial behave as before.
- [ ] Admin: `/explore?streetEdgeId=<id>&panoId=<bogus>` lands at the street's coordinates instead of bouncing to a new street, and writes **no** `street_edge_issue` row.
- [ ] Admin: the same URL with a valid pano ID still lands on that pano.
- [ ] A Mapillary city behaves the same (a dead Mapillary pano rejects via its 12 s timeout, then falls back).

🤖 Generated with [Claude Code](https://claude.com/claude-code)