### PR TITLE
Measure street distances geodesically instead of through UTM zone 18N

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,8 +265,12 @@ jobs:
       # - RouteAuthPostureSpec (#4441): asserts every declared /adminapi/ route refuses an anonymous request, so a new
       #   admin route that forgets its guard fails here. Its data-dependent shape checks `assume` a non-empty result and
       #   report as CANCELED against this job's empty city schema rather than passing vacuously.
-      - name: Run gating/auth tests (health dashboard + route auth posture)
-        run: sbt 'set Test / parallelExecution := false' 'testOnly controllers.HealthDashboardSpec service.HealthServiceSpec controllers.RouteAuthPostureSpec'
+      # - GeodesicDistanceSpec (#4641): street lengths must be geodesic, not projected to a fixed CRS. Its synthetic-
+      #   fixture layer inserts its own streets and checks them against analytically derived WGS84 arc lengths, so it
+      #   is meaningful even here — a reintroduced projection fails by double digits. Its cache-freshness layer needs
+      #   real data and CANCELs on this empty schema, same as RouteAuthPostureSpec's shape checks.
+      - name: Run gating/auth tests (health dashboard + route auth posture + geodesic distances)
+        run: sbt 'set Test / parallelExecution := false' 'testOnly controllers.HealthDashboardSpec service.HealthServiceSpec controllers.RouteAuthPostureSpec models.street.GeodesicDistanceSpec'
         env:
           DATABASE_URL: jdbc:postgresql://localhost:5432/sidewalk
           DATABASE_USER: sidewalk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,9 +266,9 @@ jobs:
       #   admin route that forgets its guard fails here. Its data-dependent shape checks `assume` a non-empty result and
       #   report as CANCELED against this job's empty city schema rather than passing vacuously.
       # - GeodesicDistanceSpec (#4641): street lengths must be geodesic, not projected to a fixed CRS. Its synthetic-
-      #   fixture layer inserts its own streets and checks them against analytically derived WGS84 arc lengths, so it
-      #   is meaningful even here — a reintroduced projection fails by double digits. Its cache-freshness layer needs
-      #   real data and CANCELs on this empty schema, same as RouteAuthPostureSpec's shape checks.
+      #   fixture tests (analytic WGS84 arc lengths, the #4774 nightly-refresh regression) seed every row they read,
+      #   so they are meaningful even here — a reintroduced projection fails by double digits. Its cache-freshness
+      #   comparisons need real data and CANCEL on this empty schema, same as RouteAuthPostureSpec's shape checks.
       - name: Run gating/auth tests (health dashboard + route auth posture + geodesic distances)
         run: sbt 'set Test / parallelExecution := false' 'testOnly controllers.HealthDashboardSpec service.HealthServiceSpec controllers.RouteAuthPostureSpec models.street.GeodesicDistanceSpec'
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,10 +201,10 @@ When you catch yourself writing a frontend constant that mirrors a backend value
   overstated street distances by up to +51% (#4641). Cached distance columns (`user_stat.meters_audited`,
   `labels_per_meter` and the `high_quality` flag derived from it, `region_completion`, `route.distance_meters`) must
   equal what their runtime recompute would produce, so changing a distance query means recomputing its caches in the
