### PR TITLE
Lint the other half of our CSS: make .stylelintignore a denylist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
         run: npx eslint public/js/ public/locales/ test/js/ test/e2e/ playwright.config.js
 
       # Blocking: the CSS tree is kept stylelint-clean (#2487), the CSS counterpart to the ESLint gate above. Same glob
-      # `make stylelint` defaults to; vendored/generated CSS is carved out by stylelint.config.mjs's own `ignoreFiles`.
+      # `make stylelint` defaults to; vendored/generated CSS is carved out by `.stylelintignore`.
       # The glob is single-quoted so Stylelint's own globber expands `**` (not the shell). Like ESLint, no
       # `--max-warnings` flag: the one `warning` rule (max-line-length) is deliberately advisory — CLAUDE.md sanctions
       # long-line exceptions — so an over-limit line nags but doesn't block. `if: always()` runs it even when an earlier

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,6 +1,11 @@
-*
-**/*.*
-!**/*.css
-!public/
-!public/css/
-!public/css/*
+# Read with .gitignore semantics, against the `public/**/*.css` glob `make stylelint` and CI pass in. Everything that
+# glob reaches is ours and gets linted, so this file only names the CSS under public/ that isn't: Grunt's concatenated
+# output and vendored libraries.
+#
+# Deny, never allow. This was an allowlist (`*` plus a `!` line per directory) until #5218, and that shape hid 32 of
+# our 66 stylesheets for two months: `*` excludes a path component at *every* depth, and .gitignore can't re-include a
+# file whose parent directory is excluded, so the `!public/css/*` line reached only the direct children of css/ and
+# every pages/<family>/ subdirectory (explore/, validate/, gallery/, api-docs/) went unlinted in silence. A denylist
+# names nothing under public/css/, so moving files around in there can't drop them from the lint again.
+public/js/**/build/
+public/vendor/

--- a/stylelint.config.mjs
+++ b/stylelint.config.mjs
@@ -1,6 +1,7 @@
 // Stylelint config (Stylelint 17).
-// Run with `make stylelint` (defaults to all non-vendored CSS under public/); not a CI gate yet — that waits on the
-// tree being lint-clean, like the ESLint rollout (#2487).
+// Run with `make stylelint` (defaults to all non-vendored CSS under public/), and a blocking CI gate. Generated
+// bundles and vendored libraries are excluded in `.stylelintignore` — the one place ignores live, so there's no
+// second list to fall out of sync with the tree (#5218).
 //
 // Formatting/whitespace rules live in @stylistic/stylelint-plugin, not Stylelint core: core removed all of its
 // stylistic rules in v16 (the same move ESLint made) and the plugin is their non-deprecated home — mirroring our
@@ -10,17 +11,6 @@ export default {
   // Listed first so the explicit rules below override it.
   extends: ['stylelint-config-standard'],
   plugins: ['@stylistic/stylelint-plugin', 'stylelint-plugin-use-baseline'],
-  // Generated bundles and vendored libraries. Unlike JS (where vendored code all lives under lib/), some vendored
-  // CSS sits directly in public/stylesheets/ next to our own files, so it's carved out file-by-file.
-  ignoreFiles: [
-    'public/javascripts/**/build/**',
-    'public/javascripts/lib/**',
-    'public/stylesheets/bootstrap/**',
-    'public/stylesheets/animate.css',
-    'public/stylesheets/dataTables.bootstrap.min.css',
-    'public/stylesheets/magnific-popup.css',
-    'public/stylesheets/pannellum-2.5.7.css',
-  ],
   rules: {
     // Only allow CSS features that are Baseline "newly available" (shipped in every core browser, but not yet for
     // the 30+ months "widely" requires) — the CSS analogue of the JS side's ES2022 target. Wrap genuinely


### PR DESCRIPTION
Closes #5218.

`make stylelint` is a blocking CI gate, but `.stylelintignore` was hiding **32 of our 66 stylesheets** from it — every file in a `pages/<family>/` subdirectory: `pages/explore/` (12), `pages/api-docs/` (11), `pages/validate/` (5), `pages/gallery/` (4). All of Explore's and Validate's CSS has never been linted.

## Why it happened

The file was written as an allowlist:

```gitignore
*
**/*.*
!**/*.css
!public/
!public/css/
!public/css/*
```

Two `.gitignore` rules interact badly there: `*` (no slash) excludes a path component at **every** depth, so `public/css/pages/explore` is an excluded *directory* — and `.gitignore` cannot re-include a file whose parent directory is excluded, so `!**/*.css` never gets a chance at the files inside it. `!public/css/*` reached only the direct children of `public/css/`.

It broke in a77e3afcd (#4468), the #2292 asset reorg. Before it the tool stylesheets lived at `public/js/<App>/css/` and the ignore file re-included each of those directories by name:

```gitignore
!public/js/SVLabel/css
!public/js/SVValidate/css
!public/js/Gallery/css
```

The reorg moved them to `public/css/pages/<app>/` and deleted those three lines without adding replacements. It's been silent since — a fully-skipped file produces no output, so `make stylelint` and CI report green over a 34-file run with no hint that 32 more exist.

One path *was* loud, and is worth knowing about: a **scoped** run whose every file is ignored errors rather than passing.

```console
$ stylelint 'public/css/pages/explore/**/*.css'    # i.e. make stylelint dir=public/css/pages/explore
AllFilesIgnoredError: All input files were ignored because of the ignore pattern.
exit 1
```

So the silence is specific to the broad glob `make stylelint` and CI actually use, where ignored files just quietly aren't in the count.

## What this does

**Inverts it to a denylist.** Two lines name the only CSS under `public/` that isn't ours (`public/js/**/build/` and `public/vendor/`). Nothing enumerates `public/css/`, so a future move inside it can't silently drop files from the lint again — which is the actual bug, not the missing subdirectories.

**Deletes `stylelint.config.mjs`'s `ignoreFiles`.** Every path in it (`public/javascripts/**`, `public/stylesheets/**`) has been gone since the same reorg, so it was excluding nothing and `.stylelintignore` was already the only thing carving out `vendor/` and the Grunt bundles. Both CLAUDE.md and the CI comment said otherwise; the CI comment is corrected here (develop's condensed CLAUDE.md no longer makes the claim).

## Config only — no CSS churn

The 32 files come in clean, so there's nothing to fix alongside this:

```console
$ stylelint 'public/**/*.css'
public/css/pages/mobile-validate.css
  666:121  ⚠  Expected line length to be no more than 120 characters  @stylistic/max-line-length

⚠ 1 problem (0 errors, 1 warning)
```

That one warning is pre-existing, advisory (`max-line-length` is deliberately `severity: warning`), and in a file that was already being linted.

## Verification

| | before | after |
|---|---|---|
| stylesheets linted | 34 | **66** |
| in `pages/<family>/` | 0 | **32** |
| `vendor/` or `build/` leaked in | 0 | **0** |
| errors | 0 | **0** |

```console
$ stylelint 'public/**/*.css' --formatter json | grep -c '"source"'
66
$ make lint-css-layout
CSS layout OK -- 66 stylesheets, every page file linked only by its page.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 5 (1M context), `claude-opus-5[1m]`
