### PR TITLE
Consolidate mobile detection into ControllerUtils.isMobile (#4887)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,8 +274,9 @@ jobs:
       #   tutorial street, so all four tests CANCEL on this empty schema — listed here so they run the moment the job
       #   has a seeded DB, and so the cancel is visible rather than the suite silently not existing.
       # - MobileDetectionSpec (#4887): the layout must stamp ControllerUtils.isMobile's verdict on
-      #   <html data-mobile-device>, the single mobile definition util.isMobile() reads back. Fetches /signIn, which
-      #   renders without data, so it is meaningful on this empty schema.
+      #   <html data-mobile-device>, the single mobile definition util.isMobile() reads back; also pins the landing
+      #   page's navbar-padding opt-out to request.path. Fetches /signIn and the landing page, which render without
+      #   data (the landing shows zeros/NaN stats), so both are meaningful on this empty schema.
       - name: Run gating/auth tests (health dashboard + route auth posture + geodesic distances)
         run: sbt 'set Test / parallelExecution := false' 'testOnly controllers.HealthDashboardSpec service.HealthServiceSpec controllers.RouteAuthPostureSpec models.street.GeodesicDistanceSpec service.ExploreTutorialRouteSpec controllers.MobileDetectionSpec'
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,8 +273,11 @@ jobs:
       #   It seeds its own users and route walks, but hangs them on an existing street/region and needs a configured
       #   tutorial street, so all four tests CANCEL on this empty schema — listed here so they run the moment the job
       #   has a seeded DB, and so the cancel is visible rather than the suite silently not existing.
+      # - MobileDetectionSpec (#4887): the layout must stamp ControllerUtils.isMobile's verdict on
+      #   <html data-mobile-device>, the single mobile definition util.isMobile() reads back. Fetches /signIn, which
+      #   renders without data, so it is meaningful on this empty schema.
       - name: Run gating/auth tests (health dashboard + route auth posture + geodesic distances)
-        run: sbt 'set Test / parallelExecution := false' 'testOnly controllers.HealthDashboardSpec service.HealthServiceSpec controllers.RouteAuthPostureSpec models.street.GeodesicDistanceSpec service.ExploreTutorialRouteSpec'
+        run: sbt 'set Test / parallelExecution := false' 'testOnly controllers.HealthDashboardSpec service.HealthServiceSpec controllers.RouteAuthPostureSpec models.street.GeodesicDistanceSpec service.ExploreTutorialRouteSpec controllers.MobileDetectionSpec'
         env:
           DATABASE_URL: jdbc:postgresql://localhost:5432/sidewalk
           DATABASE_USER: sidewalk

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,14 @@ No npm-based module system on the frontend — files are simply concatenated in 
 
 **Naming conventions (from #2292):** directories are **kebab-case**; CSS files are **kebab-case**; JS files follow Airbnb style — **PascalCase** for files that define a class/constructor (`AppManager.js`, `LabelPopup.js`), **camelCase** for function/utility/entry files (`main.js`, `aggregateStats.js`). Kebab-case is not used for JS files. Full write-up in [`docs/style-guide.md`](docs/style-guide.md). **Deferred mismatch:** the app dirs were renamed (`SVLabel → explore`, `SVValidate → validate`, `Progress → user-dashboard`), but the internal JS namespace *identifiers* `svl` (Explore) and `sg` (Gallery) were left as-is — renaming those is a large independent refactor, not part of the file reorg.
 
+**Mobile detection has one definition: `ControllerUtils.isMobile` (server-side UA regex).** It gates which UI a
+request is served (mobile → `/mobileLanding`, `/mobile`, the shared auth pages; other pages redirect), and
+`main.scala.html` stamps its verdict on every page as `<html data-mobile-device>`; client code asks
+`util.isMobile()`, which reads that stamp — never re-sniff the UA in JS (#4887; `MobileDetectionSpec` pins the
+stamp). For touch-vs-hover behavior questions, use a capability query (`pointer: coarse` — see `ShareWidget.js`)
+rather than the mobile flag. The device regex in `FunnelStatTable.scala` classifies stored analytics rows by
+recorded OS name and is analytics-only, never a product gate. (Longer-term direction: #4875.)
+
 ## Internationalization
 Two separate i18n systems:
 1. **Backend**: Play i18n with message files in `conf/messages/` (server-rendered strings)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,7 +135,9 @@ interactions, update the logging accordingly.
   `localhost:9000/?referrer=mturk&hitId=h1&workerId=worker1&assignmentId=a1&minutes=60`. To start a fresh turker,
   change `workerId`/`hitId`/`assignmentId`.
 
-**Test on mobile if you touched the Validate page** (the only page served on mobile). Start with Chrome DevTools
+**Test on mobile if you touched the Validate page or the auth pages** — the pages mobile visitors are actually
+served (`/mobileLanding`, the mobile Validate page at `/mobile`, and the sign-in/sign-up flow; every other page
+redirects them to `/mobileLanding`). Start with Chrome DevTools
 [device mode](https://developer.chrome.com/docs/devtools/device-mode/); if it looks good, test on a real device by
 visiting `<your-computer-ip>:9000` (phone and computer on the same Wi-Fi; this often fails on public/café networks).
 

--- a/app/controllers/helper/ControllerUtils.scala
+++ b/app/controllers/helper/ControllerUtils.scala
@@ -23,6 +23,10 @@ object ControllerUtils {
    */
   val NoUserId: String = ""
 
+  /** Mobile OS/device tokens in a User-Agent. Compiled once: isMobile runs on every page render (the layout stamp). */
+  private val mobileOsRegex: Regex =
+    "(iPhone|webOS|iPod|Android|BlackBerry|mobile|SAMSUNG|IEMobile|OperaMobi|BB10|iPad|Tablet)".r.unanchored
+
   /**
    * Whether the request comes from a mobile device, judged by matching its User-Agent against a list of mobile OS
    * and device tokens.
@@ -35,14 +39,12 @@ object ControllerUtils {
    * @return        True if that header is present and matches a mobile token; false if it is absent or matches none.
    */
   def isMobile(implicit request: RequestHeader): Boolean = {
-    val mobileOS: Regex =
-      "(iPhone|webOS|iPod|Android|BlackBerry|mobile|SAMSUNG|IEMobile|OperaMobi|BB10|iPad|Tablet)".r.unanchored
     request.headers
       .get("User-Agent")
       .exists(agent => {
         agent match {
-          case mobileOS(a) => true
-          case _           => false
+          case mobileOsRegex(_) => true
+          case _                => false
         }
       })
   }

--- a/app/models/utils/FunnelStatTable.scala
+++ b/app/models/utils/FunnelStatTable.scala
@@ -194,6 +194,12 @@ class FunnelStatTable @Inject() (protected val dbConfigProvider: DatabaseConfigP
    * a real per-cookie population, kept and counted. The schema and events body are trusted (config + code), so they are
    * spliced in literally.
    *
+   * The device CTE's mobile/desktop split is an ANALYTICS-ONLY classification of historical rows: it works from what
+   * the client recorded (Bowser OS names in `audit_task_environment.operating_system`, screen/browser widths) plus
+   * Visit_Index/Visit_MobileLanding hints, because a stored row has no User-Agent to ask. It therefore cannot reuse
+   * `ControllerUtils.isMobile` — the product's single mobile definition, which gates live requests (#4887) — and must
+   * never be treated as one: keep this regex out of product gates, and keep product gates out of here.
+   *
    * @param schema   The database schema (already validated as a configured city schema).
    * @param events   The UNION ALL body producing (user_id, step) rows.
    * @param numSteps How many step columns to aggregate (6 for mapping, 3 for contribution).

--- a/app/views/common/main.scala.html
+++ b/app/views/common/main.scala.html
@@ -1,3 +1,4 @@
+@import controllers.helper.ControllerUtils
 @import play.api.Configuration
 @import service.CommonPageData
 @import play.filters.csrf.CSRF
@@ -7,6 +8,9 @@
 @currentCity = @{commonData.currentCity}
 @* Pages that render the map full-window (no footer, #wrap becomes a fixed-height flex column). *@
 @fullWindow = @{url == "/labelMap" || url == "/routeBuilder"}
+@* The landing page draws its hero under the fixed navbar and pads itself (homepage.css), so it opts out of the
+   global navbar offset that main.css puts on <body>. *@
+@bodyClass = @{if (url == "/" || url == "/home") "no-navbar-offset" else ""}
 
 @* The one moment locale this request needs. Locale files register lowercase names ('zh-tw', 'pt-br') matching their
    filenames, and moment lowercases the code it's given, so a language code maps straight to a filename (#4486).
@@ -21,7 +25,9 @@
 }
 
 <!DOCTYPE html>
-<html lang="@messages.lang.code">
+@* data-mobile-device is the server's mobile verdict (ControllerUtils.isMobile, the single mobile definition) for
+   this request; util.isMobile() reads it back so client and server always agree on which UI variant is running. *@
+<html lang="@messages.lang.code" data-mobile-device="@ControllerUtils.isMobile">
   <head>
       <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=@commonData.googleAnalyticsId"></script>
@@ -77,20 +83,14 @@
     <script src='@assets.path("js/common/Navbar.js")' defer></script>
 
     <script src='@assets.path("vendor/bowser/bowser-2.14.1.min.js")'></script>
-    <script src='@assets.path("js/common/pagetopPadding.js")' defer></script>
     <script src='@assets.path("js/common/utilities.js")'></script>
     <script src='@assets.path("js/common/utilitiesMath.js")'></script>
     <script src='@assets.path("js/common/i18nDom.js")'></script>
     <script src='@assets.path("js/common/psTooltip.js")'></script>
     <script src='@assets.path("/js/common/AppManager.js")'></script>
   </head>
-  <body>
+  <body class="@bodyClass">
     <script>
-      // Removes top padding on the pages that render without a fixed navbar. Fires on full load to match the old
-      // <body onload>, which ran after all resources settled.
-      @* Lazy lookup: pagetopPadding.js is deferred, so checkIfPaddingNeeded isn't defined at parse time yet. *@
-      window.addEventListener('load', () => checkIfPaddingNeeded());
-
       // Set up AppManager to initialize stuff that we need on every page (CSRF token, i18next, etc.).
       $(document).ready(function() {
         const csrfToken = "@CSRF.getToken.map(_.value)";

--- a/app/views/common/main.scala.html
+++ b/app/views/common/main.scala.html
@@ -9,8 +9,10 @@
 @* Pages that render the map full-window (no footer, #wrap becomes a fixed-height flex column). *@
 @fullWindow = @{url == "/labelMap" || url == "/routeBuilder"}
 @* The landing page draws its hero under the fixed navbar and pads itself (homepage.css), so it opts out of the
-   global navbar offset that main.css puts on <body>. *@
-@bodyClass = @{if (url == "/" || url == "/home") "no-navbar-offset" else ""}
+   global navbar offset that main.css puts on <body>. Keyed on request.path (like navbar.scala.html's isLanding),
+   NOT the url parameter: url defaults to "/", so the ~50 views that omit it would otherwise all be classified as
+   the landing page and lose their navbar padding. MobileDetectionSpec pins this. *@
+@bodyClass = @{if (request.path == "/" || request.path == "/home") "no-navbar-offset" else ""}
 
 @* The one moment locale this request needs. Locale files register lowercase names ('zh-tw', 'pt-br') matching their
    filenames, and moment lowercases the code it's given, so a language code maps straight to a filename (#4486).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -141,6 +141,16 @@ First-party assets split by type: `public/js/` is JavaScript-only, `public/css/`
 `public/videos/`. Directories and CSS files are kebab-case; JS files use Airbnb casing (PascalCase for class files,
 camelCase otherwise). See [`style-guide.md`](style-guide.md) for the full layout and naming conventions.
 
+**Mobile detection has exactly one definition:** `ControllerUtils.isMobile`, a server-side User-Agent check that
+decides which UI a request is served (mobile visitors get `/mobileLanding`, the mobile Validate page at `/mobile`,
+and the shared auth pages; other pages redirect them). The shared layout stamps that verdict on every page as
+`<html data-mobile-device>`, and client code reads it back through `util.isMobile()` — never re-sniff the UA in JS,
+or client and server can disagree about which UI variant is running. Where the real question is touch-vs-hover
+capability rather than "which variant is this page", use a media query (`pointer: coarse`) instead. The device
+regex in the funnel-stats SQL classifies *stored* analytics rows by recorded OS name; it is analytics-only, never a
+product gate. (The longer-term direction — responsive pages replacing the UA fork entirely — is
+[#4875](https://github.com/ProjectSidewalk/SidewalkWebpage/issues/4875).)
+
 ## Internationalization
 
 Two separate i18n systems:

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -238,6 +238,12 @@ body {
   padding-top: calc(var(--navbar-height) + var(--test-banner-height, 0px));
 }
 
+/* The landing page draws its hero under the fixed navbar and pads itself (homepage.css), so main.scala.html gives
+   its <body> this class to opt out of the navbar offset above. */
+body.no-navbar-offset {
+  padding-top: 0;
+}
+
 .spacer10 { height: 10px; }
 .spacer20 { height: 20px; }
 

--- a/public/js/common/pagetopPadding.js
+++ b/public/js/common/pagetopPadding.js
@@ -1,6 +1,0 @@
-function checkIfPaddingNeeded() {
-  if (window.location.pathname === '/'
-    || window.location.pathname === '/home') {
-    document.body.style.paddingTop = '0px';
-  }
-}

--- a/public/js/common/utilities.js
+++ b/public/js/common/utilities.js
@@ -288,8 +288,12 @@ util.getOperatingSystem = () => _bowserParser.getOSName();
 util.isSafari = () => util.getBrowserName() === 'Safari';
 util.isChrome = () => util.getBrowserName() === 'Chrome';
 util.isFirefox = () => util.getBrowserName() === 'Firefox';
-// Tablets count as mobile: they get the touch-oriented mobile UI (and the /mobile redirect) same as phones.
-util.isMobile = () => ['mobile', 'tablet'].includes(_bowserParser.getPlatformType());
+
+// Whether the server judged this device mobile (ControllerUtils.isMobile — the single mobile definition; tablets
+// count as mobile) and so served it the mobile UI. main.scala.html stamps the verdict on <html>; reading it back,
+// rather than re-sniffing the UA client-side, means client and server can't disagree about which variant this page
+// is (#4887). For touch-vs-hover behavior questions, prefer a capability query (`pointer: coarse`) over this flag.
+util.isMobile = () => document.documentElement.dataset.mobileDevice === 'true';
 
 // A cross-browser function to capture a mouse position, relative to the given DOM element. The UI is scaled through
 // real layout sizes (var(--ui-scale)), so offset() already reflects the scaled position and no compensation is needed.

--- a/test/controllers/MobileDetectionSpec.scala
+++ b/test/controllers/MobileDetectionSpec.scala
@@ -12,6 +12,7 @@ import play.api.test.Helpers._
  * layout stamps it on `<html data-mobile-device>` so `util.isMobile()` reads the server's answer back instead of
  * re-sniffing the UA client-side. These specs pin the stamp on both verdicts — lose it and the Validate app silently
  * treats every page as desktop. Fetches /signIn because it serves every device with no session or data requirements.
+ * Also pins the layout's other request-derived body marker, the landing page's navbar-padding opt-out.
  *
  * Requires a Postgres+PostGIS database (via DATABASE_URL / DATABASE_USER / DATABASE_PASSWORD env, as in dev/CI).
  */
@@ -35,6 +36,20 @@ class MobileDetectionSpec extends PlaySpec with GuiceOneAppPerSuite {
       val resp = route(app, FakeRequest(GET, "/signIn")).get
       status(resp) mustBe OK
       contentAsString(resp) must include("data-mobile-device=\"false\"")
+    }
+  }
+
+  "The layout's landing padding opt-out" should {
+    // The class must key on request.path, not the layout's `url` parameter — that parameter defaults to "/", so the
+    // many views that omit it would otherwise all read as the landing page and lose their fixed-navbar padding.
+    "mark the landing page's body and no other page's" in {
+      val landing = route(app, FakeRequest(GET, "/")).get
+      status(landing) mustBe OK
+      contentAsString(landing) must include("no-navbar-offset")
+
+      val signIn = route(app, FakeRequest(GET, "/signIn")).get
+      status(signIn) mustBe OK
+      contentAsString(signIn) must not include "no-navbar-offset"
     }
   }
 }

--- a/test/controllers/MobileDetectionSpec.scala
+++ b/test/controllers/MobileDetectionSpec.scala
@@ -1,0 +1,40 @@
+package controllers
+
+import org.scalatestplus.play.PlaySpec
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+
+/**
+ * The single-mobile-definition contract (#4887): `ControllerUtils.isMobile` is the one mobile verdict, and the shared
+ * layout stamps it on `<html data-mobile-device>` so `util.isMobile()` reads the server's answer back instead of
+ * re-sniffing the UA client-side. These specs pin the stamp on both verdicts — lose it and the Validate app silently
+ * treats every page as desktop. Fetches /signIn because it serves every device with no session or data requirements.
+ *
+ * Requires a Postgres+PostGIS database (via DATABASE_URL / DATABASE_USER / DATABASE_PASSWORD env, as in dev/CI).
+ */
+class MobileDetectionSpec extends PlaySpec with GuiceOneAppPerSuite {
+
+  override def fakeApplication(): Application =
+    new GuiceApplicationBuilder()
+      .disable[modules.ActorModule] // No eager background actors during tests.
+      .build()
+
+  private val mobileUa = "User-Agent" -> "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)"
+
+  "The layout's data-mobile-device stamp" should {
+    "carry the server's true verdict on a page served to a mobile browser" in {
+      val resp = route(app, FakeRequest(GET, "/signIn").withHeaders(mobileUa)).get
+      status(resp) mustBe OK
+      contentAsString(resp) must include("data-mobile-device=\"true\"")
+    }
+
+    "carry the server's false verdict on a page served to a desktop browser" in {
+      val resp = route(app, FakeRequest(GET, "/signIn")).get
+      status(resp) mustBe OK
+      contentAsString(resp) must include("data-mobile-device=\"false\"")
+    }
+  }
+}


### PR DESCRIPTION
Closes #4887. Part of #4875 Phase 1 (delete the auth fork + converge on one "mobile" definition); the auth-fork half was #4884 / PR #4885.

## What this does

**Makes `ControllerUtils.isMobile` the single mobile definition.** The shared layout stamps the server's verdict on every page:

```html
<html lang="…" data-mobile-device="true|false">
```

and `util.isMobile()` now reads that stamp back instead of re-sniffing the UA with Bowser. All ~30 call sites in the Validate app are unchanged — they just can no longer disagree with the server about which UI variant is running (previously, any UA where the Scala regex and Bowser's platform check diverged got one variant's page with the other variant's JS behavior — e.g. desktop Validate with no `KeyboardManager`). Bowser stays for browser/OS names in environment logging.

**Documents the funnel-stats regex as analytics-only.** `FunnelStatTable`'s device CTE classifies *stored* rows (recorded OS names, screen widths) — it has no User-Agent to ask, so it genuinely can't reuse the Scala helper. Its ScalaDoc now says so and warns it must never become a product gate.

**Deletes `pagetopPadding.js`.** After #4885 its path list was down to `/` + `/home`, so the landing-page padding opt-out is now a server-rendered `body.no-navbar-offset` class. The padding applies at parse time rather than on `load`, which also removes a visible layout jump on the landing page.

**Locks the contract in tests + CI.** New `MobileDetectionSpec` fetches `/signIn` (serves every device, needs no data — meaningful even on CI's empty schema) with mobile and desktop UAs and asserts the stamp both ways. Added to ci.yml's enumerated gating step, since that list is an allowlist and an unlisted spec silently never runs.

**Docs synced:** CLAUDE.md + `docs/architecture.md` record the rule (never re-sniff the UA in JS; use a `pointer: coarse` capability query where the real question is touch-vs-hover), and CONTRIBUTING's stale "(the only page served on mobile)" line now reflects that the auth pages serve mobile users too.

## Deliberately deferred (per the plan)

- Phone-vs-tablet split in the helper — meaningful only once the Phase 2 un-redirects land.
- Capability-based variant selection and folding `/mobile` into `/validate` — Phase 3.

## Verification

- `sbt compile` warning-clean; scalafmt clean; ESLint/Stylelint/HTMLHint clean on everything touched.
- Backend: `MobileDetectionSpec` (2/2), plus `UserAuthControllerSpec` + `SeoSpec` regression — 15/15 against the local seeded DB.
- JS: full jsdom suite 703/703 (the suite stubs `util.isMobile`, so it pins the call sites, not the sniffing).
- Headless Playwright against the running app: emulated iPhone on `/mobile` → stamp `true`, `util.isMobile()` true, no `KeyboardManager` built; desktop `/validate` → the inverse with `KeyboardManager` present; desktop landing → `padding-top: 0` at parse time; zero console/page errors on all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-fable-5)
