### PR TITLE
Add `make worktree-remove` for tearing down git worktrees

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -443,6 +443,18 @@ Implementation: `tools/qa-worktree.sh` — both targets run the **worktree's own
 make reports `No rule to make target 'qa-worktree'`. Either check out a branch that has it, or run the worktree's script
 directly: `docker exec -it projectsidewalk-web bash /home/.claude/worktrees/<name>/tools/qa-worktree.sh <name>`.
 
+**Disposing of a worktree entirely** is **`make worktree-remove wt=<name>`** (`tools/worktree-remove.sh`): it stops any
+QA session, deletes the directory *and* git's registration under `.git/worktrees/`, then deletes the branch if every
+commit on it is already in `develop` (otherwise it names the branch and leaves it). `rm -rf` on the directory alone is
+**not** equivalent — the registration survives and the worktree keeps showing up in `git worktree list` until something
+prunes it; the target recognizes and cleans up that half-removed state too. Unlike the QA targets it runs **host-side**:
+a worktree's `.git` file points at the main repo's `.git/worktrees/<name>` by absolute host path, which doesn't exist
+inside the container, so git can't touch the worktree from in there. It stops before doing anything if the worktree has
+uncommitted or untracked files (`force=1` deletes them along with it) or if the worktree is **locked** — an active
+Claude Code worktree session holds a lock, and git refuses a locked worktree even with `--force`. The main-checkout
+caveat above applies here too; the direct invocation is host-side rather than through docker:
+`bash .claude/worktrees/<name>/tools/worktree-remove.sh <name>`.
+
 **Admin-authenticated QA:** the dev DB is seeded from a dump that includes real accounts and their bcrypt password
 hashes, and password verification is config-independent (plain bcrypt, no server-side pepper), so if your own account is
 in the dump you can just sign in with your normal credentials. If you don't have credentials for a seeded account — or

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev docker-up docker-up-db docker-run docker-stop ssh qa-worktree qa-worktree-stop test-e2e \
+.PHONY: dev docker-up docker-up-db docker-run docker-stop ssh qa-worktree qa-worktree-stop worktree-remove test-e2e \
         test-python test-python-app test-python-tools \
         import-users import-dump create-new-schema fill-new-schema hide-streets-without-imagery \
         import-street-imagery reveal-or-hide-neighborhoods \
@@ -15,9 +15,12 @@ dir ?= ./
 args ?=
 wt ?=
 clean ?=
+force ?=
 
 # `clean=1` (or true/yes) expands to the qa-worktree-stop --clean flag; anything else (incl. empty) expands to nothing.
 qa-stop-clean-flag = $(if $(filter 1 true yes,$(clean)),--clean,)
+# Same idiom for worktree-remove's `force=1`.
+worktree-force-flag = $(if $(filter 1 true yes,$(force)),--force,)
 
 # Resolve which copy of qa-worktree.sh to run, then exec it with the args in $(1). The main repo is mounted at the
 # container's /home, so /home/tools/qa-worktree.sh is the script as it exists on whatever branch the MAIN checkout
@@ -30,8 +33,8 @@ qa-worktree-exec = script="/home/.claude/worktrees/$(wt)/tools/qa-worktree.sh"; 
   [ -f "$$script" ] || script=/home/tools/qa-worktree.sh; \
   [ -f "$$script" ] || { echo "error: no tools/qa-worktree.sh in worktree $(wt) or in the main checkout"; exit 1; }; \
   exec bash "$$script" $(1)
