### PR TITLE
Stop the emphasized "today" axis label from being stroked like a reference line

### DIFF
--- a/public/css/pages/admin-dashboard.css
+++ b/public/css/pages/admin-dashboard.css
@@ -593,7 +593,11 @@
 
 /* Emphasized category (opts.emphasisIndex — e.g. the in-progress "today" bar): bolder, darker text; the bar itself
    renders with a lighter fill + solid outline so a partial period reads as still accumulating. */
-.mini-axis--emphasis,
+.mini-axis--emphasis {
+  fill: var(--color-neutral-900);
+  font: var(--text-caption-semibold);
+}
+
 /* Reference line: a target the bars are read against (e.g. the poll's nightly batch size), not a data series. */
 .mini-ref {
   stroke: var(--color-neutral-700);


### PR DESCRIPTION
Fixes #5051.

### The bug

On `/admin/across-cities` → **This week (rolling 7 days)**, the current day's x-axis label renders with a broken,
smeared outline instead of the intended bold. It is not a font problem.

![Across Cities "Labels per day" chart for the rolling 7 days: Sun through Fri render normally, while Sat (today) is drawn with a broken, dashed outline over the glyphs](https://raw.githubusercontent.com/ProjectSidewalk/SidewalkWebpage/d69e1278edc9eb300bc82c0bc2e3483fe46053f7/5051-across-cities-today-axis-label.png)

`.mini-axis--emphasis` was separated from its own declarations by the comment that introduces `.mini-ref`, so CSS
parsed it as the first half of the reference line's selector list:

```css
.mini-axis--emphasis,
/* Reference line: a target the bars are read against ... */
.mini-ref {
  stroke: var(--color-neutral-700);
  stroke-width: 1.5;
  stroke-dasharray: 5 4;
  opacity: 0.75;
}
```

Every glyph of the emphasized weekday was therefore painted with a 1.5px dashed stroke at 75% opacity, and it never
received the bold, darker fill the comment above it promises. #4689 added the selector correctly paired with
`.mini-value--emphasis`; #4908 inserted the new `.mini-ref` rule between the selector and the block it belonged to.
`.mini-value--emphasis` kept the original declarations, which is why the number above the bar still looks right and
only the axis label is broken.

### The fix

Split the selector back out into its own rule, setting the weight with the composite caption token rather than the
pre-#4300 raw `font-weight: 700`:

```css
.mini-axis--emphasis {
  fill: var(--color-neutral-900);
  font: var(--text-caption-semibold);
}
```

### Scope

`emphasisIndex` has exactly one caller — `AcrossCitiesPage.js` `#drawWeekBars()` — so this touches the last (today)
bar's label on the three rolling-7-day charts (Labels, Validations, Contributors) and nothing else. Purely visual.

The broken rule is identical on `master`, so prod carries it until the next release; merging here does not ship it.

### Testing

- `stylelint` clean and `tools/check-css-layout.mjs` OK, both run against this branch's copy of the file.
- Visual QA on the three rolling-7-day charts: today's weekday label should render solid semibold in
  `--color-neutral-900` with no outline, and the other six unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-opus-5[1m])