### PR TITLE
Drive the community stat band's layout from its tile count (#5186)

### DIFF
--- a/app/views/userDashboard/leaderboard.scala.html
+++ b/app/views/userDashboard/leaderboard.scala.html
@@ -1,4 +1,5 @@
 @import controllers.helper.ControllerUtils.distanceUnitWords
+@import play.twirl.api.HtmlFormat
 @import service.{CityImpact, CommonPageData, GlobalLeaderboardEntry}
 @import models.api.AggregateStats
 @import models.user.{LeaderboardStat, SidewalkUserWithRole, UserStanding}
@@ -75,28 +76,36 @@
 }
 
 @*
-* The community band keeps all five tiles on one line, which means a value has only a fifth of the band to sit in.
+* The community band keeps every tile on one line, which leaves a value only its own share of the band to sit in.
 * Each of its figures therefore renders twice — the exact one and a short one — and CSS shows whichever fits, so the
 * band abbreviates under pressure rather than shrinking its type. The full figure carries the accessible reading at
-* every width; the short form is decorative. Values with no shorter form render as themselves, unwrapped.
+* every width; the short form is decorative. Values with no shorter form render as themselves, unwrapped. The digits
+* here and in CrossCityStats.#shortNum have to agree: the two fill the same band, whose type is sized to them.
 *@
 @shortCount(n: Int) = @{
-  if (n >= 1000000) "%.1fM".formatLocal(locale, n / 1000000.0)
-  else if (n >= 10000) "%.0fk".formatLocal(locale, n / 1000.0)
+  // Rounding decides the tier, not the raw value: 999,999 rounds to 1000 thousands, and printing that as "1000k"
+  // would read as a million while claiming not to be one.
+  val thousands = math.round(n / 1000.0)
+  if (thousands >= 1000) "%.1fM".formatLocal(locale, n / 1000000.0)
+  else if (n >= 10000) "%dk".formatLocal(locale, thousands)
   else fmtCount(n)
 }
 
 @twoForm(full: String, short: String) = @{
-  if (full == short) Html(full)
-  else Html(s"""<span class="ud-value-full">$full</span><span class="ud-value-short" aria-hidden="true">$short</span>""")
+  // Escaped rather than interpolated raw: a distance carries a translated unit, so these strings are not all ours.
+  val f = HtmlFormat.escape(full)
+  if (full == short) f
+  else {
+    val s = HtmlFormat.escape(short)
+    Html(s"""<span class="ud-value-full">$f</span><span class="ud-value-short" aria-hidden="true">$s</span>""")
+  }
 }
 
 @communityCount(n: Int) = @{ twoForm(fmtCount(n), shortCount(n)) }
 
 @communityDist(km: Double) = @{
   val dist = if (isMetric) km else km * 0.621371
-  val unit = unitWords.abbr
-  val short = if (dist >= 10000) s"""${"%.0fk".formatLocal(locale, dist / 1000.0)} $unit""" else fmtBigDist(km)
+  val short = if (dist >= 10000) s"""${shortCount(dist.toInt)} ${unitWords.abbr}""" else fmtBigDist(km)
   twoForm(fmtBigDist(km), short)
 }
 

--- a/public/css/pages/user-dashboard.css
+++ b/public/css/pages/user-dashboard.css
@@ -1246,13 +1246,21 @@
 
 /* ---- Leaderboard: community band + podium ---------------------------------------------------------------------- */
 
