### PR TITLE
Address the label hover card review; restyle the shared tooltip (#4731)

### DIFF
--- a/app/views/apps/explore.scala.html
+++ b/app/views/apps/explore.scala.html
@@ -513,9 +513,11 @@
                 <img id="label-hover-card-severity-icon" class="label-hover-card__severity-icon" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" alt="">
                 <span id="label-hover-card-severity-text"></span>
               </span>
+              @* The prompt names severity or quality depending on the label type, so Label.js sets it rather than
+                 i18nDom -- a positive feature is rated for how well it works, not how badly it blocks. *@
               <span id="label-hover-card-not-rated" class="label-hover-card__not-rated">
                 <span class="label-hover-card__not-rated-icon" aria-hidden="true">?</span>
-                <span data-i18n="audit:center-ui.context-menu.severity">Please click to label a severity</span>
+                <span id="label-hover-card-not-rated-text"></span>
               </span>
               <span id="label-hover-card-tags" class="label-hover-card__tags"></span>
               <span id="label-hover-card-description" class="label-hover-card__description"></span>

--- a/app/views/apps/mobileValidate.scala.html
+++ b/app/views/apps/mobileValidate.scala.html
@@ -59,7 +59,7 @@
       <div id="view-control-layer"></div>
       @components.validateLabelCard()
       <div id="label-visibility-control-holder" class="pano-overlay-button-group">
-        <button type="button" id="label-visibility-control-button" class="pano-overlay-button" data-i18n-tooltip="validate:top-ui.visibility-control-tooltip"></button>
+        <button type="button" id="label-visibility-control-button" class="pano-overlay-button"></button>
       </div>
       <button type="button" id="validate-undo-button" class="pano-overlay-button">
         <img src='@assets.path("images/icons/undo-icon.svg")' class="hide-label-button-icon" alt="undo">

--- a/app/views/apps/validate.scala.html
+++ b/app/views/apps/validate.scala.html
@@ -104,7 +104,7 @@
         @* Same shared pill Explore uses for its Stuck/Sound/Feedback controls in this corner. Labelled by
            LabelVisibilityControl, which keeps it in step with the toggle in the label card's footer. *@
         <div id="label-visibility-control-holder" class="pano-overlay-button-group">
-          <button type="button" id="label-visibility-control-button" class="pano-overlay-button" data-i18n-tooltip="validate:top-ui.visibility-control-tooltip"></button>
+          <button type="button" id="label-visibility-control-button" class="pano-overlay-button"></button>
         </div>
         <div id="svv-panorama-date-holder">
           <span id="svv-panorama-date"></span>

--- a/app/views/components/validateLabelCard.scala.html
+++ b/app/views/components/validateLabelCard.scala.html
@@ -28,9 +28,10 @@
     <span id="label-card-no-info" class="label-hover-card__no-info" data-i18n="validate:center-ui.no-info">No available information</span>
   </div>
   @* Labelled by LabelVisibilityControl, which keeps it in step with the always-visible toggle in the pano's top-left
-     corner. No tooltip on this one: the card is itself a hover panel, so a second panel would open on top of what
-     the validator is reading. The explanation lives on the top-left control, which has the room for it. *@
+     corner — and which also swaps its tooltip, since the button reverses meaning when the label is hidden.
+     A short tooltip, not the top-left control's full sentence, and pinned below: the card is itself a hover panel,
+     so the default placement would open this over the rating the validator is reading. *@
   <div class="label-hover-card__actions">
-    <button type="button" id="label-visibility-button-on-label" class="button-ps button--tiny label-hover-card__action-button"></button>
+    <button type="button" id="label-visibility-button-on-label" class="button-ps button--tiny label-hover-card__action-button" data-ps-tooltip-placement="bottom"></button>
   </div>
 </div>

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1798,14 +1798,17 @@ kbd {
 
    Dark fill, not a white card: a tooltip is a transient aside over whatever it explains, and the panels it opens over
    (the label card, the context menu, the pano overlays) are themselves white cards — a fourth white surface stacked on
-   those reads as another panel rather than as a passing note. 9.15:1 white-on-neutral-800, so it clears AAA. */
+   those reads as another panel rather than as a passing note. Specifically asphalt-500, the same surface the dark
+   toast uses (common/toast.css), because these two are the same idea at two sizes: a note laid over the tool rather
+   than a piece of it. It also keeps the tooltip clear of the asphalt-400 pano-overlay buttons it most often opens
+   above, which a neutral dark gray sat too close to. 13.9:1 white-on-asphalt-500, comfortably past AAA. */
 .ps-tooltip {
   position: fixed;
   left: -9999px;
   top: -9999px;
   max-width: calc(280px * var(--ui-scale, 1));
   padding: calc(5px * var(--ui-scale, 1)) calc(9px * var(--ui-scale, 1));
-  background: var(--color-neutral-800);
+  background: var(--color-asphalt-500);
   border-radius: calc(6px * var(--ui-scale, 1));
   box-shadow: 0 2px 8px rgb(0 0 0 / 20%);
   font: var(--text-caption-regular);
@@ -1833,7 +1836,7 @@ kbd {
   width: calc(12px * var(--ui-scale, 1));
   height: calc(6px * var(--ui-scale, 1));
   margin-left: calc(-6px * var(--ui-scale, 1));
-  background: var(--color-neutral-800);
+  background: var(--color-asphalt-500);
   clip-path: polygon(0 0, 100% 0, 50% 100%);
 }
 

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1794,24 +1794,54 @@ kbd {
 
 /* The single fixed-position card that psTooltip.js shows for the active [data-ps-tooltip] trigger. Parked off-screen
    until positioned; pointer-events stays off so the card never steals the hover that opened it. Sits above the navbar
-   and Bootstrap modals (~1050) since a tooltip is always the most transient thing on screen. */
+   and Bootstrap modals (~1050) since a tooltip is always the most transient thing on screen.
+
+   Dark fill, not a white card: a tooltip is a transient aside over whatever it explains, and the panels it opens over
+   (the label card, the context menu, the pano overlays) are themselves white cards — a fourth white surface stacked on
+   those reads as another panel rather than as a passing note. 9.15:1 white-on-neutral-800, so it clears AAA. */
 .ps-tooltip {
   position: fixed;
   left: -9999px;
   top: -9999px;
   max-width: calc(280px * var(--ui-scale, 1));
-  padding: calc(8px * var(--ui-scale, 1)) calc(12px * var(--ui-scale, 1));
-  background: var(--color-neutral-white);
-  border: 1px solid var(--color-neutral-600);
-  border-radius: calc(8px * var(--ui-scale, 1));
-  box-shadow: 0 2px 8px rgb(0 0 0 / 12%);
-  font: var(--text-small-regular);
-  color: var(--color-neutral-black);
+  padding: calc(5px * var(--ui-scale, 1)) calc(9px * var(--ui-scale, 1));
+  background: var(--color-neutral-800);
+  border-radius: calc(6px * var(--ui-scale, 1));
+  box-shadow: 0 2px 8px rgb(0 0 0 / 20%);
+  font: var(--text-caption-regular);
+
+  /* Tighter than the token's 18px leading, which is set for running body copy: a tooltip is a line or two of aside,
+     and at that length the token's spacing opens the card up more than the text inside it warrants. */
+  line-height: calc(15px * var(--ui-scale, 1));
+  color: var(--color-neutral-white);
   pointer-events: none;
   opacity: 0;
   visibility: hidden;
   transition: opacity 0.12s ease;
   z-index: calc(var(--navbar-z-index) + 70);
+}
+
+/* Tail aimed at the trigger. Its x comes from the JS rather than a flat 50%, because the card is clamped to the
+   viewport and so does not stay centered on its trigger near a screen edge. One clip-path triangle here, not the
+   label panel's two stacked layers (css/common/label-anchored-panel.css): the fill is solid and borderless, so there
+   is no hairline to carry along the slanted edges and nothing to seam. */
+.ps-tooltip::after {
+  content: "";
+  position: absolute;
+  left: var(--ps-tooltip-tail-left, 50%);
+  top: 100%;
+  width: calc(12px * var(--ui-scale, 1));
+  height: calc(6px * var(--ui-scale, 1));
+  margin-left: calc(-6px * var(--ui-scale, 1));
+  background: var(--color-neutral-800);
+  clip-path: polygon(0 0, 100% 0, 50% 100%);
+}
+
+/* Flipped: there was no room above, so the card sits below the trigger and the tail moves to its top edge. */
+.ps-tooltip--flipped::after {
+  top: auto;
+  bottom: 100%;
+  clip-path: polygon(0 100%, 100% 100%, 50% 0);
 }
 
 .ps-tooltip--visible {

--- a/public/js/common/psTooltip.js
+++ b/public/js/common/psTooltip.js
@@ -3,8 +3,9 @@
  *
  * A single fixed-position card (`.ps-tooltip`, styled in main.css) follows the active trigger: it appears near the
  * element after a short hover delay (or immediately on keyboard focus), preferring the space above the trigger and
- * flipping below when there isn't room. Escape dismisses it (WCAG 1.4.13). Set the attribute directly, or via
- * i18nDom's `data-i18n-tooltip="ns:key"` so the text stays translated.
+ * flipping below when there isn't room. A tail points back at the trigger; this file places it, and main.css draws
+ * it. Escape dismisses it (WCAG 1.4.13). Set the attribute directly, or via i18nDom's `data-i18n-tooltip="ns:key"`
+ * so the text stays translated.
  *
  * The attribute value renders as HTML so translation strings can carry inline emphasis (<b>, <i>). That makes it a
  * hard rule that `data-ps-tooltip` only ever holds first-party strings (our translation files) — never user-supplied
@@ -15,12 +16,27 @@
  */
 (() => {
   const SHOW_DELAY_MS = 250;
+  // Trigger-to-card gap. The tail is drawn into it, so this has to stay above the tail's height below.
   const TRIGGER_GAP_PX = 8;
   const VIEWPORT_MARGIN_PX = 8;
+  // Half the tail's width and the card's corner radius, both matching main.css. Their sum is how far the tail has to
+  // stay in from either end of the card for its base to land on a straight run of edge rather than on a corner.
+  const TAIL_HALF_WIDTH_PX = 6;
+  const CORNER_RADIUS_PX = 6;
 
   let tooltip = null;
   let activeTrigger = null; // The trigger whose tooltip is visible, or pending via showTimer.
   let showTimer = null;
+
+  /**
+   * Reads the zoom factor `util.applyToolScale` puts on the document root, so the gaps measured here match the tail
+   * and corner radius that main.css scales by the same value. Pages outside the Explore/Validate tools never set it.
+   * @returns {number} The current --ui-scale, or 1 where it is unset or unusable.
+   */
+  const uiScale = () => {
+    const raw = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--ui-scale'));
+    return Number.isFinite(raw) && raw > 0 ? raw : 1;
+  };
 
   /**
    * Lazily creates the single shared tooltip element.
@@ -39,14 +55,17 @@
 
   /**
    * Shows the tooltip for a trigger: fills in its text, sizes it, then places it centered above the trigger —
-   * clamped into the viewport, and flipped below the trigger when the space above is too tight.
+   * clamped into the viewport, and flipped below the trigger when the space above is too tight. Finally aims the
+   * tail back at the trigger.
    * @param {Element} trigger - The element carrying data-ps-tooltip.
    */
   const show = (trigger) => {
     const card = ensureTooltip();
     // Rendered as HTML per the header contract: tooltip strings are first-party translations, never user input.
     card.innerHTML = trigger.getAttribute('data-ps-tooltip');
+    card.classList.remove('ps-tooltip--flipped'); // Reset before measuring; the flip below re-adds it if needed.
 
+    const scale = uiScale();
     const triggerRect = trigger.getBoundingClientRect();
     const cardRect = card.getBoundingClientRect(); // Text is set, so this measures the final size while still hidden.
     const left = Math.max(
@@ -56,12 +75,21 @@
         window.innerWidth - cardRect.width - VIEWPORT_MARGIN_PX,
       ),
     );
-    let top = triggerRect.top - cardRect.height - TRIGGER_GAP_PX;
+    let top = triggerRect.top - cardRect.height - TRIGGER_GAP_PX * scale;
     if (top < VIEWPORT_MARGIN_PX) {
-      top = triggerRect.bottom + TRIGGER_GAP_PX;
+      top = triggerRect.bottom + TRIGGER_GAP_PX * scale;
+      card.classList.add('ps-tooltip--flipped');
     }
     card.style.left = `${left}px`;
     card.style.top = `${top}px`;
+
+    // Aim the tail at the trigger's center, not the card's: the clamp above slides the card sideways near a viewport
+    // edge, and a tail pinned to the card's middle would then point at empty space.
+    const tailInset = (TAIL_HALF_WIDTH_PX + CORNER_RADIUS_PX) * scale;
+    card.style.setProperty('--ps-tooltip-tail-left', `${Math.max(
+      tailInset,
+      Math.min(triggerRect.left + triggerRect.width / 2 - left, cardRect.width - tailInset),
+    )}px`);
 
     card.classList.add('ps-tooltip--visible');
     trigger.setAttribute('aria-describedby', 'ps-tooltip');

--- a/public/js/common/psTooltip.js
+++ b/public/js/common/psTooltip.js
@@ -28,6 +28,9 @@
   let tooltip = null;
   let activeTrigger = null; // The trigger whose tooltip is visible, or pending via showTimer.
   let showTimer = null;
+  // Watches the open trigger's text for changes under it. A toggle button relabels itself on click, and the pointer
+  // is still resting on it at that moment, so without this the card sits there describing the state just left.
+  let textObserver = null;
 
   /**
    * Reads the zoom factor `util.applyToolScale` puts on the document root, so the gaps measured here match the tail
@@ -102,12 +105,25 @@
     card.classList.add('ps-tooltip--visible');
     trigger.setAttribute('aria-describedby', 'ps-tooltip');
     activeTrigger = trigger;
+
+    // Re-run this whole placement if the text changes while the card is up: the new string is a different width, so
+    // refreshing the copy alone would leave it centered and tailed for the old one.
+    if (textObserver === null) {
+      textObserver = new MutationObserver(() => {
+        if (activeTrigger !== null && tooltip?.classList.contains('ps-tooltip--visible')) {
+          show(activeTrigger);
+        }
+      });
+    }
+    textObserver.disconnect();
+    textObserver.observe(trigger, { attributes: true, attributeFilter: ['data-ps-tooltip'] });
   };
 
   /**
    * Hides the tooltip (if visible) and cancels any pending show.
    */
   const hide = () => {
+    textObserver?.disconnect();
     if (showTimer !== null) {
       clearTimeout(showTimer);
       showTimer = null;

--- a/public/js/common/psTooltip.js
+++ b/public/js/common/psTooltip.js
@@ -3,9 +3,10 @@
  *
  * A single fixed-position card (`.ps-tooltip`, styled in main.css) follows the active trigger: it appears near the
  * element after a short hover delay (or immediately on keyboard focus), preferring the space above the trigger and
- * flipping below when there isn't room. A tail points back at the trigger; this file places it, and main.css draws
- * it. Escape dismisses it (WCAG 1.4.13). Set the attribute directly, or via i18nDom's `data-i18n-tooltip="ns:key"`
- * so the text stays translated.
+ * flipping below when there isn't room. Add `data-ps-tooltip-placement="bottom"` to reverse that preference, for a
+ * trigger sitting at the bottom of a panel the tooltip must not cover. A tail points back at the trigger; this file
+ * places it, and main.css draws it. Escape dismisses it (WCAG 1.4.13). Set the attribute directly, or via i18nDom's
+ * `data-i18n-tooltip="ns:key"` so the text stays translated.
  *
  * The attribute value renders as HTML so translation strings can carry inline emphasis (<b>, <i>). That makes it a
  * hard rule that `data-ps-tooltip` only ever holds first-party strings (our translation files) — never user-supplied
@@ -75,9 +76,16 @@
         window.innerWidth - cardRect.width - VIEWPORT_MARGIN_PX,
       ),
     );
-    let top = triggerRect.top - cardRect.height - TRIGGER_GAP_PX * scale;
-    if (top < VIEWPORT_MARGIN_PX) {
-      top = triggerRect.bottom + TRIGGER_GAP_PX * scale;
+    // Above by default, below when asked for or when there is no room above. "Asked for" still yields to a bottom
+    // edge it would run off, so the preference orders the two sides rather than pinning the card to one.
+    const gap = TRIGGER_GAP_PX * scale;
+    const above = triggerRect.top - cardRect.height - gap;
+    const below = triggerRect.bottom + gap;
+    const prefersBelow = trigger.getAttribute('data-ps-tooltip-placement') === 'bottom';
+    const fitsBelow = below + cardRect.height <= window.innerHeight - VIEWPORT_MARGIN_PX;
+    let top = above;
+    if (prefersBelow ? fitsBelow : above < VIEWPORT_MARGIN_PX) {
+      top = below;
       card.classList.add('ps-tooltip--flipped');
     }
     card.style.left = `${left}px`;

--- a/public/js/explore/src/Main.js
+++ b/public/js/explore/src/Main.js
@@ -522,6 +522,7 @@ class Main {
     svl.ui.canvas.hoverCardSeverityIcon = $('#label-hover-card-severity-icon');
     svl.ui.canvas.hoverCardSeverityText = $('#label-hover-card-severity-text');
     svl.ui.canvas.hoverCardNotRated = $('#label-hover-card-not-rated');
+    svl.ui.canvas.hoverCardNotRatedText = $('#label-hover-card-not-rated-text');
     svl.ui.canvas.hoverCardTags = $('#label-hover-card-tags');
     svl.ui.canvas.hoverCardDescription = $('#label-hover-card-description');
     svl.ui.canvas.hoverCardDelete = $('#label-hover-card-delete');

--- a/public/js/explore/src/canvas/ContextMenu.js
+++ b/public/js/explore/src/canvas/ContextMenu.js
@@ -225,10 +225,16 @@ class ContextMenu {
 
     const $header = $('#severity-header-text');
     if ($header.length) $header.text(i18next.t(`common:${headerKey}`));
+    // data-original-title only, never title: Bootstrap moves title into data-original-title when it initializes the
+    // tooltip and blanks the attribute, so writing title back here restores the browser's own tooltip on top of
+    // Bootstrap's and both appear at once (#4731). The other info icons set title from Twirl, before that init, so
+    // they never hit this.
     const $info = $('#severity-header-info');
+    // The alt rides along because it is this icon's accessible name, and the markup's static one says "severity"
+    // whichever dimension is on screen.
     if ($info.length) {
-      $info.attr('title', i18next.t(`common:${infoKey}`));
-      $info.attr('data-original-title', i18next.t(`common:${infoKey}`));
+      const info = i18next.t(`common:${infoKey}`);
+      $info.attr({ 'data-original-title': info, 'alt': info });
     }
     for (let sev = 1; sev <= 3; sev++) {
       $(`.severity-button[data-severity="${sev}"] .severity-button__label`)

--- a/public/js/explore/src/label/Label.js
+++ b/public/js/explore/src/label/Label.js
@@ -327,7 +327,14 @@ class Label {
     } else {
       ui.hoverCardSeverity.css('display', 'none');
     }
-    ui.hoverCardNotRated.css('display', hasSeverity && severity === null ? 'flex' : 'none');
+    const needsRating = hasSeverity && severity === null;
+    if (needsRating) {
+      // Ask for the dimension this type is actually rated on. The same 1-3 scale means opposite things either side
+      // of util.misc.isPositiveLabelType, and asking a curb ramp for its "severity" names the wrong one.
+      const promptKey = util.misc.isPositiveLabelType(labelType) ? 'rate-quality-prompt' : 'rate-severity-prompt';
+      ui.hoverCardNotRatedText.text(i18next.t(`audit:center-ui.context-menu.${promptKey}`));
+    }
+    ui.hoverCardNotRated.css('display', needsRating ? 'flex' : 'none');
 
     // Tags, as static (non-interactive) pills — built as DOM nodes with textContent so the tag text stays inert.
     const tagNames = this.#getTagNames();
@@ -412,20 +419,23 @@ class Label {
   #showSeverityAlert(ctx) {
     const x = this.#properties.currCanvasXY.x;
     const y = this.#properties.currCanvasXY.y;
+    // Canvas resolves neither CSS variables nor --ui-scale, so the design tokens are read off :root. (No scaling
+    // wanted here regardless: this canvas keeps its fixed logical size and is scaled up by the browser.)
+    const rootStyle = getComputedStyle(document.documentElement);
 
-    // Draws circle.
+    // Draws circle. The same --color-error-200 the hover card's unrated chip uses, so the "?" on the canvas and the
+    // "?" on the card that describes it are one mark in two places rather than two different reds (#4731).
     ctx.beginPath();
-    ctx.fillStyle = 'rgb(160, 45, 50, 0.9)';
+    // Trimmed: a custom property's value keeps the whitespace after the colon, and an unparseable fillStyle is
+    // silently ignored rather than throwing — the circle would just keep whatever color was set last.
+    ctx.fillStyle = rootStyle.getPropertyValue('--color-error-200').trim();
     ctx.ellipse(x - 15, y - 10.5, 8, 8, 0, 0, 2 * Math.PI);
     ctx.fill();
     ctx.closePath();
 
     // Draws text.
     ctx.beginPath();
-
-    // Canvas fonts can't resolve CSS variables, so the design system's --font-primary stack is read from :root.
-    // No --ui-scale here: this canvas keeps its fixed logical size and is scaled up by the browser.
-    ctx.font = `400 12px ${getComputedStyle(document.documentElement).getPropertyValue('--font-primary')}`;
+    ctx.font = `400 12px ${rootStyle.getPropertyValue('--font-primary')}`;
     ctx.fillStyle = 'rgb(255, 255, 255)';
     ctx.fillText('?', x - 17.5, y - 6);
     ctx.closePath();

--- a/public/js/validate/src/label/LabelVisibilityControl.js
+++ b/public/js/validate/src/label/LabelVisibilityControl.js
@@ -110,7 +110,6 @@ class LabelVisibilityControl {
   #setVisibilityButtons(text, icon, tooltip) {
     const htmlString = `${icon}<span>${text}</span>`;
     this.#labelVisibilityControlButton.html(htmlString).attr('data-ps-tooltip', tooltip);
-    // Absent on mobile, which has no label card. .attr() on an empty set is a no-op.
     this.#labelVisibilityButtonOnPano.html(htmlString).attr('data-ps-tooltip', tooltip);
   }
 

--- a/public/js/validate/src/label/LabelVisibilityControl.js
+++ b/public/js/validate/src/label/LabelVisibilityControl.js
@@ -39,8 +39,8 @@ class LabelVisibilityControl {
     this.#card = $('#label-card');
     this.#hideText = i18next.t('top-ui.visibility-control-hide');
     this.#showText = i18next.t('top-ui.visibility-control-show');
-    this.#hideTooltip = i18next.t('top-ui.visibility-control-tooltip-short-hide');
-    this.#showTooltip = i18next.t('top-ui.visibility-control-tooltip-short-show');
+    this.#hideTooltip = i18next.t('top-ui.visibility-control-tooltip-hide');
+    this.#showTooltip = i18next.t('top-ui.visibility-control-tooltip-show');
 
     // Set up the event listeners.
     this.#labelVisibilityControlButton.on('click', this.#clickAdjustLabel);
@@ -100,19 +100,18 @@ class LabelVisibilityControl {
    * The label is inserted as HTML, not text: the translations underline the keyboard shortcut inline (the English
    * ones are "<u>H</u>ide Label" / "S<u>h</u>ow Label"). It is a locale string, not user input.
    *
-   * Only the card's button gets a tooltip here. The top-left control carries a fuller sentence set from Twirl, and
-   * it does not reverse the way this one does — the tooltip has to turn over with the action, or it describes the
-   * opposite of what clicking now does.
+   * The tooltip turns over with them rather than being set once from Twirl: these buttons reverse meaning when the
+   * label is hidden, so a fixed string spends half its life describing the opposite of what clicking now does.
    *
    * @param {string} text    The action the buttons now offer, as translated markup.
    * @param {string} icon    Inline SVG for the eye icon that goes with it.
-   * @param {string} tooltip That same action spelled out, for the card button's tooltip.
+   * @param {string} tooltip That same action spelled out, for both buttons' tooltips.
    */
   #setVisibilityButtons(text, icon, tooltip) {
     const htmlString = `${icon}<span>${text}</span>`;
-    this.#labelVisibilityControlButton.html(htmlString);
-    this.#labelVisibilityButtonOnPano.html(htmlString);
-    this.#labelVisibilityButtonOnPano.attr('data-ps-tooltip', tooltip);
+    this.#labelVisibilityControlButton.html(htmlString).attr('data-ps-tooltip', tooltip);
+    // Absent on mobile, which has no label card. .attr() on an empty set is a no-op.
+    this.#labelVisibilityButtonOnPano.html(htmlString).attr('data-ps-tooltip', tooltip);
   }
 
   /**

--- a/public/js/validate/src/label/LabelVisibilityControl.js
+++ b/public/js/validate/src/label/LabelVisibilityControl.js
@@ -30,6 +30,8 @@ class LabelVisibilityControl {
   #card;
   #hideText;
   #showText;
+  #hideTooltip;
+  #showTooltip;
 
   constructor() {
     this.#labelVisibilityControlButton = $('#label-visibility-control-button');
@@ -37,6 +39,8 @@ class LabelVisibilityControl {
     this.#card = $('#label-card');
     this.#hideText = i18next.t('top-ui.visibility-control-hide');
     this.#showText = i18next.t('top-ui.visibility-control-show');
+    this.#hideTooltip = i18next.t('top-ui.visibility-control-tooltip-short-hide');
+    this.#showTooltip = i18next.t('top-ui.visibility-control-tooltip-short-show');
 
     // Set up the event listeners.
     this.#labelVisibilityControlButton.on('click', this.#clickAdjustLabel);
@@ -68,7 +72,7 @@ class LabelVisibilityControl {
    */
   unhideLabel() {
     this.#visible = true;
-    this.#setVisibilityButtons(this.#hideText, LabelVisibilityControl.#ICON_EYE_OFF);
+    this.#setVisibilityButtons(this.#hideText, LabelVisibilityControl.#ICON_EYE_OFF, this.#hideTooltip);
     // The marker is briefly absent while the viewer swaps (primary ↔ Pannellum); the button state above is what
     // renderPanoMarker's replacement will be read against, so it is set either way.
     svv.panoManager.getPanoMarker()?.marker_.classList.remove('label-marker--hidden');
@@ -85,7 +89,7 @@ class LabelVisibilityControl {
    */
   hideLabel() {
     this.#visible = false;
-    this.#setVisibilityButtons(this.#showText, LabelVisibilityControl.#ICON_EYE_ON);
+    this.#setVisibilityButtons(this.#showText, LabelVisibilityControl.#ICON_EYE_ON, this.#showTooltip);
     svv.panoManager.getPanoMarker()?.marker_.classList.add('label-marker--hidden');
   }
 
@@ -96,13 +100,19 @@ class LabelVisibilityControl {
    * The label is inserted as HTML, not text: the translations underline the keyboard shortcut inline (the English
    * ones are "<u>H</u>ide Label" / "S<u>h</u>ow Label"). It is a locale string, not user input.
    *
-   * @param {string} text The action the buttons now offer, as translated markup.
-   * @param {string} icon Inline SVG for the eye icon that goes with it.
+   * Only the card's button gets a tooltip here. The top-left control carries a fuller sentence set from Twirl, and
+   * it does not reverse the way this one does — the tooltip has to turn over with the action, or it describes the
+   * opposite of what clicking now does.
+   *
+   * @param {string} text    The action the buttons now offer, as translated markup.
+   * @param {string} icon    Inline SVG for the eye icon that goes with it.
+   * @param {string} tooltip That same action spelled out, for the card button's tooltip.
    */
-  #setVisibilityButtons(text, icon) {
+  #setVisibilityButtons(text, icon, tooltip) {
     const htmlString = `${icon}<span>${text}</span>`;
     this.#labelVisibilityControlButton.html(htmlString);
     this.#labelVisibilityButtonOnPano.html(htmlString);
+    this.#labelVisibilityButtonOnPano.attr('data-ps-tooltip', tooltip);
   }
 
   /**

--- a/public/locales/de/audit.json
+++ b/public/locales/de/audit.json
@@ -183,7 +183,8 @@
       "edit": "Bearbeiten"
     },
     "context-menu": {
-      "severity": "Zur Kennzeichnung eines Schweregrades bitte anklicken",
+      "rate-severity-prompt": "Zum Bewerten des Schweregrads anklicken",
+      "rate-quality-prompt": "Zum Bewerten der Qualität anklicken",
       "severity-shortcuts": "Drücken Sie die Tasten 1-3 für den Schweregrad",
       "label-popup-shortcuts": "Drücken Sie <tag-underline>{{c}}</tag-underline>, um einen Tag hinzuzufügen",
       "tag": {

--- a/public/locales/de/validate.json
+++ b/public/locales/de/validate.json
@@ -11,9 +11,8 @@
     },
     "visibility-control-hide": "Beschriftung ausblenden (<u>H</u>)",
     "visibility-control-show": "Beschriftung einblenden (<u>h</u>)",
-    "visibility-control-tooltip": "Blendet die Beschriftung vorübergehend aus, um besser zu sehen. (<u>H</u>)",
-    "visibility-control-tooltip-short-hide": "Blendet die Beschriftung aus, um besser zu sehen. (<u>H</u>)",
-    "visibility-control-tooltip-short-show": "Blendet die Beschriftung wieder ein. (<u>h</u>)"
+    "visibility-control-tooltip-hide": "Blendet die Beschriftung vorübergehend aus, um besser zu sehen. (<u>H</u>)",
+    "visibility-control-tooltip-show": "Blendet die Beschriftung wieder ein. (<u>h</u>)"
   },
   "validate-menu": {
     "disagree-reason": {

--- a/public/locales/de/validate.json
+++ b/public/locales/de/validate.json
@@ -11,7 +11,9 @@
     },
     "visibility-control-hide": "Beschriftung ausblenden (<u>H</u>)",
     "visibility-control-show": "Beschriftung einblenden (<u>h</u>)",
-    "visibility-control-tooltip": "Blende die Beschriftung vorübergehend aus, um den Gehweg dahinter zu sehen. Tastenkürzel: <b>H</b>"
+    "visibility-control-tooltip": "Blendet die Beschriftung vorübergehend aus, um besser zu sehen. (<u>H</u>)",
+    "visibility-control-tooltip-short-hide": "Blendet die Beschriftung aus, um besser zu sehen. (<u>H</u>)",
+    "visibility-control-tooltip-short-show": "Blendet die Beschriftung wieder ein. (<u>h</u>)"
   },
   "validate-menu": {
     "disagree-reason": {

--- a/public/locales/en/audit.json
+++ b/public/locales/en/audit.json
@@ -183,7 +183,8 @@
       "edit": "Edit"
     },
     "context-menu": {
-      "severity": "Please click to label a severity",
+      "rate-severity-prompt": "Please click to rate severity",
+      "rate-quality-prompt": "Please click to rate quality",
       "severity-shortcuts": "Press keys 1-3 for severity",
       "label-popup-shortcuts": "Press <tag-underline>{{c}}</tag-underline> to add tag",
       "tag": {

--- a/public/locales/en/validate.json
+++ b/public/locales/en/validate.json
@@ -11,9 +11,8 @@
     },
     "visibility-control-hide": "<u>H</u>ide Label",
     "visibility-control-show": "S<u>h</u>ow Label",
-    "visibility-control-tooltip": "Temporarily <u>h</u>ide the label to see better.",
-    "visibility-control-tooltip-short-hide": "<u>H</u>ides the label to see better.",
-    "visibility-control-tooltip-short-show": "S<u>h</u>ows the label again."
+    "visibility-control-tooltip-hide": "Temporarily <u>h</u>ide the label to see better.",
+    "visibility-control-tooltip-show": "S<u>h</u>ow the label again."
   },
   "validate-menu": {
     "disagree-reason": {

--- a/public/locales/en/validate.json
+++ b/public/locales/en/validate.json
@@ -11,7 +11,9 @@
     },
     "visibility-control-hide": "<u>H</u>ide Label",
     "visibility-control-show": "S<u>h</u>ow Label",
-    "visibility-control-tooltip": "Temporarily hide the label so you can see the sidewalk behind it. Shortcut: <b>H</b>"
+    "visibility-control-tooltip": "Temporarily <u>h</u>ide the label to see better.",
+    "visibility-control-tooltip-short-hide": "<u>H</u>ides the label to see better.",
+    "visibility-control-tooltip-short-show": "S<u>h</u>ows the label again."
   },
   "validate-menu": {
     "disagree-reason": {

--- a/public/locales/es/audit.json
+++ b/public/locales/es/audit.json
@@ -183,7 +183,8 @@
       "edit": "Editar"
     },
     "context-menu": {
-      "severity": "Por favor haz clic para etiquetar la gravedad",
+      "rate-severity-prompt": "Haz clic para valorar la gravedad",
+      "rate-quality-prompt": "Haz clic para valorar la calidad",
       "severity-shortcuts": "Presiona las teclas 1-3 para gravedad",
       "label-popup-shortcuts": "Presiona <tag-underline>{{c}}</tag-underline> para agregar la etiqueta",
       "tag": {

--- a/public/locales/es/validate.json
+++ b/public/locales/es/validate.json
@@ -11,9 +11,8 @@
     },
     "visibility-control-hide": "Ocultar (<u>H</u>)",
     "visibility-control-show": "Mostrar (<u>H</u>)",
-    "visibility-control-tooltip": "Oculta temporalmente la etiqueta para ver mejor. (<u>H</u>)",
-    "visibility-control-tooltip-short-hide": "Oculta la etiqueta para ver mejor. (<u>H</u>)",
-    "visibility-control-tooltip-short-show": "Vuelve a mostrar la etiqueta. (<u>H</u>)"
+    "visibility-control-tooltip-hide": "Oculta temporalmente la etiqueta para ver mejor. (<u>H</u>)",
+    "visibility-control-tooltip-show": "Vuelve a mostrar la etiqueta. (<u>H</u>)"
   },
   "validate-menu": {
     "disagree-reason": {

--- a/public/locales/es/validate.json
+++ b/public/locales/es/validate.json
@@ -11,7 +11,9 @@
     },
     "visibility-control-hide": "Ocultar (<u>H</u>)",
     "visibility-control-show": "Mostrar (<u>H</u>)",
-    "visibility-control-tooltip": "Oculta la etiqueta temporalmente para ver la acera que hay detrás. Atajo: <b>H</b>"
+    "visibility-control-tooltip": "Oculta temporalmente la etiqueta para ver mejor. (<u>H</u>)",
+    "visibility-control-tooltip-short-hide": "Oculta la etiqueta para ver mejor. (<u>H</u>)",
+    "visibility-control-tooltip-short-show": "Vuelve a mostrar la etiqueta. (<u>H</u>)"
   },
   "validate-menu": {
     "disagree-reason": {

--- a/public/locales/nl/audit.json
+++ b/public/locales/nl/audit.json
@@ -183,7 +183,8 @@
       "edit": "Bewerken"
     },
     "context-menu": {
-      "severity": "Klik om de mate van  ernst te labelen",
+      "rate-severity-prompt": "Klik om de ernst te beoordelen",
+      "rate-quality-prompt": "Klik om de kwaliteit te beoordelen",
       "severity-shortcuts": "Druk toetsen 1-3 voor de beoordeling van de ernst",
       "label-popup-shortcuts": "Druk <tag-underline>{{c}}</tag-underline> om een tag toe te voegen",
       "tag": {

--- a/public/locales/nl/validate.json
+++ b/public/locales/nl/validate.json
@@ -11,9 +11,8 @@
     },
     "visibility-control-hide": "Verberg Label (<u>H</u>)",
     "visibility-control-show": "Toon Label (<u>H</u>)",
-    "visibility-control-tooltip": "Verbergt het label tijdelijk om beter te zien. (<u>H</u>)",
-    "visibility-control-tooltip-short-hide": "Verbergt het label om beter te zien. (<u>H</u>)",
-    "visibility-control-tooltip-short-show": "Toont het label weer. (<u>H</u>)"
+    "visibility-control-tooltip-hide": "Verbergt het label tijdelijk om beter te zien. (<u>H</u>)",
+    "visibility-control-tooltip-show": "Toont het label weer. (<u>H</u>)"
   },
   "validate-menu": {
     "disagree-reason": {

--- a/public/locales/nl/validate.json
+++ b/public/locales/nl/validate.json
@@ -11,7 +11,9 @@
     },
     "visibility-control-hide": "Verberg Label (<u>H</u>)",
     "visibility-control-show": "Toon Label (<u>H</u>)",
-    "visibility-control-tooltip": "Verberg het label tijdelijk zodat je de stoep erachter kunt zien. Sneltoets: <b>H</b>"
+    "visibility-control-tooltip": "Verbergt het label tijdelijk om beter te zien. (<u>H</u>)",
+    "visibility-control-tooltip-short-hide": "Verbergt het label om beter te zien. (<u>H</u>)",
+    "visibility-control-tooltip-short-show": "Toont het label weer. (<u>H</u>)"
   },
   "validate-menu": {
     "disagree-reason": {

--- a/public/locales/pt-BR/audit.json
+++ b/public/locales/pt-BR/audit.json
@@ -183,7 +183,8 @@
       "edit": "Editar"
     },
     "context-menu": {
-      "severity": "Por favor, clique para rotular uma gravidade",
+      "rate-severity-prompt": "Clique para avaliar a gravidade",
+      "rate-quality-prompt": "Clique para avaliar a qualidade",
       "severity-shortcuts": "Pressione as teclas 1-3 para gravidade",
       "label-popup-shortcuts": "Pressione <tag-underline>{{c}}</tag-underline> para adicionar etiqueta",
       "tag": {

--- a/public/locales/pt-BR/validate.json
+++ b/public/locales/pt-BR/validate.json
@@ -11,9 +11,8 @@
     },
     "visibility-control-hide": "Ocultar rótulo (<u>H</u>)",
     "visibility-control-show": "Mostrar rótulo (<u>H</u>)",
-    "visibility-control-tooltip": "Oculta temporariamente o rótulo para ver melhor. (<u>H</u>)",
-    "visibility-control-tooltip-short-hide": "Oculta o rótulo para ver melhor. (<u>H</u>)",
-    "visibility-control-tooltip-short-show": "Mostra o rótulo novamente. (<u>H</u>)"
+    "visibility-control-tooltip-hide": "Oculta temporariamente o rótulo para ver melhor. (<u>H</u>)",
+    "visibility-control-tooltip-show": "Mostra o rótulo novamente. (<u>H</u>)"
   },
   "validate-menu": {
     "disagree-reason": {

--- a/public/locales/pt-BR/validate.json
+++ b/public/locales/pt-BR/validate.json
@@ -11,7 +11,9 @@
     },
     "visibility-control-hide": "Ocultar rótulo (<u>H</u>)",
     "visibility-control-show": "Mostrar rótulo (<u>H</u>)",
-    "visibility-control-tooltip": "Oculte o rótulo temporariamente para ver a calçada atrás dele. Atalho: <b>H</b>"
+    "visibility-control-tooltip": "Oculta temporariamente o rótulo para ver melhor. (<u>H</u>)",
+    "visibility-control-tooltip-short-hide": "Oculta o rótulo para ver melhor. (<u>H</u>)",
+    "visibility-control-tooltip-short-show": "Mostra o rótulo novamente. (<u>H</u>)"
   },
   "validate-menu": {
     "disagree-reason": {

--- a/public/locales/zh-TW/audit.json
+++ b/public/locales/zh-TW/audit.json
@@ -182,7 +182,8 @@
       "edit": "編輯"
     },
     "context-menu": {
-      "severity": "請點選並標記問題嚴重度",
+      "rate-severity-prompt": "請點選以評定嚴重度",
+      "rate-quality-prompt": "請點選以評定品質",
       "severity-shortcuts": "從1-3選擇品質",
       "label-popup-shortcuts": "點選<tag-underline>{{c}}</tag-underline>以增加標籤",
       "tag": {

--- a/public/locales/zh-TW/validate.json
+++ b/public/locales/zh-TW/validate.json
@@ -11,7 +11,9 @@
     },
     "visibility-control-hide": "隱藏標記<u>H</u>",
     "visibility-control-show": "顯示標記<u>h</u>",
-    "visibility-control-tooltip": "暫時隱藏標記，以便看清後方的人行道。快速鍵：<b>H</b>"
+    "visibility-control-tooltip": "暫時隱藏標記以看得更清楚。(<u>H</u>)",
+    "visibility-control-tooltip-short-hide": "隱藏標記以看得更清楚。(<u>H</u>)",
+    "visibility-control-tooltip-short-show": "重新顯示標記。(<u>h</u>)"
   },
   "validate-menu": {
     "disagree-reason": {

--- a/public/locales/zh-TW/validate.json
+++ b/public/locales/zh-TW/validate.json
@@ -11,9 +11,8 @@
     },
     "visibility-control-hide": "隱藏標記<u>H</u>",
     "visibility-control-show": "顯示標記<u>h</u>",
-    "visibility-control-tooltip": "暫時隱藏標記以看得更清楚。(<u>H</u>)",
-    "visibility-control-tooltip-short-hide": "隱藏標記以看得更清楚。(<u>H</u>)",
-    "visibility-control-tooltip-short-show": "重新顯示標記。(<u>h</u>)"
+    "visibility-control-tooltip-hide": "暫時隱藏標記以看得更清楚。(<u>H</u>)",
+    "visibility-control-tooltip-show": "重新顯示標記。(<u>h</u>)"
   },
   "validate-menu": {
     "disagree-reason": {

--- a/test/js/psTooltip.test.js
+++ b/test/js/psTooltip.test.js
@@ -1,0 +1,159 @@
+/**
+ * Tests for the shared tooltip (public/js/common/psTooltip.js).
+ *
+ * Covers the two behaviors that a screenshot pass would not catch, because both only show up in motion or at an
+ * edge: the placement preference (above by default, below on request, each yielding to the side that has room) and
+ * the live refresh when a trigger's text changes while its tooltip is open. That second one is the Validate
+ * Hide/Show toggle — it relabels itself on click with the pointer still resting on it, so a card that only read the
+ * text on open would sit there describing the state the user just left.
+ *
+ * psTooltip.js is an IIFE that wires document listeners on load, so the test evaluates the source directly.
+ * jsdom has no layout engine, so getBoundingClientRect is stubbed: the tooltip reports the size each test states,
+ * and triggers report the rect they were assigned.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const SOURCE = fs.readFileSync(
+    path.resolve(__dirname, '..', '..', 'public/js/common/psTooltip.js'), 'utf8'
+);
+
+// Matches the constants in psTooltip.js.
+const TRIGGER_GAP = 8;
+const VIEWPORT_MARGIN = 8;
+const TAIL_INSET = 12; // TAIL_HALF_WIDTH_PX + CORNER_RADIUS_PX
+
+const VIEWPORT_WIDTH = 1000;
+const VIEWPORT_HEIGHT = 800;
+const CARD_WIDTH = 200;
+const CARD_HEIGHT = 40;
+
+/** Installs a layout stub: the tooltip card reports a fixed size, every other element the rect it was given. */
+function stubLayout() {
+    Element.prototype.getBoundingClientRect = function () {
+        if (this.classList.contains('ps-tooltip')) {
+            return {
+                left: 0, top: 0, right: CARD_WIDTH, bottom: CARD_HEIGHT, width: CARD_WIDTH, height: CARD_HEIGHT,
+            };
+        }
+        const r = this._rect || { left: 0, top: 0, width: 0, height: 0 };
+        return { ...r, right: r.left + r.width, bottom: r.top + r.height };
+    };
+}
+
+/** Adds a trigger at `rect` carrying `text`, plus any extra attributes. */
+function addTrigger(rect, text, attrs = {}) {
+    const el = document.createElement('button');
+    el.setAttribute('data-ps-tooltip', text);
+    for (const [k, v] of Object.entries(attrs)) el.setAttribute(k, v);
+    el._rect = rect;
+    document.body.appendChild(el);
+    return el;
+}
+
+/** Opens a trigger's tooltip via the keyboard path, which skips the hover delay. */
+function open(trigger) {
+    trigger.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+    return document.getElementById('ps-tooltip');
+}
+
+beforeEach(() => {
+    document.body.innerHTML = '';
+    window.innerWidth = VIEWPORT_WIDTH;
+    window.innerHeight = VIEWPORT_HEIGHT;
+    stubLayout();
+    new Function(SOURCE)();
+});
+
+describe('psTooltip placement', () => {
+    test('opens above the trigger by default', () => {
+        const trigger = addTrigger({ left: 400, top: 300, width: 100, height: 30 }, 'above');
+        const card = open(trigger);
+
+        expect(card.style.top).toBe(`${300 - CARD_HEIGHT - TRIGGER_GAP}px`);
+        expect(card.classList.contains('ps-tooltip--flipped')).toBe(false);
+    });
+
+    test('flips below when there is no room above', () => {
+        const trigger = addTrigger({ left: 400, top: 4, width: 100, height: 30 }, 'no room');
+        const card = open(trigger);
+
+        expect(card.style.top).toBe(`${34 + TRIGGER_GAP}px`);
+        expect(card.classList.contains('ps-tooltip--flipped')).toBe(true);
+    });
+
+    test('opens below when the trigger asks for it', () => {
+        const trigger = addTrigger(
+            { left: 400, top: 300, width: 100, height: 30 }, 'below', { 'data-ps-tooltip-placement': 'bottom' }
+        );
+        const card = open(trigger);
+
+        expect(card.style.top).toBe(`${330 + TRIGGER_GAP}px`);
+        expect(card.classList.contains('ps-tooltip--flipped')).toBe(true);
+    });
+
+    test('a bottom-placed tooltip still yields to the viewport floor', () => {
+        // Asking for below orders the two sides; it does not pin the card off the bottom of the screen.
+        const trigger = addTrigger(
+            { left: 400, top: 770, width: 100, height: 25 }, 'below', { 'data-ps-tooltip-placement': 'bottom' }
+        );
+        const card = open(trigger);
+
+        expect(card.style.top).toBe(`${770 - CARD_HEIGHT - TRIGGER_GAP}px`);
+        expect(card.classList.contains('ps-tooltip--flipped')).toBe(false);
+    });
+
+    test('clamps into the viewport but keeps the tail on the trigger', () => {
+        const trigger = addTrigger({ left: 0, top: 300, width: 40, height: 30 }, 'at the edge');
+        const card = open(trigger);
+
+        // Centering would put the card at -80; it clamps to the margin instead.
+        expect(card.style.left).toBe(`${VIEWPORT_MARGIN}px`);
+        // The tail stays aimed at the trigger's center (20px), not the card's, and clears the rounded corner.
+        expect(card.style.getPropertyValue('--ps-tooltip-tail-left')).toBe(`${TAIL_INSET}px`);
+    });
+
+    test('holds the tail off the far corner too', () => {
+        const trigger = addTrigger({ left: 970, top: 300, width: 30, height: 30 }, 'far edge');
+        const card = open(trigger);
+
+        expect(card.style.getPropertyValue('--ps-tooltip-tail-left')).toBe(`${CARD_WIDTH - TAIL_INSET}px`);
+    });
+});
+
+describe('psTooltip live refresh', () => {
+    test('re-renders when the open trigger relabels itself', async () => {
+        const trigger = addTrigger({ left: 400, top: 300, width: 100, height: 30 }, 'Hide the label.');
+        const card = open(trigger);
+        expect(card.innerHTML).toBe('Hide the label.');
+
+        trigger.setAttribute('data-ps-tooltip', 'Show the label again.');
+        await Promise.resolve(); // MutationObserver callbacks are microtasks.
+
+        expect(card.innerHTML).toBe('Show the label again.');
+    });
+
+    test('re-places, not just re-fills — the new string is a different width', async () => {
+        const trigger = addTrigger({ left: 0, top: 300, width: 40, height: 30 }, 'Hide the label.');
+        const card = open(trigger);
+
+        card.style.setProperty('--ps-tooltip-tail-left', '999px'); // Sentinel: a re-fill alone would leave this.
+        trigger.setAttribute('data-ps-tooltip', 'Show the label again.');
+        await Promise.resolve();
+
+        expect(card.style.getPropertyValue('--ps-tooltip-tail-left')).toBe(`${TAIL_INSET}px`);
+    });
+
+    test('stops watching a trigger once its tooltip is dismissed', async () => {
+        const trigger = addTrigger({ left: 400, top: 300, width: 100, height: 30 }, 'Hide the label.');
+        const card = open(trigger);
+
+        document.dispatchEvent(new FocusEvent('focusout', { bubbles: true }));
+        trigger.setAttribute('data-ps-tooltip', 'Show the label again.');
+        await Promise.resolve();
+
+        expect(card.classList.contains('ps-tooltip--visible')).toBe(false);
+        expect(card.innerHTML).toBe('Hide the label.');
+    });
+});

--- a/test/js/psTooltip.test.js
+++ b/test/js/psTooltip.test.js
@@ -58,12 +58,43 @@ function open(trigger) {
     return document.getElementById('ps-tooltip');
 }
 
+/**
+ * Evaluates psTooltip.js, returning a teardown that detaches the listeners that evaluation registered.
+ *
+ * Each test needs its own evaluation, because the module keeps `activeTrigger` and its card in a closure with no
+ * way to reset them from outside. But it wires six document/window listeners on load, so without the teardown
+ * every test would leave its set attached and the file would finish with nine of them stacked up — harmless here,
+ * since a stale set only ever touches its own detached card, but not something to hand to the next test that
+ * counts calls. addEventListener is patched on EventTarget.prototype so it catches document and window alike.
+ * @returns {function(): void} Detaches every listener the evaluation added.
+ */
+function loadPsTooltip() {
+    const added = [];
+    const original = EventTarget.prototype.addEventListener;
+    EventTarget.prototype.addEventListener = function (...args) {
+        added.push([this, args]);
+        return original.apply(this, args);
+    };
+    try {
+        new Function(SOURCE)();
+    } finally {
+        EventTarget.prototype.addEventListener = original;
+    }
+    return () => added.forEach(([target, args]) => target.removeEventListener(...args));
+}
+
+let unloadPsTooltip;
+
 beforeEach(() => {
     document.body.innerHTML = '';
     window.innerWidth = VIEWPORT_WIDTH;
     window.innerHeight = VIEWPORT_HEIGHT;
     stubLayout();
-    new Function(SOURCE)();
+    unloadPsTooltip = loadPsTooltip();
+});
+
+afterEach(() => {
+    unloadPsTooltip();
 });
 
 describe('psTooltip placement', () => {


### PR DESCRIPTION
Closes #4731.

Follow-up to #4720 / #4725, addressing @misaugstad's review of the label hover card. Items 2 (section separators) and 3 (the label-type icon) were declined in the issue thread and are untouched here.

## The review items

**1. "Please click to label a severity"** was static markup, so it asked *every* type for a severity. The same 1–3 scale means opposite things either side of `util.misc.isPositiveLabelType` — a curb ramp is rated for quality — so this was asking the wrong question, not just phrasing it awkwardly. `Label.js` now picks the prompt the way `ContextMenu.#updateRatingText` already picks its rating header. Reworded to "rate" per the review, and split into `rate-severity-prompt` / `rate-quality-prompt` across all six locales.

**4. The two reds.** The canvas "?" was a hardcoded `rgb(160, 45, 50, 0.9)` against the card chip's `--color-error-200`, so the same mark appeared in two different reds depending on where you looked. The canvas side was the wrong one; it now reads the token off `:root`, as it already did for `--font-primary` a few lines down.

> ⚠️ `getPropertyValue` keeps the whitespace after the colon, and an unparseable `ctx.fillStyle` is **silently ignored** — the circle would just keep whatever color was set last. Hence the `.trim()`, and hence verifying it against a sentinel rather than by eye.

**5. Two tooltips on the rating ⓘ.** `#updateRatingText` set both `title` and `data-original-title`. Bootstrap moves `title` into `data-original-title` when it initializes the tooltip and blanks the attribute, so writing `title` back afterwards restored the browser's own tooltip *on top of* Bootstrap's. Every other ⓘ sets `title` from Twirl, before that init, which is why only this one doubled. Now sets `data-original-title` only. Left on Bootstrap deliberately: the tags ⓘ sits right beside it, and migrating one of the pair would render two adjacent icons in two different tooltip styles.

Its `alt` swaps with the dimension too — the static one said "More information about severity" whichever dimension was on screen, and that string is the icon's accessible name.

**6. The Hide Label button.** The hover state Mikey asked for had been removed on purpose (a second panel opening over the card you are reading), so the fix went into the shared tooltip instead.

## The shared tooltip

`psTooltip` was a white card — a fourth white surface stacked on the label card, the context menu and the pano overlays, which reads as another panel rather than as a passing note. It is now the same `--color-asphalt-500` surface as the dark toast (`common/toast.css`); the two are the same idea at two sizes. White-on-dark goes 4.6:1 → 13.9:1. Type drops 14px → 12px, matching `.ps-toast--compact`'s message.

It also grows a tail, and two behaviors worth calling out:

- **The tail's x comes from the JS, not a flat 50%.** The card is clamped to the viewport, so near a screen edge it stops being centered on its trigger and a fixed tail would point at empty space.
- **`data-ps-tooltip-placement="bottom"`**, for a trigger at the foot of a panel the tooltip must not cover — which is exactly the label card's Hide button. It *orders* the two sides rather than pinning one, so a card near the bottom of the window still yields and opens upward.

The trigger gap now scales with `--ui-scale`; it was a bare constant while CSS scaled the tail, so above ~1.3× the tail overlapped its own trigger. Same mismatch as the `anchorPanelToLabel` finding in #4720's review.

**Both visibility toggles now swap their tooltip with their label.** They reverse meaning once the label is hidden, so a fixed string spends half its life describing the opposite of what clicking does — and WCAG 2.5.3 (Label in Name) means the accessible name and the visible label cannot disagree. That also collapsed two near-identical string pairs into one; the long/short split stopped meaning anything once the long one was trimmed.

**An open tooltip now refreshes when its trigger relabels itself.** The card read `data-ps-tooltip` once, on open — but the toggle rewrites it on click with the pointer still resting on the button, so the tooltip stays up showing the state the user just left. A change re-runs the whole placement, not just the text: the new string is a different width, so re-filling alone would leave the card centered and tailed for the old one.

## Testing

`test/js/psTooltip.test.js` — 9 cases over what a screenshot pass cannot reach: placement preference, the yield at each viewport edge, the tail clamp, and the live refresh. Each was **mutation-checked** against a deliberately broken `psTooltip` (observer removed; "bottom" pinned instead of ordered; tail aimed at the card's center) and every break was caught by the tests that should catch it.

Suite: 331 passing. ESLint / Stylelint / HTMLHint / locale parity all clean.

Geometry and colour were verified in headless Chrome against the real stylesheets — placement in all five configurations, the tail junction at 1× and at the 1.8× `applyToolScale` cap, and the canvas red against the card chip. GSV-dependent behavior (hovering an actual label in Explore) is not automatable and needs a visual pass.

## QA checklist

- [ ] **Explore** — hover an unrated *problem* label (obstacle, surface problem): prompt reads "Please click to rate severity", and the "?" on the card is the same red as the "?" on the canvas beside it.
- [ ] **Explore** — hover an unrated *positive* label (curb ramp, crosswalk): prompt reads "…rate quality".
- [ ] **Explore** — open the context menu and hover the ⓘ beside RATE SEVERITY / RATE QUALITY: exactly one tooltip, in our style.
- [ ] **Validate** — hover the card's Hide Label button: tooltip opens *below* it and covers no part of the card.
- [ ] **Validate** — click Hide Label without moving the pointer: the tooltip text flips to "Show the label again." in place.
- [ ] **Validate** — same for the top-left control.
- [ ] Zoom the browser / resize so `--ui-scale` moves off 1: the tail still meets its trigger without overlapping it.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-opus-5[1m])
