### PR TITLE
Skips the imagery provider check when pano_data already has the answer

### DIFF
--- a/app/models/pano/PanoDataTable.scala
+++ b/app/models/pano/PanoDataTable.scala
@@ -167,6 +167,33 @@ class PanoDataTable @Inject() (protected val dbConfigProvider: DatabaseConfigPro
   }
 
   /**
+   * Looks up the imagery-existence answers we can reuse for the given panos instead of asking the provider (#3004).
+   *
+   * A row qualifies when either:
+   *   - `expired` is true. Imagery loss is effectively permanent, and `CheckImageExpiryActor` re-checks expired panos
+   *     nightly to catch ones marked so incorrectly, so the foreground call only ever confirms what we know.
+   *   - `expired` is false and `last_checked` is at or after `liveCheckedSince`. Liveness *can* lapse at any moment, so
+   *     this side carries a TTL that bounds how long we'd keep handing out a pano that has since gone away.
+   *
+   * GSV only: Mapillary has no nightly expiry check behind it (`getPanoIdsToCheckExpiration` is GSV-only), so its
+   * foreground check is the only one there is and must keep running. Infra3d is never checked against a provider at
+   * all. Both simply get no cache entry here.
+   *
+   * @param panoIds          Panos to look up.
+   * @param liveCheckedSince Cutoff for reusing a non-expired result; older ones are re-checked.
+   * @return                 Pano ID -> whether its imagery exists, holding only the panos an answer is reusable for.
+   */
+  def getReusableImageryStatus(panoIds: Set[String], liveCheckedSince: OffsetDateTime): DBIO[Map[String, Boolean]] = {
+    panoDataRecords
+      .filter(_.panoId inSet panoIds)
+      .filter(_.source === PanoSource.Gsv)
+      .filter(pano => pano.expired || pano.lastChecked >= liveCheckedSince)
+      .map(pano => (pano.panoId, pano.expired))
+      .result
+      .map(_.map { case (panoId, expired) => panoId -> !expired }.toMap)
+  }
+
+  /**
    * Sets has_backup = true for the given pano, but only if it isn't already true.
    *
    * @param panoId The ID of the pano whose has_backup flag should be set.

--- a/app/service/LabelService.scala
+++ b/app/service/LabelService.scala
@@ -381,34 +381,47 @@ class LabelServiceImpl @Inject() (
   }
 
   // Checks each label in a batch for imagery availability. When useCrops is true, labels with a locally-saved crop
-  // image are accepted without querying the API; only labels lacking a crop are checked. When useCrops is false, all
-  // labels are checked via panoExists(); labels with a viewable locally-hosted backup pass as well.
+  // image are accepted without any imagery lookup; only labels lacking a crop are looked up. When useCrops is false,
+  // every label is looked up, and one with a viewable locally-hosted backup passes even when its imagery is gone.
   //
-  // This is the real gate for expired imagery, not pano_data.expired: that column is refreshed lazily, so a row still
-  // claiming expired = false while the imagery is gone sails past LabelTable.imageryViewable to here.
+  // This is the gate expired imagery has to clear: LabelTable.imageryViewable screens on pano_data.expired, which a row
+  // keeps claiming false until something checks it, so a label whose imagery died arrives here still looking live. The
+  // lookup answers from pano_data where that's sound (getReusableImageryStatus) and asks the provider otherwise.
   private def checkImageryBatch[A <: BasicLabelMetadata](labels: Seq[A], useCrops: Boolean): Future[Seq[A]] = {
-    if (useCrops) {
-      // Partition: labels with local crops pass immediately; the rest are checked via panoExists().
-      val (withCrop, withoutCrop) = labels.partition(l => panoDataService.cropExists(l.labelId, l.labelType))
-      Future
-        .traverse(withoutCrop) { label =>
-          panoDataService.panoExists(label.panoId, label.panoSource).map {
-            case Some(true) => Some(label)
-            case _          => None
-          }
+    // Partition: labels with local crops need no imagery lookup at all; the rest are checked one by one.
+    val (withCrop, toCheck) =
+      if (useCrops) labels.partition(l => panoDataService.cropExists(l.labelId, l.labelType))
+      else (Seq.empty[A], labels)
+
+    // One query up front for the answers we can reuse, so the per-label lookups below skip the provider where they can.
+    panoDataService.getReusableImageryStatus(toCheck.map(_.panoId).toSet).flatMap { reusable =>
+      def imageryExists(label: A): Future[Option[Boolean]] =
+        reusable.get(label.panoId) match {
+          case Some(exists) => Future.successful(Some(exists))
+          case None         => panoDataService.panoExists(label.panoId, label.panoSource)
         }
-        .map(results => withCrop ++ results.flatten)
-    } else {
-      Future
-        .traverse(labels) { label =>
-          panoDataService.panoExists(label.panoId, label.panoSource).flatMap {
-            case Some(true) => Future.successful(Some(label))
-            // getLocalBackupImage, not backupExists: a file on disk is only usable if pano_data also has the metadata
-            // Pannellum needs. Validate has no fallback behind it, so admitting a label we can't render is #4804.
-            case _ => panoDataService.getLocalBackupImage(label.panoId).map(_.map(_ => label))
+
+      if (useCrops) {
+        Future
+          .traverse(toCheck) { label =>
+            imageryExists(label).map {
+              case Some(true) => Some(label)
+              case _          => None
+            }
           }
-        }
-        .map(_.flatten)
+          .map(results => withCrop ++ results.flatten)
+      } else {
+        Future
+          .traverse(toCheck) { label =>
+            imageryExists(label).flatMap {
+              case Some(true) => Future.successful(Some(label))
+              // getLocalBackupImage, not backupExists: a file on disk is only usable if pano_data also has the metadata
+              // Pannellum needs. Validate has no fallback behind it, so admitting a label we can't render is #4804.
+              case _ => panoDataService.getLocalBackupImage(label.panoId).map(_.map(_ => label))
+            }
+          }
+          .map(_.flatten)
+      }
     }
   }
 

--- a/app/service/LabelService.scala
+++ b/app/service/LabelService.scala
@@ -7,6 +7,7 @@ import models.label.LabelTable._
 import models.label.LabelTypeEnum.labelTypeToId
 import models.label.{Tag, _}
 import models.mission.{Mission, MissionTable, MissionType}
+import models.pano.PanoSource
 import models.pano.PanoSource.PanoSource
 import models.user.SidewalkUserWithRole
 import models.utils.CommonUtils.UiSource
@@ -394,7 +395,10 @@ class LabelServiceImpl @Inject() (
       else (Seq.empty[A], labels)
 
     // One query up front for the answers we can reuse, so the per-label lookups below skip the provider where they can.
-    panoDataService.getReusableImageryStatus(toCheck.map(_.panoId).toSet).flatMap { reusable =>
+    // Only GSV answers are reusable, and every batch is single-source (the label queries filter on the viewer's
+    // source), so asking about a Mapillary or Infra3d batch would spend a round trip to be told nothing.
+    val cacheablePanoIds: Set[String] = toCheck.collect { case l if l.panoSource == PanoSource.Gsv => l.panoId }.toSet
+    panoDataService.getReusableImageryStatus(cacheablePanoIds).flatMap { reusable =>
       def imageryExists(label: A): Future[Option[Boolean]] =
         reusable.get(label.panoId) match {
           case Some(exists) => Future.successful(Some(exists))

--- a/app/service/PanoDataService.scala
+++ b/app/service/PanoDataService.scala
@@ -14,7 +14,7 @@ import play.api.http.ContentTypes
 import play.api.libs.json.{JsObject, Json}
 import play.api.libs.ws.WSClient
 import play.api.{Configuration, Logger}
-import service.PanoDataService.getFov
+import service.PanoDataService.{getFov, LiveImageryTtlDays}
 import slick.dbio.DBIO
 
 import java.io.{File, IOException}
@@ -31,6 +31,16 @@ import scala.concurrent.{ExecutionContext, Future}
  * Companion object with constants and functions that are shared throughout codebase, that shouldn't require injection.
  */
 object PanoDataService {
+
+  /**
+   * How long a "the imagery is still there" answer stays good before we ask the provider again (#3004).
+   *
+   * The window bounds how long a pano that has since disappeared can keep being handed to users, so it trades page
+   * load time against that exposure. A pano's odds of vanishing in any given week are on the order of 0.1%, small
+   * enough to keep bad hand-outs rare, and a window this wide covers a whole mapathon rather than only the day a
+   * label was placed.
+   */
+  val LiveImageryTtlDays: Long = 7
 
   /**
    * Hacky fix to generate the FOV for an image. Determined experimentally.
@@ -228,6 +238,7 @@ trait PanoDataService {
    */
   def getInfra3dToken(cityId: String): Future[String]
   def panoExists(panoId: String, panoSource: PanoSource): Future[Option[Boolean]]
+  def getReusableImageryStatus(panoIds: Set[String]): Future[Map[String, Boolean]]
   def getImageUrl(panoId: String, panoSrc: PanoSource, heading: Double, pitch: Double, zoom: Double): Option[String]
   def getGsvImageUrlsForStreet(streetEdgeId: Int): Future[Seq[String]]
   def insertPanoHistories(histories: Seq[PanoHistorySubmission]): Future[Unit]
@@ -318,6 +329,19 @@ class PanoDataServiceImpl @Inject() (
       case PanoSource.Mapillary => mapillaryPanoExists(panoId)
       case _                    => Future.successful(Some(true))
     }
+  }
+
+  /**
+   * Looks up which of the given panos we already know the imagery-existence answer for, skipping a provider call.
+   *
+   * See `PanoDataTable.getReusableImageryStatus` for which rows qualify and why.
+   *
+   * @param panoIds Panos to look up.
+   * @return        Pano ID -> whether its imagery exists, holding only the panos an answer is reusable for.
+   */
+  def getReusableImageryStatus(panoIds: Set[String]): Future[Map[String, Boolean]] = {
+    if (panoIds.isEmpty) Future.successful(Map.empty)
+    else db.run(panoDataTable.getReusableImageryStatus(panoIds, OffsetDateTime.now.minusDays(LiveImageryTtlDays)))
   }
 
   /**

--- a/test/models/pano/PanoDataTableSpec.scala
+++ b/test/models/pano/PanoDataTableSpec.scala
@@ -9,8 +9,10 @@ import play.api.db.slick.DatabaseConfigProvider
 import play.api.inject.guice.GuiceApplicationBuilder
 import service.PanoDataService.LiveImageryTtlDays
 import slick.dbio.DBIO
+import slick.jdbc.TransactionIsolation
 
 import java.time.OffsetDateTime
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
@@ -36,10 +38,17 @@ class PanoDataTableSpec extends PlaySpec with GuiceOneAppPerSuite {
   private val dbConfig                   = app.injector.instanceOf[DatabaseConfigProvider].get[MyPostgresProfile]
   private def run[T](action: DBIO[T]): T = Await.result(dbConfig.db.run(action), 60.seconds)
 
-  private val cutoff: OffsetDateTime         = OffsetDateTime.now.minusDays(LiveImageryTtlDays)
-  private val sample: Seq[PanoData]          = run(panoDataTable.panoDataRecords.take(1000).result)
-  private val sampleIds: Set[String]         = sample.map(_.panoId).toSet
-  private val statuses: Map[String, Boolean] = run(panoDataTable.getReusableImageryStatus(sampleIds, cutoff))
+  private val cutoff: OffsetDateTime = OffsetDateTime.now.minusDays(LiveImageryTtlDays)
+
+  // Both reads happen in one repeatable-read transaction so they see the same snapshot: the exact-match assertion below
+  // compares them directly, and other suites run in parallel and write pano_data (AiSubmissionSpec inserts and deletes
+  // rows; savePanoInfo bumps last_checked), which would otherwise let a row shift between the two queries.
+  private val (sample, statuses) = run(
+    (for {
+      rows     <- panoDataTable.panoDataRecords.sortBy(_.panoId).take(1000).result
+      statuses <- panoDataTable.getReusableImageryStatus(rows.map(_.panoId).toSet, cutoff)
+    } yield (rows, statuses)).transactionally.withTransactionIsolation(TransactionIsolation.RepeatableRead)
+  )
 
   "PanoDataTable.getReusableImageryStatus" should {
     "return an answer for exactly the panos the reuse rule covers" in {

--- a/test/models/pano/PanoDataTableSpec.scala
+++ b/test/models/pano/PanoDataTableSpec.scala
@@ -1,0 +1,75 @@
+package models.pano
+
+import models.utils.MyPostgresProfile
+import models.utils.MyPostgresProfile.api._
+import org.scalatestplus.play.PlaySpec
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
+import play.api.db.slick.DatabaseConfigProvider
+import play.api.inject.guice.GuiceApplicationBuilder
+import service.PanoDataService.LiveImageryTtlDays
+import slick.dbio.DBIO
+
+import java.time.OffsetDateTime
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+/**
+ * DB-backed contract test for `PanoDataTable.getReusableImageryStatus`, the lookup that lets an imagery check skip the
+ * provider (#3004).
+ *
+ * Asserts the rule the query encodes against whatever rows the connected DB holds, rather than any particular data: a
+ * known-expired GSV pano is always reusable, a live one only while its check is inside the TTL, and no other source is
+ * reusable at all. Passes against an empty DB.
+ *
+ * Requires a Postgres+PostGIS database (via DATABASE_URL / DATABASE_USER / DATABASE_PASSWORD env, as in dev/CI). The
+ * eager scheduling actors are disabled so they don't fire background work during the test.
+ */
+class PanoDataTableSpec extends PlaySpec with GuiceOneAppPerSuite {
+
+  override def fakeApplication(): Application =
+    new GuiceApplicationBuilder().disable[modules.ActorModule].build()
+
+  private val panoDataTable = app.injector.instanceOf[PanoDataTable]
+  // Keep the DatabaseConfig as a stable val and call .db.run inline; binding .db to its own val would infer a
+  // path-dependent existential type that needs -language:existentials.
+  private val dbConfig                   = app.injector.instanceOf[DatabaseConfigProvider].get[MyPostgresProfile]
+  private def run[T](action: DBIO[T]): T = Await.result(dbConfig.db.run(action), 60.seconds)
+
+  private val cutoff: OffsetDateTime         = OffsetDateTime.now.minusDays(LiveImageryTtlDays)
+  private val sample: Seq[PanoData]          = run(panoDataTable.panoDataRecords.take(1000).result)
+  private val sampleIds: Set[String]         = sample.map(_.panoId).toSet
+  private val statuses: Map[String, Boolean] = run(panoDataTable.getReusableImageryStatus(sampleIds, cutoff))
+
+  "PanoDataTable.getReusableImageryStatus" should {
+    "return an answer for exactly the panos the reuse rule covers" in {
+      val expected: Map[String, Boolean] = sample.collect {
+        case pano if pano.source == PanoSource.Gsv && (pano.expired || !pano.lastChecked.isBefore(cutoff)) =>
+          pano.panoId -> !pano.expired
+      }.toMap
+      statuses mustBe expected
+    }
+
+    "reuse a known-expired pano no matter how long ago it was checked" in {
+      val staleExpired = sample.filter(p => p.source == PanoSource.Gsv && p.expired && p.lastChecked.isBefore(cutoff))
+      assume(staleExpired.nonEmpty, "connected DB has no expired GSV pano checked before the TTL cutoff")
+      staleExpired.foreach(pano => statuses.get(pano.panoId) mustBe Some(false))
+    }
+
+    "make a live pano checked before the cutoff fall through to a fresh check" in {
+      val staleLive = sample.filter(p => p.source == PanoSource.Gsv && !p.expired && p.lastChecked.isBefore(cutoff))
+      assume(staleLive.nonEmpty, "connected DB has no live GSV pano checked before the TTL cutoff")
+      staleLive.foreach(pano => statuses.get(pano.panoId) mustBe None)
+    }
+
+    "never answer for a source with no provider check behind it" in {
+      val nonGsv = sample.filter(_.source != PanoSource.Gsv)
+      assume(nonGsv.nonEmpty, "connected DB holds only GSV panos")
+      nonGsv.foreach(pano => statuses.get(pano.panoId) mustBe None)
+    }
+
+    "return nothing when asked about no panos" in {
+      run(panoDataTable.getReusableImageryStatus(Set.empty, cutoff)) mustBe empty
+    }
+  }
+}