-/* Five tiles on one line, always (#5175). Each basis is a fifth of what's left once the gaps are paid for, so five
-   exactly fill the row, and `min-width: 0` stops a long value from growing its own tile and pushing a lone widow
-   onto a second row. Two things keep the values inside those fifths, in that order of preference: each swaps to the
-   short form it also renders (1,662,874 → 1.7M) once full figures stop fitting, and only then does the type give
+/* Every tile on one line, always (#5175). Each basis is an equal share of what's left once the gaps are paid for, so
+   they exactly fill the row, and `min-width: 0` stops a long value from growing its own tile and pushing a lone
+   widow onto a second row. Two things keep the values inside their share, in that order of preference: each swaps to
+   the short form it also renders (1,662,874 → 1.7M) once full figures stop fitting, and only then does the type give
    ground. The band is its own container so both rules can measure it directly — its width depends on which of the
-   page shell's three regimes is in play, so the viewport is a poor proxy. */
+   page shell's three regimes is in play, so the viewport is a poor proxy.
+
+   `--band-cols` is how many tiles the band holds, and every share below is computed from it. The leaderboard's has
+   five and the dashboard's cross-city copy has four, so a hardcoded fifth strands the fourth tile alone on a second
+   row at the narrow step — which is the failure this whole rule exists to prevent (#5186). A band that sets neither
+   the variable nor a matching tile count is the one thing that can still go wrong here. */
 .ud-community-band {
+  --band-cols: 5;
+  --band-cols-narrow: 3;
+
   display: flex;
   flex-wrap: wrap;
   container-type: inline-size;
@@ -1267,8 +1275,14 @@
   color: var(--color-neutral-900);
 }
 
+/* The dashboard's cross-city copy of the band carries one tile fewer than the leaderboard's. */
+.ud-cities-band {
+  --band-cols: 4;
+  --band-cols-narrow: 2;
+}
+
 .ud-community-stat {
-  flex: 1 1 calc((100% - 4 * var(--space-lg)) / 5);
+  flex: 1 1 calc((100% - (var(--band-cols) - 1) * var(--space-lg)) / var(--band-cols));
   min-width: 0;
   display: flex;
   flex-direction: column;
@@ -1281,6 +1295,10 @@
 .ud-community-icon {
   height: 56px;
   width: auto;
+
+  /* The tiles carry no intrinsic floor, so an icon wider than its share would paint over the next tile rather than
+     widen its own. The widest today clears the narrowest tile by about 4px; this keeps the next one safe too. */
+  max-width: 100%;
   object-fit: contain;
 }
 
@@ -1296,10 +1314,11 @@
   font-family: var(--font-primary);
 
   /* px, not rem, for the reason given on .ud-impact-value above, and sized off the band (cqi) rather than the
-     viewport so it tracks the width the tiles actually get. The coefficient is "how much of a fifth of the band one
-     value may occupy", derived from the widest short form the tiles can hold; it is not a free parameter, and
-     stat-bands.spec.js fails if it is wrong in either direction. */
-  font-size: clamp(18px, calc(4.8cqi - 5px), 30px);
+     viewport so it tracks the width the tiles actually get. One expression covers every column count: a value may
+     occupy 24% of its own tile, which is what the widest short form the tiles can hold needs. The 5px absorbs the
+     gap the share calculation already paid for. Too large and a figure spills; too small and the numbers are
+     needlessly meek, and only the first of those is something stat-bands.spec.js can fail on. */
+  font-size: clamp(18px, calc(24cqi / var(--band-cols) - 5px), 30px);
   font-weight: 700;
   font-variant-numeric: tabular-nums;
   line-height: 1.1;
@@ -1315,8 +1334,9 @@
   display: none;
 }
 
-/* Where five full figures no longer fit their fifth of the band, show the short forms instead of shrinking the type
-   to suit the longest number anyone might one day reach. The full figure is only hidden visually. */
+/* Where a row of full figures outgrows the shares it has to sit in, show the short forms instead of shrinking the
+   type to suit the longest number anyone might one day reach. The full figure is only hidden visually. The threshold
+   is the five-tile band's; a four-tile one gets wider shares and so abbreviates a little earlier than it must. */
 @container (width < 1000px) {
   .ud-community-value .ud-value-full {
     position: absolute;
@@ -1332,15 +1352,14 @@
   }
 }
 
-/* Narrower than this even five short forms are illegible, so the row becomes 3 + 2 — two tiles on the last line
-   rather than the lone one that reads as a mistake. */
+/* Narrower than this even the short forms are illegible across a full row, so the band drops to `--band-cols-narrow`
+   per line: five tiles go 3 + 2 and four go 2 + 2. Neither leaves the lone tile that reads as a mistake, which is why
+   this is a per-band number rather than one divisor — three columns would strand the fourth tile of a four-tile band.
+   The count is overridden on the tiles rather than the band because a container cannot restyle itself; the value's
+   type inherits it from there. */
 @container (width < 470px) {
   .ud-community-stat {
-    flex-basis: calc((100% - 2 * var(--space-lg)) / 3);
-  }
-
-  .ud-community-value {
-    font-size: clamp(18px, calc(8cqi - 4px), 30px);
+    --band-cols: var(--band-cols-narrow);
   }
 }
 
@@ -1348,11 +1367,7 @@
    own. One per line is the other shape with no odd tile out, and it buys back the full type size. */
 @container (width < 265px) {
   .ud-community-stat {
-    flex-basis: 100%;
-  }
-
-  .ud-community-value {
-    font-size: clamp(18px, calc(24cqi - 4px), 30px);
+    --band-cols: 1;
   }
 }
 
@@ -2056,7 +2071,7 @@
   font: var(--text-small-regular);
 }
 
