### PR TITLE
Suppress a resumable route walk during the Explore tutorial

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,8 +269,12 @@ jobs:
       #   fixture tests (analytic WGS84 arc lengths, the #4774 nightly-refresh regression) seed every row they read,
       #   so they are meaningful even here — a reintroduced projection fails by double digits. Its cache-freshness
       #   comparisons need real data and CANCEL on this empty schema, same as RouteAuthPostureSpec's shape checks.
+      # - ExploreTutorialRouteSpec (#4816): a resumable route walk must not surface while the session is the tutorial.
+      #   It seeds its own users and route walks, but hangs them on an existing street/region and needs a configured
+      #   tutorial street, so all four tests CANCEL on this empty schema — listed here so they run the moment the job
+      #   has a seeded DB, and so the cancel is visible rather than the suite silently not existing.
       - name: Run gating/auth tests (health dashboard + route auth posture + geodesic distances)
-        run: sbt 'set Test / parallelExecution := false' 'testOnly controllers.HealthDashboardSpec service.HealthServiceSpec controllers.RouteAuthPostureSpec models.street.GeodesicDistanceSpec'
+        run: sbt 'set Test / parallelExecution := false' 'testOnly controllers.HealthDashboardSpec service.HealthServiceSpec controllers.RouteAuthPostureSpec models.street.GeodesicDistanceSpec service.ExploreTutorialRouteSpec'
         env:
           DATABASE_URL: jdbc:postgresql://localhost:5432/sidewalk
           DATABASE_USER: sidewalk

