### PR TITLE
Offset the pano date by the actual imagery-source logo width (#4317)

### DIFF
--- a/public/css/explore/svl.css
+++ b/public/css/explore/svl.css
@@ -106,7 +106,7 @@ input[type="radio"] {
   /* Sits just right of the imagery-source logo, whose width varies by source (Mapillary's wordmark is the widest),
      so the offset tracks the logo via --pano-logo-width, published by PanoViewerLogo. The fallback is the width of
      Google's own Street View logo, which GSV draws itself rather than through our logo overlay. */
-  left: calc((var(--pano-logo-width, 63px) + 8px) * var(--ui-scale));
+  left: calc((var(--pano-logo-width, 66px) + 8px) * var(--ui-scale));
   z-index: 1;
   font: var(--text-small-medium);
   text-shadow:
@@ -148,8 +148,10 @@ input[type="radio"] {
   transform-origin: bottom left;
 }
 
+/* No left padding: the gap to the imagery-source logo is owned by the holder's left offset above, and doubling up
+   on it is what pushed the date away from the logo. */
 #svl-panorama-date {
-  padding: calc(3px * var(--ui-scale));
+  padding: calc(3px * var(--ui-scale)) calc(3px * var(--ui-scale)) calc(3px * var(--ui-scale)) 0;
 }
 
 /* Scale Bootstrap tooltips (severity descriptions, button hints, etc.) with the UI. They render on <body>, so they read

--- a/public/css/explore/svl.css
+++ b/public/css/explore/svl.css
@@ -102,7 +102,11 @@ input[type="radio"] {
   height: calc(28px * var(--ui-scale));
   position: absolute;
   bottom: calc(var(--bottom-left-links-clearance, 0px) * var(--ui-scale));
-  left: calc(71px * var(--ui-scale));
+
+  /* Sits just right of the imagery-source logo, whose width varies by source (Mapillary's wordmark is the widest),
+     so the offset tracks the logo via --pano-logo-width, published by PanoViewerLogo. The fallback is the width of
+     Google's own Street View logo, which GSV draws itself rather than through our logo overlay. */
+  left: calc((var(--pano-logo-width, 63px) + 8px) * var(--ui-scale));
   z-index: 1;
   font: var(--text-small-medium);
   text-shadow:

--- a/public/css/explore/svl.css
+++ b/public/css/explore/svl.css
@@ -103,9 +103,10 @@ input[type="radio"] {
   position: absolute;
   bottom: calc(var(--bottom-left-links-clearance, 0px) * var(--ui-scale));
 
-  /* Sits just right of the imagery-source logo, whose width varies by source (Mapillary's wordmark is the widest),
-     so the offset tracks the logo via --pano-logo-width, published by PanoViewerLogo. The fallback is the width of
-     Google's own Street View logo, which GSV draws itself rather than through our logo overlay. */
+  /* Sits 8px right of wherever the imagery-source logo's pixels end. How far that is varies by source (Mapillary's
+     wordmark is the widest), so the offset tracks the logo through --pano-logo-width, which PanoViewerLogo measures
+     and publishes. The fallback covers GSV, which draws its own logo instead of going through that overlay: 66px is
+     where Google's Street View logo ends. */
   left: calc((var(--pano-logo-width, 66px) + 8px) * var(--ui-scale));
   z-index: 1;
   font: var(--text-small-medium);
@@ -148,8 +149,7 @@ input[type="radio"] {
   transform-origin: bottom left;
 }
 
-/* No left padding: the gap to the imagery-source logo is owned by the holder's left offset above, and doubling up
-   on it is what pushed the date away from the logo. */
+/* No left padding — the holder's left offset above owns the whole gap to the imagery-source logo. */
 #svl-panorama-date {
   padding: calc(3px * var(--ui-scale)) calc(3px * var(--ui-scale)) calc(3px * var(--ui-scale)) 0;
 }

--- a/public/css/validate/svv-panorama.css
+++ b/public/css/validate/svv-panorama.css
@@ -124,7 +124,7 @@
   /* Sits just right of the imagery-source logo, whose width varies by source (Mapillary's wordmark is the widest),
      so the offset tracks the logo via --pano-logo-width, published by PanoViewerLogo. The fallback is the width of
      Google's own Street View logo, which GSV draws itself rather than through our logo overlay. */
-  left: calc((var(--pano-logo-width, 63px) + 8px) * var(--ui-scale));
+  left: calc((var(--pano-logo-width, 66px) + 8px) * var(--ui-scale));
   z-index: 2;
   font: var(--text-small-medium);
   text-shadow:
@@ -132,8 +132,10 @@
   color: var(--color-neutral-white);
 }
 
