### PR TITLE
Merge the users dump into sidewalk_login instead of replacing it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,11 +19,14 @@ args ?=
 wt ?=
 clean ?=
 force ?=
+replace ?=
 
 # `clean=1` (or true/yes) expands to the qa-worktree-stop --clean flag; anything else (incl. empty) expands to nothing.
 qa-stop-clean-flag = $(if $(filter 1 true yes,$(clean)),--clean,)
 # Same idiom for worktree-remove's `force=1`.
 worktree-force-flag = $(if $(filter 1 true yes,$(force)),--force,)
+# Same idiom for import-users' `replace=1`, which wipes the login schema instead of merging into it.
+import-users-replace-flag = $(if $(filter 1 true yes,$(replace)),--replace,)
 
 # Resolve which copy of qa-worktree.sh to run, then exec it with the args in $(1). The main repo is mounted at the
 # container's /home, so /home/tools/qa-worktree.sh is the script as it exists on whatever branch the MAIN checkout
@@ -180,7 +183,7 @@ worktree-remove:
 	@bash tools/worktree-remove.sh $(wt) --container $(web-container) $(worktree-force-flag)
 
 import-users:
-	@docker exec -it $(db-container) sh -c "/opt/scripts/import-users.sh"
+	@docker exec -it $(db-container) sh -c "/opt/scripts/import-users.sh $(import-users-replace-flag)"
 
 import-dump:
 	@docker exec -it $(db-container) sh -c "/opt/scripts/import-dump.sh $(db)"

--- a/db/dc-migration/README.md
+++ b/db/dc-migration/README.md
@@ -60,8 +60,9 @@ harness/postclean.sh                 # shape it like a city; prints the remainin
   at boot. The merge now re-points both at `sidewalk_login` first and refuses to drop the schema while anything in
   the city schema still depends on it. Re-running the merge after a fresh `make import-dump db=sidewalk_dc` over an
   already-merged `sidewalk_login` is a no-op for accounts (everything maps by id or email, nothing is inserted), so
-  a re-import never needs `make import-users`. Avoid that anyway: the July users dump predates 372, and nothing
-  would re-convert the restored login schema since every city's `play_evolutions` is already past it.
+  a re-import never needs `make import-users`. If you run it anyway, keep to its default merge: `replace=1` would
+  restore the July users dump, which predates 372, and nothing would re-convert that login schema since every city's
+  `play_evolutions` is already past it.
 
 ### Legacy-data decisions the overlay encodes (all Mikey's, 2026-09-02)
 

--- a/db/scripts/README.md
+++ b/db/scripts/README.md
@@ -100,21 +100,22 @@ or `ROLLBACK`. Edit the candidate-id list and the `search_path` (target city sch
 
 ## Gotchas
 
-- **Restores kill all DB connections.** `import-users.sh` and `import-dump.sh` call `pg_terminate_backend` on every
-  connection to the `sidewalk` database before dropping a schema. If the web app (`npm start`) is running, its
-  connections are killed — that's expected; sbt reconnects.
+- **Restores kill all DB connections.** `import-dump.sh` and `import-users.sh replace=1` call `pg_terminate_backend`
+  on every connection to the `sidewalk` database before dropping a schema. If the web app (`npm start`) is running,
+  its connections are killed — that's expected; sbt reconnects. A merging `import-users` leaves them alone.
 - **Merge `import-users`, don't replace it, once you have cities loaded.** Local test accounts exist only in your DB,
   and your cities' data points at them. A merge keeps them; `replace=1` drops them, and its `DROP SCHEMA ... CASCADE`
-  also deletes every city's foreign keys into `sidewalk_login`, so a replace means re-importing every city after it.
+  also takes every city's foreign keys into `sidewalk_login`, its `survey_question.survey_user_role` column (typed as
+  that schema's `role` enum) and its `label_comments_agg` view, so a replace means re-importing every city after it.
 - **Dump files must exist in `db/`, named `<schema>-dump`.** Real city dumps are **git-ignored**; only the small
   `sidewalk_init-dump` / `sidewalk_init_users-dump` templates are committed. The scripts now fail with a clear message
   if a dump is missing, rather than a cryptic `pg_restore` error.
 - **Schema / city names must be valid bare SQL identifiers** (`^[a-z][a-z0-9_]*$`) — they're interpolated into DDL.
   `import-dump.sh` and `create-new-schema.sh` validate this.
-- **Large restores can run for a minute or more.** The ~1 GB users dump is the slowest (~2.5 min to restore). The
-  restore scripts show a live elapsed-time clock and run `pg_restore` in parallel (`-j`), but it's still a wait —
-  don't assume it's hung. A merge adds time for each new account: ~3 min for ~300k (a refresh a few months
-  stale), ~20 min for all ~6M into a fresh DB, which is why the first import uses `replace=1`.
+- **Large restores can run for a minute or more.** The ~1 GB users dump is the slowest: ~2.5 min to restore with
+  `replace=1`, under a minute to load for a merge. The scripts show a live elapsed-time clock, so don't assume a
+  quiet one is hung. A merge then adds time for each new account: ~3 min for ~300k (a refresh a few months stale),
+  ~20 min for all ~6M into a fresh DB, which is why the first import uses `replace=1`.
 - **`init.sh` only runs on a fresh volume.** Editing it does nothing to an existing dev DB until you recreate the volume
   (`make docker-stop` + remove the db volume, or `docker compose down -v`).
 - **`reveal-or-hide-neighborhoods.sh` has a server mode** (test/prod) with different connection params; the default is

--- a/db/scripts/README.md
+++ b/db/scripts/README.md
@@ -28,7 +28,7 @@ maintenance operation.
 
 ```bash
 make dev                      # bring up the db container (init.sh runs automatically on a fresh volume)
-make import-users             # load the shared login schema (sidewalk_login) from sidewalk_users-dump
+make import-users replace=1   # load the shared login schema (sidewalk_login); later imports drop replace=1 to merge
 make import-dump db=sidewalk_seattle   # load a city's data from sidewalk_seattle-dump
 ```
 
@@ -40,7 +40,7 @@ are **git-ignored** and must be placed in `db/` yourself; see [`docs/dev-environ
 | File | `make` target | What it does | When you need it |
 |------|---------------|--------------|------------------|
 | `init.sh` | _(automatic on first boot)_ | Creates the `sidewalk` DB + roles, enables PostGIS, restores the committed **template** dumps (`sidewalk_init-dump`, `sidewalk_init_users-dump`), seeds the `SidewalkAI` user and read-only `readonly_user` role, and switches local auth to `trust`. | Never run by hand — it runs itself on a fresh db volume. |
-| `import-users.sh` | `make import-users` | Drops and reloads the shared **login schema** (`sidewalk_login`) from `sidewalk_users-dump` (~900 MB); re-grants read-only afterward. | After first boot, and whenever you refresh the users dump. |
+| `import-users.sh` | `make import-users [replace=1]` | **Merges** `sidewalk_users-dump` (~1 GB) into the shared **login schema** (`sidewalk_login`): adds the accounts you're missing, keeps every account you have (local test accounts included) and every city's foreign keys into the schema. `replace=1` drops and reloads the schema instead. See the script header for how the merge works (#3721). | After first boot (with `replace=1`), and whenever a newer city dump needs a newer users dump. |
 | `import-dump.sh` | `make import-dump db=<schema>` | Drops and reloads **one city's schema** from `<schema>-dump`; recreates the role, sets its `search_path`, re-grants read-only. | To load or refresh a city's data. |
 | `create-new-schema.sh` | `make create-new-schema name=<schema> donor=<schema>` | Builds a **brand-new empty city schema** by cloning a live city's structure plus its seed rows (evolutions, version, `config` + tutorial street, tags, surveys) and bumping the sequences. Refuses a donor that has applied an evolution beyond the checkout's highest, or whose top evolution is another branch's under the same number — accepted when its hash is the file's (`make` passes both), otherwise the other city schemas must agree with it. The committed template is not used here — it is frozen at evolution 252 and can't be replayed past 372 (#5198). | When standing up a city you don't yet have a dump for. |
 | `fill-new-schema.sh` | `make fill-new-schema` | Populates a new city's `street_edge` / `region` / priority tables from the **staging tables** (`qgis_road`, `qgis_region` — from `scripts/onboard_city.py` or a QGIS export), relocates the seeded tutorial street past the imported ids, sets the city center, map bounds, and zoom from the open regions, and prints what landed. | After `create-new-schema` + loading the staging SQL, to bring the city online. |
@@ -57,7 +57,7 @@ are **git-ignored** and must be placed in `db/` yourself; see [`docs/dev-environ
 **Fresh dev database (the common case):**
 
 ```
-make dev  ─▶  init.sh (auto)  ─▶  make import-users  ─▶  make import-dump db=sidewalk_seattle
+make dev  ─▶  init.sh (auto)  ─▶  make import-users replace=1  ─▶  make import-dump db=sidewalk_seattle
 ```
 
 **Standing up a brand-new city (no dump yet):** the whole sequence, from open data to a server-ready dump, is
@@ -103,13 +103,18 @@ or `ROLLBACK`. Edit the candidate-id list and the `search_path` (target city sch
 - **Restores kill all DB connections.** `import-users.sh` and `import-dump.sh` call `pg_terminate_backend` on every
   connection to the `sidewalk` database before dropping a schema. If the web app (`npm start`) is running, its
   connections are killed — that's expected; sbt reconnects.
+- **Merge `import-users`, don't replace it, once you have cities loaded.** Local test accounts exist only in your DB,
+  and your cities' data points at them. A merge keeps them; `replace=1` drops them, and its `DROP SCHEMA ... CASCADE`
+  also deletes every city's foreign keys into `sidewalk_login`, so a replace means re-importing every city after it.
 - **Dump files must exist in `db/`, named `<schema>-dump`.** Real city dumps are **git-ignored**; only the small
   `sidewalk_init-dump` / `sidewalk_init_users-dump` templates are committed. The scripts now fail with a clear message
   if a dump is missing, rather than a cryptic `pg_restore` error.
 - **Schema / city names must be valid bare SQL identifiers** (`^[a-z][a-z0-9_]*$`) — they're interpolated into DDL.
   `import-dump.sh` and `create-new-schema.sh` validate this.
-- **Large restores can run for a minute or more.** The ~900 MB users dump is the slowest (~1 min). The restore scripts
-  show a live elapsed-time clock and run `pg_restore` in parallel (`-j`), but it's still a wait — don't assume it's hung.
+- **Large restores can run for a minute or more.** The ~1 GB users dump is the slowest (~2.5 min to restore). The
+  restore scripts show a live elapsed-time clock and run `pg_restore` in parallel (`-j`), but it's still a wait —
+  don't assume it's hung. A merge adds time for each new account: ~3 min for ~300k (a refresh a few months
+  stale), ~20 min for all ~6M into a fresh DB, which is why the first import uses `replace=1`.
 - **`init.sh` only runs on a fresh volume.** Editing it does nothing to an existing dev DB until you recreate the volume
   (`make docker-stop` + remove the db volume, or `docker compose down -v`).
 - **`reveal-or-hide-neighborhoods.sh` has a server mode** (test/prod) with different connection params; the default is

--- a/db/scripts/import-users.sh
+++ b/db/scripts/import-users.sh
@@ -1,57 +1,299 @@
 #!/usr/bin/env bash
 # =====================================================================================================================
-# import-users.sh — (re)load the shared login schema (sidewalk_login) from the committed users dump.
+# import-users.sh — load the shared login schema (sidewalk_login) from the users dump, merging it into what you have.
 #
 # WHY THIS EXISTS: every city schema shares one `sidewalk_login` schema that holds accounts, roles, and auth data. The
 # dev/CI database seeds this from a binary `pg_restore` dump rather than regenerating it, because it's large and not
-# something evolutions produce. Run this once after the db container is up (and again whenever you refresh the dump).
+# something evolutions produce. Run this once after the db container is up, and again whenever a newer city dump needs
+# accounts that were made on prod after your last users import.
 #
-# HOW IT'S RUN:  make import-users   →   docker exec ... /opt/scripts/import-users.sh   (inside projectsidewalk-db).
+# TWO MODES (#3721):
+#   merge (default)  Adds the dump's accounts that you don't have yet and leaves every account you do have alone,
+#                    including test accounts you made locally. Those local accounts are what break a wipe: the cities
+#                    you already imported still point at them. Merging keeps them, and it also keeps every city's
+#                    foreign keys into sidewalk_login, which a DROP SCHEMA ... CASCADE deletes.
+#   --replace        Drop sidewalk_login and restore the dump from scratch. Use it for a fresh DB's first import, where
+#                    there's nothing to keep and merging every account would take ~20 min. Anywhere else it throws away
+#                    local-only accounts and every city's foreign keys into sidewalk_login; re-import your cities after.
+#
+# HOW A MERGE WORKS: pg_restore can only restore into the schema name the dump was made with, so the live schema steps
+# aside as sidewalk_login_parked while the dump restores as sidewalk_login. When the restore finishes, the
+# live schema gets its name again, the dump's copy becomes sidewalk_login_import, and one transaction copies the new
+# accounts across. Renaming a schema doesn't disturb anything pointing into it: the cities' foreign keys follow the
+# tables, not the name.
+#
+# HOW IT'S RUN:  make import-users [replace=1]  →  docker exec ... /opt/scripts/import-users.sh [--replace]
 # INPUT:         /opt/sidewalk_users-dump  (i.e. db/sidewalk_users-dump on the host; git-ignored — see dev-environment.md).
 #
 # GOTCHAS:
-#   - This force-terminates ALL connections to the `sidewalk` database before dropping the schema. If the web app
-#     (`npm start`) is running, its DB connections are killed; just let sbt reconnect.
-#   - The users dump is ~900 MB, so the restore takes a couple of minutes. run_with_progress shows a live clock; the
-#     restore runs in parallel (-j) to keep that as short as possible.
+#   - This force-terminates ALL connections to the `sidewalk` database first. If the web app (`npm start`) is running,
+#     its DB connections are killed; just let sbt reconnect, but don't use the site until the script finishes.
+#   - The users dump is ~1 GB, so the restore takes a couple of minutes, and a merge needs room for a second copy of
+#     the login tables while it runs.
+#   - A merged account keeps its user_id (what city data points at) but gets new row ids in the other login tables
+#     (login_info_id, user_role_id, ...): your local sign-ups already used some of the ids the dump has since handed
+#     out on prod. Nothing outside sidewalk_login refers to those ids.
+#   - An account you already have is never updated from the dump, even if it changed on prod since.
+#   - If a new account's username is taken by one of your local accounts, the local one is renamed (the script lists
+#     it) so the prod account, which city dumps may reference, can come in under its real name.
+#   - A merge copies the columns both copies of a table have, so a dump a few evolutions away from your local schema
+#     still merges. If it fails on a missing column, start the app once so your local schema catches up, then re-run.
 # =====================================================================================================================
 set -euo pipefail
 
 source /opt/scripts/helpers.sh
 
+DB=sidewalk
 DUMP=/opt/sidewalk_users-dump
-if [[ ! -f "$DUMP" ]]; then
-    echo "Error: users dump not found at $DUMP." >&2
-    echo "       Place 'sidewalk_users-dump' in the db/ directory (it is git-ignored; see docs/dev-environment.md)." >&2
+
+MODE=merge
+case "${1:-}" in
+  "") ;;
+  --replace) MODE=replace ;;
+  *)
+    echo "Usage: import-users.sh [--replace]" >&2
+    echo "       Typically run via: make import-users [replace=1]" >&2
     exit 1
