### PR TITLE
Page only among labels the sidebar filters leave visible (#5124)

### DIFF
--- a/app/views/apps/labelMap.scala.html
+++ b/app/views/apps/labelMap.scala.html
@@ -229,12 +229,14 @@
             || Boolean(aiValidationOptionsParam),
         }), 'top-right');
         // Popup arrows step through spatially nearby labels using the already-loaded map data, skipping any the
-        // sidebar filters hide (#5124); a filter change re-derives the arrows' enabled states.
+        // sidebar filters hide (#5124). Built after MapSidebarUrlSync above has restored the URL's filters: that
+        // restore applies state without firing onChange, so it must land before anything derives arrow state.
         self.nearbyNav = createNearbyLabelNavigator(self.mapData, {
           isCandidate: (labelType, feature) => sidebarFilter.matchesFilters(labelType, feature),
         });
         params.popupLabelViewer.setNearbyNavigator(self.nearbyNav);
-        sidebarFilter.onChange(() => self.nearbyNav.refresh());
+        // A user-driven filter change starts a fresh tour and re-derives the arrows' enabled states.
+        sidebarFilter.onChange(() => self.nearbyNav.filtersChanged());
 
         // Viewport label loading (#5002): label data streams in (and refreshes as the map moves) after the map
         // is ready, so everything reading the loaded label set re-syncs on each data event.

--- a/app/views/apps/labelMap.scala.html
+++ b/app/views/apps/labelMap.scala.html
@@ -228,9 +228,13 @@
           showsPartialFilterCaveat: Boolean(regionsParam) || Boolean(routesParam)
             || Boolean(aiValidationOptionsParam),
         }), 'top-right');
-        // Popup arrows step through spatially nearby labels using the already-loaded map data.
-        self.nearbyNav = createNearbyLabelNavigator(self.mapData);
+        // Popup arrows step through spatially nearby labels using the already-loaded map data, skipping any the
+        // sidebar filters hide (#5124); a filter change re-derives the arrows' enabled states.
+        self.nearbyNav = createNearbyLabelNavigator(self.mapData, {
+          isCandidate: (labelType, feature) => sidebarFilter.matchesFilters(labelType, feature),
+        });
         params.popupLabelViewer.setNearbyNavigator(self.nearbyNav);
+        sidebarFilter.onChange(() => self.nearbyNav.refresh());
 
         // Viewport label loading (#5002): label data streams in (and refreshes as the map moves) after the map
         // is ready, so everything reading the loaded label set re-syncs on each data event.

