### PR TITLE
Show more navbar items on mobile, and put the shell sidebar toggle in flow (#4857, #4856)

### DIFF
--- a/app/controllers/helper/ControllerUtils.scala
+++ b/app/controllers/helper/ControllerUtils.scala
@@ -3,7 +3,7 @@ package controllers.helper
 import models.label.LabelTypeEnum
 import models.user.{RoleTable, SidewalkUserWithRole}
 import play.api.mvc.Results.{Redirect, Unauthorized}
-import play.api.mvc.{Request, RequestHeader, Result}
+import play.api.mvc.{RequestHeader, Result}
 
 import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
@@ -25,8 +25,12 @@ object ControllerUtils {
 
   /**
    * Returns true if the user is on mobile, false if the user is not on mobile.
+   *
+   * Takes a `RequestHeader` rather than a `Request[A]` so views can call it too — the navbar hides the destinations
+   * that redirect mobile visitors to /mobileLanding, and a Twirl template only ever has the header. Controllers pass
+   * their `Request[A]` unchanged, since it is one.
    */
-  def isMobile[A](implicit request: Request[A]): Boolean = {
+  def isMobile(implicit request: RequestHeader): Boolean = {
     val mobileOS: Regex =
       "(iPhone|webOS|iPod|Android|BlackBerry|mobile|SAMSUNG|IEMobile|OperaMobi|BB10|iPad|Tablet)".r.unanchored
     request.headers

--- a/app/controllers/helper/ControllerUtils.scala
+++ b/app/controllers/helper/ControllerUtils.scala
@@ -24,11 +24,15 @@ object ControllerUtils {
   val NoUserId: String = ""
 
   /**
-   * Returns true if the user is on mobile, false if the user is not on mobile.
+   * Whether the request comes from a mobile device, judged by matching its User-Agent against a list of mobile OS
+   * and device tokens.
    *
-   * Takes a `RequestHeader` rather than a `Request[A]` so views can call it too — the navbar hides the destinations
-   * that redirect mobile visitors to /mobileLanding, and a Twirl template only ever has the header. Controllers pass
-   * their `Request[A]` unchanged, since it is one.
+   * Accepts a `RequestHeader`, the widest type carrying headers, so Twirl templates can ask as well — the navbar drops
+   * the destinations that would only redirect a mobile visitor to /mobileLanding, and a template holds nothing but the
+   * header. A controller's `Request[A]` satisfies it unchanged, being one.
+   *
+   * @param request The request whose User-Agent header is inspected.
+   * @return        True if that header is present and matches a mobile token; false if it is absent or matches none.
    */
   def isMobile(implicit request: RequestHeader): Boolean = {
     val mobileOS: Regex =

--- a/app/views/admin/dashboard/adminLayout.scala.html
+++ b/app/views/admin/dashboard/adminLayout.scala.html
@@ -23,4 +23,5 @@
 </div>
 
 <script src="@assets.path("js/common/utilitiesSidewalk.js")"></script>
+<script src="@assets.path("js/common/sidebarDisclosure.js")"></script>
 <script src="@assets.path("js/admin-dashboard/AdminShell.js")"></script>

--- a/app/views/apiDocs/layout.scala.html
+++ b/app/views/apiDocs/layout.scala.html
@@ -42,6 +42,7 @@
 </div>
 
 
+<script src="@assets.path("js/common/sidebarDisclosure.js")"></script>
 <script src="@assets.path("js/api-docs/apiDocs.js")"></script>
 <script src="@assets.path("js/common/utilitiesSidewalk.js")"></script>
 

--- a/app/views/common/navbar.scala.html
+++ b/app/views/common/navbar.scala.html
@@ -1,3 +1,4 @@
+@import controllers.helper.ControllerUtils
 @import models.user.SidewalkUserWithRole
 @import play.api.Configuration
 @import play.filters.csrf.CSRF
@@ -12,6 +13,11 @@
    city is pinned separately at the top of the switcher. Country order is alphabetical by country id. *@
 @otherCitiesByCountry = @{cityInfo.filter(_.cityId != commonData.cityId).sortBy(c => (c.countryId, c.stateId, c.cityId)).groupBy(_.countryId).toSeq.sortBy(_._1)}
 @isAdmin = @{user.isDefined && (user.get.role == "Administrator" || user.get.role == "Owner")}
+@* Destinations that redirect a mobile visitor to /mobileLanding (Explore, Label Map, Gallery, Route Builder) or to
+   /mobile (Expert Validate) are left out of the menu on those devices: a link that can only bounce you somewhere else
+   is worse than no link. This is deliberately the same user-agent test the controllers redirect on, not a width
+   breakpoint — a narrow desktop window still reaches all of them (#4857). *@
+@isMobileDevice = @{ControllerUtils.isMobile}
 @isLanding = @{request.path == "/" || request.path == "/home"}
 @isExplore = @{request.path == "/explore"}
 @curPath = @{request.path.toLowerCase}
@@ -32,6 +38,9 @@
       <div class="navbar-logo">
         <a id="navbar-brand" href="/"><img alt="Project Sidewalk Logo" height="28" src='@assets.path("images/" + config.get[String]("city-params.logo-img." + commonData.cityId))'></a>
       </div>
+      @* Filled by Navbar.js at collapsed widths with as many `data-nav-quick` items as fit, as icon-only buttons.
+         Empty in the inline bar, where those items sit in their own groups. *@
+      <ul class="navbar-nav navbar-quick" id="navbar-quick"></ul>
       <button type="button" class="navbar-toggle" data-nav-toggle aria-controls="navbar" aria-expanded="false" aria-label="@Messages("navbar.menu.toggle")">
         <img class="navbar-toggle-icon" src='@assets.path("images/icons/menu-feather.svg")' alt="" aria-hidden="true">
       </button>
@@ -41,18 +50,24 @@
       <ul class="navbar-nav navbar-nav--primary" id="topbuttons">
         @* Explore is the single dominant call to action. It stays visible and is marked active on /explore (rather
            than being hidden), so the link set is stable page to page. *@
-        <li class="navbar-lnk">
-          <a class="navbar-button@if(isExplore){ is-active}" id="navbar-start-btn" href="@routes.ExploreController.explore()"@if(isExplore){ aria-current="page"}>@common.navbarLnkIcon("compass")@Messages("navbar.explore")</a>
-        </li>
-        <li class="navbar-lnk">
-          <a class="navbar-button@if(request.path == "/validate"){ is-active}" id="navbar-validate-btn" href="@routes.ValidateController.validate()"@if(request.path == "/validate"){ aria-current="page"}>@common.navbarLnkIcon("check-circle")@Messages("navbar.validate")</a>
+        @if(!isMobileDevice) {
+          <li class="navbar-lnk">
+            <a class="navbar-button@if(isExplore){ is-active}" id="navbar-start-btn" href="@routes.ExploreController.explore()"@if(isExplore){ aria-current="page"}>@common.navbarLnkIcon("compass")@Messages("navbar.explore")</a>
+          </li>
+        }
+        @* `data-nav-quick` marks an item the collapsed bar shows as an icon beside the hamburger, lowest number first;
+           whatever doesn't fit stays in the panel. See #applyQuickStrip in Navbar.js. *@
+        <li class="navbar-lnk" data-nav-quick="2">
+          <a class="navbar-button@if(request.path == "/validate"){ is-active}" id="navbar-validate-btn" href="@routes.ValidateController.validate()"@if(request.path == "/validate"){ aria-current="page"}>@common.navbarLnkIcon("check-circle")<span class="navbar-lnk-label">@Messages("navbar.validate")</span></a>
         </li>
         @* Label Map is the results/output view — a top-level peer of the Explore (contribute) + Validate (verify) loop.
            `data-nav-shed` marks it droppable when the bar runs out of room (it stays reachable under Tools ▸ Analyze);
            see the shed order in Navbar.js. *@
-        <li class="navbar-lnk" data-nav-shed="5">
-          <a class="navbar-button@if(request.path.toLowerCase == "/labelmap"){ is-active}" id="navbar-labelmap-btn" href="@routes.ApplicationController.labelMap(None)"@if(request.path.toLowerCase == "/labelmap"){ aria-current="page"}>@common.navbarLnkIcon("map")@Messages("navbar.labelmap")</a>
-        </li>
+        @if(!isMobileDevice) {
+          <li class="navbar-lnk" data-nav-shed="5">
+            <a class="navbar-button@if(request.path.toLowerCase == "/labelmap"){ is-active}" id="navbar-labelmap-btn" href="@routes.ApplicationController.labelMap(None)"@if(request.path.toLowerCase == "/labelmap"){ aria-current="page"}>@common.navbarLnkIcon("map")@Messages("navbar.labelmap")</a>
+          </li>
+        }
         @* Retake Tutorial and Help are genuine /explore-only features, not the current page hidden. *@
         @if(isExplore) {
           <li class="navbar-lnk">
@@ -77,30 +92,36 @@
           <button type="button" id="nav-tools-dropdown" class="navbar-button navbar-dropdown-toggle@if(toolsToggleActive){ is-active}" data-nav-dropdown aria-haspopup="true" aria-expanded="false" aria-controls="nav-tools-menu">
             @common.navbarLnkIcon("tool")@Messages("navbar.tools")<b class="caret" aria-hidden="true"></b>
           </button>
+          @* On a mobile device only the Community group survives, so its section header would be labelling the whole
+             menu; the headers are what make three groups scannable, not one. *@
           <ul id="nav-tools-menu" class="dropdown-menu" aria-label="@Messages("navbar.tools")">
-            <li class="dropdown-section">@Messages("navbar.tools.analyze")</li>
-            <li><a id="navbar-gallery-btn" href="@routes.GalleryController.gallery()"@if(curPath == "/gallery"){ class="is-active" aria-current="page"}>@common.navbarMenuIcon("grid")@Messages("gallery")</a></li>
-            <li><a id="navbar-labelmap-btn-tools" href="@routes.ApplicationController.labelMap(None)"@if(curPath == "/labelmap"){ class="is-active" aria-current="page"}>@common.navbarMenuIcon("map")@Messages("navbar.labelmap")</a></li>
-            <li class="dropdown-section">@Messages("navbar.tools.community")</li>
+            @if(!isMobileDevice) {
+              <li class="dropdown-section">@Messages("navbar.tools.analyze")</li>
+              <li><a id="navbar-gallery-btn" href="@routes.GalleryController.gallery()"@if(curPath == "/gallery"){ class="is-active" aria-current="page"}>@common.navbarMenuIcon("grid")@Messages("gallery")</a></li>
+              <li><a id="navbar-labelmap-btn-tools" href="@routes.ApplicationController.labelMap(None)"@if(curPath == "/labelmap"){ class="is-active" aria-current="page"}>@common.navbarMenuIcon("map")@Messages("navbar.labelmap")</a></li>
+              <li class="dropdown-section">@Messages("navbar.tools.community")</li>
+            }
             <li><a id="navbar-leaderboard-btn" href='@routes.UserDashboardController.leaderboard'@if(curPath == "/leaderboard"){ class="is-active" aria-current="page"}>@common.navbarMenuIcon("award")@Messages("navbar.leaderboard")</a></li>
             <li><a id="navbar-stories-btn" href='@routes.StoryController.storiesPage'@if(curPath == "/stories"){ class="is-active" aria-current="page"}>@common.navbarMenuIcon("message-circle")@Messages("navbar.stories")</a></li>
             <li><a id="navbar-routes-btn" href='@routes.RouteBuilderController.routesPage'@if(curPath == "/routes"){ class="is-active" aria-current="page"}>@common.navbarMenuIcon("flag")@Messages("navbar.routes")</a></li>
-            <li class="dropdown-section">@Messages("navbar.tools.build")</li>
-            <li><a id="navbar-route-builder-btn" href='@routes.ApplicationController.routeBuilder'@if(curPath == "/routebuilder"){ class="is-active" aria-current="page"}>@common.navbarMenuIcon("navigation")@Messages("routebuilder.name")</a></li>
-            @if(isAdmin) {
-              <li class="dropdown-section">@Messages("navbar.tools.admin")</li>
-              <li><a id="navbar-expert-validate-btn-tools" href='@routes.ValidateController.expertValidate()'@if(curPath == "/expertvalidate" || curPath == "/adminvalidate"){ class="is-active" aria-current="page"}>@common.navbarMenuIcon("check-square")@Messages("navbar.expert.validate")</a></li>
+            @if(!isMobileDevice) {
+              <li class="dropdown-section">@Messages("navbar.tools.build")</li>
+              <li><a id="navbar-route-builder-btn" href='@routes.ApplicationController.routeBuilder'@if(curPath == "/routebuilder"){ class="is-active" aria-current="page"}>@common.navbarMenuIcon("navigation")@Messages("routebuilder.name")</a></li>
+              @if(isAdmin) {
+                <li class="dropdown-section">@Messages("navbar.tools.admin")</li>
+                <li><a id="navbar-expert-validate-btn-tools" href='@routes.ValidateController.expertValidate()'@if(curPath == "/expertvalidate" || curPath == "/adminvalidate"){ class="is-active" aria-current="page"}>@common.navbarMenuIcon("check-square")@Messages("navbar.expert.validate")</a></li>
+              }
             }
           </ul>
         </li>
 
-        <li class="navbar-lnk" data-nav-shed="3">
-          <a class="navbar-button" id="navbar-api-btn" href="@routes.ApiDocsController.index" aria-label="Developer API">@common.navbarLnkIcon("code")@Messages("navbar.api")</a>
+        <li class="navbar-lnk" data-nav-shed="3" data-nav-quick="4">
+          <a class="navbar-button" id="navbar-api-btn" href="@routes.ApiDocsController.index" aria-label="Developer API">@common.navbarLnkIcon("code")<span class="navbar-lnk-label">@Messages("navbar.api")</span></a>
         </li>
         @* About is the first item shed when the bar runs out of room: it's the only non-task link up here, and it
            stays reachable from the footer on every page. *@
-        <li class="navbar-lnk" data-nav-shed="1">
-          <a class="navbar-button@if(curPath == "/about"){ is-active}" id="navbar-about-btn" href="@routes.ApplicationController.about"@if(curPath == "/about"){ aria-current="page"}>@common.navbarLnkIcon("info")@Messages("navbar.about")</a>
+        <li class="navbar-lnk" data-nav-shed="1" data-nav-quick="3">
+          <a class="navbar-button@if(curPath == "/about"){ is-active}" id="navbar-about-btn" href="@routes.ApplicationController.about"@if(curPath == "/about"){ aria-current="page"}>@common.navbarLnkIcon("info")<span class="navbar-lnk-label">@Messages("navbar.about")</span></a>
         </li>
       </ul>
 
@@ -143,7 +164,9 @@
           </div>
         </li>
 
-        <li class="dropdown navbar-lnk" id="navbar-user-dropdown-list">
+        @* Highest quick-strip priority: signed-in or not is the one thing the collapsed bar should never hide, and
+           it is the entry point to everything personal. *@
+        <li class="dropdown navbar-lnk" id="navbar-user-dropdown-list" data-nav-quick="1">
         @if(user.isDefined && user.get.role != "Anonymous") {
           <button type="button" id="nav-user-dropdown" class="navbar-button navbar-dropdown-toggle@if(userToggleActive){ is-active}" data-nav-dropdown aria-haspopup="true" aria-expanded="false" aria-controls="nav-user-menu" aria-label="User options for @user.get.username">
             <img class="navbar-select-icon" src='@assets.path("images/icons/user-feather.svg")' alt="" aria-hidden="true"><span class="navbar-user-name">@user.get.username</span><b class="caret" aria-hidden="true"></b>
@@ -185,9 +208,11 @@
               <li>
                 <a id="navbar-admin-btn" href='@routes.AdminDashboardController.overview'@if(curPath == "/admin" || curPath == "/admin/overview"){ class="is-active" aria-current="page"}>@common.navbarMenuIcon("shield")@Messages("navbar.admin")</a>
               </li>
-              <li>
-                <a id="navbar-expert-validate-btn-user" href='@routes.ValidateController.expertValidate()'@if(curPath == "/expertvalidate" || curPath == "/adminvalidate"){ class="is-active" aria-current="page"}>@common.navbarMenuIcon("check-square")@Messages("navbar.expert.validate")</a>
-              </li>
+              @if(!isMobileDevice) {
+                <li>
+                  <a id="navbar-expert-validate-btn-user" href='@routes.ValidateController.expertValidate()'@if(curPath == "/expertvalidate" || curPath == "/adminvalidate"){ class="is-active" aria-current="page"}>@common.navbarMenuIcon("check-square")@Messages("navbar.expert.validate")</a>
+                </li>
+              }
             }
             <li class="dropdown-divider" role="separator"></li>
             <li>
@@ -197,7 +222,7 @@
         } else {
           @* Real href so it works on pages without the dialog (e.g. /signIn itself); AuthModal intercepts the
              click to open the dialog everywhere else. *@
-          <a id="navbar-sign-in-btn" href="@routes.UserController.signIn()" data-au-open="signIn" class="navbar-button">@common.navbarLnkIcon("log-in")@Messages("navbar.signin")</a>
+          <a id="navbar-sign-in-btn" href="@routes.UserController.signIn()" data-au-open="signIn" class="navbar-button">@common.navbarLnkIcon("log-in")<span class="navbar-lnk-label">@Messages("navbar.signin")</span></a>
         }
         </li>
 

--- a/app/views/common/navbar.scala.html
+++ b/app/views/common/navbar.scala.html
@@ -38,8 +38,9 @@
       <div class="navbar-logo">
         <a id="navbar-brand" href="/"><img alt="Project Sidewalk Logo" height="28" src='@assets.path("images/" + config.get[String]("city-params.logo-img." + commonData.cityId))'></a>
       </div>
-      @* Filled by Navbar.js at collapsed widths with as many `data-nav-quick` items as fit, as icon-only buttons.
-         Empty in the inline bar, where those items sit in their own groups. *@
+      @* Filled by Navbar.js at collapsed widths with as many `data-nav-quick` items as fit. The items are moved here,
+         not cloned: their ids are what the click logging and the auth dialog key on, so a second copy would break
+         both. Empty in the inline bar, where those items sit in their own groups. *@
       <ul class="navbar-nav navbar-quick" id="navbar-quick"></ul>
       <button type="button" class="navbar-toggle" data-nav-toggle aria-controls="navbar" aria-expanded="false" aria-label="@Messages("navbar.menu.toggle")">
         <img class="navbar-toggle-icon" src='@assets.path("images/icons/menu-feather.svg")' alt="" aria-hidden="true">

--- a/app/views/mobileLanding.scala.html
+++ b/app/views/mobileLanding.scala.html
@@ -10,18 +10,7 @@
 @common.main(commonData, title, url = "/mobileLanding") {
   <link rel="stylesheet" href='@assets.path("css/mobile-landing.css")'>
 
-    <!-- Slim header: logo + sign-in link. No full navbar on mobile landing. -->
-  <header id="mobile-landing-header">
-    <img src='@assets.path("images/" + config.get[String]("city-params.logo-img." + commonData.cityId))'
-    id="mobile-landing-logo-header"
-    alt="Project Sidewalk Logo">
-    @* A cookie-less visitor (None) gets the same signed-out header as an anonymous account. *@
-    @if(user.forall(_.role == "Anonymous")) {
-      <a href='@routes.UserController.signInMobile()' class="mobile-header-signin">@Messages("navbar.signin")</a>
-    } else {
-      <span class="mobile-header-signin">@user.map(_.username)</span>
-    }
-  </header>
+  @common.navbar(commonData, user)
 
     <!-- Hero section with background video, tagline, and CTA -->
   <section id="mobile-landing-hero">

--- a/app/views/userDashboard/layout.scala.html
+++ b/app/views/userDashboard/layout.scala.html
@@ -30,4 +30,5 @@
 </div>
 
 <script src="@assets.path("js/common/utilitiesSidewalk.js")"></script>
+<script src="@assets.path("js/common/sidebarDisclosure.js")"></script>
 <script src="@assets.path("js/admin-dashboard/AdminShell.js")"></script>

--- a/public/css/api-docs/api-docs.css
+++ b/public/css/api-docs/api-docs.css
@@ -793,20 +793,52 @@ h6:hover .permalink {
 
 /* ---- Sidebar Toggle ---- */
 
+/*
+ * Disclosure that opens the section nav on narrow screens. It is the first child of .api-sidebar and shares the
+ * sidebar's in-flow strip, so the nav it controls opens directly beneath it and pushes the page down rather than
+ * covering it. Hidden at widths where the sidebar is a real column.
+ */
 .api-sidebar-toggle {
   display: none;
-  background-color: var(--color-accent-link);
-  color: var(--color-text-on-accent);
-  border: none;
+  width: 100%;
+  align-items: center;
+  gap: var(--space-xs);
   padding: var(--space-sm) var(--space-md);
-  margin: var(--space-sm);
-  border-radius: var(--border-radius);
-  cursor: pointer;
+  border: none;
+  background-color: transparent;
+  color: var(--color-text-heading);
+  font-family: inherit;
   font-size: var(--font-size-md);
-  position: fixed;
-  top: calc(var(--navbar-height) + 10px);
-  left: var(--space-sm);
-  z-index: var(--z-index-sticky);
+  font-weight: 600;
+  text-align: left;
+  cursor: pointer;
+}
+
+.api-sidebar-toggle:hover {
+  background-color: var(--color-bg-hover);
+}
+
+.api-sidebar-toggle:focus-visible {
+  outline: 2px solid var(--color-accent-link);
+  outline-offset: -2px;
+}
+
+.api-sidebar-toggle-icon {
+  flex: none;
+  width: 12px;
+  transition: transform var(--transition-fast);
+}
+
+.api-sidebar-toggle[aria-expanded="true"] .api-sidebar-toggle-icon {
+  transform: rotate(180deg);
+}
+
+/* Pushes the chevron to the trailing edge so the label reads as a heading and the affordance sits where a thumb is. */
+.api-sidebar-toggle-label {
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* ==========================================================================
@@ -967,6 +999,11 @@ var(--breakpoint-md) → 992px */
     flex-direction: column;
   }
 
+  /*
+   * The sidebar stops being a column and becomes an in-flow strip between the navbar and the content, holding the
+   * disclosure button; its nav list collapses into that disclosure. The strip itself always renders, so nothing has to
+   * be floated over the page to reach the nav (#4856).
+   */
   .api-sidebar {
     flex: 0 0 auto;
     height: auto;
@@ -974,11 +1011,22 @@ var(--breakpoint-md) → 992px */
     width: 100%;
     border-right: none;
     border-bottom: 1px solid var(--color-border-light);
-    display: none;
+    display: block;
+    overflow: visible;
   }
 
-  .api-sidebar.mobile-visible {
+  .api-sidebar .api-nav {
+    display: none;
+    padding: 0 0 var(--space-sm);
+  }
+
+  .api-sidebar.mobile-visible .api-nav {
     display: block;
+  }
+
+  /* The strip already separates the nav from the page, so the desktop spacing above the first group is dead space. */
+  .api-sidebar .api-nav-header:first-child {
+    margin-top: 0;
   }
 
   .api-content {
@@ -987,7 +1035,7 @@ var(--breakpoint-md) → 992px */
   }
 
   .api-sidebar-toggle {
-    display: block;
+    display: flex;
   }
 
   /* Adjust heading sizes */

--- a/public/css/api-docs/api-docs.css
+++ b/public/css/api-docs/api-docs.css
@@ -807,7 +807,7 @@ h6:hover .permalink {
   border: none;
   background-color: transparent;
   color: var(--color-text-heading);
-  font-family: inherit;
+  font-family: var(--font-sans);
   font-size: var(--font-size-md);
   font-weight: 600;
   text-align: left;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -422,6 +422,14 @@ a {
   height: 24px;
 }
 
+/* Holds the collapsed bar's icon-only links; empty and hidden until the breakpoint below fills it. */
+.navbar-quick {
+  display: none;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
 #language-icon {
   height: 16px;
   width: 16px;
@@ -1616,9 +1624,16 @@ kbd {
   .navbar-brand-area {
     display: flex;
     align-items: center;
-    justify-content: space-between;
     width: 100%;
     min-height: var(--navbar-height);
+  }
+
+  /* None of the three may shrink: Navbar.js decides how many quick links fit by comparing their summed widths against
+     the row, and a shrunk child would always measure as fitting. */
+  .navbar-logo,
+  .navbar-quick,
+  .navbar-toggle {
+    flex: none;
   }
 
   .navbar-toggle {
@@ -1640,16 +1655,18 @@ kbd {
     margin-left: 0;
   }
 
+  /* Full-bleed rather than a narrow card hanging off the right edge: at these widths the menu is the page's whole
+     navigation, and a 220px panel over a 390px screen reads as an afterthought. */
   #navbar {
     position: absolute;
     top: var(--navbar-height);
-    right: 4.5%;
-    min-width: 220px;
+    right: 0;
+    left: 0;
     padding: 6px 0;
     z-index: var(--navbar-z-index);
     background-color: var(--color-neutral-white);
-    box-shadow: 0 1px 8px 0 #999999;
-    border-radius: 5px;
+    box-shadow: 0 6px 16px rgb(0 0 0 / 17.5%);
+    border-bottom: 1px solid var(--color-neutral-300);
   }
 
   #header.header--tall #navbar {
@@ -1727,6 +1744,79 @@ kbd {
 
   .navbar-lnk.is-open > .dropdown-menu.nav-city-panel {
     width: 100%;
+  }
+
+  /*
+   * Quick strip: the destinations worth one tap, shown as icons between the logo and the hamburger. Navbar.js moves
+   * as many `data-nav-quick` items here as fit and leaves the rest in the panel, so this styles whichever it picked.
+   */
+  .navbar-quick {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+    margin: 0 4px 0 auto; /* auto pushes the strip and the hamburger to the trailing edge. */
+    padding: 0;
+    list-style: none;
+  }
+
+  .navbar-quick > .navbar-lnk {
+    display: block;
+    margin-left: 0;
+  }
+
+  /* Square tap target sized past the 24px WCAG 2.5.8 minimum, since these sit right next to each other. */
+  .navbar-nav.navbar-quick > li > .navbar-button {
+    display: flex;
+    justify-content: center;
+    width: auto;
+    min-width: 40px;
+    height: 40px;
+    padding: 0;
+    gap: 0;
+    border: none;
+    border-radius: 8px;
+  }
+
+  .navbar-quick .navbar-lnk-icon,
+  .navbar-quick .navbar-select-icon {
+    display: block;
+    width: 20px;
+    height: 20px;
+  }
+
+  /* The icon carries the meaning visually; the label still names the control for assistive tech. */
+  .navbar-quick .navbar-lnk-label,
+  .navbar-quick .navbar-user-name {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  .navbar-quick .caret {
+    display: none;
+  }
+
+  /* Current page: a filled pill, since the underline the inline bar uses has no room under a 20px icon. */
+  .navbar-nav.navbar-quick > li > .navbar-button.is-active {
+    background-color: var(--color-banana-300);
+    color: var(--color-neutral-black);
+  }
+
+  /* The panel's rules above flatten dropdowns into the stacked list; a strip dropdown is a real popover again,
+     anchored to its icon and kept inside the viewport. */
+  .navbar-quick .navbar-lnk.is-open > .dropdown-menu {
+    position: absolute;
+    width: max-content;
+    max-width: min(320px, calc(100vw - 24px));
+    border: 1px solid rgb(0 0 0 / 15%);
+    border-radius: 8px;
+    box-shadow: 0 6px 16px rgb(0 0 0 / 17.5%);
   }
 }
 

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1655,18 +1655,22 @@ kbd {
     margin-left: 0;
   }
 
-  /* Full-bleed rather than a narrow card hanging off the right edge: at these widths the menu is the page's whole
-     navigation, and a 220px panel over a 390px screen reads as an afterthought. */
+  /* Wide enough to read as the page's whole navigation rather than a 220px card hanging off one corner, but capped
+     so it stays under the hamburger that opened it instead of stretching across a tablet. On a phone the cap is
+     wider than the screen, so it goes full-bleed. */
   #navbar {
     position: absolute;
     top: var(--navbar-height);
     right: 0;
-    left: 0;
+    left: auto;
+    width: 100%;
+    max-width: 420px;
     padding: 6px 0;
     z-index: var(--navbar-z-index);
     background-color: var(--color-neutral-white);
-    box-shadow: 0 6px 16px rgb(0 0 0 / 17.5%);
     border-bottom: 1px solid var(--color-neutral-300);
+    border-radius: 0 0 8px 8px;
+    box-shadow: 0 6px 16px rgb(0 0 0 / 17.5%);
   }
 
   #header.header--tall #navbar {
@@ -1682,7 +1686,8 @@ kbd {
     overflow: hidden !important;
   }
 
-  .navbar-nav {
+  /* Scoped to the panel: the quick strip is a .navbar-nav too, and it stays a horizontal row in the bar. */
+  #navbar .navbar-nav {
     display: block !important;
     width: 100%;
     margin: 0;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1769,28 +1769,44 @@ kbd {
     margin-left: 0;
   }
 
-  /* Square tap target sized past the 24px WCAG 2.5.8 minimum, since these sit right next to each other. */
+  /*
+   * Destinations keep their labels here: an icon alone is only reliable for glyphs people have already learned, and
+   * "About" and "API" aren't among them. Labelling costs width, which is why Navbar.js measures — fewer items reach
+   * the bar on a small phone, and the rest stay one tap away in the panel.
+   */
   .navbar-nav.navbar-quick > li > .navbar-button {
     display: flex;
+    align-items: center;
     justify-content: center;
     width: auto;
     min-width: 40px;
-    height: 40px;
-    padding: 0;
-    gap: 0;
+    height: 36px;
+    padding: 0 10px;
+    gap: 4px;
     border: none;
     border-radius: 8px;
+
+    /* The panel lets labels wrap onto a second line; in this single-line bar that would break the row. */
+    white-space: nowrap;
   }
 
   .navbar-quick .navbar-lnk-icon,
   .navbar-quick .navbar-select-icon {
     display: block;
-    width: 20px;
-    height: 20px;
+    width: 18px;
+    height: 18px;
   }
 
-  /* The icon carries the meaning visually; the label still names the control for assistive tech. */
-  .navbar-quick .navbar-lnk-label,
+  /*
+   * The account control is the exception, and only because the person glyph is one of the learned ones. A username is
+   * also the longest, least predictable label in the bar — showing it would crowd out the destinations on a phone,
+   * and the button's aria-label still names it.
+   */
+  #navbar-quick #navbar-user-dropdown-list > .navbar-button {
+    min-width: 40px;
+    padding: 0;
+  }
+
   .navbar-quick .navbar-user-name {
     position: absolute;
     width: 1px;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -696,10 +696,31 @@ a {
   min-height: 20px;
 }
 
+/* The three columns don't fill the 900px evenly, so centering the row alone leaves the group visibly left of centre;
+   the offset is what makes the *content* read as centered. */
 #footer-container .footer-links-row {
   width: 900px;
   position: relative;
   left: 80px;
+}
+
+/*
+ * Below the width that fits 900px plus that 80px offset, both turn into overflow: the row is laid out past the right
+ * edge, which widens the page. Every page carries this footer, so every page scrolled sideways on a phone — and since
+ * the navbar is fixed to the initial containing block that the overflow widens, the navbar was laid out wider than
+ * the screen too, pushing the hamburger off it (#4857).
+ *
+ * Bootstrap's gutters have to go with it: .row pulls itself 15px wider on each side expecting a block container to
+ * absorb the difference, and #footer-container is a flex container, so that width lands outside the viewport instead.
+ * The columns keep their own padding, which is what still indents the text once the row stops overhanging.
+ */
+@media (width <= 1060px) {
+  #footer-container .footer-links-row {
+    width: 100%;
+    left: 0;
+    margin-left: 0;
+    margin-right: 0;
+  }
 }
 
 #info-footer .footer-logos-row {
@@ -895,25 +916,27 @@ a {
   outline-offset: 2px;
 }
 
-@media only screen and (device-width <= 500px) {
-  #award-num {
-    width: 100% !important;
-    right: 0% !important;
-  }
-}
-
-@media only screen and (device-width <= 800px) and (device-width >= 500px) {
-  #award-num {
-    width: 350% !important;
-    right: 45% !important;
-  }
-}
-
+/* Sized as a multiple of its own column because the award text is far wider than the narrow .col-sm-1 it sits under,
+   and pulled back left by the matching offset so it stays under the NSF logo. */
 #award-num {
   font-size:10px;
   color:#c0becf;
   width: 220%;
   right: 35%;
+}
+
+/*
+ * Below Bootstrap's sm breakpoint the columns stop floating and stack full-width, so a percentage picked for a narrow
+ * column becomes multiples of the viewport — 220% of 737px is 1621px of page, and the fixed navbar is sized from the
+ * containing block that widens with it (#4857). Keyed on `width` rather than the `device-width` this used before:
+ * device-width is the physical screen, so it missed every resized desktop window and fired off the wrong dimension on
+ * a rotated tablet.
+ */
+@media (width <= 767px) {
+  #award-num {
+    width: 100%;
+    right: 0;
+  }
 }
 
 #funding-title {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -928,9 +928,9 @@ a {
 /*
  * Below Bootstrap's sm breakpoint the columns stop floating and stack full-width, so a percentage picked for a narrow
  * column becomes multiples of the viewport — 220% of 737px is 1621px of page, and the fixed navbar is sized from the
- * containing block that widens with it (#4857). Keyed on `width` rather than the `device-width` this used before:
- * device-width is the physical screen, so it missed every resized desktop window and fired off the wrong dimension on
- * a rotated tablet.
+ * containing block that widens with it (#4857). Keyed on `width` because the viewport is what the columns lay out
+ * against: `device-width` is the physical screen, which ignores a resized desktop window entirely and reports the
+ * wrong dimension on a rotated tablet.
  */
 @media (width <= 767px) {
   #award-num {
@@ -1821,11 +1821,16 @@ kbd {
   }
 
   /*
-   * The account control is the exception, and only because the person glyph is one of the learned ones. A username is
-   * also the longest, least predictable label in the bar — showing it would crowd out the destinations on a phone,
-   * and the button's aria-label still names it.
+   * The signed-in account control is the exception, and only because the person glyph is one of the learned ones. A
+   * username is also the longest, least predictable label in the bar — showing it would crowd out the destinations on
+   * a phone, and the button's aria-label still names it.
+   *
+   * Scoped to that one button rather than the <li>, which also wraps the signed-out sign-in link: a log-in arrow is
+   * not a learned glyph, "Sign in" is short and predictable, and the label is that link's whole accessible name. It
+   * keeps its text and the shared pill padding above; Navbar.js measures, so the wider pill just means one fewer
+   * destination fits.
    */
-  #navbar-quick #navbar-user-dropdown-list > .navbar-button {
+  #navbar-quick #nav-user-dropdown {
     min-width: 40px;
     padding: 0;
   }

--- a/public/css/mobile-landing.css
+++ b/public/css/mobile-landing.css
@@ -1,37 +1,5 @@
 /* CSS for mobile landing page */
 
-/* Slim sticky header */
-#mobile-landing-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 10px 16px;
-  background: var(--color-neutral-white);
-  box-shadow: 0 1px 3px rgb(0 0 0 / 12%);
-  position: sticky;
-  top: 0;
-  z-index: 100;
-}
-
-#mobile-landing-logo-header {
-  height: 36px;
-  width: auto;
-}
-
-.mobile-header-signin {
-  font-family: Raleway, sans-serif;
-  font-size: 13px;
-  font-weight: bold;
-  color: var(--color-asphalt-500);
-  text-decoration: none;
-}
-
-.mobile-header-signin:hover,
-.mobile-header-signin:focus {
-  color: var(--color-asphalt-500);
-  text-decoration: underline;
-}
-
 /* Slightly smaller variant for the hero CTA so it doesn't compete with the tagline */
 #mobile-hero-cta-btn {
   font-size: 13px;

--- a/public/css/user-dashboard/user-dashboard.css
+++ b/public/css/user-dashboard/user-dashboard.css
@@ -1541,9 +1541,9 @@
   }
   .ud-field-inline .ud-input { flex: 1 1 auto; }
 
-  /* Mobile nav: the shared shell floats a fixed hamburger that overlaps our heading and uses an off-brand blue.
-       Our section nav is only a few links and the sidebar is the first child of the container, so instead we show it
-       inline above the content as a tidy chip row and hide that floating toggle entirely. */
+  /* Mobile nav: this surface's section nav is two or three links, so it fits inline above the content as a chip row
+       and needs no disclosure to open it — unlike the API docs' 18 links and the admin dashboard's 12, which the
+       shared shell collapses behind .api-sidebar-toggle. */
   .api-sidebar-toggle { display: none !important; }
 
   .api-container .api-sidebar {

--- a/public/js/admin-dashboard/AdminShell.js
+++ b/public/js/admin-dashboard/AdminShell.js
@@ -1,7 +1,7 @@
 /**
  * Shell behaviors for the redesigned admin dashboard (#4272): builds the right-hand "On this page" table of
  * contents from the page's headings, highlights the active section on scroll (scroll-spy), smooth-scrolls anchor
- * clicks past the fixed navbar, and provides a hamburger toggle for the left nav on narrow screens.
+ * clicks past the fixed navbar, and adds the left nav's mobile disclosure (sidebarDisclosure.js).
  *
  * This is a clean ES6 reimplementation of the equivalent api-docs.js logic, operating on the same .api-* markup so
  * the look and behavior match. It self-initializes on DOMContentLoaded.
@@ -23,7 +23,7 @@ class AdminShell {
     this.#buildTableOfContents();
     this.#setupScrollSpy();
     this.#setupSmoothScrolling();
-    this.#setupMobileNav();
+    initSidebarDisclosure();
     this.#localizeDeployTimes();
   }
 
@@ -111,23 +111,6 @@ class AdminShell {
         history.replaceState(null, '', `#${id}`);
       });
     });
-  }
-
-  /** Adds a hamburger button (shown via CSS on narrow screens) that toggles the left nav. */
-  #setupMobileNav() {
-    const sidebar = document.querySelector('.api-sidebar');
-    if (!sidebar || document.querySelector('.api-sidebar-toggle')) return;
-
-    const toggle = document.createElement('button');
-    toggle.className = 'api-sidebar-toggle';
-    toggle.setAttribute('aria-label', 'Toggle navigation');
-    toggle.setAttribute('aria-expanded', 'false');
-    toggle.innerHTML = '☰';
-    toggle.addEventListener('click', () => {
-      const open = sidebar.classList.toggle('mobile-visible');
-      toggle.setAttribute('aria-expanded', String(open));
-    });
-    document.body.appendChild(toggle);
   }
 }
 

--- a/public/js/api-docs/apiDocs.js
+++ b/public/js/api-docs/apiDocs.js
@@ -36,7 +36,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // 4. Initialize other features.
   generateTableOfContents();
   setupScrollSpy();
-  setupMobileNavigation();
+  initSidebarDisclosure();
   setupPermalinkCopying();
   setupSmoothScrolling();
 
@@ -413,42 +413,6 @@ function setupSmoothScrolling() {
       }
     });
   });
-}
-
-/**
- * Sets up mobile-specific navigation behavior (toggle button).
- * @returns {void}
- */
-function setupMobileNavigation() {
-  const sidebar = document.querySelector('.api-sidebar');
-  const toggleButton = document.querySelector('.api-sidebar-toggle');
-
-  // Only create toggle if it doesn't exist and sidebar exists.
-  if (sidebar && !toggleButton) {
-    const button = document.createElement('button');
-    button.className = 'api-sidebar-toggle';
-    button.innerHTML = '☰ Menu';
-    button.setAttribute('aria-label', 'Toggle Navigation Menu');
-    button.setAttribute('aria-expanded', 'false'); // Initial state is closed
-    button.setAttribute('aria-controls', 'api-sidebar-nav'); // Assuming sidebar nav has this ID
-
-    // Add ID to nav container if it doesn't have one.
-    const nav = sidebar.querySelector('.api-nav');
-    if (nav && !nav.id) {
-      nav.id = 'api-sidebar-nav';
-    }
-
-    button.addEventListener('click', function () {
-      const isVisible = sidebar.classList.toggle('mobile-visible');
-      this.setAttribute('aria-expanded', isVisible);
-      this.innerHTML = isVisible ? '✕ Close' : '☰ Menu';
-    });
-
-    // Insert button at the beginning of the body or a designated header area.
-    document.body.insertBefore(button, document.body.firstChild);
-  } else if (toggleButton) {
-    console.log('Mobile navigation toggle already exists.');
-  }
 }
 
 /**

--- a/public/js/common/Navbar.js
+++ b/public/js/common/Navbar.js
@@ -28,6 +28,9 @@ class NavbarController {
   /** @type {?HTMLElement} The strip in the brand area that holds the collapsed bar's quick links. */
   #quickStrip = null;
 
