### PR TITLE
Add 390px no-overflow checks to the smoke suite; fix the two API-docs offenders (#4883)

### DIFF
--- a/app/views/apiDocs/layout.scala.html
+++ b/app/views/apiDocs/layout.scala.html
@@ -1,6 +1,8 @@
 @(activePage: String)(content: Html)(implicit request: RequestHeader, assets: AssetsFinder)
 
 <link rel="stylesheet" href="@assets.path("css/api-docs/api-docs.css")">
+<!-- Loaded ahead of the page content, whose embedded preview scripts call it as soon as their data arrives. -->
+<script src="@assets.path("js/api-docs/apiTableWrapper.js")"></script>
 
 <div class="api-container">
     <!-- Left Sidebar Navigation -->

--- a/public/css/api-docs/api-docs.css
+++ b/public/css/api-docs/api-docs.css
@@ -253,6 +253,12 @@ a:hover {
   box-shadow: var(--box-shadow-sm);
 }
 
+/* Inside the scroller the wrapper owns the vertical rhythm; a table margin would just push the scrollbar
+   away from the content. */
+.api-table-wrapper > table {
+  margin: 0;
+}
+
 .api-table {
   width: 100%;
   border-collapse: collapse;
@@ -345,12 +351,15 @@ pre > code.language-csv {
   white-space: nowrap;
 }
 
-/* On a phone-width viewport a long inline code token (an endpoint URL) has nowhere to go but past the screen
-   edge, so wrapping must win over the nowrap look; wider viewports keep code tokens on one line (#4883). */
-@media (width <= 600px) {
+/* On a single-column viewport (var(--breakpoint-sm)) a long inline code token (an endpoint URL) has nowhere
+   to go but past the screen edge, so wrapping must win over the nowrap look; wider viewports keep code tokens
+   on one line (#4883). break-word rather than anywhere: anywhere feeds its break points into min-content
+   sizing, letting code-bearing table columns squash below token width instead of engaging the
+   .api-table-wrapper scroller. */
+@media (width <= 768px) {
   :not(pre) > code {
     white-space: normal;
-    overflow-wrap: anywhere;
+    overflow-wrap: break-word;
   }
 }
 

--- a/public/css/api-docs/api-docs.css
+++ b/public/css/api-docs/api-docs.css
@@ -345,6 +345,15 @@ pre > code.language-csv {
   white-space: nowrap;
 }
 
+/* On a phone-width viewport a long inline code token (an endpoint URL) has nowhere to go but past the screen
+   edge, so wrapping must win over the nowrap look; wider viewports keep code tokens on one line (#4883). */
+@media (width <= 600px) {
+  :not(pre) > code {
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
+}
+
 /* ---- Permalink Style ---- */
 
 .permalink {

--- a/public/css/api-docs/label-types.css
+++ b/public/css/api-docs/label-types.css
@@ -28,6 +28,12 @@
   font-size: var(--font-size-sm);
 }
 
+/* Inside the shared scroller (#4883) the wrapper owns the vertical rhythm, so the table's own margin would
+   just push the scrollbar away from the content. */
+.api-table-wrapper > .label-types-table {
+  margin: 0;
+}
+
 .label-types-table th:not(:last-child),
 .label-types-table td:not(:last-child) {
   padding-right: 6px; /* Add spacing between columns */

--- a/public/css/api-docs/label-types.css
+++ b/public/css/api-docs/label-types.css
@@ -24,14 +24,7 @@
   width: 100%;
   border-collapse: separate;
   border-spacing: 0;
-  margin: var(--space-lg) 0;
   font-size: var(--font-size-sm);
-}
-
-/* Inside the shared scroller (#4883) the wrapper owns the vertical rhythm, so the table's own margin would
-   just push the scrollbar away from the content. */
-.api-table-wrapper > .label-types-table {
-  margin: 0;
 }
 
 .label-types-table th:not(:last-child),

--- a/public/js/api-docs/aggregateStatsPreview.js
+++ b/public/js/api-docs/aggregateStatsPreview.js
@@ -163,7 +163,7 @@
         tbody.appendChild(row);
       });
       table.appendChild(tbody);
-      container.appendChild(table);
+      container.appendChild(window.createApiTableWrapper(table, 'Labels by label type'));
     },
   };
 })();

