### PR TITLE
Improve qa-worktree.sh: grunt watch auto-rebuild, clean exit, stop target (#4659)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -375,10 +375,14 @@ To QA an uncommitted branch that lives in a git **worktree** (`.claude/worktrees
 run **`make qa-worktree wt=<name>`** (the same on Mac, Linux, and WSL — all the setup runs inside the web container).
 It handles what the plain `npm start` flow doesn't for a worktree: symlink the main repo's `node_modules` (gitignored,
 so absent in worktrees), build that branch's JS/CSS bundles (also gitignored/absent — without them every page 404s its
-assets), free `:9000`, kill any stray `sbt --client` server sharing the worktree's `target/` (it deadlocks `~ run` on
-compile locks), and launch `sbt ~ run` with `-Dconfig.file` at the worktree's own conf and the sbt caches pointed at the
-main repo's warm `.coursier`/`.sbt` (cwd-relative caches from a worktree would re-download gigabytes). The first HTTP
-request triggers the dev compile; Ctrl-C stops it. Implementation: `tools/qa-worktree.sh`.
+assets), start a backgrounded **`grunt watch`** so later `public/js/**` / `public/css/**` edits rebuild the bundles
+automatically (a plain hard-reload always reflects the latest source — no manual reconcat), free `:9000`, kill any stray
+`sbt --client` server *or* hung `sbtn` task sharing the worktree's `target/` (either deadlocks `~ run` on compile locks),
+and launch `sbt ~ run` with `-Dconfig.file` at the worktree's own conf and the sbt caches pointed at the main repo's warm
+`.coursier`/`.sbt` (cwd-relative caches from a worktree would re-download gigabytes). The first HTTP request triggers the
+dev compile; **Ctrl-C stops the app and reaps the grunt watch** (a trap, so the watcher never lingers). To tear a session
+down out-of-band, run **`make qa-worktree-stop wt=<name>`** (add `clean=1` to also drop the `node_modules` symlink).
+Implementation: `tools/qa-worktree.sh`.
 
 **Admin-authenticated QA:** the dev DB is seeded from a dump that includes real accounts and their bcrypt password
 hashes, and password verification is config-independent (plain bcrypt, no server-side pepper), so if your own account is

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev docker-up docker-up-db docker-run docker-stop ssh qa-worktree test-python \
+.PHONY: dev docker-up docker-up-db docker-run docker-stop ssh qa-worktree qa-worktree-stop test-python \
         import-users import-dump create-new-schema fill-new-schema hide-streets-without-imagery \
         import-street-imagery reveal-or-hide-neighborhoods \
         lint lint-fix lint-evolutions lint-locales scalafmt scalafmt-fix \
@@ -13,6 +13,10 @@ db ?= sidewalk
 dir ?= ./
 args ?=
 wt ?=
