### PR TITLE
Make one comment per (label, user) a constraint, not a convention (#4942)

### DIFF
--- a/app/controllers/ValidateController.scala
+++ b/app/controllers/ValidateController.scala
@@ -517,7 +517,7 @@ class ValidateController @Inject() (
   }
 
   /**
-   * Handles a comment POST request. It parses the comment and inserts it into the comment table.
+   * Handles a comment POST request from LabelMap, replacing whatever the user had said about the label before.
    */
   def postLabelMapComment = cc.securityService.SecuredAction(parse.json) { implicit request =>
     val submission = request.body.validate[LabelMapValidationCommentSubmission]
@@ -533,8 +533,7 @@ class ValidateController @Inject() (
             MissionType.LabelmapValidation,
             labelTypeId
           )
-          _              <- validationService.deleteCommentIfExists(submission.labelId, userId)
-          commentId: Int <- validationService.insertComment(
+          commentId: Int <- validationService.replaceComment(
             ValidationTaskComment(0, mission.get.missionId, submission.labelId, userId, request.ipAddress,
               submission.panoId, submission.heading, submission.pitch, submission.zoom, submission.lat, submission.lng,
               OffsetDateTime.now, submission.comment)

--- a/app/models/validation/ValidationTaskCommentTable.scala
+++ b/app/models/validation/ValidationTaskCommentTable.scala
@@ -48,6 +48,9 @@ class ValidationTaskCommentTableDef(tag: Tag) extends Table[ValidationTaskCommen
   def * = (validationTaskCommentId, missionId, labelId, userId, ipAddress, panoId, heading, pitch, zoom, lat, lng,
     timestamp, comment) <> ((ValidationTaskComment.apply _).tupled, ValidationTaskComment.unapply)
 
+  def labelUserUnique =
+    index("validation_task_comment_label_id_user_id_unique", (labelId, userId), unique = true)
+
   def mission =
     foreignKey("validation_task_comment_mission_id_fkey", missionId, TableQuery[MissionTableDef])(_.missionId)
   def label = foreignKey("validation_task_comment_label_id_fkey", labelId, TableQuery[LabelTableDef])(_.labelId)
@@ -79,7 +82,7 @@ class ValidationTaskCommentTable @Inject() (
    * has usually rolled over by the time the same user revisits the label from a label card (#4653). Matching on the
    * current mission would strand the old comment on a label whose validation had just been replaced or cleared.
    *
-   * @return Count of comments deleted, normally 0 or 1.
+   * @return Count of comments deleted, 0 or 1 — (label_id, user_id) is UNIQUE.
    */
   def deleteIfExists(labelId: Int, userId: String): DBIO[Int] = {
     validationTaskComments.filter(comment => comment.labelId === labelId && comment.userId === userId).delete

--- a/app/service/ValidationService.scala
+++ b/app/service/ValidationService.scala
@@ -28,8 +28,7 @@ trait ValidationService {
   def countValidations(userId: String): Future[Int]
   def insertEnvironment(env: ValidationTaskEnvironment): Future[Int]
   def insertMultipleInteractions(interactions: Seq[ValidationTaskInteraction]): Future[Seq[Int]]
-  def insertComment(comment: ValidationTaskComment): Future[Int]
-  def deleteCommentIfExists(labelId: Int, userId: String): Future[Int]
+  def replaceComment(comment: ValidationTaskComment): Future[Int]
   def submitValidations(validationSubmissions: Seq[ValidationSubmission]): Future[Seq[Int]]
   def submitValidationsDbio(validationSubmissions: Seq[ValidationSubmission]): DBIO[Seq[Int]]
 }
@@ -55,6 +54,17 @@ class ValidationServiceImpl @Inject() (
 
   /** SQLState for a Postgres unique-constraint violation. */
   private val UniqueViolation: String = "23505"
+
+  /**
+   * Runs a write that replaces a user's earlier row, re-running it once if a concurrent writer got there first.
+   *
+   * These write paths decide whether to replace by reading their own snapshot, so two overlapping submissions can
+   * both find nothing and race to insert. Re-running once is enough: the winner has committed by then, so the retry
+   * sees its row and takes the replace path (#4377, #4942).
+   */
+  private def runWithUniqueViolationRetry[T](action: => DBIO[T]): Future[T] = {
+    db.run(action).recoverWith { case e: PSQLException if e.getSQLState == UniqueViolation => db.run(action) }
+  }
 
   def countValidations: Future[Int]                 = db.run(labelValidationTable.countValidations)
   def countHumanValidations: Future[Int]            = db.run(labelValidationTable.countHumanValidations)
@@ -216,10 +226,17 @@ class ValidationServiceImpl @Inject() (
   def insertMultipleInteractions(interactions: Seq[ValidationTaskInteraction]): Future[Seq[Int]] =
     db.run(validationTaskInteractionTable.insertMultiple(interactions))
 
-  def insertComment(comment: ValidationTaskComment): Future[Int] = db.run(validationTaskCommentTable.insert(comment))
-
-  def deleteCommentIfExists(labelId: Int, userId: String): Future[Int] =
-    db.run(validationTaskCommentTable.deleteIfExists(labelId, userId))
+  /**
+   * Records the user's comment on a label, replacing whatever they had said about it before.
+   *
+   * @return The validation_task_comment_id of the comment that was stored.
+   */
+  def replaceComment(comment: ValidationTaskComment): Future[Int] = runWithUniqueViolationRetry {
+    (for {
+      _         <- validationTaskCommentTable.deleteIfExists(comment.labelId, comment.userId)
+      commentId <- validationTaskCommentTable.insert(comment)
+    } yield commentId).transactionally
+  }
 
   /**
    * Updates severity and tags in the label table and saves the change in the label_history table. Called from Validate.
@@ -266,16 +283,8 @@ class ValidationServiceImpl @Inject() (
    * @param validationSubmissions A sequence of ValidationSubmission objects
    * @return A sequence of the label_validation_ids of the inserted/updated validations.
    */
-  def submitValidations(validationSubmissions: Seq[ValidationSubmission]): Future[Seq[Int]] = {
-    // The duplicate check in submitValidationsDbio reads its own snapshot, so two overlapping submissions of the same
-    // validation can both find nothing and race to insert. Re-running once is enough: the winner has committed by
-    // then, so the retry sees the row and takes the replace path (#4377).
-    val submission = db.run(submitValidationsDbio(validationSubmissions))
-    submission.recoverWith {
-      case e: PSQLException if e.getSQLState == UniqueViolation =>
-        db.run(submitValidationsDbio(validationSubmissions))
-    }
-  }
+  def submitValidations(validationSubmissions: Seq[ValidationSubmission]): Future[Seq[Int]] =
+    runWithUniqueViolationRetry(submitValidationsDbio(validationSubmissions))
 
   /**
    * Submits a set of validations from a POST request on Validate.

--- a/app/service/ValidationService.scala
+++ b/app/service/ValidationService.scala
@@ -58,9 +58,9 @@ class ValidationServiceImpl @Inject() (
   /**
    * Runs a write that replaces a user's earlier row, re-running it once if a concurrent writer got there first.
    *
-   * These write paths decide whether to replace by reading their own snapshot, so two overlapping submissions can
-   * both find nothing and race to insert. Re-running once is enough: the winner has committed by then, so the retry
-   * sees its row and takes the replace path (#4377, #4942).
+   * Neither write path can see a concurrent writer's uncommitted row: one reads its own snapshot to decide whether to
+   * replace and finds nothing, the other deletes and removes nothing, so both go on to insert. Re-running once is
+   * enough: the winner has committed by then, so the retry's read or delete does see its row (#4377, #4942).
    */
   private def runWithUniqueViolationRetry[T](action: => DBIO[T]): Future[T] = {
     db.run(action).recoverWith { case e: PSQLException if e.getSQLState == UniqueViolation => db.run(action) }

--- a/conf/evolutions/default/359.sql
+++ b/conf/evolutions/default/359.sql
@@ -1,0 +1,22 @@
+# --- !Ups
+-- #4942: one comment per (label_id, user_id) has always been an app invariant. This evolution formalizes this in a
+-- constraint, and cleans up the small number of exceptions that slipped through (future issues fixed in for #4942).
+--
+-- Prod's duplicates were resolved by hand before this ships, keeping or merging whichever comment the user meant.
+DELETE FROM validation_task_comment
+USING (
+  SELECT validation_task_comment_id,
+         row_number() OVER (PARTITION BY label_id, user_id
+                            ORDER BY timestamp DESC, validation_task_comment_id DESC) AS newest_first
+  FROM validation_task_comment
+) superseded
+WHERE superseded.validation_task_comment_id = validation_task_comment.validation_task_comment_id
+  AND superseded.newest_first > 1;
+
+-- Named and ordered to match label_validation_user_id_label_id_unique on the sibling table, except label_id leads
+-- here because reads of this table filter by label alone (the label popup's comment list) far more often than by user.
+ALTER TABLE validation_task_comment
+  ADD CONSTRAINT validation_task_comment_label_id_user_id_unique UNIQUE (label_id, user_id);
+
+# --- !Downs
+ALTER TABLE validation_task_comment DROP CONSTRAINT validation_task_comment_label_id_user_id_unique;

--- a/conf/evolutions/default/359.sql
+++ b/conf/evolutions/default/359.sql
@@ -1,6 +1,6 @@
 # --- !Ups
 -- #4942: one comment per (label_id, user_id) has always been an app invariant. This evolution formalizes this in a
--- constraint, and cleans up the small number of exceptions that slipped through (future issues fixed in for #4942).
+-- constraint, and cleans up the small number of exceptions that slipped through (future issues fixed for #4942).
 --
 -- Prod's duplicates were resolved by hand before this ships, keeping or merging whichever comment the user meant.
 DELETE FROM validation_task_comment

--- a/test/controllers/ValidateSubmissionSpec.scala
+++ b/test/controllers/ValidateSubmissionSpec.scala
@@ -19,9 +19,10 @@ import play.api.test.Helpers._
 import java.time.OffsetDateTime
 
 /**
- * Functional tests for the Validate submission endpoints — `POST /validationTask` (the Validate tool) and
- * `POST /labelmap/validate` (the LabelMap/Gallery path) — the write path that turns a validation into a
- * `label_validation` row and the label's updated agree/disagree/unsure counts (#4777).
+ * Functional tests for the Validate submission endpoints — `POST /validationTask` (the Validate tool),
+ * `POST /labelmap/validate`, and `POST /labelmap/comment` (the LabelMap/Gallery paths) — the write path that turns a
+ * validation into a `label_validation` row and the label's updated agree/disagree/unsure counts (#4777), and the one
+ * that keeps a user to a single comment per label (#4942).
  *
  * Follows the real client bootstrap: GET /validate embeds the assigned mission and label batch as inline page JS
  * (`param.*`), and the spec validates the first label of that real batch. Both tests run the endpoint's own undo flow
@@ -239,6 +240,20 @@ class ValidateSubmissionSpec
     )
   }
 
+  /** A `POST /labelmap/comment` payload for the given label. */
+  private def labelMapCommentJson(label: JsObject, text: String): JsObject =
+    Json.obj(
+      "label_id"   -> (label \ "label_id").as[Int],
+      "label_type" -> (label \ "label_type").as[String],
+      "comment"    -> text,
+      "pano_id"    -> (label \ "pano_id").as[String],
+      "heading"    -> (label \ "heading").as[Double],
+      "pitch"      -> (label \ "pitch").as[Double],
+      "zoom"       -> (label \ "zoom").as[Double],
+      "lat"        -> (label \ "lat").as[Double],
+      "lng"        -> (label \ "lng").as[Double]
+    )
+
   /** Posts a Validate-tool submission over HTTP as the session's user. */
   private def postValidationTask(session: Seq[Cookie], payload: JsValue) =
     route(app, FakeRequest(POST, "/validationTask").withCookies(session: _*).withJsonBody(payload).withCSRFToken).get
@@ -248,6 +263,13 @@ class ValidateSubmissionSpec
     route(
       app,
       FakeRequest(POST, "/labelmap/validate").withCookies(session: _*).withJsonBody(payload).withCSRFToken
+    ).get
+
+  /** Posts a LabelMap/Gallery comment over HTTP as the session's user. */
+  private def postLabelMapComment(session: Seq[Cookie], payload: JsValue) =
+    route(
+      app,
+      FakeRequest(POST, "/labelmap/comment").withCookies(session: _*).withJsonBody(payload).withCSRFToken
     ).get
 
   /**
@@ -517,6 +539,25 @@ class ValidateSubmissionSpec
       status(undone) mustBe OK
       validationRow(labelId, b.userId) mustBe None
       labelState(labelId) mustBe before
+    }
+  }
+
+  "POST /labelmap/comment" should {
+    "replace the user's earlier comment on the label rather than stacking a second one (#4942)" in {
+      val session = freshAnonSession()
+      val b       = fetchValidateBootstrap(session)
+      val label   = b.labels.head
+      val labelId = (label \ "label_id").as[Int]
+
+      val first = postLabelMapComment(session, labelMapCommentJson(label, "Ramp is behind the parked car."))
+      status(first) mustBe OK
+      (contentAsJson(first) \ "comment_id").as[Int] must be > 0
+      commentsOn(labelId, b.userId) mustBe Seq("Ramp is behind the parked car.")
+
+      // Revising a comment is the flow that has to land on the user's existing row for the label, not beside it.
+      val revised = postLabelMapComment(session, labelMapCommentJson(label, "Looking again, it is fine."))
+      status(revised) mustBe OK
+      commentsOn(labelId, b.userId) mustBe Seq("Looking again, it is fine.")
     }
   }
 }


### PR DESCRIPTION
resolves #4942

Both comment write paths delete the user's earlier comment on a label before inserting the new one, so the app has always treated one comment per `(label_id, user_id)` as an invariant — but the schema never said so, and `postLabelMapComment` ran its delete and insert as two separate `db.run` calls with no transaction. An audit of all 54 prod cities found **123 duplicate pairs**, the most recent from 2025-08.

### Write paths

- `postLabelMapComment` now calls `ValidationService.replaceComment`, which runs the delete and insert in one transaction. Without it, a failing insert left the user with neither their old comment nor their new one.
- The unique-violation retry `submitValidations` picked up in #4940 is now shared by both paths (`runWithUniqueViolationRetry`), so a submission that loses a race replaces rather than duplicates.
- `insertComment` / `deleteCommentIfExists` are gone; `replaceComment` was their only caller pairing.

### Constraint

Evolution 359 collapses any remaining duplicate to the newest row, then adds `UNIQUE (label_id, user_id)`, mirrored in `ValidationTaskCommentTableDef`. Named to match `label_validation_user_id_label_id_unique` on the sibling table; `label_id` leads because reads of this table aggregate by label with no user filter.

### Prod cleanup, done by hand before merge

The evolution's keep-the-latest rule would have silently dropped the older comment in all 123 pairs, and **73 of them differ in text** — often the same validator commenting on two different things (`'severity = 2'` then `'tag = rail/tram track'`), sometimes with the *later* comment being the less informative one. So the duplicates were resolved by hand first, per pair, and that pass has already run on prod: 21 merged, 11 kept the older row, 91 kept the newest; 125 rows deleted; every city verified at 0 duplicate pairs.

Evolution 359 therefore finds nothing to delete on prod. It stays in for dev dumps and for anything that races in between that pass and the deploy.

The audit and cleanup scripts, the per-pair decision CSV, and the generators that build the SQL from it are in `scratchpad/` (untracked).

### Testing

`ValidateSubmissionSpec` gains a `POST /labelmap/comment` case (revising a comment lands on the user's existing row). Full spec passes against a seeded schema with evolution 359 applied and the constraint live — including the two #4377 duplicate-submission cases that now depend on the retry path. Note the suite cancels entirely on a schema with no validatable labels, so it needs a seeded city.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
