### PR TITLE
Fix the Gallery card's ghost comment row, its comment crash, and stale-POV validations (#4697, #4711)

### DIFF
--- a/public/css/label-detail.css
+++ b/public/css/label-detail.css
@@ -570,11 +570,15 @@ button.label-detail__meta-cell:focus-visible {
   transition: max-height 220ms ease, opacity 180ms ease, margin-bottom 220ms ease, visibility 0s 220ms;
 }
 
+/* `inherit`, never `visible`: an explicit `visibility: visible` paints through an ancestor's `visibility: hidden`,
+   and Gallery's inline host hides itself exactly that way. With `visible` here, an open comment row kept rendering
+   over the card grid after the expanded view closed and stayed clickable there (#4697). Inheriting keeps the row
+   visible when the card is, and hidden with it when it isn't. */
 .label-detail__comment-row.is-open {
   max-height: 60px; /* Anything comfortably above the input's 34px; the transition end point. */
   margin-bottom: 8px;
   opacity: 1;
-  visibility: visible;
+  visibility: inherit;
   transition-delay: 0s; /* Reveal immediately on open; the delay above only applies to the collapse. */
 }
 

--- a/public/js/common/label-detail/LabelDetail.js
+++ b/public/js/common/label-detail/LabelDetail.js
@@ -31,6 +31,37 @@ class LabelDetail {
     return parseInt(new URLSearchParams(window.location.search).get('labelId'), 10) || null;
   }
 
+  /**
+   * Resolves the pano, camera position, and POV to record with a validator comment.
+   *
+   * A pano viewer only describes this label while it's actually showing it. On the static-crop fallback it isn't:
+   * the primary viewer still reports whatever pano it last loaded, and reports nothing at all when the crop was the
+   * first thing opened — the null position that crashed submitting a comment (#4697). The crop is a screenshot of
+   * the label's own pano at its stored POV, so fall back to the label's metadata. None of these fields are optional
+   * server-side: validation_task_comment.lat/lng are NOT NULL and pano_id is a foreign key into pano_data.
+   *
+   * @param {?{panoId: ?string, position: ?{lat: number, lng: number},
+   *     pov: ?{heading: number, pitch: number, zoom: number}}} viewer - What the viewer showing this label reports,
+   *     or null when none is (the static-crop fallback). Its own fields may still be null before imagery resolves.
+   * @param {Object} meta - The current label's metadata payload.
+   * @returns {{panoId: ?string, lat: ?number, lng: ?number, heading: ?number, pitch: ?number, zoom: ?number}}
+   */
+  static commentContext(viewer, meta) {
+    const viewerPos = viewer && viewer.position;
+    const position = Number.isFinite(viewerPos?.lat) && Number.isFinite(viewerPos?.lng)
+      ? viewerPos
+      : { lat: meta.camera_lat ?? meta.lat, lng: meta.camera_lng ?? meta.lng };
+    const pov = (viewer && viewer.pov) || { heading: meta.heading, pitch: meta.pitch, zoom: meta.zoom };
+    return {
+      panoId: (viewer && viewer.panoId) || meta.pano_id || null,
+      lat: position.lat ?? null,
+      lng: position.lng ?? null,
+      heading: pov.heading ?? null,
+      pitch: pov.pitch ?? null,
+      zoom: pov.zoom ?? null,
+    };
+  }
+
   panoManager; // Public: hosts (ExpandedView, LabelPopup callsites) reach in for the pano manager.
 
   #root;
