### PR TITLE
Fit admin chart axes to their labels, with rounded/abbreviated ticks (#4855)

### DIFF
--- a/public/js/admin-dashboard/ApiAnalyticsPage.js
+++ b/public/js/admin-dashboard/ApiAnalyticsPage.js
@@ -94,9 +94,7 @@ class ApiAnalyticsPage {
       { name: 'Docs', key: 'apidocs', values: keys.map((k) => at(k).docs) },
     ];
     const fmt = (v) => `${Math.round(v).toLocaleString()} calls`;
-    MiniLineChart.renderInto(el, labels, series, {
-      tickFormat: (v) => Math.round(v).toLocaleString(), valueFormat: fmt, ariaLabel: 'API call volume over time',
-    });
+    MiniLineChart.renderInto(el, labels, series, { valueFormat: fmt, ariaLabel: 'API call volume over time' });
   }
 
   /**

--- a/public/js/admin-dashboard/MiniLineChart.js
+++ b/public/js/admin-dashboard/MiniLineChart.js
@@ -13,8 +13,10 @@ class MiniLineChart {
    *   each series' values align to `categories`; null = gap. Optional per-point tooltip strings.
    * @param {{yMax?: number, tickFormat?: function(number): string, valueFormat?: function(number): string,
    *          ariaLabel?: string, dotRadius?: number, kind?: string, maxXLabels?: number, barValues?: boolean,
-   *          emphasisIndex?: number, minMarginL?: number, minMarginR?: number}} [opts] - yMax defaults to the data
-   *   max; tickFormat labels the y-axis; valueFormat formats values in the default tooltip and in bar value labels;
+   *          emphasisIndex?: number, minMarginL?: number, minMarginR?: number}} [opts] - yMax defaults to a nice
+   *   rounded max above the data; tickFormat labels the y-axis (abbreviated by default, e.g. "1.6M") while
+   *   valueFormat formats values in the default tooltip and in bar value labels, so hovering still gives the exact
+   *   count;
    *   dotRadius sizes the point markers (default 3); kind 'bar' draws bars instead of lines; maxXLabels caps how many
    *   x labels are drawn (default 6); barValues draws each bar's value above it (meant for single-series bar charts —
    *   grouped bars would collide); emphasisIndex marks that index's bar and labels with `--emphasis` classes (e.g. an
@@ -28,8 +30,11 @@ class MiniLineChart {
     const n = categories.length;
     const isBar = opts.kind === 'bar';
     const allVals = series.flatMap((s) => s.values.filter((v) => v !== null && v !== undefined));
-    const yMax = opts.yMax || Math.max(1, ...allVals);
-    const tickFormat = opts.tickFormat || ((v) => Math.round(v).toLocaleString());
+    // Scaling the axis to the exact data max makes every gridline an arbitrary number (350,037 · 700,073 · 1,050,110);
+    // rounding the top up to a nice step lands them on values a reader can compare at a glance. Tooltips keep the
+    // exact counts, so the axis can trade precision for legibility.
+    const yMax = opts.yMax || MiniLineChart.#niceMax(Math.max(1, ...allVals), allVals.every(Number.isInteger));
+    const tickFormat = opts.tickFormat || MiniLineChart.#compact;
     const valueFormat = opts.valueFormat || ((v) => Math.round(v).toLocaleString());
     const dotRadius = opts.dotRadius ?? 3;
 
@@ -196,6 +201,39 @@ class MiniLineChart {
       minMarginL: Math.ceil(Number(grid.getAttribute('x1')) + Math.max(0, left)),
       minMarginR: Math.ceil(width - Number(grid.getAttribute('x2')) + Math.max(0, right)),
     };
+  }
+
+  /**
+   * Rounds a data max up so the four gridline gaps below it are a nice step (400,000 rather than 350,036.5). The
+   * candidate steps are the round-looking mantissas; the finer ones (1.5, 3, 6, 8) keep the headroom small, since a
+   * coarse 1-2-5 ladder can push a 2.28M series onto a 4M axis and leave the line hugging the floor.
+   *
+   * @param {number} dataMax - Largest value in the data (> 0).
+   * @param {boolean} integral - Whether the data are whole numbers, in which case fractional ticks read as noise.
+   * @returns {number} A y-max whose quarter is a nice step.
+   */
+  static #niceMax(dataMax, integral) {
+    const rawStep = dataMax / 4;
+    const magnitude = 10 ** Math.floor(Math.log10(rawStep));
+    const mantissa = rawStep / magnitude;
+    let step = ([1, 1.5, 2, 2.5, 3, 4, 5, 6, 8, 10].find((c) => mantissa <= c) ?? 10) * magnitude;
+    if (integral && !Number.isInteger(step)) step = Math.ceil(step);
+    return step * 4;
+  }
+
+  /**
+   * Abbreviates a tick value ("1.6M", "800k", "250"). Axis room is scarce and the exact figure is a hover away in the
+   * tooltip, so ticks trade digits for readability. Matches the dashboard's own compact style — lowercase k, capital
+   * M/B — so an axis and a KPI tile spell the same number the same way.
+   *
+   * @param {number} v - The value to label.
+   * @returns {string} Abbreviated label.
+   */
+  static #compact(v) {
+    const abs = Math.abs(v);
+    const unit = [[1e9, 'B'], [1e6, 'M'], [1e3, 'k']].find(([min]) => abs >= min);
+    if (!unit) return Math.round(v).toLocaleString();
+    return `${(v / unit[0]).toFixed(1).replace(/\.0$/, '')}${unit[1]}`;
   }
 
   /** Font size of `.mini-axis` / `.mini-value` in px — keep in sync with admin-dashboard.css. */

