### PR TITLE
Reserve /r/ for slugs: take bare route ids back out (#5157)

### DIFF
--- a/app/controllers/RouteBuilderController.scala
+++ b/app/controllers/RouteBuilderController.scala
@@ -127,7 +127,7 @@ class RouteBuilderController @Inject() (
   }
 
   /**
-   * Redirects a /r/<x> share link to the route in Explore. Unauthenticated so share links work logged-out
+   * Redirects a /r/<slug> share link to the route in Explore. Unauthenticated so share links work logged-out
    * (/explore handles anonymous sign-up itself); retired slugs of renamed routes keep redirecting via the alias
    * table.
    *
@@ -138,8 +138,8 @@ class RouteBuilderController @Inject() (
    * debugging one. Deleted and never-existed are deliberately not told apart — that costs another query, and the
    * copy is honest about both.
    *
-   * @param slug A route reference: the route's slug, matched case-insensitively so a retyped link resolves, or a
-   *             bare route id (#5157). 404 if it names nothing or the route has been deleted.
+   * @param slug The route's slug, matched case-insensitively so a retyped link resolves; 404 if unknown or the
+   *             route has been deleted.
    */
   def routeBySlug(slug: String): Action[AnyContent] = Action.async { implicit request =>
     routeService.resolveSlug(slug).map {

--- a/app/models/route/RouteSlugAliasTable.scala
+++ b/app/models/route/RouteSlugAliasTable.scala
@@ -45,14 +45,6 @@ class RouteSlugAliasTable @Inject() (protected val dbConfigProvider: DatabaseCon
   }
 
   /**
-   * Whether this slug has ever been retired here, including by a route since deleted — which is what keeps a dead
-   * share link dead rather than letting it be reread as a bare route id (#5157).
-   */
-  def slugReserved(slug: String): DBIO[Boolean] = {
-    slugAliases.filter(_.slug === slug).exists.result
-  }
-
-  /**
    * Gets aliases whose slug is the given base or starts with "<base>-", with their owning route ids — the
    * candidate set the slug uniquifier must avoid (an alias owned by the route being renamed is reclaimable).
    */

--- a/app/models/route/RouteTable.scala
+++ b/app/models/route/RouteTable.scala
@@ -305,17 +305,6 @@ class RouteTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
   }
 
   /**
-   * Whether any route carries this slug, deleted routes included.
-   *
-   * Deleted ones count on purpose. A slug stays reserved after its route is gone — the same reservation
-   * `slugsStartingWith` enforces when generating one — so a share link that died with its route can never come
-   * back pointing at a different route (#5157).
-   */
-  def slugReserved(slug: String): DBIO[Boolean] = {
-    routes.filter(_.slug === slug).exists.result
-  }
-
-  /**
    * Gets slugs (with their route ids) equal to the given base or starting with "<base>-" — the candidate set the
    * slug uniquifier must avoid. Includes deleted routes: their slugs stay reserved so a recycled slug can't make
    * an old share link point at someone else's route.

--- a/app/service/RouteService.scala
+++ b/app/service/RouteService.scala
@@ -391,29 +391,28 @@ class RouteServiceImpl @Inject() (
   }
 
   /**
-   * Resolves a /r/<x> share link to a route id: a live route's slug, a retired slug still redirecting, or a bare id.
+   * Resolves a share slug to a route id: the current slug of a live route, or a retired slug still redirecting.
    *
-   * The three are tried in that order, and the order is what keeps the last one safe (#5157): a route legitimately
-   * named "2024" is slugged "2024" and keeps /r/2024 for itself, and a retired numeric slug still outranks an id
-   * that collides with it. Within the slug steps the link is tried under several spellings (see `slugCandidates`),
-   * so a link retyped from the route's name rather than copied still lands on it (#5150).
+   * The slug is tried under several spellings (see `slugCandidates`) so a link retyped from the route's name rather
+   * than copied still lands on it (#5150). Live routes outrank retired slugs whichever spelling matched: a link that
+   * still works beats one kept alive only for old shares.
+   *
+   * /r/ resolves slugs and nothing else. A bare route id was accepted here briefly (#5157) and taken back out: ids
+   * are dense, so a mistyped one lands on a real route instead of 404ing, and a slug's sparseness — the fact that a
+   * typo misses — is the only error detection a share link has. /explore?routeId=<id> is where an id belongs.
    *
    * Retyping stays lossy in two ways no fold can close, both preferable to a 404: "/r/STRASSE-TOUR" misses a route
    * slugged "straße-tour" (ß has no canonical decomposition), and where the uniquifier appended "-2" a retyped name
    * reaches whichever route holds the unsuffixed slug. A copied link is always unambiguous.
    *
-   * @return None if no spelling or id is known, or the matched route has been soft-deleted.
+   * @return None if no spelling is known or the matched route has been soft-deleted.
    */
   def resolveSlug(slug: String): Future[Option[Int]] = {
     val candidates: Seq[String] = slugCandidates(slug)
     db.run(routeTable.getRouteIdsBySlugs(candidates)).flatMap { live =>
       bestMatch(candidates, live) match {
         case found @ Some(_) => Future.successful(found)
-        case None            =>
-          resolveRetiredSlug(candidates).flatMap {
-            case found @ Some(_) => Future.successful(found)
-            case None            => resolveRouteId(slug)
-          }
+        case None            => resolveRetiredSlug(candidates)
       }
     }
   }
@@ -437,52 +436,6 @@ class RouteServiceImpl @Inject() (
       // route legitimately slugged "route". An empty candidate is dropped instead.
       SlugUtils.slugify(slug, fallback = "")
     ).filter(_.nonEmpty).distinct
-  }
-
-  /**
-   * Resolves the link as a bare route id, the last resort once every slug spelling has missed (#5157).
-   *
-   * It exists so a share link can be spoken: "projectsidewalk.org/r/2" survives being read out in a demo, where a
-   * slug does not. It reaches no route that /explore?routeId=<id> doesn't already reach — `getRoute` filters on
-   * `deleted` alone, and the Explore entry point applies no ownership or visibility check either — so this is a
-   * shorter spelling of a URL that already works. It does make existence cheaper to probe than the alternatives,
-   * which need a session and write a walk row per attempt; the answer it gives away (this city has a route with
-   * this id) is not secret.
-   *
-   * The id is refused for a spelling that is — or ever was — some route's slug, even one since deleted. A slug
-   * stays reserved past a delete precisely so an old share link can't return pointing at a stranger's route, and
-   * rereading a dead numeric slug as an id would recycle it after all: /r/2024 for a deleted route named "2024"
-   * must stay 404 rather than start serving whatever route holds id 2024.
-   *
-   * Unlike a slug, an id means nothing across cities: each city schema numbers its routes from 1, so the same
-   * /r/2 resolves at every host and the wrong host answers with an unrelated route instead of a 404. The host is
-   * the part a spoken link most easily loses, so a slug stays the better thing to hand out where one exists.
-   *
-   * @param ref The path segment as it arrived in the URL.
-   * @return None unless `ref` is a route id in canonical decimal form, unreserved as a slug, naming a live route.
-   */
-  private def resolveRouteId(ref: String): Future[Option[Int]] = {
-    bareRouteId(ref) match {
-      case None          => Future.successful(None)
-      case Some(routeId) =>
-        db.run(routeTable.slugReserved(ref).zip(routeSlugAliasTable.slugReserved(ref))).flatMap {
-          case (false, false) => db.run(routeTable.getRoute(routeId)).map(_.map(_.routeId))
-          case _              => Future.successful(None)
-        }
-    }
-  }
-
-  /**
-   * The route id a /r/<x> path segment names, if it is written as one.
-   *
-   * Only the canonical decimal spelling counts. `toIntOption` on its own also accepts "+2", "007" and Unicode
-   * digits ("٢"), which would hand every route an unbounded family of URLs redirecting to the same place — and
-   * would give "/r/007" a route to id 7 that the reservation check above, keyed on the literal spelling, never
-   * sees. Ten digits is the widest an Int can be; a longer one is refused here and an in-range overflow like
-   * "9999999999" by `toIntOption`.
-   */
-  private def bareRouteId(ref: String): Option[Int] = {
-    if (ref.matches("[1-9][0-9]{0,9}")) ref.toIntOption else None
   }
 
   /** Resolves the candidates against retired slugs, dropping a hit whose route has since been soft-deleted. */

--- a/test/controllers/RouteBuilderControllerSpec.scala
+++ b/test/controllers/RouteBuilderControllerSpec.scala
@@ -446,76 +446,24 @@ class RouteBuilderControllerSpec extends PlaySpec with GuiceOneAppPerSuite {
         .foreach(mustRedirectTo(_, routeId))
     }
 
-    // #5157: /r/2 is the spelling of a share link that survives being read aloud in a demo; a slug is not speakable.
-    "resolve a bare route id, and 404 an id that names nothing" in {
+    // #5157 briefly made /r/<x> accept a bare route id too; it was taken back out because ids are dense, so a
+    // mistyped one lands on a real route instead of 404ing — and a slug's sparseness, the fact that a typo misses,
+    // is the only error detection a share link has. This pins the namespace closed: a live route's id is not a way
+    // in, however tempting it looks. /explore?routeId=<id> is where an id belongs, and still takes one.
+    "not resolve a bare route id — /r/ is for slugs" in {
       val user                 = signUpFreshUser()
       val (streetId, regionId) = anyStreet(user)
 
-      val saved = saveRoute(user, saveRouteBody(regionId, streetId, Some(s"Speakable Walk ${uniqueTag()}")))
+      val saved = saveRoute(user, saveRouteBody(regionId, streetId, Some(s"Slug Only Walk ${uniqueTag()}")))
       status(saved) mustBe OK
       val routeId = (contentAsJson(saved) \ "route_id").as[Int]
+      val slug    = (contentAsJson(saved) \ "slug").as[String]
 
-      mustRedirectTo(routeId.toString, routeId)
-
-      // Ids naming nothing 404 rather than erroring, including one past Int's range: the path is bound as a String,
-      // so nothing upstream rejects it for us. Only the canonical decimal spelling is read as an id at all, so the
-      // route above answers at exactly one numeric URL rather than at "+id", "0id", "00id", ... as well.
-      Seq("0", "-1", Int.MaxValue.toString, "99999999999999999999", s"0$routeId", s"+$routeId").foreach { path =>
+      // The slug reaches it; its id does not, in any spelling.
+      mustRedirectTo(slug, routeId)
+      Seq(routeId.toString, s"0$routeId", s"+$routeId", "0", "-1").foreach { path =>
         withClue(s"/r/$path: ") { status(route(app, FakeRequest(GET, s"/r/$path")).get) mustBe NOT_FOUND }
       }
-
-      // A deleted route's id stops resolving, exactly as its slug does.
-      status(deleteRoute(user, routeId)) mustBe OK
-      status(route(app, FakeRequest(GET, s"/r/$routeId")).get) mustBe NOT_FOUND
-    }
-
-    // A slug outliving its route is the point of the reservation: RouteTable.slugsStartingWith keeps a deleted
-    // route's slug taken so a later route can't inherit its share links. Reading a dead numeric slug as an id
-    // would sidestep that — silently, and onto a stranger's route rather than onto a 404.
-    "keep a deleted route's numeric slug dead rather than rereading it as the id of a live route" in {
-      val user                 = signUpFreshUser()
-      val (streetId, regionId) = anyStreet(user)
-
-      val live = saveRoute(user, saveRouteBody(regionId, streetId, Some(s"Reservation Target ${uniqueTag()}")))
-      status(live) mustBe OK
-      val liveId = (contentAsJson(live) \ "route_id").as[Int]
-
-      // A second route named after the first one's id, deleted without ever being renamed — so the reservation
-      // rests on the route row alone, with no alias to fall back on.
-      val namesake = saveRoute(user, saveRouteBody(regionId, streetId, Some(liveId.toString)))
-      status(namesake) mustBe OK
-      (contentAsJson(namesake) \ "slug").as[String] mustBe liveId.toString
-      status(deleteRoute(user, (contentAsJson(namesake) \ "route_id").as[Int])) mustBe OK
-
-      status(route(app, FakeRequest(GET, s"/r/$liveId")).get) mustBe NOT_FOUND
-    }
-
-    // The candidate order is the whole safety argument for bare ids, so it gets a route whose slug *is* another
-    // route's id: every step of the order is observable on one URL.
-    "let a slug spelled as a number outrank the route id it collides with" in {
-      val user                 = signUpFreshUser()
-      val (streetId, regionId) = anyStreet(user)
-
-      val target = saveRoute(user, saveRouteBody(regionId, streetId, Some(s"Collision Target ${uniqueTag()}")))
-      status(target) mustBe OK
-      val targetId = (contentAsJson(target) \ "route_id").as[Int]
-
-      val namesake = saveRoute(user, saveRouteBody(regionId, streetId, Some(targetId.toString)))
-      status(namesake) mustBe OK
-      val namesakeId = (contentAsJson(namesake) \ "route_id").as[Int]
-      (contentAsJson(namesake) \ "slug").as[String] mustBe targetId.toString
-
-      // A live slug beats the id.
-      mustRedirectTo(targetId.toString, namesakeId)
-
-      // Renaming retires that slug to the alias table, which is still tried ahead of the id.
-      status(putRoute(user, namesakeId, Json.obj("name" -> s"Renamed Namesake ${uniqueTag()}"))) mustBe OK
-      mustRedirectTo(targetId.toString, namesakeId)
-
-      // Deleting the namesake doesn't hand the URL to the id either: a retired slug stays retired, so the link
-      // dies with the route that owned it instead of quietly retargeting.
-      status(deleteRoute(user, namesakeId)) mustBe OK
-      status(route(app, FakeRequest(GET, s"/r/$targetId")).get) mustBe NOT_FOUND
     }
 
     // #5164: this page is the whole of what a share-link recipient sees when the link is dead, and they were, by


### PR DESCRIPTION
Reverts the bare-id half of #5157 (shipped in #5160). Closes #5166.

## Why

Review of #5160 turned up two hazards that come with giving route ids their own URL namespace, neither of which the slug namespace has:

1. **A mistyped id lands on a live route, silently.** Ids are dense — `route_id` 1–93 with no gaps in one schema — so `/r/3` when you meant `/r/2` starts a walk on somebody else's route. A slug typo 404s, and **that miss is the only error detection a share link has**. For the demo scenario #5157 was written for, bare ids are strictly worse than what they replaced.
2. **A published `/r/<id>` link is squattable, then permanently killable.** Digits survive `slugify`, slugs outrank ids, and a slug stays reserved past a delete — so any user can create a route named "2", take `/r/2`, delete it, and leave `/r/2` 404ing forever.

The clean prevention for (2) — never mint a bare-decimal slug — contradicts #5157's own acceptance criterion that a route named "2024" keeps `/r/2024`. Rather than trade one away, @jonfroehlich called it: `/r/` means one thing.

## What changes

Out: `RouteServiceImpl.resolveRouteId` and `bareRouteId`, plus `RouteTable.slugReserved` and `RouteSlugAliasTable.slugReserved` — those two queries existed only to keep the id step from reviving a dead numeric slug, so they go with it. `resolveSlug` is back to live slugs → retired slugs, and its scaladoc records why the third step isn't there, so the idea doesn't get reinvented.

Untouched:

- **`/explore?routeId=<id>` still takes a bare id.** It always did; only the `/r/` namespace is slug-only.
- All of #5150's retyped-link folding — `/r/Demo-For-Yochai` still resolves.
- #5164's route-aware 404, which now catches the `/r/<id>` attempts too and points them at `/routes`.

## Tests

The three bare-id specs are replaced by one that pins the namespace closed: a live route's slug redirects, and its **id** 404s in every spelling (`<id>`, `0<id>`, `+<id>`, `0`, `-1`). 24 cases green in `RouteBuilderControllerSpec`; `make lint` and `scalafmtCheckAll` clean.

Net −118 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-opus-5[1m])
