### PR TITLE
Name a one-region city's region after the city, not its source

### DIFF
--- a/.claude/skills/onboard-city/SKILL.md
+++ b/.claude/skills/onboard-city/SKILL.md
@@ -30,6 +30,9 @@ checkout** (`db/` is the bind mount), so run these from the main checkout, not a
      "quartiers", "barrios", "council districts". Prefer official, non-overlapping polygons that tile the city.
   3. Let the tool fall back: OSM neighbourhood polygons (used only above 75% coverage), then US census tracts
      (TIGERweb), then the whole city as one region (small towns; split later in QGIS if it grows).
+- **A one-region city** takes the city's name (from `--place`), not the source's — otherwise a small town is the
+  neighbourhood "Census Tract 7801" in every mission message and API response. Use `--single-region-name` with a
+  `--boundary-file`, or to override. Names you chose (`--regions-file`, a `--merge-regions` target) are left alone.
 - **City boundary.** `--place "<City, State, Country>"` geocodes the OSM admin boundary; check the report's
   "Boundary:" line names the right place. A partner file goes in with `--boundary-file`.
 - **Scope.** Whole city, or a phased launch opening some regions first (`onboard-city` asks; the imagery scan

--- a/docs/onboarding-a-city.md
+++ b/docs/onboarding-a-city.md
@@ -30,6 +30,11 @@ Run the three from the **main checkout**: `db/` is the bind mount the db contain
      US census tracts, then the whole city as one region (fine for a small town).
   Whatever you use, record where it came from with `--regions-source` (a URL, or the collaborator's email); it is
   stored in `region.data_source`.
+  A town small enough to come out as **one region** is named after the city, not after whatever source it landed in
+  — Laurens, IA would otherwise be the neighbourhood "Census Tract 7801" everywhere a region name shows (missions,
+  the dashboard, LabelMap's filters, the API's `region_name`). The name comes from `--place`; pass
+  `--single-region-name` when the boundary came from a file, or to choose a different one. A name you picked
+  yourself — a `--regions-file` dataset, or a `--merge-regions` target — is never second-guessed.
 - **Imagery provider** — `gsv`, `mapillary`, `panoramax`, or `infra3d`. The preflight in step 2 tells you which
   actually covers the city. The web container needs the provider's credentials for the scan (Panoramax needs none).
 - **The web image** must carry the geo stack (`osmnx`, `geopandas` — in `requirements-offline-tools.txt`). It is

--- a/scripts/onboard_city.py
+++ b/scripts/onboard_city.py
@@ -1788,8 +1788,9 @@ def main(argv=None):
     if args.single_region_name and len(regions) != 1:
         logger.warning('Ignoring --single-region-name "%s": it names the lone region of a city small enough to be '
                        'one region, and this city has %d.', args.single_region_name, len(regions))
-    # A hand-picked name always wins, and a hand-picked name is never second-guessed: a --regions-file dataset and
-    # a --merge-regions target were both named on purpose, so only an automatically sourced lone region is renamed.
+    # Precedence: --single-region-name first, then the city name derived from --place -- but the derived one only
+    # when nothing else picked the names. A --regions-file dataset and a --merge-regions target were named on
+    # purpose, so a name we worked out ourselves must not displace them; a name typed on this command line may.
     deliberate_names = bool(args.regions_file or merge_mapping)
     city_name = args.single_region_name or (None if deliberate_names else place_city_name(args.place))
     regions = name_single_region(regions, city_name, deliberate_names)

--- a/scripts/onboard_city.py
+++ b/scripts/onboard_city.py
@@ -1653,6 +1653,13 @@ def parse_args(argv=None):
     if args.from_gpkg and args.single_region_name:
         parser.error('--single-region-name needs a fetch run (--place/--boundary-file): a re-export takes its '
                      'region names from the edited GeoPackage.')
+    if args.single_region_name is not None:
+        # Normalized here rather than where it is used, because this string becomes region.name verbatim: an
+        # untrimmed one ships padding into the load SQL, and an all-whitespace one survives to validate_staging,
+        # whose "every region needs a non-empty name" reads as a bug in the generator rather than in the flag.
+        args.single_region_name = args.single_region_name.strip()
+        if not args.single_region_name:
+            parser.error('--single-region-name needs an actual name.')
     if args.from_gpkg and args.merge_regions:
         parser.error('--merge-regions needs a fetch run (--place/--boundary-file): streets must be re-assigned and '
                      're-healed against the merged boundaries, which a re-export cannot do.')
@@ -1778,6 +1785,9 @@ def main(argv=None):
         # passes see the final boundaries.
         regions = merge_regions(regions, merge_mapping)
         logger.info('Merged regions: %s', ', '.join(f'"{s}" into "{t}"' for s, t in merge_mapping.items()))
+    if args.single_region_name and len(regions) != 1:
+        logger.warning('Ignoring --single-region-name "%s": it names the lone region of a city small enough to be '
+                       'one region, and this city has %d.', args.single_region_name, len(regions))
     # A hand-picked name always wins, and a hand-picked name is never second-guessed: a --regions-file dataset and
     # a --merge-regions target were both named on purpose, so only an automatically sourced lone region is renamed.
     deliberate_names = bool(args.regions_file or merge_mapping)

--- a/scripts/onboard_city.py
+++ b/scripts/onboard_city.py
@@ -868,6 +868,24 @@ def valid_city_id(value):
     return value
 
 
+def place_city_name(place):
+    """
+    Pulls the city's own name out of a Nominatim-geocodable place string.
+
+    ``"Laurens, Iowa, USA"`` -> ``"Laurens"``. The first comma-separated component of such a string is the place
+    itself; everything after it qualifies the place (county, state, country).
+
+    Args:
+        place: The ``--place`` string, or None when the boundary came from ``--boundary-file``.
+
+    Returns:
+        The city name, or None when there is nothing to derive one from.
+    """
+    if not place:
+        return None
+    return place.split(',')[0].strip() or None
+
+
 # ---------------------------------------------------------------------------------------------------------------------
 # Data acquisition (network I/O).
 # ---------------------------------------------------------------------------------------------------------------------
@@ -1121,6 +1139,40 @@ def prepare_regions(raw_regions, boundary, min_part_m2):
 
     warn_if_overlapping(dissolved)
     return dissolved[['region_id', 'name', 'geometry']]
+
+
+def name_single_region(regions, city_name, deliberate_names):
+    """
+    Renames a city's lone region after the city itself.
+
+    A town small enough to land in one region inherits that region's *source* name — Laurens, IA came out as
+    "Census Tract 7801", the tract it happened to fall inside — and that name is what users then see in mission
+    messages, the dashboard, LabelMap's filters and the API's ``region_name``. When there is only one region it
+    *is* the whole city, so the city's name is the honest one.
+
+    Args:
+        regions:          The prepared regions, one row per region.
+        city_name:        The name to give the lone region, or None when there is none to give.
+        deliberate_names: True when the region names were chosen by hand — a ``--regions-file`` dataset, or the
+                          target of a ``--merge-regions`` fold. Then silence is right: nothing was guessed, so
+                          there is nothing to warn about.
+
+    Returns:
+        ``regions``, with the lone region renamed when there was one and a name to give it.
+    """
+    if len(regions) != 1:
+        return regions
+    row = regions.index[0]
+    source_name = regions.at[row, 'name']
+    if not city_name:
+        if not deliberate_names:
+            logger.warning('The city collapsed to one region, still named "%s" after its source. Pass '
+                           '--single-region-name (or --place) to name it after the city instead.', source_name)
+        return regions
+    if city_name != source_name:
+        logger.info('One region covers the whole city: naming it "%s" rather than "%s".', city_name, source_name)
+    regions.loc[row, 'name'] = city_name
+    return regions
 
 
 def disambiguate_names(names):
@@ -1566,6 +1618,9 @@ def parse_args(argv=None):
                                                  'collaborator\'s email.')
     parser.add_argument('--region-name-col', default='name',
                         help='Column of --regions-file holding the region names (default: name).')
+    parser.add_argument('--single-region-name',
+                        help='Name for the region a city small enough to collapse to ONE region ends up with '
+                             '(default: the city name from --place). Has no effect on a multi-region city.')
     parser.add_argument('--merge-tiny-m', type=float, default=20,
                         help='Merge street pieces shorter than this into a touching piece of the same OSM way '
                              '(#4717 tier 1; roundabout arcs, dual-carriageway stubs). 0 disables it (default: 20).')
@@ -1595,6 +1650,9 @@ def parse_args(argv=None):
         args.from_gpkg = str(REPO_ROOT / 'db' / 'onboarding' / args.city_id / f'{args.city_id}_qa.gpkg')
     if bool(args.from_gpkg) == bool(args.place or args.boundary_file):
         parser.error('provide either --place/--boundary-file (fetch run) or --from-gpkg (re-export run).')
+    if args.from_gpkg and args.single_region_name:
+        parser.error('--single-region-name needs a fetch run (--place/--boundary-file): a re-export takes its '
+                     'region names from the edited GeoPackage.')
     if args.from_gpkg and args.merge_regions:
         parser.error('--merge-regions needs a fetch run (--place/--boundary-file): streets must be re-assigned and '
                      're-healed against the merged boundaries, which a re-export cannot do.')
@@ -1720,6 +1778,11 @@ def main(argv=None):
         # passes see the final boundaries.
         regions = merge_regions(regions, merge_mapping)
         logger.info('Merged regions: %s', ', '.join(f'"{s}" into "{t}"' for s, t in merge_mapping.items()))
+    # A hand-picked name always wins, and a hand-picked name is never second-guessed: a --regions-file dataset and
+    # a --merge-regions target were both named on purpose, so only an automatically sourced lone region is renamed.
+    deliberate_names = bool(args.regions_file or merge_mapping)
+    city_name = args.single_region_name or (None if deliberate_names else place_city_name(args.place))
+    regions = name_single_region(regions, city_name, deliberate_names)
     # Provenance rides in the staging data itself, so fill-new-schema.sh needs no data-source input.
     regions['data_source'] = region_source
     name_warnings = check_region_names(list(regions['name']))

--- a/test/python/test_onboard_city.py
+++ b/test/python/test_onboard_city.py
@@ -963,6 +963,36 @@ def test_single_region_name_is_rejected_in_re_export_mode():
         oc.parse_args(['--city-id', 'x', '--from-gpkg', 'edited.gpkg', '--single-region-name', 'Laurens'])
 
 
+def test_single_region_name_is_trimmed_and_must_not_be_blank():
+    args = oc.parse_args(['--city-id', 'x', '--place', 'a', '--single-region-name', '  Laurens  '])
+    assert args.single_region_name == 'Laurens'
+    for blank in ['', '   ']:
+        with pytest.raises(SystemExit):
+            oc.parse_args(['--city-id', 'x', '--place', 'a', '--single-region-name', blank])
+
+
+def test_main_says_so_when_single_region_name_cannot_apply(tmp_path, monkeypatch, caplog):
+    _patch_pipeline(monkeypatch, _two_hoods())
+    with caplog.at_level(logging.WARNING):
+        oc.main(['--city-id', 'testville', '--place', 'Testville, USA', '--out-dir', str(tmp_path),
+                 '--single-region-name', 'Ignored Me'])
+    assert any('Ignoring --single-region-name' in record.message for record in caplog.records)
+    assert 'Ignored Me' not in (tmp_path / 'report.md').read_text()
+
+
+def test_main_keeps_a_regions_file_name_when_the_city_collapses_to_one_region(tmp_path, monkeypatch, caplog):
+    _patch_pipeline(monkeypatch, _empty_regions())
+    boundary_path = tmp_path / 'boundary.geojson'
+    _CITY_GDF.to_file(boundary_path, driver='GeoJSON')
+    regions_path = tmp_path / 'hoods.geojson'
+    gpd.GeoDataFrame({'name': ['Westside']}, geometry=[_W], crs='EPSG:4326').to_file(regions_path, driver='GeoJSON')
+    with caplog.at_level(logging.WARNING):
+        oc.main(['--city-id', 'testville', '--place', 'Testville, USA', '--regions-file', str(regions_path),
+                 '--regions-source', 'https://data.testville.gov/hoods', '--out-dir', str(tmp_path / 'out')])
+    assert '| 1 | Westside |' in (tmp_path / 'out' / 'report.md').read_text()
+    assert not any('--single-region-name' in record.message for record in caplog.records)
+
+
 def test_main_uses_regions_file_and_warns_on_low_coverage(tmp_path, monkeypatch, caplog):
     _patch_pipeline(monkeypatch, _empty_regions())
     boundary_path = tmp_path / 'boundary.geojson'

--- a/test/python/test_onboard_city.py
+++ b/test/python/test_onboard_city.py
@@ -980,6 +980,18 @@ def test_main_says_so_when_single_region_name_cannot_apply(tmp_path, monkeypatch
     assert 'Ignored Me' not in (tmp_path / 'report.md').read_text()
 
 
+def test_main_single_region_name_overrides_a_hand_picked_name(tmp_path, monkeypatch):
+    _patch_pipeline(monkeypatch, _empty_regions())
+    regions_path = tmp_path / 'hoods.geojson'
+    gpd.GeoDataFrame({'name': ['Westside']}, geometry=[_W], crs='EPSG:4326').to_file(regions_path, driver='GeoJSON')
+    oc.main(['--city-id', 'testville', '--place', 'Testville, USA', '--regions-file', str(regions_path),
+             '--regions-source', 'https://data.testville.gov/hoods', '--single-region-name', 'Laurens',
+             '--out-dir', str(tmp_path / 'out')])
+    report = (tmp_path / 'out' / 'report.md').read_text()
+    assert '| 1 | Laurens |' in report
+    assert 'Westside' not in report
+
+
 def test_main_keeps_a_regions_file_name_when_the_city_collapses_to_one_region(tmp_path, monkeypatch, caplog):
     _patch_pipeline(monkeypatch, _empty_regions())
     boundary_path = tmp_path / 'boundary.geojson'

--- a/test/python/test_onboard_city.py
+++ b/test/python/test_onboard_city.py
@@ -906,6 +906,63 @@ def test_main_single_region_fallback_and_default_out_dir(tmp_path, monkeypatch):
     assert 'Regions: **1**' in report
 
 
+def test_place_city_name_takes_the_first_component():
+    assert oc.place_city_name('Laurens, Iowa, USA') == 'Laurens'
+    assert oc.place_city_name('  Bayonne  ') == 'Bayonne'
+
+
+def test_place_city_name_returns_none_without_a_usable_place():
+    assert oc.place_city_name(None) is None
+    assert oc.place_city_name(', Iowa, USA') is None
+
+
+def test_name_single_region_leaves_a_multi_region_city_alone():
+    regions = _region_set()
+    assert list(oc.name_single_region(regions, 'Testville', False)['name']) == list(regions['name'])
+
+
+def test_main_keeps_a_merge_target_name_when_the_city_collapses_to_one_region(tmp_path, monkeypatch, caplog):
+    _patch_pipeline(monkeypatch, _two_hoods())
+    with caplog.at_level(logging.WARNING):
+        oc.main(['--city-id', 'testville', '--place', 'Testville, USA', '--out-dir', str(tmp_path),
+                 '--merge-regions', 'west:east'])
+    assert '| 1 | east |' in (tmp_path / 'report.md').read_text()
+    assert not any('--single-region-name' in record.message for record in caplog.records)
+
+
+def test_main_names_a_lone_region_after_the_city(tmp_path, monkeypatch):
+    tract = gpd.GeoDataFrame({'name': ['Census Tract 7801']}, geometry=[_SQUARE], crs='EPSG:4326')
+    _patch_pipeline(monkeypatch, _empty_regions(), tracts=tract)
+    oc.main(['--city-id', 'laurens-ia', '--place', 'Laurens, Iowa, USA', '--out-dir', str(tmp_path)])
+    report = (tmp_path / 'report.md').read_text()
+    assert 'Laurens' in report
+    assert 'Census Tract 7801' not in report
+
+
+def test_main_single_region_name_overrides_the_place(tmp_path, monkeypatch):
+    tract = gpd.GeoDataFrame({'name': ['Census Tract 7801']}, geometry=[_SQUARE], crs='EPSG:4326')
+    _patch_pipeline(monkeypatch, _empty_regions(), tracts=tract)
+    oc.main(['--city-id', 'laurens-ia', '--place', 'Laurens, Iowa, USA', '--out-dir', str(tmp_path),
+             '--single-region-name', 'Downtown Laurens'])
+    assert 'Downtown Laurens' in (tmp_path / 'report.md').read_text()
+
+
+def test_main_warns_when_a_lone_region_has_no_city_name_to_take(tmp_path, monkeypatch, caplog):
+    boundary_path = tmp_path / 'boundary.geojson'
+    _CITY_GDF.to_file(boundary_path, driver='GeoJSON')
+    tract = gpd.GeoDataFrame({'name': ['Census Tract 7801']}, geometry=[_SQUARE], crs='EPSG:4326')
+    _patch_pipeline(monkeypatch, _empty_regions(), tracts=tract)
+    with caplog.at_level(logging.WARNING):
+        oc.main(['--city-id', 'laurens-ia', '--boundary-file', str(boundary_path), '--out-dir', str(tmp_path)])
+    assert any('--single-region-name' in record.message for record in caplog.records)
+    assert 'Census Tract 7801' in (tmp_path / 'report.md').read_text()
+
+
+def test_single_region_name_is_rejected_in_re_export_mode():
+    with pytest.raises(SystemExit):
+        oc.parse_args(['--city-id', 'x', '--from-gpkg', 'edited.gpkg', '--single-region-name', 'Laurens'])
+
+
 def test_main_uses_regions_file_and_warns_on_low_coverage(tmp_path, monkeypatch, caplog):
     _patch_pipeline(monkeypatch, _empty_regions())
     boundary_path = tmp_path / 'boundary.geojson'


### PR DESCRIPTION
## The problem

A town small enough to collapse to a **single region** inherited that region's *source* name. Laurens, IA falls entirely inside one census tract, so the fallback chain (no OSM neighbourhoods → TIGERweb tracts → clip to boundary) produced exactly one region named **"Census Tract 7801"**.

That name is not internal. It is what users see in Explore's mission messages, the user dashboard, LabelMap's region filter, and the API's `region_name` — so a small city ships with a neighborhood called "Census Tract 7801".

The last-resort branch below it isn't better: it names the region `city_id.title()`, which for `laurens-ia` would give "Laurens-Ia".

## The change

When there is only one region, it *is* the whole city — so name it after the city.

- **`place_city_name()`** takes the first comma-separated component of the `--place` string (`"Laurens, Iowa, USA"` → `"Laurens"`). That is Nominatim's own convention: the place first, its qualifiers after.
- **`name_single_region()`** applies it after merges and before the report, so the report, the QA GeoPackage and the load SQL all carry the final name.
- **`--single-region-name`** supplies or overrides it. Needed for a `--boundary-file` city, which has no place string to read. Rejected in `--from-gpkg` mode, the way `--merge-regions` already is — a re-export takes its names from the edited GeoPackage.

**A name you picked is never second-guessed.** A `--regions-file` dataset and a `--merge-regions` target keep their names even when the city collapses to one region; only an automatically sourced name is replaced. (This came out of review: the first version clobbered the `--merge-regions west:east` target name, and the existing test for that caught it.) When there is no city name available and nothing was hand-picked, the run **warns** rather than renaming silently.

## Testing

7 new tests. Both interpreter halves green at 100% coverage:

- `python3.13`: 335 passed
- `python3` (3.8): 110 passed

Docs updated in the same change: `docs/onboarding-a-city.md` and `.claude/skills/onboard-city/SKILL.md`.

## Note

Laurens is not deployed anywhere — it exists only in one dev database — so there is no data migration here. Its schema will be rebuilt by the end-to-end rerun of the onboarding scripts, which produces the corrected name directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 5 (1M context), claude-opus-5[1m]