-# Both qa-worktree targets fail fast on a missing wt= rather than passing an empty name into the container.
-qa-worktree-require-wt = @[ -n "$(wt)" ] || { echo "usage: make $@ wt=<name>   (a dir under .claude/worktrees/)"; exit 2; }
+# Every wt= target fails fast on a missing name rather than passing an empty one along.
+worktree-require-wt = @[ -n "$(wt)" ] || { echo "usage: make $@ wt=<name>   (a dir under .claude/worktrees/)"; exit 2; }
 
 # ANSI colors for the `lint` summary.
 GREEN := \033[0;32m
@@ -96,14 +99,21 @@ ssh:
 # Run an uncommitted git worktree's app on :9000 for QA (not the main repo). See tools/qa-worktree.sh and CLAUDE.md
 # "Running a worktree's app for QA". e.g. `make qa-worktree wt=remove-admin-classic`.
 qa-worktree:
-	$(qa-worktree-require-wt)
+	$(worktree-require-wt)
 	@docker exec -it $(web-container) bash -c '$(call qa-worktree-exec,$(wt))'
 
 # Tear down a qa-worktree session: stop its `~ run` and grunt watch. Add `clean=1` to also drop the node_modules
 # symlink. e.g. `make qa-worktree-stop wt=remove-admin-classic` or `make qa-worktree-stop wt=... clean=1`.
 qa-worktree-stop:
-	$(qa-worktree-require-wt)
+	$(worktree-require-wt)
 	@docker exec $(web-container) bash -c '$(call qa-worktree-exec,$(wt) --stop $(qa-stop-clean-flag))'
+
+# Tear a worktree down for good: its QA session, its directory, its git registration, and its branch once that branch is
+# in develop. Host-side (git can't reach a worktree from inside the container — see tools/worktree-remove.sh). Add
+# `force=1` to discard uncommitted work in it. e.g. `make worktree-remove wt=remove-admin-classic`.
+worktree-remove:
+	$(worktree-require-wt)
+	@bash tools/worktree-remove.sh $(wt) --container $(web-container) $(worktree-force-flag)
 
 import-users:
 	@docker exec -it $(db-container) sh -c "/opt/scripts/import-users.sh"

--- a/docs/dev-environment.md
+++ b/docs/dev-environment.md
@@ -281,6 +281,18 @@ repo's `node_modules`, builds that branch's JS/CSS bundles, frees `:9000`, and l
 worktree's own config while reusing the main repo's warm sbt caches. The first request triggers the dev compile;
 `Ctrl+C` stops it. It behaves the same on macOS, Linux, and WSL because the work runs inside the web container.
 
+When you're done with a worktree for good, remove it with:
+
+```bash
+make worktree-remove wt=<worktree-name>
+```
+
+That stops its QA session, deletes the directory and the registration git keeps for it, and deletes its branch once
+that branch is fully merged into `develop` — it tells you what it kept otherwise. Deleting the directory yourself
+leaves the registration behind, so the worktree lingers in `git worktree list`; run the target and it cleans that up
+instead. It stops and tells you if the worktree still has uncommitted or untracked files; add `force=1` to delete
+those along with it.
+
 To QA admin-only pages you need an account with a role. The dev database is seeded from a dump that includes real
 accounts, so if your own account is in it you can sign in normally — password checks work the same locally as in
 production. Otherwise — or if you'd rather use a throwaway account — create a fresh one through the sign-up form and

--- a/tools/worktree-remove.sh
+++ b/tools/worktree-remove.sh
@@ -29,7 +29,11 @@ CONTAINER="projectsidewalk-web"
 while [ $# -gt 0 ]; do
   case "$1" in
     --force) FORCE="1" ;;
-    --container) shift; CONTAINER="${1:-}" ;;
+    --container)
+      shift
+      [ $# -gt 0 ] || { echo "error: --container needs a value"; exit 2; }
+      CONTAINER="$1"
+      ;;
     *) echo "error: unknown argument: $1"; exit 2 ;;
   esac
   shift
@@ -115,24 +119,34 @@ clean_up_branch() {
   fi
 }
 