--- a/public/js/common/label-detail/LabelPopup.js
+++ b/public/js/common/label-detail/LabelPopup.js
@@ -112,6 +112,9 @@ async function LabelPopup(admin, viewerType, viewerAccessToken, currUsername, op
     if (opts.syncUrlSource) LabelDetail.syncUrlLabelId(labelId);
     currentLabelId = labelId;
     lastSource = source;
+    // The arrows are computed from the navigator alone, so they can reflect this label now rather than showing the
+    // previous label's state until its metadata fetch resolves.
+    updatePagingState();
     // Before the await so the host's map movement runs in parallel with the pano load.
     if (typeof opts.onShow === 'function') opts.onShow(labelId);
     const meta = await innerShowLabel(labelId, source);
@@ -138,8 +141,9 @@ async function LabelPopup(admin, viewerType, viewerAccessToken, currUsername, op
    * Enables the prev/next arrows, stepping through labels via the given navigator (see nearbyLabelNavigator.js).
    * @param {{next: function, prev: function, hasPrev: function, hasNext: function,
    *     onRefresh: function}} nav Navigator over the host's label set. Its onRefresh is what keeps the arrows
-   *     honest on a host whose label set changes under them: LabelMap loads labels by viewport (#5002), so a
-   *     deep-linked popup opens over an empty set and has nowhere to page until the set fills (#5068).
+   *     honest on a host whose reachable set changes under them: LabelMap loads labels by viewport (#5002), so a
+   *     deep-linked popup opens over an empty set and has nowhere to page until the set fills (#5068), and its
+   *     sidebar filters narrow where "next" may land (#5124).
    */
   labelDetail.setNearbyNavigator = (nav) => {
     // Subscribe only for a navigator we haven't seen, so a repeat call can't stack duplicate recomputes.

--- a/public/js/ps-map/MapSidebarFilter.js
+++ b/public/js/ps-map/MapSidebarFilter.js
@@ -90,18 +90,28 @@ class MapSidebarFilter {
     const bounds = this.#countBounds();
     let total = 0;
     for (const [labelType, features] of Object.entries(this.#mapData.sortedLabels)) {
-      if (!(this.#sidebar.querySelector(`#${labelType}-checkbox`)?.checked ?? false)) continue;
+      if (!this.#typeChecked(labelType)) continue;
       for (const feature of features) {
-        const props = feature.properties;
         if (bounds && !bounds.contains(feature.geometry.coordinates)) continue;
-        if (!this.#passesQualityFilters(props)) continue;
-        if (this.#passesSeverity(props) && this.#passesTags(labelType, props)
-          && this.#mapData[this.#validationCategory(props)]) {
-          total += 1;
-        }
+        if (this.#passesLabelFilters(labelType, feature.properties)) total += 1;
       }
     }
     return total;
+  }
+
+  /**
+   * Returns true when the current filters leave a loaded label visible on the map: its type is checked and it
+   * passes the quality, severity, tag, and validation filters. The viewport is not consulted — a label just off
+   * screen is still a legitimate place to page to — and neither is the spotlight bypass, which is a popup
+   * affordance rather than part of the matching data. Backs the popup's prev/next navigator, so the arrows step
+   * only among labels the user can see (#5124).
+   *
+   * @param {string} labelType The label's type key (e.g. 'CurbRamp').
+   * @param {object} feature   The label's GeoJSON feature.
+   * @returns {boolean} Whether the label matches the active filters.
+   */
+  matchesFilters(labelType, feature) {
+    return this.#typeChecked(labelType) && this.#passesLabelFilters(labelType, feature.properties);
   }
 
   /**
@@ -236,7 +246,7 @@ class MapSidebarFilter {
     const typeCounts = {};
     const validationCounts = { correct: 0, incorrect: 0, unsure: 0, unvalidated: 0 };
     for (const [labelType, features] of Object.entries(this.#mapData.sortedLabels)) {
-      const typeChecked = this.#sidebar.querySelector(`#${labelType}-checkbox`)?.checked ?? false;
+      const typeChecked = this.#typeChecked(labelType);
       let count = 0;
       for (const feature of features) {
         const props = feature.properties;
@@ -266,6 +276,28 @@ class MapSidebarFilter {
   /** @returns {?mapboxgl.LngLatBounds} The current viewport under viewportCounts, else null (no restriction). */
   #countBounds() {
     return this.#viewportCounts ? this.#map.getBounds() : null;
+  }
+
+  /**
+   * Returns true when the label type's sidebar checkbox is checked (false for a type the sidebar doesn't render).
+   * @param {string} labelType The label type key.
+   * @returns {boolean}
+   */
+  #typeChecked(labelType) {
+    return this.#sidebar.querySelector(`#${labelType}-checkbox`)?.checked ?? false;
+  }
+
+  /**
+   * Returns true when a label passes every per-label filter other than its type checkbox: quality, severity,
+   * tags, and validation status. The faceted counts can't use this whole (they ignore one axis at a time), so it
+   * serves the all-axes consumers: the visible-label count and the popup navigator.
+   * @param {string} labelType The label's type key.
+   * @param {object} props     The label's GeoJSON properties.
+   * @returns {boolean}
+   */
+  #passesLabelFilters(labelType, props) {
+    return this.#passesQualityFilters(props) && this.#passesSeverity(props) && this.#passesTags(labelType, props)
+      && Boolean(this.#mapData[this.#validationCategory(props)]);
   }
 
   /**

--- a/public/js/ps-map/MapSidebarFilter.js
+++ b/public/js/ps-map/MapSidebarFilter.js
@@ -25,6 +25,8 @@ class MapSidebarFilter {
   #viewportCounts;
   /** @type {object} Last-applied per-type layer visibility, so unchanged layers aren't re-set on every click. */
   #layerVisibility = {};
+  /** @type {Map<string, ?HTMLInputElement>} Each label type's checkbox (null when the sidebar omits it). */
+  #typeCheckboxes = new Map();
   /** @type {Array<() => void>} */
   #changeCallbacks = [];
 
@@ -51,6 +53,7 @@ class MapSidebarFilter {
 
     for (const labelType of Object.keys(this.#mapData.layerNames)) {
       this.#layerVisibility[labelType] = true;
+      this.#typeCheckboxes.set(labelType, this.#sidebar.querySelector(`#${labelType}-checkbox`));
     }
 
     this.#filters.enable();
@@ -279,12 +282,18 @@ class MapSidebarFilter {
   }
 
   /**
-   * Returns true when the label type's sidebar checkbox is checked (false for a type the sidebar doesn't render).
+   * Returns true when the label type's sidebar checkbox is checked. The elements are looked up once at construction
+   * (this runs per label inside city-sized scans) but `checked` is read live, so the DOM stays the source of truth.
+   *
+   * A type the sidebar doesn't render counts as unchecked: every host renders every type the feed can carry, and a
+   * host that dropped one would hide its layer on the first filter change anyway (#syncLayerVisibility only shows
+   * checked types), so "not pageable" is the state the map converges to.
+   *
    * @param {string} labelType The label type key.
-   * @returns {boolean}
+   * @returns {boolean} Whether labels of this type are currently shown.
    */
   #typeChecked(labelType) {
-    return this.#sidebar.querySelector(`#${labelType}-checkbox`)?.checked ?? false;
+    return this.#typeCheckboxes.get(labelType)?.checked ?? false;
   }
 
   /**
@@ -293,11 +302,11 @@ class MapSidebarFilter {
    * serves the all-axes consumers: the visible-label count and the popup navigator.
    * @param {string} labelType The label's type key.
    * @param {object} props     The label's GeoJSON properties.
-   * @returns {boolean}
+   * @returns {boolean} Whether the label survives all four axes.
    */
   #passesLabelFilters(labelType, props) {
     return this.#passesQualityFilters(props) && this.#passesSeverity(props) && this.#passesTags(labelType, props)
-      && Boolean(this.#mapData[this.#validationCategory(props)]);
+      && this.#mapData[this.#validationCategory(props)] === true;
   }
 
   /**
@@ -306,9 +315,9 @@ class MapSidebarFilter {
    * @returns {boolean} Whether the label's severity is currently enabled.
    */
   #passesSeverity(props) {
-    return Number.isInteger(props.severity)
-      ? Boolean(this.#mapData.severities[props.severity])
-      : this.#mapData.severities[0];
+    return Boolean(Number.isInteger(props.severity)
+      ? this.#mapData.severities[props.severity]
+      : this.#mapData.severities[0]);
   }
 
   /**
@@ -343,7 +352,11 @@ class MapSidebarFilter {
     const selected = this.#mapData.selectedTags[labelType];
     if (!selected || selected.size === 0) return true;
     const tags = props.tags ?? [];
-    return Array.from(selected).some((tag) => tags.includes(tag));
+    // A plain loop over the Set: this runs per label inside city-sized scans, so no per-call array copy.
+    for (const tag of selected) {
+      if (tags.includes(tag)) return true;
+    }
+    return false;
   }
 
   /**

--- a/public/js/ps-map/nearbyLabelNavigator.js
+++ b/public/js/ps-map/nearbyLabelNavigator.js
@@ -4,6 +4,13 @@
  * trail. Operates on the same in-memory GeoJSON features the map layers draw, so paging costs no requests.
  *
  * @param {Object} mapData The map layer tracker returned by addLabelsToMap (reads .sortedLabels).
+ * @param {Object} [options]
+ * @param {function(string, Object): boolean} [options.isCandidate] Called with a label's type and GeoJSON feature
+ *     to decide whether "next" may land on it; omit to page over every loaded label. LabelMap passes the sidebar
+ *     filters here so the arrows never step onto a label the user has filtered off the map (#5124). Evaluated on
+ *     each call rather than cached, so a filter change takes effect on the very next click; call refresh() after
+ *     one so subscribers (the popup's arrow states) re-derive too. "prev" is exempt: it retraces where the user
+ *     has actually been, and the spotlight keeps that label visible whatever the filters say.
  * @returns {{next: function(number): ?number, prev: function(number): ?number, hasPrev: function(number): boolean,
  *     hasNext: function(number): boolean, getCoords: function(number): ?Array<number>,
  *     getLabelType: function(number): ?string, refresh: function(): void,
@@ -13,17 +20,20 @@
  *     re-reads .sortedLabels after a viewport refetch has swapped the loaded labels, notifying onRefresh
  *     subscribers so everything derived from the label set (e.g. the popup's arrow states) follows it.
  */
-function createNearbyLabelNavigator(mapData) {
-  // label_id -> [lng, lat] and label_id -> label type for every label on the map, flattened across types.
+function createNearbyLabelNavigator(mapData, { isCandidate = () => true } = {}) {
+  // label_id -> [lng, lat], label type, and feature for every label on the map, flattened across types.
   const coordsById = new Map();
   const typeById = new Map();
+  const featureById = new Map();
   const rebuild = () => {
     coordsById.clear();
     typeById.clear();
+    featureById.clear();
     for (const [labelType, features] of Object.entries(mapData.sortedLabels)) {
       for (const f of features) {
         coordsById.set(f.properties.label_id, f.geometry.coordinates);
         typeById.set(f.properties.label_id, labelType);
+        featureById.set(f.properties.label_id, f);
       }
     }
   };
@@ -39,6 +49,16 @@ function createNearbyLabelNavigator(mapData) {
   // which the popup already renders as "nowhere to go".
   const trail = [];         // Visited label IDs in visit order; backs prev().
   const visited = new Set(); // next() never revisits, so repeated clicks tour outward instead of ping-ponging.
+
+  /**
+   * Whether next() may land on a label: not the one being paged from, not yet toured, and passing the host's
+   * filter predicate.
+   * @param {number} id A loaded label's ID.
+   * @param {number} currentId The label being paged from.
+   * @returns {boolean}
+   */
+  const isReachable = (id, currentId) =>
+    id !== currentId && !visited.has(id) && isCandidate(typeById.get(id), featureById.get(id));
 
   /**
    * Squared equirectangular distance — plenty for ranking nearby points.
@@ -65,7 +85,7 @@ function createNearbyLabelNavigator(mapData) {
       let best = null;
       let bestD = Infinity;
       for (const [id, coords] of coordsById) {
-        if (visited.has(id)) continue;
+        if (!isReachable(id, currentId)) continue;
         const d = dist2(here, coords, kx);
         if (d < bestD) {
           bestD = d;
@@ -83,10 +103,10 @@ function createNearbyLabelNavigator(mapData) {
     },
     hasNext(currentId) {
       // Mirrors next()'s reachability without mutating state: a known current label plus at least one other
-      // unvisited label. Backs the Next button's disabled state.
+      // reachable label. Backs the Next button's disabled state.
       if (!coordsById.has(currentId)) return false;
       for (const id of coordsById.keys()) {
-        if (id !== currentId && !visited.has(id)) return true;
+        if (isReachable(id, currentId)) return true;
       }
       return false;
     },

--- a/public/js/ps-map/nearbyLabelNavigator.js
+++ b/public/js/ps-map/nearbyLabelNavigator.js
@@ -1,48 +1,54 @@
 /**
  * Prev/next navigation over the map's loaded labels for the label popup (#4572): "next" greedily walks to the
- * nearest label not yet visited this page-load (touring along a street and outward), "prev" retraces the visited
+ * nearest label not yet visited this tour (touring along a street and outward), "prev" retraces the visited
  * trail. Operates on the same in-memory GeoJSON features the map layers draw, so paging costs no requests.
  *
+ * A host can narrow where "next" may land with `isCandidate`: LabelMap passes its sidebar filters so the arrows
+ * never step onto a label the user has filtered off the map (#5124). The predicate is evaluated on each call
+ * rather than cached, so a filter change takes effect on the very next click; the host reports the change through
+ * filtersChanged(), which starts a fresh tour (a narrowed filter shouldn't strand "next" on labels an earlier tour
+ * already passed) and re-derives subscribers' state. "prev" is exempt from the predicate: it retraces where the
+ * user has actually been, and the spotlight keeps that label visible whatever the filters say.
+ *
  * @param {Object} mapData The map layer tracker returned by addLabelsToMap (reads .sortedLabels).
- * @param {Object} [options]
- * @param {function(string, Object): boolean} [options.isCandidate] Called with a label's type and GeoJSON feature
- *     to decide whether "next" may land on it; omit to page over every loaded label. LabelMap passes the sidebar
- *     filters here so the arrows never step onto a label the user has filtered off the map (#5124). Evaluated on
- *     each call rather than cached, so a filter change takes effect on the very next click; call refresh() after
- *     one so subscribers (the popup's arrow states) re-derive too. "prev" is exempt: it retraces where the user
- *     has actually been, and the spotlight keeps that label visible whatever the filters say.
+ * @param {Object} [options] Navigation options.
+ * @param {function(string, Object): boolean} [options.isCandidate] Called with a label's type and GeoJSON feature;
+ *     returns whether "next" may land on it. Omit to page over every loaded label.
  * @returns {{next: function(number): ?number, prev: function(number): ?number, hasPrev: function(number): boolean,
  *     hasNext: function(number): boolean, getCoords: function(number): ?Array<number>,
- *     getLabelType: function(number): ?string, refresh: function(): void,
+ *     getLabelType: function(number): ?string, refresh: function(): void, filtersChanged: function(): void,
  *     onRefresh: function(function(): void): void}}
  *     Navigator whose paging methods take the currently shown label ID and return the label ID to show (null when
  *     there is nowhere to go); getCoords/getLabelType look up a loaded label's [lng, lat] / label type; refresh
- *     re-reads .sortedLabels after a viewport refetch has swapped the loaded labels, notifying onRefresh
- *     subscribers so everything derived from the label set (e.g. the popup's arrow states) follows it.
+ *     re-reads .sortedLabels after a viewport refetch has swapped the loaded labels, and filtersChanged restarts
+ *     the tour after the host's predicate changed — both notify onRefresh subscribers so everything derived from
+ *     the reachable set (e.g. the popup's arrow states) follows it.
  */
 function createNearbyLabelNavigator(mapData, { isCandidate = () => true } = {}) {
-  // label_id -> [lng, lat], label type, and feature for every label on the map, flattened across types.
+  // label_id -> [lng, lat] and label_id -> label type for every label on the map, flattened across types. The
+  // scans themselves walk mapData.sortedLabels directly rather than a third per-label map of features: the loaded
+  // set is city-sized on desktop, so every parallel structure is another few hundred thousand entries.
   const coordsById = new Map();
   const typeById = new Map();
-  const featureById = new Map();
   const rebuild = () => {
     coordsById.clear();
     typeById.clear();
-    featureById.clear();
     for (const [labelType, features] of Object.entries(mapData.sortedLabels)) {
       for (const f of features) {
         coordsById.set(f.properties.label_id, f.geometry.coordinates);
         typeById.set(f.properties.label_id, labelType);
-        featureById.set(f.properties.label_id, f);
       }
     }
   };
   rebuild();
 
-  // Subscribers re-derive whatever they compute from the label set. Anything holding state keyed on the set —
+  // Subscribers re-derive whatever they compute from the reachable set. Anything holding state keyed on it —
   // the popup's prev/next disabled states — is only correct if it recomputes with the set, so the navigator
   // announces the change rather than leaving each host to pair a second call with every refresh() (#5068).
   const refreshListeners = [];
+  const notify = () => {
+    for (const listener of refreshListeners) listener();
+  };
 
   // The trail and visited set deliberately survive refresh(): prev() retraces even labels a refetch dropped
   // (the page falls back to popup-metadata coords for those), and next() from a dropped label returns null,
@@ -52,13 +58,17 @@ function createNearbyLabelNavigator(mapData, { isCandidate = () => true } = {}) 
 
   /**
    * Whether next() may land on a label: not the one being paged from, not yet toured, and passing the host's
-   * filter predicate.
-   * @param {number} id A loaded label's ID.
+   * predicate. The cheap checks come first so the predicate — the host's filter logic — runs only on labels that
+   * are otherwise reachable.
+   * @param {string} labelType The label's type key.
+   * @param {Object} feature   The label's GeoJSON feature.
    * @param {number} currentId The label being paged from.
    * @returns {boolean}
    */
-  const isReachable = (id, currentId) =>
-    id !== currentId && !visited.has(id) && isCandidate(typeById.get(id), featureById.get(id));
+  const isReachable = (labelType, feature, currentId) => {
+    const id = feature.properties.label_id;
+    return id !== currentId && !visited.has(id) && isCandidate(labelType, feature);
+  };
 
   /**
    * Squared equirectangular distance — plenty for ranking nearby points.
@@ -84,12 +94,14 @@ function createNearbyLabelNavigator(mapData, { isCandidate = () => true } = {}) 
       const kx = Math.cos(here[1] * (Math.PI / 180));
       let best = null;
       let bestD = Infinity;
-      for (const [id, coords] of coordsById) {
-        if (!isReachable(id, currentId)) continue;
-        const d = dist2(here, coords, kx);
-        if (d < bestD) {
-          bestD = d;
-          best = id;
+      for (const [labelType, features] of Object.entries(mapData.sortedLabels)) {
+        for (const f of features) {
+          if (!isReachable(labelType, f, currentId)) continue;
+          const d = dist2(here, f.geometry.coordinates, kx);
+          if (d < bestD) {
+            bestD = d;
+            best = f.properties.label_id;
+          }
         }
       }
       return best;
@@ -105,8 +117,10 @@ function createNearbyLabelNavigator(mapData, { isCandidate = () => true } = {}) 
       // Mirrors next()'s reachability without mutating state: a known current label plus at least one other
       // reachable label. Backs the Next button's disabled state.
       if (!coordsById.has(currentId)) return false;
-      for (const id of coordsById.keys()) {
-        if (isReachable(id, currentId)) return true;
+      for (const [labelType, features] of Object.entries(mapData.sortedLabels)) {
+        for (const f of features) {
+          if (isReachable(labelType, f, currentId)) return true;
+        }
       }
       return false;
     },
@@ -118,7 +132,12 @@ function createNearbyLabelNavigator(mapData, { isCandidate = () => true } = {}) 
     },
     refresh() {
       rebuild();
-      for (const listener of refreshListeners) listener();
+      notify();
+    },
+    filtersChanged() {
+      // The trail is kept: "prev" still means "where I just was", filters or not.
+      visited.clear();
+      notify();
     },
     onRefresh(callback) {
       refreshListeners.push(callback);

--- a/test/js/labelPopupPagingRefresh.test.js
+++ b/test/js/labelPopupPagingRefresh.test.js
@@ -118,14 +118,29 @@ describe('LabelPopup paging state', () => {
         expect(prevBtn.disabled).toBe(false);
     });
 
-    test('Next disables on the host\'s nav.refresh() after a filter change hides the only neighbor', async () => {
+    test('Next disables on the host\'s nav.filtersChanged() after a filter hides the only neighbor', async () => {
         await popup.showLabel(1, 'LabelMap');
         landViewportData(TWO_LABELS);
         expect(nextBtn.disabled).toBe(false);
 
-        // The user unchecks the neighbor's label type; LabelMap's sidebar onChange handler calls nav.refresh().
+        // The user unchecks the neighbor's label type; LabelMap's sidebar onChange handler reports it.
         hiddenByFilters.add(2);
-        nav.refresh();
+        nav.filtersChanged();
+
+        expect(nextBtn.disabled).toBe(true);
+    });
+
+    test('the arrows reflect the newly shown label before its metadata fetch resolves', async () => {
+        await popup.showLabel(1, 'LabelMap');
+        landViewportData(TWO_LABELS);
+        expect(nextBtn.disabled).toBe(false);
+
+        // Rebuild the popup over a label fetch that never settles, so the pre-await state is observable.
+        global.LabelDetail.create = async () => ({ showLabel: () => new Promise(() => {}) });
+        const pending = await global.LabelPopup(false, null, null, null, {});
+        pending.setNearbyNavigator(nav);
+        hiddenByFilters.add(1); // From label 2, the only other label (1) is filtered out: nowhere to go.
+        pending.showLabel(2, 'LabelMap');
 
         expect(nextBtn.disabled).toBe(true);
     });

--- a/test/js/labelPopupPagingRefresh.test.js
+++ b/test/js/labelPopupPagingRefresh.test.js
@@ -35,6 +35,7 @@ describe('LabelPopup paging state', () => {
     let popup;
     let mapData;
     let nav;
+    let hiddenByFilters;
     let prevBtn;
     let nextBtn;
 
@@ -56,8 +57,12 @@ describe('LabelPopup paging state', () => {
         (0, eval)(fs.readFileSync(POPUP_PATH, 'utf8')); // Declares LabelPopup globally.
 
         // The navigator is created over the map's label set, which is still empty while the viewport data loads.
+        // The predicate stands in for LabelMap's sidebar filters (#5124).
         mapData = { sortedLabels: {} };
-        nav = global.createNearbyLabelNavigator(mapData);
+        hiddenByFilters = new Set();
+        nav = global.createNearbyLabelNavigator(mapData, {
+            isCandidate: (labelType, feature) => !hiddenByFilters.has(feature.properties.label_id),
+        });
         popup = await global.LabelPopup(false, null, null, null, {});
         popup.setNearbyNavigator(nav);
         prevBtn = document.querySelector('.label-detail__paging--prev');
@@ -111,5 +116,17 @@ describe('LabelPopup paging state', () => {
         landViewportData({ CurbRamp: [feature(2, 0.001, 0)] });
 
         expect(prevBtn.disabled).toBe(false);
+    });
+
+    test('Next disables on the host\'s nav.refresh() after a filter change hides the only neighbor', async () => {
+        await popup.showLabel(1, 'LabelMap');
+        landViewportData(TWO_LABELS);
+        expect(nextBtn.disabled).toBe(false);
+
+        // The user unchecks the neighbor's label type; LabelMap's sidebar onChange handler calls nav.refresh().
+        hiddenByFilters.add(2);
+        nav.refresh();
+
+        expect(nextBtn.disabled).toBe(true);
     });
 });

--- a/test/js/mapSidebarCounts.test.js
+++ b/test/js/mapSidebarCounts.test.js
@@ -236,6 +236,45 @@ describe('MapSidebarFilter counts', () => {
         });
     });
 
+    // The per-label predicate behind the popup's prev/next arrows (#5124): the same filters the count applies,
+    // minus the viewport, which is not a filter.
+    describe('matchesFilters', () => {
+        it('applies the type checkbox and every per-label filter axis', () => {
+            const sidebar = build({ CurbRamp: [], Obstacle: [] });
+            const visible = label({ correct: true });
+            expect(sidebar.matchesFilters('CurbRamp', visible)).toBe(true);
+            expect(sidebar.matchesFilters('CurbRamp', label({ correct: false }))).toBe(false); // Off by default.
+            expect(sidebar.matchesFilters('CurbRamp', label({ high_quality_user: false }))).toBe(false);
+
+            mapData.severities[1] = false;
+            expect(sidebar.matchesFilters('CurbRamp', visible)).toBe(false);
+            mapData.severities[1] = true;
+
+            mapData.selectedTags.CurbRamp.add('narrow');
+            expect(sidebar.matchesFilters('CurbRamp', visible)).toBe(false);
+            expect(sidebar.matchesFilters('CurbRamp', label({ correct: true, tags: ['narrow'] }))).toBe(true);
+            mapData.selectedTags.CurbRamp.clear();
+
+            document.querySelector('#Obstacle-checkbox').click();
+            expect(sidebar.matchesFilters('Obstacle', visible)).toBe(false);
+            expect(sidebar.matchesFilters('CurbRamp', visible)).toBe(true);
+        });
+
+        it('ignores the viewport: a label just off screen is still a match', () => {
+            buildFixture();
+            mapData = buildMapData({ CurbRamp: [] });
+            const map = {
+                getLayer: () => true,
+                easeTo: () => {},
+                setPadding: () => {},
+                getBounds: () => ({ contains: () => false }),
+            };
+            const sidebar = new window.MapSidebarFilter(map, mapData, { viewportCounts: true });
+            const offScreen = { ...label({ correct: true }), geometry: { coordinates: [5, 5] } };
+            expect(sidebar.matchesFilters('CurbRamp', offScreen)).toBe(true);
+        });
+    });
+
     // Viewport-scoped label loading (#5002): counts restrict to the current view, and refresh() recomputes
     // after a data swap or pan with no filter interaction.
     describe('viewportCounts', () => {

--- a/test/js/mapSidebarCounts.test.js
+++ b/test/js/mapSidebarCounts.test.js
@@ -260,6 +260,30 @@ describe('MapSidebarFilter counts', () => {
             expect(sidebar.matchesFilters('CurbRamp', visible)).toBe(true);
         });
 
+        it('splits unvalidated labels from unsure ones on has_validations, like the layer filter', () => {
+            const sidebar = build({ CurbRamp: [] });
+            const unsure = label({ correct: null, has_validations: true });
+            const unvalidated = label({ correct: null, has_validations: false });
+            expect(sidebar.matchesFilters('CurbRamp', unsure)).toBe(true);
+            expect(sidebar.matchesFilters('CurbRamp', unvalidated)).toBe(true);
+
+            document.querySelector('#unsure').click();
+            expect(sidebar.matchesFilters('CurbRamp', unsure)).toBe(false);
+            expect(sidebar.matchesFilters('CurbRamp', unvalidated)).toBe(true);
+        });
+
+        it('applies the admin-only "not admin validated" filter when a host turns it on', () => {
+            const sidebar = build({ CurbRamp: [] });
+            mapData.notAdminValidated = true;
+            expect(sidebar.matchesFilters('CurbRamp', label({ has_admin_validation: false }))).toBe(true);
+            expect(sidebar.matchesFilters('CurbRamp', label({ has_admin_validation: true }))).toBe(false);
+        });
+
+        it('treats a label type the sidebar does not render as unchecked', () => {
+            const sidebar = build({ CurbRamp: [] });
+            expect(sidebar.matchesFilters('Signal', label({ correct: true }))).toBe(false);
+        });
+
         it('ignores the viewport: a label just off screen is still a match', () => {
             buildFixture();
             mapData = buildMapData({ CurbRamp: [] });

--- a/test/js/nearbyLabelNavigator.test.js
+++ b/test/js/nearbyLabelNavigator.test.js
@@ -19,12 +19,15 @@ function loadFactory() {
     return global.createNearbyLabelNavigator;
 }
 
-/** Builds a map-data stub in the shape addLabelsToMap produces: features bucketed by label type. */
+/**
+ * Builds a map-data stub in the shape addLabelsToMap produces: features bucketed by label type. A label is
+ * `[id, lng, lat]`, optionally followed by extra feature properties.
+ */
 function mapDataWith(featuresByType) {
     const sortedLabels = {};
     for (const [type, labels] of Object.entries(featuresByType)) {
-        sortedLabels[type] = labels.map(([id, lng, lat]) => ({
-            properties: { label_id: id },
+        sortedLabels[type] = labels.map(([id, lng, lat, props = {}]) => ({
+            properties: { label_id: id, ...props },
             geometry: { coordinates: [lng, lat] },
         }));
     }
@@ -147,5 +150,69 @@ describe('createNearbyLabelNavigator', () => {
         nav.refresh();
 
         expect(seen).toEqual([true, 'second subscriber']);
+    });
+
+    // The host's filter predicate (#5124): LabelMap passes its sidebar filters so paging never lands on a label
+    // the user has filtered off the map.
+    describe('isCandidate', () => {
+        // Two types interleaved along a street; the Obstacle at 2 is nearest to 1 but may be filtered out.
+        const MIXED = {
+            CurbRamp: [[1, 0, 0], [3, 0.002, 0]],
+            Obstacle: [[2, 0.001, 0], [4, 0.003, 0]],
+        };
+
+        test('next() skips labels the predicate rejects and hasNext() agrees', () => {
+            const onlyCurbRamps = (labelType) => labelType === 'CurbRamp';
+            const nav = loadFactory()(mapDataWith(MIXED), { isCandidate: onlyCurbRamps });
+            expect(nav.hasNext(1)).toBe(true);
+            expect(nav.next(1)).toBe(3); // Not the nearer Obstacle at 2.
+            expect(nav.hasNext(3)).toBe(false); // The only other labels are Obstacles.
+            expect(nav.next(3)).toBeNull();
+        });
+
+        test('the predicate sees the label type and its full feature', () => {
+            const seen = [];
+            const nav = loadFactory()(mapDataWith({ CurbRamp: [[1, 0, 0], [2, 0.001, 0, { severity: 3 }]] }), {
+                isCandidate: (labelType, feature) => {
+                    seen.push([labelType, feature.properties.severity]);
+                    return true;
+                },
+            });
+            nav.next(1);
+            expect(seen).toEqual([['CurbRamp', 3]]);
+        });
+
+        test('is evaluated live, so a filter change takes effect on the next click', () => {
+            let hidden = new Set();
+            const nav = loadFactory()(mapDataWith(MIXED), {
+                isCandidate: (labelType, feature) => !hidden.has(feature.properties.label_id),
+            });
+            expect(nav.hasNext(1)).toBe(true);
+
+            hidden = new Set([2, 3, 4]);
+            expect(nav.hasNext(1)).toBe(false);
+            expect(nav.next(1)).toBeNull();
+
+            hidden = new Set([2]);
+            expect(nav.next(1)).toBe(3);
+        });
+
+        test('prev() still retraces a label the predicate now rejects', () => {
+            let hidden = new Set();
+            const nav = loadFactory()(mapDataWith(MIXED), {
+                isCandidate: (labelType, feature) => !hidden.has(feature.properties.label_id),
+            });
+            nav.next(1); // -> 2
+            nav.next(2); // -> 3
+            hidden = new Set([2]); // The user filters out the label they came through.
+            // Back means back: the spotlight keeps that label visible whatever the filters say.
+            expect(nav.hasPrev(3)).toBe(true);
+            expect(nav.prev(3)).toBe(2);
+        });
+
+        test('defaults to every loaded label when the host passes no predicate', () => {
+            const nav = loadFactory()(mapDataWith(MIXED));
+            expect(nav.next(1)).toBe(2);
+        });
     });
 });

--- a/test/js/nearbyLabelNavigator.test.js
+++ b/test/js/nearbyLabelNavigator.test.js
@@ -197,6 +197,29 @@ describe('createNearbyLabelNavigator', () => {
             expect(nav.next(1)).toBe(3);
         });
 
+        test('filtersChanged() restarts the tour, keeps the trail, and notifies subscribers', () => {
+            let hidden = new Set();
+            const nav = loadFactory()(mapDataWith(MIXED), {
+                isCandidate: (labelType, feature) => !hidden.has(feature.properties.label_id),
+            });
+            const notified = [];
+            nav.onRefresh(() => notified.push(nav.hasNext(4)));
+            nav.next(1); // -> 2
+            nav.next(2); // -> 3
+            nav.next(3); // -> 4
+            expect(nav.hasNext(4)).toBe(false); // Every other label is toured.
+
+            // The user narrows the filters; labels the earlier tour passed are fair game for the new one.
+            hidden = new Set([2]);
+            nav.filtersChanged();
+
+            expect(notified).toEqual([true]);
+            expect(nav.next(4)).toBe(3);
+            // The trail is intact: back from 3 is 4, and back from there retraces the first tour.
+            expect(nav.prev(3)).toBe(4);
+            expect(nav.prev(4)).toBe(3);
+        });
+
         test('prev() still retraces a label the predicate now rejects', () => {
             let hidden = new Set();
             const nav = loadFactory()(mapDataWith(MIXED), {


### PR DESCRIPTION
Fixes #5124.

## Problem

The label popup's prev/next arrows on LabelMap ranked every loaded label by distance and never consulted the sidebar, so filtering to one label type (e.g. Crosswalk) still paged onto the other labels at the same intersection.

## Fix

- **`nearbyLabelNavigator.js`** takes an optional `isCandidate(labelType, feature)` predicate. `next()` and `hasNext()` skip labels it rejects. It is evaluated live on each call, so a filter change applies on the very next click.
- **`MapSidebarFilter.matchesFilters(labelType, feature)`** is the new public per-label check: type checkbox plus the quality, severity, tag, and validation filters. The viewport is deliberately not consulted (a label just off screen is still a fine place to page to), and neither is the spotlight bypass. `getVisibleLabelCount()` now shares the same helper so the two can't drift.
- **`labelMap.scala.html`** passes that check into the navigator and refreshes the navigator on sidebar changes, so the arrows' enabled states follow the filters.
- **Prev is exempt on purpose.** It retraces where the user has actually been, and the spotlight keeps that label visible even if the filters now hide it.

## Tests

- 8 new Jest tests across `nearbyLabelNavigator.test.js`, `mapSidebarCounts.test.js`, and `labelPopupPagingRefresh.test.js`; full suite 1445/1445.
- ESLint and HTMLHint clean on the touched files.

## QA

Open LabelMap, click "Only" on Crosswalk, open a label, and click Next repeatedly: every label shown should be a Crosswalk. With a popup open, uncheck every type but the current one and confirm Next disables when nothing else qualifies.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Fable 5.1, claude-fable-5-1

https://claude.ai/code/session_01RNpsRDxvKbjwn31EEZz78c