+  /** @type {?boolean} Whether the last fit found the nav collapsed; null before the first one. */
+  #stacked = null;
+
   /**
    * The `data-nav-quick` items in authored order, which is the order the collapsed bar shows them in — destinations
    * then the account control, matching the inline bar's primary-then-utility reading order.
@@ -115,7 +118,7 @@ class NavbarController {
    * @param {boolean} [focusFirst=false] - Move focus into the panel (search input if present, else first item).
    */
   #open(li, btn, panel, focusFirst = false) {
-    this.#closeAll(li);
+    this.#closeAll({ except: li });
     // A dropdown outside the collapsible panel is a peer of it, not a child, so the two can't both be showing. The
     // ones still inside it (Tools, city, language) obviously must leave it open.
     if (this.#menu && !this.#menu.contains(li)) this.#setMenuOpen(false);
@@ -148,13 +151,18 @@ class NavbarController {
   }
 
   /**
-   * Closes every open dropdown except an optional one to keep open.
-   * @param {?HTMLElement} [except] - A <li> to leave open.
+   * Closes every open dropdown, optionally sparing one or limiting the sweep to a container.
+   *
+   * @param {Object} [opts] - Options.
+   * @param {?HTMLElement} [opts.except] - A <li> to leave open.
+   * @param {?HTMLElement} [opts.within] - Close only dropdowns inside this element; all of them when omitted.
    */
-  #closeAll(except) {
+  #closeAll({ except = null, within = null } = {}) {
     for (const btn of this.#toggles) {
       const li = btn.closest('.navbar-lnk');
-      if (li && li !== except && li.classList.contains('is-open')) this.#close(li, btn);
+      if (!li || li === except || !li.classList.contains('is-open')) continue;
+      if (within && !within.contains(li)) continue;
+      this.#close(li, btn);
     }
   }
 
