### PR TITLE
Anchor tutorial instructions to what they point at

### DIFF
--- a/public/css/explore/svl-onboarding.css
+++ b/public/css/explore/svl-onboarding.css
@@ -32,31 +32,15 @@
   top: 0;
   left: 0;
 
-  /* Above everything in the pano area — the border frame (2) and the context menu (3). A tie with the menu would
-     let DOM order decide. The rule below gives the user a way back to the menu if a callout ever lands over it. */
-  z-index: 1100;
+  /* Above every layer of the tool itself — the pano border frame (2), the context menu (3, or 6 with its share
+     popover open), the ribbon (4), the minimap (5) — but below the tooltip layer (~1030). */
+  z-index: 10;
   font: var(--text-subtitle-regular);
   transform: none;
 
   border-radius: calc(3px * var(--ui-scale));
   background: var(--color-neutral-white);
   transition: background 0.5s;
-}
-
-/* The callout is meant to shrink rather than overlap the control it points at (see the size() middleware in
-   Onboarding's anchorMessageTo), but that guarantee is only as good as Floating UI being loaded — without it the box
-   falls back to the pano's top-left corner, over the menu. Reaching the menu drops the callout behind it so the user
-   can always read and reach what they are being asked to click. Focus counts as reaching it, not just the pointer:
-   the menu's tooltips open on Bootstrap's default `hover focus` trigger, so tabbing to a tag opens one with the
-   pointer nowhere near the panel.
-
-   The callout gives way rather than the menu lifting, because the menu's tooltips are appended to <body> and live in
-   the tooltip layer (~1030): a menu raised past that layer paints over every tooltip opened from it, and the menu is
-   hovered exactly when those tooltips are showing (#4850). The takeover message is excluded — it is centered over the
-   dimmer at z-index 1028, with no menu underneath to make room for. */
-#street-view-holder:has(#context-menu-holder:is(:hover, :focus-within))
-#onboarding-message-holder:not(.onboarding-message-takeover) {
-  z-index: 2;
 }
 
 /* Flashes the message box's background to draw the user's attention when a new message is shown. */
@@ -188,6 +172,12 @@
   background: var(--color-neutral-white);
   transform: rotate(45deg);
   z-index: -1;
