### PR TITLE
Say when the daily story cap lifts, instead of "tomorrow"

### DIFF
--- a/app/controllers/StoryController.scala
+++ b/app/controllers/StoryController.scala
@@ -91,12 +91,12 @@ class StoryController @Inject() (
       def dataPart(name: String): Option[String] = request.body.dataParts.get(name).flatMap(_.headOption)
 
       // Inert-until-enabled IP burst layer on top of the always-on per-user DB limit in StoryService.
+      val ipKey   = s"story-submit:ip:${request.ipAddress}"
       val ipLimit = rateLimiter.limit("story-submit")
-      if (!rateLimiter.allow(s"story-submit:ip:${request.ipAddress}", ipLimit)) {
-        Future.successful(
-          TooManyRequests(StoryFormats.rejectionToJson(StoryRejection.RateLimited))
-            .withHeaders("Retry-After" -> ipLimit.window.toSeconds.toString)
-        )
+      if (!rateLimiter.allow(ipKey, ipLimit)) {
+        // Time left in this IP's window, not the whole window length — the caller is already partway through it.
+        val retryAfter = rateLimiter.retryAfterSeconds(ipKey).orElse(Some(ipLimit.window.toSeconds))
+        Future.successful(rejectionResult(StoryRejection.RateLimited(retryAfter)))
       } else {
         dataPart("label_id").flatMap(s => Try(s.toInt).toOption) match {
           case None          => Future.successful(BadRequest(Json.obj("error" -> "story.error.label-id-missing")))
@@ -131,12 +131,12 @@ class StoryController @Inject() (
 
       def dataPart(name: String): Option[String] = request.body.dataParts.get(name).flatMap(_.headOption)
 
+      val ipKey   = s"story-submit:ip:${request.ipAddress}"
       val ipLimit = rateLimiter.limit("story-submit")
-      if (!rateLimiter.allow(s"story-submit:ip:${request.ipAddress}", ipLimit)) {
-        Future.successful(
-          TooManyRequests(StoryFormats.rejectionToJson(StoryRejection.RateLimited))
-            .withHeaders("Retry-After" -> ipLimit.window.toSeconds.toString)
-        )
+      if (!rateLimiter.allow(ipKey, ipLimit)) {
+        // Time left in this IP's window, not the whole window length — the caller is already partway through it.
+        val retryAfter = rateLimiter.retryAfterSeconds(ipKey).orElse(Some(ipLimit.window.toSeconds))
+        Future.successful(rejectionResult(StoryRejection.RateLimited(retryAfter)))
       } else {
         val text            = dataPart("text").getOrElse("")
         val displayNameMode = dataPart("display_name_mode").getOrElse(Story.DisplayNameAnonymous)
@@ -260,7 +260,9 @@ class StoryController @Inject() (
       case StoryRejection.LabelNotFound => NotFound(body)
       case StoryRejection.StoryNotFound => NotFound(body)
       case StoryRejection.AlreadyExists => Conflict(body)
-      case StoryRejection.RateLimited   => TooManyRequests(body)
+      // Retry-After is the standard companion to a 429; the body carries the same number for the composer's copy.
+      case StoryRejection.RateLimited(retryAfter) =>
+        retryAfter.foldLeft(TooManyRequests(body))((res, secs) => res.withHeaders("Retry-After" -> secs.toString))
       case StoryRejection.PhotoTooLarge => EntityTooLarge(body)
       case _                            => BadRequest(body)
     }

--- a/app/controllers/StoryController.scala
+++ b/app/controllers/StoryController.scala
@@ -96,7 +96,7 @@ class StoryController @Inject() (
       if (!rateLimiter.allow(ipKey, ipLimit)) {
         // Time left in this IP's window, not the whole window length — the caller is already partway through it.
         val retryAfter = rateLimiter.retryAfterSeconds(ipKey).orElse(Some(ipLimit.window.toSeconds))
-        Future.successful(rejectionResult(StoryRejection.RateLimited(retryAfter)))
+        Future.successful(rejectionResult(StoryRejection.RateLimitedIp(retryAfter)))
       } else {
         dataPart("label_id").flatMap(s => Try(s.toInt).toOption) match {
           case None          => Future.successful(BadRequest(Json.obj("error" -> "story.error.label-id-missing")))
@@ -136,7 +136,7 @@ class StoryController @Inject() (
       if (!rateLimiter.allow(ipKey, ipLimit)) {
         // Time left in this IP's window, not the whole window length — the caller is already partway through it.
         val retryAfter = rateLimiter.retryAfterSeconds(ipKey).orElse(Some(ipLimit.window.toSeconds))
-        Future.successful(rejectionResult(StoryRejection.RateLimited(retryAfter)))
+        Future.successful(rejectionResult(StoryRejection.RateLimitedIp(retryAfter)))
       } else {
         val text            = dataPart("text").getOrElse("")
         val displayNameMode = dataPart("display_name_mode").getOrElse(Story.DisplayNameAnonymous)
@@ -256,15 +256,17 @@ class StoryController @Inject() (
   /** Maps a submission rejection to its HTTP status; the body carries the i18n key + English fallback. */
   private def rejectionResult(rejection: StoryRejection) = {
     val body = StoryFormats.rejectionToJson(rejection)
+    // Retry-After is the standard companion to a 429; the body carries the same number for the composer's copy.
+    def tooMany(retryAfter: Option[Long]) =
+      retryAfter.foldLeft(TooManyRequests(body))((res, secs) => res.withHeaders("Retry-After" -> secs.toString))
     rejection match {
-      case StoryRejection.LabelNotFound => NotFound(body)
-      case StoryRejection.StoryNotFound => NotFound(body)
-      case StoryRejection.AlreadyExists => Conflict(body)
-      // Retry-After is the standard companion to a 429; the body carries the same number for the composer's copy.
-      case StoryRejection.RateLimited(retryAfter) =>
-        retryAfter.foldLeft(TooManyRequests(body))((res, secs) => res.withHeaders("Retry-After" -> secs.toString))
-      case StoryRejection.PhotoTooLarge => EntityTooLarge(body)
-      case _                            => BadRequest(body)
+      case StoryRejection.LabelNotFound             => NotFound(body)
+      case StoryRejection.StoryNotFound             => NotFound(body)
+      case StoryRejection.AlreadyExists             => Conflict(body)
+      case StoryRejection.RateLimited(retryAfter)   => tooMany(retryAfter)
+      case StoryRejection.RateLimitedIp(retryAfter) => tooMany(retryAfter)
+      case StoryRejection.PhotoTooLarge             => EntityTooLarge(body)
+      case _                                        => BadRequest(body)
     }
   }
 }

--- a/app/formats/json/StoryFormats.scala
+++ b/app/formats/json/StoryFormats.scala
@@ -77,8 +77,9 @@ object StoryFormats {
       case StoryRejection.TextTooLong(maxLength)    => base + ("max" -> JsNumber(maxLength))
       case StoryRejection.AltTextTooLong(maxLength) => base + ("max" -> JsNumber(maxLength))
       // How long until the next submission slot opens, so the composer can say it rather than guess "tomorrow".
-      case StoryRejection.RateLimited(Some(secs)) => base + ("retry_after_seconds" -> JsNumber(secs))
-      case _                                      => base
+      case StoryRejection.RateLimited(Some(secs))   => base + ("retry_after_seconds" -> JsNumber(secs))
+      case StoryRejection.RateLimitedIp(Some(secs)) => base + ("retry_after_seconds" -> JsNumber(secs))
+      case _                                        => base
     }
   }
 }

--- a/app/formats/json/StoryFormats.scala
+++ b/app/formats/json/StoryFormats.scala
@@ -76,7 +76,9 @@ object StoryFormats {
       // (the composer may not have fetched /stories — and its max_text_length — before submitting).
       case StoryRejection.TextTooLong(maxLength)    => base + ("max" -> JsNumber(maxLength))
       case StoryRejection.AltTextTooLong(maxLength) => base + ("max" -> JsNumber(maxLength))
-      case _                                        => base
+      // How long until the next submission slot opens, so the composer can say it rather than guess "tomorrow".
+      case StoryRejection.RateLimited(Some(secs)) => base + ("retry_after_seconds" -> JsNumber(secs))
+      case _                                      => base
     }
   }
 }

--- a/app/models/story/StoryTable.scala
+++ b/app/models/story/StoryTable.scala
@@ -128,6 +128,30 @@ class StoryTable @Inject() (
     stories.filter(s => s.userId === userId && s.createdAt >= since).length.result
   }
 
+  /**
+   * When the oldest story still counting against the user's daily cap was posted — the one whose expiry from the
+   * rolling window frees the next slot, so the composer can tell the user how long that is.
+   *
+   * Skips `maxPerDay - 1` rows from the newest end rather than simply taking the oldest in the window, so it stays
+   * right when the user is *over* the cap (which happens whenever the configured cap is lowered): with C stories in
+   * the window and a cap of N, C - N + 1 of them have to age out, and this is the newest of those.
+   *
+   * @param userId    The submitting user.
+   * @param since     Start of the rolling window (now - 24h).
+   * @param maxPerDay The configured cap.
+   * @return          The story's timestamp, or None if the user is under the cap.
+   */
+  def nthNewestInWindowAt(userId: String, since: OffsetDateTime, maxPerDay: Int): DBIO[Option[OffsetDateTime]] = {
+    stories
+      .filter(s => s.userId === userId && s.createdAt >= since)
+      .sortBy(_.createdAt.desc)
+      .drop(math.max(0, maxPerDay - 1))
+      .take(1)
+      .map(_.createdAt)
+      .result
+      .headOption
+  }
+
   def getMediaForStory(storyId: Int): DBIO[Seq[StoryMedia]] = {
     storyMedia.filter(_.storyId === storyId).result
   }

--- a/app/models/story/StoryViewModels.scala
+++ b/app/models/story/StoryViewModels.scala
@@ -131,6 +131,17 @@ object StoryRejection {
         "story.error.rate-limited",
         "You've published as many stories as we allow in a day — please try again later."
       )
+
+  /**
+   * The IP burst layer (`rate-limit.story-submit`) refused the request. Distinct from [[RateLimited]] because the
+   * reader may have published nothing themselves — the IP can be a whole building behind one NAT — so the copy has
+   * to blame the network, not the person. `retryAfterSeconds` is the time left in the IP's current window.
+   */
+  case class RateLimitedIp(retryAfterSeconds: Option[Long])
+      extends StoryRejection(
+        "story.error.rate-limited-ip",
+        "Too many stories have been submitted from your network recently — please try again later."
+      )
   case object StoryNotFound
       extends StoryRejection("story.error.story-not-found", "That story doesn't exist or isn't yours.")
   case object PhotoTooLarge extends StoryRejection("story.error.photo-too-large", "That photo is too large to upload.")

--- a/app/models/story/StoryViewModels.scala
+++ b/app/models/story/StoryViewModels.scala
@@ -119,8 +119,18 @@ object StoryRejection {
       extends StoryRejection("story.error.invalid-display-name", "Invalid display-name option.")
   case object AlreadyExists
       extends StoryRejection("story.error.already-exists", "You've already shared a story on this label.")
-  case object RateLimited
-      extends StoryRejection("story.error.rate-limited", "You've shared several stories recently — try again tomorrow.")
+
+  /**
+   * The daily submission cap is a *rolling* 24 hours from each story, so there is no "tomorrow" to point at: a slot
+   * frees up 24h after the oldest story still counting. `retryAfterSeconds` is how long that is, so the composer can
+   * say it as a duration — true in every timezone, and needing none. None when the wait isn't known (the IP burst
+   * layer only knows its own window).
+   */
+  case class RateLimited(retryAfterSeconds: Option[Long])
+      extends StoryRejection(
+        "story.error.rate-limited",
+        "You've published as many stories as we allow in a day — please try again later."
+      )
   case object StoryNotFound
       extends StoryRejection("story.error.story-not-found", "That story doesn't exist or isn't yours.")
   case object PhotoTooLarge extends StoryRejection("story.error.photo-too-large", "That photo is too large to upload.")

--- a/app/service/RateLimiter.scala
+++ b/app/service/RateLimiter.scala
@@ -91,6 +91,20 @@ class RateLimiter @Inject() (config: Configuration) {
     )
   }
 
+  /**
+   * How long until `key`'s current window elapses and its count resets — the honest value for a `Retry-After`
+   * header, rather than quoting the full window length to someone who is already partway through it.
+   *
+   * @param key The key whose window to inspect; not recorded as an attempt.
+   * @return    Seconds remaining (at least one), or None if the key has no active window.
+   */
+  def retryAfterSeconds(key: String): Option[Long] = {
+    Option(windows.get(key)).map { w =>
+      val remainingMs = w.startMs + w.windowMs - nowMs
+      math.max(1L, (remainingMs + 999) / 1000) // Round up: never quote a moment before the window actually clears.
+    }
+  }
+
   /** Drops windows that have fully elapsed as of `now`, freeing memory. The CHM iterator supports safe live removal. */
   private def evictExpired(now: Long): Unit = {
     val it = windows.entrySet().iterator()

--- a/app/service/StoryService.scala
+++ b/app/service/StoryService.scala
@@ -104,21 +104,6 @@ class StoryServiceImpl @Inject() (
       "store)\\b)").r
 
   /**
-   * How long until the story posted at `freesAt` leaves the rolling 24h window, freeing a submission slot.
-   *
-   * Floored at one second so an expiry that has just landed can't reach the UI as "in 0 minutes", and rounded up so
-   * the number we quote is never earlier than the moment the slot actually opens — a user who retries exactly when
-   * told must not be refused again.
-   *
-   * @param freesAt When the oldest story still counting against the cap was posted; None when the cap isn't hit.
-   * @return        Seconds to wait, or None when there is no wait to report.
-   */
-  private def secondsUntilFree(freesAt: Option[OffsetDateTime]): Option[Long] = freesAt.map { posted =>
-    val wait = ChronoUnit.SECONDS.between(OffsetDateTime.now(ZoneOffset.UTC), posted.plusHours(24))
-    math.max(1L, wait)
-  }
-
-  /**
    * Metadata read from an upload's EXIF: the coarse recency/near-label signals that drive the card, plus the raw
    * capture time and GPS (when present). The raw values are persisted for internal analysis only — never surfaced.
    */
@@ -183,7 +168,12 @@ class StoryServiceImpl @Inject() (
         } yield {
           if (!labelOk) Some(StoryRejection.LabelNotFound)
           else if (duplicate) Some(StoryRejection.AlreadyExists)
-          else if (recent >= maxPerDay) Some(StoryRejection.RateLimited(secondsUntilFree(freesAt)))
+          else if (recent >= maxPerDay)
+            Some(
+              StoryRejection.RateLimited(
+                StoryServiceImpl.secondsUntilFree(freesAt, OffsetDateTime.now(ZoneOffset.UTC))
+              )
+            )
           else None
         }
         db.run(checks).flatMap {
@@ -656,4 +646,24 @@ class StoryServiceImpl @Inject() (
       logger.error(s"Failed to delete story media file story_$storyMediaId.jpg: ${e.getMessage}")
     }
   }
+}
+
+object StoryServiceImpl {
+
+  /**
+   * How long until the story posted at `freesAt` leaves the rolling 24h window, freeing a submission slot.
+   *
+   * Ceiled to whole seconds — a fractional second rounds *up* — and floored at one, so the value we quote (in the
+   * 429 body and on its `Retry-After` header) is never a moment before the slot actually opens: a caller who retries
+   * exactly when told must not be refused again. Pure so the sub-second edges are unit-testable.
+   *
+   * @param freesAt When the oldest story still counting against the cap was posted; None when the cap isn't hit.
+   * @param now     The current instant.
+   * @return        Seconds to wait, or None when there is no wait to report.
+   */
+  private[service] def secondsUntilFree(freesAt: Option[OffsetDateTime], now: OffsetDateTime): Option[Long] =
+    freesAt.map { posted =>
+      val waitMs = ChronoUnit.MILLIS.between(now, posted.plusHours(24))
+      math.max(1L, (waitMs + 999) / 1000)
+    }
 }

--- a/app/service/StoryService.scala
+++ b/app/service/StoryService.scala
@@ -104,6 +104,21 @@ class StoryServiceImpl @Inject() (
       "store)\\b)").r
 
   /**
+   * How long until the story posted at `freesAt` leaves the rolling 24h window, freeing a submission slot.
+   *
+   * Floored at one second so an expiry that has just landed can't reach the UI as "in 0 minutes", and rounded up so
+   * the number we quote is never earlier than the moment the slot actually opens — a user who retries exactly when
+   * told must not be refused again.
+   *
+   * @param freesAt When the oldest story still counting against the cap was posted; None when the cap isn't hit.
+   * @return        Seconds to wait, or None when there is no wait to report.
+   */
+  private def secondsUntilFree(freesAt: Option[OffsetDateTime]): Option[Long] = freesAt.map { posted =>
+    val wait = ChronoUnit.SECONDS.between(OffsetDateTime.now(ZoneOffset.UTC), posted.plusHours(24))
+    math.max(1L, wait)
+  }
+
+  /**
    * Metadata read from an upload's EXIF: the coarse recency/near-label signals that drive the card, plus the raw
    * capture time and GPS (when present). The raw values are persisted for internal analysis only — never surfaced.
    */
@@ -160,10 +175,15 @@ class StoryServiceImpl @Inject() (
           labelOk   <- storyTable.labelExists(labelId)
           duplicate <- storyTable.userHasStoryOnLabel(labelId, userId)
           recent    <- storyTable.countByUserSince(userId, since)
+          // Only when the cap is already hit: the timestamp whose 24h expiry frees the next slot, so the rejection
+          // can carry how long that is instead of the composer guessing.
+          freesAt <-
+            if (recent >= maxPerDay) storyTable.nthNewestInWindowAt(userId, since, maxPerDay)
+            else DBIO.successful(None)
         } yield {
           if (!labelOk) Some(StoryRejection.LabelNotFound)
           else if (duplicate) Some(StoryRejection.AlreadyExists)
-          else if (recent >= maxPerDay) Some(StoryRejection.RateLimited)
+          else if (recent >= maxPerDay) Some(StoryRejection.RateLimited(secondsUntilFree(freesAt)))
           else None
         }
         db.run(checks).flatMap {

--- a/public/js/common/label-detail/StoryComposer.js
+++ b/public/js/common/label-detail/StoryComposer.js
@@ -623,9 +623,12 @@ class StoryComposer {
    * story, so there is no "tomorrow" to name; and a duration is true for a reader in any timezone without the server
    * ever having to know which one they're in.
    *
-   * Minutes below the 90-minute mark and hours above it: the alternative — always hours — would round a 40-minute
-   * wait down to "in 1 hour", which is a lie in the direction that matters (they'd come back and be refused again).
-   * Minutes round up for the same reason.
+   * Minutes below the 90-minute mark and hours above it, and both round *up*: the phrase is a promise about when a
+   * retry succeeds, and a quoted moment before the slot actually opens is the lie that matters — someone who comes
+   * back exactly when told must not be refused again. (Always-hours would round a 40-minute wait to "in 1 hour";
+   * round-to-nearest hours would tell a 3h29m wait "in 3 hours" — the same broken promise at a larger scale.
+   * Ceiling can overshoot — a 3h05m wait reads "in 4 hours" — but at hour scale nobody is waiting on the minute,
+   * and coming back late always succeeds.)
    *
    * @param {*} seconds - The server's `retry_after_seconds`, or anything non-numeric when it didn't say.
    * @returns {?string} The localized phrase, or null when there's nothing to format.
@@ -643,6 +646,6 @@ class StoryComposer {
     }
     return seconds < 5400
       ? fmt.format(Math.ceil(seconds / 60), 'minute')
-      : fmt.format(Math.round(seconds / 3600), 'hour');
+      : fmt.format(Math.ceil(seconds / 3600), 'hour');
   }
 }

--- a/public/js/common/label-detail/StoryComposer.js
+++ b/public/js/common/label-detail/StoryComposer.js
@@ -343,8 +343,14 @@ class StoryComposer {
           // Non-JSON error body (e.g. Play's body-parser cutoff or a proxy error page); handled by status below.
         }
         const key = body && body.error ? `labelmap:${body.error}` : null;
+        // When the server said how long the wait is (the daily story cap), prefer the variant of the message that
+        // names it. Falls back to the plain message whenever the wait is unknown or unformattable.
+        const when = StoryComposer.#relativeTime(body && body.retry_after_seconds);
+        const timedKey = key && when ? `${key}-retry` : null;
         let message;
-        if (key && i18next.exists(key)) {
+        if (timedKey && i18next.exists(timedKey)) {
+          message = i18next.t(timedKey, { when });
+        } else if (key && i18next.exists(key)) {
           // The server rides the real limit along on text-too-long (body.max); #maxLength is only the fallback
           // since it's null until the /stories fetch lands.
           message = i18next.t(key, { max: (body && body.max) || this.#maxLength });
@@ -608,5 +614,35 @@ class StoryComposer {
 
   #clearError() {
     this.#els.error.hidden = true;
+  }
+
+  /**
+   * Formats a wait in seconds as a localized phrase — "in 3 hours", "in 20 minutes".
+   *
+   * A duration rather than a wall-clock time, deliberately. The daily story cap is a *rolling* 24 hours from each
+   * story, so there is no "tomorrow" to name; and a duration is true for a reader in any timezone without the server
+   * ever having to know which one they're in.
+   *
+   * Minutes below the 90-minute mark and hours above it: the alternative — always hours — would round a 40-minute
+   * wait down to "in 1 hour", which is a lie in the direction that matters (they'd come back and be refused again).
+   * Minutes round up for the same reason.
+   *
+   * @param {*} seconds - The server's `retry_after_seconds`, or anything non-numeric when it didn't say.
+   * @returns {?string} The localized phrase, or null when there's nothing to format.
+   * @private
+   */
+  static #relativeTime(seconds) {
+    const usable = typeof seconds === 'number' && Number.isFinite(seconds) && seconds > 0;
+    if (!usable || typeof Intl === 'undefined' || typeof Intl.RelativeTimeFormat !== 'function') return null;
+    const lang = (typeof i18next !== 'undefined' && i18next.language) || document.documentElement.lang || 'en';
+    let fmt;
+    try {
+      fmt = new Intl.RelativeTimeFormat(lang, { numeric: 'always' });
+    } catch {
+      return null; // Unknown or malformed tag — fall back to the untimed message rather than throw mid-error-path.
+    }
+    return seconds < 5400
+      ? fmt.format(Math.ceil(seconds / 60), 'minute')
+      : fmt.format(Math.round(seconds / 3600), 'hour');
   }
 }

--- a/public/locales/de/labelmap.json
+++ b/public/locales/de/labelmap.json
@@ -112,7 +112,8 @@
       "links-not-allowed": "Links sind in Geschichten oder Fotobeschreibungen nicht erlaubt.",
       "invalid-display-name": "Ungültige Anzeigename-Option.",
       "already-exists": "Sie haben an dieser Beschriftung bereits eine Geschichte geteilt.",
-      "rate-limited": "Sie haben kürzlich mehrere Geschichten geteilt – bitte versuchen Sie es morgen erneut.",
+      "rate-limited": "Sie haben bereits so viele Geschichten veröffentlicht, wie wir pro Tag zulassen. Bitte versuchen Sie es später erneut.",
+      "rate-limited-retry": "Sie haben bereits so viele Geschichten veröffentlicht, wie wir pro Tag zulassen. Sie können {{when}} eine weitere veröffentlichen.",
       "photo-too-large": "Dieses Foto ist zu groß zum Hochladen.",
       "photo-invalid": "Wir konnten diese Datei nicht als Bild lesen (JPEG oder PNG)."
     }

--- a/public/locales/de/labelmap.json
+++ b/public/locales/de/labelmap.json
@@ -114,6 +114,8 @@
       "already-exists": "Sie haben an dieser Beschriftung bereits eine Geschichte geteilt.",
       "rate-limited": "Sie haben bereits so viele Geschichten veröffentlicht, wie wir pro Tag zulassen. Bitte versuchen Sie es später erneut.",
       "rate-limited-retry": "Sie haben bereits so viele Geschichten veröffentlicht, wie wir pro Tag zulassen. Sie können {{when}} eine weitere veröffentlichen.",
+      "rate-limited-ip": "Aus Ihrem Netzwerk wurden kürzlich zu viele Geschichten eingereicht. Bitte versuchen Sie es später erneut.",
+      "rate-limited-ip-retry": "Aus Ihrem Netzwerk wurden kürzlich zu viele Geschichten eingereicht. Sie können es {{when}} erneut versuchen.",
       "photo-too-large": "Dieses Foto ist zu groß zum Hochladen.",
       "photo-invalid": "Wir konnten diese Datei nicht als Bild lesen (JPEG oder PNG)."
     }

--- a/public/locales/en/labelmap.json
+++ b/public/locales/en/labelmap.json
@@ -112,7 +112,8 @@
       "links-not-allowed": "Links aren't allowed in stories or photo descriptions.",
       "invalid-display-name": "Invalid display-name option.",
       "already-exists": "You've already shared a story on this label.",
-      "rate-limited": "You've shared several stories recently — please try again tomorrow.",
+      "rate-limited": "You’ve published as many stories as we allow in a day. Please try again later.",
+      "rate-limited-retry": "You’ve published as many stories as we allow in a day. You can publish another {{when}}.",
       "photo-too-large": "That photo is too large to upload.",
       "photo-invalid": "We couldn't read that file as an image (JPEG or PNG)."
     }

--- a/public/locales/en/labelmap.json
+++ b/public/locales/en/labelmap.json
@@ -114,6 +114,8 @@
       "already-exists": "You've already shared a story on this label.",
       "rate-limited": "You’ve published as many stories as we allow in a day. Please try again later.",
       "rate-limited-retry": "You’ve published as many stories as we allow in a day. You can publish another {{when}}.",
+      "rate-limited-ip": "Too many stories have been submitted from your network recently. Please try again later.",
+      "rate-limited-ip-retry": "Too many stories have been submitted from your network recently. You can try again {{when}}.",
       "photo-too-large": "That photo is too large to upload.",
       "photo-invalid": "We couldn't read that file as an image (JPEG or PNG)."
     }

--- a/public/locales/es/labelmap.json
+++ b/public/locales/es/labelmap.json
@@ -114,6 +114,8 @@
       "already-exists": "Ya compartiste una historia en esta etiqueta.",
       "rate-limited": "Has publicado tantas historias como permitimos en un día. Vuelve a intentarlo más tarde.",
       "rate-limited-retry": "Has publicado tantas historias como permitimos en un día. Puedes publicar otra {{when}}.",
+      "rate-limited-ip": "Se han enviado demasiadas historias desde tu red últimamente. Vuelve a intentarlo más tarde.",
+      "rate-limited-ip-retry": "Se han enviado demasiadas historias desde tu red últimamente. Puedes volver a intentarlo {{when}}.",
       "photo-too-large": "Esa foto es demasiado grande para subirla.",
       "photo-invalid": "No pudimos leer ese archivo como imagen (JPEG o PNG)."
     }

--- a/public/locales/es/labelmap.json
+++ b/public/locales/es/labelmap.json
@@ -112,7 +112,8 @@
       "links-not-allowed": "No se permiten enlaces en las historias ni en las descripciones de fotos.",
       "invalid-display-name": "Opción de nombre no válida.",
       "already-exists": "Ya compartiste una historia en esta etiqueta.",
-      "rate-limited": "Has compartido varias historias recientemente; inténtalo de nuevo mañana.",
+      "rate-limited": "Has publicado tantas historias como permitimos en un día. Vuelve a intentarlo más tarde.",
+      "rate-limited-retry": "Has publicado tantas historias como permitimos en un día. Puedes publicar otra {{when}}.",
       "photo-too-large": "Esa foto es demasiado grande para subirla.",
       "photo-invalid": "No pudimos leer ese archivo como imagen (JPEG o PNG)."
     }

--- a/public/locales/nl/labelmap.json
+++ b/public/locales/nl/labelmap.json
@@ -114,6 +114,8 @@
       "already-exists": "Je hebt al een verhaal gedeeld bij dit etiket.",
       "rate-limited": "Je hebt zoveel verhalen gepubliceerd als we per dag toestaan. Probeer het later opnieuw.",
       "rate-limited-retry": "Je hebt zoveel verhalen gepubliceerd als we per dag toestaan. Je kunt {{when}} een nieuw verhaal publiceren.",
+      "rate-limited-ip": "Er zijn onlangs te veel verhalen ingediend vanaf je netwerk. Probeer het later opnieuw.",
+      "rate-limited-ip-retry": "Er zijn onlangs te veel verhalen ingediend vanaf je netwerk. Je kunt het {{when}} opnieuw proberen.",
       "photo-too-large": "Die foto is te groot om te uploaden.",
       "photo-invalid": "We konden dat bestand niet als afbeelding lezen (JPEG of PNG)."
     }

--- a/public/locales/nl/labelmap.json
+++ b/public/locales/nl/labelmap.json
@@ -112,7 +112,8 @@
       "links-not-allowed": "Links zijn niet toegestaan in verhalen of fotobeschrijvingen.",
       "invalid-display-name": "Ongeldige naamweergave-optie.",
       "already-exists": "Je hebt al een verhaal gedeeld bij dit etiket.",
-      "rate-limited": "Je hebt onlangs meerdere verhalen gedeeld; probeer het morgen opnieuw.",
+      "rate-limited": "Je hebt zoveel verhalen gepubliceerd als we per dag toestaan. Probeer het later opnieuw.",
+      "rate-limited-retry": "Je hebt zoveel verhalen gepubliceerd als we per dag toestaan. Je kunt {{when}} een nieuw verhaal publiceren.",
       "photo-too-large": "Die foto is te groot om te uploaden.",
       "photo-invalid": "We konden dat bestand niet als afbeelding lezen (JPEG of PNG)."
     }

--- a/public/locales/pt-BR/labelmap.json
+++ b/public/locales/pt-BR/labelmap.json
@@ -112,7 +112,8 @@
       "links-not-allowed": "Links não são permitidos em histórias ou descrições de fotos.",
       "invalid-display-name": "Opção de exibição de nome inválida.",
       "already-exists": "Você já compartilhou uma história neste rótulo.",
-      "rate-limited": "Você compartilhou várias histórias recentemente; tente novamente amanhã.",
+      "rate-limited": "Você publicou tantas histórias quanto permitimos por dia. Tente novamente mais tarde.",
+      "rate-limited-retry": "Você publicou tantas histórias quanto permitimos por dia. Você pode publicar outra {{when}}.",
       "photo-too-large": "Essa foto é grande demais para o envio.",
       "photo-invalid": "Não conseguimos ler esse arquivo como imagem (JPEG ou PNG)."
     }

--- a/public/locales/pt-BR/labelmap.json
+++ b/public/locales/pt-BR/labelmap.json
@@ -114,6 +114,8 @@
       "already-exists": "Você já compartilhou uma história neste rótulo.",
       "rate-limited": "Você publicou tantas histórias quanto permitimos por dia. Tente novamente mais tarde.",
       "rate-limited-retry": "Você publicou tantas histórias quanto permitimos por dia. Você pode publicar outra {{when}}.",
+      "rate-limited-ip": "Muitas histórias foram enviadas da sua rede recentemente. Tente novamente mais tarde.",
+      "rate-limited-ip-retry": "Muitas histórias foram enviadas da sua rede recentemente. Você pode tentar novamente {{when}}.",
       "photo-too-large": "Essa foto é grande demais para o envio.",
       "photo-invalid": "Não conseguimos ler esse arquivo como imagem (JPEG ou PNG)."
     }

--- a/public/locales/zh-TW/labelmap.json
+++ b/public/locales/zh-TW/labelmap.json
@@ -108,6 +108,8 @@
       "already-exists": "您已在此標記分享過故事。",
       "rate-limited": "您發布的故事已達每日上限。請稍後再試。",
       "rate-limited-retry": "您發布的故事已達每日上限。您可以在{{when}}再發布一則。",
+      "rate-limited-ip": "您的網路最近提交了太多故事。請稍後再試。",
+      "rate-limited-ip-retry": "您的網路最近提交了太多故事。您可以在{{when}}再試一次。",
       "photo-too-large": "這張照片太大，無法上傳。",
       "photo-invalid": "我們無法將該檔案讀取為圖片（JPEG 或 PNG）。"
     }

