### PR TITLE
Derive the admin sidebar's Owner links from the signed-in user (#4880)

### DIFF
--- a/app/views/admin/dashboard/acrossCities.scala.html
+++ b/app/views/admin/dashboard/acrossCities.scala.html
@@ -311,5 +311,5 @@
 
 @common.main(commonData, "Sidewalk - Across Cities") {
   @common.navbar(commonData, Some(user))
-  @admin.dashboard.adminLayout("across-cities", commonData, user.role == "Owner")(content)
+  @admin.dashboard.adminLayout("across-cities", commonData, user)(content)
 }

--- a/app/views/admin/dashboard/activity.scala.html
+++ b/app/views/admin/dashboard/activity.scala.html
@@ -122,5 +122,5 @@
 
 @common.main(commonData, "Sidewalk - Admin Activity", i18Namespaces = Seq("common", "labelmap")) {
   @common.navbar(commonData, Some(user))
-  @admin.dashboard.adminLayout("activity", commonData, user.role == "Owner")(content)
+  @admin.dashboard.adminLayout("activity", commonData, user)(content)
 }

--- a/app/views/admin/dashboard/adminLayout.scala.html
+++ b/app/views/admin/dashboard/adminLayout.scala.html
@@ -1,13 +1,17 @@
+@import models.user.SidewalkUserWithRole
 @import service.CommonPageData
-@(activePage: String, commonData: CommonPageData, isOwner: Boolean = false)(content: Html)(implicit request: RequestHeader, assets: AssetsFinder)
+@(activePage: String, commonData: CommonPageData, user: SidewalkUserWithRole)(content: Html)(implicit request: RequestHeader, assets: AssetsFinder)
 
