### PR TITLE
Fix the blank AccessScore intersections preview map, and add "Explore here" to its popup (#5095)

### DIFF
--- a/app/views/apiDocs/accessScoreIntersections.scala.html
+++ b/app/views/apiDocs/accessScoreIntersections.scala.html
@@ -25,7 +25,7 @@
 
   <div class="page-section" id="access-score-intersections-preview-section">
     <h2 class="page-heading" id="visual-example">AccessScore: Intersections Preview <a href="#visual-example" class="permalink">#</a></h2>
-    <p>Below is a live preview of intersection AccessScores from a sample region in @cityName, retrieved directly from the API. Each intersection is colored from red (low accessibility) to green (high); gray intersections have no audited street yet, and hollow ones are grade-separated crossings. Hover or click an intersection to see its score and the corner features that produced it.</p>
+    <p>Below is a live preview of intersection AccessScores from a sample region in @cityName, retrieved directly from the API. Each intersection is colored from red (low accessibility) to green (high); gray intersections have no audited street yet, and hollow ones are grade-separated crossings. Hover or click an intersection to see its score, the corner features that produced it, and a link into Explore at that corner.</p>
     <p class="download-note"><strong>One method, not the method.</strong> There is no single correct way to measure whether an intersection is crossable — researchers and practitioners use many different approaches. AccessScore implements just one such algorithm, and it is experimental: the weighting is deliberately simple and subject to change. Treat these scores as one lens rather than a definitive measure, and compute your own index from the <a href="@routes.ApiDocsController.labelClusters">Label Clusters API</a> if a different method suits your needs better.</p>
     <div id="access-score-intersections-preview" class="map-container"></div>
 

--- a/app/views/apiDocs/accessScoreIntersections.scala.html
+++ b/app/views/apiDocs/accessScoreIntersections.scala.html
@@ -25,7 +25,7 @@
 
   <div class="page-section" id="access-score-intersections-preview-section">
     <h2 class="page-heading" id="visual-example">AccessScore: Intersections Preview <a href="#visual-example" class="permalink">#</a></h2>
-    <p>Below is a live preview of intersection AccessScores from a sample region in @cityName, retrieved directly from the API. Each intersection is colored from red (low accessibility) to green (high); gray intersections have no audited street yet, and hollow ones are grade-separated crossings. Hover or click an intersection to see its score, the corner features that produced it, and a link into Explore at that corner.</p>
+    <p>Below is a live preview of intersection AccessScores from a sample region in @cityName, retrieved directly from the API. Each intersection is colored from red (low accessibility) to green (high); gray intersections have no audited street yet, and hollow ones are grade-separated crossings. Hover an intersection to highlight it; click for its score and the corner features that produced it.</p>
     <p class="download-note"><strong>One method, not the method.</strong> There is no single correct way to measure whether an intersection is crossable — researchers and practitioners use many different approaches. AccessScore implements just one such algorithm, and it is experimental: the weighting is deliberately simple and subject to change. Treat these scores as one lens rather than a definitive measure, and compute your own index from the <a href="@routes.ApiDocsController.labelClusters">Label Clusters API</a> if a different method suits your needs better.</p>
     <div id="access-score-intersections-preview" class="map-container"></div>
 

--- a/public/css/pages/api-docs/access-score.css
+++ b/public/css/pages/api-docs/access-score.css
@@ -1,22 +1,25 @@
 /**
  * AccessScore API Documentation - Specific Styles.
  *
- * The AccessScore (streets + regions) preview frames and their feature popups; toolbar, legend, and status messages
- * use the shared map classes in api-docs.css.
+ * The AccessScore (streets, regions, and intersections) preview frames and their feature popups; toolbar, legend,
+ * and status messages use the shared map classes in api-docs.css.
  */
 
 /* ---- Preview Container ---- */
 
-/* The toolbar stacks above the map inside the shared .map-container frame. */
+/* The toolbar (where a preview has one) stacks above the map inside the shared .map-container frame, which sets the
+   frame's height; without a rule of its own the map element is a zero-height block and nothing renders. */
 #access-score-streets-preview,
-#access-score-regions-preview {
+#access-score-regions-preview,
+#access-score-intersections-preview {
   display: flex;
   flex-direction: column;
   background-color: var(--color-neutral-white);
 }
 
 #access-score-streets-map,
-#access-score-regions-map {
+#access-score-regions-map,
+#access-score-intersections-map {
   flex: 1 1 auto;
   min-height: 0;
   width: 100%;

--- a/public/css/pages/api-docs/access-score.css
+++ b/public/css/pages/api-docs/access-score.css
@@ -7,8 +7,8 @@
 
 /* ---- Preview Container ---- */
 
