### PR TITLE
Point the documented sbt thin client at --jvm-client

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,12 +55,12 @@ file, and this table says which doc to read first:
 ## Before a change is done
 
 - **Scala:** `make scalafmt-fix` (a blocking CI gate). Compile check without fighting the developer's `sbt ~ run`:
-  `docker exec projectsidewalk-web bash -lc "cd /home && sbt --client compile"`. `-Xfatal-warnings` is on, so a
+  `docker exec projectsidewalk-web bash -lc "cd /home && sbt --jvm-client compile"`. `-Xfatal-warnings` is on, so a
   success is warning-clean.
 - **Frontend:** `make lint` (ESLint, Stylelint, HTMLHint, locale parity, CSS layout, asset paths, vendor versions,
   evolutions lint; all blocking CI gates), or scope it with `make eslint dir=…` / `make stylelint dir=…`.
   `make lint-fix` handles the mechanical fixes. The tree is lint-clean, so any finding is from your change.
-- **Tests:** `sbt --client test` (same `docker exec`; needs the db container), `make test-js` (jsdom unit suite),
+- **Tests:** `sbt --jvm-client test` (same `docker exec`; needs the db container), `make test-js` (jsdom unit suite),
   `make test-e2e` against a running app, `make test-python`. Details and what CI gates: `docs/testing-and-ci.md`.
 
 ## Conventions the linters can't check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,10 +113,10 @@ user-facing text, add at least temporary (machine) translations for the other la
 ## Testing your changes
 
 There's a backend test suite (ScalaTest) under `test/` — mainly public-API functional specs. Run it with
