### PR TITLE
Harden RouteAuthPostureSpec: require an auth-guard refusal, not merely "not 2xx"

### DIFF
--- a/test/controllers/RouteAuthPostureSpec.scala
+++ b/test/controllers/RouteAuthPostureSpec.scala
@@ -95,6 +95,18 @@ class RouteAuthPostureSpec extends PlaySpec with GuiceOneAppPerSuite {
   }
 
   /**
+   * Statuses that prove an anonymous request was turned away by the auth guard: 401 is the XHR arm of
+   * `ControllerUtils.anonSignupRedirect`, 303 its navigation arm, 403 a `WithAdmin()` refusal.
+   *
+   * The namespace check asserts membership in this set rather than merely "not 2xx", because anything outside it — a
+   * 400 from a path-parameter binder, a 404, a 415 from a body parser — means the request died before reaching the
+   * guard and so says nothing about whether the route is gated. `concreteRequestPath` substitutes `1` for dynamic
+   * segments, which binds for every /adminapi/ parameter today; the day one takes a type `1` can't bind as, a not-2xx
+   * check would wave an ungated route through on the router's own rejection.
+   */
+  private val AuthRejections: Set[Int] = Set(UNAUTHORIZED, SEE_OTHER, FORBIDDEN)
+
+  /**
    * Email of an existing user holding `role`, or None if this schema has none.
    *
    * Reads rather than creates: minting a user would leave a fixture account behind in whatever database the suite is
@@ -217,7 +229,7 @@ class RouteAuthPostureSpec extends PlaySpec with GuiceOneAppPerSuite {
   }
 
   "the /adminapi/ namespace" should {
-    "never answer an anonymous request with 2xx" in {
+    "refuse every anonymous request at the auth guard" in {
       // Vacuity guard: if Router.documentation's pattern format ever drifts, discovery finds nothing and `leaks` is
       // trivially empty, so this spec would pass while checking zero routes.
       declaredAdminApiRoutes.map(_._2) must contain("/adminapi/labelTags")
@@ -225,9 +237,9 @@ class RouteAuthPostureSpec extends PlaySpec with GuiceOneAppPerSuite {
       val leaks = declaredAdminApiRoutes
         .filterNot { case (_, path) => KnownAnonymousAdminApiRoutes.contains(path) }
         .flatMap { case (method, path) => anonymousStatus(method, path).map(code => (method, path, code)) }
-        .filter { case (_, _, code) => code >= 200 && code < 300 }
+        .filterNot { case (_, _, code) => AuthRejections.contains(code) }
 
-      withClue(s"served anonymously: ${leaks.map { case (m, p, c) => s"$m $p -> $c" }.mkString(", ")}. ") {
+      withClue(s"not refused by the auth guard: ${leaks.map { case (m, p, c) => s"$m $p -> $c" }.mkString(", ")}. ") {
         leaks mustBe empty
       }
     }

--- a/test/controllers/RouteAuthPostureSpec.scala
+++ b/test/controllers/RouteAuthPostureSpec.scala
@@ -99,10 +99,11 @@ class RouteAuthPostureSpec extends PlaySpec with GuiceOneAppPerSuite {
    * `ControllerUtils.anonSignupRedirect`, 303 its navigation arm, 403 a `WithAdmin()` refusal.
    *
    * The namespace check asserts membership in this set rather than merely "not 2xx", because anything outside it — a
-   * 400 from a path-parameter binder, a 404, a 415 from a body parser — means the request died before reaching the
-   * guard and so says nothing about whether the route is gated. `concreteRequestPath` substitutes `1` for dynamic
-   * segments, which binds for every /adminapi/ parameter today; the day one takes a type `1` can't bind as, a not-2xx
-   * check would wave an ungated route through on the router's own rejection.
+   * 400 from a path-parameter binder, a 415 from a body parser, a 404 from an ungated action that looked up a record
+   * the substituted id doesn't match — was refused by something other than the guard, and so says nothing about
+   * whether the route is gated. `concreteRequestPath` substitutes `1` for dynamic segments, which binds for every
+   * /adminapi/ parameter today; the day a parameter takes a type that `1` cannot bind to, a not-2xx check would wave
+   * an ungated route through on the router's own rejection.
    */
   private val AuthRejections: Set[Int] = Set(UNAUTHORIZED, SEE_OTHER, FORBIDDEN)
 


### PR DESCRIPTION
Follow-up to #4441, closing a nit raised in review of #4742. Test-only, one file.

### The gap

`RouteAuthPostureSpec` walks every declared `/adminapi/` route and asserts none of them answers an anonymous request. To turn a declared *pattern* into a requestable *path* it substitutes `1` for each dynamic segment, then flagged anything in the 2xx band:

```scala
.filter { case (_, _, code) => code >= 200 && code < 300 }
```

That assertion is negative — "not 2xx is fine" — but a request that never *reaches* the auth guard also isn't 2xx. All six `/adminapi/` path parameters are `Int` today, so `1` binds and the check is honest. Add a route whose parameter is a UUID, an enum, or anything with a custom binder, and the literal `1` stops binding: Play's router answers 400 before the guard runs, and an ungated route passes on the router's own rejection.

### The change

Assert membership in the set of statuses the auth layer actually produces:

```scala
private val AuthRejections: Set[Int] = Set(UNAUTHORIZED, SEE_OTHER, FORBIDDEN)
```

401 is the XHR arm of `ControllerUtils.anonSignupRedirect`, 303 its navigation arm, 403 a `WithAdmin()` refusal. A 400 from a binder, a 404, or a 415 from a body parser now count as leaks, because none of them prove the route is guarded. This brings the check up to the standard the sibling write test already meets — that one requires the status to *be* `UNAUTHORIZED`, not merely not-2xx.

### Verification

`testOnly controllers.RouteAuthPostureSpec` → 21/21 pass, 0 canceled (run against a populated schema, so the authenticated admin / non-admin cases executed rather than skipping). `Test/scalafmtCheck` clean.

Mutation-tested to confirm the new assertion actually bites — temporarily substituting a non-`Int` for dynamic segments simulates the future parameter type this guards against, and all six parameterized routes come back 400:

```
not refused by the auth guard: GET /adminapi/auditpath/notanint -> 400,
GET /adminapi/label/id/notanint -> 400, PUT /adminapi/updateTeamStatus/notanint -> 400,
PUT /adminapi/updateTeamVisibility/notanint -> 400,
PUT /adminapi/stories/notanint/visibility -> 400, DELETE /adminapi/stories/notanint -> 400
```

The old filter ignored all six. The mutation was reverted before committing; the suite is green on the committed state.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-opus-5[1m])
