### PR TITLE
Enable CSP violation reporting on local and test, not prod

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -123,7 +123,8 @@ play.filters.csp {
     # evaluated by the browser at all, meaning no protection and no data (WebKit also logs a "will have no effect"
     # warning once per document). Reporting is switched on per-environment in application.local.conf and
     # application.test.conf instead, to measure the report volume on -test before prod logs take it -- see #4793,
-    # which also tracks flipping reportOnly = false once the reports are quiet.
+    # which also tracks flipping reportOnly = false once the reports are quiet. Staging deliberately stays inert
+    # like prod: -test is the designated measuring point, and staging's traffic adds nothing but log volume.
     default-src = "'self'"
 
     # Scripts: gtag.js from Tag Manager (Google Analytics), Google Maps JS API, the Vega/Vega-Lite/Vega-Embed

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -119,8 +119,11 @@ play.filters.enabled += play.filters.csp.CSPFilter
 play.filters.csp {
   reportOnly = true
   directives = {
-    # Uncomment below when we want the reports sent to our logger. There are too many now for it to be worthwhile.
-#    report-uri = "/cspReport"
+    # No report-uri here, so the policy is inert on prod: a report-only policy with no reporting destination isn't
+    # evaluated by the browser at all, meaning no protection and no data (WebKit also logs a "will have no effect"
+    # warning once per document). Reporting is switched on per-environment in application.local.conf and
+    # application.test.conf instead, to measure the report volume on -test before prod logs take it -- see #4793,
+    # which also tracks flipping reportOnly = false once the reports are quiet.
     default-src = "'self'"
 
     # Scripts: gtag.js from Tag Manager (Google Analytics), Google Maps JS API, the Vega/Vega-Lite/Vega-Embed

--- a/conf/application.local.conf
+++ b/conf/application.local.conf
@@ -9,3 +9,8 @@ play.http.session.cookieName="LOCAL_PLAY_SESSION"
 play.i18n.langCookieName = "LOCAL_PLAY_LANG"
 play.filters.hosts.allowed = ["localhost:9000"]
 ai-enabled=false # Comment out to allow AI requests in local dev environment.
+
+# Send CSP violations to SecurityPolicyController.cspReport. Without a report-uri the report-only policy in
+# application.conf is inert, so this is what makes local dev actually evaluate it and produce data. Prod is
+# deliberately left inert until we see what the volume looks like on the test stage -- #4793.
+play.filters.csp.directives.report-uri = "/cspReport"

--- a/conf/application.test.conf
+++ b/conf/application.test.conf
@@ -5,3 +5,8 @@ silhouette.authenticator.cookieDomain=".cs.washington.edu"
 silhouette.authenticator.cookieName="test-authenticator"
 play.http.session.cookieName="TEST_PLAY_SESSION"
 play.i18n.langCookieName = "TEST_PLAY_LANG"
+
+# Send CSP violations to SecurityPolicyController.cspReport. Without a report-uri the report-only policy in
+# application.conf is inert, so this is what makes the test stage actually evaluate it and produce data. Prod is
+# deliberately left inert until we see what the volume looks like on the test stage -- #4793.
+play.filters.csp.directives.report-uri = "/cspReport"


### PR DESCRIPTION
Refs #4793. Independent of #4794 — the two merge cleanly (both touch `application.local.conf`, in different regions).

## The problem

Our CSP filter runs in report-only mode, added during the Play 3 upgrade (d0e0ae9f8) with the stated plan: collect reports, tune the directives until quiet, then enforce. That rollout stalled — `report-uri = "/cspReport"` was commented out ("There are too many now for it to be worthwhile"), leaving `reportOnly = true` with no reporting destination.

**A report-only policy with no destination is completely inert.** The browser doesn't evaluate it, so we get no protection *and* no data. The only observable effect is a console warning, logged once per document:

```
The Content Security Policy '…' was delivered in report-only mode, but does not specify a 'report-to';
the policy will have no effect. Please either add a 'report-to' directive, or deliver the policy via the
'Content-Security-Policy' header.
```

This appears in **Safari but not Chrome**, which is why it went unnoticed — the same blind spot as #3957.

## The change

Enable `report-uri` through the per-environment overlays (`application.local.conf`, `application.test.conf`). **`application.conf` changes only a comment** — production stays inert deliberately, because log volume is exactly why reporting was switched off in the first place, and we should measure that on `-test` before prod takes it.

`report-uri` alone is sufficient. `report-to` would additionally require a `Reporting-Endpoints` response header that Play's CSP filter cannot emit, so a bare `report-to` directive would point at a nonexistent endpoint group.

## Verification

Real WebKit 26.5 (Playwright), against a local dev server:

| | before | after |
|---|---|---|
| CSP console messages on `/` | 4 | **0** |
| on `/labelmap` | 7 | **0** |
| policy evaluated by browser | no | yes |
| violations reported | — | 0 |

The report sink is confirmed working end to end, so "zero violations" is real signal rather than an inert-policy false quiet — a synthetic report POST returns 204 and logs:

```
WARN c.SecurityPolicyController - CSP violation: violated-directive = img-src -- blocked = Some(https://example.com/probe.png)
```

I also verified the HOCON overlay form (`play.filters.csp.directives.report-uri`) actually merges into the nested `directives` block by checking the served header, since that's the part most likely to fail silently.

## Coverage caveat

Verification covers `/` and `/labelmap` only. The pages most likely to violate — **`/explore`**, **`/validate`** (Street View / Mapbox) and the **Vega-based admin charts** — aren't exercised by automated page-load testing. #4793 tracks watching those on `-test`, then deciding on prod reporting and on flipping `reportOnly = false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