+}
+
+/* Callouts anchored to a placed label sit over the pano the user has to reach past them: the label to hover, the
+   Delete button on its hover card. They carry no controls of their own, so they stay out of the way entirely. */
+#onboarding-message-holder.onboarding-message-pass-through {
+  pointer-events: none;
 }
 
 /* Pinned just above a pano annotation arrow (see Onboarding's positionMessageAtPanoCoord); the translate puts

--- a/public/css/explore/tutorial-screens.css
+++ b/public/css/explore/tutorial-screens.css
@@ -277,6 +277,7 @@
   position: absolute;
   height: auto;
   pointer-events: none;
+  z-index: 11; /* Makes sure that they show above the hero. */
 }
 
 .tutorial-complete__fireworks--1 {

--- a/public/js/explore/src/onboarding/Onboarding.js
+++ b/public/js/explore/src/onboarding/Onboarding.js
@@ -497,7 +497,7 @@ class Onboarding {
   }
 
   /**
-   * On-screen rect of a placed label's icon, for use as a Floating UI virtual reference.
+   * On-screen rect of a placed label, for use as a Floating UI virtual reference.
    *
    * The projection is left unbounded and the result clamped into the pano instead, so a label the user has panned
    * off-screen keeps a rect that rides the near edge.
@@ -520,15 +520,25 @@ class Onboarding {
     const size = this.#svl.LABEL_ICON_RADIUS * scale * 2;
     const paneRect = pane.getBoundingClientRect();
     const clamp = (v, min, max) => Math.min(Math.max(v, min), Math.max(min, max));
-    return new DOMRect(
+    const iconRect = new DOMRect(
       clamp(paneRect.left + coord.x * scale - size / 2, paneRect.left, paneRect.right - size),
       clamp(paneRect.top + coord.y * scale - size / 2, paneRect.top, paneRect.bottom - size),
       size, size,
     );
+
+    const card = this.#svl.ui.canvas.hoverCard;
+    if (label.getHoverInfoVisibility() !== 'visible' || card.css('visibility') !== 'visible') return iconRect;
+
+    const cardRect = card[0].getBoundingClientRect();
+    const left = Math.min(iconRect.left, cardRect.left);
+    const top = Math.min(iconRect.top, cardRect.top);
+    return new DOMRect(
+      left, top, Math.max(iconRect.right, cardRect.right) - left, Math.max(iconRect.bottom, cardRect.bottom) - top,
+    );
   }
 
   /**
-   * Builds an anchor resolver that points the message at a placed label (or it's hover menu if it's up).
+   * Builds an anchor resolver that points the message at a placed label.
    *
    * @param {Label} label The label to point at.
    * @returns {Function} Resolver for #anchorMessageTo.
@@ -536,21 +546,7 @@ class Onboarding {
   #labelAnchor(label) {
     return () => {
       const rect = this.#labelRect(label);
-      if (!rect) return null;
-
-      const card = this.#svl.ui.canvas.hoverCard;
-      if (label.getHoverInfoVisibility() === 'visible' && card.css('visibility') === 'visible') {
-        const cardRect = card[0].getBoundingClientRect();
-        const left = Math.min(rect.left, cardRect.left);
-        const top = Math.min(rect.top, cardRect.top);
-        return {
-          rect: new DOMRect(left, top, Math.max(rect.right, cardRect.right) - left,
-            Math.max(rect.bottom, cardRect.bottom) - top),
-          placement: 'top',
-          boundedByPane: true,
-        };
-      }
-      return { rect, placement: 'top', boundedByPane: true };
+      return rect ? { rect, placement: 'top', boundedByPane: true } : null;
     };
   }
 

--- a/public/js/explore/src/onboarding/Onboarding.js
+++ b/public/js/explore/src/onboarding/Onboarding.js
@@ -497,14 +497,95 @@ class Onboarding {
   }
 
   /**
-   * Position the onboarding message box beside a live UI element using Floating UI lib, with an arrow pointing at it.
-   * @param {string} anchorSelector CSS selector of the element to point the box at.
-   * @param {string} placement Preferred Floating UI placement (e.g. 'left', 'right', 'top', 'bottom').
+   * On-screen rect of a placed label's icon, for use as a Floating UI virtual reference.
+   *
+   * The projection is left unbounded and the result clamped into the pano instead, so a label the user has panned
+   * off-screen keeps a rect that rides the near edge.
+   *
+   * @param {Label} label The label to measure.
+   * @returns {DOMRect|null} null if there is no such label or its position can't be projected.
    */
-  #anchorMessageTo(anchorSelector, placement) {
-    const reference = document.querySelector(anchorSelector);
+  #labelRect(label) {
+    const pane = document.getElementById('street-view-holder');
+    const centeredPov = label && !label.isDeleted() && label.getProperty('povOfLabelIfCentered');
+    if (!pane || !centeredPov) return null;
+
+    const coord = util.pano.centeredPovToCanvasCoord(
+      centeredPov, this.#svl.panoViewer.getPov(),
+      util.EXPLORE_CANVAS_WIDTH, util.EXPLORE_CANVAS_HEIGHT, Infinity,
+    );
+    if (!coord) return null;
+
+    const scale = util.exploreDisplayScale();
+    const size = this.#svl.LABEL_ICON_RADIUS * scale * 2;
+    const paneRect = pane.getBoundingClientRect();
+    const clamp = (v, min, max) => Math.min(Math.max(v, min), Math.max(min, max));
+    return new DOMRect(
+      clamp(paneRect.left + coord.x * scale - size / 2, paneRect.left, paneRect.right - size),
+      clamp(paneRect.top + coord.y * scale - size / 2, paneRect.top, paneRect.bottom - size),
+      size, size,
+    );
+  }
+
+  /**
+   * Builds an anchor resolver that points the message at a placed label (or it's hover menu if it's up).
+   *
+   * @param {Label} label The label to point at.
+   * @returns {Function} Resolver for #anchorMessageTo.
+   */
+  #labelAnchor(label) {
+    return () => {
+      const rect = this.#labelRect(label);
+      if (!rect) return null;
+
+      const card = this.#svl.ui.canvas.hoverCard;
+      if (label.getHoverInfoVisibility() === 'visible' && card.css('visibility') === 'visible') {
+        const cardRect = card[0].getBoundingClientRect();
+        const left = Math.min(rect.left, cardRect.left);
+        const top = Math.min(rect.top, cardRect.top);
+        return {
+          rect: new DOMRect(left, top, Math.max(rect.right, cardRect.right) - left,
+            Math.max(rect.bottom, cardRect.bottom) - top),
+          placement: 'top',
+          boundedByPane: true,
+        };
+      }
+      return { rect, placement: 'top', boundedByPane: true };
+    };
+  }
+
+  /**
+   * Builds an anchor resolver that points the message at a UI element.
+   *
+   * A callout anchored inside the context menu follows the menu's label while the menu is closed: the menu is
+   * hidden with `visibility`, so it keeps a rect the callout would otherwise go on pointing at (#4859).
+   *
+   * @param {string} selector CSS selector of the element to point the box at.
+   * @param {string} placement Preferred Floating UI placement (e.g. 'left', 'right', 'top', 'bottom').
+   * @returns {Function} Resolver for #anchorMessageTo.
+   */
+  #elementAnchor(selector, placement) {
+    return () => {
+      const el = document.querySelector(selector);
+      if (!el) return null;
+
+      if (!this.#contextMenu.isOpen() && this.#svl.ui.contextMenu.holder[0]?.contains(el)) {
+        const rect = this.#labelRect(this.#contextMenu.getTargetLabel());
+        if (rect) return { rect, placement: 'top', boundedByPane: true };
+      }
+      const pane = document.getElementById('street-view-holder');
+      return { rect: el.getBoundingClientRect(), placement, boundedByPane: Boolean(pane?.contains(el)) };
+    };
+  }
+
+  /**
+   * Position the onboarding message box beside its anchor using Floating UI lib, with an arrow pointing at it.
+   * @param {Function} resolveAnchor Returns {rect, placement, boundedByPane} for the current frame, or null.
+   */
+  #anchorMessageTo(resolveAnchor) {
     const floating = this.#uiOnboarding.messageHolder.get(0);