--- a/public/locales/zh-TW/labelmap.json
+++ b/public/locales/zh-TW/labelmap.json
@@ -106,7 +106,8 @@
       "links-not-allowed": "故事或照片描述中不允許包含連結。",
       "invalid-display-name": "無效的顯示名稱選項。",
       "already-exists": "您已在此標記分享過故事。",
-      "rate-limited": "您最近分享了多則故事，請明天再試。",
+      "rate-limited": "您發布的故事已達每日上限。請稍後再試。",
+      "rate-limited-retry": "您發布的故事已達每日上限。您可以在{{when}}再發布一則。",
       "photo-too-large": "這張照片太大，無法上傳。",
       "photo-invalid": "我們無法將該檔案讀取為圖片（JPEG 或 PNG）。"
     }

--- a/test/controllers/StoryControllerSpec.scala
+++ b/test/controllers/StoryControllerSpec.scala
@@ -404,8 +404,17 @@ class StoryControllerSpec extends PlaySpec with GuiceOneAppPerSuite {
         status(resp) mustBe OK
         (contentAsJson(resp) \ "story_id").as[Int]
       }
-      try status(postStory(session, labelIds(maxPerDay), "one over the daily cap")) mustBe TOO_MANY_REQUESTS
-      finally posted.foreach(storyId => status(deleteStory(session, storyId)) mustBe OK)
+      try {
+        val refused = postStory(session, labelIds(maxPerDay), "one over the daily cap")
+        status(refused) mustBe TOO_MANY_REQUESTS
+
+        // The cap is a rolling 24h window, so the refusal says how long the wait is rather than naming a day: the
+        // stories were just posted, so the next slot is a shade under 24h away. Same number on the standard header.
+        val retryAfter = (contentAsJson(refused) \ "retry_after_seconds").as[Long]
+        retryAfter must be > 23.hours.toSeconds
+        retryAfter must be <= 24.hours.toSeconds
+        header("Retry-After", refused).value mustBe retryAfter.toString
+      } finally posted.foreach(storyId => status(deleteStory(session, storyId)) mustBe OK)
     }
 
     "ingest a photo (re-encoded, resized, signed URL), serve it, and remove the bytes on retraction" in {

--- a/test/controllers/StoryControllerSpec.scala
+++ b/test/controllers/StoryControllerSpec.scala
@@ -675,3 +675,60 @@ class StoryControllerSpec extends PlaySpec with GuiceOneAppPerSuite {
     }
   }
 }