-/* `.ud-community-band` sets `display: grid`, which outranks the UA's `[hidden] { display: none }` — so a band the
+/* `.ud-community-band` sets a `display` that outranks the UA's `[hidden] { display: none }` — so a band the
  * script hasn't filled in yet would render as a row of empty stat labels. */
 .ud-community-band[hidden] { display: none; }
 

--- a/public/js/user-dashboard/CrossCityStats.js
+++ b/public/js/user-dashboard/CrossCityStats.js
@@ -341,8 +341,12 @@ class CrossCityStats {
 
   /**
    * Fills a community-band tile with a figure in both the forms the band's CSS can choose between: the exact one,
-   * which always carries the accessible reading, and a short one for widths too narrow to seat five exact figures
-   * across the row. Both are built here from numbers we formatted ourselves, so there is no caller text to escape.
+   * which always carries the accessible reading, and a short one for widths too narrow to seat a full row of exact
+   * figures.
+   *
+   * Built as elements rather than markup: a distance's unit is a translated Messages value, so these strings are not
+   * all ours to trust, and textContent keeps this method inside the escaping rule the rest of the file follows. It
+   * also leaves no whitespace around the figure, which `white-space: nowrap` would otherwise carry into a selection.
    *
    * @param {string} id - Element id of the tile's `.ud-community-value`.
    * @param {string} full - The exact figure, e.g. "1,234,567".
@@ -355,9 +359,14 @@ class CrossCityStats {
       el.textContent = full;
       return;
     }
-    el.innerHTML = `
-      <span class="ud-value-full">${full}</span><span class="ud-value-short" aria-hidden="true">${short}</span>
-    `;
+    const fullSpan = document.createElement('span');
+    fullSpan.className = 'ud-value-full';
+    fullSpan.textContent = full;
+    const shortSpan = document.createElement('span');
+    shortSpan.className = 'ud-value-short';
+    shortSpan.setAttribute('aria-hidden', 'true');
+    shortSpan.textContent = short;
+    el.replaceChildren(fullSpan, shortSpan);
   }
 
   /**
@@ -369,8 +378,13 @@ class CrossCityStats {
    */
   static #shortNum(n) {
     const v = Number(n || 0);
-    if (v >= 1000000) return `${(v / 1000000).toLocaleString(undefined, { maximumFractionDigits: 1 })}M`;
-    if (v >= 10000) return `${Math.round(v / 1000).toLocaleString()}k`;
+    // Rounding picks the tier, so 999,999 reads "1.0M" rather than a "1000k" that claims not to be a million. The
+    // digits match leaderboard.scala.html's shortCount exactly -- one decimal at M, none and ungrouped at k --
+    // because the two feed the same band and its type is sized to the character count.
+    const thousands = Math.round(v / 1000);
+    const oneDecimal = { minimumFractionDigits: 1, maximumFractionDigits: 1 };
+    if (thousands >= 1000) return `${(v / 1000000).toLocaleString(undefined, oneDecimal)}M`;
+    if (v >= 10000) return `${thousands}k`;
     return CrossCityStats.#num(v);
   }
 
