### PR TITLE
Pulse the validate marker on each new label to draw the eye

### DIFF
--- a/public/css/label-detail.css
+++ b/public/css/label-detail.css
@@ -166,19 +166,14 @@ dialog.label-detail[open]::backdrop {
   cursor: grabbing;
 }
 
-/* Halo pulse draws the eye to the label marker when the card opens; the marker icon alone is small and often
-   low-contrast against pavement. The background sizing scales the SVG marker to whatever box PanoMarker sets. */
-@keyframes label-detail-marker-pulse {
-  from { box-shadow: 0 0 0 0 rgb(255 255 255 / 90%); }
-  to { box-shadow: 0 0 0 18px rgb(255 255 255 / 0%); }
-}
-
-.label-detail__marker-pulse {
+/* The label marker on the card's pano. The background sizing scales the SVG marker to whatever box PanoMarker
+   sets. The halo that draws the eye to it is main.css's .label-marker-pulse, which PopupPanoManager adds
+   alongside this class. */
+.label-detail__marker {
   border-radius: 50%;
   background-size: contain;
   background-repeat: no-repeat;
   background-position: center;
-  animation: label-detail-marker-pulse 1.4s ease-out 1;
 
   /* Visual only: let a click-and-drag pass through to the pano so the streetscape still pans when the drag
      starts over the marker (#4574, Mikey #6) — matching the crop fallback marker, which is already pass-through. */
@@ -186,7 +181,7 @@ dialog.label-detail[open]::backdrop {
 }
 
 /* The AI-generated badge keeps its own hover tooltip; it's a tiny corner target, so panning is barely affected. */
-.label-detail__marker-pulse .admin-ai-icon-marker { pointer-events: auto; }
+.label-detail__marker .admin-ai-icon-marker { pointer-events: auto; }
 
 /* One-time "pannable" hint chip over the imagery; LabelDetail toggles is-visible briefly on first open. Sits at
    the top of the image, clear of the hover validation overlay at the bottom. */
@@ -210,8 +205,6 @@ dialog.label-detail[open]::backdrop {
 .label-detail__pan-hint.is-visible { opacity: 1; }
 
 @media (prefers-reduced-motion: reduce) {
-  .label-detail__marker-pulse { animation: none; }
-
   .label-detail__pan-hint { transition: none; }
 }
 

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1544,6 +1544,41 @@ kbd {
   .labelmap-beacon::after { animation: none; }
 }
 
+/* One-shot halo drawing the eye to a label marker on a panorama: Validate replays it on every new label (#4790),
+   the Label Detail Card plays it when the card opens (#4572). Both markers are small and easy to lose against a
+   busy streetscape.
+
+   The spread is a fraction of the marker's own diameter, which PanoMarker publishes as --marker-diameter, because
+   the same marker is drawn at very different sizes — 22px on desktop Validate but 52px on mobile, where a fixed
+   spread would leave the halo a thin fringe on the surface that can least afford one. That property is already in
+   ui-scaled pixels, so the halo needs no --ui-scale of its own.
+
+   The dark shadow carries the same spread as the white one but blurred, so it reads only as a soft edge just
+   outside the halo rather than as a second ring. Without it the halo disappears over concrete and sky, which is
+   most of what a marker sits on. */
+@keyframes label-marker-pulse {
+  from {
+    box-shadow: 0 0 0 0 rgb(255 255 255 / 90%), 0 0 var(--marker-pulse-blur) 0 rgb(0 0 0 / 50%);
+  }
+
+  to {
+    box-shadow:
+      0 0 0 var(--marker-pulse-spread) rgb(255 255 255 / 0%),
+      0 0 var(--marker-pulse-blur) var(--marker-pulse-spread) rgb(0 0 0 / 0%);
+  }
+}
+
+.label-marker-pulse {
+  --marker-pulse-spread: calc(var(--marker-diameter, 22px) * 0.8);
+  --marker-pulse-blur: calc(var(--marker-diameter, 22px) * 0.18);
+
+  animation: label-marker-pulse 1.4s ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .label-marker-pulse { animation: none; }
+}
+
 /* Chat-bubble tail tying the /labelMap popup dialog to the spotlighted label's beacon: a full-viewport fixed
    SVG whose one polygon the page script repositions on every map/dialog change. Sits below the dialog's top
    layer (so the light backdrop dims it slightly) but above the map and its controls. */

--- a/public/css/validate/svv-panorama.css
+++ b/public/css/validate/svv-panorama.css
@@ -89,25 +89,6 @@
   outline-offset: calc(1px * var(--ui-scale));
 }
 
-/* One-shot halo pulse replayed each time a new label is shown, drawing the eye to the marker so the validator
-   doesn't have to scan the streetscape for it — the same affordance as the Label Detail Card's marker pulse
-   (#4572, label-detail.css). The marker element is reused across labels, so PanoManager restarts the animation
-   by taking this class off and re-adding it on every render. */
-@keyframes label-marker-pulse {
-  from { box-shadow: 0 0 0 0 rgb(255 255 255 / 90%); }
-  to { box-shadow: 0 0 0 calc(18px * var(--ui-scale, 1)) rgb(255 255 255 / 0%); }
-}
-
-#validate-pano-marker.label-marker--pulse {
-  animation: label-marker-pulse 1.4s ease-out 1;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  #validate-pano-marker.label-marker--pulse {
-    animation: none;
-  }
-}
-
 /* Sits in the top-right just left of the stacked zoom control, scaled down to match its height. transform-origin keeps
    the top-right corner pinned so the scaled sign still lines up with the zoom buttons. */
 .speed-limit-sign {

--- a/public/css/validate/svv-panorama.css
+++ b/public/css/validate/svv-panorama.css
@@ -89,6 +89,25 @@
   outline-offset: calc(1px * var(--ui-scale));
 }
 
