### PR TITLE
Retire the legacy Raleway families and fix the skyline stat figures

### DIFF
--- a/public/css/components/deployment-map.css
+++ b/public/css/components/deployment-map.css
@@ -326,7 +326,8 @@
 
 .deployment-sites-stats-header {
   font-size: 30px;
-  font-family: raleway-extrabold, sans-serif;
+  font-family: var(--font-accent);
+  font-weight: 800;
   color: #2c3e50;
   line-height: 1.2;
 
@@ -391,7 +392,8 @@
 
 .cta-title {
   font-size: 28px;
-  font-family: raleway-extrabold, sans-serif;
+  font-family: var(--font-accent);
+  font-weight: 800;
   color: #2c3e50;
   margin-bottom: 15px;
 }

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -265,8 +265,6 @@
 /* Raleway's three weights, as weights of one family — which is what lets `font-weight: 700` on --font-accent pick
    Raleway Bold. A weight the family doesn't declare is drawn by smearing the regular outlines instead, so the
    --text-h1-bold / --text-h2-bold headings are the ones this is here for.
-   The raleway-bold and raleway-extrabold families below name the same two files, for the older rules that select a
-   weight by family name; prefer the weight on this family in anything new.
    `swap` on all of them: Raleway sets headings, and the alternative is a heading that is simply absent until the
    face arrives. The flash of fallback it trades that for is short — these are same-origin now, not a round trip to
    Google — and it matches what the Mulish/Inter/JetBrains Mono faces in css/fonts.css already do. */
@@ -293,19 +291,6 @@
   font-style: normal;
   font-display: swap;
 }
-
-@font-face {
-  font-family: raleway-bold;
-  src: url("../fonts/Raleway/Raleway-Bold.woff2") format("woff2");
-  font-display: swap;
-}
-
-@font-face {
-  font-family: raleway-extrabold;
-  src: url("../fonts/Raleway/Raleway-ExtraBold.woff2") format("woff2");
-  font-display: swap;
-}
-
 
 html,
 body {
@@ -1235,8 +1220,8 @@ kbd {
  * CSS for the footer header
 */
 .footer-header {
-  font-family: raleway-extrabold, sans-serif;
-  font-weight: bold;
+  font-family: var(--font-accent);
+  font-weight: 800;
   color: var(--color-asphalt-500);
   font-size: 12px;
   line-height: 2.1em;

--- a/public/css/pages/homepage.css
+++ b/public/css/pages/homepage.css
@@ -315,10 +315,13 @@ video#bgvid {
   text-align: center;
 }
 
+/* Digits in Raleway, against the general rule (#4912): these four are the homepage's headline moment, and `lnum` is
+   already a feature of the face we ship, so lining figures cost nothing the rule exists to protect. */
 .ps-skyline-stats-holder-stat-number {
   font-size: 60px;
   font-family: var(--font-accent);
   font-weight: 800;
+  font-variant-numeric: lining-nums;
 }
 
 .ps-skyline-stats-holder-stat-label {

--- a/public/css/pages/homepage.css
+++ b/public/css/pages/homepage.css
@@ -310,7 +310,6 @@ video#bgvid {
 
   display: grid;
   grid-template-columns: 1fr 1fr 1fr 1fr;
-  gap: 8px;
 
   text-align: center;
 }

--- a/public/css/pages/homepage.css
+++ b/public/css/pages/homepage.css
@@ -96,7 +96,8 @@
 }
 
 .activetab {
-  font-family: Raleway-bold, sans-serif;
+  font-family: var(--font-accent);
+  font-weight: 700;
   background-color: var(--color-pine-500);
   overflow: hidden;
 }
@@ -314,8 +315,8 @@ video#bgvid {
   text-align: center;
 }
 
-/* Digits in Raleway, against the general rule (#4912): these four are the homepage's headline moment, and `lnum` is
-   already a feature of the face we ship, so lining figures cost nothing the rule exists to protect. */
+/* Digits in Raleway, against the general rule: these four are the homepage's headline moment, and `lnum` is already a
+   feature of the face we ship, so lining figures cost nothing the rule exists to protect. */
 .ps-skyline-stats-holder-stat-number {
   font-size: 60px;
   font-family: var(--font-accent);

--- a/public/css/pages/homepage.css
+++ b/public/css/pages/homepage.css
@@ -202,12 +202,12 @@ video#bgvid {
 */
 
 .tagline {
-  font-family: raleway-bold, sans-serif;
+  font-family: var(--font-accent);
   font-size: 50px;
   letter-spacing: 0.05em;
   font-style: normal;
   font-variant: normal;
-  font-weight: bold;
+  font-weight: 700;
   line-height: 1em;
   color: var(--color-neutral-white);
 }
@@ -317,7 +317,8 @@ video#bgvid {
 
 .ps-skyline-stats-holder-stat-number {
   font-size: 60px;
-  font-family: raleway-extrabold, sans-serif;
+  font-family: var(--font-accent);
+  font-weight: 800;
 }
 
 .ps-skyline-stats-holder-stat-label {

--- a/public/css/pages/mobile-landing.css
+++ b/public/css/pages/mobile-landing.css
@@ -43,9 +43,9 @@
 }
 
 #mobile-landing-tagline {
-  font-family: Raleway-bold, sans-serif;
+  font-family: var(--font-accent);
   font-size: 30px;
-  font-weight: bold;
+  font-weight: 700;
   color: var(--color-neutral-white);
   line-height: 1.2;
   letter-spacing: 0.04em;
@@ -177,11 +177,12 @@
   margin: 24px auto 0;
 }
 