+/* No left padding: the gap to the imagery-source logo is owned by the holder's left offset above, and doubling up
+   on it is what pushed the date away from the logo. */
 #svv-panorama-date {
-  padding: calc(3px * var(--ui-scale));
+  padding: calc(3px * var(--ui-scale)) calc(3px * var(--ui-scale)) calc(3px * var(--ui-scale)) 0;
 }
 
 #pano-info-button {

--- a/public/css/validate/svv-panorama.css
+++ b/public/css/validate/svv-panorama.css
@@ -120,7 +120,11 @@
   height: calc(28px * var(--ui-scale));
   position: absolute;
   bottom: 0;
-  left: calc(71px * var(--ui-scale));
+
+  /* Sits just right of the imagery-source logo, whose width varies by source (Mapillary's wordmark is the widest),
+     so the offset tracks the logo via --pano-logo-width, published by PanoViewerLogo. The fallback is the width of
+     Google's own Street View logo, which GSV draws itself rather than through our logo overlay. */
+  left: calc((var(--pano-logo-width, 63px) + 8px) * var(--ui-scale));
   z-index: 2;
   font: var(--text-small-medium);
   text-shadow:

--- a/public/css/validate/svv-panorama.css
+++ b/public/css/validate/svv-panorama.css
@@ -121,9 +121,10 @@
   position: absolute;
   bottom: 0;
 
-  /* Sits just right of the imagery-source logo, whose width varies by source (Mapillary's wordmark is the widest),
-     so the offset tracks the logo via --pano-logo-width, published by PanoViewerLogo. The fallback is the width of
-     Google's own Street View logo, which GSV draws itself rather than through our logo overlay. */
+  /* Sits 8px right of wherever the imagery-source logo's pixels end. How far that is varies by source (Mapillary's
+     wordmark is the widest), so the offset tracks the logo through --pano-logo-width, which PanoViewerLogo measures
+     and publishes. The fallback covers GSV, which draws its own logo instead of going through that overlay: 66px is
+     where Google's Street View logo ends. */
   left: calc((var(--pano-logo-width, 66px) + 8px) * var(--ui-scale));
   z-index: 2;
   font: var(--text-small-medium);
@@ -132,8 +133,7 @@
   color: var(--color-neutral-white);
 }
 
-/* No left padding: the gap to the imagery-source logo is owned by the holder's left offset above, and doubling up
-   on it is what pushed the date away from the logo. */
+/* No left padding — the holder's left offset above owns the whole gap to the imagery-source logo. */
 #svv-panorama-date {
   padding: calc(3px * var(--ui-scale)) calc(3px * var(--ui-scale)) calc(3px * var(--ui-scale)) 0;
 }

--- a/public/js/common/pano-viewer/src/PanoViewerLogo.js
+++ b/public/js/common/pano-viewer/src/PanoViewerLogo.js
@@ -6,8 +6,8 @@
  *   - showPrimaryLogo() — use when the primary viewer (GSV/Mapillary/Infra3D) is active.
  *   - showSourceLogo()  — use when Pannellum is active as a backup for the primary source.
  *
