### PR TITLE
Let gallery card tags shrink below their content so narrow cards don't overflow

### DIFF
--- a/public/css/gallery/cards.css
+++ b/public/css/gallery/cards.css
@@ -216,7 +216,10 @@ with respect to the image holder. This allows the validation menu to be placed o
   height: 100%;
   flex-direction: row;
   flex: 1; /* Takes all remaining space */
-  right: 0;
+
+  /* Without this, the flex item's auto min-width lets nowrap tag pills inflate it past the card — and
+     TagDisplay measures the inflated width, so its fit budget never hides a tag (#5009). */
+  min-width: 0;
   padding-left: 7px;
 }
 

--- a/public/js/gallery/src/displays/TagDisplay.js
+++ b/public/js/gallery/src/displays/TagDisplay.js
@@ -54,45 +54,65 @@ class TagDisplay {
       });
       $(tagContainer).append(tagEls);
 
-      // The width (amount of horizontal space) we have for our tags is the length of the container subtracted by
-      // the space taken up by the header. Multiply by 1.25 to deal with the padding from the space between the
-      // "Tag" header and the actual list of tags.
-      let remainingWidth = $(container).width() - ($(tagHeader).width() * 1.25);
+      // A pill has to keep a few characters ahead of its ellipsis to say which tag it is; any narrower and it reads
+      // as nothing, so that width is the cutoff for showing the tag at all. Each cutoff is measured off a probe
+      // carrying that tag's own opening characters, since the pill's padding, the card-relative font size, and the
+      // script the tag is written in all feed it — and a cutoff fixed in px tracks none of them: on a phone-width
+      // card it outgrows the entire tag budget, so every card falls back to a bare "+n" (#5009).
+      const MIN_TAG_CHARS = 6;
+      const minWidthProbes = tagsText.map((text) => {
+        const probe = document.createElement('div');
+        probe.className = 'gallery-tag thumbnail-tag';
+        probe.innerText = `${[...text].slice(0, MIN_TAG_CHARS).join('')}…`;
+        return probe;
+      });
+      $(tagContainer).append(minWidthProbes);
+
+      // The "+n" pill is measured rather than estimated, at the widest count it could end up carrying, so the space
+      // held back for it is what the pill actually costs in this locale's font at this card's size. It is the row's
+      // last child either way, so it stays put when the real count is filled in below.
+      const overflowPill = document.createElement('div');
+      overflowPill.className = 'gallery-tag additional-count';
+      overflowPill.innerText = ` + ${tagsText.length}`;
+      $(tagContainer).append(overflowPill);
+
+      // The tags' share of the row is the holder's own width, read rather than derived from the container minus an
+      // estimate of the header: the holder is the flex item that takes whatever the header leaves, so it already
+      // accounts for the header's padding in every locale, however wide that locale writes "Tags".
+      //
+      // Every width is read through outerWidth, which puts the padding, border and margins a pill costs the row
+      // into the one number the fit spends — a computed `width` carries a different box depending on box-sizing.
+      const widthOf = (el) => $(el).outerWidth(true);
+      let remainingWidth = $(tagContainer).width();
+      const tagWidths = tagEls.map(widthOf);
+      const minTagWidths = minWidthProbes.map(widthOf);
+      const widthForPlusN = widthOf(overflowPill);
+      minWidthProbes.forEach((probe) => probe.remove());
 
       // Measured off a pill this card owns: a document-wide `.gallery-tag` lookup matches whichever card rendered
-      // first, and matches nothing at all on the first card after a clear — where parseFloat(undefined) then
-      // poisons every comparison below with NaN and buries tags that plainly fit.
+      // first, and matches nothing at all on the first card after a clear — where parseFloat(undefined) turns the
+      // clamp below into NaN, dropping the one thing keeping an ellipsized pill inside the card.
       const MARGIN_BW_TAGS
                 = parseFloat($(tagEls[0]).css('marginLeft')) + parseFloat($(tagEls[0]).css('marginRight'));