+
+/**
+ * The IP burst layer end-to-end (#4740): its own app so `rate-limit.story-submit` can be enabled with a one-attempt
+ * cap (the suite above disables the layer so it can post freely). The refusal must blame the *network*, not the
+ * person — a shared NAT can trip this for someone who published nothing, so its error key differs from the per-user
+ * cap's — and must say how long is left in the IP's window, in the body and on the standard Retry-After header.
+ */
+class StoryControllerIpLimitSpec extends PlaySpec with GuiceOneAppPerSuite {
+
+  override def fakeApplication(): Application =
+    new GuiceApplicationBuilder()
+      .disable[modules.ActorModule]
+      .configure(
+        "rate-limit.story-submit.enabled"        -> true,
+        "rate-limit.story-submit.max-attempts"   -> 1,
+        "rate-limit.story-submit.window-seconds" -> 3600
+      )
+      .build()
+
+  implicit lazy val mat: Materializer = app.materializer
+
+  "POST /userapi/stories under the IP burst limit" should {
+    "429 with the network-scoped error and the time left in the window" in {
+      val sessionResp = route(app, FakeRequest(GET, "/anonSignUp?url=%2F")).get
+      status(sessionResp) mustBe SEE_OTHER
+      val session = cookies(sessionResp).toSeq
+
+      // The limiter charges every attempt before the body's fields are even read, so a bodyless POST exercises it
+      // without creating a story (nothing to clean up, no dependence on labels in the test DB).
+      def post() = route(
+        app,
+        FakeRequest(POST, "/userapi/stories")
+          .withCookies(session: _*)
+          .withMultipartFormDataBody(
+            MultipartFormData[play.api.libs.Files.TemporaryFile](
+              dataParts = Map.empty,
+              files = Seq.empty,
+              badParts = Nil
+            )
+          )
+          .withCSRFToken
+      ).get
+
+      status(post()) mustBe BAD_REQUEST // Within the cap: refused for the missing label_id, not the IP.
+
+      val refused = post()
+      status(refused) mustBe TOO_MANY_REQUESTS
+      (contentAsJson(refused) \ "error").as[String] mustBe "story.error.rate-limited-ip"
+      // The time left in this IP's window — positive, never more than the window itself, and the same number on the
+      // standard header (the old code quoted the window's full length regardless of how far through it the IP was).
+      val retryAfter = (contentAsJson(refused) \ "retry_after_seconds").as[Long]
+      retryAfter must be > 0L
+      retryAfter must be <= 3600L
+      header("Retry-After", refused).value mustBe retryAfter.toString
+    }
+  }
+}