+    ;;
+esac
+
+if [[ ! -f "$DUMP" ]]; then
+  echo "Error: users dump not found at $DUMP." >&2
+  echo "       Place 'sidewalk_users-dump' in the db/ directory (it is git-ignored; see docs/dev-environment.md)." >&2
+  exit 1
 fi
 
-# Terminate other backends first so the DROP doesn't hit "database is being accessed by other users" / lock waits, then
-# drop the login schema so the restore starts from a clean slate.
-psql -v ON_ERROR_STOP=1 -U postgres -d sidewalk <<-EOSQL
+# Recovers from a merge that stopped partway (also run up front, for a run killed outright): while the live schema is
+# parked, whatever holds the sidewalk_login name is a half-restored dump, so it's safe to drop.
+cleanup_merge() {
+  # client_min_messages hides the "skipping" and "drop cascades to" notices, which are routine here.
+  psql -q -v ON_ERROR_STOP=1 -U postgres -d "$DB" <<-'EOSQL'
+    SET client_min_messages = warning;
+    DO $$
+    BEGIN
+      IF EXISTS (SELECT FROM pg_namespace WHERE nspname = 'sidewalk_login_parked') THEN
+        RAISE WARNING 'Moving your login schema back into place after an interrupted merge.';
+        DROP SCHEMA IF EXISTS sidewalk_login CASCADE;
+        ALTER SCHEMA sidewalk_login_parked RENAME TO sidewalk_login;
+      END IF;
+    END $$;
+    DROP SCHEMA IF EXISTS sidewalk_login_import CASCADE;
+EOSQL
+}
+
+# Terminate other backends first so the DROP/RENAME doesn't hit lock waits.
+psql -v ON_ERROR_STOP=1 -U postgres -d "$DB" <<-EOSQL
     SELECT pg_terminate_backend(pg_stat_activity.pid)
     FROM pg_stat_activity
-    WHERE (pg_stat_activity.datname = 'sidewalk')
-    AND pid <> pg_backend_pid();
-
-    DROP SCHEMA IF EXISTS sidewalk_login CASCADE;
+    WHERE pg_stat_activity.datname = '$DB'
+      AND pid <> pg_backend_pid();
 EOSQL
 
-# -j 4: parallel restore (valid for the -Fc custom-format dump; we don't use --single-transaction) to speed up the
-# large users dump. Wrapped in run_with_progress so the multi-minute restore isn't a silent wait.
-run_with_progress "Restoring users dump (sidewalk_login)" \
-    pg_restore -U sidewalk -Fc -j 4 -d sidewalk "$DUMP"
+cleanup_merge
+trap cleanup_merge EXIT
 
