### PR TITLE
Store each Panoramax picture's licence, and credit the imagery wherever we render it ourselves

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,7 @@ public/js/ps-map/build/*
 public/js/route-builder/build/*
 public/js/shared-label/build/*
 public/js/common/pano-viewer/build/*
+public/js/common/pano-credit/build/*
 # Bundles written to the pre-#2292 asset layout by an out-of-date Gruntfile; the paths are dead but a stale
 # checkout can still regenerate them, and they'd otherwise slip past the public/js/*/build/* rules above.
 public/javascripts/

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -147,6 +147,15 @@ module.exports = function (grunt) {
           'public/js/common/pano-viewer/src/PanoInfoPopover.js'
         ],
         dest: 'public/js/common/pano-viewer/build/pano-viewer.js'
+      },
+      // The imagery-credit overlays alone, for a page with stills but no viewer (the landing grid, #5202). Neither
+      // file may reference a viewer class — that is what lets them stand alone. A page loads one bundle or the other.
+      dist_pano_credit: {
+        src: [
+          'public/js/common/pano-viewer/src/PanoViewerLogo.js',
+          'public/js/common/pano-viewer/src/PanoAttribution.js'
+        ],
+        dest: 'public/js/common/pano-credit/build/pano-credit.js'
       }
     },
     concat_css: {

--- a/app/formats/json/ExploreFormats.scala
+++ b/app/formats/json/ExploreFormats.scala
@@ -100,6 +100,8 @@ object ExploreFormats {
       cameraRoll: Option[Double],
       links: Seq[PanoLinkSubmission],
       copyright: Option[String],
+      // The licence identifier the imagery provider records per picture. Panoramax only (#5202).
+      license: Option[String],
       address: Option[String],
       history: Seq[PanoDate],
       // Verbatim imagery-provider metadata blob; sent by the AI labeler only, never by the Explore client (#4806).
@@ -310,6 +312,7 @@ object ExploreFormats {
       (JsPath \ "camera_roll").readNullable[Double] and
       (JsPath \ "links").read[Seq[PanoLinkSubmission]] and
       (JsPath \ "copyright").readNullable[String] and
+      (JsPath \ "license").readNullable[String] and
       (JsPath \ "address").readNullable[String] and
       (JsPath \ "history").read[Seq[PanoDate]] and
       (JsPath \ "source_metadata").readNullable[JsObject](sourceMetadataReads)

--- a/app/formats/json/LabelFormats.scala
+++ b/app/formats/json/LabelFormats.scala
@@ -275,7 +275,7 @@ object LabelFormats {
     "camera_pitch"   -> pm.cameraPitch,
     "camera_roll"    -> pm.cameraRoll,
     "copyright"      -> pm.copyright,
-    "attribution"    -> ImageryAttribution.line(source, pm.copyright).map(_.toJson),
+    "attribution"    -> ImageryAttribution.line(source, pm.copyright, pm.license).map(_.toJson),
     "address"        -> pm.address
   )
 
@@ -299,7 +299,7 @@ object LabelFormats {
       "cameraRoll"    -> p.cameraRoll,
       "captureDate"   -> p.captureDate,
       "copyright"     -> p.copyright,
-      "attribution"   -> ImageryAttribution.line(p.source, p.copyright).map(_.toJson),
+      "attribution"   -> ImageryAttribution.line(p.source, p.copyright, p.license).map(_.toJson),
       "address"       -> p.address
     )
   }

--- a/app/formats/json/LabelFormats.scala
+++ b/app/formats/json/LabelFormats.scala
@@ -126,9 +126,9 @@ object LabelFormats {
       "from_current_user"   -> labelMetadata.fromCurrentUser,
       "backup_image_url"    -> backupImageUrl,
       // Per label, not per city: a city that has changed providers holds labels from both (#5202).
-      "pano_source"         -> labelMetadata.panoSource.toString,
-      "pano_data"           -> labelMetadata.panoMetadata.map(panoViewerMetadataToJson(_, labelMetadata.panoSource)),
-      "admin_data"          -> adminData.map(ad =>
+      "pano_source" -> labelMetadata.panoSource.toString,
+      "pano_data"   -> labelMetadata.panoMetadata.map(panoViewerMetadataToJson(_, labelMetadata.panoSource)),
+      "admin_data"  -> adminData.map(ad =>
         Json.obj(
           "username"             -> ad.username,
           "previous_validations" -> ad.previousValidations.map(prevVal =>

--- a/app/formats/json/LabelFormats.scala
+++ b/app/formats/json/LabelFormats.scala
@@ -125,6 +125,8 @@ object LabelFormats {
       "comments"            -> labelMetadata.comments.map(commentToJson(_, currUsername, commenterIdx)),
       "from_current_user"   -> labelMetadata.fromCurrentUser,
       "backup_image_url"    -> backupImageUrl,
+      // Per label, not per city: a city that has changed providers holds labels from both (#5202).
+      "pano_source"         -> labelMetadata.panoSource.toString,
       "pano_data"           -> labelMetadata.panoMetadata.map(panoViewerMetadataToJson(_, labelMetadata.panoSource)),
       "admin_data"          -> adminData.map(ad =>
         Json.obj(

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -424,8 +424,9 @@ object LabelTable {
           Option[Double],
           Option[Double],
           Option[String],
+          Option[String],
           Option[String]
-      ) // 22. pano dims, camera & address
+      ) // 22. pano dims, camera, attribution & address
   )
   type LabelValidationMetadataTupleRep = (
       Rep[Int],                                   // 1.  labelId
@@ -456,7 +457,7 @@ object LabelTable {
       Rep[Boolean],                               // 19. aiGenerated
       Rep[Option[String]],                        // 20. comments (JSON-aggregated)
       Rep[Boolean],                               // 21. fromCurrentUser
-      (                                           // 22. pano dims, camera & address
+      (                                           // 22. pano dims, camera, attribution & address
           Rep[Option[Int]],                       // 1. width
           Rep[Option[Int]],                       // 2. height
           Rep[Option[Int]],                       // 3. tileWidth
@@ -465,7 +466,8 @@ object LabelTable {
           Rep[Option[Double]],                    // 6. cameraPitch
           Rep[Option[Double]],                    // 7. cameraRoll
           Rep[Option[String]],                    // 8. copyright
-          Rep[Option[String]]                     // 9. address
+          Rep[Option[String]],                    // 9. license
+          Rep[Option[String]]                     // 10. address
       )
   )
 
@@ -514,7 +516,8 @@ object LabelTable {
         comments = t._20.map(parseCommentsJson).getOrElse(Seq.empty),
         fromCurrentUser = t._21,
         panoMetadata = Some(
-          PanoViewerMetadata(t._22._1, t._22._2, t._22._3, t._22._4, t._22._5, t._22._6, t._22._7, t._22._8, t._22._9)
+          PanoViewerMetadata(t._22._1, t._22._2, t._22._3, t._22._4, t._22._5, t._22._6, t._22._7, t._22._8, t._22._9,
+            t._22._10)
         )
       )
     }
@@ -757,6 +760,7 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
           r.nextDoubleOption(), // cameraPitch
           r.nextDoubleOption(), // cameraRoll
           r.nextStringOption(), // copyright
+          r.nextStringOption(), // license
           r.nextStringOption()  // address
         )
       ),
@@ -1158,6 +1162,7 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
              pano_data.camera_pitch,
              pano_data.camera_roll,
              pano_data.copyright,
+             pano_data.license,
              pano_data.address,
              pano_data.source
       FROM label AS lb1
@@ -1383,7 +1388,7 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
           None.asInstanceOf[Option[String]].asColumnOf[Option[String]], // Comments not needed for validation rn.
           false.bind,
           (pd.width, pd.height, pd.tileWidth, pd.tileHeight, pd.cameraHeading, pd.cameraPitch, pd.cameraRoll,
-            pd.copyright, pd.address)
+            pd.copyright, pd.license, pd.address)
         )
       }
 
@@ -1534,7 +1539,7 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
       comments.flatMap(_.comments), // pre-aggregated comments string from VIEW
       lb.userId === userId.bind,
       (pd.width, pd.height, pd.tileWidth, pd.tileHeight, pd.cameraHeading, pd.cameraPitch, pd.cameraRoll, pd.copyright,
-        pd.address)
+        pd.license, pd.address)
     )
 
     // Remove duplicates if needed, then order newest-first or randomized. Callers that batch through this query

--- a/app/models/pano/ImageryAttribution.scala
+++ b/app/models/pano/ImageryAttribution.scala
@@ -9,16 +9,42 @@ import play.api.libs.json.{JsObject, Json}
  *
  * Mapillary imagery is CC BY-SA 4.0: redistribution is permitted with visible attribution, so the line names the
  * contributor (`pano_data.copyright` holds the bare Mapillary username), the provider and the licence. Panoramax
- * imagery is open too, but under a licence its contributor picks per picture (CC BY-SA 4.0, CC BY 4.0 or
- * etalab 2.0), and `pano_data` records no licence, so the line names the producer and Panoramax and stops there.
- * Google's and infra3d's imagery carries the copyright string the provider supplied, which is the whole of what
- * they ask shown.
+ * imagery is open too, but under a licence its contributor picks per picture, so the licence comes from
+ * `pano_data.license` rather than from the source (#5202). Google's and infra3d's imagery carries the copyright
+ * string the provider supplied, which is the whole of what they ask shown.
  */
 object ImageryAttribution {
 
   /** The Mapillary licence, and where its text lives. */
   val MapillaryLicense: String    = "CC BY-SA 4.0"
   val MapillaryLicenseUrl: String = "https://creativecommons.org/licenses/by-sa/4.0/"
+
+  /**
+   * A licence as it should read on screen, and where its text lives.
+   *
+   * @param name The licence's short display name, e.g. `CC BY-SA 4.0`.
+   * @param url  Where that licence's text lives.
+   */
+  case class License(name: String, url: String)
+
+  /**
+   * The licence identifiers Panoramax uses, mapped to how we show them. Not exhaustive by construction: an instance
+   * may record any identifier, and one that isn't here is shown verbatim rather than dropped.
+   *
+   * This is the only copy. `main.scala.html` stamps [[panoramaxLicensesJson]] onto the page as
+   * `window.panoramaxLicenses` so `PanoramaxViewer` can render the live viewer's overlay from the same table
+   * (#5202) — change it here and both follow.
+   */
+  val PanoramaxLicenses: Map[String, License] = Map(
+    "CC-BY-SA-4.0" -> License("CC BY-SA 4.0", "https://creativecommons.org/licenses/by-sa/4.0/"),
+    "CC-BY-4.0"    -> License("CC BY 4.0", "https://creativecommons.org/licenses/by/4.0/"),
+    "etalab-2.0"   -> License("Licence Ouverte 2.0", "https://www.etalab.gouv.fr/licence-ouverte-open-licence/")
+  )
+
+  /** [[PanoramaxLicenses]] as the `{id: {name, url}}` object the page stamp hands to `PanoramaxViewer`. */
+  val panoramaxLicensesJson: String = Json.stringify(
+    JsObject(PanoramaxLicenses.view.mapValues(l => Json.obj("name" -> l.name, "url" -> l.url)).toSeq)
+  )
 
   /**
    * One attribution, structured so the UI can link the licence without knowing which providers carry one.
@@ -44,12 +70,14 @@ object ImageryAttribution {
   /**
    * @param source    Where the imagery came from.
    * @param copyright The provider's copyright string for the pano, as `pano_data.copyright` stores it.
+   * @param license   The licence identifier recorded for the pano, as `pano_data.license` stores it. Only Panoramax
+   *                  records one; Mapillary's is uniform and known from `source`, and the other providers have none.
    * @return          The attribution to show beside the imagery, or None when nothing is known to attribute. For
    *                  Mapillary the provider and the licence are known from `source` alone, so a pano with no recorded
    *                  contributor is still credited to Mapillary under its licence; likewise a Panoramax pano is
    *                  credited to Panoramax whether or not its producer was recorded.
    */
-  def line(source: PanoSource, copyright: Option[String]): Option[Line] = {
+  def line(source: PanoSource, copyright: Option[String], license: Option[String]): Option[Line] = {
     val recorded = copyright.map(_.trim).filter(_.nonEmpty)
     source match {
       case PanoSource.Mapillary =>
@@ -61,14 +89,17 @@ object ImageryAttribution {
             Some(MapillaryLicenseUrl)
           )
         )
-      // The licence is deliberately absent rather than guessed: it varies per picture and nothing stores it (#5202).
+      // An unrecognized identifier is still named, unlinked: identifying the licence is what CC BY-SA asks for, and a
+      // raw `etalab-2.0` does that where saying nothing does not. A pano recorded before #5202 has none to name.
       case PanoSource.Panoramax =>
+        val recordedLicense = license.map(_.trim).filter(_.nonEmpty)
+        val known           = recordedLicense.flatMap(PanoramaxLicenses.get)
         Some(
           Line(
             recorded.map(holder => s"© $holder").getOrElse("Panoramax"),
             recorded.map(_ => "Panoramax"),
-            None,
-            None
+            known.map(_.name).orElse(recordedLicense),
+            known.map(_.url)
           )
         )
       case _ => recorded.map(Line(_, None, None, None))

--- a/app/models/pano/PanoDataTable.scala
+++ b/app/models/pano/PanoDataTable.scala
@@ -23,6 +23,7 @@ case class PanoViewerMetadata(
     cameraPitch: Option[Double],
     cameraRoll: Option[Double],
     copyright: Option[String],
+    license: Option[String],
     address: Option[String]
 )
 
@@ -34,6 +35,9 @@ case class PanoData(
     tileHeight: Option[Int],
     captureDate: String,
     copyright: Option[String],
+    // The licence the imagery is shared under, when the provider records one per picture. Panoramax only (#5202);
+    // Mapillary's is uniform and known from `source`, and the other providers publish a copyright string instead.
+    license: Option[String],
     lat: Option[Double],
     lng: Option[Double],
     cameraHeading: Option[Double],
@@ -112,6 +116,7 @@ class PanoDataTableDef(tag: Tag) extends Table[PanoData](tag, "pano_data") {
   def tileHeight: Rep[Option[Int]]       = column[Option[Int]]("tile_height")
   def captureDate: Rep[String]           = column[String]("capture_date")
   def copyright: Rep[Option[String]]     = column[Option[String]]("copyright")
+  def license: Rep[Option[String]]       = column[Option[String]]("license")
   def lat: Rep[Option[Double]]           = column[Option[Double]]("lat")
   def lng: Rep[Option[Double]]           = column[Option[Double]]("lng")
   def cameraHeading: Rep[Option[Double]] = column[Option[Double]]("camera_heading")
@@ -131,8 +136,9 @@ class PanoDataTableDef(tag: Tag) extends Table[PanoData](tag, "pano_data") {
   // CHECK constraint, which Slick can't express: NULL unless `expired`.
   def expiredAt: Rep[Option[OffsetDateTime]] = column[Option[OffsetDateTime]]("expired_at")
 
-  def * = (panoId, width, height, tileWidth, tileHeight, captureDate, copyright, lat, lng, cameraHeading, cameraPitch,
-    cameraRoll, expired, lastViewed, panoHistorySaved, lastChecked, source, hasBackup, address, sourceMetadata) <>
+  def * = (panoId, width, height, tileWidth, tileHeight, captureDate, copyright, license, lat, lng, cameraHeading,
+    cameraPitch, cameraRoll, expired, lastViewed, panoHistorySaved, lastChecked, source, hasBackup, address,
+    sourceMetadata) <>
     ((PanoData.apply _).tupled, PanoData.unapply)
 }
 
@@ -376,7 +382,8 @@ class PanoDataTable @Inject() (protected val dbConfigProvider: DatabaseConfigPro
    *
    * Update semantics when the pano is already recorded:
    *   - Position/camera fields take the submitted value but are never cleared.
-   *   - Intrinsic fields (dims, copyright) keep their existing value and only fill in NULLs, as they never change.
+   *   - Intrinsic fields (dims, copyright, licence) keep their existing value and only fill in NULLs, as they never
+   *     change.
    *   - `address` and `source_metadata` are only ever replaced, never cleared.
    *   - The pano was just viewed, so `expired` resets to false and the viewed/checked timestamps refresh.
    *
@@ -398,11 +405,11 @@ class PanoDataTable @Inject() (protected val dbConfigProvider: DatabaseConfigPro
         INSERT INTO pano_imagery_change (pano_id, expired, changed_at, source)
         SELECT pano_id, FALSE, ${data.lastViewed}, $source::pano_imagery_change_source FROM edge
       )
-      INSERT INTO pano_data (pano_id, width, height, tile_width, tile_height, capture_date, copyright, lat, lng,
-                             camera_heading, camera_pitch, camera_roll, expired, last_viewed, pano_history_saved,
+      INSERT INTO pano_data (pano_id, width, height, tile_width, tile_height, capture_date, copyright, license, lat,
+                             lng, camera_heading, camera_pitch, camera_roll, expired, last_viewed, pano_history_saved,
                              last_checked, source, has_backup, address, source_metadata)
       VALUES (${data.panoId}, ${data.width}, ${data.height}, ${data.tileWidth}, ${data.tileHeight},
-              ${data.captureDate}, ${data.copyright}, ${data.lat}, ${data.lng}, ${data.cameraHeading},
+              ${data.captureDate}, ${data.copyright}, ${data.license}, ${data.lat}, ${data.lng}, ${data.cameraHeading},
               ${data.cameraPitch}, ${data.cameraRoll}, ${data.expired}, ${data.lastViewed}, ${data.panoHistorySaved},
               ${data.lastChecked}, ${data.source.toString}::pano_source, ${data.hasBackup}, ${data.address},
               ${data.sourceMetadata.map(m => Json.stringify(m))}::jsonb)
@@ -417,6 +424,7 @@ class PanoDataTable @Inject() (protected val dbConfigProvider: DatabaseConfigPro
         tile_width = COALESCE(pano_data.tile_width, EXCLUDED.tile_width),
         tile_height = COALESCE(pano_data.tile_height, EXCLUDED.tile_height),
         copyright = COALESCE(pano_data.copyright, EXCLUDED.copyright),
+        license = COALESCE(pano_data.license, EXCLUDED.license),
         address = COALESCE(EXCLUDED.address, pano_data.address),
         source_metadata = COALESCE(EXCLUDED.source_metadata, pano_data.source_metadata),
         expired = false,

--- a/app/service/ExploreService.scala
+++ b/app/service/ExploreService.scala
@@ -782,8 +782,8 @@ class ExploreServiceImpl @Inject() (
     for {
       _ <- panoDataTable.upsert(
         PanoData(pano.panoId, pano.width, pano.height, pano.tileWidth, pano.tileHeight, pano.captureDate,
-          pano.copyright, pano.lat, pano.lng, pano.cameraHeading, pano.cameraPitch, pano.cameraRoll, expired = false,
-          timestamp, Some(timestamp), timestamp, pano.source, hasBackup = None, address = pano.address,
+          pano.copyright, pano.license, pano.lat, pano.lng, pano.cameraHeading, pano.cameraPitch, pano.cameraRoll,
+          expired = false, timestamp, Some(timestamp), timestamp, pano.source, hasBackup = None, address = pano.address,
           sourceMetadata = pano.sourceMetadata)
       )
 

--- a/app/views/common/main.scala.html
+++ b/app/views/common/main.scala.html
@@ -1,4 +1,5 @@
 @import controllers.helper.ControllerUtils
+@import models.pano.ImageryAttribution
 @import play.api.Configuration
 @import play.api.libs.json.Json
 @import service.CommonPageData
@@ -100,6 +101,11 @@
        (AssetManifestService does it once at startup), so this interpolates a string rather than a several-hundred-
        entry map. *@
     <script>window.assetDigests = @commonData.assetDigestsJson;</script>
+    @* Panoramax licence identifier -> display name and licence-text URL (#5202). ImageryAttribution owns the table so
+       that the attribution the server renders on a crop or a self-hosted pano and the one PanoramaxViewer renders in
+       the live viewer name the same licence the same way. PanoramaxViewer shows an identifier it can't find here
+       verbatim, so a page that never stamps this (jsdom, the error pages) degrades rather than breaks. *@
+    <script>window.panoramaxLicenses = @Html(ImageryAttribution.panoramaxLicensesJson);</script>
     <script src='@assets.path("js/common/utilities.js")'></script>
     <script src='@assets.path("js/common/utilitiesMath.js")'></script>
     <script src='@assets.path("js/common/i18nDom.js")'></script>

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -258,10 +258,13 @@
     <script src='@assets.path("js/homepage.js")' defer></script>
     <script src='@assets.path("js/common/utilitiesSidewalk.js")' defer></script>
     <script src='@assets.path("js/common/share/ShareWidget.js")' defer></script>
+    @* The grid's imagery credits, without the 170 KB pano-viewer bundle: this page shows stills, never a live viewer. *@
+    <script src='@assets.path("js/common/pano-credit/build/pano-credit.js")' defer></script>
     <script src='@assets.path("js/LandingValidationGrid.js")' defer></script>
     <link href='@assets.path("css/components/choropleth.css")' rel="stylesheet">
     <link href='@assets.path("css/components/deployment-map.css")' rel="stylesheet">
     <link href='@assets.path("css/components/landing-validation-grid.css")' rel="stylesheet">
+    <link href='@assets.path("css/components/pano-attribution.css")' rel="stylesheet">
     @* The grid cards' share chip + popover (.label-detail__share-*) are styled by css/components/share-widget.css, which common/main.scala.html links on every page — nothing else here needs label-detail.css. *@
 
     <script>

--- a/conf/evolutions/default/376.sql
+++ b/conf/evolutions/default/376.sql
@@ -1,0 +1,13 @@
+# --- !Ups
+-- Record the licence a Panoramax picture is shared under (#5202). Panoramax contributors pick one per picture -- the
+-- federated catalog serves CC-BY-SA-4.0, CC-BY-4.0 and etalab-2.0 side by side -- so unlike Mapillary's uniform
+-- CC BY-SA it cannot be inferred from `source`. Without it, everything Project Sidewalk renders itself (a crop, a
+-- self-hosted backup pano) can name the producer but not the licence, which CC BY-SA requires shown alongside.
+-- Nullable: only Panoramax records one, and it starts complete because no Panoramax label exists yet.
+-- Deliberately no CHECK constraint. The value set is open, not closed: it is whatever licence identifier the
+-- contributor's own instance recorded, so a CHECK would reject an id we haven't seen and lose the one fact this
+-- column exists to keep. ImageryAttribution falls back to showing an unrecognized id verbatim instead.
+ALTER TABLE pano_data ADD COLUMN license TEXT;
+
+# --- !Downs
+ALTER TABLE pano_data DROP COLUMN license;

--- a/public/css/components/label-detail.css
+++ b/public/css/components/label-detail.css
@@ -259,9 +259,29 @@ dialog.label-detail[open]::backdrop {
   bottom: 4.5px;
   right: 10px;
 
-  /* Under the hover validation bar (1), like the source logo opposite it: while that bar is up it belongs to the
-     vote buttons, and a credit painted over them would be the thing in the way. */
-  z-index: 0;
+  z-index: 0; /* Under the hover validation bar (1), like the source logo opposite it. */
+}
+
+/* Both halves of the credit step aside for the vote bar rather than being occluded by it — the bar's own reveal
+   condition, read from the wrap with :has() because the credit sits inside .label-detail__pano, a *previous*
+   sibling of the bar. [hidden] is part of that condition: the bar is dropped entirely on the viewer's own label
+   (#5047), and the credit would otherwise vanish for a bar that never arrives. */
+.label-detail .pano-attribution,
+.label-detail .pano-viewer-logo {
+  transition: opacity 150ms ease; /* The bar's own fade. */
+}
+
+.label-detail__pano-wrap:hover:has(.label-detail__pano-overlay:not([hidden])) .pano-attribution,
+.label-detail__pano-wrap:hover:has(.label-detail__pano-overlay:not([hidden])) .pano-viewer-logo,
+.label-detail__pano-wrap:has(.label-detail__pano-overlay:focus-within) .pano-attribution,
+.label-detail__pano-wrap:has(.label-detail__pano-overlay:focus-within) .pano-viewer-logo {
+  opacity: 0;
+  pointer-events: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .label-detail .pano-attribution,
+  .label-detail .pano-viewer-logo { transition: none; }
 }
 
 /* Hide-label toggle (#2477) in the pano's top-left. Revealed on hover like the paging arrows. */

--- a/public/css/components/label-detail.css
+++ b/public/css/components/label-detail.css
@@ -252,12 +252,16 @@ dialog.label-detail[open]::backdrop {
   .label-detail__pan-hint { transition: none; }
 }
 
-/* Imagery attribution (#4865; look in css/components/pano-attribution.css, which every host of this dialog links) in
-   the pano's top-right, clear of the hide-label control (top-left) and the hover validation bar (bottom). */
+/* Imagery attribution (#4865; look in css/components/pano-attribution.css, which every host of this dialog links).
+   4.5px puts the 26px pill's center on the source logo's optical line opposite it — 17.5px above the pano's bottom
+   edge (PanoViewerLogo's 2px clearance plus the 15.5px its own art centers on) — so the two read as one credit. */
 .label-detail .pano-attribution {
-  top: 10px;
+  bottom: 4.5px;
   right: 10px;
-  z-index: 6; /* Above the validation ring (5), below the info popover (10), like the hide-label control. */
+
+  /* Under the hover validation bar (1), like the source logo opposite it: while that bar is up it belongs to the
+     vote buttons, and a credit painted over them would be the thing in the way. */
+  z-index: 0;
 }
 
 /* Hide-label toggle (#2477) in the pano's top-left. Revealed on hover like the paging arrows. */

--- a/public/css/components/landing-validation-grid.css
+++ b/public/css/components/landing-validation-grid.css
@@ -51,6 +51,17 @@
   background: var(--color-neutral-100, #f0f0f0);
 }
 
+/* Imagery credit on the card's own still (#4865, #5202; look in css/components/pano-attribution.css). Nothing else
+   overlays this image — the vote buttons live in the figcaption below it — so both sit flush. */
+.lvg-card-img .pano-viewer-logo {
+  --ui-scale: 0.72; /* Card-sized: the 29px logo row down to ~21px. Only the logo — the pill sets its own type. */
+}
+
+.lvg-card-img .pano-attribution {
+  right: 6px;
+  bottom: 3px;
+}
+
 .lvg-card-photo {
   width: 100%;
   height: 100%;

--- a/public/css/components/landing-validation-grid.css
+++ b/public/css/components/landing-validation-grid.css
@@ -59,7 +59,7 @@
 
 .lvg-card-img .pano-attribution {
   right: 6px;
-  bottom: 3px;
+  bottom: 4.6px; /* Puts the 16px pill's center on the scaled logo's art center, 12.6px above the image's edge. */
 }
 
 .lvg-card-photo {

--- a/public/css/components/pano-attribution.css
+++ b/public/css/components/pano-attribution.css
@@ -3,8 +3,9 @@
    own. Always visible, not hover-revealed: it is an obligation of the licence, not a control. Dark pill for contrast
    on any imagery; the licence token is the one link.
 
-   Mounted by PanoAttribution.js (pano-viewer bundle) inside a positioned pano container. This file is the look; each
-   host positions the pill where its own overlays leave room (label-detail.css, validate/svv-panorama.css). */
+   Mounted by PanoAttribution.js (the pano-viewer and pano-credit bundles) inside a positioned pano container. This
+   file is the look; each host positions the pill where its own overlays leave room (label-detail.css,
+   validate/svv-panorama.css, gallery/cards.css, landing-validation-grid.css). */
 .pano-attribution {
   position: absolute;
   max-width: calc(100% - 20px);
@@ -28,6 +29,18 @@
 .pano-attribution a:focus-visible {
   outline: 2px solid var(--color-neutral-white);
   outline-offset: 2px;
+}
+
+/* Card-sized form (#5202). The source logo opposite it names the provider, so this half carries only the holder and
+   the licence. It wraps rather than truncating: the licence name is the last thing that may be cut. */
+.pano-attribution--compact {
+  max-width: 62%;
+  padding: 2px 6px;
+  border-radius: 7px;
+  font: var(--text-tiny-medium);
+  white-space: normal;
+  text-align: right;
+  text-overflow: clip;
 }
 
 /* The "(opens in a new tab)" cue for assistive tech, off-screen like the other hosts' visually-hidden text. */

--- a/public/css/pages/gallery/cards.css
+++ b/public/css/pages/gallery/cards.css
@@ -57,16 +57,23 @@ with respect to the image holder. This allows the validation menu to be placed o
   border-top-right-radius: 20px;
 }
 
-/* Imagery credit on the card's own still (#4865, #5202; look in css/components/pano-attribution.css). Both hug the
-   bottom edge, overlapping the hover validation bar while it is up. */
+/* Imagery credit on the card's own still (#4865, #5202; look in css/components/pano-attribution.css), clear of the
+   vote row that owns the bottom 14% of the holder. The clearance is static rather than revealed on hover, and it is
+   not optional: (pointer: coarse) keeps that row up permanently, so a credit inside the band is invisible on every
+   touch device, and the row's buttons hit-test even at opacity 0, so a click on the licence would vote instead.
+   The +6.2px puts the pill's center on the logo's art center, 11.16px above whatever line the two share. */
+.image-holder {
+  --credit-clearance: calc(14% + 3px);
+}
+
 .image-holder .pano-viewer-logo {
   --ui-scale: 0.72; /* Card-sized: the 29px logo row down to ~21px. Only the logo — the pill sets its own type. */
+  --pano-logo-bottom: var(--credit-clearance);
 }
 
 .image-holder .pano-attribution {
   right: 6px;
-  bottom: 3px;
-  z-index: 1; /* Under the hover validation bar (2), like the source logo opposite it. */
+  bottom: calc(var(--credit-clearance) + 6.2px);
 }
 
 #gallery-validation-button-holder {

--- a/public/css/pages/gallery/cards.css
+++ b/public/css/pages/gallery/cards.css
@@ -57,23 +57,23 @@ with respect to the image holder. This allows the validation menu to be placed o
   border-top-right-radius: 20px;
 }
 
-/* Imagery credit on the card's own still (#4865, #5202; look in css/components/pano-attribution.css), clear of the
-   vote row that owns the bottom 14% of the holder. The clearance is static rather than revealed on hover, and it is
-   not optional: (pointer: coarse) keeps that row up permanently, so a credit inside the band is invisible on every
-   touch device, and the row's buttons hit-test even at opacity 0, so a click on the licence would vote instead.
-   The +6.2px puts the pill's center on the logo's art center, 11.16px above whatever line the two share. */
-.image-holder {
-  --credit-clearance: calc(14% + 3px);
-}
+/* Imagery credit on the card's own still (#4865, #5202; look in css/components/pano-attribution.css). Along the
+   card's top edge, which is the only clear one: the vote row owns the bottom 14% of the holder, and (pointer:
+   coarse) keeps that row up permanently, so a credit down there is invisible on every touch device — and the row's
+   buttons hit-test even at opacity 0, so a click on the licence would cast a vote instead of opening it.
 
+   The logo is anchored by its own inline `bottom`, so releasing that to `auto` is what lets `top` take over. 4.7px
+   puts the pill's center on the logo's art center, both 12.7px below the top edge. */
 .image-holder .pano-viewer-logo {
   --ui-scale: 0.72; /* Card-sized: the 29px logo row down to ~21px. Only the logo — the pill sets its own type. */
-  --pano-logo-bottom: var(--credit-clearance);
+  --pano-logo-bottom: auto;
+
+  top: 3px;
 }
 
 .image-holder .pano-attribution {
+  top: 4.7px;
   right: 6px;
-  bottom: calc(var(--credit-clearance) + 6.2px);
 }
 
 #gallery-validation-button-holder {

--- a/public/css/pages/gallery/cards.css
+++ b/public/css/pages/gallery/cards.css
@@ -57,23 +57,52 @@ with respect to the image holder. This allows the validation menu to be placed o
   border-top-right-radius: 20px;
 }
 
-/* Imagery credit on the card's own still (#4865, #5202; look in css/components/pano-attribution.css). Along the
-   card's top edge, which is the only clear one: the vote row owns the bottom 14% of the holder, and (pointer:
-   coarse) keeps that row up permanently, so a credit down there is invisible on every touch device — and the row's
-   buttons hit-test even at opacity 0, so a click on the licence would cast a vote instead of opening it.
-
-   The logo is anchored by its own inline `bottom`, so releasing that to `auto` is what lets `top` take over. 4.7px
-   puts the pill's center on the logo's art center, both 12.7px below the top edge. */
+/* Imagery credit on the card's own still (#4865, #5202; look in css/components/pano-attribution.css). It shares the
+   bottom edge with the vote row, so it steps aside when that row comes up rather than being occluded by it. 4.6px
+   puts the pill's center on the logo's art center, both 12.6px above the image's bottom edge. */
 .image-holder .pano-viewer-logo {
   --ui-scale: 0.72; /* Card-sized: the 29px logo row down to ~21px. Only the logo — the pill sets its own type. */
-  --pano-logo-bottom: auto;
-
-  top: 3px;
 }
 
 .image-holder .pano-attribution {
-  top: 4.7px;
   right: 6px;
+  bottom: 4.6px;
+}
+
+.image-holder .pano-viewer-logo,
+.image-holder .pano-attribution {
+  transition: opacity 120ms ease; /* The vote buttons' own fade. */
+}
+
+.gallery-card:hover .pano-viewer-logo,
+.gallery-card:hover .pano-attribution {
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* Hover can't reveal the vote row on a touch-primary device, so it never leaves — and a credit that yields to it
+   would never be seen at all. The credit takes the top edge there instead, where nothing competes for the space. */
+@media (pointer: coarse) {
+  .image-holder .pano-viewer-logo {
+    --pano-logo-bottom: auto;
+
+    top: 3px;
+  }
+
+  .image-holder .pano-attribution {
+    top: 4.7px; /* Puts the pill's center on the logo's art center, both 12.7px below the top edge. */
+    bottom: auto;
+  }
+
+  .gallery-card:hover .pano-viewer-logo,
+  .gallery-card:hover .pano-attribution {
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .image-holder .pano-viewer-logo,
+  .image-holder .pano-attribution { transition: none; }
 }
 
 #gallery-validation-button-holder {

--- a/public/css/pages/gallery/cards.css
+++ b/public/css/pages/gallery/cards.css
@@ -57,6 +57,18 @@ with respect to the image holder. This allows the validation menu to be placed o
   border-top-right-radius: 20px;
 }
 
+/* Imagery credit on the card's own still (#4865, #5202; look in css/components/pano-attribution.css). Both hug the
+   bottom edge, overlapping the hover validation bar while it is up. */
+.image-holder .pano-viewer-logo {
+  --ui-scale: 0.72; /* Card-sized: the 29px logo row down to ~21px. Only the logo — the pill sets its own type. */
+}
+
+.image-holder .pano-attribution {
+  right: 6px;
+  bottom: 3px;
+  z-index: 1; /* Under the hover validation bar (2), like the source logo opposite it. */
+}
+
 #gallery-validation-button-holder {
   display: flex;
   flex-flow: row wrap;

--- a/public/js/LandingValidationGrid.js
+++ b/public/js/LandingValidationGrid.js
@@ -167,6 +167,10 @@ class LandingValidationGrid {
       marker.style.top = `${(100 * label.canvas_y) / util.EXPLORE_CANVAS_HEIGHT}%`;
       imgWrap.appendChild(marker);
     }
+    // The credit owed on a still we serve ourselves (#4865, #5202). Only licensed imagery carries a licence, so
+    // createPanoAttribution hides itself for a source with none, leaving the logo alone.
+    createPanoViewerLogo(imgWrap, label.pano_source).showSourceLogo();
+    createPanoAttribution(imgWrap, { compact: true }).show(label.pano_data?.attribution);
     card.appendChild(imgWrap);
 
     const body = document.createElement('figcaption');

--- a/public/js/common/label-detail/PopupPanoManager.js
+++ b/public/js/common/label-detail/PopupPanoManager.js
@@ -174,7 +174,7 @@ class PopupPanoManager {
     });
     this.#fallbackPanzoom.on('transform', () => this.#updateFallbackMarkerPosition());
 
-    this.#logo = createPanoViewerLogo(this.svHolder[0], this.#viewerType);
+    this.#logo = createPanoViewerLogo(this.svHolder[0], this.#viewerType.SOURCE);
     this.#logo.showPrimaryLogo();
     this.#attribution = createPanoAttribution(this.svHolder[0]);
 

--- a/public/js/common/pano-viewer/src/GsvViewer.js
+++ b/public/js/common/pano-viewer/src/GsvViewer.js
@@ -3,6 +3,9 @@
  * Docs: https://developers.google.com/maps/documentation/javascript/reference/street-view
  */
 class GsvViewer extends PanoViewer {
+  /** The `pano_data.source` value, so code outside the viewer can name this source without holding the class. */
+  static SOURCE = 'gsv';
+
   // If GSV's internal pano load never fires position_changed (e.g. its metadata RPC 502s), fail the load after this
   // long so the in-flight move can recover instead of hanging the UI forever. Generous, so it won't abort slow loads.
   static #PANO_LOAD_TIMEOUT_MS = 10000;

--- a/public/js/common/pano-viewer/src/Infra3dViewer.js
+++ b/public/js/common/pano-viewer/src/Infra3dViewer.js
@@ -3,6 +3,9 @@
  * Docs: https://developers.infra3d.com/javascript-api/reference/classes/Viewer.Viewer.html
  */
 class Infra3dViewer extends PanoViewer {
+  /** The `pano_data.source` value, so code outside the viewer can name this source without holding the class. */
+  static SOURCE = 'infra3d';
+
   constructor() {
     super();
     this.viewer = undefined;

--- a/public/js/common/pano-viewer/src/MapillaryViewer.js
+++ b/public/js/common/pano-viewer/src/MapillaryViewer.js
@@ -3,6 +3,9 @@
  * Docs: https://mapillary.github.io/mapillary-js/api/classes/viewer.Viewer
  */
 class MapillaryViewer extends PanoViewer {
+  /** The `pano_data.source` value, so code outside the viewer can name this source without holding the class. */
+  static SOURCE = 'mapillary';
+
   // The vertical fov Mapillary can actually render a spherical image at: it renders fov = 2·atan(2^−zoom) and
   // clamps zoom to [0, 3], giving [14.25°, 90°]. Requests outside that are silently clamped by the SDK (#4852).
   // Plain Math rather than util.math.toDegrees: these evaluate at bundle load, and util ships in a separate

--- a/public/js/common/pano-viewer/src/PannellumViewer.js
+++ b/public/js/common/pano-viewer/src/PannellumViewer.js
@@ -13,6 +13,9 @@
  * swap panos via addScene()/loadScene() without destroying and recreating the WebGL context.
  */
 class PannellumViewer extends PanoViewer {
+  /** The `pano_data.source` value, so code outside the viewer can name this source without holding the class. */
+  static SOURCE = 'pannellum';
+
   /** @type {object} The underlying pannellum viewer instance. */
   #viewer = undefined;
 

--- a/public/js/common/pano-viewer/src/PanoAttribution.js
+++ b/public/js/common/pano-viewer/src/PanoAttribution.js
@@ -8,15 +8,19 @@
  * imagery carries a copyright string instead of a licence, which the source logo and the viewer's own copyright
  * line already convey, so a second copy of it is noise (Jon, 2026-09-04).
  *
- * The container must establish a CSS positioning context, as for createPanoViewerLogo. The overlay sits top-right,
- * clear of the hide-label control (top-left) and the hover validation bar (bottom).
+ * The container must establish a CSS positioning context, as for createPanoViewerLogo. Each host positions the
+ * overlay where its own controls leave room; the look lives in css/components/pano-attribution.css.
  *
  * @param {Element} container The positioned pano container element.
+ * @param {object} [options]
+ * @param {boolean} [options.compact=false] Card-sized form: smaller type, wrapping rather than truncating, and no
+ *     provider name, since the source logo opposite it is already carrying that.
  * @returns {{ show: Function, hide: Function }}
  */
-function createPanoAttribution(container) {
+function createPanoAttribution(container, options = {}) {
+  const compact = options.compact === true;
   const holder = document.createElement('small');
-  holder.className = 'pano-attribution';
+  holder.className = compact ? 'pano-attribution pano-attribution--compact' : 'pano-attribution';
   holder.hidden = true;
   container.appendChild(holder);
 
@@ -26,7 +30,7 @@ function createPanoAttribution(container) {
    */
   function render(attribution) {
     const parts = [document.createTextNode(attribution.holder)];
-    if (attribution.provider) parts.push(document.createTextNode(attribution.provider));
+    if (attribution.provider && !compact) parts.push(document.createTextNode(attribution.provider));
     if (attribution.license) {
       if (attribution.license_url) {
         // Only the licence token links out, so the line's other names don't read as links to the provider.

--- a/public/js/common/pano-viewer/src/PanoData.js
+++ b/public/js/common/pano-viewer/src/PanoData.js
@@ -19,6 +19,7 @@ class PanoData {
    * @param {moment} params.captureDate Time when the picture was taken, only using up to month/year granularity
    * @param {string} [params.address] Optional address for the current location
    * @param {string} [params.copyright] Optional associated copyright info for the image
+   * @param {string} [params.license] Optional licence identifier the provider records per image (Panoramax only)
    * @param {Array<{panoId: string, heading: number}>} params.linkedPanos List of nearby panos linked to with nav arrows
    * @param {Array<{panoId: string, captureDate: Date}>} params.history List of panos at this pano's location over time
    * @param {boolean} [params.submitted=false] Whether we've sent this data to the server yet; false unless in tutorial
@@ -75,6 +76,7 @@ class PanoData {
       tileHeight: params.tileHeight || params.height,
       address: params.address || null,
       copyright: params.copyright || null,
+      license: params.license || null,
       captureDate: params.captureDate,
       linkedPanos: params.linkedPanos || [],
       history: params.history || [],

--- a/public/js/common/pano-viewer/src/PanoViewer.js
+++ b/public/js/common/pano-viewer/src/PanoViewer.js
@@ -47,20 +47,17 @@ class PanoViewer {
   constructor() {
     if (new.target === PanoViewer) {
       throw new Error('Cannot instantiate abstract class directly');
-    } else if (new.target === GsvViewer) {
-      this.viewerType = 'gsv';
+    }
+    this.viewerType = new.target.SOURCE;
+    if (new.target === GsvViewer) {
       this.canvasClass = 'widget-scene-canvas';
     } else if (new.target === MapillaryViewer) {
-      this.viewerType = 'mapillary';
       this.canvasClass = 'mapillary-canvas';
     } else if (new.target === Infra3dViewer) {
-      this.viewerType = 'infra3d';
       this.canvasClass = 'infra3dsdk-canvas';
     } else if (new.target === PannellumViewer) {
-      this.viewerType = 'pannellum';
       this.canvasClass = 'pannellum-canvas';
     } else if (new.target === PanoramaxViewer) {
-      this.viewerType = 'panoramax';
       this.canvasClass = 'psv-canvas';
     }
   }

--- a/public/js/common/pano-viewer/src/PanoViewerLogo.js
+++ b/public/js/common/pano-viewer/src/PanoViewerLogo.js
@@ -4,29 +4,34 @@
  * The container must establish a CSS positioning context (position: relative, absolute, or fixed) so that
  * the absolutely-positioned logo is scoped to the pano area. Returns an object with two methods:
  *   - showPrimaryLogo() — use when the primary viewer (GSV/Mapillary/Infra3D) is active.
- *   - showSourceLogo()  — use when Pannellum is active as a backup for the primary source.
+ *   - showSourceLogo()  — use when Pannellum is active as a backup, and on a still we render ourselves (a crop on
+ *     a Gallery or landing card), where no live viewer brands the imagery at all.
  *
  * The overlay also publishes where the logo's pixels end, as the --pano-logo-width CSS variable on the container,
  * so that overlays sitting to its right (the pano capture date and info button) can clear it.
  *
+ * Keyed on the `pano_data.source` string rather than a viewer class, so this file can ship in the pano-credit
+ * bundle that pages with no viewer load (#5202).
+ *
  * @param {Element} container The positioned pano container element.
- * @param {typeof PanoViewer} primaryViewerType The primary viewer class (GsvViewer, MapillaryViewer, etc.).
+ * @param {string} primarySource The imagery source ('gsv', 'mapillary', 'infra3d', 'panoramax'); a viewer class
+ *     exposes its own as the static SOURCE.
  * @returns {{ showPrimaryLogo: Function, showSourceLogo: Function }}
  */
-function createPanoViewerLogo(container, primaryViewerType) {
+function createPanoViewerLogo(container, primarySource) {
   /**
    * The logo art per imagery source. paddingLeft is hand-tuned per logo, in unscaled px. A `label` is a wordmark
    * drawn as text after the art, for a source whose mark alone doesn't say who it is.
-   * @type {Map<typeof PanoViewer, {src: string, alt: string, paddingLeft: number, label?: string}>}
+   * @type {Map<string, {src: string, alt: string, paddingLeft: number, label?: string}>}
    */
   const LOGOS = new Map([
-    [GsvViewer, { src: util.assetPath('images/logos/google-logo.svg'), alt: 'Google', paddingLeft: 10 }],
-    [MapillaryViewer, {
+    ['gsv', { src: util.assetPath('images/logos/google-logo.svg'), alt: 'Google', paddingLeft: 10 }],
+    ['mapillary', {
       src: util.assetPath('images/logos/mapillary-logo-white.png'), alt: 'Mapillary', paddingLeft: 5,
     }],
-    [Infra3dViewer, { src: util.assetPath('images/logos/infra3d-logo.svg'), alt: 'infra3D', paddingLeft: 6 }],
+    ['infra3d', { src: util.assetPath('images/logos/infra3d-logo.svg'), alt: 'infra3D', paddingLeft: 6 }],
     // Panoramax publishes only its icon; the name is set beside it because the icon isn't widely recognized.
-    [PanoramaxViewer, {
+    ['panoramax', {
       src: util.assetPath('images/logos/panoramax-logo.svg'), alt: 'Panoramax', paddingLeft: 6, label: 'Panoramax',
     }],
   ]);
@@ -41,6 +46,8 @@ function createPanoViewerLogo(container, primaryViewerType) {
   const PADDING_TOP = HOLDER_HEIGHT - IMG_HEIGHT - PADDING_BOTTOM;
 
   const holder = document.createElement('div');
+  // A host needing the logo at another size sets --ui-scale on this, which every dimension below is sized against.
+  holder.className = 'pano-viewer-logo';
   Object.assign(holder.style, {
     display: 'none',
     position: 'absolute',
@@ -140,11 +147,11 @@ function createPanoViewerLogo(container, primaryViewerType) {
   resizeObserver.observe(label);
 
   /**
-   * Shows the logo for the given viewer type.
-   * @param {typeof PanoViewer} viewerType
+   * Shows the logo for the given imagery source.
+   * @param {string} source
    */
-  function showLogo(viewerType) {
-    const info = LOGOS.get(viewerType);
+  function showLogo(source) {
+    const info = LOGOS.get(source);
     if (!info) return;
     activeLogo = info;
     img.src = info.src;
@@ -162,21 +169,21 @@ function createPanoViewerLogo(container, primaryViewerType) {
      * Shows the logo for the primary viewer, or hides the overlay for GSV (which provides its own branding).
      */
     showPrimaryLogo() {
-      if (primaryViewerType === GsvViewer) {
+      if (primarySource === 'gsv') {
         holder.style.display = 'none';
         activeLogo = null;
         // Google draws its own logo, so overlays to its right fall back to the offset that clears that one.
         container.style.removeProperty('--pano-logo-width');
       } else {
-        showLogo(primaryViewerType);
+        showLogo(primarySource);
       }
     },
 
     /**
-     * Shows the source logo for the primary viewer's imagery. Used when Pannellum is active.
+     * Shows the source logo for the primary viewer's imagery. Used when Pannellum is active, and on our own stills.
      */
     showSourceLogo() {
-      showLogo(primaryViewerType);
+      showLogo(primarySource);
     },
   };
 }

--- a/public/js/common/pano-viewer/src/PanoViewerLogo.js
+++ b/public/js/common/pano-viewer/src/PanoViewerLogo.js
@@ -51,7 +51,8 @@ function createPanoViewerLogo(container, primarySource) {
   Object.assign(holder.style, {
     display: 'none',
     position: 'absolute',
-    bottom: 'calc(var(--bottom-left-links-clearance, 2px) * var(--ui-scale, 1))',
+    // --pano-logo-bottom lets a host lift the logo from CSS, which this inline style would otherwise win against.
+    bottom: 'var(--pano-logo-bottom, calc(var(--bottom-left-links-clearance, 2px) * var(--ui-scale, 1)))',
     left: '0',
     zIndex: '1',
     height: `calc(${HOLDER_HEIGHT}px * var(--ui-scale, 1))`,

--- a/public/js/common/pano-viewer/src/PanoramaxViewer.js
+++ b/public/js/common/pano-viewer/src/PanoramaxViewer.js
@@ -19,6 +19,9 @@
  *   MapillaryViewer already does for Mapillary.
  */
 class PanoramaxViewer extends PanoViewer {
+  /** The `pano_data.source` value, so code outside the viewer can name this source without holding the class. */
+  static SOURCE = 'panoramax';
+
   /** The federated meta-catalog, which searches every Panoramax instance at once. */
   static API_BASE = 'https://api.panoramax.xyz/api';
 

--- a/public/js/common/pano-viewer/src/PanoramaxViewer.js
+++ b/public/js/common/pano-viewer/src/PanoramaxViewer.js
@@ -47,12 +47,17 @@ class PanoramaxViewer extends PanoViewer {
   /** Widest vertical field of view we render at, matching MapillaryViewer's clamp so zoom 1 looks the same. */
   static #MAX_VERTICAL_FOV = 90;
 
-  /** The licence identifiers Panoramax uses, mapped to the display name and link our attribution overlay shows. */
-  static #LICENSES = {
-    'CC-BY-SA-4.0': { name: 'CC BY-SA 4.0', url: 'https://creativecommons.org/licenses/by-sa/4.0/' },
-    'CC-BY-4.0': { name: 'CC BY 4.0', url: 'https://creativecommons.org/licenses/by/4.0/' },
-    'etalab-2.0': { name: 'Licence Ouverte 2.0', url: 'https://www.etalab.gouv.fr/licence-ouverte-open-licence/' },
-  };
+  /**
+   * The licence identifiers Panoramax uses, mapped to the display name and link our attribution overlay shows.
+   *
+   * Stamped onto the page by main.scala.html from ImageryAttribution.PanoramaxLicenses, which is the one copy of the
+   * table (#5202): the server names the licence the same way when it renders a crop or a self-hosted pano itself.
+   * Empty when a page didn't stamp it, which #attributionFor handles by showing the raw identifier.
+   * @returns {Object<string, {name: string, url: string}>}
+   */
+  static get #LICENSES() {
+    return window.panoramaxLicenses ?? {};
+  }
 
   /** @type {object} The underlying Photo Sphere Viewer instance. */
   #viewer = undefined;
@@ -506,6 +511,7 @@ class PanoramaxViewer extends PanoViewer {
       cameraPitch: props['pers:pitch'] || 0,
       cameraRoll: props['pers:roll'] ?? undefined,
       copyright: props['geovisio:producer'],
+      license: props.license,
       linkedPanos: [],
       history: [],
     };

--- a/public/js/explore/src/data/Form.js
+++ b/public/js/explore/src/data/Form.js
@@ -79,6 +79,7 @@ class Form {
         description: link.description || null,
       })),
       copyright: props.copyright || null,
+      license: props.license || null,
       address: props.address || null,
       history: props.history.map((prevPano) => ({
         pano_id: prevPano.panoId,

--- a/public/js/explore/src/panorama/PanoManager.js
+++ b/public/js/explore/src/panorama/PanoManager.js
@@ -247,7 +247,7 @@ class PanoManager {
       }
     });
 
-    const panoViewerLogo = createPanoViewerLogo(this.panoCanvas.parentElement, panoViewerType);
+    const panoViewerLogo = createPanoViewerLogo(this.panoCanvas.parentElement, panoViewerType.SOURCE);
     panoViewerLogo.showPrimaryLogo();
 
     if (panoViewerType === GsvViewer) {

--- a/public/js/gallery/src/cards/Card.js
+++ b/public/js/gallery/src/cards/Card.js
@@ -15,6 +15,7 @@ class Card {
     label_id: undefined,
     label_type: undefined,
     pano_id: undefined,
+    pano_source: undefined,
     pano_data: undefined,
     lat: undefined,
     lng: undefined,
@@ -211,6 +212,11 @@ class Card {
     }
     imageHolder.appendChild(markerWrapper);
     imageHolder.appendChild(panoImage);
+
+    // The credit owed on a still we serve ourselves (#4865, #5202). Only licensed imagery carries a licence, so
+    // createPanoAttribution hides itself for a source with none, leaving the logo alone.
+    createPanoViewerLogo(imageHolder, properties.pano_source).showSourceLogo();
+    createPanoAttribution(imageHolder, { compact: true }).show(properties.pano_data?.attribution);
 
     this.#card.appendChild(cardInfo);
     this.validationMenu = new ValidationMenu(this, $(imageHolder));

--- a/public/js/validate/src/panorama/PanoManager.js
+++ b/public/js/validate/src/panorama/PanoManager.js
@@ -79,7 +79,7 @@ class PanoManager {
     svv.panoViewer = this.#primaryViewer;
 
     // Set up the imagery source logo. #showPannellumPano will override it if Pannellum takes over below.
-    this.#logo = createPanoViewerLogo(this.#panoCanvas.parentElement, panoViewerType);
+    this.#logo = createPanoViewerLogo(this.#panoCanvas.parentElement, panoViewerType.SOURCE);
     this.#logo.showPrimaryLogo();
     this.#attribution = createPanoAttribution(this.#panoCanvas.parentElement);
 

--- a/test/js/galleryCardLocation.test.js
+++ b/test/js/galleryCardLocation.test.js
@@ -60,6 +60,8 @@ describe('a Gallery card\'s location line', () => {
         window.ValidationInfoDisplay = class {};
         window.ValidationMenu = class {};
         window.TagDisplay = class {};
+        window.createPanoViewerLogo = () => ({ showSourceLogo: () => {} });
+        window.createPanoAttribution = () => ({ show: () => {} });
         window.$ = () => ({ tooltip: () => ({ tooltip: () => {} }) });
         window.eval(`${CARD_SRC}\nwindow.Card = Card;`);
     });

--- a/test/models/audit/OutdatedImageryFlagSyncSpec.scala
+++ b/test/models/audit/OutdatedImageryFlagSyncSpec.scala
@@ -280,7 +280,7 @@ class OutdatedImageryFlagSyncSpec extends PlaySpec with GuiceOneAppPerSuite with
       """.as[(Double, Double)].head
 
     def panoAt(lat: Double, lng: Double): PanoData =
-      PanoData(testPanoId, None, None, None, None, "2024-06", None, Some(lat), Some(lng), None, None, None,
+      PanoData(testPanoId, None, None, None, None, "2024-06", None, None, Some(lat), Some(lng), None, None, None,
         expired = false, OffsetDateTime.now, None, OffsetDateTime.now, PanoSource.Gsv, None, None, None)
 
     "create a street's imagery row from a recently-viewed pano on it" in {

--- a/test/models/pano/ImageryAttributionSpec.scala
+++ b/test/models/pano/ImageryAttributionSpec.scala
@@ -1,14 +1,14 @@
 package models.pano
 
 import org.scalatestplus.play.PlaySpec
-import play.api.libs.json.{JsNull, Json}
+import play.api.libs.json.{JsNull, JsObject, Json}
 
 /** The attribution owed for imagery Project Sidewalk shows a copy of (#4865). Pure. */
 class ImageryAttributionSpec extends PlaySpec {
 
   "ImageryAttribution.line" should {
     "credit a Mapillary contributor with the provider and the CC BY-SA licence" in {
-      val line = ImageryAttribution.line(PanoSource.Mapillary, Some("jacobwhall")).value
+      val line = ImageryAttribution.line(PanoSource.Mapillary, Some("jacobwhall"), None).value
       line.holder mustBe "© jacobwhall"
       line.provider mustBe Some("Mapillary")
       line.license mustBe Some(ImageryAttribution.MapillaryLicense)
@@ -17,10 +17,10 @@ class ImageryAttributionSpec extends PlaySpec {
     }
 
     "pass a provider's own copyright string through unchanged" in {
-      val line = ImageryAttribution.line(PanoSource.Gsv, Some("© 2025 Google")).value
+      val line = ImageryAttribution.line(PanoSource.Gsv, Some("© 2025 Google"), None).value
       line mustBe ImageryAttribution.Line("© 2025 Google", None, None, None)
       line.text mustBe "© 2025 Google"
-      ImageryAttribution.line(PanoSource.Infra3d, Some("City of Zurich and iNovitas AG")).value.text mustBe
+      ImageryAttribution.line(PanoSource.Infra3d, Some("City of Zurich and iNovitas AG"), None).value.text mustBe
         "City of Zurich and iNovitas AG"
     }
 
@@ -31,38 +31,80 @@ class ImageryAttributionSpec extends PlaySpec {
         Some(ImageryAttribution.MapillaryLicense),
         Some(ImageryAttribution.MapillaryLicenseUrl)
       )
-      ImageryAttribution.line(PanoSource.Mapillary, None).value mustBe expected
-      ImageryAttribution.line(PanoSource.Mapillary, Some("  ")).value mustBe expected
+      ImageryAttribution.line(PanoSource.Mapillary, None, None).value mustBe expected
+      ImageryAttribution.line(PanoSource.Mapillary, Some("  "), None).value mustBe expected
       expected.text mustBe "Mapillary · CC BY-SA 4.0"
     }
 
-    "name Panoramax beside its producer, with no licence, since the licence varies per picture (#5202)" in {
-      val line = ImageryAttribution.line(PanoSource.Panoramax, Some("Arretche")).value
-      line mustBe ImageryAttribution.Line("© Arretche", Some("Panoramax"), None, None)
-      line.text mustBe "© Arretche · Panoramax"
-      ImageryAttribution.line(PanoSource.Panoramax, None).value mustBe
+    "name a Panoramax picture's own licence, since its contributor picks one per picture (#5202)" in {
+      val line = ImageryAttribution.line(PanoSource.Panoramax, Some("Arretche"), Some("CC-BY-SA-4.0")).value
+      line mustBe ImageryAttribution.Line(
+        "© Arretche",
+        Some("Panoramax"),
+        Some("CC BY-SA 4.0"),
+        Some("https://creativecommons.org/licenses/by-sa/4.0/")
+      )
+      line.text mustBe "© Arretche · Panoramax · CC BY-SA 4.0"
+
+      ImageryAttribution.line(PanoSource.Panoramax, None, Some("etalab-2.0")).value mustBe
+        ImageryAttribution.Line(
+          "Panoramax",
+          None,
+          Some("Licence Ouverte 2.0"),
+          Some("https://www.etalab.gouv.fr/licence-ouverte-open-licence/")
+        )
+    }
+
+    "name an unrecognized Panoramax licence verbatim rather than dropping it, since identifying it is the point" in {
+      val line = ImageryAttribution.line(PanoSource.Panoramax, Some("Arretche"), Some("ODbL-1.0")).value
+      line mustBe ImageryAttribution.Line("© Arretche", Some("Panoramax"), Some("ODbL-1.0"), None)
+      line.text mustBe "© Arretche · Panoramax · ODbL-1.0"
+    }
+
+    "credit a Panoramax picture whose licence wasn't recorded, naming none" in {
+      ImageryAttribution.line(PanoSource.Panoramax, Some("Arretche"), None).value mustBe
+        ImageryAttribution.Line("© Arretche", Some("Panoramax"), None, None)
+      ImageryAttribution.line(PanoSource.Panoramax, None, Some("  ")).value mustBe
         ImageryAttribution.Line("Panoramax", None, None, None)
     }
 
+    "ignore a licence recorded against a source whose licence follows from the source itself" in {
+      ImageryAttribution.line(PanoSource.Mapillary, Some("jacobwhall"), Some("CC-BY-4.0")).value.license mustBe
+        Some(ImageryAttribution.MapillaryLicense)
+      ImageryAttribution.line(PanoSource.Gsv, Some("© 2025 Google"), Some("CC-BY-4.0")).value.license mustBe None
+    }
+
     "attribute nothing when a provider's copyright string is all that could be shown and none is recorded" in {
-      ImageryAttribution.line(PanoSource.Gsv, None) mustBe None
-      ImageryAttribution.line(PanoSource.Gsv, Some(" ")) mustBe None
-      ImageryAttribution.line(PanoSource.Infra3d, None) mustBe None
+      ImageryAttribution.line(PanoSource.Gsv, None, None) mustBe None
+      ImageryAttribution.line(PanoSource.Gsv, Some(" "), None) mustBe None
+      ImageryAttribution.line(PanoSource.Infra3d, None, None) mustBe None
     }
 
     "serialize with the licence link the UI needs, and nulls where there is none" in {
-      ImageryAttribution.line(PanoSource.Mapillary, Some("jacobwhall")).value.toJson mustBe Json.obj(
+      ImageryAttribution.line(PanoSource.Mapillary, Some("jacobwhall"), None).value.toJson mustBe Json.obj(
         "holder"      -> "© jacobwhall",
         "provider"    -> "Mapillary",
         "license"     -> "CC BY-SA 4.0",
         "license_url" -> "https://creativecommons.org/licenses/by-sa/4.0/"
       )
-      ImageryAttribution.line(PanoSource.Gsv, Some("© 2025 Google")).value.toJson mustBe Json.obj(
+      ImageryAttribution.line(PanoSource.Gsv, Some("© 2025 Google"), None).value.toJson mustBe Json.obj(
         "holder"      -> "© 2025 Google",
         "provider"    -> JsNull,
         "license"     -> JsNull,
         "license_url" -> JsNull
       )
+    }
+  }
+
+  "ImageryAttribution.panoramaxLicensesJson" should {
+    // main.scala.html stamps this as window.panoramaxLicenses and PanoramaxViewer indexes it by identifier, so the
+    // shape is a contract between the two halves of what is deliberately one table (#5202).
+    "carry the whole table in the shape PanoramaxViewer looks an identifier up in" in {
+      val stamped = Json.parse(ImageryAttribution.panoramaxLicensesJson)
+      stamped.as[JsObject].keys mustBe ImageryAttribution.PanoramaxLicenses.keySet
+      ImageryAttribution.PanoramaxLicenses.foreach { case (id, license) =>
+        (stamped \ id).get mustBe Json.obj("name" -> license.name, "url" -> license.url)
+      }
     }
   }
 }

--- a/test/models/pano/PanoExpiredAtSpec.scala
+++ b/test/models/pano/PanoExpiredAtSpec.scala
@@ -42,9 +42,10 @@ class PanoExpiredAtSpec extends PlaySpec with BeforeAndAfterAll with GuiceOneApp
   /** The pano as a user's viewer would first record it: present, unexpired, never expired. */
   private def freshPano(viewedAt: OffsetDateTime): PanoData = PanoData(
     panoId = panoId, width = Some(16384), height = Some(8192), tileWidth = Some(512), tileHeight = Some(512),
-    captureDate = "2020-06", copyright = Some("test"), lat = Some(47.0), lng = Some(-122.0), cameraHeading = Some(0d),
-    cameraPitch = Some(0d), cameraRoll = Some(0d), expired = false, lastViewed = viewedAt, panoHistorySaved = None,
-    lastChecked = viewedAt, source = PanoSource.Gsv, hasBackup = Some(false), address = None, sourceMetadata = None
+    captureDate = "2020-06", copyright = Some("test"), license = None, lat = Some(47.0), lng = Some(-122.0),
+    cameraHeading = Some(0d), cameraPitch = Some(0d), cameraRoll = Some(0d), expired = false, lastViewed = viewedAt,
+    panoHistorySaved = None, lastChecked = viewedAt, source = PanoSource.Gsv, hasBackup = Some(false), address = None,
+    sourceMetadata = None
   )
 
   /** Truncated to microseconds, the precision Postgres stores — a raw Instant carries nanoseconds it drops. */

--- a/test/models/pano/PanoImageryLogSpec.scala
+++ b/test/models/pano/PanoImageryLogSpec.scala
@@ -47,9 +47,10 @@ class PanoImageryLogSpec extends PlaySpec with BeforeAndAfterAll with GuiceOneAp
   /** The pano as a user's viewer would first record it: present, unexpired, never expired. */
   private def freshPano(viewedAt: OffsetDateTime): PanoData = PanoData(
     panoId = panoId, width = Some(16384), height = Some(8192), tileWidth = Some(512), tileHeight = Some(512),
-    captureDate = "2020-06", copyright = Some("test"), lat = Some(47.0), lng = Some(-122.0), cameraHeading = Some(0d),
-    cameraPitch = Some(0d), cameraRoll = Some(0d), expired = false, lastViewed = viewedAt, panoHistorySaved = None,
-    lastChecked = viewedAt, source = PanoSource.Gsv, hasBackup = Some(false), address = None, sourceMetadata = None
+    captureDate = "2020-06", copyright = Some("test"), license = None, lat = Some(47.0), lng = Some(-122.0),
+    cameraHeading = Some(0d), cameraPitch = Some(0d), cameraRoll = Some(0d), expired = false, lastViewed = viewedAt,
+    panoHistorySaved = None, lastChecked = viewedAt, source = PanoSource.Gsv, hasBackup = Some(false), address = None,
+    sourceMetadata = None
   )
 
   /** The log for the seeded pano, oldest first, as (direction, source) pairs. */

--- a/test/models/pano/PanoLicenseSpec.scala
+++ b/test/models/pano/PanoLicenseSpec.scala
@@ -1,0 +1,92 @@
+package models.pano
+
+import models.utils.MyPostgresProfile
+import models.utils.MyPostgresProfile.api._
+import org.scalatest.BeforeAndAfterAll
+import org.scalatestplus.play.PlaySpec
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
+import play.api.db.slick.DatabaseConfigProvider
+import play.api.inject.guice.GuiceApplicationBuilder
+import slick.dbio.DBIO
+
+import java.time.OffsetDateTime
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+/**
+ * DB-backed contract test for `pano_data.license` (#5202, evolution 376).
+ *
+ * A Panoramax contributor picks a licence per picture, so it can't be inferred from `source` the way Mapillary's
+ * can, and it is what lets `ImageryAttribution` name the licence on a crop or a self-hosted pano that Project
+ * Sidewalk renders itself. It is an intrinsic property of the picture, so `upsert` treats it like `copyright`: fill
+ * a NULL, never overwrite, never clear.
+ *
+ * Seeds its own pano rather than hunting for one in the connected DB, so it can never pass vacuously. Requires a
+ * Postgres+PostGIS database (DATABASE_URL / DATABASE_USER / DATABASE_PASSWORD, as in dev/CI); the scheduling actors
+ * are disabled so no background sweep touches the row mid-test.
+ */
+class PanoLicenseSpec extends PlaySpec with BeforeAndAfterAll with GuiceOneAppPerSuite {
+
+  override def fakeApplication(): Application =
+    new GuiceApplicationBuilder().disable[modules.ActorModule].build()
+
+  private val panoDataTable = app.injector.instanceOf[PanoDataTable]
+  private val dbConfig      = app.injector.instanceOf[DatabaseConfigProvider].get[MyPostgresProfile]
+
+  private def run[T](action: DBIO[T]): T = Await.result(dbConfig.db.run(action), 60.seconds)
+
+  private val panoId = "test-5202-license"
+
+  /** A Panoramax picture as its viewer would record it, with whatever licence the submission carried. */
+  private def pano(license: Option[String]): PanoData = PanoData(
+    panoId = panoId, width = Some(8192), height = Some(4096), tileWidth = Some(512), tileHeight = Some(512),
+    captureDate = "2025-04", copyright = Some("Arretche"), license = license, lat = Some(43.49), lng = Some(-1.47),
+    cameraHeading = Some(0d), cameraPitch = Some(0d), cameraRoll = Some(0d), expired = false,
+    lastViewed = OffsetDateTime.now, panoHistorySaved = None, lastChecked = OffsetDateTime.now,
+    source = PanoSource.Panoramax, hasBackup = Some(false), address = None, sourceMetadata = None
+  )
+
+  private def storedLicense: Option[String] = run(panoDataTable.getPano(panoId)).flatMap(_.license)
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    val _ = run(sqlu"DELETE FROM pano_data WHERE pano_id = $panoId")
+  }
+
+  override def afterAll(): Unit = {
+    val _ = run(sqlu"DELETE FROM pano_data WHERE pano_id = $panoId")
+    super.afterAll()
+  }
+
+  "pano_data.license" should {
+    "be null for a pano submitted without one" in {
+      run(panoDataTable.upsert(pano(None)))
+      storedLicense mustBe None
+    }
+
+    "be filled in by a later submission that carries one" in {
+      run(panoDataTable.upsert(pano(Some("CC-BY-SA-4.0"))))
+      storedLicense mustBe Some("CC-BY-SA-4.0")
+    }
+
+    "survive a later submission that carries none, rather than being cleared" in {
+      run(panoDataTable.upsert(pano(None)))
+      storedLicense mustBe Some("CC-BY-SA-4.0")
+    }
+
+    // A picture's licence is a property of the picture, so a differing value is a client bug or a stale tab, not a
+    // relicensing. Keeping the first recorded value matches how `copyright` and the dimensions behave.
+    "keep the recorded value when a later submission disagrees" in {
+      run(panoDataTable.upsert(pano(Some("etalab-2.0"))))
+      storedLicense mustBe Some("CC-BY-SA-4.0")
+    }
+
+    "reach the attribution a crop or a self-hosted pano is rendered with" in {
+      val stored = run(panoDataTable.getPano(panoId)).value
+      val line   = ImageryAttribution.line(stored.source, stored.copyright, stored.license).value
+      line.text mustBe "© Arretche · Panoramax · CC BY-SA 4.0"
+      line.licenseUrl mustBe Some("https://creativecommons.org/licenses/by-sa/4.0/")
+    }
+  }
+}

--- a/test/service/ExploreAddressServiceSpec.scala
+++ b/test/service/ExploreAddressServiceSpec.scala
@@ -229,7 +229,7 @@ class ExploreAddressServiceSpec
         PanoSubmission(panoId = specPanoId, source = PanoSource.Gsv, captureDate = "2024-06", width = Some(8192),
           height = Some(4096), tileWidth = Some(512), tileHeight = Some(512), lat = Some(41.87), lng = Some(-87.62),
           cameraHeading = Some(180d), cameraPitch = Some(0d), cameraRoll = None, links = Seq.empty, copyright = None,
-          address = None, history = Seq.empty, sourceMetadata = None)
+          license = None, address = None, history = Seq.empty, sourceMetadata = None)
       )
     )
 


### PR DESCRIPTION
Closes #5202.

A Panoramax contributor picks a licence **per picture** — the federated catalog serves `CC-BY-SA-4.0`, `CC-BY-4.0` and `etalab-2.0` side by side — so unlike Mapillary's uniform CC BY-SA it cannot be inferred from the imagery source. The live viewer read it off the STAC item, but `pano_data` recorded nothing, so everything Project Sidewalk renders itself could name the producer and Panoramax and stop there. CC BY-SA asks that the licence be identified alongside the attribution.

Bayonne launches on 09-18, so this needs to land before the first Panoramax labels exist — after that, the only way to recover a picture's licence is to re-fetch every item from the API.

## Storing the licence

Evolution **376** adds a nullable `pano_data.license`, carried from the STAC item through `PanoData`/`Form.js` into `PanoSubmission` and the upsert, where it is `COALESCE`d like `copyright`: fill a NULL, never overwrite, never clear.

**Deliberately no CHECK constraint.** The value set is open rather than closed — it is whatever identifier the contributor's own instance recorded — so a CHECK would reject an unseen id and lose the one fact the column exists to keep. `ImageryAttribution` names an unrecognized id verbatim and unlinked, since identifying the licence is the point.

The identifier → display name/URL table lives only in `ImageryAttribution`. `main.scala.html` stamps it as `window.panoramaxLicenses`, and `PanoramaxViewer` reads that, so the attribution the server renders on a crop and the one the live viewer renders name the same licence the same way.

## Showing it everywhere we serve our own imagery

A licence is only useful where it is shown, and it was shown in one place: the label-detail card. The **Gallery grid** and the **landing page's validation grid** serve crops we cut ourselves and rendered licensed imagery with no attribution on screen at all.

Both grids now carry the same pair the detail card does — the source logo bottom-left, the rights holder and licence bottom-right. On a card the pill takes a compact form: tiny type, wrapping rather than truncating (the licence name is the last thing that may be cut), and no provider name, since the logo opposite it already carries that. Only licensed imagery has a licence to name, so the pill hides itself on GSV and infra3d; **the logo is new on those cities' cards**, where nothing previously said whose imagery it was.

Both sit flush at the bottom edge and paint *under* the hover vote bar, which owns that strip while it is up.

The detail card's own pill moves from the pano's top-right to its bottom-right, onto the source logo's optical line, so the two read as one credit rather than two chips in opposite corners.

## Two supporting changes

- **Labels carry `pano_source` in their JSON.** A card's credit has to name the source *its own* imagery came from, and a city that has changed providers holds labels from both. The Gallery's viewer class is picked per *city*, which is the wrong granularity for this.
- **`PanoViewerLogo` is keyed on that source string rather than on a viewer class.** It therefore references no viewer and can ship, with `PanoAttribution`, as the 13 KB `pano-credit` bundle. The landing page defers everything it can and has no business loading the 170 KB viewer bundle for two overlays. The source name each viewer already knew is now its `static SOURCE`, read once by `PanoViewer`'s constructor instead of repeated per subclass.

## Testing

- Verified on a local Bayonne app: `pano_data.license` populated from the API, `/label/labels` returning `pano_source` alongside the Licence Ouverte 2.0 attribution, and the credit rendering on the detail card and both grids.
- `npx jest` — 117 suites / 1597 tests green (`galleryCardLocation.test.js` gained stubs for the two credit helpers `Card` now builds).
- ESLint, Stylelint, HTMLHint, `check-asset-paths`, `check-css-layout` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 5 (1M context), claude-opus-5[1m]
