### PR TITLE
Drop the db image's unused postgresql-16-pgrouting (#5197)

### DIFF
--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -2,24 +2,25 @@ FROM postgis/postgis:16-3.5
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Everything this image adds comes from apt.postgresql.org, and nothing but repository indexes is fetched from
-# deb.debian.org (#5195). That matters because the Debian pool sits behind Fastly edges that intermittently 404 a
-# file their own freshly-fetched index advertises, and a build that pulls no package files from there cannot lose
-# that lottery — where retrying only re-rolls it, since apt retries against the same edge.
+# The only thing this image adds to the base is the scoped Postgres upgrade below, and every package file it fetches
+# comes from apt.postgresql.org; deb.debian.org is touched only for repository indexes (#5195). That matters because
+# the Debian pool sits behind Fastly edges that intermittently 404 a file their own freshly-fetched index advertises,
+# and a build that pulls no package files from there cannot lose that lottery. Retrying only re-rolls it, since apt
+# retries against the same edge.
 #
 # `--no-install-recommends` is what keeps that true. Recommends are installed by default and a pgdg package can
-# recommend one that lives in the Debian pool, so without the flag the next package added here could quietly reopen
-# the failure class. It selects the same set as today, so it costs nothing to hold the line.
+# recommend one that lives in the Debian pool, so without the flag any package added here could quietly reopen the
+# failure class.
 #
-# The Postgres upgrade names its two packages instead of running a blanket upgrade (#5176): they are all the base
-# image actually holds back, pinned to the release docker-postgis generated it against, and republishing its tag
-# does not move them. PostGIS stays off that list on purpose — pgdg carries no bullseye build past the 3.5.2 the
-# base ships, so naming it would be a no-op that could later split it from its own -scripts package. gdal-bin stays
-# out because it is only the GDAL command-line tools, which nothing here calls, and it hard-depends on python3-gdal,
-# which would drag a Python 3.9 stack out of debian-security. PostGIS raster support does not go through it: that
-# links libgdal28, which the base image already ships. pgrouting is gone for the same reason (#5197): nothing has
-# run `CREATE EXTENSION pgrouting` since 2021, and no code here has ever called a `pgr_*` function. It was a
-# leftover from the 2015 access-route project that shared this database.
+# The upgrade names its two packages instead of running a blanket upgrade (#5176): they are all the base image
+# actually holds back, pinned to the release docker-postgis generated it against, and republishing its tag does not
+# move them. PostGIS is not on that list because pgdg carries no bullseye build past the 3.5.2 the base ships, so
+# naming it would be a no-op that could later split it from its own -scripts package.
+#
+# Nothing else is installed, on purpose. PostGIS raster support links the libgdal28 the base image already ships,
+# so gdal-bin is not needed (#5196): it is only the GDAL command-line tools, which nothing here calls, and it
+# hard-depends on python3-gdal, which would drag a Python 3.9 stack out of debian-security. pgrouting is not
+# needed either (#5197): no code calls a `pgr_*` function and no database this repo builds enables the extension.
 #
 # Retries go in apt.conf.d rather than in a `-o` flag, which would apply to a single invocation, so that they cover
 # the package downloads and not just the index fetch.

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -17,14 +17,15 @@ ENV DEBIAN_FRONTEND=noninteractive
 # base ships, so naming it would be a no-op that could later split it from its own -scripts package. gdal-bin stays
 # out because it is only the GDAL command-line tools, which nothing here calls, and it hard-depends on python3-gdal,
 # which would drag a Python 3.9 stack out of debian-security. PostGIS raster support does not go through it: that
-# links libgdal28, which the base image already ships.
+# links libgdal28, which the base image already ships. pgrouting is gone for the same reason (#5197): nothing has
+# run `CREATE EXTENSION pgrouting` since 2021, and no code here has ever called a `pgr_*` function. It was a
+# leftover from the 2015 access-route project that shared this database.
 #
 # Retries go in apt.conf.d rather than in a `-o` flag, which would apply to a single invocation, so that they cover
 # the package downloads and not just the index fetch.
 RUN echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries && \
   apt-get update && \
   apt-get install -y --no-install-recommends --only-upgrade postgresql-16 postgresql-client-16 && \
-  apt-get install -y --no-install-recommends postgresql-16-pgrouting && \
   # Drop the cached .deb files and package lists, which would otherwise ship inside the image.
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
resolves #5197

Removes the `postgresql-16-pgrouting` install from `db/Dockerfile`. The full history is in the [issue comment](https://github.com/ProjectSidewalk/SidewalkWebpage/issues/5197#issuecomment-5574488401); short version: the extension came from the 2015 [access-route](https://github.com/ProjectSidewalk/access-route) project that shared this database, its last tables left the schema in evolution 24 (Jan 2019), `CREATE EXTENSION pgrouting` left `schema.sql` in Dec 2021, and no code in the repo's history has ever called a `pgr_*` function.

With it gone the db image's only apt step is the scoped `--only-upgrade` of the two Postgres packages, so the build fetches no package files beyond those.

**Verified:** built the image locally; `dpkg -l` and `/usr/share/postgresql/16/extension/` both have zero pgrouting entries and `psql` is 16.15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176qAHoG92YGNnLYEgPfZ84