-@* Shared shell for the redesigned admin dashboard (#4272): left nav + main content + right "On this page" TOC. Deliberately reuses the API-docs stylesheet and its .api-* class names so the two surfaces look identical; admin-dashboard.css adds only the components the docs don't have (maps, charts, KPI cards). The right TOC is populated client-side from the page's h2/h3 headings by admin-shell.js. Every page opens with the deployment-info strip so there's never a question of which instance/version you're looking at. *@
+@* Shared shell for the redesigned admin dashboard (#4272): left nav + main content + right "On this page" TOC. Deliberately reuses the API-docs stylesheet and its .api-* class names so the two surfaces look identical; admin-dashboard.css adds only the components the docs don't have (maps, charts, KPI cards). The right TOC is populated client-side from the page's h2/h3 headings by admin-shell.js. Every page opens with the deployment-info strip so there's never a question of which instance/version you're looking at.
+*
+* The layout derives the sidebar's Owner-only visibility from the signed-in user rather than taking a boolean, so every page gets the same nav by construction: a page can't quietly render a shorter sidebar by passing the wrong flag or leaning on a default, and the required `user` param makes omitting it a compile error.
+*@
 
 <link rel="stylesheet" href="@assets.path("css/api-docs/api-docs.css")">
 <link rel="stylesheet" href="@assets.path("css/admin-dashboard/admin-dashboard.css")">
 
 <div class="api-container">
-  @admin.dashboard._sidebar(activePage, isOwner)
+  @admin.dashboard._sidebar(activePage, user.role == "Owner")
 
   <main class="api-content">
     @admin.dashboard._deploymentInfo(commonData)

--- a/app/views/admin/dashboard/apiAnalytics.scala.html
+++ b/app/views/admin/dashboard/apiAnalytics.scala.html
@@ -79,5 +79,5 @@
 
 @common.main(commonData, "Sidewalk - Admin API Analytics") {
   @common.navbar(commonData, Some(user))
-  @admin.dashboard.adminLayout("api-analytics", commonData, user.role == "Owner")(content)
+  @admin.dashboard.adminLayout("api-analytics", commonData, user)(content)
 }

--- a/app/views/admin/dashboard/contributors.scala.html
+++ b/app/views/admin/dashboard/contributors.scala.html
@@ -99,5 +99,5 @@
 
 @common.main(commonData, "Sidewalk - Admin Contributors") {
   @common.navbar(commonData, Some(user))
-  @admin.dashboard.adminLayout("contributors", commonData, user.role == "Owner")(content)
+  @admin.dashboard.adminLayout("contributors", commonData, user)(content)
 }

--- a/app/views/admin/dashboard/coverage.scala.html
+++ b/app/views/admin/dashboard/coverage.scala.html
@@ -79,5 +79,5 @@
 
 @common.main(commonData, "Sidewalk - Admin Coverage") {
   @common.navbar(commonData, Some(user))
-  @admin.dashboard.adminLayout("coverage", commonData, user.role == "Owner")(content)
+  @admin.dashboard.adminLayout("coverage", commonData, user)(content)
 }

--- a/app/views/admin/dashboard/health.scala.html
+++ b/app/views/admin/dashboard/health.scala.html
@@ -83,5 +83,5 @@
 
 @common.main(commonData, "Sidewalk - Health") {
   @common.navbar(commonData, Some(user))
-  @admin.dashboard.adminLayout("health", commonData, user.role == "Owner")(content)
+  @admin.dashboard.adminLayout("health", commonData, user)(content)
 }

--- a/app/views/admin/dashboard/humansVsAi.scala.html
+++ b/app/views/admin/dashboard/humansVsAi.scala.html
@@ -76,5 +76,5 @@
 
 @common.main(commonData, "Sidewalk - Humans vs AI") {
   @common.navbar(commonData, Some(user))
-  @admin.dashboard.adminLayout("humans-vs-ai", commonData, user.role == "Owner")(content)
+  @admin.dashboard.adminLayout("humans-vs-ai", commonData, user)(content)
 }

--- a/app/views/admin/dashboard/labelMap.scala.html
+++ b/app/views/admin/dashboard/labelMap.scala.html
@@ -83,5 +83,5 @@
 
 @common.main(commonData, "Sidewalk - Admin Label Map", i18Namespaces = Seq("common", "labelmap")) {
   @common.navbar(commonData, Some(user))
-  @admin.dashboard.adminLayout("label-map", commonData, user.role == "Owner")(content)
+  @admin.dashboard.adminLayout("label-map", commonData, user)(content)
 }

--- a/app/views/admin/dashboard/management.scala.html
+++ b/app/views/admin/dashboard/management.scala.html
@@ -84,5 +84,5 @@
 
 @common.main(commonData, "Sidewalk - Admin Management") {
   @common.navbar(commonData, Some(user))
-  @admin.dashboard.adminLayout("management", commonData, user.role == "Owner")(content)
+  @admin.dashboard.adminLayout("management", commonData, user)(content)
 }

--- a/app/views/admin/dashboard/overview.scala.html
+++ b/app/views/admin/dashboard/overview.scala.html
@@ -99,5 +99,5 @@
 
 @common.main(commonData, "Sidewalk - Admin Overview") {
   @common.navbar(commonData, Some(user))
-  @admin.dashboard.adminLayout("overview", commonData, user.role == "Owner")(content)
+  @admin.dashboard.adminLayout("overview", commonData, user)(content)
 }

--- a/app/views/admin/dashboard/quality.scala.html
+++ b/app/views/admin/dashboard/quality.scala.html
@@ -90,5 +90,5 @@
 
 @common.main(commonData, "Sidewalk - Admin Data Quality") {
   @common.navbar(commonData, Some(user))
-  @admin.dashboard.adminLayout("quality", commonData, user.role == "Owner")(content)
+  @admin.dashboard.adminLayout("quality", commonData, user)(content)
 }

--- a/app/views/admin/dashboard/stories.scala.html
+++ b/app/views/admin/dashboard/stories.scala.html
@@ -72,5 +72,5 @@
 
 @common.main(commonData, "Sidewalk - Admin Stories", i18Namespaces = Seq("common", "labelmap")) {
   @common.navbar(commonData, Some(user))
-  @admin.dashboard.adminLayout("stories", commonData, user.role == "Owner")(content)
+  @admin.dashboard.adminLayout("stories", commonData, user)(content)
 }

--- a/app/views/admin/dashboard/streetStatus.scala.html
+++ b/app/views/admin/dashboard/streetStatus.scala.html
@@ -56,5 +56,5 @@
 
 @common.main(commonData, "Sidewalk - Admin Street Status") {
   @common.navbar(commonData, Some(user))
-  @admin.dashboard.adminLayout("street-status", commonData)(content)
+  @admin.dashboard.adminLayout("street-status", commonData, user)(content)
 }


### PR DESCRIPTION
Fixes #4880.

## The bug

/admin/street-status rendered a shorter left nav than every other admin page: signed in as an Owner, **Across Cities** and **Health** were missing there and present everywhere else.

The nav is already one shared partial (`_sidebar.scala.html`, rendered by `adminLayout.scala.html`) — the drift came from how the layout was parameterized:

```scala
@(activePage: String, commonData: CommonPageData, isOwner: Boolean = false)
```

Twelve of the thirteen admin pages pass `user.role == "Owner"`. `streetStatus.scala.html` passed nothing, silently got the default `false`, and lost the two Owner-only entries.

## The fix

The layout takes the user and does the role test itself:

```scala
@(activePage: String, commonData: CommonPageData, user: SidewalkUserWithRole)
```

Every page view already had `user` in scope, so the call sites are a mechanical change. This fixes the class of bug rather than the instance: there's no default to fall through, omitting the argument is now a compile error, and the role test lives in one place instead of being copy-pasted thirteen times.

## Verification

`sbt compile` clean (`-Xfatal-warnings`), HTMLHint clean. Worth a click through the admin pages as an Owner to confirm the nav is now identical everywhere — street-status is the one that changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-opus-5[1m])