### PR TITLE
Enable auth rate limiting by default with spoof-resistant client IPs

### DIFF
--- a/app/controllers/UserController.scala
+++ b/app/controllers/UserController.scala
@@ -70,8 +70,8 @@ class UserController @Inject() (
   /**
    * Checks a named rate limit for the given keys; if any is exceeded, returns a ready 429 response, else `None`.
    *
-   * Inert unless `rate-limit.enabled` (see `RateLimiter`). All keys are counted (so IP- and email-scoped limits both
-   * register the attempt) before deciding. The 429 is JSON for async submits and a flashed redirect for the no-JS
+   * On by default via `rate-limit.enabled` (see `RateLimiter`). All keys are counted (so IP- and email-scoped limits
+   * both register the attempt) before deciding. The 429 is JSON for async submits and a flashed redirect for the no-JS
    * fallback, so both surfaces show the same throttle message.
    *
    * @param name     The `rate-limit.<name>` block to read the max/window from.
@@ -82,15 +82,17 @@ class UserController @Inject() (
   private def rateLimited(name: String, keys: Seq[String], redirect: String)(implicit
       request: play.api.mvc.RequestHeader
   ): Option[play.api.mvc.Result] = {
-    val limit   = rateLimiter.limit(name)
-    val allowed = keys.map(k => rateLimiter.allow(k, limit.maxAttempts, limit.window)).forall(identity)
-    if (allowed) None
+    val limit       = rateLimiter.limit(name)
+    val blockedKeys = keys.filterNot(k => rateLimiter.allow(k, limit.maxAttempts, limit.window))
+    if (blockedKeys.isEmpty) None
     else {
-      val msg    = Messages("authenticate.error.too.many")
-      val result =
+      // Quote the longest wait among the tripped scopes, from when its window actually clears (#4740).
+      val retryAfter = blockedKeys.flatMap(rateLimiter.retryAfterSeconds).reduceOption(_ max _)
+      val msg        = Messages("authenticate.error.too.many")
+      val result     =
         if (wantsJson) TooManyRequests(fieldErrorJson("_summary", msg))
         else Redirect(redirect).flashing("error" -> msg)
-      Some(result.withHeaders("Retry-After" -> limit.window.toSeconds.toString))
+      Some(result.withHeaders("Retry-After" -> retryAfter.getOrElse(limit.window.toSeconds).toString))
     }
   }
 
@@ -253,89 +255,106 @@ class UserController @Inject() (
             // email below; an unrecognized identifier passes through unchanged so authentication fails with the same
             // generic "email and password don't match" error — no account-enumeration signal.
             val identifier: String = data.email.trim
-            cc.loggingService.insert(currUserId, ipAddress, s"""SignInAttempt_Email="$identifier"""")
 
-            // Grab the URL we want to redirect to that was passed as a hidden field in the form.
-            val returnUrl = request.body.asFormUrlEncoded
-              .flatMap(_.get("returnUrl"))
-              .flatMap(_.headOption)
-              .getOrElse("/") // Default redirect path if no returnUrl.
-            val (returnUrlPath, returnUrlQuery) = parseURL(returnUrl)
-            // Constrain to a same-origin path so a crafted returnUrl can't open-redirect a signed-in user off-site.
-            // Async submits get the destination as JSON (the dialog navigates itself); the authenticator cookie is
-            // embedded into whichever result we hand Silhouette below.
-            val redirectTarget = safeLocalPath(returnUrl)
-            val result         = if (wantsJson) Ok(Json.obj("redirect" -> redirectTarget)) else Redirect(redirectTarget)
+            // Per-account throttle keyed on the submitted email-or-username, which only exists after form binding.
+            // This is the actual brute-force backstop (#1102): the per-IP bound above stays generous for classrooms
+            // behind one NAT, so a targeted account needs its own, tighter limit. Keyed case-insensitively and
+            // length-capped so a flood of giant identifiers can't bloat the limiter's key set.
+            rateLimited("login-identifier", Seq(s"login:id:${identifier.toLowerCase.take(255)}"), "/signIn") match {
+              case Some(throttledResult) =>
+                cc.loggingService.insert(currUserId, ipAddress, s"""SignInThrottled_Email="$identifier"""")
+                Future.successful(throttledResult)
 
-            // Resolve the identifier to an email: pass an email through as-is; look a username up to its email; and
-            // fall back to the identifier unchanged when it matches nothing, so auth fails with the generic error.
-            val emailFut: Future[String] =
-              if (identifier.contains("@")) Future.successful(identifier.toLowerCase)
-              else
-                authenticationService.findByUsername(identifier).map(_.map(_.email).getOrElse(identifier.toLowerCase))
+              case None =>
+                cc.loggingService.insert(currUserId, ipAddress, s"""SignInAttempt_Email="$identifier"""")
 
-            // Try to authenticate the user.
-            emailFut.flatMap { email =>
-              authenticationService
-                .authenticate(email, data.password)
-                .flatMap { loginInfo =>
-                  authenticationService.retrieve(loginInfo).flatMap {
-                    case Some(user) =>
-                      val c = config.underlying
-                      silhouette.env.authenticatorService
-                        .create(loginInfo)
-                        .map {
-                          case authenticator if data.rememberMe =>
-                            // Set up the remember me cookie.
-                            authenticator.copy(
-                              expirationDateTime = clock.now + c
-                                .as[FiniteDuration]("silhouette.authenticator.rememberMe.authenticatorExpiry"),
-                              idleTimeout =
-                                c.getAs[FiniteDuration]("silhouette.authenticator.rememberMe.authenticatorIdleTimeout"),
-                              cookieMaxAge = c.getAs[FiniteDuration]("silhouette.authenticator.rememberMe.cookieMaxAge")
-                            )
-                          case authenticator => authenticator
-                        }
-                        .flatMap { authenticator =>
-                          // Log successful sign in attempt.
-                          val activity: String = s"""SignInSuccess_Email="${user.email}""""
-                          cc.loggingService.insert(user.userId, ipAddress, activity)
+                // Grab the URL we want to redirect to that was passed as a hidden field in the form.
+                val returnUrl = request.body.asFormUrlEncoded
+                  .flatMap(_.get("returnUrl"))
+                  .flatMap(_.headOption)
+                  .getOrElse("/") // Default redirect path if no returnUrl.
+                val (returnUrlPath, returnUrlQuery) = parseURL(returnUrl)
+                // Constrain to a same-origin path so a crafted returnUrl can't open-redirect a signed-in user
+                // off-site. Async submits get the destination as JSON (the dialog navigates itself); the
+                // authenticator cookie is embedded into whichever result we hand Silhouette below.
+                val redirectTarget = safeLocalPath(returnUrl)
+                val result = if (wantsJson) Ok(Json.obj("redirect" -> redirectTarget)) else Redirect(redirectTarget)
 
-                          // Sign in the user.
-                          silhouette.env.eventBus.publish(LoginEvent(user, request))
-                          silhouette.env.authenticatorService.init(authenticator).flatMap { v =>
-                            silhouette.env.authenticatorService.embed(v, result)
-                          }
-                        }
-                    case None =>
-                      // Log failed sign-in due to a database issue.
-                      val activity: String = s"""SignInFailed_Email="$email"_Reason="user not found in db""""
-                      cc.loggingService.insert(currUserId, ipAddress, activity)
-                      Future.failed(new IdentityNotFoundException("Couldn't find the user in db"))
-                  }
-                }
-                .recover {
-                  case e: ProviderException =>
-                    // Log failed sign-in due to invalid credentials. Should be the only reason for failed sign-in.
-                    val activity: String = s"""SignInFailed_Email="$email"_Reason="invalid credentials""""
-                    cc.loggingService.insert(currUserId, ipAddress, activity)
+                // Resolve the identifier to an email: pass an email through as-is; look a username up to its email;
+                // and fall back to the identifier unchanged when it matches nothing, so auth fails with the generic
+                // error.
+                val emailFut: Future[String] =
+                  if (identifier.contains("@")) Future.successful(identifier.toLowerCase)
+                  else
+                    authenticationService
+                      .findByUsername(identifier)
+                      .map(_.map(_.email).getOrElse(identifier.toLowerCase))
 
-                    if (wantsJson)
-                      Unauthorized(
-                        fieldErrorJson("_summary", Messages("authenticate.error.invalid.credentials.detail"))
-                      )
-                    else
-                      Redirect("/signIn", returnUrlQuery + ("url" -> Seq(returnUrlPath)))
-                        .flashing("error" -> Messages("authenticate.error.invalid.credentials"))
-                  case e: Exception =>
-                    val activity: String = s"""SignInFailed_Email="$email"_Reason="unexpected""""
-                    cc.loggingService.insert(currUserId, ipAddress, activity)
+                // Try to authenticate the user.
+                emailFut.flatMap { email =>
+                  authenticationService
+                    .authenticate(email, data.password)
+                    .flatMap { loginInfo =>
+                      authenticationService.retrieve(loginInfo).flatMap {
+                        case Some(user) =>
+                          val c = config.underlying
+                          silhouette.env.authenticatorService
+                            .create(loginInfo)
+                            .map {
+                              case authenticator if data.rememberMe =>
+                                // Set up the remember me cookie.
+                                authenticator.copy(
+                                  expirationDateTime = clock.now + c
+                                    .as[FiniteDuration]("silhouette.authenticator.rememberMe.authenticatorExpiry"),
+                                  idleTimeout = c.getAs[FiniteDuration](
+                                    "silhouette.authenticator.rememberMe.authenticatorIdleTimeout"
+                                  ),
+                                  cookieMaxAge =
+                                    c.getAs[FiniteDuration]("silhouette.authenticator.rememberMe.cookieMaxAge")
+                                )
+                              case authenticator => authenticator
+                            }
+                            .flatMap { authenticator =>
+                              // Log successful sign in attempt.
+                              val activity: String = s"""SignInSuccess_Email="${user.email}""""
+                              cc.loggingService.insert(user.userId, ipAddress, activity)
 
-                    if (wantsJson)
-                      InternalServerError(fieldErrorJson("_summary", Messages("authenticate.error.generic")))
-                    else
-                      Redirect("/signIn", returnUrlQuery + ("url" -> Seq(returnUrlPath)))
-                        .flashing("error" -> "Unexpected error")
+                              // Sign in the user.
+                              silhouette.env.eventBus.publish(LoginEvent(user, request))
+                              silhouette.env.authenticatorService.init(authenticator).flatMap { v =>
+                                silhouette.env.authenticatorService.embed(v, result)
+                              }
+                            }
+                        case None =>
+                          // Log failed sign-in due to a database issue.
+                          val activity: String = s"""SignInFailed_Email="$email"_Reason="user not found in db""""
+                          cc.loggingService.insert(currUserId, ipAddress, activity)
+                          Future.failed(new IdentityNotFoundException("Couldn't find the user in db"))
+                      }
+                    }
+                    .recover {
+                      case e: ProviderException =>
+                        // Log failed sign-in due to invalid credentials. Should be the only reason for a failure.
+                        val activity: String = s"""SignInFailed_Email="$email"_Reason="invalid credentials""""
+                        cc.loggingService.insert(currUserId, ipAddress, activity)
+
+                        if (wantsJson)
+                          Unauthorized(
+                            fieldErrorJson("_summary", Messages("authenticate.error.invalid.credentials.detail"))
+                          )
+                        else
+                          Redirect("/signIn", returnUrlQuery + ("url" -> Seq(returnUrlPath)))
+                            .flashing("error" -> Messages("authenticate.error.invalid.credentials"))
+                      case e: Exception =>
+                        val activity: String = s"""SignInFailed_Email="$email"_Reason="unexpected""""
+                        cc.loggingService.insert(currUserId, ipAddress, activity)
+
+                        if (wantsJson)
+                          InternalServerError(fieldErrorJson("_summary", Messages("authenticate.error.generic")))
+                        else
+                          Redirect("/signIn", returnUrlQuery + ("url" -> Seq(returnUrlPath)))
+                            .flashing("error" -> "Unexpected error")
+                    }
                 }
             }
           }
@@ -473,46 +492,65 @@ class UserController @Inject() (
       case Some(user) =>
         Future.successful(Redirect(url, qString))
       case None =>
-        val randomPassword: String = Random.alphanumeric take 16 mkString ""
-        val pwInfo                 = passwordHasher.hash(randomPassword)
+        // Each anon sign-up costs a bcrypt hash and inserts across several tables, unauthenticated, so it needs its
+        // own IP bound. Checked directly rather than via rateLimited(): that helper's no-JS branch redirects, and any
+        // redirect from here can loop — every SecuredAction bounces cookie-less clients back to /anonSignUp
+        // (CustomSecuredErrorHandler), so the throttle response must stay a plain 429.
+        val anonKey   = s"anon-signup:ip:${request.ipAddress}"
+        val anonLimit = rateLimiter.limit("anon-signup")
+        if (!rateLimiter.allow(anonKey, anonLimit)) {
+          val retryAfter = rateLimiter.retryAfterSeconds(anonKey).getOrElse(anonLimit.window.toSeconds)
+          Future.successful(
+            TooManyRequests(Messages("authenticate.error.too.many"))
+              .withHeaders("Retry-After" -> retryAfter.toString)
+          )
+        } else signUpAnonUser(url, qString)
+    }
+  }
 
-        for {
-          newAnonUser: SidewalkUserWithRole <- authenticationService.generateUniqueAnonUser()
-          loginInfo: LoginInfo = LoginInfo(CredentialsProvider.ID, newAnonUser.email)
+  /** Creates an anon user with a randomly generated username/password, signs them in, and redirects to `url`. */
+  private def signUpAnonUser(url: String, qString: Map[String, Seq[String]])(implicit
+      request: play.silhouette.api.actions.UserAwareRequest[DefaultEnv, play.api.mvc.AnyContent]
+  ): Future[play.api.mvc.Result] = {
+    val randomPassword: String = Random.alphanumeric take 16 mkString ""
+    val pwInfo                 = passwordHasher.hash(randomPassword)
 
-          user          <- authenticationService.createUser(newAnonUser, loginInfo.providerID, pwInfo, oldUserId = None)
-          authenticator <- silhouette.env.authenticatorService.create(loginInfo)
-          value         <- silhouette.env.authenticatorService.init(authenticator)
-          // Strip UTM params from redirect to avoid double-capture in index().
-          qStringNoUtm = qString.filterNot { case (k, _) => k.startsWith("utm_") }
-          result <- silhouette.env.authenticatorService.embed(value, Redirect(url, qStringNoUtm))
+    for {
+      newAnonUser: SidewalkUserWithRole <- authenticationService.generateUniqueAnonUser()
+      loginInfo: LoginInfo = LoginInfo(CredentialsProvider.ID, newAnonUser.email)
 
-          // Save UTM parameters if present, awaiting the write so failures surface to the error handler (#4229). UTM
-          // params are stripped from the redirect URL (above) to avoid double-capture when index() also checks for UTM
-          // params on returning users.
-          _ <- {
-            if (ControllerUtils.hasUtmParams(qString)) {
-              val flat = qString.map { case (k, v) => k -> v.mkString }
-              userService.insertUserUtm(
-                UserUtm(
-                  0, user.userId, flat.get("utm_source"), flat.get("utm_medium"), flat.get("utm_campaign"),
-                  flat.get("utm_content"), flat.get("utm_term"), configService.getCityId, java.time.OffsetDateTime.now
-                )
-              )
-            } else Future.successful(())
-          }
-        } yield {
-          // Log the anon sign-up along with url and query string of the page they came from.
-          val activityStr =
-            if (qString.isEmpty) s"""AnonAutoSignUp_url="$url""""
-            else s"""AnonAutoSignUp_url="$url?${qString.map { case (k, v) => k + "=" + v.mkString }.mkString("&")}""""
-          cc.loggingService.insert(user.userId, request.ipAddress, activityStr)
+      user          <- authenticationService.createUser(newAnonUser, loginInfo.providerID, pwInfo, oldUserId = None)
+      authenticator <- silhouette.env.authenticatorService.create(loginInfo)
+      value         <- silhouette.env.authenticatorService.init(authenticator)
+      // Strip UTM params from redirect to avoid double-capture in index().
+      qStringNoUtm = qString.filterNot { case (k, _) => k.startsWith("utm_") }
+      result <- silhouette.env.authenticatorService.embed(value, Redirect(url, qStringNoUtm))
 
-          silhouette.env.eventBus.publish(SignUpEvent(user, request))
-          silhouette.env.eventBus.publish(LoginEvent(user, request))
+      // Save UTM parameters if present, awaiting the write so failures surface to the error handler (#4229). UTM
+      // params are stripped from the redirect URL (above) to avoid double-capture when index() also checks for UTM
+      // params on returning users.
+      _ <- {
+        if (ControllerUtils.hasUtmParams(qString)) {
+          val flat = qString.map { case (k, v) => k -> v.mkString }
+          userService.insertUserUtm(
+            UserUtm(
+              0, user.userId, flat.get("utm_source"), flat.get("utm_medium"), flat.get("utm_campaign"),
+              flat.get("utm_content"), flat.get("utm_term"), configService.getCityId, java.time.OffsetDateTime.now
+            )
+          )
+        } else Future.successful(())
+      }
+    } yield {
+      // Log the anon sign-up along with url and query string of the page they came from.
+      val activityStr =
+        if (qString.isEmpty) s"""AnonAutoSignUp_url="$url""""
+        else s"""AnonAutoSignUp_url="$url?${qString.map { case (k, v) => k + "=" + v.mkString }.mkString("&")}""""
+      cc.loggingService.insert(user.userId, request.ipAddress, activityStr)
 
-          result
-        }
+      silhouette.env.eventBus.publish(SignUpEvent(user, request))
+      silhouette.env.eventBus.publish(LoginEvent(user, request))
+
+      result
     }
   }
 
