### PR TITLE
Store timestamps as timestamptz and widen mission.pay (#4826, #4827)

### DIFF
--- a/app/models/audit/AuditTaskTable.scala
+++ b/app/models/audit/AuditTaskTable.scala
@@ -79,7 +79,7 @@ class AuditTaskTableDef(tag: slick.lifted.Tag) extends Table[AuditTask](tag, "au
   def amtAssignmentId: Rep[Option[Int]] = column[Option[Int]]("amt_assignment_id")
   def userId: Rep[String]               = column[String]("user_id")
   def streetEdgeId: Rep[Int]            = column[Int]("street_edge_id")
-  // DEFAULT timezone('utc'::text, now()) in the DB -- not equivalent to now() outside a UTC session (#4826).
+  // DEFAULT now() in the DB (O.Default holds a value, not an expression).
   def taskStart: Rep[OffsetDateTime]          = column[OffsetDateTime]("task_start")
   def taskEnd: Rep[OffsetDateTime]            = column[OffsetDateTime]("task_end")
   def completed: Rep[Boolean]                 = column[Boolean]("completed", O.Default(false))

--- a/app/models/cluster/ClusteringSessionTable.scala
+++ b/app/models/cluster/ClusteringSessionTable.scala
@@ -37,7 +37,7 @@ class ClusteringSessionTableDef(tag: Tag) extends Table[ClusteringSession](tag, 
   def clusteringSessionId: Rep[Int]             = column[Int]("clustering_session_id", O.PrimaryKey, O.AutoInc)
   def regionId: Rep[Int]                        = column[Int]("region_id")
   def thresholds: Rep[Seq[ClusteringThreshold]] = column[Seq[ClusteringThreshold]]("thresholds")
-  // DEFAULT CURRENT_TIMESTAMP in the DB (O.Default holds a value, not an expression).
+  // DEFAULT now() in the DB (O.Default holds a value, not an expression).
   def timestamp: Rep[OffsetDateTime] = column[OffsetDateTime]("timestamp")
 
   def * = (clusteringSessionId, regionId, thresholds, timestamp) <>

--- a/app/models/label/LabelAiAssessmentTable.scala
+++ b/app/models/label/LabelAiAssessmentTable.scala
@@ -49,15 +49,13 @@ class LabelAiAssessmentTableDef(tag: Tag) extends Table[LabelAiAssessment](tag, 
   def tagsConfidence: Rep[Option[Seq[AiTagConfidence]]] = column[Option[Seq[AiTagConfidence]]]("tags_confidence")
   def apiVersion: Rep[String]                           = column[String]("api_version")
   def validatorModelId: Rep[String]                     = column[String]("validator_model_id")
-  // validator_training_date, tagger_training_date and timestamp are `timestamp` (no time zone) in the DB, unlike
-  // every other timestamp column in the schema, so the offset an OffsetDateTime carries is not actually stored
-  // (#4826). timestamp is also DEFAULT CURRENT_TIMESTAMP there (O.Default holds a value, not an expression).
-  def validatorTrainingDate: Rep[OffsetDateTime]      = column[OffsetDateTime]("validator_training_date")
-  def taggerModelId: Rep[Option[String]]              = column[Option[String]]("tagger_model_id")
-  def taggerTrainingDate: Rep[Option[OffsetDateTime]] = column[Option[OffsetDateTime]]("tagger_training_date")
-  def timestamp: Rep[OffsetDateTime]                  = column[OffsetDateTime]("timestamp")
-  def labelValidationId: Rep[Option[Int]]             = column[Option[Int]]("label_validation_id")
-  def aiImageSource: Rep[AiImageSource]               = column[AiImageSource]("ai_image_source")
+  def validatorTrainingDate: Rep[OffsetDateTime]        = column[OffsetDateTime]("validator_training_date")
+  def taggerModelId: Rep[Option[String]]                = column[Option[String]]("tagger_model_id")
+  def taggerTrainingDate: Rep[Option[OffsetDateTime]]   = column[Option[OffsetDateTime]]("tagger_training_date")
+  // DEFAULT now() in the DB (O.Default holds a value, not an expression).
+  def timestamp: Rep[OffsetDateTime]      = column[OffsetDateTime]("timestamp")
+  def labelValidationId: Rep[Option[Int]] = column[Option[Int]]("label_validation_id")
+  def aiImageSource: Rep[AiImageSource]   = column[AiImageSource]("ai_image_source")
 
   def * =
     (labelAiAssessmentId, labelId, validationResult, validationAccuracy, validationConfidence, tags, tagsNotPresent,

--- a/app/models/label/LabelAiFailureTable.scala
+++ b/app/models/label/LabelAiFailureTable.scala
@@ -14,9 +14,7 @@ case class LabelAiFailure(labelId: Int, reason: String, timestamp: OffsetDateTim
 class LabelAiFailureTableDef(tag: Tag) extends Table[LabelAiFailure](tag, "label_ai_failure") {
   def labelId: Rep[Int]   = column[Int]("label_id", O.PrimaryKey)
   def reason: Rep[String] = column[String]("reason")
-  // `timestamp` (no time zone) in the DB, unlike every other timestamp column in the schema, so the offset an
-  // OffsetDateTime carries is not actually stored (#4826). DEFAULT CURRENT_TIMESTAMP there, which O.Default can't
-  // express (it holds a value, not an expression).
+  // DEFAULT now() in the DB (O.Default holds a value, not an expression).
   def timestamp: Rep[OffsetDateTime] = column[OffsetDateTime]("timestamp")
 
   def * = (labelId, reason, timestamp) <> (

--- a/app/models/label/LabelAiInfoTable.scala
+++ b/app/models/label/LabelAiInfoTable.scala
@@ -19,13 +19,11 @@ case class LabelAiInfo(
 )
 
 class LabelAiInfoTableDef(tag: Tag) extends Table[LabelAiInfo](tag, "label_ai_info") {
-  def labelAiInfoId: Rep[Int] = column[Int]("label_ai_info_id", O.PrimaryKey, O.AutoInc)
-  def labelId: Rep[Int]       = column[Int]("label_id")
-  def confidence: Rep[Double] = column[Double]("confidence")
-  def apiVersion: Rep[String] = column[String]("api_version")
-  def modelId: Rep[String]    = column[String]("model_id")
-  // `timestamp` (no time zone) in the DB, unlike every other timestamp column in the schema, so the offset an
-  // OffsetDateTime carries is not actually stored (#4826).
+  def labelAiInfoId: Rep[Int]                = column[Int]("label_ai_info_id", O.PrimaryKey, O.AutoInc)
+  def labelId: Rep[Int]                      = column[Int]("label_id")
+  def confidence: Rep[Double]                = column[Double]("confidence")
+  def apiVersion: Rep[String]                = column[String]("api_version")
+  def modelId: Rep[String]                   = column[String]("model_id")
   def modelTrainingDate: Rep[OffsetDateTime] = column[OffsetDateTime]("model_training_date")
 
   def * = (labelAiInfoId, labelId, confidence, apiVersion, modelId, modelTrainingDate) <> (

--- a/app/models/mission/MissionTable.scala
+++ b/app/models/mission/MissionTable.scala
@@ -51,10 +51,9 @@ class MissionTableDef(tag: Tag) extends Table[Mission](tag, "mission") {
   def missionType: Rep[MissionType.Value] = column[MissionType.Value]("mission_type")
   def userId: Rep[String]                 = column[String]("user_id")
   // DEFAULT now() in the DB (O.Default holds a value, not an expression).
-  def missionStart: Rep[OffsetDateTime] = column[OffsetDateTime]("mission_start")
-  def missionEnd: Rep[OffsetDateTime]   = column[OffsetDateTime]("mission_end")
-  def completed: Rep[Boolean]           = column[Boolean]("completed")
-  // `real` (float4) in the DB, so a Double written here is narrowed and doesn't round-trip (#4827).
+  def missionStart: Rep[OffsetDateTime]     = column[OffsetDateTime]("mission_start")
+  def missionEnd: Rep[OffsetDateTime]       = column[OffsetDateTime]("mission_end")
+  def completed: Rep[Boolean]               = column[Boolean]("completed")
   def pay: Rep[Double]                      = column[Double]("pay", O.Default(0.0))
   def paid: Rep[Boolean]                    = column[Boolean]("paid")
   def distanceMeters: Rep[Option[Double]]   = column[Option[Double]]("distance_meters")

--- a/app/models/mturk/AMTAssignmentTable.scala
+++ b/app/models/mturk/AMTAssignmentTable.scala
@@ -23,7 +23,7 @@ class AMTAssignmentTableDef(tag: Tag) extends Table[AMTAssignment](tag, "amt_ass
   def amtAssignmentId: Rep[Int] = column[Int]("amt_assignment_id", O.PrimaryKey, O.AutoInc)
   def hitId: Rep[String]        = column[String]("hit_id")
   def assignmentId: Rep[String] = column[String]("assignment_id")
-  // DEFAULT timezone('utc'::text, now()) in the DB -- not equivalent to now() outside a UTC session (#4826).
+  // DEFAULT now() in the DB (O.Default holds a value, not an expression).
   def assignmentStart: Rep[OffsetDateTime] = column[OffsetDateTime]("assignment_start")
   def assignmentEnd: Rep[OffsetDateTime]   = column[OffsetDateTime]("assignment_end")
   def workerId: Rep[String]                = column[String]("turker_id")

--- a/app/models/street/StreetEdgeTable.scala
+++ b/app/models/street/StreetEdgeTable.scala
@@ -61,7 +61,7 @@ class StreetEdgeTableDef(tag: Tag) extends Table[StreetEdge](tag, "street_edge")
   def y2: Rep[Double]                     = column[Double]("y2")
   def wayType: Rep[WayType.Value]         = column[WayType.Value]("way_type")
   def status: Rep[StreetEdgeStatus.Value] = column[StreetEdgeStatus.Value]("status")
-  // DEFAULT timezone('utc'::text, now()) in the DB -- not equivalent to now() outside a UTC session (#4826).
+  // DEFAULT now() in the DB (O.Default holds a value, not an expression).
   def timestamp: Rep[OffsetDateTime] = column[OffsetDateTime]("timestamp")
 
   def * = (streetEdgeId, geom, x1, y1, x2, y2, wayType, status, timestamp) <> (

--- a/conf/evolutions/default/350.sql
+++ b/conf/evolutions/default/350.sql
@@ -6,5 +6,59 @@
 -- says Double.
 ALTER TABLE mission ALTER COLUMN pay TYPE DOUBLE PRECISION;
 
+-- These five AI-table columns are the only `timestamp without time zone` columns we own -- the other 39 timestamp
+-- columns are all timestamptz -- yet every one is modeled in Slick as OffsetDateTime, which is a promise a zoneless
+-- column cannot keep: the offset is discarded on write and re-invented on read from whatever zone the JVM happens to
+-- be in, and a `WHERE timestamp > ?` comparison is off by that same offset (#4826). The USING clause is not optional.
+-- Without it Postgres reads the stored values in the session's TimeZone, which would shift every existing row if this
+-- ever ran outside UTC. Our containers all run UTC, so the stored values are UTC wall clocks and 'UTC' is the correct
+-- reading of them.
+ALTER TABLE label_ai_assessment
+  ALTER COLUMN timestamp TYPE TIMESTAMPTZ USING "timestamp" AT TIME ZONE 'UTC',
+  ALTER COLUMN validator_training_date TYPE TIMESTAMPTZ USING validator_training_date AT TIME ZONE 'UTC',
+  ALTER COLUMN tagger_training_date TYPE TIMESTAMPTZ USING tagger_training_date AT TIME ZONE 'UTC';
+ALTER TABLE label_ai_failure ALTER COLUMN timestamp TYPE TIMESTAMPTZ USING "timestamp" AT TIME ZONE 'UTC';
+ALTER TABLE label_ai_info
+  ALTER COLUMN model_training_date TYPE TIMESTAMPTZ USING model_training_date AT TIME ZONE 'UTC';
+
+-- timezone('utc', now()) returns a timestamp *without* a zone -- the UTC wall clock as a bare number -- so assigning it
+-- to a timestamptz column makes Postgres cast it back, and that cast reads the bare number in the session's TimeZone.
+-- Under a UTC session that is identical to now(), which is why nothing is visibly wrong today. Under, say,
+-- America/Chicago it stores an instant five hours in the future. now() returns a timestamptz directly and is correct in
+-- every session, so it is the one form to use on these columns (#4826).
+ALTER TABLE audit_task ALTER COLUMN task_start SET DEFAULT now();
+ALTER TABLE audit_task ALTER COLUMN task_end SET DEFAULT now();
+ALTER TABLE amt_assignment ALTER COLUMN assignment_start SET DEFAULT now();
+ALTER TABLE amt_assignment ALTER COLUMN assignment_end SET DEFAULT now();
+ALTER TABLE street_edge ALTER COLUMN timestamp SET DEFAULT now();
+
+-- CURRENT_TIMESTAMP is now() by another name and has none of the problem above. These three change only so that the
+-- schema has a single spelling to copy for the next column that needs a timestamp default (#4822).
+ALTER TABLE clustering_session ALTER COLUMN timestamp SET DEFAULT now();
+ALTER TABLE label_ai_assessment ALTER COLUMN timestamp SET DEFAULT now();
+ALTER TABLE label_ai_failure ALTER COLUMN timestamp SET DEFAULT now();
+
 # --- !Downs
+-- Reading a timestamptz AT TIME ZONE 'UTC' gives back the UTC wall clock the Ups above interpreted, so this restores
+-- the exact values the columns held before. The type changes come before the default restorations so that the
+-- defaults, which Postgres rewrites with an explicit cast whenever a column's type changes under them, are left in
+-- their original spelling.
+ALTER TABLE label_ai_info
+  ALTER COLUMN model_training_date TYPE TIMESTAMP USING model_training_date AT TIME ZONE 'UTC';
+ALTER TABLE label_ai_failure ALTER COLUMN timestamp TYPE TIMESTAMP USING "timestamp" AT TIME ZONE 'UTC';
+ALTER TABLE label_ai_assessment
+  ALTER COLUMN tagger_training_date TYPE TIMESTAMP USING tagger_training_date AT TIME ZONE 'UTC',
+  ALTER COLUMN validator_training_date TYPE TIMESTAMP USING validator_training_date AT TIME ZONE 'UTC',
+  ALTER COLUMN timestamp TYPE TIMESTAMP USING "timestamp" AT TIME ZONE 'UTC';
+
+ALTER TABLE label_ai_failure ALTER COLUMN timestamp SET DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE label_ai_assessment ALTER COLUMN timestamp SET DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE clustering_session ALTER COLUMN timestamp SET DEFAULT CURRENT_TIMESTAMP;
+
+ALTER TABLE street_edge ALTER COLUMN timestamp SET DEFAULT timezone('utc'::text, now());
+ALTER TABLE amt_assignment ALTER COLUMN assignment_end SET DEFAULT timezone('utc'::text, now());
+ALTER TABLE amt_assignment ALTER COLUMN assignment_start SET DEFAULT timezone('utc'::text, now());
+ALTER TABLE audit_task ALTER COLUMN task_end SET DEFAULT timezone('utc'::text, now());
+ALTER TABLE audit_task ALTER COLUMN task_start SET DEFAULT timezone('utc'::text, now());
+
 ALTER TABLE mission ALTER COLUMN pay TYPE REAL;

--- a/conf/evolutions/default/350.sql
+++ b/conf/evolutions/default/350.sql
@@ -1,0 +1,10 @@
+# --- !Ups
+-- mission.pay is the schema's only `real` (float4) column -- every other floating-point column is double precision --
+-- while MissionTable models it as Double. Slick binds a double precision parameter, Postgres narrows it to ~7
+-- significant digits on write and widens it back on read, so a written value never comes back equal to itself (#4827).
+-- Widening is lossless, so no USING clause and no data risk. The DEFAULT 0.0 carries over, and the model already
+-- says Double.
+ALTER TABLE mission ALTER COLUMN pay TYPE DOUBLE PRECISION;
+
+# --- !Downs
+ALTER TABLE mission ALTER COLUMN pay TYPE REAL;


### PR DESCRIPTION
resolves #4827
resolves #4826

Two column-type fixes surfaced by the default-mirroring sweep in #4801/#4823. Both are schema-only and share evolution `350.sql` (one file per PR), one commit each.

### `mission.pay`: `real` → `double precision` (#4827)

The schema's only float4 column, while `MissionTable` models it as `Double` — Slick binds a `double precision` parameter, Postgres narrows it to ~7 significant digits on write and widens it back on read, so a written value never comes back equal to itself. Widening is lossless, so no `USING` clause and no data risk. The `DEFAULT 0.0` and the Slick model both carry over unchanged.

### Timestamp storage (#4826)

**Five columns → `timestamptz`.** `label_ai_assessment.timestamp` / `.validator_training_date` / `.tagger_training_date`, `label_ai_failure.timestamp`, `label_ai_info.model_training_date` were the only `timestamp without time zone` columns we own (`play_evolutions.applied_at` is Play's, left alone), yet all five are modeled as `OffsetDateTime`. Converted with an explicit `USING <col> AT TIME ZONE 'UTC'` — without it Postgres would read the stored values in the session's `TimeZone` and shift every row if the evolution ever ran outside UTC.

**Five DEFAULTs → `now()`.** `audit_task.task_start`/`task_end`, `amt_assignment.assignment_start`/`assignment_end`, and `street_edge.timestamp` defaulted to `timezone('utc', now())`, which returns a *zoneless* timestamp that Postgres then casts back using the session's `TimeZone` — identical to `now()` only in a UTC session. Plain `now()` is correct in every session.

**Plus, slightly beyond the issue:** the three `CURRENT_TIMESTAMP` defaults (`clustering_session.timestamp`, `label_ai_assessment.timestamp`, `label_ai_failure.timestamp`) also become `now()`. They were never wrong — this is just so there's a single spelling to copy when #4822 adds defaults to eight more timestamp columns. Easy to drop if you'd rather keep that out of here.

Slick models needed no type changes; the `// DEFAULT ... in the DB` comments were updated to match.

### Testing

- Evolution applied against the local `sidewalk_chicago` schema, then forced through a full **Downs → Ups** round trip by touching the file (autoApplyDowns is on locally). All 137,011 `label_ai_assessment` rows kept identical `min`/`max` timestamps across the round trip, and no `timestamp without time zone` columns remain outside `play_evolutions`.
- `make lint-evolutions`, `sbt scalafmtCheckAll`, and `sbt compile` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