+clean ?=
+
+# `clean=1` (or true/yes) expands to the qa-worktree-stop --clean flag; anything else (incl. empty) expands to nothing.
+qa-stop-clean-flag = $(if $(filter 1 true yes,$(clean)),--clean,)
 
 # ANSI colors for the `lint` summary.
 GREEN := \033[0;32m
@@ -78,6 +82,11 @@ ssh:
 # "Running a worktree's app for QA". e.g. `make qa-worktree wt=remove-admin-classic`.
 qa-worktree:
 	@docker exec -it $(web-container) bash /home/tools/qa-worktree.sh $(wt)
+
+# Tear down a qa-worktree session: stop its `~ run` and grunt watch. Add `clean=1` to also drop the node_modules
+# symlink. e.g. `make qa-worktree-stop wt=remove-admin-classic` or `make qa-worktree-stop wt=... clean=1`.
+qa-worktree-stop:
+	@docker exec $(web-container) bash /home/tools/qa-worktree.sh $(wt) --stop $(qa-stop-clean-flag)
 
 import-users:
 	@docker exec -it $(db-container) sh -c "/opt/scripts/import-users.sh"

--- a/tools/qa-worktree.sh
+++ b/tools/qa-worktree.sh
@@ -73,10 +73,14 @@ if [ "$MODE" = "stop" ]; then
   # SIGKILL anything that ignored the SIGTERM above.
   reap_in_worktree KILL 'grunt' "grunt watch"
   reap_in_worktree KILL '~ run' "app on :9000 (~ run)"
-  rm -f "$GRUNT_WATCH_LOG"
-  if [ -n "$CLEAN" ] && [ -L "$WT_DIR/node_modules" ]; then
-    rm -f "$WT_DIR/node_modules"
-    echo "==> removed node_modules symlink"
+  # --clean drops the gitignored setup artifacts too; keep the grunt watch log by default so a watch failure stays
+  # diagnosable after a stop.
+  if [ -n "$CLEAN" ]; then
+    rm -f "$GRUNT_WATCH_LOG"
+    if [ -L "$WT_DIR/node_modules" ]; then
+      rm -f "$WT_DIR/node_modules"
+      echo "==> removed node_modules symlink"
+    fi
   fi
   echo "==> done."
   exit 0

--- a/tools/qa-worktree.sh
+++ b/tools/qa-worktree.sh
@@ -3,33 +3,86 @@
 # Run an uncommitted git worktree's app on http://localhost:9000 for QA.
 #
 # Runs INSIDE the web container (the main repo is mounted at /home). Invoke via:
-#     make qa-worktree wt=<name>                 # from the host - Mac, Linux, or WSL
-#     bash /home/tools/qa-worktree.sh <name>     # from inside the container shell
+#     make qa-worktree wt=<name>                  # start; from the host - Mac, Linux, or WSL
+#     make qa-worktree-stop wt=<name> [clean=1]   # stop; teardown the session started above
+#     bash /home/tools/qa-worktree.sh <name>            # start; from inside the container shell
+#     bash /home/tools/qa-worktree.sh <name> --stop     # stop; add --clean to drop the node_modules symlink
 #
 # Handles the worktree-specific setup the plain `npm start` flow doesn't (node_modules,
-# bundles, sbt caches, config.file, thin-client contention). See CLAUDE.md ->
-# "Running a worktree's app for QA".
+# bundles, a backgrounded grunt watch, sbt caches, config.file, thin-client contention).
+# See CLAUDE.md -> "Running a worktree's app for QA".
 #
 set -euo pipefail
 
 WT="${1:-}"
-[ -n "$WT" ] || { echo "usage: qa-worktree <name>   (a dir under .claude/worktrees/)"; exit 2; }
+[ -n "$WT" ] || {
+  echo "usage: qa-worktree <name> [--stop] [--clean]   (a dir under .claude/worktrees/)"
+  exit 2
+}
 # Require a bare directory name so $WT can't escape the worktrees dir (e.g. "../..").
 case "$WT" in
   */* | . | ..) echo "error: wt must be a bare worktree directory name (no '/', '.', or '..')"; exit 2 ;;
 esac
-# procps' pgrep is used below to find the running app + thin-client servers; fail clearly if it's missing.
+# Parse the optional mode/flags after the worktree name.
+shift
+MODE="run"
+CLEAN=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --stop)  MODE="stop" ;;
+    --clean) CLEAN="1" ;;
+    *) echo "error: unknown argument: $1"; exit 2 ;;
+  esac
+  shift
+done
+# procps' pgrep is used below to find the running app + thin-client/watch servers; fail clearly if it's missing.
 command -v pgrep >/dev/null 2>&1 || { echo "error: pgrep not found — install procps in the web container"; exit 1; }
+
+WT_DIR="/home/.claude/worktrees/$WT"
+# grunt watch's log lives here (per-worktree) so `make qa-worktree-stop clean=1` can remove it.
+GRUNT_WATCH_LOG="/tmp/qa-worktree-grunt-watch-$WT.log"
 
 # True (exit 0) when something is listening on :9000 inside the container.
 port_9000_in_use() { (exec 3<>/dev/tcp/127.0.0.1/9000) 2>/dev/null; }
 
-WT_DIR="/home/.claude/worktrees/$WT"
+# Reap every process whose full command line matches $2 and whose working directory is this worktree, sending
+# signal $1. cwd-scoping is deliberate: it reaps only the sbt/grunt processes bound to *this* worktree (target/
+# contention, the backgrounded watch) and never touches the main repo's own sbt server or npm-start grunt watch.
+reap_in_worktree() {
+  local sig="$1" pattern="$2" label="$3" p
+  for p in $(pgrep -f "$pattern" 2>/dev/null || true); do
+    if [ "$(readlink "/proc/$p/cwd" 2>/dev/null || true)" = "$WT_DIR" ]; then
+      echo "==> killing $label (pid $p)"
+      kill "-$sig" "$p" 2>/dev/null || true
+    fi
+  done
+}
+
 if [ ! -d "$WT_DIR" ]; then
   echo "error: no worktree at $WT_DIR"
   echo "available worktrees:"; ls /home/.claude/worktrees
   exit 1
 fi
+
+# --- stop mode: tear down the session started by a prior launch, then exit. ------------------------------------
+if [ "$MODE" = "stop" ]; then
+  echo "==> stopping worktree QA session: $WT_DIR"
+  reap_in_worktree TERM 'grunt' "grunt watch"
+  reap_in_worktree TERM '~ run' "app on :9000 (~ run)"
+  sleep 2
+  # SIGKILL anything that ignored the SIGTERM above.
+  reap_in_worktree KILL 'grunt' "grunt watch"
+  reap_in_worktree KILL '~ run' "app on :9000 (~ run)"
+  rm -f "$GRUNT_WATCH_LOG"
+  if [ -n "$CLEAN" ] && [ -L "$WT_DIR/node_modules" ]; then
+    rm -f "$WT_DIR/node_modules"
+    echo "==> removed node_modules symlink"
+  fi
+  echo "==> done."
+  exit 0
+fi
+
+# --- run mode: set up and launch the worktree's app. -----------------------------------------------------------
 cd "$WT_DIR"
 echo "==> worktree: $WT_DIR"
 
@@ -41,19 +94,16 @@ if [ ! -d node_modules ]; then
   echo "==> linked node_modules -> /home/node_modules"
 fi
 
-# 2. build/ bundles are gitignored (absent) -> build this branch's JS/CSS.
+# 2. build/ bundles are gitignored (absent) -> build this branch's JS/CSS once up front.
 echo "==> building bundles (grunt concat concat_css)"
 node_modules/.bin/grunt concat concat_css >/dev/null
 
-# 3. A stray `sbt --client` server whose cwd is this worktree shares target/ and deadlocks `~ run`. Kill it.
-for p in $(pgrep -f sbt-launch 2>/dev/null || true); do
-  if [ "$(readlink "/proc/$p/cwd" 2>/dev/null || true)" = "$WT_DIR" ]; then
-    echo "==> killing thin-client sbt $p (shares target/)"
-    kill -9 "$p" 2>/dev/null || true
-  fi
-done
+# 3. A stray `sbt --client` server (or a hung `sbtn` task, e.g. a wedged `scalafmtAll`) whose cwd is this worktree
+#    shares target/ and deadlocks `~ run` on compile locks. Reap them.
+reap_in_worktree KILL 'sbt-launch|sbtn' "thin-client / hung sbt task (shares target/)"
 
-# 4. Free :9000 -> stop whatever `~ run` currently serves it (SIGTERM, then SIGKILL if it lingers).
+# 4. Free :9000 -> stop whatever `~ run` currently serves it (SIGTERM, then SIGKILL if it lingers). Not cwd-scoped:
+#    the app holding :9000 may be the main repo's, so match `~ run` anywhere rather than only in this worktree.
 for p in $(pgrep -f '~ run' 2>/dev/null || true); do
   echo "==> stopping running app (pid $p) on :9000"
   kill "$p" 2>/dev/null || true
@@ -70,10 +120,28 @@ if port_9000_in_use; then
   exit 1
 fi
 
-# 5. Launch. Absolute cache paths reuse the main repo's warm .coursier/.sbt; cwd-relative caches from a
-#    worktree would trigger a multi-GB re-download. config.file points at the worktree's own conf.
+# 5. Start a backgrounded `grunt watch` so `public/js/**` / `public/css/**` edits rebuild the bundles automatically —
+#    a plain hard-reload then always reflects the latest source (no manual reconcat). The trap tears it down on exit
+#    (Ctrl-C, sbt quitting, an error) so it never outlives the app it was serving.
+GRUNT_WATCH_PID=""
+cleanup() {
+  trap - EXIT INT TERM  # disarm so cleanup runs at most once
+  if [ -n "$GRUNT_WATCH_PID" ] && kill -0 "$GRUNT_WATCH_PID" 2>/dev/null; then
+    echo ""
+    echo "==> stopping grunt watch (pid $GRUNT_WATCH_PID)"
+    kill "$GRUNT_WATCH_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT INT TERM
+node_modules/.bin/grunt watch >"$GRUNT_WATCH_LOG" 2>&1 &
+GRUNT_WATCH_PID=$!
+echo "==> grunt watch running (pid $GRUNT_WATCH_PID) — bundles rebuild on save; log: $GRUNT_WATCH_LOG"
+
+# 6. Launch. Absolute cache paths reuse the main repo's warm .coursier/.sbt; cwd-relative caches from a
+#    worktree would trigger a multi-GB re-download. config.file points at the worktree's own conf. Run sbt in the
+#    foreground (not `exec`) so the exit trap above can reap grunt watch once it stops.
 echo "==> starting sbt ~ run  (first HTTP request triggers the dev compile; Ctrl-C to stop)"
-exec sbt \
+sbt \
   -Dconfig.file="$WT_DIR/conf/application.local.conf" \
   -Dsbt.coursier.home=/home/.coursier \
   -Dsbt.global.base=/home/.sbt \


### PR DESCRIPTION
Closes #4659.

Four improvements to `tools/qa-worktree.sh` (the script behind `make qa-worktree`), so QA'ing a worktree branch on :9000 needs less babysitting. Independent tooling change; own branch.

## What changed

1. **Auto-rebuild bundles.** After the one-shot build, launch a backgrounded **`grunt watch`** so later `public/js/**` / `public/css/**` edits rebuild the JS/CSS bundles automatically — a plain hard-reload always reflects the latest source, no manual reconcat. (This was the recurring papercut during the #4637 / #4648 card QA: new Twirl HTML rendered against a stale bundle.) Watch output goes to a per-worktree log under `/tmp`.
2. **Clean teardown on exit.** A `trap cleanup EXIT INT TERM` reaps the grunt watch when the script exits (Ctrl-C, sbt quitting, an error), so the watcher never outlives the app. sbt now runs in the **foreground** instead of `exec` so the trap can fire; a one-shot `trap -` guard keeps cleanup from running twice.
3. **Reap hung `sbtn` tasks.** The existing stray-reap (a thin-client server sharing the worktree's `target/`) is broadened from `sbt-launch` to `sbt-launch|sbtn`, via a shared cwd-scoped `reap_in_worktree` helper — so a wedged `sbtn` task (e.g. a stuck `scalafmtAll`) bound to the worktree gets cleared too. cwd-scoping keeps it from ever touching the main repo's own sbt/grunt work.
4. **`make qa-worktree-stop` teardown target.** New `--stop [--clean]` script mode + `make qa-worktree-stop wt=<name> [clean=1]` — stops the worktree's `~ run` and grunt watch; `clean=1` also drops the gitignored `node_modules` symlink and watch log.

`CLAUDE.md`'s "Running a worktree's app for QA" section is updated to match.

## Testing

Ran the launcher end-to-end in the web container (`setsid bash <worktree>/tools/qa-worktree.sh <wt>`):

- **Auto-rebuild:** edited `public/css/gallery/cards.css` → `gallery.css` bundle rebuilt in ~2s (md5 changed, watch log confirmed).
- **Launch integrity:** app compiled and served (`/` → 400 AllowedHosts on `127.0.0.1`, 303 with a proper `Host` header, `/anonSignUp` → 303).
- **Trap:** killed *only* the sbt JVM (grunt watch left unsignaled) → the EXIT trap independently reaped grunt watch.
- **Hung `sbtn`:** planted a fake `sbtn scalafmtAll` bound to the worktree → step 3 SIGKILL'd it.
- **Stop target:** `--stop` reaped grunt + `~ run` and freed :9000 (symlink kept); `--stop --clean` dropped the symlink + log.
- Makefile flag expansion (`clean=1|true|yes` → `--clean`, else nothing) and arg-parse error paths verified.

Caveat: the *interactive* Ctrl-C path can't be driven from a non-TTY test harness — under `setsid`, a single SIGINT to headless `sbt "~ run"` only cancels the task (frees :9000) but leaves the JVM at its prompt, so the trap fires only via `--stop`/second signal. With a real TTY (`docker exec -it`) sbt exits on Ctrl-C as the old `exec sbt` did, returning control so the trap fires — no regression; the trap's two halves (EXIT-path reap + SIGINT in an isolated harness) are each verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)