### PR TITLE
Set the LabelMap/Gallery filter sidebar in Mulish, from the type tokens

### DIFF
--- a/public/css/filter-sidebar.css
+++ b/public/css/filter-sidebar.css
@@ -16,7 +16,10 @@
   overflow-y: auto;
   scrollbar-gutter: stable;
   padding: 40px 30px 30px;
-  font-family: Raleway, sans-serif;
+
+  /* The panel's inherited face only, deliberately not a --text-* token: each control below sets its own, and a
+     composite here would stamp a size onto anything that doesn't. */
+  font-family: var(--font-primary);
   transition: transform 0.2s ease;
 }
 
@@ -147,9 +150,7 @@ body.filter-sidebar-resizing {
 }
 
 .filter-sidebar__heading {
-  font-family: Raleway, sans-serif;
-  font-size: 16px;
-  font-weight: 700;
+  font: var(--text-body-bold);
   color: var(--color-neutral-black);
   margin: 0;
   line-height: normal;
@@ -167,9 +168,7 @@ body.filter-sidebar-resizing {
   border: none;
   color: var(--color-asphalt-400);
   cursor: pointer;
-  font-family: Raleway, sans-serif;
-  font-size: 13px;
-  font-weight: 600;
+  font: var(--text-caption-semibold);
   padding: 0;
 }
 
@@ -302,9 +301,7 @@ body.filter-sidebar-resizing {
 }
 
 .filter-sidebar__item label {
-  font-family: Raleway, sans-serif;
-  font-size: 16px;
-  font-weight: 500;
+  font: var(--text-body-medium);
   color: var(--color-neutral-black);
   margin: 0;
   cursor: pointer;
@@ -505,9 +502,7 @@ body.filter-sidebar-resizing {
 }
 
 .filter-sidebar__count {
-  font-family: Raleway, sans-serif;
-  font-size: 13px;
-  font-weight: 500;
+  font: var(--text-caption-medium);
   font-variant-numeric: tabular-nums;
   color: var(--color-neutral-700);
 }
@@ -517,9 +512,7 @@ body.filter-sidebar-resizing {
   border: none;
   padding: 0;
   cursor: pointer;
-  font-family: Raleway, sans-serif;
-  font-size: 13px;
-  font-weight: 600;
+  font: var(--text-caption-semibold);
   color: var(--color-asphalt-400);
   display: none;
 }


### PR DESCRIPTION
Closes #4907.

## What was wrong

Raleway defaults to **old-style figures**, so the label-type counts never shared a baseline. Measuring each digit's ink box in the count's own resolved font, at its own size:

```
Raleway  0:8/0  1:8/0  2:8/0  3:8/2  4:9/2  5:8/2  6:9/0  7:8/2  8:9/0  9:8/2
Mulish   0:9/1  1:9/0  2:9/0  3:9/1  4:9/0  5:9/1  6:9/1  7:9/0  8:9/1  9:9/1
         (ascent/descent in px)
```

In Raleway, **4, 6 and 8 stand a pixel taller** than the rest and **3, 4, 5, 7 and 9 hang two pixels below the baseline** — the sixes riding high and the seven dipping that @misaugstad reported. In Mulish every digit has the same ascent, and the only descent left is a pixel of curve overshoot on the round digits (0, 3, 5, 6, 8, 9), which is how a baseline is supposed to look.

`font-variant-numeric: tabular-nums` was already on the count and could never have fixed it — it equalizes advance *width*, not height.

## What changed

Raleway is the branded display face, scoped to the three `--text-*-accent` tokens, and CLAUDE.md says outright that anything rendering digits gets a primary-font token. A sidebar of controls and counts isn't display type. So rather than swap one family name for another, the six rules take the token that matches what they were hand-assembling:

| rule | was | now |
| --- | --- | --- |
| `.filter-sidebar__heading` | 16px / 700 | `--text-body-bold` (exact) |
| `.filter-sidebar__item label` | 16px / 500 | `--text-body-medium` (exact) |
| `.filter-sidebar__count` | 13px / 500 | `--text-caption-medium` |
| `.filter-sidebar__deselect-all` | 13px / 600 | `--text-caption-semibold` |
| `.filter-sidebar__only` | 13px / 600 | `--text-caption-semibold` |
| `.filter-sidebar` | Raleway | `var(--font-primary)` |

**Worth a look on review:** the three 13px rules land on 12px, because 13 was never on the type scale. Mulish carries more x-height than Raleway at a given size, so the type reads no smaller for it — but it is a real 1px change and easy to revert to a size override if you'd rather.

The panel keeps a bare `font-family` rather than a composite token, deliberately: each control sets its own, and a composite there would stamp a size onto anything that doesn't.

## Verified

Both `/labelMap` and `/gallery`, with the stylesheet swapped at the network layer so the real cascade applies:

```
BEFORE /labelMap  panel Raleway 400 14px | heading Raleway 700 16px | count Raleway 500 13px
AFTER  /labelMap  panel Mulish  400 14px | heading Mulish  700 16px | count Mulish  500 12px
BEFORE /gallery   heading Raleway 700 16px | only Raleway 600 13px
AFTER  /gallery   heading Mulish  700 16px | only Mulish  600 12px
```

Digit cap-height spread goes 1px → 0. Stylelint clean.

(Gallery's sidebar has no `.filter-sidebar` container or `.filter-sidebar__count` — it reuses the same BEM children in its own wrapper, so it gets the heading/label/only fixes and has no counts to straighten.)

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-opus-5[1m])
