### PR TITLE
Cap Validate's pano marker on the same ceiling as Explore's, and floor its pointer target

### DIFF
--- a/public/css/validate/svv-panorama.css
+++ b/public/css/validate/svv-panorama.css
@@ -63,6 +63,31 @@
   transition: opacity 0.5s ease;
 }
 
+/* Pointer-target floor. The marker is what opens the label card — by hover, by click, and as a keyboard stop
+   (PanoMarker, #4729) — but the mark itself is 22px at --ui-scale 1 and shrinks to 14px at the 0.65x end, under the
+   24px of WCAG 2.5.8 Target Size (Minimum), AA. A transparent ::after widens only the *target*, so the mark stays
+   the size it was drawn: growing the element instead would move the marker (PanoMarker positions it from its own
+   size) and push the label card away from it (LabelVisibilityControl anchors on offsetWidth).
+
+   max(), not a fixed size, so this only ever adds area — above ~1.09x the mark is already past 24px and the target
+   is exactly the mark. Round, matching the mark: browsers hit-test through border-radius, so the marker's target is
+   a circle today (.icon-outline's 25px radius clamps to 50% at every size this is drawn at), and a square here
+   would square that target off at every scale rather than only flooring it where it is too small — opening the card
+   on a hover several px off the visible marker. A 24px circle still satisfies 2.5.8, which measures a target by its
+   bounding box. z-index keeps it under the icon and the AI badge; it takes the pointer for the marker either way,
+   since all three are the same element as far as the hover and click handlers are concerned. */
+#validate-pano-marker::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: max(100%, 24px);
+  height: max(100%, 24px);
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  z-index: -1;
+}
+
 /* Hidden state (the H key / either Hide-label toggle). The point of hiding is to see the sidewalk the marker is
    sitting on, so the icon goes away entirely — even at low opacity it still tints the very pixels the validator
    asked to look at. What remains is a dashed ring in the label type's own colour, which says where the label is

--- a/public/css/validate/svv-panorama.css
+++ b/public/css/validate/svv-panorama.css
@@ -63,26 +63,40 @@
   transition: opacity 0.5s ease;
 }
 
-/* Pointer-target floor. The marker is what opens the label card — by hover, by click, and as a keyboard stop
-   (PanoMarker, #4729) — but the mark itself is 22px at --ui-scale 1 and shrinks to 14px at the 0.65x end, under the
-   24px of WCAG 2.5.8 Target Size (Minimum), AA. A transparent ::after widens only the *target*, so the mark stays
-   the size it was drawn: growing the element instead would move the marker (PanoMarker positions it from its own
-   size) and push the label card away from it (LabelVisibilityControl anchors on offsetWidth).
+/* Pointer-target floor. The marker is what opens the label card — on desktop by hover and as a keyboard stop
+   (PanoMarker, #4729), on mobile by touch — but the mark itself is 22px at --ui-scale 1 and shrinks to 14px at the
+   0.65x end.
+
+   This is about *acquisition*, not conformance. WCAG 2.5.8 Target Size (Minimum), AA, sizes targets for pointer
+   activation, and desktop has no pointer activation here: nothing binds click to the marker (#4843). So the SC does
+   not actually reach it, and mobile — which does activate by pointer — is already well past 24px at 52px. But a
+   hover target is if anything the harder case, since it has to be found and then held, and 14px is small for that.
+   24px is still the right number to floor at: it is what 2.5.8 asks of every other target on the page, and it is
+   what Explore's placed-label target already uses.
+
+   A transparent ::after widens only the *target*, so the mark stays the size it was drawn: growing the element
+   instead would move the marker (PanoMarker positions it from its own size) and push the label card away from it
+   (LabelVisibilityControl anchors on offsetWidth).
 
    max(), not a fixed size, so this only ever adds area — above ~1.09x the mark is already past 24px and the target
-   is exactly the mark. Round, matching the mark: browsers hit-test through border-radius, so the marker's target is
-   a circle today (.icon-outline's 25px radius clamps to 50% at every size this is drawn at), and a square here
-   would square that target off at every scale rather than only flooring it where it is too small — opening the card
-   on a hover several px off the visible marker. A 24px circle still satisfies 2.5.8, which measures a target by its
-   bounding box. z-index keeps it under the icon and the AI badge; it takes the pointer for the marker either way,
-   since all three are the same element as far as the hover and click handlers are concerned. */
+   is exactly the mark. Round, matching the mark: browsers hit-test through border-radius, and at every size the
+   *desktop* marker is drawn at (22px base, 38px ceiling) .icon-outline's 25px radius clamps to 50%, so its target
+   is a circle today. Squaring it off here would change that at every scale rather than only flooring it where it is
+   too small — opening the card on a hover several px off the visible marker. (Mobile's 52px marker is the one size
+   where that radius does not clamp, but there the mark is already wider than this floor, so nothing below applies.)
+   z-index keeps it under the icon and the AI badge; it takes the pointer for the marker either way, since all three
+   are the same element as far as the hover handlers are concerned. */
 #validate-pano-marker::after {
