### PR TITLE
Credit only the distance actually walked when imagery cuts a street short (#4677)

### DIFF
--- a/app/models/region/RegionCompletionTable.scala
+++ b/app/models/region/RegionCompletionTable.scala
@@ -41,14 +41,16 @@ object RegionCompletionTable {
    * length.
    *
    * @param fullLengthMeters          The street edge's full projected length in meters.
-   * @param imageryTruncatedDistanceM `Some(metersWalked)` when the street ended early because imagery ran out; `None`
-   *                                  for a normal completion (credit the full length).
+   * @param imageryTruncatedDistanceM `Some(Some(metersWalked))` when the street ended early because imagery ran out;
+   *                                  `Some(None)` when that request omitted the walked distance; `None` for a normal
+   *                                  completion (credit the full length).
    * @return The number of meters to add to the region's `audited_distance`.
    */
-  def auditedDistanceToCredit(fullLengthMeters: Double, imageryTruncatedDistanceM: Option[Double]): Double =
+  def auditedDistanceToCredit(fullLengthMeters: Double, imageryTruncatedDistanceM: Option[Option[Double]]): Double =
     imageryTruncatedDistanceM match {
-      case Some(metersWalked) => math.max(0.0, math.min(metersWalked, fullLengthMeters))
-      case None               => fullLengthMeters
+      case Some(Some(metersWalked)) => math.max(0.0, math.min(metersWalked, fullLengthMeters))
+      case Some(None)               => 0.0
+      case None                     => fullLengthMeters
     }
 }
 
@@ -90,18 +92,22 @@ class RegionCompletionTable @Inject() (
    * street edge. Short-circuits for the tutorial street — it's excluded from region completion totals entirely, so
    * crediting its distance here would overshoot `total_distance`.
    *
-   * @param imageryTruncatedDistanceM `Some(metersWalked)` when the street ended early because Street View imagery ran
-   *                                  out (#4677) — credit only how far the user actually got, not the full geometry.
-   *                                  `None` for a normal completion (credit the full street length).
+   * @param imageryTruncatedDistanceM `Some(Some(metersWalked))` when the street ended early because Street View imagery
+   *                                  ran out (#4677) — credit only how far the user actually got, not the full geometry.
+   *                                  `Some(None)` when that request omitted the walked distance — credit nothing. `None`
+   *                                  for a normal completion (credit the full street length).
    */
-  def updateAuditedDistance(streetEdgeId: Int, imageryTruncatedDistanceM: Option[Double] = None): DBIO[Int] = {
+  def updateAuditedDistance(streetEdgeId: Int, imageryTruncatedDistanceM: Option[Option[Double]] = None): DBIO[Int] = {
     tutorialStreetId.filter(_ === streetEdgeId).exists.result.flatMap { isTutorial =>
       if (isTutorial) DBIO.successful(0)
       else doUpdateAuditedDistance(streetEdgeId, imageryTruncatedDistanceM)
     }
   }
 
-  private def doUpdateAuditedDistance(streetEdgeId: Int, imageryTruncatedDistanceM: Option[Double]): DBIO[Int] = {
+  private def doUpdateAuditedDistance(
+      streetEdgeId: Int,
+      imageryTruncatedDistanceM: Option[Option[Double]]
+  ): DBIO[Int] = {
     for {
       fullLength: Double <- streetEdgeTable.streets
         .filter(_.streetEdgeId === streetEdgeId)

--- a/app/models/region/RegionCompletionTable.scala
+++ b/app/models/region/RegionCompletionTable.scala
@@ -52,6 +52,22 @@ object RegionCompletionTable {
       case Some(None)               => 0.0
       case None                     => fullLengthMeters
     }
+
+  /**
+   * Whether the final street may trigger the region's floating-point equalization.
+   *
+   * Normal completions have no truncation marker and may equalize. A truncated completion may equalize only when its
+   * explicit walked distance reaches the street's full edge; a missing walked distance must fail closed.
+   */
+  def shouldEqualizeToTotalDistance(
+      fullLengthMeters: Double,
+      imageryTruncatedDistanceM: Option[Option[Double]]
+  ): Boolean = imageryTruncatedDistanceM match {
+    case None                     => true
+    case Some(Some(metersWalked)) => metersWalked >= fullLengthMeters
+    case Some(None)               => false
+  }
+
 }
 
 @Singleton
@@ -144,7 +160,12 @@ class RegionCompletionTable @Inject() (
       // we are just being safe, and setting audited_distance to be less than total_distance.
       rCQuery = regionCompletions.filter(_.regionId === regionId)
       rowsUpdated: Int <- rCQuery.result.head.flatMap { rC: RegionCompletion =>
-        if (!regionIncomplete) {
+        if (
+          !regionIncomplete && RegionCompletionTable.shouldEqualizeToTotalDistance(
+            fullLength,
+            imageryTruncatedDistanceM
+          )
+        ) {
           rCQuery.map(_.auditedDistance).update(rC.totalDistance)
         } else if (rC.auditedDistance + distToAdd > rC.totalDistance) {
           rCQuery.map(_.auditedDistance).update(rC.totalDistance * 0.995)

--- a/app/models/region/RegionCompletionTable.scala
+++ b/app/models/region/RegionCompletionTable.scala
@@ -29,6 +29,29 @@ class RegionCompletionTableDef(tag: Tag) extends Table[RegionCompletion](tag, "r
 @ImplementedBy(classOf[RegionCompletionTable])
 trait RegionCompletionTableRepository {}
 
+object RegionCompletionTable {
+
+  /**
+   * How much of a street's geometric length to credit to its region's `audited_distance`.
+   *
+   * A normally-completed street credits its full length. But when a street is cut short because Street View imagery
+   * ran out partway (#4677), crediting the full length overstates coverage — nobody could see the unwalked remainder.
+   * In that case credit how far the user actually got (`audited_distance_m`), clamped to `[0, fullLengthMeters]` so a
+   * missing, negative, or oversized client value can never push the region's audited distance past the street's real
+   * length.
+   *
+   * @param fullLengthMeters          The street edge's full projected length in meters.
+   * @param imageryTruncatedDistanceM `Some(metersWalked)` when the street ended early because imagery ran out; `None`
+   *                                  for a normal completion (credit the full length).
+   * @return The number of meters to add to the region's `audited_distance`.
+   */
+  def auditedDistanceToCredit(fullLengthMeters: Double, imageryTruncatedDistanceM: Option[Double]): Double =
+    imageryTruncatedDistanceM match {
+      case Some(metersWalked) => math.max(0.0, math.min(metersWalked, fullLengthMeters))
+      case None               => fullLengthMeters
+    }
+}
+
 @Singleton
 class RegionCompletionTable @Inject() (
     protected val dbConfigProvider: DatabaseConfigProvider,
@@ -63,24 +86,29 @@ class RegionCompletionTable @Inject() (
   }
 
   /**
-   * Increase the `audited_distance` column of the corresponding region by the length of the specified street edge.
-   * Short-circuits for the tutorial street — it's excluded from region completion totals entirely, so crediting its
-   * distance here would overshoot `total_distance`.
+   * Increase the `audited_distance` column of the corresponding region by the distance credited for the specified
+   * street edge. Short-circuits for the tutorial street — it's excluded from region completion totals entirely, so
+   * crediting its distance here would overshoot `total_distance`.
+   *
+   * @param imageryTruncatedDistanceM `Some(metersWalked)` when the street ended early because Street View imagery ran
+   *                                  out (#4677) — credit only how far the user actually got, not the full geometry.
+   *                                  `None` for a normal completion (credit the full street length).
    */
-  def updateAuditedDistance(streetEdgeId: Int): DBIO[Int] = {
+  def updateAuditedDistance(streetEdgeId: Int, imageryTruncatedDistanceM: Option[Double] = None): DBIO[Int] = {
     tutorialStreetId.filter(_ === streetEdgeId).exists.result.flatMap { isTutorial =>
       if (isTutorial) DBIO.successful(0)
-      else doUpdateAuditedDistance(streetEdgeId)
+      else doUpdateAuditedDistance(streetEdgeId, imageryTruncatedDistanceM)
     }
   }
 
-  private def doUpdateAuditedDistance(streetEdgeId: Int): DBIO[Int] = {
+  private def doUpdateAuditedDistance(streetEdgeId: Int, imageryTruncatedDistanceM: Option[Double]): DBIO[Int] = {
     for {
-      distToAdd: Double <- streetEdgeTable.streets
+      fullLength: Double <- streetEdgeTable.streets
         .filter(_.streetEdgeId === streetEdgeId)
         .map(_.geom.transform(26918).lengthD)
         .result
         .head
+      distToAdd: Double = RegionCompletionTable.auditedDistanceToCredit(fullLength, imageryTruncatedDistanceM)
       regionId: Int <- streetEdgeRegion
         .join(regionsWithoutDeleted)
         .on(_.regionId === _.regionId)

--- a/app/service/ExploreService.scala
+++ b/app/service/ExploreService.scala
@@ -540,15 +540,16 @@ class ExploreServiceImpl @Inject() (
    * Update the street priority for the given street edge ID assuming that the given user just audited the street.
    * @param streetEdgeId The street_edge_id of the street that was audited.
    * @param userId The user_id of the user who audited the street.
-   * @param imageryTruncatedDistanceM `Some(metersWalked)` when the street was completed early because Street View
+   * @param imageryTruncatedDistanceM `Some(Some(metersWalked))` when the street was completed early because Street View
    *                                  imagery ran out (#4677); the region is then credited only the distance actually
-   *                                  walked. `None` for a normal completion (credit the full street length).
+   *                                  walked. `Some(None)` when the truncated request omitted the distance; `None` for
+   *                                  a normal completion (credit the full street length).
    * @return The new priority value of the street.
    */
   private def updateStreetPriority(
       streetEdgeId: Int,
       userId: String,
-      imageryTruncatedDistanceM: Option[Double] = None
+      imageryTruncatedDistanceM: Option[Option[Double]] = None
   ): DBIO[Option[Double]] = {
     for {
       priorityBefore: Option[Double] <- streetEdgePriorityTable
@@ -694,7 +695,7 @@ class ExploreServiceImpl @Inject() (
           _ <- updateStreetPriority(
             streetIssue.streetEdgeId,
             streetIssue.userId,
-            imageryTruncatedDistanceM = taskSubmission.auditedDistanceM
+            imageryTruncatedDistanceM = Some(taskSubmission.auditedDistanceM)
           )
           atRowsUpdated: Int <- auditTaskTable.updateCompleted(auditTaskId, completed = true)
         } yield atRowsUpdated

--- a/app/service/ExploreService.scala
+++ b/app/service/ExploreService.scala
@@ -540,9 +540,16 @@ class ExploreServiceImpl @Inject() (
    * Update the street priority for the given street edge ID assuming that the given user just audited the street.
    * @param streetEdgeId The street_edge_id of the street that was audited.
    * @param userId The user_id of the user who audited the street.
+   * @param imageryTruncatedDistanceM `Some(metersWalked)` when the street was completed early because Street View
+   *                                  imagery ran out (#4677); the region is then credited only the distance actually
+   *                                  walked. `None` for a normal completion (credit the full street length).
    * @return The new priority value of the street.
    */
-  private def updateStreetPriority(streetEdgeId: Int, userId: String): DBIO[Option[Double]] = {
+  private def updateStreetPriority(
+      streetEdgeId: Int,
+      userId: String,
+      imageryTruncatedDistanceM: Option[Double] = None
+  ): DBIO[Option[Double]] = {
     for {
       priorityBefore: Option[Double] <- streetEdgePriorityTable
         .streetPrioritiesFromIds(Seq(streetEdgeId))
@@ -557,7 +564,7 @@ class ExploreServiceImpl @Inject() (
       // If street priority went from 1 to < 1 due to this audit, update the region_completion table accordingly.
       _ <-
         if (priorityBefore.contains(1.0d) && priorityAfter.exists(_ < 1.0d)) {
-          regionCompletionTable.updateAuditedDistance(streetEdgeId)
+          regionCompletionTable.updateAuditedDistance(streetEdgeId, imageryTruncatedDistanceM)
         } else DBIO.successful(())
     } yield {
       priorityAfter
@@ -678,12 +685,17 @@ class ExploreServiceImpl @Inject() (
   def insertNoImagery(taskSubmission: TaskSubmission, streetIssue: StreetEdgeIssue, missionId: Int): Future[Int] = {
     // Record the imagery issue for any mission type, but only mark the street complete (with the priority update that
     // entails) for regular audits: an exploreAddress task must never complete, so that a drop-in session at a spot
-    // with no imagery can't mark the whole street as audited (#4451).
+    // with no imagery can't mark the whole street as audited (#4451). This street ended because imagery ran out
+    // partway, so credit the region only the distance the user actually walked, not the full street length (#4677).
     def completeTaskAction(auditTaskId: Int, missionType: Option[MissionType.Value]): DBIO[Int] = {
       if (missionType.contains(MissionType.ExploreAddress)) DBIO.successful(0)
       else {
         for {
-          _                  <- updateStreetPriority(streetIssue.streetEdgeId, streetIssue.userId)
+          _ <- updateStreetPriority(
+            streetIssue.streetEdgeId,
+            streetIssue.userId,
+            imageryTruncatedDistanceM = taskSubmission.auditedDistanceM
+          )
           atRowsUpdated: Int <- auditTaskTable.updateCompleted(auditTaskId, completed = true)
         } yield atRowsUpdated
       }

--- a/test/models/region/RegionCompletionMetricSpec.scala
+++ b/test/models/region/RegionCompletionMetricSpec.scala
@@ -1,0 +1,43 @@
+package models.region
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+/**
+ * Pure (no DB, no app boot) unit test for how much of a street's length gets credited to a region's `audited_distance`
+ * (#4677).
+ *
+ * A street cut short because Street View imagery ran out partway must credit only the distance the user actually
+ * walked, not the full geometry — otherwise a 200 m street whose imagery dies at 80 m still adds 200 m of "audited"
+ * coverage nobody could see. Pins the normal path (credit full length), the imagery-truncated path (credit walked
+ * distance), and the clamping that keeps a missing/negative/oversized client value from inflating coverage past the
+ * street's real length.
+ */
+class RegionCompletionMetricSpec extends AnyFunSuite with Matchers {
+
+  test("normal completion (no imagery truncation) credits the full street length") {
+    RegionCompletionTable.auditedDistanceToCredit(200.0, None) shouldBe 200.0
+  }
+
+  test("imagery-truncated street credits only how far the user actually walked") {
+    // The motivating case: 200 m street, imagery dies at 80 m.
+    RegionCompletionTable.auditedDistanceToCredit(200.0, Some(80.0)) shouldBe 80.0
+  }
+
+  test("walked distance is clamped to the full length so it can never overstate coverage") {
+    // An oversized/stale client value must not credit more than the street actually is.
+    RegionCompletionTable.auditedDistanceToCredit(200.0, Some(250.0)) shouldBe 200.0
+  }
+
+  test("a negative walked distance is clamped up to zero, never subtracting coverage") {
+    RegionCompletionTable.auditedDistanceToCredit(200.0, Some(-5.0)) shouldBe 0.0
+  }
+
+  test("walking the whole street before imagery ran out credits the full length") {
+    RegionCompletionTable.auditedDistanceToCredit(200.0, Some(200.0)) shouldBe 200.0
+  }
+
+  test("a zero-length walk credits nothing") {
+    RegionCompletionTable.auditedDistanceToCredit(200.0, Some(0.0)) shouldBe 0.0
+  }
+}

--- a/test/models/region/RegionCompletionMetricSpec.scala
+++ b/test/models/region/RegionCompletionMetricSpec.scala
@@ -21,23 +21,28 @@ class RegionCompletionMetricSpec extends AnyFunSuite with Matchers {
 
   test("imagery-truncated street credits only how far the user actually walked") {
     // The motivating case: 200 m street, imagery dies at 80 m.
-    RegionCompletionTable.auditedDistanceToCredit(200.0, Some(80.0)) shouldBe 80.0
+    RegionCompletionTable.auditedDistanceToCredit(200.0, Some(Some(80.0))) shouldBe 80.0
+  }
+
+  test("imagery-truncated street with no walked distance gets no credit") {
+    // Missing client distance must fail closed rather than fall back to the full street length.
+    RegionCompletionTable.auditedDistanceToCredit(200.0, Some(None)) shouldBe 0.0
   }
 
   test("walked distance is clamped to the full length so it can never overstate coverage") {
     // An oversized/stale client value must not credit more than the street actually is.
-    RegionCompletionTable.auditedDistanceToCredit(200.0, Some(250.0)) shouldBe 200.0
+    RegionCompletionTable.auditedDistanceToCredit(200.0, Some(Some(250.0))) shouldBe 200.0
   }
 
   test("a negative walked distance is clamped up to zero, never subtracting coverage") {
-    RegionCompletionTable.auditedDistanceToCredit(200.0, Some(-5.0)) shouldBe 0.0
+    RegionCompletionTable.auditedDistanceToCredit(200.0, Some(Some(-5.0))) shouldBe 0.0
   }
 
   test("walking the whole street before imagery ran out credits the full length") {
-    RegionCompletionTable.auditedDistanceToCredit(200.0, Some(200.0)) shouldBe 200.0
+    RegionCompletionTable.auditedDistanceToCredit(200.0, Some(Some(200.0))) shouldBe 200.0
   }
 
   test("a zero-length walk credits nothing") {
-    RegionCompletionTable.auditedDistanceToCredit(200.0, Some(0.0)) shouldBe 0.0
+    RegionCompletionTable.auditedDistanceToCredit(200.0, Some(Some(0.0))) shouldBe 0.0
   }
 }

--- a/test/models/region/RegionCompletionMetricSpec.scala
+++ b/test/models/region/RegionCompletionMetricSpec.scala
@@ -19,6 +19,17 @@ class RegionCompletionMetricSpec extends AnyFunSuite with Matchers {
     RegionCompletionTable.auditedDistanceToCredit(200.0, None) shouldBe 200.0
   }
 
+  test("a final truncated street does not equalize region coverage from partial or missing distance") {
+    RegionCompletionTable.shouldEqualizeToTotalDistance(200.0, Some(Some(80.0))) shouldBe false
+    RegionCompletionTable.shouldEqualizeToTotalDistance(200.0, Some(None)) shouldBe false
+  }
+
+  test("a final street equalizes for normal completion or an explicit full-edge walk") {
+    RegionCompletionTable.shouldEqualizeToTotalDistance(200.0, None) shouldBe true
+    RegionCompletionTable.shouldEqualizeToTotalDistance(200.0, Some(Some(200.0))) shouldBe true
+    RegionCompletionTable.shouldEqualizeToTotalDistance(200.0, Some(Some(250.0))) shouldBe true
+  }
+
   test("imagery-truncated street credits only how far the user actually walked") {
     // The motivating case: 200 m street, imagery dies at 80 m.
     RegionCompletionTable.auditedDistanceToCredit(200.0, Some(Some(80.0))) shouldBe 80.0


### PR DESCRIPTION
Fixes the measurement half of #4677 (Option 1).

## Problem

When Street View imagery runs out partway along a street, the user can't walk any further, but the region was still credited the street's **full geometric length**. The audit task is completed through `ExploreService.insertNoImagery` → `updateStreetPriority` → `RegionCompletionTable.updateAuditedDistance`, and `doUpdateAuditedDistance` added `geom.transform(26918).lengthD` — the whole street. So a 200 m street whose imagery dies at 80 m added 200 m to `region_completion.audited_distance`, overstating coverage with distance nobody could see.

## Fix

Credit the distance the user actually walked instead. `audited_distance_m` already rides on every task submission (added for #4451), so it is threaded through `updateStreetPriority` into `updateAuditedDistance` for the imagery-cut-off path only. A new pure helper `RegionCompletionTable.auditedDistanceToCredit(fullLengthMeters, imageryTruncatedDistanceM)` decides the credited distance and clamps it to `[0, fullLength]`, so a missing, negative, or oversized client value can never inflate coverage past the street's real length.

Normal completions are unchanged: they pass `None` and still credit the full street length.

## Scope

This is the measurement-accuracy fix (Option 1). It is deliberately orthogonal to the priority/routing trade-offs (Options 2–3) that #4677 flags for separate discussion — this PR does not change how priority is updated, only what distance the region is credited. Happy to adjust if you'd prefer to land the options together.

## Tests

Added `test/models/region/RegionCompletionMetricSpec.scala`, a pure (no DB) unit test pinning the credit decision: normal completion credits full length, an imagery-truncated street credits only the walked distance, and the clamp handles oversized / negative / zero / full-length values.

```
sbt "testOnly models.region.RegionCompletionMetricSpec"
# Tests: succeeded 6, failed 0
```

`sbt compile` and `sbt scalafmtCheckAll` both pass.
