### PR TITLE
Keep the label card's meta strip from scrolling the card sideways on phones

### DIFF
--- a/public/css/label-detail.css
+++ b/public/css/label-detail.css
@@ -463,6 +463,19 @@ dialog.label-detail[open]::backdrop {
 .label-detail__meta-row--no-time .label-detail__timestamp-time { display: none; }
 .label-detail__meta-row--compact-details .label-detail__meta-cell--details > span:first-child { display: none; }
 
+/* #fitMetaRow's last resort. The card is a scroll container (overflow-y: auto computes overflow-x to auto), so an
+   unbreakable row that no longer fits scrolls the whole card sideways instead of clipping. */
+.label-detail__meta-row--wrap {
+  flex-wrap: wrap;
+  gap: 4px 16px;
+}
+
+/* Dividers are flex items, so a wrapped row strands one at a line end; key/value pairing separates the facts. */
+.label-detail__meta-row--wrap .label-detail__meta-divider { display: none; }
+
+/* The auto margin would strand Details at the far right of whatever line it lands on. */
+.label-detail__meta-row--wrap .label-detail__meta-cell--details { margin-left: 0; }
+
 /* Addresses can be long; ellipsize instead of widening the row. */
 .label-detail__address {
   min-width: 0;

--- a/public/js/common/label-detail/LabelDetail.js
+++ b/public/js/common/label-detail/LabelDetail.js
@@ -1213,21 +1213,29 @@ class LabelDetail {
   }
 
   /**
-   * Keeps the meta strip on a single line (#4572, Mikey review). CSS makes the address the row's only shrinkable
-   * cell, so it ellipsizes rather than letting the row wrap. When that clipping kicks in, hand the address more
-   * room by dropping the least useful bits in order: first the clock time, then the "Details" word (the ⓘ and its
-   * aria-label remain). Idempotent — it resets to the roomiest state before measuring, so it's safe to re-run on
-   * every address change and on card resize.
+   * Keeps the meta strip on a single line (#4572, Mikey review), giving up room in order: the clock time, then the
+   * "Details" word (the ⓘ and its aria-label remain), then wrapping.
+   *
+   * Out of room means the address clips or the fixed cells overflow the row outright. With no address only the
+   * row's own overflow reports it — unhandled, it scrolls the whole card sideways (#5021).
+   *
+   * Idempotent: resets to the roomiest state before measuring, so it is safe to re-run on every address change and
+   * card resize. Reset and re-measure are synchronous, so the driving ResizeObserver sees no net size change.
    */
   #fitMetaRow() {
     const els = this.#els;
-    if (!els.metaRow || !els.addressCell) return;
-    els.metaRow.classList.remove('label-detail__meta-row--no-time', 'label-detail__meta-row--compact-details');
-    if (els.addressCell.hidden) return; // No address competing for the row → nothing to trim.
-    // +1 absorbs sub-pixel rounding so a flush-fitting address doesn't flap the classes on and off.
-    const addressClipped = () => els.address.scrollWidth > els.address.clientWidth + 1;
-    if (addressClipped()) els.metaRow.classList.add('label-detail__meta-row--no-time');
-    if (addressClipped()) els.metaRow.classList.add('label-detail__meta-row--compact-details');
+    if (!els.metaRow) return;
+    els.metaRow.classList.remove('label-detail__meta-row--no-time', 'label-detail__meta-row--compact-details',
+      'label-detail__meta-row--wrap');
+    // +1 absorbs sub-pixel rounding so a flush-fitting row doesn't flap the classes on and off.
+    const rowOverflows = () => els.metaRow.scrollWidth > els.metaRow.clientWidth + 1;
+    const addressClipped = () => Boolean(els.address) && !els.addressCell?.hidden
+      && els.address.scrollWidth > els.address.clientWidth + 1;
+    const cramped = () => addressClipped() || rowOverflows();
+
+    if (cramped()) els.metaRow.classList.add('label-detail__meta-row--no-time');
+    if (cramped()) els.metaRow.classList.add('label-detail__meta-row--compact-details');
+    if (rowOverflows()) els.metaRow.classList.add('label-detail__meta-row--wrap');
   }
 
   /**

--- a/test/e2e/phone-viewport.spec.js
+++ b/test/e2e/phone-viewport.spec.js
@@ -13,11 +13,15 @@
  * UA those pages currently redirect to /mobileLanding, so listing them today would only re-test it
  * (loadAndSettle's stayed-put URL assert catches a covered page joining that redirect set later).
  *
+ * The label detail card gets its own block at the end, measured against itself: the page walk never opens the
+ * modal, and its `overflow-y: auto` would exempt it from that walk anyway.
+ *
  * Lives apart from explore-validate.spec.js on purpose: that file skips wholesale without a real Google Maps
  * key (absent on fork PRs), and nothing here needs one.
  */
 const {devices} = require('@playwright/test');
-const {test, expect, loadAndSettle, horizontalOverflowReport, STORAGE_STATE} = require('./fixtures');
+const {test, expect, stubMapbox, waitForAppReady, loadAndSettle, horizontalOverflowReport, STORAGE_STATE} =
+  require('./fixtures');
 
 // devices['iPhone 13'] supplies the mobile UA, touch support and DPR. defaultBrowserType is dropped because the
 // suite's chromium project already fixes the browser, and the viewport is widened to the full 390×844 screen.
@@ -86,6 +90,112 @@ test.describe('narrow phone viewport (320px)', () => {
       await checkPhoneViewport(page, context, consoleErrors, p);
     });
   }
+});
+
+/**
+ * Finds a label near the city center from the label feed.
+ *
+ * @param {import('@playwright/test').Page} page - The test's page, used only for its request context.
+ * @returns {Promise<Object|null>} The label's GeoJSON feature, or null when the database has none there (CI's
+ *   near-empty seed).
+ */
+let cachedLabelFeature; // The feed fetch dominates these tests' runtime on a seeded dev DB; one fetch serves all.
+async function findLabelFeature(page) {
+  if (cachedLabelFeature !== undefined) return cachedLabelFeature;
+  const {city_center: center} = await (await page.request.get('/cityMapParams')).json();
+  const pad = 0.05;
+  const bbox = [center.lng - pad, center.lat - pad, center.lng + pad, center.lat + pad].join(',');
+  const feed = await (await page.request.get(`/labels/all?bbox=${bbox}`)).json();
+  cachedLabelFeature = feed.features?.[0] ?? null;
+  return cachedLabelFeature;
+}
+
+/**
+ * Opens a label's detail card by deep link and asserts it doesn't scroll sideways.
+ *
+ * Measured against the card rather than the viewport: horizontalOverflowReport exempts the descendants of a
+ * horizontal scroller, and the card's `overflow-y: auto` computes `overflow-x` to `auto` on the same box. The
+ * meta strip is measured too — it is the row that overflows first, its cells fixed-width but for the address.
+ *
+ * Skips when the database has no label to open (CI's near-empty seed).
+ *
+ * @param {import('@playwright/test').Page} page - The test's page, already at a phone viewport.
+ * @param {Object} [opts] - Options.
+ * @param {boolean} [opts.withoutAddress=false] - Measure with the address cell hidden: the state a label whose
+ *   imagery is gone lands in, leaving no shrinkable cell to absorb a narrow card.
+ */
+async function checkLabelCardFits(page, {withoutAddress = false} = {}) {
+  // Slow from the first step: these load map + modal + pano late in a full run, when the shared browser is heaviest.
+  test.slow();
+  const feature = await findLabelFeature(page);
+  test.skip(!feature, 'the connected database has no labels near the city center');
+  // The page's own feed is stubbed to just this label: the card needs only its one marker, and rendering a
+  // full-city feed can crash the 320px tab outright.
+  await page.route('**/labels/all*', route => route.fulfill({
+    contentType: 'application/json',
+    body: JSON.stringify({type: 'FeatureCollection', features: [feature]}),
+  }));
+  await page.goto(`/labelMap?labelId=${feature.properties.label_id}`);
+  await waitForAppReady(page);
+  await expect(page.locator('#label-modal')).toBeVisible({timeout: 30_000});
+  // The strip refits when the address resolves from the loaded imagery, which is after the card first paints.
+  await page.waitForTimeout(2000);
+
+  if (withoutAddress) {
+    // Hidden rather than stubbed out of the metadata: the loaded imagery re-supplies an address, so a label served
+    // without one still gets one once its pano loads. Hiding the cell is the state #showAddress itself reaches,
+    // and it re-runs the fitter through the same ResizeObserver production uses.
+    await page.evaluate(() => {
+      document.querySelector('.label-detail__meta-cell--address').hidden = true;
+      document.querySelector('.label-detail__meta-divider--address').hidden = true;
+    });
+    await page.waitForTimeout(600);
+  }
+
+  const fit = await page.evaluate(() => {
+    const card = document.getElementById('label-modal');
+    const row = card.querySelector('.label-detail__meta-row');
+    return {
+      cardScrollWidth: card.scrollWidth,
+      cardClientWidth: card.clientWidth,
+      rowScrollWidth: row.scrollWidth,
+      rowClientWidth: row.clientWidth,
+      rowClasses: row.className,
+    };
+  });
+  expect(fit.cardScrollWidth, `the label card scrolls sideways: ${JSON.stringify(fit)}`)
+    .toBeLessThanOrEqual(fit.cardClientWidth + 1);
+  expect(fit.rowScrollWidth, `the meta strip overflows its row: ${JSON.stringify(fit)}`)
+    .toBeLessThanOrEqual(fit.rowClientWidth + 1);
+}
+
+// The label detail card (#4572) is a modal over the map, so the page walk above never opens it. Three cases,
+// because the strip runs out of room two ways: with an address it shrinks that cell and then wraps; without one
+// there is nothing to shrink and the fixed facts have to be trimmed. Same seed caveat as the card grids — with
+// no labels in the database there is nothing to open, and these skip.
+test.describe('phone viewport (390px), label detail card', () => {
+  test.use(IPHONE);
+
+  test('an open label card fits', async ({page, context}) => {
+    await stubMapbox(context);
+    await checkLabelCardFits(page);
+  });
+
+  // The reported case (#5021): the fixed facts needed 388px in a 317px strip, scrolling the whole card ~50px
+  // sideways with its title, section headings and footer buttons clipped off the left edge.
+  test('an open label card fits with no address to shrink', async ({page, context}) => {
+    await stubMapbox(context);
+    await checkLabelCardFits(page, {withoutAddress: true});
+  });
+});
+
+test.describe('narrow phone viewport (320px), label detail card', () => {
+  test.use({...IPHONE, viewport: {width: 320, height: 653}});
+
+  test('an open label card fits', async ({page, context}) => {
+    await stubMapbox(context);
+    await checkLabelCardFits(page);
+  });
 });
 
 test.describe('phone viewport (390px), registered user', () => {


### PR DESCRIPTION
Fixes #5021.

On a phone-width viewport, a label whose imagery is gone (so no address resolves) made the whole detail card scroll sideways — title, section headings, and footer buttons clipped off the left edge. Root cause and measurements are in the issue; in short, `#fitMetaRow()` bailed out entirely when the address cell was hidden, and the card's `overflow-y: auto` turned the resulting row overflow into a horizontal scroll of the entire card.

## Changes

- **`LabelDetail.js`** — `#fitMetaRow()` treats "out of room" as *either* the address clipping *or* the meta row overflowing itself, so an address-less card gets the same two trims (drop the clock time, then the "Details" word — the ⓘ and its aria-label remain).
- **`label-detail.css`** — a `--wrap` last resort: when both trims are spent and the row still overflows (320px, or narrow cards with an address), the row wraps instead of scrolling the card. Wrapped rows drop the `|` dividers, which otherwise strand one at a line end.
- **`phone-viewport.spec.js`** — three regression cases (390px, 390px with the address hidden, 320px), each measuring the card's own `scrollWidth` and the meta strip's. The existing page-level overflow walk exempts descendants of a horizontal scroller — its docstring names that blind spot — so it structurally can't catch this. The tests stub the page's `/labels/all` feed down to the one label under test: they only need its marker, and rendering a full-city feed (which develop serves until #5002 narrows it to the viewport) can crash the 320px tab outright.

## Testing

- Full `phone-viewport.spec.js` via `make test-e2e` against this branch on a seeded dev DB: 18 passed including the 3 new cases; the only failures are the two `/dashboard` tests that need the auth setup project skipped by `--no-deps`.
- `eslint` + `stylelint` clean on the touched files.
- Desktop unaffected — verified at 1440px: no trim classes, full timestamp with clock time, "Details" word intact, single line.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Fable 5, claude-fable-5

https://claude.ai/code/session_01VrYJNgvLirxQr3uV9Rw9tv
