### PR TITLE
Move the last of the city-onboarding runbook out of the wiki (#4291)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,8 +186,8 @@ Full gating policy and rationale: [`docs/testing-and-ci.md`](docs/testing-and-ci
 
 - **In this repo:** [`README.md`](README.md), [`CONTRIBUTING.md`](CONTRIBUTING.md), [`SECURITY.md`](SECURITY.md),
   [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md), [`CLAUDE.md`](CLAUDE.md), and guides under [`docs/`](docs/).
-- **In the [wiki](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki):** operational runbooks, city-deployment
-  guidance, and visual/GIS tutorials.
+- **In the [wiki](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki):** the partner-facing deployment
+  considerations and the few operational how-tos for a running deployment that haven't moved into `docs/` yet.
 
 If you change behavior a doc describes, update the doc in the same PR.
 

--- a/README.md
+++ b/README.md
@@ -79,12 +79,14 @@ guide: **[`docs/dev-environment.md`](docs/dev-environment.md)**.
 **Developer documentation lives in this repository** — versioned with the code, reviewed in pull requests, and
 searchable by tooling (and AI assistants). That includes how code ships: cutting a release and the deployment stages
 are in [`docs/deployment-and-stages.md`](docs/deployment-and-stages.md). The
-[**wiki**](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki) holds **city-deployment and GIS data preparation**
-(building a new city's database, road geometries, revealing and hiding regions), and other **operational how-tos and
-visual tutorials** — content that changes independently of the code or is maintained by non-developers.
+Onboarding a city — streets, regions, schema, configs — is in the repo too, in
+[`docs/onboarding-a-city.md`](docs/onboarding-a-city.md), because tooling in this repo does it. The
+[**wiki**](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki) is being wound down to what changes independently
+of the code or is maintained by non-developers: the partner-facing deployment considerations and a few **operational
+how-tos** for a running deployment (adding road geometries after launch, revealing and hiding regions).
 
-Rule of thumb: *if it describes the code, how to contribute, or how the code gets deployed, it's in the repo; if it's
-about preparing a new city's data or operating a running deployment's content, it's in the wiki.* We keep one source of
+Rule of thumb: *if it describes the code, how to contribute, how the code gets deployed, or how a city gets set up,
+it's in the repo; if it's about operating a running deployment's content, it's in the wiki.* We keep one source of
 truth per topic and cross-link rather than duplicate.
 
 ## AI in Project Sidewalk

--- a/docs/onboarding-a-city.md
+++ b/docs/onboarding-a-city.md
@@ -1,8 +1,11 @@
 # Onboarding a city
 
 How a new deployment goes from "we'd like Project Sidewalk in X" to a schema on the server, using the tooling in this
-repo. It replaces the wiki's QGIS-by-hand runbook for everything but the visual QA, and takes an afternoon rather
-than days (#4291). The `onboard-city` Claude Code skill drives this same sequence with the judgment calls filled in.
+repo. It replaces the QGIS-by-hand runbook that used to live in the wiki for everything but the visual QA, and takes
+an afternoon rather than days (#4291); the retired runbook's last revision stays readable in the
+[wiki page's history](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Creating-database-for-a-new-city/fdd8da7)
+for the manual QGIS steps. The `onboard-city` Claude Code skill drives this same sequence with the judgment calls
+filled in.
 
 ```
 make build-city-data id=<city-id> args="..."          # 1. streets + regions → db/onboarding/<city-id>/  (minutes)
@@ -144,10 +147,29 @@ where a person is needed and skips whatever a previous run already did:
   and clears the donor's `mapathon_event_link`. Check them before launch.
 - **Visual QA.** Land on the site as the new city (`SIDEWALK_CITY_ID` + `DATABASE_USER` in
   `docker-compose.override.yml`, recreate the container): the map centers on the city, neighborhood names read right,
-  one street walks in Explore on the chosen imagery, the Explore tag lists match `excluded_tags`.
+  one street walks in Explore on the chosen imagery, the Explore tag lists match `excluded_tags`. Two things the
+  first visit needs: sign in **before** switching the dev env to the new city — from a dev env pointed at an existing
+  city — so that whatever your testing logs is attributed to a user that already exists in the production
+  `sidewalk_login`; and if the landing map needs a different zoom, edit `config.default_map_zoom` and clear the Play
+  cache from the admin page (it caches the config row), the same after hiding streets on a live server, since the
+  total street distance behind the completion percentage is cached too.
 - **Server.** `scp db/<schema>-dump makelab1.cs.washington.edu:/www/sidewalk/new-city-dumps/`, then the IT tooling
   (`uwcseit-sidewalk-tools`: `bin/setup-new.pl`, test stage first), the Maps-key referrers for both URLs
-  (`docs/google-cloud.md`), DNS, and the PR with the config, message, and docs changes.
+  (`docs/google-cloud.md`), DNS, and the PR with the config, message, and docs changes. Where the tooling can't be
+  used, the fallback is an email to CS support asking for the test and prod servers, with both URLs, any redirect
+  from an older name, `SIDEWALK_CITY_ID`, and `DATABASE_USER`.
+
+## Optional follow-ups
+
+- **Pano scraper**, only when the deployment is also a computer-vision dataset: once prod is up, create the city's
+  directory under `sidewalk_panos/Panoramas/<city-id>` on the panorama store, seed it with a `log.csv` carrying the
+  same headers as the other cities' scraper logs (no trailing newline), and add a crontab entry for the city on the
+  scraper host, copied from another city's and spaced out to a different hour. Mikey holds the access to both.
+- **Uptime monitoring.** In [Uptime Robot](https://uptimerobot.com/), add an HTTP(s) monitor at a 5-minute interval
+  on the `/signIn` endpoint of each stage (e.g. `https://sidewalk-<city>-test.cs.washington.edu/signIn`).
+- **A launch limited to an arbitrary boundary** (streets around transit stations, say) has no tooling: phased launches
+  are by region (`include:`/`exclude:` at fill time, `make reveal-or-hide-neighborhoods` later). The retired runbook's
+  hand recipe for it is in the wiki page history linked above, but it predates `street_edge.status`.
 
 ## Re-running, and doing it by hand
 

--- a/scripts/onboard_city.py
+++ b/scripts/onboard_city.py
@@ -3,7 +3,7 @@ Builds a new city's street + region data (the ``qgis_road`` / ``qgis_region`` st
 replacing the manual QGIS pipeline for the repeatable parts of city onboarding (issue #4291).
 
 This is a standalone, manually-run utility (it is not invoked by the app). It automates the deterministic ~90% of the
-"Creating database for a new city" wiki workflow — data acquisition, filtering, splitting, clipping, and id
+retired "Creating database for a new city" QGIS runbook — data acquisition, filtering, splitting, clipping, and id
 assignment — while keeping a human in the loop for visual QA: the script never writes to the database. It emits a
 GeoPackage to eyeball in QGIS plus a SQL file that loads the two staging tables, and loading that SQL is a separate,
 deliberate step.
@@ -58,8 +58,8 @@ becomes ``street_edge_id``, ``geom`` LineString 4326 pre-split at intersections,
 
 Street semantics vs. the manual QGIS flow:
 
-  * The highway filter is the same one the wiki prescribes (trunk/primary/secondary/tertiary/residential/unclassified/
-    pedestrian/living_street, plus ``service``+``service=alley`` with ``--include-alleys``).
+  * The highway filter is the one the retired QGIS runbook prescribed (trunk/primary/secondary/tertiary/residential/
+    unclassified/pedestrian/living_street, plus ``service``+``service=alley`` with ``--include-alleys``).
   * osmnx returns the graph already noded at intersections, but only at *shared OSM nodes within the filtered
     network*: excluded way types don't cause splits, and grade-separated crossings (overpasses) share no node so —
     unlike QGIS "Split with lines", which splits at any geometric crossing — they correctly stay unsplit. Its
@@ -70,7 +70,7 @@ Street semantics vs. the manual QGIS flow:
     arcs, the stubs between a dual carriageway's links — are merged back into a touching piece of the *same* OSM way
     (#4717 tier 1), never closing a ring. On Bayonne this took sub-20 m streets from 27% to 16% of the network, in
     line with the production average.
-  * Streets are additionally split at region boundaries by the region-assignment overlay (same as the wiki's
+  * Streets are additionally split at region boundaries by the region-assignment overlay (same as the runbook's
     "Intersection" step). A region boundary that runs *along* a street (census tract boundaries usually follow
     street centerlines) would shred it into fragments alternating between the two regions, so a healing pass
     reabsorbs fragments shorter than ``--heal-segment-m`` into their touching neighbor on the same street (which
@@ -84,7 +84,7 @@ Street semantics vs. the manual QGIS flow:
     *along* the boundary rather than across it — one side lying entirely within ``--boundary-merge-tol-m`` of the
     other side's region — so a boundary-running road split midway comes back as one street (genuine crossings pull
     away from the boundary and keep their split; merged junctions land in the ``rider_merges`` QA layer). Whatever
-    is still shorter than ``--min-segment-m`` after healing is dropped (the wiki's manual "delete tiny segments"
+    is still shorter than ``--min-segment-m`` after healing is dropped (the runbook's manual "delete tiny segments"
     pass) — kept in the QA GeoPackage's ``dropped_segments`` layer for review.
 
 The decision logic lives in pure, import-safe functions; network and file I/O live in the ``fetch_*``/``write_*``
@@ -121,7 +121,7 @@ def _osmnx():
     ox.settings.cache_folder = str(REPO_ROOT / 'db' / 'onboarding' / 'osmnx-cache')
     return ox
 
-# The way types we audit — the same filter the manual QGIS flow applies (wiki: "Creating database for a new city").
+# The way types we audit — the same filter the manual QGIS flow applies (the retired QGIS runbook).
 # Every value is a label of the DB's way_type enum, so fill-new-schema.sh's ::way_type cast can't fail.
 DEFAULT_WAY_TYPES = (
     'trunk', 'primary', 'secondary', 'tertiary', 'residential', 'unclassified', 'pedestrian', 'living_street'
@@ -531,7 +531,7 @@ def restore_boundary_tails(edge_geom, pieces, buffered_coverage):
     inside). When such a missing end lies entirely within the buffered coverage — the rides-the-boundary test of
     :func:`absorb_boundary_riders`, with outside-the-city as the "other side" — it is recovered from the original
     edge geometry and welded onto the adjacent piece. An end that pulls away from the covered area genuinely leaves
-    the city and stays truncated. (This automates the wiki's manual advice to nudge boundary polygons outward so
+    the city and stays truncated. (This automates the runbook's advice to nudge boundary polygons outward so
     they fully capture parallel streets.)
 
     Args:
@@ -1244,7 +1244,7 @@ def assign_regions(streets, regions, min_segment_m, heal_m, boundary_merge_tol_m
     """
     Splits streets at region boundaries, tags each piece with its ``region_id``, and assigns road ids.
 
-    This is the wiki's "Intersection" geoprocessing step (pieces outside every region are trimmed away) followed by a
+    This is the runbook's "Intersection" geoprocessing step (pieces outside every region are trimmed away) followed by a
     healing pass: out-of-region gaps and truncated ends are restored from the original street geometry when short or
     riding the boundary of the covered area (:func:`bridge_short_gaps` / :func:`restore_boundary_tails` — a street
     hugging the city boundary stays whole rather than losing mid-block chunks or its ends), and fragments shorter


### PR DESCRIPTION
Follow-up to #5203 (references #4291).

The wiki page ["Creating database for a new city"](https://github.com/ProjectSidewalk/SidewalkWebpage/wiki/Creating-database-for-a-new-city) is now a stub pointing at `docs/onboarding-a-city.md` (wiki commit 4f381bf; its last full revision stays linked for the manual QGIS steps), and the wiki sidebar links the repo doc. This PR moves into the doc what that page still held and the tooling doesn't cover, and updates the places that described the wiki as the home of city onboarding.

## Changes

- **`docs/onboarding-a-city.md`**
  - Visual QA: sign in from a dev env pointed at an existing city *before* switching to the new one, so test logs belong to a user that exists in the production `sidewalk_login`; clear the Play cache after tuning `default_map_zoom` and after hiding streets on a live server (both are cached).
  - Server: the CS-support email as the fallback when the IT tooling can't be used.
  - New "Optional follow-ups": pano-scraper setup (when the deployment is also a CV dataset), Uptime Robot monitors, and a note that arbitrary-boundary launches have no tooling (phased launches are by region).
  - Links the retired runbook's last wiki revision.
- **README / CONTRIBUTING**: the wiki is described as what it is becoming — the partner-facing deployment considerations plus the few operational how-tos for a running deployment that haven't moved yet (adding road geometries, revealing/hiding regions); city onboarding is in the repo.
- **`scripts/onboard_city.py`**: docstrings cite "the retired QGIS runbook" instead of the wiki page (which no longer holds the steps).

Docs and docstrings only; `test_onboard_city.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Fable 5.1, claude-fable-5-1
