### PR TITLE
Build the web container natively instead of pinning x86_64 (#5069)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
 services:
+  # No `platform:` — the image is arch-agnostic, so each host builds natively instead of emulating (#5069).
   web:
     image: projectsidewalk/web
     container_name: projectsidewalk-web
@@ -12,7 +13,6 @@ services:
       - "/home/node_modules"
     ports:
       - "9000:9000"
-    platform: linux/x86_64
     environment:
       - DATABASE_USER=sidewalk
       - SIDEWALK_CITY_ID=DUMMY_CITY_ID

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
 services:
-  # No `platform:` — the image is arch-agnostic, so each host builds natively instead of emulating (#5069).
   web:
     image: projectsidewalk/web
     container_name: projectsidewalk-web
@@ -13,6 +12,8 @@ services:
       - "/home/node_modules"
     ports:
       - "9000:9000"
+    # No `platform:` here — the web image builds on both amd64 and arm64, so each host builds natively instead of
+    # emulating (#5069). An override file's `platform:` still wins over this, so leave that one commented too.
     environment:
       - DATABASE_USER=sidewalk
       - SIDEWALK_CITY_ID=DUMMY_CITY_ID

--- a/docker/e2e/Dockerfile
+++ b/docker/e2e/Dockerfile
@@ -2,9 +2,8 @@
 #
 # Why its own image rather than the web container: the official Playwright image already carries Chromium and
 # every OS library it needs at PLAYWRIGHT_BROWSERS_PATH=/ms-playwright, and it publishes a multi-arch manifest,
-# so Apple Silicon gets a native browser. The web image installs none of Chromium's runtime libs, pins
-# `platform: linux/x86_64` (an emulated browser on M-series Macs), caps /dev/shm at 256mb, and would lose any
-# browser installed at runtime the next time the container is recreated.
+# so Apple Silicon gets a native browser. The web image installs none of Chromium's runtime libs, caps /dev/shm at
+# 256mb, and would lose any browser installed at runtime the next time the container is recreated.
 #
 # PW_VERSION comes from `make test-e2e`, which reads it out of package.json. The base image tag and the runner
 # installed below therefore both derive from the repo's @playwright/test pin and cannot drift apart.

--- a/docs/dev-environment.md
+++ b/docs/dev-environment.md
@@ -95,7 +95,9 @@ Make sure Docker is running (you'll see the whale icon in your tray; you can set
    edit it for the city you want to run:
    - **`SIDEWALK_CITY_ID`** — the city to run (e.g. `seattle-wa`); see the [City IDs table](#city-ids).
    - **`DATABASE_USER`** — that city's database user, replacing the default `sidewalk` (e.g. `sidewalk_seattle`).
-   - **`platform`** — *Apple Silicon (M-series) only:* uncomment this line.
+   - **`platform`** — leave it commented. Every host builds the web image for its own architecture as of
+     [#5069](https://github.com/ProjectSidewalk/SidewalkWebpage/issues/5069), so Apple Silicon is native
+     without it. Uncomment it *only* if a native build fails, to force an emulated `linux/amd64` build.
 
 2. **Stage the database dumps.** Put the dump files from your maintainer in the **`db/`** directory and rename them
    to the exact names the import scripts expect:
@@ -379,6 +381,7 @@ Roughly ordered by when you'd hit them during setup.
 | `make` commands "just don't work" | Reinstall `make`. As a fallback, run the underlying command from the `Makefile` directly (e.g. `make ssh target=web` ≈ `docker exec -it projectsidewalk-web /bin/bash`). |
 | A new `src/` JS file isn't bundled | Make sure its path matches a glob in `Gruntfile.js`. |
 | First compile seems stuck | It isn't — initial dependency resolution is genuinely slow. Watch the container logs. |
+| Compiles are slow on Apple Silicon | Your `projectsidewalk/web` image may predate [#5069](https://github.com/ProjectSidewalk/SidewalkWebpage/issues/5069) and still be x86_64 — Compose reuses a locally tagged image instead of rebuilding it, so pulling that change alone doesn't help. Check with `docker image inspect projectsidewalk/web --format '{{.Architecture}}'` (expect `arm64`); if it says `amd64`, rebuild with `make docker-stop && docker compose build web`. Also make sure `platform` is commented out in your `docker-compose.override.yml`. |
 
 **Slick query errors while developing:**
 


### PR DESCRIPTION
Closes #5069.

`docker-compose.yml` pinned the web service to `platform: linux/x86_64` in [715d0cf57](https://github.com/ProjectSidewalk/SidewalkWebpage/commit/715d0cf57a2d5ad7a14b5d26a35fd3db92f174a2) (2022-12-30), which replaced an existing `linux/arm64` line. The reason was never recorded, and on Apple Silicon it means every `sbt` compile during local QA runs under emulation.

Nothing in the image needs x86_64 anymore. This **removes the `platform:` line entirely** rather than flipping it to arm64, so each host builds and runs for its own architecture — Intel and WSL contributors are unaffected, and Apple Silicon goes native.

The comment in `docker/e2e/Dockerfile` listed the web image's x86 pin among the reasons the Playwright suite needs its own image; that clause is dropped. The other three reasons (no Chromium runtime libs, the 256mb `/dev/shm` cap, and losing a runtime-installed browser on container recreation) still hold, so the separate image stays.

## Verified locally (aarch64, Apple Silicon)

Rebuilt the image natively and recreated the container:

| Check | Result |
|---|---|
| Image | `linux/arm64`, builds clean |
| JVM | Java 17.0.15, `os.arch = aarch64` |
| node / npm | v24.20.0 / 11.19.0 |
| python3 (3.8.10) | pandas 2.0.3, scipy, haversine, requests — aarch64 wheels |
| python3.13 (3.13.15) | pandas 3.0.5, shapely, geopy |
| `node_modules` volume | repopulates from the image |
| `sbt --jvm-client compile` | `[success] elapsed: 45 s` |
| App boot | serves `/`, `/labelmap`, `/gallery`, `/v3/api/labelTypes`, `/v3/api-docs` — all 200 |

That last row is the one that matters: @misaugstad's recollection of the original problem was "you couldn't spin up the app in the dev env," and the app now boots and serves natively.

## Blast radius

Dev-only:

- **CI** only ever brings up the **db** service via compose (`docker compose up -d --build db`, `ci.yml:189` and `:519`) — it never builds or runs `web`.
- **Deploys** are tag-triggered on makelab1, not compose-driven.

So the only thing this changes is what architecture a contributor's local web container is built for.

## Not fixed by this

I expected going native to also fix the sbtn crash that makes us use `sbt --jvm-client` instead of the documented `sbt --client`. It does not — the failure is byte-for-byte identical on aarch64, just naming a different libc path:

```
sbtn: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found
sbtn: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found
```

That's the base image's glibc — `eclipse-temurin:17-jdk-focal` is Ubuntu 20.04 (glibc 2.31) — not the architecture. A jammy/noble base would be the real fix; happy to file that separately if it's worth doing.

## Sign-off

@misaugstad approved all three questions on #5069: no remembered reason for the pin beyond the 2022 failure, no objection to removing `platform:` entirely, and nothing he wants checked on his machine (Intel Mac, so he never exercises this path).

## Testing

Verified locally as above. Post-merge, worth a sanity check that a fresh `make dev` still works for anyone on Intel/WSL — the change is a no-op there, since Docker was already selecting x86_64 for those hosts, but it's the one path I can't exercise.

## Upgrading an existing checkout

Pulling this change is not enough on its own. Compose reuses a locally tagged `projectsidewalk/web` rather than
rebuilding it, and none of the `make` targets pass `--build`, so an existing container keeps running its old
x86_64 image under emulation — silently, since there is no longer a `platform:` key for the mismatch to trip over:

```bash
docker image inspect projectsidewalk/web --format '{{.Architecture}}'   # expect arm64
make docker-stop && docker compose build web                            # if it says amd64
```

That's now a troubleshooting row in `docs/dev-environment.md`.

**@misaugstad — one thing on your side:** the `docker-compose.override.yml` you distribute still carries a
commented `platform:` line, and the setup docs told Apple Silicon contributors to uncomment it. Compose merges the
override on top of `docker-compose.yml`, so that line re-pins exactly the hosts this PR frees. The docs now describe
it as an escape hatch to use *only* if a native build fails; worth dropping it from the template you hand out.

## How much this actually saves

Same JDK image, same workload, only the architecture differs (`eclipse-temurin:17-jdk-focal`, arm64 vs amd64 on an
M-series host):

| Workload | native arm64 | emulated amd64 | penalty |
|---|---|---|---|
| `javac` over 80 files — class loading + compiler front-end | **561 ms** | **2889 ms** | **5.1x** |
| JIT-heavy tight compute loop — steady state | 547 ms | 611 ms | 1.12x |

Rosetta translates a hot loop once and then runs it near-native, so the emulation cost concentrates in startup,
class loading, and compiler work — which is essentially all of what `sbt compile` does.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 5 (1M context), claude-opus-5[1m]