--- a/public/js/api-docs/apiTableWrapper.js
+++ b/public/js/api-docs/apiTableWrapper.js
@@ -1,0 +1,27 @@
+/**
+ * Shared horizontal scroller for the JS-rendered api-docs preview tables.
+ *
+ * Loaded by apiDocs/layout.scala.html ahead of the page content so it is guaranteed to exist before any
+ * embedded preview script's render callback fires.
+ */
+
+/**
+ * Wraps a preview table in the same `.api-table-wrapper` scroller the server-rendered api-docs tables sit in:
+ * on a narrow viewport a wide table scrolls inside it instead of being clipped unreachable by the page's
+ * overflow-x clipping (#4883).
+ *
+ * @param {HTMLTableElement} table - The table to wrap.
+ * @param {string} label - Accessible name for the scroll region.
+ * @returns {HTMLElement} The wrapper, with the table inside it.
+ */
+window.createApiTableWrapper = (table, label) => {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'api-table-wrapper';
+  // A scroll region needs keyboard focus so off-screen columns stay reachable without a pointer (WCAG 2.1.1),
+  // and a role + name so the focus stop announces as something rather than nothing.
+  wrapper.tabIndex = 0;
+  wrapper.setAttribute('role', 'region');
+  wrapper.setAttribute('aria-label', label);
+  wrapper.appendChild(table);
+  return wrapper;
+};

--- a/public/js/api-docs/labelTagsPreview.js
+++ b/public/js/api-docs/labelTagsPreview.js
@@ -244,7 +244,7 @@
         });
 
         table.appendChild(tbody);
-        section.appendChild(table);
+        section.appendChild(window.createApiTableWrapper(table, `${labelType} tags`));
 
         container.appendChild(section);
       });
@@ -323,7 +323,7 @@
       });
 
       table.appendChild(tbody);
-      container.appendChild(table);
+      container.appendChild(window.createApiTableWrapper(table, 'Label tags by label type'));
     },
   };
 })();

--- a/public/js/api-docs/labelTypesPreview.js
+++ b/public/js/api-docs/labelTypesPreview.js
@@ -182,9 +182,15 @@
 
       table.appendChild(tbody);
 
+      // The shared horizontal scroller: on a phone-width viewport the seven-column table scrolls inside it
+      // instead of pushing the whole page wider than the screen (#4883).
+      const wrapper = document.createElement('div');
+      wrapper.className = 'api-table-wrapper';
+      wrapper.appendChild(table);
+
       // Clear container and add table.
       container.innerHTML = '';
-      container.appendChild(table);
+      container.appendChild(wrapper);
 
       return table;
     },

--- a/public/js/api-docs/labelTypesPreview.js
+++ b/public/js/api-docs/labelTypesPreview.js
@@ -182,15 +182,8 @@
 
       table.appendChild(tbody);
 
-      // The shared horizontal scroller: on a phone-width viewport the seven-column table scrolls inside it
-      // instead of pushing the whole page wider than the screen (#4883).
-      const wrapper = document.createElement('div');
-      wrapper.className = 'api-table-wrapper';
-      wrapper.appendChild(table);
-
-      // Clear container and add table.
       container.innerHTML = '';
-      container.appendChild(wrapper);
+      container.appendChild(window.createApiTableWrapper(table, 'Label types'));
 
       return table;
     },

--- a/public/js/api-docs/streetTypesPreview.js
+++ b/public/js/api-docs/streetTypesPreview.js
@@ -159,9 +159,8 @@
 
       table.appendChild(tbody);
 
-      // Clear container and add table.
       container.innerHTML = '';
-      container.appendChild(table);
+      container.appendChild(window.createApiTableWrapper(table, 'Street types'));
 
       return table;
     },

--- a/public/js/api-docs/validationResultTypesPreview.js
+++ b/public/js/api-docs/validationResultTypesPreview.js
@@ -143,7 +143,7 @@
       table.appendChild(tbody);
 
       container.innerHTML = '';
