### PR TITLE
Replace the comment-discipline prompt reminder with a Stop hook

### DIFF
--- a/.claude/hooks/comment-trim-check.sh
+++ b/.claude/hooks/comment-trim-check.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+#
+# Stop hook: requests a comment-trim pass on the comment lines the working diff adds.
+#
+# Fires on growth in the count rather than on presence, which is what makes it converge:
+# a trim lowers the count, the per-session ratchet follows it down, and the next stop is
+# silent until later edits push it back up.
+#
+# Dry run (no state written, no JSON emitted):
+#   .claude/hooks/comment-trim-check.sh --dry-run
+#   CTC_DIFF_BASE=develop .claude/hooks/comment-trim-check.sh --dry-run
+
+set -uo pipefail
+
+DRY_RUN=0
+[ "${1:-}" = "--dry-run" ] && DRY_RUN=1
+
+if [ "$DRY_RUN" -eq 0 ]; then
+  input=$(cat)
+  # A block already sent us back around; a second one would loop.
+  [ "$(printf '%s' "$input" | jq -r '.stop_hook_active // false')" = "true" ] && exit 0
+  session=$(printf '%s' "$input" | jq -r '.session_id // "nosession"')
+  cwd=$(printf '%s' "$input" | jq -r '.cwd // "."')
+  cd "$cwd" 2>/dev/null || exit 0
+fi
+
+git rev-parse --git-dir >/dev/null 2>&1 || exit 0
+
+BASE="${CTC_DIFF_BASE:-HEAD}"
+
+# Gated per file type so a CSS hex color, a JS decrement, and a SQL dash don't all read
+# as comments.
+read -r -d '' AWK_LIB <<'AWKEOF'
+function skip_path(f) {
+  return (f ~ /(^|\/)(build|vendor|node_modules|target|dist)\// || f ~ /\.min\./)
+}
+function is_comment(f, s,   t) {
+  t = s
+  sub(/^[ \t]+/, "", t)
+  if (t == "") return 0
+  # Doc-block scaffolding is structure, not prose: counting it inflates the ratchet and
+  # buries the real prose in the listing.
+  if (t ~ /^(\/\*\*?|\*\/|\*|@\*|\*@)[ \t]*$/) return 0
+  if (t ~ /^\*[ \t]*@(param|return|returns|throws|tparam)\b/) return 0
+  if (f ~ /\.html$/)                    return (t ~ /^(<!--|@\*|\*)/)
+  if (f ~ /\.(scala|js|mjs|java)$/)     return (t ~ /^(\/\/|\/\*|\*)/)
+  if (f ~ /\.css$/)                     return (t ~ /^(\/\*|\*)/)
+  if (f ~ /\.sql$/)                     return (t ~ /^--/)
+  if (f ~ /\.(py|sh|conf|yml|yaml)$/)   return (t ~ /^#/)
+  return 0
+}
+AWKEOF
+
+tracked=$(git diff "$BASE" --unified=0 --no-color -- . 2>/dev/null | awk "
+$AWK_LIB
+/^\+\+\+ b\// { file = substr(\$0, 7); next }
+/^\+\+\+ \/dev\/null/ { file = \"\"; next }
+/^@@ / {
+  if (match(\$0, /\+[0-9]+/)) ln = substr(\$0, RSTART + 1, RLENGTH - 1)
+  next
+}
+/^\+/ {
+  if (file == \"\" || skip_path(file)) next
+  line = substr(\$0, 2)
+  if (is_comment(file, line)) printf \"%s:%d: %s\n\", file, ln, line
+  ln++
+}
+")
+
+# Untracked files never appear in a diff, so every comment line in them is new.
+untracked=""
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  [ -f "$f" ] || continue
+  hits=$(awk "
+$AWK_LIB
+{ if (!skip_path(FILENAME) && is_comment(FILENAME, \$0)) printf \"%s:%d: %s\n\", FILENAME, NR, \$0 }
+" "$f" 2>/dev/null)
+  [ -n "$hits" ] && untracked+="$hits"$'\n'
+done < <(git ls-files --others --exclude-standard 2>/dev/null)
+
+flagged=$(printf '%s\n%s' "$tracked" "$untracked" | grep -c . >/dev/null 2>&1 && printf '%s\n%s' "$tracked" "$untracked" | grep . || true)
+count=$(printf '%s' "$flagged" | grep -c . || true)
+count=${count:-0}
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  printf '%s\n' "$flagged"
+  printf -- '--- added comment lines: %s (base: %s)\n' "$count" "$BASE"
+  exit 0
+fi
+
+state_dir="${HOME}/.claude/comment-trim-state"
+mkdir -p "$state_dir" 2>/dev/null
+state_file="${state_dir}/${session}.count"
+last=0
+[ -f "$state_file" ] && last=$(cat "$state_file" 2>/dev/null || printf '0')
+case "$last" in ''|*[!0-9]*) last=0 ;; esac
+
+printf '%s' "$count" > "$state_file"
+
+[ "$count" -le "$last" ] && exit 0
+
+listing=$(printf '%s' "$flagged" | head -60)
+extra=$((count - 60))
+[ "$extra" -gt 0 ] && listing="${listing}
+... and ${extra} more"
+
+reason="Before this turn ends, do the comment-trim pass on the ${count} comment lines this working diff adds.
+
+Re-read each one below and apply CLAUDE.md's standard - comments say WHY, not WHAT:
+- Delete any that restate what the code already says.
+- Delete any that narrate the change you just made (git history covers that).
+- Delete doc headers on trivial helpers; keep ScalaDoc/JSDoc on non-trivial ones, but cut the prose to the contract.
+- Collapse multi-line comments that fit on one line. One tight line beats three.
+- Keep the ones that carry a reason, a constraint, an invariant, or a non-obvious tradeoff.
+
+Edit the files to apply the trims. If a comment genuinely earns its place, leave it - this is a review, not a
+mandate to cut everything. We don't need an update on what was cut.
+
+Comment lines added by this diff:
+${listing}"
+
+jq -n --arg r "$reason" \
+  '{decision:"block", reason:$r, systemMessage:"comment-trim hook: requesting a trim pass on newly added comments"}'

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -60,13 +60,13 @@
         ]
       }
     ],
-    "UserPromptSubmit": [
+    "Stop": [
       {
         "hooks": [
           {
             "type": "command",
-            "command": "jq -n '{hookSpecificOutput:{hookEventName:\"UserPromptSubmit\", additionalContext:\"Comment discipline (CLAUDE.md, applies to every edit): write WHY, not WHAT. Before calling an edit done, re-read every comment you added and cut it back - delete ones that restate the code, ones that narrate the change you just made, and doc headers on trivial helpers. One tight line beats three. Keep ScalaDoc/JSDoc on non-trivial functions, but keep the prose minimal.\"}}'",
-            "statusMessage": "Adding comment-conciseness reminder"
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/comment-trim-check.sh\"",
+            "statusMessage": "Checking whether added comments need a trim pass"
           }
         ]
       }


### PR DESCRIPTION
Replaces the `UserPromptSubmit` comment-discipline reminder with a `Stop` hook that asks for the trim pass directly.

### Why

The old hook injected a comment-discipline reminder into every prompt. It fired at turn start, before any code existed, and competed with the rest of the prompt — by the time comments were actually being written it was far back in context. It also fired on non-code prompts, so it read as wallpaper. In practice it still took an explicit follow-up ask to get a verbosity pass, which is exactly what it was meant to prevent.

The `Stop` hook automates that follow-up. On stop it counts the prose comment lines the working diff adds and blocks with a targeted trim instruction plus a `file:line` listing, so the review happens at the one point where the whole change is visible at once.

### How it converges

The gate is a per-session ratchet on the count, firing on **growth** rather than presence:

- Edits add 20 comment lines, ratchet at 0 → fires, ratchet moves to 20.
- Trim to 12 → 12 ≤ 20, silent pass, ratchet follows down to 12.
- A later batch adds 5 → 17 > 12 → fires again.

So the trim pass itself never re-triggers the hook. `stop_hook_active` guards the immediate re-entry, and the ratchet handles the rest. A rewrite that holds the count flat won't re-fire, which is deliberate — the pass already happened.

### Detection

Comment matching is gated per file type (`.scala`/`.js`/`.css`/`.sql`/`.py`/`.html`/…) so a CSS hex color, a JS decrement, and a SQL dash don't all read as comments. Build output, `vendor/`, `node_modules/`, `target/`, `dist/`, and minified files are skipped.

Doc-block scaffolding — bare `*` separators, `/**`, `*/`, and `@param`/`@return`/`@throws` tags — is excluded. It's structure rather than prose, and counting it both inflates the ratchet and buries the real prose in the listing.

Untracked files never appear in a diff, so every comment line in them counts as new.

### Flag rates

Measured against recent commits (prose comment lines only):

| commit | flagged |
|---|---|
| `7d483389a` (merge) | 0 |
| `b29cd3882` (i18next — deletions only) | 0 |
| `1fad6308a` (comment trimming) | 1 |
| `408f509d2` (cross-city cleanup) | 10 |
| `83b1ec48a` (admin label/task pages) | 54 |

It tracks actual comment authorship rather than firing every turn.

### Testing

- First fire blocks with the listing; a second fire on the same session exits silently.
- `stop_hook_active: true` exits 0 without blocking.
- `jq` parses `settings.json`; `bash -n` passes on the script.
- Dry-run mode for local inspection: `.claude/hooks/comment-trim-check.sh --dry-run`, with `CTC_DIFF_BASE` to point at any ref or range.

The two existing `PostToolUse` comment hooks (changelog phrasing, code-restating comments) are unchanged — this covers the verbosity case they can't regex for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