--- a/app/service/ExploreService.scala
+++ b/app/service/ExploreService.scala
@@ -301,8 +301,9 @@ class ExploreServiceImpl @Inject() (
       makeCrops: Boolean                         <- configTable.getMakeCrops
     } yield {
       // The tutorial takes over the whole session, so a resumable route must not surface mid-tutorial: shipping its
-      // id flips the client into route mode and draws the route over the tutorial map (#4816). The user_route row is
-      // left untouched so the route still resumes on the post-tutorial reload of /explore.
+      // id flips the client into route mode and draws the route over the tutorial map (#4816). Only the page payload
+      // is suppressed — the walk stays active, so it resumes on the post-tutorial reload of /explore. (An explicit
+      // ?routeId= still sets a walk up above, since that is the user asking for one; it just waits for them.)
       val (pageUserRoute, pageRoute) =
         if (updatedMission.missionType == MissionType.AuditOnboarding) (None, None) else (userRoute, routeOption)
       ExplorePageData(task, updatedMission, region.get, pageUserRoute, pageRoute, hasCompletedAMission, nextTempLabelId,

--- a/app/service/ExploreService.scala
+++ b/app/service/ExploreService.scala
@@ -300,7 +300,12 @@ class ExploreServiceImpl @Inject() (
       tutorialStreetId: Int                      <- configTable.getTutorialStreetId
       makeCrops: Boolean                         <- configTable.getMakeCrops
     } yield {
-      ExplorePageData(task, updatedMission, region.get, userRoute, routeOption, hasCompletedAMission, nextTempLabelId,
+      // The tutorial takes over the whole session, so a resumable route must not surface mid-tutorial: shipping its
+      // id flips the client into route mode and draws the route over the tutorial map (#4816). The user_route row is
+      // left untouched so the route still resumes on the post-tutorial reload of /explore.
+      val (pageUserRoute, pageRoute) =
+        if (updatedMission.missionType == MissionType.AuditOnboarding) (None, None) else (userRoute, routeOption)
+      ExplorePageData(task, updatedMission, region.get, pageUserRoute, pageRoute, hasCompletedAMission, nextTempLabelId,
         surveyData, tutorialStreetId, makeCrops)
     }
     db.run(getExploreDataAction.transactionally)

--- a/test/service/ExploreTutorialRouteSpec.scala
+++ b/test/service/ExploreTutorialRouteSpec.scala
@@ -13,7 +13,7 @@ import models.route.{
   UserRouteTableDef
 }
 import models.street.{StreetEdgeRegionTableDef, StreetEdgeTable, StreetEdgeTableDef}
-import models.user.SidewalkUserWithRole
+import models.user.{SidewalkUserWithRole, UserCurrentRegionTableDef}
 import models.utils.{ConfigTableDef, MyPostgresProfile}
 import models.utils.MyPostgresProfile.api._
 import org.scalatestplus.play.PlaySpec
@@ -137,9 +137,16 @@ class ExploreTutorialRouteSpec extends PlaySpec with org.scalatest.BeforeAndAfte
     )
   }
 
-  /** The bare `/explore` visit: no explicit route/region/street params, resumeRoute at its routes-file default. */
-  private def pageData(userId: String, retakingTutorial: Boolean = false): ExplorePageData = await(
-    exploreService.getDataForExplorePage(userId, retakingTutorial, newRegion = false, routeId = None,
+  /**
+   * The `/explore` visit: no region/street params, resumeRoute at its routes-file default. `routeId` defaults to the
+   * bare visit; pass it to exercise the link-to-a-route path, which sets a walk up rather than just resuming one.
+   */
+  private def pageData(
+      userId: String,
+      retakingTutorial: Boolean = false,
+      routeId: Option[Int] = None
+  ): ExplorePageData = await(
+    exploreService.getDataForExplorePage(userId, retakingTutorial, newRegion = false, routeId = routeId,
       resumeRoute = true, regionId = None, streetEdgeId = None)
   )
 
@@ -163,7 +170,7 @@ class ExploreTutorialRouteSpec extends PlaySpec with org.scalatest.BeforeAndAfte
           userRoutes.filter(_.userId inSet userIds).delete,
           routeStreets.filter(_.routeId in seededRouteIds).delete,
           routes.filter(_.userId inSet userIds).delete,
-          TableQuery[models.user.UserCurrentRegionTableDef].filter(_.userId inSet userIds).delete
+          TableQuery[UserCurrentRegionTableDef].filter(_.userId inSet userIds).delete
         )
         .transactionally
     )
@@ -222,6 +229,36 @@ class ExploreTutorialRouteSpec extends PlaySpec with org.scalatest.BeforeAndAfte
           data.mission.missionType mustBe MissionType.AuditOnboarding
           data.userRoute mustBe None
           data.route mustBe None
+
+          // Same suppress-not-discard contract as the implicit tutorial: a retake must not cost the user the walk
+          // they had going, since they land back on /explore the moment the retake ends.
+          val walk = run(userRoutes.filter(_.userId === user.userId).result.head)
+          walk.completed mustBe false
+          walk.discarded mustBe false
+      }
+    }
+
+    "leave a route requested by id waiting rather than shipping it into the tutorial" in {
+      seedStreet match {
+        case None                           => cancel("No street/region rows in the connected DB; nothing to exercise.")
+        case Some((streetEdgeId, regionId)) =>
+          if (!tutorialStreetExists) cancel("No tutorial street configured in the connected DB.")
+          val user = newAnonUser()
+          // The one path that *writes*: an explicit ?routeId= sets a walk up (setUpPossibleUserRoute) before the
+          // mission resolves to the tutorial, so the suppression has to hold over a walk the same call created.
+          val routeId = seedActiveRouteWalk(user.userId, streetEdgeId, regionId)
+
+          val data = pageData(user.userId, routeId = Some(routeId))
+
+          data.mission.missionType mustBe MissionType.AuditOnboarding
+          data.userRoute mustBe None
+          data.route mustBe None
+
+          // The requested route is still theirs to walk once the tutorial hands them back to /explore.
+          val walk = run(userRoutes.filter(_.userId === user.userId).result.head)
+          walk.routeId mustBe routeId
+          walk.completed mustBe false
+          walk.discarded mustBe false
       }
     }
   }

