### PR TITLE
Build label-type stats columns and lookups from LabelTypeEnum

### DIFF
--- a/app/models/api/AccessScoreApiModels.scala
+++ b/app/models/api/AccessScoreApiModels.scala
@@ -10,6 +10,7 @@
  */
 package models.api
 
+import models.label.LabelTypeEnum
 import models.utils.LatLngBBox
 import models.utils.MyPostgresProfile.api._
 import org.locationtech.jts.geom.{LineString, MultiPolygon, Point}
@@ -23,7 +24,7 @@ import service.AccessScoreCalculator
  */
 object AccessScoreApiModels {
 
-  /** The scored label types in stable column order (by label-type id). */
+  /** The scored label types in canonical order, so output columns stay stable. */
   val orderedTypes: Seq[String] = AccessScoreCalculator.orderedScoredTypes
 
   /** Converts a CamelCase label-type name to snake_case for GeoPackage column names ("NoCurbRamp" → "no_curb_ramp"). */
@@ -31,18 +32,23 @@ object AccessScoreApiModels {
     labelType.replaceAll("([a-z0-9])([A-Z])", "$1_$2").toLowerCase
 
   /**
-   * Short (<= 10 char) column codes for the per-type fields in shapefile output, where the DBF format truncates column
-   * names at 10 characters. GeoJSON/CSV/GeoPackage use the full names instead.
+   * Short code for a label type's shapefile columns, since DBF cuts column names off at 10 characters. Covers every
+   * type, not just the scored ones, so the compiler flags a newly added type that has no code.
+   *
+   * @param labelType A label type name (e.g. "NoCurbRamp").
+   * @return          Its short code (e.g. "NoCRamp").
    */
-  val shapefileTypeCode: Map[String, String] = Map(
-    "CurbRamp"       -> "CRamp",
-    "NoCurbRamp"     -> "NoCRamp",
-    "Obstacle"       -> "Obst",
-    "SurfaceProblem" -> "Surf",
-    "NoSidewalk"     -> "NoSwk",
-    "Crosswalk"      -> "Xwalk",
-    "Signal"         -> "Signal"
-  )
+  def shapefileTypeCode(labelType: String): String = LabelTypeEnum.withName(labelType) match {
+    case LabelTypeEnum.CurbRamp       => "CRamp"
+    case LabelTypeEnum.NoCurbRamp     => "NoCRamp"
+    case LabelTypeEnum.Obstacle       => "Obst"
+    case LabelTypeEnum.SurfaceProblem => "Surf"
+    case LabelTypeEnum.Crosswalk      => "Xwalk"
+    case LabelTypeEnum.Signal         => "Signal"
+    case LabelTypeEnum.NoSidewalk     => "NoSwk"
+    case LabelTypeEnum.Occlusion      => "Occl"
+    case LabelTypeEnum.Other          => "Other"
+  }
 
   /** The rating buckets a cluster can fall into, in column order. */
   val severityBuckets: Seq[String] = AccessScoreCalculator.severityBuckets

--- a/app/models/label/LabelTable.scala
+++ b/app/models/label/LabelTable.scala
@@ -300,6 +300,10 @@ object LabelTable {
     "ai"    -> "user_role.role = 'AI'"
   )
 
+  // The types the AI validates, each broken out in getOverallStatsForApi's AI stats. ORDER MATTERS (see
+  // validationStatLabelTypes).
+  val aiStatLabelTypes: Seq[LabelTypeEnum.Base] = LabelTypeEnum.ordered.filter(aiLabelTypes.contains)
+
   /**
    * Builds the `WHERE` fragment for the Raw Labels API's `tags` filter.
    *
@@ -832,18 +836,10 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
       r.nextDurationOption(),
       r.nextDurationOption(),
       r.nextDurationOption(),
-      Map(
-        CurbRamp.name   -> LabelSevStats(r.nextInt(), r.nextIntOption(), r.nextDoubleOption(), r.nextDoubleOption()),
-        NoCurbRamp.name -> LabelSevStats(r.nextInt(), r.nextIntOption(), r.nextDoubleOption(), r.nextDoubleOption()),
-        Obstacle.name   -> LabelSevStats(r.nextInt(), r.nextIntOption(), r.nextDoubleOption(), r.nextDoubleOption()),
-        SurfaceProblem.name ->
-          LabelSevStats(r.nextInt(), r.nextIntOption(), r.nextDoubleOption(), r.nextDoubleOption()),
-        NoSidewalk.name -> LabelSevStats(r.nextInt(), r.nextIntOption(), r.nextDoubleOption(), r.nextDoubleOption()),
-        Crosswalk.name  -> LabelSevStats(r.nextInt(), r.nextIntOption(), r.nextDoubleOption(), r.nextDoubleOption()),
-        Signal.name     -> LabelSevStats(r.nextInt(), r.nextIntOption(), r.nextDoubleOption(), r.nextDoubleOption()),
-        Occlusion.name  -> LabelSevStats(r.nextInt(), r.nextIntOption(), r.nextDoubleOption(), r.nextDoubleOption()),
-        Other.name      -> LabelSevStats(r.nextInt(), r.nextIntOption(), r.nextDoubleOption(), r.nextDoubleOption())
-      ), {
+      // Read by position, so this must follow the column order getOverallStatsForApi writes.
+      LabelTypeEnum.ordered.map { lt =>
+        lt.name -> LabelSevStats(r.nextInt(), r.nextIntOption(), r.nextDoubleOption(), r.nextDoubleOption())
+      }.toMap, {
         // Read the combined/human/ai validation breakdowns in the exact order getOverallStatsForApi emits them: for
         // each source, the total validation count followed by one LabelAccuracy per validationStatLabelTypes entry.
         // Seq.map is strict and left-to-right, so this reads columns positionally in sync with the SELECT.
@@ -860,32 +856,13 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
         val ai       = readSource()
         ValidationStats(combined, human, ai)
       },
-      Map(
-        "Overall" -> Map(
-          "human_majority_vote" -> AiConcurrence(r.nextInt(), r.nextInt(), r.nextInt(), r.nextInt()),
-          "admin_majority_vote" -> AiConcurrence(r.nextInt(), r.nextInt(), r.nextInt(), r.nextInt())
-        ),
-        CurbRamp.name -> Map(
-          "human_majority_vote" -> AiConcurrence(r.nextInt(), r.nextInt(), r.nextInt(), r.nextInt()),
-          "admin_majority_vote" -> AiConcurrence(r.nextInt(), r.nextInt(), r.nextInt(), r.nextInt())
-        ),
-        NoCurbRamp.name -> Map(
-          "human_majority_vote" -> AiConcurrence(r.nextInt(), r.nextInt(), r.nextInt(), r.nextInt()),
-          "admin_majority_vote" -> AiConcurrence(r.nextInt(), r.nextInt(), r.nextInt(), r.nextInt())
-        ),
-        Obstacle.name -> Map(
-          "human_majority_vote" -> AiConcurrence(r.nextInt(), r.nextInt(), r.nextInt(), r.nextInt()),
-          "admin_majority_vote" -> AiConcurrence(r.nextInt(), r.nextInt(), r.nextInt(), r.nextInt())
-        ),
-        SurfaceProblem.name -> Map(
-          "human_majority_vote" -> AiConcurrence(r.nextInt(), r.nextInt(), r.nextInt(), r.nextInt()),
-          "admin_majority_vote" -> AiConcurrence(r.nextInt(), r.nextInt(), r.nextInt(), r.nextInt())
-        ),
-        Crosswalk.name -> Map(
+      // Read by position, so this must follow the column order getOverallStatsForApi writes.
+      ("Overall" +: aiStatLabelTypes.map(_.name)).map { group =>
+        group -> Map(
           "human_majority_vote" -> AiConcurrence(r.nextInt(), r.nextInt(), r.nextInt(), r.nextInt()),
           "admin_majority_vote" -> AiConcurrence(r.nextInt(), r.nextInt(), r.nextInt(), r.nextInt())
         )
-      )
+      }.toMap
     )
   }
 
@@ -2239,6 +2216,45 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
       }
       .mkString(",\n                 ")
 
+    // One (alias, expression) list feeds both a subquery's columns and the top-level SELECT's, so they can't drift.
+    def subqueryCols(cols: Seq[(String, String)]): String =
+      cols.map { case (alias, expr) => s"$expr AS $alias" }.mkString(",\n                 ")
+    def topLevelCols(subquery: String, cols: Seq[(String, String)]): String =
+      cols.map { case (alias, _) => s"$subquery.$alias" }.mkString(",\n             ")
+
+    // (e) Count and rating stats per label type, in the order projectSidewalkStatsConverter reads them. Unrated types
+    // have no ratings to summarize, so their rating columns are NULL.
+    val sevStatCols: Seq[(String, String)] = LabelTypeEnum.ordered.flatMap { lt =>
+      val col        = lt.name.toLowerCase
+      val isType     = s"label.label_type = '${lt.name}'"
+      val ratingCols = Seq(
+        s"n_${col}_with_sev" -> s"COUNT(CASE WHEN $isType AND severity IS NOT NULL THEN 1 END)",
+        s"${col}_sev_mean"   -> s"AVG(CASE WHEN $isType THEN severity END)",
+        s"${col}_sev_sd"     -> s"STDDEV(CASE WHEN $isType THEN severity END)"
+      )
+      val ratingColsOrNull =
+        if (lt.ratingScale == RatingScale.Unrated) ratingCols.map { case (alias, _) => alias -> "NULL" } else ratingCols
+      (s"n_$col" -> s"COUNT(CASE WHEN $isType THEN 1 END)") +: ratingColsOrNull
+    }
+
+    // (f) How often the AI's vote matched the human and admin majority votes (1 = agree, 2 = disagree), across all
+    // types and then per aiStatLabelTypes entry, in the order projectSidewalkStatsConverter reads them.
+    val aiComparisons: Seq[(String, String)] = Seq(
+      "ai_yes_mv_yes"    -> "ai_mv = 1 AND human_mv = 1",
+      "ai_yes_mv_no"     -> "ai_mv = 1 AND human_mv = 2",
+      "ai_no_mv_yes"     -> "ai_mv = 2 AND human_mv = 1",
+      "ai_no_mv_no"      -> "ai_mv = 2 AND human_mv = 2",
+      "ai_yes_admin_yes" -> "ai_mv = 1 AND admin_mv = 1",
+      "ai_yes_admin_no"  -> "ai_mv = 1 AND admin_mv = 2",
+      "ai_no_admin_yes"  -> "ai_mv = 2 AND admin_mv = 1",
+      "ai_no_admin_no"   -> "ai_mv = 2 AND admin_mv = 2"
+    )
+    val aiStatCols: Seq[(String, String)] = (None +: LabelTable.aiStatLabelTypes.map(Some(_))).flatMap { labelType =>
+      val prefix   = labelType.map(lt => s"${lt.name.toLowerCase}_").getOrElse("")
+      val typeCond = labelType.map(lt => s"label_type = '${lt.name}' AND ").getOrElse("")
+      aiComparisons.map { case (name, cond) => s"$prefix$name" -> s"COUNT(CASE WHEN $typeCond$cond THEN 1 END)" }
+    }
+
     sql"""
       SELECT '#$launchDate' AS launch_date,
              #${avgRecentLabels.map(avg => s"'$avg'").getOrElse("NULL")} AS avg_timestamp_last_100_labels,
@@ -2263,91 +2279,9 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
              label_counts_and_severity.avg_age_when_labeled,
              label_counts_and_severity.stddev_label_timestamp,
              label_counts_and_severity.stddev_age_when_labeled,
-             label_counts_and_severity.n_ramp,
-             label_counts_and_severity.n_ramp_with_sev,
-             label_counts_and_severity.ramp_sev_mean,
-             label_counts_and_severity.ramp_sev_sd,
-             label_counts_and_severity.n_noramp,
-             label_counts_and_severity.n_noramp_with_sev,
-             label_counts_and_severity.noramp_sev_mean,
-             label_counts_and_severity.noramp_sev_sd,
-             label_counts_and_severity.n_obs,
-             label_counts_and_severity.n_obs_with_sev,
-             label_counts_and_severity.obs_sev_mean,
-             label_counts_and_severity.obs_sev_sd,
-             label_counts_and_severity.n_surf,
-             label_counts_and_severity.n_surf_with_sev,
-             label_counts_and_severity.surf_sev_mean,
-             label_counts_and_severity.surf_sev_sd,
-             label_counts_and_severity.n_nosidewalk,
-             NULL AS nosidewalk_with_sev,
-             NULL AS nosidewalk_sev_mean,
-             NULL AS nosidewalk_sev_sd,
-             label_counts_and_severity.n_crswlk,
-             label_counts_and_severity.n_crswlk_with_sev,
-             label_counts_and_severity.crswlk_sev_mean,
-             label_counts_and_severity.crswlk_sev_sd,
-             label_counts_and_severity.n_signal,
-             NULL AS signal_with_sev,
-             NULL AS signal_sev_mean,
-             NULL AS signal_sev_sd,
-             label_counts_and_severity.n_occlusion,
-             NULL AS occlusion_with_sev,
-             NULL AS occlusion_sev_mean,
-             NULL AS occlusion_sev_sd,
-             label_counts_and_severity.n_other,
-             label_counts_and_severity.n_other_with_sev,
-             label_counts_and_severity.other_sev_mean,
-             label_counts_and_severity.other_sev_sd,
+             #${topLevelCols("label_counts_and_severity", sevStatCols)},
              #$validationSelectCols,
-             ai_stats.ai_yes_mv_yes,
-             ai_stats.ai_yes_mv_no,
-             ai_stats.ai_no_mv_yes,
-             ai_stats.ai_no_mv_no,
-             ai_stats.ai_yes_admin_yes,
-             ai_stats.ai_yes_admin_no,
-             ai_stats.ai_no_admin_yes,
-             ai_stats.ai_no_admin_no,
-             ai_stats.ramp_ai_yes_mv_yes,
-             ai_stats.ramp_ai_yes_mv_no,
-             ai_stats.ramp_ai_no_mv_yes,
-             ai_stats.ramp_ai_no_mv_no,
-             ai_stats.ramp_ai_yes_admin_yes,
-             ai_stats.ramp_ai_yes_admin_no,
-             ai_stats.ramp_ai_no_admin_yes,
-             ai_stats.ramp_ai_no_admin_no,
-             ai_stats.noramp_ai_yes_mv_yes,
-             ai_stats.noramp_ai_yes_mv_no,
-             ai_stats.noramp_ai_no_mv_yes,
-             ai_stats.noramp_ai_no_mv_no,
-             ai_stats.noramp_ai_yes_admin_yes,
-             ai_stats.noramp_ai_yes_admin_no,
-             ai_stats.noramp_ai_no_admin_yes,
-             ai_stats.noramp_ai_no_admin_no,
-             ai_stats.obs_ai_yes_mv_yes,
-             ai_stats.obs_ai_yes_mv_no,
-             ai_stats.obs_ai_no_mv_yes,
-             ai_stats.obs_ai_no_mv_no,
-             ai_stats.obs_ai_yes_admin_yes,
-             ai_stats.obs_ai_yes_admin_no,
-             ai_stats.obs_ai_no_admin_yes,
-             ai_stats.obs_ai_no_admin_no,
-             ai_stats.surf_ai_yes_mv_yes,
-             ai_stats.surf_ai_yes_mv_no,
-             ai_stats.surf_ai_no_mv_yes,
-             ai_stats.surf_ai_no_mv_no,
-             ai_stats.surf_ai_yes_admin_yes,
-             ai_stats.surf_ai_yes_admin_no,
-             ai_stats.surf_ai_no_admin_yes,
-             ai_stats.surf_ai_no_admin_no,
-             ai_stats.crswlk_ai_yes_mv_yes,
-             ai_stats.crswlk_ai_yes_mv_no,
-             ai_stats.crswlk_ai_no_mv_yes,
-             ai_stats.crswlk_ai_no_mv_no,
-             ai_stats.crswlk_ai_yes_admin_yes,
-             ai_stats.crswlk_ai_yes_admin_no,
-             ai_stats.crswlk_ai_no_admin_yes,
-             ai_stats.crswlk_ai_no_admin_no
+             #${topLevelCols("ai_stats", aiStatCols)}
       FROM (
           SELECT SUM(ST_Length(geom::geography)) / 1000 AS km_audited
           FROM street_edge
@@ -2455,33 +2389,7 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
                          END
                      ))
                  ) * INTERVAL '1 second' AS stddev_age_when_labeled,
-                 COUNT(CASE WHEN label.label_type = 'CurbRamp' THEN 1 END) AS n_ramp,
-                 COUNT(CASE WHEN label.label_type = 'CurbRamp' AND severity IS NOT NULL THEN 1 END) AS n_ramp_with_sev,
-                 avg(CASE WHEN label.label_type = 'CurbRamp' THEN severity END) AS ramp_sev_mean,
-                 stddev(CASE WHEN label.label_type = 'CurbRamp' THEN severity END) AS ramp_sev_sd,
-                 COUNT(CASE WHEN label.label_type = 'NoCurbRamp' THEN 1 END) AS n_noramp,
-                 COUNT(CASE WHEN label.label_type = 'NoCurbRamp' AND severity IS NOT NULL THEN 1 END) AS n_noramp_with_sev,
-                 avg(CASE WHEN label.label_type = 'NoCurbRamp' THEN severity END) AS noramp_sev_mean,
-                 stddev(CASE WHEN label.label_type = 'NoCurbRamp' THEN severity END) AS noramp_sev_sd,
-                 COUNT(CASE WHEN label.label_type = 'Obstacle' THEN 1 END) AS n_obs,
-                 COUNT(CASE WHEN label.label_type = 'Obstacle' AND severity IS NOT NULL THEN 1 END) AS n_obs_with_sev,
-                 avg(CASE WHEN label.label_type = 'Obstacle' THEN severity END) AS obs_sev_mean,
-                 stddev(CASE WHEN label.label_type = 'Obstacle' THEN severity END) AS obs_sev_sd,
-                 COUNT(CASE WHEN label.label_type = 'SurfaceProblem' THEN 1 END) AS n_surf,
-                 COUNT(CASE WHEN label.label_type = 'SurfaceProblem' AND severity IS NOT NULL THEN 1 END) AS n_surf_with_sev,
-                 avg(CASE WHEN label.label_type = 'SurfaceProblem' THEN severity END) AS surf_sev_mean,
-                 stddev(CASE WHEN label.label_type = 'SurfaceProblem' THEN severity END) AS surf_sev_sd,
-                 COUNT(CASE WHEN label.label_type = 'NoSidewalk' THEN 1 END) AS n_nosidewalk,
-                 COUNT(CASE WHEN label.label_type = 'Crosswalk' THEN 1 END) AS n_crswlk,
-                 COUNT(CASE WHEN label.label_type = 'Crosswalk' AND severity IS NOT NULL THEN 1 END) AS n_crswlk_with_sev,
-                 avg(CASE WHEN label.label_type = 'Crosswalk' THEN severity END) AS crswlk_sev_mean,
-                 stddev(CASE WHEN label.label_type = 'Crosswalk' THEN severity END) AS crswlk_sev_sd,
-                 COUNT(CASE WHEN label.label_type = 'Signal' THEN 1 END) AS n_signal,
-                 COUNT(CASE WHEN label.label_type = 'Occlusion' THEN 1 END) AS n_occlusion,
-                 COUNT(CASE WHEN label.label_type = 'Other' THEN 1 END) AS n_other,
-                 COUNT(CASE WHEN label.label_type = 'Other' AND severity IS NOT NULL THEN 1 END) AS n_other_with_sev,
-                 avg(CASE WHEN label.label_type = 'Other' THEN severity END) AS other_sev_mean,
-                 stddev(CASE WHEN label.label_type = 'Other' THEN severity END) AS other_sev_sd
+                 #${subqueryCols(sevStatCols)}
           FROM label
           INNER JOIN user_stat ON label.user_id = user_stat.user_id
           INNER JOIN audit_task ON label.audit_task_id = audit_task.audit_task_id
@@ -2527,54 +2435,7 @@ class LabelTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvid
               GROUP BY label.label_id, label.label_type::text
           ) AS label_verdicts
       ) AS val_counts, (
-          SELECT COUNT(CASE WHEN ai_mv = 1 AND human_mv = 1 THEN 1 END) AS ai_yes_mv_yes,
-                 COUNT(CASE WHEN ai_mv = 1 AND human_mv = 2 THEN 1 END) AS ai_yes_mv_no,
-                 COUNT(CASE WHEN ai_mv = 2 AND human_mv = 1 THEN 1 END) AS ai_no_mv_yes,
-                 COUNT(CASE WHEN ai_mv = 2 AND human_mv = 2 THEN 1 END) AS ai_no_mv_no,
-                 COUNT(CASE WHEN ai_mv = 1 AND admin_mv = 1 THEN 1 END) AS ai_yes_admin_yes,
-                 COUNT(CASE WHEN ai_mv = 1 AND admin_mv = 2 THEN 1 END) AS ai_yes_admin_no,
-                 COUNT(CASE WHEN ai_mv = 2 AND admin_mv = 1 THEN 1 END) AS ai_no_admin_yes,
-                 COUNT(CASE WHEN ai_mv = 2 AND admin_mv = 2 THEN 1 END) AS ai_no_admin_no,
-                 COUNT(CASE WHEN label_type = 'CurbRamp' AND ai_mv = 1 AND human_mv = 1 THEN 1 END) AS ramp_ai_yes_mv_yes,
-                 COUNT(CASE WHEN label_type = 'CurbRamp' AND ai_mv = 1 AND human_mv = 2 THEN 1 END) AS ramp_ai_yes_mv_no,
-                 COUNT(CASE WHEN label_type = 'CurbRamp' AND ai_mv = 2 AND human_mv = 1 THEN 1 END) AS ramp_ai_no_mv_yes,
-                 COUNT(CASE WHEN label_type = 'CurbRamp' AND ai_mv = 2 AND human_mv = 2 THEN 1 END) AS ramp_ai_no_mv_no,
-                 COUNT(CASE WHEN label_type = 'CurbRamp' AND ai_mv = 1 AND admin_mv = 1 THEN 1 END) AS ramp_ai_yes_admin_yes,
-                 COUNT(CASE WHEN label_type = 'CurbRamp' AND ai_mv = 1 AND admin_mv = 2 THEN 1 END) AS ramp_ai_yes_admin_no,
-                 COUNT(CASE WHEN label_type = 'CurbRamp' AND ai_mv = 2 AND admin_mv = 1 THEN 1 END) AS ramp_ai_no_admin_yes,
-                 COUNT(CASE WHEN label_type = 'CurbRamp' AND ai_mv = 2 AND admin_mv = 2 THEN 1 END) AS ramp_ai_no_admin_no,
-                 COUNT(CASE WHEN label_type = 'NoCurbRamp' AND ai_mv = 1 AND human_mv = 1 THEN 1 END) AS noramp_ai_yes_mv_yes,
-                 COUNT(CASE WHEN label_type = 'NoCurbRamp' AND ai_mv = 1 AND human_mv = 2 THEN 1 END) AS noramp_ai_yes_mv_no,
-                 COUNT(CASE WHEN label_type = 'NoCurbRamp' AND ai_mv = 2 AND human_mv = 1 THEN 1 END) AS noramp_ai_no_mv_yes,
-                 COUNT(CASE WHEN label_type = 'NoCurbRamp' AND ai_mv = 2 AND human_mv = 2 THEN 1 END) AS noramp_ai_no_mv_no,
-                 COUNT(CASE WHEN label_type = 'NoCurbRamp' AND ai_mv = 1 AND admin_mv = 1 THEN 1 END) AS noramp_ai_yes_admin_yes,
-                 COUNT(CASE WHEN label_type = 'NoCurbRamp' AND ai_mv = 1 AND admin_mv = 2 THEN 1 END) AS noramp_ai_yes_admin_no,
-                 COUNT(CASE WHEN label_type = 'NoCurbRamp' AND ai_mv = 2 AND admin_mv = 1 THEN 1 END) AS noramp_ai_no_admin_yes,
-                 COUNT(CASE WHEN label_type = 'NoCurbRamp' AND ai_mv = 2 AND admin_mv = 2 THEN 1 END) AS noramp_ai_no_admin_no,
-                 COUNT(CASE WHEN label_type = 'Obstacle' AND ai_mv = 1 AND human_mv = 1 THEN 1 END) AS obs_ai_yes_mv_yes,
-                 COUNT(CASE WHEN label_type = 'Obstacle' AND ai_mv = 1 AND human_mv = 2 THEN 1 END) AS obs_ai_yes_mv_no,
-                 COUNT(CASE WHEN label_type = 'Obstacle' AND ai_mv = 2 AND human_mv = 1 THEN 1 END) AS obs_ai_no_mv_yes,
-                 COUNT(CASE WHEN label_type = 'Obstacle' AND ai_mv = 2 AND human_mv = 2 THEN 1 END) AS obs_ai_no_mv_no,
-                 COUNT(CASE WHEN label_type = 'Obstacle' AND ai_mv = 1 AND admin_mv = 1 THEN 1 END) AS obs_ai_yes_admin_yes,
-                 COUNT(CASE WHEN label_type = 'Obstacle' AND ai_mv = 1 AND admin_mv = 2 THEN 1 END) AS obs_ai_yes_admin_no,
-                 COUNT(CASE WHEN label_type = 'Obstacle' AND ai_mv = 2 AND admin_mv = 1 THEN 1 END) AS obs_ai_no_admin_yes,
-                 COUNT(CASE WHEN label_type = 'Obstacle' AND ai_mv = 2 AND admin_mv = 2 THEN 1 END) AS obs_ai_no_admin_no,
-                 COUNT(CASE WHEN label_type = 'SurfaceProblem' AND ai_mv = 1 AND human_mv = 1 THEN 1 END) AS surf_ai_yes_mv_yes,
-                 COUNT(CASE WHEN label_type = 'SurfaceProblem' AND ai_mv = 1 AND human_mv = 2 THEN 1 END) AS surf_ai_yes_mv_no,
-                 COUNT(CASE WHEN label_type = 'SurfaceProblem' AND ai_mv = 2 AND human_mv = 1 THEN 1 END) AS surf_ai_no_mv_yes,
-                 COUNT(CASE WHEN label_type = 'SurfaceProblem' AND ai_mv = 2 AND human_mv = 2 THEN 1 END) AS surf_ai_no_mv_no,
-                 COUNT(CASE WHEN label_type = 'SurfaceProblem' AND ai_mv = 1 AND admin_mv = 1 THEN 1 END) AS surf_ai_yes_admin_yes,
-                 COUNT(CASE WHEN label_type = 'SurfaceProblem' AND ai_mv = 1 AND admin_mv = 2 THEN 1 END) AS surf_ai_yes_admin_no,
-                 COUNT(CASE WHEN label_type = 'SurfaceProblem' AND ai_mv = 2 AND admin_mv = 1 THEN 1 END) AS surf_ai_no_admin_yes,
-                 COUNT(CASE WHEN label_type = 'SurfaceProblem' AND ai_mv = 2 AND admin_mv = 2 THEN 1 END) AS surf_ai_no_admin_no,
-                 COUNT(CASE WHEN label_type = 'Crosswalk' AND ai_mv = 1 AND human_mv = 1 THEN 1 END) AS crswlk_ai_yes_mv_yes,
-                 COUNT(CASE WHEN label_type = 'Crosswalk' AND ai_mv = 1 AND human_mv = 2 THEN 1 END) AS crswlk_ai_yes_mv_no,
-                 COUNT(CASE WHEN label_type = 'Crosswalk' AND ai_mv = 2 AND human_mv = 1 THEN 1 END) AS crswlk_ai_no_mv_yes,
-                 COUNT(CASE WHEN label_type = 'Crosswalk' AND ai_mv = 2 AND human_mv = 2 THEN 1 END) AS crswlk_ai_no_mv_no,
-                 COUNT(CASE WHEN label_type = 'Crosswalk' AND ai_mv = 1 AND admin_mv = 1 THEN 1 END) AS crswlk_ai_yes_admin_yes,
-                 COUNT(CASE WHEN label_type = 'Crosswalk' AND ai_mv = 1 AND admin_mv = 2 THEN 1 END) AS crswlk_ai_yes_admin_no,
-                 COUNT(CASE WHEN label_type = 'Crosswalk' AND ai_mv = 2 AND admin_mv = 1 THEN 1 END) AS crswlk_ai_no_admin_yes,
-                 COUNT(CASE WHEN label_type = 'Crosswalk' AND ai_mv = 2 AND admin_mv = 2 THEN 1 END) AS crswlk_ai_no_admin_no
+          SELECT #${subqueryCols(aiStatCols)}
           FROM (
               SELECT label.label_id, label.label_type::text,
                      -- Note that we're doing majority vote with AI for simplicity. Should only be one vote from AI.

--- a/app/models/user/UserStatTable.scala
+++ b/app/models/user/UserStatTable.scala
@@ -244,17 +244,10 @@ class UserStatTable @Inject() (
       r.nextInt(),
       r.nextInt(),
       r.nextInt(),
-      Map(
-        LabelTypeEnum.CurbRamp.name       -> LabelTypeStat(r.nextInt(), r.nextInt(), r.nextInt(), r.nextInt()),
-        LabelTypeEnum.NoCurbRamp.name     -> LabelTypeStat(r.nextInt(), r.nextInt(), r.nextInt(), r.nextInt()),
-        LabelTypeEnum.Obstacle.name       -> LabelTypeStat(r.nextInt(), r.nextInt(), r.nextInt(), r.nextInt()),
-        LabelTypeEnum.SurfaceProblem.name -> LabelTypeStat(r.nextInt(), r.nextInt(), r.nextInt(), r.nextInt()),
-        LabelTypeEnum.NoSidewalk.name     -> LabelTypeStat(r.nextInt(), r.nextInt(), r.nextInt(), r.nextInt()),
-        LabelTypeEnum.Crosswalk.name      -> LabelTypeStat(r.nextInt(), r.nextInt(), r.nextInt(), r.nextInt()),
-        LabelTypeEnum.Signal.name         -> LabelTypeStat(r.nextInt(), r.nextInt(), r.nextInt(), r.nextInt()),
-        LabelTypeEnum.Occlusion.name      -> LabelTypeStat(r.nextInt(), r.nextInt(), r.nextInt(), r.nextInt()),
-        LabelTypeEnum.Other.name          -> LabelTypeStat(r.nextInt(), r.nextInt(), r.nextInt(), r.nextInt())
-      )
+      // Read by position, so this must follow the column order getStatsForApiWithFilters writes.
+      LabelTypeEnum.ordered.map { lt =>
+        lt.name -> LabelTypeStat(r.nextInt(), r.nextInt(), r.nextInt(), r.nextInt())
+      }.toMap
     )
   )
 
@@ -1166,6 +1159,24 @@ class UserStatTable @Inject() (
     val minAccuracyClause =
       minAccuracy.map(min => s"AND user_stat.accuracy IS NOT NULL AND user_stat.accuracy >= $min").getOrElse("")
 
+    // Four counts per label type, in the order userStatApiConverter reads them.
+    val labelTypeStatCols: Seq[(String, String)] = LabelTypeEnum.ordered.flatMap { lt =>
+      val col    = lt.name.toLowerCase
+      val isType = s"label_type = '${lt.name}'"
+      Seq(
+        s"${col}_labels"              -> s"COUNT(CASE WHEN $isType THEN 1 END)",
+        s"${col}_validated_correct"   -> s"COUNT(CASE WHEN $isType AND correct THEN 1 END)",
+        s"${col}_validated_incorrect" -> s"COUNT(CASE WHEN $isType AND NOT correct THEN 1 END)",
+        s"${col}_not_validated"       -> s"COUNT(CASE WHEN $isType AND correct IS NULL THEN 1 END)"
+      )
+    }
+    val labelTypeSelectCols: String = labelTypeStatCols
+      .map { case (alias, _) => s"COALESCE(label_counts.$alias, 0) AS $alias" }
+      .mkString(",\n             ")
+    val labelTypeCountCols: String = labelTypeStatCols
+      .map { case (alias, expr) => s"$expr AS $alias" }
+      .mkString(",\n                 ")
+
     sql"""
       SELECT user_stat.user_id,
              COALESCE(label_counts.labels, 0) AS labels,
@@ -1184,42 +1195,7 @@ class UserStatTable @Inject() (
              COALESCE(validations.agree_validations_given, 0) AS agree_validations_given,
              COALESCE(validations.disagree_validations_given, 0) AS disagree_validations_given,
              COALESCE(validations.unsure_validations_given, 0) AS unsure_validations_given,
-             COALESCE(label_counts.curb_ramp_labels, 0) AS curb_ramp_labels,
-             COALESCE(label_counts.curb_ramp_validated_correct, 0) AS curb_ramp_validated_correct,
-             COALESCE(label_counts.curb_ramp_validated_incorrect, 0) AS curb_ramp_validated_incorrect,
-             COALESCE(label_counts.curb_ramp_not_validated, 0) AS curb_ramp_not_validated,
-             COALESCE(label_counts.no_curb_ramp_labels, 0) AS no_curb_ramp_labels,
-             COALESCE(label_counts.no_curb_ramp_validated_correct, 0) AS no_curb_ramp_validated_correct,
-             COALESCE(label_counts.no_curb_ramp_validated_incorrect, 0) AS no_curb_ramp_validated_incorrect,
-             COALESCE(label_counts.no_curb_ramp_not_validated, 0) AS no_curb_ramp_not_validated,
-             COALESCE(label_counts.obstacle_labels, 0) AS obstacle_labels,
-             COALESCE(label_counts.obstacle_validated_correct, 0) AS obstacle_validated_correct,
-             COALESCE(label_counts.obstacle_validated_incorrect, 0) AS obstacle_validated_incorrect,
-             COALESCE(label_counts.obstacle_not_validated, 0) AS obstacle_not_validated,
-             COALESCE(label_counts.surface_problem_labels, 0) AS surface_problem_labels,
-             COALESCE(label_counts.surface_problem_validated_correct, 0) AS surface_problem_validated_correct,
-             COALESCE(label_counts.surface_problem_validated_incorrect, 0) AS surface_problem_validated_incorrect,
-             COALESCE(label_counts.surface_problem_not_validated, 0) AS surface_problem_not_validated,
-             COALESCE(label_counts.no_sidewalk_labels, 0) AS no_sidewalk_labels,
-             COALESCE(label_counts.no_sidewalk_validated_correct, 0) AS no_sidewalk_validated_correct,
-             COALESCE(label_counts.no_sidewalk_validated_incorrect, 0) AS no_sidewalk_validated_incorrect,
-             COALESCE(label_counts.no_sidewalk_not_validated, 0) AS no_sidewalk_not_validated,
-             COALESCE(label_counts.marked_crosswalk_labels, 0) AS marked_crosswalk_labels,
-             COALESCE(label_counts.marked_crosswalk_validated_correct, 0) AS marked_crosswalk_validated_correct,
-             COALESCE(label_counts.marked_crosswalk_validated_incorrect, 0) AS marked_crosswalk_validated_incorrect,
-             COALESCE(label_counts.marked_crosswalk_not_validated, 0) AS marked_crosswalk_not_validated,
-             COALESCE(label_counts.pedestrian_signal_labels, 0) AS pedestrian_signal_labels,
-             COALESCE(label_counts.pedestrian_signal_validated_correct, 0) AS pedestrian_signal_validated_correct,
-             COALESCE(label_counts.pedestrian_signal_validated_incorrect, 0) AS pedestrian_signal_validated_incorrect,
-             COALESCE(label_counts.pedestrian_signal_not_validated, 0) AS pedestrian_signal_not_validated,
-             COALESCE(label_counts.cant_see_sidewalk_labels, 0) AS cant_see_sidewalk_labels,
-             COALESCE(label_counts.cant_see_sidewalk_validated_correct, 0) AS cant_see_sidewalk_validated_correct,
-             COALESCE(label_counts.cant_see_sidewalk_validated_incorrect, 0) AS cant_see_sidewalk_validated_incorrect,
-             COALESCE(label_counts.cant_see_sidewalk_not_validated, 0) AS cant_see_sidewalk_not_validated,
-             COALESCE(label_counts.other_labels, 0) AS other_labels,
-             COALESCE(label_counts.other_validated_correct, 0) AS other_validated_correct,
-             COALESCE(label_counts.other_validated_incorrect, 0) AS other_validated_incorrect,
-             COALESCE(label_counts.other_not_validated, 0) AS other_not_validated
+             #$labelTypeSelectCols
       FROM user_stat
       INNER JOIN user_role ON user_stat.user_id = user_role.user_id
       -- Validations given.
@@ -1251,42 +1227,7 @@ class UserStatTable @Inject() (
                  COUNT(CASE WHEN correct THEN 1 END) AS labels_validated_correct,
                  COUNT(CASE WHEN NOT correct THEN 1 END) AS labels_validated_incorrect,
                  COUNT(CASE WHEN correct IS NULL THEN 1 END) AS labels_not_validated,
-                 COUNT(CASE WHEN label_type = 'CurbRamp' THEN 1 END) AS curb_ramp_labels,
-                 COUNT(CASE WHEN label_type = 'CurbRamp' AND correct THEN 1 END) AS curb_ramp_validated_correct,
-                 COUNT(CASE WHEN label_type = 'CurbRamp' AND NOT correct THEN 1 END) AS curb_ramp_validated_incorrect,
-                 COUNT(CASE WHEN label_type = 'CurbRamp' AND correct IS NULL THEN 1 END) AS curb_ramp_not_validated,
-                 COUNT(CASE WHEN label_type = 'NoCurbRamp' THEN 1 END) AS no_curb_ramp_labels,
-                 COUNT(CASE WHEN label_type = 'NoCurbRamp' AND correct THEN 1 END) AS no_curb_ramp_validated_correct,
-                 COUNT(CASE WHEN label_type = 'NoCurbRamp' AND NOT correct THEN 1 END) AS no_curb_ramp_validated_incorrect,
-                 COUNT(CASE WHEN label_type = 'NoCurbRamp' AND correct IS NULL THEN 1 END) AS no_curb_ramp_not_validated,
-                 COUNT(CASE WHEN label_type = 'Obstacle' THEN 1 END) AS obstacle_labels,
-                 COUNT(CASE WHEN label_type = 'Obstacle' AND correct THEN 1 END) AS obstacle_validated_correct,
-                 COUNT(CASE WHEN label_type = 'Obstacle' AND NOT correct THEN 1 END) AS obstacle_validated_incorrect,
-                 COUNT(CASE WHEN label_type = 'Obstacle' AND correct IS NULL THEN 1 END) AS obstacle_not_validated,
-                 COUNT(CASE WHEN label_type = 'SurfaceProblem' THEN 1 END) AS surface_problem_labels,
-                 COUNT(CASE WHEN label_type = 'SurfaceProblem' AND correct THEN 1 END) AS surface_problem_validated_correct,
-                 COUNT(CASE WHEN label_type = 'SurfaceProblem' AND NOT correct THEN 1 END) AS surface_problem_validated_incorrect,
-                 COUNT(CASE WHEN label_type = 'SurfaceProblem' AND correct IS NULL THEN 1 END) AS surface_problem_not_validated,
-                 COUNT(CASE WHEN label_type = 'NoSidewalk' THEN 1 END) AS no_sidewalk_labels,
-                 COUNT(CASE WHEN label_type = 'NoSidewalk' AND correct THEN 1 END) AS no_sidewalk_validated_correct,
-                 COUNT(CASE WHEN label_type = 'NoSidewalk' AND NOT correct THEN 1 END) AS no_sidewalk_validated_incorrect,
-                 COUNT(CASE WHEN label_type = 'NoSidewalk' AND correct IS NULL THEN 1 END) AS no_sidewalk_not_validated,
-                 COUNT(CASE WHEN label_type = 'Crosswalk' THEN 1 END) AS marked_crosswalk_labels,
-                 COUNT(CASE WHEN label_type = 'Crosswalk' AND correct THEN 1 END) AS marked_crosswalk_validated_correct,
-                 COUNT(CASE WHEN label_type = 'Crosswalk' AND NOT correct THEN 1 END) AS marked_crosswalk_validated_incorrect,
-                 COUNT(CASE WHEN label_type = 'Crosswalk' AND correct IS NULL THEN 1 END) AS marked_crosswalk_not_validated,
-                 COUNT(CASE WHEN label_type = 'Signal' THEN 1 END) AS pedestrian_signal_labels,
-                 COUNT(CASE WHEN label_type = 'Signal' AND correct THEN 1 END) AS pedestrian_signal_validated_correct,
-                 COUNT(CASE WHEN label_type = 'Signal' AND NOT correct THEN 1 END) AS pedestrian_signal_validated_incorrect,
-                 COUNT(CASE WHEN label_type = 'Signal' AND correct IS NULL THEN 1 END) AS pedestrian_signal_not_validated,
-                 COUNT(CASE WHEN label_type = 'Occlusion' THEN 1 END) AS cant_see_sidewalk_labels,
-                 COUNT(CASE WHEN label_type = 'Occlusion' AND correct THEN 1 END) AS cant_see_sidewalk_validated_correct,
-                 COUNT(CASE WHEN label_type = 'Occlusion' AND NOT correct THEN 1 END) AS cant_see_sidewalk_validated_incorrect,
-                 COUNT(CASE WHEN label_type = 'Occlusion' AND correct IS NULL THEN 1 END) AS cant_see_sidewalk_not_validated,
-                 COUNT(CASE WHEN label_type = 'Other' THEN 1 END) AS other_labels,
-                 COUNT(CASE WHEN label_type = 'Other' AND correct THEN 1 END) AS other_validated_correct,
-                 COUNT(CASE WHEN label_type = 'Other' AND NOT correct THEN 1 END) AS other_validated_incorrect,
-                 COUNT(CASE WHEN label_type = 'Other' AND correct IS NULL THEN 1 END) AS other_not_validated
+                 #$labelTypeCountCols
           FROM audit_task
           INNER JOIN label ON audit_task.audit_task_id = label.audit_task_id
           WHERE deleted = FALSE

--- a/app/service/UserService.scala
+++ b/app/service/UserService.scala
@@ -2,7 +2,7 @@ package service
 
 import com.google.inject.ImplementedBy
 import models.audit.{AuditTaskComment, AuditTaskInteractionTable, AuditTaskTable, OutdatedStreetForUser}
-import models.label.{LabelLocation, LabelTable}
+import models.label.{LabelLocation, LabelTable, LabelTypeEnum}
 import models.mission.MissionTable
 import models.region.Region
 import models.street.StreetEdge
@@ -288,7 +288,7 @@ object UserService {
 
   /** Label types shown in the per-type accuracy bars (the ones with canonical `--color-label-*` colors), in order. */
   private val PrimaryLabelTypes: Seq[String] =
-    Seq("CurbRamp", "NoCurbRamp", "Obstacle", "SurfaceProblem", "NoSidewalk", "Crosswalk", "Signal")
+    LabelTypeEnum.ordered.filter(LabelTypeEnum.primaryLabelTypes.contains).map(_.name)
 
   /**
    * Minimum validated labels of a type before it's eligible to be flagged as the user's "weakest" (avoids flagging a

--- a/test/controllers/api/StatsApiSpec.scala
+++ b/test/controllers/api/StatsApiSpec.scala
@@ -1,5 +1,6 @@
 package controllers.api
 
+import models.label.LabelTypeEnum
 import org.apache.pekko.stream.Materializer
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
@@ -108,6 +109,19 @@ class StatsApiSpec extends PlaySpec with GuiceOneAppPerSuite {
       explorable mustBe (open +- 0.001)
     }
 
+    // Data-independent. Per-type columns are read back by position, so a wrong sum or stray rating stats means a
+    // column landed in the wrong field.
+    "report per-label-type counts that sum to the total, with no rating stats on unrated types" in {
+      val labels = (contentAsJson(route(app, FakeRequest(GET, "/v3/api/overallStats")).get) \ "labels").as[JsObject]
+      val byType = LabelTypeEnum.ordered.map(lt => lt -> (labels \ lt.name).as[JsObject])
+
+      byType.map { case (_, stats) => (stats \ "count").as[Int] }.sum mustBe (labels \ "count").as[Int]
+      byType.filter(_._1.ratingScale == LabelTypeEnum.RatingScale.Unrated).foreach { case (_, stats) =>
+        (stats \ "count_with_severity").asOpt[Int] mustBe None
+        (stats \ "severity_mean").asOpt[Double] mustBe None
+      }
+    }
+
     "return 200 CSV containing the new km rows" in {
       val resp = route(app, FakeRequest(GET, "/v3/api/overallStats?filetype=csv")).get
       status(resp) mustBe OK
@@ -117,6 +131,22 @@ class StatsApiSpec extends PlaySpec with GuiceOneAppPerSuite {
         "km_explored_multiple_users", "km_explored_single_user", "km_needs_reaudit", "km_explorable",
         "km_by_status.open", "km_by_status.no_imagery", "km_by_status.closed", "km_by_status.disabled"
       ).foreach(key => body must include(key))
+    }
+  }
+
+  "GET /v3/api/userStats" should {
+    // Data-independent. Per-type columns are read back by position, so a wrong sum means one landed in the wrong field.
+    "report counts for every label type that sum to each user's totals" in {
+      val rows = contentAsJson(route(app, FakeRequest(GET, "/v3/api/userStats")).get).as[Seq[JsObject]]
+      rows.foreach { row =>
+        val byType = (row \ "stats_by_label_type").as[JsObject]
+        byType.keys mustBe LabelTypeEnum.labelTypeNames
+        def sumOf(field: String): Int = byType.values.map { (lt: JsValue) => (lt \ field).as[Int] }.sum
+        sumOf("labels") mustBe (row \ "labels").as[Int]
+        sumOf("validated_correct") mustBe (row \ "labels_validated_correct").as[Int]
+        sumOf("validated_incorrect") mustBe (row \ "labels_validated_incorrect").as[Int]
+        sumOf("not_validated") mustBe (row \ "labels_not_validated").as[Int]
+      }
     }
   }
 


### PR DESCRIPTION
resolves #3854

Removes the label type names still hand-written in Scala after #5125, so adding a label type no longer means hunting down string literals.

- **Stats SQL (`LabelTable.getOverallStatsForApi`, `UserStatTable.getStatsForApiWithFilters`):** the per-label-type columns for severity stats, AI agreement, and user label counts are generated from `LabelTypeEnum`, along with the positional parsers that read them back. One `(alias, expression)` list feeds the subquery, the top-level SELECT, and the parser order, so they can't drift. Before, a new label type would have crashed `/v3/api/userStats`, whose output fields already loop over every type.
- **`UserService.computeAccuracyByType`:** the primary-type list comes from `primaryLabelTypes` in canonical order. NoSidewalk now sorts after Signal in the dashboard accuracy bars.
- **`AccessScoreApiModels.shapefileTypeCode`:** an exhaustive `match` on the enum instead of a string map, so a new type without a shapefile code fails to compile.

## Testing
- `/v3/api/overallStats` and `/v3/api/userStats` output is byte-identical to `develop` on the Seattle dev DB (userStats compared with rows sorted by `user_id`, since that query has no ORDER BY).
- New `StatsApiSpec` checks: per-type counts sum to the totals for both endpoints, and unrated types carry no rating stats in overallStats.
- Stats, access-score, and `UserServiceMathSpec` specs pass locally (50/50).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RHCtcd7nK1ZCKpKs9GQ7kp