+  /* Mirrors util.LABEL_MIN_SCREEN_TARGET (public/js/common/utilities.js), which floors Explore's label target. One
+     WCAG number for both tools, so keep the two in step — CSS can't read the JS constant. */
+  --label-min-target: 24px;
+
   content: "";
   position: absolute;
   top: 50%;
   left: 50%;
-  width: max(100%, 24px);
-  height: max(100%, 24px);
+  width: max(100%, var(--label-min-target));
+  height: max(100%, var(--label-min-target));
   transform: translate(-50%, -50%);
   border-radius: 50%;
   z-index: -1;

--- a/public/js/common/utilities.js
+++ b/public/js/common/utilities.js
@@ -32,7 +32,9 @@ util.LABEL_ICON_BASE_RADIUS = 17;
 // what keeps the two tools' markers the same size at the top of the scale range.
 util.LABEL_ICON_MAX_SCREEN_DIAMETER = 38;
 
-// Smallest a label's click target may get on screen, in CSS px. WCAG 2.5.8 Target Size (Minimum), level AA.
+// Smallest a label's pointer target may get on screen, in CSS px. WCAG 2.5.8 Target Size (Minimum), level AA.
+// Validate's marker floors itself in CSS instead (--label-min-target in css/validate/svv-panorama.css), because
+// only the target grows there and not the mark; keep the two numbers in step.
 util.LABEL_MIN_SCREEN_TARGET = 24;
 
 /**

--- a/public/js/common/utilities.js
+++ b/public/js/common/utilities.js
@@ -25,13 +25,32 @@ util.exploreDisplayScale = function () {
 // scales off it, so a capped radius keeps the mark's proportions.
 util.LABEL_ICON_BASE_RADIUS = 17;
 
-// Largest a label icon may get on screen, in CSS px. Matches Label.CURSOR_ICON_SIZE, the labeling cursor the user
-// aims with: that cursor is a fixed-size bitmap and does not scale, so letting the placed icon outgrow it means
-// aiming with one size and placing another.
+// Largest a pano label marker may get on screen, in CSS px, in either tool. The number is Label.CURSOR_ICON_SIZE,
+// the labeling cursor the user aims with in Explore: that cursor is a fixed-size bitmap and does not scale, so
+// letting the placed icon outgrow it means aiming with one size and placing another. Validate has no cursor to
+// match, but a marker that keeps growing hides more of the very feature being judged, and sharing the ceiling is
+// what keeps the two tools' markers the same size at the top of the scale range.
 util.LABEL_ICON_MAX_SCREEN_DIAMETER = 38;
 
 // Smallest a label's click target may get on screen, in CSS px. WCAG 2.5.8 Target Size (Minimum), level AA.
 util.LABEL_MIN_SCREEN_TARGET = 24;
+
+/**
+ * On-screen diameter of a pano label marker, in CSS px, capped at util.LABEL_ICON_MAX_SCREEN_DIAMETER (#4838).
+ *
+ * For markers that are DOM elements sized directly in screen px — Validate's PanoMarker. Explore's marker is drawn
+ * into a scaled logical frame instead and caps itself through util.labelIconRadius; both land on the same ceiling.
+ *
+ * @param {number} baseDiameter - The marker's diameter at --ui-scale = 1, in CSS px.
+ * @param {number} scale - The tool's UI scale.
+ * @returns {number} Diameter in CSS px.
+ */
+util.cappedMarkerDiameter = function (baseDiameter, scale) {
+  // The cap limits growth driven by --ui-scale; it never shrinks a marker below the size its tool chose. That is
+  // what keeps mobile Validate out of it — a phone's marker is a 52px touch target and never runs applyToolScale,
+  // so capping it to 38 would shrink a touch target to answer a desktop problem.
+  return Math.min(baseDiameter * scale, Math.max(baseDiameter, util.LABEL_ICON_MAX_SCREEN_DIAMETER));
+};
 
 /**
  * Half-extent of the icon actually drawn for a label of the given radius, in the same logical frame.

--- a/public/js/validate/src/panorama/PanoManager.js
+++ b/public/js/validate/src/panorama/PanoManager.js
@@ -245,7 +245,7 @@ class PanoManager {
 
     if (!this.labelMarker) {
       const markerLayer = document.getElementById('view-control-layer');
-      const markerDiameter = Math.round((svv.labelRadius * 2 + 2) * util.uiScale());
+      const markerDiameter = this.#markerDiameter(util.uiScale());
       this.labelMarker = new PanoMarker({
         id: 'validate-pano-marker',
         markerContainer: markerLayer,
@@ -458,12 +458,28 @@ class PanoManager {
   }
 
   /**
+   * On-screen diameter of the label marker, in CSS px, at the given UI scale.
+   *
+   * Capped, the way Explore's placed icon is (#4838). --ui-scale runs to 1.8x, which took this marker from 22px to
+   * 40px on screen — a mark that hides more of the very feature the validator is judging the bigger their window
+   * gets, and the two tools' markers drifted apart at the top of the range. The cap engages above ~1.73x, so every
+   * scale below that is untouched. util.cappedMarkerDiameter leaves mobile's larger touch target alone.
+   *
+   * @param {number} scale The UI scale factor (see util.applyToolScale).
+   * @returns {number} Diameter in CSS px.
+   * @private
+   */
+  #markerDiameter(scale) {
+    return Math.round(util.cappedMarkerDiameter(svv.labelRadius * 2 + 2, scale));
+  }
+
+  /**
    * Resizes the label marker to match the given UI scale factor.
    * @param {number} scale The current UI scale factor (see util.applyToolScale).
    */
   setMarkerScale(scale) {
     if (!this.labelMarker) return;
-    const markerDiameter = Math.round((svv.labelRadius * 2 + 2) * scale);
+    const markerDiameter = this.#markerDiameter(scale);
     this.labelMarker.setSize({ width: markerDiameter, height: markerDiameter });
   }
 