-/* The toolbar (where a preview has one) stacks above the map inside the shared .map-container frame, which sets the
-   frame's height; without a rule of its own the map element is a zero-height block and nothing renders. */
+/* .map-container carries the frame's height; the map element has none of its own, so it has to be told to fill the
+   column, and a toolbar (where a preview has one) stacks above it. */
 #access-score-streets-preview,
 #access-score-regions-preview,
 #access-score-intersections-preview {

--- a/public/css/pages/api-docs/api-docs.css
+++ b/public/css/pages/api-docs/api-docs.css
@@ -424,6 +424,19 @@ pre > code.language-csv {
   margin-top: var(--space-xs);
 }
 
+/* The "(opens in a new tab)" cue for assistive tech, off-screen like the other hosts' visually-hidden text. */
+.map-popup__sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
 /* Map Overlays - Chips and legends layered over a preview map, positioned by the map's own control corners. */
 .map-chip {
   font: var(--text-caption-regular);

--- a/public/js/api-docs/accessScoreIntersectionsPreview.js
+++ b/public/js/api-docs/accessScoreIntersectionsPreview.js
@@ -125,15 +125,13 @@
     /** Wire up the click popup for the intersection layer, including a compact per-type cluster breakdown. */
     addIntersectionPopups(map) {
       map.on('click', INTERSECTION_LAYER, (e) => {
-        const p = e.features[0].properties;
+        const feature = e.features[0];
+        const p = feature.properties;
         const score = (p.score === null || p.score === undefined) ? 'N/A (unscored)' : p.score.toFixed(3);
         const counts = ApiDocsMap.featureProp(p, 'cluster_counts') || {};
         const breakdown = Object.keys(counts).filter((k) => counts[k] > 0).map((k) => `${k}: ${counts[k]}`).join(', ')
           || 'no scored features';
         const kind = p.grade_separated ? ' (grade-separated crossing)' : '';
-        // The intersection's own centroid, not e.lngLat: the click lands wherever in the circle the pointer was, and
-        // Explore's lat/lng drop-in should start the user at the corner the score describes.
-        const [lng, lat] = e.features[0].geometry.coordinates;
 
         ApiDocsMap.popup(map, e.lngLat, `
           <h4>Intersection ${p.intersection_id}${kind}</h4>
@@ -141,12 +139,30 @@
           <p><strong>Streets:</strong> ${p.degree} &nbsp; <strong>Audits:</strong> ${p.audit_count} &nbsp;
             <strong>Labels:</strong> ${p.label_count}</p>
           <p class="as-breakdown"><strong>Clusters:</strong> ${breakdown}</p>
-          <a href="/explore?lat=${lat}&lng=${lng}" class="button-ps button--primary button--tiny"
-            target="_blank" rel="noopener">
-            Explore here
-          </a>
+          ${this.exploreHereLink(feature)}
         `);
       });
+    },
+
+    /**
+     * Builds the popup's call to action into Explore, or an empty string where it would be a dead end.
+     *
+     * @param {object} feature - The clicked intersection feature.
+     * @returns {string} The link's HTML, or '' on mobile.
+     */
+    exploreHereLink(feature) {
+      // /explore sends a mobile visitor to /mobileLanding before reading any of this, and these docs pages are read
+      // on phones, so the link can only take the reader somewhere they didn't ask to go. LabelDetail hides its own
+      // "Explore here" for the same reason.
+      if (util.isMobile()) return '';
+      // The intersection's own centroid, not e.lngLat: the click lands wherever in the circle the pointer was, and
+      // Explore's lat/lng drop-in should start the user at the corner the score describes.
+      const [lng, lat] = feature.geometry.coordinates;
+      return `
+        <a href="/explore?lat=${lat}&amp;lng=${lng}" class="button-ps button--primary button--tiny"
+          target="_blank" rel="noopener">
+          Explore here<span class="map-popup__sr-only"> (opens in a new tab)</span>
+        </a>`;
     },
 
     /** Show an on-map message (e.g. when there is no data). */

--- a/public/js/api-docs/accessScoreIntersectionsPreview.js
+++ b/public/js/api-docs/accessScoreIntersectionsPreview.js
@@ -131,6 +131,9 @@
         const breakdown = Object.keys(counts).filter((k) => counts[k] > 0).map((k) => `${k}: ${counts[k]}`).join(', ')
           || 'no scored features';
         const kind = p.grade_separated ? ' (grade-separated crossing)' : '';
+        // The intersection's own centroid, not e.lngLat: the click lands wherever in the circle the pointer was, and
+        // Explore's lat/lng drop-in should start the user at the corner the score describes.
+        const [lng, lat] = e.features[0].geometry.coordinates;
 
         ApiDocsMap.popup(map, e.lngLat, `
           <h4>Intersection ${p.intersection_id}${kind}</h4>
@@ -138,6 +141,10 @@
           <p><strong>Streets:</strong> ${p.degree} &nbsp; <strong>Audits:</strong> ${p.audit_count} &nbsp;
             <strong>Labels:</strong> ${p.label_count}</p>
           <p class="as-breakdown"><strong>Clusters:</strong> ${breakdown}</p>
+          <a href="/explore?lat=${lat}&lng=${lng}" class="button-ps button--primary button--tiny"
+            target="_blank" rel="noopener">
+            Explore here
+          </a>
         `);
       });
     },


