### PR TITLE
Load the landing page's heavy below-fold content deferred but eager (#4486)

### DIFF
--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -311,58 +311,71 @@
     </div>
 
 
-    <script src='@assets.path("js/homepage.js")'></script>
-    <script src='@assets.path("vendor/mapbox-gl/mapbox-gl-3.21.0.js")'></script>
-    <script src='@assets.path("vendor/mapbox-gl/mapbox-gl-language-1.0.1.js")'></script>
-    <link href='@assets.path("vendor/mapbox-gl/mapbox-gl-3.21.0.css")' rel="stylesheet">
-    <script src='@assets.path("vendor/turf/turf-7.3.4.min.js")'></script>
-    <script src='@assets.path("vendor/i18next/i18next-23.16.8.min.js")'></script>
-    <script src='@assets.path("vendor/i18next-http-backend/i18nextHttpBackend-3.0.4.min.js")'></script>
+    @* Deferred: every reference below sits inside an appManager.ready callback, which runs off $(document).ready and so lands after all deferred scripts. i18next and its http backend are NOT re-included here — common/main.scala.html already loads both, deferred, on every page (#4486). *@
+    <script src='@assets.path("js/homepage.js")' defer></script>
+    <script src='@assets.path("js/common/utilitiesSidewalk.js")' defer></script>
+    <script src='@assets.path("js/common/share/ShareWidget.js")' defer></script>
+    <script src='@assets.path("js/LandingValidationGrid.js")' defer></script>
     <link href='@assets.path("css/choropleth.css")' rel="stylesheet">
     <link href='@assets.path("css/deployment-map.css")' rel="stylesheet">
     <link href='@assets.path("css/landing-validation-grid.css")' rel="stylesheet">
-    @* The grid cards' share chip + popover (.label-detail__share-*) are styled by css/common/share-widget.css,
-       which common/main.scala.html links on every page — nothing else here needs label-detail.css. *@
-    <script src='@assets.path("js/ps-map/build/ps-map.js")'></script>
-    <script src='@assets.path("js/common/utilitiesSidewalk.js")'></script>
-    <script src='@assets.path("js/common/share/ShareWidget.js")'></script>
-    <script src='@assets.path("js/LandingValidationGrid.js")'></script>
+    @* The grid cards' share chip + popover (.label-detail__share-*) are styled by css/common/share-widget.css, which common/main.scala.html links on every page — nothing else here needs label-detail.css. *@
 
     <script>
-      // Gets all translations before loading the maps.
+      // The map stack (mapbox-gl + mapbox-gl-language + turf + ps-map) is ~600KB gz — roughly 75% of this page's JS —
+      // for two maps that both sit well below the fold, so it's kept out of the page's load path entirely but pulled
+      // in on the visitor's first interaction (#4486) so it's loaded by the time a user scrolls to the map.
+      util.onFirstInteractionOrIdle(function () {
+        const mapboxCss = document.createElement('link');
+        mapboxCss.rel = 'stylesheet';
+        mapboxCss.href = '@assets.path("vendor/mapbox-gl/mapbox-gl-3.21.0.css")';
+        document.head.appendChild(mapboxCss);
+
+        util.loadScriptsInOrder([
+          '@assets.path("vendor/mapbox-gl/mapbox-gl-3.21.0.js")',
+          '@assets.path("vendor/mapbox-gl/mapbox-gl-language-1.0.1.js")',
+          '@assets.path("vendor/turf/turf-7.3.4.min.js")',
+          '@assets.path("js/ps-map/build/ps-map.js")'
+        ]).then(function () {
+          // createPSMap reads translated strings, so it still waits on the app's i18next setup.
+          window.appManager.ready(function () {
+            // Create the choropleth map.
+            const choroplethParams = {
+              mapName: 'landing-choropleth',
+              mapStyle: 'mapbox://styles/mapbox/light-v11?optimize=true',
+              mapboxApiKey: '@commonData.mapboxApiKey',
+              mapboxLogoLocation: 'bottom-right',
+              scrollWheelZoom: false,
+              neighborhoodsURL: '/neighborhoods',
+              completionRatesURL: '/neighborhoods/completionRate',
+              neighborhoodFillMode: 'completionRate',
+              neighborhoodTooltip: 'completionRate'
+            };
+            createPSMap($, choroplethParams).then(m => {
+              window.choropleth = m[0];
+            });
+
+            // Create the deployment cities map.
+            const deploymentMapParams = {
+              mapName: 'deployment-map',
+              mapStyle: 'mapbox://styles/mapbox/light-v11?optimize=true',
+              mapboxApiKey: '@commonData.mapboxApiKey',
+              mapboxLogoLocation: 'bottom-left',
+              scrollWheelZoom: false,
+              loadCities: true,
+              logClicks: true
+            };
+            createPSMap($, deploymentMapParams).then(m => {
+              window.deploymentMap = m[0];
+            });
+          });
+        }).catch(e => console.error('Failed to load the landing page maps', e));
+      });
+
+      // Gets all translations before setting up the grid, which reads translated strings as it builds each card. The
+      // grid renders its skeletons immediately to reserve layout, then fills itself once the page is idle.
       window.appManager.ready(function () {
-        // Set up the validation grid of recently-found labels. It lazy-loads once scrolled near.
         new LandingValidationGrid(document.getElementById('landing-validation-container'));
-
-        // Create the choropleth map.
-        const choroplethParams = {
-          mapName: 'landing-choropleth',
-          mapStyle: 'mapbox://styles/mapbox/light-v11?optimize=true',
-          mapboxApiKey: '@commonData.mapboxApiKey',
-          mapboxLogoLocation: 'bottom-right',
-          scrollWheelZoom: false,
-          neighborhoodsURL: '/neighborhoods',
-          completionRatesURL: '/neighborhoods/completionRate',
-          neighborhoodFillMode: 'completionRate',
-          neighborhoodTooltip: 'completionRate'
-        };
-        createPSMap($, choroplethParams).then(m => {
-          window.choropleth = m[0];
-        });
-
-        // Create the deployment cities map.
-        const deploymentMapParams = {
-          mapName: 'deployment-map',
-          mapStyle: 'mapbox://styles/mapbox/light-v11?optimize=true',
-          mapboxApiKey: '@commonData.mapboxApiKey',
-          mapboxLogoLocation: 'bottom-left',
-          scrollWheelZoom: false,
-          loadCities: true,
-          logClicks: true
-        };
-        createPSMap($, deploymentMapParams).then(m => {
-          window.deploymentMap = m[0];
-        });
       });
     </script>
   </div>

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -112,7 +112,8 @@
             <source src='@assets.path("videos/segment-1-1.mp4")' type="video/mp4">
           </video>
           @* vid2/vid3 start hidden and only play once their tab is clicked (homepage.js switchToVideo calls play()),
-             so they don't autoplay and preload="none" keeps them from downloading on page load. *@
+             so they don't autoplay and preload="none" keeps them out of the page's load path. homepage.js
+             warmHiddenInstructionVideos downloads them shortly after load, so the tab switch is instant. *@
           <video id="vid2" width="800" playsinline muted loop preload="none" poster='@assets.path("images/segment-2.jpg")' class="visible-desktop ps-hidden">
             <source src='@assets.path("videos/segment-2.mp4")' type="video/mp4">
           </video>
@@ -373,7 +374,7 @@
       });
 
       // Gets all translations before setting up the grid, which reads translated strings as it builds each card. The
-      // grid renders its skeletons immediately to reserve layout, then fills itself once the page is idle.
+      // grid renders its skeletons immediately to reserve layout, then fills itself on the first interaction.
       window.appManager.ready(function () {
         new LandingValidationGrid(document.getElementById('landing-validation-container'));
       });

--- a/public/js/LandingValidationGrid.js
+++ b/public/js/LandingValidationGrid.js
@@ -8,7 +8,7 @@
  * server-side. Validated cards are swapped for a fresh label from a prefetched pool, giving the "live" feel.
  *
  * Label data comes from POST /label/labels with sort: 'recent', i.e. a shuffled pool of the newest labels needing
- * validation. Nothing is fetched during page load; the grid fills itself once the page is loaded and idle.
+ * validation. Nothing is fetched during page load; the grid fills itself once the visitor interacts with the page.
  */
 class LandingValidationGrid {
   static #GRID_SIZE = 6;
@@ -47,11 +47,6 @@ class LandingValidationGrid {
       this.#grid.appendChild(skeleton);
     }
 
-    // Off the page's load path, but not gated on scrolling near (#4486). Waiting for the section to approach the
-    // viewport meant the label query and its imagery checks were still in flight as the grid came into view, so it
-    // sat on skeletons for a beat. Gating on first interaction instead has the cards ready long before a visitor
-    // scrolls this far, while still keeping the query off every crawler and link-preview fetch — it isn't cheap
-    // (a query per label type, plus an imagery check per candidate lacking a local crop).
     // Don't hit the server (label queries + imagery checks) until first page interaction, keeping simple crawlers from
     // hitting expensive queries frequently.
     util.onFirstInteractionOrIdle(() => this.#start());
@@ -141,10 +136,13 @@ class LandingValidationGrid {
     imgWrap.className = 'lvg-card-img';
     const img = document.createElement('img');
     img.className = 'lvg-card-photo';
-    // Eager for the slots actually on screen at this width, so a card is never blank when the visitor scrolls to it
-    // — browser lazy-loading holds the fetch until the image nears the viewport, which would undo the idle preload
-    // above. Cards the CSS hides at narrow widths stay lazy so a phone never pays for an image it can't show.
-    img.loading = index < LandingValidationGrid.#visibleCardCount() ? 'eager' : 'lazy';
+    // Eager only for a crop-backed card in a slot this width actually shows, so the grid isn't blank on arrival:
+    // browser lazy-loading holds the fetch until the image nears the viewport, which would undo the early start.
+    // Crops are served from our own disk, so warming one costs bandwidth and nothing else. An API-backed card stays
+    // lazy however visible it is — gsvImageUrl is the Street View Static API, billed per request, and this now runs
+    // for every engaged visitor rather than only the ones who scroll two-thirds down the page.
+    const freeToWarm = entry.cropUrl && !util.saveDataEnabled();
+    img.loading = freeToWarm && index < LandingValidationGrid.#visibleCardCount() ? 'eager' : 'lazy';
     img.alt = i18next.t(`common:${typeKebab}`);
     img.addEventListener('error', () => {
       // The saved crop can 404 (signed URLs expire after a while); fall back to the GSV Static API image. A card

--- a/public/js/LandingValidationGrid.js
+++ b/public/js/LandingValidationGrid.js
@@ -8,10 +8,13 @@
  * server-side. Validated cards are swapped for a fresh label from a prefetched pool, giving the "live" feel.
  *
  * Label data comes from POST /label/labels with sort: 'recent', i.e. a shuffled pool of the newest labels needing
- * validation. Nothing is fetched until the section is scrolled near (IntersectionObserver).
+ * validation. Nothing is fetched during page load; the grid fills itself once the page is loaded and idle.
  */
 class LandingValidationGrid {
   static #GRID_SIZE = 6;
+  // Cards past the third are hidden by CSS below 650px — keep in sync with the nth-child(n+4) rule in
+  // css/landing-validation-grid.css. Purely a layout breakpoint, so there's no backend value to source it from.
+  static #NARROW_VISIBLE_CARDS = 3;
   // The server splits n across the 6 label types validatable from a static image (static_imagery_only — Signal
   // needs a pan up its pole, so it's excluded server-side), so fetch sizes are multiples of 6: 2 per type up
   // front (6 rendered + the rest pooled for replacements), 1 per type on refills.
@@ -44,22 +47,22 @@ class LandingValidationGrid {
       this.#grid.appendChild(skeleton);
     }
 
-    // Don't hit the server (label queries + imagery checks) until the visitor actually scrolls near the section.
-    const observer = new IntersectionObserver((entries) => {
-      if (entries.some((entry) => entry.isIntersecting)) {
-        observer.disconnect();
-        this.#start();
-      }
-    }, { rootMargin: '300px' });
-    observer.observe(sectionEl);
+    // Off the page's load path, but not gated on scrolling near (#4486). Waiting for the section to approach the
+    // viewport meant the label query and its imagery checks were still in flight as the grid came into view, so it
+    // sat on skeletons for a beat. Gating on first interaction instead has the cards ready long before a visitor
+    // scrolls this far, while still keeping the query off every crawler and link-preview fetch — it isn't cheap
+    // (a query per label type, plus an imagery check per candidate lacking a local crop).
+    // Don't hit the server (label queries + imagery checks) until first page interaction, keeping simple crawlers from
+    // hitting expensive queries frequently.
+    util.onFirstInteractionOrIdle(() => this.#start());
   }
 
   /** Fetches the initial batch and swaps the skeletons for real cards (or hides the section if there are none). */
   async #start() {
     await this.#loadBatch(LandingValidationGrid.#INITIAL_FETCH);
-    this.#grid.querySelectorAll('.lvg-card-skeleton').forEach((skeleton) => {
+    this.#grid.querySelectorAll('.lvg-card-skeleton').forEach((skeleton, index) => {
       const entry = this.#pool.shift();
-      if (entry) skeleton.replaceWith(this.#buildCard(entry));
+      if (entry) skeleton.replaceWith(this.#buildCard(entry, index));
       else skeleton.remove();
     });
 
@@ -69,6 +72,16 @@ class LandingValidationGrid {
       this.#firstLoadLogged = true;
       window.logWebpageActivity(`View_module=LandingValidationGrid_labelCount=${count}`);
     }
+  }
+
+  /**
+   * How many grid slots the CSS actually shows at the current viewport width.
+   * @returns {number}
+   */
+  static #visibleCardCount() {
+    return window.matchMedia('(width <= 650px)').matches
+      ? LandingValidationGrid.#NARROW_VISIBLE_CARDS
+      : LandingValidationGrid.#GRID_SIZE;
   }
 
   /**
@@ -113,9 +126,10 @@ class LandingValidationGrid {
    * Builds one card: the label image with the label-type icon marked at its canvas position, the localized
    * "Is this a …?" question, and the three validation buttons.
    * @param {Object} entry - One {label, cropUrl, gsvImageUrl} entry from /label/labels.
+   * @param {number} index - The card's slot in the grid, which decides whether its image loads eagerly.
    * @returns {HTMLElement}
    */
-  #buildCard(entry) {
+  #buildCard(entry, index) {
     const label = entry.label;
     const typeKebab = util.camelToKebab(label.label_type);
     const card = document.createElement('figure');
@@ -127,8 +141,10 @@ class LandingValidationGrid {
     imgWrap.className = 'lvg-card-img';
     const img = document.createElement('img');
     img.className = 'lvg-card-photo';
-    // Lazy so the cards CSS hides at narrow widths (the 4th+) never fetch their images.
-    img.loading = 'lazy';
+    // Eager for the slots actually on screen at this width, so a card is never blank when the visitor scrolls to it
+    // — browser lazy-loading holds the fetch until the image nears the viewport, which would undo the idle preload
+    // above. Cards the CSS hides at narrow widths stay lazy so a phone never pays for an image it can't show.
+    img.loading = index < LandingValidationGrid.#visibleCardCount() ? 'eager' : 'lazy';
     img.alt = i18next.t(`common:${typeKebab}`);
     img.addEventListener('error', () => {
       // The saved crop can 404 (signed URLs expire after a while); fall back to the GSV Static API image. A card
@@ -369,9 +385,10 @@ class LandingValidationGrid {
       if (this.#pool.length === 0) await refill;
     }
     const hadFocus = card.contains(document.activeElement);
+    const index = [...this.#grid.children].indexOf(card);
     const entry = this.#pool.shift();
     if (entry) {
-      const fresh = this.#buildCard(entry);
+      const fresh = this.#buildCard(entry, index);
       card.replaceWith(fresh);
       if (hadFocus) fresh.querySelector('.lvg-btn')?.focus();
     } else {

--- a/public/js/common/utilities.js
+++ b/public/js/common/utilities.js
@@ -336,13 +336,13 @@ util.hasSession = hasSession;
  * on top of this.
  *
  * @param {Function} fn - The work to run. Called once.
- * @param {number} [timeout=2000] - Idle deadline in ms. Past it the browser runs the callback anyway (as a normal
- *   task, with didTimeout set), so a busy main thread can delay the work but never starve it.
  */
-function afterLoadIdle(fn, timeout = 2000) {
+function afterLoadIdle(fn) {
   const schedule = () => {
-    // requestIdleCallback is unavailable before Safari 17.4; a short timeout approximates it well enough here.
-    if (window.requestIdleCallback) window.requestIdleCallback(fn, { timeout });
+    // Past the deadline the browser runs the callback anyway (as a normal task, with didTimeout set), so a busy main
+    // thread can delay the work but never starve it. requestIdleCallback is unavailable before Safari 17.4, where a
+    // short timeout approximates it well enough.
+    if (window.requestIdleCallback) window.requestIdleCallback(fn, { timeout: 2000 });
     else setTimeout(fn, 200);
   };
   if (document.readyState === 'complete') schedule();
@@ -355,12 +355,23 @@ util.afterLoadIdle = afterLoadIdle;
 // twitch — which is the point: the gate has to clear long before the visitor could scroll to the deferred content.
 const INTERACTION_EVENTS = ['pointermove', 'pointerdown', 'scroll', 'keydown', 'touchstart', 'wheel'];
 
+// Latched at module level, not per caller: an interaction that happened before a caller registered still counts. The
+// callers here register at very different times (parse time vs. inside an appManager.ready callback, i.e. after
+// i18next's fetches resolve), and a single early mouse twitch has to satisfy all of them.
+const firstInteraction = new Promise((resolve) => {
+  for (const type of INTERACTION_EVENTS) window.addEventListener(type, () => resolve(), { once: true, passive: true });
+});
+
 /**
- * Runs fn at the visitor's first sign of engagement, falling back to util.afterLoadIdle plus a delay if none comes.
+ * Runs fn at the visitor's first sign of engagement, falling back to a delay after load-idle if none comes.
  *
- * For deferred work that costs the *server* — a query, an API call — where afterLoadIdle alone would spend that cost
- * on every crawler, link-preview prefetch, and drive-by load. An input event is a cheap, near-perfect filter for
- * those, and it still fires far sooner than a human could reach anything below the fold.
+ * For deferred work that costs the *server* — a query, an API call — where util.afterLoadIdle alone would spend that
+ * cost on every crawler, link-preview prefetch, and drive-by load. An input event is a cheap, near-perfect filter for
+ * those, and it still clears far sooner than a human could reach anything below the fold.
+ *
+ * An interaction only cancels the wait for the fallback; it never jumps the load queue. The work always goes through
+ * afterLoadIdle, because a mouse twitch at 400ms is the common case, not the rare one, and starting a 600KB download
+ * then would put this back on the critical path — the opposite of the point.
  *
  * The fallback is deliberately slow, and its delay is nearly invisible in practice: deferred content sits below the
  * fold, so actually looking at it requires a scroll, which trips the interaction path first. It exists only so a
@@ -374,11 +385,9 @@ function onFirstInteractionOrIdle(fn, fallbackMs = 5000) {
   const run = () => {
     if (fired) return;
     fired = true;
-    // once:true retires the listener that fired; the rest have to be taken down by hand.
-    for (const type of INTERACTION_EVENTS) window.removeEventListener(type, run);
-    fn();
+    afterLoadIdle(fn);
   };
-  for (const type of INTERACTION_EVENTS) window.addEventListener(type, run, { once: true, passive: true });
+  firstInteraction.then(run);
   afterLoadIdle(() => setTimeout(run, fallbackMs));
 }
 

--- a/public/js/common/utilities.js
+++ b/public/js/common/utilities.js
@@ -323,6 +323,100 @@ function hasSession() {
 
 util.hasSession = hasSession;
 
+/**
+ * Runs fn once the page has finished loading and the main thread next goes idle.
+ *
+ * The "deferred but eager" pattern for below-the-fold work (#4486). Keeping something off the critical path and
+ * deciding when it starts loading are separate choices: gating on an IntersectionObserver or a click answers both at
+ * once, which is right for work a visitor probably won't reach, but leaves them watching a blank space for anything
+ * they usually do reach. Waiting for `load` keeps the work out of the critical path; running it at idle rather than
+ * on an interaction means it has long since finished by the time the visitor arrives.
+ *
+ * When the work also costs the server something, prefer util.onFirstInteractionOrIdle, which adds an engagement gate
+ * on top of this.
+ *
+ * @param {Function} fn - The work to run. Called once.
+ * @param {number} [timeout=2000] - Idle deadline in ms. Past it the browser runs the callback anyway (as a normal
+ *   task, with didTimeout set), so a busy main thread can delay the work but never starve it.
+ */
+function afterLoadIdle(fn, timeout = 2000) {
+  const schedule = () => {
+    // requestIdleCallback is unavailable before Safari 17.4; a short timeout approximates it well enough here.
+    if (window.requestIdleCallback) window.requestIdleCallback(fn, { timeout });
+    else setTimeout(fn, 200);
+  };
+  if (document.readyState === 'complete') schedule();
+  else window.addEventListener('load', schedule, { once: true });
+}
+
+util.afterLoadIdle = afterLoadIdle;
+
+// Any of these means a human is present. pointermove is the earliest of them by a wide margin — a single mouse
+// twitch — which is the point: the gate has to clear long before the visitor could scroll to the deferred content.
+const INTERACTION_EVENTS = ['pointermove', 'pointerdown', 'scroll', 'keydown', 'touchstart', 'wheel'];
+
+/**
+ * Runs fn at the visitor's first sign of engagement, falling back to util.afterLoadIdle plus a delay if none comes.
+ *
+ * For deferred work that costs the *server* — a query, an API call — where afterLoadIdle alone would spend that cost
+ * on every crawler, link-preview prefetch, and drive-by load. An input event is a cheap, near-perfect filter for
+ * those, and it still fires far sooner than a human could reach anything below the fold.
+ *
+ * The fallback is deliberately slow, and its delay is nearly invisible in practice: deferred content sits below the
+ * fold, so actually looking at it requires a scroll, which trips the interaction path first. It exists only so a
+ * visitor who somehow generates no input events still ends up with a working page.
+ *
+ * @param {Function} fn - The work to run. Called once, whichever path gets there first.
+ * @param {number} [fallbackMs=5000] - How long after load-idle to give up waiting for an interaction.
+ */
+function onFirstInteractionOrIdle(fn, fallbackMs = 5000) {
+  let fired = false;
+  const run = () => {
+    if (fired) return;
+    fired = true;
+    // once:true retires the listener that fired; the rest have to be taken down by hand.
+    for (const type of INTERACTION_EVENTS) window.removeEventListener(type, run);
+    fn();
+  };
+  for (const type of INTERACTION_EVENTS) window.addEventListener(type, run, { once: true, passive: true });
+  afterLoadIdle(() => setTimeout(run, fallbackMs));
+}
+
+util.onFirstInteractionOrIdle = onFirstInteractionOrIdle;
+
+/**
+ * Injects scripts that fetch in parallel but execute in insertion order.
+ *
+ * Dynamically created scripts default to async, so a dependent bundle can run before its dependencies exist. Setting
+ * `async = false` restores ordered execution without serializing the downloads — what `defer` does for scripts that
+ * were in the markup at parse time. Pair with util.afterLoadIdle to pull a heavy, below-the-fold bundle in after load.
+ *
+ * @param {string[]} srcs - Script URLs, in the order they must execute.
+ * @returns {Promise} Resolves once all of them have run; rejects on the first that fails to load.
+ */
+function loadScriptsInOrder(srcs) {
+  return Promise.all(srcs.map((src) => new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.src = src;
+    script.async = false;
+    script.onload = resolve;
+    script.onerror = () => reject(new Error(`failed to load ${src}`));
+    document.head.appendChild(script);
+  })));
+}
+
+util.loadScriptsInOrder = loadScriptsInOrder;
+
+/**
+ * Whether the visitor asked the browser to conserve data, in which case optional prefetching should be skipped.
+ * @returns {boolean} True only if Save-Data is explicitly on; unsupported browsers report false.
+ */
+function saveDataEnabled() {
+  return navigator.connection?.saveData === true;
+}
+
+util.saveDataEnabled = saveDataEnabled;
+
 // Sums an array's numbers (a helper, not an Array.prototype extension, to avoid polluting native prototypes).
 util.array = util.array || {};
 util.array.sum = (arr) => arr.reduce((a, b) => a + b, 0);

--- a/public/js/homepage.js
+++ b/public/js/homepage.js
@@ -216,7 +216,25 @@ window.appManager.ready(() => {
   // Auto advance instruction videos.
   switchToVideo(DEFAULT_VIDEO);
   setInterval(autoAdvanceLaptopVideos, TICK_SIZE);
+
+  warmHiddenInstructionVideos();
 });
+
+/**
+ * Downloads the two initially-hidden how-it-works videos once the page is loaded and idle (#4486).
+ */
+function warmHiddenInstructionVideos() {
+  if (util.saveDataEnabled()) return;
+  util.afterLoadIdle(() => {
+    for (const video of [document.getElementById('vid2'), document.getElementById('vid3')]) {
+      if (!video) continue;
+      video.preload = 'auto';
+      // Changing the attribute doesn't re-run resource selection on its own; load() does. Safe here because these
+      // two are paused and unstarted until their tab is picked.
+      video.load();
+    }
+  });
+}
 
 const pausedVideos = {};
 

--- a/public/js/homepage.js
+++ b/public/js/homepage.js
@@ -227,10 +227,13 @@ function warmHiddenInstructionVideos() {
   if (util.saveDataEnabled()) return;
   util.afterLoadIdle(() => {
     for (const video of [document.getElementById('vid2'), document.getElementById('vid3')]) {
-      if (!video) continue;
+      // Only warm a video nothing has touched. load() aborts playback and resets currentTime, and by the time this
+      // runs either of these may be playing: lazyPlay starts every video in the section on scroll, hidden ones
+      // included, and auto-advance switches to vid2 about 9s in. Restarting isn't automatic either — lazyPlay still
+      // believes it's playing — so the visitor would be left watching a frozen frame.
+      if (!video || !video.paused || video.currentTime > 0) continue;
       video.preload = 'auto';
-      // Changing the attribute doesn't re-run resource selection on its own; load() does. Safe here because these
-      // two are paused and unstarted until their tab is picked.
+      // Changing the attribute doesn't re-run resource selection on its own; load() does.
       video.load();
     }
   });

--- a/test/e2e/pages.spec.js
+++ b/test/e2e/pages.spec.js
@@ -39,6 +39,11 @@ for (const p of PAGES) {
     const response = await page.goto(p.path);
     expect(response.status(), `${p.path} responded ${response.status()}`).toBeLessThan(400);
     await waitForAppReady(page);
+    // The landing page defers its maps and validation grid behind util.onFirstInteractionOrIdle (#4486). Headless
+    // Chromium generates no input events, so without a nudge they'd only start on the 5s fallback — after the settle
+    // window below, silently costing this spec its coverage of map init rather than failing it.
+    await page.mouse.move(10, 10);
+    if (p.path === '/') await page.waitForFunction(() => window.choropleth && window.deploymentMap);
     if (p.loadingOverlay) await page.locator('#page-loading').waitFor({state: 'hidden'});
     // Settle window: init errors from late async work (post-ready fetches, map callbacks) land here.
     await page.waitForTimeout(1000);


### PR DESCRIPTION
Addresses items 1 and 3 of #4486, plus a slice of item 2. **Deliberately not "resolves"** — items 4, 5, 6, 7 and the bulk of item 2 are untouched, so the issue should stay open.

## The problem with how #4482 did this

Keeping work off the critical path and deciding *when* it starts loading are separate choices. Gating on an `IntersectionObserver` or a click answers both at once. That's right for work a visitor probably won't reach — but it's wrong for the validation grid a fold and a half down, and for tabs 2/3 of a 3-tab widget, which nearly everyone who engages will hit. There we traded a load-time cost for an arrival-time cost, which is more visible, not less: the grid sat on skeletons as it scrolled into view, and the 2nd/3rd how-it-works videos flashed empty on first click.

The pattern here is **deferred but eager**: off the critical path, started as soon as the page is loaded and the visitor shows any sign of being human.

## New utilities (`public/js/common/utilities.js`)

- **`util.afterLoadIdle(fn)`** — waits for `load`, then `requestIdleCallback` (`setTimeout` fallback for Safari < 17.4, 2s deadline). For deferred work that costs only bandwidth.
- **`util.onFirstInteractionOrIdle(fn)`** — fires on the first `pointermove` / `pointerdown` / `scroll` / `keydown` / `touchstart` / `wheel`, with `afterLoadIdle` + 5s as a fallback. For deferred work that also costs the *server*, where `afterLoadIdle` alone would spend that cost on every crawler and link-preview prefetch. `pointermove` fires on a single mouse twitch, so it clears far sooner than anyone could scroll below the fold.
- **`util.loadScriptsInOrder(srcs)`** — injects scripts with `async = false`: parallel fetch, ordered execution.
- **`util.saveDataEnabled()`** — so optional prefetching can back off.

## Changes

**Map stack (item 1).** `mapbox-gl` + `mapbox-gl-language` + `turf` + `ps-map` — ~600KB gz, roughly 75% of this page's JS, for two maps well below the fold — leave the markup entirely and load on first interaction, with `createPSMap` inside the resulting `appManager.ready`. Not intersection-gated: parsing mapbox, spinning up WebGL, and fetching tiles plus region data take long enough that proximity triggering would show a blank map for a beat.

**Validation grid.** Two gates were behind the blank cards, and fixing only the first would not have fixed the symptom:
1. The `IntersectionObserver` (`rootMargin: '300px'`) held back the `/label/labels` POST — now on first interaction. Skeletons still render synchronously, so layout is reserved exactly as before.
2. `img.loading = 'lazy'` held the image fetches back *even with data already in hand*. Now only the slots CSS hides below 650px (`nth-child(n+4)`) stay lazy.

**Videos.** `vid2`/`vid3` keep `preload="none"` in the markup and warm to `preload="auto"` at idle. They're 293KB and 231KB, so a tab switch becomes instant for the cost of a background fetch. Skipped under Save-Data.

**Item 3 + a slice of item 2.** Duplicate i18next includes dropped (`common/main.scala.html` already loads both deferred on every page), and `defer` added to the four remaining first-party scripts. Safe because every reference in the inline block sits inside an `appManager.ready` callback, which runs off `$(document).ready` and therefore after all deferred scripts. This is *not* the full item-2 pass — the `<head>` scripts in `main.scala.html` (jQuery, Bootstrap, moment, …) are untouched, and that's still the part that needs the most care.

## Notes for review

- **The interaction gate is not absolute.** A crawler that lingers past load + idle + 5s still trips the fallback. It filters drive-bys, not determined crawlers. The fallback has to exist or a visitor generating no input events would sit on skeletons forever — and its delay is nearly invisible in practice, since *seeing* the grid requires a scroll, which trips the interaction path first.
- **The maps are gated the same way** despite having no server cost, so a crawler doesn't pull 600KB of mapbox either, and there's one trigger across the page. Easy to split if you'd rather they stay on plain idle.
- **The grid's per-request cost is #3004's**, not this PR's — the imagery check runs an uncached Street View metadata call plus a DB write per candidate lacking a local crop (`LabelService.checkImageryBatch` → `PanoDataService.gsvPanoExists`), and #3004 skips it for recently-checked labels.
- If profiling later shows mapbox's parse janking the main thread, the fallback is a two-phase split: `<link rel="preload" as="script">` at idle, then execute + init on intersection with a generous `rootMargin`.

## Testing

- Landing page renders 200; rendered HTML confirms no eager map-stack tags, i18next appearing once, and `defer` on the four landing scripts.
- `make eslint` — 0 errors (the 5 remaining `max-len` warnings are pre-existing in `HealthPage.js` / `MyRoutes.js`).
- `make htmlhint` — clean.
- **Not run: the `test/e2e` smoke suite** — needs a host-side Playwright install. Worth running before merge, and note the `/` spec may need adjusting: it waits on `appManager.isReady` plus a 1s settle window, and headless Chromium generates no input events, so map init now lands on the 5s fallback and falls outside that window. A synthetic `pointermove`, or waiting on `window.choropleth`, would keep it covering map init.

Manual check (no GSV involved, so this is all visually verifiable): load the page, wait a few seconds without scrolling, then scroll to the grid and the maps — all should be ready on arrival. Then click through the how-it-works tabs; 2 and 3 should play without a flash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
