### PR TITLE
Add Copilot code-review custom instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,7 +14,7 @@ Focus on correctness, domain rules, and the conventions in the path-scoped files
 - **Backend is the source of truth.** Flag hardcoded frontend literals that mirror
   backend domain values: label colors/icons, enum members, value ranges (min/max),
   thresholds, and especially mappings between them. Colors must come from
-  `util.misc.getLabelColors()`; other domain values from a `/v3/api/...` endpoint or
+  `util.misc.getLabelColors(labelType)`; other domain values from a `/v3/api/...` endpoint or
   a controller-injected view binding — never re-declared as a JS constant. Note:
   severity's good/ok/bad meaning is NOT fixed (positive vs negative features invert
   it), so flag any `{1:'good',2:'ok',3:'bad'}`-style literal.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,30 @@
+# Project Sidewalk — Copilot review guidance
+
+Crowdsourced sidewalk-accessibility mapping. Backend: Scala 2.13 + Play 3.0,
+Slick over Postgres/PostGIS. Frontend: vanilla JS (Grunt concat, no transpile),
+Twirl views. Schema via Play evolutions. Two i18n systems.
+
+## Don't duplicate the linters
+Formatting and mechanical style are enforced by blocking CI gates: scalafmt,
+ESLint, Stylelint, HTMLHint, locale key-parity. Do NOT spend review comments on
+formatting, whitespace, quote style, semicolons, import order, or line length.
+Focus on correctness, domain rules, and the conventions in the path-scoped files.
+
+## Cross-cutting rules to flag
+- **Backend is the source of truth.** Flag hardcoded frontend literals that mirror
+  backend domain values: label colors/icons, enum members, value ranges (min/max),
+  thresholds, and especially mappings between them. Colors must come from
+  `util.misc.getLabelColors()`; other domain values from a `/v3/api/...` endpoint or
+  a controller-injected view binding — never re-declared as a JS constant. Note:
+  severity's good/ok/bad meaning is NOT fixed (positive vs negative features invert
+  it), so flag any `{1:'good',2:'ok',3:'bad'}`-style literal.
+- **Comments say WHY, not WHAT.** Flag comments that restate the code, and
+  changelog/narration comments that only make sense against the diff. Tell-tale
+  words: "used to", "previously", "formerly", "replaces the old", "renamed
+  to/from", "no longer". Flag TODO/FIXME with no linked issue.
+- **i18n:** user-facing text changes need translations in all supported languages
+  (en, es, nl, zh-TW, de, pt-BR, en-US, en-NZ). See i18n instructions. EXCEPTION:
+  admin-only pages/routes (`app/views/admin/**`, `/admin/*`) ship English-only —
+  do not flag missing translations there.
+- **Accessibility:** new/changed UI must meet WCAG 2.1/2.2 AA — flag missing alt
+  text, unlabeled controls, non-token colors with poor contrast, keyboard traps.

--- a/.github/instructions/css.instructions.md
+++ b/.github/instructions/css.instructions.md
@@ -1,0 +1,17 @@
+---
+applyTo: "public/css/**/*.css"
+---
+# CSS review
+
+- **Design tokens (`main.css :root`):** colors via `--color-*`; type via composite
+  `--text-*` font shorthands (`font: var(--text-body-regular);`) — not raw
+  `--font-*` plus hand-picked size/weight. Flag hardcoded hex colors or
+  hand-assembled font stacks where a token fits.
+- **Never set numbers in the accent font (Raleway).** It uses old-style figures that
+  misalign; anything rendering digits (counts, stats, timers, %, dates) gets a
+  primary-font `--text-*` token, even inside an accent heading. Flag digits in a
+  Raleway/`--font-accent` token.
+- **Tool UI scaling:** for Explore/Validate/overlay UI, every fixed dimension
+  (padding, gap, width/height, border width/radius, raw font-size) must be
+  `calc(<n>px * var(--ui-scale, 1))`. `--text-*` tokens already bake it in. Flag
+  bare px. Fixed page chrome (navbar) is exempt.

