### PR TITLE
Add a camera icon to the story composer's photo button

### DIFF
--- a/app/views/common/storyComposer.scala.html
+++ b/app/views/common/storyComposer.scala.html
@@ -31,6 +31,7 @@
       @* Accepted types must stay in sync with StoryService's sniffed-format allowlist (stock ImageIO: no WebP). *@
       <input type="file" id="@{idPrefix}-photo" class="story-composer__photo-input sr-only"
              accept="image/jpeg,image/png">
+      <img class="story-composer__photo-icon" src='@assets.path("images/icons/camera-feather.svg")' alt="">
       <span data-i18n="labelmap:story.add-photo">Add a photo (optional)</span>
     </label>
     <div class="story-composer__photo-preview" hidden>

--- a/public/css/components/label-detail.css
+++ b/public/css/components/label-detail.css
@@ -1520,6 +1520,12 @@ dialog.story-lightbox::backdrop { background: rgb(0 0 0 / 45%); }
 
 .story-composer__photo-attach[hidden] { display: none; }
 
+.story-composer__photo-icon {
+  width: 16px;
+  height: 16px;
+  display: block;
+}
+
 .story-composer__photo-attach:hover {
   border-color: var(--color-pine-700);
   color: var(--color-pine-800);

--- a/public/images/icons/camera-feather.svg
+++ b/public/images/icons/camera-feather.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z" stroke="#242424" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="12" cy="13" r="4" stroke="#242424" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
## What

The story composer's **"Add a photo (optional)"** control was the only unadorned affordance in the dialog. With a
dashed border, a muted label and no icon, it read as an empty text field rather than something to click. This adds a
camera icon to it.

| Before | After |
| --- | --- |
| `[ Add a photo (optional) ]` | `[ 📷 Add a photo (optional) ]` |

## Following the existing icon convention

Project Sidewalk's UI icons are **Feather**, hand-vendored one file at a time into `public/images/icons/` as
`*-feather.svg` — 42 of them (`award`, `chevron-*`, `file-text`, `map-pin`, `message-circle`, `trash-2`, …), each an
exact Feather glyph name. There is no npm package or `vendor/` folder for the set, so a new icon means adding the
file.

`camera` was simply missing. `public/images/icons/camera-feather.svg` is the official Feather `camera` glyph in the
folder's house format — 24×24, `viewBox="0 0 24 24"`, `fill="none"`, per-element `stroke="#242424"`,
`stroke-width="2"`, round caps and joins — matching `file-text-feather.svg` beside it.

## Changes

- **`public/images/icons/camera-feather.svg`** (new) — the Feather `camera` glyph.
- **`app/views/common/storyComposer.scala.html`** — one `<img>` before the label span, referenced through
  `assets.path` and quoted the same way as the dialog's existing close-button icon (single quotes, since the Twirl
  expression carries double ones).
- **`public/css/components/label-detail.css`** — a 4-line rule sizing it to 16px square. The button was already
  `display: inline-flex` with an `8px` gap, so no layout change was needed.

## Accessibility

`alt=""` — the icon is decorative and the button's own text carries the meaning, so it is never the only cue. No
user-facing strings change, so no locale files are touched.

One known limitation: the button's text shifts to `--color-pine-800` on hover, but an `<img>` cannot inherit
`currentColor`, so the icon stays `#242424`. Every other icon in the repo behaves this way; tinting it would mean an
inline SVG or a CSS mask, which felt out of proportion for this change. Happy to do it if preferred.

## Testing

- Verified live on a local dev app: the `<img>` renders in `/labelMap`'s markup and `camera-feather.svg` serves
  `HTTP 200`; the icon appears in the composer at the intended size.
- Stylelint, HTMLHint, and `check-css-layout.mjs` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 5 (1M context), `claude-opus-5[1m]`

https://claude.ai/code/session_01Q3MkRGUjnQRqwipDS8t6yT