-# The DROP SCHEMA above wiped readonly_user's grants on sidewalk_login, and the restored objects don't carry them, so
-# re-grant read-only access (mirrors init.sh and import-dump.sh) — otherwise DB exploration via readonly_user breaks
-# after every users re-import.
-psql -v ON_ERROR_STOP=1 -U sidewalk -d sidewalk <<-EOSQL
+has_login_schema=$(psql -At -U postgres -d "$DB" \
+  -c "SELECT EXISTS (SELECT FROM pg_namespace WHERE nspname = 'sidewalk_login');")
+if [[ "$MODE" == merge && "$has_login_schema" != t ]]; then
+  echo "No sidewalk_login schema yet, so there's nothing to merge into; restoring the dump as-is."
+  MODE=replace
+fi
+
+if [[ "$MODE" == replace ]]; then
+  psql -q -v ON_ERROR_STOP=1 -U postgres -d "$DB" -c "DROP SCHEMA IF EXISTS sidewalk_login CASCADE;"
+  # -j 4: parallel restore (valid for the -Fc custom-format dump; we don't use --single-transaction).
+  run_with_progress "Restoring users dump (sidewalk_login)" \
+    pg_restore -U sidewalk -Fc -j 4 -d "$DB" "$DUMP"
+else
+  psql -q -v ON_ERROR_STOP=1 -U postgres -d "$DB" -c "ALTER SCHEMA sidewalk_login RENAME TO sidewalk_login_parked;"
+  run_with_progress "Restoring users dump into a side schema" \
+    pg_restore -U sidewalk -Fc -j 4 -d "$DB" "$DUMP"
+  psql -q -v ON_ERROR_STOP=1 -U postgres -d "$DB" <<-'EOSQL'
+    BEGIN;
+    ALTER SCHEMA sidewalk_login RENAME TO sidewalk_login_import;
+    ALTER SCHEMA sidewalk_login_parked RENAME TO sidewalk_login;
+    COMMIT;
+EOSQL
+
+  echo "⏳ Merging new accounts into sidewalk_login..." >&2
+  psql -q -v ON_ERROR_STOP=1 -U sidewalk -d "$DB" <<-'EOSQL'
+    BEGIN;
+    -- The joins below run over millions of accounts; the dev server's 4 MB default spills every one of them to disk.
+    -- Parallel workers would share that memory through /dev/shm, which Docker caps at 64 MB, so they're turned off.
+    SET LOCAL work_mem = '256MB';
+    SET LOCAL max_parallel_workers_per_gather = 0;
+
+    -- Copies rows from the dump's copy of a login table into the live one and returns how many it copied. It takes
+    -- every column the two copies share except those in `skip`, so a dump that's an evolution or two away from the
+    -- local schema still lines up. A column whose type differs goes through text: that's how the dump's copy of the
+    -- `role` enum lands in the live one. `extra_cols` / `extra_vals` add columns the caller fills itself (a remapped
+    -- id), and `joins` picks which of the dump's rows to copy.
+    CREATE FUNCTION pg_temp.copy_rows(tbl text, skip text[], joins text, extra_cols text DEFAULT NULL,
+                                      extra_vals text DEFAULT NULL) RETURNS bigint LANGUAGE plpgsql AS $$
+    DECLARE
+      target_cols text;
+      source_cols text;
+      copied bigint;
+    BEGIN
+      WITH live_col AS (
+        SELECT attname, attnum, atttypid, atttypmod
+        FROM pg_attribute
+        WHERE attrelid = format('sidewalk_login.%I', tbl)::regclass AND attnum > 0 AND NOT attisdropped
+      ), import_col AS (
+        SELECT attname, atttypid
+        FROM pg_attribute
+        WHERE attrelid = format('sidewalk_login_import.%I', tbl)::regclass AND attnum > 0 AND NOT attisdropped
+      )
+      SELECT string_agg(format('%I', live_col.attname), ', ' ORDER BY live_col.attnum),
+             string_agg(CASE WHEN live_col.atttypid = import_col.atttypid
+                             THEN format('sidewalk_login_import.%I.%I', tbl, live_col.attname)
+                             ELSE format('sidewalk_login_import.%I.%I::text::%s', tbl, live_col.attname,
+                                         format_type(live_col.atttypid, live_col.atttypmod))
+                        END, ', ' ORDER BY live_col.attnum)
+      INTO target_cols, source_cols
+      FROM live_col
+      INNER JOIN import_col ON import_col.attname = live_col.attname
+      WHERE live_col.attname <> ALL (skip);
+
+      EXECUTE format('INSERT INTO sidewalk_login.%I (%s) SELECT %s FROM sidewalk_login_import.%I %s',
+                     tbl, concat_ws(', ', extra_cols, target_cols), concat_ws(', ', extra_vals, source_cols),
+                     tbl, joins);
+      GET DIAGNOSTICS copied = ROW_COUNT;
+      RETURN copied;
+    END $$;
+
+    -- A login table this script has no rule for would silently lose the dump's rows, so name it.
+    DO $$
+    DECLARE
+      unhandled text;
+    BEGIN
+      SELECT string_agg(tablename, ', ') INTO unhandled
+      FROM pg_tables
+      WHERE schemaname = 'sidewalk_login_import'
+        AND tablename <> ALL (
+          '{sidewalk_user,login_info,user_login_info,user_password_info,user_role,user_utm,partner}'
+        );
+      IF unhandled IS NOT NULL THEN
+        RAISE WARNING 'The dump has login tables this script does not merge: %. Add a rule for them to %.',
+          unhandled, 'import-users.sh';
+      END IF;
+    END $$;
+
+    -- The accounts to add: in the dump, but not here.
+    CREATE TEMP TABLE new_account ON COMMIT DROP AS
+    SELECT user_id FROM sidewalk_login_import.sidewalk_user
+    EXCEPT
+    SELECT user_id FROM sidewalk_login.sidewalk_user;
+    ALTER TABLE new_account ADD PRIMARY KEY (user_id);
+    ANALYZE new_account;
+
+    -- A local account holding a username that one of the new accounts has on prod gives the name up, keeping a short
+    -- piece of its user_id so the new name stays unique and within the 30-character limit.
+    CREATE TEMP TABLE renamed_account ON COMMIT DROP AS
+    SELECT user_id, username AS old_username, left(username, 21) || '_' || left(user_id, 8) AS new_username
+    FROM sidewalk_login.sidewalk_user
+    WHERE username IN (
+      SELECT sidewalk_user.username
+      FROM sidewalk_login_import.sidewalk_user
+      INNER JOIN new_account ON new_account.user_id = sidewalk_user.user_id
+    );
+    UPDATE sidewalk_login.sidewalk_user
+    SET username = renamed_account.new_username
+    FROM renamed_account
+    WHERE renamed_account.user_id = sidewalk_user.user_id;
+
+    -- The dump's login_info ids for newer accounts overlap the ones local sign-ups took from the same sequence, so
+    -- every merged login_info row gets a fresh id, and the two tables that point at login_info follow this map.
+    CREATE TEMP TABLE login_info_map ON COMMIT DROP AS
+    WITH merged_login_info AS (
+      SELECT DISTINCT user_login_info.login_info_id
+      FROM sidewalk_login_import.user_login_info
+      INNER JOIN new_account ON new_account.user_id = user_login_info.user_id
+    )
+    SELECT login_info_id AS old_id,
+           nextval(pg_get_serial_sequence('sidewalk_login.login_info', 'login_info_id')) AS new_id
+    FROM merged_login_info;
+    ALTER TABLE login_info_map ADD PRIMARY KEY (old_id);
+    ANALYZE login_info_map;
+
+    SELECT pg_temp.copy_rows('sidewalk_user', '{}',
+      'INNER JOIN new_account ON new_account.user_id = sidewalk_user.user_id') AS accounts_added \gset
+    SELECT pg_temp.copy_rows('login_info', '{login_info_id}',
+      'INNER JOIN login_info_map ON login_info_map.old_id = login_info.login_info_id',
+      'login_info_id', 'login_info_map.new_id') AS login_info_added \gset
+    SELECT pg_temp.copy_rows('user_login_info', '{user_login_info_id,login_info_id}',
+      'INNER JOIN new_account ON new_account.user_id = user_login_info.user_id
+       INNER JOIN login_info_map ON login_info_map.old_id = user_login_info.login_info_id',
+      'login_info_id', 'login_info_map.new_id') AS user_login_info_added \gset
+    SELECT pg_temp.copy_rows('user_password_info', '{user_password_info_id,login_info_id}',
+      'INNER JOIN login_info_map ON login_info_map.old_id = user_password_info.login_info_id',
+      'login_info_id', 'login_info_map.new_id') AS user_password_info_added \gset
+    SELECT pg_temp.copy_rows('user_role', '{user_role_id}',
+      'INNER JOIN new_account ON new_account.user_id = user_role.user_id') AS user_role_added \gset
+    SELECT pg_temp.copy_rows('user_utm', '{user_utm_id}',
+      'INNER JOIN new_account ON new_account.user_id = user_utm.user_id') AS user_utm_added \gset
+    -- Partners aren't owned by an account, so a dump partner comes in unless that city already has one by its name.
+    SELECT pg_temp.copy_rows('partner', '{partner_id}',
+      'WHERE NOT EXISTS (
+         SELECT FROM sidewalk_login.partner
+         WHERE sidewalk_login.partner.name = sidewalk_login_import.partner.name
+           AND sidewalk_login.partner.city_id IS NOT DISTINCT FROM sidewalk_login_import.partner.city_id
+       )') AS partner_added \gset
+
+    -- Anonymous clashes can number in the thousands (a city's login migration run locally gives its accounts different
+    -- user_ids than prod's run did), and nobody logs in to one, so only the other renamed accounts are listed.
+    CREATE TEMP TABLE renamed_login ON COMMIT DROP AS
+    SELECT renamed_account.old_username, renamed_account.new_username
+    FROM renamed_account
+    WHERE NOT EXISTS (
+      SELECT FROM sidewalk_login.user_role
+      WHERE user_role.user_id = renamed_account.user_id AND user_role.role::text = 'Anonymous'
+    );
+    SELECT (SELECT count(*) FROM renamed_account) AS renamed_count,
+           (SELECT count(*) FROM renamed_login) AS renamed_login_count,
+           (SELECT count(*) > 0 FROM renamed_login) AS any_renamed_login,
+           (SELECT count(*) > 25 FROM renamed_login) AS more_renamed_login \gset
+    \if :any_renamed_login
+      \echo 'These accounts the dump does not have used a username one of its new accounts has, so they were renamed:'
+      SELECT format('  %s -> %s', old_username, new_username) FROM renamed_login ORDER BY old_username LIMIT 25
+      \g (format=unaligned tuples_only=on)
+      \if :more_renamed_login
+        \echo '  (first 25 of' :renamed_login_count 'shown)'
+      \endif
+    \endif
+
+    SELECT format('✓ Added %s new accounts (%s login_info, %s user_login_info, %s user_password_info, %s user_role, '
+                  '%s user_utm rows) and %s partners. Kept %s accounts the dump does not have, renaming %s of them '
+                  'for a username clash.',
+                  :accounts_added, :login_info_added, :user_login_info_added, :user_password_info_added,
+                  :user_role_added, :user_utm_added, :partner_added,
+                  (SELECT count(*)
+                   FROM sidewalk_login.sidewalk_user
+                   WHERE NOT EXISTS (
+                     SELECT FROM sidewalk_login_import.sidewalk_user
+                     WHERE sidewalk_login_import.sidewalk_user.user_id = sidewalk_login.sidewalk_user.user_id
+                   )),
+                  :renamed_count)
+    \g (format=unaligned tuples_only=on)
+
+    COMMIT;
+EOSQL
+
+  cleanup_merge
+  # The planner's row counts for these tables are stale after a big merge (e.g. into the tiny first-boot schema).
+  psql -q -v ON_ERROR_STOP=1 -U sidewalk -d "$DB" -c "ANALYZE sidewalk_login.sidewalk_user, sidewalk_login.login_info,
+    sidewalk_login.user_login_info, sidewalk_login.user_password_info, sidewalk_login.user_role,
+    sidewalk_login.user_utm, sidewalk_login.partner;"
+fi
+
+# A fresh restore's objects don't carry readonly_user's grants, so re-grant them (mirrors init.sh and import-dump.sh).
+psql -q -v ON_ERROR_STOP=1 -U sidewalk -d "$DB" <<-EOSQL
     DO \$\$
     BEGIN
-        IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'readonly_user') THEN
-            GRANT USAGE ON SCHEMA sidewalk_login TO readonly_user;
-            GRANT SELECT ON ALL TABLES IN SCHEMA sidewalk_login TO readonly_user;
-            ALTER DEFAULT PRIVILEGES FOR ROLE sidewalk IN SCHEMA sidewalk_login GRANT SELECT ON TABLES TO readonly_user;
-        END IF;
+      IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'readonly_user') THEN
+        GRANT USAGE ON SCHEMA sidewalk_login TO readonly_user;
+        GRANT SELECT ON ALL TABLES IN SCHEMA sidewalk_login TO readonly_user;
+        ALTER DEFAULT PRIVILEGES FOR ROLE sidewalk IN SCHEMA sidewalk_login GRANT SELECT ON TABLES TO readonly_user;
+      END IF;
     END \$\$;
 EOSQL

--- a/db/scripts/import-users.sh
+++ b/db/scripts/import-users.sh
@@ -10,34 +10,37 @@
 # TWO MODES (#3721):
 #   merge (default)  Adds the dump's accounts that you don't have yet and leaves every account you do have alone,
 #                    including test accounts you made locally. Those local accounts are what break a wipe: the cities
-#                    you already imported still point at them. Merging keeps them, and it also keeps every city's
-#                    foreign keys into sidewalk_login, which a DROP SCHEMA ... CASCADE deletes.
+#                    you already imported still point at them. A merge only writes rows, so the live schema's structure,
+#                    and everything in the cities that depends on it, stays as it is.
 #   --replace        Drop sidewalk_login and restore the dump from scratch. Use it for a fresh DB's first import, where
-#                    there's nothing to keep and merging every account would take ~20 min. Anywhere else it throws away
-#                    local-only accounts and every city's foreign keys into sidewalk_login; re-import your cities after.
+#                    there's nothing to keep and merging every account would take ~20 min. Anywhere else it's
+#                    destructive: DROP SCHEMA ... CASCADE also drops every city's foreign keys into sidewalk_login,
+#                    its survey_question.survey_user_role column (typed as the schema's `role` enum) and its
+#                    label_comments_agg view, so re-import every city after it.
 #
-# HOW A MERGE WORKS: pg_restore can only restore into the schema name the dump was made with, so the live schema steps
-# aside as sidewalk_login_parked while the dump restores as sidewalk_login. When the restore finishes, the
-# live schema gets its name again, the dump's copy becomes sidewalk_login_import, and one transaction copies the new
-# accounts across. Renaming a schema doesn't disturb anything pointing into it: the cities' foreign keys follow the
-# tables, not the name.
+# HOW A MERGE WORKS: pg_restore can only restore into the schema name the dump was made with, so the dump is turned
+# into SQL, and its schema name is rewritten to sidewalk_login_import on the way into psql. Only the table definitions
+# and the COPY/setval lines name the schema, so data rows pass through untouched. One transaction then copies the new
+# accounts across. The live schema is never renamed or dropped, so the app can keep running meanwhile.
 #
 # HOW IT'S RUN:  make import-users [replace=1]  →  docker exec ... /opt/scripts/import-users.sh [--replace]
 # INPUT:         /opt/sidewalk_users-dump  (i.e. db/sidewalk_users-dump on the host; git-ignored — see dev-environment.md).
 #
 # GOTCHAS:
