### PR TITLE
Split OsmWayService into an @ImplementedBy trait and an Impl

### DIFF
--- a/app/service/OsmWayService.scala
+++ b/app/service/OsmWayService.scala
@@ -1,5 +1,6 @@
 package service
 
+import com.google.inject.ImplementedBy
 import models.street.{OsmWay, OsmWayTable, WayType}
 import models.utils.MyPostgresProfile
 import org.apache.pekko.actor.ActorSystem
@@ -25,15 +26,40 @@ import scala.util.control.NonFatal
  * lookup used when a user wanders onto a street outside our network — checked against our DB first so each unknown
  * spot costs Overpass at most one query ever, across all users.
  */
+@ImplementedBy(classOf[OsmWayServiceImpl])
+trait OsmWayService {
+
+  /**
+   * Refreshes cached way data for every mapped way whose row is missing or older than `STALENESS_PERIOD`.
+   *
+   * @return Number of ways refreshed (0 when everything is fresh).
+   */
+  def refreshOsmWayData(): Future[Int]
+
+  /**
+   * Gets the speed limit at a point, for positions not on our street network (the /speedLimit fallback).
+   *
+   * @return The raw maxspeed tag of the nearest road within `SEARCH_RADIUS_M`; None if no road or no tag, and on any
+   *         Overpass failure (this method never propagates an error).
+   */
+  def getSpeedLimitAtPoint(lat: Double, lng: Double): Future[Option[String]]
+
+  /**
+   * Gets the maxspeed for each of the given streets, keyed by street_edge_id. Streets with no known speed are absent.
+   */
+  def getMaxSpeedsForStreets(streetEdgeIds: Seq[Int]): Future[Map[Int, String]]
+}
+
 @Singleton
