### PR TITLE
Rename the Bayonne city id to bayonne-fr and schema to sidewalk_bayonne_fr

### DIFF
--- a/.claude/skills/onboard-city/SKILL.md
+++ b/.claude/skills/onboard-city/SKILL.md
@@ -19,7 +19,7 @@ checkout** (`db/` is the bind mount), so run these from the main checkout, not a
 ## 1. Intake — ask before building
 
 - **City id.** Lowercase kebab-case; US cities carry the state (`laurens-ia`), others the country only when it
-  disambiguates (`bayonne`, `sao-paulo-brazil`). It becomes `SIDEWALK_CITY_ID`, the schema (`sidewalk_laurens_ia`),
+  disambiguates (`bayonne-fr`, `sao-paulo-brazil`). It becomes `SIDEWALK_CITY_ID`, the schema (`sidewalk_laurens_ia`),
   the output dir, and the server name (state dropped: `sidewalk-laurens`).
 - **Imagery provider.** `gsv` unless the partner says otherwise; `mapillary` / `panoramax` / `infra3d` need the
   matching credentials in the web container (Panoramax needs none). If unsure, the preflight in step 3 decides.
@@ -42,7 +42,7 @@ checkout** (`db/` is the bind mount), so run these from the main checkout, not a
 
 ```
 make build-city-data id=laurens-ia args="--place 'Laurens, Iowa, USA'"
-make build-city-data id=bayonne args="--boundary-file /path/city.geojson --regions-file /path/quartiers.geojson \
+make build-city-data id=bayonne-fr args="--boundary-file /path/city.geojson --regions-file /path/quartiers.geojson \
     --region-name-col nom --regions-source 'https://…'"
 ```
 

--- a/.claude/skills/onboard-city/SKILL.md
+++ b/.claude/skills/onboard-city/SKILL.md
@@ -18,9 +18,10 @@ checkout** (`db/` is the bind mount), so run these from the main checkout, not a
 
 ## 1. Intake — ask before building
 
