### PR TITLE
Give each nightly job one definition of its run details

### DIFF
--- a/app/actor/ClusteringActor.scala
+++ b/app/actor/ClusteringActor.scala
@@ -4,7 +4,6 @@ import actor.ActorUtils.{dateFormatter, getTimeToNextUpdate}
 import org.apache.pekko.actor.{Actor, Cancellable}
 import play.api.Logger
 import models.utils.JobRunTrigger
-import play.api.libs.json.Json
 import service.{ClusterService, ConfigService, JobRunService}
 
 import java.time.Instant
@@ -58,9 +57,7 @@ class ClusteringActor @Inject() (clusterService: ClusterService, jobRunService: 
     val currentTimeStart: String = dateFormatter.format(Instant.now())
     logger.info(s"Auto-scheduled clustering of labels starting at: $currentTimeStart")
     jobRunService
-      .record(ClusteringActor.Name, JobRunTrigger.Scheduled)(clusterService.runClustering()) { results =>
-        Json.obj("labels_clustered" -> results.labelCount, "clusters_created" -> results.clusterCount)
-      }
+      .record(ClusteringActor.Name, JobRunTrigger.Scheduled)(clusterService.runClustering())(_.runDetails)
       .onComplete {
         case Success(results) =>
           val currentEndTime: String = dateFormatter.format(Instant.now())

--- a/app/actor/FunnelStatActor.scala
+++ b/app/actor/FunnelStatActor.scala
@@ -4,7 +4,7 @@ import actor.ActorUtils.{dateFormatter, getTimeToNextUpdate}
 import org.apache.pekko.actor.{Actor, Cancellable}
 import play.api.Logger
 import models.utils.JobRunTrigger
-import play.api.libs.json.Json
+import play.api.libs.json.{JsObject, Json}
 import service.{AdminService, ConfigService, JobRunService}
 
 import java.time.Instant
@@ -16,6 +16,17 @@ import scala.util.{Failure, Success}
 object FunnelStatActor {
   val Name = "funnel-stat-actor"
   case object Tick
+
+  /**
+   * The counts as they are stored against a `background_job_run` row.
+   *
+   * Defined here rather than at each call site so the nightly recompute and the admin hand-trigger can't record the
+   * same job under two different shapes.
+   *
+   * @param rowsWritten Rows written to `funnel_stat`.
+   * @return The run's `details` object.
+   */
+  def runDetails(rowsWritten: Int): JsObject = Json.obj("rows_written" -> rowsWritten)
 }
 
 /**
@@ -67,9 +78,9 @@ class FunnelStatActor @Inject() (adminService: AdminService, jobRunService: JobR
     val currentTimeStart: String = dateFormatter.format(Instant.now())
     logger.info(s"Auto-scheduled computation of engagement funnel starting at: $currentTimeStart")
     jobRunService
-      .record(FunnelStatActor.Name, JobRunTrigger.Scheduled)(adminService.updateFunnelStatTable()) { nRows =>
-        Json.obj("rows_written" -> nRows)
-      }
+      .record(FunnelStatActor.Name, JobRunTrigger.Scheduled)(adminService.updateFunnelStatTable())(
+        FunnelStatActor.runDetails
+      )
       .onComplete {
         case Success(nRows) =>
           val currentEndTime: String = dateFormatter.format(Instant.now())

--- a/app/actor/OsmWayRefreshActor.scala
+++ b/app/actor/OsmWayRefreshActor.scala
@@ -4,7 +4,7 @@ import actor.ActorUtils.{dateFormatter, getTimeToNextUpdate}
 import org.apache.pekko.actor.{Actor, Cancellable}
 import play.api.Logger
 import models.utils.JobRunTrigger
-import play.api.libs.json.Json
+import play.api.libs.json.{JsObject, Json}
 import service.{ConfigService, JobRunService, OsmWayService}
 
 import java.time.Instant
@@ -16,6 +16,17 @@ import scala.util.{Failure, Success}
 object OsmWayRefreshActor {
   val Name = "osm-way-refresh-actor"
   case object Tick
+
+  /**
+   * The counts as they are stored against a `background_job_run` row.
+   *
+   * Defined here rather than at each call site so the nightly refresh and the admin hand-trigger can't record the
+   * same job under two different shapes.
+   *
+   * @param waysRefreshed Ways re-fetched from Overpass and upserted into `osm_way`.
+   * @return The run's `details` object.
+   */
+  def runDetails(waysRefreshed: Int): JsObject = Json.obj("ways_refreshed" -> waysRefreshed)
 }
 
 /**
@@ -64,9 +75,9 @@ class OsmWayRefreshActor @Inject() (osmWayService: OsmWayService, jobRunService:
     val currentTimeStart: String = dateFormatter.format(Instant.now())
     logger.info(s"Auto-scheduled OSM way data refresh starting at: $currentTimeStart")
     jobRunService
-      .record(OsmWayRefreshActor.Name, JobRunTrigger.Scheduled)(osmWayService.refreshOsmWayData()) { waysRefreshed =>
-        Json.obj("ways_refreshed" -> waysRefreshed)
-      }
+      .record(OsmWayRefreshActor.Name, JobRunTrigger.Scheduled)(osmWayService.refreshOsmWayData())(
+        OsmWayRefreshActor.runDetails
+      )
       .onComplete {
         case Success(waysRefreshed) =>
           logger.info(s"OSM way data refresh completed at: ${dateFormatter.format(Instant.now())}")

--- a/app/actor/RecalculateStreetPriorityActor.scala
+++ b/app/actor/RecalculateStreetPriorityActor.scala
@@ -4,7 +4,7 @@ import actor.ActorUtils.{dateFormatter, getTimeToNextUpdate}
 import models.utils.JobRunTrigger
 import org.apache.pekko.actor.{Actor, Cancellable}
 import play.api.Logger
-import play.api.libs.json.Json
+import play.api.libs.json.{JsNull, JsNumber, JsObject, JsValue, Json}
 import service.{ConfigService, ImageryFreshnessService, JobRunService, RegionService, StreetService}
 
 import java.time.Instant
@@ -26,6 +26,20 @@ object RecalculateStreetPriorityActor {
   val FreshnessSyncJobName = "imagery-freshness-sync"
 
   case object Tick
+
+  /**
+   * The counts as they are stored against a `background_job_run` row.
+   *
+   * Defined here rather than at each call site so the nightly sequence and the admin hand-trigger can't record the
+   * same job under two different shapes.
+   *
+   * @param regionsSeeded Rows written to `region_completion` by the rebuild that follows the recalculation, or `None`
+   *                      for the hand-trigger, which runs the recalculation alone. A plain `0` would file "the
+   *                      rebuild found no regions" and "no rebuild ran" as the same run.
+   * @return The run's `details` object.
+   */
+  def runDetails(regionsSeeded: Option[Int]): JsObject =
+    Json.obj("regions_seeded" -> regionsSeeded.fold[JsValue](JsNull)(count => JsNumber(count)))
 }
 
 @Singleton
