### PR TITLE
Exempt visibility:hidden boxes from the phone-viewport overflow walk (#5025)

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -141,6 +141,7 @@ local development** — your edit / `grunt watch` / reload loop is untouched.
 | `auth.setup.js` | Registers a throwaway user, saves storageState for registered-user specs |
 | `pages.spec.js` | Table-driven phase-1 anonymous pages |
 | `phone-viewport.spec.js` | The same pages at a 390×844 phone viewport: no horizontal overflow (#4883) |
+| `overflow-report.spec.js` | `horizontalOverflowReport`'s exemption rules, pinned against synthetic DOM |
 | `dashboard.spec.js` | Registered-user pages |
 | `explore-validate.spec.js` | Phase-2 Explore/Validate/mobile-Validate specs (skip without the real GSV key) |
 | `labelmap-feed-failure.spec.js` | What `/labelMap` shows when its label feed fails (intercepted, so DB-independent) |

--- a/test/e2e/fixtures.js
+++ b/test/e2e/fixtures.js
@@ -10,6 +10,11 @@ const base = require('@playwright/test');
 // Where auth.setup.js saves the registered user's session for the specs that need one (dashboard.spec.js).
 const STORAGE_STATE = 'test-results/.auth/registered.json';
 
+// The phone profile the viewport specs measure at. defaultBrowserType is dropped because the suite's chromium
+// project already fixes the browser; shared so the page walk and the checks that pin its rules can't drift apart.
+const PHONE_DEVICE = {...base.devices['iPhone 13'], viewport: {width: 390, height: 844}};
+delete PHONE_DEVICE.defaultBrowserType;
+
 // Known-benign console errors ONLY. Keep this tight: every entry needs a comment explaining the cause, and
 // entries are added only for observed, understood noise — never to get a red run green. `pageerror` (an
 // uncaught exception) is NEVER allowlisted.
@@ -163,13 +168,15 @@ async function loadAndSettle(page, context, p) {
  * closed rather than exempted here. Known blind spot: `overflow-y: auto` computes `overflow-x: auto` on the
  * same box, so a vertical-only scroll pane (e.g. the auth pages' .au-body) exempts its descendants.
  *
- * `visibility: hidden` is exempt, which is the other half of that same contract: it is a parking mechanism the
- * walk recommends, so honoring it here is what lets a page use it. Nothing is lost — a hidden box that stretches
- * a *visible* ancestor still reports that ancestor, and the #4857 shape is visible by definition. It is also what
- * keeps third-party probes out of the results: the Google Maps SDK measures font metrics with a hidden
- * `<span style="position:absolute; font-size:300px">BESbswy</span>` on `<body>`, ~1200px wide and parented by an
- * `overflow-x: hidden` div that the scroller rule above does not exempt. It lives only until the font resolves,
- * so it lands in some runs and not others — it cost #5025 a full investigation to name.
+ * `visibility: hidden` (and `collapse`) is exempt, so a page can take the parking advice above —
+ * `.filter-sidebar--hidden` does, citing this file. It also keeps third-party probes out: the Google Maps SDK
+ * measures font metrics with a hidden `<span style="position:absolute; font-size:300px">BESbswy</span>` on
+ * `<body>`, ~1200px wide under an `overflow-x: hidden` div the scroller rule does not exempt, alive only until
+ * the font resolves — so it lands in some runs and not others, and cost #5025 a full investigation to name.
+ *
+ * A hidden `position: fixed` box is reported anyway: that is the #4857 shape itself, and nothing else measures
+ * it. Second known blind spot, therefore: a hidden `absolute` box is measured by nothing — it stretches no
+ * ancestor to report in its place, and `body {overflow-x: clip}` keeps it out of `pageScrollWidth`.
  *
  * @param {import('@playwright/test').Page} page - The page to measure, already loaded and settled.
  * @returns {Promise<{viewportWidth: number, pageScrollWidth: number, offenders: string[], offenderCount: number}>}
@@ -192,7 +199,8 @@ async function horizontalOverflowReport(page) {
       const rect = el.getBoundingClientRect();
       if (rect.width === 0 || rect.height === 0 || rect.right <= viewportWidth + TOLERANCE_PX) continue;
       const style = getComputedStyle(el);
-      if (style.visibility === 'hidden') continue; // See the header: a parked or third-party-probe box.
+      // See the header: a parked or third-party-probe box, unless it is fixed — that one is the #4857 shape.
+      if (['hidden', 'collapse'].includes(style.visibility) && style.position !== 'fixed') continue;
       let inScroller = false;
       // A fixed element's containing block is the viewport, so no ancestor scrolls or clips it (the #4857
       // footer bug shape); and the walk stops before body so a horizontally scrollable page can't exempt
@@ -209,9 +217,10 @@ async function horizontalOverflowReport(page) {
         if (a === document.body) break; // Everything is under html; naming it places nothing.
       }
       // An element with neither id nor class is unidentifiable from its tag alone, so those carry a text
-      // sample too — that is the whole gap #5025 hit, where `span right=1284px` named no way to find it.
+      // sample too — that is the whole gap #5025 hit, where `span right=1284px` named no way to find it. Double
+      // quotes become single so the sample can't close its own quoting mid-line.
       const bare = !el.id && !el.classList.length;
-      const text = bare ? (el.textContent || '').trim().replace(/\s+/g, ' ').slice(0, 40) : '';
+      const text = bare ? (el.textContent || '').trim().replace(/\s+/g, ' ').replace(/"/g, '\'').slice(0, 40) : '';
       offenders.push(`${describe(el)} right=${Math.round(rect.right)}px width=${Math.round(rect.width)}px` +
         `${ancestry.length ? ` in ${ancestry.join(' < ')}` : ''}${text ? ` text="${text}"` : ''}`);
     }
@@ -250,5 +259,6 @@ module.exports = {
   waitForAppReady,
   loadAndSettle,
   horizontalOverflowReport,
+  PHONE_DEVICE,
   STORAGE_STATE,
 };

--- a/test/e2e/fixtures.js
+++ b/test/e2e/fixtures.js
@@ -163,32 +163,57 @@ async function loadAndSettle(page, context, p) {
  * closed rather than exempted here. Known blind spot: `overflow-y: auto` computes `overflow-x: auto` on the
  * same box, so a vertical-only scroll pane (e.g. the auth pages' .au-body) exempts its descendants.
  *
+ * `visibility: hidden` is exempt, which is the other half of that same contract: it is a parking mechanism the
+ * walk recommends, so honoring it here is what lets a page use it. Nothing is lost — a hidden box that stretches
+ * a *visible* ancestor still reports that ancestor, and the #4857 shape is visible by definition. It is also what
+ * keeps third-party probes out of the results: the Google Maps SDK measures font metrics with a hidden
+ * `<span style="position:absolute; font-size:300px">BESbswy</span>` on `<body>`, ~1200px wide and parented by an
+ * `overflow-x: hidden` div that the scroller rule above does not exempt. It lives only until the font resolves,
+ * so it lands in some runs and not others — it cost #5025 a full investigation to name.
+ *
  * @param {import('@playwright/test').Page} page - The page to measure, already loaded and settled.
  * @returns {Promise<{viewportWidth: number, pageScrollWidth: number, offenders: string[], offenderCount: number}>}
- *   Offenders are CSS-selector-ish descriptions (`div#gallery.sidebar right=612px`), capped at 10; offenderCount
- *   is the uncapped total.
+ *   Offenders are CSS-selector-ish descriptions with their nearest ancestors
+ *   (`div#gallery.sidebar right=612px width=270px in main.page < body`), capped at 10; offenderCount is the
+ *   uncapped total.
  */
 async function horizontalOverflowReport(page) {
   return page.evaluate(() => {
     const TOLERANCE_PX = 1; // Sub-pixel rounding at fractional device-pixel-ratios is not overflow.
+    const ANCESTORS_SHOWN = 3; // Enough to place an element without turning the line into a full DOM path.
     const viewportWidth = document.documentElement.clientWidth;
+    const describe = (node) => {
+      const id = node.id ? `#${node.id}` : '';
+      const cls = node.classList.length ? `.${[...node.classList].join('.')}` : '';
+      return `${node.tagName.toLowerCase()}${id}${cls}`;
+    };
     const offenders = [];
     for (const el of document.querySelectorAll('body *')) {
       const rect = el.getBoundingClientRect();
       if (rect.width === 0 || rect.height === 0 || rect.right <= viewportWidth + TOLERANCE_PX) continue;
+      const style = getComputedStyle(el);
+      if (style.visibility === 'hidden') continue; // See the header: a parked or third-party-probe box.
       let inScroller = false;
       // A fixed element's containing block is the viewport, so no ancestor scrolls or clips it (the #4857
       // footer bug shape); and the walk stops before body so a horizontally scrollable page can't exempt
       // everything on it.
-      if (getComputedStyle(el).position !== 'fixed') {
+      if (style.position !== 'fixed') {
         for (let a = el.parentElement; a && a !== document.body && !inScroller; a = a.parentElement) {
           inScroller = ['auto', 'scroll'].includes(getComputedStyle(a).overflowX);
         }
       }
       if (inScroller) continue;
-      const id = el.id ? `#${el.id}` : '';
-      const cls = el.classList.length ? `.${[...el.classList].join('.')}` : '';
-      offenders.push(`${el.tagName.toLowerCase()}${id}${cls} right=${Math.round(rect.right)}px`);
+      const ancestry = [];
+      for (let a = el.parentElement; a && ancestry.length < ANCESTORS_SHOWN; a = a.parentElement) {
+        ancestry.push(describe(a));
+        if (a === document.body) break; // Everything is under html; naming it places nothing.
+      }
+      // An element with neither id nor class is unidentifiable from its tag alone, so those carry a text
+      // sample too — that is the whole gap #5025 hit, where `span right=1284px` named no way to find it.
+      const bare = !el.id && !el.classList.length;
+      const text = bare ? (el.textContent || '').trim().replace(/\s+/g, ' ').slice(0, 40) : '';
+      offenders.push(`${describe(el)} right=${Math.round(rect.right)}px width=${Math.round(rect.width)}px` +
+        `${ancestry.length ? ` in ${ancestry.join(' < ')}` : ''}${text ? ` text="${text}"` : ''}`);
     }
     return {
       viewportWidth,

--- a/test/e2e/overflow-report.spec.js
+++ b/test/e2e/overflow-report.spec.js
@@ -1,0 +1,79 @@
+/**
+ * Unit checks for horizontalOverflowReport (fixtures.js), the helper phone-viewport.spec.js measures every page
+ * with. It runs against synthetic markup via setContent rather than the app, so it needs no database, no imagery
+ * key, and no seeded city — the exemption rules are the subject, not any particular page.
+ *
+ * Worth pinning because the rules are subtle and a wrong one is silent in both directions: an exemption that is
+ * too broad hides a real #4883 overflow, and one that is too narrow reports noise nobody can act on. #5025 was
+ * the second kind — the Google Maps SDK's hidden font probe surfaced as an unidentifiable `span right=1284px`.
+ *
+ * Every fixture page carries a viewport meta tag: without one, a mobile-UA Chromium lays out against a 980px
+ * fallback viewport instead of the device width, and the elements below would not overflow at all.
+ */
+const {devices} = require('@playwright/test');
+const {test, expect, horizontalOverflowReport} = require('./fixtures');
+
+const IPHONE = {...devices['iPhone 13'], viewport: {width: 390, height: 844}};
+delete IPHONE.defaultBrowserType;
+
+const HEAD = '<html><head><meta name="viewport" content="width=device-width, initial-scale=1"></head>';
+
+test.describe('horizontalOverflowReport', () => {
+  test.use(IPHONE);
+
+  test('reports visible overflow and exempts hidden boxes', async ({page}) => {
+    await page.setContent(`${HEAD}
+      <body style="margin:0">
+        <div id="visible-wide" style="width:1200px;height:20px">wide and visible</div>
+
+        <!-- The Google Maps font probe's shape: a hidden wrapper whose overflow-x is 'hidden', which the
+             scroller exemption deliberately does not cover, around a span far wider than the viewport. -->
+        <div id="hidden-wrap" style="visibility:hidden;position:absolute;overflow-x:hidden;width:1px">
+          <span style="position:absolute;font-size:300px">BESbswy</span>
+        </div>
+
+        <!-- A hidden child inside a visible parent: the parent is what a reader can actually see stretched,
+             and it is what must still be reported. -->
+        <div id="parent-stretched" style="width:max-content">
+          <span id="hidden-child" style="visibility:hidden;display:inline-block;width:1100px;height:10px"></span>
+        </div>
+      </body></html>
+    `);
+
+    const offenders = (await horizontalOverflowReport(page)).offenders.join('\n');
+
+    expect(offenders).toContain('div#visible-wide');
+    expect(offenders).toContain('div#parent-stretched');
+    expect(offenders).not.toContain('BESbswy');
+    expect(offenders).not.toContain('hidden-wrap');
+    expect(offenders).not.toContain('hidden-child');
+  });
+
+  test('exempts descendants of a horizontal scroller', async ({page}) => {
+    await page.setContent(`${HEAD}
+      <body style="margin:0">
+        <div style="overflow-x:auto;width:100%">
+          <table id="wide-table" style="width:1200px"><tr><td>sanctioned wide content</td></tr></table>
+        </div>
+      </body></html>
+    `);
+
+    const report = await horizontalOverflowReport(page);
+    expect(report.offenders).toEqual([]);
+  });
+
+  test('describes an offender well enough to find it', async ({page}) => {
+    await page.setContent(`${HEAD}
+      <body style="margin:0">
+        <main class="page"><div><span style="display:inline-block;width:900px;height:10px">findable text</span></div></main>
+      </body></html>
+    `);
+
+    const [offender] = (await horizontalOverflowReport(page)).offenders;
+
+    // Width and ancestry place it; the text sample names an element that carries no id or class of its own.
+    expect(offender).toContain('width=900px');
+    expect(offender).toContain('in div < main.page < body');
+    expect(offender).toContain('text="findable text"');
+  });
+});

--- a/test/e2e/overflow-report.spec.js
+++ b/test/e2e/overflow-report.spec.js
@@ -1,7 +1,8 @@
 /**
  * Unit checks for horizontalOverflowReport (fixtures.js), the helper phone-viewport.spec.js measures every page
- * with. It runs against synthetic markup via setContent rather than the app, so it needs no database, no imagery
- * key, and no seeded city — the exemption rules are the subject, not any particular page.
+ * with. Every case is synthetic markup via setContent, so no database, imagery key or seeded city is involved.
+ * The chromium project still depends on `setup`, which registers a user against a running app; `--no-deps` runs
+ * this file without one.
  *
  * Worth pinning because the rules are subtle and a wrong one is silent in both directions: an exemption that is
  * too broad hides a real #4883 overflow, and one that is too narrow reports noise nobody can act on. #5025 was
@@ -10,25 +11,24 @@
  * Every fixture page carries a viewport meta tag: without one, a mobile-UA Chromium lays out against a 980px
  * fallback viewport instead of the device width, and the elements below would not overflow at all.
  */
-const {devices} = require('@playwright/test');
-const {test, expect, horizontalOverflowReport} = require('./fixtures');
-
-const IPHONE = {...devices['iPhone 13'], viewport: {width: 390, height: 844}};
-delete IPHONE.defaultBrowserType;
+const {test, expect, horizontalOverflowReport, PHONE_DEVICE} = require('./fixtures');
 
 const HEAD = '<html><head><meta name="viewport" content="width=device-width, initial-scale=1"></head>';
 
 test.describe('horizontalOverflowReport', () => {
-  test.use(IPHONE);
+  test.use(PHONE_DEVICE);
 
   test('reports visible overflow and exempts hidden boxes', async ({page}) => {
     await page.setContent(`${HEAD}
       <body style="margin:0">
         <div id="visible-wide" style="width:1200px;height:20px">wide and visible</div>
 
+        <!-- An in-flow hidden box: wide enough to report on its size alone, exempt on its visibility. -->
+        <div id="hidden-wide" style="visibility:hidden;width:1200px;height:20px">parked off-screen</div>
+
         <!-- The Google Maps font probe's shape: a hidden wrapper whose overflow-x is 'hidden', which the
              scroller exemption deliberately does not cover, around a span far wider than the viewport. -->
-        <div id="hidden-wrap" style="visibility:hidden;position:absolute;overflow-x:hidden;width:1px">
+        <div id="hidden-wrap" style="visibility:hidden;position:absolute;overflow-x:hidden;width:1px;height:1px">
           <span style="position:absolute;font-size:300px">BESbswy</span>
         </div>
 
@@ -45,8 +45,36 @@ test.describe('horizontalOverflowReport', () => {
     expect(offenders).toContain('div#visible-wide');
     expect(offenders).toContain('div#parent-stretched');
     expect(offenders).not.toContain('BESbswy');
-    expect(offenders).not.toContain('hidden-wrap');
+    expect(offenders).not.toContain('hidden-wide');
     expect(offenders).not.toContain('hidden-child');
+  });
+
+  // Why the rule can't just be "skip anything hidden": a fixed box contributes nothing to scrollWidth either, so
+  // skipping it here would leave it measured by nothing. Ours park hidden until they open (.gallery-expanded-view).
+  test('still reports a hidden fixed box', async ({page}) => {
+    await page.setContent(`${HEAD}
+      <body style="margin:0">
+        <div id="hidden-fixed" style="visibility:hidden;position:fixed;top:0;left:0;width:1200px;height:20px">
+          the #4857 shape
+        </div>
+      </body></html>
+    `);
+
+    expect((await horizontalOverflowReport(page)).offenders.join('\n')).toContain('div#hidden-fixed');
+  });
+
+  // visibility is inherited, so the exemption covers a hidden box's subtree — but a descendant can take it back
+  // and paint (label-detail.css warns about exactly that: "`inherit`, never `visible`").
+  test('still reports a visible descendant of a hidden ancestor', async ({page}) => {
+    await page.setContent(`${HEAD}
+      <body style="margin:0">
+        <div id="hidden-ancestor" style="visibility:hidden">
+          <div id="visible-again" style="visibility:visible;width:1200px;height:20px">painted anyway</div>
+        </div>
+      </body></html>
+    `);
+
+    expect((await horizontalOverflowReport(page)).offenders.join('\n')).toContain('div#visible-again');
   });
 
   test('exempts descendants of a horizontal scroller', async ({page}) => {
@@ -65,7 +93,9 @@ test.describe('horizontalOverflowReport', () => {
   test('describes an offender well enough to find it', async ({page}) => {
     await page.setContent(`${HEAD}
       <body style="margin:0">
-        <main class="page"><div><span style="display:inline-block;width:900px;height:10px">findable text</span></div></main>
+        <main class="page">
+          <div><span style="display:inline-block;width:900px;height:10px">findable text</span></div>
+        </main>
       </body></html>
     `);
 

--- a/test/e2e/phone-viewport.spec.js
+++ b/test/e2e/phone-viewport.spec.js
@@ -19,14 +19,8 @@
  * Lives apart from explore-validate.spec.js on purpose: that file skips wholesale without a real Google Maps
  * key (absent on fork PRs), and nothing here needs one.
  */
-const {devices} = require('@playwright/test');
-const {test, expect, stubMapbox, waitForAppReady, loadAndSettle, horizontalOverflowReport, STORAGE_STATE} =
-  require('./fixtures');
-
-// devices['iPhone 13'] supplies the mobile UA, touch support and DPR. defaultBrowserType is dropped because the
-// suite's chromium project already fixes the browser, and the viewport is widened to the full 390×844 screen.
-const IPHONE = {...devices['iPhone 13'], viewport: {width: 390, height: 844}};
-delete IPHONE.defaultBrowserType;
+const {test, expect, stubMapbox, waitForAppReady, loadAndSettle, horizontalOverflowReport, PHONE_DEVICE,
+  STORAGE_STATE} = require('./fixtures');
 
 /**
  * Loads a page-table entry and runs the shared no-errors + no-horizontal-overflow assertions.
@@ -68,7 +62,7 @@ const PAGES = [
 ];
 
 test.describe('phone viewport (390px)', () => {
-  test.use(IPHONE);
+  test.use(PHONE_DEVICE);
 
   for (const p of PAGES) {
     test(`${p.path} fits without horizontal overflow`, async ({page, context, consoleErrors}) => {
@@ -82,7 +76,7 @@ test.describe('phone viewport (390px)', () => {
 // and it bites harder: with nothing in CI's DB these load the empty shell, which fits at any width — the
 // cards are exercised by a local run against a seeded DB.
 test.describe('narrow phone viewport (320px)', () => {
-  test.use({...IPHONE, viewport: {width: 320, height: 653}});
+  test.use({...PHONE_DEVICE, viewport: {width: 320, height: 653}});
 
   const NARROW_PATHS = ['/routes', '/stories', '/gallery'];
   for (const p of PAGES.filter((page) => NARROW_PATHS.includes(page.path))) {
@@ -154,14 +148,22 @@ async function checkLabelCardFits(page, {withoutAddress = false} = {}) {
   // Both cases author the address cell rather than accepting whatever the imagery resolved: whether an address
   // arrives at all, and how long it is, varies by label and by run, and the strip's width follows it. Authored
   // through the DOM rather than stubbed out of the metadata because the loaded imagery re-supplies an address
-  // either way; these are the states #showAddress itself reaches, and each re-runs the fitter through the same
-  // ResizeObserver production uses.
+  // either way; these are the states #showAddress itself reaches.
   await page.evaluate(({hide, address}) => {
     document.querySelector('.label-detail__meta-cell--address').hidden = hide;
     document.querySelector('.label-detail__meta-divider--address').hidden = hide;
     if (!hide) document.querySelector('.label-detail__address').textContent = address;
   }, {hide: withoutAddress, address: LONG_ADDRESS});
-  await page.waitForTimeout(600);
+
+  // Those writes reach the DOM but not the fitter: #fitMetaRow runs from a ResizeObserver on the meta row, and
+  // toggling that row's own children never changes its box. Unfitted, the strip keeps whatever trims the real
+  // address left on it — the per-run variance this helper exists to pin. A 1px viewport round-trip is the resize
+  // path production takes on rotation, and lands back on the width under test.
+  const viewport = page.viewportSize();
+  await page.setViewportSize({...viewport, width: viewport.width - 1});
+  await page.setViewportSize(viewport);
+  // ResizeObserver callbacks land before paint, so two frames covers the re-fit and its relayout.
+  await page.evaluate(() => new Promise(done => requestAnimationFrame(() => requestAnimationFrame(done))));
 
   const fit = await page.evaluate(() => {
     const card = document.getElementById('label-modal');
@@ -172,8 +174,21 @@ async function checkLabelCardFits(page, {withoutAddress = false} = {}) {
       rowScrollWidth: row.scrollWidth,
       rowClientWidth: row.clientWidth,
       rowClasses: row.className,
+      addressHidden: card.querySelector('.label-detail__meta-cell--address').hidden,
+      addressText: card.querySelector('.label-detail__address').textContent,
     };
   });
+  // A late pano load calls #showAddress again, restoring the cell and its own address under us. Fail on that
+  // rather than quietly measuring a different layout than the one the test names.
+  expect(fit.addressHidden, `the address cell left the state under test: ${JSON.stringify(fit)}`)
+    .toBe(withoutAddress);
+  if (!withoutAddress) {
+    expect(fit.addressText, `the authored address was overwritten: ${JSON.stringify(fit)}`).toBe(LONG_ADDRESS);
+    // LONG_ADDRESS fits no phone-width strip, so the row it is measured on must be in the trimmed state. The
+    // width assertions can't check that: the address cell ellipsizes any length on its own, fitted or not.
+    expect(fit.rowClasses, `the meta strip was never re-fitted: ${JSON.stringify(fit)}`)
+      .toContain('label-detail__meta-row--no-time');
+  }
   expect(fit.cardScrollWidth, `the label card scrolls sideways: ${JSON.stringify(fit)}`)
     .toBeLessThanOrEqual(fit.cardClientWidth + 1);
   expect(fit.rowScrollWidth, `the meta strip overflows its row: ${JSON.stringify(fit)}`)
@@ -185,7 +200,7 @@ async function checkLabelCardFits(page, {withoutAddress = false} = {}) {
 // there is nothing to shrink and the fixed facts have to be trimmed. Same seed caveat as the card grids — with
 // no labels in the database there is nothing to open, and these skip.
 test.describe('phone viewport (390px), label detail card', () => {
-  test.use(IPHONE);
+  test.use(PHONE_DEVICE);
 
   test('an open label card fits', async ({page, context}) => {
     await stubMapbox(context);
@@ -201,7 +216,7 @@ test.describe('phone viewport (390px), label detail card', () => {
 });
 
 test.describe('narrow phone viewport (320px), label detail card', () => {
-  test.use({...IPHONE, viewport: {width: 320, height: 653}});
+  test.use({...PHONE_DEVICE, viewport: {width: 320, height: 653}});
 
   test('an open label card fits', async ({page, context}) => {
     await stubMapbox(context);
@@ -210,7 +225,7 @@ test.describe('narrow phone viewport (320px), label detail card', () => {
 });
 
 test.describe('phone viewport (390px), registered user', () => {
-  test.use({...IPHONE, storageState: STORAGE_STATE});
+  test.use({...PHONE_DEVICE, storageState: STORAGE_STATE});
 
   test('/dashboard fits without horizontal overflow', async ({page, context, consoleErrors}) => {
     await checkPhoneViewport(page, context, consoleErrors, {path: '/dashboard', mapbox: true});

--- a/test/e2e/phone-viewport.spec.js
+++ b/test/e2e/phone-viewport.spec.js
@@ -142,18 +142,26 @@ async function checkLabelCardFits(page, {withoutAddress = false} = {}) {
   await page.goto(`/labelMap?labelId=${feature.properties.label_id}`);
   await waitForAppReady(page);
   await expect(page.locator('#label-modal')).toBeVisible({timeout: 30_000});
-  // The strip refits when the address resolves from the loaded imagery, which is after the card first paints.
-  await page.waitForTimeout(2000);
-
   // Both cases author the address cell rather than accepting whatever the imagery resolved: whether an address
   // arrives at all, and how long it is, varies by label and by run, and the strip's width follows it. Authored
   // through the DOM rather than stubbed out of the metadata because the loaded imagery re-supplies an address
   // either way; these are the states #showAddress itself reaches.
-  await page.evaluate(({hide, address}) => {
-    document.querySelector('.label-detail__meta-cell--address').hidden = hide;
-    document.querySelector('.label-detail__meta-divider--address').hidden = hide;
-    if (!hide) document.querySelector('.label-detail__address').textContent = address;
-  }, {hide: withoutAddress, address: LONG_ADDRESS});
+  //
+  // Re-authored until it sticks, because #showAddress runs again when the pano finishes loading — a fixed wait
+  // for that loses the race whenever the browser is busy, and the state has to hold through the measurement
+  // below, not just at the moment it is written.
+  await expect(async () => {
+    const held = await page.evaluate(async ({hide, address}) => {
+      const cell = document.querySelector('.label-detail__meta-cell--address');
+      const value = document.querySelector('.label-detail__address');
+      cell.hidden = hide;
+      document.querySelector('.label-detail__meta-divider--address').hidden = hide;
+      if (!hide) value.textContent = address;
+      await new Promise(done => setTimeout(done, 500));
+      return cell.hidden === hide && (hide || value.textContent === address);
+    }, {hide: withoutAddress, address: LONG_ADDRESS});
+    expect(held, 'the app overwrote the authored address state').toBe(true);
+  }).toPass({timeout: 30_000});
 
   // Those writes reach the DOM but not the fitter: #fitMetaRow runs from a ResizeObserver on the meta row, and
   // toggling that row's own children never changes its box. Unfitted, the strip keeps whatever trims the real

--- a/test/e2e/phone-viewport.spec.js
+++ b/test/e2e/phone-viewport.spec.js
@@ -147,56 +147,56 @@ async function checkLabelCardFits(page, {withoutAddress = false} = {}) {
   // through the DOM rather than stubbed out of the metadata because the loaded imagery re-supplies an address
   // either way; these are the states #showAddress itself reaches.
   //
-  // Re-authored until it sticks, because #showAddress runs again when the pano finishes loading — a fixed wait
-  // for that loses the race whenever the browser is busy, and the state has to hold through the measurement
-  // below, not just at the moment it is written.
+  // Authoring, re-fitting and measuring share one retry because #showAddress runs again when the pano resolves,
+  // which is network-timed and can land between any two of those steps. Holding the state briefly and then
+  // measuring outside the retry loses that race whenever the pano settles in the gap. Once it has run there is
+  // nothing left to rewrite the cell, so the block converges rather than spinning.
+  let fit;
   await expect(async () => {
-    const held = await page.evaluate(async ({hide, address}) => {
+    await page.evaluate(({hide, address}) => {
       const cell = document.querySelector('.label-detail__meta-cell--address');
-      const value = document.querySelector('.label-detail__address');
       cell.hidden = hide;
       document.querySelector('.label-detail__meta-divider--address').hidden = hide;
-      if (!hide) value.textContent = address;
-      await new Promise(done => setTimeout(done, 500));
-      return cell.hidden === hide && (hide || value.textContent === address);
+      if (!hide) document.querySelector('.label-detail__address').textContent = address;
     }, {hide: withoutAddress, address: LONG_ADDRESS});
-    expect(held, 'the app overwrote the authored address state').toBe(true);
+
+    // Those writes reach the DOM but not the fitter: #fitMetaRow runs from a ResizeObserver on the meta row, and
+    // toggling that row's own children never changes its box. Unfitted, the strip keeps whatever trims the real
+    // address left on it — the per-run variance this helper exists to pin. A 1px viewport round-trip is the
+    // resize path production takes on rotation, and lands back on the width under test.
+    const viewport = page.viewportSize();
+    await page.setViewportSize({...viewport, width: viewport.width - 1});
+    await page.setViewportSize(viewport);
+    // ResizeObserver callbacks land before paint, so two frames covers the re-fit and its relayout.
+    await page.evaluate(() => new Promise(done => requestAnimationFrame(() => requestAnimationFrame(done))));
+
+    fit = await page.evaluate(() => {
+      const card = document.getElementById('label-modal');
+      const row = card.querySelector('.label-detail__meta-row');
+      return {
+        cardScrollWidth: card.scrollWidth,
+        cardClientWidth: card.clientWidth,
+        rowScrollWidth: row.scrollWidth,
+        rowClientWidth: row.clientWidth,
+        rowClasses: row.className,
+        addressHidden: card.querySelector('.label-detail__meta-cell--address').hidden,
+        addressText: card.querySelector('.label-detail__address').textContent,
+      };
+    });
+
+    expect(fit.addressHidden, `the address cell left the state under test: ${JSON.stringify(fit)}`)
+      .toBe(withoutAddress);
+    if (!withoutAddress) {
+      expect(fit.addressText, `the authored address was overwritten: ${JSON.stringify(fit)}`).toBe(LONG_ADDRESS);
+      // LONG_ADDRESS fits no phone-width strip, so the row it is measured on must be in the trimmed state. The
+      // width assertions can't check that: the address cell ellipsizes any length on its own, fitted or not.
+      expect(fit.rowClasses, `the meta strip was never re-fitted: ${JSON.stringify(fit)}`)
+        .toContain('label-detail__meta-row--no-time');
+    }
   }).toPass({timeout: 30_000});
 
-  // Those writes reach the DOM but not the fitter: #fitMetaRow runs from a ResizeObserver on the meta row, and
-  // toggling that row's own children never changes its box. Unfitted, the strip keeps whatever trims the real
-  // address left on it — the per-run variance this helper exists to pin. A 1px viewport round-trip is the resize
-  // path production takes on rotation, and lands back on the width under test.
-  const viewport = page.viewportSize();
-  await page.setViewportSize({...viewport, width: viewport.width - 1});
-  await page.setViewportSize(viewport);
-  // ResizeObserver callbacks land before paint, so two frames covers the re-fit and its relayout.
-  await page.evaluate(() => new Promise(done => requestAnimationFrame(() => requestAnimationFrame(done))));
-
-  const fit = await page.evaluate(() => {
-    const card = document.getElementById('label-modal');
-    const row = card.querySelector('.label-detail__meta-row');
-    return {
-      cardScrollWidth: card.scrollWidth,
-      cardClientWidth: card.clientWidth,
-      rowScrollWidth: row.scrollWidth,
-      rowClientWidth: row.clientWidth,
-      rowClasses: row.className,
-      addressHidden: card.querySelector('.label-detail__meta-cell--address').hidden,
-      addressText: card.querySelector('.label-detail__address').textContent,
-    };
-  });
-  // A late pano load calls #showAddress again, restoring the cell and its own address under us. Fail on that
-  // rather than quietly measuring a different layout than the one the test names.
-  expect(fit.addressHidden, `the address cell left the state under test: ${JSON.stringify(fit)}`)
-    .toBe(withoutAddress);
-  if (!withoutAddress) {
-    expect(fit.addressText, `the authored address was overwritten: ${JSON.stringify(fit)}`).toBe(LONG_ADDRESS);
-    // LONG_ADDRESS fits no phone-width strip, so the row it is measured on must be in the trimmed state. The
-    // width assertions can't check that: the address cell ellipsizes any length on its own, fitted or not.
-    expect(fit.rowClasses, `the meta strip was never re-fitted: ${JSON.stringify(fit)}`)
-      .toContain('label-detail__meta-row--no-time');
-  }
+  // Outside the retry: once the state above holds, a card that still scrolls sideways is a real overflow, not a
+  // race, and re-measuring it until the timeout would only delay the report.
   expect(fit.cardScrollWidth, `the label card scrolls sideways: ${JSON.stringify(fit)}`)
     .toBeLessThanOrEqual(fit.cardClientWidth + 1);
   expect(fit.rowScrollWidth, `the meta strip overflows its row: ${JSON.stringify(fit)}`)

--- a/test/e2e/phone-viewport.spec.js
+++ b/test/e2e/phone-viewport.spec.js
@@ -92,12 +92,16 @@ test.describe('narrow phone viewport (320px)', () => {
   }
 });
 
+// A long-but-real street address, written into the card below so the shrinkable cell is always measured at a
+// width worth testing instead of at whatever this database's chosen label happens to carry.
+const LONG_ADDRESS = '1234 Northwest Martin Luther King Jr Boulevard';
+
 /**
- * Finds a label near the city center from the label feed.
+ * Finds the label near the city center that these tests measure.
  *
  * @param {import('@playwright/test').Page} page - The test's page, used only for its request context.
- * @returns {Promise<Object|null>} The label's GeoJSON feature, or null when the database has none there (CI's
- *   near-empty seed).
+ * @returns {Promise<Object|null>} The lowest-numbered label's GeoJSON feature, or null when the database has none
+ *   there (CI's near-empty seed).
  */
 let cachedLabelFeature; // The feed fetch dominates these tests' runtime on a seeded dev DB; one fetch serves all.
 async function findLabelFeature(page) {
@@ -106,7 +110,12 @@ async function findLabelFeature(page) {
   const pad = 0.05;
   const bbox = [center.lng - pad, center.lat - pad, center.lng + pad, center.lat + pad].join(',');
   const feed = await (await page.request.get(`/labels/all?bbox=${bbox}`)).json();
-  cachedLabelFeature = feed.features?.[0] ?? null;
+  // Lowest label_id rather than whatever the feed lists first: the endpoint imposes no order, so features[0]
+  // picked a different label per run, and the card's width follows the label (#5025).
+  const features = feed.features ?? [];
+  cachedLabelFeature = features.length
+    ? features.reduce((lowest, f) => (f.properties.label_id < lowest.properties.label_id ? f : lowest))
+    : null;
   return cachedLabelFeature;
 }
 
@@ -122,7 +131,8 @@ async function findLabelFeature(page) {
  * @param {import('@playwright/test').Page} page - The test's page, already at a phone viewport.
  * @param {Object} [opts] - Options.
  * @param {boolean} [opts.withoutAddress=false] - Measure with the address cell hidden: the state a label whose
- *   imagery is gone lands in, leaving no shrinkable cell to absorb a narrow card.
+ *   imagery is gone lands in, leaving no shrinkable cell to absorb a narrow card. Otherwise the cell is shown
+ *   carrying LONG_ADDRESS.
  */
 async function checkLabelCardFits(page, {withoutAddress = false} = {}) {
   // Slow from the first step: these load map + modal + pano late in a full run, when the shared browser is heaviest.
@@ -141,16 +151,17 @@ async function checkLabelCardFits(page, {withoutAddress = false} = {}) {
   // The strip refits when the address resolves from the loaded imagery, which is after the card first paints.
   await page.waitForTimeout(2000);
 
-  if (withoutAddress) {
-    // Hidden rather than stubbed out of the metadata: the loaded imagery re-supplies an address, so a label served
-    // without one still gets one once its pano loads. Hiding the cell is the state #showAddress itself reaches,
-    // and it re-runs the fitter through the same ResizeObserver production uses.
-    await page.evaluate(() => {
-      document.querySelector('.label-detail__meta-cell--address').hidden = true;
-      document.querySelector('.label-detail__meta-divider--address').hidden = true;
-    });
-    await page.waitForTimeout(600);
-  }
+  // Both cases author the address cell rather than accepting whatever the imagery resolved: whether an address
+  // arrives at all, and how long it is, varies by label and by run, and the strip's width follows it. Authored
+  // through the DOM rather than stubbed out of the metadata because the loaded imagery re-supplies an address
+  // either way; these are the states #showAddress itself reaches, and each re-runs the fitter through the same
+  // ResizeObserver production uses.
+  await page.evaluate(({hide, address}) => {
+    document.querySelector('.label-detail__meta-cell--address').hidden = hide;
+    document.querySelector('.label-detail__meta-divider--address').hidden = hide;
+    if (!hide) document.querySelector('.label-detail__address').textContent = address;
+  }, {hide: withoutAddress, address: LONG_ADDRESS});
+  await page.waitForTimeout(600);
 
   const fit = await page.evaluate(() => {
     const card = document.getElementById('label-modal');


### PR DESCRIPTION
Closes #5025.

## What this was

`/stories` was reported as laying out ~894px past a 390px phone viewport in 3 of 4 runs, by a bare `<span>` the
report could only name as `span right=1284px`. That element turns out to be the **Google Maps SDK's
webfont-metrics probe**:

```html
<span style="position: absolute; font-size: 300px; width: auto; height: auto;
             margin: 0px; padding: 0px; font-family: Roboto, Arial, sans-serif;">BESbswy</span>
```

`visibility: hidden`, ~1200px wide, appended to `<body>`, wrapped in an `overflow-x: hidden` 1px div that the
scroller exemption deliberately does not cover. It exists only until the font resolves, which is why it landed in
some runs and not others.

**There is no `/stories` layout bug.** Three premises in the issue were wrong and are corrected in a
[comment there](https://github.com/ProjectSidewalk/SidewalkWebpage/issues/5025#issuecomment-5458166184): the story
cards are server-rendered, both local schemas have zero stories (so `/stories` was rendering the empty shell — there
were no cards to blame), and the repro precondition is a real Google Maps key rather than a seeded DB. CI is green
because CI has no key, so the SDK never loads; `/stories` pulls it in via `LabelPopup` regardless of story count.

## Changes

**`test/e2e/fixtures.js`** — `horizontalOverflowReport` already documented `visibility: hidden` as a sanctioned way
to park content off-screen, but never checked it. Honor that contract. Nothing real is lost: a hidden box that
stretches a *visible* ancestor still reports that ancestor, and the #4857 fixed-footer shape is visible by
definition.

Offender lines now carry width, the nearest ancestors, and — for an element with neither id nor class — a text
sample, so the next one is identifiable from a CI log instead of an investigation:

```
span right=900px width=900px in div < main.page < body text="findable text"
```

**`test/e2e/phone-viewport.spec.js`** — the two label-card tests sampled their input twice over: they took whatever
label `/labels/all` listed first (the endpoint imposes no order) and then measured whatever address the imagery
happened to resolve. Both are now pinned — lowest `label_id`, and an authored address cell — which makes them
deterministic and, with a fixed long address, a stronger check than before. These are the tests #5025 also recorded
as intermittent.

Pinning the address turned out to be racy in its own right, which took a second pass to get right. `#showAddress`
runs again when `setPano` resolves, on network time. Authoring the state, holding it briefly, then measuring
outside the retry still lost that race whenever the pano settled in the gap: locally the three label-card tests
failed **5 of 9** runs at `--repeat-each=3`, each time on the guard reporting the app's own address back.
Authoring, the re-fit and the measurement now share one `toPass`, so a late callback retries instead of failing.
The width assertions stay outside it — once the address state holds, a card that still scrolls sideways is a real
overflow rather than a race, and retrying would only delay the report.

**`test/e2e/overflow-report.spec.js`** (new) — pins the exemption rules against synthetic DOM via `setContent`, so
it needs **no database and no imagery key**. It still belongs to the `chromium` project, which depends on `setup`
(that registers a user against a running app), so running it without an app means passing `--no-deps`. Worth having
because the rules are subtle and a wrong one is silent in both directions: too broad hides a real #4883 overflow,
too narrow reports noise nobody can act on.

## Testing

Run locally against a seeded `teaneck` DB (22,762 labels). That matters here: CI's near-empty seed makes the
label-card and `/stories` tests render empty shells or skip outright, so local is the only place they exercise
anything — and it is where the flake above lived while CI stayed green.

- `phone-viewport.spec.js` + `overflow-report.spec.js`: **26/26**.
- `-g 'label detail card' --repeat-each=3`, run twice: **10/10** and **10/10**. The same command on the previous
  commit: 5 failed / 5 passed.
- `overflow-report.spec.js --no-deps`: **5/5**.
- `overflow-report.spec.js` verified non-vacuous — commenting out the `visibility` check makes it fail with
  `BESbswy` in the offenders.
- ESLint clean on `test/e2e/` and `playwright.config.js`.

No app code, CSS, or views are touched — the diff is entirely under `test/e2e/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 5 (1M context), `claude-opus-5[1m]`

https://claude.ai/code/session_01Q3MkRGUjnQRqwipDS8t6yT
