### PR TITLE
Stop marking local dev cookies Secure so Safari can store them

### DIFF
--- a/conf/application.local.conf
+++ b/conf/application.local.conf
@@ -5,7 +5,13 @@ silhouette.authenticator.cookieDomain=null
 silhouette.authenticator.cookieName="local-authenticator"
 play.http.session.domain=null
 play.http.session.cookieName="LOCAL_PLAY_SESSION"
-#play.http.session.secure=false # Disable for local dev to allow http in addition to https. But it hasn't been an issue.
+
+# Local dev serves plain http://localhost:9000, so cookies must not be marked Secure. Chrome and Firefox make an
+# exception and store Secure cookies on http://localhost anyway, but WebKit/Safari does not — it silently drops the
+# Set-Cookie. Without the authenticator cookie every request looks signed out, so /explore 303s to /anonSignUp, which
+# mints an anon user and 303s back, forever: Safari gives up with "too many redirects".
+silhouette.authenticator.secureCookie=false
+play.http.session.secure=false
 play.i18n.langCookieName = "LOCAL_PLAY_LANG"
 play.filters.hosts.allowed = ["localhost:9000"]
 ai-enabled=false # Comment out to allow AI requests in local dev environment.


### PR DESCRIPTION
Fixes #3957.

## The bug

Local dev serves plain `http://localhost:9000`, but both auth cookies were marked `Secure`. Chrome and Firefox treat `http://localhost` as a trustworthy origin and store `Secure` cookies anyway — **WebKit/Safari does not**, and drops the `Set-Cookie` silently. That's why this was Safari-only and went unnoticed for so long.

Captured against a local dev server with no cookies:

```
GET /explore                    → 303  Location: /anonSignUp?url=%2Fexplore
GET /anonSignUp?url=/explore    → 303  Location: /explore
                                  Set-Cookie: local-authenticator=…; SameSite=Lax; Path=/; Secure; HTTPOnly
```

`/explore` is a `SecuredAction`; with no identity, `CustomSecuredErrorHandler` → `anonSignupRedirect` (`app/controllers/helper/ControllerUtils.scala:181`) bounces to `/anonSignUp`, which mints an anon user and embeds the authenticator cookie on a 303 back to `/explore`. Auth is cookie-only — `CookieAuthenticatorService` is built with a `None` repository (`app/modules/SilhouetteModule.scala:130`), so no cookie means no identity, unconditionally. Safari drops the cookie, the next hop looks signed out, and the two-hop loop never terminates.

Both symptoms in #3957 are this one bug in two places:

| symptom | cookie | source |
|---|---|---|
| infinite redirect | `local-authenticator` | `silhouette.authenticator.secureCookie=true` (`conf/silhouette.conf:15`) |
| "No CSRF token found in headers" on `/signIn` | `LOCAL_PLAY_SESSION` (carries the CSRF token) | `play.http.session.secure=true` (`conf/application.conf:159`) |

`conf/application.local.conf` already overrode the authenticator cookie's *name* and *domain* for local dev, but never the `Secure` flag. The `play.http.session.secure=false` override was sitting commented out, annotated "it hasn't been an issue" — it is this issue.

## Scope

**Local dev only.** Prod and test serve https, where `Secure` is correct and load-bearing; `application.conf`, `application.test.conf`, and `application.staging.conf` are untouched. Confirmed from the other direction: `https://sidewalk-chicago-test.cs.washington.edu/explore` works in Safari today *without* this fix, because https satisfies `Secure`.

## Verification

`curl` enforces the `Secure` flag the same way WebKit does, so this reproduces headlessly:

```bash
curl -s -o /dev/null -L --max-redirs 10 -c /tmp/jar.txt -b /tmp/jar.txt \
  -w "final: %{http_code}  redirects: %{num_redirects}\n" \
  -H 'Sec-Fetch-Mode: navigate' http://localhost:9000/explore
grep -v '^#' /tmp/jar.txt
```

| | before | after |
|---|---|---|
| `Set-Cookie` flags | `…; SameSite=Lax; Path=/; Secure; HTTPOnly` | `…; SameSite=Lax; Path=/; HTTPOnly` |
| `/explore` signed out | loop, cookie jar empty | **200** after 2 redirects |
| `/signIn` | CSRF token error | **200**, `csrfToken` present |
| cookies stored | none | `local-authenticator`, `LOCAL_PLAY_SESSION` |

## Reviewer note

I verified with curl and headless WebKit, not with real Safari, and I did not exercise `/explore`'s panorama interaction. Worth one manual click through Explore and sign-in in a fresh Safari profile to confirm nothing else Safari-specific is hiding behind this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
