### PR TITLE
Across Cities "this week": count people, not pipelines, and explain each number on hover (#4931)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,6 +289,9 @@ jobs:
       #   data (the landing shows zeros/NaN stats), so both are meaningful on this empty schema.
       # - PanoDataServiceSpec (#4765/#4766): pure unit tests (no DB, no app boot) pinning the label lat/lng estimator
       #   against research-derived constants — costs nothing here and otherwise runs nowhere in CI.
+      # - ActivityBreakdownSpec (#4931): pure unit tests (no DB, no app boot) pinning the rule that keeps AI-role
+      #   output out of the Across Cities "this week" counts. It has to be synthetic — this job's schema has no
+      #   AI-role accounts, so a DB-backed version of these assertions would pass without exercising one.
       # - ConfigTableVoidedArchiveSpec (#4842): the voided-vote archive must count as work credit in the per-schema
       #   aggregate queries AND those queries must survive a schema that hasn't applied evolution 355 (the cross-city
       #   fan-out reads other schemas mid-rollout). Self-seeding in rolled-back transactions, meaningful even here.
@@ -302,7 +305,7 @@ jobs:
       #   data preconditions check for an assignable region rather than a bare street count, because the template's
       #   lone tutorial street belongs to no region and /explore 500s on that (#4748) instead of answering.
       - name: Run gating/auth tests (health dashboard + route auth posture + geodesic distances)
-        run: sbt 'set Test / parallelExecution := false' 'testOnly controllers.HealthDashboardSpec service.HealthServiceSpec controllers.RouteAuthPostureSpec models.street.GeodesicDistanceSpec service.ExploreTutorialRouteSpec controllers.MobileDetectionSpec service.PanoDataServiceSpec models.utils.ConfigTableVoidedArchiveSpec controllers.api.StatsApiSpec controllers.ExploreSubmissionSpec controllers.ValidateSubmissionSpec controllers.ExploreNoImageryRateLimitSpec'
+        run: sbt 'set Test / parallelExecution := false' 'testOnly controllers.HealthDashboardSpec service.HealthServiceSpec controllers.RouteAuthPostureSpec models.street.GeodesicDistanceSpec service.ExploreTutorialRouteSpec controllers.MobileDetectionSpec service.PanoDataServiceSpec service.ActivityBreakdownSpec models.utils.ConfigTableVoidedArchiveSpec controllers.api.StatsApiSpec controllers.ExploreSubmissionSpec controllers.ValidateSubmissionSpec controllers.ExploreNoImageryRateLimitSpec'
         env:
           DATABASE_URL: jdbc:postgresql://localhost:5432/sidewalk
           DATABASE_USER: sidewalk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,9 +289,15 @@ jobs:
       #   data (the landing shows zeros/NaN stats), so both are meaningful on this empty schema.
       # - PanoDataServiceSpec (#4765/#4766): pure unit tests (no DB, no app boot) pinning the label lat/lng estimator
       #   against research-derived constants — costs nothing here and otherwise runs nowhere in CI.
-      # - ActivityBreakdownSpec (#4931): pure unit tests (no DB, no app boot) pinning the rule that keeps AI-role
-      #   output out of the Across Cities "this week" counts. It has to be synthetic — this job's schema has no
-      #   AI-role accounts, so a DB-backed version of these assertions would pass without exercising one.
+      # - ActivityBreakdownSpec (#4931): pure unit tests (no DB, no app boot) pinning the rules that keep AI-role output
+      #   out of the Across Cities "this week" counts, anonymous cookie identities out of its headcounts, and a person
+      #   who mapped in several cities counted once. It has to be synthetic — this job's schema has no AI-role or
+      #   anonymous accounts, so a DB-backed version of these assertions would pass without exercising one.
+      # - ConfigServiceTrendSpec + CityScorecardSpec (#4931): the DB-backed half of the same section. These are what
+      #   connect the new SQL to the summaries above — that volumes sum across cities while headcounts dedupe, that the
+      #   untruncated contributor total bounds the capped list, and that no anonymous cookie id reaches a hover card.
+      #   Shape and invariant assertions rather than data values, so they hold on this job's near-empty schema, and they
+      #   are the only coverage of the per-schema query's column order, which GetResult reads positionally.
       # - ConfigTableVoidedArchiveSpec (#4842): the voided-vote archive must count as work credit in the per-schema
       #   aggregate queries AND those queries must survive a schema that hasn't applied evolution 355 (the cross-city
       #   fan-out reads other schemas mid-rollout). Self-seeding in rolled-back transactions, meaningful even here.
@@ -305,7 +311,7 @@ jobs:
       #   data preconditions check for an assignable region rather than a bare street count, because the template's
       #   lone tutorial street belongs to no region and /explore 500s on that (#4748) instead of answering.
       - name: Run gating/auth tests (health dashboard + route auth posture + geodesic distances)
-        run: sbt 'set Test / parallelExecution := false' 'testOnly controllers.HealthDashboardSpec service.HealthServiceSpec controllers.RouteAuthPostureSpec models.street.GeodesicDistanceSpec service.ExploreTutorialRouteSpec controllers.MobileDetectionSpec service.PanoDataServiceSpec service.ActivityBreakdownSpec models.utils.ConfigTableVoidedArchiveSpec controllers.api.StatsApiSpec controllers.ExploreSubmissionSpec controllers.ValidateSubmissionSpec controllers.ExploreNoImageryRateLimitSpec'
+        run: sbt 'set Test / parallelExecution := false' 'testOnly controllers.HealthDashboardSpec service.HealthServiceSpec controllers.RouteAuthPostureSpec models.street.GeodesicDistanceSpec service.ExploreTutorialRouteSpec controllers.MobileDetectionSpec service.PanoDataServiceSpec service.ActivityBreakdownSpec service.ConfigServiceTrendSpec models.utils.CityScorecardSpec models.utils.ConfigTableVoidedArchiveSpec controllers.api.StatsApiSpec controllers.ExploreSubmissionSpec controllers.ValidateSubmissionSpec controllers.ExploreNoImageryRateLimitSpec'
         env:
           DATABASE_URL: jdbc:postgresql://localhost:5432/sidewalk
           DATABASE_USER: sidewalk

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -585,16 +585,45 @@ class AdminController @Inject() (
   /**
    * Serializes one rolling week-over-week activity window for the Across Cities page (#4758).
    *
+   * Label and validation counts are what people did; AI-role output is reported in its own `ai_*` fields rather than
+   * folded in, because one pipeline account can dwarf every person in the project (#4931).
+   *
    * @param w The current- and prior-window totals for one city, or summed across all of them.
    * @return  The window as snake_case JSON (v3 API convention).
    */
   private def activityWindowJson(w: ActivityWindowSummary): JsObject = Json.obj(
-    "labels_7d"             -> w.labels7d,
-    "labels_prior_7d"       -> w.labelsPrior7d,
-    "validations_7d"        -> w.validations7d,
-    "validations_prior_7d"  -> w.validationsPrior7d,
-    "contributors_7d"       -> w.contributors7d,
-    "contributors_prior_7d" -> w.contributorsPrior7d
+    "labels_7d"               -> w.labels7d,
+    "labels_prior_7d"         -> w.labelsPrior7d,
+    "validations_7d"          -> w.validations7d,
+    "validations_prior_7d"    -> w.validationsPrior7d,
+    "ai_labels_7d"            -> w.aiLabels7d,
+    "ai_labels_prior_7d"      -> w.aiLabelsPrior7d,
+    "ai_validations_7d"       -> w.aiValidations7d,
+    "ai_validations_prior_7d" -> w.aiValidationsPrior7d,
+    "contributors_7d"         -> w.contributors7d,
+    "contributors_prior_7d"   -> w.contributorsPrior7d,
+    "ai_agents_7d"            -> w.aiAgents7d
+  )
+
+  /**
+   * Serializes one city's window plus the contributors it is made of, for the "Most active cities" hover cards (#4931).
+   *
+   * Contributors are named because the page is Owner-gated; these are the same usernames the admin user table shows.
+   *
+   * @param w One city's rolling windows and its (already capped) contributor list.
+   * @return  The window's fields plus a `contributors` array, busiest first.
+   */
+  private def cityActivityWindowJson(w: CityActivityWindow): JsObject = activityWindowJson(w.summary) ++ Json.obj(
+    "contributors" -> JsArray(w.contributors.map { c =>
+      Json.obj(
+        "username"             -> c.username,
+        "is_ai"                -> c.isAi,
+        "labels_7d"            -> c.labels7d,
+        "labels_prior_7d"      -> c.labelsPrior7d,
+        "validations_7d"       -> c.validations7d,
+        "validations_prior_7d" -> c.validationsPrior7d
+      )
+    })
   )
 
   /**
@@ -732,12 +761,30 @@ class AdminController @Inject() (
       })
 
       // Trailing-7-day cross-city daily series for the "this week" bar charts (#4686); zero-filled, today partial.
+      // Each day also carries the breakdown its hover card shows (#4931): the human/AI split, the day's busiest
+      // cities, and the people who were active, so the card is derived from the same rows the bar is summed from.
       val overTimeDaily = JsArray(dailyTrend.map { d =>
         Json.obj(
-          "day"          -> d.day.toString,
-          "labels"       -> d.labels,
-          "validations"  -> d.validations,
-          "active_users" -> d.activeUsers
+          "day"            -> d.point.day.toString,
+          "labels"         -> d.point.labels,
+          "validations"    -> d.point.validations,
+          "active_users"   -> d.point.activeUsers,
+          "ai_labels"      -> d.point.aiLabels,
+          "ai_validations" -> d.point.aiValidations,
+          "ai_agents"      -> d.point.aiAgents,
+          "top_cities"     -> JsArray(d.topCities.map { city =>
+            val cityName: String = cityInfoById.get(city.cityId).map(_.cityNameShort).getOrElse(city.cityId)
+            Json.obj(
+              "city_id"      -> city.cityId,
+              "city_name"    -> cityName,
+              "labels"       -> city.labels,
+              "validations"  -> city.validations,
+              "contributors" -> city.contributors
+            )
+          }),
+          "contributors" -> JsArray(d.contributors.map { c =>
+            Json.obj("username" -> c.username, "is_ai" -> c.isAi, "labels" -> c.labels, "validations" -> c.validations)
+          })
         )
       })
 
@@ -767,7 +814,7 @@ class AdminController @Inject() (
           // merged into `cities` because the scorecard rows already carry labels_7d/validations_7d on a slightly
           // different basis (see getCityActivityWindowsBySchema) and two same-named fields would invite mixing them.
           "window_by_city" -> JsObject(windowSummary.byCity.toSeq.map { case (cityId, w) =>
-            cityId -> activityWindowJson(w)
+            cityId -> cityActivityWindowJson(w)
           }),
           "summary" -> Json.obj(
             "num_cities"                -> scorecards.length,

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -602,6 +602,8 @@ class AdminController @Inject() (
     "ai_validations_prior_7d" -> w.aiValidationsPrior7d,
     "contributors_7d"         -> w.contributors7d,
     "contributors_prior_7d"   -> w.contributorsPrior7d,
+    "anon_sessions_7d"        -> w.anonSessions7d,
+    "anon_sessions_prior_7d"  -> w.anonSessionsPrior7d,
     "ai_agents_7d"            -> w.aiAgents7d
   )
 
@@ -609,15 +611,18 @@ class AdminController @Inject() (
    * Serializes one city's window plus the contributors it is made of, for the "Most active cities" hover cards (#4931).
    *
    * Contributors are named because the page is Owner-gated; these are the same usernames the admin user table shows.
+   * `contributor_total` is how many the capped array was drawn from, which is what lets a card say how many people it
+   * is not showing — counting that from the array itself would be bounded by the cap.
    *
    * @param w One city's rolling windows and its (already capped) contributor list.
-   * @return  The window's fields plus a `contributors` array, busiest first.
+   * @return  The window's fields plus a `contributors` array, busiest first, and the untruncated count.
    */
   private def cityActivityWindowJson(w: CityActivityWindow): JsObject = activityWindowJson(w.summary) ++ Json.obj(
-    "contributors" -> JsArray(w.contributors.map { c =>
+    "contributor_total" -> w.contributorTotal,
+    "contributors"      -> JsArray(w.contributors.map { c =>
       Json.obj(
         "username"             -> c.username,
-        "is_ai"                -> c.isAi,
+        "kind"                 -> c.kind.toString,
         "labels_7d"            -> c.labels7d,
         "labels_prior_7d"      -> c.labelsPrior7d,
         "validations_7d"       -> c.validations7d,
@@ -765,14 +770,16 @@ class AdminController @Inject() (
       // cities, and the people who were active, so the card is derived from the same rows the bar is summed from.
       val overTimeDaily = JsArray(dailyTrend.map { d =>
         Json.obj(
-          "day"            -> d.point.day.toString,
-          "labels"         -> d.point.labels,
-          "validations"    -> d.point.validations,
-          "active_users"   -> d.point.activeUsers,
-          "ai_labels"      -> d.point.aiLabels,
-          "ai_validations" -> d.point.aiValidations,
-          "ai_agents"      -> d.point.aiAgents,
-          "top_cities"     -> JsArray(d.topCities.map { city =>
+          "day"               -> d.point.day.toString,
+          "labels"            -> d.point.labels,
+          "validations"       -> d.point.validations,
+          "contributors"      -> d.point.contributors,
+          "anon_sessions"     -> d.point.anonSessions,
+          "ai_labels"         -> d.point.aiLabels,
+          "ai_validations"    -> d.point.aiValidations,
+          "ai_agents"         -> d.point.aiAgents,
+          "contributor_total" -> d.contributorTotal,
+          "top_cities"        -> JsArray(d.topCities.map { city =>
             val cityName: String = cityInfoById.get(city.cityId).map(_.cityNameShort).getOrElse(city.cityId)
             Json.obj(
               "city_id"      -> city.cityId,
@@ -782,8 +789,13 @@ class AdminController @Inject() (
               "contributors" -> city.contributors
             )
           }),
-          "contributors" -> JsArray(d.contributors.map { c =>
-            Json.obj("username" -> c.username, "is_ai" -> c.isAi, "labels" -> c.labels, "validations" -> c.validations)
+          "contributor_list" -> JsArray(d.contributors.map { c =>
+            Json.obj(
+              "username"    -> c.username,
+              "kind"        -> c.kind.toString,
+              "labels"      -> c.labels,
+              "validations" -> c.validations
+            )
           })
         )
       })
@@ -808,11 +820,13 @@ class AdminController @Inject() (
           "over_time_all_time" -> overTimeAllTime,
           "over_time_daily"    -> overTimeDaily,
           // Rolling week-over-week windows (trailing 7 days vs the 7 before) for the "Today & this week" tiles
-          // (#4758). Contributors are distinct per city per window, summed across cities (no cross-city dedup).
+          // (#4758). Headcounts here are distinct across every city, so they can come out below the same column
+          // summed down `window_by_city` — someone who mapped in three cities is one contributor here.
           "window_summary" -> activityWindowJson(windowSummary.total),
           // The same windows kept per city, for the "Most active cities" table. Emitted as its own block rather than
           // merged into `cities` because the scorecard rows already carry labels_7d/validations_7d on a slightly
-          // different basis (see getCityActivityWindowsBySchema) and two same-named fields would invite mixing them.
+          // different basis (see getCityWindowActivityByUserBySchema) and two same-named fields would invite mixing
+          // them.
           "window_by_city" -> JsObject(windowSummary.byCity.toSeq.map { case (cityId, w) =>
             cityId -> cityActivityWindowJson(w)
           }),

--- a/app/models/utils/ConfigTable.scala
+++ b/app/models/utils/ConfigTable.scala
@@ -4,7 +4,14 @@ import com.google.inject.ImplementedBy
 import models.street.StreetEdgeTableDef
 import models.utils.MyPostgresProfile.api._
 import play.api.db.slick.{DatabaseConfigProvider, HasDatabaseConfigProvider}
-import service.{ActivityWindowSummary, AggregateStats, CityScorecard, DailyPoint, LabelTypeStats, WeeklyPoint}
+import service.{
+  AggregateStats,
+  CityScorecard,
+  ContributorWindowActivity,
+  DailyContributorActivity,
+  LabelTypeStats,
+  WeeklyPoint
+}
 import slick.jdbc.GetResult
 
 import java.time.{LocalDate, OffsetDateTime, ZoneOffset}
@@ -730,27 +737,49 @@ class ConfigTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvi
   }
 
   /**
-   * Daily label/validation/active-user volume for one city's trailing window, for the "this week" bar charts (#4686).
+   * The `ai_users` CTE body: every user id carrying the shared `AI` role.
+   *
+   * AI authorship is a `sidewalk_login` role, not anything in the city schema, so every per-schema activity query
+   * resolves it the same way. `DISTINCT` matters — a user with more than one role row would otherwise fan its
+   * activity out through the join and double-count it.
+   */
+  private val aiUsersCte: String =
+    """ai_users AS (
+          SELECT DISTINCT user_role.user_id
+          FROM sidewalk_login.user_role
+          INNER JOIN sidewalk_login.role ON user_role.role_id = role.role_id
+          WHERE role.role = 'AI'
+      )"""
+
+  /**
+   * Per-person daily label/validation volume for one city's trailing window, for the "this week" bar charts (#4686)
+   * and their hover breakdowns (#4931).
    *
    * The daily counterpart of [[getCityWeeklyTrendBySchema]]: identical activity definition and exclusions, bucketed by
-   * calendar day in Pacific time. Days with no activity are absent (the service zero-fills the window). The time bound
-   * is a raw-timestamp comparison one day wider than the window so it stays index-friendly (no per-row time-zone
-   * conversion in the WHERE); the service trims to the exact Pacific-day window.
+   * calendar day in Pacific time. Reporting at (day, person) grain rather than as day totals lets the service derive
+   * the bars, the human/AI split, and the named contributor list from one scan, so a bar can never disagree with the
+   * card that explains it. Days with no activity are absent (the service zero-fills the window). The time bound is a
+   * raw-timestamp comparison one day wider than the window so it stays index-friendly (no per-row time-zone conversion
+   * in the WHERE); the service trims to the exact Pacific-day window.
+   *
+   * The username join is a LEFT JOIN so a person missing from `sidewalk_user` still contributes their counts to the
+   * day's totals (which the service sums from these rows) instead of vanishing from them.
    *
    * @param schema The database schema to query.
    * @param days   Trailing calendar days to include (the last of them being today, partial).
-   * @return       DBIO yielding (day, labels, validations, activeUsers), ascending by day.
+   * @return       DBIO yielding one row per (day, person), ascending by day.
    */
-  def getCityDailyTrendBySchema(schema: String, days: Int): DBIO[Seq[DailyPoint]] = {
-    implicit val getResult: GetResult[DailyPoint] =
-      GetResult(r => DailyPoint(LocalDate.parse(r.nextString()), r.nextInt(), r.nextInt(), r.nextInt()))
+  def getCityDailyActivityByUserBySchema(schema: String, days: Int): DBIO[Seq[DailyContributorActivity]] = {
+    implicit val getResult: GetResult[DailyContributorActivity] =
+      GetResult(r =>
+        DailyContributorActivity(
+          LocalDate.parse(r.nextString()), r.nextString(), r.nextString(), r.nextBoolean(), r.nextInt(), r.nextInt()
+        )
+      )
 
     sql"""
-      SELECT CAST(DATE_TRUNC('day', activity_ts AT TIME ZONE 'US/Pacific')::date AS TEXT) AS day,
-             COUNT(*) FILTER (WHERE kind = 'label')      AS labels,
-             COUNT(*) FILTER (WHERE kind = 'validation') AS validations,
-             COUNT(DISTINCT activity_user_id)            AS active_users
-      FROM (
+      WITH #$aiUsersCte,
+      activity AS (
           SELECT label.time_created AS activity_ts, label.user_id AS activity_user_id, 'label' AS kind
           FROM "#$schema".label
           INNER JOIN "#$schema".user_stat ON label.user_id = user_stat.user_id
@@ -762,43 +791,57 @@ class ConfigTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvi
           INNER JOIN "#$schema".user_stat ON label_validation.user_id = user_stat.user_id
           WHERE NOT user_stat.excluded
               AND label_validation.end_timestamp >= NOW() - ((${days} + 1) * INTERVAL '1 day')
-      ) AS activity
-      GROUP BY day
-      ORDER BY day ASC;
-    """.as[DailyPoint]
+      ),
+      per_day_user AS (
+          SELECT DATE_TRUNC('day', activity_ts AT TIME ZONE 'US/Pacific')::date AS day, activity_user_id,
+                 COUNT(*) FILTER (WHERE kind = 'label')      AS labels,
+                 COUNT(*) FILTER (WHERE kind = 'validation') AS validations
+          FROM activity
+          GROUP BY day, activity_user_id
+      )
+      SELECT CAST(per_day_user.day AS TEXT), per_day_user.activity_user_id,
+             COALESCE(sidewalk_user.username, ''), (ai_users.user_id IS NOT NULL),
+             per_day_user.labels, per_day_user.validations
+      FROM per_day_user
+      LEFT JOIN sidewalk_login.sidewalk_user ON per_day_user.activity_user_id = sidewalk_user.user_id
+      LEFT JOIN ai_users ON per_day_user.activity_user_id = ai_users.user_id
+      ORDER BY per_day_user.day ASC;
+    """.as[DailyContributorActivity]
   }
 
   /**
-   * Rolling week-over-week activity for one city: the trailing 7 days vs the 7 before, for the "Today & this week"
-   * tiles and "Most active cities" table on the Across Cities page (#4758).
+   * Per-person rolling week-over-week activity for one city — the trailing 7 days vs the 7 before — behind the
+   * "Today & this week" tiles, the "Most active cities" table, and their hover breakdowns (#4758, #4931).
    *
    * One bounded scan of the trailing 14 days using the same activity union and exclusions as
-   * [[getCityDailyTrendBySchema]], split into the current and prior window by FILTER clauses. Bounds compare raw
-   * timestamps against NOW() so both legs stay on their btree indexes (label_time_created_idx /
+   * [[getCityDailyActivityByUserBySchema]], split into the current and prior window by FILTER clauses. Bounds compare
+   * raw timestamps against NOW() so both legs stay on their btree indexes (label_time_created_idx /
    * label_validation_end_timestamp_idx, evolution 346). Windows are exact rolling 168-hour spans, deliberately NOT
    * Pacific calendar days, so these totals line up with each other rather than the daily-trend chart's day buckets.
+   *
+   * Reporting at person grain rather than as city totals is what lets the page name contributors, split human from AI
+   * work, and still guarantee that a headline count equals the breakdown that explains it — the service sums these
+   * same rows for both. The username join is a LEFT JOIN so a person missing from `sidewalk_user` still contributes
+   * their counts to those totals.
    *
    * These label counts run ~0.1% above the scorecard's labels_7d, which additionally joins through `audit_task` and
    * drops the tutorial street. Both are defensible; the page keeps each table on a single basis so a level and its
    * week-over-week delta never mix the two.
    *
    * @param schema The database schema to query.
-   * @return       DBIO yielding one [[ActivityWindowSummary]]; contributors are counted distinct within each window.
+   * @return       DBIO yielding one row per person with activity in either window, busiest first.
    */
-  def getCityActivityWindowsBySchema(schema: String): DBIO[ActivityWindowSummary] = {
-    implicit val getResult: GetResult[ActivityWindowSummary] =
+  def getCityWindowActivityByUserBySchema(schema: String): DBIO[Seq[ContributorWindowActivity]] = {
+    implicit val getResult: GetResult[ContributorWindowActivity] =
       GetResult(r =>
-        ActivityWindowSummary(r.nextInt(), r.nextInt(), r.nextInt(), r.nextInt(), r.nextInt(), r.nextInt())
+        ContributorWindowActivity(
+          r.nextString(), r.nextString(), r.nextBoolean(), r.nextInt(), r.nextInt(), r.nextInt(), r.nextInt()
+        )
       )
 
     sql"""
-      SELECT COUNT(*) FILTER (WHERE kind = 'label' AND activity_ts >= NOW() - INTERVAL '7 days')      AS labels_7d,
-             COUNT(*) FILTER (WHERE kind = 'label' AND activity_ts < NOW() - INTERVAL '7 days')       AS labels_prior_7d,
-             COUNT(*) FILTER (WHERE kind = 'validation' AND activity_ts >= NOW() - INTERVAL '7 days') AS validations_7d,
-             COUNT(*) FILTER (WHERE kind = 'validation' AND activity_ts < NOW() - INTERVAL '7 days')  AS validations_prior_7d,
-             COUNT(DISTINCT activity_user_id) FILTER (WHERE activity_ts >= NOW() - INTERVAL '7 days') AS contributors_7d,
-             COUNT(DISTINCT activity_user_id) FILTER (WHERE activity_ts < NOW() - INTERVAL '7 days')  AS contributors_prior_7d
-      FROM (
+      WITH #$aiUsersCte,
+      activity AS (
           SELECT label.time_created AS activity_ts, label.user_id AS activity_user_id, 'label' AS kind
           FROM "#$schema".label
           INNER JOIN "#$schema".user_stat ON label.user_id = user_stat.user_id
@@ -810,8 +853,23 @@ class ConfigTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvi
           INNER JOIN "#$schema".user_stat ON label_validation.user_id = user_stat.user_id
           WHERE NOT user_stat.excluded
               AND label_validation.end_timestamp >= NOW() - INTERVAL '14 days'
-      ) AS activity;
-    """.as[ActivityWindowSummary].head
+      ),
+      per_user AS (
+          SELECT activity_user_id,
+                 COUNT(*) FILTER (WHERE kind = 'label' AND activity_ts >= NOW() - INTERVAL '7 days')      AS labels_7d,
+                 COUNT(*) FILTER (WHERE kind = 'label' AND activity_ts < NOW() - INTERVAL '7 days')       AS labels_prior_7d,
+                 COUNT(*) FILTER (WHERE kind = 'validation' AND activity_ts >= NOW() - INTERVAL '7 days') AS validations_7d,
+                 COUNT(*) FILTER (WHERE kind = 'validation' AND activity_ts < NOW() - INTERVAL '7 days')  AS validations_prior_7d
+          FROM activity
+          GROUP BY activity_user_id
+      )
+      SELECT per_user.activity_user_id, COALESCE(sidewalk_user.username, ''), (ai_users.user_id IS NOT NULL),
+             per_user.labels_7d, per_user.labels_prior_7d, per_user.validations_7d, per_user.validations_prior_7d
+      FROM per_user
+      LEFT JOIN sidewalk_login.sidewalk_user ON per_user.activity_user_id = sidewalk_user.user_id
+      LEFT JOIN ai_users ON per_user.activity_user_id = ai_users.user_id
+      ORDER BY per_user.labels_7d + per_user.validations_7d DESC;
+    """.as[ContributorWindowActivity]
   }
 
   /**

--- a/app/models/utils/ConfigTable.scala
+++ b/app/models/utils/ConfigTable.scala
@@ -7,6 +7,7 @@ import play.api.db.slick.{DatabaseConfigProvider, HasDatabaseConfigProvider}
 import service.{
   AggregateStats,
   CityScorecard,
+  ContributorKind,
   ContributorWindowActivity,
   DailyContributorActivity,
   LabelTypeStats,
@@ -737,19 +738,46 @@ class ConfigTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvi
   }
 
   /**
-   * The `ai_users` CTE body: every user id carrying the shared `AI` role.
+   * The `account_kinds` CTE body: how each already-selected contributor's activity should be attributed.
    *
-   * AI authorship is a `sidewalk_login` role, not anything in the city schema, so every per-schema activity query
-   * resolves it the same way. `DISTINCT` matters — a user with more than one role row would otherwise fan its
-   * activity out through the join and double-count it.
+   * Authorship kind is a `sidewalk_login` role, not anything in the city schema, so every per-schema activity query
+   * resolves it the same way: `AI` marks pipeline output, `Anonymous` marks a per-cookie identity that is not
+   * necessarily a distinct person, and everything else is a registered account.
+   *
+   * **This CTE must be driven from the caller's already-narrowed set of active users, which is why it takes the
+   * driving CTE's name rather than being a constant.** `user_role` runs to millions of rows and is ~99.9% `Anonymous`
+   * (5.73M of 5.74M in prod), so a body that grouped every user — or even filtered on the role names — would aggregate
+   * millions of rows, and these queries run once per city schema across ~56 schemas per cache refresh. Restricting to
+   * the handful of users active in the window keeps it index lookups on `user_role_user_id_idx` instead.
+   *
+   * `BOOL_OR` + `GROUP BY` rather than a join on role name: a user with several role rows must yield exactly one row
+   * here, or the join would fan their activity out and double-count it.
+   *
+   * @param activityCte Name of the preceding CTE holding the active users, with an `activity_user_id` column.
+   * @return            The CTE body, for interpolation into a `WITH` list after `activityCte`.
    */
-  private val aiUsersCte: String =
-    """ai_users AS (
-          SELECT DISTINCT user_role.user_id
+  private def accountKindsCte(activityCte: String): String =
+    s"""account_kinds AS (
+          SELECT user_role.user_id,
+                 BOOL_OR(role.role = 'AI')        AS is_ai,
+                 BOOL_OR(role.role = 'Anonymous') AS is_anonymous
           FROM sidewalk_login.user_role
           INNER JOIN sidewalk_login.role ON user_role.role_id = role.role_id
-          WHERE role.role = 'AI'
+          WHERE user_role.user_id IN (SELECT activity_user_id FROM $activityCte)
+          GROUP BY user_role.user_id
       )"""
+
+  /**
+   * The `account_kind` SELECT expression pairing with [[accountKindsCte]].
+   *
+   * `AI` outranks `Anonymous` so an account carrying both resolves deterministically to pipeline output. A contributor
+   * with no `user_role` row at all leaves both flags NULL and falls through to `registered`, matching how the rest of
+   * the app treats a role-less account.
+   */
+  private val accountKindSelect: String =
+    """CASE WHEN account_kinds.is_ai THEN 'ai'
+                  WHEN account_kinds.is_anonymous THEN 'anonymous'
+                  ELSE 'registered' END"""
 
   /**
    * Per-person daily label/validation volume for one city's trailing window, for the "this week" bar charts (#4686)
@@ -773,13 +801,13 @@ class ConfigTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvi
     implicit val getResult: GetResult[DailyContributorActivity] =
       GetResult(r =>
         DailyContributorActivity(
-          LocalDate.parse(r.nextString()), r.nextString(), r.nextString(), r.nextBoolean(), r.nextInt(), r.nextInt()
+          LocalDate.parse(r.nextString()), r.nextString(), r.nextString(), ContributorKind.withName(r.nextString()),
+          r.nextInt(), r.nextInt()
         )
       )
 
     sql"""
-      WITH #$aiUsersCte,
-      activity AS (
+      WITH activity AS (
           SELECT label.time_created AS activity_ts, label.user_id AS activity_user_id, 'label' AS kind
           FROM "#$schema".label
           INNER JOIN "#$schema".user_stat ON label.user_id = user_stat.user_id
@@ -798,14 +826,15 @@ class ConfigTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvi
                  COUNT(*) FILTER (WHERE kind = 'validation') AS validations
           FROM activity
           GROUP BY day, activity_user_id
-      )
+      ),
+      #${accountKindsCte("per_day_user")}
       SELECT CAST(per_day_user.day AS TEXT), per_day_user.activity_user_id,
-             COALESCE(sidewalk_user.username, ''), (ai_users.user_id IS NOT NULL),
+             COALESCE(sidewalk_user.username, ''), #$accountKindSelect,
              per_day_user.labels, per_day_user.validations
       FROM per_day_user
       LEFT JOIN sidewalk_login.sidewalk_user ON per_day_user.activity_user_id = sidewalk_user.user_id
-      LEFT JOIN ai_users ON per_day_user.activity_user_id = ai_users.user_id
-      ORDER BY per_day_user.day ASC;
+      LEFT JOIN account_kinds ON per_day_user.activity_user_id = account_kinds.user_id
+      ORDER BY per_day_user.day ASC, per_day_user.activity_user_id ASC;
     """.as[DailyContributorActivity]
   }
 
@@ -835,13 +864,13 @@ class ConfigTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvi
     implicit val getResult: GetResult[ContributorWindowActivity] =
       GetResult(r =>
         ContributorWindowActivity(
-          r.nextString(), r.nextString(), r.nextBoolean(), r.nextInt(), r.nextInt(), r.nextInt(), r.nextInt()
+          r.nextString(), r.nextString(), ContributorKind.withName(r.nextString()), r.nextInt(), r.nextInt(),
+          r.nextInt(), r.nextInt()
         )
       )
 
     sql"""
-      WITH #$aiUsersCte,
-      activity AS (
+      WITH activity AS (
           SELECT label.time_created AS activity_ts, label.user_id AS activity_user_id, 'label' AS kind
           FROM "#$schema".label
           INNER JOIN "#$schema".user_stat ON label.user_id = user_stat.user_id
@@ -862,13 +891,14 @@ class ConfigTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvi
                  COUNT(*) FILTER (WHERE kind = 'validation' AND activity_ts < NOW() - INTERVAL '7 days')  AS validations_prior_7d
           FROM activity
           GROUP BY activity_user_id
-      )
-      SELECT per_user.activity_user_id, COALESCE(sidewalk_user.username, ''), (ai_users.user_id IS NOT NULL),
+      ),
+      #${accountKindsCte("per_user")}
+      SELECT per_user.activity_user_id, COALESCE(sidewalk_user.username, ''), #$accountKindSelect,
              per_user.labels_7d, per_user.labels_prior_7d, per_user.validations_7d, per_user.validations_prior_7d
       FROM per_user
       LEFT JOIN sidewalk_login.sidewalk_user ON per_user.activity_user_id = sidewalk_user.user_id
-      LEFT JOIN ai_users ON per_user.activity_user_id = ai_users.user_id
-      ORDER BY per_user.labels_7d + per_user.validations_7d DESC;
+      LEFT JOIN account_kinds ON per_user.activity_user_id = account_kinds.user_id
+      ORDER BY per_user.labels_7d + per_user.validations_7d DESC, per_user.activity_user_id ASC;
     """.as[ContributorWindowActivity]
   }
 

--- a/app/service/ConfigService.scala
+++ b/app/service/ConfigService.scala
@@ -137,40 +137,191 @@ case class AggregateStats(
 case class WeeklyPoint(weekStart: LocalDate, labels: Int, validations: Int, activeUsers: Int, newUsers: Int)
 
 /**
- * One day's contribution volume summed across cities, for the Across Cities "this week" bar charts (#4686).
+ * One person's contribution to one city on one day, the grain the "this week" bar charts are built from (#4931).
  *
- * @param day          Calendar day (Pacific).
- * @param labels       Non-tutorial, non-excluded labels created that day.
- * @param validations  Validations by non-excluded users that day.
- * @param activeUsers  Distinct non-excluded users who labeled or validated that day, summed per city (a person active
- *                     in two cities is counted in each).
+ * @param day         Calendar day (Pacific).
+ * @param userId      The contributor's user id, which identifies them across cities when their days are merged.
+ * @param username    Their display name, empty when `sidewalk_login` has no row for the id.
+ * @param isAi        Whether the account carries the shared `AI` role, i.e. this is pipeline output, not a person.
+ * @param labels      Non-tutorial, non-excluded labels they created that day.
+ * @param validations Validations they submitted that day.
  */
-case class DailyPoint(day: LocalDate, labels: Int, validations: Int, activeUsers: Int)
+case class DailyContributorActivity(
+    day: LocalDate,
+    userId: String,
+    username: String,
+    isAi: Boolean,
+    labels: Int,
+    validations: Int
+)
+
+/**
+ * One person's contribution to one city across both rolling weekly windows (#4931).
+ *
+ * @param userId              The contributor's user id.
+ * @param username            Their display name, empty when `sidewalk_login` has no row for the id.
+ * @param isAi                Whether the account carries the shared `AI` role.
+ * @param labels7d            Labels they created in the trailing 7 days.
+ * @param labelsPrior7d       Labels they created 7–14 days ago.
+ * @param validations7d       Validations they submitted in the trailing 7 days.
+ * @param validationsPrior7d  Validations they submitted 7–14 days ago.
+ */
+case class ContributorWindowActivity(
+    userId: String,
+    username: String,
+    isAi: Boolean,
+    labels7d: Int,
+    labelsPrior7d: Int,
+    validations7d: Int,
+    validationsPrior7d: Int
+)
+
+/**
+ * One day's contribution volume summed across cities, for the Across Cities "this week" bar charts (#4686, #4931).
+ *
+ * Human and AI work is counted separately rather than pooled: one AI account can out-produce every person in the
+ * project on a given day, so a blended total describes the pipeline's schedule, not the community's week.
+ *
+ * @param day           Calendar day (Pacific).
+ * @param labels        Non-tutorial, non-excluded labels people created that day.
+ * @param validations   Validations people submitted that day.
+ * @param activeUsers   Distinct people who labeled or validated that day, summed per city (a person active in two
+ *                      cities is counted in each).
+ * @param aiLabels      Labels created that day by accounts holding the `AI` role.
+ * @param aiValidations Validations submitted that day by accounts holding the `AI` role.
+ * @param aiAgents      Distinct AI accounts active that day, summed per city.
+ */
+case class DailyPoint(
+    day: LocalDate,
+    labels: Int,
+    validations: Int,
+    activeUsers: Int,
+    aiLabels: Int,
+    aiValidations: Int,
+    aiAgents: Int
+)
+
+/**
+ * One day's cross-city activity: the volumes behind that day's bars, plus the breakdown its hover card shows (#4931).
+ *
+ * @param point        The day's totals.
+ * @param topCities    The day's busiest cities, most human activity first.
+ * @param contributors The day's busiest contributors, merged across cities so a person active in two shows up once.
+ */
+case class DailyActivity(point: DailyPoint, topCities: Seq[CityDayTotals], contributors: Seq[DailyContributor])
+
+/**
+ * One city's share of a single day, for the "top cities" line of a day's hover card (#4931).
+ *
+ * @param cityId       The city id (e.g. "seattle-wa").
+ * @param labels       Labels people created there that day.
+ * @param validations  Validations people submitted there that day.
+ * @param contributors Distinct people active there that day.
+ */
+case class CityDayTotals(cityId: String, labels: Int, validations: Int, contributors: Int)
+
+/**
+ * One contributor's day, merged across every city they were active in (#4931).
+ *
+ * @param username    Their display name, empty when `sidewalk_login` has no row for the id.
+ * @param isAi        Whether the account carries the shared `AI` role.
+ * @param labels      Labels they created that day.
+ * @param validations Validations they submitted that day.
+ */
+case class DailyContributor(username: String, isAi: Boolean, labels: Int, validations: Int)
 
 /**
  * Cross-city rolling week-over-week activity — the trailing 7 days vs the 7 before — for the "Today & this week"
  * tiles on the Across Cities page (#4758).
  *
  * Windows are exact rolling 168-hour spans (the same basis as [[CityScorecard]]'s labels7d/validations7d), not
- * Pacific calendar days, so the tiles agree with the per-city 7d columns. Same activity definition and exclusions as
- * [[DailyPoint]].
+ * Pacific calendar days, so the tiles agree with the per-city 7d columns. Same activity definition, exclusions, and
+ * human/AI separation as [[DailyPoint]]: the label and validation counts are what people did, with AI output reported
+ * beside them, and contributors are people (`AI`-role accounts are counted as agents instead).
  *
- * @param labels7d            Labels created in the trailing 7 days.
- * @param labelsPrior7d       Labels created 7–14 days ago.
- * @param validations7d       Validations in the trailing 7 days.
- * @param validationsPrior7d  Validations 7–14 days ago.
- * @param contributors7d      Distinct users who labeled or validated in the trailing 7 days, summed per city (a
- *                            person active in two cities is counted in each, as with [[DailyPoint]] active users).
- * @param contributorsPrior7d Same, for 7–14 days ago.
+ * @param labels7d              Labels people created in the trailing 7 days.
+ * @param labelsPrior7d         Labels people created 7–14 days ago.
+ * @param validations7d         Validations people submitted in the trailing 7 days.
+ * @param validationsPrior7d    Validations people submitted 7–14 days ago.
+ * @param aiLabels7d            Labels created in the trailing 7 days by `AI`-role accounts.
+ * @param aiLabelsPrior7d       Labels created 7–14 days ago by `AI`-role accounts.
+ * @param aiValidations7d       Validations submitted in the trailing 7 days by `AI`-role accounts.
+ * @param aiValidationsPrior7d  Validations submitted 7–14 days ago by `AI`-role accounts.
+ * @param contributors7d        Distinct people who labeled or validated in the trailing 7 days, summed per city (a
+ *                              person active in two cities is counted in each, as with [[DailyPoint]] active users).
+ * @param contributorsPrior7d   Same, for 7–14 days ago.
+ * @param aiAgents7d            Distinct `AI`-role accounts active in the trailing 7 days, summed per city.
  */
 case class ActivityWindowSummary(
     labels7d: Int,
     labelsPrior7d: Int,
     validations7d: Int,
     validationsPrior7d: Int,
+    aiLabels7d: Int,
+    aiLabelsPrior7d: Int,
+    aiValidations7d: Int,
+    aiValidationsPrior7d: Int,
     contributors7d: Int,
-    contributorsPrior7d: Int
+    contributorsPrior7d: Int,
+    aiAgents7d: Int
 )
+
+object ActivityWindowSummary {
+
+  /** A window with nothing in it — the fallback for a city whose schema read failed, and the fold's starting point. */
+  val empty: ActivityWindowSummary = ActivityWindowSummary(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+
+  /**
+   * Rolls one city's per-person rows up into its window totals.
+   *
+   * Every count the page shows comes from this one derivation, so a headline number and the contributor list behind it
+   * can't drift apart. Contributor counts are distinct people with activity in that window; AI accounts are excluded
+   * from them and counted as agents.
+   *
+   * @param rows One city's contributors, as returned by the DAO.
+   * @return     That city's window totals.
+   */
+  def fromContributors(rows: Seq[ContributorWindowActivity]): ActivityWindowSummary = {
+    val (ai, people) = rows.partition(_.isAi)
+    ActivityWindowSummary(
+      labels7d = people.map(_.labels7d).sum,
+      labelsPrior7d = people.map(_.labelsPrior7d).sum,
+      validations7d = people.map(_.validations7d).sum,
+      validationsPrior7d = people.map(_.validationsPrior7d).sum,
+      aiLabels7d = ai.map(_.labels7d).sum,
+      aiLabelsPrior7d = ai.map(_.labelsPrior7d).sum,
+      aiValidations7d = ai.map(_.validations7d).sum,
+      aiValidationsPrior7d = ai.map(_.validationsPrior7d).sum,
+      contributors7d = people.count(c => c.labels7d + c.validations7d > 0),
+      contributorsPrior7d = people.count(c => c.labelsPrior7d + c.validationsPrior7d > 0),
+      aiAgents7d = ai.count(c => c.labels7d + c.validations7d > 0)
+    )
+  }
+
+  /** Adds two windows field by field, for summing per-city windows into the cross-city total. */
+  def add(a: ActivityWindowSummary, b: ActivityWindowSummary): ActivityWindowSummary = ActivityWindowSummary(
+    a.labels7d + b.labels7d,
+    a.labelsPrior7d + b.labelsPrior7d,
+    a.validations7d + b.validations7d,
+    a.validationsPrior7d + b.validationsPrior7d,
+    a.aiLabels7d + b.aiLabels7d,
+    a.aiLabelsPrior7d + b.aiLabelsPrior7d,
+    a.aiValidations7d + b.aiValidations7d,
+    a.aiValidationsPrior7d + b.aiValidationsPrior7d,
+    a.contributors7d + b.contributors7d,
+    a.contributorsPrior7d + b.contributorsPrior7d,
+    a.aiAgents7d + b.aiAgents7d
+  )
+}
+
+/**
+ * One city's rolling weekly windows, with the people whose work they are made of (#4758, #4931).
+ *
+ * @param summary      The city's window totals.
+ * @param contributors Its contributors, busiest first and capped at [[ConfigService.WindowContributorLimit]], for the
+ *                     "Most active cities" hover cards.
+ */
+case class CityActivityWindow(summary: ActivityWindowSummary, contributors: Seq[ContributorWindowActivity])
 
 /**
  * Rolling week-over-week activity for every available city plus the cross-city total (#4758).
@@ -181,7 +332,7 @@ case class ActivityWindowSummary(
  * @param byCity Per-city windows, keyed by city id. Cities whose query failed carry zeros rather than being dropped.
  * @param total  The per-city rows summed; contributor counts are summed, not deduplicated across cities.
  */
-case class CrossCityActivityWindows(byCity: Map[String, ActivityWindowSummary], total: ActivityWindowSummary)
+case class CrossCityActivityWindows(byCity: Map[String, CityActivityWindow], total: ActivityWindowSummary)
 
 /**
  * One city's summary row for the cross-city "Across Cities" admin overview (#4329).
@@ -341,6 +492,65 @@ object ConfigService {
 
   /** A city with activity within this many days is "active". */
   val ActiveWithinDays: Long = 30
+
+  /**
+   * How many contributors each city ships for its "Most active cities" hover cards (#4931).
+   *
+   * Generous rather than tight: the cards rank by labels in one place and by validations in another, so a cap that
+   * only just covered one list would drop people from the other. Across all 56 deployments a busy week runs to a few
+   * dozen contributors total, so this bounds a pathological mapathon rather than trimming the normal case.
+   */
+  val WindowContributorLimit: Int = 25
+
+  /** How many cities a day's hover card lists. The card draws every one it is sent, so this is the only cap. */
+  val DayTopCityLimit: Int = 3
+
+  /** How many contributors a day's hover card lists. */
+  val DayContributorLimit: Int = 8
+
+  /**
+   * Rolls one day's per-city, per-person rows up into the day's bars and the breakdown behind them (#4931).
+   *
+   * Every figure the day's hover card shows is derived here, from the same rows the bars are summed from, so the card
+   * can't contradict the bar it explains. Contributors merge across cities (one person, one entry, counts added up),
+   * while the day's `activeUsers` stays per-city-summed to match the counting basis the rest of the section uses.
+   *
+   * @param day  The Pacific calendar day being summarized.
+   * @param rows That day's (cityId, contributor-activity) rows; empty for a day nobody was active.
+   * @return     The day's totals, its busiest cities, and its busiest contributors.
+   */
+  def summarizeDay(day: LocalDate, rows: Seq[(String, DailyContributorActivity)]): DailyActivity = {
+    val (aiRows, peopleRows) = rows.partition(_._2.isAi)
+    val point                = DailyPoint(
+      day = day,
+      labels = peopleRows.map(_._2.labels).sum,
+      validations = peopleRows.map(_._2.validations).sum,
+      activeUsers = peopleRows.size,
+      aiLabels = aiRows.map(_._2.labels).sum,
+      aiValidations = aiRows.map(_._2.validations).sum,
+      aiAgents = aiRows.size
+    )
+    // Cities are ranked and listed by what people did there; AI output belongs to the pipeline, not to a community.
+    val topCities = peopleRows
+      .groupBy(_._1)
+      .map { case (cityId, cityRows) =>
+        CityDayTotals(cityId, cityRows.map(_._2.labels).sum, cityRows.map(_._2.validations).sum, cityRows.size)
+      }
+      .toSeq
+      .sortBy(city => -(city.labels + city.validations))
+      .take(DayTopCityLimit)
+    val contributors = rows
+      .groupBy(_._2.userId)
+      .values
+      .map { userRows =>
+        val first = userRows.head._2
+        DailyContributor(first.username, first.isAi, userRows.map(_._2.labels).sum, userRows.map(_._2.validations).sum)
+      }
+      .toSeq
+      .sortBy(c => -(c.labels + c.validations))
+      .take(DayContributorLimit)
+    DailyActivity(point, topCities, contributors)
+  }
 
   /**
    * The (table, column) pairs the global leaderboard's cross-schema query reads (#3719).
@@ -522,18 +732,21 @@ trait ConfigService {
 
   /**
    * Returns the daily label/validation/active-user volume summed across all available cities for the trailing window
-   * (#4686), for the "this week" bar charts. Same definitions and exclusions as [[getCrossCityWeeklyTrend]]; active
-   * users are summed per city, so a person active in multiple cities is counted in each (documented on the page).
+   * (#4686), plus the busiest cities and named contributors behind each day (#4931), for the "this week" bar charts
+   * and their hover cards. Same definitions and exclusions as [[getCrossCityWeeklyTrend]]; active users are summed per
+   * city, so a person active in multiple cities is counted in each (documented on the page), while the contributor
+   * list merges their cities so each person appears once.
    *
    * @param days Trailing calendar days (Pacific) to include; the last day is today, so its counts are partial.
-   * @return     Exactly `days` points, zero-filled and ascending by day.
+   * @return     Exactly `days` days, zero-filled and ascending by day.
    */
-  def getCrossCityDailyTrend(days: Int): Future[Seq[DailyPoint]]
+  def getCrossCityDailyTrend(days: Int): Future[Seq[DailyActivity]]
 
   /**
    * Returns rolling week-over-week activity across all available cities (#4758): the trailing 7 days vs the 7 before,
-   * for the "Today & this week" tiles and the "Most active cities" table. Same activity definition and exclusions as
-   * [[getCrossCityDailyTrend]]; contributors are distinct per city per window and summed across cities.
+   * for the "Today & this week" tiles and the "Most active cities" table, each city carrying the contributors its
+   * counts are made of (#4931). Same activity definition and exclusions as [[getCrossCityDailyTrend]]; contributors
+   * are distinct per city per window and summed across cities.
    *
    * @return Per-city windows plus their cross-city total.
    */
@@ -1040,28 +1253,27 @@ class ConfigServiceImpl @Inject() (
     }
   }
 
-  def getCrossCityDailyTrend(days: Int): Future[Seq[DailyPoint]] = {
-    cacheApi.getOrElseUpdate[Seq[DailyPoint]](s"getCrossCityDailyTrend_$days", Duration(10, "minutes")) {
+  def getCrossCityDailyTrend(days: Int): Future[Seq[DailyActivity]] = {
+    cacheApi.getOrElseUpdate[Seq[DailyActivity]](s"getCrossCityDailyTrend_$days", Duration(10, "minutes")) {
       availableCityIds().flatMap { availableCities =>
         val perCityFutures = availableCities.map { cityId =>
-          db.run(configTable.getCityDailyTrendBySchema(getCitySchema(cityId), days))
+          db.run(configTable.getCityDailyActivityByUserBySchema(getCitySchema(cityId), days))
             .recover { case e: Exception =>
               logger.warn(s"Failed to fetch daily trend for city $cityId: ${e.getMessage}")
-              Seq.empty[DailyPoint]
+              Seq.empty[DailyContributorActivity]
             }
+            .map(cityId -> _)
         }
         Future.sequence(perCityFutures).map { perCity =>
-          val byDay = perCity.flatten
-            .groupBy(_.day)
-            .map { case (day, pts) =>
-              day -> DailyPoint(day, pts.map(_.labels).sum, pts.map(_.validations).sum, pts.map(_.activeUsers).sum)
-            }
+          val rowsByDay: Map[LocalDate, Seq[(String, DailyContributorActivity)]] = perCity
+            .flatMap { case (cityId, rows) => rows.map(cityId -> _) }
+            .groupBy(_._2.day)
           // Zero-fill the exact trailing window so the page always gets `days` bars. Iterating the window (rather
           // than the query results) also drops any extra day the DAO's index-friendly coarse bound let through.
           val today = LocalDate.now(ZoneId.of("US/Pacific"))
           (0 until days).map { i =>
             val day = today.minusDays((days - 1 - i).toLong)
-            byDay.getOrElse(day, DailyPoint(day, 0, 0, 0))
+            ConfigService.summarizeDay(day, rowsByDay.getOrElse(day, Seq.empty))
           }
         }
       }
@@ -1072,23 +1284,23 @@ class ConfigServiceImpl @Inject() (
     cacheApi.getOrElseUpdate[CrossCityActivityWindows]("getCrossCityActivitySummary", Duration(10, "minutes")) {
       availableCityIds().flatMap { availableCities =>
         val perCityFutures = availableCities.map { cityId =>
-          db.run(configTable.getCityActivityWindowsBySchema(getCitySchema(cityId)))
+          db.run(configTable.getCityWindowActivityByUserBySchema(getCitySchema(cityId)))
             .recover { case e: Exception =>
               logger.warn(s"Failed to fetch activity windows for city $cityId: ${e.getMessage}")
-              ActivityWindowSummary(0, 0, 0, 0, 0, 0)
+              Seq.empty[ContributorWindowActivity]
             }
-            .map(cityId -> _)
+            .map { rows =>
+              // The DAO returns every contributor because the totals are summed from them; only the list the page
+              // renders is capped, and it is capped after the summing so a long tail can't skew a headline count.
+              cityId -> CityActivityWindow(
+                ActivityWindowSummary.fromContributors(rows),
+                rows.filter(c => c.labels7d + c.validations7d > 0).take(ConfigService.WindowContributorLimit)
+              )
+            }
         }
         Future.sequence(perCityFutures).map { perCity =>
-          val total = perCity.foldLeft(ActivityWindowSummary(0, 0, 0, 0, 0, 0)) { case (acc, (_, city)) =>
-            ActivityWindowSummary(
-              acc.labels7d + city.labels7d,
-              acc.labelsPrior7d + city.labelsPrior7d,
-              acc.validations7d + city.validations7d,
-              acc.validationsPrior7d + city.validationsPrior7d,
-              acc.contributors7d + city.contributors7d,
-              acc.contributorsPrior7d + city.contributorsPrior7d
-            )
+          val total = perCity.foldLeft(ActivityWindowSummary.empty) { case (acc, (_, city)) =>
+            ActivityWindowSummary.add(acc, city.summary)
           }
           CrossCityActivityWindows(perCity.toMap, total)
         }

--- a/app/service/ConfigService.scala
+++ b/app/service/ConfigService.scala
@@ -137,12 +137,28 @@ case class AggregateStats(
 case class WeeklyPoint(weekStart: LocalDate, labels: Int, validations: Int, activeUsers: Int, newUsers: Int)
 
 /**
+ * How one account's contribution is attributed on the Across Cities page (#4931).
+ *
+ * The distinction is what lets the page report community activity honestly. `Ai` output can dwarf everything people
+ * did — one pipeline account was 80% of prod's weekly validations — and an `Anonymous` account is a per-cookie
+ * identity, so a repeat visitor without an account shows up as several of them and cannot be counted as a person.
+ *
+ * String values match the labels [[models.utils.ConfigTable]]'s `account_kinds` CTE emits, which is how a row is
+ * parsed back into this type.
+ */
+object ContributorKind extends Enumeration {
+  val Registered: ContributorKind.Value = Value("registered")
+  val Anonymous: ContributorKind.Value  = Value("anonymous")
+  val Ai: ContributorKind.Value         = Value("ai")
+}
+
+/**
  * One person's contribution to one city on one day, the grain the "this week" bar charts are built from (#4931).
  *
  * @param day         Calendar day (Pacific).
  * @param userId      The contributor's user id, which identifies them across cities when their days are merged.
  * @param username    Their display name, empty when `sidewalk_login` has no row for the id.
- * @param isAi        Whether the account carries the shared `AI` role, i.e. this is pipeline output, not a person.
+ * @param kind        How this account's activity is attributed — a person, a cookie identity, or the pipeline.
  * @param labels      Non-tutorial, non-excluded labels they created that day.
  * @param validations Validations they submitted that day.
  */
@@ -150,7 +166,7 @@ case class DailyContributorActivity(
     day: LocalDate,
     userId: String,
     username: String,
-    isAi: Boolean,
+    kind: ContributorKind.Value,
     labels: Int,
     validations: Int
 )
@@ -160,7 +176,7 @@ case class DailyContributorActivity(
  *
  * @param userId              The contributor's user id.
  * @param username            Their display name, empty when `sidewalk_login` has no row for the id.
- * @param isAi                Whether the account carries the shared `AI` role.
+ * @param kind                How this account's activity is attributed.
  * @param labels7d            Labels they created in the trailing 7 days.
  * @param labelsPrior7d       Labels they created 7–14 days ago.
  * @param validations7d       Validations they submitted in the trailing 7 days.
@@ -169,7 +185,7 @@ case class DailyContributorActivity(
 case class ContributorWindowActivity(
     userId: String,
     username: String,
-    isAi: Boolean,
+    kind: ContributorKind.Value,
     labels7d: Int,
     labelsPrior7d: Int,
     validations7d: Int,
@@ -177,25 +193,27 @@ case class ContributorWindowActivity(
 )
 
 /**
- * One day's contribution volume summed across cities, for the Across Cities "this week" bar charts (#4686, #4931).
+ * One day's contribution volume across cities, for the Across Cities "this week" bar charts (#4686, #4931).
  *
- * Human and AI work is counted separately rather than pooled: one AI account can out-produce every person in the
- * project on a given day, so a blended total describes the pipeline's schedule, not the community's week.
+ * Counted on the same two bases as [[ActivityWindowSummary]] — volumes are human work with pipeline work beside it,
+ * headcounts are distinct and split registered / anonymous / AI. One AI account can out-produce every person in the
+ * project on a given day, so a blended total would describe the pipeline's schedule, not the community's day.
  *
  * @param day           Calendar day (Pacific).
- * @param labels        Non-tutorial, non-excluded labels people created that day.
+ * @param labels        Non-tutorial, non-excluded labels people created that day (registered and anonymous).
  * @param validations   Validations people submitted that day.
- * @param activeUsers   Distinct people who labeled or validated that day, summed per city (a person active in two
- *                      cities is counted in each).
+ * @param contributors  Distinct registered people who labeled or validated that day, across all cities.
+ * @param anonSessions  Distinct anonymous (per-cookie) identities active that day, across all cities.
  * @param aiLabels      Labels created that day by accounts holding the `AI` role.
  * @param aiValidations Validations submitted that day by accounts holding the `AI` role.
- * @param aiAgents      Distinct AI accounts active that day, summed per city.
+ * @param aiAgents      Distinct AI accounts active that day, across all cities.
  */
 case class DailyPoint(
     day: LocalDate,
     labels: Int,
     validations: Int,
-    activeUsers: Int,
+    contributors: Int,
+    anonSessions: Int,
     aiLabels: Int,
     aiValidations: Int,
     aiAgents: Int
@@ -204,11 +222,21 @@ case class DailyPoint(
 /**
  * One day's cross-city activity: the volumes behind that day's bars, plus the breakdown its hover card shows (#4931).
  *
- * @param point        The day's totals.
- * @param topCities    The day's busiest cities, most human activity first.
- * @param contributors The day's busiest contributors, merged across cities so a person active in two shows up once.
+ * @param point            The day's totals.
+ * @param topCities        The day's busiest cities, most human activity first.
+ * @param contributors     The day's busiest *nameable* contributors — registered accounts and AI, merged across cities
+ *                         so a person active in two shows up once, capped at [[ConfigService.DayContributorLimit]].
+ *                         Anonymous contributors are counted in `point.anonSessions` but never listed, because their
+ *                         usernames are generated cookie ids rather than names.
+ * @param contributorTotal How many contributors the capped list was drawn from, on the same nameable basis, so a card
+ *                         can say exactly how many it is not showing.
  */
-case class DailyActivity(point: DailyPoint, topCities: Seq[CityDayTotals], contributors: Seq[DailyContributor])
+case class DailyActivity(
+    point: DailyPoint,
+    topCities: Seq[CityDayTotals],
+    contributors: Seq[DailyContributor],
+    contributorTotal: Int
+)
 
 /**
  * One city's share of a single day, for the "top cities" line of a day's hover card (#4931).
@@ -224,11 +252,11 @@ case class CityDayTotals(cityId: String, labels: Int, validations: Int, contribu
  * One contributor's day, merged across every city they were active in (#4931).
  *
  * @param username    Their display name, empty when `sidewalk_login` has no row for the id.
- * @param isAi        Whether the account carries the shared `AI` role.
+ * @param kind        How this account's activity is attributed.
  * @param labels      Labels they created that day.
  * @param validations Validations they submitted that day.
  */
-case class DailyContributor(username: String, isAi: Boolean, labels: Int, validations: Int)
+case class DailyContributor(username: String, kind: ContributorKind.Value, labels: Int, validations: Int)
 
 /**
  * Cross-city rolling week-over-week activity — the trailing 7 days vs the 7 before — for the "Today & this week"
@@ -236,10 +264,18 @@ case class DailyContributor(username: String, isAi: Boolean, labels: Int, valida
  *
  * Windows are exact rolling 168-hour spans (the same basis as [[CityScorecard]]'s labels7d/validations7d), not
  * Pacific calendar days, so the tiles agree with the per-city 7d columns. Same activity definition, exclusions, and
- * human/AI separation as [[DailyPoint]]: the label and validation counts are what people did, with AI output reported
- * beside them, and contributors are people (`AI`-role accounts are counted as agents instead).
+ * attribution split as [[DailyPoint]].
  *
- * @param labels7d              Labels people created in the trailing 7 days.
+ * The two families of number here are counted differently, and the difference is the whole point. **Volumes** are
+ * human work with pipeline work reported beside it: `labels7d`/`validations7d` cover registered *and* anonymous
+ * contributors, because an anonymous visitor's label is still a person's label, while `ai*` is the pipeline's.
+ * **Headcounts** split three ways, because only a registered account reliably denotes one person: an anonymous account
+ * is a per-cookie identity that a repeat visitor mints again, so it is reported as a session, not a contributor.
+ *
+ * Every headcount is *distinct* at whatever scope the instance describes — see [[ActivityWindowSummary.fromContributors]]
+ * for the one-row-per-person precondition that guarantees it.
+ *
+ * @param labels7d              Labels people created in the trailing 7 days (registered and anonymous).
  * @param labelsPrior7d         Labels people created 7–14 days ago.
  * @param validations7d         Validations people submitted in the trailing 7 days.
  * @param validationsPrior7d    Validations people submitted 7–14 days ago.
@@ -247,10 +283,11 @@ case class DailyContributor(username: String, isAi: Boolean, labels: Int, valida
  * @param aiLabelsPrior7d       Labels created 7–14 days ago by `AI`-role accounts.
  * @param aiValidations7d       Validations submitted in the trailing 7 days by `AI`-role accounts.
  * @param aiValidationsPrior7d  Validations submitted 7–14 days ago by `AI`-role accounts.
- * @param contributors7d        Distinct people who labeled or validated in the trailing 7 days, summed per city (a
- *                              person active in two cities is counted in each, as with [[DailyPoint]] active users).
+ * @param contributors7d        Distinct registered people who labeled or validated in the trailing 7 days.
  * @param contributorsPrior7d   Same, for 7–14 days ago.
- * @param aiAgents7d            Distinct `AI`-role accounts active in the trailing 7 days, summed per city.
+ * @param anonSessions7d        Distinct anonymous (per-cookie) identities active in the trailing 7 days.
+ * @param anonSessionsPrior7d   Same, for 7–14 days ago.
+ * @param aiAgents7d            Distinct `AI`-role accounts active in the trailing 7 days.
  */
 case class ActivityWindowSummary(
     labels7d: Int,
@@ -263,26 +300,37 @@ case class ActivityWindowSummary(
     aiValidationsPrior7d: Int,
     contributors7d: Int,
     contributorsPrior7d: Int,
+    anonSessions7d: Int,
+    anonSessionsPrior7d: Int,
     aiAgents7d: Int
 )
 
 object ActivityWindowSummary {
 
-  /** A window with nothing in it — the fallback for a city whose schema read failed, and the fold's starting point. */
-  val empty: ActivityWindowSummary = ActivityWindowSummary(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+  /** A window with nothing in it — the fallback for a city whose schema read failed. */
+  val empty: ActivityWindowSummary = ActivityWindowSummary(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
 
   /**
-   * Rolls one city's per-person rows up into its window totals.
+   * Rolls per-person rows up into window totals.
    *
    * Every count the page shows comes from this one derivation, so a headline number and the contributor list behind it
-   * can't drift apart. Contributor counts are distinct people with activity in that window; AI accounts are excluded
-   * from them and counted as agents.
+   * can't drift apart.
    *
-   * @param rows One city's contributors, as returned by the DAO.
-   * @return     That city's window totals.
+   * **Precondition: `rows` holds at most one row per person.** Headcounts here are `count`s of matching rows, so they
+   * are distinct people exactly as far as that holds. It holds per city because the DAO groups by user; to summarize
+   * across cities, merge a person's rows first (see [[ConfigService.mergeByContributor]]) rather than summing
+   * per-city summaries — summing would count someone active in three cities as three contributors. There is
+   * deliberately no `add` on this type: field-wise addition is correct for the volumes and wrong for every headcount,
+   * and a single combinator can't be both.
+   *
+   * @param rows Contributors, at most one row each.
+   * @return     Their window totals.
    */
   def fromContributors(rows: Seq[ContributorWindowActivity]): ActivityWindowSummary = {
-    val (ai, people) = rows.partition(_.isAi)
+    val byKind = rows.groupBy(_.kind).withDefaultValue(Seq.empty)
+    val ai     = byKind(ContributorKind.Ai)
+    val anon   = byKind(ContributorKind.Anonymous)
+    val people = byKind(ContributorKind.Registered) ++ anon
     ActivityWindowSummary(
       labels7d = people.map(_.labels7d).sum,
       labelsPrior7d = people.map(_.labelsPrior7d).sum,
@@ -292,45 +340,44 @@ object ActivityWindowSummary {
       aiLabelsPrior7d = ai.map(_.labelsPrior7d).sum,
       aiValidations7d = ai.map(_.validations7d).sum,
       aiValidationsPrior7d = ai.map(_.validationsPrior7d).sum,
-      contributors7d = people.count(c => c.labels7d + c.validations7d > 0),
-      contributorsPrior7d = people.count(c => c.labelsPrior7d + c.validationsPrior7d > 0),
+      contributors7d = byKind(ContributorKind.Registered).count(c => c.labels7d + c.validations7d > 0),
+      contributorsPrior7d = byKind(ContributorKind.Registered).count(c => c.labelsPrior7d + c.validationsPrior7d > 0),
+      anonSessions7d = anon.count(c => c.labels7d + c.validations7d > 0),
+      anonSessionsPrior7d = anon.count(c => c.labelsPrior7d + c.validationsPrior7d > 0),
       aiAgents7d = ai.count(c => c.labels7d + c.validations7d > 0)
     )
   }
-
-  /** Adds two windows field by field, for summing per-city windows into the cross-city total. */
-  def add(a: ActivityWindowSummary, b: ActivityWindowSummary): ActivityWindowSummary = ActivityWindowSummary(
-    a.labels7d + b.labels7d,
-    a.labelsPrior7d + b.labelsPrior7d,
-    a.validations7d + b.validations7d,
-    a.validationsPrior7d + b.validationsPrior7d,
-    a.aiLabels7d + b.aiLabels7d,
-    a.aiLabelsPrior7d + b.aiLabelsPrior7d,
-    a.aiValidations7d + b.aiValidations7d,
-    a.aiValidationsPrior7d + b.aiValidationsPrior7d,
-    a.contributors7d + b.contributors7d,
-    a.contributorsPrior7d + b.contributorsPrior7d,
-    a.aiAgents7d + b.aiAgents7d
-  )
 }
 
 /**
  * One city's rolling weekly windows, with the people whose work they are made of (#4758, #4931).
  *
- * @param summary      The city's window totals.
- * @param contributors Its contributors, busiest first and capped at [[ConfigService.WindowContributorLimit]], for the
- *                     "Most active cities" hover cards.
+ * @param summary          The city's window totals.
+ * @param contributors     Its nameable contributors — registered accounts and AI — busiest first and capped at
+ *                         [[ConfigService.WindowContributorLimit]], for the "Most active cities" hover cards.
+ *                         Anonymous contributors are counted in the summary but never listed (generated cookie ids).
+ * @param contributorTotal How many contributors the capped list was drawn from, on the same nameable basis, so a card
+ *                         can say exactly how many it is not showing.
  */
-case class CityActivityWindow(summary: ActivityWindowSummary, contributors: Seq[ContributorWindowActivity])
+case class CityActivityWindow(
+    summary: ActivityWindowSummary,
+    contributors: Seq[ContributorWindowActivity],
+    contributorTotal: Int
+)
 
 /**
  * Rolling week-over-week activity for every available city plus the cross-city total (#4758).
  *
- * The per-city rows and the total come from one pass: each city is queried once, and `total` is those rows summed. So
- * the "Most active cities" table costs nothing beyond the "Today & this week" tiles that need the total anyway.
+ * The per-city rows and the total come from one pass: each city is queried once, and `total` is derived from those same
+ * rows. So the "Most active cities" table costs nothing beyond the "Today & this week" tiles that need the total anyway.
+ *
+ * `total` is **not** the per-city summaries added up. Volumes would survive that, but headcounts would not: someone who
+ * mapped in three cities is three per-city contributors and one person. So the total re-derives from every city's rows
+ * merged by person, which is why it can be smaller than the same column summed down the table — worth a note wherever
+ * the two appear together.
  *
  * @param byCity Per-city windows, keyed by city id. Cities whose query failed carry zeros rather than being dropped.
- * @param total  The per-city rows summed; contributor counts are summed, not deduplicated across cities.
+ * @param total  Cross-city totals: volumes summed, headcounts distinct across all cities.
  */
 case class CrossCityActivityWindows(byCity: Map[String, CityActivityWindow], total: ActivityWindowSummary)
 
@@ -494,62 +541,143 @@ object ConfigService {
   val ActiveWithinDays: Long = 30
 
   /**
+   * Age beyond which a cross-city read is refreshed in the background when served (#4931).
+   *
+   * One `/admin/across-cities` request triggers five of these reads, and each fans a query out to every city schema —
+   * ~280 queries against a 25-connection pool at ~56 deployments. What `staleWhileRevalidate` buys over a plain
+   * expiring cache is that **no request ever waits on that fan-out**: past this age the cached copy is still served
+   * immediately and the refresh runs behind it, whereas an expiring entry makes whichever request arrives first pay
+   * for the whole thing while holding pool connections that Explore and Validate share. (Coalescing concurrent
+   * callers is not the difference — Caffeine's `get(key, mappingFunction)` under `getOrElseUpdate` is already atomic
+   * per key. `refreshCachedValue` keeps that property for background refreshes.)
+   */
+  val CrossCityFreshFor: FiniteDuration = Duration(10, "minutes")
+
+  /**
+   * How long a cross-city read may be served at all; past this a request blocks on recomputing it.
+   *
+   * Far above [[CrossCityFreshFor]] because staleness is much cheaper here than a blocking fan-out: these numbers are
+   * for an overview page, and a background refresh runs every time one is served past the fresh window anyway. So this
+   * bound only decides how old the page may get while refreshes keep failing — not how fresh it normally is.
+   */
+  val CrossCityMaxAge: FiniteDuration = Duration(2, "hours")
+
+  /**
+   * How long the cross-city labeling-speed read may be served, and when it refreshes.
+   *
+   * Its own pair because it scans the interaction tables — by far the heaviest of the fan-outs, and the least volatile:
+   * labeling speed barely moves day to day.
+   */
+  val LabelingSpeedFreshFor: FiniteDuration = Duration(24, "hours")
+
+  /** How long a labeling-speed read may be served at all; see [[LabelingSpeedFreshFor]]. */
+  val LabelingSpeedMaxAge: FiniteDuration = Duration(7, "days")
+
+  /**
    * How many contributors each city ships for its "Most active cities" hover cards (#4931).
    *
-   * Generous rather than tight: the cards rank by labels in one place and by validations in another, so a cap that
-   * only just covered one list would drop people from the other. Across all 56 deployments a busy week runs to a few
-   * dozen contributors total, so this bounds a pathological mapathon rather than trimming the normal case.
+   * Sized to what the cards can draw, not to the population. The untruncated count travels separately as
+   * `CityActivityWindow.contributorTotal`, so this list only has to cover what is rendered: ~5 rows per card, plus
+   * headroom because the cards rank by labels in one column and validations in another and so draw different people
+   * from the same list. This ships per city for every deployment, so each unit of it is paid ~56 times.
    */
-  val WindowContributorLimit: Int = 25
+  val WindowContributorLimit: Int = 10
 
   /** How many cities a day's hover card lists. The card draws every one it is sent, so this is the only cap. */
   val DayTopCityLimit: Int = 3
 
-  /** How many contributors a day's hover card lists. */
+  /** How many contributors a day's hover card lists, with the untruncated count sent alongside as a total. */
   val DayContributorLimit: Int = 8
+
+  /**
+   * Merges a person's rows from several cities into one row per person, summing their volumes.
+   *
+   * The precondition [[ActivityWindowSummary.fromContributors]] needs in order to count distinct people: without this,
+   * summarizing across cities counts someone who mapped in three cities three times. Sorted busiest-first with the user
+   * id breaking ties, so a caller that truncates keeps a reproducible list across cache refreshes rather than one that
+   * depends on `HashMap` iteration order.
+   *
+   * @param rows Per-city, per-person rows from any number of cities.
+   * @return     One row per person, volumes summed, busiest first.
+   */
+  def mergeByContributor(rows: Seq[ContributorWindowActivity]): Seq[ContributorWindowActivity] = rows
+    .groupBy(_.userId)
+    .values
+    .map(userRows =>
+      userRows.head.copy(
+        labels7d = userRows.map(_.labels7d).sum,
+        labelsPrior7d = userRows.map(_.labelsPrior7d).sum,
+        validations7d = userRows.map(_.validations7d).sum,
+        validationsPrior7d = userRows.map(_.validationsPrior7d).sum
+      )
+    )
+    .toSeq
+    .sortBy(c => (-(c.labels7d + c.validations7d), c.userId))
 
   /**
    * Rolls one day's per-city, per-person rows up into the day's bars and the breakdown behind them (#4931).
    *
    * Every figure the day's hover card shows is derived here, from the same rows the bars are summed from, so the card
-   * can't contradict the bar it explains. Contributors merge across cities (one person, one entry, counts added up),
-   * while the day's `activeUsers` stays per-city-summed to match the counting basis the rest of the section uses.
+   * can't contradict the bar it explains. That includes the headcounts: they are derived from the *merged* rows, the
+   * same ones the card names, so the day's contributor count and the list under it can never disagree about how many
+   * people there were.
    *
    * @param day  The Pacific calendar day being summarized.
    * @param rows That day's (cityId, contributor-activity) rows; empty for a day nobody was active.
    * @return     The day's totals, its busiest cities, and its busiest contributors.
    */
   def summarizeDay(day: LocalDate, rows: Seq[(String, DailyContributorActivity)]): DailyActivity = {
-    val (aiRows, peopleRows) = rows.partition(_._2.isAi)
-    val point                = DailyPoint(
+    val byKind     = rows.groupBy(_._2.kind).withDefaultValue(Seq.empty)
+    val aiRows     = byKind(ContributorKind.Ai)
+    val peopleRows = byKind(ContributorKind.Registered) ++ byKind(ContributorKind.Anonymous)
+    // Ranked and truncated below, so ties break on a stable key rather than on HashMap iteration order.
+    val merged = rows
+      .groupBy(_._2.userId)
+      .toSeq
+      .map { case (userId, userRows) =>
+        val first = userRows.head._2
+        (
+          userId,
+          DailyContributor(
+            first.username,
+            first.kind,
+            userRows.map(_._2.labels).sum,
+            userRows.map(_._2.validations).sum
+          )
+        )
+      }
+      .sortBy { case (userId, c) => (-(c.labels + c.validations), userId) }
+      .map(_._2)
+    def activeOfKind(kind: ContributorKind.Value): Int =
+      merged.count(c => c.kind == kind && c.labels + c.validations > 0)
+    // Anonymous contributors are counted (as sessions, on the point) but not listed: their usernames are generated
+    // cookie ids, so naming them fills the card with hex and implies a person behind each one.
+    val named = merged.filter(_.kind != ContributorKind.Anonymous)
+    val point = DailyPoint(
       day = day,
       labels = peopleRows.map(_._2.labels).sum,
       validations = peopleRows.map(_._2.validations).sum,
-      activeUsers = peopleRows.size,
+      contributors = activeOfKind(ContributorKind.Registered),
+      anonSessions = activeOfKind(ContributorKind.Anonymous),
       aiLabels = aiRows.map(_._2.labels).sum,
       aiValidations = aiRows.map(_._2.validations).sum,
-      aiAgents = aiRows.size
+      aiAgents = activeOfKind(ContributorKind.Ai)
     )
     // Cities are ranked and listed by what people did there; AI output belongs to the pipeline, not to a community.
     val topCities = peopleRows
       .groupBy(_._1)
+      .toSeq
       .map { case (cityId, cityRows) =>
-        CityDayTotals(cityId, cityRows.map(_._2.labels).sum, cityRows.map(_._2.validations).sum, cityRows.size)
+        CityDayTotals(
+          cityId,
+          cityRows.map(_._2.labels).sum,
+          cityRows.map(_._2.validations).sum,
+          cityRows.map(_._2.userId).distinct.size
+        )
       }
-      .toSeq
-      .sortBy(city => -(city.labels + city.validations))
+      .sortBy(city => (-(city.labels + city.validations), city.cityId))
       .take(DayTopCityLimit)
-    val contributors = rows
-      .groupBy(_._2.userId)
-      .values
-      .map { userRows =>
-        val first = userRows.head._2
-        DailyContributor(first.username, first.isAi, userRows.map(_._2.labels).sum, userRows.map(_._2.validations).sum)
-      }
-      .toSeq
-      .sortBy(c => -(c.labels + c.validations))
-      .take(DayContributorLimit)
-    DailyActivity(point, topCities, contributors)
+    DailyActivity(point, topCities, named.take(DayContributorLimit), named.size)
   }
 
   /**
@@ -1203,8 +1331,11 @@ class ConfigServiceImpl @Inject() (
   }
 
   def getCityScorecards(): Future[Seq[CityScorecardWithFlags]] = {
-    // Heavier than getAggregateStats (a multi-subquery per city) and only viewed by Owners, so cache a bit longer.
-    cacheApi.getOrElseUpdate[Seq[CityScorecardWithFlags]]("getCityScorecards", Duration(10, "minutes")) {
+    staleWhileRevalidate[Seq[CityScorecardWithFlags]](
+      "getCityScorecards",
+      ConfigService.CrossCityFreshFor,
+      ConfigService.CrossCityMaxAge
+    ) {
       availableCityIds().flatMap { availableCities =>
         // Query each available city in parallel; one failing schema yields None rather than sinking the whole page.
         val scorecardFutures: Seq[Future[Option[CityScorecard]]] = availableCities.map { cityId =>
@@ -1224,7 +1355,7 @@ class ConfigServiceImpl @Inject() (
 
   def getCrossCityWeeklyTrend(weeks: Option[Int]): Future[Seq[WeeklyPoint]] = {
     val cacheKey = s"getCrossCityWeeklyTrend_${weeks.map(_.toString).getOrElse("all")}"
-    cacheApi.getOrElseUpdate[Seq[WeeklyPoint]](cacheKey, Duration(10, "minutes")) {
+    staleWhileRevalidate[Seq[WeeklyPoint]](cacheKey, ConfigService.CrossCityFreshFor, ConfigService.CrossCityMaxAge) {
       availableCityIds().flatMap { availableCities =>
         val perCityFutures = availableCities.map { cityId =>
           db.run(configTable.getCityWeeklyTrendBySchema(getCitySchema(cityId), weeks))
@@ -1254,7 +1385,11 @@ class ConfigServiceImpl @Inject() (
   }
 
   def getCrossCityDailyTrend(days: Int): Future[Seq[DailyActivity]] = {
-    cacheApi.getOrElseUpdate[Seq[DailyActivity]](s"getCrossCityDailyTrend_$days", Duration(10, "minutes")) {
+    staleWhileRevalidate[Seq[DailyActivity]](
+      s"getCrossCityDailyTrend_$days",
+      ConfigService.CrossCityFreshFor,
+      ConfigService.CrossCityMaxAge
+    ) {
       availableCityIds().flatMap { availableCities =>
         val perCityFutures = availableCities.map { cityId =>
           db.run(configTable.getCityDailyActivityByUserBySchema(getCitySchema(cityId), days))
@@ -1281,7 +1416,11 @@ class ConfigServiceImpl @Inject() (
   }
 
   def getCrossCityActivitySummary(): Future[CrossCityActivityWindows] = {
-    cacheApi.getOrElseUpdate[CrossCityActivityWindows]("getCrossCityActivitySummary", Duration(10, "minutes")) {
+    staleWhileRevalidate[CrossCityActivityWindows](
+      "getCrossCityActivitySummary",
+      ConfigService.CrossCityFreshFor,
+      ConfigService.CrossCityMaxAge
+    ) {
       availableCityIds().flatMap { availableCities =>
         val perCityFutures = availableCities.map { cityId =>
           db.run(configTable.getCityWindowActivityByUserBySchema(getCitySchema(cityId)))
@@ -1289,20 +1428,25 @@ class ConfigServiceImpl @Inject() (
               logger.warn(s"Failed to fetch activity windows for city $cityId: ${e.getMessage}")
               Seq.empty[ContributorWindowActivity]
             }
-            .map { rows =>
-              // The DAO returns every contributor because the totals are summed from them; only the list the page
-              // renders is capped, and it is capped after the summing so a long tail can't skew a headline count.
-              cityId -> CityActivityWindow(
-                ActivityWindowSummary.fromContributors(rows),
-                rows.filter(c => c.labels7d + c.validations7d > 0).take(ConfigService.WindowContributorLimit)
-              )
-            }
+            .map(cityId -> _)
         }
         Future.sequence(perCityFutures).map { perCity =>
-          val total = perCity.foldLeft(ActivityWindowSummary.empty) { case (acc, (_, city)) =>
-            ActivityWindowSummary.add(acc, city.summary)
+          val byCity = perCity.map { case (cityId, rows) =>
+            // The DAO returns every contributor because the city's totals are derived from all of them; only the list
+            // the page renders is capped, and capping after the derivation keeps a long tail out of a headline count.
+            val named = rows.filter(c => c.labels7d + c.validations7d > 0 && c.kind != ContributorKind.Anonymous)
+            cityId -> CityActivityWindow(
+              ActivityWindowSummary.fromContributors(rows),
+              named.take(ConfigService.WindowContributorLimit),
+              named.size
+            )
           }
-          CrossCityActivityWindows(perCity.toMap, total)
+          // Merging every city's rows by person before summarizing is what makes the cross-city headcounts distinct
+          // people rather than per-city contributor slots added up.
+          val total = ActivityWindowSummary.fromContributors(
+            ConfigService.mergeByContributor(perCity.flatMap { case (_, rows) => rows })
+          )
+          CrossCityActivityWindows(byCity.toMap, total)
         }
       }
     }
@@ -1328,8 +1472,11 @@ class ConfigServiceImpl @Inject() (
   }
 
   def getCrossCityLabelingSpeed(): Future[Map[String, Double]] = {
-    // Daily cache: this is the heavy interaction-table scan, and labeling speed barely moves day to day.
-    cacheApi.getOrElseUpdate[Map[String, Double]]("getCrossCityLabelingSpeed", Duration(24, "hours")) {
+    staleWhileRevalidate[Map[String, Double]](
+      "getCrossCityLabelingSpeed",
+      ConfigService.LabelingSpeedFreshFor,
+      ConfigService.LabelingSpeedMaxAge
+    ) {
       availableCityIds().flatMap { availableCities =>
         val perCityFutures: Seq[Future[Option[(String, Double)]]] = availableCities.map { cityId =>
           labelingSpeedForSchema(getCitySchema(cityId)).map(_.map(cityId -> _))

--- a/app/views/admin/dashboard/acrossCities.scala.html
+++ b/app/views/admin/dashboard/acrossCities.scala.html
@@ -31,20 +31,20 @@
 
   <div class="api-section" id="ac-now-section">
     <h2 class="api-heading" id="today-this-week">Today &amp; this week <a href="#today-this-week" class="permalink">#</a></h2>
-    <p>What's happening right now — today so far, and the trailing 7 days compared with the 7 before. Contributor counts are distinct people per city, summed across cities (a person active in two cities is counted in each).</p>
+    <p>What's happening right now — today so far, and the trailing 7 days compared with the 7 before. Every count in this section is what <em>people</em> did; AI-role accounts are reported separately on their own line, because a single pipeline account can out-produce every contributor in the project. Contributor counts are distinct people per city, summed across cities (a person active in two cities is counted in each). Hover a bar or a table cell for the day or city behind it.</p>
 
     <h3 class="ac-chart-group-title" id="today-so-far">Today (so far)</h3>
     <div class="ac-hero-row">
-      <div class="ac-hero-stat"><span class="ac-hero-value" id="now-labels-today">—</span><span class="ac-hero-label">Labels today</span></div>
-      <div class="ac-hero-stat"><span class="ac-hero-value" id="now-validations-today">—</span><span class="ac-hero-label">Validations today</span></div>
-      <div class="ac-hero-stat"><span class="ac-hero-value" id="now-contributors-today">—</span><span class="ac-hero-label">Contributors today</span></div>
+      <div class="ac-hero-stat"><span class="ac-hero-value" id="now-labels-today">—</span><span class="ac-hero-label">Labels today</span><span class="ac-hero-ai" id="now-labels-today-ai"></span></div>
+      <div class="ac-hero-stat"><span class="ac-hero-value" id="now-validations-today">—</span><span class="ac-hero-label">Validations today</span><span class="ac-hero-ai" id="now-validations-today-ai"></span></div>
+      <div class="ac-hero-stat"><span class="ac-hero-value" id="now-contributors-today">—</span><span class="ac-hero-label">Contributors today</span><span class="ac-hero-ai" id="now-contributors-today-ai"></span></div>
     </div>
 
     <h3 class="ac-chart-group-title" id="past-7-days">Past 7 days</h3>
     <div class="ac-hero-row">
-      <div class="ac-hero-stat"><span class="ac-hero-value" id="now-labels-7d">—</span><span class="ac-hero-label">Labels</span><span class="ac-hero-delta" id="now-labels-7d-delta"></span></div>
-      <div class="ac-hero-stat"><span class="ac-hero-value" id="now-validations-7d">—</span><span class="ac-hero-label">Validations</span><span class="ac-hero-delta" id="now-validations-7d-delta"></span></div>
-      <div class="ac-hero-stat"><span class="ac-hero-value" id="now-contributors-7d">—</span><span class="ac-hero-label">Contributors</span><span class="ac-hero-delta" id="now-contributors-7d-delta"></span></div>
+      <div class="ac-hero-stat"><span class="ac-hero-value" id="now-labels-7d">—</span><span class="ac-hero-label">Labels</span><span class="ac-hero-delta" id="now-labels-7d-delta"></span><span class="ac-hero-ai" id="now-labels-7d-ai"></span></div>
+      <div class="ac-hero-stat"><span class="ac-hero-value" id="now-validations-7d">—</span><span class="ac-hero-label">Validations</span><span class="ac-hero-delta" id="now-validations-7d-delta"></span><span class="ac-hero-ai" id="now-validations-7d-ai"></span></div>
+      <div class="ac-hero-stat"><span class="ac-hero-value" id="now-contributors-7d">—</span><span class="ac-hero-label">Contributors</span><span class="ac-hero-delta" id="now-contributors-7d-delta"></span><span class="ac-hero-ai" id="now-contributors-7d-ai"></span></div>
       <div class="ac-hero-stat"><span class="ac-hero-value" id="now-cities-active">—</span><span class="ac-hero-label">Cities active</span></div>
       <div class="ac-hero-stat"><span class="ac-hero-value" id="now-top-city">—</span><span class="ac-hero-label">Top city this week</span><span class="ac-hero-delta" id="now-top-city-count"></span></div>
       <div class="ac-hero-stat"><span class="ac-hero-value" id="now-new-contributors">—</span><span class="ac-hero-label">New contributors this calendar week</span></div>
@@ -65,10 +65,10 @@
         <div class="mini-chart" id="ac-chart-week-users"></div>
       </div>
     </div>
-    <p class="ac-note">“Active users” counts distinct people who labeled or validated that day, summed across cities (a person active in two cities is counted in each). The last bar is today, still filling in.</p>
+    <p class="ac-note">“Active users” counts distinct people who labeled or validated that day, summed across cities (a person active in two cities is counted in each). The last bar is today, still filling in. Hovering (or tabbing to) a bar shows that day's full breakdown: all three volumes, any AI output, the busiest cities, and who was active.</p>
 
     <h3 class="ac-chart-group-title" id="most-active-cities">Most active cities</h3>
-    <p>The busiest deployments of the past 7 days, with each count's change from the 7 days before. Click a column header to re-rank — the table always shows the top five <em>by the column you sort on</em> (sorting by City keeps the busiest five, ordered by name). Cities with no activity this week are left out.</p>
+    <p>The busiest deployments of the past 7 days, with each count's change from the 7 days before. Click a column header to re-rank — the table always shows the top five <em>by the column you sort on</em> (sorting by City keeps the busiest five, ordered by name). Cities with no activity this week are left out. Hover (or tab to) a count for both weeks' raw numbers and the contributors behind them, by name.</p>
     <div class="ac-table-wrap">
       <table class="ac-table" id="ac-top-table">
         <thead>

--- a/app/views/admin/dashboard/acrossCities.scala.html
+++ b/app/views/admin/dashboard/acrossCities.scala.html
@@ -37,14 +37,14 @@
     <div class="ac-hero-row">
       <div class="ac-hero-stat"><span class="ac-hero-value" id="now-labels-today">—</span><span class="ac-hero-label">Labels today</span><span class="ac-hero-ai" id="now-labels-today-ai"></span></div>
       <div class="ac-hero-stat"><span class="ac-hero-value" id="now-validations-today">—</span><span class="ac-hero-label">Validations today</span><span class="ac-hero-ai" id="now-validations-today-ai"></span></div>
-      <div class="ac-hero-stat"><span class="ac-hero-value" id="now-contributors-today">—</span><span class="ac-hero-label">Contributors today</span><span class="ac-hero-ai" id="now-contributors-today-ai"></span></div>
+      <div class="ac-hero-stat"><span class="ac-hero-value" id="now-contributors-today">—</span><span class="ac-hero-label">Contributors today</span><span class="ac-hero-ai" id="now-contributors-today-anon"></span><span class="ac-hero-ai" id="now-contributors-today-ai"></span></div>
     </div>
 
     <h3 class="ac-chart-group-title" id="past-7-days">Past 7 days</h3>
     <div class="ac-hero-row">
       <div class="ac-hero-stat"><span class="ac-hero-value" id="now-labels-7d">—</span><span class="ac-hero-label">Labels</span><span class="ac-hero-delta" id="now-labels-7d-delta"></span><span class="ac-hero-ai" id="now-labels-7d-ai"></span></div>
       <div class="ac-hero-stat"><span class="ac-hero-value" id="now-validations-7d">—</span><span class="ac-hero-label">Validations</span><span class="ac-hero-delta" id="now-validations-7d-delta"></span><span class="ac-hero-ai" id="now-validations-7d-ai"></span></div>
-      <div class="ac-hero-stat"><span class="ac-hero-value" id="now-contributors-7d">—</span><span class="ac-hero-label">Contributors</span><span class="ac-hero-delta" id="now-contributors-7d-delta"></span><span class="ac-hero-ai" id="now-contributors-7d-ai"></span></div>
+      <div class="ac-hero-stat"><span class="ac-hero-value" id="now-contributors-7d">—</span><span class="ac-hero-label">Contributors</span><span class="ac-hero-delta" id="now-contributors-7d-delta"></span><span class="ac-hero-ai" id="now-contributors-7d-anon"></span><span class="ac-hero-ai" id="now-contributors-7d-ai"></span></div>
       <div class="ac-hero-stat"><span class="ac-hero-value" id="now-cities-active">—</span><span class="ac-hero-label">Cities active</span></div>
       <div class="ac-hero-stat"><span class="ac-hero-value" id="now-top-city">—</span><span class="ac-hero-label">Top city this week</span><span class="ac-hero-delta" id="now-top-city-count"></span></div>
       <div class="ac-hero-stat"><span class="ac-hero-value" id="now-new-contributors">—</span><span class="ac-hero-label">New contributors this calendar week</span></div>
@@ -61,14 +61,14 @@
         <div class="mini-chart" id="ac-chart-week-validations"></div>
       </div>
       <div class="ac-chart">
-        <h4 class="ac-chart-title">Active users per day</h4>
+        <h4 class="ac-chart-title">Contributors per day</h4>
         <div class="mini-chart" id="ac-chart-week-users"></div>
       </div>
     </div>
-    <p class="ac-note">“Active users” counts distinct people who labeled or validated that day, summed across cities (a person active in two cities is counted in each). The last bar is today, still filling in. Hovering (or tabbing to) a bar shows that day's full breakdown: all three volumes, any AI output, the busiest cities, and who was active.</p>
+    <p class="ac-note">“Contributors” counts distinct registered people who labeled or validated that day, deduplicated across cities (someone active in two cities counts once). Anonymous visitors are counted separately as sessions, since each is a browser cookie rather than a known person, and AI accounts separately again — their work is in the label and validation bars but never in this one. The last bar is today, still filling in. Hovering (or tabbing to) any bar shows that day's full breakdown: all three volumes, the anonymous and AI split, the busiest cities, and who was active.</p>
 
     <h3 class="ac-chart-group-title" id="most-active-cities">Most active cities</h3>
-    <p>The busiest deployments of the past 7 days, with each count's change from the 7 days before. Click a column header to re-rank — the table always shows the top five <em>by the column you sort on</em> (sorting by City keeps the busiest five, ordered by name). Cities with no activity this week are left out. Hover (or tab to) a count for both weeks' raw numbers and the contributors behind them, by name.</p>
+    <p>The busiest deployments of the past 7 days, with each count's change from the 7 days before. Click a column header to re-rank — the table always shows the top five <em>by the column you sort on</em> (sorting by City keeps the busiest five, ordered by name). Cities with no activity this week are left out. Hover (or tab to) a count for both weeks' raw numbers and the contributors behind them, by name. Each row's Contributors count is that city's own; adding the column up therefore exceeds the project total in the tiles above, which counts someone who mapped in several cities once.</p>
     <div class="ac-table-wrap">
       <table class="ac-table" id="ac-top-table">
         <thead>

--- a/public/css/admin-dashboard/admin-dashboard.css
+++ b/public/css/admin-dashboard/admin-dashboard.css
@@ -713,6 +713,19 @@
   stroke-width: 1.5;
 }
 
+/* Full-plot-height hover/focus target for each bar, so a zero-value category is still reachable. Must be
+   `transparent` and not `none`: `fill: none` makes an SVG shape ignore pointer events entirely. */
+.mini-bar-hit {
+  fill: transparent;
+}
+
+.mini-bar-hit:focus-visible {
+  outline: none;
+  stroke: var(--color-text-primary, #222222);
+  stroke-dasharray: 3 2;
+  stroke-width: 1.5;
+}
+
 .mini-line {
   fill: none;
   stroke-width: 2;
@@ -2298,7 +2311,7 @@ img.activity-feed-thumb:hover { box-shadow: 0 2px 6px rgb(0 0 0 / 18%); }
 .ac-hero-ai,
 .ac-cell-ai {
   display: block;
-  font-size: var(--font-size-xs, 0.8125rem);
+  font: var(--text-caption-regular);
   color: var(--color-text-tertiary, #88a1ad);
   white-space: nowrap;
 }
@@ -2350,8 +2363,13 @@ img.activity-feed-thumb:hover { box-shadow: 0 2px 6px rgb(0 0 0 / 18%); }
 .ac-tip-row--ai { opacity: 0.75; }
 
 /* The line the hovered bar or cell actually draws. Weight alone carries it — the card is one type size throughout,
-   so a heavier line reads as "this is your number" without breaking the column of figures down the right edge. */
-.ac-tip-row--strong { font: var(--text-caption-semibold); }
+   so a heavier line reads as "this is your number" without breaking the column of figures down the right edge.
+   Selected by the card's `data-emph` rather than baked into the row's class, so the three per-day charts can share one
+   built card and each still emphasize its own line. */
+.ac-tip-row--strong,
+.ac-tip[data-emph="labels"] [data-tip-row="labels"],
+.ac-tip[data-emph="validations"] [data-tip-row="validations"],
+.ac-tip[data-emph="contributors"] [data-tip-row="contributors"] { font: var(--text-caption-semibold); }
 
 .ac-tip-head {
   font: var(--text-tiny-semibold);

--- a/public/css/admin-dashboard/admin-dashboard.css
+++ b/public/css/admin-dashboard/admin-dashboard.css
@@ -2292,6 +2292,95 @@ img.activity-feed-thumb:hover { box-shadow: 0 2px 6px rgb(0 0 0 / 18%); }
 .ac-cell-delta--down { color: #c0392b; }
 .ac-cell-delta--flat { color: var(--color-text-tertiary, #88a1ad); }
 
+/* AI output reported beside the human count it accompanies, on a tile and in a table cell (#4931). Deliberately
+   quieter than the delta chips: it qualifies the number above it rather than competing with it, and it is dotted-
+   underlined because it carries its own tooltip explaining the split. */
+.ac-hero-ai,
+.ac-cell-ai {
+  display: block;
+  font-size: var(--font-size-xs, 0.8125rem);
+  color: var(--color-text-tertiary, #88a1ad);
+  white-space: nowrap;
+}
+
+.ac-hero-ai {
+  margin-top: 2px;
+  text-decoration: underline dotted;
+  text-underline-offset: 2px;
+}
+
+.ac-hero-ai:empty,
+.ac-cell-ai:empty { display: none; }
+
+.ac-cell-ai { margin-top: 1px; }
+
+/* A cell whose hover card is also keyboard reachable: it takes focus, so it needs a focus ring (WCAG 2.4.7) and a
+   cursor that says there is more here than the number. */
+.ac-table td[data-ps-tooltip] { cursor: help; }
+
+.ac-table td[data-ps-tooltip]:focus-visible {
+  outline: 2px solid var(--color-accent-link, #0566f5);
+  outline-offset: -2px;
+}
+
+/* Hover-card contents (#4931). The card itself is styled in main.css (.ps-tooltip); these are the rows inside it,
+   which is why they live outside any page-scoped selector — psTooltip parks its card on <body>. */
+.ac-tip {
+  display: block;
+  min-width: 168px;
+}
+
+.ac-tip-title {
+  font: var(--text-caption-semibold);
+  margin-bottom: 3px;
+}
+
+.ac-tip-row {
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+}
+
+/* Tabular figures so the right-hand numbers line up column-wise down the card. */
+.ac-tip-num {
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.ac-tip-row--ai { opacity: 0.75; }
+
+.ac-tip-head {
+  font: var(--text-tiny-semibold);
+  margin-top: 6px;
+  margin-bottom: 1px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  opacity: 0.7;
+}
+
+.ac-tip-more {
+  opacity: 0.7;
+  font-style: italic;
+}
+
+/* Marks a contributor line as pipeline output rather than a person. */
+.ac-tip-tag {
+  margin-left: 4px;
+  padding: 0 3px;
+  border: 1px solid currentcolor;
+  border-radius: 3px;
+  font: var(--text-tiny-semibold);
+  opacity: 0.8;
+}
+
+/* Bars carrying a hover card take focus so the card is reachable by keyboard. `outline` on an SVG shape is unreliable
+   across engines, so the ring is drawn as a stroke on the bar itself. */
+.mini-bar[data-ps-tooltip]:focus-visible {
+  outline: none;
+  stroke: var(--color-text-primary, #1c3644);
+  stroke-width: 2;
+}
+
 /* Row-count status and the link out to the full city list, on one line under a table. */
 .ac-table-foot {
   display: flex;

--- a/public/css/admin-dashboard/admin-dashboard.css
+++ b/public/css/admin-dashboard/admin-dashboard.css
@@ -2349,6 +2349,10 @@ img.activity-feed-thumb:hover { box-shadow: 0 2px 6px rgb(0 0 0 / 18%); }
 
 .ac-tip-row--ai { opacity: 0.75; }
 
+/* The line the hovered bar or cell actually draws. Weight alone carries it — the card is one type size throughout,
+   so a heavier line reads as "this is your number" without breaking the column of figures down the right edge. */
+.ac-tip-row--strong { font: var(--text-caption-semibold); }
+
 .ac-tip-head {
   font: var(--text-tiny-semibold);
   margin-top: 6px;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -2067,6 +2067,12 @@ kbd {
   clip-path: polygon(0 100%, 100% 100%, 50% 0);
 }
 
+/* A card too tall to fit on either side of its trigger gets clamped into the viewport, which leaves its edges away
+   from the trigger — a tail would point at nothing, so there is none. */
+.ps-tooltip--untailed::after {
+  display: none;
+}
+
 .ps-tooltip--visible {
   opacity: 1;
   visibility: visible;

--- a/public/js/admin-dashboard/AcrossCitiesPage.js
+++ b/public/js/admin-dashboard/AcrossCitiesPage.js
@@ -199,6 +199,9 @@ class AcrossCitiesPage {
    * labels_7d / validations_7d counted on a slightly different basis (the scorecard joins through audit_task and drops
    * the tutorial street). Keeping them apart is what stops a table from pairing one basis's level with the other's
    * delta. Cities the endpoint has no window for (a failed schema read) get zeros, so they simply rank last.
+   *
+   * `activity_7d` counts what people did, since it decides which cities the table calls the busiest — ranking by a
+   * total that included AI output would put the pipeline's target city on top of a list about communities (#4931).
    */
   #joinActivityWindows() {
     for (const c of this.#cities) {
@@ -214,6 +217,10 @@ class AcrossCitiesPage {
    * Fills the "Today & this week" tiles (#4758): today from the daily series' last (partial) point, the 7-day window
    * values and week-over-week deltas from the endpoint's window_summary, the cities-active / top-city tiles from the
    * per-city rolling windows, and the new-contributor tile from the all-time weekly series.
+   *
+   * Every count here is what people did. AI-role output is real work the project depends on, but pooling it with the
+   * community's would let one pipeline account decide what the whole band says, so it is reported on its own line
+   * under the count it accompanies (#4931).
    */
   #renderNow() {
     // Today (so far): the last point of the zero-filled daily series is today, partial. No delta on these tiles —
@@ -223,6 +230,9 @@ class AcrossCitiesPage {
       this.#setText('now-labels-today', this.#num(today.labels));
       this.#setText('now-validations-today', this.#num(today.validations));
       this.#setText('now-contributors-today', this.#num(today.active_users));
+      this.#renderAiNote('now-labels-today-ai', today.ai_labels, today.labels, 'labels', 'today');
+      this.#renderAiNote('now-validations-today-ai', today.ai_validations, today.validations, 'validations', 'today');
+      this.#renderAgentNote('now-contributors-today-ai', today.ai_agents, 'today');
     }
 
     // Past 7 days: values AND deltas from window_summary so both share the same exact rolling-window basis (summing
@@ -235,6 +245,10 @@ class AcrossCitiesPage {
       this.#renderDelta('now-labels-7d-delta', ws.labels_7d, ws.labels_prior_7d);
       this.#renderDelta('now-validations-7d-delta', ws.validations_7d, ws.validations_prior_7d);
       this.#renderDelta('now-contributors-7d-delta', ws.contributors_7d, ws.contributors_prior_7d);
+      const period = 'in the last 7 days';
+      this.#renderAiNote('now-labels-7d-ai', ws.ai_labels_7d, ws.labels_7d, 'labels', period);
+      this.#renderAiNote('now-validations-7d-ai', ws.ai_validations_7d, ws.validations_7d, 'validations', period);
+      this.#renderAgentNote('now-contributors-7d-ai', ws.ai_agents_7d, period);
     }
 
     // Cities active / top city, from the same per-city rolling windows as the "Most active cities" table below, so
@@ -253,6 +267,49 @@ class AcrossCitiesPage {
     // only series that knows each person's true first-activity week, hence the calendar-week (not rolling) basis.
     const week = this.#allTimeTrend.length ? this.#allTimeTrend[this.#allTimeTrend.length - 1] : null;
     if (week) this.#setText('now-new-contributors', this.#num(week.new_users));
+  }
+
+  /**
+   * Reports the AI output beside a tile's human count, or clears the line when no AI account contributed.
+   *
+   * @param {string} id - Element id of the tile's AI line.
+   * @param {number} aiCount - What AI-role accounts produced in the period.
+   * @param {number} humanCount - What people produced in the same period, for the tooltip's share.
+   * @param {string} noun - What is being counted: 'labels' or 'validations'.
+   * @param {string} period - Phrase naming the period, e.g. 'today' or 'in the last 7 days'.
+   */
+  #renderAiNote(id, aiCount, humanCount, noun, period) {
+    const el = document.getElementById(id);
+    if (!el) return;
+    const ai = aiCount || 0;
+    const people = humanCount || 0;
+    el.textContent = ai ? `+ ${this.#num(ai)} by AI` : '';
+    if (ai) {
+      el.setAttribute('data-ps-tooltip', AcrossCitiesPage.#esc(`People made ${this.#num(people)} of the `
+        + `${this.#num(people + ai)} ${noun} ${period}; ${this.#num(ai)} came from AI accounts.`));
+    } else {
+      el.removeAttribute('data-ps-tooltip');
+    }
+  }
+
+  /**
+   * Reports the AI accounts active alongside a tile's contributor count, or clears the line when there were none.
+   *
+   * @param {string} id - Element id of the tile's AI line.
+   * @param {number} agentCount - Distinct AI-role accounts active in the period.
+   * @param {string} period - Phrase naming the period, e.g. 'today' or 'in the last 7 days'.
+   */
+  #renderAgentNote(id, agentCount, period) {
+    const el = document.getElementById(id);
+    if (!el) return;
+    const agents = agentCount || 0;
+    el.textContent = agents ? `+ ${this.#num(agents)} AI ${agents === 1 ? 'account' : 'accounts'}` : '';
+    if (agents) {
+      el.setAttribute('data-ps-tooltip', AcrossCitiesPage.#esc(`The contributor count is people. `
+        + `${this.#num(agents)} AI ${agents === 1 ? 'account was' : 'accounts were'} also active ${period}.`));
+    } else {
+      el.removeAttribute('data-ps-tooltip');
+    }
   }
 
   /**
@@ -300,19 +357,51 @@ class AcrossCitiesPage {
   }
 
   /**
-   * A table cell's worth of "count + week-over-week change": the count, with a small direction-colored delta chip
-   * beneath it. A city with no activity in either window gets the bare count, since "→ 0%" is noise.
+   * Pulls one metric's current, prior, and AI counts out of a city's rolling window.
    *
-   * @param {number} current - Trailing-7-day count.
-   * @param {number} prior - Count for the 7 days before that.
-   * @returns {string} The cell's inner HTML.
+   * @param {object} w - The city's `activity_window`.
+   * @param {string} metric - 'activity' | 'labels' | 'validations' | 'contributors'.
+   * @returns {{current: number, prior: number, ai: number}} What people did in each window, and what AI produced in
+   *   the current one (for contributors, the AI figure is accounts rather than output).
    */
-  #deltaCell(current, prior) {
-    const count = this.#num(current);
-    if (!current && !prior) return count;
-    const d = this.#deltaParts(current, prior);
-    return `${count}<span class="ac-cell-delta ac-cell-delta--${d.dir}" `
-      + `title="${AcrossCitiesPage.#esc(d.title)}">${d.short}</span>`;
+  #metricCounts(w, metric) {
+    switch (metric) {
+      case 'labels':
+        return { current: w.labels_7d || 0, prior: w.labels_prior_7d || 0, ai: w.ai_labels_7d || 0 };
+      case 'validations':
+        return { current: w.validations_7d || 0, prior: w.validations_prior_7d || 0, ai: w.ai_validations_7d || 0 };
+      case 'contributors':
+        return { current: w.contributors_7d || 0, prior: w.contributors_prior_7d || 0, ai: w.ai_agents_7d || 0 };
+      default: // 'activity' — labels and validations together, the column the table ranks on.
+        return {
+          current: (w.labels_7d || 0) + (w.validations_7d || 0),
+          prior: (w.labels_prior_7d || 0) + (w.validations_prior_7d || 0),
+          ai: (w.ai_labels_7d || 0) + (w.ai_validations_7d || 0),
+        };
+    }
+  }
+
+  /**
+   * A "Most active cities" cell: what people did, the week-over-week chip qualifying it, the AI output alongside, and
+   * a hover card naming the contributors behind the number.
+   *
+   * The chip carries no `title` of its own — the raw counts it would have shown are in the card, and a native tooltip
+   * would open on top of it. The cell takes `tabindex` so the card is reachable by keyboard, since psTooltip opens on
+   * focus too.
+   *
+   * @param {object} city - The scorecard row, carrying `activity_window`.
+   * @param {string} metric - 'activity' | 'labels' | 'validations' | 'contributors'.
+   * @param {boolean} [showDelta=true] - False on the Activity column, where three chipped neighbors are enough.
+   * @returns {string} The cell's markup.
+   */
+  #weekCell(city, metric, showDelta = true) {
+    const { current, prior, ai } = this.#metricCounts(city.activity_window || {}, metric);
+    // A city with no activity in either window gets the bare count, since "→ 0%" is noise.
+    const d = showDelta && (current || prior) ? this.#deltaParts(current, prior) : null;
+    const delta = d ? `<span class="ac-cell-delta ac-cell-delta--${d.dir}">${d.short}</span>` : '';
+    const aiChip = ai ? `<span class="ac-cell-ai">+${this.#compact(ai)} AI</span>` : '';
+    return `<td class="ac-num" tabindex="0" data-ps-tooltip="`
+      + `${AcrossCitiesPage.#esc(this.#cityTipHtml(city, metric))}">${this.#num(current)}${delta}${aiChip}</td>`;
   }
 
   // --- Deployment cities map --------------------------------------------------------------------------------------
@@ -589,19 +678,23 @@ class AcrossCitiesPage {
   /**
    * Draws the "Today & this week" section's rolling-7-day bar charts (#4686) from the server's zero-filled daily
    * series. A rolling 7-day window holds exactly one of each weekday, so short weekday names are unambiguous x
-   * labels; tooltips carry the full date.
+   * labels; the hover card carries the full date.
+   *
+   * All three charts share one card per day (#4931): the three volumes move together, so someone asking why Tuesday's
+   * labels spiked wants that day's validations, cities, and people in the same breath — not three separate hovers.
    */
   #drawWeekBars() {
     const series = this.#dailyTrend;
     const cats = series.map((d) => AcrossCitiesPage.#weekday(d.day));
+    const tooltipsHtml = series.map((d) => this.#dayTipHtml(d));
     const draw = (id, key, jsonKey, name) => {
       const host = document.getElementById(id);
       if (!host) return;
       const values = series.map((d) => d[jsonKey] || 0);
       const tooltips = series.map((d, i) => `${AcrossCitiesPage.#shortDate(d.day)} · ${name}: ${this.#num(values[i])}`);
-      // Compact value labels above each bar (exact counts stay in the tooltips); the last bar is today, still
+      // Compact value labels above each bar (exact counts stay in the cards); the last bar is today, still
       // filling in, so it gets the emphasis treatment.
-      MiniLineChart.renderInto(host, cats, [{ name, key, values, tooltips }],
+      MiniLineChart.renderInto(host, cats, [{ name, key, values, tooltips, tooltipsHtml }],
         { ariaLabel: name, kind: 'bar', maxXLabels: 7, barValues: true, valueFormat: (v) => this.#compact(v),
           emphasisIndex: series.length - 1 });
     };
@@ -785,19 +878,16 @@ class AcrossCitiesPage {
       : this.#sortedCities(state.key, state.dir, active);
     let rows = ranked.slice(0, AcrossCitiesPage.#TOP_CITIES_LIMIT);
     if (state.key === 'city_name') rows = this.#sortedCities(state.key, state.dir, rows);
-    tbody.innerHTML = rows.map((c) => {
-      const w = c.activity_window || {};
-      return `
+    tbody.innerHTML = rows.map((c) => `
         <tr>
           <td class="ac-td-city">${this.#cityLink(c)}</td>
-          <td class="ac-num" title="Labels plus validations in the last 7 days">${this.#num(c.activity_7d)}</td>
-          <td class="ac-num">${this.#deltaCell(w.labels_7d || 0, w.labels_prior_7d || 0)}</td>
-          <td class="ac-num">${this.#deltaCell(w.validations_7d || 0, w.validations_prior_7d || 0)}</td>
-          <td class="ac-num">${this.#deltaCell(w.contributors_7d || 0, w.contributors_prior_7d || 0)}</td>
+          ${this.#weekCell(c, 'activity', false)}
+          ${this.#weekCell(c, 'labels')}
+          ${this.#weekCell(c, 'validations')}
+          ${this.#weekCell(c, 'contributors')}
           <td class="ac-num">${this.#num(c.audits_7d)}</td>
           <td class="ac-spark-cell">${this.#sparkline((c.weekly_trend || []).map((wk) => wk.labels || 0))}</td>
-        </tr>`;
-    }).join('');
+        </tr>`).join('');
     this.#markSortedHeader('ac-top-table');
     this.#setText('ac-top-status', active.length > rows.length
       ? `Top ${rows.length} of ${this.#num(active.length)} cities active in the past 7 days.`
@@ -1110,6 +1200,131 @@ class AcrossCitiesPage {
       + `${legend}${stepRows}</div>`;
   }
 
+  // --- Hover breakdown cards --------------------------------------------------------------------------------------
+
+  /**
+   * One "name — value" line of a hover card.
+   *
+   * @param {string} label - Already-escaped line label.
+   * @param {string} value - Already-escaped value, set at the right edge.
+   * @param {boolean} [muted=false] - True for the AI lines, which sit under the human counts they qualify.
+   * @returns {string} The line's markup.
+   */
+  static #tipRow(label, value, muted = false) {
+    return `<div class="ac-tip-row${muted ? ' ac-tip-row--ai' : ''}"><span>${label}</span>`
+      + `<span class="ac-tip-num">${value}</span></div>`;
+  }
+
+  /**
+   * A section heading inside a hover card.
+   *
+   * @param {string} text - Already-escaped heading text.
+   * @returns {string} The heading's markup.
+   */
+  static #tipHead(text) {
+    return `<div class="ac-tip-head">${text}</div>`;
+  }
+
+  /**
+   * The named-contributor lines of a hover card: one person per line, their labels and validations at the right.
+   *
+   * Usernames are user-supplied and these cards render as HTML, so every name is escaped here rather than at the call
+   * sites — one place to get right. AI accounts keep their line but are marked, so a card that looks like a busy week
+   * can't hide that a pipeline produced it.
+   *
+   * @param {Array<{username: string, isAi: boolean, labels: number, validations: number}>} people - Sorted, busiest
+   *   first.
+   * @param {number} limit - How many lines to draw before collapsing the rest into a "+N more" line. That count is of
+   *   the list the endpoint sent, which it caps (ConfigService.WindowContributorLimit) far above a normal week — so
+   *   the only case it understates is a city with more contributors in one week than the project has ever had.
+   * @returns {string} The lines' markup, empty when nobody qualifies.
+   */
+  #tipPeople(people, limit) {
+    if (!people.length) return '';
+    const shown = people.slice(0, limit).map((p) => {
+      const name = p.username ? AcrossCitiesPage.#esc(p.username) : 'unknown user';
+      const tag = p.isAi ? '<span class="ac-tip-tag">AI</span>' : '';
+      return AcrossCitiesPage.#tipRow(`${name}${tag}`, `${this.#num(p.labels)} · ${this.#num(p.validations)}`);
+    }).join('');
+    const rest = people.length - limit;
+    return rest > 0 ? `${shown}<div class="ac-tip-more">+ ${this.#num(rest)} more</div>` : shown;
+  }
+
+  /**
+   * The hover card for one day's bar: the day's whole picture rather than the one number the bar draws — all three
+   * volumes, what AI contributed, which cities were busiest, and who was active (#4931).
+   *
+   * @param {object} d - A `over_time_daily` entry.
+   * @returns {string} The card's markup.
+   */
+  #dayTipHtml(d) {
+    const title = `<div class="ac-tip-title">${AcrossCitiesPage.#esc(AcrossCitiesPage.#longDate(d.day))}</div>`;
+    const quiet = !d.labels && !d.validations && !d.ai_labels && !d.ai_validations;
+    if (quiet) return `<div class="ac-tip">${title}<div class="ac-tip-more">No activity.</div></div>`;
+
+    let out = title
+      + AcrossCitiesPage.#tipRow('Labels', this.#num(d.labels))
+      + AcrossCitiesPage.#tipRow('Validations', this.#num(d.validations))
+      + AcrossCitiesPage.#tipRow('Contributors', this.#num(d.active_users));
+    if (d.ai_labels) out += AcrossCitiesPage.#tipRow('AI labels', this.#num(d.ai_labels), true);
+    if (d.ai_validations) out += AcrossCitiesPage.#tipRow('AI validations', this.#num(d.ai_validations), true);
+
+    const cities = d.top_cities || [];
+    if (cities.length) {
+      out += AcrossCitiesPage.#tipHead('Busiest cities');
+      out += cities.map((city) => AcrossCitiesPage.#tipRow(
+        AcrossCitiesPage.#esc(city.city_name || city.city_id),
+        this.#num((city.labels || 0) + (city.validations || 0)),
+      )).join('');
+    }
+
+    const people = (d.contributors || []).map((c) => ({
+      username: c.username, isAi: c.is_ai, labels: c.labels || 0, validations: c.validations || 0,
+    }));
+    if (people.length) {
+      out += AcrossCitiesPage.#tipHead('Who was active (labels · validations)');
+      out += this.#tipPeople(people, 5);
+    }
+    return `<div class="ac-tip">${out}</div>`;
+  }
+
+  /**
+   * The hover card for one "Most active cities" cell: both windows' raw counts behind the delta chip, the AI output
+   * beside them, and the people the count is made of — ranked by whichever kind of work the column is about (#4931).
+   *
+   * @param {object} city - The scorecard row, carrying `activity_window`.
+   * @param {string} metric - 'activity' | 'labels' | 'validations' | 'contributors'.
+   * @returns {string} The card's markup.
+   */
+  #cityTipHtml(city, metric) {
+    const w = city.activity_window || {};
+    const { current, prior, ai } = this.#metricCounts(w, metric);
+    const heading = { labels: 'labels', validations: 'validations', contributors: 'contributors' }[metric]
+      ?? 'labels + validations';
+    const title = `${AcrossCitiesPage.#esc(city.city_name || city.city_id)} · ${AcrossCitiesPage.#esc(heading)}`;
+    let out = `<div class="ac-tip-title">${title}</div>`;
+    out += AcrossCitiesPage.#tipRow('Last 7 days', this.#num(current));
+    out += AcrossCitiesPage.#tipRow('7 days before', this.#num(prior));
+    if (ai) {
+      out += AcrossCitiesPage.#tipRow(metric === 'contributors' ? 'AI accounts' : 'By AI', this.#num(ai), true);
+    }
+
+    // The Labels and Validations columns each rank people by the work that column is about; a top labeler and a top
+    // validator are usually different people, and a single "busiest overall" list would bury one of them.
+    const all = (w.contributors || []).map((c) => ({
+      username: c.username, isAi: c.is_ai, labels: c.labels_7d || 0, validations: c.validations_7d || 0,
+    }));
+    const rank = { labels: (p) => p.labels, validations: (p) => p.validations }[metric]
+      ?? ((p) => p.labels + p.validations);
+    const people = all.filter((p) => rank(p) > 0).sort((a, b) => rank(b) - rank(a));
+    if (people.length) {
+      const head = { labels: 'Top labelers', validations: 'Top validators' }[metric] ?? 'Contributors';
+      out += AcrossCitiesPage.#tipHead(`${head} (labels · validations)`);
+      out += this.#tipPeople(people, 5);
+    }
+    return `<div class="ac-tip">${out}</div>`;
+  }
+
   // --- Shared cell builders ---------------------------------------------------------------------------------------
 
   #cityLink(c) {
@@ -1211,6 +1426,13 @@ class AcrossCitiesPage {
     const d = new Date(`${iso}T00:00:00`);
     if (isNaN(d)) return iso;
     return `${d.toLocaleDateString(undefined, { month: 'short' })} '${String(d.getFullYear()).slice(-2)}`;
+  }
+
+  /** "Thu, Jun 9"-style weekday + date from an ISO date string, for hover cards that have room to be unambiguous. */
+  static #longDate(iso) {
+    const d = new Date(`${iso}T00:00:00`);
+    if (isNaN(d)) return iso;
+    return d.toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' });
   }
 
   /** "Thu"-style short weekday from an ISO date string. */

--- a/public/js/admin-dashboard/AcrossCitiesPage.js
+++ b/public/js/admin-dashboard/AcrossCitiesPage.js
@@ -87,6 +87,7 @@ class AcrossCitiesPage {
   #summary = {};         // The summary block (thresholds + cross-city median + hero totals).
   #allTimeTrend = [];    // Cross-city weekly series for the full project history (the "All time" toggle).
   #dailyTrend = [];      // Cross-city daily series for the trailing 7 days (the "this week" bar charts, #4686).
+  #dayTipCards = new Map(); // day → its built hover card, shared by all three per-day charts (#4931).
   #windowSummary = null; // Rolling 7d-vs-prior-7d totals for the "Today & this week" tiles (#4758).
   #windowByCity = {};    // The same rolling windows per city id, for the "Most active cities" table (#4758).
   #trendSeries = {};     // { recent: [...], all: [...] } weekly aggregates for the over-time charts.
@@ -123,6 +124,7 @@ class AcrossCitiesPage {
       this.#summary = (data && data.summary) || {};
       this.#allTimeTrend = (data && data.over_time_all_time) || [];
       this.#dailyTrend = (data && data.over_time_daily) || [];
+      this.#dayTipCards.clear(); // Cards are keyed by day, and a reload can bring new numbers for the same day.
       this.#windowSummary = (data && data.window_summary) || null;
       this.#windowByCity = (data && data.window_by_city) || {};
       this.#joinActivityWindows();
@@ -229,9 +231,10 @@ class AcrossCitiesPage {
     if (today) {
       this.#setText('now-labels-today', this.#num(today.labels));
       this.#setText('now-validations-today', this.#num(today.validations));
-      this.#setText('now-contributors-today', this.#num(today.active_users));
+      this.#setText('now-contributors-today', this.#num(today.contributors));
       this.#renderAiNote('now-labels-today-ai', today.ai_labels, today.labels, 'labels', 'today');
       this.#renderAiNote('now-validations-today-ai', today.ai_validations, today.validations, 'validations', 'today');
+      this.#renderAnonNote('now-contributors-today-anon', today.anon_sessions, 'today');
       this.#renderAgentNote('now-contributors-today-ai', today.ai_agents, 'today');
     }
 
@@ -248,6 +251,7 @@ class AcrossCitiesPage {
       const period = 'in the last 7 days';
       this.#renderAiNote('now-labels-7d-ai', ws.ai_labels_7d, ws.labels_7d, 'labels', period);
       this.#renderAiNote('now-validations-7d-ai', ws.ai_validations_7d, ws.validations_7d, 'validations', period);
+      this.#renderAnonNote('now-contributors-7d-anon', ws.anon_sessions_7d, period);
       this.#renderAgentNote('now-contributors-7d-ai', ws.ai_agents_7d, period);
     }
 
@@ -293,10 +297,36 @@ class AcrossCitiesPage {
   }
 
   /**
+   * Reports the anonymous sessions beside a tile's contributor count, or clears the line when there were none.
+   *
+   * Kept out of the contributor count rather than folded in: an anonymous account is minted per browser cookie, so one
+   * person who visits from two browsers — or clears their cookies — is several of these. Counting them as contributors
+   * would inflate a headline that reads as a headcount, and the work itself is already in the label and validation
+   * totals either way.
+   *
+   * @param {string} id - Element id of the tile's anonymous line.
+   * @param {number} anonCount - Distinct anonymous identities active in the period.
+   * @param {string} period - Phrase naming the period, e.g. 'today' or 'in the last 7 days'.
+   */
+  #renderAnonNote(id, anonCount, period) {
+    const el = document.getElementById(id);
+    if (!el) return;
+    const anon = anonCount || 0;
+    el.textContent = anon ? `+ ${this.#num(anon)} anonymous ${anon === 1 ? 'session' : 'sessions'}` : '';
+    if (anon) {
+      el.setAttribute('data-ps-tooltip', AcrossCitiesPage.#esc('The contributor count is registered accounts. '
+        + `${this.#num(anon)} anonymous ${anon === 1 ? 'session' : 'sessions'} also contributed ${period}; each is a `
+        + 'browser cookie rather than a known person, so they are counted separately.'));
+    } else {
+      el.removeAttribute('data-ps-tooltip');
+    }
+  }
+
+  /**
    * Reports the AI accounts active alongside a tile's contributor count, or clears the line when there were none.
    *
    * @param {string} id - Element id of the tile's AI line.
-   * @param {number} agentCount - Distinct AI-role accounts active in the period.
+   * @param {number} agentCount - Distinct AI-role accounts active in the period, across all cities.
    * @param {string} period - Phrase naming the period, e.g. 'today' or 'in the last 7 days'.
    */
   #renderAgentNote(id, agentCount, period) {
@@ -701,7 +731,7 @@ class AcrossCitiesPage {
     };
     draw('ac-chart-week-labels', 'aclabels', 'labels', 'Labels');
     draw('ac-chart-week-validations', 'acvals', 'validations', 'Validations');
-    draw('ac-chart-week-users', 'acusers', 'active_users', 'Active users');
+    draw('ac-chart-week-users', 'acusers', 'contributors', 'Contributors');
   }
 
   // --- Scorecard table --------------------------------------------------------------------------------------------
@@ -1208,14 +1238,15 @@ class AcrossCitiesPage {
    *
    * @param {string} label - Already-escaped line label.
    * @param {string} value - Already-escaped value, set at the right edge.
-   * @param {boolean} [muted=false] - True for the AI lines, which sit under the human counts they qualify.
-   * @param {boolean} [strong=false] - True for the line the hovered bar or cell actually draws, so a card shared by
-   *   several charts still answers the one you're on first.
+   * @param {boolean} [muted=false] - True for the AI and anonymous lines, which qualify the human counts above them.
+   * @param {string} [rowKey] - Names this row so a card can emphasize it via its own `data-emph`, which is what lets
+   *   the three per-day charts share one built card and each still lean on the line it draws.
    * @returns {string} The line's markup.
    */
-  static #tipRow(label, value, muted = false, strong = false) {
-    const mod = `${muted ? ' ac-tip-row--ai' : ''}${strong ? ' ac-tip-row--strong' : ''}`;
-    return `<div class="ac-tip-row${mod}"><span>${label}</span>`
+  static #tipRow(label, value, muted = false, rowKey = null) {
+    const mod = muted ? ' ac-tip-row--ai' : '';
+    const key = rowKey ? ` data-tip-row="${rowKey}"` : '';
+    return `<div class="ac-tip-row${mod}"${key}><span>${label}</span>`
       + `<span class="ac-tip-num">${value}</span></div>`;
   }
 
@@ -1236,21 +1267,22 @@ class AcrossCitiesPage {
    * sites — one place to get right. AI accounts keep their line but are marked, so a card that looks like a busy week
    * can't hide that a pipeline produced it.
    *
-   * @param {Array<{username: string, isAi: boolean, labels: number, validations: number}>} people - Sorted, busiest
-   *   first.
-   * @param {number} limit - How many lines to draw before collapsing the rest into a "+N more" line. That count is of
-   *   the list the endpoint sent, which it caps (ConfigService.WindowContributorLimit) far above a normal week — so
-   *   the only case it understates is a city with more contributors in one week than the project has ever had.
+   * @param {Array<{username: string, kind: string, labels: number, validations: number}>} people - Sorted, busiest
+   *   first. Already filtered to nameable accounts by the endpoint.
+   * @param {number} limit - How many lines to draw before collapsing the rest into a "+N more" line.
+   * @param {number} total - How many contributors the endpoint's list was drawn from before it capped it. The "+N more"
+   *   count must come from this and not from `people.length`, which is bounded by that cap and would silently
+   *   understate a busy day by an unlimited amount.
    * @returns {string} The lines' markup, empty when nobody qualifies.
    */
-  #tipPeople(people, limit) {
+  #tipPeople(people, limit, total) {
     if (!people.length) return '';
     const shown = people.slice(0, limit).map((p) => {
       const name = p.username ? AcrossCitiesPage.#esc(p.username) : 'unknown user';
-      const tag = p.isAi ? '<span class="ac-tip-tag">AI</span>' : '';
+      const tag = p.kind === 'ai' ? '<span class="ac-tip-tag">AI</span>' : '';
       return AcrossCitiesPage.#tipRow(`${name}${tag}`, `${this.#num(p.labels)} · ${this.#num(p.validations)}`);
     }).join('');
-    const rest = people.length - limit;
+    const rest = Math.max(0, (total ?? people.length) - Math.min(limit, people.length));
     return rest > 0 ? `${shown}<div class="ac-tip-more">+ ${this.#num(rest)} more</div>` : shown;
   }
 
@@ -1258,20 +1290,45 @@ class AcrossCitiesPage {
    * The hover card for one day's bar: the day's whole picture rather than the one number the bar draws — all three
    * volumes, what AI contributed, which cities were busiest, and who was active (#4931).
    *
+   * The card body is built once per day and cached: all three charts show the same day the same way, differing only in
+   * which line they lean on, and that is a `data-emph` on the card root the CSS keys off — so hovering three charts
+   * costs one card, and the three can't drift apart in content.
+   *
    * @param {object} d - A `over_time_daily` entry.
    * @param {string} [emphasisKey] - The `over_time_daily` key the hovered chart draws ('labels', 'validations',
-   *   'active_users'), whose line the card leans on.
+   *   'contributors'), whose line the card leans on.
    * @returns {string} The card's markup.
    */
   #dayTipHtml(d, emphasisKey) {
+    let card = this.#dayTipCards.get(d.day);
+    if (card === undefined) {
+      card = this.#buildDayTip(d);
+      this.#dayTipCards.set(d.day, card);
+    }
+    return emphasisKey ? card.replace('data-emph=""', `data-emph="${AcrossCitiesPage.#esc(emphasisKey)}"`) : card;
+  }
+
+  /**
+   * Builds one day's hover card, with an empty `data-emph` for [[#dayTipHtml]] to fill in per chart.
+   *
+   * @param {object} d - A `over_time_daily` entry.
+   * @returns {string} The card's markup.
+   */
+  #buildDayTip(d) {
     const title = `<div class="ac-tip-title">${AcrossCitiesPage.#esc(AcrossCitiesPage.#longDate(d.day))}</div>`;
-    const quiet = !d.labels && !d.validations && !d.ai_labels && !d.ai_validations;
-    if (quiet) return `<div class="ac-tip">${title}<div class="ac-tip-more">No activity.</div></div>`;
+    // A day with no human work can still have plenty to report — the AI pipeline runs on its own schedule — so the
+    // quiet case is "nothing at all happened", not "the bar this chart draws is zero".
+    const quiet = !d.labels && !d.validations && !d.contributors && !d.anon_sessions
+      && !d.ai_labels && !d.ai_validations;
+    if (quiet) return `<div class="ac-tip" data-emph="">${title}<div class="ac-tip-more">No activity.</div></div>`;
 
     let out = title
-      + AcrossCitiesPage.#tipRow('Labels', this.#num(d.labels), false, emphasisKey === 'labels')
-      + AcrossCitiesPage.#tipRow('Validations', this.#num(d.validations), false, emphasisKey === 'validations')
-      + AcrossCitiesPage.#tipRow('Contributors', this.#num(d.active_users), false, emphasisKey === 'active_users');
+      + AcrossCitiesPage.#tipRow('Labels', this.#num(d.labels), false, 'labels')
+      + AcrossCitiesPage.#tipRow('Validations', this.#num(d.validations), false, 'validations')
+      + AcrossCitiesPage.#tipRow('Contributors', this.#num(d.contributors), false, 'contributors');
+    if (d.anon_sessions) {
+      out += AcrossCitiesPage.#tipRow('Anonymous sessions', this.#num(d.anon_sessions), true);
+    }
     if (d.ai_labels) out += AcrossCitiesPage.#tipRow('AI labels', this.#num(d.ai_labels), true);
     if (d.ai_validations) out += AcrossCitiesPage.#tipRow('AI validations', this.#num(d.ai_validations), true);
 
@@ -1286,14 +1343,14 @@ class AcrossCitiesPage {
       )).join('');
     }
 
-    const people = (d.contributors || []).map((c) => ({
-      username: c.username, isAi: c.is_ai, labels: c.labels || 0, validations: c.validations || 0,
+    const people = (d.contributor_list || []).map((c) => ({
+      username: c.username, kind: c.kind, labels: c.labels || 0, validations: c.validations || 0,
     }));
     if (people.length) {
       out += AcrossCitiesPage.#tipHead('Who was active (labels · validations)');
-      out += this.#tipPeople(people, 5);
+      out += this.#tipPeople(people, 5, d.contributor_total);
     }
-    return `<div class="ac-tip">${out}</div>`;
+    return `<div class="ac-tip" data-emph="">${out}</div>`;
   }
 
   /**
@@ -1313,6 +1370,9 @@ class AcrossCitiesPage {
     let out = `<div class="ac-tip-title">${title}</div>`;
     out += AcrossCitiesPage.#tipRow('Last 7 days', this.#num(current));
     out += AcrossCitiesPage.#tipRow('7 days before', this.#num(prior));
+    if (metric === 'contributors' && w.anon_sessions_7d) {
+      out += AcrossCitiesPage.#tipRow('Anonymous sessions', this.#num(w.anon_sessions_7d), true);
+    }
     if (ai) {
       out += AcrossCitiesPage.#tipRow(metric === 'contributors' ? 'AI accounts' : 'By AI', this.#num(ai), true);
     }
@@ -1320,15 +1380,24 @@ class AcrossCitiesPage {
     // The Labels and Validations columns each rank people by the work that column is about; a top labeler and a top
     // validator are usually different people, and a single "busiest overall" list would bury one of them.
     const all = (w.contributors || []).map((c) => ({
-      username: c.username, isAi: c.is_ai, labels: c.labels_7d || 0, validations: c.validations_7d || 0,
+      username: c.username, kind: c.kind, labels: c.labels_7d || 0, validations: c.validations_7d || 0,
     }));
     const rank = { labels: (p) => p.labels, validations: (p) => p.validations }[metric]
       ?? ((p) => p.labels + p.validations);
-    const people = all.filter((p) => rank(p) > 0).sort((a, b) => rank(b) - rank(a));
-    if (people.length) {
+    // The rows above this list count people only, with AI reported separately, so the list has to be on that basis too.
+    // Ranked together, one pipeline account sorts above every person and reads as the top contributor to a number it is
+    // explicitly excluded from — so AI lines sit after the people, not among them.
+    const ranked = all.filter((p) => rank(p) > 0).sort((a, b) => rank(b) - rank(a));
+    const people = ranked.filter((p) => p.kind !== 'ai');
+    const agents = ranked.filter((p) => p.kind === 'ai');
+    if (people.length || agents.length) {
       const head = { labels: 'Top labelers', validations: 'Top validators' }[metric] ?? 'Contributors';
       out += AcrossCitiesPage.#tipHead(`${head} (labels · validations)`);
-      out += this.#tipPeople(people, 5);
+      // `contributor_total` counts AI alongside people, so discount the agents listed below to keep "+N more" about
+      // the people this list is ranking.
+      const peopleTotal = Math.max(people.length, (w.contributor_total ?? people.length) - agents.length);
+      out += this.#tipPeople(people, 5, peopleTotal);
+      out += this.#tipPeople(agents, agents.length, agents.length);
     }
     return `<div class="ac-tip">${out}</div>`;
   }

--- a/public/js/admin-dashboard/AcrossCitiesPage.js
+++ b/public/js/admin-dashboard/AcrossCitiesPage.js
@@ -682,15 +682,16 @@ class AcrossCitiesPage {
    *
    * All three charts share one card per day (#4931): the three volumes move together, so someone asking why Tuesday's
    * labels spiked wants that day's validations, cities, and people in the same breath — not three separate hovers.
+   * Each chart leans on its own line so the shared card still answers the bar under the cursor first.
    */
   #drawWeekBars() {
     const series = this.#dailyTrend;
     const cats = series.map((d) => AcrossCitiesPage.#weekday(d.day));
-    const tooltipsHtml = series.map((d) => this.#dayTipHtml(d));
     const draw = (id, key, jsonKey, name) => {
       const host = document.getElementById(id);
       if (!host) return;
       const values = series.map((d) => d[jsonKey] || 0);
+      const tooltipsHtml = series.map((d) => this.#dayTipHtml(d, jsonKey));
       const tooltips = series.map((d, i) => `${AcrossCitiesPage.#shortDate(d.day)} · ${name}: ${this.#num(values[i])}`);
       // Compact value labels above each bar (exact counts stay in the cards); the last bar is today, still
       // filling in, so it gets the emphasis treatment.
@@ -1208,10 +1209,13 @@ class AcrossCitiesPage {
    * @param {string} label - Already-escaped line label.
    * @param {string} value - Already-escaped value, set at the right edge.
    * @param {boolean} [muted=false] - True for the AI lines, which sit under the human counts they qualify.
+   * @param {boolean} [strong=false] - True for the line the hovered bar or cell actually draws, so a card shared by
+   *   several charts still answers the one you're on first.
    * @returns {string} The line's markup.
    */
-  static #tipRow(label, value, muted = false) {
-    return `<div class="ac-tip-row${muted ? ' ac-tip-row--ai' : ''}"><span>${label}</span>`
+  static #tipRow(label, value, muted = false, strong = false) {
+    const mod = `${muted ? ' ac-tip-row--ai' : ''}${strong ? ' ac-tip-row--strong' : ''}`;
+    return `<div class="ac-tip-row${mod}"><span>${label}</span>`
       + `<span class="ac-tip-num">${value}</span></div>`;
   }
 
@@ -1255,26 +1259,30 @@ class AcrossCitiesPage {
    * volumes, what AI contributed, which cities were busiest, and who was active (#4931).
    *
    * @param {object} d - A `over_time_daily` entry.
+   * @param {string} [emphasisKey] - The `over_time_daily` key the hovered chart draws ('labels', 'validations',
+   *   'active_users'), whose line the card leans on.
    * @returns {string} The card's markup.
    */
-  #dayTipHtml(d) {
+  #dayTipHtml(d, emphasisKey) {
     const title = `<div class="ac-tip-title">${AcrossCitiesPage.#esc(AcrossCitiesPage.#longDate(d.day))}</div>`;
     const quiet = !d.labels && !d.validations && !d.ai_labels && !d.ai_validations;
     if (quiet) return `<div class="ac-tip">${title}<div class="ac-tip-more">No activity.</div></div>`;
 
     let out = title
-      + AcrossCitiesPage.#tipRow('Labels', this.#num(d.labels))
-      + AcrossCitiesPage.#tipRow('Validations', this.#num(d.validations))
-      + AcrossCitiesPage.#tipRow('Contributors', this.#num(d.active_users));
+      + AcrossCitiesPage.#tipRow('Labels', this.#num(d.labels), false, emphasisKey === 'labels')
+      + AcrossCitiesPage.#tipRow('Validations', this.#num(d.validations), false, emphasisKey === 'validations')
+      + AcrossCitiesPage.#tipRow('Contributors', this.#num(d.active_users), false, emphasisKey === 'active_users');
     if (d.ai_labels) out += AcrossCitiesPage.#tipRow('AI labels', this.#num(d.ai_labels), true);
     if (d.ai_validations) out += AcrossCitiesPage.#tipRow('AI validations', this.#num(d.ai_validations), true);
 
     const cities = d.top_cities || [];
     if (cities.length) {
-      out += AcrossCitiesPage.#tipHead('Busiest cities');
+      // Cities carry the same "labels · validations" pair as the contributor lines below rather than one combined
+      // total: a lone number under a "busiest" heading reads as whichever row above it happens to match that day.
+      out += AcrossCitiesPage.#tipHead('Busiest cities (labels · validations)');
       out += cities.map((city) => AcrossCitiesPage.#tipRow(
         AcrossCitiesPage.#esc(city.city_name || city.city_id),
-        this.#num((city.labels || 0) + (city.validations || 0)),
+        `${this.#num(city.labels || 0)} · ${this.#num(city.validations || 0)}`,
       )).join('');
     }
 

--- a/public/js/admin-dashboard/MiniLineChart.js
+++ b/public/js/admin-dashboard/MiniLineChart.js
@@ -9,8 +9,13 @@
 class MiniLineChart {
   /**
    * @param {string[]} categories - x-axis labels (one per data index).
-   * @param {Array<{name: string, key: string, values: Array<number|null>, tooltips?: string[]}>} series -
-   *   each series' values align to `categories`; null = gap. Optional per-point tooltip strings.
+   * @param {Array<{name: string, key: string, values: Array<number|null>, tooltips?: string[],
+   *          tooltipsHtml?: string[]}>} series -
+   *   each series' values align to `categories`; null = gap. Optional per-point tooltip strings, and optional
+   *   per-point rich cards: where `tooltipsHtml` has an entry, the point trades its native `<title>` for a
+   *   `data-ps-tooltip` card and becomes focusable, so the breakdown is reachable by keyboard as well as hover (the
+   *   plain `tooltips` string stays on as its accessible name). Card markup is first-party only — escape any name or
+   *   other data that came from a user before putting it in one.
    * @param {{yMax?: number, tickFormat?: function(number): string, valueFormat?: function(number): string,
    *          ariaLabel?: string, dotRadius?: number, kind?: string, maxXLabels?: number, barValues?: boolean,
    *          emphasisIndex?: number, minMarginL?: number, minMarginR?: number}} [opts] - yMax defaults to a nice
@@ -88,8 +93,8 @@ class MiniLineChart {
           let out = h <= 0
             ? ''
             : `<rect class="mini-bar mini-bar--${s.key}${emph ? ' mini-bar--emphasis' : ''}" x="${bx.toFixed(1)}" `
-              + `y="${top.toFixed(1)}" width="${barW.toFixed(1)}" height="${h.toFixed(1)}">`
-              + `<title>${MiniLineChart.#esc(tip)}</title></rect>`;
+              + `y="${top.toFixed(1)}" width="${barW.toFixed(1)}" height="${h.toFixed(1)}"`
+              + `${MiniLineChart.#pointTip(tip, s.tooltipsHtml?.[i])}</rect>`;
           if (opts.barValues) {
             out += `<text class="mini-value${emph ? ' mini-value--emphasis' : ''}" x="${(bx + barW / 2).toFixed(1)}" `
               + `y="${((h > 0 ? top : yFrac(0)) - 4).toFixed(1)}" text-anchor="middle">`
@@ -114,8 +119,8 @@ class MiniLineChart {
           if (v === null || v === undefined) return '';
           const tip = s.tooltips?.[i] ?? `${categories[i]} · ${s.name}: ${valueFormat(v)}`;
           return `<circle class="mini-pt mini-pt--${s.key}" cx="${x(i).toFixed(1)}" `
-            + `cy="${yFrac(v / yMax).toFixed(1)}" r="${dotRadius}">`
-            + `<title>${MiniLineChart.#esc(tip)}</title></circle>`;
+            + `cy="${yFrac(v / yMax).toFixed(1)}" r="${dotRadius}"`
+            + `${MiniLineChart.#pointTip(tip, s.tooltipsHtml?.[i])}</circle>`;
         }).join('');
         body += `<path class="mini-line mini-line--${s.key}" d="${d.trim()}"/>${dots}`;
       }
@@ -268,6 +273,23 @@ class MiniLineChart {
       else em += 0.58;
     }
     return em * MiniLineChart.#AXIS_FONT_PX;
+  }
+
+  /**
+   * Closes a point's opening tag and gives it a tooltip: a native `<title>` normally, or a psTooltip card plus the
+   * focusability and accessible name that card needs when the caller supplied rich markup for this point.
+   *
+   * The two are exclusive on purpose — a point carrying both would answer a hover with a card and a native tooltip
+   * stacked on top of each other.
+   *
+   * @param {string} tip - Plain-text summary of the point.
+   * @param {string} [html] - Rich card markup for the point; already escaped for any user-supplied text it contains.
+   * @returns {string} Markup closing the point's opening tag, with its `<title>` child when there is one.
+   */
+  static #pointTip(tip, html) {
+    if (!html) return `><title>${MiniLineChart.#esc(tip)}</title>`;
+    return ` tabindex="0" role="img" aria-label="${MiniLineChart.#esc(tip)}" `
+      + `data-ps-tooltip="${MiniLineChart.#esc(html)}">`;
   }
 
   static #esc(s) {

--- a/public/js/admin-dashboard/MiniLineChart.js
+++ b/public/js/admin-dashboard/MiniLineChart.js
@@ -89,12 +89,17 @@ class MiniLineChart {
           const h = m.t + ih - top;
           const bx = x(i) - groupW / 2 + si * barW;
           const tip = s.tooltips?.[i] ?? `${categories[i]} · ${s.name}: ${valueFormat(v)}`;
-          // Zero values draw no bar; the x label (and value label, if enabled) still mark the category.
+          // A zero value draws no bar, so the interaction lives on a full-height invisible rect instead of on the bar
+          // itself. Otherwise a zero-value category would have nothing to hover or focus — and a day can read zero here
+          // while still having something to say (an AI-only day, or one whose other charts are non-zero). It doubles as
+          // a bigger target for the non-zero bars.
           let out = h <= 0
             ? ''
             : `<rect class="mini-bar mini-bar--${s.key}${emph ? ' mini-bar--emphasis' : ''}" x="${bx.toFixed(1)}" `
-              + `y="${top.toFixed(1)}" width="${barW.toFixed(1)}" height="${h.toFixed(1)}"`
-              + `${MiniLineChart.#pointTip(tip, s.tooltipsHtml?.[i])}</rect>`;
+              + `y="${top.toFixed(1)}" width="${barW.toFixed(1)}" height="${h.toFixed(1)}"/>`;
+          out += `<rect class="mini-bar-hit" x="${bx.toFixed(1)}" y="${m.t.toFixed(1)}" `
+            + `width="${barW.toFixed(1)}" height="${ih.toFixed(1)}"`
+            + `${MiniLineChart.#pointTip(tip, s.tooltipsHtml?.[i])}</rect>`;
           if (opts.barValues) {
             out += `<text class="mini-value${emph ? ' mini-value--emphasis' : ''}" x="${(bx + barW / 2).toFixed(1)}" `
               + `y="${((h > 0 ? top : yFrac(0)) - 4).toFixed(1)}" text-anchor="middle">`
@@ -132,7 +137,12 @@ class MiniLineChart {
       xlab += `<text class="mini-axis${emph}" x="${x(i).toFixed(1)}" y="${H - 8}" text-anchor="middle">`
         + `${MiniLineChart.#esc(categories[i])}</text>`;
     }
-    const svg = `<svg class="mini-chart-svg" viewBox="0 0 ${W} ${H}" preserveAspectRatio="xMidYMid meet" role="img" `
+    // `role="img"` makes an element's subtree presentational, which would prune the per-point roles and labels below it
+    // out of the accessibility tree. So a chart whose points are individually focusable is a `group` instead, leaving
+    // them reachable and announced; a chart that is just a picture keeps `img`.
+    const hasFocusablePoints = series.some((s) => s.tooltipsHtml?.some(Boolean));
+    const svg = `<svg class="mini-chart-svg" viewBox="0 0 ${W} ${H}" preserveAspectRatio="xMidYMid meet" `
+      + `role="${hasFocusablePoints ? 'group' : 'img'}" `
       + `aria-label="${MiniLineChart.#esc(opts.ariaLabel || 'Line chart')}"><g>${grid}</g>${body}<g>${xlab}</g></svg>`;
     const legendItems = series.map((s) =>
       `<span class="mini-legend-item"><span class="mini-swatch mini-swatch--${s.key}"></span>`

--- a/public/js/common/psTooltip.js
+++ b/public/js/common/psTooltip.js
@@ -8,9 +8,18 @@
  * places it, and main.css draws it. Escape dismisses it (WCAG 1.4.13). Set the attribute directly, or via i18nDom's
  * `data-i18n-tooltip="ns:key"` so the text stays translated.
  *
- * The attribute value renders as HTML so translation strings can carry inline emphasis (<b>, <i>). That makes it a
- * hard rule that `data-ps-tooltip` only ever holds first-party strings (our translation files) — never user-supplied
- * or third-party text.
+ * **The attribute value renders as HTML** (`innerHTML`), so translation strings can carry inline emphasis (<b>, <i>)
+ * and a caller can build a small rich card. That makes escaping the caller's responsibility, and the requirement is
+ * *double* escaping for anything user-supplied — a username, a label description, any third-party text:
+ *
+ *   1. Escape the value, and interpolate it into the card markup.
+ *   2. Escape that whole markup string again when writing it into the `data-ps-tooltip` attribute.
+ *
+ * Parsing the attribute consumes one level and `innerHTML` here consumes the other, so a username of
+ * `<img onerror=...>` arrives as text. One level of escaping is a stored-XSS hole, not a cosmetic bug: skip step 2 and
+ * the attribute closes early, letting the value inject arbitrary markup into the host page.
+ * `AcrossCitiesPage.#dayTipHtml` is the worked example, and `test/js/acrossCitiesBreakdowns.test.js` pins it.
+ * Plain-text callers need none of this — pass first-party text and it renders as-is.
  *
  * Loaded globally from main.scala.html (like i18nDom.js); no per-app setup needed — listeners are delegated on the
  * document, so triggers added at any time just work.
@@ -70,7 +79,8 @@
     // dialog sets no transform/filter, so the card stays fixed to the viewport and escapes the dialog's overflow.
     const host = trigger.closest('dialog[open]') ?? document.body;
     if (card.parentElement !== host) host.appendChild(card);
-    // Rendered as HTML per the header contract: tooltip strings are first-party translations, never user input.
+    // Rendered as HTML per the header contract, which is also why that contract requires callers to double-escape any
+    // user-supplied text they interpolate: this is the second of the two levels being consumed.
     card.innerHTML = trigger.getAttribute('data-ps-tooltip');
     card.classList.remove('ps-tooltip--flipped'); // Reset before measuring; the flip below re-adds it if needed.
 
@@ -96,8 +106,18 @@
       top = below;
       card.classList.add('ps-tooltip--flipped');
     }
+    // Clamp vertically the same way as horizontally, because a tall card near the middle of a short viewport fits on
+    // neither side and would otherwise run off the bottom with its lower rows unreachable. A card taller than the
+    // viewport still overflows, but pins to the top so it is read from the beginning.
+    const clampedTop = Math.max(
+      VIEWPORT_MARGIN_PX,
+      Math.min(top, window.innerHeight - cardRect.height - VIEWPORT_MARGIN_PX),
+    );
+    // A clamp moves the card off the trigger's edge, so its tail would point at empty space; drop the tail instead.
+    if (clampedTop !== top) card.classList.add('ps-tooltip--untailed');
+    else card.classList.remove('ps-tooltip--untailed');
     card.style.left = `${left}px`;
-    card.style.top = `${top}px`;
+    card.style.top = `${clampedTop}px`;
 
     // Aim the tail at the trigger's center, not the card's: the clamp above slides the card sideways near a viewport
     // edge, and a tail pinned to the card's middle would then point at empty space.

--- a/test/js/acrossCitiesBreakdowns.test.js
+++ b/test/js/acrossCitiesBreakdowns.test.js
@@ -1,10 +1,11 @@
 /**
- * Tests for the human/AI split and the hover breakdown cards on /admin/across-cities (#4931).
+ * Tests for the attribution split and the hover breakdown cards on /admin/across-cities (#4931).
  *
- * Two contracts worth pinning. First, every count in the "Today & this week" section is what people did, with AI
- * output reported on its own line — one pipeline account can out-produce the whole community, so a blended count
- * would describe the pipeline. Second, the cards that explain those counts name the contributors behind them, which
- * means they carry user-supplied text into markup and must escape it.
+ * Three contracts worth pinning. First, every volume in the "Today & this week" section is what people did, with AI
+ * output reported on its own line — one pipeline account can out-produce the whole community, so a blended count would
+ * describe the pipeline. Second, every headcount is registered people, with anonymous cookie identities and AI accounts
+ * counted beside them rather than folded in. Third, the cards that explain those counts name the contributors behind
+ * them, which means they carry user-supplied text into markup and must escape it twice (see psTooltip's header).
  *
  * Runs under jsdom (jest.config.js). AcrossCitiesPage is a bare top-level class in a concatenated bundle, so it is
  * eval'd into global scope rather than required; MiniLineChart has to be present first, since the page draws with it.
@@ -25,12 +26,13 @@ function loadPage() {
 const MARKUP = `
   <span id="now-labels-today">—</span><span id="now-labels-today-ai"></span>
   <span id="now-validations-today">—</span><span id="now-validations-today-ai"></span>
-  <span id="now-contributors-today">—</span><span id="now-contributors-today-ai"></span>
+  <span id="now-contributors-today">—</span><span id="now-contributors-today-anon"></span>
+  <span id="now-contributors-today-ai"></span>
   <span id="now-labels-7d">—</span><span id="now-labels-7d-delta"></span><span id="now-labels-7d-ai"></span>
   <span id="now-validations-7d">—</span><span id="now-validations-7d-delta"></span>
   <span id="now-validations-7d-ai"></span>
   <span id="now-contributors-7d">—</span><span id="now-contributors-7d-delta"></span>
-  <span id="now-contributors-7d-ai"></span>
+  <span id="now-contributors-7d-anon"></span><span id="now-contributors-7d-ai"></span>
   <span id="now-cities-active">—</span><span id="now-top-city">—</span><span id="now-top-city-count"></span>
   <div class="mini-chart" id="ac-chart-week-labels"></div>
   <div class="mini-chart" id="ac-chart-week-validations"></div>
@@ -57,12 +59,14 @@ function makeDay(day, d = {}) {
     day,
     labels: 0,
     validations: 0,
-    active_users: 0,
+    contributors: 0,
+    anon_sessions: 0,
     ai_labels: 0,
     ai_validations: 0,
     ai_agents: 0,
+    contributor_total: 0,
     top_cities: [],
-    contributors: [],
+    contributor_list: [],
     ...d,
   };
 }
@@ -82,7 +86,10 @@ function makeCity(id, w) {
       ai_validations_prior_7d: 0,
       contributors_7d: 0,
       contributors_prior_7d: 0,
+      anon_sessions_7d: 0,
+      anon_sessions_prior_7d: 0,
       ai_agents_7d: 0,
+      contributor_total: (w?.contributors || []).length,
       contributors: [],
       ...w,
     },
@@ -90,10 +97,10 @@ function makeCity(id, w) {
 }
 
 /** One entry of a city window's contributor list. */
-function contributor(username, labels, validations, isAi = false) {
+function contributor(username, labels, validations, kind = 'registered') {
   return {
     username,
-    is_ai: isAi,
+    kind,
     labels_7d: labels,
     labels_prior_7d: 0,
     validations_7d: validations,
@@ -101,7 +108,12 @@ function contributor(username, labels, validations, isAi = false) {
   };
 }
 
-describe('Across Cities — human/AI split and hover breakdowns', () => {
+/** One entry of a day's contributor list. */
+function dayContributor(username, labels, validations, kind = 'registered') {
+  return { username, kind, labels, validations };
+}
+
+describe('Across Cities — attribution split and hover breakdowns', () => {
   let AcrossCitiesPage;
 
   /**
@@ -135,9 +147,14 @@ describe('Across Cities — human/AI split and hover breakdowns', () => {
     return document.querySelectorAll('#ac-top-tbody tr')[0].cells[index].getAttribute('data-ps-tooltip');
   }
 
+  /** The hover/focus target for the bar at `index` of a per-day chart. */
+  function barTarget(index, chart = 'labels') {
+    return document.querySelectorAll(`#ac-chart-week-${chart} rect.mini-bar-hit`)[index];
+  }
+
   /** The hover-card markup on the bar at `index` of the labels-per-day chart. */
-  function barCard(index) {
-    return document.querySelectorAll('#ac-chart-week-labels rect.mini-bar')[index].getAttribute('data-ps-tooltip');
+  function barCard(index, chart = 'labels') {
+    return barTarget(index, chart).getAttribute('data-ps-tooltip');
   }
 
   beforeEach(() => {
@@ -158,6 +175,27 @@ describe('Across Cities — human/AI split and hover breakdowns', () => {
       expect(document.getElementById('now-validations-7d-ai').textContent).toBe('+ 6,420 by AI');
       expect(document.getElementById('now-contributors-7d').textContent).toBe('64');
       expect(document.getElementById('now-contributors-7d-ai').textContent).toBe('+ 1 AI account');
+    });
+
+    it('reports anonymous sessions beside the contributor count, not inside it', async () => {
+      await render({
+        summary: {
+          labels_7d: 100, validations_7d: 50, contributors_7d: 41, contributors_prior_7d: 40,
+          anon_sessions_7d: 23, ai_agents_7d: 1,
+        },
+      });
+
+      expect(document.getElementById('now-contributors-7d').textContent).toBe('41');
+      expect(document.getElementById('now-contributors-7d-anon').textContent).toBe('+ 23 anonymous sessions');
+      expect(document.getElementById('now-contributors-7d-anon').getAttribute('data-ps-tooltip'))
+        .toContain('browser cookie');
+    });
+
+    it('leaves the anonymous line empty when no anonymous visitor contributed', async () => {
+      await render({ summary: { labels_7d: 10, contributors_7d: 3, anon_sessions_7d: 0 } });
+
+      expect(document.getElementById('now-contributors-7d-anon').textContent).toBe('');
+      expect(document.getElementById('now-contributors-7d-anon').hasAttribute('data-ps-tooltip')).toBe(false);
     });
 
     it('measures the week-over-week delta on the human count, not the blended one', async () => {
@@ -190,32 +228,36 @@ describe('Across Cities — human/AI split and hover breakdowns', () => {
 
     it('reports today from the daily series on the same split', async () => {
       await render({
-        daily: [makeDay('2026-08-12', { labels: 12, validations: 3, active_users: 2, ai_validations: 400,
-          ai_agents: 1 })],
+        daily: [makeDay('2026-08-12', { labels: 12, validations: 3, contributors: 2, anon_sessions: 5,
+          ai_validations: 400, ai_agents: 1 })],
       });
 
       expect(document.getElementById('now-labels-today').textContent).toBe('12');
+      expect(document.getElementById('now-contributors-today').textContent).toBe('2');
       expect(document.getElementById('now-validations-today-ai').textContent).toBe('+ 400 by AI');
+      expect(document.getElementById('now-contributors-today-anon').textContent).toBe('+ 5 anonymous sessions');
       expect(document.getElementById('now-contributors-today-ai').textContent).toBe('+ 1 AI account');
     });
   });
 
   describe('day bars', () => {
     const DAILY = [
-      makeDay('2026-08-11', { labels: 40, validations: 10, active_users: 3 }),
+      makeDay('2026-08-11', { labels: 40, validations: 10, contributors: 3, contributor_total: 3 }),
       makeDay('2026-08-12', {
         labels: 120,
         validations: 30,
-        active_users: 4,
+        contributors: 4,
+        anon_sessions: 6,
         ai_validations: 6420,
         ai_agents: 1,
+        contributor_total: 5,
         top_cities: [
           { city_id: 'chicago-il', city_name: 'Chicago', labels: 100, validations: 20, contributors: 3 },
           { city_id: 'seattle-wa', city_name: 'Seattle', labels: 20, validations: 10, contributors: 1 },
         ],
-        contributors: [
-          { username: 'alice', is_ai: false, labels: 100, validations: 20 },
-          { username: 'sidewalk-ai', is_ai: true, labels: 0, validations: 6420 },
+        contributor_list: [
+          dayContributor('alice', 100, 20),
+          dayContributor('sidewalk-ai', 0, 6420, 'ai'),
         ],
       }),
     ];
@@ -233,26 +275,28 @@ describe('Across Cities — human/AI split and hover breakdowns', () => {
       expect(card).toContain('6,420');
     });
 
-    it('gives every chart the same day, so one hover explains all three', async () => {
+    it('reports the day\'s anonymous sessions as their own line', async () => {
       await render({ daily: DAILY });
-      const fromValidations = document.querySelectorAll('#ac-chart-week-validations rect.mini-bar')[1]
-        .getAttribute('data-ps-tooltip');
-      const strip = (card) => card.replace(/ ac-tip-row--strong/g, '');
 
-      expect(strip(fromValidations)).toBe(strip(barCard(1)));
+      expect(barCard(1)).toContain('Anonymous sessions');
+      expect(barCard(1)).toContain('<span>Anonymous sessions</span><span class="ac-tip-num">6</span>');
+    });
+
+    it('gives every chart the identical card, so one hover explains all three', async () => {
+      await render({ daily: DAILY });
+      const strip = (card) => card.replace(/ data-emph="[a-z]*"/, '');
+
+      expect(strip(barCard(1, 'validations'))).toBe(strip(barCard(1)));
+      expect(strip(barCard(1, 'users'))).toBe(strip(barCard(1)));
     });
 
     it('leans on the line the hovered chart draws, so a shared card still answers this bar', async () => {
       await render({ daily: DAILY });
-      const strongRow = (card) => card.match(/ac-tip-row ac-tip-row--strong"><span>([^<]+)/)[1];
-      const fromValidations = document.querySelectorAll('#ac-chart-week-validations rect.mini-bar')[1]
-        .getAttribute('data-ps-tooltip');
-      const fromUsers = document.querySelectorAll('#ac-chart-week-users rect.mini-bar')[1]
-        .getAttribute('data-ps-tooltip');
+      const emph = (card) => card.match(/data-emph="([a-z]*)"/)[1];
 
-      expect(strongRow(barCard(1))).toBe('Labels');
-      expect(strongRow(fromValidations)).toBe('Validations');
-      expect(strongRow(fromUsers)).toBe('Contributors');
+      expect(emph(barCard(1))).toBe('labels');
+      expect(emph(barCard(1, 'validations'))).toBe('validations');
+      expect(emph(barCard(1, 'users'))).toBe('contributors');
     });
 
     it('names the day\'s busiest cities and its contributors', async () => {
@@ -280,9 +324,33 @@ describe('Across Cities — human/AI split and hover breakdowns', () => {
       expect(barCard(1)).toContain('ac-tip-tag');
     });
 
+    it('counts "+N more" from the untruncated total the server sent, not from the capped list', async () => {
+      // The server caps the list it ships, so a count derived from the list can never exceed (cap - shown) and would
+      // silently understate a busy day. 40 contributors, 8 shipped, 5 shown → "+ 35 more", not "+ 3 more".
+      const people = Array.from({ length: 8 }, (_, i) => dayContributor(`user${i}`, 10 - i, 0));
+      await render({
+        daily: [makeDay('2026-08-12', {
+          labels: 100, contributors: 40, contributor_total: 40, contributor_list: people,
+        })],
+      });
+
+      expect(barCard(0)).toContain('+ 35 more');
+    });
+
+    it('omits "+N more" when the list is complete', async () => {
+      await render({
+        daily: [makeDay('2026-08-12', {
+          labels: 10, contributors: 2, contributor_total: 2,
+          contributor_list: [dayContributor('a', 8, 0), dayContributor('b', 2, 0)],
+        })],
+      });
+
+      expect(barCard(0)).not.toContain('more');
+    });
+
     it('makes each bar focusable and named, so the card is reachable without a pointer', async () => {
       await render({ daily: DAILY });
-      const bar = document.querySelectorAll('#ac-chart-week-labels rect.mini-bar')[1];
+      const bar = barTarget(1);
 
       expect(bar.getAttribute('tabindex')).toBe('0');
       expect(bar.getAttribute('aria-label')).toContain('Labels');
@@ -290,15 +358,55 @@ describe('Across Cities — human/AI split and hover breakdowns', () => {
       expect(bar.querySelector('title')).toBeNull();
     });
 
-    it('says so plainly when nothing happened that day', async () => {
-      await render({
-        daily: [makeDay('2026-08-11'), makeDay('2026-08-12', { labels: 5, active_users: 1 })],
-      });
-      // The quiet day draws no bar, so its card rides the value label; assert through the chart's own series data.
-      const bars = document.querySelectorAll('#ac-chart-week-labels rect.mini-bar');
+    it('gives a zero-value day a hover target too, so no day is unreachable', async () => {
+      // A bar of height zero draws no rect, so the interaction has to live on a full-height hit area instead.
+      await render({ daily: [makeDay('2026-08-11'), makeDay('2026-08-12', { labels: 5, contributors: 1 })] });
 
-      expect(bars.length).toBe(1);
-      expect(bars[0].getAttribute('data-ps-tooltip')).toContain('5');
+      expect(document.querySelectorAll('#ac-chart-week-labels rect.mini-bar').length).toBe(1);
+      expect(document.querySelectorAll('#ac-chart-week-labels rect.mini-bar-hit').length).toBe(2);
+      expect(barTarget(0).getAttribute('tabindex')).toBe('0');
+    });
+
+    it('still reports an AI-only day, whose every bar reads zero', async () => {
+      // The pipeline runs on its own schedule, so this is a real day in prod — and the card is the only place its work
+      // can show up. Treating it as quiet would hide 6,420 validations behind an empty slot.
+      await render({
+        daily: [makeDay('2026-08-12', { ai_validations: 6420, ai_agents: 1, contributor_total: 1,
+          contributor_list: [dayContributor('sidewalk-ai', 0, 6420, 'ai')] })],
+      });
+      const card = barCard(0);
+
+      expect(card).not.toContain('No activity.');
+      expect(card).toContain('AI validations');
+      expect(card).toContain('6,420');
+      expect(card).toContain('sidewalk-ai');
+    });
+
+    it('says so plainly when nothing happened that day', async () => {
+      await render({ daily: [makeDay('2026-08-11'), makeDay('2026-08-12', { labels: 5, contributors: 1 })] });
+
+      expect(barCard(0)).toContain('No activity.');
+    });
+
+    it('escapes usernames in a day card, which is markup carrying user-supplied text', async () => {
+      await render({
+        daily: [makeDay('2026-08-12', {
+          labels: 2, contributors: 1, contributor_total: 1,
+          contributor_list: [dayContributor('<img src=x onerror=alert(1)>', 2, 0)],
+        })],
+      });
+      // Two levels of escaping: attribute parsing consumes one, psTooltip's innerHTML the other. Reading the attribute
+      // back through the DOM has already consumed the first, so rendering it as HTML models exactly what psTooltip does.
+      document.body.insertAdjacentHTML('beforeend', `<div id="probe">${barCard(0)}</div>`);
+
+      expect(document.querySelectorAll('#probe img').length).toBe(0);
+    });
+
+    it('groups a chart whose bars are individually focusable, so their names survive in the a11y tree', async () => {
+      // role="img" on the <svg> would make its subtree presentational and prune the per-bar roles and labels.
+      await render({ daily: DAILY });
+
+      expect(document.querySelector('#ac-chart-week-labels svg').getAttribute('role')).toBe('group');
     });
   });
 
@@ -311,12 +419,14 @@ describe('Across Cities — human/AI split and hover breakdowns', () => {
       ai_validations_7d: 6420,
       contributors_7d: 3,
       contributors_prior_7d: 2,
+      anon_sessions_7d: 4,
       ai_agents_7d: 1,
+      contributor_total: 4,
       contributors: [
         contributor('carol', 5, 25),
         contributor('alice', 100, 2),
         contributor('bob', 15, 3),
-        contributor('sidewalk-ai', 0, 6420, true),
+        contributor('sidewalk-ai', 0, 6420, 'ai'),
       ],
     })];
 
@@ -355,14 +465,44 @@ describe('Across Cities — human/AI split and hover breakdowns', () => {
 
       // alice labels most; carol validates most among people — one "busiest overall" list would bury one of them.
       expect(cellCard(2).indexOf('alice')).toBeLessThan(cellCard(2).indexOf('carol'));
-      expect(cellCard(3).indexOf('sidewalk-ai')).toBeLessThan(cellCard(3).indexOf('carol'));
       expect(cellCard(3).indexOf('carol')).toBeLessThan(cellCard(3).indexOf('bob'));
+    });
+
+    it('lists AI after the people, since the count above it excludes AI', async () => {
+      // Ranked together, the pipeline sorts first and reads as the top contributor to a number it is not part of: the
+      // card's headline says 30 validations while the AI line says 6,420.
+      await render({ cities: CITIES });
+
+      expect(cellCard(3).indexOf('carol')).toBeLessThan(cellCard(3).indexOf('sidewalk-ai'));
+    });
+
+    it('keeps "+N more" about the people it ranks, discounting the AI lines it also shows', async () => {
+      const people = Array.from({ length: 10 }, (_, i) => contributor(`user${i}`, 20 - i, 0));
+      const cities = [makeCity('busy', {
+        labels_7d: 500,
+        contributors_7d: 30,
+        ai_agents_7d: 1,
+        contributor_total: 31,
+        contributors: [...people, contributor('sidewalk-ai', 999, 0, 'ai')],
+      })];
+      await render({ cities });
+
+      // 31 nameable contributors, one of which is the AI listed separately → 30 people, 5 shown.
+      expect(cellCard(2)).toContain('+ 25 more');
+    });
+
+    it('reports a city\'s anonymous sessions in its contributors card', async () => {
+      await render({ cities: CITIES });
+
+      expect(cellCard(4)).toContain('Anonymous sessions');
+      expect(cellCard(4)).toContain('<span>Anonymous sessions</span><span class="ac-tip-num">4</span>');
     });
 
     it('leaves out anyone with no activity in the window the column is about', async () => {
       const cities = [makeCity('quiet', {
         labels_7d: 4,
         contributors_7d: 2,
+        contributor_total: 2,
         contributors: [contributor('labeler', 4, 0), contributor('validator-only', 0, 0)],
       })];
       await render({ cities });
@@ -375,6 +515,7 @@ describe('Across Cities — human/AI split and hover breakdowns', () => {
       const cities = [makeCity('city', {
         labels_7d: 2,
         contributors_7d: 1,
+        contributor_total: 1,
         contributors: [contributor('<img src=x onerror=alert(1)>', 2, 0)],
       })];
       await render({ cities });

--- a/test/js/acrossCitiesBreakdowns.test.js
+++ b/test/js/acrossCitiesBreakdowns.test.js
@@ -233,11 +233,26 @@ describe('Across Cities — human/AI split and hover breakdowns', () => {
       expect(card).toContain('6,420');
     });
 
-    it('gives every chart the same card for a given day, so one hover explains all three', async () => {
+    it('gives every chart the same day, so one hover explains all three', async () => {
       await render({ daily: DAILY });
-      const fromValidations = document.querySelectorAll('#ac-chart-week-validations rect.mini-bar')[1];
+      const fromValidations = document.querySelectorAll('#ac-chart-week-validations rect.mini-bar')[1]
+        .getAttribute('data-ps-tooltip');
+      const strip = (card) => card.replace(/ ac-tip-row--strong/g, '');
 
-      expect(fromValidations.getAttribute('data-ps-tooltip')).toBe(barCard(1));
+      expect(strip(fromValidations)).toBe(strip(barCard(1)));
+    });
+
+    it('leans on the line the hovered chart draws, so a shared card still answers this bar', async () => {
+      await render({ daily: DAILY });
+      const strongRow = (card) => card.match(/ac-tip-row ac-tip-row--strong"><span>([^<]+)/)[1];
+      const fromValidations = document.querySelectorAll('#ac-chart-week-validations rect.mini-bar')[1]
+        .getAttribute('data-ps-tooltip');
+      const fromUsers = document.querySelectorAll('#ac-chart-week-users rect.mini-bar')[1]
+        .getAttribute('data-ps-tooltip');
+
+      expect(strongRow(barCard(1))).toBe('Labels');
+      expect(strongRow(fromValidations)).toBe('Validations');
+      expect(strongRow(fromUsers)).toBe('Contributors');
     });
 
     it('names the day\'s busiest cities and its contributors', async () => {
@@ -248,6 +263,15 @@ describe('Across Cities — human/AI split and hover breakdowns', () => {
       expect(card).toContain('Seattle');
       expect(card).toContain('alice');
       expect(card).toContain('sidewalk-ai');
+    });
+
+    it('splits a busiest city into labels and validations rather than one unlabeled total', async () => {
+      await render({ daily: DAILY });
+      const card = barCard(1);
+
+      expect(card).toContain('Busiest cities (labels · validations)');
+      expect(card).toContain('<span>Chicago</span><span class="ac-tip-num">100 · 20</span>');
+      expect(card).toContain('<span>Seattle</span><span class="ac-tip-num">20 · 10</span>');
     });
 
     it('marks an AI account in the contributor list rather than passing it off as a person', async () => {

--- a/test/js/acrossCitiesBreakdowns.test.js
+++ b/test/js/acrossCitiesBreakdowns.test.js
@@ -1,0 +1,369 @@
+/**
+ * Tests for the human/AI split and the hover breakdown cards on /admin/across-cities (#4931).
+ *
+ * Two contracts worth pinning. First, every count in the "Today & this week" section is what people did, with AI
+ * output reported on its own line — one pipeline account can out-produce the whole community, so a blended count
+ * would describe the pipeline. Second, the cards that explain those counts name the contributors behind them, which
+ * means they carry user-supplied text into markup and must escape it.
+ *
+ * Runs under jsdom (jest.config.js). AcrossCitiesPage is a bare top-level class in a concatenated bundle, so it is
+ * eval'd into global scope rather than required; MiniLineChart has to be present first, since the page draws with it.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const JS_DIR = path.resolve(__dirname, '..', '..', 'public/js');
+
+/** Loads MiniLineChart into global scope and returns the AcrossCitiesPage class. */
+function loadPage() {
+  const chart = fs.readFileSync(path.join(JS_DIR, 'admin-dashboard/MiniLineChart.js'), 'utf8');
+  const page = fs.readFileSync(path.join(JS_DIR, 'admin-dashboard/AcrossCitiesPage.js'), 'utf8');
+  return (0, eval)(`${chart}\nglobalThis.MiniLineChart = MiniLineChart;\n${page}\nAcrossCitiesPage;`);
+}
+
+const MARKUP = `
+  <span id="now-labels-today">—</span><span id="now-labels-today-ai"></span>
+  <span id="now-validations-today">—</span><span id="now-validations-today-ai"></span>
+  <span id="now-contributors-today">—</span><span id="now-contributors-today-ai"></span>
+  <span id="now-labels-7d">—</span><span id="now-labels-7d-delta"></span><span id="now-labels-7d-ai"></span>
+  <span id="now-validations-7d">—</span><span id="now-validations-7d-delta"></span>
+  <span id="now-validations-7d-ai"></span>
+  <span id="now-contributors-7d">—</span><span id="now-contributors-7d-delta"></span>
+  <span id="now-contributors-7d-ai"></span>
+  <span id="now-cities-active">—</span><span id="now-top-city">—</span><span id="now-top-city-count"></span>
+  <div class="mini-chart" id="ac-chart-week-labels"></div>
+  <div class="mini-chart" id="ac-chart-week-validations"></div>
+  <div class="mini-chart" id="ac-chart-week-users"></div>
+  <table id="ac-top-table">
+    <thead>
+      <tr>
+        <th data-sort="city_name">City</th>
+        <th data-sort="activity_7d">Activity</th>
+        <th data-sort="activity_window.labels_7d">Labels</th>
+        <th data-sort="activity_window.validations_7d">Validations</th>
+        <th data-sort="activity_window.contributors_7d">Contributors</th>
+        <th data-sort="audits_7d">Streets</th>
+        <th>Trend</th>
+      </tr>
+    </thead>
+    <tbody id="ac-top-tbody"></tbody>
+  </table>
+  <div id="ac-top-status"></div>`;
+
+/** A day of the cross-city daily series, with only the fields the bars and their cards read. */
+function makeDay(day, d = {}) {
+  return {
+    day,
+    labels: 0,
+    validations: 0,
+    active_users: 0,
+    ai_labels: 0,
+    ai_validations: 0,
+    ai_agents: 0,
+    top_cities: [],
+    contributors: [],
+    ...d,
+  };
+}
+
+/** A scorecard row plus the `window_by_city` entry the "Most active cities" table reads for it. */
+function makeCity(id, w) {
+  return {
+    city: { city_id: id, city_name: id, lifecycle: 'active', audits_7d: 3, weekly_trend: [] },
+    window: {
+      labels_7d: 0,
+      labels_prior_7d: 0,
+      validations_7d: 0,
+      validations_prior_7d: 0,
+      ai_labels_7d: 0,
+      ai_labels_prior_7d: 0,
+      ai_validations_7d: 0,
+      ai_validations_prior_7d: 0,
+      contributors_7d: 0,
+      contributors_prior_7d: 0,
+      ai_agents_7d: 0,
+      contributors: [],
+      ...w,
+    },
+  };
+}
+
+/** One entry of a city window's contributor list. */
+function contributor(username, labels, validations, isAi = false) {
+  return {
+    username,
+    is_ai: isAi,
+    labels_7d: labels,
+    labels_prior_7d: 0,
+    validations_7d: validations,
+    validations_prior_7d: 0,
+  };
+}
+
+describe('Across Cities — human/AI split and hover breakdowns', () => {
+  let AcrossCitiesPage;
+
+  /**
+   * Renders the page against a fixture and returns the initialized instance.
+   *
+   * @param {{cities?: Array, daily?: Array, summary?: ?object}} fixture - Any subset of the endpoint's payload.
+   * @returns {Promise<object>} The initialized AcrossCitiesPage.
+   */
+  async function render({ cities = [], daily = [], summary = null } = {}) {
+    document.body.innerHTML = MARKUP;
+    const windowByCity = {};
+    cities.forEach((c) => { windowByCity[c.city.city_id] = c.window; });
+    global.fetch = jest.fn(() => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({
+        cities: cities.map((c) => c.city),
+        summary: {},
+        over_time_all_time: [],
+        over_time_daily: daily,
+        window_summary: summary,
+        window_by_city: windowByCity,
+      }),
+    }));
+    const page = new AcrossCitiesPage({ scorecardsUrl: '/adminapi/cityScorecards' });
+    await page.init();
+    return page;
+  }
+
+  /** The hover-card markup on the nth cell of the first table row (0 = city name). */
+  function cellCard(index) {
+    return document.querySelectorAll('#ac-top-tbody tr')[0].cells[index].getAttribute('data-ps-tooltip');
+  }
+
+  /** The hover-card markup on the bar at `index` of the labels-per-day chart. */
+  function barCard(index) {
+    return document.querySelectorAll('#ac-chart-week-labels rect.mini-bar')[index].getAttribute('data-ps-tooltip');
+  }
+
+  beforeEach(() => {
+    AcrossCitiesPage = loadPage();
+  });
+
+  describe('tiles', () => {
+    it('counts what people did and reports AI output on its own line', async () => {
+      await render({
+        summary: {
+          labels_7d: 2626, labels_prior_7d: 2000, ai_labels_7d: 0, ai_labels_prior_7d: 0,
+          validations_7d: 1628, validations_prior_7d: 1500, ai_validations_7d: 6420, ai_validations_prior_7d: 5000,
+          contributors_7d: 64, contributors_prior_7d: 60, ai_agents_7d: 1,
+        },
+      });
+
+      expect(document.getElementById('now-validations-7d').textContent).toBe('1,628');
+      expect(document.getElementById('now-validations-7d-ai').textContent).toBe('+ 6,420 by AI');
+      expect(document.getElementById('now-contributors-7d').textContent).toBe('64');
+      expect(document.getElementById('now-contributors-7d-ai').textContent).toBe('+ 1 AI account');
+    });
+
+    it('measures the week-over-week delta on the human count, not the blended one', async () => {
+      // AI output tripled while people did less; the tile must report the drop people saw.
+      await render({
+        summary: {
+          labels_7d: 100, labels_prior_7d: 200, ai_labels_7d: 9000, ai_labels_prior_7d: 3000,
+          validations_7d: 0, validations_prior_7d: 0, ai_validations_7d: 0, ai_validations_prior_7d: 0,
+          contributors_7d: 2, contributors_prior_7d: 2, ai_agents_7d: 1,
+        },
+      });
+
+      const delta = document.getElementById('now-labels-7d-delta');
+      expect(delta.className).toContain('ac-hero-delta--down');
+      expect(delta.textContent).toContain('50%');
+    });
+
+    it('leaves the AI line empty when no AI account contributed', async () => {
+      await render({
+        summary: {
+          labels_7d: 10, labels_prior_7d: 5, ai_labels_7d: 0, ai_labels_prior_7d: 0,
+          validations_7d: 4, validations_prior_7d: 4, ai_validations_7d: 0, ai_validations_prior_7d: 0,
+          contributors_7d: 3, contributors_prior_7d: 3, ai_agents_7d: 0,
+        },
+      });
+
+      expect(document.getElementById('now-labels-7d-ai').textContent).toBe('');
+      expect(document.getElementById('now-labels-7d-ai').hasAttribute('data-ps-tooltip')).toBe(false);
+    });
+
+    it('reports today from the daily series on the same split', async () => {
+      await render({
+        daily: [makeDay('2026-08-12', { labels: 12, validations: 3, active_users: 2, ai_validations: 400,
+          ai_agents: 1 })],
+      });
+
+      expect(document.getElementById('now-labels-today').textContent).toBe('12');
+      expect(document.getElementById('now-validations-today-ai').textContent).toBe('+ 400 by AI');
+      expect(document.getElementById('now-contributors-today-ai').textContent).toBe('+ 1 AI account');
+    });
+  });
+
+  describe('day bars', () => {
+    const DAILY = [
+      makeDay('2026-08-11', { labels: 40, validations: 10, active_users: 3 }),
+      makeDay('2026-08-12', {
+        labels: 120,
+        validations: 30,
+        active_users: 4,
+        ai_validations: 6420,
+        ai_agents: 1,
+        top_cities: [
+          { city_id: 'chicago-il', city_name: 'Chicago', labels: 100, validations: 20, contributors: 3 },
+          { city_id: 'seattle-wa', city_name: 'Seattle', labels: 20, validations: 10, contributors: 1 },
+        ],
+        contributors: [
+          { username: 'alice', is_ai: false, labels: 100, validations: 20 },
+          { username: 'sidewalk-ai', is_ai: true, labels: 0, validations: 6420 },
+        ],
+      }),
+    ];
+
+    it('answers a hover with the whole day, not just the bar being hovered', async () => {
+      await render({ daily: DAILY });
+      const card = barCard(1);
+
+      expect(card).toContain('Labels');
+      expect(card).toContain('120');
+      expect(card).toContain('Validations');
+      expect(card).toContain('30');
+      expect(card).toContain('Contributors');
+      expect(card).toContain('AI validations');
+      expect(card).toContain('6,420');
+    });
+
+    it('gives every chart the same card for a given day, so one hover explains all three', async () => {
+      await render({ daily: DAILY });
+      const fromValidations = document.querySelectorAll('#ac-chart-week-validations rect.mini-bar')[1];
+
+      expect(fromValidations.getAttribute('data-ps-tooltip')).toBe(barCard(1));
+    });
+
+    it('names the day\'s busiest cities and its contributors', async () => {
+      await render({ daily: DAILY });
+      const card = barCard(1);
+
+      expect(card).toContain('Chicago');
+      expect(card).toContain('Seattle');
+      expect(card).toContain('alice');
+      expect(card).toContain('sidewalk-ai');
+    });
+
+    it('marks an AI account in the contributor list rather than passing it off as a person', async () => {
+      await render({ daily: DAILY });
+
+      expect(barCard(1)).toContain('ac-tip-tag');
+    });
+
+    it('makes each bar focusable and named, so the card is reachable without a pointer', async () => {
+      await render({ daily: DAILY });
+      const bar = document.querySelectorAll('#ac-chart-week-labels rect.mini-bar')[1];
+
+      expect(bar.getAttribute('tabindex')).toBe('0');
+      expect(bar.getAttribute('aria-label')).toContain('Labels');
+      // A native <title> would open its own tooltip on top of the card.
+      expect(bar.querySelector('title')).toBeNull();
+    });
+
+    it('says so plainly when nothing happened that day', async () => {
+      await render({
+        daily: [makeDay('2026-08-11'), makeDay('2026-08-12', { labels: 5, active_users: 1 })],
+      });
+      // The quiet day draws no bar, so its card rides the value label; assert through the chart's own series data.
+      const bars = document.querySelectorAll('#ac-chart-week-labels rect.mini-bar');
+
+      expect(bars.length).toBe(1);
+      expect(bars[0].getAttribute('data-ps-tooltip')).toContain('5');
+    });
+  });
+
+  describe('most active cities', () => {
+    const CITIES = [makeCity('chicago', {
+      labels_7d: 120,
+      labels_prior_7d: 80,
+      validations_7d: 30,
+      validations_prior_7d: 10,
+      ai_validations_7d: 6420,
+      contributors_7d: 3,
+      contributors_prior_7d: 2,
+      ai_agents_7d: 1,
+      contributors: [
+        contributor('carol', 5, 25),
+        contributor('alice', 100, 2),
+        contributor('bob', 15, 3),
+        contributor('sidewalk-ai', 0, 6420, true),
+      ],
+    })];
+
+    it('shows the human count with the AI output beside it', async () => {
+      await render({ cities: CITIES });
+      const validations = document.querySelectorAll('#ac-top-tbody tr')[0].cells[3];
+
+      expect(validations.textContent).toContain('30');
+      expect(validations.querySelector('.ac-cell-ai').textContent).toBe('+6,420 AI');
+    });
+
+    it('ranks the busiest cities on what people did there', async () => {
+      // A city where only the AI pipeline ran is not the week's busiest community.
+      const cities = [
+        makeCity('ai-only', { validations_7d: 0, ai_validations_7d: 90000, ai_agents_7d: 1 }),
+        makeCity('people', { labels_7d: 3, contributors_7d: 2 }),
+      ];
+      await render({ cities });
+
+      expect([...document.querySelectorAll('#ac-top-tbody tr')].map((tr) => tr.cells[0].textContent.trim()))
+        .toEqual(['people']);
+    });
+
+    it('puts both windows\' raw counts in the card behind the delta chip', async () => {
+      await render({ cities: CITIES });
+      const card = cellCard(2);
+
+      expect(card).toContain('Last 7 days');
+      expect(card).toContain('120');
+      expect(card).toContain('7 days before');
+      expect(card).toContain('80');
+    });
+
+    it('ranks the Labels card by labels and the Validations card by validations', async () => {
+      await render({ cities: CITIES });
+
+      // alice labels most; carol validates most among people — one "busiest overall" list would bury one of them.
+      expect(cellCard(2).indexOf('alice')).toBeLessThan(cellCard(2).indexOf('carol'));
+      expect(cellCard(3).indexOf('sidewalk-ai')).toBeLessThan(cellCard(3).indexOf('carol'));
+      expect(cellCard(3).indexOf('carol')).toBeLessThan(cellCard(3).indexOf('bob'));
+    });
+
+    it('leaves out anyone with no activity in the window the column is about', async () => {
+      const cities = [makeCity('quiet', {
+        labels_7d: 4,
+        contributors_7d: 2,
+        contributors: [contributor('labeler', 4, 0), contributor('validator-only', 0, 0)],
+      })];
+      await render({ cities });
+
+      expect(cellCard(2)).toContain('labeler');
+      expect(cellCard(2)).not.toContain('validator-only');
+    });
+
+    it('escapes usernames, which are user-supplied text going into card markup', async () => {
+      const cities = [makeCity('city', {
+        labels_7d: 2,
+        contributors_7d: 1,
+        contributors: [contributor('<img src=x onerror=alert(1)>', 2, 0)],
+      })];
+      await render({ cities });
+      document.body.insertAdjacentHTML('beforeend', `<div id="probe">${cellCard(2)}</div>`);
+
+      expect(document.querySelectorAll('#probe img').length).toBe(0);
+    });
+
+    it('makes the cells focusable so their cards are reachable by keyboard', async () => {
+      await render({ cities: CITIES });
+      const cells = [...document.querySelectorAll('#ac-top-tbody tr')[0].cells];
+
+      expect(cells.filter((td) => td.getAttribute('tabindex') === '0').length).toBe(4);
+    });
+  });
+});

--- a/test/js/psTooltip.test.js
+++ b/test/js/psTooltip.test.js
@@ -29,12 +29,16 @@ const VIEWPORT_HEIGHT = 800;
 const CARD_WIDTH = 200;
 const CARD_HEIGHT = 40;
 
-/** Installs a layout stub: the tooltip card reports a fixed size, every other element the rect it was given. */
+// The height the card stub reports. Tests that need a tall card (the Across Cities day breakdown runs to ~250px)
+// reassign this before opening one.
+let cardHeight = CARD_HEIGHT;
+
+/** Installs a layout stub: the tooltip card reports `cardHeight`, every other element the rect it was given. */
 function stubLayout() {
     Element.prototype.getBoundingClientRect = function () {
         if (this.classList.contains('ps-tooltip')) {
             return {
-                left: 0, top: 0, right: CARD_WIDTH, bottom: CARD_HEIGHT, width: CARD_WIDTH, height: CARD_HEIGHT,
+                left: 0, top: 0, right: CARD_WIDTH, bottom: cardHeight, width: CARD_WIDTH, height: cardHeight,
             };
         }
         const r = this._rect || { left: 0, top: 0, width: 0, height: 0 };
@@ -89,6 +93,7 @@ beforeEach(() => {
     document.body.innerHTML = '';
     window.innerWidth = VIEWPORT_WIDTH;
     window.innerHeight = VIEWPORT_HEIGHT;
+    cardHeight = CARD_HEIGHT;
     stubLayout();
     unloadPsTooltip = loadPsTooltip();
 });
@@ -150,6 +155,44 @@ describe('psTooltip placement', () => {
         const card = open(trigger);
 
         expect(card.style.getPropertyValue('--ps-tooltip-tail-left')).toBe(`${CARD_WIDTH - TAIL_INSET}px`);
+    });
+
+    test('keeps a tall card that fits on neither side inside the viewport', () => {
+        // The Across Cities day breakdown is a ~250px card on triggers that sit mid-page. In a short window there is
+        // room for it neither above nor below, and without a vertical clamp its lower rows run off screen unread.
+        cardHeight = 250;
+        window.innerHeight = 400;
+        const trigger = addTrigger({ left: 400, top: 180, width: 100, height: 30 }, 'tall');
+        const card = open(trigger);
+
+        const top = parseFloat(card.style.top);
+        expect(top).toBeGreaterThanOrEqual(VIEWPORT_MARGIN);
+        expect(top + cardHeight).toBeLessThanOrEqual(400 - VIEWPORT_MARGIN);
+    });
+
+    test('drops the tail when the clamp moves the card off its trigger', () => {
+        // A tail is only meaningful while an edge of the card still touches the trigger.
+        cardHeight = 250;
+        window.innerHeight = 400;
+        const trigger = addTrigger({ left: 400, top: 180, width: 100, height: 30 }, 'tall');
+        const card = open(trigger);
+
+        expect(card.classList.contains('ps-tooltip--untailed')).toBe(true);
+    });
+
+    test('pins a card taller than the viewport to the top, so it is read from the beginning', () => {
+        cardHeight = VIEWPORT_HEIGHT + 200;
+        const trigger = addTrigger({ left: 400, top: 400, width: 100, height: 30 }, 'enormous');
+        const card = open(trigger);
+
+        expect(card.style.top).toBe(`${VIEWPORT_MARGIN}px`);
+    });
+
+    test('leaves an ordinary card tailed, since it still sits against its trigger', () => {
+        const trigger = addTrigger({ left: 400, top: 300, width: 100, height: 30 }, 'ordinary');
+        const card = open(trigger);
+
+        expect(card.classList.contains('ps-tooltip--untailed')).toBe(false);
     });
 });
 

--- a/test/models/utils/CityScorecardSpec.scala
+++ b/test/models/utils/CityScorecardSpec.scala
@@ -6,7 +6,7 @@ import play.api.Application
 import play.api.db.slick.DatabaseConfigProvider
 import play.api.inject.guice.GuiceApplicationBuilder
 import models.utils.MyPostgresProfile.api._
-import service.{ActivityWindowSummary, AggregateStats, CityScorecard}
+import service.{AggregateStats, CityScorecard}
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -81,8 +81,11 @@ class CityScorecardSpec extends PlaySpec with GuiceOneAppPerSuite {
       run(configTable.getCityWeeklyTrendBySchema(schema, None)) mustBe a[Seq[_]]
       run(configTable.getCityWeeklyTrendBySchema(schema, Some(4))) mustBe a[Seq[_]]
     }
-    "execute getCityActivityWindowsBySchema" in {
-      run(configTable.getCityActivityWindowsBySchema(schema)) mustBe a[ActivityWindowSummary]
+    "execute getCityWindowActivityByUserBySchema" in {
+      run(configTable.getCityWindowActivityByUserBySchema(schema)) mustBe a[Seq[_]]
+    }
+    "execute getCityDailyActivityByUserBySchema" in {
+      run(configTable.getCityDailyActivityByUserBySchema(schema, 7)) mustBe a[Seq[_]]
     }
     "execute getCityContributorOutputBySchema" in {
       run(configTable.getCityContributorOutputBySchema(schema)) mustBe a[Product] // 7-tuple

--- a/test/service/ActivityBreakdownSpec.scala
+++ b/test/service/ActivityBreakdownSpec.scala
@@ -1,0 +1,160 @@
+package service
+
+import org.scalatestplus.play.PlaySpec
+
+import java.time.LocalDate
+
+/**
+ * Unit tests for the two pure rollups behind the Across Cities "Today & this week" section (#4931): the rolling
+ * weekly windows and the daily breakdown the bar hover cards read.
+ *
+ * These are the rules that keep AI output from being read as community activity, so they are pinned against
+ * synthetic rows rather than against whatever the connected database happens to hold — a dev or CI database with no
+ * AI-role accounts would pass every AI assertion without exercising one. No DB, no app boot.
+ */
+class ActivityBreakdownSpec extends PlaySpec {
+
+  private val day = LocalDate.of(2026, 8, 12)
+
+  private def person(id: String, labels7d: Int, validations7d: Int, priorLabels: Int = 0, priorVals: Int = 0) =
+    ContributorWindowActivity(id, s"user-$id", isAi = false, labels7d, priorLabels, validations7d, priorVals)
+
+  private def agent(id: String, labels7d: Int, validations7d: Int, priorLabels: Int = 0, priorVals: Int = 0) =
+    ContributorWindowActivity(id, s"ai-$id", isAi = true, labels7d, priorLabels, validations7d, priorVals)
+
+  private def dayRow(cityId: String, id: String, labels: Int, validations: Int, isAi: Boolean = false) =
+    cityId -> DailyContributorActivity(day, id, if (isAi) s"ai-$id" else s"user-$id", isAi, labels, validations)
+
+  "ActivityWindowSummary.fromContributors" should {
+    "keep AI output out of the label and validation counts" in {
+      val summary = ActivityWindowSummary.fromContributors(
+        Seq(person("a", 10, 4), person("b", 5, 1), agent("bot", 900, 8000))
+      )
+
+      summary.labels7d mustBe 15
+      summary.validations7d mustBe 5
+      summary.aiLabels7d mustBe 900
+      summary.aiValidations7d mustBe 8000
+    }
+
+    "count people as contributors and AI accounts as agents" in {
+      val summary = ActivityWindowSummary.fromContributors(
+        Seq(person("a", 10, 0), person("b", 0, 3), agent("bot", 0, 8000))
+      )
+
+      summary.contributors7d mustBe 2
+      summary.aiAgents7d mustBe 1
+    }
+
+    "split the prior window on the same rule as the current one" in {
+      val summary = ActivityWindowSummary.fromContributors(
+        Seq(person("a", 2, 2, priorLabels = 7, priorVals = 3), agent("bot", 1, 1, priorLabels = 40, priorVals = 60))
+      )
+
+      summary.labelsPrior7d mustBe 7
+      summary.validationsPrior7d mustBe 3
+      summary.aiLabelsPrior7d mustBe 40
+      summary.aiValidationsPrior7d mustBe 60
+      summary.contributorsPrior7d mustBe 1
+    }
+
+    "leave someone active only in the prior window out of the current window's contributors" in {
+      val summary = ActivityWindowSummary.fromContributors(Seq(person("gone", 0, 0, priorLabels = 12)))
+
+      summary.contributors7d mustBe 0
+      summary.contributorsPrior7d mustBe 1
+    }
+
+    "return an empty window for a city with no activity" in {
+      ActivityWindowSummary.fromContributors(Seq.empty) mustBe ActivityWindowSummary.empty
+    }
+  }
+
+  "ActivityWindowSummary.add" should {
+    "sum every field, so per-city windows roll up into the cross-city total" in {
+      val a     = ActivityWindowSummary.fromContributors(Seq(person("a", 3, 4, 1, 2), agent("bot", 5, 6, 7, 8)))
+      val b     = ActivityWindowSummary.fromContributors(Seq(person("b", 30, 40, 10, 20)))
+      val total = ActivityWindowSummary.add(a, b)
+
+      total.labels7d mustBe 33
+      total.validations7d mustBe 44
+      total.labelsPrior7d mustBe 11
+      total.validationsPrior7d mustBe 22
+      total.aiLabels7d mustBe 5
+      total.aiValidationsPrior7d mustBe 8
+      total.contributors7d mustBe 2
+      total.aiAgents7d mustBe 1
+    }
+  }
+
+  "ConfigService.summarizeDay" should {
+    "report the day's human volumes and its AI output separately" in {
+      val summary = ConfigService.summarizeDay(
+        day,
+        Seq(dayRow("seattle-wa", "a", 12, 3), dayRow("seattle-wa", "bot", 0, 4000, isAi = true))
+      )
+
+      summary.point.labels mustBe 12
+      summary.point.validations mustBe 3
+      summary.point.activeUsers mustBe 1
+      summary.point.aiValidations mustBe 4000
+      summary.point.aiAgents mustBe 1
+    }
+
+    "count a person active in two cities once per city, matching the bar's counting basis" in {
+      val summary =
+        ConfigService.summarizeDay(day, Seq(dayRow("seattle-wa", "a", 5, 0), dayRow("chicago-il", "a", 7, 0)))
+
+      summary.point.activeUsers mustBe 2
+      summary.point.labels mustBe 12
+    }
+
+    "merge that same person into one contributor line with their cities added up" in {
+      val summary =
+        ConfigService.summarizeDay(day, Seq(dayRow("seattle-wa", "a", 5, 1), dayRow("chicago-il", "a", 7, 2)))
+
+      summary.contributors.map(_.username) mustBe Seq("user-a")
+      summary.contributors.head.labels mustBe 12
+      summary.contributors.head.validations mustBe 3
+    }
+
+    "rank cities by what people did there, leaving AI output out of the ordering" in {
+      val summary = ConfigService.summarizeDay(
+        day,
+        Seq(
+          dayRow("quiet-city", "bot", 9000, 0, isAi = true),
+          dayRow("quiet-city", "a", 1, 0),
+          dayRow("busy-city", "b", 40, 5)
+        )
+      )
+
+      summary.topCities.map(_.cityId) mustBe Seq("busy-city", "quiet-city")
+      summary.topCities.head.contributors mustBe 1
+    }
+
+    "keep AI accounts in the contributor list but marked, so a busy-looking day says who made it busy" in {
+      val summary =
+        ConfigService.summarizeDay(day, Seq(dayRow("seattle-wa", "bot", 0, 900, isAi = true), dayRow("x", "a", 2, 0)))
+
+      summary.contributors.map(c => (c.username, c.isAi)) mustBe Seq(("ai-bot", true), ("user-a", false))
+    }
+
+    "cap the lists it ships to the page" in {
+      val cities  = (1 to 9).map(i => dayRow(s"city-$i", s"u$i", i, 0))
+      val summary = ConfigService.summarizeDay(day, cities)
+
+      summary.topCities.length mustBe ConfigService.DayTopCityLimit
+      summary.contributors.length mustBe ConfigService.DayContributorLimit
+      // Capping keeps the busiest, so the biggest city can never be the one dropped.
+      summary.topCities.head.cityId mustBe "city-9"
+    }
+
+    "zero-fill a day nobody was active" in {
+      val summary = ConfigService.summarizeDay(day, Seq.empty)
+
+      summary.point mustBe DailyPoint(day, 0, 0, 0, 0, 0, 0)
+      summary.topCities mustBe empty
+      summary.contributors mustBe empty
+    }
+  }
+}

--- a/test/service/ActivityBreakdownSpec.scala
+++ b/test/service/ActivityBreakdownSpec.scala
@@ -5,25 +5,58 @@ import org.scalatestplus.play.PlaySpec
 import java.time.LocalDate
 
 /**
- * Unit tests for the two pure rollups behind the Across Cities "Today & this week" section (#4931): the rolling
- * weekly windows and the daily breakdown the bar hover cards read.
+ * Unit tests for the pure rollups behind the Across Cities "Today & this week" section (#4931): the rolling weekly
+ * windows, the per-person merge that makes cross-city headcounts distinct, and the daily breakdown the bar hover cards
+ * read.
  *
- * These are the rules that keep AI output from being read as community activity, so they are pinned against
- * synthetic rows rather than against whatever the connected database happens to hold — a dev or CI database with no
- * AI-role accounts would pass every AI assertion without exercising one. No DB, no app boot.
+ * These are the rules that keep AI output from being read as community activity and cookie identities from being read
+ * as people, so they are pinned against synthetic rows rather than against whatever the connected database happens to
+ * hold — a dev or CI database with no AI-role accounts would pass every AI assertion without exercising one. No DB, no
+ * app boot.
  */
 class ActivityBreakdownSpec extends PlaySpec {
 
   private val day = LocalDate.of(2026, 8, 12)
 
   private def person(id: String, labels7d: Int, validations7d: Int, priorLabels: Int = 0, priorVals: Int = 0) =
-    ContributorWindowActivity(id, s"user-$id", isAi = false, labels7d, priorLabels, validations7d, priorVals)
+    ContributorWindowActivity(
+      id,
+      s"user-$id",
+      ContributorKind.Registered,
+      labels7d,
+      priorLabels,
+      validations7d,
+      priorVals
+    )
+
+  private def anon(id: String, labels7d: Int, validations7d: Int, priorLabels: Int = 0, priorVals: Int = 0) =
+    ContributorWindowActivity(
+      id,
+      s"cookie-$id",
+      ContributorKind.Anonymous,
+      labels7d,
+      priorLabels,
+      validations7d,
+      priorVals
+    )
 
   private def agent(id: String, labels7d: Int, validations7d: Int, priorLabels: Int = 0, priorVals: Int = 0) =
-    ContributorWindowActivity(id, s"ai-$id", isAi = true, labels7d, priorLabels, validations7d, priorVals)
+    ContributorWindowActivity(id, s"ai-$id", ContributorKind.Ai, labels7d, priorLabels, validations7d, priorVals)
 
-  private def dayRow(cityId: String, id: String, labels: Int, validations: Int, isAi: Boolean = false) =
-    cityId -> DailyContributorActivity(day, id, if (isAi) s"ai-$id" else s"user-$id", isAi, labels, validations)
+  private def dayRow(
+      cityId: String,
+      id: String,
+      labels: Int,
+      validations: Int,
+      kind: ContributorKind.Value = ContributorKind.Registered
+  ) = {
+    val name = kind match {
+      case ContributorKind.Ai        => s"ai-$id"
+      case ContributorKind.Anonymous => s"cookie-$id"
+      case _                         => s"user-$id"
+    }
+    cityId -> DailyContributorActivity(day, id, name, kind, labels, validations)
+  }
 
   "ActivityWindowSummary.fromContributors" should {
     "keep AI output out of the label and validation counts" in {
@@ -37,25 +70,45 @@ class ActivityBreakdownSpec extends PlaySpec {
       summary.aiValidations7d mustBe 8000
     }
 
-    "count people as contributors and AI accounts as agents" in {
+    "count anonymous work as human volume, because an anonymous visitor's label is still a person's label" in {
+      val summary = ActivityWindowSummary.fromContributors(Seq(person("a", 10, 4), anon("c1", 3, 2)))
+
+      summary.labels7d mustBe 13
+      summary.validations7d mustBe 6
+    }
+
+    "split headcounts three ways: registered people, anonymous sessions, AI agents" in {
       val summary = ActivityWindowSummary.fromContributors(
-        Seq(person("a", 10, 0), person("b", 0, 3), agent("bot", 0, 8000))
+        Seq(person("a", 10, 0), person("b", 0, 3), anon("c1", 1, 0), anon("c2", 0, 1), agent("bot", 0, 8000))
       )
 
       summary.contributors7d mustBe 2
+      summary.anonSessions7d mustBe 2
       summary.aiAgents7d mustBe 1
     }
 
-    "split the prior window on the same rule as the current one" in {
+    "never count an anonymous session as a contributor" in {
+      val summary = ActivityWindowSummary.fromContributors(Seq(anon("c1", 5, 5), anon("c2", 5, 5)))
+
+      summary.contributors7d mustBe 0
+      summary.anonSessions7d mustBe 2
+    }
+
+    "split the prior window on the same rules as the current one" in {
       val summary = ActivityWindowSummary.fromContributors(
-        Seq(person("a", 2, 2, priorLabels = 7, priorVals = 3), agent("bot", 1, 1, priorLabels = 40, priorVals = 60))
+        Seq(
+          person("a", 2, 2, priorLabels = 7, priorVals = 3),
+          anon("c1", 0, 0, priorLabels = 1, priorVals = 1),
+          agent("bot", 1, 1, priorLabels = 40, priorVals = 60)
+        )
       )
 
-      summary.labelsPrior7d mustBe 7
-      summary.validationsPrior7d mustBe 3
+      summary.labelsPrior7d mustBe 8
+      summary.validationsPrior7d mustBe 4
       summary.aiLabelsPrior7d mustBe 40
       summary.aiValidationsPrior7d mustBe 60
       summary.contributorsPrior7d mustBe 1
+      summary.anonSessionsPrior7d mustBe 1
     }
 
     "leave someone active only in the prior window out of the current window's contributors" in {
@@ -70,20 +123,58 @@ class ActivityBreakdownSpec extends PlaySpec {
     }
   }
 
-  "ActivityWindowSummary.add" should {
-    "sum every field, so per-city windows roll up into the cross-city total" in {
-      val a     = ActivityWindowSummary.fromContributors(Seq(person("a", 3, 4, 1, 2), agent("bot", 5, 6, 7, 8)))
-      val b     = ActivityWindowSummary.fromContributors(Seq(person("b", 30, 40, 10, 20)))
-      val total = ActivityWindowSummary.add(a, b)
+  "ConfigService.mergeByContributor" should {
+    "collapse one person's cities into a single row with their volumes added up" in {
+      val merged = ConfigService.mergeByContributor(Seq(person("a", 5, 1, 2, 0), person("a", 7, 2, 3, 4)))
 
-      total.labels7d mustBe 33
-      total.validations7d mustBe 44
-      total.labelsPrior7d mustBe 11
-      total.validationsPrior7d mustBe 22
-      total.aiLabels7d mustBe 5
-      total.aiValidationsPrior7d mustBe 8
+      merged.map(_.userId) mustBe Seq("a")
+      merged.head.labels7d mustBe 12
+      merged.head.validations7d mustBe 3
+      merged.head.labelsPrior7d mustBe 5
+      merged.head.validationsPrior7d mustBe 4
+    }
+
+    "preserve each contributor's kind through the merge" in {
+      val merged = ConfigService.mergeByContributor(Seq(agent("bot", 1, 1), agent("bot", 2, 2), person("a", 1, 1)))
+
+      merged.find(_.userId == "bot").map(_.kind) mustBe Some(ContributorKind.Ai)
+      merged.find(_.userId == "a").map(_.kind) mustBe Some(ContributorKind.Registered)
+    }
+
+    "order busiest first" in {
+      val merged = ConfigService.mergeByContributor(Seq(person("small", 1, 0), person("big", 90, 5)))
+
+      merged.map(_.userId) mustBe Seq("big", "small")
+    }
+
+    "break ties on user id, so a truncated list is reproducible across cache refreshes" in {
+      // Same total for every contributor: without an explicit tiebreak the order would follow HashMap iteration and
+      // could hand a different set to `.take` on each refresh, with no change in the underlying data.
+      val rows   = (1 to 40).map(i => person(f"u$i%02d", 5, 5))
+      val first  = ConfigService.mergeByContributor(rows).map(_.userId)
+      val second = ConfigService.mergeByContributor(rows.reverse).map(_.userId)
+
+      first mustBe second
+      first.take(3) mustBe Seq("u01", "u02", "u03")
+    }
+
+    "make the cross-city total's headcount distinct people rather than per-city slots" in {
+      // What getCrossCityActivitySummary composes: someone who mapped in three cities is one contributor, and summing
+      // three per-city summaries instead would have called them three.
+      val everyCitysRows = Seq(person("a", 4, 0), person("a", 4, 0), person("a", 4, 0), person("b", 1, 0))
+      val total          = ActivityWindowSummary.fromContributors(ConfigService.mergeByContributor(everyCitysRows))
+
       total.contributors7d mustBe 2
+      total.labels7d mustBe 13
+    }
+
+    "count one AI account working in many cities as one agent" in {
+      val rows  = Seq(agent("bot", 100, 200), agent("bot", 300, 400), agent("bot", 5, 6))
+      val total = ActivityWindowSummary.fromContributors(ConfigService.mergeByContributor(rows))
+
       total.aiAgents7d mustBe 1
+      total.aiLabels7d mustBe 405
+      total.aiValidations7d mustBe 606
     }
   }
 
@@ -91,22 +182,40 @@ class ActivityBreakdownSpec extends PlaySpec {
     "report the day's human volumes and its AI output separately" in {
       val summary = ConfigService.summarizeDay(
         day,
-        Seq(dayRow("seattle-wa", "a", 12, 3), dayRow("seattle-wa", "bot", 0, 4000, isAi = true))
+        Seq(dayRow("seattle-wa", "a", 12, 3), dayRow("seattle-wa", "bot", 0, 4000, ContributorKind.Ai))
       )
 
       summary.point.labels mustBe 12
       summary.point.validations mustBe 3
-      summary.point.activeUsers mustBe 1
+      summary.point.contributors mustBe 1
       summary.point.aiValidations mustBe 4000
       summary.point.aiAgents mustBe 1
     }
 
-    "count a person active in two cities once per city, matching the bar's counting basis" in {
+    "count a person active in two cities once" in {
       val summary =
         ConfigService.summarizeDay(day, Seq(dayRow("seattle-wa", "a", 5, 0), dayRow("chicago-il", "a", 7, 0)))
 
-      summary.point.activeUsers mustBe 2
+      summary.point.contributors mustBe 1
       summary.point.labels mustBe 12
+    }
+
+    "keep the contributor count and the contributor list on one basis" in {
+      // The count and the list are derived from the same merged rows, so a card can't say "4 contributors" over two
+      // names. Two people, each working two cities.
+      val summary = ConfigService.summarizeDay(
+        day,
+        Seq(
+          dayRow("seattle-wa", "a", 5, 1),
+          dayRow("chicago-il", "a", 7, 2),
+          dayRow("seattle-wa", "b", 1, 1),
+          dayRow("chicago-il", "b", 2, 2)
+        )
+      )
+
+      summary.point.contributors mustBe 2
+      summary.contributors.length mustBe 2
+      summary.contributorTotal mustBe 2
     }
 
     "merge that same person into one contributor line with their cities added up" in {
@@ -118,11 +227,39 @@ class ActivityBreakdownSpec extends PlaySpec {
       summary.contributors.head.validations mustBe 3
     }
 
+    "count anonymous visitors as sessions and keep their volume in the human totals" in {
+      val summary = ConfigService.summarizeDay(
+        day,
+        Seq(dayRow("seattle-wa", "a", 4, 0), dayRow("seattle-wa", "c1", 3, 2, ContributorKind.Anonymous))
+      )
+
+      summary.point.contributors mustBe 1
+      summary.point.anonSessions mustBe 1
+      summary.point.labels mustBe 7
+      summary.point.validations mustBe 2
+    }
+
+    "leave anonymous visitors out of the named list, since their usernames are generated cookie ids" in {
+      val summary = ConfigService.summarizeDay(
+        day,
+        Seq(
+          dayRow("seattle-wa", "c1", 900, 0, ContributorKind.Anonymous),
+          dayRow("seattle-wa", "c2", 800, 0, ContributorKind.Anonymous),
+          dayRow("seattle-wa", "a", 1, 0)
+        )
+      )
+
+      // The anonymous pair out-produce the person, so a list that named them would be all hex and no names.
+      summary.contributors.map(_.username) mustBe Seq("user-a")
+      summary.contributorTotal mustBe 1
+      summary.point.anonSessions mustBe 2
+    }
+
     "rank cities by what people did there, leaving AI output out of the ordering" in {
       val summary = ConfigService.summarizeDay(
         day,
         Seq(
-          dayRow("quiet-city", "bot", 9000, 0, isAi = true),
+          dayRow("quiet-city", "bot", 9000, 0, ContributorKind.Ai),
           dayRow("quiet-city", "a", 1, 0),
           dayRow("busy-city", "b", 40, 5)
         )
@@ -132,11 +269,32 @@ class ActivityBreakdownSpec extends PlaySpec {
       summary.topCities.head.contributors mustBe 1
     }
 
-    "keep AI accounts in the contributor list but marked, so a busy-looking day says who made it busy" in {
-      val summary =
-        ConfigService.summarizeDay(day, Seq(dayRow("seattle-wa", "bot", 0, 900, isAi = true), dayRow("x", "a", 2, 0)))
+    "count a city's contributors distinctly even when one person has several rows there" in {
+      val summary = ConfigService.summarizeDay(
+        day,
+        Seq(dayRow("seattle-wa", "a", 1, 0), dayRow("seattle-wa", "a", 2, 0), dayRow("seattle-wa", "b", 1, 0))
+      )
 
-      summary.contributors.map(c => (c.username, c.isAi)) mustBe Seq(("ai-bot", true), ("user-a", false))
+      summary.topCities.head.contributors mustBe 2
+    }
+
+    "break city ties on city id, so the truncated list is reproducible" in {
+      val rows   = (1 to 9).map(i => dayRow(f"city-$i%02d", s"u$i", 10, 0))
+      val first  = ConfigService.summarizeDay(day, rows).topCities.map(_.cityId)
+      val second = ConfigService.summarizeDay(day, rows.reverse).topCities.map(_.cityId)
+
+      first mustBe second
+      first mustBe Seq("city-01", "city-02", "city-03")
+    }
+
+    "keep AI accounts in the contributor list but marked, so a busy-looking day says who made it busy" in {
+      val summary = ConfigService.summarizeDay(
+        day,
+        Seq(dayRow("seattle-wa", "bot", 0, 900, ContributorKind.Ai), dayRow("x", "a", 2, 0))
+      )
+
+      summary.contributors.map(c => (c.username, c.kind)) mustBe
+        Seq(("ai-bot", ContributorKind.Ai), ("user-a", ContributorKind.Registered))
     }
 
     "cap the lists it ships to the page" in {
@@ -149,12 +307,36 @@ class ActivityBreakdownSpec extends PlaySpec {
       summary.topCities.head.cityId mustBe "city-9"
     }
 
+    "report the untruncated contributor count alongside the capped list" in {
+      // What the card's "+N more" is computed from. Deriving it from the capped list instead would bound it at
+      // DayContributorLimit and understate a busy day without limit.
+      val rows    = (1 to 40).map(i => dayRow("seattle-wa", f"u$i%02d", i, 0))
+      val summary = ConfigService.summarizeDay(day, rows)
+
+      summary.contributors.length mustBe ConfigService.DayContributorLimit
+      summary.contributorTotal mustBe 40
+      summary.point.contributors mustBe 40
+    }
+
     "zero-fill a day nobody was active" in {
       val summary = ConfigService.summarizeDay(day, Seq.empty)
 
-      summary.point mustBe DailyPoint(day, 0, 0, 0, 0, 0, 0)
+      summary.point mustBe DailyPoint(day, 0, 0, 0, 0, 0, 0, 0)
       summary.topCities mustBe empty
       summary.contributors mustBe empty
+      summary.contributorTotal mustBe 0
+    }
+
+    "describe an AI-only day as active, so the day's card is never the quiet one" in {
+      // The bars all read zero on such a day, so the card is the only place the pipeline's work shows up.
+      val summary = ConfigService.summarizeDay(day, Seq(dayRow("seattle-wa", "bot", 0, 6420, ContributorKind.Ai)))
+
+      summary.point.labels mustBe 0
+      summary.point.validations mustBe 0
+      summary.point.contributors mustBe 0
+      summary.point.aiValidations mustBe 6420
+      summary.point.aiAgents mustBe 1
+      summary.contributors.map(_.username) mustBe Seq("ai-bot")
     }
   }
 }

--- a/test/service/ConfigServiceTrendSpec.scala
+++ b/test/service/ConfigServiceTrendSpec.scala
@@ -13,7 +13,10 @@ import scala.concurrent.duration.DurationInt
  * DB-backed invariant tests for the cross-city over-time series behind the Across Cities admin page (#4329, #4686):
  * the weekly trend (with the new-users column feeding the cumulative-users chart), the trailing-7-day daily trend
  * (feeding the "this week" bar charts), and the week-over-week window summary (feeding the "Today & this week"
- * tiles, #4758).
+ * tiles, #4758) together with the breakdowns their hover cards read (#4931).
+ *
+ * The human/AI split those breakdowns turn on is pinned in [[ActivityBreakdownSpec]] against synthetic rows, since a
+ * database with no AI-role accounts would satisfy any assertion about them here without exercising one.
  *
  * Contract/shape over data values: every assertion holds against whatever the connected DB contains — ordering,
  * ranges, and cross-field relationships, never specific numbers.
@@ -66,19 +69,46 @@ class ConfigServiceTrendSpec extends PlaySpec with GuiceOneAppPerSuite {
   }
 
   "getCrossCityDailyTrend(7)" should {
+    lazy val daily = await(configService.getCrossCityDailyTrend(7))
+
     "return exactly 7 consecutive Pacific days ending today, zero-filled" in {
       val before = LocalDate.now(ZoneId.of("US/Pacific"))
-      val daily  = await(configService.getCrossCityDailyTrend(7))
+      val days   = await(configService.getCrossCityDailyTrend(7)).map(_.point)
       val after  = LocalDate.now(ZoneId.of("US/Pacific"))
 
-      daily.length mustBe 7
-      daily.zip(daily.tail).foreach { case (a, b) => b.day mustBe a.day.plusDays(1) }
+      days.length mustBe 7
+      days.zip(days.tail).foreach { case (a, b) => b.day mustBe a.day.plusDays(1) }
       // The run may legitimately cross midnight Pacific between the call and this assertion.
-      Seq(before, after) must contain(daily.last.day)
-      daily.foreach { d =>
+      Seq(before, after) must contain(days.last.day)
+      days.foreach { d =>
         d.labels must be >= 0
         d.validations must be >= 0
         d.activeUsers must be >= 0
+        d.aiLabels must be >= 0
+        d.aiValidations must be >= 0
+        d.aiAgents must be >= 0
+      }
+    }
+
+    "keep each day's breakdown inside the day it explains" in {
+      // The hover card is derived from the same rows the bars are summed from, so its parts can never exceed them.
+      daily.foreach { d =>
+        d.topCities.length must be <= ConfigService.DayTopCityLimit
+        d.contributors.length must be <= ConfigService.DayContributorLimit
+        d.topCities.map(_.labels).sum must be <= d.point.labels
+        d.topCities.map(_.validations).sum must be <= d.point.validations
+        d.topCities.map(_.contributors).sum must be <= d.point.activeUsers
+        d.contributors.map(_.labels).sum must be <= (d.point.labels + d.point.aiLabels)
+        d.contributors.map(_.validations).sum must be <= (d.point.validations + d.point.aiValidations)
+      }
+    }
+
+    "rank each day's cities and contributors busiest first" in {
+      daily.foreach { d =>
+        d.topCities.map(city => -(city.labels + city.validations)) mustBe
+          d.topCities.map(city => -(city.labels + city.validations)).sorted
+        d.contributors.map(c => -(c.labels + c.validations)) mustBe
+          d.contributors.map(c => -(c.labels + c.validations)).sorted
       }
     }
   }
@@ -94,12 +124,18 @@ class ConfigServiceTrendSpec extends PlaySpec with GuiceOneAppPerSuite {
       summary.validationsPrior7d must be >= 0
       summary.contributors7d must be >= 0
       summary.contributorsPrior7d must be >= 0
+      summary.aiLabels7d must be >= 0
+      summary.aiLabelsPrior7d must be >= 0
+      summary.aiValidations7d must be >= 0
+      summary.aiValidationsPrior7d must be >= 0
+      summary.aiAgents7d must be >= 0
     }
 
     "bound each window's distinct contributors by its event count" in {
       // Every counted contributor produced at least one label or validation in that window.
       summary.contributors7d must be <= (summary.labels7d + summary.validations7d)
       summary.contributorsPrior7d must be <= (summary.labelsPrior7d + summary.validationsPrior7d)
+      summary.aiAgents7d must be <= (summary.aiLabels7d + summary.aiValidations7d)
     }
 
     "return a per-city window for every available city" in {
@@ -110,12 +146,29 @@ class ConfigServiceTrendSpec extends PlaySpec with GuiceOneAppPerSuite {
     "report totals that are exactly the per-city windows summed" in {
       // The "Most active cities" table ranks on the per-city rows while the tiles above it show the total, so the two
       // must not be able to disagree.
-      windows.byCity.values.map(_.labels7d).sum mustBe summary.labels7d
-      windows.byCity.values.map(_.labelsPrior7d).sum mustBe summary.labelsPrior7d
-      windows.byCity.values.map(_.validations7d).sum mustBe summary.validations7d
-      windows.byCity.values.map(_.validationsPrior7d).sum mustBe summary.validationsPrior7d
-      windows.byCity.values.map(_.contributors7d).sum mustBe summary.contributors7d
-      windows.byCity.values.map(_.contributorsPrior7d).sum mustBe summary.contributorsPrior7d
+      val cities = windows.byCity.values.map(_.summary)
+      cities.map(_.labels7d).sum mustBe summary.labels7d
+      cities.map(_.labelsPrior7d).sum mustBe summary.labelsPrior7d
+      cities.map(_.validations7d).sum mustBe summary.validations7d
+      cities.map(_.validationsPrior7d).sum mustBe summary.validationsPrior7d
+      cities.map(_.contributors7d).sum mustBe summary.contributors7d
+      cities.map(_.contributorsPrior7d).sum mustBe summary.contributorsPrior7d
+      cities.map(_.aiLabels7d).sum mustBe summary.aiLabels7d
+      cities.map(_.aiValidations7d).sum mustBe summary.aiValidations7d
+      cities.map(_.aiAgents7d).sum mustBe summary.aiAgents7d
+    }
+
+    "carry the contributors each city's counts are made of, busiest first and capped" in {
+      windows.byCity.values.foreach { city =>
+        city.contributors.length must be <= ConfigService.WindowContributorLimit
+        city.contributors.map(c => -(c.labels7d + c.validations7d)) mustBe
+          city.contributors.map(c => -(c.labels7d + c.validations7d)).sorted
+        // Only people with current-window activity are listed, since the cards rank on it.
+        city.contributors.foreach(c => (c.labels7d + c.validations7d) must be > 0)
+        city.contributors.count(!_.isAi) must be <= city.summary.contributors7d
+        city.contributors.filter(!_.isAi).map(_.labels7d).sum must be <= city.summary.labels7d
+        city.contributors.filter(_.isAi).map(_.validations7d).sum must be <= city.summary.aiValidations7d
+      }
     }
   }
 }

--- a/test/service/ConfigServiceTrendSpec.scala
+++ b/test/service/ConfigServiceTrendSpec.scala
@@ -83,7 +83,8 @@ class ConfigServiceTrendSpec extends PlaySpec with GuiceOneAppPerSuite {
       days.foreach { d =>
         d.labels must be >= 0
         d.validations must be >= 0
-        d.activeUsers must be >= 0
+        d.contributors must be >= 0
+        d.anonSessions must be >= 0
         d.aiLabels must be >= 0
         d.aiValidations must be >= 0
         d.aiAgents must be >= 0
@@ -97,10 +98,36 @@ class ConfigServiceTrendSpec extends PlaySpec with GuiceOneAppPerSuite {
         d.contributors.length must be <= ConfigService.DayContributorLimit
         d.topCities.map(_.labels).sum must be <= d.point.labels
         d.topCities.map(_.validations).sum must be <= d.point.validations
-        d.topCities.map(_.contributors).sum must be <= d.point.activeUsers
         d.contributors.map(_.labels).sum must be <= (d.point.labels + d.point.aiLabels)
         d.contributors.map(_.validations).sum must be <= (d.point.validations + d.point.aiValidations)
+        // Per-city contributor counts are per city, so they can only ever add up to at least the distinct total.
+        d.topCities.map(_.contributors).sum must be >= 0
       }
+    }
+
+    "count the day's contributors distinctly across cities" in {
+      // A person active in several cities is one contributor, so the distinct total can only sit at or below the
+      // per-city counts added up — and never below the busiest single city.
+      daily.foreach { d =>
+        val perCitySum = d.topCities.map(_.contributors).sum
+        if (d.topCities.length < ConfigService.DayTopCityLimit && perCitySum > 0) {
+          d.point.contributors + d.point.anonSessions must be <= perCitySum
+          d.point.contributors + d.point.anonSessions must be >= d.topCities.map(_.contributors).max
+        }
+      }
+    }
+
+    "report the untruncated contributor count alongside the capped list" in {
+      daily.foreach { d =>
+        d.contributorTotal must be >= d.contributors.length
+        // The list holds registered accounts and AI, never anonymous ones, so those two counts bound it.
+        d.contributorTotal must be <= (d.point.contributors + d.point.aiAgents)
+      }
+    }
+
+    "never name an anonymous contributor" in {
+      // Their usernames are generated cookie ids; they are counted in anonSessions instead.
+      daily.foreach(d => d.contributors.foreach(_.kind must not be ContributorKind.Anonymous))
     }
 
     "rank each day's cities and contributors busiest first" in {
@@ -110,6 +137,28 @@ class ConfigServiceTrendSpec extends PlaySpec with GuiceOneAppPerSuite {
         d.contributors.map(c => -(c.labels + c.validations)) mustBe
           d.contributors.map(c => -(c.labels + c.validations)).sorted
       }
+    }
+  }
+
+  "the cross-city reads" should {
+    // Each of these fires a query per city schema — ~56 apiece against a 25-connection pool — and one page request
+    // triggers five of them, so how often that fan-out runs is the page's whole cost story. These two pin the sharing
+    // properties; what `staleWhileRevalidate` adds on top (never making a *request* wait on a refresh) turns on a
+    // 10-minute clock this suite can't advance, and is documented on ConfigService.CrossCityFreshFor.
+    "give concurrent callers of a cold key one shared computation" in {
+      // `days = 5` is a key nothing else in the suite requests, so this is the genuinely-cold path. Identity is the
+      // observable proof of sharing: a layer that recomputed per caller would hand back equal-but-distinct values.
+      val inFlight = (1 to 5).map(_ => configService.getCrossCityDailyTrend(5))
+      val results  = inFlight.map(f => await(f))
+
+      results.foreach(r => assert(r eq results.head))
+    }
+
+    "serve a warmed key without recomputing it" in {
+      val first  = await(configService.getCrossCityActivitySummary())
+      val second = await(configService.getCrossCityActivitySummary())
+
+      assert(second eq first)
     }
   }
 
@@ -124,6 +173,8 @@ class ConfigServiceTrendSpec extends PlaySpec with GuiceOneAppPerSuite {
       summary.validationsPrior7d must be >= 0
       summary.contributors7d must be >= 0
       summary.contributorsPrior7d must be >= 0
+      summary.anonSessions7d must be >= 0
+      summary.anonSessionsPrior7d must be >= 0
       summary.aiLabels7d must be >= 0
       summary.aiLabelsPrior7d must be >= 0
       summary.aiValidations7d must be >= 0
@@ -135,6 +186,7 @@ class ConfigServiceTrendSpec extends PlaySpec with GuiceOneAppPerSuite {
       // Every counted contributor produced at least one label or validation in that window.
       summary.contributors7d must be <= (summary.labels7d + summary.validations7d)
       summary.contributorsPrior7d must be <= (summary.labelsPrior7d + summary.validationsPrior7d)
+      summary.anonSessions7d must be <= (summary.labels7d + summary.validations7d)
       summary.aiAgents7d must be <= (summary.aiLabels7d + summary.aiValidations7d)
     }
 
@@ -143,19 +195,33 @@ class ConfigServiceTrendSpec extends PlaySpec with GuiceOneAppPerSuite {
       windows.byCity.keys.foreach(_ must not be empty)
     }
 
-    "report totals that are exactly the per-city windows summed" in {
+    "report volumes that are exactly the per-city windows summed" in {
       // The "Most active cities" table ranks on the per-city rows while the tiles above it show the total, so the two
-      // must not be able to disagree.
+      // must not be able to disagree about how much work was done.
       val cities = windows.byCity.values.map(_.summary)
       cities.map(_.labels7d).sum mustBe summary.labels7d
       cities.map(_.labelsPrior7d).sum mustBe summary.labelsPrior7d
       cities.map(_.validations7d).sum mustBe summary.validations7d
       cities.map(_.validationsPrior7d).sum mustBe summary.validationsPrior7d
-      cities.map(_.contributors7d).sum mustBe summary.contributors7d
-      cities.map(_.contributorsPrior7d).sum mustBe summary.contributorsPrior7d
       cities.map(_.aiLabels7d).sum mustBe summary.aiLabels7d
+      cities.map(_.aiLabelsPrior7d).sum mustBe summary.aiLabelsPrior7d
       cities.map(_.aiValidations7d).sum mustBe summary.aiValidations7d
-      cities.map(_.aiAgents7d).sum mustBe summary.aiAgents7d
+      cities.map(_.aiValidationsPrior7d).sum mustBe summary.aiValidationsPrior7d
+    }
+
+    "report headcounts deduplicated across cities, not summed" in {
+      // A person or pipeline account working in several cities is one of each here. So the total sits at or below the
+      // per-city counts added up, and at or above any single city's — which is what the table's caveat tells the reader.
+      val cities                                     = windows.byCity.values.map(_.summary).toSeq
+      def check(total: Int, perCity: Seq[Int]): Unit = {
+        total must be <= perCity.sum
+        val _ = total must be >= perCity.maxOption.getOrElse(0)
+      }
+
+      check(summary.contributors7d, cities.map(_.contributors7d))
+      check(summary.contributorsPrior7d, cities.map(_.contributorsPrior7d))
+      check(summary.anonSessions7d, cities.map(_.anonSessions7d))
+      check(summary.aiAgents7d, cities.map(_.aiAgents7d))
     }
 
     "carry the contributors each city's counts are made of, busiest first and capped" in {
@@ -165,9 +231,20 @@ class ConfigServiceTrendSpec extends PlaySpec with GuiceOneAppPerSuite {
           city.contributors.map(c => -(c.labels7d + c.validations7d)).sorted
         // Only people with current-window activity are listed, since the cards rank on it.
         city.contributors.foreach(c => (c.labels7d + c.validations7d) must be > 0)
-        city.contributors.count(!_.isAi) must be <= city.summary.contributors7d
-        city.contributors.filter(!_.isAi).map(_.labels7d).sum must be <= city.summary.labels7d
-        city.contributors.filter(_.isAi).map(_.validations7d).sum must be <= city.summary.aiValidations7d
+        val people = city.contributors.filter(_.kind == ContributorKind.Registered)
+        people.length must be <= city.summary.contributors7d
+        people.map(_.labels7d).sum must be <= city.summary.labels7d
+        city.contributors.filter(_.kind == ContributorKind.Ai).map(_.validations7d).sum must
+          be <= city.summary.aiValidations7d
+        // Anonymous accounts are counted in the summary but never named, so the list can't leak a cookie id.
+        city.contributors.foreach(_.kind must not be ContributorKind.Anonymous)
+      }
+    }
+
+    "report an untruncated contributor total that the capped list can't understate" in {
+      windows.byCity.values.foreach { city =>
+        city.contributorTotal must be >= city.contributors.length
+        city.contributorTotal must be <= (city.summary.contributors7d + city.summary.aiAgents7d)
       }
     }
   }


### PR DESCRIPTION
Fixes #4931.

The "Today & this week" section of `/admin/across-cities` counted AI-role output as community activity. Measured
against prod on 2026-08-17 (rolling 7 days, all 56 city schemas):

| Metric | Shown before | AI | Actually people |
|---|---:|---:|---:|
| Labels | 2,626 | 0 | 2,626 |
| Validations | **8,048** | **6,420** | **1,628** |
| Contributors | 65 | 1 AI account | 64 |

So the Validations tile read 8,048 when people did 1,628 — 80% of the headline was a single AI account — and the
week-over-week delta beside it tracked the pipeline's schedule rather than anything a contributor did. The same blend
reached the per-day bars and the Most-active-cities columns. The per-city scorecards (#4329) always split AI out; the
newer rolling-window (#4758) and daily-trend (#4686) paths filtered only `NOT user_stat.excluded`, which does not
exclude the `AI` role.

## Counting people

Every count in the section is now what people did, with everything else reported beside it rather than folded in.
Two families of number, counted differently on purpose:

- **Volumes** are human work — registered *and* anonymous, because an anonymous visitor's label is still a person's
  label — with AI's output on its own muted line.
- **Headcounts** split three ways. Only a registered account reliably denotes one person. An anonymous account is a
  per-cookie identity that a repeat visitor mints again, so it is reported as a *session*; AI accounts as *agents*.

Headcounts are also **distinct across cities**: someone who mapped in three cities is one contributor. That makes the
project total smaller than the same column summed down the Most-active-cities table, which the table's caveat says.

Cities rank on human activity, so a city where only the pipeline ran is not the week's busiest community.

## Hover breakdowns

Hovering (or tabbing to) a **day's bar** answers with the whole day — labels, validations and contributors together,
the anonymous and AI split, the busiest cities that day, and who was active, by name. A **Most-active-cities cell**
gives both windows' raw counts behind the delta chip and the contributors behind them, ranked by the work its column
is about (top labelers under Labels, top validators under Validations).

Naming individuals is fine here: the page is Owner-gated (`WithOwner()`) and these are the same usernames the admin
user table already shows. Anonymous contributors are the exception — their usernames are generated cookie ids like
`5fibdme5zcw3rcg0`, so they are counted but never listed.

The cards ride the shared `psTooltip`, which opens on focus as well as hover, so `MiniLineChart` gained a per-point
`tooltipsHtml` option that swaps the native `<title>` for a card. Every day gets a full-height transparent hit area,
so a day whose bar is zero is still reachable — an AI-only day is a real day whose human bars all read zero, and the
card is the only place its work shows up.

## Cost

Both per-city queries work at a per-person grain (`getCityWindowActivityByUserBySchema`, 14 d;
`getCityDailyActivityByUserBySchema`, 8 d), and the service derives the totals *and* the card contents from those same
rows — one *fewer* scan than before, over the same index-bounded windows, and a headline number and the card
explaining it become structurally unable to drift apart.

Two things keep this off the request path at 56 deployments:

- **The `account_kinds` CTE is driven from the already-narrowed active-user set.** `user_role` is 5.7M rows and 99.9%
  `Anonymous`, so a CTE that grouped every user — or even filtered on the role names — would aggregate millions of
  rows per schema, across every schema, twice per cache refresh. Restricted to the users active in the window it is
  index lookups on `user_role_user_id_idx`: 40 rows, 201 buffers, 11 ms in EXPLAIN.
- **The five cross-city fan-outs are stale-while-revalidate.** One `getCityScorecards` request triggers all five, each
  firing a query per schema — ~280 against a 25-connection pool. Past the fresh window the cached copy is still served
  immediately and the refresh runs behind it, so no request waits on the fan-out while holding connections that
  Explore and Validate share.

## Testing

- **`test/service/ActivityBreakdownSpec.scala`** — 27 pure unit tests pinning the attribution split, the per-person
  merge that makes headcounts distinct, and the day summarizer. Synthetic on purpose: CI's schema has no AI-role or
  anonymous accounts, so a DB-backed version would pass without exercising one.
- **`ConfigServiceTrendSpec`** / **`CityScorecardSpec`** — DB-backed invariants connecting the new SQL to those
  summaries: volumes sum across cities while headcounts dedupe, the untruncated total bounds the capped list, and no
  cookie id reaches a hover card. **All three specs are now in the ci.yml allowlist** — the two DB-backed ones were
  otherwise dead weight in CI.
- **`test/js/acrossCitiesBreakdowns.test.js`** (31) and **`test/js/psTooltip.test.js`** (13) — card construction and
  rendering, including XSS tests pinning the two-step escaping rule on both call paths.

59 Scala and 911 JS tests green locally, plus real-browser QA of both hover surfaces.

## QA checklist

Owner account required. On `/admin/across-cities`:

- [ ] Tiles show human counts, with a muted AI line and an anonymous-sessions line beneath where each applies
      (Validations is the one to watch for AI).
- [ ] Week-over-week deltas move with human activity, not the pipeline's schedule.
- [ ] Hover a bar in each of the three per-day charts — card shows all three volumes, the anonymous/AI split, top
      cities, names.
- [ ] The bolded line in that card is the one the chart you're on draws (Labels chart → Labels, and so on).
- [ ] Hover a day whose bars read zero — the card still opens, and says either what AI did or "No activity."
- [ ] Busiest-city lines read as `labels · validations`, matching the contributor lines below them.
- [ ] Hover a Labels / Validations / Contributors cell in Most active cities — both weeks' raw counts + named
      contributors, ranked by that column's work, with any AI listed after the people.
- [ ] Tab to a bar and to a cell — card opens on focus, `aria-label` reads sensibly.
- [ ] Re-sort Most active cities by each column; ranking reflects human activity.
- [ ] The Contributors tile can read lower than the table's Contributors column summed — that is the cross-city
      dedup, and the note under the table says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-opus-5[1m])
