### PR TITLE
Stop three test suites from failing only against a seeded database

### DIFF
--- a/test/controllers/ExploreTaskSubmissionSpec.scala
+++ b/test/controllers/ExploreTaskSubmissionSpec.scala
@@ -414,7 +414,7 @@ class ExploreTaskSubmissionSpec extends PlaySpec with BeforeAndAfterAll with Eve
       // label_pano_id_fkey (evolution 360) is the only thing standing between a blockless label and an orphan, and
       // nothing checks ahead of it, so this surfaces as a failed transaction rather than a validation error: the
       // submission is rejected whole, exactly as a failed pano block is. Every seeded deployment has the tutorial
-      // panos, so the shape should be unreachable in practice (#5073).
+      // panos, so the shape should be unreachable in practice; #5101 tracks giving it a cleaner answer than a 500.
       val panoId = s"$panoPrefix-orphan"
 
       val resp = post(submission(labels = Seq(label(panoId, tempLabelId = 5)), panos = Seq.empty))

--- a/test/controllers/ExploreTaskSubmissionSpec.scala
+++ b/test/controllers/ExploreTaskSubmissionSpec.scala
@@ -32,6 +32,8 @@ import scala.concurrent.duration._
  *   - a label whose pano block fails to write (here: a lat outside pano_data's CHECK constraint) fails the whole
  *     submission, saving neither the label nor the pano;
  *   - a label whose pano block describes a *different* pano is refused outright at validation;
+ *   - a label carrying no block at all (the tutorial shape) attaches to the pano_data row already there and leaves
+ *     it untouched, and is refused whole when there is no such row;
  *   - a failing *viewed* pano costs nothing else in the submission (the viewed batch is written off the request's
  *     critical path, so those assertions poll);
  *   - resubmitting a pano refreshes its metadata without clearing anything: position fields take the newest value,
@@ -99,6 +101,13 @@ class ExploreTaskSubmissionSpec extends PlaySpec with BeforeAndAfterAll with Eve
     val prefixPattern = s"$panoPrefix%"
     val _             = runDb(
       DBIO.seq(
+        // Labels first: label.pano_id is an FK to pano_data (evolution 360), so a label a dead run left behind would
+        // block the pano delete. Scoped to this suite's pano prefix, so it can't reach a real label.
+        sqlu"""DELETE FROM label_history
+               WHERE label_id IN (SELECT label_id FROM label WHERE pano_id LIKE $prefixPattern)""",
+        sqlu"""DELETE FROM label_point
+               WHERE label_id IN (SELECT label_id FROM label WHERE pano_id LIKE $prefixPattern)""",
+        sqlu"DELETE FROM label WHERE pano_id LIKE $prefixPattern",
         sqlu"DELETE FROM pano_link WHERE pano_id LIKE $prefixPattern",
         sqlu"DELETE FROM pano_history WHERE location_curr_pano_id LIKE $prefixPattern",
         sqlu"DELETE FROM pano_data WHERE pano_id LIKE $prefixPattern"
@@ -233,6 +242,14 @@ class ExploreTaskSubmissionSpec extends PlaySpec with BeforeAndAfterAll with Eve
 
   private def labelCount(panoId: String): Int =
     runDb(sql"SELECT count(*) FROM label WHERE pano_id = $panoId AND user_id = $userId".as[Int].head)
+
+  /** Puts a bare pano_data row in place, standing in for one a scrape or evolution 360's tutorial seed wrote. */
+  private def seedPanoRow(panoId: String, address: String): Unit = {
+    val _ = runDb(
+      sqlu"""INSERT INTO pano_data (pano_id, capture_date, source, width, address)
+             VALUES ($panoId, '2014-05', 'gsv', 4096, $address)"""
+    )
+  }
 
   private def panoRow(panoId: String): Option[(Option[Double], Option[Int], Option[String])] =
     runDb(
@@ -379,17 +396,31 @@ class ExploreTaskSubmissionSpec extends PlaySpec with BeforeAndAfterAll with Eve
       runDb(sql"SELECT count(*) FROM pano_history WHERE location_curr_pano_id = $panoId".as[Int].head) mustBe 1
     }
 
-    "save a label that carries no pano block, the shape tutorial labels use" in {
+    "save a label that carries no pano block onto the pano row already there, the shape tutorial labels use" in {
       // Labels on the locally-served tutorial panos omit the block so their fabricated metadata can't touch the
-      // seeded pano_data rows; the server extends the same leniency to any blockless label. The eventual FK on
-      // label.pano_id (#4587's endgame, once legacy orphans are backfilled) is what will make this shape impossible
-      // for non-tutorial panos.
-      val panoId = s"$panoPrefix-absent"
+      // pano_data rows evolution 360 seeded for them; the server extends the same leniency to any blockless label.
+      // The stored row must come through untouched — that leniency is the whole point of the shape.
+      val panoId = s"$panoPrefix-blockless"
+      seedPanoRow(panoId, "456 Seeded Ave")
 
       val resp = post(submission(labels = Seq(label(panoId, tempLabelId = 4)), panos = Seq.empty))
 
       status(resp) mustBe OK
       labelCount(panoId) mustBe 1
+      panoRow(panoId) mustBe Some((None, Some(4096), Some("456 Seeded Ave")))
+    }
+
+    "refuse the whole submission when a blockless label names a pano with no row" in {
+      // label_pano_id_fkey (evolution 360) is the only thing standing between a blockless label and an orphan, and
+      // nothing checks ahead of it, so this surfaces as a failed transaction rather than a validation error: the
+      // submission is rejected whole, exactly as a failed pano block is. Every seeded deployment has the tutorial
+      // panos, so the shape should be unreachable in practice (#5073).
+      val panoId = s"$panoPrefix-orphan"
+
+      val resp = post(submission(labels = Seq(label(panoId, tempLabelId = 5)), panos = Seq.empty))
+
+      status(resp) mustBe INTERNAL_SERVER_ERROR
+      labelCount(panoId) mustBe 0
       panoRow(panoId) mustBe None
     }
   }

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -95,6 +95,18 @@ identical in both environments.
 keeping each section on its server-rendered fallback. That makes the measured DOM deterministic and keeps an
 ML-site outage from failing the run.
 
+### Map base-layer stub
+
+The two `/labelMap` behavior specs (`labelmap-feed-failure.spec.js`, `labelmap-viewport-fetch.spec.js`) add
+`stubMapBaseLayers()`, which answers `/neighborhoods`, `/neighborhoods/completionRate`, and
+`/contribution/streets/all` with empty collections. `createPSMap` loads all three before the label feed, and on a
+seeded schema they run to megabytes (~7.4 MB in Seattle) that must reach mapbox-gl before the page promise
+resolves — long enough to blow the 5s default `expect` timeout with four workers competing at the start of a run,
+and invisible in CI, whose schema is empty (#5081). Neither spec reads that data: both assert request and error
+behavior, so serving none of it makes them behave identically against a seeded schema and an empty one, in content
+and in how long they take. The smoke and a11y specs deliberately do **not** stub it — they are there to load the
+real page.
+
 ### Accessibility gate
 
 `a11y.spec.js` runs axe-core (`@axe-core/playwright`) over every page in `pages.js`, tagged `wcag2a` +

--- a/test/e2e/fixtures.js
+++ b/test/e2e/fixtures.js
@@ -109,6 +109,25 @@ async function stubMakeabilityLab(context) {
 }
 
 /**
+ * Stubs the neighborhood and street layers that createPSMap loads before a map's label feed.
+ *
+ * On a seeded schema those are ~7.4 MB (Seattle) that must download, parse, and reach mapbox-gl before
+ * createPSMap resolves — and only then can a label-feed assertion become true. That doesn't reliably fit the
+ * 5s default expect timeout with four workers competing at the start of a run, and CI's empty database hides
+ * it (#5081). Specs asserting feed behavior never read this data, so serving none of it costs them nothing.
+ *
+ * @param {import('@playwright/test').BrowserContext} context - The context whose requests to intercept.
+ */
+async function stubMapBaseLayers(context) {
+  const emptyGeoJson = {type: 'FeatureCollection', features: []};
+  // `*` stops at a path separator, so the /neighborhoods route can't swallow /neighborhoods/completionRate —
+  // which answers with a rate array, not GeoJSON (addNeighborhoodsToMap looks regions up in it by region_id).
+  await context.route('**/neighborhoods*', (route) => route.fulfill({json: emptyGeoJson}));
+  await context.route('**/neighborhoods/completionRate*', (route) => route.fulfill({json: []}));
+  await context.route('**/contribution/streets/all*', (route) => route.fulfill({json: emptyGeoJson}));
+}
+
+/**
  * Waits until the shared AppManager (public/js/common/AppManager.js, wired into every page by
  * app/views/common/main.scala.html) reports initialization complete.
  *
@@ -256,6 +275,7 @@ module.exports = {
   expect: base.expect,
   stubMapbox,
   stubMakeabilityLab,
+  stubMapBaseLayers,
   waitForAppReady,
   loadAndSettle,
   horizontalOverflowReport,

--- a/test/e2e/labelmap-feed-failure.spec.js
+++ b/test/e2e/labelmap-feed-failure.spec.js
@@ -10,14 +10,14 @@
  * failure and assert what the user is shown. Kept to DOM state (which card is visible, is retry focused) —
  * canvas and imagery testing stays manual, per the suite's charter.
  *
- * Every case intercepts the feed, so none of them read the database: they behave identically against a
- * seeded dev schema and CI's empty one.
+ * Every case intercepts the feed and the base map layers, so none of them read the database: they behave
+ * identically against a seeded dev schema and CI's empty one, in content and in how long they take (#5081).
  *
  * /admin/label-map renders the same overlay through the same MapLoadingOverlay class, so these cover its
  * behavior too — it isn't driven directly here because reaching it needs an admin session, which the suite's
  * setup (a throwaway *registered* user) doesn't mint.
  */
-const {test, expect, stubMapbox, waitForAppReady} = require('./fixtures');
+const {test, expect, stubMapbox, stubMapBaseLayers, waitForAppReady} = require('./fixtures');
 
 // A valid GeoJSON prefix that simply stops — what a client sees when the database stream dies after the 200
 // has gone out. Status and Content-Type both still say success.
@@ -43,8 +43,12 @@ const serveEmptyFeed = (route) =>
   route.fulfill({status: 200, contentType: 'application/json', body: EMPTY_FEED});
 
 test.describe('/labelMap label feed failure', () => {
-  test('shows a retryable error when the feed cannot be reached', async ({page, context}) => {
+  test.beforeEach(async ({context}) => {
     await stubMapbox(context);
+    await stubMapBaseLayers(context);
+  });
+
+  test('shows a retryable error when the feed cannot be reached', async ({page, context}) => {
     await routeLabelFeed(context, (route) => route.abort('failed'));
 
     await openLabelMap(page);
@@ -63,7 +67,6 @@ test.describe('/labelMap label feed failure', () => {
 
   // The regression this file exists for: a 200 whose body stops early still has to reach the user as an error.
   test('shows the error when the streamed body is truncated under a 200', async ({page, context}) => {
-    await stubMapbox(context);
     await routeLabelFeed(context, (route) =>
       route.fulfill({status: 200, contentType: 'application/json', body: TRUNCATED_FEED}));
 
@@ -76,7 +79,6 @@ test.describe('/labelMap label feed failure', () => {
   // Truncation rather than abort: an aborted request also emits Chromium's own resource-load error, which
   // would drown out the signal here. A 200 with a short body produces only the failure the page itself reports.
   test('a failed feed leaves no uncaught errors behind', async ({page, context, consoleErrors}) => {
-    await stubMapbox(context);
     await routeLabelFeed(context, (route) =>
       route.fulfill({status: 200, contentType: 'application/json', body: TRUNCATED_FEED}));
 
@@ -90,7 +92,6 @@ test.describe('/labelMap label feed failure', () => {
   });
 
   test('retry re-requests the feed in place and recovers once it answers', async ({page, context}) => {
-    await stubMapbox(context);
     let attempts = 0;
     await routeLabelFeed(context, (route) => {
       attempts += 1;
@@ -116,7 +117,6 @@ test.describe('/labelMap label feed failure', () => {
   });
 
   test('an empty feed is a normal result, not an error', async ({page, context, consoleErrors}) => {
-    await stubMapbox(context);
     await routeLabelFeed(context, serveEmptyFeed);
 
     await openLabelMap(page);

--- a/test/e2e/labelmap-viewport-fetch.spec.js
+++ b/test/e2e/labelmap-viewport-fetch.spec.js
@@ -2,11 +2,12 @@
  * Behavior tests for /labelMap's viewport-scoped label feed (#5002): the page requests `/labels/all` with a
  * bbox, skips refetching while the view stays inside the padded fetched area, and refetches when it escapes.
  *
- * Every case intercepts the feed (these assert request behavior, not data), so they behave identically
- * against a seeded dev schema and CI's empty one. The zoom floor is exercised in the jest suite
- * (test/js/viewportLabelLoader.test.js) instead — mobile emulation plus zoom thresholds are flaky here.
+ * Every case intercepts the feed and the base map layers (these assert request behavior, not data), so they
+ * behave identically against a seeded dev schema and CI's empty one, in content and in how long they take
+ * (#5081). The zoom floor is exercised in the jest suite (test/js/viewportLabelLoader.test.js) instead —
+ * mobile emulation plus zoom thresholds are flaky here.
  */
-const {test, expect, stubMapbox, waitForAppReady} = require('./fixtures');
+const {test, expect, stubMapbox, stubMapBaseLayers, waitForAppReady} = require('./fixtures');
 
 const EMPTY_FEED = '{"type":"FeatureCollection","features":[]}';
 
@@ -24,10 +25,14 @@ async function waitForMap(page) {
 }
 
 test.describe('/labelMap viewport-scoped feed', () => {
+  test.beforeEach(async ({context}) => {
+    await stubMapbox(context);
+    await stubMapBaseLayers(context);
+  });
+
   test('a desktop load issues exactly one bbox-scoped request, and a small pan issues none', async ({
     page, context,
   }) => {
-    await stubMapbox(context);
     const feedUrls = [];
     await recordLabelFeed(context, feedUrls);
 
@@ -44,7 +49,6 @@ test.describe('/labelMap viewport-scoped feed', () => {
   });
 
   test('moving beyond the fetched area refetches with a new bbox', async ({page, context}) => {
-    await stubMapbox(context);
     const feedUrls = [];
     await recordLabelFeed(context, feedUrls);
 

--- a/test/service/ExploreAddressServiceSpec.scala
+++ b/test/service/ExploreAddressServiceSpec.scala
@@ -5,7 +5,7 @@ import formats.json.MissionFormats._
 import models.audit.{AuditTask, AuditTaskTable, AuditTaskTableDef}
 import models.label.{LabelHistoryTableDef, LabelPointTableDef, LabelTableDef}
 import models.mission.{Mission, MissionTableDef, MissionType}
-import models.pano.PanoSource
+import models.pano.{PanoDataTableDef, PanoSource}
 import models.region.RegionCompletionTableDef
 import models.userdashboard.TrophyTable
 import models.street.{
@@ -126,8 +126,8 @@ class ExploreAddressServiceSpec
    * Deletes every row the suite created under its throwaway users and restores the street priority / region
    * completion the completion tests moved. Mission and audit_task reference each other
    * (mission.current_audit_task_id / audit_task.current_mission_id), so the mission->task pointer is nulled first;
-   * label children (point, history) go before the labels themselves. The bare user/auth rows are left behind,
-   * matching UserAuthControllerSpec's happy-path precedent.
+   * label children (point, history) go before the labels themselves, and the labels before the pano_data row they
+   * reference. The bare user/auth rows are left behind, matching UserAuthControllerSpec's happy-path precedent.
    */
   override def afterAll(): Unit = {
     val userIds  = createdUserIds.toSeq
@@ -142,7 +142,8 @@ class ExploreAddressServiceSpec
           auditTasks.filter(_.userId inSet userIds).delete,
           missions.filter(_.userId inSet userIds).delete,
           streetIssues.filter(_.userId inSet userIds).delete,
-          TableQuery[models.user.UserCurrentRegionTableDef].filter(_.userId inSet userIds).delete
+          TableQuery[models.user.UserCurrentRegionTableDef].filter(_.userId inSet userIds).delete,
+          TableQuery[PanoDataTableDef].filter(_.panoId === specPanoId).delete
         )
         .transactionally
     )
@@ -180,10 +181,13 @@ class ExploreAddressServiceSpec
     )
   }
 
+  /** The one pano this suite's labels sit on; the first submission carrying it creates its pano_data row. */
+  private val specPanoId = "explore-address-spec-pano"
+
   /** A minimal non-tutorial label placement, as the Explore client would submit during a drop-in session. */
   private def labelSubmission(temporaryLabelId: Int): LabelSubmission =
     LabelSubmission(
-      panoId = "explore-address-spec-pano",
+      panoId = specPanoId,
       panoSource = PanoSource.Gsv,
       labelType = "Obstacle",
       deleted = false,
@@ -194,7 +198,12 @@ class ExploreAddressServiceSpec
       temporaryLabelId = temporaryLabelId,
       timeCreated = Some(OffsetDateTime.now),
       tutorial = false,
-      pano = None
+      // Every non-tutorial label carries its pano's metadata (#4587), which is what satisfies label.pano_id's FK to
+      // pano_data (evolution 360) — the service writes the pano row in the same transaction as the label.
+      pano = Some(
+        PanoSubmission(specPanoId, PanoSource.Gsv, "2024-06", Some(8192), Some(4096), Some(512), Some(512), Some(41.87),
+          Some(-87.62), Some(180d), Some(0d), None, Seq.empty, None, None, Seq.empty, None)
+      )
     )
 
   "getDataForExploreAddressPage" should {

--- a/test/service/ExploreAddressServiceSpec.scala
+++ b/test/service/ExploreAddressServiceSpec.scala
@@ -123,37 +123,62 @@ class ExploreAddressServiceSpec
     run(auditTasks.filter(_.auditTaskId === auditTaskId).result.head)
 
   /**
-   * Deletes every row the suite created under its throwaway users and restores the street priority / region
-   * completion the completion tests moved. Mission and audit_task reference each other
-   * (mission.current_audit_task_id / audit_task.current_mission_id), so the mission->task pointer is nulled first;
-   * label children (point, history) go before the labels themselves, and the labels before the pano_data row they
-   * reference. The bare user/auth rows are left behind, matching UserAuthControllerSpec's happy-path precedent.
+   * Drops this suite's pano and everything hanging off it. Scoped by pano id rather than by user, so it also reaches
+   * what a dead earlier run left behind — label.pano_id is an FK to pano_data (evolution 360), so one orphaned label
+   * would otherwise pin the pano row in place and fail every later run's cleanup.
    */
-  override def afterAll(): Unit = {
-    val userIds  = createdUserIds.toSeq
-    val labelIds = labels.filter(_.userId inSet userIds).map(_.labelId)
-    val _        = run(
+  private def deleteSpecPanoRows(): Unit = {
+    val labelIdsOnPano = labels.filter(_.panoId === specPanoId).map(_.labelId)
+    val _              = run(
       DBIO
         .seq(
-          labelPoints.filter(_.labelId in labelIds).delete,
-          labelHistories.filter(_.labelId in labelIds).delete,
-          labels.filter(_.userId inSet userIds).delete,
-          missions.filter(_.userId inSet userIds).map(_.currentAuditTaskId).update(None),
-          auditTasks.filter(_.userId inSet userIds).delete,
-          missions.filter(_.userId inSet userIds).delete,
-          streetIssues.filter(_.userId inSet userIds).delete,
-          TableQuery[models.user.UserCurrentRegionTableDef].filter(_.userId inSet userIds).delete,
+          labelPoints.filter(_.labelId in labelIdsOnPano).delete,
+          labelHistories.filter(_.labelId in labelIdsOnPano).delete,
+          labels.filter(_.panoId === specPanoId).delete,
           TableQuery[PanoDataTableDef].filter(_.panoId === specPanoId).delete
         )
         .transactionally
     )
-    priorityRestore.foreach { case (streetEdgeId, p) =>
-      val _ = run(priorities.filter(_.streetEdgeId === streetEdgeId).map(_.priority).update(p))
-    }
-    auditedDistanceRestore.foreach { case (regionId, d) =>
-      val _ = run(regionCompletion.filter(_.regionId === regionId).map(_.auditedDistance).update(d))
-    }
-    super.afterAll()
+  }
+
+  override def beforeAll(): Unit = { super.beforeAll(); deleteSpecPanoRows() }
+
+  /**
+   * Deletes every row the suite created under its throwaway users and restores the street priority / region
+   * completion the completion tests moved. Mission and audit_task reference each other
+   * (mission.current_audit_task_id / audit_task.current_mission_id), so the mission->task pointer is nulled first;
+   * label children (point, history) go before the labels themselves. The bare user/auth rows are left behind,
+   * matching UserAuthControllerSpec's happy-path precedent.
+   */
+  override def afterAll(): Unit = {
+    try {
+      // Restores run first because they are the ones that must not be skipped: they put shared city state back,
+      // where everything below only drops rows this suite created.
+      priorityRestore.foreach { case (streetEdgeId, p) =>
+        val _ = run(priorities.filter(_.streetEdgeId === streetEdgeId).map(_.priority).update(p))
+      }
+      auditedDistanceRestore.foreach { case (regionId, d) =>
+        val _ = run(regionCompletion.filter(_.regionId === regionId).map(_.auditedDistance).update(d))
+      }
+
+      val userIds  = createdUserIds.toSeq
+      val labelIds = labels.filter(_.userId inSet userIds).map(_.labelId)
+      val _        = run(
+        DBIO
+          .seq(
+            labelPoints.filter(_.labelId in labelIds).delete,
+            labelHistories.filter(_.labelId in labelIds).delete,
+            labels.filter(_.userId inSet userIds).delete,
+            missions.filter(_.userId inSet userIds).map(_.currentAuditTaskId).update(None),
+            auditTasks.filter(_.userId inSet userIds).delete,
+            missions.filter(_.userId inSet userIds).delete,
+            streetIssues.filter(_.userId inSet userIds).delete,
+            TableQuery[models.user.UserCurrentRegionTableDef].filter(_.userId inSet userIds).delete
+          )
+          .transactionally
+      )
+      deleteSpecPanoRows()
+    } finally super.afterAll()
   }
 
   /** A minimal explore submission for the given session state, label-free unless labels are passed. */
@@ -201,8 +226,10 @@ class ExploreAddressServiceSpec
       // Every non-tutorial label carries its pano's metadata (#4587), which is what satisfies label.pano_id's FK to
       // pano_data (evolution 360) — the service writes the pano row in the same transaction as the label.
       pano = Some(
-        PanoSubmission(specPanoId, PanoSource.Gsv, "2024-06", Some(8192), Some(4096), Some(512), Some(512), Some(41.87),
-          Some(-87.62), Some(180d), Some(0d), None, Seq.empty, None, None, Seq.empty, None)
+        PanoSubmission(panoId = specPanoId, source = PanoSource.Gsv, captureDate = "2024-06", width = Some(8192),
+          height = Some(4096), tileWidth = Some(512), tileHeight = Some(512), lat = Some(41.87), lng = Some(-87.62),
+          cameraHeading = Some(180d), cameraPitch = Some(0d), cameraRoll = None, links = Seq.empty, copyright = None,
+          address = None, history = Seq.empty, sourceMetadata = None)
       )
     )
 

--- a/test/service/ExploreRoutePauseSpec.scala
+++ b/test/service/ExploreRoutePauseSpec.scala
@@ -1,5 +1,6 @@
 package service
 
+import formats.json.ExploreFormats._
 import models.mission.{Mission, MissionTableDef, MissionType}
 import models.audit.AuditTaskTableDef
 import models.region.RegionTableDef
@@ -39,7 +40,8 @@ import scala.concurrent.duration._
  *   - An explicit `/explore?routeId=X` visit resumes the *same* paused walk (same user_route row, progress intact).
  *   - `/explore?routeId=X&resumeRoute=false` is the one destructive path: it discards the old walk and starts fresh.
  *   - Entering a different route pauses (not discards) the walk being left behind.
- *   - `routeResumed` (which drives the resume toast) is set only once a street of the walk has been served.
+ *   - `routeResumed` (which drives the resume toast) is set only once a street of the walk has been submitted, which
+ *     is what separates a walk in progress from one entered and abandoned before anything was recorded.
  *
  * Setup/teardown mirror ExploreTutorialRouteSpec: throwaway anonymous users, seeded route walks, all rows swept in
  * afterAll. Requires a Postgres+PostGIS DB with at least one street/region (as in dev/CI); cancels otherwise.
@@ -141,6 +143,33 @@ class ExploreRoutePauseSpec
     run(userRoutes.filter(_.userId === userId).sortBy(_.userRouteId).result)
 
   /**
+   * Submits the street the page just served, which is what enters the walk: the audit_task_user_route row that
+   * `hasBeenWalked` reads is written by submitExploreData, never by serving the page. Left incomplete, so the walk
+   * stays active and no street priority moves.
+   */
+  private def submitServedStreet(userId: String, data: ExplorePageData): Unit = {
+    val task = data.task.value
+    val now  = OffsetDateTime.now
+    val _    = await(
+      exploreService.submitExploreData(
+        AuditTaskSubmission(
+          missionProgress = AuditMissionProgress(data.mission.missionId, Some(0d), data.region.regionId,
+            completed = false, task.auditTaskId, skipped = false),
+          auditTask = TaskSubmission(task.edgeId, now, task.auditTaskId, Some(false), task.currentLat, task.currentLng,
+            startPointReversed = false, None, now, requestUpdatedStreetPriority = false, None, task.routeStreetId),
+          labels = Seq.empty,
+          interactions = Seq.empty,
+          environment = EnvironmentSubmission(None, None, None, None, None, None, None, None, None, "en", 100),
+          panos = Seq.empty,
+          userRouteId = data.userRoute.map(_.userRouteId),
+          timestamp = now
+        ),
+        userId
+      )
+    )
+  }
+
+  /**
    * Deletes every row the suite created under its throwaway users. Mission and audit_task reference each other
    * (mission.current_audit_task_id), so the mission->task pointer is nulled first; route children (route_street,
    * user_route and its audit_task_user_route rows) go before the routes themselves. The bare user/auth rows are
@@ -229,14 +258,14 @@ class ExploreRoutePauseSpec
       }
     }
 
-    "not report a walk as resumed until a street of it has actually been served" in {
+    "not report a walk as resumed until a street of it has actually been walked" in {
       seedStreet match {
         case None                           => cancel("No street/region rows in the connected DB; nothing to exercise.")
         case Some((streetEdgeId, regionId)) =>
           val user = newTutorialGraduate()
           val _    = seedActiveRouteWalk(user.userId, streetEdgeId, regionId)
 
-          // Never handed a street of it, so picking the walk up is a first entry rather than a resume.
+          // Nothing submitted against it, so picking the walk up is a first entry rather than a resume.
           val data = pageData(user.userId)
           data.userRoute mustBe defined
           data.routeResumed mustBe false
@@ -252,6 +281,7 @@ class ExploreRoutePauseSpec
 
           val firstData = pageData(user.userId, routeId = Some(routeId))
           firstData.routeResumed mustBe false
+          submitServedStreet(user.userId, firstData)
           run(
             auditTaskUserRoutes.filter(_.userRouteId === firstData.userRoute.value.userRouteId).result
           ) must not be empty


### PR DESCRIPTION
Resolves #5081, resolves #5073, resolves #5074.

Three tests that fail against a seeded dev DB and pass in CI, for the same underlying reason: **CI's schema is empty**, so the cases never run there. Each is a stale test premise, not a product bug.

## #5081 — the labelMap specs race the database

`labelmap-feed-failure.spec.js` and `labelmap-viewport-fetch.spec.js` intercepted only `/labels/all`, leaving `/neighborhoods` and `/contribution/streets/all` to hit the real app. On a seeded Seattle schema that's ~7.4 MB (1.0 MB + 6.3 MB) that has to download, parse, and reach mapbox-gl before `createPSMap` resolves — and only then can a feed assertion become true. That doesn't fit the 5 s default `expect` timeout with four workers contending at the start of a run.

The tell is that the failures were exactly the first-scheduled test in each file. Both files' header comments already claimed schema-independence; neither reads that data.

New `stubMapBaseLayers` fixture serves empty GeoJSON for both, applied in a `beforeEach` alongside the existing `stubMapbox`. The two previously-failing cases now finish in 5.3 s and 1.6 s instead of still being unresolved at 10 s.

## #5073 — three Explore specs insert labels on panos that don't exist

Evolution 360 added `label_pano_id_fkey`, so a fabricated pano id is no longer insertable. Two suites hit it differently:

- **`ExploreAddressServiceSpec`** sent `pano = None` with a made-up id. It now sends the pano block a real Explore client sends, so `submitExploreData` writes the `pano_data` row in the same transaction as the label — the mechanism that satisfies the FK in production. `afterAll` drops that row after the labels.
- **`ExploreTaskSubmissionSpec`**'s blockless case now seeds the `pano_data` row up front (the tutorial's actual situation, since 360 part 1 seeds those two panos) and asserts the submission leaves it untouched — which was always the point of that test. A second case pins the other half: a blockless label naming a pano with *no* row gets the whole submission refused, nothing saved.

`deleteTestPanos` also sweeps labels first now — with the FK in place, a label left by a dead run blocks the pano delete.

**Left as is, deliberately:** that refusal is a 500, not a clean 400. Nothing checks ahead of the constraint, so it arrives as a failed transaction and `ExploreController` logs "Explore submission failed; nothing from it was saved". Worth its own issue if we want it cleaned up; this PR only states the current contract.

## #5074 — `ExploreRoutePauseSpec` expects a row the page load never writes

Neither of the issue's two readings. `audit_task_user_route` is written by `submitExploreData`, never by serving `/explore?routeId=`, so the assertion could not hold. `hasBeenWalked` reads that table, which means a walk counts as entered only once a street of it has been **submitted** — the right semantics: a route entered and abandoned with nothing recorded shouldn't fire the resume toast.

The spec now submits the street it was served. The adjacent test is renamed from "served" to "walked", since "served" is what misled the fixture.

## Testing

- `make test-e2e wt=…` with `HAS_REAL_GMAPS_KEY=true`: **124/124 passed**, including the a11y project.
- `testOnly controllers.ExploreTaskSubmissionSpec service.ExploreAddressServiceSpec service.ExploreRoutePauseSpec` against a seeded dev DB: **28/28 passed** (4 failures before).
- ESLint and scalafmt clean.

No product code changed — this is tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X28LcybgHaJLgwvVTRZ3jm
