### PR TITLE
Backfill stored label positions with the approximation3 estimator (#4818)

### DIFF
--- a/app/controllers/ClusterController.scala
+++ b/app/controllers/ClusterController.scala
@@ -41,46 +41,51 @@ class ClusterController @Inject() (
 
   /**
    * Runs clustering, emitting status updates as a server-sent event stream.
+   *
+   * @param allRegions Re-cluster every region rather than only those whose set of clusterable labels has changed. Use
+   *                   after something moves labels the clusterer already knows about, like the #4818 position
+   *                   backfill: membership is unchanged, so the default selection would find nothing to do.
    */
-  def runClustering(): Action[AnyContent] = cc.securityService.SecuredAction(WithAdmin()) { implicit request =>
-    cc.loggingService.insert(request.identity.userId, request.ipAddress, request.toString)
+  def runClustering(allRegions: Boolean): Action[AnyContent] = cc.securityService.SecuredAction(WithAdmin()) {
+    implicit request =>
+      cc.loggingService.insert(request.identity.userId, request.ipAddress, request.toString)
 
-    // Create a shared status object for clustering progress updates.
-    val statusRef = new AtomicReference[String]("Starting")
+      // Create a shared status object for clustering progress updates.
+      val statusRef = new AtomicReference[String]("Starting")
 
-    // Run the clustering.
-    val resultFuture: Future[JsObject] = clusterService.runClustering(Some(statusRef)).map { results =>
-      Json.obj("labels" -> results.labelCount, "clusters" -> results.clusterCount)
-    }
-
-    // Create a source that emits status updates.
-    val statusSource = Source
-      .tick(initialDelay = 0.seconds, interval = 2.seconds, tick = ())
-      .mapMaterializedValue { mat =>
-        // Cancel the ticker when clustering ends or the client disconnects.
-        resultFuture.onComplete(_ => mat.cancel())
-        mat
+      // Run the clustering.
+      val resultFuture: Future[JsObject] = clusterService.runClustering(Some(statusRef), allRegions).map { results =>
+        Json.obj("labels" -> results.labelCount, "clusters" -> results.clusterCount)
       }
-      .takeWhile(_ =>
-        // Send normal status updates.
-        !resultFuture.isCompleted
-      )
-      .map { _ => s"""data: {"status": "${statusRef.get()}"}\n\n""" }
 
-    // When the main task completes, emit the final status and complete the stream.
-    val resultSource = Source.future(resultFuture).map { resultJson =>
-      s"""data: {"status": "Complete", "results": ${resultJson.toString}}\n\n"""
-    }
-
-    // Combine the sources and return as event stream.
-    Future.successful(
-      Ok.chunked(statusSource.concat(resultSource))
-        .as("text/event-stream")
-        .withHeaders(
-          "Cache-Control" -> "no-cache, no-store, must-revalidate",
-          "Connection"    -> "keep-alive"
+      // Create a source that emits status updates.
+      val statusSource = Source
+        .tick(initialDelay = 0.seconds, interval = 2.seconds, tick = ())
+        .mapMaterializedValue { mat =>
+          // Cancel the ticker when clustering ends or the client disconnects.
+          resultFuture.onComplete(_ => mat.cancel())
+          mat
+        }
+        .takeWhile(_ =>
+          // Send normal status updates.
+          !resultFuture.isCompleted
         )
-    )
+        .map { _ => s"""data: {"status": "${statusRef.get()}"}\n\n""" }
+
+      // When the main task completes, emit the final status and complete the stream.
+      val resultSource = Source.future(resultFuture).map { resultJson =>
+        s"""data: {"status": "Complete", "results": ${resultJson.toString}}\n\n"""
+      }
+
+      // Combine the sources and return as event stream.
+      Future.successful(
+        Ok.chunked(statusSource.concat(resultSource))
+          .as("text/event-stream")
+          .withHeaders(
+            "Cache-Control" -> "no-cache, no-store, must-revalidate",
+            "Connection"    -> "keep-alive"
+          )
+      )
   }
 
   /**

--- a/app/models/cluster/ClusteringSessionTable.scala
+++ b/app/models/cluster/ClusteringSessionTable.scala
@@ -60,6 +60,19 @@ trait ClusteringSessionTableRepository {
   def getRegionsToCluster: DBIO[Seq[Int]]
 
   /**
+   * Get every region that clustering could produce output for, whether or not its labels have changed.
+   *
+   * The query above compares label *membership*, so a change that moves labels the clusterer already knows about --
+   * an evolution that recomputes stored positions (#4818), a re-tuned clustering threshold -- flags no region at all
+   * and never gets picked up. This is the list to use when the positions themselves changed and everything has to be
+   * rebuilt. It is a superset of getRegionsToCluster: regions holding clusterable labels, plus regions reachable
+   * through existing cluster data (so a region whose labels have all become ineligible is still cleaned up).
+   *
+   * @return A sequence of region_ids, wrapped in a DBIO action
+   */
+  def getAllRegionsToCluster: DBIO[Seq[Int]]
+
+  /**
    * Returns labels that were placed by the specified user in the format needed for clustering.
    * @param regionId The region whose labels should be retrieved
    * @return A sequence of LabelToCluster objects wrapped in a DBIO action
@@ -118,23 +131,29 @@ class ClusteringSessionTable @Inject() (protected val dbConfigProvider: Database
   } yield (ser.regionId, us.userId, l.panoId, l.labelId, lt.labelType, lp.lat.ifNull(-1d), lp.lng.ifNull(-1d),
     l.severity)
 
-  def getRegionsToCluster: DBIO[Seq[Int]] = {
-    // Get the labels that are currently present in the API.
-    val labelsInApi = for {
-      cl  <- clusterLabels
-      l   <- labelsUnfiltered if cl.labelId === l.labelId
-      ser <- streetEdgeRegions if l.streetEdgeId === ser.streetEdgeId
-    } yield (ser.regionId, l.labelId)
+  // The labels that are currently present in the API, by the region their street belongs to now.
+  private def labelsInApiQuery = for {
+    cl  <- clusterLabels
+    l   <- labelsUnfiltered if cl.labelId === l.labelId
+    ser <- streetEdgeRegions if l.streetEdgeId === ser.streetEdgeId
+  } yield (ser.regionId, l.labelId)
 
-    // Find all mismatches between the list of labels above using an outer join.
+  def getRegionsToCluster: DBIO[Seq[Int]] = {
+    // Find all mismatches between the two label lists using an outer join.
     labelsForApiQuery
-      .joinFull(labelsInApi)
+      .joinFull(labelsInApiQuery)
       .on(_._4 === _._2)                               // FULL OUTER JOIN on label_id.
       .filter(x => x._1.isEmpty || x._2.isEmpty)       // WHERE no_api.label_id IS NULL OR in_api.label_id IS NULL.
       .map(x => x._1.map(_._1).ifNull(x._2.map(_._1))) // COALESCE(no_api.region_id, in_api.region_id).
       .distinct                                        // SELECT DISTINCT and flatten.
       .result
       .map(_.flatten)
+  }
+
+  def getAllRegionsToCluster: DBIO[Seq[Int]] = {
+    // Both sides of the mismatch join above, plus regions that hold a clustering session, so this is a superset of
+    // getRegionsToCluster by construction (that query can only return a region id one of those sides produced).
+    (labelsForApiQuery.map(_._1) ++ labelsInApiQuery.map(_._1) ++ clusteringSessions.map(_.regionId)).distinct.result
   }
 
   def getLabelsToClusterInRegion(regionId: Int): DBIO[Seq[LabelToCluster]] = {

--- a/app/service/ApiService.scala
+++ b/app/service/ApiService.scala
@@ -51,7 +51,13 @@ trait ApiService {
   def getLabelCVMetadata(batchSize: Int): Source[LabelCVMetadata, _]
 
   def getLabelsToClusterInRegion(regionId: Int): Future[Seq[LabelToCluster]]
-  def getRegionsToCluster: Future[Seq[Int]]
+
+  /**
+   * Regions for a clustering run: those whose label membership has changed, or every region when allRegions is set.
+   *
+   * @param allRegions Force a full rebuild, for when the labels' positions changed but the membership did not
+   */
+  def getRegionsToCluster(allRegions: Boolean): Future[Seq[Int]]
 
   /**
    * Submits clustering results for a region.
@@ -316,11 +322,14 @@ class ApiServiceImpl @Inject() (
   def getLabelsToClusterInRegion(regionId: Int): Future[Seq[LabelToCluster]] =
     db.run(clusteringSessionTable.getLabelsToClusterInRegion(regionId))
 
-  def getRegionsToCluster: Future[Seq[Int]] = {
-    // The list of regions that need re-clustering because their underlying labels have changed. Old data is no longer
-    // wiped here: each region's old clusters are deleted inside submitClusteringResults' transaction, so the API keeps
-    // serving the region's previous clusters until its re-cluster commits (#2507).
-    db.run(clusteringSessionTable.getRegionsToCluster)
+  def getRegionsToCluster(allRegions: Boolean): Future[Seq[Int]] = {
+    // The list of regions that need re-clustering because their underlying labels have changed, or every region when
+    // the caller is forcing a rebuild. This reads only: a region's old clusters are dropped inside
+    // submitClusteringResults' transaction, so the API keeps serving them until that region's re-cluster commits
+    // (#2507) -- which is what lets even a forced full rebuild run without an empty-cluster window.
+    db.run(
+      if (allRegions) clusteringSessionTable.getAllRegionsToCluster else clusteringSessionTable.getRegionsToCluster
+    )
   }
 
   def submitClusteringResults(

--- a/app/service/ClusterService.scala
+++ b/app/service/ClusterService.scala
@@ -21,10 +21,14 @@ trait ClusterService {
   /**
    * Runs clustering across all regions, updating the attached reference with progress.
    *
-   * @param statusRef Reference to a string that will be updated with the clustering progress.
-   * @return          Final counts of labels and clusters.
+   * @param statusRef  Reference to a string that will be updated with the clustering progress.
+   * @param allRegions Re-cluster every region instead of only those whose label membership changed.
+   * @return           Final counts of labels and clusters.
    */
-  def runClustering(statusRef: Option[AtomicReference[String]] = None): Future[ClusteringResults]
+  def runClustering(
+      statusRef: Option[AtomicReference[String]] = None,
+      allRegions: Boolean = false
+  ): Future[ClusteringResults]
 }
 
 /**
@@ -41,18 +45,19 @@ class ClusterServiceImpl @Inject() (
     extends ClusterService {
   private val logger = Logger(this.getClass)
 
-  def runClustering(statusRef: Option[AtomicReference[String]]): Future[ClusteringResults] = {
+  def runClustering(statusRef: Option[AtomicReference[String]], allRegions: Boolean): Future[ClusteringResults] = {
     for {
-      _      <- runMultiUserClustering(statusRef)
+      _      <- runMultiUserClustering(statusRef, allRegions)
       counts <- apiService.getClusteringInfo // Gets the counts to show how many labels were clustered.
     } yield ClusteringResults(labelCount = counts._1, clusterCount = counts._2)
   }
 
   /**
    * Runs clustering for the labels in each region.
-   * @param statusRef Reference to a string that will be updated with the clustering progress.
+   * @param statusRef  Reference to a string that will be updated with the clustering progress.
+   * @param allRegions Re-cluster every region instead of only those whose label membership changed.
    */
-  private def runMultiUserClustering(statusRef: Option[AtomicReference[String]]): Future[Unit] = {
+  private def runMultiUserClustering(statusRef: Option[AtomicReference[String]], allRegions: Boolean): Future[Unit] = {
     val key: String = config.get[String]("internal-api-key")
 
     // Resolve the script against the app's root path (where scripts/ is packaged via Universal / mappings in build.sbt)
@@ -68,41 +73,43 @@ class ClusterServiceImpl @Inject() (
 
     // Each shell-out blocks until that region's clustering script finishes, so the loop runs on the cpu-intensive
     // pool to keep these potentially minutes-long waits off Play's default dispatcher.
-    apiService.getRegionsToCluster.map { regionIds =>
-      val nRegions: Int = regionIds.length
-      logger.info("N regions = " + nRegions)
+    apiService
+      .getRegionsToCluster(allRegions)
+      .map { regionIds =>
+        val nRegions: Int = regionIds.length
+        logger.info("N regions = " + nRegions)
 
-      // Runs clustering within each region.
-      for ((regionId, i) <- regionIds.view.zipWithIndex) {
-        // Update the status in event stream and send a log message.
-        statusRef.foreach(_.set(s"Finished ${f"${100.0 * i / nRegions}%1.2f"}% of regions"))
-        logger.info(s"Finished ${f"${100.0 * i / nRegions}%1.2f"}% of regions, next: $regionId.")
+        // Runs clustering within each region.
+        for ((regionId, i) <- regionIds.view.zipWithIndex) {
+          // Update the status in event stream and send a log message.
+          statusRef.foreach(_.set(s"Finished ${f"${100.0 * i / nRegions}%1.2f"}% of regions"))
+          logger.info(s"Finished ${f"${100.0 * i / nRegions}%1.2f"}% of regions, next: $regionId.")
 
-        // Run the clustering script for this region. Pass the internal key via the subprocess environment rather than
-        // an argv flag so it can't leak into the process table / `ps` output.
-        val process = Process(
-          Seq("/usr/bin/python3", script.getAbsolutePath, "--region_id", regionId.toString),
-          None,
-          "INTERNAL_API_KEY" -> key
-        )
-
-        // Capture stdout/stderr separately so a subprocess failure surfaces the Python error to Play's logger.
-        val stdout   = new StringBuilder
-        val stderr   = new StringBuilder
-        val exitCode = process.!(
-          ProcessLogger(
-            line => { stdout.append(line).append('\n'); () },
-            line => { stderr.append(line).append('\n'); () }
+          // Run the clustering script for this region. Pass the internal key via the subprocess environment rather than
+          // an argv flag so it can't leak into the process table / `ps` output.
+          val process = Process(
+            Seq("/usr/bin/python3", script.getAbsolutePath, "--region_id", regionId.toString),
+            None,
+            "INTERNAL_API_KEY" -> key
           )
-        )
 
-        if (exitCode != 0) {
-          logger.error(s"Clustering script failed for region $regionId (exit $exitCode):\n${stderr.toString.trim}")
-          throw new RuntimeException(s"Clustering failed for region $regionId (exit $exitCode)")
+          // Capture stdout/stderr separately so a subprocess failure surfaces the Python error to Play's logger.
+          val stdout   = new StringBuilder
+          val stderr   = new StringBuilder
+          val exitCode = process.!(
+            ProcessLogger(
+              line => { stdout.append(line).append('\n'); () },
+              line => { stderr.append(line).append('\n'); () }
+            )
+          )
+
+          if (exitCode != 0) {
+            logger.error(s"Clustering script failed for region $regionId (exit $exitCode):\n${stderr.toString.trim}")
+            throw new RuntimeException(s"Clustering failed for region $regionId (exit $exitCode)")
+          }
+          logger.debug(stdout.toString)
         }
-        logger.debug(stdout.toString)
-      }
-      logger.info("Finished 100% of regions!!\n\n")
-    }(cpuEc)
+        logger.info("Finished 100% of regions!!\n\n")
+      }(cpuEc)
   }
 }

--- a/app/views/clustering.scala.html
+++ b/app/views/clustering.scala.html
@@ -6,11 +6,23 @@
 
 @common.main(commonData, title) {
   @common.navbar(commonData, Some(user))
+  <style>
+    .all-regions-toggle { margin-left: 10px; font-weight: normal; }
+    .all-regions-help { max-width: 60em; }
+  </style>
   <div id="content">
     <div class="container">
       <h1>Clustering labels</h1>
       <button type="button" id="btn-run-clustering">Run Clustering</button>
-      <br>
+      <label for="chk-all-regions" class="all-regions-toggle">
+        <input type="checkbox" id="chk-all-regions"> Re-cluster every region
+      </label>
+      <p class="all-regions-help">
+        A normal run only visits regions whose set of clusterable labels has changed. Check the box when the labels
+        themselves moved instead &mdash; after a position backfill, or a change to the clustering thresholds &mdash;
+        since that leaves membership identical and a normal run would find nothing to do. Every region is replaced in
+        its own transaction, so the API keeps serving each region's existing clusters until its new ones are ready.
+      </p>
       <p id="clustering-status"></p>
     </div>
   </div>
@@ -41,7 +53,8 @@
 
       // Creates a new EventSource for the run clustering button click and sets up the event handlers.
       document.getElementById('btn-run-clustering').onclick = function() {
-        const eventSource = new EventSource('/runClustering');
+        const allRegions = document.getElementById('chk-all-regions').checked;
+        const eventSource = new EventSource(allRegions ? '/runClustering?allRegions=true' : '/runClustering');
         eventSource.onmessage = clusteringEventOnMessage;
         eventSource.onerror = clusteringEventOnError;
       };

--- a/conf/evolutions/default/352.sql
+++ b/conf/evolutions/default/352.sql
@@ -1,0 +1,176 @@
+# --- !Ups
+-- #4818: recompute every stored 'approximation2' label position with the 'approximation3' estimator (#4765/#4766)
+-- that live submissions run, and stamp the rows accordingly. All of the estimator's inputs are already stored
+-- (label_point.pano_x/pano_y plus pano_data lat/lng/camera_heading/width/height), so the whole recompute is SQL: a
+-- statement-for-statement port of PanoDataService.calculatePovFromPanoXY, PanoDataService.estimateDistanceFromPanoM,
+-- and CommonUtils.calculateDestination (spherical haversine on R = 6371 km, matching the app bit-for-bit rather than
+-- the geodesic ST_Project), so an independent recompute of every row (tools/verify_latlng_backfill.py) agrees to
+-- float noise. Constant provenance: the LatLngEstimation scaladoc and the label-latlng-estimation repo reports it
+-- links. 'depth' rows hold positions measured from GSV depth data, better than any estimate, and are untouched.
+-- Rows without usable pano_data metadata keep 'approximation2', so computation_method stays honest about which
+-- estimator produced each stored position.
+
+-- Backup of every row this evolution modifies, so the Down is a lossless restore-from-copy rather than a formula
+-- replay (179.sql precedent). computation_method is TEXT here so this table cannot block the enum rebuild below.
+-- street_edge_id is captured for every backed-up label even though only AI-authored labels are reattached below,
+-- keeping the restore envelope complete if a later sweep reattaches the rest (#4818 discussion).
+CREATE TABLE old_label_point_position (
+    label_point_id INT PRIMARY KEY REFERENCES label_point (label_point_id),
+    label_id INT NOT NULL UNIQUE REFERENCES label (label_id),
+    lat DOUBLE PRECISION,
+    lng DOUBLE PRECISION,
+    geom geometry,
+    computation_method TEXT NOT NULL,
+    street_edge_id INT NOT NULL REFERENCES street_edge (street_edge_id)
+);
+ALTER TABLE old_label_point_position OWNER TO sidewalk;
+
+-- The recompute set: 'approximation2' rows with usable pano metadata. Every needed pano_data field is nullable and a
+-- pano_data row can be missing outright, so the inner join plus NOT NULL and positive-dimension guards define who is
+-- recomputed -- the UPDATE below drives off this table, so backed-up set and modified set are identical by
+-- construction. Comparing computation_method to 'approximation2' (a long-standing value) is safe even when 349.sql
+-- is pending in this same transaction -- the in-transaction restriction covers only a newly added value.
+INSERT INTO old_label_point_position
+    (label_point_id, label_id, lat, lng, geom, computation_method, street_edge_id)
+SELECT label_point.label_point_id, label.label_id, label_point.lat, label_point.lng, label_point.geom,
+       label_point.computation_method::text, label.street_edge_id
+FROM label_point
+INNER JOIN label ON label_point.label_id = label.label_id
+INNER JOIN pano_data ON label.pano_id = pano_data.pano_id
+WHERE label_point.computation_method = 'approximation2'
+    AND pano_data.lat IS NOT NULL
+    AND pano_data.lng IS NOT NULL
+    AND pano_data.camera_heading IS NOT NULL
+    AND pano_data.width IS NOT NULL AND pano_data.width > 0
+    AND pano_data.height IS NOT NULL AND pano_data.height > 0;
+
+-- Rebuild the enum rather than using the value 349.sql added: evolutions share one transaction (autocommit=false in
+-- application.conf), so on a database where 349 is still pending both files apply together and naming
+-- 'approximation3' -- even as a text-to-enum cast -- fails with "unsafe use of new value". A type created inside the
+-- current transaction carries no such restriction (342.sql mechanics, mandated by 349.sql's comment). The recompute
+-- UPDATE below runs while the column is plain text, touching no enum machinery at all. label_point.computation_method
+-- is the type's only column anywhere, so this is the whole rebuild.
+ALTER TABLE label_point ALTER COLUMN computation_method TYPE TEXT USING computation_method::text;
+DROP TYPE computation_method;
+CREATE TYPE computation_method AS ENUM ('depth', 'approximation2', 'approximation3');
+
+-- The recompute itself. Each CTE is one stage of the Scala pipeline it is named for, and every fitted constant
+-- appears exactly once in the constants CTE, so a refit (for example, if the absolute-scale question in
+-- label-latlng-estimation#7 resolves against the current camera height) re-runs this same UPDATE as a later
+-- evolution with one changed literal.
+WITH constants AS (
+    -- PanoDataService.LatLngEstimation and CommonUtils.EARTH_RADIUS_KM, verbatim.
+    SELECT 2.341219672825709::float8 AS camera_height_m,
+           11.25::float8 AS blend_deg,
+           50.0::float8 AS max_distance_m,
+           6371.0::float8 AS earth_radius_km
+), recompute_inputs AS (
+    SELECT old_label_point_position.label_point_id,
+           pano_data.lat AS pano_lat, pano_data.lng AS pano_lng, pano_data.camera_heading,
+           pano_data.width, pano_data.height, label_point.pano_x, label_point.pano_y
+    FROM old_label_point_position
+    INNER JOIN label_point ON old_label_point_position.label_point_id = label_point.label_point_id
+    INNER JOIN label ON label_point.label_id = label.label_id
+    INNER JOIN pano_data ON label.pano_id = pano_data.pano_id
+), angles AS (
+    -- calculatePovFromPanoXY: depression below the horizon from the pixel row, bearing from the pixel column (pixel
+    -- column zero looks 180 degrees behind the camera). mod(numeric, numeric) keeps the dividend's sign exactly like
+    -- Scala's %, so a westward heading can leave the bearing negative -- harmless, it only ever feeds sin and cos.
+    -- The float8 casts and leading float literals block integer division.
+    SELECT label_point_id, pano_lat, pano_lng,
+           180.0 * pano_y / height - 90.0 AS depression_deg,
+           mod((camera_heading - 180.0 + (pano_x::float8 / width) * 360.0)::numeric, 360.0)::float8 AS bearing_deg
+    FROM recompute_inputs
+), distances AS (
+    -- estimateDistanceFromPanoM: flat-ground cotangent at or steeper than blend_deg, then a linear tail with matched
+    -- value and slope, held flat above the horizon (GREATEST) and capped (LEAST -- cannot bind at this height, kept
+    -- so the estimate is bounded by construction). angular_dist is the haversine input, distance over Earth radius.
+    SELECT label_point_id, pano_lat, pano_lng, bearing_deg,
+           CASE
+               WHEN depression_deg >= blend_deg THEN camera_height_m / tan(radians(depression_deg))
+               ELSE LEAST(
+                   camera_height_m / tan(radians(blend_deg))
+                       + camera_height_m * (pi() / 180.0) / power(sin(radians(blend_deg)), 2)
+                         * (blend_deg - GREATEST(depression_deg, 0.0)),
+                   max_distance_m)
+           END / 1000.0 / earth_radius_km AS angular_dist
+    FROM angles, constants
+), new_latitudes AS (
+    -- CommonUtils.calculateDestination, latitude half. The LEAST/GREATEST clamp is the one deliberate deviation from
+    -- the Scala (whose asin would yield NaN) -- it can only engage within float error of a pole, where no imagery
+    -- exists, and keeps the statement total instead of erroring mid-apply.
+    SELECT label_point_id, pano_lat, pano_lng, bearing_deg, angular_dist,
+           asin(LEAST(1.0, GREATEST(-1.0,
+               sin(radians(pano_lat)) * cos(angular_dist)
+                   + cos(radians(pano_lat)) * sin(angular_dist) * cos(radians(bearing_deg))
+           ))) AS new_lat_rad
+    FROM distances
+), new_positions AS (
+    -- Longitude half. Like the Scala, the result is not wrapped into [-180, 180]: it could only escape for a pano
+    -- within ~24 m of the antimeridian, no deployed city is within hundreds of km of one, and the table's
+    -- label_point_lat_lng_check constraint would fail this evolution loudly rather than store a wrapped-out value.
+    SELECT label_point_id, degrees(new_lat_rad) AS new_lat,
+           degrees(radians(pano_lng) + atan2(
+               sin(radians(bearing_deg)) * sin(angular_dist) * cos(radians(pano_lat)),
+               cos(angular_dist) - sin(radians(pano_lat)) * sin(new_lat_rad)
+           )) AS new_lng
+    FROM new_latitudes
+)
+UPDATE label_point
+SET lat = new_lat,
+    lng = new_lng,
+    geom = ST_SetSRID(ST_Point(new_lng, new_lat), 4326),
+    computation_method = 'approximation3'
+FROM new_positions
+WHERE label_point.label_point_id = new_positions.label_point_id;
+
+ALTER TABLE label_point
+    ALTER COLUMN computation_method TYPE computation_method USING computation_method::computation_method;
+
+-- Reattach AI-authored labels to the street nearest their corrected position. An AI label's street_edge_id was
+-- chosen at submission time as the open street (tutorial included) nearest the estimated position
+-- (ExploreService.submitAiLabelData -> LabelTable.getStreetEdgeIdClosestToLatLng), so it follows the position.
+-- Human labels keep their street here pending the flip-rate measurement on #4818. The KNN prefilter narrows to 20
+-- candidates by degree distance and the exact sphere distance picks among them, reproducing the app's uncapped
+-- nearest-street ordering without a full per-label scan. The UUID is SidewalkUserTable.aiUserId.
+UPDATE label
+SET street_edge_id = nearest_street.street_edge_id
+FROM old_label_point_position
+INNER JOIN label_point ON old_label_point_position.label_point_id = label_point.label_point_id
+CROSS JOIN LATERAL (
+    SELECT candidate_streets.street_edge_id
+    FROM (
+        SELECT street_edge.street_edge_id, street_edge.geom
+        FROM street_edge
+        WHERE street_edge.status = 'open'
+        ORDER BY street_edge.geom <-> label_point.geom
+        LIMIT 20
+    ) candidate_streets
+    ORDER BY ST_DistanceSphere(candidate_streets.geom, label_point.geom)
+    LIMIT 1
+) nearest_street
+WHERE label.label_id = old_label_point_position.label_id
+    AND label.user_id = '51b0b927-3c8a-45b2-93de-bd878d1e5cf4'
+    AND label.street_edge_id <> nearest_street.street_edge_id;
+
+# --- !Downs
+-- Restore every modified row byte-for-byte from the backup. Labels created after the Up ran are absent from the
+-- backup and correctly keep their live-computed values. The AI-user filter mirrors the Up so a human label whose
+-- street changed through app activity between Up and Down cannot be clobbered. The enum keeps all three values --
+-- the running app writes 'approximation3', and 349.sql's Down already declines the rebuild removing a value takes.
+UPDATE label
+SET street_edge_id = old_label_point_position.street_edge_id
+FROM old_label_point_position
+WHERE label.label_id = old_label_point_position.label_id
+    AND label.user_id = '51b0b927-3c8a-45b2-93de-bd878d1e5cf4'
+    AND label.street_edge_id <> old_label_point_position.street_edge_id;
+
+UPDATE label_point
+SET lat = old_label_point_position.lat,
+    lng = old_label_point_position.lng,
+    geom = old_label_point_position.geom,
+    computation_method = old_label_point_position.computation_method::computation_method
+FROM old_label_point_position
+WHERE label_point.label_point_id = old_label_point_position.label_point_id;
+
+DROP TABLE old_label_point_position;

--- a/conf/evolutions/default/352.sql
+++ b/conf/evolutions/default/352.sql
@@ -9,11 +9,18 @@
 -- links. 'depth' rows hold positions measured from GSV depth data, better than any estimate, and are untouched.
 -- Rows without usable pano_data metadata keep 'approximation2', so computation_method stays honest about which
 -- estimator produced each stored position.
+--
+-- Not done here, and deliberately: label clusters are NOT invalidated. ClusteringSessionTable.getRegionsToCluster
+-- picks regions by comparing which labels *should* be clustered against which ones *are*, so moving a label the
+-- clusterer already knows about flags nothing, and neither the nightly ClusteringActor nor an admin /runClustering
+-- will revisit it (#4818 review). Forcing a full re-cluster means emptying clustering_session (cascades to cluster
+-- and cluster_label) so every region reads as unclustered -- but that also empties the clusters the Access Score and
+-- attribute APIs serve until each region is rebuilt, which is a deploy-time operator decision about a visible
+-- outage, not something an evolution should do to 54 schemas on its own. It is a rollout step, tracked on #4818.
 
 -- Backup of every row this evolution modifies, so the Down is a lossless restore-from-copy rather than a formula
 -- replay (179.sql precedent). computation_method is TEXT here so this table cannot block the enum rebuild below.
--- street_edge_id is captured for every backed-up label even though only AI-authored labels are reattached below,
--- keeping the restore envelope complete if a later sweep reattaches the rest (#4818 discussion).
+-- street_edge_id is captured for every backed-up label, since the reattachment below sweeps the whole population.
 CREATE TABLE old_label_point_position (
     label_point_id INT PRIMARY KEY REFERENCES label_point (label_point_id),
     label_id INT NOT NULL UNIQUE REFERENCES label (label_id),
@@ -127,12 +134,20 @@ WHERE label_point.label_point_id = new_positions.label_point_id;
 ALTER TABLE label_point
     ALTER COLUMN computation_method TYPE computation_method USING computation_method::computation_method;
 
--- Reattach AI-authored labels to the street nearest their corrected position. An AI label's street_edge_id was
--- chosen at submission time as the open street (tutorial included) nearest the estimated position
--- (ExploreService.submitAiLabelData -> LabelTable.getStreetEdgeIdClosestToLatLng), so it follows the position.
--- Human labels keep their street here pending the flip-rate measurement on #4818. The KNN prefilter narrows to 20
--- candidates by degree distance and the exact sphere distance picks among them, reproducing the app's uncapped
--- nearest-street ordering without a full per-label scan. The UUID is SidewalkUserTable.aiUserId.
+-- Reattach every backfilled label to the street nearest its corrected position. Both authorship paths pick
+-- street_edge_id at submission time as the open street (tutorial street included) nearest the *estimated* position --
+-- crowd labels since 8713a521e (Feb 2019) via ExploreService.insertLabel, AI labels via
+-- ExploreService.submitAiLabelData, both calling LabelTable.getStreetEdgeIdClosestToLatLng -- so the attachment
+-- follows the position for the whole population rather than the AI slice alone (#4818 review). Labels whose stored
+-- position was NULL are skipped: those took the audit task's own street at insert instead of a computed one, so
+-- their attachment never derived from the estimator and must not be replaced by a guess.
+--
+-- The exactness argument for the prefilter: PostGIS's <-> on geometry is planar distance in degrees, so it ranks by
+-- sqrt(dlat^2 + dlng^2) while the app ranks by true distance, which scales dlng by cos(latitude). A street can
+-- therefore only beat the degree-nearest one on the sphere if its degree distance is under 1/cos(latitude) times the
+-- minimum -- a factor of 2 at 60 degrees, past every deployed city. Fifty candidates is far more street edges than
+-- can pass within twice a label's nearest-street distance (metres to tens of metres) at any real street density, and
+-- the verifier's companion query re-derives every attachment with a ten-times-wider window (expect 0 disagreements).
 UPDATE label
 SET street_edge_id = nearest_street.street_edge_id
 FROM old_label_point_position
@@ -144,25 +159,26 @@ CROSS JOIN LATERAL (
         FROM street_edge
         WHERE street_edge.status = 'open'
         ORDER BY street_edge.geom <-> label_point.geom
-        LIMIT 20
+        LIMIT 50
     ) candidate_streets
     ORDER BY ST_DistanceSphere(candidate_streets.geom, label_point.geom)
     LIMIT 1
 ) nearest_street
 WHERE label.label_id = old_label_point_position.label_id
-    AND label.user_id = '51b0b927-3c8a-45b2-93de-bd878d1e5cf4'
+    AND old_label_point_position.lat IS NOT NULL
+    AND old_label_point_position.lng IS NOT NULL
     AND label.street_edge_id <> nearest_street.street_edge_id;
 
 # --- !Downs
 -- Restore every modified row byte-for-byte from the backup. Labels created after the Up ran are absent from the
--- backup and correctly keep their live-computed values. The AI-user filter mirrors the Up so a human label whose
--- street changed through app activity between Up and Down cannot be clobbered. The enum keeps all three values --
--- the running app writes 'approximation3', and 349.sql's Down already declines the rebuild removing a value takes.
+-- backup and correctly keep their live-computed values. label.street_edge_id is insert-only in the app (no code path
+-- updates it), so restoring the backed-up value cannot overwrite anything that happened between Up and Down. The
+-- inequality is only there to skip no-op rows. The enum keeps all three values -- the running app writes
+-- 'approximation3', and 349.sql's Down already declines the rebuild that removing a value would take.
 UPDATE label
 SET street_edge_id = old_label_point_position.street_edge_id
 FROM old_label_point_position
 WHERE label.label_id = old_label_point_position.label_id
-    AND label.user_id = '51b0b927-3c8a-45b2-93de-bd878d1e5cf4'
     AND label.street_edge_id <> old_label_point_position.street_edge_id;
 
 UPDATE label_point

--- a/conf/routes
+++ b/conf/routes
@@ -191,7 +191,7 @@ GET     /assets/*file                                   controllers.Assets.versi
 
 # Clustering
 GET     /clustering                                     controllers.ClusterController.index
-GET     /runClustering                                  controllers.ClusterController.runClustering()
+GET     /runClustering                                  controllers.ClusterController.runClustering(allRegions: Boolean ?= false)
 GET     /labelsToClusterInRegion                        controllers.ClusterController.getLabelsToClusterInRegion(regionId: Int)
 # Authenticated by the internal key (ControllerUtils.internalKeyValid), not a browser session.
 + nocsrf

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,9 @@
 [tool.pytest.ini_options]
 # Only collect the Python utility tests; keep pytest away from the Scala/JS test trees.
 testpaths = ["test/python"]
-# Put scripts/ on sys.path so tests can `import label_clustering` / `import check_streets_for_imagery` without packaging.
-pythonpath = ["scripts"]
+# Put scripts/ and tools/ on sys.path so tests can `import label_clustering` / `import verify_latlng_backfill`
+# without packaging.
+pythonpath = ["scripts", "tools"]
 python_files = ["test_*.py"]
 # Always measure correctness coverage of the scripts and fail the run if it regresses below the gate. Branch coverage
 # is on so both sides of every decision must be exercised, not just every line.

--- a/test/python/test_verify_latlng_backfill.py
+++ b/test/python/test_verify_latlng_backfill.py
@@ -1,0 +1,257 @@
+"""
+Unit tests for tools/verify_latlng_backfill.py, the #4818 backfill rollout-gate verifier.
+
+Covers the estimator transcription (pinned research fixtures, blend continuity, monotonicity, horizon flatness),
+the destination math (identity, direction, the deliberate no-antimeridian-wrap app parity), the row verifier
+(parity pass/fail, stamp and NULL checks, the failure cap, displacement stats), the fixture self-test's own
+failure detection, and `main` end-to-end via argv/CSV. The verifier is deliberately an independent transcription
+of PanoDataService/CommonUtils, so these tests pin it to the published research values the Scala spec pins
+(test/service/PanoDataServiceSpec.scala) rather than to the implementation under test.
+"""
+
+import csv
+import math
+
+import pytest
+
+import verify_latlng_backfill as vb
+
+
+def _row(pano_lat=47.6553, pano_lng=-122.3035, camera_heading=90.0, width=13312, height=6656,
+         x=6656, y=4160, label_point_id="1", **overrides):
+    """A synthetic export row whose stored values are the verifier's own recompute (parity delta exactly 0)."""
+    lat, lng = vb.to_lat_lng(pano_lat, pano_lng, x, y, width, height, camera_heading)
+    row = {
+        "label_point_id": label_point_id, "pano_lat": str(pano_lat), "pano_lng": str(pano_lng),
+        "camera_heading": str(camera_heading), "pano_width": str(width), "pano_height": str(height),
+        "pano_x": str(x), "pano_y": str(y), "new_lat": repr(lat), "new_lng": repr(lng),
+        "computation_method": "approximation3", "old_lat": str(pano_lat), "old_lng": str(pano_lng),
+    }
+    row.update(overrides)
+    return row
+
+
+# --------------------------------------------------------------------------------------------------------------------
+# estimate_distance_from_pano_m
+# --------------------------------------------------------------------------------------------------------------------
+
+@pytest.mark.parametrize("depression, expected", [
+    (45.0, 2.341219672825709), (15.0, 8.737550770665331), (30.0, 4.055111425013912), (60.0, 1.351703808337971),
+    (11.25, 11.770106120938644), (5.0, 18.480192309211834), (2.0, 21.701033679582963),
+    (0.0, 23.848261259830384), (-10.0, 23.848261259830384),
+])
+def test_distance_matches_pinned_research_values(depression, expected):
+    assert vb.estimate_distance_from_pano_m(depression) == pytest.approx(expected, abs=1e-9)
+
+
+def test_distance_blend_handoff_is_continuous():
+    at_blend = vb.estimate_distance_from_pano_m(vb.BLEND_DEG)
+    just_below = vb.estimate_distance_from_pano_m(vb.BLEND_DEG - 1e-9)
+    assert just_below == pytest.approx(at_blend, abs=1e-6)
+
+
+def test_distance_decreases_monotonically_with_depression():
+    distances = [vb.estimate_distance_from_pano_m(d) for d in range(-5, 86)]
+    assert all(steeper <= near_horizon for near_horizon, steeper in zip(distances, distances[1:]))
+
+
+def test_distance_is_flat_above_the_horizon():
+    assert vb.estimate_distance_from_pano_m(-90.0) == vb.estimate_distance_from_pano_m(0.0)
+
+
+# --------------------------------------------------------------------------------------------------------------------
+# calculate_destination / haversine_meters
+# --------------------------------------------------------------------------------------------------------------------
+
+def test_destination_zero_distance_is_identity():
+    # Not bit-exact: the degrees -> radians -> degrees round trip may differ by a ulp.
+    assert vb.calculate_destination(47.6553, -122.3035, 0.0, 123.4) == pytest.approx((47.6553, -122.3035), abs=1e-12)
+
+
+def test_destination_due_north_moves_only_latitude():
+    lat, lng = vb.calculate_destination(10.0, 20.0, 1.0, 0.0)
+    assert lat > 10.0
+    assert lng == pytest.approx(20.0, abs=1e-12)
+
+
+def test_destination_does_not_wrap_at_the_antimeridian():
+    # App parity, pinned deliberately: CommonUtils.calculateDestination leaves longitude unwrapped, and the SQL port
+    # matches it -- label_point's lat/lng CHECK constraint is the guard that makes an out-of-range value loud.
+    lat, lng = vb.calculate_destination(0.0, 179.9999, 20.0, 90.0)
+    assert lng > 180.0
+
+
+def test_haversine_zero_for_identical_points():
+    assert vb.haversine_meters(47.0, -122.0, 47.0, -122.0) == 0.0
+
+
+def test_haversine_round_trips_destination_distance():
+    lat, lng = vb.calculate_destination(47.6553, -122.3035, 0.0238, 33.0)
+    assert vb.haversine_meters(47.6553, -122.3035, lat, lng) == pytest.approx(23.8, abs=1e-6)
+
+
+# --------------------------------------------------------------------------------------------------------------------
+# to_lat_lng
+# --------------------------------------------------------------------------------------------------------------------
+
+def test_center_column_lands_along_the_camera_heading():
+    expected = vb.calculate_destination(47.6553, -122.3035, vb.estimate_distance_from_pano_m(22.5) / 1000.0, 90.0)
+    got = vb.to_lat_lng(47.6553, -122.3035, 6656, 4160, 13312, 6656, 90.0)
+    assert got == pytest.approx(expected, abs=1e-9)
+
+
+def test_quarter_width_bears_ninety_degrees_counter_clockwise():
+    expected = vb.calculate_destination(47.6553, -122.3035, vb.estimate_distance_from_pano_m(22.5) / 1000.0, 147.5)
+    got = vb.to_lat_lng(47.6553, -122.3035, 3328, 4160, 13312, 6656, 237.5)
+    assert got == pytest.approx(expected, abs=1e-9)
+
+
+def test_negative_bearing_equals_its_in_range_equivalent():
+    # An eighth across at heading 10 gives 10 - 180 + 45 = -125 degrees, whose in-range equivalent is 235.
+    expected = vb.calculate_destination(47.6553, -122.3035, vb.estimate_distance_from_pano_m(22.5) / 1000.0, 235.0)
+    got = vb.to_lat_lng(47.6553, -122.3035, 1664, 4160, 13312, 6656, 10.0)
+    assert got == pytest.approx(expected, abs=1e-9)
+
+
+def test_to_lat_lng_is_independent_of_panorama_resolution():
+    low = vb.to_lat_lng(47.6553, -122.3035, 1440, 1800, 5760, 2880, 237.5)
+    high = vb.to_lat_lng(47.6553, -122.3035, 3328, 4160, 13312, 6656, 237.5)
+    assert low == pytest.approx(high, abs=1e-9)
+
+
+# --------------------------------------------------------------------------------------------------------------------
+# quantile
+# --------------------------------------------------------------------------------------------------------------------
+
+def test_quantile_of_empty_list_is_nan():
+    assert math.isnan(vb.quantile([], 0.5))
+
+
+def test_quantile_single_element():
+    assert vb.quantile([7.0], 0.5) == 7.0
+    assert vb.quantile([7.0], 0.99) == 7.0
+
+
+def test_quantile_nearest_rank_on_known_list():
+    values = list(range(1, 101))
+    assert vb.quantile(values, 0.50) == 50
+    assert vb.quantile(values, 0.90) == 90
+    assert vb.quantile(values, 0.99) == 99
+
+
+# --------------------------------------------------------------------------------------------------------------------
+# self_test
+# --------------------------------------------------------------------------------------------------------------------
+
+def test_self_test_passes_with_shipped_constants():
+    assert vb.self_test() == []
+
+
+def test_self_test_detects_a_wrong_camera_height(monkeypatch):
+    # The self-test guards the transcription, so it must actually fail when a constant drifts from the research.
+    monkeypatch.setattr(vb, "CAMERA_HEIGHT_M", 2.6)
+    assert vb.self_test() != []
+
+
+# --------------------------------------------------------------------------------------------------------------------
+# verify_rows
+# --------------------------------------------------------------------------------------------------------------------
+
+def test_verify_rows_passes_on_faithful_rows():
+    stats, failures = vb.verify_rows([_row(label_point_id=str(i)) for i in range(1, 4)], eps=1e-9)
+    assert failures == []
+    assert stats["rows"] == 3
+    assert stats["max_delta_deg"] == 0.0
+    # old position is the pano itself, so displacement equals the estimated distance at 22.5 degrees depression.
+    assert stats["displacement_p50_m"] == pytest.approx(vb.estimate_distance_from_pano_m(22.5), abs=1e-6)
+
+
+def test_verify_rows_flags_a_wrong_stamp():
+    stats, failures = vb.verify_rows([_row(computation_method="approximation2")], eps=1e-9)
+    assert len(failures) == 1
+    assert "stamped" in failures[0]
+
+
+def test_verify_rows_flags_null_lat_lng():
+    stats, failures = vb.verify_rows([_row(new_lat="", new_lng="")], eps=1e-9)
+    assert len(failures) == 1
+    assert "NULL" in failures[0]
+
+
+def test_verify_rows_flags_a_value_beyond_eps():
+    good = _row()
+    bad = dict(good, new_lat=repr(float(good["new_lat"]) + 1e-6))
+    stats, failures = vb.verify_rows([bad], eps=1e-9)
+    assert len(failures) == 1
+    assert "delta" in failures[0]
+    assert stats["max_delta_deg"] == pytest.approx(1e-6, rel=1e-3)
+
+
+def test_verify_rows_caps_reported_failures_at_twenty():
+    rows = [_row(label_point_id=str(i), computation_method="depth") for i in range(25)]
+    stats, failures = vb.verify_rows(rows, eps=1e-9)
+    assert len(failures) == 20
+    assert stats["rows"] == 25
+
+
+def test_verify_rows_skips_displacement_when_old_position_is_missing():
+    stats, failures = vb.verify_rows([_row(old_lat="", old_lng="")], eps=1e-9)
+    assert failures == []
+    assert math.isnan(stats["displacement_p50_m"])
+
+
+# --------------------------------------------------------------------------------------------------------------------
+# main
+# --------------------------------------------------------------------------------------------------------------------
+
+def _write_csv(path, rows):
+    with open(path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def test_main_self_test_only_exits_zero(monkeypatch, capsys):
+    monkeypatch.setattr("sys.argv", ["verify_latlng_backfill.py", "--self-test-only"])
+    assert vb.main() == 0
+    assert "self-test: OK" in capsys.readouterr().out
+
+
+def test_main_passes_on_a_faithful_export(tmp_path, monkeypatch, capsys):
+    path = tmp_path / "rows.csv"
+    _write_csv(path, [_row(label_point_id=str(i)) for i in range(1, 6)])
+    monkeypatch.setattr("sys.argv", ["verify_latlng_backfill.py", str(path)])
+    assert vb.main() == 0
+    out = capsys.readouterr().out
+    assert "rows verified:      5" in out
+    assert "PASSED" in out
+
+
+def test_main_fails_on_a_corrupted_export(tmp_path, monkeypatch, capsys):
+    good = _row()
+    path = tmp_path / "rows.csv"
+    _write_csv(path, [dict(good, new_lng=repr(float(good["new_lng"]) + 0.001))])
+    monkeypatch.setattr("sys.argv", ["verify_latlng_backfill.py", str(path)])
+    assert vb.main() == 1
+    assert "FAILED" in capsys.readouterr().out
+
+
+def test_main_fails_on_an_empty_export(tmp_path, monkeypatch, capsys):
+    path = tmp_path / "rows.csv"
+    _write_csv(path, [_row()])
+    # Header only: rewrite with zero data rows.
+    with open(path, "w", newline="") as f:
+        csv.DictWriter(f, fieldnames=list(_row().keys())).writeheader()
+    monkeypatch.setattr("sys.argv", ["verify_latlng_backfill.py", str(path)])
+    assert vb.main() == 1
+    assert "no rows" in capsys.readouterr().out
+
+
+def test_main_reads_stdin_when_no_path_is_given(tmp_path, monkeypatch, capsys):
+    path = tmp_path / "rows.csv"
+    _write_csv(path, [_row()])
+    monkeypatch.setattr("sys.argv", ["verify_latlng_backfill.py"])
+    with open(path) as f:
+        monkeypatch.setattr("sys.stdin", f)
+        assert vb.main() == 0
+    assert "PASSED" in capsys.readouterr().out

--- a/test/service/ClusteringServiceSpec.scala
+++ b/test/service/ClusteringServiceSpec.scala
@@ -26,6 +26,10 @@ import scala.concurrent.duration._
  *      empty submission clears the region; other regions are untouched.
  *   2. getRegionsToCluster no longer deletes anything -> querying the to-cluster list leaves existing clusters intact.
  *
+ * Also covers the forced full rebuild that the #4818 position backfill needs: because the default selection compares
+ * label *membership*, a region whose labels merely moved is invisible to it, so allRegions = true must reach a region
+ * that is already consistent -- while still never dropping one the default selection would have picked.
+ *
  * Not covered here: the literal "a concurrent reader never observes the region empty mid-swap" guarantee. That follows
  * from Postgres MVCC plus the single-transaction delete+insert and is not deterministically reproducible in a unit test
  * (it would require racing a reader against the in-flight transaction); these tests instead pin the committed-state
@@ -181,11 +185,46 @@ class ClusteringServiceSpec extends PlaySpec with GuiceOneAppPerSuite {
             val totalBefore       = run(clusters.length.result)
             regionCountBefore mustBe 1
 
-            await(apiService.getRegionsToCluster)
+            await(apiService.getRegionsToCluster(allRegions = false))
 
             clusterCountForRegion(regionId) mustBe regionCountBefore
             run(clusters.length.result) mustBe totalBefore
           }
+      }
+    }
+  }
+
+  "ApiService.getRegionsToCluster(allRegions = true) (#4818)" should {
+    "return a region whose clusters are already up to date, which the default selection skips" in {
+      candidateRegion match {
+        case None => cancel("No region in the connected DB has clusterable labels; nothing to exercise.")
+        case Some((regionId, labels)) =>
+          withRegionRestored(regionId) {
+            // Make the region's clusters exactly consistent with its clusterable labels, which is what the default
+            // selection tests for. One cluster holding every label is enough: the mismatch query compares label ids,
+            // and it is the state a region is in whenever nothing has been labeled since the last clustering run.
+            val clusterSubs = Seq(ClusterSubmission(labels.head.labelType, 1, labels.head.lat, labels.head.lng, None))
+            val labelSubs   = labels.map(l => ClusteredLabelSubmission(l.labelId, l.labelType, 1))
+            await(apiService.submitClusteringResults(regionId, clusterSubs, labelSubs, Seq.empty))
+
+            // Moving those labels would not change this: membership is what the default selection reads, so a
+            // position backfill leaves the region invisible to it. Forcing the rebuild is the only way to reach it.
+            await(apiService.getRegionsToCluster(allRegions = false)) must not contain regionId
+            await(apiService.getRegionsToCluster(allRegions = true)) must contain(regionId)
+          }
+      }
+    }
+
+    "be a superset of the default selection, so forcing a rebuild can never skip pending work" in {
+      candidateRegion match {
+        case None                => cancel("No region in the connected DB has clusterable labels; nothing to exercise.")
+        case Some((regionId, _)) =>
+          val toCluster    = await(apiService.getRegionsToCluster(allRegions = false))
+          val allToCluster = await(apiService.getRegionsToCluster(allRegions = true))
+
+          allToCluster must contain(regionId) // Not vacuous: this region has clusterable labels.
+          allToCluster.distinct.length mustBe allToCluster.length
+          toCluster.toSet.subsetOf(allToCluster.toSet) mustBe true
       }
     }
   }

--- a/tools/verify_latlng_backfill.py
+++ b/tools/verify_latlng_backfill.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""Rollout-gate verifier for the #4818 backfill (evolution 352): recompute every backfilled label position
+independently and confirm the stored values match to float noise.
+
+The evolution ports PanoDataService.calculatePovFromPanoXY, PanoDataService.estimateDistanceFromPanoM, and
+CommonUtils.calculateDestination to SQL. This script carries its own transcription of the same math (deliberately a
+second, independent copy -- agreement between the two implementations on every row is the certification), plus the
+pinned research fixtures from test/service/PanoDataServiceSpec.scala as a self-test, so a transcription error here
+fails loudly before the script judges any database.
+
+Run it at every rollout stage (localhost -> test server -> production), per city schema:
+
+  1. Export the backfilled rows with the canonical COPY query below, running psql as the city's own role
+     (e.g. -U sidewalk_seattle) so unqualified table names resolve to that city's schema:
+
+       COPY (
+           SELECT label_point.label_point_id, pano_data.lat AS pano_lat, pano_data.lng AS pano_lng,
+                  pano_data.camera_heading, pano_data.width AS pano_width, pano_data.height AS pano_height,
+                  label_point.pano_x, label_point.pano_y, label_point.lat AS new_lat, label_point.lng AS new_lng,
+                  label_point.computation_method::text AS computation_method,
+                  old_label_point_position.lat AS old_lat, old_label_point_position.lng AS old_lng
+           FROM old_label_point_position
+           INNER JOIN label_point ON old_label_point_position.label_point_id = label_point.label_point_id
+           INNER JOIN label ON label_point.label_id = label.label_id
+           INNER JOIN pano_data ON label.pano_id = pano_data.pano_id
+       ) TO STDOUT WITH CSV HEADER
+
+     localhost:  docker exec projectsidewalk-db psql -U sidewalk_<city> -d sidewalk -c "COPY (...) TO STDOUT
+                 WITH CSV HEADER" > rows.csv
+     test/prod:  ssh <server> 'psql ... -c "COPY (...) TO STDOUT WITH CSV HEADER"' > rows.csv
+                 (the public v3 API cannot drive this -- it exposes neither computation_method nor the pano's
+                 own lat/lng)
+
+  2. python3 tools/verify_latlng_backfill.py rows.csv
+
+Companion invariants, run as psql one-liners alongside the parity check:
+
+  -- Every 'approximation2' row left behind is missing metadata (expect 0):
+  SELECT count(*) FROM label_point
+  INNER JOIN label ON label_point.label_id = label.label_id
+  INNER JOIN pano_data ON label.pano_id = pano_data.pano_id
+  WHERE label_point.computation_method = 'approximation2'
+      AND pano_data.lat IS NOT NULL AND pano_data.lng IS NOT NULL AND pano_data.camera_heading IS NOT NULL
+      AND pano_data.width IS NOT NULL AND pano_data.width > 0
+      AND pano_data.height IS NOT NULL AND pano_data.height > 0;
+
+  -- 'depth' rows untouched (compare to the pre-apply count):
+  SELECT count(*) FROM label_point WHERE computation_method = 'depth';
+
+  -- geom agrees with lat/lng on every backfilled row (expect 0):
+  SELECT count(*) FROM label_point
+  INNER JOIN old_label_point_position
+      ON label_point.label_point_id = old_label_point_position.label_point_id
+  WHERE ST_X(label_point.geom) IS DISTINCT FROM label_point.lng
+      OR ST_Y(label_point.geom) IS DISTINCT FROM label_point.lat;
+
+  -- Street-flip measurement for the human-label reattachment decision on #4818 (read-only):
+  SELECT count(*) FILTER (WHERE nearest_street.street_edge_id <> label.street_edge_id) AS flipped, count(*) AS total
+  FROM old_label_point_position
+  INNER JOIN label_point ON old_label_point_position.label_point_id = label_point.label_point_id
+  INNER JOIN label ON old_label_point_position.label_id = label.label_id
+  CROSS JOIN LATERAL (
+      SELECT candidate_streets.street_edge_id
+      FROM (
+          SELECT street_edge.street_edge_id, street_edge.geom
+          FROM street_edge
+          WHERE street_edge.status = 'open'
+          ORDER BY street_edge.geom <-> label_point.geom
+          LIMIT 20
+      ) candidate_streets
+      ORDER BY ST_DistanceSphere(candidate_streets.geom, label_point.geom)
+      LIMIT 1
+  ) nearest_street;
+"""
+
+import argparse
+import csv
+import math
+import sys
+
+# PanoDataService.LatLngEstimation and CommonUtils.EARTH_RADIUS_KM. A refit that changes the backend constants must
+# change these with them (and re-pin the fixtures below from the new research summary, as the Scala spec requires).
+CAMERA_HEIGHT_M = 2.341219672825709
+BLEND_DEG = 11.25
+MAX_DISTANCE_M = 50.0
+EARTH_RADIUS_KM = 6371.0
+
+
+def estimate_distance_from_pano_m(depression_deg):
+    """PanoDataService.estimateDistanceFromPanoM: saturating-cotangent blend on the single camera height.
+
+    @param depression_deg: Degrees below the horizon (negative when above it).
+    @return: Estimated distance in meters, bounded at the horizon's answer for any input.
+    """
+    blend_rad = math.radians(BLEND_DEG)
+    if depression_deg >= BLEND_DEG:
+        return CAMERA_HEIGHT_M / math.tan(math.radians(depression_deg))
+    tail_m = CAMERA_HEIGHT_M / math.tan(blend_rad) + \
+        CAMERA_HEIGHT_M * (math.pi / 180.0) / math.sin(blend_rad) ** 2 * \
+        (BLEND_DEG - max(depression_deg, 0.0))
+    return min(tail_m, MAX_DISTANCE_M)
+
+
+def calculate_destination(lat, lng, distance_km, bearing_deg):
+    """CommonUtils.calculateDestination: spherical (haversine) forward destination on R = 6371 km.
+
+    @return: (lat, lng) of the destination in degrees. Longitude is not wrapped into [-180, 180], same as the app.
+    """
+    lat1 = math.radians(lat)
+    lng1 = math.radians(lng)
+    bearing = math.radians(bearing_deg)
+    angular = distance_km / EARTH_RADIUS_KM
+    lat2 = math.asin(math.sin(lat1) * math.cos(angular) + math.cos(lat1) * math.sin(angular) * math.cos(bearing))
+    lng2 = lng1 + math.atan2(math.sin(bearing) * math.sin(angular) * math.cos(lat1),
+                             math.cos(angular) - math.sin(lat1) * math.sin(lat2))
+    return math.degrees(lat2), math.degrees(lng2)
+
+
+def to_lat_lng(pano_lat, pano_lng, pano_x, pano_y, pano_width, pano_height, camera_heading):
+    """PanoDataService.toLatLng: pixel position within the pano to an estimated label lat/lng.
+
+    math.fmod keeps the dividend's sign like Scala's %, so a westward heading can leave the bearing negative --
+    harmless, the destination formula is periodic.
+    """
+    bearing_deg = math.fmod(camera_heading - 180.0 + (pano_x / pano_width) * 360.0, 360.0)
+    depression_deg = 180.0 * pano_y / pano_height - 90.0
+    distance_m = estimate_distance_from_pano_m(depression_deg)
+    return calculate_destination(pano_lat, pano_lng, distance_m / 1000.0, bearing_deg)
+
+
+def haversine_meters(lat1, lng1, lat2, lng2):
+    """CommonUtils.haversineMeters: great-circle distance in meters, for displacement stats."""
+    d_lat = math.radians(lat2 - lat1)
+    d_lng = math.radians(lng2 - lng1)
+    a = math.sin(d_lat / 2) ** 2 + math.cos(math.radians(lat1)) * math.cos(math.radians(lat2)) * \
+        math.sin(d_lng / 2) ** 2
+    return 2 * EARTH_RADIUS_KM * 1000 * math.asin(math.sqrt(a))
+
+
+def self_test():
+    """Pin this script's transcription to the research fixtures in PanoDataServiceSpec before judging any data.
+
+    @return: List of failure descriptions, empty when the transcription is faithful.
+    """
+    eps = 1e-9
+    failures = []
+
+    # Distance fixtures, pinned from the label-latlng-estimation summaries (same values the Scala spec pins).
+    pinned = [(45.0, 2.341219672825709), (15.0, 8.737550770665331), (30.0, 4.055111425013912),
+              (60.0, 1.351703808337971), (11.25, 11.770106120938644), (5.0, 18.480192309211834),
+              (2.0, 21.701033679582963), (0.0, 23.848261259830384), (-10.0, 23.848261259830384)]
+    for depression, expected in pinned:
+        got = estimate_distance_from_pano_m(depression)
+        if abs(got - expected) > eps:
+            failures.append(f"distance({depression}) = {got!r}, pinned {expected!r}")
+
+    # A label on the pano's center column lands along the camera heading.
+    expected = calculate_destination(47.6553, -122.3035, estimate_distance_from_pano_m(22.5) / 1000.0, 90.0)
+    got = to_lat_lng(47.6553, -122.3035, 6656, 4160, 13312, 6656, 90.0)
+    if max(abs(got[0] - expected[0]), abs(got[1] - expected[1])) > eps:
+        failures.append(f"center-column fixture: {got!r} != {expected!r}")
+
+    # A quarter of the way across the pano bears 90 degrees counter-clockwise of the camera heading.
+    expected = calculate_destination(47.6553, -122.3035, estimate_distance_from_pano_m(22.5) / 1000.0, 147.5)
+    got = to_lat_lng(47.6553, -122.3035, 3328, 4160, 13312, 6656, 237.5)
+    if max(abs(got[0] - expected[0]), abs(got[1] - expected[1])) > eps:
+        failures.append(f"quarter-width fixture: {got!r} != {expected!r}")
+
+    # A negative bearing lands where its in-range equivalent does (-125 vs 235 for an eighth across at heading 10).
+    expected = calculate_destination(47.6553, -122.3035, estimate_distance_from_pano_m(22.5) / 1000.0, 235.0)
+    got = to_lat_lng(47.6553, -122.3035, 1664, 4160, 13312, 6656, 10.0)
+    if max(abs(got[0] - expected[0]), abs(got[1] - expected[1])) > eps:
+        failures.append(f"negative-bearing fixture: {got!r} != {expected!r}")
+
+    # Resolution independence (#4765): proportional pixel coordinates at two native resolutions agree.
+    low = to_lat_lng(47.6553, -122.3035, 1440, 1800, 5760, 2880, 237.5)
+    high = to_lat_lng(47.6553, -122.3035, 3328, 4160, 13312, 6656, 237.5)
+    if max(abs(low[0] - high[0]), abs(low[1] - high[1])) > eps:
+        failures.append(f"resolution-independence fixture: {low!r} != {high!r}")
+
+    return failures
+
+
+def quantile(sorted_values, q):
+    """Nearest-rank quantile over an already-sorted list, empty-safe."""
+    if not sorted_values:
+        return float("nan")
+    index = min(len(sorted_values) - 1, max(0, math.ceil(q * len(sorted_values)) - 1))
+    return sorted_values[index]
+
+
+def verify_rows(reader, eps):
+    """Recompute every exported row and compare against the stored values.
+
+    @param reader: csv.DictReader over the canonical COPY export.
+    @param eps:    Max tolerated |difference| in degrees on either axis (float-noise scale, not perceptual).
+    @return: (stats dict, list of failure descriptions capped at 20).
+    """
+    failures = []
+    total = 0
+    max_delta_deg = 0.0
+    displacements_m = []
+
+    for row in reader:
+        total += 1
+        expected_lat, expected_lng = to_lat_lng(
+            float(row["pano_lat"]), float(row["pano_lng"]), int(row["pano_x"]), int(row["pano_y"]),
+            int(row["pano_width"]), int(row["pano_height"]), float(row["camera_heading"]))
+        if row["computation_method"] != "approximation3":
+            if len(failures) < 20:
+                failures.append(f"label_point {row['label_point_id']}: stamped {row['computation_method']!r}")
+            continue
+        if row["new_lat"] == "" or row["new_lng"] == "":
+            if len(failures) < 20:
+                failures.append(f"label_point {row['label_point_id']}: NULL lat/lng after backfill")
+            continue
+        delta = max(abs(float(row["new_lat"]) - expected_lat), abs(float(row["new_lng"]) - expected_lng))
+        max_delta_deg = max(max_delta_deg, delta)
+        if delta > eps:
+            if len(failures) < 20:
+                failures.append(f"label_point {row['label_point_id']}: stored ({row['new_lat']}, {row['new_lng']}), "
+                                f"recomputed ({expected_lat!r}, {expected_lng!r}), delta {delta:.3e} deg")
+        if row["old_lat"] != "" and row["old_lng"] != "":
+            displacements_m.append(haversine_meters(
+                float(row["old_lat"]), float(row["old_lng"]), float(row["new_lat"]), float(row["new_lng"])))
+
+    displacements_m.sort()
+    stats = {
+        "rows": total,
+        "max_delta_deg": max_delta_deg,
+        "displacement_p50_m": quantile(displacements_m, 0.50),
+        "displacement_p90_m": quantile(displacements_m, 0.90),
+        "displacement_p99_m": quantile(displacements_m, 0.99),
+        "displacement_max_m": displacements_m[-1] if displacements_m else float("nan"),
+    }
+    return stats, failures
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Verify the #4818 lat/lng backfill (see module docstring).")
+    parser.add_argument("csv_path", nargs="?", help="CSV from the canonical COPY query. Omit to read stdin.")
+    parser.add_argument("--eps", type=float, default=1e-9,
+                        help="Max tolerated |delta| in degrees per axis (default 1e-9, about 0.1 mm).")
+    parser.add_argument("--self-test-only", action="store_true", help="Run the fixture self-test and exit.")
+    args = parser.parse_args()
+
+    self_test_failures = self_test()
+    if self_test_failures:
+        print("SELF-TEST FAILED -- this script's transcription is wrong, no data was judged:")
+        for failure in self_test_failures:
+            print(f"  {failure}")
+        return 1
+    print("self-test: OK (9 pinned distances, 4 toLatLng fixtures)")
+    if args.self_test_only:
+        return 0
+
+    source = open(args.csv_path, newline="") if args.csv_path else sys.stdin
+    try:
+        stats, failures = verify_rows(csv.DictReader(source), args.eps)
+    finally:
+        if args.csv_path:
+            source.close()
+
+    print(f"rows verified:      {stats['rows']}")
+    print(f"max |delta|:        {stats['max_delta_deg']:.3e} deg (eps {args.eps:.1e})")
+    print(f"displacement p50:   {stats['displacement_p50_m']:.3f} m")
+    print(f"displacement p90:   {stats['displacement_p90_m']:.3f} m")
+    print(f"displacement p99:   {stats['displacement_p99_m']:.3f} m")
+    print(f"displacement max:   {stats['displacement_max_m']:.3f} m")
+
+    if failures:
+        print(f"\nFAILED -- {len(failures)} shown (cap 20):")
+        for failure in failures:
+            print(f"  {failure}")
+        return 1
+    if stats["rows"] == 0:
+        print("\nFAILED -- no rows in the export (wrong schema, or the evolution has not applied)")
+        return 1
+    print("\nPASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/verify_latlng_backfill.py
+++ b/tools/verify_latlng_backfill.py
@@ -54,8 +54,9 @@ Companion invariants, run as psql one-liners alongside the parity check:
   WHERE ST_X(label_point.geom) IS DISTINCT FROM label_point.lng
       OR ST_Y(label_point.geom) IS DISTINCT FROM label_point.lat;
 
-  -- Street-flip measurement for the human-label reattachment decision on #4818 (read-only):
-  SELECT count(*) FILTER (WHERE nearest_street.street_edge_id <> label.street_edge_id) AS flipped, count(*) AS total
+  -- Every repositioned label hangs off its nearest open street (expect 0). The candidate window here is ten times
+  -- the evolution's, so a disagreement would also be the first evidence that fifty candidates is too few:
+  SELECT count(*)
   FROM old_label_point_position
   INNER JOIN label_point ON old_label_point_position.label_point_id = label_point.label_point_id
   INNER JOIN label ON old_label_point_position.label_id = label.label_id
@@ -66,11 +67,20 @@ Companion invariants, run as psql one-liners alongside the parity check:
           FROM street_edge
           WHERE street_edge.status = 'open'
           ORDER BY street_edge.geom <-> label_point.geom
-          LIMIT 20
+          LIMIT 500
       ) candidate_streets
       ORDER BY ST_DistanceSphere(candidate_streets.geom, label_point.geom)
       LIMIT 1
-  ) nearest_street;
+  ) nearest_street
+  WHERE old_label_point_position.lat IS NOT NULL AND old_label_point_position.lng IS NOT NULL
+      AND label.street_edge_id <> nearest_street.street_edge_id;
+
+  -- How many labels the reattachment moved, for the record (labels cluster at intersections, where streets are near
+  -- equidistant, so a flip rate around 10% is expected rather than alarming):
+  SELECT count(*) FILTER (WHERE label.street_edge_id <> old_label_point_position.street_edge_id) AS reattached,
+         count(*) AS total
+  FROM old_label_point_position
+  INNER JOIN label ON old_label_point_position.label_id = label.label_id;
 """
 
 import argparse


### PR DESCRIPTION
Closes #4818.

`approximation3` (#4765/#4766, PR #4819) applies at insert time, so every stored `approximation2` position — 1.38M rows across 54 production schemas — still sits where the 2021 linear model put it, about a metre of median error away. This recomputes them.

## What ships

**`conf/evolutions/default/352.sql`** — one evolution per schema:

1. Copies every row it will touch into `old_label_point_position` (`label_point` position + `computation_method` + the label's `street_edge_id`), so the Down is a lossless restore rather than a formula replay (179.sql precedent).
2. **Rebuilds the `computation_method` enum** rather than using the value 349.sql added. Evolutions share one transaction (`autocommit=false`), so on any database where 349 is still pending — a dev DB, CI, a fresh clone — naming `'approximation3'` would fail with *unsafe use of new value*. A type created inside the current transaction carries no such restriction (342.sql mechanics, mandated by 349.sql's own comment).
3. Recomputes `lat`/`lng`/`geom` in one CTE `UPDATE` that is a statement-for-statement port of `PanoDataService.calculatePovFromPanoXY`, `estimateDistanceFromPanoM`, and `CommonUtils.calculateDestination` — spherical haversine on R = 6371 km, matching the app bit-for-bit rather than the geodesic `ST_Project`. Every fitted constant appears exactly once, so a future height refit re-runs the same `UPDATE` as a later evolution with one changed literal.
4. Stamps the rows `approximation3`, and **reattaches every repositioned label to the street nearest its corrected position**. Both authorship paths choose `street_edge_id` at submission time as the nearest open street to the *estimated* position (`ExploreService.insertLabel` since Feb 2019, `submitAiLabelData` for AI labels), so the attachment follows the position for the whole population. After this runs, every label's `street_edge_id` is exactly what today's code would compute for its current position.

Rows the estimator can't reach — no usable `pano_data` metadata — honestly keep `approximation2`; `depth` rows are never touched.

**`allRegions` on `/runClustering`** — clustering picks regions by diffing *which labels should be clustered* against *which are*, so labels that merely moved flag nothing and neither the nightly actor nor a manual run would revisit them. Truncating `clustering_session` would force it, but leaves every city's Access Score and attribute API empty until its regions rebuild — the exact window #2507's per-region atomic swap removed. Instead: `/runClustering?allRegions=true` plus a checkbox on the admin clustering page, feeding the same per-region pipeline so each region keeps serving its existing clusters until its replacement commits. Superset of the normal selection by construction.

**`tools/verify_latlng_backfill.py`** — stdlib-only independent recompute of every backfilled row, self-tested against `PanoDataServiceSpec`'s pinned research fixtures before it judges any data. This is the gate at each rollout stage, fed by a `psql COPY` export (the v3 API can't drive it — no `computation_method`, no pano lat/lng). 29 unit tests in `test/python/`.

## Verification

Dry-runs applied the pending evolutions in one transaction per schema and rolled back, so numbers come from the real data:

| | teaneck (351→352) | seattle (347→352) |
|---|---:|---:|
| repositioned → `approximation3` | 22,766 | 197,330 |
| left at `approximation2` (no usable metadata) | 1,238 | 499 |
| `depth` rows (untouched) | 8 | 120,094 |
| reattached to a different street | 1,439 (6.3%) | 21,329 (10.8%) |
| …of those, landing in a different region | 307 | 1,615 |
| independent recompute vs stored | 1.4e-14° | 2.8e-14° |
| displacement p50 / p90 | 0.75 / 2.9 m | 2.0 / 3.9 m |
| 352 wall-clock | 8.7 s | 96 s |

Invariants checked on both schemas, all clean: no `approximation2` row with usable metadata left behind; `geom` agrees with `lat`/`lng` everywhere; every new position within 23.8483 m of its pano (the estimator's structural bound, hit exactly); nearest-street re-derived with a **ten-times-wider** candidate window disagrees on **0** rows; zero rows skipped for a missing stored position.

**The Down is byte-identical.** md5 over all of `label_point` *and* over every `(label_id, street_edge_id)` pair is unchanged across a full Up→Down cycle on both schemas — 21,329 reattachments included.

**The enum landmine is tested for real.** The local seattle schema sits at 346, so the dry-run applied 347→352 in a single transaction — 349's `ADD VALUE` and 352's use of that value together, the scenario 349 warned about. Clean, because 352 rebuilds the type. The teaneck schema (at 350) additionally had 351+352 applied end-to-end by a booting Play app, not by hand.

Also green: full Scala suite, evolution lint, htmlhint, scalafmt.

## Rollout

Per stage (localhost → test → prod), per city: export with the `COPY` in the verifier's docstring, run `verify_latlng_backfill.py`, then run clustering with **Re-cluster every region** checked so clusters and Access Scores pick up the moved positions.

`old_label_point_position` stays in each schema for now (#4818 discussion) — a later cleanup evolution can drop it.

## Notes for review

- **Evolution number**: 352 is free on develop today, but #4800 and #4649 both still claim 348 (taken). Whichever of us merges second renumbers.
- **Mapillary per-rig heights** are deliberately *not* applied here: only two rigs have measured absolute heights (clovis 2.297 m, richmond 2.407 m), only one of those is a deployed city, the four measured GSV runs span a wider range than those two sit apart, and all six carry the same unresolved δ that label-latlng-estimation#7's scale question would move by ~0.32 m. The live app applies the flat height to every city, so per-rig stored positions would be permanently out of step with new labels in the same city. The order is: app gains a per-city height → this re-runs with per-city literals.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-opus-5[1m])
