### PR TITLE
Keep the dev Postgres data on a named Docker volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,8 +43,15 @@ services:
     volumes:
       - "./db/scripts/init.sh:/docker-entrypoint-initdb.d/init.sh"
       - "./db:/opt"
+      # Named, so the data survives `make docker-stop`, which runs `docker compose rm -f`, rather than being orphaned.
+      - "pgdata:/var/lib/postgresql/data"
     ports:
       - "5432:5432"
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=sidewalk
+
+volumes:
+  # Leave this unprefixed. Compose namespaces it per project (-> sidewalk_pgdata), so an explicit `name:` would point
+  # every Sidewalk checkout on the machine at one shared database.
+  pgdata:

--- a/docs/dev-environment.md
+++ b/docs/dev-environment.md
@@ -321,6 +321,7 @@ Roughly ordered by when you'd hit them during setup.
 | `pg_restore: ... schema "public" already exists` | Safe to ignore — no effect. |
 | `import-dump` otherwise errors | Don't skip ahead. Re-check the dump filename and `db=` value, then see the [Troubleshooting wiki](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Troubleshooting-Dev-Environment) and ask. |
 | `Execution exception [NoSuchElementException: None.get]` at runtime | The data wasn't imported — run `make import-dump` (the init only creates the schema, not the data). |
+| Database suddenly looks empty (`role "sidewalk_<city>" does not exist`, no city schemas) | Your data is most likely parked on an orphaned Docker volume, not gone — `docker volume ls -qf dangling=true` lists the candidates, and you can copy one back onto `sidewalk_pgdata`. Don't run `docker volume prune` while you're looking; that is what actually destroys them. |
 | `Cannot create container for service web: Conflict ... name "/projectsidewalk-web" already in use` | A prior `web` container wasn't shut down cleanly: `docker container rm /projectsidewalk-web`. |
 | Errors after the computer was shut off mid-run (WSL) | Run `wsl --shutdown`; when Docker offers to restart WSL, accept. Otherwise restart Docker manually. |
 | Can't connect to the database | The db container may not be listening on all addresses. `make ssh target=db`, edit `/var/lib/postgresql/data/postgresql.conf`, set `listen_addresses = '*'`. |


### PR DESCRIPTION
Fixes #4919.

## ⚠️ Run this before you pull

If your dev database predates this change, it is sitting on an anonymous Docker volume, and your first `make dev` after pulling will come up on an **empty** one. Copy it across first — while the db container still exists, which is the easy case:

```bash
# 1. The copy must not read a live database.
docker compose stop db

# 2. Print the anonymous volume your data is on (one hash — bind mounts have no name).
docker inspect projectsidewalk-db --format '{{range .Mounts}}{{.Name}}{{end}}'

# 3. Create the named volume. The two labels are the ones Compose stamps on volumes it creates
#    itself; without them every later `up` warns "already exists but was not created by Docker Compose".
docker volume create --label com.docker.compose.project=sidewalk --label com.docker.compose.volume=pgdata sidewalk_pgdata

# 4. Copy the data in. Slow for a large database, but the source is read-only, so nothing is at risk.
docker run --rm -v <hash>:/from:ro -v sidewalk_pgdata:/to --entrypoint sh projectsidewalk/db -c 'cp -a /from/. /to/'
```

Then pull and `make docker-up-db`. Once you have confirmed your cities are there (`\dn` in `psql`), reclaim the space with `docker volume rm <hash>`.

Two adjustments: Compose prefixes the volume with your **project name** — your checkout folder lowercased — so substitute yours in steps 3 and 4 if you didn't clone into `Sidewalk`. And if you have already removed the db container, step 2 has nothing to read; find the orphan in `docker volume ls -qf dangling=true` instead.

**Do not run `docker volume prune` before migrating.** An orphaned volume is detached, not erased, so a database that looks lost is usually still recoverable — `prune` is what actually destroys it.

## The bug

The `db` service never declared a volume for `/var/lib/postgresql/data`. The `postgres` image declares `VOLUME` on that path itself, so Docker supplied an **anonymous** volume. Anonymous volumes belong to the container, and `make docker-stop` runs `docker compose rm -f` — so removing the container orphaned the data, and the next `up` created a fresh empty volume, re-ran `init.sh`, and the app died with `role "sidewalk_<city>" does not exist`.

This is why it doesn't bite everyone: only container *removal* orphans the volume.

| What you run | Data survives? |
|---|---|
| `docker compose stop` → `up` | ✅ yes |
| Config change → Compose recreates the container | ✅ yes |
| `make docker-stop` (`stop` + `rm -f`) → `up` | ❌ **gone** |
| `docker compose down` → `up` | ❌ **gone** |

Verified all four against a throwaway compose project.

## The fix

Five lines in `docker-compose.yml`: mount `pgdata:/var/lib/postgresql/data`, declare the volume, and two comments.

The key is left **unprefixed** on purpose. Compose namespaces volume keys by project, so this resolves to `sidewalk_pgdata` — the same treatment our networks already get (`sidewalk_default`, `sidewalkdc_default`, ...). Giving it an explicit `name:` would opt out of that and point every Sidewalk checkout on a machine at one shared database, which is a worse and much quieter failure than the one being fixed. That's the one thing worth not undoing later, so it's a comment right where someone would be tempted to add the `name:`.

## Why the migration isn't in the docs

It's a one-time step for the two of us, and it stops being runnable the moment we've each done it. Leaving it in `docs/dev-environment.md` would just be a permanent set of instructions for a situation that no longer exists. This PR is the durable copy.

The one durable piece did land in the docs: a troubleshooting row so that "my database is suddenly empty" points at *an orphaned volume you can probably recover* rather than at re-importing a dump.