-#   - This force-terminates ALL connections to the `sidewalk` database first. If the web app (`npm start`) is running,
-#     its DB connections are killed; just let sbt reconnect, but don't use the site until the script finishes.
-#   - The users dump is ~1 GB, so the restore takes a couple of minutes, and a merge needs room for a second copy of
-#     the login tables while it runs.
+#   - --replace force-terminates ALL connections to the `sidewalk` database first. If the web app (`npm start`) is
+#     running, its DB connections are killed; just let sbt reconnect.
+#   - The users dump is ~1 GB, so loading it takes a minute or two, and a merge needs room for a second copy of the
+#     login tables while it runs.
 #   - A merged account keeps its user_id (what city data points at) but gets new row ids in the other login tables
 #     (login_info_id, user_role_id, ...): your local sign-ups already used some of the ids the dump has since handed
 #     out on prod. Nothing outside sidewalk_login refers to those ids.
-#   - An account you already have is never updated from the dump, even if it changed on prod since.
-#   - If a new account's username is taken by one of your local accounts, the local one is renamed (the script lists
-#     it) so the prod account, which city dumps may reference, can come in under its real name.
-#   - A merge copies the columns both copies of a table have, so a dump a few evolutions away from your local schema
-#     still merges. If it fails on a missing column, start the app once so your local schema catches up, then re-run.
+#   - An account you already have is never updated from the dump, even if it changed on prod since. The exception is a
+#     clash: the app finds accounts by username and by email, so if a new account has the username or email of one you
+#     have, yours gives it up (the script lists which). The new account may be what a city dump references.
+#   - A merge copies the columns both copies of a table have. It warns about columns only the dump has (start the app
+#     once so your schema catches up, then re-run) and fails on a required column only yours has (get a newer dump).
+#   - It moves rows, not structure. Constraints and indexes the dump has but your schema lacks are listed, not added:
+#     one could fail on your local data, and `--replace` is the way to take prod's structure wholesale.
 # =====================================================================================================================
 set -euo pipefail
 
@@ -63,231 +66,45 @@ if [[ ! -f "$DUMP" ]]; then
   exit 1
 fi
 
-# Recovers from a merge that stopped partway (also run up front, for a run killed outright): while the live schema is
-# parked, whatever holds the sidewalk_login name is a half-restored dump, so it's safe to drop.
-cleanup_merge() {
-  # client_min_messages hides the "skipping" and "drop cascades to" notices, which are routine here.
-  psql -q -v ON_ERROR_STOP=1 -U postgres -d "$DB" <<-'EOSQL'
-    SET client_min_messages = warning;
-    DO $$
-    BEGIN
-      IF EXISTS (SELECT FROM pg_namespace WHERE nspname = 'sidewalk_login_parked') THEN
-        RAISE WARNING 'Moving your login schema back into place after an interrupted merge.';
-        DROP SCHEMA IF EXISTS sidewalk_login CASCADE;
-        ALTER SCHEMA sidewalk_login_parked RENAME TO sidewalk_login;
-      END IF;
-    END $$;
-    DROP SCHEMA IF EXISTS sidewalk_login_import CASCADE;
-EOSQL
-}
+# A second run would load into, and then drop, the side schema the first one is using.
+exec 9>/tmp/import-users.lock
+if ! flock -n 9; then
+  echo "Error: another import-users is already running." >&2
+  exit 1
+fi
 
-# Terminate other backends first so the DROP/RENAME doesn't hit lock waits.
-psql -v ON_ERROR_STOP=1 -U postgres -d "$DB" <<-EOSQL
+# -X skips any ~/.psqlrc, which could add output to what's parsed here.
+has_login_schema=$(psql -X -At -U postgres -d "$DB" \
+  -c "SELECT EXISTS (SELECT FROM pg_namespace WHERE nspname = 'sidewalk_login');")
+case "$has_login_schema" in
+  t) ;;
+  f)
+    if [[ "$MODE" == merge ]]; then
+      echo "No sidewalk_login schema yet, so there's nothing to merge into; restoring the dump as-is."
+      MODE=replace
+    fi
+    ;;
+  *)
+    echo "Error: couldn't tell whether sidewalk_login exists; psql returned: $has_login_schema" >&2
+    exit 1
+    ;;
+esac
+
+if [[ "$MODE" == replace ]]; then
+  # Terminate other backends first so the DROP doesn't hit lock waits.
+  psql -X -v ON_ERROR_STOP=1 -U postgres -d "$DB" <<-EOSQL
     SELECT pg_terminate_backend(pg_stat_activity.pid)
     FROM pg_stat_activity
     WHERE pg_stat_activity.datname = '$DB'
       AND pid <> pg_backend_pid();
 EOSQL
-
-cleanup_merge
-trap cleanup_merge EXIT
-
-has_login_schema=$(psql -At -U postgres -d "$DB" \
-  -c "SELECT EXISTS (SELECT FROM pg_namespace WHERE nspname = 'sidewalk_login');")
-if [[ "$MODE" == merge && "$has_login_schema" != t ]]; then
-  echo "No sidewalk_login schema yet, so there's nothing to merge into; restoring the dump as-is."
-  MODE=replace
-fi
-
-if [[ "$MODE" == replace ]]; then
-  psql -q -v ON_ERROR_STOP=1 -U postgres -d "$DB" -c "DROP SCHEMA IF EXISTS sidewalk_login CASCADE;"
+  psql -X -q -v ON_ERROR_STOP=1 -U postgres -d "$DB" -c "DROP SCHEMA IF EXISTS sidewalk_login CASCADE;"
   # -j 4: parallel restore (valid for the -Fc custom-format dump; we don't use --single-transaction).
   run_with_progress "Restoring users dump (sidewalk_login)" \
     pg_restore -U sidewalk -Fc -j 4 -d "$DB" "$DUMP"
-else
-  psql -q -v ON_ERROR_STOP=1 -U postgres -d "$DB" -c "ALTER SCHEMA sidewalk_login RENAME TO sidewalk_login_parked;"
-  run_with_progress "Restoring users dump into a side schema" \
-    pg_restore -U sidewalk -Fc -j 4 -d "$DB" "$DUMP"
-  psql -q -v ON_ERROR_STOP=1 -U postgres -d "$DB" <<-'EOSQL'
-    BEGIN;
-    ALTER SCHEMA sidewalk_login RENAME TO sidewalk_login_import;
-    ALTER SCHEMA sidewalk_login_parked RENAME TO sidewalk_login;
-    COMMIT;
-EOSQL
 
