### PR TITLE
Check Mapillary imagery in the nightly expiry sweep, with bounded concurrency

### DIFF
--- a/app/models/pano/PanoDataTable.scala
+++ b/app/models/pano/PanoDataTable.scala
@@ -56,6 +56,11 @@ object PanoSource extends Enumeration {
   val Gsv       = Value("gsv")
   val Mapillary = Value("mapillary")
   val Infra3d   = Value("infra3d")
+
+  /**
+   * Sources whose imagery `PanoDataService.panoExists` can actually verify against a provider API.
+   */
+  val providerCheckedSources: Set[Value] = Set(Gsv, Mapillary)
 }
 
 case class PanoDataSlim(
@@ -127,13 +132,15 @@ class PanoDataTable @Inject() (protected val dbConfigProvider: DatabaseConfigPro
   }
 
   /**
-   * Count the number of panos that have associated labels. Only including GSV imagery for now.
+   * Count the panos that have associated labels and an imagery source we can verify against a provider API.
+   *
+   * Sizes the nightly expiry sample, so it counts the same population `getPanoIdsToCheckExpiration` draws from.
    */
-  def countGsvPanosWithLabels: DBIO[Int] = {
+  def countCheckablePanosWithLabels: DBIO[Int] = {
     labelTable
       .join(panoDataRecords)
       .on(_.panoId === _.panoId)
-      .filter(_._2.source === PanoSource.Gsv)
+      .filter(_._2.source inSet PanoSource.providerCheckedSources)
       .map(_._2.panoId)
       .countDistinct
       .result
@@ -175,9 +182,9 @@ class PanoDataTable @Inject() (protected val dbConfigProvider: DatabaseConfigPro
    *   - `expired` is false and `last_checked` is at or after `liveCheckedSince`. Liveness *can* lapse at any moment, so
    *     this side carries a TTL that bounds how long we'd keep handing out a pano that has since gone away.
    *
-   * GSV only: Mapillary has no nightly expiry check behind it (`getPanoIdsToCheckExpiration` is GSV-only), so its
-   * foreground check is the only one there is and must keep running. Infra3d is never checked against a provider at
-   * all. Both simply get no cache entry here.
+   * Restricted to `PanoSource.providerCheckedSources`, because both branches lean on the nightly sweep: it is what
+   * re-checks expired panos to catch ones marked so incorrectly, and what keeps `last_checked` moving. Infra3d is
+   * never checked against a provider, so its columns don't reflect a real answer and it gets no cache entry here.
    *
    * @param panoIds          Panos to look up.
    * @param liveCheckedSince Cutoff for reusing a non-expired result; older ones are re-checked.
@@ -186,7 +193,7 @@ class PanoDataTable @Inject() (protected val dbConfigProvider: DatabaseConfigPro
   def getReusableImageryStatus(panoIds: Set[String], liveCheckedSince: OffsetDateTime): DBIO[Map[String, Boolean]] = {
     panoDataRecords
       .filter(_.panoId inSet panoIds)
-      .filter(_.source === PanoSource.Gsv)
+      .filter(_.source inSet PanoSource.providerCheckedSources)
       .filter(pano => pano.expired || pano.lastChecked >= liveCheckedSince)
       .map(pano => (pano.panoId, pano.expired))
       .result
@@ -206,28 +213,28 @@ class PanoDataTable @Inject() (protected val dbConfigProvider: DatabaseConfigPro
   }
 
   /**
-   * Get a list of n least recently checked pano ids that have not been checked in the last 3 months.
+   * Get the n least recently checked panos that haven't been checked in the last 3 months; providerCheckedSources only.
    *
-   * Note: only getting panos from GSV for now; we haven't set up imagery checking for other sources yet
-   * @param n Number of least recently checked panos to return.
+   * @param n       Number of least recently checked panos to return.
    * @param expired Whether to check for expired or unexpired panos.
+   * @return        Pano ID paired with its imagery source, least recently checked first.
    */
-  def getPanoIdsToCheckExpiration(n: Int, expired: Boolean): DBIO[Seq[String]] = {
-    // Dedup on (pano_id, last_checked) pairs — equivalent to deduping pano_id alone, since both come from the same
-    // pano_data row — so that the sort sits at/above the DISTINCT. An ORDER BY buried in a subquery below a DISTINCT
-    // is one Postgres is free to discard, which would break the least-recently-checked-first contract.
+  def getPanoIdsToCheckExpiration(n: Int, expired: Boolean): DBIO[Seq[(String, PanoSource)]] = {
+    // Dedup on (pano_id, source, last_checked) triples — equivalent to deduping pano_id alone, since all three come
+    // from the same pano_data row — so that the sort sits at/above the DISTINCT. An ORDER BY buried in a subquery
+    // below a DISTINCT is one Postgres is free to discard, which would break "least-recently-checked-first".
     panoDataRecords
       .join(labelTable)
       .on(_.panoId === _.panoId)
-      .filter(gsv =>
-        gsv._1.source === PanoSource.Gsv
-          && gsv._1.expired === expired
-          && gsv._1.lastChecked < OffsetDateTime.now().minusMonths(3)
+      .filter(pano =>
+        (pano._1.source inSet PanoSource.providerCheckedSources)
+          && pano._1.expired === expired
+          && pano._1.lastChecked < OffsetDateTime.now().minusMonths(3)
       )
-      .map(gsv => (gsv._1.panoId, gsv._1.lastChecked))
+      .map(pano => (pano._1.panoId, pano._1.source, pano._1.lastChecked))
       .distinct
-      .sortBy(_._2.asc)
-      .map(_._1)
+      .sortBy(_._3.asc)
+      .map(pano => (pano._1, pano._2))
       .take(n)
       .result
   }

--- a/app/models/pano/PanoDataTable.scala
+++ b/app/models/pano/PanoDataTable.scala
@@ -182,9 +182,8 @@ class PanoDataTable @Inject() (protected val dbConfigProvider: DatabaseConfigPro
    *   - `expired` is false and `last_checked` is at or after `liveCheckedSince`. Liveness *can* lapse at any moment, so
    *     this side carries a TTL that bounds how long we'd keep handing out a pano that has since gone away.
    *
-   * Restricted to `PanoSource.providerCheckedSources`, because both branches lean on the nightly sweep: it is what
-   * re-checks expired panos to catch ones marked so incorrectly, and what keeps `last_checked` moving. Infra3d is
-   * never checked against a provider, so its columns don't reflect a real answer and it gets no cache entry here.
+   * Restricted to `PanoSource.providerCheckedSources`: Infra3d imagery is never asked about, so its `expired` and
+   * `last_checked` hold no real answer to reuse.
    *
    * @param panoIds          Panos to look up.
    * @param liveCheckedSince Cutoff for reusing a non-expired result; older ones are re-checked.

--- a/app/service/LabelService.scala
+++ b/app/service/LabelService.scala
@@ -395,9 +395,10 @@ class LabelServiceImpl @Inject() (
       else (Seq.empty[A], labels)
 
     // One query up front for the answers we can reuse, so the per-label lookups below skip the provider where they can.
-    // Only GSV answers are reusable, and every batch is single-source (the label queries filter on the viewer's
-    // source), so asking about a Mapillary or Infra3d batch would spend a round trip to be told nothing.
-    val cacheablePanoIds: Set[String] = toCheck.collect { case l if l.panoSource == PanoSource.Gsv => l.panoId }.toSet
+    // Only provider-checked sources have reusable answers, and every batch is single-source (the label queries filter
+    // on the viewer's source), so asking about an Infra3d batch would spend a round trip to be told nothing.
+    val cacheablePanoIds: Set[String] =
+      toCheck.collect { case l if PanoSource.providerCheckedSources.contains(l.panoSource) => l.panoId }.toSet
     panoDataService.getReusableImageryStatus(cacheablePanoIds).flatMap { reusable =>
       def imageryExists(label: A): Future[Option[Boolean]] =
         reusable.get(label.panoId) match {

--- a/app/service/PanoDataService.scala
+++ b/app/service/PanoDataService.scala
@@ -16,7 +16,7 @@ import play.api.http.ContentTypes
 import play.api.libs.json.{JsObject, Json}
 import play.api.libs.ws.WSClient
 import play.api.{Configuration, Logger}
-import service.PanoDataService.{getFov, ImageryCheckConcurrency, LiveImageryTtlDays}
+import service.PanoDataService.{getFov, ImageryCheckConcurrency, LiveImageryTtlDays, MaxUnexpiredPanosPerSweep}
 import slick.dbio.DBIO
 
 import java.io.{File, IOException}
@@ -28,6 +28,7 @@ import javax.crypto.spec.SecretKeySpec
 import javax.inject._
 import scala.concurrent.duration.{Duration, DurationInt}
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.control.NonFatal
 
 /**
  * Companion object with constants and functions that are shared throughout codebase, that shouldn't require injection.
@@ -48,6 +49,9 @@ object PanoDataService {
    * How many panos the nightly expiry sweep may have in flight at once (#4559).
    */
   val ImageryCheckConcurrency: Int = 10
+
+  /** Ceiling on the unexpired panos one nightly expiry sweep will check. */
+  val MaxUnexpiredPanosPerSweep: Int = 5000
 
   /**
    * Hacky fix to generate the FOV for an image. Determined experimentally.
@@ -563,7 +567,8 @@ class PanoDataServiceImpl @Inject() (
       for {
         // Choose a bunch of panos that haven't been checked in the past 3 months to check.
         nPanos: Int <- panoDataTable.countCheckablePanosWithLabels
-        nUnexpiredPanosToCheck: Int = Math.max(minPanosToCheck, Math.min(5000, (0.05 * nPanos).toInt))
+        nUnexpiredPanosToCheck: Int =
+          Math.max(minPanosToCheck, Math.min(MaxUnexpiredPanosPerSweep, (0.05 * nPanos).toInt))
         panosToCheck: Seq[(String, PanoSource)] <- panoDataTable
           .getPanoIdsToCheckExpiration(nUnexpiredPanosToCheck, expired = false)
         _ = logger.info(s"Checking ${panosToCheck.length} unexpired panos.")
@@ -592,7 +597,14 @@ class PanoDataServiceImpl @Inject() (
    */
   private def checkImageryBounded(panos: Seq[(String, PanoSource)]): Future[Seq[Option[Boolean]]] = {
     Source(panos.toVector)
-      .mapAsyncUnordered(ImageryCheckConcurrency) { case (panoId, source) => panoExists(panoId, source) }
+      .mapAsyncUnordered(ImageryCheckConcurrency) { case (panoId, source) =>
+        // One bad pano must not abort the sweep: the stream's default supervision would drop every pano not yet
+        // pulled. The providers recover their own exceptions, so this only catches a throw before their Future exists.
+        Future(panoExists(panoId, source)).flatten.recover { case NonFatal(e) =>
+          logger.warn(s"Imagery check for $panoId threw; treating as inconclusive.", e)
+          None
+        }
+      }
       .runWith(Sink.seq)
   }
 

--- a/app/service/PanoDataService.scala
+++ b/app/service/PanoDataService.scala
@@ -7,6 +7,8 @@ import models.pano.PanoSource.PanoSource
 import models.pano._
 import models.street.StreetEdge
 import models.utils.{CommonUtils, MyPostgresProfile}
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.{Sink, Source}
 import org.locationtech.jts.geom.Point
 import play.api.cache.AsyncCacheApi
 import play.api.db.slick.{DatabaseConfigProvider, HasDatabaseConfigProvider}
@@ -14,7 +16,7 @@ import play.api.http.ContentTypes
 import play.api.libs.json.{JsObject, Json}
 import play.api.libs.ws.WSClient
 import play.api.{Configuration, Logger}
-import service.PanoDataService.{getFov, LiveImageryTtlDays}
+import service.PanoDataService.{getFov, ImageryCheckConcurrency, LiveImageryTtlDays}
 import slick.dbio.DBIO
 
 import java.io.{File, IOException}
@@ -41,6 +43,11 @@ object PanoDataService {
    * label was placed.
    */
   val LiveImageryTtlDays: Long = 7
+
+  /**
+   * How many panos the nightly expiry sweep may have in flight at once (#4559).
+   */
+  val ImageryCheckConcurrency: Int = 10
 
   /**
    * Hacky fix to generate the FOV for an image. Determined experimentally.
@@ -266,7 +273,8 @@ class PanoDataServiceImpl @Inject() (
     panoHistoryTable: PanoHistoryTable,
     streetEdgeTable: models.street.StreetEdgeTable,
     signingService: ImageSigningService
-) extends PanoDataService
+)(implicit mat: Materializer)
+    extends PanoDataService
     with HasDatabaseConfigProvider[MyPostgresProfile] {
 
   private val logger = Logger(this.getClass)
@@ -554,27 +562,38 @@ class PanoDataServiceImpl @Inject() (
     db.run(
       for {
         // Choose a bunch of panos that haven't been checked in the past 3 months to check.
-        nPanos: Int <- panoDataTable.countGsvPanosWithLabels
+        nPanos: Int <- panoDataTable.countCheckablePanosWithLabels
         nUnexpiredPanosToCheck: Int = Math.max(minPanosToCheck, Math.min(5000, (0.05 * nPanos).toInt))
-        panoIdsToCheck: Seq[String] <- panoDataTable
+        panosToCheck: Seq[(String, PanoSource)] <- panoDataTable
           .getPanoIdsToCheckExpiration(nUnexpiredPanosToCheck, expired = false)
-        _ = logger.info(s"Checking ${panoIdsToCheck.length} unexpired panos.")
+        _ = logger.info(s"Checking ${panosToCheck.length} unexpired panos.")
 
         // Choose some panos that are already marked as expired to double-check.
         nExpiredPanosToCheck: Int =
-          Math.max(minPanosToCheck, Math.min(2500, (0.025 * nPanos).toInt) - panoIdsToCheck.length)
-        expiredPanoIdsToCheck: Seq[String] <-
+          Math.max(minPanosToCheck, Math.min(2500, (0.025 * nPanos).toInt) - panosToCheck.length)
+        expiredPanosToCheck: Seq[(String, PanoSource)] <-
           panoDataTable.getPanoIdsToCheckExpiration(nExpiredPanosToCheck, expired = true)
       } yield {
-        logger.info(s"Checking ${expiredPanoIdsToCheck.length} expired panos.")
+        logger.info(s"Checking ${expiredPanosToCheck.length} expired panos.")
 
-        // Run the panoExists function to check for imagery, then log some stats.
-        Future.traverse(panoIdsToCheck ++ expiredPanoIdsToCheck) { panoId => panoExists(panoId, PanoSource.Gsv) }.map {
-          responses =>
-            s"Not expired: ${responses.count(_ == Some(true))}. Expired: ${responses.count(_ == Some(false))}. Errors: ${responses.count(_.isEmpty)}."
+        // Check each pano against whichever provider it came from, then log some stats.
+        checkImageryBounded(panosToCheck ++ expiredPanosToCheck).map { responses =>
+          s"Not expired: ${responses.count(_ == Some(true))}. Expired: ${responses.count(_ == Some(false))}. Errors: ${responses.count(_.isEmpty)}."
         }
       }
     ).flatten
+  }
+
+  /**
+   * Runs `panoExists` over a batch of panos with at most `ImageryCheckConcurrency` checks in flight at once.
+   *
+   * @param panos Pano IDs paired with the imagery source to check each one against.
+   * @return      One result per pano, in completion order: `Some(true)` exists, `Some(false)` gone, `None` unknown.
+   */
+  private def checkImageryBounded(panos: Seq[(String, PanoSource)]): Future[Seq[Option[Boolean]]] = {
+    Source(panos.toVector)
+      .mapAsyncUnordered(ImageryCheckConcurrency) { case (panoId, source) => panoExists(panoId, source) }
+      .runWith(Sink.seq)
   }
 
   def getCropDirectory: String =

--- a/test/models/pano/PanoDataTableSpec.scala
+++ b/test/models/pano/PanoDataTableSpec.scala
@@ -17,12 +17,12 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 
 /**
- * DB-backed contract test for `PanoDataTable.getReusableImageryStatus`, the lookup that lets an imagery check skip the
- * provider (#3004).
+ * DB-backed contract tests for the two `PanoDataTable` queries behind imagery-expiry checking: the reuse lookup that
+ * lets a foreground check skip the provider (#3004), and the sampling query the nightly sweep draws from (#4862).
  *
- * Asserts the rule the query encodes against whatever rows the connected DB holds, rather than any particular data: a
- * known-expired GSV pano is always reusable, a live one only while its check is inside the TTL, and no other source is
- * reusable at all. Passes against an empty DB.
+ * Both assert the rule the query encodes against whatever rows the connected DB holds, rather than any particular
+ * data: a known-expired pano is always reusable, a live one only while its check is inside the TTL, and a source with
+ * no provider check behind it is neither reusable nor ever sampled. Passes against an empty DB.
  *
  * Requires a Postgres+PostGIS database (via DATABASE_URL / DATABASE_USER / DATABASE_PASSWORD env, as in dev/CI). The
  * eager scheduling actors are disabled so they don't fire background work during the test.
@@ -50,35 +50,107 @@ class PanoDataTableSpec extends PlaySpec with GuiceOneAppPerSuite {
     } yield (rows, statuses)).transactionally.withTransactionIsolation(TransactionIsolation.RepeatableRead)
   )
 
+  private def checkable(pano: PanoData): Boolean = PanoSource.providerCheckedSources.contains(pano.source)
+
   "PanoDataTable.getReusableImageryStatus" should {
     "return an answer for exactly the panos the reuse rule covers" in {
       val expected: Map[String, Boolean] = sample.collect {
-        case pano if pano.source == PanoSource.Gsv && (pano.expired || !pano.lastChecked.isBefore(cutoff)) =>
+        case pano if checkable(pano) && (pano.expired || !pano.lastChecked.isBefore(cutoff)) =>
           pano.panoId -> !pano.expired
       }.toMap
       statuses mustBe expected
     }
 
     "reuse a known-expired pano no matter how long ago it was checked" in {
-      val staleExpired = sample.filter(p => p.source == PanoSource.Gsv && p.expired && p.lastChecked.isBefore(cutoff))
-      assume(staleExpired.nonEmpty, "connected DB has no expired GSV pano checked before the TTL cutoff")
+      val staleExpired = sample.filter(p => checkable(p) && p.expired && p.lastChecked.isBefore(cutoff))
+      assume(staleExpired.nonEmpty, "connected DB has no expired provider-checked pano checked before the TTL cutoff")
       staleExpired.foreach(pano => statuses.get(pano.panoId) mustBe Some(false))
     }
 
     "make a live pano checked before the cutoff fall through to a fresh check" in {
-      val staleLive = sample.filter(p => p.source == PanoSource.Gsv && !p.expired && p.lastChecked.isBefore(cutoff))
-      assume(staleLive.nonEmpty, "connected DB has no live GSV pano checked before the TTL cutoff")
+      val staleLive = sample.filter(p => checkable(p) && !p.expired && p.lastChecked.isBefore(cutoff))
+      assume(staleLive.nonEmpty, "connected DB has no live provider-checked pano checked before the TTL cutoff")
       staleLive.foreach(pano => statuses.get(pano.panoId) mustBe None)
     }
 
     "never answer for a source with no provider check behind it" in {
-      val nonGsv = sample.filter(_.source != PanoSource.Gsv)
-      assume(nonGsv.nonEmpty, "connected DB holds only GSV panos")
-      nonGsv.foreach(pano => statuses.get(pano.panoId) mustBe None)
+      val unchecked = sample.filterNot(checkable)
+      assume(unchecked.nonEmpty, "connected DB holds only provider-checked panos")
+      unchecked.foreach(pano => statuses.get(pano.panoId) mustBe None)
     }
 
     "return nothing when asked about no panos" in {
       run(panoDataTable.getReusableImageryStatus(Set.empty, cutoff)) mustBe empty
+    }
+  }
+
+  // Sample both halves of the nightly sweep alongside the pano_data rows they came from, in one snapshot, so the
+  // per-pano assertions below compare a result against the row that actually produced it.
+  private val sampleSize                                    = 500
+  private val (unexpiredSample, expiredSample, sampledRows) = run(
+    (for {
+      unexpired <- panoDataTable.getPanoIdsToCheckExpiration(sampleSize, expired = false)
+      expired   <- panoDataTable.getPanoIdsToCheckExpiration(sampleSize, expired = true)
+      rows      <- panoDataTable.panoDataRecords
+        .filter(_.panoId inSet (unexpired ++ expired).map(_._1).toSet)
+        .result
+    } yield (unexpired, expired, rows.map(pano => pano.panoId -> pano).toMap)).transactionally
+      .withTransactionIsolation(TransactionIsolation.RepeatableRead)
+  )
+  // Upper bound on the staleness cutoff the queries built from their own now(), which ran before this line.
+  private val staleCutoff: OffsetDateTime = OffsetDateTime.now.minusMonths(3)
+
+  "PanoDataTable.getPanoIdsToCheckExpiration" should {
+    "pair every sampled pano with the source it is actually stored under" in {
+      // The sweep dispatches on this source, so a wrong one checks the pano against the wrong provider's API.
+      assume(unexpiredSample.nonEmpty || expiredSample.nonEmpty, "connected DB has no panos due for an expiry check")
+      (unexpiredSample ++ expiredSample).foreach { case (panoId, source) =>
+        sampledRows.get(panoId).map(_.source) mustBe Some(source)
+      }
+    }
+
+    "only sample panos whose imagery a provider can actually be asked about" in {
+      assume(unexpiredSample.nonEmpty || expiredSample.nonEmpty, "connected DB has no panos due for an expiry check")
+      (unexpiredSample ++ expiredSample).foreach { case (_, source) =>
+        PanoSource.providerCheckedSources must contain(source)
+      }
+    }
+
+    "only sample panos that are due, on the side of the expired flag that was asked for" in {
+      assume(unexpiredSample.nonEmpty || expiredSample.nonEmpty, "connected DB has no panos due for an expiry check")
+      unexpiredSample.foreach { case (panoId, _) => sampledRows(panoId).expired mustBe false }
+      expiredSample.foreach { case (panoId, _) => sampledRows(panoId).expired mustBe true }
+      (unexpiredSample ++ expiredSample).foreach { case (panoId, _) =>
+        sampledRows(panoId).lastChecked.isBefore(staleCutoff) mustBe true
+      }
+    }
+
+    "include Mapillary panos, not just GSV ones" in {
+      // Counted independently of the query under test, and a minute past the cutoff so a pano landing on the boundary
+      // can't count as due here while the query's own now() saw it as fresh.
+      val dueMapillary = run(
+        panoDataTable.panoDataRecords
+          .join(panoDataTable.labelTable)
+          .on(_.panoId === _.panoId)
+          .filter(_._1.source === PanoSource.Mapillary)
+          .filter(_._1.lastChecked < staleCutoff.minusMinutes(1))
+          .map(_._1.panoId)
+          .countDistinct
+          .result
+      )
+      assume(dueMapillary > 0, "connected DB has no labeled Mapillary pano due for an expiry check")
+
+      // Drawn uncapped rather than reusing the sample above: on a GSV-heavy city every Mapillary pano can sit behind
+      // more than `sampleSize` staler GSV ones, so a capped draw would hide a regression instead of catching one.
+      val allDue = run(for {
+        unexpired <- panoDataTable.getPanoIdsToCheckExpiration(Int.MaxValue, expired = false)
+        expired   <- panoDataTable.getPanoIdsToCheckExpiration(Int.MaxValue, expired = true)
+      } yield unexpired ++ expired)
+      allDue.map(_._2) must contain(PanoSource.Mapillary)
+    }
+
+    "return nothing when asked for no panos" in {
+      run(panoDataTable.getPanoIdsToCheckExpiration(0, expired = false)) mustBe empty
     }
   }
 }

--- a/test/models/pano/PanoDataTableSpec.scala
+++ b/test/models/pano/PanoDataTableSpec.scala
@@ -7,7 +7,7 @@ import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Application
 import play.api.db.slick.DatabaseConfigProvider
 import play.api.inject.guice.GuiceApplicationBuilder
-import service.PanoDataService.LiveImageryTtlDays
+import service.PanoDataService.{LiveImageryTtlDays, MaxUnexpiredPanosPerSweep}
 import slick.dbio.DBIO
 import slick.jdbc.TransactionIsolation
 
@@ -140,13 +140,14 @@ class PanoDataTableSpec extends PlaySpec with GuiceOneAppPerSuite {
       )
       assume(dueMapillary > 0, "connected DB has no labeled Mapillary pano due for an expiry check")
 
-      // Drawn uncapped rather than reusing the sample above: on a GSV-heavy city every Mapillary pano can sit behind
-      // more than `sampleSize` staler GSV ones, so a capped draw would hide a regression instead of catching one.
-      val allDue = run(for {
-        unexpired <- panoDataTable.getPanoIdsToCheckExpiration(Int.MaxValue, expired = false)
-        expired   <- panoDataTable.getPanoIdsToCheckExpiration(Int.MaxValue, expired = true)
+      // Drawn at the sweep's own nightly cap rather than reusing the smaller sample above: on a GSV-heavy city a
+      // Mapillary pano can sit behind more than `sampleSize` staler GSV ones, and a pano beyond the real cap is one
+      // the sweep wouldn't have reached either.
+      val nightlyDraw = run(for {
+        unexpired <- panoDataTable.getPanoIdsToCheckExpiration(MaxUnexpiredPanosPerSweep, expired = false)
+        expired   <- panoDataTable.getPanoIdsToCheckExpiration(MaxUnexpiredPanosPerSweep, expired = true)
       } yield unexpired ++ expired)
-      allDue.map(_._2) must contain(PanoSource.Mapillary)
+      nightlyDraw.map(_._2) must contain(PanoSource.Mapillary)
     }
 
     "return nothing when asked for no panos" in {


### PR DESCRIPTION
Resolves #4862. Resolves #4559.

## Mapillary imagery is now checked (#4862)

The nightly sweep (`CheckImageExpiryActor` → `PanoDataService.checkForImagery`) sampled **GSV panos only**, so `pano_data.expired`, `has_backup`, and `last_checked` were never refreshed for Mapillary imagery. On a Mapillary city, a deleted image stayed marked available forever.

As the issue noted, `mapillaryPanoExists` already did the real work — this is mostly sampling:

- **`PanoSource.providerCheckedSources`** (`Set(Gsv, Mapillary)`) names the sources `panoExists` can verify against a provider API. Infra3d stays out: it has no existence-check endpoint, so `panoExists` assumes its imagery is always there. That's the out-of-scope note in #4862, unchanged.
- **`getPanoIdsToCheckExpiration`** draws from those sources and returns `Seq[(String, PanoSource)]`, so the sweep dispatches each pano through `panoExists(panoId, source)` with its real source rather than a hardcoded `PanoSource.Gsv`.
- **`countGsvPanosWithLabels` → `countCheckablePanosWithLabels`**, so the sample size is computed over the same population it's drawn from.
- **`getReusableImageryStatus`** (the #3004 lookup that lets a foreground check skip the provider) was GSV-only *because* Mapillary had no nightly check behind it. That rationale is gone, so it now covers both sources — and `LabelService.checkImageryBatch`, which built its cacheable set with a hardcoded `panoSource == Gsv`, uses the shared set. Without that second change the query change alone would have done nothing for Mapillary.

## Bounded concurrency (#4559)

Item 3 of #4862 asked us to decide rate limiting, and the answer also fixes #4559. The sweep submitted a per-pano DB action for the whole sample effectively at once, filling Slick's executor (pool size 25, queue 1000) and rejecting the overflow — while the pool stayed saturated, *every* DB-backed request on the instance failed, including `/leaderboard`. Nightly, transient, and a full-city outage while it lasted.

`Future.traverse` is now `Source(...).mapAsyncUnordered(ImageryCheckConcurrency).runWith(Sink.seq)`, capping in-flight checks at 10 — well under the queue depth, and it doubles as the rate limit on the Mapillary Graph API now that the sweep talks to it. The sweep is a background job with all night to finish, so throughput costs nothing here. `PanoDataServiceImpl` gained an implicit `Materializer` (same DI pattern as `AccessScoreService`).

## Testing

`PanoDataTableSpec` gains a `getPanoIdsToCheckExpiration` block, in the same data-independent style as the existing reuse-lookup tests — asserting the rule the query encodes against whatever the connected DB holds, and `assume`-cancelling rather than passing vacuously:

- each sampled pano is paired with the source it's actually stored under (a wrong pairing would check it against the wrong provider's API);
- only provider-checked sources are ever sampled;
- sampled panos are due, on the requested side of the `expired` flag;
- **Mapillary panos are sampled, not just GSV** — drawn uncapped, since on a GSV-heavy city every Mapillary pano can sort behind thousands of staler GSV ones, and guarded by an independently-computed count of due Mapillary panos.

That Mapillary case **ran rather than cancelling** against a seeded dev DB, so it's real evidence the fix works.

Locally: `sbt compile` clean under `-Xfatal-warnings`, `scalafmtCheckAll` passes, full suite 613/615. The two failures are `GeodesicDistanceSpec` cached-distance assertions, unrelated to this diff — they fail identically on a clean `develop`, and their recomputed value drifted between runs minutes apart while the cached value held, i.e. live QA activity outrunning the nightly refresh. Those comparisons need real seeded data, so they cancel on CI's empty schema.

## Notes for review

- No schema change, no user-facing text, no frontend files.
- `expired` panos are still re-checked nightly to catch ones marked wrongly — that path now covers Mapillary too, which is what makes the reuse cache's "expired is always reusable" branch sound for it.
