### PR TITLE
Correct the backend-tests description in dev-environment.md

### DIFF
--- a/docs/dev-environment.md
+++ b/docs/dev-environment.md
@@ -277,9 +277,10 @@ docker exec projectsidewalk-web bash -lc "cd /home && sbt --client test"
 docker exec projectsidewalk-web bash -lc "cd /home && sbt --client \"testOnly controllers.api.PublicApiSpec\""
 ```
 
-The `backend-tests` CI job is a required check, but it runs a **named subset** of these specs, not `sbt test` — so a
-spec that nobody adds to that list in `.github/workflows/ci.yml` can rot without CI ever going red. Run the whole suite
-locally before you trust it, and add new specs to the job in the same PR.
+The `backend-tests` CI job is a required check and runs **all of `test/`** (`sbt coverage test`, since #5042), so a
+new spec file is picked up with nothing to enroll it in. Still run the suite locally before you trust it: the
+DB-dependent specs `assume` their way to *canceled* rather than failing when the data they need isn't there, so a
+green run isn't proof that everything in it actually ran.
 
 There are also Python unit tests for the `scripts/` utilities (`make test-python`) and a jsdom Jest suite for
 frontend modules (`docker exec projectsidewalk-web bash -lc "cd /home && npm run test:js"` — Jest's

--- a/docs/dev-environment.md
+++ b/docs/dev-environment.md
@@ -278,9 +278,12 @@ docker exec projectsidewalk-web bash -lc "cd /home && sbt --client \"testOnly co
 ```
 
 The `backend-tests` CI job is a required check and runs **all of `test/`** (`sbt coverage test`, since #5042), so a
-new spec file is picked up with nothing to enroll it in. Still run the suite locally before you trust it: the
-DB-dependent specs `assume` their way to *canceled* rather than failing when the data they need isn't there, so a
-green run isn't proof that everything in it actually ran.
+new spec file is picked up with nothing to enroll it in. Still run the suite locally before you trust it — and read
+the CANCELED lines, not just the green ones. Specs `assume` their preconditions instead of failing on them, and they
+cancel in both directions: most want rows your schema may not have, while `NightlyJobStatusSpec` and
+`ImageryPollOutcomeSpec` cancel on a database holding *more* than CI's — every nightly job already recorded, say.
+CI's seeded schema (#5115) is expected to cancel nothing, so a CANCELED line there means the seed stopped covering
+something.
 
 There are also Python unit tests for the `scripts/` utilities (`make test-python`) and a jsdom Jest suite for
 frontend modules (`docker exec projectsidewalk-web bash -lc "cd /home && npm run test:js"` — Jest's


### PR DESCRIPTION
resolves #5137

`docs/dev-environment.md` still described the pre-#5042 `backend-tests` job as running a hand-maintained list of spec names, and told contributors to add new specs to that list — a list that no longer exists in `.github/workflows/ci.yml`. The job has run `sbt coverage test` over all of `test/` since #5042, which is what `docs/testing-and-ci.md` and `CONTRIBUTING.md` already say.

Rewrote the paragraph to say the whole suite runs and a new spec is picked up with nothing to enroll it in, and kept the "run it locally first" advice with the reason it still matters: the DB-dependent specs `assume` their way to *canceled* rather than failing when their data isn't there, so a green run isn't proof everything in it ran.

Docs only — no code or CI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGXxovcZiYekyRAudA9Yt2