### PR TITLE
make qa-worktree: run the worktree's own copy of the script (#4628)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -382,7 +382,12 @@ and launch `sbt ~ run` with `-Dconfig.file` at the worktree's own conf and the s
 `.coursier`/`.sbt` (cwd-relative caches from a worktree would re-download gigabytes). The first HTTP request triggers the
 dev compile; **Ctrl-C stops the app and reaps the grunt watch** (a trap, so the watcher never lingers). To tear a session
 down out-of-band, run **`make qa-worktree-stop wt=<name>`** (add `clean=1` to also drop the `node_modules` symlink).
-Implementation: `tools/qa-worktree.sh`.
+Implementation: `tools/qa-worktree.sh` — both targets run the **worktree's own** copy of that script when it has one
+(falling back to the main checkout's), so the branch being QA'd supplies its own tooling.
+
+`make` itself still reads the **main checkout's** Makefile, so when that checkout sits on a branch without the target,
+make reports `No rule to make target 'qa-worktree'`. Either check out a branch that has it, or run the worktree's script
+directly: `docker exec -it projectsidewalk-web bash /home/.claude/worktrees/<name>/tools/qa-worktree.sh <name>`.
 
 **Admin-authenticated QA:** the dev DB is seeded from a dump that includes real accounts and their bcrypt password
 hashes, and password verification is config-independent (plain bcrypt, no server-side pepper), so if your own account is
@@ -455,7 +460,26 @@ docker exec projectsidewalk-db psql -U readonly_user -d sidewalk -c "\dt sidewal
 docker exec projectsidewalk-db psql -U readonly_user -d sidewalk -c "SELECT * FROM sidewalk_login.role;"
 ```
 
-Each city has its own schema (`sidewalk_<city>`), and they are essentially identical — `sidewalk_seattle` is a safe default for schema questions; authentication lives in `sidewalk_login`. If you need to query *actual data* (not just structure), **ask which city we're working in first**. Evolutions in `conf/evolutions/default/` are auto-applied when a page loads, so you don't run them manually.
+Each city has its own schema (`sidewalk_<city>`), and they are essentially identical — `sidewalk_seattle` is a safe default for **schema** questions; authentication lives in `sidewalk_login`. Evolutions in `conf/evolutions/default/` are auto-applied when a page loads, so you don't run them manually.
+
+**For anything about *data* or *migration state*, first find out which city is actually running** — don't assume `sidewalk_seattle`:
+
+```bash
+docker exec projectsidewalk-web bash -lc 'echo $DATABASE_USER'   # this value IS the active schema name
+```
+
+`DATABASE_USER` selects the schema and is authoritative; `SIDEWALK_CITY_ID` only selects `cityparams.conf` entries (map center, bounds, display name). The two are *supposed* to correspond (see [`docs/dev-environment.md`](docs/dev-environment.md) → "City IDs"), but a container can be left with them **mismatched**, in which case the app renders one city's params over another city's data — an empty map with no error in any log. Confirm what the app believes it is with `curl -s -b <cookie-jar> localhost:9000/labelmap | grep -oE 'cityId: "[^"]*"'`.
+
+**`readonly_user` cannot see every schema, and the failure is silent.** It is granted per-schema, so it may have no rights on the active city's schema — and `information_schema` / `\dt` simply **omit** what you can't see rather than erroring, which reads as "that schema doesn't exist" or "that evolution never applied". `pg_namespace` is world-readable, so enumerate with it, then query the city as its own role:
+
+```bash
+docker exec projectsidewalk-db psql -U readonly_user -d sidewalk -tAc \
+  "SELECT nspname FROM pg_namespace WHERE nspname LIKE 'sidewalk%' ORDER BY 1"
+docker exec projectsidewalk-db psql -U sidewalk_teaneck -d sidewalk -c \
+  "SELECT max(id) FROM sidewalk_teaneck.play_evolutions"
+```
+
+Never conclude "evolution N didn't apply" from a `readonly_user` query without first confirming which schema the app uses.
 
 **The dev DB is not representative of production size, and some tables may be absent.** The two largest production tables by a wide margin are **`audit_task_interaction`** and **`validation_task_interaction`** (raw per-action interaction logs — pans, zooms, clicks). The dev DB dumps that seed local development **omit** these tables to stay manageable, so locally they are typically empty or missing. Never infer a table's production size or existence from the local DB. When reasoning about query cost or indexes, treat these two interaction tables — not `webpage_activity` — as the heavyweight logs.
 

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,20 @@ clean ?=
 # `clean=1` (or true/yes) expands to the qa-worktree-stop --clean flag; anything else (incl. empty) expands to nothing.
 qa-stop-clean-flag = $(if $(filter 1 true yes,$(clean)),--clean,)
 
+# Resolve which copy of qa-worktree.sh to run, then exec it with the args in $(1). The main repo is mounted at the
+# container's /home, so /home/tools/qa-worktree.sh is the script as it exists on whatever branch the MAIN checkout
+# happens to be on — which may predate the script entirely (#4628). Prefer the worktree's own copy so the branch being
+# QA'd supplies its own tooling, and fall back to the main repo's for worktrees branched before the script existed.
+# Held in a variable rather than written inline in a recipe: make condenses a variable's backslash-continuations into
+# single spaces at parse time, so the container's shell receives one flat line — no reliance on how a given make version
+# passes continuations and leading tabs through to the shell (macOS still ships make 3.81, WSL/Linux run 4.x).
+qa-worktree-exec = script="/home/.claude/worktrees/$(wt)/tools/qa-worktree.sh"; \
+  [ -f "$$script" ] || script=/home/tools/qa-worktree.sh; \
+  [ -f "$$script" ] || { echo "error: no tools/qa-worktree.sh in worktree $(wt) or in the main checkout"; exit 1; }; \
+  exec bash "$$script" $(1)
+# Both qa-worktree targets fail fast on a missing wt= rather than passing an empty name into the container.
+qa-worktree-require-wt = @[ -n "$(wt)" ] || { echo "usage: make $@ wt=<name>   (a dir under .claude/worktrees/)"; exit 2; }
+
 # ANSI colors for the `lint` summary.
 GREEN := \033[0;32m
 RED   := \033[0;31m
@@ -81,12 +95,14 @@ ssh:
 # Run an uncommitted git worktree's app on :9000 for QA (not the main repo). See tools/qa-worktree.sh and CLAUDE.md
 # "Running a worktree's app for QA". e.g. `make qa-worktree wt=remove-admin-classic`.
 qa-worktree:
-	@docker exec -it $(web-container) bash /home/tools/qa-worktree.sh $(wt)
+	$(qa-worktree-require-wt)
+	@docker exec -it $(web-container) bash -c '$(call qa-worktree-exec,$(wt))'
 
 # Tear down a qa-worktree session: stop its `~ run` and grunt watch. Add `clean=1` to also drop the node_modules
 # symlink. e.g. `make qa-worktree-stop wt=remove-admin-classic` or `make qa-worktree-stop wt=... clean=1`.
 qa-worktree-stop:
-	@docker exec $(web-container) bash /home/tools/qa-worktree.sh $(wt) --stop $(qa-stop-clean-flag)
+	$(qa-worktree-require-wt)
+	@docker exec $(web-container) bash -c '$(call qa-worktree-exec,$(wt) --stop $(qa-stop-clean-flag))'
 
 import-users:
 	@docker exec -it $(db-container) sh -c "/opt/scripts/import-users.sh"

--- a/tools/qa-worktree.sh
+++ b/tools/qa-worktree.sh
@@ -8,6 +8,11 @@
 #     bash /home/tools/qa-worktree.sh <name>            # start; from inside the container shell
 #     bash /home/tools/qa-worktree.sh <name> --stop     # stop; add --clean to drop the node_modules symlink
 #
+# The make targets run the WORKTREE's copy of this script when it has one, so the branch being QA'd supplies its own
+# tooling. `make` itself still reads the main checkout's Makefile, though, so when that checkout sits on a branch
+# without the target, make reports "No rule to make target". Invoke the worktree's copy directly instead (#4628):
+#     docker exec -it projectsidewalk-web bash /home/.claude/worktrees/<name>/tools/qa-worktree.sh <name>
+#
 # Handles the worktree-specific setup the plain `npm start` flow doesn't (node_modules,
 # bundles, a backgrounded grunt watch, sbt caches, config.file, thin-client contention).
 # See CLAUDE.md -> "Running a worktree's app for QA".


### PR DESCRIPTION
Closes #4628.

`make qa-worktree wt=<name>` launched the script via the **main repo's** copy:

```make
qa-worktree:
	@docker exec -it $(web-container) bash /home/tools/qa-worktree.sh $(wt)
```

The main repo is mounted at the container's `/home`, so `/home/tools/qa-worktree.sh` is the script as it exists on whatever branch the *main checkout* currently has — not the worktree being launched. When the main checkout sits on a branch that predates #4622, the launch fails with `No such file or directory` (exit 127) even though the target worktree has the script. Easy to hit: you're QA-ing worktree B while your main checkout is on older feature branch A.

## What this does

- **Resolve the worktree's own copy first**, falling back to the main checkout's for worktrees branched before the script existed. Applies to both `qa-worktree` and `qa-worktree-stop` (the `--stop` target arrived later, in #4661).
- **Fail fast on a missing `wt=`** instead of passing an empty name into the container.
- **Docs.** `CLAUDE.md` and the script header note the one case this *can't* fix: `make` reads the **main checkout's** Makefile, so if that checkout is on a branch without the target at all, make reports `No rule to make target`. The escape hatch is running the worktree's script directly.
- **Unrelated doc fix in the same area** — `CLAUDE.md` → "Inspecting the database" now says how to find the schema the app is *actually* using. `DATABASE_USER` is the authoritative schema selector (`SIDEWALK_CITY_ID` only picks `cityparams.conf` entries), the two can drift, and `readonly_user` *silently omits* schemas it has no rights on — which reads as "that schema doesn't exist" or "that evolution never applied". Both cost real debugging time.

## Make portability

The resolution logic lives in a make variable rather than inline in the recipe: make condenses a variable's backslash-continuations into single spaces at parse time, so the container's shell receives one flat line — no reliance on how a given make version passes continuations and leading tabs through (macOS still ships make 3.81; WSL/Linux run 4.x).

## Testing

- `make -n` on both targets expands to a single flat `docker exec … bash -c '…'` line, with `--clean` flowing through correctly.
- Missing `wt=` exits 2 with a usage message on both targets.
- Resolution verified in a container with the repo mounted at `/home`, all three paths:
  - worktree has its own copy → uses it
  - worktree lacks one (`4380-funnel-visited`, which genuinely predates #4622) → falls back to `/home/tools/qa-worktree.sh`
  - nonexistent worktree → falls back (the script's own bare-name validation then rejects it)
- `shellcheck` clean on `tools/qa-worktree.sh`.

No Scala/JS/CSS touched, so no scalafmt or frontend-lint surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)