### PR TITLE
Emit high_quality_user on rawLabels in all four formats

### DIFF
--- a/app/controllers/helper/ShapefilesCreatorHelper.scala
+++ b/app/controllers/helper/ShapefilesCreatorHelper.scala
@@ -268,6 +268,7 @@ class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: M
       + "tags:String,"            // Tags list
       + "descriptn:String,"       // Description
       + "labelTime:String,"       // Creation timestamp
+      + "hiQualUser:Boolean,"     // Whether the labeler is flagged as a high-quality contributor
       + "streetId:Integer,"       // Street edge ID
       + "osmWayId:String,"        // OSM street ID
       + "regionId:Integer,"       // Region (neighborhood) ID
@@ -311,6 +312,7 @@ class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: M
       featureBuilder.add(label.tags.mkString("[", ",", "]"))
       featureBuilder.add(label.description.orNull)
       featureBuilder.add(label.timeCreated)
+      featureBuilder.add(label.highQualityUser)
       featureBuilder.add(label.streetEdgeId)
       featureBuilder.add(label.osmWayId.toString)
       featureBuilder.add(label.regionId)
@@ -714,43 +716,44 @@ class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: M
     // Define the feature type schema.
     val featureType: SimpleFeatureType = DataUtilities.createType(
       "labels",
-      "the_geom:Point:srid=4326," // the geometry attribute: Point type
-      + "label_id:Integer,"       // label ID
-      + "user_id:String,"         // User Id
-      + "pano_id:String,"         // Pano ID
-      + "pano_source:String,"     // Imagery provider (gsv, mapillary, infra3d)
-      + "label_type:String,"      // Label type
-      + "severity:Integer,"       // Severity
-      + "tags:String,"            // Label Tags
-      + "description:String,"     // Label Description
-      + "time_created:String,"    // Creation timestamp
-      + "street_edge_id:Integer," // Street edge ID
-      + "osm_way_id:String,"      // OSM street ID
-      + "region_id:Integer,"      // Region (neighborhood) ID
-      + "region_name:String,"     // Region (neighborhood) name
-      + "correct:String,"         // Validation correctness
-      + "agree_count:Integer,"    // Agree validations
-      + "disagree_count:Integer," // Disagree validations
-      + "unsure_count:Integer,"   // Unsure validations
-      + "validations:String,"     // Validation details
-      + "audit_task_id:Integer,"  // Audit task ID
-      + "mission_id:Integer,"     // Mission ID
-      + "image_date:String,"      // Image capture date
-      + "heading:Double,"         // Heading angle
-      + "pitch:Double,"           // Pitch angle
-      + "zoom:Integer,"           // Zoom level
-      + "canvas_x:Integer,"       // Canvas X position
-      + "canvas_y:Integer,"       // Canvas Y position
-      + "canvas_width:Integer,"   // Canvas width
-      + "canvas_height:Integer,"  // Canvas height
-      + "pano_x:Integer,"         // Panorama X position
-      + "pano_y:Integer,"         // Panorama Y position
-      + "pano_width:Integer,"     // Panorama width
-      + "pano_height:Integer,"    // Panorama height
-      + "camera_heading:Double,"  // Camera heading
-      + "camera_pitch:Double,"    // Camera pitch
-      + "camera_roll:Double,"     // Camera pitch
-      + "pano_url:String"         // Provider viewer URL (empty for providers without one)
+      "the_geom:Point:srid=4326,"    // the geometry attribute: Point type
+      + "label_id:Integer,"          // label ID
+      + "user_id:String,"            // User Id
+      + "pano_id:String,"            // Pano ID
+      + "pano_source:String,"        // Imagery provider (gsv, mapillary, infra3d)
+      + "label_type:String,"         // Label type
+      + "severity:Integer,"          // Severity
+      + "tags:String,"               // Label Tags
+      + "description:String,"        // Label Description
+      + "time_created:String,"       // Creation timestamp
+      + "high_quality_user:Boolean," // Whether the labeler is flagged as a high-quality contributor
+      + "street_edge_id:Integer,"    // Street edge ID
+      + "osm_way_id:String,"         // OSM street ID
+      + "region_id:Integer,"         // Region (neighborhood) ID
+      + "region_name:String,"        // Region (neighborhood) name
+      + "correct:String,"            // Validation correctness
+      + "agree_count:Integer,"       // Agree validations
+      + "disagree_count:Integer,"    // Disagree validations
+      + "unsure_count:Integer,"      // Unsure validations
+      + "validations:String,"        // Validation details
+      + "audit_task_id:Integer,"     // Audit task ID
+      + "mission_id:Integer,"        // Mission ID
+      + "image_date:String,"         // Image capture date
+      + "heading:Double,"            // Heading angle
+      + "pitch:Double,"              // Pitch angle
+      + "zoom:Integer,"              // Zoom level
+      + "canvas_x:Integer,"          // Canvas X position
+      + "canvas_y:Integer,"          // Canvas Y position
+      + "canvas_width:Integer,"      // Canvas width
+      + "canvas_height:Integer,"     // Canvas height
+      + "pano_x:Integer,"            // Panorama X position
+      + "pano_y:Integer,"            // Panorama Y position
+      + "pano_width:Integer,"        // Panorama width
+      + "pano_height:Integer,"       // Panorama height
+      + "camera_heading:Double,"     // Camera heading
+      + "camera_pitch:Double,"       // Camera pitch
+      + "camera_roll:Double,"        // Camera pitch
+      + "pano_url:String"            // Provider viewer URL (empty for providers without one)
     )
 
     val geometryFactory: GeometryFactory = JTSFactoryFinder.getGeometryFactory