-  echo "⏳ Merging new accounts into sidewalk_login..." >&2
-  psql -q -v ON_ERROR_STOP=1 -U sidewalk -d "$DB" <<-'EOSQL'
-    BEGIN;
-    -- The joins below run over millions of accounts; the dev server's 4 MB default spills every one of them to disk.
-    -- Parallel workers would share that memory through /dev/shm, which Docker caps at 64 MB, so they're turned off.
-    SET LOCAL work_mem = '256MB';
-    SET LOCAL max_parallel_workers_per_gather = 0;
-
-    -- Copies rows from the dump's copy of a login table into the live one and returns how many it copied. It takes
-    -- every column the two copies share except those in `skip`, so a dump that's an evolution or two away from the
-    -- local schema still lines up. A column whose type differs goes through text: that's how the dump's copy of the
-    -- `role` enum lands in the live one. `extra_cols` / `extra_vals` add columns the caller fills itself (a remapped
-    -- id), and `joins` picks which of the dump's rows to copy.
-    CREATE FUNCTION pg_temp.copy_rows(tbl text, skip text[], joins text, extra_cols text DEFAULT NULL,
-                                      extra_vals text DEFAULT NULL) RETURNS bigint LANGUAGE plpgsql AS $$
-    DECLARE
-      target_cols text;
-      source_cols text;
-      copied bigint;
-    BEGIN
-      WITH live_col AS (
-        SELECT attname, attnum, atttypid, atttypmod
-        FROM pg_attribute
-        WHERE attrelid = format('sidewalk_login.%I', tbl)::regclass AND attnum > 0 AND NOT attisdropped
-      ), import_col AS (
-        SELECT attname, atttypid
-        FROM pg_attribute
-        WHERE attrelid = format('sidewalk_login_import.%I', tbl)::regclass AND attnum > 0 AND NOT attisdropped
-      )
-      SELECT string_agg(format('%I', live_col.attname), ', ' ORDER BY live_col.attnum),
-             string_agg(CASE WHEN live_col.atttypid = import_col.atttypid
-                             THEN format('sidewalk_login_import.%I.%I', tbl, live_col.attname)
-                             ELSE format('sidewalk_login_import.%I.%I::text::%s', tbl, live_col.attname,
-                                         format_type(live_col.atttypid, live_col.atttypmod))
-                        END, ', ' ORDER BY live_col.attnum)
-      INTO target_cols, source_cols
-      FROM live_col
-      INNER JOIN import_col ON import_col.attname = live_col.attname
-      WHERE live_col.attname <> ALL (skip);
-
-      EXECUTE format('INSERT INTO sidewalk_login.%I (%s) SELECT %s FROM sidewalk_login_import.%I %s',
-                     tbl, concat_ws(', ', extra_cols, target_cols), concat_ws(', ', extra_vals, source_cols),
-                     tbl, joins);
-      GET DIAGNOSTICS copied = ROW_COUNT;
-      RETURN copied;
-    END $$;
-
-    -- A login table this script has no rule for would silently lose the dump's rows, so name it.
-    DO $$
-    DECLARE
-      unhandled text;
-    BEGIN
-      SELECT string_agg(tablename, ', ') INTO unhandled
-      FROM pg_tables
-      WHERE schemaname = 'sidewalk_login_import'
-        AND tablename <> ALL (
-          '{sidewalk_user,login_info,user_login_info,user_password_info,user_role,user_utm,partner}'
-        );
-      IF unhandled IS NOT NULL THEN
-        RAISE WARNING 'The dump has login tables this script does not merge: %. Add a rule for them to %.',
-          unhandled, 'import-users.sh';
-      END IF;
-    END $$;
-
-    -- The accounts to add: in the dump, but not here.
-    CREATE TEMP TABLE new_account ON COMMIT DROP AS
-    SELECT user_id FROM sidewalk_login_import.sidewalk_user
-    EXCEPT
-    SELECT user_id FROM sidewalk_login.sidewalk_user;
-    ALTER TABLE new_account ADD PRIMARY KEY (user_id);
-    ANALYZE new_account;
-
-    -- A local account holding a username that one of the new accounts has on prod gives the name up, keeping a short
-    -- piece of its user_id so the new name stays unique and within the 30-character limit.
-    CREATE TEMP TABLE renamed_account ON COMMIT DROP AS
-    SELECT user_id, username AS old_username, left(username, 21) || '_' || left(user_id, 8) AS new_username
-    FROM sidewalk_login.sidewalk_user
-    WHERE username IN (
-      SELECT sidewalk_user.username
-      FROM sidewalk_login_import.sidewalk_user
-      INNER JOIN new_account ON new_account.user_id = sidewalk_user.user_id
-    );
-    UPDATE sidewalk_login.sidewalk_user
-    SET username = renamed_account.new_username
-    FROM renamed_account
-    WHERE renamed_account.user_id = sidewalk_user.user_id;
-
-    -- The dump's login_info ids for newer accounts overlap the ones local sign-ups took from the same sequence, so
-    -- every merged login_info row gets a fresh id, and the two tables that point at login_info follow this map.
-    CREATE TEMP TABLE login_info_map ON COMMIT DROP AS
-    WITH merged_login_info AS (
-      SELECT DISTINCT user_login_info.login_info_id
-      FROM sidewalk_login_import.user_login_info
-      INNER JOIN new_account ON new_account.user_id = user_login_info.user_id
-    )
-    SELECT login_info_id AS old_id,
-           nextval(pg_get_serial_sequence('sidewalk_login.login_info', 'login_info_id')) AS new_id
-    FROM merged_login_info;
-    ALTER TABLE login_info_map ADD PRIMARY KEY (old_id);
-    ANALYZE login_info_map;
-
-    SELECT pg_temp.copy_rows('sidewalk_user', '{}',
-      'INNER JOIN new_account ON new_account.user_id = sidewalk_user.user_id') AS accounts_added \gset
-    SELECT pg_temp.copy_rows('login_info', '{login_info_id}',
-      'INNER JOIN login_info_map ON login_info_map.old_id = login_info.login_info_id',
-      'login_info_id', 'login_info_map.new_id') AS login_info_added \gset
-    SELECT pg_temp.copy_rows('user_login_info', '{user_login_info_id,login_info_id}',
-      'INNER JOIN new_account ON new_account.user_id = user_login_info.user_id
-       INNER JOIN login_info_map ON login_info_map.old_id = user_login_info.login_info_id',
-      'login_info_id', 'login_info_map.new_id') AS user_login_info_added \gset
-    SELECT pg_temp.copy_rows('user_password_info', '{user_password_info_id,login_info_id}',
-      'INNER JOIN login_info_map ON login_info_map.old_id = user_password_info.login_info_id',
-      'login_info_id', 'login_info_map.new_id') AS user_password_info_added \gset
-    SELECT pg_temp.copy_rows('user_role', '{user_role_id}',
-      'INNER JOIN new_account ON new_account.user_id = user_role.user_id') AS user_role_added \gset
-    SELECT pg_temp.copy_rows('user_utm', '{user_utm_id}',
-      'INNER JOIN new_account ON new_account.user_id = user_utm.user_id') AS user_utm_added \gset
-    -- Partners aren't owned by an account, so a dump partner comes in unless that city already has one by its name.
-    SELECT pg_temp.copy_rows('partner', '{partner_id}',
-      'WHERE NOT EXISTS (
-         SELECT FROM sidewalk_login.partner
-         WHERE sidewalk_login.partner.name = sidewalk_login_import.partner.name
-           AND sidewalk_login.partner.city_id IS NOT DISTINCT FROM sidewalk_login_import.partner.city_id
-       )') AS partner_added \gset
-
-    -- Anonymous clashes can number in the thousands (a city's login migration run locally gives its accounts different
-    -- user_ids than prod's run did), and nobody logs in to one, so only the other renamed accounts are listed.
-    CREATE TEMP TABLE renamed_login ON COMMIT DROP AS
-    SELECT renamed_account.old_username, renamed_account.new_username
-    FROM renamed_account
-    WHERE NOT EXISTS (
-      SELECT FROM sidewalk_login.user_role
-      WHERE user_role.user_id = renamed_account.user_id AND user_role.role::text = 'Anonymous'
-    );
-    SELECT (SELECT count(*) FROM renamed_account) AS renamed_count,
-           (SELECT count(*) FROM renamed_login) AS renamed_login_count,
-           (SELECT count(*) > 0 FROM renamed_login) AS any_renamed_login,
-           (SELECT count(*) > 25 FROM renamed_login) AS more_renamed_login \gset
-    \if :any_renamed_login
-      \echo 'These accounts the dump does not have used a username one of its new accounts has, so they were renamed:'
-      SELECT format('  %s -> %s', old_username, new_username) FROM renamed_login ORDER BY old_username LIMIT 25
-      \g (format=unaligned tuples_only=on)
-      \if :more_renamed_login
-        \echo '  (first 25 of' :renamed_login_count 'shown)'
-      \endif
-    \endif
-
-    SELECT format('✓ Added %s new accounts (%s login_info, %s user_login_info, %s user_password_info, %s user_role, '
-                  '%s user_utm rows) and %s partners. Kept %s accounts the dump does not have, renaming %s of them '
-                  'for a username clash.',
-                  :accounts_added, :login_info_added, :user_login_info_added, :user_password_info_added,
-                  :user_role_added, :user_utm_added, :partner_added,
-                  (SELECT count(*)
-                   FROM sidewalk_login.sidewalk_user
-                   WHERE NOT EXISTS (
-                     SELECT FROM sidewalk_login_import.sidewalk_user
-                     WHERE sidewalk_login_import.sidewalk_user.user_id = sidewalk_login.sidewalk_user.user_id
-                   )),
-                  :renamed_count)
-    \g (format=unaligned tuples_only=on)
-
-    COMMIT;
-EOSQL
-
-  cleanup_merge
-  # The planner's row counts for these tables are stale after a big merge (e.g. into the tiny first-boot schema).
-  psql -q -v ON_ERROR_STOP=1 -U sidewalk -d "$DB" -c "ANALYZE sidewalk_login.sidewalk_user, sidewalk_login.login_info,
-    sidewalk_login.user_login_info, sidewalk_login.user_password_info, sidewalk_login.user_role,
-    sidewalk_login.user_utm, sidewalk_login.partner;"
-fi
-
-# A fresh restore's objects don't carry readonly_user's grants, so re-grant them (mirrors init.sh and import-dump.sh).
-psql -q -v ON_ERROR_STOP=1 -U sidewalk -d "$DB" <<-EOSQL
+  # The restored objects don't carry readonly_user's grants, so re-grant them (mirrors init.sh and import-dump.sh).
+  psql -X -q -v ON_ERROR_STOP=1 -U sidewalk -d "$DB" <<-EOSQL
     DO \$\$
     BEGIN
       IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'readonly_user') THEN
@@ -297,3 +114,277 @@ psql -q -v ON_ERROR_STOP=1 -U sidewalk -d "$DB" <<-EOSQL
       END IF;
     END \$\$;
 EOSQL
