### PR TITLE
Save pano metadata atomically with each label to stop orphaned pano_ids

### DIFF
--- a/app/controllers/AiController.scala
+++ b/app/controllers/AiController.scala
@@ -49,8 +49,12 @@ class AiController @Inject() (
         errors => { Future.successful(BadRequest(Json.obj("status" -> "Error", "message" -> JsError.toJson(errors)))) },
         submission => {
           if (configService.getAiLabelSubmissionEnabled) {
-            exploreService.savePanoInfo(Seq(submission.pano)).flatMap { _ =>
-              exploreService.submitAiLabelData(submission).map(_ => Ok("success!"))
+            exploreService.savePanoInfo(Seq(submission.pano)).flatMap {
+              case true  => exploreService.submitAiLabelData(submission).map(_ => Ok("success!"))
+              case false =>
+                Future.successful(
+                  InternalServerError(Json.obj("status" -> "Error", "message" -> "Failed to save pano metadata."))
+                )
             }
           } else {
             Future.successful(BadRequest("AI label submission is not enabled for this city."))

--- a/app/controllers/AiController.scala
+++ b/app/controllers/AiController.scala
@@ -49,13 +49,13 @@ class AiController @Inject() (
         errors => { Future.successful(BadRequest(Json.obj("status" -> "Error", "message" -> JsError.toJson(errors)))) },
         submission => {
           if (configService.getAiLabelSubmissionEnabled) {
-            exploreService.savePanoInfo(Seq(submission.pano)).flatMap {
-              case true  => exploreService.submitAiLabelData(submission).map(_ => Ok("success!"))
-              case false =>
-                Future.successful(
-                  InternalServerError(Json.obj("status" -> "Error", "message" -> "Failed to save pano metadata."))
-                )
-            }
+            exploreService
+              .submitAiLabelData(submission)
+              .map(_ => Ok("success!"))
+              .recover { case e =>
+                logger.error("AI label submission failed; nothing from it was saved.", e)
+                InternalServerError(Json.obj("status" -> "Error", "message" -> "Failed to save AI label data."))
+              }
           } else {
             Future.successful(BadRequest("AI label submission is not enabled for this city."))
           }

--- a/app/controllers/ExploreController.scala
+++ b/app/controllers/ExploreController.scala
@@ -262,22 +262,22 @@ class ExploreController @Inject() (
     val currTime: OffsetDateTime = data.timestamp
 
     // First do all the important stuff that needs to be done synchronously.
-    val response: Future[Result] =
-      exploreService.submitExploreData(data, user.userId).map { returnData: ExploreTaskPostReturnValue =>
+    val response: Future[Result] = exploreService
+      .savePanoInfo(data.panos)
+      .flatMap(_ => exploreService.submitExploreData(data, user.userId))
+      .map { returnData: ExploreTaskPostReturnValue =>
         // Now we do all the stuff that can be done async, we can return the response before these are done.
-        // TODO we should catch any errors from these submissions and log them.
-
-        // Insert pano metadata async.
-        // TODO would make sense to do this before submitting labels, then label table can have foreign key on pano_id.
-        exploreService.savePanoInfo(data.panos)
 
         // Insert environment async.
         val env: EnvironmentSubmission = data.environment
-        exploreService.insertEnvironment(
-          AuditTaskEnvironment(0, returnData.auditTaskId, missionId, env.browser, env.browserVersion, env.browserWidth,
-            env.browserHeight, env.availWidth, env.availHeight, env.screenWidth, env.screenHeight, env.operatingSystem,
-            Some(ipAddress), env.language, env.cssZoom, Some(currTime))
-        )
+        exploreService
+          .insertEnvironment(
+            AuditTaskEnvironment(0, returnData.auditTaskId, missionId, env.browser, env.browserVersion,
+              env.browserWidth, env.browserHeight, env.availWidth, env.availHeight, env.screenWidth, env.screenHeight,
+              env.operatingSystem, Some(ipAddress), env.language, env.cssZoom, Some(currTime))
+          )
+          .failed
+          .foreach(e => logger.error("Error saving explore environment data.", e))
 
         // Insert interactions async, send time spent auditing to scistarter (which uses the interactions table).
         exploreService
@@ -310,8 +310,12 @@ class ExploreController @Inject() (
                 .flatMap { timeSpent: Double =>
                   configService.sendSciStarterContributions(user.email, returnData.newLabels.length, timeSpent)
                 }
+                .failed
+                .foreach(e => logger.error("Error sending contributions to SciStarter.", e))
             }
           }
+          .failed
+          .foreach(e => logger.error("Error saving explore interaction data.", e))
 
         // Return the final result.
         Ok(
@@ -325,6 +329,12 @@ class ExploreController @Inject() (
             "refresh_page" -> returnData.refreshPage // If we notice something out of whack, tell front-end to refresh.
           )
         )
+      }
+      .recover { case e =>
+        // submitExploreData is transactional, so a failure here (including a label's integral pano write, #4587)
+        // means none of the submission was saved.
+        logger.error("Explore submission failed; nothing from it was saved.", e)
+        InternalServerError(Json.obj("status" -> "Error", "message" -> "Failed to save submitted data."))
       }
     response
   }

--- a/app/controllers/ExploreController.scala
+++ b/app/controllers/ExploreController.scala
@@ -22,7 +22,7 @@ import service.ExploreTaskPostReturnValue
 import java.time.OffsetDateTime
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success}
+import scala.util.{Failure, Success, Try}
 
 @Singleton
 class ExploreController @Inject() (
@@ -261,80 +261,89 @@ class ExploreController @Inject() (
     val missionId: Int           = data.missionProgress.missionId
     val currTime: OffsetDateTime = data.timestamp
 
+    // Save metadata for panos merely viewed this session, off the request's critical path (failures are logged inside
+    // savePanoInfo and cost nothing else). Panos carried by a label are excluded: submitExploreData commits those
+    // atomically with their labels (#4587), so writing them here too would just double the statements.
+    val labeledPanoIds: Set[String] = data.labels.flatMap(_.pano).map(_.panoId).toSet
+    val _ = exploreService.savePanoInfo(data.panos.filterNot(p => labeledPanoIds.contains(p.panoId)))
+
     // First do all the important stuff that needs to be done synchronously.
     val response: Future[Result] = exploreService
-      .savePanoInfo(data.panos)
-      .flatMap(_ => exploreService.submitExploreData(data, user.userId))
-      .map { returnData: ExploreTaskPostReturnValue =>
-        // Now we do all the stuff that can be done async, we can return the response before these are done.
+      .submitExploreData(data, user.userId)
+      .transform {
+        case Failure(e) =>
+          // submitExploreData is transactional, so a failure inside it (including a label's integral pano write, #4587)
+          // means none of the submission was saved. Scoped to that future alone: once the success branch below runs,
+          // the transaction has committed, and a failure there must not claim otherwise.
+          logger.error("Explore submission failed; nothing from it was saved.", e)
+          Success(InternalServerError(Json.obj("status" -> "Error", "message" -> "Failed to save submitted data.")))
+        case Success(returnData: ExploreTaskPostReturnValue) =>
+          Try {
+            // Now we do all the stuff that can be done async, we can return the response before these are done.
 
-        // Insert environment async.
-        val env: EnvironmentSubmission = data.environment
-        exploreService
-          .insertEnvironment(
-            AuditTaskEnvironment(0, returnData.auditTaskId, missionId, env.browser, env.browserVersion,
-              env.browserWidth, env.browserHeight, env.availWidth, env.availHeight, env.screenWidth, env.screenHeight,
-              env.operatingSystem, Some(ipAddress), env.language, env.cssZoom, Some(currTime))
-          )
-          .failed
-          .foreach(e => logger.error("Error saving explore environment data.", e))
+            // Insert environment async.
+            val env: EnvironmentSubmission = data.environment
+            exploreService
+              .insertEnvironment(
+                AuditTaskEnvironment(0, returnData.auditTaskId, missionId, env.browser, env.browserVersion,
+                  env.browserWidth, env.browserHeight, env.availWidth, env.availHeight, env.screenWidth,
+                  env.screenHeight, env.operatingSystem, Some(ipAddress), env.language, env.cssZoom, Some(currTime))
+              )
+              .failed
+              .foreach(e => logger.error("Error saving explore environment data.", e))
 
-        // Insert interactions async, send time spent auditing to scistarter (which uses the interactions table).
-        exploreService
-          .insertMultipleInteractions(data.interactions.map { interaction =>
-            AuditTaskInteraction(0, returnData.auditTaskId, missionId, interaction.action, interaction.panoId,
-              interaction.lat, interaction.lng, interaction.heading, interaction.pitch, interaction.zoom,
-              interaction.note, interaction.temporaryLabelId, interaction.timestamp)
-          })
-          .map { _ =>
-            // Send labels to SidewalkAI API for AI validation. Only available for some label types and imagery sources.
-            val labelsToSend = returnData.newLabels.filter { l =>
-              LabelTypeEnum.aiLabelTypes.contains(l.labelType) && l.panoSource == PanoSource.Gsv && !l.tutorial
-            }
-            aiService
-              .validateLabelsWithAi(labelsToSend.map(_.labelId))
-              .onComplete {
-                case Success(_) => if (labelsToSend.nonEmpty) logger.info(s"AI validation(s) completed successfully.")
-                case Failure(e) => logger.error("Error occurred when submitting AI validations:", e)
-              }
-
-            // Send contributions to SciStarter async so that it can be recorded in their user dashboard there.
-            val eligibleUser: Boolean = RoleTable.SCISTARTER_ROLES.contains(user.role)
-            if (returnData.newLabels.nonEmpty && config.get[String]("environment-type") == "prod" && eligibleUser) {
-              exploreService
-                .secondsSpentAuditing(
-                  user.userId,
-                  returnData.newLabels.map(_.labelId).min,
-                  returnData.newLabels.map(_.timeCreated).max
-                )
-                .flatMap { timeSpent: Double =>
-                  configService.sendSciStarterContributions(user.email, returnData.newLabels.length, timeSpent)
+            // Insert interactions async, send time spent auditing to scistarter (which uses the interactions table).
+            exploreService
+              .insertMultipleInteractions(data.interactions.map { interaction =>
+                AuditTaskInteraction(0, returnData.auditTaskId, missionId, interaction.action, interaction.panoId,
+                  interaction.lat, interaction.lng, interaction.heading, interaction.pitch, interaction.zoom,
+                  interaction.note, interaction.temporaryLabelId, interaction.timestamp)
+              })
+              .map { _ =>
+                // Send labels to SidewalkAI API for AI validation. Only available for some label types and imagery sources.
+                val labelsToSend = returnData.newLabels.filter { l =>
+                  LabelTypeEnum.aiLabelTypes.contains(l.labelType) && l.panoSource == PanoSource.Gsv && !l.tutorial
                 }
-                .failed
-                .foreach(e => logger.error("Error sending contributions to SciStarter.", e))
-            }
-          }
-          .failed
-          .foreach(e => logger.error("Error saving explore interaction data.", e))
+                aiService
+                  .validateLabelsWithAi(labelsToSend.map(_.labelId))
+                  .onComplete {
+                    case Success(_) =>
+                      if (labelsToSend.nonEmpty) logger.info(s"AI validation(s) completed successfully.")
+                    case Failure(e) => logger.error("Error occurred when submitting AI validations:", e)
+                  }
 
-        // Return the final result.
-        Ok(
-          Json.obj(
-            "audit_task_id"  -> returnData.auditTaskId,
-            "street_edge_id" -> data.auditTask.streetEdgeId,
-            "mission"        -> returnData.mission.map(Json.toJson(_)),
-            "label_ids"      -> returnData.newLabels
-              .map(l => Json.obj("label_id" -> l.labelId, "temporary_label_id" -> l.temporaryLabelId)),
-            "updated_streets" -> returnData.updatedStreets.map(Json.toJson(_)),
-            "refresh_page" -> returnData.refreshPage // If we notice something out of whack, tell front-end to refresh.
-          )
-        )
-      }
-      .recover { case e =>
-        // submitExploreData is transactional, so a failure here (including a label's integral pano write, #4587)
-        // means none of the submission was saved.
-        logger.error("Explore submission failed; nothing from it was saved.", e)
-        InternalServerError(Json.obj("status" -> "Error", "message" -> "Failed to save submitted data."))
+                // Send contributions to SciStarter async so that it can be recorded in their user dashboard there.
+                val eligibleUser: Boolean = RoleTable.SCISTARTER_ROLES.contains(user.role)
+                if (returnData.newLabels.nonEmpty && config.get[String]("environment-type") == "prod" && eligibleUser) {
+                  exploreService
+                    .secondsSpentAuditing(
+                      user.userId,
+                      returnData.newLabels.map(_.labelId).min,
+                      returnData.newLabels.map(_.timeCreated).max
+                    )
+                    .flatMap { timeSpent: Double =>
+                      configService.sendSciStarterContributions(user.email, returnData.newLabels.length, timeSpent)
+                    }
+                    .failed
+                    .foreach(e => logger.error("Error sending contributions to SciStarter.", e))
+                }
+              }
+              .failed
+              .foreach(e => logger.error("Error saving explore interaction data.", e))
+
+            // Return the final result.
+            Ok(
+              Json.obj(
+                "audit_task_id"  -> returnData.auditTaskId,
+                "street_edge_id" -> data.auditTask.streetEdgeId,
+                "mission"        -> returnData.mission.map(Json.toJson(_)),
+                "label_ids"      -> returnData.newLabels
+                  .map(l => Json.obj("label_id" -> l.labelId, "temporary_label_id" -> l.temporaryLabelId)),
+                "updated_streets" -> returnData.updatedStreets.map(Json.toJson(_)),
+                "refresh_page" -> returnData.refreshPage // If we notice something out of whack, tell front-end to refresh.
+              )
+            )
+          }
       }
     response
   }

--- a/app/formats/json/ExploreFormats.scala
+++ b/app/formats/json/ExploreFormats.scala
@@ -64,7 +64,8 @@ object ExploreFormats {
       point: LabelPointSubmission,
       temporaryLabelId: Int,
       timeCreated: Option[OffsetDateTime],
-      tutorial: Boolean
+      tutorial: Boolean,
+      pano: Option[PanoSubmission] // Added in #4587 to support the pano_data row that is integral to a label.
   )
   case class TaskSubmission(
       streetEdgeId: Int,
@@ -272,40 +273,6 @@ object ExploreFormats {
       (JsPath \ "computation_method").readNullable[ComputationMethod.Value]
   )(LabelPointSubmission.apply _)
 
-  implicit val labelSubmissionReads: Reads[LabelSubmission] = (
-    (JsPath \ "pano_id").read[String] and
-      (JsPath \ "pano_source").read[PanoSource.Value] and
-      (JsPath \ "label_type").read[String] and
-      (JsPath \ "deleted").read[Boolean] and
-      (JsPath \ "severity").readNullable[Int] and
-      (JsPath \ "description").readNullable[String] and
-      (JsPath \ "tag_ids").read[Seq[Int]] and
-      (JsPath \ "label_point").read[LabelPointSubmission] and
-      (JsPath \ "temporary_label_id").read[Int] and
-      (JsPath \ "time_created").readNullable[OffsetDateTime] and
-      (JsPath \ "tutorial").read[Boolean]
-  )(LabelSubmission.apply _)
-
-  implicit val auditTaskReads: Reads[TaskSubmission] = (
-    (JsPath \ "street_edge_id").read[Int] and
-      (JsPath \ "task_start").read[OffsetDateTime] and
-      (JsPath \ "audit_task_id").readNullable[Int] and
-      (JsPath \ "completed").readNullable[Boolean] and
-      (JsPath \ "current_lat").read[Double] and
-      (JsPath \ "current_lng").read[Double] and
-      (JsPath \ "start_point_reversed").read[Boolean] and
-      (JsPath \ "current_mission_start").readNullable[Point] and
-      (JsPath \ "last_priority_update_time").read[OffsetDateTime] and
-      (JsPath \ "request_updated_street_priority").read[Boolean] and
-      (JsPath \ "audited_distance_m").readNullable[Double] and
-      (JsPath \ "route_street_id").readNullable[Int]
-  )(TaskSubmission.apply _)
-
-  implicit val noStreetViewSubmissionReads: Reads[NoStreetViewSubmission] = (
-    (JsPath \ "audit_task").read[TaskSubmission] and
-      (JsPath \ "mission_id").read[Int]
-  )(NoStreetViewSubmission.apply _)
-
   implicit val panoLinkSubmissionReads: Reads[PanoLinkSubmission] = (
     (JsPath \ "target_pano_id").read[String] and
       (JsPath \ "yaw_deg").read[Double] and
@@ -344,6 +311,41 @@ object ExploreFormats {
       (JsPath \ "history").read[Seq[PanoDate]] and
       (JsPath \ "source_metadata").readNullable[JsObject](sourceMetadataReads)
   )(PanoSubmission.apply _)
+
+  implicit val labelSubmissionReads: Reads[LabelSubmission] = (
+    (JsPath \ "pano_id").read[String] and
+      (JsPath \ "pano_source").read[PanoSource.Value] and
+      (JsPath \ "label_type").read[String] and
+      (JsPath \ "deleted").read[Boolean] and
+      (JsPath \ "severity").readNullable[Int] and
+      (JsPath \ "description").readNullable[String] and
+      (JsPath \ "tag_ids").read[Seq[Int]] and
+      (JsPath \ "label_point").read[LabelPointSubmission] and
+      (JsPath \ "temporary_label_id").read[Int] and
+      (JsPath \ "time_created").readNullable[OffsetDateTime] and
+      (JsPath \ "tutorial").read[Boolean] and
+      (JsPath \ "pano").readNullable[PanoSubmission]
+  )(LabelSubmission.apply _)
+
+  implicit val auditTaskReads: Reads[TaskSubmission] = (
+    (JsPath \ "street_edge_id").read[Int] and
+      (JsPath \ "task_start").read[OffsetDateTime] and
+      (JsPath \ "audit_task_id").readNullable[Int] and
+      (JsPath \ "completed").readNullable[Boolean] and
+      (JsPath \ "current_lat").read[Double] and
+      (JsPath \ "current_lng").read[Double] and
+      (JsPath \ "start_point_reversed").read[Boolean] and
+      (JsPath \ "current_mission_start").readNullable[Point] and
+      (JsPath \ "last_priority_update_time").read[OffsetDateTime] and
+      (JsPath \ "request_updated_street_priority").read[Boolean] and
+      (JsPath \ "audited_distance_m").readNullable[Double] and
+      (JsPath \ "route_street_id").readNullable[Int]
+  )(TaskSubmission.apply _)
+
+  implicit val noStreetViewSubmissionReads: Reads[NoStreetViewSubmission] = (
+    (JsPath \ "audit_task").read[TaskSubmission] and
+      (JsPath \ "mission_id").read[Int]
+  )(NoStreetViewSubmission.apply _)
 
   implicit val auditMissionProgressReads: Reads[AuditMissionProgress] = (
     (JsPath \ "mission_id").read[Int] and

--- a/app/formats/json/ExploreFormats.scala
+++ b/app/formats/json/ExploreFormats.scala
@@ -326,6 +326,11 @@ object ExploreFormats {
       (JsPath \ "tutorial").read[Boolean] and
       (JsPath \ "pano").readNullable[PanoSubmission]
   )(LabelSubmission.apply _)
+    // A mismatched block would let a buggy client write one pano's metadata while committing a label that points at
+    // another — exactly the orphan #4587 exists to prevent — so refuse it before anything touches the database.
+    .filter(JsonValidationError("The label's pano block must describe the label's own pano_id."))(label =>
+      label.pano.forall(_.panoId == label.panoId)
+    )
 
   implicit val auditTaskReads: Reads[TaskSubmission] = (
     (JsPath \ "street_edge_id").read[Int] and

--- a/app/models/pano/PanoDataTable.scala
+++ b/app/models/pano/PanoDataTable.scala
@@ -6,7 +6,7 @@ import models.pano.PanoSource.PanoSource
 import models.utils.MyPostgresProfile
 import models.utils.MyPostgresProfile.api._
 import play.api.db.slick.{DatabaseConfigProvider, HasDatabaseConfigProvider}
-import play.api.libs.json.JsValue
+import play.api.libs.json.{JsValue, Json}
 
 import java.time.OffsetDateTime
 import javax.inject.{Inject, Singleton}
@@ -233,43 +233,49 @@ class PanoDataTable @Inject() (protected val dbConfigProvider: DatabaseConfigPro
   }
 
   /**
-   * Updates the pano data if anything has changed.
+   * Inserts the pano's metadata, or refreshes it if the pano is already recorded.
+   *
+   * A single `INSERT ... ON CONFLICT` statement rather than an exists-check + insert/update pair, so two concurrent
+   * submissions of the same new pano (e.g. a `pagehide` flush racing a mission-complete POST, or two open tabs) can't
+   * fail on a duplicate key and leave labels without their pano row (#4587).
+   *
+   * Update semantics when the pano is already recorded:
+   *   - Position/camera fields take the submitted value but are never cleared.
+   *   - Intrinsic fields (dims, copyright) keep their existing value and only fill in NULLs, as they never change.
+   *   - `address` and `source_metadata` are only ever replaced, never cleared.
+   *   - The pano was just viewed, so `expired` resets to false and the viewed/checked timestamps refresh.
+   *
+   * @param data The pano metadata to save.
+   * @return Number of rows inserted/updated (always 1).
    */
-  def updateFromExplore(
-      panoId: String,
-      lat: Option[Double],
-      lng: Option[Double],
-      heading: Option[Double],
-      pitch: Option[Double],
-      roll: Option[Double],
-      address: Option[String],
-      expired: Boolean,
-      lastViewed: OffsetDateTime,
-      panoHistorySaved: Option[OffsetDateTime]
-  ): DBIO[Int] = {
-    // A stored address is only ever replaced, never cleared: submissions without one (e.g. non-GSV sources) leave
-    // the column untouched, so it needs its own (still static) query shape rather than a second UPDATE round trip.
-    if (address.isDefined) {
-      val q = for {
-        pano <- panoDataRecords if pano.panoId === panoId
-      } yield (pano.lat, pano.lng, pano.cameraHeading, pano.cameraPitch, pano.cameraRoll, pano.expired, pano.lastViewed,
-        pano.panoHistorySaved, pano.lastChecked, pano.address)
-      q.update((lat, lng, heading, pitch, roll, expired, lastViewed, panoHistorySaved, lastViewed, address))
-    } else {
-      val q = for {
-        pano <- panoDataRecords if pano.panoId === panoId
-      } yield (pano.lat, pano.lng, pano.cameraHeading, pano.cameraPitch, pano.cameraRoll, pano.expired, pano.lastViewed,
-        pano.panoHistorySaved, pano.lastChecked)
-      q.update((lat, lng, heading, pitch, roll, expired, lastViewed, panoHistorySaved, lastViewed))
-    }
-  }
-
-  /**
-   * Checks if the given panorama id already exists in the table.
-   * @param panoId Unique ID for the panorama
-   */
-  def panoramaExists(panoId: String): DBIO[Boolean] = {
-    panoDataRecords.filter(_.panoId === panoId).exists.result
+  def upsert(data: PanoData): DBIO[Int] = {
+    sqlu"""
+      INSERT INTO pano_data (pano_id, width, height, tile_width, tile_height, capture_date, copyright, lat, lng,
+                             camera_heading, camera_pitch, camera_roll, expired, last_viewed, pano_history_saved,
+                             last_checked, source, has_backup, address, source_metadata)
+      VALUES (${data.panoId}, ${data.width}, ${data.height}, ${data.tileWidth}, ${data.tileHeight},
+              ${data.captureDate}, ${data.copyright}, ${data.lat}, ${data.lng}, ${data.cameraHeading},
+              ${data.cameraPitch}, ${data.cameraRoll}, ${data.expired}, ${data.lastViewed}, ${data.panoHistorySaved},
+              ${data.lastChecked}, ${data.source.toString}::pano_source, ${data.hasBackup}, ${data.address},
+              ${data.sourceMetadata.map(m => Json.stringify(m))}::jsonb)
+      ON CONFLICT (pano_id) DO UPDATE SET
+        lat = COALESCE(EXCLUDED.lat, pano_data.lat),
+        lng = COALESCE(EXCLUDED.lng, pano_data.lng),
+        camera_heading = COALESCE(EXCLUDED.camera_heading, pano_data.camera_heading),
+        camera_pitch = COALESCE(EXCLUDED.camera_pitch, pano_data.camera_pitch),
+        camera_roll = COALESCE(EXCLUDED.camera_roll, pano_data.camera_roll),
+        width = COALESCE(pano_data.width, EXCLUDED.width),
+        height = COALESCE(pano_data.height, EXCLUDED.height),
+        tile_width = COALESCE(pano_data.tile_width, EXCLUDED.tile_width),
+        tile_height = COALESCE(pano_data.tile_height, EXCLUDED.tile_height),
+        copyright = COALESCE(pano_data.copyright, EXCLUDED.copyright),
+        address = COALESCE(EXCLUDED.address, pano_data.address),
+        source_metadata = COALESCE(EXCLUDED.source_metadata, pano_data.source_metadata),
+        expired = false,
+        last_viewed = EXCLUDED.last_viewed,
+        pano_history_saved = EXCLUDED.pano_history_saved,
+        last_checked = EXCLUDED.last_checked
+    """
   }
 
   /**
@@ -288,28 +294,5 @@ class PanoDataTable @Inject() (protected val dbConfigProvider: DatabaseConfigPro
    */
   def updatePanoHistorySaved(panoId: String, panoHistorySaved: Option[OffsetDateTime]): DBIO[Int] = {
     panoDataRecords.filter(_.panoId === panoId).map(_.panoHistorySaved).update(panoHistorySaved)
-  }
-
-  /**
-   * Sets a pano's provider metadata blob.
-   *
-   * Kept separate from updateFromExplore so only payloads that carry the blob (AI submissions) ever write the column;
-   * a crowd submission must never clear one saved earlier (#4806).
-   *
-   * updateFromExplore solves that same "replace, never clear" problem for `address` by branching between two static
-   * query shapes rather than issuing a second UPDATE. The blob doesn't follow suit because the two columns sit on
-   * very different paths: every Explore submission carries an address, so folding it in saves a round trip on the
-   * hottest write we have, whereas the blob has one caller (the AI ingest) whose volume is a nightly batch. Paying a
-   * round trip there is cheaper than doubling updateFromExplore's branches to four.
-   *
-   * @param panoId   Unique ID for the panorama
-   * @param metadata Verbatim imagery-provider metadata blob for this pano
-   */
-  def updateSourceMetadata(panoId: String, metadata: JsValue): DBIO[Int] = {
-    panoDataRecords.filter(_.panoId === panoId).map(_.sourceMetadata).update(Some(metadata))
-  }
-
-  def insert(data: PanoData): DBIO[String] = {
-    (panoDataRecords returning panoDataRecords.map(_.panoId)) += data
   }
 }

--- a/app/models/pano/PanoHistoryTable.scala
+++ b/app/models/pano/PanoHistoryTable.scala
@@ -36,15 +36,17 @@ class PanoHistoryTable @Inject() (
 
   /**
    * Save a pano history object to the PanoHistory table if it isn't already in the table.
+   *
+   * `ON CONFLICT DO NOTHING` rather than a check-then-insert, so concurrent submissions of the same history entry
+   * (e.g. a `pagehide` flush racing a mission-complete POST) can't fail on a duplicate key (#4587).
+   *
+   * @return Number of rows inserted (0 if the history entry was already recorded).
    */
   def insertIfNew(history: PanoHistory): DBIO[Int] = {
-    panoHistoryTable
-      .filter(h => h.panoId === history.panoId && h.locationCurrPanoId === history.locationCurrPanoId)
-      .result
-      .headOption
-      .flatMap {
-        case Some(_) => DBIO.successful(0)
-        case None    => panoHistoryTable += history
-      }
+    sqlu"""
+      INSERT INTO pano_history (pano_id, capture_date, location_curr_pano_id)
+      VALUES (${history.panoId}, ${history.captureDate}, ${history.locationCurrPanoId})
+      ON CONFLICT DO NOTHING
+    """
   }
 }

--- a/app/models/pano/PanoLinkTable.scala
+++ b/app/models/pano/PanoLinkTable.scala
@@ -36,15 +36,17 @@ class PanoLinkTable @Inject() (
 
   /**
    * Save a PanoLink object to the PanoLink table if it isn't already in the table.
+   *
+   * `ON CONFLICT DO NOTHING` rather than a check-then-insert, so concurrent submissions of the same link (e.g. a
+   * `pagehide` flush racing a mission-complete POST) can't fail on a duplicate key (#4587).
+   *
+   * @return Number of rows inserted (0 if the link was already recorded).
    */
   def insertIfNew(link: PanoLink): DBIO[Int] = {
-    panoLinks
-      .filter(l => l.panoId === link.panoId && l.targetPanoId === link.targetPanoId)
-      .result
-      .headOption
-      .flatMap {
-        case Some(_) => DBIO.successful(0)
-        case None    => panoLinks += link
-      }
+    sqlu"""
+      INSERT INTO pano_link (pano_id, target_pano_id, yaw_deg, description)
+      VALUES (${link.panoId}, ${link.targetPanoId}, ${link.yawDeg}, ${link.description})
+      ON CONFLICT DO NOTHING
+    """
   }
 }

--- a/app/service/AiService.scala
+++ b/app/service/AiService.scala
@@ -68,9 +68,9 @@ class AiServiceImpl @Inject() (
               // Call the AI API to process the panorama data and validate labels.
               case Some(labelData) => callAiApiAndSubmitData(labelData)
               case None            =>
-                // Unexpected but recoverable: the label has no pano_data row with dimensions, e.g. because
-                // savePanoInfo (which runs in parallel with label submission) hasn't saved it yet. The nightly
-                // validateLabelsWithAiDaily sweep will pick the label up once its pano data exists.
+                // Unexpected but recoverable: the label's pano_data row lacks dimensions — a label commits atomically
+                // with its pano row (#4587), but the dimension columns are nullable and not every payload carries
+                // them. The nightly validateLabelsWithAiDaily sweep will pick the label up once its pano data exists.
                 logger.warn(s"Skipping AI validation for label $labelId: no label/pano data eligible for AI found.")
                 Future.successful(None)
             }

--- a/app/service/ExploreService.scala
+++ b/app/service/ExploreService.scala
@@ -99,7 +99,7 @@ trait ExploreService {
    *
    * Each pano is saved independently and any failure is logged rather than thrown, so one bad pano can't abort the rest
    * of the batch (#4587). This is the lenient path for panos merely *viewed* during a session; a labeled pano's
-   * metadata additionally rides its label (LabelSubmission.pano) and commits atomically with it in submitExploreData.
+   * metadata rides its label (LabelSubmission.pano) instead and commits atomically with it in submitExploreData.
    *
    * @param panos All pano-related data submitted from the Explore page front-end.
    * @return Whether every pano in the batch was saved successfully.
@@ -615,11 +615,6 @@ class ExploreServiceImpl @Inject() (
     } yield gf.createPoint(new Coordinate(_lng, _lat))
 
     for {
-      // The pano's metadata is integral to the label (#4587): saving it here, inside the caller's transaction, means
-      // a label can never be committed without its pano_data row — and a pano whose write fails takes the label (and
-      // the rest of the submission) with it rather than quietly producing an orphan. Only skipped for tutorial labels.
-      _ <- label.pano.map(savePanoAction(_, OffsetDateTime.now)).getOrElse(DBIO.successful(()))
-
       // Use label's lat/lng to determine street_edge_id. If lat/lng isn't defined, use audit_task's as backup.
       calculatedStreetEdgeId: Int <- (point.lat, point.lng) match {
         case (Some(lat), Some(lng)) => labelTable.getStreetEdgeIdClosestToLatLng(lat, lng)
@@ -814,7 +809,9 @@ class ExploreServiceImpl @Inject() (
         } yield ()
       }
     }
-    db.run(labelSubmitActions.transactionally)
+    // The pano's metadata is integral to its labels (#4587): writing it in the same transaction means a label can
+    // never be committed without its pano_data row, and a failed pano write fails the whole request.
+    db.run(savePanoAction(pano, currTime).andThen(labelSubmitActions).transactionally)
   }
 
   def submitExploreData(data: AuditTaskSubmission, userId: String): Future[ExploreTaskPostReturnValue] = {
@@ -822,93 +819,107 @@ class ExploreServiceImpl @Inject() (
     val streetEdgeId: Int    = data.auditTask.streetEdgeId
     val missionId: Int       = data.missionProgress.missionId
 
+    // Each label's pano metadata is integral to the label (#4587): writing it in the same transaction as the labels
+    // means a label can never be committed without its pano_data row, and a failed pano write takes the whole
+    // submission with it rather than quietly producing an orphan.
+    val labeledPanos: Seq[PanoSubmission]  = data.labels.flatMap(_.pano).distinctBy(_.panoId).sortBy(_.panoId)
+    val saveLabeledPanosAction: DBIO[Unit] = DBIO.seq(labeledPanos.map(savePanoAction(_, OffsetDateTime.now)): _*)
+
     // Update the audit_task table and get the audit_task_id. This is needed to submit all other data.
-    db.run(updateAuditTaskTable(userId, data.auditTask, missionId).flatMap { auditTaskId: Int =>
-      missionTable.getMissionType(missionId).flatMap { missionType: Option[MissionType.Value] =>
-        // If task is complete, mark it in the db and update the street priority. A normal audit is completed by the
-        // client; a free-exploration drop-in has no such client signal, so the server derives it from how far the user
-        // walked (#4451). Deriving it also means a forged completed=true can't mark a drop-in street audited.
-        // Ordering is load-bearing: updateStreetPriority skips streets the user already completed, so it must read the
-        // completed flag before updateCompleted flips it — flipping first would skip the one legitimate update, and it
-        // is also what keeps re-running this action (every post-completion submission) from shifting priority again.
-        val completeTaskAction: DBIO[Int] = for {
-          newPriority: Option[Double] <- updateStreetPriority(streetEdgeId, userId)
-          atRowsUpdated: Int          <- auditTaskTable.updateCompleted(auditTaskId, completed = true)
-        } yield atRowsUpdated
+    val submitAction: DBIO[ExploreTaskPostReturnValue] = updateAuditTaskTable(userId, data.auditTask, missionId)
+      .flatMap { auditTaskId: Int =>
+        missionTable.getMissionType(missionId).flatMap { missionType: Option[MissionType.Value] =>
+          // If task is complete, mark it in the db and update the street priority. A normal audit is completed by the
+          // client; a free-exploration drop-in has no such client signal, so the server derives it from how far the
+          // user walked (#4451). Deriving it also means a forged completed=true can't mark a drop-in street audited.
+          // Ordering is load-bearing: updateStreetPriority skips streets the user already completed, so it must read
+          // the completed flag before updateCompleted flips it — flipping first would skip the one legitimate update,
+          // and it is also what keeps re-running this action from shifting priority again.
+          val completeTaskAction: DBIO[Int] = for {
+            newPriority: Option[Double] <- updateStreetPriority(streetEdgeId, userId)
+            atRowsUpdated: Int          <- auditTaskTable.updateCompleted(auditTaskId, completed = true)
+          } yield atRowsUpdated
 
-        val taskCompletedAction: DBIO[Int] = missionType match {
-          case Some(MissionType.Audit) if data.auditTask.completed.getOrElse(false) => completeTaskAction
-          case Some(MissionType.ExploreAddress)                                     =>
-            streetWalkedFarEnough(auditTaskId, streetEdgeId, data.auditTask.auditedDistanceM).flatMap {
-              farEnough: Boolean => if (farEnough) completeTaskAction else DBIO.successful(0)
+          val taskCompletedAction: DBIO[Int] = missionType match {
+            case Some(MissionType.Audit) if data.auditTask.completed.getOrElse(false) => completeTaskAction
+            case Some(MissionType.ExploreAddress)                                     =>
+              streetWalkedFarEnough(auditTaskId, streetEdgeId, data.auditTask.auditedDistanceM).flatMap {
+                farEnough: Boolean => if (farEnough) completeTaskAction else DBIO.successful(0)
+              }
+            case _ => DBIO.successful(0)
+          }
+
+          // Add to the audit_task_user_route and user_route tables if we are on a route and not in the tutorial.
+          val userRouteAction: DBIO[Boolean] =
+            if (data.userRouteId.isDefined && missionType.contains(MissionType.Audit)) {
+              for {
+                _ <- auditTaskUserRouteTable.insertIfNew(
+                  data.userRouteId.get,
+                  auditTaskId,
+                  data.auditTask.routeStreetId
+                )
+                routeComplete: Boolean <- userRouteTable.updateCompleteness(data.userRouteId.get)
+              } yield routeComplete
+            } else DBIO.successful(false)
+
+          // Update the MissionTable.
+          val updateMissionAction: DBIO[Option[Mission]] =
+            missionService.updateMissionTableExplore(userId, data.missionProgress)
+
+          // Insert any labels.
+          val labelSubmitActions: Seq[DBIO[Option[NewLabelData]]] =
+            data.labels.map { label: LabelSubmission =>
+              val labelTypeId: Int = LabelTypeEnum.labelTypeToId(label.labelType)
+              labelTable.find(label.temporaryLabelId, userId).flatMap {
+                case Some(existingLabel) =>
+                  // If there is already a label with this temp id but a mismatched label type, the user probably has the
+                  // Explore page open in multiple browsers. Don't add the label; tell the front-end to refresh the page.
+                  if (existingLabel.labelTypeId != labelTypeId) {
+                    refreshPage = true
+                    DBIO.successful(None)
+                  } else {
+                    // If the label exists and there are no issues, update it.
+                    for {
+                      // Map tag IDs to their string representations. Then update the label.
+                      allTags: Seq[Tag] <- labelService.selectAllTags
+                      tagStrings: List[String] = label.tagIds.distinct
+                        .flatMap(t => allTags.filter(_.tagId == t).map(_.tag).headOption)
+                        .toList
+                      _ <- labelService.updateLabelFromExplore(existingLabel.labelId, label.deleted, label.severity,
+                        label.description, tagStrings)
+                    } yield None
+                  }
+                // If there is no existing label with this temp id, insert a new one.
+                case None => insertLabel(label, userId, auditTaskId, streetEdgeId, missionId).map(Some(_))
+              }
             }
-          case _ => DBIO.successful(0)
+
+          // Check for streets in the user's neighborhood that have been audited by other users while they were auditing.
+          val updatedStreetsAction: DBIO[Option[UpdatedStreets]] =
+            if (data.auditTask.requestUpdatedStreetPriority) {
+              // Get streetEdgeIds and priority values for streets that have been updated since lastPriorityUpdateTime.
+              val lastPriorityUpdateTime: OffsetDateTime = data.auditTask.lastPriorityUpdateTime
+              streetEdgePriorityTable
+                .streetPrioritiesUpdatedSinceTime(data.missionProgress.regionId, lastPriorityUpdateTime)
+                .map(updatedStreetPriorities => Some(UpdatedStreets(OffsetDateTime.now, updatedStreetPriorities)))
+            } else {
+              DBIO.successful(None)
+            }
+
+          // Zip the actions together so that they can be completed in parallel, returning result once all complete.
+          taskCompletedAction
+            .zip(userRouteAction)
+            .zip(updateMissionAction)
+            .zip(DBIO.sequence(labelSubmitActions))
+            .zip(updatedStreetsAction)
+            .map { case ((((_, _), possibleNewMission), newLabels), updatedStreets) =>
+              ExploreTaskPostReturnValue(auditTaskId, possibleNewMission, newLabels.flatten, updatedStreets,
+                refreshPage)
+            }
         }
-
-        // Add to the audit_task_user_route and user_route tables if we are on a route and not in the tutorial.
-        val userRouteAction: DBIO[Boolean] =
-          if (data.userRouteId.isDefined && missionType.contains(MissionType.Audit)) {
-            for {
-              _ <- auditTaskUserRouteTable.insertIfNew(data.userRouteId.get, auditTaskId, data.auditTask.routeStreetId)
-              routeComplete: Boolean <- userRouteTable.updateCompleteness(data.userRouteId.get)
-            } yield routeComplete
-          } else DBIO.successful(false)
-
-        // Update the MissionTable.
-        val updateMissionAction: DBIO[Option[Mission]] =
-          missionService.updateMissionTableExplore(userId, data.missionProgress)
-
-        // Insert any labels.
-        val labelSubmitActions: Seq[DBIO[Option[NewLabelData]]] =
-          data.labels.map { label: LabelSubmission =>
-            val labelTypeId: Int = LabelTypeEnum.labelTypeToId(label.labelType)
-            labelTable.find(label.temporaryLabelId, userId).flatMap {
-              case Some(existingLabel) =>
-                // If there is already a label with this temp id but a mismatched label type, the user probably has the
-                // Explore page open in multiple browsers. Don't add the label; tell the front-end to refresh the page.
-                if (existingLabel.labelTypeId != labelTypeId) {
-                  refreshPage = true
-                  DBIO.successful(None)
-                } else {
-                  // If the label exists and there are no issues, update it.
-                  for {
-                    // Map tag IDs to their string representations. Then update the label.
-                    allTags: Seq[Tag] <- labelService.selectAllTags
-                    tagStrings: List[String] = label.tagIds.distinct
-                      .flatMap(t => allTags.filter(_.tagId == t).map(_.tag).headOption)
-                      .toList
-                    _ <- labelService.updateLabelFromExplore(existingLabel.labelId, label.deleted, label.severity,
-                      label.description, tagStrings)
-                  } yield None
-                }
-              // If there is no existing label with this temp id, insert a new one.
-              case None => insertLabel(label, userId, auditTaskId, streetEdgeId, missionId).map(Some(_))
-            }
-          }
-
-        // Check for streets in the user's neighborhood that have been audited by other users while they were auditing.
-        val updatedStreetsAction: DBIO[Option[UpdatedStreets]] =
-          if (data.auditTask.requestUpdatedStreetPriority) {
-            // Get streetEdgeIds and priority values for streets that have been updated since lastPriorityUpdateTime.
-            val lastPriorityUpdateTime: OffsetDateTime = data.auditTask.lastPriorityUpdateTime
-            streetEdgePriorityTable
-              .streetPrioritiesUpdatedSinceTime(data.missionProgress.regionId, lastPriorityUpdateTime)
-              .map(updatedStreetPriorities => Some(UpdatedStreets(OffsetDateTime.now, updatedStreetPriorities)))
-          } else {
-            DBIO.successful(None)
-          }
-
-        // Zip the actions together so that they can be completed in parallel, returning result once all complete.
-        taskCompletedAction
-          .zip(userRouteAction)
-          .zip(updateMissionAction)
-          .zip(DBIO.sequence(labelSubmitActions))
-          .zip(updatedStreetsAction)
-          .map { case ((((_, _), possibleNewMission), newLabels), updatedStreets) =>
-            ExploreTaskPostReturnValue(auditTaskId, possibleNewMission, newLabels.flatten, updatedStreets, refreshPage)
-          }
       }
-    }.transactionally)
+
+    db.run(saveLabeledPanosAction.andThen(submitAction).transactionally)
   }
 
   def secondsSpentAuditing(userId: String, timeRangeStartLabelId: Int, timeRangeEnd: OffsetDateTime): Future[Double] =

--- a/app/service/ExploreService.scala
+++ b/app/service/ExploreService.scala
@@ -96,9 +96,15 @@ trait ExploreService {
 
   /**
    * Takes data submitted from the Explore page updates the pano_data, pano_link, and pano_history tables accordingly.
+   *
+   * Each pano is saved independently and any failure is logged rather than thrown, so one bad pano can't abort the rest
+   * of the batch (#4587). This is the lenient path for panos merely *viewed* during a session; a labeled pano's
+   * metadata additionally rides its label (LabelSubmission.pano) and commits atomically with it in submitExploreData.
+   *
    * @param panos All pano-related data submitted from the Explore page front-end.
+   * @return Whether every pano in the batch was saved successfully.
    */
-  def savePanoInfo(panos: Seq[PanoSubmission]): Future[Unit]
+  def savePanoInfo(panos: Seq[PanoSubmission]): Future[Boolean]
   def insertComment(comment: AuditTaskComment): Future[Int]
 
   /**
@@ -609,6 +615,11 @@ class ExploreServiceImpl @Inject() (
     } yield gf.createPoint(new Coordinate(_lng, _lat))
 
     for {
+      // The pano's metadata is integral to the label (#4587): saving it here, inside the caller's transaction, means
+      // a label can never be committed without its pano_data row — and a pano whose write fails takes the label (and
+      // the rest of the submission) with it rather than quietly producing an orphan. Only skipped for tutorial labels.
+      _ <- label.pano.map(savePanoAction(_, OffsetDateTime.now)).getOrElse(DBIO.successful(()))
+
       // Use label's lat/lng to determine street_edge_id. If lat/lng isn't defined, use audit_task's as backup.
       calculatedStreetEdgeId: Int <- (point.lat, point.lng) match {
         case (Some(lat), Some(lng)) => labelTable.getStreetEdgeIdClosestToLatLng(lat, lng)
@@ -651,46 +662,49 @@ class ExploreServiceImpl @Inject() (
     }
   }
 
-  def savePanoInfo(panos: Seq[PanoSubmission]): Future[Unit] = {
-    val currTime: OffsetDateTime = OffsetDateTime.now
-    val panoSubmissionActions    = panos.map { pano: PanoSubmission =>
-      (for {
-        // Insert new entry to pano_data table, or update the last_viewed/checked columns if we've already recorded it.
-        panoExists: Boolean <- panoDataTable.panoramaExists(pano.panoId)
-        _                   <-
-          if (panoExists) {
-            // source_metadata is written only when the payload carries it (AI submissions do, crowd submissions
-            // don't), so a crowd submission for the same pano can never clear the saved blob (#4806).
-            panoDataTable
-              .updateFromExplore(pano.panoId, pano.lat, pano.lng, pano.cameraHeading, pano.cameraPitch, pano.cameraRoll,
-                pano.address, expired = false, currTime, Some(currTime))
-              .andThen(
-                pano.sourceMetadata
-                  .map(metadata => panoDataTable.updateSourceMetadata(pano.panoId, metadata))
-                  .getOrElse(DBIO.successful(0))
-              )
-          } else {
-            panoDataTable.insert(
-              PanoData(pano.panoId, pano.width, pano.height, pano.tileWidth, pano.tileHeight, pano.captureDate,
-                pano.copyright, pano.lat, pano.lng, pano.cameraHeading, pano.cameraPitch, pano.cameraRoll,
-                expired = false, currTime, Some(currTime), currTime, pano.source, hasBackup = None,
-                address = pano.address, sourceMetadata = pano.sourceMetadata)
-            )
-          }
-      } yield {
-        // Once panorama is saved, save the links and history.
-        val panoLinkInserts = pano.links.map { link =>
-          panoLinkTable.insertIfNew(PanoLink(pano.panoId, link.targetPanoId, link.yawDeg, link.description))
-        }
-        val panoHistoryInserts = pano.history.map { h =>
-          panoHistoryTable.insertIfNew(PanoHistory(h.panoId, h.date, pano.panoId))
-        }
+  /**
+   * Saves one pano's metadata: an upsert of its pano_data row, then any new pano_link / pano_history rows.
+   *
+   * The upsert never clears a saved address or source_metadata blob with an absent one (#4806); see
+   * PanoDataTable.upsert. Every statement is idempotent, so the action is safe to repeat.
+   */
+  private def savePanoAction(pano: PanoSubmission, timestamp: OffsetDateTime): DBIO[Unit] = {
+    for {
+      _ <- panoDataTable.upsert(
+        PanoData(pano.panoId, pano.width, pano.height, pano.tileWidth, pano.tileHeight, pano.captureDate,
+          pano.copyright, pano.lat, pano.lng, pano.cameraHeading, pano.cameraPitch, pano.cameraRoll, expired = false,
+          timestamp, Some(timestamp), timestamp, pano.source, hasBackup = None, address = pano.address,
+          sourceMetadata = pano.sourceMetadata)
+      )
 
-        // Run the pano_link and pano_history inserts in parallel.
-        DBIO.sequence(panoLinkInserts).zip(DBIO.sequence(panoHistoryInserts)).map(_ => ())
-      }).flatten
-    }
-    db.run(DBIO.sequence(panoSubmissionActions).map(_ => ()))
+      // Once panorama is saved, save the links and history. Run the two groups in parallel.
+      _ <- DBIO
+        .sequence(pano.links.map { link =>
+          panoLinkTable.insertIfNew(PanoLink(pano.panoId, link.targetPanoId, link.yawDeg, link.description))
+        })
+        .zip(DBIO.sequence(pano.history.map { h =>
+          panoHistoryTable.insertIfNew(PanoHistory(h.panoId, h.date, pano.panoId))
+        }))
+    } yield ()
+  }
+
+  def savePanoInfo(panos: Seq[PanoSubmission]): Future[Boolean] = {
+    val currTime: OffsetDateTime = OffsetDateTime.now
+    // asTry so one pano's failure can't abort the rest of the batch; failures are logged below.
+    val panoSubmissionActions = panos.map { pano: PanoSubmission => savePanoAction(pano, currTime).asTry }
+
+    db.run(DBIO.sequence(panoSubmissionActions))
+      .map { results =>
+        results.zip(panos).foreach { case (result, pano) =>
+          result.failed.foreach(e => logger.error(s"Failed to save pano metadata for pano ${pano.panoId}.", e))
+        }
+        results.forall(_.isSuccess)
+      }
+      .recover {
+        case e => // A failure of the batch itself, e.g. no connection available.
+          logger.error("Failed to save submitted pano metadata.", e)
+          false
+      }
   }
 
   def insertComment(comment: AuditTaskComment): Future[Int] = {
@@ -790,7 +804,8 @@ class ExploreServiceImpl @Inject() (
             severity = None,
             description = None,
             tagIds = Seq.empty[Int],
-            point = labelPoint
+            point = labelPoint,
+            pano = Some(pano)
           )
           labelId <- insertLabel(labelSubmission, aiUserId, auditTaskId, streetEdgeId, missionId).map(_.labelId)
           _       <- labelAiInfoTable.save(

--- a/public/js/explore/src/data/Form.js
+++ b/public/js/explore/src/data/Form.js
@@ -53,6 +53,41 @@ class Form {
   }
 
   /**
+   * Serializes a pano's metadata into the block the back end expects (both in `data.panos` and on each label).
+   *
+   * @param {PanoData} panoData - The pano metadata held by the PanoStore.
+   * @returns {Object} The pano metadata in the submission's wire format.
+   */
+  #compilePanoData(panoData) {
+    const props = panoData.getProperties();
+    return {
+      pano_id: props.panoId,
+      source: props.source,
+      capture_date: props.captureDate.format('YYYY-MM'),
+      width: props.width,
+      height: props.height,
+      tile_width: props.tileWidth,
+      tile_height: props.tileHeight,
+      lat: props.lat,
+      lng: props.lng,
+      camera_heading: props.cameraHeading,
+      camera_pitch: props.cameraPitch,
+      camera_roll: props.cameraRoll,
+      links: props.linkedPanos.map((link) => ({
+        target_pano_id: link.panoId,
+        yaw_deg: link.heading,
+        description: link.description || null,
+      })),
+      copyright: props.copyright || null,
+      address: props.address || null,
+      history: props.history.map((prevPano) => ({
+        pano_id: prevPano.panoId,
+        date: prevPano.captureDate.format('YYYY-MM'),
+      })),
+    };
+  }
+
+  /**
    * Gathers all the data needed to submit logs to the back end.
    *
    * @param {Task} task - The audit task to compile submission data for.
@@ -157,52 +192,16 @@ class Form {
         temp.label_point.computation_method = labelLatLng.latLngComputationMethod;
       }
 
+      // Tutorial panos are locally served with fabricated metadata, so their labels lean on the seeded pano_data rows.
+      if (!util.pano.TUTORIAL_PANO_IDS.has(prop.panoId)) {
+        temp.pano = this.#compilePanoData(panoData);
+      }
+
       data.labels.push(temp);
     }
 
-    // Keep pano metadata. This is particularly important to keep track of the date when the images were taken.
-    data.panos = [];
-
-    let temp;
-    const panoramas = this.#panoStore.getStagedPanoData();
-    for (let i = 0; i < panoramas.length; i++) {
-      const panoData = panoramas[i].getProperties();
-      const links = panoData.linkedPanos.map((link) => {
-        return {
-          target_pano_id: link.panoId,
-          yaw_deg: link.heading,
-          description: link.description || null,
-        };
-      });
-      const history = panoData.history.map((prevPano) => {
-        return {
-          pano_id: prevPano.panoId,
-          date: prevPano.captureDate.format('YYYY-MM'),
-        };
-      });
-
-      temp = {
-        pano_id: panoData.panoId,
-        source: panoData.source,
-        capture_date: panoData.captureDate.format('YYYY-MM'),
-        width: panoData.width,
-        height: panoData.height,
-        tile_width: panoData.tileWidth,
-        tile_height: panoData.tileHeight,
-        lat: panoData.lat,
-        lng: panoData.lng,
-        camera_heading: panoData.cameraHeading,
-        camera_pitch: panoData.cameraPitch,
-        camera_roll: panoData.cameraRoll,
-        links,
-        copyright: panoData.copyright || null,
-        address: panoData.address || null,
-        history,
-      };
-
-      data.panos.push(temp);
-      panoramas[i].setProperty('submitted', true);
-    }
+    // Keep metadata for every pano viewed this session, labeled or not.
+    data.panos = this.#panoStore.getStagedPanoData().map((panoData) => this.#compilePanoData(panoData));
     return data;
   }
 
@@ -221,7 +220,16 @@ class Form {
       headers: { 'Content-Type': 'application/json; charset=utf-8' },
       body: JSON.stringify(data),
     })
-      .then((response) => response.json())
+      .then((response) => {
+        // Mark panos as submitted only once the server has accepted them, so that after a failed POST their metadata
+        // stays staged and rides along with the next submission instead of being lost (#4587).
+        if (response.ok) {
+          for (const pano of data.panos) {
+            this.#panoStore.getPanoData(pano.pano_id)?.setProperty('submitted', true);
+          }
+        }
+        return response.json();
+      })
       .then((result) => {
         task.setProperty('auditTaskId', result.audit_task_id);
         svl.tracker.setAuditTaskID(result.audit_task_id);

--- a/public/js/explore/src/data/Form.js
+++ b/public/js/explore/src/data/Form.js
@@ -221,12 +221,14 @@ class Form {
       body: JSON.stringify(data),
     })
       .then((response) => {
+        // A failed submission (e.g. the server's JSON 500) must not fall through to the success handler below, which
+        // would clobber the task's audit_task_id with undefined and desync the next submission.
+        if (!response.ok) throw new Error(`Explore submission failed with status ${response.status}.`);
+
         // Mark panos as submitted only once the server has accepted them, so that after a failed POST their metadata
         // stays staged and rides along with the next submission instead of being lost (#4587).
-        if (response.ok) {
-          for (const pano of data.panos) {
-            this.#panoStore.getPanoData(pano.pano_id)?.setProperty('submitted', true);
-          }
+        for (const pano of data.panos) {
+          this.#panoStore.getPanoData(pano.pano_id)?.setProperty('submitted', true);
         }
         return response.json();
       })

--- a/test/controllers/AiSubmissionSpec.scala
+++ b/test/controllers/AiSubmissionSpec.scala
@@ -39,9 +39,11 @@ class AiSubmissionSpec extends PlaySpec with BeforeAndAfterAll with GuiceOneAppP
   private val internalApiKey = "test-internal-api-key"
 
   // The provenance cases below walk one pano through insert → re-POST → omitted-key, so they share a row and run in
-  // order. The insert-without-the-key case needs a pristine row of its own, hence the second id.
-  private val panoId     = "AiSubmissionSpec-pano-4806"
-  private val barePanoId = "AiSubmissionSpec-pano-4806-no-metadata"
+  // order. The insert-without-the-key case needs a pristine row of its own, hence the second id, and the
+  // failed-pano-write case (#4587) a third.
+  private val panoId       = "AiSubmissionSpec-pano-4806"
+  private val barePanoId   = "AiSubmissionSpec-pano-4806-no-metadata"
+  private val badLatPanoId = "AiSubmissionSpec-pano-4587-bad-lat"
 
   // `city-id` resolves from this env var (conf/application.conf), which has no default — an unset value would boot an
   // app whose city flag this spec can't address, so fail loudly here instead of failing obscurely four cases later.
@@ -65,7 +67,7 @@ class AiSubmissionSpec extends PlaySpec with BeforeAndAfterAll with GuiceOneAppP
   private def runDb[T](action: DBIO[T]): T = Await.result(dbConfig.db.run(action), 30.seconds)
 
   private def deleteTestPanos(): Unit = {
-    val _ = runDb(sqlu"DELETE FROM pano_data WHERE pano_id IN ($panoId, $barePanoId)")
+    val _ = runDb(sqlu"DELETE FROM pano_data WHERE pano_id IN ($panoId, $barePanoId, $badLatPanoId)")
   }
 
   private def panoRowCount(id: String = panoId): Int =
@@ -159,6 +161,17 @@ class AiSubmissionSpec extends PlaySpec with BeforeAndAfterAll with GuiceOneAppP
       val oversized = Json.obj("padding" -> "x" * (64 * 1024))
       status(post(payloadWithRawMetadata(oversized))) mustBe BAD_REQUEST
       storedMetadata().map(Json.parse) mustBe Some(metadataV2)
+    }
+
+    "fail the whole request when the pano write fails, rather than saving labels without their pano (#4587)" in {
+      // lat=999 violates pano_data's lat/lng CHECK constraint, so the pano write fails at the database and the
+      // submission is refused outright — the pano must be recorded even for a label-less payload like this one, and
+      // the automated labeler can simply retry.
+      val base      = payload(None, id = badLatPanoId)
+      val badLatPay = base + ("pano" -> ((base \ "pano").as[JsObject] + ("lat" -> Json.toJson(999.0))))
+
+      status(post(badLatPay)) mustBe INTERNAL_SERVER_ERROR
+      panoRowCount(badLatPanoId) mustBe 0
     }
   }
 }

--- a/test/controllers/ExploreTaskSubmissionSpec.scala
+++ b/test/controllers/ExploreTaskSubmissionSpec.scala
@@ -31,7 +31,9 @@ import scala.concurrent.duration._
  *   - a label's pano block alone (no `panos` batch) produces the pano_data, pano_link, and pano_history rows;
  *   - a label whose pano block fails to write (here: a lat outside pano_data's CHECK constraint) fails the whole
  *     submission, saving neither the label nor the pano;
- *   - a failing *viewed* pano costs nothing else in the submission;
+ *   - a label whose pano block describes a *different* pano is refused outright at validation;
+ *   - a failing *viewed* pano costs nothing else in the submission (the viewed batch is written off the request's
+ *     critical path, so those assertions poll);
  *   - resubmitting a pano refreshes its metadata without clearing anything: position fields take the newest value,
  *     absent fields leave existing values alone, NULL intrinsics (e.g. width) get filled in, and re-sent links and
  *     history entries don't duplicate (also the race-safety guarantee — concurrent duplicate submissions must not
@@ -292,23 +294,46 @@ class ExploreTaskSubmissionSpec extends PlaySpec with BeforeAndAfterAll with Eve
       panoRow(panoId) mustBe None
     }
 
+    "reject a label whose pano block describes a different pano" in {
+      val labelPanoId = s"$panoPrefix-mismatch-label"
+      val blockPanoId = s"$panoPrefix-mismatch-block"
+
+      // A mismatched block would commit a label pointing at one pano while writing another's pano_data row — the
+      // orphan #4587 exists to prevent — so validation refuses the submission before anything touches the database.
+      val resp = post(
+        submission(
+          labels = Seq(label(labelPanoId, tempLabelId = 6, pano = Some(pano(blockPanoId)))),
+          panos = Seq.empty
+        )
+      )
+
+      status(resp) mustBe BAD_REQUEST
+      labelCount(labelPanoId) mustBe 0
+      panoRow(blockPanoId) mustBe None
+    }
+
     "save the labels and the rest of the batch when a viewed pano's metadata write fails" in {
-      val badPanoId  = s"$panoPrefix-bad"
-      val goodPanoId = s"$panoPrefix-good"
+      val badPanoId    = s"$panoPrefix-bad"
+      val goodPanoId   = s"$panoPrefix-good"
+      val viewedPanoId = s"$panoPrefix-viewed"
 
       // The `panos` batch tracks panos merely viewed this session, so a CHECK-violating entry there is logged and
       // skipped without costing the labels (whose own pano rides the label) or the other viewed panos.
       val resp = post(
         submission(
           labels = Seq(label(goodPanoId, tempLabelId = 3, pano = Some(pano(goodPanoId)))),
-          panos = Seq(pano(badPanoId, lat = Some(999.0)), pano(goodPanoId))
+          panos = Seq(pano(badPanoId, lat = Some(999.0)), pano(viewedPanoId))
         )
       )
 
       status(resp) mustBe OK
       labelCount(goodPanoId) mustBe 1
+      panoRow(goodPanoId) mustBe Some((Some(41.87), Some(8192), None))
+      // The viewed batch is written off the request's critical path, so its rows may land after the response.
+      eventually(timeout(Span(10, Seconds)), interval(Span(200, Millis))) {
+        panoRow(viewedPanoId) mustBe Some((Some(41.87), Some(8192), None)) // A bad viewed pano doesn't sink the rest.
+      }
       panoRow(badPanoId) mustBe None
-      panoRow(goodPanoId) mustBe Some((Some(41.87), Some(8192), None)) // A bad viewed pano doesn't sink the rest.
     }
 
     "refresh pano metadata on resubmission without clearing or duplicating anything" in {
@@ -328,6 +353,11 @@ class ExploreTaskSubmissionSpec extends PlaySpec with BeforeAndAfterAll with Eve
         )
       )
       status(first) mustBe OK
+      // The viewed batch is written off the request's critical path; wait for the first write to land so the
+      // newest-position-wins assertion below can't race it.
+      eventually(timeout(Span(10, Seconds)), interval(Span(200, Millis))) {
+        panoRow(panoId) mustBe Some((Some(41.1), None, Some("123 Main St")))
+      }
 
       // Resubmit the same pano: a newer position, dimensions this time, no address, and the same link + history.
       val second = post(
@@ -342,7 +372,9 @@ class ExploreTaskSubmissionSpec extends PlaySpec with BeforeAndAfterAll with Eve
       status(second) mustBe OK
 
       // Newest position wins, the NULL width was filled in, and the absent address didn't clear the stored one.
-      panoRow(panoId) mustBe Some((Some(41.2), Some(4096), Some("123 Main St")))
+      eventually(timeout(Span(10, Seconds)), interval(Span(200, Millis))) {
+        panoRow(panoId) mustBe Some((Some(41.2), Some(4096), Some("123 Main St")))
+      }
       runDb(sql"SELECT count(*) FROM pano_link WHERE pano_id = $panoId".as[Int].head) mustBe 1
       runDb(sql"SELECT count(*) FROM pano_history WHERE location_curr_pano_id = $panoId".as[Int].head) mustBe 1
     }

--- a/test/controllers/ExploreTaskSubmissionSpec.scala
+++ b/test/controllers/ExploreTaskSubmissionSpec.scala
@@ -1,0 +1,364 @@
+package controllers
+
+import models.utils.MyPostgresProfile
+import models.utils.MyPostgresProfile.api._
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.Eventually
+import org.scalatest.time.{Millis, Seconds, Span}
+import org.scalatestplus.play.PlaySpec
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
+import play.api.db.slick.DatabaseConfigProvider
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.json.{JsArray, JsNull, JsObject, Json}
+import play.api.mvc.Cookie
+import play.api.test.CSRFTokenHelper._
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+
+import java.time.OffsetDateTime
+import java.util.UUID
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+/**
+ * Locks the pano/label contract of POST /task (#4587). A pano's metadata is integral to its labels: each label
+ * carries a `pano` block, and the server commits the pano_data row and the label atomically in one transaction, so a
+ * label can never be saved without its pano row — and a label whose pano block fails to write fails the whole
+ * submission rather than quietly producing an orphan. The separate `panos` batch only tracks panos *viewed* during
+ * the session, so it keeps the opposite, lenient semantics: a failure there is logged and costs neither the labels
+ * nor the rest of the batch. Specifically:
+ *   - a label's pano block alone (no `panos` batch) produces the pano_data, pano_link, and pano_history rows;
+ *   - a label whose pano block fails to write (here: a lat outside pano_data's CHECK constraint) fails the whole
+ *     submission, saving neither the label nor the pano;
+ *   - a failing *viewed* pano costs nothing else in the submission;
+ *   - resubmitting a pano refreshes its metadata without clearing anything: position fields take the newest value,
+ *     absent fields leave existing values alone, NULL intrinsics (e.g. width) get filled in, and re-sent links and
+ *     history entries don't duplicate (also the race-safety guarantee — concurrent duplicate submissions must not
+ *     error, and ON CONFLICT is what makes both hold).
+ *
+ * Boots the real application against Postgres+PostGIS and drives the endpoint over HTTP through Silhouette's
+ * anonymous session, like ImageControllerSpec. The submission needs a real mission row for the signed-in user, so the
+ * suite mints one anon session, finds its user_id via the AnonAutoSignUp activity log (tagged with a unique marker),
+ * and inserts one audit mission for it directly; everything written under that user is deleted in afterAll.
+ */
+// Mixin order matters: GuiceOneAppPerSuite must be rightmost so its run() wraps BeforeAndAfterAll's — otherwise
+// afterAll's cleanup executes after the app (and its DB pool) has shut down and aborts the suite.
+class ExploreTaskSubmissionSpec extends PlaySpec with BeforeAndAfterAll with Eventually with GuiceOneAppPerSuite {
+
+  // Every pano this suite creates carries this prefix, so cleanup can't touch real panos.
+  private val panoPrefix = "ExploreTaskSubmissionSpec-4587"
+
+  override def fakeApplication(): Application =
+    new GuiceApplicationBuilder()
+      .disable[modules.ActorModule] // No eager background actors during tests.
+      .configure("ai-enabled" -> false) // Label submission fires AI validation calls; keep the suite offline.
+      .build()
+
+  private lazy val dbConfig = app.injector.instanceOf[DatabaseConfigProvider].get[MyPostgresProfile]
+
+  /** Runs a DBIO synchronously; for arrange/assert queries only, never the code under test. */
+  private def runDb[T](action: DBIO[T]): T = Await.result(dbConfig.db.run(action), 30.seconds)
+
+  // One anon session + mission fixture shared by the whole suite, minted on first use. The var mirrors of the lazy
+  // vals let afterAll clean up without forcing fixture creation when a run dies before any test used them.
+  private var mintedUserId: Option[String] = None
+
+  private lazy val (sessionCookies: Seq[Cookie], userId: String) = {
+    val marker = UUID.randomUUID().toString
+    val resp   = route(app, FakeRequest(GET, s"/anonSignUp?url=%2F%3Fspec%3D$marker")).get
+    status(resp) mustBe SEE_OTHER
+    // The signup's activity-log write is async; poll for the marker to learn the fresh user's id.
+    val id = eventually(timeout(Span(10, Seconds)), interval(Span(200, Millis))) {
+      val ids = runDb(sql"SELECT user_id FROM webpage_activity WHERE activity LIKE ${s"%spec=$marker%"}".as[String])
+      ids must have size 1
+      ids.head
+    }
+    mintedUserId = Some(id)
+    (cookies(resp).toSeq, id)
+  }
+
+  private lazy val (streetEdgeId: Int, regionId: Int) = runDb(
+    sql"""SELECT street_edge_region.street_edge_id, street_edge_region.region_id
+          FROM street_edge_region
+          JOIN region ON street_edge_region.region_id = region.region_id
+          WHERE region.deleted = false
+          LIMIT 1""".as[(Int, Int)].head
+  )
+
+  private lazy val missionId: Int = runDb(
+    sql"""INSERT INTO mission (mission_type, user_id, completed, pay, paid, distance_meters, distance_progress,
+                               skipped, region_id)
+          VALUES ('audit', $userId, false, 0.0, false, 500.0, 0.0, false, $regionId)
+          RETURNING mission_id""".as[Int].head
+  )
+
+  private def deleteTestPanos(): Unit = {
+    val prefixPattern = s"$panoPrefix%"
+    val _             = runDb(
+      DBIO.seq(
+        sqlu"DELETE FROM pano_link WHERE pano_id LIKE $prefixPattern",
+        sqlu"DELETE FROM pano_history WHERE location_curr_pano_id LIKE $prefixPattern",
+        sqlu"DELETE FROM pano_data WHERE pano_id LIKE $prefixPattern"
+      )
+    )
+  }
+
+  /** Removes everything the suite's submissions wrote under its throwaway anon user (the bare user row stays). */
+  private def deleteTestSubmissionData(): Unit = mintedUserId.foreach { uId =>
+    val _ = runDb(
+      DBIO.seq(
+        sqlu"""DELETE FROM label_history
+               WHERE label_id IN (SELECT label_id FROM label WHERE user_id = $uId)""",
+        sqlu"""DELETE FROM label_point
+               WHERE label_id IN (SELECT label_id FROM label WHERE user_id = $uId)""",
+        sqlu"DELETE FROM label WHERE user_id = $uId",
+        sqlu"""DELETE FROM audit_task_environment
+               WHERE audit_task_id IN (SELECT audit_task_id FROM audit_task WHERE user_id = $uId)""",
+        sqlu"""DELETE FROM audit_task_interaction
+               WHERE audit_task_id IN (SELECT audit_task_id FROM audit_task WHERE user_id = $uId)""",
+        sqlu"DELETE FROM audit_task WHERE user_id = $uId",
+        sqlu"DELETE FROM mission WHERE user_id = $uId"
+      )
+    )
+  }
+
+  override def beforeAll(): Unit = { super.beforeAll(); deleteTestPanos() } // A dead earlier run may have left rows.
+  override def afterAll(): Unit  = {
+    try { deleteTestSubmissionData(); deleteTestPanos() }
+    finally super.afterAll()
+  }
+
+  private def label(panoId: String, tempLabelId: Int, pano: Option[JsObject] = None): JsObject = {
+    val base = Json.obj(
+      "pano_id"            -> panoId,
+      "pano_source"        -> "gsv",
+      "label_type"         -> "CurbRamp",
+      "deleted"            -> false,
+      "severity"           -> JsNull,
+      "description"        -> JsNull,
+      "tag_ids"            -> Json.arr(),
+      "temporary_label_id" -> tempLabelId,
+      "time_created"       -> OffsetDateTime.now.toString,
+      "tutorial"           -> false,
+      // No lat/lng: the label then attaches to the audit task's street, so the spec needs no spatial fixtures.
+      "label_point" -> Json.obj(
+        "pano_x"   -> 100,
+        "pano_y"   -> 100,
+        "canvas_x" -> 200,
+        "canvas_y" -> 200,
+        "heading"  -> 90.0,
+        "pitch"    -> 0.0,
+        "zoom"     -> 1.0,
+        "lat"      -> JsNull,
+        "lng"      -> JsNull
+      )
+    )
+    pano.fold(base)(p => base + ("pano" -> p))
+  }
+
+  private def pano(
+      panoId: String,
+      lat: Option[Double] = Some(41.87),
+      lng: Option[Double] = Some(-87.62),
+      width: Option[Int] = Some(8192),
+      address: Option[String] = None,
+      links: Seq[JsObject] = Seq.empty,
+      history: Seq[JsObject] = Seq.empty
+  ): JsObject = Json.obj(
+    "pano_id"        -> panoId,
+    "source"         -> "gsv",
+    "capture_date"   -> "2024-06",
+    "width"          -> width,
+    "height"         -> width.map(_ / 2),
+    "lat"            -> lat,
+    "lng"            -> lng,
+    "camera_heading" -> 180.0,
+    "links"          -> JsArray(links),
+    "address"        -> address,
+    "history"        -> JsArray(history)
+  )
+
+  private def submission(labels: Seq[JsObject], panos: Seq[JsObject]): JsObject = {
+    val now = OffsetDateTime.now.toString
+    Json.obj(
+      "mission" -> Json.obj(
+        "mission_id"        -> missionId,
+        "distance_progress" -> 1.0,
+        "region_id"         -> regionId,
+        "completed"         -> false,
+        "audit_task_id"     -> JsNull,
+        "skipped"           -> false
+      ),
+      // completed=false keeps the submission from touching street priority / region completion state.
+      "audit_task" -> Json.obj(
+        "street_edge_id"                  -> streetEdgeId,
+        "task_start"                      -> now,
+        "audit_task_id"                   -> JsNull,
+        "completed"                       -> false,
+        "current_lat"                     -> 41.85,
+        "current_lng"                     -> -87.65,
+        "start_point_reversed"            -> false,
+        "current_mission_start"           -> JsNull,
+        "last_priority_update_time"       -> now,
+        "request_updated_street_priority" -> false,
+        "audited_distance_m"              -> 0.0,
+        "route_street_id"                 -> JsNull
+      ),
+      "labels"       -> JsArray(labels),
+      "interactions" -> Json.arr(),
+      "environment"  -> Json.obj(
+        "browser"          -> "chrome",
+        "browser_version"  -> "1",
+        "browser_width"    -> 1920,
+        "browser_height"   -> 1080,
+        "avail_width"      -> 1920,
+        "avail_height"     -> 1080,
+        "screen_width"     -> 1920,
+        "screen_height"    -> 1080,
+        "operating_system" -> "linux",
+        "language"         -> "en",
+        "css_zoom"         -> 100
+      ),
+      "panos"         -> JsArray(panos),
+      "user_route_id" -> JsNull,
+      "timestamp"     -> now
+    )
+  }
+
+  private def post(body: JsObject) =
+    route(app, FakeRequest(POST, "/task").withCookies(sessionCookies: _*).withJsonBody(body).withCSRFToken).get
+
+  private def labelCount(panoId: String): Int =
+    runDb(sql"SELECT count(*) FROM label WHERE pano_id = $panoId AND user_id = $userId".as[Int].head)
+
+  private def panoRow(panoId: String): Option[(Option[Double], Option[Int], Option[String])] =
+    runDb(
+      sql"SELECT lat, width, address FROM pano_data WHERE pano_id = $panoId"
+        .as[(Option[Double], Option[Int], Option[String])]
+        .headOption
+    )
+
+  "POST /task" should {
+    "save a label atomically with the pano metadata, links, and history it carries" in {
+      val panoId       = s"$panoPrefix-happy"
+      val targetPanoId = s"$panoPrefix-happy-target"
+      val prevPanoId   = s"$panoPrefix-happy-prev"
+      val link         = Json.obj("target_pano_id" -> targetPanoId, "yaw_deg" -> 45.0, "description" -> JsNull)
+      val history      = Json.obj("pano_id" -> prevPanoId, "date" -> "2019-05")
+
+      // The pano rides the label only — an empty `panos` batch proves the label path alone produces the pano rows.
+      val resp = post(
+        submission(
+          labels = Seq(
+            label(
+              panoId,
+              tempLabelId = 1,
+              pano = Some(pano(panoId, address = Some("123 Main St"), links = Seq(link), history = Seq(history)))
+            )
+          ),
+          panos = Seq.empty
+        )
+      )
+
+      status(resp) mustBe OK
+      (contentAsJson(resp) \ "label_ids").as[Seq[JsObject]] must have size 1
+      labelCount(panoId) mustBe 1
+      panoRow(panoId) mustBe Some((Some(41.87), Some(8192), Some("123 Main St")))
+      runDb(
+        sql"SELECT count(*) FROM pano_link WHERE pano_id = $panoId AND target_pano_id = $targetPanoId".as[Int].head
+      ) mustBe 1
+      runDb(
+        sql"SELECT count(*) FROM pano_history WHERE pano_id = $prevPanoId AND location_curr_pano_id = $panoId"
+          .as[Int]
+          .head
+      ) mustBe 1
+    }
+
+    "fail the whole submission when a label's own pano block fails to write, saving neither" in {
+      val panoId = s"$panoPrefix-label-bad"
+
+      // lat=999 violates pano_data's lat/lng CHECK constraint. The pano is integral to the label, so the write
+      // failure must roll back the label with it instead of quietly saving an orphan.
+      val resp = post(
+        submission(
+          labels = Seq(label(panoId, tempLabelId = 2, pano = Some(pano(panoId, lat = Some(999.0))))),
+          panos = Seq.empty
+        )
+      )
+
+      status(resp) mustBe INTERNAL_SERVER_ERROR
+      labelCount(panoId) mustBe 0
+      panoRow(panoId) mustBe None
+    }
+
+    "save the labels and the rest of the batch when a viewed pano's metadata write fails" in {
+      val badPanoId  = s"$panoPrefix-bad"
+      val goodPanoId = s"$panoPrefix-good"
+
+      // The `panos` batch tracks panos merely viewed this session, so a CHECK-violating entry there is logged and
+      // skipped without costing the labels (whose own pano rides the label) or the other viewed panos.
+      val resp = post(
+        submission(
+          labels = Seq(label(goodPanoId, tempLabelId = 3, pano = Some(pano(goodPanoId)))),
+          panos = Seq(pano(badPanoId, lat = Some(999.0)), pano(goodPanoId))
+        )
+      )
+
+      status(resp) mustBe OK
+      labelCount(goodPanoId) mustBe 1
+      panoRow(badPanoId) mustBe None
+      panoRow(goodPanoId) mustBe Some((Some(41.87), Some(8192), None)) // A bad viewed pano doesn't sink the rest.
+    }
+
+    "refresh pano metadata on resubmission without clearing or duplicating anything" in {
+      val panoId       = s"$panoPrefix-refresh"
+      val targetPanoId = s"$panoPrefix-refresh-target"
+      val prevPanoId   = s"$panoPrefix-refresh-prev"
+      val link         = Json.obj("target_pano_id" -> targetPanoId, "yaw_deg" -> 45.0, "description" -> JsNull)
+      val history      = Json.obj("pano_id" -> prevPanoId, "date" -> "2019-05")
+
+      val first = post(
+        submission(
+          labels = Seq.empty,
+          panos = Seq(
+            pano(panoId, lat = Some(41.1), width = None, address = Some("123 Main St"), links = Seq(link),
+              history = Seq(history))
+          )
+        )
+      )
+      status(first) mustBe OK
+
+      // Resubmit the same pano: a newer position, dimensions this time, no address, and the same link + history.
+      val second = post(
+        submission(
+          labels = Seq.empty,
+          panos = Seq(
+            pano(panoId, lat = Some(41.2), width = Some(4096), address = None, links = Seq(link),
+              history = Seq(history))
+          )
+        )
+      )
+      status(second) mustBe OK
+
+      // Newest position wins, the NULL width was filled in, and the absent address didn't clear the stored one.
+      panoRow(panoId) mustBe Some((Some(41.2), Some(4096), Some("123 Main St")))
+      runDb(sql"SELECT count(*) FROM pano_link WHERE pano_id = $panoId".as[Int].head) mustBe 1
+      runDb(sql"SELECT count(*) FROM pano_history WHERE location_curr_pano_id = $panoId".as[Int].head) mustBe 1
+    }
+
+    "save a label that carries no pano block, the shape tutorial labels use" in {
+      // Labels on the locally-served tutorial panos omit the block so their fabricated metadata can't touch the
+      // seeded pano_data rows; the server extends the same leniency to any blockless label. The eventual FK on
+      // label.pano_id (#4587's endgame, once legacy orphans are backfilled) is what will make this shape impossible
+      // for non-tutorial panos.
+      val panoId = s"$panoPrefix-absent"
+
+      val resp = post(submission(labels = Seq(label(panoId, tempLabelId = 4)), panos = Seq.empty))
+
+      status(resp) mustBe OK
+      labelCount(panoId) mustBe 1
+      panoRow(panoId) mustBe None
+    }
+  }
+}

--- a/test/js/exploreFormPanoSubmitted.test.js
+++ b/test/js/exploreFormPanoSubmitted.test.js
@@ -179,11 +179,16 @@ describe('Form pano submission staging', () => {
 
     test('keeps panos staged for the next submission when the server rejects the POST', async () => {
         window.fetch = jest.fn(() => Promise.resolve({ ok: false, json: async () => ({}) }));
+        const task = taskStub();
 
-        await form.submitData(taskStub());
+        await form.submitData(task);
 
         // Still staged: the next submission's payload will carry their metadata again.
         for (const pano of panos) expect(pano.getProperty('submitted')).toBe(false);
+        // And the success handler must not run against the error body — that would clobber the task's and the
+        // tracker's audit_task_id with undefined and desync every later submission.
+        expect(task.setProperty).not.toHaveBeenCalled();
+        expect(window.svl.tracker.setAuditTaskID).not.toHaveBeenCalled();
     });
 
     test('keeps panos staged when the POST fails at the network level', async () => {

--- a/test/js/exploreFormPanoSubmitted.test.js
+++ b/test/js/exploreFormPanoSubmitted.test.js
@@ -1,0 +1,225 @@
+/**
+ * Tests for Form's pano staging contract (public/js/explore/src/data/Form.js, issue #4587).
+ *
+ * A pano's metadata is submitted at most once per session: PanoStore hands Form only panos not yet marked
+ * `submitted`. That mark must therefore mean "the server accepted this pano" — if it were set when the payload is
+ * compiled, a failed POST would permanently drop the pano's metadata while later submissions keep referencing its
+ * pano_id in labels, orphaning them. These tests pin the contract: panos are marked `submitted` only on a 2xx
+ * response, and stay staged (to ride along with the next submission) on an HTTP error or a network failure.
+ *
+ * Form is a top-level `class` declaration, so the test evals the source into the jsdom global scope (the
+ * ShareWidget/PanoInfoPopover pattern) rather than using loadGlobalScript.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const FORM_SRC = fs.readFileSync(
+    path.resolve(__dirname, '..', '..', 'public/js/explore/src/data/Form.js'), 'utf8'
+);
+
+/** Loads a fresh Form class into the jsdom global scope. */
+function loadForm() {
+    window.eval(`${FORM_SRC}\nwindow.Form = Form;`);
+    return window.Form;
+}
+
+/** A stand-in for a PanoStore pano whose metadata hasn't been submitted yet. */
+function panoStub(panoId) {
+    const props = {
+        panoId,
+        source: 'gsv',
+        captureDate: { format: () => '2024-06' },
+        width: 8192,
+        height: 4096,
+        tileWidth: 512,
+        tileHeight: 512,
+        lat: 41.87,
+        lng: -87.62,
+        cameraHeading: 180,
+        cameraPitch: 0,
+        cameraRoll: 0,
+        linkedPanos: [],
+        history: [],
+        copyright: null,
+        address: null,
+        submitted: false,
+    };
+    return {
+        getProperties: () => props,
+        getProperty: (k) => props[k],
+        setProperty: jest.fn((k, v) => { props[k] = v; }),
+    };
+}
+
+/** A stand-in for a label placed this session on the given pano. */
+function labelStub(panoId, tempLabelId) {
+    const props = {
+        panoId,
+        tutorial: false,
+        panoXY: { x: 100, y: 100 },
+        originalCanvasXY: { x: 200, y: 200 },
+        originalPov: { heading: 90, pitch: 0, zoom: 1 },
+        temporaryLabelId: tempLabelId,
+        severity: null,
+        tagIds: [],
+        description: null,
+    };
+    return {
+        getProperties: () => props,
+        getProperty: (k) => props[k],
+        toLatLng: () => null,
+        isDeleted: () => false,
+        getLabelType: () => 'CurbRamp',
+    };
+}
+
+/** A stand-in for the current audit task. */
+function taskStub() {
+    return {
+        getAuditTaskId: () => 12,
+        getStreetEdgeId: () => 34,
+        getProperty: () => null,
+        isComplete: () => false,
+        getMissionStart: () => null,
+        getAuditedDistance: () => 0,
+        lineDistance: () => 1,
+        setProperty: jest.fn(),
+    };
+}
+
+describe('Form pano submission staging', () => {
+    let panos;
+    let labels;
+    let form;
+
+    /** Builds a Form wired to stub collaborators, staging the given panos and labels. */
+    function buildForm() {
+        const Form = loadForm();
+        const missionProps = { missionId: 5, distanceProgress: 0, distance: 100, isComplete: false, skipped: false };
+        const mission = { getProperty: (k) => missionProps[k], updateDistanceProgress: jest.fn() };
+        const labelContainer = { getLabelsToLog: () => labels, clearLabelsToLog: jest.fn(), getAllLabels: () => [] };
+        const panoStore = {
+            getStagedPanoData: () => panos.filter((p) => !p.getProperty('submitted')),
+            getPanoData: (id) => panos.find((p) => p.getProperty('panoId') === id) ?? null,
+        };
+        const taskContainer = { getCurrentTask: taskStub, updateTaskPriorities: jest.fn() };
+        return new Form(
+            labelContainer,
+            { on: jest.fn() }, // missionModel
+            { getCurrentMission: () => mission }, // missionContainer
+            panoStore,
+            taskContainer,
+            { getActions: () => [], refresh: jest.fn(), push: jest.fn() }, // tracker
+            '/task'
+        );
+    }
+
+    /** Stubs fetch to accept the POST, capturing each request body as parsed JSON. */
+    function acceptingFetch() {
+        const bodies = [];
+        window.fetch = jest.fn((url, opts) => {
+            bodies.push(JSON.parse(opts.body));
+            return Promise.resolve({
+                ok: true,
+                json: async () => ({ audit_task_id: 12, label_ids: [], refresh_page: false }),
+            });
+        });
+        return bodies;
+    }
+
+    beforeEach(() => {
+        // Form's collaborators that live on globals rather than constructor args.
+        window.AsyncLock = class { async acquire(key, fn) { return fn(); } };
+        window.svl = {
+            userRouteId: null,
+            regionId: 1,
+            isOnboarding: () => false,
+            panoViewer: { getPosition: () => ({ lat: 41.85, lng: -87.65 }) },
+            tracker: { setAuditTaskID: jest.fn() },
+        };
+        window.util = {
+            getBrowser: () => 'chrome',
+            getBrowserVersion: () => '1',
+            getOperatingSystem: () => 'linux',
+            math: { kmsToMeters: (km) => km * 1000 },
+            pano: { TUTORIAL_PANO_IDS: new Set(['tutorial', 'afterWalkTutorial']) },
+        };
+        window.$ = jest.fn(() => ({ width: () => 1920, height: () => 1080 }));
+        window.i18next = { language: 'en' };
+
+        panos = [panoStub('pano-A'), panoStub('pano-B')];
+        labels = [];
+        form = buildForm();
+
+        // The failure paths end in window.location.reload(), which jsdom reports as "Not implemented: navigation"
+        // through console.error; swallow that expected noise without hiding real errors from the assertions.
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test('marks panos submitted only once the server has accepted them', async () => {
+        window.fetch = jest.fn(() => {
+            // At POST time the panos must still be staged: the mark means "accepted", not "sent".
+            for (const pano of panos) expect(pano.getProperty('submitted')).toBe(false);
+            return Promise.resolve({
+                ok: true,
+                json: async () => ({ audit_task_id: 12, label_ids: [], refresh_page: false }),
+            });
+        });
+
+        await form.submitData(taskStub());
+
+        expect(window.fetch).toHaveBeenCalledTimes(1);
+        for (const pano of panos) expect(pano.getProperty('submitted')).toBe(true);
+    });
+
+    test('keeps panos staged for the next submission when the server rejects the POST', async () => {
+        window.fetch = jest.fn(() => Promise.resolve({ ok: false, json: async () => ({}) }));
+
+        await form.submitData(taskStub());
+
+        // Still staged: the next submission's payload will carry their metadata again.
+        for (const pano of panos) expect(pano.getProperty('submitted')).toBe(false);
+    });
+
+    test('keeps panos staged when the POST fails at the network level', async () => {
+        window.fetch = jest.fn(() => Promise.reject(new Error('network down')));
+
+        await form.submitData(taskStub());
+
+        for (const pano of panos) expect(pano.getProperty('submitted')).toBe(false);
+    });
+
+    test('attaches the pano metadata block to each label so the server can commit them atomically', async () => {
+        labels = [labelStub('pano-A', 7)];
+        const bodies = acceptingFetch();
+
+        await form.submitData(taskStub());
+
+        const sent = bodies[0].labels[0];
+        expect(sent.temporary_label_id).toBe(7);
+        // The block carries the pano's full metadata, not just an id reference (#4587).
+        expect(sent.pano).toMatchObject({ pano_id: 'pano-A', source: 'gsv', capture_date: '2024-06', width: 8192 });
+        // The same pano still rides the viewed-panos batch; the server's writes are idempotent.
+        expect(bodies[0].panos.map((p) => p.pano_id)).toContain('pano-A');
+    });
+
+    test('omits the pano block for labels on the locally-served tutorial panos', async () => {
+        // Tutorial panos carry fabricated metadata that must never touch the seeded pano_data rows; PanoStore also
+        // marks them submitted on arrival, so they are excluded from the viewed-panos batch.
+        const tutorialPano = panoStub('tutorial');
+        tutorialPano.setProperty('submitted', true);
+        panos = [tutorialPano];
+        labels = [labelStub('tutorial', 8)];
+        const bodies = acceptingFetch();
+
+        await form.submitData(taskStub());
+
+        expect(bodies[0].labels[0].pano).toBeUndefined();
+        expect(bodies[0].panos).toHaveLength(0);
+    });
+});

--- a/test/service/ExploreAddressServiceSpec.scala
+++ b/test/service/ExploreAddressServiceSpec.scala
@@ -194,7 +194,8 @@ class ExploreAddressServiceSpec extends PlaySpec with org.scalatest.BeforeAndAft
       point = LabelPointSubmission(0, 0, 0, 0, 0d, 0d, 1d, None, None, None),
       temporaryLabelId = temporaryLabelId,
       timeCreated = Some(OffsetDateTime.now),
-      tutorial = false
+      tutorial = false,
+      pano = None
     )
 
   "getDataForExploreAddressPage" should {


### PR DESCRIPTION
Addresses the "stop creating new orphans" half of #4587 (the backfill for existing orphans will be a separate PR, so this should not auto-close the issue).

Fixes #4812

## Problem

Labels referencing a `pano_id` with no `pano_data` row silently drop out of every query that inner-joins `pano_data` (API exports, Gallery, AI validation). The pano write was fire-and-forget after the labels were committed:

- failures were silently swallowed (the two standing TODOs in `ExploreController`);
- `DBIO.sequence` was fail-fast, so one bad pano aborted every other pano in the batch;
- the check-then-insert pattern lost duplicate-key races between concurrent submissions (`pagehide` flush racing a mission-complete POST, two open tabs);
- the client marked panos `submitted` at compile time, so a pano whose server-side write failed was never re-sent — orphaning every later label placed on it that session.

## Changes

**A pano's metadata is integral to its labels.** Each `LabelSubmission` now carries its pano's metadata block, and the server upserts the `pano_data` row (plus `pano_link`/`pano_history`) inside the same transaction as the label insert. A label can never be committed without its pano row, and a label whose pano write fails rolls back with it (logged JSON 500) instead of quietly producing an orphan. Labels on the locally-served tutorial panos omit the block so their fabricated metadata can't touch the seeded rows.

**The `data.panos` batch is now purely view-tracking** (panos seen but not labeled) with deliberately lenient semantics:
- `pano_data` writes are a single `INSERT ... ON CONFLICT` upsert: race-proof, never clears existing values (newest position wins, NULLs never overwrite; dimensions/copyright fill NULLs only; `address`/`source_metadata` keep #4806's replace-never-clear semantics).
- `pano_link`/`pano_history` use `ON CONFLICT DO NOTHING`.
- Per-pano failure isolation with error logging — one bad viewed pano costs nothing else.

**Client retry.** `Form.js` marks panos `submitted` only on a 2xx response, so a failed POST's pano metadata stays staged and rides along with the next submission.

**AI ingest** (`/ai/submitLabelsOnPano`) keeps its fail-fast up-front pano write (needed for its label-less payloads) and gains the same per-label atomicity through the shared insert path.

Once the backfill clears legacy orphans, this sets up the FK on `label.pano_id` → `pano_data.pano_id`.

## Testing

- New `ExploreTaskSubmissionSpec` drives POST `/task` over HTTP with a real anon session + mission fixture: a label's pano block alone produces the pano/link/history rows; a CHECK-violating label-pano saves neither label nor pano (500); a bad viewed pano costs nothing else; resubmission refreshes without clearing or duplicating; blockless (tutorial-shaped) labels still save.
- `AiSubmissionSpec` gained the fail-fast case; its existing source-metadata provenance cases regression-test the upsert.
- New jsdom tests for `Form.js`: the label payload carries the pano block (tutorial labels don't), and panos stay staged after failed POSTs.
- Full `sbt test`, `npm run test:js` (672/672), scalafmt + ESLint clean. Manual QA of Explore labeling done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)