### PR TITLE
Recover from a hung GSV pano load instead of wedging Explore

### DIFF
--- a/public/js/common/pano-viewer/src/GsvViewer.js
+++ b/public/js/common/pano-viewer/src/GsvViewer.js
@@ -3,6 +3,10 @@
  * Docs: https://developers.google.com/maps/documentation/javascript/reference/street-view
  */
 class GsvViewer extends PanoViewer {
+  // If GSV's internal pano load never fires position_changed (e.g. its metadata RPC 502s), fail the load after this
+  // long so the in-flight move can recover instead of hanging the UI forever. Generous, so it won't abort slow loads.
+  static #PANO_LOAD_TIMEOUT_MS = 10000;
+
   constructor() {
     super();
     this.streetViewService = undefined;
@@ -67,7 +71,9 @@ class GsvViewer extends PanoViewer {
     // If defaultNavigation is enabled, we need a pano_changed listener to record the pano metadata after moving.
     if (panoOpts.defaultNavigation) {
       this.addListener('pano_changed', () => {
-        return this.streetViewService.getPanorama({ pano: this.gsvPano.pano }).then(this.#updateCurrPanoData);
+        return this.streetViewService.getPanorama({ pano: this.gsvPano.pano })
+          .then(this.#updateCurrPanoData)
+          .catch((err) => console.error('Failed to refresh pano metadata after navigation:', err));
       });
     }
   };
@@ -150,23 +156,43 @@ class GsvViewer extends PanoViewer {
     // Package the data into a PanoData object and save it in this.currPanoData.
     this.#updateCurrPanoData(newPanoData);
 
-    // Now we actually set the pano and wait to resolve until it's finished loading.
+    // If the pano didn't actually change, nothing needs to load.
     const newPano = this.currPanoData.getPanoId();
     const prevPano = this.prevPanoData ? this.prevPanoData.getPanoId() : undefined;
-    return await new Promise((resolve) => {
-      // If the pano didn't actually change, nothing needs to change, so just resolve immediately.
-      if (newPano === prevPano) {
-        resolve(this.currPanoData);
-      } else {
-        // Listen for the position_changed event which fires when the panorama has finished loading.
-        const listener = this.gsvPano.addListener('position_changed', () => {
-          google.maps.event.removeListener(listener);
-          resolve(this.currPanoData);
-        });
-        this.gsvPano.setPano(newPano);
-      }
-    });
+    if (newPano === prevPano) return this.currPanoData;
+
+    // Otherwise set it and wait until it's finished loading (with a hang guard — see _loadPanoWithTimeout).
+    return await this._loadPanoWithTimeout(newPano, this.currPanoData);
   };
+
+  /**
+   * Sets the GSV panorama to `newPano` and resolves once it has finished loading (its position_changed event).
+   *
+   * Guards against a load that never fires position_changed — e.g. GSV's internal metadata RPC 502s — by rejecting
+   * after #PANO_LOAD_TIMEOUT_MS. Without the guard the promise hangs forever and the in-flight move
+   * (NavigationService.moveToPano) never restores the UI it disabled, wedging the tool (frozen pano, dead
+   * minimap/nav); rejecting instead lets moveToPano's catch restore interaction. Underscore-prefixed (not `#private`)
+   * so it can be unit-tested.
+   *
+   * @param {string} newPano       Id of the pano to load.
+   * @param {PanoData} resolveValue Value to resolve with once the pano has loaded (the current PanoData).
+   * @return {Promise<PanoData>}   Resolves with resolveValue on load; rejects if the load times out.
+   */
+  _loadPanoWithTimeout(newPano, resolveValue) {
+    return new Promise((resolve, reject) => {
+      let timeoutId;
+      const listener = this.gsvPano.addListener('position_changed', () => {
+        clearTimeout(timeoutId);
+        google.maps.event.removeListener(listener);
+        resolve(resolveValue);
+      });
+      timeoutId = setTimeout(() => {
+        google.maps.event.removeListener(listener);
+        reject(new Error(`Timed out loading pano ${newPano} (position_changed never fired)`));
+      }, GsvViewer.#PANO_LOAD_TIMEOUT_MS);
+      this.gsvPano.setPano(newPano);
+    });
+  }
 
   setLocation = async (latLng, excludedPanos = new Set()) => {
     const { LatLng } = await google.maps.importLibrary('core');

--- a/test/js/gsvViewerPanoLoadTimeout.test.js
+++ b/test/js/gsvViewerPanoLoadTimeout.test.js
@@ -1,0 +1,103 @@
+/**
+ * Tests for GsvViewer._loadPanoWithTimeout — the guard that keeps a hung GSV pano load from wedging the tool.
+ *
+ * When GSV's internal metadata RPC 502s, its `position_changed` event can never fire, so the load promise would hang
+ * forever; the in-flight move (NavigationService.moveToPano) would then never restore the UI it disabled, freezing the
+ * pano and the minimap. The guard rejects after a timeout so the move can recover. These tests exercise that race
+ * directly: resolve on position_changed, reject on timeout, and settle only once.
+ *
+ * GsvViewer is a top-level `class` written for Grunt concatenation, so we eval the source into the jsdom global scope.
+ * It only needs its parent `PanoViewer` defined at class-definition time — the google.maps/PanoData/moment references
+ * live inside other methods that these tests never call.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const GSV_SRC = fs.readFileSync(
+    path.resolve(__dirname, '..', '..', 'public/js/common/pano-viewer/src/GsvViewer.js'), 'utf8'
+);
+
+/** Loads a fresh GsvViewer class into the jsdom global scope and returns it. */
+function loadGsvViewer() {
+    window.eval(`
+        class PanoViewer {}
+        ${GSV_SRC}
+        window.GsvViewer = GsvViewer;
+    `);
+    return window.GsvViewer;
+}
+
+describe('GsvViewer._loadPanoWithTimeout', () => {
+    let GsvViewer;
+
+    beforeAll(() => {
+        GsvViewer = loadGsvViewer();
+    });
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        // The race detaches its position_changed listener via google.maps.event.removeListener.
+        global.google = { maps: { event: { removeListener: jest.fn() } } };
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+        delete global.google;
+    });
+
+    /**
+     * Builds a viewer whose gsvPano stub captures the position_changed callback (so a test can fire it — or not, to
+     * simulate a hang) and records setPano calls.
+     */
+    function viewerWithCapturedListener() {
+        const viewer = new GsvViewer();
+        const captured = {};
+        viewer.gsvPano = {
+            addListener: (event, cb) => { captured.event = event; captured.cb = cb; return { event }; },
+            setPano: jest.fn(),
+        };
+        return { viewer, captured };
+    }
+
+    test('sets the pano and resolves with the given value once position_changed fires', async () => {
+        const { viewer, captured } = viewerWithCapturedListener();
+        const panoData = { id: 'CURR' };
+
+        const promise = viewer._loadPanoWithTimeout('newpano', panoData);
+        expect(viewer.gsvPano.setPano).toHaveBeenCalledWith('newpano');
+        expect(captured.event).toBe('position_changed');
+
+        captured.cb(); // GSV finished loading.
+
+        await expect(promise).resolves.toBe(panoData);
+        // Listener detached, and the timeout cleared (advancing time must not also reject).
+        expect(global.google.maps.event.removeListener).toHaveBeenCalledTimes(1);
+        jest.advanceTimersByTime(60000);
+        await expect(promise).resolves.toBe(panoData);
+    });
+
+    test('rejects after the timeout when position_changed never fires (the 502 hang)', async () => {
+        const { viewer } = viewerWithCapturedListener();
+
+        const promise = viewer._loadPanoWithTimeout('deadpano', { id: 'CURR' });
+        const assertion = expect(promise).rejects.toThrow(/Timed out loading pano deadpano/);
+
+        jest.advanceTimersByTime(60000); // well past the load timeout.
+
+        await assertion;
+        expect(global.google.maps.event.removeListener).toHaveBeenCalledTimes(1);
+    });
+
+    test('a late position_changed after the timeout does not flip the rejected promise', async () => {
+        const { viewer, captured } = viewerWithCapturedListener();
+
+        const promise = viewer._loadPanoWithTimeout('deadpano', { id: 'CURR' });
+        const assertion = expect(promise).rejects.toThrow(/Timed out/);
+        jest.advanceTimersByTime(60000);
+        await assertion;
+
+        // A late load event must be a no-op (promises settle once), not throw or resolve.
+        expect(() => captured.cb()).not.toThrow();
+    });
+});


### PR DESCRIPTION
## Problem

Explore can wedge into a fully non-interactive state — **frozen panorama, dead minimap/nav, keyboard and labeling unresponsive** — after a transient Google Street View failure. It shows up in the console as:

```
POST https://maps.googleapis.com/$rpc/.../MapsJsInternalService/GetMetadata net::ERR_FAILED 502 (Bad Gateway)
```

(The accompanying CORS error is a red herring — a 502 response just doesn't carry `Access-Control-Allow-Origin`.)

## Root cause

`GsvViewer`'s pano-load promise resolved **only** on the panorama's `position_changed` event, with no timeout and no reject path:

```js
return await new Promise((resolve) => {
  const listener = this.gsvPano.addListener('position_changed', () => { … resolve … });
  this.gsvPano.setPano(newPano);   // kicks off GSV's own internal metadata load
});
```

When `gsvPano.setPano()` starts GSV's internal load and **that** 502s, `position_changed` may never fire, so the promise **hangs forever**. The in-flight move (`NavigationService.moveToPano`) `await`s it and never returns — so the UI that `#updateUiBeforeMove()` disabled (walking, panning, labeling, keyboard) is **never restored**. The minimap goes dead too because `returnToPano` is gated on `disableWalking`.

This is **pre-existing and affects every Explore move** (normal walking included); it was surfaced during minimap QA.

## Fix

- Extract the load into **`GsvViewer._loadPanoWithTimeout`** and **reject after a timeout** (`#PANO_LOAD_TIMEOUT_MS`, 10s — generous so it won't abort slow-but-valid loads). `moveToPano` already has a `catch → #restoreUiAfterFailedMove()`, so a timeout now makes the tool **self-recover** instead of freezing.
- Add a `.catch` to the post-navigation metadata refresh (`pano_changed` → `getPanorama`) so a failure there logs cleanly instead of surfacing as an uncaught promise rejection (the red console line above).
- `_loadPanoWithTimeout` is underscore-prefixed (not `#private`) so it's unit-testable — same convention as the existing `_moveToInitialLocation`.

## Testing

New `test/js/gsvViewerPanoLoadTimeout.test.js` (jsdom) covers the race directly: resolves on `position_changed`, **rejects after the timeout when it never fires** (the 502 hang), and settles only once. Full JS suite green (14 suites / 99 tests).

Note: this is the **prototype** JS test layer (`test/js/`), which is opt-in and not yet a CI gate (sequenced with #2487). The behavior itself can't be exercised in an automated GSV/browser test, so the fix was reasoned from the hang + verified by unit-testing the extracted race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
