### PR TITLE
Re-enable the label popup's Next arrow when a deep link's labels land

### DIFF
--- a/app/views/apps/labelMap.scala.html
+++ b/app/views/apps/labelMap.scala.html
@@ -242,6 +242,8 @@
         labelLoader.onData(() => {
           sidebarFilter.refresh();
           self.nearbyNav.refresh();
+          // The navigator's label set decides whether the arrows are live, so the open popup re-evaluates them.
+          params.popupLabelViewer.refreshPagingState();
           // Re-assert the spotlight for an open (deep-linked) label: the layer filters survive a data swap, but
           // the label itself may only now be present in the source — and its exact coords refine an approximate
           // camera-coords placement.

--- a/app/views/apps/labelMap.scala.html
+++ b/app/views/apps/labelMap.scala.html
@@ -241,9 +241,8 @@
         let zoomHintLogged = false;
         labelLoader.onData(() => {
           sidebarFilter.refresh();
+          // Also re-evaluates the popup's prev/next arrows, which subscribe to the navigator they page over.
           self.nearbyNav.refresh();
-          // The navigator's label set decides whether the arrows are live, so the open popup re-evaluates them.
-          params.popupLabelViewer.refreshPagingState();
           // Re-assert the spotlight for an open (deep-linked) label: the layer filters survive a data swap, but
           // the label itself may only now be present in the source — and its exact coords refine an approximate
           // camera-coords placement.

--- a/public/js/common/label-detail/LabelPopup.js
+++ b/public/js/common/label-detail/LabelPopup.js
@@ -147,6 +147,14 @@ async function LabelPopup(admin, viewerType, viewerAccessToken, currUsername, op
     updatePagingState();
   };
 
+  /**
+   * Recomputes the arrows' disabled state against the navigator's current label set. A host whose label data
+   * arrives (or is swapped by a refetch) after the popup opened calls this once the navigator has been
+   * refreshed; without it a deep-linked label's arrows keep the state computed while the set was still empty
+   * (#5068).
+   */
+  labelDetail.refreshPagingState = updatePagingState;
+
   // Expose the LabelDetail instance's properties for backwards compatibility with callsites that reach
   // into the popup (e.g. for `panoManager`).
   labelDetail.showLabel = showLabel;

--- a/public/js/common/label-detail/LabelPopup.js
+++ b/public/js/common/label-detail/LabelPopup.js
@@ -136,24 +136,20 @@ async function LabelPopup(admin, viewerType, viewerAccessToken, currUsername, op
 
   /**
    * Enables the prev/next arrows, stepping through labels via the given navigator (see nearbyLabelNavigator.js).
-   * @param {{next: function, prev: function, hasPrev: function, hasNext: function}} nav Navigator over the
-   *     host's label set.
+   * @param {{next: function, prev: function, hasPrev: function, hasNext: function,
+   *     onRefresh: function}} nav Navigator over the host's label set. Its onRefresh is what keeps the arrows
+   *     honest on a host whose label set changes under them: LabelMap loads labels by viewport (#5002), so a
+   *     deep-linked popup opens over an empty set and has nowhere to page until the set fills (#5068).
    */
   labelDetail.setNearbyNavigator = (nav) => {
+    // Subscribe only for a navigator we haven't seen, so a repeat call can't stack duplicate recomputes.
+    if (nav !== nearbyNav) nav.onRefresh(updatePagingState);
     nearbyNav = nav;
     if (!prevBtn || !nextBtn) return;
     prevBtn.hidden = false;
     nextBtn.hidden = false;
     updatePagingState();
   };
-
-  /**
-   * Recomputes the arrows' disabled state against the navigator's current label set. A host whose label data
-   * arrives (or is swapped by a refetch) after the popup opened calls this once the navigator has been
-   * refreshed; without it a deep-linked label's arrows keep the state computed while the set was still empty
-   * (#5068).
-   */
-  labelDetail.refreshPagingState = updatePagingState;
 
   // Expose the LabelDetail instance's properties for backwards compatibility with callsites that reach
   // into the popup (e.g. for `panoManager`).

--- a/public/js/ps-map/nearbyLabelNavigator.js
+++ b/public/js/ps-map/nearbyLabelNavigator.js
@@ -6,10 +6,12 @@
  * @param {Object} mapData The map layer tracker returned by addLabelsToMap (reads .sortedLabels).
  * @returns {{next: function(number): ?number, prev: function(number): ?number, hasPrev: function(number): boolean,
  *     hasNext: function(number): boolean, getCoords: function(number): ?Array<number>,
- *     getLabelType: function(number): ?string, refresh: function(): void}}
+ *     getLabelType: function(number): ?string, refresh: function(): void,
+ *     onRefresh: function(function(): void): void}}
  *     Navigator whose paging methods take the currently shown label ID and return the label ID to show (null when
  *     there is nowhere to go); getCoords/getLabelType look up a loaded label's [lng, lat] / label type; refresh
- *     re-reads .sortedLabels after a viewport refetch has swapped the loaded labels.
+ *     re-reads .sortedLabels after a viewport refetch has swapped the loaded labels, notifying onRefresh
+ *     subscribers so everything derived from the label set (e.g. the popup's arrow states) follows it.
  */
 function createNearbyLabelNavigator(mapData) {
   // label_id -> [lng, lat] and label_id -> label type for every label on the map, flattened across types.
@@ -26,6 +28,11 @@ function createNearbyLabelNavigator(mapData) {
     }
   };
   rebuild();
+
+  // Subscribers re-derive whatever they compute from the label set. Anything holding state keyed on the set —
+  // the popup's prev/next disabled states — is only correct if it recomputes with the set, so the navigator
+  // announces the change rather than leaving each host to pair a second call with every refresh() (#5068).
+  const refreshListeners = [];
 
   // The trail and visited set deliberately survive refresh(): prev() retraces even labels a refetch dropped
   // (the page falls back to popup-metadata coords for those), and next() from a dropped label returns null,
@@ -89,6 +96,12 @@ function createNearbyLabelNavigator(mapData) {
     getLabelType(labelId) {
       return typeById.get(labelId) ?? null;
     },
-    refresh: rebuild,
+    refresh() {
+      rebuild();
+      for (const listener of refreshListeners) listener();
+    },
+    onRefresh(callback) {
+      refreshListeners.push(callback);
+    },
   };
 }

--- a/test/js/labelPopupPagingRefresh.test.js
+++ b/test/js/labelPopupPagingRefresh.test.js
@@ -1,0 +1,81 @@
+/**
+ * Tests for the label popup's prev/next arrow state (public/js/common/label-detail/LabelPopup.js) when the host's
+ * label data arrives after the popup has already opened.
+ *
+ * LabelMap loads labels by viewport (#5002), so a `?labelId=` deep link opens the popup before any label data
+ * exists. The arrows are computed from the nearby-label navigator, which is empty at that moment, so the host has
+ * to ask the popup to recompute once the data lands — otherwise Next stays disabled forever (#5068).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const NAV_PATH = path.join(REPO_ROOT, 'public/js/ps-map/nearbyLabelNavigator.js');
+const POPUP_PATH = path.join(REPO_ROOT, 'public/js/common/label-detail/LabelPopup.js');
+
+/** Builds the parts of labelPopup.scala.html / labelDetail.scala.html that LabelPopup queries. */
+function renderPopupMarkup() {
+    document.body.innerHTML = `
+        <dialog id="label-modal" class="label-detail">
+          <button type="button" data-action="close-label-detail"></button>
+          <button type="button" class="label-detail__paging label-detail__paging--prev"></button>
+          <button type="button" class="label-detail__paging label-detail__paging--next"></button>
+        </dialog>`;
+}
+
+/** A label feature in the shape addLabelsToMap produces. */
+const feature = (id, lng, lat) => ({ properties: { label_id: id }, geometry: { coordinates: [lng, lat] } });
+
+describe('LabelPopup paging state', () => {
+    let popup;
+    let mapData;
+    let nav;
+
+    beforeEach(async () => {
+        renderPopupMarkup();
+        // jsdom has no modal dialog implementation, and LabelPopup's init sequence opens and closes the dialog.
+        window.HTMLDialogElement.prototype.showModal = jest.fn();
+        window.HTMLDialogElement.prototype.close = jest.fn();
+        window.requestAnimationFrame = (cb) => cb();
+        window.logWebpageActivity = jest.fn();
+        // LabelDetail does the rendering/fetching; the popup only wraps it, so a stub is enough here.
+        global.LabelDetail = {
+            create: async () => ({ showLabel: async () => ({}) }),
+            urlLabelId: () => null,
+            syncUrlLabelId: jest.fn(),
+        };
+
+        (0, eval)(fs.readFileSync(NAV_PATH, 'utf8')); // Declares createNearbyLabelNavigator globally.
+        (0, eval)(fs.readFileSync(POPUP_PATH, 'utf8')); // Declares LabelPopup globally.
+
+        // The navigator is created over the map's label set, which is still empty while the viewport data loads.
+        mapData = { sortedLabels: {} };
+        nav = global.createNearbyLabelNavigator(mapData);
+        popup = await global.LabelPopup(false, null, null, null, {});
+        popup.setNearbyNavigator(nav);
+    });
+
+    test('Next is enabled once the host refreshes the navigator and the paging state', async () => {
+        const nextBtn = document.querySelector('.label-detail__paging--next');
+        await popup.showLabel(1, 'LabelMap');
+        expect(nextBtn.disabled).toBe(true);
+
+        // The viewport's labels land, as labelMap's labelLoader.onData handler sees it.
+        mapData.sortedLabels = { CurbRamp: [feature(1, 0, 0), feature(2, 0.001, 0)] };
+        nav.refresh();
+        popup.refreshPagingState();
+
+        expect(nextBtn.disabled).toBe(false);
+    });
+
+    test('Prev stays disabled on the first label, since nothing has been visited yet', async () => {
+        const prevBtn = document.querySelector('.label-detail__paging--prev');
+        await popup.showLabel(1, 'LabelMap');
+        mapData.sortedLabels = { CurbRamp: [feature(1, 0, 0), feature(2, 0.001, 0)] };
+        nav.refresh();
+        popup.refreshPagingState();
+
+        expect(prevBtn.disabled).toBe(true);
+    });
+});

--- a/test/js/labelPopupPagingRefresh.test.js
+++ b/test/js/labelPopupPagingRefresh.test.js
@@ -1,10 +1,11 @@
 /**
  * Tests for the label popup's prev/next arrow state (public/js/common/label-detail/LabelPopup.js) when the host's
- * label data arrives after the popup has already opened.
+ * label data changes after the popup has already opened.
  *
  * LabelMap loads labels by viewport (#5002), so a `?labelId=` deep link opens the popup before any label data
- * exists. The arrows are computed from the nearby-label navigator, which is empty at that moment, so the host has
- * to ask the popup to recompute once the data lands — otherwise Next stays disabled forever (#5068).
+ * exists. The arrows are computed from the nearby-label navigator, which is empty at that moment, so the popup
+ * subscribes to the navigator and recomputes whenever the loaded set changes — a single `nav.refresh()` from the
+ * host has to be enough, in both directions (#5068).
  */
 
 const fs = require('fs');
@@ -27,10 +28,15 @@ function renderPopupMarkup() {
 /** A label feature in the shape addLabelsToMap produces. */
 const feature = (id, lng, lat) => ({ properties: { label_id: id }, geometry: { coordinates: [lng, lat] } });
 
+/** Two labels ~111m apart, the shape a viewport fetch lands in. */
+const TWO_LABELS = { CurbRamp: [feature(1, 0, 0), feature(2, 0.001, 0)] };
+
 describe('LabelPopup paging state', () => {
     let popup;
     let mapData;
     let nav;
+    let prevBtn;
+    let nextBtn;
 
     beforeEach(async () => {
         renderPopupMarkup();
@@ -54,28 +60,56 @@ describe('LabelPopup paging state', () => {
         nav = global.createNearbyLabelNavigator(mapData);
         popup = await global.LabelPopup(false, null, null, null, {});
         popup.setNearbyNavigator(nav);
+        prevBtn = document.querySelector('.label-detail__paging--prev');
+        nextBtn = document.querySelector('.label-detail__paging--next');
     });
 
-    test('Next is enabled once the host refreshes the navigator and the paging state', async () => {
-        const nextBtn = document.querySelector('.label-detail__paging--next');
-        await popup.showLabel(1, 'LabelMap');
-        expect(nextBtn.disabled).toBe(true);
-
-        // The viewport's labels land, as labelMap's labelLoader.onData handler sees it.
-        mapData.sortedLabels = { CurbRamp: [feature(1, 0, 0), feature(2, 0.001, 0)] };
+    /** Lands a viewport fetch's worth of labels the way labelMap's labelLoader.onData handler does. */
+    function landViewportData(sortedLabels) {
+        mapData.sortedLabels = sortedLabels;
         nav.refresh();
-        popup.refreshPagingState();
+    }
+
+    test('Next enables on the host\'s nav.refresh() alone, with no second call to the popup', async () => {
+        await popup.showLabel(1, 'LabelMap');
+        expect(nextBtn.disabled).toBe(true); // Nowhere to go while the navigator has never heard of label 1.
+
+        landViewportData(TWO_LABELS);
 
         expect(nextBtn.disabled).toBe(false);
     });
 
-    test('Prev stays disabled on the first label, since nothing has been visited yet', async () => {
-        const prevBtn = document.querySelector('.label-detail__paging--prev');
+    test('Next disables again when a refetch drops every label but the shown one', async () => {
         await popup.showLabel(1, 'LabelMap');
-        mapData.sortedLabels = { CurbRamp: [feature(1, 0, 0), feature(2, 0.001, 0)] };
-        nav.refresh();
-        popup.refreshPagingState();
+        landViewportData(TWO_LABELS);
+        expect(nextBtn.disabled).toBe(false);
 
-        expect(prevBtn.disabled).toBe(true);
+        // The map moved on, so the neighbor is outside the new bbox and the popup can no longer page to it.
+        landViewportData({ CurbRamp: [feature(1, 0, 0)] });
+
+        expect(nextBtn.disabled).toBe(true);
+    });
+
+    test('Prev is disabled on the first label and enables once the tour moves on', async () => {
+        await popup.showLabel(1, 'LabelMap');
+        landViewportData(TWO_LABELS);
+        expect(prevBtn.disabled).toBe(true); // Trail-based: nothing has been visited yet.
+
+        nextBtn.click();
+        await Promise.resolve(); // The click's showLabel() is async; let it settle.
+
+        expect(prevBtn.disabled).toBe(false);
+    });
+
+    test('a refetch that drops the trail\'s labels leaves Prev live', async () => {
+        await popup.showLabel(1, 'LabelMap');
+        landViewportData(TWO_LABELS);
+        nextBtn.click();
+        await Promise.resolve();
+
+        // Label 1 is gone from the loaded set, but it is still where Prev goes back to.
+        landViewportData({ CurbRamp: [feature(2, 0.001, 0)] });
+
+        expect(prevBtn.disabled).toBe(false);
     });
 });

--- a/test/js/nearbyLabelNavigator.test.js
+++ b/test/js/nearbyLabelNavigator.test.js
@@ -131,4 +131,21 @@ describe('createNearbyLabelNavigator', () => {
         expect(nav.prev(2)).toBe(1);
         expect(nav.next(1)).toBeNull();
     });
+
+    test('refresh() notifies onRefresh subscribers, after the new label set is readable', () => {
+        const mapData = mapDataWith({ CurbRamp: [[1, 0, 0]] });
+        const nav = loadFactory()(mapData);
+        const seen = [];
+        // Subscribers exist to re-derive state from the label set (the popup's arrow states), so what they can
+        // read when they run is the contract, not just that they ran.
+        nav.onRefresh(() => seen.push(nav.hasNext(1)));
+        nav.onRefresh(() => seen.push('second subscriber'));
+
+        expect(seen).toEqual([]); // Subscribing is not itself a refresh.
+
+        mapData.sortedLabels.CurbRamp.push({ properties: { label_id: 2 }, geometry: { coordinates: [0.001, 0] } });
+        nav.refresh();
+
+        expect(seen).toEqual([true, 'second subscriber']);
+    });
 });


### PR DESCRIPTION
Fixes #5068.

## Problem

On `/labelMap?labelId=<id>` both popup arrows are greyed out, and **Next** never comes back — it only works once you open a different label some other way (a map click).

The arrows' `disabled` state is computed by `LabelPopup.updatePagingState()`, which ran in exactly two places: `showLabel()` and `setNearbyNavigator()`. Since #5002 `/labelMap` loads label data by viewport, so on a deep link both of those run while the nearby-label navigator's set is still empty, and `hasNext()` answers `false` for a label it has never heard of. The map's `labelLoader.onData()` handler does rebuild the navigator (`nearbyNav.refresh()`), but nothing recomputed the buttons — so they kept the state computed against the empty set.

(Prev being disabled on the *first* label is correct: `hasPrev` is trail-based.)

## Fix

The arrows are derived from the navigator's label set, so they are only correct while something recomputes them whenever that set changes. Rather than ask each host to pair a popup call with every `nav.refresh()` — which leaves the same gap open for the next call site — **the navigator publishes the change and the popup subscribes**:

- `createNearbyLabelNavigator` gains `onRefresh(cb)`, and `refresh()` notifies subscribers after the rebuild. This is the same shape `ViewportLabelLoader` already uses for `onData` / `onError` / `onStateChange`.
- `LabelPopup.setNearbyNavigator()` subscribes its recompute, so the arrows re-evaluate whenever the loaded set does — on the first viewport load and on every refetch after it.
- `labelMap.scala.html`'s data handler is unchanged in size: `self.nearbyNav.refresh()` alone now keeps the arrows honest.

## Tests

`test/js/labelPopupPagingRefresh.test.js` drives the real `LabelPopup` and the real `createNearbyLabelNavigator`, and pins **both** directions: a deep-linked label over an empty set has Next disabled, viewport data landing enables it, and a refetch that drops the neighbours disables it again. Two more cover Prev — disabled on the first label, enabled once the tour moves on, and still enabled after a refetch drops the trail's labels (the trail deliberately outlives the label set). All four fail with the subscription removed.

`test/js/nearbyLabelNavigator.test.js` gains a case for the new `onRefresh` contract: subscribers fire on `refresh()` in order, and the new label set is already readable when they do.

`npm run test:js`: 1346 passed, 1 pre-existing failure unrelated to this PR (`selfHostedAssets.test.js` asserts `>= 5` self-hosted font families; #5048 took `public/fonts/` down to 3). `make lint` is fully green.

## QA

Verified in the running dev app on `/labelMap?labelId=…` deep links: Next goes live once the viewport labels stream in, Prev lights up after the first hop, and a mid-tour refresh (the popup writes `?labelId=` into the URL) recovers on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-opus-5[1m])
