### PR TITLE
Stop publishing private deployments' URLs from /v3/api/cities (#5259)

### DIFF
--- a/app/controllers/api/CitiesApiController.scala
+++ b/app/controllers/api/CitiesApiController.scala
@@ -40,7 +40,7 @@ class CitiesApiController @Inject() (
    * This endpoint provides details about each city including:
    * - City ID and country
    * - City names (short and formatted)
-   * - URL for the city's Project Sidewalk site
+   * - URL for the city's Project Sidewalk site, or null when the city isn't publicly launched
    * - Visibility status (public, private, etc.)
    * - Geographic center coordinates
    * - Zoom level
@@ -105,9 +105,13 @@ class CitiesApiController @Inject() (
    *
    * `url` is null for any city that isn't publicly launched (#5259). Those deployments are research partnerships and
    * internal UW studies, and this endpoint is how a crawler reaches them: /cities is in the sitemap and the map
-   * component it loads fetches this endpoint client-side, so publishing their addresses here publishes them. The
-   * field stays present rather than being dropped, so response shape and the CSV column layout are unchanged, and
-   * the row itself stays so the city count, map geometry and `visibility` are still available.
+   * component it loads fetches this endpoint client-side, so an address published here lands in a crawlable link
+   * graph. The field stays present rather than being dropped, so response shape and the CSV column layout are
+   * unchanged, and the row itself stays so the city count, map geometry and `visibility` are still available.
+   *
+   * This keeps unlaunched deployments out of link graphs; it does not make their hostnames unguessable. `city_id` is
+   * still published and the deployment hostnames mostly follow from it, so a reader who studies one public row can
+   * infer the rest. Closing that would mean dropping the rows entirely, which costs the city count and the map.
    *
    * @param cityInfo Basic city information from ConfigService.
    * @param mapParamsOpt Optional map parameters for the city from the database.
@@ -120,7 +124,7 @@ class CitiesApiController @Inject() (
       "country_id"          -> cityInfo.countryId,
       "city_name_short"     -> cityInfo.cityNameShort,
       "city_name_formatted" -> cityInfo.cityNameFormatted,
-      "url"                 -> (if (cityInfo.visibility == "public") JsString(cityInfo.URL) else JsNull),
+      "url"                 -> (if (cityInfo.isPublic) JsString(cityInfo.URL) else JsNull),
       "visibility"          -> cityInfo.visibility
     )
 

--- a/app/controllers/api/CitiesApiController.scala
+++ b/app/controllers/api/CitiesApiController.scala
@@ -3,7 +3,7 @@ package controllers.api
 import controllers.base.CustomControllerComponents
 import models.api.ApiError
 import play.api.Logger
-import play.api.libs.json.{JsNumber, JsObject, JsString, Json}
+import play.api.libs.json.{JsNull, JsNumber, JsObject, JsString, Json}
 import play.silhouette.api.Silhouette
 import service.{CityInfo, ConfigService}
 
@@ -103,6 +103,12 @@ class CitiesApiController @Inject() (
    * This private helper method constructs a JSON object with city details. If map parameters are available, it includes
    * geographic information such as center coordinates and boundaries. If not, it returns basic city information only.
    *
+   * `url` is null for any city that isn't publicly launched (#5259). Those deployments are research partnerships and
+   * internal UW studies, and this endpoint is how a crawler reaches them: /cities is in the sitemap and the map
+   * component it loads fetches this endpoint client-side, so publishing their addresses here publishes them. The
+   * field stays present rather than being dropped, so response shape and the CSV column layout are unchanged, and
+   * the row itself stays so the city count, map geometry and `visibility` are still available.
+   *
    * @param cityInfo Basic city information from ConfigService.
    * @param mapParamsOpt Optional map parameters for the city from the database.
    * @return JSON object with city details.
@@ -114,7 +120,7 @@ class CitiesApiController @Inject() (
       "country_id"          -> cityInfo.countryId,
       "city_name_short"     -> cityInfo.cityNameShort,
       "city_name_formatted" -> cityInfo.cityNameFormatted,
-      "url"                 -> cityInfo.URL,
+      "url"                 -> (if (cityInfo.visibility == "public") JsString(cityInfo.URL) else JsNull),
       "visibility"          -> cityInfo.visibility
     )
 

--- a/app/service/ConfigService.scala
+++ b/app/service/ConfigService.scala
@@ -59,7 +59,17 @@ case class CityInfo(
     cityNameFormatted: String,
     URL: String,
     visibility: String
-)
+) {
+
+  /**
+   * Whether this deployment is publicly launched, i.e. its `city-params.status` entry is `public`.
+   *
+   * The one place the rule lives for callers holding a [[CityInfo]], so a surface that decides whether to publish a
+   * deployment's address can't drift from the others. Any unrecognized status reads as not public: the failure that
+   * matters here is disclosing an unlaunched deployment, not withholding a launched one (#5259).
+   */
+  def isPublic: Boolean = visibility == "public"
+}
 case class CommonPageData(
     cityId: String,
     environmentType: String,

--- a/app/views/apiDocs/cities.scala.html
+++ b/app/views/apiDocs/cities.scala.html
@@ -172,6 +172,23 @@
         "west": -81
       }
     },
+    {
+      "city_id": "taipei",
+      "country_id": "taiwan",
+      "city_name_short": "Taipei",
+      "city_name_formatted": "Taipei, Taiwan",
+      "url": null, // Not publicly launched, so no address is published.
+      "visibility": "private",
+      "center_lat": 25.04,
+      "center_lng": 121.51,
+      "zoom": 12.75,
+      "bounds": {
+        "north": 25.3,
+        "south": 24.9,
+        "east": 121.7,
+        "west": 121.3
+      }
+    },
     // ... more cities
   ]
 }</code></pre>