--- a/public/js/admin-dashboard/MiniLineChart.js
+++ b/public/js/admin-dashboard/MiniLineChart.js
@@ -13,37 +13,57 @@ class MiniLineChart {
    *   each series' values align to `categories`; null = gap. Optional per-point tooltip strings.
    * @param {{yMax?: number, tickFormat?: function(number): string, valueFormat?: function(number): string,
    *          ariaLabel?: string, dotRadius?: number, kind?: string, maxXLabels?: number, barValues?: boolean,
-   *          emphasisIndex?: number}} [opts] - yMax defaults to the data max; tickFormat labels the y-axis;
-   *   valueFormat formats values in the default tooltip and in bar value labels; dotRadius sizes the point markers
-   *   (default 3); kind 'bar' draws bars instead of lines; maxXLabels caps how many x labels are drawn (default 6);
-   *   barValues draws each bar's value above it (meant for single-series bar charts — grouped bars would collide);
-   *   emphasisIndex marks that index's bar and labels with `--emphasis` classes (e.g. an in-progress "today" bar).
+   *          emphasisIndex?: number, minMarginL?: number, minMarginR?: number}} [opts] - yMax defaults to the data
+   *   max; tickFormat labels the y-axis; valueFormat formats values in the default tooltip and in bar value labels;
+   *   dotRadius sizes the point markers (default 3); kind 'bar' draws bars instead of lines; maxXLabels caps how many
+   *   x labels are drawn (default 6); barValues draws each bar's value above it (meant for single-series bar charts —
+   *   grouped bars would collide); emphasisIndex marks that index's bar and labels with `--emphasis` classes (e.g. an
+   *   in-progress "today" bar); minMarginL/minMarginR raise the axis margins, which renderInto uses to redraw at
+   *   measured label widths.
    * @returns {string} SVG markup plus an optional HTML legend.
    */
   static svg(categories, series, opts = {}) {
     const W = opts.width || 760;
     const H = 220;
-    const m = { l: 48, r: 14, t: 14, b: 30 };
-    const iw = W - m.l - m.r;
-    const ih = H - m.t - m.b;
     const n = categories.length;
     const isBar = opts.kind === 'bar';
-    // Bars sit on band centers; line points span the full width edge to edge.
-    const x = (i) => (isBar ? m.l + ((i + 0.5) / n) * iw : m.l + (n === 1 ? iw / 2 : (i / (n - 1)) * iw));
-    const yFrac = (f) => m.t + (1 - f) * ih; // f in [0, 1]
     const allVals = series.flatMap((s) => s.values.filter((v) => v !== null && v !== undefined));
     const yMax = opts.yMax || Math.max(1, ...allVals);
     const tickFormat = opts.tickFormat || ((v) => Math.round(v).toLocaleString());
     const valueFormat = opts.valueFormat || ((v) => Math.round(v).toLocaleString());
     const dotRadius = opts.dotRadius ?? 3;
 
+    const tickFracs = [0, 0.25, 0.5, 0.75, 1];
+    const tickText = tickFracs.map((f) => tickFormat(f * yMax));
+    const step = Math.max(1, Math.ceil(n / (opts.maxXLabels || 6)));
+    const xLabelIdx = [];
+    for (let i = 0; i < n; i += step) xLabelIdx.push(i);
+
+    // Margins are sized to the labels rather than fixed: anything drawn outside the viewBox is clipped by the SVG, so
+    // a fixed left margin beheaded seven-digit y ticks ("1,400,146" → "400,146") and a fixed right margin cut the last
+    // x label in half (#4855). The end-anchored y ticks need their full width plus the gap; the centered outermost x
+    // labels need half of theirs. Floors keep the usual small-number case looking exactly as before.
+    const yTickW = Math.max(...tickText.map((t) => MiniLineChart.#labelWidth(t)));
+    const xEdgeHalf = (i) => (i === undefined ? 0 : MiniLineChart.#labelWidth(categories[i]) / 2);
+    const m = {
+      l: Math.ceil(Math.max(48, yTickW + MiniLineChart.#AXIS_GAP + 2, xEdgeHalf(xLabelIdx[0]), opts.minMarginL || 0)),
+      r: Math.ceil(Math.max(14, xEdgeHalf(xLabelIdx[xLabelIdx.length - 1]) + 2, opts.minMarginR || 0)),
+      t: 14,
+      b: 30,
+    };
+    const iw = W - m.l - m.r;
+    const ih = H - m.t - m.b;
+    // Bars sit on band centers; line points span the full width edge to edge.
+    const x = (i) => (isBar ? m.l + ((i + 0.5) / n) * iw : m.l + (n === 1 ? iw / 2 : (i / (n - 1)) * iw));
+    const yFrac = (f) => m.t + (1 - f) * ih; // f in [0, 1]
+
     let grid = '';
-    for (const f of [0, 0.25, 0.5, 0.75, 1]) {
+    tickFracs.forEach((f, ti) => {
       const yy = yFrac(f).toFixed(1);
       grid += `<line class="mini-grid" x1="${m.l}" y1="${yy}" x2="${W - m.r}" y2="${yy}"/>`
-        + `<text class="mini-axis" x="${m.l - 6}" y="${(yFrac(f) + 3).toFixed(1)}" text-anchor="end">`
-        + `${MiniLineChart.#esc(tickFormat(f * yMax))}</text>`;
-    }
+        + `<text class="mini-axis" x="${m.l - MiniLineChart.#AXIS_GAP}" y="${(yFrac(f) + 3).toFixed(1)}" `
+        + `text-anchor="end">${MiniLineChart.#esc(tickText[ti])}</text>`;
+    });
 
     let body = '';
     if (isBar) {
@@ -96,9 +116,8 @@ class MiniLineChart {
       }
     }
 
-    const step = Math.max(1, Math.ceil(n / (opts.maxXLabels || 6)));
     let xlab = '';
-    for (let i = 0; i < n; i += step) {
+    for (const i of xLabelIdx) {
       const emph = i === opts.emphasisIndex ? ' mini-axis--emphasis' : '';
       xlab += `<text class="mini-axis${emph}" x="${x(i).toFixed(1)}" y="${H - 8}" text-anchor="middle">`
         + `${MiniLineChart.#esc(categories[i])}</text>`;
@@ -130,6 +149,11 @@ class MiniLineChart {
     container._miniDraw = () => {
       const width = Math.max(280, Math.round(container.clientWidth) || 760);
       container.innerHTML = MiniLineChart.svg(categories, series, { ...opts, width });
+      // svg() can only estimate label widths from character counts, and the axis font is whatever the page resolves
+      // `--font-sans` to. Now that the SVG is in the document its text can be measured for real, so widen the margins
+      // and redraw if anything still overhangs the viewBox — the estimate stays the fast path, this is the guarantee.
+      const grown = MiniLineChart.#marginsForOverhang(container, width);
+      if (grown) container.innerHTML = MiniLineChart.svg(categories, series, { ...opts, width, ...grown });
     };
     container._miniDraw();
     if (typeof ResizeObserver !== 'undefined' && !container._miniResizeObserver) {
@@ -138,6 +162,67 @@ class MiniLineChart {
       ro.observe(container);
       container._miniResizeObserver = ro;
     }
+  }
+
+  /**
+   * Measures the rendered labels of a drawn chart and returns margins wide enough to hold the ones that overhang the
+   * viewBox, or null when everything already fits (the usual case) or nothing can be measured — a container that is
+   * display:none has no layout, and getBBox is absent under jsdom.
+   *
+   * @param {HTMLElement} container - Container holding a chart drawn by svg().
+   * @param {number} width - The viewBox width the chart was drawn at.
+   * @returns {?{minMarginL: number, minMarginR: number}} Margin floors for a redraw, or null to keep the current draw.
+   */
+  static #marginsForOverhang(container, width) {
+    const grid = container.querySelector('line.mini-grid');
+    const labels = container.querySelectorAll('text');
+    if (!grid || !labels.length || typeof labels[0].getBBox !== 'function') return null;
+    let left = 0;
+    let right = 0;
+    for (const label of labels) {
+      let box;
+      try {
+        box = label.getBBox();
+      } catch {
+        return null; // Not laid out (e.g. a hidden container); a later resize-driven draw will measure it.
+      }
+      if (!box.width) continue;
+      left = Math.max(left, -box.x);
+      right = Math.max(right, box.x + box.width - width);
+    }
+    // Sub-pixel overhang is antialiasing, not a clipped glyph; redrawing for it would just churn.
+    if (left < 0.5 && right < 0.5) return null;
+    return {
+      minMarginL: Math.ceil(Number(grid.getAttribute('x1')) + Math.max(0, left)),
+      minMarginR: Math.ceil(width - Number(grid.getAttribute('x2')) + Math.max(0, right)),
+    };
+  }
+
+  /** Font size of `.mini-axis` / `.mini-value` in px — keep in sync with admin-dashboard.css. */
+  static #AXIS_FONT_PX = 11;
+
+  /** Gap in px between a y-axis tick label and the axis it labels. */
+  static #AXIS_GAP = 6;
+
+  /**
+   * Estimates the rendered width of an axis label so the margins can make room for it. The chart is built as a string
+   * with no DOM to measure against, so widths come from per-character advances for a generic sans face; digits,
+   * separators, and caps differ too much for a flat average to size something like "1,400,146". The estimate rounds
+   * up on purpose — a few px of over-reserved margin is invisible, an underestimate clips the label.
+   *
+   * @param {string} s - The label text.
+   * @returns {number} Estimated width in px.
+   */
+  static #labelWidth(s) {
+    let em = 0;
+    for (const ch of String(s)) {
+      if (ch >= '0' && ch <= '9') em += 0.56;
+      else if (' ,.:'.includes(ch)) em += 0.3;
+      else if (ch === '%') em += 0.9;
+      else if (ch >= 'A' && ch <= 'Z') em += 0.72;
+      else em += 0.58;
+    }
+    return em * MiniLineChart.#AXIS_FONT_PX;
   }
 
   static #esc(s) {

--- a/public/js/admin-dashboard/MiniLineChart.js
+++ b/public/js/admin-dashboard/MiniLineChart.js
@@ -149,16 +149,23 @@ class MiniLineChart {
    */
   static renderInto(container, categories, series, opts = {}) {
     if (!container) return;
+    // The measured correction below depends on label text and font, not on width, so it's the same at every width
+    // once known — cache it per draw and skip re-measuring (a forced-layout getBBox() pass) on every resize tick.
+    let grownMargins = null;
     // Store the latest draw on the container so a persistent container re-rendered with new data (e.g. a trend that
     // re-fetches on a range change) keeps the resize observer pointed at the current data, not the first call's.
     container._miniDraw = () => {
       const width = Math.max(280, Math.round(container.clientWidth) || 760);
-      container.innerHTML = MiniLineChart.svg(categories, series, { ...opts, width });
+      container.innerHTML = MiniLineChart.svg(categories, series, { ...opts, width, ...grownMargins });
+      if (grownMargins) return;
       // svg() can only estimate label widths from character counts, and the axis font is whatever the page resolves
       // `--font-sans` to. Now that the SVG is in the document its text can be measured for real, so widen the margins
       // and redraw if anything still overhangs the viewBox — the estimate stays the fast path, this is the guarantee.
       const grown = MiniLineChart.#marginsForOverhang(container, width);
-      if (grown) container.innerHTML = MiniLineChart.svg(categories, series, { ...opts, width, ...grown });
+      if (grown) {
+        grownMargins = grown;
+        container.innerHTML = MiniLineChart.svg(categories, series, { ...opts, width, ...grown });
+      }
     };
     container._miniDraw();
     if (typeof ResizeObserver !== 'undefined' && !container._miniResizeObserver) {

--- a/test/js/miniLineChartAxisLabels.test.js
+++ b/test/js/miniLineChartAxisLabels.test.js
@@ -1,0 +1,103 @@
+/**
+ * Tests for public/js/admin-dashboard/MiniLineChart.js axis-label fitting (#4855).
+ *
+ * Anything drawn outside the SVG's viewBox is clipped, so the chart's margins have to be sized to the labels they
+ * host: the cumulative all-time charts on /admin/across-cities reach seven-digit y ticks, and multi-year x axes carry
+ * dates long enough to run off the right edge. These tests pin "the label fits" as a geometry contract, using a
+ * conservative independent width estimate (a generic sans at 11px averages well under 5.2px per digit/letter), so
+ * they fail if a margin ever stops making room rather than only if a specific pixel value changes.
+ *
+ * Runs under jsdom (jest.config.js); MiniLineChart.svg is a pure string builder, so tests parse its output into a
+ * detached container and assert on the resulting DOM.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const CHART_PATH = path.resolve(__dirname, '..', '..', 'public/js/admin-dashboard/MiniLineChart.js');
+
+/** Lower bound on rendered width, in px, of an axis label at the chart's 11px font. */
+const MIN_PX_PER_CHAR = 5.2;
+
+/** Load MiniLineChart.js (a plain top-level class declaration, concatenation-style) and return the class. */
+function loadMiniLineChart() {
+    const src = fs.readFileSync(CHART_PATH, 'utf8');
+    // Indirect eval runs the script in global scope; the trailing expression hands the class binding back out.
+    return (0, eval)(`${src}\nMiniLineChart;`);
+}
+
+describe('MiniLineChart axis labels', () => {
+    const WIDTH = 760;
+    let MiniLineChart;
+
+    /** Render a line series into a detached div and return the div for querying. */
+    function render(categories, values, opts = {}) {
+        const div = document.createElement('div');
+        div.innerHTML = MiniLineChart.svg(categories, [{ name: 'Total labels', key: 'aclabels', values }],
+            { width: WIDTH, ...opts });
+        return div;
+    }
+
+    /** The plot's left edge, which is also where the y-axis tick labels end. */
+    function plotLeft(div) {
+        return Number(div.querySelector('line.mini-grid').getAttribute('x1'));
+    }
+
+    /** The y-axis tick labels, right-aligned against the plot's left edge. */
+    function yTicks(div) {
+        return [...div.querySelectorAll('text.mini-axis')]
+            .filter((t) => t.getAttribute('text-anchor') === 'end')
+            .map((t) => ({ text: t.textContent, x: Number(t.getAttribute('x')) }));
+    }
+
+    /** The x-axis category labels, centered on their data point. */
+    function xLabels(div) {
+        return [...div.querySelectorAll('text.mini-axis')]
+            .filter((t) => t.getAttribute('text-anchor') === 'middle')
+            .map((t) => ({ text: t.textContent, x: Number(t.getAttribute('x')) }));
+    }
+
+    beforeEach(() => {
+        MiniLineChart = loadMiniLineChart();
+    });
+
+    test('seven-digit y ticks fit between the SVG edge and the plot', () => {
+        const div = render(['Jan 2020', 'Aug 2026'], [12000, 1400146]);
+        for (const tick of yTicks(div)) {
+            expect(tick.x).toBeGreaterThanOrEqual(tick.text.length * MIN_PX_PER_CHAR);
+        }
+        expect(yTicks(div).map((t) => t.text)).toContain('1,400,146');
+    });
+
+    test('small y ticks keep the standard margin, so short-number charts are unchanged', () => {
+        const div = render(['Jan', 'Feb', 'Mar'], [10, 40, 100]);
+        expect(plotLeft(div)).toBe(48);
+    });
+
+    test('the left margin grows with the widest tick, not the last one drawn', () => {
+        const narrow = plotLeft(render(['Jan', 'Feb'], [10, 100]));
+        const wide = plotLeft(render(['Jan', 'Feb'], [10, 1400146]));
+        expect(wide).toBeGreaterThan(narrow);
+    });
+
+    test('a long trailing x label fits inside the right edge', () => {
+        const cats = ['Jan 5 2020', 'Mar 8 2023', 'Aug 10 2026'];
+        const div = render(cats, [1, 2, 3]);
+        const last = xLabels(div).pop();
+        expect(last.text).toBe('Aug 10 2026');
+        expect(WIDTH - last.x).toBeGreaterThanOrEqual((last.text.length / 2) * MIN_PX_PER_CHAR);
+    });
+
+    test('a long leading x label fits inside the left edge', () => {
+        const cats = ['Jan 5 2020', 'Mar 8 2023', 'Aug 10 2026'];
+        const div = render(cats, [1, 2, 3], { tickFormat: () => '0' });
+        const first = xLabels(div).shift();
+        expect(first.x).toBeGreaterThanOrEqual((first.text.length / 2) * MIN_PX_PER_CHAR);
+    });
+
+    test('percentage ticks (yMax 1) still render one label per gridline', () => {
+        const pct = (v) => `${Math.round(v * 100)}%`;
+        const div = render(['Jan', 'Feb'], [0.5, 0.9], { yMax: 1, tickFormat: pct });
+        expect(yTicks(div).map((t) => t.text)).toEqual(['0%', '25%', '50%', '75%', '100%']);
+    });
+});

--- a/test/js/miniLineChartAxisLabels.test.js
+++ b/test/js/miniLineChartAxisLabels.test.js
@@ -61,12 +61,11 @@ describe('MiniLineChart axis labels', () => {
         MiniLineChart = loadMiniLineChart();
     });
 
-    test('seven-digit y ticks fit between the SVG edge and the plot', () => {
-        const div = render(['Jan 2020', 'Aug 2026'], [12000, 1400146]);
+    test('wide y ticks fit between the SVG edge and the plot', () => {
+        const div = render(['Jan 2020', 'Aug 2026'], [12000, 1400146], { tickFormat: (v) => v.toLocaleString() });
         for (const tick of yTicks(div)) {
             expect(tick.x).toBeGreaterThanOrEqual(tick.text.length * MIN_PX_PER_CHAR);
         }
-        expect(yTicks(div).map((t) => t.text)).toContain('1,400,146');
     });
 
     test('small y ticks keep the standard margin, so short-number charts are unchanged', () => {
@@ -75,8 +74,9 @@ describe('MiniLineChart axis labels', () => {
     });
 
     test('the left margin grows with the widest tick, not the last one drawn', () => {
-        const narrow = plotLeft(render(['Jan', 'Feb'], [10, 100]));
-        const wide = plotLeft(render(['Jan', 'Feb'], [10, 1400146]));
+        const fmt = (v) => v.toLocaleString();
+        const narrow = plotLeft(render(['Jan', 'Feb'], [10, 100], { tickFormat: fmt }));
+        const wide = plotLeft(render(['Jan', 'Feb'], [10, 1400146], { tickFormat: fmt }));
         expect(wide).toBeGreaterThan(narrow);
     });
 

--- a/test/js/miniLineChartTicks.test.js
+++ b/test/js/miniLineChartTicks.test.js
@@ -1,0 +1,78 @@
+/**
+ * Tests for public/js/admin-dashboard/MiniLineChart.js y-axis tick values and formatting (#4855).
+ *
+ * The axis rounds its top up to a nice step and abbreviates the labels, so gridlines land on numbers a reader can
+ * compare at a glance instead of quarters of the data max. Precision moves to the tooltips rather than being lost,
+ * which is the part worth pinning: these tests cover the scale, the abbreviation, the integer-data case, and that an
+ * explicit yMax (the Data Quality agreement chart) still wins.
+ *
+ * Runs under jsdom (jest.config.js); MiniLineChart.svg is a pure string builder, so tests parse its output into a
+ * detached container and assert on the resulting DOM.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const CHART_PATH = path.resolve(__dirname, '..', '..', 'public/js/admin-dashboard/MiniLineChart.js');
+
+/** Load MiniLineChart.js (a plain top-level class declaration, concatenation-style) and return the class. */
+function loadMiniLineChart() {
+    const src = fs.readFileSync(CHART_PATH, 'utf8');
+    // Indirect eval runs the script in global scope; the trailing expression hands the class binding back out.
+    return (0, eval)(`${src}\nMiniLineChart;`);
+}
+
+describe('MiniLineChart y-axis ticks', () => {
+    let MiniLineChart;
+
+    /** Render a line series into a detached div and return the div for querying. */
+    function render(values, opts = {}) {
+        const div = document.createElement('div');
+        const categories = values.map((_, i) => `w${i}`);
+        div.innerHTML = MiniLineChart.svg(categories, [{ name: 'Total labels', key: 'aclabels', values }],
+            { width: 760, ...opts });
+        return div;
+    }
+
+    /** The y-axis tick labels, bottom-to-top (the order svg() draws them). */
+    function tickText(div) {
+        return [...div.querySelectorAll('text.mini-axis')]
+            .filter((t) => t.getAttribute('text-anchor') === 'end')
+            .map((t) => t.textContent);
+    }
+
+    beforeEach(() => {
+        MiniLineChart = loadMiniLineChart();
+    });
+
+    test('rounds the axis top up so ticks are whole steps, abbreviated', () => {
+        expect(tickText(render([12000, 640000, 1400146]))).toEqual(['0', '400k', '800k', '1.2M', '1.6M']);
+    });
+
+    test('keeps a tight axis rather than jumping to the next power of ten', () => {
+        // 2.28M sits just above a 2M axis; the 1-2-5 ladder's next rung (4M) would leave the line hugging the floor.
+        const ticks = tickText(render([4000, 980000, 2276971]));
+        expect(ticks).toEqual(['0', '600k', '1.2M', '1.8M', '2.4M']);
+    });
+
+    test('whole-number data never gets fractional ticks', () => {
+        expect(tickText(render([1, 2, 3]))).toEqual(['0', '1', '2', '3', '4']);
+        expect(tickText(render([2, 5, 9]))).toEqual(['0', '3', '6', '9', '12']);
+    });
+
+    test('values under a thousand stay exact', () => {
+        expect(tickText(render([10, 40, 100]))).toEqual(['0', '25', '50', '75', '100']);
+    });
+
+    test('an explicit yMax is used as given', () => {
+        const pct = (v) => `${Math.round(v * 100)}%`;
+        expect(tickText(render([0.5, 0.93], { yMax: 1, tickFormat: pct })))
+            .toEqual(['0%', '25%', '50%', '75%', '100%']);
+    });
+
+    test('tooltips carry the exact value the axis abbreviates', () => {
+        const div = render([12000, 1400146]);
+        const tips = [...div.querySelectorAll('circle title')].map((t) => t.textContent);
+        expect(tips[tips.length - 1]).toContain('1,400,146');
+    });
+});


### PR DESCRIPTION
Fixes #4855.

## The bug

`MiniLineChart` drew into hardcoded margins (`{l: 48, r: 14}`), and an SVG clips anything outside its viewBox — so a label wider than its margin silently loses its leading glyphs. On /admin/across-cities the cumulative all-time charts reach seven digits, so `1,400,146` rendered as `400,146`. The same bug cut the last x label in half on the right edge (`Aug 1(` in the issue screenshot).

## The fix

**Margins are sized to the labels they hold** — end-anchored y ticks get their full width plus the gap, centered outermost x labels get half of theirs. The old values stay as floors, so short-number charts are pixel-identical to before.

A string builder can't measure text, so this is two layers: `svg()` estimates widths per character, then `renderInto()` measures the *drawn* text (`getBBox` vs the viewBox) and redraws once if anything still overhangs. The second pass is what makes it font-proof — the axis font is whatever the page resolves `--font-sans` to, and an estimate calibrated for one face under-reserves for another.

**The ticks themselves are now rounded and abbreviated.** They were quarters of the exact data max (350,037 · 700,073 · 1,050,110); the axis top now rounds up to a nice step and labels abbreviate: `0 · 400k · 800k · 1.2M · 1.6M`. Precision moves rather than disappears — tooltips still carry exact counts, and a caller wanting literal ticks passes its own `tickFormat`. The step ladder includes 1.5/3/6/8 so a 2.28M series lands on a 2.4M axis rather than being flattened against a 4M one. `ApiAnalyticsPage` drops its `tickFormat` override to pick up the shared style; Data Quality's `yMax: 1` percentage axis is untouched.

## Verification

- **Real browser** (headless Chromium, real CSS, real component): pre-fix it reports exactly the issue's clipped labels — `1,400,146`, `2,276,971`, `Aug '26` — post-fix, zero clipped.
- **16 jsdom tests** across `test/js/miniLineChartAxisLabels.test.js` (new), `miniLineChartTicks.test.js` (new), and the existing bar-mode suite. The fitting tests assert a geometry contract rather than pixel values, and 3 of them fail against pre-fix code.
- ESLint clean.

Affects every `MiniLineChart` caller (Across Cities, Data Quality, API Analytics, Activity), so it's worth a look at those four pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-opus-5[1m])