### PR TITLE
Allowlist the YouTube compute-pressure violation in the e2e smoke suite

### DIFF
--- a/test/e2e/fixtures.js
+++ b/test/e2e/fixtures.js
@@ -25,6 +25,11 @@ const CONSOLE_ERROR_ALLOWLIST = [
   // /help YouTube iframes) emit these on every load. Enforcement policy is a backend-config concern, not the
   // page-runtime breakage this suite exists to catch.
   /report-only Content Security Policy/,
+  // The /help YouTube embeds' player script probes the Compute Pressure API, which the embedding iframes don't
+  // delegate (no allow="compute-pressure"), and Chromium logs the violation as a console error attributed to
+  // the player's own base.js. Intermittent: it fires only when the player boots far enough within the settle
+  // window. Anchored to the violation text plus a youtube.com source so nothing of ours can hide behind it.
+  /^console\.error: Permissions policy violation: compute-pressure .+ \(https:\/\/www\.youtube\.com\/.+\)$/,
   // The rawLabels/streets api-docs live previews pick a demo region via /v3/api/regionWithMostLabels. CI's
   // database is the bare sidewalk_init template — no labels, so there is nothing to pick and the endpoint 404s.
   // Three messages come out of that one 404: Chromium's own "Failed to load resource" line (matched by the URL)


### PR DESCRIPTION
## Summary

Removes the one known source of flake in the advisory `e2e-smoke` job: the `/help` spec intermittently fails (then passes on retry, reporting as flaky) because the page's YouTube embeds' player script probes the Compute Pressure API, which the iframes don't delegate. Chromium logs the permissions-policy violation as a console error attributed to the player's own `base.js`:

```
console.error: Permissions policy violation: compute-pressure is not allowed in this document. (https://www.youtube.com/s/player/.../base.js)
```

(Observed in CI run 30933590310; it fires only when the player boots far enough within the spec's settle window, hence the intermittence.)

This is third-party noise, not page breakage — exactly what the fixture's allowlist policy admits ("observed, understood noise"). The new entry is anchored to the violation text **plus** a `youtube.com` source URL, so a compute-pressure violation coming from our own code would still fail the spec.

## Why now

The job comment in `ci.yml` plans to ramp `e2e-smoke` to blocking "once it's proven stable" — a known recurring flake is what keeps that record ambiguous. Part of #4504.

## Verification

- Regex tested against the verbatim CI log line (matches) and against lookalikes — the same violation text from an app-served script, and an app error that merely mentions a youtube.com URL (both correctly rejected).
- `npx eslint test/e2e/fixtures.js` clean; `node --check` passes.
- Data-only change to the test fixture; no app code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-fable-5)