### PR TITLE
Drop the mobile Validate font-face declaration the browser never parsed (#4915)

### DIFF
--- a/public/js/mobileValidate.js
+++ b/public/js/mobileValidate.js
@@ -8,11 +8,6 @@ const applyMissionScale = () => {
 };
 
 $(document).ready(() => {
-  // Raleway doesn't load after being redirected from another page; redeclaring the font-face fixes that.
-  const font = '<style> @@font-face{ font-family: \'raleway\'; '
-    + 'src: url(\'/assets/fonts/Raleway/Raleway-Regular.woff2\');} </style>';
-  $('head').append(font);
-
   applyMissionScale();
   window.addEventListener('resize', applyMissionScale);
 


### PR DESCRIPTION
Closes #4915.

`public/js/mobileValidate.js` opened by injecting a `<style>` element to re-declare Raleway:

```js
// Raleway doesn't load after being redirected from another page; redeclaring the font-face fixes that.
const font = '<style> @@font-face{ font-family: \'raleway\'; '
  + 'src: url(\'/assets/fonts/Raleway/Raleway-Regular.woff2\');} </style>';
$('head').append(font);
```

Note the **`@@font-face`**. Doubling the `@` is Twirl's escape for a literal at-sign, but this file is a plain static
asset loaded with `<script src='@assets.path("js/mobileValidate.js")'>` — never rendered by Twirl. Both at-signs reach
the CSS parser, `@@font-face { ... }` is not a valid at-rule, and the whole rule is dropped as an invalid selector.

**Measured in Chromium**, injecting each form and reading back `styleSheet.cssRules`:

```
as shipped ("@@font-face"):  ruleCount: 0, rules: []
corrected  ("@font-face"):   ruleCount: 1, rules: ["CSSFontFaceRule: @font-face { font-family: raleway2; ... }"]
```

## Why delete rather than repair the `@`

Because nothing has to take its place. `app/views/apps/mobileValidate.scala.html` wraps in `@common.main`, which links
`css/main.css` — where Raleway's `@font-face` rules live. The page has always had a properly declared Raleway through
the normal stylesheet path, so the injected copy was redundant even in the form that would have parsed.

**This cannot change how the page renders.** Since the injected rule has never parsed, the page as it renders today
already *is* the "without it" case. Removing code that has never executed is behaviour-preserving by construction.

The comment described Raleway failing to load after a redirect from another page. Whatever that was, this never
addressed it — so this removes a false explanation as much as it removes dead code. If the symptom is still live it
needs a real diagnosis, and the misleading workaround was in the way of getting one.

## Verification

- **818 tests / 68 suites pass**; ESLint, Stylelint, HTMLHint and locale parity all clean.
- The invariant is already pinned, so no new test earns its place here: `selfHostedAssets.test.js` fails if any
  `--font-*` token names a family no `@font-face` declares, and `--font-accent` → `raleway`. Delete main.css's
  declarations and that test goes red.
- Drive-by: this was one of the last `+`-concatenated HTML strings, which CLAUDE.md forbids in favour of template
  literals. It goes with the block.

Held back from #4909 deliberately, even though that PR edited this very line: the deletion conflicted with #4892,
which added `applyMissionScale` around it. Both have since landed, so this now applies cleanly to `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-opus-5[1m])
