### PR TITLE
Replace the vancouver-wa hard gate on AI label submission with a per-city flag

### DIFF
--- a/app/controllers/AiController.scala
+++ b/app/controllers/AiController.scala
@@ -48,12 +48,12 @@ class AiController @Inject() (
       submission.fold(
         errors => { Future.successful(BadRequest(Json.obj("status" -> "Error", "message" -> JsError.toJson(errors)))) },
         submission => {
-          if (configService.getCityId == "vancouver-wa") {
+          if (configService.getAiLabelSubmissionEnabled) {
             exploreService.savePanoInfo(Seq(submission.pano)).flatMap { _ =>
               exploreService.submitAiLabelData(submission).map(_ => Ok("success!"))
             }
           } else {
-            Future.successful(BadRequest("AI label submission beta is only supported in Vancouver, WA at the moment."))
+            Future.successful(BadRequest("AI label submission is not enabled for this city."))
           }
         }
       )

--- a/app/service/ConfigService.scala
+++ b/app/service/ConfigService.scala
@@ -663,6 +663,7 @@ trait ConfigService {
   def getCurrentCountryId: String
   def getCityName(lang: Lang): String
   def getAiTagSuggestionsEnabled: Boolean
+  def getAiLabelSubmissionEnabled: Boolean
   def getPrivateProfilesByDefault: Boolean
   def getPanoSource: PanoSource
   def sendSciStarterContributions(email: String, contributions: Int, timeSpent: Double): Future[Int]
@@ -1683,6 +1684,8 @@ class ConfigServiceImpl @Inject() (
   def getCityName(lang: Lang): String = messagesApi(s"city.name.$getCityId")(lang)
 
   def getAiTagSuggestionsEnabled: Boolean = config.get[Boolean](s"city-params.ai-tag-suggestions-enabled.$getCityId")
+
+  def getAiLabelSubmissionEnabled: Boolean = cityFlag("ai-label-submission-enabled", getCityId)
 
   def getPrivateProfilesByDefault: Boolean = cityFlag("private-profiles-by-default", getCityId)
 

--- a/conf/cityparams.conf
+++ b/conf/cityparams.conf
@@ -895,6 +895,13 @@ city-params {
     waltham-ma = true
     houston-tx = true
   }
+  // When true for a city, that city accepts AI-generated label submissions on /ai/submitLabelsOnPano (the
+  // sidewalk-auto-labeler pipeline, #4760). Read through cityFlag, so a city omitted here is treated as false and
+  // its submissions are rejected — only cities being onboarded to AI labeling need an entry. Submission also
+  // requires a valid INTERNAL_API_KEY on the instance, which fails closed when unset.
+  ai-label-submission-enabled {
+    vancouver-wa = true
+  }
   ai-validation-min-accuracy {
     newberg-or = "0.92"
     washington-dc = "0.92"

--- a/docs/ai-subsystems.md
+++ b/docs/ai-subsystems.md
@@ -84,9 +84,11 @@ validation.
    for improving the model (continual-improvement roadmap:
    `sidewalk-auto-labeler/docs/design-review-2026-07.md`).
 
-**⚠ City gate:** `submitAiLabel` currently hard-rejects every city except `vancouver-wa`
-(added Sept 2025 for the pilot). Onboarding another city to AI labeling (e.g. Bend) requires
-changing this — ideally to a per-city `cityparams.conf` flag.
+**City gate:** `submitAiLabel` is gated by the per-city `ai-label-submission-enabled` flag in
+`cityparams.conf` (default **false**; unlisted cities reject submissions). Onboarding another
+city to AI labeling (e.g. Bend) means setting the flag to `true` for that city. Note that this
+only opens the gate — submission still requires a valid `INTERNAL_API_KEY` on that instance,
+which fails closed when the key is unset.
 
 **Model** (from [`RampNet`](https://github.com/ProjectSidewalk/RampNet), ICCV'25 workshop
 paper): ConvNeXtV2-Base + heatmap head, input 2048×4096, trained on ~214k panoramas
@@ -169,7 +171,6 @@ sidewalk-tagger-ai ────┤ (HF: sidewalk-tagger-ai-models)          Ramp
   endpoints in June 2026 and broke consumers independently (see
   `sidewalk-auto-labeler/docs/design-review-2026-07.md` §3) — worth consolidating on one
   maintained fetch path.
-- The `vancouver-wa` hard gate on `/ai/submitLabelsOnPano` (above).
 - Model provenance (`model_id`, training date) is hardcoded in the auto-labeler rather than
   read from the HF model config.
 - RampNet must get a tagged ICCV'25-state release before any code changes land

--- a/test/service/CityFlagConfigSpec.scala
+++ b/test/service/CityFlagConfigSpec.scala
@@ -1,0 +1,60 @@
+package service
+
+import com.typesafe.config.{Config, ConfigFactory}
+import org.scalatestplus.play.PlaySpec
+
+import scala.jdk.CollectionConverters._
+
+/**
+ * Shape checks on the per-city boolean blocks in `cityparams.conf` that `ConfigServiceImpl.cityFlag` reads.
+ *
+ * These blocks are deliberately *not* exhaustive: `cityFlag` returns false for a missing key or a missing parent, so a
+ * city omitted from a block just gets the default. That default-false design has one failure mode with no other
+ * tripwire — a misspelled city id silently reads as "not configured" rather than raising, so e.g. a typo'd entry in
+ * `ai-label-submission-enabled` would leave a city gated off with no error anywhere. Play never validates these keys,
+ * and the flags are consumed one city at a time on a running deployment, so nothing else would catch it.
+ *
+ * Pure config parsing — no app boot and no database.
+ */
+class CityFlagConfigSpec extends PlaySpec {
+
+  /** The `city-params` blocks read through `cityFlag`, i.e. the ones where an unlisted city is legal. */
+  private val optionalFlagBlocks =
+    Seq("ai-label-submission-enabled", "private-profiles-by-default", "global-leaderboard-excluded")
+
+  private lazy val config: Config       = ConfigFactory.load()
+  private lazy val cityIds: Set[String] = config.getStringList("city-params.city-ids").asScala.toSet
+
+  "the per-city flag blocks read through cityFlag" should {
+    "key every entry on a configured city id, so a typo can't silently read as the default" in {
+      cityIds must not be empty
+      optionalFlagBlocks.foreach { block =>
+        val path = s"city-params.$block"
+        if (config.hasPath(path)) {
+          config.getConfig(path).root().keySet().asScala.foreach { cityId =>
+            withClue(s"$block.$cityId is not in city-params.city-ids: ") { cityIds must contain(cityId) }
+          }
+        }
+      }
+    }
+
+    "hold boolean values, since cityFlag reads them as Boolean and would throw on anything else" in {
+      optionalFlagBlocks.foreach { block =>
+        val path = s"city-params.$block"
+        if (config.hasPath(path)) {
+          config.getConfig(path).root().keySet().asScala.foreach { cityId =>
+            withClue(s"$block.$cityId: ") { noException must be thrownBy config.getBoolean(s"$path.$cityId") }
+          }
+        }
+      }
+    }
+  }
+
+  "ai-label-submission-enabled" should {
+    // Replacing the old hard-coded `getCityId == "vancouver-wa"` check with this flag (#4760) is only behavior-
+    // preserving as long as Vancouver stays listed — dropping the entry would silently close the pilot's gate.
+    "keep the vancouver-wa pilot enabled, the city the flag replaced a hard-coded check for (#4760)" in {
+      config.getBoolean("city-params.ai-label-submission-enabled.vancouver-wa") mustBe true
+    }
+  }
+}


### PR DESCRIPTION
Closes #4760.

`AiController.submitAiLabel` has hard-rejected every city except `vancouver-wa` since the Sept 2025 pilot. This replaces that check with a per-city `ai-label-submission-enabled` flag, so onboarding a city to AI labeling is a one-line conf change instead of a code change.

```diff
- if (configService.getCityId == "vancouver-wa") {
+ if (configService.getAiLabelSubmissionEnabled) {
```

**Runtime behavior is identical to today for all 57 cities.** The flag is read through `ConfigServiceImpl.cityFlag`, which returns false for a missing key *or* a missing parent, so unlisted cities reject submissions exactly as they do now. `vancouver-wa` is the only entry. The one user-visible difference anywhere is the rejection message, which no longer names Vancouver.

No DB migration, no evolution, no frontend change.

### Why this matters

The [sidewalk-auto-labeler](https://github.com/ProjectSidewalk/sidewalk-auto-labeler) pipeline has finished nine more cities (bend, paterson, gainesville, sao_paulo, richmond, clovis, morgantown, annapolis, budapest_district5) and **not one of them has ever been submitted to a Project Sidewalk server**. Vancouver, WA remains the only city that has received AI labels, from the 2025 pilot. This conditional is the only thing in the way of the rest. Tracked labeler-side as sidewalk-auto-labeler#21.

### Changes

| file | change |
|---|---|
| `app/controllers/AiController.scala` | gate on the flag; rejection message becomes "AI label submission is not enabled for this city." |
| `app/service/ConfigService.scala` | `getAiLabelSubmissionEnabled` on the trait + impl, delegating to the existing `cityFlag` helper |
| `conf/cityparams.conf` | new `ai-label-submission-enabled { vancouver-wa = true }` block |
| `docs/ai-subsystems.md` | the "⚠ City gate" note now describes the flag |
| `test/service/CityFlagConfigSpec.scala` | **new** — config-shape guards, see below |

### On the test

Default-false has one silent failure mode with no other tripwire: a **misspelled city id reads as "not configured" rather than raising**, so the gate stays shut with no error anywhere. Play doesn't validate these keys, and the flags are consumed one city at a time on a running deployment, so a typo would only surface as "why aren't submissions working?"

`CityFlagConfigSpec` asserts that every entry across all three `cityFlag` blocks (`ai-label-submission-enabled`, `private-profiles-by-default`, `global-leaderboard-excluded`) keys on a configured city id and holds a boolean, and pins `vancouver-wa = true` so the swap from the hard-coded check stays behavior-preserving. It's pure `ConfigFactory.load()` parsing — no app boot, no database — so it runs in the blocking backend job rather than the advisory DB-backed suite.

Mutation-checked: injecting `vancover-wa = true` fails it with `ai-label-submission-enabled.vancover-wa is not in city-params.city-ids`.

### Testing

Local, in the web container: `compile` clean, `scalafmtCheckAll` clean, `testOnly service.CityFlagConfigSpec` 3/3 green.

There is nothing meaningful to exercise functionally until a city is flagged on — the change is a config read, and `ConfigServiceImpl` is the trait's only implementer with no mocks anywhere.

### Follow-ups (not in this PR)

- **Flipping on the next city.** Vancouver, WA is already receiving AI labels and stays enabled — this PR carries the pilot forward with no change to it. Merging only puts the mechanism in place; no city's behavior changes. Richmond, VA is the intended next target: it would be the **second** city to receive AI labels and the **first enabled through this flag** (private status, Mapillary viewer, effectively empty, best-validated run we have). Nobody has run a **non-GSV** submission end to end, so the test stage is where to find out whether `pano_source: "mapillary"` survives POV math, `getStreetEdgeIdClosestToLatLng`, and the `pano_data` upsert.
- **Opening the gate isn't sufficient on its own.** Submission also needs a valid `INTERNAL_API_KEY` on the instance; `internalKeyValid` fails closed when it's unset, so a flagged-on city still 401s until UW CSE IT provisions one. Called out in the conf comment and the doc.
- **AI validation won't cover AI-submitted labels.** `LabelTable.getLabelsToValidateWithAi` filters `r.role =!= "AI"` and `pd.source === PanoSource.Gsv`, so the daily validator skips both AI-authored labels and Mapillary panos. Filing separately — flagging in case either filter was narrower than intended.

@misaugstad you added the original gate and own this area — not blocking on you (`develop` has no required reviews), but flagging for judgment.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-opus-5[1m])