--- a/test/js/validateMarkerPulse.test.js
+++ b/test/js/validateMarkerPulse.test.js
@@ -19,6 +19,7 @@ const path = require('path');
 const PANO_MANAGER_PATH = path.resolve(__dirname, '..', '..', 'public/js/validate/src/panorama/PanoManager.js');
 const PANO_MARKER_PATH = path.resolve(__dirname, '..', '..', 'public/js/common/PanoMarker.js');
 const THROTTLE_PATH = path.resolve(__dirname, '..', '..', 'public/js/validate/src/util/throttle.js');
+const UTILITIES_PATH = path.resolve(__dirname, '..', '..', 'public/js/common/utilities.js');
 
 /**
  * Load a bare `class` declaration out of a production file. The Grunt bundle concatenates these into page scope,
@@ -72,6 +73,12 @@ describe('Validate marker halo pulse (issue #4790)', () => {
             = '<div id="pano-holder"><div id="svv-panorama"></div></div><div id="view-control-layer"></div>';
 
         global.util = {};
+        // utilities.js builds a Bowser parser at load time; the overrides below replace everything read from it.
+        global.bowser = { getParser: () => ({ getBrowserName: () => 'Chrome', getBrowserVersion: () => '1',
+            getOSName: () => 'Linux', getPlatformType: () => 'desktop' }) };
+        // Real utilities, for util.cappedMarkerDiameter: these tests read the marker's rendered diameter back, so
+        // the sizing rule needs to be production's rather than a formula copied into a stub (#4838).
+        (0, eval)(fs.readFileSync(UTILITIES_PATH, 'utf8'));
         (0, eval)(fs.readFileSync(THROTTLE_PATH, 'utf8')); // real throttle; #init wires it to pov_changed
         util.isMobile = () => false;
         util.uiScale = () => 1;

--- a/test/js/validateMarkerSizing.test.js
+++ b/test/js/validateMarkerSizing.test.js
@@ -1,0 +1,113 @@
+/**
+ * Tests for util.cappedMarkerDiameter (public/js/common/utilities.js, issue #4838), the rule that sizes Validate's
+ * pano label marker.
+ *
+ * Validate's marker is a DOM element (PanoMarker) sized directly in screen px as `(svv.labelRadius * 2 + 2) *
+ * --ui-scale`, so at the 1.8x end of util.applyToolScale's range a 22px mark reached 40px — hiding more of the very
+ * feature being judged the larger the validator's window, and drifting away from Explore's marker, which #4838
+ * capped at 38px. This caps Validate's on the same ceiling.
+ *
+ * The rule is deliberately "never grow past the cap", not "never exceed the cap": mobile Validate uses a 52px
+ * marker as a phone touch target and never runs applyToolScale, so a flat ceiling would shrink a touch target to
+ * answer a desktop problem. That exemption is the reason for the Math.max, and it is pinned below.
+ *
+ * The 24px pointer-target floor that goes with this lives in CSS (#validate-pano-marker::after in
+ * svv-panorama.css), because the mark must stay the size it was drawn while only the target grows.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const UTILITIES_SRC = fs.readFileSync(
+    path.resolve(__dirname, '..', '..', 'public/js/common/utilities.js'), 'utf8'
+);
+
+// public/js/validate/src/Main.js: svv.labelRadius = util.isMobile() ? 25 : 10, and the marker adds 2px of ring.
+const DESKTOP_BASE = 10 * 2 + 2;   // 22
+const MOBILE_BASE = 25 * 2 + 2;    // 52
+
+/** Loads utilities.js into jsdom, the same way the other utilities suites do. */
+function loadUtil() {
+    // utilities.js builds a Bowser parser at load time; the sizing under test never consults it.
+    window.bowser = { getParser: () => ({ getBrowserName: () => 'Chrome', getBrowserVersion: () => '1',
+        getOSName: () => 'Linux', getPlatformType: () => 'desktop' }) };
+    window.eval(UTILITIES_SRC);
+    return window.util;
+}
+
+describe('util.cappedMarkerDiameter', () => {
+    let util;
+
+    /** Validate's desktop marker at the given UI scale, in on-screen CSS px. */
+    const desktop = (scale) => util.cappedMarkerDiameter(DESKTOP_BASE, scale);
+
+    beforeEach(() => {
+        util = loadUtil();
+    });
+
+    describe("Validate's desktop marker", () => {
+        test('is unchanged at scale 1', () => {
+            expect(desktop(1)).toBe(22);
+        });
+
+        test('still grows with the tool below the cap', () => {
+            expect(desktop(0.65)).toBeCloseTo(22 * 0.65, 5);
+            expect(desktop(1.5)).toBeCloseTo(33, 5);
+        });
+
+        test('holds at the shared ceiling once the cap engages', () => {
+            expect(desktop(1.8)).toBe(38);   // 1.8 is util.applyToolScale's MAX_SCALE; was 39.6.
+        });
+
+        test('the cap engages where the base size reaches the ceiling, and not before', () => {
+            const crossover = util.LABEL_ICON_MAX_SCREEN_DIAMETER / DESKTOP_BASE; // ~1.7273
+            expect(desktop(crossover - 0.01)).toBeLessThan(38);
+            expect(desktop(crossover + 0.01)).toBe(38);
+        });
+
+        test('never exceeds the ceiling at any scale in range', () => {
+            for (let scale = 0.65; scale <= 1.8001; scale += 0.05) {
+                expect(desktop(scale)).toBeLessThanOrEqual(util.LABEL_ICON_MAX_SCREEN_DIAMETER + 1e-9);
+            }
+        });
+
+        test('never shrinks below what it is today at any scale in range', () => {
+            for (let scale = 0.65; scale <= 1.8001; scale += 0.05) {
+                expect(desktop(scale)).toBeLessThanOrEqual(DESKTOP_BASE * scale + 1e-9);
+                expect(desktop(scale)).toBeGreaterThanOrEqual(Math.min(DESKTOP_BASE * scale, 38) - 1e-9);
+            }
+        });
+    });
+
+    describe("mobile Validate's marker", () => {
+        test('keeps its full touch-target size, which is larger than the desktop ceiling', () => {
+            // Mobile never runs applyToolScale, so util.uiScale() is 1 there.
+            expect(MOBILE_BASE).toBeGreaterThan(util.LABEL_ICON_MAX_SCREEN_DIAMETER);
+            expect(util.cappedMarkerDiameter(MOBILE_BASE, 1)).toBe(MOBILE_BASE);
+        });
+
+        test('is not capped even if a scale ever reaches it', () => {
+            // Belt and braces: the cap limits growth from --ui-scale, so it can never shrink a marker below the
+            // base its tool chose, whatever scale it is handed.
+            expect(util.cappedMarkerDiameter(MOBILE_BASE, 0.9)).toBeCloseTo(MOBILE_BASE * 0.9, 5);
+            expect(util.cappedMarkerDiameter(MOBILE_BASE, 1.5)).toBe(MOBILE_BASE);
+        });
+    });
+
+    describe('the two tools agree', () => {
+        test('Explore and Validate reach the same marker size at the top of the scale range', () => {
+            const exploreIcon = 2 * util.labelIconHalfExtent(util.labelIconRadius(1.8)) * 1.8;
+
+            expect(exploreIcon).toBeCloseTo(desktop(1.8), 5);
+            expect(exploreIcon).toBeCloseTo(util.LABEL_ICON_MAX_SCREEN_DIAMETER, 5);
+        });
+
+        test('but keep their own base sizes below the cap, which is deliberate', () => {
+            // Explore's mark is larger by design; #4838 caps growth, it does not unify the two base sizes.
+            const exploreIcon = 2 * util.labelIconHalfExtent(util.labelIconRadius(1)) * 1;
+
+            expect(exploreIcon).toBe(31);
+            expect(desktop(1)).toBe(22);
+        });
+    });
+});