--- a/test/service/ExploreTutorialRouteSpec.scala
+++ b/test/service/ExploreTutorialRouteSpec.scala
@@ -1,0 +1,228 @@
+package service
+
+import models.mission.{Mission, MissionTableDef, MissionType}
+import models.audit.AuditTaskTableDef
+import models.region.RegionTableDef
+import models.route.{
+  AuditTaskUserRouteTableDef,
+  Route,
+  RouteStreet,
+  RouteStreetTableDef,
+  RouteTableDef,
+  UserRoute,
+  UserRouteTableDef
+}
+import models.street.{StreetEdgeRegionTableDef, StreetEdgeTable, StreetEdgeTableDef}
+import models.user.SidewalkUserWithRole
+import models.utils.{ConfigTableDef, MyPostgresProfile}
+import models.utils.MyPostgresProfile.api._
+import org.scalatestplus.play.PlaySpec
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
+import play.api.db.slick.DatabaseConfigProvider
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.silhouette.api.util.PasswordInfo
+import slick.dbio.DBIO
+
+import java.time.OffsetDateTime
+import java.util.concurrent.atomic.AtomicInteger
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+/**
+ * DB-backed regression tests for #4816: an in-progress route walk must never surface on the Explore page while the
+ * session is the tutorial.
+ *
+ * The leak: `getDataForExplorePage` resolves a resumable `user_route` row before it resolves the mission, and a row
+ * left active by an abandoned RouteBuilder walk would ship to the client even when the mission came back as the
+ * tutorial — flipping the frontend into route mode and drawing the old route over the tutorial map. The contract
+ * under test is suppress-not-discard: the tutorial page data carries no route, but the row itself stays active so
+ * the walk still resumes on the post-tutorial reload of /explore.
+ *
+ * Creates throwaway anonymous users (same approach as ExploreAddressServiceSpec) and seeds each one's route walk
+ * directly; a control test proves the same seed *does* surface for a tutorial graduate, so the suppression
+ * assertions can't pass vacuously. All seeded route/user_route/mission rows are deleted in afterAll — mandatory,
+ * not just tidy: the dev DB is shared. Requires a Postgres+PostGIS DB with at least one street/region and a
+ * configured tutorial street (as in dev/CI); cancels gracefully otherwise.
+ */
+// BeforeAndAfterAll must be mixed in BEFORE GuiceOneAppPerSuite: linearization then runs afterAll inside the running
+// app, rather than after the app (and its DB pool) has already been stopped.
+class ExploreTutorialRouteSpec extends PlaySpec with org.scalatest.BeforeAndAfterAll with GuiceOneAppPerSuite {
+
+  override def fakeApplication(): Application =
+    new GuiceApplicationBuilder().disable[modules.ActorModule].build()
+
+  private val exploreService  = app.injector.instanceOf[ExploreService]
+  private val authService     = app.injector.instanceOf[AuthenticationService]
+  private val streetEdgeTable = app.injector.instanceOf[StreetEdgeTable]
+  // Keep the DatabaseConfig as a stable val and call .db.run inline; binding .db to its own val would infer a
+  // path-dependent existential type that needs -language:existentials.
+  private val dbConfig                   = app.injector.instanceOf[DatabaseConfigProvider].get[MyPostgresProfile]
+  private def run[T](action: DBIO[T]): T = Await.result(dbConfig.db.run(action), 60.seconds)
+  private def await[T](f: scala.concurrent.Future[T]): T = Await.result(f, 60.seconds)
+
+  private val missions            = TableQuery[MissionTableDef]
+  private val auditTasks          = TableQuery[AuditTaskTableDef]
+  private val routes              = TableQuery[RouteTableDef]
+  private val routeStreets        = TableQuery[RouteStreetTableDef]
+  private val userRoutes          = TableQuery[UserRouteTableDef]
+  private val auditTaskUserRoutes = TableQuery[AuditTaskUserRouteTableDef]
+
+  /** Every throwaway user the suite creates, so afterAll can sweep all of their rows uniformly. */
+  private val createdUserIds = scala.collection.mutable.Set[String]()
+
+  /** Distinguishes seeded routes' slugs; route.slug is globally unique (route_slug_idx). */
+  private val slugCounter = new AtomicInteger(0)
+
+  /** Creates a throwaway anonymous user and registers it for afterAll cleanup. */
+  private def newAnonUser(): SidewalkUserWithRole = {
+    val generated = await(authService.generateUniqueAnonUser())
+    val pwInfo    = PasswordInfo("bcrypt-sha256", "spec-only-not-a-hash", None)
+    val user      = await(authService.createUser(generated, "credentials", pwInfo, oldUserId = None))
+    createdUserIds += user.userId
+    user
+  }
+
+  /** A routable (open, non-tutorial) street and its region to hang seeded routes on; None means the DB is unseeded. */
+  private lazy val seedStreet: Option[(Int, Int)] = run(
+    TableQuery[StreetEdgeRegionTableDef]
+      .join(streetEdgeTable.streets)
+      .on(_.streetEdgeId === _.streetEdgeId)
+      .join(TableQuery[RegionTableDef].filterNot(_.deleted))
+      .on(_._1.regionId === _.regionId)
+      .map { case ((streetEdgeRegion, _), _) => (streetEdgeRegion.streetEdgeId, streetEdgeRegion.regionId) }
+      .result
+      .headOption
+  )
+
+  /** Tutorial page data needs the configured tutorial street to exist (AuditTaskTable.getATutorialTask joins it). */
+  private lazy val tutorialStreetExists: Boolean = run(
+    TableQuery[StreetEdgeTableDef]
+      .join(TableQuery[ConfigTableDef])
+      .on(_.streetEdgeId === _.tutorialStreetEdgeID)
+      .exists
+      .result
+  )
+
+  /** Seeds a one-street route and an in-progress (active) walk of it for the given user; returns the route id. */
+  private def seedActiveRouteWalk(userId: String, streetEdgeId: Int, regionId: Int): Int = {
+    val n       = slugCounter.incrementAndGet()
+    val routeId = run(
+      (routes returning routes.map(_.routeId)) +=
+        Route(
+          0,
+          userId,
+          regionId,
+          s"4816 spec route $n",
+          s"spec-4816-route-$n",
+          None,
+          public = false,
+          deleted = false,
+          OffsetDateTime.now,
+          0d,
+          1
+        )
+    )
+    val _ = run(routeStreets += RouteStreet(0, routeId, streetEdgeId, reverse = false, position = 0))
+    val _ = run(userRoutes += UserRoute(0, routeId, userId, completed = false, discarded = false))
+    routeId
+  }
+
+  /** Records tutorial completion the way the schema does: a completed auditOnboarding mission. */
+  private def markOnboardingComplete(userId: String): Unit = {
+    val now = OffsetDateTime.now
+    val _   = run(
+      missions += Mission(0, MissionType.AuditOnboarding, userId, now, now, completed = true, 0d, paid = false, None,
+        None, None, None, None, None, skipped = false, None, None)
+    )
+  }
+
+  /** The bare `/explore` visit: no explicit route/region/street params, resumeRoute at its routes-file default. */
+  private def pageData(userId: String, retakingTutorial: Boolean = false): ExplorePageData = await(
+    exploreService.getDataForExplorePage(userId, retakingTutorial, newRegion = false, routeId = None,
+      resumeRoute = true, regionId = None, streetEdgeId = None)
+  )
+
+  /**
+   * Deletes every row the suite created under its throwaway users. Mission and audit_task reference each other
+   * (mission.current_audit_task_id), so the mission->task pointer is nulled first; route children (route_street,
+   * user_route and its audit_task_user_route rows) go before the routes themselves. The bare user/auth rows are
+   * left behind, matching ExploreAddressServiceSpec's precedent.
+   */
+  override def afterAll(): Unit = {
+    val userIds        = createdUserIds.toSeq
+    val seededRouteIds = routes.filter(_.userId inSet userIds).map(_.routeId)
+    val seededWalkIds  = userRoutes.filter(_.userId inSet userIds).map(_.userRouteId)
+    val _              = run(
+      DBIO
+        .seq(
+          missions.filter(_.userId inSet userIds).map(_.currentAuditTaskId).update(None),
+          auditTaskUserRoutes.filter(_.userRouteId in seededWalkIds).delete,
+          auditTasks.filter(_.userId inSet userIds).delete,
+          missions.filter(_.userId inSet userIds).delete,
+          userRoutes.filter(_.userId inSet userIds).delete,
+          routeStreets.filter(_.routeId in seededRouteIds).delete,
+          routes.filter(_.userId inSet userIds).delete,
+          TableQuery[models.user.UserCurrentRegionTableDef].filter(_.userId inSet userIds).delete
+        )
+        .transactionally
+    )
+    super.afterAll()
+  }
+
+  "getDataForExplorePage" should {
+    "not surface an in-progress route walk to a user who still needs the tutorial (#4816)" in {
+      seedStreet match {
+        case None                           => cancel("No street/region rows in the connected DB; nothing to exercise.")
+        case Some((streetEdgeId, regionId)) =>
+          if (!tutorialStreetExists) cancel("No tutorial street configured in the connected DB.")
+          val user = newAnonUser()
+          seedActiveRouteWalk(user.userId, streetEdgeId, regionId)
+
+          val data = pageData(user.userId)
+
+          data.mission.missionType mustBe MissionType.AuditOnboarding
+          data.userRoute mustBe None
+          data.route mustBe None
+
+          // Suppress, not discard: the walk must stay active so it resumes on the post-tutorial reload.
+          val walk = run(userRoutes.filter(_.userId === user.userId).result.head)
+          walk.completed mustBe false
+          walk.discarded mustBe false
+      }
+    }
+
+    "resume the same seeded walk for a tutorial graduate (control: the suppression tests aren't vacuous)" in {
+      seedStreet match {
+        case None                           => cancel("No street/region rows in the connected DB; nothing to exercise.")
+        case Some((streetEdgeId, regionId)) =>
+          val user = newAnonUser()
+          markOnboardingComplete(user.userId)
+          val routeId = seedActiveRouteWalk(user.userId, streetEdgeId, regionId)
+
+          val data = pageData(user.userId)
+
+          data.mission.missionType must not be MissionType.AuditOnboarding
+          data.userRoute.value.routeId mustBe routeId
+          data.route.value.routeId mustBe routeId
+      }
+    }
+
+    "suppress the route again when a tutorial graduate retakes the tutorial" in {
+      seedStreet match {
+        case None                           => cancel("No street/region rows in the connected DB; nothing to exercise.")
+        case Some((streetEdgeId, regionId)) =>
+          if (!tutorialStreetExists) cancel("No tutorial street configured in the connected DB.")
+          val user = newAnonUser()
+          markOnboardingComplete(user.userId)
+          seedActiveRouteWalk(user.userId, streetEdgeId, regionId)
+
+          val data = pageData(user.userId, retakingTutorial = true)
+
+          data.mission.missionType mustBe MissionType.AuditOnboarding
+          data.userRoute mustBe None
+          data.route mustBe None
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #4816.

An abandoned RouteBuilder walk leaves its `user_route` row active (`completed=false, discarded=false`) forever, and `ExploreService.getDataForExplorePage` resolves that resumable row **before** it resolves the mission — so a user who still needed the tutorial got the old route's id shipped to the client, which flipped the minimap into route mode and drew the RouteBuilder route over the tutorial map. Incognito "fixed" it because anonymous users are a per-cookie identity: a fresh cookie means a fresh anon user with no `user_route` rows.

**Fix:** null the route out of `ExplorePageData` whenever the resolved mission is `auditOnboarding`. The `user_route` row itself is deliberately left untouched (suppress, not discard), so:
- a tutorial-pending guest who clicks a RouteBuilder link still gets their route queued, resuming on the post-tutorial reload of `/explore`;
- a returning user's in-progress walk still resumes on their first real mission, per the `resumeRoute=true` default.

**Testing:** new DB-backed `ExploreTutorialRouteSpec` seeds a throwaway anon user with an active walk and asserts suppress-not-discard for both first-time and retake-tutorial paths, with a tutorial-graduate control proving the same seed *does* surface (so the suppression assertions can't pass vacuously). Browser-QA'd by @jonfroehlich as part of the v11.8.0 tutorial QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-fable-5)
