### PR TITLE
Prep for v11.8.1 release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import com.typesafe.sbt.packager.MappingsHelper.directory
 
 name := """sidewalk-webpage"""
 
-version := "11.8.0"
+version := "11.8.1"
 
 scalaVersion := "2.13.18"
 

--- a/conf/evolutions/default/353.sql
+++ b/conf/evolutions/default/353.sql
@@ -1,0 +1,5 @@
+# --- !Ups
+INSERT INTO version VALUES ('11.8.1', now(), 'Improves lat/lng estimation for all labels, speeds up landing page & mapillary pano loads plus some bug fixes.');
+
+# --- !Downs
+DELETE FROM version WHERE version_id = '11.8.1';


### PR DESCRIPTION
Updates the build.sbt to the new version number, and adds the new entry to the `version` table through an evolution.