### PR TITLE
Model label-type access impact and rating scale as enums, sourced by the frontend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,8 @@ file, and this table says which doc to read first:
 Domain values (enum members, ranges, thresholds, and especially the mappings between them) come from the backend, a
 `/v3/api/...` endpoint or a value the controller passes to the view, and are never re-declared as frontend literals.
 Even a "trivial" constant encodes logic: severity 1–3 maps to good/ok/bad in opposite directions for positive
-features (curb ramps) and negative ones (obstacles). Source it; if no source exists, expose one as part of the task;
+features (curb ramps) and negative ones (obstacles) — which direction a type reads is its `access_impact`, from
+`/v3/api/labelTypes`. Source it; if no source exists, expose one as part of the task;
 only if genuinely unavoidable, centralize the literal with a comment saying why it isn't sourced.
 
 ## Label type colors and icons

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,8 +92,8 @@ file, and this table says which doc to read first:
 Domain values (enum members, ranges, thresholds, and especially the mappings between them) come from the backend, a
 `/v3/api/...` endpoint or a value the controller passes to the view, and are never re-declared as frontend literals.
 Even a "trivial" constant encodes logic: severity 1–3 maps to good/ok/bad in opposite directions for positive
-features (curb ramps) and negative ones (obstacles) — which direction a type reads is its `access_impact`, from
-`/v3/api/labelTypes`. Source it; if no source exists, expose one as part of the task;
+features (curb ramps) and negative ones (obstacles) — which direction a type reads, or whether it's rated at all, is
+its `rating_scale`, from `/v3/api/labelTypes`. Source it; if no source exists, expose one as part of the task;
 only if genuinely unavoidable, centralize the literal with a comment saying why it isn't sourced.
 
 ## Label type colors and icons

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -711,7 +711,7 @@ class AdminController @Inject() (
           "labels_validated_share"   -> (if (sc.totalLabels > 0) sc.labelsValidated.toDouble / sc.totalLabels else 0.0),
           "labels_with_severity"     -> sc.labelsWithSeverity,
           "labels_severity_eligible" -> sc.labelsSeverityEligible,
-          // Share computed only over types that CAN have a severity (NoSidewalk/Signal/Occlusion excluded).
+          // Share computed only over types that CAN have a rating, i.e. RatingScale other than Unrated.
           "severity_share" -> (if (sc.labelsSeverityEligible > 0)
                                  sc.labelsWithSeverity.toDouble / sc.labelsSeverityEligible
                                else 0.0),

--- a/app/controllers/ShareController.scala
+++ b/app/controllers/ShareController.scala
@@ -2,6 +2,7 @@ package controllers
 
 import controllers.base._
 import models.auth.{DefaultEnv, WithAdmin}
+import models.label.LabelTypeEnum.AccessImpact
 import models.label.{CropMarker, LabelMetadata, LabelTypeEnum}
 import models.pano.PanoSource.PanoSource
 import models.story.StoryForView
@@ -181,12 +182,12 @@ class ShareController @Inject() (
   }
 
   /**
-   * Builds the localized share title. Issue types ("I found an accessibility issue...") and non-issue types (positive
-   * features like curb ramps, or neutral types like occlusions — "Look what I found...") take opposite framings, so
-   * the copy forks on the label type's `isAccessProblem`.
+   * Builds the localized share title. Problems ("I found an accessibility issue...") and everything else (positive
+   * features like curb ramps, neutral types like occlusions — "Look what I found...") take opposite framings.
    */
   private def shareTitle(meta: LabelMetadata)(implicit messages: Messages): String = {
-    val key: String = if (meta.labelType.isAccessProblem) "share.meta.title.issue" else "share.meta.title.feature"
+    val isProblem   = meta.labelType.accessImpact == AccessImpact.Problem
+    val key: String = if (isProblem) "share.meta.title.issue" else "share.meta.title.feature"
     Messages(key, Messages(meta.labelType.nameKey))
   }
 
@@ -225,7 +226,7 @@ class ShareController @Inject() (
           Some(Messages("share.meta.description.spotted", cityName)),
           meta.panoMetadata.flatMap(_.address).map(a => Messages("share.meta.description.address", a)),
           meta.severity
-            .filter(_ => meta.labelType.isAccessProblem)
+            .filter(_ => meta.labelType.accessImpact == AccessImpact.Problem)
             .map(s => Messages("share.meta.description.severity", s)),
           Option(meta.tags)
             .filter(_.nonEmpty)

--- a/app/controllers/ShareController.scala
+++ b/app/controllers/ShareController.scala
@@ -408,7 +408,7 @@ class ShareController @Inject() (
 
     // The colored "small" icon variant is the same marker family the Gallery overlays on card photos, carrying the
     // label type's canonical color (the large `{name}.png` illustrations are grayscale).
-    val iconFile: File = environment.getFile(s"public/images/icons/label_type_icons/${labelType.name}_small.png")
+    val iconFile: File = environment.getFile(s"public/${labelType.smallIconPath}")
     if (iconFile.exists()) {
       Option(ImageIO.read(iconFile)).foreach { icon =>
         val centerX: Int = (marker.x * scaledW).toInt - offX

--- a/app/controllers/StoryController.scala
+++ b/app/controllers/StoryController.scala
@@ -63,20 +63,20 @@ class StoryController @Inject() (
    * no session at all, so this mirrors LabelController.getLabelData's UserAwareAction (#456).
    */
   def getStories(labelId: Int) = silhouette.UserAwareAction.async { implicit request =>
-    val viewerUserId    = request.identity.map(_.userId)
-    val storiesFuture   = storyService.getStoriesForLabel(labelId, viewerUserId, isAdmin(request.identity))
-    val isProblemFuture = storyService.isLabelAccessProblem(labelId)
+    val viewerUserId  = request.identity.map(_.userId)
+    val storiesFuture = storyService.getStoriesForLabel(labelId, viewerUserId, isAdmin(request.identity))
+    val impactFuture  = storyService.labelAccessImpact(labelId)
     for {
-      stories   <- storiesFuture
-      isProblem <- isProblemFuture
+      stories <- storiesFuture
+      impact  <- impactFuture
     } yield Ok(
       Json.obj(
         "label_id"        -> labelId,
         "max_text_length" -> storyService.maxTextLength, // Composer counter limit; sourced here, never a JS literal.
         // Problem-vs-feature story prompts flip on this; sourced from LabelTypeEnum, never re-derived in JS. Null
         // when the label doesn't exist (the card then keeps its default copy).
-        "is_access_problem" -> isProblem,
-        "stories"           -> stories.map(StoryFormats.storyForViewToJson)
+        "access_impact" -> impact.map(_.name),
+        "stories"       -> stories.map(StoryFormats.storyForViewToJson)
       )
     )
   }

--- a/app/formats/json/StoryFormats.scala
+++ b/app/formats/json/StoryFormats.scala
@@ -41,7 +41,7 @@ object StoryFormats {
       "label_id"   -> s.story.labelId,
       "label_type" -> s.labelType,
       // Flips the edit composer's problem-vs-feature phrasing (LabelTypeEnum-sourced, never re-derived in JS).
-      "is_access_problem" -> s.isAccessProblem,
+      "access_impact"     -> s.accessImpact.name,
       "text"              -> s.story.storyText,
       "display_name_mode" -> s.story.displayNameMode,
       "hidden"            -> !s.story.visible,

--- a/app/models/api/LabelTypeApiModels.scala
+++ b/app/models/api/LabelTypeApiModels.scala
@@ -17,6 +17,8 @@ import play.api.libs.json.{Json, JsonConfiguration, JsonNaming, OFormat}
  * @param color Hex color code associated with this label type
  * @param accessImpact What this type says about accessibility: "problem", "feature", or "neutral". Severity means the
  *                     opposite thing on a problem than on a feature, so read this rather than hardcode type names.
+ * @param ratingScale Which 1-3 rating this type's labels carry: "quality" (1 good, 3 bad), "severity" (1 low, 3 high),
+ *                    or "unrated" for a type whose labels never carry one
  * @param isPrimary Whether this is a primary label type
  * @param isPrimaryValidate Whether this type is included in primary validation
  */
@@ -29,6 +31,7 @@ case class LabelTypeForApi(
     tinyIconUrl: String,
     color: String,
     accessImpact: String,
+    ratingScale: String,
     isPrimary: Boolean,
     isPrimaryValidate: Boolean
 )

--- a/app/models/api/LabelTypeApiModels.scala
+++ b/app/models/api/LabelTypeApiModels.scala
@@ -15,6 +15,8 @@ import play.api.libs.json.{Json, JsonConfiguration, JsonNaming, OFormat}
  * @param smallIconUrl URL to the small icon image
  * @param tinyIconUrl URL to the tiny icon image
  * @param color Hex color code associated with this label type
+ * @param accessImpact What this type says about accessibility: "problem", "feature", or "neutral". Severity means the
+ *                     opposite thing on a problem than on a feature, so read this rather than hardcode type names.
  * @param isPrimary Whether this is a primary label type
  * @param isPrimaryValidate Whether this type is included in primary validation
  */
@@ -26,6 +28,7 @@ case class LabelTypeForApi(
     smallIconUrl: String,
     tinyIconUrl: String,
     color: String,
+    accessImpact: String,
     isPrimary: Boolean,
     isPrimaryValidate: Boolean
 )

--- a/app/models/api/LabelTypeApiModels.scala
+++ b/app/models/api/LabelTypeApiModels.scala
@@ -15,8 +15,9 @@ import play.api.libs.json.{Json, JsonConfiguration, JsonNaming, OFormat}
  * @param smallIconUrl URL to the small icon image
  * @param tinyIconUrl URL to the tiny icon image
  * @param color Hex color code associated with this label type
- * @param accessImpact What this type says about accessibility: "problem", "feature", or "neutral". Severity means the
- *                     opposite thing on a problem than on a feature, so read this rather than hardcode type names.
+ * @param accessImpact What this type says about accessibility: "problem" (a barrier), "feature" (something that
+ *                     helps), or "neutral". This is about framing, not ratings — to read a label's severity, use
+ *                     `ratingScale`
  * @param ratingScale Which 1-3 rating this type's labels carry: "quality" (1 good, 3 bad), "severity" (1 low, 3 high),
  *                    or "unrated" for a type whose labels never carry one
  * @param isPrimary Whether this is a primary label type

--- a/app/models/label/LabelTypeEnum.scala
+++ b/app/models/label/LabelTypeEnum.scala
@@ -1,5 +1,7 @@
 package models.label
 
+import play.api.libs.json.Json
+
 /**
  * Enumeration of all label types with their associated properties, backing the `label_type` Postgres enum type.
  *
@@ -7,8 +9,14 @@ package models.label
  * each type is the enum label, and it is emitted verbatim in every API response and internal JSON payload.
  */
 object LabelTypeEnum {
-  // Base path for all icon images.
-  private val iconBasePath = "/assets/images/icons/label_type_icons"
+  // Icon directory as a logical path under public/ — the one form assets.path (Twirl), util.assetPath (JS) and
+  // environment.getFile (server-side compositing) all take. A rendered "/assets/..." URL would suit only one of the
+  // three, leaving the others to rebuild the convention by hand.
+  private val iconBasePath = "images/icons/label_type_icons"
+
+  // The un-fingerprinted URL prefix for a logical path, for the icon URLs the public API publishes. Deliberately not
+  // the fingerprinted one: a consumer that stores an icon_url wants it to survive our next deploy.
+  private val assetUrlPrefix = "/assets/"
 
   /**
    * What a label type says about accessibility. Anything that interprets a label's severity, or writes copy about it,
@@ -33,6 +41,28 @@ object LabelTypeEnum {
   }
 
   /**
+   * Which 1-3 rating a label of this type carries, if any. Independent of [[AccessImpact]] in both directions — Other
+   * is Neutral but rated, NoSidewalk is a Problem but unrated — so it can't be derived from it.
+   *
+   * @param name The value published to clients (the API's `rating_scale`, and our own JSON payloads)
+   */
+  sealed abstract class RatingScale(val name: String) {
+    override def toString: String = name
+  }
+
+  object RatingScale {
+
+    /** Rated good (1) to bad (3): how well the thing labeled does its job. */
+    case object Quality extends RatingScale("quality")
+
+    /** Rated low (1) to high (3): how much the thing labeled gets in the way. */
+    case object Severity extends RatingScale("severity")
+
+    /** Carries no rating, so asking for its severity is a question with no answer. */
+    case object Unrated extends RatingScale("unrated")
+  }
+
+  /**
    * Base class for all label types in the system.
    *
    * This sealed abstract class represents the base type for all label types in the system, providing type safety and
@@ -42,12 +72,14 @@ object LabelTypeEnum {
    * @param descriptionKey A key to get a human-readable description of this label type from the Messages API
    * @param color Hex color code associated with this label type
    * @param accessImpact What this type says about accessibility; see [[AccessImpact]]
+   * @param ratingScale Which 1-3 rating its labels carry, if any; see [[RatingScale]]
    */
   sealed abstract class Base(
       val name: String,
       val descriptionKey: String,
       val color: String,
-      val accessImpact: AccessImpact
+      val accessImpact: AccessImpact,
+      val ratingScale: RatingScale
   ) {
     override def toString: String = name
 
@@ -55,27 +87,40 @@ object LabelTypeEnum {
     // the two can't drift.
     val nameKey: String = descriptionKey.stripSuffix(".description")
 
-    // Paths to the icon images for this label type. The scalable marker is what our own pages render; the rasters are
-    // for consumers that can't take vector art — share-image compositing (ShareController) and the icon URLs the
-    // public API publishes.
+    // Logical paths (under public/) to this type's icons. The scalable marker is what our own pages render; the
+    // rasters are for consumers that can't take vector art — share-image compositing (ShareController) and the icon
+    // URLs the public API publishes. Render each through whichever resolver the caller needs; see iconBasePath.
     val smallIconSvgPath: String = s"$iconBasePath/${name}_small.svg"
     val iconPath: String         = s"$iconBasePath/${name}.png"
     val smallIconPath: String    = s"$iconBasePath/${name}_small.png"
     val tinyIconPath: String     = s"$iconBasePath/${name}_tiny.png"
+
+    /** This type's icons as the plain, un-fingerprinted URLs the public API publishes. */
+    def iconUrl: String      = assetUrlPrefix + iconPath
+    def smallIconUrl: String = assetUrlPrefix + smallIconPath
+    def tinyIconUrl: String  = assetUrlPrefix + tinyIconPath
   }
 
   // Representations for the full set of label types in the system.
   // TODO These colors should probably match the colors in our Design System Tokens in main.css.
-  case object CurbRamp   extends Base("CurbRamp", "curb.ramp.description", "#90C31F", AccessImpact.Feature)
-  case object NoCurbRamp extends Base("NoCurbRamp", "missing.ramp.description", "#E679B6", AccessImpact.Problem)
-  case object Obstacle   extends Base("Obstacle", "obstacle.description", "#78B0EA", AccessImpact.Problem)
+  case object CurbRamp
+      extends Base("CurbRamp", "curb.ramp.description", "#90C31F", AccessImpact.Feature, RatingScale.Quality)
+  case object NoCurbRamp
+      extends Base("NoCurbRamp", "missing.ramp.description", "#E679B6", AccessImpact.Problem, RatingScale.Severity)
+  case object Obstacle
+      extends Base("Obstacle", "obstacle.description", "#78B0EA", AccessImpact.Problem, RatingScale.Severity)
   case object SurfaceProblem
-      extends Base("SurfaceProblem", "surface.problem.description", "#F68D3E", AccessImpact.Problem)
-  case object Crosswalk  extends Base("Crosswalk", "crosswalk.description", "#FABF1C", AccessImpact.Feature)
-  case object Signal     extends Base("Signal", "signal.description", "#63C0AB", AccessImpact.Feature)
-  case object NoSidewalk extends Base("NoSidewalk", "no.sidewalk.description", "#BE87D8", AccessImpact.Problem)
-  case object Occlusion  extends Base("Occlusion", "occlusion.description", "#B3B3B3", AccessImpact.Neutral)
-  case object Other      extends Base("Other", "other.description", "#B3B3B3", AccessImpact.Neutral)
+      extends Base(
+        "SurfaceProblem", "surface.problem.description", "#F68D3E", AccessImpact.Problem, RatingScale.Severity
+      )
+  case object Crosswalk
+      extends Base("Crosswalk", "crosswalk.description", "#FABF1C", AccessImpact.Feature, RatingScale.Quality)
+  case object Signal extends Base("Signal", "signal.description", "#63C0AB", AccessImpact.Feature, RatingScale.Unrated)
+  case object NoSidewalk
+      extends Base("NoSidewalk", "no.sidewalk.description", "#BE87D8", AccessImpact.Problem, RatingScale.Unrated)
+  case object Occlusion
+      extends Base("Occlusion", "occlusion.description", "#B3B3B3", AccessImpact.Neutral, RatingScale.Unrated)
+  case object Other extends Base("Other", "other.description", "#B3B3B3", AccessImpact.Neutral, RatingScale.Severity)
 
   // The one canonical order, by prominence: the six primary validate types, then NoSidewalk, then the meta types.
   // API output, CSV columns and error messages sort by position here, never by the Postgres enum's declaration order
@@ -91,6 +136,11 @@ object LabelTypeEnum {
   lazy val byName: Map[String, Base] = values.map(lt => lt.name -> lt).toMap
 
   lazy val byAccessImpact: Map[AccessImpact, Set[Base]] = values.groupBy(_.accessImpact)
+
+  // Types whose labels carry a 1-3 rating. The denominator for any "% rated" stat, in SQL as well as on the page.
+  lazy val ratedTypes: Seq[Base]                      = ordered.filter(_.ratingScale != RatingScale.Unrated)
+  lazy val ratedTypeNames: Seq[String]                = ratedTypes.map(_.name)
+  lazy val byRatingScale: Map[RatingScale, Set[Base]] = values.groupBy(_.ratingScale)
 
   // Maps label type names to their associated colors. Used for retrieving colors by label type name.
   lazy val labelTypeToColor: Map[String, String] = values.map(lt => lt.name -> lt.color).toMap
@@ -116,4 +166,23 @@ object LabelTypeEnum {
   /** Parses a label type name, throwing on an unknown one (the shape the Slick enum mapper wants). */
   def withName(name: String): Base =
     byName.getOrElse(name, throw new NoSuchElementException(s"No label type named '$name'"))
+
+  /**
+   * The label-type table as `main.scala.html` stamps it onto every page (`window.labelTypes`), in canonical order.
+   *
+   * This is the only copy the frontend gets: `utilitiesSidewalk.js` builds its lookups from it rather than keeping a
+   * parallel set of literals. Everything here is fixed at build time — no city, no language, no DB — so it serializes
+   * once at class-load and each render only interpolates the string. Localized names are absent by design; the
+   * frontend already has those in its locale files, and including them would make this per-language.
+   */
+  lazy val pageStampJson: String = Json.stringify(Json.toJson(ordered.map { lt =>
+    Json.obj(
+      "name"              -> lt.name,
+      "color"             -> lt.color,
+      "accessImpact"      -> lt.accessImpact.name,
+      "ratingScale"       -> lt.ratingScale.name,
+      "isPrimary"         -> primaryLabelTypes.contains(lt),
+      "isPrimaryValidate" -> primaryValidateLabelTypes.contains(lt)
+    )
+  }))
 }

--- a/app/models/label/LabelTypeEnum.scala
+++ b/app/models/label/LabelTypeEnum.scala
@@ -11,6 +11,28 @@ object LabelTypeEnum {
   private val iconBasePath = "/assets/images/icons/label_type_icons"
 
   /**
+   * What a label type says about accessibility. Anything that interprets a label's severity, or writes copy about it,
+   * has to branch on this rather than on the label type itself.
+   *
+   * @param name The value published to clients (the API's `access_impact`, and our own JSON payloads)
+   */
+  sealed abstract class AccessImpact(val name: String) {
+    override def toString: String = name
+  }
+
+  object AccessImpact {
+
+    /** The thing labeled is a barrier; severity says how bad it is. */
+    case object Problem extends AccessImpact("problem")
+
+    /** The thing labeled helps people get around; severity says how good it is. */
+    case object Feature extends AccessImpact("feature")
+
+    /** Not a statement about accessibility at all, so severity says nothing about quality. */
+    case object Neutral extends AccessImpact("neutral")
+  }
+
+  /**
    * Base class for all label types in the system.
    *
    * This sealed abstract class represents the base type for all label types in the system, providing type safety and
@@ -19,16 +41,13 @@ object LabelTypeEnum {
    * @param name The string representation of this label type, matching the Postgres enum label
    * @param descriptionKey A key to get a human-readable description of this label type from the Messages API
    * @param color Hex color code associated with this label type
-   * @param isAccessProblem Whether this label type marks an accessibility problem (severity means "how bad"), as opposed
-   *                      to a positive access feature like a curb ramp or a neutral meta type like an occlusion. Copy
-   *                      and severity interpretation flip direction on this, so it must come from here, not be
-   *                      re-derived in feature code.
+   * @param accessImpact What this type says about accessibility; see [[AccessImpact]]
    */
   sealed abstract class Base(
       val name: String,
       val descriptionKey: String,
       val color: String,
-      val isAccessProblem: Boolean
+      val accessImpact: AccessImpact
   ) {
     override def toString: String = name
 
@@ -47,16 +66,16 @@ object LabelTypeEnum {
 
   // Representations for the full set of label types in the system.
   // TODO These colors should probably match the colors in our Design System Tokens in main.css.
-  case object CurbRamp   extends Base("CurbRamp", "curb.ramp.description", "#90C31F", isAccessProblem = false)
-  case object NoCurbRamp extends Base("NoCurbRamp", "missing.ramp.description", "#E679B6", isAccessProblem = true)
-  case object Obstacle   extends Base("Obstacle", "obstacle.description", "#78B0EA", isAccessProblem = true)
+  case object CurbRamp   extends Base("CurbRamp", "curb.ramp.description", "#90C31F", AccessImpact.Feature)
+  case object NoCurbRamp extends Base("NoCurbRamp", "missing.ramp.description", "#E679B6", AccessImpact.Problem)
+  case object Obstacle   extends Base("Obstacle", "obstacle.description", "#78B0EA", AccessImpact.Problem)
   case object SurfaceProblem
-      extends Base("SurfaceProblem", "surface.problem.description", "#F68D3E", isAccessProblem = true)
-  case object Crosswalk  extends Base("Crosswalk", "crosswalk.description", "#FABF1C", isAccessProblem = false)
-  case object Signal     extends Base("Signal", "signal.description", "#63C0AB", isAccessProblem = false)
-  case object NoSidewalk extends Base("NoSidewalk", "no.sidewalk.description", "#BE87D8", isAccessProblem = true)
-  case object Occlusion  extends Base("Occlusion", "occlusion.description", "#B3B3B3", isAccessProblem = false)
-  case object Other      extends Base("Other", "other.description", "#B3B3B3", isAccessProblem = false)
+      extends Base("SurfaceProblem", "surface.problem.description", "#F68D3E", AccessImpact.Problem)
+  case object Crosswalk  extends Base("Crosswalk", "crosswalk.description", "#FABF1C", AccessImpact.Feature)
+  case object Signal     extends Base("Signal", "signal.description", "#63C0AB", AccessImpact.Feature)
+  case object NoSidewalk extends Base("NoSidewalk", "no.sidewalk.description", "#BE87D8", AccessImpact.Problem)
+  case object Occlusion  extends Base("Occlusion", "occlusion.description", "#B3B3B3", AccessImpact.Neutral)
+  case object Other      extends Base("Other", "other.description", "#B3B3B3", AccessImpact.Neutral)
 
   // The one canonical order, by prominence: the six primary validate types, then NoSidewalk, then the meta types.
   // API output, CSV columns and error messages sort by position here, never by the Postgres enum's declaration order
@@ -70,6 +89,8 @@ object LabelTypeEnum {
 
   // Lookup map for finding a label type by its string name.
   lazy val byName: Map[String, Base] = values.map(lt => lt.name -> lt).toMap
+
+  lazy val byAccessImpact: Map[AccessImpact, Set[Base]] = values.groupBy(_.accessImpact)
 
   // Maps label type names to their associated colors. Used for retrieving colors by label type name.
   lazy val labelTypeToColor: Map[String, String] = values.map(lt => lt.name -> lt.color).toMap

--- a/app/models/label/LabelTypeEnum.scala
+++ b/app/models/label/LabelTypeEnum.scala
@@ -19,8 +19,9 @@ object LabelTypeEnum {
   private val assetUrlPrefix = "/assets/"
 
   /**
-   * What a label type says about accessibility. Anything that interprets a label's severity, or writes copy about it,
-   * has to branch on this rather than on the label type itself.
+   * What a label type says about accessibility: how we frame it in copy, not how its rating reads. Anything writing
+   * copy about a label branches on this rather than on the label type itself; how to read a label's 1-3 rating is a
+   * separate question, answered by [[RatingScale]].
    *
    * @param name The value published to clients (the API's `access_impact`, and our own JSON payloads)
    */
@@ -30,13 +31,13 @@ object LabelTypeEnum {
 
   object AccessImpact {
 
-    /** The thing labeled is a barrier; severity says how bad it is. */
+    /** The thing labeled is a barrier: finding one is bad news. */
     case object Problem extends AccessImpact("problem")
 
-    /** The thing labeled helps people get around; severity says how good it is. */
+    /** The thing labeled helps people get around: finding one is good news. */
     case object Feature extends AccessImpact("feature")
 
-    /** Not a statement about accessibility at all, so severity says nothing about quality. */
+    /** Says nothing either way — a meta note about the imagery or a catch-all. */
     case object Neutral extends AccessImpact("neutral")
   }
 
@@ -135,12 +136,8 @@ object LabelTypeEnum {
   // Lookup map for finding a label type by its string name.
   lazy val byName: Map[String, Base] = values.map(lt => lt.name -> lt).toMap
 
-  lazy val byAccessImpact: Map[AccessImpact, Set[Base]] = values.groupBy(_.accessImpact)
-
   // Types whose labels carry a 1-3 rating. The denominator for any "% rated" stat, in SQL as well as on the page.
-  lazy val ratedTypes: Seq[Base]                      = ordered.filter(_.ratingScale != RatingScale.Unrated)
-  lazy val ratedTypeNames: Seq[String]                = ratedTypes.map(_.name)
-  lazy val byRatingScale: Map[RatingScale, Set[Base]] = values.groupBy(_.ratingScale)
+  lazy val ratedTypeNames: Seq[String] = ordered.filter(_.ratingScale != RatingScale.Unrated).map(_.name)
 
   // Maps label type names to their associated colors. Used for retrieving colors by label type name.
   lazy val labelTypeToColor: Map[String, String] = values.map(lt => lt.name -> lt.color).toMap

--- a/app/models/story/StoryViewModels.scala
+++ b/app/models/story/StoryViewModels.scala
@@ -1,6 +1,7 @@
 package models.story
 
 import models.label.LabelTypeEnum
+import models.label.LabelTypeEnum.AccessImpact
 
 import java.io.File
 import java.time.OffsetDateTime
@@ -47,7 +48,7 @@ case class StoryForAdmin(
 
 /**
  * A story on the author's own dashboard management list (hidden ones included, so they can still retract).
- * `isAccessProblem` comes from LabelTypeEnum so the dashboard's edit composer can pick the problem-vs-feature
+ * `accessImpact` comes from LabelTypeEnum so the dashboard's edit composer can pick the problem-vs-feature
  * phrasing without re-deriving that mapping in JS.
  * `labelImageUrl` is a signed preview of the story's label (crop, else GSV static) — only populated when the story
  * has no uploaded photo, so every row can still carry a thumbnail; None when neither source is available.
@@ -55,7 +56,7 @@ case class StoryForAdmin(
 case class StoryForOwner(
     story: Story,
     labelType: String,
-    isAccessProblem: Boolean,
+    accessImpact: AccessImpact,
     media: Option[StoryMediaForView],
     labelImageUrl: Option[String]
 )

--- a/app/models/utils/ConfigTable.scala
+++ b/app/models/utils/ConfigTable.scala
@@ -2,6 +2,7 @@ package models.utils
 
 import com.google.inject.ImplementedBy
 import models.api.{AggregateStats, LabelTypeStats}
+import models.label.LabelTypeEnum
 import models.street.StreetEdgeTableDef
 import models.utils.MyPostgresProfile.api._
 import play.api.db.slick.{DatabaseConfigProvider, HasDatabaseConfigProvider}
@@ -524,10 +525,9 @@ class ConfigTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvi
           SELECT COUNT(DISTINCT label.label_id) AS label_count,
                  COUNT(DISTINCT label.label_id) FILTER (WHERE user_role.role = 'AI') AS ai_count,
                  COUNT(DISTINCT label.label_id) FILTER (WHERE label.severity IS NOT NULL) AS with_severity,
-                 -- Denominator for "% with severity": only types that CAN take a severity. The three excluded here
-                 -- mirror UtilitiesSidewalk.js LABEL_TYPES_WITHOUT_SEVERITY (NoSidewalk, Signal, Occlusion).
+                 -- Denominator for "% with severity": only types that CAN take a rating, per LabelTypeEnum.
                  COUNT(DISTINCT label.label_id) FILTER (
-                     WHERE NOT #${labelTypeSql.labelIsOneOf(Seq("NoSidewalk", "Signal", "Occlusion"))}
+                     WHERE #${labelTypeSql.labelIsOneOf(LabelTypeEnum.ratedTypeNames)}
                  ) AS severity_eligible,
                  COUNT(DISTINCT label.label_id) FILTER (WHERE cardinality(label.tags) > 0) AS with_tags,
                  -- Denominator for "% with tags": only types that CAN take tags, i.e. types that have any tag defined

--- a/app/service/ApiService.scala
+++ b/app/service/ApiService.scala
@@ -276,6 +276,7 @@ class ApiServiceImpl @Inject() (
         smallIconUrl = labelType.smallIconPath,
         tinyIconUrl = labelType.tinyIconPath,
         color = labelType.color,
+        accessImpact = labelType.accessImpact.name,
         isPrimary = LabelTypeEnum.primaryLabelTypes.contains(labelType),
         isPrimaryValidate = LabelTypeEnum.primaryValidateLabelTypes.contains(labelType)
       )

--- a/app/service/ApiService.scala
+++ b/app/service/ApiService.scala
@@ -272,11 +272,12 @@ class ApiServiceImpl @Inject() (
         name = labelType.name,
         displayName = messagesApi(labelType.nameKey)(lang),
         description = messagesApi(labelType.descriptionKey)(lang),
-        iconUrl = labelType.iconPath,
-        smallIconUrl = labelType.smallIconPath,
-        tinyIconUrl = labelType.tinyIconPath,
+        iconUrl = labelType.iconUrl,
+        smallIconUrl = labelType.smallIconUrl,
+        tinyIconUrl = labelType.tinyIconUrl,
         color = labelType.color,
         accessImpact = labelType.accessImpact.name,
+        ratingScale = labelType.ratingScale.name,
         isPrimary = LabelTypeEnum.primaryLabelTypes.contains(labelType),
         isPrimaryValidate = LabelTypeEnum.primaryValidateLabelTypes.contains(labelType)
       )

--- a/app/service/ConfigService.scala
+++ b/app/service/ConfigService.scala
@@ -387,8 +387,8 @@ case class CrossCityActivityWindows(byCity: Map[String, CityActivityWindow], tot
  * @param totalLabels             Non-tutorial, non-excluded labels (reconciles with the city's single-city total).
  * @param aiLabels                Subset of totalLabels authored by the AI role.
  * @param labelsWithSeverity      Subset of totalLabels that have a severity rating (a data-completeness signal).
- * @param labelsSeverityEligible  Labels whose type CAN take a severity (excludes NoSidewalk/Signal/Occlusion) — the
- *                                correct denominator for "% with severity".
+ * @param labelsSeverityEligible  Labels whose type CAN take a rating (LabelTypeEnum.ratedTypeNames) — the correct
+ *                                denominator for "% with severity".
  * @param labelsWithTags          Subset of totalLabels that have at least one tag applied.
  * @param labelsTagEligible       Labels whose type CAN take tags (types present in this deployment's tag table) — the
  *                                correct denominator for "% with tags".

--- a/app/service/StoryService.scala
+++ b/app/service/StoryService.scala
@@ -4,6 +4,7 @@ import com.drew.imaging.ImageMetadataReader
 import com.drew.metadata.exif.{ExifSubIFDDirectory, GpsDirectory}
 import com.google.inject.ImplementedBy
 import executors.CpuIntensiveExecutionContext
+import models.label.LabelTypeEnum.AccessImpact
 import models.label.{LabelTypeEnum, LatLng}
 import models.story._
 import models.utils.MyPostgresProfile.api._
@@ -25,7 +26,7 @@ import scala.util.Try
 @ImplementedBy(classOf[StoryServiceImpl])
 trait StoryService {
   def getStoriesForLabel(labelId: Int, viewerUserId: Option[String], isAdmin: Boolean): Future[Seq[StoryForView]]
-  def isLabelAccessProblem(labelId: Int): Future[Option[Boolean]]
+  def labelAccessImpact(labelId: Int): Future[Option[AccessImpact]]
   def submitStory(
       labelId: Int,
       userId: String,
@@ -140,12 +141,9 @@ class StoryServiceImpl @Inject() (
       })
   }
 
-  /**
-   * Whether the label marks an accessibility problem (vs a positive feature like a curb ramp), from
-   * LabelTypeEnum.isAccessProblem — the card's story prompts flip phrasing on this. None when the label doesn't exist.
-   */
-  def isLabelAccessProblem(labelId: Int): Future[Option[Boolean]] = {
-    db.run(storyTable.labelTypeForLabel(labelId)).map(_.map(_.isAccessProblem))
+  /** The label type's accessImpact; the card's story prompts flip on it. None when the label doesn't exist. */
+  def labelAccessImpact(labelId: Int): Future[Option[AccessImpact]] = {
+    db.run(storyTable.labelTypeForLabel(labelId)).map(_.map(_.accessImpact))
   }
 
   def submitStory(
@@ -386,7 +384,7 @@ class StoryServiceImpl @Inject() (
           StoryForOwner(
             story,
             labelType.name,
-            labelType.isAccessProblem,
+            labelType.accessImpact,
             media.map(toMediaForView),
             labelImageUrl = if (media.isDefined) None else previewById.get(story.labelId)
           )

--- a/app/views/admin/dashboard/acrossCities.scala.html
+++ b/app/views/admin/dashboard/acrossCities.scala.html
@@ -1,8 +1,20 @@
+@import models.label.LabelTypeEnum
 @import service.CommonPageData
 @import models.user.SidewalkUserWithRole
 @import play.api.Configuration
 @(commonData: CommonPageData, user: SidewalkUserWithRole
 )(implicit request: RequestHeader, messages: Messages, assets: AssetsFinder, config: Configuration)
+
+@* The types that carry no rating, named from LabelTypeEnum so the "% w/ severity" caveats below can't outlive a
+   change to it — they are the same types ConfigTable excludes from that column's denominator. *@
+@unratedTypeNames = @{
+  LabelTypeEnum.ordered.filter(_.ratingScale == LabelTypeEnum.RatingScale.Unrated).map(lt => Messages(lt.nameKey))
+}
+@unratedList = @{unratedTypeNames.mkString(", ")}
+@unratedProse = @{
+  if (unratedTypeNames.size > 1) unratedTypeNames.init.mkString(", ") + ", and " + unratedTypeNames.last
+  else unratedTypeNames.mkString
+}
 
 @* Across Cities page for the redesigned admin dashboard (#4329). A cross-deployment overview comparing every Project Sidewalk city across four lenses — coverage (how much is left), activity (what's happening and when), data patterns (the label-type mix, city vs city), and data quality (how trustworthy the data is) — plus a "Today & this week" band of current-activity tiles, a top-cities table, and daily bar charts (#4758), a GA-backed web-traffic table (Planning#8), a "needs attention" panel of server-computed anomalies, and overview line charts of labels / validations / active users over time. Owner-only. Driven entirely client-side from /adminapi/cityScorecards (traffic from /adminapi/cityTraffic). *@
 
@@ -310,7 +322,7 @@
             <th>% validated</th>
             <th>Validations / label</th>
             <th title="Share of HUMAN agree/disagree validations that agreed. AI verdicts are excluded here and shown in the AI validations column.">Agreement <span class="ac-fn">†</span></th>
-            <th title="Calculated only over label types that can have a severity (excludes No Sidewalk, Signal, Occlusion).">% w/ severity <span class="ac-fn">†</span></th>
+            <th title="Calculated only over label types that can have a severity (excludes @unratedList).">% w/ severity <span class="ac-fn">†</span></th>
             <th title="Calculated only over label types that have tags defined for this deployment (e.g. excludes Occlusion).">% w/ tags <span class="ac-fn">†</span></th>
             <th>AI labels</th>
             <th>AI validations</th>
@@ -320,7 +332,7 @@
         <tbody id="ac-quality-tbody"></tbody>
       </table>
     </div>
-    <p class="ac-note"><span class="ac-fn">†</span> <strong>% w/ severity</strong> and <strong>% w/ tags</strong> are calculated only over the labels whose type <em>can</em> have them, not all labels. Severity excludes No&nbsp;Sidewalk, Signal, and Occlusion; tags exclude types with no tags defined for the deployment (e.g. Occlusion). So a city can reach 100% even though some label types never carry a severity or tag. <strong>Agreement</strong> (and the High-disagreement flag) counts only <strong>human</strong> validators — AI verdicts are excluded and shown separately in <strong>AI validations</strong>.</p>
+    <p class="ac-note"><span class="ac-fn">†</span> <strong>% w/ severity</strong> and <strong>% w/ tags</strong> are calculated only over the labels whose type <em>can</em> have them, not all labels. Severity excludes @unratedProse; tags exclude types with no tags defined for the deployment (e.g. Occlusion). So a city can reach 100% even though some label types never carry a severity or tag. <strong>Agreement</strong> (and the High-disagreement flag) counts only <strong>human</strong> validators — AI verdicts are excluded and shown separately in <strong>AI validations</strong>.</p>
   </div>
 
   <link rel="stylesheet" href="@assets.path("vendor/mapbox-gl/mapbox-gl-3.21.0.css")">

--- a/app/views/apiDocs/labelTypes.scala.html
+++ b/app/views/apiDocs/labelTypes.scala.html
@@ -167,7 +167,7 @@
           <tr>
             <td><code>label_types[].access_impact</code></td>
             <td><code>string</code></td>
-            <td>What this label type says about accessibility: <code>"problem"</code> (a barrier, e.g. a missing curb ramp — a label's <code>severity</code> says how bad it is), <code>"feature"</code> (something that helps, e.g. a curb ramp — <code>severity</code> says how good it is), or <code>"neutral"</code> (not an accessibility judgment at all, e.g. an occlusion). Use this rather than a hardcoded list of label types when interpreting severity.</td>
+            <td>What this label type says about accessibility: <code>"problem"</code> (a barrier, e.g. a missing curb ramp), <code>"feature"</code> (something that helps, e.g. a curb ramp), or <code>"neutral"</code> (not an accessibility judgment at all, e.g. an occlusion). This is about framing, not ratings — to interpret a label's <code>severity</code>, use <code>rating_scale</code>.</td>
           </tr>
           <tr>
             <td><code>label_types[].rating_scale</code></td>

--- a/app/views/apiDocs/labelTypes.scala.html
+++ b/app/views/apiDocs/labelTypes.scala.html
@@ -87,6 +87,7 @@
       "tiny_icon_url": "/assets/images/icons/label_type_icons/CurbRamp_tiny.png",
       "color": "#90C31F",
       "access_impact": "feature",
+      "rating_scale": "quality",
       "is_primary": true,
       "is_primary_validate": true
     },
@@ -99,6 +100,7 @@
       "tiny_icon_url": "/assets/images/icons/label_type_icons/NoCurbRamp_tiny.png",
       "color": "#E679B6",
       "access_impact": "problem",
+      "rating_scale": "severity",
       "is_primary": true,
       "is_primary_validate": true
     },
@@ -166,6 +168,11 @@
             <td><code>label_types[].access_impact</code></td>
             <td><code>string</code></td>
             <td>What this label type says about accessibility: <code>"problem"</code> (a barrier, e.g. a missing curb ramp — a label's <code>severity</code> says how bad it is), <code>"feature"</code> (something that helps, e.g. a curb ramp — <code>severity</code> says how good it is), or <code>"neutral"</code> (not an accessibility judgment at all, e.g. an occlusion). Use this rather than a hardcoded list of label types when interpreting severity.</td>
+          </tr>
+          <tr>
+            <td><code>label_types[].rating_scale</code></td>
+            <td><code>string</code></td>
+            <td>Which 1&ndash;3 rating this type's labels carry: <code>"quality"</code> (1 is good, 3 is bad), <code>"severity"</code> (1 is low, 3 is high), or <code>"unrated"</code> for a type whose labels never carry one. Independent of <code>access_impact</code> &mdash; a label type can be an access problem and still be unrated.</td>
           </tr>
           <tr>
             <td><code>label_types[].is_primary</code></td>

--- a/app/views/apiDocs/labelTypes.scala.html
+++ b/app/views/apiDocs/labelTypes.scala.html
@@ -86,6 +86,7 @@
       "small_icon_url": "/assets/images/icons/label_type_icons/CurbRamp_small.png",
       "tiny_icon_url": "/assets/images/icons/label_type_icons/CurbRamp_tiny.png",
       "color": "#90C31F",
+      "access_impact": "feature",
       "is_primary": true,
       "is_primary_validate": true
     },
@@ -97,6 +98,7 @@
       "small_icon_url": "/assets/images/icons/label_type_icons/NoCurbRamp_small.png",
       "tiny_icon_url": "/assets/images/icons/label_type_icons/NoCurbRamp_tiny.png",
       "color": "#E679B6",
+      "access_impact": "problem",
       "is_primary": true,
       "is_primary_validate": true
     },
@@ -159,6 +161,11 @@
             <td><code>label_types[].color</code></td>
             <td><code>string</code></td>
             <td>Hex color code (e.g., "#90C31F") associated with this label type.</td>
+          </tr>
+          <tr>
+            <td><code>label_types[].access_impact</code></td>
+            <td><code>string</code></td>
+            <td>What this label type says about accessibility: <code>"problem"</code> (a barrier, e.g. a missing curb ramp — a label's <code>severity</code> says how bad it is), <code>"feature"</code> (something that helps, e.g. a curb ramp — <code>severity</code> says how good it is), or <code>"neutral"</code> (not an accessibility judgment at all, e.g. an occlusion). Use this rather than a hardcoded list of label types when interpreting severity.</td>
           </tr>
           <tr>
             <td><code>label_types[].is_primary</code></td>

--- a/app/views/apps/storyList.scala.html
+++ b/app/views/apps/storyList.scala.html
@@ -83,7 +83,7 @@
               }
               <div class="story-card__foot">
                 <span class="community-chip community-chip--type" data-type-color="@s.labelType.color">
-                  <img class="community-chip__icon" src="@s.labelType.smallIconSvgPath" alt="">
+                  <img class="community-chip__icon" src="@assets.path(s.labelType.smallIconSvgPath)" alt="">
                   <span class="community-chip__text">@Messages(s.labelType.nameKey)</span>
                 </span>
                 <a class="button-ps button--primary button--small story-card__label-link" data-label-id="@s.labelId"

--- a/app/views/common/main.scala.html
+++ b/app/views/common/main.scala.html
@@ -1,4 +1,5 @@
 @import controllers.helper.ControllerUtils
+@import models.label.LabelTypeEnum
 @import models.pano.ImageryAttribution
 @import play.api.Configuration
 @import play.api.libs.json.Json
@@ -106,6 +107,11 @@
        the live viewer name the same licence the same way. PanoramaxViewer shows an identifier it can't find here
        verbatim, so a page that never stamps this (jsdom, the error pages) degrades rather than breaks. *@
     <script>window.panoramaxLicenses = @Html(ImageryAttribution.panoramaxLicensesJson);</script>
+    @* The label-type table, in canonical order — colour, access impact, rating scale, primary flags. LabelTypeEnum
+       owns it; utilitiesSidewalk.js builds every label-type lookup from this rather than keeping a parallel set of
+       literals that can drift from the backend. Must precede the tool bundles, which read it at load time. A page
+       that never stamps it (jsdom, the error pages) leaves util.misc with an empty table. *@
+    <script>window.labelTypes = @Html(LabelTypeEnum.pageStampJson);</script>
     <script src='@assets.path("js/common/utilities.js")'></script>
     <script src='@assets.path("js/common/utilitiesMath.js")'></script>
     <script src='@assets.path("js/common/i18nDom.js")'></script>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -328,6 +328,12 @@ canonical color and icon set. The source of truth is the **`/v3/api/labelTypes`*
 `util.misc.getLabelColors(labelType)` rather than hardcoding hex values. See [`CLAUDE.md`](../CLAUDE.md) for the
 canonical color table and icon locations.
 
+Each type also carries an **access impact** (`LabelTypeEnum.AccessImpact`, published as `access_impact`): `problem`
+(a barrier, so a label's severity says how bad it is), `feature` (something that helps, so severity says how good it
+is), or `neutral` (Occlusion and Other, where severity says nothing about quality). Severity means the opposite
+thing on a problem than on a feature, so any code that reads severity — or writes copy about a label — branches on
+this rather than on a hand-written list of type names.
+
 ## Where to go next
 
 - [`docs/dev-environment.md`](dev-environment.md) — get it running locally.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -328,11 +328,21 @@ canonical color and icon set. The source of truth is the **`/v3/api/labelTypes`*
 `util.misc.getLabelColors(labelType)` rather than hardcoding hex values. See [`CLAUDE.md`](../CLAUDE.md) for the
 canonical color table and icon locations.
 
-Each type also carries an **access impact** (`LabelTypeEnum.AccessImpact`, published as `access_impact`): `problem`
-(a barrier, so a label's severity says how bad it is), `feature` (something that helps, so severity says how good it
-is), or `neutral` (Occlusion and Other, where severity says nothing about quality). Severity means the opposite
-thing on a problem than on a feature, so any code that reads severity — or writes copy about a label — branches on
-this rather than on a hand-written list of type names.
+Each type carries two independent domain facts, both published by that endpoint:
+
+- **access impact** (`LabelTypeEnum.AccessImpact`, `access_impact`) — `problem` (a barrier), `feature` (something
+  that helps), or `neutral` (Occlusion and Other). This drives framing and copy.
+- **rating scale** (`LabelTypeEnum.RatingScale`, `rating_scale`) — `quality` (1 is good, 3 is bad), `severity`
+  (1 is low, 3 is high), or `unrated` for a type whose labels never carry a 1–3 rating. Anything that *reads* a
+  label's severity branches on this.
+
+Neither derives from the other: Other is `neutral` but rated on the severity scale, NoSidewalk is a `problem` that
+is unrated, and Signal is a `feature` that is unrated. Source both rather than hand-writing a list of type names —
+`util.misc.isPositiveLabelType` is `rating_scale === 'quality'`, not an access-impact check.
+
+`main.scala.html` stamps this whole table onto every page as `window.labelTypes` (like `window.assetDigests`), and
+`utilitiesSidewalk.js` builds every frontend label-type list, colour and rating flag from it. A page that doesn't
+stamp it gets an empty table, so `util.misc`'s lists come back empty rather than erroring.
 
 ## Where to go next
 

--- a/public/js/admin-dashboard/AcrossCitiesPage.js
+++ b/public/js/admin-dashboard/AcrossCitiesPage.js
@@ -33,12 +33,12 @@ class AcrossCitiesPage {
   /** How many cities the "Most active cities" table shows; the full list lives in the Activity section below it. */
   static #TOP_CITIES_LIMIT = 5;
 
-  /** Canonical label-type order + short display names for the data-patterns bars. */
-  static #LABEL_TYPES = [
-    ['CurbRamp', 'Curb ramp'], ['NoCurbRamp', 'Missing curb ramp'], ['Obstacle', 'Obstacle'],
-    ['SurfaceProblem', 'Surface problem'], ['NoSidewalk', 'No sidewalk'], ['Crosswalk', 'Crosswalk'],
-    ['Signal', 'Signal'], ['Occlusion', 'Occlusion'], ['Other', 'Other'],
-  ];
+  /** Short display names for the data-patterns bars. The order comes from util.misc, which is backend-sourced. */
+  static #LABEL_TYPE_NAMES = {
+    CurbRamp: 'Curb ramp', NoCurbRamp: 'Missing curb ramp', Obstacle: 'Obstacle',
+    SurfaceProblem: 'Surface problem', NoSidewalk: 'No sidewalk', Crosswalk: 'Crosswalk',
+    Signal: 'Signal', Occlusion: 'Occlusion', Other: 'Other',
+  };
 
   /** Lifecycle → map circle color (matches the badge tones). */
   static #LIFECYCLE_COLOR = {
@@ -1135,8 +1135,10 @@ class AcrossCitiesPage {
     if (!host) return;
 
     // Only show label types that actually appear in at least one city, in canonical order.
-    const present = AcrossCitiesPage.#LABEL_TYPES.filter(([key]) =>
-      this.#cities.some((c) => c.by_label_type && c.by_label_type[key] && c.by_label_type[key].labels > 0));
+    const present = util.misc.VALID_LABEL_TYPES
+      .map((key) => [key, AcrossCitiesPage.#LABEL_TYPE_NAMES[key] || key])
+      .filter(([key]) =>
+        this.#cities.some((c) => c.by_label_type && c.by_label_type[key] && c.by_label_type[key].labels > 0));
 
     if (legendEl) {
       legendEl.innerHTML = present.map(([key, name]) => `

--- a/public/js/admin-dashboard/DataQualityPage.js
+++ b/public/js/admin-dashboard/DataQualityPage.js
@@ -260,14 +260,6 @@ class DataQualityPage {
   #renderTagSeverity(rows) {
     const el = document.getElementById('dq-tag-severity');
     if (!el) return;
-    const hasSeverity = (t) => {
-      try {
-        return util.misc.labelTypeHasSeverity(t);
-      } catch {
-        return true;
-      }
-    };
-
     const byType = new Map();
     for (const r of rows) {
       if (!byType.has(r.label_type)) byType.set(r.label_type, new Map());
@@ -279,7 +271,7 @@ class DataQualityPage {
     }
 
     const blocks = this.#order
-      .filter((type) => byType.has(type) && hasSeverity(type))
+      .filter((type) => byType.has(type) && this.#hasSeverity(type))
       .map((type) => {
         const color = this.#color(type);
         const tags = [...byType.get(type).entries()]

--- a/public/js/common/label-detail/StoryComposer.js
+++ b/public/js/common/label-detail/StoryComposer.js
@@ -96,14 +96,13 @@ class StoryComposer {
   }
 
   /**
-   * Switches the intro and textarea placeholder between problem and positive-feature phrasing, per the label type's
-   * backend-sourced `is_access_problem` flag (see /stories). Anything but an explicit false — including null while
-   * the flag is still unknown — keeps the default problem copy. Safe to call while the dialog is open: the host
-   * re-applies it when a late /stories response lands.
-   * @param {?boolean} isAccessProblem
+   * Switches the intro and textarea placeholder between problem and positive-feature phrasing. Anything other than a
+   * known non-problem bucket — including null while it's still unknown — keeps the default problem copy. Safe to call
+   * while the dialog is open: the host re-applies it when a late /stories response lands.
+   * @param {?string} accessImpact - 'problem', 'feature' or 'neutral', from /stories (LabelTypeEnum.AccessImpact).
    */
-  setCopyVariant(isAccessProblem) {
-    const positive = isAccessProblem === false;
+  setCopyVariant(accessImpact) {
+    const positive = accessImpact === 'feature' || accessImpact === 'neutral';
     this.#els.intro.textContent
       = i18next.t(positive ? 'labelmap:story.composer-intro-positive' : 'labelmap:story.composer-intro');
     this.#els.text.placeholder

--- a/public/js/common/label-detail/StorySection.js
+++ b/public/js/common/label-detail/StorySection.js
@@ -13,7 +13,6 @@ class StorySection {
   #composer;
   #labelId = null;
   #maxTextLength = null;
-  #accessImpact = null; // From the /stories payload (LabelTypeEnum-sourced); flips the composer's phrasing.
   #fetchToken = 0; // Guards against a stale response landing after a newer label was opened.
   #highlightStoryId = null; // Pending story deep link (#4722); the first render that could show it consumes it.
 
@@ -78,7 +77,6 @@ class StorySection {
   setLabel(labelId, labelTypeName = null) {
     this.#labelId = labelId;
     this.#composer.setLabelType(labelTypeName);
-    this.#accessImpact = null;
     this.#els.list.replaceChildren();
     this.#els.count.hidden = true;
     // Empty posture until the fetch lands (most labels have no stories): section hidden, footer CTA up. This is
@@ -116,11 +114,10 @@ class StorySection {
       const data = await res.json();
       if (token !== this.#fetchToken) return;
       this.#maxTextLength = data.max_text_length;
-      this.#accessImpact = data.access_impact;
       // Positive access features (curb ramps, signals, ...) get "story about a feature" phrasing instead of "has a
       // problem affected you". Applied on every fetch so paging between label types re-picks the right copy — and
       // reaches the composer even if it was opened before this response landed (the sign-in resume path).
-      this.#composer.setCopyVariant(this.#accessImpact);
+      this.#composer.setCopyVariant(data.access_impact);
       this.#render(data.stories);
     } catch (err) {
       console.error(err);

--- a/public/js/common/label-detail/StorySection.js
+++ b/public/js/common/label-detail/StorySection.js
@@ -13,7 +13,7 @@ class StorySection {
   #composer;
   #labelId = null;
   #maxTextLength = null;
-  #isAccessProblem = null; // From the /stories payload (LabelTypeEnum-sourced); flips the composer's phrasing.
+  #accessImpact = null; // From the /stories payload (LabelTypeEnum-sourced); flips the composer's phrasing.
   #fetchToken = 0; // Guards against a stale response landing after a newer label was opened.
   #highlightStoryId = null; // Pending story deep link (#4722); the first render that could show it consumes it.
 
@@ -78,7 +78,7 @@ class StorySection {
   setLabel(labelId, labelTypeName = null) {
     this.#labelId = labelId;
     this.#composer.setLabelType(labelTypeName);
-    this.#isAccessProblem = null;
+    this.#accessImpact = null;
     this.#els.list.replaceChildren();
     this.#els.count.hidden = true;
     // Empty posture until the fetch lands (most labels have no stories): section hidden, footer CTA up. This is
@@ -116,11 +116,11 @@ class StorySection {
       const data = await res.json();
       if (token !== this.#fetchToken) return;
       this.#maxTextLength = data.max_text_length;
-      this.#isAccessProblem = data.is_access_problem;
+      this.#accessImpact = data.access_impact;
       // Positive access features (curb ramps, signals, ...) get "story about a feature" phrasing instead of "has a
       // problem affected you". Applied on every fetch so paging between label types re-picks the right copy — and
       // reaches the composer even if it was opened before this response landed (the sign-in resume path).
-      this.#composer.setCopyVariant(this.#isAccessProblem);
+      this.#composer.setCopyVariant(this.#accessImpact);
       this.#render(data.stories);
     } catch (err) {
       console.error(err);

--- a/public/js/common/utilitiesSidewalk.js
+++ b/public/js/common/utilitiesSidewalk.js
@@ -432,6 +432,9 @@ function UtilitiesMisc(JSON) {
     return category ? descriptions[category] : descriptions;
   }
 
+  // Duplicates `access_impact: "feature"` on /v3/api/labelTypes: sourcing it would make every caller of
+  // isPositiveLabelType() wait on a fetch, so it stays hardcoded until this file gets an async bootstrap (#4457).
+  // Signal is a feature too, but carries no severity, so it never reaches these functions.
   const POSITIVE_LABEL_TYPES = ['CurbRamp', 'Crosswalk'];
   const LABEL_TYPES_WITHOUT_SEVERITY = ['NoSidewalk', 'Signal', 'Occlusion'];
 

--- a/public/js/common/utilitiesSidewalk.js
+++ b/public/js/common/utilitiesSidewalk.js
@@ -4,26 +4,40 @@ util.misc = util.misc || {};
 function UtilitiesMisc(JSON) {
   const self = { className: 'UtilitiesMisc' };
 
-  // Corresponds to the label type lists defined in LabelTypeEnum.scala.
-  self.VALID_LABEL_TYPES = [
-    'CurbRamp', 'NoCurbRamp', 'Obstacle', 'SurfaceProblem', 'Other', 'Occlusion', 'NoSidewalk', 'Crosswalk', 'Signal',
-  ];
-  self.PRIMARY_LABEL_TYPES
-    = ['CurbRamp', 'NoCurbRamp', 'Obstacle', 'SurfaceProblem', 'NoSidewalk', 'Crosswalk', 'Signal'];
-  self.PRIMARY_VALIDATE_LABEL_TYPES = ['CurbRamp', 'NoCurbRamp', 'Obstacle', 'SurfaceProblem', 'Crosswalk', 'Signal'];
-  self.VALID_LABEL_TYPES_WITHOUT_OTHER
-    = ['CurbRamp', 'NoCurbRamp', 'Obstacle', 'SurfaceProblem', 'Occlusion', 'NoSidewalk', 'Crosswalk', 'Signal'];
+  // The label-type table LabelTypeEnum stamps onto every page (main.scala.html), in canonical order. It is the only
+  // copy the frontend has: every list, colour and behavior flag below is derived from it, so none of them can drift
+  // from the backend. A page that doesn't stamp it (jsdom, the error pages) leaves these empty rather than serving a
+  // stale duplicate — the surfaces that read them don't render on such a page.
+  const labelTypes = Array.isArray(window.labelTypes) ? window.labelTypes : [];
+  const byName = new Map(labelTypes.map((lt) => [lt.name, lt]));
 
-  // Returns the marker-icon path for each label type. Every frontend surface — canvas, map markers, cards, cursors —
-  // uses the one scalable SVG so the icon stays crisp at whatever size it lands at; the raster `_small`/`_tiny`/full
-  // -size PNGs beside it exist only for consumers that can't take vector art (server-side share-image compositing in
-  // ShareController, and the icon URLs published by /v3/api/labelTypes).
+  self.VALID_LABEL_TYPES = labelTypes.map((lt) => lt.name);
+  self.PRIMARY_LABEL_TYPES = labelTypes.filter((lt) => lt.isPrimary).map((lt) => lt.name);
+  self.PRIMARY_VALIDATE_LABEL_TYPES = labelTypes.filter((lt) => lt.isPrimaryValidate).map((lt) => lt.name);
+  self.VALID_LABEL_TYPES_WITHOUT_OTHER = self.VALID_LABEL_TYPES.filter((name) => name !== 'Other');
+
+  /**
+   * The marker-icon path for each label type, or for one when `category` names it.
+   *
+   * Every frontend surface — canvas, map markers, cards, cursors — uses the one scalable SVG so the icon stays crisp
+   * at whatever size it lands at; the raster `_small`/`_tiny`/full-size PNGs beside it exist only for consumers that
+   * can't take vector art (share-image compositing in ShareController, and /v3/api/labelTypes' icon URLs). Walk is
+   * Explore's cursor mode rather than a label type, so the backend knows nothing about it and it carries no icon.
+   *
+   * The filename is built here rather than read off the stamp so `make lint-asset-paths` can still see which asset
+   * family this resolves to and check it against the fingerprint manifest; a server-supplied string is opaque to it.
+   * Only the naming convention lives here — which types exist comes from the stamp — and LabelTypeEnumSpec fails if
+   * any of these files goes missing.
+   *
+   * @param {string} [category] - A label type name, or 'Walk'. Omit for the whole map.
+   * @returns {Object} `{id, iconImagePath}` for that type, or a map of them keyed by type name.
+   */
   function getIconImagePaths(category) {
     const imagePaths = { Walk: { id: 'Walk', iconImagePath: null } };
-    for (const labelType of self.VALID_LABEL_TYPES) {
-      imagePaths[labelType] = {
-        id: labelType,
-        iconImagePath: util.assetPath(`images/icons/label_type_icons/${labelType}_small.svg`),
+    for (const labelType of labelTypes) {
+      imagePaths[labelType.name] = {
+        id: labelType.name,
+        iconImagePath: util.assetPath(`images/icons/label_type_icons/${labelType.name}_small.svg`),
       };
     }
 
@@ -432,28 +446,27 @@ function UtilitiesMisc(JSON) {
     return category ? descriptions[category] : descriptions;
   }
 
-  // Duplicates `access_impact: "feature"` on /v3/api/labelTypes: sourcing it would make every caller of
-  // isPositiveLabelType() wait on a fetch, so it stays hardcoded until this file gets an async bootstrap (#4457).
-  // Signal is a feature too, but carries no severity, so it never reaches these functions.
-  const POSITIVE_LABEL_TYPES = ['CurbRamp', 'Crosswalk'];
-  const LABEL_TYPES_WITHOUT_SEVERITY = ['NoSidewalk', 'Signal', 'Occlusion'];
-
   /**
-   * Returns true if label type uses the "positive" rating scheme (Good/Okay/Bad) vs the "negative" (Low/Medium/High).
+   * Whether a label type uses the "positive" rating scheme (Good/Okay/Bad) vs the "negative" (Low/Medium/High).
+   *
+   * This is the type's rating scale, NOT its access impact: Signal is a positive access feature that carries no
+   * rating at all, so reading it off the impact would put it on the wrong scheme.
+   *
    * @param {string} labelType
    * @returns {boolean}
    */
   function isPositiveLabelType(labelType) {
-    return POSITIVE_LABEL_TYPES.includes(labelType);
+    return byName.get(labelType)?.ratingScale === 'quality';
   }
 
   /**
-   * Returns true if label type supports a severity/quality rating.
+   * Whether a label type's labels carry a 1-3 rating at all.
    * @param {string} labelType
    * @returns {boolean}
    */
   function labelTypeHasSeverity(labelType) {
-    return !LABEL_TYPES_WITHOUT_SEVERITY.includes(labelType);
+    const scale = byName.get(labelType)?.ratingScale;
+    return scale !== undefined && scale !== 'unrated';
   }
 
   /**
@@ -646,60 +659,28 @@ function UtilitiesMisc(JSON) {
     }
   }
 
+  // The outline each marker gets on the canvas. White for everything except the two grey meta types, which would be
+  // indistinguishable from each other with a white ring. No backend counterpart: LabelTypeEnum owns the fill colour
+  // (it's the type's identity, and the API publishes it), while the outline is only ever a canvas rendering choice.
   // TODO These colors should probably match the colors in our Design System Tokens in main.css.
-  const colors = {
-    Walk: {
-      id: 'Walk',
-      fillStyle: 'rgba(0, 0, 0, 1)',
-      strokeStyle: '#FFFFFF',
-    },
-    CurbRamp: {
-      id: 'CurbRamp',
-      fillStyle: '#90C31F',
-      strokeStyle: '#FFFFFF',
-    },
-    NoCurbRamp: {
-      id: 'NoCurbRamp',
-      fillStyle: '#E679B6',
-      strokeStyle: '#FFFFFF',
-    },
-    Obstacle: {
-      id: 'Obstacle',
-      fillStyle: '#78B0EA',
-      strokeStyle: '#FFFFFF',
-    },
-    Other: {
-      id: 'Other',
-      fillStyle: '#B3B3B3',
-      strokeStyle: '#0000FF',
-    },
-    Occlusion: {
-      id: 'Occlusion',
-      fillStyle: '#B3B3B3',
-      strokeStyle: '#009902',
-    },
-    NoSidewalk: {
-      id: 'NoSidewalk',
-      fillStyle: '#BE87D8',
-      strokeStyle: '#FFFFFF',
-    },
-    SurfaceProblem: {
-      id: 'SurfaceProblem',
-      fillStyle: '#F68D3E',
-      strokeStyle: '#FFFFFF',
-    },
-    Crosswalk: {
-      id: 'Crosswalk',
-      fillStyle: '#FABF1C',
-      strokeStyle: '#FFFFFF',
-    },
-    Signal: {
-      id: 'Signal',
-      fillStyle: '#63C0AB',
-      strokeStyle: '#FFFFFF',
-    },
-  };
+  const STROKE_STYLES = { Other: '#0000FF', Occlusion: '#009902' };
+  const DEFAULT_STROKE_STYLE = '#FFFFFF';
 
+  // Walk is Explore's cursor mode rather than a label type, so it has no backend entry and needs its colours here.
+  const colors = { Walk: { id: 'Walk', fillStyle: 'rgba(0, 0, 0, 1)', strokeStyle: DEFAULT_STROKE_STYLE } };
+  for (const labelType of labelTypes) {
+    colors[labelType.name] = {
+      id: labelType.name,
+      fillStyle: labelType.color,
+      strokeStyle: STROKE_STYLES[labelType.name] || DEFAULT_STROKE_STYLE,
+    };
+  }
+
+  /**
+   * One label type's canvas fill colour, or the whole `{fillStyle, strokeStyle}` table when no type is named.
+   * @param {string} [category] - A label type name, or 'Walk'. Omit for the whole table.
+   * @returns {string|Object}
+   */
   function getLabelColors(category) {
     return category ? colors[category].fillStyle : colors;
   }
@@ -733,9 +714,7 @@ function UtilitiesMisc(JSON) {
   self.getIconImagePaths = getIconImagePaths;
   self.getLabelDescriptions = getLabelDescriptions;
   self.isPositiveLabelType = isPositiveLabelType;
-  self.POSITIVE_LABEL_TYPES = POSITIVE_LABEL_TYPES;
   self.labelTypeHasSeverity = labelTypeHasSeverity;
-  self.LABEL_TYPES_WITHOUT_SEVERITY = LABEL_TYPES_WITHOUT_SEVERITY;
   self.getSmileyIconPath = getSmileyIconPath;
   self.getSeverityLevelColors = getSeverityLevelColors;
   self.getRatingLevelKeys = getRatingLevelKeys;

--- a/public/js/common/utilitiesSidewalk.js
+++ b/public/js/common/utilitiesSidewalk.js
@@ -4,10 +4,10 @@ util.misc = util.misc || {};
 function UtilitiesMisc(JSON) {
   const self = { className: 'UtilitiesMisc' };
 
-  // The label-type table LabelTypeEnum stamps onto every page (main.scala.html), in canonical order. It is the only
-  // copy the frontend has: every list, colour and behavior flag below is derived from it, so none of them can drift
-  // from the backend. A page that doesn't stamp it (jsdom, the error pages) leaves these empty rather than serving a
-  // stale duplicate — the surfaces that read them don't render on such a page.
+  // The label-type table LabelTypeEnum stamps onto every page (main.scala.html), in canonical order. Every list,
+  // colour and behavior flag below is derived from it, so none of them can drift from the backend — anything else
+  // in the frontend that needs the set of label types should read util.misc rather than write its own copy.
+  // A page that doesn't stamp it (jsdom, the error pages) leaves these empty rather than serving a stale duplicate.
   const labelTypes = Array.isArray(window.labelTypes) ? window.labelTypes : [];
   const byName = new Map(labelTypes.map((lt) => [lt.name, lt]));
 
@@ -461,12 +461,15 @@ function UtilitiesMisc(JSON) {
 
   /**
    * Whether a label type's labels carry a 1-3 rating at all.
+   *
+   * A type we have no entry for answers false, so an unstamped page hides its rating controls rather than offering
+   * a scale it can't name. Callers use the answer to decide whether to render the rating UI at all.
+   *
    * @param {string} labelType
    * @returns {boolean}
    */
   function labelTypeHasSeverity(labelType) {
-    const scale = byName.get(labelType)?.ratingScale;
-    return scale !== undefined && scale !== 'unrated';
+    return (byName.get(labelType)?.ratingScale ?? 'unrated') !== 'unrated';
   }
 
   /**

--- a/public/js/explore/src/keyboard/KeyboardManager.js
+++ b/public/js/explore/src/keyboard/KeyboardManager.js
@@ -164,7 +164,9 @@ class KeyboardManager {
       for (const mode of ['Walk'].concat(util.misc.VALID_LABEL_TYPES_WITHOUT_OTHER)) {
         // Some keyup events (synthetic events, certain IME/compose keys) arrive with no `key`; skip the shortcut
         // match rather than throwing on undefined.toUpperCase().
-        if (e.key && e.key.toUpperCase() === util.misc.getLabelDescriptions(mode).keyChar) {
+        // The type list is backend-sourced but getLabelDescriptions is a local table, so a label type added to
+        // LabelTypeEnum lands here before it has a keyChar. Skip it rather than throwing on every keyup.
+        if (e.key && e.key.toUpperCase() === util.misc.getLabelDescriptions(mode)?.keyChar) {
           if (mode !== 'Walk') this.#closeContextMenu(e.keyCode);
           this.#ribbon.modeSwitch(mode);
           svl.tracker.push(`KeyboardShortcut_ModeSwitch_${mode}`, { keyCode: e.keyCode });

--- a/public/js/ps-map/psMapUtilities.js
+++ b/public/js/ps-map/psMapUtilities.js
@@ -165,10 +165,7 @@ function CreateMapLayerTracker() {
   // One flat array of features and one layer name string per label type.
   mapData.sortedLabels = {};
   mapData.layerNames = {};
-  const labelTypes = [
-    'CurbRamp', 'NoCurbRamp', 'Obstacle', 'SurfaceProblem', 'Occlusion', 'NoSidewalk', 'Crosswalk', 'Signal', 'Other',
-  ];
-  for (const labelType of labelTypes) {
+  for (const labelType of util.misc.VALID_LABEL_TYPES) {
     mapData.sortedLabels[labelType] = [];
     mapData.layerNames[labelType] = '';
     mapData.selectedTags[labelType] = new Set();

--- a/public/js/user-dashboard/StoriesSection.js
+++ b/public/js/user-dashboard/StoriesSection.js
@@ -152,7 +152,7 @@ class StoriesSection {
       edit.setAttribute('aria-label', i18next.t('labelmap:story.edit-aria', { labelType: typeName, date: postedDate }));
       edit.addEventListener('click', () => {
         // Problem-vs-feature phrasing comes from the payload's LabelTypeEnum-sourced flag, never derived here.
-        this.#composer.setCopyVariant(story.is_access_problem);
+        this.#composer.setCopyVariant(story.access_impact);
         this.#composer.openForEdit(story, this.#maxTextLength);
       });
       meta.appendChild(edit);

--- a/test/controllers/ShareControllerSpec.scala
+++ b/test/controllers/ShareControllerSpec.scala
@@ -1,5 +1,6 @@
 package controllers
 
+import models.label.LabelTypeEnum.AccessImpact
 import models.label.{CropMarker, LabelMetadata, LabelTypeEnum}
 import models.story.Story
 import org.apache.pekko.stream.Materializer
@@ -184,7 +185,7 @@ class ShareControllerSpec extends PlaySpec with GuiceOneAppPerSuite {
     }
 
     "use the issue title framing for access-issue label types" in {
-      labelWhere(_.labelType.isAccessProblem) match {
+      labelWhere(_.labelType.accessImpact == AccessImpact.Problem) match {
         case None        => cancel("No recent access-issue label in the test DB.")
         case Some(label) =>
           val body = contentAsString(route(app, FakeRequest(GET, s"/label/${label.labelId}")).get)
@@ -193,7 +194,7 @@ class ShareControllerSpec extends PlaySpec with GuiceOneAppPerSuite {
     }
 
     "use the feature title framing for non-issue label types" in {
-      labelWhere(!_.labelType.isAccessProblem) match {
+      labelWhere(_.labelType.accessImpact != AccessImpact.Problem) match {
         case None        => cancel("No recent non-issue label in the test DB.")
         case Some(label) =>
           val body = contentAsString(route(app, FakeRequest(GET, s"/label/${label.labelId}")).get)
@@ -202,7 +203,7 @@ class ShareControllerSpec extends PlaySpec with GuiceOneAppPerSuite {
     }
 
     "state the severity in the description for an access-issue label that has one" in {
-      labelWhere(l => l.labelType.isAccessProblem && l.severity.isDefined) match {
+      labelWhere(l => l.labelType.accessImpact == AccessImpact.Problem && l.severity.isDefined) match {
         case None        => cancel("No recent access-issue label with a severity in the test DB.")
         case Some(label) =>
           val body = contentAsString(route(app, FakeRequest(GET, s"/label/${label.labelId}")).get)

--- a/test/controllers/StoryControllerSpec.scala
+++ b/test/controllers/StoryControllerSpec.scala
@@ -51,11 +51,11 @@ class StoryControllerSpec extends PlaySpec with RolledBackDb with AnonSession wi
   private val labelTable                 = app.injector.instanceOf[models.label.LabelTable]
 
   // Direct table access for the listing-page fixtures (seed/restore a pano address), per ExploreAddressServiceSpec.
-  private val labelsQ               = TableQuery[LabelTableDef]
-  private val panoDataQ             = TableQuery[PanoDataTableDef]
-  private val maxTextLength: Int    = app.configuration.get[Int]("stories.max-text-length")
-  private val maxAltTextLength: Int = app.configuration.get[Int]("stories.max-alt-text-length")
-  private val maxPerDay: Int        = app.configuration.get[Int]("stories.max-per-user-per-day")
+  private val labelsQ                  = TableQuery[LabelTableDef]
+  private val panoDataQ                = TableQuery[PanoDataTableDef]
+  private val maxTextLength: Int       = app.configuration.get[Int]("stories.max-text-length")
+  private val maxAltTextLength: Int    = app.configuration.get[Int]("stories.max-alt-text-length")
+  private val maxPerDay: Int           = app.configuration.get[Int]("stories.max-per-user-per-day")
   private val impactNames: Set[String] = LabelTypeEnum.values.map(_.accessImpact.name)
 
   private lazy val labelIds: Seq[Int] =

--- a/test/controllers/StoryControllerSpec.scala
+++ b/test/controllers/StoryControllerSpec.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import models.label.LabelTableDef
+import models.label.{LabelTableDef, LabelTypeEnum}
 import models.pano.{PanoDataTableDef, PanoSource}
 import models.story.Story
 import models.utils.MyPostgresProfile.api._
@@ -56,6 +56,7 @@ class StoryControllerSpec extends PlaySpec with RolledBackDb with AnonSession wi
   private val maxTextLength: Int    = app.configuration.get[Int]("stories.max-text-length")
   private val maxAltTextLength: Int = app.configuration.get[Int]("stories.max-alt-text-length")
   private val maxPerDay: Int        = app.configuration.get[Int]("stories.max-per-user-per-day")
+  private val impactNames: Set[String] = LabelTypeEnum.values.map(_.accessImpact.name)
 
   private lazy val labelIds: Seq[Int] =
     Await.result(labelService.getRecentLabelMetadata(50), 60.seconds).map(_.labelId).distinct
@@ -130,8 +131,8 @@ class StoryControllerSpec extends PlaySpec with RolledBackDb with AnonSession wi
           status(resp) mustBe OK
           (contentAsJson(resp) \ "label_id").as[Int] mustBe id
           (contentAsJson(resp) \ "max_text_length").as[Int] mustBe maxTextLength
-          // Real labels always resolve to a boolean (the card's problem-vs-feature prompt switch).
-          (contentAsJson(resp) \ "is_access_problem").asOpt[Boolean] mustBe defined
+          // Real labels always resolve to a bucket (the card's problem-vs-feature prompt switch).
+          impactNames must contain((contentAsJson(resp) \ "access_impact").as[String])
           (contentAsJson(resp) \ "stories").asOpt[JsArray] mustBe defined
       }
     }
@@ -560,7 +561,7 @@ class StoryControllerSpec extends PlaySpec with RolledBackDb with AnonSession wi
             mine mustBe defined
             (mine.get \ "label_id").as[Int] mustBe id
             (mine.get \ "label_type").asOpt[String] mustBe defined
-            (mine.get \ "is_access_problem").asOpt[Boolean] mustBe defined
+            impactNames must contain((mine.get \ "access_impact").as[String])
             (mine.get \ "display_name_mode").as[String] mustBe Story.DisplayNameAnonymous
             // The thumbnail source rides the payload; null is fine (no crop/pano), but the key must be there.
             (mine.get \ "label_image_url").toOption mustBe defined

--- a/test/controllers/api/MetadataApiSpec.scala
+++ b/test/controllers/api/MetadataApiSpec.scala
@@ -53,6 +53,15 @@ class MetadataApiSpec extends PlaySpec with GuiceOneAppPerSuite {
       types.find(lt => (lt \ "name").as[String] == "NoCurbRamp").map(lt => (lt \ "display_name").as[String]) mustBe
         Some("Missing Curb Ramp")
     }
+
+    "publish each type's access impact so clients can read severity the right way round" in {
+      // Severity means "how bad" on a problem and "how good" on a feature, so a client has to source this (#4457).
+      val json  = contentAsJson(route(app, FakeRequest(GET, "/v3/api/labelTypes")).get)
+      val types = (json \ "label_types").as[Seq[JsObject]]
+
+      types.map(lt => (lt \ "name").as[String] -> (lt \ "access_impact").as[String]).toMap mustBe
+        LabelTypeEnum.values.map(lt => lt.name -> lt.accessImpact.name).toMap
+    }
   }
 
   "GET /v3/api/cities" should {

--- a/test/controllers/api/MetadataApiSpec.scala
+++ b/test/controllers/api/MetadataApiSpec.scala
@@ -62,6 +62,26 @@ class MetadataApiSpec extends PlaySpec with GuiceOneAppPerSuite {
       types.map(lt => (lt \ "name").as[String] -> (lt \ "access_impact").as[String]).toMap mustBe
         LabelTypeEnum.values.map(lt => lt.name -> lt.accessImpact.name).toMap
     }
+
+    "publish each type's rating scale, which is a separate question from its access impact" in {
+      // Signal is an access feature that carries no rating at all, so a client reading the scale off the impact
+      // would put it on the wrong one (#4457).
+      val json  = contentAsJson(route(app, FakeRequest(GET, "/v3/api/labelTypes")).get)
+      val types = (json \ "label_types").as[Seq[JsObject]]
+
+      types.map(lt => (lt \ "name").as[String] -> (lt \ "rating_scale").as[String]).toMap mustBe
+        LabelTypeEnum.values.map(lt => lt.name -> lt.ratingScale.name).toMap
+    }
+
+    "publish icon URLs that survive a deploy, so a consumer can store one" in {
+      val json  = contentAsJson(route(app, FakeRequest(GET, "/v3/api/labelTypes")).get)
+      val types = (json \ "label_types").as[Seq[JsObject]]
+
+      types.foreach { lt =>
+        val name = (lt \ "name").as[String]
+        (lt \ "icon_url").as[String] mustBe s"/assets/images/icons/label_type_icons/$name.png"
+      }
+    }
   }
 
   "GET /v3/api/cities" should {

--- a/test/js/dashboardStoriesSection.test.js
+++ b/test/js/dashboardStoriesSection.test.js
@@ -24,7 +24,7 @@ const SECTION_SRC = fs.readFileSync(
 /** One story payload, shaped like an entry from GET /userapi/stories/mine. */
 function story(overrides = {}) {
     return {
-        story_id: 11, label_id: 501, label_type: 'SurfaceProblem', is_access_problem: true,
+        story_id: 11, label_id: 501, label_type: 'SurfaceProblem', access_impact: 'problem',
         text: 'The cracked panel here tips my chair.', display_name_mode: 'anonymous', hidden: false,
         created_at: '2026-07-01T12:00:00Z', media: null, label_image_url: null, ...overrides,
     };
@@ -124,17 +124,17 @@ describe('the dashboard\'s "Your stories" list', () => {
 
         document.querySelector('.ud-story-edit').click();
 
-        expect(composer.setCopyVariant).toHaveBeenCalledWith(true);
+        expect(composer.setCopyVariant).toHaveBeenCalledWith('problem');
         expect(composer.openForEdit).toHaveBeenCalledWith(expect.objectContaining({ story_id: 11 }), 1200);
     });
 
     it('passes a positive access feature\'s phrasing through unchanged', async () => {
-        stories = [story({ label_type: 'CurbRamp', is_access_problem: false })];
+        stories = [story({ label_type: 'CurbRamp', access_impact: 'feature' })];
         await renderSection();
 
         document.querySelector('.ud-story-edit').click();
 
-        expect(composer.setCopyVariant).toHaveBeenCalledWith(false);
+        expect(composer.setCopyVariant).toHaveBeenCalledWith('feature');
     });
 
     it('re-fetches the list on the story-changed signal, so an edited story\'s row shows the new text', async () => {

--- a/test/js/loadGlobalScript.js
+++ b/test/js/loadGlobalScript.js
@@ -43,6 +43,17 @@ function loadGlobalScript(relativePath) {
 const assetPathStub = (logicalPath) => `/assets/${logicalPath}`;
 
 /**
+ * Stamps `window.labelTypes` the way main.scala.html does, so `util.misc` has a label-type table to build from.
+ *
+ * The fixture is a committed copy of what LabelTypeEnum serializes, and LabelTypeEnumSpec fails if the two diverge —
+ * so this can't quietly become the stale duplicate that sourcing the table from the backend was meant to remove.
+ */
+function stampLabelTypes() {
+    const fixture = path.join(REPO_ROOT, 'test/resources/label-types-stamp.json');
+    window.labelTypes = JSON.parse(fs.readFileSync(fixture, 'utf8'));
+}
+
+/**
  * Installs the real `util.misc` (public/js/common/utilitiesSidewalk.js) onto an already-stubbed `window.util`.
  *
  * For suites that want the genuine helper rather than a copy of its logic — `labelMarkerFraction` above all, which
@@ -51,7 +62,8 @@ const assetPathStub = (logicalPath) => `/assets/${logicalPath}`;
  * must already be set, since `getIconImagePaths` builds its paths through it.
  */
 function installUtilitiesMisc() {
+    stampLabelTypes();
     window.eval(fs.readFileSync(path.join(REPO_ROOT, 'public/js/common/utilitiesSidewalk.js'), 'utf8'));
 }
 
-module.exports = { loadGlobalScript, REPO_ROOT, assetPathStub, installUtilitiesMisc };
+module.exports = { loadGlobalScript, REPO_ROOT, assetPathStub, installUtilitiesMisc, stampLabelTypes };

--- a/test/js/storySectionLinkedStory.test.js
+++ b/test/js/storySectionLinkedStory.test.js
@@ -72,7 +72,7 @@ describe("StorySection's linked-story reveal (#4722)", () => {
         stories = [story()];
         window.fetch = jest.fn().mockImplementation(() => Promise.resolve({
             ok: true,
-            json: () => Promise.resolve({ max_text_length: 500, is_access_problem: true, stories }),
+            json: () => Promise.resolve({ max_text_length: 500, access_impact: 'problem', stories }),
         }));
     });
 

--- a/test/models/label/LabelTypeEnumSpec.scala
+++ b/test/models/label/LabelTypeEnumSpec.scala
@@ -1,5 +1,6 @@
 package models.label
 
+import models.label.LabelTypeEnum.AccessImpact
 import org.scalatestplus.play.PlaySpec
 
 import java.io.File
@@ -7,21 +8,32 @@ import java.io.File
 /**
  * Pure unit tests for the label-type enum's derived and declared properties. No app boot or DB required.
  *
- * These pin domain facts that feature code depends on: the issue/feature split drives share copy and severity
+ * These pin domain facts that feature code depends on: the access-impact bucketing drives share copy and severity
  * interpretation (positive access features and problems read severity in opposite directions), `nameKey` must track
  * `descriptionKey`, and the icon files must exist on disk because share-image compositing loads them by convention.
  */
 class LabelTypeEnumSpec extends PlaySpec {
 
-  "isAccessProblem" should {
-    "be true for exactly the accessibility-problem label types" in {
-      val issueTypes = LabelTypeEnum.values.filter(_.isAccessProblem)
-      issueTypes mustBe Set(
+  "accessImpact" should {
+    "put every label type in the right bucket" in {
+      // A type in the wrong bucket silently inverts share copy and every severity interpretation built on this.
+      LabelTypeEnum.byAccessImpact(AccessImpact.Problem) mustBe Set(
         LabelTypeEnum.NoCurbRamp,
         LabelTypeEnum.Obstacle,
         LabelTypeEnum.SurfaceProblem,
         LabelTypeEnum.NoSidewalk
       )
+      LabelTypeEnum.byAccessImpact(AccessImpact.Feature) mustBe Set(
+        LabelTypeEnum.CurbRamp,
+        LabelTypeEnum.Crosswalk,
+        LabelTypeEnum.Signal
+      )
+      LabelTypeEnum.byAccessImpact(AccessImpact.Neutral) mustBe Set(LabelTypeEnum.Occlusion, LabelTypeEnum.Other)
+    }
+
+    "publish a distinct name per bucket, since clients match on those strings" in {
+      val impacts = Seq(AccessImpact.Problem, AccessImpact.Feature, AccessImpact.Neutral)
+      impacts.map(_.name) mustBe Seq("problem", "feature", "neutral")
     }
   }
 

--- a/test/models/label/LabelTypeEnumSpec.scala
+++ b/test/models/label/LabelTypeEnumSpec.scala
@@ -18,18 +18,21 @@ class LabelTypeEnumSpec extends PlaySpec {
   "accessImpact" should {
     "put every label type in the right bucket" in {
       // A type in the wrong bucket silently inverts share copy and every severity interpretation built on this.
-      LabelTypeEnum.byAccessImpact(AccessImpact.Problem) mustBe Set(
+      LabelTypeEnum.values.filter(_.accessImpact == AccessImpact.Problem) mustBe Set(
         LabelTypeEnum.NoCurbRamp,
         LabelTypeEnum.Obstacle,
         LabelTypeEnum.SurfaceProblem,
         LabelTypeEnum.NoSidewalk
       )
-      LabelTypeEnum.byAccessImpact(AccessImpact.Feature) mustBe Set(
+      LabelTypeEnum.values.filter(_.accessImpact == AccessImpact.Feature) mustBe Set(
         LabelTypeEnum.CurbRamp,
         LabelTypeEnum.Crosswalk,
         LabelTypeEnum.Signal
       )
-      LabelTypeEnum.byAccessImpact(AccessImpact.Neutral) mustBe Set(LabelTypeEnum.Occlusion, LabelTypeEnum.Other)
+      LabelTypeEnum.values.filter(_.accessImpact == AccessImpact.Neutral) mustBe Set(
+        LabelTypeEnum.Occlusion,
+        LabelTypeEnum.Other
+      )
     }
 
     "publish a distinct name per bucket, since clients match on those strings" in {
@@ -40,14 +43,17 @@ class LabelTypeEnumSpec extends PlaySpec {
 
   "ratingScale" should {
     "put every label type on the right scale" in {
-      LabelTypeEnum.byRatingScale(RatingScale.Quality) mustBe Set(LabelTypeEnum.CurbRamp, LabelTypeEnum.Crosswalk)
-      LabelTypeEnum.byRatingScale(RatingScale.Severity) mustBe Set(
+      LabelTypeEnum.values.filter(_.ratingScale == RatingScale.Quality) mustBe Set(
+        LabelTypeEnum.CurbRamp,
+        LabelTypeEnum.Crosswalk
+      )
+      LabelTypeEnum.values.filter(_.ratingScale == RatingScale.Severity) mustBe Set(
         LabelTypeEnum.NoCurbRamp,
         LabelTypeEnum.Obstacle,
         LabelTypeEnum.SurfaceProblem,
         LabelTypeEnum.Other
       )
-      LabelTypeEnum.byRatingScale(RatingScale.Unrated) mustBe Set(
+      LabelTypeEnum.values.filter(_.ratingScale == RatingScale.Unrated) mustBe Set(
         LabelTypeEnum.Signal,
         LabelTypeEnum.NoSidewalk,
         LabelTypeEnum.Occlusion

--- a/test/models/label/LabelTypeEnumSpec.scala
+++ b/test/models/label/LabelTypeEnumSpec.scala
@@ -1,7 +1,8 @@
 package models.label
 
-import models.label.LabelTypeEnum.AccessImpact
+import models.label.LabelTypeEnum.{AccessImpact, RatingScale}
 import org.scalatestplus.play.PlaySpec
+import play.api.libs.json.{JsObject, Json}
 
 import java.io.File
 
@@ -37,6 +38,37 @@ class LabelTypeEnumSpec extends PlaySpec {
     }
   }
 
+  "ratingScale" should {
+    "put every label type on the right scale" in {
+      LabelTypeEnum.byRatingScale(RatingScale.Quality) mustBe Set(LabelTypeEnum.CurbRamp, LabelTypeEnum.Crosswalk)
+      LabelTypeEnum.byRatingScale(RatingScale.Severity) mustBe Set(
+        LabelTypeEnum.NoCurbRamp,
+        LabelTypeEnum.Obstacle,
+        LabelTypeEnum.SurfaceProblem,
+        LabelTypeEnum.Other
+      )
+      LabelTypeEnum.byRatingScale(RatingScale.Unrated) mustBe Set(
+        LabelTypeEnum.Signal,
+        LabelTypeEnum.NoSidewalk,
+        LabelTypeEnum.Occlusion
+      )
+    }
+
+    "publish a distinct name per scale, since clients match on those strings" in {
+      Seq(RatingScale.Quality, RatingScale.Severity, RatingScale.Unrated).map(_.name) mustBe
+        Seq("quality", "severity", "unrated")
+    }
+
+    "only ever be Quality on an access feature" in {
+      // The two axes are otherwise independent — Other is Neutral but rated, NoSidewalk a Problem but unrated — but
+      // "1 is good" only makes sense for something whose presence helps. A Problem on the quality scale would read
+      // its own severity backwards.
+      for (lt <- LabelTypeEnum.values if lt.ratingScale == RatingScale.Quality) {
+        withClue(s"${lt.name}: ") { lt.accessImpact mustBe AccessImpact.Feature }
+      }
+    }
+  }
+
   "staticValidatableLabelTypes" should {
     "be the primary types minus Signal" in {
       // Signal is labeled at the base of its pole, so judging it needs a pan upward that a static image (the
@@ -57,15 +89,36 @@ class LabelTypeEnumSpec extends PlaySpec {
 
   "label type icons" should {
     "exist on disk in every variant for every label type" in {
-      // Share-image compositing resolves public/images/icons/label_type_icons/<name>_small.png (the colored marker)
-      // by convention, and the enum exposes paths for the scalable marker and all three raster sizes; a missing file
-      // degrades silently to a markerless preview, so pin the convention here.
+      // A missing file degrades silently — a markerless share preview, a broken chip — so pin every variant. The
+      // paths are logical (under public/), which is what makes this check a plain file lookup.
       for (lt <- LabelTypeEnum.values) {
-        for (variant <- Seq(".png", "_small.png", "_tiny.png", "_small.svg")) {
-          val icon = new File(s"public/images/icons/label_type_icons/${lt.name}$variant")
+        for (path <- Seq(lt.iconPath, lt.smallIconPath, lt.tinyIconPath, lt.smallIconSvgPath)) {
+          val icon = new File(s"public/$path")
           assert(icon.exists(), s"missing icon for ${lt.name}: ${icon.getPath}")
         }
       }
+    }
+
+    "publish API URLs that are the logical path under /assets/, un-fingerprinted" in {
+      // A consumer that stores an icon_url expects it to survive our next deploy, so these deliberately skip the
+      // content-hashed name our own pages use.
+      LabelTypeEnum.CurbRamp.iconUrl mustBe "/assets/images/icons/label_type_icons/CurbRamp.png"
+      LabelTypeEnum.CurbRamp.smallIconUrl mustBe "/assets/images/icons/label_type_icons/CurbRamp_small.png"
+      LabelTypeEnum.CurbRamp.tinyIconUrl mustBe "/assets/images/icons/label_type_icons/CurbRamp_tiny.png"
+    }
+  }
+
+  "the page stamp" should {
+    "match the fixture the jsdom suite builds util.misc from" in {
+      // test/js/loadGlobalScript.js stamps that fixture as window.labelTypes. If it stops matching what the pages
+      // actually stamp, the JS suite is testing a table no browser ever sees — so fail here instead, with the diff.
+      val fixture = Json.parse(new File("test/resources/label-types-stamp.json").toURI.toURL.openStream())
+      Json.parse(LabelTypeEnum.pageStampJson) mustBe fixture
+    }
+
+    "carry every label type, in canonical order" in {
+      Json.parse(LabelTypeEnum.pageStampJson).as[Seq[JsObject]].map(t => (t \ "name").as[String]) mustBe
+        LabelTypeEnum.orderedNames
     }
   }
 }

--- a/test/resources/label-types-stamp.json
+++ b/test/resources/label-types-stamp.json
@@ -1,0 +1,74 @@
+[
+  {
+    "name": "CurbRamp",
+    "color": "#90C31F",
+    "accessImpact": "feature",
+    "ratingScale": "quality",
+    "isPrimary": true,
+    "isPrimaryValidate": true
+  },
+  {
+    "name": "NoCurbRamp",
+    "color": "#E679B6",
+    "accessImpact": "problem",
+    "ratingScale": "severity",
+    "isPrimary": true,
+    "isPrimaryValidate": true
+  },
+  {
+    "name": "Obstacle",
+    "color": "#78B0EA",
+    "accessImpact": "problem",
+    "ratingScale": "severity",
+    "isPrimary": true,
+    "isPrimaryValidate": true
+  },
+  {
+    "name": "SurfaceProblem",
+    "color": "#F68D3E",
+    "accessImpact": "problem",
+    "ratingScale": "severity",
+    "isPrimary": true,
+    "isPrimaryValidate": true
+  },
+  {
+    "name": "Crosswalk",
+    "color": "#FABF1C",
+    "accessImpact": "feature",
+    "ratingScale": "quality",
+    "isPrimary": true,
+    "isPrimaryValidate": true
+  },
+  {
+    "name": "Signal",
+    "color": "#63C0AB",
+    "accessImpact": "feature",
+    "ratingScale": "unrated",
+    "isPrimary": true,
+    "isPrimaryValidate": true
+  },
+  {
+    "name": "NoSidewalk",
+    "color": "#BE87D8",
+    "accessImpact": "problem",
+    "ratingScale": "unrated",
+    "isPrimary": true,
+    "isPrimaryValidate": false
+  },
+  {
+    "name": "Occlusion",
+    "color": "#B3B3B3",
+    "accessImpact": "neutral",
+    "ratingScale": "unrated",
+    "isPrimary": false,
+    "isPrimaryValidate": false
+  },
+  {
+    "name": "Other",
+    "color": "#B3B3B3",
+    "accessImpact": "neutral",
+    "ratingScale": "severity",
+    "isPrimary": false,
+    "isPrimaryValidate": false
+  }
+]

--- a/test/service/AccessScoreCalculatorSpec.scala
+++ b/test/service/AccessScoreCalculatorSpec.scala
@@ -1,5 +1,7 @@
 package service
 
+import models.label.LabelTypeEnum
+import models.label.LabelTypeEnum.AccessImpact
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import service.AccessScoreCalculator.ClusterScoreInput
@@ -320,6 +322,20 @@ class AccessScoreCalculatorSpec extends AnyFunSuite with Matchers {
     AccessScoreCalculator.orderedScoredTypes shouldBe Seq(
       "CurbRamp", "NoCurbRamp", "Obstacle", "SurfaceProblem", "Crosswalk", "Signal", "NoSidewalk"
     )
+  }
+
+  test("the scored types are exactly the ones that say something about access, signed the way they read") {
+    // The weights are tuned by hand, but which types get one, and which way it points, is not a taste call (#4457).
+    val (neutral, meaningful) = LabelTypeEnum.values.partition(_.accessImpact == AccessImpact.Neutral)
+    AccessScoreCalculator.scoredTypeNames shouldBe meaningful.map(_.name)
+    neutral.map(_.name).intersect(AccessScoreCalculator.scoredTypeNames) shouldBe empty
+
+    AccessScoreCalculator.typeWeights.foreach { case (typeName, weight) =>
+      val impact = LabelTypeEnum.byName(typeName).accessImpact
+      withClue(s"$typeName is a $impact but weighs ${weight.baseWeight}: ") {
+        if (impact == AccessImpact.Problem) weight.baseWeight should be < 0.0 else weight.baseWeight should be > 0.0
+      }
+    }
   }
 
   // --- Intersections as a scoring unit, and length normalization (#5095) ---

--- a/test/service/AccessScoreCalculatorSpec.scala
+++ b/test/service/AccessScoreCalculatorSpec.scala
@@ -1,7 +1,7 @@
 package service
 
 import models.label.LabelTypeEnum
-import models.label.LabelTypeEnum.AccessImpact
+import models.label.LabelTypeEnum.{AccessImpact, RatingScale}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import service.AccessScoreCalculator.ClusterScoreInput
@@ -326,14 +326,30 @@ class AccessScoreCalculatorSpec extends AnyFunSuite with Matchers {
 
   test("the scored types are exactly the ones that say something about access, signed the way they read") {
     // The weights are tuned by hand, but which types get one, and which way it points, is not a taste call (#4457).
-    val (neutral, meaningful) = LabelTypeEnum.values.partition(_.accessImpact == AccessImpact.Neutral)
+    val meaningful = LabelTypeEnum.values.filterNot(_.accessImpact == AccessImpact.Neutral)
     AccessScoreCalculator.scoredTypeNames shouldBe meaningful.map(_.name)
-    neutral.map(_.name).intersect(AccessScoreCalculator.scoredTypeNames) shouldBe empty
 
     AccessScoreCalculator.typeWeights.foreach { case (typeName, weight) =>
       val impact = LabelTypeEnum.byName(typeName).accessImpact
       withClue(s"$typeName is a $impact but weighs ${weight.baseWeight}: ") {
         if (impact == AccessImpact.Problem) weight.baseWeight should be < 0.0 else weight.baseWeight should be > 0.0
+      }
+    }
+  }
+
+  test("each scoring mode agrees with the label type's rating scale") {
+    // Scoring carries what the enum doesn't know (per-cluster vs pooled vs presence-only, length normalization), but
+    // which way a rating reads is LabelTypeEnum's to say. Pin them together so the two can't drift (#4457).
+    AccessScoreCalculator.typeWeights.foreach { case (typeName, weight) =>
+      val scale = LabelTypeEnum.byName(typeName).ratingScale
+      withClue(s"$typeName is $scale but scores as ${weight.scoring}: ") {
+        weight.scoring match {
+          case AccessScoreCalculator.PositiveQuality  => scale shouldBe RatingScale.Quality
+          case AccessScoreCalculator.NegativeSeverity => scale shouldBe RatingScale.Severity
+          // Both ignore the rating entirely, which is only sound for a type that never carries one.
+          case AccessScoreCalculator.PresenceOnly | AccessScoreCalculator.StreetCondition =>
+            scale shouldBe RatingScale.Unrated
+        }
       }
     }
   }


### PR DESCRIPTION
resolves #4457

Replaces `LabelTypeEnum`'s `isAccessProblem` boolean with a three-way `accessImpact` enum, then follows the thread to the place the boolean was compensating for: the pile of hand-maintained label-type literals in `utilitiesSidewalk.js`.

## `accessImpact` (Problem | Feature | Neutral)

The boolean collapsed Feature and Neutral into its `false` case, and a two-boolean workaround could encode an invalid "both true" state. Occlusion and Other are now `Neutral` rather than lumped in with curb ramps.

Both callers migrated (the share-title fork in `ShareController`, and the story composer's phrasing), with no behavior change — neutral types keep the feature phrasing, so no new translations. Published as `access_impact` on `/v3/api/labelTypes`.

## `ratingScale` (Quality | Severity | Unrated)

The frontend also encoded a *second* domain fact across two literals — `POSITIVE_LABEL_TYPES` and `LABEL_TYPES_WITHOUT_SEVERITY` — and `ConfigTable.scala` hardcoded a third copy in SQL, with a comment naming a JS file as its source of truth.

Every consumer asks the same two questions together (does this type carry a rating, and on which scale), so it's one three-valued fact. It is **not** derivable from `accessImpact` in either direction:

| | access impact | rating scale |
|---|---|---|
| Other | Neutral | Severity |
| NoSidewalk | Problem | Unrated |
| Signal | Feature | Unrated |

That last row was a live trap: sourcing "positive rating scheme" from the access impact would have put Signal on the wrong scale. It's unreachable today only because `labelTypeHasSeverity` happens to gate every call site.

The one invariant that does hold — Quality ⟹ Feature — is pinned as a spec assertion rather than merged into one field. Published as `rating_scale`.

## Sourcing the frontend's table

`main.scala.html` already stamps server-owned tables onto every page (`window.assetDigests`, `window.panoramaxLicenses`). Adding `window.labelTypes` alongside them lets `utilitiesSidewalk.js` build its lists, colors and behavior flags from the backend instead of parallel literals. Everything in the stamp is fixed at build time (no city, no language, no DB), so it serializes once at class-load and reads stay **synchronous** — none of the 11 call sites of `isPositiveLabelType` change.

Gone: `VALID_LABEL_TYPES`, `PRIMARY_LABEL_TYPES`, `PRIMARY_VALIDATE_LABEL_TYPES`, `VALID_LABEL_TYPES_WITHOUT_OTHER`, the `colors` fill table, `POSITIVE_LABEL_TYPES`, `LABEL_TYPES_WITHOUT_SEVERITY`, and the `ConfigTable` SQL list.

Still local, with reasons in comments: marker **stroke** colors (canvas rendering, no backend counterpart), the `Walk` cursor mode (not a label type), and the icon *filename* convention (kept as a template literal so `make lint-asset-paths` can still check the asset family — `LabelTypeEnumSpec` pins that every icon file exists).

`test/resources/label-types-stamp.json` is the fixture the jsdom suite stamps; `LabelTypeEnumSpec` fails if it drifts from what the pages actually serve, so it can't become the stale duplicate this removes.

## Icon paths

`LabelTypeEnum`'s icon paths are now logical paths under `public/` — the one form `assets.path` (Twirl), `util.assetPath` (JS) and `environment.getFile` (server-side compositing) all take. The stored `/assets/`-prefixed string fit exactly one of those three, so `ShareController` and `LabelTypeEnumSpec` each rebuilt the convention by hand.

Fixes a live bug on the way: `storyList.scala.html` rendered its label-type chips from that raw string, so they were served **unfingerprinted**; `make lint-asset-paths` can't see it because it only scans `public/js/` and `public/css/`. They now go through `assets.path`.

API `icon_url`/`small_icon_url`/`tiny_icon_url` stay deliberately un-fingerprinted — a consumer that stores one wants it to survive the next deploy. Pinned by a spec.

## Worth an eye in review

The mission-complete legend now renders its dots in canonical order (primary validate types, NoSidewalk, then the meta types) rather than the old array's arbitrary order, since `VALID_LABEL_TYPES` comes from the stamp. Visible change; I think it reads better, easy to revert if not.

## Testing

- Scala: full suite green (1373 tests); affected specs re-run green (125)
- JS: 1742 jsdom tests
- E2E: 141 Playwright tests against this branch — the stamp is in every page's `<head>`, so this was the check that mattered
- All 7 `make lint` gates, scalafmt

Verified against the running app: the stamp renders, `/v3/api/labelTypes` carries both new fields, and the story-list chips resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VBygQwYDvt1tNh7t7oiaHn
