### PR TITLE
Hold validating and commenting until the label's imagery loads (#4711 follow-up)

### DIFF
--- a/public/js/common/label-detail/LabelDetail.js
+++ b/public/js/common/label-detail/LabelDetail.js
@@ -92,6 +92,7 @@ class LabelDetail {
   #source = undefined;      // Set in showLabel().
   #readonly = false;        // Set per-label in #handleData() based on meta.from_current_user.
   #noImagery = false;  // Set per-label once setPano() resolves; true when no navigable imagery could be loaded.
+  #panoLoading = false;     // True from #handleData() until this label's setPano() resolves. See #interactionBlocked.
   #validationCounts = { Agree: null, Disagree: null, Unsure: null };
   #flags = { low_quality: null, incomplete: null, stale: null };
   #prevAction = null;
@@ -367,7 +368,7 @@ class LabelDetail {
     // separate "clear" affordance — a dedicated control would cost card space for a rare action (Mikey, #4653).
     // buttonSource overrides #source for this specific button group; falls back to #source if null.
     const voteHandler = (action, buttonSource) => () => {
-      if (this.#locked) return;
+      if (this.#interactionBlocked) return;
       this.#setVoteButtonsDisabled(true);
       this.#submitValidation(action, buttonSource || this.#source, this.#prevAction === action);
     };
@@ -380,13 +381,13 @@ class LabelDetail {
       const btn = els.voteButtons[action];
       const img = els.voteIcons[action];
       btn.addEventListener('mouseenter', () => {
-        if (this.#locked) return;
+        if (this.#interactionBlocked) return;
         const state = this.#prevAction === action ? 'outline' : 'filled';
         const ai = this.#aiValidation === action ? '-ai' : '';
         img.src = `${this.#iconBase}${action.toLowerCase()}-${state}${ai}.svg`;
       });
       btn.addEventListener('mouseleave', () => {
-        if (this.#locked) return;
+        if (this.#interactionBlocked) return;
         this.#renderVoteIcons();
       });
     }
@@ -397,7 +398,7 @@ class LabelDetail {
     els.commentInput.addEventListener('keydown', (e) => {
       if (e.key === 'Enter') {
         e.preventDefault();
-        if (this.#locked) return;
+        if (this.#interactionBlocked) return;
         const comment = els.commentInput.value.trim();
         if (comment) this.#submitComment(comment);
       } else if (e.key === 'Escape') {
@@ -414,7 +415,7 @@ class LabelDetail {
       }
     });
     els.commentButton.addEventListener('click', () => {
-      if (this.#locked) return;
+      if (this.#interactionBlocked) return;
       const comment = els.commentInput.value.trim();
       if (comment) this.#submitComment(comment);
     });
@@ -472,9 +473,11 @@ class LabelDetail {
     this.#currentLabelMeta = meta;
 
     // Read-only mode for the user's own labels — no validating/commenting. Imagery availability is unknown until
-    // setPano() resolves below, so assume it's present for now and re-apply the lock once we know.
+    // setPano() resolves below, so assume it's present for now and re-apply the lock once we know. Submitting is
+    // held until then either way: there's nothing on screen to judge yet, and nothing that describes this label.
     this.#readonly = !!meta.from_current_user;
     this.#noImagery = false;
+    this.#panoLoading = true;
     this.#applyInteractionLock();
 
     const labelPov = { heading: meta.heading, pitch: meta.pitch, zoom: meta.zoom };
@@ -507,6 +510,7 @@ class LabelDetail {
         // Guard against a newer label having been opened while this resolved.
         if (this.#currentLabelMeta !== meta) return;
         this.#noImagery = !imageShown;
+        this.#panoLoading = false;
         this.#applyInteractionLock();
 
         // The live imagery's metadata may carry an address the label payload didn't. Only read it when the shown
@@ -522,6 +526,15 @@ class LabelDetail {
         if (address) this.#showAddress(address, livePano ? this.#panoLink(meta) : null);
 
         if (imageShown) this.#showPanHintOnce();
+      })
+      .catch((err) => {
+        // setPano() resolves its own failures into the fallback chain, so a rejection here means the pipeline broke
+        // outright. Land on "no imagery" rather than leaving the card locked on a load that will never finish.
+        if (this.#currentLabelMeta !== meta) return;
+        console.error('setPano failed; treating the label as having no imagery:', err);
+        this.#noImagery = true;
+        this.#panoLoading = false;
+        this.#applyInteractionLock();
       });
 
     // Validation counts + AI validation.
@@ -714,21 +727,36 @@ class LabelDetail {
   // ───────────────────────────────────────────────────────────────────
 
   /**
-   * What the pano viewer can truthfully report about the label on screen, or null when it isn't showing it.
+   * Whether a pano viewer is rendering the label currently on the card, and so may be believed about it.
    *
-   * Only 'Default' (the primary GSV/Mapillary/Infra3d viewer) and 'Pannellum' mean a viewer is rendering *this*
-   * label. On the static-crop fallback — and before the very first pano resolves — panoViewer still points at
-   * imagery that isn't this label's, so nothing it reports may be recorded against it. Feeds submissionContext(),
-   * which supplies the label's own metadata in that case.
+   * Only 'Default' (the primary GSV/Mapillary/Infra3d viewer) and 'Pannellum' mean one is. On the static-crop
+   * fallback — and before the very first pano resolves — panoViewer still points at imagery that isn't this
+   * label's, so nothing it reports may be recorded against it.
+   *
+   * The load window is the same trap one step earlier: activeViewerName is only assigned once setPano() settles on
+   * a viewer, so until then it still names the one that showed the *previous* label. #interactionBlocked keeps a
+   * submission from being made in that window at all; this makes the staleness unreadable rather than merely
+   * unreachable.
+   *
+   * @param {string} activeViewerName - PopupPanoManager's name for the viewer that last won a setPano() race.
+   * @param {boolean} panoLoading - Whether this label's setPano() is still in flight.
+   * @returns {boolean}
+   */
+  static viewerShowsLabel(activeViewerName, panoLoading) {
+    if (panoLoading) return false;
+    return activeViewerName === 'Default' || activeViewerName === 'Pannellum';
+  }
+
+  /**
+   * What the pano viewer can truthfully report about the label on screen, or null when it isn't showing it.
+   * Feeds submissionContext(), which supplies the label's own metadata in that case.
    *
    * @returns {?{panoId: ?string, position: ?{lat: number, lng: number},
    *     pov: ?{heading: number, pitch: number, zoom: number}}} Null when no viewer is showing this label; individual
    *     fields may still be null when a viewer is up but its imagery hasn't resolved.
    */
   #viewerState() {
-    const showingThisLabel = this.panoManager.activeViewerName === 'Default'
-      || this.panoManager.activeViewerName === 'Pannellum';
-    if (!showingThisLabel) return null;
+    if (!LabelDetail.viewerShowsLabel(this.panoManager.activeViewerName, this.#panoLoading)) return null;
     return {
       panoId: this.panoManager.panoViewer.getPanoId(),
       position: this.panoManager.panoViewer.getPosition(),
@@ -867,14 +895,20 @@ class LabelDetail {
   }
 
   /**
+   * Disables the vote controls for the duration of a vote's POST, then hands them back.
+   *
+   * Re-enabling defers to the card's own lock: a POST that resolves after the user has paged on must not switch the
+   * controls back on over a label that can't be voted on, or one whose imagery hasn't loaded yet.
+   *
    * @param {boolean} disabled
    */
   #setVoteButtonsDisabled(disabled) {
+    const off = disabled || this.#interactionBlocked;
     for (const btn of Object.values(this.#els.panoOverlayButtons)) {
-      btn.disabled = disabled;
+      btn.disabled = off;
     }
     for (const btn of Object.values(this.#els.voteButtons)) {
-      btn.disabled = disabled;
+      btn.disabled = off;
     }
   }
 
@@ -933,7 +967,7 @@ class LabelDetail {
     for (const btn of Object.values(this.#els.panoOverlayButtons)) {
       btn.classList.remove('is-selected');
       btn.setAttribute('aria-pressed', 'false');
-      if (!this.#locked) btn.disabled = false;
+      if (!this.#interactionBlocked) btn.disabled = false;
     }
     for (const btn of Object.values(this.#els.voteButtons)) {
       btn.setAttribute('aria-pressed', 'false');
@@ -953,8 +987,24 @@ class LabelDetail {
   }
 
   /**
+   * Whether the card's interactive controls are off right now. Everything #locked covers, plus the window where
+   * this label's imagery is still loading: setPano() hides the pano holder on entry and only names the viewer it
+   * settled on once it resolves, so until then there is nothing on screen to judge the label by and
+   * activeViewerName still describes the *previous* label (the #4711 staleness, one step earlier).
+   *
+   * Kept separate from #locked because this one is transient: the comment row stays put through it rather than
+   * animating shut and back open on every page-through.
+   * @returns {boolean}
+   */
+  get #interactionBlocked() {
+    return this.#locked || this.#panoLoading;
+  }
+
+  /**
    * The reason validating/commenting is blocked for the current label, or null when it's allowed. The viewer's
-   * own label wins over no-imagery since it's the more specific reason to surface.
+   * own label wins over no-imagery since it's the more specific reason to surface. A label whose imagery is merely
+   * still loading gets no reason: the controls are disabled for the moment it takes, and a tooltip that appears and
+   * vanishes within it would be noise (and a translated string in every locale for a state nobody can read).
    * @returns {?string}
    */
   #lockReason() {
@@ -970,20 +1020,22 @@ class LabelDetail {
    */
   #applyInteractionLock() {
     const els = this.#els;
-    const locked = this.#locked;
-    this.#root.classList.toggle('label-detail--readonly', locked);
+    const blocked = this.#interactionBlocked;
+    this.#root.classList.toggle('label-detail--readonly', blocked);
     const tip = this.#lockReason() ?? '';
 
     this.#renderVoteTooltips();
-    for (const btn of Object.values(els.panoOverlayButtons)) btn.disabled = locked;
-    for (const btn of Object.values(els.voteButtons)) btn.disabled = locked;
+    for (const btn of Object.values(els.panoOverlayButtons)) btn.disabled = blocked;
+    for (const btn of Object.values(els.voteButtons)) btn.disabled = blocked;
 
     // Comment input and submit button.
-    els.commentInput.disabled = locked;
+    els.commentInput.disabled = blocked;
     els.commentInput.title = tip;
-    els.commentButton.disabled = locked;
+    els.commentButton.disabled = blocked;
     els.commentButton.title = tip;
-    this.#updateCommentRow(); // Locking also hides the comment box (it only shows with a Disagree/Unsure vote).
+    // A durable lock also hides the comment box (it only shows with a Disagree/Unsure vote); a load in flight
+    // leaves it in place and just disables it, since it's about to be usable again.
+    this.#updateCommentRow();
   }
 
   /**

--- a/test/js/labelDetailSubmissionContext.test.js
+++ b/test/js/labelDetailSubmissionContext.test.js
@@ -12,6 +12,9 @@
  * validation_task_comment.lat/lng, with pano_id a foreign key into pano_data), so "fall back" has to mean real
  * values, not nulls, whenever the label carries them.
  *
+ * viewerShowsLabel() is the other half: it decides whether there's a viewer worth believing in the first place, and
+ * the card feeds its answer to submissionContext(). Both are exercised here.
+ *
  * LabelDetail is a top-level `class` declaration written for the Grunt-concatenation world, so (like
  * share-widget.test.js) the source is eval'd into the jsdom global scope with an epilogue that exposes the class.
  * Only the static method is exercised here — constructing a LabelDetail needs a live pano viewer.
@@ -127,4 +130,37 @@ describe('LabelDetail.submissionContext', () => {
             panoId: null, lat: null, lng: null, heading: null, pitch: null, zoom: null
         });
     });
+});
+
+describe('LabelDetail.viewerShowsLabel', () => {
+    let LabelDetail;
+
+    beforeEach(() => {
+        LabelDetail = loadLabelDetail();
+    });
+
+    test.each([
+        ['Default', 'the primary GSV/Mapillary/Infra3d viewer'],
+        ['Pannellum', 'the self-hosted copy of an expired pano']
+    ])('%s is rendering the label, so it may be believed', (name) => {
+        expect(LabelDetail.viewerShowsLabel(name, false)).toBe(true);
+    });
+
+    test('the static-crop fallback is not a viewer showing this label', () => {
+        // panoViewer still points at whatever pano it last loaded, which is some other label's (#4711).
+        expect(LabelDetail.viewerShowsLabel('StaticCrop', false)).toBe(false);
+    });
+
+    test('a card that has never resolved a pano has no viewer to believe', () => {
+        // activeViewerName's initial value, before any setPano() call has settled.
+        expect(LabelDetail.viewerShowsLabel('', false)).toBe(false);
+    });
+
+    test.each(['Default', 'Pannellum'])(
+        '%s is not believed while this label is still loading', (name) => {
+            // The window between paging to a label and its setPano() resolving: activeViewerName still names the
+            // viewer that showed the *previous* label, so believing it records that label's pano and POV.
+            expect(LabelDetail.viewerShowsLabel(name, true)).toBe(false);
+        }
+    );
 });


### PR DESCRIPTION
Follow-up to #4710, which auto-merged while this was being written. Same bug as #4711, one step earlier in the
label's lifecycle.

## The window

`PopupPanoManager` only assigns `activeViewerName` once `setPano()` settles on a viewer (`Default`, `Pannellum`, or
`StaticCrop`), and `showLabel()` fires `setPano()` without awaiting it. So from the moment the user pages to a label
until its imagery resolves, `activeViewerName` still names the viewer that showed the **previous** label — and
`#viewerState()` hands that back as the truth about this one.

Vote inside that window and it's #4711 again, narrower: the previous label's pano and POV, plus the
`canvas_x`/`canvas_y` derived from them. `label_validation.heading/pitch/zoom` are `NOT NULL`, so the row reads as a
real point of view and nothing downstream can tell it apart. The window is a pano-metadata round-trip — wider on the
path that also fetches a backup image's metadata — and paging then voting immediately is ordinary Gallery rhythm.
This file already guards the same "user acted while an async call was in flight" shape twice, with its
`#currentLabelMeta` checks.

## Holding the controls, rather than guessing better data

`setPano()` hides the pano holder on entry, so there is nothing on screen to judge the label by during that window
either. Validating a label you cannot see isn't a validation worth recording whichever POV we attach to it, so the
card now holds its controls until the imagery lands — the same way `#noImagery` already holds them when none is
coming.

That also sidesteps the reason a naive gate doesn't work: `viewer_type` is a `NOT NULL` Postgres enum
(`Default | Pannellum | StaticApi | StaticCrop`) with no honest value to report mid-load, and the `''` it currently
starts at is rejected outright by `viewerTypeReads`.

Three details worth a look:

- **`#interactionBlocked` is kept separate from `#locked` on purpose.** The transient reason gates the controls; the
  durable ones (`#readonly`, `#noImagery`) still gate whether the comment row is *shown*. Folding them together made
  the row animate shut and back open on every page-through — a regression in the feature #4710 existed to fix.
- **The re-enabling paths defer to it too.** `#setVoteButtonsDisabled(false)` and `#resetVoteButtonStyles()` now
  check the block before switching controls back on, so a vote's POST resolving after the user has paged on can't
  hand them back over a label that's still loading. `#setVoteButtonsDisabled`'s error path isn't behind the
  paged-on guard, so this was reachable.
- **No new i18n string.** `#lockReason()` returns null while merely loading, so the vote controls keep their normal
  count tooltips rather than adding a translated string in ten locales for a sub-second state nobody can read.

`viewerShowsLabel(activeViewerName, panoLoading)` is split out as a static for the same reason `submissionContext`
was in #4710 — the gate is now unit-testable without booting a pano viewer — and `#viewerState()` consults it, so
the staleness is unreadable rather than merely unreachable.

Also here: a `setPano()` that rejects outright now lands on "no imagery" instead of leaving the card locked on a
load that will never finish. Without it, the new gate would have introduced that failure mode.

## Testing

- `test/js/labelDetailSubmissionContext.test.js` — 6 new cases over `viewerShowsLabel()`: both viewers that are
  showing the label, the static-crop fallback, a card that has never resolved a pano, and both live viewers during
  the load window.
- Full jsdom suite green: 24 suites / 257 tests.
- ESLint clean.

Not browser-verified — this is a timing bug behind a Street View pano, so the browser half is manual QA.

### QA checklist

1. Page to a new label in the Gallery and try to vote **immediately**, before its imagery paints. The vote controls
   and comment box should be briefly greyed and the click should do nothing, then come back on their own once the
   pano is up. Throttle the network to widen the window enough to hit reliably.
2. On a label you'd already voted Disagree/Unsure on, page to it and watch the comment row through that same window
   — it should stay on screen, not collapse and re-open.
3. Confirm the controls still come back for a label with no imagery at all (they should stay disabled, with the
   existing "no imagery" tooltip) and for your own labels (read-only, unchanged).
4. Same flow on the LabelMap popup and `/label/:id`, plus one validation from `/admin/task/:id` after panning to a
   different pano, to confirm the viewer still wins once loading is done.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-opus-5[1m])
