### PR TITLE
Fetch the nightly OSM way refresh from the OSM API, not Overpass (#5237)

### DIFF
--- a/app/actor/OsmWayRefreshActor.scala
+++ b/app/actor/OsmWayRefreshActor.scala
@@ -23,11 +23,16 @@ object OsmWayRefreshActor {
    * Defined here rather than at each call site so the nightly refresh and the admin hand-trigger can't record the
    * same job under two different shapes.
    *
-   * @param result Ways re-fetched from Overpass and written to `osm_way`, and how many of them are gone from OSM.
+   * @param result Ways re-fetched from Overpass and written to `osm_way`, how many of them are gone from OSM, and
+   *               how many gone ways had their lost tags recovered from the OSM history or turned out unrecoverable.
    * @return The run's `details` object.
    */
-  def runDetails(result: OsmWayRefreshResult): JsObject =
-    Json.obj("ways_refreshed" -> result.waysRefreshed, "ways_missing" -> result.waysMissing)
+  def runDetails(result: OsmWayRefreshResult): JsObject = Json.obj(
+    "ways_refreshed"     -> result.waysRefreshed,
+    "ways_missing"       -> result.waysMissing,
+    "tags_recovered"     -> result.tagsRecovered,
+    "tags_unrecoverable" -> result.tagsUnrecoverable
+  )
 }
 
 /**
@@ -82,7 +87,10 @@ class OsmWayRefreshActor @Inject() (osmWayService: OsmWayService, jobRunService:
       .onComplete {
         case Success(result) =>
           logger.info(s"OSM way data refresh completed at: ${dateFormatter.format(Instant.now())}")
-          logger.info(s"Ways refreshed: ${result.waysRefreshed}; of those, gone from OSM: ${result.waysMissing}")
+          logger.info(
+            s"Ways refreshed: ${result.waysRefreshed}; of those, gone from OSM: ${result.waysMissing}. " +
+              s"Tags recovered from OSM history: ${result.tagsRecovered}; unrecoverable: ${result.tagsUnrecoverable}."
+          )
         case Failure(e) => logger.error(s"Error refreshing OSM way data: ${e.getMessage}")
       }
   }

--- a/app/actor/OsmWayRefreshActor.scala
+++ b/app/actor/OsmWayRefreshActor.scala
@@ -23,7 +23,7 @@ object OsmWayRefreshActor {
    * Defined here rather than at each call site so the nightly refresh and the admin hand-trigger can't record the
    * same job under two different shapes.
    *
-   * @param result Ways re-fetched from Overpass and written to `osm_way`, how many of them are gone from OSM, and
+   * @param result Ways re-fetched from the OSM API and written to `osm_way`, how many of them are gone from OSM, and
    *               how many gone ways had their lost tags recovered from the OSM history or turned out unrecoverable.
    * @return The run's `details` object.
    */
@@ -52,7 +52,7 @@ class OsmWayRefreshActor @Inject() (osmWayService: OsmWayService, jobRunService:
 
   override def preStart(): Unit = {
     super.preStart()
-    // Per-city hour offset staggers computation/resource use across deployments (and their Overpass requests).
+    // Per-city hour offset staggers computation/resource use across deployments (and their OSM API requests).
     configService.getOffsetHours.foreach { hoursOffset =>
       // Scheduled time comes from ScheduledJobs, shifted by this city's offset.
       cancellable = Some(

--- a/app/models/street/OsmWayTable.scala
+++ b/app/models/street/OsmWayTable.scala
@@ -12,7 +12,7 @@ import javax.inject.{Inject, Singleton}
 import scala.concurrent.ExecutionContext
 
 /**
- * Cached data about an OSM way, refreshed periodically from the Overpass API (#4654).
+ * Cached data about an OSM way, refreshed periodically from the OSM API (#4654).
  *
  * @param osmWayId  OSM way identifier.
  * @param tags      The way's full OSM tag map, so future features can read name/sidewalk/surface/etc. without
@@ -20,10 +20,10 @@ import scala.concurrent.ExecutionContext
  * @param maxspeed  Raw OSM `maxspeed` tag (e.g. "25 mph", "30"); None if the way carries no maxspeed tag.
  * @param geom      Way geometry, present only on rows discovered by the on-demand point lookup (batch rows are located
  *                  via street_edge geometry instead).
- * @param source       Where the tags came from: "batch" (nightly Overpass refresh), "on_demand" (point-lookup
- *                     fallback), or "history" (recovered from the OSM API's way history after the way died in OSM,
+ * @param source       Where the tags came from: "batch" (nightly refresh from the OSM API), "on_demand" (Overpass
+ *                     point-lookup fallback), or "history" (recovered from the OSM API's way history after the way died in OSM,
  *                     #5244 -- empty tags under this source mean the history had nothing usable, checked once).
- * @param updatedAt    When the way was last fetched from Overpass; drives the staleness-based refresh.
+ * @param updatedAt    When the way was last fetched by the refresh; drives the staleness-based re-check.
  * @param missingSince When the refresh first found the way absent from OSM (deleted or merged away); None while it is
  *                     present. The tags of a missing way are its last known ones, kept because they still describe
  *                     the street geometry we imported (#5244).
@@ -106,8 +106,8 @@ class OsmWayTable @Inject() (
   /**
    * Gets the distinct way ids from osm_way_street_edge whose osm_way row is missing or last fetched before `cutoff`.
    *
-   * Ways marked `missing_since` are included once they go stale like any other: re-asking Overpass for a few hundred
-   * dead ids a month is one extra request, and it is what clears the mark if a way comes back.
+   * Ways marked `missing_since` are included once they go stale like any other: re-asking the OSM API for a few
+   * hundred dead ids a month is one extra request, and it is what clears the mark if a way comes back.
    */
   def getWayIdsMissingOrStale(cutoff: OffsetDateTime): DBIO[Seq[Long]] = {
     osmWayStreetEdges
@@ -179,7 +179,7 @@ class OsmWayTable @Inject() (
   def upsert(way: OsmWay): DBIO[Int] = osmWays.insertOrUpdate(way)
 
   /**
-   * Records one refresh chunk: the ways Overpass returned, as (osm_way_id, tags, maxspeed) triples written with source
+   * Records one refresh chunk: the ways the OSM API holds, as (osm_way_id, tags, maxspeed) triples written with source
    * 'batch', and the requested ids it did not return, which are marked missing.
    *
    * A found way takes the new tags and loses any `missing_since` mark. A missing way keeps its tags, maxspeed, and

--- a/app/models/street/OsmWayTable.scala
+++ b/app/models/street/OsmWayTable.scala
@@ -20,7 +20,9 @@ import scala.concurrent.ExecutionContext
  * @param maxspeed  Raw OSM `maxspeed` tag (e.g. "25 mph", "30"); None if the way carries no maxspeed tag.
  * @param geom      Way geometry, present only on rows discovered by the on-demand point lookup (batch rows are located
  *                  via street_edge geometry instead).
- * @param source       How the row was written: "batch" (nightly refresh) or "on_demand" (point-lookup fallback).
+ * @param source       Where the tags came from: "batch" (nightly Overpass refresh), "on_demand" (point-lookup
+ *                     fallback), or "history" (recovered from the OSM API's way history after the way died in OSM,
+ *                     #5244 -- empty tags under this source mean the history had nothing usable, checked once).
  * @param updatedAt    When the way was last fetched from Overpass; drives the staleness-based refresh.
  * @param missingSince When the refresh first found the way absent from OSM (deleted or merged away); None while it is
  *                     present. The tags of a missing way are its last known ones, kept because they still describe
@@ -41,7 +43,7 @@ class OsmWayTableDef(tag: Tag) extends Table[OsmWay](tag, "osm_way") {
   def tags: Rep[JsValue]            = column[JsValue]("tags", O.Default(Json.obj()))
   def maxspeed: Rep[Option[String]] = column[Option[String]]("maxspeed")
   def geom: Rep[Option[LineString]] = column[Option[LineString]]("geom")
-  // CHECK (source IN ('batch', 'on_demand')) in the DB (no Slick DSL for CHECK constraints).
+  // CHECK (source IN ('batch', 'on_demand', 'history')) in the DB (no Slick DSL for CHECK constraints).
   def source: Rep[String]                       = column[String]("source")
   def updatedAt: Rep[OffsetDateTime]            = column[OffsetDateTime]("updated_at")
   def missingSince: Rep[Option[OffsetDateTime]] = column[Option[OffsetDateTime]]("missing_since")
@@ -116,6 +118,41 @@ class OsmWayTable @Inject() (
       .filter { case (_, way) => way.map(_.updatedAt < cutoff).getOrElse(true) }
       .map(_._1)
       .result
+  }
+
+  /**
+   * Gets the mapped way ids that are gone from OSM and whose tags were lost before the refresh learned to keep them:
+   * marked missing, still empty, and not yet looked up in the OSM history (#5244). Each is a candidate for one
+   * history fetch; `recordHistoryTags` takes it out of this set whatever the history held.
+   */
+  def getWayIdsToBackfill: DBIO[Seq[Long]] = {
+    sql"""
+      SELECT DISTINCT osm_way.osm_way_id
+      FROM osm_way
+      INNER JOIN osm_way_street_edge ON osm_way.osm_way_id = osm_way_street_edge.osm_way_id
+      WHERE osm_way.missing_since IS NOT NULL AND osm_way.tags = '{}'::jsonb AND osm_way.source <> 'history'
+      ORDER BY osm_way.osm_way_id
+    """.as[Long]
+  }
+
+  /**
+   * Stores what the OSM history held for a way that is gone from OSM: the tags of its last visible version, or
+   * nothing. Either way the row's source becomes 'history', so the way is looked up once; with tags recovered the
+   * readers see a bridge again, with none they keep treating the way as unknown.
+   *
+   * Leaves `missing_since` (the way is still gone), `geom`, and `updated_at` alone: `updated_at` is the last
+   * Overpass fetch and drives the monthly re-check, which is what lets a reappearing way overwrite this with live
+   * tags.
+   *
+   * @return 1 if the row exists, else 0.
+   */
+  def recordHistoryTags(wayId: Long, tags: Option[JsValue], maxspeed: Option[String]): DBIO[Int] = {
+    val storedTags = Json.stringify(tags.getOrElse(Json.obj()))
+    sqlu"""
+      UPDATE osm_way
+      SET tags = $storedTags::jsonb, maxspeed = $maxspeed, source = 'history'
+      WHERE osm_way_id = $wayId
+    """
   }
 
   /**

--- a/app/models/street/OsmWayTable.scala
+++ b/app/models/street/OsmWayTable.scala
@@ -21,8 +21,9 @@ import scala.concurrent.ExecutionContext
  * @param geom      Way geometry, present only on rows discovered by the on-demand point lookup (batch rows are located
  *                  via street_edge geometry instead).
  * @param source       Where the tags came from: "batch" (nightly refresh from the OSM API), "on_demand" (Overpass
- *                     point-lookup fallback), or "history" (recovered from the OSM API's way history after the way died in OSM,
- *                     #5244 -- empty tags under this source mean the history had nothing usable, checked once).
+ *                     point-lookup fallback), or "history" (recovered from the OSM API's way history after the way
+ *                     died in OSM, #5244 -- empty tags under this source mean the history had nothing usable,
+ *                     checked once).
  * @param updatedAt    When the way was last fetched by the refresh; drives the staleness-based re-check.
  * @param missingSince When the refresh first found the way absent from OSM (deleted or merged away); None while it is
  *                     present. The tags of a missing way are its last known ones, kept because they still describe
@@ -107,17 +108,19 @@ class OsmWayTable @Inject() (
    * Gets the distinct way ids from osm_way_street_edge whose osm_way row is missing or last fetched before `cutoff`.
    *
    * Ways marked `missing_since` are included once they go stale like any other: re-asking the OSM API for a few
-   * hundred dead ids a month is one extra request, and it is what clears the mark if a way comes back.
+   * hundred dead ids a month is one extra request, and it is what clears the mark if a way comes back. The one
+   * exception is a 'history' row with empty tags: the API has never held that id, or held it with nothing on it, so
+   * there is nothing to come back, and asking again would 404 the whole chunk and force the narrowing every month.
    */
   def getWayIdsMissingOrStale(cutoff: OffsetDateTime): DBIO[Seq[Long]] = {
-    osmWayStreetEdges
-      .map(_.osmWayId)
-      .distinct
-      .joinLeft(osmWays)
-      .on(_ === _.osmWayId)
-      .filter { case (_, way) => way.map(_.updatedAt < cutoff).getOrElse(true) }
-      .map(_._1)
-      .result
+    sql"""
+      SELECT DISTINCT osm_way_street_edge.osm_way_id
+      FROM osm_way_street_edge
+      LEFT JOIN osm_way ON osm_way_street_edge.osm_way_id = osm_way.osm_way_id
+      WHERE osm_way.osm_way_id IS NULL
+         OR (osm_way.updated_at < $cutoff AND NOT (osm_way.source = 'history' AND osm_way.tags = '{}'::jsonb))
+      ORDER BY osm_way_street_edge.osm_way_id
+    """.as[Long]
   }
 
   /**

--- a/app/models/street/OsmWayTable.scala
+++ b/app/models/street/OsmWayTable.scala
@@ -140,18 +140,22 @@ class OsmWayTable @Inject() (
    * nothing. Either way the row's source becomes 'history', so the way is looked up once; with tags recovered the
    * readers see a bridge again, with none they keep treating the way as unknown.
    *
+   * Writes only a row that still qualifies for the lookup (gone, empty, not yet 'history'). The nightly actor and the
+   * admin hand-trigger can overlap, and if the other run's refresh found the way alive and wrote live tags in the
+   * meantime, those must win: a historical tag map landing on a present way would otherwise stand for a month.
+   *
    * Leaves `missing_since` (the way is still gone), `geom`, and `updated_at` alone: `updated_at` is the last
-   * Overpass fetch and drives the monthly re-check, which is what lets a reappearing way overwrite this with live
+   * refresh fetch and drives the monthly re-check, which is what lets a reappearing way overwrite this with live
    * tags.
    *
-   * @return 1 if the row exists, else 0.
+   * @return 1 if the row was still a lookup candidate and is now written, else 0.
    */
   def recordHistoryTags(wayId: Long, tags: Option[JsValue], maxspeed: Option[String]): DBIO[Int] = {
     val storedTags = Json.stringify(tags.getOrElse(Json.obj()))
     sqlu"""
       UPDATE osm_way
       SET tags = $storedTags::jsonb, maxspeed = $maxspeed, source = 'history'
-      WHERE osm_way_id = $wayId
+      WHERE osm_way_id = $wayId AND missing_since IS NOT NULL AND tags = '{}'::jsonb AND source <> 'history'
     """
   }
 

--- a/app/service/ImageryFreshnessService.scala
+++ b/app/service/ImageryFreshnessService.scala
@@ -537,7 +537,7 @@ class ImageryFreshnessServiceImpl @Inject() (
     val (dLat, dLng) = bboxHalfWidths(lat, SampleRadiusMeters)
     val bbox         = s"${lng - dLng},${lat - dLat},${lng + dLng},${lat + dLat}"
     ws.url(s"https://api.panoramax.xyz/api/search?bbox=$bbox&filter=field_of_view%3D360&sortby=-ts&limit=100")
-      .addHttpHeaders("User-Agent" -> PanoDataService.PanoramaxUserAgent)
+      .addHttpHeaders("User-Agent" -> OutboundHttp.UserAgent)
       .withRequestTimeout(5.seconds)
       .get()
       .map { response =>

--- a/app/service/OsmWayService.scala
+++ b/app/service/OsmWayService.scala
@@ -16,8 +16,8 @@ import java.time.OffsetDateTime
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.Success
 import scala.util.control.NonFatal
+import scala.util.{Failure, Success}
 
 /**
  * What one run of the OSM way refresh did.
@@ -57,8 +57,9 @@ trait OsmWayService {
    * refresh learned to keep them, or gone before it ever saw them -- and asks the OSM API for the way's history, one
    * id at a time with a delay between requests, storing the tags of its last visible version (#5244 step 2). A
    * deleted way's final tags describe the same geometry we imported, so a bridge comes back as a bridge; nothing is
-   * matched to whatever OSM holds there now. A way whose history has nothing usable is marked too, so each id costs
-   * one lookup ever.
+   * matched to whatever OSM holds there now. That includes `maxspeed`: the sign then shows the last limit OSM
+   * recorded for that road, which is also what the refresh keeps for a way that dies from now on. A way whose
+   * history has nothing usable is marked too, so each id costs one lookup ever.
    *
    * A failed chunk or lookup fails the whole run; the next nightly tick resumes from whatever is still stale or
    * unrecovered.
@@ -110,14 +111,22 @@ class OsmWayServiceImpl @Inject() (
 
   def refreshOsmWayData(): Future[OsmWayRefreshResult] = {
     // The two phases talk to different hosts, and Overpass refuses a good share of our runs (#5237), so a failure in
-    // one must not cost the other its work: both run, and the run fails afterwards if either did.
+    // one must not cost the other its work: both run, and the run fails afterwards if either did. The run record
+    // then carries the first failure and no counts (JobRunService stores details on success only), so each phase
+    // logs its own counts, and a second failure is logged here rather than lost behind the first.
     for {
       refreshed <- refreshFromOverpass().transform(Success(_))
       recovered <- backfillMissingTags().transform(Success(_))
-      result    <- Future.fromTry(for {
-        r <- refreshed
-        b <- recovered
-      } yield r + b)
+      result    <- (refreshed, recovered) match {
+        case (Failure(first), Failure(second)) =>
+          logger.error("The OSM history backfill failed too, behind the refresh's own failure.", second)
+          Future.failed(first)
+        case _ =>
+          Future.fromTry(for {
+            r <- refreshed
+            b <- recovered
+          } yield r + b)
+      }
     } yield result
   }
 
@@ -181,12 +190,18 @@ class OsmWayServiceImpl @Inject() (
               _       <- if (idx == 0) Future.unit else after(HISTORY_REQUEST_DELAY, actorSystem.scheduler)(Future.unit)
               history <- fetchWayHistoryWithRetry(wayId)
               tags = history.flatMap(lastVisibleTags)
-              _ <- db.run(osmWayTable.recordHistoryTags(wayId, tags, tags.flatMap(maxspeedFrom)))
+              written <- db.run(osmWayTable.recordHistoryTags(wayId, tags, tags.flatMap(maxspeedFrom)))
             } yield {
-              if (tags.isEmpty) {
-                logger.warn(s"OSM way $wayId is gone from OSM and its history holds no tags; nothing to recover.")
+              if (written == 0) {
+                // Another run's refresh got to the row first (the way came back, or its history was already read).
+                logger.info(s"OSM way $wayId was no longer waiting for its history by the time it was read; skipped.")
+                acc
+              } else {
+                if (tags.isEmpty) {
+                  logger.warn(s"OSM way $wayId is gone from OSM and its history holds no tags; nothing to recover.")
+                }
+                acc + OsmWayRefreshResult(0, 0, if (tags.isDefined) 1 else 0, if (tags.isEmpty) 1 else 0)
               }
-              acc + OsmWayRefreshResult(0, 0, if (tags.isDefined) 1 else 0, if (tags.isEmpty) 1 else 0)
             }
           }
           .map { result =>
@@ -275,6 +290,10 @@ class OsmWayServiceImpl @Inject() (
   /**
    * Fetches every version of a way from the main OSM API, deleted versions included.
    *
+   * A 200 whose body is not a history document (no `elements` array: a gateway page, a truncated body) is a failure
+   * to retry, not an empty history. Reading it as "nothing to recover" would mark the way checked and never ask
+   * again, which is the one outcome of this phase that no later run corrects.
+   *
    * @return The history document, or None when the API has never held a way with this id (404).
    */
   private def fetchWayHistory(wayId: Long): Future[Option[JsValue]] = {
@@ -284,7 +303,12 @@ class OsmWayServiceImpl @Inject() (
       .get()
       .map { response =>
         response.status match {
-          case 200   => Some(Json.parse(response.body))
+          case 200 =>
+            val json = Json.parse(response.body)
+            if ((json \ "elements").asOpt[Seq[JsValue]].isEmpty) {
+              throw new RuntimeException(s"OSM history response for way $wayId has no elements array.")
+            }
+            Some(json)
           case 404   => None
           case other => throw new RuntimeException(s"OSM history query for way $wayId failed with status $other.")
         }

--- a/app/service/OsmWayService.scala
+++ b/app/service/OsmWayService.scala
@@ -149,10 +149,26 @@ class OsmWayServiceImpl @Inject() (
               acc <- accFuture
               // Space out requests to the shared API; no delay before the first chunk.
               _ <- if (chunkIdx == 0) Future.unit else after(BATCH_CHUNK_DELAY, actorSystem.scheduler)(Future.unit)
-              fetched <- fetchSplittingOnNotFound(chunk)(fetchTagsForWaysWithRetry(_))
-              split = chunk.partition(fetched.contains)
+              fetched <- fetchSplittingOnNotFound(chunk)(
+                fetchTagsForWaysWithRetry(_),
+                () => after(BATCH_CHUNK_DELAY, actorSystem.scheduler)(Future.unit)
+              )
+              // Every id in a multi-id chunk answering 404 is an API that is not itself (a maintenance page, a
+              // proxy), not a chunk of ids that never existed; treating it as the latter would mark a whole city
+              // missing in one night. A lone bad id is a real data defect and is named.
+              _ = if (chunk.size > 1 && fetched.neverHeld.size == chunk.size) {
+                throw new RuntimeException(
+                  s"The OSM API answered 404 for every one of ${chunk.size} ways in a chunk; treating the API as down."
+                )
+              }
+              _ = if (fetched.neverHeld.nonEmpty) {
+                logger.warn(
+                  s"The OSM API has never held mapped way ids ${fetched.neverHeld.mkString(", ")}; marked missing."
+                )
+              }
+              split = chunk.partition(fetched.live.contains)
               rows  = split._1.map { wayId =>
-                val tags = fetched(wayId)
+                val tags = fetched.live(wayId)
                 (wayId, tags: JsValue, maxspeedFrom(tags))
               }
               n <- db.run(osmWayTable.upsertBatch(rows, split._2, OffsetDateTime.now))
@@ -322,6 +338,7 @@ class OsmWayServiceImpl @Inject() (
   private def queryAndStoreNearestRoad(lat: Double, lng: Double): Future[Option[String]] = {
     val query = s"[out:json][timeout:10];way['highway'](around:$SEARCH_RADIUS_M,$lat,$lng);out geom;"
     ws.url(OVERPASS_URL)
+      .addHttpHeaders("User-Agent" -> OutboundHttp.UserAgent)
       .withRequestTimeout(15.seconds)
       .post(Map("data" -> Seq(query)))
       .flatMap { response =>
@@ -340,7 +357,7 @@ class OsmWayServiceImpl @Inject() (
 }
 
 /**
- * Pure parsing/selection logic for Overpass API responses, kept free of I/O so it can be unit-tested directly.
+ * Pure parsing/selection logic for OSM API and Overpass responses, kept free of I/O so it can be unit-tested directly.
  */
 object OsmWayService {
   val OVERPASS_URL = "https://overpass-api.de/api/interpreter"
@@ -351,7 +368,7 @@ object OsmWayService {
   /** Refresh each way monthly; OSM speed limits change slowly. */
   val STALENESS_PERIOD_DAYS: Long = 30
 
-  /** Way ids per Overpass batch request, and the pause between consecutive requests. */
+  /** Way ids per OSM API multi-fetch request, and the pause between consecutive requests. */
   val BATCH_CHUNK_SIZE: Int             = 300
   val BATCH_CHUNK_DELAY: FiniteDuration = 2.seconds
 
@@ -383,41 +400,55 @@ object OsmWayService {
    * Parses an OSM API multi-fetch (`/ways.json?ways=…`) response into a map from way id to its tag map, for the
    * ways that still exist. A deleted way is returned with `visible: false` and no tags; it is left out, so absence
    * from the result means "gone from OSM". A live way with no `tags` field maps to an empty tag map.
+   *
+   * A body with no `elements` array is not a multi-fetch response (a gateway page, a truncated body) and throws, so
+   * the caller retries rather than reading every requested way as gone.
    */
   def parseWaysResponse(json: JsValue): Map[Long, JsObject] = {
     (json \ "elements")
       .asOpt[Seq[JsObject]]
-      .getOrElse(Seq.empty)
+      .getOrElse(throw new RuntimeException("OSM API multi-fetch response has no elements array."))
       .filter { el => (el \ "type").asOpt[String].contains("way") && (el \ "visible").asOpt[Boolean].getOrElse(true) }
       .flatMap { el => (el \ "id").asOpt[Long].map { id => id -> (el \ "tags").asOpt[JsObject].getOrElse(Json.obj()) } }
       .toMap
   }
 
   /**
+   * What a chunk fetch settled: the live ways' tags, and the ids the API has never held.
+   *
+   * A way that is neither live nor never-held was deleted (returned with `visible: false`). The caller marks both
+   * kinds missing, but only the never-held ones are worth a warning and the whole-chunk sanity check.
+   */
+  case class ChunkFetch(live: Map[Long, JsObject], neverHeld: Seq[Long])
+
+  /**
    * Fetches a chunk of way ids, narrowing down any id the API has never held.
    *
    * The multi-fetch answers 404 for the whole request when one requested id has never existed, without naming it. A
-   * chunk that comes back None is split in two and each half fetched in turn, down to a single id whose 404 makes it
-   * simply absent from the result -- the same shape as a deleted way, and what it is for our purposes. A bad id
-   * costs about log2(chunk size) extra requests, once; the caller marks it missing and the history phase then marks
-   * it checked, so it is not asked about again.
+   * chunk that comes back None is split in two and each half fetched in turn, with `pause` before each of those
+   * extra requests, down to a single id whose 404 names it. A bad id costs about 2·log2(chunk size) extra requests
+   * (both halves at each level are fetched); once its row is marked, `getWayIdsMissingOrStale` stops re-asking.
    *
    * @param wayIds The chunk to fetch.
    * @param fetch  One request: the live ways' tags by id, or None when the API answered 404.
-   * @return       The live ways' tags for every id the API holds.
+   * @param pause  Run before every request after the first, so a narrowing is paced like the chunks are.
+   * @return       The live ways' tags for every id the API holds, and the ids it has never held.
    */
-  def fetchSplittingOnNotFound(wayIds: Seq[Long])(fetch: Seq[Long] => Future[Option[Map[Long, JsObject]]])(implicit
-      ec: ExecutionContext
-  ): Future[Map[Long, JsObject]] = {
+  def fetchSplittingOnNotFound(wayIds: Seq[Long])(
+      fetch: Seq[Long] => Future[Option[Map[Long, JsObject]]],
+      pause: () => Future[Unit] = () => Future.unit
+  )(implicit ec: ExecutionContext): Future[ChunkFetch] = {
     fetch(wayIds).flatMap {
-      case Some(found)              => Future.successful(found)
-      case None if wayIds.size <= 1 => Future.successful(Map.empty)
+      case Some(found)              => Future.successful(ChunkFetch(found, Nil))
+      case None if wayIds.size <= 1 => Future.successful(ChunkFetch(Map.empty, wayIds))
       case None                     =>
         val (left, right) = wayIds.splitAt(wayIds.size / 2)
         for {
-          l <- fetchSplittingOnNotFound(left)(fetch)
-          r <- fetchSplittingOnNotFound(right)(fetch)
-        } yield l ++ r
+          _ <- pause()
+          l <- fetchSplittingOnNotFound(left)(fetch, pause)
+          _ <- pause()
+          r <- fetchSplittingOnNotFound(right)(fetch, pause)
+        } yield ChunkFetch(l.live ++ r.live, l.neverHeld ++ r.neverHeld)
     }
   }
 

--- a/app/service/OsmWayService.scala
+++ b/app/service/OsmWayService.scala
@@ -23,7 +23,7 @@ import scala.util.{Failure, Success}
  * What one run of the OSM way refresh did.
  *
  * @param waysRefreshed     Ways whose row was written, present in OSM or not (0 when everything was fresh).
- * @param waysMissing       Of those, ways Overpass did not return: deleted or merged away in OSM since our import.
+ * @param waysMissing       Of those, ways the OSM API reports gone: deleted or merged away in OSM since our import.
  *                          Their last known tags are kept and `osm_way.missing_since` is stamped (#5244).
  * @param tagsRecovered     Gone ways whose lost tags were recovered from the OSM history in this run.
  * @param tagsUnrecoverable Gone ways looked up in the OSM history this run that had nothing usable there. Marked so
@@ -49,9 +49,9 @@ trait OsmWayService {
    * Refreshes cached way data for every mapped way whose row is missing or older than `STALENESS_PERIOD`, then
    * recovers the tags of gone ways that lost them.
    *
-   * The refresh fetches tags from Overpass in chunks of `BATCH_CHUNK_SIZE` ids, sequentially with a delay between
-   * chunks. Every requested id is written even when absent from the response, so it won't re-queue nightly: a found
-   * way takes its current tags, a missing one keeps its last known tags and is marked `missing_since`.
+   * The refresh fetches tags from the main OSM API by id, in chunks of `BATCH_CHUNK_SIZE`, sequentially with a delay
+   * between chunks. Every requested id is written, so it won't re-queue nightly: a found way takes its current tags,
+   * a way the API reports deleted (or never held) keeps its last known tags and is marked `missing_since`.
    *
    * The backfill then takes every mapped way that is marked missing but still has empty tags -- blanked before the
    * refresh learned to keep them, or gone before it ever saw them -- and asks the OSM API for the way's history, one
@@ -90,10 +90,12 @@ trait OsmWayService {
 /**
  * Maintains the cached OSM way data (osm_way table) that backs the speed-limit sign (#4654).
  *
- * Two write paths, both polite to the shared community Overpass instance: a nightly batch refresh that bulk-fetches
- * tags for every way mapped in osm_way_street_edge (monthly per way, via a staleness cutoff), and an on-demand point
- * lookup used when a user wanders onto a street outside our network — checked against our DB first so each unknown
- * spot costs Overpass at most one query ever, across all users.
+ * Two write paths. A nightly batch refresh fetches tags for every way mapped in osm_way_street_edge (monthly per way,
+ * via a staleness cutoff) from the main OSM API, whose multi-fetch is built for exactly this fetch-by-id and reports
+ * a deleted way as such; the shared community Overpass instance is a query engine, and asking it for ids was what
+ * got ~57 deployments refused (#5237). An on-demand point lookup, used when a user wanders onto a street outside
+ * our network, is the one thing that still needs Overpass (a spatial query) — checked against our DB first so each
+ * unknown spot costs Overpass at most one query ever, across all users.
  */
 @Singleton
 class OsmWayServiceImpl @Inject() (
@@ -110,12 +112,12 @@ class OsmWayServiceImpl @Inject() (
   private val logger = Logger(this.getClass)
 
   def refreshOsmWayData(): Future[OsmWayRefreshResult] = {
-    // The two phases talk to different hosts, and Overpass refuses a good share of our runs (#5237), so a failure in
-    // one must not cost the other its work: both run, and the run fails afterwards if either did. The run record
-    // then carries the first failure and no counts (JobRunService stores details on success only), so each phase
-    // logs its own counts, and a second failure is logged here rather than lost behind the first.
+    // Either phase can fail on the network, and a failure in one must not cost the other its work: both run, and the
+    // run fails afterwards if either did. The run record then carries the first failure and no counts (JobRunService
+    // stores details on success only), so each phase logs its own counts, and a second failure is logged here rather
+    // than lost behind the first.
     for {
-      refreshed <- refreshFromOverpass().transform(Success(_))
+      refreshed <- refreshFromOsmApi().transform(Success(_))
       recovered <- backfillMissingTags().transform(Success(_))
       result    <- (refreshed, recovered) match {
         case (Failure(first), Failure(second)) =>
@@ -131,10 +133,10 @@ class OsmWayServiceImpl @Inject() (
   }
 
   /**
-   * Phase one: re-fetches every stale mapped way's tags from Overpass, chunked and paced, marking the ways it no
-   * longer returns as missing.
+   * Phase one: re-fetches every stale mapped way's tags from the main OSM API, chunked and paced, marking the ways
+   * it reports deleted (or never held) as missing.
    */
-  private def refreshFromOverpass(): Future[OsmWayRefreshResult] = {
+  private def refreshFromOsmApi(): Future[OsmWayRefreshResult] = {
     db.run(osmWayTable.getWayIdsMissingOrStale(OffsetDateTime.now.minusDays(STALENESS_PERIOD_DAYS))).flatMap { wayIds =>
       if (wayIds.isEmpty) { Future.successful(OsmWayRefreshResult.empty) }
       else {
@@ -145,9 +147,9 @@ class OsmWayServiceImpl @Inject() (
           .foldLeft(Future.successful(OsmWayRefreshResult.empty)) { case (accFuture, (chunk, chunkIdx)) =>
             for {
               acc <- accFuture
-              // Space out requests to the shared Overpass instance; no delay before the first chunk.
+              // Space out requests to the shared API; no delay before the first chunk.
               _ <- if (chunkIdx == 0) Future.unit else after(BATCH_CHUNK_DELAY, actorSystem.scheduler)(Future.unit)
-              fetched <- fetchTagsForWaysWithRetry(chunk)
+              fetched <- fetchSplittingOnNotFound(chunk)(fetchTagsForWaysWithRetry(_))
               split = chunk.partition(fetched.contains)
               rows  = split._1.map { wayId =>
                 val tags = fetched(wayId)
@@ -235,46 +237,44 @@ class OsmWayServiceImpl @Inject() (
   }
 
   /**
-   * Fetches a chunk's tags, retrying transient failures — the shared Overpass instance sheds load with 429s/504s
-   * routinely, so one bad response shouldn't sink a whole run. Waits BATCH_RETRY_DELAY x attempt between tries to
-   * give a loaded server breathing room.
+   * Fetches a chunk's tags, retrying transient failures (a 429, a 5xx, a timeout) so one bad response doesn't sink a
+   * whole run. Waits BATCH_RETRY_DELAY x attempt between tries to give a loaded server breathing room. A 404 is an
+   * answer, not a failure, and is passed through for the caller to split on.
    */
-  private def fetchTagsForWaysWithRetry(wayIds: Seq[Long], attempt: Int = 1): Future[Map[Long, JsObject]] = {
+  private def fetchTagsForWaysWithRetry(wayIds: Seq[Long], attempt: Int = 1): Future[Option[Map[Long, JsObject]]] = {
     fetchTagsForWays(wayIds).recoverWith {
       case NonFatal(e) if attempt < BATCH_MAX_ATTEMPTS =>
-        logger.warn(s"Overpass batch attempt $attempt/$BATCH_MAX_ATTEMPTS failed (${e.getMessage}); retrying.")
+        logger.warn(s"OSM API batch attempt $attempt/$BATCH_MAX_ATTEMPTS failed (${e.getMessage}); retrying.")
         after(BATCH_RETRY_DELAY * attempt.toLong, actorSystem.scheduler)(fetchTagsForWaysWithRetry(wayIds, attempt + 1))
     }
   }
 
   /**
-   * Fetches the full tag map for the given way ids from Overpass, keyed by way id.
+   * Fetches the current version of each given way from the main OSM API's multi-fetch, keyed by way id.
    *
-   * Ways absent from a complete response are gone from OSM (deleted or merged away) and are simply missing from the
-   * returned map. A cut-short response is a failure, not a list of dead ways: Overpass reports a query that timed out
-   * or ran out of memory as HTTP 200 with whatever elements it had reached plus a top-level `remark` (measured: a
-   * 1-second-budget query came back `200`, zero elements, `remark: runtime error: Query timed out ...`), and reading
-   * that as "every requested way is missing" would stamp a whole chunk `missing_since` in one bad night.
+   * A way that has been deleted comes back with `visible: false` and no tags, and is left out of the returned map,
+   * which is how the caller learns it is gone. A way id the API has never held makes the whole request a 404 without
+   * saying which id (measured 2026-09-09: one bad id among live ones, 404), so that is reported as None for
+   * `fetchSplittingOnNotFound` to narrow down rather than treated as an error.
+   *
+   * @return The live ways' tag maps, or None when some requested id has never existed.
    */
-  private def fetchTagsForWays(wayIds: Seq[Long]): Future[Map[Long, JsObject]] = {
-    val query = s"[out:json][timeout:180];way(id:${wayIds.mkString(",")});out tags;"
-    ws.url(OVERPASS_URL)
-      .withRequestTimeout(3.minutes)
-      .post(Map("data" -> Seq(query)))
+  private def fetchTagsForWays(wayIds: Seq[Long]): Future[Option[Map[Long, JsObject]]] = {
+    ws.url(s"$OSM_API_URL/ways.json?ways=${wayIds.mkString(",")}")
+      .addHttpHeaders("User-Agent" -> OutboundHttp.UserAgent)
+      .withRequestTimeout(1.minute)
+      .get()
       .map { response =>
-        if (response.status != 200) {
-          throw new RuntimeException(s"Overpass batch query failed with status ${response.status}.")
+        response.status match {
+          case 200   => Some(parseWaysResponse(Json.parse(response.body)))
+          case 404   => None
+          case other => throw new RuntimeException(s"OSM API batch query failed with status $other.")
         }
-        val json: JsValue = Json.parse(response.body)
-        truncationRemark(json).foreach { remark =>
-          throw new RuntimeException(s"Overpass batch query was cut short: $remark")
-        }
-        parseBatchResponse(json)
       }
   }
 
   /**
-   * Fetches a way's history, retrying transient failures with the same budget and spacing as the Overpass chunks.
+   * Fetches a way's history, retrying transient failures with the same budget and spacing as the batch chunks.
    * A 404 is an answer (the id never existed), not a failure, and is not retried.
    */
   private def fetchWayHistoryWithRetry(wayId: Long, attempt: Int = 1): Future[Option[JsValue]] = {
@@ -380,21 +380,45 @@ object OsmWayService {
   private val geometryFactory = new GeometryFactory(new PrecisionModel(), 4326)
 
   /**
-   * The `remark` Overpass attaches to a response it could not complete (a timeout or memory limit hit mid-query), or
-   * None for a complete one. Its presence means the element list is partial, so absence from it proves nothing.
+   * Parses an OSM API multi-fetch (`/ways.json?ways=…`) response into a map from way id to its tag map, for the
+   * ways that still exist. A deleted way is returned with `visible: false` and no tags; it is left out, so absence
+   * from the result means "gone from OSM". A live way with no `tags` field maps to an empty tag map.
    */
-  def truncationRemark(json: JsValue): Option[String] = (json \ "remark").asOpt[String].filter(_.nonEmpty)
-
-  /**
-   * Parses a batch `out tags;` Overpass response into a map from way id to its tag map.
-   */
-  def parseBatchResponse(json: JsValue): Map[Long, JsObject] = {
+  def parseWaysResponse(json: JsValue): Map[Long, JsObject] = {
     (json \ "elements")
       .asOpt[Seq[JsObject]]
       .getOrElse(Seq.empty)
-      .filter(el => (el \ "type").asOpt[String].contains("way"))
+      .filter { el => (el \ "type").asOpt[String].contains("way") && (el \ "visible").asOpt[Boolean].getOrElse(true) }
       .flatMap { el => (el \ "id").asOpt[Long].map { id => id -> (el \ "tags").asOpt[JsObject].getOrElse(Json.obj()) } }
       .toMap
+  }
+
+  /**
+   * Fetches a chunk of way ids, narrowing down any id the API has never held.
+   *
+   * The multi-fetch answers 404 for the whole request when one requested id has never existed, without naming it. A
+   * chunk that comes back None is split in two and each half fetched in turn, down to a single id whose 404 makes it
+   * simply absent from the result -- the same shape as a deleted way, and what it is for our purposes. A bad id
+   * costs about log2(chunk size) extra requests, once; the caller marks it missing and the history phase then marks
+   * it checked, so it is not asked about again.
+   *
+   * @param wayIds The chunk to fetch.
+   * @param fetch  One request: the live ways' tags by id, or None when the API answered 404.
+   * @return       The live ways' tags for every id the API holds.
+   */
+  def fetchSplittingOnNotFound(wayIds: Seq[Long])(fetch: Seq[Long] => Future[Option[Map[Long, JsObject]]])(implicit
+      ec: ExecutionContext
+  ): Future[Map[Long, JsObject]] = {
+    fetch(wayIds).flatMap {
+      case Some(found)              => Future.successful(found)
+      case None if wayIds.size <= 1 => Future.successful(Map.empty)
+      case None                     =>
+        val (left, right) = wayIds.splitAt(wayIds.size / 2)
+        for {
+          l <- fetchSplittingOnNotFound(left)(fetch)
+          r <- fetchSplittingOnNotFound(right)(fetch)
+        } yield l ++ r
+    }
   }
 
   /**

--- a/app/service/OsmWayService.scala
+++ b/app/service/OsmWayService.scala
@@ -16,29 +16,55 @@ import java.time.OffsetDateTime
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Success
 import scala.util.control.NonFatal
 
 /**
  * What one run of the OSM way refresh did.
  *
- * @param waysRefreshed Ways whose row was written, present in OSM or not (0 when everything was fresh).
- * @param waysMissing   Of those, ways Overpass did not return: deleted or merged away in OSM since our import. Their
- *                      last known tags are kept and `osm_way.missing_since` is stamped (#5244).
+ * @param waysRefreshed     Ways whose row was written, present in OSM or not (0 when everything was fresh).
+ * @param waysMissing       Of those, ways Overpass did not return: deleted or merged away in OSM since our import.
+ *                          Their last known tags are kept and `osm_way.missing_since` is stamped (#5244).
+ * @param tagsRecovered     Gone ways whose lost tags were recovered from the OSM history in this run.
+ * @param tagsUnrecoverable Gone ways looked up in the OSM history this run that had nothing usable there. Marked so
+ *                          they are not asked about again.
  */
-case class OsmWayRefreshResult(waysRefreshed: Int, waysMissing: Int)
+case class OsmWayRefreshResult(waysRefreshed: Int, waysMissing: Int, tagsRecovered: Int, tagsUnrecoverable: Int) {
+  def +(other: OsmWayRefreshResult): OsmWayRefreshResult = OsmWayRefreshResult(
+    waysRefreshed + other.waysRefreshed,
+    waysMissing + other.waysMissing,
+    tagsRecovered + other.tagsRecovered,
+    tagsUnrecoverable + other.tagsUnrecoverable
+  )
+}
+
+object OsmWayRefreshResult {
+  val empty: OsmWayRefreshResult = OsmWayRefreshResult(0, 0, 0, 0)
+}
 
 @ImplementedBy(classOf[OsmWayServiceImpl])
 trait OsmWayService {
 
   /**
-   * Refreshes cached way data for every mapped way whose row is missing or older than `STALENESS_PERIOD`.
+   * Refreshes cached way data for every mapped way whose row is missing or older than `STALENESS_PERIOD`, then
+   * recovers the tags of gone ways that lost them.
    *
-   * Fetches tags in chunks of `BATCH_CHUNK_SIZE` ids, sequentially with a delay between chunks. Every requested id is
-   * written even when absent from the response, so it won't re-queue nightly: a found way takes its current tags, a
-   * missing one keeps its last known tags and is marked `missing_since`. A failed chunk fails the whole run; the next
-   * nightly tick retries from whatever is still stale.
+   * The refresh fetches tags from Overpass in chunks of `BATCH_CHUNK_SIZE` ids, sequentially with a delay between
+   * chunks. Every requested id is written even when absent from the response, so it won't re-queue nightly: a found
+   * way takes its current tags, a missing one keeps its last known tags and is marked `missing_since`.
    *
-   * @return How many ways were written, and how many of them are gone from OSM.
+   * The backfill then takes every mapped way that is marked missing but still has empty tags -- blanked before the
+   * refresh learned to keep them, or gone before it ever saw them -- and asks the OSM API for the way's history, one
+   * id at a time with a delay between requests, storing the tags of its last visible version (#5244 step 2). A
+   * deleted way's final tags describe the same geometry we imported, so a bridge comes back as a bridge; nothing is
+   * matched to whatever OSM holds there now. A way whose history has nothing usable is marked too, so each id costs
+   * one lookup ever.
+   *
+   * A failed chunk or lookup fails the whole run; the next nightly tick resumes from whatever is still stale or
+   * unrecovered.
+   *
+   * @return How many ways were written and how many of them are gone from OSM, plus how many gone ways had their
+   *         tags recovered and how many turned out unrecoverable.
    */
   def refreshOsmWayData(): Future[OsmWayRefreshResult]
 
@@ -83,14 +109,31 @@ class OsmWayServiceImpl @Inject() (
   private val logger = Logger(this.getClass)
 
   def refreshOsmWayData(): Future[OsmWayRefreshResult] = {
+    // The two phases talk to different hosts, and Overpass refuses a good share of our runs (#5237), so a failure in
+    // one must not cost the other its work: both run, and the run fails afterwards if either did.
+    for {
+      refreshed <- refreshFromOverpass().transform(Success(_))
+      recovered <- backfillMissingTags().transform(Success(_))
+      result    <- Future.fromTry(for {
+        r <- refreshed
+        b <- recovered
+      } yield r + b)
+    } yield result
+  }
+
+  /**
+   * Phase one: re-fetches every stale mapped way's tags from Overpass, chunked and paced, marking the ways it no
+   * longer returns as missing.
+   */
+  private def refreshFromOverpass(): Future[OsmWayRefreshResult] = {
     db.run(osmWayTable.getWayIdsMissingOrStale(OffsetDateTime.now.minusDays(STALENESS_PERIOD_DAYS))).flatMap { wayIds =>
-      if (wayIds.isEmpty) { Future.successful(OsmWayRefreshResult(0, 0)) }
+      if (wayIds.isEmpty) { Future.successful(OsmWayRefreshResult.empty) }
       else {
         logger.info(s"Refreshing OSM way data for ${wayIds.size} ways.")
         wayIds
           .grouped(BATCH_CHUNK_SIZE)
           .zipWithIndex
-          .foldLeft(Future.successful(OsmWayRefreshResult(0, 0))) { case (accFuture, (chunk, chunkIdx)) =>
+          .foldLeft(Future.successful(OsmWayRefreshResult.empty)) { case (accFuture, (chunk, chunkIdx)) =>
             for {
               acc <- accFuture
               // Space out requests to the shared Overpass instance; no delay before the first chunk.
@@ -102,7 +145,7 @@ class OsmWayServiceImpl @Inject() (
                 (wayId, tags: JsValue, maxspeedFrom(tags))
               }
               n <- db.run(osmWayTable.upsertBatch(rows, split._2, OffsetDateTime.now))
-            } yield OsmWayRefreshResult(acc.waysRefreshed + n, acc.waysMissing + split._2.size)
+            } yield acc + OsmWayRefreshResult(n, split._2.size, 0, 0)
           }
           .map { result =>
             // A dead way id is normal OSM churn, but a jump in this count means a re-match (#5244) is overdue.
@@ -112,6 +155,45 @@ class OsmWayServiceImpl @Inject() (
                   "(deleted or merged away); kept their last known tags and marked them missing."
               )
             }
+            result
+          }
+      }
+    }
+  }
+
+  /**
+   * Phase two: recovers the tags of gone ways that have none, from the OSM API's way history (#5244 step 2).
+   *
+   * One request per way, sequential, with `HISTORY_REQUEST_DELAY` between them: the main OSM API is not built for
+   * bulk reads, and the candidate set is a few hundred ids per city once, then whatever dies before its first fetch.
+   * Each way is written as soon as its history is read, so a failure partway keeps what was recovered and the next
+   * run resumes from the rest.
+   */
+  private def backfillMissingTags(): Future[OsmWayRefreshResult] = {
+    db.run(osmWayTable.getWayIdsToBackfill).flatMap { wayIds =>
+      if (wayIds.isEmpty) { Future.successful(OsmWayRefreshResult.empty) }
+      else {
+        logger.info(s"Recovering tags for ${wayIds.size} OSM ways that are gone from OSM, from their history.")
+        wayIds.zipWithIndex
+          .foldLeft(Future.successful(OsmWayRefreshResult.empty)) { case (accFuture, (wayId, idx)) =>
+            for {
+              acc     <- accFuture
+              _       <- if (idx == 0) Future.unit else after(HISTORY_REQUEST_DELAY, actorSystem.scheduler)(Future.unit)
+              history <- fetchWayHistoryWithRetry(wayId)
+              tags = history.flatMap(lastVisibleTags)
+              _ <- db.run(osmWayTable.recordHistoryTags(wayId, tags, tags.flatMap(maxspeedFrom)))
+            } yield {
+              if (tags.isEmpty) {
+                logger.warn(s"OSM way $wayId is gone from OSM and its history holds no tags; nothing to recover.")
+              }
+              acc + OsmWayRefreshResult(0, 0, if (tags.isDefined) 1 else 0, if (tags.isEmpty) 1 else 0)
+            }
+          }
+          .map { result =>
+            logger.info(
+              s"Recovered tags for ${result.tagsRecovered} gone OSM ways from their history; " +
+                s"${result.tagsUnrecoverable} had nothing to recover."
+            )
             result
           }
       }
@@ -177,6 +259,39 @@ class OsmWayServiceImpl @Inject() (
   }
 
   /**
+   * Fetches a way's history, retrying transient failures with the same budget and spacing as the Overpass chunks.
+   * A 404 is an answer (the id never existed), not a failure, and is not retried.
+   */
+  private def fetchWayHistoryWithRetry(wayId: Long, attempt: Int = 1): Future[Option[JsValue]] = {
+    fetchWayHistory(wayId).recoverWith {
+      case NonFatal(e) if attempt < BATCH_MAX_ATTEMPTS =>
+        logger.warn(
+          s"OSM history attempt $attempt/$BATCH_MAX_ATTEMPTS for way $wayId failed (${e.getMessage}); retrying."
+        )
+        after(BATCH_RETRY_DELAY * attempt.toLong, actorSystem.scheduler)(fetchWayHistoryWithRetry(wayId, attempt + 1))
+    }
+  }
+
+  /**
+   * Fetches every version of a way from the main OSM API, deleted versions included.
+   *
+   * @return The history document, or None when the API has never held a way with this id (404).
+   */
+  private def fetchWayHistory(wayId: Long): Future[Option[JsValue]] = {
+    ws.url(s"$OSM_API_URL/way/$wayId/history.json")
+      .addHttpHeaders("User-Agent" -> OutboundHttp.UserAgent)
+      .withRequestTimeout(30.seconds)
+      .get()
+      .map { response =>
+        response.status match {
+          case 200   => Some(Json.parse(response.body))
+          case 404   => None
+          case other => throw new RuntimeException(s"OSM history query for way $wayId failed with status $other.")
+        }
+      }
+  }
+
+  /**
    * Queries Overpass for roads within `SEARCH_RADIUS_M` of the point, stores the nearest one (with geometry, so later
    * lookups nearby hit our DB), and returns its maxspeed tag.
    */
@@ -223,6 +338,12 @@ object OsmWayService {
   /** Per-coordinate cache TTL for the on-demand point lookup (doubles as a negative cache for "no road here"). */
   val POINT_CACHE_TTL: FiniteDuration = 10.minutes
 
+  /** The main OSM API (not Overpass): the one place a deleted way's history can still be read (#5244). */
+  val OSM_API_URL = "https://api.openstreetmap.org/api/0.6"
+
+  /** Pause between consecutive history requests; they go one way at a time to an API not meant for bulk reads. */
+  val HISTORY_REQUEST_DELAY: FiniteDuration = 500.millis
+
   /**
    * OSM highway values that count as drivable roads for the speed-limit sign; footpaths/cycleways etc. are excluded.
    */
@@ -250,6 +371,31 @@ object OsmWayService {
       .filter(el => (el \ "type").asOpt[String].contains("way"))
       .flatMap { el => (el \ "id").asOpt[Long].map { id => id -> (el \ "tags").asOpt[JsObject].getOrElse(Json.obj()) } }
       .toMap
+  }
+
+  /**
+   * Picks, from an OSM API way-history document, the tags that best describe the way as it was last mapped.
+   *
+   * A deleted version carries `visible: false` and no tags, and a live one omits `visible`. Of the visible versions
+   * with tags, the highest-numbered one that still carries `highway` wins, so a way retagged out of the road network
+   * just before deletion is read as the road it was (our street is still one); failing that, the highest-numbered one
+   * with any tags at all.
+   *
+   * @return The chosen version's tag map, or None when no visible version carried tags.
+   */
+  def lastVisibleTags(history: JsValue): Option[JsObject] = {
+    val tagged = (history \ "elements")
+      .asOpt[Seq[JsObject]]
+      .getOrElse(Seq.empty)
+      .filter { el => (el \ "type").asOpt[String].contains("way") && (el \ "visible").asOpt[Boolean].getOrElse(true) }
+      .flatMap { el =>
+        for {
+          version <- (el \ "version").asOpt[Long]
+          tags    <- (el \ "tags").asOpt[JsObject] if tags.keys.nonEmpty
+        } yield (version, tags)
+      }
+    val roads = tagged.filter { case (_, tags) => tags.keys.contains("highway") }
+    (if (roads.nonEmpty) roads else tagged).maxByOption(_._1).map(_._2)
   }
 
   /**

--- a/app/service/OutboundHttp.scala
+++ b/app/service/OutboundHttp.scala
@@ -1,0 +1,14 @@
+package service
+
+/**
+ * What our server-to-server HTTP calls have in common.
+ */
+object OutboundHttp {
+
+  /**
+   * How we identify ourselves to keyless, community-run APIs (Panoramax, #5185; the OSM API, #5244). Where a key
+   * already says who is calling (GSV, Mapillary) nothing else is needed, but these operators otherwise have no way to
+   * tell whose traffic this is or where to write if it misbehaves, and the OSM API's usage policy requires it.
+   */
+  val UserAgent: String = "ProjectSidewalk/1.0 (+https://projectsidewalk.org; sidewalk@cs.uw.edu)"
+}

--- a/app/service/PanoDataService.scala
+++ b/app/service/PanoDataService.scala
@@ -52,13 +52,6 @@ object PanoDataService {
   val LiveImageryTtlDays: Long = 7
 
   /**
-   * How we identify ourselves to Panoramax (#5185). Its API is keyless and community-run, so unlike GSV and
-   * Mapillary — where the key already says who is calling — nothing else tells the operators whose traffic this is
-   * or where to write if it misbehaves.
-   */
-  val PanoramaxUserAgent: String = "ProjectSidewalk/1.0 (+https://projectsidewalk.org; sidewalk@cs.uw.edu)"
-
-  /**
    * How many panos the nightly expiry sweep may have in flight at once (#4559).
    */
   val ImageryCheckConcurrency: Int = 10
@@ -576,7 +569,7 @@ class PanoDataServiceImpl @Inject() (
    */
   private def panoramaxPanoExists(panoId: String): Future[Option[Boolean]] = {
     ws.url(s"https://api.panoramax.xyz/api/pictures/$panoId")
-      .addHttpHeaders("User-Agent" -> PanoDataService.PanoramaxUserAgent)
+      .addHttpHeaders("User-Agent" -> OutboundHttp.UserAgent)
       .withRequestTimeout(5.seconds)
       .get()
       .flatMap { response =>

--- a/conf/evolutions/default/382.sql
+++ b/conf/evolutions/default/382.sql
@@ -1,0 +1,16 @@
+# --- !Ups
+-- A third provenance for a cached way's tags (#5244, step 2). 'batch' rows hold what Overpass last returned and
+-- 'on_demand' rows what the point lookup found. 'history' marks a way that is gone from OSM (missing_since set)
+-- whose tags were recovered from the main OSM API's way history -- the tags of the last visible version, which
+-- describe the same geometry we imported. A 'history' row with empty tags is one whose history had nothing usable
+-- (the id never existed, or no visible version carried tags), and the mark keeps the refresh from re-asking for it
+-- every night. The monthly Overpass re-check still covers these ids, and a way that reappears goes back to 'batch'.
+ALTER TABLE osm_way DROP CONSTRAINT osm_way_source_check;
+ALTER TABLE osm_way ADD CONSTRAINT osm_way_source_check CHECK (source IN ('batch', 'on_demand', 'history'));
+
+# --- !Downs
+-- Recovered rows fold back into 'batch' first, or the narrower CHECK would fail on them. Their tags stay, so no
+-- bridge is lost, only the provenance.
+UPDATE osm_way SET source = 'batch' WHERE source = 'history';
+ALTER TABLE osm_way DROP CONSTRAINT osm_way_source_check;
+ALTER TABLE osm_way ADD CONSTRAINT osm_way_source_check CHECK (source IN ('batch', 'on_demand'));

--- a/conf/evolutions/default/382.sql
+++ b/conf/evolutions/default/382.sql
@@ -1,16 +1,18 @@
 # --- !Ups
--- A third provenance for a cached way's tags (#5244, step 2). 'batch' rows hold what Overpass last returned and
--- 'on_demand' rows what the point lookup found. 'history' marks a way that is gone from OSM (missing_since set)
--- whose tags were recovered from the main OSM API's way history -- the tags of the last visible version, which
--- describe the same geometry we imported. A 'history' row with empty tags is one whose history had nothing usable
--- (the id never existed, or no visible version carried tags), and the mark keeps the refresh from re-asking for it
--- every night. The monthly Overpass re-check still covers these ids, and a way that reappears goes back to 'batch'.
+-- A third provenance for a cached way's tags (#5244, step 2). 'batch' rows hold what the nightly refresh last
+-- fetched and 'on_demand' rows what the point lookup found. 'history' marks a way that is gone from OSM
+-- (missing_since set) whose tags were recovered from the main OSM API's way history -- the tags of the last visible
+-- version, which describe the same geometry we imported. A 'history' row with empty tags is one whose history had
+-- nothing usable (the id never existed, or no visible version carried tags), and the mark keeps the refresh from
+-- re-asking for it every night. The monthly re-check still covers these ids, and a way that reappears goes back to
+-- 'batch'.
 ALTER TABLE osm_way DROP CONSTRAINT osm_way_source_check;
 ALTER TABLE osm_way ADD CONSTRAINT osm_way_source_check CHECK (source IN ('batch', 'on_demand', 'history'));
 
 # --- !Downs
 -- Recovered rows fold back into 'batch' first, or the narrower CHECK would fail on them. Their tags stay, so no
--- bridge is lost, only the provenance.
+-- bridge is lost. What is lost is the provenance and the checked-once mark: a row whose history held nothing folds
+-- back into a plain empty missing row, and the next Up looks it up again.
 UPDATE osm_way SET source = 'batch' WHERE source = 'history';
 ALTER TABLE osm_way DROP CONSTRAINT osm_way_source_check;
 ALTER TABLE osm_way ADD CONSTRAINT osm_way_source_check CHECK (source IN ('batch', 'on_demand'));

--- a/test/actor/JobRunDetailsSpec.scala
+++ b/test/actor/JobRunDetailsSpec.scala
@@ -30,8 +30,8 @@ class JobRunDetailsSpec extends PlaySpec {
     }
 
     "record the OSM way refresh under the key its readers use" in {
-      OsmWayRefreshActor.runDetails(OsmWayRefreshResult(13, 2)) mustBe
-        Json.obj("ways_refreshed" -> 13, "ways_missing" -> 2)
+      OsmWayRefreshActor.runDetails(OsmWayRefreshResult(13, 2, 3, 1)) mustBe
+        Json.obj("ways_refreshed" -> 13, "ways_missing" -> 2, "tags_recovered" -> 3, "tags_unrecoverable" -> 1)
     }
 
     "record clustering under the keys its readers use" in {

--- a/test/controllers/AdminJobTriggerSpec.scala
+++ b/test/controllers/AdminJobTriggerSpec.scala
@@ -50,7 +50,7 @@ import scala.concurrent.Future
  * and read the row back.
  *
  * The work itself is stubbed. Left alone these recompute a whole city's user stats, funnels and street priorities,
- * shell out to the Python clusterer, and call out to Overpass and the imagery providers; the assertion here is about
+ * shell out to the Python clusterer, and call out to the OSM API and the imagery providers; the assertion here is about
  * the bookkeeping around the call, not the call's arithmetic, which each service's own spec covers.
  *
  * Requires a Postgres+PostGIS database (DATABASE_URL / DATABASE_USER / DATABASE_PASSWORD, as in dev/CI); the

--- a/test/controllers/AdminJobTriggerSpec.scala
+++ b/test/controllers/AdminJobTriggerSpec.scala
@@ -65,9 +65,10 @@ class AdminJobTriggerSpec
     with Eventually {
 
   // Distinctive values, so an assertion can tell the stub's answer from anything the connected city really holds.
-  private val UsersUpdated   = 4611
-  private val FunnelRows     = 4612
-  private val WaysRefreshed  = OsmWayRefreshResult(waysRefreshed = 4613, waysMissing = 27)
+  private val UsersUpdated  = 4611
+  private val FunnelRows    = 4612
+  private val WaysRefreshed =
+    OsmWayRefreshResult(waysRefreshed = 4613, waysMissing = 27, tagsRecovered = 19, tagsUnrecoverable = 2)
   private val ImageryResult  = ImageryCheckResult(stillThere = 7, gone = 2, errors = 1, reconciled = Some(3))
   private val ClusterResults = ClusteringResults(labelCount = 4614, clusterCount = 4615)
   private val CropResult     = CropRunResult(
@@ -78,7 +79,7 @@ class AdminJobTriggerSpec
   )
 
   /** Set per test: this endpoint's failure path is part of its contract, and Guice owns the stub. */
-  @volatile private var osmWayAnswer: Future[OsmWayRefreshResult] = Future.successful(OsmWayRefreshResult(0, 0))
+  @volatile private var osmWayAnswer: Future[OsmWayRefreshResult] = Future.successful(OsmWayRefreshResult.empty)
 
   /** Set per test: whether the crop service reports a run in flight, which is the trigger's refusal path. */
   @volatile private var cropRunning: Boolean = false

--- a/test/models/street/OsmWayTableSpec.scala
+++ b/test/models/street/OsmWayTableSpec.scala
@@ -195,4 +195,31 @@ class OsmWayTableSpec
       stored mustBe ((bridgeTags, None, "history", micros(recheckAt), Some(micros(goneAt))))
     }
   }
+
+  "OsmWayTable.getWayIdsMissingOrStale" should {
+    "re-check a stale gone way, recovered or not, but never one the API has nothing for" in {
+      val staleAt = OffsetDateTime.now.minusDays(40)
+      val cutoff  = OffsetDateTime.now.minusDays(30)
+      val listed  = runRolledBack(for {
+        _   <- insertGoneWay(blankedId, Json.obj(), "batch", staleAt)    // gone, blanked: re-check
+        _   <- insertGoneWay(keptTagsId, bridgeTags, "history", staleAt) // gone, recovered: re-check
+        _   <- insertGoneWay(checkedId, Json.obj(), "history", staleAt)  // never held: nothing to come back
+        ids <- osmWayTable.getWayIdsMissingOrStale(cutoff)
+      } yield ids.filter(recoveryIds.contains))
+      listed mustBe Seq(blankedId, keptTagsId)
+    }
+
+    "leave a fresh row alone and list a mapped way with no row at all" in {
+      val cutoff = OffsetDateTime.now.minusDays(30)
+      val listed = runRolledBack(for {
+        _            <- insertGoneWay(blankedId, Json.obj(), "batch", OffsetDateTime.now)
+        streetEdgeId <- insertStreet()
+        _            <- sqlu"""INSERT INTO osm_way_street_edge (osm_way_street_edge_id, osm_way_id, street_edge_id)
+                    VALUES ((SELECT COALESCE(MAX(osm_way_street_edge_id), 0) + 1 FROM osm_way_street_edge),
+                            $keptTagsId, $streetEdgeId)"""
+        ids <- osmWayTable.getWayIdsMissingOrStale(cutoff)
+      } yield ids.filter(recoveryIds.contains))
+      listed mustBe Seq(keptTagsId)
+    }
+  }
 }

--- a/test/models/street/OsmWayTableSpec.scala
+++ b/test/models/street/OsmWayTableSpec.scala
@@ -14,7 +14,7 @@ import java.time.temporal.ChronoUnit
 import java.time.{Instant, OffsetDateTime}
 
 /**
- * DB-backed contract test for how the nightly refresh records a way that Overpass does not return (#5244, evolution
+ * DB-backed contract test for how the nightly refresh records a way the OSM API reports gone (#5244, evolution
  * 380) and how the lost tags of such a way are recovered from the OSM history (step 2, evolution 382).
  *
  * A mapped way id can die in OSM (the way deleted or merged away) while the street it described stays in our
@@ -143,7 +143,7 @@ class OsmWayTableSpec
   }
 
   "OsmWayTable.recordHistoryTags" should {
-    "store recovered tags under source 'history', keeping the way marked missing and its Overpass fetch time" in {
+    "store recovered tags under source 'history', keeping the way marked missing and its refresh fetch time" in {
       val goneAt                = OffsetDateTime.now.minusDays(3)
       val (stored, listedAfter) = runRolledBack(for {
         _      <- insertGoneWay(blankedId, Json.obj(), "batch", goneAt)

--- a/test/models/street/OsmWayTableSpec.scala
+++ b/test/models/street/OsmWayTableSpec.scala
@@ -170,5 +170,29 @@ class OsmWayTableSpec
     "write nothing for a way that has no row" in {
       runRolledBack(osmWayTable.recordHistoryTags(unseenId + 100, Some(bridgeTags), None)) mustBe 0
     }
+
+    "leave a way alone that came back to life while its history was being read" in {
+      val (written, stored) = runRolledBack(for {
+        _ <- insertGoneWay(blankedId, Json.obj(), "batch", OffsetDateTime.now)
+        // Another run's refresh found the way in OSM again and wrote its live tags.
+        _       <- osmWayTable.upsertBatch(Seq((blankedId, bridgeTags, Some("40 mph"))), Nil, OffsetDateTime.now)
+        written <- osmWayTable.recordHistoryTags(blankedId, Some(Json.obj("highway" -> "footway")), None)
+        stored  <- storedRow(blankedId)
+      } yield (written, stored))
+      written mustBe 0
+      stored._1 mustBe bridgeTags
+      stored._3 mustBe "batch"
+    }
+
+    "keep recovered tags and the 'history' source through a later refresh that still finds the way gone" in {
+      val goneAt    = OffsetDateTime.now.minusDays(40)
+      val recheckAt = OffsetDateTime.now
+      val stored    = runRolledBack(for {
+        _      <- insertGoneWay(blankedId, bridgeTags, "history", goneAt)
+        _      <- osmWayTable.upsertBatch(Nil, Seq(blankedId), recheckAt)
+        stored <- storedRow(blankedId)
+      } yield stored)
+      stored mustBe ((bridgeTags, None, "history", micros(recheckAt), Some(micros(goneAt))))
+    }
   }
 }

--- a/test/models/street/OsmWayTableSpec.scala
+++ b/test/models/street/OsmWayTableSpec.scala
@@ -1,43 +1,43 @@
 package models.street
 
-import models.utils.MyPostgresProfile
 import models.utils.MyPostgresProfile.api._
 import org.scalatest.BeforeAndAfterAll
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Application
-import play.api.db.slick.DatabaseConfigProvider
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.{JsValue, Json}
 import slick.dbio.DBIO
+import util.{RolledBackDb, StreetFixtures}
 
 import java.time.temporal.ChronoUnit
 import java.time.{Instant, OffsetDateTime}
-import scala.concurrent.Await
-import scala.concurrent.duration._
 
 /**
- * DB-backed contract test for how the nightly refresh records a way that Overpass no longer returns (#5244, evolution
- * 380).
+ * DB-backed contract test for how the nightly refresh records a way that Overpass does not return (#5244, evolution
+ * 380) and how the lost tags of such a way are recovered from the OSM history (step 2, evolution 382).
  *
  * A mapped way id can die in OSM (the way deleted or merged away) while the street it described stays in our
  * network. The refresh must keep that way's last known tags -- they still describe the geometry we imported, and
  * `bridge`/`tunnel`/`layer` on a dead way id are what keeps a bridge grade-separated -- and date the disappearance in
- * `missing_since`, once. Every case here is one edge of that contract.
+ * `missing_since`, once. A way blanked before the refresh learned that is looked up in the OSM history exactly once,
+ * whatever the history held. Every case here is one edge of that contract.
  *
  * Seeds its own rows under ids no real way will ever reach, so it can never pass vacuously and never touches a
  * mapped way. Requires a Postgres+PostGIS database (DATABASE_URL / DATABASE_USER / DATABASE_PASSWORD, as in dev/CI);
  * the scheduling actors are disabled so no background refresh touches the rows mid-test.
  */
-class OsmWayTableSpec extends PlaySpec with BeforeAndAfterAll with GuiceOneAppPerSuite {
+class OsmWayTableSpec
+    extends PlaySpec
+    with BeforeAndAfterAll
+    with GuiceOneAppPerSuite
+    with RolledBackDb
+    with StreetFixtures {
 
   override def fakeApplication(): Application =
     new GuiceApplicationBuilder().disable[modules.ActorModule].build()
 
   private val osmWayTable = app.injector.instanceOf[OsmWayTable]
-  private val dbConfig    = app.injector.instanceOf[DatabaseConfigProvider].get[MyPostgresProfile]
-
-  private def run[T](action: DBIO[T]): T = Await.result(dbConfig.db.run(action), 60.seconds)
 
   private val wayId      = 900000000001L
   private val unseenId   = 900000000002L
@@ -100,6 +100,75 @@ class OsmWayTableSpec extends PlaySpec with BeforeAndAfterAll with GuiceOneAppPe
     "count found and missing ways together, and write nothing for an empty chunk" in {
       run(osmWayTable.upsertBatch(Seq((wayId, bridgeTags, Some("40 mph"))), Seq(unseenId), OffsetDateTime.now)) mustBe 2
       run(osmWayTable.upsertBatch(Nil, Nil, OffsetDateTime.now)) mustBe 0
+    }
+  }
+
+  /** The recovery contract's three seeded ways, all mapped to a street so the backfill scan can see them. */
+  private val blankedId   = 900000000003L
+  private val keptTagsId  = 900000000004L
+  private val checkedId   = 900000000005L
+  private val recoveryIds = Seq(blankedId, keptTagsId, checkedId)
+
+  /** A gone way, mapped to a fresh street, with the given tags and source. */
+  private def insertGoneWay(osmWayId: Long, tags: JsValue, source: String, goneAt: OffsetDateTime): DBIO[Int] =
+    for {
+      streetEdgeId <- insertStreet()
+      _            <- sqlu"""INSERT INTO osm_way (osm_way_id, tags, maxspeed, geom, source, updated_at, missing_since)
+                  VALUES ($osmWayId, ${Json.stringify(tags)}::jsonb, NULL, NULL, $source, $goneAt, $goneAt)"""
+      n <- sqlu"""INSERT INTO osm_way_street_edge (osm_way_street_edge_id, osm_way_id, street_edge_id)
+                  VALUES ((SELECT COALESCE(MAX(osm_way_street_edge_id), 0) + 1 FROM osm_way_street_edge),
+                          $osmWayId, $streetEdgeId)"""
+    } yield n
+
+  /** (tags, maxspeed, source, updated_at, missing_since) as stored, read inside the test's transaction. */
+  private def storedRow(id: Long): DBIO[(JsValue, Option[String], String, Instant, Option[Instant])] =
+    sql"SELECT tags::text, maxspeed, source, updated_at, missing_since FROM osm_way WHERE osm_way_id = $id"
+      .as[(String, Option[String], String, OffsetDateTime, Option[OffsetDateTime])]
+      .head
+      .map { case (tags, maxspeed, source, updatedAt, missingSince) =>
+        (Json.parse(tags), maxspeed, source, micros(updatedAt), missingSince.map(micros))
+      }
+
+  "OsmWayTable.getWayIdsToBackfill" should {
+    "list only the gone ways whose tags are empty and whose history has not been read" in {
+      val goneAt = OffsetDateTime.now
+      val listed = runRolledBack(for {
+        _   <- insertGoneWay(blankedId, Json.obj(), "batch", goneAt)
+        _   <- insertGoneWay(keptTagsId, bridgeTags, "batch", goneAt)
+        _   <- insertGoneWay(checkedId, Json.obj(), "history", goneAt)
+        ids <- osmWayTable.getWayIdsToBackfill
+      } yield ids.filter(recoveryIds.contains))
+      listed mustBe Seq(blankedId)
+    }
+  }
+
+  "OsmWayTable.recordHistoryTags" should {
+    "store recovered tags under source 'history', keeping the way marked missing and its Overpass fetch time" in {
+      val goneAt                = OffsetDateTime.now.minusDays(3)
+      val (stored, listedAfter) = runRolledBack(for {
+        _      <- insertGoneWay(blankedId, Json.obj(), "batch", goneAt)
+        n      <- osmWayTable.recordHistoryTags(blankedId, Some(bridgeTags), Some("40 mph"))
+        stored <- storedRow(blankedId)
+        ids    <- osmWayTable.getWayIdsToBackfill
+      } yield { n mustBe 1; (stored, ids.filter(recoveryIds.contains)) })
+      stored mustBe ((bridgeTags, Some("40 mph"), "history", micros(goneAt), Some(micros(goneAt))))
+      listedAfter mustBe Nil
+    }
+
+    "mark a way whose history held nothing as checked, with empty tags, so it is not looked up again" in {
+      val goneAt                = OffsetDateTime.now
+      val (stored, listedAfter) = runRolledBack(for {
+        _      <- insertGoneWay(blankedId, Json.obj(), "batch", goneAt)
+        _      <- osmWayTable.recordHistoryTags(blankedId, None, None)
+        stored <- storedRow(blankedId)
+        ids    <- osmWayTable.getWayIdsToBackfill
+      } yield (stored, ids.filter(recoveryIds.contains)))
+      stored mustBe ((Json.obj(), None, "history", micros(goneAt), Some(micros(goneAt))))
+      listedAfter mustBe Nil
+    }
+
+    "write nothing for a way that has no row" in {
+      runRolledBack(osmWayTable.recordHistoryTags(unseenId + 100, Some(bridgeTags), None)) mustBe 0
     }
   }
 }

--- a/test/service/OsmWayServiceSpec.scala
+++ b/test/service/OsmWayServiceSpec.scala
@@ -70,6 +70,51 @@ class OsmWayServiceSpec extends PlaySpec {
     }
   }
 
+  "lastVisibleTags" should {
+
+    /** One version of a way in an OSM API history document; `tags = None` with `visible = false` is a deletion. */
+    def version(n: Long, tags: Option[JsObject], visible: Boolean = true): JsObject = {
+      Json.obj("type" -> "way", "id" -> 116721547L, "version" -> n) ++
+        (if (visible) Json.obj() else Json.obj("visible" -> false)) ++
+        tags.map(t => Json.obj("tags" -> t)).getOrElse(Json.obj())
+    }
+    def history(versions: JsObject*): JsValue = Json.obj("elements" -> versions)
+
+    val bridgeV17 = Json.obj("highway" -> "trunk", "bridge" -> "yes", "layer" -> "1", "maxspeed" -> "40 mph")
+    val bridgeV18 = bridgeV17 ++ Json.obj("parking:lane:both" -> "no_stopping")
+
+    "take the last visible version's tags of a deleted way" in {
+      val aurora = history(version(17, Some(bridgeV17)), version(18, Some(bridgeV18)), version(19, None, false))
+      OsmWayService.lastVisibleTags(aurora) mustBe Some(bridgeV18)
+    }
+
+    "prefer the last version that was still a road over a later one retagged out of the network" in {
+      val retagged = history(
+        version(3, Some(bridgeV18)),
+        version(4, Some(Json.obj("landuse" -> "construction"))),
+        version(5, None, false)
+      )
+      OsmWayService.lastVisibleTags(retagged) mustBe Some(bridgeV18)
+    }
+
+    "fall back to the last tagged version when no version carried highway" in {
+      val noRoad = history(version(1, Some(Json.obj("name" -> "Old"))), version(2, Some(Json.obj("name" -> "New"))))
+      OsmWayService.lastVisibleTags(noRoad) mustBe Some(Json.obj("name" -> "New"))
+    }
+
+    "order by version number, not document order" in {
+      val shuffled = history(version(18, Some(bridgeV18)), version(17, Some(bridgeV17)))
+      OsmWayService.lastVisibleTags(shuffled) mustBe Some(bridgeV18)
+    }
+
+    "skip versions with no tags and return None when nothing is left" in {
+      OsmWayService.lastVisibleTags(history(version(1, Some(Json.obj())), version(2, None, false))) mustBe None
+      OsmWayService.lastVisibleTags(history(version(1, None))) mustBe None
+      OsmWayService.lastVisibleTags(Json.obj("elements" -> Json.arr())) mustBe None
+      OsmWayService.lastVisibleTags(Json.obj()) mustBe None
+    }
+  }
+
   "maxspeedFrom" should {
     "extract the raw maxspeed value" in {
       OsmWayService.maxspeedFrom(Json.obj("maxspeed" -> "30")) mustBe Some("30")

--- a/test/service/OsmWayServiceSpec.scala
+++ b/test/service/OsmWayServiceSpec.scala
@@ -3,15 +3,20 @@ package service
 import org.scalatestplus.play.PlaySpec
 import play.api.libs.json.{JsObject, JsValue, Json}
 
+import scala.concurrent.duration._
+import scala.concurrent.{Await, ExecutionContext, Future}
+
 /**
- * Unit tests for OsmWayService's pure Overpass-response parsing and nearest-road selection (#4654). No application,
- * DB, or network required — the functions under test live on the companion object and take parsed JSON.
+ * Unit tests for OsmWayService's pure response parsing, chunk splitting, and nearest-road selection (#4654). No
+ * application, DB, or network required — the functions under test live on the companion object and take parsed JSON
+ * or a fake fetch.
  */
 class OsmWayServiceSpec extends PlaySpec {
+  implicit private val ec: ExecutionContext = ExecutionContext.global
 
-  /** Builds an Overpass `out tags;` batch response element for a way. */
+  /** Builds an OSM API multi-fetch response element for a live way. */
   private def wayWithTags(id: Long, tags: JsObject): JsObject = {
-    Json.obj("type" -> "way", "id" -> id, "tags" -> tags)
+    Json.obj("type" -> "way", "id" -> id, "version" -> 3, "tags" -> tags)
   }
 
   /** Builds an Overpass `out geom;` response element for a way along the given (lat, lon) points. */
@@ -28,15 +33,15 @@ class OsmWayServiceSpec extends PlaySpec {
     )
   }
 
-  "parseBatchResponse" should {
-    "map way ids to their full tag maps" in {
+  "parseWaysResponse" should {
+    "map live way ids to their full tag maps" in {
       val json: JsValue = Json.obj(
         "elements" -> Json.arr(
           wayWithTags(1L, Json.obj("maxspeed" -> "25 mph", "name" -> "Main St", "sidewalk" -> "both")),
           wayWithTags(2L, Json.obj("highway" -> "residential"))
         )
       )
-      val parsed = OsmWayService.parseBatchResponse(json)
+      val parsed = OsmWayService.parseWaysResponse(json)
       parsed.keySet mustBe Set(1L, 2L)
       (parsed(1L) \ "maxspeed").as[String] mustBe "25 mph"
       (parsed(1L) \ "name").as[String] mustBe "Main St"
@@ -44,29 +49,71 @@ class OsmWayServiceSpec extends PlaySpec {
       (parsed(2L) \ "maxspeed").asOpt[String] mustBe None
     }
 
-    "return an empty tag map for a way with no tags field" in {
-      val json: JsValue = Json.obj("elements" -> Json.arr(Json.obj("type" -> "way", "id" -> 5L)))
-      OsmWayService.parseBatchResponse(json) mustBe Map(5L -> Json.obj())
+    "leave out a deleted way, which the API returns with visible false and no tags" in {
+      val json: JsValue = Json.obj(
+        "elements" -> Json.arr(
+          wayWithTags(1L, Json.obj("highway" -> "primary")),
+          Json.obj("type" -> "way", "id" -> 116721547L, "version" -> 19, "visible" -> false)
+        )
+      )
+      OsmWayService.parseWaysResponse(json).keySet mustBe Set(1L)
+    }
+
+    "return an empty tag map for a live way with no tags field" in {
+      val json: JsValue = Json.obj("elements" -> Json.arr(Json.obj("type" -> "way", "id" -> 5L, "version" -> 1)))
+      OsmWayService.parseWaysResponse(json) mustBe Map(5L -> Json.obj())
     }
 
     "ignore non-way elements and tolerate an empty or missing elements array" in {
       val json: JsValue = Json.obj("elements" -> Json.arr(Json.obj("type" -> "node", "id" -> 9L)))
-      OsmWayService.parseBatchResponse(json) mustBe Map.empty
-      OsmWayService.parseBatchResponse(Json.obj("elements" -> Json.arr())) mustBe Map.empty
-      OsmWayService.parseBatchResponse(Json.obj()) mustBe Map.empty
+      OsmWayService.parseWaysResponse(json) mustBe Map.empty
+      OsmWayService.parseWaysResponse(Json.obj("elements" -> Json.arr())) mustBe Map.empty
+      OsmWayService.parseWaysResponse(Json.obj()) mustBe Map.empty
     }
   }
 
-  "truncationRemark" should {
-    "report the remark Overpass attaches to a query it cut short, and nothing for a complete response" in {
-      val cut = Json.obj(
-        "elements" -> Json.arr(wayWithTags(5L, Json.obj("highway" -> "primary"))),
-        "remark"   -> "runtime error: Query timed out in \"query\" at line 1 after 2 seconds."
-      )
-      OsmWayService.truncationRemark(cut) mustBe
-        Some("runtime error: Query timed out in \"query\" at line 1 after 2 seconds.")
-      OsmWayService.truncationRemark(Json.obj("elements" -> Json.arr())) mustBe None
-      OsmWayService.truncationRemark(Json.obj("elements" -> Json.arr(), "remark" -> "")) mustBe None
+  "fetchSplittingOnNotFound" should {
+    val tags = Json.obj("highway" -> "residential")
+
+    /**
+     * A fake multi-fetch that 404s (None) any request naming a never-existing id, answering the rest with `tags`, and
+     * records every request it gets.
+     */
+    class FakeApi(neverExisted: Set[Long]) {
+      var requests: List[Seq[Long]]                                  = Nil
+      def fetch(ids: Seq[Long]): Future[Option[Map[Long, JsObject]]] = {
+        requests = requests :+ ids
+        Future.successful(if (ids.exists(neverExisted)) None else Some(ids.map(_ -> tags).toMap))
+      }
+    }
+
+    def fetchAll(ids: Seq[Long], api: FakeApi): Map[Long, JsObject] =
+      Await.result(OsmWayService.fetchSplittingOnNotFound(ids)(api.fetch), 5.seconds)
+
+    "fetch a chunk with no bad id in one request" in {
+      val api = new FakeApi(Set.empty)
+      fetchAll(1L to 8L, api).keySet mustBe (1L to 8L).toSet
+      api.requests mustBe List(1L to 8L)
+    }
+
+    "narrow a 404 down to the one bad id, keeping every other id, in a bisection rather than one request per id" in {
+      val api = new FakeApi(Set(6L))
+      fetchAll(1L to 8L, api).keySet mustBe Set(1L, 2L, 3L, 4L, 5L, 7L, 8L)
+      // 1-8 → 1-4 (ok), 5-8 → 5-6 → 5 (ok), 6 (404); then 7-8 (ok).
+      api.requests mustBe List(1L to 8L, 1L to 4L, 5L to 8L, 5L to 6L, Seq(5L), Seq(6L), 7L to 8L)
+    }
+
+    "return nothing for a chunk that is all bad ids" in {
+      val api = new FakeApi(Set(1L, 2L))
+      fetchAll(Seq(1L, 2L), api) mustBe Map.empty
+      api.requests mustBe List(Seq(1L, 2L), Seq(1L), Seq(2L))
+    }
+
+    "propagate a failed request rather than treating it as a 404" in {
+      val boom                                                      = new RuntimeException("503")
+      val failing: Seq[Long] => Future[Option[Map[Long, JsObject]]] = _ => Future.failed(boom)
+      the[RuntimeException] thrownBy
+        Await.result(OsmWayService.fetchSplittingOnNotFound(Seq(1L, 2L))(failing), 5.seconds) mustBe boom
     }
   }
 

--- a/test/service/OsmWayServiceSpec.scala
+++ b/test/service/OsmWayServiceSpec.scala
@@ -64,11 +64,15 @@ class OsmWayServiceSpec extends PlaySpec {
       OsmWayService.parseWaysResponse(json) mustBe Map(5L -> Json.obj())
     }
 
-    "ignore non-way elements and tolerate an empty or missing elements array" in {
+    "ignore non-way elements and tolerate an empty elements array" in {
       val json: JsValue = Json.obj("elements" -> Json.arr(Json.obj("type" -> "node", "id" -> 9L)))
       OsmWayService.parseWaysResponse(json) mustBe Map.empty
       OsmWayService.parseWaysResponse(Json.obj("elements" -> Json.arr())) mustBe Map.empty
-      OsmWayService.parseWaysResponse(Json.obj()) mustBe Map.empty
+    }
+
+    "throw on a body with no elements array, rather than read every requested way as gone" in {
+      a[RuntimeException] mustBe thrownBy(OsmWayService.parseWaysResponse(Json.obj()))
+      a[RuntimeException] mustBe thrownBy(OsmWayService.parseWaysResponse(Json.obj("error" -> "Bad Gateway")))
     }
   }
 
@@ -77,35 +81,47 @@ class OsmWayServiceSpec extends PlaySpec {
 
     /**
      * A fake multi-fetch that 404s (None) any request naming a never-existing id, answering the rest with `tags`, and
-     * records every request it gets.
+     * records every request it gets and every pause it is asked for. A request `failing` accepts fails outright.
      */
-    class FakeApi(neverExisted: Set[Long]) {
+    class FakeApi(neverExisted: Set[Long], failing: Seq[Long] => Boolean = _ => false) {
       var requests: List[Seq[Long]]                                  = Nil
+      var pauses: Int                                                = 0
       def fetch(ids: Seq[Long]): Future[Option[Map[Long, JsObject]]] = {
         requests = requests :+ ids
-        Future.successful(if (ids.exists(neverExisted)) None else Some(ids.map(_ -> tags).toMap))
+        if (failing(ids)) Future.failed(new RuntimeException("503"))
+        else Future.successful(if (ids.exists(neverExisted)) None else Some(ids.map(_ -> tags).toMap))
       }
+      def pause(): Future[Unit] = { pauses += 1; Future.unit }
     }
 
-    def fetchAll(ids: Seq[Long], api: FakeApi): Map[Long, JsObject] =
-      Await.result(OsmWayService.fetchSplittingOnNotFound(ids)(api.fetch), 5.seconds)
+    def fetchAll(ids: Seq[Long], api: FakeApi): OsmWayService.ChunkFetch =
+      Await.result(OsmWayService.fetchSplittingOnNotFound(ids)(api.fetch, () => api.pause()), 5.seconds)
 
-    "fetch a chunk with no bad id in one request" in {
-      val api = new FakeApi(Set.empty)
-      fetchAll(1L to 8L, api).keySet mustBe (1L to 8L).toSet
+    "fetch a chunk with no bad id in one request and no pause" in {
+      val api    = new FakeApi(Set.empty)
+      val result = fetchAll(1L to 8L, api)
+      result.live.keySet mustBe (1L to 8L).toSet
+      result.neverHeld mustBe Nil
       api.requests mustBe List(1L to 8L)
+      api.pauses mustBe 0
     }
 
     "narrow a 404 down to the one bad id, keeping every other id, in a bisection rather than one request per id" in {
-      val api = new FakeApi(Set(6L))
-      fetchAll(1L to 8L, api).keySet mustBe Set(1L, 2L, 3L, 4L, 5L, 7L, 8L)
+      val api    = new FakeApi(Set(6L))
+      val result = fetchAll(1L to 8L, api)
+      result.live.keySet mustBe Set(1L, 2L, 3L, 4L, 5L, 7L, 8L)
+      result.neverHeld mustBe Seq(6L)
       // 1-8 → 1-4 (ok), 5-8 → 5-6 → 5 (ok), 6 (404); then 7-8 (ok).
       api.requests mustBe List(1L to 8L, 1L to 4L, 5L to 8L, 5L to 6L, Seq(5L), Seq(6L), 7L to 8L)
+      // One pause before each request after the first.
+      api.pauses mustBe api.requests.size - 1
     }
 
-    "return nothing for a chunk that is all bad ids" in {
-      val api = new FakeApi(Set(1L, 2L))
-      fetchAll(Seq(1L, 2L), api) mustBe Map.empty
+    "name every id in a chunk that is all bad ids" in {
+      val api    = new FakeApi(Set(1L, 2L))
+      val result = fetchAll(Seq(1L, 2L), api)
+      result.live mustBe Map.empty
+      result.neverHeld mustBe Seq(1L, 2L)
       api.requests mustBe List(Seq(1L, 2L), Seq(1L), Seq(2L))
     }
 
@@ -114,6 +130,13 @@ class OsmWayServiceSpec extends PlaySpec {
       val failing: Seq[Long] => Future[Option[Map[Long, JsObject]]] = _ => Future.failed(boom)
       the[RuntimeException] thrownBy
         Await.result(OsmWayService.fetchSplittingOnNotFound(Seq(1L, 2L))(failing), 5.seconds) mustBe boom
+    }
+
+    "propagate a failure in the second half even after the first half succeeded" in {
+      // 1-4 404s because 3 never existed, so it splits: 1-2 is fine, then 3-4 fails on the request itself.
+      val api = new FakeApi(neverExisted = Set(3L), failing = _ == Seq(3L, 4L))
+      a[RuntimeException] mustBe thrownBy(fetchAll(1L to 4L, api))
+      api.requests mustBe List(1L to 4L, 1L to 2L, 3L to 4L)
     }
   }
 


### PR DESCRIPTION
Fixes #5237. Stacked on the #5244 step-2 branch (it reuses that branch's `OutboundHttp.UserAgent` and `OSM_API_URL`), so that PR merges first.

## What was wrong

`osm-way-refresh-actor` failed 42% of the time in production, almost always `Connection refused` from `overpass-api.de`, and makelab1 is refused outright while another network is served in the same minute. The issue proposed pacing and serialising the ~57 per-city jobs against Overpass's slot limits.

## What changes

The batch refresh does not need Overpass at all. It asks for tags **by way id**, which is exactly what the main OSM API's multi-fetch is for; Overpass is a query engine we only need for the spatial `around:` point lookup behind the speed-limit fallback. Measured 2026-09-09:

| `GET /api/0.6/ways.json?ways=…` | |
|---|---|
| 300 Seattle ids | 200 in 1.1 s, 134 KB, 295 live + 5 with `visible: false` |
| deleted way 116721547 | returned with `visible: false`, no tags |
| any id that never existed | 404 for the whole request, without naming the id |

- `fetchTagsForWays` now does that GET with the identifying `User-Agent`, keeping the chunking (300), pacing (2 s), and retries (3 × 15 s·n).
- `parseWaysResponse` leaves out a `visible: false` way, so the existing missing path is unchanged and a deleted way is a positive signal rather than an inference from absence. The Overpass cut-short-response guard from #5246 goes with it.
- `fetchSplittingOnNotFound` narrows a 404 down by bisecting the chunk, about log2(300) extra requests once per bad id; the id then goes down the missing path and the history phase marks it checked. It is a pure combinator the spec drives with a fake fetch, asserting request order so it cannot degrade to one request per id.
- The point lookup still uses Overpass: one cached query per unknown spot, user-paced.

Not done, on purpose: no `/api/status` slot check or cross-city serialisation (nothing left on Overpass to serialise), no per-city jitter, and no health change (the Health panel already shows `failuresInWindow` and the 36 h overdue flag). The block on makelab1's address is a separate question for the operators; the nightly job no longer depends on the answer.

## Verification

- `OsmWayServiceSpec` (4 `parseWaysResponse` + 4 `fetchSplittingOnNotFound` cases), `OsmWayTableSpec`, `JobRunDetailsSpec`, `AdminJobTriggerSpec`: 47/47 green. Compile clean under `-Xfatal-warnings`, scalafmt clean.
- Seattle dev schema with 1,000 rows aged past the staleness cutoff: `ways_refreshed = 1000` in 8.6 s (4 requests), `ways_missing = 11`, exactly the rows already known dead; 989 live rows re-fetched under `source = 'batch'`, the 11 dead rows kept their recovered tags and `source = 'history'`; zero Overpass requests in the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Fable 5.1, claude-fable-5-1
