### PR TITLE
Rename panoCoordToPov to horizonRelativeCoordToPov — it is not povToPanoCoord's inverse

### DIFF
--- a/public/js/common/pano-viewer/src/panoUtilities.js
+++ b/public/js/common/pano-viewer/src/panoUtilities.js
@@ -115,18 +115,26 @@ util.pano.fovToZoom = (fov) => {
 };
 
 /**
- * Returns the panorama's pov if this label were centered using pano XY coordinates.
+ * Decodes the Explore tutorial's angular annotation coordinates into the POV at which the annotation is centered.
  *
- * @param {number} panoX The x-coordinate within the panorama image
- * @param {number} panoY The y-coordinate within the panorama image
+ * Despite the parallel shape, this is NOT the inverse of povToPanoCoord, and must never be fed a real image
+ * coordinate such as a stored label's pano_x/pano_y (the true inverse of povToPanoCoord is the Scala
+ * PanoDataService.calculatePovFromPanoXY). The inputs here are angles merely *expressed in* pano-pixel units:
+ * x runs east from true north (x = 0 is heading 0°; the pano's cameraHeading plays no part), and y is measured
+ * from the horizon, positive up (y = 0 is pitch 0°) — whereas povToPanoCoord's output puts the horizon at row
+ * panoHeight / 2 and column 0 at cameraHeading − 180°. Its only callers are the tutorial's annotation drawing
+ * paths, whose coordinates in OnboardingStates.js are authored in this convention (#4957).
+ *
+ * @param {number} xFromNorth Heading in pano-pixel units east of true north; panoWidth spans 360°.
+ * @param {number} yAboveHorizon Pitch in pano-pixel units above the horizon; panoHeight / 2 spans 90°.
  * @param {number} panoWidth The width of the panorama image
  * @param {number} panoHeight The height of the panorama image
  * @returns {{heading: number, pitch: number}}
  */
