### PR TITLE
Remove the to_regclass guard on cross-schema voided_label_validation reads

### DIFF
--- a/app/models/user/UserStatTable.scala
+++ b/app/models/user/UserStatTable.scala
@@ -843,19 +843,6 @@ class UserStatTable @Inject() (
   def currentSchema: DBIO[String] = sql"SELECT current_schema()".as[String].head
 
   /**
-   * Which schemas have the `voided_label_validation` archive, so the cross-city query knows where it may read it.
-   *
-   * Every city is its own app instance at its own evolution level, so a schema without the archive is normal rather
-   * than broken (#4878) — and referencing a missing relation would fail the whole union, dropping every city rather
-   * than one. An unmigrated schema's archive contribution is genuinely zero, so the arm is simply left out there.
-   * Read from `information_schema` in one shot rather than probed per schema, so nothing is spliced into SQL.
-   */
-  def schemasWithVoidedValidationArchive: DBIO[Set[String]] =
-    sql"""SELECT table_schema FROM information_schema.tables WHERE table_name = 'voided_label_validation'"""
-      .as[String]
-      .map(_.toSet)
-
-  /**
    * One user's contribution totals in each of `citySchemas`, for the dashboard's cross-city section (#4496).
    *
    * Accounts are global while contributions are per-city, so a mapper's real Project Sidewalk totals only exist as a
@@ -875,19 +862,13 @@ class UserStatTable @Inject() (
    *    so no visibility flag applies — and a schema behind on evolutions may not have those columns at all, which
    *    would fail the entire union rather than one city.
    *
-   * @param citySchemas    DB schema names to report on, already vetted by the caller for existence and required
-   *                       columns. Spliced into SQL, so each must be a bare identifier.
-   * @param archiveSchemas Which of those schemas have `voided_label_validation`, from
-   *                       [[schemasWithVoidedValidationArchive]]; the archive arm is omitted for the rest.
-   * @param userId         The mapper whose totals to gather; bound once and referenced by every block.
-   * @return               One row per schema, including cities where the user did nothing (the caller drops those),
-   *                       most labels first.
+   * @param citySchemas DB schema names to report on, already vetted by the caller for existence and required
+   *                    columns. Spliced into SQL, so each must be a bare identifier.
+   * @param userId      The mapper whose totals to gather; bound once and referenced by every block.
+   * @return            One row per schema, including cities where the user did nothing (the caller drops those),
+   *                    most labels first.
    */
-  def getCrossCityUserStats(
-      citySchemas: Seq[String],
-      archiveSchemas: Set[String],
-      userId: String
-  ): DBIO[Seq[CrossCityUserStat]] = {
+  def getCrossCityUserStats(citySchemas: Seq[String], userId: String): DBIO[Seq[CrossCityUserStat]] = {
     if (citySchemas.isEmpty) {
       DBIO.successful(Seq.empty[CrossCityUserStat])
     } else {
@@ -899,15 +880,11 @@ class UserStatTable @Inject() (
       // built as plain strings, so an interpolated `$userId` inside them would be spliced rather than bound.
       val blocks: String = citySchemas
         .map { schema =>
-          // Validations count as work credit: the #4842 repair deleted voided votes from label_validation but archived
-          // them, and the work happened, so countValidations adds the archive back. This mirrors it per schema.
-          val archiveArm: String =
-            if (!archiveSchemas.contains(schema)) ""
-            else s""" + (SELECT COUNT(*)::int FROM "$schema".voided_label_validation
-           WHERE voided_label_validation.user_id = (SELECT user_id FROM me))"""
           // Label filters mirror LabelTable.labelsWithExcludedUsers: joined to audit_task, not deleted, not tutorial,
           // and on neither the label's nor the task's tutorial street. "Excluded" users are counted on purpose — this
-          // is their own dashboard, and countLabelsFromUser makes the same call.
+          // is their own dashboard, and countLabelsFromUser makes the same call. Validations add the archive back for
+          // the same reason countValidations does: the #4842 repair moved voided votes out of label_validation, but
+          // the work happened.
           s"""  SELECT '$schema'::text AS city_schema,
          (SELECT COUNT(*)::int
             FROM "$schema".label
@@ -918,7 +895,9 @@ class UserStatTable @Inject() (
              AND audit_task.street_edge_id NOT IN (SELECT tutorial_street_edge_id FROM "$schema".config)
          ) AS labels,
          (SELECT COUNT(*)::int FROM "$schema".label_validation
-           WHERE label_validation.user_id = (SELECT user_id FROM me))$archiveArm AS validations,
+           WHERE label_validation.user_id = (SELECT user_id FROM me))
+           + (SELECT COUNT(*)::int FROM "$schema".voided_label_validation
+           WHERE voided_label_validation.user_id = (SELECT user_id FROM me)) AS validations,
          (SELECT COUNT(*)::int FROM "$schema".mission
            WHERE mission.user_id = (SELECT user_id FROM me)
              AND mission.completed = TRUE AND mission.skipped = FALSE) AS missions,

--- a/app/models/utils/ConfigTable.scala
+++ b/app/models/utils/ConfigTable.scala
@@ -292,7 +292,7 @@ class ConfigTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvi
    * @param schema The database schema to query.
    * @return DBIO action yielding the distinct contributor `user_id`s (a `text` column) for this schema.
    */
-  def getContributorUserIdsBySchema(schema: String): DBIO[Seq[String]] = {
+  def getContributorUserIdsBySchema(schema: String): DBIO[Seq[String]] =
     sql"""
       SELECT label.user_id
       FROM "#$schema".label
@@ -314,7 +314,6 @@ class ConfigTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvi
       INNER JOIN "#$schema".user_stat ON voided_label_validation.user_id = user_stat.user_id
       WHERE NOT user_stat.excluded;
     """.as[String]
-  }
 
   /**
    * Label type statistics for a specific schema from its existing vote counts, with a row for every type.
@@ -473,8 +472,7 @@ class ConfigTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvi
         );
       """.as[Boolean].head
 
-    def coreQuery(upToDateFilter: String, hasLabelTypeEnum: Boolean) = {
-      val labelTypeSql = LabelTypeSql(schema, hasLabelTypeEnum)
+    def coreQuery(upToDateFilter: String, labelTypeSql: LabelTypeSql) = {
       sql"""
       SELECT total_streets.cnt          AS total_streets,
              audited_streets.cnt        AS audited_streets,
@@ -573,7 +571,8 @@ class ConfigTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvi
           WHERE NOT user_stat.excluded AND user_role.role = 'AI'
       ) AS ai_val_counts, (
           -- Work-credit add-on (#4842): archived voided votes count toward total_validations (activity volume) but
-          -- not the agree/disagree verdict columns, whose verdicts they no longer have.
+          -- not the agree/disagree verdict columns — those verdicts were cast against an off-target marker, so they
+          -- are kept as study material and deliberately left out of the agreement signal.
           SELECT COUNT(*) AS cnt
           FROM "#$schema".voided_label_validation
           INNER JOIN "#$schema".user_stat ON voided_label_validation.user_id = user_stat.user_id
@@ -630,8 +629,9 @@ class ConfigTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvi
     withJitOff(for {
       hasOutdatedImageryCol <- upToDateFilterQuery
       hasLabelTypeEnum      <- schemaHasLabelTypeEnum(schema)
-      core <- coreQuery(if (hasOutdatedImageryCol) "AND audit_task.outdated_imagery = FALSE" else "", hasLabelTypeEnum)
-      byLabelType <- labelTypeStatsBySchema(schema, LabelTypeSql(schema, hasLabelTypeEnum))
+      labelTypeSql = LabelTypeSql(schema, hasLabelTypeEnum)
+      core <- coreQuery(if (hasOutdatedImageryCol) "AND audit_task.outdated_imagery = FALSE" else "", labelTypeSql)
+      byLabelType <- labelTypeStatsBySchema(schema, labelTypeSql)
       weeklyTrend <- getCityWeeklyTrendBySchema(schema, Some(ScorecardTrendWeeks))
       output      <- getCityContributorOutputBySchema(schema)
     } yield {

--- a/app/models/utils/ConfigTable.scala
+++ b/app/models/utils/ConfigTable.scala
@@ -135,28 +135,11 @@ class ConfigTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvi
   }
 
   /**
-   * True iff `voided_label_validation` (created by evolution 355, #4842) exists in the given schema.
-   *
-   * Cross-schema queries must not assume another city's schema is at this instance's evolution level: each city is
-   * its own app instance, so on a rolling release there is a window where this instance (new code) queries a schema
-   * that hasn't applied 354 yet — and a parked deployment (schema present, no running app) may never apply it. A
-   * missing relation would fail the whole query, and the callers' `.recover` would then drop the entire city from
-   * the aggregate surfaces. An unmigrated schema's archive contribution is genuinely 0 (no repair has run there), so
-   * the right behavior is to probe first and skip the archive arm, not to fail. `to_regclass` resolves a relation
-   * name to NULL instead of erroring when absent, which makes it the safe probe.
-   *
-   * @param schema The database schema to probe.
-   * @return       DBIO yielding true when the archive table exists in that schema.
-   */
-  private def schemaHasVoidedValidationArchive(schema: String): DBIO[Boolean] =
-    sql"""SELECT to_regclass('"#$schema".voided_label_validation') IS NOT NULL""".as[Boolean].head
-
-  /**
-   * Whether the schema has replaced its label_type lookup table with the label_type enum (373.sql). Same rolling-
-   * release hazard as schemaHasVoidedValidationArchive: until every deployment is past 373, the fan-out SQL below has
-   * to read whichever shape the other city's schema currently has, or that city silently drops out of the aggregate
-   * surfaces. The lookup table's absence is the signal, since 373 drops it in the same transaction that types the
-   * columns. Delete this probe and the lookup-table arms of LabelTypeSql once the release is on every server (#5118).
+   * Whether the schema has replaced its label_type lookup table with the label_type enum (373.sql). Each city is its
+   * own app instance, so until every deployment is past 373 the fan-out SQL below has to read whichever shape the
+   * other city's schema currently has, or that city errors out and silently drops out of the aggregate surfaces. The
+   * lookup table's absence is the signal, since 373 drops it in the same transaction that types the columns. Delete
+   * this probe and the lookup-table arms of LabelTypeSql once the release is on every server (#5118).
    *
    * @param schema The database schema to probe.
    * @return       DBIO yielding true when the schema is on the enum shape.
@@ -218,21 +201,9 @@ class ConfigTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvi
    * @param schema The database schema name for the target city
    * @return DBIO action that yields AggregateStats
    */
-  def getCityAggregateDataBySchema(schema: String): DBIO[AggregateStats] = schemaHasVoidedValidationArchive(schema)
-    .zip(schemaHasLabelTypeEnum(schema))
-    .flatMap { case (hasVoidedArchive, hasLabelTypeEnum) =>
+  def getCityAggregateDataBySchema(schema: String): DBIO[AggregateStats] = schemaHasLabelTypeEnum(schema)
+    .flatMap { hasLabelTypeEnum =>
       val labelTypeSql = LabelTypeSql(schema, hasLabelTypeEnum)
-      // Work-credit count (#4842): votes voided by the off-target-markers repair are archived in
-      // voided_label_validation, not deleted, so the "how many validations happened" total keeps counting them.
-      // Guarded per-schema because the table may not exist there yet (see schemaHasVoidedValidationArchive).
-      val voidedCountArm =
-        if (hasVoidedArchive) s""" + (
-              SELECT COUNT(*)
-              FROM "$schema".voided_label_validation
-              INNER JOIN "$schema".user_stat ON voided_label_validation.user_id = user_stat.user_id
-              WHERE NOT user_stat.excluded
-          )"""
-        else ""
       sql"""
       SELECT km_audited.km_audited AS km_explored,
             km_audited_no_overlap.km_audited_no_overlap AS km_explored_no_overlap,
@@ -274,12 +245,19 @@ class ConfigTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvi
               AND deleted = FALSE
               AND tutorial = TRUE
       ) AS tutorial_label_counts, (
+          -- Work-credit count (#4842): votes voided by the off-target-markers repair are archived in
+          -- voided_label_validation, not deleted, so the "how many validations happened" total keeps counting them.
           SELECT (
               SELECT COUNT(*)
               FROM "#$schema".label_validation
               INNER JOIN "#$schema".user_stat ON label_validation.user_id = user_stat.user_id
               WHERE NOT user_stat.excluded
-          )#$voidedCountArm AS validation_count
+          ) + (
+              SELECT COUNT(*)
+              FROM "#$schema".voided_label_validation
+              INNER JOIN "#$schema".user_stat ON voided_label_validation.user_id = user_stat.user_id
+              WHERE NOT user_stat.excluded
+          ) AS validation_count
       ) AS total_val_count;
     """
         .as[(Double, Double, Int, Int, Int)]
@@ -314,18 +292,8 @@ class ConfigTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvi
    * @param schema The database schema to query.
    * @return DBIO action yielding the distinct contributor `user_id`s (a `text` column) for this schema.
    */
-  def getContributorUserIdsBySchema(schema: String): DBIO[Seq[String]] = schemaHasVoidedValidationArchive(schema)
-    .flatMap { hasVoidedArchive =>
-      // Votes voided by the #4842 repair still mark their caster as a contributor — the participation happened.
-      // Guarded per-schema because the archive may not exist there yet (see schemaHasVoidedValidationArchive).
-      val voidedUnionArm =
-        if (hasVoidedArchive) s"""UNION
-      SELECT voided_label_validation.user_id
-      FROM "$schema".voided_label_validation
-      INNER JOIN "$schema".user_stat ON voided_label_validation.user_id = user_stat.user_id
-      WHERE NOT user_stat.excluded"""
-        else ""
-      sql"""
+  def getContributorUserIdsBySchema(schema: String): DBIO[Seq[String]] = {
+    sql"""
       SELECT label.user_id
       FROM "#$schema".label
       INNER JOIN "#$schema".user_stat ON label.user_id = user_stat.user_id
@@ -340,9 +308,13 @@ class ConfigTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvi
       FROM "#$schema".label_validation
       INNER JOIN "#$schema".user_stat ON label_validation.user_id = user_stat.user_id
       WHERE NOT user_stat.excluded
-      #$voidedUnionArm;
+      UNION
+      SELECT voided_label_validation.user_id
+      FROM "#$schema".voided_label_validation
+      INNER JOIN "#$schema".user_stat ON voided_label_validation.user_id = user_stat.user_id
+      WHERE NOT user_stat.excluded;
     """.as[String]
-    }
+  }
 
   /**
    * Label type statistics for a specific schema from its existing vote counts, with a row for every type.
@@ -501,27 +473,8 @@ class ConfigTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvi
         );
       """.as[Boolean].head
 
-    // Both archive reads are guarded per-schema because voided_label_validation may not exist there yet (see
-    // schemaHasVoidedValidationArchive); an unmigrated schema contributes 0 voided votes and no extra contributors.
-    def coreQuery(upToDateFilter: String, hasVoidedArchive: Boolean, hasLabelTypeEnum: Boolean) = {
+    def coreQuery(upToDateFilter: String, hasLabelTypeEnum: Boolean) = {
       val labelTypeSql = LabelTypeSql(schema, hasLabelTypeEnum)
-      // Work-credit add-on (#4842): archived voided votes count toward total_validations (activity volume) but
-      // not the agree/disagree verdict columns. The archive is human-only by construction.
-      val voidedValCountsBody =
-        if (hasVoidedArchive) s"""SELECT COUNT(*) AS cnt
-          FROM "$schema".voided_label_validation
-          INNER JOIN "$schema".user_stat ON voided_label_validation.user_id = user_stat.user_id
-          WHERE NOT user_stat.excluded"""
-        else "SELECT 0 AS cnt"
-      // Voided votes (#4842) still mark their caster as a contributor; the archive is human-only by construction,
-      // so no AI-role filter is needed.
-      val voidedContributorArm =
-        if (hasVoidedArchive) s"""UNION
-              SELECT voided_label_validation.user_id AS contributor_id
-              FROM "$schema".voided_label_validation
-              INNER JOIN "$schema".user_stat ON voided_label_validation.user_id = user_stat.user_id
-              WHERE NOT user_stat.excluded"""
-        else ""
       sql"""
       SELECT total_streets.cnt          AS total_streets,
              audited_streets.cnt        AS audited_streets,
@@ -619,7 +572,12 @@ class ConfigTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvi
           LEFT  JOIN sidewalk_login.user_role ON label_validation.user_id = user_role.user_id
           WHERE NOT user_stat.excluded AND user_role.role = 'AI'
       ) AS ai_val_counts, (
-          #$voidedValCountsBody
+          -- Work-credit add-on (#4842): archived voided votes count toward total_validations (activity volume) but
+          -- not the agree/disagree verdict columns, whose verdicts they no longer have.
+          SELECT COUNT(*) AS cnt
+          FROM "#$schema".voided_label_validation
+          INNER JOIN "#$schema".user_stat ON voided_label_validation.user_id = user_stat.user_id
+          WHERE NOT user_stat.excluded
       ) AS voided_val_counts, (
           SELECT COUNT(DISTINCT street_edge_id) FILTER (WHERE task_end >= NOW() - INTERVAL '7 days')  AS audits_7d,
                  COUNT(DISTINCT street_edge_id) FILTER (WHERE task_end >= NOW() - INTERVAL '30 days') AS audits_30d
@@ -641,7 +599,13 @@ class ConfigTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvi
               INNER JOIN "#$schema".user_stat ON label_validation.user_id = user_stat.user_id
               LEFT  JOIN sidewalk_login.user_role ON label_validation.user_id = user_role.user_id
               WHERE NOT user_stat.excluded AND user_role.role IS DISTINCT FROM 'AI'
-              #$voidedContributorArm
+              -- Voided votes (#4842) still mark their caster as a contributor. No AI-role filter here, unlike the
+              -- arms above: the archive is human-only by construction.
+              UNION
+              SELECT voided_label_validation.user_id AS contributor_id
+              FROM "#$schema".voided_label_validation
+              INNER JOIN "#$schema".user_stat ON voided_label_validation.user_id = user_stat.user_id
+              WHERE NOT user_stat.excluded
           ) AS contributor_union
       ) AS active_contributors, (
           -- Distinct EXCLUDED (low-quality) users who placed a label — the data-quality "how much got filtered" signal.
@@ -665,13 +629,8 @@ class ConfigTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvi
     // PostGIS (#4376).
     withJitOff(for {
       hasOutdatedImageryCol <- upToDateFilterQuery
-      hasVoidedArchive      <- schemaHasVoidedValidationArchive(schema)
       hasLabelTypeEnum      <- schemaHasLabelTypeEnum(schema)
-      core                  <- coreQuery(
-        if (hasOutdatedImageryCol) "AND audit_task.outdated_imagery = FALSE" else "",
-        hasVoidedArchive,
-        hasLabelTypeEnum
-      )
+      core <- coreQuery(if (hasOutdatedImageryCol) "AND audit_task.outdated_imagery = FALSE" else "", hasLabelTypeEnum)
       byLabelType <- labelTypeStatsBySchema(schema, LabelTypeSql(schema, hasLabelTypeEnum))
       weeklyTrend <- getCityWeeklyTrendBySchema(schema, Some(ScorecardTrendWeeks))
       output      <- getCityContributorOutputBySchema(schema)

--- a/app/service/UserService.scala
+++ b/app/service/UserService.scala
@@ -782,15 +782,12 @@ class UserServiceImpl @Inject() (
             for {
               // Identifies the current city by the schema the connection actually reads, so the row marked "you're
               // here" is the one the hero KPIs above it were computed from.
-              // Both in one round trip; neither depends on the other.
-              (currentSchema, archiveSchemas) <- db.run(
-                userStatTable.currentSchema.zip(userStatTable.schemasWithVoidedValidationArchive)
-              )
+              currentSchema <- db.run(userStatTable.currentSchema)
               // That city's distance is recomputed live rather than read from the nightly user_stat value, so its row
               // matches the hero KPI exactly. Other cities keep the nightly value — recomputing geodesic lengths in a
               // 50-way union is what the cross-schema query exists to avoid.
               liveMeters <- db.run(auditTaskTable.getDistanceAudited(userId))
-              rows       <- db.run(userStatTable.getCrossCityUserStats(scope.map(_._2), archiveSchemas, userId))
+              rows       <- db.run(userStatTable.getCrossCityUserStats(scope.map(_._2), userId))
             } yield CrossCityFanOut(rows, currentSchema, liveMeters)
           }
           .map { fanOut =>

--- a/docs/deployment-and-stages.md
+++ b/docs/deployment-and-stages.md
@@ -185,9 +185,9 @@ INNER JOIN label_validation
 restarts — so mid-rollout an already-updated instance can query a schema that hasn't applied the new evolution yet. The
 missing relation fails that city's whole query, and the service layer's `.recover` then drops the city from the
 aggregate surfaces silently. Two ways to handle it: ship the evolution one release ahead of the code that reads it, or
-add a `to_regclass` existence probe that skips the new table's arm (`ConfigTable.schemaHasVoidedValidationArchive` does
-this for 354) **plus a tracking issue to delete the probe once the release has reached every server** — without the
-issue, the temporary guard becomes permanent.
+add a `to_regclass` existence probe that picks the SQL matching whichever shape the other schema currently has
+(`ConfigTable.schemaHasLabelTypeEnum` does this for 373) **plus a tracking issue to delete the probe once the release
+has reached every server** — without the issue, the temporary guard becomes permanent.
 
 ### Writing the release notes
 

--- a/docs/deployment-and-stages.md
+++ b/docs/deployment-and-stages.md
@@ -160,11 +160,11 @@ unattended. A Down that cannot apply leaves that instance **down until a human i
 evolutions that refuse to destroy data silently, so check those for conflicts *before* rolling back rather than
 discovering them one crashed city at a time.
 
-The canonical example is evolution **354** (#4842): its Down re-inserts archived voided votes with deliberately no
+The canonical example is evolution **355** (#4842): its Down re-inserts archived voided votes with deliberately no
 `ON CONFLICT`. If any validator re-voted on a repaired label after the evolution applied, their new vote holds the
 `(user_id, label_id)` unique slot, the re-insert fails on `label_validation_user_id_label_id_unique`, and the instance
 won't start. That is the designed outcome — an archived verdict must never be discarded silently; a human decides
-which of the two votes survives. Before rolling back past 354, run this per city schema and resolve any rows it
+which of the two votes survives. Before rolling back past 355, run this per city schema and resolve any rows it
 returns (delete whichever vote loses, then roll back):
 
 ```sql
@@ -185,9 +185,16 @@ INNER JOIN label_validation
 restarts — so mid-rollout an already-updated instance can query a schema that hasn't applied the new evolution yet. The
 missing relation fails that city's whole query, and the service layer's `.recover` then drops the city from the
 aggregate surfaces silently. Two ways to handle it: ship the evolution one release ahead of the code that reads it, or
-add a `to_regclass` existence probe that picks the SQL matching whichever shape the other schema currently has
-(`ConfigTable.schemaHasLabelTypeEnum` does this for 373) **plus a tracking issue to delete the probe once the release
-has reached every server** — without the issue, the temporary guard becomes permanent.
+guard the read with a `to_regclass` probe **plus a tracking issue to delete the probe once the release has reached
+every server** — without the issue, the temporary guard becomes permanent.
+
+What the probe does depends on the change. For an *added* table, probe for its presence and omit its arm where it is
+absent — an unmigrated schema's contribution is genuinely zero (evolution 355 was handled this way, and the guard came
+out in #4878 once the release was everywhere). For a change that *reshapes* an existing read, there is no arm to omit:
+the probe has to pick between two spellings, so it keys on whichever side of the change is detectable. Evolution 373
+drops the `label_type` lookup table in the same transaction that types the columns, so `schemaHasLabelTypeEnum` treats
+the lookup table's **absence** as the signal and `LabelTypeSql` carries a fragment per shape (removal tracked in
+#5118).
 
 ### Writing the release notes
 

--- a/test/models/utils/ConfigTableLabelTypeShapeSpec.scala
+++ b/test/models/utils/ConfigTableLabelTypeShapeSpec.scala
@@ -23,8 +23,6 @@ class ConfigTableLabelTypeShapeSpec extends PlaySpec with GuiceOneAppPerSuite wi
 
   private val configTable = app.injector.instanceOf[ConfigTable]
 
-  private def currentSchema: DBIO[String] = sql"SELECT current_schema()".as[String].head
-
   "the cross-schema queries against a schema on the label_type lookup table" should {
     // LIKE copies the enum-typed label_type column, which the scratch schema can't resolve as its own type, hence the
     // manual swap back to the pre-373 label_type_id columns plus a lookup table to join.
@@ -37,10 +35,13 @@ class ConfigTableLabelTypeShapeSpec extends PlaySpec with GuiceOneAppPerSuite wi
         _      <- sqlu"CREATE SCHEMA #$scratch"
         _      <- DBIO.sequence(clonedTables.map { t => sqlu"""CREATE TABLE #$scratch.#$t (LIKE "#$schema".#$t)""" })
         _      <- sqlu"""CREATE TABLE #$scratch.label_type (label_type_id INT PRIMARY KEY, label_type TEXT NOT NULL)"""
-        _      <- sqlu"""ALTER TABLE #$scratch.label DROP COLUMN label_type, ADD COLUMN label_type_id INT"""
-        _      <- sqlu"""ALTER TABLE #$scratch.tag DROP COLUMN label_type, ADD COLUMN label_type_id INT"""
-        agg    <- configTable.getCityAggregateDataBySchema(scratch)
-        ids    <- configTable.getContributorUserIdsBySchema(scratch)
+        // Populated so the lookup arms have to resolve a real join key, GROUP BY and name column; an empty table
+        // would let a wrong one return zero rows and pass.
+        _         <- sqlu"""INSERT INTO #$scratch.label_type VALUES (1, 'CurbRamp'), (2, 'Obstacle')"""
+        _         <- sqlu"""ALTER TABLE #$scratch.label DROP COLUMN label_type, ADD COLUMN label_type_id INT"""
+        _         <- sqlu"""ALTER TABLE #$scratch.tag DROP COLUMN label_type, ADD COLUMN label_type_id INT"""
+        agg       <- configTable.getCityAggregateDataBySchema(scratch)
+        ids       <- configTable.getContributorUserIdsBySchema(scratch)
         scorecard <- configTable.getCityScorecardBySchema(scratch)
       } yield (agg, ids, scorecard))
 
@@ -48,6 +49,9 @@ class ConfigTableLabelTypeShapeSpec extends PlaySpec with GuiceOneAppPerSuite wi
       ids mustBe empty
       scorecard.totalValidations mustBe 0
       scorecard.activeContributors mustBe 0
+      // Every type in the lookup table gets a row, at zero — the same guarantee CityScorecardSpec pins for the enum.
+      agg.byLabelType.keySet mustBe Set("CurbRamp", "Obstacle")
+      scorecard.byLabelType.keySet mustBe Set("CurbRamp", "Obstacle")
     }
   }
 }

--- a/test/models/utils/ConfigTableLabelTypeShapeSpec.scala
+++ b/test/models/utils/ConfigTableLabelTypeShapeSpec.scala
@@ -1,0 +1,53 @@
+package models.utils
+
+import models.utils.MyPostgresProfile.api._
+import org.scalatestplus.play.PlaySpec
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import slick.dbio.DBIO
+import util.RolledBackDb
+
+/**
+ * Pins ConfigTable's cross-schema fan-out against a city schema that has not applied evolution 373 (#4103) and so
+ * still reads its label types from the `label_type` lookup table.
+ *
+ * Getting the shape wrong is silent: the query errors, and the service layer's `.recover` drops the whole city from
+ * /v3/api/aggregateStats and the Owner scorecard. The lookup-table arms of `ConfigTable.LabelTypeSql` have no other
+ * coverage — the dev DB is always on the enum — so this spec goes away with the probe itself (#5118).
+ */
+class ConfigTableLabelTypeShapeSpec extends PlaySpec with GuiceOneAppPerSuite with RolledBackDb {
+
+  override def fakeApplication(): Application =
+    new GuiceApplicationBuilder().disable[modules.ActorModule].build()
+
+  private val configTable = app.injector.instanceOf[ConfigTable]
+
+  private def currentSchema: DBIO[String] = sql"SELECT current_schema()".as[String].head
+
+  "the cross-schema queries against a schema on the label_type lookup table" should {
+    // LIKE copies the enum-typed label_type column, which the scratch schema can't resolve as its own type, hence the
+    // manual swap back to the pre-373 label_type_id columns plus a lookup table to join.
+    "still succeed, reading label types through the lookup table" in {
+      val scratch      = "ci_lookup_shape_scratch"
+      val clonedTables = Seq("street_edge", "audit_task", "user_stat", "label", "config", "label_validation", "tag",
+        "mission", "audit_task_interaction_small", "voided_label_validation")
+      val (agg, ids, scorecard) = runRolledBack(for {
+        schema <- currentSchema
+        _      <- sqlu"CREATE SCHEMA #$scratch"
+        _      <- DBIO.sequence(clonedTables.map { t => sqlu"""CREATE TABLE #$scratch.#$t (LIKE "#$schema".#$t)""" })
+        _      <- sqlu"""CREATE TABLE #$scratch.label_type (label_type_id INT PRIMARY KEY, label_type TEXT NOT NULL)"""
+        _      <- sqlu"""ALTER TABLE #$scratch.label DROP COLUMN label_type, ADD COLUMN label_type_id INT"""
+        _      <- sqlu"""ALTER TABLE #$scratch.tag DROP COLUMN label_type, ADD COLUMN label_type_id INT"""
+        agg    <- configTable.getCityAggregateDataBySchema(scratch)
+        ids    <- configTable.getContributorUserIdsBySchema(scratch)
+        scorecard <- configTable.getCityScorecardBySchema(scratch)
+      } yield (agg, ids, scorecard))
+
+      agg.totalValidations mustBe 0
+      ids mustBe empty
+      scorecard.totalValidations mustBe 0
+      scorecard.activeContributors mustBe 0
+    }
+  }
+}

--- a/test/models/utils/ConfigTableVoidedArchiveSpec.scala
+++ b/test/models/utils/ConfigTableVoidedArchiveSpec.scala
@@ -18,17 +18,9 @@ import scala.util.control.NoStackTrace
 /**
  * DB-backed tests for ConfigTable's voided-vote archive reads (#4842, PR #4866 review).
  *
- * Two guarantees, one per direction of the same review finding:
- *   1. Work credit: an archived voided vote counts in the per-schema aggregate `total_validations` and marks its
- *      caster as a contributor (aggregate data, contributor ids, and the Owner scorecard). Self-seeding — each test
- *      inserts the full FK chain for one archived vote inside a rolled-back transaction — so it is meaningful on an
- *      empty CI schema and leaves a seeded dev DB exactly as found.
- *   2. Rollout safety: the same queries must SURVIVE a schema that does not have `voided_label_validation` yet.
- *      These queries fan out across OTHER cities' schemas, and each city applies evolution 355 on its own release
- *      schedule (a parked deployment may never apply it) — without the `to_regclass` guard, the missing table failed
- *      the whole per-city query and the service layer's `.recover` silently dropped that city from
- *      /v3/api/aggregateStats and the scorecard. Pinned by cloning the city schema's tables into a scratch schema
- *      WITHOUT the archive table and running all three queries against it.
+ * An archived voided vote counts in the per-schema aggregate `total_validations` and marks its caster as a
+ * contributor (aggregate data, contributor ids, and the Owner scorecard). Self-seeding inside a rolled-back
+ * transaction, so it is meaningful on an empty CI schema and leaves a seeded dev DB exactly as found.
  */
 class ConfigTableVoidedArchiveSpec extends PlaySpec with GuiceOneAppPerSuite {
 
@@ -152,33 +144,6 @@ class ConfigTableVoidedArchiveSpec extends PlaySpec with GuiceOneAppPerSuite {
       // Archived verdicts must never resurface in the agree/disagree quality columns.
       after.validationsAgree mustBe before.validationsAgree
       after.validationsDisagree mustBe before.validationsDisagree
-    }
-  }
-
-  "the cross-schema queries against a schema without voided_label_validation" should {
-    // The review's rollout scenario: another city that hasn't applied 355 or 373, so its labels and tags reference a
-    // label_type lookup table by id. LIKE copies this schema's enum column, which the scratch schema can't resolve,
-    // hence the manual swap. Also the only coverage of the lookup-table arm of ConfigTable.LabelTypeSql (#5118).
-    "still succeed, contributing zero archive rows" in {
-      val scratch      = "ci_unmigrated_scratch"
-      val clonedTables = Seq("street_edge", "audit_task", "user_stat", "label", "config", "label_validation", "tag",
-        "mission", "audit_task_interaction_small")
-      val (agg, ids, scorecard) = runRolledBack(for {
-        schema <- currentSchema
-        _      <- sqlu"CREATE SCHEMA #$scratch"
-        _      <- DBIO.sequence(clonedTables.map { t => sqlu"""CREATE TABLE #$scratch.#$t (LIKE "#$schema".#$t)""" })
-        _      <- sqlu"""CREATE TABLE #$scratch.label_type (label_type_id INT PRIMARY KEY, label_type TEXT NOT NULL)"""
-        _      <- sqlu"""ALTER TABLE #$scratch.label DROP COLUMN label_type, ADD COLUMN label_type_id INT"""
-        _      <- sqlu"""ALTER TABLE #$scratch.tag DROP COLUMN label_type, ADD COLUMN label_type_id INT"""
-        agg    <- configTable.getCityAggregateDataBySchema(scratch)
-        ids    <- configTable.getContributorUserIdsBySchema(scratch)
-        scorecard <- configTable.getCityScorecardBySchema(scratch)
-      } yield (agg, ids, scorecard))
-
-      agg.totalValidations mustBe 0
-      ids mustBe empty
-      scorecard.totalValidations mustBe 0
-      scorecard.activeContributors mustBe 0
     }
   }
 }

--- a/test/models/utils/ConfigTableVoidedArchiveSpec.scala
+++ b/test/models/utils/ConfigTableVoidedArchiveSpec.scala
@@ -1,19 +1,12 @@
 package models.utils
 
 import models.utils.MyPostgresProfile.api._
-import org.apache.pekko.stream.Materializer
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Application
-import play.api.db.slick.DatabaseConfigProvider
 import play.api.inject.guice.GuiceApplicationBuilder
-import slick.basic.DatabaseConfig
 import slick.dbio.DBIO
-
-import scala.concurrent.Await
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.duration.DurationInt
-import scala.util.control.NoStackTrace
+import util.RolledBackDb
 
 /**
  * DB-backed tests for ConfigTable's voided-vote archive reads (#4842, PR #4866 review).
@@ -22,36 +15,12 @@ import scala.util.control.NoStackTrace
  * contributor (aggregate data, contributor ids, and the Owner scorecard). Self-seeding inside a rolled-back
  * transaction, so it is meaningful on an empty CI schema and leaves a seeded dev DB exactly as found.
  */
-class ConfigTableVoidedArchiveSpec extends PlaySpec with GuiceOneAppPerSuite {
+class ConfigTableVoidedArchiveSpec extends PlaySpec with GuiceOneAppPerSuite with RolledBackDb {
 
   override def fakeApplication(): Application =
     new GuiceApplicationBuilder().disable[modules.ActorModule].build()
 
-  implicit lazy val mat: Materializer = app.materializer
-
   private val configTable = app.injector.instanceOf[ConfigTable]
-  // Typed explicitly: letting `.db` infer here yields an existential type the compiler rejects under -Xfatal-warnings.
-  private val dbConfig: DatabaseConfig[MyPostgresProfile] =
-    app.injector.instanceOf[DatabaseConfigProvider].get[MyPostgresProfile]
-
-  // Carries a successful result out through the forced-rollback failure path of `runRolledBack`.
-  private case class RollbackWithResult(result: Any) extends RuntimeException with NoStackTrace
-
-  /**
-   * Runs `action` inside a transaction that is ALWAYS rolled back, returning the action's result. Lets a test seed
-   * synthetic rows (or whole scratch schemas) against the shared dev DB and leave it exactly as found — even if an
-   * assertion later fails. Same idiom as GeodesicDistanceSpec.
-   */
-  private def runRolledBack[T](action: DBIO[T]): T = {
-    val alwaysRollback = action.flatMap(r => DBIO.failed(RollbackWithResult(r))).transactionally
-    Await.result(
-      dbConfig.db.run(alwaysRollback).recover { case RollbackWithResult(r) => r.asInstanceOf[T] },
-      120.seconds
-    )
-  }
-
-  /** The active city schema (first search_path entry) — what the service layer passes for the own-city fan-out arm. */
-  private def currentSchema: DBIO[String] = sql"SELECT current_schema()".as[String].head
 
   /**
    * Seeds the minimal FK chain for one archived voided vote — user (+ non-excluded user_stat), street, audit task,

--- a/test/service/DashboardStatsInvariantSpec.scala
+++ b/test/service/DashboardStatsInvariantSpec.scala
@@ -435,23 +435,19 @@ class DashboardStatsInvariantSpec extends PlaySpec with GuiceOneAppPerSuite {
     "refuse a schema name that isn't a bare identifier" in {
       // Guards the one place this query interpolates rather than binds; a thrown error beats a crafted query.
       Seq("public; DROP TABLE label", "sidewalk_seattle\"", "Sidewalk_Seattle", "").foreach { bad =>
-        an[IllegalArgumentException] must be thrownBy userStatTable.getCrossCityUserStats(
-          Seq(bad),
-          Set.empty[String],
-          ghostId
-        )
+        an[IllegalArgumentException] must be thrownBy userStatTable.getCrossCityUserStats(Seq(bad), ghostId)
       }
     }
 
     "return nothing at all when no city qualifies, rather than building an empty union" in {
       await(
-        dbConfig.db.run(userStatTable.getCrossCityUserStats(Seq.empty[String], Set.empty[String], ghostId))
+        dbConfig.db.run(userStatTable.getCrossCityUserStats(Seq.empty[String], ghostId))
       ) mustBe empty
     }
 
     "report every queried schema, so the service can tell 'no activity' from 'not queried'" in {
       val schemas = await(configService.getCrossCityUserScope).map(_._2)
-      val rows    = await(dbConfig.db.run(userStatTable.getCrossCityUserStats(schemas, Set.empty[String], ghostId)))
+      val rows    = await(dbConfig.db.run(userStatTable.getCrossCityUserStats(schemas, ghostId)))
       rows.map(_.citySchema).toSet mustBe schemas.toSet
       // A user id that belongs to nobody: every count is zero, and none of them is negative or null-shaped.
       rows.foreach { row =>

--- a/test/util/RolledBackDb.scala
+++ b/test/util/RolledBackDb.scala
@@ -34,6 +34,9 @@ trait RolledBackDb { this: GuiceOneAppPerSuite =>
   /** Runs an action against the connected DB and blocks for the result. */
   protected def run[T](action: DBIO[T]): T = Await.result(dbConfig.db.run(action), dbTimeout)
 
+  /** The active city schema (first search_path entry) — what the service layer passes for the own-city arm. */
+  protected def currentSchema: DBIO[String] = sql"SELECT current_schema()".as[String].head
+
   /** Sentinel used to abort (and thus roll back) the wrapping transaction after the test body has run. */
   private object RollbackSentinel extends RuntimeException("intentional rollback -- leave the DB untouched")
 


### PR DESCRIPTION
resolves #4878

The release carrying evolution 355 has reached every prod and test server, so every schema the cross-schema fan-outs can reach now has `voided_label_validation` and the `to_regclass` guards on it are dead code.

**Removed — two copies of the same guard**
- `ConfigTable.schemaHasVoidedValidationArchive`, and the three conditionally-built SQL arms that branched on it — `getCityAggregateDataBySchema`, `getContributorUserIdsBySchema`, and the Owner-scorecard `coreQuery` — each collapsed back to a plain query. `getContributorUserIdsBySchema` no longer needs a `flatMap` at all, and `hasVoidedArchive` is gone from `coreQuery`'s signature and the scorecard's for-comprehension.
- `UserStatTable.schemasWithVoidedValidationArchive` and the `archiveArm` it fed on the dashboard's cross-city fan-out (found in review). #4878 was its only tracking issue, so removing only the `ConfigTable` copy would have left it permanent by exactly the mechanism `docs/deployment-and-stages.md` warns about. `archiveSchemas` is dropped from `getCrossCityUserStats`, and `UserService` no longer zips the probe in — one fewer `information_schema.tables` scan per uncached dashboard load.

**Kept, but moved**
- The work-credit half of `ConfigTableVoidedArchiveSpec` — it pins live behavior, not the guard. It now mixes in `util.RolledBackDb` instead of carrying its own copy of `runRolledBack`.
- The rollout-safety half was also the **only** coverage of the lookup-table arms of `ConfigTable.LabelTypeSql`, whose own probe stays live until #5118. Rather than delete that coverage along with this guard, the scratch-schema clone test moves to a new `ConfigTableLabelTypeShapeSpec`, with `voided_label_validation` added to the cloned tables since the queries require it unconditionally. Its lookup table is now seeded so the join key, `GROUP BY` and name fragments are actually exercised rather than only parsed. It goes away with #5118.

**Also from review**
- `docs/deployment-and-stages.md` → "Rolling back a release" named evolution **354** for the archive Down; the #4842 renumber (`3a5973e47`) made it **355**, and 354 is the unrelated `user_stat` constraint evolution for #4604. Corrected — this matters because that section is now the only remaining documentation of the rollback hazard.
- "Adding a table that cross-schema queries read" keeps the additive recipe (probe for presence, omit the arm) as the answer to its own heading, citing 355/#4878, and adds the reshaped-read case — where the probe keys on an **absence** — as a second variant citing 373/#5118.
- The scorecard's work-credit comment no longer implies archived votes lack their verdicts; `validation_result` is `NOT NULL`, and excluding them from the agreement signal is a deliberate policy call.
- `LabelTypeSql` is built once per scorecard rather than twice from the same boolean.

**Accepted trade** (per the issue): rolling a single instance back past 355 recreates the same condition in reverse, now unguarded. That path is already documented as a human-intervention step with a pre-flight collision query in "Rolling back a release", so it isn't a silent failure mode.

**Testing:** full `sbt test` over the final state — **1156/1156 pass**, 0 failures (4 canceled, as usual). That also settles the 8 failures an earlier run showed: they were in suites that don't touch this code and are gone on a clean run, i.e. dev-env flakiness. `scalafmtCheckAll` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T6rDqrpraeVMspTMdqxaSz
