### PR TITLE
Anchor the folded-night spec seeds to a fixed hour

### DIFF
--- a/test/service/ImageryFreshnessReportServiceSpec.scala
+++ b/test/service/ImageryFreshnessReportServiceSpec.scala
@@ -103,7 +103,9 @@ class ImageryFreshnessReportServiceSpec extends PlaySpec with BeforeAndAfterAll 
 
     "fold a night's poll and sync runs into one row of the series" in {
       cleanUp()
-      val night = OffsetDateTime.now.minusDays(2)
+      // Anchored to the small hours rather than to `now`: the two runs have to land on one calendar day to be one
+      // night, and `now` alone puts the sync on the next date whenever the suite happens to run in the last hour.
+      val night = OffsetDateTime.now.minusDays(2).withHour(2).withMinute(0).withSecond(0).withNano(0)
       seed(pollJob, night, Map("streets_selected" -> 500, "streets_polled" -> 480, "streets_skipped" -> 20))
       seed(syncJob, night.plusHours(1), Map("audits_flagged" -> 7, "audits_unflagged" -> 2))
 


### PR DESCRIPTION
Resolves #4969.

`"fold a night's poll and sync runs into one row of the series"` seeded its two runs an hour apart from `OffsetDateTime.now`, so between 23:00 and midnight local time they landed on different calendar days and `days.size mustBe 1` failed. The seeds are now anchored to 02:00 on the target day, matching the pattern the "hand-run job" test already uses.

I checked the rest of the suite for the same `now`-relative pattern: the other multi-seed cases are safe. `"serve a repeat read of the same window from cache"` and `"key the cache on the clamped window"` compare a cached report against itself, so a midnight straddle can't change the assertion, and every remaining case seeds a single run or leaves a wide margin against the window edge.

Verified with `sbt "testOnly service.ImageryFreshnessReportServiceSpec"` — 14/14 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)