### PR TITLE
Enable AI label submission for Richmond, VA

### DIFF
--- a/conf/cityparams.conf
+++ b/conf/cityparams.conf
@@ -901,6 +901,7 @@ city-params {
   // requires a valid INTERNAL_API_KEY on the instance, which fails closed when unset.
   ai-label-submission-enabled {
     vancouver-wa = true
+    richmond-va = true
   }
   ai-validation-min-accuracy {
     newberg-or = "0.92"


### PR DESCRIPTION
Fixes #4802.

One line in `conf/cityparams.conf`:

```hocon
 ai-label-submission-enabled {
   vancouver-wa = true
+  richmond-va = true
 }
```

#4760 shipped the per-city flag but listed only Vancouver, so `cityFlag`'s default-false read left every other city rejecting AI label submissions. Richmond is the first city to actually use the mechanism.

No code, no evolution, no frontend change. `CityFlagConfigSpec` already asserts the shape this has to satisfy — `richmond-va` is in `city-params.city-ids` and the value is a boolean — so the existing test covers it.

**Why Richmond:** its instance is `private` and effectively empty (2 users, 93 labels, 0.34 of 45.7 km explored), its `pano-viewer-type` is already `mapillary` so the auto-labeler's pano ids render, and its run is the best-validated non-GSV city we have (9,091 panos → 9,526 detections, GT P 0.965 / R 0.895). Cities with real crowd labels stay off.

**Timing:** production is still on `v11.7.0` (cut 2026-07-17), which predates #4760 — so prod currently has the *original* `vancouver-wa` hard gate, not just an unlisted city. This needs to be on `develop` before the next release branch is cut, otherwise Richmond waits a full cycle even though the mechanism is merged.

The flag only opens the gate; submission still requires a valid `INTERNAL_API_KEY` on the instance, which fails closed when unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-opus-5[1m])