-- **City id.** Lowercase kebab-case; US cities carry the state (`laurens-ia`), others the country only when it
-  disambiguates (`bayonne-fr`, `sao-paulo-brazil`). It becomes `SIDEWALK_CITY_ID`, the schema (`sidewalk_laurens_ia`),
-  the output dir, and the server name (state dropped: `sidewalk-laurens`).
+- **City id.** Lowercase kebab-case ending in the state for US cities (`laurens-ia`), the country elsewhere
+  (`bayonne-fr`). It becomes `SIDEWALK_CITY_ID`, the schema (`sidewalk_laurens_ia`), and the output dir.
+- **Server name.** The id without its suffix (`sidewalk-laurens`), unless a clearly larger city shares the name
+  (`sidewalk-newport-ky`).
 - **Imagery provider.** `gsv` unless the partner says otherwise; `mapillary` / `panoramax` / `infra3d` need the
   matching credentials in the web container (Panoramax needs none). If unsure, the preflight in step 3 decides.
 - **Neighborhood boundaries**, in this order of preference, and record where they came from (`--regions-source`, a

--- a/conf/cityparams.conf
+++ b/conf/cityparams.conf
@@ -61,7 +61,7 @@ city-params {
     "waltham-ma"
     "houston-tx"
     "newport-ky"
-    "bayonne"
+    "bayonne-fr"
     "laurens-ia"
   ]
 
@@ -125,7 +125,7 @@ city-params {
     waltham-ma = "sidewalk_waltham"
     houston-tx = "sidewalk_houston"
     newport-ky = "sidewalk_newport_ky"
-    bayonne = "sidewalk_bayonne"
+    bayonne-fr = "sidewalk_bayonne"
     laurens-ia = "sidewalk_laurens_ia"
   }
 
@@ -188,7 +188,7 @@ city-params {
     waltham-ma = null
     houston-tx = null
     newport-ky = null
-    bayonne = null
+    bayonne-fr = null
     laurens-ia = null
   }
   state-id {
@@ -250,7 +250,7 @@ city-params {
     waltham-ma = "massachusetts"
     houston-tx = "texas"
     newport-ky = "kentucky"
-    bayonne = null
+    bayonne-fr = null
     laurens-ia = "iowa"
   }
   country-id {
@@ -312,7 +312,7 @@ city-params {
     waltham-ma = "usa"
     houston-tx = "usa"
     newport-ky = "usa"
-    bayonne = "france"
+    bayonne-fr = "france"
     laurens-ia = "usa"
   }
   status {
@@ -374,7 +374,7 @@ city-params {
     waltham-ma = "public"
     houston-tx = "public"
     newport-ky = "public"
-    bayonne = "private"
+    bayonne-fr = "private"
     laurens-ia = "private"
   }
   launch-date {
@@ -436,7 +436,7 @@ city-params {
     waltham-ma = "2026-05-12"
     houston-tx = "2026-07-17"
     newport-ky = "2026-08-28"
-    bayonne = "2026-09-18"
+    bayonne-fr = "2026-09-18"
     laurens-ia = "2026-09-11"
   }
   skyline-img = {
@@ -498,7 +498,7 @@ city-params {
     waltham-ma = "skyline1.png"
     houston-tx = "skyline1.png"
     newport-ky = "skyline1.png"
-    bayonne = "skyline1.png"
+    bayonne-fr = "skyline1.png"
     laurens-ia = "skyline1.png"
   }
   logo-img = {
@@ -560,7 +560,7 @@ city-params {
     waltham-ma = "sidewalk-logo.png"
     houston-tx = "sidewalk-logo.png"
     newport-ky = "sidewalk-logo.png"
-    bayonne = "sidewalk-logo.png"
+    bayonne-fr = "sidewalk-logo.png"
     laurens-ia = "sidewalk-logo.png"
   }
   landing-page-url {
@@ -623,7 +623,7 @@ city-params {
       waltham-ma = "https://sidewalk-waltham.cs.washington.edu"
       houston-tx = "https://sidewalk-houston.cs.washington.edu"
       newport-ky = "https://sidewalk-newport-ky.cs.washington.edu"
-      bayonne = "https://sidewalk-bayonne.cs.washington.edu"
+      bayonne-fr = "https://sidewalk-bayonne.cs.washington.edu"
       laurens-ia = "https://sidewalk-laurens.cs.washington.edu"
     }
     test {
@@ -685,7 +685,7 @@ city-params {
       waltham-ma = "https://sidewalk-waltham-test.cs.washington.edu"
       houston-tx = "https://sidewalk-houston-test.cs.washington.edu"
       newport-ky = "https://sidewalk-newport-ky-test.cs.washington.edu"
-      bayonne = "https://sidewalk-bayonne-test.cs.washington.edu"
+      bayonne-fr = "https://sidewalk-bayonne-test.cs.washington.edu"
       laurens-ia = "https://sidewalk-laurens-test.cs.washington.edu"
     }
     local = ${city-params.landing-page-url.test}
@@ -750,7 +750,7 @@ city-params {
       waltham-ma = "G-WPQ95RFSJ2"
       houston-tx = "G-N8F4GMS59Q"
       newport-ky = "G-JNRNZDXN4G"
-      bayonne = "G-JJTGTHJ9SF"
+      bayonne-fr = "G-JJTGTHJ9SF"
       laurens-ia = "G-7KKGLZNVF7"
     }
     test {
@@ -811,7 +811,7 @@ city-params {
       waltham-ma = "G-P31JHZQ4TV"
       houston-tx = "G-WXB1XWE56V"
       newport-ky = "G-834QDYWDJP"
-      bayonne = "G-EFNCPF8658"
+      bayonne-fr = "G-EFNCPF8658"
       laurens-ia = "G-SS5FFF684J"
     }
     local = ${city-params.google-analytics-4-id.test}
@@ -876,7 +876,7 @@ city-params {
       waltham-ma = "537336408"
       houston-tx = "544422788"
       newport-ky = "550774837"
-      bayonne = "553018978"
+      bayonne-fr = "553018978"
       laurens-ia = "553056658"
     }
     test {
@@ -936,7 +936,7 @@ city-params {
       waltham-ma = "537360551"
       houston-tx = "544445091"
       newport-ky = "550803984"
-      bayonne = "553018587"
+      bayonne-fr = "553018587"
       laurens-ia = "553079248"
     }
     local = ${city-params.google-analytics-property-id.test}
@@ -1000,7 +1000,7 @@ city-params {
     waltham-ma = true
     houston-tx = true
     newport-ky = true
-    bayonne = true
+    bayonne-fr = true
     laurens-ia = true
   }
   // When true for a city, new users there start with their leaderboard/public-profile privacy flags OFF
@@ -1078,7 +1078,7 @@ city-params {
     waltham-ma = true
     houston-tx = true
     newport-ky = true
-    bayonne = true
+    bayonne-fr = true
     laurens-ia = true
   }
   // When true for a city, that city accepts AI-generated label submissions on /ai/submitLabelsOnPano (the
@@ -1148,7 +1148,7 @@ city-params {
     waltham-ma = "0.92"
     houston-tx = "0.92"
     newport-ky = "0.92"
-    bayonne = "0.92"
+    bayonne-fr = "0.92"
     laurens-ia = "0.92"
   }
   pano-viewer-type {
@@ -1210,7 +1210,7 @@ city-params {
     waltham-ma = "gsv"
     houston-tx = "gsv"
     newport-ky = "gsv"
-    bayonne = "panoramax"
+    bayonne-fr = "panoramax"
     laurens-ia = "mapillary"
   }
 }

--- a/conf/cityparams.conf
+++ b/conf/cityparams.conf
@@ -125,7 +125,7 @@ city-params {
     waltham-ma = "sidewalk_waltham"
     houston-tx = "sidewalk_houston"
     newport-ky = "sidewalk_newport_ky"
-    bayonne-fr = "sidewalk_bayonne"
+    bayonne-fr = "sidewalk_bayonne_fr"
     laurens-ia = "sidewalk_laurens_ia"
   }
 

--- a/conf/messages/messages
+++ b/conf/messages/messages
@@ -63,7 +63,7 @@ city.name.winterthur-infra3d = Winterthur
 city.name.waltham-ma = Waltham
 city.name.houston-tx = Houston
 city.name.newport-ky = Newport
-city.name.bayonne = Bayonne
+city.name.bayonne-fr = Bayonne
 city.name.laurens-ia = Laurens
 
 state.name.dc = DC

--- a/conf/messages/messages.es
+++ b/conf/messages/messages.es
@@ -80,7 +80,7 @@ city.name.la-ca = Los Ángeles
 city.name.knox-oh = Condado de Knox
 city.name.niagara-falls-ny = Cataratas del Niágara
 city.name.fort-wayne-in = Fuerte Wayne
-city.name.bayonne = Bayona
+city.name.bayonne-fr = Bayona
 
 state.name.oregon = Oregón
 state.name.pennsylvania = Pensilvania

--- a/conf/messages/messages.zh-TW
+++ b/conf/messages/messages.zh-TW
@@ -126,7 +126,7 @@ city.name.winterthur-infra3d = 溫特圖爾
 city.name.waltham-ma = 沃爾瑟姆
 city.name.houston-tx = 休士頓
 city.name.newport-ky = 紐波特
-city.name.bayonne = 巴約訥
+city.name.bayonne-fr = 巴約訥
 city.name.laurens-ia = 勞倫斯
 
 state.name.dc = 特區

--- a/docs/dev-environment.md
+++ b/docs/dev-environment.md
@@ -223,7 +223,7 @@ truth**; the snapshot below is a convenience copy (it may lag as new cities are 
 | mendota-il | sidewalk_mendota | | waltham-ma | sidewalk_waltham |
 | knox-oh | sidewalk_knox | | houston-tx | sidewalk_houston |
 | kaohsiung-tw | sidewalk_kaohsiung | | newport-ky | sidewalk_newport_ky |
-| bayonne | sidewalk_bayonne | | laurens-ia | sidewalk_laurens_ia |
+| bayonne-fr | sidewalk_bayonne | | laurens-ia | sidewalk_laurens_ia |
 
 ---
 

--- a/docs/dev-environment.md
+++ b/docs/dev-environment.md
@@ -223,7 +223,7 @@ truth**; the snapshot below is a convenience copy (it may lag as new cities are 
 | mendota-il | sidewalk_mendota | | waltham-ma | sidewalk_waltham |
 | knox-oh | sidewalk_knox | | houston-tx | sidewalk_houston |
 | kaohsiung-tw | sidewalk_kaohsiung | | newport-ky | sidewalk_newport_ky |
-| bayonne-fr | sidewalk_bayonne | | laurens-ia | sidewalk_laurens_ia |
+| bayonne-fr | sidewalk_bayonne_fr | | laurens-ia | sidewalk_laurens_ia |
 
 ---
 

--- a/docs/onboarding-a-city.md
+++ b/docs/onboarding-a-city.md
@@ -18,10 +18,11 @@ Run the three from the **main checkout**: `db/` is the bind mount the db contain
 
 ## Before you start
 
-- **City id** — lowercase kebab-case. US cities carry the state (`laurens-ia`, `walla-walla-wa`); elsewhere add
-  the country only to disambiguate (`bayonne-fr`, `sao-paulo-brazil`). The id becomes `SIDEWALK_CITY_ID`, the schema
-  (`sidewalk_laurens_ia` — new cities keep the full id), the output dir, and the server name (state dropped:
-  `sidewalk-laurens.cs.washington.edu`).
+- **City id** — lowercase kebab-case ending in the state for US cities (`laurens-ia`), the country elsewhere
+  (`bayonne-fr`). The id becomes `SIDEWALK_CITY_ID`, the schema (`sidewalk_laurens_ia` — new cities keep the full
+  id), and the output dir.
+- **Server name** — the id without its suffix (`sidewalk-laurens`), unless a clearly larger city shares the name
+  (`sidewalk-newport-ky`).
 - **Neighborhood boundaries** — the thing worth spending time on, in order of preference:
   1. a dataset from the partner or the city (any OGR-readable format and CRS; note its name column);
   2. the city's open-data portal (ArcGIS Hub, Socrata, CKAN, data.gouv.fr, …) — look for official, non-overlapping

--- a/docs/onboarding-a-city.md
+++ b/docs/onboarding-a-city.md
@@ -19,7 +19,7 @@ Run the three from the **main checkout**: `db/` is the bind mount the db contain
 ## Before you start
 
 - **City id** — lowercase kebab-case. US cities carry the state (`laurens-ia`, `walla-walla-wa`); elsewhere add
-  the country only to disambiguate (`bayonne`, `sao-paulo-brazil`). The id becomes `SIDEWALK_CITY_ID`, the schema
+  the country only to disambiguate (`bayonne-fr`, `sao-paulo-brazil`). The id becomes `SIDEWALK_CITY_ID`, the schema
   (`sidewalk_laurens_ia` — new cities keep the full id), the output dir, and the server name (state dropped:
   `sidewalk-laurens.cs.washington.edu`).
 - **Neighborhood boundaries** — the thing worth spending time on, in order of preference:
@@ -45,7 +45,7 @@ Run the three from the **main checkout**: `db/` is the bind mount the db contain
 
 ```
 make build-city-data id=laurens-ia args="--place 'Laurens, Iowa, USA'"
-make build-city-data id=bayonne args="--boundary-file bayonne.geojson --regions-file quartiers.geojson \
+make build-city-data id=bayonne-fr args="--boundary-file bayonne.geojson --regions-file quartiers.geojson \
     --region-name-col nom --regions-source 'https://www.data.gouv.fr/… (Ville de Bayonne, Licence Ouverte 2.0)'"
 ```
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -188,7 +188,7 @@ loop and the imagery preflight, is [`docs/onboarding-a-city.md`](../docs/onboard
 
 ```bash
 make build-city-data id=laurens-ia args="--place 'Laurens, Iowa, USA'"
-make build-city-data id=bayonne args="--boundary-file city.geojson --regions-file quartiers.geojson \
+make build-city-data id=bayonne-fr args="--boundary-file city.geojson --regions-file quartiers.geojson \
     --region-name-col nom --regions-source 'https://…'"
 ```
 

--- a/test/python/test_create_ga_properties.py
+++ b/test/python/test_create_ga_properties.py
@@ -50,7 +50,7 @@ def _lines():
 
 def test_property_display_name_follows_the_convention(repo_copy):
     assert ga.property_display_name(_lines(), 'testville-wa') == 'Testville, WA'
-    assert ga.property_display_name(_lines(), 'bayonne') == 'Bayonne, France'
+    assert ga.property_display_name(_lines(), 'bayonne-fr') == 'Bayonne, France'
 
 
 def test_config_lookups_fail_loudly_for_an_unregistered_city(repo_copy):

--- a/tools/setup_new_city.py
+++ b/tools/setup_new_city.py
@@ -136,7 +136,7 @@ def split_city_id(city_id):
     Splits a city id into its display tokens and, for US cities, the state the trailing token abbreviates.
 
     Args:
-        city_id: e.g. ``laurens-ia`` or ``bayonne``.
+        city_id: e.g. ``laurens-ia`` or ``bayonne-fr``.
 
     Returns:
         ``(display_default, us_state)``: the title-cased name without the state suffix, and the state id


### PR DESCRIPTION
Renames Bayonne's city id from `bayonne` to `bayonne-fr` and its schema from `sidewalk_bayonne` to `sidewalk_bayonne_fr`, following the "new cities keep the full id" schema convention. Covers `cityparams.conf`, the `city.name.*` messages, docs, and the GA-properties test.

Server URLs are unchanged. Bayonne hasn't been deployed yet, so nothing on a server needs migrating: hand off `sidewalk_bayonne_fr-empty-dump` (the original dump with its schema and role renamed; contents otherwise identical) and set the server's `SIDEWALK_CITY_ID` to `bayonne-fr`.

**Tested:** loaded the new dump with `import-dump.sh`, then ran this branch as `bayonne-fr` / `sidewalk_bayonne_fr`. No evolutions pending (dump is at 384). `/`, `/explore`, `/validate`, `/leaderboard`, and `/v3/api/{regions,streets,overallStats,cities}` all return 200 with Bayonne's 26 regions and 2,721 streets, and `/v3/api/cities` lists `bayonne-fr` as "Bayonne, France".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015WpHLXbZ5rJM4XDavE45Gk