### PR TITLE
Declare the real extent in GeoPackage exports

### DIFF
--- a/app/controllers/helper/ShapefilesCreatorHelper.scala
+++ b/app/controllers/helper/ShapefilesCreatorHelper.scala
@@ -18,22 +18,25 @@ import org.apache.pekko.util.ByteString
 import org.geotools.api.data.{DataStore, DataStoreFinder, SimpleFeatureStore, Transaction}
 import org.geotools.api.feature.simple.{SimpleFeature, SimpleFeatureType}
 import org.geotools.data.shapefile.ShapefileDataStoreFactory
+import org.geotools.data.simple.SimpleFeatureCollection
 import org.geotools.data.{DataUtilities, DefaultTransaction}
 import org.geotools.feature.simple.SimpleFeatureBuilder
 import org.geotools.geometry.jts.JTSFactoryFinder
 import org.geotools.geopkg.GeoPkgDataStoreFactory
 import org.geotools.jdbc.JDBCDataStore
-import org.locationtech.jts.geom.{Coordinate, Envelope, Geometry, GeometryFactory}
+import org.locationtech.jts.geom.{Coordinate, Envelope, GeometryFactory}
 import play.api.Logger
 import play.api.libs.json.Json
 
 import java.io.{BufferedInputStream, File}
 import java.nio.file.{Files, Path}
+import java.sql.Types
 import java.util.zip.{ZipEntry, ZipOutputStream}
 import javax.inject.{Inject, Singleton}
+import scala.collection.mutable
 import scala.concurrent.{ExecutionContext, Future}
-import scala.jdk.CollectionConverters.{ListHasAsScala, MapHasAsJava}
-import scala.util.Using
+import scala.jdk.CollectionConverters.{ListHasAsScala, MapHasAsJava, SeqHasAsJava}
+import scala.util.{Failure, Success, Try, Using}
 
 /**
  * This class handles the creation of Shapefile archives to be used by the ApiController.
@@ -58,39 +61,100 @@ class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: M
     ).asJava
     DataStoreFinder.getDataStore(params) match {
       case store: JDBCDataStore => store
-      case _                    =>
+      case null                 =>
         throw new IllegalStateException(
           "No GeoTools DataStore factory accepted the GeoPackage params (is gt-geopkg on " +
             "the classpath with its META-INF/services entry?)"
         )
+      case other =>
+        other.dispose()
+        throw new IllegalStateException(
+          s"gt-geopkg returned a ${other.getClass.getName}, not a JDBCDataStore, so layer extents can't be saved"
+        )
     }
   }
 
-  private def expandExtent(extent: Envelope, features: java.util.List[SimpleFeature]): Unit =
-    features.forEach { f =>
-      Option(f.getDefaultGeometry).foreach(g => extent.expandToInclude(g.asInstanceOf[Geometry].getEnvelopeInternal))
-    }
+  /**
+   * Creates a GeoPackage, lets `writeLayers` fill it, and closes it. A failed export deletes its half-written file,
+   * since the caller only cleans up a file it gets back.
+   *
+   * @param outputFile The output filename (with no extension).
+   * @param writeLayers Writes every layer into the open GeoPackage, each through [[writeGeoPackageLayer]].
+   * @return Path to the finished GeoPackage, or None if any part of it failed.
+   */
+  private def createGeoPackage(outputFile: String)(writeLayers: JDBCDataStore => Future[Unit]): Future[Option[Path]] = {
+    val geopackagePath: Path = new File(outputFile + ".gpkg").toPath
+    Future(openGeoPackage(geopackagePath))
+      .flatMap(dataStore => Future.delegate(writeLayers(dataStore)).andThen(_ => dataStore.dispose()))
+      .map(_ => Some(geopackagePath))
+      .recover { case e: Exception =>
+        logger.error(s"Error creating GeoPackage: ${e.getMessage}", e)
+        val _ = Try(Files.deleteIfExists(geopackagePath))
+        None
+      }
+  }
+
+  /**
+   * Writes one layer of an open GeoPackage a batch at a time, then saves the layer's extent. Every GeoPackage layer is
+   * written through here, so none can be left claiming an extent of (0, 0, 0, 0) (#5275).
+   *
+   * @param dataStore The open GeoPackage.
+   * @param featureType The layer's schema; its type name becomes the table name.
+   * @param batches The layer's features, each batch saved in its own transaction.
+   * @return Completes once every batch is saved; fails if any batch fails.
+   */
+  private def writeGeoPackageLayer(
+      dataStore: JDBCDataStore,
+      featureType: SimpleFeatureType,
+      batches: Source[java.util.List[SimpleFeature], _]
+  ): Future[Unit] = {
+    dataStore.createSchema(featureType)
+    val tableName    = featureType.getTypeName
+    val featureStore = dataStore.getFeatureSource(tableName).asInstanceOf[SimpleFeatureStore]
+    val extent       = new Envelope()
+    batches
+      .runForeach { features =>
+        val batch = DataUtilities.collection(features)
+        writeFeatureBatch(featureStore, batch)
+        extent.expandToInclude(batch.getBounds)
+      }
+      .map(_ => writeGeoPackageExtent(dataStore, tableName, extent))
+  }
 
   /**
    * Saves a layer's real bounding box in `gpkg_contents`, which QGIS and GDAL trust as the layer's extent. GeoTools
    * writes that row before any feature exists and never updates it, leaving (0, 0, 0, 0) (#5275). An empty layer gets
-   * NULLs, which the GeoPackage spec reads as "extent unknown".
+   * NULLs, which the GeoPackage spec reads as "extent unknown". A failure is only logged: every feature is already
+   * saved, so the file is still worth serving.
    *
    * @param dataStore The open GeoPackage; call before disposing it.
+   * @param extent The bounding box of every feature written to the layer.
    */
   private def writeGeoPackageExtent(dataStore: JDBCDataStore, tableName: String, extent: Envelope): Unit = {
-    val bounds: Seq[java.lang.Double] =
-      if (extent.isNull) Seq.fill(4)(null)
-      else Seq(extent.getMinX, extent.getMinY, extent.getMaxX, extent.getMaxY).map(Double.box)
-    Using.Manager { use =>
+    val bounds: Seq[Option[Double]] =
+      if (extent.isNull) Seq.fill(4)(None)
+      else Seq(extent.getMinX, extent.getMinY, extent.getMaxX, extent.getMaxY).map(Some(_))
+    val rowsUpdated: Try[Int] = Using.Manager { use =>
       val cx   = use(dataStore.getConnection(Transaction.AUTO_COMMIT))
       val stmt = use(
-        cx.prepareStatement("UPDATE gpkg_contents SET min_x = ?, min_y = ?, max_x = ?, max_y = ? WHERE table_name = ?")
+        cx.prepareStatement(
+          "UPDATE gpkg_contents SET min_x = ?, min_y = ?, max_x = ?, max_y = ?, " +
+            "last_change = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE table_name = ?"
+        )
       )
-      bounds.zipWithIndex.foreach { case (b, i) => stmt.setObject(i + 1, b) }
+      bounds.zipWithIndex.foreach {
+        case (Some(bound), i) => stmt.setDouble(i + 1, bound)
+        case (None, i)        => stmt.setNull(i + 1, Types.DOUBLE)
+      }
       stmt.setString(5, tableName)
-      val _ = stmt.executeUpdate()
-    }.get
+      stmt.executeUpdate()
+    }
+    rowsUpdated match {
+      case Success(1) => ()
+      // No matching row means GeoTools has started naming the row differently, and exports are back to (0, 0, 0, 0).
+      case Success(n) => logger.warn(s"GeoPackage extent not saved: $n gpkg_contents rows match $tableName")
+      case Failure(e) => logger.warn(s"GeoPackage extent not saved for $tableName: ${e.getMessage}", e)
+    }
   }
 
   /** Rejects attribute names over the DBF format's 10-char limit, which GeoTools would otherwise truncate silently. */
