### PR TITLE
Fix LabelMap download/map disagreement and comma-shredded tag params (#4782, #4783)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,6 +24,8 @@ module.exports = function (grunt) {
       },
       dist_progress: {
         src: [
+          // Shared deep-link query rules; every reader/writer of the URL's filter params depends on it.
+          'public/js/common/urlQuery.js',
           'public/js/common/aiLabelIndicator.js',
           'public/js/admin/src/*.js',
           // PopupPanoManager and LabelDetail must be concatenated before LabelPopup.
@@ -46,6 +48,8 @@ module.exports = function (grunt) {
       },
       dist_admin: {
         src: [
+          // Shared deep-link query rules; every reader/writer of the URL's filter params depends on it.
+          'public/js/common/urlQuery.js',
           'public/js/common/aiLabelIndicator.js',
           // Toast must be concatenated before BadgeAchievements, which LabelDetail uses for validation badges.
           'public/js/common/Toast.js',
@@ -100,6 +104,8 @@ module.exports = function (grunt) {
       },
       dist_gallery: {
         src: [
+          // Shared deep-link query rules; every reader/writer of the URL's filter params depends on it.
+          'public/js/common/urlQuery.js',
           'public/js/common/aiLabelIndicator.js',
           // Toast must be concatenated before BadgeAchievements, which builds badge-unlock toasts.
           'public/js/common/Toast.js',
@@ -128,6 +134,8 @@ module.exports = function (grunt) {
       },
       dist_map: {
         src: [
+          // Shared deep-link query rules; every reader/writer of the URL's filter params depends on it.
+          'public/js/common/urlQuery.js',
           // The shared filter sidebar owns the sidebar controls; MapSidebarFilter is the map's adapter for it.
           'public/js/common/filter-sidebar/*.js',
           'public/js/ps-map/*.js',
@@ -146,6 +154,8 @@ module.exports = function (grunt) {
         src: [
           // The shared LabelDetail component + its deps (same set the Gallery bundle pulls in), plus the
           // SharedLabel app. The pano-viewer classes and ps-map load from their own bundles (script tags).
+          // Shared deep-link query rules; every reader/writer of the URL's filter params depends on it.
+          'public/js/common/urlQuery.js',
           'public/js/common/aiLabelIndicator.js',
           // Toast must precede BadgeAchievements, which builds badge-unlock toasts.
           'public/js/common/Toast.js',

--- a/app/controllers/GalleryController.scala
+++ b/app/controllers/GalleryController.scala
@@ -39,7 +39,7 @@ class GalleryController @Inject() (
       labelType: String,
       neighborhoods: String,
       severities: String,
-      tags: String,
+      tags: List[String],
       validationOptions: String,
       aiValidationOptions: String
   ): Action[AnyContent] =
@@ -78,7 +78,15 @@ class GalleryController @Inject() (
             val tokens = severities.split(",").filter(validSeverities.contains).distinct.toSeq
             if (tokens.isEmpty) validSeverities else tokens
           }
-          val tagList: List[String]   = tags.split(",").filter(possibleTags.contains).toList
+          // One occurrence per tag (?tags=a&tags=b), so a tag whose name contains a comma survives — "yellow box,
+          // accessibility features not visible" is a real one, and a joined list shredded it into two halves that
+          // named nothing, silently dropping the filter (#4783). Older comma-joined links still work: a value is
+          // only split once it fails to name a tag on its own.
+          val tagList: List[String] = tags.flatMap { entry =>
+            val whole = entry.trim
+            if (possibleTags.contains(whole)) Seq(whole)
+            else whole.split(",").map(_.trim).filter(possibleTags.contains).toSeq
+          }
           val valOptions: Seq[String] =
             validationOptions.split(",").filter(Seq("correct", "incorrect", "unsure", "unvalidated").contains(_)).toSeq
           val aiValOptions: Seq[String] =

--- a/app/controllers/api/AccessScoreApiController.scala
+++ b/app/controllers/api/AccessScoreApiController.scala
@@ -8,7 +8,6 @@ import org.apache.pekko.stream.scaladsl.Source
 import play.silhouette.api.Silhouette
 import service.{AccessScoreService, ApiService, ConfigService}
 
-import java.time.OffsetDateTime
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -62,7 +61,7 @@ class AccessScoreApiController @Inject() (
             // A region's bbox can overlap neighbors, so restrict to the requested region when one was given.
             val streets: Seq[StreetAccessScoreForApi] =
               regionFilterId.fold(allStreets)(id => allStreets.filter(_.regionId == id))
-            val baseFileName: String                             = s"accessScoreStreets_${OffsetDateTime.now()}"
+            val baseFileName: String                             = timestampedFilename("accessScoreStreets")
             val streetStream: Source[StreetAccessScoreForApi, _] = Source.fromIterator(() => streets.iterator)
             cc.loggingService.insert(request.identity.map(_.userId), request.ipAddress, request.toString)
 
@@ -79,7 +78,7 @@ class AccessScoreApiController @Inject() (
               case Some("geopackage") =>
                 outputGeopackage(streetStream, baseFileName, shapefileCreator.createStreetAccessScoreGeopackage, inline)
               case _ =>
-                outputGeoJSON(streetStream, inline, baseFileName + ".json")
+                outputGeoJSON(streetStream, inline, baseFileName + ".geojson")
             }
         }
     }
@@ -110,7 +109,7 @@ class AccessScoreApiController @Inject() (
         accessScoreService.computeRegionScoresV3(resolvedBbox, DEFAULT_BATCH_SIZE).flatMap { allRegions =>
           val regions: Seq[RegionAccessScoreForApi] =
             regionFilterId.fold(allRegions)(id => allRegions.filter(_.regionId == id))
-          val baseFileName: String                             = s"accessScoreRegions_${OffsetDateTime.now()}"
+          val baseFileName: String                             = timestampedFilename("accessScoreRegions")
           val regionStream: Source[RegionAccessScoreForApi, _] = Source.fromIterator(() => regions.iterator)
           cc.loggingService.insert(request.identity.map(_.userId), request.ipAddress, request.toString)
 
@@ -127,7 +126,7 @@ class AccessScoreApiController @Inject() (
             case Some("geopackage") =>
               outputGeopackage(regionStream, baseFileName, shapefileCreator.createRegionAccessScoreGeopackage, inline)
             case _ =>
-              outputGeoJSON(regionStream, inline, baseFileName + ".json")
+              outputGeoJSON(regionStream, inline, baseFileName + ".geojson")
           }
         }
     }

--- a/app/controllers/api/LabelApiController.scala
+++ b/app/controllers/api/LabelApiController.scala
@@ -120,7 +120,8 @@ class LabelApiController @Inject() (
    *
    * @param bbox Bounding box in format "minLng,minLat,maxLng,maxLat"
    * @param labelType Comma-separated list of label types to include
-   * @param tags Comma-separated list of tags to filter by; a "LabelType:tag" entry only matches that label type
+   * @param tags Repeatable tag filter (`?tags=a&tags=b`), one tag per occurrence; a "LabelType:tag" entry narrows
+   *             only that label type. Not comma-separated — tag names may themselves contain commas.
    * @param severity Comma-separated set of severities to include ("1", "2", "3", "none" for unrated); mutually
    *                 exclusive with minSeverity/maxSeverity
    * @param minSeverity Minimum severity score (1-3 scale)
@@ -139,7 +140,7 @@ class LabelApiController @Inject() (
   def getRawLabelsV3(
       bbox: Option[String],
       labelType: Option[String],
-      tags: Option[String],
+      tags: List[String],
       severity: Option[String],
       minSeverity: Option[Int],
       maxSeverity: Option[Int],
@@ -247,41 +248,44 @@ class LabelApiController @Inject() (
       })
 
   /**
-   * Parses the tags parameter, supporting optional label-type scoping (e.g. "CurbRamp:narrow").
+   * Parses the repeatable tags parameter, supporting optional label-type scoping (e.g. "CurbRamp:narrow").
    *
-   * For each comma-separated entry, if the substring before the first colon exactly matches a label type name, the
-   * entry only matches that tag on that label type; otherwise the whole entry is a tag matching any label type (tag
-   * names may themselves contain colons, so an unrecognized prefix cannot be treated as an error).
+   * Each occurrence of the parameter is exactly one entry, never a comma-separated list: tag names are free-form
+   * label text and at least one of them contains a comma ("yellow box, accessibility features not visible"), so
+   * splitting on commas would silently shred it into two tags that match nothing (#4095).
    *
-   * @param raw The optional tags query parameter.
+   * If an entry's substring before the first colon exactly matches a label type name, the entry only narrows that
+   * label type; otherwise the whole entry is a tag narrowing every label type (tag names may themselves contain
+   * colons — "cycle lane: faded paint" — so an unrecognized prefix cannot be treated as an error).
+   *
+   * @param raw The tags query parameter occurrences, in the order they were supplied.
    * @return `Right(None)` if absent, `Right(Some(filters))` if valid, or `Left(ApiError)` if an entry is empty or a
    *         scoped entry is missing its tag.
    */
-  private def parseTagsParam(raw: Option[String]): Either[ApiError, Option[Seq[TagFilterForApi]]] =
-    parseCommaSeparated(raw) match {
-      case None         => Right(None)
-      case Some(tokens) =>
-        if (tokens.exists(_.isEmpty)) {
-          Left(ApiError.invalidParameter("The tags parameter contains an empty value.", "tags"))
-        } else {
-          val parsed = tokens.map { token =>
-            val prefix = token.takeWhile(_ != ':')
-            if (token.contains(':') && LabelTypeEnum.validLabelTypes.contains(prefix))
-              TagFilterForApi(Some(prefix), token.drop(prefix.length + 1).trim)
-            else TagFilterForApi(None, token)
-          }
-          parsed.find(tagFilter => tagFilter.labelType.isDefined && tagFilter.tag.isEmpty) match {
-            case Some(bad) =>
-              Left(
-                ApiError.invalidParameter(
-                  s"Missing tag after label type '${bad.labelType.get}:' in the tags parameter.",
-                  "tags"
-                )
-              )
-            case None => Right(Some(parsed))
-          }
-        }
+  private def parseTagsParam(raw: List[String]): Either[ApiError, Option[Seq[TagFilterForApi]]] = {
+    val entries = raw.map(_.trim)
+    if (entries.isEmpty) Right(None)
+    else if (entries.exists(_.isEmpty)) {
+      Left(ApiError.invalidParameter("The tags parameter contains an empty value.", "tags"))
+    } else {
+      val parsed = entries.map { entry =>
+        val prefix = entry.takeWhile(_ != ':')
+        if (entry.contains(':') && LabelTypeEnum.validLabelTypes.contains(prefix))
+          TagFilterForApi(Some(prefix), entry.drop(prefix.length + 1).trim)
+        else TagFilterForApi(None, entry)
+      }
+      parsed.find(tagFilter => tagFilter.labelType.isDefined && tagFilter.tag.isEmpty) match {
+        case Some(bad) =>
+          Left(
+            ApiError.invalidParameter(
+              s"Missing tag after label type '${bad.labelType.get}:' in the tags parameter.",
+              "tags"
+            )
+          )
+        case None => Right(Some(parsed))
+      }
     }
+  }
 
   /**
    * Retrieves all panorama IDs that have labels.

--- a/app/controllers/api/LabelApiController.scala
+++ b/app/controllers/api/LabelApiController.scala
@@ -121,7 +121,9 @@ class LabelApiController @Inject() (
    * @param bbox Bounding box in format "minLng,minLat,maxLng,maxLat"
    * @param labelType Comma-separated list of label types to include
    * @param tags Repeatable tag filter (`?tags=a&tags=b`), one tag per occurrence; a "LabelType:tag" entry narrows
-   *             only that label type. Not comma-separated — tag names may themselves contain commas.
+   *             only that label type. Not comma-separated — tag names may themselves contain commas. Values are
+   *             validated against the city's tags (400 on an unknown one), with an entry that fails whole re-read
+   *             as an older comma-joined list; see `TagFilterForApi.parse`.
    * @param severity Comma-separated set of severities to include ("1", "2", "3", "none" for unrated); mutually
    *                 exclusive with minSeverity/maxSeverity
    * @param minSeverity Minimum severity score (1-3 scale)
@@ -161,53 +163,62 @@ class LabelApiController @Inject() (
     val parsedEndDate            = parseDateTimeParam(endDate, "endDate")
     val parsedValidationStatuses = parseValidationStatuses(validationStatus)
     val parsedLabelTypes         = parseAllowlistedList(labelType, LabelTypeEnum.validLabelTypes, "labelType")
-    val parsedTags               = parseTagsParam(tags)
     val parsedSeverity           = parseSeverityParam(severity, minSeverity, maxSeverity)
 
-    // Collect the first invalid-parameter error, if any.
-    val firstError: Option[ApiError] = Seq(
-      validateBBoxParam(bbox, parsedBbox),
-      parsedLabelTypes.left.toOption,
-      parsedTags.left.toOption,
-      parsedSeverity.left.toOption,
-      parsedValidationStatuses.left.toOption,
-      parsedStartDate.left.toOption,
-      parsedEndDate.left.toOption,
-      validateRegionId(regionId)
-    ).flatten.headOption
-
-    firstError match {
-      case Some(error) => Future.successful(badRequest(error))
-      case None        =>
-        configService.getCityMapParams.flatMap { cityMapParams =>
-          val (finalBbox, finalRegionId, finalRegionName) =
-            resolveGeoFilters(bbox, parsedBbox, regionId, regionName, cityMapParams)
-
-          // Create filters object.
-          val filters = RawLabelFiltersForApi(
-            bbox = finalBbox, labelTypes = parsedLabelTypes.toOption.flatten, tags = parsedTags.toOption.flatten,
-            severity = parsedSeverity.toOption.flatten, minSeverity = minSeverity, maxSeverity = maxSeverity,
-            validationStatuses = parsedValidationStatuses.toOption.flatten,
-            highQualityUserOnly = highQualityUserOnly.getOrElse(false), startDate = parsedStartDate.toOption.flatten,
-            endDate = parsedEndDate.toOption.flatten, regionId = finalRegionId, regionName = finalRegionName
-          )
-
-          // Get the data stream.
-          val dbDataStream: Source[LabelDataForApi, _] = apiService.getRawLabels(filters, DEFAULT_BATCH_SIZE)
-          val baseFileName: String                     = timestampedFilename("labels")
-
-          // Output data in the appropriate file format.
-          filetype match {
-            case Some("csv") =>
-              outputCSV(dbDataStream, LabelDataForApi.csvHeader, inline, baseFileName + ".csv")
-            case Some("shapefile") =>
-              outputShapefile(dbDataStream, baseFileName, shapefileCreator.createRawLabelShapefile, shapefileCreator)
-            case Some("geopackage") =>
-              outputGeopackage(dbDataStream, baseFileName, shapefileCreator.createRawLabelDataGeopackage, inline)
-            case _ => // Default to GeoJSON.
-              outputGeoJSON(dbDataStream, inline, baseFileName + ".geojson")
-          }
+    // Tag values are validated against the city's full tag list (cached), not the UI-facing one: a tag a city hides
+    // from its menus (config's excluded tags) may still be carried by existing labels, so filtering on it is valid.
+    labelService.selectAllTagsFuture.flatMap { cityTags =>
+      val tagsByLabelType: Map[String, Set[String]] =
+        cityTags.groupMap(t => LabelTypeEnum.labelTypeIdToLabelType(t.labelTypeId))(_.tag).map { case (lt, tagNames) =>
+          lt -> tagNames.toSet
         }
+      val parsedTags = TagFilterForApi.parse(tags, LabelTypeEnum.validLabelTypes, tagsByLabelType)
+
+      // Collect the first invalid-parameter error, if any.
+      val firstError: Option[ApiError] = Seq(
+        validateBBoxParam(bbox, parsedBbox),
+        parsedLabelTypes.left.toOption,
+        parsedTags.left.toOption,
+        parsedSeverity.left.toOption,
+        parsedValidationStatuses.left.toOption,
+        parsedStartDate.left.toOption,
+        parsedEndDate.left.toOption,
+        validateRegionId(regionId)
+      ).flatten.headOption
+
+      firstError match {
+        case Some(error) => Future.successful(badRequest(error))
+        case None        =>
+          configService.getCityMapParams.flatMap { cityMapParams =>
+            val (finalBbox, finalRegionId, finalRegionName) =
+              resolveGeoFilters(bbox, parsedBbox, regionId, regionName, cityMapParams)
+
+            // Create filters object.
+            val filters = RawLabelFiltersForApi(
+              bbox = finalBbox, labelTypes = parsedLabelTypes.toOption.flatten, tags = parsedTags.toOption.flatten,
+              severity = parsedSeverity.toOption.flatten, minSeverity = minSeverity, maxSeverity = maxSeverity,
+              validationStatuses = parsedValidationStatuses.toOption.flatten,
+              highQualityUserOnly = highQualityUserOnly.getOrElse(false), startDate = parsedStartDate.toOption.flatten,
+              endDate = parsedEndDate.toOption.flatten, regionId = finalRegionId, regionName = finalRegionName
+            )
+
+            // Get the data stream.
+            val dbDataStream: Source[LabelDataForApi, _] = apiService.getRawLabels(filters, DEFAULT_BATCH_SIZE)
+            val baseFileName: String                     = timestampedFilename("labels")
+
+            // Output data in the appropriate file format.
+            filetype match {
+              case Some("csv") =>
+                outputCSV(dbDataStream, LabelDataForApi.csvHeader, inline, baseFileName + ".csv")
+              case Some("shapefile") =>
+                outputShapefile(dbDataStream, baseFileName, shapefileCreator.createRawLabelShapefile, shapefileCreator)
+              case Some("geopackage") =>
+                outputGeopackage(dbDataStream, baseFileName, shapefileCreator.createRawLabelDataGeopackage, inline)
+              case _ => // Default to GeoJSON.
+                outputGeoJSON(dbDataStream, inline, baseFileName + ".geojson")
+            }
+          }
+      }
     }
   }
 
@@ -246,46 +257,6 @@ class LabelApiController @Inject() (
       parseAllowlistedList(raw, Set("1", "2", "3", "none"), "severity").map(_.map { tokens =>
         SeverityFilterForApi(tokens.filter(_ != "none").map(_.toInt).toSet, tokens.contains("none"))
       })
-
-  /**
-   * Parses the repeatable tags parameter, supporting optional label-type scoping (e.g. "CurbRamp:narrow").
-   *
-   * Each occurrence of the parameter is exactly one entry, never a comma-separated list: tag names are free-form
-   * label text and at least one of them contains a comma ("yellow box, accessibility features not visible"), so
-   * splitting on commas would silently shred it into two tags that match nothing (#4095).
-   *
-   * If an entry's substring before the first colon exactly matches a label type name, the entry only narrows that
-   * label type; otherwise the whole entry is a tag narrowing every label type (tag names may themselves contain
-   * colons — "cycle lane: faded paint" — so an unrecognized prefix cannot be treated as an error).
-   *
-   * @param raw The tags query parameter occurrences, in the order they were supplied.
-   * @return `Right(None)` if absent, `Right(Some(filters))` if valid, or `Left(ApiError)` if an entry is empty or a
-   *         scoped entry is missing its tag.
-   */
-  private def parseTagsParam(raw: List[String]): Either[ApiError, Option[Seq[TagFilterForApi]]] = {
-    val entries = raw.map(_.trim)
-    if (entries.isEmpty) Right(None)
-    else if (entries.exists(_.isEmpty)) {
-      Left(ApiError.invalidParameter("The tags parameter contains an empty value.", "tags"))
-    } else {
-      val parsed = entries.map { entry =>
-        val prefix = entry.takeWhile(_ != ':')
-        if (entry.contains(':') && LabelTypeEnum.validLabelTypes.contains(prefix))
-          TagFilterForApi(Some(prefix), entry.drop(prefix.length + 1).trim)
-        else TagFilterForApi(None, entry)
-      }
-      parsed.find(tagFilter => tagFilter.labelType.isDefined && tagFilter.tag.isEmpty) match {
-        case Some(bad) =>
-          Left(
-            ApiError.invalidParameter(
-              s"Missing tag after label type '${bad.labelType.get}:' in the tags parameter.",
-              "tags"
-            )
-          )
-        case None => Right(Some(parsed))
-      }
-    }
-  }
 
   /**
    * Retrieves all panorama IDs that have labels.

--- a/app/controllers/api/LabelClustersApiController.scala
+++ b/app/controllers/api/LabelClustersApiController.scala
@@ -12,7 +12,6 @@ import play.silhouette.api.Silhouette
 import service.{ApiService, ConfigService}
 
 import java.nio.file.Files
-import java.time.OffsetDateTime
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
@@ -113,7 +112,7 @@ class LabelClustersApiController @Inject() (
 
           // Get the data stream.
           val dbDataStream: Source[LabelClusterForApi, _] = apiService.getLabelClusters(filters, DEFAULT_BATCH_SIZE)
-          val baseFileName: String                        = s"labelClusters_${OffsetDateTime.now()}"
+          val baseFileName: String                        = timestampedFilename("labelClusters")
 
           // Output data in the appropriate file format.
           filetype match {
@@ -188,7 +187,7 @@ class LabelClustersApiController @Inject() (
             case Some("geopackage") =>
               outputGeopackage(dbDataStream, baseFileName, shapefileCreator.createLabelClusterGeopackage, inline)
             case _ => // Default to GeoJSON.
-              outputGeoJSON(dbDataStream, inline, baseFileName + ".json")
+              outputGeoJSON(dbDataStream, inline, baseFileName + ".geojson")
           }
         }
     }

--- a/app/controllers/api/RegionApiController.scala
+++ b/app/controllers/api/RegionApiController.scala
@@ -9,7 +9,6 @@ import play.api.libs.json.Json
 import play.silhouette.api.Silhouette
 import service.{ApiService, ConfigService}
 
-import java.time.OffsetDateTime
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -78,7 +77,7 @@ class RegionApiController @Inject() (
           )
 
           val dbDataStream: Source[RegionDataForApi, _] = apiService.getRegions(filters, DEFAULT_BATCH_SIZE)
-          val baseFileName: String                      = s"regions_${OffsetDateTime.now()}"
+          val baseFileName: String                      = timestampedFilename("regions")
           cc.loggingService.insert(request.identity.map(_.userId), request.ipAddress, request.toString)
 
           filetype match {
@@ -89,7 +88,7 @@ class RegionApiController @Inject() (
             case Some("geopackage") =>
               outputGeopackage(dbDataStream, baseFileName, shapefileCreator.createRegionDataGeopackage, inline)
             case _ => // Default to GeoJSON.
-              outputGeoJSON(dbDataStream, inline, baseFileName + ".json")
+              outputGeoJSON(dbDataStream, inline, baseFileName + ".geojson")
           }
         }
     }

--- a/app/controllers/api/StatsApiController.scala
+++ b/app/controllers/api/StatsApiController.scala
@@ -11,7 +11,7 @@ import play.api.mvc.Result
 import play.silhouette.api.Silhouette
 import service.{AggregateStats, ApiService, ConfigService}
 
-import java.time.{LocalDate, OffsetDateTime}
+import java.time.LocalDate
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -64,7 +64,7 @@ class StatsApiController @Inject() (
         minAccuracy = minAccuracy
       )
       .map { filteredStats: Seq[UserStatForApi] =>
-        val baseFileName: String = s"userStats_${OffsetDateTime.now()}"
+        val baseFileName: String = timestampedFilename("userStats")
         cc.loggingService.insert(request.identity.map(_.userId), request.ipAddress, request.toString)
 
         // Output data in the appropriate file format: CSV or JSON (default).
@@ -88,7 +88,7 @@ class StatsApiController @Inject() (
   def getOverallSidewalkStats(filterLowQuality: Boolean, filetype: Option[String]) = silhouette.UserAwareAction.async {
     implicit request =>
       apiService.getOverallStats(filterLowQuality).map { stats: ProjectSidewalkStats =>
-        val baseFileName: String = s"projectSidewalkStats_${OffsetDateTime.now()}"
+        val baseFileName: String = timestampedFilename("projectSidewalkStats")
         cc.loggingService.insert(request.identity.map(_.userId), request.ipAddress, request.toString)
 
         // Output data in the appropriate file format: CSV or JSON (default).
@@ -193,7 +193,7 @@ class StatsApiController @Inject() (
         filetype match {
           case Some("csv") =>
             val csvContent   = generateAggregateStatsCsv(aggregateStats)
-            val baseFileName = s"aggregateStats_${OffsetDateTime.now()}"
+            val baseFileName = timestampedFilename("aggregateStats")
 
             // Create temporary CSV file (following the same pattern as other endpoints).
             val aggregateStatsFile = new java.io.File(s"$baseFileName.csv")
@@ -333,7 +333,7 @@ class StatsApiController @Inject() (
   private def renderDailyStats(stats: Seq[DailyStatRecord], filetype: Option[String], baseName: String): Result = {
     filetype match {
       case Some("csv") =>
-        val file   = new java.io.File(s"${baseName}_${OffsetDateTime.now()}.csv")
+        val file   = new java.io.File(s"${timestampedFilename(baseName)}.csv")
         val writer = new java.io.PrintStream(file, "UTF-8")
         writer.print(DailyStatRecord.csvHeader)
         stats.foreach { r =>

--- a/app/controllers/api/StreetsApiController.scala
+++ b/app/controllers/api/StreetsApiController.scala
@@ -9,7 +9,6 @@ import play.api.libs.json.Json
 import play.silhouette.api.Silhouette
 import service.{ApiService, ConfigService}
 
-import java.time.OffsetDateTime
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -81,7 +80,7 @@ class StreetsApiController @Inject() (
 
           // Get the data stream.
           val dbDataStream: Source[StreetDataForApi, _] = apiService.getStreets(filters, DEFAULT_BATCH_SIZE)
-          val baseFileName: String                      = s"streets_${OffsetDateTime.now()}"
+          val baseFileName: String                      = timestampedFilename("streets")
           cc.loggingService.insert(request.identity.map(_.userId), request.ipAddress, request.toString)
 
           // Output data in the appropriate file format.
@@ -93,7 +92,7 @@ class StreetsApiController @Inject() (
             case Some("geopackage") =>
               outputGeopackage(dbDataStream, baseFileName, shapefileCreator.createStreetDataGeopackage, inline)
             case _ => // Default to GeoJSON.
-              outputGeoJSON(dbDataStream, inline, baseFileName + ".json")
+              outputGeoJSON(dbDataStream, inline, baseFileName + ".geojson")
           }
         }
     }

--- a/app/controllers/api/ValidationApiController.scala
+++ b/app/controllers/api/ValidationApiController.scala
@@ -9,7 +9,6 @@ import play.api.libs.json.Json
 import play.silhouette.api.Silhouette
 import service.ApiService
 
-import java.time.OffsetDateTime
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -118,7 +117,7 @@ class ValidationApiController @Inject() (
           changedSeverityLevels = changedSeverityLevels, source = parsedSource.toOption.flatten
         )
         val dbDataStream: Source[ValidationDataForApi, _] = apiService.getValidations(filters, DEFAULT_BATCH_SIZE)
-        val baseFileName: String                          = s"validations_${OffsetDateTime.now()}"
+        val baseFileName: String                          = timestampedFilename("validations")
 
         // Output data in the appropriate file format.
         filetype match {

--- a/app/models/api/LabelApiModels.scala
+++ b/app/models/api/LabelApiModels.scala
@@ -43,6 +43,88 @@ case class SeverityFilterForApi(severities: Set[Int], includeNullSeverity: Boole
  */
 case class TagFilterForApi(labelType: Option[String], tag: String)
 
+object TagFilterForApi {
+
+  /**
+   * Parses and validates the Raw Labels API's repeatable `tags` parameter against a city's tag vocabulary.
+   *
+   * Each occurrence of the parameter is one entry. If an entry's text before the first colon names a label type, the
+   * entry narrows only that type ("CurbRamp:narrow"); otherwise the whole entry is a tag narrowing every type (tag
+   * names may themselves contain colons — "cycle lane: faded paint" — so an unrecognized prefix is not an error).
+   *
+   * An entry is valid when its tag exists in the vocabulary: for its own label type if scoped, on any label type
+   * otherwise. An unknown tag is a 400 rather than a silently-empty match — the same strictness `labelType` gets —
+   * except that an entry which fails whole is first re-read as an older comma-joined list (`tags=a,b` from a
+   * pre-#4786 link) and accepted if every piece is itself valid. Validating before splitting is what lets a tag name
+   * that contains a comma ("yellow box, accessibility features not visible") survive intact.
+   *
+   * @param entries         The tags query parameter occurrences, in the order they were supplied.
+   * @param validLabelTypes Label type names an entry may be scoped to.
+   * @param tagsByLabelType The city's tag vocabulary: label type name -> the tag names of that type.
+   * @return `Right(None)` if absent, `Right(Some(filters))` if every entry validates, or `Left(ApiError)` describing
+   *         the first empty, mis-scoped, or unknown entry.
+   */
+  def parse(
+      entries: List[String],
+      validLabelTypes: Set[String],
+      tagsByLabelType: Map[String, Set[String]]
+  ): Either[ApiError, Option[Seq[TagFilterForApi]]] = {
+    lazy val allTagNames: Set[String] = tagsByLabelType.values.flatten.toSet
+    val emptyValueError               = ApiError.invalidParameter("The tags parameter contains an empty value.", "tags")
+
+    def syntacticParse(entry: String): TagFilterForApi = {
+      val prefix = entry.takeWhile(_ != ':')
+      if (entry.contains(':') && validLabelTypes.contains(prefix))
+        TagFilterForApi(Some(prefix), entry.drop(prefix.length + 1).trim)
+      else TagFilterForApi(None, entry)
+    }
+
+    def validationError(filter: TagFilterForApi): Option[ApiError] = filter match {
+      case TagFilterForApi(Some(labelType), "") =>
+        Some(ApiError.invalidParameter(s"Missing tag after label type '$labelType:' in the tags parameter.", "tags"))
+      case TagFilterForApi(Some(labelType), tag) if !tagsByLabelType.getOrElse(labelType, Set.empty).contains(tag) =>
+        Some(
+          ApiError.invalidParameter(
+            s"'$tag' is not a tag of label type '$labelType'; see /v3/api/labelTags for this city's tags.",
+            "tags"
+          )
+        )
+      case TagFilterForApi(None, tag) if !allTagNames.contains(tag) =>
+        Some(ApiError.invalidParameter(s"Unknown tag '$tag'; see /v3/api/labelTags for this city's tags.", "tags"))
+      case _ => None
+    }
+
+    def resolveEntry(entry: String): Either[ApiError, Seq[TagFilterForApi]] =
+      if (entry.isEmpty) Left(emptyValueError)
+      else {
+        val whole = syntacticParse(entry)
+        validationError(whole) match {
+          case None                           => Right(Seq(whole))
+          case Some(_) if entry.contains(',') =>
+            val pieces = entry.split(",").map(_.trim).toSeq
+            if (pieces.exists(_.isEmpty)) Left(emptyValueError)
+            else {
+              val parsed = pieces.map(syntacticParse)
+              // A piece-level error names the actual offender; the whole-entry error would name the joined text.
+              parsed.flatMap(validationError).headOption.toLeft(parsed)
+            }
+          case Some(wholeError) => Left(wholeError)
+        }
+      }
+
+    val trimmed = entries.map(_.trim)
+    if (trimmed.isEmpty) Right(None)
+    else {
+      trimmed
+        .foldLeft[Either[ApiError, Vector[TagFilterForApi]]](Right(Vector.empty)) {
+          case (Left(error), _)    => Left(error)
+          case (Right(acc), entry) => resolveEntry(entry).map(acc ++ _)
+        }
+        .map(filters => Some(filters))
+    }
+  }
+}
+
 /**
  * Represents parsed and validated filters from query parameters for the Raw Labels API.
  *

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -1,7 +1,13 @@
 package models.label
 
 import com.google.inject.ImplementedBy
-import models.api.{LabelDataForApi, LabelValidationSummaryForApi, RawLabelFiltersForApi, RawLabelValidationStatus}
+import models.api.{
+  LabelDataForApi,
+  LabelValidationSummaryForApi,
+  RawLabelFiltersForApi,
+  RawLabelValidationStatus,
+  TagFilterForApi
+}
 import models.audit.AuditTaskTableDef
 import models.label.LabelTable._
 import models.label.LabelTypeEnum._
@@ -307,6 +313,55 @@ object LabelTable {
     "human" -> "role <> 'AI'",
     "ai"    -> "role = 'AI'"
   )
+
+  /**
+   * Builds the `WHERE` fragment for the Raw Labels API's `tags` filter.
+   *
+   * Every entry contributes to the set of tags that narrows one or more label types, and a label is kept when it
+   * carries any tag from the set that applies to *its* type:
+   *
+   *   - an unscoped entry applies to every label type;
+   *   - an entry scoped to a type (`CurbRamp:narrow`) applies only to that type;
+   *   - a type that ends up with an empty applicable set is not narrowed at all.
+   *
+   * That last rule is what lets the LabelMap's download reproduce what the map shows: the sidebar narrows each label
+   * type by its own tag pills and leaves the untagged types alone, so scoping a tag to `CurbRamp` must not drop every
+   * `Obstacle` (#4095). With no scoped entries the clause reduces to a flat OR over the tags, which is the behavior
+   * unscoped callers have always had.
+   *
+   * Label types are allowlisted `LabelTypeEnum` names (validated at parse time) and so are safe to splice; only the
+   * caller-supplied tag text needs escaping.
+   *
+   * @param tags Parsed tag filters; must be non-empty.
+   * @return A parenthesized SQL condition over `label.tags` and `label_type.label_type`.
+   */
+  def tagWhereClause(tags: Seq[TagFilterForApi]): String = {
+    def matchesTag(tag: String): String         = s"'${tag.replace("'", "''")}' = ANY(label.tags)"
+    def anyOf(tagsToMatch: Seq[String]): String = tagsToMatch.distinct.map(matchesTag).mkString(" OR ")
+
+    val unscopedTags: Seq[String]            = tags.collect { case TagFilterForApi(None, tag) => tag }
+    val scopedTags: Map[String, Seq[String]] = tags
+      .collect { case TagFilterForApi(Some(labelType), tag) =>
+        labelType -> tag
+      }
+      .groupMap(_._1)(_._2)
+
+    // Sorted so the emitted SQL is deterministic regardless of the order the caller listed the entries in.
+    val scopedConditions: Seq[String] = scopedTags.toSeq.sortBy(_._1).map { case (labelType, tagsForType) =>
+      s"(label_type.label_type = '$labelType' AND (${anyOf(tagsForType ++ unscopedTags)}))"
+    }
+
+    val otherTypesCondition: String = if (scopedTags.isEmpty) {
+      anyOf(unscopedTags)
+    } else {
+      val scopedTypeList = scopedTags.keys.toSeq.sorted.map(labelType => s"'$labelType'").mkString(", ")
+      val notScoped      = s"label_type.label_type NOT IN ($scopedTypeList)"
+      // No unscoped tags means the types nobody scoped are left unnarrowed, so they pass on type alone.
+      if (unscopedTags.isEmpty) notScoped else s"($notScoped AND (${anyOf(unscopedTags)}))"
+    }
+
+    s"(${(scopedConditions :+ otherTypesCondition).mkString(" OR ")})"
+  }
 
   // Type aliases for the tuple representation of LabelMetadataUserDash and queries for them.
   // TODO in Scala 3 I think that we can make these top-level like we do for the case class version.
@@ -1936,18 +1991,7 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
     }
 
     if (filters.tags.isDefined && filters.tags.get.nonEmpty) {
-      // Scoped entries only match the tag on their label type; bare entries match it on any type. The label type is
-      // always an allowlisted LabelTypeEnum name (validated at parse time), so only the tag needs escaping.
-      val tagConditions = filters.tags.get
-        .map { tagFilter =>
-          val tagCondition = s"'${tagFilter.tag.replace("'", "''")}' = ANY(label.tags)"
-          tagFilter.labelType match {
-            case Some(labelType) => s"(label_type.label_type = '$labelType' AND $tagCondition)"
-            case None            => tagCondition
-          }
-        }
-        .mkString(" OR ")
-      whereConditions :+= s"($tagConditions)"
+      whereConditions :+= tagWhereClause(filters.tags.get)
     }
 
     filters.severity.foreach { severityFilter =>

--- a/app/views/apiDocs/rawLabels.scala.html
+++ b/app/views/apiDocs/rawLabels.scala.html
@@ -133,10 +133,10 @@
           </tr>
           <tr>
             <td><code>tags</code></td>
-            <td><code>string</code></td>
+            <td><code>string</code> (repeatable)</td>
             <td>Filter by one or more tags associated with labels. <strong>Repeat the parameter once per tag</strong> (e.g., <code>tags=missing tactile warning&amp;tags=uneven surface</code>). Matches labels containing *any* of the specified tags.
               An entry may be scoped to a single label type with a <code>LabelType:tag</code> prefix (e.g., <code>tags=CurbRamp:narrow</code>). A scoped entry narrows <em>only</em> that label type — labels of types nobody scoped come back unfiltered — so pair it with <code>labelType</code> if you want the other types dropped too. An entry whose prefix (the text before the first colon) is not a valid label type is treated as a plain tag applying to every type, since tag names may themselves contain colons (e.g., <code>cycle lane: faded paint</code>).
-              <strong>Changed August 2026</strong> (v3 is a preview API): <code>tags</code> is no longer comma-separated, because tag names may contain commas (e.g., <code>yellow box, accessibility features not visible</code>) and splitting on them silently shredded such a tag into two that matched nothing. Replace <code>tags=a,b</code> with <code>tags=a&amp;tags=b</code>. Scoped entries also no longer exclude the label types they don't name.
+              <strong>Changed August 2026</strong> (v3 is a preview API): <code>tags</code> is no longer comma-separated, because tag names may contain commas (e.g., <code>yellow box, accessibility features not visible</code>) and splitting on them silently shredded such a tag into two that matched nothing. Repeat the parameter instead (<code>tags=a&amp;tags=b</code>); a comma-joined value from an older link is still accepted when its pieces name real tags. Values are now validated against this city's tags — an unknown tag, or a tag scoped to a label type that doesn't carry it, returns a 400 error naming the parameter instead of silently matching nothing. Scoped entries also no longer exclude the label types they don't name.
               See <a target="_blank" href="@routes.ApiDocsController.labelTags">Tags Reference</a> for available tags. </td>
           </tr>
           <tr>

--- a/app/views/apiDocs/rawLabels.scala.html
+++ b/app/views/apiDocs/rawLabels.scala.html
@@ -58,7 +58,9 @@
       <p><code><a href="/v3/api/rawLabels?labelType=CurbRamp">/v3/api/rawLabels?labelType=CurbRamp</a></code> Get all raw labels of type <code>CurbRamp</code>. The available label types match those in the <a href="@routes.ApiDocsController.labelTypes">Label Types API</a></p>
       <p><code><a href="/v3/api/rawLabels?labelType=SurfaceProblem&minSeverity=2">/v3/api/rawLabels?labelType=SurfaceProblem&minSeverity=2</a></code> Get all raw labels of type <code>SurfaceProblem</code> with a minimum severity of 2.</p>
       <p><code><a href="/v3/api/rawLabels?severity=none,3">/v3/api/rawLabels?severity=none,3</a></code> Get all raw labels that are either unrated or severity 3.</p>
-      <p><code><a href="/v3/api/rawLabels?tags=CurbRamp:narrow">/v3/api/rawLabels?tags=CurbRamp:narrow</a></code> Get all raw labels with the <code>narrow</code> tag, only on <code>CurbRamp</code> labels.</p>
+      <p><code><a href="/v3/api/rawLabels?tags=narrow&tags=uneven surface">/v3/api/rawLabels?tags=narrow&amp;tags=uneven surface</a></code> Get all raw labels carrying either the <code>narrow</code> or the <code>uneven surface</code> tag. Repeat <code>tags</code> once per tag.</p>
+      <p><code><a href="/v3/api/rawLabels?tags=CurbRamp:narrow">/v3/api/rawLabels?tags=CurbRamp:narrow</a></code> Narrow <code>CurbRamp</code> labels to those tagged <code>narrow</code>, leaving every other label type unfiltered.</p>
+      <p><code><a href="/v3/api/rawLabels?labelType=CurbRamp&tags=CurbRamp:narrow">/v3/api/rawLabels?labelType=CurbRamp&amp;tags=CurbRamp:narrow</a></code> Get <em>only</em> <code>CurbRamp</code> labels tagged <code>narrow</code> — pair the scoped tag with <code>labelType</code> to also drop the other types.</p>
     </div>
   </div>
 
@@ -126,12 +128,16 @@
           <tr>
             <td><code>labelType</code></td>
             <td><code>string</code></td>
-            <td>Filter by one or more label types. Provide comma-separated values (e.g., <code>labelType=CurbRamp,Obstacle</code>). See <a target="_blank" href="@routes.ApiDocsController.labelTypes">Label Types Reference</a> for available types. </td>
+            <td>Filter by one or more label types. Provide comma-separated values (e.g., <code>labelType=CurbRamp,Obstacle</code>). See <a target="_blank" href="@routes.ApiDocsController.labelTypes">Label Types Reference</a> for available types.
+              <strong>Changed August 2026</strong> (v3 is a preview API): values are validated against the known label types, so an unrecognized or empty value now returns a 400 error naming the parameter instead of silently matching nothing. </td>
           </tr>
           <tr>
             <td><code>tags</code></td>
             <td><code>string</code></td>
-            <td>Filter by one or more tags associated with labels. Provide comma-separated values (e.g., <code>tags=missing tactile warning,uneven surface</code>). Matches labels containing *any* of the specified tags. An entry may be scoped to a single label type with a <code>LabelType:tag</code> prefix (e.g., <code>tags=CurbRamp:narrow</code>), which only matches that tag on that label type; an entry whose prefix (the text before the first colon) is not a valid label type is treated as a plain tag matching any type, since tag names may themselves contain colons. See <a target="_blank" href="@routes.ApiDocsController.labelTags">Tags Reference</a> for available tags. </td>
+            <td>Filter by one or more tags associated with labels. <strong>Repeat the parameter once per tag</strong> (e.g., <code>tags=missing tactile warning&amp;tags=uneven surface</code>). Matches labels containing *any* of the specified tags.
+              An entry may be scoped to a single label type with a <code>LabelType:tag</code> prefix (e.g., <code>tags=CurbRamp:narrow</code>). A scoped entry narrows <em>only</em> that label type — labels of types nobody scoped come back unfiltered — so pair it with <code>labelType</code> if you want the other types dropped too. An entry whose prefix (the text before the first colon) is not a valid label type is treated as a plain tag applying to every type, since tag names may themselves contain colons (e.g., <code>cycle lane: faded paint</code>).
+              <strong>Changed August 2026</strong> (v3 is a preview API): <code>tags</code> is no longer comma-separated, because tag names may contain commas (e.g., <code>yellow box, accessibility features not visible</code>) and splitting on them silently shredded such a tag into two that matched nothing. Replace <code>tags=a,b</code> with <code>tags=a&amp;tags=b</code>. Scoped entries also no longer exclude the label types they don't name.
+              See <a target="_blank" href="@routes.ApiDocsController.labelTags">Tags Reference</a> for available tags. </td>
           </tr>
           <tr>
             <td><code>severity</code></td>
@@ -176,7 +182,8 @@
           <tr>
             <td><code>inline</code></td>
             <td><code>boolean</code></td>
-            <td>Whether to display the file inline or as an attachment. Default: <code>false</code> (attachment). Set to <code>true</code> to view data in the browser instead of downloading.</td>
+            <td>Whether to display the file inline or as an attachment. Default: <code>false</code> (attachment). Set to <code>true</code> to view data in the browser instead of downloading.
+              <strong>Fixed August 2026:</strong> <code>filetype=csv</code> previously forced an attachment and ignored this parameter. The fix applies to every <code>/v3</code> endpoint that emits CSV, not just this one.</td>
           </tr>
         </tbody>
       </table>

--- a/app/views/apps/labelMap.scala.html
+++ b/app/views/apps/labelMap.scala.html
@@ -190,13 +190,19 @@
         new MapSidebarUrlSync(sidebarFilter, self.map);
         // "Download" control (#4095), added after the labels stream in so its count is always real. A single
         // deep-linked region is passed through to the download; the other page-level params (multi-region, routes,
-        // AI validation) have no rawLabels counterpart, so the menu shows a caveat instead.
-        const regionIdList = regionsParam ? regionsParam.split(',') : [];
+        // AI validation) have no rawLabels counterpart, so the panel shows a caveat instead.
+        // Only one well-formed region id can be passed through. A malformed one is dropped rather than forwarded:
+        // it would reach rawLabels as a bad value and 400, which a plain anchor download shows as nothing happening.
+        const rawRegionIds = regionsParam ? regionsParam.split(',') : [];
+        const regionIds = rawRegionIds.map(Number).filter(Number.isInteger);
+        const downloadRegionId = rawRegionIds.length === 1 && regionIds.length === 1 ? regionIds[0] : null;
         self.map.addControl(new MapDownloadControl({
           getFilterState: () => sidebarFilter.getState(),
           getVisibleLabelCount: () => sidebarFilter.getVisibleLabelCount(),
-          regionId: regionIdList.length === 1 ? Number(regionIdList[0]) : null,
-          showsPartialFilterCaveat: regionIdList.length > 1 || Boolean(routesParam) || Boolean(aiValidationOptionsParam),
+          regionId: downloadRegionId,
+          // Any region param the download can't carry verbatim leaves the file wider than the map, caveat included.
+          showsPartialFilterCaveat: (rawRegionIds.length > 0 && downloadRegionId === null)
+            || Boolean(routesParam) || Boolean(aiValidationOptionsParam),
         }), 'top-right');
         // Popup arrows step through spatially nearby labels using the already-loaded map data.
         self.nearbyNav = createNearbyLabelNavigator(self.mapData);

--- a/conf/routes
+++ b/conf/routes
@@ -230,7 +230,7 @@ POST    /ai/analyzeScene                                controllers.AiController
 POST    /ai/submitLabelsOnPano                          controllers.AiController.submitAiLabel
 
 # Public API (v3) for Project Sidewalk data and metadata.
-GET     /v3/api/rawLabels                               controllers.api.LabelApiController.getRawLabelsV3(bbox: Option[String], labelType: Option[String], tags: Option[String], severity: Option[String], minSeverity: Option[Int], maxSeverity: Option[Int], validationStatus: Option[String], highQualityUserOnly: Option[Boolean], startDate: Option[String], endDate: Option[String], regionId: Option[Int], regionName: Option[String], filetype: Option[String], inline: Option[Boolean])
+GET     /v3/api/rawLabels                               controllers.api.LabelApiController.getRawLabelsV3(bbox: Option[String], labelType: Option[String], tags: List[String], severity: Option[String], minSeverity: Option[Int], maxSeverity: Option[Int], validationStatus: Option[String], highQualityUserOnly: Option[Boolean], startDate: Option[String], endDate: Option[String], regionId: Option[Int], regionName: Option[String], filetype: Option[String], inline: Option[Boolean])
 GET     /v3/api/labelTypes                              controllers.api.LabelApiController.getLabelTypes
 GET     /v3/api/labelTags                               controllers.api.LabelApiController.getLabelTags
 GET     /v3/api/regionWithMostLabels                    controllers.api.RegionApiController.getRegionWithMostLabels

--- a/conf/routes
+++ b/conf/routes
@@ -9,7 +9,7 @@ GET     /developer                                      controllers.ApiDocsContr
 GET     /terms                                          controllers.ApplicationController.terms
 GET     /labelMap                                       controllers.ApplicationController.labelMap(regions: Option[String] ?= None, routes: Option[String] ?= None, aiValidationOptions: Option[String] ?= None)
 GET     /labelmap                                       controllers.ApplicationController.labelMap(regions: Option[String] ?= None, routes: Option[String] ?= None, aiValidationOptions: Option[String] ?= None)
-GET     /gallery                                        controllers.GalleryController.gallery(labelType: String ?= "Assorted", neighborhoods: String ?= "", severities: String ?= "", tags: String ?= "", validationOptions: String ?= "correct,unvalidated", aiValidationOptions: String ?= "")
+GET     /gallery                                        controllers.GalleryController.gallery(labelType: String ?= "Assorted", neighborhoods: String ?= "", severities: String ?= "", tags: List[String] ?= List(), validationOptions: String ?= "correct,unvalidated", aiValidationOptions: String ?= "")
 GET     /help                                           controllers.ApplicationController.help
 GET     /labelingGuide                                  controllers.ApplicationController.labelingGuide
 GET     /labelingguide                                  controllers.ApplicationController.labelingGuide

--- a/conf/routes
+++ b/conf/routes
@@ -230,7 +230,7 @@ POST    /ai/analyzeScene                                controllers.AiController
 POST    /ai/submitLabelsOnPano                          controllers.AiController.submitAiLabel
 
 # Public API (v3) for Project Sidewalk data and metadata.
-GET     /v3/api/rawLabels                               controllers.api.LabelApiController.getRawLabelsV3(bbox: Option[String], labelType: Option[String], tags: List[String], severity: Option[String], minSeverity: Option[Int], maxSeverity: Option[Int], validationStatus: Option[String], highQualityUserOnly: Option[Boolean], startDate: Option[String], endDate: Option[String], regionId: Option[Int], regionName: Option[String], filetype: Option[String], inline: Option[Boolean])
+GET     /v3/api/rawLabels                               controllers.api.LabelApiController.getRawLabelsV3(bbox: Option[String], labelType: Option[String], tags: List[String] ?= List(), severity: Option[String], minSeverity: Option[Int], maxSeverity: Option[Int], validationStatus: Option[String], highQualityUserOnly: Option[Boolean], startDate: Option[String], endDate: Option[String], regionId: Option[Int], regionName: Option[String], filetype: Option[String], inline: Option[Boolean])
 GET     /v3/api/labelTypes                              controllers.api.LabelApiController.getLabelTypes
 GET     /v3/api/labelTags                               controllers.api.LabelApiController.getLabelTags
 GET     /v3/api/regionWithMostLabels                    controllers.api.RegionApiController.getRegionWithMostLabels

--- a/docs/logged-events.md
+++ b/docs/logged-events.md
@@ -75,9 +75,9 @@ vocabulary mirrors the Gallery filter events (`SeverityApply`, `TagApply`, `Vali
 that renders the sidebar; use the accompanying page-visit events to segment by page.
 
 The LabelMap's "Download" control (`ps-map/MapDownloadControl.js`, #4095) logs the
-**`Click_module=MapDownload_<Action>`** family: `MapDownload_Open` when the menu opens,
+**`Click_module=MapDownload_<Action>`** family: `MapDownload_Open` when the panel opens,
 `MapDownload_Download_format=<geojson|csv|shapefile|geopackage>` when a format is picked (the download itself is a
-`/v3/api/rawLabels` request, so it also appears in the API request log), and `MapDownload_DocsLink` when the menu's
+`/v3/api/rawLabels` request, so it also appears in the API request log), and `MapDownload_DocsLink` when the panel's
 API-documentation link is followed.
 
 The Gallery renders the same sidebar (`gallery/src/filter/GalleryFilter.js`) and logs to `gallery_task_interaction`

--- a/public/css/map-download-control.css
+++ b/public/css/map-download-control.css
@@ -1,5 +1,5 @@
 /* "Download" map control on the LabelMap (#4095): a labeled pill to the left of the zoom/compass cluster that opens
-   a dropdown menu of download formats. Fixed page chrome, so no --ui-scale. */
+   a disclosure panel of download formats. Fixed page chrome, so no --ui-scale. */
 
 /* Lay the corner's controls out in a row so the pill sits beside the zoom/compass cluster instead of stacking
    under it. Safe to restyle Mapbox's corner container: this stylesheet loads only on the LabelMap. */
@@ -39,6 +39,29 @@
   background: var(--color-neutral-100);
 }
 
+/* While a download is being prepared the pill is a status, not an invitation — drop the hover affordance. */
+.map-download-control__button[aria-busy="true"] {
+  color: var(--color-neutral-700);
+  cursor: progress;
+}
+
+.map-download-control__button[aria-busy="true"]:hover {
+  background: var(--color-neutral-white);
+}
+
+/* Text carried only for screen readers: the live-region status and the docs link's new-tab warning. */
+.map-download-control__sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
 .map-download-control__button:focus-visible,
 .map-download-control__item:focus-visible,
 .map-download-control__docs-link:focus-visible {
@@ -46,13 +69,13 @@
   outline-offset: 1px;
 }
 
-.map-download-control__menu {
+.map-download-control__panel {
   position: absolute;
   top: calc(100% + 6px);
   right: 0;
   min-width: 260px;
 
-  /* The menu's own padding sets the single left edge everything below aligns to: title, count pill, the format
+  /* The panel's own padding sets the single left edge everything below aligns to: title, count pill, the format
      buttons' borders, the separator, and the docs link all start here. Text rows carry no horizontal margins of
      their own — an outdented card border is what makes the panel read as messy. */
   padding: 12px;

--- a/public/js/common/filter-sidebar/FilterSidebar.js
+++ b/public/js/common/filter-sidebar/FilterSidebar.js
@@ -64,12 +64,20 @@ class FilterSidebar {
   /**
    * Returns the current filter state, read straight off the DOM.
    *
-   * @returns {{severities: number[], sections: object, tags: object}} Enabled severities; per-section arrays of the
-   *      selected values (label types as bare type names, everything else as control ids); and the active tags of
-   *      every label type, including types with none selected so hosts can clear stale tag filters.
+   * `allSeverities` and `allLabelTypes` report what the host actually *rendered*, not what the app supports: a page
+   * may drop the severity toggles or a label type entirely, and a consumer that needs to recognize "everything is
+   * selected" has to compare against the rendered set rather than a hardcoded count.
+   *
+   * @returns {{severities: number[], allSeverities: number[], sections: object, tags: object,
+   *      allLabelTypes: string[]}} Enabled severities and every rendered severity; per-section arrays of the
+   *      selected values (label types as bare type names, everything else as control ids); the active tags of
+   *      every label type, including types with none selected so hosts can clear stale tag filters; and every
+   *      rendered label type.
    */
   getState() {
-    const severities = this.#severityButtons()
+    const severityButtons = this.#severityButtons();
+    const allSeverities = severityButtons.map((btn) => Number(btn.dataset.severity));
+    const severities = severityButtons
       .filter((btn) => btn.getAttribute('aria-pressed') === 'true')
       .map((btn) => Number(btn.dataset.severity));
 
@@ -88,7 +96,7 @@ class FilterSidebar {
       tags[pill.dataset.labelType]?.push(pill.dataset.tag);
     }
 
-    return { severities, sections, tags };
+    return { severities, allSeverities, sections, tags, allLabelTypes: Object.keys(tags) };
   }
 
   /**

--- a/public/js/common/label-detail/LabelDetail.js
+++ b/public/js/common/label-detail/LabelDetail.js
@@ -20,13 +20,7 @@ class LabelDetail {
     const url = new URL(window.location);
     if (labelId) url.searchParams.set('labelId', labelId);
     else url.searchParams.delete('labelId');
-    // Commas are legal unencoded in a query value; keep any list params (the map/Gallery filters) readable
-    // rather than letting URL serialization re-encode them as %2C. MapSidebarUrlSync serializes identically on
-    // purpose — on the LabelMap both writers touch the same query string, and byte-differing output would have
-    // them rewrite each other's params on every toggle. A value carrying a literal comma is indistinguishable
-    // from a separator after this, which is fine while every list param here is comma-delimited.
-    const query = url.searchParams.toString().replace(/%2C/g, ',');
-    history.replaceState(null, '', `${url.pathname}${query ? `?${query}` : ''}${url.hash}`);
+    util.url.replaceQuery(url);
   }
 
   /**

--- a/public/js/common/label-detail/StorySection.js
+++ b/public/js/common/label-detail/StorySection.js
@@ -99,11 +99,10 @@ class StorySection {
    * @param {number} labelId
    */
   #maybeResumeDraft(labelId) {
-    const params = new URLSearchParams(window.location.search);
-    if (params.get('resumeStory') !== String(labelId)) return;
-    params.delete('resumeStory');
-    const qs = params.toString();
-    window.history.replaceState(null, '', window.location.pathname + (qs ? `?${qs}` : '') + window.location.hash);
+    const url = new URL(window.location);
+    if (url.searchParams.get('resumeStory') !== String(labelId)) return;
+    url.searchParams.delete('resumeStory');
+    util.url.replaceQuery(url);
     this.#composer.open(labelId, this.#maxTextLength);
   }
 

--- a/public/js/common/urlQuery.js
+++ b/public/js/common/urlQuery.js
@@ -1,0 +1,78 @@
+window.util = window.util || {};
+
+/**
+ * Shared rules for the deep-link query strings our pages read and write.
+ *
+ * Several independent writers touch the same query string on one page — the LabelMap runs MapSidebarUrlSync (filter
+ * params) and LabelDetail.syncUrlLabelId (the open label) side by side, and StorySection strips its own marker after
+ * a sign-in bounce. They have to agree byte for byte on how a param is serialized, or each rewrite re-encodes the
+ * others' params and they fight over the URL on every toggle. That agreement lives here rather than in a comment
+ * repeated at each call site.
+ */
+util.url = util.url || {};
+
+/**
+ * Serializes query params, leaving commas and colons as themselves.
+ *
+ * `URLSearchParams` percent-encodes both, but RFC 3986 allows them unencoded in a query (`pchar` covers sub-delims,
+ * ":" and "@"), and our params are comma-separated lists of values that can carry a colon — so a shared LabelMap
+ * link reads `tags=CurbRamp:narrow` instead of `tags=CurbRamp%3Anarrow` (#4782).
+ *
+ * @param {URLSearchParams} params The params to serialize.
+ * @returns {string} The query string, without a leading "?" (empty when there are no params).
+ */
+util.url.serialize = (params) => params.toString().replace(/%2C/g, ',').replace(/%3A/g, ':');
+
+/**
+ * Rewrites the current URL's query in place, without adding a history entry.
+ *
+ * `replaceState` rather than `pushState` throughout: filter toggles and popup opens are not navigation, and rapid
+ * toggling would otherwise bury the page the user arrived from under dozens of back-button steps.
+ *
+ * @param {URL} url The URL whose pathname/params/hash should become the current URL.
+ */
+util.url.replaceQuery = (url) => {
+  const query = util.url.serialize(url.searchParams);
+  window.history.replaceState(null, '', `${url.pathname}${query ? `?${query}` : ''}${url.hash}`);
+};
+
+/**
+ * Writes a repeatable list param: one occurrence per value (`?tags=a&tags=b`), or none when the list is empty.
+ *
+ * Use this — rather than joining on commas — for any list whose values are free-form text. Tag names are the case
+ * that forces it: they are author-written label text, and at least one real tag contains a comma ("yellow box,
+ * accessibility features not visible"), which a joined list shreds into two values that match nothing (#4783).
+ * Lists of closed values (severities, label types, validation options) stay comma-joined, since they can't contain
+ * a comma and one readable param beats several.
+ *
+ * @param {URLSearchParams} params The params to write into.
+ * @param {string} name The param name.
+ * @param {string[]} values The values; an empty array deletes the param.
+ */
+util.url.setRepeated = (params, name, values) => {
+  params.delete(name);
+  for (const value of values) params.append(name, value);
+};
+
+/**
+ * Reads a repeatable list param, accepting both the repeated form and the older comma-joined one.
+ *
+ * An occurrence that is itself a valid value is taken whole, so a value containing a comma survives; only an
+ * occurrence that isn't valid on its own is split on commas, which is what an old shared link looks like. Validating
+ * before splitting is what makes the two forms distinguishable, so `isValid` has to be a real membership test
+ * against what the page can render, not a shape check.
+ *
+ * @param {URLSearchParams} params The params to read.
+ * @param {string} name The param name.
+ * @param {(value: string) => boolean} isValid Whether a value is one this page recognizes.
+ * @returns {?string[]} The valid values, `[]` when the param is present but selects nothing, `null` when absent.
+ */
+util.url.getRepeated = (params, name, isValid) => {
+  const occurrences = params.getAll(name);
+  if (occurrences.length === 0) return null;
+  return occurrences.flatMap((occurrence) => {
+    const whole = occurrence.trim();
+    if (isValid(whole)) return [whole];
+    return whole.split(',').map((value) => value.trim()).filter(isValid);
+  });
+};

--- a/public/js/gallery/src/filter/GalleryFilter.js
+++ b/public/js/gallery/src/filter/GalleryFilter.js
@@ -138,8 +138,9 @@ class GalleryFilter {
       params.set('labelType', this.#status.currentLabelTypes.join());
     }
     // Tags belong to a label type, so they only mean something alongside the types they narrow.
-    const tags = this.getAppliedTagNames();
-    if (tags.length > 0) params.set('tags', tags.join());
+    // One occurrence per tag rather than a comma-joined list: tag names are free-form and one of them contains a
+    // comma (#4783); see util.url.setRepeated.
+    util.url.setRepeated(params, 'tags', this.getAppliedTagNames());
     // TODO once we add a UI for neighborhood filtering, have that process mirror what we have for other filters.
     const { neighborhoods, aiValidationOptions } = this.#initialFilters;
     if (neighborhoods.length > 0) params.set('neighborhoods', neighborhoods.join());
@@ -150,9 +151,7 @@ class GalleryFilter {
     // TODO once we add a UI for filtering on AI validation, have that process mirror the other filters.
     if (aiValidationOptions.length > 0) params.set('aiValidationOptions', aiValidationOptions.join());
 
-    // Commas are legal unencoded in a query value, and these params are comma-separated lists, so leaving them
-    // readable keeps the shared URLs legible without changing what the server parses.
-    const query = params.toString().replace(/%2C/g, ',');
+    const query = util.url.serialize(params);
     return query ? `/gallery?${query}` : '/gallery';
   }
 

--- a/public/js/ps-map/MapDownloadControl.js
+++ b/public/js/ps-map/MapDownloadControl.js
@@ -1,10 +1,14 @@
 /**
- * "Download" map control: a labeled pill that opens a dropdown menu for downloading the labels currently shown on
- * the map via the public /v3/api/rawLabels endpoint, in the user's choice of format.
+ * "Download" map control: a labeled pill that opens a panel for downloading the labels currently shown on the map
+ * via the public /v3/api/rawLabels endpoint, in the user's choice of format.
  *
  * Implements the Mapbox IControl interface (onAdd/onRemove) so it stacks with the built-in controls in a map corner.
  * The host page supplies accessors for the live filter state and visible-label count; the control turns that state
  * into rawLabels query parameters at click time, so the file always reflects the current sidebar selections.
+ *
+ * The panel is a disclosure (button + `aria-expanded`/`aria-controls`), not an ARIA menu: it mixes static text (the
+ * title, the count, the caveat) with actions, and `role="menu"` may only contain menu items. Arrow/Home/End keys are
+ * still wired up as a convenience for the run of buttons inside.
  */
 class MapDownloadControl {
   /** @type {HTMLElement} */
@@ -12,7 +16,9 @@ class MapDownloadControl {
   /** @type {HTMLButtonElement} */
   #button;
   /** @type {HTMLElement} */
-  #menu;
+  #panel;
+  /** @type {HTMLElement} */
+  #status;
   /** @type {() => object} */
   #getFilterState;
   /** @type {() => number} */
@@ -23,10 +29,28 @@ class MapDownloadControl {
   #showsPartialFilterCaveat;
   /** @type {boolean} */
   #open = false;
+  /** @type {string} Prefix for this instance's element ids, so two controls on one page can't collide. */
+  #idPrefix;
+  /** @type {?number} */
+  #outsideClickTimer = null;
+  /** @type {?number} */
+  #busyTimer = null;
   /** @type {(e: MouseEvent) => void} Stable reference so the capturing document listener can be removed. */
   #boundOutsideClick = (e) => this.#onOutsideClick(e);
 
-  /** The download formats offered, in menu order. Format names are proper nouns and are not translated. */
+  /** Instances built so far, used to make element ids unique. */
+  static #instanceCount = 0;
+
+  /**
+   * How long the pill stays in its "preparing your download" state, in ms.
+   *
+   * The transfer is a plain browser navigation, which fires no completion event we can listen for, so the state is
+   * time-boxed rather than tied to the response. It exists to acknowledge the click — a city-wide GeoPackage takes a
+   * while to first byte, and with no feedback at all people click again.
+   */
+  static #BUSY_MS = 4000;
+
+  /** The download formats offered, in panel order. Format names are proper nouns and are not translated. */
   static #FORMATS = [
     { format: 'geojson', name: 'GeoJSON', hintKey: 'hint-geojson', hintFallback: 'Web mapping standard' },
     { format: 'csv', name: 'CSV', hintKey: 'hint-csv', hintFallback: 'For Excel, Google Sheets' },
@@ -55,16 +79,18 @@ class MapDownloadControl {
     this.#getVisibleLabelCount = getVisibleLabelCount;
     this.#regionId = regionId;
     this.#showsPartialFilterCaveat = showsPartialFilterCaveat;
+    this.#idPrefix = `map-download-${MapDownloadControl.#instanceCount++}`;
   }
 
   /**
    * Builds the relative /v3/api/rawLabels URL for the given sidebar state.
    *
-   * A section with every option selected is omitted — the endpoint's default already covers it. A section with
-   * nothing selected is also omitted: it means the map shows nothing, and callers disable the download actions in
-   * that case (the endpoint cannot express an empty selection).
+   * A section with every rendered option selected is omitted — the endpoint's default already covers it. A section
+   * with nothing selected is also omitted: it means the map shows nothing, and callers disable the download actions
+   * in that case (the endpoint cannot express an empty selection).
    *
-   * @param {{severities: number[], sections: object, tags: object}} state FilterSidebar.getState()'s shape.
+   * @param {{severities: number[], allSeverities: number[], sections: object, tags: object,
+   *      allLabelTypes: string[]}} state FilterSidebar.getState()'s shape.
    * @param {object} options
    * @param {string} options.format One of 'geojson', 'csv', 'shapefile', 'geopackage'.
    * @param {?number} [options.regionId] Single region id to scope the download to, or null.
@@ -77,17 +103,13 @@ class MapDownloadControl {
     // highQualityFilter: true), so downloads must match.
     params.set('highQualityUserOnly', 'true');
 
-    // state.tags carries every rendered label type (FilterSidebar.getState()'s contract), checked or not.
-    const renderedTypeCount = Object.keys(state.tags).length;
     const checkedTypes = state.sections['label-type'] ?? [];
-    if (checkedTypes.length > 0 && checkedTypes.length < renderedTypeCount) {
+    if (checkedTypes.length > 0 && checkedTypes.length < state.allLabelTypes.length) {
       params.set('labelType', checkedTypes.join(','));
     }
 
-    // The sidebar renders exactly four severity toggles (N/A + 1-3, filterSidebar.scala.html); all four selected
-    // is the endpoint's default.
     const severities = [...state.severities].sort((a, b) => a - b);
-    if (severities.length > 0 && severities.length < 4) {
+    if (severities.length > 0 && severities.length < state.allSeverities.length) {
       params.set('severity', severities.map((severity) => (severity === 0 ? 'none' : String(severity))).join(','));
     }
 
@@ -99,9 +121,13 @@ class MapDownloadControl {
       );
     }
 
-    const tagPairs = Object.entries(state.tags)
-      .flatMap(([labelType, tags]) => tags.map((tag) => `${labelType}:${tag}`));
-    if (tagPairs.length > 0) params.set('tags', tagPairs.join(','));
+    // One `tags` occurrence per tag rather than a comma-separated list: tag names are free-form label text and at
+    // least one of them contains a comma ("yellow box, accessibility features not visible"), which a list would
+    // shred into two tags matching nothing. Each entry is scoped to its label type, which the endpoint reads as
+    // "narrow this type by these tags", leaving the untagged types alone — exactly what the sidebar does.
+    for (const [labelType, tags] of Object.entries(state.tags)) {
+      for (const tag of tags) params.append('tags', `${labelType}:${tag}`);
+    }
 
     if (regionId !== null) params.set('regionId', String(regionId));
     return `/v3/api/rawLabels?${params}`;
@@ -113,41 +139,56 @@ class MapDownloadControl {
    * @returns {HTMLElement} The control's root element.
    */
   onAdd() {
+    const panelId = `${this.#idPrefix}-panel`;
+    const titleId = `${this.#idPrefix}-title`;
+    const countId = `${this.#idPrefix}-count`;
+    const caveatId = `${this.#idPrefix}-caveat`;
+    // The caveat only describes the panel when it's actually shown, or screen readers announce a warning that isn't
+    // on screen.
+    const describedBy = this.#showsPartialFilterCaveat ? `${countId} ${caveatId}` : countId;
+
     this.#container = document.createElement('div');
     this.#container.className = 'mapboxgl-ctrl map-download-control';
     const formatItems = MapDownloadControl.#FORMATS.map(({ format, name, hintKey, hintFallback }) => `
-        <button type="button" role="menuitem" class="map-download-control__item" data-format="${format}">
+        <button type="button" class="map-download-control__item" data-format="${format}">
           <span class="map-download-control__format">${name}</span>
           <span class="map-download-control__hint" data-i18n="labelmap:download.${hintKey}">${hintFallback}</span>
         </button>`).join('');
     this.#container.innerHTML = `
-      <button type="button" class="map-download-control__button" aria-haspopup="menu" aria-expanded="false"
-              aria-controls="map-download-menu">
+      <button type="button" class="map-download-control__button" aria-expanded="false" aria-controls="${panelId}">
         <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
           <path d="M8 2v8m0 0 3-3m-3 3L5 7M3 12v1.5a.5.5 0 0 0 .5.5h9a.5.5 0 0 0 .5-.5V12"
                 stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
         </svg>
-        <span data-i18n="labelmap:download.button">Download</span>
+        <span class="map-download-control__label" data-i18n="labelmap:download.button">Download</span>
+        <span class="map-download-control__label map-download-control__label--busy"
+              data-i18n="labelmap:download.preparing" hidden>Preparing your download…</span>
       </button>
-      <div id="map-download-menu" class="map-download-control__menu" role="menu" aria-labelledby="map-download-title"
-           aria-describedby="map-download-count" hidden>
-        <p id="map-download-title" class="map-download-control__title"
+      <div id="${panelId}" class="map-download-control__panel" role="group" aria-labelledby="${titleId}"
+           aria-describedby="${describedBy}" hidden>
+        <p id="${titleId}" class="map-download-control__title"
            data-i18n="labelmap:download.title">Select a file format to download</p>
-        <p id="map-download-count" class="map-download-control__count"></p>
-        <p class="map-download-control__caveat" data-i18n="labelmap:download.caveat" hidden>
-          Some filters from this page's link (multiple regions, routes, or AI validation) aren't applied to downloads.
+        <p id="${countId}" class="map-download-control__count"></p>
+        <p id="${caveatId}" class="map-download-control__caveat" data-i18n="labelmap:download.caveat" hidden>
+          Some filters from this page's link (multiple regions, routes, or AI validation) can't be applied to
+          downloads, so the file may contain more labels than the count above.
         </p>${formatItems}
-        <a role="menuitem" class="map-download-control__docs-link" href="/v3/api-docs/rawLabels" target="_blank"
-           data-i18n="labelmap:download.api-docs-link">Raw Labels API documentation</a>
-      </div>`;
+        <a class="map-download-control__docs-link" href="/v3/api-docs/rawLabels" target="_blank" rel="noopener">
+          <span data-i18n="labelmap:download.api-docs-link">Raw Labels API documentation</span>
+          <span class="map-download-control__sr-only"
+                data-i18n="labelmap:download.opens-new-tab"> (opens in a new tab)</span>
+        </a>
+      </div>
+      <p class="map-download-control__sr-only" role="status"></p>`;
 
     this.#button = this.#container.querySelector('.map-download-control__button');
-    this.#menu = this.#container.querySelector('#map-download-menu');
+    this.#panel = this.#container.querySelector(`#${panelId}`);
+    this.#status = this.#container.querySelector('[role="status"]');
     if (this.#showsPartialFilterCaveat) this.#container.querySelector('.map-download-control__caveat').hidden = false;
 
-    this.#button.addEventListener('click', () => (this.#open ? this.#closeMenu() : this.#openMenu()));
+    this.#button.addEventListener('click', () => (this.#open ? this.#closePanel() : this.#openPanel()));
     this.#container.addEventListener('keydown', (e) => this.#onKeydown(e));
-    for (const item of this.#menu.querySelectorAll('.map-download-control__item')) {
+    for (const item of this.#panel.querySelectorAll('.map-download-control__item')) {
       item.addEventListener('click', () => this.#triggerDownload(item.dataset.format));
     }
     this.#container.querySelector('.map-download-control__docs-link')
@@ -159,27 +200,33 @@ class MapDownloadControl {
 
   /** Tears down the control. Called by Mapbox when the control is removed from the map. */
   onRemove() {
+    clearTimeout(this.#outsideClickTimer);
+    clearTimeout(this.#busyTimer);
     document.removeEventListener('click', this.#boundOutsideClick, true);
     this.#container.remove();
   }
 
   /**
-   * Opens the menu: refreshes the count line, disables the format actions when nothing is shown, and moves focus in.
+   * Opens the panel: refreshes the count line, disables the format actions when nothing is shown, and moves focus in.
    * @param {boolean} [focusLast=false] Whether to focus the last item instead of the first (ArrowUp convention).
    */
-  #openMenu(focusLast = false) {
+  #openPanel(focusLast = false) {
     const count = this.#getVisibleLabelCount();
     this.#renderCount(count);
-    for (const item of this.#menu.querySelectorAll('.map-download-control__item')) {
+    for (const item of this.#panel.querySelectorAll('.map-download-control__item')) {
       item.disabled = count === 0;
     }
 
-    this.#menu.hidden = false;
+    this.#panel.hidden = false;
     this.#open = true;
     this.#button.setAttribute('aria-expanded', 'true');
 
-    // Defer listener registration so the click that opened the menu doesn't immediately close it.
-    setTimeout(() => document.addEventListener('click', this.#boundOutsideClick, true), 0);
+    // Defer listener registration so the click that opened the panel doesn't immediately close it. The guard covers
+    // a close that lands before the timer fires, which would otherwise leave a listener attached to a closed panel.
+    clearTimeout(this.#outsideClickTimer);
+    this.#outsideClickTimer = setTimeout(() => {
+      if (this.#open) document.addEventListener('click', this.#boundOutsideClick, true);
+    }, 0);
 
     const items = this.#focusableItems();
     (focusLast ? items.at(-1) : items[0])?.focus();
@@ -187,13 +234,14 @@ class MapDownloadControl {
   }
 
   /**
-   * Closes the menu and tears down the outside-click listener.
+   * Closes the panel and tears down the outside-click listener.
    * @param {boolean} [returnFocus=true] Whether to move focus back to the pill (skip on outside-click/Tab).
    */
-  #closeMenu(returnFocus = true) {
-    this.#menu.hidden = true;
+  #closePanel(returnFocus = true) {
+    this.#panel.hidden = true;
     this.#open = false;
     this.#button.setAttribute('aria-expanded', 'false');
+    clearTimeout(this.#outsideClickTimer);
     document.removeEventListener('click', this.#boundOutsideClick, true);
     if (returnFocus) this.#button.focus();
   }
@@ -212,7 +260,25 @@ class MapDownloadControl {
     link.click();
     link.remove();
     this.#logActivity(`Click_module=MapDownload_Download_format=${format}`);
-    this.#closeMenu();
+    this.#setBusy(true);
+    this.#closePanel();
+  }
+
+  /**
+   * Puts the pill into (or out of) its "preparing your download" state and announces the change.
+   * @param {boolean} busy Whether a download has just been started.
+   */
+  #setBusy(busy) {
+    const idle = this.#button.querySelector('.map-download-control__label:not(.map-download-control__label--busy)');
+    const working = this.#button.querySelector('.map-download-control__label--busy');
+    idle.hidden = busy;
+    working.hidden = !busy;
+    this.#button.setAttribute('aria-busy', String(busy));
+    // Announce the localized string the pill itself is showing, rather than a second copy that could drift from it.
+    this.#status.textContent = busy ? working.textContent.trim() : '';
+
+    clearTimeout(this.#busyTimer);
+    if (busy) this.#busyTimer = setTimeout(() => this.#setBusy(false), MapDownloadControl.#BUSY_MS);
   }
 
   /**
@@ -226,20 +292,20 @@ class MapDownloadControl {
     pill.className = 'map-download-control__count-pill';
     pill.textContent = hasI18n ? i18next.t('labelmap:download.count', { count }) : `${count} labels`;
     const suffix = hasI18n ? i18next.t('labelmap:download.count-match', { count }) : 'match your filters';
-    this.#menu.querySelector('.map-download-control__count').replaceChildren(pill, suffix);
+    this.#panel.querySelector('.map-download-control__count').replaceChildren(pill, suffix);
   }
 
   /**
-   * Returns the menu's currently actionable items in navigation order (enabled formats, then the docs link).
-   * @returns {HTMLElement[]} The focusable menu items.
+   * Returns the panel's currently actionable items in navigation order (enabled formats, then the docs link).
+   * @returns {HTMLElement[]} The focusable items.
    */
   #focusableItems() {
     const selector = '.map-download-control__item:not(:disabled), .map-download-control__docs-link';
-    return [...this.#menu.querySelectorAll(selector)];
+    return [...this.#panel.querySelectorAll(selector)];
   }
 
   /**
-   * Handles keyboard interaction: ArrowDown/ArrowUp open the menu from the pill; inside the menu, arrows cycle,
+   * Handles keyboard interaction: ArrowDown/ArrowUp open the panel from the pill; inside it, arrows cycle,
    * Home/End jump, Escape closes and refocuses the pill, and Tab closes while letting focus move on.
    * @param {KeyboardEvent} e The keydown event.
    */
@@ -247,7 +313,7 @@ class MapDownloadControl {
     if (!this.#open) {
       if (document.activeElement === this.#button && (e.key === 'ArrowDown' || e.key === 'ArrowUp')) {
         e.preventDefault();
-        this.#openMenu(e.key === 'ArrowUp');
+        this.#openPanel(e.key === 'ArrowUp');
       }
       return;
     }
@@ -256,7 +322,7 @@ class MapDownloadControl {
     const index = items.indexOf(document.activeElement);
     if (e.key === 'Escape') {
       e.preventDefault();
-      this.#closeMenu();
+      this.#closePanel();
     } else if (e.key === 'ArrowDown') {
       e.preventDefault();
       items[(index + 1) % items.length]?.focus();
@@ -270,16 +336,18 @@ class MapDownloadControl {
       e.preventDefault();
       items.at(-1)?.focus();
     } else if (e.key === 'Tab') {
-      this.#closeMenu(false);
+      // Deferred: hiding the focused element's subtree synchronously leaves the browser resolving sequential focus
+      // from a display:none element, which can drop focus at the top of the document. Let the default Tab land first.
+      setTimeout(() => this.#closePanel(false), 0);
     }
   }
 
   /**
-   * Closes the menu when a click lands outside the control.
+   * Closes the panel when a click lands outside the control.
    * @param {MouseEvent} e The document-level click event.
    */
   #onOutsideClick(e) {
-    if (!this.#container.contains(e.target)) this.#closeMenu(false);
+    if (!this.#container.contains(e.target)) this.#closePanel(false);
   }
 
   /**

--- a/public/js/ps-map/MapDownloadControl.js
+++ b/public/js/ps-map/MapDownloadControl.js
@@ -35,6 +35,8 @@ class MapDownloadControl {
   #outsideClickTimer = null;
   /** @type {?number} */
   #busyTimer = null;
+  /** @type {?number} */
+  #tabCloseTimer = null;
   /** @type {(e: MouseEvent) => void} Stable reference so the capturing document listener can be removed. */
   #boundOutsideClick = (e) => this.#onOutsideClick(e);
 
@@ -202,6 +204,7 @@ class MapDownloadControl {
   onRemove() {
     clearTimeout(this.#outsideClickTimer);
     clearTimeout(this.#busyTimer);
+    clearTimeout(this.#tabCloseTimer);
     document.removeEventListener('click', this.#boundOutsideClick, true);
     this.#container.remove();
   }
@@ -338,7 +341,8 @@ class MapDownloadControl {
     } else if (e.key === 'Tab') {
       // Deferred: hiding the focused element's subtree synchronously leaves the browser resolving sequential focus
       // from a display:none element, which can drop focus at the top of the document. Let the default Tab land first.
-      setTimeout(() => this.#closePanel(false), 0);
+      clearTimeout(this.#tabCloseTimer);
+      this.#tabCloseTimer = setTimeout(() => this.#closePanel(false), 0);
     }
   }
 

--- a/public/js/ps-map/MapSidebarUrlSync.js
+++ b/public/js/ps-map/MapSidebarUrlSync.js
@@ -143,10 +143,11 @@ class MapSidebarUrlSync {
 
     // Each tag carries the type it narrows: names repeat across types ("narrow" is both a curb ramp and a
     // sidewalk tag), so a bare name couldn't say which one the user filtered, and restoring it would widen the
-    // filter to every checked type that renders it.
+    // filter to every checked type that renders it. One occurrence per tag rather than a comma-joined list —
+    // tag names are free-form and one of them contains a comma (#4783); see util.url.setRepeated.
     const tags = Object.entries(state.tags)
       .flatMap(([labelType, tagNames]) => tagNames.map((tag) => `${labelType}:${tag}`));
-    this.#setOrDelete(url, 'tags', tags.length === 0 ? null : tags.join(','));
+    util.url.setRepeated(url.searchParams, 'tags', tags);
 
     const streetIds = state.sections.streets ?? [];
     const streets = streetIds.map((id) => id.replace('-street', ''));
@@ -158,12 +159,7 @@ class MapSidebarUrlSync {
     url.searchParams.set('lng', center.lng.toFixed(5));
     url.searchParams.set('zoom', this.#map.getZoom().toFixed(2));
 
-    // Commas are legal unencoded in a query value, and these params are comma-separated lists, so leaving them
-    // readable keeps the shared URLs legible (Gallery precedent). LabelDetail.syncUrlLabelId serializes
-    // identically on purpose: both writers run on this page, and byte-differing output would make them fight
-    // over the same params (pinned by test/js/mapSidebarUrlSync.test.js).
-    const query = url.searchParams.toString().replace(/%2C/g, ',');
-    window.history.replaceState(null, '', `${url.pathname}${query ? `?${query}` : ''}${url.hash}`);
+    util.url.replaceQuery(url);
   }
 
   /**
@@ -191,24 +187,21 @@ class MapSidebarUrlSync {
   /**
    * Parses the `tags` param's `labelType:tag` tokens, keeping only pairs the sidebar actually renders.
    *
-   * Tokens are validated whole, before being split, so the split can safely take the first colon as the
-   * delimiter: label type keys never contain one, but tag names do ("parallel lines:yes").
+   * Tokens are matched whole against the rendered pills, which is what lets a token be split safely afterwards:
+   * the first colon is the delimiter (label type keys never contain one, but tag names do — "parallel
+   * lines:yes"), and a comma-joined token from an older link is only split once it fails to match on its own.
    *
    * @param {URLSearchParams} params The current query params.
    * @returns {?Array<{labelType: string, tag: string}>} The valid pairs, or null when the param is absent.
    */
   #parseTagPairs(params) {
-    const raw = params.get('tags');
-    if (raw === null) return null;
     const rendered = new Set(Array.from(this.#sidebar.querySelectorAll('.tag-pill[data-tag]'))
       .map((pill) => `${pill.dataset.labelType}:${pill.dataset.tag}`));
-    return raw.split(',')
-      .map((token) => token.trim())
-      .filter((token) => rendered.has(token))
-      .map((token) => {
+    return util.url.getRepeated(params, 'tags', (token) => rendered.has(token))
+      ?.map((token) => {
         const colon = token.indexOf(':');
         return { labelType: token.slice(0, colon), tag: token.slice(colon + 1) };
-      });
+      }) ?? null;
   }
 
   /**

--- a/public/locales/de/labelmap.json
+++ b/public/locales/de/labelmap.json
@@ -58,6 +58,7 @@
   "download": {
     "button": "Herunterladen",
     "title": "Dateiformat zum Herunterladen auswählen",
+    "preparing": "Download wird vorbereitet…",
     "count_one": "{{count}} Beschriftung",
     "count_other": "{{count}} Beschriftungen",
     "count-match_one": "entspricht Ihren Filtern",
@@ -66,8 +67,9 @@
     "hint-csv": "Für Excel, Google Sheets",
     "hint-shapefile": "Für ArcGIS, QGIS",
     "hint-geopackage": "Offenes GIS-Format",
-    "caveat": "Einige Filter aus dem Link dieser Seite (mehrere Regionen, Routen oder KI-Validierung) werden auf Downloads nicht angewendet.",
-    "api-docs-link": "Dokumentation der Raw-Labels-API"
+    "caveat": "Einige Filter aus dem Link dieser Seite (mehrere Regionen, Routen oder KI-Validierung) können auf Downloads nicht angewendet werden, daher kann die Datei mehr Beschriftungen enthalten als oben angegeben.",
+    "api-docs-link": "Dokumentation der Raw-Labels-API",
+    "opens-new-tab": " (wird in einem neuen Tab geöffnet)"
   },
   "story": {
     "heading": "Erfahrungsberichte",

--- a/public/locales/en/labelmap.json
+++ b/public/locales/en/labelmap.json
@@ -58,6 +58,7 @@
   "download": {
     "button": "Download",
     "title": "Select a file format to download",
+    "preparing": "Preparing your download…",
     "count_one": "{{count}} label",
     "count_other": "{{count}} labels",
     "count-match_one": "matches your filters",
@@ -66,8 +67,9 @@
     "hint-csv": "For Excel, Google Sheets",
     "hint-shapefile": "For ArcGIS, QGIS",
     "hint-geopackage": "Open GIS format",
-    "caveat": "Some filters from this page's link (multiple regions, routes, or AI validation) aren't applied to downloads.",
-    "api-docs-link": "Raw Labels API documentation"
+    "caveat": "Some filters from this page's link (multiple regions, routes, or AI validation) can't be applied to downloads, so the file may contain more labels than the count above.",
+    "api-docs-link": "Raw Labels API documentation",
+    "opens-new-tab": " (opens in a new tab)"
   },
   "story": {
     "heading": "Community stories",

--- a/public/locales/es/labelmap.json
+++ b/public/locales/es/labelmap.json
@@ -58,6 +58,7 @@
   "download": {
     "button": "Descargar",
     "title": "Selecciona un formato de archivo para descargar",
+    "preparing": "Preparando tu descarga…",
     "count_one": "{{count}} etiqueta",
     "count_other": "{{count}} etiquetas",
     "count-match_one": "coincide con tus filtros",
@@ -66,8 +67,9 @@
     "hint-csv": "Para Excel, Google Sheets",
     "hint-shapefile": "Para ArcGIS, QGIS",
     "hint-geopackage": "Formato SIG abierto",
-    "caveat": "Algunos filtros del enlace de esta página (varias regiones, rutas o validación por IA) no se aplican a las descargas.",
-    "api-docs-link": "Documentación de la API de etiquetas sin procesar"
+    "caveat": "Algunos filtros del enlace de esta página (varias regiones, rutas o validación por IA) no se pueden aplicar a las descargas, por lo que el archivo puede contener más etiquetas que el número indicado arriba.",
+    "api-docs-link": "Documentación de la API de etiquetas sin procesar",
+    "opens-new-tab": " (se abre en una pestaña nueva)"
   },
   "story": {
     "heading": "Historias de la comunidad",

--- a/public/locales/nl/labelmap.json
+++ b/public/locales/nl/labelmap.json
@@ -58,6 +58,7 @@
   "download": {
     "button": "Downloaden",
     "title": "Kies een bestandsformaat om te downloaden",
+    "preparing": "Je download wordt voorbereid…",
     "count_one": "{{count}} etiket",
     "count_other": "{{count}} etiketten",
     "count-match_one": "komt overeen met je filters",
@@ -66,8 +67,9 @@
     "hint-csv": "Voor Excel, Google Spreadsheets",
     "hint-shapefile": "Voor ArcGIS, QGIS",
     "hint-geopackage": "Open GIS-formaat",
-    "caveat": "Sommige filters uit de link van deze pagina (meerdere regio's, routes of AI-validatie) worden niet toegepast op downloads.",
-    "api-docs-link": "Documentatie van de Raw Labels API"
+    "caveat": "Sommige filters uit de link van deze pagina (meerdere regio’s, routes of AI-validatie) kunnen niet worden toegepast op downloads, dus het bestand kan meer etiketten bevatten dan het aantal hierboven.",
+    "api-docs-link": "Documentatie van de Raw Labels API",
+    "opens-new-tab": " (opent in een nieuw tabblad)"
   },
   "story": {
     "heading": "Verhalen uit de community",

--- a/public/locales/pt-BR/labelmap.json
+++ b/public/locales/pt-BR/labelmap.json
@@ -58,6 +58,7 @@
   "download": {
     "button": "Baixar",
     "title": "Selecione um formato de arquivo para baixar",
+    "preparing": "Preparando seu download…",
     "count_one": "{{count}} rótulo",
     "count_other": "{{count}} rótulos",
     "count-match_one": "corresponde aos seus filtros",
@@ -66,8 +67,9 @@
     "hint-csv": "Para Excel, Planilhas Google",
     "hint-shapefile": "Para ArcGIS, QGIS",
     "hint-geopackage": "Formato SIG aberto",
-    "caveat": "Alguns filtros do link desta página (várias regiões, rotas ou validação por IA) não são aplicados aos downloads.",
-    "api-docs-link": "Documentação da API de rótulos brutos"
+    "caveat": "Alguns filtros do link desta página (várias regiões, rotas ou validação por IA) não podem ser aplicados aos downloads, então o arquivo pode conter mais rótulos do que o número indicado acima.",
+    "api-docs-link": "Documentação da API de rótulos brutos",
+    "opens-new-tab": " (abre em uma nova aba)"
   },
   "story": {
     "heading": "Histórias da comunidade",

--- a/public/locales/zh-TW/labelmap.json
+++ b/public/locales/zh-TW/labelmap.json
@@ -52,14 +52,16 @@
   "download": {
     "button": "下載",
     "title": "選擇要下載的檔案格式",
+    "preparing": "正在準備您的下載…",
     "count_other": "{{count}} 個標記",
     "count-match_other": "符合您的篩選條件",
     "hint-geojson": "網頁地圖標準格式",
     "hint-csv": "適用於 Excel、Google 試算表",
     "hint-shapefile": "適用於 ArcGIS、QGIS",
     "hint-geopackage": "開放 GIS 格式",
-    "caveat": "此頁面連結中的部分篩選條件（多個區域、路線或 AI 檢核）不會套用於下載。",
-    "api-docs-link": "原始標記 API 文件"
+    "caveat": "此頁面連結中的部分篩選條件（多個區域、路線或 AI 檢核）無法套用於下載，因此檔案中的標記可能會多於上方顯示的數量。",
+    "api-docs-link": "原始標記 API 文件",
+    "opens-new-tab": "（在新分頁中開啟）"
   },
   "story": {
     "heading": "社群故事",

--- a/test/controllers/GalleryPageSpec.scala
+++ b/test/controllers/GalleryPageSpec.scala
@@ -29,8 +29,9 @@ class GalleryPageSpec extends PlaySpec with GuiceOneAppPerSuite {
       .disable[modules.ActorModule] // No eager background actors during tests.
       .build()
 
-  private val renderedTag = """data-tag="([^"]*)"""".r
-  private val activeTag   = """tag-pill--active"\s+data-tag="([^"]*)"""".r
+  // Matches a whole tag-pill element so the active-class check doesn't depend on attribute order within the tag.
+  // Twirl HTML-escapes ">" in attribute values, so [^>]* can't end the element early.
+  private val tagPillElement = """<button\b[^>]*\bdata-tag="([^"]*)"[^>]*>""".r
 
   /** Fetches /gallery with the given query and returns its HTML. */
   private def galleryPage(query: String = ""): String = {
@@ -39,8 +40,10 @@ class GalleryPageSpec extends PlaySpec with GuiceOneAppPerSuite {
     contentAsString(resp)
   }
 
-  private def renderedTags(body: String): Seq[String] = renderedTag.findAllMatchIn(body).map(_.group(1)).distinct.toSeq
-  private def activeTags(body: String): Set[String]   = activeTag.findAllMatchIn(body).map(_.group(1)).toSet
+  private def renderedTags(body: String): Seq[String] =
+    tagPillElement.findAllMatchIn(body).map(_.group(1)).distinct.toSeq
+  private def activeTags(body: String): Set[String] =
+    tagPillElement.findAllMatchIn(body).filter(_.matched.contains("tag-pill--active")).map(_.group(1)).toSet
 
   private def encode(tag: String): String = URLEncoder.encode(tag, "UTF-8")
 

--- a/test/controllers/GalleryPageSpec.scala
+++ b/test/controllers/GalleryPageSpec.scala
@@ -1,0 +1,78 @@
+package controllers
+
+import org.scalatestplus.play.PlaySpec
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+
+import java.net.URLEncoder
+
+/**
+ * Locks the `tags` deep-link contract of GET /gallery: the selection a shared link carries has to come back on the
+ * page, including for tag names that contain a comma (#4783).
+ *
+ * The filter is invisible when it breaks — an unrecognized tag is dropped rather than reported, so the page renders
+ * a perfectly normal grid of unfiltered cards. That is how a comma-joined `tags` param hid the fact that it was
+ * shredding "yellow box, accessibility features not visible" into two names that matched nothing.
+ *
+ * Reads the tag vocabulary off the page itself rather than hardcoding one, since which tags exist depends on the
+ * city the connected database holds.
+ *
+ * Requires a Postgres+PostGIS database (via DATABASE_URL / DATABASE_USER / DATABASE_PASSWORD env, as in dev/CI).
+ */
+class GalleryPageSpec extends PlaySpec with GuiceOneAppPerSuite {
+
+  override def fakeApplication(): Application =
+    new GuiceApplicationBuilder()
+      .disable[modules.ActorModule] // No eager background actors during tests.
+      .build()
+
+  private val renderedTag = """data-tag="([^"]*)"""".r
+  private val activeTag   = """tag-pill--active"\s+data-tag="([^"]*)"""".r
+
+  /** Fetches /gallery with the given query and returns its HTML. */
+  private def galleryPage(query: String = ""): String = {
+    val resp = route(app, FakeRequest(GET, s"/gallery$query")).get
+    status(resp) mustBe OK
+    contentAsString(resp)
+  }
+
+  private def renderedTags(body: String): Seq[String] = renderedTag.findAllMatchIn(body).map(_.group(1)).distinct.toSeq
+  private def activeTags(body: String): Set[String]   = activeTag.findAllMatchIn(body).map(_.group(1)).toSet
+
+  private def encode(tag: String): String = URLEncoder.encode(tag, "UTF-8")
+
+  "GET /gallery" should {
+    "render with no tags selected by default" in {
+      activeTags(galleryPage()) mustBe empty
+    }
+
+    "restore every tag a repeated tags parameter names" in {
+      val tags = renderedTags(galleryPage()).take(2)
+      assume(tags.size == 2, "connected database renders fewer than two tags")
+
+      val query = tags.map(tag => s"tags=${encode(tag)}").mkString("?", "&", "")
+      activeTags(galleryPage(query)) must contain allElementsOf tags
+    }
+
+    "restore a tag whose name contains a comma" in {
+      val commaTag = renderedTags(galleryPage()).find(_.contains(","))
+      assume(commaTag.isDefined, "connected database has no tag containing a comma")
+
+      activeTags(galleryPage(s"?tags=${encode(commaTag.get)}")) must contain(commaTag.get)
+    }
+
+    "still restore a link written in the older comma-joined form" in {
+      val tags = renderedTags(galleryPage()).filterNot(_.contains(",")).take(2)
+      assume(tags.size == 2, "connected database renders fewer than two comma-free tags")
+
+      activeTags(galleryPage(s"?tags=${encode(tags.mkString(","))}")) must contain allElementsOf tags
+    }
+
+    "drop a tag the city does not have, rather than failing the page" in {
+      activeTags(galleryPage("?tags=definitely-not-a-real-tag")) mustBe empty
+    }
+  }
+}

--- a/test/controllers/api/RawLabelsApiSpec.scala
+++ b/test/controllers/api/RawLabelsApiSpec.scala
@@ -90,10 +90,16 @@ class RawLabelsApiSpec extends PlaySpec with GuiceOneAppPerSuite {
     }
 
     "take a tag containing a comma as one tag rather than splitting it" in {
-      // Real Signal tag. Split on the comma it would become two tags that match nothing, so the only thing that can
-      // go wrong here is a 400/500 — a body assertion can't tell the two readings apart on an arbitrary DB.
+      // Real Signal tag. Tag values are validated against the city's tags, so the 200 is meaningful: split on the
+      // comma, the entry would become two names the vocabulary doesn't contain, and the request would 400.
       val url  = s"/v3/api/rawLabels?$tinyBbox&tags=Signal:yellow box, accessibility features not visible"
       val resp = route(app, FakeRequest(GET, url)).get
+      status(resp) mustBe OK
+      (contentAsJson(resp) \ "type").as[String] mustBe "FeatureCollection"
+    }
+
+    "still accept an older comma-joined tags value whose pieces name real tags" in {
+      val resp = route(app, FakeRequest(GET, s"/v3/api/rawLabels?$tinyBbox&tags=CurbRamp:narrow,uneven surface")).get
       status(resp) mustBe OK
       (contentAsJson(resp) \ "type").as[String] mustBe "FeatureCollection"
     }
@@ -136,6 +142,19 @@ class RawLabelsApiSpec extends PlaySpec with GuiceOneAppPerSuite {
 
     "reject an empty tags occurrence with 400 (parameter=tags)" in {
       val resp = route(app, FakeRequest(GET, "/v3/api/rawLabels?tags=narrow&tags=")).get
+      status(resp) mustBe BAD_REQUEST
+      (contentAsJson(resp) \ "parameter").as[String] mustBe "tags"
+    }
+
+    "reject a tag the city does not have with 400 (parameter=tags)" in {
+      val resp = route(app, FakeRequest(GET, "/v3/api/rawLabels?tags=definitely-not-a-real-tag")).get
+      status(resp) mustBe BAD_REQUEST
+      (contentAsJson(resp) \ "parameter").as[String] mustBe "tags"
+    }
+
+    "reject a tag scoped to a label type that does not carry it with 400 (parameter=tags)" in {
+      // APS is a Signal tag; scoping it to CurbRamp would otherwise silently drop every CurbRamp label.
+      val resp = route(app, FakeRequest(GET, "/v3/api/rawLabels?tags=CurbRamp:APS")).get
       status(resp) mustBe BAD_REQUEST
       (contentAsJson(resp) \ "parameter").as[String] mustBe "tags"
     }

--- a/test/controllers/api/RawLabelsApiSpec.scala
+++ b/test/controllers/api/RawLabelsApiSpec.scala
@@ -82,8 +82,18 @@ class RawLabelsApiSpec extends PlaySpec with GuiceOneAppPerSuite {
       (contentAsJson(resp) \ "type").as[String] mustBe "FeatureCollection"
     }
 
-    "accept both scoped and bare tags entries" in {
-      val resp = route(app, FakeRequest(GET, s"/v3/api/rawLabels?$tinyBbox&tags=CurbRamp:narrow,uneven surface")).get
+    "accept both scoped and unscoped tags entries, one per repeated parameter" in {
+      val url  = s"/v3/api/rawLabels?$tinyBbox&tags=CurbRamp:narrow&tags=uneven surface"
+      val resp = route(app, FakeRequest(GET, url)).get
+      status(resp) mustBe OK
+      (contentAsJson(resp) \ "type").as[String] mustBe "FeatureCollection"
+    }
+
+    "take a tag containing a comma as one tag rather than splitting it" in {
+      // Real Signal tag. Split on the comma it would become two tags that match nothing, so the only thing that can
+      // go wrong here is a 400/500 — a body assertion can't tell the two readings apart on an arbitrary DB.
+      val url  = s"/v3/api/rawLabels?$tinyBbox&tags=Signal:yellow box, accessibility features not visible"
+      val resp = route(app, FakeRequest(GET, url)).get
       status(resp) mustBe OK
       (contentAsJson(resp) \ "type").as[String] mustBe "FeatureCollection"
     }
@@ -120,6 +130,12 @@ class RawLabelsApiSpec extends PlaySpec with GuiceOneAppPerSuite {
 
     "reject a scoped tags entry with a missing tag with 400 (parameter=tags)" in {
       val resp = route(app, FakeRequest(GET, "/v3/api/rawLabels?tags=CurbRamp:")).get
+      status(resp) mustBe BAD_REQUEST
+      (contentAsJson(resp) \ "parameter").as[String] mustBe "tags"
+    }
+
+    "reject an empty tags occurrence with 400 (parameter=tags)" in {
+      val resp = route(app, FakeRequest(GET, "/v3/api/rawLabels?tags=narrow&tags=")).get
       status(resp) mustBe BAD_REQUEST
       (contentAsJson(resp) \ "parameter").as[String] mustBe "tags"
     }

--- a/test/js/galleryFilter.test.js
+++ b/test/js/galleryFilter.test.js
@@ -14,6 +14,7 @@ const fs = require('fs');
 const path = require('path');
 
 const SRC_DIR = path.resolve(__dirname, '..', '..', 'public/js');
+const URL_QUERY_SRC = fs.readFileSync(path.join(SRC_DIR, 'common/urlQuery.js'), 'utf8');
 const FILTER_SIDEBAR_SRC = fs.readFileSync(path.join(SRC_DIR, 'common/filter-sidebar/FilterSidebar.js'), 'utf8');
 const GALLERY_FILTER_SRC = fs.readFileSync(path.join(SRC_DIR, 'gallery/src/filter/GalleryFilter.js'), 'utf8');
 
@@ -146,6 +147,7 @@ describe('GalleryFilter', () => {
                 },
             },
         };
+        window.eval(URL_QUERY_SRC); // Defines util.url, which the URL readers/writers depend on.
         window.eval(`${FILTER_SIDEBAR_SRC}\nwindow.FilterSidebar = FilterSidebar;`);
         window.eval(`${GALLERY_FILTER_SRC}\nwindow.GalleryFilter = GalleryFilter;`);
     });
@@ -193,7 +195,25 @@ describe('GalleryFilter', () => {
                 CurbRamp: ['curbramp-tag'], Crosswalk: [], Obstacle: ['obstacle-tag'], NoSidewalk: [],
             });
             expect(filter.getAppliedTagNames()).toEqual(['curbramp-tag', 'obstacle-tag']);
-            expect(currentUrl()).toBe('/gallery?tags=curbramp-tag,obstacle-tag');
+            // One occurrence per tag, so a tag name is free to contain a comma (#4783).
+            expect(currentUrl()).toBe('/gallery?tags=curbramp-tag&tags=obstacle-tag');
+        });
+
+        it('leaves a colon inside a tag name literal rather than percent-encoding it (#4782)', () => {
+            // Real tag shape: the "cycle lane: ..." family carries a colon in the name itself.
+            tagPill('CurbRamp').dataset.tag = 'cycle lane: faded paint';
+            tagPill('CurbRamp').click();
+
+            expect(currentUrl()).toBe('/gallery?tags=cycle+lane:+faded+paint');
+        });
+
+        it('keeps a comma inside a tag name out of the separator position (#4783)', () => {
+            tagPill('CurbRamp').dataset.tag = 'yellow box, accessibility features not visible';
+            tagPill('CurbRamp').click();
+            tagPill('Obstacle').click();
+
+            const tags = new URLSearchParams(window.location.search).getAll('tags');
+            expect(tags).toEqual(['yellow box, accessibility features not visible', 'obstacle-tag']);
         });
 
         it('lists the severities that are left, with "null" for the N/A bucket', () => {

--- a/test/js/mapDownloadControl.test.js
+++ b/test/js/mapDownloadControl.test.js
@@ -5,8 +5,9 @@
  * world, so the source is eval'd into the jsdom global scope with an explicit window epilogue.
  *
  * Coverage: the buildDownloadUrl state→query-parameter mapping (all-selected omission, severity `none` token,
- * validation token mapping, per-type tag pairs, regionId), and the menu behavior — ARIA contract, count line and
- * zero-count disabling, keyboard navigation, outside-click close, download anchor URLs, and activity logging.
+ * validation token mapping, one repeated `tags` parameter per tag, regionId), and the panel behavior — the
+ * disclosure ARIA contract, count line and zero-count disabling, keyboard navigation, outside-click close,
+ * download anchor URLs, the post-click busy state, and activity logging.
  */
 
 const fs = require('fs');
@@ -29,26 +30,32 @@ const ALL_TYPES = [
 
 const ALL_VALIDATIONS = ['correct', 'incorrect', 'unsure', 'unvalidated'];
 
+/** The four severity toggles the sidebar renders: N/A, then 1-3. */
+const ALL_SEVERITIES = [0, 1, 2, 3];
+
 /**
  * Builds a FilterSidebar.getState()-shaped object. Defaults model "everything selected, no tags".
  * @param {object} [overrides]
- * @returns {{severities: number[], sections: object, tags: object}}
+ * @returns {{severities: number[], allSeverities: number[], sections: object, tags: object,
+ *      allLabelTypes: string[]}}
  */
-function makeState({ severities = [0, 1, 2, 3], labelTypes = ALL_TYPES, validations = ALL_VALIDATIONS,
+function makeState({ severities = ALL_SEVERITIES, labelTypes = ALL_TYPES, validations = ALL_VALIDATIONS,
     tags = {} } = {}) {
     const tagState = {};
     for (const labelType of ALL_TYPES) tagState[labelType] = tags[labelType] ?? [];
     return {
         severities,
+        allSeverities: ALL_SEVERITIES,
         sections: { 'label-type': labelTypes, 'label-validations': validations, streets: ['audited-street'] },
         tags: tagState,
+        allLabelTypes: ALL_TYPES,
     };
 }
 
 /** Parses the query string of a built URL. */
 const queryOf = (url) => new URLSearchParams(url.split('?')[1]);
 
-/** Flushes pending promise microtasks / zero-delay timeouts (the outside-click listener defers registration). */
+/** Flushes pending promise microtasks / zero-delay timeouts (several listeners defer registration). */
 const flushTimeouts = () => new Promise((resolve) => setTimeout(resolve, 0));
 
 describe('MapDownloadControl.buildDownloadUrl', () => {
@@ -78,6 +85,12 @@ describe('MapDownloadControl.buildDownloadUrl', () => {
         expect(queryOf(url).get('filetype')).toBe('csv');
     });
 
+    test('measures "all selected" against the rendered options, not a fixed count', () => {
+        // A host that renders only severities 1-3 has "all selected" at three, not four.
+        const state = { ...makeState({ severities: [1, 2, 3] }), allSeverities: [1, 2, 3] };
+        expect(queryOf(MapDownloadControl.buildDownloadUrl(state, { format: 'geojson' })).has('severity')).toBe(false);
+    });
+
     test('serializes severities sorted, with 0 as the none token', () => {
         const url = MapDownloadControl.buildDownloadUrl(makeState({ severities: [3, 0] }), { format: 'geojson' });
         expect(queryOf(url).get('severity')).toBe('none,3');
@@ -94,10 +107,28 @@ describe('MapDownloadControl.buildDownloadUrl', () => {
         expect(queryOf(url).get('validationStatus')).toBe('validated_incorrect');
     });
 
-    test('serializes tags as LabelType:tag pairs, preserving spaces and colons in tag names', () => {
+    test('sends one repeated tags parameter per tag, scoped to its label type', () => {
         const url = MapDownloadControl.buildDownloadUrl(
-            makeState({ tags: { CurbRamp: ['narrow'], Crosswalk: ['parallel lines:yes'] } }), { format: 'geojson' });
-        expect(queryOf(url).get('tags')).toBe('CurbRamp:narrow,Crosswalk:parallel lines:yes');
+            makeState({ tags: { CurbRamp: ['narrow', 'steep'], Crosswalk: ['parallel lines:yes'] } }),
+            { format: 'geojson' });
+        expect(queryOf(url).getAll('tags'))
+            .toEqual(['CurbRamp:narrow', 'CurbRamp:steep', 'Crosswalk:parallel lines:yes']);
+    });
+
+    test('keeps a tag name containing a comma in one piece', () => {
+        // A comma-separated list would shred this real Signal tag into two tags that match nothing.
+        const tag = 'yellow box, accessibility features not visible';
+        const url = MapDownloadControl.buildDownloadUrl(makeState({ tags: { Signal: [tag] } }), { format: 'geojson' });
+        expect(queryOf(url).getAll('tags')).toEqual([`Signal:${tag}`]);
+    });
+
+    test('tagging one type does not narrow the download to that type', () => {
+        // The sidebar leaves the untagged types showing in full, so the download must not add a labelType filter;
+        // the endpoint reads a scoped tag as narrowing only its own type.
+        const url = MapDownloadControl.buildDownloadUrl(
+            makeState({ tags: { CurbRamp: ['narrow'] } }), { format: 'geojson' });
+        expect(queryOf(url).has('labelType')).toBe(false);
+        expect(queryOf(url).getAll('tags')).toEqual(['CurbRamp:narrow']);
     });
 
     test('includes regionId only when provided', () => {
@@ -117,7 +148,7 @@ describe('MapDownloadControl.buildDownloadUrl', () => {
     });
 });
 
-describe('MapDownloadControl menu', () => {
+describe('MapDownloadControl panel', () => {
     let MapDownloadControl;
     let control;
     let container;
@@ -137,8 +168,9 @@ describe('MapDownloadControl menu', () => {
     }
 
     const button = () => container.querySelector('.map-download-control__button');
-    const menu = () => container.querySelector('.map-download-control__menu');
+    const panel = () => container.querySelector('.map-download-control__panel');
     const items = () => [...container.querySelectorAll('.map-download-control__item')];
+    const busyLabel = () => container.querySelector('.map-download-control__label--busy');
 
     beforeEach(() => {
         document.body.innerHTML = '';
@@ -158,26 +190,38 @@ describe('MapDownloadControl menu', () => {
         delete window.i18next;
     });
 
-    test('renders a collapsed menu button with the ARIA menu contract', () => {
+    test('renders a collapsed disclosure wired to its own panel', () => {
         mount();
-        expect(button().getAttribute('aria-haspopup')).toBe('menu');
         expect(button().getAttribute('aria-expanded')).toBe('false');
-        expect(button().getAttribute('aria-controls')).toBe('map-download-menu');
-        expect(menu().hidden).toBe(true);
-        // The visible title is the menu's accessible name.
-        expect(menu().getAttribute('aria-labelledby')).toBe('map-download-title');
-        expect(menu().querySelector('.map-download-control__title').id).toBe('map-download-title');
+        expect(panel().hidden).toBe(true);
+        // A disclosure, not an ARIA menu: the panel holds static text alongside the actions.
+        expect(button().hasAttribute('aria-haspopup')).toBe(false);
+        expect(container.querySelector('[role="menu"], [role="menuitem"]')).toBeNull();
+        expect(panel().getAttribute('role')).toBe('group');
+        // The visible title is the panel's accessible name, and the count line describes it.
+        expect(button().getAttribute('aria-controls')).toBe(panel().id);
+        expect(panel().getAttribute('aria-labelledby'))
+            .toBe(panel().querySelector('.map-download-control__title').id);
+        expect(panel().getAttribute('aria-describedby'))
+            .toBe(panel().querySelector('.map-download-control__count').id);
         expect(items().map((item) => item.dataset.format)).toEqual(['geojson', 'csv', 'shapefile', 'geopackage']);
+    });
+
+    test('gives each instance its own element ids', () => {
+        const first = mount();
+        const firstPanelId = first.querySelector('.map-download-control__panel').id;
+        const second = mount();
+        expect(second.querySelector('.map-download-control__panel').id).not.toBe(firstPanelId);
     });
 
     test('opens on click: expands, renders the count pill + suffix, focuses the first item, and logs', () => {
         mount({ count: 7 });
         button().click();
         expect(button().getAttribute('aria-expanded')).toBe('true');
-        expect(menu().hidden).toBe(false);
-        expect(menu().querySelector('.map-download-control__count-pill').textContent)
+        expect(panel().hidden).toBe(false);
+        expect(panel().querySelector('.map-download-control__count-pill').textContent)
             .toBe('labelmap:download.count[7]');
-        expect(menu().querySelector('.map-download-control__count').textContent)
+        expect(panel().querySelector('.map-download-control__count').textContent)
             .toBe('labelmap:download.count[7]labelmap:download.count-match[7]');
         expect(document.activeElement).toBe(items()[0]);
         expect(window.logWebpageActivity).toHaveBeenCalledWith('Click_module=MapDownload_Open');
@@ -190,7 +234,7 @@ describe('MapDownloadControl menu', () => {
         expect(container.querySelector('.map-download-control__docs-link').hasAttribute('disabled')).toBe(false);
     });
 
-    test('clicking a format downloads the built URL, logs, and closes the menu', () => {
+    test('clicking a format downloads the built URL, logs, and closes the panel', () => {
         mount({ regionId: 42 });
         button().click();
         items().find((item) => item.dataset.format === 'csv').click();
@@ -202,20 +246,40 @@ describe('MapDownloadControl menu', () => {
         expect(params.get('labelType')).toBe('CurbRamp');
         expect(params.get('regionId')).toBe('42');
         expect(window.logWebpageActivity).toHaveBeenCalledWith('Click_module=MapDownload_Download_format=csv');
-        expect(menu().hidden).toBe(true);
+        expect(panel().hidden).toBe(true);
         expect(document.activeElement).toBe(button());
     });
 
-    test('Escape closes the menu and returns focus to the button', () => {
+    test('acknowledges the click with a busy pill and a live-region status, then restores itself', () => {
+        jest.useFakeTimers();
+        try {
+            mount();
+            button().click();
+            items()[0].click();
+
+            expect(button().getAttribute('aria-busy')).toBe('true');
+            expect(busyLabel().hidden).toBe(false);
+            expect(container.querySelector('[role="status"]').textContent).toBe('Preparing your download…');
+
+            jest.advanceTimersByTime(4000);
+            expect(button().getAttribute('aria-busy')).toBe('false');
+            expect(busyLabel().hidden).toBe(true);
+            expect(container.querySelector('[role="status"]').textContent).toBe('');
+        } finally {
+            jest.useRealTimers();
+        }
+    });
+
+    test('Escape closes the panel and returns focus to the button', () => {
         mount();
         button().click();
         items()[0].dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
-        expect(menu().hidden).toBe(true);
+        expect(panel().hidden).toBe(true);
         expect(button().getAttribute('aria-expanded')).toBe('false');
         expect(document.activeElement).toBe(button());
     });
 
-    test('arrow keys cycle through the menu items and wrap', () => {
+    test('arrow keys cycle through the panel items and wrap', () => {
         mount();
         button().click();
         const first = items()[0];
@@ -227,21 +291,51 @@ describe('MapDownloadControl menu', () => {
         expect(document.activeElement).toBe(container.querySelector('.map-download-control__docs-link'));
     });
 
-    test('a click outside the control closes the menu without stealing focus back', async () => {
+    test('Tab closes the panel only after the browser has moved focus on', async () => {
+        mount();
+        button().click();
+        items()[0].dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
+        // Still open during the keydown, so focus does not have to escape a display:none subtree.
+        expect(panel().hidden).toBe(false);
+        await flushTimeouts();
+        expect(panel().hidden).toBe(true);
+    });
+
+    test('a click outside the control closes the panel without stealing focus back', async () => {
         mount();
         button().click();
         await flushTimeouts(); // The outside-click listener registers on a zero-delay timeout.
         document.body.click();
-        expect(menu().hidden).toBe(true);
+        expect(panel().hidden).toBe(true);
         expect(document.activeElement).not.toBe(button());
     });
 
-    test('shows the partial-filter caveat only when the page carries inexpressible deep-link filters', () => {
+    test('does not leave an outside-click listener behind when closed before the timeout fires', async () => {
+        mount();
+        button().click();
+        button().click(); // Close again within the same tick, before the deferred registration runs.
+        const addedAfterClose = jest.spyOn(document, 'addEventListener');
+        await flushTimeouts();
+        expect(addedAfterClose).not.toHaveBeenCalled();
+    });
+
+    test('shows the partial-filter caveat, and describes the panel with it, only when it applies', () => {
         mount({ showsPartialFilterCaveat: true });
-        expect(container.querySelector('.map-download-control__caveat').hidden).toBe(false);
+        const caveat = container.querySelector('.map-download-control__caveat');
+        expect(caveat.hidden).toBe(false);
+        expect(panel().getAttribute('aria-describedby').split(' ')).toContain(caveat.id);
 
         document.body.innerHTML = '';
         mount({ showsPartialFilterCaveat: false });
         expect(container.querySelector('.map-download-control__caveat').hidden).toBe(true);
+        expect(panel().getAttribute('aria-describedby').split(' '))
+            .not.toContain(container.querySelector('.map-download-control__caveat').id);
+    });
+
+    test('warns screen reader users that the docs link opens in a new tab', () => {
+        mount();
+        const link = container.querySelector('.map-download-control__docs-link');
+        expect(link.getAttribute('target')).toBe('_blank');
+        expect(link.textContent).toContain('opens in a new tab');
     });
 });

--- a/test/js/mapSidebarUrlSync.test.js
+++ b/test/js/mapSidebarUrlSync.test.js
@@ -16,15 +16,22 @@ const fs = require('fs');
 const path = require('path');
 
 const SRC_DIR = path.resolve(__dirname, '..', '..', 'public/js');
+const URL_QUERY_SRC = fs.readFileSync(path.join(SRC_DIR, 'common/urlQuery.js'), 'utf8');
 const FILTER_SIDEBAR_SRC = fs.readFileSync(path.join(SRC_DIR, 'common/filter-sidebar/FilterSidebar.js'), 'utf8');
 const MAP_SIDEBAR_SRC = fs.readFileSync(path.join(SRC_DIR, 'ps-map/MapSidebarFilter.js'), 'utf8');
 const URL_SYNC_SRC = fs.readFileSync(path.join(SRC_DIR, 'ps-map/MapSidebarUrlSync.js'), 'utf8');
 const LABEL_DETAIL_SRC = fs.readFileSync(path.join(SRC_DIR, 'common/label-detail/LabelDetail.js'), 'utf8');
 
 const LABEL_TYPES = ['CurbRamp', 'Obstacle'];
-// "shared" appears on both types, mirroring real tags that repeat across types ("narrow" is both a curb ramp's
-// and a sidewalk's).
-const TAGS_BY_TYPE = { CurbRamp: ['narrow', 'shared'], Obstacle: ['shared'] };
+// Three real-world tag shapes the URL contract has to survive: "shared" repeats across types ("narrow" is both a
+// curb ramp's tag and a sidewalk's), "cycle lane: faded paint" carries a colon of its own so the labelType:tag
+// delimiter has to be the *first* colon, and the yellow-box tag carries a comma so the param can't be a
+// comma-joined list (#4783).
+const COMMA_TAG = 'yellow box, accessibility features not visible';
+const TAGS_BY_TYPE = {
+    CurbRamp: ['narrow', 'shared', 'cycle lane: faded paint'],
+    Obstacle: ['shared', COMMA_TAG],
+};
 
 /** Builds the sidebar markup the classes bind to, mirroring the Twirl partial's hooks and default state. */
 function buildFixture() {
@@ -141,6 +148,7 @@ describe('MapSidebarUrlSync', () => {
         window.filterStreetLayer = jest.fn();
         window.toggleLabelLayer = jest.fn();
         window.logWebpageActivity = jest.fn();
+        window.eval(URL_QUERY_SRC); // Defines util.url, which the URL readers/writers depend on.
         window.eval(`${FILTER_SIDEBAR_SRC}\nwindow.FilterSidebar = FilterSidebar;`);
         window.eval(`${MAP_SIDEBAR_SRC}\nwindow.MapSidebarFilter = MapSidebarFilter;`);
         window.eval(`${URL_SYNC_SRC}\nwindow.MapSidebarUrlSync = MapSidebarUrlSync;`);
@@ -326,6 +334,73 @@ describe('MapSidebarUrlSync', () => {
             expect(params.get('streets')).toBe('audited');
         });
 
+        it('leaves the labelType:tag colon literal rather than percent-encoding it (#4782)', () => {
+            build();
+            tagPill('CurbRamp', 'narrow').click();
+            jest.advanceTimersByTime(300);
+
+            expect(search()).toContain('tags=CurbRamp:narrow');
+            expect(search()).not.toContain('%3A');
+        });
+
+        it('round-trips a tag whose own name contains a colon', () => {
+            build();
+            tagPill('CurbRamp', 'cycle lane: faded paint').click();
+            jest.advanceTimersByTime(300);
+
+            // Both colons are literal in the URL; only the first separates the label type from the tag.
+            expect(search()).toContain('tags=CurbRamp:cycle+lane:+faded+paint');
+            expect(search()).not.toContain('%3A');
+
+            window.history.replaceState({}, '', `/labelMap${search()}`);
+            build();
+            expect(Array.from(mapData.selectedTags.CurbRamp)).toEqual(['cycle lane: faded paint']);
+        });
+
+        it('round-trips a tag whose name contains a comma (#4783)', () => {
+            build();
+            tagPill('Obstacle', COMMA_TAG).click();
+            jest.advanceTimersByTime(300);
+
+            // One occurrence per tag, so the comma inside the name is never mistaken for a separator.
+            expect(new URLSearchParams(search()).getAll('tags')).toEqual([`Obstacle:${COMMA_TAG}`]);
+
+            window.history.replaceState({}, '', `/labelMap${search()}`);
+            build();
+            expect(Array.from(mapData.selectedTags.Obstacle)).toEqual([COMMA_TAG]);
+        });
+
+        it('writes one occurrence per tag rather than a comma-joined list', () => {
+            build();
+            tagPill('CurbRamp', 'narrow').click();
+            tagPill('Obstacle', 'shared').click();
+            jest.advanceTimersByTime(300);
+
+            const tags = new URLSearchParams(search()).getAll('tags');
+            expect(tags).toEqual(['CurbRamp:narrow', 'Obstacle:shared']);
+
+            window.history.replaceState({}, '', `/labelMap${search()}`);
+            build();
+            expect(Array.from(mapData.selectedTags.CurbRamp)).toEqual(['narrow']);
+            expect(Array.from(mapData.selectedTags.Obstacle)).toEqual(['shared']);
+        });
+
+        it('still restores a link written in the older comma-joined form', () => {
+            window.history.replaceState({}, '', '/labelMap?tags=CurbRamp:narrow,Obstacle:shared');
+            build();
+
+            expect(Array.from(mapData.selectedTags.CurbRamp)).toEqual(['narrow']);
+            expect(Array.from(mapData.selectedTags.Obstacle)).toEqual(['shared']);
+        });
+
+        it('rescues a comma-carrying tag from an older comma-joined link when it stands alone', () => {
+            // The whole value matches a rendered pill, so it is taken before any comma splitting happens.
+            window.history.replaceState({}, '', `/labelMap?tags=Obstacle:${COMMA_TAG}`);
+            build();
+
+            expect(Array.from(mapData.selectedTags.Obstacle)).toEqual([COMMA_TAG]);
+        });
+
         it('round-trips a tag back onto its own type only', () => {
             build();
             tagPill('CurbRamp', 'shared').click();
@@ -404,11 +479,16 @@ describe('MapSidebarUrlSync', () => {
             jest.advanceTimersByTime(300);
             expect(search()).toContain('severities=1,2,3');
 
-            // Opening a label popup writes labelId without touching the filter params — commas stay readable.
+            // Opening a label popup writes labelId without touching the filter params — the two writers have to
+            // agree byte for byte on how commas and colons are serialized or they rewrite each other's params.
+            tagPill('CurbRamp', 'narrow').click();
+            jest.advanceTimersByTime(300);
             window.LabelDetail.syncUrlLabelId(123);
             expect(search()).toContain('labelId=123');
             expect(search()).toContain('severities=1,2,3');
+            expect(search()).toContain('tags=CurbRamp:narrow');
             expect(search()).not.toContain('%2C');
+            expect(search()).not.toContain('%3A');
 
             // A further filter change keeps the open label's id in the URL.
             checkbox('Obstacle-checkbox').click();

--- a/test/js/urlQuery.test.js
+++ b/test/js/urlQuery.test.js
@@ -1,0 +1,133 @@
+/**
+ * Tests for util.url (public/js/common/urlQuery.js, issues #4782 / #4783).
+ *
+ * The deep-link query rules the page's several URL writers share. They matter twice over: the writers run side by
+ * side on one page and have to serialize identically or they rewrite each other's params, and the tag params carry
+ * free-form label text whose commas and colons must survive a round trip.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const URL_QUERY_SRC = fs.readFileSync(
+    path.resolve(__dirname, '..', '..', 'public/js/common/urlQuery.js'), 'utf8'
+);
+
+describe('util.url', () => {
+    beforeAll(() => {
+        window.eval(URL_QUERY_SRC);
+    });
+
+    describe('serialize', () => {
+        it('leaves commas and colons literal', () => {
+            const params = new URLSearchParams();
+            params.set('severities', '1,2,3');
+            params.set('tags', 'CurbRamp:narrow');
+
+            expect(window.util.url.serialize(params)).toBe('severities=1,2,3&tags=CurbRamp:narrow');
+        });
+
+        it('still escapes what actually needs escaping', () => {
+            const params = new URLSearchParams();
+            params.set('tags', 'a&b=c#d');
+
+            const query = window.util.url.serialize(params);
+            expect(query).toBe('tags=a%26b%3Dc%23d');
+            // The escaping has to survive a parse, or a tag could smuggle in another param.
+            expect(new URLSearchParams(query).get('tags')).toBe('a&b=c#d');
+        });
+
+        it('returns an empty string when there is nothing to serialize', () => {
+            expect(window.util.url.serialize(new URLSearchParams())).toBe('');
+        });
+    });
+
+    describe('setRepeated', () => {
+        it('writes one occurrence per value', () => {
+            const params = new URLSearchParams();
+            window.util.url.setRepeated(params, 'tags', ['CurbRamp:narrow', 'Signal:yellow box, and more']);
+
+            expect(params.getAll('tags')).toEqual(['CurbRamp:narrow', 'Signal:yellow box, and more']);
+        });
+
+        it('replaces any occurrences already there, and deletes the param for an empty list', () => {
+            const params = new URLSearchParams('tags=old&tags=older&labelTypes=CurbRamp');
+            window.util.url.setRepeated(params, 'tags', ['new']);
+            expect(params.getAll('tags')).toEqual(['new']);
+
+            window.util.url.setRepeated(params, 'tags', []);
+            expect(params.has('tags')).toBe(false);
+            expect(params.get('labelTypes')).toBe('CurbRamp'); // Other params untouched.
+        });
+    });
+
+    describe('getRepeated', () => {
+        const KNOWN = ['narrow', 'yellow box, accessibility features not visible', 'cycle lane: faded paint'];
+        const isValid = (value) => KNOWN.includes(value);
+
+        it('distinguishes an absent param from one that selects nothing', () => {
+            expect(window.util.url.getRepeated(new URLSearchParams(''), 'tags', isValid)).toBeNull();
+            expect(window.util.url.getRepeated(new URLSearchParams('tags='), 'tags', isValid)).toEqual([]);
+        });
+
+        it('reads the repeated form', () => {
+            const params = new URLSearchParams();
+            params.append('tags', 'narrow');
+            params.append('tags', KNOWN[1]);
+
+            expect(window.util.url.getRepeated(params, 'tags', isValid)).toEqual(['narrow', KNOWN[1]]);
+        });
+
+        it('falls back to splitting an older comma-joined value', () => {
+            const params = new URLSearchParams(`tags=narrow,${KNOWN[2]}`);
+
+            expect(window.util.url.getRepeated(params, 'tags', isValid)).toEqual(['narrow', KNOWN[2]]);
+        });
+
+        it('takes a whole valid occurrence before splitting, so a comma inside a value survives', () => {
+            const params = new URLSearchParams();
+            params.append('tags', KNOWN[1]);
+
+            expect(window.util.url.getRepeated(params, 'tags', isValid)).toEqual([KNOWN[1]]);
+        });
+
+        it('drops values the page does not recognize', () => {
+            const params = new URLSearchParams('tags=narrow,bogus&tags=alsoBogus');
+
+            expect(window.util.url.getRepeated(params, 'tags', isValid)).toEqual(['narrow']);
+        });
+
+        it('trims surrounding whitespace, in both forms', () => {
+            const params = new URLSearchParams('tags= narrow , cycle lane: faded paint ');
+
+            expect(window.util.url.getRepeated(params, 'tags', isValid)).toEqual(['narrow', KNOWN[2]]);
+        });
+    });
+
+    describe('replaceQuery', () => {
+        it('rewrites the query in place, keeping the path and hash, without a history entry', () => {
+            window.history.replaceState({}, '', '/labelMap?tags=CurbRamp:narrow#anchor');
+            const before = window.history.length;
+
+            const url = new URL(window.location);
+            url.searchParams.set('labelId', '42');
+            window.util.url.replaceQuery(url);
+
+            expect(window.location.pathname).toBe('/labelMap');
+            expect(window.location.search).toBe('?tags=CurbRamp:narrow&labelId=42');
+            expect(window.location.hash).toBe('#anchor');
+            expect(window.history.length).toBe(before);
+        });
+
+        it('drops the "?" entirely once the last param is gone', () => {
+            window.history.replaceState({}, '', '/labelMap?labelId=42');
+
+            const url = new URL(window.location);
+            url.searchParams.delete('labelId');
+            window.util.url.replaceQuery(url);
+
+            expect(window.location.search).toBe('');
+            expect(window.location.pathname).toBe('/labelMap');
+        });
+    });
+});

--- a/test/models/api/TagFilterForApiSpec.scala
+++ b/test/models/api/TagFilterForApiSpec.scala
@@ -1,0 +1,91 @@
+package models.api
+
+import org.scalatest.EitherValues
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+/**
+ * Pure (no DB, no app boot) test for `TagFilterForApi.parse`, the `/v3/api/rawLabels` `tags` parameter's
+ * parse-and-validate step.
+ *
+ * The rules under test: one occurrence is one entry; an entry is validated against the tag vocabulary *before* any
+ * comma splitting, so a tag name containing a comma survives intact while an older comma-joined link still resolves;
+ * and an unknown or mis-scoped tag is a 400 naming the parameter rather than a silently-empty match.
+ */
+class TagFilterForApiSpec extends AnyFunSuite with Matchers with EitherValues {
+
+  private val labelTypes = Set("CurbRamp", "Obstacle", "Signal")
+  private val commaTag   = "yellow box, accessibility features not visible"
+  private val vocabulary = Map(
+    "CurbRamp" -> Set("narrow", "steep"),
+    "Obstacle" -> Set("narrow", "trash can"),
+    "Signal"   -> Set("APS", commaTag, "cycle lane: faded paint")
+  )
+
+  private def parse(entries: String*) = TagFilterForApi.parse(entries.toList, labelTypes, vocabulary)
+
+  test("no occurrences parse to no filter") {
+    parse() shouldBe Right(None)
+  }
+
+  test("an unscoped entry names a tag on any label type") {
+    parse("narrow").value shouldBe Some(Seq(TagFilterForApi(None, "narrow")))
+  }
+
+  test("a scoped entry names a tag of its own label type") {
+    parse("CurbRamp:narrow").value shouldBe Some(Seq(TagFilterForApi(Some("CurbRamp"), "narrow")))
+  }
+
+  test("a tag name containing a comma is validated whole, never split") {
+    parse(s"Signal:$commaTag").value shouldBe Some(Seq(TagFilterForApi(Some("Signal"), commaTag)))
+    parse(commaTag).value shouldBe Some(Seq(TagFilterForApi(None, commaTag)))
+  }
+
+  test("a tag name containing a colon is an unscoped tag when its prefix is no label type") {
+    parse("cycle lane: faded paint").value shouldBe Some(Seq(TagFilterForApi(None, "cycle lane: faded paint")))
+  }
+
+  test("an older comma-joined entry is split once it fails to validate whole") {
+    parse("narrow,trash can").value shouldBe
+      Some(Seq(TagFilterForApi(None, "narrow"), TagFilterForApi(None, "trash can")))
+  }
+
+  test("an older comma-joined entry may mix scoped and unscoped pieces") {
+    parse("CurbRamp:narrow,trash can").value shouldBe
+      Some(Seq(TagFilterForApi(Some("CurbRamp"), "narrow"), TagFilterForApi(None, "trash can")))
+  }
+
+  test("an unknown tag is an error naming the tags parameter") {
+    val error = parse("definitely-not-a-tag").left.value
+    error.parameter shouldBe Some("tags")
+    error.detail should include("definitely-not-a-tag")
+  }
+
+  test("a tag scoped to a label type that does not carry it is an error") {
+    val error = parse("CurbRamp:APS").left.value
+    error.parameter shouldBe Some("tags")
+    error.detail should include("not a tag of label type 'CurbRamp'")
+  }
+
+  test("a comma-joined entry with one unknown piece is an error naming that piece") {
+    val error = parse("narrow,bogus").left.value
+    error.parameter shouldBe Some("tags")
+    error.detail should include("bogus")
+  }
+
+  test("an empty occurrence is an error") {
+    parse("narrow", "").left.value.parameter shouldBe Some("tags")
+  }
+
+  test("a scoped entry missing its tag is an error") {
+    val error = parse("CurbRamp:").left.value
+    error.parameter shouldBe Some("tags")
+    error.detail should include("Missing tag")
+  }
+
+  test("surrounding whitespace is trimmed in both forms") {
+    parse("  narrow  ").value shouldBe Some(Seq(TagFilterForApi(None, "narrow")))
+    parse("narrow , trash can").value shouldBe
+      Some(Seq(TagFilterForApi(None, "narrow"), TagFilterForApi(None, "trash can")))
+  }
+}

--- a/test/models/label/RawLabelTagFilterSpec.scala
+++ b/test/models/label/RawLabelTagFilterSpec.scala
@@ -1,0 +1,71 @@
+package models.label
+
+import models.api.TagFilterForApi
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+/**
+ * Pure (no DB, no app boot) test for the SQL that `/v3/api/rawLabels` builds from its `tags` parameter.
+ *
+ * The clause is string-built and never surfaces in a response, so nothing else can catch a mistake in it: the
+ * endpoint answers 200 with a well-formed FeatureCollection whichever way the disjuncts land, which is exactly how
+ * the LabelMap's download came to disagree with the map it was downloading (#4095).
+ *
+ * The rule under test: an entry scoped to a label type narrows only that type, and types nobody scoped come back
+ * unnarrowed — mirroring the sidebar, where tag pills chosen under `CurbRamp` say nothing about `Obstacle`.
+ */
+class RawLabelTagFilterSpec extends AnyFunSuite with Matchers {
+
+  private def scoped(labelType: String, tag: String) = TagFilterForApi(Some(labelType), tag)
+  private def unscoped(tag: String)                  = TagFilterForApi(None, tag)
+
+  test("an unscoped tag narrows every label type") {
+    LabelTable.tagWhereClause(Seq(unscoped("narrow"))) shouldBe "('narrow' = ANY(label.tags))"
+  }
+
+  test("unscoped tags are OR'd together") {
+    LabelTable.tagWhereClause(Seq(unscoped("narrow"), unscoped("uneven surface"))) shouldBe
+      "('narrow' = ANY(label.tags) OR 'uneven surface' = ANY(label.tags))"
+  }
+
+  test("a scoped tag narrows its own type and lets every other type through") {
+    LabelTable.tagWhereClause(Seq(scoped("CurbRamp", "narrow"))) shouldBe
+      "((label_type.label_type = 'CurbRamp' AND ('narrow' = ANY(label.tags))) OR " +
+      "label_type.label_type NOT IN ('CurbRamp'))"
+  }
+
+  test("each scoped type is narrowed only by its own tags") {
+    LabelTable.tagWhereClause(
+      Seq(scoped("CurbRamp", "narrow"), scoped("Obstacle", "trash can"), scoped("CurbRamp", "steep"))
+    ) shouldBe
+      "((label_type.label_type = 'CurbRamp' AND ('narrow' = ANY(label.tags) OR 'steep' = ANY(label.tags))) OR " +
+      "(label_type.label_type = 'Obstacle' AND ('trash can' = ANY(label.tags))) OR " +
+      "label_type.label_type NOT IN ('CurbRamp', 'Obstacle'))"
+  }
+
+  test("an unscoped tag still applies to the scoped types alongside their own tags") {
+    LabelTable.tagWhereClause(Seq(scoped("CurbRamp", "narrow"), unscoped("uneven surface"))) shouldBe
+      "((label_type.label_type = 'CurbRamp' AND " +
+      "('narrow' = ANY(label.tags) OR 'uneven surface' = ANY(label.tags))) OR " +
+      "(label_type.label_type NOT IN ('CurbRamp') AND ('uneven surface' = ANY(label.tags))))"
+  }
+
+  test("the clause does not depend on the order the entries arrived in") {
+    val entries = Seq(scoped("Obstacle", "trash can"), unscoped("narrow"), scoped("CurbRamp", "steep"))
+    LabelTable.tagWhereClause(entries) shouldBe LabelTable.tagWhereClause(entries.reverse)
+  }
+
+  test("tag text is escaped, so a quote cannot break out of its literal") {
+    LabelTable.tagWhereClause(Seq(unscoped("no one's ramp"))) shouldBe "('no one''s ramp' = ANY(label.tags))"
+  }
+
+  test("a tag carrying a comma or a colon survives as a single literal") {
+    // Real tags: Signal's "yellow box, ..." and the "cycle lane: ..." family.
+    LabelTable.tagWhereClause(Seq(scoped("Signal", "yellow box, accessibility features not visible"))) shouldBe
+      "((label_type.label_type = 'Signal' AND " +
+      "('yellow box, accessibility features not visible' = ANY(label.tags))) OR " +
+      "label_type.label_type NOT IN ('Signal'))"
+    LabelTable.tagWhereClause(Seq(unscoped("cycle lane: faded paint"))) shouldBe
+      "('cycle lane: faded paint' = ANY(label.tags))"
+  }
+}


### PR DESCRIPTION
Follow-up to #4775, which is already merged. Resolves #4782 and #4783.

Started as a code review of the LabelMap download button and turned up two bugs that made the
downloaded file disagree with the map it came from, plus a sibling bug in the deep-link URLs.

## ⚠️ Changes to documented `/v3` and page-URL behavior

@misaugstad — these change behavior people may already be scripting against. v3 is a preview
surface, so per convention they're made in place, and each carries a "Changed August 2026" note
in the API docs.

1. **A scoped `tags` entry now narrows only its own label type.** `tags=CurbRamp:narrow`
   previously excluded every label type it didn't name; it now leaves them unfiltered. Pair it
   with `labelType=CurbRamp` for the old, stricter meaning.
2. **`tags` is repeatable, not comma-separated** — `?tags=a&tags=b`, on `/v3/api/rawLabels`,
   `/gallery`, and the LabelMap deep link. Old comma-joined links still work on all three
   surfaces (see #4783). The closed-value params (`labelType`, `severity`, `validationStatus`)
   stay comma-joined.
3. **`tags` values are validated against the city's tags.** An unknown tag — or a tag scoped to
   a label type that doesn't carry it — is now a 400 naming the parameter, instead of a
   silently-empty result that looks identical to "no data". Validation happens *before* the
   legacy comma-splitting fallback, which is what lets a tag name containing a comma survive
   whole while `tags=a,b` from an old link still resolves to its two tags. Validation is against
   the city's full tag list, not the UI-facing one: a tag a city hides from its menus
   (`config.excluded_tags`) may still be carried by existing labels.

(A fourth strictness change people may notice — unknown or empty `labelType` values returning a
400 — shipped in #4775; this PR only adds the "Changed August 2026" docs note for it.)

Also cross-cutting, though not a contract change anyone should be relying on: `filetype=csv`
now honors `inline=true` on **every** v3 endpoint (it previously forced an attachment), and
GeoJSON downloads are named `.geojson` rather than `.json`.

## The two bugs

**Scoped tags dropped the untagged types.** The sidebar narrows each label type by its own tag
pills and leaves the rest alone; the endpoint OR'd the scoped conditions, so any type without a
scoped entry couldn't match. Ticking "narrow" under CurbRamp left every obstacle on screen and
none in the file — while the menu had just promised a count that included them.

Verified against the dev DB (Teaneck):

| request | features | CurbRamp | Obstacle | types |
|---|---|---|---|---|
| no filter | 21653 | 6710 | 459 | 9 |
| `tags=CurbRamp:missing tactile warning` | 15351 | **408** | **459** | **9** |
| `+ labelType=CurbRamp` | 408 | 408 | 0 | 1 |

408 is exactly what the DB reports for that tag; obstacles are untouched.

**A comma in a tag name was shredded** (#4783). `yellow box, accessibility features not visible`
is a real Signal tag. Split on its comma it becomes two names matching nothing, and the filter
is silently dropped — an unfiltered page looks identical to a page with nothing to filter. Hit
`/v3/api/rawLabels`, the Gallery deep link, and the LabelMap deep link. Not reproducible on the
dev DB: both seeded cities list that tag in `config.excluded_tags`, so it never renders locally,
but cities that don't exclude it are affected.

## Rest of the review

- `timestampedFilename` now covers all ten download endpoints rather than the two it shipped
  with — its own docstring says colons break Windows filenames.
- A malformed `?regions=` is dropped instead of forwarded as `regionId=NaN`, which a plain
  anchor download shows the user as nothing happening. Picking a format now acknowledges the
  click with a busy pill and a live-region status.
- **Accessibility**: the panel is a disclosure, not an ARIA menu — it mixes static text with
  actions, and `role="menu"` may only contain menu items. The caveat is wired into
  `aria-describedby`, Tab defers the close so focus never escapes a hidden subtree, and the docs
  link says it opens in a new tab.
- "All selected" is measured against what the sidebar actually rendered (new `allSeverities` /
  `allLabelTypes` on `FilterSidebar.getState()`) instead of a hardcoded four.
- Per-instance element ids; the outside-click listener can't outlive a fast close; every timer
  the control sets is tracked and cleared on teardown.

## `util.url` (#4782)

`tags=CurbRamp%3Anarrow` should read `tags=CurbRamp:narrow` — commas were already decoded for
readability, colons weren't, though RFC 3986 allows both unencoded in a query.

Four writers touch these query strings (`MapSidebarUrlSync` and `LabelDetail.syncUrlLabelId` run
side by side on the LabelMap, `GalleryFilter` builds the Gallery's, `StorySection` strips its own
marker after a sign-in bounce), each with its own copy of the serialization and a comment warning
the copies mustn't drift. They now share `util.url` (`common/urlQuery.js`), −34/+29 at the call
sites. `StorySection` was the latent case: it re-encoded, so returning from sign-in would have
undone the readable form until the next filter change.

## Testing

- **Scala**: new `RawLabelTagFilterSpec` (8) pins the tag SQL directly — the endpoint answers
  200 with a well-formed FeatureCollection whichever way the disjuncts land, so nothing else
  catches a mistake there. New `TagFilterForApiSpec` (13) pins the parse-and-validate rules,
  including validate-before-split and the legacy comma fallback. New `GalleryPageSpec` (5) reads
  the tag vocabulary off the page and round-trips it, proving `List[String] ?= List()` binds
  every occurrence. `RawLabelsApiSpec` +5, covering the new 400s and the legacy form. 44 pass,
  1 cancels on a DB that can't render the comma tag.
- **JS**: new `urlQuery.test.js` (13); `mapDownloadControl` and `mapSidebarUrlSync` extended for
  the comma/colon cases, the busy state, and the listener leak. 507 pass across 42 suites.
- `scalafmtCheckAll`, compile, ESLint, Stylelint, HTMLHint, locale parity, evolutions lint: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
