### PR TITLE
Teach the imagery scan to check Infra3d streets

### DIFF
--- a/app/service/ImageryFreshnessService.scala
+++ b/app/service/ImageryFreshnessService.scala
@@ -239,6 +239,12 @@ class ImageryFreshnessServiceImpl @Inject() (
               new MissingImageryCredentialException("No mapillary-access-token configured for a Mapillary city.")
             )
         }
+      // Infra3d is deliberately not polled, though it could be: scripts/check_streets_for_imagery.py --infra3d shows
+      // the query (framegate's nearest-frame `knn/query`, with the token PanoDataService.getInfra3dToken mints, and
+      // the frame `timestamp` as the capture date). It isn't worth a nightly run because each Infra3d city is a single
+      // commissioned drive -- one campaign, whose project_uid is hardcoded per city in Infra3dViewer.js -- so the
+      // dates never change on their own. A fresh drive would arrive as a new campaign/project needing that hardcoded
+      // id updated anyway, which is the moment to add a fetchInfra3dPointObservations here.
       case other =>
         Future.successful(PollResult.notPolled(s"Imagery-age polling isn't supported for provider $other; skipping."))
     }

--- a/public/js/common/pano-viewer/src/Infra3dViewer.js
+++ b/public/js/common/pano-viewer/src/Infra3dViewer.js
@@ -14,7 +14,10 @@ class Infra3dViewer extends PanoViewer {
   async initialize(canvasElem, panoOptions = {}) {
     const manager = await infra3dapi.init(canvasElem.id, panoOptions.accessToken);
 
-    // Each city has their own project_UID. Faster to hard code it rather than fetching projects in real time.
+    // Each city has their own project_UID. Faster to hard code it rather than fetching projects in real time. A
+    // project is one commissioned drive (a single campaign), so a city getting new imagery means a new project whose
+    // id has to be swapped in here -- which is also why nothing polls Infra3d for imagery age (see
+    // ImageryFreshnessService.pollImageryAges).
     const projectId = window.cityId === 'winterthur-infra3d'
       ? 'ab6045da-46b4-44d2-8123-e19c7cdbe7ea'
       : 'bd8196f8-dbe5-4e67-849f-977452fe7587';

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -55,7 +55,8 @@ Standalone and manual — nothing in the app calls it.
    ```bash
    python3.13 scripts/check_streets_for_imagery.py --gsv         # needs GOOGLE_MAPS_API_KEY
    python3.13 scripts/check_streets_for_imagery.py --mapillary   # needs MAPILLARY_ACCESS_TOKEN
-   python3.13 scripts/check_streets_for_imagery.py --infra3d     # needs INFRA3D_CLIENT_ID + INFRA3D_CLIENT_SECRET
+   python3.13 scripts/check_streets_for_imagery.py --infra3d     # needs INFRA3D_CLIENT_ID + INFRA3D_CLIENT_SECRET;
+                                                                 # add --campaign <uid> if the tenant has several
    ```
    It checks each street's endpoints first, then samples points along the street, and flags streets where enough points
    lack imagery. It writes streets without imagery to `db/streets_with_no_imagery.csv`, and a per-street imagery
@@ -80,6 +81,11 @@ differ from the other providers:
 - Frames are filtered server-side to 360° types (`calotte`/`cubemap`), matching the viewer's `setFilter` — Infra3d
   datasets mix in flat mono/stereo photos that Explore can't label on, so a street with only flat frames counts as
   having no imagery.
+- Frames are also restricted to a **campaign** (one drive). The viewer restricts every query to its project's
+  campaigns (the `project_uid` hardcoded in `Infra3dViewer.js`), but our credentials can't read the project, so the
+  scan lists the tenant's campaigns at startup instead: with one campaign (every city today) it's used automatically
+  and printed; with several, the scan lists them and stops until you pass `--campaign <uid>` (repeatable). Without
+  this, frames from any other drive in the tenant would count as imagery Explore can't actually reach.
 
 The token lives 60 minutes and is refreshed automatically during a long scan. Infra3d publishes no rate limit; the
 default `--max-qps 10` is in the range of a single busy browser session, so keep it there (or lower) rather than

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -46,8 +46,8 @@ dependencies must be installed in the `python3` interpreter the app shells out t
 
 ## `check_streets_for_imagery.py`
 
-Finds streets lacking street-view imagery (Google Street View or Mapillary) and writes them to a CSV. Standalone and
-manual — nothing in the app calls it.
+Finds streets lacking street-view imagery (Google Street View, Mapillary, or Infra3d) and writes them to a CSV.
+Standalone and manual — nothing in the app calls it.
 
 1. Export a CSV of the `street_edge` table with columns `street_edge_id, region_id, x1, y1, x2, y2, geom` (geom as WKB
    hex), named `street_edge_endpoints.csv`, in the repo root.
@@ -55,6 +55,7 @@ manual — nothing in the app calls it.
    ```bash
    python3.13 scripts/check_streets_for_imagery.py --gsv         # needs GOOGLE_MAPS_API_KEY
    python3.13 scripts/check_streets_for_imagery.py --mapillary   # needs MAPILLARY_ACCESS_TOKEN
+   python3.13 scripts/check_streets_for_imagery.py --infra3d     # needs INFRA3D_CLIENT_ID + INFRA3D_CLIENT_SECRET
    ```
    It checks each street's endpoints first, then samples points along the street, and flags streets where enough points
    lack imagery. It writes streets without imagery to `db/streets_with_no_imagery.csv`, and a per-street imagery
@@ -64,14 +65,34 @@ manual — nothing in the app calls it.
 Optional flags: `--workers N` (streets checked concurrently, default 8) and `--max-qps F` (global cap on requests per
 second across all workers, default 10 — deliberately conservative; Google allows ~500/s).
 
+### Infra3d
+
+Infra3d has no metadata endpoint, so `--infra3d` uses the nearest-frame query (`framegate`'s `knn/query`) that the
+vendored viewer SDK issues on every `setLocation` — the same request a labeler's browser makes as they move — with the
+same per-city OAuth client credentials the app uses (`PanoDataService.getInfra3dToken`). Export **one** city's pair as
+`INFRA3D_CLIENT_ID` / `INFRA3D_CLIENT_SECRET` (in the web container they're `INFRA3D_CLIENT_ID_ZURICH`,
+`..._WINTERTHUR`, etc.); the tenant to query comes from the token's own scope, so nothing else is per-city. Two things
+differ from the other providers:
+
+- The query returns the nearest frame **with no distance cap** (a point far outside the city still gets the city's
+  closest frame), so "has imagery" is decided client-side: the nearest frame within the same 25 m (endpoints) / 15 m
+  (along-street) radius GSV uses.
+- Frames are filtered server-side to 360° types (`calotte`/`cubemap`), matching the viewer's `setFilter` — Infra3d
+  datasets mix in flat mono/stereo photos that Explore can't label on, so a street with only flat frames counts as
+  having no imagery.
+
+The token lives 60 minutes and is refreshed automatically during a long scan. Infra3d publishes no rate limit; the
+default `--max-qps 10` is in the range of a single busy browser session, so keep it there (or lower) rather than
+raising it.
+
 ### Imagery age
 
-The GSV metadata responses we already fetch also carry an imagery capture `date`, so — for **no extra API calls** — the
-scan records each street's capture-date range (oldest/newest) and pano count into `db/street_imagery_summary.csv`
+The GSV and Infra3d responses we already fetch also carry an imagery capture date, so — for **no extra API calls** —
+the scan records each street's capture-date range (oldest/newest) and pano count into `db/street_imagery_summary.csv`
 (`street_edge_id, region_id, has_imagery, oldest_capture, newest_capture, n_panos`). That tells us not just whether a
-street has imagery but how old it is. Mapillary capture dates are a future enhancement (GSV only for now). Persisting
-this into the database — to power a "stale imagery" signal alongside the `street_edge_status` work (#3888) — is tracked
-as a separate follow-up (#4348).
+street has imagery but how old it is. Mapillary capture dates are a future enhancement. Persisting this into the
+database — to power a "stale imagery" signal alongside the `street_edge_status` work (#3888) — is tracked as a
+separate follow-up (#4348).
 
 ### Resilience & resume
 
@@ -105,7 +126,7 @@ from it on purpose, because the two tools answer different questions:
 - **Concurrency — conservative threads, not async.** GSV Tracker uses `asyncio`/`aiohttp` tuned for maximum throughput
   (toward Google's ~500 req/s ceiling). We use a small thread pool + a token-bucket QPS cap and deliberately stay well
   under the limit; at that bounded concurrency, threads are simpler and sufficient and async's scale benefit is wasted.
-- **Providers — GSV *and* Mapillary.** GSV Tracker is GSV-only.
+- **Providers — GSV, Mapillary, *and* Infra3d.** GSV Tracker is GSV-only.
 
 ## Persisting imagery age to the database (#4348)
 

--- a/scripts/check_streets_for_imagery.py
+++ b/scripts/check_streets_for_imagery.py
@@ -13,8 +13,9 @@ This is a standalone, manually-run utility (it is not invoked by the app). Workf
 
      ``--gsv`` needs ``GOOGLE_MAPS_API_KEY``; ``--mapillary`` needs ``MAPILLARY_ACCESS_TOKEN``; ``--infra3d`` needs
      ``INFRA3D_CLIENT_ID`` and ``INFRA3D_CLIENT_SECRET`` (one city's pair — the same OAuth client-credentials the app
-     holds per city as ``INFRA3D_CLIENT_ID_<CITY>``). It is ``python3.13`` rather than the container's default
-     ``python3`` because this tool's libraries need Python >= 3.11.
+     holds per city as ``INFRA3D_CLIENT_ID_<CITY>``), plus ``--campaign <uid>`` if the city's tenant holds more than
+     one campaign. It is ``python3.13`` rather than the container's default ``python3`` because this tool's libraries
+     need Python >= 3.11.
   3. It writes streets without imagery to ``db/streets_with_no_imagery.csv``, and a per-street imagery summary
      (presence + capture-date range) to ``db/street_imagery_summary.csv``.
   4. Run ``make hide-streets-without-imagery`` to mark those streets in the database.
@@ -33,7 +34,10 @@ per-city OAuth token the app fetches in ``PanoDataService.getInfra3dToken``. The
 frame with no distance cap, so "imagery here" is decided client-side: the nearest 360° frame within the same 25 m /
 15 m radius GSV bakes into its URL. Flat mono/stereo frames are filtered out server-side, matching the viewer's
 ``setFilter(['in', 'cameraType', 'calotte', 'cubemap'])`` — an Infra3d street with only flat photos is unusable for
-labeling and should count as having no imagery.
+labeling and should count as having no imagery. The viewer also scopes every frame query to its project's campaigns
+(the ``project_uid`` hardcoded in ``Infra3dViewer.js``); our M2M credentials can't read a project, so the scan scopes
+to the tenant's campaign list instead -- the one campaign a city tenant holds today, or the ``--campaign`` uid(s)
+chosen by the operator once there are several -- so it never counts frames Explore can't navigate to.
 
 Resilience (so a long scan survives a flaky network): each request is retried with exponential backoff; a street that
 still fails is logged and the scan continues rather than aborting, and the failed set is retried once at the end (any
@@ -42,7 +46,7 @@ still-failing streets land in ``db/failed_streets.csv``). Progress is checkpoint
 streets. The final ``db/streets_with_no_imagery.csv`` is derived from the checkpoint, so its schema is unchanged.
 
 The pure functions (``create_bounding_box``, ``redistribute_vertices``, ``gsv_has_imagery``, ``mapillary_has_imagery``,
-``infra3d_pano_info``, ``standardize_capture_date``, ``gsv_capture_date``, ``imagery_verdict``,
+``infra3d_pano_info``, ``infra3d_campaigns``, ``standardize_capture_date``, ``gsv_capture_date``, ``imagery_verdict``,
 ``street_has_no_imagery``, ``summarize_dates``) are import-safe and unit-tested in
 ``test/python/test_check_streets_for_imagery.py``; network and file I/O live in thin wrappers and ``main``.
 
@@ -134,6 +138,9 @@ INFRA3D_API_URL = 'https://api.infra3d.com/framegate'
 INFRA3D_API_KEY = '6zGSQ8u14j3AqL8myGcP54rbXS9aLCpr6lY99B9F'
 # 360° frames only, matching Infra3dViewer's setFilter: Explore can't label on Infra3d's flat mono/stereo photos.
 INFRA3D_PANO_FILTER = "type in '(calotte, cubemap)'"
+# Lists a tenant's campaigns (drives). The viewer restricts frames to its project's campaigns and we can't read the
+# project with M2M credentials, so the campaign list is how the scan learns what to restrict to.
+INFRA3D_CAMPAIGNS_URL = '%s/campaigns/%s/query'
 # Infra3d access tokens live 60 minutes; refresh this many seconds before expiry so a long scan never sends a stale one.
 INFRA3D_TOKEN_REFRESH_MARGIN = 300
 
@@ -165,6 +172,9 @@ StreetResult = namedtuple('StreetResult', CHECKPOINT_COLUMNS)
 
 # Imagery seen at one queried location: whether imagery is present and its (standardized) capture date, if any.
 PanoInfo = namedtuple('PanoInfo', ['has_imagery', 'capture_date'])
+
+# What an Infra3d scan needs per request: the token holder and the campaign uids every frame query is restricted to.
+Infra3dScan = namedtuple('Infra3dScan', ['auth', 'campaign_uids'])
 
 
 class ImageryApiError(Exception):
@@ -203,13 +213,19 @@ class Infra3dAuth:
         if response.status_code != 200:
             raise ImageryApiError('Infra3d token request failed with status %d: %s' % (response.status_code,
                                                                                       response.text))
-        self._token = response.json()['access_token']
-        claims = _jwt_claims(self._token)
-        self._expires_at = claims['exp']
-        tenants = [s.split('/', 1)[1] for s in claims.get('scope', '').split() if s.startswith('framegate/')]
-        if not tenants:
-            raise ImageryApiError('Infra3d token carries no framegate/<tenant> scope: %s' % claims.get('scope'))
-        self.tenant = tenants[0]
+        # Validate everything into locals before touching self: a refresh that fails halfway must not leave a fresh
+        # expiry next to a stale tenant, or the next headers() call would skip the refresh and stop raising.
+        try:
+            token = response.json()['access_token']
+            claims = _jwt_claims(token)
+            expires_at = claims['exp']
+            scope = claims.get('scope', '')
+        except (KeyError, IndexError, TypeError, ValueError, AttributeError) as err:
+            raise ImageryApiError('unexpected Infra3d token response: %r' % err) from err
+        tenants = [s.split('/', 1)[1] for s in scope.split() if s.startswith('framegate/')]
+        if len(tenants) != 1:
+            raise ImageryApiError('Infra3d token must carry exactly one framegate/<tenant> scope, got: %s' % scope)
+        self._token, self._expires_at, self.tenant = token, expires_at, tenants[0]
 
     def headers(self):
         """Returns the auth headers for a framegate request, minting/refreshing the token first if needed."""
@@ -387,17 +403,45 @@ def infra3d_pano_info(response_json, lat, lng, radius_km):
         A ``PanoInfo``: imagery present iff the nearest frame is within the radius, with that frame's capture date.
 
     Raises:
-        ImageryApiError: If the response has no ``value`` list (auth failure, bad request, ...).
+        ImageryApiError: If the response has no ``value`` list (auth failure, bad request, ...) or a frame is malformed.
     """
-    frames = response_json.get('value') if isinstance(response_json, dict) else None
-    if not isinstance(frames, list):
-        raise ImageryApiError('unexpected Infra3d response: ' + json.dumps(response_json)[:200])
+    frames = _infra3d_value_list(response_json)
     if not frames:
         return PanoInfo(False, None)
-    nearest = min(frames, key=lambda f: geodesic((lat, lng), (f['latitude'], f['longitude'])).km)
-    if geodesic((lat, lng), (nearest['latitude'], nearest['longitude'])).km > radius_km:
-        return PanoInfo(False, None)
-    return PanoInfo(True, standardize_capture_date((nearest.get('timestamp') or '')[:10]))
+    try:
+        nearest = min(frames, key=lambda f: geodesic((lat, lng), (f['latitude'], f['longitude'])).km)
+        if geodesic((lat, lng), (nearest['latitude'], nearest['longitude'])).km > radius_km:
+            return PanoInfo(False, None)
+        return PanoInfo(True, standardize_capture_date((nearest.get('timestamp') or '')[:10]))
+    except (KeyError, TypeError, ValueError, AttributeError) as err:
+        raise ImageryApiError('malformed Infra3d frame: %r' % err) from err
+
+
+def infra3d_campaigns(response_json):
+    """
+    Interprets an Infra3d campaign-list (``campaigns/{tenant}/query``) response.
+
+    Args:
+        response_json: The decoded JSON from the framegate campaigns endpoint (``{"value": [campaign, ...]}``).
+
+    Returns:
+        ``(uid, name)`` pairs, one per campaign, in the API's order.
+
+    Raises:
+        ImageryApiError: If the response has no ``value`` list or a campaign has no ``uid``.
+    """
+    try:
+        return [(c['uid'], c.get('name')) for c in _infra3d_value_list(response_json)]
+    except (KeyError, TypeError, AttributeError) as err:
+        raise ImageryApiError('malformed Infra3d campaign: %r' % err) from err
+
+
+def _infra3d_value_list(response_json):
+    """Returns the ``value`` list of a framegate query response, or raises ``ImageryApiError`` if there isn't one."""
+    value = response_json.get('value') if isinstance(response_json, dict) else None
+    if not isinstance(value, list):
+        raise ImageryApiError('unexpected Infra3d response: ' + json.dumps(response_json)[:200])
+    return value
 
 
 def imagery_verdict(n_fail, n_success, n_coords, endpoint_failed):
@@ -508,17 +552,56 @@ def _mapillary_bbox_url(mapillary_url, lat, lng, radius_km):
     return mapillary_url + '&bbox=' + ','.join(str(coord) for coord in bbox)
 
 
-def _infra3d_knn_url(tenant, lat, lng):
-    """Builds the framegate nearest-360°-frame query URL for a point."""
+def _infra3d_frame_filter(campaign_uids):
+    """The framegate ``filter`` restricting frames to 360° types within the given campaigns, as the viewer does."""
+    return "%s and campaign_uid in '(%s)'" % (INFRA3D_PANO_FILTER, ', '.join(campaign_uids))
+
+
+def _infra3d_knn_url(tenant, lat, lng, campaign_uids):
+    """Builds the framegate nearest-360°-frame query URL for a point, scoped to ``campaign_uids``."""
     return '%s/frames/%s/knn/query?longitude=%s&latitude=%s&filter=%s' % (
-        INFRA3D_API_URL, tenant, lng, lat, quote(INFRA3D_PANO_FILTER, safe=''))
+        INFRA3D_API_URL, tenant, lng, lat, quote(_infra3d_frame_filter(campaign_uids), safe=''))
 
 
-def _infra3d_point_pano_info(auth, lat, lng, radius_km, fetch):
+def _infra3d_point_pano_info(infra3d, lat, lng, radius_km, fetch):
     """Queries Infra3d for the nearest 360° frame to a point (via ``fetch``) and returns its ``PanoInfo``."""
-    headers = auth.headers()  # Before the URL: minting the token is what populates auth.tenant.
-    response = fetch(_infra3d_knn_url(auth.tenant, lat, lng), method='POST', headers=headers)
-    return infra3d_pano_info(response, lat, lng, radius_km)
+    headers = infra3d.auth.headers()  # Before the URL: minting the token is what populates auth.tenant.
+    url = _infra3d_knn_url(infra3d.auth.tenant, lat, lng, infra3d.campaign_uids)
+    return infra3d_pano_info(fetch(url, method='POST', headers=headers), lat, lng, radius_km)
+
+
+def _infra3d_list_campaigns(auth, fetch):
+    """Lists the campaigns the token's tenant holds, as ``(uid, name)`` pairs."""
+    headers = auth.headers()
+    return infra3d_campaigns(fetch(INFRA3D_CAMPAIGNS_URL % (INFRA3D_API_URL, auth.tenant), method='POST',
+                                   headers=headers))
+
+
+def choose_infra3d_campaigns(campaigns, requested):
+    """
+    Picks the campaign uids an Infra3d scan is restricted to.
+
+    Args:
+        campaigns: ``(uid, name)`` pairs of every campaign in the tenant.
+        requested: Campaign uids named on the command line (may be empty).
+
+    Returns:
+        ``requested`` if given, else the tenant's only campaign.
+
+    Raises:
+        ValueError: If a requested uid isn't in the tenant, or nothing was requested and the tenant holds zero or
+                    several campaigns (the message lists them, so the operator can pick with ``--campaign``).
+    """
+    known = {uid for uid, _ in campaigns}
+    if requested:
+        unknown = [uid for uid in requested if uid not in known]
+        if unknown:
+            raise ValueError('campaign(s) not in this tenant: %s' % ', '.join(unknown))
+        return list(requested)
+    if len(campaigns) != 1:
+        listing = ''.join('\n  %s  %s' % c for c in campaigns) or ' (none)'
+        raise ValueError('tenant holds %d campaigns; pick with --campaign <uid>:%s' % (len(campaigns), listing))
+    return [campaigns[0][0]]
 
 
 def _pano_info(api, response_json):
@@ -533,26 +616,27 @@ def _pano_info(api, response_json):
     return PanoInfo(mapillary_has_imagery(response_json), None)
 
 
-def _point_pano_info(api, lat, lng, fetch, gsv_url, mapillary_url, radius_km, infra3d_auth=None):
+def _point_pano_info(api, lat, lng, fetch, gsv_url, mapillary_url, radius_km, infra3d=None):
     """
     Queries the configured provider at one point (via ``fetch``) and returns its ``PanoInfo``.
 
     ``radius_km`` is the Mapillary bbox half-extent / Infra3d max frame distance; GSV bakes its radius into ``gsv_url``.
+    ``infra3d`` is the ``Infra3dScan`` (token holder + campaign scope), needed only for that provider.
     """
     if api == 'GSV':
         return _pano_info(api, fetch(gsv_url + '&location=' + str(lat) + ',' + str(lng)))
     if api == 'Infra3d':
-        return _infra3d_point_pano_info(infra3d_auth, lat, lng, radius_km, fetch)
+        return _infra3d_point_pano_info(infra3d, lat, lng, radius_km, fetch)
     return _pano_info(api, fetch(_mapillary_bbox_url(mapillary_url, lat, lng, radius_km)))
 
 
-def _check_endpoints(street, api, fetch, gsv_url_endpoint, mapillary_url, infra3d_auth=None):
+def _check_endpoints(street, api, fetch, gsv_url_endpoint, mapillary_url, infra3d=None):
     """Checks both of a street's endpoints; returns ``(first_pano_info, second_pano_info)``."""
     # GSV carries its radius in the URL, so the endpoint URL goes where the along-street point URL normally would.
     first = _point_pano_info(api, street.y1, street.x1, fetch, gsv_url_endpoint, mapillary_url, ENDPOINT_RADIUS_KM,
-                             infra3d_auth)
+                             infra3d)
     second = _point_pano_info(api, street.y2, street.x2, fetch, gsv_url_endpoint, mapillary_url, ENDPOINT_RADIUS_KM,
-                              infra3d_auth)
+                              infra3d)
     return first, second
 
 
@@ -571,7 +655,7 @@ def summarize_dates(dates):
     return min(dates), max(dates), len(dates)
 
 
-def process_street(street, api, fetch, gsv_url, gsv_url_endpoint, mapillary_url, infra3d_auth=None):
+def process_street(street, api, fetch, gsv_url, gsv_url_endpoint, mapillary_url, infra3d=None):
     """
     Checks one street for imagery and returns its outcome (pure of any file/checkpoint I/O, so it is pool-safe).
 
@@ -586,7 +670,7 @@ def process_street(street, api, fetch, gsv_url, gsv_url_endpoint, mapillary_url,
         gsv_url:          GSV metadata base URL with the along-street radius baked in (GSV only).
         gsv_url_endpoint: GSV metadata base URL with the endpoint radius baked in (GSV only).
         mapillary_url:    Mapillary images base URL (Mapillary only).
-        infra3d_auth:     An ``Infra3dAuth`` supplying the tenant and bearer headers (Infra3d only).
+        infra3d:          An ``Infra3dScan`` (token holder + campaign scope) (Infra3d only).
 
     Returns:
         A ``StreetResult`` with outcome ``NO_IMAGERY`` / ``HAS_IMAGERY`` / ``FAILED`` and, for settled streets, the
@@ -594,7 +678,7 @@ def process_street(street, api, fetch, gsv_url, gsv_url_endpoint, mapillary_url,
         early-exit point sampling means no extra API calls are made.
     """
     try:
-        first, second = _check_endpoints(street, api, fetch, gsv_url_endpoint, mapillary_url, infra3d_auth)
+        first, second = _check_endpoints(street, api, fetch, gsv_url_endpoint, mapillary_url, infra3d)
         coords = list(street['geom'].coords)
         dates = [d for d in (first.capture_date, second.capture_date) if d]
 
@@ -606,7 +690,7 @@ def process_street(street, api, fetch, gsv_url, gsv_url_endpoint, mapillary_url,
             # real street, which has >= 2 points), so the generator is abandoned rather than run to completion.
             for coord in coords:  # pragma: no branch  -- Shapely coords are (x=lng, y=lat).
                 info = _point_pano_info(api, coord[1], coord[0], fetch, gsv_url, mapillary_url, POINT_RADIUS_KM,
-                                        infra3d_auth)
+                                        infra3d)
                 if info.capture_date:
                     dates.append(info.capture_date)
                 yield info.has_imagery
@@ -686,7 +770,7 @@ def main(argv=None):
         argv: Optional argument list (defaults to ``sys.argv``); accepted to make the entrypoint testable.
 
     Returns:
-        Process exit code: 0 on success, 1 on a missing API key or a user interrupt.
+        Process exit code: 0 on success, 1 on a missing API key, an unusable Infra3d setup, or a user interrupt.
     """
     parser = argparse.ArgumentParser(
         description='Loops through streets, outputting any without imagery to a separate file.')
@@ -696,26 +780,37 @@ def main(argv=None):
                           help='Check for Mapillary imagery (needs MAPILLARY_ACCESS_TOKEN)')
     provider.add_argument('--infra3d', action='store_true',
                           help='Check for Infra3d imagery (needs INFRA3D_CLIENT_ID + INFRA3D_CLIENT_SECRET)')
+    parser.add_argument('--campaign', action='append', default=[], metavar='UID',
+                        help='Infra3d campaign to count imagery from (repeatable). Required only when the tenant '
+                             'holds more than one campaign; the scan lists them if so.')
     parser.add_argument('--workers', type=int, default=DEFAULT_WORKERS,
                         help='Number of streets to check concurrently (default: %(default)s).')
     parser.add_argument('--max-qps', type=float, default=DEFAULT_MAX_QPS,
                         help='Global cap on requests per second across all workers (default: %(default)s).')
     args = parser.parse_args(argv)
     api = 'GSV' if args.gsv else 'Mapillary' if args.mapillary else 'Infra3d'
+    # One shared rate limiter caps total request rate across all worker threads.
+    fetch = make_fetch(rate_limiter=RateLimiter(args.max_qps))
 
     api_key = None
-    infra3d_auth = None
+    infra3d = None
     if api == 'Infra3d':
         client_id, client_secret = os.getenv('INFRA3D_CLIENT_ID'), os.getenv('INFRA3D_CLIENT_SECRET')
         if client_id is None or client_secret is None:
             print("Couldn't read INFRA3D_CLIENT_ID / INFRA3D_CLIENT_SECRET environment variables.")
             return 1
-        infra3d_auth = Infra3dAuth(client_id, client_secret)
+        auth = Infra3dAuth(client_id, client_secret)
         try:
-            infra3d_auth.headers()  # Mint the first token up front so bad credentials fail fast, not per street.
-        except (requests.exceptions.RequestException, ImageryApiError) as err:
-            print("Couldn't get an Infra3d access token: %s" % err)
+            # Minting the token and listing campaigns up front makes bad credentials fail fast, not per street.
+            campaigns = _infra3d_list_campaigns(auth, fetch)
+            campaign_uids = choose_infra3d_campaigns(campaigns, args.campaign)
+        except (requests.exceptions.RequestException, ImageryApiError, ValueError) as err:
+            print("Couldn't set up the Infra3d scan: %s" % err)
             return 1
+        infra3d = Infra3dScan(auth, campaign_uids)
+        names = dict(campaigns)
+        print('Checking Infra3d tenant %s, campaign(s): %s' % (
+            auth.tenant, ', '.join('%s (%s)' % (uid, names[uid]) for uid in campaign_uids)))
     else:
         api_key = os.getenv('GOOGLE_MAPS_API_KEY') if api == 'GSV' else os.getenv('MAPILLARY_ACCESS_TOKEN')
         if api_key is None:
@@ -738,12 +833,10 @@ def main(argv=None):
     gsv_url = gsv_base_url + '&radius=15'
     gsv_url_endpoint = gsv_base_url + '&radius=25'
     mapillary_url = 'https://graph.mapillary.com/images?is_pano=true&access_token=%s' % api_key
-    # One shared rate limiter caps total request rate across all worker threads.
-    fetch = make_fetch(rate_limiter=RateLimiter(args.max_qps))
     checkpoint_lock = threading.Lock()
 
     def check_and_record(street):
-        result = process_street(street, api, fetch, gsv_url, gsv_url_endpoint, mapillary_url, infra3d_auth)
+        result = process_street(street, api, fetch, gsv_url, gsv_url_endpoint, mapillary_url, infra3d)
         with checkpoint_lock:  # process_street does no file I/O; only the checkpoint append needs serializing.
             append_checkpoint(result, checkpoint_path)
         return result
@@ -776,10 +869,11 @@ def main(argv=None):
                 future.result()
     except KeyboardInterrupt:
         print("\nInterrupted; progress saved to the checkpoint. Re-run to resume.")
-        finalize_outputs(checkpoint_path, output_path, failed_path, summary_path)
         return 1
-
-    finalize_outputs(checkpoint_path, output_path, failed_path, summary_path)
+    finally:
+        # Derive the outputs however the scan ended -- interrupt, or a bug escaping a worker -- so the streets already
+        # settled in the checkpoint are never lost to a traceback.
+        finalize_outputs(checkpoint_path, output_path, failed_path, summary_path)
     return 0
 
 

--- a/scripts/check_streets_for_imagery.py
+++ b/scripts/check_streets_for_imagery.py
@@ -1,5 +1,5 @@
 """
-Finds streets that lack street-view imagery (Google Street View or Mapillary) and writes them to a CSV.
+Finds streets that lack street-view imagery (Google Street View, Mapillary, or Infra3d) and writes them to a CSV.
 
 This is a standalone, manually-run utility (it is not invoked by the app). Workflow:
 
@@ -9,9 +9,12 @@ This is a standalone, manually-run utility (it is not invoked by the app). Workf
 
          python3.13 scripts/check_streets_for_imagery.py --gsv
          python3.13 scripts/check_streets_for_imagery.py --mapillary
+         python3.13 scripts/check_streets_for_imagery.py --infra3d
 
-     ``--gsv`` needs ``GOOGLE_MAPS_API_KEY``; ``--mapillary`` needs ``MAPILLARY_ACCESS_TOKEN``. It is ``python3.13``
-     rather than the container's default ``python3`` because this tool's libraries need Python >= 3.11.
+     ``--gsv`` needs ``GOOGLE_MAPS_API_KEY``; ``--mapillary`` needs ``MAPILLARY_ACCESS_TOKEN``; ``--infra3d`` needs
+     ``INFRA3D_CLIENT_ID`` and ``INFRA3D_CLIENT_SECRET`` (one city's pair — the same OAuth client-credentials the app
+     holds per city as ``INFRA3D_CLIENT_ID_<CITY>``). It is ``python3.13`` rather than the container's default
+     ``python3`` because this tool's libraries need Python >= 3.11.
   3. It writes streets without imagery to ``db/streets_with_no_imagery.csv``, and a per-street imagery summary
      (presence + capture-date range) to ``db/street_imagery_summary.csv``.
   4. Run ``make hide-streets-without-imagery`` to mark those streets in the database.
@@ -20,9 +23,17 @@ For each street it first checks both endpoints; if neither has imagery the stree
 walks points along the street (added roughly every 15 m) and flags the street once enough points lack imagery (see
 ``imagery_verdict`` for the exact thresholds).
 
-Imagery age: the GSV responses we already fetch also carry a capture ``date``, so for no extra API calls we record each
-street's imagery capture-date range (oldest/newest) into the summary file — telling us not just whether a street has
-imagery but how old it is. (Mapillary capture dates are a future enhancement; GSV only for now.)
+Imagery age: the GSV and Infra3d responses we already fetch also carry a capture date, so for no extra API calls we
+record each street's imagery capture-date range (oldest/newest) into the summary file — telling us not just whether a
+street has imagery but how old it is. (Mapillary capture dates are a future enhancement.)
+
+Infra3d has no metadata endpoint of its own; the check uses the same nearest-frame query (``framegate``'s
+``knn/query``) that the vendored Infra3d viewer SDK issues on every ``setLocation``, authenticated with the same
+per-city OAuth token the app fetches in ``PanoDataService.getInfra3dToken``. The query returns the single nearest
+frame with no distance cap, so "imagery here" is decided client-side: the nearest 360° frame within the same 25 m /
+15 m radius GSV bakes into its URL. Flat mono/stereo frames are filtered out server-side, matching the viewer's
+``setFilter(['in', 'cameraType', 'calotte', 'cubemap'])`` — an Infra3d street with only flat photos is unusable for
+labeling and should count as having no imagery.
 
 Resilience (so a long scan survives a flaky network): each request is retried with exponential backoff; a street that
 still fails is logged and the scan continues rather than aborting, and the failed set is retried once at the end (any
@@ -31,9 +42,9 @@ still-failing streets land in ``db/failed_streets.csv``). Progress is checkpoint
 streets. The final ``db/streets_with_no_imagery.csv`` is derived from the checkpoint, so its schema is unchanged.
 
 The pure functions (``create_bounding_box``, ``redistribute_vertices``, ``gsv_has_imagery``, ``mapillary_has_imagery``,
-``standardize_capture_date``, ``gsv_capture_date``, ``imagery_verdict``, ``street_has_no_imagery``, ``summarize_dates``)
-are import-safe and unit-tested in ``test/python/test_check_streets_for_imagery.py``; network and file I/O live in thin
-wrappers and ``main``.
+``infra3d_pano_info``, ``standardize_capture_date``, ``gsv_capture_date``, ``imagery_verdict``,
+``street_has_no_imagery``, ``summarize_dates``) are import-safe and unit-tested in
+``test/python/test_check_streets_for_imagery.py``; network and file I/O live in thin wrappers and ``main``.
 
 The paths above are resolved relative to the repo root (this script's parent directory), so the tool works the same no
 matter which directory you launch it from.
@@ -51,11 +62,13 @@ concurrent fetching. We deliberately differ from it in three ways, because the t
   * Concurrency: GSV Tracker uses asyncio/aiohttp tuned for maximum throughput (toward Google's ~500 req/s ceiling). We
     use a small thread pool plus a conservative token-bucket QPS cap, deliberately staying well under the limit; at that
     bounded concurrency, threads are simpler and sufficient, and async's scale advantage would be wasted.
-  * Providers: we support GSV *and* Mapillary (Project Sidewalk uses both); GSV Tracker is GSV-only.
+  * Providers: we support GSV, Mapillary, *and* Infra3d (Project Sidewalk uses all three); GSV Tracker is GSV-only.
 """
 
 import argparse
+import base64
 import csv
+import json
 import logging
 import os
 import sys
@@ -64,6 +77,7 @@ import time
 from collections import namedtuple
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
+from urllib.parse import quote
 
 import pandas as pd
 import requests
@@ -106,10 +120,22 @@ DEFAULT_MAX_QPS = 10.0
 # Spacing between interpolated vertices along a street, in lat/lng degrees (~15 m). Accuracy here is not critical.
 DISTANCE = 0.000135
 
-# Bounding-box half-extents (km) for Mapillary queries: 25 m at endpoints, 15 m at along-street points (a smaller
-# radius along the street avoids picking up imagery from a nearby parallel street). GSV bakes these into the URL.
+# Search radii, in km: 25 m at street endpoints, 15 m at along-street points — the smaller mid-street radius avoids
+# picking up imagery from a nearby parallel street.
 ENDPOINT_RADIUS_KM = 0.025
 POINT_RADIUS_KM = 0.015
+
+# Infra3d: the token grant mirrors PanoDataService.getInfra3dToken; the framegate route is what the vendored viewer SDK
+# calls for setLocation. The route's tenant segment comes from the token's scope, so there is no per-city config.
+INFRA3D_TOKEN_URL = 'https://uzh.auth.eu-west-1.amazoncognito.com/oauth2/token'
+INFRA3D_API_URL = 'https://api.infra3d.com/framegate'
+# The SDK's own API-gateway key, baked into the vendored bundle and sent by every browser session alongside the bearer;
+# it identifies the SDK, not us -- the per-city bearer token is what grants access to a tenant's imagery.
+INFRA3D_API_KEY = '6zGSQ8u14j3AqL8myGcP54rbXS9aLCpr6lY99B9F'
+# 360° frames only, matching Infra3dViewer's setFilter: Explore can't label on Infra3d's flat mono/stereo photos.
+INFRA3D_PANO_FILTER = "type in '(calotte, cubemap)'"
+# Infra3d access tokens live 60 minutes; refresh this many seconds before expiry so a long scan never sends a stale one.
+INFRA3D_TOKEN_REFRESH_MARGIN = 300
 
 # A street is flagged as missing imagery once the fraction of checked points without imagery reaches FAIL_FRACTION, or
 # reaches FAIL_FRACTION_WITH_ENDPOINT when at least one endpoint already lacked imagery. Conversely the check stops
@@ -143,6 +169,55 @@ PanoInfo = namedtuple('PanoInfo', ['has_imagery', 'capture_date'])
 
 class ImageryApiError(Exception):
     """Raised when an imagery provider returns an unexpected error response that should abort checking a street."""
+
+
+def _jwt_claims(token):
+    """Decodes a JWT's payload (no signature check -- we only read our own token's scope/expiry)."""
+    payload = token.split('.')[1]
+    return json.loads(base64.urlsafe_b64decode(payload + '=' * (-len(payload) % 4)))
+
+
+class Infra3dAuth:
+    """
+    Holds an Infra3d access token for the scan, refreshing it before it expires.
+
+    The token is minted with the per-city OAuth client credentials (the same grant ``PanoDataService.getInfra3dToken``
+    uses), and its ``framegate/<tenant>`` scope names the tenant whose frames we may query. ``headers()`` is safe to
+    call from the worker threads; the clock and HTTP ``post`` are injectable for deterministic tests.
+    """
+
+    def __init__(self, client_id, client_secret, post=None, now=time.time):
+        self._client_id = client_id
+        self._client_secret = client_secret
+        self._post = post if post is not None else requests.post
+        self._now = now
+        self._lock = threading.Lock()
+        self._token = None
+        self._expires_at = 0
+        self.tenant = None
+
+    def _refresh(self):
+        body = {'client_id': self._client_id, 'client_secret': self._client_secret, 'grant_type': 'client_credentials'}
+        response = self._post(INFRA3D_TOKEN_URL, data=body, headers={'Accept': 'application/json'},
+                              timeout=REQUEST_TIMEOUT)
+        if response.status_code != 200:
+            raise ImageryApiError('Infra3d token request failed with status %d: %s' % (response.status_code,
+                                                                                      response.text))
+        self._token = response.json()['access_token']
+        claims = _jwt_claims(self._token)
+        self._expires_at = claims['exp']
+        tenants = [s.split('/', 1)[1] for s in claims.get('scope', '').split() if s.startswith('framegate/')]
+        if not tenants:
+            raise ImageryApiError('Infra3d token carries no framegate/<tenant> scope: %s' % claims.get('scope'))
+        self.tenant = tenants[0]
+
+    def headers(self):
+        """Returns the auth headers for a framegate request, minting/refreshing the token first if needed."""
+        with self._lock:
+            if self._now() >= self._expires_at - INFRA3D_TOKEN_REFRESH_MARGIN:
+                self._refresh()
+            return {'Authorization': 'Bearer ' + self._token, 'x-api-key': INFRA3D_API_KEY,
+                    'Accept': 'application/json'}
 
 
 class RateLimiter:
@@ -294,6 +369,37 @@ def mapillary_has_imagery(response_json):
     return not no_imagery
 
 
+def infra3d_pano_info(response_json, lat, lng, radius_km):
+    """
+    Interprets an Infra3d nearest-frame (``knn/query``) response for a query point.
+
+    The endpoint returns the nearest frame(s) with no distance cap -- a point 90 km outside the city still gets the
+    city's closest frame -- so presence means "the nearest frame is within ``radius_km`` of the point". The frames are
+    already filtered to 360° types by the request's ``filter`` param.
+
+    Args:
+        response_json: The decoded JSON from the framegate ``knn/query`` endpoint (``{"value": [frame, ...]}``).
+        lat:           Latitude of the queried point.
+        lng:           Longitude of the queried point.
+        radius_km:     Max distance from the point at which a frame counts as imagery for it.
+
+    Returns:
+        A ``PanoInfo``: imagery present iff the nearest frame is within the radius, with that frame's capture date.
+
+    Raises:
+        ImageryApiError: If the response has no ``value`` list (auth failure, bad request, ...).
+    """
+    frames = response_json.get('value') if isinstance(response_json, dict) else None
+    if not isinstance(frames, list):
+        raise ImageryApiError('unexpected Infra3d response: ' + json.dumps(response_json)[:200])
+    if not frames:
+        return PanoInfo(False, None)
+    nearest = min(frames, key=lambda f: geodesic((lat, lng), (f['latitude'], f['longitude'])).km)
+    if geodesic((lat, lng), (nearest['latitude'], nearest['longitude'])).km > radius_km:
+        return PanoInfo(False, None)
+    return PanoInfo(True, standardize_capture_date((nearest.get('timestamp') or '')[:10]))
+
+
 def imagery_verdict(n_fail, n_success, n_coords, endpoint_failed):
     """
     Decides, from running point counts, whether the street's imagery status is settled yet.
@@ -355,14 +461,20 @@ def street_has_no_imagery(first_endpoint_fail, second_endpoint_fail, point_has_i
     return False
 
 
-def _get_json(url):
-    """GETs a URL and returns the decoded JSON (with a bounded per-attempt timeout)."""
-    return requests.get(url, timeout=REQUEST_TIMEOUT).json()
+def _get_json(url, **kwargs):
+    """
+    Requests a URL and returns the decoded JSON (with a bounded per-attempt timeout).
+
+    GET by default; ``kwargs`` (``method``, ``headers``, ...) pass through to ``requests.request`` for providers that
+    need more, like Infra3d's POST + bearer token.
+    """
+    kwargs.setdefault('method', 'GET')
+    return requests.request(url=url, timeout=REQUEST_TIMEOUT, **kwargs).json()
 
 
 def make_fetch(max_attempts=MAX_ATTEMPTS, sleep=None, rate_limiter=None):
     """
-    Builds a ``fetch(url) -> json`` that retries transient network errors with exponential backoff + jitter.
+    Builds a ``fetch(url, **kwargs) -> json`` that retries transient network errors with exponential backoff + jitter.
 
     The retry/backoff approach is adapted from GSV Tracker (see the module "Design lineage" note).
 
@@ -372,7 +484,7 @@ def make_fetch(max_attempts=MAX_ATTEMPTS, sleep=None, rate_limiter=None):
         rate_limiter: Optional ``RateLimiter``; if given, a token is acquired before every request (including retries).
 
     Returns:
-        A ``fetch`` callable.
+        A ``fetch`` callable; any keyword arguments are passed through to ``_get_json``.
     """
     retryer = tenacity.Retrying(
         stop=tenacity.stop_after_attempt(max_attempts),
@@ -382,18 +494,31 @@ def make_fetch(max_attempts=MAX_ATTEMPTS, sleep=None, rate_limiter=None):
         reraise=True,
     )
 
-    def attempt(url):
+    def attempt(url, **kwargs):
         if rate_limiter is not None:
             rate_limiter.acquire()
-        return _get_json(url)
+        return _get_json(url, **kwargs)
 
-    return lambda url: retryer(lambda: attempt(url))
+    return lambda url, **kwargs: retryer(lambda: attempt(url, **kwargs))
 
 
 def _mapillary_bbox_url(mapillary_url, lat, lng, radius_km):
     """Appends a ``&bbox=`` query (a box of ``radius_km`` around the point) to the Mapillary base URL."""
     bbox = create_bounding_box(lat, lng, radius_km)
     return mapillary_url + '&bbox=' + ','.join(str(coord) for coord in bbox)
+
+
+def _infra3d_knn_url(tenant, lat, lng):
+    """Builds the framegate nearest-360°-frame query URL for a point."""
+    return '%s/frames/%s/knn/query?longitude=%s&latitude=%s&filter=%s' % (
+        INFRA3D_API_URL, tenant, lng, lat, quote(INFRA3D_PANO_FILTER, safe=''))
+
+
+def _infra3d_point_pano_info(auth, lat, lng, radius_km, fetch):
+    """Queries Infra3d for the nearest 360° frame to a point (via ``fetch``) and returns its ``PanoInfo``."""
+    headers = auth.headers()  # Before the URL: minting the token is what populates auth.tenant.
+    response = fetch(_infra3d_knn_url(auth.tenant, lat, lng), method='POST', headers=headers)
+    return infra3d_pano_info(response, lat, lng, radius_km)
 
 
 def _pano_info(api, response_json):
@@ -408,21 +533,26 @@ def _pano_info(api, response_json):
     return PanoInfo(mapillary_has_imagery(response_json), None)
 
 
-def _point_pano_info(api, lat, lng, fetch, gsv_url, mapillary_url, mapillary_radius_km):
-    """Queries the configured provider at one point (via ``fetch``) and returns its ``PanoInfo``."""
+def _point_pano_info(api, lat, lng, fetch, gsv_url, mapillary_url, radius_km, infra3d_auth=None):
+    """
+    Queries the configured provider at one point (via ``fetch``) and returns its ``PanoInfo``.
+
+    ``radius_km`` is the Mapillary bbox half-extent / Infra3d max frame distance; GSV bakes its radius into ``gsv_url``.
+    """
     if api == 'GSV':
         return _pano_info(api, fetch(gsv_url + '&location=' + str(lat) + ',' + str(lng)))
-    return _pano_info(api, fetch(_mapillary_bbox_url(mapillary_url, lat, lng, mapillary_radius_km)))
+    if api == 'Infra3d':
+        return _infra3d_point_pano_info(infra3d_auth, lat, lng, radius_km, fetch)
+    return _pano_info(api, fetch(_mapillary_bbox_url(mapillary_url, lat, lng, radius_km)))
 
 
-def _check_endpoints(street, api, fetch, gsv_url_endpoint, mapillary_url):
+def _check_endpoints(street, api, fetch, gsv_url_endpoint, mapillary_url, infra3d_auth=None):
     """Checks both of a street's endpoints; returns ``(first_pano_info, second_pano_info)``."""
-    if api == 'GSV':
-        first = _pano_info(api, fetch(gsv_url_endpoint + '&location=' + str(street.y1) + ',' + str(street.x1)))
-        second = _pano_info(api, fetch(gsv_url_endpoint + '&location=' + str(street.y2) + ',' + str(street.x2)))
-    else:
-        first = _pano_info(api, fetch(_mapillary_bbox_url(mapillary_url, street.y1, street.x1, ENDPOINT_RADIUS_KM)))
-        second = _pano_info(api, fetch(_mapillary_bbox_url(mapillary_url, street.y2, street.x2, ENDPOINT_RADIUS_KM)))
+    # GSV carries its radius in the URL, so the endpoint URL goes where the along-street point URL normally would.
+    first = _point_pano_info(api, street.y1, street.x1, fetch, gsv_url_endpoint, mapillary_url, ENDPOINT_RADIUS_KM,
+                             infra3d_auth)
+    second = _point_pano_info(api, street.y2, street.x2, fetch, gsv_url_endpoint, mapillary_url, ENDPOINT_RADIUS_KM,
+                              infra3d_auth)
     return first, second
 
 
@@ -441,7 +571,7 @@ def summarize_dates(dates):
     return min(dates), max(dates), len(dates)
 
 
-def process_street(street, api, fetch, gsv_url, gsv_url_endpoint, mapillary_url):
+def process_street(street, api, fetch, gsv_url, gsv_url_endpoint, mapillary_url, infra3d_auth=None):
     """
     Checks one street for imagery and returns its outcome (pure of any file/checkpoint I/O, so it is pool-safe).
 
@@ -451,11 +581,12 @@ def process_street(street, api, fetch, gsv_url, gsv_url_endpoint, mapillary_url)
 
     Args:
         street:           A street row (Series) with ``street_edge_id``, ``region_id``, endpoint x/y, and ``geom``.
-        api:              ``'GSV'`` or ``'Mapillary'``.
-        fetch:            A ``fetch(url) -> json`` (typically from ``make_fetch``, with retry).
+        api:              ``'GSV'``, ``'Mapillary'``, or ``'Infra3d'``.
+        fetch:            A ``fetch(url, **kwargs) -> json`` (typically from ``make_fetch``, with retry).
         gsv_url:          GSV metadata base URL with the along-street radius baked in (GSV only).
         gsv_url_endpoint: GSV metadata base URL with the endpoint radius baked in (GSV only).
         mapillary_url:    Mapillary images base URL (Mapillary only).
+        infra3d_auth:     An ``Infra3dAuth`` supplying the tenant and bearer headers (Infra3d only).
 
     Returns:
         A ``StreetResult`` with outcome ``NO_IMAGERY`` / ``HAS_IMAGERY`` / ``FAILED`` and, for settled streets, the
@@ -463,7 +594,7 @@ def process_street(street, api, fetch, gsv_url, gsv_url_endpoint, mapillary_url)
         early-exit point sampling means no extra API calls are made.
     """
     try:
-        first, second = _check_endpoints(street, api, fetch, gsv_url_endpoint, mapillary_url)
+        first, second = _check_endpoints(street, api, fetch, gsv_url_endpoint, mapillary_url, infra3d_auth)
         coords = list(street['geom'].coords)
         dates = [d for d in (first.capture_date, second.capture_date) if d]
 
@@ -474,7 +605,8 @@ def process_street(street, api, fetch, gsv_url, gsv_url_endpoint, mapillary_url)
             # `no branch`: street_has_no_imagery settles and stops consuming before this loop is exhausted (for any
             # real street, which has >= 2 points), so the generator is abandoned rather than run to completion.
             for coord in coords:  # pragma: no branch  -- Shapely coords are (x=lng, y=lat).
-                info = _point_pano_info(api, coord[1], coord[0], fetch, gsv_url, mapillary_url, POINT_RADIUS_KM)
+                info = _point_pano_info(api, coord[1], coord[0], fetch, gsv_url, mapillary_url, POINT_RADIUS_KM,
+                                        infra3d_auth)
                 if info.capture_date:
                     dates.append(info.capture_date)
                 yield info.has_imagery
@@ -558,23 +690,37 @@ def main(argv=None):
     """
     parser = argparse.ArgumentParser(
         description='Loops through streets, outputting any without imagery to a separate file.')
-    parser.add_argument('--gsv', action='store_true', help='Include if checking for GSV imagery')
-    parser.add_argument('--mapillary', action='store_true', help='Include if checking for Mapillary imagery')
+    provider = parser.add_mutually_exclusive_group(required=True)
+    provider.add_argument('--gsv', action='store_true', help='Check for GSV imagery (needs GOOGLE_MAPS_API_KEY)')
+    provider.add_argument('--mapillary', action='store_true',
+                          help='Check for Mapillary imagery (needs MAPILLARY_ACCESS_TOKEN)')
+    provider.add_argument('--infra3d', action='store_true',
+                          help='Check for Infra3d imagery (needs INFRA3D_CLIENT_ID + INFRA3D_CLIENT_SECRET)')
     parser.add_argument('--workers', type=int, default=DEFAULT_WORKERS,
                         help='Number of streets to check concurrently (default: %(default)s).')
     parser.add_argument('--max-qps', type=float, default=DEFAULT_MAX_QPS,
                         help='Global cap on requests per second across all workers (default: %(default)s).')
     args = parser.parse_args(argv)
-    if not (args.gsv or args.mapillary):
-        parser.error('At least one of --gsv or --mapillary is required')
-    if args.gsv and args.mapillary:
-        parser.error('Please specify only one of --gsv or --mapillary')
-    api = 'GSV' if args.gsv else 'Mapillary'
+    api = 'GSV' if args.gsv else 'Mapillary' if args.mapillary else 'Infra3d'
 
-    api_key = os.getenv('GOOGLE_MAPS_API_KEY') if api == 'GSV' else os.getenv('MAPILLARY_ACCESS_TOKEN')
-    if api_key is None:
-        print("Couldn't read API key environment variable.")
-        return 1
+    api_key = None
+    infra3d_auth = None
+    if api == 'Infra3d':
+        client_id, client_secret = os.getenv('INFRA3D_CLIENT_ID'), os.getenv('INFRA3D_CLIENT_SECRET')
+        if client_id is None or client_secret is None:
+            print("Couldn't read INFRA3D_CLIENT_ID / INFRA3D_CLIENT_SECRET environment variables.")
+            return 1
+        infra3d_auth = Infra3dAuth(client_id, client_secret)
+        try:
+            infra3d_auth.headers()  # Mint the first token up front so bad credentials fail fast, not per street.
+        except (requests.exceptions.RequestException, ImageryApiError) as err:
+            print("Couldn't get an Infra3d access token: %s" % err)
+            return 1
+    else:
+        api_key = os.getenv('GOOGLE_MAPS_API_KEY') if api == 'GSV' else os.getenv('MAPILLARY_ACCESS_TOKEN')
+        if api_key is None:
+            print("Couldn't read API key environment variable.")
+            return 1
 
     # Resolve every data file against the repo root so the script works regardless of the working directory.
     input_path = os.path.join(REPO_ROOT, INPUT_FILE)
@@ -588,17 +734,16 @@ def main(argv=None):
     street_data = street_data.sort_values(by=['region_id', 'street_edge_id'])
     street_data['geom'] = list(map(lambda g: redistribute_vertices(wkb.loads(g, hex=True)), list(street_data['geom'])))
 
-    # GSV bakes the search radius into the URL (25 m at endpoints, 15 m along the street); Mapillary uses a bbox.
-    gsv_base_url = 'https://maps.googleapis.com/maps/api/streetview/metadata?source=outdoor&key=' + api_key
+    gsv_base_url = 'https://maps.googleapis.com/maps/api/streetview/metadata?source=outdoor&key=%s' % api_key
     gsv_url = gsv_base_url + '&radius=15'
     gsv_url_endpoint = gsv_base_url + '&radius=25'
-    mapillary_url = 'https://graph.mapillary.com/images?is_pano=true&access_token=' + api_key
+    mapillary_url = 'https://graph.mapillary.com/images?is_pano=true&access_token=%s' % api_key
     # One shared rate limiter caps total request rate across all worker threads.
     fetch = make_fetch(rate_limiter=RateLimiter(args.max_qps))
     checkpoint_lock = threading.Lock()
 
     def check_and_record(street):
-        result = process_street(street, api, fetch, gsv_url, gsv_url_endpoint, mapillary_url)
+        result = process_street(street, api, fetch, gsv_url, gsv_url_endpoint, mapillary_url, infra3d_auth)
         with checkpoint_lock:  # process_street does no file I/O; only the checkpoint append needs serializing.
             append_checkpoint(result, checkpoint_path)
         return result

--- a/test/python/test_check_streets_for_imagery.py
+++ b/test/python/test_check_streets_for_imagery.py
@@ -7,6 +7,8 @@ thresholds), the retry/fetch and per-street worker (including imagery-age captur
 flagging, resume, fail-soft + retry, and interrupt). See test/python/README.md.
 """
 
+import base64
+import json
 import os
 
 import pandas as pd
@@ -95,6 +97,122 @@ def test_pano_info():
     assert cs._pano_info('Mapillary', {'data': [{'id': 1}]}) == cs.PanoInfo(True, None)  # Mapillary date not captured
 
 
+# --------------------------------------------------------------------------------------------------------------------
+# Infra3d: nearest-frame interpretation + token handling
+# --------------------------------------------------------------------------------------------------------------------
+
+def _frame(lat, lng, timestamp='2024-06-17T11:23:09.795417+00:00'):
+    return {'latitude': lat, 'longitude': lng, 'timestamp': timestamp, 'type': 'cubemap'}
+
+
+def test_infra3d_pano_info_nearest_within_radius():
+    # ~11 m north of the point, inside the 15 m radius.
+    response = {'value': [_frame(47.6001, -122.3)]}
+    assert cs.infra3d_pano_info(response, 47.6, -122.3, 0.015) == cs.PanoInfo(True, '2024-06-17')
+
+
+def test_infra3d_pano_info_picks_the_nearest_of_several():
+    response = {'value': [_frame(47.61, -122.3, '2020-01-01T00:00:00+00:00'), _frame(47.6001, -122.3)]}
+    assert cs.infra3d_pano_info(response, 47.6, -122.3, 0.015) == cs.PanoInfo(True, '2024-06-17')
+
+
+def test_infra3d_pano_info_nearest_beyond_radius_is_no_imagery():
+    # The endpoint has no distance cap, so a frame 1 km away still comes back; it must not count.
+    response = {'value': [_frame(47.61, -122.3)]}
+    assert cs.infra3d_pano_info(response, 47.6, -122.3, 0.015) == cs.PanoInfo(False, None)
+
+
+def test_infra3d_pano_info_empty_value_is_no_imagery():
+    assert cs.infra3d_pano_info({'value': []}, 47.6, -122.3, 0.015) == cs.PanoInfo(False, None)
+
+
+def test_infra3d_pano_info_missing_timestamp_has_no_date():
+    response = {'value': [{'latitude': 47.6, 'longitude': -122.3, 'timestamp': None}]}
+    assert cs.infra3d_pano_info(response, 47.6, -122.3, 0.015) == cs.PanoInfo(True, None)
+
+
+@pytest.mark.parametrize('response', [{'message': 'Unauthorized'}, {'value': 'nope'}, ['not', 'a', 'dict']])
+def test_infra3d_pano_info_unexpected_response_raises(response):
+    with pytest.raises(cs.ImageryApiError):
+        cs.infra3d_pano_info(response, 47.6, -122.3, 0.015)
+
+
+def test_infra3d_knn_url_encodes_pano_filter():
+    url = cs._infra3d_knn_url('uzh', 47.6, -122.3)
+    assert url.startswith('https://api.infra3d.com/framegate/frames/uzh/knn/query?longitude=-122.3&latitude=47.6')
+    assert url.endswith('&filter=type%20in%20%27%28calotte%2C%20cubemap%29%27')
+
+
+def _jwt(claims):
+    payload = base64.urlsafe_b64encode(json.dumps(claims).encode()).decode().rstrip('=')
+    return 'header.%s.signature' % payload
+
+
+def test_jwt_claims_decodes_unpadded_payload():
+    assert cs._jwt_claims(_jwt({'exp': 1, 'scope': 'a b'})) == {'exp': 1, 'scope': 'a b'}
+
+
+class _TokenResp:
+    def __init__(self, status_code, token=None, text='error body'):
+        self.status_code = status_code
+        self._token = token
+        self.text = text
+
+    def json(self):
+        return {'access_token': self._token}
+
+
+def _auth(post, now):
+    return cs.Infra3dAuth('id', 'secret', post=post, now=now)
+
+
+def test_infra3d_auth_mints_token_and_reads_tenant_from_scope():
+    calls = []
+
+    def post(url, data, headers, timeout):
+        calls.append((url, data))
+        return _TokenResp(200, _jwt({'exp': 4000, 'scope': 'permission/edit framegate/uzh role/user'}))
+
+    auth = _auth(post, now=lambda: 1000)
+    headers = auth.headers()
+    assert auth.tenant == 'uzh'
+    assert headers['Authorization'].startswith('Bearer header.')
+    assert headers['x-api-key'] == cs.INFRA3D_API_KEY
+    assert calls == [(cs.INFRA3D_TOKEN_URL,
+                      {'client_id': 'id', 'client_secret': 'secret', 'grant_type': 'client_credentials'})]
+
+
+def test_infra3d_auth_reuses_token_until_near_expiry():
+    clock = {'t': 1000}
+    calls = {'n': 0}
+
+    def post(url, data, headers, timeout):
+        calls['n'] += 1
+        return _TokenResp(200, _jwt({'exp': clock['t'] + 3600, 'scope': 'framegate/uzh'}))
+
+    auth = _auth(post, now=lambda: clock['t'])
+    auth.headers()
+    clock['t'] += 3600 - cs.INFRA3D_TOKEN_REFRESH_MARGIN - 1  # still (just) outside the refresh margin
+    auth.headers()
+    assert calls['n'] == 1
+    clock['t'] += 1  # now inside the margin -> refreshed
+    auth.headers()
+    assert calls['n'] == 2
+
+
+def test_infra3d_auth_non_200_raises():
+    auth = _auth(lambda url, data, headers, timeout: _TokenResp(401, text='bad client'), now=lambda: 0)
+    with pytest.raises(cs.ImageryApiError, match='401'):
+        auth.headers()
+
+
+def test_infra3d_auth_scope_without_tenant_raises():
+    auth = _auth(lambda url, data, headers, timeout: _TokenResp(200, _jwt({'exp': 9, 'scope': 'role/user'})),
+                 now=lambda: 0)
+    with pytest.raises(cs.ImageryApiError, match='framegate'):
+        auth.headers()
+
+
 def test_summarize_dates():
     assert cs.summarize_dates([]) == (None, None, 0)
     assert cs.summarize_dates(['2020-05-05', '2019-01-01', '2019-06-01']) == ('2019-01-01', '2020-05-05', 3)
@@ -180,13 +298,43 @@ def test_make_fetch_reraises_after_max_attempts(monkeypatch):
         fetch('http://x')
 
 
-def test_get_json(monkeypatch):
+def test_get_json_defaults_to_get(monkeypatch):
     class _Resp:
         def json(self):
             return {'ok': True}
 
-    monkeypatch.setattr(cs.requests, 'get', lambda url, timeout: _Resp())
+    seen = {}
+
+    def request(**kwargs):
+        seen.update(kwargs)
+        return _Resp()
+
+    monkeypatch.setattr(cs.requests, 'request', request)
     assert cs._get_json('http://x') == {'ok': True}
+    assert seen == {'url': 'http://x', 'method': 'GET', 'timeout': cs.REQUEST_TIMEOUT}
+
+
+def test_get_json_passes_method_and_headers_through(monkeypatch):
+    seen = {}
+
+    class _Resp:
+        def json(self):
+            return {}
+
+    def request(**kwargs):
+        seen.update(kwargs)
+        return _Resp()
+
+    monkeypatch.setattr(cs.requests, 'request', request)
+    cs._get_json('http://x', method='POST', headers={'x-api-key': 'k'})
+    assert (seen['method'], seen['headers']) == ('POST', {'x-api-key': 'k'})
+
+
+def test_make_fetch_forwards_kwargs(monkeypatch):
+    seen = {}
+    monkeypatch.setattr(cs, '_get_json', lambda url, **kwargs: seen.update(kwargs) or {'ok': True})
+    assert cs.make_fetch(sleep=lambda _s: None)('http://x', method='POST') == {'ok': True}
+    assert seen == {'method': 'POST'}
 
 
 def test_mapillary_bbox_url_appends_four_coords():
@@ -282,6 +430,49 @@ def test_process_street_mapillary_has_imagery():
 
 def test_process_street_mapillary_no_imagery():
     assert _run_process(_LINE_60, 'Mapillary', lambda url: {'data': []}).outcome == cs.NO_IMAGERY
+
+
+class _FakeInfra3dAuth:
+    tenant = 'uzh'
+
+    def headers(self):
+        return {'Authorization': 'Bearer t'}
+
+
+def _run_process_infra3d(line, fetch):
+    return cs.process_street(_street(line), 'Infra3d', fetch, None, None, None, _FakeInfra3dAuth())
+
+
+def _frame_at(url, timestamp='2024-06-17T11:23:09.795417+00:00'):
+    # Echoing the query point back as the nearest frame means every checked point has imagery.
+    query = dict(part.split('=') for part in url.split('?')[1].split('&'))
+    return {'value': [{'latitude': float(query['latitude']), 'longitude': float(query['longitude']),
+                       'timestamp': timestamp, 'type': 'cubemap'}]}
+
+
+def test_process_street_infra3d_has_imagery_with_dates():
+    seen = []
+
+    def fetch(url, **kwargs):
+        seen.append((url, kwargs))
+        return _frame_at(url)
+
+    result = _run_process_infra3d(_LINE_60, fetch)
+    assert result.outcome == cs.HAS_IMAGERY
+    assert (result.oldest_capture, result.newest_capture) == ('2024-06-17', '2024-06-17')
+    assert result.n_panos >= 3
+    assert all(url.startswith('https://api.infra3d.com/framegate/frames/uzh/knn/query?') for url, _ in seen)
+    assert all(kw == {'method': 'POST', 'headers': {'Authorization': 'Bearer t'}} for _, kw in seen)
+
+
+def test_process_street_infra3d_nearest_frame_too_far_is_no_imagery():
+    # The API answers (nearest frame ~1 km away), but nothing is within radius.
+    far = {'value': [{'latitude': 47.61, 'longitude': -122.3, 'timestamp': '2024-01-01T00:00:00+00:00'}]}
+    assert _run_process_infra3d(_LINE_60, lambda url, **kw: far).outcome == cs.NO_IMAGERY
+
+
+def test_process_street_infra3d_bad_response_is_failed():
+    assert _run_process_infra3d(_LINE_60, lambda url, **kw: {'message': 'Unauthorized'}).outcome == cs.FAILED
 
 
 def test_process_street_request_error_is_failed():
@@ -530,6 +721,34 @@ def test_main_mapillary_branch(monkeypatch, tmp_path):
     monkeypatch.setattr(cs, '_get_json', lambda url: {'data': []})  # no imagery
     assert cs.main(['--mapillary']) == 0
     assert _output(tmp_path)['street_edge_id'].tolist() == [100]
+
+
+def _infra3d_token_post(status_code=200):
+    def post(url, data, headers, timeout):
+        return _TokenResp(status_code, _jwt({'exp': 10 ** 10, 'scope': 'framegate/uzh'}))
+    return post
+
+
+def test_main_infra3d_branch(monkeypatch, tmp_path):
+    _setup(monkeypatch, tmp_path, [(100, 1, _LINE_60)], env_var='INFRA3D_CLIENT_ID')
+    monkeypatch.setenv('INFRA3D_CLIENT_SECRET', 'dummy')
+    monkeypatch.setattr(cs.requests, 'post', _infra3d_token_post())
+    monkeypatch.setattr(cs, '_get_json', lambda url, **kwargs: {'value': []})  # no imagery
+    assert cs.main(['--infra3d']) == 0
+    assert _output(tmp_path)['street_edge_id'].tolist() == [100]
+
+
+def test_main_infra3d_missing_credentials_returns_1(monkeypatch):
+    monkeypatch.setenv('INFRA3D_CLIENT_ID', 'dummy')
+    monkeypatch.delenv('INFRA3D_CLIENT_SECRET', raising=False)
+    assert cs.main(['--infra3d']) == 1
+
+
+def test_main_infra3d_token_failure_returns_1(monkeypatch, tmp_path):
+    _setup(monkeypatch, tmp_path, [(100, 1, _LINE_60)], env_var='INFRA3D_CLIENT_ID')
+    monkeypatch.setenv('INFRA3D_CLIENT_SECRET', 'dummy')
+    monkeypatch.setattr(cs.requests, 'post', _infra3d_token_post(status_code=401))
+    assert cs.main(['--infra3d']) == 1
 
 
 def test_main_keyboard_interrupt_finalizes_and_returns_1(monkeypatch, tmp_path):

--- a/test/python/test_check_streets_for_imagery.py
+++ b/test/python/test_check_streets_for_imagery.py
@@ -137,10 +137,59 @@ def test_infra3d_pano_info_unexpected_response_raises(response):
         cs.infra3d_pano_info(response, 47.6, -122.3, 0.015)
 
 
-def test_infra3d_knn_url_encodes_pano_filter():
-    url = cs._infra3d_knn_url('uzh', 47.6, -122.3)
+@pytest.mark.parametrize('frame', [
+    {'longitude': -122.3, 'timestamp': 'x'},  # no latitude
+    {'latitude': 'north', 'longitude': -122.3},  # non-numeric coordinate
+    {'latitude': 47.6, 'longitude': -122.3, 'timestamp': 1718622189},  # numeric, not ISO
+    'not a frame',
+])
+def test_infra3d_pano_info_malformed_frame_raises_api_error(frame):
+    # A bad frame must surface as ImageryApiError (-> the street is FAILED), never as a raw KeyError/TypeError that
+    # would escape process_street and kill the whole scan.
+    with pytest.raises(cs.ImageryApiError, match='malformed'):
+        cs.infra3d_pano_info({'value': [frame]}, 47.6, -122.3, 0.015)
+
+
+def test_infra3d_campaigns_parses_uid_and_name():
+    response = {'value': [{'uid': 'c1', 'name': '2024 Zürich'}, {'uid': 'c2'}]}
+    assert cs.infra3d_campaigns(response) == [('c1', '2024 Zürich'), ('c2', None)]
+
+
+@pytest.mark.parametrize('response', [{'message': 'Unauthorized'}, {'value': [{'name': 'no uid'}]}, {'value': ['x']}])
+def test_infra3d_campaigns_unexpected_response_raises(response):
+    with pytest.raises(cs.ImageryApiError):
+        cs.infra3d_campaigns(response)
+
+
+def test_choose_infra3d_campaigns_uses_the_only_campaign():
+    assert cs.choose_infra3d_campaigns([('c1', 'only')], []) == ['c1']
+
+
+def test_choose_infra3d_campaigns_honors_request():
+    assert cs.choose_infra3d_campaigns([('c1', 'a'), ('c2', 'b')], ['c2', 'c1']) == ['c2', 'c1']
+
+
+def test_choose_infra3d_campaigns_several_without_request_lists_them():
+    with pytest.raises(ValueError, match=r'2 campaigns.*\n  c1  a\n  c2  b'):
+        cs.choose_infra3d_campaigns([('c1', 'a'), ('c2', 'b')], [])
+
+
+def test_choose_infra3d_campaigns_none_in_tenant():
+    with pytest.raises(ValueError, match='0 campaigns'):
+        cs.choose_infra3d_campaigns([], [])
+
+
+def test_choose_infra3d_campaigns_unknown_request_rejected():
+    # Filtering on a uid the tenant doesn't hold makes the knn query time out server-side, so catch it up front.
+    with pytest.raises(ValueError, match='not in this tenant: c9'):
+        cs.choose_infra3d_campaigns([('c1', 'a')], ['c1', 'c9'])
+
+
+def test_infra3d_knn_url_encodes_pano_and_campaign_filter():
+    url = cs._infra3d_knn_url('uzh', 47.6, -122.3, ['c1', 'c2'])
     assert url.startswith('https://api.infra3d.com/framegate/frames/uzh/knn/query?longitude=-122.3&latitude=47.6')
-    assert url.endswith('&filter=type%20in%20%27%28calotte%2C%20cubemap%29%27')
+    assert url.endswith('&filter=type%20in%20%27%28calotte%2C%20cubemap%29%27%20and%20campaign_uid%20in%20%27%28c1'
+                        '%2C%20c2%29%27')
 
 
 def _jwt(claims):
@@ -206,10 +255,49 @@ def test_infra3d_auth_non_200_raises():
         auth.headers()
 
 
-def test_infra3d_auth_scope_without_tenant_raises():
-    auth = _auth(lambda url, data, headers, timeout: _TokenResp(200, _jwt({'exp': 9, 'scope': 'role/user'})),
+@pytest.mark.parametrize('scope', ['role/user', 'framegate/uzh framegate/uzh_winterthur'])
+def test_infra3d_auth_scope_without_exactly_one_tenant_raises(scope):
+    auth = _auth(lambda url, data, headers, timeout: _TokenResp(200, _jwt({'exp': 9, 'scope': scope})),
                  now=lambda: 0)
-    with pytest.raises(cs.ImageryApiError, match='framegate'):
+    with pytest.raises(cs.ImageryApiError, match='exactly one framegate'):
+        auth.headers()
+
+
+class _RawTokenResp:
+    status_code = 200
+    text = ''
+
+    def __init__(self, body):
+        self._body = body
+
+    def json(self):
+        return self._body
+
+
+@pytest.mark.parametrize('body', [
+    {'error': 'captive portal'},  # 200 without an access_token
+    {'access_token': 'not-a-jwt'},  # no payload segment
+    {'access_token': 'h.!!!.s'},  # payload isn't base64/JSON
+    {'access_token': _jwt({'scope': 'framegate/uzh'})},  # no exp
+    {'access_token': 42},
+])
+def test_infra3d_auth_unparseable_token_response_is_api_error(body):
+    auth = _auth(lambda url, data, headers, timeout: _RawTokenResp(body), now=lambda: 0)
+    with pytest.raises(cs.ImageryApiError, match='unexpected Infra3d token response'):
+        auth.headers()
+
+
+def test_infra3d_auth_failed_refresh_keeps_raising():
+    # A refresh that fails validation must not commit the new token/expiry: otherwise the next call would see an
+    # unexpired token, skip the refresh, and carry on with the stale tenant.
+    responses = [_TokenResp(200, _jwt({'exp': 4000, 'scope': 'framegate/uzh'})),
+                 _TokenResp(200, _jwt({'exp': 99999, 'scope': 'role/user'}))]
+    auth = _auth(lambda url, data, headers, timeout: responses.pop(0), now=lambda: 5000)
+    auth.headers()  # first token: fine
+    with pytest.raises(cs.ImageryApiError):  # already past its expiry, so this refreshes -> rejected
+        auth.headers()
+    assert auth.tenant == 'uzh'
+    with pytest.raises(IndexError):  # tries to refresh again rather than serving the rejected token
         auth.headers()
 
 
@@ -440,7 +528,8 @@ class _FakeInfra3dAuth:
 
 
 def _run_process_infra3d(line, fetch):
-    return cs.process_street(_street(line), 'Infra3d', fetch, None, None, None, _FakeInfra3dAuth())
+    scan = cs.Infra3dScan(_FakeInfra3dAuth(), ['c1'])
+    return cs.process_street(_street(line), 'Infra3d', fetch, None, None, None, scan)
 
 
 def _frame_at(url, timestamp='2024-06-17T11:23:09.795417+00:00'):
@@ -462,6 +551,7 @@ def test_process_street_infra3d_has_imagery_with_dates():
     assert (result.oldest_capture, result.newest_capture) == ('2024-06-17', '2024-06-17')
     assert result.n_panos >= 3
     assert all(url.startswith('https://api.infra3d.com/framegate/frames/uzh/knn/query?') for url, _ in seen)
+    assert all('campaign_uid%20in%20%27%28c1%29%27' in url for url, _ in seen)
     assert all(kw == {'method': 'POST', 'headers': {'Authorization': 'Bearer t'}} for _, kw in seen)
 
 
@@ -729,13 +819,49 @@ def _infra3d_token_post(status_code=200):
     return post
 
 
-def test_main_infra3d_branch(monkeypatch, tmp_path):
+def _setup_infra3d(monkeypatch, tmp_path, campaigns, seen=None):
+    """Fakes a tenant holding ``campaigns`` (``(uid, name)`` pairs) whose every knn query finds no imagery."""
     _setup(monkeypatch, tmp_path, [(100, 1, _LINE_60)], env_var='INFRA3D_CLIENT_ID')
     monkeypatch.setenv('INFRA3D_CLIENT_SECRET', 'dummy')
     monkeypatch.setattr(cs.requests, 'post', _infra3d_token_post())
-    monkeypatch.setattr(cs, '_get_json', lambda url, **kwargs: {'value': []})  # no imagery
+
+    def get_json(url, **kwargs):
+        if seen is not None:
+            seen.append(url)
+        if url == 'https://api.infra3d.com/framegate/campaigns/uzh/query':
+            return {'value': [{'uid': uid, 'name': name} for uid, name in campaigns]}
+        return {'value': []}
+
+    monkeypatch.setattr(cs, '_get_json', get_json)
+
+
+def test_main_infra3d_branch_scopes_to_the_only_campaign(monkeypatch, tmp_path, capsys):
+    seen = []
+    _setup_infra3d(monkeypatch, tmp_path, [('c1', '2024 Zürich')], seen)
     assert cs.main(['--infra3d']) == 0
     assert _output(tmp_path)['street_edge_id'].tolist() == [100]
+    assert 'tenant uzh, campaign(s): c1 (2024 Zürich)' in capsys.readouterr().out
+    assert all('campaign_uid%20in%20%27%28c1%29%27' in url for url in seen[1:])
+
+
+def test_main_infra3d_several_campaigns_need_a_choice(monkeypatch, tmp_path, capsys):
+    _setup_infra3d(monkeypatch, tmp_path, [('c1', 'a'), ('c2', 'b')])
+    assert cs.main(['--infra3d']) == 1
+    out = capsys.readouterr().out
+    assert '--campaign' in out and 'c1  a' in out and 'c2  b' in out
+
+
+def test_main_infra3d_campaign_flag_selects_scope(monkeypatch, tmp_path):
+    seen = []
+    _setup_infra3d(monkeypatch, tmp_path, [('c1', 'a'), ('c2', 'b')], seen)
+    assert cs.main(['--infra3d', '--campaign', 'c2', '--campaign', 'c1']) == 0
+    assert all('campaign_uid%20in%20%27%28c2%2C%20c1%29%27' in url for url in seen[1:])
+
+
+def test_main_infra3d_unknown_campaign_returns_1(monkeypatch, tmp_path, capsys):
+    _setup_infra3d(monkeypatch, tmp_path, [('c1', 'a')])
+    assert cs.main(['--infra3d', '--campaign', 'nope']) == 1
+    assert 'not in this tenant: nope' in capsys.readouterr().out
 
 
 def test_main_infra3d_missing_credentials_returns_1(monkeypatch):
@@ -749,6 +875,21 @@ def test_main_infra3d_token_failure_returns_1(monkeypatch, tmp_path):
     monkeypatch.setenv('INFRA3D_CLIENT_SECRET', 'dummy')
     monkeypatch.setattr(cs.requests, 'post', _infra3d_token_post(status_code=401))
     assert cs.main(['--infra3d']) == 1
+
+
+def test_main_unexpected_worker_error_still_finalizes_outputs(monkeypatch, tmp_path):
+    _setup(monkeypatch, tmp_path, [(100, 1, _LINE_60), (200, 1, _LINE_61)])
+    monkeypatch.setattr(cs.time, 'sleep', lambda *_a: None)
+
+    def get_json(url):
+        if '47.61' in url:
+            raise RuntimeError('a bug, not a network error')
+        return {'status': 'ZERO_RESULTS'}
+
+    monkeypatch.setattr(cs, '_get_json', get_json)
+    with pytest.raises(RuntimeError):  # not swallowed: a bug should still be loud...
+        cs.main(['--gsv', '--workers', '1', '--max-qps', '1000'])
+    assert _output(tmp_path)['street_edge_id'].tolist() == [100]  # ...but the settled streets are written out.
 
 
 def test_main_keyboard_interrupt_finalizes_and_returns_1(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

Adds `--infra3d` to `scripts/check_streets_for_imagery.py`, so the streets-without-imagery scan works for Infra3d cities (Zürich) the same way it already does for GSV and Mapillary.

**How it queries Infra3d.** Same request the Explore page's viewer SDK makes on load: a Cognito client-credentials token (from `INFRA3D_CLIENT_ID` / `INFRA3D_CLIENT_SECRET`) plus the SDK's `x-api-key`, against `POST {framegate}/frames/{tenant}/knn/query` with the tenant taken from the token's `framegate/<tenant>` scope and a `type in '(calotte, cubemap)'` filter so only 360° panos count. The endpoint has no distance cap and ignores `limit`, so presence is decided client-side: the nearest pano must be within the existing endpoint/along-street radii. Capture date comes from the frame's `timestamp`. Tokens last 60 min and are refreshed 5 min before expiry (thread-safe, so `--workers` works).

**Campaign scoping.** The viewer restricts every frame query to its project's campaigns, and our M2M credentials can't read the project (403), so the scan lists the tenant's campaigns at startup and restricts to them: the single campaign every city holds today is used automatically (and printed), and if a tenant ever holds several the scan lists them and requires `--campaign <uid>`. Zürich and Winterthur are separate tenants (`uzh` / `uzh_winterthur`), one campaign each.

**Nightly poll deliberately left alone.** `ImageryFreshnessService.pollImageryAges` still skips Infra3d, and the rationale is now recorded in code (there and at the hardcoded `project_UID` in `Infra3dViewer.js`): each Infra3d city is a single commissioned drive whose project id is hardcoded, so imagery dates can't change without a code change — which is the moment to add the Infra3d branch to the poll.

## Changes

- `scripts/check_streets_for_imagery.py` — `Infra3dAuth`, `infra3d_pano_info`, `infra3d_campaigns` / `choose_infra3d_campaigns`, Infra3d branch in `_point_pano_info` / `process_street` / `main`; `_get_json` now forwards method/headers so the fetch/retry wrapper works for the POST. Malformed provider responses surface as `ImageryApiError` (one failed street) rather than escaping the worker, and `main` finalizes outputs in a `finally`.
- `test/python/test_check_streets_for_imagery.py` — coverage for all of the above (auth mint/refresh/error paths, nearest-frame logic, campaign selection, URL building, `main --infra3d` incl. missing creds, token failure, multi-campaign tenants). 146 tests, 100% coverage.
- `scripts/README.md` — `### Infra3d` section (credentials, no-distance-cap caveat, pano-only filter, keep `--max-qps 10` or lower).
- `app/service/ImageryFreshnessService.scala`, `public/js/common/pano-viewer/src/Infra3dViewer.js` — comments only (see above).

## Testing

- `pytest`: 146 passed, 100% coverage.
- Live run over all 8,482 Zürich streets with real credentials completed cleanly; sampled streets show the June/July 2024 campaign dates, and a synthetic street in the lake is flagged as no-imagery.
- Street 7085 (the one that dead-ended in Explore) is reported as *having* imagery — a cubemap sits 2.7 m from one end — so that case is a single-pano route-sweep dead end, not a missing-imagery street; the scan's thresholds are unchanged.
- ESLint clean on the JS file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