### PR DESCRIPTION
resolves #3004

Validate, Gallery, and the user dashboard check every candidate label's pano against the imagery provider before serving it — **50 calls per Validate page load** (a 10-label mission oversampled 5x), **140 per Gallery load** (7 label types x 20). An imagery check now consults `pano_data` first and only calls out when the DB can't answer.

## The rule

| `pano_data` state | behavior |
|---|---|
| `expired = true` | answered from the DB, no provider call |
| `expired = false`, `last_checked` within 7 days | answered from the DB, no provider call |
| `expired = false`, `last_checked` older | provider call, as before |

The two sides are deliberately asymmetric. Imagery loss is permanent and `CheckImageExpiryActor` already re-checks expired panos nightly to catch ones marked so incorrectly, so a foreground call on an expired pano only ever confirms what we know. Liveness *can* lapse at any moment, so that side carries a TTL that bounds how long a pano that has since disappeared keeps being handed out.

Everything downstream is untouched — the lookup just supplies the `Option[Boolean]` that `panoExists` would have returned, so a cached "expired" lands on the same backup path a live check would have, and a cached "live" passes exactly as before.

**GSV only.** Mapillary keeps checking every time, because `getPanoIdsToCheckExpiration` is GSV-only and the foreground check is the only expiry check it has (there's a separate ticket for adding Mapillary imagery checking). Infra3d is never checked against a provider at all. Both simply get no cache entry.

## Interaction with backup panos

`LabelTable.imageryViewable` admits `expired = true` panos when a usable backup exists, so a large share of the queue is panos we already know are dead — and we ask Google every time just to be told so, then do the disk lookup for the backup anyway:

- Chicago: 57,267 / 152,698 (37%) of validatable labels sit on known-expired panos
- Seattle: 170,745 / 267,492 (64%)

Those calls are pure waste, and a cache that only remembered *good* answers wouldn't touch them. Hence the unconditional skip on the expired side.

## Measured

Counting `pano_data` rows whose `last_checked` gets bumped, over 5 Validate page loads against the Chicago dev DB:

| | provider calls | of which known-expired |
|---|---|---|
| develop | 250 (50/load) | 93 |
| this branch | **135 (27/load)** | 3 |

Page wall time is unchanged on this DB, and that's expected rather than disappointing: the calls run in parallel, so a batch costs the *max* of k calls, not the sum. Bootstrapping from measured per-call latency (p50 86 ms, p90 175 ms, max 428 ms), dropping 50 calls to 26 saves ~20 ms, while dropping to zero saves ~215 ms. The latency win only materializes when a whole batch is cached — which is the mapathon case the issue was filed for, where labels are placed and validated inside the same window. The win visible today is the halved call volume and halved `pano_data` writes, i.e. the throughput side.

## Trade-off worth a second opinion

The 7-day TTL means a pano that dies mid-week can be served until its entry ages out. A pano's odds of vanishing in a given week look to be ~0.1% (Seattle has accumulated ~39% expired over ~8 years), so roughly 1% of 10-label missions might carry one label whose imagery is gone. Validate has no fallback behind that, so it shows as a broken pano. Shortening the constant (`PanoDataService.LiveImageryTtlDays`) is a one-line change if that reads too loose.

## Testing

- `test/models/pano/PanoDataTableSpec.scala` — DB-backed contract test for the reuse rule; asserts against whatever rows the connected DB holds, so it passes on an empty DB.
- `testOnly service.* models.*` → 251 passed, 0 failed.
- `sbt compile` clean under `-Xfatal-warnings`; `scalafmtCheckAll` clean.
- QA'd by running the branch alongside the dev app and confirming Validate still builds full 10-label missions and Gallery still fills a page.

## Notes for review

- A cache hit leaves `last_checked` / `last_viewed` untouched. Nothing reads `last_viewed`. `has_backup` refresh falls to the nightly job: `updateExpiredStatus` (which rewrites the column from what's on disk) runs on every provider check, foreground or nightly, while `markHasBackup` only ever sets it `true` on upload. `getPanoIdsToCheckExpiration` picks up panos whose `last_checked` is over 3 months old, so a pano that skips the foreground check ages into that queue instead of being held out of it, and the column still converges — on a nightly cadence rather than a per-view one. The expired half of that job is gated on #4638.
- The nightly job is unchanged. Its expired re-check is still a leftovers budget that only runs when there aren't enough overdue unexpired panos (and #4638 covers its inverted `max`/`min`). That path becoming the only resurrection detection is a deliberate accepted trade here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