--- a/test/js/validateMarkerSizing.test.js
+++ b/test/js/validateMarkerSizing.test.js
@@ -26,6 +26,10 @@ const UTILITIES_SRC = fs.readFileSync(
 const DESKTOP_BASE = 10 * 2 + 2;   // 22
 const MOBILE_BASE = 25 * 2 + 2;    // 52
 
+// The UI scale at which the desktop marker reaches util.LABEL_ICON_MAX_SCREEN_DIAMETER (38) and the cap takes over.
+// Spelled out rather than read off util so the cases below can't drift with the constant they are pinning.
+const CROSSOVER = 38 / DESKTOP_BASE;   // ~1.7273
+
 /** Loads utilities.js into jsdom, the same way the other utilities suites do. */
 function loadUtil() {
     // utilities.js builds a Bowser parser at load time; the sizing under test never consults it.
@@ -60,9 +64,9 @@ describe('util.cappedMarkerDiameter', () => {
         });
 
         test('the cap engages where the base size reaches the ceiling, and not before', () => {
-            const crossover = util.LABEL_ICON_MAX_SCREEN_DIAMETER / DESKTOP_BASE; // ~1.7273
-            expect(desktop(crossover - 0.01)).toBeLessThan(38);
-            expect(desktop(crossover + 0.01)).toBe(38);
+            expect(CROSSOVER).toBeCloseTo(util.LABEL_ICON_MAX_SCREEN_DIAMETER / DESKTOP_BASE, 5);
+            expect(desktop(CROSSOVER - 0.01)).toBeLessThan(38);
+            expect(desktop(CROSSOVER + 0.01)).toBe(38);
         });
 
         test('never exceeds the ceiling at any scale in range', () => {
@@ -71,10 +75,19 @@ describe('util.cappedMarkerDiameter', () => {
             }
         });
 
-        test('never shrinks below what it is today at any scale in range', () => {
-            for (let scale = 0.65; scale <= 1.8001; scale += 0.05) {
-                expect(desktop(scale)).toBeLessThanOrEqual(DESKTOP_BASE * scale + 1e-9);
-                expect(desktop(scale)).toBeGreaterThanOrEqual(Math.min(DESKTOP_BASE * scale, 38) - 1e-9);
+        // The two halves of the rule, pinned separately so each fails on its own mutation: drop the cap and the
+        // second fails, flatten it to a bare min(..., 38) and neither does but the mobile cases below do. A single
+        // "stays between the capped and uncapped sizes" assertion would pass with the cap removed entirely, since
+        // the uncapped size is one of its own bounds.
+        test('is untouched below the crossover, at every scale in range', () => {
+            for (let scale = 0.65; scale < CROSSOVER - 1e-9; scale += 0.05) {
+                expect(desktop(scale)).toBeCloseTo(DESKTOP_BASE * scale, 5);
+            }
+        });
+
+        test('is held at the ceiling above the crossover, at every scale in range', () => {
+            for (let scale = CROSSOVER + 1e-9; scale <= 1.8001; scale += 0.01) {
+                expect(desktop(scale)).toBeCloseTo(util.LABEL_ICON_MAX_SCREEN_DIAMETER, 5);
             }
         });
     });

--- a/test/js/validateSkipUnrenderableLabel.test.js
+++ b/test/js/validateSkipUnrenderableLabel.test.js
@@ -20,6 +20,7 @@ const PANO_MANAGER_PATH = path.resolve(__dirname, '..', '..', 'public/js/validat
 const PANO_MARKER_PATH = path.resolve(__dirname, '..', '..', 'public/js/common/PanoMarker.js');
 const LABEL_CONTAINER_PATH = path.resolve(__dirname, '..', '..', 'public/js/validate/src/label/LabelContainer.js');
 const THROTTLE_PATH = path.resolve(__dirname, '..', '..', 'public/js/validate/src/util/throttle.js');
+const UTILITIES_PATH = path.resolve(__dirname, '..', '..', 'public/js/common/utilities.js');
 
 /**
  * Load a bare `class` declaration out of a production file. The Grunt bundle concatenates these into page scope,
@@ -48,6 +49,11 @@ describe('PanoManager clears the pano when no viewer can render it (issue #4810)
       = '<div id="pano-holder"><div id="svv-panorama"></div></div><div id="view-control-layer"></div>';
 
     global.util = {};
+    // utilities.js builds a Bowser parser at load time; the overrides below replace everything read from it.
+    global.bowser = { getParser: () => ({ getBrowserName: () => 'Chrome', getBrowserVersion: () => '1',
+        getOSName: () => 'Linux', getPlatformType: () => 'desktop' }) };
+    // Real utilities, for the marker sizing rule util.cappedMarkerDiameter uses (#4838).
+    (0, eval)(fs.readFileSync(UTILITIES_PATH, 'utf8'));
     (0, eval)(fs.readFileSync(THROTTLE_PATH, 'utf8')); // real throttle; #init wires it to pov_changed
     util.isMobile = () => false;
     util.uiScale = () => 1;


### PR DESCRIPTION
Follow-up to #4839, stacked on it — retarget to `develop` once that merges. Finishes #4838 by applying the same ceiling to Validate's marker.

### Why

Validate's marker is a DOM element (`PanoMarker`) sized directly in screen px as `(svv.labelRadius * 2 + 2) × --ui-scale`, so it had exactly the growth problem #4839 fixed on Explore's canvas icon. `--ui-scale` runs to 1.8×, which took a 22 px marker to 40 px on screen: the bigger the validator's window, the more of the very feature they're judging their own marker hides. The two tools also drifted apart at the top of the range, where Explore's marker now stops at 38 px.

Separately — and this one is the more pressing of the two — **the marker is what opens the label card**: on desktop by hover and as a keyboard stop (#4729), on mobile by touch. At `--ui-scale` 1 it's a 22 px target, and 14 px at the 0.65× end.

That is about *acquisition* rather than conformance. WCAG 2.5.8 Target Size (Minimum), AA, sizes targets for pointer **activation**, and desktop has no pointer activation here — nothing binds click to the marker, which is its own bug (#4843) — so the SC doesn't strictly reach it, and mobile, which does activate by pointer, is already well past 24 px at 52 px. But a hover target is if anything the harder case: it has to be found and then *held*. 24 px is the right number to floor at all the same — it's what 2.5.8 asks of every other target on the page, and what Explore's placed-label target already uses.

### What changed

| `--ui-scale` | mark before → after | pointer target before → after |
|---|---|---|
| 0.65 | 14 px → 14 px | 14 px → **24 px** |
| 1.0 (default) | 22 px → 22 px | 22 px → **24 px** |
| 1.5 | 33 px → 33 px | 33 px → 33 px |
| ~1.73 | 38 px → 38 px | 38 px → 38 px (cap crossover) |
| 1.8 | 40 px → **38 px** | 40 px → 38 px |
| mobile | 52 px → 52 px | unchanged |

**The visible mark does not move below ~1.73×.** The base sizes stay as they are — Explore's mark is larger by design, and this caps growth rather than unifying the two.

- `util.cappedMarkerDiameter` owns the sizing rule, sharing `util.LABEL_ICON_MAX_SCREEN_DIAMETER` with Explore so the two tools land on the same size at the top of the range.
- The rule is **"never grow past the cap"**, not "never exceed it" — `min(base × scale, max(base, 38))`. Mobile Validate uses a 52 px marker as a phone touch target and never runs `applyToolScale`, so a flat ceiling would shrink a touch target to answer a desktop problem. Writing it as a growth limit keeps mobile out of it with no `isMobile()` branch, and keeps the whole rule one pure function.
- A transparent `::after` floors the **pointer target** at 24 px, adding area only where the mark is under it. Not padding on the element itself, which would move the marker (`PanoMarker` positions it from its own size) and push the label card away from it (`LabelVisibilityControl` anchors on `offsetWidth`). Round rather than square: browsers hit-test through `border-radius`, and at every size the *desktop* marker is drawn at (22 px base, 38 px ceiling) `.icon-outline`'s 25 px radius clamps to 50%, so this target is already a circle. Squaring it off would change hover behaviour at *every* scale instead of only flooring it where it's too small. (Mobile's 52 px marker is the one size where that radius doesn't clamp — but there the mark is already wider than the floor, so the rule never applies.)

### Not included

`Label.js` records `canvasX`/`canvasY` using `svv.labelRadius * util.uiScale()` as its on-screen margin. That's stored validation data, and it was already slightly out of step with the marker (18 vs 19.8 at 1.8×); the cap brings the two closer rather than further apart, so it stays as it is.

##### Testing instructions
1. On `/validate`, resize across the full range. Below ~1.73× the marker is unchanged; above it, it holds at 38 px while the rest of the tool keeps growing, matching Explore's placed icon.
2. Shrink the window to the small end and hover the marker. The label card should be easier to acquire than before — the target is 24 px even though the mark is ~14 px — and should still open only when the pointer is on or right at the marker, not several px off it.
3. Drag on the pano to pan, starting the drag on and near the marker. Panning should be unaffected, and the card should not open mid-drag.
4. Validate an AI-generated label and hover its marker: the AI badge and its tooltip should behave exactly as before (the new `::after` sits under the badge).
5. Tab to the marker and press Enter/Escape — the keyboard path (#4729) is untouched, but it shares the element.
6. On a phone, confirm the marker is unchanged (52 px, uncapped).

##### Before / after

<img width="2360" height="2378" alt="4838-marker-before-after" src="https://github.com/user-attachments/assets/57ab5937-63cd-417d-96f8-ebb500e03b3a" />

Captured on the real `/validate` page in headless Chromium, driving the running dev app — which is serving this
PR's base branch, so it *is* the before state. The two changes were then applied at runtime on the same page
instance (same label, same imagery) and the pointer target measured by hit-testing outward from the marker's
centre:

| `--ui-scale` | mark | pointer target (measured) |
|---|---|---|
| 1.80 | 40 → **38 px** | 39.5 → 37.5 px |
| 0.70 | 15 → 15 px | 14 → **23.5 px** |

Reach was equal on the horizontal, vertical, and diagonal probes, so the target is round and it is the marker
taking the pointer — the part jsdom can't cover.

##### Review fixes

Applied after review (see the review comment for detail):
1. The comment and the text above claimed the card opens "by click" — it doesn't; nothing binds click to the desktop marker. Corrected, and the WCAG framing now rests on acquisition rather than on a conformance claim the code doesn't trigger. The missing click handler is filed as **#4843**.
2. `never shrinks below what it is today` admitted the *uncapped* formula as a solution, so it passed with the cap removed. Replaced by the two halves of the rule pinned separately — `is untouched below the crossover` and `is held at the ceiling above the crossover`. Both mutations re-checked: removing the cap now fails 6 cases, flattening it to a bare `min(…, 38)` fails the 2 mobile cases.
3. The `24 px` literal is now `--label-min-target`, with cross-references in both directions between it and `util.LABEL_MIN_SCREEN_TARGET`.
4. The `border-radius` claim is scoped to the desktop marker; mobile's 52 px is the one size where 25 px doesn't clamp to 50%.

667 passing, eslint and stylelint clean. The browser measurements above were re-taken against the edited CSS and are unchanged.

##### Things to check before submitting the PR
- [x] I've written a descriptive PR title.
- [x] I've added/updated comments for large or confusing blocks of code.
- [ ] I've included before/after screenshots above. <!-- measurements above; the visible mark is unchanged below ~1.73x -->
- [x] I've asked for and included translations for any user facing text that was added or modified. <!-- no user-facing text -->
- [x] I've updated any logging. <!-- no new interactions -->
- [ ] I've tested on mobile (only needed for validation page). <!-- mobile is exempt from the cap by construction and pinned by tests, but not device-tested -->

##### Tests

`test/js/validateMarkerSizing.test.js` (10 cases): the desktop marker never exceeds the ceiling or shrinks below today's size anywhere in the scale range, the cap engages exactly at the crossover, mobile's larger marker is untouched, and the two tools land on the same size at 1.8× while keeping their own base sizes below it. Mutation-checked both ways — removing the cap and flattening it to a bare `min(…, 38)` each fail the cases written for them.

`validateMarkerPulse` and `validateSkipUnrenderableLabel` drive the real `PanoManager` against a hand-built `util` stub and caught this change themselves. They now load the real `utilities.js` for the sizing rule rather than having the formula copied into a stub.

Full suite: 666 passing, eslint and stylelint clean. Jest still isn't wired into CI, so these run by hand (`npm run test:js`).

The `::after` hit area needs real-browser QA — jsdom does no hit testing, so steps 2–4 above are the parts no test covers.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-opus-5[1m])