@@ -436,7 +450,7 @@ class CrossCityStats {
    */
   static #shortDist(floored, unit) {
     if (floored < 10000) return CrossCityStats.#fmtDist(floored, unit);
-    return `${Math.round(floored / 1000).toLocaleString()}k ${unit || ''}`.trim();
+    return `${CrossCityStats.#shortNum(floored)} ${unit || ''}`.trim();
   }
 
   /** Localized month-and-year for a last-labeled timestamp, or a dash when the mapper only validated there. */

--- a/test/e2e/stat-bands.spec.js
+++ b/test/e2e/stat-bands.spec.js
@@ -130,6 +130,19 @@ const BANDS = [
         ],
       },
       {
+        // The dashboard's cross-city band is this one with a tile removed. Hardcoding five columns strands that
+        // fourth tile at the narrow step (#5186), which is the failure the band's whole rule exists to prevent.
+        name: 'four tiles, as the dashboard renders them',
+        drop: 1,
+        bandClass: 'ud-cities-band',
+        stats: [
+          ['12', 'Cities'],
+          ['1,234,567', 'Labels', '1.2M'],
+          ['2,345,678', 'Validations', '2.3M'],
+          ['12,345.6 km', 'Distance', '12k km'],
+        ],
+      },
+      {
         name: 'longest German captions',
         stats: [
           ['19.343', 'Mitwirkende', '19k'],
@@ -142,6 +155,23 @@ const BANDS = [
     ],
   },
 ];
