### PR TITLE
Fix inverted max/min in nightly pano expiry sampling; always re-check some expired panos

### DIFF
--- a/app/models/pano/PanoDataTable.scala
+++ b/app/models/pano/PanoDataTable.scala
@@ -186,18 +186,17 @@ class PanoDataTable @Inject() (protected val dbConfigProvider: DatabaseConfigPro
    * @param expired Whether to check for expired or unexpired panos.
    */
   def getPanoIdsToCheckExpiration(n: Int, expired: Boolean): DBIO[Seq[String]] = {
+    // A semi-join (exists) rather than a join: a join's DISTINCT would force a subquery whose ORDER BY Postgres is
+    // free to discard, breaking the least-recently-checked-first contract.
     panoDataRecords
-      .join(labelTable)
-      .on(_.panoId === _.panoId)
-      .filter(gsv =>
-        gsv._1.source === PanoSource.Gsv
-          && gsv._1.expired === expired
-          && gsv._1.lastChecked < OffsetDateTime.now().minusMonths(3)
+      .filter(pano =>
+        pano.source === PanoSource.Gsv
+          && pano.expired === expired
+          && pano.lastChecked < OffsetDateTime.now().minusMonths(3)
+          && labelTable.filter(_.panoId === pano.panoId).exists
       )
-      .sortBy(_._1.lastChecked.asc)
-      .subquery
-      .map(_._1.panoId)
-      .distinct
+      .sortBy(_.lastChecked.asc)
+      .map(_.panoId)
       .take(n)
       .result
   }

--- a/app/models/pano/PanoDataTable.scala
+++ b/app/models/pano/PanoDataTable.scala
@@ -179,7 +179,7 @@ class PanoDataTable @Inject() (protected val dbConfigProvider: DatabaseConfigPro
   }
 
   /**
-   * Get a list of n least recently checked pano ids that have not been viewed in the last 3 months.
+   * Get a list of n least recently checked pano ids that have not been checked in the last 3 months.
    *
    * Note: only getting panos from GSV for now; we haven't set up imagery checking for other sources yet
    * @param n Number of least recently checked panos to return.

--- a/app/models/pano/PanoDataTable.scala
+++ b/app/models/pano/PanoDataTable.scala
@@ -186,17 +186,21 @@ class PanoDataTable @Inject() (protected val dbConfigProvider: DatabaseConfigPro
    * @param expired Whether to check for expired or unexpired panos.
    */
   def getPanoIdsToCheckExpiration(n: Int, expired: Boolean): DBIO[Seq[String]] = {
-    // A semi-join (exists) rather than a join: a join's DISTINCT would force a subquery whose ORDER BY Postgres is
-    // free to discard, breaking the least-recently-checked-first contract.
+    // Dedup on (pano_id, last_checked) pairs — equivalent to deduping pano_id alone, since both come from the same
+    // pano_data row — so that the sort sits at/above the DISTINCT. An ORDER BY buried in a subquery below a DISTINCT
+    // is one Postgres is free to discard, which would break the least-recently-checked-first contract.
     panoDataRecords
-      .filter(pano =>
-        pano.source === PanoSource.Gsv
-          && pano.expired === expired
-          && pano.lastChecked < OffsetDateTime.now().minusMonths(3)
-          && labelTable.filter(_.panoId === pano.panoId).exists
+      .join(labelTable)
+      .on(_.panoId === _.panoId)
+      .filter(gsv =>
+        gsv._1.source === PanoSource.Gsv
+          && gsv._1.expired === expired
+          && gsv._1.lastChecked < OffsetDateTime.now().minusMonths(3)
       )
-      .sortBy(_.lastChecked.asc)
-      .map(_.panoId)
+      .map(gsv => (gsv._1.panoId, gsv._1.lastChecked))
+      .distinct
+      .sortBy(_._2.asc)
+      .map(_._1)
       .take(n)
       .result
   }

--- a/app/service/PanoDataService.scala
+++ b/app/service/PanoDataService.scala
@@ -518,27 +518,28 @@ class PanoDataServiceImpl @Inject() (
    * Checks if panos are expired on a nightly basis. Called from CheckImageExpiryActor.scala.
    *
    * Get as many as 5% of the panos with labels on them, or 5000, whichever is smaller. Check if the panos are expired
-   * and update the database accordingly. If there aren't enough of those remaining that haven't been checked in the
-   * last 3 months, check up to 2.5% or 2500 (whichever is smaller) of the panos that are already marked as expired to
-   * make sure that they weren't marked so incorrectly.
+   * and update the database accordingly. Also re-check panos that are already marked as expired to make sure that they
+   * weren't marked so incorrectly: at least `minExpiredPanosToCheck` every night, plus any capacity (up to 2.5% or
+   * 2500, whichever is smaller) left unused by the unexpired check.
    */
   def checkForImagery: Future[String] = {
+    // Nightly floor of expired panos to re-verify even when the unexpired queue fills the whole sample, so that
+    // re-verification of expired panos always makes some progress (#4638).
+    val minExpiredPanosToCheck: Int = 100
     db.run(
       for {
-        // Choose a bunch of panos that haven't been checked in the past 6 months to check.
+        // Choose a bunch of panos that haven't been checked in the past 3 months to check.
         nPanos: Int <- panoDataTable.countGsvPanosWithLabels
-        nUnexpiredPanosToCheck: Int = Math.max(5000, Math.min(100, 0.05 * nPanos).toInt)
+        nUnexpiredPanosToCheck: Int = Math.min(5000, (0.05 * nPanos).toInt)
         panoIdsToCheck: Seq[String] <- panoDataTable
           .getPanoIdsToCheckExpiration(nUnexpiredPanosToCheck, expired = false)
         _ = logger.info(s"Checking ${panoIdsToCheck.length} unexpired panos.")
 
-        // Choose a few panos that are already marked as expired to double-check.
-        nExpiredPanosToCheck: Int = Math.max(2500, Math.min(50, 0.025 * nPanos).toInt)
+        // Choose some panos that are already marked as expired to double-check.
+        nExpiredPanosToCheck: Int =
+          Math.max(minExpiredPanosToCheck, Math.min(2500, (0.025 * nPanos).toInt) - panoIdsToCheck.length)
         expiredPanoIdsToCheck: Seq[String] <-
-          if (panoIdsToCheck.length < nExpiredPanosToCheck) {
-            val nRemainingExpiredPanosToCheck: Int = nExpiredPanosToCheck - panoIdsToCheck.length
-            panoDataTable.getPanoIdsToCheckExpiration(nRemainingExpiredPanosToCheck, expired = true)
-          } else DBIO.successful(Seq())
+          panoDataTable.getPanoIdsToCheckExpiration(nExpiredPanosToCheck, expired = true)
       } yield {
         logger.info(s"Checking ${expiredPanoIdsToCheck.length} expired panos.")
 

--- a/app/service/PanoDataService.scala
+++ b/app/service/PanoDataService.scala
@@ -517,27 +517,28 @@ class PanoDataServiceImpl @Inject() (
   /**
    * Checks if panos are expired on a nightly basis. Called from CheckImageExpiryActor.scala.
    *
-   * Get as many as 5% of the panos with labels on them, or 5000, whichever is smaller. Check if the panos are expired
-   * and update the database accordingly. Also re-check panos that are already marked as expired to make sure that they
-   * weren't marked so incorrectly: at least `minExpiredPanosToCheck` every night, plus any capacity (up to 2.5% or
-   * 2500, whichever is smaller) left unused by the unexpired check.
+   * Get as many as 5% of the panos with labels on them, or 5000, whichever is smaller (but at least
+   * `minPanosToCheck`). Check if the panos are expired and update the database accordingly. Also re-check panos that
+   * are already marked as expired to make sure that they weren't marked so incorrectly: a budget of 2.5% or 2500
+   * (whichever is smaller) minus the number of unexpired panos checked, but at least `minPanosToCheck`.
    */
   def checkForImagery: Future[String] = {
-    // Nightly floor of expired panos to re-verify even when the unexpired queue fills the whole sample, so that
-    // re-verification of expired panos always makes some progress (#4638).
-    val minExpiredPanosToCheck: Int = 100
+    // Nightly floor for both sample sizes, so that checking always makes some progress: the percentage-based sizes
+    // round to 0 on small corpora, and the expired budget zeroes out on nights when the unexpired queue is full.
+    // getPanoIdsToCheckExpiration's take(n) caps at the stale pool, so the floor never overshoots (#4638).
+    val minPanosToCheck: Int = 100
     db.run(
       for {
         // Choose a bunch of panos that haven't been checked in the past 3 months to check.
         nPanos: Int <- panoDataTable.countGsvPanosWithLabels
-        nUnexpiredPanosToCheck: Int = Math.min(5000, (0.05 * nPanos).toInt)
+        nUnexpiredPanosToCheck: Int = Math.max(minPanosToCheck, Math.min(5000, (0.05 * nPanos).toInt))
         panoIdsToCheck: Seq[String] <- panoDataTable
           .getPanoIdsToCheckExpiration(nUnexpiredPanosToCheck, expired = false)
         _ = logger.info(s"Checking ${panoIdsToCheck.length} unexpired panos.")
 
         // Choose some panos that are already marked as expired to double-check.
         nExpiredPanosToCheck: Int =
-          Math.max(minExpiredPanosToCheck, Math.min(2500, (0.025 * nPanos).toInt) - panoIdsToCheck.length)
+          Math.max(minPanosToCheck, Math.min(2500, (0.025 * nPanos).toInt) - panoIdsToCheck.length)
         expiredPanoIdsToCheck: Seq[String] <-
           panoDataTable.getPanoIdsToCheckExpiration(nExpiredPanosToCheck, expired = true)
       } yield {


### PR DESCRIPTION
resolves #4638

## What this does

**Fixes the inverted `max`/`min` in the nightly expiry sampling** (`PanoDataService.checkForImagery`). The inner `Math.min(100, ...)` / `Math.min(50, ...)` made both sample sizes constants (always 5000 and 2500) and `nPanos` dead. The sizes now match the docstring:

```scala
nUnexpiredPanosToCheck: Int = Math.max(minPanosToCheck, Math.min(5000, (0.05 * nPanos).toInt))
```

**Guarantees nightly progress on both sides.** Both sample sizes get a shared floor of 100 (`minPanosToCheck`): the percentage-based sizes round to 0 on corpora under ~20 panos, and the expired budget zeroes out on nights when the unexpired queue fills the whole sample. The expired sample is `max(100, min(2500, 2.5%) - unexpiredChecked)` — the budget-minus-checked formula acting as a total-nightly-load limiter. This makes the conditional around the expired query unnecessary, so it's dropped; `getPanoIdsToCheckExpiration`'s `.take(n)` already handles a smaller-than-requested pool, which is also why the floor never overshoots on tiny cities.

**Makes `getPanoIdsToCheckExpiration` honor its least-recently-checked-first contract.** The query dedups on `(pano_id, last_checked)` pairs (equivalent to deduping `pano_id` alone, since both come from the same row) so the `ORDER BY` sits above the `DISTINCT` instead of buried in a subquery Postgres is free to discard — the plan becomes Sort → Unique → Limit, so ordering survives to the `LIMIT` structurally. Costs the same as the buried-sort form (54ms vs 52ms on the Chicago dev schema, 263k panos) where an `exists` semi-join measured 2x that.

**Fixes two stale comments** that disagreed with the 3-month `last_checked` filter in `getPanoIdsToCheckExpiration`: one saying "6 months", one saying "viewed".

## Notes

- The nightly check remains GSV-only; Mapillary is tracked separately in #4862.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