-if [ ! -d "$WT_DIR" ]; then
-  if worktree_is_registered; then
-    echo "==> $WT_DIR is already gone; pruning its stale git registration"
-    BRANCH="$(registered_branch)"
-    git -C "$MAIN_REPO" worktree prune
-    clean_up_branch "$BRANCH"
-    echo "==> done."
-    exit 0
+# Establish that git owns $WT_DIR before touching it. A plain directory that happens to sit under .claude/worktrees/
+# is still *inside* the main repo, so `git -C "$WT_DIR" status` below would report the MAIN repo's changes.
+if ! worktree_is_registered; then
+  if [ -d "$WT_DIR" ]; then
+    echo "error: $WT_DIR exists but git has no worktree registered for it (see: git worktree list)."
+    echo "       It isn't ours to remove — delete it by hand if you're sure."
+  else
+    echo "error: no worktree at $WT_DIR"
   fi
-  echo "error: no worktree at $WT_DIR"
   echo "available worktrees:"; ls "$MAIN_REPO/.claude/worktrees" 2>/dev/null || echo "  (none)"
   exit 1
 fi
 
+# Checked before both teardown paths: `git worktree prune` skips a locked worktree just as `git worktree remove`
+# refuses one, and the branch cleanup would then die on git's "used by worktree" error instead of this message.
 if worktree_is_locked; then
   echo "error: $WT is locked, so git won't remove it. A running Claude Code session in it holds a lock; otherwise"
   echo "       someone locked it deliberately. End that session, or unlock it: git worktree unlock \"$WT_DIR\""
   exit 1
+fi
+
+if [ ! -d "$WT_DIR" ]; then
+  echo "==> $WT_DIR is already gone; pruning its stale git registration"
+  BRANCH="$(registered_branch)"
+  git -C "$MAIN_REPO" worktree prune
+  clean_up_branch "$BRANCH"
+  echo "==> done."
+  exit 0
 fi
 
 # `git worktree remove` makes the same judgement, but only once the QA session is already stopped — checking up front

