### PR TITLE
Fix the pano info popover's provider link on fallback imagery (#4813)

### DIFF
--- a/public/js/common/label-detail/LabelDetail.js
+++ b/public/js/common/label-detail/LabelDetail.js
@@ -237,17 +237,19 @@ class LabelDetail {
     const host = this.#q('.label-detail__info-button-host');
     if (!host) return;
 
-    const panoViewer = this.panoManager.panoViewer;
+    // Resolve panoManager.panoViewer per use rather than capturing it: it swaps between the primary viewer and
+    // Pannellum as labels are opened, and a captured viewer keeps describing the previously shown pano (#4813).
+    const panoViewer = () => this.panoManager.panoViewer;
     new PanoInfoPopover(
       host,
-      this.panoManager.panoViewer,
+      panoViewer,
       () =>
         this.#currentLabelMeta && { lat: this.#currentLabelMeta.camera_lat, lng: this.#currentLabelMeta.camera_lng },
       () => this.#currentLabelMeta && this.#currentLabelMeta.pano_id,
       () => this.#currentLabelMeta && this.#currentLabelMeta.street_edge_id,
       () => this.#currentLabelMeta && this.#currentLabelMeta.region_id,
       () => this.#currentLabelMeta && moment(new Date(this.#currentLabelMeta.image_capture_date)),
-      () => (panoViewer.currPanoData ? panoViewer.currPanoData.getProperty('address') : null),
+      () => (panoViewer().currPanoData ? panoViewer().currPanoData.getProperty('address') : null),
       () => this.#currentLabelMeta && {
         heading: this.#currentLabelMeta.heading, pitch: this.#currentLabelMeta.pitch, zoom: this.#currentLabelMeta.zoom,
       },

--- a/public/js/common/pano-viewer/src/PanoInfoPopover.js
+++ b/public/js/common/pano-viewer/src/PanoInfoPopover.js
@@ -10,7 +10,8 @@ class PanoInfoPopover {
   /** @type {HTMLImageElement} The info button that triggers the popover. */
   #infoButton;
 
-  /** @type {PanoViewer} */
+  /** @type {function(): PanoViewer} Returns the *currently active* viewer — Validate and the label card swap
+   * viewers per label (primary ↔ Pannellum), so this must be resolved on each open, not captured once (#4813). */
   #panoViewer;
   /** @type {function(): {lat: number, lng: number}} */
   #coords;
@@ -38,10 +39,12 @@ class PanoInfoPopover {
   #labelId;
   /** @type {function(): object|undefined} Optional — returns the label's timestamp as a moment object. */
   #labelDate;
+  /** @type {Set<PanoViewer>} Viewers already subscribed to by #watchViewer(). */
+  #watchedViewers = new Set();
 
   /**
    * @param {HTMLElement} container Element where the info button will be appended
-   * @param {PanoViewer} panoViewer PanoViewer object
+   * @param {function} panoViewer Function that returns the currently active PanoViewer
    * @param {function} coords Function that returns { lat, lng } for the current position
    * @param {function} panoId Function that returns the current panorama/image ID
    * @param {function} streetEdgeId Function that returns the current Street Edge ID
@@ -99,11 +102,6 @@ class PanoInfoPopover {
     if (this.#labelId) this.#showOptionalRow('label-id');
     if (this.#labelDate) this.#showOptionalRow('label-date');
 
-    // Hide the view-in-pano link for viewers that have no external URL.
-    if (this.#panoViewer.getViewerType() === 'infra3d') {
-      this.#popoverEl.querySelector('.pano-info-popover__view-link').style.display = 'none';
-    }
-
     // Toggle the popover on info button click.
     this.#infoButton.addEventListener('click', () => {
       if (this.#popoverEl.matches(':popover-open')) {
@@ -129,8 +127,20 @@ class PanoInfoPopover {
       }
     });
 
-    // Close whenever the panorama changes.
-    this.#panoViewer.addListener('pano_changed', () => {
+    this.#watchViewer(this.#panoViewer());
+  }
+
+  /**
+   * Subscribes to a viewer's pano_changed so the popover closes rather than sitting there with stale values.
+   *
+   * Called again on every open because viewers are created lazily: Validate and the label card only build their
+   * Pannellum viewer once an expired pano needs it, so it doesn't exist yet at construction time.
+   * @param {PanoViewer} viewer The viewer to subscribe to; ignored if null or already subscribed
+   */
+  #watchViewer(viewer) {
+    if (!viewer || this.#watchedViewers.has(viewer)) return;
+    this.#watchedViewers.add(viewer);
+    viewer.addListener('pano_changed', () => {
       if (this.#popoverEl.matches(':popover-open')) this.#popoverEl.hidePopover();
     });
   }
@@ -168,6 +178,9 @@ class PanoInfoPopover {
    * Reads the current pano/label state and updates value spans in the popover, then wires the clipboard/view actions.
    */
   #updateVals() {
+    const viewer = this.#panoViewer();
+    this.#watchViewer(viewer);
+
     const currCoords = this.#coords ? this.#coords() : null;
     const currPanoId = this.#panoId ? this.#panoId() : null;
     const currStreetEdgeId = this.#streetEdgeId ? this.#streetEdgeId() : null;
@@ -204,17 +217,29 @@ class PanoInfoPopover {
     if (currLabelDate) setVal('label-date', currLabelDate);
 
     // Update the view-in-pano link (at the live camera angle, unlike the label card's stored-POV address link).
+    // Two things have to hold for it to lead anywhere real, and both are re-checked on every open because the
+    // active viewer changes from label to label (#4813). First, the provider has to publish a viewer at all —
+    // Infra3d doesn't, and publicViewerLink() returns null for it. Second, that viewer has to actually be holding
+    // the pano this popover is describing: on the Pannellum and static-crop fallbacks we're showing our own copy
+    // of imagery the provider has dropped, while panoViewer still points at the provider's viewer sitting on
+    // whichever pano it loaded last — so a link built from it would open the wrong label's pano, or a dead one.
     const viewLink = this.#popoverEl.querySelector('.pano-info-popover__view-link');
-    if (viewLink && !viewLink.hidden) {
-      viewLink.onclick = this.#viewPanoLogging;
-      const link = this.#panoViewer.publicViewerLink(currPanoId, {
-        heading: currPov.heading,
-        pitch: currPov.pitch,
-        center: this.#panoViewer.currCenter,
-      });
+    const showingThisPano = !!viewer && !!viewer.currPanoData && viewer.currPanoData.getPanoId() === currPanoId;
+    const link = showingThisPano && viewer.publicViewerLink(currPanoId, {
+      heading: currPov.heading,
+      pitch: currPov.pitch,
+      center: viewer.currCenter,
+    });
+    if (viewLink) {
+      // Inline style, not the hidden attribute: .pano-info-popover__view-link sets display: block, which outranks
+      // the UA's [hidden] rule.
+      viewLink.style.display = link ? '' : 'none';
       if (link) {
+        viewLink.onclick = this.#viewPanoLogging;
         viewLink.href = link.url;
         viewLink.textContent = i18next.t(link.i18nKey);
+      } else {
+        viewLink.removeAttribute('href');
       }
     }
 
@@ -235,7 +260,7 @@ class PanoInfoPopover {
         + `${i18next.t('common:pano-info.pano-date')}: ${currPanoDate}\n`;
       if (currLabelId) text += `${i18next.t('common:pano-info.label-id')}: ${currLabelId}\n`;
       if (currLabelDate) text += `${i18next.t('common:pano-info.label-date')}: ${currLabelDate}\n`;
-      if (viewLink && !viewLink.hidden) text += `Pano URL: ${viewLink.href}`;
+      if (link) text += `Pano URL: ${link.url}`;
 
       navigator.clipboard.writeText(text);
 

--- a/public/js/explore/src/Main.js
+++ b/public/js/explore/src/Main.js
@@ -176,12 +176,13 @@ class Main {
     svl.panoOverlayControls = new PanoOverlayControls(svl.tracker, svl.navigationService, svl.stuckAlert,
       svl.keyboardShortcutAlert);
 
-    svl.infoPopover = new PanoInfoPopover(svl.ui.streetview.dateHolder, svl.panoViewer, svl.panoViewer.getPosition,
-      svl.panoViewer.getPanoId, () => svl.taskContainer.getCurrentTaskStreetEdgeId(),
+    svl.infoPopover = new PanoInfoPopover(svl.ui.streetview.dateHolder, () => svl.panoViewer,
+      () => svl.panoViewer.getPosition(), () => svl.panoViewer.getPanoId(),
+      () => svl.taskContainer.getCurrentTaskStreetEdgeId(),
       () => svl.neighborhoodModel.currentNeighborhood().getRegionId(),
       () => svl.panoStore.getPanoData(svl.panoViewer.getPanoId()).getProperty('captureDate'),
       () => svl.panoStore.getPanoData(svl.panoViewer.getPanoId()).getProperty('address'),
-      svl.panoViewer.getPov, true,
+      () => svl.panoViewer.getPov(), true,
       () => {
         svl.tracker.push('PanoInfoButton_Click');
       },

--- a/public/js/validate/src/Main.js
+++ b/public/js/validate/src/Main.js
@@ -214,8 +214,12 @@ class Main {
     svv.missionContainer.createAMission(param.mission, param.progress);
 
     if (!util.isMobile()) {
+      // Read svv.panoViewer through closures rather than capturing it here: PanoManager swaps it between the
+      // primary viewer and Pannellum as labels come and go, and a captured viewer keeps reporting the pano from
+      // the last label it showed (#4813).
       svv.infoPopover = new PanoInfoPopover(
-        svv.ui.viewer.dateHolder, svv.panoViewer, svv.panoViewer.getPosition, svv.panoViewer.getPanoId,
+        svv.ui.viewer.dateHolder, () => svv.panoViewer,
+        () => svv.panoViewer.getPosition(), () => svv.panoViewer.getPanoId(),
         () => {
           return svv.labelContainer.getCurrentLabel().getAuditProperty('streetEdgeId');
         },
@@ -228,7 +232,7 @@ class Main {
         () => {
           return svv.panoStore.getPanoData(svv.panoViewer.getPanoId()).getProperty('address');
         },
-        svv.panoViewer.getPov, true, () => {
+        () => svv.panoViewer.getPov(), true, () => {
           svv.tracker.push('PanoInfoButton_Click');
         },
         () => {

--- a/test/js/README.md
+++ b/test/js/README.md
@@ -32,6 +32,13 @@ Also covered, beyond the api-docs previews:
 - `community/*.js` → `communityListPage.test.js` — the /stories + /routes listing pages' client layer (#4688):
   search filtering (hidden attr, live count, no-results), sort orders and tie-breaks, localized dates, type-chip
   tinting, the read-more clamp toggle, view-label popup-vs-navigation routing, and the copy-share-link fallbacks.
+- `common/pano-viewer/src/PanoInfoPopover.js` → `panoInfoViewLink.test.js` — the pano info popover's
+  "view in \<provider\>" link (#4813). Validate and the label card swap the active viewer from label to label, so the
+  popover resolves it on every open and offers the link only when that viewer both publishes a public site and is
+  holding the pano on screen. These pin the link hidden — rather than left pointing at the previous label's pano — on
+  both fallbacks: Pannellum, and the static crop, where the provider's viewer is still loaded but with someone else's
+  pano. Like `ShareWidget` this is a top-level `class`, so the test evals the source instead of using
+  `loadGlobalScript`. jsdom implements neither the Popover API nor `:popover-open`, so the test stands both up.
 
 Each test file has:
 

--- a/test/js/panoInfoViewLink.test.js
+++ b/test/js/panoInfoViewLink.test.js
@@ -1,0 +1,278 @@
+/**
+ * Tests for PanoInfoPopover's "view in <provider>" link (public/js/common/pano-viewer/src/PanoInfoPopover.js).
+ *
+ * Regression coverage for #4813. Validate (and the Gallery/LabelMap label card) swap the active pano viewer from
+ * label to label: the provider's own viewer for live imagery, Pannellum for our self-hosted copy of imagery the
+ * provider has dropped, and a static crop when neither exists. Only the first of those has anywhere to link to, so
+ * the popover resolves the active viewer on every open and offers the link only when that viewer both publishes a
+ * public site and is holding the pano on screen.
+ *
+ * PanoInfoPopover is a top-level `class` declaration written for the Grunt-concatenation world, so — as with
+ * ShareWidget — the source is eval'd into the jsdom global scope with an explicit `window.X = X` epilogue rather
+ * than require()-d.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const POPOVER_SRC = fs.readFileSync(
+    path.resolve(__dirname, '..', '..', 'public/js/common/pano-viewer/src/PanoInfoPopover.js'), 'utf8'
+);
+
+// The parts of app/views/common/panoInfoPopover.scala.html the class actually reads. Kept minimal on purpose: if a
+// selector is renamed there without being renamed here, these tests fail, which is the point.
+const POPOVER_MARKUP = `
+<div id="pano-info-popover" popover="manual">
+  <button type="button" class="pano-info-popover__clipboard"></button>
+  <button type="button" class="pano-info-popover__close"></button>
+  <span class="pano-info-popover__copied" hidden></span>
+  <dl>
+    <div><dd class="pano-info-popover__val" data-field="image-id">-</dd></div>
+    <div><dd class="pano-info-popover__val" data-field="latitude">-</dd></div>
+    <div><dd class="pano-info-popover__val" data-field="longitude">-</dd></div>
+    <div><dd class="pano-info-popover__val" data-field="street-id">-</dd></div>
+    <div><dd class="pano-info-popover__val" data-field="region-id">-</dd></div>
+  </dl>
+  <a class="pano-info-popover__view-link" href="#" target="_blank" rel="noopener noreferrer">-</a>
+</div>`;
+
+const GSV_PANO = 'gsvPano1';
+const BACKUP_PANO = 'backupPano2';
+const CROPPED_PANO = 'croppedPano3';
+
+/**
+ * Minimal stand-in for a PanoViewer. `link` mirrors the real contract: a {url, i18nKey} for providers with a public
+ * viewer (GsvViewer, MapillaryViewer), null for those without — Infra3d, and Pannellum, which inherits PanoViewer's
+ * null-returning base implementation because our self-hosted backup image has no provider page to link to.
+ * `currPanoData` is what the popover reads to tell whether this viewer is the one showing the pano on screen.
+ */
+function makeViewer(panoId, link) {
+    return {
+        panoId,
+        currPanoData: { getPanoId: () => panoId },
+        publicViewerLink: jest.fn(() => (link ? { ...link } : null)),
+        getPosition: () => ({ lat: 38.9, lng: -77.0 }),
+        getPov: () => ({ heading: 12, pitch: -3 }),
+        addListener: jest.fn(),
+    };
+}
+
+/** A provider-hosted viewer: has a real destination. */
+const makeGsvViewer = () => makeViewer(GSV_PANO, {
+    url: `https://www.google.com/maps/@?api=1&map_action=pano&pano=${GSV_PANO}&heading=12&pitch=-3`,
+    i18nKey: 'common:pano-info.view-in-gsv',
+});
+
+/** The Pannellum fallback: self-hosted imagery, so no public link. */
+const makePannellumViewer = () => makeViewer(BACKUP_PANO, null);
+
+describe('PanoInfoPopover view-in-pano link', () => {
+    let PanoInfoPopover;
+    let activeViewer;
+    let popoverEl;
+    let viewLink;
+    let clipboardText;
+    // Explore and Validate report the active viewer's own pano id; the Gallery/LabelMap label card reports the pano
+    // id off the label's metadata instead, which is how the two can disagree on the static-crop fallback. Leave this
+    // null for the viewer-sourced shape, set it for the label-sourced one.
+    let labelPanoId;
+
+    /** Constructs a popover whose accessors all read through `activeViewer`, as the real call sites now do. */
+    function buildPopover() {
+        return new PanoInfoPopover(
+            document.getElementById('host'),
+            () => activeViewer,
+            () => activeViewer.getPosition(),
+            () => labelPanoId ?? activeViewer.panoId,
+            () => 100,  // streetEdgeId
+            () => 200,  // regionId
+            () => ({ format: () => 'Jan 2020' }),  // panoDate
+            () => '123 Main St',                   // panoAddress
+            () => activeViewer.getPov(),
+            true,           // whiteIcon
+            jest.fn(),      // infoLogging
+            jest.fn(),      // clipboardLogging
+            jest.fn(),      // viewPanoLogging
+        );
+    }
+
+    /** Clicks the info button, which is what triggers the popover's value/link refresh. */
+    function openPopover() {
+        document.getElementById('pano-info-button').click();
+    }
+
+    /** Closes the popover so the next openPopover() takes the "open" branch of the toggle. */
+    function closePopover() {
+        document.getElementById('pano-info-button').click();
+    }
+
+    beforeEach(() => {
+        document.body.innerHTML = `<span id="host"></span>${POPOVER_MARKUP}`;
+        popoverEl = document.getElementById('pano-info-popover');
+        viewLink = popoverEl.querySelector('.pano-info-popover__view-link');
+
+        // jsdom (via jest-environment-jsdom 29) implements neither the Popover API nor the :popover-open
+        // pseudo-class, so stand both up over a simple open flag.
+        let open = false;
+        popoverEl.showPopover = () => { open = true; };
+        popoverEl.hidePopover = () => { open = false; };
+        const domMatches = popoverEl.matches.bind(popoverEl);
+        popoverEl.matches = (sel) => (sel === ':popover-open' ? open : domMatches(sel));
+
+        // Translations render as their raw keys so assertions stay locale-independent.
+        window.i18next = { t: (key) => key };
+        window.cityName = 'Washington';
+        clipboardText = null;
+        Object.defineProperty(navigator, 'clipboard', {
+            value: { writeText: jest.fn((text) => { clipboardText = text; return Promise.resolve(); }) },
+            configurable: true,
+        });
+
+        window.eval(`${POPOVER_SRC}\nwindow.PanoInfoPopover = PanoInfoPopover;`);
+        PanoInfoPopover = window.PanoInfoPopover;
+
+        activeViewer = makeGsvViewer();
+        labelPanoId = null;
+    });
+
+    it('shows the provider link when the active viewer has a public viewer', () => {
+        buildPopover();
+        openPopover();
+
+        expect(viewLink.style.display).not.toBe('none');
+        expect(viewLink.getAttribute('href')).toContain(`pano=${GSV_PANO}`);
+        expect(viewLink.textContent).toBe('common:pano-info.view-in-gsv');
+    });
+
+    it('hides the link, rather than leaving href="#", when the first pano opened is a Pannellum one', () => {
+        // The markup ships with href="#", which resolves to the current page — so leaving the link visible and
+        // untouched would open Validate again in a new tab.
+        activeViewer = makePannellumViewer();
+        buildPopover();
+        openPopover();
+
+        expect(viewLink.style.display).toBe('none');
+        expect(viewLink.hasAttribute('href')).toBe(false);
+    });
+
+    it('drops a stale provider link when the viewer swaps to Pannellum', () => {
+        // A link left in place across the swap points at the previous label's pano, which is worse than none.
+        buildPopover();
+        openPopover();
+        expect(viewLink.getAttribute('href')).toContain(`pano=${GSV_PANO}`);
+        closePopover();
+
+        activeViewer = makePannellumViewer();
+        openPopover();
+
+        expect(viewLink.style.display).toBe('none');
+        expect(viewLink.hasAttribute('href')).toBe(false);
+    });
+
+    it('restores the link when the viewer swaps back to a provider-hosted pano', () => {
+        activeViewer = makePannellumViewer();
+        buildPopover();
+        openPopover();
+        expect(viewLink.style.display).toBe('none');
+        closePopover();
+
+        activeViewer = makeGsvViewer();
+        openPopover();
+
+        expect(viewLink.style.display).not.toBe('none');
+        expect(viewLink.getAttribute('href')).toContain(`pano=${GSV_PANO}`);
+    });
+
+    it('hides the link on the static-crop fallback, where the provider viewer holds a different pano', () => {
+        // Gallery/LabelMap fall back to a stored crop when neither live nor backup imagery exists. panoViewer is
+        // pointed back at the provider's viewer, still sitting on whatever pano it loaded for an earlier label, so
+        // the provider does publish a viewer — it just isn't showing this label. Building the link anyway lands the
+        // user on a provider page for imagery the provider has already dropped.
+        labelPanoId = CROPPED_PANO;
+        buildPopover();
+        openPopover();
+
+        expect(viewLink.style.display).toBe('none');
+        expect(viewLink.hasAttribute('href')).toBe(false);
+        expect(activeViewer.publicViewerLink).not.toHaveBeenCalled();
+    });
+
+    it('shows the link when the provider viewer is holding the label-sourced pano', () => {
+        labelPanoId = GSV_PANO;
+        buildPopover();
+        openPopover();
+
+        expect(viewLink.style.display).not.toBe('none');
+        expect(viewLink.getAttribute('href')).toContain(`pano=${GSV_PANO}`);
+    });
+
+    it('reads the displayed values from the active viewer, not the one present at construction', () => {
+        buildPopover();
+        openPopover();
+        expect(popoverEl.querySelector('[data-field="image-id"]').textContent).toBe(GSV_PANO);
+        closePopover();
+
+        activeViewer = makePannellumViewer();
+        openPopover();
+
+        expect(popoverEl.querySelector('[data-field="image-id"]').textContent).toBe(BACKUP_PANO);
+    });
+
+    it('builds the link against the active viewer and the live camera angle', () => {
+        activeViewer = makePannellumViewer();
+        const pannellumViewer = activeViewer;
+        buildPopover();
+        openPopover();
+
+        expect(pannellumViewer.publicViewerLink).toHaveBeenCalledWith(
+            BACKUP_PANO, expect.objectContaining({ heading: 12, pitch: -3 })
+        );
+    });
+
+    it('omits the pano URL from the copied text when there is no link', () => {
+        buildPopover();
+        openPopover();
+        popoverEl.querySelector('.pano-info-popover__clipboard').click();
+        expect(clipboardText)
+            .toContain(`Pano URL: https://www.google.com/maps/@?api=1&map_action=pano&pano=${GSV_PANO}`);
+        closePopover();
+
+        activeViewer = makePannellumViewer();
+        openPopover();
+        popoverEl.querySelector('.pano-info-popover__clipboard').click();
+
+        expect(clipboardText).toContain(BACKUP_PANO);
+        expect(clipboardText).not.toContain('Pano URL:');
+    });
+
+    it('closes on pano_changed from a viewer that only appeared after construction', () => {
+        // Pannellum is built lazily, so the popover can't subscribe to it up front — it has to attach on open.
+        buildPopover();
+        const pannellumViewer = makePannellumViewer();
+        activeViewer = pannellumViewer;
+        openPopover();
+
+        expect(pannellumViewer.addListener).toHaveBeenCalledWith('pano_changed', expect.any(Function));
+        expect(popoverEl.matches(':popover-open')).toBe(true);
+
+        // Fire the handler the popover registered; it should close itself rather than sit there showing stale values.
+        const handler = pannellumViewer.addListener.mock.calls
+            .find(([event]) => event === 'pano_changed')[1];
+        handler();
+
+        expect(popoverEl.matches(':popover-open')).toBe(false);
+    });
+
+    it('subscribes to each viewer only once, however many times the popover is opened', () => {
+        const gsvViewer = activeViewer;
+        buildPopover();
+        openPopover();
+        closePopover();
+        openPopover();
+        closePopover();
+
+        const panoChangedSubscriptions = gsvViewer.addListener.mock.calls
+            .filter(([event]) => event === 'pano_changed');
+        expect(panoChangedSubscriptions).toHaveLength(1);
+    });
+});


### PR DESCRIPTION
resolves #4813

The pano info popover captured the active pano viewer at construction time. The viewer swaps from label to label — the provider's own viewer for live imagery, Pannellum for our self-hosted copy of imagery the provider has dropped — and the accessors it was handed (`svv.panoViewer.getPanoId`, `.getPosition`, `.getPov`) are bound arrow class fields, so the popover kept describing whichever pano the provider's viewer last showed. On a Pannellum label that meant the markup's untouched `href="#"` on the first open (which just reopened Validate in a new tab) and the previous label's pano URL on every open after.

### What changed

- **All three call sites** (`explore/src/Main.js`, `validate/src/Main.js`, `common/label-detail/LabelDetail.js`) pass closures instead of a captured viewer, so the popover resolves the active viewer on every open.
- **The link is shown only when it leads somewhere real**, re-checked per open on two conditions:
  1. The provider publishes a public viewer at all — `publicViewerLink()` returns null for Infra3d and for Pannellum, which inherits `PanoViewer`'s null-returning base. This replaces the old construction-time `getViewerType() === 'infra3d'` special case with the general rule.
  2. That viewer is actually holding the pano the popover is describing (`viewer.currPanoData.getPanoId() === currPanoId`).
- Hidden via inline `display`, not the `hidden` attribute — `.pano-info-popover__view-link` sets `display: block`, which outranks the UA's `[hidden]` rule — and the `href` is removed so the `#` fallback can't fire.
- The copy-to-clipboard text drops its `Pano URL:` line in the same cases.
- `pano_changed` is now subscribed per viewer on open rather than once at construction, since Pannellum is built lazily and doesn't exist yet when the popover is created.

### The static-crop case

Condition 2 also fixes a case that was broken on `develop` independently of the Pannellum bug. When Gallery/LabelMap fall back to a static crop (or the "imagery not available" panel), `PopupPanoManager.setPano` calls `#teardownPannellum()`, which points `panoViewer` back at the primary GSV/Mapillary viewer. Condition 1 alone passes there — GSV does publish a viewer — so the popover offered a Google link built from the label's `pano_id`, sending users to a pano Google no longer hosts. The pano-id check suppresses it, matching the `livePano` guard `LabelDetail` already applies to its address link.

### Testing

New `test/js/panoInfoViewLink.test.js` (11 tests) covers the live-provider, Pannellum, static-crop, and swap-back paths, the clipboard text, and the lazy `pano_changed` subscription. Full JS suite: 569 passing. ESLint clean.

Pano interaction isn't automated per CLAUDE.md, so this still needs a manual pass before merge:
- [ ] Validate: land directly on a Pannellum label → no link.
- [ ] Validate: GSV label → close → Pannellum label → link disappears rather than showing the prior pano.
- [ ] Validate: back to a GSV label → link returns, at the live camera angle.
- [ ] Gallery/LabelMap: a label showing the static crop → no link.
- [ ] Gallery/LabelMap: a normal live label → link present and correct.
- [ ] Copy-to-clipboard in the no-link cases omits the `Pano URL:` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