+/* Primary font, not the accent one: Raleway's old-style figures drop 3/4/5/7/9 below the baseline. */
 .mobile-stat-number {
   display: block;
-  font-family: Raleway-extrabold, sans-serif;
+  font-family: var(--font-primary);
   font-size: 36px;
-  font-weight: bold;
+  font-weight: 800;
   color: var(--color-asphalt-500);
   line-height: 1.1;
 }
@@ -241,9 +242,9 @@
 }
 
 .mobile-cta-heading {
-  font-family: Raleway-bold, sans-serif;
+  font-family: var(--font-accent);
   font-size: 26px;
-  font-weight: bold;
+  font-weight: 700;
   color: var(--color-neutral-white);
   margin: 0 0 12px;
   line-height: 1.2;


### PR DESCRIPTION
resolves #4912

Four commits, split so the visual changes are easy to review or revert on their own.

### 1. Retire the legacy `raleway-bold` / `raleway-extrabold` families

Now that `raleway` carries real 400/700/800 faces (#4901), the two single-face families that selected a weight by family name are redundant — each names the same file as a weight on `raleway`. The rules that still used them move to `var(--font-accent)` plus the weight, and the two `@font-face` blocks are removed.

Three are exact no-ops. They set no weight, so they asked for 400 from a family whose only face declares no weight descriptor, and now ask for 800 from a family that has one — same file, same match:

- `pages/homepage.css` — `.ps-skyline-stats-holder-stat-number`
- `components/deployment-map.css` — `.deployment-sites-stats-header`, `.cta-title`

**Two are not, and they change how the page looks.** `.tagline` (homepage) and `.footer-header` (site-wide) asked for `bold` from a family whose only face is 400, so the browser *synthesized* bold on top of outlines that were already Bold and ExtraBold respectively — both have been rendering double-bolded. On the real weight axis they pick the actual face, which reads **visibly lighter** than what ships today. Same defect #4901 fixed for the heading tokens.

The issue also called for deleting `leaderboard.css` and migrating `user-profile.css`'s `.user-stats-header`; both files were already removed by the CSS reorg (#5030) and the user dashboard redesign, so nothing was left to do there.

### 2. Give the skyline stats lining figures

The four numbers under the homepage skyline are the largest digits on the site and the loudest case of Raleway's old-style figures: 3, 4, 5, 7 and 9 drop below the baseline while 0, 1 and 2 sit short, so a six-figure count reads as a wobble. This is the same defect as #4907, on the homepage instead of the sidebar.

Raleway ships an `lnum` feature, so `font-variant-numeric: lining-nums` gets aligned digits out of the face that is already loaded — no second family, no new `@font-face`, no new download.

This is a deliberate one-off exception to the "never set numbers in Raleway" rule in CLAUDE.md, taken because these four numbers are the one place on the homepage the accent face is really carrying the design, and because `lnum` removes the reason the rule exists. The alternative considered was swapping them to a primary-font token, which works but costs the brand moment. A comment on the rule records the reasoning; the general rule is unchanged and still applies everywhere else.

Note that Raleway ships `lnum` but **not** `tnum`, so the digits are aligned but still proportional — the CountUp animation shimmies slightly as it runs. That is unchanged from today (the old-style digits were proportional too) and isn't fixable from this face.

### 3. Close the gap between the stats and their labels

Aligning the figures added a little vertical air under each number, so the `gap` on `.ps-skyline-stats-holder` comes off. Purely a look call, made against the running page.

### 4. Migrate the four rules the first pass missed

The audit in commit 1 matched `Raleway-bold` / `Raleway-extrabold` case-sensitively and so skipped four rules that spell the family with a capital R. CSS family matching is ASCII case-insensitive, so those were live consumers and would have dropped to the system sans-serif once the `@font-face` blocks went away:

- `pages/homepage.css` — `.activetab`
- `pages/mobile-landing.css` — `#mobile-landing-tagline`, `.mobile-cta-heading`

Those three keep their intended Raleway weight via `var(--font-accent)`. The fourth, `pages/mobile-landing.css`'s `.mobile-stat-number`, holds a bare digit string, so it moves to `var(--font-primary)` per the numbers rule rather than back to the accent face — **another intended visual change**, on the mobile landing page's two stat figures.

### Testing

- Compared all the candidates on the running homepage with the real vendored fonts and real data before picking.
- Confirmed the shipped Raleway faces' OpenType features directly with fontTools: `aalt dlig kern liga lnum onum salt smcp ss01 ss02` on all three.
- `stylelint` clean on `public/css/**`; `check-css-layout.mjs` passes.
- Worth an eyeball on the homepage tagline, the site footer header, and the mobile landing stats, since those are the intended visual changes.
