### PR TITLE
Recover a dead OSM way's lost tags from the OSM history API (#5244 step 2)

### DIFF
--- a/app/actor/OsmWayRefreshActor.scala
+++ b/app/actor/OsmWayRefreshActor.scala
@@ -23,11 +23,16 @@ object OsmWayRefreshActor {
    * Defined here rather than at each call site so the nightly refresh and the admin hand-trigger can't record the
    * same job under two different shapes.
    *
-   * @param result Ways re-fetched from Overpass and written to `osm_way`, and how many of them are gone from OSM.
+   * @param result Ways re-fetched from Overpass and written to `osm_way`, how many of them are gone from OSM, and
+   *               how many gone ways had their lost tags recovered from the OSM history or turned out unrecoverable.
    * @return The run's `details` object.
    */
-  def runDetails(result: OsmWayRefreshResult): JsObject =
-    Json.obj("ways_refreshed" -> result.waysRefreshed, "ways_missing" -> result.waysMissing)
+  def runDetails(result: OsmWayRefreshResult): JsObject = Json.obj(
+    "ways_refreshed"     -> result.waysRefreshed,
+    "ways_missing"       -> result.waysMissing,
+    "tags_recovered"     -> result.tagsRecovered,
+    "tags_unrecoverable" -> result.tagsUnrecoverable
+  )
 }
 
 /**
@@ -82,7 +87,10 @@ class OsmWayRefreshActor @Inject() (osmWayService: OsmWayService, jobRunService:
       .onComplete {
         case Success(result) =>
           logger.info(s"OSM way data refresh completed at: ${dateFormatter.format(Instant.now())}")
-          logger.info(s"Ways refreshed: ${result.waysRefreshed}; of those, gone from OSM: ${result.waysMissing}")
+          logger.info(
+            s"Ways refreshed: ${result.waysRefreshed}; of those, gone from OSM: ${result.waysMissing}. " +
+              s"Tags recovered from OSM history: ${result.tagsRecovered}; unrecoverable: ${result.tagsUnrecoverable}."
+          )
         case Failure(e) => logger.error(s"Error refreshing OSM way data: ${e.getMessage}")
       }
   }

--- a/app/models/street/OsmWayTable.scala
+++ b/app/models/street/OsmWayTable.scala
@@ -20,7 +20,9 @@ import scala.concurrent.ExecutionContext
  * @param maxspeed  Raw OSM `maxspeed` tag (e.g. "25 mph", "30"); None if the way carries no maxspeed tag.
  * @param geom      Way geometry, present only on rows discovered by the on-demand point lookup (batch rows are located
  *                  via street_edge geometry instead).
- * @param source       How the row was written: "batch" (nightly refresh) or "on_demand" (point-lookup fallback).
+ * @param source       Where the tags came from: "batch" (nightly Overpass refresh), "on_demand" (point-lookup
+ *                     fallback), or "history" (recovered from the OSM API's way history after the way died in OSM,
+ *                     #5244 -- empty tags under this source mean the history had nothing usable, checked once).
  * @param updatedAt    When the way was last fetched from Overpass; drives the staleness-based refresh.
  * @param missingSince When the refresh first found the way absent from OSM (deleted or merged away); None while it is
  *                     present. The tags of a missing way are its last known ones, kept because they still describe
@@ -41,7 +43,7 @@ class OsmWayTableDef(tag: Tag) extends Table[OsmWay](tag, "osm_way") {
   def tags: Rep[JsValue]            = column[JsValue]("tags", O.Default(Json.obj()))
   def maxspeed: Rep[Option[String]] = column[Option[String]]("maxspeed")
   def geom: Rep[Option[LineString]] = column[Option[LineString]]("geom")
-  // CHECK (source IN ('batch', 'on_demand')) in the DB (no Slick DSL for CHECK constraints).
+  // CHECK (source IN ('batch', 'on_demand', 'history')) in the DB (no Slick DSL for CHECK constraints).
   def source: Rep[String]                       = column[String]("source")
   def updatedAt: Rep[OffsetDateTime]            = column[OffsetDateTime]("updated_at")
   def missingSince: Rep[Option[OffsetDateTime]] = column[Option[OffsetDateTime]]("missing_since")
@@ -116,6 +118,41 @@ class OsmWayTable @Inject() (
       .filter { case (_, way) => way.map(_.updatedAt < cutoff).getOrElse(true) }
       .map(_._1)
       .result
+  }
+
+  /**
+   * Gets the mapped way ids that are gone from OSM and whose tags were lost before the refresh learned to keep them:
+   * marked missing, still empty, and not yet looked up in the OSM history (#5244). Each is a candidate for one
+   * history fetch; `recordHistoryTags` takes it out of this set whatever the history held.
+   */
+  def getWayIdsToBackfill: DBIO[Seq[Long]] = {
+    sql"""
+      SELECT DISTINCT osm_way.osm_way_id
+      FROM osm_way
+      INNER JOIN osm_way_street_edge ON osm_way.osm_way_id = osm_way_street_edge.osm_way_id
+      WHERE osm_way.missing_since IS NOT NULL AND osm_way.tags = '{}'::jsonb AND osm_way.source <> 'history'
+      ORDER BY osm_way.osm_way_id
+    """.as[Long]
+  }
+
+  /**
+   * Stores what the OSM history held for a way that is gone from OSM: the tags of its last visible version, or
+   * nothing. Either way the row's source becomes 'history', so the way is looked up once; with tags recovered the
+   * readers see a bridge again, with none they keep treating the way as unknown.
+   *
+   * Leaves `missing_since` (the way is still gone), `geom`, and `updated_at` alone: `updated_at` is the last
+   * Overpass fetch and drives the monthly re-check, which is what lets a reappearing way overwrite this with live
+   * tags.
+   *
+   * @return 1 if the row exists, else 0.
+   */
+  def recordHistoryTags(wayId: Long, tags: Option[JsValue], maxspeed: Option[String]): DBIO[Int] = {
+    val storedTags = Json.stringify(tags.getOrElse(Json.obj()))
+    sqlu"""
+      UPDATE osm_way
+      SET tags = $storedTags::jsonb, maxspeed = $maxspeed, source = 'history'
+      WHERE osm_way_id = $wayId
+    """
   }
 
   /**

--- a/app/models/street/OsmWayTable.scala
+++ b/app/models/street/OsmWayTable.scala
@@ -140,18 +140,22 @@ class OsmWayTable @Inject() (
    * nothing. Either way the row's source becomes 'history', so the way is looked up once; with tags recovered the
    * readers see a bridge again, with none they keep treating the way as unknown.
    *
+   * Writes only a row that still qualifies for the lookup (gone, empty, not yet 'history'). The nightly actor and the
+   * admin hand-trigger can overlap, and if the other run's refresh found the way alive and wrote live tags in the
+   * meantime, those must win: a historical tag map landing on a present way would otherwise stand for a month.
+   *
    * Leaves `missing_since` (the way is still gone), `geom`, and `updated_at` alone: `updated_at` is the last
-   * Overpass fetch and drives the monthly re-check, which is what lets a reappearing way overwrite this with live
+   * refresh fetch and drives the monthly re-check, which is what lets a reappearing way overwrite this with live
    * tags.
    *
-   * @return 1 if the row exists, else 0.
+   * @return 1 if the row was still a lookup candidate and is now written, else 0.
    */
   def recordHistoryTags(wayId: Long, tags: Option[JsValue], maxspeed: Option[String]): DBIO[Int] = {
     val storedTags = Json.stringify(tags.getOrElse(Json.obj()))
     sqlu"""
       UPDATE osm_way
       SET tags = $storedTags::jsonb, maxspeed = $maxspeed, source = 'history'
-      WHERE osm_way_id = $wayId
+      WHERE osm_way_id = $wayId AND missing_since IS NOT NULL AND tags = '{}'::jsonb AND source <> 'history'
     """
   }
 

