### PR TITLE
Have the comment-trim pass restate the summary last

### DIFF
--- a/.claude/hooks/comment-trim-check.sh
+++ b/.claude/hooks/comment-trim-check.sh
@@ -115,7 +115,12 @@ Re-read each one below and apply CLAUDE.md's standard - comments say WHY, not WH
 - Keep the ones that carry a reason, a constraint, an invariant, or a non-obvious tradeoff.
 
 Edit the files to apply the trims. If a comment genuinely earns its place, leave it - this is a review, not a
-mandate to cut everything. We don't need an update on what was cut.
+mandate to cut everything.
+
+Then close the turn by repeating, in full, the summary of the actual work that you had written before this pass.
+This pass is housekeeping and lands below that summary, so without the repeat the user has to scroll back past it
+to read the part they care about. Do not describe what you trimmed, and do not add a line saying you are repeating
+yourself - just restate the summary as your final message.
 
 Comment lines added by this diff:
 ${listing}"


### PR DESCRIPTION
Follow-up to #4996. The trim pass lands below whatever summary the turn had already written, so the part worth reading got buried. The hook now asks for the summary to be repeated in full as the final message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)