-  same evolution. `GeodesicDistanceSpec` checks that against the connected database — it needs a *seeded* one, since
-  its cache-freshness tests `assume` non-empty tables and CANCEL otherwise. Treat a full-suite run against your dev DB
-  as the real gate. (`meters_audited` is the one column the runtime does **not** keep fresh on its own — the nightly
-  refresh only reaches users with an `audit`-type mission, #4774.)
+  same evolution — and the nightly refresh that maintains them has to reach every row a full recompute would touch
+  (#4774). `GeodesicDistanceSpec` checks both against the connected database. It needs a *seeded* one: its
+  cache-freshness tests `assume` non-empty tables and CANCEL otherwise, so treat a full-suite run against your dev DB
+  as the real gate.
 - After editing any Scala file, run `make scalafmt-fix` (reformats the whole tree in place via the sbt thin client) before treating the change as done — scalafmt is a blocking CI gate, so unformatted Scala fails the build. One run after a batch of edits is enough; no need to format after every single edit.
 - After editing frontend files, lint what you touched and get to zero before the change is done. All four frontend linters are **blocking CI gates** (steps in the `frontend` job — see Continuous integration), the JS/CSS/HTML/i18n counterparts to the scalafmt rule above, so a finding fails the build. The whole tree is lint-clean (#2487), so any finding is from your change.
   - **JavaScript** (`public/js/`): `make eslint-fix dir=<what you touched>`, hand-fix what `--fix` can't, until `make eslint` passes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,6 +195,13 @@ When you catch yourself writing a frontend constant that mirrors a backend value
 - Update said code to use the native `fetch` API rather than jQuery, and to make use of Promises. But if said refactor would impact many other functions that use it, then wait for a dedicated refactor.
 - Replace uses of Bootstrap with native JS alternatives as you come across them
 - When writing SQL, avoid table aliases
+- **Measure geographic distances geodesically** — `ST_Length(geom::geography)` in raw SQL, the `lengthGeodesic`
+  extension method in Slick (defined in `MyPostgresProfile`), turf.js on the frontend. Never measure by projecting to
+  a fixed SRID: a projection is only accurate near its own meridian, and measuring every city through UTM zone 18N
+  overstated street distances by up to +51% (#4641). Cached distance columns (`user_stat.meters_audited`,
+  `labels_per_meter` and the `high_quality` flag derived from it, `region_completion`, `route.distance_meters`) must
+  always equal what their runtime recompute would produce — `GeodesicDistanceSpec` enforces this, so changing a
+  distance query means recomputing its caches.
 - After editing any Scala file, run `make scalafmt-fix` (reformats the whole tree in place via the sbt thin client) before treating the change as done — scalafmt is a blocking CI gate, so unformatted Scala fails the build. One run after a batch of edits is enough; no need to format after every single edit.
 - After editing frontend files, lint what you touched and get to zero before the change is done. All four frontend linters are **blocking CI gates** (steps in the `frontend` job — see Continuous integration), the JS/CSS/HTML/i18n counterparts to the scalafmt rule above, so a finding fails the build. The whole tree is lint-clean (#2487), so any finding is from your change.
   - **JavaScript** (`public/js/`): `make eslint-fix dir=<what you touched>`, hand-fix what `--fix` can't, until `make eslint` passes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,8 +200,11 @@ When you catch yourself writing a frontend constant that mirrors a backend value
   a fixed SRID: a projection is only accurate near its own meridian, and measuring every city through UTM zone 18N
   overstated street distances by up to +51% (#4641). Cached distance columns (`user_stat.meters_audited`,
   `labels_per_meter` and the `high_quality` flag derived from it, `region_completion`, `route.distance_meters`) must
-  always equal what their runtime recompute would produce — `GeodesicDistanceSpec` enforces this, so changing a
-  distance query means recomputing its caches.
+  equal what their runtime recompute would produce, so changing a distance query means recomputing its caches in the
+  same evolution. `GeodesicDistanceSpec` checks that against the connected database — it needs a *seeded* one, since
+  its cache-freshness tests `assume` non-empty tables and CANCEL otherwise. Treat a full-suite run against your dev DB
+  as the real gate. (`meters_audited` is the one column the runtime does **not** keep fresh on its own — the nightly
+  refresh only reaches users with an `audit`-type mission, #4774.)
 - After editing any Scala file, run `make scalafmt-fix` (reformats the whole tree in place via the sbt thin client) before treating the change as done — scalafmt is a blocking CI gate, so unformatted Scala fails the build. One run after a batch of edits is enough; no need to format after every single edit.
 - After editing frontend files, lint what you touched and get to zero before the change is done. All four frontend linters are **blocking CI gates** (steps in the `frontend` job — see Continuous integration), the JS/CSS/HTML/i18n counterparts to the scalafmt rule above, so a finding fails the build. The whole tree is lint-clean (#2487), so any finding is from your change.
   - **JavaScript** (`public/js/`): `make eslint-fix dir=<what you touched>`, hand-fix what `--fix` can't, until `make eslint` passes.

--- a/app/models/audit/AuditTaskTable.scala
+++ b/app/models/audit/AuditTaskTable.scala
@@ -354,7 +354,7 @@ class AuditTaskTable @Inject() (
       .filter(_.userId === userId)
       .join(streetEdgeTable.streets)
       .on(_.streetEdgeId === _.streetEdgeId)
-      .map(_._2.geom.transform(26918).lengthD)
+      .map(_._2.geom.lengthGeodesic)
       .sum
       .getOrElse(0d)
       .result
@@ -367,7 +367,7 @@ class AuditTaskTable @Inject() (
     getStreetEdgeRegionsNotAuditedQuery(userId, regionId)
       .join(streetEdgeTable.streets)
       .on(_.streetEdgeId === _.streetEdgeId)
-      .map(_._2.geom.transform(26918).lengthD)
+      .map(_._2.geom.lengthGeodesic)
       .sum
       .result
       .map(_.getOrElse(0d))

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -2176,13 +2176,13 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
              ai_stats.crswlk_ai_no_admin_yes,
              ai_stats.crswlk_ai_no_admin_no
       FROM (
-          SELECT SUM(ST_LENGTH(ST_TRANSFORM(geom, 26918))) / 1000 AS km_audited
+          SELECT SUM(ST_Length(geom::geography)) / 1000 AS km_audited
           FROM street_edge
           INNER JOIN audit_task ON street_edge.street_edge_id = audit_task.street_edge_id
           INNER JOIN user_stat ON audit_task.user_id = user_stat.user_id
           WHERE completed = TRUE AND #$userFilter
       ) AS km_audited, (
-          SELECT SUM(ST_LENGTH(ST_TRANSFORM(geom, 26918))) / 1000 AS km_audited_no_overlap
+          SELECT SUM(ST_Length(geom::geography)) / 1000 AS km_audited_no_overlap
           FROM (
               SELECT DISTINCT street_edge.street_edge_id, geom
               FROM street_edge
@@ -2194,7 +2194,7 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
           -- Redundant-coverage km: streets with a completed audit by ≥2 distinct (non-excluded) users. Mirrors the
           -- km_audited_no_overlap subquery but groups per street and keeps only those audited by 2+ people. Single-user
           -- km is derived (no_overlap − multiple_users) in projectSidewalkStatsConverter, so it is not selected here.
-          SELECT COALESCE(SUM(ST_LENGTH(ST_TRANSFORM(geom, 26918))) / 1000, 0) AS km_explored_multiple_users
+          SELECT COALESCE(SUM(ST_Length(geom::geography)) / 1000, 0) AS km_explored_multiple_users
           FROM (
               SELECT street_edge.street_edge_id, geom
               FROM street_edge
@@ -2213,7 +2213,7 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
                  COALESCE(SUM(len) FILTER (WHERE status = 'closed'), 0)     AS km_closed,
                  COALESCE(SUM(len) FILTER (WHERE status = 'disabled'), 0)   AS km_disabled
           FROM (
-              SELECT status, ST_LENGTH(ST_TRANSFORM(geom, 26918)) / 1000 AS len
+              SELECT status, ST_Length(geom::geography) / 1000 AS len
               FROM street_edge
               WHERE street_edge_id <> (SELECT tutorial_street_edge_id FROM config)
           ) street_lengths

--- a/app/models/region/RegionCompletionTable.scala
+++ b/app/models/region/RegionCompletionTable.scala
@@ -78,7 +78,7 @@ class RegionCompletionTable @Inject() (
     for {
       distToAdd: Double <- streetEdgeTable.streets
         .filter(_.streetEdgeId === streetEdgeId)
-        .map(_.geom.transform(26918).lengthD)
+        .map(_.geom.lengthGeodesic)
         .result
         .head
       regionId: Int <- streetEdgeRegion

--- a/app/models/route/RouteTable.scala
+++ b/app/models/route/RouteTable.scala
@@ -149,7 +149,7 @@ class RouteTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
       .filter(_.routeId === routeId)
       .join(streetEdges)
       .on(_.streetEdgeId === _.streetEdgeId)
-      .map { case (_, streetEdge) => streetEdge.geom.transform(26918).lengthD }
+      .map { case (_, streetEdge) => streetEdge.geom.lengthGeodesic }
       .sum
       .getOrElse(0d)
       .result
@@ -200,15 +200,15 @@ class RouteTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
    * Recomputes a route's cached distance and street count from its current streets.
    *
    * Called whenever the street list changes, so listings can read the stats straight off the route row instead of
-   * re-measuring every street's geometry per request. Distance is in meters (UTM 18N, matching the previous
-   * derivation); a route with no streets gets zeroes.
+   * re-measuring every street's geometry per request. Distance is in geodesic meters; a route with no streets gets
+   * zeroes.
    */
   def updateStats(routeId: Int): DBIO[Int] = {
     sqlu"""
       UPDATE route
       SET distance_meters = COALESCE(stats.distance_meters, 0), street_count = COALESCE(stats.street_count, 0)
       FROM (
-          SELECT SUM(ST_Length(ST_Transform(street_edge.geom, 26918))) AS distance_meters,
+          SELECT SUM(ST_Length(street_edge.geom::geography)) AS distance_meters,
                  COUNT(*) AS street_count
           FROM route_street
           INNER JOIN street_edge ON route_street.street_edge_id = street_edge.street_edge_id

--- a/app/models/street/StreetEdgePriorityTable.scala
+++ b/app/models/street/StreetEdgePriorityTable.scala
@@ -55,7 +55,7 @@ class StreetEdgePriorityTable @Inject() (
       se  <- streetEdgeTable.streets
       sep <- streetEdgePriorities if se.streetEdgeId === sep.streetEdgeId
       if sep.priority < 1.0d
-    } yield se.geom.transform(26918).lengthD
+    } yield se.geom.lengthGeodesic
 
     // Sum the lengths and convert from meters to miles.
     edgeLengths.sum.result.map(x => x.getOrElse(0.0d))

--- a/app/models/street/StreetEdgeTable.scala
+++ b/app/models/street/StreetEdgeTable.scala
@@ -139,7 +139,7 @@ class StreetEdgeTable @Inject() (
    * Get the total street distance in meters.
    */
   def totalStreetDistance: DBIO[Double] = {
-    streets.map(_.geom.transform(26918).lengthD).sum.result.map(x => x.getOrElse(0.0d))
+    streets.map(_.geom.lengthGeodesic).sum.result.map(x => x.getOrElse(0.0d))
   }
 
   /**
@@ -156,7 +156,7 @@ class StreetEdgeTable @Inject() (
     } yield _edges
 
     // Get length of each street segment, sum the lengths, and convert from meters to miles.
-    edges.distinctOn(_.streetEdgeId).map(_.geom.transform(26918).lengthD).sum.getOrElse(0d).result
+    edges.distinctOn(_.streetEdgeId).map(_.geom.lengthGeodesic).sum.getOrElse(0d).result
   }
 
   /**
@@ -224,11 +224,10 @@ class StreetEdgeTable @Inject() (
   }
 
   /**
-   * Gets the length in meters of each of the given street edges.
+   * Gets the geodesic length in meters of each of the given street edges.
    *
-   * Lengths are computed by projecting the geometry to UTM zone 18N (EPSG:26918) so the result is in meters rather than
-   * degrees — the same projection used by the distance methods above. Used to length-weight region AccessScores (#3855).
-   * `inSet` inlines the ids (rather than binding them) to avoid the bound-parameter limit on whole-city id lists.
+   * Length-weights region AccessScores (#3855). `inSet` inlines the ids (rather than binding them) to avoid the
+   * bound-parameter limit on whole-city id lists.
    *
    * @param streetEdgeIds The street edge ids to measure.
    * @return A map from street edge id to its length in meters (empty for an empty input).
@@ -238,7 +237,7 @@ class StreetEdgeTable @Inject() (
     else
       streetsUnfiltered
         .filter(_.streetEdgeId inSet streetEdgeIds)
-        .map(s => (s.streetEdgeId, s.geom.transform(26918).lengthD))
+        .map(s => (s.streetEdgeId, s.geom.lengthGeodesic))
         .result
         .map(_.toMap)
   }

--- a/app/models/user/UserStatTable.scala
+++ b/app/models/user/UserStatTable.scala
@@ -296,7 +296,7 @@ class UserStatTable @Inject() (
       .join(streetEdgeTable.streets)
       .on(_._1.streetEdgeId === _.streetEdgeId)
       .groupBy(_._1._1.userId)
-      .map(x => (x._1, x._2.map(_._2.geom.transform(26918).lengthD).sum))
+      .map(x => (x._1, x._2.map(_._2.geom.lengthGeodesic).sum))
       .result
       .flatMap { auditedDists: Seq[(String, Option[Double])] =>
         // Update the meters_audited column in the user_stat table.
@@ -529,9 +529,9 @@ class UserStatTable @Inject() (
    *
    * Interim workaround for #4376 (mirrors `ConfigTable.withJitOff`): the projectsidewalk/db image ships a broken
    * Postgres JIT (PostGIS bitcode built with LLVM 16, runtime llvmjit linked against LLVM 11). A query expensive enough
-   * to cross the JIT inline-cost threshold and inline PostGIS bitcode (ST_TRANSFORM/ST_LENGTH) segfaults the backend,
+   * to cross the JIT inline-cost threshold and inline PostGIS bitcode (e.g. ST_LENGTH) segfaults the backend,
    * dropping the connection (SQLSTATE 08006) and forcing Postgres crash-recovery — which surfaces as a site-wide 502.
-   * `getLeaderboardStats` computes audited distance with ST_LENGTH(ST_TRANSFORM(...)) and is expensive enough to trip
+   * `getLeaderboardStats` computes audited distance with PostGIS ST_Length and is expensive enough to trip
    * this (#4545), so it must run with JIT off. `SET LOCAL` scopes the setting to this one transaction. Remove once #4376
    * disables JIT at the DB config level.
    *
@@ -636,7 +636,7 @@ class UserStatTable @Inject() (
           GROUP BY #$groupingCol
       ) "missions_counts" ON label_counts.#$groupingColName = missions_counts.#$groupingColName
       LEFT JOIN (
-          SELECT #$groupingCol, COALESCE(SUM(ST_LENGTH(ST_TRANSFORM(geom, 26918))), 0) AS distance_meters
+          SELECT #$groupingCol, COALESCE(SUM(ST_Length(geom::geography)), 0) AS distance_meters
           FROM street_edge
           INNER JOIN audit_task ON street_edge.street_edge_id = audit_task.street_edge_id
           INNER JOIN sidewalk_user ON audit_task.user_id = sidewalk_user.user_id
@@ -674,8 +674,8 @@ class UserStatTable @Inject() (
    * statement rather than a per-city fan-out because all city schemas live in the same database.
    *
    * Two deliberate departures from the per-city board, both to keep this cheap enough to run on a page load:
-   *  - Distance sums the nightly-precomputed `user_stat.meters_audited` instead of recomputing
-   *    `ST_LENGTH(ST_TRANSFORM(...))` per city. It is the same quantity by the same definition (see
+   *  - Distance sums the nightly-precomputed `user_stat.meters_audited` instead of recomputing geodesic street
+   *    lengths per city. It is the same quantity by the same definition (see
    *    `updateAuditedDistanceHelper`), just up to a day stale, and it keeps PostGIS out of a 50-way union — which also
    *    sidesteps the JIT segfault that forces `withJitOff` on the per-city board (#4376/#4545).
    *  - Ranking is by raw label count, so the rows are in true rank order (the per-city board's composite score has a

--- a/app/models/user/UserStatTable.scala
+++ b/app/models/user/UserStatTable.scala
@@ -271,17 +271,8 @@ class UserStatTable @Inject() (
    * Update meters_audited column in the user_stat table for users who have done any auditing since `cutoffTime`.
    */
   def updateAuditedDistance(cutoffTime: OffsetDateTime): DBIO[Unit] = {
-    // Get the list of users who have done any auditing since the cutoff time.
-    val usersToUpdate: Query[Rep[String], String, Seq] =
-      auditMissions.filter(_.missionEnd > cutoffTime).groupBy(_.userId).map(_._1)
-
-    // Computes the audited distance in meters for each user using the audit_task and street_edge tables.
-    updateAuditedDistanceHelper(usersToUpdate)
+    updateAuditedDistanceHelper(usersThatAuditedSinceCutoffTime(cutoffTime))
   }
-
-  /**
-   * Update the meters_audited column in the user_stat table for users who have done any auditing since `cutoffTime`.
-   */
 
   /**
    * Updates the meters_audited column in the user_stat table for the given users.
@@ -505,15 +496,23 @@ class UserStatTable @Inject() (
   }
 
   /**
-   * Helper function to get the list of users who have done any auditing since the cutoff time.
+   * The users who have done any auditing since the cutoff time, i.e. whose cached stats may have gone stale.
+   *
+   * Completed audit tasks, not just audit missions, decide this. A user can accumulate completed audit tasks under a
+   * mission of another type — `auditOnboarding`, or the `exploreAddress` drop-ins of #4451 — and a mission-only
+   * selector never reaches them, so `meters_audited` stays at whatever it was, usually 0, forever (#4774). The audit
+   * missions are still unioned in rather than replaced, so a user whose missions moved but whose tasks did not is
+   * still refreshed.
+   *
+   * Deliberately does not require `meters_audited > 0`: that is the value this set exists to correct, so requiring it
+   * would keep exactly the stuck-at-zero users out of the refresh that would unstick them.
    */
   def usersThatAuditedSinceCutoffTime(cutoffTime: OffsetDateTime): Query[Rep[String], String, Seq] = {
-    (for {
-      _userStat <- userStats
-      _mission  <- auditMissions if _mission.userId === _userStat.userId
-      if _userStat.metersAudited > 0d
-      if _mission.missionEnd > cutoffTime
-    } yield _userStat.userId).groupBy(x => x).map(_._1)
+    val fromMissions: Query[Rep[String], String, Seq] = auditMissions.filter(_.missionEnd > cutoffTime).map(_.userId)
+    val fromTasks: Query[Rep[String], String, Seq]    =
+      auditTaskTable.filter(task => task.completed && task.taskEnd > cutoffTime).map(_.userId)
+
+    (fromMissions ++ fromTasks).distinct
   }
 
   /**

--- a/app/models/user/UserStatTable.scala
+++ b/app/models/user/UserStatTable.scala
@@ -423,8 +423,11 @@ class UserStatTable @Inject() (
           !x.excluded &&                              // false if excluded=true
           x.highQualityManual.getOrElse(true) && (    // false if high_quality_manual=false
             x.highQualityManual.getOrElse(false) || ( // true if high_quality_manual set to true
+              // 0.6d, not 0.6f: widening the float would compare against 0.60000002, so this path and the bulk
+              // `updateHighQuality` below would disagree for an accuracy in that sliver. Evolution 347 and
+              // GeodesicDistanceSpec both assume the two agree exactly.
               (x.metersAudited === 0d || x.labelsPerMeter.getOrElse(5d) > LABEL_PER_METER_THRESHOLD)
-                && (x.accuracy.getOrElse(1.0d) > 0.6f.asColumnOf[Double] || x.ownLabelsValidated < 50.asColumnOf[Int])
+                && (x.accuracy.getOrElse(1.0d) > 0.6d.asColumnOf[Double] || x.ownLabelsValidated < 50.asColumnOf[Int])
             )
           )
         }

--- a/app/models/utils/ConfigTable.scala
+++ b/app/models/utils/ConfigTable.scala
@@ -90,7 +90,7 @@ class ConfigTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvi
    *
    * Interim workaround for #4376: the projectsidewalk/db image ships a broken Postgres JIT (PostGIS bitcode built with
    * LLVM 16, runtime llvmjit linked against LLVM 11). An expensive query that JIT-inlines PostGIS function bitcode
-   * (ST_TRANSFORM/ST_LENGTH) segfaults the backend, surfacing as a dropped connection (SQLSTATE 08006). The cross-city
+   * (e.g. ST_LENGTH) segfaults the backend, surfacing as a dropped connection (SQLSTATE 08006). The cross-city
    * scorecard and labeling-speed queries cross the JIT cost thresholds and call those functions, so they trip it.
    * `SET LOCAL` scopes the setting to this one transaction. Remove once #4376 disables JIT at the DB config level.
    *
@@ -145,13 +145,13 @@ class ConfigTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvi
             tutorial_label_counts.tutorial_label_count AS tutorial_labels,
             total_val_count.validation_count AS total_validations
       FROM (
-          SELECT SUM(ST_LENGTH(ST_TRANSFORM(geom, 26918))) / 1000 AS km_audited
+          SELECT SUM(ST_Length(geom::geography)) / 1000 AS km_audited
           FROM "#$schema".street_edge
           INNER JOIN "#$schema".audit_task ON street_edge.street_edge_id = audit_task.street_edge_id
           INNER JOIN "#$schema".user_stat ON audit_task.user_id = user_stat.user_id
           WHERE completed = TRUE AND NOT user_stat.excluded
       ) AS km_audited, (
-          SELECT SUM(ST_LENGTH(ST_TRANSFORM(geom, 26918))) / 1000 AS km_audited_no_overlap
+          SELECT SUM(ST_Length(geom::geography)) / 1000 AS km_audited_no_overlap
           FROM (
               SELECT DISTINCT street_edge.street_edge_id, geom
               FROM "#$schema".street_edge
@@ -410,11 +410,11 @@ class ConfigTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvi
           INNER JOIN "#$schema".user_stat ON audit_task.user_id = user_stat.user_id
           WHERE completed = TRUE AND NOT user_stat.excluded AND street_edge.status = 'open'
       ) AS audited_streets, (
-          SELECT SUM(ST_LENGTH(ST_TRANSFORM(geom, 26918))) / 1000 AS km
+          SELECT SUM(ST_Length(geom::geography)) / 1000 AS km
           FROM "#$schema".street_edge WHERE status = 'open'
       ) AS street_km, (
           -- Distinct audited length (no double-counting overlapping audits), open-only (see audited_streets).
-          SELECT SUM(ST_LENGTH(ST_TRANSFORM(geom, 26918))) / 1000 AS km
+          SELECT SUM(ST_Length(geom::geography)) / 1000 AS km
           FROM (
               SELECT DISTINCT street_edge.street_edge_id, geom
               FROM "#$schema".street_edge
@@ -819,7 +819,7 @@ class ConfigTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvi
           ) time_diffs
           WHERE diff < '00:05:00' AND diff > '00:00:00'
       ) AS audit_time, (
-          SELECT SUM(ST_LENGTH(ST_TRANSFORM(geom, 26918))) / 1000 AS km
+          SELECT SUM(ST_Length(geom::geography)) / 1000 AS km
           FROM "#$schema".street_edge
           INNER JOIN "#$schema".audit_task ON street_edge.street_edge_id = audit_task.street_edge_id
           INNER JOIN "#$schema".user_stat ON audit_task.user_id = user_stat.user_id

--- a/app/models/utils/MyPostgresProfile.scala
+++ b/app/models/utils/MyPostgresProfile.scala
@@ -75,6 +75,26 @@ trait MyPostgresProfile
 
       def lengthD[R](implicit om: o#to[Double, R]): Rep[R] = om.column(GeomLibrary.Length, n)
 
+      /**
+       * Geodesic length in meters of a 4326 geometry, measured on the WGS84 spheroid via a `::geography` cast.
+       *
+       * This is the canonical measure for street distances (#4641): accurate worldwide, and consistent with the
+       * frontend, which measures distances geodesically with turf.js. Never measure by projecting to a fixed CRS —
+       * transverse Mercator distortion away from the zone's central meridian reaches +51% (Auckland through the
+       * UTM zone 18N that all cities were once measured in).
+       *
+       * Unlike `lengthD`, this does not Option-lift: it is only for non-nullable geometry columns (NULL would fail
+       * result conversion outside an aggregate).
+       */
+      def lengthGeodesic: Rep[Double] = SimpleExpression
+        .unary[P1, Double] { (geomNode, queryBuilder) =>
+          queryBuilder.sqlBuilder += "ST_Length(("
+          queryBuilder.expr(geomNode)
+          queryBuilder.sqlBuilder += ")::geography)"
+          ()
+        }
+        .apply(c)
+
       def distanceSphereD[P2, R](geom: Rep[P2])(implicit om: o#to[Double, R]): Rep[R] =
         om.column(GeomLibrary.DistanceSphere, n, geom.toNode)
 

--- a/app/service/ExploreService.scala
+++ b/app/service/ExploreService.scala
@@ -511,10 +511,10 @@ class ExploreServiceImpl @Inject() (
    * mid-street drop-ins never do, which errs on the cheap side (under-crediting costs nothing, over-crediting
    * corrupts coverage).
    *
-   * Length is measured with `::geography` (geodesic) rather than a projected CRS because the value it is compared
-   * against — the client's `audited_distance_m` — is itself computed geodesically. Projecting to a fixed UTM zone the
-   * way `RegionCompletionTable` does would inflate the length outside that zone (~25% in Amsterdam), pushing the
-   * threshold past the street's real length so it could never be reached.
+   * Length is measured with `::geography` (geodesic, the codebase-wide convention — #4641) which matters doubly here:
+   * the value it is compared against — the client's `audited_distance_m` — is itself computed geodesically (turf), so
+   * any other measure would skew the threshold (a fixed-UTM-zone projection inflates lengths ~25% in Amsterdam,
+   * pushing it past the street's real length so it could never be reached).
    *
    * @param auditTaskId      The session's task, holding where along the street it dropped in.
    * @param streetEdgeId     The street being explored.

--- a/app/service/RegionService.scala
+++ b/app/service/RegionService.scala
@@ -20,6 +20,7 @@ trait RegionService {
   def selectAllNamedNeighborhoodCompletions(regionIds: Seq[Int]): Future[Seq[NamedRegionCompletion]]
   def truncateRegionCompletionTable: Future[Int]
   def initializeRegionCompletionTable: Future[Int]
+  def initializeRegionCompletionTableAction: DBIO[Int]
 }
 
 @Singleton
@@ -56,7 +57,15 @@ class RegionServiceImpl @Inject() (
    * @return The number of rows inserted into the region_completion table.
    */
   def initializeRegionCompletionTable: Future[Int] = {
-    val tableInitAction = for {
+    db.run(initializeRegionCompletionTableAction.transactionally)
+  }
+
+  /**
+   * The composable action behind `initializeRegionCompletionTable` — exposed separately so tests can run the real
+   * recompute inside their own (rolled-back) transaction and compare it against the cached values.
+   */
+  def initializeRegionCompletionTableAction: DBIO[Int] = {
+    for {
       count: Int       <- regionCompletionTable.count
       numInserted: Int <-
         if (count == 0) {
@@ -64,14 +73,14 @@ class RegionServiceImpl @Inject() (
             _edgeRegion   <- streetEdgeRegion
             _edges        <- streetEdgeTable.streets if _edges.streetEdgeId === _edgeRegion.streetEdgeId
             _edgePriority <- streetEdgePriorities if _edges.streetEdgeId === _edgePriority.streetEdgeId
-          } yield (_edgeRegion.regionId, _edges.geom.transform(26918), _edgePriority.priority < 1.0)
+          } yield (_edgeRegion.regionId, _edges.geom.lengthGeodesic, _edgePriority.priority < 1.0)
 
           // Get region_id, total_distance, audited_distance for each region.
           val regionsQuery = streetsInRegion.groupBy(_._1).map { case (regionId, group) =>
             (
               regionId,
-              group.map(_._2.lengthD).sum.getOrElse(0.0d),                                    // total distance
-              group.map(s => Case.If(s._3).Then(s._2.lengthD).Else(0.0d)).sum.getOrElse(0.0d) // audited distance
+              group.map(_._2).sum.getOrElse(0.0d),                                    // total distance
+              group.map(s => Case.If(s._3).Then(s._2).Else(0.0d)).sum.getOrElse(0.0d) // audited distance
             )
           }
 
@@ -91,7 +100,5 @@ class RegionServiceImpl @Inject() (
           DBIO.successful(0) // If the table is already initialized, 0 rows inserted.
         }
     } yield numInserted
-
-    db.run(tableInitAction.transactionally)
   }
 }

--- a/conf/evolutions/default/347.sql
+++ b/conf/evolutions/default/347.sql
@@ -1,0 +1,98 @@
+# --- !Ups
+-- Street distances are now measured geodesically -- ST_Length over geography, accurate worldwide -- instead of by
+-- projecting every city's geometry to UTM zone 18N (EPSG:26918), which is only correct near the US East Coast and
+-- overstated lengths by up to +51% (Auckland) elsewhere (#4641). This migration recomputes every cached distance so
+-- stored values agree with what the app now computes on the fly. Each statement mirrors the runtime recompute it
+-- caches for -- named in the comment above it -- so the invariant "stored value == fresh recompute" holds afterwards.
+-- mission.distance_meters / distance_progress are deliberately untouched: they are historical per-mission records
+-- (fixed targets, or clipped to a region remainder at creation time) that nothing recomputes or compares globally.
+
+-- The recomputes are expensive PostGIS queries, which can trip the broken JIT that ships in the projectsidewalk/db
+-- image (#4376) and segfault the backend. Evolutions run with autocommit off, i.e. inside one transaction, so
+-- SET LOCAL scopes the guard to this migration.
+SET LOCAL jit = off;
+
+-- region_completion: mirrors RegionService.initializeRegionCompletionTable. Only open streets excluding the tutorial
+-- street count, and a street is audited when its priority has dropped below 1. Regions with no qualifying streets get
+-- zeroes, matching what a fresh initialization would insert for them.
+UPDATE region_completion
+SET total_distance   = COALESCE(recomputed.total_distance, 0),
+    audited_distance = COALESCE(recomputed.audited_distance, 0)
+FROM region_completion AS current_completion
+LEFT JOIN (
+    SELECT street_edge_region.region_id,
+           SUM(ST_Length(street_edge.geom::geography)) AS total_distance,
+           SUM(ST_Length(street_edge.geom::geography)) FILTER (WHERE street_edge_priority.priority < 1.0) AS audited_distance
+    FROM street_edge_region
+    INNER JOIN street_edge ON street_edge_region.street_edge_id = street_edge.street_edge_id
+    INNER JOIN street_edge_priority ON street_edge.street_edge_id = street_edge_priority.street_edge_id
+    WHERE street_edge.status = 'open'
+        AND street_edge.street_edge_id <> (SELECT tutorial_street_edge_id FROM config)
+    GROUP BY street_edge_region.region_id
+) recomputed ON current_completion.region_id = recomputed.region_id
+WHERE region_completion.region_id = current_completion.region_id;
+
+-- user_stat.meters_audited: mirrors UserStatTable.updateAuditedDistanceHelper -- per completed audit task (a street
+-- audited by the same user twice counts twice), open streets excluding the tutorial street. Restricted to users with
+-- at least one qualifying task, exactly the set a full runtime recompute would touch.
+UPDATE user_stat
+SET meters_audited = recomputed.meters_audited
+FROM (
+    SELECT audit_task.user_id, SUM(ST_Length(street_edge.geom::geography)) AS meters_audited
+    FROM audit_task
+    INNER JOIN street_edge ON audit_task.street_edge_id = street_edge.street_edge_id
+    WHERE audit_task.completed
+        AND street_edge.status = 'open'
+        AND street_edge.street_edge_id <> (SELECT tutorial_street_edge_id FROM config)
+    GROUP BY audit_task.user_id
+) recomputed
+WHERE user_stat.user_id = recomputed.user_id;
+
+-- user_stat.labels_per_meter: mirrors UserStatTable.updateLabelsPerMeterHelper, which derives it from meters_audited
+-- (recomputed above). Labels are counted through the user's audit missions, dropping deleted and tutorial labels and
+-- anything on the tutorial street. Users with zero audited meters keep their value (runtime leaves it NULL for them).
+UPDATE user_stat
+SET labels_per_meter = COALESCE(label_counts.label_count, 0) / user_stat.meters_audited
+FROM user_stat AS current_stat
+LEFT JOIN (
+    SELECT mission.user_id, COUNT(label.label_id) AS label_count
+    FROM mission
+    INNER JOIN label ON mission.mission_id = label.mission_id
+    INNER JOIN audit_task ON label.audit_task_id = audit_task.audit_task_id
+    WHERE mission.mission_type = 'audit'
+        AND NOT label.deleted
+        AND NOT label.tutorial
+        AND label.street_edge_id <> (SELECT tutorial_street_edge_id FROM config)
+        AND audit_task.street_edge_id <> (SELECT tutorial_street_edge_id FROM config)
+    GROUP BY mission.user_id
+) label_counts ON current_stat.user_id = label_counts.user_id
+WHERE user_stat.user_id = current_stat.user_id
+    AND user_stat.meters_audited > 0;
+
+-- user_stat.high_quality: labels_per_meter (just recomputed above) is an input to the quality heuristic, so refresh
+-- the flag too. Mirrors UserStatTable.updateHighQuality, which is a pure function of user_stat columns -- the manual
+-- override, then the 0.0375 labels-per-meter floor and the 60%-accuracy-at-50+-validations floor -- so this writes
+-- exactly what any runtime refresh of the same row would.
+UPDATE user_stat
+SET high_quality =
+    NOT excluded
+    AND COALESCE(high_quality_manual, TRUE)
+    AND (COALESCE(high_quality_manual, FALSE)
+         OR ((meters_audited = 0 OR COALESCE(labels_per_meter, 5) > 0.0375)
+             AND (COALESCE(accuracy, 1.0) > 0.6 OR own_labels_validated < 50)));
+
+-- route.distance_meters: mirrors RouteTable.updateStats -- every street on the route regardless of status. Routes
+-- with no streets stay at 0.
+UPDATE route
+SET distance_meters = recomputed.distance_meters
+FROM (
+    SELECT route_street.route_id, SUM(ST_Length(street_edge.geom::geography)) AS distance_meters
+    FROM route_street
+    INNER JOIN street_edge ON route_street.street_edge_id = street_edge.street_edge_id
+    GROUP BY route_street.route_id
+) recomputed
+WHERE route.route_id = recomputed.route_id;
+
+# --- !Downs
+-- One-way recompute: the cached distances are re-derived from street geometry under the geodesic measure, and
+-- restoring the old projected values would just reintroduce the #4641 error, so there is nothing to revert.

--- a/conf/evolutions/default/347.sql
+++ b/conf/evolutions/default/347.sql
@@ -6,6 +6,13 @@
 -- caches for -- named in the comment above it -- so the invariant "stored value == fresh recompute" holds afterwards.
 -- mission.distance_meters / distance_progress are deliberately untouched: they are historical per-mission records
 -- (fixed targets, or clipped to a region remainder at creation time) that nothing recomputes or compares globally.
+--
+-- These are full recomputes, not rescalings, so they also repair rows the nightly refresh has never reached. On the
+-- Seattle dev dump 352 users have a completed audit task on an open street but meters_audited = 0 stored, because
+-- UserStatTable.updateAuditedDistance(cutoffTime) picks its users from `audit`-type missions and those users have
+-- only auditOnboarding ones (#4774). Repairing them gives labels_per_meter = 0, which fails the quality floor, so of
+-- the 432 high_quality flips this migration produces on that dump, 326 are that repair and 96 are the geodesic
+-- effect (shorter streets raise labels_per_meter, lifting users over the floor).
 
 -- The recomputes are expensive PostGIS queries, which can trip the broken JIT that ships in the projectsidewalk/db
 -- image (#4376) and segfault the backend. Evolutions run with autocommit off, i.e. inside one transaction, so
@@ -15,6 +22,8 @@ SET LOCAL jit = off;
 -- region_completion: mirrors RegionService.initializeRegionCompletionTable. Only open streets excluding the tutorial
 -- street count, and a street is audited when its priority has dropped below 1. Regions with no qualifying streets get
 -- zeroes, matching what a fresh initialization would insert for them.
+-- UPDATE ... FROM cannot LEFT JOIN its own target, so the target is re-listed under an alias and joined back by
+-- primary key. Without that, regions missing from `recomputed` would keep their stale value instead of going to 0.
 UPDATE region_completion
 SET total_distance   = COALESCE(recomputed.total_distance, 0),
     audited_distance = COALESCE(recomputed.audited_distance, 0)
@@ -73,13 +82,23 @@ WHERE user_stat.user_id = current_stat.user_id
 -- the flag too. Mirrors UserStatTable.updateHighQuality, which is a pure function of user_stat columns -- the manual
 -- override, then the 0.0375 labels-per-meter floor and the 60%-accuracy-at-50+-validations floor -- so this writes
 -- exactly what any runtime refresh of the same row would.
+-- The WHERE repeats the expression rather than joining a subquery that computes it once, for two reasons: both the
+-- SET and the filter must read the row being updated (user_id carries no UNIQUE constraint, so a self-join on it can
+-- match the wrong row), and without the filter this rewrites every user_stat row -- 995k rows and 10s of the
+-- migration's 11s on the Seattle dump, to change 432 of them.
 UPDATE user_stat
 SET high_quality =
     NOT excluded
     AND COALESCE(high_quality_manual, TRUE)
     AND (COALESCE(high_quality_manual, FALSE)
          OR ((meters_audited = 0 OR COALESCE(labels_per_meter, 5) > 0.0375)
-             AND (COALESCE(accuracy, 1.0) > 0.6 OR own_labels_validated < 50)));
+             AND (COALESCE(accuracy, 1.0) > 0.6 OR own_labels_validated < 50)))
+WHERE high_quality IS DISTINCT FROM (
+    NOT excluded
+    AND COALESCE(high_quality_manual, TRUE)
+    AND (COALESCE(high_quality_manual, FALSE)
+         OR ((meters_audited = 0 OR COALESCE(labels_per_meter, 5) > 0.0375)
+             AND (COALESCE(accuracy, 1.0) > 0.6 OR own_labels_validated < 50))));
 
 -- route.distance_meters: mirrors RouteTable.updateStats -- every street on the route regardless of status. Routes
 -- with no streets stay at 0.
@@ -94,5 +113,82 @@ FROM (
 WHERE route.route_id = recomputed.route_id;
 
 # --- !Downs
--- One-way recompute: the cached distances are re-derived from street geometry under the geodesic measure, and
--- restoring the old projected values would just reintroduce the #4641 error, so there is nothing to revert.
+-- Reverting this migration means reverting to code that measures through UTM zone 18N, so the caches are recomputed
+-- under that measure again. The point is not to restore the exact prior bytes -- some of them were stale, and the Up
+-- repaired that -- but to leave the caches agreeing with whatever code is about to read them. Leaving the geodesic
+-- values in place instead is what makes a downgrade silently wrong: region completion, dashboards and the leaderboard
+-- would mix geodesic caches with UTM-measured live queries, with nothing to signal it. Each statement below is its
+-- Up counterpart with ST_Length(geom::geography) swapped for the projected measure.
+SET LOCAL jit = off;
+
+UPDATE region_completion
+SET total_distance   = COALESCE(recomputed.total_distance, 0),
+    audited_distance = COALESCE(recomputed.audited_distance, 0)
+FROM region_completion AS current_completion
+LEFT JOIN (
+    SELECT street_edge_region.region_id,
+           SUM(ST_Length(ST_Transform(street_edge.geom, 26918))) AS total_distance,
+           SUM(ST_Length(ST_Transform(street_edge.geom, 26918))) FILTER (WHERE street_edge_priority.priority < 1.0) AS audited_distance
+    FROM street_edge_region
+    INNER JOIN street_edge ON street_edge_region.street_edge_id = street_edge.street_edge_id
+    INNER JOIN street_edge_priority ON street_edge.street_edge_id = street_edge_priority.street_edge_id
+    WHERE street_edge.status = 'open'
+        AND street_edge.street_edge_id <> (SELECT tutorial_street_edge_id FROM config)
+    GROUP BY street_edge_region.region_id
+) recomputed ON current_completion.region_id = recomputed.region_id
+WHERE region_completion.region_id = current_completion.region_id;
+
+UPDATE user_stat
+SET meters_audited = recomputed.meters_audited
+FROM (
+    SELECT audit_task.user_id, SUM(ST_Length(ST_Transform(street_edge.geom, 26918))) AS meters_audited
+    FROM audit_task
+    INNER JOIN street_edge ON audit_task.street_edge_id = street_edge.street_edge_id
+    WHERE audit_task.completed
+        AND street_edge.status = 'open'
+        AND street_edge.street_edge_id <> (SELECT tutorial_street_edge_id FROM config)
+    GROUP BY audit_task.user_id
+) recomputed
+WHERE user_stat.user_id = recomputed.user_id;
+
+UPDATE user_stat
+SET labels_per_meter = COALESCE(label_counts.label_count, 0) / user_stat.meters_audited
+FROM user_stat AS current_stat
+LEFT JOIN (
+    SELECT mission.user_id, COUNT(label.label_id) AS label_count
+    FROM mission
+    INNER JOIN label ON mission.mission_id = label.mission_id
+    INNER JOIN audit_task ON label.audit_task_id = audit_task.audit_task_id
+    WHERE mission.mission_type = 'audit'
+        AND NOT label.deleted
+        AND NOT label.tutorial
+        AND label.street_edge_id <> (SELECT tutorial_street_edge_id FROM config)
+        AND audit_task.street_edge_id <> (SELECT tutorial_street_edge_id FROM config)
+    GROUP BY mission.user_id
+) label_counts ON current_stat.user_id = label_counts.user_id
+WHERE user_stat.user_id = current_stat.user_id
+    AND user_stat.meters_audited > 0;
+
+UPDATE user_stat
+SET high_quality =
+    NOT excluded
+    AND COALESCE(high_quality_manual, TRUE)
+    AND (COALESCE(high_quality_manual, FALSE)
+         OR ((meters_audited = 0 OR COALESCE(labels_per_meter, 5) > 0.0375)
+             AND (COALESCE(accuracy, 1.0) > 0.6 OR own_labels_validated < 50)))
+WHERE high_quality IS DISTINCT FROM (
+    NOT excluded
+    AND COALESCE(high_quality_manual, TRUE)
+    AND (COALESCE(high_quality_manual, FALSE)
+         OR ((meters_audited = 0 OR COALESCE(labels_per_meter, 5) > 0.0375)
+             AND (COALESCE(accuracy, 1.0) > 0.6 OR own_labels_validated < 50))));
+
+UPDATE route
+SET distance_meters = recomputed.distance_meters
+FROM (
+    SELECT route_street.route_id, SUM(ST_Length(ST_Transform(street_edge.geom, 26918))) AS distance_meters
+    FROM route_street
+    INNER JOIN street_edge ON route_street.street_edge_id = street_edge.street_edge_id
+    GROUP BY route_street.route_id
+) recomputed
+WHERE route.route_id = recomputed.route_id;

--- a/conf/evolutions/default/347.sql
+++ b/conf/evolutions/default/347.sql
@@ -83,9 +83,9 @@ WHERE user_stat.user_id = current_stat.user_id
 -- override, then the 0.0375 labels-per-meter floor and the 60%-accuracy-at-50+-validations floor -- so this writes
 -- exactly what any runtime refresh of the same row would.
 -- The WHERE repeats the expression rather than joining a subquery that computes it once, for two reasons: both the
--- SET and the filter must read the row being updated (user_id carries no UNIQUE constraint, so a self-join on it can
--- match the wrong row), and without the filter this rewrites every user_stat row -- 995k rows and 10s of the
--- migration's 11s on the Seattle dump, to change 432 of them.
+-- SET and the filter must read the row being updated (user_id carries no UNIQUE constraint and duplicate rows exist,
+-- #4776, so a self-join on it can match the wrong row), and without the filter this rewrites every user_stat row --
+-- 995k rows and 10s of the migration's 11s on the Seattle dump, to change 432 of them.
 UPDATE user_stat
 SET high_quality =
     NOT excluded

--- a/conf/evolutions/default/347.sql
+++ b/conf/evolutions/default/347.sql
@@ -7,12 +7,13 @@
 -- mission.distance_meters / distance_progress are deliberately untouched: they are historical per-mission records
 -- (fixed targets, or clipped to a region remainder at creation time) that nothing recomputes or compares globally.
 --
--- These are full recomputes, not rescalings, so they also repair rows the nightly refresh has never reached. On the
--- Seattle dev dump 352 users have a completed audit task on an open street but meters_audited = 0 stored, because
--- UserStatTable.updateAuditedDistance(cutoffTime) picks its users from `audit`-type missions and those users have
--- only auditOnboarding ones (#4774). Repairing them gives labels_per_meter = 0, which fails the quality floor, so of
--- the 432 high_quality flips this migration produces on that dump, 326 are that repair, 96 are the geodesic effect
--- proper (shorter streets raise labels_per_meter, lifting users over the floor), and 10 are other demotions.
+-- These are full recomputes, not rescalings, so they also repair rows the nightly refresh had never reached: on the
+-- Seattle dev dump 352 users have a completed audit task on an open street but meters_audited = 0 stored (#4774,
+-- fixed alongside this migration -- UserStatTable.usersThatAuditedSinceCutoffTime now selects on completed audit
+-- tasks, so nothing falls out of the nightly refresh again). Repairing them gives labels_per_meter = 0, which fails
+-- the quality floor, so of the 432 high_quality flips this migration produces on that dump, 326 are that repair, 96
+-- are the geodesic effect proper (shorter streets raise labels_per_meter, lifting users over the floor), and 10 are
+-- other demotions.
 
 -- The recomputes are expensive PostGIS queries, which can trip the broken JIT that ships in the projectsidewalk/db
 -- image (#4376) and segfault the backend. Evolutions run with autocommit off, i.e. inside one transaction, so

--- a/conf/evolutions/default/347.sql
+++ b/conf/evolutions/default/347.sql
@@ -11,8 +11,8 @@
 -- Seattle dev dump 352 users have a completed audit task on an open street but meters_audited = 0 stored, because
 -- UserStatTable.updateAuditedDistance(cutoffTime) picks its users from `audit`-type missions and those users have
 -- only auditOnboarding ones (#4774). Repairing them gives labels_per_meter = 0, which fails the quality floor, so of
--- the 432 high_quality flips this migration produces on that dump, 326 are that repair and 96 are the geodesic
--- effect (shorter streets raise labels_per_meter, lifting users over the floor).
+-- the 432 high_quality flips this migration produces on that dump, 326 are that repair, 96 are the geodesic effect
+-- proper (shorter streets raise labels_per_meter, lifting users over the floor), and 10 are other demotions.
 
 -- The recomputes are expensive PostGIS queries, which can trip the broken JIT that ships in the projectsidewalk/db
 -- image (#4376) and segfault the backend. Evolutions run with autocommit off, i.e. inside one transaction, so

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -179,6 +179,10 @@ is a blocking CI gate). Conventions scalafmt doesn't cover:
   120 chars or hurt readability.
 - **Use Slick for database access**, not raw SQL, wherever possible — you get compile-time type checking. When you
   must write SQL, **avoid table aliases**.
+- **Measure geographic distances geodesically** — `ST_Length(geom::geography)` in raw SQL, the `lengthGeodesic`
+  extension method in Slick, turf.js on the frontend. Never measure by projecting to a fixed SRID: a projection is
+  only accurate near its own meridian (measuring every city through UTM zone 18N overstated street distances by up
+  to +51% — issue #4641).
 - **Two performance gotchas:** count rows with `.size.result` (emits `COUNT(*)`), **not** `.length.result` (which
   loads every row into memory); for CPU-heavy work use the `cpu-intensive` `ExecutionContext` rather than the default
   (see existing usages).

--- a/public/js/explore/src/mission/MissionController.js
+++ b/public/js/explore/src/mission/MissionController.js
@@ -107,8 +107,9 @@ class MissionController {
   #checkMissionComplete(mission, neighborhood) {
     // On a route the mission IS the route walk (one route-scoped mission, sized to the route server-side), so its
     // completion is finishing the route — handled in wrapUpRouteOrNeighborhood, not by this distance check. The
-    // check would also misfire here: the server measures the route in EPSG:26918 while the client's progress is
-    // turf/WGS84, so the two cross the 99.9% threshold at slightly different points.
+    // check would also misfire here: the server sizes the route geodesically on the WGS84 spheroid while the
+    // client's progress is turf (spherical haversine), so the two cross the 99.9% threshold at slightly
+    // different points.
     if (svl.neighborhoodModel.isRoute) return;
 
     if (mission.getMissionCompletionRate() > 0.999) {

--- a/test/models/street/GeodesicDistanceSpec.scala
+++ b/test/models/street/GeodesicDistanceSpec.scala
@@ -5,6 +5,7 @@ import models.user.{UserStatTable, UserStatTableDef}
 import models.utils.MyPostgresProfile
 import models.utils.MyPostgresProfile.api._
 import org.apache.pekko.stream.Materializer
+import org.scalatest.OptionValues
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Application
@@ -38,8 +39,15 @@ import scala.concurrent.duration.DurationInt
  *      route.distance_meters) and the distance-derived high_quality flag must match what their runtime recomputes
  *      produce — run for real inside a rolled-back transaction. This is exactly the postcondition evolution 347's
  *      backfill promises, so it also fails if that backfill ever drifts from the runtime code it mirrors.
+ *
+ * Layer 3 needs a seeded database, so each of its tests `assume`s the table it reads is non-empty — against an empty
+ * schema they report as canceled rather than passing vacuously (the convention `RouteAuthPostureSpec` uses).
+ *
+ * Known decay: the meters_audited postcondition holds after evolution 347 but is not maintained by the runtime, which
+ * refreshes only users with an `audit`-type mission (#4774). A failure there with no distance query touched means new
+ * users of that shape have accumulated, not that this measure regressed.
  */
-class GeodesicDistanceSpec extends PlaySpec with GuiceOneAppPerSuite {
+class GeodesicDistanceSpec extends PlaySpec with GuiceOneAppPerSuite with OptionValues {
 
   override def fakeApplication(): Application =
     new GuiceApplicationBuilder().disable[modules.ActorModule].build()
@@ -121,6 +129,7 @@ class GeodesicDistanceSpec extends PlaySpec with GuiceOneAppPerSuite {
         lifted <- streetEdgeTable.getStreetLengths(raw.map(_._1))
       } yield (raw, lifted))
 
+      assume(rawLengths.nonEmpty, "no streets in this schema; cross-implementation agreement needs a seeded DB")
       rawLengths.foreach { case (streetEdgeId, rawLength) => assertClose(liftedLengths(streetEdgeId), rawLength) }
     }
 
@@ -132,6 +141,7 @@ class GeodesicDistanceSpec extends PlaySpec with GuiceOneAppPerSuite {
       val json        = contentAsJson(route(app, FakeRequest(GET, "/v3/api/overallStats")).get)
       val kmOpen      = (json \ "km_by_status" \ "open").as[Double]
 
+      assume(slickMeters > 0, "no open streets in this schema; comparing the two total-km paths needs a seeded DB")
       assertClose(slickMeters / 1000.0, kmOpen, relTol = 1e-9, absTol = 1e-6)
     }
   }
@@ -147,7 +157,10 @@ class GeodesicDistanceSpec extends PlaySpec with GuiceOneAppPerSuite {
         after  <- sql"SELECT user_id, meters_audited FROM user_stat".as[(String, Double)].map(_.toMap)
       } yield (before, after))
 
-      after.foreach { case (userId, recomputed) => assertClose(before(userId), recomputed) }
+      assume(after.nonEmpty, "no users in this schema; cache freshness needs a seeded DB")
+      // See the class scaladoc: a failure here without a distance query having changed points at #4774, not at the
+      // measure. `.get` rather than `apply` so a user vanishing between the two reads reports as a failed assertion.
+      after.foreach { case (userId, recomputed) => assertClose(before.get(userId).value, recomputed) }
     }
 
     "match a fresh runtime recompute of user_stat.labels_per_meter for users with audited meters" in {
@@ -164,8 +177,9 @@ class GeodesicDistanceSpec extends PlaySpec with GuiceOneAppPerSuite {
           .map(_.toMap)
       } yield (before, after))
 
+      assume(after.nonEmpty, "no users with audited meters in this schema; cache freshness needs a seeded DB")
       after.foreach { case (userId, recomputed) =>
-        (before(userId), recomputed) match {
+        (before.get(userId).value, recomputed) match {
           case (Some(cached), Some(fresh)) => assertClose(cached, fresh, relTol = 1e-9, absTol = 1e-12)
           case (cached, fresh)             => cached mustBe fresh
         }
@@ -182,7 +196,8 @@ class GeodesicDistanceSpec extends PlaySpec with GuiceOneAppPerSuite {
         after  <- sql"SELECT user_id, high_quality FROM user_stat".as[(String, Boolean)].map(_.toMap)
       } yield (before, after))
 
-      after.foreach { case (userId, recomputed) => before(userId) mustBe recomputed }
+      assume(after.nonEmpty, "no users in this schema; cache freshness needs a seeded DB")
+      after.foreach { case (userId, recomputed) => before.get(userId).value mustBe recomputed }
     }
 
     "match a fresh runtime recompute of region_completion.total_distance, with audited_distance in bounds" in {
@@ -200,8 +215,12 @@ class GeodesicDistanceSpec extends PlaySpec with GuiceOneAppPerSuite {
           .map(_.map { case (id, total, audited) => id -> (total, audited) }.toMap)
       } yield (cached, fresh))
 
+      assume(cached.nonEmpty, "no region_completion rows in this schema; cache freshness needs a seeded DB")
       cached.foreach { case (regionId, (cachedTotal, cachedAudited)) =>
-        fresh.get(regionId).foreach { case (freshTotal, _) => assertClose(cachedTotal, freshTotal) }
+        // A cached region absent from the recompute is itself a failure: initializeRegionCompletionTable inserts a
+        // row per non-deleted region, so the only way to be missing is to belong to a region that was deleted.
+        val (freshTotal, _) = fresh.get(regionId).value
+        assertClose(cachedTotal, freshTotal)
         cachedAudited must be >= 0.0
         cachedAudited must be <= cachedTotal + 1e-6
       }
@@ -209,6 +228,7 @@ class GeodesicDistanceSpec extends PlaySpec with GuiceOneAppPerSuite {
 
     "match a fresh runtime recompute of route.distance_meters, which equals getRouteDistance" in {
       val routeIds = run(sql"SELECT route_id FROM route WHERE NOT deleted".as[Int])
+      assume(routeIds.nonEmpty, "no routes in this schema; cache freshness needs a seeded DB")
 
       val results: Seq[(Int, Double, Double, Double)] = runRolledBack(DBIO.sequence(routeIds.map { routeId =>
         for {

--- a/test/models/street/GeodesicDistanceSpec.scala
+++ b/test/models/street/GeodesicDistanceSpec.scala
@@ -1,0 +1,228 @@
+package models.street
+
+import models.route.RouteTable
+import models.user.{UserStatTable, UserStatTableDef}
+import models.utils.MyPostgresProfile
+import models.utils.MyPostgresProfile.api._
+import org.apache.pekko.stream.Materializer
+import org.scalatestplus.play.PlaySpec
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
+import play.api.db.slick.DatabaseConfigProvider
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import service.RegionService
+import slick.basic.DatabaseConfig
+import slick.dbio.DBIO
+
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.DurationInt
+
+/**
+ * DB-backed tests locking in the geodesic street-distance measure (#4641).
+ *
+ * Street distances are measured geodesically — `ST_Length` over `::geography` in raw SQL, `lengthGeodesic` in Slick —
+ * which is accurate worldwide. Measuring by projecting to a fixed CRS is the bug this suite guards against: UTM zone
+ * 18N is only correct near its 75°W central meridian and overstated other cities' distances by up to +51% (Auckland).
+ *
+ * Three layers of protection, all city-agnostic so they hold against any test DB:
+ *   1. Known-geometry fixtures: synthetic streets whose WGS84 geodesic lengths are derived analytically (closed-form
+ *      equator arc, numerically integrated meridian arc) — independent of PostGIS — inserted and measured inside a
+ *      rolled-back transaction. These fail loudly, by double-digit percentages, if anyone reintroduces a projection.
+ *   2. Cross-implementation consistency: the Slick (`lengthGeodesic`) and raw-SQL (`ST_Length(geom::geography)`)
+ *      paths must report identical lengths, and the two independent implementations of "total open street km"
+ *      (StreetEdgeTable via Slick, the overallStats API via raw SQL) must agree.
+ *   3. Cache freshness: every cached distance (user_stat.meters_audited, labels_per_meter, region_completion,
+ *      route.distance_meters) and the distance-derived high_quality flag must match what their runtime recomputes
+ *      produce — run for real inside a rolled-back transaction. This is exactly the postcondition evolution 347's
+ *      backfill promises, so it also fails if that backfill ever drifts from the runtime code it mirrors.
+ */
+class GeodesicDistanceSpec extends PlaySpec with GuiceOneAppPerSuite {
+
+  override def fakeApplication(): Application =
+    new GuiceApplicationBuilder().disable[modules.ActorModule].build()
+
+  implicit lazy val mat: Materializer = app.materializer
+
+  private val streetEdgeTable = app.injector.instanceOf[StreetEdgeTable]
+  private val userStatTable   = app.injector.instanceOf[UserStatTable]
+  private val routeTable      = app.injector.instanceOf[RouteTable]
+  private val regionService   = app.injector.instanceOf[RegionService]
+  // Typed explicitly: letting `.db` infer here yields an existential type the compiler rejects under -Xfatal-warnings.
+  private val dbConfig: DatabaseConfig[MyPostgresProfile] =
+    app.injector.instanceOf[DatabaseConfigProvider].get[MyPostgresProfile]
+
+  private def run[T](action: DBIO[T]): T = Await.result(dbConfig.db.run(action), 120.seconds)
+
+  // Carries a successful result out through the forced-rollback failure path of `runRolledBack`.
+  private case class RollbackWithResult(result: Any) extends RuntimeException with scala.util.control.NoStackTrace
+
+  /**
+   * Runs `action` inside a transaction that is ALWAYS rolled back, returning the action's result. Lets a test insert a
+   * synthetic fixture or run a real recompute against the shared dev DB and leave it exactly as found — even if an
+   * assertion later fails.
+   */
+  private def runRolledBack[T](action: DBIO[T]): T = {
+    val alwaysRollback = action.flatMap(r => DBIO.failed(RollbackWithResult(r))).transactionally
+    Await.result(
+      dbConfig.db.run(alwaysRollback).recover { case RollbackWithResult(r) => r.asInstanceOf[T] },
+      120.seconds
+    )
+  }
+
+  /** Relative-with-absolute-floor closeness check for distances in meters. */
+  private def assertClose(actual: Double, expected: Double, relTol: Double = 1e-9, absTol: Double = 1e-6): Unit = {
+    val bound = math.max(relTol * math.max(actual.abs, expected.abs), absTol)
+    actual mustBe expected +- bound
+    ()
+  }
+
+  /**
+   * Inserts a throwaway street with the given endpoints and measures it with `getStreetLengths` (the Slick
+   * `lengthGeodesic` path), all inside a rolled-back transaction. Status `closed` also pins that measuring does not
+   * depend on a street being open.
+   */
+  private def measureSyntheticStreet(x1: Double, y1: Double, x2: Double, y2: Double): Double =
+    runRolledBack(for {
+      // Explicit id: seeded dev dumps insert streets with explicit ids without advancing the sequence, so the
+      // sequence default can collide. Rolled back, so the id is never really claimed.
+      streetEdgeId <- sql"""INSERT INTO street_edge (street_edge_id, geom, x1, y1, x2, y2, way_type, status)
+                            VALUES ((SELECT COALESCE(MAX(street_edge_id), 0) + 1 FROM street_edge),
+                                    ST_SetSRID(ST_MakeLine(ST_MakePoint($x1, $y1), ST_MakePoint($x2, $y2)), 4326),
+                                    $x1, $y1, $x2, $y2, 'residential', 'closed')
+                            RETURNING street_edge_id""".as[Int].head
+      lengths <- streetEdgeTable.getStreetLengths(Seq(streetEdgeId))
+    } yield lengths(streetEdgeId))
+
+  // WGS84 reference lengths, derived independently of PostGIS. The equator arc is closed-form (semi-major axis
+  // a = 6378137 m, so one degree = a * π/180); the 47°N→48°N meridian arc is M = a(1−e²)∫(1−e²sin²φ)^(−3/2)dφ,
+  // numerically integrated (Simpson). PostGIS's spheroid computation agrees with both to < 1e-6 m.
+  private val EquatorOneDegreeMeters = 111319.4908
+  private val Meridian47To48Meters   = 111180.5865
+
+  "street lengths (the geodesic measure, #4641)" should {
+    "measure one degree along the equator as the WGS84 closed-form arc" in {
+      // Projected through UTM zone 18N this line would measure 469,932 m — 4.2× reality. The tight tolerance fails
+      // for ANY fixed-CRS projection, not just zone 18N.
+      assertClose(measureSyntheticStreet(0, 0, 1, 0), EquatorOneDegreeMeters, absTol = 0.5)
+    }
+
+    "measure a Seattle-longitude meridian degree as the WGS84 meridian arc" in {
+      // Projected through UTM zone 18N this line would measure 128,046 m (+15.2%) — the overstatement every Seattle
+      // distance carried before #4641.
+      assertClose(measureSyntheticStreet(-122.3, 47, -122.3, 48), Meridian47To48Meters, absTol = 0.5)
+    }
+
+    "agree between the Slick lengthGeodesic path and raw ST_Length(geom::geography) SQL for real streets" in {
+      val (rawLengths, liftedLengths) = run(for {
+        raw    <- sql"SELECT street_edge_id, ST_Length(geom::geography) FROM street_edge LIMIT 100".as[(Int, Double)]
+        lifted <- streetEdgeTable.getStreetLengths(raw.map(_._1))
+      } yield (raw, lifted))
+
+      rawLengths.foreach { case (streetEdgeId, rawLength) => assertClose(liftedLengths(streetEdgeId), rawLength) }
+    }
+
+    "report the same total open-street km from the Slick path and the overallStats raw-SQL path" in {
+      // Two independent implementations of the same quantity: StreetEdgeTable.totalStreetDistance (Slick) and the
+      // overallStats km-by-status bucket (raw SQL in LabelTable). Both cover open streets minus the tutorial street,
+      // so any drift between the measures the two paths use shows up here.
+      val slickMeters = run(streetEdgeTable.totalStreetDistance)
+      val json        = contentAsJson(route(app, FakeRequest(GET, "/v3/api/overallStats")).get)
+      val kmOpen      = (json \ "km_by_status" \ "open").as[Double]
+
+      assertClose(slickMeters / 1000.0, kmOpen, relTol = 1e-9, absTol = 1e-6)
+    }
+  }
+
+  "cached distances" should {
+    "match a fresh runtime recompute of user_stat.meters_audited" in {
+      // Runs the REAL runtime recompute (updateAuditedDistanceHelper) over every user inside a rolled-back
+      // transaction: cached values must already equal what it writes. Also evolution 347's backfill postcondition.
+      val allUserIds                                                  = TableQuery[UserStatTableDef].map(_.userId)
+      val (before, after): (Map[String, Double], Map[String, Double]) = runRolledBack(for {
+        before <- sql"SELECT user_id, meters_audited FROM user_stat".as[(String, Double)].map(_.toMap)
+        _      <- userStatTable.updateAuditedDistanceHelper(allUserIds)
+        after  <- sql"SELECT user_id, meters_audited FROM user_stat".as[(String, Double)].map(_.toMap)
+      } yield (before, after))
+
+      after.foreach { case (userId, recomputed) => assertClose(before(userId), recomputed) }
+    }
+
+    "match a fresh runtime recompute of user_stat.labels_per_meter for users with audited meters" in {
+      // Scoped to meters_audited > 0: for users without audited meters the runtime recompute writes NULL while
+      // legacy rows may carry other values, and no distance is involved in that difference.
+      val allUserIds = TableQuery[UserStatTableDef].map(_.userId)
+      val (before, after): (Map[String, Option[Double]], Map[String, Option[Double]]) = runRolledBack(for {
+        before <- sql"SELECT user_id, labels_per_meter FROM user_stat WHERE meters_audited > 0"
+          .as[(String, Option[Double])]
+          .map(_.toMap)
+        _     <- userStatTable.updateLabelsPerMeterHelper(allUserIds)
+        after <- sql"SELECT user_id, labels_per_meter FROM user_stat WHERE meters_audited > 0"
+          .as[(String, Option[Double])]
+          .map(_.toMap)
+      } yield (before, after))
+
+      after.foreach { case (userId, recomputed) =>
+        (before(userId), recomputed) match {
+          case (Some(cached), Some(fresh)) => assertClose(cached, fresh, relTol = 1e-9, absTol = 1e-12)
+          case (cached, fresh)             => cached mustBe fresh
+        }
+      }
+    }
+
+    "match a fresh runtime recompute of the distance-derived user_stat.high_quality flag" in {
+      // labels_per_meter is an input to the quality heuristic, so the cached flag must agree with a fresh
+      // updateHighQuality run. Epoch cutoff = every user the runtime recompute would ever touch.
+      val epoch = java.time.OffsetDateTime.parse("1970-01-01T00:00:00Z")
+      val (before, after): (Map[String, Boolean], Map[String, Boolean]) = runRolledBack(for {
+        before <- sql"SELECT user_id, high_quality FROM user_stat".as[(String, Boolean)].map(_.toMap)
+        _      <- userStatTable.updateHighQuality(epoch)
+        after  <- sql"SELECT user_id, high_quality FROM user_stat".as[(String, Boolean)].map(_.toMap)
+      } yield (before, after))
+
+      after.foreach { case (userId, recomputed) => before(userId) mustBe recomputed }
+    }
+
+    "match a fresh runtime recompute of region_completion.total_distance, with audited_distance in bounds" in {
+      // total_distance must equal what initializeRegionCompletionTable would write today. audited_distance is only
+      // bounds-checked: it is maintained incrementally at runtime (with deliberate equalization fudges in
+      // RegionCompletionTable), so exact equality with a fresh recompute is not an invariant.
+      val (cached, fresh): (Map[Int, (Double, Double)], Map[Int, (Double, Double)]) = runRolledBack(for {
+        cached <- sql"SELECT region_id, total_distance, audited_distance FROM region_completion"
+          .as[(Int, Double, Double)]
+          .map(_.map { case (id, total, audited) => id -> (total, audited) }.toMap)
+        _     <- sqlu"TRUNCATE TABLE region_completion"
+        _     <- regionService.initializeRegionCompletionTableAction
+        fresh <- sql"SELECT region_id, total_distance, audited_distance FROM region_completion"
+          .as[(Int, Double, Double)]
+          .map(_.map { case (id, total, audited) => id -> (total, audited) }.toMap)
+      } yield (cached, fresh))
+
+      cached.foreach { case (regionId, (cachedTotal, cachedAudited)) =>
+        fresh.get(regionId).foreach { case (freshTotal, _) => assertClose(cachedTotal, freshTotal) }
+        cachedAudited must be >= 0.0
+        cachedAudited must be <= cachedTotal + 1e-6
+      }
+    }
+
+    "match a fresh runtime recompute of route.distance_meters, which equals getRouteDistance" in {
+      val routeIds = run(sql"SELECT route_id FROM route WHERE NOT deleted".as[Int])
+
+      val results: Seq[(Int, Double, Double, Double)] = runRolledBack(DBIO.sequence(routeIds.map { routeId =>
+        for {
+          cached       <- sql"SELECT distance_meters FROM route WHERE route_id = $routeId".as[Double].head
+          slickMeasure <- routeTable.getRouteDistance(routeId)
+          _            <- routeTable.updateStats(routeId)
+          fresh        <- sql"SELECT distance_meters FROM route WHERE route_id = $routeId".as[Double].head
+        } yield (routeId, cached, slickMeasure, fresh)
+      }))
+
+      results.foreach { case (_, cached, slickMeasure, fresh) =>
+        assertClose(cached, fresh)        // cache is what the runtime recompute (raw SQL) writes
+        assertClose(cached, slickMeasure) // ...and what the Slick lengthGeodesic path measures
+      }
+    }
+  }
+}

--- a/test/models/street/GeodesicDistanceSpec.scala
+++ b/test/models/street/GeodesicDistanceSpec.scala
@@ -41,11 +41,12 @@ import scala.concurrent.duration.DurationInt
  *      produce — run for real inside a rolled-back transaction. This is exactly the postcondition evolution 347's
  *      backfill promises, so it also fails if that backfill ever drifts from the runtime code it mirrors.
  *
- * Layer 3 needs a seeded database, so each of its tests `assume`s the table it reads is non-empty — against an empty
+ * Layer 3's comparisons need a seeded database, so each `assume`s the table it reads is non-empty — against an empty
  * schema they report as canceled rather than passing vacuously (the convention `RouteAuthPostureSpec` uses).
  *
  * It also checks that the *nightly* refresh reaches every user a full recompute would, since a postcondition the
- * runtime cannot maintain would decay back out of agreement on its own (#4774).
+ * runtime cannot maintain would decay back out of agreement on its own (#4774). That test seeds every row it reads,
+ * so it runs everywhere the synthetic-fixture layer does, empty schemas included.
  */
 class GeodesicDistanceSpec extends PlaySpec with GuiceOneAppPerSuite with OptionValues {
 
@@ -88,20 +89,27 @@ class GeodesicDistanceSpec extends PlaySpec with GuiceOneAppPerSuite with Option
   }
 
   /**
+   * Inserts a throwaway street with the given endpoints and status, returning its id. Only safe inside a rolled-back
+   * transaction.
+   */
+  private def insertSyntheticStreet(x1: Double, y1: Double, x2: Double, y2: Double, status: String): DBIO[Int] =
+    // Explicit id: seeded dev dumps insert streets with explicit ids without advancing the sequence, so the
+    // sequence default can collide. Rolled back, so the id is never really claimed.
+    sql"""INSERT INTO street_edge (street_edge_id, geom, x1, y1, x2, y2, way_type, status)
+          VALUES ((SELECT COALESCE(MAX(street_edge_id), 0) + 1 FROM street_edge),
+                  ST_SetSRID(ST_MakeLine(ST_MakePoint($x1, $y1), ST_MakePoint($x2, $y2)), 4326),
+                  $x1, $y1, $x2, $y2, 'residential', CAST($status AS street_edge_status))
+          RETURNING street_edge_id""".as[Int].head
+
+  /**
    * Inserts a throwaway street with the given endpoints and measures it with `getStreetLengths` (the Slick
    * `lengthGeodesic` path), all inside a rolled-back transaction. Status `closed` also pins that measuring does not
    * depend on a street being open.
    */
   private def measureSyntheticStreet(x1: Double, y1: Double, x2: Double, y2: Double): Double =
     runRolledBack(for {
-      // Explicit id: seeded dev dumps insert streets with explicit ids without advancing the sequence, so the
-      // sequence default can collide. Rolled back, so the id is never really claimed.
-      streetEdgeId <- sql"""INSERT INTO street_edge (street_edge_id, geom, x1, y1, x2, y2, way_type, status)
-                            VALUES ((SELECT COALESCE(MAX(street_edge_id), 0) + 1 FROM street_edge),
-                                    ST_SetSRID(ST_MakeLine(ST_MakePoint($x1, $y1), ST_MakePoint($x2, $y2)), 4326),
-                                    $x1, $y1, $x2, $y2, 'residential', 'closed')
-                            RETURNING street_edge_id""".as[Int].head
-      lengths <- streetEdgeTable.getStreetLengths(Seq(streetEdgeId))
+      streetEdgeId <- insertSyntheticStreet(x1, y1, x2, y2, "closed")
+      lengths      <- streetEdgeTable.getStreetLengths(Seq(streetEdgeId))
     } yield lengths(streetEdgeId))
 
   // WGS84 reference lengths, derived independently of PostGIS. The equator arc is closed-form (semi-major axis
@@ -168,11 +176,12 @@ class GeodesicDistanceSpec extends PlaySpec with GuiceOneAppPerSuite with Option
       // sit under an auditOnboarding or exploreAddress mission (#4451's drop-ins) is never refreshed, so their
       // meters_audited stays at 0 no matter how far they walk.
       //
-      // Seeds exactly that user rather than looking for one, so the check is real against any seeded DB — the shape
-      // is absent from some city schemas and the test would otherwise quietly prove nothing there.
+      // Seeds the street as well as the user rather than looking for either, so the check runs for real against any
+      // schema — including CI's empty one, which has no street to find. The street must be open: the refresh only
+      // credits open streets.
       val cutoff                                     = OffsetDateTime.now().minusHours(1)
       val (credited, streetLength): (Double, Double) = runRolledBack(for {
-        streetEdgeId <- streetEdgeTable.streets.map(_.streetEdgeId).result.head
+        streetEdgeId <- insertSyntheticStreet(-122.3, 47.6, -122.301, 47.6, "open")
         length       <- streetEdgeTable.getStreetLengths(Seq(streetEdgeId)).map(_(streetEdgeId))
         userId       <- sql"""INSERT INTO sidewalk_login.sidewalk_user (user_id, username, email)
                               VALUES ('4774-fixture', '4774-fixture', '4774-fixture@example.com')

--- a/test/models/street/GeodesicDistanceSpec.scala
+++ b/test/models/street/GeodesicDistanceSpec.scala
@@ -17,6 +17,7 @@ import service.RegionService
 import slick.basic.DatabaseConfig
 import slick.dbio.DBIO
 
+import java.time.OffsetDateTime
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.DurationInt
@@ -43,9 +44,8 @@ import scala.concurrent.duration.DurationInt
  * Layer 3 needs a seeded database, so each of its tests `assume`s the table it reads is non-empty — against an empty
  * schema they report as canceled rather than passing vacuously (the convention `RouteAuthPostureSpec` uses).
  *
- * Known decay: the meters_audited postcondition holds after evolution 347 but is not maintained by the runtime, which
- * refreshes only users with an `audit`-type mission (#4774). A failure there with no distance query touched means new
- * users of that shape have accumulated, not that this measure regressed.
+ * It also checks that the *nightly* refresh reaches every user a full recompute would, since a postcondition the
+ * runtime cannot maintain would decay back out of agreement on its own (#4774).
  */
 class GeodesicDistanceSpec extends PlaySpec with GuiceOneAppPerSuite with OptionValues {
 
@@ -158,9 +158,36 @@ class GeodesicDistanceSpec extends PlaySpec with GuiceOneAppPerSuite with Option
       } yield (before, after))
 
       assume(after.nonEmpty, "no users in this schema; cache freshness needs a seeded DB")
-      // See the class scaladoc: a failure here without a distance query having changed points at #4774, not at the
-      // measure. `.get` rather than `apply` so a user vanishing between the two reads reports as a failed assertion.
+      // `.get` rather than `apply` so a user vanishing between the two reads reports as a failed assertion.
       after.foreach { case (userId, recomputed) => assertClose(before.get(userId).value, recomputed) }
+    }
+
+    "credit a mission-less audit task through the nightly refresh (#4774)" in {
+      // The cache-freshness invariant is only durable if the nightly job's cutoff selector reaches every user a full
+      // recompute would touch. A selector keyed on `audit`-type missions does not: a user whose completed audit tasks
+      // sit under an auditOnboarding or exploreAddress mission (#4451's drop-ins) is never refreshed, so their
+      // meters_audited stays at 0 no matter how far they walk.
+      //
+      // Seeds exactly that user rather than looking for one, so the check is real against any seeded DB — the shape
+      // is absent from some city schemas and the test would otherwise quietly prove nothing there.
+      val cutoff                                     = OffsetDateTime.now().minusHours(1)
+      val (credited, streetLength): (Double, Double) = runRolledBack(for {
+        streetEdgeId <- streetEdgeTable.streets.map(_.streetEdgeId).result.head
+        length       <- streetEdgeTable.getStreetLengths(Seq(streetEdgeId)).map(_(streetEdgeId))
+        userId       <- sql"""INSERT INTO sidewalk_login.sidewalk_user (user_id, username, email)
+                              VALUES ('4774-fixture', '4774-fixture', '4774-fixture@example.com')
+                              RETURNING user_id""".as[String].head
+        _ <- sqlu"""INSERT INTO user_stat (user_id, meters_audited, high_quality, excluded)
+                    VALUES ($userId, 0, TRUE, FALSE)"""
+        // completed, recent, and deliberately unaccompanied by any mission of any type.
+        _ <- sqlu"""INSERT INTO audit_task
+                        (user_id, street_edge_id, task_start, task_end, completed, current_lat, current_lng)
+                    VALUES ($userId, $streetEdgeId, now(), now(), TRUE, 0, 0)"""
+        _        <- userStatTable.updateAuditedDistance(cutoff)
+        credited <- sql"SELECT meters_audited FROM user_stat WHERE user_id = $userId".as[Double].head
+      } yield (credited, length))
+
+      assertClose(credited, streetLength)
     }
 
     "match a fresh runtime recompute of user_stat.labels_per_meter for users with audited meters" in {
@@ -189,7 +216,7 @@ class GeodesicDistanceSpec extends PlaySpec with GuiceOneAppPerSuite with Option
     "match a fresh runtime recompute of the distance-derived user_stat.high_quality flag" in {
       // labels_per_meter is an input to the quality heuristic, so the cached flag must agree with a fresh
       // updateHighQuality run. Epoch cutoff = every user the runtime recompute would ever touch.
-      val epoch = java.time.OffsetDateTime.parse("1970-01-01T00:00:00Z")
+      val epoch                                                         = OffsetDateTime.parse("1970-01-01T00:00:00Z")
       val (before, after): (Map[String, Boolean], Map[String, Boolean]) = runRolledBack(for {
         before <- sql"SELECT user_id, high_quality FROM user_stat".as[(String, Boolean)].map(_.toMap)
         _      <- userStatTable.updateHighQuality(epoch)


### PR DESCRIPTION
Closes #4641. Closes #3655. Closes #4774.

## Problem

Every street-length query projected geometry to **UTM zone 18N (EPSG:26918)** regardless of city — correct near the US East Coast, and increasingly wrong elsewhere: **+15% in Seattle, +25% in Amsterdam, +35% in Zurich, +51% in Auckland** (measured against prod in #4641). Meanwhile the frontend has always measured geodesically with turf.js, so backend stats disagreed with the tool's own progress display. This touched everything: `/v3/api/overallStats` and `aggregateStats`, leaderboards, user dashboards, region completion, mission sizing (targets clipped to a region's remaining distance were inflated, so the last mission in a region couldn't fill its progress bar outside zone 18N), and RouteBuilder's saved route distances (two `RouteTable` call sites the issue's inventory missed — 22 sites total, not 20).

## Fix

- **All 22 call sites now measure geodesically**: `ST_Length(geom::geography)` in raw SQL, and a new `lengthGeodesic` extension method in `MyPostgresProfile` for Slick queries. Geodesic measurement is accurate worldwide, so #3655's per-city SRID configuration becomes unnecessary — no config surface, no zone-straddling edge cases.
- Backend and frontend now agree; the residual turf (spherical haversine) vs. PostGIS (WGS84 spheroid) gap is ≤~0.5% and is documented where it matters (`MissionController`).
- The geodesic rule is documented in `CLAUDE.md` and `docs/style-guide.md` so it can't silently regress.

## Evolution 347 — cached-value recompute

Recomputes every cached distance so stored values equal what the app now computes on the fly, each statement mirroring its runtime recompute exactly:

- `region_completion.total_distance` / `audited_distance` (mirrors `initializeRegionCompletionTable`)
- `user_stat.meters_audited` (mirrors `updateAuditedDistanceHelper`) and `labels_per_meter` (mirrors `updateLabelsPerMeterHelper`)
- `user_stat.high_quality` — it thresholds on labels_per_meter, which *rises* when meters shrink. Only rows whose value actually changes are written (`WHERE high_quality IS DISTINCT FROM (…)`); the unfiltered form rewrote all 995k rows and cost 10 s of the migration's 11 s
- `route.distance_meters` (mirrors `RouteTable.updateStats`)

`mission.distance_meters` / `distance_progress` are deliberately untouched — historical per-mission records nothing recomputes or compares globally. The evolution runs with `SET LOCAL jit = off` (#4376 guard) and was dry-run against `sidewalk_seattle` in a rollback transaction: region totals 2,604.7 → 2,263.0 km, user meters 6,392.4 → 5,473.8 km (−13–14%, matching #4641's Seattle measurements), ~11 s.

**These are full recomputes, not rescalings, so they also repair rows the nightly refresh has never reached** — worth knowing before merging, because it moves more than distance. On the Seattle dump 2,214 of the 2,923 users with audit history had a stored `meters_audited` that disagreed with even a *UTM* recompute (520 of them by more than a metre, one by 88 km), and 352 sat at 0 despite having a completed audit task. The cause is that the nightly refresh selected its users from `audit`-type missions, and those users have only `auditOnboarding` ones — so nothing ever refreshed them (**#4774**, fixed here: `usersThatAuditedSinceCutoffTime` now unions in users with a completed audit task since the cutoff, and drops the `meters_audited > 0` precondition that gated the very value the refresh exists to correct). Without that, evolution 347 would be a one-time repair and the invariant this PR states would decay on its own. Measured on the Seattle dump: the old selector missed 352 of the 2,923 users with auditable distance, the new one misses none.

Repairing them lifts `meters_audited` off 0, which drops `labels_per_meter` to 0 and fails the quality floor. So the migration flips **432** `high_quality` values on that dump, not the 1 an earlier revision of this description claimed: **326 demoted** by that staleness repair, 10 demoted for other reasons, and **96 promoted** by the geodesic effect proper (shorter streets ⇒ higher labels-per-meter ⇒ over the floor). `high_quality` gates every `filterLowQuality` surface — label map, clustering input, AccessScore, validation weighting — so those 326 contributors' labels drop out of them.

The **Downs** recomputes the same caches through `ST_Length(ST_Transform(geom, 26918))` rather than being a no-op. Reverting this migration means reverting to code that measures in UTM, and the point of a down is to leave the caches agreeing with whatever code is about to read them — a no-op down silently leaves geodesic values under UTM-measuring queries, with nothing to signal it. Verified by round-tripping Up→Down against `sidewalk_seattle`: after the Up, 0 users disagree with a geodesic recompute; after the Down, 0 disagree with a UTM one; `region_completion` and `route` return to their exact original values.

## Tests (new `GeodesicDistanceSpec`, DB-backed; full suite 531/531 green locally)

1. **Analytic fixtures** — synthetic streets inserted in always-rolled-back transactions, asserted against WGS84 arc lengths derived independently of PostGIS (closed-form equator arc **111,319.49 m**; numerically integrated 47→48°N meridian arc **111,180.59 m**, which UTM 18N would misreport as 128,046 m). A projection regression fails by double digits.
2. **Cross-implementation consistency** — Slick and raw-SQL lengths must be identical per street; `totalStreetDistance` (Slick) must equal overallStats' `km_open` (raw SQL).
3. **Cache-freshness invariants** — every cached value above must equal what its *real* runtime recompute writes, executed inside rolled-back transactions (`RegionService` gained a composable `initializeRegionCompletionTableAction: DBIO` for this). These also verify evolution 347's backfill matches the runtime code it mirrors, now and in the future.

## Notes for review / QA

- **Published numbers change everywhere outside zone 18N** — that is the point, but it's visible: overallStats/aggregateStats, leaderboards, dashboards, Across Cities. Whether to restate historical figures already cited in papers (Seattle −722 km, Amsterdam −225 km on the published queries) is a separate research-communication decision; this PR only corrects the computation.
- Suggested local QA: load the landing page + user dashboard and confirm km stats look ~15% lower than before (Seattle); create/open a RouteBuilder route and check its listed distance matches the builder's live turf measurement; audit a street in Explore and confirm mission progress/region completion advance normally.
- Audit missions in flight at deploy time keep whatever target they were created with. Only the last mission in a region is clipped to the region remainder (`getNextAuditMissionDistance`), so only those carry an inflated target, and only until they finish.
- Dev-DB note: booting this branch (or its tests) applies evolutions 344–347 to the shared dev DB, and an older running branch auto-reverts them on reload. Now that the Down does real work, that ping-pong **rewrites the cached distances each way** rather than being inert — each state is self-consistent, but a stale-evolution app sharing the database will flip values out from under a running test suite. Run the suite with no other branch's app up (two of the three cache tests failed exactly this way mid-review, then passed 531/531 twice once the DB stopped being reverted).

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-fable-5)
🤖 Revised after review with [Claude Code](https://claude.com/claude-code) (claude-opus-5[1m])

