### PR TITLE
Reconcile pano_imagery_change against pano_data so the imagery log self-heals (#5007)

### DIFF
--- a/app/models/pano/PanoDataTable.scala
+++ b/app/models/pano/PanoDataTable.scala
@@ -209,7 +209,8 @@ class PanoDataTable @Inject() (protected val dbConfigProvider: DatabaseConfigPro
    *
    * That snapshot is also the limit of what `edge` can see: a flip committed by another connection mid-statement is
    * invisible to it, so a sweep expiring a pano while a labeler's `upsert` is in flight can leave a loss with no
-   * matching recovery. The window is one autocommit statement, which is rare enough to accept. Do not reach for
+   * matching recovery. The window is one autocommit statement, which is rare enough to accept — and the nightly
+   * reconciliation pass heals what slips through (`PanoImageryChangeTable.reconcile`, #5007). Do not reach for
    * `FOR UPDATE` on `edge` to close it — that collides with the same statement's own write of the row, so `edge`
    * comes back empty and the ordinary uncontended case silently stops logging (verified on PG 16).
    *

--- a/app/models/pano/PanoImageryChangeTable.scala
+++ b/app/models/pano/PanoImageryChangeTable.scala
@@ -97,34 +97,63 @@ class PanoImageryChangeTable @Inject() (protected val dbConfigProvider: Database
    * that went away and one that came back, not a spike. Weeks with nothing to report are absent — the client
    * zero-fills, matching the other admin time series.
    *
+   * Healed rows are left out: a `reconciliation` row's `changed_at` is when the pass noticed, so charting one would
+   * put a crossing in a week it did not happen in — the rewriting of history this table exists to stop.
+   * `healedSince` counts what the window is therefore missing, and the page owns that gap like the undated one.
+   *
    * @param since Only transitions at or after this instant.
    */
   def transitionsByWeek(since: OffsetDateTime): DBIO[Seq[PanoImageryWeek]] = {
+    val healed = PanoImageryChangeSource.Reconciliation.toString
     sql"""SELECT date_trunc('week', changed_at)::date,
                  COUNT(DISTINCT pano_id) FILTER (WHERE expired),
                  COUNT(DISTINCT pano_id) FILTER (WHERE NOT expired)
           FROM pano_imagery_change
           WHERE changed_at >= $since
+              AND source <> $healed::pano_imagery_change_source
           GROUP BY date_trunc('week', changed_at)::date
           ORDER BY date_trunc('week', changed_at)::date""".as[PanoImageryWeek]
   }
 
   /**
-   * Inserts the missing event for every pano whose newest log row disagrees with its current `pano_data.expired`.
+   * Panos the reconciliation pass healed inside the window: real crossings `transitionsByWeek` cannot place.
+   *
+   * Counts distinct panos, the unit that series reports in, so the page can set the two side by side.
+   *
+   * @param since Only healed rows at or after this instant.
+   */
+  def healedSince(since: OffsetDateTime): DBIO[Int] = {
+    val healed = PanoImageryChangeSource.Reconciliation.toString
+    sql"""SELECT COUNT(DISTINCT pano_id)
+          FROM pano_imagery_change
+          WHERE changed_at >= $since
+              AND source = $healed::pano_imagery_change_source""".as[Int].head
+  }
+
+  /**
+   * Inserts the missing event for every pano whose log disagrees with its current `pano_data.expired`.
    *
    * The log depends on every writer of `pano_data.expired` recording its own transition in-statement, and a miss —
    * a writer that forgets to log, or the snapshot race documented on `PanoDataTable.updateExpiredStatus` — leaves
-   * exactly that footprint. Run nightly after the expiry sweep, this turns each miss into a row marked
-   * `reconciliation`, whose `changed_at` (the column's DEFAULT now()) is detection time rather than the real
-   * transition time — which is why the marker exists. Panos with no log rows at all are left alone: those are the
-   * pre-358 expiries 364's backfill had no date for (the chart's undated-expiries footnote), not missed transitions.
+   * one of two footprints. Run nightly after the expiry sweep, this turns each into a row marked `reconciliation`,
+   * whose `changed_at` (the column's DEFAULT now()) is detection time rather than the real transition time — which
+   * is why the marker exists, and why `transitionsByWeek` leaves these rows out.
    *
-   * One statement means one snapshot, so each pano row and its newest log row are read consistently. A flip
-   * committing concurrently can still make an inserted event stale by the time it lands; the next night's pass
-   * detects and heals that, the same self-correcting posture as the race this exists to repair. Do not add
-   * `FOR UPDATE` — see the trap documented on `updateExpiredStatus`.
+   * The first footprint is a newest log row contradicting the flag. The second is a dated expiry with no log rows
+   * at all: 364 seeded a row for every pano `expired_at` had a date for, so one arriving since then went unlogged.
+   * That second shape is the likelier one — only panos that have already crossed carry log history, so a new
+   * writer's first miss lands on a pano with none.
    *
-   * @return The ids of the panos healed — non-empty is evidence some writer is skipping the log.
+   * Undated expiries stay excluded: those are the pre-358 ones 364 had no date to seed from (the chart's
+   * undated-expiries footnote), where nothing claims a transition happened. A writer that skips `expired_at` too is
+   * indistinguishable from them, so it stays invisible here.
+   *
+   * One statement means one snapshot, so each pano row and its log are read consistently. A flip committing
+   * concurrently can still make an inserted event stale by the time it lands; the next night's pass detects and
+   * heals that, the same self-correcting posture as the race this exists to repair. Do not add `FOR UPDATE` — see
+   * the trap documented on `updateExpiredStatus`.
+   *
+   * @return The ids of the panos healed. Non-empty means a writer skipped the log or the snapshot race fired.
    */
   def reconcile(): DBIO[Seq[String]] = {
     val source = PanoImageryChangeSource.Reconciliation.toString
@@ -136,8 +165,9 @@ class PanoImageryChangeTable @Inject() (protected val dbConfigProvider: Database
           INSERT INTO pano_imagery_change (pano_id, expired, source)
           SELECT pano_data.pano_id, pano_data.expired, $source::pano_imagery_change_source
           FROM pano_data
-          INNER JOIN latest ON pano_data.pano_id = latest.pano_id
-          WHERE latest.expired <> pano_data.expired
+          LEFT JOIN latest ON pano_data.pano_id = latest.pano_id
+          WHERE (latest.pano_id IS NOT NULL AND latest.expired <> pano_data.expired)
+              OR (latest.pano_id IS NULL AND pano_data.expired AND pano_data.expired_at IS NOT NULL)
           RETURNING pano_id""".as[String]
   }
 }

--- a/app/models/pano/PanoImageryChangeTable.scala
+++ b/app/models/pano/PanoImageryChangeTable.scala
@@ -23,6 +23,12 @@ object PanoImageryChangeSource extends Enumeration {
   /** A labeler loaded the pano, which is itself proof the imagery is there. */
   val PanoView: Value = Value("pano_view")
 
+  /**
+   * A healed event from the nightly reconciliation pass (#5007): the newest log row disagreed with
+   * `pano_data.expired`, so a writer missed a transition. Carries detection time, not the real transition time.
+   */
+  val Reconciliation: Value = Value("reconciliation")
+
   /** Parses a string into a change source, returning None if it doesn't match a known value. */
   def fromString(name: String): Option[Value] = values.find(_.toString == name)
 }
@@ -67,12 +73,13 @@ class PanoImageryChangeTableDef(tag: Tag) extends Table[PanoImageryChange](tag, 
 trait PanoImageryChangeTableRepository {}
 
 /**
- * Read-only DAO over the pano imagery-transition log (#4947).
+ * DAO over the pano imagery-transition log (#4947).
  *
- * The rows are written by `PanoDataTable`, in the same statement as the `expired` flip they describe, so nothing here
- * inserts. What this table buys over `pano_data.expired_at` is that its rows are never rewritten: `expired_at` is
- * cleared when the imagery returns, which retroactively empties the week the pano expired in, while a log row stays
- * put and the recovery arrives as its own event.
+ * The rows are written by `PanoDataTable`, in the same statement as the `expired` flip they describe; the one insert
+ * here is `reconcile`, which heals events those writers missed rather than observing transitions itself (#5007).
+ * What this table buys over `pano_data.expired_at` is that its rows are never rewritten: `expired_at` is cleared
+ * when the imagery returns, which retroactively empties the week the pano expired in, while a log row stays put and
+ * the recovery arrives as its own event.
  */
 @Singleton
 class PanoImageryChangeTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvider)
@@ -100,5 +107,37 @@ class PanoImageryChangeTable @Inject() (protected val dbConfigProvider: Database
           WHERE changed_at >= $since
           GROUP BY date_trunc('week', changed_at)::date
           ORDER BY date_trunc('week', changed_at)::date""".as[PanoImageryWeek]
+  }
+
+  /**
+   * Inserts the missing event for every pano whose newest log row disagrees with its current `pano_data.expired`.
+   *
+   * The log depends on every writer of `pano_data.expired` recording its own transition in-statement, and a miss —
+   * a writer that forgets to log, or the snapshot race documented on `PanoDataTable.updateExpiredStatus` — leaves
+   * exactly that footprint. Run nightly after the expiry sweep, this turns each miss into a row marked
+   * `reconciliation`, whose `changed_at` (the column's DEFAULT now()) is detection time rather than the real
+   * transition time — which is why the marker exists. Panos with no log rows at all are left alone: those are the
+   * pre-358 expiries 364's backfill had no date for (the chart's undated-expiries footnote), not missed transitions.
+   *
+   * One statement means one snapshot, so each pano row and its newest log row are read consistently. A flip
+   * committing concurrently can still make an inserted event stale by the time it lands; the next night's pass
+   * detects and heals that, the same self-correcting posture as the race this exists to repair. Do not add
+   * `FOR UPDATE` — see the trap documented on `updateExpiredStatus`.
+   *
+   * @return The ids of the panos healed — non-empty is evidence some writer is skipping the log.
+   */
+  def reconcile(): DBIO[Seq[String]] = {
+    val source = PanoImageryChangeSource.Reconciliation.toString
+    sql"""WITH latest AS (
+            SELECT DISTINCT ON (pano_id) pano_id, expired
+            FROM pano_imagery_change
+            ORDER BY pano_id, changed_at DESC, pano_imagery_change_id DESC
+          )
+          INSERT INTO pano_imagery_change (pano_id, expired, source)
+          SELECT pano_data.pano_id, pano_data.expired, $source::pano_imagery_change_source
+          FROM pano_data
+          INNER JOIN latest ON pano_data.pano_id = latest.pano_id
+          WHERE latest.expired <> pano_data.expired
+          RETURNING pano_id""".as[String]
   }
 }

--- a/app/service/PanoDataService.scala
+++ b/app/service/PanoDataService.scala
@@ -13,7 +13,7 @@ import org.locationtech.jts.geom.Point
 import play.api.cache.AsyncCacheApi
 import play.api.db.slick.{DatabaseConfigProvider, HasDatabaseConfigProvider}
 import play.api.http.ContentTypes
-import play.api.libs.json.{JsObject, Json}
+import play.api.libs.json.{JsNull, JsNumber, JsObject, JsValue, Json}
 import play.api.libs.ws.WSClient
 import play.api.{Configuration, Environment, Logger}
 import service.PanoDataService.{
@@ -66,20 +66,22 @@ object PanoDataService {
    * provider key that has expired or hit its quota turns every check inconclusive, which leaves the expired counts
    * looking reassuringly quiet while the sweep has in fact stopped learning anything.
    *
-   * @param stillThere        Panos the provider confirmed still serve imagery.
-   * @param gone              Panos the provider confirmed it has no imagery for.
-   * @param errors            Panos the provider gave no usable answer for (timeout, auth failure, unexpected status).
-   * @param reconciledPanoIds Panos whose newest `pano_imagery_change` row disagreed with `pano_data.expired`, healed
-   *                          after the checks (#5007). Non-empty means some writer is skipping the log.
+   * @param stillThere Panos the provider confirmed still serve imagery.
+   * @param gone       Panos the provider confirmed it has no imagery for.
+   * @param errors     Panos the provider gave no usable answer for (timeout, auth failure, unexpected status).
+   * @param reconciled Panos whose `pano_imagery_change` log disagreed with `pano_data.expired`, healed after the
+   *                   checks (#5007). `None` when the repair itself failed — a plain `0` would file "nothing was
+   *                   wrong" and "we never looked" as the same run.
    */
-  case class ImageryCheckResult(stillThere: Int, gone: Int, errors: Int, reconciledPanoIds: Seq[String]) {
+  case class ImageryCheckResult(stillThere: Int, gone: Int, errors: Int, reconciled: Option[Int]) {
 
     /** Total panos the sweep asked the providers about. */
     def checked: Int = stillThere + gone + errors
 
     /** One line for the actor log and the admin endpoint's response body. */
     def summary: String =
-      s"Not expired: $stillThere. Expired: $gone. Errors: $errors. Reconciled: ${reconciledPanoIds.length}."
+      s"Not expired: $stillThere. Expired: $gone. Errors: $errors. " +
+        s"Reconciled: ${reconciled.map(_.toString).getOrElse("failed")}."
 
     /**
      * The counts as they are stored against a `background_job_run` row.
@@ -92,7 +94,7 @@ object PanoDataService {
       "still_there"   -> stillThere,
       "gone"          -> gone,
       "errors"        -> errors,
-      "reconciled"    -> reconciledPanoIds.length
+      "reconciled"    -> reconciled.fold[JsValue](JsNull)(count => JsNumber(count))
     )
   }
 
@@ -693,23 +695,33 @@ class PanoDataServiceImpl @Inject() (
 
         // Check each pano against whichever provider it came from, then tally the three outcomes.
         checkImageryBounded(panosToCheck ++ expiredPanosToCheck).flatMap { responses =>
-          // After the checks, heal any pano whose newest log row disagrees with pano_data.expired, so a missed
-          // imagery transition dangles for at most a day (#5007).
-          db.run(panoImageryChangeTable.reconcile()).map { healedPanoIds =>
-            if (healedPanoIds.nonEmpty) {
-              val preview = healedPanoIds.take(20).mkString(", ") + (if (healedPanoIds.length > 20) ", ..." else "")
-              logger.warn(
-                s"Healed ${healedPanoIds.length} missed imagery transition(s) — some writer of pano_data.expired " +
-                  s"is skipping the pano_imagery_change log: $preview"
+          // Heal any pano whose log disagrees with pano_data.expired, so a missed transition dangles for at most a
+          // day (#5007). The sweep's own updates have already committed by here, so a failed repair must not
+          // propagate: that would mark a successful sweep failed on /admin/health and lose the counts it learned.
+          db.run(panoImageryChangeTable.reconcile())
+            .map { healedPanoIds =>
+              if (healedPanoIds.nonEmpty) {
+                val preview = healedPanoIds.take(20).mkString(", ") + (if (healedPanoIds.length > 20) ", ..." else "")
+                logger.warn(
+                  s"Healed ${healedPanoIds.length} missed imagery transition(s) — either a writer of " +
+                    s"pano_data.expired is skipping the pano_imagery_change log, or the snapshot race documented " +
+                    s"on PanoDataTable.updateExpiredStatus fired: $preview"
+                )
+              }
+              Some(healedPanoIds.length)
+            }
+            .recover { case NonFatal(e) =>
+              logger.error("Imagery-log reconciliation failed; the sweep's own results stand.", e)
+              None
+            }
+            .map { reconciled =>
+              ImageryCheckResult(
+                stillThere = responses.count(_.contains(true)),
+                gone = responses.count(_.contains(false)),
+                errors = responses.count(_.isEmpty),
+                reconciled = reconciled
               )
             }
-            ImageryCheckResult(
-              stillThere = responses.count(_.contains(true)),
-              gone = responses.count(_.contains(false)),
-              errors = responses.count(_.isEmpty),
-              reconciledPanoIds = healedPanoIds
-            )
-          }
         }
       }
     ).flatten

--- a/app/service/PanoDataService.scala
+++ b/app/service/PanoDataService.scala
@@ -66,17 +66,20 @@ object PanoDataService {
    * provider key that has expired or hit its quota turns every check inconclusive, which leaves the expired counts
    * looking reassuringly quiet while the sweep has in fact stopped learning anything.
    *
-   * @param stillThere Panos the provider confirmed still serve imagery.
-   * @param gone       Panos the provider confirmed it has no imagery for.
-   * @param errors     Panos the provider gave no usable answer for (timeout, auth failure, unexpected status).
+   * @param stillThere        Panos the provider confirmed still serve imagery.
+   * @param gone              Panos the provider confirmed it has no imagery for.
+   * @param errors            Panos the provider gave no usable answer for (timeout, auth failure, unexpected status).
+   * @param reconciledPanoIds Panos whose newest `pano_imagery_change` row disagreed with `pano_data.expired`, healed
+   *                          after the checks (#5007). Non-empty means some writer is skipping the log.
    */
-  case class ImageryCheckResult(stillThere: Int, gone: Int, errors: Int) {
+  case class ImageryCheckResult(stillThere: Int, gone: Int, errors: Int, reconciledPanoIds: Seq[String]) {
 
     /** Total panos the sweep asked the providers about. */
     def checked: Int = stillThere + gone + errors
 
     /** One line for the actor log and the admin endpoint's response body. */
-    def summary: String = s"Not expired: $stillThere. Expired: $gone. Errors: $errors."
+    def summary: String =
+      s"Not expired: $stillThere. Expired: $gone. Errors: $errors. Reconciled: ${reconciledPanoIds.length}."
 
     /**
      * The counts as they are stored against a `background_job_run` row.
@@ -88,7 +91,8 @@ object PanoDataService {
       "panos_checked" -> checked,
       "still_there"   -> stillThere,
       "gone"          -> gone,
-      "errors"        -> errors
+      "errors"        -> errors,
+      "reconciled"    -> reconciledPanoIds.length
     )
   }
 
@@ -380,6 +384,7 @@ class PanoDataServiceImpl @Inject() (
     implicit val ec: ExecutionContext,
     panoDataTable: PanoDataTable,
     panoHistoryTable: PanoHistoryTable,
+    panoImageryChangeTable: PanoImageryChangeTable,
     streetEdgeTable: models.street.StreetEdgeTable,
     signingService: ImageSigningService
 )(implicit mat: Materializer)
@@ -687,12 +692,24 @@ class PanoDataServiceImpl @Inject() (
         logger.info(s"Checking ${expiredPanosToCheck.length} expired panos.")
 
         // Check each pano against whichever provider it came from, then tally the three outcomes.
-        checkImageryBounded(panosToCheck ++ expiredPanosToCheck).map { responses =>
-          ImageryCheckResult(
-            stillThere = responses.count(_.contains(true)),
-            gone = responses.count(_.contains(false)),
-            errors = responses.count(_.isEmpty)
-          )
+        checkImageryBounded(panosToCheck ++ expiredPanosToCheck).flatMap { responses =>
+          // After the checks, heal any pano whose newest log row disagrees with pano_data.expired, so a missed
+          // imagery transition dangles for at most a day (#5007).
+          db.run(panoImageryChangeTable.reconcile()).map { healedPanoIds =>
+            if (healedPanoIds.nonEmpty) {
+              val preview = healedPanoIds.take(20).mkString(", ") + (if (healedPanoIds.length > 20) ", ..." else "")
+              logger.warn(
+                s"Healed ${healedPanoIds.length} missed imagery transition(s) — some writer of pano_data.expired " +
+                  s"is skipping the pano_imagery_change log: $preview"
+              )
+            }
+            ImageryCheckResult(
+              stillThere = responses.count(_.contains(true)),
+              gone = responses.count(_.contains(false)),
+              errors = responses.count(_.isEmpty),
+              reconciledPanoIds = healedPanoIds
+            )
+          }
         }
       }
     ).flatten

--- a/app/service/StreetLifecycleService.scala
+++ b/app/service/StreetLifecycleService.scala
@@ -33,6 +33,8 @@ import scala.concurrent.{ExecutionContext, Future}
  * @param corroboratedStreets  Still-open streets several labelers independently reported as having no imagery.
  * @param minReporters         Distinct labelers a street needs to appear in `corroboratedStreets`.
  * @param panosExpiredUndated  Expired panos with no recorded expiry date, i.e. what these series can't account for.
+ * @param panosHealed          Panos the reconciliation pass healed inside the window: crossings that did happen, but
+ *                             carry the date they were noticed, so `panoImageryChanges` can't place them in a week.
  */
 case class StreetStatusTrend(
     weeks: Int,
@@ -43,7 +45,8 @@ case class StreetStatusTrend(
     topReportRegions: Seq[NoImageryReportRegion],
     corroboratedStreets: Seq[CorroboratedNoImageryStreet],
     minReporters: Int,
-    panosExpiredUndated: Int
+    panosExpiredUndated: Int,
+    panosHealed: Int
 )
 
 object StreetStatusTrend {
@@ -153,7 +156,7 @@ class StreetLifecycleServiceImpl @Inject() (
     )
   }
 
-  /** Runs the six series queries that back one window. */
+  /** Runs the seven series queries that back one window. */
   private def assembleTrend(window: Int): Future[StreetStatusTrend] = {
     // Bucket boundaries are ISO weeks, so start the window on one: an inclusive cutoff mid-week would leave the
     // oldest bucket a partial week that reads as a dip.
@@ -169,7 +172,7 @@ class StreetLifecycleServiceImpl @Inject() (
       .atStartOfDay(ZoneId.systemDefault)
       .toOffsetDateTime
 
-    // Bound before the for-comprehension so the six reads run concurrently rather than one after another.
+    // Bound before the for-comprehension so the seven reads run concurrently rather than one after another.
     val statusChangesF = db.run(statusChangeTable.transitionsByWeek(since))
     val reportsF       = db.run(streetEdgeIssueTable.reportsByWeek(since))
     val imageryF       = db.run(panoImageryChangeTable.transitionsByWeek(since))
@@ -182,6 +185,7 @@ class StreetLifecycleServiceImpl @Inject() (
       )
     )
     val undatedF = db.run(panoDataTable.countExpiredWithoutExpiryDate)
+    val healedF  = db.run(panoImageryChangeTable.healedSince(since))
 
     for {
       statusChanges  <- statusChangesF
@@ -190,7 +194,8 @@ class StreetLifecycleServiceImpl @Inject() (
       regions        <- regionsF
       corroborated   <- corroboratedF
       undated        <- undatedF
+      healed         <- healedF
     } yield StreetStatusTrend(window, since, statusChanges, reports, imageryChanges, regions, corroborated,
-      StreetLifecycleService.MinCorroboratingReporters, undated)
+      StreetLifecycleService.MinCorroboratingReporters, undated, healed)
   }
 }

--- a/conf/evolutions/default/365.sql
+++ b/conf/evolutions/default/365.sql
@@ -13,15 +13,15 @@
 ALTER TYPE pano_imagery_change_source ADD VALUE IF NOT EXISTS 'reconciliation';
 
 -- The reconciliation pass reads the newest log row per pano: DISTINCT ON (pano_id) ordered by pano_id,
--- changed_at DESC, pano_imagery_change_id DESC. This composite serves that as one presorted index scan, joined hash-
--- wise to a single pass over pano_data -- no per-row subqueries. Its pano_id prefix also covers everything the plain
--- pano_id index served (the FK's ON DELETE CASCADE lookups), so that index is dropped rather than kept as a
+-- changed_at DESC, pano_imagery_change_id DESC. This composite serves that as one presorted index scan, left-joined
+-- hash-wise to a single pass over pano_data -- no per-row subqueries. Its pano_id prefix also covers everything the
+-- plain pano_id index served (the FK's ON DELETE CASCADE lookups), so that index is dropped rather than kept as a
 -- redundant copy -- net index count on the table is unchanged.
-CREATE INDEX pano_imagery_change_pano_id_changed_at_idx
+CREATE INDEX IF NOT EXISTS pano_imagery_change_pano_id_changed_at_idx
     ON pano_imagery_change (pano_id, changed_at DESC, pano_imagery_change_id DESC);
-DROP INDEX pano_imagery_change_pano_id_idx;
+DROP INDEX IF EXISTS pano_imagery_change_pano_id_idx;
 
 # --- !Downs
 -- The reconciliation value stays: Postgres can't drop an enum value without rebuilding the type (331/339 precedent).
-CREATE INDEX pano_imagery_change_pano_id_idx ON pano_imagery_change (pano_id);
-DROP INDEX pano_imagery_change_pano_id_changed_at_idx;
+CREATE INDEX IF NOT EXISTS pano_imagery_change_pano_id_idx ON pano_imagery_change (pano_id);
+DROP INDEX IF EXISTS pano_imagery_change_pano_id_changed_at_idx;

--- a/conf/evolutions/default/365.sql
+++ b/conf/evolutions/default/365.sql
@@ -1,0 +1,27 @@
+# --- !Ups
+-- #5007: the imagery-change log (364.sql) is only as honest as its writers -- every writer of pano_data.expired must
+-- record its own transition in the same statement, and that invariant can be missed by a writer that forgets to log
+-- or by the READ COMMITTED snapshot race documented on PanoDataTable.updateExpiredStatus. Both misses leave the same
+-- footprint: a pano whose newest log row disagrees with its current pano_data.expired. A nightly reconciliation pass
+-- (PanoImageryChangeTable.reconcile, run with the CheckImageExpiryActor sweep) inserts the missing event, and this
+-- value marks the healed rows. It has to be its own value because a healed event carries detection time, not the
+-- real transition time -- it can land up to a day late, or in the wrong week -- so it must never be mistaken for an
+-- observed one, and unlike scheduled-vs-manual (deliberately not a value here, see 364.sql) the distinction is not
+-- answerable from background_job_run: healed and observed rows land during the same sweep's run.
+-- Adding a value in a transaction is fine as long as the transaction doesn't use it (339/361.sql precedent) -- the
+-- healing happens only at runtime, so nothing in this evolution does.
+ALTER TYPE pano_imagery_change_source ADD VALUE IF NOT EXISTS 'reconciliation';
+
+-- The reconciliation pass reads the newest log row per pano: DISTINCT ON (pano_id) ordered by pano_id,
+-- changed_at DESC, pano_imagery_change_id DESC. This composite serves that as one presorted index scan, joined hash-
+-- wise to a single pass over pano_data -- no per-row subqueries. Its pano_id prefix also covers everything the plain
+-- pano_id index served (the FK's ON DELETE CASCADE lookups), so that index is dropped rather than kept as a
+-- redundant copy -- net index count on the table is unchanged.
+CREATE INDEX pano_imagery_change_pano_id_changed_at_idx
+    ON pano_imagery_change (pano_id, changed_at DESC, pano_imagery_change_id DESC);
+DROP INDEX pano_imagery_change_pano_id_idx;
+
+# --- !Downs
+-- The reconciliation value stays: Postgres can't drop an enum value without rebuilding the type (331/339 precedent).
+CREATE INDEX pano_imagery_change_pano_id_idx ON pano_imagery_change (pano_id);
+DROP INDEX pano_imagery_change_pano_id_changed_at_idx;

--- a/public/js/admin-dashboard/StreetStatusTrend.js
+++ b/public/js/admin-dashboard/StreetStatusTrend.js
@@ -172,13 +172,28 @@ class StreetStatusTrend {
       ariaLabel: 'Panoramas whose imagery went away, and whose imagery came back, per week',
     });
 
+    // Both counts are crossings the bars can't show. Unexplained, the gap reads as a broken chart.
+    const notes = [];
+
     // These panos have no logged loss but do log their recovery, so "came back" can outrun "went away" until the
-    // count drains. Unexplained, that reads as a broken chart.
+    // count drains.
     const undated = data.panos_expired_undated || 0;
-    AdminShell.setText('trend-expiry-note', undated === 0
-      ? ''
-      : `${AdminShell.num(undated)} panos were already expired before any of this was recorded, so they appear in `
-        + 'no week above. If one regains imagery it still charts as a recovery, with no matching loss before it.');
+    if (undated > 0) {
+      notes.push(`${AdminShell.num(undated)} panos were already expired before any of this was recorded, so they `
+        + 'appear in no week above. If one regains imagery it still charts as a recovery, with no matching loss '
+        + 'before it.');
+    }
+
+    // Healed events carry the night the pass noticed, not the day the imagery moved, so charting one would put a
+    // real crossing in the wrong week.
+    const healed = data.panos_healed || 0;
+    if (healed > 0) {
+      notes.push(`${AdminShell.num(healed)} pano${healed === 1 ? '' : 's'} crossed the boundary without the change `
+        + 'being logged, and the nightly reconciliation pass filled the event in afterwards. Those carry the date '
+        + 'they were noticed rather than the date they moved, so they are left out of the weeks above too.');
+    }
+
+    AdminShell.setText('trend-expiry-note', notes.join(' '));
   }
 
   /** The review queue: still-open streets that several distinct labelers reported as empty. */

--- a/test/js/streetStatusTrend.test.js
+++ b/test/js/streetStatusTrend.test.js
@@ -58,6 +58,7 @@ function payload(overrides = {}) {
     corroborated_streets: [],
     min_reporters: 2,
     panos_expired_undated: 0,
+    panos_healed: 0,
     ...overrides,
   };
 }
@@ -213,8 +214,21 @@ describe('the expiry note', () => {
       .toMatch(/recovery, with no matching loss before it/);
   });
 
+  test('says how many crossings were healed after the fact', async () => {
+    await render(payload({ panos_healed: 7 }));
+    // Healed rows are left out of the bars; dropped silently, the chart understates the losses it knows about.
+    expect(document.getElementById('trend-expiry-note').textContent)
+      .toMatch(/^7 panos crossed the boundary without the change being logged/);
+  });
+
+  test('reports both gaps together, undated first', async () => {
+    await render(payload({ panos_expired_undated: 1234, panos_healed: 7 }));
+    const note = document.getElementById('trend-expiry-note').textContent;
+    expect(note.indexOf('1,234 panos were already expired')).toBeLessThan(note.indexOf('7 panos crossed'));
+  });
+
   test('stays silent when every expired pano is accounted for', async () => {
-    await render(payload({ panos_expired_undated: 0 }));
+    await render(payload({ panos_expired_undated: 0, panos_healed: 0 }));
     expect(document.getElementById('trend-expiry-note').textContent).toBe('');
   });
 });

--- a/test/models/pano/PanoImageryLogSpec.scala
+++ b/test/models/pano/PanoImageryLogSpec.scala
@@ -21,7 +21,8 @@ import scala.concurrent.duration._
  * recovery retroactively empties the week the pano expired in. The log exists to survive that round trip, and these
  * cases are the two halves of the contract that makes it worth having — every real crossing is recorded exactly
  * once, and nothing else is. The second half is what keeps the table small enough to be free: the nightly sweep
- * re-checks every already-expired pano, and a labeler's viewer re-upserts every pano they load.
+ * re-checks every already-expired pano, and a labeler's viewer re-upserts every pano they load. The `reconcile`
+ * cases cover the pass that heals a crossing a writer missed (#5007).
  *
  * Seeds its own pano rather than hunting for one in the connected DB, so it can never pass vacuously. Requires a
  * Postgres+PostGIS database (DATABASE_URL / DATABASE_USER / DATABASE_PASSWORD, as in dev/CI); the scheduling actors
@@ -179,6 +180,55 @@ class PanoImageryLogSpec extends PlaySpec with BeforeAndAfterAll with GuiceOneAp
       run(sqlu"DELETE FROM pano_data WHERE pano_id = $panoId")
       run(panoDataTable.updateExpiredStatus(panoId, expired = true, Some(false), OffsetDateTime.now)) mustBe 0
       events mustBe empty
+    }
+  }
+
+  "reconcile" should {
+    "heal a loss the log never recorded" in {
+      reset()
+      run(sqlu"""INSERT INTO pano_imagery_change (pano_id, expired, source)
+                 VALUES ($panoId, TRUE, 'provider_check')""")
+      // The pano is unexpired but its newest log row says the imagery went away: the footprint of a writer that
+      // skipped the log, or of the snapshot race documented on updateExpiredStatus.
+      run(imageryChangeTable.reconcile()) must contain(panoId)
+      events mustBe Seq(true -> "provider_check", false -> "reconciliation")
+    }
+
+    "heal a recovery the log never recorded" in {
+      reset()
+      run(sqlu"UPDATE pano_data SET expired = TRUE, expired_at = NULL WHERE pano_id = $panoId")
+      run(sqlu"""INSERT INTO pano_imagery_change (pano_id, expired, source)
+                 VALUES ($panoId, FALSE, 'pano_view')""")
+      run(imageryChangeTable.reconcile()) must contain(panoId)
+      events mustBe Seq(false -> "pano_view", true -> "reconciliation")
+    }
+
+    "insert nothing when the newest log row already agrees, however many times it runs" in {
+      reset()
+      run(panoDataTable.updateExpiredStatus(panoId, expired = true, Some(false), OffsetDateTime.now))
+      run(imageryChangeTable.reconcile()) must not contain panoId
+      run(imageryChangeTable.reconcile()) must not contain panoId
+      events mustBe Seq(true -> "provider_check")
+    }
+
+    "leave a pano with no log rows alone" in {
+      reset()
+      run(sqlu"UPDATE pano_data SET expired = TRUE, expired_at = NULL WHERE pano_id = $panoId")
+      // No rows at all is the pre-358 undated-expiries population the chart footnotes, not a missed transition:
+      // there is no real transition time even a detection-stamped row could stand in for.
+      run(imageryChangeTable.reconcile()) must not contain panoId
+      events mustBe empty
+    }
+
+    "take the newest row by id when timestamps tie" in {
+      reset()
+      run(sqlu"""INSERT INTO pano_imagery_change (pano_id, expired, changed_at, source)
+                 VALUES ($panoId, FALSE, '2026-01-01 00:00:00+00', 'provider_check'),
+                        ($panoId, TRUE,  '2026-01-01 00:00:00+00', 'provider_check')""")
+      // Same instant, so changed_at can't order the two rows; the serial id can, and the later insert says the
+      // imagery went away while pano_data says it is there.
+      run(imageryChangeTable.reconcile()) must contain(panoId)
+      events.last mustBe (false -> "reconciliation")
     }
   }
 

--- a/test/models/pano/PanoImageryLogSpec.scala
+++ b/test/models/pano/PanoImageryLogSpec.scala
@@ -24,9 +24,12 @@ import scala.concurrent.duration._
  * re-checks every already-expired pano, and a labeler's viewer re-upserts every pano they load. The `reconcile`
  * cases cover the pass that heals a crossing a writer missed (#5007).
  *
- * Seeds its own pano rather than hunting for one in the connected DB, so it can never pass vacuously. Requires a
- * Postgres+PostGIS database (DATABASE_URL / DATABASE_USER / DATABASE_PASSWORD, as in dev/CI); the scheduling actors
- * are disabled so no background sweep touches the row mid-test.
+ * Seeds its own pano rather than hunting for one in the connected DB, so it can never pass vacuously, and every
+ * assertion is scoped to that pano or to a delta. `reconcile` is the exception: it is a whole-table repair, so those
+ * cases also heal any other disagreeing pano in the connected DB — the same write the nightly sweep would make.
+ *
+ * Requires a Postgres+PostGIS database (DATABASE_URL / DATABASE_USER / DATABASE_PASSWORD, as in dev/CI); the
+ * scheduling actors are disabled so no background sweep touches the row mid-test.
  */
 class PanoImageryLogSpec extends PlaySpec with BeforeAndAfterAll with GuiceOneAppPerSuite {
 
@@ -211,11 +214,20 @@ class PanoImageryLogSpec extends PlaySpec with BeforeAndAfterAll with GuiceOneAp
       events mustBe Seq(true -> "provider_check")
     }
 
-    "leave a pano with no log rows alone" in {
+    "heal a dated expiry the log has no row for at all" in {
+      reset()
+      run(sqlu"""UPDATE pano_data SET expired = TRUE, expired_at = now() WHERE pano_id = $panoId""")
+      // The likelier shape of a missed transition: only panos that have already crossed carry log history, so a
+      // new writer's first miss lands on a pano with none.
+      run(imageryChangeTable.reconcile()) must contain(panoId)
+      events mustBe Seq(true -> "reconciliation")
+    }
+
+    "leave an undated expiry with no log rows alone" in {
       reset()
       run(sqlu"UPDATE pano_data SET expired = TRUE, expired_at = NULL WHERE pano_id = $panoId")
-      // No rows at all is the pre-358 undated-expiries population the chart footnotes, not a missed transition:
-      // there is no real transition time even a detection-stamped row could stand in for.
+      // No date and no rows is the pre-358 undated-expiries population the chart footnotes: nothing here claims a
+      // transition happened, so there is none to stamp.
       run(imageryChangeTable.reconcile()) must not contain panoId
       events mustBe empty
     }
@@ -274,6 +286,35 @@ class PanoImageryLogSpec extends PlaySpec with BeforeAndAfterAll with GuiceOneAp
       // The row is still there — the log is append-only — it is simply outside what this window asks for.
       events.size mustBe 1
       seededCounts(OffsetDateTime.now.minusWeeks(4)) mustBe before
+    }
+
+    "leave out a healed crossing, and count it under healedSince instead" in {
+      reset()
+      val since        = OffsetDateTime.now.minusWeeks(1)
+      val before       = seededCounts(since)
+      val healedBefore = run(imageryChangeTable.healedSince(since))
+      run(sqlu"""INSERT INTO pano_imagery_change (pano_id, expired, source)
+                 VALUES ($panoId, TRUE, 'provider_check')""")
+      run(imageryChangeTable.reconcile()) must contain(panoId)
+
+      // Charting the healed row would put a real crossing in a week it did not happen in — the rewriting of history
+      // this table exists to stop. The count is what lets the page own the gap instead of dropping it silently.
+      seededCounts(since) mustBe (before._1 + 1, before._2)
+      run(imageryChangeTable.healedSince(since)) mustBe healedBefore + 1
+    }
+
+    "leave out a healed crossing older than the window from that count too" in {
+      reset()
+      run(sqlu"""INSERT INTO pano_imagery_change (pano_id, expired, source)
+                 VALUES ($panoId, TRUE, 'provider_check')""")
+      run(imageryChangeTable.reconcile()) must contain(panoId)
+      val since  = OffsetDateTime.now.minusWeeks(4)
+      val before = run(imageryChangeTable.healedSince(since))
+      run(sqlu"""UPDATE pano_imagery_change SET changed_at = now() - INTERVAL '20 weeks'
+                 WHERE pano_id = $panoId AND source = 'reconciliation'""")
+
+      // The footnote counts what this window is missing, so it has to move with the window like the series do.
+      run(imageryChangeTable.healedSince(since)) mustBe before - 1
     }
   }
 }

--- a/test/service/ImageryPollOutcomeSpec.scala
+++ b/test/service/ImageryPollOutcomeSpec.scala
@@ -87,18 +87,21 @@ class ImageryPollOutcomeSpec extends PlaySpec with GuiceOneAppPerSuite {
     "total the three outcomes it distinguishes" in {
       // `errors` is the signal worth watching: a key at its quota turns every check inconclusive, which leaves the
       // expired counts looking reassuringly quiet while the sweep has stopped learning anything.
-      val result = ImageryCheckResult(stillThere = 7, gone = 2, errors = 1)
+      val result = ImageryCheckResult(stillThere = 7, gone = 2, errors = 1, reconciledPanoIds = Seq("healed-pano"))
       result.checked mustBe 10
-      result.summary mustBe "Not expired: 7. Expired: 2. Errors: 1."
+      // Reconciled rows are healed log entries, not provider answers, so they don't count toward `checked`.
+      result.summary mustBe "Not expired: 7. Expired: 2. Errors: 1. Reconciled: 1."
     }
 
     "record one shape for both the nightly sweep and the hand-trigger" in {
       // Defined on the result rather than at each call site, so the two callers can't fork the recorded shape.
-      val details = ImageryCheckResult(stillThere = 7, gone = 2, errors = 1).runDetails
+      val details =
+        ImageryCheckResult(stillThere = 7, gone = 2, errors = 1, reconciledPanoIds = Seq("healed-pano")).runDetails
       (details \ "panos_checked").as[Int] mustBe 10
       (details \ "still_there").as[Int] mustBe 7
       (details \ "gone").as[Int] mustBe 2
       (details \ "errors").as[Int] mustBe 1
+      (details \ "reconciled").as[Int] mustBe 1
     }
   }
 }

--- a/test/service/ImageryPollOutcomeSpec.scala
+++ b/test/service/ImageryPollOutcomeSpec.scala
@@ -7,6 +7,7 @@ import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.db.slick.DatabaseConfigProvider
 import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.json.JsNull
 import play.api.libs.ws.WSClient
 import play.api.{Application, Configuration}
 import service.ImageryFreshnessService.{MissingImageryCredentialException, PollResult}
@@ -87,7 +88,7 @@ class ImageryPollOutcomeSpec extends PlaySpec with GuiceOneAppPerSuite {
     "total the three outcomes it distinguishes" in {
       // `errors` is the signal worth watching: a key at its quota turns every check inconclusive, which leaves the
       // expired counts looking reassuringly quiet while the sweep has stopped learning anything.
-      val result = ImageryCheckResult(stillThere = 7, gone = 2, errors = 1, reconciledPanoIds = Seq("healed-pano"))
+      val result = ImageryCheckResult(stillThere = 7, gone = 2, errors = 1, reconciled = Some(1))
       result.checked mustBe 10
       // Reconciled rows are healed log entries, not provider answers, so they don't count toward `checked`.
       result.summary mustBe "Not expired: 7. Expired: 2. Errors: 1. Reconciled: 1."
@@ -95,13 +96,22 @@ class ImageryPollOutcomeSpec extends PlaySpec with GuiceOneAppPerSuite {
 
     "record one shape for both the nightly sweep and the hand-trigger" in {
       // Defined on the result rather than at each call site, so the two callers can't fork the recorded shape.
-      val details =
-        ImageryCheckResult(stillThere = 7, gone = 2, errors = 1, reconciledPanoIds = Seq("healed-pano")).runDetails
+      val details = ImageryCheckResult(stillThere = 7, gone = 2, errors = 1, reconciled = Some(1)).runDetails
       (details \ "panos_checked").as[Int] mustBe 10
       (details \ "still_there").as[Int] mustBe 7
       (details \ "gone").as[Int] mustBe 2
       (details \ "errors").as[Int] mustBe 1
       (details \ "reconciled").as[Int] mustBe 1
+    }
+
+    "say the repair could not run rather than reporting it healed nothing" in {
+      // The repair is subordinate to the sweep, so its failure leaves the counts standing. Recording that as a 0
+      // would file "nothing was wrong" and "we never looked" under the same row, which is the thing a
+      // background_job_run row exists to tell apart.
+      val failed = ImageryCheckResult(stillThere = 7, gone = 2, errors = 1, reconciled = None)
+      failed.summary mustBe "Not expired: 7. Expired: 2. Errors: 1. Reconciled: failed."
+      (failed.runDetails \ "reconciled").get mustBe JsNull
+      (failed.runDetails \ "panos_checked").as[Int] mustBe 10
     }
   }
 }

--- a/test/service/StreetLifecycleServiceSpec.scala
+++ b/test/service/StreetLifecycleServiceSpec.scala
@@ -151,6 +151,7 @@ class StreetLifecycleServiceSpec extends PlaySpec with BeforeAndAfterAll with Gu
       Seq("status_changes", "no_imagery_reports", "pano_imagery_changes", "top_report_regions", "corroborated_streets")
         .foreach(key => (json \ key).asOpt[play.api.libs.json.JsArray] mustBe defined)
       (json \ "panos_expired_undated").as[Int] must be >= 0
+      (json \ "panos_healed").as[Int] must be >= 0
       // The window start is what the client steps its week grid from, so it has to stay an ISO string rather than
       // whatever a serializer's default for a timestamp happens to be.
       (json \ "since").as[String] must startWith(trend.since.toLocalDate.toString)


### PR DESCRIPTION
Fixes #5007. Follow-up to #4994 (evolution 364).

## What

The imagery-change log relies on every writer of `pano_data.expired` recording its own transition in-statement. A miss — a future writer that forgets, or the documented READ COMMITTED snapshot race on `PanoDataTable.updateExpiredStatus` — leaves a pano whose log disagrees with its current `expired` flag, and a dangling loss is exactly what `/admin/street-status` teaches admins to read as permanent imagery loss. This PR makes the log self-heal: a reconciliation pass runs right after the nightly `CheckImageExpiryActor` sweep (and the admin hand-trigger, which shares `checkForImagery`), finds those panos, and inserts the missing event.

**Two footprints get healed.** `PanoImageryChangeTable.reconcile()` looks for a newest log row that contradicts the flag, *and* for a dated expiry with no log rows at all — 364 seeded a row for every pano `expired_at` had a date for, so one arriving since then went unlogged. The second is the likelier shape of a missed transition, because only panos that have already crossed the boundary carry any log history, so a new writer's first miss lands on a pano with none.

**Undated expiries stay out.** A pano that is expired with no `expired_at` and no log rows is the pre-358 population 364's backfill had no date for (the chart's undated-expiries footnote), where nothing claims a transition happened. A writer that skips `expired_at` along with the log is indistinguishable from those, and stays invisible here — stated out loud on `reconcile` rather than left as a silent gap.

**Healed rows are marked, and the marker is read.** They carry a new `pano_imagery_change_source` value, `reconciliation` (evolution 365, runtime-only use so plain `ADD VALUE` is safe), because their `changed_at` is detection time, not the real transition time. `transitionsByWeek` therefore excludes them: charting one would put a real crossing in a week it did not happen in, which is the rewriting of history the log exists to stop. `healedSince` counts what the window is missing as a result, and the Street Status page footnotes it beside the undated expiries instead of dropping it silently.

**Efficiency.** `reconcile()` is one `DISTINCT ON (pano_id)` latest-row set left-joined to a single pass over `pano_data` — no correlated subqueries. Evolution 365 adds a composite index `(pano_id, changed_at DESC, pano_imagery_change_id DESC)` that serves the newest-row-per-pano scan presorted, and drops the plain `pano_id` index it subsumes (its prefix still covers the FK cascade lookups), so net index count is unchanged. `EXPLAIN ANALYZE` on a synthetic prod-scale set (266k `pano_data`, ~8k log rows over 5.3k panos) plans as `Index Scan` on the composite → `Unique` → `Hash Left Join` ← `Seq Scan on pano_data`, ~74 ms.

**The repair can't take the sweep down with it.** By the time it runs, the sweep's own `updateExpiredStatus` writes have committed, so a failed repair propagating would mark a healthy run `Failed` on `/admin/health` and discard the counts it did learn. It recovers, logs at error, and reports `Option[Int]` — a plain `0` would file "nothing was wrong" and "we never looked" as the same `background_job_run` row.

**Log what it repairs.** The sweep's summary and `background_job_run` details gain `Reconciled: N` (`failed`/`null` when the repair could not run), and a non-zero count logs a warning naming up to 20 healed pano ids. The warning names both possible causes — a writer skipping the log, or the documented snapshot race — since the two leave the same footprint.

Reconciliation itself can race a concurrent flip and insert a stale event; the next night's pass detects and heals that — the same rare-and-self-correcting posture as the race it repairs (documented on `reconcile`, no `FOR UPDATE` per the trap on `updateExpiredStatus`).

## Tests

`PanoImageryLogSpec` gains eight cases: both heal directions, the dated-expiry-with-no-log-rows heal and the undated exclusion, idempotence (an agreeing newest row inserts nothing on repeated runs), the `changed_at` tie broken by id, and the two sides of the chart split (a healed crossing leaves `transitionsByWeek` and lands in `healedSince`, and drops out of that count once it's outside the window). `EnumTypeParitySpec` pins the enum parity both ways; `ImageryPollOutcomeSpec` covers the extended result shape including the repair-failed case; `StreetLifecycleServiceSpec` pins `panos_healed` in the payload; the jsdom trend suite covers the new footnote sentence and the ordering of the two.

Local gates: compile warning-clean, scalafmt clean, `make lint` green (including `lint-evolutions`), targeted suites green (PanoImageryLogSpec 25/25, StreetLifecycleServiceSpec + PanoExpiredAtSpec 19/19, ImageryPollOutcomeSpec 5/5, jsdom trend suite 26/26); evolution 365 applied + Downs verified on the dev DB, and `EXPLAIN` confirms the access path.

## Note before merging

`4929-reopen-no-imagery-streets` also claims `365.sql`. Whichever of the two merges second needs to renumber to 366.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Fable 5, claude-fable-5, effort: high; review fixes by Opus 5 (1M context), claude-opus-5[1m]

https://claude.ai/code/session_01HWmZTLpWWSdrGWqpbufWDm
