### PR TITLE
Fix the lat/lng estimator's citation of the LightGBM ceiling check

### DIFF
--- a/app/service/PanoDataService.scala
+++ b/app/service/PanoDataService.scala
@@ -81,16 +81,24 @@ object PanoDataService {
    * **label-latlng-estimation** repo, which holds the notebooks, the held-out splits, and the reports:
    *
    *  - Form (cotangent + matched-slope tail, and `BLEND_DEG`):
-   *    [[https://github.com/ProjectSidewalk/label-latlng-estimation/blob/master/reports/2026-08-07-distance-refit.md]]
+   *    [[https://github.com/ProjectSidewalk/label-latlng-estimation/blob/main/reports/2026-08-07-distance-refit.md]]
    *    (PR #12). Won a 12-rung bake-off on 316,118 training rows of GSV depth truth, scored on a held-out 79,029.
    *  - Falsification on a second imagery source (Mapillary), which located the residual scale error in the camera
    *    rigs rather than the form:
-   *    [[https://github.com/ProjectSidewalk/label-latlng-estimation/blob/master/reports/2026-08-07-mapillary-falsification.md]]
-   *    (PR #13). A LightGBM ceiling check found no headroom left for a learned model to recover:
-   *    [[https://github.com/ProjectSidewalk/label-latlng-estimation/blob/master/reports/2026-08-07-gbm-ceiling.md]]
-   *    (PR #14).
+   *    [[https://github.com/ProjectSidewalk/label-latlng-estimation/blob/main/reports/2026-08-07-mapillary-falsification.md]]
+   *    (PR #13).
+   *  - Headroom for a learned model, checked twice with opposite-looking answers. A LightGBM given the same inputs
+   *    and split beat this form by 74% on 2017-2020 truth:
+   *    [[https://github.com/ProjectSidewalk/label-latlng-estimation/blob/main/reports/2026-08-07-gbm-ceiling.md]]
+   *    (PR #14). Scored against truth it was never fitted on, that gap inverts — with one calibration parameter on
+   *    each side this two-parameter form answers 0.410 m against 0.459-0.542 m for every recalibrated booster,
+   *    including one trained on modern truth directly:
+   *    [[https://github.com/ProjectSidewalk/label-latlng-estimation/blob/main/reports/2026-08-10-gbm-transfer.md]]
+   *    (PR #21). The booster's apparent edge was the era truth's own resolution-conditioned scale, not scene
+   *    structure. So there is no headroom for a learned model to recover here — but read the second report for that,
+   *    not the first, which measures only what the 2017-2020 truth frame supports.
    *  - Absolute scale (`CAMERA_HEIGHT_M`), and the evidence for one height rather than a per-label-type table:
-   *    [[https://github.com/ProjectSidewalk/label-latlng-estimation/blob/master/reports/2026-08-07-modern-truth.md]]
+   *    [[https://github.com/ProjectSidewalk/label-latlng-estimation/blob/main/reports/2026-08-07-modern-truth.md]]
    *    (PR #16, §7 mechanism and §9 decision). Canonical values: `final_coefficients` in
    *    `data/modern-truth-summary.json`.
    *
@@ -110,9 +118,10 @@ object PanoDataService {
     /**
      * Depression angle (degrees below the horizon) where the cotangent hands off to its linear tail.
      *
-     * Fitted, not picked: `provisional_coefficients.params.blend_deg` in `data/distance-refit-summary.json`, from
-     * the rung (`D_blend_type_l1`) that won the distance refit's bake-off on train-half median absolute distance
-     * error. Only the angle carries over from that rung — `CAMERA_HEIGHT_M` is calibrated separately.
+     * Fitted, not picked: `era_fit_coefficients.params.blend_deg` in `data/distance-refit-summary.json` (that block
+     * was called `provisional_coefficients` when this comment was written), from the rung (`D_blend_type_l1`) that
+     * won the distance refit's bake-off on train-half median absolute distance error. Only the angle carries over
+     * from that rung — `CAMERA_HEIGHT_M` is calibrated separately.
      */
     val BLEND_DEG: Double = 11.25
 


### PR DESCRIPTION
Comments only — no behaviour change.

`PanoDataService.LatLngEstimation`'s Scaladoc said:

> A LightGBM ceiling check found no headroom left for a learned model to recover:
> [2026-08-07-gbm-ceiling.md] (PR #14).

That report concluded the **opposite**: a LightGBM given the same inputs and split beat this
form by 74%, and its §9 called the gap "real conditional structure the geometry is not
using." So the shipped estimator's own justification cited a document that argued against it.

The conclusion turns out to be right, but the evidence for it is a different report. The
follow-up ([label-latlng-estimation#21](https://github.com/ProjectSidewalk/label-latlng-estimation/pull/21),
[report](https://github.com/ProjectSidewalk/label-latlng-estimation/blob/main/reports/2026-08-10-gbm-transfer.md))
scored those same frozen boosters against modern measured-plane truth they were never fitted
on. With one calibration parameter on each side, fitted on a train half of panoramas and
scored on the disjoint half:

| held-out half (n = 1,362) | median \|err\| |
|---|---:|
| **this estimator** | **0.410 m** |
| GBM trained on modern truth itself | 0.459 m |
| GBM + affine recalibration | 0.461 m |
| GBM + one scale | 0.498 m |
| GBM + monotone quantile map | 0.542 m |

Every paired cluster-bootstrap interval excludes zero. The booster's era-frame edge was the
2017–2020 truth's own resolution-conditioned scale — that truth implies 2.80 m of camera
height where `pano_height` is absent and 2.79 m at 6656 px, but 2.35 m at 8192 px, within a
centimetre of `CAMERA_HEIGHT_M` — so a model that can read `pano_height` was learning which
subpopulation answers on which scale, which is worth a lot inside that truth and nothing
outside it.

This rewrites the bullet to say both things and point at both reports, so a future reader
who follows the link does not find it contradicting the code.

Two stale references in the same block, fixed while here:

- the five report links used `blob/master`; that repo's default branch is `main` and the old
  paths resolve only through GitHub's rename redirect;
- `BLEND_DEG` cited `provisional_coefficients.params.blend_deg`, since renamed to
  `era_fit_coefficients` (the value, 11.25, is unchanged).

I re-verified the constants against the canonical artifact while I was in here:
`CAMERA_HEIGHT_M = 2.341219672825709` matches `final_coefficients.params.height_m` exactly,
`BLEND_DEG = 11.25` and `MAX_DISTANCE_M = 50.0` match `data/distance-refit-summary.json`, and
`estimateDistanceFromPanoM` matches the reference blend (including the matched-slope tail and
the `max(depressionDeg, 0)` clamp), as does the Label.js copy fed from `asJson`.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-opus-5[1m])