@@ -212,6 +229,7 @@
     <pre tabindex="0"><code class="language-csv">city_id,country_id,city_name_short,city_name_formatted,url,visibility,center_lat,center_lng,zoom,bounds.north,bounds.south,bounds.east,bounds.west
 teaneck-nj,usa,Teaneck,"Teaneck, NJ",https://sidewalk-teaneck.cs.washington.edu,public,40.888,-74.015,12.75,41.4,40.4,-73.5,-74.5
 pittsburgh-pa,usa,Pittsburgh,"Pittsburgh, PA",https://sidewalk-pittsburgh-test.cs.washington.edu,public,40.435,-79.96,11.75,41,40,-79,-81
+taipei,taiwan,Taipei,"Taipei, Taiwan",,private,25.04,121.51,12.75,25.3,24.9,121.7,121.3
 ...</code></pre>
 
     <h4 id="response-geojson">GeoJSON Format <a href="#response-geojson" class="permalink">#</a></h4>

--- a/app/views/apiDocs/cities.scala.html
+++ b/app/views/apiDocs/cities.scala.html
@@ -193,7 +193,7 @@
           <tr><td><code>country_id</code></td><td><code>string</code></td><td>Identifier for the country where the city is located.</td></tr>
           <tr><td><code>city_name_short</code></td><td><code>string</code></td><td>Short name of the city.</td></tr>
           <tr><td><code>city_name_formatted</code></td><td><code>string</code></td><td>Full formatted name of the city, including state/province or country information.</td></tr>
-          <tr><td><code>url</code></td><td><code>string</code></td><td>URL for the city's Project Sidewalk instance.</td></tr>
+          <tr><td><code>url</code></td><td><code>string | null</code></td><td>URL for the city's Project Sidewalk instance. <code>null</code> unless <code>visibility</code> is <code>public</code>; the CSV renders that as an empty cell.</td></tr>
           <tr><td><code>visibility</code></td><td><code>string</code></td><td>Visibility status of the city: <code>public</code> or <code>private</code>.</td></tr>
           <tr><td><code>center_lat</code></td><td><code>number | null</code></td><td>Latitude of the city's center point. Present only if geographic information is available.</td></tr>
           <tr><td><code>center_lng</code></td><td><code>number | null</code></td><td>Longitude of the city's center point. Present only if geographic information is available.</td></tr>

