### PR TITLE
Allow undoing the final mission validation

### DIFF
--- a/public/js/validate/src/data/Form.js
+++ b/public/js/validate/src/data/Form.js
@@ -196,10 +196,11 @@ class Form {
           svv.missionContainer.createAMission(result.mission, result.progress);
           svv.labelContainer.resetLabelList(result.labels, result.mission.label_type_id);
           await svv.labelContainer.renderCurrentLabel();
-          svv.modalMissionComplete.nextMissionLoaded();
+          svv.modalMissionComplete.submissionFinished(true);
         }
       } else {
         // Otherwise, display popup that says there are no more labels left.
+        svv.modalMissionComplete.submissionFinished(false);
         svv.modalMissionComplete.hide();
         svv.modalNoNewMission.show();
       }

--- a/public/js/validate/src/menu/UndoValidation.js
+++ b/public/js/validate/src/menu/UndoValidation.js
@@ -37,9 +37,13 @@ class UndoValidation {
     svv.tracker.push('ModalUndo_Click');
     svv.validationMenu.saveValidationState();
 
-    // Progress is rolled back only once the previous label is actually on screen, so that an undo the label container
-    // couldn't complete leaves the mission counting the validation the user still has standing.
-    if (await svv.labelContainer.undoLabel()) {
+    const currentMission = svv.missionContainer.getCurrentMission();
+    const missionJustCompleted = currentMission.isComplete();
+
+    // After the final validation, the current label is still on screen, so there is
+    // no need to move back. Otherwise, only roll back progress once the previous
+    // label has been successfully rendered.
+    if (missionJustCompleted || await svv.labelContainer.undoLabel()) {
       svv.missionContainer.updateAMissionUndoValidation();
       this.disableUndo();
     }

--- a/public/js/validate/src/mission/Mission.js
+++ b/public/js/validate/src/mission/Mission.js
@@ -80,36 +80,39 @@ class Mission {
    */
   updateMissionProgress(undo) {
     let labelsProgress = this.getProperty('labelsProgress');
-    if (labelsProgress < this.getProperty('labelsValidated')) {
-      if (undo) {
-        labelsProgress -= 1;
-        const priorLabelFormData = svv.labelContainer.getPriorLabelFormData();
-        this.updateValidationResult(priorLabelFormData.validation_result, true);
-        svv.statusField.decrementLabelCounts();
-        // We either have or have not submitted the last label to the backend.
-        if (svv.labelContainer.getLabelsToSubmit().length > 0) {
-          svv.labelContainer.pop();
-        } else {
-          svv.labelContainer.pushUndoValidation(priorLabelFormData);
-        }
+    const labelsValidated = this.getProperty('labelsValidated');
+
+    if (undo && labelsProgress > 0) {
+      labelsProgress -= 1;
+
+      const priorLabelFormData = svv.labelContainer.getPriorLabelFormData();
+      this.updateValidationResult(priorLabelFormData.validation_result, true);
+      svv.statusField.decrementLabelCounts();
+
+      if (svv.labelContainer.getLabelsToSubmit().length > 0) {
+        svv.labelContainer.pop();
       } else {
-        labelsProgress += 1;
-        svv.statusField.incrementLabelCounts();
+        svv.labelContainer.pushUndoValidation(priorLabelFormData);
       }
 
-      this.setProperty('labelsProgress', labelsProgress);
-      // Submit mission if mission is complete.
-      if (labelsProgress >= this.getProperty('labelsValidated')) {
-        this.setProperty('completed', true);
-        svv.missionContainer.completeAMission();
-        svv.undoValidation.disableUndo();
+      if (this.getProperty('completed')) {
+        this.setProperty('completed', false);
+        svv.missionContainer.cancelMissionCompletion();
       }
+    } else if (!undo && labelsProgress < labelsValidated) {
+      labelsProgress += 1;
+      svv.statusField.incrementLabelCounts();
     }
 
-    // Update progress bar.
-    const labelsInMission = this.getProperty('labelsValidated');
-    svv.statusField.setProgressBar(labelsProgress, labelsInMission);
-    svv.statusField.setProgressText(labelsProgress, labelsInMission);
+    this.setProperty('labelsProgress', labelsProgress);
+
+    if (!undo && labelsProgress >= labelsValidated) {
+      this.setProperty('completed', true);
+      svv.missionContainer.completeAMission();
+    }
+
+    svv.statusField.setProgressBar(labelsProgress, labelsValidated);
+    svv.statusField.setProgressText(labelsProgress, labelsValidated);
   }
 
   /**

--- a/public/js/validate/src/mission/MissionContainer.js
+++ b/public/js/validate/src/mission/MissionContainer.js
@@ -32,14 +32,23 @@ class MissionContainer {
   }
 
   /**
-   * Submits this mission to the backend.
-   */
+  * Shows the mission-complete state while keeping the final validation undoable.
+  */
+
   completeAMission() {
     svv.missionsCompleted += 1;
     svv.modalMissionComplete.show(this.#currentMission);
+  }
+
+  cancelMissionCompletion() {
+    svv.missionsCompleted -= 1;
+    svv.modalMissionComplete.hide();
+  }
+
+  submitCompletedMission() {
     const data = svv.form.compileSubmissionData(true);
-    svv.form.submit(data); // Note that this happens async. Once finished, it enables start next mission button.
     this.#addToCompletedMissions(this.#currentMission);
+    svv.form.submit(data);
   }
 
   /**

--- a/public/js/validate/src/modal/ModalMissionComplete.js
+++ b/public/js/validate/src/modal/ModalMissionComplete.js
@@ -4,6 +4,8 @@
 class ModalMissionComplete {
   #uiModalMissionComplete;
   #language;
+  #pendingButton;
+  #completedMission;
 
   /**
    * @param {object} uiModalMissionComplete Mission-complete modal UI elements.
@@ -16,28 +18,53 @@ class ModalMissionComplete {
   }
 
   #handleButtonClick = (event) => {
-    // If they've done three missions and clicked the audit button, load the explore page.
-    if (event.data.button === 'primary' && svv.missionsCompleted % 3 === 0 && !util.isMobile()) {
-      window.location.replace('/explore');
-    } else {
-      // If there is a new validate mission available, we should show the mission screens.
-      const newMission = svv.missionContainer.getCurrentMission();
-      if (newMission && newMission.getProperty('missionType') === 'validation') {
-        const labelTypeID = newMission.getProperty('labelTypeId');
-        new MissionStartTutorial(
-          'validate', svv.labelTypes[labelTypeID],
-          { nLabels: newMission.getProperty('labelsValidated') }, svv, this.#language,
-        );
-      }
+    this.#pendingButton = event.data.button;
 
-      this.hide();
+    // Once the user chooses to continue, the completed mission is committed and
+    // can no longer be undone.
+    svv.undoValidation.disableUndo();
 
-      // The new mission's first label rendered while this modal was still up (Form.js loads it before re-enabling
-      // the button), so its halo pulse played unseen. Replay it now that the marker can be seen — or once the
-      // mission-start tutorial raised just above clears (#4790).
-      svv.panoManager.replayMarkerPulse();
-    }
+    this.#setButtonsLoading();
+
+    svv.tracker.push(
+      'MissionComplete',
+      {
+        missionId: this.#completedMission.getProperty('missionId'),
+        missionType: this.#completedMission.getProperty('missionType'),
+        labelTypeId: this.#completedMission.getProperty('labelTypeId'),
+        labelsValidated: this.#completedMission.getProperty('labelsValidated'),
+      },
+    );
+
+    svv.missionContainer.submitCompletedMission();
   };
+
+  #setButtonsLoading() {
+    this.#uiModalMissionComplete.closeButtonPrimary.off('click');
+    this.#uiModalMissionComplete.closeButtonSecondary.off('click');
+
+    this.#uiModalMissionComplete.closeButtonPrimary
+      .removeClass('btn-primary')
+      .addClass('btn-loading');
+
+    this.#uiModalMissionComplete.closeButtonSecondary
+      .removeClass('btn-secondary')
+      .addClass('btn-loading');
+  }
+
+  #enableButtons() {
+    this.#uiModalMissionComplete.closeButtonPrimary
+      .removeClass('btn-loading')
+      .addClass('btn-primary')
+      .off('click')
+      .on('click', { button: 'primary' }, this.#handleButtonClick);
+
+    this.#uiModalMissionComplete.closeButtonSecondary
+      .removeClass('btn-loading')
+      .addClass('btn-secondary')
+      .off('click')
+      .on('click', { button: 'secondary' }, this.#handleButtonClick);
+  }
 
   /**
    * Hides the mission complete menu.
@@ -103,7 +130,6 @@ class ModalMissionComplete {
    */
   show(mission) {
     // Disable keyboard on mobile.
-    svv.undoValidation.disableUndo();
     if (svv.keyboard) {
       svv.keyboard.disableKeyboard();
     }
@@ -113,10 +139,7 @@ class ModalMissionComplete {
 
     // Disable user from clicking the 'Validate next mission' button and set background to gray. When we have a new
     // mission from the back end, nextMissionLoaded() will be called from Form.js to re-enable the button.
-    this.#uiModalMissionComplete.closeButtonPrimary.removeClass('btn-primary');
-    this.#uiModalMissionComplete.closeButtonPrimary.addClass('btn-loading');
-    this.#uiModalMissionComplete.closeButtonSecondary.removeClass('btn-secondary');
-    this.#uiModalMissionComplete.closeButtonSecondary.addClass('btn-loading');
+    this.#enableButtons();
 
     this.#uiModalMissionComplete.background.css('visibility', 'visible');
     this.#uiModalMissionComplete.missionTitle.html(i18next.t('mission-complete.title'));
@@ -153,16 +176,6 @@ class ModalMissionComplete {
       this.#uiModalMissionComplete.closeButtonSecondary.css('visibility', 'hidden');
     }
 
-    svv.tracker.push(
-      'MissionComplete',
-      {
-        missionId: mission.getProperty('missionId'),
-        missionType: mission.getProperty('missionType'),
-        labelTypeId: mission.getProperty('labelTypeId'),
-        labelsValidated: mission.getProperty('labelsValidated'),
-      },
-    );
-
     // Celebrate a newly unlocked mission badge if this completion crossed a threshold.
     BadgeAchievements.recordMissionComplete(document.getElementById('modal-mission-complete-foreground'));
   }
@@ -170,13 +183,34 @@ class ModalMissionComplete {
   /**
    * Re-enables the start next mission button; called once a new mission has loaded from the back end.
    */
-  nextMissionLoaded() {
-    // Enable button clicks, reset the CSS for primary/secondary close buttons.
-    this.#uiModalMissionComplete.closeButtonPrimary.removeClass('btn-loading');
-    this.#uiModalMissionComplete.closeButtonPrimary.addClass('btn-primary');
-    this.#uiModalMissionComplete.closeButtonPrimary.on('click', { button: 'primary' }, this.#handleButtonClick);
-    this.#uiModalMissionComplete.closeButtonSecondary.removeClass('btn-loading');
-    this.#uiModalMissionComplete.closeButtonSecondary.addClass('btn-secondary');
-    this.#uiModalMissionComplete.closeButtonSecondary.on('click', { button: 'secondary' }, this.#handleButtonClick);
+  submissionFinished(hasNextMission) {
+    BadgeAchievements.recordMissionComplete(
+      document.getElementById('modal-mission-complete-foreground'),
+    );
+
+    const button = this.#pendingButton;
+    this.#pendingButton = undefined;
+
+    if (!hasNextMission) return;
+
+    if (button === 'primary' && svv.missionsCompleted % 3 === 0 && !util.isMobile()) {
+      window.location.replace('/explore');
+      return;
+    }
+
+    const newMission = svv.missionContainer.getCurrentMission();
+    if (newMission && newMission.getProperty('missionType') === 'validation') {
+      const labelTypeID = newMission.getProperty('labelTypeId');
+      new MissionStartTutorial(
+        'validate',
+        svv.labelTypes[labelTypeID],
+        { nLabels: newMission.getProperty('labelsValidated') },
+        svv,
+        this.#language,
+      );
+    }
+
+    this.hide();
+    svv.panoManager.replayMarkerPulse();
   }
 }

--- a/test/js/validateFormSubmit.test.js
+++ b/test/js/validateFormSubmit.test.js
@@ -47,7 +47,7 @@ describe('Form.submit (issue #2745 resilience)', () => {
                 resetLabelList: jest.fn(),
                 renderCurrentLabel: jest.fn(() => Promise.resolve())
             },
-            modalMissionComplete: { nextMissionLoaded: jest.fn(), hide: jest.fn() },
+            modalMissionComplete: { submissionFinished: jest.fn(), hide: jest.fn() },
             modalNoNewMission: { show: jest.fn() }
         };
 
@@ -179,7 +179,7 @@ describe('Form.submit (issue #2745 resilience)', () => {
         expect(svv.missionContainer.createAMission).toHaveBeenCalledWith(mission, { agree_count: 1 });
         // The label type rides along so the container can ask for replacement labels of the right type (#4810).
         expect(svv.labelContainer.resetLabelList).toHaveBeenCalledWith([{ label_id: 9 }], 3);
-        expect(svv.modalMissionComplete.nextMissionLoaded).toHaveBeenCalled();
+        expect(svv.modalMissionComplete.submissionFinished).toHaveBeenCalledWith(true);
         expect(window.location.reload).not.toHaveBeenCalled();
     });
 
@@ -208,14 +208,15 @@ describe('Form.submit (issue #2745 resilience)', () => {
         expect(global.fetch).toHaveBeenCalledTimes(2);
     });
 
-    test('a non-intermediate submit with no mission available shows the no-new-mission modal', async () => {
-        stubFetchOk({ has_mission_available: false });
+   test('a non-intermediate submit with no mission available shows the no-new-mission modal', async () => {
+      stubFetchOk({ has_mission_available: false });
 
-        await form.submit({});
+      await form.submit({});
 
-        expect(svv.modalMissionComplete.hide).toHaveBeenCalled();
-        expect(svv.modalNoNewMission.show).toHaveBeenCalled();
-    });
+      expect(svv.modalMissionComplete.submissionFinished).toHaveBeenCalledWith(false);
+      expect(svv.modalMissionComplete.hide).toHaveBeenCalled();
+      expect(svv.modalNoNewMission.show).toHaveBeenCalled();
+  });
 
     test('a mission-available response with a null mission is a no-op (mid-mission flush shape)', async () => {
         // The server returns has_mission_available:true with mission:null while a mission is still in progress; the
@@ -314,7 +315,7 @@ describe('Form.submit (issue #2745 resilience)', () => {
 
         expect(global.fetch).toHaveBeenCalledTimes(2);
         expect(svv.missionContainer.createAMission).toHaveBeenCalledWith({ mission_id: 4 }, {});
-        expect(svv.modalMissionComplete.nextMissionLoaded).toHaveBeenCalled();
+        expect(svv.modalMissionComplete.submissionFinished).toHaveBeenCalledWith(true);
         expect(svv.tracker.push).not.toHaveBeenCalledWith('SubmitFailedGaveUp', expect.anything());
     });
 
@@ -327,7 +328,7 @@ describe('Form.submit (issue #2745 resilience)', () => {
         await jest.advanceTimersByTimeAsync(60000);
 
         expect(errorSpy).toHaveBeenCalled();
-        expect(svv.modalMissionComplete.nextMissionLoaded).not.toHaveBeenCalled();
+        expect(svv.modalMissionComplete.submissionFinished).not.toHaveBeenCalled();
         expect(global.fetch).toHaveBeenCalledTimes(1);
         expect(window.location.reload).not.toHaveBeenCalled();
     });

--- a/test/js/validateMissionUndo.test.js
+++ b/test/js/validateMissionUndo.test.js
@@ -1,0 +1,108 @@
+const fs = require('fs');
+const path = require('path');
+
+function loadClass(relativePath, className) {
+    const src = fs.readFileSync(path.resolve(__dirname, '..', '..', relativePath), 'utf8');
+    return (0, eval)('(() => {\n' + src + '\nreturn ' + className + ';\n})()');
+}
+
+const Mission = loadClass(
+    'public/js/validate/src/mission/Mission.js',
+    'Mission'
+);
+
+const UndoValidation = loadClass(
+    'public/js/validate/src/menu/UndoValidation.js',
+    'UndoValidation'
+);
+
+describe('Validate final-validation undo (#4034)', () => {
+    afterEach(() => {
+        delete global.svv;
+    });
+
+    test('a completed 10/10 mission can roll back to 9/10', () => {
+        global.svv = {
+            labelContainer: {
+                getPriorLabelFormData: jest.fn(() => ({
+                    validation_result: 'Agree'
+                })),
+                getLabelsToSubmit: jest.fn(() => [{ label_id: 1 }]),
+                pop: jest.fn(),
+                pushUndoValidation: jest.fn()
+            },
+            statusField: {
+                decrementLabelCounts: jest.fn(),
+                incrementLabelCounts: jest.fn(),
+                setProgressBar: jest.fn(),
+                setProgressText: jest.fn()
+            },
+            missionContainer: {
+                cancelMissionCompletion: jest.fn(),
+                completeAMission: jest.fn()
+            }
+        };
+
+        const mission = new Mission({
+            agreeCount: 1,
+            disagreeCount: 0,
+            unsureCount: 0,
+            completed: true,
+            labelsProgress: 10,
+            labelsValidated: 10,
+            missionId: 1,
+            missionType: 'validation',
+            labelTypeId: 1
+        });
+
+        mission.updateMissionProgress(true);
+
+        expect(mission.getProperty('labelsProgress')).toBe(9);
+        expect(mission.getProperty('completed')).toBe(false);
+        expect(mission.getProperty('agreeCount')).toBe(0);
+
+        expect(svv.labelContainer.pop).toHaveBeenCalled();
+        expect(svv.missionContainer.cancelMissionCompletion).toHaveBeenCalled();
+        expect(svv.missionContainer.completeAMission).not.toHaveBeenCalled();
+
+        expect(svv.statusField.setProgressBar).toHaveBeenCalledWith(9, 10);
+        expect(svv.statusField.setProgressText).toHaveBeenCalledWith(9, 10);
+    });
+
+    test('undoing the final validation keeps the current label on screen', async () => {
+        let clickHandler;
+
+        const undoButton = {
+            on: jest.fn((event, handler) => {
+                clickHandler = handler;
+            }),
+            prop: jest.fn()
+        };
+
+        global.svv = {
+            tracker: {
+                push: jest.fn()
+            },
+            validationMenu: {
+                saveValidationState: jest.fn()
+            },
+            labelContainer: {
+                undoLabel: jest.fn(() => Promise.resolve(true))
+            },
+            missionContainer: {
+                getCurrentMission: jest.fn(() => ({
+                    isComplete: () => true
+                })),
+                updateAMissionUndoValidation: jest.fn()
+            }
+        };
+
+        new UndoValidation({ undoButton });
+
+        await clickHandler();
+
+        expect(svv.labelContainer.undoLabel).not.toHaveBeenCalled();
+        expect(svv.missionContainer.updateAMissionUndoValidation).toHaveBeenCalled();
+        expect(undoButton.prop).toHaveBeenCalledWith('disabled', true);
+    });
+});


### PR DESCRIPTION
Resolves #4034

Allows users to undo the final validation in a validation mission.

Previously, submitting the 10th validation immediately completed and submitted the mission, disabling the undo action and advancing the mission state. This change keeps the mission completion pending until the user chooses to continue, allowing the final validation to be undone from 10/10 back to 9/10.

When undoing the final validation, the current label is kept on screen instead of moving back to the previous label. If the user chooses to continue, the mission is submitted normally and the existing retry behavior is preserved.

##### Before/After screenshots (if applicable)

N/A — this is a behavioral change with no visual changes.

##### Testing instructions

1. Complete 9 out of 10 validations in a validation mission.
2. Submit the 10th validation.
3. Confirm that the mission-complete screen appears.
4. Undo the final validation.
5. Confirm that progress returns from 10/10 to 9/10 and the final label remains on screen.
6. Submit the final validation again and continue.
7. Confirm that the mission is submitted and the next mission loads normally.

Automated tests:

* `test/js/validateMissionUndo.test.js`
* `test/js/validateFormSubmit.test.js`
* `test/js/validateMissionScreens.test.js`

##### Things to check before submitting the PR <!-- if something doesn't apply, just check the box or remove the line -->

<!-- You can check the box by replacing the space with an "x". So instead of "- [ ]" it would be "- [x]" -->

* [x] I've written a descriptive PR title. <!-- No need to include the issue number. Just a half sentence summary of the fix/feature! -->
* [x] I've added/updated comments for large or confusing blocks of code.
* [x] I've included before/after screenshots above. <!-- N/A: no visual changes. -->
* [x] I've asked for and included translations for any user facing text that was added or modified. <!-- N/A: no user-facing text changed. -->
* [x] I've updated any logging. Clicks, keyboard presses, and other user interactions should be logged. If you're not sure how (or if you need to update the logging), ask Mikey. Then make sure [`[docs/logged-events.md](https://chatgpt.com/g/g-p-6a8cf2668b548191a324139d56fa10ea/docs/logged-events.md)`](../docs/logged-events.md) is up to date for the logs you added/updated. <!-- No new logging events were added; the existing MissionComplete event is preserved. -->
* [ ] I've tested on mobile (only needed for validation page).