--- a/app/service/ImageryFreshnessService.scala
+++ b/app/service/ImageryFreshnessService.scala
@@ -537,7 +537,7 @@ class ImageryFreshnessServiceImpl @Inject() (
     val (dLat, dLng) = bboxHalfWidths(lat, SampleRadiusMeters)
     val bbox         = s"${lng - dLng},${lat - dLat},${lng + dLng},${lat + dLat}"
     ws.url(s"https://api.panoramax.xyz/api/search?bbox=$bbox&filter=field_of_view%3D360&sortby=-ts&limit=100")
-      .addHttpHeaders("User-Agent" -> PanoDataService.PanoramaxUserAgent)
+      .addHttpHeaders("User-Agent" -> OutboundHttp.UserAgent)
       .withRequestTimeout(5.seconds)
       .get()
       .map { response =>

--- a/app/service/OsmWayService.scala
+++ b/app/service/OsmWayService.scala
@@ -16,8 +16,8 @@ import java.time.OffsetDateTime
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.Success
 import scala.util.control.NonFatal
+import scala.util.{Failure, Success}
 
 /**
  * What one run of the OSM way refresh did.
@@ -57,8 +57,9 @@ trait OsmWayService {
    * refresh learned to keep them, or gone before it ever saw them -- and asks the OSM API for the way's history, one
    * id at a time with a delay between requests, storing the tags of its last visible version (#5244 step 2). A
    * deleted way's final tags describe the same geometry we imported, so a bridge comes back as a bridge; nothing is
-   * matched to whatever OSM holds there now. A way whose history has nothing usable is marked too, so each id costs
-   * one lookup ever.
+   * matched to whatever OSM holds there now. That includes `maxspeed`: the sign then shows the last limit OSM
+   * recorded for that road, which is also what the refresh keeps for a way that dies from now on. A way whose
+   * history has nothing usable is marked too, so each id costs one lookup ever.
    *
    * A failed chunk or lookup fails the whole run; the next nightly tick resumes from whatever is still stale or
    * unrecovered.
@@ -110,14 +111,22 @@ class OsmWayServiceImpl @Inject() (
 
   def refreshOsmWayData(): Future[OsmWayRefreshResult] = {
     // The two phases talk to different hosts, and Overpass refuses a good share of our runs (#5237), so a failure in
-    // one must not cost the other its work: both run, and the run fails afterwards if either did.
+    // one must not cost the other its work: both run, and the run fails afterwards if either did. The run record
+    // then carries the first failure and no counts (JobRunService stores details on success only), so each phase
+    // logs its own counts, and a second failure is logged here rather than lost behind the first.
     for {
       refreshed <- refreshFromOverpass().transform(Success(_))
       recovered <- backfillMissingTags().transform(Success(_))
-      result    <- Future.fromTry(for {
-        r <- refreshed
-        b <- recovered
-      } yield r + b)
+      result    <- (refreshed, recovered) match {
+        case (Failure(first), Failure(second)) =>
+          logger.error("The OSM history backfill failed too, behind the refresh's own failure.", second)
+          Future.failed(first)
+        case _ =>
+          Future.fromTry(for {
+            r <- refreshed
+            b <- recovered
+          } yield r + b)
+      }
     } yield result
   }
 
@@ -181,12 +190,18 @@ class OsmWayServiceImpl @Inject() (
               _       <- if (idx == 0) Future.unit else after(HISTORY_REQUEST_DELAY, actorSystem.scheduler)(Future.unit)
               history <- fetchWayHistoryWithRetry(wayId)
               tags = history.flatMap(lastVisibleTags)
-              _ <- db.run(osmWayTable.recordHistoryTags(wayId, tags, tags.flatMap(maxspeedFrom)))
+              written <- db.run(osmWayTable.recordHistoryTags(wayId, tags, tags.flatMap(maxspeedFrom)))
             } yield {
-              if (tags.isEmpty) {
-                logger.warn(s"OSM way $wayId is gone from OSM and its history holds no tags; nothing to recover.")
+              if (written == 0) {
+                // Another run's refresh got to the row first (the way came back, or its history was already read).
+                logger.info(s"OSM way $wayId was no longer waiting for its history by the time it was read; skipped.")
+                acc
+              } else {
+                if (tags.isEmpty) {
+                  logger.warn(s"OSM way $wayId is gone from OSM and its history holds no tags; nothing to recover.")
+                }
+                acc + OsmWayRefreshResult(0, 0, if (tags.isDefined) 1 else 0, if (tags.isEmpty) 1 else 0)
               }
-              acc + OsmWayRefreshResult(0, 0, if (tags.isDefined) 1 else 0, if (tags.isEmpty) 1 else 0)
             }
           }
           .map { result =>
@@ -275,6 +290,10 @@ class OsmWayServiceImpl @Inject() (
   /**
    * Fetches every version of a way from the main OSM API, deleted versions included.
    *
+   * A 200 whose body is not a history document (no `elements` array: a gateway page, a truncated body) is a failure
+   * to retry, not an empty history. Reading it as "nothing to recover" would mark the way checked and never ask
+   * again, which is the one outcome of this phase that no later run corrects.
+   *
    * @return The history document, or None when the API has never held a way with this id (404).
    */
   private def fetchWayHistory(wayId: Long): Future[Option[JsValue]] = {
@@ -284,7 +303,12 @@ class OsmWayServiceImpl @Inject() (
       .get()
       .map { response =>
         response.status match {
-          case 200   => Some(Json.parse(response.body))
+          case 200 =>
+            val json = Json.parse(response.body)
+            if ((json \ "elements").asOpt[Seq[JsValue]].isEmpty) {
+              throw new RuntimeException(s"OSM history response for way $wayId has no elements array.")
+            }
+            Some(json)
           case 404   => None
           case other => throw new RuntimeException(s"OSM history query for way $wayId failed with status $other.")
         }

--- a/app/service/OsmWayService.scala
+++ b/app/service/OsmWayService.scala
@@ -16,29 +16,55 @@ import java.time.OffsetDateTime
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Success
 import scala.util.control.NonFatal
 
 /**
  * What one run of the OSM way refresh did.
  *
- * @param waysRefreshed Ways whose row was written, present in OSM or not (0 when everything was fresh).
- * @param waysMissing   Of those, ways Overpass did not return: deleted or merged away in OSM since our import. Their
- *                      last known tags are kept and `osm_way.missing_since` is stamped (#5244).
+ * @param waysRefreshed     Ways whose row was written, present in OSM or not (0 when everything was fresh).
+ * @param waysMissing       Of those, ways Overpass did not return: deleted or merged away in OSM since our import.
+ *                          Their last known tags are kept and `osm_way.missing_since` is stamped (#5244).
+ * @param tagsRecovered     Gone ways whose lost tags were recovered from the OSM history in this run.
+ * @param tagsUnrecoverable Gone ways looked up in the OSM history this run that had nothing usable there. Marked so
+ *                          they are not asked about again.
  */
-case class OsmWayRefreshResult(waysRefreshed: Int, waysMissing: Int)
+case class OsmWayRefreshResult(waysRefreshed: Int, waysMissing: Int, tagsRecovered: Int, tagsUnrecoverable: Int) {
+  def +(other: OsmWayRefreshResult): OsmWayRefreshResult = OsmWayRefreshResult(
+    waysRefreshed + other.waysRefreshed,
+    waysMissing + other.waysMissing,
+    tagsRecovered + other.tagsRecovered,
+    tagsUnrecoverable + other.tagsUnrecoverable
+  )
+}
+
+object OsmWayRefreshResult {
+  val empty: OsmWayRefreshResult = OsmWayRefreshResult(0, 0, 0, 0)
+}
 
 @ImplementedBy(classOf[OsmWayServiceImpl])
 trait OsmWayService {
 
   /**
-   * Refreshes cached way data for every mapped way whose row is missing or older than `STALENESS_PERIOD`.
+   * Refreshes cached way data for every mapped way whose row is missing or older than `STALENESS_PERIOD`, then
+   * recovers the tags of gone ways that lost them.
    *
-   * Fetches tags in chunks of `BATCH_CHUNK_SIZE` ids, sequentially with a delay between chunks. Every requested id is
-   * written even when absent from the response, so it won't re-queue nightly: a found way takes its current tags, a
-   * missing one keeps its last known tags and is marked `missing_since`. A failed chunk fails the whole run; the next
-   * nightly tick retries from whatever is still stale.
+   * The refresh fetches tags from Overpass in chunks of `BATCH_CHUNK_SIZE` ids, sequentially with a delay between
+   * chunks. Every requested id is written even when absent from the response, so it won't re-queue nightly: a found
+   * way takes its current tags, a missing one keeps its last known tags and is marked `missing_since`.
    *
-   * @return How many ways were written, and how many of them are gone from OSM.
+   * The backfill then takes every mapped way that is marked missing but still has empty tags -- blanked before the
+   * refresh learned to keep them, or gone before it ever saw them -- and asks the OSM API for the way's history, one
+   * id at a time with a delay between requests, storing the tags of its last visible version (#5244 step 2). A
+   * deleted way's final tags describe the same geometry we imported, so a bridge comes back as a bridge; nothing is
+   * matched to whatever OSM holds there now. A way whose history has nothing usable is marked too, so each id costs
+   * one lookup ever.
+   *
+   * A failed chunk or lookup fails the whole run; the next nightly tick resumes from whatever is still stale or
+   * unrecovered.
+   *
+   * @return How many ways were written and how many of them are gone from OSM, plus how many gone ways had their
+   *         tags recovered and how many turned out unrecoverable.
    */
   def refreshOsmWayData(): Future[OsmWayRefreshResult]
 
@@ -83,14 +109,31 @@ class OsmWayServiceImpl @Inject() (
   private val logger = Logger(this.getClass)
 
   def refreshOsmWayData(): Future[OsmWayRefreshResult] = {
+    // The two phases talk to different hosts, and Overpass refuses a good share of our runs (#5237), so a failure in
+    // one must not cost the other its work: both run, and the run fails afterwards if either did.
+    for {
+      refreshed <- refreshFromOverpass().transform(Success(_))
+      recovered <- backfillMissingTags().transform(Success(_))
+      result    <- Future.fromTry(for {
+        r <- refreshed
+        b <- recovered
+      } yield r + b)
+    } yield result
+  }
+
+  /**
+   * Phase one: re-fetches every stale mapped way's tags from Overpass, chunked and paced, marking the ways it no
+   * longer returns as missing.
+   */
+  private def refreshFromOverpass(): Future[OsmWayRefreshResult] = {
     db.run(osmWayTable.getWayIdsMissingOrStale(OffsetDateTime.now.minusDays(STALENESS_PERIOD_DAYS))).flatMap { wayIds =>
-      if (wayIds.isEmpty) { Future.successful(OsmWayRefreshResult(0, 0)) }
+      if (wayIds.isEmpty) { Future.successful(OsmWayRefreshResult.empty) }
       else {
         logger.info(s"Refreshing OSM way data for ${wayIds.size} ways.")
         wayIds
           .grouped(BATCH_CHUNK_SIZE)
           .zipWithIndex
-          .foldLeft(Future.successful(OsmWayRefreshResult(0, 0))) { case (accFuture, (chunk, chunkIdx)) =>
+          .foldLeft(Future.successful(OsmWayRefreshResult.empty)) { case (accFuture, (chunk, chunkIdx)) =>
             for {
               acc <- accFuture
               // Space out requests to the shared Overpass instance; no delay before the first chunk.
@@ -102,7 +145,7 @@ class OsmWayServiceImpl @Inject() (
                 (wayId, tags: JsValue, maxspeedFrom(tags))
               }
               n <- db.run(osmWayTable.upsertBatch(rows, split._2, OffsetDateTime.now))
-            } yield OsmWayRefreshResult(acc.waysRefreshed + n, acc.waysMissing + split._2.size)
+            } yield acc + OsmWayRefreshResult(n, split._2.size, 0, 0)
           }
           .map { result =>
             // A dead way id is normal OSM churn, but a jump in this count means a re-match (#5244) is overdue.
@@ -112,6 +155,45 @@ class OsmWayServiceImpl @Inject() (
                   "(deleted or merged away); kept their last known tags and marked them missing."
               )
             }
+            result
+          }
+      }
+    }
+  }
+
+  /**
+   * Phase two: recovers the tags of gone ways that have none, from the OSM API's way history (#5244 step 2).
+   *
+   * One request per way, sequential, with `HISTORY_REQUEST_DELAY` between them: the main OSM API is not built for
+   * bulk reads, and the candidate set is a few hundred ids per city once, then whatever dies before its first fetch.
+   * Each way is written as soon as its history is read, so a failure partway keeps what was recovered and the next
+   * run resumes from the rest.
+   */
+  private def backfillMissingTags(): Future[OsmWayRefreshResult] = {
+    db.run(osmWayTable.getWayIdsToBackfill).flatMap { wayIds =>
+      if (wayIds.isEmpty) { Future.successful(OsmWayRefreshResult.empty) }
+      else {
+        logger.info(s"Recovering tags for ${wayIds.size} OSM ways that are gone from OSM, from their history.")
+        wayIds.zipWithIndex
+          .foldLeft(Future.successful(OsmWayRefreshResult.empty)) { case (accFuture, (wayId, idx)) =>
+            for {
+              acc     <- accFuture
+              _       <- if (idx == 0) Future.unit else after(HISTORY_REQUEST_DELAY, actorSystem.scheduler)(Future.unit)
+              history <- fetchWayHistoryWithRetry(wayId)
+              tags = history.flatMap(lastVisibleTags)
+              _ <- db.run(osmWayTable.recordHistoryTags(wayId, tags, tags.flatMap(maxspeedFrom)))
+            } yield {
+              if (tags.isEmpty) {
+                logger.warn(s"OSM way $wayId is gone from OSM and its history holds no tags; nothing to recover.")
+              }
+              acc + OsmWayRefreshResult(0, 0, if (tags.isDefined) 1 else 0, if (tags.isEmpty) 1 else 0)
+            }
+          }
+          .map { result =>
+            logger.info(
+              s"Recovered tags for ${result.tagsRecovered} gone OSM ways from their history; " +
+                s"${result.tagsUnrecoverable} had nothing to recover."
+            )
             result
           }
       }
@@ -177,6 +259,39 @@ class OsmWayServiceImpl @Inject() (
   }
 
   /**
+   * Fetches a way's history, retrying transient failures with the same budget and spacing as the Overpass chunks.
+   * A 404 is an answer (the id never existed), not a failure, and is not retried.
+   */
+  private def fetchWayHistoryWithRetry(wayId: Long, attempt: Int = 1): Future[Option[JsValue]] = {
+    fetchWayHistory(wayId).recoverWith {
+      case NonFatal(e) if attempt < BATCH_MAX_ATTEMPTS =>
+        logger.warn(
+          s"OSM history attempt $attempt/$BATCH_MAX_ATTEMPTS for way $wayId failed (${e.getMessage}); retrying."
+        )
+        after(BATCH_RETRY_DELAY * attempt.toLong, actorSystem.scheduler)(fetchWayHistoryWithRetry(wayId, attempt + 1))
+    }
+  }
+
+  /**
+   * Fetches every version of a way from the main OSM API, deleted versions included.
+   *
+   * @return The history document, or None when the API has never held a way with this id (404).
+   */
+  private def fetchWayHistory(wayId: Long): Future[Option[JsValue]] = {
+    ws.url(s"$OSM_API_URL/way/$wayId/history.json")
+      .addHttpHeaders("User-Agent" -> OutboundHttp.UserAgent)
+      .withRequestTimeout(30.seconds)
+      .get()
+      .map { response =>
+        response.status match {
+          case 200   => Some(Json.parse(response.body))
+          case 404   => None
+          case other => throw new RuntimeException(s"OSM history query for way $wayId failed with status $other.")
+        }
+      }
+  }
+
+  /**
    * Queries Overpass for roads within `SEARCH_RADIUS_M` of the point, stores the nearest one (with geometry, so later
    * lookups nearby hit our DB), and returns its maxspeed tag.
    */
@@ -223,6 +338,12 @@ object OsmWayService {
   /** Per-coordinate cache TTL for the on-demand point lookup (doubles as a negative cache for "no road here"). */
   val POINT_CACHE_TTL: FiniteDuration = 10.minutes
 
+  /** The main OSM API (not Overpass): the one place a deleted way's history can still be read (#5244). */
+  val OSM_API_URL = "https://api.openstreetmap.org/api/0.6"
+
+  /** Pause between consecutive history requests; they go one way at a time to an API not meant for bulk reads. */
+  val HISTORY_REQUEST_DELAY: FiniteDuration = 500.millis
+
   /**
    * OSM highway values that count as drivable roads for the speed-limit sign; footpaths/cycleways etc. are excluded.
    */
@@ -250,6 +371,31 @@ object OsmWayService {
       .filter(el => (el \ "type").asOpt[String].contains("way"))
       .flatMap { el => (el \ "id").asOpt[Long].map { id => id -> (el \ "tags").asOpt[JsObject].getOrElse(Json.obj()) } }
       .toMap
+  }
+
+  /**
+   * Picks, from an OSM API way-history document, the tags that best describe the way as it was last mapped.
+   *
+   * A deleted version carries `visible: false` and no tags, and a live one omits `visible`. Of the visible versions
+   * with tags, the highest-numbered one that still carries `highway` wins, so a way retagged out of the road network
+   * just before deletion is read as the road it was (our street is still one); failing that, the highest-numbered one
+   * with any tags at all.
+   *
+   * @return The chosen version's tag map, or None when no visible version carried tags.
+   */
+  def lastVisibleTags(history: JsValue): Option[JsObject] = {
+    val tagged = (history \ "elements")
+      .asOpt[Seq[JsObject]]
+      .getOrElse(Seq.empty)
+      .filter { el => (el \ "type").asOpt[String].contains("way") && (el \ "visible").asOpt[Boolean].getOrElse(true) }
+      .flatMap { el =>
+        for {
+          version <- (el \ "version").asOpt[Long]
+          tags    <- (el \ "tags").asOpt[JsObject] if tags.keys.nonEmpty
+        } yield (version, tags)
+      }
+    val roads = tagged.filter { case (_, tags) => tags.keys.contains("highway") }
+    (if (roads.nonEmpty) roads else tagged).maxByOption(_._1).map(_._2)
   }
 
   /**

--- a/app/service/OutboundHttp.scala
+++ b/app/service/OutboundHttp.scala
@@ -1,0 +1,14 @@
+package service
+
+/**
+ * What our server-to-server HTTP calls have in common.
+ */
+object OutboundHttp {
+
+  /**
+   * How we identify ourselves to keyless, community-run APIs (Panoramax, #5185; the OSM API, #5244). Where a key
+   * already says who is calling (GSV, Mapillary) nothing else is needed, but these operators otherwise have no way to
+   * tell whose traffic this is or where to write if it misbehaves, and the OSM API's usage policy requires it.
+   */
+  val UserAgent: String = "ProjectSidewalk/1.0 (+https://projectsidewalk.org; sidewalk@cs.uw.edu)"
+}

--- a/app/service/PanoDataService.scala
+++ b/app/service/PanoDataService.scala
@@ -52,13 +52,6 @@ object PanoDataService {
   val LiveImageryTtlDays: Long = 7
 
   /**
-   * How we identify ourselves to Panoramax (#5185). Its API is keyless and community-run, so unlike GSV and
-   * Mapillary — where the key already says who is calling — nothing else tells the operators whose traffic this is
-   * or where to write if it misbehaves.
-   */
-  val PanoramaxUserAgent: String = "ProjectSidewalk/1.0 (+https://projectsidewalk.org; sidewalk@cs.uw.edu)"
-
-  /**
    * How many panos the nightly expiry sweep may have in flight at once (#4559).
    */
   val ImageryCheckConcurrency: Int = 10
@@ -576,7 +569,7 @@ class PanoDataServiceImpl @Inject() (
    */
   private def panoramaxPanoExists(panoId: String): Future[Option[Boolean]] = {
     ws.url(s"https://api.panoramax.xyz/api/pictures/$panoId")
-      .addHttpHeaders("User-Agent" -> PanoDataService.PanoramaxUserAgent)
+      .addHttpHeaders("User-Agent" -> OutboundHttp.UserAgent)
       .withRequestTimeout(5.seconds)
       .get()
       .flatMap { response =>

--- a/conf/evolutions/default/382.sql
+++ b/conf/evolutions/default/382.sql
@@ -1,0 +1,16 @@
+# --- !Ups
+-- A third provenance for a cached way's tags (#5244, step 2). 'batch' rows hold what Overpass last returned and
+-- 'on_demand' rows what the point lookup found. 'history' marks a way that is gone from OSM (missing_since set)
+-- whose tags were recovered from the main OSM API's way history -- the tags of the last visible version, which
+-- describe the same geometry we imported. A 'history' row with empty tags is one whose history had nothing usable
+-- (the id never existed, or no visible version carried tags), and the mark keeps the refresh from re-asking for it
+-- every night. The monthly Overpass re-check still covers these ids, and a way that reappears goes back to 'batch'.
+ALTER TABLE osm_way DROP CONSTRAINT osm_way_source_check;
+ALTER TABLE osm_way ADD CONSTRAINT osm_way_source_check CHECK (source IN ('batch', 'on_demand', 'history'));
+
+# --- !Downs
+-- Recovered rows fold back into 'batch' first, or the narrower CHECK would fail on them. Their tags stay, so no
+-- bridge is lost, only the provenance.
+UPDATE osm_way SET source = 'batch' WHERE source = 'history';
+ALTER TABLE osm_way DROP CONSTRAINT osm_way_source_check;
+ALTER TABLE osm_way ADD CONSTRAINT osm_way_source_check CHECK (source IN ('batch', 'on_demand'));

--- a/conf/evolutions/default/382.sql
+++ b/conf/evolutions/default/382.sql
@@ -1,16 +1,18 @@
 # --- !Ups
--- A third provenance for a cached way's tags (#5244, step 2). 'batch' rows hold what Overpass last returned and
--- 'on_demand' rows what the point lookup found. 'history' marks a way that is gone from OSM (missing_since set)
--- whose tags were recovered from the main OSM API's way history -- the tags of the last visible version, which
--- describe the same geometry we imported. A 'history' row with empty tags is one whose history had nothing usable
--- (the id never existed, or no visible version carried tags), and the mark keeps the refresh from re-asking for it
--- every night. The monthly Overpass re-check still covers these ids, and a way that reappears goes back to 'batch'.
+-- A third provenance for a cached way's tags (#5244, step 2). 'batch' rows hold what the nightly refresh last
+-- fetched and 'on_demand' rows what the point lookup found. 'history' marks a way that is gone from OSM
+-- (missing_since set) whose tags were recovered from the main OSM API's way history -- the tags of the last visible
+-- version, which describe the same geometry we imported. A 'history' row with empty tags is one whose history had
+-- nothing usable (the id never existed, or no visible version carried tags), and the mark keeps the refresh from
+-- re-asking for it every night. The monthly re-check still covers these ids, and a way that reappears goes back to
+-- 'batch'.
 ALTER TABLE osm_way DROP CONSTRAINT osm_way_source_check;
 ALTER TABLE osm_way ADD CONSTRAINT osm_way_source_check CHECK (source IN ('batch', 'on_demand', 'history'));
 
 # --- !Downs
 -- Recovered rows fold back into 'batch' first, or the narrower CHECK would fail on them. Their tags stay, so no
--- bridge is lost, only the provenance.
+-- bridge is lost. What is lost is the provenance and the checked-once mark: a row whose history held nothing folds
+-- back into a plain empty missing row, and the next Up looks it up again.
 UPDATE osm_way SET source = 'batch' WHERE source = 'history';
 ALTER TABLE osm_way DROP CONSTRAINT osm_way_source_check;
 ALTER TABLE osm_way ADD CONSTRAINT osm_way_source_check CHECK (source IN ('batch', 'on_demand'));

--- a/test/actor/JobRunDetailsSpec.scala
+++ b/test/actor/JobRunDetailsSpec.scala
@@ -30,8 +30,8 @@ class JobRunDetailsSpec extends PlaySpec {
     }
 
     "record the OSM way refresh under the key its readers use" in {
-      OsmWayRefreshActor.runDetails(OsmWayRefreshResult(13, 2)) mustBe
-        Json.obj("ways_refreshed" -> 13, "ways_missing" -> 2)
+      OsmWayRefreshActor.runDetails(OsmWayRefreshResult(13, 2, 3, 1)) mustBe
+        Json.obj("ways_refreshed" -> 13, "ways_missing" -> 2, "tags_recovered" -> 3, "tags_unrecoverable" -> 1)
     }
 
     "record clustering under the keys its readers use" in {

--- a/test/controllers/AdminJobTriggerSpec.scala
+++ b/test/controllers/AdminJobTriggerSpec.scala
@@ -65,9 +65,10 @@ class AdminJobTriggerSpec
     with Eventually {
 
   // Distinctive values, so an assertion can tell the stub's answer from anything the connected city really holds.
-  private val UsersUpdated   = 4611
-  private val FunnelRows     = 4612
-  private val WaysRefreshed  = OsmWayRefreshResult(waysRefreshed = 4613, waysMissing = 27)
+  private val UsersUpdated  = 4611
+  private val FunnelRows    = 4612
+  private val WaysRefreshed =
+    OsmWayRefreshResult(waysRefreshed = 4613, waysMissing = 27, tagsRecovered = 19, tagsUnrecoverable = 2)
   private val ImageryResult  = ImageryCheckResult(stillThere = 7, gone = 2, errors = 1, reconciled = Some(3))
   private val ClusterResults = ClusteringResults(labelCount = 4614, clusterCount = 4615)
   private val CropResult     = CropRunResult(
@@ -78,7 +79,7 @@ class AdminJobTriggerSpec
   )
 
   /** Set per test: this endpoint's failure path is part of its contract, and Guice owns the stub. */
-  @volatile private var osmWayAnswer: Future[OsmWayRefreshResult] = Future.successful(OsmWayRefreshResult(0, 0))
+  @volatile private var osmWayAnswer: Future[OsmWayRefreshResult] = Future.successful(OsmWayRefreshResult.empty)
 
   /** Set per test: whether the crop service reports a run in flight, which is the trigger's refusal path. */
   @volatile private var cropRunning: Boolean = false

--- a/test/models/street/OsmWayTableSpec.scala
+++ b/test/models/street/OsmWayTableSpec.scala
@@ -170,5 +170,29 @@ class OsmWayTableSpec
     "write nothing for a way that has no row" in {
       runRolledBack(osmWayTable.recordHistoryTags(unseenId + 100, Some(bridgeTags), None)) mustBe 0
     }
+
+    "leave a way alone that came back to life while its history was being read" in {
+      val (written, stored) = runRolledBack(for {
+        _ <- insertGoneWay(blankedId, Json.obj(), "batch", OffsetDateTime.now)
+        // Another run's refresh found the way in OSM again and wrote its live tags.
+        _       <- osmWayTable.upsertBatch(Seq((blankedId, bridgeTags, Some("40 mph"))), Nil, OffsetDateTime.now)
+        written <- osmWayTable.recordHistoryTags(blankedId, Some(Json.obj("highway" -> "footway")), None)
+        stored  <- storedRow(blankedId)
+      } yield (written, stored))
+      written mustBe 0
+      stored._1 mustBe bridgeTags
+      stored._3 mustBe "batch"
+    }
+
+    "keep recovered tags and the 'history' source through a later refresh that still finds the way gone" in {
+      val goneAt    = OffsetDateTime.now.minusDays(40)
+      val recheckAt = OffsetDateTime.now
+      val stored    = runRolledBack(for {
+        _      <- insertGoneWay(blankedId, bridgeTags, "history", goneAt)
+        _      <- osmWayTable.upsertBatch(Nil, Seq(blankedId), recheckAt)
+        stored <- storedRow(blankedId)
+      } yield stored)
+      stored mustBe ((bridgeTags, None, "history", micros(recheckAt), Some(micros(goneAt))))
+    }
   }
 }

--- a/test/models/street/OsmWayTableSpec.scala
+++ b/test/models/street/OsmWayTableSpec.scala
@@ -1,43 +1,43 @@
 package models.street
 
-import models.utils.MyPostgresProfile
 import models.utils.MyPostgresProfile.api._
 import org.scalatest.BeforeAndAfterAll
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Application
-import play.api.db.slick.DatabaseConfigProvider
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.{JsValue, Json}
 import slick.dbio.DBIO
+import util.{RolledBackDb, StreetFixtures}
 
 import java.time.temporal.ChronoUnit
 import java.time.{Instant, OffsetDateTime}
-import scala.concurrent.Await
-import scala.concurrent.duration._
 
 /**
- * DB-backed contract test for how the nightly refresh records a way that Overpass no longer returns (#5244, evolution
- * 380).
+ * DB-backed contract test for how the nightly refresh records a way that Overpass does not return (#5244, evolution
+ * 380) and how the lost tags of such a way are recovered from the OSM history (step 2, evolution 382).
  *
  * A mapped way id can die in OSM (the way deleted or merged away) while the street it described stays in our
  * network. The refresh must keep that way's last known tags -- they still describe the geometry we imported, and
  * `bridge`/`tunnel`/`layer` on a dead way id are what keeps a bridge grade-separated -- and date the disappearance in
- * `missing_since`, once. Every case here is one edge of that contract.
+ * `missing_since`, once. A way blanked before the refresh learned that is looked up in the OSM history exactly once,
+ * whatever the history held. Every case here is one edge of that contract.
  *
  * Seeds its own rows under ids no real way will ever reach, so it can never pass vacuously and never touches a
  * mapped way. Requires a Postgres+PostGIS database (DATABASE_URL / DATABASE_USER / DATABASE_PASSWORD, as in dev/CI);
  * the scheduling actors are disabled so no background refresh touches the rows mid-test.
  */
-class OsmWayTableSpec extends PlaySpec with BeforeAndAfterAll with GuiceOneAppPerSuite {
+class OsmWayTableSpec
+    extends PlaySpec
+    with BeforeAndAfterAll
+    with GuiceOneAppPerSuite
+    with RolledBackDb
+    with StreetFixtures {
 
   override def fakeApplication(): Application =
     new GuiceApplicationBuilder().disable[modules.ActorModule].build()
 
   private val osmWayTable = app.injector.instanceOf[OsmWayTable]
-  private val dbConfig    = app.injector.instanceOf[DatabaseConfigProvider].get[MyPostgresProfile]
-
-  private def run[T](action: DBIO[T]): T = Await.result(dbConfig.db.run(action), 60.seconds)
 
   private val wayId      = 900000000001L
   private val unseenId   = 900000000002L
@@ -100,6 +100,75 @@ class OsmWayTableSpec extends PlaySpec with BeforeAndAfterAll with GuiceOneAppPe
     "count found and missing ways together, and write nothing for an empty chunk" in {
       run(osmWayTable.upsertBatch(Seq((wayId, bridgeTags, Some("40 mph"))), Seq(unseenId), OffsetDateTime.now)) mustBe 2
       run(osmWayTable.upsertBatch(Nil, Nil, OffsetDateTime.now)) mustBe 0
+    }
+  }
+
+  /** The recovery contract's three seeded ways, all mapped to a street so the backfill scan can see them. */
+  private val blankedId   = 900000000003L
+  private val keptTagsId  = 900000000004L
+  private val checkedId   = 900000000005L
+  private val recoveryIds = Seq(blankedId, keptTagsId, checkedId)
+
+  /** A gone way, mapped to a fresh street, with the given tags and source. */
+  private def insertGoneWay(osmWayId: Long, tags: JsValue, source: String, goneAt: OffsetDateTime): DBIO[Int] =
+    for {
+      streetEdgeId <- insertStreet()
+      _            <- sqlu"""INSERT INTO osm_way (osm_way_id, tags, maxspeed, geom, source, updated_at, missing_since)
+                  VALUES ($osmWayId, ${Json.stringify(tags)}::jsonb, NULL, NULL, $source, $goneAt, $goneAt)"""
+      n <- sqlu"""INSERT INTO osm_way_street_edge (osm_way_street_edge_id, osm_way_id, street_edge_id)
+                  VALUES ((SELECT COALESCE(MAX(osm_way_street_edge_id), 0) + 1 FROM osm_way_street_edge),
+                          $osmWayId, $streetEdgeId)"""
+    } yield n
+
+  /** (tags, maxspeed, source, updated_at, missing_since) as stored, read inside the test's transaction. */
+  private def storedRow(id: Long): DBIO[(JsValue, Option[String], String, Instant, Option[Instant])] =
+    sql"SELECT tags::text, maxspeed, source, updated_at, missing_since FROM osm_way WHERE osm_way_id = $id"
+      .as[(String, Option[String], String, OffsetDateTime, Option[OffsetDateTime])]
+      .head
+      .map { case (tags, maxspeed, source, updatedAt, missingSince) =>
+        (Json.parse(tags), maxspeed, source, micros(updatedAt), missingSince.map(micros))
+      }
+
+  "OsmWayTable.getWayIdsToBackfill" should {
+    "list only the gone ways whose tags are empty and whose history has not been read" in {
+      val goneAt = OffsetDateTime.now
+      val listed = runRolledBack(for {
+        _   <- insertGoneWay(blankedId, Json.obj(), "batch", goneAt)
+        _   <- insertGoneWay(keptTagsId, bridgeTags, "batch", goneAt)
+        _   <- insertGoneWay(checkedId, Json.obj(), "history", goneAt)
+        ids <- osmWayTable.getWayIdsToBackfill
+      } yield ids.filter(recoveryIds.contains))
+      listed mustBe Seq(blankedId)
+    }
+  }
+
+  "OsmWayTable.recordHistoryTags" should {
+    "store recovered tags under source 'history', keeping the way marked missing and its Overpass fetch time" in {
+      val goneAt                = OffsetDateTime.now.minusDays(3)
+      val (stored, listedAfter) = runRolledBack(for {
+        _      <- insertGoneWay(blankedId, Json.obj(), "batch", goneAt)
+        n      <- osmWayTable.recordHistoryTags(blankedId, Some(bridgeTags), Some("40 mph"))
+        stored <- storedRow(blankedId)
+        ids    <- osmWayTable.getWayIdsToBackfill
+      } yield { n mustBe 1; (stored, ids.filter(recoveryIds.contains)) })
+      stored mustBe ((bridgeTags, Some("40 mph"), "history", micros(goneAt), Some(micros(goneAt))))
+      listedAfter mustBe Nil
+    }
+
+    "mark a way whose history held nothing as checked, with empty tags, so it is not looked up again" in {
+      val goneAt                = OffsetDateTime.now
+      val (stored, listedAfter) = runRolledBack(for {
+        _      <- insertGoneWay(blankedId, Json.obj(), "batch", goneAt)
+        _      <- osmWayTable.recordHistoryTags(blankedId, None, None)
+        stored <- storedRow(blankedId)
+        ids    <- osmWayTable.getWayIdsToBackfill
+      } yield (stored, ids.filter(recoveryIds.contains)))
+      stored mustBe ((Json.obj(), None, "history", micros(goneAt), Some(micros(goneAt))))
+      listedAfter mustBe Nil
+    }
+
+    "write nothing for a way that has no row" in {
+      runRolledBack(osmWayTable.recordHistoryTags(unseenId + 100, Some(bridgeTags), None)) mustBe 0
     }
   }
 }

--- a/test/service/OsmWayServiceSpec.scala
+++ b/test/service/OsmWayServiceSpec.scala
@@ -70,6 +70,51 @@ class OsmWayServiceSpec extends PlaySpec {
     }
   }
 
+  "lastVisibleTags" should {
+
+    /** One version of a way in an OSM API history document; `tags = None` with `visible = false` is a deletion. */
+    def version(n: Long, tags: Option[JsObject], visible: Boolean = true): JsObject = {
+      Json.obj("type" -> "way", "id" -> 116721547L, "version" -> n) ++
+        (if (visible) Json.obj() else Json.obj("visible" -> false)) ++
+        tags.map(t => Json.obj("tags" -> t)).getOrElse(Json.obj())
+    }
+    def history(versions: JsObject*): JsValue = Json.obj("elements" -> versions)
+
+    val bridgeV17 = Json.obj("highway" -> "trunk", "bridge" -> "yes", "layer" -> "1", "maxspeed" -> "40 mph")
+    val bridgeV18 = bridgeV17 ++ Json.obj("parking:lane:both" -> "no_stopping")
+
+    "take the last visible version's tags of a deleted way" in {
+      val aurora = history(version(17, Some(bridgeV17)), version(18, Some(bridgeV18)), version(19, None, false))
+      OsmWayService.lastVisibleTags(aurora) mustBe Some(bridgeV18)
+    }
+
+    "prefer the last version that was still a road over a later one retagged out of the network" in {
+      val retagged = history(
+        version(3, Some(bridgeV18)),
+        version(4, Some(Json.obj("landuse" -> "construction"))),
+        version(5, None, false)
+      )
+      OsmWayService.lastVisibleTags(retagged) mustBe Some(bridgeV18)
+    }
+
+    "fall back to the last tagged version when no version carried highway" in {
+      val noRoad = history(version(1, Some(Json.obj("name" -> "Old"))), version(2, Some(Json.obj("name" -> "New"))))
+      OsmWayService.lastVisibleTags(noRoad) mustBe Some(Json.obj("name" -> "New"))
+    }
+
+    "order by version number, not document order" in {
+      val shuffled = history(version(18, Some(bridgeV18)), version(17, Some(bridgeV17)))
+      OsmWayService.lastVisibleTags(shuffled) mustBe Some(bridgeV18)
+    }
+
+    "skip versions with no tags and return None when nothing is left" in {
+      OsmWayService.lastVisibleTags(history(version(1, Some(Json.obj())), version(2, None, false))) mustBe None
+      OsmWayService.lastVisibleTags(history(version(1, None))) mustBe None
+      OsmWayService.lastVisibleTags(Json.obj("elements" -> Json.arr())) mustBe None
+      OsmWayService.lastVisibleTags(Json.obj()) mustBe None
+    }
+  }
+
   "maxspeedFrom" should {
     "extract the raw maxspeed value" in {
       OsmWayService.maxspeedFrom(Json.obj("maxspeed" -> "30")) mustBe Some("30")


### PR DESCRIPTION
Step 2 of #5244. Step 1 (#5246) stopped the nightly refresh from blanking a dead way's tags; this recovers the rows it had already blanked.

## What was wrong

`osm_way_street_edge` freezes OSM way ids at import, and ways get deleted or merged in OSM afterwards. Before #5246 the refresh stored `tags = '{}'` for any way Overpass no longer returned, and every reader took that as "surface street, no maxspeed". On Seattle that is 377 of 12,573 mapped ways, the Aurora Bridge among them, and 15 confirmed missed grade-separation flags. Their tags are gone from our DB but not from OSM: the way's history still holds the tags of its last visible version, which describe the same geometry we imported.

## What changes

- **A second phase in `refreshOsmWayData`.** Every mapped way that is marked `missing_since` with empty tags is looked up once at `api.openstreetmap.org/api/0.6/way/{id}/history.json`, one id at a time with 500 ms between requests and the identifying `User-Agent` the OSM API asks for. `OsmWayService.lastVisibleTags` takes the highest-numbered visible version, preferring one still tagged `highway=*`, so a way retagged out of the road network just before deletion is read as the road it was.
- **Provenance.** Recovered tags are stored under a new `osm_way.source = 'history'` (evolution 382 widens the CHECK). A way whose history has nothing usable is stamped the same way with empty tags, so each id costs one lookup ever; the intersection derivation keeps reading it as layer unknown. `missing_since`, `geom`, and `updated_at` are left alone, so the monthly re-check still covers these ids and a way that reappears goes back to `source = 'batch'`: live tags always win over recovered ones.
- **The two phases run independently.** Overpass refuses a good share of our runs (#5237), and that must not block recovery, so both phases run and the job fails afterwards if either did. The run's details gain `tags_recovered` and `tags_unrecoverable`.
- The User-Agent string moves from `PanoDataService.PanoramaxUserAgent` to `OutboundHttp.UserAgent`, since two keyless community APIs now send it.

What is adopted is the tags OSM last held for the exact geometry we imported, never a re-match to what is there now. That re-match (step 3) is deferred.

## Verification

- `OsmWayServiceSpec` (5 new `lastVisibleTags` cases), `OsmWayTableSpec` (4 new cases for `getWayIdsToBackfill` and `recordHistoryTags`, in rolled-back transactions), `JobRunDetailsSpec`, `AdminJobTriggerSpec`: 43/43 green. Compile is clean under `-Xfatal-warnings`; scalafmt and `make lint-evolutions` clean.
- Evolution 382 applied on the Seattle dev schema, including the revert/re-apply of a foreign 380 that schema held.
- Hand-trigger against Seattle: `tags_recovered = 377`, `tags_unrecoverable = 0`, 263 s. Recovered rows carry `highway` (377), `bridge` (9), `tunnel` (4), `layer` (12), `maxspeed` (325). Way 116721547 came back as `bridge=yes`, `layer=1`, `name=Aurora Bridge`, `maxspeed=40 mph`. After the next intersection rebuild Seattle went from 45 to 55 grade-separated intersections, six of the seven nodes on the Aurora Bridge way among them (the seventh is the abutment, correctly not a crossing). A second trigger reported 0 recovered in 70 ms.

Follow-up stacked on this branch: #5237 moves the Overpass batch to the same main-API host.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Fable 5.1, claude-fable-5-1