@@ -537,49 +575,60 @@ class UserController @Inject() (
               BadRequest(views.html.authentication.forgotPassword(form, commonData))
             },
           email => {
-            val result = Redirect(routes.UserController.forgotPassword())
-              .flashing("info" -> Messages("reset.pw.email.reset.pw.sent"))
-            cc.loggingService.insert(userId, ipAddress, s"""PasswordResetAttempt_Email="$email"""")
-
-            authenticationService.findByEmail(email).flatMap {
-              case Some(user) =>
-                // User exists, create a new token and send an email with the reset link.
-                authenticationService.createToken(user.userId).flatMap { authTokenID =>
-                  val url = routes.UserController.resetPasswordPage(authTokenID).absoluteURL()
-
-                  val resetEmail = Email(
-                    Messages("reset.pw.email.reset.title"),
-                    s"Project Sidewalk <${config.get[String]("noreply-email-address")}>",
-                    Seq(email),
-                    bodyHtml = Some(views.html.authentication.resetPasswordEmail(user, url).body)
-                  )
-
-                  try {
-                    mailerClient.send(resetEmail)
-                    cc.loggingService.insert(userId, ipAddress, s"""PasswordResetSuccess_Email="$email"""")
-                    Future.successful(result)
-                  } catch {
-                    case e: Exception =>
-                      cc.loggingService.insert(
-                        userId,
-                        ipAddress,
-                        s"""PasswordResetFail_Email="$email"_Reason=${e.getClass.getCanonicalName}"""
-                      )
-                      logger.error("Failed to send password reset email", e)
-                      // Show the same confirmation regardless: a mailer outage must not 500 the user, nor reveal
-                      // (via a differing response) that this email is registered. Delivery health is ops' concern.
-                      Future.successful(result)
-                  }
-                }
-
-              // This is the case where the email was not found in the database.
-              case None =>
-                cc.loggingService
-                  .insert(userId, ipAddress, s"""PasswordResetFail_Email="$email"_Reason=EmailNotFound""")
-                Future.successful(result)
-            }
+            // Per-target-email throttle (only possible after form binding) so one address can't be reset-mail bombed
+            // from many IPs; the pre-bind check above bounds per-IP volume. Same block, disjoint key namespaces.
+            rateLimited("forgot", Seq(s"forgot:email:${email.trim.toLowerCase.take(255)}"), "/forgotPassword")
+              .map(Future.successful)
+              .getOrElse(submitForgottenPasswordForEmail(email, userId, ipAddress))
           }
         )
+    }
+  }
+
+  /** Emails password reset instructions to `email` if it belongs to an account, responding identically either way. */
+  private def submitForgottenPasswordForEmail(email: String, userId: Option[String], ipAddress: String)(implicit
+      request: play.silhouette.api.actions.UserAwareRequest[DefaultEnv, play.api.mvc.AnyContent]
+  ): Future[play.api.mvc.Result] = {
+    val result = Redirect(routes.UserController.forgotPassword())
+      .flashing("info" -> Messages("reset.pw.email.reset.pw.sent"))
+    cc.loggingService.insert(userId, ipAddress, s"""PasswordResetAttempt_Email="$email"""")
+
+    authenticationService.findByEmail(email).flatMap {
+      case Some(user) =>
+        // User exists, create a new token and send an email with the reset link.
+        authenticationService.createToken(user.userId).flatMap { authTokenID =>
+          val url = routes.UserController.resetPasswordPage(authTokenID).absoluteURL()
+
+          val resetEmail = Email(
+            Messages("reset.pw.email.reset.title"),
+            s"Project Sidewalk <${config.get[String]("noreply-email-address")}>",
+            Seq(email),
+            bodyHtml = Some(views.html.authentication.resetPasswordEmail(user, url).body)
+          )
+
+          try {
+            mailerClient.send(resetEmail)
+            cc.loggingService.insert(userId, ipAddress, s"""PasswordResetSuccess_Email="$email"""")
+            Future.successful(result)
+          } catch {
+            case e: Exception =>
+              cc.loggingService.insert(
+                userId,
+                ipAddress,
+                s"""PasswordResetFail_Email="$email"_Reason=${e.getClass.getCanonicalName}"""
+              )
+              logger.error("Failed to send password reset email", e)
+              // Show the same confirmation regardless: a mailer outage must not 500 the user, nor reveal
+              // (via a differing response) that this email is registered. Delivery health is ops' concern.
+              Future.successful(result)
+          }
+        }
+
+      // This is the case where the email was not found in the database.
+      case None =>
+        cc.loggingService
+          .insert(userId, ipAddress, s"""PasswordResetFail_Email="$email"_Reason=EmailNotFound""")
+        Future.successful(result)
     }
   }
 
@@ -588,6 +637,17 @@ class UserController @Inject() (
    * @param token The token to identify a user.
    */
   def resetPassword(token: String) = silhouette.UserAwareAction.async { implicit request =>
+    // Per-IP throttle before the token lookup and bcrypt hash; bounds reset-token guessing (#1102). Reset links point
+    // at /resetPassword/:token (a GET page), so bouncing the no-JS fallback to /signIn is a safe, loop-free target.
+    rateLimited("reset-password", Seq(s"reset-password:ip:${request.ipAddress}"), "/signIn")
+      .map(Future.successful)
+      .getOrElse(resetPasswordWithToken(token))
+  }
+
+  /** Validates the reset `token` and updates the account's password from the submitted form. */
+  private def resetPasswordWithToken(token: String)(implicit
+      request: play.silhouette.api.actions.UserAwareRequest[DefaultEnv, play.api.mvc.AnyContent]
+  ): Future[play.api.mvc.Result] = {
     authenticationService.validateToken(token).flatMap {
       case Some(authToken) =>
         ResetPasswordForm.form

--- a/app/controllers/UserController.scala
+++ b/app/controllers/UserController.scala
@@ -68,11 +68,12 @@ class UserController @Inject() (
     Json.obj("errors" -> Json.obj(field -> message))
 
   /**
-   * Checks a named rate limit for the given keys; if any is exceeded, returns a ready 429 response, else `None`.
+   * Counts this attempt against a named rate limit's keys; if any is exceeded, returns a ready 429, else `None`.
    *
-   * On by default via `rate-limit.enabled` (see `RateLimiter`). All keys are counted (so IP- and email-scoped limits
-   * both register the attempt) before deciding. The 429 is JSON for async submits and a flashed redirect for the no-JS
-   * fallback, so both surfaces show the same throttle message.
+   * On by default via `rate-limit.enabled` (see `RateLimiter`). Every key is counted (so IP- and email-scoped limits
+   * both register the attempt) before deciding. Suits the endpoints whose cost is the request itself — a bcrypt hash,
+   * a mailer send — where a legitimate caller has to pay too; `failureThrottled` covers the ones that should only
+   * charge for failures.
    *
    * @param name     The `rate-limit.<name>` block to read the max/window from.
    * @param keys     The keys to count this attempt against (e.g. IP and email scopes).
@@ -83,17 +84,47 @@ class UserController @Inject() (
       request: play.api.mvc.RequestHeader
   ): Option[play.api.mvc.Result] = {
     val limit       = rateLimiter.limit(name)
-    val blockedKeys = keys.filterNot(k => rateLimiter.allow(k, limit.maxAttempts, limit.window))
-    if (blockedKeys.isEmpty) None
-    else {
-      // Quote the longest wait among the tripped scopes, from when its window actually clears (#4740).
-      val retryAfter = blockedKeys.flatMap(rateLimiter.retryAfterSeconds).reduceOption(_ max _)
-      val msg        = Messages("authenticate.error.too.many")
-      val result     =
-        if (wantsJson) TooManyRequests(fieldErrorJson("_summary", msg))
-        else Redirect(redirect).flashing("error" -> msg)
-      Some(result.withHeaders("Retry-After" -> retryAfter.getOrElse(limit.window.toSeconds).toString))
-    }
+    val blockedKeys = keys.filterNot(k => rateLimiter.allow(k, limit))
+    if (blockedKeys.isEmpty) None else Some(throttledResponse(blockedKeys, limit, redirect))
+  }
+
+  /**
+   * Reports whether `key` has already spent a named limit's budget, without counting the current attempt.
+   *
+   * The caller is expected to charge the budget itself — via `rateLimiter.record`/`clear` — once it knows the outcome.
+   * That is what keeps a per-account sign-in throttle from being tripped by *successful* logins, which would lock out
+   * a shared classroom account and would leave the counter running after the right password finally arrived.
+   *
+   * @param name     The `rate-limit.<name>` block to read the max/window from.
+   * @param key      The single key whose budget to inspect.
+   * @param redirect Where the no-JS fallback should bounce to when throttled.
+   * @return `Some(result)` if already over budget, `None` if there is room.
+   */
+  private def failureThrottled(name: String, key: String, redirect: String)(implicit
+      request: play.api.mvc.RequestHeader
+  ): Option[play.api.mvc.Result] = {
+    val limit = rateLimiter.limit(name)
+    if (rateLimiter.isBlocked(key, limit)) Some(throttledResponse(Seq(key), limit, redirect)) else None
+  }
+
+  /**
+   * The throttle response: JSON for async submits, a flashed redirect for the no-JS fallback, so both surfaces show
+   * the same message.
+   *
+   * @param blockedKeys The tripped keys, whose windows set the honest `Retry-After`.
+   * @param limit       The limit they tripped; its window is the fallback when a key has no live window.
+   * @param redirect    Where the no-JS fallback should bounce to.
+   */
+  private def throttledResponse(blockedKeys: Seq[String], limit: service.RateLimiter.Limit, redirect: String)(implicit
+      request: play.api.mvc.RequestHeader
+  ): play.api.mvc.Result = {
+    // Quote the longest wait among the tripped scopes, from when its window actually clears (#4740).
+    val retryAfter = blockedKeys.flatMap(rateLimiter.retryAfterSeconds).reduceOption(_ max _)
+    val msg        = Messages("authenticate.error.too.many")
+    val result     =
+      if (wantsJson) TooManyRequests(fieldErrorJson("_summary", msg))
+      else Redirect(redirect).flashing("error" -> msg)
+    result.withHeaders("Retry-After" -> retryAfter.getOrElse(limit.window.toSeconds).toString)
   }
 
   /**
@@ -235,8 +266,14 @@ class UserController @Inject() (
     val ipAddress: String          = request.ipAddress
     val currUserId: Option[String] = request.identity.map(_.userId)
 
-    // Per-IP throttle before we do any work (inert unless rate-limit.enabled).
-    rateLimited("login", Seq(s"login:ip:$ipAddress"), "/signIn").map(Future.successful).getOrElse {
+    // Two per-IP bounds, both before any work happens. The per-minute one caps how *fast* one address can drive the
+    // bcrypt path while staying generous enough for a classroom behind a single NAT; the per-hour one caps how *many*
+    // accounts it can work through in a sitting, which is credential stuffing — a shape the per-account limit below is
+    // blind to, since every guess there targets a different account. Both are evaluated rather than short-circuited so
+    // that each records the attempt.
+    val burstLimited     = rateLimited("login", Seq(s"login:ip:$ipAddress"), "/signIn")
+    val sustainedLimited = rateLimited("login-ip-hourly", Seq(s"login:ip:hour:$ipAddress"), "/signIn")
+    burstLimited.orElse(sustainedLimited).map(Future.successful).getOrElse {
       SignInForm.form
         .bindFromRequest()
         .fold(
@@ -257,10 +294,22 @@ class UserController @Inject() (
             val identifier: String = data.email.trim
 
             // Per-account throttle keyed on the submitted email-or-username, which only exists after form binding.
-            // This is the actual brute-force backstop (#1102): the per-IP bound above stays generous for classrooms
+            // This is the actual brute-force backstop (#1102): the per-IP bounds above stay generous for classrooms
             // behind one NAT, so a targeted account needs its own, tighter limit. Keyed case-insensitively and
             // length-capped so a flood of giant identifiers can't bloat the limiter's key set.
-            rateLimited("login-identifier", Seq(s"login:id:${identifier.toLowerCase.take(255)}"), "/signIn") match {
+            //
+            // Only *failed* attempts are charged (recorded in the ProviderException branch below, refunded on
+            // success): a budget that counted successes too would lock a shared classroom account out of its own
+            // logins, and would leave the counter running even after the right password arrived. The remaining
+            // tradeoff is deliberate — someone who knows a username can still deny it to its owner for one window by
+            // spending the budget on bad guesses, which is inherent to any per-account limit and is bounded by that
+            // window. One residual: the key is the submitted string, so an account reachable by both username and
+            // email has a bucket for each. Collapsing them would mean a DB lookup before the throttle, i.e. doing the
+            // work the throttle exists to avoid.
+            val idKey   = s"login:id:${identifier.toLowerCase.take(255)}"
+            val idLimit = rateLimiter.limit("login-identifier")
+
+            failureThrottled("login-identifier", idKey, "/signIn") match {
               case Some(throttledResult) =>
                 cc.loggingService.insert(currUserId, ipAddress, s"""SignInThrottled_Email="$identifier"""")
                 Future.successful(throttledResult)
@@ -297,6 +346,9 @@ class UserController @Inject() (
                     .flatMap { loginInfo =>
                       authenticationService.retrieve(loginInfo).flatMap {
                         case Some(user) =>
+                          // Correct credentials: refund the account's budget so a run of typos doesn't follow the
+                          // user into their next session.
+                          rateLimiter.clear(idKey)
                           val c = config.underlying
                           silhouette.env.authenticatorService
                             .create(loginInfo)
@@ -334,6 +386,11 @@ class UserController @Inject() (
                     }
                     .recover {
                       case e: ProviderException =>
+                        // A rejected credential is exactly what the per-account budget is for, so charge it here and
+                        // nowhere else. The generic branch below deliberately doesn't: an outage on our side must not
+                        // spend a real user's budget.
+                        rateLimiter.record(idKey, idLimit)
+
                         // Log failed sign-in due to invalid credentials. Should be the only reason for a failure.
                         val activity: String = s"""SignInFailed_Email="$email"_Reason="invalid credentials""""
                         cc.loggingService.insert(currUserId, ipAddress, activity)
@@ -376,7 +433,8 @@ class UserController @Inject() (
       .getOrElse("/") // Default redirect path if no returnUrl.
     val (returnUrlPath, returnUrlQuery) = parseURL(returnUrl)
 
-    // Per-IP throttle on account creation (inert unless rate-limit.enabled).
+    // Per-IP throttle on account creation, checked pre-bind so rejected POSTs count too — each one still costs a form
+    // bind and, past it, a bcrypt hash.
     rateLimited("signup", Seq(s"signup:ip:$ipAddress"), "/signUp").map(Future.successful).getOrElse {
       SignUpForm.form
         .bindFromRequest()
@@ -564,7 +622,7 @@ class UserController @Inject() (
     val ipAddress: String      = request.ipAddress
     val userId: Option[String] = request.identity.map(_.userId)
 
-    // Per-IP throttle on reset requests (inert unless rate-limit.enabled).
+    // Per-IP throttle on reset requests; the per-target-email one is post-bind, further down.
     rateLimited("forgot", Seq(s"forgot:ip:$ipAddress"), "/forgotPassword").map(Future.successful).getOrElse {
 
       ForgotPasswordForm.form

--- a/app/controllers/base/CustomBaseController.scala
+++ b/app/controllers/base/CustomBaseController.scala
@@ -15,17 +15,18 @@ abstract class CustomBaseController(cc: CustomControllerComponents)
   //  protected def loggingService: LoggingService = cc.loggingService
   //  protected def securityService: CustomControllerComponents = cc.securityService
 
-  // Adds a ipAddress method to RequestHeader for easy access to the client's IP address (cleaner than remoteAddress).
+  // Adds a ipAddress method to RequestHeader for easy access to the client's IP address.
   // See: https://github.com/ProjectSidewalk/SidewalkWebpage/issues/465
   implicit class RequestHeaderExtensions(request: RequestHeader) {
-    def ipAddress: String = {
-      request.headers
-        .get("X-Forwarded-For")
-        .map(_.split(",").head.trim)
-        .filter(_.nonEmpty)
-        .orElse(request.headers.get("X-Real-IP"))
-        .getOrElse(request.remoteAddress.split(",").head.trim)
-    }
+
+    /**
+     * The client IP as resolved by Play's forwarded-header processing (`play.http.forwarded.*` in application.conf):
+     * `remoteAddress` walks X-Forwarded-For right-to-left past trusted proxies (the prod Apache reverse proxy connects
+     * from 127.0.0.1 and appends the true client IP) and yields the first untrusted hop. Unlike taking the header's
+     * first value, a client-supplied X-Forwarded-For cannot spoof this, so it is safe to key rate limits on (#1102).
+     * With no proxy in front (dev/Docker), it is simply the TCP peer address.
+     */
+    def ipAddress: String = request.remoteAddress
   }
 
   // Could add other common controller utilities here. Not sure if they should be here or in ControllerUtils.scala.

--- a/app/service/RateLimiter.scala
+++ b/app/service/RateLimiter.scala
@@ -36,36 +36,56 @@ class RateLimiter @Inject() (config: Configuration) {
   protected def nowMs: Long = System.currentTimeMillis()
 
   /**
-   * Records an attempt against `key` and reports whether it is within the limit.
+   * Records an attempt against `key` and reports whether it is within `limit`.
    *
-   * Always returns true when rate limiting is disabled. Otherwise increments the current window's counter (starting a
-   * fresh window if none is active or the previous one has elapsed) and returns whether the running count is still at or
-   * below `maxAttempts`. Counting is atomic per key via `ConcurrentHashMap.compute`.
+   * Increments the current window's counter (starting a fresh window if none is active or the previous one has
+   * elapsed) and returns whether the running count is still at or below the limit's `maxAttempts`. Counting is atomic
+   * per key via `ConcurrentHashMap.compute`. Honors the limit's own `enabled` flag, which a per-endpoint config block
+   * can set independently of the global `rate-limit.enabled` (story-submit ships enabled so photo uploads are
+   * IP-bounded by default).
    *
-   * @param key         Identifies the thing being limited (e.g. `s"login:ip:$ip"`). Callers namespace their own keys.
-   * @param maxAttempts Attempts allowed within one window before this returns false.
-   * @param window      Length of the fixed window.
-   * @return            True if the attempt is allowed, false if `maxAttempts` has been exceeded within the window.
-   */
-  def allow(key: String, maxAttempts: Int, window: FiniteDuration): Boolean = {
-    if (!enabled) true else allowInWindow(key, maxAttempts, window)
-  }
-
-  /**
-   * Records an attempt against `key` and reports whether it is within `limit`, honoring the limit's own `enabled`
-   * flag (which a per-endpoint config block can turn on even while the global `rate-limit.enabled` is off — e.g.
-   * story-submit ships enabled so photo uploads are IP-bounded by default).
+   * Use this when the limit exists to bound request *volume*, because the work behind the endpoint is itself the cost
+   * — a bcrypt hash, a photo transcode, an Overpass query — so every request has to pay whether or not it turns out to
+   * be legitimate. When the limit instead exists to bound *failures*, pair [[isBlocked]] with [[record]] so a caller
+   * who succeeds never spends budget.
    *
-   * @param key   Identifies the thing being limited; callers namespace their own keys.
+   * @param key   Identifies the thing being limited (e.g. `s"login:ip:$ip"`). Callers namespace their own keys.
    * @param limit The named limit, carrying its max-attempts, window, and effective enabled flag.
    * @return      True if the attempt is allowed, false if the limit has been exceeded within the window.
    */
   def allow(key: String, limit: RateLimiter.Limit): Boolean = {
-    if (!limit.enabled) true else allowInWindow(key, limit.maxAttempts, limit.window)
+    if (!limit.enabled) true else countAttempt(key, limit.window) <= limit.maxAttempts
   }
 
-  /** The window-counting core shared by both `allow` overloads; assumes the enabled check already passed. */
-  private def allowInWindow(key: String, maxAttempts: Int, window: FiniteDuration): Boolean = {
+  /**
+   * Reports whether `key` has already spent `limit`'s budget in the current window, *without* recording an attempt.
+   *
+   * The read half of the failure-counted pattern: check here, then [[record]] only on the outcome that should cost
+   * something and [[clear]] on the one that shouldn't. Sign-in uses it so that a shared classroom account isn't locked
+   * out by its own successful logins, and so the right password resets the counter instead of inheriting it.
+   *
+   * @param key   Identifies the thing being limited; callers namespace their own keys.
+   * @param limit The named limit, carrying its max-attempts, window, and effective enabled flag.
+   * @return      True if a further attempt would exceed the limit; false if the budget or the window has room.
+   */
+  def isBlocked(key: String, limit: RateLimiter.Limit): Boolean = {
+    if (!limit.enabled) false
+    else {
+      val now = nowMs
+      Option(windows.get(key)).exists(w => now - w.startMs < w.windowMs && w.count >= limit.maxAttempts)
+    }
+  }
+
+  /** Spends one unit of `key`'s budget, starting a window if none is active. The write half of [[isBlocked]]. */
+  def record(key: String, limit: RateLimiter.Limit): Unit = {
+    if (limit.enabled) { val _ = countAttempt(key, limit.window) }
+  }
+
+  /** Restores `key`'s full budget, ending its window early (e.g. a sign-in that finally succeeded). */
+  def clear(key: String): Unit = { val _ = windows.remove(key) }
+
+  /** Counts one attempt against `key` and returns the running count; starts a fresh window if none is live. */
+  private def countAttempt(key: String, window: FiniteDuration): Int = {
     val now      = nowMs
     val windowMs = window.toMillis
     if (windows.size > MaxTrackedKeys) evictExpired(now)
@@ -73,14 +93,14 @@ class RateLimiter @Inject() (config: Configuration) {
     val remap: BiFunction[String, Window, Window] = (_, existing) =>
       if (existing == null || now - existing.startMs >= windowMs) Window(now, windowMs, 1)
       else existing.copy(count = existing.count + 1)
-    windows.compute(key, remap).count <= maxAttempts
+    windows.compute(key, remap).count
   }
 
   /**
    * Looks up a named limit from the `rate-limit.<name>` config block. A block may carry its own `enabled` flag; when
    * absent it inherits the global `rate-limit.enabled`, so an endpoint can opt in to limiting independently.
    *
-   * @param name The limit's config key (e.g. "login", "signup", "ai-ingest").
+   * @param name The limit's config key (e.g. "login", "signup", "story-submit").
    * @return     The configured max-attempts, window, and effective enabled flag.
    */
   def limit(name: String): RateLimiter.Limit = {

--- a/app/service/RateLimiter.scala
+++ b/app/service/RateLimiter.scala
@@ -10,10 +10,11 @@ import scala.concurrent.duration.{DurationInt, FiniteDuration}
 /**
  * In-memory, fixed-window rate limiter for a single application instance.
  *
- * Tracks a per-key attempt count within a sliding fixed window. It is a no-op when `rate-limit.enabled` is false, so it
- * can be wired into endpoints and shipped inert, then enabled by config once the deployment's proxy client-IP handling
- * is confirmed (see `CustomBaseController.ipAddress`). State is per-instance and resets on restart, which fits the
- * current single-instance deployment; a multi-instance future would need a shared store (e.g. Redis).
+ * Tracks a per-key attempt count within a sliding fixed window. On by default (`rate-limit.enabled`); a deployment can
+ * turn it off with `RATE_LIMIT_ENABLED=false`. IP keys are safe to limit on because client IPs come from Play's
+ * forwarded-header processing (`play.http.forwarded.*`; see `CustomBaseController.ipAddress`), which a client-supplied
+ * X-Forwarded-For can't spoof. State is per-instance and resets on restart, which fits the current
+ * one-process-per-city deployment; a multi-instance future would need a shared store (e.g. Redis).
  *
  * @param config Application configuration; supplies `rate-limit.enabled` and the per-endpoint limit blocks.
  */

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -165,6 +165,14 @@ play.http.session {
 # https://www.playframework.com/documentation/3.0.x/SettingsLogger
 play.logger.includeConfigProperties=true
 
+# Client IPs come from Play's forwarded-header processing: request.remoteAddress walks X-Forwarded-For right-to-left
+# past trustedProxies and yields the first untrusted hop, so a client-supplied X-Forwarded-For can't spoof it (#1102).
+# Prod's Apache reverse proxy connects from 127.0.0.1 on the same host. These ARE Play's defaults; pinned here because
+# rate limiting and activity logging depend on them. If a proxy hop is ever added or moved off-host, extend
+# trustedProxies accordingly.
+play.http.forwarded.version = "x-forwarded"
+play.http.forwarded.trustedProxies = ["127.0.0.1", "::1"]
+
 # API keys and secrets for various services.
 mapbox-api-key = ${?MAPBOX_API_KEY}
 google-maps-api-key = ${?GOOGLE_MAPS_API_KEY}
@@ -178,21 +186,27 @@ infra3d-client-secret-zurich = ${?INFRA3D_CLIENT_SECRET_ZURICH}
 infra3d-client-secret-winterthur = ${?INFRA3D_CLIENT_SECRET_WINTERTHUR}
 internal-api-key = ${?INTERNAL_API_KEY}
 
-# In-memory auth rate limiting (service.RateLimiter). Shipped disabled; enable per deployment via RATE_LIMIT_ENABLED
-# only after confirming the prod proxy forwards the real client IP (see CustomBaseController.ipAddress).
+# In-memory auth rate limiting (service.RateLimiter). Enabled by default now that client IPs are spoof-resistant
+# (play.http.forwarded above); set RATE_LIMIT_ENABLED=false to turn it off for a deployment. Per-IP limits are sized
+# to be classroom-safe: 30-40 students behind one school NAT IP signing in/up within a few minutes must not trip them.
+# The per-account brute-force backstop is login-identifier, not the per-IP login bound (#1102).
 rate-limit {
-  enabled = false
+  enabled = true
   enabled = ${?RATE_LIMIT_ENABLED}
-  login {         max-attempts = 10,  window-seconds = 60 }   # per IP and per email
-  signup {        max-attempts = 5,   window-seconds = 3600 } # per IP
-  forgot {        max-attempts = 5,   window-seconds = 3600 } # per email+IP
-  anon-signup {   max-attempts = 30,  window-seconds = 3600 } # per IP
-  ai-ingest {     max-attempts = 120, window-seconds = 60 }   # per IP (bulk caller; caps requests, not labels)
-  speed-limit {   max-attempts = 60,  window-seconds = 60 }   # per IP (cache misses trigger an Overpass query)
-  # Enabled by default (independent of the global flag above): stories accept anonymous uploads that each cost a photo
-  # transcode, and the per-user DB cap resets per anonymous session, so an IP bound is the practical spam/abuse floor.
-  # Keys on the client IP from X-Forwarded-For (CustomBaseController.ipAddress); set enabled=false to revert.
-  story-submit {  enabled = true, max-attempts = 20, window-seconds = 86400 } # per IP (on top of the per-user DB cap)
+  login            { max-attempts = 40,  window-seconds = 60 }   # per IP, checked before form binding
+  login-identifier { max-attempts = 10,  window-seconds = 300 }  # per submitted email/username, after binding
+  signup           { max-attempts = 100, window-seconds = 3600 } # per IP (pre-bind: rejected POSTs count too)
+  forgot           { max-attempts = 10,  window-seconds = 3600 } # per IP (pre-bind) and per target email (post-bind)
+  reset-password   { max-attempts = 20,  window-seconds = 3600 } # per IP (bounds token guessing + bcrypt CPU)
+  # Crawlers currently funnel through /anonSignUp for every secured page (see SeoController), so this needs crawl
+  # headroom until public pages render sessionless (#4643); tighten afterwards. The throttle response must stay a
+  # plain 429 — a redirect would loop via CustomSecuredErrorHandler.
+  anon-signup      { max-attempts = 100, window-seconds = 3600 } # per IP
+  ai-ingest        { max-attempts = 120, window-seconds = 60 }   # per IP (bulk caller; caps requests, not labels)
+  speed-limit      { max-attempts = 60,  window-seconds = 60 }   # per IP (cache misses trigger an Overpass query)
+  # Stories accept anonymous uploads that each cost a photo transcode, and the per-user DB cap resets per anonymous
+  # session, so an IP bound is the practical spam/abuse floor (on top of the per-user DB cap).
+  story-submit     { enabled = true, max-attempts = 20, window-seconds = 86400 } # per IP
 }
 
 # Sidewalk AI API settings. The ai-enabled flag is only used so that we can disable AI requests in the dev env.

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -194,15 +194,20 @@ rate-limit {
   enabled = true
   enabled = ${?RATE_LIMIT_ENABLED}
   login            { max-attempts = 40,  window-seconds = 60 }   # per IP, checked before form binding
+  # A second, wider bound on the same IP. The per-minute limit above caps burst rate; this caps total volume, which is
+  # what credential stuffing looks like — many accounts, one guess each, slowly. 300/hr clears a full class signing in
+  # (and fumbling a few passwords) with room to spare while cutting an unattended stuffing run by ~8x.
+  login-ip-hourly  { max-attempts = 300, window-seconds = 3600 } # per IP, checked before form binding
+  # Counts only FAILED sign-ins and is refunded on success (see UserController.authenticate), so a shared account
+  # can't lock itself out and a run of typos doesn't outlive the login that fixes them.
   login-identifier { max-attempts = 10,  window-seconds = 300 }  # per submitted email/username, after binding
-  signup           { max-attempts = 100, window-seconds = 3600 } # per IP (pre-bind: rejected POSTs count too)
+  signup           { max-attempts = 50,  window-seconds = 3600 } # per IP (pre-bind: rejected POSTs count too)
   forgot           { max-attempts = 10,  window-seconds = 3600 } # per IP (pre-bind) and per target email (post-bind)
   reset-password   { max-attempts = 20,  window-seconds = 3600 } # per IP (bounds token guessing + bcrypt CPU)
   # Crawlers currently funnel through /anonSignUp for every secured page (see SeoController), so this needs crawl
   # headroom until public pages render sessionless (#4643); tighten afterwards. The throttle response must stay a
   # plain 429 — a redirect would loop via CustomSecuredErrorHandler.
   anon-signup      { max-attempts = 100, window-seconds = 3600 } # per IP
-  ai-ingest        { max-attempts = 120, window-seconds = 60 }   # per IP (bulk caller; caps requests, not labels)
   speed-limit      { max-attempts = 60,  window-seconds = 60 }   # per IP (cache misses trigger an Overpass query)
   # Stories accept anonymous uploads that each cost a photo transcode, and the per-user DB cap resets per anonymous
   # session, so an IP bound is the practical spam/abuse floor (on top of the per-user DB cap).

--- a/test/controllers/ForwardedClientIpSpec.scala
+++ b/test/controllers/ForwardedClientIpSpec.scala
@@ -1,0 +1,56 @@
+package controllers
+
+import org.scalatestplus.play.PlaySpec
+import org.scalatestplus.play.guice.GuiceOneServerPerSuite
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.ws.WSClient
+import play.api.test.Helpers._
+
+/**
+ * End-to-end proof that client IPs are spoof-resistant (#1102): Play's forwarded-header processing
+ * (`play.http.forwarded.*`) resolves `remoteAddress` by walking X-Forwarded-For right-to-left past trusted proxies,
+ * so a client-supplied left-hand hop can't move a request into a different rate-limit bucket.
+ *
+ * This needs a real server (`route()` bypasses the server layer where the header is processed). The test client
+ * connects from 127.0.0.1 — a trusted proxy, i.e. exactly the position of the prod Apache reverse proxy — so the
+ * rightmost X-Forwarded-For entry plays the role of the address Apache appends for the true client.
+ */
+class ForwardedClientIpSpec extends PlaySpec with GuiceOneServerPerSuite {
+
+  override def fakeApplication(): Application =
+    new GuiceApplicationBuilder()
+      .disable[modules.ActorModule]
+      .configure(
+        "rate-limit.enabled"                    -> true,
+        "rate-limit.anon-signup.max-attempts"   -> 1,
+        "rate-limit.anon-signup.window-seconds" -> 3600
+      )
+      .build()
+
+  "Client IP resolution behind the reverse proxy" should {
+    "key rate limits on the rightmost untrusted X-Forwarded-For hop, ignoring client-supplied ones" in {
+      val ws                      = app.injector.instanceOf[WSClient]
+      def anonSignUp(xff: String) =
+        await(
+          ws.url(s"http://localhost:$port/anonSignUp")
+            .withHttpHeaders("X-Forwarded-For" -> xff)
+            .withFollowRedirects(false)
+            .get()
+        )
+
+      // Budget is 1 per IP. The rightmost hop (what the trusted proxy appends: the true client) is the bucket key.
+      anonSignUp("6.6.6.6, 2.2.2.2").status mustBe SEE_OTHER
+
+      // Same true client, different spoofed left-hand hop: must land in the same bucket and get throttled. Under the
+      // old first-XFF-value resolution this would have been a fresh bucket and a 303.
+      val throttled = anonSignUp("9.9.9.9, 2.2.2.2")
+      throttled.status mustBe TOO_MANY_REQUESTS
+      throttled.header("Retry-After") mustBe defined
+      throttled.header("Location") mustBe empty
+
+      // A different true client is its own bucket.
+      anonSignUp("6.6.6.6, 3.3.3.3").status mustBe SEE_OTHER
+    }
+  }
+}

--- a/test/controllers/UserAuthControllerSpec.scala
+++ b/test/controllers/UserAuthControllerSpec.scala
@@ -25,7 +25,13 @@ import java.util.UUID
 class UserAuthControllerSpec extends PlaySpec with GuiceOneAppPerSuite {
 
   override def fakeApplication(): Application =
-    new GuiceApplicationBuilder().disable[modules.ActorModule].build()
+    new GuiceApplicationBuilder()
+      .disable[modules.ActorModule]
+      // All requests here share FakeRequest's default 127.0.0.1, so the suite's auth POSTs would eat into one shared
+      // per-IP budget. Throttle behavior has its own dedicated coverage (UserAuthRateLimitSpec); keeping the limiter
+      // off here decouples these tests from limit tuning.
+      .configure("rate-limit.enabled" -> false)
+      .build()
 
   implicit lazy val mat: Materializer = app.materializer
 

--- a/test/controllers/UserAuthRateLimitSpec.scala
+++ b/test/controllers/UserAuthRateLimitSpec.scala
@@ -5,14 +5,20 @@ import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.mvc.request.RemoteConnection
 import play.api.test.CSRFTokenHelper._
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 
 /**
- * Proves the auth rate limiter is actually wired into the sign-in path (#4375). Boots the app with
- * `rate-limit.enabled = true` and a tiny per-window budget, then exceeds it and asserts the throttle response — the
- * default-off `UserAuthControllerSpec` can't cover this since the limiter is inert there.
+ * Proves the auth rate limiter is actually wired into the sign-in, anon-signup, and password-reset paths
+ * (#4375, #1102). Boots the app with tiny per-window budgets, then exceeds them and asserts the throttle responses —
+ * `UserAuthControllerSpec` pins the limiter off, so it can't cover this.
+ *
+ * One app per suite means one shared limiter, so each test isolates its buckets with its own fake source IPs (via
+ * `withConnection`) and its own identifiers. Note that `route()` bypasses the server layer where Play processes
+ * X-Forwarded-For, so `withConnection` sets the resolved remote address directly; end-to-end header processing is
+ * covered by `ForwardedClientIpSpec`.
  */
 class UserAuthRateLimitSpec extends PlaySpec with GuiceOneAppPerSuite {
 
@@ -20,24 +26,34 @@ class UserAuthRateLimitSpec extends PlaySpec with GuiceOneAppPerSuite {
     new GuiceApplicationBuilder()
       .disable[modules.ActorModule]
       .configure(
-        "rate-limit.enabled"              -> true,
-        "rate-limit.login.max-attempts"   -> 2,
-        "rate-limit.login.window-seconds" -> 60
+        "rate-limit.enabled"                         -> true,
+        "rate-limit.login.max-attempts"              -> 2,
+        "rate-limit.login.window-seconds"            -> 60,
+        "rate-limit.login-identifier.max-attempts"   -> 2,
+        "rate-limit.login-identifier.window-seconds" -> 300,
+        "rate-limit.anon-signup.max-attempts"        -> 2,
+        "rate-limit.anon-signup.window-seconds"      -> 3600,
+        "rate-limit.reset-password.max-attempts"     -> 2,
+        "rate-limit.reset-password.window-seconds"   -> 3600,
+        "rate-limit.forgot.max-attempts"             -> 2,
+        "rate-limit.forgot.window-seconds"           -> 3600
       )
       .build()
 
   implicit lazy val mat: Materializer = app.materializer
 
-  private def badLogin() =
+  private def badLogin(email: String = "throttle@example.test", ip: Option[String] = None) = {
+    val base = FakeRequest(POST, "/authenticate/credentials")
     route(
       app,
-      FakeRequest(POST, "/authenticate/credentials")
+      ip.fold(base)(addr => base.withConnection(RemoteConnection(addr, secure = false, None)))
         .withHeaders("X-Requested-With" -> "XMLHttpRequest")
-        .withFormUrlEncodedBody("email" -> "throttle@example.test", "password" -> "WrongPass9A", "rememberMe" -> "true")
+        .withFormUrlEncodedBody("email" -> email, "password" -> "WrongPass9A", "rememberMe" -> "true")
         .withCSRFToken
     ).get
+  }
 
-  "The login rate limiter" should {
+  "The per-IP login rate limiter" should {
     "return 429 with a Retry-After header once the per-window attempt budget is exceeded" in {
       // First two attempts are within budget (unauthorized, not throttled).
       status(badLogin()) mustBe UNAUTHORIZED
@@ -48,6 +64,111 @@ class UserAuthRateLimitSpec extends PlaySpec with GuiceOneAppPerSuite {
       status(throttled) mustBe TOO_MANY_REQUESTS
       header("Retry-After", throttled) mustBe defined
       (contentAsJson(throttled) \ "errors" \ "_summary").asOpt[String] mustBe defined
+    }
+
+    "not consult the X-Forwarded-For header when bucketing by IP" in {
+      // Same source address, a different client-supplied XFF each time. The old first-XFF-value resolution would have
+      // put each request in its own bucket and never throttled; remoteAddress-based resolution must ignore the header
+      // (#1102). Distinct identifiers keep the per-identifier limit out of the picture.
+      def spoofed(n: Int) =
+        route(
+          app,
+          FakeRequest(POST, "/authenticate/credentials")
+            .withConnection(RemoteConnection("10.2.0.1", secure = false, None))
+            .withHeaders("X-Requested-With" -> "XMLHttpRequest", "X-Forwarded-For" -> s"172.16.$n.$n")
+            .withFormUrlEncodedBody("email" -> s"xff$n@example.test", "password" -> "WrongPass9A")
+            .withCSRFToken
+        ).get
+
+      status(spoofed(1)) mustBe UNAUTHORIZED
+      status(spoofed(2)) mustBe UNAUTHORIZED
+      status(spoofed(3)) mustBe TOO_MANY_REQUESTS
+    }
+  }
+
+  "The per-identifier login rate limiter" should {
+    "throttle a targeted account across distinct IPs, keyed case-insensitively" in {
+      // Each attempt comes from a fresh IP, so only the identifier bucket can accumulate.
+      status(badLogin("Target@Example.Test", Some("10.1.0.1"))) mustBe UNAUTHORIZED
+      status(badLogin("target@example.test", Some("10.1.0.2"))) mustBe UNAUTHORIZED
+
+      val throttled = badLogin("TARGET@EXAMPLE.TEST", Some("10.1.0.3"))
+      status(throttled) mustBe TOO_MANY_REQUESTS
+      header("Retry-After", throttled) mustBe defined
+
+      // A different identifier from yet another fresh IP is unaffected — proves the key, not some global counter.
+      status(badLogin("someone.else@example.test", Some("10.1.0.4"))) mustBe UNAUTHORIZED
+    }
+  }
+
+  "The anon-signup rate limiter" should {
+    "return a plain 429 — never a redirect — once the per-IP budget is exceeded" in {
+      def anonSignUp() =
+        route(
+          app,
+          FakeRequest(GET, "/anonSignUp?url=%2F").withConnection(RemoteConnection("10.3.0.1", secure = false, None))
+        ).get
+
+      status(anonSignUp()) mustBe SEE_OTHER
+      status(anonSignUp()) mustBe SEE_OTHER
+
+      val throttled = anonSignUp()
+      status(throttled) mustBe TOO_MANY_REQUESTS
+      header("Retry-After", throttled) mustBe defined
+      // Guard against a future refactor responding with a redirect: every SecuredAction bounces cookie-less clients
+      // back to /anonSignUp, so a redirect here would loop.
+      header("Location", throttled) mustBe empty
+    }
+  }
+
+  "The reset-password rate limiter" should {
+    "throttle repeated reset attempts from one IP" in {
+      def resetAttempt() =
+        route(
+          app,
+          FakeRequest(POST, "/resetPassword?token=not-a-real-token")
+            .withConnection(RemoteConnection("10.4.0.1", secure = false, None))
+            // XHR marker so the throttle branch answers 429 JSON; the within-budget bounce is a 303 either way,
+            // which keeps the two outcomes distinguishable by status.
+            .withHeaders("X-Requested-With" -> "XMLHttpRequest")
+            .withFormUrlEncodedBody("password" -> "NewPass9A", "passwordConfirm" -> "NewPass9A")
+            .withCSRFToken
+        ).get
+
+      // Bogus tokens bounce to /signIn with a flash; that's the within-budget behavior.
+      status(resetAttempt()) mustBe SEE_OTHER
+      status(resetAttempt()) mustBe SEE_OTHER
+
+      val throttled = resetAttempt()
+      status(throttled) mustBe TOO_MANY_REQUESTS
+      header("Retry-After", throttled) mustBe defined
+    }
+  }
+
+  "The forgot-password rate limiter" should {
+    "throttle one target email across distinct IPs" in {
+      // An unknown address exercises the EmailNotFound path, so no mail delivery is involved.
+      def forgot(email: String, ip: String) =
+        route(
+          app,
+          FakeRequest(POST, "/forgotPassword")
+            .withConnection(RemoteConnection(ip, secure = false, None))
+            // XHR marker so the throttle branch answers 429 JSON instead of a 303 that would mimic the success bounce.
+            .withHeaders("X-Requested-With" -> "XMLHttpRequest")
+            .withFormUrlEncodedBody("emailForgotPassword" -> email)
+            .withCSRFToken
+        ).get
+
+      status(forgot("bombed@example.test", "10.5.0.1")) mustBe SEE_OTHER
+      status(forgot("bombed@example.test", "10.5.0.2")) mustBe SEE_OTHER
+
+      // Third request for the same address rides a fresh IP, so only the per-email key can be what throttles it.
+      val throttled = forgot("bombed@example.test", "10.5.0.3")
+      status(throttled) mustBe TOO_MANY_REQUESTS
+      header("Retry-After", throttled) mustBe defined
+
+      // A different address from another fresh IP is unaffected.
+      status(forgot("fine@example.test", "10.5.0.4")) mustBe SEE_OTHER
     }
   }
 }

--- a/test/controllers/UserAuthRateLimitSpec.scala
+++ b/test/controllers/UserAuthRateLimitSpec.scala
@@ -10,6 +10,8 @@ import play.api.test.CSRFTokenHelper._
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 
+import java.util.UUID
+
 /**
  * Proves the auth rate limiter is actually wired into the sign-in, anon-signup, and password-reset paths
  * (#4375, #1102). Boots the app with tiny per-window budgets, then exceeds them and asserts the throttle responses —
@@ -42,11 +44,12 @@ class UserAuthRateLimitSpec extends PlaySpec with GuiceOneAppPerSuite {
 
   implicit lazy val mat: Materializer = app.materializer
 
-  private def badLogin(email: String = "throttle@example.test", ip: Option[String] = None) = {
-    val base = FakeRequest(POST, "/authenticate/credentials")
+  /** A sign-in that can't succeed, from a caller-chosen source address so each test owns its own per-IP bucket. */
+  private def badLogin(email: String, ip: String) = {
     route(
       app,
-      ip.fold(base)(addr => base.withConnection(RemoteConnection(addr, secure = false, None)))
+      FakeRequest(POST, "/authenticate/credentials")
+        .withConnection(RemoteConnection(ip, secure = false, None))
         .withHeaders("X-Requested-With" -> "XMLHttpRequest")
         .withFormUrlEncodedBody("email" -> email, "password" -> "WrongPass9A", "rememberMe" -> "true")
         .withCSRFToken
@@ -55,12 +58,14 @@ class UserAuthRateLimitSpec extends PlaySpec with GuiceOneAppPerSuite {
 
   "The per-IP login rate limiter" should {
     "return 429 with a Retry-After header once the per-window attempt budget is exceeded" in {
-      // First two attempts are within budget (unauthorized, not throttled).
-      status(badLogin()) mustBe UNAUTHORIZED
-      status(badLogin()) mustBe UNAUTHORIZED
+      // A distinct identifier per attempt, so only the per-IP bucket can accumulate — otherwise the per-identifier
+      // limit (also 2 here) would trip on the same attempt and the assertion couldn't tell the two apart.
+      def attempt(n: Int) = badLogin(s"burst$n@example.test", "10.0.0.1")
 
-      // The third crosses the limit.
-      val throttled = badLogin()
+      status(attempt(1)) mustBe UNAUTHORIZED
+      status(attempt(2)) mustBe UNAUTHORIZED
+
+      val throttled = attempt(3)
       status(throttled) mustBe TOO_MANY_REQUESTS
       header("Retry-After", throttled) mustBe defined
       (contentAsJson(throttled) \ "errors" \ "_summary").asOpt[String] mustBe defined
@@ -89,15 +94,58 @@ class UserAuthRateLimitSpec extends PlaySpec with GuiceOneAppPerSuite {
   "The per-identifier login rate limiter" should {
     "throttle a targeted account across distinct IPs, keyed case-insensitively" in {
       // Each attempt comes from a fresh IP, so only the identifier bucket can accumulate.
-      status(badLogin("Target@Example.Test", Some("10.1.0.1"))) mustBe UNAUTHORIZED
-      status(badLogin("target@example.test", Some("10.1.0.2"))) mustBe UNAUTHORIZED
+      status(badLogin("Target@Example.Test", "10.1.0.1")) mustBe UNAUTHORIZED
+      status(badLogin("target@example.test", "10.1.0.2")) mustBe UNAUTHORIZED
 
-      val throttled = badLogin("TARGET@EXAMPLE.TEST", Some("10.1.0.3"))
+      val throttled = badLogin("TARGET@EXAMPLE.TEST", "10.1.0.3")
       status(throttled) mustBe TOO_MANY_REQUESTS
       header("Retry-After", throttled) mustBe defined
 
       // A different identifier from yet another fresh IP is unaffected — proves the key, not some global counter.
-      status(badLogin("someone.else@example.test", Some("10.1.0.4"))) mustBe UNAUTHORIZED
+      status(badLogin("someone.else@example.test", "10.1.0.4")) mustBe UNAUTHORIZED
+    }
+
+    "charge only failed attempts, refunding the budget when a sign-in succeeds" in {
+      // Needs a real account so the success path actually runs. Every request rides its own IP: the per-IP budget is
+      // 2 here and this test needs six.
+      val tag      = UUID.randomUUID().toString.replace("-", "").take(20)
+      val email    = s"refund.$tag@example.test"
+      val password = "TestPass1"
+
+      val signUp = route(
+        app,
+        FakeRequest(POST, "/signUp")
+          .withConnection(RemoteConnection("10.6.0.1", secure = false, None))
+          .withHeaders("X-Requested-With" -> "XMLHttpRequest")
+          .withFormUrlEncodedBody(
+            "username"        -> s"refund$tag",
+            "email"           -> email,
+            "password"        -> password,
+            "passwordConfirm" -> password,
+            "terms"           -> "true",
+            "returnUrl"       -> "/explore"
+          )
+          .withCSRFToken
+      ).get
+      status(signUp) mustBe OK
+
+      def goodLogin(ip: String) = route(
+        app,
+        FakeRequest(POST, "/authenticate/credentials")
+          .withConnection(RemoteConnection(ip, secure = false, None))
+          .withHeaders("X-Requested-With" -> "XMLHttpRequest")
+          .withFormUrlEncodedBody("email" -> email, "password" -> password, "rememberMe" -> "false")
+          .withCSRFToken
+      ).get
+
+      status(badLogin(email, "10.6.0.2")) mustBe UNAUTHORIZED // 1 of 2 spent.
+      status(goodLogin("10.6.0.3")) mustBe OK                 // Refunds it.
+
+      // A limiter that charged every attempt would be at three by now and answer 429. Two more failures must fit.
+      status(badLogin(email, "10.6.0.4")) mustBe UNAUTHORIZED
+      status(badLogin(email, "10.6.0.5")) mustBe UNAUTHORIZED
+
+      status(badLogin(email, "10.6.0.6")) mustBe TOO_MANY_REQUESTS
     }
   }
 
@@ -169,6 +217,52 @@ class UserAuthRateLimitSpec extends PlaySpec with GuiceOneAppPerSuite {
 
       // A different address from another fresh IP is unaffected.
       status(forgot("fine@example.test", "10.5.0.4")) mustBe SEE_OTHER
+    }
+  }
+}
+
+/**
+ * Sign-in carries two per-IP bounds — a per-minute burst cap and a per-hour volume cap — and from a single address
+ * only the tighter of the two can ever be observed, so this suite exists to make the volume cap the binding one.
+ * That cap is what covers credential stuffing: many accounts, one guess each, spread thinly enough that a per-minute
+ * cap never notices and a per-account cap never sees the same account twice. `UserAuthRateLimitSpec` has the budgets
+ * the other way round and covers the burst cap.
+ */
+class LoginIpVolumeRateLimitSpec extends PlaySpec with GuiceOneAppPerSuite {
+
+  override def fakeApplication(): Application =
+    new GuiceApplicationBuilder()
+      .disable[modules.ActorModule]
+      .configure(
+        "rate-limit.enabled"                        -> true,
+        "rate-limit.login.max-attempts"             -> 100, // Held out of the way so only the hourly bound can trip.
+        "rate-limit.login.window-seconds"           -> 60,
+        "rate-limit.login-ip-hourly.max-attempts"   -> 2,
+        "rate-limit.login-ip-hourly.window-seconds" -> 3600
+      )
+      .build()
+
+  implicit lazy val mat: Materializer = app.materializer
+
+  "The per-IP hourly login volume limiter" should {
+    "throttle one address working through a series of different accounts" in {
+      // A different account every time, so neither the per-identifier budget nor some global counter can explain it.
+      def attempt(n: Int) =
+        route(
+          app,
+          FakeRequest(POST, "/authenticate/credentials")
+            .withConnection(RemoteConnection("10.7.0.1", secure = false, None))
+            .withHeaders("X-Requested-With" -> "XMLHttpRequest")
+            .withFormUrlEncodedBody("email" -> s"stuffing$n@example.test", "password" -> "WrongPass9A")
+            .withCSRFToken
+        ).get
+
+      status(attempt(1)) mustBe UNAUTHORIZED
+      status(attempt(2)) mustBe UNAUTHORIZED
+
+      val throttled = attempt(3)
+      status(throttled) mustBe TOO_MANY_REQUESTS
+      header("Retry-After", throttled) mustBe defined
     }
   }
 }

--- a/test/service/RateLimiterSpec.scala
+++ b/test/service/RateLimiterSpec.scala
@@ -27,49 +27,64 @@ class RateLimiterSpec extends PlaySpec {
       }
     """)))
 
+  /** An ad-hoc limit, so counting behavior can be exercised without going through a config block. */
+  private def lim(maxAttempts: Int, seconds: Int = 60, enabled: Boolean = true): RateLimiter.Limit =
+    RateLimiter.Limit(maxAttempts, seconds.seconds, enabled)
+
   "RateLimiter.allow" should {
     "allow up to maxAttempts within a window, then deny" in {
       val rl = limiter(enabled = true)
-      rl.allow("k", 3, 60.seconds) mustBe true
-      rl.allow("k", 3, 60.seconds) mustBe true
-      rl.allow("k", 3, 60.seconds) mustBe true
-      rl.allow("k", 3, 60.seconds) mustBe false
+      rl.allow("k", lim(3)) mustBe true
+      rl.allow("k", lim(3)) mustBe true
+      rl.allow("k", lim(3)) mustBe true
+      rl.allow("k", lim(3)) mustBe false
     }
 
     "reset the counter once the window elapses" in {
       val rl = limiter(enabled = true)
-      rl.allow("k", 2, 60.seconds) mustBe true
-      rl.allow("k", 2, 60.seconds) mustBe true
-      rl.allow("k", 2, 60.seconds) mustBe false
+      rl.allow("k", lim(2)) mustBe true
+      rl.allow("k", lim(2)) mustBe true
+      rl.allow("k", lim(2)) mustBe false
       rl.currentMs = 60000 // advance exactly one window
-      rl.allow("k", 2, 60.seconds) mustBe true
+      rl.allow("k", lim(2)) mustBe true
     }
 
     "not reset until the full window has elapsed" in {
       val rl = limiter(enabled = true)
-      rl.allow("k", 1, 60.seconds) mustBe true
+      rl.allow("k", lim(1)) mustBe true
       rl.currentMs = 59999 // one ms short of the window
-      rl.allow("k", 1, 60.seconds) mustBe false
+      rl.allow("k", lim(1)) mustBe false
     }
 
     "track keys independently" in {
       val rl = limiter(enabled = true)
-      rl.allow("a", 1, 60.seconds) mustBe true
-      rl.allow("a", 1, 60.seconds) mustBe false
-      rl.allow("b", 1, 60.seconds) mustBe true
+      rl.allow("a", lim(1)) mustBe true
+      rl.allow("a", lim(1)) mustBe false
+      rl.allow("b", lim(1)) mustBe true
     }
 
-    "be a no-op (always allow) when disabled" in {
-      val rl = limiter(enabled = false)
-      (1 to 100).foreach(_ => rl.allow("k", 1, 60.seconds) mustBe true)
+    "enforce a limit whose block opts in, even while global rate limiting is disabled" in {
+      val rl    = limiter(enabled = false)
+      val story = rl.limit("story-submit") // enabled = true, max-attempts = 2
+      rl.allow("ip:1", story) mustBe true
+      rl.allow("ip:1", story) mustBe true
+      rl.allow("ip:1", story) mustBe false
+    }
+
+    "be a no-op for a limit that is not enabled" in {
+      // A login limit with the global off and no block flag -> disabled -> never denies. The enabled decision belongs
+      // to the Limit, so an endpoint can't accidentally consult the global flag instead of its own block's.
+      val rl    = limiter(enabled = false)
+      val login = rl.limit("login")
+      (1 to 100).foreach(_ => rl.allow("ip:1", login) mustBe true)
     }
   }
 
   "RateLimiter.limit" should {
     "read max-attempts and window from the named config block" in {
-      val lim = limiter(enabled = true).limit("login")
-      lim.maxAttempts mustBe 3
-      lim.window mustBe 60.seconds
+      val login = limiter(enabled = true).limit("login")
+      login.maxAttempts mustBe 3
+      login.window mustBe 60.seconds
     }
 
     "let a block's own enabled flag override the global default when the global is off" in {
@@ -83,41 +98,74 @@ class RateLimiterSpec extends PlaySpec {
     }
   }
 
-  "RateLimiter.allow(key, limit)" should {
-    "enforce a limit whose block opts in, even while global rate limiting is disabled" in {
-      val rl  = limiter(enabled = false)
-      val lim = rl.limit("story-submit") // enabled = true, max-attempts = 2
-      rl.allow("ip:1", lim) mustBe true
-      rl.allow("ip:1", lim) mustBe true
-      rl.allow("ip:1", lim) mustBe false
+  // The check/charge/refund trio backs limits that should only cost something on failure — a sign-in throttle that
+  // counted successes would lock a shared account out of its own logins (#1102).
+  "RateLimiter.isBlocked with record and clear" should {
+    "not spend budget on its own" in {
+      val rl = limiter(enabled = true)
+      (1 to 100).foreach(_ => rl.isBlocked("k", lim(1)) mustBe false)
     }
 
-    "be a no-op for a limit that is not enabled" in {
-      // A login limit with the global off and no block flag -> disabled -> never denies.
-      val rl  = limiter(enabled = false)
-      val lim = rl.limit("login")
-      (1 to 100).foreach(_ => rl.allow("ip:1", lim) mustBe true)
+    "block only once maxAttempts have been recorded" in {
+      val rl = limiter(enabled = true)
+      rl.record("k", lim(2))
+      rl.isBlocked("k", lim(2)) mustBe false
+      rl.record("k", lim(2))
+      rl.isBlocked("k", lim(2)) mustBe true
+    }
+
+    "stop blocking once the window elapses" in {
+      val rl = limiter(enabled = true)
+      rl.record("k", lim(1))
+      rl.isBlocked("k", lim(1)) mustBe true
+      rl.currentMs = 60000
+      rl.isBlocked("k", lim(1)) mustBe false
+    }
+
+    "hand the whole budget back on clear" in {
+      val rl = limiter(enabled = true)
+      rl.record("k", lim(2))
+      rl.record("k", lim(2))
+      rl.isBlocked("k", lim(2)) mustBe true
+
+      rl.clear("k")
+      rl.isBlocked("k", lim(2)) mustBe false
+      // A full budget, not a reprieve of one: two more failures fit before it blocks again.
+      rl.record("k", lim(2))
+      rl.isBlocked("k", lim(2)) mustBe false
+      rl.record("k", lim(2))
+      rl.isBlocked("k", lim(2)) mustBe true
+    }
+
+    "neither block nor count for a limit that is not enabled" in {
+      val rl       = limiter(enabled = true)
+      val disabled = lim(1, enabled = false)
+      rl.record("k", disabled)
+      rl.record("k", disabled)
+      rl.isBlocked("k", disabled) mustBe false
+      // Nothing was counted, so re-enabling finds an untouched budget rather than a hidden one.
+      rl.isBlocked("k", lim(1)) mustBe false
     }
   }
 
   "RateLimiter.retryAfterSeconds" should {
     "report the time left in the key's window, not the window's full length" in {
       val rl = limiter(enabled = true)
-      rl.allow("k", 1, 60.seconds) mustBe true
+      rl.allow("k", lim(1)) mustBe true
       rl.currentMs += 20000
       rl.retryAfterSeconds("k") mustBe Some(40L)
     }
 
     "round up, so the quoted moment is never before the window actually clears" in {
       val rl = limiter(enabled = true)
-      rl.allow("k", 1, 60.seconds) mustBe true
+      rl.allow("k", lim(1)) mustBe true
       rl.currentMs += 19500 // 40.5s left: quoting 40 would send them back a half-second early.
       rl.retryAfterSeconds("k") mustBe Some(41L)
     }
 
     "never report zero for a window that has only just elapsed" in {
       val rl = limiter(enabled = true)
-      rl.allow("k", 1, 60.seconds) mustBe true
+      rl.allow("k", lim(1)) mustBe true
       rl.currentMs += 60000
       rl.retryAfterSeconds("k") mustBe Some(1L)
     }


### PR DESCRIPTION
Closes #1102 — the 2017 brute-force ticket. Part 1 of 3 of the auth-hardening + sessionless-pages consolidation (with #4643 and #4442).

## What this does

**Client IPs are now spoof-resistant.** `CustomBaseController.ipAddress` previously took the *first* `X-Forwarded-For` value, which any client can forge (and our Apache proxy *appends* the real IP to whatever the client sends). It now delegates to Play's forwarded-header processing (`request.remoteAddress`), which walks XFF right-to-left past `play.http.forwarded.trustedProxies` (pinned to `127.0.0.1`/`::1` — exactly where the prod Apache proxy connects from) and yields the first untrusted hop. Spoofed hops are ignored; this holds everywhere `ipAddress` is used (rate limiting **and** `webpage_activity` logging).

**Rate limiting is on by default.** The limiter shipped with #4375 disabled pending exactly this IP-trust fix. `RATE_LIMIT_ENABLED=false` remains the per-deployment kill switch. Limits are tuned to be classroom-safe (30–40 students behind one school NAT):

| block | limit | key |
|---|---|---|
| `login` | 40/min | per IP, pre-bind |
| `login-identifier` (new) | 10/5min | per submitted email/username — the actual brute-force backstop |
| `signup` | 100/hr | per IP |
| `forgot` | 10/hr | per IP + per target email (new key) |
| `reset-password` (new) | 20/hr | per IP |
| `anon-signup` (now wired) | 100/hr | per IP — generous while crawlers still funnel through `/anonSignUp`; tightens after #4643 |

**Endpoint wiring:** `signUpAnon` now enforces the previously dead `anon-signup` block with a plain 429 (never a redirect — a redirect would loop, since every SecuredAction bounces cookie-less clients back to `/anonSignUp`); `POST /resetPassword` gets its first limit; throttled logins log `SignInThrottled_Email=...`; `Retry-After` now quotes the honest time left in the window.

## Notes for review / deploy

- `webpage_activity.ip_address` semantics shift for XFF-bearing clients: the rightmost-untrusted (egress) IP is recorded instead of the client-claimed first hop. Strictly more trustworthy; flagging for anyone who queries by IP.
- The `speed-limit` block (60/min/IP on the `/speedLimit` fallback) also becomes active with the global flip; misses degrade gracefully.
- If a proxy hop is ever added in front of Apache or moved off-host, `trustedProxies` must be extended (comment pinned in `application.conf`).
- No UI changes: the 429 dialog/flash surfaces shipped with #4375.

## Testing

- `UserAuthRateLimitSpec` extended: per-identifier throttling across distinct IPs (case-insensitive), XFF ignored at the controller layer, anon-signup 429-with-no-Location loop guard, reset-password and forgot-per-email coverage. Per-test fake source IPs via `withConnection`.
- New `ForwardedClientIpSpec` (real server + WSClient, since `route()` bypasses server-layer XFF processing): proves a spoofed left-hand XFF hop lands in the same bucket and a different true client doesn't — the literal #1102 scenario.
- `UserAuthControllerSpec` pinned to `rate-limit.enabled=false` so it stays decoupled from limit tuning.
- Full suite: 474/474 green locally in the dev container.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-fable-5)