--- a/test/js/storyRateLimitMessage.test.js
+++ b/test/js/storyRateLimitMessage.test.js
@@ -50,6 +50,10 @@ const STRINGS = {
         'You’ve published as many stories as we allow in a day. Please try again later.',
     'labelmap:story.error.rate-limited-retry':
         'You’ve published as many stories as we allow in a day. You can publish another {{when}}.',
+    'labelmap:story.error.rate-limited-ip':
+        'Too many stories have been submitted from your network recently. Please try again later.',
+    'labelmap:story.error.rate-limited-ip-retry':
+        'Too many stories have been submitted from your network recently. You can try again {{when}}.',
     'labelmap:story.error.generic': 'Something went wrong.',
 };
 
@@ -111,6 +115,12 @@ describe('the daily-cap message', () => {
         expect(errorText()).toContain('in 80 minutes');
     });
 
+    test('hours round up too — a 2h05m wait must not read "in 2 hours"', async () => {
+        // Rounding to nearest would promise a moment 5 minutes before the slot opens; ceiling never does.
+        await submitAndFail({ ...RATE_LIMITED, retry_after_seconds: 2 * 3600 + 300 });
+        expect(errorText()).toContain('in 3 hours');
+    });
+
     test('falls back to the untimed message when the server sends no wait', async () => {
         await submitAndFail(RATE_LIMITED);
         expect(errorText()).toBe('You’ve published as many stories as we allow in a day. Please try again later.');
@@ -125,5 +135,23 @@ describe('the daily-cap message', () => {
         window.i18next.language = 'es';
         await submitAndFail({ ...RATE_LIMITED, retry_after_seconds: 3 * 3600 });
         expect(errorText()).toContain('dentro de 3 horas');
+    });
+});
+
+describe('the network (IP) burst message', () => {
+    // The IP layer can trip for someone who published nothing themselves (a shared NAT), so its copy blames the
+    // network rather than the person — a distinct key from the per-user daily cap's.
+    const IP_LIMITED = { error: 'story.error.rate-limited-ip', message: 'fallback' };
+
+    test('names the wait when the server says how long is left in the window', async () => {
+        await submitAndFail({ ...IP_LIMITED, retry_after_seconds: 2 * 3600 });
+        expect(errorText()).toBe(
+            'Too many stories have been submitted from your network recently. You can try again in 2 hours.');
+    });
+
+    test('falls back to the untimed network message when the server sends no wait', async () => {
+        await submitAndFail(IP_LIMITED);
+        expect(errorText()).toBe(
+            'Too many stories have been submitted from your network recently. Please try again later.');
     });
 });

