### PR TITLE
Accept the expired bullseye-security Release in the db image build (#5232)

### DIFF
--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -24,7 +24,11 @@ ENV DEBIAN_FRONTEND=noninteractive
 #
 # Retries go in apt.conf.d rather than in a `-o` flag, which would apply to a single invocation, so that they cover
 # the package downloads and not just the index fetch.
-RUN echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries && \
+#
+# Check-Valid-Until is off because the base image's bullseye-security suite reached end-of-life and its Release file
+# is now expired, which apt otherwise treats as fatal (#5232). The upgrade pulls only the two named packages from the
+# current apt.postgresql.org Release, nothing from debian-security, so accepting its stale index changes nothing here.
+RUN echo 'Acquire::Retries "3"; Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/80-retries && \
   apt-get update && \
   apt-get install -y --no-install-recommends --only-upgrade postgresql-16 postgresql-client-16 && \
   # Drop the cached .deb files and package lists, which would otherwise ship inside the image.


### PR DESCRIPTION
fixes #5232

The `projectsidewalk/db` image build fails at `apt-get update` on every branch, breaking the **Backend tests** and **E2E smoke** CI jobs:

```
E: Release file for http://deb.debian.org/debian-security/dists/bullseye-security/InRelease
   is expired (invalid since ...). Updates for this repository will not be applied.
```

The base image `postgis/postgis:16-3.5` is built on Debian bullseye (11), whose LTS just lapsed, so `bullseye-security`'s signed metadata is no longer refreshed and apt treats the expired `Release` as fatal (exit 100). Runs before ~2026-09-07 21:12 UTC were green, so it is not branch-specific.

This adds `Acquire::Check-Valid-Until "false";` to the apt config the build already writes, so the stale index is a warning rather than a fatal error. The step installs only the two named Postgres packages from the current `apt.postgresql.org` Release and pulls nothing from `debian-security`, so accepting its stale index changes nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)