### PR TITLE
Attach the CSRF token only to genuinely same-origin fetches

### DIFF
--- a/public/js/common/AppManager.js
+++ b/public/js/common/AppManager.js
@@ -117,7 +117,11 @@ class AppManager {
     // hosts reject, so we skip them rather than maintaining an allowlist of hosts to exclude (#4232).
     const originalFetch = window.fetch;
     window.fetch = function (url, options = {}) {
-      const requestUrl = (typeof url === 'string') ? url : url.url;
+      // `fetch` accepts a string, a `URL`, or a `Request`. Only a `Request` carries its address on `.url`; a `URL`
+      // has to be stringified. Reading `.url` off a `URL` gives undefined, which resolves to <origin>/undefined and
+      // so reads as same-origin -- meaning a cross-origin `URL` would be handed a token, the very case above. The
+      // `typeof` guard is for non-browser hosts (jsdom); any browser with `fetch` also has `Request`.
+      const requestUrl = (typeof Request !== 'undefined' && url instanceof Request) ? url.url : String(url);
 
       // Resolve against the page origin so relative URLs (our routes) are correctly treated as same-origin.
       let isSameOrigin;

--- a/public/js/common/AppManager.js
+++ b/public/js/common/AppManager.js
@@ -136,6 +136,9 @@ class AppManager {
         return originalFetch(url, options);
       }
 
+      // Known limitation: per the fetch spec, an init `headers` replaces a `Request` argument's own headers
+      // wholesale, so a same-origin `Request` constructed with its own headers loses them here. No call site passes
+      // a `Request`; if one ever needs to, merge `url.headers` into this object.
       const newOptions = {
         ...options,
         headers: {

--- a/public/js/ps-map/createPSMap.js
+++ b/public/js/ps-map/createPSMap.js
@@ -146,10 +146,7 @@ function createPSMap($, params) {
    * @returns {Promise<object>} The parsed GeoJSON FeatureCollection.
    */
   async function fetchLabelFeed(url) {
-    // Pass a string, never the URL object callers build: AppManager's CSRF wrapper around window.fetch reads
-    // `url.url` for any non-string argument, which is undefined for a URL, so its same-origin check resolves
-    // against a bogus path instead of the real one.
-    const response = await fetch(String(url));
+    const response = await fetch(url);
     if (!response.ok) throw new Error(`Label feed ${url} failed with HTTP ${response.status}.`);
     try {
       return await response.json();

--- a/public/js/ps-map/createPSMap.js
+++ b/public/js/ps-map/createPSMap.js
@@ -7,13 +7,13 @@
  * @param {string} params.mapStyle - URL of a Mapbox style.
  * @param {string} [params.mapboxApiKey] - Mapbox API key to use for the map.
  * @param {string} [params.neighborhoodFillMode] - One of 'singleColor' or 'completionRate'.
- * @param {string} [params.neighborhoodsURL] - URL of the endpoint containing neighborhood boundaries.
- * @param {string} params.completionRatesURL - URL of the endpoint containing neighborhood completion rates.
+ * @param {string|URL} [params.neighborhoodsURL] - URL of the endpoint containing neighborhood boundaries.
+ * @param {string|URL} params.completionRatesURL - URL of the endpoint containing neighborhood completion rates.
  * @param {boolean} [params.loadCities] - Whether to load deployment cities on the map.
  * @param {boolean} [params.animateCityFit=true] - Whether the fit to all deployment cities is animated. Set false to
  *     have the world view simply appear, with no flight out from the city's own center.
- * @param {string} [params.streetsURL] - URL of the endpoint containing streets.
- * @param {string} [params.labelsURL] - URL of the endpoint containing labels.
+ * @param {string|URL} [params.streetsURL] - URL of the endpoint containing streets.
+ * @param {string|URL} [params.labelsURL] - URL of the endpoint containing labels.
  * @param {number} [params.zoomCorrection=0] - Amount to increase default zoom to account for different map dimensions.
  * @param {boolean} [params.scrollWheelZoom=true] - Whether to allow zooming with the scroll wheel.
  * @param {string} [params.mapboxLogoLocation=bottom-left] - 'top-left', 'top-right', 'bottom-left', or 'bottom-right'.

--- a/test/js/README.md
+++ b/test/js/README.md
@@ -26,6 +26,9 @@ Also covered, beyond the api-docs previews:
   fork, the popover's ARIA contract and focus management, clipboard/intents, and activity logging. `ShareWidget` is a
   top-level `class` declaration (not a `window.X = ...` assignment), so the test evals the source into the jsdom
   global scope instead of using `loadGlobalScript`.
+- `common/AppManager.js` → `appManagerCsrfFetch.test.js` — the `window.fetch` CSRF wrapper (#4232): the token must
+  reach same-origin requests and *only* same-origin requests, across all three argument types `fetch` accepts
+  (string, `URL`, `Request`). jsdom implements neither `fetch` nor `Request`, so the test supplies both.
 - `community/*.js` → `communityListPage.test.js` — the /stories + /routes listing pages' client layer (#4688):
   search filtering (hidden attr, live count, no-results), sort orders and tie-breaks, localized dates, type-chip
   tinting, the read-more clamp toggle, view-label popup-vs-navigation routing, and the copy-share-link fallbacks.

--- a/test/js/appManagerCsrfFetch.test.js
+++ b/test/js/appManagerCsrfFetch.test.js
@@ -37,12 +37,12 @@ describe('AppManager CSRF fetch wrapper', () => {
 
     /** The options object the wrapper passed to the underlying fetch on its most recent call. */
     function forwardedOptions() {
-        return originalFetch.mock.calls[0][1];
+        return originalFetch.mock.lastCall[1];
     }
 
     /** The first argument (the URL/Request) the wrapper passed to the underlying fetch on its most recent call. */
     function forwardedTarget() {
-        return originalFetch.mock.calls[0][0];
+        return originalFetch.mock.lastCall[0];
     }
 
     beforeEach(() => {
@@ -113,8 +113,8 @@ describe('AppManager CSRF fetch wrapper', () => {
             expect(forwardedOptions()).not.toHaveProperty(['headers', 'Csrf-Token']);
         });
 
-        // The case #4232 was written to prevent, and the one the wrapper used to get wrong: reading `.url` off a URL
-        // yields undefined, which resolves to <origin>/undefined and so passes the same-origin check.
+        // The regression this file exists to pin: a wrapper that reads `.url` off a URL gets undefined, which
+        // resolves to <origin>/undefined, passes the same-origin check, and hands the token to a cross-origin host.
         test('URL object', async () => {
             await window.fetch(new URL(CROSS_ORIGIN));
 

--- a/test/js/appManagerCsrfFetch.test.js
+++ b/test/js/appManagerCsrfFetch.test.js
@@ -1,0 +1,171 @@
+/**
+ * Tests for the `window.fetch` CSRF wrapper installed by public/js/common/AppManager.js (`_setupCSRF`).
+ *
+ * The wrapper attaches Play's `Csrf-Token` header to same-origin requests only. Cross-origin requests must be left
+ * strictly alone: the token is meaningless to a third party, and adding a custom header turns a simple request into
+ * one that needs a CORS preflight, which several of the hosts we talk to (Mapillary, Infra3d, sibling city servers)
+ * reject (#4232).
+ *
+ * `fetch` accepts three argument types -- string, `URL`, `Request` -- and the same-origin decision has to be right
+ * for all three. These tests pin that matrix: same-origin string/URL/Request receive the token, cross-origin
+ * string/URL/Request do not.
+ *
+ * Runs under jsdom (jest.config.js). jsdom implements neither `fetch` nor `Request`, so both are supplied here: the
+ * fetch under test is a jest.fn() standing in for the browser's, captured by the wrapper as its `originalFetch`.
+ */
+
+const { loadGlobalScript } = require('./loadGlobalScript');
+
+const CSRF_TOKEN = 'test-csrf-token';
+const CROSS_ORIGIN = 'https://graph.mapillary.com/images?fields=id';
+
+// jsdom ships no Fetch API, so `Request` is absent. Model the one behavior the wrapper relies on: a Request resolves
+// its input against the document's base URL and exposes the resulting absolute address as `.url`. That matches the
+// browser, and it is what distinguishes a Request (address on `.url`) from a `URL` (address via stringification).
+if (typeof global.Request === 'undefined') {
+    global.Request = class Request {
+        constructor(input) {
+            this.url = new URL(String(input), window.location.origin).href;
+        }
+    };
+}
+
+describe('AppManager CSRF fetch wrapper', () => {
+    let originalFetch;
+    /** Absolute same-origin URL string, built from jsdom's actual origin so the tests do not hardcode one. */
+    let sameOriginUrl;
+
+    /** The options object the wrapper passed to the underlying fetch on its most recent call. */
+    function forwardedOptions() {
+        return originalFetch.mock.calls[0][1];
+    }
+
+    /** The first argument (the URL/Request) the wrapper passed to the underlying fetch on its most recent call. */
+    function forwardedTarget() {
+        return originalFetch.mock.calls[0][0];
+    }
+
+    beforeEach(() => {
+        sameOriginUrl = `${window.location.origin}/label/geo`;
+
+        // AppManager's _setupCSRF also configures jQuery; stub just enough for it to run under jsdom.
+        global.$ = { ajaxSetup: jest.fn() };
+
+        // Install a stand-in for the browser's fetch *before* loading AppManager, since the wrapper closes over
+        // whatever `window.fetch` is at setup time and delegates to it.
+        originalFetch = jest.fn(() => Promise.resolve({ ok: true }));
+        window.fetch = originalFetch;
+
+        loadGlobalScript('public/js/common/AppManager.js');
+        window.appManager._setupCSRF(CSRF_TOKEN);
+    });
+
+    afterEach(() => {
+        delete global.$;
+        delete window.appManager;
+        delete window.fetch;
+    });
+
+    describe('same-origin requests get the token', () => {
+        test('relative string (our own routes)', async () => {
+            await window.fetch('/label/geo');
+
+            expect(forwardedOptions().headers['Csrf-Token']).toBe(CSRF_TOKEN);
+        });
+
+        test('absolute same-origin string', async () => {
+            await window.fetch(sameOriginUrl);
+
+            expect(forwardedOptions().headers['Csrf-Token']).toBe(CSRF_TOKEN);
+        });
+
+        test('URL object', async () => {
+            await window.fetch(new URL(sameOriginUrl));
+
+            expect(forwardedOptions().headers['Csrf-Token']).toBe(CSRF_TOKEN);
+        });
+
+        test('Request object', async () => {
+            await window.fetch(new Request('/label/geo'));
+
+            expect(forwardedOptions().headers['Csrf-Token']).toBe(CSRF_TOKEN);
+        });
+
+        test('existing options and headers are preserved alongside the token', async () => {
+            await window.fetch('/label/geo', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: '{}',
+            });
+
+            expect(forwardedOptions()).toEqual({
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'Csrf-Token': CSRF_TOKEN },
+                body: '{}',
+            });
+        });
+    });
+
+    describe('cross-origin requests are left untouched', () => {
+        test('string', async () => {
+            await window.fetch(CROSS_ORIGIN);
+
+            expect(forwardedOptions()).not.toHaveProperty(['headers', 'Csrf-Token']);
+        });
+
+        // The case #4232 was written to prevent, and the one the wrapper used to get wrong: reading `.url` off a URL
+        // yields undefined, which resolves to <origin>/undefined and so passes the same-origin check.
+        test('URL object', async () => {
+            await window.fetch(new URL(CROSS_ORIGIN));
+
+            expect(forwardedOptions()).not.toHaveProperty(['headers', 'Csrf-Token']);
+        });
+
+        test('Request object', async () => {
+            await window.fetch(new Request(CROSS_ORIGIN));
+
+            expect(forwardedOptions()).not.toHaveProperty(['headers', 'Csrf-Token']);
+        });
+
+        test('the caller\'s own options object is forwarded unmodified', async () => {
+            const options = { method: 'GET', headers: { Accept: 'application/json' } };
+
+            await window.fetch(CROSS_ORIGIN, options);
+
+            expect(forwardedOptions()).toBe(options); // same reference, not a copy with a header added
+            expect(options.headers).toEqual({ Accept: 'application/json' });
+        });
+    });
+
+    describe('the request itself is passed through unchanged', () => {
+        test('a URL object reaches fetch as the same URL instance, not a string', async () => {
+            const url = new URL(sameOriginUrl);
+
+            await window.fetch(url);
+
+            expect(forwardedTarget()).toBe(url);
+        });
+
+        test('a Request object reaches fetch as the same Request instance', async () => {
+            const request = new Request('/label/geo');
+
+            await window.fetch(request);
+
+            expect(forwardedTarget()).toBe(request);
+        });
+
+        test('the underlying fetch response is returned to the caller', async () => {
+            const response = await window.fetch('/label/geo');
+
+            expect(response).toEqual({ ok: true });
+        });
+    });
+
+    test('an unparseable URL is forwarded untouched rather than guessed at', async () => {
+        // Malformed IPv6 literal: `new URL(...)` throws, so the wrapper cannot decide the origin and must not assume.
+        await window.fetch('http://[');
+
+        expect(originalFetch).toHaveBeenCalledTimes(1);
+        expect(forwardedOptions()).not.toHaveProperty(['headers', 'Csrf-Token']);
+    });
+});


### PR DESCRIPTION
No issue — found while writing the label-feed error handling in #4772. Follow-up to #4232.

### The problem

#4232 wrapped `window.fetch` in `AppManager._setupCSRF` so Play's `Csrf-Token` header is attached to **same-origin requests only**. The comment right above the code says why: a token signed by our server is meaningless to a third party, and adding a custom header turns a simple cross-origin request into one that needs a CORS preflight, which several hosts we talk to (Mapillary, Infra3d, sibling city servers) reject.

The line under that comment contradicted it:

```js
const requestUrl = (typeof url === 'string') ? url : url.url;
```

`fetch` accepts three argument types — `string`, `URL`, `Request` — and only a `Request` carries its address on `.url`. For a `URL`, `requestUrl` came out `undefined`, `new URL(undefined, origin)` resolved it to `<origin>/undefined`, and that classified as same-origin. **A cross-origin `URL` was handed the CSRF token** — precisely the case the guard exists to prevent.

Two ways that bites: the likely one is operational — someone fetches a third-party host with a `URL`, gets a preflight rejection, and has no reason to suspect a CSRF wrapper they didn't know existed. The other is that a session's CSRF token ends up in a request header to a host that isn't ours.

### The fix

```js
const requestUrl = (typeof Request !== 'undefined' && url instanceof Request) ? url.url : String(url);
```

Total over the three types `fetch` accepts, rather than enumerating two. The `typeof` guard is for non-browser hosts (jsdom, where the tests run); any browser with `fetch` also has `Request`.

The second commit drops the workaround this bug forced on the label feed in #4772 — `createPSMap.js` was calling `fetch(String(url))` with a comment explaining the bug, which would otherwise now describe a bug that no longer exists.

### Risk

**One live call site passes a `URL` to `fetch` once the second commit lands**: `/labelMap` builds `labelsURL` as a `URL` object (`labelMap.scala.html`), which `createPSMap`'s `fetchLabelFeed` now forwards as-is — so every `/labelMap` load exercises the fixed branch. That URL is always same-origin, and a *same-origin* `URL` was accidentally classified correctly even by the old line (`<origin>/undefined` is still same-origin), so its behavior is unchanged; the cross-origin case was the only one ever broken, and no call site hits it today. That accidental same-origin correctness is also why dropping the `createPSMap` workaround is safe independent of this fix.

### Tests

The wrapper had no coverage at all, and it's security-adjacent with a known-wrong case, so new `test/js/appManagerCsrfFetch.test.js` (13 tests) pins the whole matrix:

- same-origin `string` / `URL` / `Request` receive the token; relative paths too
- cross-origin `string` / `URL` / `Request` do **not**
- caller options and headers are merged, not clobbered; on the cross-origin path the caller's own options object is forwarded by reference, unmodified
- the `URL` / `Request` instance reaches `fetch` unchanged (not stringified)
- an unparseable URL is passed through rather than guessed at

jsdom implements neither `fetch` nor `Request`; the test supplies both, with a minimal `Request` stub whose `.url` is the input resolved against the document origin — the browser contract, and the only property the wrapper reads.

##### Testing instructions

1. `npm run test:js` — 491 tests across 42 files, green.
2. Negative control: restore the old line and re-run. Exactly one test fails, `cross-origin requests are left untouched › URL object`, and nothing else.
3. Browser: any map page (`/labelMap`, `/admin/label-map`) still loads its labels — that's the `createPSMap` call site the second commit touches.

Not browser-QA'd on my end. The wrapper is on the path of every `fetch` on the site, so a click-through of a map page and one page that POSTs (e.g. `/explore`) is worth a minute.

##### Things to check before submitting the PR
- [x] I've written a descriptive PR title.
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above. <!-- no visual change -->
- [x] I've asked for and included translations for any user facing text that was added or modified. <!-- no user-facing text -->
- [x] I've updated any logging. <!-- no logging change -->
- [x] I've tested on mobile (only needed for validation page). <!-- n/a -->

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-opus-5[1m])