-`sbt --client test` (the DB-backed API specs boot the app against Postgres+PostGIS, so the `db` container must be
+`sbt --jvm-client test` (the DB-backed API specs boot the app against Postgres+PostGIS, so the `db` container must be
 up); the overall strategy and phased rollout are in [`docs/testing-and-ci.md`](docs/testing-and-ci.md). CI runs the
 whole suite as a blocking, required check — a new spec is picked up by existing, with nothing to enroll it in — but
-coverage is still thin, so also compile (`sbt --client compile`) and exercise behavior in the running app. See
+coverage is still thin, so also compile (`sbt --jvm-client compile`) and exercise behavior in the running app. See
 [`docs/dev-environment.md`](docs/dev-environment.md) for the exact commands.
 
 **Update logging.** User interactions (clicks, key presses, etc.) should be logged. If you add or change

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,19 @@ RUN chmod 644 /etc/apt/trusted.gpg.d/scalasbt-release.gpg
 
 RUN apt-get update && apt-get upgrade -y
 
+# The `sbt` package is only the launcher: it downloads and runs whatever version `project/build.properties` asks
+# for. Unpinned, every rebuild grabs the newest sbt published, which is how a 2.x launcher ended up starting our
+# 1.x build (#5268). Pinning it to the version the build already declares means Scala Steward's monthly bump of
+# that file moves the image too, with nothing extra to remember.
+COPY project/build.properties /tmp/build.properties
+
 RUN apt-get install -y \
     unzip \
     python3-dev \
     python3-pip \
     nodejs \
-    sbt && \
+    "sbt=$(sed -n 's/^sbt\.version=//p' /tmp/build.properties)" && \
+  rm /tmp/build.properties && \
   apt-get autoremove && \
   apt-get clean
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,8 @@ RUN chmod 644 /etc/apt/trusted.gpg.d/scalasbt-release.gpg
 
 RUN apt-get update && apt-get upgrade -y
 
-# The `sbt` package is only the launcher: it downloads and runs whatever version `project/build.properties` asks
-# for. Unpinned, every rebuild grabs the newest sbt published, which is how a 2.x launcher ended up starting our
-# 1.x build (#5268). Pinning it to the version the build already declares means Scala Steward's monthly bump of
-# that file moves the image too, with nothing extra to remember.
+# The `sbt` package is only the launcher, so pin it to the version the build itself declares — unpinned, each
+# rebuild silently grabs whatever sbt shipped most recently (#5268).
 COPY project/build.properties /tmp/build.properties
 
 RUN apt-get install -y \

--- a/Makefile
+++ b/Makefile
@@ -344,9 +344,8 @@ lint-vendor-versions:
 	@echo "Finished checking vendor versions";
 
 # Scala formatting (.scalafmt.conf). The sbt thin client (`--jvm-client`) shares the running `sbt ~ run`'s server
-# instead of colliding with it over build locks; the native client (`--client`) can't run in the container at all
-# (docs/dev-environment.md).
-# `scalafmt` checks (the blocking CI gate); `scalafmt-fix` reformats in place.
+# instead of colliding with it over build locks. `scalafmt` checks (the blocking CI gate); `scalafmt-fix` reformats
+# in place.
 scalafmt:
 	@echo "Checking Scala formatting..."; docker exec -it $(web-container) bash -lc "cd /home && sbt --jvm-client scalafmtCheckAll"
 

--- a/Makefile
+++ b/Makefile
@@ -343,13 +343,15 @@ lint-vendor-versions:
 	@docker exec $(web-container) bash -lc "cd /home && node tools/check-vendor-versions.mjs"
 	@echo "Finished checking vendor versions";
 
-# Scala formatting (.scalafmt.conf). The sbt thin client (`--client`) shares the running `sbt ~ run`'s server instead
-# of colliding with it over build locks. `scalafmt` checks (the blocking CI gate); `scalafmt-fix` reformats in place.
+# Scala formatting (.scalafmt.conf). The sbt thin client (`--jvm-client`) shares the running `sbt ~ run`'s server
+# instead of colliding with it over build locks; the native client (`--client`) can't run in the container at all
+# (docs/dev-environment.md).
+# `scalafmt` checks (the blocking CI gate); `scalafmt-fix` reformats in place.
 scalafmt:
-	@echo "Checking Scala formatting..."; docker exec -it $(web-container) bash -lc "cd /home && sbt --client scalafmtCheckAll"
+	@echo "Checking Scala formatting..."; docker exec -it $(web-container) bash -lc "cd /home && sbt --jvm-client scalafmtCheckAll"
 
 scalafmt-fix:
-	@echo "Formatting Scala..."; docker exec -it $(web-container) bash -lc "cd /home && sbt --client scalafmtAll"
+	@echo "Formatting Scala..."; docker exec -it $(web-container) bash -lc "cd /home && sbt --jvm-client scalafmtAll"
 
 # The JS/CSS/HTML linters run in the web container, where their node_modules live (no host-side npm install).
 # `-e FORCE_COLOR=1` (not `docker exec -t`) restores colorized output while keeping the targets pipeable.

--- a/docs/dev-environment.md
+++ b/docs/dev-environment.md
@@ -291,15 +291,19 @@ make dev
 
 ### Checking that backend changes compile
 
-The quickest pass/fail on a Scala change is a compile. The sbt **thin client** uses its own server, so it won't
-collide with a running `sbt ~ run`:
+The quickest pass/fail on a Scala change is a compile. The sbt **thin client** hands the command to a background
+sbt server, so it won't collide with a running `sbt ~ run` over build locks:
 
 ```bash
-docker exec projectsidewalk-web bash -lc "cd /home && sbt --client compile"
+docker exec projectsidewalk-web bash -lc "cd /home && sbt --jvm-client compile"
 ```
 
 The first call after a container boot starts the compile server (~30s); later calls are near-instant. `build.sbt`
 sets `-Xfatal-warnings`, so a `[success]` is also warning-clean.
+
+Use `--jvm-client`, not `--client`: the native client (`sbtn`) needs a newer glibc than the container's focal base,
+so it dies on startup, though `sbt --client --version` still prints happily (#5268). A server belongs to one project
+directory, so each worktree gets its own; `sbt shutdownall` stops every one of them, the running `~ run` included.
 
 ### Running the backend tests
 
@@ -307,8 +311,8 @@ ScalaTest specs live under `test/` — mostly functional specs for the public AP
 specs. They boot the real app against Postgres+PostGIS, so the `db` container has to be up:
 
 ```bash
-docker exec projectsidewalk-web bash -lc "cd /home && sbt --client test"
-docker exec projectsidewalk-web bash -lc "cd /home && sbt --client \"testOnly controllers.api.PublicApiSpec\""
+docker exec projectsidewalk-web bash -lc "cd /home && sbt --jvm-client test"
+docker exec projectsidewalk-web bash -lc "cd /home && sbt --jvm-client \"testOnly controllers.api.PublicApiSpec\""
 ```
 
 The `backend-tests` CI job is a required check and runs **all of `test/`** (`sbt coverage test`, since #5042), so a
@@ -353,8 +357,8 @@ make qa-worktree wt=<worktree-name>
 A worktree needs more setup than the main repo (its `node_modules` and built asset bundles aren't checked in, and
 sbt's caches and config have to be pointed at the right places), so this target handles all of it: it links the main
 repo's `node_modules`, builds that branch's JS/CSS bundles, starts a backgrounded `grunt watch` so later edits
-rebuild automatically, frees `:9000`, kills any stray `sbt --client` server or hung `sbtn` task sharing the worktree's
-`target/` (either deadlocks `~ run` on compile locks), and launches `sbt ~ run` against the worktree's own config
+rebuild automatically, frees `:9000`, kills any stray sbt server or hung sbt task sharing the worktree's `target/`
+(either deadlocks `~ run` on compile locks), and launches `sbt ~ run` against the worktree's own config
 while reusing the main repo's warm sbt caches. The first request triggers the dev compile; `Ctrl+C` stops it and
 reaps the grunt watch. To tear a session down out-of-band, run `make qa-worktree-stop wt=<name>` (add `clean=1` to
 also drop the `node_modules` symlink). It behaves the same on macOS, Linux, and WSL because the work runs inside the

--- a/docs/upgrading-libraries.md
+++ b/docs/upgrading-libraries.md
@@ -82,8 +82,11 @@ These versions live in [`build.sbt`](../build.sbt), [`project/build.properties`]
   [#3936](https://github.com/ProjectSidewalk/SidewalkWebpage/issues/3936) (unclear if all our libraries support it
   yet). Edit `scalaVersion` in `build.sbt`.
   [Releases](https://www.scala-lang.org/download/all.html) · [Changelog](https://github.com/scala/scala/releases)
-- **sbt: 1.12.13** — set in `project/build.properties`; downloaded automatically on the next `npm start`. You may need
-  to bump Play at the same time for major sbt updates. [Releases](https://github.com/sbt/sbt/releases)
+- **sbt: 1.12.13** — set in `project/build.properties`; downloaded automatically on the next `npm start`. The
+  `Dockerfile` pins the apt `sbt` launcher to that same version, so also `docker compose build web` after a bump
+  (Compose won't rebuild on its own). sbt **2.x** is gated on Play: its `sbt-plugin` has no sbt 2 build outside the
+  3.1.0 milestones, and sbt 2 build definitions are Scala 3, so it's a tracked migration rather than a bump. You may
+  need to bump Play at the same time for major sbt updates. [Releases](https://github.com/sbt/sbt/releases)
 - **Play Framework: 3.0.11** — to update: (1) change the version in `project/plugins.sbt` (the `sbt-plugin`
   dependency), and (2) change it in `build.sbt` for the Play-provided libraries that share Play's versioning scheme
   (`play-guice`, `play-cache`, `play-ws`, `play-caffeine-cache`).

--- a/docs/upgrading-libraries.md
+++ b/docs/upgrading-libraries.md
@@ -34,8 +34,9 @@ listed separately and are *expected* to differ; the goal is skew that's written 
 
 - **Focal does more than it looks.** It's what makes `python3` mean 3.8 (retiring that is
   [#4396](https://github.com/ProjectSidewalk/SidewalkWebpage/issues/4396)), and its glibc 2.31 is older than the
-  2.32 and 2.34 that sbt's `sbtn` needs, so `sbt --client` can't run in the container at all. Jammy (glibc 2.35,
-  `python3` 3.10) or noble (2.39, 3.12) fixes both, but a move has to say what happens to 3.8 first.
+  2.32 and 2.34 that sbt's `sbtn` needs, so `sbt --client` can't run in the container at all and everything uses
+  `sbt --jvm-client` instead (#5268). Jammy (glibc 2.35, `python3` 3.10) or noble (2.39, 3.12) fixes both, but a
+  move has to say what happens to 3.8 first.
 - **The `16-3.5` image line is a dead end.** apt.postgresql.org's bullseye pool stops at PostGIS 3.5.2, and
   docker-postgis publishes no `16-3.6` tag (3.6 images start at Postgres 17) or bookworm variant for 16 — so newer
   geospatial libraries in dev means moving the Postgres major *and* the base OS together, not a version bump.
@@ -73,7 +74,7 @@ readonly_user -d sidewalk`).
 
 These versions live in [`build.sbt`](../build.sbt), [`project/build.properties`](../project/build.properties), and
 [`project/plugins.sbt`](../project/plugins.sbt). After changing any of them, rerun `npm start` (or
-`sbt --client compile`) so the new versions download and the build re-resolves.
+`sbt --jvm-client compile`) so the new versions download and the build re-resolves.
 
 ### Core toolchain
 

--- a/tools/qa-worktree.sh
+++ b/tools/qa-worktree.sh
@@ -107,7 +107,7 @@ fi
 echo "==> building bundles (grunt concat concat_css)"
 node_modules/.bin/grunt concat concat_css >/dev/null
 
-# 3. A stray `sbt --client` server (or a hung `sbtn` task, e.g. a wedged `scalafmtAll`) whose cwd is this worktree
+# 3. A stray thin-client sbt server (or a hung task, e.g. a wedged `scalafmtAll`) whose cwd is this worktree
 #    shares target/ and deadlocks `~ run` on compile locks. Reap them.
 reap_in_worktree KILL 'sbt-launch|sbtn' "thin-client / hung sbt task (shares target/)"
 


### PR DESCRIPTION
resolves #5268

`sbt --client` runs `sbtn`, a native binary that needs glibc 2.32/2.34 — newer than the web container's focal base
— so every documented use of it fails, including `make scalafmt` and `make scalafmt-fix`, a blocking CI gate's local
command.

Two changes: swap the documented command, and stop the underlying drift.

### 1. `sbt --client` → `sbt --jvm-client`

Not plain `sbt`. `--jvm-client` is the same thin client, just on the JVM instead of a native binary, so it keeps the
reason the flag was there: work goes to a background sbt server instead of booting a second sbt that fights the
running `sbt ~ run` over build locks.

Beyond the spots listed in the issue, this also covers `docs/dev-environment.md:356` and `tools/qa-worktree.sh:110`,
which described the processes they reap in terms of `sbtn`.

### 2. Pin the apt `sbt` launcher to `project/build.properties`

The instructions were true when they were written. Running each `sbtn` release inside the container:

| sbtn | on focal (glibc 2.31) |
|---|---|
| 1.8.2, 1.9.9, 1.10.0, 1.10.8 | starts fine |
| 1.11.6, 1.12.5, 2.0.0-8753a981 | `GLIBC_2.32` / `GLIBC_2.34` not found |

sbt's native client moved to a newer build toolchain at 1.11, and `Dockerfile:18` installed `sbt` unpinned from apt —
so the breakage arrived on an image rebuild, not on a commit, and anyone whose image predates it still has a working
`sbt --client` until their next `docker build --no-cache`.

The same unpinned install also left the container bootstrapping our **1.12.13** build with a **2.0.8** launcher,
which nobody chose. The launcher is version-agnostic (it downloads and runs whatever `build.properties` names), so
that mismatch is harmless today — but it's undirected. The Dockerfile now derives the pin from `build.properties`,
which hands maintenance to the Scala Steward bump that already moves that file, with no new bot and no new version
to remember. The sbt apt repo keeps 136 versions back to 0.12.4, so the pin won't rot.

Worth being explicit: the pin does **not** bring `--client` back. The 1.12.13 launcher hardcodes an sbtn 2.0.0 build
too, so it's equally broken on focal. What it buys is that a change like this arrives as a reviewable diff instead of
appearing on whoever rebuilds next. The base-image move (#4396 / #4385) is what actually restores `--client`, as a
speedup rather than a fix.

sbt **2.x** stays out of reach for a separate reason, now noted in `docs/upgrading-libraries.md`: Play's `sbt-plugin`
has no sbt 2 build outside the 3.1.0 milestones (`sbt-plugin_sbt2_3` publishes 3.1.0-M5…M9 only), and sbt 2 build
definitions are Scala 3. Our other three plugins do have sbt 2 builds.

### Testing

- Built the image through the sbt install: `dpkg -l sbt` → `1.12.13`, temp copy of `build.properties` cleaned up.
- `sbt --jvm-client scalafmtCheckAll` in a worktree: `[success] elapsed: 13 s`, 240 sources checked.
- `sbt --client "print name"` for contrast: the GLIBC error, exit 1.
- Read the 1.12.13 launcher script from its deb to confirm `--jvm-client` exists there too, so the pin and the
  documented command agree.
- `node tools/check-vendor-versions.mjs` (it reads `docs/upgrading-libraries.md`): OK, 29 doc entries cross-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012D89F3BmQU9hzpyniLnukV
