### PR TITLE
Lazy identity-on-first-write: mint the anon session at first contribution

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -186,6 +186,9 @@ rate-limit {
   login {         max-attempts = 10,  window-seconds = 60 }   # per IP and per email
   signup {        max-attempts = 5,   window-seconds = 3600 } # per IP
   forgot {        max-attempts = 5,   window-seconds = 3600 } # per email+IP
+  # Public pages render sessionlessly (#4643) and robots.txt disallows /anonSignUp, so crawlers no longer funnel
+  # through it. The budget only has to cover deliberate first-writes — util.lazyIdentityFetch mints on a visitor's
+  # first vote/comment/story/route save (#4442) — plus legacy /anonSignUp links, so a modest per-IP cap suffices.
   anon-signup {   max-attempts = 30,  window-seconds = 3600 } # per IP
   ai-ingest {     max-attempts = 120, window-seconds = 60 }   # per IP (bulk caller; caps requests, not labels)
   speed-limit {   max-attempts = 60,  window-seconds = 60 }   # per IP (cache misses trigger an Overpass query)

--- a/public/js/LandingValidationGrid.js
+++ b/public/js/LandingValidationGrid.js
@@ -333,7 +333,9 @@ class LandingValidationGrid {
     };
 
     try {
-      const response = await fetch('/labelmap/validate', {
+      // A first-time visitor has no session (#4643), so this vote may be their first-ever write: lazyIdentityFetch
+      // mints the anonymous session on an auth-shaped failure and retries once (#4442).
+      const response = await util.lazyIdentityFetch('/labelmap/validate', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),

--- a/public/js/common/label-detail/LabelDetail.js
+++ b/public/js/common/label-detail/LabelDetail.js
@@ -790,8 +790,7 @@ class LabelDetail {
   /**
    * POSTs JSON to a session-requiring endpoint via util.lazyIdentityFetch (#4442): every host page renders with no
    * session for a first-time visitor, so an auth-shaped failure mints the shared anonymous session and retries once.
-   * Delegating (rather than the old retry-on-ANY-non-OK here) means a real rejection — 409 duplicate, 429 rate
-   * limit, 400 validation — surfaces instead of being silently re-posted.
+   * A real rejection — 409 duplicate, 429 rate limit, 400 validation — surfaces instead of being re-posted.
    *
    * @param {string} url - The endpoint to POST to.
    * @param {object} data - The JSON-serializable request body.

--- a/public/js/common/label-detail/LabelDetail.js
+++ b/public/js/common/label-detail/LabelDetail.js
@@ -788,30 +788,21 @@ class LabelDetail {
   }
 
   /**
-   * POSTs JSON to a session-requiring endpoint, minting the shared anonymous session first if it's missing.
-   *
-   * The public spotlight page (#456) is reachable with no session at all, and SecuredAction answers a session-less
-   * POST by bouncing it through /anonSignUp — which mints the session but swallows the submission. So on a failed
-   * first attempt, mint the session explicitly (idempotent: signUpAnon just redirects when a session exists) and
-   * retry once. redirect: 'manual' keeps the mint cheap — the Set-Cookie on the redirect response is stored without
-   * fetching the page it points at. On every other surface a session always exists, so the retry never fires.
+   * POSTs JSON to a session-requiring endpoint via util.lazyIdentityFetch (#4442): every host page renders with no
+   * session for a first-time visitor, so an auth-shaped failure mints the shared anonymous session and retries once.
+   * Delegating (rather than the old retry-on-ANY-non-OK here) means a real rejection — 409 duplicate, 429 rate
+   * limit, 400 validation — surfaces instead of being silently re-posted.
    *
    * @param {string} url - The endpoint to POST to.
    * @param {object} data - The JSON-serializable request body.
-   * @returns {Promise<Response>} The first OK response, or the retry's response (which may itself not be OK).
+   * @returns {Promise<Response>} The first non-auth-failure response, or the retry's (which may itself not be OK).
    */
-  async #postJson(url, data) {
-    const post = () => fetch(url, {
+  #postJson(url, data) {
+    return util.lazyIdentityFetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json; charset=utf-8' },
       body: JSON.stringify(data),
     });
-    let res = await post();
-    if (!res.ok) {
-      await fetch('/anonSignUp?url=%2F', { redirect: 'manual' });
-      res = await post();
-    }
-    return res;
   }
 
   /**

--- a/public/js/common/label-detail/StoryComposer.js
+++ b/public/js/common/label-detail/StoryComposer.js
@@ -372,23 +372,17 @@ class StoryComposer {
   }
 
   /**
-   * POSTs multipart form data, minting the shared anonymous session and retrying once — but only when the failure
-   * looks auth-shaped (401/403/redirect). That's deliberately narrower than LabelDetail's #postJson, which retries
-   * on any non-OK response: a story rejection (409 duplicate, 429 rate-limited) must surface, not be re-posted.
-   * No Content-Type header: the browser sets the multipart boundary itself.
+   * POSTs multipart form data via util.lazyIdentityFetch (#4442): an auth-shaped failure (401/403/redirect) mints
+   * the shared anonymous session and retries once, while a story rejection (409 duplicate, 429 rate-limited) still
+   * surfaces rather than being re-posted. This method's narrowed retry condition is where the shared helper's
+   * semantics came from. No Content-Type header: the browser sets the multipart boundary itself.
    * @param {string} url
    * @param {FormData} formData
    * @param {string} [method='POST'] - 'PUT' for in-place story edits.
    * @returns {Promise<Response>}
    */
-  async #postForm(url, formData, method = 'POST') {
-    const post = () => fetch(url, { method, body: formData });
-    let res = await post();
-    if (!res.ok && (res.status === 401 || res.status === 403 || res.type === 'opaqueredirect' || res.redirected)) {
-      await fetch('/anonSignUp?url=%2F', { redirect: 'manual' });
-      res = await post();
-    }
-    return res;
+  #postForm(url, formData, method = 'POST') {
+    return util.lazyIdentityFetch(url, { method, body: formData });
   }
 
   /**

--- a/public/js/common/label-detail/StoryComposer.js
+++ b/public/js/common/label-detail/StoryComposer.js
@@ -373,9 +373,8 @@ class StoryComposer {
 
   /**
    * POSTs multipart form data via util.lazyIdentityFetch (#4442): an auth-shaped failure (401/403/redirect) mints
-   * the shared anonymous session and retries once, while a story rejection (409 duplicate, 429 rate-limited) still
-   * surfaces rather than being re-posted. This method's narrowed retry condition is where the shared helper's
-   * semantics came from. No Content-Type header: the browser sets the multipart boundary itself.
+   * the shared anonymous session and retries once, while a story rejection (409 duplicate, 429 rate-limited)
+   * surfaces rather than being re-posted. No Content-Type header: the browser sets the multipart boundary itself.
    * @param {string} url
    * @param {FormData} formData
    * @param {string} [method='POST'] - 'PUT' for in-place story edits.

--- a/public/js/common/utilities.js
+++ b/public/js/common/utilities.js
@@ -221,6 +221,40 @@ function getImage(imageUrl) {
 
 util.getImage = getImage;
 
+/**
+ * Fetches a session-requiring write (POST/PUT), lazily minting the shared anonymous session when it's missing.
+ *
+ * Public pages render with no session at all since #4643, so a first-time visitor's very first interaction — a
+ * validation vote, a comment, a story, a guest route save — reaches the server with no identity. Historically that
+ * request either bounced through /anonSignUp (minting an account as a redirect side effect but SWALLOWING the
+ * submission) or failed outright with a 401 (#4442). Instead: if the failure is auth-shaped, mint the anonymous
+ * session explicitly via GET /anonSignUp (idempotent: it just redirects when a session already exists), then retry
+ * the original request ONCE with the same options. On every later interaction the session exists, so the extra
+ * round-trip never happens.
+ *
+ * Auth-shaped means 401/403, an opaque redirect, or a followed redirect — the ways SecuredAction answers a
+ * session-less write. Anything else (400 validation, 409 duplicate, 429 rate limit, 500) surfaces unchanged: a
+ * rejected submission must never be silently re-posted. redirect: 'manual' keeps the mint cheap — the Set-Cookie on
+ * the redirect response is stored without fetching the page it points at. If the mint itself is rate-limited (429
+ * from the anon-signup budget), the retry fails with 401 again and that response is returned, so the caller's
+ * normal error path shows.
+ *
+ * @param {string} url - The endpoint to fetch.
+ * @param {object} options - The fetch options (method, headers, body, ...); reused as-is for the retry.
+ * @returns {Promise<Response>} The first non-auth-failure response, or the retry's response (which may not be OK).
+ */
+util.lazyIdentityFetch = async function (url, options) {
+  const attempt = () => fetch(url, options);
+  const authShaped = (res) =>
+    !res.ok && (res.status === 401 || res.status === 403 || res.type === 'opaqueredirect' || res.redirected);
+  let res = await attempt();
+  if (authShaped(res)) {
+    await fetch('/anonSignUp?url=%2F', { redirect: 'manual' });
+    res = await attempt();
+  }
+  return res;
+};
+
 // Sums an array's numbers (a helper, not an Array.prototype extension, to avoid polluting native prototypes).
 util.array = util.array || {};
 util.array.sum = (arr) => arr.reduce((a, b) => a + b, 0);

--- a/public/js/common/utilities.js
+++ b/public/js/common/utilities.js
@@ -221,39 +221,63 @@ function getImage(imageUrl) {
 
 util.getImage = getImage;
 
+/** The anonymous-session mint currently in flight, if any, so simultaneous first writes share one. */
+let anonSessionMint = null;
+
+/**
+ * Mints the shared anonymous session, joining a mint already in flight instead of starting a second one.
+ *
+ * Two quick clicks on the landing validation grid both reach the server unauthenticated and both come back needing a
+ * session; minting twice would create two accounts, let the second cookie win, and file the two votes under different
+ * users with one account orphaned. Collapsing concurrent callers onto one request avoids that. The handle is released
+ * once the request settles, so a session that expires later can still be re-minted.
+ *
+ * @returns {Promise<Response>} The mint response; `redirect: 'manual'` keeps it cheap, storing the Set-Cookie on the
+ *   redirect without fetching the page it points at.
+ */
+function mintAnonSession() {
+  if (!anonSessionMint) {
+    anonSessionMint = fetch('/anonSignUp?url=%2F', { redirect: 'manual' }).finally(() => {
+      anonSessionMint = null;
+    });
+  }
+  return anonSessionMint;
+}
+
 /**
  * Fetches a session-requiring write (POST/PUT), lazily minting the shared anonymous session when it's missing.
  *
- * Public pages render with no session at all since #4643, so a first-time visitor's very first interaction — a
- * validation vote, a comment, a story, a guest route save — reaches the server with no identity. Historically that
- * request either bounced through /anonSignUp (minting an account as a redirect side effect but SWALLOWING the
- * submission) or failed outright with a 401 (#4442). Instead: if the failure is auth-shaped, mint the anonymous
- * session explicitly via GET /anonSignUp (idempotent: it just redirects when a session already exists), then retry
- * the original request ONCE with the same options. On every later interaction the session exists, so the extra
- * round-trip never happens.
+ * Public pages render with no session at all (#4643), so a first-time visitor's very first interaction — a validation
+ * vote, a comment, a story, a guest route save — reaches the server with no identity. When that comes back
+ * auth-shaped, mint the anonymous session via GET /anonSignUp (idempotent: it just redirects when a session already
+ * exists) and retry the original request ONCE with the same options, so the submission survives rather than being
+ * dropped on the way through the bounce (#4442). Every later interaction has a session, so the extra round-trip
+ * never happens.
  *
- * Auth-shaped means 401/403, an opaque redirect, or a followed redirect — the ways SecuredAction answers a
+ * Auth-shaped means 401/403, an opaque redirect, or a followed redirect — the ways a SecuredAction answers a
  * session-less write. Anything else (400 validation, 409 duplicate, 429 rate limit, 500) surfaces unchanged: a
- * rejected submission must never be silently re-posted. redirect: 'manual' keeps the mint cheap — the Set-Cookie on
- * the redirect response is stored without fetching the page it points at. If the mint itself is rate-limited (429
- * from the anon-signup budget), the retry fails with 401 again and that response is returned, so the caller's
- * normal error path shows.
+ * rejected submission must never be silently re-posted. If the mint is itself refused (429 from the anon-signup
+ * budget), the retry comes back auth-shaped again and that response is returned, so the caller's normal error path
+ * shows.
  *
  * @param {string} url - The endpoint to fetch.
- * @param {object} options - The fetch options (method, headers, body, ...); reused as-is for the retry.
+ * @param {object} options - The fetch options (method, headers, body, ...). The same object is reused verbatim for
+ *   the retry, so the body has to be re-readable: a string, FormData, or Blob — never a ReadableStream.
  * @returns {Promise<Response>} The first non-auth-failure response, or the retry's response (which may not be OK).
  */
-util.lazyIdentityFetch = async function (url, options) {
+async function lazyIdentityFetch(url, options) {
   const attempt = () => fetch(url, options);
   const authShaped = (res) =>
     !res.ok && (res.status === 401 || res.status === 403 || res.type === 'opaqueredirect' || res.redirected);
   let res = await attempt();
   if (authShaped(res)) {
-    await fetch('/anonSignUp?url=%2F', { redirect: 'manual' });
+    await mintAnonSession();
     res = await attempt();
   }
   return res;
-};
+}
+
+util.lazyIdentityFetch = lazyIdentityFetch;
 
 // Sums an array's numbers (a helper, not an Array.prototype extension, to avoid polluting native prototypes).
 util.array = util.array || {};

--- a/public/js/gallery/src/validation/ValidationMenu.js
+++ b/public/js/gallery/src/validation/ValidationMenu.js
@@ -228,7 +228,9 @@ class ValidationMenu {
     };
 
     const isNewValidation = !undone && refCard.getProperty('user_validation') === null;
-    return fetch('/labelmap/validate', {
+    // A first-time visitor browses the Gallery with no session (#4643), so a card vote can be their first-ever
+    // write: lazyIdentityFetch mints the anonymous session on an auth-shaped failure and retries once (#4442).
+    return util.lazyIdentityFetch('/labelmap/validate', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(data),

--- a/public/js/route-builder/src/SaveModal.js
+++ b/public/js/route-builder/src/SaveModal.js
@@ -154,7 +154,9 @@ class SaveModal {
     const name = this.#nameInput.value.trim();
     const description = this.#descriptionInput?.value.trim() ?? '';
 
-    fetch('/saveRoute', {
+    // "Continue without account" from a cookie-less visitor (#4643) makes this their first-ever write:
+    // lazyIdentityFetch mints the anonymous session on an auth-shaped failure and retries once (#4442).
+    util.lazyIdentityFetch('/saveRoute', {
       method: 'POST',
       headers: {
         'Accept': 'application/json',

--- a/test/js/lazyIdentityFetch.test.js
+++ b/test/js/lazyIdentityFetch.test.js
@@ -6,7 +6,8 @@
  *     a rejected submission must never be silently re-posted;
  *   - an auth-shaped failure (401 | 403 | opaqueredirect | redirected) mints the anonymous session via
  *     GET /anonSignUp?url=%2F with { redirect: 'manual' }, then retries ONCE with the same options object;
- *   - a second auth failure after the mint (e.g. the mint itself was rate-limited) is returned, never looped on.
+ *   - a second auth failure after the mint (e.g. the mint itself was rate-limited) is returned, never looped on;
+ *   - writes that need a session at the same moment share one mint, so a double-click can't create two accounts.
  */
 
 const { loadGlobalScript } = require('./loadGlobalScript');
@@ -98,5 +99,75 @@ describe('an auth-shaped failure', () => {
         const { result, calls } = await run([ok]);
         expect(result).toBe(ok);
         expect(calls).toHaveLength(1);
+    });
+});
+
+describe('concurrent first writes', () => {
+    const MINT = '/anonSignUp?url=%2F';
+
+    /**
+     * Drives N writes that all fail auth, with the mint held open until `release()` is called, so the test can look
+     * at the world while every caller is waiting on it.
+     */
+    function scriptedMint() {
+        const urls = [];
+        let releaseMint;
+        const mintGate = new Promise((resolve) => { releaseMint = resolve; });
+        let failuresLeft = 0;
+
+        const fetchMock = jest.fn((url) => {
+            urls.push(url);
+            if (url === MINT) return mintGate.then(() => response({ ok: true }));
+            // The opening writes fail auth; anything after the mint succeeds.
+            if (failuresLeft > 0) { failuresLeft -= 1; return Promise.resolve(response({ status: 401 })); }
+            return Promise.resolve(OK());
+        });
+        window.fetch = fetchMock;
+
+        return {
+            urls,
+            release: releaseMint,
+            mintCalls: () => urls.filter((u) => u === MINT).length,
+            failFirst: (n) => { failuresLeft = n; },
+        };
+    }
+
+    /** Lets every already-queued microtask/timer callback run, so pending awaits settle. */
+    const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+    test('collapse onto a single /anonSignUp, so two rapid votes do not create two accounts', async () => {
+        const s = scriptedMint();
+        s.failFirst(2); // Both openers reach the server unauthenticated.
+
+        const both = Promise.all([
+            window.util.lazyIdentityFetch('/labelmap/validate', { method: 'POST', body: '{"a":1}' }),
+            window.util.lazyIdentityFetch('/labelmap/validate', { method: 'POST', body: '{"b":2}' }),
+        ]);
+
+        await flush();
+        // Both are now parked on the mint. A second mint here is the bug: two accounts, and the later cookie wins.
+        expect(s.mintCalls()).toBe(1);
+
+        s.release();
+        const [first, second] = await both;
+        expect(first.ok).toBe(true);
+        expect(second.ok).toBe(true);
+        expect(s.mintCalls()).toBe(1);
+        // Two openers + one mint + two retries.
+        expect(s.urls).toHaveLength(5);
+    });
+
+    test('a write after the mint has settled can still mint again, for a session that expired', async () => {
+        const s = scriptedMint();
+        s.failFirst(1);
+        s.release(); // No need to hold it open; these two writes are sequential.
+
+        expect((await window.util.lazyIdentityFetch('/labelmap/validate', { method: 'POST' })).ok).toBe(true);
+        expect(s.mintCalls()).toBe(1);
+
+        // Second write, much later, whose session is gone again. Sharing must be per-burst, not a permanent cache.
+        s.failFirst(1);
+        expect((await window.util.lazyIdentityFetch('/labelmap/validate', { method: 'POST' })).ok).toBe(true);
+        expect(s.mintCalls()).toBe(2);
     });
 });

--- a/test/js/lazyIdentityFetch.test.js
+++ b/test/js/lazyIdentityFetch.test.js
@@ -1,0 +1,102 @@
+/**
+ * Tests for util.lazyIdentityFetch (#4442), the shared first-write helper: public pages render with no session at
+ * all (#4643), so a first-time visitor's first vote/comment/story/route save reaches the server unauthenticated.
+ * The helper's contract:
+ *   - a success (or any non-auth failure: 400 validation, 409 duplicate, 429 rate limit) passes through UNCHANGED —
+ *     a rejected submission must never be silently re-posted;
+ *   - an auth-shaped failure (401 | 403 | opaqueredirect | redirected) mints the anonymous session via
+ *     GET /anonSignUp?url=%2F with { redirect: 'manual' }, then retries ONCE with the same options object;
+ *   - a second auth failure after the mint (e.g. the mint itself was rate-limited) is returned, never looped on.
+ */
+
+const { loadGlobalScript } = require('./loadGlobalScript');
+
+/** A minimal Response-shaped object carrying only the fields the helper reads. */
+function response(overrides = {}) {
+    return { ok: false, status: 200, type: 'basic', redirected: false, ...overrides };
+}
+
+const OK = () => response({ ok: true });
+
+beforeEach(() => {
+    // utilities.js builds a Bowser parser at load time; the helper never touches it, but the file needs the global.
+    window.bowser = {
+        getParser: () => ({
+            getBrowserName: () => 'Test', getBrowserVersion: () => '1',
+            getOSName: () => 'TestOS', getPlatformType: () => 'desktop',
+        }),
+    };
+    loadGlobalScript('public/js/common/utilities.js');
+});
+
+/** Runs the helper against a scripted sequence of responses and returns { result, calls }. */
+async function run(responses, options = { method: 'POST', body: '{"x":1}' }) {
+    const fetchMock = jest.fn();
+    responses.forEach((r) => fetchMock.mockResolvedValueOnce(r));
+    window.fetch = fetchMock;
+    const result = await window.util.lazyIdentityFetch('/labelmap/validate', options);
+    return { result, options, calls: fetchMock.mock.calls };
+}
+
+describe('a response that is not an auth failure', () => {
+    test('a success passes through untouched, with no mint and no retry', async () => {
+        const ok = OK();
+        const { result, calls } = await run([ok]);
+        expect(result).toBe(ok);
+        expect(calls).toHaveLength(1);
+        expect(calls[0][0]).toBe('/labelmap/validate');
+    });
+
+    test.each([400, 409, 429, 500])('a %i failure surfaces unchanged — no mint, no re-post', async (status) => {
+        const failure = response({ status });
+        const { result, calls } = await run([failure, OK()]);
+        expect(result).toBe(failure);
+        // The one call is the original request; in particular /anonSignUp was never fetched and nothing re-posted.
+        expect(calls).toHaveLength(1);
+        expect(calls.map((c) => c[0])).not.toContain('/anonSignUp?url=%2F');
+    });
+});
+
+describe('an auth-shaped failure', () => {
+    test('a 401 mints the anonymous session (redirect: manual), then retries once and returns the retry', async () => {
+        const ok = OK();
+        const { result, options, calls } = await run([response({ status: 401 }), response({ ok: true }), ok]);
+        // Call order: original -> mint -> retry. The middle mock response is consumed by the mint fetch.
+        expect(calls).toHaveLength(3);
+        expect(calls[0][0]).toBe('/labelmap/validate');
+        expect(calls[1]).toEqual(['/anonSignUp?url=%2F', { redirect: 'manual' }]);
+        expect(calls[2][0]).toBe('/labelmap/validate');
+        // The retry reuses the SAME options object — same method, headers, and body as the swallowed first attempt.
+        expect(calls[2][1]).toBe(options);
+        expect(result).toBe(ok);
+    });
+
+    test.each([
+        ['403', response({ status: 403 })],
+        ['opaqueredirect', response({ status: 0, type: 'opaqueredirect' })],
+        ['followed redirect', response({ status: 404, redirected: true })],
+    ])('a %s also mints and retries', async (_name, failure) => {
+        const ok = OK();
+        const { result, calls } = await run([failure, response({ ok: true }), ok]);
+        expect(calls).toHaveLength(3);
+        expect(calls[1][0]).toBe('/anonSignUp?url=%2F');
+        expect(result).toBe(ok);
+    });
+
+    test('a second 401 after the mint is returned as-is — one retry, never a loop', async () => {
+        // The mint can itself be refused (anon-signup rate limit), leaving the retry unauthenticated again.
+        const second401 = response({ status: 401 });
+        const { result, calls } = await run([response({ status: 401 }), response({ ok: true }), second401]);
+        expect(result).toBe(second401);
+        // original + mint + retry and nothing more: no second mint, no third attempt.
+        expect(calls).toHaveLength(3);
+        expect(calls.map((c) => c[0])).toEqual(['/labelmap/validate', '/anonSignUp?url=%2F', '/labelmap/validate']);
+    });
+
+    test('a redirected-but-OK response does not trigger the mint (only failures are auth-shaped)', async () => {
+        const ok = response({ ok: true, redirected: true });
+        const { result, calls } = await run([ok]);
+        expect(result).toBe(ok);
+        expect(calls).toHaveLength(1);
+    });
+});

--- a/test/js/storyRateLimitMessage.test.js
+++ b/test/js/storyRateLimitMessage.test.js
@@ -77,6 +77,10 @@ async function submitAndFail(body) {
 
 beforeEach(() => {
     window.eval(`${COMPOSER_SRC}\nwindow.StoryComposer = StoryComposer;`);
+    // #postForm posts through util.lazyIdentityFetch (#4442). The real helper passes a non-auth failure like this
+    // suite's 429 through unchanged, so a pass-through stub is faithful; the mint/retry path has its own suite
+    // (lazyIdentityFetch.test.js).
+    window.util = { lazyIdentityFetch: (url, options) => window.fetch(url, options) };
     window.i18next = {
         language: 'en',
         exists: (key) => key in STRINGS,


### PR DESCRIPTION
Closes #4442. Part 3 of 3 (after #4744 and #4746). **Stacked on #4746** — I'll retarget to `develop` when it merges.

## What this does

Since #4746, public pages render with no session, so a first-time visitor's very first interaction (a vote, comment, story, guest route save) reaches the server with no identity. Previously that request either bounced through `/anonSignUp` — minting an account as a redirect side effect while **swallowing the submission** — or failed with a 401. Now account creation happens exactly at first contribution, and the contribution isn't lost:

- **`util.lazyIdentityFetch(url, options)`** in `utilities.js` (on every page): if a write fails auth-shaped (401/403/redirect), mint the anon session via `GET /anonSignUp` with `redirect: 'manual'`, retry once. Non-auth failures (400/409/429/500) surface unchanged — a rejected submission is never re-posted. Generalized from the pattern `StoryComposer` and `LabelDetail` already used.
- **Adopted at every user-triggered first-write** on the sessionless surface: `LabelDetail#postJson` (labelMap popup / gallery expanded view / share page votes+comments — and this **fixes a real bug**: it used to retry on *any* non-OK, silently re-posting 409s/429s), `StoryComposer#postForm`, `LandingValidationGrid` votes, gallery `ValidationMenu` votes, RouteBuilder's "Continue without account" save.
- **Deliberately not adopted**: `/galleryTask` beacons and `logWebpageActivity` — passive telemetry must never mint an account (the latter logs under the shared anon user server-side since #4746). Author-only writes (story edit/delete, route rename) necessarily have a session already.
- `anon-signup` limit comment rewritten: with crawlers no longer funneling through `/anonSignUp`, its 30/hr-per-IP budget only needs deliberate first-writes.

## Merge-order note

⚠️ The `rate-limit` block in `application.conf` will conflict with #4744 (which rewrites that whole block and adds the *enforcement* of `anon-signup` in `signUpAnon`). Resolution when this rebases after #4744 + #4746: keep #4744's enforcement and this PR's `30/3600` + comment (#4744 ships `100/3600` precisely as crawler headroom for the window before this stack lands).

## Testing

- New `test/js/lazyIdentityFetch.test.js` (11 cases, drives the real `utilities.js`): pass-through on success; no mint/re-post on 400/409/429/500; mint + single retry with the same options on 401/403/opaqueredirect/redirect; no infinite loop when the retry fails again. Mutation-checked in both directions (widened auth check → exactly the no-mint tests fail; removed retry → exactly the mint tests fail).
- Full suites green locally in the container: 423 JS (jest — reminder: not wired into CI), 474 Scala.
- eslint clean from the worktree (warnings identical to baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-fable-5)