### PR TITLE
Precompute OSM speed limits and serve from our DB (#4654)

### DIFF
--- a/app/actor/OsmWayRefreshActor.scala
+++ b/app/actor/OsmWayRefreshActor.scala
@@ -1,0 +1,68 @@
+package actor
+
+import actor.ActorUtils.{dateFormatter, getTimeToNextUpdate}
+import org.apache.pekko.actor.{Actor, Cancellable, Props}
+import play.api.Logger
+import service.{ConfigService, OsmWayService}
+
+import java.time.Instant
+import javax.inject._
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+import scala.util.{Failure, Success}
+
+object OsmWayRefreshActor {
+  val Name  = "osm-way-refresh-actor"
+  def props = Props[OsmWayRefreshActor]()
+  case object Tick
+}
+
+/**
+ * Nightly refresh of the cached OSM way data behind the speed-limit sign (#4654).
+ *
+ * Ticks daily, but OsmWayService only re-fetches ways whose row is missing or older than its staleness period, so
+ * most nights are a fast no-op; a new city's ways are backfilled on the first tick after its streets are imported.
+ */
+@Singleton
+class OsmWayRefreshActor @Inject() (osmWayService: OsmWayService)(implicit
+    ec: ExecutionContext,
+    configService: ConfigService
+) extends Actor {
+
+  private var cancellable: Option[Cancellable] = None
+  private val logger                           = Logger(this.getClass)
+
+  override def preStart(): Unit = {
+    super.preStart()
+    // Per-city hour offset staggers computation/resource use across deployments (and their Overpass requests).
+    configService.getOffsetHours.foreach { hoursOffset =>
+      // Target time is 2:00 am Pacific + offset.
+      cancellable = Some(
+        context.system.scheduler.scheduleAtFixedRate(
+          getTimeToNextUpdate(2, 0, hoursOffset).toMillis.millis,
+          24.hours,
+          self,
+          OsmWayRefreshActor.Tick
+        )(context.dispatcher)
+      )
+      logger.info("OsmWayRefreshActor created")
+    }
+  }
+
+  override def postStop(): Unit = {
+    cancellable.foreach(_.cancel())
+    cancellable = None
+    super.postStop()
+  }
+
+  def receive: Receive = { case OsmWayRefreshActor.Tick =>
+    val currentTimeStart: String = dateFormatter.format(Instant.now())
+    logger.info(s"Auto-scheduled OSM way data refresh starting at: $currentTimeStart")
+    osmWayService.refreshOsmWayData().onComplete {
+      case Success(waysRefreshed) =>
+        logger.info(s"OSM way data refresh completed at: ${dateFormatter.format(Instant.now())}")
+        logger.info(s"Ways refreshed: $waysRefreshed")
+      case Failure(e) => logger.error(s"Error refreshing OSM way data: ${e.getMessage}")
+    }
+  }
+}

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -27,6 +27,7 @@ import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 import scala.util.Try
+import scala.util.control.NonFatal
 
 @Singleton
 class AdminController @Inject() (
@@ -1029,7 +1030,7 @@ class AdminController @Inject() (
     osmWayService
       .refreshOsmWayData()
       .map { waysRefreshed => Ok(Json.obj("ways_refreshed" -> waysRefreshed)) }
-      .recover { case e: Exception =>
+      .recover { case NonFatal(e) =>
         logger.error("OSM way data refresh failed.", e)
         // Chunks upsert as they complete, so partial progress survives and a re-trigger resumes from what's missing.
         ServiceUnavailable(

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -1026,7 +1026,16 @@ class AdminController @Inject() (
    */
   def refreshOsmWayData() = cc.securityService.SecuredAction(WithAdmin()) { implicit request =>
     logger.debug(request.toString) // Added bc scalafmt doesn't like "implicit _" & compiler needs us to use request.
-    osmWayService.refreshOsmWayData().map { waysRefreshed => Ok(Json.obj("ways_refreshed" -> waysRefreshed)) }
+    osmWayService
+      .refreshOsmWayData()
+      .map { waysRefreshed => Ok(Json.obj("ways_refreshed" -> waysRefreshed)) }
+      .recover { case e: Exception =>
+        logger.error("OSM way data refresh failed.", e)
+        // Chunks upsert as they complete, so partial progress survives and a re-trigger resumes from what's missing.
+        ServiceUnavailable(
+          Json.obj("error" -> s"Refresh failed partway (${e.getMessage}). Progress is saved; trigger again to resume.")
+        )
+      }
   }
 
   /**

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -41,6 +41,7 @@ class AdminController @Inject() (
     labelService: LabelService,
     streetService: StreetService,
     panoDataService: PanoDataService,
+    osmWayService: service.OsmWayService,
     userService: service.UserService,
     actorSystem: ActorSystem,
     cpuEc: CpuIntensiveExecutionContext
@@ -1018,6 +1019,14 @@ class AdminController @Inject() (
   def checkImagery() = cc.securityService.SecuredAction(WithAdmin()) { implicit request =>
     logger.debug(request.toString) // Added bc scalafmt doesn't like "implicit _" & compiler needs us to use request.
     panoDataService.checkForImagery.map { results => Ok(results) }
+  }
+
+  /**
+   * Refreshes the cached OSM way data (speed limits etc.). Same as the nightly process, for QA and initial backfill.
+   */
+  def refreshOsmWayData() = cc.securityService.SecuredAction(WithAdmin()) { implicit request =>
+    logger.debug(request.toString) // Added bc scalafmt doesn't like "implicit _" & compiler needs us to use request.
+    osmWayService.refreshOsmWayData().map { waysRefreshed => Ok(Json.obj("ways_refreshed" -> waysRefreshed)) }
   }
 
   /**

--- a/app/controllers/ExploreController.scala
+++ b/app/controllers/ExploreController.scala
@@ -31,6 +31,7 @@ class ExploreController @Inject() (
     val config: Configuration,
     configService: service.ConfigService,
     exploreService: service.ExploreService,
+    osmWayService: service.OsmWayService,
     missionService: service.MissionService,
     aiService: service.AiService
 )(implicit ec: ExecutionContext, assets: AssetsFinder)
@@ -219,6 +220,14 @@ class ExploreController @Inject() (
     exploreService
       .selectTasksInRoute(userRouteId)
       .map(tasks => Ok(Json.obj("type" -> "FeatureCollection", "features" -> JsArray(tasks.map(Json.toJson(_))))))
+  }
+
+  /**
+   * Get the speed limit at a point. Fallback for positions off our street network; served from our DB when possible.
+   */
+  def getSpeedLimit(lat: Double, lng: Double) = cc.securityService.SecuredAction { implicit request =>
+    logger.debug(request.toString) // Added bc scalafmt doesn't like "implicit _" & compiler needs us to use request.
+    osmWayService.getSpeedLimitAtPoint(lat, lng).map(maxSpeed => Ok(Json.obj("max_speed" -> maxSpeed)))
   }
 
   /**

--- a/app/controllers/ExploreController.scala
+++ b/app/controllers/ExploreController.scala
@@ -32,6 +32,7 @@ class ExploreController @Inject() (
     configService: service.ConfigService,
     exploreService: service.ExploreService,
     osmWayService: service.OsmWayService,
+    rateLimiter: service.RateLimiter,
     missionService: service.MissionService,
     aiService: service.AiService
 )(implicit ec: ExecutionContext, assets: AssetsFinder)
@@ -226,8 +227,16 @@ class ExploreController @Inject() (
    * Get the speed limit at a point. Fallback for positions off our street network; served from our DB when possible.
    */
   def getSpeedLimit(lat: Double, lng: Double) = cc.securityService.SecuredAction { implicit request =>
-    logger.debug(request.toString) // Added bc scalafmt doesn't like "implicit _" & compiler needs us to use request.
-    osmWayService.getSpeedLimitAtPoint(lat, lng).map(maxSpeed => Ok(Json.obj("max_speed" -> maxSpeed)))
+    // Inert-until-enabled IP guard: each cache-missing lookup can cost an Overpass query, so cap scripted floods.
+    val limit = rateLimiter.limit("speed-limit")
+    if (!rateLimiter.allow(s"speed-limit:ip:${request.ipAddress}", limit)) {
+      Future.successful(
+        TooManyRequests(Json.obj("error" -> "Too many speed limit lookups."))
+          .withHeaders("Retry-After" -> limit.window.toSeconds.toString)
+      )
+    } else {
+      osmWayService.getSpeedLimitAtPoint(lat, lng).map(maxSpeed => Ok(Json.obj("max_speed" -> maxSpeed)))
+    }
   }
 
   /**

--- a/app/controllers/ValidateController.scala
+++ b/app/controllers/ValidateController.scala
@@ -45,6 +45,7 @@ class ValidateController @Inject() (
     authenticationService: service.AuthenticationService,
     regionService: service.RegionService,
     panoDataService: service.PanoDataService,
+    osmWayService: service.OsmWayService,
     missionService: service.MissionService
 )(implicit assets: AssetsFinder)
     extends CustomBaseController(cc) {
@@ -263,6 +264,7 @@ class ValidateController @Inject() (
         labelService.getDataForValidationPages(user, labelCount, validateParams)
       completedValidations <- validationService.countValidations(user.userId)
       tags: Seq[Tag]       <- labelService.getTagsForCurrentCity
+      maxSpeeds            <- osmWayService.getMaxSpeedsForStreets(labels.map(_.streetEdgeId).distinct)
     } yield {
       val missionJsObject: Option[JsValue] = mission.map(m => Json.toJson(m))
       val progressJsObject                 =
@@ -270,10 +272,21 @@ class ValidateController @Inject() (
       val hasDataForMission: Boolean          = labels.nonEmpty
       val labelMetadataJsonSeq: Seq[JsObject] = if (validateParams.adminVersion) {
         labels.sortBy(_.labelId).zip(adminData.sortBy(_.labelId)).map { case (l, admin) =>
-          LabelFormats.validationLabelMetadataToJson(l, panoDataService.backupImageUrl(l.panoId), Some(admin))
+          LabelFormats.validationLabelMetadataToJson(
+            l,
+            panoDataService.backupImageUrl(l.panoId),
+            Some(admin),
+            maxSpeed = maxSpeeds.get(l.streetEdgeId)
+          )
         }
       } else {
-        labels.map { l => LabelFormats.validationLabelMetadataToJson(l, panoDataService.backupImageUrl(l.panoId)) }
+        labels.map { l =>
+          LabelFormats.validationLabelMetadataToJson(
+            l,
+            panoDataService.backupImageUrl(l.panoId),
+            maxSpeed = maxSpeeds.get(l.streetEdgeId)
+          )
+        }
       }
       val labelMetadataJson: JsValue = Json.toJson(labelMetadataJsonSeq)
       ValidatePageData(missionJsObject, Some(labelMetadataJson), progressJsObject, hasDataForMission,
@@ -313,14 +326,24 @@ class ValidateController @Inject() (
 
       // Get data to return in POST response. Not much unless the mission is over and we need the next batch of labels.
       returnValue <- labelService.getDataForValidatePostRequest(user, data.missionProgress, data.validateParams)
+      maxSpeeds   <- osmWayService.getMaxSpeedsForStreets(returnValue.labels.map(_.streetEdgeId).distinct)
     } yield {
       val labelMetadataJsonSeq: Seq[JsObject] = if (data.validateParams.adminVersion) {
         returnValue.labels.sortBy(_.labelId).zip(returnValue.adminData.sortBy(_.labelId)).map { case (l, admin) =>
-          LabelFormats.validationLabelMetadataToJson(l, panoDataService.backupImageUrl(l.panoId), Some(admin))
+          LabelFormats.validationLabelMetadataToJson(
+            l,
+            panoDataService.backupImageUrl(l.panoId),
+            Some(admin),
+            maxSpeed = maxSpeeds.get(l.streetEdgeId)
+          )
         }
       } else {
         returnValue.labels.map { l =>
-          LabelFormats.validationLabelMetadataToJson(l, panoDataService.backupImageUrl(l.panoId))
+          LabelFormats.validationLabelMetadataToJson(
+            l,
+            panoDataService.backupImageUrl(l.panoId),
+            maxSpeed = maxSpeeds.get(l.streetEdgeId)
+          )
         }
       }
       Ok(

--- a/app/controllers/helper/ShapefilesCreatorHelper.scala
+++ b/app/controllers/helper/ShapefilesCreatorHelper.scala
@@ -825,6 +825,7 @@ class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: M
       + "regionId:Integer,"            // Region ID
       + "regionName:String,"           // Region name
       + "wayType:String,"              // Type of street/way
+      + "maxSpeed:String,"             // Raw OSM maxspeed tag (e.g. "25 mph"); empty when unknown
       + "status:String,"               // Street availability: open, no_imagery, closed, or disabled
       + "labelCount:Integer,"          // Number of labels on this street
       + "auditCount:Integer,"          // Number of times audited
@@ -844,6 +845,7 @@ class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: M
       featureBuilder.add(street.regionId)
       featureBuilder.add(street.regionName)
       featureBuilder.add(street.wayType)
+      featureBuilder.add(street.maxSpeed.orNull)
       featureBuilder.add(street.status)
       featureBuilder.add(street.labelCount)
       featureBuilder.add(street.auditCount)
@@ -885,6 +887,7 @@ class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: M
       + "region_id:Integer,"           // Region ID
       + "region_name:String,"          // Region name
       + "way_type:String,"         // Type of street/way. Using String instead of Long to avoid type resolution issues.
+      + "max_speed:String,"        // Raw OSM maxspeed tag (e.g. "25 mph"); empty when unknown
       + "status:String,"           // Street availability: open, no_imagery, closed, or disabled
       + "label_count:Integer,"     // Number of labels on this street
       + "audit_count:Integer,"     // Number of times audited
@@ -907,6 +910,7 @@ class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: M
       featureBuilder.add(street.regionId)
       featureBuilder.add(street.regionName)
       featureBuilder.add(street.wayType)
+      featureBuilder.add(street.maxSpeed.orNull)
       featureBuilder.add(street.status)
       featureBuilder.add(street.labelCount)
       featureBuilder.add(street.auditCount)

--- a/app/formats/json/ExploreFormats.scala
+++ b/app/formats/json/ExploreFormats.scala
@@ -184,6 +184,7 @@ object ExploreFormats {
         "current_lng"           -> task.currentLng,
         "current_lat"           -> task.currentLat,
         "way_type"              -> task.wayType.toString,
+        "max_speed"             -> task.maxSpeed,
         "start_point_reversed"  -> task.startPointReversed,
         "task_start"            -> task.taskStart.toString,
         "completed_by_any_user" -> task.completedByAnyUser,

--- a/app/formats/json/LabelFormats.scala
+++ b/app/formats/json/LabelFormats.scala
@@ -98,7 +98,8 @@ object LabelFormats {
       labelMetadata: LabelValidationMetadata,
       backupImageUrl: Option[String],
       adminData: Option[AdminValidationData] = None,
-      currUsername: Option[String] = None
+      currUsername: Option[String] = None,
+      maxSpeed: Option[String] = None
   ): JsObject = {
     val commenterIdx: Map[String, Int] = commenterIndices(labelMetadata.comments)
     Json.obj(
@@ -119,6 +120,7 @@ object LabelFormats {
       "severity"            -> labelMetadata.severity,
       "description"         -> labelMetadata.description,
       "street_edge_id"      -> labelMetadata.streetEdgeId,
+      "max_speed"           -> maxSpeed,
       "region_id"           -> labelMetadata.regionId,
       "correct"             -> labelMetadata.validationInfo.correct,
       "agree_count"         -> labelMetadata.validationInfo.agreeCount,

--- a/app/models/api/StreetsApiModels.scala
+++ b/app/models/api/StreetsApiModels.scala
@@ -22,6 +22,7 @@ import java.time.OffsetDateTime
  * @param regionId Region ID where the street is located
  * @param regionName Name of the region where the street is located
  * @param wayType Type of way (e.g., "residential", "primary", etc.)
+ * @param maxSpeed Raw OSM maxspeed tag for the street's way (e.g., "25 mph", "30"); None when untagged or unknown
  * @param status Availability of the street: "open", "no_imagery", "closed", or "disabled"
  * @param userIds List of user IDs who have applied labels to this street
  * @param labelCount Number of labels applied to this street
@@ -36,6 +37,7 @@ case class StreetDataForApi(
     regionId: Int,
     regionName: String,
     wayType: String,
+    maxSpeed: Option[String],
     status: String,
     userIds: Seq[String],
     labelCount: Int,
@@ -64,6 +66,7 @@ case class StreetDataForApi(
         "region_id"        -> regionId,
         "region_name"      -> regionName,
         "way_type"         -> wayType,
+        "max_speed"        -> maxSpeed,
         "status"           -> status,
         "user_ids"         -> userIds,
         "label_count"      -> labelCount,
@@ -88,6 +91,7 @@ case class StreetDataForApi(
       regionId.toString,
       escapeCsvField(regionName),
       escapeCsvField(wayType),
+      maxSpeed.map(escapeCsvField).getOrElse(""),
       escapeCsvField(status),
       escapeCsvField(userIds.mkString("[", ",", "]")),
       labelCount.toString,
@@ -113,8 +117,8 @@ object StreetDataForApi {
    * CSV header string with field names in the same order as the toCsvRow output.
    * This should be included as the first line when generating CSV output.
    */
-  val csvHeader: String = "street_edge_id,osm_way_id,region_id,region_name,way_type,status,user_ids,label_count," +
-    "audit_count,user_count,first_label_date,last_label_date,start_point,end_point\n"
+  val csvHeader: String = "street_edge_id,osm_way_id,region_id,region_name,way_type,max_speed,status,user_ids," +
+    "label_count,audit_count,user_count,first_label_date,last_label_date,start_point,end_point\n"
 
   /**
    * Implicit JSON writer for StreetDataForApi that uses the toJson method.

--- a/app/models/audit/AuditTaskTable.scala
+++ b/app/models/audit/AuditTaskTable.scala
@@ -52,7 +52,8 @@ case class NewTask(
     currentMissionId: Option[Int],
     currentMissionStart: Option[Point], // If a mission was started mid-task, the loc where it started.
     routeStreetId: Option[Int],         // The route_street_id if this task is part of a route.
-    routeStreetPosition: Option[Int]    // The street's walking-order position within that route.
+    routeStreetPosition: Option[Int],   // The street's walking-order position within that route.
+    maxSpeed: Option[String]            // Raw OSM maxspeed tag for the street's way (e.g. "25 mph"), if known.
 )
 case class AuditedStreetWithTimestamp(
     streetEdgeId: Int,
@@ -116,7 +117,8 @@ trait AuditTaskTableRepository {}
 
 class AuditTaskTable @Inject() (
     protected val dbConfigProvider: DatabaseConfigProvider,
-    streetEdgeTable: StreetEdgeTable
+    streetEdgeTable: StreetEdgeTable,
+    osmWayTable: OsmWayTable
 )(implicit ec: ExecutionContext)
     extends AuditTaskTableRepository
     with HasDatabaseConfigProvider[MyPostgresProfile] {
@@ -388,6 +390,7 @@ class AuditTaskTable @Inject() (
       se   <- streetEdgeTable.streets if se.streetEdgeId === streetEdgeId
       scau <- streetCompletedByAnyUser if se.streetEdgeId === scau._1
       sep  <- streetEdgePriorities if scau._1 === sep.streetEdgeId
+      sms  <- osmWayTable.streetMaxSpeeds if se.streetEdgeId === sms._1
     } yield (
       se.streetEdgeId,
       se.geom,
@@ -403,7 +406,8 @@ class AuditTaskTable @Inject() (
       Some(missionId).asColumnOf[Option[Int]],
       None: Option[Point], // currentMissionStart is None for a new task.
       routeStreetId,
-      routeStreetPosition
+      routeStreetPosition,
+      sms._2 // maxSpeed
     )
 
     edges.result.head.map(NewTask.tupled)
@@ -433,7 +437,8 @@ class AuditTaskTable @Inject() (
           missionId.asColumnOf[Option[Int]],
           None: Option[Point], // currentMissionStart is None for a new task.
           None: Option[Int],   // routeStreetId is None for the tutorial task.
-          None: Option[Int]    // routeStreetPosition is None for the tutorial task.
+          None: Option[Int],   // routeStreetPosition is None for the tutorial task.
+          None: Option[String] // maxSpeed isn't shown during the tutorial.
         )
       }
       .result
@@ -451,6 +456,7 @@ class AuditTaskTable @Inject() (
       se  <- streetEdgeTable.streets if ser.streetEdgeId === se.streetEdgeId
       sp  <- streetEdgePriorities if se.streetEdgeId === sp.streetEdgeId
       sc  <- streetCompletedByAnyUser if se.streetEdgeId === sc._1
+      sms <- osmWayTable.streetMaxSpeeds if se.streetEdgeId === sms._1
     } yield (
       se.streetEdgeId,
       se.geom,
@@ -466,7 +472,8 @@ class AuditTaskTable @Inject() (
       Some(missionId).asColumnOf[Option[Int]],
       None: Option[Point], // currentMissionStart is None for a new task.
       None: Option[Int],   // routeStreetId
-      None: Option[Int]    // routeStreetPosition
+      None: Option[Int],   // routeStreetPosition
+      sms._2               // maxSpeed
     )
 
     // Get the priority of the highest priority task.
@@ -497,14 +504,15 @@ class AuditTaskTable @Inject() (
   ): DBIO[Option[NewTask]] = {
     val matchingTasks = if (includeCompleted) auditTasks else activeTasks
     val newTask       = for {
-      at <- matchingTasks if at.auditTaskId === taskId
-      se <- streetEdgeTable.streetsWithTutorial if at.streetEdgeId === se.streetEdgeId
-      sp <- streetEdgePriorities if se.streetEdgeId === sp.streetEdgeId
-      sc <- streetCompletedByAnyUser if sp.streetEdgeId === sc._1
+      at  <- matchingTasks if at.auditTaskId === taskId
+      se  <- streetEdgeTable.streetsWithTutorial if at.streetEdgeId === se.streetEdgeId
+      sp  <- streetEdgePriorities if se.streetEdgeId === sp.streetEdgeId
+      sc  <- streetCompletedByAnyUser if sp.streetEdgeId === sc._1
+      sms <- osmWayTable.streetMaxSpeeds if se.streetEdgeId === sms._1
     } yield (
       se.streetEdgeId, se.geom, at.currentLng, at.currentLat, se.wayType, at.startPointReversed, at.taskStart, sc._2,
       sp.priority, at.completed, at.auditTaskId.?, at.currentMissionId, at.currentMissionStart, routeStreetId,
-      routeStreetPosition
+      routeStreetPosition, sms._2
     )
 
     newTask.result.headOption.map(_.map(NewTask.tupled))
@@ -530,6 +538,7 @@ class AuditTaskTable @Inject() (
       se         <- streetEdgeTable.streets if ser.streetEdgeId === se.streetEdgeId
       sep        <- streetEdgePriorities if se.streetEdgeId === sep.streetEdgeId
       scau       <- streetCompletedByAnyUser if sep.streetEdgeId === scau._1
+      sms        <- osmWayTable.streetMaxSpeeds if se.streetEdgeId === sms._1
     } yield (
       se.streetEdgeId,
       se.geom,
@@ -545,7 +554,8 @@ class AuditTaskTable @Inject() (
       ucs.map(_._4).flatten, // fill currentMissionId if the user has an existing mission for this street.
       ucs.map(_._5).flatten, // fill currentMissionStart if the user has an existing mission for this street.
       None: Option[Int],     // routeStreetId
-      None: Option[Int]      // routeStreetPosition
+      None: Option[Int],     // routeStreetPosition
+      sms._2                 // maxSpeed
     )
 
     tasks.result.map(_.map(NewTask.tupled(_)))
@@ -596,6 +606,7 @@ class AuditTaskTable @Inject() (
       _se2               <- streetEdgeTable.streets if _se1.streetEdgeId === _se2.streetEdgeId
       _sep               <- streetEdgePriorities if _se2.streetEdgeId === _sep.streetEdgeId
       _scau              <- streetCompletedByAnyUser if _sep.streetEdgeId === _scau._1
+      _sms               <- osmWayTable.streetMaxSpeeds if _se2.streetEdgeId === _sms._1
     } yield (
       _se2.streetEdgeId,
       _se2.geom,
@@ -611,7 +622,8 @@ class AuditTaskTable @Inject() (
       ucs.flatMap(_._4), // fill currentMissionId if the user has an existing mission for this street.
       ucs.flatMap(_._5), // fill currentMissionStart if the user has an existing mission for this street.
       _rs.routeStreetId.asColumnOf[Option[Int]],
-      _rs.position.asColumnOf[Option[Int]]
+      _rs.position.asColumnOf[Option[Int]],
+      _sms._2 // maxSpeed
     )
 
     tasks.result.map(_.map(NewTask.tupled(_)))

--- a/app/models/street/OsmWayTable.scala
+++ b/app/models/street/OsmWayTable.scala
@@ -1,0 +1,150 @@
+package models.street
+
+import com.google.inject.ImplementedBy
+import models.utils.MyPostgresProfile
+import models.utils.MyPostgresProfile.api._
+import org.locationtech.jts.geom.LineString
+import play.api.db.slick.{DatabaseConfigProvider, HasDatabaseConfigProvider}
+import play.api.libs.json.{JsValue, Json}
+
+import java.time.OffsetDateTime
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.ExecutionContext
+
+/**
+ * Cached data about an OSM way, refreshed periodically from the Overpass API (#4654).
+ *
+ * @param osmWayId  OSM way identifier.
+ * @param tags      The way's full OSM tag map, so future features can read name/sidewalk/surface/etc. without
+ *                  re-fetching.
+ * @param maxspeed  Raw OSM `maxspeed` tag (e.g. "25 mph", "30"); None if the way carries no maxspeed tag.
+ * @param geom      Way geometry, present only on rows discovered by the on-demand point lookup (batch rows are located
+ *                  via street_edge geometry instead).
+ * @param source    How the row was written: "batch" (nightly refresh) or "on_demand" (point-lookup fallback).
+ * @param updatedAt When the way was last fetched from Overpass; drives the staleness-based refresh.
+ */
+case class OsmWay(
+    osmWayId: Long,
+    tags: JsValue,
+    maxspeed: Option[String],
+    geom: Option[LineString],
+    source: String,
+    updatedAt: OffsetDateTime
+)
+
+class OsmWayTableDef(tag: Tag) extends Table[OsmWay](tag, "osm_way") {
+  def osmWayId: Rep[Long]           = column[Long]("osm_way_id", O.PrimaryKey)
+  def tags: Rep[JsValue]            = column[JsValue]("tags")
+  def maxspeed: Rep[Option[String]] = column[Option[String]]("maxspeed")
+  def geom: Rep[Option[LineString]] = column[Option[LineString]]("geom")
+  // CHECK (source IN ('batch', 'on_demand')) in the DB (no Slick DSL for CHECK constraints).
+  def source: Rep[String]            = column[String]("source")
+  def updatedAt: Rep[OffsetDateTime] = column[OffsetDateTime]("updated_at")
+
+  def * = (osmWayId, tags, maxspeed, geom, source, updatedAt) <> ((OsmWay.apply _).tupled, OsmWay.unapply)
+}
+
+@ImplementedBy(classOf[OsmWayTable])
+trait OsmWayTableRepository {}
+
+/**
+ * Queries over the cached OSM way data: per-street maxspeed lookups for the Explore/Validate payloads, the
+ * missing-or-stale scan that drives the nightly refresh, and the point lookup behind the on-demand fallback.
+ */
+@Singleton
+class OsmWayTable @Inject() (
+    protected val dbConfigProvider: DatabaseConfigProvider,
+    streetEdgeTable: StreetEdgeTable
+)(implicit ec: ExecutionContext)
+    extends OsmWayTableRepository
+    with HasDatabaseConfigProvider[MyPostgresProfile] {
+
+  val osmWays           = TableQuery[OsmWayTableDef]
+  val osmWayStreetEdges = TableQuery[OsmWayStreetEdgeTableDef]
+
+  /**
+   * Sub query with columns (street_edge_id, maxspeed): (Int, Option[String]).
+   *
+   * Left-joined over all streets (like AuditTaskTable.streetCompletedByAnyUser) so consumers can inner-join it as a
+   * plain generator without dropping streets that have no osm_way row yet.
+   */
+  def streetMaxSpeeds: Query[(Rep[Int], Rep[Option[String]]), (Int, Option[String]), Seq] = {
+    val speedByStreet = osmWayStreetEdges
+      .join(osmWays)
+      .on(_.osmWayId === _.osmWayId)
+      .map(x => (x._1.streetEdgeId, x._2.maxspeed))
+
+    streetEdgeTable.streetsWithTutorial.joinLeft(speedByStreet).on(_.streetEdgeId === _._1).map { case (_edge, _sp) =>
+      (_edge.streetEdgeId, _sp.flatMap(_._2))
+    }
+  }
+
+  /**
+   * Gets the maxspeed for each of the given streets, keyed by street_edge_id.
+   *
+   * @return Map from street_edge_id to raw maxspeed tag; streets with no cached way or no maxspeed tag are absent.
+   */
+  def getMaxSpeeds(streetEdgeIds: Seq[Int]): DBIO[Map[Int, String]] = {
+    osmWayStreetEdges
+      .filter(_.streetEdgeId inSetBind streetEdgeIds)
+      .join(osmWays)
+      .on(_.osmWayId === _.osmWayId)
+      .map(x => (x._1.streetEdgeId, x._2.maxspeed))
+      .result
+      .map(_.collect { case (streetEdgeId, Some(maxspeed)) => streetEdgeId -> maxspeed }.toMap)
+  }
+
+  /**
+   * Gets the distinct way ids from osm_way_street_edge whose osm_way row is missing or last fetched before `cutoff`.
+   */
+  def getWayIdsMissingOrStale(cutoff: OffsetDateTime): DBIO[Seq[Long]] = {
+    osmWayStreetEdges
+      .map(_.osmWayId)
+      .distinct
+      .joinLeft(osmWays)
+      .on(_ === _.osmWayId)
+      .filter { case (_, way) => way.map(_.updatedAt < cutoff).getOrElse(true) }
+      .map(_._1)
+      .result
+  }
+
+  /**
+   * Finds the nearest way with stored geometry within `radiusM` meters of the given point.
+   */
+  def getNearestWithGeom(lat: Double, lng: Double, radiusM: Double): DBIO[Option[OsmWay]] = {
+    osmWays
+      .filter(_.geom.isDefined)
+      .map(way => (way, way.geom.distanceSphereD(makePoint(lng.bind, lat.bind).setSRID(4326))))
+      .filter(_._2 < radiusM)
+      .sortBy(_._2)
+      .map(_._1)
+      .result
+      .headOption
+  }
+
+  /**
+   * Inserts or updates a single way, including its geometry. Used by the on-demand point-lookup path.
+   */
+  def upsert(way: OsmWay): DBIO[Int] = osmWays.insertOrUpdate(way)
+
+  /**
+   * Inserts or updates a batch of ways as (osm_way_id, tags, maxspeed) triples with source 'batch'.
+   *
+   * Raw SQL rather than Slick's insertOrUpdate so that an existing row's geom survives: the nightly batch fetches tags
+   * only, and overwriting geom with NULL would throw away the geometry an earlier on-demand lookup stored.
+   */
+  def upsertBatch(ways: Seq[(Long, JsValue, Option[String])], timestamp: OffsetDateTime): DBIO[Int] = {
+    if (ways.isEmpty) DBIO.successful(0)
+    else {
+      val actions = ways.map { case (wayId, tags, maxspeed) =>
+        sqlu"""
+          INSERT INTO osm_way (osm_way_id, tags, maxspeed, source, updated_at)
+          VALUES ($wayId, ${Json.stringify(tags)}::jsonb, $maxspeed, 'batch', $timestamp)
+          ON CONFLICT (osm_way_id) DO UPDATE
+          SET tags = EXCLUDED.tags, maxspeed = EXCLUDED.maxspeed, source = 'batch', updated_at = EXCLUDED.updated_at
+        """
+      }
+      DBIO.sequence(actions).map(_.sum)
+    }
+  }
+}

--- a/app/models/street/OsmWayTable.scala
+++ b/app/models/street/OsmWayTable.scala
@@ -66,7 +66,9 @@ class OsmWayTable @Inject() (
    * Sub query with columns (street_edge_id, maxspeed): (Int, Option[String]).
    *
    * Left-joined over all streets (like AuditTaskTable.streetCompletedByAnyUser) so consumers can inner-join it as a
-   * plain generator without dropping streets that have no osm_way row yet.
+   * plain generator without dropping streets that have no osm_way row yet. That guarantee is load-bearing: the
+   * NewTask queries in AuditTaskTable all consume this in inner-join position, so removing the left-join wrapper
+   * would silently drop every street that lacks a cached OSM way from task selection.
    */
   def streetMaxSpeeds: Query[(Rep[Int], Rep[Option[String]]), (Int, Option[String]), Seq] = {
     val speedByStreet = osmWayStreetEdges
@@ -144,7 +146,8 @@ class OsmWayTable @Inject() (
           SET tags = EXCLUDED.tags, maxspeed = EXCLUDED.maxspeed, source = 'batch', updated_at = EXCLUDED.updated_at
         """
       }
-      DBIO.sequence(actions).map(_.sum)
+      // One transaction per chunk: a single commit instead of one per row, and a failed chunk leaves no partial rows.
+      DBIO.sequence(actions).map(_.sum).transactionally
     }
   }
 }

--- a/app/models/street/StreetEdgeTable.scala
+++ b/app/models/street/StreetEdgeTable.scala
@@ -285,9 +285,11 @@ class StreetEdgeTable @Inject() (
     // numeric filters are safe; see #2756 for migrating these raw builders to bound parameters.
     val queryStr = s"""
       WITH filtered_streets AS (
-        SELECT s.street_edge_id, s.geom, s.way_type, s.status, o.osm_way_id, r.region_id, reg.name as region_name
+        SELECT s.street_edge_id, s.geom, s.way_type, s.status, o.osm_way_id, osm_way.maxspeed AS max_speed,
+               r.region_id, reg.name as region_name
         FROM street_edge s
         JOIN osm_way_street_edge o ON s.street_edge_id = o.street_edge_id
+        LEFT JOIN osm_way ON o.osm_way_id = osm_way.osm_way_id
         JOIN street_edge_region r ON s.street_edge_id = r.street_edge_id
         JOIN region reg ON r.region_id = reg.region_id
         -- The API returns all streets (open, no_imagery, disabled) tagged with their status (#3888); only the tutorial
@@ -327,7 +329,7 @@ class StreetEdgeTable @Inject() (
         GROUP BY s.street_edge_id
       )
       -- Final selection with all filters applied.
-      SELECT s.street_edge_id, s.osm_way_id, s.region_id, s.region_name, s.way_type, s.status,
+      SELECT s.street_edge_id, s.osm_way_id, s.region_id, s.region_name, s.way_type, s.max_speed, s.status,
              COALESCE(l.user_ids, ARRAY[]::text[]) as user_ids,
              COALESCE(l.label_count, 0) as label_count,
              COALESCE(a.audit_count, 0) as audit_count,
@@ -351,6 +353,7 @@ class StreetEdgeTable @Inject() (
         regionId = r.nextInt(),
         regionName = r.nextString(),
         wayType = r.nextString(),
+        maxSpeed = r.nextStringOption(),
         status = r.nextString(),
         userIds = {
           // Handle PostgreSQL array type properly.

--- a/app/modules/ActorModule.scala
+++ b/app/modules/ActorModule.scala
@@ -13,6 +13,7 @@ class ActorModule extends AbstractModule with PekkoGuiceSupport {
     bindActor[RecalculateStreetPriorityActor]("recalculate-street-priority-actor")
     bindActor[AuthTokenCleanerActor]("auth-token-cleaner-actor")
     bindActor[ClusteringActor]("clustering-actor")
+    bindActor[OsmWayRefreshActor]("osm-way-refresh-actor")
     bind(classOf[ActorInitializer]).asEagerSingleton()
   }
 }

--- a/app/service/OsmWayService.scala
+++ b/app/service/OsmWayService.scala
@@ -15,6 +15,7 @@ import java.time.OffsetDateTime
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.control.NonFatal
 
 /**
  * Maintains the cached OSM way data (osm_way table) that backs the speed-limit sign (#4654).
@@ -87,7 +88,7 @@ class OsmWayService @Inject() (
           case Some(way) => Future.successful(way.maxspeed)
           case None      => queryAndStoreNearestRoad(lat, lng)
         }
-        .recover { case e: Exception =>
+        .recover { case NonFatal(e) =>
           logger.warn(s"Speed limit lookup failed for ($lat, $lng); returning no speed limit.", e)
           None
         }
@@ -108,7 +109,7 @@ class OsmWayService @Inject() (
    */
   private def fetchTagsForWaysWithRetry(wayIds: Seq[Long], attempt: Int = 1): Future[Map[Long, JsObject]] = {
     fetchTagsForWays(wayIds).recoverWith {
-      case e: Exception if attempt < BATCH_MAX_ATTEMPTS =>
+      case NonFatal(e) if attempt < BATCH_MAX_ATTEMPTS =>
         logger.warn(s"Overpass batch attempt $attempt/$BATCH_MAX_ATTEMPTS failed (${e.getMessage}); retrying.")
         after(BATCH_RETRY_DELAY * attempt.toLong, actorSystem.scheduler)(fetchTagsForWaysWithRetry(wayIds, attempt + 1))
     }

--- a/app/service/OsmWayService.scala
+++ b/app/service/OsmWayService.scala
@@ -1,0 +1,234 @@
+package service
+
+import models.street.{OsmWay, OsmWayTable, WayType}
+import models.utils.MyPostgresProfile
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.pattern.after
+import org.locationtech.jts.geom.{Coordinate, GeometryFactory, LineString, PrecisionModel}
+import play.api.Logger
+import play.api.cache.AsyncCacheApi
+import play.api.db.slick.{DatabaseConfigProvider, HasDatabaseConfigProvider}
+import play.api.libs.json.{JsObject, JsValue, Json}
+import play.api.libs.ws.WSClient
+
+import java.time.OffsetDateTime
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future}
+
+/**
+ * Maintains the cached OSM way data (osm_way table) that backs the speed-limit sign (#4654).
+ *
+ * Two write paths, both polite to the shared community Overpass instance: a nightly batch refresh that bulk-fetches
+ * tags for every way mapped in osm_way_street_edge (monthly per way, via a staleness cutoff), and an on-demand point
+ * lookup used when a user wanders onto a street outside our network — checked against our DB first so each unknown
+ * spot costs Overpass at most one query ever, across all users.
+ */
+@Singleton
+class OsmWayService @Inject() (
+    protected val dbConfigProvider: DatabaseConfigProvider,
+    ws: WSClient,
+    cacheApi: AsyncCacheApi,
+    actorSystem: ActorSystem,
+    osmWayTable: OsmWayTable
+)(implicit ec: ExecutionContext)
+    extends HasDatabaseConfigProvider[MyPostgresProfile] {
+  import OsmWayService._
+
+  private val logger = Logger(this.getClass)
+
+  /**
+   * Refreshes cached way data for every mapped way whose row is missing or older than `STALENESS_PERIOD`.
+   *
+   * Fetches tags in chunks of `BATCH_CHUNK_SIZE` ids, sequentially with a delay between chunks. Every requested id is
+   * upserted even when absent from the response (deleted/redacted ways get empty tags), so it won't re-queue nightly.
+   * A failed chunk fails the whole run; the next nightly tick retries from whatever is still stale.
+   *
+   * @return Number of ways refreshed (0 when everything is fresh).
+   */
+  def refreshOsmWayData(): Future[Int] = {
+    db.run(osmWayTable.getWayIdsMissingOrStale(OffsetDateTime.now.minusDays(STALENESS_PERIOD_DAYS))).flatMap { wayIds =>
+      if (wayIds.isEmpty) { Future.successful(0) }
+      else {
+        logger.info(s"Refreshing OSM way data for ${wayIds.size} ways.")
+        wayIds.grouped(BATCH_CHUNK_SIZE).zipWithIndex.foldLeft(Future.successful(0)) {
+          case (accFuture, (chunk, chunkIdx)) =>
+            for {
+              acc <- accFuture
+              // Space out requests to the shared Overpass instance; no delay before the first chunk.
+              _ <- if (chunkIdx == 0) Future.unit else after(BATCH_CHUNK_DELAY, actorSystem.scheduler)(Future.unit)
+              fetched <- fetchTagsForWays(chunk)
+              rows = chunk.map { wayId =>
+                val tags = fetched.getOrElse(wayId, Json.obj())
+                (wayId, tags: JsValue, maxspeedFrom(tags))
+              }
+              n <- db.run(osmWayTable.upsertBatch(rows, OffsetDateTime.now))
+            } yield acc + n
+        }
+      }
+    }
+  }
+
+  /**
+   * Gets the speed limit at a point, for positions not on our street network (the /speedLimit fallback).
+   *
+   * Checks ways already stored in our DB first; only on a miss does it query Overpass for the nearest road,
+   * storing the result (with geometry) so the next lookup nearby is served from the DB. Results — including "no road
+   * here" — are cached for a few minutes per rounded coordinate so repeated pano moves at the same spot are free.
+   *
+   * @return The raw maxspeed tag of the nearest road within `SEARCH_RADIUS_M`; None if no road or no tag, and on any
+   *         Overpass failure (this method never propagates an error).
+   */
+  def getSpeedLimitAtPoint(lat: Double, lng: Double): Future[Option[String]] = {
+    val cacheKey = f"speedLimitAtPoint:$lat%.4f,$lng%.4f"
+    cacheApi.getOrElseUpdate[Option[String]](cacheKey, POINT_CACHE_TTL) {
+      db.run(osmWayTable.getNearestWithGeom(lat, lng, SEARCH_RADIUS_M))
+        .flatMap {
+          case Some(way) => Future.successful(way.maxspeed)
+          case None      => queryAndStoreNearestRoad(lat, lng)
+        }
+        .recover { case e: Exception =>
+          logger.warn(s"Speed limit lookup failed for ($lat, $lng); returning no speed limit.", e)
+          None
+        }
+    }
+  }
+
+  /**
+   * Gets the maxspeed for each of the given streets, keyed by street_edge_id. Streets with no known speed are absent.
+   */
+  def getMaxSpeedsForStreets(streetEdgeIds: Seq[Int]): Future[Map[Int, String]] = {
+    db.run(osmWayTable.getMaxSpeeds(streetEdgeIds))
+  }
+
+  /**
+   * Fetches the full tag map for the given way ids from Overpass, keyed by way id.
+   *
+   * Ways absent from the response (deleted/redacted) are simply missing from the returned map.
+   */
+  private def fetchTagsForWays(wayIds: Seq[Long]): Future[Map[Long, JsObject]] = {
+    val query = s"[out:json][timeout:180];way(id:${wayIds.mkString(",")});out tags;"
+    ws.url(OVERPASS_URL)
+      .withRequestTimeout(3.minutes)
+      .post(Map("data" -> Seq(query)))
+      .map { response =>
+        if (response.status != 200) {
+          throw new RuntimeException(s"Overpass batch query failed with status ${response.status}.")
+        }
+        parseBatchResponse(Json.parse(response.body))
+      }
+  }
+
+  /**
+   * Queries Overpass for roads within `SEARCH_RADIUS_M` of the point, stores the nearest one (with geometry, so later
+   * lookups nearby hit our DB), and returns its maxspeed tag.
+   */
+  private def queryAndStoreNearestRoad(lat: Double, lng: Double): Future[Option[String]] = {
+    val query = s"[out:json][timeout:10];way['highway'](around:$SEARCH_RADIUS_M,$lat,$lng);out geom;"
+    ws.url(OVERPASS_URL)
+      .withRequestTimeout(15.seconds)
+      .post(Map("data" -> Seq(query)))
+      .flatMap { response =>
+        if (response.status != 200) {
+          throw new RuntimeException(s"Overpass point query failed with status ${response.status}.")
+        }
+        pickNearestRoad(Json.parse(response.body), lat, lng) match {
+          case Some((wayId, tags, geom)) =>
+            val maxspeed = maxspeedFrom(tags)
+            db.run(osmWayTable.upsert(OsmWay(wayId, tags, maxspeed, Some(geom), "on_demand", OffsetDateTime.now)))
+              .map(_ => maxspeed)
+          case None => Future.successful(None)
+        }
+      }
+  }
+}
+
+/**
+ * Pure parsing/selection logic for Overpass API responses, kept free of I/O so it can be unit-tested directly.
+ */
+object OsmWayService {
+  val OVERPASS_URL = "https://overpass-api.de/api/interpreter"
+
+  /** How close (meters) a road must be to a queried point to count as "here"; also the DB point-lookup radius. */
+  val SEARCH_RADIUS_M: Double = 15.0
+
+  /** Refresh each way monthly; OSM speed limits change slowly. */
+  val STALENESS_PERIOD_DAYS: Long = 30
+
+  /** Way ids per Overpass batch request, and the pause between consecutive requests. */
+  val BATCH_CHUNK_SIZE: Int             = 300
+  val BATCH_CHUNK_DELAY: FiniteDuration = 2.seconds
+
+  /** Per-coordinate cache TTL for the on-demand point lookup (doubles as a negative cache for "no road here"). */
+  val POINT_CACHE_TTL: FiniteDuration = 10.minutes
+
+  /**
+   * OSM highway values that count as drivable roads for the speed-limit sign; footpaths/cycleways etc. are excluded.
+   */
+  val ROAD_HIGHWAY_TYPES: Set[String] = Set(
+    WayType.Motorway, WayType.Trunk, WayType.Primary, WayType.Secondary, WayType.Tertiary, WayType.Unclassified,
+    WayType.Residential, WayType.MotorwayLink, WayType.TrunkLink, WayType.PrimaryLink, WayType.SecondaryLink,
+    WayType.TertiaryLink, WayType.LivingStreet, WayType.Road
+  ).map(_.toString)
+
+  private val geometryFactory = new GeometryFactory(new PrecisionModel(), 4326)
+
+  /**
+   * Parses a batch `out tags;` Overpass response into a map from way id to its tag map.
+   */
+  def parseBatchResponse(json: JsValue): Map[Long, JsObject] = {
+    (json \ "elements")
+      .asOpt[Seq[JsObject]]
+      .getOrElse(Seq.empty)
+      .filter(el => (el \ "type").asOpt[String].contains("way"))
+      .flatMap { el => (el \ "id").asOpt[Long].map { id => id -> (el \ "tags").asOpt[JsObject].getOrElse(Json.obj()) } }
+      .toMap
+  }
+
+  /**
+   * Extracts the raw maxspeed tag from a way's tag map. The single extraction point for both write paths, so the
+   * maxspeed column can never drift from the stored tags.
+   */
+  def maxspeedFrom(tags: JsObject): Option[String] = (tags \ "maxspeed").asOpt[String]
+
+  /**
+   * Picks the road nearest to (lat, lng) from an `out geom;` Overpass response.
+   *
+   * Only ways whose `highway` tag is in `ROAD_HIGHWAY_TYPES` are considered, and ways need at least two geometry
+   * points. Distance is compared in degrees, which is fine for ranking candidates within a few dozen meters.
+   *
+   * @return The nearest road's (way id, tag map, geometry), or None if the response has no qualifying road.
+   */
+  def pickNearestRoad(json: JsValue, lat: Double, lng: Double): Option[(Long, JsObject, LineString)] = {
+    val point = geometryFactory.createPoint(new Coordinate(lng, lat))
+
+    val roads = (json \ "elements")
+      .asOpt[Seq[JsObject]]
+      .getOrElse(Seq.empty)
+      .filter { el =>
+        (el \ "type").asOpt[String].contains("way") &&
+        (el \ "tags" \ "highway").asOpt[String].exists(ROAD_HIGHWAY_TYPES.contains)
+      }
+      .flatMap { el =>
+        for {
+          id     <- (el \ "id").asOpt[Long]
+          coords <- (el \ "geometry").asOpt[Seq[JsObject]]
+          points = coords.flatMap { c =>
+            for {
+              pLat <- (c \ "lat").asOpt[Double]
+              pLng <- (c \ "lon").asOpt[Double]
+            } yield new Coordinate(
+              pLng,
+              pLat
+            )
+          }
+          if points.size >= 2
+        } yield {
+          val tags = (el \ "tags").asOpt[JsObject].getOrElse(Json.obj())
+          (id, tags, geometryFactory.createLineString(points.toArray))
+        }
+      }
+
+    if (roads.isEmpty) None else Some(roads.minBy(_._3.distance(point)))
+  }
+}

--- a/app/service/OsmWayService.scala
+++ b/app/service/OsmWayService.scala
@@ -57,7 +57,7 @@ class OsmWayService @Inject() (
               acc <- accFuture
               // Space out requests to the shared Overpass instance; no delay before the first chunk.
               _ <- if (chunkIdx == 0) Future.unit else after(BATCH_CHUNK_DELAY, actorSystem.scheduler)(Future.unit)
-              fetched <- fetchTagsForWays(chunk)
+              fetched <- fetchTagsForWaysWithRetry(chunk)
               rows = chunk.map { wayId =>
                 val tags = fetched.getOrElse(wayId, Json.obj())
                 (wayId, tags: JsValue, maxspeedFrom(tags))
@@ -99,6 +99,19 @@ class OsmWayService @Inject() (
    */
   def getMaxSpeedsForStreets(streetEdgeIds: Seq[Int]): Future[Map[Int, String]] = {
     db.run(osmWayTable.getMaxSpeeds(streetEdgeIds))
+  }
+
+  /**
+   * Fetches a chunk's tags, retrying transient failures — the shared Overpass instance sheds load with 429s/504s
+   * routinely, so one bad response shouldn't sink a whole run. Waits BATCH_RETRY_DELAY x attempt between tries to
+   * give a loaded server breathing room.
+   */
+  private def fetchTagsForWaysWithRetry(wayIds: Seq[Long], attempt: Int = 1): Future[Map[Long, JsObject]] = {
+    fetchTagsForWays(wayIds).recoverWith {
+      case e: Exception if attempt < BATCH_MAX_ATTEMPTS =>
+        logger.warn(s"Overpass batch attempt $attempt/$BATCH_MAX_ATTEMPTS failed (${e.getMessage}); retrying.")
+        after(BATCH_RETRY_DELAY * attempt.toLong, actorSystem.scheduler)(fetchTagsForWaysWithRetry(wayIds, attempt + 1))
+    }
   }
 
   /**
@@ -158,6 +171,10 @@ object OsmWayService {
   /** Way ids per Overpass batch request, and the pause between consecutive requests. */
   val BATCH_CHUNK_SIZE: Int             = 300
   val BATCH_CHUNK_DELAY: FiniteDuration = 2.seconds
+
+  /** Retry budget for one chunk's fetch, with a delay that grows linearly per attempt. */
+  val BATCH_MAX_ATTEMPTS: Int           = 3
+  val BATCH_RETRY_DELAY: FiniteDuration = 15.seconds
 
   /** Per-coordinate cache TTL for the on-demand point lookup (doubles as a negative cache for "no road here"). */
   val POINT_CACHE_TTL: FiniteDuration = 10.minutes

--- a/app/views/apiDocs/streets.scala.html
+++ b/app/views/apiDocs/streets.scala.html
@@ -20,7 +20,7 @@
 
   <div class="api-section" id="streets-intro-section">
     <h1 class="api-heading" id="streets-api">Streets API <a href="#streets-api" class="permalink">#</a></h1>
-    <p>The Streets API provides access to Project Sidewalk's street segment data, including auditing statistics, accessibility label counts, and geographic information. Project Sidewalk uses <a href="https://www.openstreetmap.org/">OpenStreetMap</a> for street data, filtered to particular <a href="https://wiki.openstreetmap.org/wiki/Key:highway">way types</a>. Users are routed through these streets to find and label sidewalk accessibility features and barriers.</p>
+    <p>The Streets API provides access to Project Sidewalk's street segment data, including auditing statistics, accessibility label counts, and geographic information. Project Sidewalk uses <a href="https://www.openstreetmap.org/">OpenStreetMap</a> for street data, filtered to particular <a href="https://wiki.openstreetmap.org/wiki/Key:highway">way types</a>. Users are routed through these streets to find and label sidewalk accessibility features and barriers. OSM-derived fields (street geometry, <code>way_type</code>, <code>max_speed</code>) are &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>, available under the <a href="https://opendatacommons.org/licenses/odbl/">Open Database License</a>.</p>
   </div>
 
   <div class="api-section" id="streets-preview-section">
@@ -192,6 +192,7 @@
         "region_id": 8,
         "region_name": "Teaneck Community Charter School",
         "way_type": "residential",
+        "max_speed": "25 mph",
         "status": "open",
         "user_ids": [
           "18b26a38-24ab-402d-a64e-158fc0bb8a8a",
@@ -219,6 +220,7 @@
         "region_id": 8,
         "region_name": "Teaneck Community Charter School",
         "way_type": "primary",
+        "max_speed": null,
         "status": "open",
         "user_ids": [
           "8af92eb8-fb84-4aa6-9539-abc95216dcd7"
@@ -283,6 +285,11 @@
             <td>OpenStreetMap classification of the road type (e.g., <code>residential</code>, <code>primary</code>, <code>secondary</code>, <code>service</code>, <code>footway</code>).</td>
           </tr>
           <tr>
+            <td><code>properties.max_speed</code></td>
+            <td><code>string</code></td>
+            <td>Speed limit of the street, as the raw OpenStreetMap <code>maxspeed</code> tag (e.g., <code>25 mph</code>, <code>30</code>; a bare number means km/h per OSM convention). <code>null</code> when the way is untagged or the value is not yet cached.</td>
+          </tr>
+          <tr>
             <td><code>properties.status</code></td>
             <td><code>string</code></td>
             <td>Availability of the street in Project Sidewalk. One of <code>open</code> (usable for auditing), <code>no_imagery</code> (no street-view imagery available), <code>closed</code> (in a region not yet opened to the public), or <code>disabled</code> (manually hidden, e.g. an OSM miscategorization). A street is auditable only when its status is <code>open</code>.</td>
@@ -327,9 +334,9 @@
 
     <h4 id="response-csv">CSV Format <a href="#response-csv" class="permalink">#</a></h4>
     <p>If <code>filetype=csv</code> is specified, the response body will be CSV data. The first row contains the headers, corresponding to the fields in the GeoJSON properties object, plus geometry representation. CRS is WGS84 (EPSG:4326).</p>
-    <pre tabindex="0"><code class="language-csv">street_edge_id,osm_way_id,region_id,region_name,way_type,status,user_ids,label_count,audit_count,user_count,first_label_date,last_label_date,start_point,end_point
-951,11584845,8,Teaneck Community Charter School,residential,open,"[18b26a38-24ab-402d-a64e-158fc0bb8a8a,53ad4d79-9a7b-4d3c-a753-63bbfca34c9b]",23,5,2,2023-06-20T14:32:45Z,2023-08-15T10:22:18Z,"-74.0243606567383,40.8839912414551","-74.0245123456789,40.8836789012345"
-952,11566031,8,Teaneck Community Charter School,primary,open,[8af92eb8-fb84-4aa6-9539-abc95216dcd7],8,1,1,2023-06-22T11:12:24Z,2023-06-22T11:45:33Z,"-74.0245835449219,40.8835416503906","-74.0246123456789,40.8833789012345"
+    <pre tabindex="0"><code class="language-csv">street_edge_id,osm_way_id,region_id,region_name,way_type,max_speed,status,user_ids,label_count,audit_count,user_count,first_label_date,last_label_date,start_point,end_point
+951,11584845,8,Teaneck Community Charter School,residential,25 mph,open,"[18b26a38-24ab-402d-a64e-158fc0bb8a8a,53ad4d79-9a7b-4d3c-a753-63bbfca34c9b]",23,5,2,2023-06-20T14:32:45Z,2023-08-15T10:22:18Z,"-74.0243606567383,40.8839912414551","-74.0245123456789,40.8836789012345"
+952,11566031,8,Teaneck Community Charter School,primary,,open,[8af92eb8-fb84-4aa6-9539-abc95216dcd7],8,1,1,2023-06-22T11:12:24Z,2023-06-22T11:45:33Z,"-74.0245835449219,40.8835416503906","-74.0246123456789,40.8833789012345"
 ...</code></pre>
 
     <p>Note: The complete LineString geometry is simplified to start and end points in the CSV format due to the tabular nature of CSV. For full geometry data, use the GeoJSON format.</p>

--- a/app/views/apps/explore.scala.html
+++ b/app/views/apps/explore.scala.html
@@ -920,6 +920,7 @@
     }
 
     mainParam.language = "@messages.lang.code";
+    mainParam.countryId = "@currentCity.countryId";
     mainParam.mapboxApiKey = "@commonData.mapboxApiKey";
     mainParam.makeCrops = @data.makeCrops;
     const imagerySrc = "@commonData.imagerySource.toString";

--- a/app/views/apps/explore.scala.html
+++ b/app/views/apps/explore.scala.html
@@ -437,7 +437,7 @@
           </div>
         </div>
         <div id="street-view-holder">
-          <div id="speed-limit-sign" class="speed-limit-sign" data-design-style="us-canada" data-i18n-tooltip="common:speed-limit-tooltip">
+          <div id="speed-limit-sign" class="speed-limit-sign" data-design-style="us-canada" tabindex="0" role="img" data-i18n-tooltip="common:speed-limit-tooltip">
             <div class="speed-limit-holder">
               <span class="speed-limit-text"><span id="speed-limit">N/A</span><span id="speed-limit-sub">N/A</span></span>
             </div>

--- a/app/views/apps/explore.scala.html
+++ b/app/views/apps/explore.scala.html
@@ -437,7 +437,7 @@
           </div>
         </div>
         <div id="street-view-holder">
-          <div id="speed-limit-sign" class="speed-limit-sign" data-design-style="us-canada">
+          <div id="speed-limit-sign" class="speed-limit-sign" data-design-style="us-canada" data-i18n-tooltip="common:speed-limit-tooltip">
             <div class="speed-limit-holder">
               <span class="speed-limit-text"><span id="speed-limit">N/A</span><span id="speed-limit-sub">N/A</span></span>
             </div>

--- a/app/views/apps/validate.scala.html
+++ b/app/views/apps/validate.scala.html
@@ -98,7 +98,7 @@
           <div id="label-description-box"></div>
         </div>
         <div id="pano-border-frame"></div>
-        <div id="speed-limit-sign" class="speed-limit-sign" data-design-style="us-canada" data-i18n-tooltip="common:speed-limit-tooltip">
+        <div id="speed-limit-sign" class="speed-limit-sign" data-design-style="us-canada" tabindex="0" role="img" data-i18n-tooltip="common:speed-limit-tooltip">
           <div class="speed-limit-holder">
             <span class="speed-limit-text"><span id="speed-limit">N/A</span><span id="speed-limit-sub">N/A</span></span>
           </div>

--- a/app/views/apps/validate.scala.html
+++ b/app/views/apps/validate.scala.html
@@ -98,7 +98,7 @@
           <div id="label-description-box"></div>
         </div>
         <div id="pano-border-frame"></div>
-        <div id="speed-limit-sign" class="speed-limit-sign" data-design-style="us-canada">
+        <div id="speed-limit-sign" class="speed-limit-sign" data-design-style="us-canada" data-i18n-tooltip="common:speed-limit-tooltip">
           <div class="speed-limit-holder">
             <span class="speed-limit-text"><span id="speed-limit">N/A</span><span id="speed-limit-sub">N/A</span></span>
           </div>

--- a/app/views/apps/validate.scala.html
+++ b/app/views/apps/validate.scala.html
@@ -251,6 +251,7 @@
       param.hasNextMission = @validatePageData.hasNextMission;
       param.completedValidations = @validatePageData.completedValidations;
       param.language = "@messages.lang.code";
+      param.countryId = "@currentCity.countryId";
       const imagerySrc = "@commonData.imagerySource.toString";
       param.viewerType = imagerySrc === 'mapillary' ? MapillaryViewer : imagerySrc === 'infra3d' ? Infra3dViewer : GsvViewer;
       param.viewerAccessToken = "@commonData.imageryAccessToken";

--- a/app/views/common/main.scala.html
+++ b/app/views/common/main.scala.html
@@ -69,6 +69,7 @@
     <script src='@assets.path("js/common/utilities.js")'></script>
     <script src='@assets.path("js/common/utilitiesMath.js")'></script>
     <script src='@assets.path("js/common/i18nDom.js")'></script>
+    <script src='@assets.path("js/common/psTooltip.js")'></script>
     <script src='@assets.path("/js/common/AppManager.js")'></script>
   </head>
   <body>

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -188,6 +188,7 @@ rate-limit {
   forgot {        max-attempts = 5,   window-seconds = 3600 } # per email+IP
   anon-signup {   max-attempts = 30,  window-seconds = 3600 } # per IP
   ai-ingest {     max-attempts = 120, window-seconds = 60 }   # per IP (bulk caller; caps requests, not labels)
+  speed-limit {   max-attempts = 60,  window-seconds = 60 }   # per IP (cache misses trigger an Overpass query)
   # Enabled by default (independent of the global flag above): stories accept anonymous uploads that each cost a photo
   # transcode, and the per-user DB cap resets per anonymous session, so an IP bound is the practical spam/abuse floor.
   # Keys on the client IP from X-Forwarded-For (CustomBaseController.ipAddress); set enabled=false to revert.

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -139,10 +139,10 @@ play.filters.csp {
     # Fonts: Font Awesome web fonts (cdnjs) and Google Fonts files (fonts.gstatic.com); data: covers inlined fonts.
     font-src = "'self' data: https://cdnjs.cloudflare.com https://fonts.gstatic.com"
 
-    # XHR/fetch/beacons: GA4 collect, Google Maps API, Mapbox tiles/style/telemetry, and the OpenStreetMap Overpass API
-    # (Explore reverse-geocodes the current pano's country/nearest road). 'self' must be listed explicitly -- once
-    # connect-src is set it no longer falls back to default-src (this is what logged the GA /g/collect report).
-    connect-src = "'self' https://*.google-analytics.com https://*.analytics.google.com https://www.googletagmanager.com https://maps.googleapis.com https://*.gstatic.com https://api.mapbox.com https://events.mapbox.com https://overpass-api.de"
+    # XHR/fetch/beacons: GA4 collect, Google Maps API, and Mapbox tiles/style/telemetry. 'self' must be listed
+    # explicitly -- a set connect-src replaces the default-src fallback entirely (this is what logged the GA
+    # /g/collect report).
+    connect-src = "'self' https://*.google-analytics.com https://*.analytics.google.com https://www.googletagmanager.com https://maps.googleapis.com https://*.gstatic.com https://api.mapbox.com https://events.mapbox.com"
 
     # Web Workers: Mapbox GL spins up its worker from a blob: URL (worker-src otherwise falls back to script-src).
     worker-src = "'self' blob:"

--- a/conf/evolutions/default/345.sql
+++ b/conf/evolutions/default/345.sql
@@ -1,0 +1,22 @@
+# --- !Ups
+-- Cached OSM way data (#4654). The speed-limit sign is served from here instead of live client-side Overpass API
+-- queries (which flooded the shared community instance with a request per pano move). Rows keyed 'batch' are written by
+-- the nightly refresh of every way in osm_way_street_edge, while 'on_demand' rows are ways discovered by the /speedLimit
+-- point-lookup fallback and carry geometry so later lookups near them hit our DB instead of Overpass. tags holds the
+-- way's full OSM tag map (Overpass returns it either way, and future features can mine name/sidewalk/surface/etc.
+-- without re-fetching). maxspeed is extracted from tags at write time by OsmWayService, the single write path. A NULL
+-- maxspeed means the way was fetched but carries no maxspeed tag. geom is NULL on batch rows because street_edge
+-- geometry already locates them. No FK to osm_way_street_edge: on_demand ways are generally outside our street network.
+CREATE TABLE osm_way (
+    osm_way_id BIGINT PRIMARY KEY,
+    tags JSONB NOT NULL DEFAULT '{}'::jsonb,
+    maxspeed TEXT,
+    geom geometry(LineString, 4326),
+    source TEXT NOT NULL CHECK (source IN ('batch', 'on_demand')),
+    updated_at TIMESTAMPTZ NOT NULL
+);
+ALTER TABLE osm_way OWNER TO sidewalk;
+CREATE INDEX osm_way_geom_idx ON osm_way USING GIST (geom);
+
+# --- !Downs
+DROP TABLE osm_way;

--- a/conf/routes
+++ b/conf/routes
@@ -104,6 +104,7 @@ PUT     /adminapi/setTaskFlag                           controllers.AdminControl
 PUT     /adminapi/updateTeamStatus/:teamId              controllers.AdminController.updateTeamStatus(teamId: Int)
 PUT     /adminapi/updateTeamVisibility/:teamId          controllers.AdminController.updateTeamVisibility(teamId: Int)
 GET     /adminapi/checkImagery                          controllers.AdminController.checkImagery()
+GET     /adminapi/refreshOsmWayData                     controllers.AdminController.refreshOsmWayData()
 GET     /adminapi/threadPoolStats                       controllers.AdminController.getThreadPoolStats
 
 GET     /labels/all                                     controllers.AdminController.getAllLabelsForLabelMap(regions: Option[String] ?= None, routes: Option[String] ?= None, aiValidationOptions: Option[String] ?= None)
@@ -129,6 +130,7 @@ GET     /adminValidate                                  controllers.ValidateCont
 # Task API
 GET     /tasks                                          controllers.ExploreController.getTasksInARegion(regionId: Int)
 GET     /routeTasks                                     controllers.ExploreController.getTasksInARoute(userRouteId: Int)
+GET     /speedLimit                                     controllers.ExploreController.getSpeedLimit(lat: Double, lng: Double)
 POST    /task                                           controllers.ExploreController.post
 POST    /validationTask                                 controllers.ValidateController.post
 POST    /galleryTask                                    controllers.GalleryController.post

--- a/public/css/explore/svl-canvas.css
+++ b/public/css/explore/svl-canvas.css
@@ -171,7 +171,10 @@
   border-radius: calc(5px * var(--ui-scale));
   position: absolute;
   z-index: 2;
-  pointer-events: none;
+
+  /* Hover must reach the sign for its title tooltip; `auto` also guards against a no-pointer-events ancestor. */
+  pointer-events: auto;
+  cursor: help;
   transform: scale(0.657);
   transform-origin: top right;
   background: rgb(from var(--color-neutral-white) r g b / 75%);

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1775,3 +1775,32 @@ kbd {
   text-align: center;
   white-space: nowrap;
 }
+
+/* ---------- Shared tooltip (psTooltip.js) ---------- */
+
+/* The single fixed-position card that psTooltip.js shows for the active [data-ps-tooltip] trigger. Parked off-screen
+   until positioned; pointer-events stays off so the card never steals the hover that opened it. Sits above the navbar
+   and Bootstrap modals (~1050) since a tooltip is always the most transient thing on screen. */
+.ps-tooltip {
+  position: fixed;
+  left: -9999px;
+  top: -9999px;
+  max-width: calc(280px * var(--ui-scale, 1));
+  padding: calc(8px * var(--ui-scale, 1)) calc(12px * var(--ui-scale, 1));
+  background: var(--color-neutral-white);
+  border: 1px solid var(--color-neutral-600);
+  border-radius: calc(8px * var(--ui-scale, 1));
+  box-shadow: 0 2px 8px rgb(0 0 0 / 12%);
+  font: var(--text-small-regular);
+  color: var(--color-neutral-black);
+  pointer-events: none;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.12s ease;
+  z-index: calc(var(--navbar-z-index) + 70);
+}
+
+.ps-tooltip--visible {
+  opacity: 1;
+  visibility: visible;
+}

--- a/public/css/validate/svv-panorama.css
+++ b/public/css/validate/svv-panorama.css
@@ -66,7 +66,10 @@
   border-radius: calc(5px * var(--ui-scale));
   position: absolute;
   z-index: 3;
-  pointer-events: none;
+
+  /* Hover must reach the sign for its title tooltip; `auto` also guards against a no-pointer-events ancestor. */
+  pointer-events: auto;
+  cursor: help;
   transform: scale(0.657);
   transform-origin: top right;
   background: rgb(from var(--color-neutral-white) r g b / 75%);

--- a/public/js/common/AppManager.js
+++ b/public/js/common/AppManager.js
@@ -113,7 +113,7 @@ class AppManager {
     // Set up CSRF token for fetch requests by overwriting the fetch function. The token is only attached to
     // same-origin requests: Play's CSRF filter only checks requests to our own server, and a token signed by this
     // server is meaningless to anyone else. Attaching it to cross-origin requests (Mapbox, Mapillary, Infra3d,
-    // Overpass, sibling city servers, ...) does nothing useful and forces an unnecessary CORS preflight that some
+    // sibling city servers, ...) does nothing useful and forces an unnecessary CORS preflight that some
     // hosts reject, so we skip them rather than maintaining an allowlist of hosts to exclude (#4232).
     const originalFetch = window.fetch;
     window.fetch = function (url, options = {}) {

--- a/public/js/common/SpeedLimit.js
+++ b/public/js/common/SpeedLimit.js
@@ -32,6 +32,9 @@ class SpeedLimit {
   // Monotonic token so a slow fallback response can't overwrite the sign after the user has already moved on.
   #latestUpdateId = 0;
 
+  // Pending re-check while the pano position / street list are still loading at page startup.
+  #startupRetryTimer = null;
+
   /**
    * @param {PanoViewer} panoViewer PanoramaViewer object.
    * @param {function} coords Function that returns current longitude and latitude coordinates.
@@ -70,6 +73,10 @@ class SpeedLimit {
 
     // Listen for pano changes.
     panoViewer.addListener('pano_changed', this.#panoChangeListener);
+
+    // The initial pano usually finishes loading before this listener attaches, so its pano_changed is missed; run one
+    // update for the current position so the sign shows on the first pano without requiring movement.
+    this.#panoChangeListener();
   }
 
   /**
@@ -116,12 +123,24 @@ class SpeedLimit {
    * @returns {Promise<string|null>} Raw OSM maxspeed value (e.g. '25 mph', '30'), or null if unknown.
    */
   async #maxSpeedNearCurrentPosition() {
-    const { lat, lng } = this.#coords();
-    const point = turf.point([lng, lat]);
+    const position = this.#coords();
+    const tasks = this.#taskContainer.getTasks() ?? [];
+    if (!Number.isFinite(position?.lat) || tasks.length === 0) {
+      // At page startup the pano position and street list can lag this component. Re-check shortly instead of
+      // treating the spot as off-network (which would pointlessly ask the server about an on-network street).
+      if (this.#startupRetryTimer === null) {
+        this.#startupRetryTimer = setTimeout(() => {
+          this.#startupRetryTimer = null;
+          this.#panoChangeListener();
+        }, 1000);
+      }
+      return null;
+    }
+    const point = turf.point([position.lng, position.lat]);
 
     let nearestTask = null;
     let minDistance = Infinity;
-    for (const task of this.#taskContainer.getTasks() ?? []) {
+    for (const task of tasks) {
       const distance = turf.pointToLineDistance(point, task.getGeoJSON(), { units: 'meters' });
       if (distance < minDistance) {
         minDistance = distance;

--- a/public/js/common/SpeedLimit.js
+++ b/public/js/common/SpeedLimit.js
@@ -18,6 +18,9 @@ class SpeedLimit {
   // counts as "on a road here".
   static #NEARBY_STREET_THRESHOLD_M = 15;
 
+  // Cap on remembered fallback lookups; a long session off the network shouldn't grow the cache without bound.
+  static #POINT_LOOKUP_CACHE_MAX = 100;
+
   #coords;
   #isOnboarding;
   #panoViewer;
@@ -151,7 +154,7 @@ class SpeedLimit {
     if (nearestTask !== null && minDistance <= SpeedLimit.#NEARBY_STREET_THRESHOLD_M) {
       return nearestTask.getProperty('maxSpeed');
     }
-    return await this.#fetchSpeedLimitAtPoint(lat, lng);
+    return await this.#fetchSpeedLimitAtPoint(position.lat, position.lng);
   }
 
   /**
@@ -178,6 +181,10 @@ class SpeedLimit {
         return null;
       }
     })();
+    // Evict the oldest entry once full (Map preserves insertion order, so the first key is the oldest).
+    if (this.#pointLookupCache.size >= SpeedLimit.#POINT_LOOKUP_CACHE_MAX) {
+      this.#pointLookupCache.delete(this.#pointLookupCache.keys().next().value);
+    }
     this.#pointLookupCache.set(panoId, promise);
     return await promise;
   }

--- a/public/js/common/SpeedLimit.js
+++ b/public/js/common/SpeedLimit.js
@@ -1,61 +1,56 @@
 /**
  * An indicator that displays the speed limit of the current position's nearest road.
  *
+ * Speed limits come from our own backend (precomputed per street from OSM, #4654): in Explore from the loaded tasks'
+ * `maxSpeed` property, in Validate from the current label's `maxSpeed` audit property. Only when the user wanders off
+ * our street network does it ask our server's `/speedLimit` point-lookup fallback — this code never calls a
+ * third-party API.
+ *
  * Exposes `container` (the sign element), `speedLimit` (`{ number, sub }` where `sub` is the units, e.g. 'mph'),
  * `speedLimitVisible` (boolean), and `updateSpeedLimit()`.
  */
 class SpeedLimit {
-  static #ROAD_HIGHWAY_TYPES = [
-    'motorway',
-    'trunk',
-    'primary',
-    'secondary',
-    'tertiary',
-    'unclassified',
-    'residential',
-    'motorway_link',
-    'trunk_link',
-    'primary_link',
-    'secondary_link',
-    'tertiary_link',
-    'living_street',
-    'road',
-  ];
-
   // Labels in which speed limit is necessary context for validation. Speed limit will not display for other labels.
   static #SPEED_LIMIT_RELEVANT_LABELS = ['NoCurbRamp'];
 
+  // How close (meters) a loaded street must be to the current position to supply the sign's value. Chosen to match
+  // the server's /speedLimit search radius (OsmWayService.SEARCH_RADIUS_M) so the client and fallback agree on what
+  // counts as "on a road here".
+  static #NEARBY_STREET_THRESHOLD_M = 15;
+
   #coords;
   #isOnboarding;
+  #panoViewer;
+  #taskContainer;
   #labelContainer;
   #labelType;
+  #fallbackUnits;
 
-  #cache = {};
+  // Fallback lookups keyed by pano id, holding the in-flight promise so concurrent pano events share one request.
+  #pointLookupCache = new Map();
 
-  // Country info (ISO 3166-1 code) for the current session. Country doesn't change while a user is auditing, so we
-  // fetch it once and reuse it to cut Overpass request volume roughly in half. Null until first successful fetch; on
-  // failure we reset to null so the next pano change can retry.
-  #countryCodePromise = null;
+  // Monotonic token so a slow fallback response can't overwrite the sign after the user has already moved on.
+  #latestUpdateId = 0;
 
   /**
    * @param {PanoViewer} panoViewer PanoramaViewer object.
    * @param {function} coords Function that returns current longitude and latitude coordinates.
    * @param {function} isOnboarding Function that returns a boolean on whether the current mission is the tutorial task.
-   * @param {LabelContainer} [labelContainer] Label container for pre-fetching validation labels. Can be null.
-   * @param {string} [labelType] Label type being validated; null/undefined shows the speed limit by default.
+   * @param {string} countryId The current city's country id (e.g. 'usa'), for sign design and fallback units.
+   * @param {object} [sources] Where to read speed limits from; exactly one should be provided.
+   * @param {TaskContainer} [sources.taskContainer] Explore's task container; the sign tracks the nearest loaded street.
+   * @param {LabelContainer} [sources.labelContainer] Validate's label container; the sign shows the current label's
+   *                                                  street.
+   * @param {string} [sources.labelType] Label type being validated; null/undefined shows the speed limit by default.
    */
-  constructor(panoViewer, coords, isOnboarding, labelContainer, labelType) {
+  constructor(panoViewer, coords, isOnboarding, countryId, { taskContainer = null, labelContainer = null,
+    labelType = null } = {}) {
     this.#coords = coords;
     this.#isOnboarding = isOnboarding;
+    this.#panoViewer = panoViewer;
+    this.#taskContainer = taskContainer;
     this.#labelContainer = labelContainer;
     this.#labelType = labelType;
-
-    // If labelType is null/undefined (not provided), the speed limit will be displayed by default.
-    const speedLimitRelevant = !labelType || SpeedLimit.#SPEED_LIMIT_RELEVANT_LABELS.includes(labelType);
-    if (typeof (labelContainer) !== 'undefined' && labelContainer !== null && speedLimitRelevant) {
-      this.#prefetchLabels(); // Note that this happens async.
-      labelContainer.resetLabelListUpdateCallback(this.#prefetchLabels);
-    }
 
     this.container = document.getElementById('speed-limit-sign');
     this.speedLimit = {
@@ -63,6 +58,14 @@ class SpeedLimit {
       sub: '',
     };
     this.speedLimitVisible = false;
+
+    // US/Canada use the MUTCD-style rectangular sign; everywhere else gets the Vienna-convention circle. Fallback
+    // units (used when the OSM maxspeed value carries no unit suffix) are mph only in the US.
+    this.container.setAttribute(
+      'data-design-style', ['usa', 'canada'].includes(countryId) ? 'us-canada' : 'non-us-canada',
+    );
+    this.#fallbackUnits = countryId === 'usa' ? 'mph' : 'km/h';
+
     this.updateSpeedLimit();
 
     // Listen for pano changes.
@@ -79,153 +82,12 @@ class SpeedLimit {
   }
 
   /**
-   * Finds the closest road given overpass API's response of nearby roads and the current position.
-   *
-   * @param {object} data The overpass API's response of nearby roads.
-   * @param {number} lat The latitude of the current position.
-   * @param {number} lon The longitude of the current position.
-   */
-  #findClosestRoad(data, lat, lon) {
-    // Filter to only be roads, and not footpaths/walkways.
-    const roads = data.elements.filter((el) =>
-      el.type === 'way' && el.tags && el.tags.highway && SpeedLimit.#ROAD_HIGHWAY_TYPES.includes(el.tags.highway),
-    );
-
-    const point = turf.point([lat, lon]);
-    let closestRoad = null;
-    let minDistance = Infinity;
-
-    // Go through all the roads and find the closest one.
-    for (const road of roads) {
-      const lineString = turf.lineString(road.geometry.map((p) => [p.lon, p.lat]));
-      const distance = turf.pointToLineDistance(point, lineString);
-
-      if (distance < minDistance) {
-        minDistance = distance;
-        closestRoad = road;
-      }
-    }
-
-    return closestRoad;
-  }
-
-  /**
-   * Function called specifically on validation page to prefetch the upcoming speed limits.
-   */
-  #prefetchLabels = async () => {
-    // Clear the cache.
-    this.#cache = {};
-
-    // Get the labels from the pano container and prefetch them.
-    const labelsToPrefetch = this.#labelContainer.getLabels();
-    for (const label of labelsToPrefetch) {
-      const cameraLat = label.getAuditProperty('cameraLat');
-      const cameraLng = label.getAuditProperty('cameraLng');
-      if (cameraLat && cameraLng) {
-        await this.#queryClosestRoadForCoords(cameraLat, cameraLng, true, label);
-      }
-    }
-  };
-
-  /**
-   * Fetches the closest nearby road for a given set of coordinates from the Overpass API.
-   *
-   * @param {number} lat The latitude of the current position.
-   * @param {number} lng The longitude of the current position.
-   * @param {boolean} shouldCache If true, this will cache the coordinates with the road response.
-   * @param {Label} label The label that is being validated. Can be null.
-   * @returns {Promise<{closestRoad: object|null}>} Object with the calculated closest road, or null on failure.
-   */
-  async #queryClosestRoadForCoords(lat, lng, shouldCache, label) {
-    const cacheKey = label === null
-      ? (this.#labelContainer === null ? '' : this.#labelContainer.getCurrentLabel().getAuditProperty('panoId'))
-      : label.getAuditProperty('panoId');
-    if (cacheKey in this.#cache) {
-      return await this.#cache[cacheKey];
-    }
-
-    // Get nearby roads and their respective information from the overpass API.
-    const overpassQuery = `
-      [out:json];
-      (
-      way['highway'](around:10.0, ${lat}, ${lng});
-      );
-      out geom;
-      `;
-    const promise = (async () => {
-      try {
-        const overpassResp = await fetch(
-          `https://overpass-api.de/api/interpreter?data=${encodeURIComponent(overpassQuery)}`,
-        );
-        // A 429 (or other non-2xx) returns XML rather than JSON, so guard before parsing.
-        if (!overpassResp.ok) {
-          return { closestRoad: null };
-        }
-        const overpassRespJson = await overpassResp.json();
-        return { closestRoad: this.#findClosestRoad(overpassRespJson, lat, lng) };
-      } catch {
-        return { closestRoad: null };
-      }
-    })();
-
-    if (shouldCache) {
-      this.#cache[cacheKey] = promise;
-    }
-
-    return await promise;
-  }
-
-  /**
-   * Fetches the ISO 3166-1 country code for the given coordinates. The result is cached for the session on first
-   * success since the country doesn't change while a user audits. On failure the cache is cleared.
-   *
-   * @param {number} lat The latitude of the current position.
-   * @param {number} lng The longitude of the current position.
-   * @returns {Promise<string|null>} ISO 3166-1 country code, or null if the lookup failed.
-   */
-  async #queryCountryCode(lat, lng) {
-    if (this.#countryCodePromise !== null) {
-      return await this.#countryCodePromise;
-    }
-
-    const overpassQuery = `
-      [out:json];
-      is_in(${lat}, ${lng})->.a;
-      rel(pivot.a)['ISO3166-1'];
-      convert country
-        ::id = id(),
-        code = t['ISO3166-1'];
-      out tags;
-      `;
-    this.#countryCodePromise = (async () => {
-      try {
-        const resp = await fetch(
-          `https://overpass-api.de/api/interpreter?data=${encodeURIComponent(overpassQuery)}`,
-        );
-        if (!resp.ok) {
-          this.#countryCodePromise = null;
-          return null;
-        }
-        const json = await resp.json();
-        const countryElements = json.elements.filter((el) => el.type === 'country');
-        return countryElements.length > 0 ? countryElements[0].tags.code : null;
-      } catch {
-        this.#countryCodePromise = null;
-        return null;
-      }
-    })();
-
-    return await this.#countryCodePromise;
-  }
-
-  /**
-   * Function to be called on a position change/movement in the google street view.
+   * Function to be called on a position change/movement in the pano viewer.
    */
   #panoChangeListener = async () => {
     // If user is in the onboarding/tutorial mission, we can skip getting the speed limit and hide the sign.
     if (this.#isOnboarding()) {
-      this.speedLimitVisible = false;
-      this.updateSpeedLimit();
+      this.#render(null, ++this.#latestUpdateId);
       return;
     }
 
@@ -234,49 +96,91 @@ class SpeedLimit {
 
     // If user is validating a label that doesn't require speed limit context, hide the speed limit.
     if (!speedLimitRelevant) {
-      this.speedLimitVisible = false;
-      this.updateSpeedLimit();
+      this.#render(null, ++this.#latestUpdateId);
       return;
     }
 
-    // Get the current position.
+    const updateId = ++this.#latestUpdateId;
+    if (this.#labelContainer !== null) {
+      // Validate: the label being judged sits on a known street, so its metadata already carries the speed limit.
+      this.#render(this.#labelContainer.getCurrentLabel()?.getAuditProperty('maxSpeed') ?? null, updateId);
+    } else {
+      this.#render(await this.#maxSpeedNearCurrentPosition(), updateId);
+    }
+  };
+
+  /**
+   * Finds the speed limit at the current position: the nearest loaded street's if one is close enough, otherwise via
+   * the server's point-lookup fallback (the user has wandered off our street network).
+   *
+   * @returns {Promise<string|null>} Raw OSM maxspeed value (e.g. '25 mph', '30'), or null if unknown.
+   */
+  async #maxSpeedNearCurrentPosition() {
     const { lat, lng } = this.#coords();
-    // Test coords here if someone finds them useful.
-    // const lat = 47.6271486;
-    // const lng = -122.3423263;
+    const point = turf.point([lng, lat]);
 
-    // Fetch roads (per-pano) and country code (session-cached) in parallel.
-    const [queryResp, countryCode] = await Promise.all([
-      this.#queryClosestRoadForCoords(lat, lng, false, null),
-      this.#queryCountryCode(lat, lng),
-    ]);
-    const closestRoad = queryResp.closestRoad;
-
-    // Fallback units should be kilometers per hour by default.
-    let fallbackUnits = 'km/h';
-
-    // Use the country code to set the speed limit indicator design and fallback units.
-    if (countryCode) {
-      // Set proper design.
-      if (countryCode === 'US' || countryCode === 'CA') {
-        this.container.setAttribute('data-design-style', 'us-canada');
-      } else {
-        this.container.setAttribute('data-design-style', 'non-us-canada');
-      }
-
-      // Set mph for fallback units if US or UK.
-      if (countryCode === 'US' || countryCode === 'UK') {
-        fallbackUnits = 'mph';
+    let nearestTask = null;
+    let minDistance = Infinity;
+    for (const task of this.#taskContainer.getTasks() ?? []) {
+      const distance = turf.pointToLineDistance(point, task.getGeoJSON(), { units: 'meters' });
+      if (distance < minDistance) {
+        minDistance = distance;
+        nearestTask = task;
       }
     }
 
-    // Extract speed limit info from closest road.
-    if (closestRoad !== null && closestRoad.tags.maxspeed) {
-      const splitMaxspeed = closestRoad.tags.maxspeed.split(' ');
+    if (nearestTask !== null && minDistance <= SpeedLimit.#NEARBY_STREET_THRESHOLD_M) {
+      return nearestTask.getProperty('maxSpeed');
+    }
+    return await this.#fetchSpeedLimitAtPoint(lat, lng);
+  }
+
+  /**
+   * Asks our server for the speed limit at a point, memoized per pano id.
+   *
+   * @param {number} lat The latitude of the current position.
+   * @param {number} lng The longitude of the current position.
+   * @returns {Promise<string|null>} Raw OSM maxspeed value, or null if unknown or on failure.
+   */
+  async #fetchSpeedLimitAtPoint(lat, lng) {
+    const panoId = this.#panoViewer.getPanoId();
+    if (this.#pointLookupCache.has(panoId)) {
+      return await this.#pointLookupCache.get(panoId);
+    }
+
+    const promise = (async () => {
+      try {
+        const resp = await fetch(`/speedLimit?lat=${lat}&lng=${lng}`);
+        if (!resp.ok) {
+          return null;
+        }
+        return (await resp.json()).max_speed ?? null;
+      } catch {
+        return null;
+      }
+    })();
+    this.#pointLookupCache.set(panoId, promise);
+    return await promise;
+  }
+
+  /**
+   * Shows the sign for the given maxspeed value, or hides it when there is none.
+   *
+   * @param {string|null} maxspeed Raw OSM maxspeed value (e.g. '25 mph', '30'), or null to hide the sign.
+   * @param {number} updateId The token from the update that produced this value; stale updates are dropped.
+   */
+  #render(maxspeed, updateId) {
+    if (updateId !== this.#latestUpdateId) {
+      return;
+    }
+
+    if (maxspeed) {
+      // A unit suffix in the value itself (e.g. '25 mph') wins over the country-based fallback units.
+      const splitMaxspeed = maxspeed.split(' ');
       const number = splitMaxspeed.shift();
       let sub = splitMaxspeed.join(' ');
       if (sub.trim().length === 0) {
-        sub = fallbackUnits;
+        sub = this.#fallbackUnits;
       }
       this.speedLimit = {
         number,
@@ -287,5 +191,5 @@ class SpeedLimit {
       this.speedLimitVisible = false;
     }
     this.updateSpeedLimit();
-  };
+  }
 }

--- a/public/js/common/SpeedLimit.js
+++ b/public/js/common/SpeedLimit.js
@@ -89,6 +89,16 @@ class SpeedLimit {
     this.container.querySelector('#speed-limit').innerText = this.speedLimit.number;
     this.container.querySelector('#speed-limit-sub').innerText = this.speedLimit.sub;
     this.container.style.display = this.speedLimitVisible ? 'flex' : 'none';
+
+    // The sign is marked role="img", so its number/units spans don't carry their own meaning to a screen reader.
+    // Name the graphic with the value folded in. Only worth doing while visible: display:none keeps the sign out of
+    // the accessibility tree, and the first call runs before i18next has initialized.
+    if (this.speedLimitVisible && typeof i18next !== 'undefined' && i18next.isInitialized) {
+      this.container.setAttribute('aria-label', i18next.t('common:speed-limit-aria-label', {
+        speed: this.speedLimit.number,
+        units: this.speedLimit.sub,
+      }));
+    }
   }
 
   /**

--- a/public/js/common/i18nDom.js
+++ b/public/js/common/i18nDom.js
@@ -6,6 +6,7 @@
  *   - data-i18n-placeholder="ns:key" -> sets the `placeholder` attribute
  *   - data-i18n-aria-label="ns:key"  -> sets the `aria-label` attribute
  *   - data-i18n-title="ns:key"       -> sets the `title` attribute (native tooltip)
+ *   - data-i18n-tooltip="ns:key"     -> sets the `data-ps-tooltip` attribute (styled tooltip via psTooltip.js)
  *   - data-i18n-alt="ns:key"         -> sets the `alt` attribute
  *
  * Convention: include English fallback text in the markup for elements that are visible during initial render (graceful
@@ -24,7 +25,8 @@
 window.localizeSubtree = function (root) {
   if (!root || typeof i18next === 'undefined' || !i18next.isInitialized) return;
 
-  const selector = '[data-i18n], [data-i18n-placeholder], [data-i18n-aria-label], [data-i18n-title], [data-i18n-alt]';
+  const selector = '[data-i18n], [data-i18n-placeholder], [data-i18n-aria-label], [data-i18n-title], '
+    + '[data-i18n-tooltip], [data-i18n-alt]';
 
   // querySelectorAll doesn't include `root` itself; check it explicitly so callers can pass an element that itself
   // carries a data-i18n attribute.
@@ -54,6 +56,9 @@ window.localizeElement = function (el) {
 
   const titleKey = el.getAttribute('data-i18n-title');
   if (titleKey) el.setAttribute('title', i18next.t(titleKey));
+
+  const tooltipKey = el.getAttribute('data-i18n-tooltip');
+  if (tooltipKey) el.setAttribute('data-ps-tooltip', i18next.t(tooltipKey));
 
   const altKey = el.getAttribute('data-i18n-alt');
   if (altKey) el.setAttribute('alt', i18next.t(altKey));

--- a/public/js/common/psTooltip.js
+++ b/public/js/common/psTooltip.js
@@ -1,0 +1,121 @@
+/**
+ * Shared, design-token-styled tooltip for any element marked with `data-ps-tooltip="text"`.
+ *
+ * A single fixed-position card (`.ps-tooltip`, styled in main.css) follows the active trigger: it appears near the
+ * element after a short hover delay (or immediately on keyboard focus), preferring the space above the trigger and
+ * flipping below when there isn't room. Escape dismisses it (WCAG 1.4.13). Set the attribute directly, or via
+ * i18nDom's `data-i18n-tooltip="ns:key"` so the text stays translated.
+ *
+ * The attribute value renders as HTML so translation strings can carry inline emphasis (<b>, <i>). That makes it a
+ * hard rule that `data-ps-tooltip` only ever holds first-party strings (our translation files) — never user-supplied
+ * or third-party text.
+ *
+ * Loaded globally from main.scala.html (like i18nDom.js); no per-app setup needed — listeners are delegated on the
+ * document, so triggers added at any time just work.
+ */
+(() => {
+  const SHOW_DELAY_MS = 250;
+  const TRIGGER_GAP_PX = 8;
+  const VIEWPORT_MARGIN_PX = 8;
+
+  let tooltip = null;
+  let activeTrigger = null; // The trigger whose tooltip is visible, or pending via showTimer.
+  let showTimer = null;
+
+  /**
+   * Lazily creates the single shared tooltip element.
+   * @returns {HTMLElement} The tooltip card.
+   */
+  const ensureTooltip = () => {
+    if (tooltip === null) {
+      tooltip = document.createElement('div');
+      tooltip.id = 'ps-tooltip';
+      tooltip.className = 'ps-tooltip';
+      tooltip.setAttribute('role', 'tooltip');
+      document.body.appendChild(tooltip);
+    }
+    return tooltip;
+  };
+
+  /**
+   * Shows the tooltip for a trigger: fills in its text, sizes it, then places it centered above the trigger —
+   * clamped into the viewport, and flipped below the trigger when the space above is too tight.
+   * @param {Element} trigger - The element carrying data-ps-tooltip.
+   */
+  const show = (trigger) => {
+    const card = ensureTooltip();
+    // Rendered as HTML per the header contract: tooltip strings are first-party translations, never user input.
+    card.innerHTML = trigger.getAttribute('data-ps-tooltip');
+
+    const triggerRect = trigger.getBoundingClientRect();
+    const cardRect = card.getBoundingClientRect(); // Text is set, so this measures the final size while still hidden.
+    const left = Math.max(
+      VIEWPORT_MARGIN_PX,
+      Math.min(
+        triggerRect.left + (triggerRect.width - cardRect.width) / 2,
+        window.innerWidth - cardRect.width - VIEWPORT_MARGIN_PX,
+      ),
+    );
+    let top = triggerRect.top - cardRect.height - TRIGGER_GAP_PX;
+    if (top < VIEWPORT_MARGIN_PX) {
+      top = triggerRect.bottom + TRIGGER_GAP_PX;
+    }
+    card.style.left = `${left}px`;
+    card.style.top = `${top}px`;
+
+    card.classList.add('ps-tooltip--visible');
+    trigger.setAttribute('aria-describedby', 'ps-tooltip');
+    activeTrigger = trigger;
+  };
+
+  /**
+   * Hides the tooltip (if visible) and cancels any pending show.
+   */
+  const hide = () => {
+    if (showTimer !== null) {
+      clearTimeout(showTimer);
+      showTimer = null;
+    }
+    if (activeTrigger !== null) {
+      activeTrigger.removeAttribute('aria-describedby');
+      activeTrigger = null;
+    }
+    tooltip?.classList.remove('ps-tooltip--visible');
+  };
+
+  /**
+   * Reacts to the pointer/focus landing on `target`: starts (or keeps) the tooltip for its trigger, or hides it.
+   * @param {EventTarget} target - The element the pointer or focus moved onto.
+   * @param {boolean} immediate - True to skip the hover delay (keyboard focus).
+   */
+  const onEnter = (target, immediate) => {
+    const trigger = target instanceof Element ? target.closest('[data-ps-tooltip]') : null;
+    if (trigger === activeTrigger) {
+      return; // Still on the same trigger (e.g. moving between its children); leave the tooltip as is.
+    }
+    hide();
+    if (trigger !== null) {
+      if (immediate) {
+        show(trigger);
+      } else {
+        activeTrigger = trigger;
+        showTimer = setTimeout(() => {
+          showTimer = null;
+          show(trigger);
+        }, SHOW_DELAY_MS);
+      }
+    }
+  };
+
+  document.addEventListener('mouseover', (event) => onEnter(event.target, false));
+  document.addEventListener('mouseleave', hide); // Pointer left the page entirely; mouseover alone would miss it.
+  document.addEventListener('focusin', (event) => onEnter(event.target, true));
+  document.addEventListener('focusout', hide);
+  // Hide on scroll (the fixed-position card would drift from its trigger) and on Escape (WCAG 1.4.13 dismissable).
+  window.addEventListener('scroll', hide, true);
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') {
+      hide();
+    }
+  });
+})();

--- a/public/js/explore/src/Main.js
+++ b/public/js/explore/src/Main.js
@@ -191,7 +191,9 @@ class Main {
     );
 
     // Speed limit
-    svl.speedLimit = new SpeedLimit(svl.panoViewer, svl.panoViewer.getPosition, svl.isOnboarding, null, null);
+    svl.speedLimit = new SpeedLimit(svl.panoViewer, svl.panoViewer.getPosition, svl.isOnboarding, params.countryId, {
+      taskContainer: svl.taskContainer,
+    });
 
     // Survey for select users
     svl.modalSurvey = new ModalSurvey();

--- a/public/js/explore/src/task/Task.js
+++ b/public/js/explore/src/task/Task.js
@@ -29,6 +29,7 @@ class Task {
     startPointReversed: false,
     tutorialTask: null,
     wayType: null,
+    maxSpeed: null,
     routeStreetId: null,
     routeStreetPosition: null,
   };
@@ -59,6 +60,7 @@ class Task {
     this.setProperty('currentMissionId', currMissionId);
     this.setProperty('auditTaskId', this.#geojson.properties.audit_task_id);
     this.setProperty('wayType', this.#geojson.properties.way_type);
+    this.setProperty('maxSpeed', this.#geojson.properties.max_speed);
     this.setProperty('routeStreetId', this.#geojson.properties.route_street_id);
     this.setProperty('routeStreetPosition', this.#geojson.properties.route_street_position);
     this.setProperty('taskStart', new Date(this.#geojson.properties.task_start));

--- a/public/js/validate/src/Main.js
+++ b/public/js/validate/src/Main.js
@@ -169,7 +169,8 @@ class Main {
       svv.panoOverlay = new PanoOverlay();
       svv.keyboard = new KeyboardManager(svv.ui.validationMenu);
       svv.speedLimit = new SpeedLimit(
-        svv.panoViewer, svv.panoViewer.getPosition, () => false, svv.labelContainer, labelType,
+        svv.panoViewer, svv.panoViewer.getPosition, () => false, param.countryId,
+        { labelContainer: svv.labelContainer, labelType },
       );
       svv.zoomControl = new ZoomControl();
       new MissionStartTutorial('validate', labelType, { nLabels: param.mission.labels_validated }, svv, param.language);

--- a/public/js/validate/src/label/Label.js
+++ b/public/js/validate/src/label/Label.js
@@ -120,6 +120,7 @@ class Label {
       }
       if ('description' in params) this.setAuditProperty('description', params.description);
       if ('street_edge_id' in params) this.setAuditProperty('streetEdgeId', params.street_edge_id);
+      if ('max_speed' in params) this.setAuditProperty('maxSpeed', params.max_speed);
       if ('region_id' in params) this.setAuditProperty('regionId', params.region_id);
       if ('tags' in params) {
         this.setAuditProperty('tags', params.tags);

--- a/public/js/validate/src/label/LabelContainer.js
+++ b/public/js/validate/src/label/LabelContainer.js
@@ -17,8 +17,6 @@ class LabelContainer {
     validationTimestamp: new Date(),
   };
 
-  #labelsUpdateCallback = () => {};
-
   /**
    * @param {Array} labelList Initial list of labels to be validated (generated when the page is loaded).
    */
@@ -145,15 +143,6 @@ class LabelContainer {
     this.#labels = labelList.map((key) => new Label(key));
     this.#currLabelIndex = 0;
     this.#currLabel = this.#labels[this.#currLabelIndex];
-    this.#labelsUpdateCallback();
-  }
-
-  /**
-   * Sets the callback that will be called after resetLabelList is called. Used by SpeedLimit.js.
-   * @param {function} callback The function that will be called.
-   */
-  resetLabelListUpdateCallback(callback) {
-    this.#labelsUpdateCallback = callback;
   }
 
   /**

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -6,6 +6,7 @@
   "unit-abbreviation-mission-distance": "m",
   "unit-distance": "kilometers",
   "speed-limit-tooltip": "Die Kenntnis des <b>Tempolimits</b> einer Straße hilft, die Sicherheit für Fußgänger besser einzuschätzen, etwa ob das Überqueren an einer ungeregelten Kreuzung <b>sicher</b> ist.",
+  "speed-limit-aria-label": "Tempolimit {{speed}} {{units}}",
   "format-number": "{{val, number}}",
   "cities-cta-join_one": "Schließen Sie sich {{count, number}} weiteren Gemeinschaft an",
   "cities-cta-join_other": "Schließen Sie sich {{count, number}} weiteren Gemeinschaften an",

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -5,6 +5,7 @@
   "unit-distance-abbreviation": "km",
   "unit-abbreviation-mission-distance": "m",
   "unit-distance": "kilometers",
+  "speed-limit-tooltip": "Die Kenntnis des <b>Tempolimits</b> einer Straße hilft, die Sicherheit für Fußgänger besser einzuschätzen, etwa ob das Überqueren an einer ungeregelten Kreuzung <b>sicher</b> ist.",
   "format-number": "{{val, number}}",
   "cities-cta-join_one": "Schließen Sie sich {{count, number}} weiteren Gemeinschaft an",
   "cities-cta-join_other": "Schließen Sie sich {{count, number}} weiteren Gemeinschaften an",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -5,6 +5,7 @@
   "unit-distance-abbreviation": "km",
   "unit-abbreviation-mission-distance": "m",
   "unit-distance": "kilometers",
+  "speed-limit-tooltip": "Knowing the <b>speed limit</b> on a street can help you better diagnose pedestrian safety, such as whether it is <b>safe</b> to cross at an uncontrolled intersection.",
   "format-number": "{{val, number}}",
   "cities-cta-join_one": "Join {{count, number}} other community",
   "cities-cta-join_other": "Join {{count, number}} other communities",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -6,6 +6,7 @@
   "unit-abbreviation-mission-distance": "m",
   "unit-distance": "kilometers",
   "speed-limit-tooltip": "Knowing the <b>speed limit</b> on a street can help you better diagnose pedestrian safety, such as whether it is <b>safe</b> to cross at an uncontrolled intersection.",
+  "speed-limit-aria-label": "Speed limit {{speed}} {{units}}",
   "format-number": "{{val, number}}",
   "cities-cta-join_one": "Join {{count, number}} other community",
   "cities-cta-join_other": "Join {{count, number}} other communities",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -6,6 +6,7 @@
   "unit-abbreviation-mission-distance": "m",
   "unit-distance": "kilometers",
   "speed-limit-tooltip": "Conocer el <b>límite de velocidad</b> de una calle puede ayudarte a evaluar mejor la seguridad peatonal, por ejemplo, si es <b>seguro</b> cruzar en una intersección no controlada.",
+  "speed-limit-aria-label": "Límite de velocidad {{speed}} {{units}}",
   "format-number": "{{val, number}}",
   "cities-cta-join_one": "Únete a {{count, number}} comunidad más",
   "cities-cta-join_other": "Únete a {{count, number}} comunidades más",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -5,6 +5,7 @@
   "unit-distance-abbreviation": "km",
   "unit-abbreviation-mission-distance": "m",
   "unit-distance": "kilometers",
+  "speed-limit-tooltip": "Conocer el <b>límite de velocidad</b> de una calle puede ayudarte a evaluar mejor la seguridad peatonal, por ejemplo, si es <b>seguro</b> cruzar en una intersección no controlada.",
   "format-number": "{{val, number}}",
   "cities-cta-join_one": "Únete a {{count, number}} comunidad más",
   "cities-cta-join_other": "Únete a {{count, number}} comunidades más",

--- a/public/locales/nl/common.json
+++ b/public/locales/nl/common.json
@@ -6,6 +6,7 @@
   "unit-abbreviation-mission-distance": "m",
   "unit-distance": "kilometers",
   "speed-limit-tooltip": "Als je de <b>maximumsnelheid</b> van een straat kent, kun je de veiligheid voor voetgangers beter inschatten, bijvoorbeeld of het <b>veilig</b> is om over te steken op een ongeregeld kruispunt.",
+  "speed-limit-aria-label": "Maximumsnelheid {{speed}} {{units}}",
   "format-number": "{{val, number}}",
   "cities-cta-join_one": "Sluit u aan bij nog {{count, number}} gemeenschap",
   "cities-cta-join_other": "Sluit u aan bij nog {{count, number}} gemeenschappen",

--- a/public/locales/nl/common.json
+++ b/public/locales/nl/common.json
@@ -5,6 +5,7 @@
   "unit-distance-abbreviation": "km",
   "unit-abbreviation-mission-distance": "m",
   "unit-distance": "kilometers",
+  "speed-limit-tooltip": "Als je de <b>maximumsnelheid</b> van een straat kent, kun je de veiligheid voor voetgangers beter inschatten, bijvoorbeeld of het <b>veilig</b> is om over te steken op een ongeregeld kruispunt.",
   "format-number": "{{val, number}}",
   "cities-cta-join_one": "Sluit u aan bij nog {{count, number}} gemeenschap",
   "cities-cta-join_other": "Sluit u aan bij nog {{count, number}} gemeenschappen",

--- a/public/locales/pt-BR/common.json
+++ b/public/locales/pt-BR/common.json
@@ -5,6 +5,7 @@
   "unit-distance-abbreviation": "km",
   "unit-abbreviation-mission-distance": "m",
   "unit-distance": "kilometers",
+  "speed-limit-tooltip": "Conhecer o <b>limite de velocidade</b> de uma rua pode ajudar a avaliar melhor a segurança dos pedestres, por exemplo, se é <b>seguro</b> atravessar em um cruzamento sem sinalização.",
   "format-number": "{{val, number}}",
   "cities-cta-join_one": "Junte-se a mais {{count, number}} comunidade",
   "cities-cta-join_other": "Junte-se a mais {{count, number}} comunidades",

--- a/public/locales/pt-BR/common.json
+++ b/public/locales/pt-BR/common.json
@@ -6,6 +6,7 @@
   "unit-abbreviation-mission-distance": "m",
   "unit-distance": "kilometers",
   "speed-limit-tooltip": "Conhecer o <b>limite de velocidade</b> de uma rua pode ajudar a avaliar melhor a segurança dos pedestres, por exemplo, se é <b>seguro</b> atravessar em um cruzamento sem sinalização.",
+  "speed-limit-aria-label": "Limite de velocidade {{speed}} {{units}}",
   "format-number": "{{val, number}}",
   "cities-cta-join_one": "Junte-se a mais {{count, number}} comunidade",
   "cities-cta-join_other": "Junte-se a mais {{count, number}} comunidades",

--- a/public/locales/zh-TW/common.json
+++ b/public/locales/zh-TW/common.json
@@ -5,6 +5,7 @@
   "unit-distance-abbreviation": "公里",
   "unit-abbreviation-mission-distance": "公尺",
   "unit-distance": "kilometers",
+  "speed-limit-tooltip": "了解街道的<b>速限</b>有助於更準確地判斷行人安全，例如在無號誌路口過馬路是否<b>安全</b>。",
   "format-number": "{{val, number}}",
   "cities-cta-join_other": "加入其他 {{count, number}} 個社區",
   "curb-ramp": "路緣斜坡",

--- a/public/locales/zh-TW/common.json
+++ b/public/locales/zh-TW/common.json
@@ -6,6 +6,7 @@
   "unit-abbreviation-mission-distance": "公尺",
   "unit-distance": "kilometers",
   "speed-limit-tooltip": "了解街道的<b>速限</b>有助於更準確地判斷行人安全，例如在無號誌路口過馬路是否<b>安全</b>。",
+  "speed-limit-aria-label": "速限 {{speed}} {{units}}",
   "format-number": "{{val, number}}",
   "cities-cta-join_other": "加入其他 {{count, number}} 個社區",
   "curb-ramp": "路緣斜坡",

--- a/test/controllers/api/StreetsApiSpec.scala
+++ b/test/controllers/api/StreetsApiSpec.scala
@@ -42,7 +42,11 @@ class StreetsApiSpec extends PlaySpec with GuiceOneAppPerSuite {
 
       val json = contentAsJson(resp)
       (json \ "type").as[String] mustBe "FeatureCollection"
-      (json \ "features").asOpt[Seq[JsObject]] mustBe defined
+      val features = (json \ "features").asOpt[Seq[JsObject]]
+      features mustBe defined
+
+      // If the tiny bbox happens to contain a street, its properties must carry the max_speed key (may be null).
+      features.get.headOption.foreach { feature => (feature \ "properties" \ "max_speed").toOption mustBe defined }
     }
 
     "return CSV with the documented snake_case header when filetype=csv" in {
@@ -53,8 +57,8 @@ class StreetsApiSpec extends PlaySpec with GuiceOneAppPerSuite {
       val body = contentAsString(resp)
       // Header from StreetDataForApi.csvHeader; assert snake_case field names are present and camelCase absent.
       body must include(
-        "street_edge_id,osm_way_id,region_id,region_name,way_type,status,user_ids,label_count,audit_count,user_count," +
-          "first_label_date,last_label_date,start_point,end_point"
+        "street_edge_id,osm_way_id,region_id,region_name,way_type,max_speed,status,user_ids,label_count,audit_count," +
+          "user_count,first_label_date,last_label_date,start_point,end_point"
       )
       body must not include "streetEdgeId"
       body must not include "labelCount"

--- a/test/service/OsmWayServiceSpec.scala
+++ b/test/service/OsmWayServiceSpec.scala
@@ -1,0 +1,124 @@
+package service
+
+import org.scalatestplus.play.PlaySpec
+import play.api.libs.json.{JsObject, JsValue, Json}
+
+/**
+ * Unit tests for OsmWayService's pure Overpass-response parsing and nearest-road selection (#4654). No application,
+ * DB, or network required — the functions under test live on the companion object and take parsed JSON.
+ */
+class OsmWayServiceSpec extends PlaySpec {
+
+  /** Builds an Overpass `out tags;` batch response element for a way. */
+  private def wayWithTags(id: Long, tags: JsObject): JsObject = {
+    Json.obj("type" -> "way", "id" -> id, "tags" -> tags)
+  }
+
+  /** Builds an Overpass `out geom;` response element for a way along the given (lat, lon) points. */
+  private def wayWithGeom(id: Long, highway: String, points: Seq[(Double, Double)], maxspeed: Option[String] = None) = {
+    Json.obj(
+      "type" -> "way",
+      "id"   -> id,
+      "tags" -> (Json.obj("highway" -> highway) ++ maxspeed
+        .map(ms => Json.obj("maxspeed" -> ms))
+        .getOrElse(
+          Json.obj()
+        )),
+      "geometry" -> points.map { case (lat, lon) => Json.obj("lat" -> lat, "lon" -> lon) }
+    )
+  }
+
+  "parseBatchResponse" should {
+    "map way ids to their full tag maps" in {
+      val json: JsValue = Json.obj(
+        "elements" -> Json.arr(
+          wayWithTags(1L, Json.obj("maxspeed" -> "25 mph", "name" -> "Main St", "sidewalk" -> "both")),
+          wayWithTags(2L, Json.obj("highway" -> "residential"))
+        )
+      )
+      val parsed = OsmWayService.parseBatchResponse(json)
+      parsed.keySet mustBe Set(1L, 2L)
+      (parsed(1L) \ "maxspeed").as[String] mustBe "25 mph"
+      (parsed(1L) \ "name").as[String] mustBe "Main St"
+      (parsed(1L) \ "sidewalk").as[String] mustBe "both"
+      (parsed(2L) \ "maxspeed").asOpt[String] mustBe None
+    }
+
+    "return an empty tag map for a way with no tags field" in {
+      val json: JsValue = Json.obj("elements" -> Json.arr(Json.obj("type" -> "way", "id" -> 5L)))
+      OsmWayService.parseBatchResponse(json) mustBe Map(5L -> Json.obj())
+    }
+
+    "ignore non-way elements and tolerate an empty or missing elements array" in {
+      val json: JsValue = Json.obj("elements" -> Json.arr(Json.obj("type" -> "node", "id" -> 9L)))
+      OsmWayService.parseBatchResponse(json) mustBe Map.empty
+      OsmWayService.parseBatchResponse(Json.obj("elements" -> Json.arr())) mustBe Map.empty
+      OsmWayService.parseBatchResponse(Json.obj()) mustBe Map.empty
+    }
+  }
+
+  "maxspeedFrom" should {
+    "extract the raw maxspeed value" in {
+      OsmWayService.maxspeedFrom(Json.obj("maxspeed" -> "30")) mustBe Some("30")
+      OsmWayService.maxspeedFrom(Json.obj("maxspeed" -> "25 mph")) mustBe Some("25 mph")
+    }
+
+    "return None when the tag is absent" in {
+      OsmWayService.maxspeedFrom(Json.obj("highway" -> "residential")) mustBe None
+      OsmWayService.maxspeedFrom(Json.obj()) mustBe None
+    }
+  }
+
+  "pickNearestRoad" should {
+    // Query point; candidate ways run north-south at small longitude offsets from it.
+    val lat = 47.6062
+    val lng = -122.3321
+
+    "pick the nearest qualifying road" in {
+      val json: JsValue = Json.obj(
+        "elements" -> Json.arr(
+          wayWithGeom(1L, "residential", Seq((lat - 0.001, lng + 0.0002), (lat + 0.001, lng + 0.0002)), Some("25 mph")),
+          wayWithGeom(2L, "primary", Seq((lat - 0.001, lng + 0.0001), (lat + 0.001, lng + 0.0001)), Some("35 mph"))
+        )
+      )
+      val result = OsmWayService.pickNearestRoad(json, lat, lng)
+      result.map(_._1) mustBe Some(2L)
+      result.flatMap(r => OsmWayService.maxspeedFrom(r._2)) mustBe Some("35 mph")
+    }
+
+    "exclude non-road highway types like footways" in {
+      val json: JsValue = Json.obj(
+        "elements" -> Json.arr(
+          // The footway is closer, but only drivable road types qualify.
+          wayWithGeom(1L, "footway", Seq((lat - 0.001, lng), (lat + 0.001, lng))),
+          wayWithGeom(2L, "residential", Seq((lat - 0.001, lng + 0.0005), (lat + 0.001, lng + 0.0005)))
+        )
+      )
+      OsmWayService.pickNearestRoad(json, lat, lng).map(_._1) mustBe Some(2L)
+    }
+
+    "build the returned geometry as (lng, lat) coordinates" in {
+      val json: JsValue = Json.obj(
+        "elements" -> Json.arr(wayWithGeom(1L, "residential", Seq((lat - 0.001, lng), (lat + 0.001, lng))))
+      )
+      val geom = OsmWayService.pickNearestRoad(json, lat, lng).get._3
+      geom.getCoordinateN(0).getX mustBe lng
+      geom.getCoordinateN(0).getY mustBe (lat - 0.001)
+    }
+
+    "return None when no qualifying road is in the response" in {
+      OsmWayService.pickNearestRoad(Json.obj("elements" -> Json.arr()), lat, lng) mustBe None
+      val onlyFootway: JsValue = Json.obj(
+        "elements" -> Json.arr(wayWithGeom(1L, "footway", Seq((lat - 0.001, lng), (lat + 0.001, lng))))
+      )
+      OsmWayService.pickNearestRoad(onlyFootway, lat, lng) mustBe None
+    }
+
+    "ignore a way with fewer than two geometry points" in {
+      val json: JsValue = Json.obj(
+        "elements" -> Json.arr(wayWithGeom(1L, "residential", Seq((lat, lng))))
+      )
+      OsmWayService.pickNearestRoad(json, lat, lng) mustBe None
+    }
+  }
+}


### PR DESCRIPTION
Fixes #4654.

## Problem

`SpeedLimit.js` made **two live Overpass API requests on every `pano_changed`** in Explore and Validate (nearest-road + country-code lookups) — a stream of 429s from the shared community instance, third-party latency on the hot path, and user coordinates sent to a third party on every move.

## Approach

Speed limit is a property of the street, so it's now precomputed per OSM way and served from our DB:

- **New `osm_way` table** (evolution 345), keyed by `osm_way_id`: the way's **full OSM tag map as JSONB** (so future features can mine `name`/`sidewalk`/`surface`/`lanes` without re-fetching), an extracted `maxspeed` column for cheap joins, geometry (on-demand rows only), `source`, and `updated_at`.
- **Nightly `OsmWayRefreshActor`** (02:00 + per-city offset) refreshes every way in `osm_way_street_edge` whose row is **missing or >30 days old** — monthly per way, auto-backfills new cities, no-ops most nights. Bulk Overpass queries (300 ids/request, sequential, 2s apart); a failed run just retries the next night. Admin-only `GET /adminapi/refreshOsmWayData` triggers it on demand for QA and the initial backfill.
- **Server-proxied fallback `GET /speedLimit?lat&lng`** for positions off our street network (the cross-street case from the issue discussion): PostGIS lookup against already-discovered ways first, Overpass only on a miss, result upserted **with geometry** so each unknown spot costs Overpass at most one query ever, across all users. Short-TTL rounded-coordinate cache doubles as a negative cache. The client never talks to Overpass — it's gone from the CSP `connect-src`.
- **Speeds ride existing payloads**: `max_speed` on the Explore task GeoJSON (next to `way_type`) and on Validate label metadata — zero new round trips for normal use.
- **Frontend rewrite of `SpeedLimit.js`**: Explore picks the nearest loaded street within 15 m (turf, client-side — this also fixes a latent `[lat, lng]` swap that made old nearest-road selection arbitrary) and only calls our fallback when off-network; Validate reads the label's street from its metadata. Sign design + fallback units now come from the city's `country-id` (also fixes the dead `'UK'` branch — the ISO code is GB — and Canada now correctly gets km/h). The `LabelContainer` callback hook that existed solely for the old prefetch is removed.
- **`/v3/api/streets`** exposes `max_speed` in all formats — GeoJSON/CSV/GeoPackage as `max_speed`, shapefile DBF as `maxSpeed` per the 10-char convention — with API docs and OSM/ODbL attribution.

## Testing

- `sbt test`: full suite green (432 tests), including new `OsmWayServiceSpec` (pure Overpass parsing/nearest-road selection — allowlist filtering, [lon,lat] ordering, missing-tag/deleted-way handling) and updated `StreetsApiSpec` (CSV header + GeoJSON `max_speed` key).
- `sbt compile` warning-clean, `scalafmtCheckAll`, ESLint/HTMLHint on touched files, `make lint-evolutions` all pass.

## Manual QA checklist (needs GSV interaction)

1. Load any page → evolution 345 applies; as admin hit `/adminapi/refreshOsmWayData` → `osm_way` fills with `source='batch'` rows (full `tags` JSONB); immediate re-run returns ~0.
2. Explore: sign shows/updates while moving; **Network tab shows zero requests to overpass-api.de**.
3. Step onto a street >15 m from any task street (alley/cross street outside the network) → one `/speedLimit` call, sign updates, a `source='on_demand'` row with geometry appears; revisiting the same pano makes no second call.
4. Validate (desktop): NoCurbRamp mission shows the sign from the label's street; other label types and onboarding hide it.
5. US vs non-US city config: `data-design-style` (rectangle vs circle) and fallback units (mph vs km/h) correct.
6. `/v3/api/streets?filetype=geojson|csv|shapefile|geopackage` all carry the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-fable-5)