@@ -103,30 +167,22 @@ class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: M
   }
 
   /**
-   * Writes a batch of features to a feature store inside a transaction.
+   * Saves a batch of features in one transaction. A failure rolls the batch back and is rethrown, so the export fails
+   * instead of serving a file with rows missing.
    *
    * @param featureStore The feature store to write to.
-   * @param features The list of features to write.
-   * @param rethrow If true, rethrows exceptions after rollback. If false, logs and swallows them.
-   * @return Whether the batch was saved; false only when an error was swallowed.
+   * @param features The batch to save.
    */
-  private def writeFeatureBatch(
-      featureStore: SimpleFeatureStore,
-      features: java.util.ArrayList[SimpleFeature],
-      rethrow: Boolean = false
-  ): Boolean = {
+  private def writeFeatureBatch(featureStore: SimpleFeatureStore, features: SimpleFeatureCollection): Unit = {
     val transaction = new DefaultTransaction("create")
     try {
       featureStore.setTransaction(transaction)
-      featureStore.addFeatures(DataUtilities.collection(features))
+      featureStore.addFeatures(features)
       transaction.commit()
-      true
     } catch {
       case e: Exception =>
         transaction.rollback()
-        if (rethrow) throw e
-        logger.error(s"Error writing features: ${e.getMessage}", e)
-        false
+        throw e
     } finally {
       transaction.close()
     }
@@ -148,54 +204,17 @@ class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: M
       batchSize: Int,
       featureType: SimpleFeatureType,
       buildFeature: (A, SimpleFeatureBuilder) => SimpleFeature
-  ): Future[Option[Path]] = {
-    val geopackagePath: Path     = new File(outputFile + ".gpkg").toPath
-    var dataStore: JDBCDataStore = null
-
-    try {
-      // Set up everything we need to create and store features before saving them.
-      dataStore = openGeoPackage(geopackagePath)
-      dataStore.createSchema(featureType)
-
-      // Get feature store for writing.
-      val typeName       = dataStore.getTypeNames()(0)
-      val featureSource  = dataStore.getFeatureSource(typeName)
-      val featureStore   = featureSource.asInstanceOf[SimpleFeatureStore]
+  ): Future[Option[Path]] =
+    createGeoPackage(outputFile) { dataStore =>
       val featureBuilder = new SimpleFeatureBuilder(featureType)
-      val features       = new java.util.ArrayList[SimpleFeature](batchSize)
-      val extent         = new Envelope()
-
-      // Process data in batches.
-      source
-        .grouped(batchSize)
-        .runForeach { batch =>
-          // Create a feature from each data point in this batch and add it to the ArrayList.
-          features.clear()
-          batch.foreach { x =>
-            featureBuilder.reset()
-            val feature: SimpleFeature = buildFeature(x, featureBuilder)
-            features.add(feature)
-          }
-
-          if (writeFeatureBatch(featureStore, features)) expandExtent(extent, features)
-        }
-        .map { _ =>
-          writeGeoPackageExtent(dataStore, typeName, extent)
-          dataStore.dispose()
-          Some(geopackagePath)
-        }
-        .recover { case e: Exception =>
-          dataStore.dispose()
-          logger.error(s"Error creating GeoPackage: ${e.getMessage}", e)
-          None
-        }
-    } catch {
-      case e: Exception =>
-        Option(dataStore).foreach(_.dispose())
-        logger.error(s"Error setting up GeoPackage: ${e.getMessage}", e)
-        Future.successful(None)
+      val batches        = source.grouped(batchSize).map { batch =>
+        batch.map { x =>
+          featureBuilder.reset()
+          buildFeature(x, featureBuilder)
+        }.asJava
+      }
+      writeGeoPackageLayer(dataStore, featureType, batches)
     }
-  }
 
   /**
    * Creates a shapefile from the given source, saving it at outputFile.
@@ -251,7 +270,7 @@ class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: M
           }
 
           // Add this batch of features to the shapefile in a transaction.
-          val _ = writeFeatureBatch(featureStore, features, rethrow = true)
+          writeFeatureBatch(featureStore, DataUtilities.collection(features))
         }
         .map { _ =>
           // Output the file path for the shapefile.
@@ -566,7 +585,7 @@ class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: M
               labelsList.foreach(label => allRawLabels.add((cluster.labelClusterId, label)))
             }
           }
-          val _ = writeFeatureBatch(clusterStore, clusterFeatures, rethrow = true)
+          writeFeatureBatch(clusterStore, DataUtilities.collection(clusterFeatures))
         }
         .map { _ =>
           clusterDataStore.dispose()
@@ -604,7 +623,7 @@ class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: M
                   labelFeatures.add(labelBuilder.buildFeature(null))
                   count += 1
                 }
-                writeFeatureBatch(labelStore, labelFeatures, rethrow = true)
+                writeFeatureBatch(labelStore, DataUtilities.collection(labelFeatures))
               }
             } finally labelDataStore.dispose()
             Some(Seq(clusterShapefilePath, labelShapefilePath))
@@ -674,113 +693,67 @@ class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: M
       + "image_date:String"       // Image capture date
     )
 
-    val geopackagePath: Path     = new File(outputFile + ".gpkg").toPath
-    var dataStore: JDBCDataStore = null
+    val geometryFactory = JTSFactoryFinder.getGeometryFactory
 
-    try {
-      dataStore = openGeoPackage(geopackagePath)
-
-      // Create both schemas.
-      dataStore.createSchema(clusterFeatureType)
-
-      val clusterTypeName = dataStore.getTypeNames()(0)
-      val clusterStore    = dataStore.getFeatureSource(clusterTypeName).asInstanceOf[SimpleFeatureStore]
-      val clusterBuilder  = new SimpleFeatureBuilder(clusterFeatureType)
-      val clusterFeatures = new java.util.ArrayList[SimpleFeature](batchSize)
-      val clusterExtent   = new Envelope()
+    createGeoPackage(outputFile) { dataStore =>
+      val clusterBuilder = new SimpleFeatureBuilder(clusterFeatureType)
+      val labelBuilder   = new SimpleFeatureBuilder(labelFeatureType)
 
       // Collect raw labels to write as a second layer after the clusters.
-      val allRawLabels    = new java.util.ArrayList[(Int, RawLabelInClusterDataForApi)]()
-      val geometryFactory = JTSFactoryFinder.getGeometryFactory
-      var hasRawLabels    = false
+      val allRawLabels = mutable.ArrayBuffer.empty[(Int, RawLabelInClusterDataForApi)]
 
-      source
-        .grouped(batchSize)
-        .runForeach { batch =>
-          clusterFeatures.clear()
-          batch.foreach { cluster =>
-            clusterBuilder.reset()
-            clusterBuilder.add(geometryFactory.createPoint(new Coordinate(cluster.avgLongitude, cluster.avgLatitude)))
-            clusterBuilder.add(cluster.labelClusterId)
-            clusterBuilder.add(cluster.labelType)
-            clusterBuilder.add(cluster.streetEdgeId)
-            clusterBuilder.add(cluster.intersectionId.map(Integer.valueOf).orNull)
-            clusterBuilder.add(cluster.osmWayId.toString)
-            clusterBuilder.add(cluster.regionId)
-            clusterBuilder.add(cluster.regionName)
-            clusterBuilder.add(cluster.avgImageCaptureDate.orNull)
-            clusterBuilder.add(cluster.avgLabelDate.orNull)
-            clusterBuilder.add(cluster.medianSeverity.map(Integer.valueOf).orNull)
-            clusterBuilder.add(cluster.agreeCount)
-            clusterBuilder.add(cluster.disagreeCount)
-            clusterBuilder.add(cluster.unsureCount)
-            clusterBuilder.add(cluster.clusterSize)
-            clusterBuilder.add(Json.stringify(Json.toJson(cluster.labelIds)))
-            clusterBuilder.add(Json.stringify(Json.toJson(cluster.userIds)))
-            clusterBuilder.add(Json.stringify(Json.toJson(cluster.tagCounts)))
-            clusterFeatures.add(clusterBuilder.buildFeature(null))
+      def buildCluster(cluster: LabelClusterForApi): SimpleFeature = {
+        clusterBuilder.reset()
+        clusterBuilder.add(geometryFactory.createPoint(new Coordinate(cluster.avgLongitude, cluster.avgLatitude)))
+        clusterBuilder.add(cluster.labelClusterId)
+        clusterBuilder.add(cluster.labelType)
+        clusterBuilder.add(cluster.streetEdgeId)
+        clusterBuilder.add(cluster.intersectionId.map(Integer.valueOf).orNull)
+        clusterBuilder.add(cluster.osmWayId.toString)
+        clusterBuilder.add(cluster.regionId)
+        clusterBuilder.add(cluster.regionName)
+        clusterBuilder.add(cluster.avgImageCaptureDate.orNull)
+        clusterBuilder.add(cluster.avgLabelDate.orNull)
+        clusterBuilder.add(cluster.medianSeverity.map(Integer.valueOf).orNull)
+        clusterBuilder.add(cluster.agreeCount)
+        clusterBuilder.add(cluster.disagreeCount)
+        clusterBuilder.add(cluster.unsureCount)
+        clusterBuilder.add(cluster.clusterSize)
+        clusterBuilder.add(Json.stringify(Json.toJson(cluster.labelIds)))
+        clusterBuilder.add(Json.stringify(Json.toJson(cluster.userIds)))
+        clusterBuilder.add(Json.stringify(Json.toJson(cluster.tagCounts)))
+        clusterBuilder.buildFeature(null)
+      }
 
-            // Collect raw labels for the second layer.
-            cluster.labels.foreach { labelsList =>
-              hasRawLabels = true
-              labelsList.foreach(label => allRawLabels.add((cluster.labelClusterId, label)))
-            }
+      def buildRawLabel(clusterId: Int, label: RawLabelInClusterDataForApi): SimpleFeature = {
+        labelBuilder.reset()
+        labelBuilder.add(geometryFactory.createPoint(new Coordinate(label.longitude, label.latitude)))
+        labelBuilder.add(label.labelId)
+        labelBuilder.add(clusterId)
+        labelBuilder.add(label.userId)
+        labelBuilder.add(label.panoId)
+        labelBuilder.add(label.panoSource.map(_.toString).orNull)
+        labelBuilder.add(label.severity.map(Integer.valueOf).orNull)
+        labelBuilder.add(label.timeCreated.toString)
+        labelBuilder.add(label.correct.map(_.toString).orNull)
+        labelBuilder.add(label.imageCaptureDate.orNull)
+        labelBuilder.buildFeature(null)
+      }
+
+      val clusterBatches = source.grouped(batchSize).map { batch =>
+        batch.foreach(c => c.labels.foreach(_.foreach(label => allRawLabels += ((c.labelClusterId, label)))))
+        batch.map(buildCluster).asJava
+      }
+      writeGeoPackageLayer(dataStore, clusterFeatureType, clusterBatches).flatMap { _ =>
+        // The raw labels layer only exists when the raw labels were included.
+        if (allRawLabels.isEmpty) Future.unit
+        else {
+          val labelBatches = Source.fromIterator(() => allRawLabels.iterator).grouped(batchSize).map { batch =>
+            batch.map { case (clusterId, label) => buildRawLabel(clusterId, label) }.asJava
           }
-
-          if (writeFeatureBatch(clusterStore, clusterFeatures)) expandExtent(clusterExtent, clusterFeatures)
+          writeGeoPackageLayer(dataStore, labelFeatureType, labelBatches)
         }
-        .flatMap { _ =>
-          writeGeoPackageExtent(dataStore, clusterTypeName, clusterExtent)
-
-          // Write the raw labels layer if the raw labels were included.
-          if (hasRawLabels && !allRawLabels.isEmpty) {
-            dataStore.createSchema(labelFeatureType)
-            val labelTypeName = "raw_labels"
-            val labelStore    = dataStore.getFeatureSource(labelTypeName).asInstanceOf[SimpleFeatureStore]
-            val labelBuilder  = new SimpleFeatureBuilder(labelFeatureType)
-            val labelFeatures = new java.util.ArrayList[SimpleFeature](batchSize)
-            val labelExtent   = new Envelope()
-
-            // Write raw labels in batches.
-            val labelIter = allRawLabels.iterator()
-            while (labelIter.hasNext) {
-              labelFeatures.clear()
-              var count = 0
-              while (labelIter.hasNext && count < batchSize) {
-                val (clusterId, label) = labelIter.next()
-                labelBuilder.reset()
-                labelBuilder.add(geometryFactory.createPoint(new Coordinate(label.longitude, label.latitude)))
-                labelBuilder.add(label.labelId)
-                labelBuilder.add(clusterId)
-                labelBuilder.add(label.userId)
-                labelBuilder.add(label.panoId)
-                labelBuilder.add(label.panoSource.map(_.toString).orNull)
-                labelBuilder.add(label.severity.map(Integer.valueOf).orNull)
-                labelBuilder.add(label.timeCreated.toString)
-                labelBuilder.add(label.correct.map(_.toString).orNull)
-                labelBuilder.add(label.imageCaptureDate.orNull)
-                labelFeatures.add(labelBuilder.buildFeature(null))
-                count += 1
-              }
-
-              if (writeFeatureBatch(labelStore, labelFeatures)) expandExtent(labelExtent, labelFeatures)
-            }
-            writeGeoPackageExtent(dataStore, labelTypeName, labelExtent)
-          }
-
-          dataStore.dispose()
-          Future.successful(Some(geopackagePath))
-        }
-        .recover { case e: Exception =>
-          dataStore.dispose()
-          logger.error(s"Error creating GeoPackage: ${e.getMessage}", e)
-          None
-        }
-    } catch {
-      case e: Exception =>
-        Option(dataStore).foreach(_.dispose())
-        logger.error(s"Error setting up GeoPackage: ${e.getMessage}", e)
-        Future.successful(None)
+      }
     }
   }
 

--- a/app/controllers/helper/ShapefilesCreatorHelper.scala
+++ b/app/controllers/helper/ShapefilesCreatorHelper.scala
@@ -15,14 +15,15 @@ import models.api.{
 import org.apache.pekko.stream.Materializer
 import org.apache.pekko.stream.scaladsl.{Source, StreamConverters}
 import org.apache.pekko.util.ByteString
-import org.geotools.api.data.{DataStore, DataStoreFinder, SimpleFeatureStore}
+import org.geotools.api.data.{DataStore, DataStoreFinder, SimpleFeatureStore, Transaction}
 import org.geotools.api.feature.simple.{SimpleFeature, SimpleFeatureType}
 import org.geotools.data.shapefile.ShapefileDataStoreFactory
 import org.geotools.data.{DataUtilities, DefaultTransaction}
 import org.geotools.feature.simple.SimpleFeatureBuilder
 import org.geotools.geometry.jts.JTSFactoryFinder
 import org.geotools.geopkg.GeoPkgDataStoreFactory
-import org.locationtech.jts.geom.{Coordinate, GeometryFactory}
+import org.geotools.jdbc.JDBCDataStore
+import org.locationtech.jts.geom.{Coordinate, Envelope, Geometry, GeometryFactory}
 import play.api.Logger
 import play.api.libs.json.Json
 
@@ -32,6 +33,7 @@ import java.util.zip.{ZipEntry, ZipOutputStream}
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.CollectionConverters.{ListHasAsScala, MapHasAsJava}
+import scala.util.Using
 
 /**
  * This class handles the creation of Shapefile archives to be used by the ApiController.
@@ -46,18 +48,49 @@ class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: M
   /**
    * Opens the GeoPackage at the given path as a data store, which the caller disposes. `DataStoreFinder` returns null
    * rather than throwing when no factory accepts the params (e.g. gt-geopkg's service file lost in packaging).
+   *
+   * @return The store as the SQL-backed kind gt-geopkg builds, so [[writeGeoPackageExtent]] can borrow its connection.
    */
-  private def openGeoPackage(geopackagePath: Path): DataStore = {
+  private def openGeoPackage(geopackagePath: Path): JDBCDataStore = {
     val params = Map(
       GeoPkgDataStoreFactory.DBTYPE.key   -> "geopkg",
       GeoPkgDataStoreFactory.DATABASE.key -> geopackagePath.toFile
     ).asJava
-    Option(DataStoreFinder.getDataStore(params)).getOrElse {
-      throw new IllegalStateException(
-        "No GeoTools DataStore factory accepted the GeoPackage params (is gt-geopkg on " +
-          "the classpath with its META-INF/services entry?)"
-      )
+    DataStoreFinder.getDataStore(params) match {
+      case store: JDBCDataStore => store
+      case _                    =>
+        throw new IllegalStateException(
+          "No GeoTools DataStore factory accepted the GeoPackage params (is gt-geopkg on " +
+            "the classpath with its META-INF/services entry?)"
+        )
     }
+  }
+
+  private def expandExtent(extent: Envelope, features: java.util.List[SimpleFeature]): Unit =
+    features.forEach { f =>
+      Option(f.getDefaultGeometry).foreach(g => extent.expandToInclude(g.asInstanceOf[Geometry].getEnvelopeInternal))
+    }
+
+  /**
+   * Saves a layer's real bounding box in `gpkg_contents`, which QGIS and GDAL trust as the layer's extent. GeoTools
+   * writes that row before any feature exists and never updates it, leaving (0, 0, 0, 0) (#5275). An empty layer gets
+   * NULLs, which the GeoPackage spec reads as "extent unknown".
+   *
+   * @param dataStore The open GeoPackage; call before disposing it.
+   */
+  private def writeGeoPackageExtent(dataStore: JDBCDataStore, tableName: String, extent: Envelope): Unit = {
+    val bounds: Seq[java.lang.Double] =
+      if (extent.isNull) Seq.fill(4)(null)
+      else Seq(extent.getMinX, extent.getMinY, extent.getMaxX, extent.getMaxY).map(Double.box)
+    Using.Manager { use =>
+      val cx   = use(dataStore.getConnection(Transaction.AUTO_COMMIT))
+      val stmt = use(
+        cx.prepareStatement("UPDATE gpkg_contents SET min_x = ?, min_y = ?, max_x = ?, max_y = ? WHERE table_name = ?")
+      )
+      bounds.zipWithIndex.foreach { case (b, i) => stmt.setObject(i + 1, b) }
+      stmt.setString(5, tableName)
+      val _ = stmt.executeUpdate()
+    }.get
   }
 
   /** Rejects attribute names over the DBF format's 10-char limit, which GeoTools would otherwise truncate silently. */
@@ -75,22 +108,25 @@ class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: M
    * @param featureStore The feature store to write to.
    * @param features The list of features to write.
    * @param rethrow If true, rethrows exceptions after rollback. If false, logs and swallows them.
+   * @return Whether the batch was saved; false only when an error was swallowed.
    */
   private def writeFeatureBatch(
       featureStore: SimpleFeatureStore,
       features: java.util.ArrayList[SimpleFeature],
       rethrow: Boolean = false
-  ): Unit = {
+  ): Boolean = {
     val transaction = new DefaultTransaction("create")
     try {
       featureStore.setTransaction(transaction)
       featureStore.addFeatures(DataUtilities.collection(features))
       transaction.commit()
+      true
     } catch {
       case e: Exception =>
         transaction.rollback()
         if (rethrow) throw e
-        else logger.error(s"Error writing features: ${e.getMessage}", e)
+        logger.error(s"Error writing features: ${e.getMessage}", e)
+        false
     } finally {
       transaction.close()
     }
@@ -113,8 +149,8 @@ class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: M
       featureType: SimpleFeatureType,
       buildFeature: (A, SimpleFeatureBuilder) => SimpleFeature
   ): Future[Option[Path]] = {
-    val geopackagePath: Path = new File(outputFile + ".gpkg").toPath
-    var dataStore: DataStore = null
+    val geopackagePath: Path     = new File(outputFile + ".gpkg").toPath
+    var dataStore: JDBCDataStore = null
 
     try {
       // Set up everything we need to create and store features before saving them.
@@ -127,6 +163,7 @@ class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: M
       val featureStore   = featureSource.asInstanceOf[SimpleFeatureStore]
       val featureBuilder = new SimpleFeatureBuilder(featureType)
       val features       = new java.util.ArrayList[SimpleFeature](batchSize)
+      val extent         = new Envelope()
 
       // Process data in batches.
       source
@@ -140,10 +177,10 @@ class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: M
             features.add(feature)
           }
 
-          writeFeatureBatch(featureStore, features)
+          if (writeFeatureBatch(featureStore, features)) expandExtent(extent, features)
         }
         .map { _ =>
-          // Return the file path for the GeoPackage.
+          writeGeoPackageExtent(dataStore, typeName, extent)
           dataStore.dispose()
           Some(geopackagePath)
         }
@@ -214,7 +251,7 @@ class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: M
           }
 
           // Add this batch of features to the shapefile in a transaction.
-          writeFeatureBatch(featureStore, features, rethrow = true)
+          val _ = writeFeatureBatch(featureStore, features, rethrow = true)
         }
         .map { _ =>
           // Output the file path for the shapefile.
@@ -529,7 +566,7 @@ class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: M
               labelsList.foreach(label => allRawLabels.add((cluster.labelClusterId, label)))
             }
           }