@@ -101,7 +115,7 @@ class RecalculateStreetPriorityActor @Inject() (
         _             <- streetService.recalculateStreetPriority
         _             <- regionService.truncateRegionCompletionTable
         regionsSeeded <- regionService.initializeRegionCompletionTable
-      } yield regionsSeeded) { regionsSeeded => Json.obj("regions_seeded" -> regionsSeeded) }
+      } yield regionsSeeded)(regionsSeeded => RecalculateStreetPriorityActor.runDetails(Some(regionsSeeded)))
       .onComplete {
         case Success(_) =>
           val currentEndTime: String = dateFormatter.format(Instant.now())

--- a/app/actor/UserStatActor.scala
+++ b/app/actor/UserStatActor.scala
@@ -4,7 +4,7 @@ import actor.ActorUtils.{dateFormatter, getTimeToNextUpdate}
 import org.apache.pekko.actor.{Actor, Cancellable}
 import play.api.Logger
 import models.utils.JobRunTrigger
-import play.api.libs.json.Json
+import play.api.libs.json.{JsObject, Json}
 import service.{AdminService, ConfigService, JobRunService}
 
 import java.time.{Instant, OffsetDateTime}
@@ -16,6 +16,17 @@ import scala.util.{Failure, Success}
 object UserStatActor {
   val Name = "user-stats-actor"
   case object Tick
+
+  /**
+   * The counts as they are stored against a `background_job_run` row.
+   *
+   * Defined here rather than at each call site so the nightly recompute and the admin hand-trigger can't record the
+   * same job under two different shapes.
+   *
+   * @param usersUpdated Rows written to `user_stat`.
+   * @return The run's `details` object.
+   */
+  def runDetails(usersUpdated: Int): JsObject = Json.obj("users_updated" -> usersUpdated)
 }
 
 @Singleton
@@ -61,7 +72,7 @@ class UserStatActor @Inject() (adminService: AdminService, jobRunService: JobRun
     jobRunService
       .record(UserStatActor.Name, JobRunTrigger.Scheduled)(
         adminService.updateUserStatTable(OffsetDateTime.now().minusHours(36))
-      ) { nUsersUpdated => Json.obj("users_updated" -> nUsersUpdated) }
+      )(UserStatActor.runDetails)
       .onComplete {
         case Success(nUsersUpdated) =>
           val currentEndTime: String = dateFormatter.format(Instant.now())

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -314,9 +314,9 @@ class AdminController @Inject() (
     }
 
     jobRunService
-      .record(UserStatActor.Name, JobRunTrigger.Manual)(adminService.updateUserStatTable(cutoffTime)) { usersUpdated =>
-        Json.obj("users_updated" -> usersUpdated)
-      }
+      .record(UserStatActor.Name, JobRunTrigger.Manual)(adminService.updateUserStatTable(cutoffTime))(
+        UserStatActor.runDetails
+      )
       .map { usersUpdated: Int => Ok(s"User stats updated for $usersUpdated users!") }
   }
 
@@ -329,9 +329,9 @@ class AdminController @Inject() (
   def updateFunnelStats = cc.securityService.SecuredAction(WithAdmin()) { implicit request =>
     cc.loggingService.insert(request.identity.userId, request.ipAddress, request.toString)
     jobRunService
-      .record(FunnelStatActor.Name, JobRunTrigger.Manual)(adminService.updateFunnelStatTable()) { rowsUpdated =>
-        Json.obj("rows_written" -> rowsUpdated)
-      }
+      .record(FunnelStatActor.Name, JobRunTrigger.Manual)(adminService.updateFunnelStatTable())(
+        FunnelStatActor.runDetails
+      )
       .map { rowsUpdated => Ok(s"Funnel stats updated ($rowsUpdated rows)!") }
   }
 
@@ -970,13 +970,13 @@ class AdminController @Inject() (
    *
    * Recorded as a `Manual` run of the nightly street-priority job (#4928). Only the recalculation step, not the
    * imagery-freshness sync and region_completion rebuild the nightly sequence wraps around it, which is why the run
-   * records no counts.
+   * records a null `regions_seeded` rather than a count.
    */
   def recalculateStreetPriority = cc.securityService.SecuredAction(WithAdmin()) { implicit request =>
     logger.debug(request.toString) // Added bc scalafmt doesn't like "implicit _" & compiler needs us to use request.
     jobRunService
       .record(RecalculateStreetPriorityActor.Name, JobRunTrigger.Manual)(streetService.recalculateStreetPriority)(_ =>
-        Json.obj()
+        RecalculateStreetPriorityActor.runDetails(None)
       )
       .map(_ => Ok("Successfully recalculated street priorities"))
   }
@@ -1030,9 +1030,9 @@ class AdminController @Inject() (
   def refreshOsmWayData() = cc.securityService.SecuredAction(WithAdmin()) { implicit request =>
     logger.debug(request.toString) // Added bc scalafmt doesn't like "implicit _" & compiler needs us to use request.
     jobRunService
-      .record(OsmWayRefreshActor.Name, JobRunTrigger.Manual)(osmWayService.refreshOsmWayData()) { waysRefreshed =>
-        Json.obj("ways_refreshed" -> waysRefreshed)
-      }
+      .record(OsmWayRefreshActor.Name, JobRunTrigger.Manual)(osmWayService.refreshOsmWayData())(
+        OsmWayRefreshActor.runDetails
+      )
       .map { waysRefreshed => Ok(Json.obj("ways_refreshed" -> waysRefreshed)) }
       .recover { case NonFatal(e) =>
         logger.error("OSM way data refresh failed.", e)

--- a/app/controllers/ClusterController.scala
+++ b/app/controllers/ClusterController.scala
@@ -59,9 +59,9 @@ class ClusterController @Inject() (
       // Run the clustering, recorded as a `Manual` run of the nightly clustering job so a hand-run leaves the same
       // counts and error trail the scheduler's does — without being able to stand in for it (#4928).
       val resultFuture: Future[JsObject] = jobRunService
-        .record(ClusteringActor.Name, JobRunTrigger.Manual)(clusterService.runClustering(Some(statusRef), allRegions)) {
-          results => Json.obj("labels_clustered" -> results.labelCount, "clusters_created" -> results.clusterCount)
-        }
+        .record(ClusteringActor.Name, JobRunTrigger.Manual)(clusterService.runClustering(Some(statusRef), allRegions))(
+          _.runDetails
+        )
         .map { results => Json.obj("labels" -> results.labelCount, "clusters" -> results.clusterCount) }
 
       // Create a source that emits status updates.

--- a/app/service/ClusterService.scala
+++ b/app/service/ClusterService.scala
@@ -2,6 +2,7 @@ package service
 
 import com.google.inject.ImplementedBy
 import executors.CpuIntensiveExecutionContext
+import play.api.libs.json.{JsObject, Json}
 import play.api.{Configuration, Environment, Logger}
 
 import java.io.File
@@ -13,7 +14,18 @@ import scala.sys.process.{Process, ProcessLogger}
 /**
  * Final counts from a clustering run: how many labels were grouped into how many clusters.
  */
-case class ClusteringResults(labelCount: Int, clusterCount: Int)
+case class ClusteringResults(labelCount: Int, clusterCount: Int) {
+
+  /**
+   * The counts as they are stored against a `background_job_run` row.
+   *
+   * Defined on the result rather than at each call site so the nightly run and the admin hand-trigger can't record
+   * the same clustering under two different shapes.
+   *
+   * @return The run's `details` object.
+   */
+  def runDetails: JsObject = Json.obj("labels_clustered" -> labelCount, "clusters_created" -> clusterCount)
+}
 
 @ImplementedBy(classOf[ClusterServiceImpl])
 trait ClusterService {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -108,6 +108,11 @@ that found nothing to do, since the absence of a log line is not something anyon
 the roster, flagging any job that is overdue, failed, or has never run. The wrapper is strictly subordinate to the
 job: a bookkeeping failure is logged and swallowed, and a job's own failure propagates unchanged.
 
+A job's counts have exactly one definition — a `runDetails` on the job's result type, or next to the actor's `Name`
+when the result is a bare count — and both the nightly actor and the admin hand-trigger pass it to `record`. A
+details object built from a literal at each call site would let the two shapes drift, and `/admin/health` charts both
+triggers as one job (#5044).
+
 ### The public API (`/v3`)
 
 The `/v3` API is the canonical public surface (handlers in `app/controllers/api/`). Conventions (issue #3871):

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -108,10 +108,11 @@ that found nothing to do, since the absence of a log line is not something anyon
 the roster, flagging any job that is overdue, failed, or has never run. The wrapper is strictly subordinate to the
 job: a bookkeeping failure is logged and swallowed, and a job's own failure propagates unchanged.
 
-A job's counts have exactly one definition — a `runDetails` on the job's result type, or next to the actor's `Name`
-when the result is a bare count — and both the nightly actor and the admin hand-trigger pass it to `record`. A
-details object built from a literal at each call site would let the two shapes drift, and `/admin/health` charts both
-triggers as one job (#5044).
+A job that both the scheduler and an admin can trigger has exactly one definition of its counts — a `runDetails` on
+the job's result type, or next to the actor's `Name` when the result is a bare count — which both call sites pass to
+`record`. A details object built from a literal at each call site would let the two shapes drift, and `/admin/health`
+charts both triggers as one job (#5044). Jobs with a single call site build theirs inline. `JobRunDetailsSpec` pins
+the key names, which readers of `background_job_run.details` are written against.
 
 ### The public API (`/v3`)
 

--- a/test/actor/JobRunDetailsSpec.scala
+++ b/test/actor/JobRunDetailsSpec.scala
@@ -1,0 +1,48 @@
+package actor
+
+import org.scalatestplus.play.PlaySpec
+import play.api.libs.json.{JsNull, Json}
+import service.ClusteringResults
+
+/**
+ * The wire shape of the run details each multi-trigger job records (#5044).
+ *
+ * Every job's `details` object has one definition that the nightly actor and the admin hand-trigger both pass to
+ * `JobRunService.record`, which is what keeps the two triggers recording the same job the same way. The cost of that
+ * is that [[controllers.AdminJobTriggerSpec]] compares a recorded row against the very builder that wrote it, so a
+ * renamed key passes there. These key names are read back out of `background_job_run.details` by key — as
+ * `ImageryFreshnessReportService` does — so they are pinned here as literals, where a rename has to be deliberate.
+ *
+ * The two jobs whose details live on an imagery result are pinned by `ImageryPollOutcomeSpec` instead.
+ *
+ * Pure — no database, no application.
+ */
+class JobRunDetailsSpec extends PlaySpec {
+
+  "the run details of a job with both a nightly and a hand trigger" should {
+    "record user stats under the key its readers use" in {
+      UserStatActor.runDetails(11) mustBe Json.obj("users_updated" -> 11)
+    }
+
+    "record funnel stats under the key its readers use" in {
+      FunnelStatActor.runDetails(12) mustBe Json.obj("rows_written" -> 12)
+    }
+
+    "record the OSM way refresh under the key its readers use" in {
+      OsmWayRefreshActor.runDetails(13) mustBe Json.obj("ways_refreshed" -> 13)
+    }
+
+    "record clustering under the keys its readers use" in {
+      ClusteringResults(labelCount = 14, clusterCount = 15).runDetails mustBe
+        Json.obj("labels_clustered" -> 14, "clusters_created" -> 15)
+    }
+
+    "record the street-priority rebuild's count, or a null where no rebuild ran" in {
+      // The hand-trigger runs the recalculation alone. Null rather than 0 so a reader can tell the rebuild that
+      // seeded no regions from the trigger that never rebuilt, and rather than a missing key so both triggers write
+      // one shape.
+      RecalculateStreetPriorityActor.runDetails(Some(16)) mustBe Json.obj("regions_seeded" -> 16)
+      RecalculateStreetPriorityActor.runDetails(None) mustBe Json.obj("regions_seeded" -> JsNull)
+    }
+  }
+}

--- a/test/controllers/AdminJobTriggerSpec.scala
+++ b/test/controllers/AdminJobTriggerSpec.scala
@@ -160,6 +160,7 @@ class AdminJobTriggerSpec
       jobRun.status mustBe JobRunStatus.Succeeded
       jobRun.finishedAt mustBe defined
       // The nightly recompute and this trigger share one details shape, so the panel can chart them as one job.
+      // The shape's own key names are pinned by JobRunDetailsSpec; comparing against the builder can't be.
       jobRun.details.value mustBe UserStatActor.runDetails(UsersUpdated)
     }
   }

--- a/test/controllers/AdminJobTriggerSpec.scala
+++ b/test/controllers/AdminJobTriggerSpec.scala
@@ -159,7 +159,8 @@ class AdminJobTriggerSpec
       jobRun.triggeredBy mustBe JobRunTrigger.Manual
       jobRun.status mustBe JobRunStatus.Succeeded
       jobRun.finishedAt mustBe defined
-      (jobRun.details.value \ "users_updated").as[Int] mustBe UsersUpdated
+      // The nightly recompute and this trigger share one details shape, so the panel can chart them as one job.
+      jobRun.details.value mustBe UserStatActor.runDetails(UsersUpdated)
     }
   }
 
@@ -170,7 +171,7 @@ class AdminJobTriggerSpec
       body must include(FunnelRows.toString)
       jobRun.triggeredBy mustBe JobRunTrigger.Manual
       jobRun.status mustBe JobRunStatus.Succeeded
-      (jobRun.details.value \ "rows_written").as[Int] mustBe FunnelRows
+      jobRun.details.value mustBe FunnelStatActor.runDetails(FunnelRows)
     }
   }
 
@@ -180,9 +181,9 @@ class AdminJobTriggerSpec
       code mustBe OK
       jobRun.triggeredBy mustBe JobRunTrigger.Manual
       jobRun.status mustBe JobRunStatus.Succeeded
-      // This one covers only the recalculation step, not the sync the nightly sequence wraps around it, so it has no
-      // counts to report -- and `record` stores an empty details object as nothing at all.
-      jobRun.details mustBe empty
+      // This one covers only the recalculation step, not the region_completion rebuild the nightly sequence wraps
+      // around it, so it reports a null count rather than a number a reader could mistake for a rebuild that ran.
+      jobRun.details.value mustBe RecalculateStreetPriorityActor.runDetails(None)
     }
   }
 
@@ -193,7 +194,6 @@ class AdminJobTriggerSpec
       body mustBe ImageryResult.summary
       jobRun.triggeredBy mustBe JobRunTrigger.Manual
       jobRun.status mustBe JobRunStatus.Succeeded
-      // The nightly sweep and this trigger share one details shape, so the panel can chart them as the same job.
       jobRun.details.value mustBe ImageryResult.runDetails
     }
   }
@@ -206,7 +206,7 @@ class AdminJobTriggerSpec
       body must include(WaysRefreshed.toString)
       jobRun.triggeredBy mustBe JobRunTrigger.Manual
       jobRun.status mustBe JobRunStatus.Succeeded
-      (jobRun.details.value \ "ways_refreshed").as[Int] mustBe WaysRefreshed
+      jobRun.details.value mustBe OsmWayRefreshActor.runDetails(WaysRefreshed)
     }
 
     "record a half-finished refresh as a failure, and say so rather than reporting a count" in {
@@ -232,8 +232,7 @@ class AdminJobTriggerSpec
       body must include(ClusterResults.clusterCount.toString)
       jobRun.triggeredBy mustBe JobRunTrigger.Manual
       jobRun.status mustBe JobRunStatus.Succeeded
-      (jobRun.details.value \ "labels_clustered").as[Int] mustBe ClusterResults.labelCount
-      (jobRun.details.value \ "clusters_created").as[Int] mustBe ClusterResults.clusterCount
+      jobRun.details.value mustBe ClusterResults.runDetails
     }
   }
 


### PR DESCRIPTION
resolves #5044

The nightly actor and the admin hand-trigger of five jobs each built the run's `details` object from its own literal.
Nothing kept them equal, so a key renamed on one side would leave `/admin/health` — which charts both triggers as one
job — reading null for whichever trigger it missed, and no test could catch it, since each side was only ever asserted
against itself.

Each job's shape now has one definition, following the `ImageryCheckResult.runDetails` precedent:

| Job | Where `runDetails` lives |
|---|---|
| `clustering-actor` | `ClusteringResults` (the result type) |
| `user-stats-actor` | `UserStatActor` object |
| `funnel-stat-actor` | `FunnelStatActor` object |
| `osm-way-refresh-actor` | `OsmWayRefreshActor` object |
| `recalculate-street-priority-actor` | `RecalculateStreetPriorityActor` object |

Result types get the method; jobs whose result is a bare count get a builder next to the actor's `Name`. Both call
sites pass it to `record`.

One behavior change: the street-priority hand-trigger runs the recalculation without the `region_completion` rebuild
the nightly sequence wraps around it, so it now records `{"regions_seeded": null}` instead of no details at all. That
keeps the key in one place and distinguishes a rebuild that seeded nothing from one that never ran — the same
reasoning behind `ImageryCheckResult.reconciled`. `AdminJobTriggerSpec` asserts the new shape.

`AdminJobTriggerSpec`'s per-key assertions become whole-object comparisons against the one definition, so a rename now
has to be made in one place and both triggers follow.

Left alone: `imagery-freshness-sync`, `ai-validation-actor` and `auth-token-cleaner-actor` have a single call site
each, so there is nothing to diverge from.

### Testing

- `sbt scalafmtCheckAll compile` — clean (`-Xfatal-warnings` on).
- `sbt "testOnly controllers.AdminJobTriggerSpec service.JobRunServiceSpec actor.ScheduledJobsSpec"` — 22/22 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XEpC3WfHB42k8jHQcLE1Vz