--- a/tools/worktree-remove.sh
+++ b/tools/worktree-remove.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+#
+# Tear down a git worktree under .claude/worktrees/ completely: its QA session, its directory, its git registration,
+# and its branch when that branch is already merged.
+#
+#     make worktree-remove wt=<name> [force=1]
+#     bash tools/worktree-remove.sh <name> [--force] [--container <web-container>]
+#
+# Runs on the HOST, unlike tools/qa-worktree.sh: a worktree's .git file points at the main repo's .git/worktrees/<name>
+# by absolute host path, which doesn't exist inside the web container, so git can't reach the worktree from in there.
+# Deleting the directory by hand isn't equivalent either — the registration survives it, and the worktree keeps showing
+# up in `git worktree list` until something prunes it.
+#
+set -euo pipefail
+
+WT="${1:-}"
+[ -n "$WT" ] || {
+  echo "usage: worktree-remove <name> [--force] [--container <name>]   (a dir under .claude/worktrees/)"
+  exit 2
+}
+# A bare, shell-safe name: $WT is interpolated into the container command below, and must not escape the worktrees dir.
+case "$WT" in
+  *[!A-Za-z0-9._-]* | . | ..) echo "error: wt must be a bare worktree directory name ([A-Za-z0-9._-])"; exit 2 ;;
+esac
+shift
+
+FORCE=""
+CONTAINER="projectsidewalk-web"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --force) FORCE="1" ;;
+    --container) shift; CONTAINER="${1:-}" ;;
+    *) echo "error: unknown argument: $1"; exit 2 ;;
+  esac
+  shift
+done
+
+# --git-common-dir resolves to the MAIN repo's .git even when this runs from inside a worktree, so `make
+# worktree-remove` works from either checkout.
+MAIN_REPO="$(dirname "$(cd "$(git rev-parse --git-common-dir)" && pwd)")"
+WT_DIR="$MAIN_REPO/.claude/worktrees/$WT"
+
+# True when git still has a registration for $WT_DIR, whether or not the directory is still there.
+worktree_is_registered() {
+  git -C "$MAIN_REPO" worktree list --porcelain | grep -qxF "worktree $WT_DIR"
+}
+
+# A live Claude Code worktree session locks its worktree, and git refuses to remove a locked one even with --force —
+# worth its own message rather than a puzzling failure late in the teardown.
+worktree_is_locked() {
+  git -C "$MAIN_REPO" worktree list --porcelain | awk -v target="worktree $WT_DIR" '
+    $0 == target { in_block = 1; next }
+    /^$/ { in_block = 0 }
+    in_block && $1 == "locked" { locked = 1 }
+    END { exit(locked ? 0 : 1) }'
+}
+
+# Short branch name, empty when HEAD is detached. Comes from the registration rather than the worktree so it's still
+# answerable once the directory is gone.
+registered_branch() {
+  git -C "$MAIN_REPO" worktree list --porcelain | awk -v target="worktree $WT_DIR" '
+    $0 == target { in_block = 1; next }
+    /^$/ { in_block = 0 }
+    in_block && $1 == "branch" { sub(/^branch refs\/heads\//, ""); print; exit }'
+}
+
+# Best-effort: no docker or no container means nothing can be running, so neither is an error.
+stop_qa_session() {
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "==> docker not found; skipping QA-session stop"
+    return
+  fi
+  if ! docker ps --format '{{.Names}}' | grep -qxF "$CONTAINER"; then
+    echo "==> $CONTAINER not running; skipping QA-session stop"
+    return
+  fi
+  echo "==> stopping any QA session for $WT"
+  # Prefer the worktree's own copy of qa-worktree.sh, falling back to the main repo's, for the same reason the Makefile
+  # does (#4628): either checkout may sit on a branch that predates the script.
+  docker exec "$CONTAINER" bash -c \
+    "script=/home/.claude/worktrees/$WT/tools/qa-worktree.sh; \
+     [ -f \"\$script\" ] || script=/home/tools/qa-worktree.sh; \
+     [ -f \"\$script\" ] || exit 0; \
+     exec bash \"\$script\" $WT --stop --clean" \
+    || echo "warning: the QA-session stop reported an error; continuing with removal"
+}
+
+# True when deleting branch $1 would lose nothing. The remote-tracking ref is checked too, since a local develop can lag
+# behind what has actually merged.
+branch_is_merged() {
+  local base
+  for base in develop origin/develop; do
+    if git -C "$MAIN_REPO" rev-parse --verify --quiet "$base" >/dev/null &&
+       git -C "$MAIN_REPO" merge-base --is-ancestor "$1" "$base"; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# The branch is the part of a teardown easiest to forget, so every outcome here prints what was decided.
+clean_up_branch() {
+  local branch="$1"
+  if [ -z "$branch" ]; then
+    echo "==> HEAD was detached; no branch to clean up"
+  elif printf '%s\n' develop master main | grep -qxF "$branch"; then
+    echo "==> kept branch $branch (long-lived branch)"
+  elif branch_is_merged "$branch"; then
+    # -D, not -d: merged-ness is settled above against develop, while -d judges it against this checkout's HEAD.
+    git -C "$MAIN_REPO" branch -D "$branch" >/dev/null
+    echo "==> deleted branch $branch (already merged into develop)"
+  else
+    echo "==> kept branch $branch — it has commits that aren't in develop yet"
+    echo "    delete it anyway with: git branch -D $branch"
+  fi
+}
+
+if [ ! -d "$WT_DIR" ]; then
+  if worktree_is_registered; then
+    echo "==> $WT_DIR is already gone; pruning its stale git registration"
+    BRANCH="$(registered_branch)"
+    git -C "$MAIN_REPO" worktree prune
+    clean_up_branch "$BRANCH"
+    echo "==> done."
+    exit 0
+  fi
+  echo "error: no worktree at $WT_DIR"
+  echo "available worktrees:"; ls "$MAIN_REPO/.claude/worktrees" 2>/dev/null || echo "  (none)"
+  exit 1
+fi
+
+if worktree_is_locked; then
+  echo "error: $WT is locked, so git won't remove it. A running Claude Code session in it holds a lock; otherwise"
+  echo "       someone locked it deliberately. End that session, or unlock it: git worktree unlock \"$WT_DIR\""
+  exit 1
+fi
+
+# `git worktree remove` makes the same judgement, but only once the QA session is already stopped — checking up front
+# keeps a refusal side-effect-free. Ignored build output (target/, logs/, node_modules) isn't work either way.
+if [ -z "$FORCE" ] && [ -n "$(git -C "$WT_DIR" status --porcelain)" ]; then
+  echo "error: $WT has work in it:"
+  git -C "$WT_DIR" status --short | sed 's/^/         /'
+  echo "       Commit or move that work, or rerun to delete it along with the worktree:"
+  echo "         make worktree-remove wt=$WT force=1"
+  exit 1
+fi
+
+BRANCH="$(registered_branch)"
+SIZE="$(du -sh "$WT_DIR" 2>/dev/null | cut -f1 || true)"
+echo "==> removing worktree $WT_DIR${BRANCH:+  (branch $BRANCH)}${SIZE:+  [$SIZE]}"
+
+stop_qa_session
+
+if ! git -C "$MAIN_REPO" worktree remove ${FORCE:+--force} "$WT_DIR"; then
+  echo "error: git declined to remove the worktree (see above). The QA session, if there was one, is already stopped."
+  exit 1
+fi
+echo "==> removed directory and git registration${SIZE:+ (reclaimed $SIZE)}"
+
+clean_up_branch "$BRANCH"
+echo "==> done."


### PR DESCRIPTION
We can start a worktree's app (`make qa-worktree`) and stop it (`make qa-worktree-stop`), but there was nothing for
getting rid of the worktree itself. Doing it by hand is easy to get wrong: `rm -rf` on the directory leaves git's
registration under `.git/worktrees/`, so the worktree keeps appearing in `git worktree list`, and the branch is left
behind either way.

`make worktree-remove wt=<name>` (`tools/worktree-remove.sh`) does the whole teardown:

1. Refuses up front if the worktree has uncommitted or untracked files — it lists them, and `force=1` deletes them
   along with the worktree. Also refuses if the worktree is **locked**: an active Claude Code worktree session holds a
   lock, and git won't remove a locked worktree even with `--force`, so it gets a clear message instead of a confusing
   git error.
2. Stops any `qa-worktree` session for it, reusing `qa-worktree.sh --stop --clean` (and preferring the worktree's own
   copy of that script, same as the Makefile does per #4628). Skipped cleanly when docker or the container isn't up.
3. `git worktree remove` — directory *and* registration — reporting the disk space reclaimed.
4. Deletes the branch only when every commit on it is already in `develop` (checking `origin/develop` too, since a
   local `develop` can lag). Otherwise it names the branch and prints the `git branch -D` you'd need. `develop`,
   `master`, and `main` are never touched.

It also recognizes the half-removed state: if the directory is already gone but still registered, it prunes the stale
entry and still cleans up the branch (git reports the branch for prunable worktrees).

Unlike the QA targets, this runs **host-side**. A worktree's `.git` file points at the main repo's
`.git/worktrees/<name>` by absolute host path, which doesn't exist inside the web container, so git can't operate on a
worktree from in there at all.

Also renames the Makefile's `qa-worktree-require-wt` guard to `worktree-require-wt`, since all three `wt=` targets
share it now.

## Testing

Exercised each path against throwaway worktrees, all cleaned up afterwards:

- normal removal, and removal with `force=1` over an untracked file
- refusal on a dirty worktree (no side effects — the QA session is not stopped)
- unmerged branch kept with instructions; merged branch deleted; detached HEAD handled
- stale-registration prune after a manual `rm -rf`, including the branch cleanup
- the locked guard, run against a live Claude Code worktree session (correctly refused)
- bad and missing `wt=` arguments, through both the script and the `make` target

Docs updated in `CLAUDE.md` and `docs/dev-environment.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