-util.pano.panoCoordToPov = (panoX, panoY, panoWidth, panoHeight) => {
+util.pano.horizonRelativeCoordToPov = (xFromNorth, yAboveHorizon, panoWidth, panoHeight) => {
   return {
-    heading: (panoX / panoWidth) * 360 % 360,
-    pitch: (panoY / (panoHeight / 2) * 90),
+    heading: (xFromNorth / panoWidth) * 360 % 360,
+    pitch: (yAboveHorizon / (panoHeight / 2) * 90),
   };
 };
 

--- a/public/js/common/utilitiesSidewalk.js
+++ b/public/js/common/utilitiesSidewalk.js
@@ -459,7 +459,8 @@ function UtilitiesMisc(JSON) {
    * representation puts an annotation — or a callout anchored to one — a full pano-width away from where the user is
    * looking. Only a point within a quarter-width of the seam is ambiguous; everything else is returned unchanged.
    *
-   * @param {number} panoX - Pano image x-coordinate, as stored on tutorial state annotations.
+   * @param {number} panoX - Tutorial annotation x-coordinate; x = 0 faces true north, so it compares directly
+   *                          against the heading (see util.pano.horizonRelativeCoordToPov).
    * @param {number} heading - The camera's current heading, in degrees.
    * @param {number} panoWidth - Full width of the pano image in pixels.
    * @returns {number} The equivalent x-coordinate nearest the current view; may be negative or exceed panoWidth.

--- a/public/js/explore/src/onboarding/Onboarding.js
+++ b/public/js/explore/src/onboarding/Onboarding.js
@@ -382,9 +382,9 @@ class Onboarding {
       imY = annotation.y;
       centeredPov = null;
 
-      // Setting the original POV and mapping an image coordinate to a canvas coordinate.
+      // Decode the annotation's angular coordinate (see OnboardingStates.js) and map it to a canvas coordinate.
       imX = util.misc.unwrapPanoX(imX, currentPov.heading, svl.TUTORIAL_PANO_WIDTH);
-      centeredPov = util.pano.panoCoordToPov(imX, imY, svl.TUTORIAL_PANO_WIDTH, svl.TUTORIAL_PANO_HEIGHT);
+      centeredPov = util.pano.horizonRelativeCoordToPov(imX, imY, svl.TUTORIAL_PANO_WIDTH, svl.TUTORIAL_PANO_HEIGHT);
       const canvasCoord = util.pano.centeredPovToCanvasCoord(
         centeredPov, currentPov, util.EXPLORE_CANVAS_WIDTH, util.EXPLORE_CANVAS_HEIGHT, svl.LABEL_ICON_RADIUS,
       ) || { x: null, y: null };
@@ -650,16 +650,18 @@ class Onboarding {
   }
 
   /**
-   * Pins the message box just above a pano-image coordinate (a step's annotation arrow), so the instruction and
+   * Pins the message box just above an annotation coordinate (a step's annotation arrow), so the instruction and
    * the arrow read as one unit. Computed once per message: the steps that use this clamp panning to a few
    * degrees, so the arrow cannot drift far from the box.
-   * @param {{x: number, y: number}} panoCoord - Pano image coordinates, as used by state annotations.
+   * @param {{x: number, y: number}} panoCoord - Angular annotation coordinates (see OnboardingStates.js).
    */
   #positionMessageAtPanoCoord(panoCoord) {
     const svl = this.#svl;
     const currentPov = svl.panoViewer.getPov();
     const imX = util.misc.unwrapPanoX(panoCoord.x, currentPov.heading, svl.TUTORIAL_PANO_WIDTH);
-    const centeredPov = util.pano.panoCoordToPov(imX, panoCoord.y, svl.TUTORIAL_PANO_WIDTH, svl.TUTORIAL_PANO_HEIGHT);
+    const centeredPov = util.pano.horizonRelativeCoordToPov(
+      imX, panoCoord.y, svl.TUTORIAL_PANO_WIDTH, svl.TUTORIAL_PANO_HEIGHT,
+    );
     const canvasCoord = util.pano.centeredPovToCanvasCoord(
       centeredPov, currentPov, util.EXPLORE_CANVAS_WIDTH, util.EXPLORE_CANVAS_HEIGHT, svl.LABEL_ICON_RADIUS,
     );

--- a/public/js/explore/src/onboarding/OnboardingStates.js
+++ b/public/js/explore/src/onboarding/OnboardingStates.js
@@ -47,6 +47,10 @@ function OnboardingStates(contextMenu, compass, panoManager) {
   // Inline keycap for teaching keyboard shortcuts (e.g. press C for Curb Ramp).
   const kbdHtml = (key) => `<kbd class="onboarding-kbd">${key}</kbd>`;
 
+  // Annotation and panoAnchor x/y below are angles expressed in tutorial-pano pixel units, not rows/columns of the
+  // tutorial image: x runs east from true north (TUTORIAL_PANO_WIDTH spans 360°) and y from the horizon, positive
+  // up (TUTORIAL_PANO_HEIGHT / 2 spans 90°) — hence the small negative y values, slightly below eye level. They are
+  // decoded by util.pano.horizonRelativeCoordToPov, which is NOT the inverse of povToPanoCoord (#4957).
   this.states = [
     {
       // The welcome/skip UI now lives in the pre-tutorial intro (TutorialIntro), so this first state only positions

--- a/test/js/panoProjection.test.js
+++ b/test/js/panoProjection.test.js
@@ -157,6 +157,34 @@ describe('util.pano projection', () => {
         });
     });
 
+    // horizonRelativeCoordToPov is deliberately NOT the inverse of povToPanoCoord (#4957): it decodes the Explore
+    // tutorial's angular annotation coordinates — x in pano pixels east of true north, y in pano pixels above the
+    // horizon — not stored label_point rows. These pin that convention, because the tutorial's arrows are authored
+    // against it: a well-meaning "fix" toward inverse symmetry would silently move every one of them.
+    describe('horizonRelativeCoordToPov (tutorial annotation convention)', () => {
+        // svl.TUTORIAL_PANO_WIDTH/HEIGHT — the dimensions every tutorial annotation is authored against.
+        const PANO_WIDTH = 13312;
+        const PANO_HEIGHT = 6656;
+
+        it('decodes the first curb-ramp arrow of OnboardingStates.js to just below eye level', () => {
+            const pov = pano.horizonRelativeCoordToPov(9730, -350, PANO_WIDTH, PANO_HEIGHT);
+
+            expect(pov.heading).toBeCloseTo(263.131, 3); // 9730 / 13312 of a full turn from north.
+            expect(pov.pitch).toBeCloseTo(-9.4651, 3); // -350 px of 3328 px per 90°, NOT a row index.
+        });
+
+        it('puts the horizon at y = 0 and north at x = 0, where povToPanoCoord puts neither', () => {
+            expect(pano.horizonRelativeCoordToPov(0, 0, PANO_WIDTH, PANO_HEIGHT)).toEqual({heading: 0, pitch: 0});
+
+            // The same POV as a real image coordinate: horizon at row panoHeight / 2, column set by the camera
+            // heading — so composing the two functions does not round-trip. With the camera at 100°, column 0
+            // faces heading -80°, putting north 80° (of 360°) into the image.
+            const coord = pano.povToPanoCoord({heading: 0, pitch: 0}, 100, PANO_WIDTH, PANO_HEIGHT);
+            expect(coord.y).toBeCloseTo(PANO_HEIGHT / 2, 6);
+            expect(coord.x).toBeCloseTo(PANO_WIDTH * 80 / 360, 6);
+        });
+    });
+
     // The shared function is only half the invariant. The 5-px fudge #4851 chased never lived in the projection
     // itself — it lived in each consumer's copy, and today's equivalent is a nudge on the arguments at a call site.
     // So pin the consumer too: a label stored at the canvas center must read back as the POV it was authored at.


### PR DESCRIPTION
Fixes #4957.

`util.pano.panoCoordToPov` shared `povToPanoCoord`'s vocabulary (`panoX`/`panoY`) while decoding a different convention, so it read as the inverse it isn't — anyone feeding it a real `pano_x`/`pano_y` (e.g. from a `label_point` row) would get a silently wrong POV. **No math change** — the tutorial's annotations are authored against the current behavior, verified visually by @jonfroehlich on this branch.

While implementing, verification showed the mismatch is broader than the issue described: the tutorial pano's fabricated metadata has `centerHeading: 50.3866`, yet the function maps `x = 0 → heading 0°` — so the annotation `x` values aren't real image columns either. Both coordinates are angles expressed in pano-pixel units: `x` east of true north, `y` above the horizon. On the issue's open question (take `cameraHeading` for symmetry?): declined — it would be a behavior change requiring re-authoring every annotation for no benefit; the asymmetry is documented instead.

## Changes

- **`panoUtilities.js`** — renamed to `util.pano.horizonRelativeCoordToPov` with params `xFromNorth`/`yAboveHorizon`; docstring states the convention and names `PanoDataService.calculatePovFromPanoXY` as `povToPanoCoord`'s true inverse.
- **`Onboarding.js`** — both call sites updated, plus the `#positionMessageAtPanoCoord` doc.
- **`OnboardingStates.js`** — note above `this.states` explaining the angular convention (and why annotation `y` values are small negatives).
- **`utilitiesSidewalk.js`** — `unwrapPanoX` `@param` corrected: its seam logic also assumes the x-from-north convention.
- **`panoProjection.test.js`** — pins the convention with the real first-arrow fixture (`9730, -350` → heading ≈ 263.13°, pitch ≈ −9.47°) and asserts the two functions deliberately don't round-trip.

## Testing

- Projection + onboarding suites pass (35/35); ESLint clean on all touched files. (4 unrelated JS suites fail identically on clean `develop`.)
- Visual QA on localhost: tutorial arrows and anchored message boxes land correctly through the tutorial steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Fable 5, claude-fable-5, effort: high