-    if (!reference || !floating || typeof FloatingUIDOM === 'undefined') return;
+    let anchor = resolveAnchor();
+    if (!anchor || !floating || typeof FloatingUIDOM === 'undefined') return;
 
     // (Re)create the arrow element Floating UI positions; showMessage's html() call wipes the box's contents.
     let arrowEl = floating.querySelector('.fui-arrow');
@@ -515,8 +596,13 @@ class Onboarding {
     }
     floating.style.position = 'absolute';
 
+    const pane = document.getElementById('street-view-holder');
+    // A virtual reference, because an anchor can be a label icon painted on the canvas, with no element of its own.
+    const reference = { getBoundingClientRect: () => (resolveAnchor() ?? anchor).rect, contextElement: pane };
+
     // Recompute on scroll/resize/layout changes so the box keeps tracking the element.
     const update = () => {
+      anchor = resolveAnchor() ?? anchor;
       // The arrow is a square rotated 45deg centered on the box edge, so its tip protrudes by half its diagonal.
       // Gap the box from the element by that distance so the tip just reaches the near edge. Re-measured each
       // update since the arrow scales with --ui-scale.
@@ -524,10 +610,9 @@ class Onboarding {
       const arrowProtrusion = arrowHalf * Math.SQRT2;
       // Confine the callout to the streetscape pane so the pane's border can't slice it — but only when its
       // anchor lives in the pane; minimap/sidebar anchors need the callout to follow them across the gutter.
-      const pane = document.getElementById('street-view-holder');
-      const boundary = pane && pane.contains(reference) ? pane : undefined;
+      const boundary = anchor.boundedByPane ? pane : undefined;
       FloatingUIDOM.computePosition(reference, floating, {
-        placement,
+        placement: anchor.placement,
         middleware: [
           FloatingUIDOM.offset(arrowProtrusion),
           // bestFit: when no side fully fits the callout, take the roomiest one rather than the preferred one.
@@ -547,23 +632,25 @@ class Onboarding {
       }).then(({ x, y, placement: finalPlacement }) => {
         Object.assign(floating.style, { left: `${x}px`, top: `${y}px`, transform: 'none' });
 
-        // Point the arrow at the center of the element's near edge, computed from live rects so it stays
-        // centered even when shift() nudged the box along that axis.
+        // Point the arrow at the center of the anchor's near edge, computed from live rects so it stays centered even
+        // when shift() nudged the box along that axis. Clamped to the box's own edge, inset by the arrow's half-width.
         const side = finalPlacement.split('-')[0];
         const staticSide = { top: 'bottom', right: 'left', bottom: 'top', left: 'right' }[side];
-        const refRect = reference.getBoundingClientRect();
+        const refRect = anchor.rect;
         const floatRect = floating.getBoundingClientRect();
+        const along = side === 'left' || side === 'right'
+          ? { prop: 'top', center: refRect.top + refRect.height / 2 - floatRect.top, boxLen: floatRect.height }
+          : { prop: 'left', center: refRect.left + refRect.width / 2 - floatRect.left, boxLen: floatRect.width };
+        const maxOffset = Math.max(arrowHalf, along.boxLen - 3 * arrowHalf);
         Object.assign(arrowEl.style, { left: '', top: '', right: '', bottom: '' });
-        if (side === 'left' || side === 'right') {
-          arrowEl.style.top = `${refRect.top + refRect.height / 2 - floatRect.top - arrowHalf}px`;
-        } else {
-          arrowEl.style.left = `${refRect.left + refRect.width / 2 - floatRect.left - arrowHalf}px`;
-        }
+        arrowEl.style[along.prop] = `${Math.min(Math.max(along.center - arrowHalf, arrowHalf), maxOffset)}px`;
         arrowEl.style[staticSide] = `${-arrowHalf}px`;
       });
     };
 
-    this.#floatingCleanup = FloatingUIDOM.autoUpdate(reference, floating, update);
+    // animationFrame: an anchor can be a canvas-painted label, or a menu section that goes visibility:hidden —
+    // neither moves in a way the observers autoUpdate uses by default can see.
+    this.#floatingCleanup = FloatingUIDOM.autoUpdate(reference, floating, update, { animationFrame: true });
   }
 
   /**
@@ -618,7 +705,7 @@ class Onboarding {
     this.#uiOnboarding.messageHolder
       .removeClass('animated fadeIn fadeInLeft fadeInRight fadeInDown fadeInUp callout-floating '
         + 'onboarding-message-takeover onboarding-message-fullpage onboarding-message-top-right '
-        + 'onboarding-message-pano-anchored')
+        + 'onboarding-message-pano-anchored onboarding-message-pass-through')
       .css({ position: '', top: '', left: '', transform: '', width: '', maxWidth: '' });
     this.#uiOnboarding.background.css('visibility', 'hidden');
 
@@ -641,10 +728,16 @@ class Onboarding {
       this.#uiOnboarding.background.css('visibility', 'visible');
       this.#uiOnboarding.messageHolder.addClass('onboarding-message-takeover');
       if (parameters.fullPage) this.#uiOnboarding.messageHolder.addClass('onboarding-message-fullpage');
-    } else if (parameters.anchor) {
-      // Anchor to a live UI element; Floating UI computes the position and arrow.
+    } else if (parameters.anchor || parameters.labelAnchor) {
+      // Anchor to a live UI element or a placed label; Floating UI computes the position and arrow.
       this.#uiOnboarding.messageHolder.addClass('callout-floating');
-      this.#anchorMessageTo(parameters.anchor, parameters.placement || 'right');
+      if (parameters.labelAnchor) {
+        // Whatever this callout ends up over, it must not intercept the hover or click the step is asking for.
+        this.#uiOnboarding.messageHolder.addClass('onboarding-message-pass-through');
+      }
+      this.#anchorMessageTo(parameters.labelAnchor
+        ? this.#labelAnchor(this.#svl.labelContainer.findLabelByTempId(this.#currentLabelId))
+        : this.#elementAnchor(parameters.anchor, parameters.placement || 'right'));
     } else if (parameters.panoAnchor) {
       // Pin just above a pano-image coordinate (e.g. the step's annotation arrow).
       this.#positionMessageAtPanoCoord(parameters.panoAnchor);
@@ -771,6 +864,11 @@ class Onboarding {
     if (action === 'LabelAccessibilityAttribute' && state.message && state.annotations) {
       const arrow = state.annotations.find((a) => a.type === 'arrow');
       if (arrow) state.message.panoAnchor = { x: arrow.x, y: arrow.y };
+    }
+
+    // Delete steps point their message at the misplaced label the user has to hover (#4859).
+    if (action === 'DeleteAccessibilityAttribute' && state.message) {
+      state.message.labelAnchor = true;
     }
 
     // Show user a message box.


### PR DESCRIPTION
Fixes #4859

Three fixes to the Explore tutorial's instruction callouts.

### The delete instruction covered the label it asked you to delete

The `delete-attribute-*` steps gave their message no positioning at all, so it stayed at the pano's default top-left corner — right on top of a label placed there, with no way to hover it and reach its Delete button.

The message now anchors to the misplaced label. While the label's hover card is up the anchor grows to cover the card too, so the callout can't land on the Delete button that sits along the card's bottom edge. It's also `pointer-events: none`: these messages carry no controls of their own, so whatever they end up over, they must never intercept the hover or click the step is asking for.

### The rate/tag instruction pointed at nothing once you closed the menu

Those steps anchor to `#severity-menu` / `#context-menu-tag-section`. `ContextMenu.hide()` uses `visibility: hidden`, not `display: none`, so the menu keeps a real rect and Floating UI happily went on pointing at an invisible panel. Anchors inside the context menu now fall back to the menu's target label while the menu is closed, and snap back when it reopens.

### The instruction hid behind the context menu on hover

The callout sat at `z-index: 1100`, above the menu's tooltips, so #4850 dropped it to `z-index: 2` whenever the menu was hovered or focused — hiding the instruction to keep the tooltips readable. Lowering it to `10` puts it above every layer of the tool (border frame 2, menu 3/6, ribbon 4, minimap 5) but below the tooltip layer (~1030), which does that job without hiding anything. The give-way rule is gone, and the arrow — the one part meant to overlap the menu — still paints over it, since it lives in the callout's own stacking context.

### How the anchoring works now

Both new cases need an anchor that moves without firing any observer `autoUpdate` watches: a label is painted on the canvas and has no element, and a `visibility` flip changes no rect. So `#anchorMessageTo` now takes a per-frame resolver and hands Floating UI a virtual reference, with `autoUpdate` in `animationFrame` mode. Two supporting details:

- Label rects are clamped into the pano. Letting them follow the label off-screen doesn't work — `shift()` only clamps along its main axis, so the callout followed the label right out of the tool. Clamping the reference instead makes it ride the near edge, which also reads as a useful "your label is that way" hint.
- The arrow offset is clamped to the box's own edge, so an anchor at the frame edge leaves the arrow at the nearest corner rather than detached.

Also raises the tutorial-complete fireworks above the hero.

### Testing

Tutorial pano interaction can't be automated, so this was checked by hand: misplacing labels in each corner, panning them off each edge, closing and reopening the menu mid rate/tag step, and hovering severity buttons and tag pills to confirm tooltips read over the callout. ESLint and Stylelint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)