### PR TITLE
Fix small critiques on Gallery & Label Detail cards

### DIFF
--- a/public/css/gallery/filter.css
+++ b/public/css/gallery/filter.css
@@ -3,7 +3,9 @@
    floating it over a map. */
 
 #card-filter {
-  width: inherit;
+  /* Fills the column its own padding included, so it still fits once the sidebar shows a scrollbar. */
+  box-sizing: border-box;
+  width: 100%;
 
   /* The 40px of headroom matches the map sidebar's, so the two panels start at the same distance from the navbar. */
   padding: 40px 5px 5px;

--- a/public/css/gallery/gallery.css
+++ b/public/css/gallery/gallery.css
@@ -1,6 +1,8 @@
 #gallery {
   display: flex;
-  overflow: hidden;
+
+  /* `clip`, not `hidden`: `hidden` would make this a scroll container, which disables the sidebar's sticky. */
+  overflow-x: clip;
 }
 
 #labels-not-found {
@@ -25,13 +27,22 @@
   border-bottom: 1px solid gray;
 }
 
-/* Note that the side bar is out of the "flow" of the grid container b/c it is fixed when we aren't loading anything. */
+/* Sticky, not fixed, so the column keeps its place in the flow: the page is then always at least as tall as the
+   sidebar and the footer starts below it, even when the results fill less than one row of cards (#4778). Sticking
+   ends at #gallery's bottom edge, so the sidebar never rides down over the paging controls or footer. */
 .sidebar {
-  padding-left: 10px;
-  min-height: calc(100vh - 610px);
-  height: 100%;
+  position: sticky;
+  top: calc(var(--navbar-height) + var(--test-banner-height, 0px));
+
+  /* A stretched flex item is as tall as the row and so has nowhere to stick to; this keeps it its own height. */
+  align-self: flex-start;
+  flex: none;
+
+  /* border-box so the padding comes out of the 275px the cards are laid out against, rather than widening the
+     column past it. */
+  box-sizing: border-box;
   width: 275px;
-  grid-row: 1/2;
+  padding-left: 10px;
 }
 
 #labels-not-found-text {
@@ -76,6 +87,12 @@
   padding: 0 10px 10px;
 }
 
+/* Takes the rest of the flex row beside the sidebar; min-width: 0 lets it shrink instead of forcing #gallery wider. */
+#gallery-content {
+  flex: 1;
+  min-width: 0;
+}
+
 /* Gallery's inline expanded view — a fixed overlay floating over the card grid (the grid never reflows around it;
    cards to its left stay visible and clickable for browsing). The max caps keep the panel content-scaled on large
    monitors — uncapped, the viewport-derived sizing balloons the card (and its flex-grown pano) on ≥27" screens
@@ -101,7 +118,6 @@
 .cards {
   display: flex;
   flex-flow: row wrap;
-  margin-left: 275px; /* Offset to compensate for the space taken up by the sidebar. */
 }
 
 /* There is no specific intended function for hover/click on labels on the gallery page.

--- a/public/css/label-detail.css
+++ b/public/css/label-detail.css
@@ -349,7 +349,6 @@ dialog.label-detail[open]::backdrop {
 }
 
 .label-detail--readonly .label-detail__comment-submit:disabled {
-  cursor: default;
   opacity: 0.5;
 }
 
@@ -622,17 +621,25 @@ button.label-detail__meta-cell:focus-visible {
   border-radius: 12px; /* Rounded rect, not a round pill — this is a button. See share-widget.css. */
   background: var(--color-neutral-200);
 
-  /* neutral-800 (not -600): the button is clickable even in this resting state, so its label must clear WCAG AA
-     (4.5:1) on the neutral-200 fill. The green .is-active state still reads as the clear "ready to send" change. */
+  /* neutral-800 (not -600): the button stays enabled and focusable in this resting state, so its label must clear
+     WCAG AA (4.5:1) on the neutral-200 fill. The green .is-active state reads as the "ready to send" change. */
   color: var(--color-neutral-800);
   font: var(--text-caption-semibold);