- * The overlay also publishes the logo's width on the container as the --pano-logo-width CSS variable so that
- * overlays sitting to its right (the pano capture date and info button) can clear it.
+ * The overlay also publishes where the logo visually ends on the container, as the --pano-logo-width CSS variable,
+ * so that overlays sitting to its right (the pano capture date and info button) can clear it.
  *
  * @param {Element} container The positioned pano container element.
  * @param {typeof PanoViewer} primaryViewerType The primary viewer class (GsvViewer, MapillaryViewer, etc.).
@@ -23,10 +23,13 @@ function createPanoViewerLogo(container, primaryViewerType) {
 
   // Logo box metrics in unscaled px. The image fills the holder's content-box height, so its rendered width follows
   // the logo's aspect ratio — which is what publishLogoWidth reports to the overlays sitting to the logo's right.
+  // The bottom padding centers the image on the same optical line as the rest of the bottom-left row: the pano date
+  // and the info button (whose own 4.5px top offset in a 28px-tall holder puts its center 15.5px above the row's
+  // bottom edge).
   const HOLDER_HEIGHT = 29;
-  const PADDING_TOP = 4;
-  const PADDING_BOTTOM = 3;
-  const IMG_HEIGHT = HOLDER_HEIGHT - PADDING_TOP - PADDING_BOTTOM;
+  const PADDING_BOTTOM = 4.5;
+  const IMG_HEIGHT = 22;
+  const PADDING_TOP = HOLDER_HEIGHT - IMG_HEIGHT - PADDING_BOTTOM;
 
   const holder = document.createElement('div');
   Object.assign(holder.style, {
@@ -48,7 +51,7 @@ function createPanoViewerLogo(container, primaryViewerType) {
   let activeLogo = null;
 
   /**
-   * Publishes the logo's unscaled width on the container as the --pano-logo-width CSS variable.
+   * Publishes the unscaled x of the logo's right edge on the container as the --pano-logo-width CSS variable.
    *
    * The logos differ widely in width — Mapillary's wordmark is much wider than Google's — so overlays anchored to
    * the pano's bottom-left corner can't clear the logo with a single fixed offset (#4317).
@@ -63,7 +66,41 @@ function createPanoViewerLogo(container, primaryViewerType) {
     const rect = img.getBoundingClientRect();
     const aspectRatio = rect.width / rect.height;
     if (!Number.isFinite(aspectRatio) || aspectRatio <= 0) return;
-    container.style.setProperty('--pano-logo-width', `${activeLogo.paddingLeft + IMG_HEIGHT * aspectRatio}px`);
+    const boxWidth = IMG_HEIGHT * aspectRatio;
+    container.style.setProperty('--pano-logo-width', `${activeLogo.paddingLeft + inkWidth(boxWidth)}px`);
+  }
+
+  /**
+   * Measures how far the logo's visible pixels actually extend within its rendered box.
+   *
+   * The logos carry transparent margins baked into their canvases (Mapillary's is ~3% of its width), so the box's
+   * right edge is not where the mark looks like it ends — spacing off the box leaves a visibly wider gap for some
+   * sources than others. Reading the alpha channel keeps the gap optically equal whatever art is dropped in.
+   *
+   * @param {number} boxWidth The image's rendered width in unscaled px.
+   * @returns {number} The rightmost visible pixel's x in unscaled px, or boxWidth if the pixels can't be read.
+   */
+  function inkWidth(boxWidth) {
+    try {
+      // Sample at the image's natural resolution when it has one; an SVG with only a viewBox reports none, so fall
+      // back to the rendered box, where a pixel of scan error is a pixel of gap error.
+      const w = img.naturalWidth || Math.ceil(boxWidth);
+      const h = img.naturalHeight || IMG_HEIGHT;
+      const canvas = document.createElement('canvas');
+      canvas.width = w;
+      canvas.height = h;
+      const ctx = canvas.getContext('2d');
+      ctx.drawImage(img, 0, 0, w, h);
+      const alpha = ctx.getImageData(0, 0, w, h).data;
+      for (let x = w - 1; x >= 0; x--) {
+        for (let y = 0; y < h; y++) {
+          if (alpha[(y * w + x) * 4 + 3] > 20) return ((x + 1) / w) * boxWidth;
+        }
+      }
+    } catch {
+      // A canvas we can't read (tainted, or no 2d context) just means no trimming; the box width still clears.
+    }
+    return boxWidth;
   }
 
   // The rendered box only has a usable ratio once the image has loaded and been laid out, which can happen well after

--- a/public/js/common/pano-viewer/src/PanoViewerLogo.js
+++ b/public/js/common/pano-viewer/src/PanoViewerLogo.js
@@ -6,17 +6,27 @@
  *   - showPrimaryLogo() — use when the primary viewer (GSV/Mapillary/Infra3D) is active.
  *   - showSourceLogo()  — use when Pannellum is active as a backup for the primary source.
  *
+ * The overlay also publishes the logo's width on the container as the --pano-logo-width CSS variable so that
+ * overlays sitting to its right (the pano capture date and info button) can clear it.
+ *
  * @param {Element} container The positioned pano container element.
  * @param {typeof PanoViewer} primaryViewerType The primary viewer class (GsvViewer, MapillaryViewer, etc.).
  * @returns {{ showPrimaryLogo: Function, showSourceLogo: Function }}
  */
 function createPanoViewerLogo(container, primaryViewerType) {
-  /** @type {Map<typeof PanoViewer, {src: string, alt: string, paddingLeft: string}>} */
+  /** @type {Map<typeof PanoViewer, {src: string, alt: string, paddingLeft: number}>} paddingLeft is unscaled px. */
   const LOGOS = new Map([
-    [GsvViewer, { src: '/assets/images/logos/google-logo.svg', alt: 'Google', paddingLeft: '10px' }],
-    [MapillaryViewer, { src: '/assets/images/logos/mapillary-logo-white.png', alt: 'Mapillary', paddingLeft: '5px' }],
-    [Infra3dViewer, { src: '/assets/images/logos/infra3d-logo.svg', alt: 'infra3D', paddingLeft: '6px' }],
+    [GsvViewer, { src: '/assets/images/logos/google-logo.svg', alt: 'Google', paddingLeft: 10 }],
+    [MapillaryViewer, { src: '/assets/images/logos/mapillary-logo-white.png', alt: 'Mapillary', paddingLeft: 5 }],
+    [Infra3dViewer, { src: '/assets/images/logos/infra3d-logo.svg', alt: 'infra3D', paddingLeft: 6 }],
   ]);
+
+  // Logo box metrics in unscaled px. The image fills the holder's content-box height, so its rendered width follows
+  // the logo's aspect ratio — which is what publishLogoWidth reports to the overlays sitting to the logo's right.
+  const HOLDER_HEIGHT = 29;
+  const PADDING_TOP = 4;
+  const PADDING_BOTTOM = 3;
+  const IMG_HEIGHT = HOLDER_HEIGHT - PADDING_TOP - PADDING_BOTTOM;
 
   const holder = document.createElement('div');
   Object.assign(holder.style, {
@@ -25,14 +35,40 @@ function createPanoViewerLogo(container, primaryViewerType) {
     bottom: 'calc(var(--bottom-left-links-clearance, 2px) * var(--ui-scale, 1))',
     left: '0',
     zIndex: '1',
-    height: 'calc(29px * var(--ui-scale, 1))',
-    padding: 'calc(4px * var(--ui-scale, 1)) 0 calc(3px * var(--ui-scale, 1)) calc(10px * var(--ui-scale, 1))',
+    height: `calc(${HOLDER_HEIGHT}px * var(--ui-scale, 1))`,
+    padding: `calc(${PADDING_TOP}px * var(--ui-scale, 1)) 0 calc(${PADDING_BOTTOM}px * var(--ui-scale, 1)) 0`,
     boxSizing: 'border-box',
   });
   const img = document.createElement('img');
   img.style.maxHeight = '100%';
   holder.appendChild(img);
   container.appendChild(holder);
+
+  /** @type {?{src: string, alt: string, paddingLeft: number}} The logo currently in the holder. */
+  let activeLogo = null;
+
+  /**
+   * Publishes the logo's unscaled width on the container as the --pano-logo-width CSS variable.
+   *
+   * The logos differ widely in width — Mapillary's wordmark is much wider than Google's — so overlays anchored to
+   * the pano's bottom-left corner can't clear the logo with a single fixed offset (#4317).
+   */
+  function publishLogoWidth() {
+    if (!activeLogo) return;
+
+    // Take the ratio of the rendered box rather than naturalWidth/naturalHeight, since an SVG sized only by a viewBox
+    // reports no intrinsic size. A ratio is independent of --ui-scale, so the published width stays in unscaled px,
+    // matching how the rest of the tool UI is authored. getBoundingClientRect (not offsetWidth) keeps subpixel
+    // precision, which matters at the small scales the tool UI shrinks to.
+    const rect = img.getBoundingClientRect();
+    const aspectRatio = rect.width / rect.height;
+    if (!Number.isFinite(aspectRatio) || aspectRatio <= 0) return;
+    container.style.setProperty('--pano-logo-width', `${activeLogo.paddingLeft + IMG_HEIGHT * aspectRatio}px`);
+  }
+
+  // The rendered box only has a usable ratio once the image has loaded and been laid out, which can happen well after
+  // the logo is set (and again if the pano starts out hidden), so republish on every resize of the image box.
+  new ResizeObserver(publishLogoWidth).observe(img);
 
   /**
    * Shows the logo for the given viewer type.
@@ -41,10 +77,12 @@ function createPanoViewerLogo(container, primaryViewerType) {
   function showLogo(viewerType) {
     const info = LOGOS.get(viewerType);
     if (!info) return;
+    activeLogo = info;
     img.src = info.src;
     img.alt = info.alt;
-    holder.style.paddingLeft = `calc(${info.paddingLeft} * var(--ui-scale, 1))`;
+    holder.style.paddingLeft = `calc(${info.paddingLeft}px * var(--ui-scale, 1))`;
     holder.style.display = 'flex';
+    publishLogoWidth();
   }
 
   return {
@@ -54,6 +92,9 @@ function createPanoViewerLogo(container, primaryViewerType) {
     showPrimaryLogo() {
       if (primaryViewerType === GsvViewer) {
         holder.style.display = 'none';
+        activeLogo = null;
+        // Google draws its own logo, so overlays to its right fall back to the offset that clears that one.
+        container.style.removeProperty('--pano-logo-width');
       } else {
         showLogo(primaryViewerType);
       }

--- a/public/js/common/pano-viewer/src/PanoViewerLogo.js
+++ b/public/js/common/pano-viewer/src/PanoViewerLogo.js
@@ -6,7 +6,7 @@
  *   - showPrimaryLogo() — use when the primary viewer (GSV/Mapillary/Infra3D) is active.
  *   - showSourceLogo()  — use when Pannellum is active as a backup for the primary source.
  *
- * The overlay also publishes where the logo visually ends on the container, as the --pano-logo-width CSS variable,
+ * The overlay also publishes where the logo's pixels end, as the --pano-logo-width CSS variable on the container,
  * so that overlays sitting to its right (the pano capture date and info button) can clear it.
  *
  * @param {Element} container The positioned pano container element.
@@ -14,7 +14,10 @@
  * @returns {{ showPrimaryLogo: Function, showSourceLogo: Function }}
  */
 function createPanoViewerLogo(container, primaryViewerType) {
-  /** @type {Map<typeof PanoViewer, {src: string, alt: string, paddingLeft: number}>} paddingLeft is unscaled px. */
+  /**
+   * The logo art per imagery source. paddingLeft is hand-tuned per logo, in unscaled px.
+   * @type {Map<typeof PanoViewer, {src: string, alt: string, paddingLeft: number}>}
+   */
   const LOGOS = new Map([
     [GsvViewer, { src: '/assets/images/logos/google-logo.svg', alt: 'Google', paddingLeft: 10 }],
     [MapillaryViewer, { src: '/assets/images/logos/mapillary-logo-white.png', alt: 'Mapillary', paddingLeft: 5 }],
@@ -22,10 +25,9 @@ function createPanoViewerLogo(container, primaryViewerType) {
   ]);
 
   // Logo box metrics in unscaled px. The image fills the holder's content-box height, so its rendered width follows
-  // the logo's aspect ratio — which is what publishLogoWidth reports to the overlays sitting to the logo's right.
-  // The bottom padding centers the image on the same optical line as the rest of the bottom-left row: the pano date
-  // and the info button (whose own 4.5px top offset in a 28px-tall holder puts its center 15.5px above the row's
-  // bottom edge).
+  // the logo's aspect ratio (see publishLogoWidth). The bottom padding puts the image's center 15.5px above the
+  // holder's bottom edge, which is the optical line the rest of the bottom-left row sits on — where the date's text
+  // falls, and where the info button lands via its own 4.5px top offset in a 28px-tall holder.
   const HOLDER_HEIGHT = 29;
   const PADDING_BOTTOM = 4.5;
   const IMG_HEIGHT = 22;
@@ -51,7 +53,8 @@ function createPanoViewerLogo(container, primaryViewerType) {
   let activeLogo = null;
 
   /**
-   * Publishes the unscaled x of the logo's right edge on the container as the --pano-logo-width CSS variable.
+   * Publishes how far the logo reaches from the pano's left edge, in unscaled px, as the --pano-logo-width CSS
+   * variable on the container.
    *
    * The logos differ widely in width — Mapillary's wordmark is much wider than Google's — so overlays anchored to
    * the pano's bottom-left corner can't clear the logo with a single fixed offset (#4317).
@@ -67,20 +70,21 @@ function createPanoViewerLogo(container, primaryViewerType) {
     const aspectRatio = rect.width / rect.height;
     if (!Number.isFinite(aspectRatio) || aspectRatio <= 0) return;
     const boxWidth = IMG_HEIGHT * aspectRatio;
-    container.style.setProperty('--pano-logo-width', `${activeLogo.paddingLeft + inkWidth(boxWidth)}px`);
+    container.style.setProperty('--pano-logo-width', `${activeLogo.paddingLeft + inkRightEdge(boxWidth)}px`);
   }
 
   /**
-   * Measures how far the logo's visible pixels actually extend within its rendered box.
+   * Measures how far the logo's visible pixels extend within its rendered box.
    *
-   * The logos carry transparent margins baked into their canvases (Mapillary's is ~3% of its width), so the box's
-   * right edge is not where the mark looks like it ends — spacing off the box leaves a visibly wider gap for some
-   * sources than others. Reading the alpha channel keeps the gap optically equal whatever art is dropped in.
+   * A logo can carry a transparent margin baked into its canvas — Mapillary's mark stops 3% of the canvas width
+   * short of the right edge — so the box is not where the mark looks like it ends, and spacing off the box leaves
+   * a wider gap for that source than for one whose art runs flush. Reading the alpha channel keeps the gap
+   * optically equal whatever art is dropped in.
    *
    * @param {number} boxWidth The image's rendered width in unscaled px.
    * @returns {number} The rightmost visible pixel's x in unscaled px, or boxWidth if the pixels can't be read.
    */
-  function inkWidth(boxWidth) {
+  function inkRightEdge(boxWidth) {
     try {
       // Sample at the image's natural resolution when it has one; an SVG with only a viewBox reports none, so fall
       // back to the rendered box, where a pixel of scan error is a pixel of gap error.
@@ -91,10 +95,10 @@ function createPanoViewerLogo(container, primaryViewerType) {
       canvas.height = h;
       const ctx = canvas.getContext('2d');
       ctx.drawImage(img, 0, 0, w, h);
-      const alpha = ctx.getImageData(0, 0, w, h).data;
+      const pixels = ctx.getImageData(0, 0, w, h).data;
       for (let x = w - 1; x >= 0; x--) {
         for (let y = 0; y < h; y++) {
-          if (alpha[(y * w + x) * 4 + 3] > 20) return ((x + 1) / w) * boxWidth;
+          if (pixels[(y * w + x) * 4 + 3] > 20) return ((x + 1) / w) * boxWidth;
         }
       }
     } catch {


### PR DESCRIPTION
Fixes #4317.

### The problem

The pano capture date + info button are anchored to the pano's bottom-left corner at a **fixed** `left: 71px`, just
right of the imagery-source logo. That offset only clears the *narrowest* logo, so Mapillary's wordmark ran straight
into the date.

Measuring the screenshots in the issue — normalized by the ⓘ button, which is the same element in all of them — the
gap between where the logo's pixels end and where the date's begin:

| Source | ink gap on develop |
|---|---|
| Google (the corner the issue calls correct) | 8.7px |
| infra3D | ~4.5px |
| Mapillary | **overlapping** |

### The fix

`PanoViewerLogo` publishes where the logo's pixels end as a `--pano-logo-width` CSS variable on the pano container;
the Explore and Validate date holders offset from that plus a fixed 8px gap. Same pattern already used for
`--bottom-left-links-clearance`.

Three details that turned out to matter:

- **Visible pixels, not the box.** A logo can carry a transparent margin baked into its canvas — Mapillary's mark
  stops 3% of the canvas width short of the right edge — so the box's right edge is nowhere near where the mark looks
  like it ends. The logo is rasterized once and its alpha channel scanned for the rightmost visible pixel, which is
  what makes the gap come out optically equal across sources without hand-tuning per asset (and keeps it that way if
  the art is ever swapped). Falls back to the box width if the canvas can't be read.
- **The box width itself comes from the rendered box's aspect ratio**, not `naturalWidth`/`naturalHeight` — infra3D
  and Google are SVGs, and a viewBox-only SVG reports no intrinsic size. A ratio is independent of `--ui-scale`, so
  the published value stays in unscaled px like the rest of the tool UI's CSS. A `ResizeObserver` republishes it, so
  load-vs-layout ordering doesn't matter.
- **Vertical alignment.** The logo box centered 14px above the row's bottom edge while the date text and the ⓘ button
  sit at 15.5px (the ⓘ gets there via a hand-tuned `margin-top: 4.5px`). The logo now uses the same optical line, and
  `#svl-panorama-date`'s left padding — which stacked on top of the gap — is gone.

GSV draws its own logo instead of going through our overlay, so it falls back to a fixed `66px + 8px` and stays
**pixel-identical to develop**.

### Result
<img width="2421" height="1436" alt="image" src="https://github.com/user-attachments/assets/4897e524-6cd9-4ab9-b048-984d48ad1551" />


Measured on Richmond, VA (Mapillary), off before/after screenshots normalized the same way as above:

- ink gap, logo → date: **15.2px → 9.9px**, against the 8.7px GSV reference
- logo baseline vs date baseline: **1.2px low → 0.4px**

### QA

- ✅ **Mapillary** — confirmed on Richmond, VA in Explore.
- ⬜ **GSV** — should be indistinguishable from develop (fixed-fallback path), but worth confirming.
- ⬜ **infra3D** — Zurich/Winterthur. Its date will shift by however much transparent margin its SVG carries, which I
  couldn't measure reliably from the issue screenshot (dark logo on a busy background); the gap should land on the
  same ~8px by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-opus-5[1m])