@@ -593,6 +624,11 @@ class LabelDetail {
     // new ones, so we mirror that here.
     this.#myCommentIdx = this.#comments.findIndex((c) => this.#isOwnComment(c));
     this.#renderComments();
+
+    // A typed-but-unsent comment belongs to the label it was typed on, so it doesn't ride along to the next one
+    // (Gallery pages between labels without ever tearing the card down).
+    els.commentInput.value = '';
+    els.commentButton.classList.remove('is-active');
 
     // Lived-experience stories (#4054): lazy per-label fetch, so the metadata payload stays untouched.
     this.#storySection?.setLabel(meta.label_id);
@@ -1176,8 +1212,19 @@ class LabelDetail {
    */
   #submitComment(comment) {
     const els = this.#els;
-    const userPov = this.panoManager.getPov();
-    const pos = this.panoManager.panoViewer.getPosition();
+    // Only 'Default' (primary viewer) and 'Pannellum' mean a viewer is actually rendering *this* label. On the
+    // static-crop fallback — and before the very first pano resolves — panoViewer still points at imagery that
+    // isn't this label's, so nothing it reports may be recorded. See LabelDetail.commentContext().
+    const showingThisLabel = this.panoManager.activeViewerName === 'Default'
+      || this.panoManager.activeViewerName === 'Pannellum';
+    const viewer = showingThisLabel
+      ? {
+          panoId: this.panoManager.panoViewer.getPanoId(),
+          position: this.panoManager.panoViewer.getPosition(),
+          pov: this.panoManager.getPov(),
+        }
+      : null;
+    const context = LabelDetail.commentContext(viewer, this.#currentLabelMeta ?? {});
 
     els.commentButton.disabled = true;
 
@@ -1185,12 +1232,12 @@ class LabelDetail {
       label_id: this.panoManager.label.labelId,
       label_type: this.panoManager.label.label_type,
       comment,
-      pano_id: this.panoManager.panoViewer.getPanoId(),
-      heading: userPov.heading,
-      pitch: userPov.pitch,
-      zoom: userPov.zoom,
-      lat: pos.lat,
-      lng: pos.lng,
+      pano_id: context.panoId,
+      heading: context.heading,
+      pitch: context.pitch,
+      zoom: context.zoom,
+      lat: context.lat,
+      lng: context.lng,
     };
 
     this.#postJson('/labelmap/comment', data).then(async (res) => {

--- a/public/js/common/label-detail/LabelDetail.js
+++ b/public/js/common/label-detail/LabelDetail.js
@@ -57,6 +57,8 @@ class LabelDetail {
       : { lat: meta.camera_lat ?? meta.lat, lng: meta.camera_lng ?? meta.lng };
     const pov = (viewer && viewer.pov) || { heading: meta.heading, pitch: meta.pitch, zoom: meta.zoom };
     return {
+      // `||` rather than `??` on purpose: an empty pano ID is as unusable as a missing one — the column is a foreign
+      // key into pano_data — so "" has to fall through to the label's own instead of being sent as-is.
       panoId: (viewer && viewer.panoId) || meta.pano_id || null,
       lat: position.lat ?? null,
       lng: position.lng ?? null,

--- a/public/js/common/label-detail/LabelDetail.js
+++ b/public/js/common/label-detail/LabelDetail.js
@@ -32,13 +32,17 @@ class LabelDetail {
   }
 
   /**
-   * Resolves the pano, camera position, and POV to record with a validator comment.
+   * Resolves the pano, camera position, and point of view to record with a validation or a validator comment.
    *
    * A pano viewer only describes this label while it's actually showing it. On the static-crop fallback it isn't:
    * the primary viewer still reports whatever pano it last loaded, and reports nothing at all when the crop was the
-   * first thing opened — the null position that crashed submitting a comment (#4697). The crop is a screenshot of
-   * the label's own pano at its stored POV, so fall back to the label's metadata. None of these fields are optional
-   * server-side: validation_task_comment.lat/lng are NOT NULL and pano_id is a foreign key into pano_data.
+   * first thing opened. That silently stored the previous label's POV with a validation (#4711) and threw outright
+   * on the null position when submitting a comment (#4697).
+   *
+   * The crop is a screenshot of the label's own pano at its stored POV, so the label's metadata describes it
+   * exactly — the same answer Gallery's card-hover menu and the landing validation grid already submit for their
+   * static images. None of these fields are optional server-side: label_validation.heading/pitch/zoom and
+   * validation_task_comment.lat/lng are NOT NULL, and the comment's pano_id is a foreign key into pano_data.
    *
    * @param {?{panoId: ?string, position: ?{lat: number, lng: number},
    *     pov: ?{heading: number, pitch: number, zoom: number}}} viewer - What the viewer showing this label reports,
@@ -46,7 +50,7 @@ class LabelDetail {
    * @param {Object} meta - The current label's metadata payload.
    * @returns {{panoId: ?string, lat: ?number, lng: ?number, heading: ?number, pitch: ?number, zoom: ?number}}
    */
-  static commentContext(viewer, meta) {
+  static submissionContext(viewer, meta) {
     const viewerPos = viewer && viewer.position;
     const position = Number.isFinite(viewerPos?.lat) && Number.isFinite(viewerPos?.lng)
       ? viewerPos
@@ -708,6 +712,29 @@ class LabelDetail {
   // ───────────────────────────────────────────────────────────────────
 
   /**
+   * What the pano viewer can truthfully report about the label on screen, or null when it isn't showing it.
+   *
+   * Only 'Default' (the primary GSV/Mapillary/Infra3d viewer) and 'Pannellum' mean a viewer is rendering *this*
+   * label. On the static-crop fallback — and before the very first pano resolves — panoViewer still points at
+   * imagery that isn't this label's, so nothing it reports may be recorded against it. Feeds submissionContext(),
+   * which supplies the label's own metadata in that case.
+   *
+   * @returns {?{panoId: ?string, position: ?{lat: number, lng: number},
+   *     pov: ?{heading: number, pitch: number, zoom: number}}} Null when no viewer is showing this label; individual
+   *     fields may still be null when a viewer is up but its imagery hasn't resolved.
+   */
+  #viewerState() {
+    const showingThisLabel = this.panoManager.activeViewerName === 'Default'
+      || this.panoManager.activeViewerName === 'Pannellum';
+    if (!showingThisLabel) return null;
+    return {
+      panoId: this.panoManager.panoViewer.getPanoId(),
+      position: this.panoManager.panoViewer.getPosition(),
+      pov: this.panoManager.getPov(),
+    };
+  }
+
+  /**
    * POSTs JSON to a session-requiring endpoint, minting the shared anonymous session first if it's missing.
    *
    * The public spotlight page (#456) is reachable with no session at all, and SecuredAction answers a session-less
@@ -750,7 +777,11 @@ class LabelDetail {
     const canvasWidth = this.panoManager.svHolder.width();
     const canvasHeight = this.panoManager.svHolder.height();
     const panoMarkerPov = this.panoManager.getOriginalPosition();
-    const userPov = this.panoManager.getPov();
+    // Where the validator was looking. On the static-crop fallback that's the label's stored POV — what the crop is
+    // a screenshot of — rather than whatever the idle pano viewer happens to report (#4711). canvas_x/canvas_y are
+    // derived from it, so they follow.
+    const context = LabelDetail.submissionContext(this.#viewerState(), this.#currentLabelMeta ?? {});
+    const userPov = { heading: context.heading, pitch: context.pitch, zoom: context.zoom };
 
     const labelRadius = 10;
     const pixelCoordinates
@@ -1212,19 +1243,7 @@ class LabelDetail {
    */
   #submitComment(comment) {
     const els = this.#els;
-    // Only 'Default' (primary viewer) and 'Pannellum' mean a viewer is actually rendering *this* label. On the
-    // static-crop fallback — and before the very first pano resolves — panoViewer still points at imagery that
-    // isn't this label's, so nothing it reports may be recorded. See LabelDetail.commentContext().
-    const showingThisLabel = this.panoManager.activeViewerName === 'Default'
-      || this.panoManager.activeViewerName === 'Pannellum';
-    const viewer = showingThisLabel
-      ? {
-          panoId: this.panoManager.panoViewer.getPanoId(),
-          position: this.panoManager.panoViewer.getPosition(),
-          pov: this.panoManager.getPov(),
-        }
-      : null;
-    const context = LabelDetail.commentContext(viewer, this.#currentLabelMeta ?? {});
+    const context = LabelDetail.submissionContext(this.#viewerState(), this.#currentLabelMeta ?? {});
 
     els.commentButton.disabled = true;
 

--- a/test/js/labelDetailCommentContext.test.js
+++ b/test/js/labelDetailCommentContext.test.js
@@ -1,0 +1,101 @@
+/**
+ * Tests for LabelDetail.commentContext (public/js/common/label-detail/LabelDetail.js, issue #4697).
+ *
+ * The pano context recorded with a validator comment used to be read straight off the pano viewer. That breaks on
+ * every label the viewer isn't actually rendering: on the static-crop fallback the primary viewer reports the pano
+ * it last loaded, and reports null before it has ever loaded one — which threw
+ * `Cannot read properties of null (reading 'lat')` on submit. commentContext() resolves those fields against the
+ * label's own metadata instead, and the columns it feeds are NOT NULL server-side (pano_id is a foreign key into
+ * pano_data), so "fall back" has to mean real values, not nulls, whenever the label carries them.
+ *
+ * LabelDetail is a top-level `class` declaration written for the Grunt-concatenation world, so (like
+ * share-widget.test.js) the source is eval'd into the jsdom global scope with an epilogue that exposes the class.
+ * Only the static method is exercised here — constructing a LabelDetail needs a live pano viewer.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const SRC = fs.readFileSync(
+    path.resolve(__dirname, '..', '..', 'public/js/common/label-detail/LabelDetail.js'), 'utf8'
+);
+
+/** Loads a fresh LabelDetail class into the jsdom global scope. */
+function loadLabelDetail() {
+    window.eval(`${SRC}\nwindow.LabelDetail = LabelDetail;`);
+    return window.LabelDetail;
+}
+
+/** A label whose metadata carries everything: its pano, that pano's camera location, and the stored POV. */
+const META = {
+    label_id: 42,
+    pano_id: 'label-pano',
+    lat: 47.61,
+    lng: -122.33,
+    camera_lat: 47.615,
+    camera_lng: -122.335,
+    heading: 250.5,
+    pitch: -12,
+    zoom: 2
+};
+
+describe('LabelDetail.commentContext', () => {
+    let LabelDetail;
+
+    beforeEach(() => {
+        LabelDetail = loadLabelDetail();
+    });
+
+    test('a viewer showing the label wins over the metadata', () => {
+        // Admin surfaces let the user navigate away from the label's own pano, so what the viewer reports is the
+        // truth about where the comment was written.
+        const viewer = {
+            panoId: 'walked-to-pano',
+            position: { lat: 47.7, lng: -122.4 },
+            pov: { heading: 10, pitch: 5, zoom: 3 }
+        };
+
+        expect(LabelDetail.commentContext(viewer, META)).toEqual({
+            panoId: 'walked-to-pano', lat: 47.7, lng: -122.4, heading: 10, pitch: 5, zoom: 3
+        });
+    });
+
+    test('no viewer (static-crop fallback) records the label pano, camera location, and stored POV', () => {
+        // The crop is a screenshot of this label's pano at its stored POV, so the metadata describes it exactly.
+        expect(LabelDetail.commentContext(null, META)).toEqual({
+            panoId: 'label-pano', lat: 47.615, lng: -122.335, heading: 250.5, pitch: -12, zoom: 2
+        });
+    });
+
+    test('a viewer that has not loaded a pano yet falls back instead of throwing', () => {
+        // The reported crash: GsvViewer reports null for both until its first pano's metadata arrives.
+        const viewer = { panoId: null, position: null, pov: { heading: 0, pitch: 0, zoom: 1 } };
+
+        expect(LabelDetail.commentContext(viewer, META)).toEqual({
+            panoId: 'label-pano', lat: 47.615, lng: -122.335, heading: 0, pitch: 0, zoom: 1
+        });
+    });
+
+    test('a viewer position missing its coordinates falls back to the camera location', () => {
+        const viewer = { panoId: 'p1', position: { lat: undefined, lng: undefined }, pov: null };
+
+        expect(LabelDetail.commentContext(viewer, META)).toMatchObject({
+            panoId: 'p1', lat: 47.615, lng: -122.335
+        });
+    });
+
+    test('a label with no stored camera location falls back to its own coordinates', () => {
+        // camera_lat/camera_lng come from pano_data and are optional in the payload; the label point is the next
+        // best answer to "where was this comment written" and is always present.
+        const noCamera = { ...META, camera_lat: undefined, camera_lng: undefined };
+
+        expect(LabelDetail.commentContext(null, noCamera)).toMatchObject({ lat: 47.61, lng: -122.33 });
+    });
+
+    test('a metadata-less card yields nulls rather than throwing', () => {
+        // Nothing to record — the POST will be rejected, but the click must not blow up the card.
+        expect(LabelDetail.commentContext(null, {})).toEqual({
+            panoId: null, lat: null, lng: null, heading: null, pitch: null, zoom: null
+        });
+    });
+});

--- a/test/js/labelDetailSubmissionContext.test.js
+++ b/test/js/labelDetailSubmissionContext.test.js
@@ -1,12 +1,16 @@
 /**
- * Tests for LabelDetail.commentContext (public/js/common/label-detail/LabelDetail.js, issue #4697).
+ * Tests for LabelDetail.submissionContext (public/js/common/label-detail/LabelDetail.js, issues #4697 and #4711).
  *
- * The pano context recorded with a validator comment used to be read straight off the pano viewer. That breaks on
- * every label the viewer isn't actually rendering: on the static-crop fallback the primary viewer reports the pano
- * it last loaded, and reports null before it has ever loaded one — which threw
- * `Cannot read properties of null (reading 'lat')` on submit. commentContext() resolves those fields against the
- * label's own metadata instead, and the columns it feeds are NOT NULL server-side (pano_id is a foreign key into
- * pano_data), so "fall back" has to mean real values, not nulls, whenever the label carries them.
+ * The pano/POV recorded with a validation or a validator comment used to be read straight off the pano viewer. That
+ * breaks on every label the viewer isn't actually rendering: on the static-crop fallback the primary viewer reports
+ * the pano it last loaded, and reports null (or GSV's uninitialized `heading: 0, pitch: 0, zoom: 1`) before it has
+ * ever loaded one. Commenting threw `Cannot read properties of null (reading 'lat')` (#4697); validating silently
+ * stored the previously viewed label's point of view (#4711).
+ *
+ * submissionContext() resolves those fields against the label's own metadata instead, which is exactly what the crop
+ * is a screenshot of. The columns it feeds are NOT NULL server-side (label_validation.heading/pitch/zoom,
+ * validation_task_comment.lat/lng, with pano_id a foreign key into pano_data), so "fall back" has to mean real
+ * values, not nulls, whenever the label carries them.
  *
  * LabelDetail is a top-level `class` declaration written for the Grunt-concatenation world, so (like
  * share-widget.test.js) the source is eval'd into the jsdom global scope with an epilogue that exposes the class.
@@ -39,7 +43,7 @@ const META = {
     zoom: 2
 };
 
-describe('LabelDetail.commentContext', () => {
+describe('LabelDetail.submissionContext', () => {
     let LabelDetail;
 
     beforeEach(() => {
@@ -48,30 +52,31 @@ describe('LabelDetail.commentContext', () => {
 
     test('a viewer showing the label wins over the metadata', () => {
         // Admin surfaces let the user navigate away from the label's own pano, so what the viewer reports is the
-        // truth about where the comment was written.
+        // truth about where the validation or comment was made.
         const viewer = {
             panoId: 'walked-to-pano',
             position: { lat: 47.7, lng: -122.4 },
             pov: { heading: 10, pitch: 5, zoom: 3 }
         };
 
-        expect(LabelDetail.commentContext(viewer, META)).toEqual({
+        expect(LabelDetail.submissionContext(viewer, META)).toEqual({
             panoId: 'walked-to-pano', lat: 47.7, lng: -122.4, heading: 10, pitch: 5, zoom: 3
         });
     });
 
     test('no viewer (static-crop fallback) records the label pano, camera location, and stored POV', () => {
         // The crop is a screenshot of this label's pano at its stored POV, so the metadata describes it exactly.
-        expect(LabelDetail.commentContext(null, META)).toEqual({
+        // Before #4711 this stored whatever POV the idle viewer reported — the previous label's, or GSV's default.
+        expect(LabelDetail.submissionContext(null, META)).toEqual({
             panoId: 'label-pano', lat: 47.615, lng: -122.335, heading: 250.5, pitch: -12, zoom: 2
         });
     });
 
     test('a viewer that has not loaded a pano yet falls back instead of throwing', () => {
-        // The reported crash: GsvViewer reports null for both until its first pano's metadata arrives.
+        // The crash reported on #4697: GsvViewer reports null for both until its first pano's metadata arrives.
         const viewer = { panoId: null, position: null, pov: { heading: 0, pitch: 0, zoom: 1 } };
 
-        expect(LabelDetail.commentContext(viewer, META)).toEqual({
+        expect(LabelDetail.submissionContext(viewer, META)).toEqual({
             panoId: 'label-pano', lat: 47.615, lng: -122.335, heading: 0, pitch: 0, zoom: 1
         });
     });
@@ -79,22 +84,38 @@ describe('LabelDetail.commentContext', () => {
     test('a viewer position missing its coordinates falls back to the camera location', () => {
         const viewer = { panoId: 'p1', position: { lat: undefined, lng: undefined }, pov: null };
 
-        expect(LabelDetail.commentContext(viewer, META)).toMatchObject({
+        expect(LabelDetail.submissionContext(viewer, META)).toMatchObject({
             panoId: 'p1', lat: 47.615, lng: -122.335
+        });
+    });
+
+    test('a viewer with no POV falls back to the stored POV', () => {
+        // getPov() reports null when the viewer has nothing loaded, and heading/pitch/zoom are NOT NULL server-side.
+        const viewer = { panoId: 'p1', position: { lat: 47.7, lng: -122.4 }, pov: null };
+
+        expect(LabelDetail.submissionContext(viewer, META)).toMatchObject({
+            heading: 250.5, pitch: -12, zoom: 2
         });
     });
 
     test('a label with no stored camera location falls back to its own coordinates', () => {
         // camera_lat/camera_lng come from pano_data and are optional in the payload; the label point is the next
-        // best answer to "where was this comment written" and is always present.
+        // best answer to "where was this written" and is always present.
         const noCamera = { ...META, camera_lat: undefined, camera_lng: undefined };
 
-        expect(LabelDetail.commentContext(null, noCamera)).toMatchObject({ lat: 47.61, lng: -122.33 });
+        expect(LabelDetail.submissionContext(null, noCamera)).toMatchObject({ lat: 47.61, lng: -122.33 });
+    });
+
+    test('a zero-valued POV survives the fallback rather than reading as missing', () => {
+        // A label placed facing due north at full zoom-out is all zeroes, which a `||` chain would discard.
+        const facingNorth = { ...META, heading: 0, pitch: 0, zoom: 0 };
+
+        expect(LabelDetail.submissionContext(null, facingNorth)).toMatchObject({ heading: 0, pitch: 0, zoom: 0 });
     });
 
     test('a metadata-less card yields nulls rather than throwing', () => {
         // Nothing to record — the POST will be rejected, but the click must not blow up the card.
-        expect(LabelDetail.commentContext(null, {})).toEqual({
+        expect(LabelDetail.submissionContext(null, {})).toEqual({
             panoId: null, lat: null, lng: null, heading: null, pitch: null, zoom: null
         });
     });

--- a/test/js/labelDetailSubmissionContext.test.js
+++ b/test/js/labelDetailSubmissionContext.test.js
@@ -113,6 +113,14 @@ describe('LabelDetail.submissionContext', () => {
         expect(LabelDetail.submissionContext(null, facingNorth)).toMatchObject({ heading: 0, pitch: 0, zoom: 0 });
     });
 
+    test('an empty pano ID from the viewer falls through to the label pano', () => {
+        // pano_id is a foreign key into pano_data, so "" is no more insertable than null — the `||` chain has to
+        // treat it as missing rather than pass it along.
+        const viewer = { panoId: '', position: { lat: 47.7, lng: -122.4 }, pov: { heading: 10, pitch: 5, zoom: 3 } };
+
+        expect(LabelDetail.submissionContext(viewer, META)).toMatchObject({ panoId: 'label-pano' });
+    });
+
     test('a metadata-less card yields nulls rather than throwing', () => {
         // Nothing to record — the POST will be rejected, but the click must not blow up the card.
         expect(LabelDetail.submissionContext(null, {})).toEqual({


### PR DESCRIPTION
Fixes #4697. Fixes #4711.

Four bugs on the Label Detail Card, three of which share a root cause.

## 1. The ghost comment row (#4697)

`.gallery-expanded-view` hides itself with `visibility: hidden`, and `visibility` is inherited — which means a
descendant that sets `visibility: visible` **explicitly** paints straight through its hidden ancestor.
`.label-detail__comment-row.is-open` did exactly that, so once a Disagree/Unsure vote opened the row, it kept
rendering over the card grid — with a live, clickable Comment button — for the rest of the session, no matter how
many times the expanded view was closed or paged.

`visibility: inherit` gives the row the same reveal (visible when the card is) without the leak. The row still
collapses to `visibility: hidden` when `.is-open` comes off, so it stays out of the tab order and the a11y tree, and
the open/close transition is unchanged.

This same trap had already been patched imperatively one element over: `ExpandedView.closeExpandedView()` clears the
inline `visibility: visible` that `PopupPanoManager.setPano()` puts on the pano holder. Those two are now the only
elements inside the card that ever set `visibility`, and both are handled. The `<dialog>`-based LabelPopup host was
never affected — it closes with `display: none`, which a descendant can't override.

## 2. The crash clicking that ghost button (#4697)

```
Uncaught TypeError: Cannot read properties of null (reading 'lat')
    at #submitComment (gallery.js:3070:16)
```

## 3. Validations recorded against a stale point of view (#4711)

Same root cause, one method over — and silent, which makes it the more damaging of the two.

A pano viewer only knows the pano, position, and POV **while it is actually rendering that label**:

- before its first pano resolves, `GsvViewer.getPosition()`/`getPanoId()` return `null` (hence the crash) and
  `getPov()` returns GSV's uninitialized `heading: 0, pitch: 0, zoom: 1`;
- on the **static-crop fallback** the primary viewer isn't showing the label at all, so it reports whatever pano it
  last loaded.

So commenting on a crop-only label either threw (first card opened) or recorded the *previous* label's pano and
camera position, and **validating** one stored the previous label's POV — plus the `canvas_x`/`canvas_y` derived from
it. `label_validation.heading/pitch/zoom` are `NOT NULL`, so those rows read as a real point of view; nothing
downstream can tell them apart.

`LabelDetail.submissionContext(viewer, meta)` now resolves all of it in one place, and `#viewerState()` decides
whether a viewer is showing this label at all (`activeViewerName` of `Default` or `Pannellum`). When it isn't, the
fallback is the label's own `pano_id`, `camera_lat`/`camera_lng` (→ `lat`/`lng`), and stored POV — which is precisely
what the static crop is a screenshot of, and already the convention elsewhere in the codebase: Gallery's card-hover
validation menu and the landing validation grid both submit `refCard.getProperty('heading'/'pitch'/'zoom')` for their
static images. None of these fields are optional server-side (`validation_task_comment.lat/lng` are `NOT NULL` and
its `pano_id` is FK'd to `pano_data`), so the fallback has to produce real values, not nulls.

Behavior on live imagery is unchanged — the viewer still wins, which is what admin pano navigation needs.

## 4. The same staleness in the pano *load* window (#4711, found in code review)

`activeViewerName` is only assigned once `setPano()` settles on a viewer, and `showLabel()` doesn't await it. So
from the moment the user pages to a label until its imagery resolves, it still names the viewer that showed the
*previous* one — and `#viewerState()` hands that back as the truth about this label. Voting in that window is #4711
again, narrower: the previous label's POV and the `canvas_x`/`canvas_y` derived from it. The window is a
pano-metadata round-trip (wider on the path that also fetches a backup image's metadata), and paging then voting
immediately is ordinary Gallery rhythm.

`setPano()` hides the pano holder on entry, so there's nothing on screen to judge the label by during that window
either — validating a label you can't see isn't worth recording whichever POV we attach to it. The card now holds
its controls until the imagery lands, exactly as `#noImagery` already holds them when none is coming. That also
sidesteps `viewer_type`, a `NOT NULL` enum (`Default | Pannellum | StaticApi | StaticCrop`) with no honest value to
report mid-load.

`#interactionBlocked` adds this transient reason to `#locked`'s durable ones, kept separate so the comment row
doesn't animate shut and back open on every page-through — a load in flight disables the row, a real lock hides it.
The re-enabling paths defer to it too, so a vote's POST resolving after the user has paged on can't hand the
controls back over a label that's still loading. `viewerShowsLabel()` is split out as a static so the gate is
testable without booting a pano viewer, and `#viewerState()` consults it: the staleness is now unreadable, not
merely unreachable. A `setPano()` that rejects outright now lands on "no imagery" rather than leaving the card
locked on a load that will never finish.

## Also

A typed-but-unsent comment no longer rides along to the next label — Gallery pages between labels without ever
tearing the card down, so the input kept its text (and could be posted against the wrong label).

## Testing

- `test/js/labelDetailSubmissionContext.test.js` — 9 cases over the fallback chain: viewer-wins (admin navigating
  away from the label's pano), static-crop fallback, the null-position case that produced the crash, a position
  missing its coordinates, a null POV, a label with no stored camera location, an all-zeroes POV (a label facing due
  north, which a `||` chain would silently discard), an empty-string pano ID, and an empty payload. Plus 6 over
  `viewerShowsLabel()`: the two viewers that are showing the label, the static-crop fallback, a card that has never
  resolved a pano, and both live viewers during the load window.
- Full jsdom suite green: 24 suites / 257 tests.
- ESLint + Stylelint clean.

Not browser-verified — per CLAUDE.md, anything behind a Street View pano is manual QA.

### QA checklist

1. Gallery → open a card → vote **Unsure** → the comment row appears.
2. Close the expanded view. **The row should be gone** (before: it stayed, floating over the grid).
3. Reopen, page next/prev between voted and unvoted labels — the row should appear/disappear with the vote, and the
   input should be empty on each new label.
4. Type a comment and click **Comment** — should post cleanly (before: `TypeError` in the console).
5. Open a label whose imagery is expired but has a crop (the still-image fallback), vote Unsure, and comment. Both
   should record the label's own pano/POV rather than the previously viewed label's — checkable with:
   ```sql
   SELECT label_id, heading, pitch, zoom, viewer_type FROM label_validation
   WHERE viewer_type = 'StaticCrop' ORDER BY end_timestamp DESC LIMIT 5;
   ```
   against the label's own `heading`/`pitch`/`zoom` in the `label` table.
6. Page to a new label and try to vote **immediately**, before its imagery paints. The vote controls and comment box
   should be briefly greyed and the click should do nothing, then they should come back on their own once the pano
   is up (before: the vote landed with the *previous* label's POV). Worth trying with the network throttled to make
   the window wide enough to hit reliably. A label you'd already voted Disagree/Unsure on should keep its comment
   row on screen through that window rather than collapsing and re-opening.
7. Same flows on the LabelMap popup and `/label/:id` to confirm nothing regressed on the modal host, and one
   validation from `/admin/task/:id` after panning to a different pano, to confirm the viewer still wins there.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-opus-5[1m])