-          writeFeatureBatch(clusterStore, clusterFeatures, rethrow = true)
+          val _ = writeFeatureBatch(clusterStore, clusterFeatures, rethrow = true)
         }
         .map { _ =>
           clusterDataStore.dispose()
@@ -637,8 +674,8 @@ class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: M
       + "image_date:String"       // Image capture date
     )
 
-    val geopackagePath: Path = new File(outputFile + ".gpkg").toPath
-    var dataStore: DataStore = null
+    val geopackagePath: Path     = new File(outputFile + ".gpkg").toPath
+    var dataStore: JDBCDataStore = null
 
     try {
       dataStore = openGeoPackage(geopackagePath)
@@ -650,6 +687,7 @@ class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: M
       val clusterStore    = dataStore.getFeatureSource(clusterTypeName).asInstanceOf[SimpleFeatureStore]
       val clusterBuilder  = new SimpleFeatureBuilder(clusterFeatureType)
       val clusterFeatures = new java.util.ArrayList[SimpleFeature](batchSize)
+      val clusterExtent   = new Envelope()
 
       // Collect raw labels to write as a second layer after the clusters.
       val allRawLabels    = new java.util.ArrayList[(Int, RawLabelInClusterDataForApi)]()
@@ -689,9 +727,11 @@ class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: M
             }
           }
 