--- a/app/views/common/navbar.scala.html
+++ b/app/views/common/navbar.scala.html
@@ -8,7 +8,7 @@
 )(implicit request: RequestHeader, messages: Messages, assets: AssetsFinder, config: Configuration)
 
 @currentCityInfo = @{commonData.allCityInfo.filter(c => c.cityId == commonData.cityId).head}
-@cityInfo = @{commonData.allCityInfo.filter(c => c.cityId == commonData.cityId || c.visibility == "public" || (currentCityInfo.countryId == "taiwan" && c.countryId == "taiwan"))}
+@cityInfo = @{commonData.allCityInfo.filter(c => c.cityId == commonData.cityId || c.isPublic || (currentCityInfo.countryId == "taiwan" && c.countryId == "taiwan"))}
 @* Every switch-target city (i.e. not the current one), grouped by country and sorted within each group; the current
    city is pinned separately at the top of the switcher. Country order is alphabetical by country id. *@
 @otherCitiesByCountry = @{cityInfo.filter(_.cityId != commonData.cityId).sortBy(c => (c.countryId, c.stateId, c.cityId)).groupBy(_.countryId).toSeq.sortBy(_._1)}

--- a/public/js/ps-map/addCitiesToMap.js
+++ b/public/js/ps-map/addCitiesToMap.js
@@ -140,9 +140,10 @@ function addCitiesToMap(map, citiesData, params) {
       const properties = feature.properties;
       const coordinates = feature.geometry.coordinates.slice();
 
-      // On localhost, for testing, I've just been using the following (otherwise we run into CORS issues):
-      // const statsUrl = `v3/api/overallStats`;
-      const statsUrl = `${properties.url}/v3/api/overallStats`;
+      // The API withholds a url for every deployment that isn't publicly launched (#5259), so branch on the url
+      // rather than on `visibility`. That keeps the client from disagreeing with the server about which cities
+      // those are: a third status value would otherwise land here still reaching for a url that isn't there.
+      const isPublicDeployment = Boolean(properties.url);
 
       // Immediately show a simple loading message.
       const loadingMessage = i18next.t('common:cities-map.loading-stats');
@@ -154,34 +155,41 @@ function addCitiesToMap(map, citiesData, params) {
       // Populate the parts of the template that do not depend on the stats API.
       popupContent.querySelector('.popup-title').textContent = properties.city_name_formatted;
       const exploreLink = popupContent.querySelector('.popup-link');
-      if (properties.visibility === 'private') {
+      if (!isPublicDeployment) {
         const privateMessage = document.createElement('div');
         privateMessage.className = 'popup-private-message';
         privateMessage.textContent = i18next.t('common:cities-map.private-deployment');
         exploreLink.replaceWith(privateMessage);
+        // The stats come from the deployment's own API, so with no url there is nothing to ask. Drop the grid
+        // rather than leave three placeholder dashes standing where numbers used to be.
+        popupContent.querySelector('.popup-stats-grid').remove();
       } else {
         exploreLink.href = `${properties.url}/explore`;
         exploreLink.setAttribute('cityId', properties.city_id);
         exploreLink.textContent = i18next.t('common:cities-map.explore', { cityName: properties.city_name_short });
       }
 
-      try {
-        // We only TRY to fetch and populate the stats.
-        const response = await fetch(statsUrl);
-        if (!response.ok) throw new Error('Network response was not ok');
-        const stats = await response.json();
+      if (isPublicDeployment) {
+        try {
+          // We only TRY to fetch and populate the stats.
+          // On localhost, for testing, I've just been using the following (otherwise we run into CORS issues):
+          // const response = await fetch(`v3/api/overallStats`);
+          const response = await fetch(`${properties.url}/v3/api/overallStats`);
+          if (!response.ok) throw new Error('Network response was not ok');
+          const stats = await response.json();
 
-        // If successful, fill in the stat values.
-        popupContent.querySelector('[data-stat="distance"]').textContent = formatDistance(stats.km_explored || 0);
-        popupContent.querySelector('[data-stat="labels"]').textContent = formatNumber(stats.labels.label_count || 0);
-        // overallStats nests validation totals under combined/human/ai; "combined" is the human+AI total (#4591).
-        popupContent.querySelector('[data-stat="validations"]').textContent = formatNumber(
-          stats.validations.combined?.total_validations || 0,
-        );
-      } catch (error) {
-        // If the fetch fails, just log the error. The popup will still be shown,
-        // but the stats will be the default placeholder values from the template.
-        console.error('Failed to fetch city stats:', error);
+          // If successful, fill in the stat values.
+          popupContent.querySelector('[data-stat="distance"]').textContent = formatDistance(stats.km_explored || 0);
+          popupContent.querySelector('[data-stat="labels"]').textContent = formatNumber(stats.labels.label_count || 0);
+          // overallStats nests validation totals under combined/human/ai; "combined" is the human+AI total (#4591).
+          popupContent.querySelector('[data-stat="validations"]').textContent = formatNumber(
+            stats.validations.combined?.total_validations || 0,
+          );
+        } catch (error) {
+          // If the fetch fails, just log the error. The popup will still be shown,
+          // but the stats will be the default placeholder values from the template.
+          console.error('Failed to fetch city stats:', error);
+        }
       }
 
       // Finally, update the popup with the content, which will have stats if they loaded.

--- a/test/controllers/api/CitiesApiSpec.scala
+++ b/test/controllers/api/CitiesApiSpec.scala
@@ -28,15 +28,30 @@ class CitiesApiSpec extends PlaySpec with GuiceOneAppPerSuite {
 
   implicit lazy val mat: Materializer = app.materializer
 
-  /** Splits a CSV row on commas outside quotes, so a quoted city name like "Washington, DC" stays one cell. */
+  /**
+   * Splits a CSV row on commas outside quotes, so a quoted city name like "Washington, DC" stays one cell.
+   *
+   * Handles RFC 4180's doubled-quote escape, emitting one `"` for each `""` inside a quoted field rather than
+   * dropping both, and tolerates a trailing `\r` so a row survives whichever line ending the generator uses.
+   *
+   * @param row One CSV line, without its terminator.
+   * @return    The row's cells in order, including a trailing empty one.
+   */
   private def splitCsvRow(row: String): Seq[String] = {
     val cells    = scala.collection.mutable.ListBuffer.empty[String]
     val cell     = new StringBuilder
     var inQuotes = false
-    row.foreach {
-      case '"'              => inQuotes = !inQuotes
-      case ',' if !inQuotes => cells += cell.toString; cell.clear()
-      case c                => cell += c
+    var i        = 0
+    val chars    = row.stripSuffix("\r")
+    while (i < chars.length) {
+      chars(i) match {
+        // A doubled quote inside a quoted field is one literal quote, so consume both and emit one.
+        case '"' if inQuotes && i + 1 < chars.length && chars(i + 1) == '"' => cell += '"'; i += 1
+        case '"'                                                            => inQuotes = !inQuotes
+        case ',' if !inQuotes                                               => cells += cell.toString; cell.clear()
+        case c                                                              => cell += c
+      }
+      i += 1
     }
     (cells += cell.toString).toSeq
   }
@@ -88,13 +103,18 @@ class CitiesApiSpec extends PlaySpec with GuiceOneAppPerSuite {
 
     "render the withheld url as an empty CSV cell, not the literal \"null\"" in {
       val body    = contentAsString(route(app, FakeRequest(GET, "/v3/api/cities?filetype=csv")).get)
-      val lines   = body.split("\n").toSeq.filter(_.nonEmpty)
+      val lines   = body.split("\r?\n").toSeq.filter(_.nonEmpty)
       val headers = splitCsvRow(lines.head)
       val urlCol  = headers.indexOf("url")
       val visCol  = headers.indexOf("visibility")
+      // Asserted rather than assumed: a renamed header would otherwise index at -1 and throw, which reads as a
+      // broken test rather than the contract change it is.
       urlCol must be >= 0
-      lines.tail.foreach { row =>
-        val cells = splitCsvRow(row)
+      visCol must be >= 0
+      val rows = lines.tail.map(splitCsvRow)
+      // Every city is a CSV row regardless of map params, so this holds wherever the JSON guard does.
+      rows.count(cells => cells(visCol) != "public") must be > 0
+      rows.foreach { cells =>
         withClue(s"${cells.head}: ") {
           if (cells(visCol) == "public") cells(urlCol) must startWith("http")
           else cells(urlCol) mustBe ""
@@ -105,9 +125,16 @@ class CitiesApiSpec extends PlaySpec with GuiceOneAppPerSuite {
     "withhold the url in GeoJSON properties too" in {
       val json     = contentAsJson(route(app, FakeRequest(GET, "/v3/api/cities?filetype=geojson")).get)
       val features = (json \ "features").as[Seq[JsObject]]
-      features.map(f => (f \ "properties").as[JsObject]).foreach { props =>
-        if ((props \ "visibility").as[String] == "public") (props \ "url").as[String] must startWith("http")
-        else (props \ "url").get mustBe play.api.libs.json.JsNull
+      val props    = features.map(f => (f \ "properties").as[JsObject])
+      props.foreach { p =>
+        if ((p \ "visibility").as[String] == "public") (p \ "url").as[String] must startWith("http")
+        else (p \ "url").get mustBe play.api.libs.json.JsNull
+      }
+      // GeoJSON carries a feature only for a city whose schema this database actually has, so on a one-city dev or
+      // CI database there may be no non-public feature to check. Cancel rather than pass, so a green run doesn't
+      // report coverage it didn't have — the JSON and CSV cases cover the rule on every city either way.
+      if (!props.exists(p => (p \ "visibility").as[String] != "public")) {
+        cancel("no non-public city has map params in this database, so GeoJSON can't exercise the withheld url")
       }
     }
 

--- a/test/controllers/api/CitiesApiSpec.scala
+++ b/test/controllers/api/CitiesApiSpec.scala
@@ -28,6 +28,19 @@ class CitiesApiSpec extends PlaySpec with GuiceOneAppPerSuite {
 
   implicit lazy val mat: Materializer = app.materializer
 
+  /** Splits a CSV row on commas outside quotes, so a quoted city name like "Washington, DC" stays one cell. */
+  private def splitCsvRow(row: String): Seq[String] = {
+    val cells    = scala.collection.mutable.ListBuffer.empty[String]
+    val cell     = new StringBuilder
+    var inQuotes = false
+    row.foreach {
+      case '"'              => inQuotes = !inQuotes
+      case ',' if !inQuotes => cells += cell.toString; cell.clear()
+      case c                => cell += c
+    }
+    (cells += cell.toString).toSeq
+  }
+
   "GET /v3/api/cities (default JSON)" should {
     "return 200 with the {status, cities:[...]} envelope" in {
       val resp = route(app, FakeRequest(GET, "/v3/api/cities")).get
@@ -52,6 +65,59 @@ class CitiesApiSpec extends PlaySpec with GuiceOneAppPerSuite {
         // camelCase keys must not appear in the output per v3 naming convention (#3871).
         (city \ "cityId").toOption mustBe None
         (city \ "cityNameShort").toOption mustBe None
+      }
+    }
+  }
+
+  "GET /v3/api/cities" should {
+    "publish a url for public cities and null for every other visibility" in {
+      // These deployments are research partnerships and internal UW studies. /cities is in the sitemap and the map
+      // component it loads fetches this endpoint client-side, so a url here is a url a crawler follows (#5259).
+      val cities = (contentAsJson(route(app, FakeRequest(GET, "/v3/api/cities")).get) \ "cities").as[Seq[JsObject]]
+      cities.count(c => (c \ "visibility").as[String] != "public") must be > 0
+      cities.foreach { city =>
+        val cityId: String = (city \ "city_id").as[String]
+        withClue(s"$cityId: ") {
+          // The key stays present either way, so response shape and CSV column layout don't change.
+          (city \ "url").toOption mustBe defined
+          if ((city \ "visibility").as[String] == "public") (city \ "url").as[String] must startWith("http")
+          else (city \ "url").get mustBe play.api.libs.json.JsNull
+        }
+      }
+    }
+
+    "render the withheld url as an empty CSV cell, not the literal \"null\"" in {
+      val body    = contentAsString(route(app, FakeRequest(GET, "/v3/api/cities?filetype=csv")).get)
+      val lines   = body.split("\n").toSeq.filter(_.nonEmpty)
+      val headers = splitCsvRow(lines.head)
+      val urlCol  = headers.indexOf("url")
+      val visCol  = headers.indexOf("visibility")
+      urlCol must be >= 0
+      lines.tail.foreach { row =>
+        val cells = splitCsvRow(row)
+        withClue(s"${cells.head}: ") {
+          if (cells(visCol) == "public") cells(urlCol) must startWith("http")
+          else cells(urlCol) mustBe ""
+        }
+      }
+    }
+
+    "withhold the url in GeoJSON properties too" in {
+      val json     = contentAsJson(route(app, FakeRequest(GET, "/v3/api/cities?filetype=geojson")).get)
+      val features = (json \ "features").as[Seq[JsObject]]
+      features.map(f => (f \ "properties").as[JsObject]).foreach { props =>
+        if ((props \ "visibility").as[String] == "public") (props \ "url").as[String] must startWith("http")
+        else (props \ "url").get mustBe play.api.libs.json.JsNull
+      }
+    }
+
+    "keep publishing the non-url fields for a private city, so counts and geometry still work" in {
+      val cities   = (contentAsJson(route(app, FakeRequest(GET, "/v3/api/cities")).get) \ "cities").as[Seq[JsObject]]
+      val private_ = cities.filter(c => (c \ "visibility").as[String] != "public")
+      private_.foreach { city =>
+        (city \ "city_id").asOpt[String] mustBe defined
+        (city \ "city_name_formatted").asOpt[String] mustBe defined
+        (city \ "visibility").asOpt[String] mustBe defined
       }
     }
   }

--- a/test/js/addCitiesToMapPopup.test.js
+++ b/test/js/addCitiesToMapPopup.test.js
@@ -95,9 +95,11 @@ function makeFakeMap() {
 
 /**
  * Synthetic click event for a public city, matching the feature shape addCitiesToMap reads.
+ *
+ * @param {object} [overrides] - Feature properties to replace, e.g. a withheld `url` for a private deployment.
  * @returns {object} A Mapbox-style click event with one feature.
  */
-function makeClickEvent() {
+function makeClickEvent(overrides = {}) {
     return {
         features: [{
             id: 'seattle',
@@ -107,6 +109,7 @@ function makeClickEvent() {
                 city_name_formatted: 'Seattle, WA',
                 city_name_short: 'Seattle',
                 visibility: 'public',
+                ...overrides,
             },
             geometry: { coordinates: [-122.33, 47.6] },
         }],
@@ -177,10 +180,10 @@ describe('addCitiesToMap city popup (#4591)', () => {
      * Wire up the map, fire a city click with the given stats body, and wait for the async handler to finish.
      * @param {object} statsBody - The overallStats JSON the stubbed fetch returns.
      */
-    async function clickCity(statsBody) {
+    async function clickCity(statsBody, overrides = {}) {
         stubFetch(statsBody);
         await addCitiesToMap(map, makeCitiesData(), { mapName: 'cities-map', logClicks: false });
-        await map.handlers['click:cities'](makeClickEvent());
+        await map.handlers['click:cities'](makeClickEvent(overrides));
     }
 
     const validationsCell = () => lastPopupContent.querySelector('[data-stat="validations"]').textContent;
@@ -206,5 +209,37 @@ describe('addCitiesToMap city popup (#4591)', () => {
         await clickCity(OLD_FLAT_STATS);
         expect(validationsCell()).toBe('0');
         expect(labelsCell()).toBe('21649');
+    });
+
+    // /v3/api/cities withholds the url for a deployment that isn't publicly launched (#5259). Building the stats
+    // request from it unconditionally would fetch the relative path "null/v3/api/overallStats" against whichever
+    // origin is serving /cities — a 404 and a console error on every click of a private city's dot.
+    describe('a deployment whose url the API withheld (#5259)', () => {
+        const PRIVATE = { url: null, visibility: 'private' };
+
+        test('makes no stats request at all', async () => {
+            await clickCity(GOOD_STATS, PRIVATE);
+            expect(global.fetch).not.toHaveBeenCalled();
+        });
+
+        test('drops the stats grid rather than showing placeholder dashes', async () => {
+            await clickCity(GOOD_STATS, PRIVATE);
+            expect(lastPopupContent.querySelector('.popup-stats-grid')).toBeNull();
+        });
+
+        test('replaces the explore link with the private-deployment message', async () => {
+            await clickCity(GOOD_STATS, PRIVATE);
+            expect(lastPopupContent.querySelector('.popup-link')).toBeNull();
+            expect(lastPopupContent.querySelector('.popup-private-message').textContent)
+                .toBe('common:cities-map.private-deployment');
+        });
+
+        // The client keys off the url, not off `visibility`, so a status value neither side has seen before can't
+        // leave it rendering href="null/explore" on the public cities map.
+        test('withholds the link for an unrecognized visibility too, whenever the url is absent', async () => {
+            await clickCity(GOOD_STATS, { url: null, visibility: 'beta' });
+            expect(global.fetch).not.toHaveBeenCalled();
+            expect(lastPopupContent.querySelector('.popup-link')).toBeNull();
+        });
     });
 });


### PR DESCRIPTION
Closes #5259.

`/v3/api/cities` published a landing-page URL for every deployment — all 56 on prod, including the 19 whose `status` in `cityparams.conf` is `private`. Those are research partnerships with outside institutions plus the internal UW deployments `validation-study` and `crowdstudy`.

This is reachable by an ordinary crawl, not just by guessing an API path: `/cities` is in the sitemap, and the shared map component that page loads (`public/js/ps-map/createPSMap.js`) fetches `/v3/api/cities?filetype=geojson` on load. A JS-rendering crawler of a page we actively promote therefore gets the whole list. The server-rendered HTML of `/cities` and `/v3/api-docs/cities` was already clean; it was the client-side fetch that exposed them.

## The change

`CitiesApiController.buildCityObject` emits `"url" -> JsNull` for any city whose `visibility` isn't `public`. All three output formats derive from that one object, so JSON, CSV (which already renders `JsNull` as an empty cell) and GeoJSON are covered together.

- **`url` stays present as a nullable field** rather than being dropped, so the response shape and the CSV column alignment don't change.
- **The row itself stays**, so the city count, the map geometry and `visibility` are still published. What goes away is the address.

## Scope: discoverability, not access

Private deployments have no auth wall (Infra3D cities aside), so a URL was always usable by anyone holding it — this doesn't revoke access it wasn't granting. Since #5120 every private deployment serves `noindex`, so the search-index consequence is handled. What this removes is us publishing the door. It's also why #5120 deliberately keeps a permissive `robots.txt` on private cities: a blocked crawl would mean Google never sees the `noindex` and can still list the bare URL from an inbound link.

## No first-party consumer regresses

- `ps-map/createPSMap.js` and `user-dashboard/CrossCityStats.js` read this endpoint for coordinates only.
- `admin-dashboard/AcrossCitiesPage.js` joins it on `city_id` for lat/lng; its URLs come from the admin scorecard JSON (`AdminController`), which builds `url` from `CityInfo` independently and is admin-only. Its map feature already falls back to the scorecard's `url` (`geo.url || (sc && sc.url) || ''`).

`/v3` is a preview surface where breaking changes are made in place (precedent: #4223), so narrowing a field here is in-policy.

## Tests

Four new cases in `test/controllers/api/CitiesApiSpec.scala`, one per output format plus a guard that the rest of a private city's row survives:

- JSON: every city carries a `url` key; public cities get an `http…` string, everything else `null`.
- CSV: the withheld url is an empty cell, not the literal `"null"` — parsed with a small quote-aware row splitter so a city name like `"Teaneck, NJ"` stays one cell.
- GeoJSON: the same rule inside `properties`.
- A private city still publishes `city_id`, `city_name_formatted` and `visibility`.

The JSON case also asserts that at least one non-public city is present, so the test can't silently pass on a config with no private deployments.

`sbt compile`, `scalafmtCheckAll`, `htmlhint` and `testOnly controllers.api.CitiesApiSpec` (9/9) all green locally.

## Docs

`app/views/apiDocs/cities.scala.html` now types `url` as `string | null` and states the rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 5 (1M context), claude-opus-5[1m]