@@ -770,6 +773,7 @@ class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: M
       featureBuilder.add(label.tags.mkString("[", ",", "]"))
       featureBuilder.add(label.description.map(String.valueOf).orNull)
       featureBuilder.add(label.timeCreated)
+      featureBuilder.add(label.highQualityUser)
       featureBuilder.add(label.streetEdgeId)
       featureBuilder.add(String.valueOf(label.osmWayId))
       featureBuilder.add(label.regionId)

--- a/app/models/api/LabelApiModels.scala
+++ b/app/models/api/LabelApiModels.scala
@@ -191,6 +191,7 @@ object LabelValidationSummaryForApi {
  * @param tags List of descriptive tags applied to the label
  * @param description Optional user-provided description of the issue
  * @param timeCreated Timestamp when the label was created
+ * @param highQualityUser Whether the labeler is flagged as a high-quality contributor (`user_stat.high_quality`)
  * @param streetEdgeId Project Sidewalk's street segment identifier
  * @param osmWayId OpenStreetMap way identifier
  * @param regionId Identifier of the region (neighborhood) the label falls within
@@ -230,6 +231,7 @@ case class LabelDataForApi(
     tags: List[String],
     description: Option[String],
     timeCreated: OffsetDateTime,
+    highQualityUser: Boolean,
     streetEdgeId: Int,
     osmWayId: Long,
     regionId: Int,
@@ -299,24 +301,25 @@ case class LabelDataForApi(
       "type"       -> "Feature",
       "geometry"   -> createGeoJsonPointGeometry(longitude, latitude),
       "properties" -> Json.obj(
-        "label_id"       -> labelId,
-        "user_id"        -> userId,
-        "pano_id"        -> panoId,
-        "pano_source"    -> panoSource.toString,
-        "label_type"     -> labelType,
-        "severity"       -> severity,
-        "tags"           -> tags,
-        "description"    -> description,
-        "time_created"   -> timeCreated,
-        "street_edge_id" -> streetEdgeId,
-        "osm_way_id"     -> osmWayId,
-        "region_id"      -> regionId,
-        "region_name"    -> regionName,
-        "correct"        -> correct,
-        "agree_count"    -> agreeCount,
-        "disagree_count" -> disagreeCount,
-        "unsure_count"   -> unsureCount,
-        "validations"    -> validations.map(v =>
+        "label_id"          -> labelId,
+        "user_id"           -> userId,
+        "pano_id"           -> panoId,
+        "pano_source"       -> panoSource.toString,
+        "label_type"        -> labelType,
+        "severity"          -> severity,
+        "tags"              -> tags,
+        "description"       -> description,
+        "time_created"      -> timeCreated,
+        "high_quality_user" -> highQualityUser,
+        "street_edge_id"    -> streetEdgeId,
+        "osm_way_id"        -> osmWayId,
+        "region_id"         -> regionId,
+        "region_name"       -> regionName,
+        "correct"           -> correct,
+        "agree_count"       -> agreeCount,
+        "disagree_count"    -> disagreeCount,
+        "unsure_count"      -> unsureCount,
+        "validations"       -> validations.map(v =>
           Json.obj(
             "user_id"    -> v.userId,
             "validation" -> v.validationType
@@ -362,6 +365,7 @@ case class LabelDataForApi(
       escapeCsvField(tags.mkString("[", ",", "]")),
       description.map(escapeCsvField).getOrElse(""),
       timeCreated.toInstant.toEpochMilli.toString,
+      highQualityUser.toString,
       streetEdgeId.toString,
       osmWayId.toString,
       regionId.toString,
@@ -410,10 +414,10 @@ object LabelDataForApi {
    * This should be included as the first line when generating CSV output.
    */
   val csvHeader: String =
-    "label_id,user_id,pano_id,pano_source,label_type,severity,tags,description,time_created,street_edge_id," +
-      "osm_way_id,region_id,region_name,correct,agree_count,disagree_count,unsure_count,validations,audit_task_id,mission_id," +
-      "image_capture_date,heading,pitch,zoom,canvas_x,canvas_y,canvas_width,canvas_height,pano_x,pano_y,pano_width," +
-      "pano_height,camera_heading,camera_pitch,camera_roll,pano_url,latitude,longitude\n"
+    "label_id,user_id,pano_id,pano_source,label_type,severity,tags,description,time_created,high_quality_user," +
+      "street_edge_id,osm_way_id,region_id,region_name,correct,agree_count,disagree_count,unsure_count,validations," +
+      "audit_task_id,mission_id,image_capture_date,heading,pitch,zoom,canvas_x,canvas_y,canvas_width,canvas_height," +
+      "pano_x,pano_y,pano_width,pano_height,camera_heading,camera_pitch,camera_roll,pano_url,latitude,longitude\n"
 
   /**
    * Implicit JSON writer for LabelData that uses the toJson method.

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -551,6 +551,7 @@ object LabelTable {
           OffsetDateTime.now(ZoneOffset.UTC)
         }
       },
+      highQualityUser = r.nextBoolean(),
       streetEdgeId = r.nextInt(),
       osmWayId = r.nextLong(),
       regionId = r.nextInt(),
@@ -2051,6 +2052,7 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
              array_to_string(label.tags, ','),
              label.description,
              label.time_created,
+             user_stat.high_quality,
              label.street_edge_id,
              osm_way_street_edge.osm_way_id,
              region.region_id,

--- a/test/controllers/api/RawLabelsApiSpec.scala
+++ b/test/controllers/api/RawLabelsApiSpec.scala
@@ -53,10 +53,11 @@ class RawLabelsApiSpec extends PlaySpec with GuiceOneAppPerSuite {
       val body = contentAsString(resp)
       // Header from LabelDataForApi.csvHeader; assert snake_case field names are present and camelCase absent.
       body must include(
-        "label_id,user_id,pano_id,pano_source,label_type,severity,tags,description,time_created,street_edge_id,osm_way_id," +
-          "region_id,region_name,correct,agree_count,disagree_count,unsure_count,validations,audit_task_id,mission_id," +
-          "image_capture_date,heading,pitch,zoom,canvas_x,canvas_y,canvas_width,canvas_height,pano_x,pano_y," +
-          "pano_width,pano_height,camera_heading,camera_pitch,camera_roll,pano_url,latitude,longitude"
+        "label_id,user_id,pano_id,pano_source,label_type,severity,tags,description,time_created,high_quality_user," +
+          "street_edge_id,osm_way_id,region_id,region_name,correct,agree_count,disagree_count,unsure_count," +
+          "validations,audit_task_id,mission_id,image_capture_date,heading,pitch,zoom,canvas_x,canvas_y," +
+          "canvas_width,canvas_height,pano_x,pano_y,pano_width,pano_height,camera_heading,camera_pitch," +
+          "camera_roll,pano_url,latitude,longitude"
       )
       body must not include "labelId"
       body must not include "streetEdgeId"

--- a/test/models/api/LabelApiModelsSpec.scala
+++ b/test/models/api/LabelApiModelsSpec.scala
@@ -10,12 +10,11 @@ import play.api.libs.json.JsObject
 import java.time.{OffsetDateTime, ZoneOffset}
 
 /**
- * Pure (no DB, no app boot) contract test for the `/v3/api/rawLabels` `pano_url` field (#3853).
+ * Pure (no DB, no app boot) contract tests for `/v3/api/rawLabels` output fields the compiler can't check.
  *
- * Locks the provider-aware behavior the compiler can't see: GSV labels get Google's documented Maps URLs link,
- * Mapillary labels get a Mapillary web-app link, and providers with no shareable viewer (infra3d) get `null` in JSON
- * and an empty CSV column. Also guards that the GSV URL carries no API key and matches the in-app `PanoInfoPopover.js`
- * shape (`map_action=pano`, label heading/pitch passed through unchanged).
+ * `pano_url` (#3853) is provider-aware: GSV gets Google's documented Maps URLs link (no API key, matching the in-app
+ * `PanoInfoPopover.js` shape), Mapillary gets a web-app link, infra3d has no viewer so it is `null` / an empty CSV
+ * column. `high_quality_user` (#5067) must reach both JSON and CSV, under the column its header names.
  */
 class LabelApiModelsSpec extends AnyFunSuite with Matchers with OptionValues {
 
@@ -34,6 +33,7 @@ class LabelApiModelsSpec extends AnyFunSuite with Matchers with OptionValues {
     tags = List.empty,
     description = None,
     timeCreated = OffsetDateTime.of(2023, 8, 16, 0, 0, 0, 0, ZoneOffset.UTC),
+    highQualityUser = true,
     streetEdgeId = 951,
     osmWayId = 11584845L,
     regionId = 1,
@@ -101,5 +101,14 @@ class LabelApiModelsSpec extends AnyFunSuite with Matchers with OptionValues {
 
     // pano_url is the antepenultimate column (followed by latitude,longitude); for infra3d it is empty.
     sampleLabel(PanoSource.Infra3d).toCsvRow should endWith(",,40.8839912414551,-74.0243606567383")
+  }
+
+  test("high_quality_user reaches GeoJSON properties and the CSV column its header names") {
+    val label = sampleLabel(PanoSource.Gsv)
+    (label.toJson \ "properties" \ "high_quality_user").as[Boolean] shouldBe true
+
+    val columnIndex = LabelDataForApi.csvHeader.trim.split(",").indexOf("high_quality_user")
+    columnIndex should be >= 0
+    label.toCsvRow.split(",", -1)(columnIndex) shouldBe "true"
   }
 }


### PR DESCRIPTION
resolves #5067

`rawLabels` has documented `properties.high_quality_user` since the `highQualityUserOnly` filter landed (08d52b3b8), but no format ever emitted it — the docs entry and the filter arrived in the same commit and only the filter was implemented. A consumer following the docs got `undefined`. This emits the field rather than removing it from the docs, per the issue's option 1: the FAIR quality work (#5053) wants the labeler's quality flag on the record, and `user_stat` is already joined for the filter, so the extra column is free.

### What's emitted

Positioned right after `time_created`, matching the sample response the docs already published.

| Format | Field | Notes |
|---|---|---|
| GeoJSON | `high_quality_user` | boolean in `properties` |
| CSV | `high_quality_user` | new column |
| Shapefile | `hiQualUser` | DBF type `L`, values `T`/`F` — abbreviated camelCase per the 10-char DBF limit |
| GeoPackage | `high_quality_user` | `BOOLEAN` (stored 0/1, as GeoPackage does) |

`user_stat.high_quality` is `NOT NULL`, so the model field is a plain `Boolean`.

### Verification

Compiled, `scalafmtCheckAll` clean, and both label API specs pass (26 tests). Also exercised live against the dev DB (Seattle, region 1, CurbRamp) in all four formats, with both `true` and `false` values present in the output — the DBF and GeoPackage files were opened and their field types/values inspected, not just downloaded.

### Tests

- `LabelApiModelsSpec` — new pure test asserting the field reaches GeoJSON properties and lands under the CSV column its header names. The column index is derived from `csvHeader` rather than hardcoded, so the row and header can't drift apart.
- `RawLabelsApiSpec` — the DB-backed CSV header assertion now includes the field.

### Notes for review

The diffs in `ShapefilesCreatorHelper.scala` and `LabelApiModels.scala` look larger than the change is: scalafmt re-aligned the trailing comments and `->` arrows in two blocks because the new field's name is longer than any of its neighbors. The substantive edits are four added lines in the helper and five in the model.

No docs changes — `rawLabels.scala.html` already describes the field in both the sample response and the field table, and the position used here matches what it promised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012KfcmJvmSnKrRJXwKyG7qa
