### PR TITLE
Clean up the cross-city stats table on the user dashboard

### DIFF
--- a/app/controllers/UserProfileController.scala
+++ b/app/controllers/UserProfileController.scala
@@ -339,7 +339,6 @@ class UserProfileController @Inject() (
                   "city_id"         -> city.cityId,
                   "city_name"       -> city.cityName,
                   "city_url"        -> city.cityUrl,
-                  "linkable"        -> city.linkable,
                   "is_current_city" -> city.isCurrentCity,
                   "labels"          -> city.labels,
                   "validations"     -> city.validations,

--- a/app/service/UserService.scala
+++ b/app/service/UserService.scala
@@ -105,9 +105,8 @@ case class GlobalLeaderboardEntry(
  *
  * @param cityId        Configured city id.
  * @param cityName      Short display name in the viewer's language.
- * @param cityUrl       That deployment's base URL; empty when the city isn't publicly launched.
- * @param linkable      Whether to offer a click-through. False for a city that isn't publicly launched — the mapper's
- *                      own numbers there are still theirs to see, but we don't publish an unlaunched URL.
+ * @param cityUrl       That deployment's base URL. Given even for a city that isn't publicly launched: this breakdown
+ *                      only lists cities the mapper has already contributed to (#4979).
  * @param isCurrentCity True for the deployment being viewed, so the UI can mark it.
  * @param labels        Labels placed here.
  * @param validations   Validations given here.
@@ -121,7 +120,6 @@ case class CityUserStat(
     cityId: String,
     cityName: String,
     cityUrl: String,
-    linkable: Boolean,
     isCurrentCity: Boolean,
     labels: Int,
     validations: Int,
@@ -686,13 +684,11 @@ class UserServiceImpl @Inject() (
                 val hasActivity: Boolean = row.labels > 0 || row.validations > 0 || row.missions > 0 || meters > 0d
                 if (!hasActivity) None
                 else {
-                  val isPublic: Boolean = city.visibility == "public"
                   Some(
                     CityUserStat(
                       city.cityId,
                       city.cityNameShort,
-                      if (isPublic) city.URL else "",
-                      isPublic,
+                      city.URL,
                       isCurrent,
                       row.labels,
                       row.validations,

--- a/app/service/UserService.scala
+++ b/app/service/UserService.scala
@@ -105,8 +105,9 @@ case class GlobalLeaderboardEntry(
  *
  * @param cityId        Configured city id.
  * @param cityName      Short display name in the viewer's language.
- * @param cityUrl       That deployment's base URL. Given even for a city that isn't publicly launched: this breakdown
- *                      only lists cities the mapper has already contributed to (#4979).
+ * @param cityUrl       That deployment's base URL, given even for a city that isn't publicly launched: every row is a
+ *                      city this mapper has already worked in, so its URL is nothing they don't have. The global
+ *                      leaderboard withholds those same URLs because it shows one mapper's city to everyone (#4979).
  * @param isCurrentCity True for the deployment being viewed, so the UI can mark it.
  * @param labels        Labels placed here.
  * @param validations   Validations given here.

--- a/app/views/userDashboard/leaderboard.scala.html
+++ b/app/views/userDashboard/leaderboard.scala.html
@@ -240,7 +240,7 @@
     </details>
     @if(overall.nonEmpty) {
       <div class="coverage-table-wrap">
-        <table class="coverage-table">
+        <table class="coverage-table ud-lb-table">
           <thead>
             @lbHead(Messages("leaderboard.header.mapper"))
           </thead>
@@ -260,7 +260,7 @@
     <p>@Messages("leaderboard.thisweek.intro")</p>
     @if(weekly.nonEmpty) {
       <div class="coverage-table-wrap">
-        <table class="coverage-table">
+        <table class="coverage-table ud-lb-table">
           <thead>
             @lbHead(Messages("leaderboard.header.mapper"))
           </thead>
@@ -289,7 +289,7 @@
     <p>@Messages("leaderboard.teams.intro")</p>
     @if(teams.nonEmpty) {
       <div class="coverage-table-wrap">
-        <table class="coverage-table">
+        <table class="coverage-table ud-lb-table">
           <thead>
             @lbHead(Messages("leaderboard.header.team"))
           </thead>
@@ -322,7 +322,7 @@
       <p>@Messages("leaderboard.allcities.intro")</p>
       @if(entries.nonEmpty) {
         <div class="coverage-table-wrap">
-          <table class="coverage-table ud-lb-global">
+          <table class="coverage-table ud-lb-table ud-lb-global">
             <thead>
               @lbHead(Messages("leaderboard.header.mapper"), Some(Messages("leaderboard.header.topcity")))
             </thead>

--- a/public/css/admin-dashboard/admin-dashboard.css
+++ b/public/css/admin-dashboard/admin-dashboard.css
@@ -381,7 +381,9 @@
 }
 .coverage-table th:not(:first-child), .coverage-table td:not(:first-child) { text-align: right; }
 
-.coverage-table tbody td {
+/* Row headers (<th scope="row">) are body cells too, so they carry the same padding and row rule as the data cells. */
+.coverage-table tbody td,
+.coverage-table tbody th {
   padding: 6px 10px;
   border-bottom: 1px solid var(--color-neutral-100);
 }

--- a/public/css/user-dashboard/user-dashboard.css
+++ b/public/css/user-dashboard/user-dashboard.css
@@ -25,7 +25,9 @@
   font-size: var(--font-size-lg, 1.125rem);
   padding: 10px 16px;
 }
-.api-content .coverage-table tbody td { padding: 14px 16px; }
+
+.api-content .coverage-table tbody td,
+.api-content .coverage-table tbody th { padding: 14px 16px; }
 
 /* Leaderboard tables are capped at ~10 rows, so show them in full — no inner scroll (admin tables keep theirs), and
    overflow visible so the Accuracy header tooltip can escape the wrap. The responsive rule restores mobile scroll. */
@@ -35,9 +37,10 @@
 }
 
 /* The admin tables right-align every non-first column (numeric); on the leaderboard the name column — and the
-   all-time "Most active in" city column — are text, so left-align them. */
-.api-content .coverage-table td:nth-child(2),
-.api-content .coverage-table th:nth-child(2) { text-align: left; }
+   all-time "Most active in" city column — are text, so left-align them. Scoped to the ranked boards: other tables in
+   .api-content (the cities-you've-mapped one) carry a number in column 2 and want the right-aligned default. */
+.api-content .ud-lb-table td:nth-child(2),
+.api-content .ud-lb-table th:nth-child(2) { text-align: left; }
 
 /* The global board's "Top city" is a name, so it reads left-aligned like Mapper rather than right like the numbers. */
 .api-content .ud-lb-global td:nth-child(3),
@@ -1991,10 +1994,9 @@
 /* The table isn't sortable, so drop the admin header's click affordance. */
 .api-content .ud-cities-table thead th { cursor: default; }
 
-/* Counts and distances read down a column, so right-align them; the shell left-aligns column 2 for name columns. */
-.api-content .ud-cities-table td,
-.api-content .ud-cities-table th:not(:first-child) { text-align: right; }
-.api-content .ud-cities-table th:first-child { text-align: left; }
+/* The shell right-aligns every column past the first, which is what the counts and distances want. The city cell is a
+   row header, and a <th> defaults to centered, so it's the one that needs saying. */
+.api-content .ud-cities-table tbody th { text-align: left; }
 
 .ud-cities-current { background: var(--color-pine-100, #e4f4ee); }
 

--- a/public/js/user-dashboard/CrossCityStats.js
+++ b/public/js/user-dashboard/CrossCityStats.js
@@ -121,10 +121,9 @@ class CrossCityStats {
 
     const rows = cities.map((c) => {
       const name = CrossCityStats.#esc(c.city_name);
-      // A city that isn't publicly launched still shows the mapper's own numbers, but we don't publish its URL.
-      const nameCell = c.linkable && c.city_url
-        ? `<a href="${CrossCityStats.#esc(c.city_url)}/dashboard">${name}</a>`
-        : name;
+      // Cities that aren't publicly launched are linked here too: every row is a deployment this mapper has already
+      // worked in, so its URL is nothing they don't have (#4979).
+      const nameCell = c.city_url ? `<a href="${CrossCityStats.#esc(c.city_url)}/dashboard">${name}</a>` : name;
       const here = c.is_current_city
         ? `<span class="ud-cities-here">${CrossCityStats.#tEsc('dashboard:cities.you-are-here')}</span>`
         : '';

--- a/test/js/crossCityStats.test.js
+++ b/test/js/crossCityStats.test.js
@@ -68,7 +68,6 @@ const city = (overrides) => ({
   city_id: 'seattle',
   city_name: 'Seattle',
   city_url: 'https://sidewalk-sea.cs.washington.edu',
-  linkable: true,
   is_current_city: false,
   labels: 10,
   validations: 5,
@@ -149,6 +148,26 @@ describe('the intro line', () => {
 
     expect(text(section, 'ud-cities-intro')).toBe('Your work in Seattle so far. '
       + 'One account works in every Project Sidewalk city.');
+  });
+});
+
+describe('the city column', () => {
+  test('links every city the mapper has worked in, launched publicly or not', async () => {
+    // An unlaunched deployment reaches the payload with a URL like any other: the mapper has already been there, so
+    // withholding the link only costs them the trip (#4979).
+    const cities = [city(), city({ city_id: 'crowdstudy', city_name: 'Crowd Study', city_url: 'https://study.example' })];
+    const section = await render(payloadOf(cities));
+
+    const hrefs = [...section.querySelectorAll('#ud-cities-table-holder a')].map((a) => a.getAttribute('href'));
+    expect(hrefs).toEqual(['https://sidewalk-sea.cs.washington.edu/dashboard', 'https://study.example/dashboard']);
+  });
+
+  test('leaves a city with no URL as plain text rather than a dead link', async () => {
+    const section = await render(payloadOf([city({ city_url: '' })]));
+    const holder = section.querySelector('#ud-cities-table-holder');
+
+    expect(holder.querySelector('a')).toBeNull();
+    expect(holder.textContent).toContain('Seattle');
   });
 });
 

--- a/test/service/DashboardStatsInvariantSpec.scala
+++ b/test/service/DashboardStatsInvariantSpec.scala
@@ -454,8 +454,8 @@ class DashboardStatsInvariantSpec extends PlaySpec with GuiceOneAppPerSuite {
           city.missions must be >= 0
           city.distance must be >= 0.0
           city.cityName.trim must not be empty
-          // A deployment that isn't publicly launched still reports the mapper's numbers, but publishes no URL.
-          if (city.linkable) city.cityUrl.trim must not be empty else city.cityUrl mustBe ""
+          // Every row is a city the mapper has worked in, so every row is linkable.
+          city.cityUrl.trim must not be empty
         }
         stats.totalLabels mustBe stats.cities.map(_.labels).sum
         stats.totalValidation mustBe stats.cities.map(_.validations).sum


### PR DESCRIPTION
resolves #4979

Three fixes to the "Cities you've mapped" table on the user dashboard.

**Row underline stops short, city name has no left padding.** The city cell is a row header (`<th scope="row">`), but only `td` carried the shared `.coverage-table` cell padding and row border. Body-cell styling now covers `th` too — this table is the only row-header user today, so nothing else moves.

**Cities that aren't publicly launched are now linked.** Every row is a deployment the mapper has already contributed to, so its URL is nothing they don't already have. The `linkable` flag that gated the link had no other consumer, so it's gone from `CityUserStat` and the `/userapi/crossCityStats` payload, along with the `isPublic` check that blanked `city_url`.

**Labels column was left-aligned under a right-aligned header.** The leaderboard's "column 2 is a name, left-align it" rule was written against `.api-content .coverage-table`, so it also hit this table and outranked its own right-align. Scoped that rule to the ranked boards with a new `ud-lb-table` class, which lets the cities table fall back to the shell's right-aligned default — only the row header needs an explicit left.

QA'd locally on the dashboard and the leaderboard. `sbt compile` clean, scalafmt run, ESLint/Stylelint/HTMLHint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
