### PR TITLE
Resolve /r/<slug> share links case-insensitively (#5150)

### DIFF
--- a/app/controllers/RouteBuilderController.scala
+++ b/app/controllers/RouteBuilderController.scala
@@ -131,7 +131,8 @@ class RouteBuilderController @Inject() (
    * (/explore handles anonymous sign-up itself); retired slugs of renamed routes keep redirecting via the alias
    * table.
    *
-   * @param slug The route's slug; 404 if unknown or the route has been deleted.
+   * @param slug The route's slug, matched case-insensitively so a retyped link resolves; 404 if unknown or the
+   *             route has been deleted.
    */
   def routeBySlug(slug: String): Action[AnyContent] = Action.async { implicit request =>
     routeService.resolveSlug(slug).map {

--- a/app/models/route/RouteSlugAliasTable.scala
+++ b/app/models/route/RouteSlugAliasTable.scala
@@ -39,9 +39,9 @@ class RouteSlugAliasTable @Inject() (protected val dbConfigProvider: DatabaseCon
     slugAliases += alias
   }
 
-  /** Gets the route id an old slug points at, if any. */
-  def getRouteIdBySlug(slug: String): DBIO[Option[Int]] = {
-    slugAliases.filter(_.slug === slug).map(_.routeId).result.headOption
+  /** Gets the (slug, route id) pairs of the retired slugs matching any spelling of an incoming share link. */
+  def getRouteIdsBySlugs(slugs: Seq[String]): DBIO[Seq[(String, Int)]] = {
+    slugAliases.filter(_.slug.inSet(slugs)).map(a => (a.slug, a.routeId)).result
   }
 
   /**

--- a/app/models/route/RouteTable.scala
+++ b/app/models/route/RouteTable.scala
@@ -294,9 +294,14 @@ class RouteTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
       .update(description)
   }
 
-  /** Gets the id of the non-deleted route with the given slug, if any. */
-  def getRouteIdBySlug(slug: String): DBIO[Option[Int]] = {
-    routes.filter(r => r.slug === slug && r.deleted === false).map(_.routeId).result.headOption
+  /**
+   * Gets the (slug, route id) pairs of the non-deleted routes carrying any of the given slugs.
+   *
+   * Plural so one `slug IN (...)` covers every spelling a share link is tried under (#5150) and still serves from
+   * route_slug_idx, where a probe per spelling would be a round trip each. The caller decides which spelling wins.
+   */
+  def getRouteIdsBySlugs(slugs: Seq[String]): DBIO[Seq[(String, Int)]] = {
+    routes.filter(r => r.slug.inSet(slugs) && r.deleted === false).map(r => (r.slug, r.routeId)).result
   }
 
   /**

--- a/app/models/utils/SlugUtils.scala
+++ b/app/models/utils/SlugUtils.scala
@@ -25,14 +25,38 @@ object SlugUtils {
    * @return The slug, capped at MaxSlugLength; `fallback` if nothing usable remains.
    */
   def slugify(name: String, fallback: String = "route"): String = {
-    val slug: String = Normalizer
-      .normalize(name, Normalizer.Form.NFD)
-      .replaceAll("\\p{M}", "") // Drop the combining marks NFD split off, turning é into e.
-      .toLowerCase(Locale.ROOT)
-      .replaceAll("[^\\p{L}\\p{N}]+", "-")
+    val slug: String = foldToSlugChars(name)
+      .replaceAll("-+", "-") // Collapse separator runs, the invariant above.
       .replaceAll("^-+|-+$", "")
       .take(MaxSlugLength)
       .replaceAll("-+$", "") // The length cap can leave a trailing dash behind.
     if (slug.isEmpty) fallback else slug
+  }
+
+  /**
+   * Canonicalizes a slug taken from a /r/<slug> URL so a retyped share link still resolves.
+   *
+   * People retype share links from the route's name, which reintroduces the capitals and spaces slugify removed
+   * ("/r/Demo-for-Yochai", "/r/Demo for Yochai"), so lookups fold the URL rather than matching it byte for byte.
+   * Deliberately does NOT collapse separator runs or apply the length cap, both of which would corrupt real
+   * slugs: evolution 344's backfill deduped with a '--<route_id>' suffix, and the uniquifier's "-2" suffix can
+   * push a slug past MaxSlugLength. The result is still an equality lookup, so it uses the unique index on
+   * route.slug rather than scanning, and callers try it only after the literal slug — the backfill kept
+   * diacritics that this fold strips, so a slug predating 344 must get its byte-for-byte chance first.
+   *
+   * @param slug The slug as it arrived in the URL (Play has already percent-decoded it).
+   * @return The canonical form to match stored slugs against; empty if nothing usable remains.
+   */
+  def canonicalizeForLookup(slug: String): String = {
+    foldToSlugChars(slug).replaceAll("^-+|-+$", "")
+  }
+
+  /** Lowercases, strips Latin diacritics, and turns every other non-alphanumeric character into a dash. */
+  private def foldToSlugChars(text: String): String = {
+    Normalizer
+      .normalize(text, Normalizer.Form.NFD)
+      .replaceAll("\\p{M}", "") // Drop the combining marks NFD split off, turning é into e.
+      .toLowerCase(Locale.ROOT)
+      .replaceAll("[^\\p{L}\\p{N}]", "-")
   }
 }

--- a/app/models/utils/SlugUtils.scala
+++ b/app/models/utils/SlugUtils.scala
@@ -34,18 +34,19 @@ object SlugUtils {
   }
 
   /**
-   * Canonicalizes a slug taken from a /r/<slug> URL so a retyped share link still resolves.
+   * Folds a slug taken from a /r/<slug> URL for case and separators, so a retyped share link still resolves.
    *
    * People retype share links from the route's name, which reintroduces the capitals and spaces slugify removed
    * ("/r/Demo-for-Yochai", "/r/Demo for Yochai"), so lookups fold the URL rather than matching it byte for byte.
-   * Deliberately does NOT collapse separator runs or apply the length cap, both of which would corrupt real
-   * slugs: evolution 344's backfill deduped with a '--<route_id>' suffix, and the uniquifier's "-2" suffix can
-   * push a slug past MaxSlugLength. The result is still an equality lookup, so it uses the unique index on
-   * route.slug rather than scanning, and callers try it only after the literal slug — the backfill kept
-   * diacritics that this fold strips, so a slug predating 344 must get its byte-for-byte chance first.
+   *
+   * Deliberately does NOT collapse separator runs or apply the length cap, both of which would corrupt a real slug:
+   * evolution 344's backfill deduped with a '--<route_id>' suffix, and the uniquifier's "-2" suffix can push a slug
+   * past MaxSlugLength. Callers pair it with `slugify` to close that gap — see RouteServiceImpl.slugCandidates.
+   *
+   * The result is still an equality lookup, so it serves from the unique index on route.slug rather than scanning.
    *
    * @param slug The slug as it arrived in the URL (Play has already percent-decoded it).
-   * @return The canonical form to match stored slugs against; empty if nothing usable remains.
+   * @return The folded form to match stored slugs against; empty if nothing usable remains.
    */
   def canonicalizeForLookup(slug: String): String = {
     foldToSlugChars(slug).replaceAll("^-+|-+$", "")

--- a/app/service/RouteService.scala
+++ b/app/service/RouteService.scala
@@ -393,9 +393,23 @@ class RouteServiceImpl @Inject() (
   /**
    * Resolves a share slug to a route id: the current slug of a live route, or a retired slug still redirecting.
    *
+   * Tries the slug as it arrived, then its canonical fold, so a link retyped from the route's name rather than
+   * copied ("/r/Demo-for-Yochai" for the route "Demo for Yochai", #5150) still lands on the route.
+   *
    * @return None if the slug is unknown or its route has been soft-deleted.
    */
-  def resolveSlug(slug: String): Future[Option[Int]] =
+  def resolveSlug(slug: String): Future[Option[Int]] = {
+    val candidates: Seq[String] = Seq(slug, SlugUtils.canonicalizeForLookup(slug)).filter(_.nonEmpty).distinct
+    candidates.foldLeft(Future.successful(Option.empty[Int])) { (soFar, candidate) =>
+      soFar.flatMap {
+        case found @ Some(_) => Future.successful(found)
+        case None            => resolveExactSlug(candidate)
+      }
+    }
+  }
+
+  /** Resolves one exact slug against live routes, then against the retired slugs that still redirect. */
+  private def resolveExactSlug(slug: String): Future[Option[Int]] =
     db.run(routeTable.getRouteIdBySlug(slug)).flatMap {
       case Some(routeId) => Future.successful(Some(routeId))
       case None          =>

--- a/app/service/RouteService.scala
+++ b/app/service/RouteService.scala
@@ -393,31 +393,67 @@ class RouteServiceImpl @Inject() (
   /**
    * Resolves a share slug to a route id: the current slug of a live route, or a retired slug still redirecting.
    *
-   * Tries the slug as it arrived, then its canonical fold, so a link retyped from the route's name rather than
-   * copied ("/r/Demo-for-Yochai" for the route "Demo for Yochai", #5150) still lands on the route.
+   * The slug is tried under several spellings (see `slugCandidates`) so a link retyped from the route's name rather
+   * than copied still lands on it (#5150). Live routes outrank retired slugs whichever spelling matched: a link that
+   * still works beats one kept alive only for old shares.
    *
-   * @return None if the slug is unknown or its route has been soft-deleted.
+   * Retyping stays lossy in two ways no fold can close, both preferable to a 404: "/r/STRASSE-TOUR" misses a route
+   * slugged "straße-tour" (ß has no canonical decomposition), and where the uniquifier appended "-2" a retyped name
+   * reaches whichever route holds the unsuffixed slug. A copied link is always unambiguous.
+   *
+   * @return None if no spelling is known or the matched route has been soft-deleted.
    */
   def resolveSlug(slug: String): Future[Option[Int]] = {
-    val candidates: Seq[String] = Seq(slug, SlugUtils.canonicalizeForLookup(slug)).filter(_.nonEmpty).distinct
-    candidates.foldLeft(Future.successful(Option.empty[Int])) { (soFar, candidate) =>
-      soFar.flatMap {
+    val candidates: Seq[String] = slugCandidates(slug)
+    db.run(routeTable.getRouteIdsBySlugs(candidates)).flatMap { live =>
+      bestMatch(candidates, live) match {
         case found @ Some(_) => Future.successful(found)
-        case None            => resolveExactSlug(candidate)
+        case None            => resolveRetiredSlug(candidates)
       }
     }
   }
 
-  /** Resolves one exact slug against live routes, then against the retired slugs that still redirect. */
-  private def resolveExactSlug(slug: String): Future[Option[Int]] =
-    db.run(routeTable.getRouteIdBySlug(slug)).flatMap {
-      case Some(routeId) => Future.successful(Some(routeId))
-      case None          =>
-        db.run(routeSlugAliasTable.getRouteIdBySlug(slug)).flatMap {
-          case Some(routeId) => db.run(routeTable.getRoute(routeId)).map(_.map(_.routeId))
-          case None          => Future.successful(None)
-        }
+  /**
+   * The spellings a /r/<slug> URL is looked up under, most literal first so the least-transformed hit wins.
+   *
+   * The literal slug goes first so a copied link keeps exactly the path it took before folding existed — no
+   * regression on the case every share link actually uses. `canonicalizeForLookup` must then stay ahead of
+   * `slugify`, whose collapsing and capping would miss one of evolution 344's '--<route_id>' dedupe suffixes or a
+   * "-2"-uniquified slug past MaxSlugLength; slugify goes last to catch a name retyped with its punctuation intact.
+   *
+   * @param slug The slug as it arrived in the URL.
+   * @return The distinct non-empty spellings to try, in priority order.
+   */
+  private def slugCandidates(slug: String): Seq[String] = {
+    Seq(
+      slug,
+      SlugUtils.canonicalizeForLookup(slug),
+      // Empty fallback on purpose: slugify's "route" default would make an all-punctuation URL like /r/!!! hit a
+      // route legitimately slugged "route". An empty candidate is dropped instead.
+      SlugUtils.slugify(slug, fallback = "")
+    ).filter(_.nonEmpty).distinct
+  }
+
+  /** Resolves the candidates against retired slugs, dropping a hit whose route has since been soft-deleted. */
+  private def resolveRetiredSlug(candidates: Seq[String]): Future[Option[Int]] = {
+    db.run(routeSlugAliasTable.getRouteIdsBySlugs(candidates)).flatMap { retired =>
+      bestMatch(candidates, retired) match {
+        case Some(routeId) => db.run(routeTable.getRoute(routeId)).map(_.map(_.routeId))
+        case None          => Future.successful(None)
+      }
     }
+  }
+
+  /**
+   * Picks the route id of the earliest candidate spelling present in a lookup's results.
+   *
+   * @param candidates The spellings that were looked up, most literal first.
+   * @param matched    The (slug, route id) rows the lookup returned, in whatever order the database produced them.
+   */
+  private def bestMatch(candidates: Seq[String], matched: Seq[(String, Int)]): Option[Int] = {
+    val routeIdBySlug: Map[String, Int] = matched.toMap
+    candidates.iterator.flatMap(routeIdBySlug.get).nextOption()
+  }
 
   /**
    * Soft-deletes a route owned by the given user. Share links to the route stop working.

--- a/test/controllers/RouteBuilderControllerSpec.scala
+++ b/test/controllers/RouteBuilderControllerSpec.scala
@@ -1,6 +1,7 @@
 package controllers
 
 import org.apache.pekko.stream.Materializer
+import org.scalatest.Assertion
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Application
@@ -122,6 +123,19 @@ class RouteBuilderControllerSpec extends PlaySpec with GuiceOneAppPerSuite {
 
   /** A short unique tag for route names so slug assertions are deterministic against a shared database. */
   private def uniqueTag(): String = UUID.randomUUID().toString.replace("-", "").take(12)
+
+  /**
+   * Asserts a /r/<slug> spelling redirects to that exact route — landing on some other route is still a failure.
+   *
+   * @return The Location assertion, so the helper composes where ScalaTest expects an Assertion.
+   */
+  private def mustRedirectTo(typedSlug: String, routeId: Int): Assertion = {
+    val visit = route(app, FakeRequest(GET, s"/r/$typedSlug")).get
+    withClue(s"/r/$typedSlug: ") {
+      status(visit) mustBe FOUND
+      header(LOCATION, visit).get must include(s"/explore?routeId=$routeId")
+    }
+  }
 
   "The RouteBuilder routes" should {
     "exist and redirect an unauthenticated GET /userapi/routes to sign-in (3xx, not 404)" in {
@@ -394,18 +408,37 @@ class RouteBuilderControllerSpec extends PlaySpec with GuiceOneAppPerSuite {
       (contentAsJson(saved) \ "slug").as[String] mustBe s"demo-for-yochai-$tag"
 
       // The third is the name itself, as a browser would encode it.
-      Seq(s"Demo-For-Yochai-$tag", s"demo-for-Yochai-$tag", s"Demo%20For%20Yochai%20$tag").foreach { typed =>
-        val visit = route(app, FakeRequest(GET, s"/r/$typed")).get
-        status(visit) mustBe FOUND
-        header(LOCATION, visit).get must include(s"/explore?routeId=$routeId")
-      }
+      Seq(s"Demo-For-Yochai-$tag", s"demo-for-Yochai-$tag", s"Demo%20For%20Yochai%20$tag")
+        .foreach(mustRedirectTo(_, routeId))
 
-      // A retired slug redirects case-insensitively too.
+      // A retired slug redirects under a retyped spelling too.
       status(putRoute(user, routeId, Json.obj("name" -> s"Renamed Walk $tag"))) mustBe OK
-      status(route(app, FakeRequest(GET, s"/r/Demo-For-Yochai-$tag")).get) mustBe FOUND
+      mustRedirectTo(s"Demo-For-Yochai-$tag", routeId)
 
       // Folding the URL must not turn an unknown slug into a hit.
       status(route(app, FakeRequest(GET, s"/r/Demo%20For%20Nobody%20$tag")).get) mustBe NOT_FOUND
+
+      // Nor may it resurrect a share link its owner deleted, by either spelling.
+      status(deleteRoute(user, routeId)) mustBe OK
+      status(route(app, FakeRequest(GET, s"/r/Renamed%20Walk%20$tag")).get) mustBe NOT_FOUND
+      status(route(app, FakeRequest(GET, s"/r/Demo-For-Yochai-$tag")).get) mustBe NOT_FOUND
+    }
+
+    // Case folding alone isn't enough: the run in "St. Louis" folds to "--", where the stored slug collapsed it to
+    // one dash. Slugifying the URL is the candidate that closes that gap (RouteServiceImpl.slugCandidates).
+    "resolve a retyped name whose punctuation collapsed when its slug was generated" in {
+      val user                 = signUpFreshUser()
+      val (streetId, regionId) = anyStreet(user)
+      val tag                  = uniqueTag()
+
+      val saved = saveRoute(user, saveRouteBody(regionId, streetId, Some(s"St. Louis Walk $tag")))
+      status(saved) mustBe OK
+      val routeId = (contentAsJson(saved) \ "route_id").as[Int]
+      (contentAsJson(saved) \ "slug").as[String] mustBe s"st-louis-walk-$tag"
+
+      // The last spelling is what the fold produces, so it exercises the slugify candidate on its own.
+      Seq(s"St.%20Louis%20Walk%20$tag", s"ST.%20LOUIS%20WALK%20$tag", s"st--louis-walk-$tag")
+        .foreach(mustRedirectTo(_, routeId))
     }
   }
 

--- a/test/controllers/RouteBuilderControllerSpec.scala
+++ b/test/controllers/RouteBuilderControllerSpec.scala
@@ -381,6 +381,32 @@ class RouteBuilderControllerSpec extends PlaySpec with GuiceOneAppPerSuite {
       status(route(app, FakeRequest(GET, s"/r/$slug1")).get) mustBe NOT_FOUND
       status(route(app, FakeRequest(GET, s"/r/$slug2")).get) mustBe NOT_FOUND
     }
+
+    // #5150: the link handed out during a demo was retyped from the route's name, so its casing missed the slug.
+    "resolve a link retyped from the route's name rather than copied" in {
+      val user                 = signUpFreshUser()
+      val (streetId, regionId) = anyStreet(user)
+      val tag                  = uniqueTag()
+
+      val saved = saveRoute(user, saveRouteBody(regionId, streetId, Some(s"Demo For Yochai $tag")))
+      status(saved) mustBe OK
+      val routeId = (contentAsJson(saved) \ "route_id").as[Int]
+      (contentAsJson(saved) \ "slug").as[String] mustBe s"demo-for-yochai-$tag"
+
+      // The third is the name itself, as a browser would encode it.
+      Seq(s"Demo-For-Yochai-$tag", s"demo-for-Yochai-$tag", s"Demo%20For%20Yochai%20$tag").foreach { typed =>
+        val visit = route(app, FakeRequest(GET, s"/r/$typed")).get
+        status(visit) mustBe FOUND
+        header(LOCATION, visit).get must include(s"/explore?routeId=$routeId")
+      }
+
+      // A retired slug redirects case-insensitively too.
+      status(putRoute(user, routeId, Json.obj("name" -> s"Renamed Walk $tag"))) mustBe OK
+      status(route(app, FakeRequest(GET, s"/r/Demo-For-Yochai-$tag")).get) mustBe FOUND
+
+      // Folding the URL must not turn an unknown slug into a hit.
+      status(route(app, FakeRequest(GET, s"/r/Demo%20For%20Nobody%20$tag")).get) mustBe NOT_FOUND
+    }
   }
 
   "GET /userapi/routes, PUT and DELETE /userapi/routes/:routeId" should {

--- a/test/models/utils/SlugUtilsSpec.scala
+++ b/test/models/utils/SlugUtilsSpec.scala
@@ -11,6 +11,25 @@ import org.scalatest.matchers.should.Matchers
  */
 class SlugUtilsSpec extends AnyFunSuite with Matchers {
 
+  /**
+   * Route names covering every shape the lookup fold could treat differently from slugify: adjacent punctuation,
+   * accented Latin (decomposable and not), non-Latin scripts, and a name past the length cap.
+   */
+  private val routeNames: Seq[String] = Seq(
+    "Demo for Yochai",
+    "St. Louis Walk",
+    "Ballard Ave / 20th",
+    "Jon's Walk (v2)",
+    "Route 1, North",
+    "Café Walk",
+    "Ødegård Loop",
+    "Straße Tour",
+    "台北 散步",
+    "Прогулка",
+    "Route 17",
+    "x" * 80
+  )
+
   test("slugify lowercases, dashes separators, and strips Latin diacritics") {
     SlugUtils.slugify("Demo for Yochai") shouldBe "demo-for-yochai"
     SlugUtils.slugify("Café Walk!") shouldBe "cafe-walk"
@@ -19,7 +38,7 @@ class SlugUtilsSpec extends AnyFunSuite with Matchers {
 
   test("slugify never emits consecutive, leading, or trailing dashes — evolution 344's '--' invariant") {
     SlugUtils.slugify("--- Park  ---  Walk ---") shouldBe "park-walk"
-    SlugUtils.slugify("a - b -- c") should not include "--"
+    SlugUtils.slugify("a - b -- c") shouldBe "a-b-c"
   }
 
   test("slugify caps length without leaving a trailing dash, and falls back when nothing usable remains") {
@@ -29,6 +48,10 @@ class SlugUtilsSpec extends AnyFunSuite with Matchers {
     SlugUtils.slugify("y" * 59 + " tail") shouldBe "y" * 59
     SlugUtils.slugify("!!!") shouldBe "route"
     SlugUtils.slugify("!!!", "fallback") shouldBe "fallback"
+  }
+
+  test("slugify with an empty fallback yields nothing, so an all-punctuation URL can't hit a route named 'route'") {
+    SlugUtils.slugify("!!!", fallback = "") shouldBe ""
   }
 
   test("canonicalizeForLookup folds the ways a share link gets retyped") {
@@ -51,5 +74,29 @@ class SlugUtilsSpec extends AnyFunSuite with Matchers {
   test("canonicalizeForLookup returns empty when a URL holds no usable slug") {
     SlugUtils.canonicalizeForLookup("---") shouldBe ""
     SlugUtils.canonicalizeForLookup("") shouldBe ""
+  }
+
+  // The invariant the whole /r/ lookup rests on: folding a stored slug is a no-op, so the extra candidates can only
+  // add matches, never miss one the literal slug would have found. Holds only because both helpers share one fold.
+  test("a stored slug is already both folded and slugified — the lookup candidates can only add matches") {
+    routeNames.foreach { name =>
+      val stored: String = SlugUtils.slugify(name)
+      withClue(s"name '$name' stores as '$stored': ") {
+        SlugUtils.canonicalizeForLookup(stored) shouldBe stored
+        SlugUtils.slugify(stored) shouldBe stored
+      }
+    }
+  }
+
+  // Retyping a name with punctuation is what the fold alone can't handle, since it deliberately preserves the '--'
+  // that evolution 344's dedupe suffix needs. slugify is the candidate that closes the gap (RouteServiceImpl).
+  test("a name retyped with its punctuation needs slugify as a candidate, not just the fold") {
+    SlugUtils.slugify("St. Louis Walk") shouldBe "st-louis-walk"
+    SlugUtils.canonicalizeForLookup("St. Louis Walk") shouldBe "st--louis-walk"
+    SlugUtils.slugify("St. Louis Walk", fallback = "") shouldBe "st-louis-walk"
+
+    SlugUtils.slugify("Jon's Walk (v2)") shouldBe "jon-s-walk-v2"
+    SlugUtils.canonicalizeForLookup("Jon's Walk (v2)") shouldBe "jon-s-walk--v2"
+    SlugUtils.slugify("Jon's Walk (v2)", fallback = "") shouldBe "jon-s-walk-v2"
   }
 }

--- a/test/models/utils/SlugUtilsSpec.scala
+++ b/test/models/utils/SlugUtilsSpec.scala
@@ -1,0 +1,55 @@
+package models.utils
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+/**
+ * Pure (no DB, no app boot) tests for the /r/<slug> share-link slug helpers.
+ *
+ * The lookup half guards #5150: a route named "Demo for Yochai" is reachable at /r/demo-for-yochai, and the link
+ * has to survive being retyped from the name instead of copied.
+ */
+class SlugUtilsSpec extends AnyFunSuite with Matchers {
+
+  test("slugify lowercases, dashes separators, and strips Latin diacritics") {
+    SlugUtils.slugify("Demo for Yochai") shouldBe "demo-for-yochai"
+    SlugUtils.slugify("Café Walk!") shouldBe "cafe-walk"
+    SlugUtils.slugify("  Ballard   Ave / 20th  ") shouldBe "ballard-ave-20th"
+  }
+
+  test("slugify never emits consecutive, leading, or trailing dashes — evolution 344's '--' invariant") {
+    SlugUtils.slugify("--- Park  ---  Walk ---") shouldBe "park-walk"
+    SlugUtils.slugify("a - b -- c") should not include "--"
+  }
+
+  test("slugify caps length without leaving a trailing dash, and falls back when nothing usable remains") {
+    val long: String = SlugUtils.slugify("x" * 80)
+    long.length shouldBe SlugUtils.MaxSlugLength
+    // The cap must not land mid-separator: "<59 chars>-<more>" would otherwise truncate to a trailing dash.
+    SlugUtils.slugify("y" * 59 + " tail") shouldBe "y" * 59
+    SlugUtils.slugify("!!!") shouldBe "route"
+    SlugUtils.slugify("!!!", "fallback") shouldBe "fallback"
+  }
+
+  test("canonicalizeForLookup folds the ways a share link gets retyped") {
+    SlugUtils.canonicalizeForLookup("demo-for-Yochai") shouldBe "demo-for-yochai"
+    SlugUtils.canonicalizeForLookup("Demo-For-Yochai") shouldBe "demo-for-yochai"
+    SlugUtils.canonicalizeForLookup("Demo for Yochai") shouldBe "demo-for-yochai"
+    SlugUtils.canonicalizeForLookup("demo_for_yochai") shouldBe "demo-for-yochai"
+  }
+
+  test("canonicalizeForLookup leaves every slug the app can store untouched") {
+    Seq(
+      "demo-for-yochai",                   // A runtime slug.
+      "walk-2",                            // The uniquifier's suffix.
+      "route-17",                          // The default name of an unnamed route.
+      "park-walk--42",                     // Evolution 344's backfill dedupe suffix: runs must NOT collapse.
+      "x" * SlugUtils.MaxSlugLength + "-2" // A uniquified slug past the cap: no truncation here.
+    ).foreach { slug => SlugUtils.canonicalizeForLookup(slug) shouldBe slug }
+  }
+
+  test("canonicalizeForLookup returns empty when a URL holds no usable slug") {
+    SlugUtils.canonicalizeForLookup("---") shouldBe ""
+    SlugUtils.canonicalizeForLookup("") shouldBe ""
+  }
+}


### PR DESCRIPTION
Fixes #5150.

## The bug

A route named "Demo for Yochai" is stored with the slug `demo-for-yochai`, but `/r/demo-for-**Y**ochai` 404'd — the slug lookup matched the URL byte for byte. Confirmed on prod:

```
sidewalk_teaneck.route:  2 | Demo for Yochai | demo-for-yochai | deleted=f
/r/demo-for-Yochai  ->  404
/r/demo-for-yochai  ->  302  /explore?routeId=2
```

`SlugUtils.slugify` lowercases every slug it generates, and `RouteService.resolveSlug` did equality lookups against `route.slug` and then `route_slug_alias.slug` with no folding of the incoming URL. Nothing in the UI ever emits a capitalized slug — the copy-link buttons in My Routes, the community route list, and the RouteBuilder "Route Saved" modal all use the server-supplied slug — so this only bites when a link is retyped or reconstructed from the route's *name* instead of copied. Which is what happened during a demo.

## The fix

`resolveSlug` looks the URL up under three spellings, most literal first, and takes the earliest one that matches. **Order is the whole design:**

1. **The slug as it arrived.** A copied link keeps exactly the path it took before any of this existed, so the case every share link actually uses carries no regression risk.
2. **`SlugUtils.canonicalizeForLookup`** — lowercases (`Locale.ROOT`), strips Latin diacritics, turns spaces, underscores and other punctuation into dashes. Deliberately does *not* collapse separator runs or cap length, because both would corrupt a real slug: evolution 344's backfill deduped with a `--<route_id>` suffix, and the uniquifier's `-2` suffix can push a slug past `MaxSlugLength`. Keeping it ahead of (3) is what lets an uppercase retype of either shape still resolve.
3. **`SlugUtils.slugify` itself**, with an empty fallback. This is what catches a name retyped *with its punctuation intact*. The fold in (2) turns "St. Louis Walk" into `st--louis-walk`, but the stored slug collapsed that run to `st-louis-walk`; running the generator over the URL reproduces the stored slug by construction. Four of ten realistic route names — `St. Louis Walk`, `Ballard Ave / 20th`, `Jon's Walk (v2)`, `Route 1, North` — fail without it. The empty fallback matters: slugify's default `"route"` would make `/r/!!!` resolve to a route legitimately slugged `route`.

So `/r/Demo-For-Yochai`, `/r/demo-for-Yochai`, `/r/Demo%20for%20Yochai` and `/r/St.%20Louis%20Walk` all resolve, and retired slugs in `route_slug_alias` fold the same way so old links keep redirecting.

Each table is queried once with `slug IN (...)` and candidate priority applied in Scala — two round trips rather than a probe per spelling, both still served by `route_slug_idx` / the alias PK. That also gets the precedence right: a live route now outranks a retired alias whichever spelling matched, where a per-candidate probe would let an alias hit on spelling 1 beat a live route on spelling 2.

`slugify` itself is unchanged in behavior; the shared character folding is factored into a private helper and `slugify` collapses runs on top of it.

Two residual limits, both preferable to a 404 and both noted in the ScalaDoc: `/r/STRASSE-TOUR` won't reach a route slugged `straße-tour` (ß has no canonical decomposition), and where the uniquifier appended `-2`, retyping the *name* reaches whichever route holds the unsuffixed slug. A copied link is always unambiguous.

## Prod slug census

Checked read-only across every city schema, to confirm what the fold is actually allowed to assume:

```
route.slug              total = 1824
  non [a-z0-9-]                 0
  containing '--'               0
  longer than 60                0
  not equal to lower(slug)      0
route_slug_alias        total = 0
```

Every stored slug is already a fixed point of the fold, so no existing link changes meaning. The `--` and >60 cases stay defended anyway: the `-2` uniquifier can still produce a slug past the cap at runtime.

## Tests

- `SlugUtilsSpec` (pure): the fold's behavior, the `--`/length cases the fold must not touch, and the invariant the whole lookup rests on — a stored slug is already both folded *and* slugified — exercised across the inputs that could re-fold differently: accented Latin (`Café`, `Ødegård`, `Straße`), CJK, Cyrillic, and names past the length cap.
- `RouteBuilderControllerSpec`: resolves three retyped spellings of "Demo For Yochai", asserts a retired slug still redirects **to the right route** after a rename, asserts the fold can't resurrect a deleted route's link, and asserts a near-miss still 404s. A separate case covers the punctuation shape ("St. Louis Walk"), including the `st--louis-walk-…` spelling that only candidate 3 can resolve.

Verified the new tests bite: with candidate 3 removed, `/r/St.%20Louis%20Walk%20…` returns 404 instead of 302. Both suites green locally, plus `scalafmt` and a warning-clean compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-opus-5[1m])