### PR DESCRIPTION
Follow-up to #5234 (#5095). Two small changes to the `/v3/api-docs/accessScoreIntersections` preview.

## 1. The preview map rendered as an empty white box

Reported on the test stage: the map was completely blank — no basemap, no points, not even the zoom controls, Mapbox logo, or attribution.

The API was fine (`/v3/api/accessScoreIntersections?regionId=358` returns 176 features for Chicago's sample region in 0.5 s). The cause was CSS: `css/pages/api-docs/access-score.css` sizes only `#access-score-streets-map` and `#access-score-regions-map`. The intersections preview builds its own bare `<div>` inside the shared 500px `.map-container` frame, so with no rule of its own it was a zero-height block and Mapbox initialized into nothing.

Fix: add the intersections ids to the two existing rules, so all three previews are sized the same way. I also swept every map element the api-docs preview JS creates (`access-score-{streets,regions,intersections}-map`, `regions-map`) — all four have a rule now, so there's no second instance of this lurking.

**Any new api-docs preview that creates its own map element needs a per-id height rule there** — the shared `.map-container` sizes the frame, not the map.

## 2. "Explore here" in the intersection popup

The popup now ends with a call to action into Explore, matching what the Streets and Regions API previews already do (`streetsPreview.js` has "Explore Street in Project Sidewalk", `accessScoreRegionsPreview.js` has "View this region's JSON"), using the same `.button-ps button--primary button--tiny` styling that `api-docs.css` already has a `.map-popup .button-ps` rule for.

Three decisions:

- **Coordinates come from the feature geometry, not `e.lngLat`.** The circles are 6–9px, so a click lands wherever in the dot the pointer was; the link uses the intersection's own centroid so Explore drops you at the corner the score describes.
- **New tab**, matching both sibling previews — you don't lose your place in a long docs page. It carries the visually-hidden "(opens in a new tab)" cue the rest of the codebase gives such links (WCAG 3.2.5, G201).
- **Hidden on mobile.** `/explore` redirects a mobile visitor to `/mobileLanding` before it reads lat/lng, and these docs pages *are* served to phones — verified locally: the page returns 200 with `data-mobile-device="true"`, while `/explore?lat&lng` 303s to `/mobileLanding`. So the link is gated on `util.isMobile()`, exactly as `LabelDetail.js` gates its own "Explore here" (with a comment naming this trap). Note `streetsPreview.js`'s Explore link is *not* gated — a pre-existing gap this PR doesn't touch.
- **`lat`/`lng`, not `streetEdgeId`.** `ExploreController`'s precedence is routeId → streetEdgeId → regionId → lat/lng; an intersection has 3+ street ids and no natural "the" street, and the lat/lng drop-in puts you at the corner.

The preview's intro sentence no longer promises the link (it isn't there on mobile) and is now accurate about what hovering does — it highlights the dot; nothing is shown until you click.

## Screenshot

<img width="1052" height="527" alt="image" src="https://github.com/user-attachments/assets/e82fbb38-1218-4830-addb-aca31209a466" />

## Testing

QA'd on Teaneck locally. Clicked a real intersection by driving headless Chrome over CDP:

```
Intersection 878   0.977 AccessScore
Streets: 3   Audits: 4   Labels: 22
Clusters: CurbRamp: 3, Crosswalk: 2
link href:  /explore?lat=40.904759657941696&lng=-74.0159010887146
link text:  Explore here     link target: _blank
```

- Before: white box, no Mapbox chrome at all. After: map draws, 49 intersections colored red→green, count chip and legend present.
- Re-run under an iPhone user agent: `data-mobile-device: true`, **0** Explore links in the popup, popup otherwise intact.
- Accessible name of the link on desktop: `Explore here (opens in a new tab)`.
- The Streets preview (control) is unchanged and still correct.
- That `/explore?lat=…&lng=…` URL returns 200 with the coordinates seeded.
- `make eslint`, `stylelint`, `htmlhint`, and `make lint-css-layout` clean on the touched files.

## Note

"Explore here" is untranslated, consistent with the rest of these pages — the api-docs preview strings are hardcoded English throughout (`"Loading AccessScore data..."`, `"49 intersections"`, the sibling previews' CTAs); only the Mapbox control locale comes from i18next. Wiring the api-docs previews into i18next is a broader change than this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 5 (1M context), claude-opus-5[1m]

