### PR TITLE
Fade a label's marker while its dialog is open, and cap how large placed label icons can get

### DIFF
--- a/public/js/common/utilities.js
+++ b/public/js/common/utilities.js
@@ -34,6 +34,31 @@ util.LABEL_ICON_MAX_SCREEN_DIAMETER = 38;
 util.LABEL_MIN_SCREEN_TARGET = 24;
 
 /**
+ * Half-extent of the icon actually drawn for a label of the given radius, in the same logical frame.
+ *
+ * Label.renderLabelIcon draws the icon at 2 * radius - 3, inset from the radius, so the mark the user sees is
+ * smaller than its nominal radius and is not proportional to it. Everything sized against the icon — the click
+ * target, the outline rings, the unrated-severity badge — measures from here rather than from the radius.
+ *
+ * @param {number} radius - Icon radius in logical px.
+ * @returns {number} Half the drawn icon's width, in logical px.
+ */
+util.labelIconHalfExtent = function (radius) {
+  return radius - 1.5;
+};
+
+/**
+ * Scale factor for icon geometry authored against util.LABEL_ICON_BASE_RADIUS, so that a decoration keeps its exact
+ * relationship to the icon's edge however the icon is sized (#4838). 1 at the base radius, smaller once capped.
+ *
+ * @param {number} radius - Icon radius in logical px.
+ * @returns {number} Multiplier for offsets, sizes, and stroke widths authored at the base radius.
+ */
+util.labelIconScale = function (radius) {
+  return util.labelIconHalfExtent(radius) / util.labelIconHalfExtent(util.LABEL_ICON_BASE_RADIUS);
+};
+
+/**
  * Radius of a placed label's icon, in Explore's fixed 720x480 logical frame (#4838).
  *
  * The logical frame is displayed at var(--ui-scale) (0.65x-1.8x, see util.applyToolScale), so a constant radius
@@ -48,12 +73,12 @@ util.LABEL_MIN_SCREEN_TARGET = 24;
  * @returns {number} Radius in logical px.
  */
 util.labelIconRadius = function (scale) {
-  const uiScale = scale || util.uiScale();
-  // Cap the drawn diameter, not the radius: the drawn size is 2 * radius - 3 (Label.renderLabelIcon), and it is the
-  // drawn size the on-screen limit is about.
-  const baseDiameter = 2 * util.LABEL_ICON_BASE_RADIUS - 3;
+  const uiScale = scale ?? util.uiScale();
+  // Cap the drawn diameter, not the radius: the icon is drawn inset from its radius (see labelIconHalfExtent), and
+  // it is the drawn size the on-screen limit is about.
+  const baseDiameter = 2 * util.labelIconHalfExtent(util.LABEL_ICON_BASE_RADIUS);
   const diameter = Math.min(baseDiameter, util.LABEL_ICON_MAX_SCREEN_DIAMETER / uiScale);
-  return (diameter + 3) / 2;
+  return diameter / 2 + 1.5;
 };
 
 /**
@@ -64,13 +89,17 @@ util.labelIconRadius = function (scale) {
  * above would have shrunk it further. The target is the visible icon instead, floored so it stays usable once the
  * tool scales down.
  *
+ * The target is a square and the icon is round, so its corners do reach a little past the icon; that slack is what
+ * lets a near miss on a lone icon still land. Where it makes two neighbouring targets overlap, Canvas.onLabel
+ * resolves the tie in favour of the icon drawn on top.
+ *
  * @param {number} [scale] - The tool's UI scale. Read from the page when omitted.
  * @returns {number} Half-width in logical px.
  */
 util.labelHitMargin = function (scale) {
-  const uiScale = scale || util.uiScale();
-  // Half the drawn diameter (2 * radius - 3), so the whole icon is clickable and nothing beyond it is.
-  const halfIcon = util.labelIconRadius(uiScale) - 1.5;
+  const uiScale = scale ?? util.uiScale();
+  // Half the drawn icon, so every point of the icon is inside the target.
+  const halfIcon = util.labelIconHalfExtent(util.labelIconRadius(uiScale));
   return Math.max(halfIcon, util.LABEL_MIN_SCREEN_TARGET / 2 / uiScale);
 };
 

--- a/public/js/common/utilities.js
+++ b/public/js/common/utilities.js
@@ -20,6 +20,60 @@ util.exploreDisplayScale = function () {
   return layer ? layer.getBoundingClientRect().width / util.EXPLORE_CANVAS_WIDTH : 1;
 };
 