--- a/test/js/storyRateLimitMessage.test.js
+++ b/test/js/storyRateLimitMessage.test.js
@@ -1,0 +1,129 @@
+/**
+ * Tests for the composer's daily-cap message: when the server says how long the wait is, the message names it as a
+ * duration ("You can publish another in 3 hours") rather than the old "try again tomorrow" — which was never true,
+ * since the cap is a rolling 24-hour window and "tomorrow" depends on a timezone the server doesn't know.
+ *
+ * The formatter is a private static, so it's exercised through the public error path: a stubbed fetch returns the
+ * 429 body the controller produces, and the rendered error text is asserted.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const COMPOSER_SRC = fs.readFileSync(
+    path.resolve(__dirname, '..', '..', 'public/js/common/label-detail/StoryComposer.js'), 'utf8'
+);
+
+/** The elements StoryComposer's constructor looks up, in a <dialog> host. */
+function setupDom() {
+    document.body.innerHTML = `
+        <dialog class="story-composer">
+            <h3 class="story-composer__title"></h3>
+            <p class="story-composer__intro"></p>
+            <textarea class="story-composer__text"></textarea>
+            <span class="story-composer__counter"></span>
+            <button type="button" class="story-composer__photo-attach"></button>
+            <input type="file" class="story-composer__photo-input">
+            <div class="story-composer__photo-preview" hidden>
+                <img class="story-composer__photo-thumb" alt="">
+                <button type="button" class="story-composer__photo-remove"></button>
+            </div>
+            <input class="story-composer__alt-input">
+            <div class="story-composer__check-row"><input type="radio" class="story-composer__name-anon"></div>
+            <div class="story-composer__check-row">
+                <input type="radio" class="story-composer__name-username">
+                <span class="story-composer__username-option"></span>
+            </div>
+            <p class="story-composer__privacy"></p>
+            <div class="story-composer__signin-cta"><button class="story-composer__signin-btn"></button></div>
+            <p class="story-composer__error" hidden></p>
+            <button type="button" class="story-composer__cancel"></button>
+            <button type="button" class="story-composer__close"></button>
+            <button type="button" class="story-composer__submit"></button>
+        </dialog>`;
+    return document.querySelector('.story-composer');
+}
+
+/** The two real English strings, so the assertions read as the user would see them. */
+const STRINGS = {
+    'labelmap:story.error.rate-limited':
+        'You’ve published as many stories as we allow in a day. Please try again later.',
+    'labelmap:story.error.rate-limited-retry':
+        'You’ve published as many stories as we allow in a day. You can publish another {{when}}.',
+    'labelmap:story.error.generic': 'Something went wrong.',
+};
+
+/** Drains the microtask queue so the submit promise chain settles. */
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+const errorText = () => document.querySelector('.story-composer__error').textContent;
+
+/** Runs a submission that the server refuses with `body` at HTTP 429. */
+async function submitAndFail(body) {
+    const composer = new window.StoryComposer(setupDom(), {});
+    window.fetch = jest.fn().mockResolvedValue({
+        ok: false, status: 429, json: () => Promise.resolve(body),
+    });
+    await composer.open(7, 5000);
+    document.querySelector('.story-composer__text').value = 'The curb here is impassable in my chair.';
+    document.querySelector('.story-composer__submit').click();
+    await flush();
+    await flush();
+}
+
+beforeEach(() => {
+    window.eval(`${COMPOSER_SRC}\nwindow.StoryComposer = StoryComposer;`);
+    window.i18next = {
+        language: 'en',
+        exists: (key) => key in STRINGS,
+        t: (key, opts) => (STRINGS[key] || key).replace('{{when}}', (opts && opts.when) || ''),
+    };
+    window.logWebpageActivity = jest.fn();
+    window.HTMLDialogElement.prototype.showModal = jest.fn();
+    window.HTMLDialogElement.prototype.close = jest.fn();
+    document.documentElement.lang = 'en';
+    // open() looks for a stashed draft in IndexedDB, which jsdom has none of; the composer already handles that by
+    // logging and carrying on, so silence the expected noise rather than let it bury a real failure.
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+    console.error.mockRestore();
+});
+
+describe('the daily-cap message', () => {
+    const RATE_LIMITED = { error: 'story.error.rate-limited', message: 'fallback' };
+
+    test('names the wait in hours when the server says how long it is', async () => {
+        await submitAndFail({ ...RATE_LIMITED, retry_after_seconds: 3 * 3600 });
+        expect(errorText()).toBe(
+            'You’ve published as many stories as we allow in a day. You can publish another in 3 hours.');
+    });
+
+    test('switches to minutes for a short wait, rounding up', async () => {
+        // 20.5 minutes: "in 21 minutes" is a promise we can keep; "in 20" would refuse them again.
+        await submitAndFail({ ...RATE_LIMITED, retry_after_seconds: 1230 });
+        expect(errorText()).toContain('in 21 minutes');
+    });
+
+    test('an 80-minute wait stays in minutes rather than rounding to "1 hour"', async () => {
+        await submitAndFail({ ...RATE_LIMITED, retry_after_seconds: 80 * 60 });
+        expect(errorText()).toContain('in 80 minutes');
+    });
+
+    test('falls back to the untimed message when the server sends no wait', async () => {
+        await submitAndFail(RATE_LIMITED);
+        expect(errorText()).toBe('You’ve published as many stories as we allow in a day. Please try again later.');
+    });
+
+    test('a nonsense wait is ignored rather than rendered', async () => {
+        await submitAndFail({ ...RATE_LIMITED, retry_after_seconds: 'soon' });
+        expect(errorText()).toBe('You’ve published as many stories as we allow in a day. Please try again later.');
+    });
+
+    test('the phrase is formatted in the reader\'s language', async () => {
+        window.i18next.language = 'es';
+        await submitAndFail({ ...RATE_LIMITED, retry_after_seconds: 3 * 3600 });
+        expect(errorText()).toContain('dentro de 3 horas');
+    });
+});