+  exit 0
+fi
+
+drop_import_schema() {
+  psql -X -q -v ON_ERROR_STOP=1 -U sidewalk -d "$DB" \
+    -c "SET client_min_messages = warning; DROP SCHEMA IF EXISTS sidewalk_login_import CASCADE;"
+}
+
+# Loads the dump into sidewalk_login_import. It skips the dump's indexes and constraints: the merge doesn't need them,
+# and building them over ~6M rows would be most of the load time.
+load_import_schema() {
+  pg_restore --section=pre-data -f - "$DUMP" \
+    | sed -E 's/\bsidewalk_login\b/sidewalk_login_import/g' \
+    | psql -X -q -v ON_ERROR_STOP=1 -U sidewalk -d "$DB"
+  pg_restore --data-only -f - "$DUMP" \
+    | sed -E '/^(COPY|SELECT pg_catalog\.setval)/ s/\bsidewalk_login\b/sidewalk_login_import/' \
+    | psql -X -q -v ON_ERROR_STOP=1 -U sidewalk -d "$DB"
+  # Without row counts the planner guesses these tables are tiny and picks nested loops over millions of rows.
+  psql -X -q -v ON_ERROR_STOP=1 -U sidewalk -d "$DB" <<-'EOSQL'
+    DO $$
+    DECLARE
+      tbl text;
+    BEGIN
+      FOR tbl IN SELECT tablename FROM pg_tables WHERE schemaname = 'sidewalk_login_import' LOOP
+        EXECUTE format('ANALYZE sidewalk_login_import.%I', tbl);
+      END LOOP;
+    END $$;
+EOSQL
+}
+
+drop_import_schema
+trap drop_import_schema EXIT
+run_with_progress "Loading users dump into a side schema" load_import_schema
+
+# The dump's constraint and index names, so the merge can point out any the live schema lacks.
+dump_objects=$(pg_restore -l "$DUMP" \
+  | awk '/^[0-9]+;/ && ($4 == "INDEX" || $4 == "CONSTRAINT" || ($4 == "FK" && $5 == "CONSTRAINT")) {print $(NF-1)}' \
+  | paste -sd, -)
+
+echo "⏳ Merging new accounts into sidewalk_login..." >&2
+psql -X -q -v ON_ERROR_STOP=1 -v dump_objects="{$dump_objects}" -U sidewalk -d "$DB" <<-'EOSQL'
+  BEGIN;
+  -- The joins below run over millions of accounts; the dev server's 4 MB default spills every one of them to disk.
+  -- Parallel workers would share that memory through /dev/shm, which Docker caps at 64 MB, so they're turned off.
+  SET LOCAL work_mem = '256MB';
+  SET LOCAL max_parallel_workers_per_gather = 0;
+
+  -- Copies rows from the dump's copy of a login table into the live one and returns how many it copied. It takes
+  -- every column the two copies share except those in `skip`, so a dump that's an evolution or two away from the
+  -- local schema still lines up. A column whose type differs goes through text: that's how the dump's copy of the
+  -- `role` enum lands in the live one. `extra_cols` / `extra_vals` add columns the caller fills itself (a remapped
+  -- id), and `joins` picks which of the dump's rows to copy.
+  CREATE FUNCTION pg_temp.copy_rows(tbl text, skip text[], joins text, extra_cols text DEFAULT NULL,
+                                    extra_vals text DEFAULT NULL) RETURNS bigint LANGUAGE plpgsql AS $$
+  DECLARE
+    target_cols text;
+    source_cols text;
+    copied bigint;
+  BEGIN
+    WITH live_col AS (
+      SELECT attname, attnum, atttypid, atttypmod
+      FROM pg_attribute
+      WHERE attrelid = format('sidewalk_login.%I', tbl)::regclass AND attnum > 0 AND NOT attisdropped
+    ), import_col AS (
+      SELECT attname, atttypid
+      FROM pg_attribute
+      WHERE attrelid = format('sidewalk_login_import.%I', tbl)::regclass AND attnum > 0 AND NOT attisdropped
+    )
+    SELECT string_agg(format('%I', live_col.attname), ', ' ORDER BY live_col.attnum),
+           string_agg(CASE WHEN live_col.atttypid = import_col.atttypid
+                           THEN format('sidewalk_login_import.%I.%I', tbl, live_col.attname)
+                           ELSE format('sidewalk_login_import.%I.%I::text::%s', tbl, live_col.attname,
+                                       format_type(live_col.atttypid, live_col.atttypmod))
+                      END, ', ' ORDER BY live_col.attnum)
+    INTO target_cols, source_cols
+    FROM live_col
+    INNER JOIN import_col ON import_col.attname = live_col.attname
+    WHERE live_col.attname <> ALL (skip);
+
+    EXECUTE format('INSERT INTO sidewalk_login.%I (%s) SELECT %s FROM sidewalk_login_import.%I %s',
+                   tbl, concat_ws(', ', extra_cols, target_cols), concat_ws(', ', extra_vals, source_cols),
+                   tbl, joins);
+    GET DIAGNOSTICS copied = ROW_COUNT;
+    RETURN copied;
+  END $$;
+
+  -- What a merge can't carry over is named rather than silently dropped.
+  DO $$
+  DECLARE
+    unhandled text;
+    dump_only_columns text;
+  BEGIN
+    SELECT string_agg(tablename, ', ') INTO unhandled
+    FROM pg_tables
+    WHERE schemaname = 'sidewalk_login_import'
+      AND tablename <> ALL (
+        '{sidewalk_user,login_info,user_login_info,user_password_info,user_role,user_utm,partner}'
+      );
+    IF unhandled IS NOT NULL THEN
+      RAISE WARNING 'The dump has login tables this script does not merge: %. Add a rule for them to %.',
+        unhandled, 'import-users.sh';
+    END IF;
+
+    SELECT string_agg(format('%s.%s', table_name, column_name), ', ' ORDER BY table_name, ordinal_position)
+    INTO dump_only_columns
+    FROM information_schema.columns
+    WHERE table_schema = 'sidewalk_login_import'
+      AND table_name IN (SELECT table_name FROM information_schema.tables WHERE table_schema = 'sidewalk_login')
+      AND (table_name, column_name) NOT IN (
+        SELECT table_name, column_name FROM information_schema.columns WHERE table_schema = 'sidewalk_login'
+      );
+    IF dump_only_columns IS NOT NULL THEN
+      RAISE WARNING 'The dump has columns your login schema lacks, so merged accounts come in without them: %. '
+        'Start the app once so your schema catches up to the dump, then re-run.', dump_only_columns;
+    END IF;
+  END $$;
+
+  WITH dump_object AS (SELECT unnest(:'dump_objects'::text[]) AS name)
+  SELECT coalesce(string_agg(name, ', ' ORDER BY name), '') AS missing_objects, count(*) > 0 AS any_missing_objects
+  FROM dump_object
+  WHERE name NOT IN (SELECT conname FROM pg_constraint WHERE connamespace = 'sidewalk_login'::regnamespace)
+    AND name NOT IN (SELECT relname FROM pg_class WHERE relnamespace = 'sidewalk_login'::regnamespace AND relkind = 'i')
+  \gset
+  \if :any_missing_objects
+    \warn 'WARNING:  Your login schema lacks these constraints/indexes the dump has:' :missing_objects
+    \warn '          A merge only moves rows; replace=1 takes the dump''s structure (then re-import every city).'
+  \endif
+
+  -- The accounts to add: in the dump, but not here.
+  CREATE TEMP TABLE new_account ON COMMIT DROP AS
+  SELECT user_id FROM sidewalk_login_import.sidewalk_user
+  EXCEPT
+  SELECT user_id FROM sidewalk_login.sidewalk_user;
+  ALTER TABLE new_account ADD PRIMARY KEY (user_id);
+  ANALYZE new_account;
+
+  CREATE TEMP TABLE new_identity ON COMMIT DROP AS
+  SELECT sidewalk_user.username, lower(sidewalk_user.email) AS lower_email
+  FROM sidewalk_login_import.sidewalk_user
+  INNER JOIN new_account ON new_account.user_id = sidewalk_user.user_id;
+  ANALYZE new_identity;
+
+  -- Sign-in, sessions and the "is it taken?" checks find an account by username or by lowercased email, so a local
+  -- account sharing either with a new one gives it up. Anonymous accounts rename outright and keep the app's
+  -- anonymous@<username>.com form. Others keep what doesn't clash, plus a short piece of their user_id so the new
+  -- value stays unique and a username stays within the 30-character limit.
+  CREATE TEMP TABLE renamed_account ON COMMIT DROP AS
+  WITH clashing AS (
+    SELECT sidewalk_user.user_id, sidewalk_user.username, sidewalk_user.email,
+           sidewalk_user.username IN (SELECT username FROM new_identity) AS username_taken,
+           lower(sidewalk_user.email) IN (SELECT lower_email FROM new_identity) AS email_taken,
+           EXISTS (
+             SELECT FROM sidewalk_login.user_role
+             WHERE user_role.user_id = sidewalk_user.user_id AND user_role.role::text = 'Anonymous'
+           ) AS anonymous
+    FROM sidewalk_login.sidewalk_user
+    WHERE sidewalk_user.username IN (SELECT username FROM new_identity)
+       OR lower(sidewalk_user.email) IN (SELECT lower_email FROM new_identity)
+  ), renamed AS (
+    SELECT clashing.*,
+           CASE WHEN username_taken OR anonymous THEN left(username, 21) || '_' || left(user_id, 8)
+                ELSE username END AS new_username
+    FROM clashing
+  )
+  SELECT user_id, anonymous, username AS old_username, new_username, email AS old_email,
+         CASE WHEN anonymous THEN 'anonymous@' || new_username || '.com'
+              WHEN email_taken THEN left(user_id, 8) || '.' || email
+              ELSE email END AS new_email
+  FROM renamed;
+
+  UPDATE sidewalk_login.sidewalk_user
+  SET username = renamed_account.new_username, email = renamed_account.new_email
+  FROM renamed_account
+  WHERE renamed_account.user_id = sidewalk_user.user_id;
+
+  -- Sign-in looks the password up through login_info's lowercased copy of the email, so that follows too.
+  UPDATE sidewalk_login.login_info
+  SET provider_key = lower(renamed_account.new_email)
+  FROM renamed_account
+  INNER JOIN sidewalk_login.user_login_info ON user_login_info.user_id = renamed_account.user_id
+  WHERE login_info.login_info_id = user_login_info.login_info_id
+    AND login_info.provider_key = lower(renamed_account.old_email)
+    AND renamed_account.new_email <> renamed_account.old_email;
+
+  -- The dump's login_info ids for newer accounts overlap the ones local sign-ups took from the same sequence, so
+  -- every merged login_info row gets a fresh id, and the two tables that point at login_info follow this map.
+  CREATE TEMP TABLE login_info_map ON COMMIT DROP AS
+  WITH merged_login_info AS (
+    SELECT DISTINCT user_login_info.login_info_id
+    FROM sidewalk_login_import.user_login_info
+    INNER JOIN new_account ON new_account.user_id = user_login_info.user_id
+  )
+  SELECT login_info_id AS old_id,
+         nextval(pg_get_serial_sequence('sidewalk_login.login_info', 'login_info_id')) AS new_id
+  FROM merged_login_info;
+  ALTER TABLE login_info_map ADD PRIMARY KEY (old_id);
+  ANALYZE login_info_map;
+
+  SELECT pg_temp.copy_rows('sidewalk_user', '{}',
+    'INNER JOIN new_account ON new_account.user_id = sidewalk_user.user_id') AS accounts_added \gset
+  SELECT pg_temp.copy_rows('login_info', '{login_info_id}',
+    'INNER JOIN login_info_map ON login_info_map.old_id = login_info.login_info_id',
+    'login_info_id', 'login_info_map.new_id') AS login_info_added \gset
+  SELECT pg_temp.copy_rows('user_login_info', '{user_login_info_id,login_info_id}',
+    'INNER JOIN new_account ON new_account.user_id = user_login_info.user_id
+     INNER JOIN login_info_map ON login_info_map.old_id = user_login_info.login_info_id',
+    'login_info_id', 'login_info_map.new_id') AS user_login_info_added \gset
+  SELECT pg_temp.copy_rows('user_password_info', '{user_password_info_id,login_info_id}',
+    'INNER JOIN login_info_map ON login_info_map.old_id = user_password_info.login_info_id',
+    'login_info_id', 'login_info_map.new_id') AS user_password_info_added \gset
+  SELECT pg_temp.copy_rows('user_role', '{user_role_id}',
+    'INNER JOIN new_account ON new_account.user_id = user_role.user_id') AS user_role_added \gset
+  SELECT pg_temp.copy_rows('user_utm', '{user_utm_id}',
+    'INNER JOIN new_account ON new_account.user_id = user_utm.user_id') AS user_utm_added \gset
+  -- Partners aren't owned by an account, so a dump partner comes in unless that city already has one by its name.
+  -- Each scope's display_order is a dense 0..n-1, so merged partners go after the ones already there, in dump order.
+  SELECT pg_temp.copy_rows('partner', '{partner_id,display_order}',
+    'WHERE NOT EXISTS (
+       SELECT FROM sidewalk_login.partner
+       WHERE sidewalk_login.partner.name = sidewalk_login_import.partner.name
+         AND sidewalk_login.partner.city_id IS NOT DISTINCT FROM sidewalk_login_import.partner.city_id
+     )',
+    'display_order',
+    '(SELECT coalesce(max(sidewalk_login.partner.display_order) + 1, 0)
+      FROM sidewalk_login.partner
+      WHERE sidewalk_login.partner.city_id IS NOT DISTINCT FROM sidewalk_login_import.partner.city_id)
+     + row_number() OVER (PARTITION BY sidewalk_login_import.partner.city_id
+                          ORDER BY sidewalk_login_import.partner.display_order) - 1') AS partner_added \gset
+
+  -- Anonymous clashes can number in the thousands (a city's login migration run locally gives its accounts different
+  -- user_ids than prod's run did), and nobody logs in to one, so only the other changed accounts are listed.
+  SELECT count(*) AS renamed_count,
+         count(*) FILTER (WHERE anonymous) AS renamed_anonymous_count,
+         count(*) FILTER (WHERE NOT anonymous) AS renamed_login_count,
+         count(*) FILTER (WHERE NOT anonymous) > 0 AS any_renamed_login,
+         count(*) FILTER (WHERE NOT anonymous) > 25 AS more_renamed_login
+  FROM renamed_account \gset
+  \if :any_renamed_login
+    \echo 'These accounts shared a username or email with one of the dump''s new accounts, so theirs changed:'
+    SELECT format('  %s: %s', old_username,
+                  concat_ws(', ', CASE WHEN new_username <> old_username THEN 'username -> ' || new_username END,
+                                  CASE WHEN new_email <> old_email THEN 'email -> ' || new_email END))
+    FROM renamed_account
+    WHERE NOT anonymous
+    ORDER BY old_username
+    LIMIT 25
+    \g (format=unaligned tuples_only=on)
+    \if :more_renamed_login
+      \echo '  (first 25 of' :renamed_login_count 'shown)'
+    \endif
+  \endif
+
+  SELECT format('✓ Added %s new accounts (%s login_info, %s user_login_info, %s user_password_info, %s user_role, '
+                '%s user_utm rows) and %s partners. Kept %s accounts the dump does not have. Changed the username '
+                'or email of %s accounts (%s anonymous) that clashed with a new one.',
+                :accounts_added, :login_info_added, :user_login_info_added, :user_password_info_added,
+                :user_role_added, :user_utm_added, :partner_added,
+                (SELECT count(*)
+                 FROM sidewalk_login.sidewalk_user
+                 WHERE NOT EXISTS (
+                   SELECT FROM sidewalk_login_import.sidewalk_user
+                   WHERE sidewalk_login_import.sidewalk_user.user_id = sidewalk_login.sidewalk_user.user_id
+                 )),
+                :renamed_count, :renamed_anonymous_count)
+  \g (format=unaligned tuples_only=on)
+
+  COMMIT;
+EOSQL
+
+drop_import_schema
+# The planner's row counts for these tables are stale after a big merge (e.g. into the tiny first-boot schema).
+psql -X -q -v ON_ERROR_STOP=1 -U sidewalk -d "$DB" -c "ANALYZE sidewalk_login.sidewalk_user, sidewalk_login.login_info,
+  sidewalk_login.user_login_info, sidewalk_login.user_password_info, sidewalk_login.user_role,
+  sidewalk_login.user_utm, sidewalk_login.partner;"

--- a/db/scripts/import-users.sh
+++ b/db/scripts/import-users.sh
@@ -1,46 +1,33 @@
 #!/usr/bin/env bash
 # =====================================================================================================================
-# import-users.sh — load the shared login schema (sidewalk_login) from the users dump, merging it into what you have.
+# import-users.sh — load user accounts (the shared sidewalk_login schema) from the users dump.
 #
-# WHY THIS EXISTS: every city schema shares one `sidewalk_login` schema that holds accounts, roles, and auth data. The
-# dev/CI database seeds this from a binary `pg_restore` dump rather than regenerating it, because it's large and not
-# something evolutions produce. Run this once after the db container is up, and again whenever a newer city dump needs
-# accounts that were made on prod after your last users import.
+# Every city shares one set of user accounts. Run this after the db container is first up, and again whenever a newer
+# city dump needs accounts that were created on prod since your last users import.
 #
 # TWO MODES (#3721):
-#   merge (default)  Adds the dump's accounts that you don't have yet and leaves every account you do have alone,
-#                    including test accounts you made locally. Those local accounts are what break a wipe: the cities
-#                    you already imported still point at them. A merge only writes rows, so the live schema's structure,
-#                    and everything in the cities that depends on it, stays as it is.
-#   --replace        Drop sidewalk_login and restore the dump from scratch. Use it for a fresh DB's first import, where
-#                    there's nothing to keep and merging every account would take ~20 min. Anywhere else it's
-#                    destructive: DROP SCHEMA ... CASCADE also drops every city's foreign keys into sidewalk_login,
-#                    its survey_question.survey_user_role column (typed as the schema's `role` enum) and its
-#                    label_comments_agg view, so re-import every city after it.
+#   merge (default)  Adds accounts from the dump that you don't have yet. Accounts you already have, including local
+#                    test accounts your cities point at, are left alone, so cities you've already imported keep working.
+#   --replace        Deletes all accounts and loads the dump from scratch. Fast, and the right choice for a fresh DB's
+#                    first import. On a DB with cities loaded it also breaks those cities (it drops their links to the
+#                    account tables, plus a survey column and a view), so re-import every city afterward.
 #
-# HOW A MERGE WORKS: pg_restore can only restore into the schema name the dump was made with, so the dump is turned
-# into SQL, and its schema name is rewritten to sidewalk_login_import on the way into psql. Only the table definitions
-# and the COPY/setval lines name the schema, so data rows pass through untouched. One transaction then copies the new
-# accounts across. The live schema is never renamed or dropped, so the app can keep running meanwhile.
+# HOW A MERGE WORKS: the dump is loaded into a temporary copy (sidewalk_login_import) beside your real accounts, the new
+# accounts are copied over in one step, and the temporary copy is deleted. Your real accounts stay available the whole
+# time, so the app can keep running.
 #
 # HOW IT'S RUN:  make import-users [replace=1]  →  docker exec ... /opt/scripts/import-users.sh [--replace]
 # INPUT:         /opt/sidewalk_users-dump  (i.e. db/sidewalk_users-dump on the host; git-ignored — see dev-environment.md).
 #
-# GOTCHAS:
-#   - --replace force-terminates ALL connections to the `sidewalk` database first. If the web app (`npm start`) is
-#     running, its DB connections are killed; just let sbt reconnect.
-#   - The users dump is ~1 GB, so loading it takes a minute or two, and a merge needs room for a second copy of the
-#     login tables while it runs.
-#   - A merged account keeps its user_id (what city data points at) but gets new row ids in the other login tables
-#     (login_info_id, user_role_id, ...): your local sign-ups already used some of the ids the dump has since handed
-#     out on prod. Nothing outside sidewalk_login refers to those ids.
-#   - An account you already have is never updated from the dump, even if it changed on prod since. The exception is a
-#     clash: the app finds accounts by username and by email, so if a new account has the username or email of one you
-#     have, yours gives it up (the script lists which). The new account may be what a city dump references.
-#   - A merge copies the columns both copies of a table have. It warns about columns only the dump has (start the app
-#     once so your schema catches up, then re-run) and fails on a required column only yours has (get a newer dump).
-#   - It moves rows, not structure. Constraints and indexes the dump has but your schema lacks are listed, not added:
-#     one could fail on your local data, and `--replace` is the way to take prod's structure wholesale.
+# GOOD TO KNOW:
+#   - --replace disconnects the running app from the database; it reconnects on its own.
+#   - A merge takes a few minutes and needs disk space for a second copy of the accounts while it runs.
+#   - Accounts you already have are never updated from the dump.
+#   - If a new account has the same username or email as one of yours, yours is changed (the script lists them), since
+#     city data may point at the new account.
+#   - Merged accounts keep their user_id but get new internal ids in the other account tables. Nothing else uses those.
+#   - If the dump has columns or database rules (constraints, indexes) that your copy lacks, the script warns you
+#     instead of adding them. Starting the app once usually brings your copy up to date.
 # =====================================================================================================================
 set -euo pipefail
 
@@ -66,14 +53,14 @@ if [[ ! -f "$DUMP" ]]; then
   exit 1
 fi
 
-# A second run would load into, and then drop, the side schema the first one is using.
+# Only one run at a time: two would trip over the same temporary copy.
 exec 9>/tmp/import-users.lock
 if ! flock -n 9; then
   echo "Error: another import-users is already running." >&2
   exit 1
 fi
 
-# -X skips any ~/.psqlrc, which could add output to what's parsed here.
+# -X ignores personal psql settings, which could change the output read here.
 has_login_schema=$(psql -X -At -U postgres -d "$DB" \
   -c "SELECT EXISTS (SELECT FROM pg_namespace WHERE nspname = 'sidewalk_login');")
 case "$has_login_schema" in
@@ -91,7 +78,7 @@ case "$has_login_schema" in
 esac
 
 if [[ "$MODE" == replace ]]; then
-  # Terminate other backends first so the DROP doesn't hit lock waits.
+  # Disconnect everyone first, or the delete below would wait on their connections.
   psql -X -v ON_ERROR_STOP=1 -U postgres -d "$DB" <<-EOSQL
     SELECT pg_terminate_backend(pg_stat_activity.pid)
     FROM pg_stat_activity
@@ -99,11 +86,11 @@ if [[ "$MODE" == replace ]]; then
       AND pid <> pg_backend_pid();
 EOSQL
   psql -X -q -v ON_ERROR_STOP=1 -U postgres -d "$DB" -c "DROP SCHEMA IF EXISTS sidewalk_login CASCADE;"
-  # -j 4: parallel restore (valid for the -Fc custom-format dump; we don't use --single-transaction).
+  # -j 4 restores four tables at a time, to save time.
   run_with_progress "Restoring users dump (sidewalk_login)" \
     pg_restore -U sidewalk -Fc -j 4 -d "$DB" "$DUMP"
 
-  # The restored objects don't carry readonly_user's grants, so re-grant them (mirrors init.sh and import-dump.sh).
+  # A fresh load loses the read-only user's access, so give it back (same as init.sh and import-dump.sh).
   psql -X -q -v ON_ERROR_STOP=1 -U sidewalk -d "$DB" <<-EOSQL
     DO \$\$
     BEGIN
@@ -122,8 +109,9 @@ drop_import_schema() {
     -c "SET client_min_messages = warning; DROP SCHEMA IF EXISTS sidewalk_login_import CASCADE;"
 }
 
-# Loads the dump into sidewalk_login_import. It skips the dump's indexes and constraints: the merge doesn't need them,
-# and building them over ~6M rows would be most of the load time.
+# Loads the dump into the temporary copy. The dump is written out as SQL with the schema name swapped, since
+# pg_restore can't load into a different name itself. Indexes and rules are skipped: the merge doesn't need them, and
+# building them would take most of the load time.
 load_import_schema() {
   pg_restore --section=pre-data -f - "$DUMP" \
     | sed -E 's/\bsidewalk_login\b/sidewalk_login_import/g' \
@@ -131,7 +119,7 @@ load_import_schema() {
   pg_restore --data-only -f - "$DUMP" \
     | sed -E '/^(COPY|SELECT pg_catalog\.setval)/ s/\bsidewalk_login\b/sidewalk_login_import/' \
     | psql -X -q -v ON_ERROR_STOP=1 -U sidewalk -d "$DB"
-  # Without row counts the planner guesses these tables are tiny and picks nested loops over millions of rows.
+  # Tell Postgres how big these tables are, or it picks a very slow way to join them.
   psql -X -q -v ON_ERROR_STOP=1 -U sidewalk -d "$DB" <<-'EOSQL'
     DO $$
     DECLARE
@@ -148,7 +136,7 @@ drop_import_schema
 trap drop_import_schema EXIT
 run_with_progress "Loading users dump into a side schema" load_import_schema
 
-# The dump's constraint and index names, so the merge can point out any the live schema lacks.
+# Names of the dump's database rules (constraints, indexes), to warn about any your copy is missing.
 dump_objects=$(pg_restore -l "$DUMP" \
   | awk '/^[0-9]+;/ && ($4 == "INDEX" || $4 == "CONSTRAINT" || ($4 == "FK" && $5 == "CONSTRAINT")) {print $(NF-1)}' \
   | paste -sd, -)
@@ -156,16 +144,13 @@ dump_objects=$(pg_restore -l "$DUMP" \
 echo "⏳ Merging new accounts into sidewalk_login..." >&2
 psql -X -q -v ON_ERROR_STOP=1 -v dump_objects="{$dump_objects}" -U sidewalk -d "$DB" <<-'EOSQL'
   BEGIN;
-  -- The joins below run over millions of accounts; the dev server's 4 MB default spills every one of them to disk.
-  -- Parallel workers would share that memory through /dev/shm, which Docker caps at 64 MB, so they're turned off.
+  -- Give the big joins below more memory. Parallel workers stay off because Docker limits the memory they share.
   SET LOCAL work_mem = '256MB';
   SET LOCAL max_parallel_workers_per_gather = 0;
 
-  -- Copies rows from the dump's copy of a login table into the live one and returns how many it copied. It takes
-  -- every column the two copies share except those in `skip`, so a dump that's an evolution or two away from the
-  -- local schema still lines up. A column whose type differs goes through text: that's how the dump's copy of the
-  -- `role` enum lands in the live one. `extra_cols` / `extra_vals` add columns the caller fills itself (a remapped
-  -- id), and `joins` picks which of the dump's rows to copy.
+  -- Copies one table's rows from the temporary copy into your real one and returns how many it copied. Only columns
+  -- both have are copied, so a dump slightly older or newer than your schema still works. `skip` leaves columns out,
+  -- `extra_cols` / `extra_vals` fill some in by hand (like a new id), and `joins` picks which rows to copy.
   CREATE FUNCTION pg_temp.copy_rows(tbl text, skip text[], joins text, extra_cols text DEFAULT NULL,
                                     extra_vals text DEFAULT NULL) RETURNS bigint LANGUAGE plpgsql AS $$
   DECLARE
@@ -200,7 +185,7 @@ psql -X -q -v ON_ERROR_STOP=1 -v dump_objects="{$dump_objects}" -U sidewalk -d "
     RETURN copied;
   END $$;
 
-  -- What a merge can't carry over is named rather than silently dropped.
+  -- Warn about anything in the dump that the merge can't bring over.
   DO $$
   DECLARE
     unhandled text;
@@ -256,10 +241,9 @@ psql -X -q -v ON_ERROR_STOP=1 -v dump_objects="{$dump_objects}" -U sidewalk -d "
   INNER JOIN new_account ON new_account.user_id = sidewalk_user.user_id;
   ANALYZE new_identity;
 
-  -- Sign-in, sessions and the "is it taken?" checks find an account by username or by lowercased email, so a local
-  -- account sharing either with a new one gives it up. Anonymous accounts rename outright and keep the app's
-  -- anonymous@<username>.com form. Others keep what doesn't clash, plus a short piece of their user_id so the new
-  -- value stays unique and a username stays within the 30-character limit.
+  -- The app looks accounts up by username and by email, so no two may share either. When a new account has the same
+  -- username or email as one of yours, yours gets the first 8 characters of its user_id added, which keeps it unique
+  -- (and usernames under 30 characters). Anonymous accounts always get a new username and matching email.
   CREATE TEMP TABLE renamed_account ON COMMIT DROP AS
   WITH clashing AS (
     SELECT sidewalk_user.user_id, sidewalk_user.username, sidewalk_user.email,
@@ -289,7 +273,7 @@ psql -X -q -v ON_ERROR_STOP=1 -v dump_objects="{$dump_objects}" -U sidewalk -d "
   FROM renamed_account
   WHERE renamed_account.user_id = sidewalk_user.user_id;
 
-  -- Sign-in looks the password up through login_info's lowercased copy of the email, so that follows too.
+  -- Sign-in finds the password by email, so the login record gets the new email too.
   UPDATE sidewalk_login.login_info
   SET provider_key = lower(renamed_account.new_email)
   FROM renamed_account
@@ -298,8 +282,8 @@ psql -X -q -v ON_ERROR_STOP=1 -v dump_objects="{$dump_objects}" -U sidewalk -d "
     AND login_info.provider_key = lower(renamed_account.old_email)
     AND renamed_account.new_email <> renamed_account.old_email;
 
-  -- The dump's login_info ids for newer accounts overlap the ones local sign-ups took from the same sequence, so
-  -- every merged login_info row gets a fresh id, and the two tables that point at login_info follow this map.
+  -- Your local sign-ups may already use the login ids of the dump's newer accounts, so merged accounts get new ids.
+  -- This maps each old id to its new one.
   CREATE TEMP TABLE login_info_map ON COMMIT DROP AS
   WITH merged_login_info AS (
     SELECT DISTINCT user_login_info.login_info_id
@@ -328,8 +312,8 @@ psql -X -q -v ON_ERROR_STOP=1 -v dump_objects="{$dump_objects}" -U sidewalk -d "
     'INNER JOIN new_account ON new_account.user_id = user_role.user_id') AS user_role_added \gset
   SELECT pg_temp.copy_rows('user_utm', '{user_utm_id}',
     'INNER JOIN new_account ON new_account.user_id = user_utm.user_id') AS user_utm_added \gset
-  -- Partners aren't owned by an account, so a dump partner comes in unless that city already has one by its name.
-  -- Each scope's display_order is a dense 0..n-1, so merged partners go after the ones already there, in dump order.
+  -- A partner from the dump is added unless that city already has one with the same name. New ones go after the
+  -- existing ones in that city's display order.
   SELECT pg_temp.copy_rows('partner', '{partner_id,display_order}',
     'WHERE NOT EXISTS (
        SELECT FROM sidewalk_login.partner
@@ -343,8 +327,7 @@ psql -X -q -v ON_ERROR_STOP=1 -v dump_objects="{$dump_objects}" -U sidewalk -d "
      + row_number() OVER (PARTITION BY sidewalk_login_import.partner.city_id
                           ORDER BY sidewalk_login_import.partner.display_order) - 1') AS partner_added \gset
 
-  -- Anonymous clashes can number in the thousands (a city's login migration run locally gives its accounts different
-  -- user_ids than prod's run did), and nobody logs in to one, so only the other changed accounts are listed.
+  -- Anonymous accounts can clash by the thousands and nobody logs in as one, so only the others are listed.
   SELECT count(*) AS renamed_count,
          count(*) FILTER (WHERE anonymous) AS renamed_anonymous_count,
          count(*) FILTER (WHERE NOT anonymous) AS renamed_login_count,
@@ -384,7 +367,7 @@ psql -X -q -v ON_ERROR_STOP=1 -v dump_objects="{$dump_objects}" -U sidewalk -d "
 EOSQL
 
 drop_import_schema
-# The planner's row counts for these tables are stale after a big merge (e.g. into the tiny first-boot schema).
+# Update Postgres's table-size estimates after a big merge.
 psql -X -q -v ON_ERROR_STOP=1 -U sidewalk -d "$DB" -c "ANALYZE sidewalk_login.sidewalk_user, sidewalk_login.login_info,
   sidewalk_login.user_login_info, sidewalk_login.user_password_info, sidewalk_login.user_role,
   sidewalk_login.user_utm, sidewalk_login.partner;"

--- a/docs/dev-environment.md
+++ b/docs/dev-environment.md
@@ -117,12 +117,15 @@ Make sure Docker is running (you'll see the whale icon in your tray; you can set
 4. **Import users and data** from a *second* terminal on your host (outside the web-container shell):
 
    ```bash
-   make import-users                   # load sidewalk_users-dump (the login schema)
+   make import-users replace=1         # load sidewalk_users-dump (the login schema)
    make import-dump db=<database_user> # load <database_user>-dump; db= defaults to "sidewalk"
    ```
 
-   Both restore from a binary dump and show a live elapsed-time clock — the users dump is ~900 MB, so it runs for a
-   couple of minutes (the restore is parallelized to keep that short); a city dump varies with its size. Read the
+   Both restore from a binary dump and show a live elapsed-time clock — the users dump is ~1 GB, so it runs for a
+   couple of minutes (the restore is parallelized to keep that short); a city dump varies with its size.
+   `replace=1` is for this first import only: a fresh DB has no accounts of its own to keep, and merging all ~6M
+   accounts one by one takes about 20 minutes. Later imports merge (see
+   [Switching / adding another city](#switching--adding-another-city)). Read the
    output carefully — if it errors, **don't** continue; check [Troubleshooting](#troubleshooting) and ask. (A
    `schema "public" already exists` notice is the one error you can safely ignore.) For what each script does and the
    full set of DB lifecycle/maintenance targets, see [`db/scripts/README.md`](../db/scripts/README.md).
@@ -172,8 +175,11 @@ Other handy targets:
 Each city is a separate database. To switch:
 
 1. Put the new dump in `db/`, renamed to `<database_user>-dump` (see the [City IDs table](#city-ids)).
-2. If that dump is newer than your existing ones, also re-import users with a fresh `sidewalk_users-dump`
-   (ask a maintainer if unsure — the creation date is in the original filename).
+2. If that dump is newer than your users dump, get a users dump at least as new, rename it `sidewalk_users-dump`,
+   and run `make import-users` (ask a maintainer if unsure — the creation date is in the original filename). It
+   merges: accounts you're missing are added, and the ones you have, including local test accounts your other cities
+   point at, are kept, so the cities you already imported keep working. `make import-users replace=1` wipes the login
+   schema and restores the dump from scratch instead; after that, re-import every other city you have.
 3. `make import-dump db=<database_user>` (from the host, outside the Docker shell).
 4. Update **`DATABASE_USER`** and **`SIDEWALK_CITY_ID`** in `docker-compose.override.yml` to match.
 5. `make dev` again.

--- a/docs/dev-environment.md
+++ b/docs/dev-environment.md
@@ -179,7 +179,8 @@ Each city is a separate database. To switch:
    and run `make import-users` (ask a maintainer if unsure — the creation date is in the original filename). It
    merges: accounts you're missing are added, and the ones you have, including local test accounts your other cities
    point at, are kept, so the cities you already imported keep working. `make import-users replace=1` wipes the login
-   schema and restores the dump from scratch instead; after that, re-import every other city you have.
+   schema and restores the dump from scratch instead. That also drops the parts of every city that depend on it
+   (foreign keys, a survey column, a view), so after it, re-import every other city you have.
 3. `make import-dump db=<database_user>` (from the host, outside the Docker shell).
 4. Update **`DATABASE_USER`** and **`SIDEWALK_CITY_ID`** in `docker-compose.override.yml` to match.
 5. `make dev` again.


### PR DESCRIPTION
resolves #3721

## What changed
`make import-users` now **merges** the users dump into your accounts instead of deleting them all first:
- Accounts from the dump that you don't have are added. Accounts you already have, including local test accounts, are left alone, so cities you've already imported keep working.
- Your cities' links to the account tables stay in place, and the app can keep running during the import.
- `make import-users replace=1` still wipes and reloads. The setup docs use it for a fresh DB's first import, where it's much faster (~2.5 min vs ~20 min).

**How it works:** the dump is loaded into a temporary copy beside your real accounts (~45s), the new accounts are copied over in one step, and the temporary copy is deleted.

Details:
- If a new account has the same username or email as one of yours, yours gets a short suffix, and the script lists what changed. The app looks accounts up by both, so they can't be shared.
- The script warns about anything in the dump it can't bring over: extra columns, extra tables, or database rules your copy lacks.
- Community partners from the dump are added unless that city already has one with the same name.
- Only one import can run at a time.

Files: `db/scripts/import-users.sh`, `Makefile` (`replace=`), `docs/dev-environment.md`, `db/scripts/README.md`, `db/dc-migration/README.md`.

## Testing
- **Test DB:** merged the 09-09 prod dump into the 09-07 test-server accounts plus planted clashes. All 6M new accounts came in matching prod, existing accounts were kept, the clashes were resolved as designed, and a second run started at the same time was refused.
- **Real dev DB (24 cities):** added ~298k accounts, and every city's links to the account tables survived. A final run added nothing and didn't disconnect the app.
- **Not re-tested:** `replace=1`, which is the old code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYfTeFowRqGL4Gortxdpea
