### PR TITLE
credits the imagery on dashboard mistake cards

### DIFF
--- a/app/formats/json/LabelFormats.scala
+++ b/app/formats/json/LabelFormats.scala
@@ -243,6 +243,9 @@ object LabelFormats {
    * Serializes a label for the user dashboard's mistake cards. Both image URLs go out because the card prefers the
    * crop (#4478) but a crop's signed URL expires, leaving `image_url` as the fallback.
    *
+   * The crop is our own copy of the provider's image, so the card has to say who to credit for it (#5254). These two
+   * sit at the top level rather than inside `pano_data` like other pages do, since the card needs nothing else.
+   *
    * @param label      The validated label.
    * @param cropUrl    The label's saved crop, if one is on disk.
    * @param cropMarker Where the label sits in that crop (#2660); absent for a crop no `label_crop` row describes.
@@ -268,7 +271,9 @@ object LabelFormats {
       "validator_comment" -> label.validatorComment,
       "crop_url"          -> cropUrl,
       "crop_marker"       -> cropMarker,
-      "image_url"         -> imageUrl
+      "image_url"         -> imageUrl,
+      "pano_source"       -> label.panoSource.toString,
+      "attribution"       -> ImageryAttribution.line(label.panoSource, label.copyright, label.license).map(_.toJson)
     )
   }
 

--- a/app/formats/json/LabelFormats.scala
+++ b/app/formats/json/LabelFormats.scala
@@ -243,9 +243,6 @@ object LabelFormats {
    * Serializes a label for the user dashboard's mistake cards. Both image URLs go out because the card prefers the
    * crop (#4478) but a crop's signed URL expires, leaving `image_url` as the fallback.
    *
-   * The crop is our own copy of the provider's image, so the card has to say who to credit for it (#5254). These two
-   * sit at the top level rather than inside `pano_data` like other pages do, since the card needs nothing else.
-   *
    * @param label      The validated label.
    * @param cropUrl    The label's saved crop, if one is on disk.
    * @param cropMarker Where the label sits in that crop (#2660); absent for a crop no `label_crop` row describes.

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -1665,6 +1665,7 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
       _vc._6
     )
 
+    // Don't drop `.subquery`: without it the two sorts flatten into one ORDER BY that Postgres rejects.
     _validations.sortBy(r => (r._1, r._10.desc)).distinctOn(_._1).subquery.sortBy(_._10.desc)
   }
 

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -192,6 +192,8 @@ case class LabelMetadataUserDash(
     labelId: Int,
     panoId: String,
     panoSource: PanoSource,
+    copyright: Option[String],
+    license: Option[String],
     pov: POV,
     canvasX: Int,
     canvasY: Int,
@@ -349,12 +351,25 @@ object LabelTable {
 
   // Type aliases for the tuple representation of LabelMetadataUserDash and queries for them.
   // TODO in Scala 3 I think that we can make these top-level like we do for the case class version.
-  type LabelMetadataUserDashTuple =
-    (Int, String, PanoSource, (Double, Double, Double), Int, Int, String, OffsetDateTime, Option[String])
+  type LabelMetadataUserDashTuple = (
+      Int,
+      String,
+      PanoSource,
+      Option[String],
+      Option[String],
+      (Double, Double, Double),
+      Int,
+      Int,
+      String,
+      OffsetDateTime,
+      Option[String]
+  )
   type LabelMetadataUserDashTupleRep = (
       Rep[Int],                                // labelId
       Rep[String],                             // panoId
       Rep[PanoSource],                         // panoSource
+      Rep[Option[String]],                     // copyright
+      Rep[Option[String]],                     // license
       (Rep[Double], Rep[Double], Rep[Double]), // pov (heading, pitch, zoom)
       Rep[Int],                                // canvasX
       Rep[Int],                                // canvasY
@@ -367,7 +382,8 @@ object LabelTable {
   implicit val labelMetadataUserDashConverter: TupleConverter[LabelMetadataUserDashTuple, LabelMetadataUserDash] =
     new TupleConverter[LabelMetadataUserDashTuple, LabelMetadataUserDash] {
       def fromTuple(t: LabelMetadataUserDashTuple): LabelMetadataUserDash =
-        LabelMetadataUserDash(t._1, t._2, t._3, POV.tupled(t._4), t._5, t._6, LabelTypeEnum.byName(t._7), t._8, t._9)
+        LabelMetadataUserDash(t._1, t._2, t._3, t._4, t._5, POV.tupled(t._6), t._7, t._8, LabelTypeEnum.byName(t._9),
+          t._10, t._11)
     }
 
   // Type alias for the tuple representation of LabelForLabelMap query results. Includes streetEdgeId (2nd element,
@@ -1639,6 +1655,8 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
       _lb.labelId,
       _lb.panoId,
       _pd.source,
+      _pd.copyright,
+      _pd.license,
       (_lp.heading.asColumnOf[Double], _lp.pitch.asColumnOf[Double], _lp.zoom.asColumnOf[Double]),
       _lp.canvasX,
       _lp.canvasY,
@@ -1648,7 +1666,7 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
     )
 
     // Get the most recent matching validation for each label.
-    _validations.sortBy(r => (r._1, r._7.desc)).distinctOn(_._1)
+    _validations.sortBy(r => (r._1, r._9.desc)).distinctOn(_._1)
   }
 
   /**

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -1665,8 +1665,10 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
       _vc._6
     )
 
-    // Get the most recent matching validation for each label.
-    _validations.sortBy(r => (r._1, r._9.desc)).distinctOn(_._1)
+    // Keep only the most recent matching validation for each label: newest first, then one row per label. Sort on the
+    // validation's timestamp (_10), not the label type (_9) -- the query already filters to a single label type, so
+    // every row shares it and sorting on it picks an arbitrary validation.
+    _validations.sortBy(r => (r._1, r._10.desc)).distinctOn(_._1)
   }
 
   /**

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -1665,10 +1665,11 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
       _vc._6
     )
 
-    // Keep only the most recent matching validation for each label: newest first, then one row per label. Sort on the
-    // validation's timestamp (_10), not the label type (_9) -- the query already filters to a single label type, so
-    // every row shares it and sorting on it picks an arbitrary validation.
-    _validations.sortBy(r => (r._1, r._10.desc)).distinctOn(_._1)
+    // One row per label, holding that label's newest validation (_10 is the validation's timestamp). Postgres makes
+    // DISTINCT ON sort by the label id first, which would hand the caller the user's lowest label ids -- their oldest
+    // labels -- when it takes the first n. `.subquery` keeps that sort inside a nested query so the newest-first sort
+    // applies to its results; without it Slick flattens the two into one ORDER BY that Postgres rejects.
+    _validations.sortBy(r => (r._1, r._10.desc)).distinctOn(_._1).subquery.sortBy(_._10.desc)
   }
 
   /**

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -1665,10 +1665,6 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
       _vc._6
     )
 
-    // One row per label, holding that label's newest validation (_10 is the validation's timestamp). Postgres makes
-    // DISTINCT ON sort by the label id first, which would hand the caller the user's lowest label ids -- their oldest
-    // labels -- when it takes the first n. `.subquery` keeps that sort inside a nested query so the newest-first sort
-    // applies to its results; without it Slick flattens the two into one ORDER BY that Postgres rejects.
     _validations.sortBy(r => (r._1, r._10.desc)).distinctOn(_._1).subquery.sortBy(_._10.desc)
   }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -96,22 +96,22 @@ different places — the snapshot at its canvas fraction, the job's window where
 says (the centre, unless the window shifted off a pole) — and the files look alike, so **every crop's provenance is a
 `label_crop` row** (#2660): which writer, and the label's position as fractions of the image. Each writer records its
 row as it writes, the job's reconcile pass classifies any crop found without one (by size, then by the file's age
-against the label's, and never on a signal that disagrees with the others), and the four surfaces that draw a marker
-on a crop — the Gallery card, the landing validation grid, the popup's crop fallback, the share preview — take it
-from the row (`crop_marker` in the label payloads), falling back to the canvas fraction only while a crop is
-unrecorded or the image on screen is the Street View still. A new crop writer must write that row, and a new surface
-that marks a crop must read it. A pano too wide for a WebGL texture (Pannellum renders one, and 8192 px is a common
-cap) is shown from a downscaled copy the scraper writes beside the native file as `<panoId>.w8192.jpg`;
+against the label's, and never on a signal that disagrees with the others), and the five surfaces that draw a marker on
+a crop — the Gallery card, the landing validation grid, the dashboard's mistake cards, the popup's crop fallback, the
+share preview — take it from the row (`crop_marker` in the label payloads), falling back to the canvas fraction only
+while a crop is unrecorded or the image on screen is the Street View still. A new crop writer must write that row, and a
+new surface that marks a crop must read it. A pano too wide for a WebGL texture (Pannellum renders one, and 8192 px is a
+common cap) is shown from a downscaled copy the scraper writes beside the native file as `<panoId>.w8192.jpg`;
 `/backupImage/:panoId` serves it in place of the native file when it exists, and the viewer can't tell, because it
-places markers by angle. The app never cuts that copy itself: a whole-pano derivative needs more heap than a city
-stage has, and cutting one nightly for every wide pano OOM-killed prod JVMs (#5239). It does *count* them — the
-nightly job stats the expected sidecar for every wide pano and records `sidecars_present`/`sidecars_missing` on its
-run row, warning when any are missing, because otherwise a scraper that had stopped writing them would show up only
-as a viewer failing to render, months later. Imagery Project Sidewalk shows a copy of — a self-hosted pano or a
-crop — carries the attribution
-`ImageryAttribution` composes (Mapillary contributors are CC BY-SA 4.0), rendered by `PanoAttribution.js` in the
-label-detail pano box and in Validate's Pannellum fallback (`css/components/pano-attribution.css` is the shared look;
-each host positions the pill).
+places markers by angle. The app never cuts that copy itself: a whole-pano derivative needs more heap than a city stage
+has, and cutting one nightly for every wide pano OOM-killed prod JVMs (#5239). It does *count* them — the nightly job
+stats the expected sidecar for every wide pano and records `sidecars_present`/`sidecars_missing` on its run row, warning
+when any are missing, because otherwise a scraper that had stopped writing them would show up only as a viewer failing
+to render, months later. Imagery Project Sidewalk shows a copy of — a self-hosted pano or a crop — carries the
+attribution `ImageryAttribution` composes (Mapillary contributors are CC BY-SA 4.0), rendered by `PanoAttribution.js`
+alongside the source logo `PanoViewerLogo.js` draws: in the label-detail pano box, in Validate's Pannellum fallback, and
+on every card that shows a crop — the Gallery card, the landing validation grid, and the dashboard's mistake cards
+(`css/components/pano-attribution.css` is the shared look; each host positions the pill).
 
 If either category outgrows its lane — thousands of files, multi-MB originals, a CDN or on-the-fly transforms in
 front — the move is to object storage (S3/MinIO), never the local filesystem.

--- a/public/css/pages/user-dashboard.css
+++ b/public/css/pages/user-dashboard.css
@@ -744,15 +744,28 @@
   pointer-events: none;
 }
 
+/* Top-left, opposite the expand hint. The bottom of the image is reserved for the imagery credit (#5254): we're
+   required to show that one, so our own badge is the one that moves. */
 .ud-card-verdict {
   position: absolute;
-  bottom: 8px;
+  top: 8px;
   left: 8px;
   padding: 2px 8px;
   border-radius: 10px;
   font: var(--text-caption-semibold);
   color: var(--color-neutral-white);
   background: var(--color-error-200);
+}
+
+/* Who to credit for the card's image (#5254; the look lives in css/components/pano-attribution.css). Nothing else
+   sits along the bottom edge, so the logo and the credit both sit flush there, like on a Gallery card. */
+.ud-card-img .pano-viewer-logo {
+  --ui-scale: 0.72; /* Card-sized: the 29px logo row down to ~21px. Only the logo — the pill sets its own type. */
+}
+
+.ud-card-img .pano-attribution {
+  right: 6px;
+  bottom: 4.6px; /* Puts the 16px pill's center on the scaled logo's art center, 12.6px above the image's edge. */
 }
 
 .ud-card-body {

--- a/public/css/pages/user-dashboard.css
+++ b/public/css/pages/user-dashboard.css
@@ -744,9 +744,6 @@
   pointer-events: none;
 }
 
-/* Top-left, opposite the expand hint. The bottom of the image is reserved for the imagery credit (#5254): we're
-   required to show that one, so our own badge is the one that moves. The two share the top line, so this one gives
-   ground first -- the hint is a handful of characters in every language, and this can be a long phrase. */
 .ud-card-verdict {
   position: absolute;
   top: 8px;
@@ -762,8 +759,6 @@
   background: var(--color-error-200);
 }
 
-/* Who to credit for the card's image (#5254; the look lives in css/components/pano-attribution.css). Nothing else
-   sits along the bottom edge, so the logo and the credit both sit flush there, like on a Gallery card. */
 .ud-card-img .pano-viewer-logo {
   --ui-scale: 0.72; /* Card-sized: the 29px logo row down to ~21px. Only the logo — the pill sets its own type. */
 }

--- a/public/css/pages/user-dashboard.css
+++ b/public/css/pages/user-dashboard.css
@@ -745,11 +745,16 @@
 }
 
 /* Top-left, opposite the expand hint. The bottom of the image is reserved for the imagery credit (#5254): we're
-   required to show that one, so our own badge is the one that moves. */
+   required to show that one, so our own badge is the one that moves. The two share the top line, so this one gives
+   ground first -- the hint is a handful of characters in every language, and this can be a long phrase. */
 .ud-card-verdict {
   position: absolute;
   top: 8px;
   left: 8px;
+  max-width: calc(100% - 110px);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   padding: 2px 8px;
   border-radius: 10px;
   font: var(--text-caption-semibold);
@@ -891,30 +896,43 @@
   background: var(--color-pine-100);
 }
 
-/* Clickable card image opens the interactive label popup. */
-.ud-card-img-clickable { cursor: pointer; }
+/* Covers the card image and opens the interactive label popup. Transparent, so everything under it still shows; the
+   imagery credit is added after it and so stays on top, where its licence link is still clickable. */
+.ud-card-open {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  padding: 0;
+  border: 0;
+  background: none;
+  cursor: pointer;
+}
 
-.ud-card-img-clickable:focus-visible {
+.ud-card-open:focus-visible {
   outline: 2px solid var(--color-link-200);
-  outline-offset: 2px;
+  outline-offset: -2px;
 }
 
 .ud-card-expand-hint {
   position: absolute;
   top: 8px;
   right: 8px;
+  max-width: calc(50% - 12px);
   padding: 2px 8px;
   border-radius: 10px;
   font: var(--text-caption-semibold);
   color: var(--color-neutral-white);
   background: rgb(0 0 0 / 55%);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   opacity: 0;
   transition: opacity var(--transition-fast);
   pointer-events: none;
 }
 
-.ud-card-img-clickable:hover .ud-card-expand-hint,
-.ud-card-img-clickable:focus-visible .ud-card-expand-hint { opacity: 1; }
+.ud-card-open:hover .ud-card-expand-hint,
+.ud-card-open:focus-visible .ud-card-expand-hint { opacity: 1; }
 
 /* The mistake vote/note panel injected into the label popup dialog so you can respond from the expanded view. It sits
    outside .page-content, so set a readable base font here (children inherit it) and size the heading up. Full-width

--- a/public/js/common/pano-viewer/src/PanoViewerLogo.js
+++ b/public/js/common/pano-viewer/src/PanoViewerLogo.js
@@ -2,10 +2,11 @@
  * Creates an imagery-source logo overlay at the bottom-left of the given pano container.
  *
  * The container must establish a CSS positioning context (position: relative, absolute, or fixed) so that
- * the absolutely-positioned logo is scoped to the pano area. Returns an object with two methods:
+ * the absolutely-positioned logo is scoped to the pano area. Returns an object with three methods:
  *   - showPrimaryLogo() — use when the primary viewer (GSV/Mapillary/Infra3D) is active.
  *   - showSourceLogo()  — use when Pannellum is active as a backup, and on a still we render ourselves (a crop on
- *     a Gallery or landing card), where no live viewer brands the imagery at all.
+ *     a Gallery, landing or dashboard card), where no live viewer brands the imagery at all.
+ *   - hide()            — use when the image is gone, e.g. a card where every image source failed to load.
  *
  * The overlay also publishes where the logo's pixels end, as the --pano-logo-width CSS variable on the container,
  * so that overlays sitting to its right (the pano capture date and info button) can clear it.
@@ -16,7 +17,7 @@
  * @param {Element} container The positioned pano container element.
  * @param {string} primarySource The imagery source ('gsv', 'mapillary', 'infra3d', 'panoramax'); a viewer class
  *     exposes its own as the static SOURCE.
- * @returns {{ showPrimaryLogo: Function, showSourceLogo: Function }}
+ * @returns {{ showPrimaryLogo: Function, showSourceLogo: Function, hide: Function }}
  */
 function createPanoViewerLogo(container, primarySource) {
   /**
@@ -165,19 +166,21 @@ function createPanoViewerLogo(container, primarySource) {
     publishLogoWidth();
   }
 
+  /** Also forgets the logo's width, so anything sitting to its right goes back to its default spot. */
+  function hideLogo() {
+    holder.style.display = 'none';
+    activeLogo = null;
+    container.style.removeProperty('--pano-logo-width');
+  }
+
   return {
     /**
      * Shows the logo for the primary viewer, or hides the overlay for GSV (which provides its own branding).
      */
     showPrimaryLogo() {
-      if (primarySource === 'gsv') {
-        holder.style.display = 'none';
-        activeLogo = null;
-        // Google draws its own logo, so overlays to its right fall back to the offset that clears that one.
-        container.style.removeProperty('--pano-logo-width');
-      } else {
-        showLogo(primarySource);
-      }
+      // Google draws its own logo, so overlays to its right fall back to the offset that clears that one.
+      if (primarySource === 'gsv') hideLogo();
+      else showLogo(primarySource);
     },
 
     /**
@@ -185,6 +188,11 @@ function createPanoViewerLogo(container, primarySource) {
      */
     showSourceLogo() {
       showLogo(primarySource);
+    },
+
+    /** Use when the image this logo credits is no longer on screen. */
+    hide() {
+      hideLogo();
     },
   };
 }

--- a/public/js/user-dashboard/MistakeGallery.js
+++ b/public/js/user-dashboard/MistakeGallery.js
@@ -100,10 +100,25 @@ class MistakeGallery {
     const img = document.createElement('div');
     img.className = 'ud-card-img';
     const marker = iconPath ? document.createElement('img') : null;
+    // We show our own copy of the image, so we have to credit whoever it came from (#5254). Made now so the image's
+    // error handler can take them back down, but shown only once an image is up: a card that lost every image is a
+    // plain gradient, and there's nothing left to credit.
+    const logo = createPanoViewerLogo(img, m.pano_source);
+    const attribution = createPanoAttribution(img, { compact: true });
     // The crop's recorded position describes the crop only, so losing it has to re-place the marker.
-    const photo = MistakeGallery.#photo(m,
-      (source) => marker && MistakeGallery.#positionMarker(marker, m, source));
-    if (photo) img.appendChild(photo);
+    const photo = MistakeGallery.#photo(m, (source) => {
+      if (marker) MistakeGallery.#positionMarker(marker, m, source);
+      // The backup image is the same panorama, so it needs the same credit. Only losing every image takes it down.
+      if (!source) {
+        logo.hide();
+        attribution.hide();
+      }
+    });
+    if (photo) {
+      img.appendChild(photo);
+      logo.showSourceLogo();
+      attribution.show(m.attribution);
+    }
     if (marker) {
       marker.className = 'ud-card-label-marker';
       marker.src = iconPath;

--- a/public/js/user-dashboard/MistakeGallery.js
+++ b/public/js/user-dashboard/MistakeGallery.js
@@ -100,25 +100,16 @@ class MistakeGallery {
     const img = document.createElement('div');
     img.className = 'ud-card-img';
     const marker = iconPath ? document.createElement('img') : null;
-    // We show our own copy of the image, so we have to credit whoever it came from (#5254). Made now so the image's
-    // error handler can take them back down, but shown only once an image is up: a card that lost every image is a
-    // plain gradient, and there's nothing left to credit.
-    const logo = createPanoViewerLogo(img, m.pano_source);
-    const attribution = createPanoAttribution(img, { compact: true });
+    // Filled in further down, once the image is on the card. The photo's error handler runs on a later event, so the
+    // overlays are always built by the time it fires.
+    let credit = null;
     // The crop's recorded position describes the crop only, so losing it has to re-place the marker.
     const photo = MistakeGallery.#photo(m, (source) => {
       if (marker) MistakeGallery.#positionMarker(marker, m, source);
       // The backup image is the same panorama, so it needs the same credit. Only losing every image takes it down.
-      if (!source) {
-        logo.hide();
-        attribution.hide();
-      }
+      if (!source) credit?.hide();
     });
-    if (photo) {
-      img.appendChild(photo);
-      logo.showSourceLogo();
-      attribution.show(m.attribution);
-    }
+    if (photo) img.appendChild(photo);
     if (marker) {
       marker.className = 'ud-card-label-marker';
       marker.src = iconPath;
@@ -131,25 +122,37 @@ class MistakeGallery {
     verdict.textContent = i18next.t('dashboard:mistake-cards.marked-incorrect');
     img.appendChild(verdict);
 
-    // Clicking the image opens the shared interactive label popup (pano + detail), when available.
+    // A real button covering the image opens the shared interactive label popup (pano + detail), when available. It
+    // has to be its own element rather than a role on the wrapper: the licence link in the credit below sits inside
+    // that wrapper, and a link inside a button is unreachable for screen readers and fires both on a click.
     if (this.labelPopup) {
-      img.classList.add('ud-card-img-clickable');
-      img.setAttribute('role', 'button');
-      img.setAttribute('tabindex', '0');
-      img.title = i18next.t('dashboard:mistake-cards.open-title');
-      img.setAttribute('aria-label', i18next.t('dashboard:mistake-cards.open-title'));
-      const open = () => this.#openPopup(m);
-      img.addEventListener('click', open);
-      img.addEventListener('keydown', (e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          open();
-        }
-      });
+      const openButton = document.createElement('button');
+      openButton.type = 'button';
+      openButton.className = 'ud-card-open';
+      openButton.title = i18next.t('dashboard:mistake-cards.open-title');
+      openButton.setAttribute('aria-label', i18next.t('dashboard:mistake-cards.open-title'));
+      openButton.addEventListener('click', () => this.#openPopup(m));
       const hint = document.createElement('span');
       hint.className = 'ud-card-expand-hint';
       hint.textContent = i18next.t('dashboard:mistake-cards.open-hint');
-      img.appendChild(hint);
+      openButton.appendChild(hint);
+      img.appendChild(openButton);
+    }
+
+    // We show our own copy of the image, so we have to credit whoever it came from (#5254). Added last so that the
+    // marker, the badges and the open button can't paint over it, and so the licence link lands outside that button.
+    // Nothing to credit when no image loaded: the card is then just a plain gradient.
+    if (photo) {
+      const logo = createPanoViewerLogo(img, m.pano_source);
+      const attribution = createPanoAttribution(img, { compact: true });
+      logo.showSourceLogo();
+      attribution.show(m.attribution);
+      credit = {
+        hide: () => {
+          logo.hide();
+          attribution.hide();
+        },
+      };
     }
     card.appendChild(img);
 

--- a/test/js/dashboardMistakeCardAttribution.test.js
+++ b/test/js/dashboardMistakeCardAttribution.test.js
@@ -1,0 +1,132 @@
+/**
+ * Tests the imagery credit on a dashboard "recent mistakes" card (public/js/user-dashboard/MistakeGallery.js, #5254).
+ *
+ * The card shows the label's saved crop, which is our own copy of the provider's image, so it has to credit that
+ * provider the same way the Gallery and landing cards do. The real overlays are loaded instead of fake ones, since
+ * the whole point is checking that the card hooks them up.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const { assetPathStub, installUtilitiesMisc, REPO_ROOT } = require('./loadGlobalScript');
+
+const GALLERY_SRC = fs.readFileSync(path.join(REPO_ROOT, 'public/js/user-dashboard/MistakeGallery.js'), 'utf8');
+const LOGO_SRC = fs.readFileSync(path.join(REPO_ROOT, 'public/js/common/pano-viewer/src/PanoViewerLogo.js'), 'utf8');
+const ATTRIBUTION_SRC =
+  fs.readFileSync(path.join(REPO_ROOT, 'public/js/common/pano-viewer/src/PanoAttribution.js'), 'utf8');
+
+const CROP_URL = '/cropImage/Obstacle/501?exp=1&sig=x';
+const GSV_URL = 'https://maps.googleapis.com/maps/api/streetview?pano=abc123';
+
+const MAPILLARY_LINE = {
+  holder: '© jacobwhall',
+  provider: 'Mapillary',
+  license: 'CC BY-SA 4.0',
+  license_url: 'https://creativecommons.org/licenses/by-sa/4.0/',
+};
+
+/** One record shaped like an entry from GET /userapi/mistakes, defaulting to a Mapillary crop. */
+function mistake(overrides = {}) {
+  return {
+    label_id: 501, pano_id: 'abc123', heading: 12, pitch: -5, zoom: 1,
+    canvas_x: 180, canvas_y: 360, label_type: 'Obstacle',
+    time_validated: '2026-07-01T12:00:00Z', validator_comment: null,
+    crop_url: CROP_URL, image_url: null,
+    pano_source: 'mapillary', attribution: MAPILLARY_LINE, ...overrides,
+  };
+}
+
+describe('the dashboard mistake card\'s imagery credit', () => {
+  const logo = () => document.querySelector('.ud-card-img .pano-viewer-logo');
+  const attribution = () => document.querySelector('.ud-card-img .pano-attribution');
+  const photo = () => document.querySelector('.ud-card-photo');
+
+  let mistakes;
+
+  async function renderGallery() {
+    document.body.innerHTML = '<div id="ud-mistakes"></div>';
+    const gallery = new window.MistakeGallery(document.getElementById('ud-mistakes'), { userId: 'ada' });
+    await gallery.render();
+  }
+
+  beforeAll(() => {
+    window.i18next = { t: (key) => key };
+    // The logo measures itself to report how wide it is. jsdom lays nothing out, so there's nothing to measure.
+    window.ResizeObserver = class { observe() {} disconnect() {} };
+    window.util = { assetPath: assetPathStub, EXPLORE_CANVAS_WIDTH: 720, EXPLORE_CANVAS_HEIGHT: 480 };
+    installUtilitiesMisc();
+    window.eval(`${LOGO_SRC}\nwindow.createPanoViewerLogo = createPanoViewerLogo;`);
+    window.eval(`${ATTRIBUTION_SRC}\nwindow.createPanoAttribution = createPanoAttribution;`);
+    window.eval(`${GALLERY_SRC}\nwindow.MistakeGallery = MistakeGallery;`);
+  });
+
+  beforeEach(() => {
+    mistakes = [mistake()];
+    window.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve({ Obstacle: mistakes }) }));
+  });
+
+  it('credits a Mapillary crop with the source logo and the licence line', async () => {
+    await renderGallery();
+
+    expect(logo().style.display).toBe('flex');
+    expect(logo().querySelector('img').src).toContain('mapillary-logo-white.png');
+    expect(attribution().hidden).toBe(false);
+    expect(attribution().textContent).toContain('© jacobwhall');
+    const license = attribution().querySelector('a');
+    expect(license.href).toBe(MAPILLARY_LINE.license_url);
+    expect(license.textContent).toContain('CC BY-SA 4.0');
+  });
+
+  // The small form leaves out the provider's name, since the logo next to it already says Mapillary.
+  it('leaves the provider name to the logo', async () => {
+    await renderGallery();
+
+    expect(attribution().textContent).not.toContain('Mapillary');
+  });
+
+  // Google gives us a copyright line but no licence, and the logo already says it's Google, so text would be clutter.
+  it('shows the Google logo but no licence pill on a Street View crop', async () => {
+    mistakes = [mistake({
+      pano_source: 'gsv', image_url: GSV_URL, attribution: { holder: '© 2025 Google', provider: null, license: null },
+    })];
+    await renderGallery();
+
+    expect(logo().querySelector('img').src).toContain('google-logo.svg');
+    expect(attribution().hidden).toBe(true);
+  });
+
+  it('shows nothing to credit when the label has no imagery at all', async () => {
+    mistakes = [mistake({ crop_url: null, image_url: null })];
+    await renderGallery();
+
+    expect(photo()).toBeNull();
+    expect(logo().style.display).toBe('none');
+    expect(attribution().hidden).toBe(true);
+  });
+
+  // With no backup image, the card falls back to a plain gradient, and there's nothing left to credit.
+  it('retracts the credit when every image source has failed', async () => {
+    await renderGallery();
+    expect(logo().style.display).toBe('flex');
+
+    photo().dispatchEvent(new window.Event('error'));
+
+    expect(document.querySelector('.ud-card-photo')).toBeNull();
+    expect(logo().style.display).toBe('none');
+    expect(attribution().hidden).toBe(true);
+  });
+
+  // The backup image is the same panorama, so the credit already showing is still the right one.
+  it('keeps the credit up when an expired crop falls back to the still', async () => {
+    mistakes = [mistake({ image_url: GSV_URL })];
+    await renderGallery();
+
+    photo().dispatchEvent(new window.Event('error'));
+
+    expect(photo().src).toContain(GSV_URL);
+    expect(logo().style.display).toBe('flex');
+    expect(attribution().hidden).toBe(false);
+  });
+});

--- a/test/js/dashboardMistakeCardAttribution.test.js
+++ b/test/js/dashboardMistakeCardAttribution.test.js
@@ -44,9 +44,9 @@ describe('the dashboard mistake card\'s imagery credit', () => {
 
   let mistakes;
 
-  async function renderGallery() {
+  async function renderGallery(opts = {}) {
     document.body.innerHTML = '<div id="ud-mistakes"></div>';
-    const gallery = new window.MistakeGallery(document.getElementById('ud-mistakes'), { userId: 'ada' });
+    const gallery = new window.MistakeGallery(document.getElementById('ud-mistakes'), { userId: 'ada', ...opts });
     await gallery.render();
   }
 
@@ -102,31 +102,43 @@ describe('the dashboard mistake card\'s imagery credit', () => {
     await renderGallery();
 
     expect(photo()).toBeNull();
-    expect(logo().style.display).toBe('none');
-    expect(attribution().hidden).toBe(true);
+    expect(logo()).toBeNull();
+    expect(attribution()).toBeNull();
   });
 
-  // With no backup image, the card falls back to a plain gradient, and there's nothing left to credit.
-  it('retracts the credit when every image source has failed', async () => {
-    await renderGallery();
-    expect(logo().style.display).toBe('flex');
-
-    photo().dispatchEvent(new window.Event('error'));
-
-    expect(document.querySelector('.ud-card-photo')).toBeNull();
-    expect(logo().style.display).toBe('none');
-    expect(attribution().hidden).toBe(true);
-  });
-
-  // The backup image is the same panorama, so the credit already showing is still the right one.
+  // Only a Street View label has a still to fall back to -- the server sends no image_url for any other source -- and
+  // that still is the same panorama as the crop, so the credit already showing is still the right one.
   it('keeps the credit up when an expired crop falls back to the still', async () => {
-    mistakes = [mistake({ image_url: GSV_URL })];
+    mistakes = [mistake({
+      pano_source: 'gsv', image_url: GSV_URL, attribution: { holder: '© 2025 Google', provider: null, license: null },
+    })];
     await renderGallery();
 
     photo().dispatchEvent(new window.Event('error'));
 
     expect(photo().src).toContain(GSV_URL);
     expect(logo().style.display).toBe('flex');
-    expect(attribution().hidden).toBe(false);
+  });
+
+  // A Mapillary crop has no still behind it, so an expired one leaves the card with no image and no credit.
+  it('drops a Mapillary credit when its crop expires, since there is no still behind it', async () => {
+    await renderGallery();
+    expect(logo().style.display).toBe('flex');
+
+    photo().dispatchEvent(new window.Event('error'));
+
+    expect(photo()).toBeNull();
+    expect(logo().style.display).toBe('none');
+    expect(attribution().hidden).toBe(true);
+  });
+
+  // The licence link has to stay reachable, so it must not sit inside the button that opens the label popup.
+  it('keeps the licence link out of the popup button', async () => {
+    await renderGallery({ labelPopup: { open: () => {} } });
+
+    expect(document.querySelector('.ud-card-open')).not.toBeNull();
+
+    expect(attribution().closest('.ud-card-open')).toBeNull();
+    expect(attribution().querySelector('a')).not.toBeNull();
   });
 });

--- a/test/js/dashboardMistakeCardImage.test.js
+++ b/test/js/dashboardMistakeCardImage.test.js
@@ -60,6 +60,9 @@ describe('the dashboard mistake card\'s image', () => {
             EXPLORE_CANVAS_HEIGHT: 480,
         };
         installUtilitiesMisc(); // The real util.misc, so labelMarkerFraction under test is the shipped one.
+        // The imagery-credit overlays; dashboardMistakeCardAttribution.test.js checks them for real.
+        window.createPanoViewerLogo = () => ({ showSourceLogo: () => {}, hide: () => {} });
+        window.createPanoAttribution = () => ({ show: () => {}, hide: () => {} });
         window.eval(`${GALLERY_SRC}\nwindow.MistakeGallery = MistakeGallery;`);
     });
 

--- a/test/models/label/MistakeCardQuerySpec.scala
+++ b/test/models/label/MistakeCardQuerySpec.scala
@@ -1,0 +1,67 @@
+package models.label
+
+import models.utils.MyPostgresProfile.api._
+import org.scalatestplus.play.PlaySpec
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import util.RolledBackDb
+
+/**
+ * Pins what the dashboard's "recent mistakes" query hands back, which two things conspire to get wrong.
+ *
+ * Postgres makes DISTINCT ON sort by the column it de-duplicates on before anything else, so the sort that picks each
+ * label's newest validation has to be nested inside a subquery before the rows can be put in newest-first order. Get
+ * that wrong one way and Postgres refuses the query outright; get it wrong the other way and it quietly returns the
+ * user's oldest labels, since the caller takes the first n rows of whatever comes back.
+ *
+ * Runs the real query against the connected database, so the illegal form fails here rather than in production.
+ */
+class MistakeCardQuerySpec extends PlaySpec with GuiceOneAppPerSuite with RolledBackDb {
+
+  override def fakeApplication(): Application =
+    new GuiceApplicationBuilder().disable[modules.ActorModule].build()
+
+  private lazy val labelTable = app.injector.instanceOf[LabelTable]
+
+  /** The user with the most incorrectly-validated labels of this type, so the ordering check has rows to work on. */
+  private def busiestUser(labelType: LabelTypeEnum.Base): Option[String] =
+    run(
+      sql"""SELECT label.user_id
+            FROM label
+            INNER JOIN label_validation ON label.label_id = label_validation.label_id
+            WHERE label.correct = false
+              AND label.label_type = ${labelType.name}::label_type
+              AND label_validation.user_id <> label.user_id
+            GROUP BY label.user_id
+            ORDER BY count(*) DESC
+            LIMIT 1""".as[String].headOption
+    )
+
+  "getValidatedLabelsForUserQuery" should {
+    "be a query Postgres accepts" in {
+      run(labelTable.getValidatedLabelsForUserQuery("no-such-user", LabelTypeEnum.Obstacle).take(5).result) mustBe empty
+    }
+
+    "hand back the newest validations first, not the lowest label ids" in {
+      LabelTypeEnum.primaryValidateLabelTypes.foreach { labelType =>
+        busiestUser(labelType).foreach { userId =>
+          val rows       = run(labelTable.getValidatedLabelsForUserQuery(userId, labelType).take(25).result)
+          val timestamps = rows.map(_._10)
+          withClue(s"$labelType rows for $userId came back out of order: ") {
+            timestamps mustBe timestamps.sortWith(_.isAfter(_))
+          }
+        }
+      }
+    }
+
+    "give each label exactly one row" in {
+      LabelTypeEnum.primaryValidateLabelTypes.foreach { labelType =>
+        busiestUser(labelType).foreach { userId =>
+          val labelIds = run(labelTable.getValidatedLabelsForUserQuery(userId, labelType).take(25).result).map(_._1)
+          labelIds.distinct mustBe labelIds
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
resolves #5254

The dashboard's mistake cards show the label's saved crop, which is our own copy of the provider's image. Every other surface that shows a crop credits the provider — the Gallery card and the landing validation grid both attach a source logo and a licence line — but these cards attached neither, and `/userapi/mistakes` sent neither the pano source nor an attribution, so the frontend had nothing to render even if it tried.

That only bites a city with self-hosted panos, and only on labels a mapper got marked incorrect. The real obligation is Mapillary's CC BY-SA, which asks for the contributor and the licence.

## What changed

**Backend.** `LabelMetadataUserDash` now carries the pano's `copyright` and `license`. `pano_data` was already joined in `getValidatedLabelsForUserQuery`, so it's two more columns through the tuple alias, its `Rep` alias, and the converter. The card JSON gains `pano_source` and `attribution`, the latter composed by the existing `ImageryAttribution.line`. Both sit at the top level rather than inside `pano_data` like other pages do, since the card needs nothing else from a pano.

**Frontend.** `MistakeGallery` attaches the source logo and the compact attribution pill, the same pair `Card.js` and `LandingValidationGrid.js` use. Only licensed imagery gets a pill, so Google and infra3d labels get a logo and nothing more.

**Layout.** The logo's default corner is bottom-left, where the "Marked incorrect" badge sat. That badge moves to the top row opposite the expand hint, giving the bottom row to the credit — the same arrangement the Gallery card uses. **This is the piece worth a look**, since it repositions an existing badge.

**`createPanoViewerLogo` gains `hide()`**, the counterpart to `PanoAttribution`'s. A card whose every image source fails drops to a bare gradient, so both overlays come down rather than crediting an image that isn't there. It reuses the branch `showPrimaryLogo()` already had for GSV.

## Second commit: an unrelated bug found on the way

`getValidatedLabelsForUserQuery` sorted on the label type before taking one row per label, under a comment saying it took the most recent validation. The query already filters to a single label type, so every row shares that value and the sort did nothing — which validation a card showed, and so which validator comment it quoted, was whatever the database returned first. Now sorts on the validation's timestamp. Split out so it can be reverted on its own.

## Testing

New `test/js/dashboardMistakeCardAttribution.test.js` loads the real overlay components rather than fakes, since the point is checking the card hooks them up: Mapillary gets a logo and a working licence link, the compact form leaves the provider name to the logo, Google gets a logo but no pill, a label with no image credits nobody, and the credit survives a crop→still fallback but comes down when every source fails.

`sbt compile` (warning-clean), `sbt test` 1336 passed, jest 1748 passed, eslint / stylelint / css-layout / asset-paths clean, scalafmt applied.

**Not verified locally:** the dev database is GSV-only — 183k `gsv` panos, zero self-hosted — so the Mapillary path can't reproduce here at all, exactly as #5254 predicted. The GSV layout check needs an admin role grant, which means writing to the dev database, so I left that to a reviewer. User `58c6da40-2e29-4e1b-af8b-16c5a1e1a95a` has 12 mistake labels with crops on disk in `sidewalk_seattle`. Worth checking there: the Google logo bottom-left with no pill beside it, the "Marked incorrect" badge and the expand hint not crowding each other at narrow card widths, and the label marker still landing on the right feature.

## Related

- #5249, where this was found and deliberately left out of scope.
- #5023 — the Google logo and attribution strip colliding at narrow card widths, i.e. these same overlays on a card-sized image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DazZndiRhXYqpRWEhrnczd