### PR TITLE
Guard the api-docs Top Labelers chart against an empty user list

### DIFF
--- a/public/js/api-docs/userStatsPreview.js
+++ b/public/js/api-docs/userStatsPreview.js
@@ -269,6 +269,16 @@
      * @param {Array} topUsers - Array of top users data
      */
     createTopContributorsChart(container, topUsers) {
+      // No users yet is an ordinary state for a young deployment; an empty set of axes reads as a broken preview.
+      if (!topUsers.length) {
+        const emptyMsg = document.createElement('div');
+        emptyMsg.textContent = 'No user contributions yet.';
+        emptyMsg.className = 'message message-info';
+        emptyMsg.setAttribute('role', 'status');
+        container.appendChild(emptyMsg);
+        return;
+      }
+
       // Create canvas for the chart.
       const canvas = document.createElement('canvas');
       canvas.width = container.offsetWidth;


### PR DESCRIPTION
fixes #5126

`createTopContributorsChart` in `public/js/api-docs/userStatsPreview.js` had no empty guard, so on a deployment with no qualifying users the Top Labelers preview rendered a Chart.js bar chart with axes and titles but no bars — indistinguishable from a broken preview. Its two siblings on the same page already say so in words.

Added the same guard, before the canvas is created: a `.message.message-info` div reading "No user contributions yet." with `role="status"`, matching the Top Labelers with Label Type section exactly.

The forced-state test added in #5122 (`test/e2e/a11y-api-docs-states.spec.js`, the `/v3/api-docs/user-stats [no contributors]` case) drives this state and now matches the Top Labelers message, since it takes the first `.message.message-info` on the page.

ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7Tqhg5q2CJjJoyYQ2KcaA
