### PR TITLE
Prepare the v11.8.0 release and migrate the release runbook from the wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ guide: **[`docs/dev-environment.md`](docs/dev-environment.md)**.
 | [`docs/dev-environment.md`](docs/dev-environment.md) | Set up and run the app locally. |
 | [`docs/editor-setup.md`](docs/editor-setup.md) | Configure IntelliJ IDEA or VS Code for the project. |
 | [`docs/architecture.md`](docs/architecture.md) | How the backend, frontend, and data fit together. |
+| [`docs/deployment-and-stages.md`](docs/deployment-and-stages.md) | Hosted stages, how code reaches each one, and the release runbook. |
 | [`CONTRIBUTING.md`](CONTRIBUTING.md) | Branch/PR workflow, coding standards, i18n. |
 | [`docs/style-guide.md`](docs/style-guide.md) | Detailed code-style conventions (JS, Scala, HTML/CSS). |
 | [`docs/internationalization.md`](docs/internationalization.md) | How translations work + adding a new language. |
@@ -73,14 +74,15 @@ guide: **[`docs/dev-environment.md`](docs/dev-environment.md)**.
 ### Where documentation lives
 
 **Developer documentation lives in this repository** — versioned with the code, reviewed in pull requests, and
-searchable by tooling (and AI assistants). The
-[**wiki**](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki) holds **operational runbooks** (e.g. deploying to
-a live server), **city-deployment and GIS data preparation**, and **visual tutorials** — content that changes
-independently of the code or is maintained by non-developers.
+searchable by tooling (and AI assistants). That includes how code ships: cutting a release and the deployment stages
+are in [`docs/deployment-and-stages.md`](docs/deployment-and-stages.md). The
+[**wiki**](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki) holds **city-deployment and GIS data preparation**
+(building a new city's database, road geometries, revealing and hiding regions), and other **operational how-tos and
+visual tutorials** — content that changes independently of the code or is maintained by non-developers.
 
-Rule of thumb: *if it describes the code or how to contribute, it's in the repo; if it's a runbook for operating a
-server or onboarding a new city's data, it's in the wiki.* We keep one source of truth per topic and cross-link rather
-than duplicate.
+Rule of thumb: *if it describes the code, how to contribute, or how the code gets deployed, it's in the repo; if it's
+about preparing a new city's data or operating a running deployment's content, it's in the wiki.* We keep one source of
+truth per topic and cross-link rather than duplicate.
 
 ## AI in Project Sidewalk
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import com.typesafe.sbt.packager.MappingsHelper.directory
 
 name := """sidewalk-webpage"""
 
-version := "11.7.0"
+version := "11.8.0"
 
 scalaVersion := "2.13.18"
 

--- a/conf/evolutions/default/351.sql
+++ b/conf/evolutions/default/351.sql
@@ -1,5 +1,7 @@
 # --- !Ups
-INSERT INTO version VALUES ('11.8.0', now(), 'Redesigns RouteBuilder, the Explore minimap, and the label card; adds a native About page, Free Exploration, a map filter sidebar, and an across-city leaderboard.');
+-- Keep this description free of semicolons. Play's evolutions parser splits statements on every one it finds, even
+-- inside a string literal, and the resulting fragment fails to apply with "unterminated string literal".
+INSERT INTO version VALUES ('11.8.0', now(), 'Redesigns RouteBuilder, the Explore minimap, and the label card. Adds a native About page, Free Exploration, a map filter sidebar, and an across-city leaderboard.');
 
 # --- !Downs
 DELETE FROM version WHERE version_id = '11.8.0';

--- a/conf/evolutions/default/351.sql
+++ b/conf/evolutions/default/351.sql
@@ -1,0 +1,5 @@
+# --- !Ups
+INSERT INTO version VALUES ('11.8.0', now(), 'Redesigns RouteBuilder, the Explore minimap, and the label card; adds a native About page, Free Exploration, a map filter sidebar, and an across-city leaderboard.');
+
+# --- !Downs
+DELETE FROM version WHERE version_id = '11.8.0';

--- a/db/scripts/lint-evolutions.sh
+++ b/db/scripts/lint-evolutions.sh
@@ -8,7 +8,11 @@
 #      its leading `--` (which stayed with the previous chunk) and gets executed as SQL, failing with a syntax error at
 #      apply time (this broke evolution 325; see #4335 / #4351). Reword the comment to drop the `;`. A `;` at the very
 #      end of a comment line is harmless (it just splits between statements at a comment boundary) and is not flagged.
-#   2. Missing `# --- !Ups` / `# --- !Downs` markers. Play needs both section headers; a missing one silently yields an
+#   2. A semicolon *inside a single-quoted string literal* -- the same split, one layer deeper. Play cuts the statement
+#      mid-string, so the chunk it hands Postgres ends with an unterminated quote and fails with SQLSTATE 42601. The
+#      usual source is prose: a `version` row description or a comment column that reads naturally with a `;`. Reword
+#      to drop it. (Dollar-quoted bodies would need separate handling, but no evolution uses them.)
+#   3. Missing `# --- !Ups` / `# --- !Downs` markers. Play needs both section headers; a missing one silently yields an
 #      empty Up or Down.
 #
 # Exit code: 0 if clean, 1 if any problem is found.
@@ -37,7 +41,43 @@ for sql_file in "$EVOLUTIONS_DIR"/*.sql; do
         problems=1
     done < <(grep -nE -- '--.*;[[:space:]]*[^[:space:]]' "$sql_file" || true)
 
-    # Check 2: both section markers must be present.
+    # Check 2: a `;` inside a single-quoted string. Scan character by character rather than with a regex, because
+    # whether a given `;` is quoted depends on every quote before it. String and block-comment state both carry across
+    # lines, since either may span them. A doubled '' is an escaped quote that stays in the string. Prose apostrophes
+    # inside comments are why comments must be skipped rather than merely ignored: `/* ... we don't ... */` holds an
+    # odd number of quotes and would otherwise open a string that never closes (242.sql).
+    while IFS= read -r match; do
+        echo "ERROR ($(basename "$sql_file")): semicolon inside a string literal -- Play splits on it and hands"
+        echo "       Postgres an unterminated string. Reword to drop the ';'."
+        echo "       $match"
+        problems=1
+    done < <(awk '
+        BEGIN { q = sprintf("%c", 39); in_str = 0; in_block = 0 }
+        {
+            reported = 0
+            n = length($0)
+            for (i = 1; i <= n; i++) {
+                c = substr($0, i, 1)
+                if (in_block) {
+                    if (c == "*" && substr($0, i + 1, 1) == "/") { in_block = 0; i++ }
+                } else if (in_str) {
+                    if (c == q) {
+                        if (substr($0, i + 1, 1) == q) { i++; continue }
+                        in_str = 0
+                    } else if (c == ";" && !reported) {
+                        print FNR ":" $0
+                        reported = 1
+                    }
+                } else {
+                    if (c == "-" && substr($0, i + 1, 1) == "-") break
+                    if (c == "/" && substr($0, i + 1, 1) == "*") { in_block = 1; i++; continue }
+                    if (c == q) in_str = 1
+                }
+            }
+        }
+    ' "$sql_file")
+
+    # Check 3: both section markers must be present.
     if ! grep -qE '^#[[:space:]]*---[[:space:]]*!Ups' "$sql_file"; then
         echo "ERROR ($(basename "$sql_file")): missing '# --- !Ups' marker."
         problems=1

--- a/docs/deployment-and-stages.md
+++ b/docs/deployment-and-stages.md
@@ -99,9 +99,17 @@ INSERT INTO version VALUES ('X.Y.Z', now(), 'One-line, user-facing summary of th
 DELETE FROM version WHERE version_id = 'X.Y.Z';
 ```
 
-Take the **next free number**, and check for collisions with in-flight PRs rather than trusting the highest file on
-`develop` — several open PRs commonly hold the same next number, and the release evolution should not be the one that
-has to renumber. `make lint-evolutions` runs the static checks CI enforces.
+Take **exactly one higher than the highest-numbered file on `develop`**. Do not skip a number to dodge one an open PR
+already claims: whichever PR merges second renumbers, and a collision is cheap to fix while a gap is not. In practice
+the question rarely comes up here, since a release is cut once `develop` has settled.
+
+**Why a gap is the dangerous mistake.** Play pairs the applied rows in `play_evolutions` against the evolution files
+*positionally*, highest revision first, and takes the first pair whose hashes differ as the point where the database
+diverged. An evolution that lands later in a skipped slot shifts every pair below it by one, so nothing matches and
+Play concludes the whole history diverged: it emits a `Down` for every applied evolution and re-applies all of them.
+We set `autoApplyDowns=true` (`conf/application.conf`), so it does that on startup without asking.
+
+`make lint-evolutions` runs the static checks CI enforces.
 
 ### 5. Open the prep PR into `develop`
 

--- a/docs/deployment-and-stages.md
+++ b/docs/deployment-and-stages.md
@@ -53,38 +53,142 @@ Practical implications for contributors:
 ## Cutting a release (runbook)
 
 Production is deployed by **creating a GitHub Release with a `vX.Y.Z` tag on `master`** — per the table above, only a
-semver tag deploys to prod. A release is more than the tag, though. Do these steps **in order**:
+semver tag deploys to prod. A release is more than the tag, though: the version the site *displays* comes from the
+database, and code reaches `master` only by way of `develop`.
 
-1. **Bump the app version** — edit `version := "X.Y.Z"` in [`build.sbt`](../build.sbt) (patch bump for a hotfix, e.g.
-   `11.6.0` → `11.6.1`).
-2. **Add a version-table evolution** — create the next-numbered `conf/evolutions/default/NNN.sql` that records the
-   release in the `version` table. This row is what the site footer / `commonData.versionId` displays (the app shows
-   the row with the latest `version_start_time`, so `now()` is correct and no manual date is needed):
-   ```sql
-   # --- !Ups
-   INSERT INTO version VALUES ('X.Y.Z', now(), 'One-line, user-facing summary of the release.');
+Releases are cut by a maintainer (**@jonfroehlich**, **@misaugstad**). Start from a `develop` that is green in CI, and
+remember that everything already merged there ships with this release — `develop` *is* the release contents. Do the
+steps below in order.
 
-   # --- !Downs
-   DELETE FROM version WHERE version_id = 'X.Y.Z';
-   ```
-3. **Land it on `develop` first** (PR) — merging to `develop` redeploys the **test** stage; verify there.
-4. **Merge `develop` → `master`** (PR).
-5. **Create the GitHub Release** with tag `vX.Y.Z` targeting `master`. That tag/release triggers the **prod** build and
-   the rolling per-city restart. Match the existing tag format exactly (`v11.6.0`, `v11.5.1`, …).
-6. **Verify prod** — the build isn't instant and city instances come up one-by-one. Confirm the *new code* is live, not
-   just that the server responds. Until an explicit version endpoint exists (**#4548**), the reliable check is
-   **behavioral**: load a page whose behavior only the new code produces. (The `/anonSignUp` liveness probe is not
-   sufficient — it passes even when a page like `/leaderboard` is crashing.)
+### 1. Pick the version number
+
+Adapted from [semver](https://semver.org/), versions are **X.Y.Z** = **Major.Minor.Patch**:
+
+| Bump | When | Example |
+|------|------|---------|
+| **Patch (Z)** | Bug fixes only. | `11.6.0` → `11.6.1`, which only fixed the leaderboard failing to load. |
+| **Minor (Y)** | Backward-compatible change — new features, enhancements, redesigns of existing pages. | `11.6.1` → `11.7.0`, which added Lived Experience Stories and redesigned the navbar and label card. |
+| **Major (X)** | Backward-incompatible change, or a release that revamps the product rather than adding to it. | `v9.0.0`, `v10.0.0`, `v11.0.0` — roughly one every six to twelve months. |
+
+Most scheduled releases are a **minor** bump; most hotfixes are a **patch**. Note that a minor bump is not capped by
+size — several 11.x minors carried 60–90 merged PRs including whole-page redesigns. **When in doubt, ask the team**
+before choosing: the number is public and permanent.
+
+### 2. Create a prep branch off `develop`
+
+```bash
+git fetch origin
+git switch -c prep-v<X.Y.Z>-release origin/develop
+```
+
+### 3. Bump the app version
+
+Edit `version := "X.Y.Z"` in [`build.sbt`](../build.sbt).
+
+### 4. Add a version-table evolution
+
+Create the next-numbered `conf/evolutions/default/NNN.sql` recording the release in the `version` table. This row is
+what the site footer / `commonData.versionId` displays — the app shows the row with the latest `version_start_time`,
+so `now()` is correct and no manual date is needed:
+
+```sql
+# --- !Ups
+INSERT INTO version VALUES ('X.Y.Z', now(), 'One-line, user-facing summary of the release.');
+
+# --- !Downs
+DELETE FROM version WHERE version_id = 'X.Y.Z';
+```
+
+Take the **next free number**, and check for collisions with in-flight PRs rather than trusting the highest file on
+`develop` — several open PRs commonly hold the same next number, and the release evolution should not be the one that
+has to renumber. `make lint-evolutions` runs the static checks CI enforces.
+
+### 5. Open the prep PR into `develop`
+
+Commit message: `<old-version> - <new-version>` (e.g. `11.7.0 - 11.8.0`). PR title: **`Prep for v<X.Y.Z> release`**.
+
+Merging it redeploys the **test** stage automatically, within roughly 15 minutes. **Verify the new version number
+appears in the site footer on test** before going further — that confirms both the build and the evolution applied.
+
+### 6. Open the release PR: `develop` → `master`
+
+Title it exactly **`v<X.Y.Z>`** (e.g. `v11.7.0`). The body is the release notes — see
+[Writing the release notes](#writing-the-release-notes) below. Then merge it into `master`.
+
+### 7. Create the GitHub Release
+
+Create a [new release](https://github.com/ProjectSidewalk/SidewalkWebpage/releases/new):
+
+- **Tag:** `v<X.Y.Z>` — match the existing format exactly (`v11.6.0`, `v11.5.1`, …).
+- **Target branch:** `master`.
+- **Title:** `v<X.Y.Z>`.
+- **Description:** the same release notes you put in the PR body.
+
+Publishing this is what triggers the **prod** build and the rolling per-city restart.
+
+### 8. Verify prod
+
+The build isn't instant and city instances come up one-by-one. Confirm the *new code* is live, not just that the
+server responds. Until an explicit version endpoint exists (**#4548**), the reliable check is **behavioral**: load a
+page whose behavior only the new code produces. (The `/anonSignUp` liveness probe is not sufficient — it passes even
+when a page like `/leaderboard` is crashing.) Also check the footer version and spot-check a few different cities,
+since they restart independently.
 
 **Two independent gotchas, both learned from #4545:**
-- Merging to `master` alone does **not** deploy to prod — the **tag** (step 5) does.
-- Bumping `build.sbt` alone does **not** change the version the site shows — the **evolution** (step 2) does.
-A hotfix that changes no schema *still* needs step 2 for the displayed version to update.
+- Merging to `master` alone does **not** deploy to prod — the **tag** (step 7) does.
+- Bumping `build.sbt` alone does **not** change the version the site shows — the **evolution** (step 4) does.
+A hotfix that changes no schema *still* needs step 4 for the displayed version to update.
 
 > **Design note:** routing release-versioning through schema evolutions couples two unrelated concerns and duplicates
 > the version string across `build.sbt`, an evolution, and the git tag. Making the git tag / build metadata the single
 > source of truth (an `sbt-buildinfo`-backed `/version` endpoint) is tracked in **#4548**; follow that convention if it
 > lands.
+
+### Writing the release notes
+
+The notes are written **for non-technical users** — contributors, city partners, and researchers read them. Same text
+serves the `develop` → `master` PR body and the GitHub Release description.
+
+Conventions, from past releases (a good model: [PR #4188](https://github.com/ProjectSidewalk/SidewalkWebpage/pull/4188),
+[PR #4614](https://github.com/ProjectSidewalk/SidewalkWebpage/pull/4614)):
+
+- One bullet per user-visible change, in **decreasing order of importance to end users** — not chronological order.
+- **Bold the one or two biggest headlines**, leave the rest plain.
+- Describe the change in plain language, from the user's point of view ("Fixes neighborhood names with `/` rendering
+  incorrectly in the mission complete screen"), not the implementation ("escapes HTML entities in `MissionTable`").
+- Cite **both the issue number and the PR number** — `#4054 (PR #4593)` — so a future reader can get back to the
+  discussion *and* the diff.
+- Group or omit pure-infra churn (CI config, lint fixes, dependency bumps, docs). One catch-all line is plenty; these
+  bullets are not a changelog of every merge.
+
+**Finding what's in the release.** Enumerate PRs by *commit reachability* from the previous tag rather than by merge
+date — a date filter both misses stragglers and picks up PRs that merged after the last tag was cut:
+
+```bash
+git fetch origin --tags
+PREV=v11.7.0   # the previous release tag
+git log $PREV..origin/develop --merges --format='%s' \
+  | grep -oP 'Merge pull request #\K[0-9]+' | sort -n -u > /tmp/prs.txt
+
+# titles
+while read n; do gh pr view "$n" --json number,title --jq '"* \(.title) (PR #\(.number))"'; done < /tmp/prs.txt
+
+# the issues each PR closes, so you can cite both numbers
+while read n; do
+  gh api graphql -f query="query{repository(owner:\"ProjectSidewalk\",name:\"SidewalkWebpage\")
+    {pullRequest(number:$n){closingIssuesReferences(first:10){nodes{number}}}}}" \
+    --jq "\"$n|\" + ([.data.repository.pullRequest.closingIssuesReferences.nodes[].number]|join(\",\"))"
+done < /tmp/prs.txt
+```
+
+That list is the raw material, not the notes — expect to merge related PRs into a single bullet, drop internal-only
+work, and rewrite every title into user-facing language.
+
+### Hotfixes
+
+A production bug that can't wait for the next scheduled release follows the same path — there is no way to reach prod
+that skips `develop` and `master`. Branch the fix off `develop`, merge it, then run the full runbook with a **patch**
+bump. The release notes can be a single bullet.
 
 ## Runtime shape
 


### PR DESCRIPTION
Prepares the **v11.8.0** release and moves the release runbook out of the wiki. This PR does **not** cut the release — no tag, no `master` merge. It only lands the version bump, the version evolution, and the docs, so the release PR that follows is a clean `develop` → `master` merge.

### Version

- `build.sbt` → `11.8.0`. Minor, not major: precedent is that a large multi-feature batch still gets a minor bump (11.6.0 was a comparable batch).
- **Evolution `351.sql`** inserts the matching `version` row. The two are separate on purpose and both are required — the tag deploys the code, the evolution changes the version the site *displays*. A release that bumps only `build.sbt` ships with a stale version in the footer.

351 is uncontested against `develop` (max is 350). Open PRs #4800 and #4649 both still claim a stale `348.sql` and will need renumbering regardless of this PR.

### Release runbook: wiki → repo

The wiki's *Deploying code to the server* page is absorbed into the existing "Cutting a release" section of [`docs/deployment-and-stages.md`](docs/deployment-and-stages.md), rather than a new `docs/releasing.md` — one source of truth per topic, per the #4252 migration. It's now an 8-step runbook: picking the version, the prep branch, the `build.sbt` bump, the version evolution, the prep PR, the release PR, the GitHub Release, and prod verification. Two sections are new:

- **Writing the release notes** — the house format (one bullet per user-visible change, ordered by importance to users, both issue *and* PR numbers cited), plus a recipe for enumerating what's in a release by **commit reachability from the previous tag** rather than by merge date. A date filter both misses stragglers and picks up PRs merged after the last tag was cut.
- **Hotfixes** — same path, patch bump; there is no route to prod that skips `develop` and `master`.

Both #4545 gotchas are kept: merging to `master` doesn't deploy (the tag does), and bumping `build.sbt` doesn't change the displayed version (the evolution does). So does the #4548 design note about making the git tag the single source of truth for the version.

The wiki page will be stubbed to point here once this merges — same treatment as the 10 pages stubbed in #4252.

### README

Adds a `docs/deployment-and-stages.md` row to the documentation table, and fixes the repo-vs-wiki rule, which used "deploying to a live server" as its example of wiki-resident content — exactly the topic this PR moves into the repo. The wiki's remaining scope (city-database creation, road geometries, revealing/hiding regions) is now what the rule describes.

### Verification

`make lint-evolutions` passes. `version.description` is `text`, so the description string has no length constraint, and the 3-value `INSERT` matches the column order.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-opus-5[1m])
