### PR TITLE
Keep the context menu below the tooltip layer

### DIFF
--- a/public/css/explore/svl-onboarding.css
+++ b/public/css/explore/svl-onboarding.css
@@ -45,10 +45,15 @@
 
 /* The callout is meant to shrink rather than overlap the control it points at (see the size() middleware in
    Onboarding's anchorMessageTo), but that guarantee is only as good as Floating UI being loaded — without it the box
-   falls back to the pano's top-left corner, over the menu. Hovering the menu lifts it past the callout so the user
-   can always read and reach what they are being asked to click. */
-#context-menu-holder:hover {
-  z-index: 1101;
+   falls back to the pano's top-left corner, over the menu. Hovering the menu drops the callout behind it so the user
+   can always read and reach what they are being asked to click.
+
+   The callout gives way rather than the menu lifting, because the menu's tooltips are appended to <body> and live in
+   the tooltip layer (~1030): a menu raised past that layer paints over every tooltip opened from it, and the menu is
+   hovered exactly when those tooltips are showing (#4850). The takeover message is excluded — it is centered over the
+   dimmer at z-index 1028, with no menu underneath to make room for. */
+#street-view-holder:has(#context-menu-holder:hover) #onboarding-message-holder:not(.onboarding-message-takeover) {
+  z-index: 2;
 }
 
 /* Flashes the message box's background to draw the user's attention when a new message is shown. */

--- a/public/css/explore/svl-onboarding.css
+++ b/public/css/explore/svl-onboarding.css
@@ -45,14 +45,17 @@
 
 /* The callout is meant to shrink rather than overlap the control it points at (see the size() middleware in
    Onboarding's anchorMessageTo), but that guarantee is only as good as Floating UI being loaded — without it the box
-   falls back to the pano's top-left corner, over the menu. Hovering the menu drops the callout behind it so the user
-   can always read and reach what they are being asked to click.
+   falls back to the pano's top-left corner, over the menu. Reaching the menu drops the callout behind it so the user
+   can always read and reach what they are being asked to click. Focus counts as reaching it, not just the pointer:
+   the menu's tooltips open on Bootstrap's default `hover focus` trigger, so tabbing to a tag opens one with the
+   pointer nowhere near the panel.
 
    The callout gives way rather than the menu lifting, because the menu's tooltips are appended to <body> and live in
    the tooltip layer (~1030): a menu raised past that layer paints over every tooltip opened from it, and the menu is
    hovered exactly when those tooltips are showing (#4850). The takeover message is excluded — it is centered over the
    dimmer at z-index 1028, with no menu underneath to make room for. */
-#street-view-holder:has(#context-menu-holder:hover) #onboarding-message-holder:not(.onboarding-message-takeover) {
+#street-view-holder:has(#context-menu-holder:is(:hover, :focus-within))
+#onboarding-message-holder:not(.onboarding-message-takeover) {
   z-index: 2;
 }
 


### PR DESCRIPTION
Fixes #4850

### The bug

`svl-onboarding.css` carried an escape hatch from the in-situ tutorial work (#4814/#4815):

```css
#context-menu-holder:hover { z-index: 1101; }
```

It exists so a tutorial callout that lands over the context menu can't trap the user — hovering the menu lifted it past the callout. But it was never scoped to the tutorial, so it applied on every page state, and `1101` is above the tooltip layer: bootstrap tooltips sit at `1030`, `.context-menu-tooltip` at `1031`, the shared `.ps-tooltip` at `1100`.

The menu is hovered exactly when its own tooltips are showing, so all of them painted behind it — the tag examples, the rating examples, and the section info icons. That matches the report that it wasn't only the tag hovers.

### The fix

Invert it: while the menu is hovered, drop the callout below the menu instead of lifting the menu above the tooltip layer. The menu stays at `z-index: 3`, so every tooltip clears it — in the tutorial too, where the old rule left the callout itself (`1100`) above them.

Takeover messages are excluded from the drop: they're centered over the dimmer at `1028` with no menu underneath to make room for.

### Verification

Diagnosed and checked headlessly against the real stylesheets in a DOM replica of the Explore page (the tooltip needs a placed label on a pano, so it isn't automatable end-to-end):

- Menu at `1101` reproduces the issue video exactly — the tooltip is occluded and clipped at the menu's edge.
- With the fix, the tooltip paints over the menu, the callout computes to `2` and goes behind it, and the `:has()`/`:not()` selector is supported.
- `stylelint` clean.

### Please eyeball during review

In the tutorial: the callout should still yield when you mouse onto the menu, and a callout anchored to the minimap/sidebar should be unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)