+/* One-shot halo pulse replayed each time a new label is shown, drawing the eye to the marker so the validator
+   doesn't have to scan the streetscape for it — the same affordance as the Label Detail Card's marker pulse
+   (#4572, label-detail.css). The marker element is reused across labels, so PanoManager restarts the animation
+   by taking this class off and re-adding it on every render. */
+@keyframes label-marker-pulse {
+  from { box-shadow: 0 0 0 0 rgb(255 255 255 / 90%); }
+  to { box-shadow: 0 0 0 calc(18px * var(--ui-scale, 1)) rgb(255 255 255 / 0%); }
+}
+
+#validate-pano-marker.label-marker--pulse {
+  animation: label-marker-pulse 1.4s ease-out 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  #validate-pano-marker.label-marker--pulse {
+    animation: none;
+  }
+}
+
 /* Sits in the top-right just left of the stacked zoom control, scaled down to match its height. transform-origin keeps
    the top-right corner pinned so the scaled sign still lines up with the zoom buttons. */
 .speed-limit-sign {

--- a/public/js/common/PanoMarker.js
+++ b/public/js/common/PanoMarker.js
@@ -112,6 +112,10 @@ class PanoMarker {
     marker.style.cursor = 'inherit';
     marker.style.width = `${this.size_.width}px`;
     marker.style.height = `${this.size_.height}px`;
+    // Markers are square, so width is the diameter. Published so decorations can size themselves off the marker
+    // instead of hardcoding px that only look right at one of its sizes (e.g. main.css's .label-marker-pulse halo,
+    // where Validate's marker is 22px on desktop but 52px on mobile).
+    marker.style.setProperty('--marker-diameter', `${this.size_.width}px`);
     marker.style.display = this.visible_ ? 'block' : 'none';
     marker.style.zIndex = this.zIndex_;
 
@@ -338,6 +342,7 @@ class PanoMarker {
     if (this.marker_) {
       this.marker_.style.width = `${size.width}px`;
       this.marker_.style.height = `${size.height}px`;
+      this.marker_.style.setProperty('--marker-diameter', `${size.width}px`);
       this.draw();
     }
   };

--- a/public/js/common/label-detail/PopupPanoManager.js
+++ b/public/js/common/label-detail/PopupPanoManager.js
@@ -410,8 +410,9 @@ class PopupPanoManager {
       icon: this.#iconFor(label.label_type),
       size: { width: 28, height: 28 },
     });
-    // Halo pulse draws the eye to the (small, often low-contrast) marker when the card opens.
-    panoMarker.marker_.classList.add('label-detail__marker-pulse');
+    // Halo pulse draws the eye to the (small, often low-contrast) marker when the card opens. A marker is built
+    // fresh per render, so the class plays once on a new element and needs no restart.
+    panoMarker.marker_.classList.add('label-detail__marker', 'label-marker-pulse');
     this.#labelMarkers.push({
       panoId: this.panoViewer.getPanoId(),
       marker: panoMarker,

--- a/public/js/validate/src/Main.js
+++ b/public/js/validate/src/Main.js
@@ -183,6 +183,11 @@ class Main {
     $('#page-loading').css({ visibility: 'hidden' });
     $('.tool-ui').removeClass('ps-invisible');
 
+    // The first label rendered while the tool was still invisible (visibility: hidden doesn't pause animations),
+    // so its halo pulse played unseen. Replay it now that the marker can be seen — or, on desktop, once the
+    // mission-start tutorial overlay raised just above it clears (#4790).
+    svv.panoManager.replayMarkerPulse();
+
     // Uniformly scale the whole tool to fit the viewport (like browser zoom) using var(--ui-scale). Mobile
     // instead fills the screen via PanoManager's own sizing.
     if (!util.isMobile()) {

--- a/public/js/validate/src/modal/ModalMissionComplete.js
+++ b/public/js/validate/src/modal/ModalMissionComplete.js
@@ -31,6 +31,11 @@ class ModalMissionComplete {
       }
 
       this.hide();
+
+      // The new mission's first label rendered while this modal was still up (Form.js loads it before re-enabling
+      // the button), so its halo pulse played unseen. Replay it now that the marker can be seen — or once the
+      // mission-start tutorial raised just above clears (#4790).
+      svv.panoManager.replayMarkerPulse();
     }
   };
 

--- a/public/js/validate/src/panorama/PanoManager.js
+++ b/public/js/validate/src/panorama/PanoManager.js
@@ -257,6 +257,30 @@ class PanoManager {
   }
 
   /**
+   * Replays the halo pulse once the marker can actually be seen, for the first label of a mission (#4790).
+   *
+   * That label renders behind page chrome — the loading overlay at boot (Main.js), the mission-complete modal on
+   * later missions (Form.js loads the next label before its button is clicked) — and visibility: hidden doesn't
+   * pause CSS animations, so the pulse plays unseen and is spent before the validator ever sees the marker. The
+   * reveal choreography calls this as its chrome clears; if the mission-start tutorial's overlay is up (desktop —
+   * mobile has no tutorial markup), the replay waits for its dismissal the same way the pano hint toast does
+   * (#4726).
+   */
+  replayMarkerPulse() {
+    if (!this.labelMarker) return;
+    const overlay = document.querySelector('.mission-start-tutorial-overlay');
+    if (overlay && getComputedStyle(overlay).display !== 'none') {
+      document.addEventListener(
+        'ps:mission-start-tutorial:done',
+        () => { if (this.labelMarker) this.#restartMarkerPulse(this.labelMarker.marker_); },
+        { once: true },
+      );
+    } else {
+      this.#restartMarkerPulse(this.labelMarker.marker_);
+    }
+  }
+
+  /**
    * Replays the one-shot halo pulse that draws the eye to the marker (#4790, main.css .label-marker-pulse).
    *
    * Validate reuses one marker element across labels, so re-adding the class is not enough on its own: when a

--- a/public/js/validate/src/panorama/PanoManager.js
+++ b/public/js/validate/src/panorama/PanoManager.js
@@ -231,7 +231,8 @@ class PanoManager {
       // Take the halo class back off once it has played so the element doesn't carry a state class it isn't in.
       // Attached here rather than per render because it belongs to the element's whole lifetime: interrupting a
       // pulse fires animationcancel, not animationend, so a per-render `{ once: true }` listener would never fire
-      // and would accumulate one dead listener per label.
+      // and would accumulate one dead listener per label. Under prefers-reduced-motion no animation ever runs or
+      // ends, so the class lingers — harmless, since the same media query is what makes it inert.
       this.labelMarker.marker_.addEventListener('animationend', (e) => {
         if (e.animationName === 'label-marker-pulse') e.currentTarget.classList.remove('label-marker-pulse');
       });

--- a/public/js/validate/src/panorama/PanoManager.js
+++ b/public/js/validate/src/panorama/PanoManager.js
@@ -228,6 +228,13 @@ class PanoManager {
         zIndex: 2,
       });
       this.#markerViewer = svv.panoViewer;
+      // Take the halo class back off once it has played so the element doesn't carry a state class it isn't in.
+      // Attached here rather than per render because it belongs to the element's whole lifetime: interrupting a
+      // pulse fires animationcancel, not animationend, so a per-render `{ once: true }` listener would never fire
+      // and would accumulate one dead listener per label.
+      this.labelMarker.marker_.addEventListener('animationend', (e) => {
+        if (e.animationName === 'label-marker-pulse') e.currentTarget.classList.remove('label-marker-pulse');
+      });
     } else {
       this.labelMarker.setPosition({ heading: labelPov.heading, pitch: labelPov.pitch });
     }
@@ -244,12 +251,24 @@ class PanoManager {
       'aria-label',
       i18next.t(`common:${util.camelToKebab(currentLabel.getAuditProperty('labelType'))}`).replace('&shy;', ''),
     );
-    // Replay the one-shot halo pulse that draws the eye to the marker (#4790). The marker element is reused
-    // across labels, so the class must come off and back on — with a reflow between — to restart the animation.
-    marker.classList.remove('label-marker--pulse');
-    void marker.offsetWidth;
-    marker.classList.add('label-marker--pulse');
+    this.#restartMarkerPulse(marker);
     this.#updateMarkerAiIndicator(currentLabel.getAuditProperty('aiGenerated'));
+  }
+
+  /**
+   * Replays the one-shot halo pulse that draws the eye to the marker (#4790, main.css .label-marker-pulse).
+   *
+   * Validate reuses one marker element across labels, so re-adding the class is not enough on its own: when a
+   * label is answered before its pulse has finished the class is still present, and the browser sees no change
+   * to act on. Reading offsetWidth in between flushes the pending style change, which is what restarts it.
+   *
+   * @param {HTMLElement} marker The marker element to pulse.
+   * @private
+   */
+  #restartMarkerPulse(marker) {
+    marker.classList.remove('label-marker-pulse');
+    void marker.offsetWidth;
+    marker.classList.add('label-marker-pulse');
   }
 
   /**

--- a/public/js/validate/src/panorama/PanoManager.js
+++ b/public/js/validate/src/panorama/PanoManager.js
@@ -244,6 +244,11 @@ class PanoManager {
       'aria-label',
       i18next.t(`common:${util.camelToKebab(currentLabel.getAuditProperty('labelType'))}`).replace('&shy;', ''),
     );
+    // Replay the one-shot halo pulse that draws the eye to the marker (#4790). The marker element is reused
+    // across labels, so the class must come off and back on — with a reflow between — to restart the animation.
+    marker.classList.remove('label-marker--pulse');
+    void marker.offsetWidth;
+    marker.classList.add('label-marker--pulse');
     this.#updateMarkerAiIndicator(currentLabel.getAuditProperty('aiGenerated'));
   }
 

--- a/test/js/validateMarkerPulse.test.js
+++ b/test/js/validateMarkerPulse.test.js
@@ -176,4 +176,32 @@ describe('Validate marker halo pulse (issue #4790)', () => {
         panoManager.labelMarker.setSize({ width: 52, height: 52 });
         expect(markerEl().style.getPropertyValue('--marker-diameter')).toBe('52px');
     });
+
+    // A mission's first label renders behind page chrome (the loading overlay at boot, the mission-complete modal
+    // on later missions), where its pulse plays unseen — visibility: hidden doesn't pause animations. The reveal
+    // choreography calls replayMarkerPulse once the marker can be seen.
+
+    test('replayMarkerPulse pulses immediately when no mission-start tutorial overlay is up', () => {
+        panoManager.renderPanoMarker(makeLabel());
+        fireAnimationEnd(markerEl(), 'label-marker-pulse'); // the unseen pulse, already spent
+
+        panoManager.replayMarkerPulse();
+        expect(markerEl().classList.contains('label-marker-pulse')).toBe(true);
+    });
+
+    test('replayMarkerPulse holds the pulse until a showing mission-start tutorial is dismissed', () => {
+        const overlay = document.createElement('div');
+        overlay.className = 'mission-start-tutorial-overlay';
+        overlay.style.display = 'flex';
+        document.body.appendChild(overlay);
+
+        panoManager.renderPanoMarker(makeLabel());
+        fireAnimationEnd(markerEl(), 'label-marker-pulse');
+
+        panoManager.replayMarkerPulse();
+        expect(markerEl().classList.contains('label-marker-pulse')).toBe(false); // held back, not spent under it
+
+        document.dispatchEvent(new CustomEvent('ps:mission-start-tutorial:done'));
+        expect(markerEl().classList.contains('label-marker-pulse')).toBe(true);
+    });
 });

--- a/test/js/validateMarkerPulse.test.js
+++ b/test/js/validateMarkerPulse.test.js
@@ -1,0 +1,179 @@
+/**
+ * Tests for the validate marker's one-shot halo pulse (issue #4790), wired up in
+ * public/js/validate/src/panorama/PanoManager.js `renderPanoMarker` / `#restartMarkerPulse`.
+ *
+ * Validate reuses one marker element across labels, so the pulse lifecycle has real edge cases: the
+ * .label-marker-pulse class must be (re)applied on every label render, taken back off by an `animationend`
+ * listener that ignores other animations ending on the marker, and re-applied even when the previous pulse is
+ * still mid-flight (a label answered within 1.4s), which fires animationcancel rather than animationend. These
+ * tests drive the REAL `PanoManager.create` factory and the REAL `PanoMarker` class (with a fake pano viewer),
+ * dispatching synthetic animation events — jsdom runs no CSS animations, so `animationend` never fires on its own.
+ *
+ * Also pins PanoMarker publishing its rendered size as --marker-diameter, which main.css's .label-marker-pulse
+ * uses to size the halo to the marker it decorates (22px on desktop Validate vs 52px on mobile).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const PANO_MANAGER_PATH = path.resolve(__dirname, '..', '..', 'public/js/validate/src/panorama/PanoManager.js');
+const PANO_MARKER_PATH = path.resolve(__dirname, '..', '..', 'public/js/common/PanoMarker.js');
+const THROTTLE_PATH = path.resolve(__dirname, '..', '..', 'public/js/validate/src/util/throttle.js');
+
+/**
+ * Load a bare `class` declaration out of a production file. The Grunt bundle concatenates these into page scope,
+ * so wrap the source in an IIFE that returns the named class (same trick as validatePanoPovThrottle.test.js).
+ * @param {string} filePath - Absolute path to the production file.
+ * @param {string} className - Name of the class the file declares.
+ * @returns {Function} The class.
+ */
+function loadClassFromFile(filePath, className) {
+    const src = fs.readFileSync(filePath, 'utf8');
+    return (0, eval)('(() => {\n' + src + '\nreturn ' + className + ';\n})()');
+}
+
+/**
+ * Dispatch a synthetic animationend on an element. A plain Event with an expando `animationName` — the only
+ * field the handler reads — avoids depending on jsdom's AnimationEvent support.
+ * @param {HTMLElement} el - The element the animation ended on.
+ * @param {string} animationName - The keyframes name to report.
+ */
+function fireAnimationEnd(el, animationName) {
+    const event = new Event('animationend', { bubbles: true });
+    event.animationName = animationName;
+    el.dispatchEvent(event);
+}
+
+/**
+ * Build a minimal fake validate Label with just the surface renderPanoMarker reads.
+ * @param {object} [auditPropOverrides] - Audit properties to override per label.
+ * @returns {object} The fake label.
+ */
+function makeLabel(auditPropOverrides = {}) {
+    const auditProps = {
+        heading: 10, pitch: 5, zoom: 1, panoId: 'pano1', labelType: 'CurbRamp', aiGenerated: false,
+        ...auditPropOverrides,
+    };
+    return {
+        getOriginalPov: () => ({ heading: 10, pitch: 5, zoom: 1 }),
+        getAuditProperty: (key) => auditProps[key],
+        getIconUrl: () => '/assets/fake-icon.svg',
+        getIconColor: () => '#abcdef', // arbitrary test value, not a real label-type color
+    };
+}
+
+describe('Validate marker halo pulse (issue #4790)', () => {
+    let panoManager;
+
+    beforeEach(async () => {
+        // The pano canvas #init looks up (with a parent for the fallback canvas + viewer logo to attach to),
+        // plus the marker layer renderPanoMarker creates the PanoMarker in.
+        document.body.innerHTML
+            = '<div id="pano-holder"><div id="svv-panorama"></div></div><div id="view-control-layer"></div>';
+
+        global.util = {};
+        (0, eval)(fs.readFileSync(THROTTLE_PATH, 'utf8')); // real throttle; #init wires it to pov_changed
+        util.isMobile = () => false;
+        util.uiScale = () => 1;
+        util.camelToKebab = (str) => str.toLowerCase();
+        // jsdom has no WebGL, so PanoMarker falls back to the 2d projection; where the marker lands is irrelevant
+        // here, only what classes/properties it carries. Returning null directly (jsdom's effective behavior)
+        // keeps the fallback deterministic without jsdom's "not implemented" console noise.
+        jest.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(null);
+        util.pano = {
+            centeredPovToCanvasCoord2d: () => ({ x: 0, y: 0 }),
+            centeredPovToCanvasCoord: () => ({ x: 0, y: 0 }),
+        };
+
+        global.PanoMarker = loadClassFromFile(PANO_MARKER_PATH, 'PanoMarker');
+        global.i18next = { t: () => 'Curb ramp' };
+        global.createPanoViewerLogo = jest.fn(() => ({ showPrimaryLogo: jest.fn(), showSourceLogo: jest.fn() }));
+        global.GsvViewer = class GsvViewer {};             // distinct from FakeViewerType, so the GSV-only
+        global.MapillaryViewer = class MapillaryViewer {}; // and Mapillary-only attribution paths are skipped
+        global.svv = {
+            tracker: { push: jest.fn() },
+            panoStore: { addPanoMetadata: jest.fn() },
+            ui: { viewer: { date: { text: jest.fn() } } },
+            labelRadius: 10, // marker diameter = (10 * 2 + 2) * uiScale = 22px, desktop Validate's real size
+        };
+
+        const panoData = {
+            getPanoId: () => 'pano1',
+            getProperty: () => ({ format: () => 'Jun 2026' })
+        };
+        const fakeViewer = {
+            setPano: jest.fn(() => Promise.resolve(panoData)),
+            addListener: jest.fn(),
+            resize: jest.fn(),
+            setPov: jest.fn(),
+            getPov: () => ({ heading: 0, pitch: 0, zoom: 1 })
+        };
+        const FakeViewerType = class FakeViewerType {
+            static create() { return Promise.resolve(fakeViewer); }
+        };
+
+        const PanoManager = loadClassFromFile(PANO_MANAGER_PATH, 'PanoManager');
+        panoManager = await PanoManager.create(FakeViewerType, 'token', 'pano1');
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+        document.body.innerHTML = '';
+        delete global.util;
+        delete global.PanoMarker;
+        delete global.i18next;
+        delete global.createPanoViewerLogo;
+        delete global.GsvViewer;
+        delete global.MapillaryViewer;
+        delete global.svv;
+    });
+
+    /** @returns {HTMLElement} The marker element PanoMarker created. */
+    function markerEl() {
+        return document.getElementById('validate-pano-marker');
+    }
+
+    test('rendering a label applies the pulse class and publishes the marker diameter for the halo', () => {
+        panoManager.renderPanoMarker(makeLabel());
+
+        expect(markerEl().classList.contains('label-marker-pulse')).toBe(true);
+        expect(markerEl().style.getPropertyValue('--marker-diameter')).toBe('22px');
+    });
+
+    test('animationend for the pulse takes the class off; other animations ending on the marker leave it alone', () => {
+        panoManager.renderPanoMarker(makeLabel());
+
+        fireAnimationEnd(markerEl(), 'some-other-animation');
+        expect(markerEl().classList.contains('label-marker-pulse')).toBe(true);
+
+        fireAnimationEnd(markerEl(), 'label-marker-pulse');
+        expect(markerEl().classList.contains('label-marker-pulse')).toBe(false);
+    });
+
+    test('the pulse replays on the next label after the previous one finished', () => {
+        panoManager.renderPanoMarker(makeLabel());
+        fireAnimationEnd(markerEl(), 'label-marker-pulse');
+
+        panoManager.renderPanoMarker(makeLabel({ labelType: 'Obstacle' }));
+        expect(markerEl().classList.contains('label-marker-pulse')).toBe(true);
+    });
+
+    test('advancing mid-pulse still pulses the new label, and the cleanup listener stays wired', () => {
+        panoManager.renderPanoMarker(makeLabel());
+
+        // No animationend in between: the first pulse is interrupted (animationcancel in a real browser).
+        panoManager.renderPanoMarker(makeLabel({ labelType: 'Obstacle' }));
+        expect(markerEl().classList.contains('label-marker-pulse')).toBe(true);
+
+        // The once-per-element listener still cleans up after re-renders reused the marker.
+        fireAnimationEnd(markerEl(), 'label-marker-pulse');
+        expect(markerEl().classList.contains('label-marker-pulse')).toBe(false);
+    });
+
+    test('setSize republishes --marker-diameter so the halo tracks setMarkerScale', () => {
+        panoManager.renderPanoMarker(makeLabel());
+
+        panoManager.labelMarker.setSize({ width: 52, height: 52 });
+        expect(markerEl().style.getPropertyValue('--marker-diameter')).toBe('52px');
+    });
+});


### PR DESCRIPTION
Resolves #4790.

Replays the Label Detail Card's one-shot halo pulse (#4572) on the Validate marker every time a new label renders, so validators don't have to scan the streetscape to find a small, low-contrast marker. Since the validate bundle is shared, this covers `/validate`, `/expertValidate`, `/mobile`, and the admin variant in one change.

Code review of the first pass found that authoring the pulse as a local copy with hardcoded dimensions caused three problems, so the animation is now a shared affordance driven by the marker it decorates. (That first-pass copy lived in `svv-panorama.css` and was reworked within this PR, so the net diff never touches that file.)

## Changes

- **`public/js/common/PanoMarker.js`** — publishes the marker's rendered size as `--marker-diameter` beside the inline width/height it already writes, in both `createMarker()` and `setSize()` (so the halo also tracks `setMarkerScale`).
- **`public/css/main.css`** — one shared `@keyframes label-marker-pulse` + `.label-marker-pulse`, beside the existing `.labelmap-beacon` animation. The spread is a fraction of `--marker-diameter` rather than a flat 18px: Validate's marker is 22px on desktop but **52px on mobile**, where a fixed spread left the halo a thin fringe on the surface that can least afford one. Because that property is already in ui-scaled pixels, the halo needs no `--ui-scale` of its own. A blurred dark shadow rides the same spread as the white one, giving the halo an edge over concrete and sky where white alone disappears.
- **`public/css/label-detail.css`** — `.label-detail__marker-pulse` conflated the card's marker geometry with the animation, so it splits into `.label-detail__marker` plus the shared class; its near-identical local keyframe is deleted.
- **`public/js/common/label-detail/PopupPanoManager.js`** — adds both classes. The card builds a fresh marker per render, so it needs no restart logic.
- **`public/js/validate/src/panorama/PanoManager.js`** — uses the shared class; the replay moves into a documented `#restartMarkerPulse()`. The class is now dropped on `animationend`, with the listener attached once per marker *element* rather than per render — interrupting a pulse fires `animationcancel`, not `animationend`, so a per-render `{ once: true }` listener would never fire and would accumulate one dead listener per label. (Under `prefers-reduced-motion` no animation runs or ends, so the class lingers — harmlessly, since the same media query is what makes it inert.)
- **First label of a mission** (QA caught it never visibly pulsing): that label renders behind page chrome — the loading overlay at boot (`Main.js` reveals the tool after `LabelContainer.create`), the mission-complete modal on later missions (`Form.js` loads the next label before its button is clicked) — and `visibility: hidden` doesn't pause CSS animations, so its pulse played unseen and was spent. `PanoManager` gains a public **`replayMarkerPulse()`** that pulses immediately, or — when the mission-start tutorial's overlay is up (desktop) — waits for `ps:mission-start-tutorial:done`, the same pattern as the pano hint toast (#4726). **`Main.js`** calls it at the boot reveal; **`ModalMissionComplete.js`** calls it when the next-mission button hides the modal.
- **`test/js/validateMarkerPulse.test.js`** — new jsdom spec driving the real `PanoManager` + `PanoMarker` with a fake viewer: pulse class applied per render, `animationend` cleanup with the animation-name guard, mid-pulse replay on advance, `--marker-diameter` publishing in both `createMarker()` and `setSize()`, and `replayMarkerPulse()` both immediate and held until tutorial dismissal.

Resulting spreads: 17.6px on desktop Validate (unchanged in practice), 41.6px on mobile, 22.4px on the Label Detail Card.

## Accessibility

One 1.4s non-repeating animation, so well clear of WCAG 2.3.1 (three flashes) and 2.2.2 (pause/stop/hide, which applies past 5s). `prefers-reduced-motion` is honored via `main.css`, covering both consumers.

## QA

Verified on laptop and phone (Chrome device emulation): pulse fires per label on `/validate` and `/expertValidate`, replays on advance, mobile halo is now proportional, H-key hide/show ring unaffected, and the Label Detail Card still pulses on open with click-drag passing through the marker.

ESLint, Stylelint, and HTMLHint pass; the jsdom suite passes (527 tests, including the 7 new pulse tests).

Still to verify visually (first-label fix): the pulse plays right after dismissing the mission-start tutorial at boot and after "Validate next mission", and on mobile right as the tool appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
