### PR TITLE
Launch Richmond, VA publicly

### DIFF
--- a/conf/cityparams.conf
+++ b/conf/cityparams.conf
@@ -349,7 +349,7 @@ city-params {
     tucson-az = "public"
     paterson-nj = "public"
     staging = "private"
-    richmond-va = "private"
+    richmond-va = "public"
     fort-wayne-in = "public"
     virden-il = "public"
     gainesville-fl = "public"


### PR DESCRIPTION
Closes #5096.

Flips `city-params.status.richmond-va` from `"private"` to `"public"` in `conf/cityparams.conf`. That is the whole
diff — visibility is read from config at boot (`ConfigService.getAllCityInfo`), not stored in the database, so there
is no admin toggle or runtime override for it.

### What this changes

- Richmond appears in the navbar city dropdown on every public deployment — `navbar.scala.html` filters
  `allCityInfo` on `visibility == "public"`.
- `/v3/api/cities` reports `"visibility": "public"` for `richmond-va`.
- Richmond's mappers become eligible for the global leaderboard's "Top city" column
  (`ConfigService.isExcludedFromGlobalLeaderboard`). Richmond sets neither `global-leaderboard-excluded` nor
  `private-profiles-by-default`, so nothing else holds it back.
- Richmond counts toward `publicCityCount`, which factors into public-profile visibility.

The site itself is already live at https://sidewalk-richmond.cs.washington.edu — it was just unlisted.

### Deployment

Merging this deploys it to **test** only. Prod needs a `vX.Y.Z` release, and it needs one for *every* city rather
than just Richmond: each instance loads the whole `cityparams.conf` and filters its own dropdown from it, so Richmond
shows up in the other cities' menus only once they're all redeployed. A release does redeploy them all, so folding
this into the next release is sufficient.

### Testing

Config-only change; nothing to lint (no JS/CSS/HTML/Scala touched). The relevant invariant in
`DashboardStatsInvariantSpec` ("name only publicly launched deployments") asserts that every city in the global
leaderboard scope is `public`, which this change satisfies rather than violates. Worth eyeballing on the test stage
that Richmond shows up in another city's dropdown before the release goes out.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 5 (1M context), claude-opus-5[1m]
