### PR TITLE
Add GA4 measurement and property ids for Bayonne and Laurens

### DIFF
--- a/conf/cityparams.conf
+++ b/conf/cityparams.conf
@@ -738,8 +738,8 @@ city-params {
       waltham-ma = "G-WPQ95RFSJ2"
       houston-tx = "G-N8F4GMS59Q"
       newport-ky = "G-JNRNZDXN4G"
-      bayonne = ""
-      laurens-ia = ""
+      bayonne = "G-JJTGTHJ9SF"
+      laurens-ia = "G-7KKGLZNVF7"
     }
     test {
       newberg-or = "G-P2JPSFFN3H"
@@ -798,8 +798,8 @@ city-params {
       waltham-ma = "G-P31JHZQ4TV"
       houston-tx = "G-WXB1XWE56V"
       newport-ky = "G-834QDYWDJP"
-      bayonne = ""
-      laurens-ia = ""
+      bayonne = "G-EFNCPF8658"
+      laurens-ia = "G-SS5FFF684J"
     }
     local = ${city-params.google-analytics-4-id.test}
   }
@@ -863,6 +863,8 @@ city-params {
       waltham-ma = "537336408"
       houston-tx = "544422788"
       newport-ky = "550774837"
+      bayonne = "553018978"
+      laurens-ia = "553056658"
     }
     test {
       newberg-or = "291455570"
@@ -921,6 +923,8 @@ city-params {
       waltham-ma = "537360551"
       houston-tx = "544445091"
       newport-ky = "550803984"
+      bayonne = "553018587"
+      laurens-ia = "553079248"
     }
     local = ${city-params.google-analytics-property-id.test}
   }

--- a/conf/messages/messages.es
+++ b/conf/messages/messages.es
@@ -80,6 +80,7 @@ city.name.la-ca = Los Ángeles
 city.name.knox-oh = Condado de Knox
 city.name.niagara-falls-ny = Cataratas del Niágara
 city.name.fort-wayne-in = Fuerte Wayne
+city.name.bayonne = Bayona
 
 state.name.oregon = Oregón
 state.name.pennsylvania = Pensilvania


### PR DESCRIPTION
resolves #5210

Both cities were registered with empty `google-analytics-4-id` placeholders and no `google-analytics-property-id` entry at all, so their pages skipped the whole gtag block and neither city showed up as a row in the admin Traffic fleet view. `laurens-ia` launches 2026-09-11 and `bayonne` 2026-09-18, so both needed the ids before then.

Ran `tools/create_ga_properties.py` for each city, which created the property + web data stream in both the prod and test GA accounts under our naming convention and wrote the ids back into `conf/cityparams.conf`:

| City | Stage | Measurement id | Property id |
|---|---|---|---|
| Bayonne, France | prod | `G-JJTGTHJ9SF` | 553018978 |
| Bayonne, France | test | `G-EFNCPF8658` | 553018587 |
| Laurens, IA | prod | `G-7KKGLZNVF7` | 553056658 |
| Laurens, IA | test | `G-SS5FFF684J` | 553079248 |

Config and messages only; no code touched.

## Translations

Also added `city.name.bayonne = Bayona` to `conf/messages/messages.es`. Spanish is the one supported locale where either city's name differs from the English form — es.wikipedia titles the article "Bayona (Francia)" and Wikidata's `es` label agrees. Checked every other locale against Wikidata and the corresponding Wikipedia:

- **de, fr, nl** — Bayonne in all three, identical to the base file they fall back to.
- **pt-BR** — Wikidata's `pt-br` label is "Bayonne". (Its plain `pt` label and pt.wikipedia's title are "Baiona", the European-Portuguese form, so this one is worth a second opinion from anyone who'd rather follow pt.wikipedia.)
- **zh-TW** — already has 巴約訥 and 勞倫斯 from #5201; left as-is. Worth knowing that the sources disagree on the transliteration (Wikidata's `zh-tw` label is 巴約蒙, zh.wikipedia's title is 巴约诺), so it's a judgment call rather than a mistake, and not one I wanted to churn in this PR.
- **Laurens** needs no entry anywhere — a US place name with no exonym in any supported language.
- `state.name.iowa` and `country.name.france` are already covered everywhere they differ from English.

`make lint-locales` passes.

## Still on a person, after this merges and the test stage redeploys

- Confirm a page load on each test URL lands in that property's realtime report, and that both cities appear as rows in the admin Traffic section.
- Set business size/objectives under Admin → Property → Business details on all four properties — UI-wizard-only fields with no API equivalent, so the script skips them. They only shape the default report collections.

## Config audit

While in here I checked both cities against every per-city block. They're complete: each has an entry in all of `db-schema`, `city-short-name`, `state-id`, `country-id`, `status`, `launch-date`, `skyline-img`, `logo-img`, `landing-page-url`, both GA blocks, `ai-tag-suggestions-enabled`, `ai-validation-enabled`, `ai-validation-min-accuracy`, and `pano-viewer-type`. The only blocks they're absent from — `private-profiles-by-default`, `global-leaderboard-excluded`, `ai-label-submission-enabled` — are false-by-default exception lists that are empty or near-empty by design. The City IDs row is in `docs/dev-environment.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHLkaLysBdyaPT5Y1HfEM1