### PR TITLE
Validate: flush the interaction buffer on a 60s deadline instead of an action count

### DIFF
--- a/docs/logged-events.md
+++ b/docs/logged-events.md
@@ -29,8 +29,8 @@ The core call is **`tracker.push(action, note)`** (see `Tracker.push` in each Tr
   event.
 
 Each pushed event is buffered with a timestamp and context (pano, task, lat/lng, …) and flushed to the backend
-periodically — on mission complete or after enough interactions accumulate — which is itself recorded as a
-`RefreshTracker` event.
+periodically — on mission complete, after enough interactions accumulate, or (in Validate) roughly a minute after the
+first interaction since the last flush (#4429) — which is itself recorded as a `RefreshTracker` event.
 
 **Environment metadata (separate from events).** Alongside interaction events, each tool's `Form.js` submits
 per-session environment fields — including `browser`, `browser_version`, and `operating_system` — stored with the task
@@ -117,7 +117,7 @@ ones whose meaning, parameters, or history aren't obvious:
 
 | Event | Why it's worth noting |
 |-------|------------------------|
-| `RefreshTracker` | Not a user action — it marks the buffer being flushed to the backend (on mission complete or after N interactions). |
+| `RefreshTracker` | Not a user action — it marks the buffer being flushed to the backend (on mission complete, after N interactions, or — in Validate — on a ~60s deadline after the first unflushed interaction). |
 | `SubmitFailed` / `SubmitFailedGaveUp` (Validate) | Not user actions — a data POST to `/validationTask` failed and is being retried (`SubmitFailed`, with `attempt` and `error`) or was abandoned after the retry cap (`SubmitFailedGaveUp`). Surfaces flaky-network submission trouble, esp. on mobile (#2745). |
 | `POV_Changed` (Validate) | The user panned/zoomed the pano. Throttled to at most one per ~500ms (with a trailing sample) so a continuous drag no longer floods the buffer (#2745) — counts undercount raw movement by design. |
 | `LowLevelEvent_<domType>` | A runtime family, not a single event (see [naming](#event-naming)); these are by far the highest-volume rows. |

--- a/public/js/validate/src/Tracker.js
+++ b/public/js/validate/src/Tracker.js
@@ -3,6 +3,16 @@
  */
 class Tracker {
   #actions = [];
+  #flushTimeout = null;
+
+  // Flush buffered interactions roughly once a minute of activity (#4429) so that a page killed without firing
+  // pagehide (crash, OOM kill — common on mobile) loses at most ~1 minute of logs. Time is the unit that actually
+  // bounds that loss; an action count's meaning shifts whenever logging verbosity changes (see #2745). The count
+  // threshold stays as a backstop so an unthrottled event storm can't grow an oversized payload within one interval.
+  // Browsers throttle background-tab timers to >=1/min, which only delays a flush — a hidden tab generates no new
+  // interactions, and the pagehide handler covers actual exits.
+  static #FLUSH_INTERVAL_MS = 60000;
+  static #MAX_BUFFERED_ACTIONS = 200;
 
   constructor() {
     this.#trackWindowEvents();
@@ -80,15 +90,29 @@ class Tracker {
    */
   push(action, notes) {
     const item = this.#createAction(action, notes);
-    const prevItem = this.#actions.slice(-1)[0];
     this.#actions.push(item);
-    if (this.#actions.length > 200) {
+    if (this.#actions.length > Tracker.#MAX_BUFFERED_ACTIONS) {
       const data = svv.form.compileSubmissionData(false);
       svv.form.submit(data, true); // Note that this happens async
+    } else if (this.#flushTimeout === null) {
+      // First push since the last flush: schedule the next timed flush. refresh() cancels this timer on every drain,
+      // so an idle tab (whose buffer holds only the post-flush RefreshTracker marker) never schedules one.
+      this.#flushTimeout = window.setTimeout(() => this.#flush(), Tracker.#FLUSH_INTERVAL_MS);
     }
-    // If there is a one-hour break between interactions (in ms), refresh the page to avoid weird bugs.
-    if (prevItem && item.timestamp - prevItem.timestamp > 3600000) window.location.reload();
     return this;
+  }
+
+  /**
+   * Flushes buffered interactions mid-mission, off the timer armed by push().
+   *
+   * Every drain path funnels through refresh(), which cancels the pending timer, so this only fires when the buffer
+   * holds unflushed interactions.
+   */
+  #flush() {
+    this.#flushTimeout = null;
+    if (!svv.form) return; // Init hasn't finished; the next push re-arms the timer.
+    const data = svv.form.compileSubmissionData(false);
+    svv.form.submit(data, true); // Note that this happens async
   }
 
   /**
@@ -97,5 +121,10 @@ class Tracker {
   refresh() {
     this.#actions = [];
     this.push('RefreshTracker');
+    // Every drain path (timed flush, count backstop, mission complete, pagehide) funnels through this method, so
+    // clearing the timer here — after the RefreshTracker push above, which would otherwise re-arm it — both cancels
+    // any pending flush and keeps an idle tab quiet: the lone marker never triggers a timed flush on its own.
+    window.clearTimeout(this.#flushTimeout);
+    this.#flushTimeout = null;
   }
 }

--- a/test/js/validateTrackerFlush.test.js
+++ b/test/js/validateTrackerFlush.test.js
@@ -1,0 +1,183 @@
+/**
+ * Tests for public/js/validate/src/Tracker.js — the timed interaction-buffer flush (issue #4429).
+ *
+ * Pins the flush lifecycle: a deadline is armed by the first push after a drain and fires ~60s later; every drain
+ * path funnels through refresh(), which cancels the pending deadline, so an idle tab (whose buffer holds only the
+ * post-flush RefreshTracker marker) never flushes on its own; the 200-action count remains as an event-storm
+ * backstop. Also pins the removal of the one-hour-gap page reload (#3226's temporary_label_id guard, which Validate
+ * never needed — it has no temp label ids).
+ *
+ * Runs under jsdom (jest.config.js sets testEnvironment) so window/document exist.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const TRACKER_PATH = path.resolve(__dirname, '..', '..', 'public/js/validate/src/Tracker.js');
+
+const FLUSH_INTERVAL_MS = 60000;
+
+/**
+ * Load the `Tracker` class out of the production file. Like Form.js, it is a bare `class Tracker {}` that the Grunt
+ * bundle concatenates into page scope, so we wrap the source in an IIFE that returns the class. String concatenation
+ * (not a template literal) is used so the backticks inside Tracker.js aren't reinterpreted.
+ * @returns {Function} The Tracker class.
+ */
+function loadTrackerClass() {
+    const src = fs.readFileSync(TRACKER_PATH, 'utf8');
+    return (0, eval)('(() => {\n' + src + '\nreturn Tracker;\n})()');
+}
+
+const Tracker = loadTrackerClass();
+
+describe('Tracker timed flush (issue #4429)', () => {
+    let tracker;
+    let compiledPayload;
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        jest.setSystemTime(1_000_000);
+
+        // The constructor binds low-level window events through jQuery; a stub with a no-op .on() is enough.
+        global.$ = jest.fn(() => ({ on: jest.fn() }));
+
+        // Minimal svv surface. compileSubmissionData mimics the production Form.js contract: it synchronously drains
+        // the tracker (tracker.refresh()) before returning the payload snapshot.
+        compiledPayload = { interactions: [] };
+        global.svv = {
+            form: {
+                compileSubmissionData: jest.fn(() => {
+                    tracker.refresh();
+                    return compiledPayload;
+                }),
+                submit: jest.fn()
+            }
+        };
+
+        // jsdom's location.reload can't be called/spied directly, so replace location with a stub we can assert on.
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            value: { reload: jest.fn(), replace: jest.fn(), href: '' }
+        });
+
+        tracker = new Tracker();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+        jest.restoreAllMocks();
+        delete global.svv;
+        delete global.$;
+    });
+
+    test('the first push arms a deadline that flushes the compiled payload as an intermediate submit', () => {
+        tracker.push('ValidationButtonClick_Agree');
+
+        expect(svv.form.compileSubmissionData).not.toHaveBeenCalled();
+        jest.advanceTimersByTime(FLUSH_INTERVAL_MS);
+
+        expect(svv.form.compileSubmissionData).toHaveBeenCalledTimes(1);
+        expect(svv.form.compileSubmissionData).toHaveBeenCalledWith(false);
+        expect(svv.form.submit).toHaveBeenCalledTimes(1);
+        expect(svv.form.submit).toHaveBeenCalledWith(compiledPayload, true);
+    });
+
+    test('the deadline is fixed from the first unflushed push, not slid by later pushes', () => {
+        tracker.push('ValidationButtonClick_Agree');
+        jest.advanceTimersByTime(FLUSH_INTERVAL_MS - 1000);
+        tracker.push('ValidationButtonClick_Disagree'); // 59s in; must not postpone the deadline.
+
+        jest.advanceTimersByTime(999);
+        expect(svv.form.submit).not.toHaveBeenCalled();
+
+        jest.advanceTimersByTime(1);
+        expect(svv.form.submit).toHaveBeenCalledTimes(1);
+    });
+
+    test('an idle tab stays quiet after a flush (the RefreshTracker marker never re-arms the deadline)', () => {
+        tracker.push('ValidationButtonClick_Agree');
+        jest.advanceTimersByTime(FLUSH_INTERVAL_MS);
+        expect(svv.form.submit).toHaveBeenCalledTimes(1);
+
+        // The drain left the buffer holding only the synthetic RefreshTracker marker; with no further user activity
+        // there must be no second flush, no matter how long the tab sits.
+        jest.advanceTimersByTime(10 * 60 * 1000);
+        expect(svv.form.submit).toHaveBeenCalledTimes(1);
+        expect(tracker.getActions().map((a) => a.action)).toEqual(['RefreshTracker']);
+    });
+
+    test('refresh() on its own never arms the deadline', () => {
+        tracker.refresh();
+
+        jest.advanceTimersByTime(10 * 60 * 1000);
+        expect(svv.form.compileSubmissionData).not.toHaveBeenCalled();
+        expect(svv.form.submit).not.toHaveBeenCalled();
+    });
+
+    test('an external drain (mission complete / pagehide) cancels the pending deadline', () => {
+        tracker.push('ValidationButtonClick_Agree');
+        jest.advanceTimersByTime(FLUSH_INTERVAL_MS / 2);
+
+        // Both the mission-complete submit and the pagehide handler drain via compileSubmissionData -> refresh().
+        tracker.refresh();
+
+        jest.advanceTimersByTime(10 * 60 * 1000);
+        expect(svv.form.submit).not.toHaveBeenCalled();
+    });
+
+    test('the action-count backstop still flushes immediately and cancels the pending deadline', () => {
+        for (let i = 0; i < 201; i++) {
+            tracker.push('LowLevelEvent_mousemove');
+        }
+
+        expect(svv.form.compileSubmissionData).toHaveBeenCalledTimes(1);
+        expect(svv.form.submit).toHaveBeenCalledTimes(1);
+        expect(svv.form.submit).toHaveBeenCalledWith(compiledPayload, true);
+
+        // The deadline armed by the first push must not produce a second, near-empty flush.
+        jest.advanceTimersByTime(10 * 60 * 1000);
+        expect(svv.form.submit).toHaveBeenCalledTimes(1);
+    });
+
+    test('the next push after a drain arms a fresh deadline', () => {
+        tracker.push('ValidationButtonClick_Agree');
+        jest.advanceTimersByTime(FLUSH_INTERVAL_MS);
+        expect(svv.form.submit).toHaveBeenCalledTimes(1);
+
+        tracker.push('ValidationButtonClick_Disagree');
+        jest.advanceTimersByTime(FLUSH_INTERVAL_MS);
+        expect(svv.form.submit).toHaveBeenCalledTimes(2);
+    });
+
+    test('a >1h gap between pushes does not reload the page', () => {
+        tracker.push('ValidationButtonClick_Agree');
+        jest.setSystemTime(1_000_000 + 2 * 60 * 60 * 1000);
+        tracker.push('ValidationButtonClick_Disagree');
+
+        expect(window.location.reload).not.toHaveBeenCalled();
+    });
+
+    test('a deadline firing before init finishes is a no-op that self-heals on the next push', () => {
+        global.svv = {}; // svv.form doesn't exist yet.
+        tracker = new Tracker();
+
+        tracker.push('ValidationButtonClick_Agree');
+        expect(() => jest.advanceTimersByTime(FLUSH_INTERVAL_MS)).not.toThrow();
+
+        // Once init has finished, the next push re-arms and the flush goes through.
+        global.svv = {
+            form: {
+                compileSubmissionData: jest.fn(() => {
+                    tracker.refresh();
+                    return compiledPayload;
+                }),
+                submit: jest.fn()
+            }
+        };
+        tracker.push('ValidationButtonClick_Disagree');
+        jest.advanceTimersByTime(FLUSH_INTERVAL_MS);
+
+        expect(svv.form.submit).toHaveBeenCalledTimes(1);
+        expect(svv.form.submit).toHaveBeenCalledWith(compiledPayload, true);
+    });
+});


### PR DESCRIPTION
Closes #4429.

## What this does

- **Time-based flush.** The first `tracker.push()` after each drain arms a ~60s deadline (`Tracker.#FLUSH_INTERVAL_MS`); when it fires, the existing intermediate flush runs (`compileSubmissionData(false)` + `submit(data, true)`). This bounds crash/OOM-kill log loss to about a minute of activity regardless of how chatty our event logging is — the old 200-action trigger was implicitly calibrated to the pre-#2745 `POV_Changed` firehose and now almost never fires within a mission.
- **The 200-action threshold stays as a backstop** (`Tracker.#MAX_BUFFERED_ACTIONS`) so a future unthrottled event storm can't build an oversized payload within one window. Mission-complete and `pagehide` flush points are unchanged.
- **Removes the one-hour-gap `window.location.reload()`.** Added in #3226 as a stale-tab tripwire against Explore's `temporary_label_id` collision bug (#3222) and mirrored into Validate purely for cross-UI consistency — Validate has no temp label ids, so the guarded failure mode can't occur here (as @misaugstad noted on the issue). Explore keeps its copy, where the guard is load-bearing alongside the server-side `refresh_page` check.

## Design notes

- Every drain path (timed flush, count backstop, mission complete, `pagehide`) funnels through `tracker.refresh()`, so that's the single cancellation point for the pending deadline. Clearing the timer *after* `refresh()`'s re-entrant `push('RefreshTracker')` means the synthetic marker can never leave a deadline armed — an idle tab settles with a lone `RefreshTracker` in the buffer and never POSTs on its own.
- Overlap safety is unchanged: `compileSubmissionData` drains the buffers synchronously before the fetch, so concurrent submits always carry disjoint snapshots.
- Known pre-existing exposure, slightly widened by more frequent POSTs: `validation_task_interaction` has no natural-key dedup, so a committed-but-lost-response retry can double-insert interaction rows. That's #4377 (server-side idempotency) and is worth doing as a follow-up.

## Testing

- New `test/js/validateTrackerFlush.test.js` (9 cases) pins the flush lifecycle: deadline arms on first real push and is fixed (not sliding), idle tabs stay quiet after a flush, external drains cancel the deadline, the count backstop still fires exactly once, re-arm after drain, no reload on a >1h gap (regression pin), and a deadline firing before init is a safe no-op that self-heals.
- Full JS suite green in the web container (37 suites, 421 tests); ESLint clean on touched files.

## Manual QA checklist (GSV interaction — please verify visually)

- [ ] Normal mission: DevTools network shows `POST /validationTask` roughly once per active minute; mission completes normally.
- [ ] **Undo after idle**: validate a label, wait 61+ s, click undo — counts/result restore correctly. (A timed flush drains `labelsToSubmit`, so undo now more often takes the backend-undo `pushUndoValidation` branch in `Mission.js`.)
- [ ] Leave the tab idle >1h, come back and keep validating — no reload, everything still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-fable-5)