-class OsmWayService @Inject() (
+class OsmWayServiceImpl @Inject() (
     protected val dbConfigProvider: DatabaseConfigProvider,
     ws: WSClient,
     cacheApi: AsyncCacheApi,
     actorSystem: ActorSystem,
     osmWayTable: OsmWayTable
 )(implicit ec: ExecutionContext)
-    extends HasDatabaseConfigProvider[MyPostgresProfile] {
+    extends OsmWayService
+    with HasDatabaseConfigProvider[MyPostgresProfile] {
   import OsmWayService._
 
   private val logger = Logger(this.getClass)

--- a/app/service/OsmWayService.scala
+++ b/app/service/OsmWayService.scala
@@ -18,19 +18,15 @@ import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 
-/**
- * Maintains the cached OSM way data (osm_way table) that backs the speed-limit sign (#4654).
- *
- * Two write paths, both polite to the shared community Overpass instance: a nightly batch refresh that bulk-fetches
- * tags for every way mapped in osm_way_street_edge (monthly per way, via a staleness cutoff), and an on-demand point
- * lookup used when a user wanders onto a street outside our network — checked against our DB first so each unknown
- * spot costs Overpass at most one query ever, across all users.
- */
 @ImplementedBy(classOf[OsmWayServiceImpl])
 trait OsmWayService {
 
   /**
    * Refreshes cached way data for every mapped way whose row is missing or older than `STALENESS_PERIOD`.
+   *
+   * Fetches tags in chunks of `BATCH_CHUNK_SIZE` ids, sequentially with a delay between chunks. Every requested id is
+   * upserted even when absent from the response (deleted/redacted ways get empty tags), so it won't re-queue nightly.
+   * A failed chunk fails the whole run; the next nightly tick retries from whatever is still stale.
    *
    * @return Number of ways refreshed (0 when everything is fresh).
    */
@@ -38,6 +34,10 @@ trait OsmWayService {
 
   /**
    * Gets the speed limit at a point, for positions not on our street network (the /speedLimit fallback).
+   *
+   * Checks ways already stored in our DB first; only on a miss does it query Overpass for the nearest road,
+   * storing the result (with geometry) so the next lookup nearby is served from the DB. Results — including "no road
+   * here" — are cached for a few minutes per rounded coordinate so repeated pano moves at the same spot are free.
    *
    * @return The raw maxspeed tag of the nearest road within `SEARCH_RADIUS_M`; None if no road or no tag, and on any
    *         Overpass failure (this method never propagates an error).
@@ -50,6 +50,14 @@ trait OsmWayService {
   def getMaxSpeedsForStreets(streetEdgeIds: Seq[Int]): Future[Map[Int, String]]
 }
 
+/**
+ * Maintains the cached OSM way data (osm_way table) that backs the speed-limit sign (#4654).
+ *
+ * Two write paths, both polite to the shared community Overpass instance: a nightly batch refresh that bulk-fetches
+ * tags for every way mapped in osm_way_street_edge (monthly per way, via a staleness cutoff), and an on-demand point
+ * lookup used when a user wanders onto a street outside our network — checked against our DB first so each unknown
+ * spot costs Overpass at most one query ever, across all users.
+ */
 @Singleton
 class OsmWayServiceImpl @Inject() (
     protected val dbConfigProvider: DatabaseConfigProvider,
@@ -64,15 +72,6 @@ class OsmWayServiceImpl @Inject() (
 
   private val logger = Logger(this.getClass)
 
-  /**
-   * Refreshes cached way data for every mapped way whose row is missing or older than `STALENESS_PERIOD`.
-   *
-   * Fetches tags in chunks of `BATCH_CHUNK_SIZE` ids, sequentially with a delay between chunks. Every requested id is
-   * upserted even when absent from the response (deleted/redacted ways get empty tags), so it won't re-queue nightly.
-   * A failed chunk fails the whole run; the next nightly tick retries from whatever is still stale.
-   *
-   * @return Number of ways refreshed (0 when everything is fresh).
-   */
   def refreshOsmWayData(): Future[Int] = {
     db.run(osmWayTable.getWayIdsMissingOrStale(OffsetDateTime.now.minusDays(STALENESS_PERIOD_DAYS))).flatMap { wayIds =>
       if (wayIds.isEmpty) { Future.successful(0) }
@@ -96,16 +95,6 @@ class OsmWayServiceImpl @Inject() (
     }
   }
 
-  /**
-   * Gets the speed limit at a point, for positions not on our street network (the /speedLimit fallback).
-   *
-   * Checks ways already stored in our DB first; only on a miss does it query Overpass for the nearest road,
-   * storing the result (with geometry) so the next lookup nearby is served from the DB. Results — including "no road
-   * here" — are cached for a few minutes per rounded coordinate so repeated pano moves at the same spot are free.
-   *
-   * @return The raw maxspeed tag of the nearest road within `SEARCH_RADIUS_M`; None if no road or no tag, and on any
-   *         Overpass failure (this method never propagates an error).
-   */
   def getSpeedLimitAtPoint(lat: Double, lng: Double): Future[Option[String]] = {
     val cacheKey = f"speedLimitAtPoint:$lat%.4f,$lng%.4f"
     cacheApi.getOrElseUpdate[Option[String]](cacheKey, POINT_CACHE_TTL) {
@@ -121,9 +110,6 @@ class OsmWayServiceImpl @Inject() (
     }
   }
 
-  /**
-   * Gets the maxspeed for each of the given streets, keyed by street_edge_id. Streets with no known speed are absent.
-   */
   def getMaxSpeedsForStreets(streetEdgeIds: Seq[Int]): Future[Map[Int, String]] = {
     db.run(osmWayTable.getMaxSpeeds(streetEdgeIds))
   }

--- a/test/controllers/AdminJobTriggerSpec.scala
+++ b/test/controllers/AdminJobTriggerSpec.scala
@@ -8,20 +8,15 @@ import actor.{
   RecalculateStreetPriorityActor,
   UserStatActor
 }
-import models.street.OsmWayTable
 import models.user.Role
 import models.utils.MyPostgresProfile.api._
 import models.utils.{BackgroundJobRun, BackgroundJobRunTable, JobRunStatus, JobRunTrigger}
-import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.stream.Materializer
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Application
-import play.api.cache.AsyncCacheApi
-import play.api.db.slick.DatabaseConfigProvider
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
-import play.api.libs.ws.WSClient
 import play.api.mvc.Cookie
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
@@ -29,8 +24,7 @@ import service.PanoDataService.ImageryCheckResult
 import service.{AdminService, ClusterService, ClusteringResults, OsmWayService, PanoDataService, StreetService}
 import util.{AnonSession, RoleSession, RolledBackDb, StubService}
 
-import javax.inject.{Inject, Singleton}
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 
 /**
  * Functional tests for the six admin routes that hand-trigger a nightly job (#4946).
@@ -62,6 +56,9 @@ class AdminJobTriggerSpec
   private val ImageryResult  = ImageryCheckResult(stillThere = 7, gone = 2, errors = 1, reconciled = Some(3))
   private val ClusterResults = ClusteringResults(labelCount = 4614, clusterCount = 4615)
 
+  /** Set per test: this endpoint's failure path is part of its contract, and Guice owns the stub. */
+  @volatile private var osmWayAnswer: Future[Int] = Future.successful(0)
+
   override def fakeApplication(): Application =
     new GuiceApplicationBuilder()
       .disable[modules.ActorModule]
@@ -91,8 +88,9 @@ class AdminJobTriggerSpec
         bind[ClusterService].toInstance(
           StubService.answering[ClusterService](Map("runClustering" -> Future.successful(ClusterResults)))
         ),
-        // A class rather than a trait, so it takes a subclass binding instead of a proxy.
-        bind[OsmWayService].to[StubOsmWayService]
+        bind[OsmWayService].toInstance(
+          StubService.answeringWith[OsmWayService](Map("refreshOsmWayData" -> (() => osmWayAnswer)))
+        )
       )
       .build()
 
@@ -145,7 +143,6 @@ class AdminJobTriggerSpec
     // RoleSession's demotion rides super.afterAll, and leaving an account Administrator in the shared login schema is
     // worse than leaving rows behind -- so a failed delete must not cost us it.
     try {
-      StubOsmWayService.answer = () => Future.successful(0)
       if (triggeredRunIds.nonEmpty) {
         val _ = run(jobRunTable.backgroundJobRuns.filter(_.backgroundJobRunId.inSet(triggeredRunIds)).delete)
       }
@@ -201,7 +198,7 @@ class AdminJobTriggerSpec
 
   "GET /adminapi/refreshOsmWayData" should {
     "record the refresh as a manual run of the nightly OSM job" in {
-      StubOsmWayService.answer = () => Future.successful(WaysRefreshed)
+      osmWayAnswer = Future.successful(WaysRefreshed)
       val (code, body, jobRun) = trigger("/adminapi/refreshOsmWayData", OsmWayRefreshActor.Name)
       code mustBe OK
       body must include(WaysRefreshed.toString)
@@ -213,7 +210,7 @@ class AdminJobTriggerSpec
     "record a half-finished refresh as a failure, and say so rather than reporting a count" in {
       // This job runs for tens of minutes over a shared community API and can die partway. The run row is the only
       // durable account of that, and the caller is told progress is kept -- both are easy to lose to a refactor.
-      StubOsmWayService.answer = () => Future.failed(new RuntimeException("overpass timed out"))
+      osmWayAnswer = Future.failed(new RuntimeException("overpass timed out"))
       val (code, body, jobRun) = trigger("/adminapi/refreshOsmWayData", OsmWayRefreshActor.Name)
       code mustBe SERVICE_UNAVAILABLE
       body must include("trigger again to resume")
@@ -258,28 +255,4 @@ class AdminJobTriggerSpec
       }
     }
   }
-}
-
-/**
- * Answers the OSM way refresh without calling Overpass.
- *
- * A subclass rather than a proxy because `OsmWayService` is a concrete class; Guice supplies the real dependencies,
- * none of which the override touches.
- */
-@Singleton
-class StubOsmWayService @Inject() (
-    dbConfigProvider: DatabaseConfigProvider,
-    ws: WSClient,
-    cacheApi: AsyncCacheApi,
-    actorSystem: ActorSystem,
-    osmWayTable: OsmWayTable
-)(implicit ec: ExecutionContext)
-    extends OsmWayService(dbConfigProvider, ws, cacheApi, actorSystem, osmWayTable) {
-  override def refreshOsmWayData(): Future[Int] = StubOsmWayService.answer()
-}
-
-object StubOsmWayService {
-
-  /** Set per test: this endpoint's failure path is part of its contract, and Guice owns the instance. */
-  @volatile var answer: () => Future[Int] = () => Future.successful(0)
 }

--- a/test/util/StubService.scala
+++ b/test/util/StubService.scala
@@ -20,6 +20,15 @@ object StubService {
    * @param answers Return value per method name. A value is reused across calls, so it must not be a one-shot.
    */
   def answering[T](answers: Map[String, Any])(implicit ct: ClassTag[T]): T = {
+    answeringWith[T](answers.map { case (name, answer) => name -> (() => answer) })
+  }
+
+  /**
+   * As `answering`, but each answer is produced per call, for a spec that varies one between its tests.
+   *
+   * @param answers Supplier of the return value, per method name.
+   */
+  def answeringWith[T](answers: Map[String, () => Any])(implicit ct: ClassTag[T]): T = {
     val iface = ct.runtimeClass
     require(iface.isInterface, s"${iface.getName} is not an interface, so it cannot be proxied.")
 
@@ -33,7 +42,7 @@ object StubService {
     val handler = new InvocationHandler {
       override def invoke(proxy: AnyRef, method: Method, args: Array[AnyRef]): AnyRef = {
         answers.get(method.getName) match {
-          case Some(answer) => answer.asInstanceOf[AnyRef]
+          case Some(answer) => answer().asInstanceOf[AnyRef]
           case None         =>
             method.getName match {
               case "toString" => s"stub of ${iface.getSimpleName} answering ${answers.keys.mkString(", ")}"

--- a/test/util/StubService.scala
+++ b/test/util/StubService.scala
@@ -20,6 +20,11 @@ object StubService {
    * @param answers Return value per method name. A value is reused across calls, so it must not be a one-shot.
    */
   def answering[T](answers: Map[String, Any])(implicit ct: ClassTag[T]): T = {
+    // Map is covariant in its value type, so an `answeringWith` map of thunks type-checks here too -- and the stub
+    // would then answer with the function itself, surfacing as a ClassCastException inside the code under test.
+    answers.foreach { case (name, answer) =>
+      require(!answer.isInstanceOf[() => Any], s"$name's answer is a function; pass it to answeringWith instead.")
+    }
     answeringWith[T](answers.map { case (name, answer) => name -> (() => answer) })
   }
 


### PR DESCRIPTION
resolves #5043

`OsmWayService` was the only nightly-job service that wasn't an `@ImplementedBy(classOf[XImpl]) trait X`, so it couldn't be replaced with a proxy over its interface the way its siblings can.

- `app/service/OsmWayService.scala`: the public methods (`refreshOsmWayData`, `getSpeedLimitAtPoint`, `getMaxSpeedsForStreets`) move to a trait; the body becomes `OsmWayServiceImpl`. Injection sites keep the same type, so nothing else changed.
- `AdminJobTriggerSpec`: the hand-written `StubOsmWayService` subclass — which repeated the real five-argument constructor just to forward it to `super` — collapses to a `StubService` proxy like the other four.
- `StubService` gains `answeringWith`, which produces each answer per call rather than reusing one fixed value. This stub is the only one whose answer varies between tests (0, a count, and a failure), and a proxy over a fixed map can't do that. `answering` now delegates to it, unchanged for callers.

Verified: `scalafmtAll`, a warning-clean `compile` + `Test/compile`, and `AdminJobTriggerSpec` + `OsmWayServiceSpec` pass (18 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019fpSrpzgZYdFwVzRJBYLp9
