### PR TITLE
Load i18next exactly once per page

### DIFF
--- a/app/views/apps/explore.scala.html
+++ b/app/views/apps/explore.scala.html
@@ -863,8 +863,6 @@
   <script src='@assets.path("vendor/kinetic/kinetic-v4.4.3.min.js")'></script>
   <script src='@assets.path("vendor/d3/d3-3.5.6.js")'></script>
 
-  <script src='@assets.path("vendor/i18next/i18next-23.16.8.min.js")'></script>
-  <script src='@assets.path("vendor/i18next-http-backend/i18nextHttpBackend-3.0.4.min.js")'></script>
   <script src='@assets.path("vendor/turf/turf-7.3.4.min.js")'></script>
   <script src='@assets.path("vendor/async-lock/async-lock-1.4.1.min.js")'></script>
   <script src='@assets.path("vendor/betterknown/betterknown-1.2.0.js")'></script>

--- a/app/views/apps/gallery.scala.html
+++ b/app/views/apps/gallery.scala.html
@@ -25,8 +25,6 @@
   <script src='@assets.path("js/common/pano-viewer/build/pano-viewer.js")'></script>
   <script src='@assets.path("vendor/panzoom/panzoom-9.4.4.min.js")'></script>
   <script src='@assets.path("js/gallery/build/gallery.js")'></script>
-  <script src='@assets.path("vendor/i18next/i18next-23.16.8.min.js")'></script>
-  <script src='@assets.path("vendor/i18next-http-backend/i18nextHttpBackend-3.0.4.min.js")'></script>
   <div id="page-loading">
     <img id="loading-animation" src='@assets.path("videos/ProjectSidewalk_LoadingAnimation_WithArmMovement_Medium.webp")' alt='@Messages("loading")'>
   </div>

--- a/app/views/apps/labelMap.scala.html
+++ b/app/views/apps/labelMap.scala.html
@@ -31,8 +31,6 @@
   <link href='@assets.path("css/map-download-control.css")' rel="stylesheet">
   <link href='@assets.path("css/tag-pills.css")' rel="stylesheet">
 
-  <script src='@assets.path("vendor/i18next/i18next-23.16.8.min.js")'></script>
-  <script src='@assets.path("vendor/i18next-http-backend/i18nextHttpBackend-3.0.4.min.js")'></script>
   <script src='@assets.path("vendor/panzoom/panzoom-9.4.4.min.js")'></script>
   @* Label-detail modules (order matters: PopupPanoManager + LabelDetail precede LabelPopup; Toast precedes Badges). *@
   <script src='@assets.path("js/common/aiLabelIndicator.js")'></script>

--- a/app/views/apps/mobileValidate.scala.html
+++ b/app/views/apps/mobileValidate.scala.html
@@ -14,8 +14,6 @@
 @common.main(commonData, title, defaultI18nNamespace = "validate", i18Namespaces = Seq("validate", "common"), "/mobile") {
   @common.icons()
 
-  <script src='@assets.path("vendor/i18next/i18next-23.16.8.min.js")'></script>
-  <script src='@assets.path("vendor/i18next-http-backend/i18nextHttpBackend-3.0.4.min.js")'></script>
   @if(commonData.imagerySource == PanoSource.Infra3d) {
     <script src='@assets.path("vendor/proj4/proj4-2.19.10.js")'></script>
     <script src='@assets.path("vendor/infra3d/infra3dapi-1.8.0.js")'></script>

--- a/app/views/apps/routeBuilder.scala.html
+++ b/app/views/apps/routeBuilder.scala.html
@@ -11,8 +11,6 @@
 @common.main(commonData, Messages("seo.title.route.builder"), defaultI18nNamespace = "routebuilder", i18Namespaces = Seq("routebuilder", "common"), url = "/routeBuilder") {
   @common.navbar(commonData, user)
 
-  <script src='@assets.path("vendor/i18next/i18next-23.16.8.min.js")'></script>
-  <script src='@assets.path("vendor/i18next-http-backend/i18nextHttpBackend-3.0.4.min.js")'></script>
   <script src='@assets.path("vendor/mapbox-gl/mapbox-gl-3.21.0.js")'></script>
   <script src='@assets.path("vendor/mapbox-gl/mapbox-gl-language-1.0.1.js")'></script>
   <link href='@assets.path("vendor/mapbox-gl/mapbox-gl-3.21.0.css")' rel="stylesheet">

--- a/app/views/apps/validate.scala.html
+++ b/app/views/apps/validate.scala.html
@@ -16,8 +16,6 @@
   @common.navbar(commonData, Some(user))
   @common.icons()
 
-  <script src='@assets.path("vendor/i18next/i18next-23.16.8.min.js")'></script>
-  <script src='@assets.path("vendor/i18next-http-backend/i18nextHttpBackend-3.0.4.min.js")'></script>
   <script src='@assets.path("vendor/turf/turf-7.3.4.min.js")'></script>
   <script src='@assets.path("vendor/selectize/selectize-0.15.2.min.js")'></script>
   <link rel="stylesheet" href='@assets.path("vendor/selectize/selectize-0.15.2.min.css")'>


### PR DESCRIPTION
resolves #4646

`common/main.scala.html` loads `vendor/i18next` + `vendor/i18next-http-backend` (deferred, since #4237) on every page. Six views included the same two vendor scripts a second time, blocking, in the body. This removes those duplicates so the libraries load exactly once.

Views changed: `apps/explore`, `apps/validate`, `apps/mobileValidate`, `apps/gallery`, `apps/labelMap`, `apps/routeBuilder`.

The issue's list also named `index`, `userProfile`, `admin/index`, `admin/label`, and `admin/task` — those already had their duplicates removed (`index` carries a comment citing #4486), so only these six were left.

### Verifying nothing touches `i18next` at parse time

With the duplicates gone, `i18next` only exists after the deferred head copy runs (just before `DOMContentLoaded`), so a parse-time consumer would throw a `ReferenceError`. Checked and clear:

- **No JS file uses `i18next` at module top level.** Every reference across `public/js/` sits inside a function or arrow body. Notably `validate/src/util/ConstantsValidate.js` — by far the largest cluster of `i18next.t()` calls — is entirely inside `defineValidateConstants()`.
- **Every one of the six views' inline scripts is wrapped** in `window.appManager.ready(...)` or `$(document).ready(...)`, both of which fire at/after `DOMContentLoaded`. Explore's one unwrapped inline script is the canvas `getContext` patch, which doesn't touch i18next.
- **`labelMap`'s parse-time statements are clean:** `new MapLoadingOverlay()`'s constructor has no `i18next` use (it's in `show()`, called from `onMapReady` inside `appManager.ready`), and `updateTimestamps()` doesn't use it either.
- **`deploymentSitesDashboard.scala.html`**, the other file flagged in the issue, has no duplicate include already, and its `i18next` uses are nested two levels inside a callback.

No behavior change — pure network/parse savings.

### Testing
- `make htmlhint` — clean
- `sbt compile` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)