--- a/test/service/RateLimiterSpec.scala
+++ b/test/service/RateLimiterSpec.scala
@@ -99,4 +99,31 @@ class RateLimiterSpec extends PlaySpec {
       (1 to 100).foreach(_ => rl.allow("ip:1", lim) mustBe true)
     }
   }
+
+  "RateLimiter.retryAfterSeconds" should {
+    "report the time left in the key's window, not the window's full length" in {
+      val rl = limiter(enabled = true)
+      rl.allow("k", 1, 60.seconds) mustBe true
+      rl.currentMs += 20000
+      rl.retryAfterSeconds("k") mustBe Some(40L)
+    }
+
+    "round up, so the quoted moment is never before the window actually clears" in {
+      val rl = limiter(enabled = true)
+      rl.allow("k", 1, 60.seconds) mustBe true
+      rl.currentMs += 19500 // 40.5s left: quoting 40 would send them back a half-second early.
+      rl.retryAfterSeconds("k") mustBe Some(41L)
+    }
+
+    "never report zero for a window that has only just elapsed" in {
+      val rl = limiter(enabled = true)
+      rl.allow("k", 1, 60.seconds) mustBe true
+      rl.currentMs += 60000
+      rl.retryAfterSeconds("k") mustBe Some(1L)
+    }
+
+    "report nothing for a key that has never been seen" in {
+      limiter(enabled = true).retryAfterSeconds("never-used") mustBe None
+    }
+  }
 }