-      const WIDTH_FOR_PLUS_N = 30;
-      const MIN_TAG_WIDTH = 75;
-      const tagWidths = tagEls.map((tagEl) => parseFloat($(tagEl).css('width')));
 
       const hiddenTags = [];
       for (let i = 0; i < tagsText.length; i++) {
         const tagEl = tagEls[i];
 
-        // Below MIN_TAG_WIDTH an ellipsized pill reads as nothing, so that budget is the cutoff for showing a tag
-        // at all. Only the last pill can spend the whole remainder: any earlier one has to leave the "+n" its
-        // width, since a tag it pushes out is what puts "+n" there.
+        // Only the last pill can spend the whole remainder: any earlier one has to leave the "+n" its width, since
+        // a tag it pushes out is what puts "+n" there.
         const isLastTag = i === tagsText.length - 1;
-        let tagWidth = tagWidths[i];
+        const reservedForPlusN = (isLastTag && hiddenTags.length === 0) ? 0 : widthForPlusN;
 
-        const extraSpaceNeeded = (isLastTag && hiddenTags.length === 0)
-          ? MARGIN_BW_TAGS
-          : MARGIN_BW_TAGS + WIDTH_FOR_PLUS_N;
-        const spaceForShortenedTag = (isLastTag && hiddenTags.length === 0)
-          ? MIN_TAG_WIDTH
-          : MIN_TAG_WIDTH + WIDTH_FOR_PLUS_N;
-
-        if ((remainingWidth > tagWidth + extraSpaceNeeded)) {
+        if (remainingWidth > tagWidths[i] + reservedForPlusN) {
           // Show the entire tag if there is enough space.
-          remainingWidth -= (tagWidth + MARGIN_BW_TAGS);
-        } else if (remainingWidth > spaceForShortenedTag) {
-          // Show a tag abbreviated with an ellipsis if there's some space, just not enough for the full tag.
-          $(tagEl).css('maxWidth', remainingWidth - extraSpaceNeeded);
-          tagWidth = parseFloat($(tagEl).css('width'));
-          remainingWidth -= (tagWidth + MARGIN_BW_TAGS);
+          remainingWidth -= tagWidths[i];
+        } else if (remainingWidth > minTagWidths[i] + reservedForPlusN) {
+          // Show a tag abbreviated with an ellipsis if there's some space, just not enough for the full tag. The
+          // pill is clamped to exactly the room it was given, so what is left over is the "+n" reserve — measuring
+          // the clamped pill would spend a second layout to learn that.
+          $(tagEl).css('maxWidth', remainingWidth - reservedForPlusN - MARGIN_BW_TAGS);
+          remainingWidth = reservedForPlusN;
           // Since we cut off with an ellipsis, add a tooltip with the full text.
           tagEl.title = tagsText[i];
         } else {
@@ -105,10 +125,8 @@ class TagDisplay {
 
       // If there was not enough space to display all the tags, show the rest in a popover on the '+n' text.
       if (hiddenTags.length > 0) {
-        const additional = document.createElement('div');
-        additional.className = 'gallery-tag additional-count';
-        additional.innerText = ` + ${hiddenTags.length}`;
-        $(additional).popover('destroy').popover({
+        overflowPill.innerText = ` + ${hiddenTags.length}`;
+        $(overflowPill).popover('destroy').popover({
           placement: 'top',
           html: true,
           delay: { show: 300, hide: 10 },
@@ -116,7 +134,8 @@ class TagDisplay {
           trigger: 'hover',
           template: this.#popoverTemplate,
         }).popover('show').popover('hide');
-        $(tagContainer).append(additional);
+      } else {
+        overflowPill.remove();
       }
     }
   }

--- a/test/js/galleryTagDisplay.test.js
+++ b/test/js/galleryTagDisplay.test.js
@@ -2,9 +2,12 @@
  * Tests the Gallery card's tag row, which fits pills into the card in measured pixels (#4691).
  *
  * jsdom has no layout engine, so widths come from a jQuery stand-in that reports whatever each test declares —
- * the same approach anchorPanelToLabel.test.js takes. That is enough to pin the two things that matter here: the
- * fitting arithmetic (which tags show whole, which is ellipsized, which fall into the "+n" popover), and that the
- * measurements are read off pills this card built rather than whatever the document happens to contain.
+ * the same approach anchorPanelToLabel.test.js takes. The stand-in models the page's global `box-sizing: border-box`
+ * the way a browser does: a declared width is the pill's content box, and `outerWidth` adds the padding, border and
+ * margins on top. That is enough to pin the things that matter here: the fitting arithmetic (which tags show whole,
+ * which is ellipsized, which fall into the "+n" popover), that a pill is charged for its own chrome, that a narrow
+ * card still shows a tag rather than a bare "+n" (#5009), and that the measurements are read off pills this card
+ * built rather than whatever the document happens to contain.
  */
 
 const fs = require('fs');
@@ -16,20 +19,21 @@ const SRC = fs.readFileSync(
 
 /** Widths the stub reports, in the units the production code compares: CSS px. */
 const HOLDER_WIDTH = 400;
-const HEADER_WIDTH = 40;
 const TAG_MARGIN = 2;
+const PILL_CHROME = 12; // A pill's own padding + border, which border-box measurements have to pay for.
+const CHAR_PX = 6; // Width of one character, for the strings a test doesn't size by name (probes, the "+n" pill).
 
 /**
  * Installs a jQuery stand-in over the real DOM.
  *
- * Only the handful of calls TagDisplay makes are implemented. `width()` and `css('width')` consult `widthOf`, so a
+ * Only the handful of calls TagDisplay makes are implemented. `width()` and `outerWidth()` consult `widthOf`, so a
  * test can declare what each pill measures; everything else falls through to the real element.
  *
  * A string argument is resolved as a selector and may match nothing, which is the case that matters: jQuery's
  * `.css()` on an empty set returns undefined, and reading a length off undefined is what silently poisons the
  * fitting arithmetic with NaN.
  *
- * @param {function(HTMLElement): number} widthOf - Reports a pill's natural width.
+ * @param {function(HTMLElement): number} widthOf - Reports an element's content-box width.
  * @returns {{layoutReads: number[]}} How many pills were attached at each width read, so batching is observable.
  */
 function stubJQuery(widthOf) {
@@ -44,6 +48,7 @@ function stubJQuery(widthOf) {
         append: () => emptySet,
         popover: () => emptySet,
         width: () => null,
+        outerWidth: () => null,
         css: () => undefined,
     };
     const live = (el) => ({
@@ -59,16 +64,19 @@ function stubJQuery(widthOf) {
         width() {
             return widthOf(el);
         },
+        outerWidth(includeMargin) {
+            reads.push(el.parentElement ? el.parentElement.children.length : 0);
+            // An ellipsized pill is clamped to its max-width, which border-box sizing applies to the whole pill.
+            const max = parseFloat(el.style.maxWidth);
+            const borderBox = Number.isNaN(max)
+                ? widthOf(el) + PILL_CHROME
+                : Math.min(max, widthOf(el) + PILL_CHROME);
+            return borderBox + (includeMargin ? TAG_MARGIN * 2 : 0);
+        },
         css(prop, value) {
             if (value !== undefined) {
                 el.style[prop] = typeof value === 'number' ? `${value}px` : value;
                 return this;
-            }
-            if (prop === 'width') {
-                reads.push(el.parentElement ? el.parentElement.children.length : 0);
-                // An ellipsized pill is clamped to its max-width; otherwise it reports its natural width.
-                const max = parseFloat(el.style.maxWidth);
-                return `${Number.isNaN(max) ? widthOf(el) : Math.min(max, widthOf(el))}px`;
             }
             if (prop === 'marginLeft' || prop === 'marginRight') return `${TAG_MARGIN}px`;
             return '';
@@ -87,16 +95,17 @@ function stubJQuery(widthOf) {
  * Renders a tag row into a fresh card.
  *
  * @param {string[]} tags - Tag names to display.
- * @param {Object<string, number>} widths - Natural width per tag name.
+ * @param {Object<string, number>} widths - Content-box width per tag name; other text is sized by character count.
+ * @param {number} [holderWidth=HOLDER_WIDTH] - The space the tag row has to spend, i.e. the card's width less its
+ *     severity, validation and "Tags" header columns.
  * @returns {{container: HTMLElement, layoutReads: number[]}}
  */
-function render(tags, widths) {
+function render(tags, widths, holderWidth = HOLDER_WIDTH) {
     document.body.innerHTML = '<div class="card-tags" id="1"></div>';
     const container = document.querySelector('.card-tags');
     const probe = stubJQuery((el) => {
-        if (el === container) return HOLDER_WIDTH;
-        if (el.classList.contains('label-tags-header')) return HEADER_WIDTH;
-        return widths[el.textContent] ?? 0;
+        if (el.classList.contains('label-tags-holder')) return holderWidth;
+        return widths[el.textContent] ?? el.textContent.length * CHAR_PX;
     });
     window.eval(`${SRC}\nwindow.TagDisplay = TagDisplay;`);
     new window.TagDisplay(container, tags);
@@ -142,15 +151,15 @@ describe('TagDisplay', () => {
     });
 
     it('moves the tags that do not fit into the "+n" popover', () => {
-        // 350px of room; the first two pills eat 300px + margins, leaving nothing for a third.
-        const {container} = render(['narrow', 'grass', 'uneven'], {narrow: 150, grass: 150, uneven: 150});
+        // 380px of room; the first two pills eat 332px of it, leaving too little for even a stub of a third.
+        const {container} = render(['narrow', 'grass', 'uneven'], {narrow: 150, grass: 150, uneven: 150}, 380);
 
         expect(shownTags(container)).toEqual(['narrow', 'grass']);
         expect(overflowPill(container)).toBe(' + 1');
     });
 
     it('ellipsizes a tag that half fits, and titles it with the full text', () => {
-        // 350px of room, and 250px of it is spent before a 150px pill with only ~100px left arrives.
+        // 400px of room, and 282px of it is spent before a 150px pill with only ~118px left arrives.
         const {container} = render(['narrow', 'grass', 'uneven'], {narrow: 150, grass: 100, uneven: 150});
 
         const last = [...container.querySelectorAll('.thumbnail-tag')].at(-1);
@@ -159,8 +168,26 @@ describe('TagDisplay', () => {
         expect(last.title).toBe('uneven');
     });
 
+    it('counts a pill\'s padding, border and margins against the row', () => {
+        // The tag's text fits the row on its own; the pill it sits in does not, so it has to be cut down.
+        const {container} = render(['narrow'], {narrow: 100}, 110);
+
+        expect(shownTags(container)).toEqual(['narrow']);
+        expect(parseFloat(container.querySelector('.thumbnail-tag').style.maxWidth)).toBeLessThan(110);
+    });
+
+    it('still shows a tag on a card too narrow to hold a whole one', () => {
+        // A phone-width card leaves the row under 100px. A cutoff fixed in px outgrew that budget and buried every
+        // tag behind a bare "+n"; the cutoff a pill actually needs to say something still fits (#5009).
+        const {container} = render(['narrow', 'grass'], {narrow: 150, grass: 150}, 100);
+
+        expect(shownTags(container)).toEqual(['narrow']);
+        expect(container.querySelector('.thumbnail-tag').title).toBe('narrow');
+        expect(overflowPill(container)).toBe(' + 1');
+    });
+
     it('keeps the popover contents out of the card, marked as not shown', () => {
-        const {container} = render(['narrow', 'grass', 'uneven'], {narrow: 150, grass: 150, uneven: 150});
+        const {container} = render(['narrow', 'grass', 'uneven'], {narrow: 150, grass: 150, uneven: 150}, 380);
 
         expect(container.querySelector('.not-added')).toBeNull();
         expect(overflowPill(container)).toBe(' + 1');
@@ -179,8 +206,9 @@ describe('TagDisplay', () => {
     it('reads every pill in one pass, after they are all attached', () => {
         const {layoutReads} = render(['narrow', 'grass', 'uneven'], {narrow: 100, grass: 100, uneven: 100});
 
-        // Interleaving attaches pill n only after measuring pill n-1, so its reads would see 1, then 2, then 3.
-        expect(layoutReads).toEqual([3, 3, 3]);
+        // Three pills, their three minimum-width probes and the "+n" pill: interleaving would attach each one only
+        // after measuring the last, so the reads would climb rather than all seeing the full row.
+        expect(layoutReads).toEqual([7, 7, 7, 7, 7, 7, 7]);
     });
 
     it('renders nothing when the label has no tags', () => {


### PR DESCRIPTION
## Summary

Fixes #5009: at narrow viewports, gallery cards' tag rows (`.card-tags` / `.label-tags-holder`) overflowed the
320px viewport by 9–17px with real label data. Invisible to CI, whose near-empty seed renders `/gallery`
without tag content — it surfaced the first time the e2e suite ran against a seeded dev DB via the dockerized
runner (#4949).

## Root cause

`.card-tags` is a `flex: 1` item with no `min-width: 0`, so its automatic minimum width let the
`white-space: nowrap` tag pills inflate it past the card. That single gap broke two layers at once:

1. **CSS** — the inflated flex item pushed itself (and `.label-tags-holder`, which fills it) past the card edge.
2. **JS** — `TagDisplay.js` decides which tags fit by budgeting against `$(container).width()`. It measures the
   *inflated* container, so every tag appeared to fit and the ellipsize/"+n" trimming logic never ran — the
   exact mechanism that exists to prevent this overflow was disarmed by the width it measured.

One `min-width: 0` on `.card-tags` fixes both: the container caps at the space the card actually has, and the
JS budget measures that real width, so extra tags trim to "+n" as designed. Desktop is unaffected —
`min-width` only bites when content exceeds available space. Also drops an inert `right: 0` from the same rule
(the element isn't positioned).

## Follow-on: the tag fitter was tuned to a desktop-width card

With the container reporting its real width, the trimming logic ran for the first time on a phone-width card —
and buried every tag. It budgeted pills against two fixed pixel constants: a 75px floor below which an
ellipsized pill was judged unreadable, and 30px held back for the "+n". Both were tuned to a ~330px desktop
card, where the row has ~126px to spend. A 320px viewport gives the row ~104px, so the 105px a non-final tag
needed no longer fit and every tag fell into the popover — a card with two tags rendered `Tags + 2` and
nothing else.

Both numbers are now measured off the card in hand rather than hardcoded:

- the readability floor comes from a probe pill carrying that tag's own first six characters, so it tracks the
  pill's padding, the card-relative font size, and the script the tag is written in;
- the "+n" reserve comes from the real "+n" pill at the widest count it could carry (measured 21.7px, not 30px).

The budget itself is read off the tags holder rather than derived from `container − header × 1.25`. The holder
is the flex item that takes what the header leaves, so the estimate's error — 0.5px in English, but ~12px in
Spanish, where "Etiquetas" is twice as wide as "Tags" — goes away. Widths are read through `outerWidth` so a
pill's padding, border and margins are one number, and the "+n" pill is built up front and reused, so both the
probes and the fit ride the existing single batched layout read.

## The /stories half of #5009

Not reproducible: it failed once in the original #4949 full-suite run, then passed six consecutive runs,
including a replay of the original conditions (full phone-viewport file, `--workers=2`). Best guess is a
timing flake around the dev container's storyMedia-404 placeholder mid-load. No blind fix; the issue has the
trail if it recurs.

## Test plan

- [x] `make test-e2e wt=<worktree> args="phone-viewport --workers=2"` against a seeded (teaneck) dev DB:
      **18/18** — previously 2 failed at 320px (`/gallery`, `/stories`)
- [x] Narrow-viewport (320px) subset re-run 4× at `--workers=1`: stable green
- [x] `test/js/galleryTagDisplay.test.js` extended for the narrow-card case and border-box measurement: **9/9**
- [x] Headless Chromium against the shipped CSS at a 300px card: before, two tags rendered no pill and a bare
      `+ 2`; after, the first tag shows ellipsized alongside `+ 1`. A 330px card renders identically before and
      after, and the row stays on one line in every case.
- [x] `eslint` + `stylelint` clean on the touched files
- [x] Manual QA on a seeded local app (`/gallery`, teaneck) at 320/375px and desktop, English and Spanish

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Fable 5, `claude-fable-5`; tag-fitter fix and
review follow-ups by Opus 5 (1M context), `claude-opus-5[1m]`
