### PR TITLE
Launch Laurens, IA and Bayonne publicly

### DIFF
--- a/conf/cityparams.conf
+++ b/conf/cityparams.conf
@@ -374,8 +374,8 @@ city-params {
     waltham-ma = "public"
     houston-tx = "public"
     newport-ky = "public"
-    bayonne = "private"
-    laurens-ia = "private"
+    bayonne = "public"
+    laurens-ia = "public"
   }
   launch-date {
     washington-dc = "2015-10-17"
@@ -436,7 +436,7 @@ city-params {
     waltham-ma = "2026-05-12"
     houston-tx = "2026-07-17"
     newport-ky = "2026-08-28"
-    bayonne = "2026-09-18"
+    bayonne = "2026-09-11"
     laurens-ia = "2026-09-11"
   }
   skyline-img = {

--- a/docs/deployment-and-stages.md
+++ b/docs/deployment-and-stages.md
@@ -52,7 +52,7 @@ verifiable from the deploy log rather than by curling every host:
 
 ```
 INFO m.SearchIndexingCheck - Search indexing: seattle-wa is INDEXABLE (environment-type=prod, status=public,
-pano-viewer-type=gsv); 37 of 60 configured cities are public. A vhost X-Robots-Tag header can still override this.
+pano-viewer-type=gsv); 39 of 60 configured cities are public. A vhost X-Robots-Tag header can still override this.
 ```
 
 It also sweeps every city's `status` and logs an error for any value that isn't `public` or `private`. Nothing there


### PR DESCRIPTION
Both cities were registered `private`, which is the onboarding default, and both are ready to be seen.

A private deployment is **still listed** by `/v3/api/cities` — with its `city_id`, names and `visibility` — but with a null `url` (#5259). It is kept out of every other deployment's navbar dropdown and out of `public_city_count`, its contributions are held off the global leaderboard, and on prod the app serves it `noindex`, with no sitemap and no canonical link (`SeoUtils.isIndexable`, #5120). Flipping both to `public` turns all of that on, and puts them on the `/cities` map with a working link.

The `SearchIndexingCheck` boot line quoted in `docs/deployment-and-stages.md` names the public/total count, which this change moves from 37 of 60 to 39, so that sample is updated here too.

Two of those effects are worth calling out. `public_city_count` (`UserService.scala:768`) feeds the *"Project Sidewalk maps sidewalks in N cities"* nudge on **every** deployment's dashboard, so that number goes up by two the moment this merges, everywhere — before either site exists. And the indexing change only makes the *app* serve indexable signals: every vhost `lab/sidewalk-tools` provisions hardcodes `Header set X-Robots-Tag "noindex, nofollow"`, which Apache applies after the backend and which therefore still masks it. Actually getting these two indexed needs [sidewalk-tools !65](https://gitlab.cs.washington.edu/lab/sidewalk-tools/-/merge_requests/65) and IT's sweep of `/etc/httpd/conf.d/*.cs.conf` — and per `docs/deployment-and-stages.md`, a *public* city's vhost can be swept at any time, so there's no ordering constraint on that half.

Bayonne's launch date moves from 2026-09-18 to 2026-09-11 to match Laurens'. Nothing gates on the date — it is descriptive — so it can be moved again if the test stage slips.

Nothing else changes with the status: `private-profiles-by-default`, `global-leaderboard-excluded` and `ai-label-submission-enabled` are unset for both, so they take the same permissive defaults every launched city has. Neither is Infra3d, so the imagery-licence noindex does not apply to either.

One property worth recording, with no impact today. While a city is private its schema joins `optOutSchemas`, and `UserStatTable` builds an `extra_opt_outs` CTE straight from `user_stat` there — deliberately not off a label join, "a mapper can opt out of a city without having labeled in it" — which removes that user from the global leaderboard everywhere. After the flip the city moves into the contributing set, where opt-out is honored through `HAVING BOOL_OR(city_labels.opted_out) = FALSE`, and `city_labels` comes from an `INNER JOIN label` — so a user with a `user_stat` row and zero labels no longer casts that veto. Flipping a *populated* city public can therefore re-expose a mapper who opted out via it. Both of these schemas are empty dumps with no users, so nothing happens here; it is a property of the next flip that matters.

##### Sequencing, worth knowing before this merges

The moment this lands on develop the test stage starts publishing both `-test` URLs in `/v3/api/cities`, in other cities' navbar dropdowns and on the `/cities` map (whose popups link and cross-origin-fetch each city), and bumps the dashboard city count everywhere; the next release tag does the same for the prod URLs. Both cities' dumps are already on makelab1 (`/www/sidewalk/new-city-dumps/sidewalk_bayonne-empty-dump` and `sidewalk_laurens_ia-empty-dump`, both at evolution 384), but the vhosts do not exist yet — so this wants to merge alongside, or just after, that server work rather than well before it.

Still on a person, outside this PR: provisioning the vhosts and restoring the dumps (`uwcseit-sidewalk-tools`, `bin/setup-new.pl`, test stage first) plus DNS; the Maps-key referrers for all four URLs (`docs/google-cloud.md`); reviewing each city's `config` row on the server, in particular Bayonne's `excluded_tags`, which the clone inherited from its donor and which a French city may well want different, and `update_offset_hours`, which comes from the load-spreading spreadsheet; and a clustering run so AccessScore has intersections, which a freshly onboarded city has none of until the nightly job first fires.

##### Testing instructions

1. `make lint-locales` — green; `city.name.bayonne` and `city.name.laurens-ia` already exist in `messages` and `messages.zh-TW`, with `es` carrying Bayonne's exonym (Bayona). The other locales fall back to English, which is the documented rule for names that don't differ.
2. Nothing in the test suite pins either city's status; `SearchIndexingCheckSpec`'s "pass against the bundled cityparams" case accepts `public` and `private` alike, so it stays green.
3. On a deployment pointed at another city, both should now appear in the navbar dropdown and carry a non-null `url` in `/v3/api/cities`.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 5 (1M context), claude-opus-5[1m]