--- a/test/service/StoryServiceSpec.scala
+++ b/test/service/StoryServiceSpec.scala
@@ -1,0 +1,39 @@
+package service
+
+import org.scalatestplus.play.PlaySpec
+
+import java.time.OffsetDateTime
+
+/**
+ * Unit tests for the pure retry-wait math behind the daily story cap's 429 (#4740). No app/DB boot: the interesting
+ * cases are sub-second roundings that the DB-backed StoryControllerSpec (which asserts only coarse bounds on a live
+ * clock) cannot pin down.
+ */
+class StoryServiceSpec extends PlaySpec {
+
+  // A story posted at 10:00:00Z counts against the rolling 24h cap until 10:00:00Z the next day.
+  private val posted = Some(OffsetDateTime.parse("2026-08-01T10:00:00Z"))
+
+  "StoryServiceImpl.secondsUntilFree" should {
+    "report the whole seconds until the oldest counting story leaves the window" in {
+      val now = OffsetDateTime.parse("2026-08-02T07:00:00Z") // 3h before the slot frees.
+      StoryServiceImpl.secondsUntilFree(posted, now) mustBe Some(3L * 3600)
+    }
+
+    "ceil a fractional second up, so the quoted wait is never before the slot opens" in {
+      val now = OffsetDateTime.parse("2026-08-02T09:59:58.700Z") // 1.3s left: quoting 1 would be 300ms early.
+      StoryServiceImpl.secondsUntilFree(posted, now) mustBe Some(2L)
+    }
+
+    "floor at one second once the slot has (just) opened" in {
+      // The count query and this computation see slightly different "now"s, so the story can age out in between;
+      // never say zero (the composer would render "in 0 minutes").
+      val now = OffsetDateTime.parse("2026-08-02T10:00:00.500Z")
+      StoryServiceImpl.secondsUntilFree(posted, now) mustBe Some(1L)
+    }
+
+    "report nothing when the cap isn't hit" in {
+      StoryServiceImpl.secondsUntilFree(None, OffsetDateTime.parse("2026-08-02T10:00:00Z")) mustBe None
+    }
+  }
+}