-      container.appendChild(table);
+      container.appendChild(window.createApiTableWrapper(table, 'Validation result types'));
       return table;
     },
   };

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -3,8 +3,9 @@
 A thin headless-browser suite (issue #4504) that loads each core page and **fails on any uncaught page
 error or non-allowlisted `console.error`**. It exists to catch the class of regression that compile, the
 grunt build, and all four linters are blind to: runtime-only JS errors — a stale bundle, a missing global,
-an unbound-method `this` bug, a route-ordering 400 breaking a fetch. It asserts *pages initialize cleanly*,
-not pixel-level behavior; deep canvas/imagery testing stays manual by design.
+an unbound-method `this` bug, a route-ordering 400 breaking a fetch. It asserts *pages initialize cleanly*
+plus one piece of layout geometry — `phone-viewport.spec.js` re-loads the responsive pages at a 390×844
+phone viewport and fails on horizontal overflow (#4883). Deep canvas/imagery testing stays manual by design.
 
 ## Running locally
 
@@ -41,13 +42,24 @@ regardless of filters), so every run registers a throwaway `ci-smoke-<timestamp>
    them, and flips `isReady` anyway — a broken page still "becomes ready".
 3. Assert the collected `pageerror` + `console.error` list (the `consoleErrors` fixture) is empty.
 
+Steps 1–2 (plus a stayed-put URL assert and a 1s settle window for late async work) live in the shared
+`loadAndSettle()` helper in `fixtures.js`, driven by per-entry flags in each spec's page table — the load
+protocol is defined once so the table-driven specs can't drift apart.
+
 ### Mapbox stub
 
-Pages that build a Mapbox map at init (`/`, `/labelMap`, `/routeBuilder`, `/cities`, `/dashboard`) get
-`stubMapbox()`: all `api.mapbox.com` traffic is intercepted and the style request answered with a minimal
+Pages that build a Mapbox map at init (`/`, `/about`, `/labelMap`, `/routeBuilder`, `/cities`, `/dashboard`)
+get `stubMapbox()`: all `api.mapbox.com` traffic is intercepted and the style request answered with a minimal
 valid empty style. Without it, CI's dummy `MAPBOX_API_KEY` 401s the style request, the map's `load` event
 never fires, and `#page-loading` hangs forever. The stub runs even against a real local key so behavior is
 identical in both environments.
+
+### Makeability Lab API stub
+
+`/about` hydrates its team/publications/grants sections from the live ML API, so it gets
+`stubMakeabilityLab()`: every `makeabilitylab.cs.washington.edu` request is answered with an empty listing,
+keeping each section on its server-rendered fallback. That makes the measured DOM deterministic and keeps an
+ML-site outage from failing the run.
 
 ### Console-error allowlist
 
@@ -77,7 +89,9 @@ local development** — your edit / `grunt watch` / reload loop is untouched.
 - **Phase 2b (open):** make CI exercise `/validate`'s real mission path — needs a committed seed of ≥ 10
   non-tutorial labels whose panos are live or locally backed up, and a real `GOOGLE_MAPS_SECRET` for the
   server-side pano-metadata check; also gallery expanded-card view and api-docs preview content asserts
-  (then drop the `regionWithMostLabels` allowlist entries in `fixtures.js`).
+  (then drop the `regionWithMostLabels` allowlist entries in `fixtures.js`). `/v3/api-docs/labelTags` can't
+  join the page tables until its missing tag example images (ids 43, 76–79) are added — each 404 is a
+  console error.
 - **Phase 3:** primary-control interactions per page (info button, tag menu, mission modal) and a few
   end-to-end flows (place a label + tag; validate a label); admin pages (promote the setup user via a
   superuser `UPDATE user_role` in CI).
@@ -87,9 +101,10 @@ local development** — your edit / `grunt watch` / reload loop is untouched.
 | File | Role |
 |---|---|
 | `../../playwright.config.js` | Config: `testDir`, retries, reporters, the `setup` → `chromium` projects |
-| `fixtures.js` | `consoleErrors` fixture, Mapbox stub, `waitForAppReady`, allowlist |
+| `fixtures.js` | `consoleErrors` fixture, Mapbox + ML-API stubs, `loadAndSettle`, `waitForAppReady`, `horizontalOverflowReport`, allowlist |
 | `auth.setup.js` | Registers a throwaway user, saves storageState for registered-user specs |
 | `pages.spec.js` | Table-driven phase-1 anonymous pages |
+| `phone-viewport.spec.js` | The same pages at a 390×844 phone viewport: no horizontal overflow (#4883) |
 | `dashboard.spec.js` | Registered-user pages |
 | `explore-validate.spec.js` | Phase-2 Explore/Validate specs (skip without the real GSV key) |
 | `labelmap-feed-failure.spec.js` | What `/labelMap` shows when its label feed fails (intercepted, so DB-independent) |

--- a/test/e2e/dashboard.spec.js
+++ b/test/e2e/dashboard.spec.js
@@ -1,18 +1,13 @@
 /**
  * Smoke tests for pages that require a REGISTERED (non-anonymous) user. Reuses the session that
- * auth.setup.js saved as storageState; anonymous sessions get bounced to /signIn by WithSignedIn().
+ * auth.setup.js saved as storageState; anonymous sessions get bounced to /signIn by WithSignedIn() —
+ * loadAndSettle's stayed-put URL assert is what catches that.
  */
-const {test, expect, stubMapbox, waitForAppReady, STORAGE_STATE} = require('./fixtures');
+const {test, expect, loadAndSettle, STORAGE_STATE} = require('./fixtures');
 
 test.use({storageState: STORAGE_STATE});
 
 test('/dashboard loads without console errors', async ({page, context, consoleErrors}) => {
-  await stubMapbox(context); // The contribution choropleth is a Mapbox map.
-  const response = await page.goto('/dashboard');
-  expect(response.status(), `/dashboard responded ${response.status()}`).toBeLessThan(400);
-  // A bounced anonymous/expired session would land on /signIn with a clean console — assert we stayed put.
-  expect(page.url()).toContain('/dashboard');
-  await waitForAppReady(page);
-  await page.waitForTimeout(1000);
+  await loadAndSettle(page, context, {path: '/dashboard', mapbox: true}); // The choropleth is a Mapbox map.
   expect(consoleErrors).toEqual([]);
 });

--- a/test/e2e/fixtures.js
+++ b/test/e2e/fixtures.js
@@ -91,6 +91,19 @@ async function stubMapbox(context) {
 }
 
 /**
+ * Stubs the Makeability Lab API that /about hydrates its team/publications/grants sections from. The empty
+ * listing keeps every section on its server-rendered fallback, so the suite measures a deterministic DOM in
+ * both environments — and an ML-site outage can't fail the run (Chromium logs its own console error for any
+ * failed fetch, which no allowlist entry covers).
+ *
+ * @param {import('@playwright/test').BrowserContext} context - The context whose requests to intercept.
+ */
+async function stubMakeabilityLab(context) {
+  await context.route('https://makeabilitylab.cs.washington.edu/**', (route) =>
+    route.fulfill({json: {results: [], next: null}}));
+}
+
+/**
  * Waits until the shared AppManager (public/js/common/AppManager.js, wired into every page by
  * app/views/common/main.scala.html) reports initialization complete.
  *
@@ -105,6 +118,36 @@ async function waitForAppReady(page) {
 }
 
 /**
+ * Navigates to a page-table entry and waits for it to settle — the one load protocol shared by
+ * pages.spec.js, dashboard.spec.js, and phone-viewport.spec.js, so it can't drift between them.
+ *
+ * @param {import('@playwright/test').Page} page - The test's page.
+ * @param {import('@playwright/test').BrowserContext} context - The page's context (route stubs are per-context).
+ * @param {{path: string, mapbox?: boolean, makeabilityLab?: boolean, loadingOverlay?: boolean,
+ *   waitFor?: function(import('@playwright/test').Page): Promise<void>}} p - The page-table entry: `mapbox` /
+ *   `makeabilityLab` install the stubs above before navigating, `loadingOverlay` waits for the shared
+ *   #page-loading overlay to hide, and `waitFor` is an extra page-specific readiness wait.
+ */
+async function loadAndSettle(page, context, p) {
+  if (p.mapbox) await stubMapbox(context);
+  if (p.makeabilityLab) await stubMakeabilityLab(context);
+  const response = await page.goto(p.path);
+  base.expect(response.status(), `${p.path} responded ${response.status()}`).toBeLessThan(400);
+  // Asserted before any waiting so a redirected load fails fast and legibly: a bounced session lands on
+  // /signIn, and a page that gained a mobile-UA redirect lands on /mobileLanding — both with a clean console.
+  base.expect(page.url(), `${p.path} landed on ${page.url()}`).toContain(p.path);
+  await waitForAppReady(page);
+  // The landing page defers its maps and validation grid behind util.onFirstInteractionOrIdle (#4486).
+  // Headless Chromium generates no input events, so without a nudge deferred init would only start on the 5s
+  // fallback — after the settle window below, silently costing coverage rather than failing.
+  await page.mouse.move(10, 10);
+  if (p.waitFor) await p.waitFor(page);
+  if (p.loadingOverlay) await page.locator('#page-loading').waitFor({state: 'hidden'});
+  // Settle window: errors from late async work (post-ready fetches, image/map callbacks) land here.
+  await page.waitForTimeout(1000);
+}
+
+/**
  * Measures horizontal overflow at the current viewport width (issue #4883): every element whose border box
  * extends past the right edge of the layout viewport, except content inside an `overflow-x: auto|scroll`
  * ancestor — a horizontal scroller is the sanctioned way to present wide content (tables, code) on a phone.
@@ -113,6 +156,12 @@ async function waitForAppReady(page) {
  * main.css means an overflowing page never shows a scrollbar, and a `position: fixed` element sized off the
  * overflowed initial containing block (the #4857 footer bug) never widens `scrollWidth` at all. The page-level
  * `scrollWidth` is still reported as a second, cheaper signal.
+ *
+ * Deliberately strict: content laid out wider than the viewport but clipped by an `overflow: hidden|clip`
+ * ancestor is still reported — unreachable-but-laid-out-wide content is the #4883 bug class itself. UI
+ * deliberately parked off-screen (an off-canvas drawer) should be display: none / visibility: hidden while
+ * closed rather than exempted here. Known blind spot: `overflow-y: auto` computes `overflow-x: auto` on the
+ * same box, so a vertical-only scroll pane (e.g. the auth pages' .au-body) exempts its descendants.
  *
  * @param {import('@playwright/test').Page} page - The page to measure, already loaded and settled.
  * @returns {Promise<{viewportWidth: number, pageScrollWidth: number, offenders: string[], offenderCount: number}>}
@@ -128,8 +177,13 @@ async function horizontalOverflowReport(page) {
       const rect = el.getBoundingClientRect();
       if (rect.width === 0 || rect.height === 0 || rect.right <= viewportWidth + TOLERANCE_PX) continue;
       let inScroller = false;
-      for (let a = el.parentElement; a && !inScroller; a = a.parentElement) {
-        inScroller = ['auto', 'scroll'].includes(getComputedStyle(a).overflowX);
+      // A fixed element's containing block is the viewport, so no ancestor scrolls or clips it (the #4857
+      // footer bug shape); and the walk stops before body so a horizontally scrollable page can't exempt
+      // everything on it.
+      if (getComputedStyle(el).position !== 'fixed') {
+        for (let a = el.parentElement; a && a !== document.body && !inScroller; a = a.parentElement) {
+          inScroller = ['auto', 'scroll'].includes(getComputedStyle(a).overflowX);
+        }
       }
       if (inScroller) continue;
       const id = el.id ? `#${el.id}` : '';
@@ -163,4 +217,13 @@ const test = base.test.extend({
   },
 });
 
-module.exports = {test, expect: base.expect, stubMapbox, waitForAppReady, horizontalOverflowReport, STORAGE_STATE};
+module.exports = {
+  test,
+  expect: base.expect,
+  stubMapbox,
+  stubMakeabilityLab,
+  waitForAppReady,
+  loadAndSettle,
+  horizontalOverflowReport,
+  STORAGE_STATE,
+};

--- a/test/e2e/fixtures.js
+++ b/test/e2e/fixtures.js
@@ -104,6 +104,47 @@ async function waitForAppReady(page) {
   await page.waitForFunction(() => window.appManager && window.appManager.isReady === true);
 }
 
+/**
+ * Measures horizontal overflow at the current viewport width (issue #4883): every element whose border box
+ * extends past the right edge of the layout viewport, except content inside an `overflow-x: auto|scroll`
+ * ancestor — a horizontal scroller is the sanctioned way to present wide content (tables, code) on a phone.
+ *
+ * Measuring layout (bounding boxes) rather than scrollbars is the point: `body {overflow-x: clip}` in
+ * main.css means an overflowing page never shows a scrollbar, and a `position: fixed` element sized off the
+ * overflowed initial containing block (the #4857 footer bug) never widens `scrollWidth` at all. The page-level
+ * `scrollWidth` is still reported as a second, cheaper signal.
+ *
+ * @param {import('@playwright/test').Page} page - The page to measure, already loaded and settled.
+ * @returns {Promise<{viewportWidth: number, pageScrollWidth: number, offenders: string[], offenderCount: number}>}
+ *   Offenders are CSS-selector-ish descriptions (`div#gallery.sidebar right=612px`), capped at 10; offenderCount
+ *   is the uncapped total.
+ */
+async function horizontalOverflowReport(page) {
+  return page.evaluate(() => {
+    const TOLERANCE_PX = 1; // Sub-pixel rounding at fractional device-pixel-ratios is not overflow.
+    const viewportWidth = document.documentElement.clientWidth;
+    const offenders = [];
+    for (const el of document.querySelectorAll('body *')) {
+      const rect = el.getBoundingClientRect();
+      if (rect.width === 0 || rect.height === 0 || rect.right <= viewportWidth + TOLERANCE_PX) continue;
+      let inScroller = false;
+      for (let a = el.parentElement; a && !inScroller; a = a.parentElement) {
+        inScroller = ['auto', 'scroll'].includes(getComputedStyle(a).overflowX);
+      }
+      if (inScroller) continue;
+      const id = el.id ? `#${el.id}` : '';
+      const cls = el.classList.length ? `.${[...el.classList].join('.')}` : '';
+      offenders.push(`${el.tagName.toLowerCase()}${id}${cls} right=${Math.round(rect.right)}px`);
+    }
+    return {
+      viewportWidth,
+      pageScrollWidth: document.scrollingElement.scrollWidth,
+      offenders: offenders.slice(0, 10),
+      offenderCount: offenders.length,
+    };
+  });
+}
+
 const test = base.test.extend({
   /**
    * Collects uncaught exceptions and non-allowlisted console errors for the test's page. Specs assert
@@ -122,4 +163,4 @@ const test = base.test.extend({
   },
 });
 
-module.exports = {test, expect: base.expect, stubMapbox, waitForAppReady, STORAGE_STATE};
+module.exports = {test, expect: base.expect, stubMapbox, waitForAppReady, horizontalOverflowReport, STORAGE_STATE};

--- a/test/e2e/pages.spec.js
+++ b/test/e2e/pages.spec.js
@@ -10,14 +10,17 @@
  * Registered-user pages live in dashboard.spec.js; /explore and /validate (which need working street-view
  * imagery) are phase 2 — see explore-validate.spec.js.
  */
-const {test, expect, stubMapbox, waitForAppReady} = require('./fixtures');
+const {test, expect, loadAndSettle} = require('./fixtures');
 
 // mapbox: page builds a Mapbox map at init — stub it (see fixtures.js) so a dummy CI key can't hang init.
 // loadingOverlay: page uses the shared #page-loading overlay — wait for it to hide before the error check.
 const PAGES = [
-  {path: '/', mapbox: true},
+  // Deferred landing maps (#4486): wait until they're built so their init errors land inside the settle window.
+  {path: '/', mapbox: true, waitFor: (page) => page.waitForFunction(() => window.choropleth && window.deploymentMap)},
   {path: '/signIn'},
   {path: '/signUp'},
+  // /about hydrates from the Makeability Lab API (stubbed for determinism) and lazy-builds a Mapbox map.
+  {path: '/about', makeabilityLab: true, mapbox: true},
   {path: '/leaderboard'},
   {path: '/routes'},
   {path: '/stories'},
@@ -35,18 +38,7 @@ const PAGES = [
 
 for (const p of PAGES) {
   test(`${p.path} loads without console errors`, async ({page, context, consoleErrors}) => {
-    if (p.mapbox) await stubMapbox(context);
-    const response = await page.goto(p.path);
-    expect(response.status(), `${p.path} responded ${response.status()}`).toBeLessThan(400);
-    await waitForAppReady(page);
-    // The landing page defers its maps and validation grid behind util.onFirstInteractionOrIdle (#4486). Headless
-    // Chromium generates no input events, so without a nudge they'd only start on the 5s fallback — after the settle
-    // window below, silently costing this spec its coverage of map init rather than failing it.
-    await page.mouse.move(10, 10);
-    if (p.path === '/') await page.waitForFunction(() => window.choropleth && window.deploymentMap);
-    if (p.loadingOverlay) await page.locator('#page-loading').waitFor({state: 'hidden'});
-    // Settle window: init errors from late async work (post-ready fetches, map callbacks) land here.
-    await page.waitForTimeout(1000);
+    await loadAndSettle(page, context, p);
     expect(consoleErrors).toEqual([]);
   });
 }

--- a/test/e2e/phone-viewport.spec.js
+++ b/test/e2e/phone-viewport.spec.js
@@ -1,0 +1,84 @@
+/**
+ * Phone-viewport regression checks (issue #4883; Phase 0 guardrails of the responsive-first direction in #4875).
+ *
+ * Each covered page is loaded at an iPhone-class 390×844 viewport with a mobile user agent and must (a) produce
+ * no uncaught/console errors — the standard smoke assertion — and (b) show no horizontal overflow: no element's
+ * border box past the right edge of the viewport (except inside a horizontal scroller — see
+ * horizontalOverflowReport in fixtures.js for why layout is measured instead of scrollbars) and no page-level
+ * scrollWidth beyond the viewport.
+ *
+ * Coverage is the pages that are already responsive, so today's good state is locked in. As #4875's phases
+ * convert the UA-redirected pages (/gallery, /labelMap, landing, …), each conversion PR adds its page here —
+ * on a mobile UA those pages currently redirect to /mobileLanding, so listing them today would only re-test it.
+ *
+ * Lives apart from explore-validate.spec.js on purpose: that file skips wholesale without a real Google Maps
+ * key (absent on fork PRs), and nothing here needs one.
+ */
+const {devices} = require('@playwright/test');
+const {test, expect, stubMapbox, waitForAppReady, horizontalOverflowReport, STORAGE_STATE} = require('./fixtures');
+
+// devices['iPhone 13'] supplies the mobile UA, touch support and DPR. defaultBrowserType is dropped because the
+// suite's chromium project already fixes the browser, and the viewport is widened to the full 390×844 screen.
+const IPHONE = {...devices['iPhone 13'], viewport: {width: 390, height: 844}};
+delete IPHONE.defaultBrowserType;
+
+/**
+ * Loads a page, waits for it to settle, and runs the shared no-errors + no-horizontal-overflow assertions.
+ *
+ * @param {import('@playwright/test').Page} page - The test's page, already configured with the phone viewport.
+ * @param {string[]} consoleErrors - The consoleErrors fixture's collector for this page.
+ * @param {{path: string, loadingOverlay?: boolean}} p - The page table entry being checked.
+ */
+async function checkPhoneViewport(page, consoleErrors, p) {
+  const response = await page.goto(p.path);
+  expect(response.status(), `${p.path} responded ${response.status()}`).toBeLessThan(400);
+  await waitForAppReady(page);
+  if (p.loadingOverlay) await page.locator('#page-loading').waitFor({state: 'hidden'});
+  // Settle window, matching pages.spec.js: late async work (post-ready fetches, image/map callbacks) lands here.
+  await page.waitForTimeout(1000);
+
+  const report = await horizontalOverflowReport(page);
+  expect(report.offenders, `${p.path}: ${report.offenderCount} element(s) overflow the ` +
+    `${report.viewportWidth}px viewport`).toEqual([]);
+  expect(report.pageScrollWidth, `${p.path}: page scrollWidth exceeds the ${report.viewportWidth}px viewport`)
+    .toBeLessThanOrEqual(report.viewportWidth + 1);
+  expect(consoleErrors).toEqual([]);
+}
+
+test.describe('phone viewport (390px)', () => {
+  test.use(IPHONE);
+
+  // mapbox / loadingOverlay flags as in pages.spec.js. Pages that UA-redirect mobile visitors are deliberately
+  // absent (see the header comment); /labelingGuide serves phones but is not yet responsive, so it joins with
+  // its #4875 phase-2 conversion.
+  const PAGES = [
+    {path: '/mobileLanding'},
+    {path: '/signIn'},
+    {path: '/signUp'},
+    {path: '/about'},
+    {path: '/leaderboard'},
+    {path: '/routes'},
+    {path: '/stories'},
+    {path: '/cities', mapbox: true},
+    {path: '/api'},
+    {path: '/v3/api-docs/rawLabels'},
+  ];
+
+  for (const p of PAGES) {
+    test(`${p.path} fits without horizontal overflow`, async ({page, context, consoleErrors}) => {
+      if (p.mapbox) await stubMapbox(context);
+      await checkPhoneViewport(page, consoleErrors, p);
+    });
+  }
+});
+
+test.describe('phone viewport (390px), registered user', () => {
+  test.use({...IPHONE, storageState: STORAGE_STATE});
+
+  test('/dashboard fits without horizontal overflow', async ({page, context, consoleErrors}) => {
+    await stubMapbox(context); // The contribution choropleth is a Mapbox map.
+    await checkPhoneViewport(page, consoleErrors, {path: '/dashboard'});
+    // A bounced anonymous/expired session would land on /signIn with a clean console — assert we stayed put.
+    expect(page.url()).toContain('/dashboard');
+  });
+});

--- a/test/e2e/phone-viewport.spec.js
+++ b/test/e2e/phone-viewport.spec.js
@@ -9,13 +9,14 @@
  *
  * Coverage is the pages that are already responsive, so today's good state is locked in. As #4875's phases
  * convert the UA-redirected pages (/gallery, /labelMap, landing, …), each conversion PR adds its page here —
- * on a mobile UA those pages currently redirect to /mobileLanding, so listing them today would only re-test it.
+ * on a mobile UA those pages currently redirect to /mobileLanding, so listing them today would only re-test it
+ * (loadAndSettle's stayed-put URL assert catches a covered page joining that redirect set later).
  *
  * Lives apart from explore-validate.spec.js on purpose: that file skips wholesale without a real Google Maps
  * key (absent on fork PRs), and nothing here needs one.
  */
 const {devices} = require('@playwright/test');
-const {test, expect, stubMapbox, waitForAppReady, horizontalOverflowReport, STORAGE_STATE} = require('./fixtures');
+const {test, expect, loadAndSettle, horizontalOverflowReport, STORAGE_STATE} = require('./fixtures');
 
 // devices['iPhone 13'] supplies the mobile UA, touch support and DPR. defaultBrowserType is dropped because the
 // suite's chromium project already fixes the browser, and the viewport is widened to the full 390×844 screen.
@@ -23,19 +24,15 @@ const IPHONE = {...devices['iPhone 13'], viewport: {width: 390, height: 844}};
 delete IPHONE.defaultBrowserType;
 
 /**
- * Loads a page, waits for it to settle, and runs the shared no-errors + no-horizontal-overflow assertions.
+ * Loads a page-table entry and runs the shared no-errors + no-horizontal-overflow assertions.
  *
  * @param {import('@playwright/test').Page} page - The test's page, already configured with the phone viewport.
+ * @param {import('@playwright/test').BrowserContext} context - The page's context.
  * @param {string[]} consoleErrors - The consoleErrors fixture's collector for this page.
- * @param {{path: string, loadingOverlay?: boolean}} p - The page table entry being checked.
+ * @param {object} p - The page table entry being checked (see loadAndSettle for the flags).
  */
-async function checkPhoneViewport(page, consoleErrors, p) {
-  const response = await page.goto(p.path);
-  expect(response.status(), `${p.path} responded ${response.status()}`).toBeLessThan(400);
-  await waitForAppReady(page);
-  if (p.loadingOverlay) await page.locator('#page-loading').waitFor({state: 'hidden'});
-  // Settle window, matching pages.spec.js: late async work (post-ready fetches, image/map callbacks) lands here.
-  await page.waitForTimeout(1000);
+async function checkPhoneViewport(page, context, consoleErrors, p) {
+  await loadAndSettle(page, context, p);
 
   const report = await horizontalOverflowReport(page);
   expect(report.offenders, `${p.path}: ${report.offenderCount} element(s) overflow the ` +
@@ -48,14 +45,16 @@ async function checkPhoneViewport(page, consoleErrors, p) {
 test.describe('phone viewport (390px)', () => {
   test.use(IPHONE);
 
-  // mapbox / loadingOverlay flags as in pages.spec.js. Pages that UA-redirect mobile visitors are deliberately
-  // absent (see the header comment); /labelingGuide serves phones but is not yet responsive, so it joins with
-  // its #4875 phase-2 conversion.
+  // mapbox / makeabilityLab / loadingOverlay flags as in pages.spec.js. Pages that UA-redirect mobile visitors
+  // are deliberately absent (see the header comment); /labelingGuide serves phones but is not yet responsive,
+  // so it joins with its #4875 phase-2 conversion. Caveat: against CI's near-empty seed the data-driven pages
+  // (/leaderboard, /routes, /stories, the rawLabels preview) render empty shells, so content-driven overflow
+  // (a long username, a story title) is only exercised by a local run against a seeded DB.
   const PAGES = [
     {path: '/mobileLanding'},
     {path: '/signIn'},
     {path: '/signUp'},
-    {path: '/about'},
+    {path: '/about', makeabilityLab: true, mapbox: true},
     {path: '/leaderboard'},
     {path: '/routes'},
     {path: '/stories'},
@@ -66,8 +65,7 @@ test.describe('phone viewport (390px)', () => {
 
   for (const p of PAGES) {
     test(`${p.path} fits without horizontal overflow`, async ({page, context, consoleErrors}) => {
-      if (p.mapbox) await stubMapbox(context);
-      await checkPhoneViewport(page, consoleErrors, p);
+      await checkPhoneViewport(page, context, consoleErrors, p);
     });
   }
 });
@@ -76,9 +74,6 @@ test.describe('phone viewport (390px), registered user', () => {
   test.use({...IPHONE, storageState: STORAGE_STATE});
 
   test('/dashboard fits without horizontal overflow', async ({page, context, consoleErrors}) => {
-    await stubMapbox(context); // The contribution choropleth is a Mapbox map.
-    await checkPhoneViewport(page, consoleErrors, {path: '/dashboard'});
-    // A bounced anonymous/expired session would land on /signIn with a clean console — assert we stayed put.
-    expect(page.url()).toContain('/dashboard');
+    await checkPhoneViewport(page, context, consoleErrors, {path: '/dashboard', mapbox: true});
   });
 });


### PR DESCRIPTION
Closes #4883.

> **⚠️ Not yet QA'd by a human.** The suite itself ran green locally (34 passed / 2 GMaps-gated skips), but the two API-docs rendering fixes below haven't been visually reviewed on desktop or device yet.

## What this does

Phase 0 (guardrails) of the responsive-first direction in #4875: a new `test/e2e/phone-viewport.spec.js` loads each already-responsive page at an iPhone-class **390×844 viewport with a mobile UA** and asserts no console errors and **no horizontal overflow** — 12 checks covering `/mobileLanding`, `/signIn`, `/signUp`, `/about`, `/leaderboard`, `/routes`, `/stories`, `/cities`, `/api`, `/v3/api-docs/rawLabels`, and `/dashboard` (registered).

Design notes:

- **Overflow is measured from layout, not scrollbars** (`horizontalOverflowReport` in `fixtures.js`): `body {overflow-x: clip}` hides an overflowing page's scrollbar, and a fixed element sized off the overflowed containing block (the #4857 footer bug) never widens `scrollWidth`. The check walks bounding boxes, exempts content inside a sanctioned `overflow-x: auto|scroll` container, and names the offending elements in the failure message. Page-level `scrollWidth` is asserted too, as the cheap second signal.
- **Lives apart from `explore-validate.spec.js`** deliberately: that file skips wholesale without a real Google Maps key (absent on fork PRs); nothing here needs one.
- Pages that UA-redirect mobile visitors (`/gallery`, `/labelMap`, landing, …) are deliberately absent — on this UA they'd only re-test `/mobileLanding`. **Each #4875 conversion PR adds its page to the table**, which is the regression lock the issue asks for.

## It caught two real bugs immediately (first commit)

On the pages the issue listed as "already responsive":

1. `/api`: the label-types table is generated without the API docs' own `.api-table-wrapper` horizontal scroller — a 491px-wide table on a 390px screen. It now renders inside the shared scroller.
2. `/api`, `/v3/api-docs/rawLabels`: `:not(pre) > code { white-space: nowrap }` makes a long endpoint URL unwrappable, pushing the page past the screen edge. Inline code now wraps below 600px; wider viewports keep the one-line look.

## Verification done

Full Playwright suite against a live QA app: **34 passed, 0 failed**, 2 skipped (the GMaps-gated Explore/Validate specs). ESLint + Stylelint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Fable 5, claude-fable-5