### PR TITLE
Require complete pano metadata before falling back to a backup pano

### DIFF
--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -1227,6 +1227,24 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
   }
 
   /**
+   * Whether Validate can actually show a label's imagery: the original is still live, or a backup stands in for it.
+   *
+   * Falling back to a backup means rendering it in Pannellum, which needs the pano's dimensions, camera location, and
+   * camera angles. Rows written before we recorded those carry nulls, and a label on one of them leaves Validate
+   * showing the *previous* label's imagery with the new label's marker drawn on it — the validator answers about an
+   * image that isn't the one they're looking at (#4804). Cheaper to leave those labels out of the queue: in Seattle
+   * they're 595 of the 70k expired panos otherwise eligible.
+   *
+   * `hasBackup` is NULL until the imagery check has looked at the pano, and is read optimistically so unchecked panos
+   * stay in the queue; the frontend still falls back to the label's static crop if no backup turns out to exist.
+   */
+  private def imageryViewable(pd: PanoDataTableDef): Rep[Boolean] = {
+    !pd.expired || (pd.hasBackup.getOrElse(true: Rep[Boolean]) &&
+      pd.width.isDefined && pd.height.isDefined && pd.lat.isDefined && pd.lng.isDefined &&
+      pd.cameraHeading.isDefined && pd.cameraPitch.isDefined)
+  }
+
+  /**
    * Returns how many labels this user has available to validate (& how many need validations) for each label type.
    *
    * @param userId User ID for the current user
@@ -1239,7 +1257,7 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
     val labelsToValidate = for {
       _lb <- labels
       _pd <- panoData if _pd.panoId === _lb.panoId
-      if (_pd.expired === false || _pd.hasBackup.getOrElse(true)) && _pd.source === viewer && _lb.userId =!= userId
+      if imageryViewable(_pd) && _pd.source === viewer && _lb.userId =!= userId
     } yield (_lb.labelId, _lb.labelTypeId, _lb.correct)
 
     // Left join with the labels that the user has already validated, then filter those out.
@@ -1294,7 +1312,7 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
       _ur             <- userRoles if _us.userId === _ur.userId
       _r              <- roleTable if _ur.roleId === _r.roleId
       if _lt.labelTypeId === labelTypeId && _lp.lat.isDefined && _lp.lng.isDefined && _lb.userId =!= userId
-      if _pd.source === viewer && (!_pd.expired || _pd.hasBackup.getOrElse(true: Rep[Boolean]))
+      if _pd.source === viewer && imageryViewable(_pd)
       if !unvalidatedOnly.asColumnOf[Boolean] || _lb.correct.isEmpty                     // Filter out validated labels.
       if skippedLabelId.map(_lb.labelId =!= _).getOrElse(true: Rep[Boolean])             // Filter out skipped label.
       if regionIds.map(ids => _ser.regionId inSetBind ids).getOrElse(true: Rep[Boolean]) // Filter by region IDs.

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -1227,16 +1227,16 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
   }
 
   /**
-   * Whether Validate can actually show a label's imagery: the original is still live, or a backup stands in for it.
+   * Whether Validate can show a label's imagery: the original is still live, or a viewable backup stands in.
    *
-   * Falling back to a backup means rendering it in Pannellum, which needs the pano's dimensions, camera location, and
-   * camera angles. Rows written before we recorded those carry nulls, and a label on one of them leaves Validate
-   * showing the *previous* label's imagery with the new label's marker drawn on it — the validator answers about an
-   * image that isn't the one they're looking at (#4804). Cheaper to leave those labels out of the queue: in Seattle
-   * they're 595 of the 70k expired panos otherwise eligible.
+   * Rendering a backup in Pannellum needs the pano's dimensions, camera location, and camera angles, and rows written
+   * before we recorded those carry nulls. A label on one of them leaves Validate showing the *previous* label's
+   * imagery under the new label's marker (#4804), so they're better left out of the queue.
    *
-   * `hasBackup` is NULL until the imagery check has looked at the pano, and is read optimistically so unchecked panos
-   * stay in the queue; the frontend still falls back to the label's static crop if no backup turns out to exist.
+   * `hasBackup` is NULL until the imagery check has looked at a pano and is read optimistically; the real gate is
+   * `LabelService.checkImageryBatch`, which checks disk and API per label as a mission is built.
+   *
+   * The six columns mirror `PanoData`'s `requiredParams` — see the note there before changing them.
    */
   private def imageryViewable(pd: PanoDataTableDef): Rep[Boolean] = {
     !pd.expired || (pd.hasBackup.getOrElse(true: Rep[Boolean]) &&

--- a/app/service/LabelService.scala
+++ b/app/service/LabelService.scala
@@ -367,7 +367,10 @@ class LabelServiceImpl @Inject() (
 
   // Checks each label in a batch for imagery availability. When useCrops is true, labels with a locally-saved crop
   // image are accepted without querying the API; only labels lacking a crop are checked. When useCrops is false, all
-  // labels are checked via panoExists(); labels with a locally-hosted backup pass as well.
+  // labels are checked via panoExists(); labels with a viewable locally-hosted backup pass as well.
+  //
+  // This is the real gate for expired imagery, not pano_data.expired: that column is refreshed lazily, so a row still
+  // claiming expired = false while the imagery is gone sails past LabelTable.imageryViewable to here.
   private def checkImageryBatch[A <: BasicLabelMetadata](labels: Seq[A], useCrops: Boolean): Future[Seq[A]] = {
     if (useCrops) {
       // Partition: labels with local crops pass immediately; the rest are checked via panoExists().
@@ -383,9 +386,11 @@ class LabelServiceImpl @Inject() (
     } else {
       Future
         .traverse(labels) { label =>
-          panoDataService.panoExists(label.panoId, label.panoSource).map {
-            case Some(true) => Some(label)
-            case _          => if (panoDataService.backupExists(label.panoId)) Some(label) else None
+          panoDataService.panoExists(label.panoId, label.panoSource).flatMap {
+            case Some(true) => Future.successful(Some(label))
+            // getLocalBackupImage, not backupExists: a file on disk is only usable if pano_data also has the metadata
+            // Pannellum needs. Validate has no fallback behind it, so admitting a label we can't render is #4804.
+            case _ => panoDataService.getLocalBackupImage(label.panoId).map(_.map(_ => label))
           }
         }
         .map(_.flatten)

--- a/app/service/PanoDataService.scala
+++ b/app/service/PanoDataService.scala
@@ -518,6 +518,9 @@ class PanoDataServiceImpl @Inject() (
 
   /**
    * Returns the pano_data row for a pano if a self-hosted image exists AND all required fields are populated.
+   *
+   * "Required" means what PannellumViewer needs to render the backup; the columns mirror `PanoData`'s
+   * `requiredParams` (public/js/common/pano-viewer/src/PanoData.js) — see the note there before changing them.
    */
   def getLocalBackupImage(panoId: String): Future[Option[PanoData]] = {
     if (localBackupImageFile(panoId).isEmpty) {

--- a/public/js/common/pano-viewer/src/PanoData.js
+++ b/public/js/common/pano-viewer/src/PanoData.js
@@ -25,7 +25,10 @@ class PanoData {
    * @constructor
    */
   constructor(params) {
-    // Validate required parameters.
+    // Validate required parameters. Three guards keep unrenderable backup panos away from PannellumViewer by
+    // requiring the subset of this list that a pano_data row can be missing, so adding a field here means updating
+    // them too (#4804): LabelTable.imageryViewable, PanoDataServiceImpl.getLocalBackupImage, and
+    // backupImageDataIsComplete in utilitiesSidewalk.js.
     const requiredParams = [
       'panoId', 'source', 'lat', 'lng', 'cameraHeading', 'cameraPitch', 'width', 'height', 'captureDate', 'linkedPanos',
       'history',

--- a/public/js/common/utilitiesSidewalk.js
+++ b/public/js/common/utilitiesSidewalk.js
@@ -648,9 +648,25 @@ function UtilitiesMisc(JSON) {
 util.misc = UtilitiesMisc(JSON);
 
 /**
+ * Whether a backup pano carries the metadata PannellumViewer needs to render it.
+ *
+ * pano_data rows written before we recorded these carry nulls for them, and PanoData rejects a pano that's missing
+ * any — so callers must check before offering a backup, and fall back to the label's static crop when it fails
+ * (#4804). Takes the camelCase shape both /backupImage/:panoId/metadata and buildBackupImageData produce.
+ *
+ * @param {?object} data Backup pano metadata, or null.
+ * @returns {boolean} True when every field the viewer needs is present and numeric.
+ */
+function backupImageDataIsComplete(data) {
+  const required = ['width', 'height', 'lat', 'lng', 'cameraHeading', 'cameraPitch'];
+  return !!data && required.every((field) => typeof data[field] === 'number' && !isNaN(data[field]));
+}
+
+/**
  * Builds the {url, metadata} object needed by Pannellum from a label metadata object sent by the server.
  *
- * Returns null if backup_image_url is absent or null, or if pano_data is missing.
+ * Returns null if backup_image_url is absent or null, if pano_data is missing, or if pano_data is too incomplete to
+ * render (see backupImageDataIsComplete).
  * @param {object} meta Label metadata object from the server.
  * @param {string|null} meta.backup_image_url URL for the self-hosted backup image, or null.
  * @param {object|null} meta.pano_data Nested pano viewer metadata, or null.
@@ -663,7 +679,7 @@ util.misc = UtilitiesMisc(JSON);
 function buildBackupImageData(meta) {
   if (!meta.backup_image_url || !meta.pano_data) return null;
   const pd = meta.pano_data;
-  return {
+  const backupImageData = {
     panoId: meta.pano_id,
     imageUrl: meta.backup_image_url,
     width: pd.width,
@@ -679,4 +695,5 @@ function buildBackupImageData(meta) {
     copyright: pd.copyright,
     address: pd.address,
   };
+  return backupImageDataIsComplete(backupImageData) ? backupImageData : null;
 }

--- a/public/js/common/utilitiesSidewalk.js
+++ b/public/js/common/utilitiesSidewalk.js
@@ -650,8 +650,11 @@ util.misc = UtilitiesMisc(JSON);
 /**
  * Fields PannellumViewer needs to render a backup pano: the subset of PanoData's `requiredParams` that a pano_data
  * row can be missing. See the note there before changing this list.
+ *
+ * A property rather than a top-level `const` because some views load this file directly on a page whose bundle
+ * already concatenates it. Re-running it must stay harmless, and a repeated `const` is a fatal redeclaration.
  */
-const BACKUP_IMAGE_REQUIRED_FIELDS = ['width', 'height', 'lat', 'lng', 'cameraHeading', 'cameraPitch'];
+util.misc.BACKUP_IMAGE_REQUIRED_FIELDS = ['width', 'height', 'lat', 'lng', 'cameraHeading', 'cameraPitch'];
 
 /**
  * Whether a backup pano carries the metadata PannellumViewer needs to render it.
@@ -663,7 +666,8 @@ const BACKUP_IMAGE_REQUIRED_FIELDS = ['width', 'height', 'lat', 'lng', 'cameraHe
  * @returns {boolean} True when every field the viewer needs is present and numeric.
  */
 function backupImageDataIsComplete(data) {
-  return !!data && BACKUP_IMAGE_REQUIRED_FIELDS.every((f) => typeof data[f] === 'number' && !isNaN(data[f]));
+  return !!data
+    && util.misc.BACKUP_IMAGE_REQUIRED_FIELDS.every((f) => typeof data[f] === 'number' && !isNaN(data[f]));
 }
 
 /**

--- a/public/js/common/utilitiesSidewalk.js
+++ b/public/js/common/utilitiesSidewalk.js
@@ -648,18 +648,22 @@ function UtilitiesMisc(JSON) {
 util.misc = UtilitiesMisc(JSON);
 
 /**
+ * Fields PannellumViewer needs to render a backup pano: the subset of PanoData's `requiredParams` that a pano_data
+ * row can be missing. See the note there before changing this list.
+ */
+const BACKUP_IMAGE_REQUIRED_FIELDS = ['width', 'height', 'lat', 'lng', 'cameraHeading', 'cameraPitch'];
+
+/**
  * Whether a backup pano carries the metadata PannellumViewer needs to render it.
  *
- * pano_data rows written before we recorded these carry nulls for them, and PanoData rejects a pano that's missing
- * any — so callers must check before offering a backup, and fall back to the label's static crop when it fails
- * (#4804). Takes the camelCase shape both /backupImage/:panoId/metadata and buildBackupImageData produce.
+ * Old pano_data rows carry nulls for these and PanoData rejects them (#4804). Guards the buildBackupImageData path
+ * only — the /backupImage/:panoId/metadata payload is already filtered server-side by `getLocalBackupImage`.
  *
- * @param {?object} data Backup pano metadata, or null.
+ * @param {?object} data Backup pano metadata in the camelCase shape buildBackupImageData produces, or null.
  * @returns {boolean} True when every field the viewer needs is present and numeric.
  */
 function backupImageDataIsComplete(data) {
-  const required = ['width', 'height', 'lat', 'lng', 'cameraHeading', 'cameraPitch'];
-  return !!data && required.every((field) => typeof data[field] === 'number' && !isNaN(data[field]));
+  return !!data && BACKUP_IMAGE_REQUIRED_FIELDS.every((f) => typeof data[f] === 'number' && !isNaN(data[f]));
 }
 
 /**

--- a/test/js/backupImageDataIsComplete.test.js
+++ b/test/js/backupImageDataIsComplete.test.js
@@ -10,6 +10,11 @@
 const fs = require('fs');
 const path = require('path');
 
+// jest-environment-jsdom doesn't expose these, and jsdom's own dependencies need them when required from within a
+// test (the "runs twice" case below drives a second jsdom instance to get real <script> semantics).
+global.TextEncoder = global.TextEncoder ?? require('node:util').TextEncoder;
+global.TextDecoder = global.TextDecoder ?? require('node:util').TextDecoder;
+
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
 const UTILITIES_PATH = path.join(REPO_ROOT, 'public/js/common/utilitiesSidewalk.js');
 const PANO_DATA_PATH = path.join(REPO_ROOT, 'public/js/common/pano-viewer/src/PanoData.js');
@@ -72,10 +77,32 @@ function labelMetadata(panoDataOverrides = {}) {
 }
 
 beforeAll(() => {
-  loadScript(UTILITIES_PATH, ['BACKUP_IMAGE_REQUIRED_FIELDS']);
+  loadScript(UTILITIES_PATH, []);
   // PanoData checks `captureDate instanceof moment`; a bare constructor is enough to satisfy it here.
   global.moment = function Moment() {};
   loadScript(PANO_DATA_PATH, ['PanoData']);
+});
+
+test('the script can run twice on one page', () => {
+  // Some views load this file directly on a page whose bundle already concatenates it, so it executes twice. A
+  // top-level `const` made the second execution a fatal redeclaration that took /labelMap down.
+  //
+  // Driven through real <script> tags rather than the eval() loader above, which cannot catch this: eval puts its
+  // lexical declarations in a scope it throws away, so a repeated `const` there is harmless.
+  const { JSDOM, VirtualConsole } = require('jsdom');
+  const virtualConsole = new VirtualConsole();
+  const errors = [];
+  virtualConsole.on('jsdomError', (e) => errors.push(e.message));
+  const dom = new JSDOM('<!doctype html><body>', { runScripts: 'dangerously', virtualConsole });
+
+  const src = fs.readFileSync(UTILITIES_PATH, 'utf8');
+  for (let i = 0; i < 2; i++) {
+    const script = dom.window.document.createElement('script');
+    script.textContent = src;
+    dom.window.document.body.appendChild(script);
+  }
+
+  expect(errors).toEqual([]);
 });
 
 describe('backupImageDataIsComplete', () => {
@@ -186,7 +213,7 @@ describe('coupling to PanoData', () => {
       delete params[field];
 
       expect(() => new PanoData(params)).toThrow(`Missing required parameter: ${field}`);
-      expect(BACKUP_IMAGE_REQUIRED_FIELDS).toContain(field);
+      expect(util.misc.BACKUP_IMAGE_REQUIRED_FIELDS).toContain(field);
     },
   );
 
@@ -195,7 +222,7 @@ describe('coupling to PanoData', () => {
     const suppliedByViewer = ['panoId', 'source', 'captureDate', 'linkedPanos', 'history'];
     for (const field of Object.keys(panoDataParams())) {
       if (!suppliedByViewer.includes(field)) {
-        expect(BACKUP_IMAGE_REQUIRED_FIELDS).toContain(field);
+        expect(util.misc.BACKUP_IMAGE_REQUIRED_FIELDS).toContain(field);
       }
     }
   });

--- a/test/js/backupImageDataIsComplete.test.js
+++ b/test/js/backupImageDataIsComplete.test.js
@@ -1,0 +1,202 @@
+/**
+ * Tests for `backupImageDataIsComplete` / `buildBackupImageData` in public/js/common/utilitiesSidewalk.js, which keep
+ * a pano_data row with null width/height from reaching PannellumViewer and throwing (#4804).
+ *
+ * The last block pins the guard's field list against PanoData, the authority it and two backend copies answer to.
+ *
+ * Runs under jsdom (jest.config.js).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const UTILITIES_PATH = path.join(REPO_ROOT, 'public/js/common/utilitiesSidewalk.js');
+const PANO_DATA_PATH = path.join(REPO_ROOT, 'public/js/common/pano-viewer/src/PanoData.js');
+
+/**
+ * Execute a production global script in the jsdom global scope, then hoist the named bindings onto `global`.
+ *
+ * Indirect eval puts top-level `function` declarations on globalThis, but not `const`/`class` — hence the epilogue.
+ *
+ * @param {string} filePath Absolute path to the script.
+ * @param {string[]} names Bindings to expose on `global`.
+ */
+function loadScript(filePath, names) {
+  const src = fs.readFileSync(filePath, 'utf8');
+  const epilogue = names.map((n) => `global.${n} = ${n};`).join('\n');
+  (0, eval)(`${src}\n${epilogue}`);
+}
+
+/** A backup pano whose metadata is complete — the shape buildBackupImageData produces. */
+function completeBackupImageData() {
+  return {
+    panoId: 'abc123',
+    imageUrl: '/backupImage/abc123?exp=1&sig=x',
+    width: 13312,
+    height: 6656,
+    tileWidth: 512,
+    tileHeight: 512,
+    lat: 47.6,
+    lng: -122.3,
+    cameraHeading: 180.5,
+    cameraPitch: 0,
+    cameraRoll: 0,
+    captureDate: '2011-05',
+    copyright: '© 2011 Google',
+    address: '123 Fake St',
+  };
+}
+
+/** Label metadata as the server sends it, for the buildBackupImageData tests. */
+function labelMetadata(panoDataOverrides = {}) {
+  return {
+    pano_id: 'abc123',
+    backup_image_url: '/backupImage/abc123?exp=1&sig=x',
+    camera_lat: 47.6,
+    camera_lng: -122.3,
+    image_capture_date: '2011-05',
+    pano_data: {
+      width: 13312,
+      height: 6656,
+      tile_width: 512,
+      tile_height: 512,
+      camera_heading: 180.5,
+      camera_pitch: 0,
+      camera_roll: 0,
+      copyright: '© 2011 Google',
+      address: '123 Fake St',
+      ...panoDataOverrides,
+    },
+  };
+}
+
+beforeAll(() => {
+  loadScript(UTILITIES_PATH, ['BACKUP_IMAGE_REQUIRED_FIELDS']);
+  // PanoData checks `captureDate instanceof moment`; a bare constructor is enough to satisfy it here.
+  global.moment = function Moment() {};
+  loadScript(PANO_DATA_PATH, ['PanoData']);
+});
+
+describe('backupImageDataIsComplete', () => {
+  test('accepts metadata with every required field', () => {
+    expect(backupImageDataIsComplete(completeBackupImageData())).toBe(true);
+  });
+
+  test.each(['width', 'height', 'lat', 'lng', 'cameraHeading', 'cameraPitch'])('rejects null %s', (field) => {
+    const data = completeBackupImageData();
+    data[field] = null; // What the server sends for a NULL pano_data column.
+    expect(backupImageDataIsComplete(data)).toBe(false);
+  });
+
+  test.each(['width', 'height', 'lat', 'lng', 'cameraHeading', 'cameraPitch'])('rejects missing %s', (field) => {
+    const data = completeBackupImageData();
+    delete data[field];
+    expect(backupImageDataIsComplete(data)).toBe(false);
+  });
+
+  test('rejects a field that is present but not a usable number', () => {
+    expect(backupImageDataIsComplete({ ...completeBackupImageData(), width: NaN })).toBe(false);
+    expect(backupImageDataIsComplete({ ...completeBackupImageData(), width: '13312' })).toBe(false);
+  });
+
+  test('accepts zero values, which are legitimate for the camera angles', () => {
+    const data = { ...completeBackupImageData(), cameraHeading: 0, cameraPitch: 0 };
+    expect(backupImageDataIsComplete(data)).toBe(true);
+  });
+
+  test('rejects null and undefined', () => {
+    expect(backupImageDataIsComplete(null)).toBe(false);
+    expect(backupImageDataIsComplete(undefined)).toBe(false);
+  });
+
+  test('does not require the optional fields', () => {
+    const data = completeBackupImageData();
+    delete data.cameraRoll;
+    delete data.tileWidth;
+    delete data.tileHeight;
+    delete data.address;
+    delete data.copyright;
+    expect(backupImageDataIsComplete(data)).toBe(true);
+  });
+});
+
+describe('buildBackupImageData', () => {
+  test('builds the viewer metadata when pano_data is complete', () => {
+    const built = buildBackupImageData(labelMetadata());
+
+    expect(built).not.toBeNull();
+    expect(built.panoId).toBe('abc123');
+    expect(built.width).toBe(13312);
+    expect(built.cameraHeading).toBe(180.5);
+    // Camera position comes off the label metadata, not the nested pano_data.
+    expect(built.lat).toBe(47.6);
+    expect(built.lng).toBe(-122.3);
+  });
+
+  test('returns null when pano_data is missing the dimensions (#4804)', () => {
+    expect(buildBackupImageData(labelMetadata({ width: null, height: null }))).toBeNull();
+  });
+
+  test('returns null when pano_data is missing the camera angles', () => {
+    expect(buildBackupImageData(labelMetadata({ camera_pitch: null }))).toBeNull();
+  });
+
+  test('returns null when there is no camera location', () => {
+    const meta = labelMetadata();
+    meta.camera_lat = null;
+    meta.camera_lng = null;
+    expect(buildBackupImageData(meta)).toBeNull();
+  });
+
+  test('returns null when there is no backup image or no pano_data at all', () => {
+    expect(buildBackupImageData({ ...labelMetadata(), backup_image_url: null })).toBeNull();
+    expect(buildBackupImageData({ ...labelMetadata(), pano_data: null })).toBeNull();
+  });
+});
+
+describe('coupling to PanoData', () => {
+  /** The params PannellumViewer hands PanoData for a complete backup pano. */
+  function panoDataParams() {
+    return {
+      panoId: 'abc123',
+      source: 'pannellum',
+      lat: 47.6,
+      lng: -122.3,
+      cameraHeading: 180.5,
+      cameraPitch: 0,
+      width: 13312,
+      height: 6656,
+      captureDate: new global.moment(),
+      linkedPanos: [],
+      history: [],
+    };
+  }
+
+  test('the params are otherwise valid, so the per-field assertions below mean what they say', () => {
+    expect(() => new PanoData(panoDataParams())).not.toThrow();
+  });
+
+  // If a field is added to PanoData's requiredParams, this fails until the guard (and its two backend copies) catch
+  // up, rather than #4804 recurring silently.
+  test.each(['width', 'height', 'lat', 'lng', 'cameraHeading', 'cameraPitch'])(
+    'PanoData rejects a pano missing %s, matching the guard',
+    (field) => {
+      const params = panoDataParams();
+      delete params[field];
+
+      expect(() => new PanoData(params)).toThrow(`Missing required parameter: ${field}`);
+      expect(BACKUP_IMAGE_REQUIRED_FIELDS).toContain(field);
+    },
+  );
+
+  test('the guard checks every field PanoData requires that a pano_data row can be missing', () => {
+    // These are supplied unconditionally by PannellumViewer#buildPanoData, so they can't be missing at runtime.
+    const suppliedByViewer = ['panoId', 'source', 'captureDate', 'linkedPanos', 'history'];
+    for (const field of Object.keys(panoDataParams())) {
+      if (!suppliedByViewer.includes(field)) {
+        expect(BACKUP_IMAGE_REQUIRED_FIELDS).toContain(field);
+      }
+    }
+  });
+});


### PR DESCRIPTION
Resolves #4804.

Takes option 1 from the issue: require valid pano metadata to show a backup pano, rather than loosening `PanoData`.

## The bug

`pano_data.width`/`height` are nullable and plenty of rows have them null — in `sidewalk_seattle`, 1,312 of 183,211 rows, 595 of them expired panos otherwise eligible for Validate. `buildBackupImageData` passed those nulls straight through to `PanoData`, whose required-params check threw.

The failure was quiet and worse than it looked. When the Pannellum fallback throws (or when `backupImage` is null to begin with), `GsvViewer.setPano` has already rejected inside `getPanorama()` — before `gsvPano.setPano()` is ever called — so the widget keeps rendering the **previous** label's panorama. `renderCurrentLabel` then continues unconditionally: it pans that stale image to the new label's POV, draws the new label's marker on it, and re-enables the validation buttons. The validator is asked about an image that is not the one in front of them. The only visible symptom is that the pano won't pan (`panoLoaded` stays false, which `PanoOverlay` gates dragging on).

## Changes

Three guards now require the same six columns — the subset of `PanoData`'s `requiredParams` that a `pano_data` row can be missing. That list is the authority and carries the note naming its dependents, so there's one place to look when it changes.

**`LabelTable.scala`** — new private `imageryViewable(pd)` helper, used by both `getAvailableValidationsLabelsByType` and `retrieveLabelListForValidationQuery`. Those two carried drifting copies of the same condition; sharing it puts one domain rule in one place, which is the drift that produced #4804 in the first place. It deliberately does **not** make the two queries equivalent: the counting query is a cheap upper bound (`label` + `pano_data`, grouped by type) whose only jobs are dropping label types with obviously too few labels and weighting a random pick. It could not match the queue even in principle — `findValidLabelsForType` → `checkImageryBatch` makes a live per-label imagery check that no DB predicate can predict.

**`LabelService.scala`** — `checkImageryBatch` accepted any backup file on disk via `backupExists`, with no metadata requirement. That matters more than the query filter: `pano_data.expired` is refreshed lazily, so most labels whose imagery is actually gone still read as `expired = false` and reach Validate through this check rather than through `imageryViewable`. It now uses `getLocalBackupImage`, which requires the file *and* the metadata.

**`utilitiesSidewalk.js`** — `buildBackupImageData` returns null when the metadata is incomplete, via a new `backupImageDataIsComplete` helper. This covers Gallery, Label Map, dashboards, and the shared-label page, which fetch labels individually rather than through the Validate query; they fall through to the static crop instead of throwing.

## Notes

- The required set includes `camera_heading`/`camera_pitch` alongside width/height/lat/lng. `PanoData` requires those too, so omitting them would let the identical exception through, and they cost nothing — zero expired Seattle panos are missing them.
- `PanoDataServiceImpl.getLocalBackupImage` already enforced this exact set, which is why `/backupImage/:panoId/metadata` correctly 404s for these panos and that path needed no client-side guard.
- **This does not fix the failure mode, only two of its causes.** Validate still keeps the previous label's pano on screen whenever a load fails for any other reason — Pannellum 404/WebGL error, or a transient GSV failure on perfectly good imagery. #4810 tracks the rendering-layer fix (report the failure, skip or show an unavailable state, tear down the stale canvas, and log it so we can tell how often it happens).
- Cost of the filter in Seattle: 595 of 182,502 eligible panos, 871 labels. #4805 tracks backfilling `width`/`height` from the backup images on disk to win most of those back.

## Testing

- `sbt compile` + `scalafmtCheckAll` clean; `make eslint` clean on the touched dirs
- `npm run test:js` — 557 passing, including 30 new cases for `backupImageDataIsComplete` / `buildBackupImageData`. The last block loads `PanoData` and asserts it genuinely throws for every field the guard checks, so adding a field to `requiredParams` fails the test rather than silently reintroducing #4804.
- Swept all 11 local schemas that have `has_backup`. Seattle is the only city that loses anything; the Mapillary (richmond) and Infra3d (zurich, winterthur) cities drop 0, though their local datasets are thin. Worst-hit label type in Seattle is NoSidewalk: 391 dropped, 51,808 still eligible against a mission length of 10, so no risk of starving a type out of the rotation.

Worth a look on the test server at a label whose pano has a backup, to confirm the Pannellum fallback still renders for the complete rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