### PR DESCRIPTION
Fixes the daily story cap's refusal message, which promised something the code doesn't do.

### The problem

`stories.max-per-user-per-day` is enforced over a **rolling** 24 hours (`StoryService`: `now.minusHours(24)`), but the message said *"try again tomorrow."* Someone who publishes their fifth story at 4pm is unblocked at 4pm the next day, not at midnight. And "midnight" is a wall-clock claim that needs a timezone the server doesn't have.

### The fix

Say it as a **duration**, not a time: *"You've published as many stories as we allow in a day. You can publish another in 3 hours."* A duration is true for a reader in any timezone without the server knowing which one they're in — and it answers the question the person actually has.

- `StoryRejection.RateLimited` now carries `retryAfterSeconds`, surfaced as `retry_after_seconds` in the 429 body (the same pattern `TextTooLong` already uses for `max`).
- The wait is the expiry of the oldest story still counting against the cap. It skips `maxPerDay - 1` rows from the newest end rather than taking the window's oldest, so it stays correct when a user is *over* the cap — which happens whenever the configured cap is lowered.
- The composer formats it with `Intl.RelativeTimeFormat`, so the phrase is localized without new strings per unit. Minutes below 90, hours above; minutes round up, because rounding a 40-minute wait down to "in 1 hour" would refuse them again when they came back.
- Falls back to the untimed message whenever the wait is unknown or unformattable.

Also: the per-user 429 now sets `Retry-After` (only the IP path had one), and the IP path quotes the time **left** in its window rather than the window's full length.

### Testing

- `RateLimiterSpec` +4 (14 total) — remaining-time, rounding-up, just-elapsed, never-seen.
- `StoryControllerSpec` — the existing daily-cap test now asserts `retry_after_seconds` and the `Retry-After` header (27 pass, DB-backed).
- New `test/js/storyRateLimitMessage.test.js` (6) — hours, minutes, the 80-minute case that must not round to "1 hour", both fallbacks, and localization. Mutation-checked: dropping the minutes branch, rounding down, and ignoring the server's wait each redden the tests that cover them.
- `sbt compile` + `scalafmtCheckAll`, eslint, locale parity, jest 386/386.

### Note

Stacked on `4722-story-share-chip` (#4735) because both touch the same `labelmap.json` story strings. **Retarget to `develop` when #4735 merges** — GitHub only auto-retargets on head-branch deletion.

Separately: the *value* of the cap (5/user/day, and the 20/IP/day layer above it) is unchanged here — that's still an open question.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-opus-5[1m])


---

## Follow-up: strengthening round (2026-08-02)

One further commit from a review pass, closing the gaps between what the code promised and what it did:

**The quoted wait now truly never lands early.** `ChronoUnit.SECONDS.between` truncates, so the 429 body and `Retry-After` header could quote a moment up to a second before the slot opened — while the doc comment claimed it rounded up. The math now ceils on milliseconds, and moved to a pure companion function (`StoryServiceImpl.secondsUntilFree`) so the sub-second edges are unit-testable — new `StoryServiceSpec` (4) pins the exact-seconds, fractional-ceil, floor-at-one and under-cap cases.

**Hours round up like minutes do.** `Math.round` told a 3h29m wait "in 3 hours" — the same promise-breaking under-quote the minutes path was built to avoid, just at a larger scale. Both units now ceil: overshooting ("in 4 hours" for a 3h05m wait) costs only patience, while undershooting refuses someone who came back exactly when told.

**The IP burst layer stops claiming the reader published anything.** It can trip for someone behind a shared NAT who posted nothing, so "You've published as many stories as we allow in a day" could be flatly false. A distinct `RateLimitedIp` rejection now renders "Too many stories have been submitted from your network recently" (new `rate-limited-ip` / `rate-limited-ip-retry` keys in all 6 translated locales; the composer's generic `-retry` mechanism picks up the timed variant with no JS changes). A new `StoryControllerIpLimitSpec` exercises the layer end-to-end — its own app with a one-attempt cap, since the main suite disables the layer — asserting the network-scoped error key, the time-left body/header pair, and that the value is the window's remainder, not its full length.

**Verification.** jest 389/389 (the hours-ceil and both IP-message tests mutation-checked — reverting ceil→round reddens exactly the new test, as does dropping the server-side `+999`); `RateLimiterSpec` 14, `StoryServiceSpec` 4, `StoryControllerSpec` 27, `StoryControllerIpLimitSpec` 1 — all green, DB-backed suites against the dev DB; `sbt compile` + `scalafmtCheckAll`, eslint, locale parity all clean.

🤖 Strengthening round generated with [Claude Code](https://claude.com/claude-code) (claude-fable-5)
