### PR TITLE
Have make docker-stop remove the containers' anonymous volumes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,9 +85,10 @@ docker-up:
 docker-up-db:
 	@docker compose up -d db
 
+# `rm -v` drops the removed containers' anonymous volumes only.
 docker-stop:
 	@docker compose stop
-	@docker compose rm -f
+	@docker compose rm -fv
 
 docker-run:
 	@docker compose run --rm --service-ports --name $(web-container) web /bin/bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
     volumes:
       - "./db/scripts/init.sh:/docker-entrypoint-initdb.d/init.sh"
       - "./db:/opt"
-      # Named, so the data survives `make docker-stop`, which runs `docker compose rm -f`, rather than being orphaned.
+      # Named, so the data survives `make docker-stop`, which runs `docker compose rm -fv`, rather than being deleted.
       - "pgdata:/var/lib/postgresql/data"
     ports:
       - "5432:5432"


### PR DESCRIPTION
resolves #4938

`make docker-stop` ran `docker compose rm -f`, which removes the containers but leaves their **anonymous** volumes on disk with nothing referencing them — so `web`'s `- "/home/node_modules"` was orphaned on every stop/start cycle, and nothing ever collected them. This adds `-v`.

`rm -v` removes only anonymous volumes attached to the containers being removed; named volumes need `down -v`. So post-#4920 this is safe by construction: `pgdata` is named and survives, and `node_modules` is *supposed* to be discarded — it re-seeds from the image layer (`Dockerfile:38` runs `npm install`) the next time the container is created.

## The gate is now clear

#4938 held this change until both dev machines had moved their database off an anonymous volume, since `rm -fv` would otherwise delete a pre-#4920 `db` container's data rather than orphaning it. Both are migrated: @jonfroehlich's on 2026-08-18, @misaugstad's verified today —

```
$ docker inspect projectsidewalk-db --format '{{range .Mounts}}{{.Name}}{{end}}'
sidewalk_pgdata
```

## Testing

- `make -n docker-stop` prints `docker compose stop` / `docker compose rm -fv`.
- Removed the 6 already-orphaned `node_modules` volumes this bug had accumulated locally (~650 MB); the named `sidewalk_pgdata` and the live containers were untouched.

Also updates the `docker-compose.yml` comment next to `pgdata`, which named the old `rm -f`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