-          writeFeatureBatch(clusterStore, clusterFeatures)
+          if (writeFeatureBatch(clusterStore, clusterFeatures)) expandExtent(clusterExtent, clusterFeatures)
         }
         .flatMap { _ =>
+          writeGeoPackageExtent(dataStore, clusterTypeName, clusterExtent)
+
           // Write the raw labels layer if the raw labels were included.
           if (hasRawLabels && !allRawLabels.isEmpty) {
             dataStore.createSchema(labelFeatureType)
@@ -699,6 +739,7 @@ class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: M
             val labelStore    = dataStore.getFeatureSource(labelTypeName).asInstanceOf[SimpleFeatureStore]
             val labelBuilder  = new SimpleFeatureBuilder(labelFeatureType)
             val labelFeatures = new java.util.ArrayList[SimpleFeature](batchSize)
+            val labelExtent   = new Envelope()
 
             // Write raw labels in batches.
             val labelIter = allRawLabels.iterator()
@@ -722,8 +763,9 @@ class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: M
                 count += 1
               }
 
-              writeFeatureBatch(labelStore, labelFeatures)
+              if (writeFeatureBatch(labelStore, labelFeatures)) expandExtent(labelExtent, labelFeatures)
             }
+            writeGeoPackageExtent(dataStore, labelTypeName, labelExtent)
           }
 
           dataStore.dispose()