--- a/.github/instructions/evolutions.instructions.md
+++ b/.github/instructions/evolutions.instructions.md
@@ -1,0 +1,27 @@
+---
+applyTo: "conf/evolutions/default/*.sql"
+---
+# Play evolution (schema) review — highest-value checks
+
+- **One evolution file per PR.** Flag a PR minting a new-numbered file when its
+  changes could fold into the PR's existing evolution.
+- **Owner:** every `CREATE TABLE` must be followed by
+  `ALTER TABLE <name> OWNER TO sidewalk;` in the same file. Flag any missing it.
+  Tables ONLY — not enum types, views, or standalone sequences; SERIAL/identity
+  sequences are covered automatically by the table's owner change.
+- **Full constraints — don't lean on the app.** For each new/altered table flag
+  missing: `NOT NULL` on never-null columns, `UNIQUE`/PK on natural keys & 1:1
+  relationships, a `FOREIGN KEY` for every reference, a `CHECK` for bounded domains
+  (severity 1–3, non-negative counts, 0–1 fractions, valid lat/lng). Each must be
+  mirrored in the Slick model.
+- **Closed value sets:** prefer a Postgres enum type (high-row / runtime-written /
+  Scala-mirrored columns) or a `CHECK (col IN (...))` (tiny config tables) over a
+  lookup table or bare text. When an enum replaces a same-named lookup table,
+  `DROP TABLE` must precede `CREATE TYPE`.
+- **Renames leave fossils.** An evolution renaming a table/column must also
+  `ALTER TABLE ... RENAME CONSTRAINT` / `ALTER INDEX ... RENAME` every constraint
+  and index embedding the old name (to `<table>_<column>_{fkey,key,pkey,check}`) and
+  update the Slick name string. Flag a rename that omits this.
+- **Parser trap:** no `;` inside a `-- comment` — Play's evolution parser splits
+  statements on `;` and will break. Flag it.
+- Both `# --- !Ups` and `# --- !Downs` sections must be present.

--- a/.github/instructions/frontend-js.instructions.md
+++ b/.github/instructions/frontend-js.instructions.md
@@ -1,0 +1,20 @@
+---
+applyTo: "public/js/**/*.js"
+---
+# Frontend JS review (ES2022 target)
+
+- Flag `var` (use const/let), string `+` concatenation for HTML (use template
+  literals), and jQuery AJAX where native `fetch` + Promises fit. Prefer arrow
+  functions in callbacks to keep `this` bound.
+- The constructor-function pattern (`function Foo(){ const self=this; ...; return
+  self }`) should be a `class` with `#private` fields. Flag new code using it.
+- **No hardcoded domain values** (see repo-wide rule): use
+  `util.misc.getLabelColors(labelType)` and `getIconImagePaths()`; source enum
+  members, ranges, and mappings from `/v3/api/...` or a view binding. Flag any
+  `{1:'good',2:'ok',3:'bad'}`-style severity map.
+- **Tool UI scaling:** in Explore, Validate, and overlays layered over them, every
+  fixed px dimension set from JS must be `calc(<n>px * var(--ui-scale, 1))`. Flag
+  bare px. (Fixed page chrome like the navbar is exempt.)
+- **JSDoc** on every class and non-trivial method (including `#private`); use
+  `@returns` (not `@return`) with a `{Type}`.
+- Prefer `data-i18n="ns:key"` over hardcoded English strings in generated HTML.

--- a/.github/instructions/frontend-js.instructions.md
+++ b/.github/instructions/frontend-js.instructions.md
@@ -9,7 +9,7 @@ applyTo: "public/js/**/*.js"
 - The constructor-function pattern (`function Foo(){ const self=this; ...; return
   self }`) should be a `class` with `#private` fields. Flag new code using it.
 - **No hardcoded domain values** (see repo-wide rule): use
-  `util.misc.getLabelColors(labelType)` and `getIconImagePaths()`; source enum
+  `util.misc.getLabelColors(labelType)` and `util.misc.getIconImagePaths(labelType)`; source enum
   members, ranges, and mappings from `/v3/api/...` or a view binding. Flag any
   `{1:'good',2:'ok',3:'bad'}`-style severity map.
 - **Tool UI scaling:** in Explore, Validate, and overlays layered over them, every