@@ -250,13 +258,15 @@ class NavbarController {
    *
    * Opening it closes any open dropdown, because the panel and the quick strip's dropdowns are peer disclosures
    * anchored to the same bar: with the account control promoted into the strip, both could otherwise be open at once
-   * and overlap each other.
+   * and overlap each other. Closing it closes the ones nested inside it, since `is-open` lives on the <li> and nothing
+   * else clears it — an expanded Tools menu would come back expanded, and render as a floating panel in the inline bar
+   * if the window widened first.
    *
    * @param {boolean} open - Whether the panel should be open.
    */
   #setMenuOpen(open) {
     if (!this.#menu) return;
-    if (open) this.#closeAll();
+    this.#closeAll(open ? {} : { within: this.#menu });
     this.#menu.classList.toggle('is-open', open);
     this.#hamburger?.setAttribute('aria-expanded', String(open));
   }
@@ -308,7 +318,18 @@ class NavbarController {
    */
   #fitNav() {
     // In the stacked hamburger panel each item has its own row, so everything is shown.
-    const stacked = this.#hamburger && this.#hamburger.offsetParent !== null;
+    const stacked = Boolean(this.#hamburger && this.#hamburger.offsetParent !== null);
+
+    // Crossing the collapse boundary restyles every disclosure in the bar: the panel is the inline bar on the far
+    // side, and a dropdown is an anchored popover on one side and a flattened row on the other. Anything open at that
+    // moment was opened against the layout being left, so it closes. Only on the crossing — a plain resize (an
+    // on-screen keyboard opening, a URL bar collapsing) must not yank a menu out from under the user mid-use.
+    if (this.#stacked !== null && stacked !== this.#stacked) {
+      this.#setMenuOpen(false);
+      this.#closeAll();
+    }
+    this.#stacked = stacked;
+
     for (const step of this.#shedSteps) step(false);
     this.#applyQuickStrip(stacked);
     if (stacked) return;
@@ -337,6 +358,7 @@ class NavbarController {
     }
 
     for (const { li } of this.#quickItems) {
+      if (li.parentElement !== this.#quickStrip) this.#closeOpenDropdown(li);
       this.#quickStrip.appendChild(li);
       li.classList.add('is-quick');
     }
@@ -358,9 +380,25 @@ class NavbarController {
   #sendHome({ li, parent }) {
     li.classList.remove('is-quick');
     if (li.parentElement === parent) return;
+    this.#closeOpenDropdown(li);
     const order = this.#quickHomes.get(parent) || [];
     const anchor = order.slice(order.indexOf(li) + 1).find((el) => el.parentElement === parent) || null;
     parent.insertBefore(li, anchor);
+  }
+
+  /**
+   * Closes an item's dropdown, if it has one open, before the item changes lists.
+   *
+   * The open state is a class on the <li> and `.navbar-lnk.is-open > .dropdown-menu` isn't scoped by breakpoint, so an
+   * item carried across the collapse boundary still open would render its panel in a bar the user never opened it
+   * from — floating and unanchored in the inline bar, with no gesture behind it.
+   *
+   * @param {HTMLElement} li - The item about to move.
+   */
+  #closeOpenDropdown(li) {
+    if (!li.classList.contains('is-open')) return;
+    const btn = li.querySelector('[data-nav-dropdown]');
+    if (btn) this.#close(li, btn);
   }
 
   /**

--- a/public/js/common/Navbar.js
+++ b/public/js/common/Navbar.js
@@ -25,15 +25,22 @@ class NavbarController {
   /** @type {HTMLElement[]} The two nav groups (primary, utility) whose combined width has to fit the bar. */
   #navGroups = [];
 
-  /** @type {?HTMLElement} The strip in the brand area that holds the collapsed bar's icon-only quick links. */
+  /** @type {?HTMLElement} The strip in the brand area that holds the collapsed bar's quick links. */
   #quickStrip = null;
 
   /**
-   * The `data-nav-quick` items, highest priority (lowest `data-nav-quick`) first — the order the collapsed bar fills
-   * them in, and the reverse of the order it drops them.
+   * The `data-nav-quick` items in authored order, which is the order the collapsed bar shows them in — destinations
+   * then the account control, matching the inline bar's primary-then-utility reading order.
    * @type {Array<{li: HTMLElement, parent: HTMLElement}>}
    */
   #quickItems = [];
+
+  /**
+   * The same items ordered by `data-nav-quick`, lowest first. This is a priority ranking, not a layout order: the bar
+   * drops from the back of it when the row won't fit, so the account control survives to the narrowest widths.
+   * @type {Array<{li: HTMLElement, parent: HTMLElement}>}
+   */
+  #quickByPriority = [];
 
   /**
    * Each quick item's original list, in its original child order, which is what says where an item goes back to.
@@ -248,8 +255,9 @@ class NavbarController {
 
     this.#quickStrip = document.getElementById('navbar-quick');
     this.#quickItems = Array.from(this.#menu.querySelectorAll('[data-nav-quick]'))
-      .sort((a, b) => Number(a.dataset.navQuick) - Number(b.dataset.navQuick))
       .map((li) => ({ li, parent: li.parentElement }));
+    this.#quickByPriority = [...this.#quickItems]
+      .sort((a, b) => Number(a.li.dataset.navQuick) - Number(b.li.dataset.navQuick));
     for (const { parent } of this.#quickItems) {
       if (!this.#quickHomes.has(parent)) this.#quickHomes.set(parent, Array.from(parent.children));
     }
@@ -295,7 +303,7 @@ class NavbarController {
   }
 
   /**
-   * Moves the `data-nav-quick` items between the collapsed bar's icon strip and their places in the inline bar.
+   * Moves the `data-nav-quick` items between the collapsed bar's quick strip and their places in the inline bar.
    *
    * Below the collapse breakpoint the bar is otherwise just a logo and a hamburger, which buries the handful of
    * destinations that are worth one tap. Each item is moved rather than duplicated — one copy keeps the ids the
@@ -316,9 +324,9 @@ class NavbarController {
       this.#quickStrip.appendChild(li);
       li.classList.add('is-quick');
     }
-    // Drop the lowest-priority icons until the row fits. Measured rather than pinned to a second breakpoint,
-    // because the logo is a per-city image and the strip's width depends on how many items the page renders.
-    for (const item of [...this.#quickItems].reverse()) {
+    // Drop the lowest-priority items until the row fits. Measured rather than pinned to a second breakpoint, because
+    // the widths involved depend on the active language's labels, the per-city logo, and which items the page renders.
+    for (const item of [...this.#quickByPriority].reverse()) {
       if (this.#quickStripFits()) return;
       this.#sendHome(item);
     }
@@ -345,7 +353,7 @@ class NavbarController {
   #quickStripFits() {
     const row = this.#quickStrip.parentElement;
     // The strip is the flex item that gives, so the row's own scrollWidth stays pinned to its width; sum the
-    // children instead. Slack leaves the logo and the icons from sitting flush against each other.
+    // children instead. The slack keeps the logo and the links from sitting flush against each other.
     const needed = Array.from(row.children)
       .reduce((sum, child) => sum + child.getBoundingClientRect().width, 0);
     return needed <= row.clientWidth - 16;

--- a/public/js/common/Navbar.js
+++ b/public/js/common/Navbar.js
@@ -25,6 +25,24 @@ class NavbarController {
   /** @type {HTMLElement[]} The two nav groups (primary, utility) whose combined width has to fit the bar. */
   #navGroups = [];
 
+  /** @type {?HTMLElement} The strip in the brand area that holds the collapsed bar's icon-only quick links. */
+  #quickStrip = null;
+
+  /**
+   * The `data-nav-quick` items, highest priority (lowest `data-nav-quick`) first — the order the collapsed bar fills
+   * them in, and the reverse of the order it drops them.
+   * @type {Array<{li: HTMLElement, parent: HTMLElement}>}
+   */
+  #quickItems = [];
+
+  /**
+   * Each quick item's original list, in its original child order, which is what says where an item goes back to.
+   * Recorded per list rather than as a "next sibling" per item, because that sibling can be a quick item that is
+   * itself away in the strip.
+   * @type {Map<HTMLElement, Element[]>}
+   */
+  #quickHomes = new Map();
+
   /**
    * Space-freeing steps for the inline bar, ordered lowest priority first. Each takes a boolean and applies or
    * clears its effect; #fitNav applies as few as will make the bar fit.
@@ -226,7 +244,15 @@ class NavbarController {
     this.#menu = document.getElementById('navbar');
     this.#hamburger = this.#nav.querySelector('[data-nav-toggle]');
     if (!this.#menu) return;
-    this.#navGroups = Array.from(this.#menu.querySelectorAll('.navbar-nav'));
+    this.#navGroups = Array.from(this.#menu.querySelectorAll('#navbar > .navbar-nav'));
+
+    this.#quickStrip = document.getElementById('navbar-quick');
+    this.#quickItems = Array.from(this.#menu.querySelectorAll('[data-nav-quick]'))
+      .sort((a, b) => Number(a.dataset.navQuick) - Number(b.dataset.navQuick))
+      .map((li) => ({ li, parent: li.parentElement }));
+    for (const { parent } of this.#quickItems) {
+      if (!this.#quickHomes.has(parent)) this.#quickHomes.set(parent, Array.from(parent.children));
+    }
 
     // Items opt in via data-nav-shed="<n>", n ascending from the first to be dropped.
     this.#shedSteps = Array.from(this.#menu.querySelectorAll('[data-nav-shed]'))
@@ -260,11 +286,69 @@ class NavbarController {
     // In the stacked hamburger panel each item has its own row, so everything is shown.
     const stacked = this.#hamburger && this.#hamburger.offsetParent !== null;
     for (const step of this.#shedSteps) step(false);
+    this.#applyQuickStrip(stacked);
     if (stacked) return;
     for (const step of this.#shedSteps) {
       if (this.#navFits()) return;
       step(true);
     }
+  }
+
+  /**
+   * Moves the `data-nav-quick` items between the collapsed bar's icon strip and their places in the inline bar.
+   *
+   * Below the collapse breakpoint the bar is otherwise just a logo and a hamburger, which buries the handful of
+   * destinations that are worth one tap. Each item is moved rather than duplicated — one copy keeps the ids the
+   * click logging and the dialog wiring key on unique — so an item promoted to the strip leaves the panel, and one
+   * that doesn't fit stays in the panel. Nothing is ever unreachable.
+   *
+   * @param {boolean} stacked - Whether the nav is collapsed behind the hamburger.
+   */
+  #applyQuickStrip(stacked) {
+    if (!this.#quickStrip) return;
+
+    if (!stacked) {
+      for (const item of this.#quickItems) this.#sendHome(item);
+      return;
+    }
+
+    for (const { li } of this.#quickItems) {
+      this.#quickStrip.appendChild(li);
+      li.classList.add('is-quick');
+    }
+    // Drop the lowest-priority icons until the row fits. Measured rather than pinned to a second breakpoint,
+    // because the logo is a per-city image and the strip's width depends on how many items the page renders.
+    for (const item of [...this.#quickItems].reverse()) {
+      if (this.#quickStripFits()) return;
+      this.#sendHome(item);
+    }
+  }
+
+  /**
+   * Puts a quick item back in its own list, before the first of its original later siblings that is currently there.
+   * Any that are still in the strip are skipped, so the surviving items keep their authored order however many of
+   * them have been promoted.
+   *
+   * @param {{li: HTMLElement, parent: HTMLElement}} item - The item and the list it belongs to.
+   */
+  #sendHome({ li, parent }) {
+    li.classList.remove('is-quick');
+    if (li.parentElement === parent) return;
+    const order = this.#quickHomes.get(parent) || [];
+    const anchor = order.slice(order.indexOf(li) + 1).find((el) => el.parentElement === parent) || null;
+    parent.insertBefore(li, anchor);
+  }
+
+  /**
+   * @returns {boolean} Whether the brand row (logo + quick strip + hamburger) fits on one line.
+   */
+  #quickStripFits() {
+    const row = this.#quickStrip.parentElement;
+    // The strip is the flex item that gives, so the row's own scrollWidth stays pinned to its width; sum the
+    // children instead. Slack leaves the logo and the icons from sitting flush against each other.
+    const needed = Array.from(row.children)
+      .reduce((sum, child) => sum + child.getBoundingClientRect().width, 0);
+    return needed <= row.clientWidth - 16;
   }
 
   /**

--- a/public/js/common/Navbar.js
+++ b/public/js/common/Navbar.js
@@ -116,6 +116,9 @@ class NavbarController {
    */
   #open(li, btn, panel, focusFirst = false) {
     this.#closeAll(li);
+    // A dropdown outside the collapsible panel is a peer of it, not a child, so the two can't both be showing. The
+    // ones still inside it (Tools, city, language) obviously must leave it open.
+    if (this.#menu && !this.#menu.contains(li)) this.#setMenuOpen(false);
     li.classList.add('is-open');
     btn.setAttribute('aria-expanded', 'true');
     this.#current = { li, btn };
@@ -234,13 +237,28 @@ class NavbarController {
 
   /** Wires the mobile hamburger toggle for the collapsed nav. */
   #wireHamburger() {
-    const toggle = this.#nav.querySelector('[data-nav-toggle]');
-    const menu = document.getElementById('navbar');
-    if (!toggle || !menu) return;
-    toggle.addEventListener('click', () => {
-      const open = menu.classList.toggle('is-open');
-      toggle.setAttribute('aria-expanded', String(open));
+    this.#hamburger = this.#nav.querySelector('[data-nav-toggle]');
+    this.#menu = document.getElementById('navbar');
+    if (!this.#hamburger || !this.#menu) return;
+    this.#hamburger.addEventListener('click', () => {
+      this.#setMenuOpen(!this.#menu.classList.contains('is-open'));
     });
+  }
+
+  /**
+   * Opens or closes the collapsed nav's panel.
+   *
+   * Opening it closes any open dropdown, because the panel and the quick strip's dropdowns are peer disclosures
+   * anchored to the same bar: with the account control promoted into the strip, both could otherwise be open at once
+   * and overlap each other.
+   *
+   * @param {boolean} open - Whether the panel should be open.
+   */
+  #setMenuOpen(open) {
+    if (!this.#menu) return;
+    if (open) this.#closeAll();
+    this.#menu.classList.toggle('is-open', open);
+    this.#hamburger?.setAttribute('aria-expanded', String(open));
   }
 
   /**
@@ -248,8 +266,6 @@ class NavbarController {
    * can have changed.
    */
   #wireResponsiveNav() {
-    this.#menu = document.getElementById('navbar');
-    this.#hamburger = this.#nav.querySelector('[data-nav-toggle]');
     if (!this.#menu) return;
     this.#navGroups = Array.from(this.#menu.querySelectorAll('#navbar > .navbar-nav'));
 
@@ -356,7 +372,22 @@ class NavbarController {
     // children instead. The slack keeps the logo and the links from sitting flush against each other.
     const needed = Array.from(row.children)
       .reduce((sum, child) => sum + child.getBoundingClientRect().width, 0);
-    return needed <= row.clientWidth - 16;
+    return needed <= this.#visibleWidth(row) - 16;
+  }
+
+  /**
+   * The width of an element that the viewer can actually see.
+   *
+   * The navbar is fixed to the initial containing block, which a horizontally overflowing page widens past the
+   * screen — so a bar that measures as fitting can still run its last item off the right edge. Anything past the
+   * visible edge doesn't count toward the budget. Reduces to clientWidth on a page that doesn't overflow.
+   *
+   * @param {HTMLElement} el - The element being measured.
+   * @returns {number} Its width in px, less however much of it sits beyond the viewport's right edge.
+   */
+  #visibleWidth(el) {
+    const overhang = Math.max(0, el.getBoundingClientRect().right - document.documentElement.clientWidth);
+    return el.clientWidth - overhang;
   }
 
   /**
@@ -369,7 +400,7 @@ class NavbarController {
     const needed = this.#navGroups.reduce((sum, group) => sum + group.getBoundingClientRect().width, 0);
 
     // Slack covers the gap between the groups plus a little breathing room, so items never sit flush together.
-    return needed <= this.#menu.clientWidth - 24;
+    return needed <= this.#visibleWidth(this.#menu) - 24;
   }
 
   /** Wires live client-side filtering of the city switcher, hiding empty country groups. */
@@ -401,7 +432,32 @@ class NavbarController {
       }
     };
     document.addEventListener('click', (e) => closeIfOutside(e.target));
-    document.addEventListener('focusin', (e) => closeIfOutside(e.target));
+
+    // The panel dismisses on press, not click: closing a dropdown reflows the panel between press and release, which
+    // moves the row out from under the finger and makes the browser retarget the click to a common ancestor. Read on
+    // click, that ancestor looks like an outside tap and would close the panel the user is still using. The hamburger
+    // is excluded — its own handler has already toggled, and closing here would undo an open just asked for.
+    document.addEventListener('pointerdown', (e) => {
+      if (!this.#menu?.classList.contains('is-open')) return;
+      if (this.#menu.contains(e.target) || this.#hamburger?.contains(e.target)) return;
+      this.#setMenuOpen(false);
+    });
+
+    // Only a focus move out of the navbar entirely closes the open dropdown. Focus landing on another navbar control
+    // is left alone: that control's own click/keydown handler closes the others via #open, and closing here would
+    // reflow the bar mid-gesture, on the mousedown before the click that opens the next one lands.
+    document.addEventListener('focusin', (e) => {
+      if (!this.#nav.contains(e.target)) closeIfOutside(e.target);
+    });
+
+    // Escape closes the panel, innermost disclosure first: a dropdown inside it consumes the key (its handlers call
+    // preventDefault), so the first Escape closes that dropdown and only the next one closes the panel.
+    document.addEventListener('keydown', (e) => {
+      if (e.key !== 'Escape' || e.defaultPrevented) return;
+      if (!this.#menu?.classList.contains('is-open')) return;
+      this.#setMenuOpen(false);
+      this.#hamburger?.focus();
+    });
   }
 
   /** Logs navbar clicks to the activity table via a single delegated listener keyed on element id. */

--- a/public/js/common/pagetopPadding.js
+++ b/public/js/common/pagetopPadding.js
@@ -2,8 +2,7 @@ function checkIfPaddingNeeded() {
   if (window.location.pathname === '/'
     || window.location.pathname === '/home'
     || window.location.pathname === '/signInMobile'
-    || window.location.pathname === '/signUpMobile'
-    || window.location.pathname === '/mobileLanding') {
+    || window.location.pathname === '/signUpMobile') {
     document.body.style.paddingTop = '0px';
   }
 }

--- a/public/js/common/sidebarDisclosure.js
+++ b/public/js/common/sidebarDisclosure.js
@@ -1,0 +1,56 @@
+/**
+ * Mobile section-nav disclosure for the shared `.api-*` shell (API docs, admin dashboard, user dashboard).
+ *
+ * At mobile widths api-docs.css turns `.api-sidebar` from a column into an in-flow strip between the navbar and the
+ * content, and collapses its `.api-nav`. This adds the button that opens it. The button lives *inside* the sidebar so
+ * the nav opens beneath it and pushes the page down — the previous control was appended to <body> and positioned
+ * fixed, so it floated over whatever the page happened to render underneath (#4856).
+ *
+ * The button is labelled with the active nav item, so the strip also answers "which page am I on?" — the thing the
+ * collapsed sidebar otherwise takes away.
+ */
+
+/**
+ * Builds the disclosure button for a shell sidebar and wires it to that sidebar's nav.
+ *
+ * @param {HTMLElement} sidebar - The `.api-sidebar` whose `.api-nav` the button discloses.
+ * @returns {HTMLButtonElement} The wired-up button, not yet inserted into the document.
+ */
+function buildSidebarDisclosure(sidebar) {
+  const nav = sidebar.querySelector('.api-nav');
+  if (nav && !nav.id) nav.id = 'api-sidebar-nav';
+
+  // The active item names the current page; the first group header is the fallback on a page with no active item.
+  const active = sidebar.querySelector('.api-nav-item.active');
+  const heading = sidebar.querySelector('.api-nav-header');
+  const label = (active || heading)?.textContent.trim() || 'Menu';
+
+  const toggle = document.createElement('button');
+  toggle.type = 'button';
+  toggle.className = 'api-sidebar-toggle';
+  toggle.setAttribute('aria-expanded', 'false');
+  if (nav) toggle.setAttribute('aria-controls', nav.id);
+  toggle.innerHTML = `
+    <span class="api-sidebar-toggle-label"></span>
+    <svg class="api-sidebar-toggle-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+         stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>`;
+  // Assigned as text rather than interpolated into the markup above so a page title can't inject HTML.
+  toggle.querySelector('.api-sidebar-toggle-label').textContent = label;
+
+  toggle.addEventListener('click', () => {
+    const open = sidebar.classList.toggle('mobile-visible');
+    toggle.setAttribute('aria-expanded', String(open));
+  });
+  return toggle;
+}
+
+/**
+ * Adds the disclosure to the page's shell sidebar, if it has one and doesn't already have the button.
+ *
+ * @returns {void}
+ */
+function initSidebarDisclosure() {
+  const sidebar = document.querySelector('.api-sidebar');
+  if (!sidebar || sidebar.querySelector('.api-sidebar-toggle')) return;
+  sidebar.prepend(buildSidebarDisclosure(sidebar));
+}

--- a/public/js/common/sidebarDisclosure.js
+++ b/public/js/common/sidebarDisclosure.js
@@ -2,9 +2,9 @@
  * Mobile section-nav disclosure for the shared `.api-*` shell (API docs, admin dashboard, user dashboard).
  *
  * At mobile widths api-docs.css turns `.api-sidebar` from a column into an in-flow strip between the navbar and the
- * content, and collapses its `.api-nav`. This adds the button that opens it. The button lives *inside* the sidebar so
- * the nav opens beneath it and pushes the page down — the previous control was appended to <body> and positioned
- * fixed, so it floated over whatever the page happened to render underneath (#4856).
+ * content, and collapses its `.api-nav`. This adds the button that opens it. The button belongs *inside* the sidebar,
+ * sharing that in-flow strip, so the nav it discloses opens directly beneath it and pushes the page down rather than
+ * covering the content it lands on (#4856).
  *
  * The button is labelled with the active nav item, so the strip also answers "which page am I on?" — the thing the
  * collapsed sidebar otherwise takes away.
@@ -36,6 +36,9 @@ function buildSidebarDisclosure(sidebar) {
          stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>`;
   // Assigned as text rather than interpolated into the markup above so a page title can't inject HTML.
   toggle.querySelector('.api-sidebar-toggle-label').textContent = label;
+  // The visible text is the page name, which says where you are but not what the control does. The accessible name
+  // has to carry both, and has to start with the visible text so speech input still reaches it (WCAG 2.5.3).
+  toggle.setAttribute('aria-label', `${label} — section navigation`);
 
   toggle.addEventListener('click', () => {
     const open = sidebar.classList.toggle('mobile-visible');

--- a/test/js/navbarDisclosures.test.js
+++ b/test/js/navbarDisclosures.test.js
@@ -84,6 +84,18 @@ describe('Navbar disclosures', () => {
     const userBtn = () => document.getElementById('user-btn');
     const langBtn = () => document.getElementById('lang-btn');
 
+    /**
+     * Puts the bar in its collapsed or inline layout and lets the debounced re-fit run.
+     * The hamburger's visibility is what the controller reads the layout from.
+     */
+    async function setStacked(stacked) {
+        Object.defineProperty(hamburger(), 'offsetParent', {
+            configurable: true, get: () => (stacked ? document.body : null),
+        });
+        window.dispatchEvent(new Event('resize'));
+        await new Promise((resolve) => requestAnimationFrame(resolve));
+    }
+
     it('closes the panel when a quick-strip dropdown opens', () => {
         hamburger().click();
         expect(panelOpen()).toBe(true);
@@ -164,5 +176,52 @@ describe('Navbar disclosures', () => {
 
         expect(isOpen('language-dropdown')).toBe(false);
         expect(panelOpen()).toBe(true);
+    });
+
+    it('closes a dropdown inside the panel when the panel is dismissed', () => {
+        hamburger().click();
+        langBtn().click();
+        expect(isOpen('language-dropdown')).toBe(true);
+
+        press(document.getElementById('page'));
+
+        expect(panelOpen()).toBe(false);
+        expect(isOpen('language-dropdown')).toBe(false);
+        expect(langBtn().getAttribute('aria-expanded')).toBe('false');
+    });
+
+    // `.navbar-lnk.is-open > .dropdown-menu` is not scoped by breakpoint, so an item that crosses the collapse
+    // boundary still carrying `is-open` renders its panel in a bar the user never opened it from.
+    describe('when the bar crosses the collapse boundary', () => {
+        it('closes a quick-strip dropdown as its item returns to the inline bar', async () => {
+            userBtn().click();
+            expect(isOpen('li-user')).toBe(true);
+
+            await setStacked(false);
+
+            expect(document.getElementById('navbar-quick').children).toHaveLength(0);
+            expect(isOpen('li-user')).toBe(false);
+            expect(userBtn().getAttribute('aria-expanded')).toBe('false');
+        });
+
+        it('closes the panel and a dropdown open inside it', async () => {
+            hamburger().click();
+            langBtn().click();
+            expect(panelOpen()).toBe(true);
+
+            await setStacked(false);
+
+            expect(panelOpen()).toBe(false);
+            expect(isOpen('language-dropdown')).toBe(false);
+        });
+
+        it('leaves an open dropdown alone on a resize that stays on one side of it', async () => {
+            userBtn().click();
+
+            // What an on-screen keyboard or a collapsing URL bar looks like: a resize, same layout, menu still in use.
+            await setStacked(true);
+
+            expect(isOpen('li-user')).toBe(true);
+        });
     });
 });

--- a/test/js/navbarDisclosures.test.js
+++ b/test/js/navbarDisclosures.test.js
@@ -1,0 +1,168 @@
+/**
+ * Tests that the collapsed navbar's disclosures stay mutually consistent (#4857).
+ *
+ * The hamburger panel and the dropdown menus are separate pieces of state, which only became visible once the account
+ * control moved out of the panel and into the quick strip: the two are peers anchored to the same bar, so both could
+ * be open at once and overlap. A dropdown still *inside* the panel is a child, not a peer, and must leave it open —
+ * that asymmetry is the whole reason this is worth pinning.
+ *
+ * Loaded the same way as navbarQuickStrip.test.js: eval'd with an explicit export, with each test building its own
+ * DOM before constructing a controller.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const NAVBAR_SRC = fs.readFileSync(
+    path.resolve(__dirname, '..', '..', 'public/js/common/Navbar.js'), 'utf8'
+);
+
+/** Builds a navbar with one quick item (the account control) and one panel-only dropdown (language). */
+function buildNavbar() {
+    document.body.innerHTML = `
+      <div id="page">page content</div>
+      <nav id="header">
+        <div class="navbar-container">
+          <div class="navbar-brand-area">
+            <div class="navbar-logo"><a id="navbar-brand" href="/"></a></div>
+            <ul class="navbar-nav navbar-quick" id="navbar-quick"></ul>
+            <button type="button" class="navbar-toggle" data-nav-toggle aria-controls="navbar"
+                    aria-expanded="false"></button>
+          </div>
+          <div id="navbar">
+            <ul class="navbar-nav navbar-nav--utility">
+              <li class="dropdown navbar-lnk" id="li-user" data-nav-quick="1">
+                <button type="button" id="user-btn" class="navbar-button" data-nav-dropdown aria-expanded="false"
+                        aria-controls="nav-user-menu"></button>
+                <ul id="nav-user-menu" class="dropdown-menu"><li><a href="/dashboard"></a></li></ul>
+              </li>
+              <li class="dropdown navbar-lnk" id="language-dropdown">
+                <button type="button" id="lang-btn" class="navbar-button" data-nav-dropdown aria-expanded="false"
+                        aria-controls="nav-language-menu"></button>
+                <ul id="nav-language-menu" class="dropdown-menu"><li><a href="/lang"></a></li></ul>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </nav>`;
+}
+
+/** Stubs enough layout for the responsive pass to treat the nav as collapsed with room for the quick item. */
+function stubLayout() {
+    const rect = (el, w) => Object.defineProperty(el, 'getBoundingClientRect', {
+        configurable: true, value: () => ({ width: w, height: 38, x: 0, y: 0, top: 0, left: 0 }),
+    });
+    const hamburger = document.querySelector('[data-nav-toggle]');
+    Object.defineProperty(hamburger, 'offsetParent', { configurable: true, get: () => document.body });
+    rect(hamburger, 44);
+    rect(document.querySelector('.navbar-logo'), 110);
+    rect(document.getElementById('navbar-quick'), 40);
+    for (const group of document.querySelectorAll('#navbar > .navbar-nav')) rect(group, 100);
+    const row = document.querySelector('.navbar-brand-area');
+    Object.defineProperty(row, 'clientWidth', { configurable: true, get: () => 800 });
+    Object.defineProperty(document.getElementById('navbar'), 'clientWidth', { configurable: true, get: () => 800 });
+}
+
+const panelOpen = () => document.getElementById('navbar').classList.contains('is-open');
+const isOpen = (id) => document.getElementById(id).classList.contains('is-open');
+const press = (el) => el.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+
+describe('Navbar disclosures', () => {
+    beforeAll(() => {
+        window.eval(`${NAVBAR_SRC}\nwindow.NavbarController = NavbarController;`);
+    });
+
+    beforeEach(() => {
+        buildNavbar();
+        stubLayout();
+        new window.NavbarController();
+        // The account control is promoted into the strip, which is what makes it a peer of the panel.
+        expect(document.getElementById('navbar-quick').children).toHaveLength(1);
+    });
+
+    const hamburger = () => document.querySelector('[data-nav-toggle]');
+    const userBtn = () => document.getElementById('user-btn');
+    const langBtn = () => document.getElementById('lang-btn');
+
+    it('closes the panel when a quick-strip dropdown opens', () => {
+        hamburger().click();
+        expect(panelOpen()).toBe(true);
+
+        userBtn().click();
+
+        expect(isOpen('li-user')).toBe(true);
+        expect(panelOpen()).toBe(false);
+    });
+
+    it('closes a quick-strip dropdown when the panel opens', () => {
+        userBtn().click();
+        expect(isOpen('li-user')).toBe(true);
+
+        hamburger().click();
+
+        expect(panelOpen()).toBe(true);
+        expect(isOpen('li-user')).toBe(false);
+    });
+
+    it('keeps the panel open for a dropdown that is still inside it', () => {
+        hamburger().click();
+
+        langBtn().click();
+
+        expect(isOpen('language-dropdown')).toBe(true);
+        expect(panelOpen()).toBe(true);
+    });
+
+    it('keeps the hamburger button aria-expanded in step with the panel', () => {
+        hamburger().click();
+        expect(hamburger().getAttribute('aria-expanded')).toBe('true');
+
+        userBtn().click();
+
+        expect(hamburger().getAttribute('aria-expanded')).toBe('false');
+    });
+
+    it('dismisses the panel on a press outside it', () => {
+        hamburger().click();
+
+        press(document.getElementById('page'));
+
+        expect(panelOpen()).toBe(false);
+    });
+
+    it('does not dismiss the panel on a press on the hamburger, which owns its own toggle', () => {
+        hamburger().click();
+
+        press(hamburger());
+
+        expect(panelOpen()).toBe(true);
+    });
+
+    it('dismisses on press rather than click, since closing a dropdown reflows the panel mid-tap', () => {
+        hamburger().click();
+        // A click whose target retargeted to an ancestor after a reflow must not read as an outside tap.
+        document.getElementById('page').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+        expect(panelOpen()).toBe(true);
+    });
+
+    it('closes the panel on Escape', () => {
+        hamburger().click();
+
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+
+        expect(panelOpen()).toBe(false);
+    });
+
+    it('leaves the panel open when Escape was already consumed by a dropdown inside it', () => {
+        hamburger().click();
+        langBtn().click();
+
+        // The dropdown's own handler calls preventDefault, which is how the panel knows the key was spoken for.
+        const consumed = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true });
+        document.getElementById('nav-language-menu').dispatchEvent(consumed);
+
+        expect(isOpen('language-dropdown')).toBe(false);
+        expect(panelOpen()).toBe(true);
+    });
+});

--- a/test/js/navbarQuickStrip.test.js
+++ b/test/js/navbarQuickStrip.test.js
@@ -73,7 +73,7 @@ function buildNavbar() {
  * @param {boolean} opts.stacked - Whether the hamburger is showing (which is what puts the nav in its collapsed form).
  * @param {number} opts.barWidth - The width available to the brand row.
  */
-function stubLayout({ stacked, barWidth }) {
+function stubLayout({ stacked, barWidth, visibleWidth = Infinity }) {
     const width = (el, w) => Object.defineProperty(el, 'getBoundingClientRect', {
         configurable: true, value: () => ({ width: w, height: 38, x: 0, y: 0, top: 0, left: 0 }),
     });
@@ -83,8 +83,18 @@ function stubLayout({ stacked, barWidth }) {
         configurable: true, get: () => (stacked ? document.body : null),
     });
 
+    // A horizontally overflowing page widens the fixed navbar's containing block past the screen, so the row can be
+    // laid out wider than the viewer can see. `visibleWidth` is where the screen actually ends.
+    Object.defineProperty(document.documentElement, 'clientWidth', {
+        configurable: true, get: () => (visibleWidth === Infinity ? barWidth : visibleWidth),
+    });
+
     const row = document.querySelector('.navbar-brand-area');
     Object.defineProperty(row, 'clientWidth', { configurable: true, get: () => barWidth });
+    Object.defineProperty(row, 'getBoundingClientRect', {
+        configurable: true,
+        value: () => ({ width: barWidth, right: barWidth, height: 38, x: 0, y: 0, top: 0, left: 0 }),
+    });
     width(document.querySelector('.navbar-logo'), LOGO_WIDTH);
     width(hamburger, HAMBURGER_WIDTH);
 
@@ -168,6 +178,18 @@ describe('Navbar quick strip', () => {
 
         it('keeps the account control even when nothing else fits', () => {
             render({ stacked: true, barWidth: LOGO_WIDTH + HAMBURGER_WIDTH + ACCOUNT_WIDTH + 16 });
+
+            expect(stripIds()).toEqual(['li-user']);
+        });
+
+        it('budgets the visible width, not a width the overflowing page laid out off-screen', () => {
+            // Room for the account control and one destination on paper, but the screen ends 90px earlier — the
+            // symptom is the hamburger pushed off the right edge by an item that "fit".
+            render({
+                stacked: true,
+                barWidth: LOGO_WIDTH + HAMBURGER_WIDTH + ACCOUNT_WIDTH + LABELLED_WIDTH + 16,
+                visibleWidth: LOGO_WIDTH + HAMBURGER_WIDTH + ACCOUNT_WIDTH + 16,
+            });
 
             expect(stripIds()).toEqual(['li-user']);
         });

--- a/test/js/navbarQuickStrip.test.js
+++ b/test/js/navbarQuickStrip.test.js
@@ -2,10 +2,11 @@
  * Tests for the collapsed navbar's quick strip in Navbar.js (#4857).
  *
  * Below the collapse breakpoint the bar is otherwise a logo and a hamburger, so Navbar.js promotes `data-nav-quick`
- * items into a strip of icons beside the hamburger — moving the elements rather than copying them, because their ids
- * are what the click logging and the sign-in dialog key on. That makes two things worth pinning: an item is in exactly
- * one place at a time (promoted items leave the panel, and anything that doesn't fit stays in it, so nothing goes
- * missing), and widening the window puts every item back where the inline bar expects it, in order.
+ * items into a strip beside the hamburger — moving the elements rather than copying them, because their ids are what
+ * the click logging and the sign-in dialog key on. That makes three things worth pinning: the strip reads in authored
+ * order while it *drops* by `data-nav-quick` priority, so the account control survives narrowest; an item is in
+ * exactly one place at a time (promoted items leave the panel, and anything that doesn't fit stays in it, so nothing
+ * goes missing); and widening the window puts every item back where the inline bar expects it, in order.
  *
  * jsdom has no layout, so the widths the fit check reads are stubbed per element; `stacked` is likewise driven by
  * stubbing the hamburger's offsetParent, which is what the real code tests.
@@ -20,7 +21,9 @@ const NAVBAR_SRC = fs.readFileSync(
 
 const LOGO_WIDTH = 110;
 const HAMBURGER_WIDTH = 44;
-const QUICK_ITEM_WIDTH = 42;
+// Destinations carry a label, so they are wider than the icon-only account control.
+const ACCOUNT_WIDTH = 40;
+const LABELLED_WIDTH = 90;
 
 /** Builds the navbar markup the template renders, reduced to what the responsive code reads. */
 function buildNavbar() {
@@ -85,11 +88,15 @@ function stubLayout({ stacked, barWidth }) {
     width(document.querySelector('.navbar-logo'), LOGO_WIDTH);
     width(hamburger, HAMBURGER_WIDTH);
 
-    // The strip is a flex row of fixed-size icons, so its width follows from how many items it holds.
+    // The strip is a flex row, so its width is the sum of whichever items are currently in it.
     const strip = document.getElementById('navbar-quick');
     Object.defineProperty(strip, 'getBoundingClientRect', {
         configurable: true,
-        value: () => ({ width: strip.children.length * QUICK_ITEM_WIDTH, height: 40, x: 0, y: 0, top: 0, left: 0 }),
+        value: () => ({
+            width: Array.from(strip.children)
+                .reduce((sum, li) => sum + (li.id === 'li-user' ? ACCOUNT_WIDTH : LABELLED_WIDTH), 0),
+            height: 36, x: 0, y: 0, top: 0, left: 0,
+        }),
     });
 
     // The inline bar's own fit check; irrelevant while stacked, and generous enough not to shed when not.
@@ -130,27 +137,37 @@ describe('Navbar quick strip', () => {
 
     describe('when the nav is collapsed', () => {
         it('promotes every quick item to the strip when they all fit', () => {
-            render({ stacked: true, barWidth: 400 });
+            render({ stacked: true, barWidth: 800 });
 
-            expect(stripIds()).toEqual(['li-user', 'li-validate', 'li-about', 'li-api']);
+            expect(stripIds()).toEqual(['li-validate', 'li-api', 'li-about', 'li-user']);
+        });
+
+        it('shows them in authored order, with the account control last as in the inline bar', () => {
+            render({ stacked: true, barWidth: 800 });
+
+            // Not `data-nav-quick` order (user, validate, about, api) — that ranking only decides what gets dropped.
+            expect(stripIds()).toEqual(['li-validate', 'li-api', 'li-about', 'li-user']);
         });
 
         it('takes promoted items out of the panel, so nothing is listed twice', () => {
-            render({ stacked: true, barWidth: 400 });
+            render({ stacked: true, barWidth: 800 });
 
             expect(panelIds()).toEqual(['li-explore', 'language-dropdown']);
         });
 
-        it('drops the lowest-priority icons on a narrow screen and leaves them in the panel', () => {
-            // Room for the logo, the hamburger, and two icons.
-            render({ stacked: true, barWidth: LOGO_WIDTH + HAMBURGER_WIDTH + (2 * QUICK_ITEM_WIDTH) + 16 });
+        it('drops the lowest-priority items on a narrow screen and leaves them in the panel', () => {
+            // Room for the logo, the hamburger, the account control, and one labelled destination.
+            render({
+                stacked: true,
+                barWidth: LOGO_WIDTH + HAMBURGER_WIDTH + ACCOUNT_WIDTH + LABELLED_WIDTH + 16,
+            });
 
-            expect(stripIds()).toEqual(['li-user', 'li-validate']);
+            expect(stripIds()).toEqual(['li-validate', 'li-user']);
             expect(panelIds()).toEqual(expect.arrayContaining(['li-about', 'li-api']));
         });
 
-        it('keeps the account item even when only one icon fits', () => {
-            render({ stacked: true, barWidth: LOGO_WIDTH + HAMBURGER_WIDTH + QUICK_ITEM_WIDTH + 16 });
+        it('keeps the account control even when nothing else fits', () => {
+            render({ stacked: true, barWidth: LOGO_WIDTH + HAMBURGER_WIDTH + ACCOUNT_WIDTH + 16 });
 
             expect(stripIds()).toEqual(['li-user']);
         });
@@ -176,7 +193,7 @@ describe('Navbar quick strip', () => {
             render({ stacked: false, barWidth: 1400 });
             const authoredOrder = panelIds();
 
-            render({ stacked: true, barWidth: 400 });
+            render({ stacked: true, barWidth: 800 });
             expect(stripIds()).toHaveLength(4);
 
             stubLayout({ stacked: false, barWidth: 1400 });
@@ -188,8 +205,11 @@ describe('Navbar quick strip', () => {
         });
 
         it('restores correctly from a partly-filled strip, where a dropped item outranks a promoted one', async () => {
-            render({ stacked: true, barWidth: LOGO_WIDTH + HAMBURGER_WIDTH + (2 * QUICK_ITEM_WIDTH) + 16 });
-            expect(stripIds()).toEqual(['li-user', 'li-validate']);
+            render({
+                stacked: true,
+                barWidth: LOGO_WIDTH + HAMBURGER_WIDTH + ACCOUNT_WIDTH + LABELLED_WIDTH + 16,
+            });
+            expect(stripIds()).toEqual(['li-validate', 'li-user']);
 
             stubLayout({ stacked: false, barWidth: 1400 });
             window.dispatchEvent(new Event('resize'));

--- a/test/js/navbarQuickStrip.test.js
+++ b/test/js/navbarQuickStrip.test.js
@@ -1,0 +1,203 @@
+/**
+ * Tests for the collapsed navbar's quick strip in Navbar.js (#4857).
+ *
+ * Below the collapse breakpoint the bar is otherwise a logo and a hamburger, so Navbar.js promotes `data-nav-quick`
+ * items into a strip of icons beside the hamburger — moving the elements rather than copying them, because their ids
+ * are what the click logging and the sign-in dialog key on. That makes two things worth pinning: an item is in exactly
+ * one place at a time (promoted items leave the panel, and anything that doesn't fit stays in it, so nothing goes
+ * missing), and widening the window puts every item back where the inline bar expects it, in order.
+ *
+ * jsdom has no layout, so the widths the fit check reads are stubbed per element; `stacked` is likewise driven by
+ * stubbing the hamburger's offsetParent, which is what the real code tests.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const NAVBAR_SRC = fs.readFileSync(
+    path.resolve(__dirname, '..', '..', 'public/js/common/Navbar.js'), 'utf8'
+);
+
+const LOGO_WIDTH = 110;
+const HAMBURGER_WIDTH = 44;
+const QUICK_ITEM_WIDTH = 42;
+
+/** Builds the navbar markup the template renders, reduced to what the responsive code reads. */
+function buildNavbar() {
+    document.body.innerHTML = `
+      <nav id="header">
+        <div class="navbar-container">
+          <div class="navbar-brand-area">
+            <div class="navbar-logo"><a id="navbar-brand" href="/"></a></div>
+            <ul class="navbar-nav navbar-quick" id="navbar-quick"></ul>
+            <button type="button" class="navbar-toggle" data-nav-toggle aria-controls="navbar"
+                    aria-expanded="false"></button>
+          </div>
+          <div id="navbar">
+            <ul class="navbar-nav navbar-nav--primary">
+              <li class="navbar-lnk" id="li-explore"><a class="navbar-button" id="navbar-start-btn"></a></li>
+              <li class="navbar-lnk" id="li-validate" data-nav-quick="2">
+                <a class="navbar-button" id="navbar-validate-btn"></a>
+              </li>
+              <li class="navbar-lnk" id="li-api" data-nav-shed="3" data-nav-quick="4">
+                <a class="navbar-button" id="navbar-api-btn"></a>
+              </li>
+              <li class="navbar-lnk" id="li-about" data-nav-shed="1" data-nav-quick="3">
+                <a class="navbar-button" id="navbar-about-btn"></a>
+              </li>
+            </ul>
+            <ul class="navbar-nav navbar-nav--utility">
+              <li class="dropdown navbar-lnk" id="li-user" data-nav-quick="1">
+                <button type="button" class="navbar-button" data-nav-dropdown aria-expanded="false"
+                        aria-controls="nav-user-menu"></button>
+                <ul id="nav-user-menu" class="dropdown-menu"><li><a href="/dashboard"></a></li></ul>
+              </li>
+              <li class="dropdown navbar-lnk" id="language-dropdown">
+                <button type="button" class="navbar-button" data-nav-dropdown aria-expanded="false"
+                        aria-controls="nav-language-menu"></button>
+                <ul id="nav-language-menu" class="dropdown-menu"><li><a href="/lang"></a></li></ul>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </nav>`;
+}
+
+/**
+ * Stubs the layout the fit check reads.
+ *
+ * @param {object} opts - Configuration.
+ * @param {boolean} opts.stacked - Whether the hamburger is showing (which is what puts the nav in its collapsed form).
+ * @param {number} opts.barWidth - The width available to the brand row.
+ */
+function stubLayout({ stacked, barWidth }) {
+    const width = (el, w) => Object.defineProperty(el, 'getBoundingClientRect', {
+        configurable: true, value: () => ({ width: w, height: 38, x: 0, y: 0, top: 0, left: 0 }),
+    });
+
+    const hamburger = document.querySelector('[data-nav-toggle]');
+    Object.defineProperty(hamburger, 'offsetParent', {
+        configurable: true, get: () => (stacked ? document.body : null),
+    });
+
+    const row = document.querySelector('.navbar-brand-area');
+    Object.defineProperty(row, 'clientWidth', { configurable: true, get: () => barWidth });
+    width(document.querySelector('.navbar-logo'), LOGO_WIDTH);
+    width(hamburger, HAMBURGER_WIDTH);
+
+    // The strip is a flex row of fixed-size icons, so its width follows from how many items it holds.
+    const strip = document.getElementById('navbar-quick');
+    Object.defineProperty(strip, 'getBoundingClientRect', {
+        configurable: true,
+        value: () => ({ width: strip.children.length * QUICK_ITEM_WIDTH, height: 40, x: 0, y: 0, top: 0, left: 0 }),
+    });
+
+    // The inline bar's own fit check; irrelevant while stacked, and generous enough not to shed when not.
+    for (const group of document.querySelectorAll('#navbar > .navbar-nav')) width(group, 100);
+    Object.defineProperty(document.getElementById('navbar'), 'clientWidth', {
+        configurable: true, get: () => barWidth,
+    });
+}
+
+/** @returns {string[]} The ids in the quick strip, in visual order. */
+function stripIds() {
+    return Array.from(document.getElementById('navbar-quick').children).map((el) => el.id);
+}
+
+/** @returns {string[]} The ids of the items still inside the collapsible panel, in DOM order. */
+function panelIds() {
+    return Array.from(document.querySelectorAll('#navbar .navbar-lnk')).map((el) => el.id);
+}
+
+describe('Navbar quick strip', () => {
+    beforeAll(() => {
+        // The source self-instantiates on load; with no #header in the document that constructor returns immediately,
+        // so each test can build its own DOM and construct explicitly.
+        window.eval(`${NAVBAR_SRC}\nwindow.NavbarController = NavbarController;`);
+    });
+
+    /**
+     * Renders the navbar at a given width and runs the responsive pass.
+     *
+     * @param {object} opts - Passed through to stubLayout.
+     * @returns {object} The controller, so a test can re-run the pass after changing the layout.
+     */
+    function render(opts) {
+        buildNavbar();
+        stubLayout(opts);
+        return new window.NavbarController();
+    }
+
+    describe('when the nav is collapsed', () => {
+        it('promotes every quick item to the strip when they all fit', () => {
+            render({ stacked: true, barWidth: 400 });
+
+            expect(stripIds()).toEqual(['li-user', 'li-validate', 'li-about', 'li-api']);
+        });
+
+        it('takes promoted items out of the panel, so nothing is listed twice', () => {
+            render({ stacked: true, barWidth: 400 });
+
+            expect(panelIds()).toEqual(['li-explore', 'language-dropdown']);
+        });
+
+        it('drops the lowest-priority icons on a narrow screen and leaves them in the panel', () => {
+            // Room for the logo, the hamburger, and two icons.
+            render({ stacked: true, barWidth: LOGO_WIDTH + HAMBURGER_WIDTH + (2 * QUICK_ITEM_WIDTH) + 16 });
+
+            expect(stripIds()).toEqual(['li-user', 'li-validate']);
+            expect(panelIds()).toEqual(expect.arrayContaining(['li-about', 'li-api']));
+        });
+
+        it('keeps the account item even when only one icon fits', () => {
+            render({ stacked: true, barWidth: LOGO_WIDTH + HAMBURGER_WIDTH + QUICK_ITEM_WIDTH + 16 });
+
+            expect(stripIds()).toEqual(['li-user']);
+        });
+
+        it('leaves the strip empty when there is no room at all', () => {
+            render({ stacked: true, barWidth: LOGO_WIDTH + HAMBURGER_WIDTH });
+
+            expect(stripIds()).toEqual([]);
+            expect(panelIds()).toEqual(
+                ['li-explore', 'li-validate', 'li-api', 'li-about', 'li-user', 'language-dropdown']
+            );
+        });
+    });
+
+    describe('when the nav is inline', () => {
+        it('leaves every item in the bar', () => {
+            render({ stacked: false, barWidth: 1400 });
+
+            expect(stripIds()).toEqual([]);
+        });
+
+        it('restores promoted items to their original positions when the window widens', async () => {
+            render({ stacked: false, barWidth: 1400 });
+            const authoredOrder = panelIds();
+
+            render({ stacked: true, barWidth: 400 });
+            expect(stripIds()).toHaveLength(4);
+
+            stubLayout({ stacked: false, barWidth: 1400 });
+            window.dispatchEvent(new Event('resize'));
+            await new Promise((resolve) => requestAnimationFrame(resolve));
+
+            expect(stripIds()).toEqual([]);
+            expect(panelIds()).toEqual(authoredOrder);
+        });
+
+        it('restores correctly from a partly-filled strip, where a dropped item outranks a promoted one', async () => {
+            render({ stacked: true, barWidth: LOGO_WIDTH + HAMBURGER_WIDTH + (2 * QUICK_ITEM_WIDTH) + 16 });
+            expect(stripIds()).toEqual(['li-user', 'li-validate']);
+
+            stubLayout({ stacked: false, barWidth: 1400 });
+            window.dispatchEvent(new Event('resize'));
+            await new Promise((resolve) => requestAnimationFrame(resolve));
+
+            expect(panelIds()).toEqual(
+                ['li-explore', 'li-validate', 'li-api', 'li-about', 'li-user', 'language-dropdown']
+            );
+        });
+    });
+});


### PR DESCRIPTION
Fixes #4857. Fixes #4856.

## What changed

**Collapsed navbar (#4857).** Below 860px the bar was a logo and a hamburger, so every destination — including the
ones that work well on a phone — took two taps and a read of a 220px panel. It now carries the account control plus
Validate, About, and API beside the hamburger, filled by priority while each still measures as fitting; what doesn't
fit stays one tap away in the panel. At 390px signed in that's Validate, at 430px About joins it, at 860px all three
plus the account.

The destinations carry text, not bare icons — neither the info circle for About nor the angle brackets for API is a
glyph people have already learned. The account control stays icon-only (the person glyph *is* learned, and a username
is the longest and least predictable label in the bar), with its `aria-label` naming the account.

Explore, Label Map, Gallery, Route Builder, and Expert Validate are dropped from the menu on a mobile device, where
all of them can only redirect to `/mobileLanding` or `/mobile`. That's gated on the same user-agent test the
controllers redirect on — not a width breakpoint — so a narrow desktop window still reaches everything.
`ControllerUtils.isMobile` now takes a `RequestHeader` so the view can ask.

`/mobileLanding` gets the shared navbar. It rendered its own slim header, so the page every mobile visitor lands on
was the one page with no navigation at all — the surface where the collapsed navbar matters most never showed it.
Sign-in now opens the shared auth dialog in place instead of routing to `/signInMobile`.

**Sidebar toggle (#4856).** The API docs and admin dashboard opened their section nav from a button appended to
`<body>` and positioned fixed at the top-left, floating over whatever the page rendered there — the deployment-info
strip on `/admin`, the page title on `/api`. The button now lives inside `.api-sidebar`, which at mobile widths
becomes an in-flow strip between the navbar and the content. Opening it pushes the page down instead of covering it,
and it's labelled with the active nav item, so the collapsed sidebar still answers "which page am I on?". Both shells
built near-identical buttons in their own JS; they now share `sidebarDisclosure.js`.

## The site-wide bug underneath

The hamburger was still landing off-screen after the strip was correct, and the reason turned out not to be a navbar
bug at all. Two footer rules laid out well beyond the screen on anything narrower than a desktop window:

- `.footer-links-row` is a fixed `900px` offset `80px` right, to make three uneven columns read as centered.
- `#award-num` is sized as a multiple of its own narrow column, which becomes multiples of the *viewport* once the
  columns stop floating — 220% of 737px is 1621px of page. Its overrides were keyed on `device-width` (the physical
  screen) rather than `width`, so they missed every resized desktop window and fired off the wrong dimension on a
  rotated tablet, which is why the damage varied by width in a way that looked random.

Because the footer renders on nearly every page, **every page has been scrolling sideways on phones** — that's also
the horizontal scroll visible in the `/api` screenshot on #4856. The navbar is `fixed`, so it's sized from the initial
containing block that the overflow widens, which is how a bar that measured as fitting still ran off the right edge.
Both rules are now bounded at the widths where they fit and keyed on `width`; the fit budget is additionally clamped
to the visible width, to keep the bar honest if overflow ever reappears elsewhere.

## Two interaction fixes the strip surfaced

- **Mutually exclusive disclosures.** The panel and a strip dropdown could be open at once and overlap. They're peers
  now: opening either closes the other, while a dropdown *inside* the panel (Tools, city, language) leaves it open.
  The panel also dismisses on outside press and Escape, as its dropdowns already did.
- **A tap-eating bug that predates this work.** With Tools open, tapping City did nothing. Closing a dropdown reflows
  the panel between press and release, sliding the next row out from under the finger, so the browser retargets the
  click to a common ancestor — which, read on `click`, looked like an outside tap. Outside-dismissal reads
  `pointerdown` now.

## Verification

- Manually QA'd at 320/390/430/500/600/700/767/768/800/900/1000/1400px: no page exceeds its viewport at any width, and
  the desktop footer renders pixel-identical (screenshot-diffed — the 80px nudge is preserved above 1060px because
  it's what actually centers those three uneven columns).
- 691 jsdom tests green, including 19 new across `navbarQuickStrip.test.js` and `navbarDisclosures.test.js`.
- ESLint, Stylelint, HTMLHint, and locale parity all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-opus-5[1m])