--- a/docs/upgrading-libraries.md
+++ b/docs/upgrading-libraries.md
@@ -139,7 +139,9 @@ These are the JVM libraries we talk to the database *through*; the database serv
 - **gt-shapefile / gt-epsg-hsql / gt-geopkg (GeoTools): 35.1** — Shapefile/GeoPackage generation. Served by the
   OSGeo resolver in `build.sbt`, not Maven Central. Needs Java 17. We use a tiny corner of the API, so bumps are
   usually mechanical; check both exports afterward (#4393). Brings Eclipse ImageN, sqlite-jdbc, and Jackson 3's
-  `jackson-core` along (its own package, so no clash with Play's Jackson 2).
+  `jackson-core` along (its own package, so no clash with Play's Jackson 2). The GeoPackage writer relies on gt-geopkg
+  handing back a `JDBCDataStore` and on it leaving the `gpkg_contents` bounds to us (#5275), so after a bump confirm
+  `ogrinfo -so <file>.gpkg <layer>` shows a real Extent, not (0, 0) - (0, 0).
   [Releases](https://mvnrepository.com/artifact/org.geotools/gt-shapefile?repo=geotools-releases) ·
   [Changelog](https://github.com/geotools/geotools/releases) ·
   [Upgrade notes](https://docs.geotools.org/latest/userguide/welcome/upgrade.html)

--- a/test/controllers/helper/RawLabelExportSpec.scala
+++ b/test/controllers/helper/RawLabelExportSpec.scala
@@ -1,6 +1,6 @@
 package controllers.helper
 
-import models.api.LabelDataForApi
+import models.api.{LabelClusterForApi, LabelDataForApi, RawLabelInClusterDataForApi}
 import models.label.StreetSide
 import models.pano.PanoSource
 import org.apache.pekko.stream.scaladsl.Source
@@ -15,10 +15,12 @@ import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
 
 import java.nio.file.{Files, Path}
+import java.sql.DriverManager
 import java.time.{OffsetDateTime, ZoneOffset}
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
 import scala.jdk.CollectionConverters._
+import scala.util.Using
 
 /**
  * Round-trips `/v3/api/rawLabels`'s two GIS exports through GeoTools and reads the attributes back.
@@ -28,6 +30,8 @@ import scala.jdk.CollectionConverters._
  * tail of every row. Reading the files back pins the field names -- including that the shapefile's stay inside the
  * DBF's 10-character limit, which is why `street_side` and `centerline_offset_m` become `streetSide` and
  * `ctrOffsetM` there (#2886) -- and pins the values that land under them.
+ *
+ * It also pins each GeoPackage layer's declared extent, which GeoTools on its own leaves at (0, 0, 0, 0) (#5275).
  */
 class RawLabelExportSpec extends PlaySpec with GuiceOneAppPerSuite with OptionValues {
 
@@ -114,6 +118,24 @@ class RawLabelExportSpec extends PlaySpec with GuiceOneAppPerSuite with OptionVa
       (names, features)
     } finally store.dispose()
 
+  /**
+   * The extent a GeoPackage declares for one layer, read straight from `gpkg_contents` the way GDAL and QGIS read it.
+   * GeoTools' own reader turns a NULL extent into zeros, so it can't tell "unknown" apart from the (0, 0) bug.
+   *
+   * @return `(min_x, min_y, max_x, max_y)`, or None when the extent is NULL (unknown).
+   */
+  private def declaredExtent(gpkg: Path, tableName: String): Option[(Double, Double, Double, Double)] =
+    Using.Manager { use =>
+      val cx   = use(DriverManager.getConnection(s"jdbc:sqlite:$gpkg"))
+      val stmt = use(cx.prepareStatement("SELECT min_x, min_y, max_x, max_y FROM gpkg_contents WHERE table_name = ?"))
+      stmt.setString(1, tableName)
+      val rs = use(stmt.executeQuery())
+      rs.next() mustBe true
+      Option(rs.getObject("min_x")).map { _ =>
+        (rs.getDouble("min_x"), rs.getDouble("min_y"), rs.getDouble("max_x"), rs.getDouble("max_y"))
+      }
+    }.get
+
   "the rawLabels shapefile" should {
     "carry streetSide and ctrOffsetM under DBF-legal names, with nulls for a label that has no side (#2886)" in {
       inTempDir("labels") { base =>
@@ -157,6 +179,63 @@ class RawLabelExportSpec extends PlaySpec with GuiceOneAppPerSuite with OptionVa
         features(8).getAttribute("centerline_offset_m") mustBe 4.25
         features(9).getAttribute("street_side") mustBe null
         features(9).getAttribute("centerline_offset_m") mustBe null
+      }
+    }
+
+    "declare the bounding box of its labels as the layer extent, not (0, 0, 0, 0) (#5275)" in {
+      val spread = Seq(
+        sampleLabel(8, None, None).copy(latitude = 40.88, longitude = -74.03),
+        sampleLabel(9, None, None).copy(latitude = 40.89, longitude = -74.02)
+      )
+      inTempDir("labels") { base =>
+        // One label per batch, so the extent has to carry over from one batch to the next.
+        val gpkg =
+          Await.result(shapefileCreator.createRawLabelDataGeopackage(Source(spread), base, 1), 60.seconds).value
+        declaredExtent(gpkg, "labels").value mustBe ((-74.03, 40.88, -74.02, 40.89))
+      }
+    }
+
+    "leave the extent unknown (NULL) when there are no labels, rather than claiming (0, 0) (#5275)" in {
+      inTempDir("labels") { base =>
+        val gpkg = Await.result(shapefileCreator.createRawLabelDataGeopackage(Source.empty, base, 2), 60.seconds).value
+        declaredExtent(gpkg, "labels") mustBe None
+      }
+    }
+  }
+
+  "the labelClusters GeoPackage" should {
+    "declare each layer's own extent: clusters from their centers, raw labels from the labels (#5275)" in {
+      def rawLabel(labelId: Int, latitude: Double, longitude: Double) = RawLabelInClusterDataForApi(
+        labelId = labelId,
+        userId = "user-uuid",
+        panoId = "DsCvWstZYz9JL81V9NloOQ",
+        panoSource = Some(PanoSource.Gsv),
+        severity = Some(1),
+        timeCreated = OffsetDateTime.of(2023, 8, 16, 0, 0, 0, 0, ZoneOffset.UTC),
+        latitude = latitude,
+        longitude = longitude,
+        correct = None,
+        imageCaptureDate = None
+      )
+      def cluster(id: Int, latitude: Double, longitude: Double, labels: Seq[RawLabelInClusterDataForApi]) =
+        LabelClusterForApi(
+          labelClusterId = id, labelType = "CurbRamp", streetEdgeId = 951, intersectionId = None, osmWayId = 11584845L,
+          regionId = 1, regionName = "Teaneck", avgImageCaptureDate = None, avgLabelDate = None,
+          medianSeverity = Some(1), agreeCount = 0, disagreeCount = 0, unsureCount = 0, clusterSize = labels.size,
+          labelIds = labels.map(_.labelId), userIds = Seq("user-uuid"), tagCounts = Map.empty, labels = Some(labels),
+          avgLatitude = latitude, avgLongitude = longitude
+        )
+
+      // Each cluster's labels sit a little outside its center, so the two layers' extents differ.
+      val clusters = Seq(
+        cluster(1, 40.88, -74.03, Seq(rawLabel(1, 40.879, -74.031), rawLabel(2, 40.881, -74.029))),
+        cluster(2, 40.89, -74.02, Seq(rawLabel(3, 40.889, -74.021), rawLabel(4, 40.891, -74.019)))
+      )
+      inTempDir("clusters") { base =>
+        val gpkg =
+          Await.result(shapefileCreator.createLabelClusterGeopackage(Source(clusters), base, 1), 60.seconds).value
+        declaredExtent(gpkg, "label_clusters").value mustBe ((-74.03, 40.88, -74.02, 40.89))
+        declaredExtent(gpkg, "raw_labels").value mustBe ((-74.031, 40.879, -74.019, 40.891))
       }
     }
   }

--- a/test/controllers/helper/RawLabelExportSpec.scala
+++ b/test/controllers/helper/RawLabelExportSpec.scala
@@ -1,6 +1,6 @@
 package controllers.helper
 
-import models.api.{LabelClusterForApi, LabelDataForApi, RawLabelInClusterDataForApi}
+import models.api.{LabelClusterForApi, LabelDataForApi, RawLabelInClusterDataForApi, StreetDataForApi}
 import models.label.StreetSide
 import models.pano.PanoSource
 import org.apache.pekko.stream.scaladsl.Source
@@ -8,6 +8,7 @@ import org.geotools.api.data.{DataStore, DataStoreFinder}
 import org.geotools.api.feature.simple.SimpleFeature
 import org.geotools.data.shapefile.ShapefileDataStoreFactory
 import org.geotools.geopkg.GeoPkgDataStoreFactory
+import org.locationtech.jts.geom.{Coordinate, GeometryFactory, PrecisionModel}
 import org.scalatest.OptionValues
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
@@ -122,7 +123,7 @@ class RawLabelExportSpec extends PlaySpec with GuiceOneAppPerSuite with OptionVa
    * The extent a GeoPackage declares for one layer, read straight from `gpkg_contents` the way GDAL and QGIS read it.
    * GeoTools' own reader turns a NULL extent into zeros, so it can't tell "unknown" apart from the (0, 0) bug.
    *
-   * @return `(min_x, min_y, max_x, max_y)`, or None when the extent is NULL (unknown).
+   * @return `(min_x, min_y, max_x, max_y)`, or None when all four are NULL (unknown). Fails on a partly NULL extent.
    */
   private def declaredExtent(gpkg: Path, tableName: String): Option[(Double, Double, Double, Double)] =
     Using.Manager { use =>
@@ -131,10 +132,12 @@ class RawLabelExportSpec extends PlaySpec with GuiceOneAppPerSuite with OptionVa
       stmt.setString(1, tableName)
       val rs = use(stmt.executeQuery())
       rs.next() mustBe true
-      Option(rs.getObject("min_x")).map { _ =>
-        (rs.getDouble("min_x"), rs.getDouble("min_y"), rs.getDouble("max_x"), rs.getDouble("max_y"))
-      }
-    }.get
+      Seq("min_x", "min_y", "max_x", "max_y").map(c => Option(rs.getObject(c)).map(_.asInstanceOf[Number].doubleValue))
+    }.get match {
+      case Seq(Some(minX), Some(minY), Some(maxX), Some(maxY)) => Some((minX, minY, maxX, maxY))
+      case Seq(None, None, None, None)                         => None
+      case partial                                             => fail(s"$tableName has a partly NULL extent: $partial")
+    }
 
   "the rawLabels shapefile" should {
     "carry streetSide and ctrOffsetM under DBF-legal names, with nulls for a label that has no side (#2886)" in {
@@ -199,6 +202,33 @@ class RawLabelExportSpec extends PlaySpec with GuiceOneAppPerSuite with OptionVa
       inTempDir("labels") { base =>
         val gpkg = Await.result(shapefileCreator.createRawLabelDataGeopackage(Source.empty, base, 2), 60.seconds).value
         declaredExtent(gpkg, "labels") mustBe None
+      }
+    }
+
+    "fail and delete its half-written file when the data stops partway, rather than serve missing rows" in {
+      inTempDir("labels") { base =>
+        val broken = Source(labels).concat(Source.failed(new RuntimeException("stream broke")))
+        Await.result(shapefileCreator.createRawLabelDataGeopackage(broken, base, 1), 60.seconds) mustBe None
+        Files.exists(Path.of(s"$base.gpkg")) mustBe false
+      }
+    }
+  }
+
+  "the streets GeoPackage" should {
+    "declare the extent of its lines, including a bend that reaches past both ends (#5275)" in {
+      // The middle point sticks out furthest, so an extent taken from each line's two ends would come up short.
+      val bent = new GeometryFactory(new PrecisionModel(), 4326).createLineString(
+        Array(new Coordinate(-74.03, 40.88), new Coordinate(-74.01, 40.90), new Coordinate(-74.02, 40.885))
+      )
+      val street = StreetDataForApi(
+        streetEdgeId = 951, osmWayId = 11584845L, regionId = 1, regionName = "Teaneck", wayType = "residential",
+        maxSpeed = None, status = "open", userIds = Seq.empty, labelCount = 0, auditCount = 0, outdated = false,
+        geometry = bent
+      )
+      inTempDir("streets") { base =>
+        val gpkg =
+          Await.result(shapefileCreator.createStreetDataGeopackage(Source.single(street), base, 1), 60.seconds).value
+        declaredExtent(gpkg, "streets").value mustBe ((-74.03, 40.88, -74.01, 40.90))
       }
     }
   }


### PR DESCRIPTION
resolves #5275

Every GeoPackage export (rawLabels, labelClusters, streets, regions, sidewalkPresence, and the three accessScore endpoints) declared an all-zero extent in `gpkg_contents`, so QGIS's "zoom to layer" went to (0, 0) off West Africa.

GeoTools writes that row inside `createSchema`, before any feature exists, and has no public method to update it afterwards. So `ShapefilesCreatorHelper` now writes every GeoPackage layer through one helper, `writeGeoPackageLayer`. It creates the table, saves the batches, grows the layer's bounding box from each saved batch, and then writes that box into `gpkg_contents` through the datastore's own connection. Both GeoPackage writers use it, and labelClusters' `label_clusters` and `raw_labels` layers each get their own extent. An empty export gets NULL bounds, which the GeoPackage spec reads as "unknown", instead of a false (0, 0).

Along the way:
- A batch that fails to save now fails the export, as the shapefile writers already did, instead of being skipped silently. A failed export deletes its half-written `.gpkg`.
- If the extent itself can't be saved, or no `gpkg_contents` row matches, that's logged and the file is still served.
- `docs/upgrading-libraries.md` says to check the extent after a GeoTools bump.

## Testing
- `RawLabelExportSpec` reads `gpkg_contents` directly, the way GDAL does. It covers a rawLabels extent written across batches, the empty-export NULL case, a streets LineString whose middle point sticks out past both ends, both cluster layers, and a stream that breaks partway (returns no file, leaves nothing behind). All 7 tests pass, as do the 25 in `StreetsApiSpec`, `RegionApiSpec` and `SidewalkPresenceApiSpec`.
- Against the running app, for Seattle and Zurich (before the review rework): for every layer of all 8 exports, the declared extent, `ogrinfo -so`'s Extent, and a GDAL scan of the features all match. An export for a bbox with no data declares NULL and opens fine in GDAL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NiNyu2x1sA1XY7tYDsuGc
