### PR TITLE
Add cumulative all-time + rolling-7-day charts to Across Cities over-time section

### DIFF
--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -716,13 +716,16 @@ class AdminController @Inject() (
 
     // Fetch the per-city scorecards and the all-time cross-city weekly series in parallel; the page's "over time" charts
     // default to the last 12 weeks (derived client-side from each city's weekly_trend) and toggle to this all-time set.
+    // The trailing-7-day daily series drives the "this week" bar charts (#4686).
     val scorecardsF    = configService.getCityScorecards()
     val allTimeF       = configService.getCrossCityWeeklyTrend(None)
+    val dailyF         = configService.getCrossCityDailyTrend(7)
     val labelingSpeedF = configService.getCrossCityLabelingSpeed()
 
     for {
       withFlags     <- scorecardsF
       allTimeTrend  <- allTimeF
+      dailyTrend    <- dailyF
       labelingSpeed <- labelingSpeedF
     } yield {
       val now        = OffsetDateTime.now()
@@ -818,12 +821,24 @@ class AdminController @Inject() (
       }
 
       // Cross-city weekly series for the full project history (the "All time" toggle on the over-time charts).
+      // new_users feeds the cumulative-users chart (#4686): each person counts once, in their first-activity week.
       val overTimeAllTime = JsArray(allTimeTrend.map { w =>
         Json.obj(
           "week_start"   -> w.weekStart.toString,
           "labels"       -> w.labels,
           "validations"  -> w.validations,
-          "active_users" -> w.activeUsers
+          "active_users" -> w.activeUsers,
+          "new_users"    -> w.newUsers
+        )
+      })
+
+      // Trailing-7-day cross-city daily series for the "this week" bar charts (#4686); zero-filled, today partial.
+      val overTimeDaily = JsArray(dailyTrend.map { d =>
+        Json.obj(
+          "day"          -> d.day.toString,
+          "labels"       -> d.labels,
+          "validations"  -> d.validations,
+          "active_users" -> d.activeUsers
         )
       })
 
@@ -845,6 +860,7 @@ class AdminController @Inject() (
         Json.obj(
           "cities"             -> cities,
           "over_time_all_time" -> overTimeAllTime,
+          "over_time_daily"    -> overTimeDaily,
           "summary"            -> Json.obj(
             "num_cities"                -> scorecards.length,
             "num_countries"             -> numCountries,

--- a/app/models/utils/ConfigTable.scala
+++ b/app/models/utils/ConfigTable.scala
@@ -4,7 +4,7 @@ import com.google.inject.ImplementedBy
 import models.street.StreetEdgeTableDef
 import models.utils.MyPostgresProfile.api._
 import play.api.db.slick.{DatabaseConfigProvider, HasDatabaseConfigProvider}
-import service.{AggregateStats, CityScorecard, LabelTypeStats, WeeklyPoint}
+import service.{AggregateStats, CityScorecard, DailyPoint, LabelTypeStats, WeeklyPoint}
 import slick.jdbc.GetResult
 
 import java.time.{LocalDate, OffsetDateTime, ZoneOffset}
@@ -577,23 +577,40 @@ class ConfigTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvi
    *
    * @param schema The database schema to query.
    * @param weeks  Trailing weeks to include, or None for the city's full history (the "All time" toggle).
-   * @return       DBIO yielding (weekStart, labels, validations, activeUsers), ascending by week.
+   * @return       DBIO yielding (weekStart, labels, validations, activeUsers, newUsers), ascending by week; newUsers
+   *               is 0 whenever `weeks` is bounded (see the inline note).
    */
   def getCityWeeklyTrendBySchema(schema: String, weeks: Option[Int]): DBIO[Seq[WeeklyPoint]] = {
     implicit val getResult: GetResult[WeeklyPoint] =
-      GetResult(r => WeeklyPoint(LocalDate.parse(r.nextString()), r.nextInt(), r.nextInt(), r.nextInt()))
+      GetResult(r => WeeklyPoint(LocalDate.parse(r.nextString()), r.nextInt(), r.nextInt(), r.nextInt(), r.nextInt()))
 
     // weeks is an Int (safe to interpolate); None drops the lower bound to return the city's full history.
     val labelBound = weeks.map(w => s"AND label.time_created >= NOW() - ($w * INTERVAL '1 week')").getOrElse("")
     val valBound   =
       weeks.map(w => s"AND label_validation.end_timestamp >= NOW() - ($w * INTERVAL '1 week')").getOrElse("")
 
+    // new_users (each user counted in the week of their first-ever activity, for the cumulative users chart, #4686)
+    // is only knowable over the full history — a trailing window would misread "first activity in the window" as
+    // "first ever" — so bounded queries get a literal 0 and skip the extra aggregation.
+    val newUsersCtes =
+      if (weeks.isEmpty) """,
+      first_weeks AS (
+          SELECT DATE_TRUNC('week', MIN(activity_ts AT TIME ZONE 'US/Pacific'))::date AS week_start
+          FROM activity
+          GROUP BY activity_user_id
+      ),
+      new_user_counts AS (
+          SELECT week_start, COUNT(*) AS new_users
+          FROM first_weeks
+          GROUP BY week_start
+      )"""
+      else ""
+    val newUsersSelect = if (weeks.isEmpty) "COALESCE(new_user_counts.new_users, 0)" else "0"
+    val newUsersJoin   =
+      if (weeks.isEmpty) "LEFT JOIN new_user_counts ON weekly.week_start = new_user_counts.week_start" else ""
+
     sql"""
-      SELECT CAST(DATE_TRUNC('week', activity_ts AT TIME ZONE 'US/Pacific')::date AS TEXT) AS week_start,
-             COUNT(*) FILTER (WHERE kind = 'label')      AS labels,
-             COUNT(*) FILTER (WHERE kind = 'validation') AS validations,
-             COUNT(DISTINCT activity_user_id)            AS active_users
-      FROM (
+      WITH activity AS (
           SELECT label.time_created AS activity_ts, label.user_id AS activity_user_id, 'label' AS kind
           FROM "#$schema".label
           INNER JOIN "#$schema".user_stat ON label.user_id = user_stat.user_id
@@ -605,10 +622,61 @@ class ConfigTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvi
           INNER JOIN "#$schema".user_stat ON label_validation.user_id = user_stat.user_id
           WHERE NOT user_stat.excluded
               #$valBound
-      ) AS activity
-      GROUP BY week_start
-      ORDER BY week_start ASC;
+      ),
+      weekly AS (
+          SELECT DATE_TRUNC('week', activity_ts AT TIME ZONE 'US/Pacific')::date AS week_start,
+                 COUNT(*) FILTER (WHERE kind = 'label')      AS labels,
+                 COUNT(*) FILTER (WHERE kind = 'validation') AS validations,
+                 COUNT(DISTINCT activity_user_id)            AS active_users
+          FROM activity
+          GROUP BY week_start
+      )
+      #$newUsersCtes
+      SELECT CAST(weekly.week_start AS TEXT) AS week_start, weekly.labels, weekly.validations, weekly.active_users,
+             #$newUsersSelect AS new_users
+      FROM weekly
+      #$newUsersJoin
+      ORDER BY weekly.week_start ASC;
     """.as[WeeklyPoint]
+  }
+
+  /**
+   * Daily label/validation/active-user volume for one city's trailing window, for the "this week" bar charts (#4686).
+   *
+   * The daily counterpart of [[getCityWeeklyTrendBySchema]]: identical activity definition and exclusions, bucketed by
+   * calendar day in Pacific time. Days with no activity are absent (the service zero-fills the window). The time bound
+   * is a raw-timestamp comparison one day wider than the window so it stays index-friendly (no per-row time-zone
+   * conversion in the WHERE); the service trims to the exact Pacific-day window.
+   *
+   * @param schema The database schema to query.
+   * @param days   Trailing calendar days to include (the last of them being today, partial).
+   * @return       DBIO yielding (day, labels, validations, activeUsers), ascending by day.
+   */
+  def getCityDailyTrendBySchema(schema: String, days: Int): DBIO[Seq[DailyPoint]] = {
+    implicit val getResult: GetResult[DailyPoint] =
+      GetResult(r => DailyPoint(LocalDate.parse(r.nextString()), r.nextInt(), r.nextInt(), r.nextInt()))
+
+    sql"""
+      SELECT CAST(DATE_TRUNC('day', activity_ts AT TIME ZONE 'US/Pacific')::date AS TEXT) AS day,
+             COUNT(*) FILTER (WHERE kind = 'label')      AS labels,
+             COUNT(*) FILTER (WHERE kind = 'validation') AS validations,
+             COUNT(DISTINCT activity_user_id)            AS active_users
+      FROM (
+          SELECT label.time_created AS activity_ts, label.user_id AS activity_user_id, 'label' AS kind
+          FROM "#$schema".label
+          INNER JOIN "#$schema".user_stat ON label.user_id = user_stat.user_id
+          WHERE NOT user_stat.excluded AND label.deleted = FALSE AND label.tutorial = FALSE
+              AND label.time_created >= NOW() - ((${days} + 1) * INTERVAL '1 day')
+          UNION ALL
+          SELECT label_validation.end_timestamp AS activity_ts, label_validation.user_id AS activity_user_id, 'validation' AS kind
+          FROM "#$schema".label_validation
+          INNER JOIN "#$schema".user_stat ON label_validation.user_id = user_stat.user_id
+          WHERE NOT user_stat.excluded
+              AND label_validation.end_timestamp >= NOW() - ((${days} + 1) * INTERVAL '1 day')
+      ) AS activity
+      GROUP BY day
+      ORDER BY day ASC;
+    """.as[DailyPoint]
   }
 
   /**

--- a/app/service/ConfigService.scala
+++ b/app/service/ConfigService.scala
@@ -15,7 +15,7 @@ import play.api.libs.ws.WSClient
 import play.api.{Configuration, Logger}
 import slick.dbio.DBIO
 
-import java.time.{LocalDate, OffsetDateTime}
+import java.time.{LocalDate, OffsetDateTime, ZoneId}
 import java.time.temporal.ChronoUnit
 import javax.inject._
 import scala.concurrent.duration.{Duration, FiniteDuration}
@@ -105,8 +105,22 @@ case class AggregateStats(
  * @param validations  Validations by non-excluded users that week.
  * @param activeUsers  Distinct non-excluded users who labeled or validated that week. Summed across cities for the
  *                     "active users over time" overview line, this slightly over-counts users active in multiple cities.
+ * @param newUsers     Users whose first-ever label or validation fell in that week — the increment for the cumulative
+ *                     users chart (#4686). Only populated on full-history queries: a trailing window can't know a
+ *                     user's true first week, so bounded queries return 0 here.
  */
-case class WeeklyPoint(weekStart: LocalDate, labels: Int, validations: Int, activeUsers: Int)
+case class WeeklyPoint(weekStart: LocalDate, labels: Int, validations: Int, activeUsers: Int, newUsers: Int)
+
+/**
+ * One day's contribution volume summed across cities, for the Across Cities "this week" bar charts (#4686).
+ *
+ * @param day          Calendar day (Pacific).
+ * @param labels       Non-tutorial, non-excluded labels created that day.
+ * @param validations  Validations by non-excluded users that day.
+ * @param activeUsers  Distinct non-excluded users who labeled or validated that day, summed per city (a person active
+ *                     in two cities is counted in each).
+ */
+case class DailyPoint(day: LocalDate, labels: Int, validations: Int, activeUsers: Int)
 
 /**
  * One city's summary row for the cross-city "Across Cities" admin overview (#4329).
@@ -426,6 +440,16 @@ trait ConfigService {
    * @return      Merged weekly series, ascending by week.
    */
   def getCrossCityWeeklyTrend(weeks: Option[Int]): Future[Seq[WeeklyPoint]]
+
+  /**
+   * Returns the daily label/validation/active-user volume summed across all available cities for the trailing window
+   * (#4686), for the "this week" bar charts. Same definitions and exclusions as [[getCrossCityWeeklyTrend]]; active
+   * users are summed per city, so a person active in multiple cities is counted in each (documented on the page).
+   *
+   * @param days Trailing calendar days (Pacific) to include; the last day is today, so its counts are partial.
+   * @return     Exactly `days` points, zero-filled and ascending by day.
+   */
+  def getCrossCityDailyTrend(days: Int): Future[Seq[DailyPoint]]
 
   /**
    * Returns each city's labeling speed as seconds of active auditing per 100 m covered (#4329).
@@ -805,8 +829,53 @@ class ConfigServiceImpl @Inject() (
             .toSeq
             .sortBy(_._1)
             .map { case (week, pts) =>
-              WeeklyPoint(week, pts.map(_.labels).sum, pts.map(_.validations).sum, pts.map(_.activeUsers).sum)
+              WeeklyPoint(
+                week,
+                pts.map(_.labels).sum,
+                pts.map(_.validations).sum,
+                pts.map(_.activeUsers).sum,
+                pts.map(_.newUsers).sum
+              )
             }
+        }
+      }
+    }
+  }
+
+  def getCrossCityDailyTrend(days: Int): Future[Seq[DailyPoint]] = {
+    cacheApi.getOrElseUpdate[Seq[DailyPoint]](s"getCrossCityDailyTrend_$days", Duration(10, "minutes")) {
+      val configuredCityIds = config.get[Seq[String]]("city-params.city-ids").filter(_ != "staging")
+
+      val schemaExistenceChecks: Seq[Future[(String, Boolean)]] = configuredCityIds.map { cityId =>
+        try {
+          checkSchemaExists(getCitySchema(cityId)).map(cityId -> _).recover { case _ => cityId -> false }
+        } catch {
+          case _: Exception => Future.successful(cityId -> false)
+        }
+      }
+
+      Future.sequence(schemaExistenceChecks).flatMap { schemaResults =>
+        val availableCities = schemaResults.filter(_._2).map(_._1)
+        val perCityFutures  = availableCities.map { cityId =>
+          db.run(configTable.getCityDailyTrendBySchema(getCitySchema(cityId), days))
+            .recover { case e: Exception =>
+              logger.warn(s"Failed to fetch daily trend for city $cityId: ${e.getMessage}")
+              Seq.empty[DailyPoint]
+            }
+        }
+        Future.sequence(perCityFutures).map { perCity =>
+          val byDay = perCity.flatten
+            .groupBy(_.day)
+            .map { case (day, pts) =>
+              day -> DailyPoint(day, pts.map(_.labels).sum, pts.map(_.validations).sum, pts.map(_.activeUsers).sum)
+            }
+          // Zero-fill the exact trailing window so the page always gets `days` bars. Iterating the window (rather
+          // than the query results) also drops any extra day the DAO's index-friendly coarse bound let through.
+          val today = LocalDate.now(ZoneId.of("US/Pacific"))
+          (0 until days).map { i =>
+            val day = today.minusDays((days - 1 - i).toLong)
+            byDay.getOrElse(day, DailyPoint(day, 0, 0, 0))
+          }
         }
       }
     }

--- a/app/views/admin/dashboard/acrossCities.scala.html
+++ b/app/views/admin/dashboard/acrossCities.scala.html
@@ -54,26 +54,62 @@
 
   <div class="api-section" id="ac-trends-section">
     <h2 class="api-heading" id="over-time">Over time <a href="#over-time" class="permalink">#</a></h2>
-    <p>Weekly totals across all cities.</p>
+    <p>How activity is trending across all cities — weekly rates, cumulative growth, and the last 7 days.</p>
+
+    <h3 class="ac-chart-group-title" id="weekly-totals">Weekly totals</h3>
     <div class="ac-toggle" id="ac-trend-toggle" role="group" aria-label="Trend range">
       <button type="button" class="ac-toggle-btn active" data-range="recent">12 weeks</button>
       <button type="button" class="ac-toggle-btn" data-range="all">All time</button>
     </div>
     <div class="ac-charts">
       <div class="ac-chart">
-        <h3 class="ac-chart-title">Labels per week</h3>
+        <h4 class="ac-chart-title">Labels per week</h4>
         <div class="mini-chart" id="ac-chart-labels"></div>
       </div>
       <div class="ac-chart">
-        <h3 class="ac-chart-title">Validations per week</h3>
+        <h4 class="ac-chart-title">Validations per week</h4>
         <div class="mini-chart" id="ac-chart-validations"></div>
       </div>
       <div class="ac-chart">
-        <h3 class="ac-chart-title">Active users per week</h3>
+        <h4 class="ac-chart-title">Active users per week</h4>
         <div class="mini-chart" id="ac-chart-users"></div>
       </div>
     </div>
     <p class="ac-note">“Active users” counts distinct people who labeled or validated that week, summed across cities (a person active in two cities is counted in each).</p>
+
+    <h3 class="ac-chart-group-title" id="cumulative-totals">Cumulative totals (all time)</h3>
+    <div class="ac-charts">
+      <div class="ac-chart">
+        <h4 class="ac-chart-title">Total labels</h4>
+        <div class="mini-chart" id="ac-chart-cum-labels"></div>
+      </div>
+      <div class="ac-chart">
+        <h4 class="ac-chart-title">Total validations</h4>
+        <div class="mini-chart" id="ac-chart-cum-validations"></div>
+      </div>
+      <div class="ac-chart">
+        <h4 class="ac-chart-title">Total users</h4>
+        <div class="mini-chart" id="ac-chart-cum-users"></div>
+      </div>
+    </div>
+    <p class="ac-note">“Users” counts each person once per city, in the week of their first label or validation — returning contributors aren't re-counted, but a person who contributes in two cities is counted in each.</p>
+
+    <h3 class="ac-chart-group-title" id="this-week">This week (rolling 7 days)</h3>
+    <div class="ac-charts">
+      <div class="ac-chart">
+        <h4 class="ac-chart-title">Labels per day</h4>
+        <div class="mini-chart" id="ac-chart-week-labels"></div>
+      </div>
+      <div class="ac-chart">
+        <h4 class="ac-chart-title">Validations per day</h4>
+        <div class="mini-chart" id="ac-chart-week-validations"></div>
+      </div>
+      <div class="ac-chart">
+        <h4 class="ac-chart-title">Active users per day</h4>
+        <div class="mini-chart" id="ac-chart-week-users"></div>
+      </div>
+    </div>
+    <p class="ac-note">“Active users” counts distinct people who labeled or validated that day, summed across cities (a person active in two cities is counted in each). The last bar is today, still filling in.</p>
   </div>
 
   <div class="api-section" id="ac-scorecard-section">

--- a/public/css/admin-dashboard/admin-dashboard.css
+++ b/public/css/admin-dashboard/admin-dashboard.css
@@ -1943,6 +1943,13 @@ img.activity-feed-thumb:hover { box-shadow: 0 2px 6px rgb(0 0 0 / 18%); }
   margin: 0 0 var(--space-xs, 8px);
 }
 
+/* Sub-group headings inside the over-time section (weekly / cumulative / this week, #4686). */
+.ac-chart-group-title {
+  font-size: var(--font-size-md, 1rem);
+  color: var(--color-text-heading, #263238);
+  margin: var(--space-lg, 24px) 0 var(--space-sm, 12px);
+}
+
 .ac-note {
   font-size: var(--font-size-xs, 0.8125rem);
   color: var(--color-text-secondary, #5a7785);
@@ -1969,6 +1976,11 @@ img.activity-feed-thumb:hover { box-shadow: 0 2px 6px rgb(0 0 0 / 18%); }
   stroke-width: 2;
 }
 .mini-pt--acusers    { fill: var(--color-label-no-sidewalk); }
+
+/* Bar variants for the "this week" charts (#4686), matching the line-series colors. */
+.mini-bar--aclabels  { fill: var(--color-primary, #4a90d9); }
+.mini-bar--acvals    { fill: #63c0ab; }
+.mini-bar--acusers   { fill: var(--color-label-no-sidewalk); }
 
 /* Per-city activity sparkline. */
 .ac-spark-cell {

--- a/public/css/admin-dashboard/admin-dashboard.css
+++ b/public/css/admin-dashboard/admin-dashboard.css
@@ -603,6 +603,27 @@
   font-family: var(--font-sans, sans-serif);
 }
 
+/* Per-bar value labels (opts.barValues). Text tokens, not the series color, so the numbers stay readable. */
+.mini-value {
+  fill: var(--color-text-secondary, #5a7785);
+  font-size: 11px;
+  font-weight: 600;
+  font-family: var(--font-sans, sans-serif);
+}
+
+/* Emphasized category (opts.emphasisIndex — e.g. the in-progress "today" bar): bolder, darker text; the bar itself
+   renders with a lighter fill + solid outline so a partial period reads as still accumulating. */
+.mini-axis--emphasis,
+.mini-value--emphasis {
+  fill: var(--color-text-primary, #222222);
+  font-weight: 700;
+}
+
+.mini-bar--emphasis {
+  fill-opacity: 0.45;
+  stroke-width: 1.5;
+}
+
 .mini-line {
   fill: none;
   stroke-width: 2;
@@ -1977,10 +1998,14 @@ img.activity-feed-thumb:hover { box-shadow: 0 2px 6px rgb(0 0 0 / 18%); }
 }
 .mini-pt--acusers    { fill: var(--color-label-no-sidewalk); }
 
-/* Bar variants for the "this week" charts (#4686), matching the line-series colors. */
+/* Bar variants for the "this week" charts (#4686), matching the line-series colors. The emphasis outline uses each
+   series' own color so today's lighter bar still reads as part of the series. */
 .mini-bar--aclabels  { fill: var(--color-primary, #4a90d9); }
 .mini-bar--acvals    { fill: #63c0ab; }
 .mini-bar--acusers   { fill: var(--color-label-no-sidewalk); }
+.mini-bar--emphasis.mini-bar--aclabels { stroke: var(--color-primary, #4a90d9); }
+.mini-bar--emphasis.mini-bar--acvals   { stroke: #63c0ab; }
+.mini-bar--emphasis.mini-bar--acusers  { stroke: var(--color-label-no-sidewalk); }
 
 /* Per-city activity sparkline. */
 .ac-spark-cell {

--- a/public/js/admin-dashboard/AcrossCitiesPage.js
+++ b/public/js/admin-dashboard/AcrossCitiesPage.js
@@ -2,7 +2,8 @@
  * Renders the admin "Across Cities" page (#4329): a cross-deployment overview of every Project Sidewalk city across
  * four lenses — coverage (how much is left), activity (what's happening and when), data patterns (the label-type mix,
  * city vs city), and data quality (how trustworthy the data is). Adds a "needs attention" panel from server-computed
- * anomaly flags and three overview line charts (labels / validations / active users per week, summed across cities).
+ * anomaly flags and an over-time section (#4686): weekly line charts (labels / validations / active users, summed
+ * across cities), cumulative all-time totals, and rolling-7-day bar charts.
  *
  * Plain HTML/CSS plus the shared MiniLineChart for the over-time charts and small inline-SVG sparklines for the
  * per-city activity trend. Owner-only; driven entirely from /adminapi/cityScorecards.
@@ -81,6 +82,7 @@ class AcrossCitiesPage {
   #cities = [];          // The latest scorecard rows, as returned by the endpoint.
   #summary = {};         // The summary block (thresholds + cross-city median + hero totals).
   #allTimeTrend = [];    // Cross-city weekly series for the full project history (the "All time" toggle).
+  #dailyTrend = [];      // Cross-city daily series for the trailing 7 days (the "this week" bar charts, #4686).
   #trendSeries = {};     // { recent: [...], all: [...] } weekly aggregates for the over-time charts.
   #trendRange = 'recent';// Which over-time range is shown: 'recent' (12 wks) | 'all'.
   #sortKey = 'coverage'; // Current sort column.
@@ -109,6 +111,7 @@ class AcrossCitiesPage {
       this.#cities = (data && data.cities) || [];
       this.#summary = (data && data.summary) || {};
       this.#allTimeTrend = (data && data.over_time_all_time) || [];
+      this.#dailyTrend = (data && data.over_time_daily) || [];
       this.#renderHero();
       this.#renderMap(citiesGeo);
       this.#renderPulse();
@@ -365,7 +368,8 @@ class AcrossCitiesPage {
 
   /**
    * Prepares the two over-time datasets (last 12 weeks, summed from each city's trend; and all-time, from the
-   * server-aggregated series), wires the range toggle, and draws the current range.
+   * server-aggregated series), wires the range toggle, and draws the current range. Also draws the toggle-independent
+   * cumulative and this-week charts (#4686), which are static once loaded.
    */
   #renderTrends() {
     this.#trendSeries = {
@@ -384,6 +388,8 @@ class AcrossCitiesPage {
       });
     }
     this.#drawTrends();
+    this.#drawCumulative();
+    this.#drawWeekBars();
   }
 
   /** Sums a flat list of weekly points into one cross-city series, ascending by week. */
@@ -402,7 +408,9 @@ class AcrossCitiesPage {
   /** Draws the three over-time line charts for the currently selected range. */
   #drawTrends() {
     const series = this.#trendSeries[this.#trendRange] || [];
-    const cats = series.map((w) => AcrossCitiesPage.#shortDate(w.week_start));
+    // Multi-year x-axes carry the year; within 12 weeks "Jun 9" is unambiguous.
+    const fmt = this.#trendRange === 'all' ? AcrossCitiesPage.#shortDateYear : AcrossCitiesPage.#shortDate;
+    const cats = series.map((w) => fmt(w.week_start));
     // Small dots on the short (12-week) view where they aid hover tooltips; none on the dense all-time view, where
     // hundreds of points would just be noise.
     const dotRadius = series.length > 30 ? 0 : 2;
@@ -413,6 +421,47 @@ class AcrossCitiesPage {
     draw('ac-chart-labels', 'aclabels', 'Labels', series.map((w) => w.labels));
     draw('ac-chart-validations', 'acvals', 'Validations', series.map((w) => w.validations));
     draw('ac-chart-users', 'acusers', 'Active users', series.map((w) => w.active_users));
+  }
+
+  /**
+   * Draws the cumulative all-time line charts (#4686) by prefix-summing the server's all-time weekly series. Labels
+   * and validations accumulate their weekly counts; users accumulate new_users (each person's first-activity week),
+   * since summing weekly active_users would re-count returning contributors.
+   */
+  #drawCumulative() {
+    const series = this.#allTimeTrend;
+    const cats = series.map((w) => AcrossCitiesPage.#shortDateYear(w.week_start));
+    const cumulative = (key) => {
+      let total = 0;
+      return series.map((w) => (total += w[key] || 0));
+    };
+    const draw = (id, key, name, values) => {
+      const host = document.getElementById(id);
+      if (host) MiniLineChart.renderInto(host, cats, [{ name, key, values }], { ariaLabel: name, dotRadius: 0 });
+    };
+    draw('ac-chart-cum-labels', 'aclabels', 'Total labels', cumulative('labels'));
+    draw('ac-chart-cum-validations', 'acvals', 'Total validations', cumulative('validations'));
+    draw('ac-chart-cum-users', 'acusers', 'Total users', cumulative('new_users'));
+  }
+
+  /**
+   * Draws the rolling-7-day bar charts (#4686) from the server's zero-filled daily series. A rolling 7-day window
+   * holds exactly one of each weekday, so short weekday names are unambiguous x labels; tooltips carry the full date.
+   */
+  #drawWeekBars() {
+    const series = this.#dailyTrend;
+    const cats = series.map((d) => AcrossCitiesPage.#weekday(d.day));
+    const draw = (id, key, jsonKey, name) => {
+      const host = document.getElementById(id);
+      if (!host) return;
+      const values = series.map((d) => d[jsonKey] || 0);
+      const tooltips = series.map((d, i) => `${AcrossCitiesPage.#shortDate(d.day)} · ${name}: ${this.#num(values[i])}`);
+      MiniLineChart.renderInto(host, cats, [{ name, key, values, tooltips }],
+        { ariaLabel: name, kind: 'bar', maxXLabels: 7 });
+    };
+    draw('ac-chart-week-labels', 'aclabels', 'labels', 'Labels');
+    draw('ac-chart-week-validations', 'acvals', 'validations', 'Validations');
+    draw('ac-chart-week-users', 'acusers', 'active_users', 'Active users');
   }
 
   // --- Scorecard table --------------------------------------------------------------------------------------------
@@ -921,6 +970,20 @@ class AcrossCitiesPage {
     const d = new Date(`${iso}T00:00:00`);
     if (isNaN(d)) return iso;
     return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  }
+
+  /** "Jun '19"-style month + year from an ISO date string, for multi-year x-axes. */
+  static #shortDateYear(iso) {
+    const d = new Date(`${iso}T00:00:00`);
+    if (isNaN(d)) return iso;
+    return `${d.toLocaleDateString(undefined, { month: 'short' })} '${String(d.getFullYear()).slice(-2)}`;
+  }
+
+  /** "Thu"-style short weekday from an ISO date string. */
+  static #weekday(iso) {
+    const d = new Date(`${iso}T00:00:00`);
+    if (isNaN(d)) return iso;
+    return d.toLocaleDateString(undefined, { weekday: 'short' });
   }
 
   /** Compact relative time ("just now", "5m ago", "3h ago", "2d ago", or a date for older items). */

--- a/public/js/admin-dashboard/AcrossCitiesPage.js
+++ b/public/js/admin-dashboard/AcrossCitiesPage.js
@@ -456,8 +456,11 @@ class AcrossCitiesPage {
       if (!host) return;
       const values = series.map((d) => d[jsonKey] || 0);
       const tooltips = series.map((d, i) => `${AcrossCitiesPage.#shortDate(d.day)} · ${name}: ${this.#num(values[i])}`);
+      // Compact value labels above each bar (exact counts stay in the tooltips); the last bar is today, still
+      // filling in, so it gets the emphasis treatment.
       MiniLineChart.renderInto(host, cats, [{ name, key, values, tooltips }],
-        { ariaLabel: name, kind: 'bar', maxXLabels: 7 });
+        { ariaLabel: name, kind: 'bar', maxXLabels: 7, barValues: true, valueFormat: (v) => this.#compact(v),
+          emphasisIndex: series.length - 1 });
     };
     draw('ac-chart-week-labels', 'aclabels', 'labels', 'Labels');
     draw('ac-chart-week-validations', 'acvals', 'validations', 'Validations');

--- a/public/js/admin-dashboard/MiniLineChart.js
+++ b/public/js/admin-dashboard/MiniLineChart.js
@@ -1,9 +1,10 @@
 /**
- * MiniLineChart — a tiny, dependency-free SVG line chart for the admin dashboard. Renders one or more series over a
- * shared set of x categories, with a fixed or auto y-max, gridlines, hover tooltips, and a legend (when >1 series).
- * Series colors come from CSS classes (`.mini-line--<key>` / `.mini-pt--<key>` / `.mini-swatch--<key>`) so callers
- * style them with design tokens. Shared by the Data Quality (agreement-over-time) and API Analytics (usage-over-time)
- * pages so the chart isn't duplicated.
+ * MiniLineChart — a tiny, dependency-free SVG chart for the admin dashboard. Renders one or more series over a shared
+ * set of x categories as lines (default) or bars (`kind: 'bar'`), with a fixed or auto y-max, gridlines, hover
+ * tooltips, and a legend (when >1 series). Series colors come from CSS classes (`.mini-line--<key>` /
+ * `.mini-pt--<key>` / `.mini-bar--<key>` / `.mini-swatch--<key>`) so callers style them with design tokens. Shared by
+ * the Data Quality (agreement-over-time), API Analytics (usage-over-time), and Across Cities pages so the chart isn't
+ * duplicated.
  */
 class MiniLineChart {
   /**
@@ -11,8 +12,10 @@ class MiniLineChart {
    * @param {Array<{name: string, key: string, values: Array<number|null>, tooltips?: string[]}>} series -
    *   each series' values align to `categories`; null = gap. Optional per-point tooltip strings.
    * @param {{yMax?: number, tickFormat?: function(number): string, valueFormat?: function(number): string,
-   *          ariaLabel?: string, dotRadius?: number}} [opts] - yMax defaults to the data max; tickFormat labels the
-   *   y-axis; valueFormat formats values in the default tooltip; dotRadius sizes the point markers (default 3).
+   *          ariaLabel?: string, dotRadius?: number, kind?: string, maxXLabels?: number}} [opts] - yMax defaults to
+   *   the data max; tickFormat labels the y-axis; valueFormat formats values in the default tooltip; dotRadius sizes
+   *   the point markers (default 3); kind 'bar' draws bars instead of lines; maxXLabels caps how many x labels are
+   *   drawn (default 6).
    * @returns {string} SVG markup plus an optional HTML legend.
    */
   static svg(categories, series, opts = {}) {
@@ -22,7 +25,9 @@ class MiniLineChart {
     const iw = W - m.l - m.r;
     const ih = H - m.t - m.b;
     const n = categories.length;
-    const x = (i) => m.l + (n === 1 ? iw / 2 : (i / (n - 1)) * iw);
+    const isBar = opts.kind === 'bar';
+    // Bars sit on band centers; line points span the full width edge to edge.
+    const x = (i) => (isBar ? m.l + ((i + 0.5) / n) * iw : m.l + (n === 1 ? iw / 2 : (i / (n - 1)) * iw));
     const yFrac = (f) => m.t + (1 - f) * ih; // f in [0, 1]
     const allVals = series.flatMap((s) => s.values.filter((v) => v !== null && v !== undefined));
     const yMax = opts.yMax || Math.max(1, ...allVals);
@@ -39,28 +44,48 @@ class MiniLineChart {
     }
 
     let body = '';
-    for (const s of series) {
-      let d = '';
-      let move = true;
-      s.values.forEach((v, i) => {
-        if (v === null || v === undefined) {
-          move = true;
-          return;
-        }
-        d += `${move ? 'M' : 'L'}${x(i).toFixed(1)},${yFrac(v / yMax).toFixed(1)} `;
-        move = false;
+    if (isBar) {
+      // With multiple series, each band is split into side-by-side bars (grouped, not stacked).
+      const band = iw / n;
+      const groupW = Math.min(band * 0.62, 48 * series.length);
+      const barW = groupW / series.length;
+      series.forEach((s, si) => {
+        body += s.values.map((v, i) => {
+          if (v === null || v === undefined) return '';
+          const top = yFrac(v / yMax);
+          const h = m.t + ih - top;
+          if (h <= 0) return ''; // Zero values draw no bar; the x label still marks the category.
+          const bx = x(i) - groupW / 2 + si * barW;
+          const tip = s.tooltips?.[i] ?? `${categories[i]} · ${s.name}: ${valueFormat(v)}`;
+          return `<rect class="mini-bar mini-bar--${s.key}" x="${bx.toFixed(1)}" y="${top.toFixed(1)}" `
+            + `width="${barW.toFixed(1)}" height="${h.toFixed(1)}">`
+            + `<title>${MiniLineChart.#esc(tip)}</title></rect>`;
+        }).join('');
       });
-      const dots = s.values.map((v, i) => {
-        if (v === null || v === undefined) return '';
-        const tip = s.tooltips?.[i] ?? `${categories[i]} · ${s.name}: ${valueFormat(v)}`;
-        return `<circle class="mini-pt mini-pt--${s.key}" cx="${x(i).toFixed(1)}" `
-          + `cy="${yFrac(v / yMax).toFixed(1)}" r="${dotRadius}">`
-          + `<title>${MiniLineChart.#esc(tip)}</title></circle>`;
-      }).join('');
-      body += `<path class="mini-line mini-line--${s.key}" d="${d.trim()}"/>${dots}`;
+    } else {
+      for (const s of series) {
+        let d = '';
+        let move = true;
+        s.values.forEach((v, i) => {
+          if (v === null || v === undefined) {
+            move = true;
+            return;
+          }
+          d += `${move ? 'M' : 'L'}${x(i).toFixed(1)},${yFrac(v / yMax).toFixed(1)} `;
+          move = false;
+        });
+        const dots = s.values.map((v, i) => {
+          if (v === null || v === undefined) return '';
+          const tip = s.tooltips?.[i] ?? `${categories[i]} · ${s.name}: ${valueFormat(v)}`;
+          return `<circle class="mini-pt mini-pt--${s.key}" cx="${x(i).toFixed(1)}" `
+            + `cy="${yFrac(v / yMax).toFixed(1)}" r="${dotRadius}">`
+            + `<title>${MiniLineChart.#esc(tip)}</title></circle>`;
+        }).join('');
+        body += `<path class="mini-line mini-line--${s.key}" d="${d.trim()}"/>${dots}`;
+      }
     }
 
-    const step = Math.max(1, Math.ceil(n / 6));
+    const step = Math.max(1, Math.ceil(n / (opts.maxXLabels || 6)));
     let xlab = '';
     for (let i = 0; i < n; i += step) {
       xlab += `<text class="mini-axis" x="${x(i).toFixed(1)}" y="${H - 8}" text-anchor="middle">`

--- a/public/js/admin-dashboard/MiniLineChart.js
+++ b/public/js/admin-dashboard/MiniLineChart.js
@@ -12,10 +12,12 @@ class MiniLineChart {
    * @param {Array<{name: string, key: string, values: Array<number|null>, tooltips?: string[]}>} series -
    *   each series' values align to `categories`; null = gap. Optional per-point tooltip strings.
    * @param {{yMax?: number, tickFormat?: function(number): string, valueFormat?: function(number): string,
-   *          ariaLabel?: string, dotRadius?: number, kind?: string, maxXLabels?: number}} [opts] - yMax defaults to
-   *   the data max; tickFormat labels the y-axis; valueFormat formats values in the default tooltip; dotRadius sizes
-   *   the point markers (default 3); kind 'bar' draws bars instead of lines; maxXLabels caps how many x labels are
-   *   drawn (default 6).
+   *          ariaLabel?: string, dotRadius?: number, kind?: string, maxXLabels?: number, barValues?: boolean,
+   *          emphasisIndex?: number}} [opts] - yMax defaults to the data max; tickFormat labels the y-axis;
+   *   valueFormat formats values in the default tooltip and in bar value labels; dotRadius sizes the point markers
+   *   (default 3); kind 'bar' draws bars instead of lines; maxXLabels caps how many x labels are drawn (default 6);
+   *   barValues draws each bar's value above it (meant for single-series bar charts — grouped bars would collide);
+   *   emphasisIndex marks that index's bar and labels with `--emphasis` classes (e.g. an in-progress "today" bar).
    * @returns {string} SVG markup plus an optional HTML legend.
    */
   static svg(categories, series, opts = {}) {
@@ -52,14 +54,23 @@ class MiniLineChart {
       series.forEach((s, si) => {
         body += s.values.map((v, i) => {
           if (v === null || v === undefined) return '';
+          const emph = i === opts.emphasisIndex;
           const top = yFrac(v / yMax);
           const h = m.t + ih - top;
-          if (h <= 0) return ''; // Zero values draw no bar; the x label still marks the category.
           const bx = x(i) - groupW / 2 + si * barW;
           const tip = s.tooltips?.[i] ?? `${categories[i]} · ${s.name}: ${valueFormat(v)}`;
-          return `<rect class="mini-bar mini-bar--${s.key}" x="${bx.toFixed(1)}" y="${top.toFixed(1)}" `
-            + `width="${barW.toFixed(1)}" height="${h.toFixed(1)}">`
-            + `<title>${MiniLineChart.#esc(tip)}</title></rect>`;
+          // Zero values draw no bar; the x label (and value label, if enabled) still mark the category.
+          let out = h <= 0
+            ? ''
+            : `<rect class="mini-bar mini-bar--${s.key}${emph ? ' mini-bar--emphasis' : ''}" x="${bx.toFixed(1)}" `
+              + `y="${top.toFixed(1)}" width="${barW.toFixed(1)}" height="${h.toFixed(1)}">`
+              + `<title>${MiniLineChart.#esc(tip)}</title></rect>`;
+          if (opts.barValues) {
+            out += `<text class="mini-value${emph ? ' mini-value--emphasis' : ''}" x="${(bx + barW / 2).toFixed(1)}" `
+              + `y="${((h > 0 ? top : yFrac(0)) - 4).toFixed(1)}" text-anchor="middle">`
+              + `${MiniLineChart.#esc(valueFormat(v))}</text>`;
+          }
+          return out;
         }).join('');
       });
     } else {
@@ -88,7 +99,8 @@ class MiniLineChart {
     const step = Math.max(1, Math.ceil(n / (opts.maxXLabels || 6)));
     let xlab = '';
     for (let i = 0; i < n; i += step) {
-      xlab += `<text class="mini-axis" x="${x(i).toFixed(1)}" y="${H - 8}" text-anchor="middle">`
+      const emph = i === opts.emphasisIndex ? ' mini-axis--emphasis' : '';
+      xlab += `<text class="mini-axis${emph}" x="${x(i).toFixed(1)}" y="${H - 8}" text-anchor="middle">`
         + `${MiniLineChart.#esc(categories[i])}</text>`;
     }
     const svg = `<svg class="mini-chart-svg" viewBox="0 0 ${W} ${H}" preserveAspectRatio="xMidYMid meet" role="img" `

--- a/test/js/miniLineChartBars.test.js
+++ b/test/js/miniLineChartBars.test.js
@@ -1,0 +1,73 @@
+/**
+ * Tests for public/js/admin-dashboard/MiniLineChart.js bar-mode value labels and emphasis (#4686).
+ *
+ * The rolling-7-day "this week" charts on /admin/across-cities label each bar with its value and emphasize the final,
+ * still-accumulating "today" bar. These tests pin that contract: one label per bar (including a "0" over an empty
+ * band, which draws no rect), the --emphasis classes landing on exactly the requested index, and the default bar
+ * output staying label-free so other MiniLineChart callers are unaffected.
+ *
+ * Runs under jsdom (jest.config.js); MiniLineChart.svg is a pure string builder, so tests parse its output into a
+ * detached container and assert on the resulting DOM.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const CHART_PATH = path.resolve(__dirname, '..', '..', 'public/js/admin-dashboard/MiniLineChart.js');
+
+/** Load MiniLineChart.js (a plain top-level class declaration, concatenation-style) and return the class. */
+function loadMiniLineChart() {
+    const src = fs.readFileSync(CHART_PATH, 'utf8');
+    // Indirect eval runs the script in global scope; the trailing expression hands the class binding back out.
+    return (0, eval)(`${src}\nMiniLineChart;`);
+}
+
+describe('MiniLineChart bar mode', () => {
+    const CATS = ['Fri', 'Sat', 'Sun', 'Mon', 'Tue', 'Wed', 'Thu'];
+    const VALUES = [5, 0, 1234, 8, 15, 3, 2];
+    let MiniLineChart;
+
+    /** Render one bar series into a detached div and return the div for querying. */
+    function render(opts = {}) {
+        const div = document.createElement('div');
+        div.innerHTML = MiniLineChart.svg(CATS, [{ name: 'Labels', key: 'aclabels', values: VALUES }],
+            { kind: 'bar', maxXLabels: 7, ...opts });
+        return div;
+    }
+
+    beforeEach(() => {
+        MiniLineChart = loadMiniLineChart();
+    });
+
+    test('barValues draws one formatted label per bar, including "0" over a zero band with no rect', () => {
+        const div = render({ barValues: true });
+        const labels = [...div.querySelectorAll('text.mini-value')].map((t) => t.textContent);
+        expect(labels).toEqual(['5', '0', '1,234', '8', '15', '3', '2']);
+        // The zero value draws a label but no bar.
+        expect(div.querySelectorAll('rect.mini-bar')).toHaveLength(6);
+    });
+
+    test('barValues labels use a caller-supplied valueFormat', () => {
+        const div = render({ barValues: true, valueFormat: (v) => `${v}!` });
+        const labels = [...div.querySelectorAll('text.mini-value')].map((t) => t.textContent);
+        expect(labels[2]).toBe('1234!');
+    });
+
+    test('emphasisIndex marks exactly that bar, its value label, and its x label', () => {
+        const last = VALUES.length - 1;
+        const div = render({ barValues: true, emphasisIndex: last });
+        expect(div.querySelectorAll('rect.mini-bar--emphasis')).toHaveLength(1);
+        const emphValues = div.querySelectorAll('text.mini-value--emphasis');
+        expect(emphValues).toHaveLength(1);
+        expect(emphValues[0].textContent).toBe('2');
+        const emphAxis = div.querySelectorAll('text.mini-axis--emphasis');
+        expect(emphAxis).toHaveLength(1);
+        expect(emphAxis[0].textContent).toBe('Thu');
+    });
+
+    test('defaults stay label- and emphasis-free', () => {
+        const div = render();
+        expect(div.querySelectorAll('text.mini-value')).toHaveLength(0);
+        expect(div.querySelectorAll('.mini-bar--emphasis, .mini-axis--emphasis')).toHaveLength(0);
+    });
+});

--- a/test/service/ConfigServiceTrendSpec.scala
+++ b/test/service/ConfigServiceTrendSpec.scala
@@ -1,0 +1,84 @@
+package service
+
+import org.scalatestplus.play.PlaySpec
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+
+import java.time.{LocalDate, ZoneId}
+import scala.concurrent.Await
+import scala.concurrent.duration.DurationInt
+
+/**
+ * DB-backed invariant tests for the cross-city over-time series behind the Across Cities admin page (#4329, #4686):
+ * the weekly trend (with the new-users column feeding the cumulative-users chart) and the trailing-7-day daily trend
+ * (feeding the "this week" bar charts).
+ *
+ * Contract/shape over data values: every assertion holds against whatever the connected DB contains — ordering,
+ * ranges, and cross-field relationships, never specific numbers.
+ *
+ * Requires a Postgres+PostGIS database (via DATABASE_URL / DATABASE_USER / DATABASE_PASSWORD env).
+ */
+class ConfigServiceTrendSpec extends PlaySpec with GuiceOneAppPerSuite {
+
+  override def fakeApplication(): Application =
+    new GuiceApplicationBuilder().disable[modules.ActorModule].build()
+
+  private val configService = app.injector.instanceOf[ConfigService]
+
+  private def await[T](f: => scala.concurrent.Future[T]): T = Await.result(f, 120.seconds)
+
+  "getCrossCityWeeklyTrend(None)" should {
+    lazy val allTime = await(configService.getCrossCityWeeklyTrend(None))
+
+    "return weeks ascending and unique with non-negative counts" in {
+      allTime.map(_.weekStart) mustBe allTime.map(_.weekStart).distinct.sorted
+      allTime.foreach { w =>
+        w.labels must be >= 0
+        w.validations must be >= 0
+        w.activeUsers must be >= 0
+        w.newUsers must be >= 0
+      }
+    }
+
+    "count each week's new users among that week's active users" in {
+      // A user's first-activity week is by definition a week they were active, so per week newUsers <= activeUsers.
+      allTime.foreach { w => w.newUsers must be <= w.activeUsers }
+    }
+
+    "have every distinct active user enter the cumulative series exactly once" in {
+      // Every user active in ANY week has exactly one first-activity week, so no single week's active-user count can
+      // exceed the all-time new-user total (= the cumulative users chart's final value).
+      if (allTime.nonEmpty) {
+        allTime.map(_.activeUsers).max must be <= allTime.map(_.newUsers).sum
+      }
+    }
+  }
+
+  "getCrossCityWeeklyTrend(Some(n))" should {
+    "leave newUsers at 0 (first-ever activity is unknowable in a trailing window)" in {
+      val recent = await(configService.getCrossCityWeeklyTrend(Some(12)))
+      // A 12-week trailing bound can straddle 13 calendar weeks (partial weeks at both ends).
+      recent.length must be <= 13
+      recent.foreach { w => w.newUsers mustBe 0 }
+    }
+  }
+
+  "getCrossCityDailyTrend(7)" should {
+    "return exactly 7 consecutive Pacific days ending today, zero-filled" in {
+      val before = LocalDate.now(ZoneId.of("US/Pacific"))
+      val daily  = await(configService.getCrossCityDailyTrend(7))
+      val after  = LocalDate.now(ZoneId.of("US/Pacific"))
+
+      daily.length mustBe 7
+      daily.zip(daily.tail).foreach { case (a, b) => b.day mustBe a.day.plusDays(1) }
+      // The run may legitimately cross midnight Pacific between the call and this assertion.
+      Seq(before, after) must contain(daily.last.day)
+      daily.foreach { d =>
+        d.labels must be >= 0
+        d.validations must be >= 0
+        d.activeUsers must be >= 0
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #4686.

Adds two chart groups to the **Over time** section of `/admin/across-cities`, alongside the existing weekly line charts:

1. **Cumulative totals (all time)** — line charts for total labels, validations, and users, prefix-summed client-side from the all-time weekly series. For users, the endpoint's `over_time_all_time` entries gain a `new_users` field (users whose *first-ever* label/validation fell in that week) — cumulative distinct users can't be derived from weekly `active_users`, which re-counts returning contributors.
2. **This week (rolling 7 days)** — bar charts of labels, validations, and active users per day, from a new `over_time_daily` array (trailing 7 Pacific calendar days, zero-filled server-side, today partial).

Both use the same activity definition/exclusions as the existing weekly trend (excluded users, deleted/tutorial labels) and the same per-schema fan-out across all city deployments, so all three groups reconcile.

Per Jon's request, each group carries a footnote pinning down what "users" means there (first-activity-week counting for cumulative; per-day distinct for the bars; both summed per city, so a person active in two cities counts in each).

## Implementation
- `ConfigTable.getCityWeeklyTrendBySchema`: restructured around an `activity` CTE; full-history calls add first-activity-week CTEs for `new_users` (bounded calls return 0 — a trailing window can't know a user's true first week, and nothing in the 12-week view uses it).
- New `ConfigTable.getCityDailyTrendBySchema` + `ConfigService.getCrossCityDailyTrend(7)` (same fan-out/sum/10-min-cache pattern as the weekly trend; index-friendly coarse time bound, exact Pacific-day window trimmed + zero-filled in the service).
- `MiniLineChart` gains a bar mode (`kind: 'bar'`, grouped bars, tooltips) and a `maxXLabels` option, so the chart component isn't duplicated; bar colors ride new `.mini-bar--<key>` CSS classes matching the existing line series.
- All-time x-axes (weekly toggle + cumulative) now carry the year (`Apr '19`) since they span multiple years; the 7-day bars use weekday labels (a rolling 7-day window holds exactly one of each weekday).

## Testing
- New DB-backed `ConfigServiceTrendSpec` (5 tests, green): weekly series ordering/ranges, `new_users ≤ active_users` per week, every active user entering the cumulative series exactly once, bounded calls returning `new_users = 0`, and the daily series being exactly 7 consecutive Pacific days ending today.
- New weekly SQL validated directly against `sidewalk_seattle`: `SUM(new_users)` exactly equals the distinct non-excluded contributor count (6020).
- `sbt compile` (fatal-warnings) green; scalafmt, ESLint, Stylelint, HTMLHint clean.

## QA checklist (needs an Owner account)
- [ ] `/admin/across-cities` → Over time: three groups render (Weekly totals / Cumulative totals / This week)
- [ ] Cumulative lines are monotonically non-decreasing; final cumulative-users value looks plausible vs the hero Contributors stat (same per-city summing)
- [ ] 7 bars per this-week chart, weekday labels, hover tooltips show full date + count; last bar = today (partial)
- [ ] 12 weeks / All time toggle still works and only affects the Weekly totals group

🤖 Generated with [Claude Code](https://claude.com/claude-code)