### PR TITLE
Follow Validate's active pano viewer for POV logging and the speed limit

### DIFF
--- a/public/js/common/SpeedLimit.js
+++ b/public/js/common/SpeedLimit.js
@@ -38,8 +38,11 @@ class SpeedLimit {
   // Pending re-check while the pano position / street list are still loading at page startup.
   #startupRetryTimer = null;
 
+  /** @type {Set<PanoViewer>} Viewers already subscribed to by #watchViewer(). */
+  #watchedViewers = new Set();
+
   /**
-   * @param {PanoViewer} panoViewer PanoramaViewer object.
+   * @param {function} panoViewer Function that returns the currently active PanoViewer.
    * @param {function} coords Function that returns current longitude and latitude coordinates.
    * @param {function} isOnboarding Function that returns a boolean on whether the current mission is the tutorial task.
    * @param {string} countryId The current city's country id (e.g. 'usa'), for sign design and fallback units.
@@ -74,12 +77,36 @@ class SpeedLimit {
 
     this.updateSpeedLimit();
 
-    // Listen for pano changes.
-    panoViewer.addListener('pano_changed', this.#panoChangeListener);
+    // Listen for pano changes, and — since the initial pano usually finishes loading before that listener attaches,
+    // so its pano_changed is missed — run one update now so the sign shows on the first pano without any movement.
+    this.refresh();
+  }
 
-    // The initial pano usually finishes loading before this listener attaches, so its pano_changed is missed; run one
-    // update for the current position so the sign shows on the first pano without requiring movement.
+  /**
+   * Points the sign at whichever viewer is active now and updates the value it shows.
+   *
+   * Validate swaps `svv.panoViewer` between the primary viewer and Pannellum as labels come and go, and the viewer
+   * that isn't showing fires nothing — so a subscription made once at construction goes quiet for the rest of the
+   * mission as soon as the tool switches away from that viewer (#4828). Callers that change which pano is on screen
+   * call this; repeated calls are cheap, since each viewer is subscribed at most once.
+   */
+  refresh() {
+    this.#watchViewer(this.#panoViewer());
     this.#panoChangeListener();
+  }
+
+  /**
+   * Subscribes to a viewer's pano_changed, once per viewer.
+   *
+   * Called from refresh() rather than only at construction because viewers are built lazily: Validate creates its
+   * Pannellum viewer the first time a label's imagery has expired, so it may not exist yet.
+   *
+   * @param {PanoViewer} viewer The viewer to subscribe to; ignored if null or already subscribed.
+   */
+  #watchViewer(viewer) {
+    if (!viewer || this.#watchedViewers.has(viewer)) return;
+    this.#watchedViewers.add(viewer);
+    viewer.addListener('pano_changed', this.#panoChangeListener);
   }
 
   /**
@@ -175,7 +202,7 @@ class SpeedLimit {
    * @returns {Promise<string|null>} Raw OSM maxspeed value, or null if unknown or on failure.
    */
   async #fetchSpeedLimitAtPoint(lat, lng) {
-    const panoId = this.#panoViewer.getPanoId();
+    const panoId = this.#panoViewer().getPanoId();
     if (this.#pointLookupCache.has(panoId)) {
       return await this.#pointLookupCache.get(panoId);
     }

--- a/public/js/common/SpeedLimit.js
+++ b/public/js/common/SpeedLimit.js
@@ -26,7 +26,6 @@ class SpeedLimit {
   #panoViewer;
   #taskContainer;
   #labelContainer;
-  #labelType;
   #fallbackUnits;
 
   // Fallback lookups keyed by pano id, holding the in-flight promise so concurrent pano events share one request.
@@ -49,17 +48,14 @@ class SpeedLimit {
    * @param {object} [sources] Where to read speed limits from; exactly one should be provided.
    * @param {TaskContainer} [sources.taskContainer] Explore's task container; the sign tracks the nearest loaded street.
    * @param {LabelContainer} [sources.labelContainer] Validate's label container; the sign shows the current label's
-   *                                                  street.
-   * @param {string} [sources.labelType] Label type being validated; null/undefined shows the speed limit by default.
+   *                                                  street, and only for label types it is relevant to.
    */
-  constructor(panoViewer, coords, isOnboarding, countryId, { taskContainer = null, labelContainer = null,
-    labelType = null } = {}) {
+  constructor(panoViewer, coords, isOnboarding, countryId, { taskContainer = null, labelContainer = null } = {}) {
     this.#coords = coords;
     this.#isOnboarding = isOnboarding;
     this.#panoViewer = panoViewer;
     this.#taskContainer = taskContainer;
     this.#labelContainer = labelContainer;
-    this.#labelType = labelType;
 
     this.container = document.getElementById('speed-limit-sign');
     this.speedLimit = {
@@ -138,8 +134,11 @@ class SpeedLimit {
       return;
     }
 
-    // If labelType is null/undefined (not provided), the speed limit will be displayed by default.
-    const speedLimitRelevant = !this.#labelType || SpeedLimit.#SPEED_LIMIT_RELEVANT_LABELS.includes(this.#labelType);
+    // Relevance follows the label being judged, read on every update rather than fixed at construction: Validate
+    // rolls into the next mission without a page reload, and that mission can be a different label type. Explore
+    // has no label to read, and its sign applies to every street it shows.
+    const labelType = this.#labelContainer?.getCurrentLabel()?.getAuditProperty('labelType') ?? null;
+    const speedLimitRelevant = !labelType || SpeedLimit.#SPEED_LIMIT_RELEVANT_LABELS.includes(labelType);
 
     // If user is validating a label that doesn't require speed limit context, hide the speed limit.
     if (!speedLimitRelevant) {

--- a/public/js/explore/src/Main.js
+++ b/public/js/explore/src/Main.js
@@ -197,9 +197,8 @@ class Main {
     );
 
     // Speed limit
-    svl.speedLimit = new SpeedLimit(svl.panoViewer, svl.panoViewer.getPosition, svl.isOnboarding, params.countryId, {
-      taskContainer: svl.taskContainer,
-    });
+    svl.speedLimit = new SpeedLimit(() => svl.panoViewer, () => svl.panoViewer.getPosition(), svl.isOnboarding,
+      params.countryId, { taskContainer: svl.taskContainer });
 
     // Survey for select users
     svl.modalSurvey = new ModalSurvey();

--- a/public/js/validate/src/Main.js
+++ b/public/js/validate/src/Main.js
@@ -179,8 +179,11 @@ class Main {
       // Shortcuts act on the current label, and behind the dead-end modal there isn't one. The modal disables the
       // keyboard when it goes up, but the first label's render can raise it before this exists to be told (#4810).
       if (svv.modalNoNewMission.isShowing()) svv.keyboard.disableKeyboard();
+      // Read svv.panoViewer through closures rather than capturing it here, for the same reason as the info popover
+      // below: PanoManager swaps it between the primary viewer and Pannellum, and the sign would otherwise stay
+      // subscribed to whichever one happened to be showing the first label (#4828).
       svv.speedLimit = new SpeedLimit(
-        svv.panoViewer, svv.panoViewer.getPosition, () => false, param.countryId,
+        () => svv.panoViewer, () => svv.panoViewer.getPosition(), () => false, param.countryId,
         { labelContainer: svv.labelContainer, labelType },
       );
       svv.zoomControl = new ZoomControl();

--- a/public/js/validate/src/Main.js
+++ b/public/js/validate/src/Main.js
@@ -184,7 +184,7 @@ class Main {
       // subscribed to whichever one happened to be showing the first label (#4828).
       svv.speedLimit = new SpeedLimit(
         () => svv.panoViewer, () => svv.panoViewer.getPosition(), () => false, param.countryId,
-        { labelContainer: svv.labelContainer, labelType },
+        { labelContainer: svv.labelContainer },
       );
       svv.zoomControl = new ZoomControl();
       new MissionStartTutorial('validate', labelType, { nLabels: param.mission.labels_validated }, svv, param.language);

--- a/public/js/validate/src/label/LabelContainer.js
+++ b/public/js/validate/src/label/LabelContainer.js
@@ -157,6 +157,10 @@ class LabelContainer {
     svv.validationMenu.resetMenu(this.#currLabel);
     if (svv.adminVersion) svv.adminInfo.updateAdminInfo(this.#currLabel);
     svv.panoManager.renderPanoMarker(this.#currLabel);
+    // Tell the sign here rather than leave it waiting on a pano_changed: the label that just loaded may have swapped
+    // the active viewer, and the viewer the sign last heard from is then the one that stays silent (#4828). Absent
+    // on mobile, and on the first label, whose render runs inside LabelContainer.create — before SpeedLimit exists.
+    svv.speedLimit?.refresh();
     // Every label starts visible. Without this the toggle keeps saying "Show Label" over a marker that renderPanoMarker
     // just drew in full — you'd have to hide and re-show to get the two back in agreement.
     svv.labelVisibilityControl?.unhideLabel();

--- a/public/js/validate/src/panorama/PanoManager.js
+++ b/public/js/validate/src/panorama/PanoManager.js
@@ -38,6 +38,9 @@ class PanoManager {
   static #POV_LOG_INTERVAL_MS = 500;
   #logPovChange;
 
+  /** @type {Set<PanoViewer>} Viewers already subscribed to by #watchViewerPov(). */
+  #povWatchedViewers = new Set();
+
   /**
    * Initializes panoViewer on the validate page and loads the first pano.
    *
@@ -67,8 +70,11 @@ class PanoManager {
             = 'position: absolute; top: 0; left: 0; width: 100%; height: 100%; display: none;';
     this.#panoCanvas.insertAdjacentElement('afterend', this.#pannellumCanvas);
 
+    this.#logPovChange = util.throttle(() => svv.tracker.push('POV_Changed'), PanoManager.#POV_LOG_INTERVAL_MS);
+
     this.#primaryViewer = await panoViewerType.create(this.#panoCanvas, panoOptions);
     svv.panoViewer = this.#primaryViewer;
+    this.#watchViewerPov(this.#primaryViewer);
 
     // Set up the imagery source logo. #showPannellumPano will override it if Pannellum takes over below.
     this.#logo = createPanoViewerLogo(this.#panoCanvas.parentElement, panoViewerType);
@@ -85,8 +91,6 @@ class PanoManager {
       }
     }
 
-    this.#logPovChange = util.throttle(() => svv.tracker.push('POV_Changed'), PanoManager.#POV_LOG_INTERVAL_MS);
-    svv.panoViewer.addListener('pov_changed', () => this.#logPovChange());
     if (util.isMobile()) {
       this.#sizePano();
       svv.panoViewer.resize(); // Necessary for PannellumViewer for correct vertical position of the label.
@@ -99,6 +103,24 @@ class PanoManager {
     } else if (panoViewerType === MapillaryViewer && !util.isMobile()) {
       this.#makeMapillaryAttributionClickable();
     }
+  }
+
+  /**
+   * Subscribes a viewer to the shared POV logger, once per viewer.
+   *
+   * Both viewers need their own subscription: only one of them is `svv.panoViewer` at a time, and Pannellum is built
+   * lazily the first time a label's imagery has expired, so it doesn't exist to subscribe to at startup (#4828).
+   * Panning and zooming a Pannellum label is the same interaction as panning a GSV one and belongs in the logs the
+   * same way. The one throttled logger is shared across viewers, so the interval covers the pano as a whole rather
+   * than giving each viewer its own window.
+   *
+   * @param {PanoViewer} viewer The viewer to subscribe; ignored if it is already subscribed.
+   * @private
+   */
+  #watchViewerPov(viewer) {
+    if (this.#povWatchedViewers.has(viewer)) return;
+    this.#povWatchedViewers.add(viewer);
+    viewer.addListener('pov_changed', () => this.#logPovChange());
   }
 
   /**
@@ -396,6 +418,7 @@ class PanoManager {
         startZoom: neutralPov.zoom,
       });
     }
+    this.#watchViewerPov(this.#pannellumViewer);
     svv.panoViewer = this.#pannellumViewer;
     svv.tracker.push('Viewer_Pannellum');
     this.#logo.showSourceLogo();

--- a/public/js/validate/src/panorama/PanoManager.js
+++ b/public/js/validate/src/panorama/PanoManager.js
@@ -74,7 +74,6 @@ class PanoManager {
 
     this.#primaryViewer = await panoViewerType.create(this.#panoCanvas, panoOptions);
     svv.panoViewer = this.#primaryViewer;
-    this.#watchViewerPov(this.#primaryViewer);
 
     // Set up the imagery source logo. #showPannellumPano will override it if Pannellum takes over below.
     this.#logo = createPanoViewerLogo(this.#panoCanvas.parentElement, panoViewerType);
@@ -90,6 +89,12 @@ class PanoManager {
         this.#setPanoCallback(panoData);
       }
     }
+
+    // Subscribed after the first pano has loaded rather than beside the viewer's creation: that load sets the
+    // viewer's initial POV, which fires pov_changed, and the throttle's leading edge would log it as a pan the
+    // user never made. (Pannellum, when the fallback above builds one, subscribes at its own creation instead —
+    // by then a POV change is a real one.)
+    this.#watchViewerPov(this.#primaryViewer);
 
     if (util.isMobile()) {
       this.#sizePano();

--- a/test/js/validateViewerSwapListeners.test.js
+++ b/test/js/validateViewerSwapListeners.test.js
@@ -47,12 +47,22 @@ describe('PanoManager logs POV changes from whichever viewer is showing (issue #
    */
   function makeFakeViewer(listenerSink) {
     return {
-      setPano: jest.fn(() => Promise.resolve(panoData)),
+      setPano: jest.fn(() => succeedingSetPano(listenerSink)),
       addListener: jest.fn((event, cb) => { listenerSink[event] = cb; }),
       resize: jest.fn(),
       setPov: jest.fn(),
       getPov: () => ({heading: 0, pitch: 0, zoom: 1}),
     };
+  }
+
+  /**
+   * A successful load, which sets the viewer's initial POV and so fires pov_changed the way real viewers do.
+   * @param {object} listenerSink - The viewer's captured listeners.
+   * @returns {Promise<object>} The loaded pano's metadata.
+   */
+  function succeedingSetPano(listenerSink) {
+    listenerSink.pov_changed?.();
+    return Promise.resolve(panoData);
   }
 
   beforeEach(async () => {
@@ -110,6 +120,15 @@ describe('PanoManager logs POV changes from whichever viewer is showing (issue #
     return svv.tracker.push.mock.calls.filter((call) => call[0] === 'POV_Changed').length;
   }
 
+  /**
+   * Drop the actions logged so far and let the throttle window lapse, so the next pan is a fresh leading edge.
+   * Lets a test count the pans it drives without the surrounding pano loads in the tally.
+   */
+  function resetPovLog() {
+    jest.advanceTimersByTime(1000);
+    svv.tracker.push.mockClear();
+  }
+
   /** Load a label whose imagery the primary viewer rejects, so Pannellum takes over. */
   async function loadPannellumLabel() {
     primaryViewer.setPano = jest.fn(() => Promise.reject(new Error('imagery expired')));
@@ -118,12 +137,19 @@ describe('PanoManager logs POV changes from whichever viewer is showing (issue #
 
   /** Load a label the primary viewer can render, handing the pano back to it. */
   async function loadPrimaryLabel(panoId) {
-    primaryViewer.setPano = jest.fn(() => Promise.resolve(panoData));
+    primaryViewer.setPano = jest.fn(() => succeedingSetPano(primaryListeners));
     await panoManager.setPanorama(panoId, null);
   }
 
+  test('the first pano load is not logged as a pan the user never made', () => {
+    // The load fires pov_changed as it sets the viewer's initial POV; logging that would open every session with
+    // a POV_Changed the validator never caused.
+    expect(povChangedLogCount()).toBe(0);
+  });
+
   test('panning a Pannellum label reaches the tracker', async () => {
     await loadPannellumLabel();
+    resetPovLog();
 
     expect(pannellumListeners.pov_changed).toBeDefined();
     pannellumListeners.pov_changed();
@@ -133,6 +159,7 @@ describe('PanoManager logs POV changes from whichever viewer is showing (issue #
   test('the primary viewer is still logged after a Pannellum label hands the pano back', async () => {
     await loadPannellumLabel();
     await loadPrimaryLabel('pano3');
+    resetPovLog();
 
     primaryListeners.pov_changed();
     expect(povChangedLogCount()).toBe(1);
@@ -140,6 +167,7 @@ describe('PanoManager logs POV changes from whichever viewer is showing (issue #
 
   test('the two viewers share one throttle window rather than one each', async () => {
     await loadPannellumLabel();
+    resetPovLog();
 
     pannellumListeners.pov_changed();
     primaryListeners.pov_changed();
@@ -153,6 +181,7 @@ describe('PanoManager logs POV changes from whichever viewer is showing (issue #
     await loadPannellumLabel();
     await loadPrimaryLabel('pano3');
     await loadPannellumLabel();
+    resetPovLog();
 
     const povSubscriptions = pannellumViewer.addListener.mock.calls.filter((call) => call[0] === 'pov_changed');
     expect(povSubscriptions).toHaveLength(1);
@@ -185,9 +214,14 @@ describe('SpeedLimit follows the active viewer (issue #4828)', () => {
     };
   }
 
-  /** Set the label the sign should be reading its speed limit from. */
-  function setCurrentLabel(maxSpeed) {
-    currentLabel = {getAuditProperty: (key) => (key === 'maxSpeed' ? maxSpeed : null)};
+  /**
+   * Set the label the sign should be reading from.
+   * @param {string} maxSpeed - Raw OSM maxspeed value for the label's street.
+   * @param {string} [labelType] - Label type; 'NoCurbRamp' is the one the sign is relevant to.
+   */
+  function setCurrentLabel(maxSpeed, labelType = 'NoCurbRamp') {
+    const props = {maxSpeed, labelType};
+    currentLabel = {getAuditProperty: (key) => props[key] ?? null};
   }
 
   /** @returns {string} The number currently rendered on the sign. */
@@ -216,8 +250,13 @@ describe('SpeedLimit follows the active viewer (issue #4828)', () => {
   function buildSpeedLimit() {
     speedLimit = new SpeedLimit(
       () => activeViewer, () => activeViewer.getPosition(), () => false, 'usa',
-      {labelContainer: {getCurrentLabel: () => currentLabel}, labelType: 'NoCurbRamp'},
+      {labelContainer: {getCurrentLabel: () => currentLabel}},
     );
+  }
+
+  /** @returns {boolean} Whether the sign is currently on screen. */
+  function signVisible() {
+    return document.getElementById('speed-limit-sign').style.display !== 'none';
   }
 
   test('the sign updates for a label shown on the Pannellum viewer', () => {
@@ -282,15 +321,28 @@ describe('SpeedLimit follows the active viewer (issue #4828)', () => {
   });
 
   test('a label type the sign is irrelevant for keeps it hidden after a viewer swap', () => {
-    setCurrentLabel('25 mph');
-    speedLimit = new SpeedLimit(
-      () => activeViewer, () => activeViewer.getPosition(), () => false, 'usa',
-      {labelContainer: {getCurrentLabel: () => currentLabel}, labelType: 'CurbRamp'},
-    );
-    expect(document.getElementById('speed-limit-sign').style.display).toBe('none');
+    setCurrentLabel('25 mph', 'CurbRamp');
+    buildSpeedLimit();
+    expect(signVisible()).toBe(false);
 
     activeViewer = pannellumViewer;
     speedLimit.refresh();
-    expect(document.getElementById('speed-limit-sign').style.display).toBe('none');
+    expect(signVisible()).toBe(false);
+  });
+
+  test('relevance follows the label type of the mission running now, not the one the tool started on', () => {
+    // Validate rolls into the next mission without a page reload, and that mission can be a different label type.
+    setCurrentLabel('25 mph', 'NoCurbRamp');
+    buildSpeedLimit();
+    expect(signVisible()).toBe(true);
+
+    setCurrentLabel('30 mph', 'CurbRamp');
+    speedLimit.refresh();
+    expect(signVisible()).toBe(false);
+
+    setCurrentLabel('35 mph', 'NoCurbRamp');
+    speedLimit.refresh();
+    expect(signVisible()).toBe(true);
+    expect(signNumber()).toBe('35');
   });
 });

--- a/test/js/validateViewerSwapListeners.test.js
+++ b/test/js/validateViewerSwapListeners.test.js
@@ -1,0 +1,296 @@
+/**
+ * Tests that Validate's startup components follow the active viewer instead of the one that happened to be showing
+ * the first label (issue #4828), across
+ * public/js/validate/src/panorama/PanoManager.js (`#watchViewerPov`) and public/js/common/SpeedLimit.js (`refresh`).
+ *
+ * PanoManager swaps `svv.panoViewer` between the primary viewer (GSV/Mapillary/Infra3d) and the Pannellum fallback as
+ * labels come and go, and the viewer that isn't showing fires no events at all. Both failures are silent — POV pans
+ * on a Pannellum label simply stop reaching the logs, and the speed-limit sign keeps showing the first label's value
+ * — so the assertions here are about events arriving from the viewer that took over.
+ *
+ * Both suites drive the REAL production classes (and the REAL `util.throttle`) against fake viewers; no pano is
+ * involved, so none of this needs imagery.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const PANO_MANAGER_PATH = path.resolve(__dirname, '..', '..', 'public/js/validate/src/panorama/PanoManager.js');
+const SPEED_LIMIT_PATH = path.resolve(__dirname, '..', '..', 'public/js/common/SpeedLimit.js');
+const THROTTLE_PATH = path.resolve(__dirname, '..', '..', 'public/js/validate/src/util/throttle.js');
+
+/**
+ * Load a bare `class` declaration out of a production file. The Grunt bundle concatenates these into page scope, so
+ * wrap the source in an IIFE that returns the named class (same trick as validateSkipUnrenderableLabel.test.js).
+ * @param {string} filePath - Absolute path to the production file.
+ * @param {string} className - Name of the class the file declares.
+ * @returns {Function} The class.
+ */
+function loadClassFromFile(filePath, className) {
+  const src = fs.readFileSync(filePath, 'utf8');
+  return (0, eval)('(() => {\n' + src + '\nreturn ' + className + ';\n})()');
+}
+
+describe('PanoManager logs POV changes from whichever viewer is showing (issue #4828)', () => {
+  let panoManager;
+  let primaryViewer;
+  let pannellumViewer;
+  let primaryListeners;   // event name -> callback captured from the primary viewer
+  let pannellumListeners; // event name -> callback captured from the Pannellum viewer
+  let panoData;
+  const backupImage = {panoId: 'pano2', cameraHeading: 90};
+
+  /**
+   * Build a fake viewer that records the listeners it is handed.
+   * @param {object} listenerSink - Object the viewer writes `event -> callback` into.
+   * @returns {object} The fake viewer.
+   */
+  function makeFakeViewer(listenerSink) {
+    return {
+      setPano: jest.fn(() => Promise.resolve(panoData)),
+      addListener: jest.fn((event, cb) => { listenerSink[event] = cb; }),
+      resize: jest.fn(),
+      setPov: jest.fn(),
+      getPov: () => ({heading: 0, pitch: 0, zoom: 1}),
+    };
+  }
+
+  beforeEach(async () => {
+    jest.useFakeTimers();
+    // Anchor the fake clock away from zero so the throttle's first elapsed check exceeds its window.
+    jest.setSystemTime(1_000_000);
+
+    document.body.innerHTML = '<div id="pano-holder"><div id="svv-panorama"></div></div>';
+
+    global.util = {};
+    (0, eval)(fs.readFileSync(THROTTLE_PATH, 'utf8')); // real throttle, the same one production wires up
+    util.isMobile = () => false;
+
+    global.createPanoViewerLogo = jest.fn(() => ({showPrimaryLogo: jest.fn(), showSourceLogo: jest.fn()}));
+    global.GsvViewer = class GsvViewer {};             // distinct from FakeViewerType, so the GSV-only
+    global.MapillaryViewer = class MapillaryViewer {}; // and Mapillary-only attribution paths are skipped
+    global.svv = {
+      tracker: {push: jest.fn()},
+      panoStore: {addPanoMetadata: jest.fn()},
+      ui: {viewer: {date: {text: jest.fn()}}},
+    };
+
+    panoData = {getPanoId: () => 'pano1', getProperty: () => ({format: () => 'Jun 2026'})};
+    primaryListeners = {};
+    pannellumListeners = {};
+    primaryViewer = makeFakeViewer(primaryListeners);
+    pannellumViewer = makeFakeViewer(pannellumListeners);
+    pannellumViewer.currPanoData = panoData;
+    pannellumViewer.loadPano = jest.fn(() => Promise.resolve(panoData));
+
+    global.PannellumViewer = class PannellumViewer {
+      static create() { return Promise.resolve(pannellumViewer); }
+    };
+    const FakeViewerType = class FakeViewerType {
+      static create() { return Promise.resolve(primaryViewer); }
+    };
+
+    const PanoManager = loadClassFromFile(PANO_MANAGER_PATH, 'PanoManager');
+    panoManager = await PanoManager.create(FakeViewerType, 'token', 'pano1');
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    document.body.innerHTML = '';
+    delete global.util;
+    delete global.createPanoViewerLogo;
+    delete global.GsvViewer;
+    delete global.MapillaryViewer;
+    delete global.PannellumViewer;
+    delete global.svv;
+  });
+
+  /** Count how many times the tracker logged a POV_Changed action. */
+  function povChangedLogCount() {
+    return svv.tracker.push.mock.calls.filter((call) => call[0] === 'POV_Changed').length;
+  }
+
+  /** Load a label whose imagery the primary viewer rejects, so Pannellum takes over. */
+  async function loadPannellumLabel() {
+    primaryViewer.setPano = jest.fn(() => Promise.reject(new Error('imagery expired')));
+    await panoManager.setPanorama('pano2', backupImage);
+  }
+
+  /** Load a label the primary viewer can render, handing the pano back to it. */
+  async function loadPrimaryLabel(panoId) {
+    primaryViewer.setPano = jest.fn(() => Promise.resolve(panoData));
+    await panoManager.setPanorama(panoId, null);
+  }
+
+  test('panning a Pannellum label reaches the tracker', async () => {
+    await loadPannellumLabel();
+
+    expect(pannellumListeners.pov_changed).toBeDefined();
+    pannellumListeners.pov_changed();
+    expect(povChangedLogCount()).toBe(1);
+  });
+
+  test('the primary viewer is still logged after a Pannellum label hands the pano back', async () => {
+    await loadPannellumLabel();
+    await loadPrimaryLabel('pano3');
+
+    primaryListeners.pov_changed();
+    expect(povChangedLogCount()).toBe(1);
+  });
+
+  test('the two viewers share one throttle window rather than one each', async () => {
+    await loadPannellumLabel();
+
+    pannellumListeners.pov_changed();
+    primaryListeners.pov_changed();
+    expect(povChangedLogCount()).toBe(1); // one leading-edge log for the pair, not one per viewer
+
+    jest.advanceTimersByTime(500);
+    expect(povChangedLogCount()).toBe(2); // one trailing log so the final POV is still recorded
+  });
+
+  test('Pannellum is subscribed once, not once per label it shows', async () => {
+    await loadPannellumLabel();
+    await loadPrimaryLabel('pano3');
+    await loadPannellumLabel();
+
+    const povSubscriptions = pannellumViewer.addListener.mock.calls.filter((call) => call[0] === 'pov_changed');
+    expect(povSubscriptions).toHaveLength(1);
+
+    pannellumListeners.pov_changed();
+    expect(povChangedLogCount()).toBe(1);
+  });
+});
+
+describe('SpeedLimit follows the active viewer (issue #4828)', () => {
+  let SpeedLimit;
+  let speedLimit;
+  let activeViewer;
+  let currentLabel;
+  let primaryViewer;
+  let pannellumViewer;
+  let primaryListeners;
+  let pannellumListeners;
+
+  /**
+   * Build a fake viewer that records the listeners it is handed.
+   * @param {object} listenerSink - Object the viewer writes `event -> callback` into.
+   * @returns {object} The fake viewer.
+   */
+  function makeFakeViewer(listenerSink) {
+    return {
+      addListener: jest.fn((event, cb) => { listenerSink[event] = cb; }),
+      getPanoId: () => 'pano1',
+      getPosition: () => ({lat: 47.6, lng: -122.3}),
+    };
+  }
+
+  /** Set the label the sign should be reading its speed limit from. */
+  function setCurrentLabel(maxSpeed) {
+    currentLabel = {getAuditProperty: (key) => (key === 'maxSpeed' ? maxSpeed : null)};
+  }
+
+  /** @returns {string} The number currently rendered on the sign. */
+  function signNumber() {
+    return document.getElementById('speed-limit').innerText;
+  }
+
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="speed-limit-sign">'
+      + '<span id="speed-limit"></span><span id="speed-limit-sub"></span></div>';
+
+    primaryListeners = {};
+    pannellumListeners = {};
+    primaryViewer = makeFakeViewer(primaryListeners);
+    pannellumViewer = makeFakeViewer(pannellumListeners);
+    activeViewer = primaryViewer;
+
+    SpeedLimit = loadClassFromFile(SPEED_LIMIT_PATH, 'SpeedLimit');
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  /** Build the sign the way Validate does, reading the active viewer through a closure. */
+  function buildSpeedLimit() {
+    speedLimit = new SpeedLimit(
+      () => activeViewer, () => activeViewer.getPosition(), () => false, 'usa',
+      {labelContainer: {getCurrentLabel: () => currentLabel}, labelType: 'NoCurbRamp'},
+    );
+  }
+
+  test('the sign updates for a label shown on the Pannellum viewer', () => {
+    setCurrentLabel('25 mph');
+    buildSpeedLimit();
+    expect(signNumber()).toBe('25');
+
+    // Next label's imagery is expired, so Pannellum takes over and the label carries a different speed limit.
+    activeViewer = pannellumViewer;
+    setCurrentLabel('40 mph');
+    speedLimit.refresh();
+
+    expect(signNumber()).toBe('40');
+  });
+
+  test('the sign subscribes to the Pannellum viewer once it becomes the active one', () => {
+    setCurrentLabel('25 mph');
+    buildSpeedLimit();
+    expect(pannellumListeners.pano_changed).toBeUndefined();
+
+    activeViewer = pannellumViewer;
+    setCurrentLabel('40 mph');
+    speedLimit.refresh();
+    expect(pannellumListeners.pano_changed).toBeDefined();
+
+    // A pano change reported by the viewer that is actually showing now moves the sign.
+    setCurrentLabel('15 mph');
+    pannellumListeners.pano_changed();
+    expect(signNumber()).toBe('15');
+  });
+
+  test('a mission whose first label is on Pannellum still follows the primary viewer afterwards', () => {
+    // PanoManager.create is awaited before SpeedLimit is built, so an expired first label leaves Pannellum active.
+    activeViewer = pannellumViewer;
+    setCurrentLabel('30 mph');
+    buildSpeedLimit();
+    expect(signNumber()).toBe('30');
+
+    activeViewer = primaryViewer;
+    setCurrentLabel('20 mph');
+    speedLimit.refresh();
+    expect(signNumber()).toBe('20');
+
+    setCurrentLabel('45 mph');
+    primaryListeners.pano_changed();
+    expect(signNumber()).toBe('45');
+  });
+
+  test('each viewer is subscribed at most once across repeated swaps', () => {
+    setCurrentLabel('25 mph');
+    buildSpeedLimit();
+
+    activeViewer = pannellumViewer;
+    speedLimit.refresh();
+    activeViewer = primaryViewer;
+    speedLimit.refresh();
+    activeViewer = pannellumViewer;
+    speedLimit.refresh();
+
+    expect(primaryViewer.addListener).toHaveBeenCalledTimes(1);
+    expect(pannellumViewer.addListener).toHaveBeenCalledTimes(1);
+  });
+
+  test('a label type the sign is irrelevant for keeps it hidden after a viewer swap', () => {
+    setCurrentLabel('25 mph');
+    speedLimit = new SpeedLimit(
+      () => activeViewer, () => activeViewer.getPosition(), () => false, 'usa',
+      {labelContainer: {getCurrentLabel: () => currentLabel}, labelType: 'CurbRamp'},
+    );
+    expect(document.getElementById('speed-limit-sign').style.display).toBe('none');
+
+    activeViewer = pannellumViewer;
+    speedLimit.refresh();
+    expect(document.getElementById('speed-limit-sign').style.display).toBe('none');
+  });
+});


### PR DESCRIPTION
Resolves #4828

Two components in Validate's startup path captured `svv.panoViewer` by value and subscribed listeners on that one object. `PanoManager` swaps `svv.panoViewer` between the primary viewer and Pannellum as labels come and go, so whichever viewer happened to be active at startup was the only one either component ever heard from. Same root pattern as #4813/#4825, different components.

### 1. `pov_changed` logging on Pannellum labels

`PanoManager` now has `#watchViewerPov(viewer)`, which subscribes a viewer to the **one** shared throttled logger (`#logPovChange`) and dedupes through a `Set`. Pannellum is subscribed as it is created in `#showPannellumPano`; the primary viewer is subscribed after the startup pano load, since that load sets the viewer's initial POV and fires `pov_changed` — subscribing before it would open every session with a `POV_Changed` nobody caused. The throttle itself is created early in `#init` so it exists when the first label falls straight to Pannellum. Both viewers share the one 500ms window rather than getting one each.

### 2. Speed-limit sign freezing on the first label's value

`SpeedLimit`'s first constructor param is now a function returning the active viewer, resolved per use. A new public `refresh()` re-resolves the viewer, subscribes to it if it hasn't been seen (`#watchViewer`, deduped), and updates the sign. `LabelContainer.renderCurrentLabel` calls it as each label renders — a swap has no event to announce itself, since the viewer being swapped away from is exactly the one that goes silent.

The same freeze had a second cause in the same object: `#labelType` was captured once at construction, but Validate rolls into the next mission without a page reload (`Form.js` → `resetLabelList`) and `svv.speedLimit` is never rebuilt. So a session that started on `NoCurbRamp` kept showing speed limits on label types they're irrelevant to, and one that started elsewhere never showed the sign at all. The label type is now read from the current label on every update, and the `labelType` constructor option is gone.

Both call sites are updated (`SpeedLimit` is shared with Explore, which never swaps viewers and has no labels, so the behavior there is unchanged).

### Testing

`test/js/validateViewerSwapListeners.test.js` — 11 tests driving the real `PanoManager` and `SpeedLimit` against fake viewers, no imagery involved. Full JS suite passes (51 suites / 621 tests); ESLint clean.

Manual reproduction — console recipe in the comment below; it manufactures the viewer swap with a stub Pannellum viewer, so it needs no imagery, DB, or file setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