+// Radius of a placed label's icon at --ui-scale = 1, in the 720x480 logical frame. Every piece of icon geometry in
+// Label.js — the drawn size, the two outline rings, the unrated-severity badge — is authored against this value and
+// scales off it, so a capped radius keeps the mark's proportions.
+util.LABEL_ICON_BASE_RADIUS = 17;
+
+// Largest a label icon may get on screen, in CSS px. Matches Label.CURSOR_ICON_SIZE, the labeling cursor the user
+// aims with: that cursor is a fixed-size bitmap and does not scale, so letting the placed icon outgrow it means
+// aiming with one size and placing another.
+util.LABEL_ICON_MAX_SCREEN_DIAMETER = 38;
+
+// Smallest a label's click target may get on screen, in CSS px. WCAG 2.5.8 Target Size (Minimum), level AA.
+util.LABEL_MIN_SCREEN_TARGET = 24;
+
+/**
+ * Radius of a placed label's icon, in Explore's fixed 720x480 logical frame (#4838).
+ *
+ * The logical frame is displayed at var(--ui-scale) (0.65x-1.8x, see util.applyToolScale), so a constant radius
+ * grows with the tool — 20 to 56 on-screen px across that range. The *drawn* size is therefore capped in screen px
+ * instead: below ~1.23x scale this returns the unchanged base radius, and above it the icon holds still while the
+ * rest of the tool keeps growing.
+ *
+ * Callers should re-read this whenever --ui-scale changes; Explore caches it in svl.LABEL_ICON_RADIUS, which its
+ * scale-applying path refreshes.
+ *
+ * @param {number} [scale] - The tool's UI scale. Read from the page when omitted.
+ * @returns {number} Radius in logical px.
+ */
+util.labelIconRadius = function (scale) {
+  const uiScale = scale || util.uiScale();
+  // Cap the drawn diameter, not the radius: the drawn size is 2 * radius - 3 (Label.renderLabelIcon), and it is the
+  // drawn size the on-screen limit is about.
+  const baseDiameter = 2 * util.LABEL_ICON_BASE_RADIUS - 3;
+  const diameter = Math.min(baseDiameter, util.LABEL_ICON_MAX_SCREEN_DIAMETER / uiScale);
+  return (diameter + 3) / 2;
+};
+
+/**
+ * Half-width of a placed label's square click target, in Explore's fixed 720x480 logical frame (#4838).
+ *
+ * Deliberately not derived from the icon radius the way Label.isOn used to derive it (radius / 2 + 2): that made
+ * the target *smaller* than the icon it belongs to — 21 logical px under a 31 px icon — and capping the radius
+ * above would have shrunk it further. The target is the visible icon instead, floored so it stays usable once the
+ * tool scales down.
+ *
+ * @param {number} [scale] - The tool's UI scale. Read from the page when omitted.
+ * @returns {number} Half-width in logical px.
+ */
+util.labelHitMargin = function (scale) {
+  const uiScale = scale || util.uiScale();
+  // Half the drawn diameter (2 * radius - 3), so the whole icon is clickable and nothing beyond it is.
+  const halfIcon = util.labelIconRadius(uiScale) - 1.5;
+  return Math.max(halfIcon, util.LABEL_MIN_SCREEN_TARGET / 2 / uiScale);
+};
+
 /**
  * Sizes an Explore-tool canvas bitmap to its on-screen size times the device pixel ratio, and scales the 2D
  * context so all drawing done in the fixed 720x480 logical frame renders at full resolution.

--- a/public/js/explore/src/Main.js
+++ b/public/js/explore/src/Main.js
@@ -27,7 +27,10 @@ class Main {
     svl.isExploreAddressMode = () => this.#params.mission.mission_type === 'exploreAddress';
     svl.regionId = params.regionId;
 
-    svl.LABEL_ICON_RADIUS = 17;
+    // Both are derived from --ui-scale and refreshed by applyExploreScale() below, which owns that variable. They
+    // start at their scale-1 values because the tool renders at scale 1 until that first call (#4838).
+    svl.LABEL_ICON_RADIUS = util.labelIconRadius(1);
+    svl.LABEL_HIT_MARGIN = util.labelHitMargin(1);
     svl.TUTORIAL_PANO_HEIGHT = 6656;
     svl.TUTORIAL_PANO_WIDTH = 13312;
     svl.TUTORIAL_PANO_SCALE_FACTOR = 3.25;
@@ -413,10 +416,17 @@ class Main {
       svl.observedArea.update();
 
       // Uniformly scale the whole tool to fit the viewport (like browser zoom) using var(--ui-scale).
-      const applyExploreScale = () => util.applyToolScale(
-        ['--pano-base-width', '--sidebar-base-gap', '--sidebar-base-width'],
-        ['--ribbon-base-top', '--ribbon-base-height', '--pano-base-height'],
-      );
+      const applyExploreScale = () => {
+        const scale = util.applyToolScale(
+          ['--pano-base-width', '--sidebar-base-gap', '--sidebar-base-width'],
+          ['--ribbon-base-top', '--ribbon-base-height', '--pano-base-height'],
+        );
+        // The label icon and its click target are capped in screen px, so both depend on the scale just applied
+        // (#4838). Cached rather than computed per render: they're read once per label per canvas render, and per
+        // label on every mousemove, and each read would otherwise force a style recalculation.
+        svl.LABEL_ICON_RADIUS = util.labelIconRadius(scale);
+        svl.LABEL_HIT_MARGIN = util.labelHitMargin(scale);
+      };
       applyExploreScale();
       // The canvas was rasterized at scale 1 during init; re-raster it at the chosen scale.
       if (svl.canvas) svl.canvas.resize();

--- a/public/js/explore/src/canvas/Canvas.js
+++ b/public/js/explore/src/canvas/Canvas.js
@@ -555,8 +555,11 @@ class Canvas {
   onLabel(x, y) {
     const labels = svl.labelContainer.getCanvasLabels();
 
-    // Check labels to see if they are under the mouse cursor.
-    for (let i = 0; i < labels.length; i += 1) {
+    // Walked back to front, because render() draws this same list in order and so the *last* match is the one the
+    // user can actually see. Searching forward returned the label underneath. That was mostly hidden while the click
+    // target was smaller than the icon; now that the target is the icon (#4838), two icons that visually touch have
+    // overlapping targets, which makes it the ordinary case rather than a corner one.
+    for (let i = labels.length - 1; i >= 0; i -= 1) {
       if (labels[i].isOn(x, y)) {
         this.#status.currentLabel = labels[i];
         return labels[i];

--- a/public/js/explore/src/canvas/ContextMenu.js
+++ b/public/js/explore/src/canvas/ContextMenu.js
@@ -323,7 +323,8 @@ class ContextMenu {
    * @returns {ContextMenu} this.
    */
   hide() {
-    if (this.isOpen()) {
+    const wasOpen = this.isOpen();
+    if (wasOpen) {
       this.#descriptionTextBox.blur(); // Force the blur event before the ContextMenu close event.
       svl.tracker.push('ContextMenu_Close');
     }
@@ -334,6 +335,10 @@ class ContextMenu {
 
     this.#menuWindow.css('visibility', 'hidden');
     this.#setStatus('visibility', 'hidden');
+
+    // Restore the target label's icon to full opacity (see Label.render). Only when the panel was actually open —
+    // hide() is also called speculatively (navigation, keyboard shortcuts) and shouldn't redraw the canvas then.
+    if (wasOpen) svl.canvas.clear().render();
 
     return this;
   }
@@ -658,6 +663,10 @@ class ContextMenu {
       this.#pointShareAtLabel(this.#getStatus('targetLabel'));
       util.anchorPanelToLabel(this.#menuWindow, labelCoord, svl.LABEL_ICON_RADIUS);
       this.#menuWindow.css('visibility', 'visible');
+
+      // Fade the target label's icon (see Label.render). Not every caller renders after opening the panel, and the
+      // ones that do — the hover card's click handler, for one — render before it, so do it here.
+      svl.canvas.clear().render();
     }
   }
 

--- a/public/js/explore/src/label/Label.js
+++ b/public/js/explore/src/label/Label.js
@@ -342,7 +342,7 @@ class Label {
     const rootStyle = getComputedStyle(document.documentElement);
     // The badge's placement and size are authored against the base icon radius, so they scale with the icon and it
     // stays pinned to the icon's upper-left however the icon is sized (#4838).
-    const k = svl.LABEL_ICON_RADIUS / util.LABEL_ICON_BASE_RADIUS;
+    const k = util.labelIconScale(svl.LABEL_ICON_RADIUS);
 
     // Draws circle. The same --color-error-200 the hover card's unrated chip uses, so the "?" on the canvas and the
     // "?" on the card that describes it are one mark in two places rather than two different reds (#4731).
@@ -558,20 +558,23 @@ class Label {
    */
   static renderLabelIcon(ctx, labelType, x, y) {
     const radius = svl.LABEL_ICON_RADIUS;
-    const size = 2 * radius - 3;
+    const halfIcon = util.labelIconHalfExtent(radius);
+    const size = 2 * halfIcon;
     const icon = window.labelIconCache[util.misc.getIconImagePaths(labelType).iconImagePath];
     if (icon) ctx.drawImage(icon, x - radius + 2, y - radius + 2, size, size);
 
-    // The rings are a hairline just inside and just outside the icon's edge, so they're offsets from the radius
-    // rather than the fixed 15.3/16.2 they used to be — the radius moves with the UI scale now (#4838). The offsets
-    // and the stroke stay absolute, which is what keeps the outline the same weight at every icon size.
-    ctx.lineWidth = 0.7;
+    // The rings are a hairline straddling the icon's edge, so they're offsets from the drawn icon rather than the
+    // fixed 15.3/16.2 they used to be — the icon's size moves with the UI scale now, and stops moving once the cap
+    // engages (#4838). The offsets and the stroke scale with it too: left absolute, the outline would read about
+    // 47% heavier against a capped icon than against a full-size one.
+    const k = util.labelIconScale(radius);
+    ctx.lineWidth = 0.7 * k;
     ctx.beginPath();
-    ctx.arc(x, y, radius - 1.7, 0, 2 * Math.PI);
+    ctx.arc(x, y, halfIcon - 0.2 * k, 0, 2 * Math.PI);
     ctx.strokeStyle = 'black';
     ctx.stroke();
     ctx.beginPath();
-    ctx.arc(x, y, radius - 0.8, 0, 2 * Math.PI);
+    ctx.arc(x, y, halfIcon + 0.7 * k, 0, 2 * Math.PI);
     ctx.strokeStyle = 'white';
     ctx.stroke();
   }

--- a/public/js/explore/src/label/Label.js
+++ b/public/js/explore/src/label/Label.js
@@ -9,11 +9,13 @@ class Label {
   #googleMarker;
 
   // Size the label-type icons are rasterized to before being drawn (see preloadIcons). The label canvas renders at
-  // its on-screen size times the device pixel ratio, so the ~34px logical icon can land on ~130 device pixels on a
-  // wide HiDPI display; rasterizing below that is what left the icon looking soft.
+  // its on-screen size times the device pixel ratio, so the icon tops out around 76 device pixels on a HiDPI
+  // display (util.LABEL_ICON_MAX_SCREEN_DIAMETER at devicePixelRatio 2); rasterizing below that is what left the
+  // icon looking soft. Kept well above that ceiling so the raster is always downscaled, never stretched.
   static #ICON_RASTER_SIZE = 128;
 
-  // On-screen size of the labeling cursor. Canvas.js centers its hotspot on this.
+  // On-screen size of the labeling cursor, in CSS px. Canvas.js centers its hotspot on this. This bitmap does not
+  // scale with the tool, so it is also the ceiling a placed icon may grow to — see util.labelIconRadius (#4838).
   static CURSOR_ICON_SIZE = 38;
 
   static #cursorUrlCache = new Map();
@@ -200,7 +202,9 @@ class Label {
    * @returns {boolean}
    */
   isOn(x, y) {
-    const margin = svl.LABEL_ICON_RADIUS / 2 + 2;
+    // Sized to the drawn icon rather than derived from its radius, which used to leave the target smaller than the
+    // icon under it. See util.labelHitMargin.
+    const margin = svl.LABEL_HIT_MARGIN;
     return !this.#status.deleted
       && this.#status.visibility === 'visible'
       && this.#properties.currCanvasXY
@@ -336,6 +340,9 @@ class Label {
     // Canvas resolves neither CSS variables nor --ui-scale, so the design tokens are read off :root. (No scaling
     // wanted here regardless: this canvas keeps its fixed logical size and is scaled up by the browser.)
     const rootStyle = getComputedStyle(document.documentElement);
+    // The badge's placement and size are authored against the base icon radius, so they scale with the icon and it
+    // stays pinned to the icon's upper-left however the icon is sized (#4838).
+    const k = svl.LABEL_ICON_RADIUS / util.LABEL_ICON_BASE_RADIUS;
 
     // Draws circle. The same --color-error-200 the hover card's unrated chip uses, so the "?" on the canvas and the
     // "?" on the card that describes it are one mark in two places rather than two different reds (#4731).
@@ -343,15 +350,15 @@ class Label {
     // Trimmed: a custom property's value keeps the whitespace after the colon, and an unparseable fillStyle is
     // silently ignored rather than throwing — the circle would just keep whatever color was set last.
     ctx.fillStyle = rootStyle.getPropertyValue('--color-error-200').trim();
-    ctx.ellipse(x - 15, y - 10.5, 8, 8, 0, 0, 2 * Math.PI);
+    ctx.ellipse(x - 15 * k, y - 10.5 * k, 8 * k, 8 * k, 0, 0, 2 * Math.PI);
     ctx.fill();
     ctx.closePath();
 
     // Draws text.
     ctx.beginPath();
-    ctx.font = `400 12px ${rootStyle.getPropertyValue('--font-primary')}`;
+    ctx.font = `400 ${12 * k}px ${rootStyle.getPropertyValue('--font-primary')}`;
     ctx.fillStyle = 'rgb(255, 255, 255)';
-    ctx.fillText('?', x - 17.5, y - 6);
+    ctx.fillText('?', x - 17.5 * k, y - 6 * k);
     ctx.closePath();
   }
 
@@ -550,17 +557,21 @@ class Label {
    * @param {number} y
    */
   static renderLabelIcon(ctx, labelType, x, y) {
-    const size = 2 * svl.LABEL_ICON_RADIUS - 3;
+    const radius = svl.LABEL_ICON_RADIUS;
+    const size = 2 * radius - 3;
     const icon = window.labelIconCache[util.misc.getIconImagePaths(labelType).iconImagePath];
-    if (icon) ctx.drawImage(icon, x - svl.LABEL_ICON_RADIUS + 2, y - svl.LABEL_ICON_RADIUS + 2, size, size);
+    if (icon) ctx.drawImage(icon, x - radius + 2, y - radius + 2, size, size);
 
+    // The rings are a hairline just inside and just outside the icon's edge, so they're offsets from the radius
+    // rather than the fixed 15.3/16.2 they used to be — the radius moves with the UI scale now (#4838). The offsets
+    // and the stroke stay absolute, which is what keeps the outline the same weight at every icon size.
     ctx.lineWidth = 0.7;
     ctx.beginPath();
-    ctx.arc(x, y, 15.3, 0, 2 * Math.PI);
+    ctx.arc(x, y, radius - 1.7, 0, 2 * Math.PI);
     ctx.strokeStyle = 'black';
     ctx.stroke();
     ctx.beginPath();
-    ctx.arc(x, y, 16.2, 0, 2 * Math.PI);
+    ctx.arc(x, y, radius - 0.8, 0, 2 * Math.PI);
     ctx.strokeStyle = 'white';
     ctx.stroke();
   }

--- a/public/js/explore/src/label/Label.js
+++ b/public/js/explore/src/label/Label.js
@@ -238,10 +238,10 @@ class Label {
 
       // Draw the label icon if it's in the visible part of the pano.
       if (this.#properties.currCanvasXY) {
-        // Tutorial only: fade the icon while its dialog is open. The marker sits exactly on the feature the copy
-        // asks the user to look at, and the dialog's tail still points at the spot.
-        const dialogTarget = svl.isOnboarding?.() && svl.contextMenu?.isOpen()
-          && svl.contextMenu.getTargetLabel() === this;
+        // Fade the icon while its dialog is open. The marker sits exactly on the feature being rated, so fading it
+        // lets the user see that feature while they rate it; the dialog's tail still marks the spot. ContextMenu's
+        // show()/hide() re-render the canvas so this toggles the moment the dialog opens or closes.
+        const dialogTarget = svl.contextMenu?.isOpen() && svl.contextMenu.getTargetLabel() === this;
         if (dialogTarget) {
           ctx.save();
           ctx.globalAlpha = 0.3;

--- a/public/js/explore/src/onboarding/Onboarding.js
+++ b/public/js/explore/src/onboarding/Onboarding.js
@@ -910,8 +910,6 @@ class Onboarding {
     this.#contextMenu.enableRatingSeverityForTutorialLabel(state.properties.labelNumber);
     // Pulse the one section the tutorial has enabled; the message box is anchored to it as well.
     this.#svl.ui.contextMenu.severityMenu.addClass('onboarding-attention');
-    // Re-render so the dialog's target label fades right away (see Label.render).
-    this.#svl.canvas.clear().render();
     const $target = this.#svl.ui.contextMenu.radioButtons;
     const callback = (e) => {
       if (listener) google.maps.event.removeListener(listener);
@@ -919,7 +917,6 @@ class Onboarding {
       this.#contextMenu.disableRatingSeverity();
       this.#svl.ui.contextMenu.severityMenu.removeClass('onboarding-attention');
       this.#transitionTo(state.transition, undefined, e.currentTarget);
-      this.#svl.canvas.clear().render();
     };
     $target.on('change', callback);
   }
@@ -928,8 +925,6 @@ class Onboarding {
     this.#contextMenu.enableTaggingForTutorialLabel(state.properties.labelNumber);
     // Pulse the one section the tutorial has enabled; the message box is anchored to it as well.
     this.#svl.ui.contextMenu.tagSection.addClass('onboarding-attention');
-    // Re-render so the dialog's target label fades right away (see Label.render).
-    this.#svl.canvas.clear().render();
     const $target = this.#svl.ui.contextMenu.tagHolder; // Grab tag holder so we can add an event listener.
     const callback = () => {
       if (listener) google.maps.event.removeListener(listener);
@@ -937,7 +932,6 @@ class Onboarding {
       this.#contextMenu.disableTagging();
       this.#svl.ui.contextMenu.tagSection.removeClass('onboarding-attention');
       this.#transitionTo(state.transition, undefined, this.#contextMenu.getTargetLabel());
-      this.#svl.canvas.clear().render();
     };
     // We use a custom event here to ensure that this is triggered after the tags have been updated.
     $target.on('tagIds-updated', callback);

--- a/test/js/canvasCtxStub.js
+++ b/test/js/canvasCtxStub.js
@@ -1,0 +1,64 @@
+/**
+ * Test helper: a CanvasRenderingContext2D stand-in that records what was drawn.
+ *
+ * Explore's label rendering is pure geometry on a 2D context, so the cheapest faithful way to test it is to hand it
+ * a recorder and read the calls back. Two kinds of thing are captured:
+ *
+ * - `alphas`, the globalAlpha in effect for each *painting* call. Recorded at paint time rather than by trusting
+ *   that save/restore were called in the right order, since a restore() in the wrong place is exactly the bug worth
+ *   catching (see exploreLabelDialogFade.test.js).
+ * - the geometry of each call, for the tests that check the icon's decorations track its size
+ *   (see labelIconSizing.test.js).
+ *
+ * jsdom's own canvas is a no-op without the optional `canvas` package, and a real context would not let us read
+ * back what was drawn anyway, so a stub is the only option here rather than a shortcut.
+ *
+ * @returns {Object} A recording 2D-context stand-in.
+ */
+function makeRecordingCtx() {
+    const savedAlphas = [];
+    return {
+        // Recorded output.
+        alphas: [],    // globalAlpha in effect for each painting call, in order.
+        arcs: [],      // { cx, cy, r, lineWidth }
+        ellipses: [],  // { cx, cy, rx, ry }
+        images: [],    // { dx, dy, w, h }
+        texts: [],     // { t, x, y, font }
+        saveCount: 0,
+
+        // Context state the code under test sets.
+        globalAlpha: 1,
+        lineWidth: 1,
+        strokeStyle: '',
+        fillStyle: '',
+        font: '',
+        textAlign: '',
+
+        save() { this.saveCount += 1; savedAlphas.push(this.globalAlpha); },
+        restore() { this.globalAlpha = savedAlphas.pop(); },
+
+        beginPath() {},
+        closePath() {},
+        moveTo() {},
+        lineTo() {},
+
+        // lineWidth is captured with the arc rather than at stroke() time; the code under test sets it before its
+        // arcs, and pairing it here is what lets a test compare stroke weight against the arc it painted.
+        arc(cx, cy, r) { this.arcs.push({ cx, cy, r, lineWidth: this.lineWidth }); },
+        ellipse(cx, cy, rx, ry) { this.ellipses.push({ cx, cy, rx, ry }); },
+
+        drawImage(img, dx, dy, w, h) {
+            this.images.push({ dx, dy, w, h });
+            this.alphas.push(this.globalAlpha);
+        },
+        fillText(t, x, y) {
+            this.texts.push({ t, x, y, font: this.font });
+            this.alphas.push(this.globalAlpha);
+        },
+        fill() { this.alphas.push(this.globalAlpha); },
+        stroke() { this.alphas.push(this.globalAlpha); },
+        measureText: () => ({ width: 0 }),
+    };
+}
+
+module.exports = { makeRecordingCtx };

--- a/test/js/exploreContextMenuRerender.test.js
+++ b/test/js/exploreContextMenuRerender.test.js
@@ -1,0 +1,172 @@
+/**
+ * Tests for the canvas re-render in ContextMenu.show()/hide() (public/js/explore/src/canvas/ContextMenu.js, #4824).
+ *
+ * Label.render() fades the icon whose dialog is open (pinned in exploreLabelDialogFade.test.js), but the canvas is
+ * only repainted when something asks it to. What makes the fade appear the instant the panel opens and clear the
+ * instant it closes is these two methods repainting themselves, rather than each of their ~15 call sites
+ * remembering to. Two things matter and neither is visible from Label.render:
+ *
+ *  - the repaint has to happen *after* the visibility flip, or it paints the state the panel just left; and
+ *  - hide() must not repaint when nothing was open, because it is also called speculatively on navigation and on
+ *    keyboard shortcuts, where a repaint per keystroke is waste.
+ *
+ * ContextMenu is a jQuery-bound class with private fields, so it is driven through a stubbed UI the way
+ * validateLabelCardKeyboard.test.js drives Validate's KeyboardManager. Only the surface show()/hide() touch is
+ * stubbed; the severity and tag sections are switched off through the same flags production uses.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const CONTEXT_MENU_SRC = fs.readFileSync(
+    path.resolve(__dirname, '..', '..', 'public/js/explore/src/canvas/ContextMenu.js'), 'utf8'
+);
+
+/** A chainable jQuery-wrapped-element stand-in. Every method returns the node; `length` 0 means "not in the DOM". */
+function makeNode(overrides = {}) {
+    const node = {
+        length: 0,
+        0: undefined,
+    };
+    const chainable = ['find', 'each', 'text', 'html', 'attr', 'prop', 'addClass', 'removeClass', 'toggleClass',
+        'css', 'val', 'on', 'off', 'blur', 'focus', 'filter', 'tooltip', 'trigger', 'append', 'remove'];
+    chainable.forEach((name) => { node[name] = () => node; });
+    return Object.assign(node, overrides);
+}
+
+/** The label a menu opens for. Only the getters show()/hide() actually call are present. */
+function makeLabel({ labelType = 'CurbRamp' } = {}) {
+    const props = {
+        labelType, severity: null, description: '', tagIds: [], temporaryLabelId: 7, auditTaskId: 3, labelId: null,
+    };
+    return {
+        getLabelType: () => labelType,
+        getCanvasXY: () => ({ x: 100, y: 100 }),
+        getProperty: (key) => props[key],
+        getProperties: () => props,
+        isDeleted: () => false,
+        setProperty: (key, value) => { props[key] = value; },
+    };
+}
+
+describe('ContextMenu repaints the canvas when the panel opens and closes', () => {
+    let menu;
+    let renders;      // One entry per canvas render, recording what Label.render would have seen at that moment.
+
+    beforeEach(() => {
+        renders = [];
+        window.$ = () => makeNode();
+        window.i18next = { t: (key) => key };
+        window.util = {
+            camelToKebab: (s) => s,
+            anchorPanelToLabel: jest.fn(),
+            misc: {
+                getIconImagePaths: () => ({ iconImagePath: 'CurbRamp.svg' }),
+                // False everywhere, which is what switches off the severity menu, its smiley images, and its
+                // tooltips — none of which this file is about.
+                labelTypeHasSeverity: () => false,
+                getLabelDescriptions: () => ({ tagInfo: {} }),
+            },
+        };
+
+        const canvas = {
+            clear: jest.fn(() => canvas),
+            // Recorded from inside the render, since "did the repaint see the new state?" is the whole question.
+            render: jest.fn(() => {
+                renders.push({ open: window.svl.contextMenu.isOpen(), target: window.svl.contextMenu.getTargetLabel() });
+                return canvas;
+            }),
+            getStatus: () => false,
+        };
+        window.svl = {
+            canvas,
+            tracker: { push: jest.fn() },
+            isOnboarding: () => false,
+            LABEL_ICON_RADIUS: 17,
+            navigationService: { setStatus: jest.fn() },
+        };
+
+        window.eval(`${CONTEXT_MENU_SRC}\nwindow.ContextMenu = ContextMenu;`);
+        // No #context-menu-share element and no ShareWidget global, so the share widget stays null.
+        menu = new window.ContextMenu({
+            holder: makeNode(),
+            severityMenu: makeNode(),
+            severityRadioHolder: makeNode(),
+            radioButtons: makeNode(),
+            textBox: makeNode(),
+            tagHolder: makeNode(),
+            tags: makeNode(),
+            closeButton: makeNode(),
+        });
+        window.svl.contextMenu = menu;
+    });
+
+    test('show() repaints once, after the panel is already open', () => {
+        const label = makeLabel();
+
+        menu.show(label);
+
+        expect(window.svl.canvas.render).toHaveBeenCalledTimes(1);
+        expect(window.svl.canvas.clear).toHaveBeenCalledTimes(1);
+        // The repaint has to see the open panel and its target, or the icon it paints is the unfaded one.
+        expect(renders).toEqual([{ open: true, target: label }]);
+    });
+
+    test('hide() repaints once, after the panel is already closed', () => {
+        const label = makeLabel();
+        menu.show(label);
+        renders.length = 0;
+
+        menu.hide();
+
+        expect(window.svl.canvas.render).toHaveBeenCalledTimes(2);
+        // Closed at repaint time, so the icon goes back to full opacity rather than staying faded until the next
+        // unrelated render.
+        expect(renders).toEqual([{ open: false, target: label }]);
+        expect(menu.isOpen()).toBe(false);
+    });
+
+    test('hide() does not repaint when nothing was open', () => {
+        menu.hide();
+        menu.hide();
+
+        expect(window.svl.canvas.render).not.toHaveBeenCalled();
+        expect(window.svl.tracker.push).not.toHaveBeenCalledWith('ContextMenu_Close');
+    });
+
+    test('a second hide() after a real one does not repaint again', () => {
+        menu.show(makeLabel());
+        menu.hide();
+        expect(window.svl.canvas.render).toHaveBeenCalledTimes(2);
+
+        menu.hide();
+
+        expect(window.svl.canvas.render).toHaveBeenCalledTimes(2);
+    });
+
+    test('opening and closing repeatedly leaves the canvas showing the closed state', () => {
+        const first = makeLabel();
+        const second = makeLabel();
+
+        menu.show(first);
+        menu.hide();
+        menu.show(second);
+        menu.hide();
+
+        expect(renders).toEqual([
+            { open: true, target: first },
+            { open: false, target: first },
+            { open: true, target: second },
+            { open: false, target: second },
+        ]);
+    });
+
+    test('Occlusion labels get no panel and no repaint', () => {
+        // Occlusion has nothing to rate or tag, so show() deliberately opens nothing for it.
+        menu.show(makeLabel({ labelType: 'Occlusion' }));
+
+        expect(menu.isOpen()).toBe(false);
+        expect(menu.getTargetLabel()).toBe(null);
+        expect(window.svl.canvas.render).not.toHaveBeenCalled();
+    });
+});

--- a/test/js/exploreLabelDialogFade.test.js
+++ b/test/js/exploreLabelDialogFade.test.js
@@ -1,0 +1,177 @@
+/**
+ * Tests for the dialog-open fade in Label#render (public/js/explore/src/label/Label.js, issue #4824).
+ *
+ * While a label's context menu is open, that label's icon draws at reduced opacity: the marker sits exactly on the
+ * feature the user is rating, so fading it lets them see the feature while they rate it. The dialog's tail still
+ * points at the spot.
+ *
+ * The behavior started life gated on `svl.isOnboarding()` (the tutorial, #4814/#4815). #4824 promoted it to regular
+ * Explore labeling, so the gate is gone — the `isOnboarding` cases below are the pin that keeps it gone. What makes
+ * the fade *visible* the instant the panel opens or closes is ContextMenu.show()/hide() re-rendering the canvas;
+ * that wiring is jQuery-bound UI and is verified in the browser, not here.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const LABEL_SRC = fs.readFileSync(
+    path.resolve(__dirname, '..', '..', 'public/js/explore/src/label/Label.js'), 'utf8'
+);
+
+/** Loads a fresh Label class into the jsdom global scope (a class declaration is not a globalThis property). */
+function loadLabel() {
+    window.eval(`${LABEL_SRC}\nwindow.Label = Label;`);
+    return window.Label;
+}
+
+/**
+ * A canvas context stand-in that records the globalAlpha in effect for every drawing call, so a test can assert what
+ * the icon was actually painted at rather than trusting that save/restore were called in the right order.
+ */
+function makeRecordingCtx() {
+    const alphas = [];
+    const savedAlphas = [];
+    return {
+        globalAlpha: 1,
+        lineWidth: 1,
+        strokeStyle: '',
+        fillStyle: '',
+        font: '',
+        textAlign: '',
+        alphas,
+        saveCount: 0,
+        save() { this.saveCount += 1; savedAlphas.push(this.globalAlpha); },
+        restore() { this.globalAlpha = savedAlphas.pop(); },
+        drawImage() { alphas.push(this.globalAlpha); },
+        beginPath() {},
+        closePath() {},
+        moveTo() {},
+        lineTo() {},
+        arc() {},
+        ellipse() {},
+        stroke() { alphas.push(this.globalAlpha); },
+        fill() { alphas.push(this.globalAlpha); },
+        fillText() { alphas.push(this.globalAlpha); },
+        measureText: () => ({ width: 0 }),
+    };
+}
+
+describe('Label render fade while the context menu is open', () => {
+    let Label;
+
+    /** A placed label with a cached lat/lng, so the constructor's toLatLng() short-circuits past the estimator. */
+    function newLabel({ labelType = 'CurbRamp', severity = 1 } = {}) {
+        const label = new Label({
+            labelType,
+            severity,
+            temporaryLabelId: 1,
+            panoXY: { x: 10, y: 20 },   // Present, so the constructor skips the pano-store lookup.
+            povOfLabelIfCentered: { heading: 90, pitch: -20, zoom: 1 },
+            panoLat: 47.6553,
+            panoLng: -122.3035,
+            labelLat: 47.6554,
+            labelLng: -122.3034,
+        });
+        // The hover card is a DOM concern and is suppressed anyway whenever the context menu is open; keep it out.
+        label.setHoverInfoVisibility('hidden');
+        return label;
+    }
+
+    /** Renders `label` with the context menu reporting `{ open, target }`, returning the alphas it painted at. */
+    function renderWith(label, { open, target }) {
+        window.svl.contextMenu = {
+            isOpen: () => open,
+            getTargetLabel: () => target,
+        };
+        const ctx = makeRecordingCtx();
+        label.render(ctx, { heading: 90, pitch: -20, zoom: 1 });
+        return ctx;
+    }
+
+    beforeEach(() => {
+        Label = loadLabel();
+        window.svl = {
+            LABEL_ICON_RADIUS: 17,
+            isOnboarding: () => false,
+            minimap: { getMap: () => null },
+        };
+        window.util = {
+            EXPLORE_CANVAS_WIDTH: 720,
+            EXPLORE_CANVAS_HEIGHT: 480,
+            pano: { centeredPovToCanvasCoord: () => ({ x: 360, y: 240 }) },
+            misc: {
+                labelTypeHasSeverity: (labelType) => labelType !== 'Occlusion',
+                getIconImagePaths: () => ({ iconImagePath: 'CurbRamp.svg' }),
+            },
+        };
+        window.labelIconCache = { 'CurbRamp.svg': {} }; // Truthy, so renderLabelIcon reaches its drawImage.
+        Label.createMinimapMarker = () => ({ addListener: () => {} });
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test('draws at full opacity when no context menu is open', () => {
+        const ctx = renderWith(newLabel(), { open: false, target: null });
+
+        expect(ctx.alphas.length).toBeGreaterThan(0);
+        expect(ctx.alphas.every((a) => a === 1)).toBe(true);
+        expect(ctx.saveCount).toBe(0); // No save/restore pair at all when there's nothing to fade.
+    });
+
+    test('fades the label the open context menu points at', () => {
+        const label = newLabel();
+        const ctx = renderWith(label, { open: true, target: label });
+
+        expect(ctx.alphas.length).toBeGreaterThan(0);
+        expect(ctx.alphas.every((a) => a === 0.3)).toBe(true);
+    });
+
+    test('leaves the alpha it was handed once the label is drawn', () => {
+        const label = newLabel();
+        const ctx = renderWith(label, { open: true, target: label });
+
+        expect(ctx.globalAlpha).toBe(1); // restore() ran, so the next label in the loop draws unfaded.
+    });
+
+    test('does not fade other labels while one label\'s menu is open', () => {
+        const other = newLabel();
+        const ctx = renderWith(newLabel(), { open: true, target: other });
+
+        expect(ctx.alphas.every((a) => a === 1)).toBe(true);
+    });
+
+    test('fades outside the tutorial too (#4824 removed the isOnboarding gate)', () => {
+        window.svl.isOnboarding = () => false;
+        const label = newLabel();
+        const ctx = renderWith(label, { open: true, target: label });
+
+        expect(ctx.alphas.every((a) => a === 0.3)).toBe(true);
+    });
+
+    test('still fades inside the tutorial', () => {
+        window.svl.isOnboarding = () => true;
+        const label = newLabel();
+        const ctx = renderWith(label, { open: true, target: label });
+
+        expect(ctx.alphas.every((a) => a === 0.3)).toBe(true);
+    });
+
+    test('fades the unrated-severity alert along with the icon', () => {
+        const label = newLabel({ severity: null }); // No severity yet, so render() also paints the "!" alert.
+        const ctx = renderWith(label, { open: true, target: label });
+
+        // More draw calls than the icon alone makes, and every one of them faded.
+        expect(ctx.alphas.length).toBeGreaterThan(renderWith(newLabel(), { open: true, target: null }).alphas.length);
+        expect(ctx.alphas.every((a) => a === 0.3)).toBe(true);
+    });
+
+    test('does not fade a hidden or deleted label (it is not drawn at all)', () => {
+        const label = newLabel();
+        label.remove();
+        const ctx = renderWith(label, { open: true, target: label });
+
+        expect(ctx.alphas).toEqual([]);
+    });
+});

--- a/test/js/exploreLabelDialogFade.test.js
+++ b/test/js/exploreLabelDialogFade.test.js
@@ -8,14 +8,18 @@
  * The behavior started life gated on `svl.isOnboarding()` (the tutorial, #4814/#4815). #4824 promoted it to regular
  * Explore labeling, so the gate is gone — the `isOnboarding` cases below are the pin that keeps it gone. What makes
  * the fade *visible* the instant the panel opens or closes is ContextMenu.show()/hide() re-rendering the canvas;
- * that wiring is jQuery-bound UI and is verified in the browser, not here.
+ * that wiring is pinned separately, in exploreContextMenuRerender.test.js.
  */
 
 const fs = require('fs');
 const path = require('path');
+const { makeRecordingCtx } = require('./canvasCtxStub');
 
 const LABEL_SRC = fs.readFileSync(
     path.resolve(__dirname, '..', '..', 'public/js/explore/src/label/Label.js'), 'utf8'
+);
+const UTILITIES_SRC = fs.readFileSync(
+    path.resolve(__dirname, '..', '..', 'public/js/common/utilities.js'), 'utf8'
 );
 
 /** Loads a fresh Label class into the jsdom global scope (a class declaration is not a globalThis property). */
@@ -25,35 +29,15 @@ function loadLabel() {
 }
 
 /**
- * A canvas context stand-in that records the globalAlpha in effect for every drawing call, so a test can assert what
- * the icon was actually painted at rather than trusting that save/restore were called in the right order.
+ * Loads the real utilities.js rather than stubbing it. Label's icon geometry is expressed in terms of
+ * util.labelIconHalfExtent/labelIconScale, and a stub of those would be the formula copied into the test.
  */
-function makeRecordingCtx() {
-    const alphas = [];
-    const savedAlphas = [];
-    return {
-        globalAlpha: 1,
-        lineWidth: 1,
-        strokeStyle: '',
-        fillStyle: '',
-        font: '',
-        textAlign: '',
-        alphas,
-        saveCount: 0,
-        save() { this.saveCount += 1; savedAlphas.push(this.globalAlpha); },
-        restore() { this.globalAlpha = savedAlphas.pop(); },
-        drawImage() { alphas.push(this.globalAlpha); },
-        beginPath() {},
-        closePath() {},
-        moveTo() {},
-        lineTo() {},
-        arc() {},
-        ellipse() {},
-        stroke() { alphas.push(this.globalAlpha); },
-        fill() { alphas.push(this.globalAlpha); },
-        fillText() { alphas.push(this.globalAlpha); },
-        measureText: () => ({ width: 0 }),
-    };
+function loadUtil() {
+    // utilities.js builds a Bowser parser at load time; nothing under test here consults it.
+    window.bowser = { getParser: () => ({ getBrowserName: () => 'Chrome', getBrowserVersion: () => '1',
+        getOSName: () => 'Linux', getPlatformType: () => 'desktop' }) };
+    window.eval(UTILITIES_SRC);
+    return window.util;
 }
 
 describe('Label render fade while the context menu is open', () => {
@@ -90,19 +74,16 @@ describe('Label render fade while the context menu is open', () => {
 
     beforeEach(() => {
         Label = loadLabel();
+        const util = loadUtil();
         window.svl = {
-            LABEL_ICON_RADIUS: 17,
+            LABEL_ICON_RADIUS: util.labelIconRadius(1),
             isOnboarding: () => false,
             minimap: { getMap: () => null },
         };
-        window.util = {
-            EXPLORE_CANVAS_WIDTH: 720,
-            EXPLORE_CANVAS_HEIGHT: 480,
-            pano: { centeredPovToCanvasCoord: () => ({ x: 360, y: 240 }) },
-            misc: {
-                labelTypeHasSeverity: (labelType) => labelType !== 'Occlusion',
-                getIconImagePaths: () => ({ iconImagePath: 'CurbRamp.svg' }),
-            },
+        util.pano = { centeredPovToCanvasCoord: () => ({ x: 360, y: 240 }) };
+        util.misc = {
+            labelTypeHasSeverity: (labelType) => labelType !== 'Occlusion',
+            getIconImagePaths: () => ({ iconImagePath: 'CurbRamp.svg' }),
         };
         window.labelIconCache = { 'CurbRamp.svg': {} }; // Truthy, so renderLabelIcon reaches its drawImage.
         Label.createMinimapMarker = () => ({ addListener: () => {} });

--- a/test/js/labelIconSizing.test.js
+++ b/test/js/labelIconSizing.test.js
@@ -1,10 +1,11 @@
 /**
- * Tests for util.labelIconRadius / util.labelHitMargin (public/js/common/utilities.js, issue #4838).
+ * Tests for util.labelIconRadius / util.labelHitMargin (public/js/common/utilities.js, issue #4838), and for the two
+ * things in Explore that consume them: Label.isOn's click target and Label.renderLabelIcon's decorations.
  *
  * Explore draws into a fixed 720x480 logical frame that is displayed at var(--ui-scale) (0.65x-1.8x). A constant
  * icon radius therefore grew with the tool, reaching 56 on-screen px at the scale cap — well past the 38px labeling
- * cursor the user aims with. These two helpers cap the drawn icon in *screen* px and size the click target to the
- * icon rather than deriving it from the radius.
+ * cursor the user aims with. These helpers cap the drawn icon in *screen* px and size the click target to the icon
+ * rather than deriving it from the radius.
  *
  * Everything below is asserted in on-screen CSS px (logical value x scale), because that is the thing being capped;
  * the logical values are an implementation detail that moves with the scale by design.
@@ -12,27 +13,32 @@
 
 const fs = require('fs');
 const path = require('path');
+const { makeRecordingCtx } = require('./canvasCtxStub');
 
 const UTILITIES_SRC = fs.readFileSync(
     path.resolve(__dirname, '..', '..', 'public/js/common/utilities.js'), 'utf8'
 );
+const LABEL_SRC = fs.readFileSync(
+    path.resolve(__dirname, '..', '..', 'public/js/explore/src/label/Label.js'), 'utf8'
+);
+const CANVAS_SRC = fs.readFileSync(
+    path.resolve(__dirname, '..', '..', 'public/js/explore/src/canvas/Canvas.js'), 'utf8'
+);
 
-/**
- * Loads utilities.js into jsdom. It is a plain global script, but its tail constructs a Bowser parser and reads
- * navigator/jQuery, so only the section up to that point is evaluated here.
- */
+/** Loads utilities.js into jsdom, the same way sizeCanvasToDisplay.test.js and anchorPanelToLabel.test.js do. */
 function loadUtil() {
-    const src = UTILITIES_SRC.slice(0, UTILITIES_SRC.indexOf('// Browser detection helpers backed by Bowser'));
-    window.util = {};
-    window.eval(src);
+    // utilities.js builds a Bowser parser at load time; none of the geometry under test consults it.
+    window.bowser = { getParser: () => ({ getBrowserName: () => 'Chrome', getBrowserVersion: () => '1',
+        getOSName: () => 'Linux', getPlatformType: () => 'desktop' }) };
+    window.eval(UTILITIES_SRC);
     return window.util;
 }
 
 describe('label icon sizing across the UI scale', () => {
     let util;
 
-    /** On-screen diameter in CSS px of the icon Label.renderLabelIcon draws (2 * radius - 3) at this scale. */
-    const iconScreenDiameter = (scale) => (2 * util.labelIconRadius(scale) - 3) * scale;
+    /** On-screen diameter in CSS px of the icon Label.renderLabelIcon draws at this scale. */
+    const iconScreenDiameter = (scale) => 2 * util.labelIconHalfExtent(util.labelIconRadius(scale)) * scale;
 
     /** On-screen width in CSS px of the square click target Label.isOn tests (2 * margin) at this scale. */
     const targetScreenSize = (scale) => 2 * util.labelHitMargin(scale) * scale;
@@ -64,7 +70,7 @@ describe('label icon sizing across the UI scale', () => {
         });
 
         test('the cap engages where the base size reaches the cursor size, and not before', () => {
-            const baseDiameter = 2 * util.LABEL_ICON_BASE_RADIUS - 3;
+            const baseDiameter = 2 * util.labelIconHalfExtent(util.LABEL_ICON_BASE_RADIUS);
             const crossover = util.LABEL_ICON_MAX_SCREEN_DIAMETER / baseDiameter; // ~1.2258
             expect(iconScreenDiameter(crossover - 0.01)).toBeLessThan(38);
             expect(iconScreenDiameter(crossover + 0.01)).toBeCloseTo(38, 5);
@@ -114,29 +120,12 @@ describe('label icon sizing across the UI scale', () => {
      * shrunken icon and the badge came unpinned from its corner. These pin them to the icon instead.
      */
     describe('icon decorations follow the radius', () => {
-        const LABEL_SRC = fs.readFileSync(
-            path.resolve(__dirname, '..', '..', 'public/js/explore/src/label/Label.js'), 'utf8'
-        );
-
-        /** Records the geometry of every drawing call so a test can compare it against the icon's own bounds. */
-        function makeRecordingCtx() {
-            return {
-                arcs: [], ellipses: [], images: [], texts: [],
-                globalAlpha: 1, lineWidth: 1, strokeStyle: '', fillStyle: '', font: '',
-                save() {}, restore() {}, beginPath() {}, closePath() {}, fill() {}, stroke() {},
-                drawImage(img, dx, dy, w, h) { this.images.push({ dx: dx, dy: dy, w: w, h: h }); },
-                arc(cx, cy, r) { this.arcs.push({ cx: cx, cy: cy, r: r }); },
-                ellipse(cx, cy, rx, ry) { this.ellipses.push({ cx: cx, cy: cy, rx: rx, ry: ry }); },
-                fillText(t, tx, ty) { this.texts.push({ t: t, x: tx, y: ty }); },
-                measureText: () => ({ width: 0 }),
-            };
-        }
-
         let Label;
 
         beforeEach(() => {
             window.util = util;
-            util.misc = { getIconImagePaths: () => ({ iconImagePath: 'CurbRamp.svg' }), labelTypeHasSeverity: () => true };
+            util.misc = { getIconImagePaths: () => ({ iconImagePath: 'CurbRamp.svg' }),
+                labelTypeHasSeverity: () => true };
             util.pano = { centeredPovToCanvasCoord: () => ({ x: 100, y: 100 }) };
             window.labelIconCache = { 'CurbRamp.svg': {} };
             window.svl = { LABEL_ICON_RADIUS: 17, minimap: { getMap: () => null } };
@@ -144,32 +133,50 @@ describe('label icon sizing across the UI scale', () => {
             Label = window.Label;
         });
 
-        /** Renders the icon at `radius` and returns the ring radii relative to the drawn icon's own half-extent. */
-        function ringOffsets(radius) {
+        /** Renders the icon at `radius` and returns its recording context. */
+        function renderIcon(radius) {
             window.svl.LABEL_ICON_RADIUS = radius;
             const ctx = makeRecordingCtx();
             Label.renderLabelIcon(ctx, 'CurbRamp', 100, 100);
-            const img = ctx.images[0];
-            const halfExtent = img.w / 2;                       // Drawn icon spans 2 * radius - 3.
-            return ctx.arcs.map((a) => a.r - halfExtent);
+            return ctx;
         }
 
-        test('the rings hug the icon edge identically at the base radius and a capped one', () => {
-            const atBase = ringOffsets(util.LABEL_ICON_BASE_RADIUS);
-            const atCapped = ringOffsets(util.labelIconRadius(1.8));
+        test('the rings still land exactly where they always did at the base radius', () => {
+            const ctx = renderIcon(util.LABEL_ICON_BASE_RADIUS);
 
-            expect(atBase).toHaveLength(2);
-            expect(atCapped[0]).toBeCloseTo(atBase[0], 10);
-            expect(atCapped[1]).toBeCloseTo(atBase[1], 10);
-            expect(atBase[0]).toBeLessThan(0);   // Inner ring inside the icon edge…
-            expect(atBase[1]).toBeGreaterThan(0); // …outer ring outside it.
+            expect(ctx.arcs.map((a) => a.r)).toEqual([15.3, 16.2]);   // The pre-#4838 literals.
+            expect(ctx.arcs.map((a) => a.lineWidth)).toEqual([0.7, 0.7]);
         });
 
-        test('the rings still land where they always did at the base radius', () => {
-            window.svl.LABEL_ICON_RADIUS = 17;
-            const ctx = makeRecordingCtx();
-            Label.renderLabelIcon(ctx, 'CurbRamp', 100, 100);
-            expect(ctx.arcs.map((a) => a.r)).toEqual([15.3, 16.2]); // The pre-#4838 literals.
+        test('the rings keep the same proportions against a capped icon as against a full-size one', () => {
+            // Not the same *absolute* offsets: the ring geometry scales with the icon, so the outline reads at the
+            // same weight relative to the mark at every size. Left absolute it was ~47% heavier once capped.
+            const relative = (radius) => {
+                const ctx = renderIcon(radius);
+                const halfExtent = ctx.images[0].w / 2;
+                return {
+                    offsets: ctx.arcs.map((a) => (a.r - halfExtent) / halfExtent),
+                    weights: ctx.arcs.map((a) => a.lineWidth / halfExtent),
+                };
+            };
+            const atBase = relative(util.LABEL_ICON_BASE_RADIUS);
+            const atCapped = relative(util.labelIconRadius(1.8));
+
+            expect(atBase.offsets).toHaveLength(2);
+            expect(atCapped.offsets[0]).toBeCloseTo(atBase.offsets[0], 10);
+            expect(atCapped.offsets[1]).toBeCloseTo(atBase.offsets[1], 10);
+            expect(atCapped.weights[0]).toBeCloseTo(atBase.weights[0], 10);
+            expect(atBase.offsets[0]).toBeLessThan(0);    // Inner ring inside the icon edge…
+            expect(atBase.offsets[1]).toBeGreaterThan(0); // …outer ring outside it.
+        });
+
+        test('the ring stays a hairline on screen once the icon is capped', () => {
+            // Scaling the stroke down must not make it vanish: the logical width is multiplied by the UI scale, and
+            // again by the device pixel ratio when the canvas is rasterized (util.sizeCanvasToDisplay).
+            const capped = renderIcon(util.labelIconRadius(1.8));
+
+            expect(capped.arcs[0].lineWidth * 1.8).toBeGreaterThan(0.5);
+            expect(capped.arcs[0].lineWidth).toBeLessThan(0.7); // …but genuinely thinner than the uncapped rule.
         });
 
         test('the unrated-severity badge scales and stays pinned to the icon corner', () => {
@@ -191,13 +198,118 @@ describe('label icon sizing across the UI scale', () => {
 
             const base = render(util.LABEL_ICON_BASE_RADIUS).ellipses[0];
             const capped = render(util.labelIconRadius(1.8)).ellipses[0];
-            const k = util.labelIconRadius(1.8) / util.LABEL_ICON_BASE_RADIUS;
+            const k = util.labelIconScale(util.labelIconRadius(1.8));
 
             expect(base).toEqual({ cx: 100 - 15, cy: 100 - 10.5, rx: 8, ry: 8 }); // The pre-#4838 literals.
             // Offset from the icon centre and the badge's own size both shrink by the same factor as the icon.
             expect(100 - capped.cx).toBeCloseTo(15 * k, 10);
             expect(100 - capped.cy).toBeCloseTo(10.5 * k, 10);
             expect(capped.rx).toBeCloseTo(8 * k, 10);
+        });
+    });
+
+    /**
+     * The click target itself, as Explore actually consumes it: Label.isOn reads svl.LABEL_HIT_MARGIN (which Main.js
+     * refreshes from util.labelHitMargin whenever the UI scale changes), and Canvas.onLabel decides which label a
+     * click belongs to when more than one target covers the point.
+     */
+    describe('hit testing', () => {
+        let Label;
+        let Canvas;
+
+        /** A label pinned to (100, 100) on the canvas. */
+        function newLabel() {
+            const label = new Label({
+                labelType: 'CurbRamp',
+                severity: 1,
+                panoXY: { x: 1, y: 1 },
+                povOfLabelIfCentered: { heading: 90, pitch: -20, zoom: 1 },
+                labelLat: 47.6, labelLng: -122.3,
+            });
+            label.setHoverInfoVisibility('hidden');
+            label.render(makeRecordingCtx(), { heading: 90, pitch: -20, zoom: 1 }); // Sets currCanvasXY.
+            return label;
+        }
+
+        beforeEach(() => {
+            window.util = util;
+            util.misc = { getIconImagePaths: () => ({ iconImagePath: 'CurbRamp.svg' }),
+                labelTypeHasSeverity: () => true };
+            util.pano = { centeredPovToCanvasCoord: () => ({ x: 100, y: 100 }) };
+            window.labelIconCache = { 'CurbRamp.svg': {} };
+            window.svl = {
+                LABEL_ICON_RADIUS: util.labelIconRadius(1),
+                LABEL_HIT_MARGIN: util.labelHitMargin(1),
+                minimap: { getMap: () => null },
+            };
+            window.eval(`${LABEL_SRC}\nwindow.Label = Label;`);
+            window.eval(`${CANVAS_SRC}\nwindow.Canvas = Canvas;`);
+            Label = window.Label;
+            Canvas = window.Canvas;
+            Label.createMinimapMarker = () => ({ addListener: () => {} });
+        });
+
+        test('Label.isOn covers the whole drawn icon', () => {
+            const label = newLabel();
+            const halfIcon = util.labelIconHalfExtent(util.labelIconRadius(1)); // 15.5 at scale 1.
+
+            expect(label.isOn(100, 100)).toBe(true);
+            expect(label.isOn(100 + halfIcon - 0.1, 100)).toBe(true);
+            expect(label.isOn(100, 100 - halfIcon + 0.1)).toBe(true);
+            // The old radius / 2 + 2 rule stopped at 10.5, well inside the icon; this is the point it used to miss.
+            expect(label.isOn(100 + 12, 100 + 12)).toBe(true);
+        });
+
+        test('Label.isOn stops at the target edge', () => {
+            const label = newLabel();
+            const halfIcon = util.labelIconHalfExtent(util.labelIconRadius(1));
+
+            expect(label.isOn(100 + halfIcon + 0.1, 100)).toBe(false);
+            expect(label.isOn(100, 100 + halfIcon + 0.1)).toBe(false);
+        });
+
+        test('Label.isOn tracks svl.LABEL_HIT_MARGIN, so it follows the UI scale', () => {
+            const label = newLabel();
+
+            // Capped: the target shrinks in logical px so it holds still on screen.
+            window.svl.LABEL_HIT_MARGIN = util.labelHitMargin(1.8);         // ~10.6 logical px.
+            expect(label.isOn(100 + util.labelHitMargin(1.8) - 0.1, 100)).toBe(true);
+            expect(label.isOn(100 + util.labelHitMargin(1.8) + 0.1, 100)).toBe(false);
+
+            // Floored: at the small end the target grows in logical px to hold the WCAG minimum on screen, which is
+            // well past where the icon ends — and past anything the old radius / 2 + 2 rule ever reached.
+            window.svl.LABEL_HIT_MARGIN = util.labelHitMargin(0.65);        // ~18.5 logical px.
+            expect(label.isOn(100 + util.labelHitMargin(0.65) - 0.1, 100)).toBe(true);
+            expect(label.isOn(100 + util.labelHitMargin(0.65) + 0.1, 100)).toBe(false);
+        });
+
+        test('a deleted label is never under the cursor', () => {
+            const label = newLabel();
+            label.remove();
+
+            expect(label.isOn(100, 100)).toBe(false);
+        });
+
+        test('Canvas.onLabel picks the label drawn on top when two targets overlap', () => {
+            // Canvas.render() draws getCanvasLabels() in order, so the last one is the one the user can see. Before
+            // #4838's larger target this rarely mattered; now two icons that visually touch overlap.
+            const under = newLabel();
+            const over = newLabel();
+            window.svl.labelContainer = { getCanvasLabels: () => [under, over] };
+            // No #label-canvas in the DOM, so Canvas#init returns before it binds any listeners.
+            const canvas = new Canvas({});
+
+            expect(canvas.onLabel(100, 100)).toBe(over);
+            expect(canvas.getCurrentLabel()).toBe(over);
+        });
+
+        test('Canvas.onLabel still finds a lone label, and reports a miss', () => {
+            const label = newLabel();
+            window.svl.labelContainer = { getCanvasLabels: () => [label] };
+            const canvas = new Canvas({});
+
+            expect(canvas.onLabel(100, 100)).toBe(label);
+            expect(canvas.onLabel(400, 400)).toBe(false);
         });
     });
 });

--- a/test/js/labelIconSizing.test.js
+++ b/test/js/labelIconSizing.test.js
@@ -1,0 +1,203 @@
+/**
+ * Tests for util.labelIconRadius / util.labelHitMargin (public/js/common/utilities.js, issue #4838).
+ *
+ * Explore draws into a fixed 720x480 logical frame that is displayed at var(--ui-scale) (0.65x-1.8x). A constant
+ * icon radius therefore grew with the tool, reaching 56 on-screen px at the scale cap — well past the 38px labeling
+ * cursor the user aims with. These two helpers cap the drawn icon in *screen* px and size the click target to the
+ * icon rather than deriving it from the radius.
+ *
+ * Everything below is asserted in on-screen CSS px (logical value x scale), because that is the thing being capped;
+ * the logical values are an implementation detail that moves with the scale by design.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const UTILITIES_SRC = fs.readFileSync(
+    path.resolve(__dirname, '..', '..', 'public/js/common/utilities.js'), 'utf8'
+);
+
+/**
+ * Loads utilities.js into jsdom. It is a plain global script, but its tail constructs a Bowser parser and reads
+ * navigator/jQuery, so only the section up to that point is evaluated here.
+ */
+function loadUtil() {
+    const src = UTILITIES_SRC.slice(0, UTILITIES_SRC.indexOf('// Browser detection helpers backed by Bowser'));
+    window.util = {};
+    window.eval(src);
+    return window.util;
+}
+
+describe('label icon sizing across the UI scale', () => {
+    let util;
+
+    /** On-screen diameter in CSS px of the icon Label.renderLabelIcon draws (2 * radius - 3) at this scale. */
+    const iconScreenDiameter = (scale) => (2 * util.labelIconRadius(scale) - 3) * scale;
+
+    /** On-screen width in CSS px of the square click target Label.isOn tests (2 * margin) at this scale. */
+    const targetScreenSize = (scale) => 2 * util.labelHitMargin(scale) * scale;
+
+    beforeEach(() => {
+        util = loadUtil();
+    });
+
+    describe('util.labelIconRadius', () => {
+        test('is unchanged at scale 1', () => {
+            expect(util.labelIconRadius(1)).toBe(17);            // The value Explore used before the cap.
+            expect(iconScreenDiameter(1)).toBe(31);
+        });
+
+        test('still grows with the tool below the cap', () => {
+            expect(iconScreenDiameter(0.65)).toBeCloseTo(31 * 0.65, 5);
+            expect(iconScreenDiameter(1.2)).toBeCloseTo(31 * 1.2, 5);
+        });
+
+        test('holds at the labeling cursor size once the cap engages', () => {
+            expect(iconScreenDiameter(1.4)).toBeCloseTo(38, 5);
+            expect(iconScreenDiameter(1.8)).toBeCloseTo(38, 5);   // 1.8 is util.applyToolScale's MAX_SCALE.
+        });
+
+        test('never exceeds the cursor the user aims with, at any scale in range', () => {
+            for (let scale = 0.65; scale <= 1.8001; scale += 0.05) {
+                expect(iconScreenDiameter(scale)).toBeLessThanOrEqual(util.LABEL_ICON_MAX_SCREEN_DIAMETER + 1e-9);
+            }
+        });
+
+        test('the cap engages where the base size reaches the cursor size, and not before', () => {
+            const baseDiameter = 2 * util.LABEL_ICON_BASE_RADIUS - 3;
+            const crossover = util.LABEL_ICON_MAX_SCREEN_DIAMETER / baseDiameter; // ~1.2258
+            expect(iconScreenDiameter(crossover - 0.01)).toBeLessThan(38);
+            expect(iconScreenDiameter(crossover + 0.01)).toBeCloseTo(38, 5);
+        });
+
+        test('reads the live scale off the page when called with no argument', () => {
+            document.documentElement.style.setProperty('--ui-scale', '1.8');
+            expect(util.labelIconRadius()).toBeCloseTo(util.labelIconRadius(1.8), 10);
+        });
+    });
+
+    describe('util.labelHitMargin', () => {
+        test('covers the whole visible icon, which the old radius/2 + 2 rule did not', () => {
+            // The old rule gave a 21px target under a 31px icon at scale 1.
+            expect(targetScreenSize(1)).toBeCloseTo(iconScreenDiameter(1), 5);
+            expect(targetScreenSize(1)).toBeGreaterThan(2 * (17 / 2 + 2));
+        });
+
+        test('does not shrink when the icon cap engages', () => {
+            // The whole point of decoupling: capping the icon must not cost the user click area at large scales.
+            expect(targetScreenSize(1.8)).toBeCloseTo(38, 5);
+            expect(targetScreenSize(1.8)).toBeGreaterThan(2 * (17 / 2 + 2) * 1.8 * 0.9);
+        });
+
+        test('floors at the WCAG minimum target size when the tool scales down', () => {
+            // At 0.65x the icon is only ~20 screen px, so the floor is what keeps the label clickable.
+            expect(iconScreenDiameter(0.65)).toBeLessThan(util.LABEL_MIN_SCREEN_TARGET);
+            expect(targetScreenSize(0.65)).toBeCloseTo(util.LABEL_MIN_SCREEN_TARGET, 5);
+        });
+
+        test('is never below the WCAG minimum at any scale in range', () => {
+            for (let scale = 0.65; scale <= 1.8001; scale += 0.05) {
+                expect(targetScreenSize(scale)).toBeGreaterThanOrEqual(util.LABEL_MIN_SCREEN_TARGET - 1e-9);
+            }
+        });
+
+        test('is never smaller than the icon it belongs to, at any scale in range', () => {
+            for (let scale = 0.65; scale <= 1.8001; scale += 0.05) {
+                expect(targetScreenSize(scale)).toBeGreaterThanOrEqual(iconScreenDiameter(scale) - 1e-9);
+            }
+        });
+    });
+
+    /**
+     * The icon's decorations — its two outline rings and its unrated-severity badge — were authored as literals
+     * against a radius of 17. A capped radius left them at their old sizes, so the rings floated well outside the
+     * shrunken icon and the badge came unpinned from its corner. These pin them to the icon instead.
+     */
+    describe('icon decorations follow the radius', () => {
+        const LABEL_SRC = fs.readFileSync(
+            path.resolve(__dirname, '..', '..', 'public/js/explore/src/label/Label.js'), 'utf8'
+        );
+
+        /** Records the geometry of every drawing call so a test can compare it against the icon's own bounds. */
+        function makeRecordingCtx() {
+            return {
+                arcs: [], ellipses: [], images: [], texts: [],
+                globalAlpha: 1, lineWidth: 1, strokeStyle: '', fillStyle: '', font: '',
+                save() {}, restore() {}, beginPath() {}, closePath() {}, fill() {}, stroke() {},
+                drawImage(img, dx, dy, w, h) { this.images.push({ dx: dx, dy: dy, w: w, h: h }); },
+                arc(cx, cy, r) { this.arcs.push({ cx: cx, cy: cy, r: r }); },
+                ellipse(cx, cy, rx, ry) { this.ellipses.push({ cx: cx, cy: cy, rx: rx, ry: ry }); },
+                fillText(t, tx, ty) { this.texts.push({ t: t, x: tx, y: ty }); },
+                measureText: () => ({ width: 0 }),
+            };
+        }
+
+        let Label;
+
+        beforeEach(() => {
+            window.util = util;
+            util.misc = { getIconImagePaths: () => ({ iconImagePath: 'CurbRamp.svg' }), labelTypeHasSeverity: () => true };
+            util.pano = { centeredPovToCanvasCoord: () => ({ x: 100, y: 100 }) };
+            window.labelIconCache = { 'CurbRamp.svg': {} };
+            window.svl = { LABEL_ICON_RADIUS: 17, minimap: { getMap: () => null } };
+            window.eval(`${LABEL_SRC}\nwindow.Label = Label;`);
+            Label = window.Label;
+        });
+
+        /** Renders the icon at `radius` and returns the ring radii relative to the drawn icon's own half-extent. */
+        function ringOffsets(radius) {
+            window.svl.LABEL_ICON_RADIUS = radius;
+            const ctx = makeRecordingCtx();
+            Label.renderLabelIcon(ctx, 'CurbRamp', 100, 100);
+            const img = ctx.images[0];
+            const halfExtent = img.w / 2;                       // Drawn icon spans 2 * radius - 3.
+            return ctx.arcs.map((a) => a.r - halfExtent);
+        }
+
+        test('the rings hug the icon edge identically at the base radius and a capped one', () => {
+            const atBase = ringOffsets(util.LABEL_ICON_BASE_RADIUS);
+            const atCapped = ringOffsets(util.labelIconRadius(1.8));
+
+            expect(atBase).toHaveLength(2);
+            expect(atCapped[0]).toBeCloseTo(atBase[0], 10);
+            expect(atCapped[1]).toBeCloseTo(atBase[1], 10);
+            expect(atBase[0]).toBeLessThan(0);   // Inner ring inside the icon edge…
+            expect(atBase[1]).toBeGreaterThan(0); // …outer ring outside it.
+        });
+
+        test('the rings still land where they always did at the base radius', () => {
+            window.svl.LABEL_ICON_RADIUS = 17;
+            const ctx = makeRecordingCtx();
+            Label.renderLabelIcon(ctx, 'CurbRamp', 100, 100);
+            expect(ctx.arcs.map((a) => a.r)).toEqual([15.3, 16.2]); // The pre-#4838 literals.
+        });
+
+        test('the unrated-severity badge scales and stays pinned to the icon corner', () => {
+            const render = (radius) => {
+                window.svl.LABEL_ICON_RADIUS = radius;
+                const label = new Label({
+                    labelType: 'CurbRamp',
+                    severity: null,
+                    panoXY: { x: 1, y: 1 },
+                    povOfLabelIfCentered: { heading: 90, pitch: -20, zoom: 1 },
+                    labelLat: 47.6, labelLng: -122.3,
+                });
+                label.setHoverInfoVisibility('hidden');
+                const ctx = makeRecordingCtx();
+                label.render(ctx, { heading: 90, pitch: -20, zoom: 1 });
+                return ctx;
+            };
+            Label.createMinimapMarker = () => ({ addListener: () => {} });
+
+            const base = render(util.LABEL_ICON_BASE_RADIUS).ellipses[0];
+            const capped = render(util.labelIconRadius(1.8)).ellipses[0];
+            const k = util.labelIconRadius(1.8) / util.LABEL_ICON_BASE_RADIUS;
+
+            expect(base).toEqual({ cx: 100 - 15, cy: 100 - 10.5, rx: 8, ry: 8 }); // The pre-#4838 literals.
+            // Offset from the icon centre and the badge's own size both shrink by the same factor as the icon.
+            expect(100 - capped.cx).toBeCloseTo(15 * k, 10);
+            expect(100 - capped.cy).toBeCloseTo(10.5 * k, 10);
+            expect(capped.rx).toBeCloseTo(8 * k, 10);
+        });
+    });
+});


### PR DESCRIPTION
Resolves #4824
Resolves #4838

Two changes to how a placed label's marker is drawn on Explore's canvas. They're together because they compound: a smaller marker plus a fade means much less of the feature is hidden while you're rating it.

### #4824 — fade the marker while its dialog is open

<img width="900" height="460" alt="4824-marker-fade-before-after" src="https://github.com/user-attachments/assets/58700b86-cd2d-4e74-adbb-b3bcbf57edf0" />

The tutorial already dimmed a label's icon to 30% while that label's context menu was open (#4814/#4815). The marker sits exactly on the feature being rated, so fading it lets the user see that feature while the panel discusses it, and the dialog's tail still marks the spot. Jon asked for the same in regular Explore labeling.

- Dropped the `svl.isOnboarding()` gate in `Label.render`.
- `ContextMenu.show()`/`hide()` now re-render the canvas, so the fade toggles the moment the panel opens or closes. Production callers don't reliably render afterwards — the hover card's Edit/click path renders *before* opening the panel — and `hide()` has a dozen call sites, so the two methods that own the visibility state are the right place. `hide()` only re-renders when the panel was actually open, since it's also called speculatively on navigation and keyboard shortcuts.
- Removed the four explicit re-renders `Onboarding` needed for this in its rate-severity and add-tag steps; `show()`/`hide()` now cover the tutorial too.

### #4838 — cap the icon's on-screen size

<img width="899" height="906" alt="4838-icon-size-before-after" src="https://github.com/user-attachments/assets/3908334d-1352-4c37-acf1-c188446a7a1e" />

The icon was authored at 31 px in Explore's fixed 720×480 logical frame, and that frame is displayed at `var(--ui-scale)`, which `util.applyToolScale` clamps to 0.65×–1.8×. So the marker was a constant 4.3% of pano width and ran **20 px → 56 px** on screen. The labeling cursor, meanwhile, is a fixed 38 px bitmap that doesn't scale at all — at large sizes you aimed with a 38 px icon and placed a 56 px one.

The radius is now derived from the UI scale, capping the **drawn diameter in screen px** at the cursor's 38 px. The cap engages only above ~1.23× scale, so normal and small windows are untouched. `util.labelIconRadius` owns the rule; Explore caches it in `svl.LABEL_ICON_RADIUS` from the same path that applies the scale, since it's read once per label per canvas render and a live read would force a style recalculation each time.

Three things had to be decoupled from the radius to make it safe to move:

- **`Label.isOn` derived the click target as `radius / 2 + 2`**, which left the target *smaller than the icon under it* — 21 px against a 31 px icon at scale 1 — and would have shrunk further under the cap. It's now the drawn icon, floored at 24 on-screen px (WCAG 2.5.8 Target Size (Minimum), AA). Never smaller than today at any scale in range.
- **The outline rings and the unrated-severity badge were literals authored against a radius of 17.** Left alone, the rings floated well outside the shrunken icon and the badge came unpinned from its corner. Both now scale with the drawn icon, so the mark keeps its proportions at every size — the rings reproduce the old 15.3/16.2 and 0.7 stroke exactly at the base radius.
- **`Canvas.onLabel` returned the label drawn *underneath*.** It searched `getCanvasLabels()` forward and took the first hit, while `render()` draws that same list in order, so the last one is the one on top. The inversion predates this PR, but a click target smaller than the icon mostly masked it; now that the target *is* the icon, two icons that visually touch have overlapping targets and it becomes the ordinary case. It searches back to front now.

##### Before/After measurements

Measured in the browser on Teaneck at `--ui-scale` 1.7727, the top of the range:

| | before | after |
|---|---|---|
| icon on screen | 55.0 css px | **38.0 css px** (cursor is 38) |
| click target on screen | 37.2 css px | **38.0 css px** |
| outline ring stroke | 1.24 css px on a 55 px icon | **0.86 css px** on a 38 px icon — the same 2.3% share of the mark |
| overlapping icons | click selects the one drawn underneath | **selects the one on top** |
| marker fade with dialog open | n/a outside the tutorial | **0.319×**, back to 1.000× on close |

##### Testing instructions
1. On `/explore`, place a label. Its marker should fade to 30% while the dialog is open and return to full opacity when you close it — via Done, the X, Esc, Delete, or clicking outside.
2. Hover an existing label and click the card (or its Edit button). Same fade. Open and close several labels quickly and check for flicker.
3. Run the tutorial end to end; the rate-severity and add-tag steps should fade the same way they did before this PR.
4. Resize the window across the full range. Below ~1.23× UI scale the icon is unchanged; above it the icon holds at the size of the labeling cursor while the rest of the tool keeps growing. The outline ring should stay a crisp hairline at the top of the range, not a heavy one.
5. Click near the edge of a label icon — anywhere on the visible icon should select it.
6. Place two labels close enough that their icons overlap, then click the overlap. The label drawn on top should be the one that opens.

##### Things to check before submitting the PR
- [x] I've written a descriptive PR title.
- [x] I've added/updated comments for large or confusing blocks of code.
- [x] I've included before/after screenshots above.
- [x] I've asked for and included translations for any user facing text that was added or modified. <!-- no user-facing text -->
- [x] I've updated any logging. <!-- no new interactions; existing ContextMenu_Open/_Close are unchanged -->
- [x] I've tested on mobile (only needed for validation page). <!-- Explore only -->

##### Tests

Three suites, 28 cases:

- `test/js/exploreLabelDialogFade.test.js` (8) — the fade decision in `Label.render`: faded only for the open menu's own target, alpha restored for the rest of the render loop, severity alert faded with the icon, and pins that it no longer depends on `isOnboarding`.
- `test/js/exploreContextMenuRerender.test.js` (6) — the wiring #4824 actually turns on, driving `ContextMenu` through a stubbed UI: `show()`/`hide()` repaint, they repaint *after* the visibility flip rather than before, and `hide()` stays silent on its speculative call sites.
- `test/js/labelIconSizing.test.js` (14) — sweeps the full 0.65×–1.8× range: the icon never outgrows the cursor, the target never drops below the WCAG minimum or below the icon, the decorations track the icon, `Label.isOn` follows `svl.LABEL_HIT_MARGIN` at both ends of the range, and `Canvas.onLabel` picks the topmost label.

Every group was mutation-checked by re-introducing the pre-fix code and confirming the relevant cases fail, and only those. Full suite: 656 passing, eslint clean.

Note that Jest still isn't wired into CI, so these run only by hand (`npm run test:js`).

##### Not included

Validate's marker is `(10 * 2 + 2) × uiScale` = 22 px base / 40 px at max, so it has the same uncapped growth and the two tools disagree on base size by ~40%. Left alone here — worth its own issue rather than folding in.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-opus-5[1m])