--- a/.github/instructions/i18n.instructions.md
+++ b/.github/instructions/i18n.instructions.md
@@ -1,0 +1,14 @@
+---
+applyTo: "conf/messages/**, public/locales/**"
+---
+# i18n review
+
+- Two systems: backend Play messages in `conf/messages/messages.<lang>`; frontend
+  JSON in `public/locales/{lang}/common.json`.
+- **English goes in `conf/messages/messages.en`, NEVER the base `messages` file.**
+  The base (no suffix) is the language-neutral fallback (proper nouns, way-type
+  keys) — flag translatable English prose added there.
+- **Key parity is a blocking CI gate:** every key must exist in every language file
+  (en, es, nl, de, pt-BR, zh-TW; en-US/en-NZ overlay en). Flag a key added to some
+  locales but not all — a missing key renders as the raw key string.
+- Admin-only strings are exempt (admin UI is English-only).

--- a/.github/instructions/scala.instructions.md
+++ b/.github/instructions/scala.instructions.md
@@ -1,0 +1,23 @@
+---
+applyTo: "app/**/*.scala, conf/routes, test/**/*.scala"
+---
+# Backend / v3 API review
+
+- **v3 API casing (`/v3/api/...`):** query/REST **parameters are camelCase**
+  (`minSeverity`, `regionId`); **all output field names are snake_case** — JSON
+  bodies, GeoJSON `properties`, CSV headers, GeoPackage fields (`label_id`,
+  `region_name`). Flag a snake_case query param or a camelCase output field. Use a
+  scoped `JsonConfiguration(JsonNaming.SnakeCase)` for macro writers. EXCEPTION:
+  Shapefile/DBF fields stay camelCase + abbreviated (DBF truncates names to 10 chars).
+- **API DTO home:** new response/filter DTOs go in `app/models/api/`
+  (`package models.api`), named `*ForApi` / `*FiltersForApi`, extending
+  `StreamingApiType` with inline `toJson`/`toCsvRow` and `csvHeader` in the
+  companion. Flag new API DTOs defined inside a `*Table.scala` file.
+- **Layering:** controllers stay thin — business logic in `app/service/`, DB access
+  in `app/models/*Table.scala`. Flag a controller querying tables directly.
+- **SQL:** no table aliases in Slick/plain SQL.
+- **ScalaDoc:** `/** */` on every class/trait/object and non-trivial method
+  (including private). Use `@return` (not `@returns`); don't repeat the type in
+  `@param`. Flag comments that narrate a change rather than state current behavior.
+- **`-Xfatal-warnings` is on:** flag unused imports/params, dead code, and discarded
+  non-Unit results — they fail the build.


### PR DESCRIPTION
## What

Adds custom instructions so **GitHub Copilot code review** reviews PRs against our own conventions instead of generic ones.

- `.github/copilot-instructions.md` — repo-wide anchor (project context + cross-cutting rules).
- `.github/instructions/*.instructions.md` — five path-scoped files, each with an `applyTo` glob so it only loads for matching files:
  | File | `applyTo` | Covers |
  |---|---|---|
  | `scala.instructions.md` | `app/**/*.scala, conf/routes, test/**/*.scala` | v3 API casing, DTO home, layering, ScalaDoc, `-Xfatal-warnings` |
  | `evolutions.instructions.md` | `conf/evolutions/default/*.sql` | one-file-per-PR, `OWNER TO sidewalk`, full constraints, enum-vs-CHECK, rename fossils, `;`-in-comment parser trap |
  | `frontend-js.instructions.md` | `public/js/**/*.js` | ES2022, no hardcoded domain values, `var(--ui-scale)`, JSDoc |
  | `css.instructions.md` | `public/css/**/*.css` | design tokens, Raleway-numbers rule, `var(--ui-scale)` |
  | `i18n.instructions.md` | `conf/messages/**, public/locales/**` | `messages.en` vs base, key parity, admin-English-only |

## Why

Distills the highest-signal, machine-checkable conventions from `CLAUDE.md` into review-framed guidance. A key design goal: steer Copilot **away** from duplicating our blocking linters (scalafmt / ESLint / Stylelint / HTMLHint / locale-parity) and **toward** correctness and domain-specific rules — the things a linter can't catch.

## Notes

- Additive only — new docs, no code touched, zero risk.
- Each path-scoped file is kept well under Copilot's instruction-size budget (GitHub warns against overly long instruction files); a file without `applyTo` is ignored, so every one includes it.
- These files are also read by Copilot in the IDE and the coding agent, so the payoff extends beyond PR review.
- **Not** enabling automatic Copilot review — these instructions only apply when a review is requested manually, so there's no per-PR credit cost unless someone opts in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)