-  cursor: pointer;
+
+  /* Empty input is a no-op on click, so the resting state gets no pointer; .is-active below turns it back on. */
+  cursor: default;
   transition: background-color 120ms ease, color 120ms ease;
 }
 
 .label-detail__comment-submit.is-active {
   background: var(--color-pine-600);
   color: var(--color-neutral-white);
+  cursor: pointer;
+}
+
+/* Comes after .is-active so an in-flight submit (still active-green) drops the pointer while it's locked out. */
+.label-detail__comment-submit:disabled {
+  cursor: default;
 }
 
 .label-detail__comment-submit:focus-visible {

--- a/public/js/common/label-detail/LabelDetail.js
+++ b/public/js/common/label-detail/LabelDetail.js
@@ -321,6 +321,7 @@ class LabelDetail {
     // (outline / filled / outline-ai / filled-ai). The base URL for the icon files is read from a data
     // attribute on the container so JS doesn't need to know the assets' path.
     const voteDisplay = this.#root.querySelector('.label-detail__vote-display');
+    els.voteDisplay = voteDisplay;
     this.#iconBase = voteDisplay ? voteDisplay.dataset.iconBase : '';
     const voteEl = (variant, child) => this.#root.querySelector(`.label-detail__vote--${variant} ${child}`);
     els.voteIcons = {
@@ -1035,11 +1036,11 @@ class LabelDetail {
     for (const btn of Object.values(els.panoOverlayButtons)) btn.disabled = blocked;
     for (const btn of Object.values(els.voteButtons)) btn.disabled = blocked;
 
-    // Comment input and submit button.
+    // Comment input and submit button. The reason rides the row rather than the two controls it applies to: a
+    // disabled control swallows the hover that opens a tooltip on it.
     els.commentInput.disabled = blocked;
-    els.commentInput.title = tip;
     els.commentButton.disabled = blocked;
-    els.commentButton.title = tip;
+    LabelDetail.#setTooltip(els.commentRow, tip);
     // A durable lock also hides the comment box (it only shows with a Disagree/Unsure vote); a load in flight
     // leaves it in place and just disables it, since it's about to be usable again.
     this.#updateCommentRow();
@@ -1057,32 +1058,49 @@ class LabelDetail {
    * That last point is also why the pano hover-overlay buttons get a tooltip only while selected: unselected, their
    * full-width Agree/Disagree/Unsure labels already say what they do (Jon, #4574), so a tooltip would just repeat
    * them — but the selected one now clears rather than casts, which nothing else on it says.
+   *
+   * While the label is locked the reason goes on the vote column as a whole: these sentences don't apply, and a
+   * disabled button swallows the hover that would open a tooltip on it anyway.
    */
   #renderVoteTooltips() {
     const els = this.#els;
     const lockTip = this.#lockReason();
+    LabelDetail.#setTooltip(els.voteDisplay, lockTip ?? '');
     for (const action of Object.keys(els.voteButtons)) {
       const isVoted = !lockTip && this.#prevAction === action;
-      let title;
-      if (lockTip) {
-        title = lockTip;
-      } else if (isVoted) {
-        // {{count}} is the *other* validators, so the user isn't double-counted in their own tooltip. The i18next
-        // `_zero` key covers "nobody else" without a second key and a branch here — it resolves whenever count is 0,
-        // even in languages (zh-TW) whose CLDR rules have no zero category, so those locales carry only _zero/_other.
-        const others = Math.max(0, (this.#validationCounts[action] ?? 1) - 1);
-        title = i18next.t(`labelmap:vote-tooltip-voted-${action.toLowerCase()}`, { count: others });
-      } else {
-        const count = this.#validationCounts[action] ?? 0;
-        title = i18next.t(`labelmap:vote-tooltip-${action.toLowerCase()}`, { count });
+      let tip = '';
+      if (!lockTip) {
+        if (isVoted) {
+          // {{count}} is the *other* validators, so the user isn't double-counted in their own tooltip. The i18next
+          // `_zero` key covers "nobody else" without a second key and a branch here — it resolves whenever count is
+          // 0, even in languages (zh-TW) whose CLDR rules have no zero category, so those carry only _zero/_other.
+          const others = Math.max(0, (this.#validationCounts[action] ?? 1) - 1);
+          tip = i18next.t(`labelmap:vote-tooltip-voted-${action.toLowerCase()}`, { count: others });
+        } else {
+          const count = this.#validationCounts[action] ?? 0;
+          tip = i18next.t(`labelmap:vote-tooltip-${action.toLowerCase()}`, { count });
+        }
+        // The AI's vote is folded into this option's count, so flag it where it applies. Sentences are appended in
+        // order of usefulness, so what clicking *does* lands last rather than trailing off into a footnote.
+        if (this.#aiValidation === action) tip += ` ${i18next.t('labelmap:vote-tooltip-ai-included')}`;
+        if (isVoted) tip += ` ${i18next.t('labelmap:vote-tooltip-clear')}`;
       }
-      // The AI's vote is folded into this option's count, so flag it where it applies. Sentences are appended in
-      // order of usefulness, so what clicking *does* lands last rather than trailing off into a footnote.
-      if (!lockTip && this.#aiValidation === action) title += ` ${i18next.t('labelmap:vote-tooltip-ai-included')}`;
-      if (isVoted) title += ` ${i18next.t('labelmap:vote-tooltip-clear')}`;
-      els.voteButtons[action].title = title;
-      els.panoOverlayButtons[action].title = isVoted ? i18next.t('labelmap:vote-tooltip-clear') : '';
+      LabelDetail.#setTooltip(els.voteButtons[action], tip);
+      LabelDetail.#setTooltip(els.panoOverlayButtons[action], isVoted ? i18next.t('labelmap:vote-tooltip-clear') : '');
     }
+  }
+
+  /**
+   * Points the shared tooltip (psTooltip.js) at an element, or takes it away. The card's own tooltips go through
+   * this rather than the native `title` attribute so a long sentence wraps inside a bounded card instead of
+   * stretching into a single browser-drawn line the width of the card (#4778).
+   * @param {?Element} el - The trigger; ignored when the host's markup doesn't include it.
+   * @param {string} text - The tooltip text, or an empty string to remove the tooltip.
+   */
+  static #setTooltip(el, text) {
+    if (!el) return;
+    if (text) el.setAttribute('data-ps-tooltip', text);
+    else el.removeAttribute('data-ps-tooltip');
   }
 
   /**

--- a/public/js/common/psTooltip.js
+++ b/public/js/common/psTooltip.js
@@ -65,6 +65,11 @@
    */
   const show = (trigger) => {
     const card = ensureTooltip();
+    // A modal <dialog> paints in the top layer, above every z-index in the page's normal stacking order, so a card
+    // parked on <body> opens behind it. Follow the trigger into its dialog (the label detail popup) instead. The
+    // dialog sets no transform/filter, so the card stays fixed to the viewport and escapes the dialog's overflow.
+    const host = trigger.closest('dialog[open]') ?? document.body;
+    if (card.parentElement !== host) host.appendChild(card);
     // Rendered as HTML per the header contract: tooltip strings are first-party translations, never user input.
     card.innerHTML = trigger.getAttribute('data-ps-tooltip');
     card.classList.remove('ps-tooltip--flipped'); // Reset before measuring; the flip below re-adds it if needed.

--- a/public/js/gallery/src/Main.js
+++ b/public/js/gallery/src/Main.js
@@ -7,8 +7,6 @@ window.sg = window.sg || {};
  * Construct instances via the `static async create()` factory, which initializes the gallery before resolving.
  */
 class Main {
-  #headerSidebarOffset = undefined;
-
   /**
    * Creates and initializes the Gallery Main module.
    * @param {object} params Object passed from gallery.scala.html containing initial values pulled from the database
@@ -23,16 +21,7 @@ class Main {
   }
 
   #initUI() {
-    sg.scrollStatus = {
-      stickySidebar: true,
-    };
-
     sg.ui = {};
-
-    // Initializes filter components in sidebar.
-    sg.ui.cardFilter = {};
-    sg.ui.cardFilter.wrapper = $('.sidebar');
-    sg.ui.cardFilter.holder = $('#card-filter');
 
     // Initialize card container component.
     sg.ui.cardContainer = {};
@@ -47,13 +36,8 @@ class Main {
 
     // Keep track of some other elements whose status or dimensions are useful.
     sg.ui.pageControl = $('.page-control');
-    sg.ui.navbar = $('#header');
     sg.pageLoading = $('#page-loading');
     sg.labelsNotFound = $('#labels-not-found');
-
-    // Calculate offset between bottom of navbar and sidebar.
-    this.#headerSidebarOffset
-            = sg.ui.cardFilter.wrapper.offset().top - (sg.ui.navbar.offset().top + sg.ui.navbar.outerHeight());
   }
 
   async #init(params) {
@@ -78,49 +62,5 @@ class Main {
     // Initialize data collection.
     sg.form = new Form(params.dataStoreUrl);
     sg.tracker = new Tracker();
-
-    const sidebarWrapper = sg.ui.cardFilter.wrapper;
-    const sidebarWidth = sidebarWrapper.css('width');
-
-    // Handle sidebar stickiness while scrolling. (The expanded view is position: fixed and needs no help.)
-    $(window).scroll(() => {
-      // Make sure the page isn't loading.
-      if (!sg.pageLoading.is(':visible') && !sg.labelsNotFound.is(':visible')) {
-        const sidebarBottomOffset = sidebarWrapper.offset().top + sidebarWrapper.outerHeight(true);
-        const cardContainerBottomOffset = sg.ui.cardContainer.holder.offset().top
-          + sg.ui.cardContainer.holder.outerHeight(true) - 5;
-
-        // Handle sidebar stickiness.
-        if (sg.scrollStatus.stickySidebar) {
-          if (cardContainerBottomOffset < sidebarBottomOffset) {
-            const sidebarHeightBeforeRelative = sidebarWrapper.outerHeight(true);
-
-            // Adjust sidebar positioning.
-            sidebarWrapper.css('position', 'relative');
-
-            // Compute the new location for the top of the sidebar, just above the paging arrows.
-            const navbarHeight = sg.ui.navbar.outerHeight(false);
-            const newTop = cardContainerBottomOffset - sidebarHeightBeforeRelative - navbarHeight;
-            sidebarWrapper.css('top', newTop);
-
-            // Adjust card container margin.
-            sg.ui.cardContainer.holder.css('margin-left', '0px');
-            sg.scrollStatus.stickySidebar = false;
-          }
-        } else {
-          const currHeaderSidebarOffset
-                        = sidebarWrapper.offset().top - (sg.ui.navbar.offset().top + sg.ui.navbar.outerHeight(false));
-          if (currHeaderSidebarOffset > this.#headerSidebarOffset) {
-            // Adjust sidebar positioning.
-            sidebarWrapper.css('position', 'fixed');
-            sidebarWrapper.css('top', '');
-
-            // Adjust card container margin.
-            sg.ui.cardContainer.holder.css('margin-left', sidebarWidth);
-            sg.scrollStatus.stickySidebar = true;
-          }
-        }
-      }
-    });
   }
 }

--- a/public/js/gallery/src/cards/Card.js
+++ b/public/js/gallery/src/cards/Card.js
@@ -175,6 +175,7 @@ class Card {
     cardValidationInfo.className = 'card-validation-info';
     this.validationInfoDisplay = new ValidationInfoDisplay(
       cardValidationInfo, properties.val_counts.Agree, properties.val_counts.Disagree, properties.ai_validation,
+      properties.user_validation,
     );
     cardData.appendChild(cardValidationInfo);
 
@@ -361,7 +362,9 @@ class Card {
       properties.user_validation = newUserValidation;
 
       // Update the small card's validation displays.
-      this.validationInfoDisplay.updateValCounts(properties.val_counts.Agree, properties.val_counts.Disagree);
+      this.validationInfoDisplay.updateValCounts(
+        properties.val_counts.Agree, properties.val_counts.Disagree, newUserValidation,
+      );
       this.validationMenu.showValidationOnCard(newUserValidation);
     }
   }

--- a/public/js/gallery/src/cards/CardContainer.js
+++ b/public/js/gallery/src/cards/CardContainer.js
@@ -417,10 +417,6 @@ class CardContainer {
         });
         sg.ui.pageControl.show();
         sg.pageLoading.hide();
-        sg.ui.cardFilter.wrapper.css('position', 'fixed');
-        sg.ui.cardFilter.wrapper.css('top', '');
-        uiCardContainer.holder.css('margin-left', sg.ui.cardFilter.wrapper.css('width'));
-        sg.scrollStatus.stickySidebar = true;
         sg.cardFilter.enable();
         if (this.#expandedView) {
           this.#expandedView.onPageCardsRendered();
@@ -439,9 +435,6 @@ class CardContainer {
    * Refreshes the UI after each query made by user.
    */
   #refreshUI() {
-    // TODO: To help the loading icon show, we make the sidebar positioned relatively while we are loading on the page.
-    // Otherwise, keep it fixed. This is hacky and needs a better fix.
-
     // Close expanded views (if open) and empty cards from current page.
     this.#expandedView.closeExpandedView();
     this.#clearCardContainer(this.#uiCardContainer.holder);
@@ -456,9 +449,6 @@ class CardContainer {
     sg.cardFilter.disable();
     sg.labelsNotFound.hide();
     sg.ui.pageControl.hide();
-
-    // Since we have returned to top of page,
-    sg.ui.cardFilter.wrapper.css('position', 'relative');
   }
 
   /**

--- a/public/js/gallery/src/displays/ValidationInfoDisplay.js
+++ b/public/js/gallery/src/displays/ValidationInfoDisplay.js
@@ -5,18 +5,22 @@ class ValidationInfoDisplay {
   static #ICON_BASE = '/assets/images/icons/validation/';
 
   #aiValidation;
+  #userValidation;
+  #lockReason = null;
 
   /**
    * @param {HTMLElement} container The DOM element that contains the display.
    * @param {number} agreeCount The agree count to display.
    * @param {number} disagreeCount The disagree count to display.
    * @param {string} aiValidation Either 'Agree' or 'Disagree', showing AI validation if there is any.
+   * @param {?string} userValidation The viewer's own vote on this label, or null if they haven't voted.
    */
-  constructor(container, agreeCount, disagreeCount, aiValidation) {
+  constructor(container, agreeCount, disagreeCount, aiValidation, userValidation) {
     this.agreeCount = agreeCount;
     this.disagreeCount = disagreeCount;
     this.validationContainer = container;
     this.#aiValidation = aiValidation;
+    this.#userValidation = userValidation;
 
     this.#init();
   }
@@ -67,6 +71,8 @@ class ValidationInfoDisplay {
 
   /**
    * Builds an <img> for the agree/disagree vote icon, using the `-ai` variant when the AI validated this option.
+   * The icon carries no tooltip of its own; hovering it falls through to the one on its container, so the icon and
+   * the count beside it explain the vote the same way.
    * @param {string} action 'Agree' or 'Disagree'.
    * @param {boolean} isAi Whether to use the AI variant of the icon.
    */
@@ -75,24 +81,61 @@ class ValidationInfoDisplay {
     icon.className = 'validation-info-image';
     icon.src = `${ValidationInfoDisplay.#ICON_BASE}${action.toLowerCase()}-outline${isAi ? '-ai' : ''}.svg`;
     icon.alt = '';
-    icon.setAttribute('data-toggle', 'tooltip');
-    icon.setAttribute('data-placement', 'top');
-
-    // Use AI disclaimer tooltip if there's an AI validation, otherwise just use the Agree/Disagree tooltip.
-    if (isAi) {
-      icon.setAttribute('title', i18next.t('common:ai-disclaimer', { aiVal: action }));
-      ensureAiTooltip(icon);
-    } else {
-      icon.setAttribute('title', i18next.t(`common:${action.toLowerCase()}`));
-      $(icon).tooltip('hide');
-    }
     return icon;
   }
 
-  updateValCounts(agreeCount, disagreeCount) {
+  /**
+   * Writes each thumb's tooltip, in the same words the Label Detail card uses for the same vote (#4778): what
+   * clicking does, how many validators have already voted that way, whether our AI's vote is among them, and — on
+   * the option the viewer picked — that clicking again clears it. The two cards show the same counts, so a vote
+   * that reads one way on the small card and another way on the expanded one is just two descriptions of one thing.
+   *
+   * A locked card (the viewer's own label) states that reason on both thumbs instead: none of the rest applies
+   * when the thumbs can't be clicked.
+   */
+  #renderTooltips() {
+    const containers = { Agree: this.agreeContainer, Disagree: this.disagreeContainer };
+    const counts = { Agree: this.agreeCount, Disagree: this.disagreeCount };
+    for (const [action, container] of Object.entries(containers)) {
+      const count = counts[action];
+      let tip = this.#lockReason;
+      if (!tip) {
+        const isVoted = this.#userValidation === action;
+        if (isVoted) {
+          // {{count}} is the *other* validators, so the viewer isn't double-counted in their own tooltip; the
+          // i18next `_zero` key covers "nobody else" (see LabelDetail's #renderVoteTooltips for the full note).
+          tip = i18next.t(`labelmap:vote-tooltip-voted-${action.toLowerCase()}`, { count: Math.max(0, count - 1) });
+        } else {
+          tip = i18next.t(`labelmap:vote-tooltip-${action.toLowerCase()}`, { count });
+        }
+        // Sentences are appended in order of usefulness, so what clicking *does* lands last.
+        if (this.#aiValidation === action) tip += ` ${i18next.t('labelmap:vote-tooltip-ai-included')}`;
+        if (isVoted) tip += ` ${i18next.t('labelmap:vote-tooltip-clear')}`;
+      }
+      container.setAttribute('data-ps-tooltip', tip);
+    }
+  }
+
+  /**
+   * Locks both thumbs' tooltips to a single reason, in place of the per-vote text.
+   * @param {string} reason Why validating is blocked on this card.
+   */
+  setLockReason(reason) {
+    this.#lockReason = reason;
+    this.#renderTooltips();
+  }
+
+  /**
+   * @param {number} agreeCount The agree count to display.
+   * @param {number} disagreeCount The disagree count to display.
+   * @param {?string} [userValidation] The viewer's vote once the change lands; omit to leave it as it was.
+   */
+  updateValCounts(agreeCount, disagreeCount, userValidation = this.#userValidation) {
     this.agreeCount = agreeCount;
     this.disagreeCount = disagreeCount;
+    this.#userValidation = userValidation;
     this.agreeText.innerText = `${this.agreeCount}`;
     this.disagreeText.innerText = `${this.disagreeCount}`;
+    this.#renderTooltips();
   }
 }

--- a/public/js/gallery/src/expandedview/ExpandedView.js
+++ b/public/js/gallery/src/expandedview/ExpandedView.js
@@ -313,12 +313,6 @@ class ExpandedView {
    * @param {HTMLElement} galleryCard
    */
   #highlightThumbnail(galleryCard) {
-    // Reset the sidebar as sticky.
-    sg.ui.cardFilter.wrapper.css('position', 'fixed');
-    sg.ui.cardFilter.wrapper.css('top', '');
-    sg.ui.cardContainer.holder.css('margin-left', sg.ui.cardFilter.wrapper.css('width'));
-    sg.scrollStatus.stickySidebar = true;
-
     // Scroll the selected card into view.
     const index = this.cardIndex;
     const page = sg.cardContainer.getCurrentPage();

--- a/public/js/gallery/src/validation/ValidationMenu.js
+++ b/public/js/gallery/src/validation/ValidationMenu.js
@@ -63,17 +63,13 @@ class ValidationMenu {
       const tip = i18next.t('labelmap:own-label-disabled');
       this.#galleryCard.addClass('gallery-card--readonly');
 
-      // Disable validation buttons + add tooltip; skip attaching click handlers.
-      for (const button of Object.values(this.#validationButtons)) {
-        button.prop('disabled', true).attr('title', tip);
-      }
+      // Disable validation buttons; skip attaching click handlers. The reason rides their holder rather than each
+      // button, since a disabled button swallows the hover that would open a tooltip on it.
+      for (const button of Object.values(this.#validationButtons)) button.prop('disabled', true);
+      this.#overlay.attr('data-ps-tooltip', tip);
 
-      // Add tooltip to thumb containers; skip attaching click handlers. Destroy the bootstrap tooltips on the
-      // inner Agree/Disagree icons so the native readonly tooltip shows on hover instead.
-      const valInfo = refCard.validationInfoDisplay;
-      valInfo.agreeContainer.title = tip;
-      valInfo.disagreeContainer.title = tip;
-      $(valInfo.validationContainer).find('img[data-toggle="tooltip"]').tooltip('destroy');
+      // Same reason on the thumbs, in place of the vote text they'd otherwise carry.
+      refCard.validationInfoDisplay.setLockReason(tip);
     } else {
       // Add onClick functions for the validation buttons.
       for (const [valKey, button] of Object.entries(this.#validationButtons)) {

--- a/public/js/validate/src/panorama/PanoManager.js
+++ b/public/js/validate/src/panorama/PanoManager.js
@@ -272,7 +272,9 @@ class PanoManager {
     if (overlay && getComputedStyle(overlay).display !== 'none') {
       document.addEventListener(
         'ps:mission-start-tutorial:done',
-        () => { if (this.labelMarker) this.#restartMarkerPulse(this.labelMarker.marker_); },
+        () => {
+          if (this.labelMarker) this.#restartMarkerPulse(this.labelMarker.marker_);
+        },
         { once: true },
       );
     } else {

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -98,7 +98,6 @@
   "bad": "Schlecht",
   "yes": "Ja",
   "no": "Nein",
-  "ai-disclaimer": "Die KI hat dieses Label analysiert und mit „$t({{aiVal}})“ bewertet. KI kann jedoch Fehler machen. Bitte bilden Sie sich Ihre eigene Meinung.",
   "ai-generated-label-tooltip": "Dieses Label wurde von der KI erstellt. KI kann Fehler machen, prüfen Sie es daher selbst.",
   "tag": {
     "narrow": "schmal",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -98,7 +98,6 @@
   "bad": "Bad",
   "yes": "Yes",
   "no": "No",
-  "ai-disclaimer": "AI analyzed this label and voted \"$t({{aiVal}})\"; however, AI can make mistakes. Please make your own assessment.",
   "ai-generated-label-tooltip": "This label was AI generated. AI can make mistakes, so please make your own assessment.",
   "tag": {
     "narrow": "narrow",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -98,7 +98,6 @@
   "bad": "Mala",
   "yes": "Sí",
   "no": "No",
-  "ai-disclaimer": "La IA analizó esta etiqueta y votó \"$t({{aiVal}})\"; sin embargo, la IA puede cometer errores. Por favor, haga su propia evaluación.",
   "ai-generated-label-tooltip": "Esta etiqueta fue generada por IA. La IA puede cometer errores, así que haga su propia evaluación.",
   "tag": {
     "narrow": "muy angosta",

--- a/public/locales/nl/common.json
+++ b/public/locales/nl/common.json
@@ -98,7 +98,6 @@
   "bad": "Slecht",
   "yes": "Ja",
   "no": "Nee",
-  "ai-disclaimer": "AI heeft dit label geanalyseerd en gestemd op \"$t({{aiVal}})\". AI kan echter fouten maken. Maak uw eigen beoordeling.",
   "ai-generated-label-tooltip": "Dit label is door AI gemaakt. AI kan fouten maken, dus maak uw eigen beoordeling.",
   "tag": {
     "narrow": "smal",

--- a/public/locales/pt-BR/common.json
+++ b/public/locales/pt-BR/common.json
@@ -98,7 +98,6 @@
   "bad": "Má",
   "yes": "Sim",
   "no": "Não",
-  "ai-disclaimer": "A IA analisou este rótulo e votou \"$t({{aiVal}})\"; no entanto, a IA pode cometer erros. Por favor, faça sua própria avaliação.",
   "ai-generated-label-tooltip": "Este rótulo foi gerado por IA. A IA pode cometer erros, então por favor faça sua própria avaliação.",
   "tag": {
     "narrow": "estreito",

--- a/public/locales/zh-TW/common.json
+++ b/public/locales/zh-TW/common.json
@@ -97,7 +97,6 @@
   "bad": "不良",
   "yes": "是",
   "no": "否",
-  "ai-disclaimer": "AI 分析了此標籤並投票「$t({{aiVal}})」；然而，AI 難免會犯錯。請自行判斷。",
   "ai-generated-label-tooltip": "此標籤由 AI 產生。AI 可能會犯錯，請自行判斷。",
   "tag": {
     "narrow": "狹窄",


### PR DESCRIPTION
Resolves #4778.

### 1. Tooltip width on the Label Detail card

The Gallery card's vote tooltips were still Bootstrap `title`/`data-toggle` tooltips. They now use the shared psTooltip (`data-ps-tooltip`), so they inherit `.ps-tooltip`'s `max-width` and wrap instead of running out to one long line.

psTooltip also had to follow its trigger into an open `<dialog>`: a modal dialog paints in the top layer, above every z-index in the normal stacking order, so a card parked on `<body>` opened *behind* the Label Detail popup.

### 2. Gallery tooltip text matching the Label Detail card

Gallery card tooltips are now generated the same way as the Label Detail card's — what clicking does, how many validators have already voted that way, whether our AI's vote is among them, and, on the option the viewer picked, that clicking again clears it. The two cards show the same counts, so they now read as two descriptions of one thing rather than two different claims.

A locked card (the viewer's own label) states that reason on both thumbs instead. The reason rides the thumbs' holder rather than each button, since a disabled button swallows the hover that would open a tooltip on it.

The `common:ai-disclaimer` key this replaces is now unused and is dropped from all six locales.

### 3. `cursor: pointer` on the disabled Comment button

The button is only actually `disabled` while a submit is in flight or while validating is locked — with an empty input it stays enabled and the click handler just no-ops. So keying the cursor off `:disabled` missed the state the report was about. The pointer now rides `.is-active` (non-empty input), with the `:disabled` rule ordered after it so an in-flight submit — still active-green — drops the pointer too.

### 4. Sidebar scrolled partway down the page

Root cause is older than the rest: the sidebar was `position: fixed`, so it contributed no page height. With less than a row of cards the document was shorter than the sidebar, its bottom was unreachable, and the footer started underneath it. Scrolling then tripped the handler that flips the sidebar to `position: relative` at a `top` computed from the card container's bottom — which goes negative on a short page and yanks the sidebar up, leaving half of it above the fold.

Rather than patch that arithmetic, the sidebar is now `position: sticky` and stays in flow. The page is always at least as tall as the sidebar, and sticking naturally ends at `#gallery`'s bottom edge, so it can't ride down over the paging controls or footer.

That retires `sg.scrollStatus`, the `$(window).scroll` handler in `Main.js`, and the sidebar repositioning in `CardContainer.render`/`#refreshUI` and `ExpandedView.#highlightThumbnail` (including the `// This is hacky and needs a better fix` TODO). Supporting CSS: `#gallery` goes from `overflow: hidden` to `overflow-x: clip` (`hidden` makes it a scroll container, which disables sticky), `.cards` drops its `margin-left: 275px`, and `#gallery-content` takes the rest of the flex row. The sidebar and `#card-filter` also become `border-box` — the column had been rendering 285px wide against a 275px card offset, and `#card-filter`'s `width: inherit` copied the sidebar's literal 275px before adding its own padding on top.

**Known limitation, unchanged from `develop`:** when the sidebar is taller than the viewport *and* there are enough cards for it to pin, its bottom stays out of reach while pinned — the same thing `position: fixed` does today. Giving it internal scrolling fixes that but costs ~15px of content width to the scrollbar gutter, so it would need the 275px column widened to match; left for a follow-up if it comes up.

### Testing

QA'd on the Gallery against Chicago data: empty/short result sets, a full page of cards, paging, changing filters mid-scroll, opening the expanded view from a card low on the page, and the vote tooltips on both the small and expanded cards.

ESLint, Stylelint, and locale key-parity all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