+
+/**
+ * Reshapes the band into a variant another page renders, so one page can stand in for both. Removing tiles and
+ * adding the variant's own class is what exercises the real rule rather than a hand-set column count.
+ *
+ * @param {import('@playwright/test').Page} page - The loaded page.
+ * @param {Object} selectors - The band's `band` and `item` selectors.
+ * @param {Object} scenario - Its `drop` (tiles to remove from the end) and `bandClass` (class the variant carries).
+ */
+async function applyShape(page, selectors, scenario) {
+  if (!scenario.drop) return;
+  await page.evaluate(({sel, drop, cls}) => {
+    const band = document.querySelector(sel.band);
+    if (cls) band.classList.add(cls);
+    [...band.querySelectorAll(sel.item)].slice(-drop).forEach((el) => el.remove());
+  }, {sel: selectors, drop: scenario.drop, cls: scenario.bandClass});
+}
 
 /**
  * Replaces every stat's value and caption, so the band is measured against known worst-case content.
@@ -224,9 +254,14 @@ function bandCollisions(page, selectors) {
     // getBoundingClientRect reports the border box whatever box-sizing says, and both bands pad their sides with no
     // border-box reset in scope — so the padding has to come off, or that much encroachment goes unreported.
     const box = band.getBoundingClientRect();
-    const contentRight = box.right - parseFloat(getComputedStyle(band).paddingRight);
-    const overflow = Math.max(0, ...items.flatMap((it) => [it.number.right - contentRight,
-      it.label.right - contentRight]));
+    const style = getComputedStyle(band);
+    const contentRight = box.right - parseFloat(style.paddingRight);
+    const contentLeft = box.left + parseFloat(style.paddingLeft);
+    // Both edges: these tiles are centred, so a value too wide for its share hangs off either side of the band.
+    const overflow = Math.max(0, ...items.flatMap((it) => [
+      it.number.right - contentRight, contentLeft - it.number.left,
+      it.label.right - contentRight, contentLeft - it.label.left,
+    ]));
 
     // How the tiles fall into rows, so a band that promises five-across can be held to it.
     const tops = [...band.querySelectorAll(sel.item)].map((el) => Math.round(el.getBoundingClientRect().top));
@@ -247,6 +282,7 @@ for (const band of BANDS) {
           }));
         }
         await loadAndSettle(page, context, band.page);
+        await applyShape(page, band.selectors, scenario);
         await setStats(page, band.selectors, scenario.stats);
 
         // Either form of a figure is a legitimate thing to measure; anything else means the band stopped holding


### PR DESCRIPTION
Fixes #5186. Follow-up to #5169, from the post-merge Opus 5 review pass ([findings](https://github.com/ProjectSidewalk/SidewalkWebpage/pull/5169#issuecomment-5547035913)).

## The bug #5169 introduced

That PR taught `.ud-community-band` to keep all its tiles on one line — but wrote the rule against the **leaderboard's five** and hardcoded five into the flex basis and the narrow step's divisor. The band has a second consumer: the dashboard's cross-city section renders **four** tiles into the same class.

```
$ grep -c 'class="ud-community-stat"' app/views/userDashboard/dashboard.scala.html
4
$ grep -c 'class="ud-community-stat"' app/views/userDashboard/leaderboard.scala.html
5
```

Four tiles divided by three lay out **3 + 1** at every band width from **265 to 469px** — a lone stranded tile, which is exactly the failure the rule exists to prevent. That range is reachable: the band measures 390px at a 1024px viewport and 308px at 390px.

I designed and measured the whole thing against the five-tile band and never checked the other consumer.

## Fix

`--band-cols` (5, or 4 on `.ud-cities-band`) drives every share, with `--band-cols-narrow` for the step below — five go 3 + 2, four go 2 + 2. That has to be per-band rather than one divisor, since which shape leaves no odd tile out depends on the count. The variable is overridden on the tiles rather than the band, because a container can't restyle itself.

**The type coefficient collapses into the same variable.** Its three hand-fitted pairs (`4.8cqi - 5px`, `8cqi - 4px`, `24cqi - 4px`) were all one rule — a value may occupy 24% of its tile — so `24cqi / var(--band-cols) - 5px` states it once and is correct for any column count, including the four-tile band that previously got fifths. That also answers the review's fair complaint that the offsets read as unexplained magic.

## Also fixed

| | |
|---|---|
| `999,500`–`999,999` rendered **"1000k"** | Reads as a million while claiming not to be one. Both halves now pick the tier *after* rounding. |
| Twirl and JS short forms disagreed | `1M` vs `1.0M`, `1,308k` vs `1308k` — they fill the same band, whose type is sized to the character count. Now one contract. |
| `#setBandValue` interpolated into `innerHTML` | The file states everything is escaped or goes via textContent, and a distance's unit is a translated Messages value. Builds elements now; `twoForm` escapes for the same reason. Also removes the stray whitespace the template literal put either side of the figure. |
| Icons had no `max-width` | Tiles carry no intrinsic floor and the widest icon clears the narrowest tile by ~4px. A cities icon is still to be sourced. |
| A comment said `display: grid` | The band is flex. |

## Test

`stat-bands.spec.js` gains the case that would have caught this: the band reshaped to four tiles with `.ud-cities-band`, as the dashboard renders it. Verified both directions —

```
against the merged CSS:  ✘ Error: at 1024px the band wraps 3+1, stranding one tile
with this fix:           ✓ 8 passed
```

Overflow is now measured on **both** edges too; the tiles are centred, so a value too wide for its share hangs off either side, and the old right-edge-only check could miss it.

## Not changed

The review also noted the full→short swap fires at 1000px though exact figures fit to ~840px, so a 1440–1600px laptop shows `1.7M` where `1,662,874` would fit. That's deliberate headroom for growth (at ten-digit counts the true fit point rises to ~1000px) and a visible-precision judgement call rather than a defect — worth @jonfroehlich's eye, but left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 5 (1M context), claude-opus-5[1m]
