### PR TITLE
Render the onboarding canvas at display resolution like the label canvas

### DIFF
--- a/public/css/explore/svl-canvas.css
+++ b/public/css/explore/svl-canvas.css
@@ -4,8 +4,9 @@
   width: var(--pano-width);
 }
 
-/* The pano viewer, label canvas, and interaction layers fill the (display-sized) street view. The canvas
-   elements keep their fixed 720x480 bitmap resolution and are scaled up to this size by the browser. */
+/* The pano viewer, label canvas, and interaction layers fill the (display-sized) street view. The label and
+   onboarding canvases are re-rastered to this display size times devicePixelRatio (util.sizeCanvasToDisplay),
+   with drawing kept in the fixed 720x480 logical frame via a context transform. */
 .window-streetview {
   position: absolute;
   left: 0;

--- a/public/js/common/utilities.js
+++ b/public/js/common/utilities.js
@@ -21,6 +21,32 @@ util.exploreDisplayScale = function () {
 };
 
 /**
+ * Sizes an Explore-tool canvas bitmap to its on-screen size times the device pixel ratio, and scales the 2D
+ * context so all drawing done in the fixed 720x480 logical frame renders at full resolution.
+ *
+ * Shared by the label canvas and the onboarding canvas so the two can't drift: both draw in the logical frame and
+ * are displayed at pano size, and a canvas left at its authored 720x480 bitmap gets CSS-stretched into visible
+ * pixelation on HiDPI displays (#4817).
+ *
+ * @param {HTMLCanvasElement} el - The canvas element to size.
+ * @param {CanvasRenderingContext2D} ctx - That canvas's 2D context.
+ */
+util.sizeCanvasToDisplay = function (el, ctx) {
+  const rect = el.getBoundingClientRect();
+  const displayWidth = rect.width || util.EXPLORE_CANVAS_WIDTH;
+  const dpr = window.devicePixelRatio || 1;
+  el.width = Math.round(displayWidth * dpr);
+  el.height = Math.round(displayWidth / util.EXPLORE_CANVAS_ASPECT_RATIO * dpr);
+  // Map the 720x480 logical frame onto the full-resolution bitmap. Setting el.width/height above resets the
+  // context, so this transform must be (re)applied here.
+  const scale = el.width / util.EXPLORE_CANVAS_WIDTH;
+  ctx.setTransform(scale, 0, 0, scale, 0, 0);
+  // Label icons are drawn from a raster sized for the densest display we support (see Label.preloadIcons), so on
+  // anything less dense they arrive downscaled; the default 'low' filter frays their outer circle.
+  ctx.imageSmoothingQuality = 'high';
+};
+
+/**
  * Positions a panel beside a label's icon in a pano and points its tail at that icon.
  *
  * Explore's hover card and its context menu are two states of one panel — read-only, then editable — so they share

--- a/public/js/explore/src/Main.js
+++ b/public/js/explore/src/Main.js
@@ -418,6 +418,7 @@ class Main {
       applyExploreScale();
       // The canvas was rasterized at scale 1 during init; re-raster it at the chosen scale.
       if (svl.canvas) svl.canvas.resize();
+      if (svl.onboarding) svl.onboarding.resize();
       if (svl.observedArea) svl.observedArea.update();
       // Redraw fog of war after the rescale. Minimap does this async, so we have to listen on this event.
       if (svl.observedArea && svl.minimap) {
@@ -431,6 +432,7 @@ class Main {
         clearTimeout(resizeRasterTimer);
         resizeRasterTimer = setTimeout(() => {
           if (svl.canvas) svl.canvas.resize();
+          if (svl.onboarding) svl.onboarding.resize();
           if (svl.observedArea) svl.observedArea.update();
         }, 150);
       });

--- a/public/js/explore/src/canvas/Canvas.js
+++ b/public/js/explore/src/canvas/Canvas.js
@@ -52,9 +52,9 @@ class Canvas {
 
     // Render the canvas at its on-screen (and HiDPI) resolution now that pano may be displayed at a different size
     // than the 720x480 logical frame, while keeping all drawing code in that logical frame via a context transform.
-    this.#sizeCanvasToDisplay(el);
+    util.sizeCanvasToDisplay(el, this.#ctx);
 
-    // clearRect() operates in the logical frame thanks to the context transform set in #sizeCanvasToDisplay.
+    // clearRect() operates in the logical frame thanks to the context transform set in util.sizeCanvasToDisplay.
     this.#canvasProperties.width = util.EXPLORE_CANVAS_WIDTH;
     this.#canvasProperties.height = util.EXPLORE_CANVAS_HEIGHT;
 
@@ -77,26 +77,6 @@ class Canvas {
     svl.ui.streetview.viewControlLayer.on('mousemove', (e) => this.#handlerViewControlLayerMouseMove(e));
     svl.ui.streetview.viewControlLayer.on('mouseleave', (e) => this.#handlerViewControlLayerMouseLeave(e));
     svl.ui.streetview.viewControlLayer[0].onselectstart = () => false;
-  }
-
-  /**
-   * Sizes the label canvas bitmap to its on-screen size times the device pixel ratio, and scales the 2D
-   * context so all drawing done in the fixed 720x480 logical frame renders at full resolution.
-   * @param {HTMLCanvasElement} el - The label canvas element.
-   */
-  #sizeCanvasToDisplay(el) {
-    const rect = el.getBoundingClientRect();
-    const displayWidth = rect.width || util.EXPLORE_CANVAS_WIDTH;
-    const dpr = window.devicePixelRatio || 1;
-    el.width = Math.round(displayWidth * dpr);
-    el.height = Math.round(displayWidth / util.EXPLORE_CANVAS_ASPECT_RATIO * dpr);
-    // Map the 720x480 logical frame onto the full-resolution bitmap. Setting el.width/height above resets
-    // the context, so this transform must be (re)applied here.
-    const scale = el.width / util.EXPLORE_CANVAS_WIDTH;
-    this.#ctx.setTransform(scale, 0, 0, scale, 0, 0);
-    // Label icons are drawn from a raster sized for the densest display we support (see Label.preloadIcons), so on
-    // anything less dense they arrive downscaled; the default 'low' filter frays their outer circle.
-    this.#ctx.imageSmoothingQuality = 'high';
   }
 
   /**
@@ -619,7 +599,7 @@ class Canvas {
   resize() {
     const el = document.getElementById('label-canvas');
     if (!el || !this.#ctx) return;
-    this.#sizeCanvasToDisplay(el);
+    util.sizeCanvasToDisplay(el, this.#ctx);
     this.clear().render();
   }
 

--- a/public/js/explore/src/onboarding/Onboarding.js
+++ b/public/js/explore/src/onboarding/Onboarding.js
@@ -208,10 +208,16 @@ class Onboarding {
     const canvasUI = this.#uiOnboarding.canvas.get(0);
     if (!canvasUI || !this.#ctx) return;
     util.sizeCanvasToDisplay(canvasUI, this.#ctx);
-    // Re-sizing the bitmap wiped the canvas; redraw like the pov_changed listener in #visit does.
-    if (this.#currentState) {
+
+    // Re-sizing the bitmap wiped the canvas; redraw like the pov_changed listener in #visit does — under the same
+    // conditions #visit draws, so a resize can't put annotations back on a state that is meant to have none. The
+    // terminal state is the one that matters: it sets #currentState and then leaves the canvas cleared while the
+    // submit-and-reload it kicked off is still in flight.
+    const state = this.#currentState;
+    if (!state || 'end-onboarding' in state) return;
+    if (this.#onboardingStateAnnotationExists(state) || this.#savedAnnotations.length > 0) {
       this.#removeFlashingFromArrow();
-      this.#drawAnnotations(this.#currentState);
+      this.#drawAnnotations(state);
     }
   }
 

--- a/public/js/explore/src/onboarding/Onboarding.js
+++ b/public/js/explore/src/onboarding/Onboarding.js
@@ -23,6 +23,7 @@ class Onboarding {
   #states;
   #statesWithProgress;
   #savedAnnotations = [];
+  #currentState = null;
   #mouseDownCanvasDrawingHandler;
   #map;
   #currentLabelId;
@@ -79,9 +80,9 @@ class Onboarding {
     const canvasUI = this.#uiOnboarding.canvas.get(0);
     if (canvasUI) {
       this.#ctx = canvasUI.getContext('2d');
-      // The example label icons are drawn from a high-resolution raster (see Label.preloadIcons) and land here
-      // downscaled; the default 'low' filter frays their outer circle.
-      this.#ctx.imageSmoothingQuality = 'high';
+      // Render at on-screen/HiDPI resolution while drawing stays in the 720x480 logical frame, like the main label
+      // canvas — a CSS-stretched 720x480 bitmap makes the example labels visibly pixelated (#4817).
+      util.sizeCanvasToDisplay(canvasUI, this.#ctx);
     }
     this.#uiOnboarding.holder.css('visibility', 'visible');
 
@@ -197,6 +198,21 @@ class Onboarding {
   clear() {
     if (this.#ctx) this.#ctx.clearRect(0, 0, util.EXPLORE_CANVAS_WIDTH, util.EXPLORE_CANVAS_HEIGHT);
     return this;
+  }
+
+  /**
+   * Re-rasterizes the onboarding canvas to the current displayed pano size and redraws the current state's
+   * annotations. Call after the UI scale changes (e.g. on window resize), mirroring Canvas.resize().
+   */
+  resize() {
+    const canvasUI = this.#uiOnboarding.canvas.get(0);
+    if (!canvasUI || !this.#ctx) return;
+    util.sizeCanvasToDisplay(canvasUI, this.#ctx);
+    // Re-sizing the bitmap wiped the canvas; redraw like the pov_changed listener in #visit does.
+    if (this.#currentState) {
+      this.#removeFlashingFromArrow();
+      this.#drawAnnotations(this.#currentState);
+    }
   }
 
   /**
@@ -654,6 +670,7 @@ class Onboarding {
       this.#tracker.push('Onboarding_Transition', { onboardingTransition: state.id });
     }
     state.visited = true;
+    this.#currentState = state;
 
     let annotationListener;
 

--- a/test/js/sizeCanvasToDisplay.test.js
+++ b/test/js/sizeCanvasToDisplay.test.js
@@ -1,0 +1,140 @@
+/**
+ * Tests for util.sizeCanvasToDisplay (public/js/common/utilities.js).
+ *
+ * Explore draws into a fixed 720x480 logical frame but displays the pano larger, so both canvases over it — the
+ * label canvas (#4719) and the tutorial's onboarding canvas (#4817) — size their bitmap to the on-screen box times
+ * the device pixel ratio and push a matching context transform. Get that pairing wrong and nothing throws: the
+ * drawing simply lands at the wrong scale, or blurs. That is only visible on a HiDPI display, at one particular
+ * window size, which makes it exactly the kind of arithmetic worth pinning here instead of re-eyeballing.
+ *
+ * jsdom has no layout engine and no 2D context, so the canvas's rect is stated outright and the context is a stub
+ * that records what the routine set on it — which is all this routine touches.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const UTILITIES_SRC = fs.readFileSync(
+    path.resolve(__dirname, '..', '..', 'public/js/common/utilities.js'), 'utf8'
+);
+
+/** A canvas whose on-screen box is fixed, since jsdom's real getBoundingClientRect is all zeroes. */
+function makeCanvas(displayWidth, displayHeight = displayWidth / 1.5) {
+    const el = document.createElement('canvas');
+    el.getBoundingClientRect = () => ({
+        left: 0, top: 0, right: displayWidth, bottom: displayHeight, width: displayWidth, height: displayHeight,
+    });
+    return el;
+}
+
+/** A stand-in for the 2D context, recording the transform and the smoothing hint. */
+function makeCtx() {
+    return {
+        transform: null,
+        imageSmoothingQuality: 'low',
+        setTransform(a, b, c, d, e, f) { this.transform = [a, b, c, d, e, f]; },
+    };
+}
+
+/** jsdom pins devicePixelRatio at 1; the whole point of the routine is what it does at other values. */
+function setDpr(value) {
+    Object.defineProperty(window, 'devicePixelRatio', { value, configurable: true, writable: true });
+}
+
+describe('util.sizeCanvasToDisplay', () => {
+    let util;
+
+    beforeEach(() => {
+        // utilities.js builds a Bowser parser at load time; the sizing under test never consults it.
+        window.bowser = { getParser: () => ({ getBrowserName: () => 'Chrome', getBrowserVersion: () => '1',
+            getOSName: () => 'Linux', getPlatformType: () => 'desktop' }) };
+        window.eval(UTILITIES_SRC);
+        util = window.util;
+        setDpr(1);
+    });
+
+    it('rasterizes at the on-screen size when the display is not HiDPI', () => {
+        const el = makeCanvas(1080);
+        util.sizeCanvasToDisplay(el, makeCtx());
+
+        expect(el.width).toBe(1080);
+        expect(el.height).toBe(720); // 1080 / 1.5, the 720x480 aspect.
+    });
+
+    it('multiplies the bitmap by the device pixel ratio on a HiDPI display', () => {
+        const el = makeCanvas(1080);
+        setDpr(2);
+        util.sizeCanvasToDisplay(el, makeCtx());
+
+        expect(el.width).toBe(2160);
+        expect(el.height).toBe(1440);
+    });
+
+    it('rounds a fractional bitmap size to whole device pixels', () => {
+        const el = makeCanvas(1000);
+        setDpr(1.5);
+        util.sizeCanvasToDisplay(el, makeCtx());
+
+        expect(el.width).toBe(1500);        // 1000 * 1.5
+        expect(el.height).toBe(1000);       // 1000 / 1.5 * 1.5, rounded from 999.99...
+        expect(Number.isInteger(el.width)).toBe(true);
+        expect(Number.isInteger(el.height)).toBe(true);
+    });
+
+    it('scales the context so the logical frame spans the whole bitmap', () => {
+        const el = makeCanvas(1080);
+        const ctx = makeCtx();
+        setDpr(2);
+        util.sizeCanvasToDisplay(el, ctx);
+
+        // A uniform scale with no translation or skew: logical (0,0) stays at the bitmap's origin...
+        const scale = 2160 / util.EXPLORE_CANVAS_WIDTH;
+        expect(ctx.transform).toEqual([scale, 0, 0, scale, 0, 0]);
+        // ...and logical (720, 480) lands on its far corner, so drawing needs no other adjustment.
+        expect(scale * util.EXPLORE_CANVAS_WIDTH).toBeCloseTo(el.width, 6);
+        expect(scale * util.EXPLORE_CANVAS_HEIGHT).toBeCloseTo(el.height, 6);
+    });
+
+    it('asks for high-quality smoothing, so downscaled label icons keep a clean outer circle', () => {
+        const ctx = makeCtx();
+        util.sizeCanvasToDisplay(makeCanvas(1080), ctx);
+
+        expect(ctx.imageSmoothingQuality).toBe('high');
+    });
+
+    it('falls back to the logical width when the canvas is unmeasurable, keeping the transform at 1:1', () => {
+        const el = makeCanvas(0);
+        const ctx = makeCtx();
+        util.sizeCanvasToDisplay(el, ctx);
+
+        expect(el.width).toBe(util.EXPLORE_CANVAS_WIDTH);
+        expect(el.height).toBe(util.EXPLORE_CANVAS_HEIGHT);
+        expect(ctx.transform).toEqual([1, 0, 0, 1, 0, 0]);
+    });
+
+    it('treats a missing devicePixelRatio as 1 rather than collapsing the bitmap', () => {
+        const el = makeCanvas(1080);
+        const ctx = makeCtx();
+        setDpr(undefined);
+        util.sizeCanvasToDisplay(el, ctx);
+
+        expect(el.width).toBe(1080);
+        expect(ctx.transform[0]).toBeCloseTo(1080 / util.EXPLORE_CANVAS_WIDTH, 6);
+    });
+
+    it('re-applies the transform on a second call, since setting width/height resets the context', () => {
+        const el = makeCanvas(1080);
+        const ctx = makeCtx();
+        util.sizeCanvasToDisplay(el, ctx);
+
+        // What a resize looks like: the box grew, and the context the browser just cleared is handed back in.
+        el.getBoundingClientRect = () => ({ left: 0, top: 0, right: 1440, bottom: 960, width: 1440, height: 960 });
+        ctx.transform = null;
+        ctx.imageSmoothingQuality = 'low';
+        util.sizeCanvasToDisplay(el, ctx);
+
+        expect(el.width).toBe(1440);
+        expect(ctx.transform).toEqual([1440 / 720, 0, 0, 1440 / 720, 0, 0]);
+        expect(ctx.imageSmoothingQuality).toBe('high');
+    });
+});


### PR DESCRIPTION
Closes #4817.

The tutorial's pre-placed example labels looked like pixelated PNGs, but they were already drawn from the SVG-sourced raster — the real cause was that `#onboarding-canvas` never received the DPR-sized-bitmap treatment #4719 gave the main label canvas, so it rendered into its authored 720×480 bitmap and was CSS-stretched to pano size.

**Fix:** extract the sizing into `util.sizeCanvasToDisplay(el, ctx)` (shared by `Canvas` and `Onboarding` so the two can't drift), apply it to the onboarding canvas at tutorial start, and add `Onboarding.resize()` — re-raster plus a redraw of the current state's annotations, since resizing a canvas bitmap wipes it — wired into the same UI-scale resize path as `svl.canvas.resize()`.

**Testing:** lint clean; browser-QA'd by @jonfroehlich on a HiDPI display (crisp example labels, crisp redraw after window resize) as part of the v11.8.0 tutorial QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-fable-5)
