### PR TITLE
Show the Explore tutorial once per account, and share settings across cities

### DIFF
--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -258,7 +258,9 @@ class AdminController @Inject() (
                       _ <- teamId
                         .map(id => userService.setUserTeam(userId, id))
                         .getOrElse(userService.leaveTeam(userId))
-                      _ <- userService.setCommunityService(userId, s.communityService)
+                      _ <-
+                        if (serviceChanged) userService.setCommunityService(userId, s.communityService)
+                        else Future.successful(0)
                       // newRole is defined here: an unrecognized one was refused by the assignable-roles check above.
                       _ <- newRole
                         .filter(_ => roleChanged)

--- a/app/controllers/AdminController.scala
+++ b/app/controllers/AdminController.scala
@@ -258,7 +258,7 @@ class AdminController @Inject() (
                       _ <- teamId
                         .map(id => userService.setUserTeam(userId, id))
                         .getOrElse(userService.leaveTeam(userId))
-                      _ <- authenticationService.setCommunityServiceStatus(userId, s.communityService)
+                      _ <- userService.setCommunityService(userId, s.communityService)
                       // newRole is defined here: an unrecognized one was refused by the assignable-roles check above.
                       _ <- newRole
                         .filter(_ => roleChanged)

--- a/app/controllers/UserController.scala
+++ b/app/controllers/UserController.scala
@@ -228,7 +228,7 @@ class UserController @Inject() (
    * Powers the one-click opt-in on `/welcome` and the toggle on `/serviceHoursInstructions` (both plain form POSTs so
    * they work without JS). Anonymous users can't opt in — they're sent to sign-up instead.
    *
-   * @param enabled Whether to enable (true) or disable (false) `user_role.community_service`.
+   * @param enabled Whether to enable (true) or disable (false) `user_settings.community_service`.
    * @param next    Same-origin path to return to; defaults to (and is constrained to) `/serviceHoursInstructions`.
    */
   def setServiceHours(enabled: Boolean, next: Option[String]) =
@@ -236,7 +236,7 @@ class UserController @Inject() (
       val target = safeLocalPath(next.getOrElse("/serviceHoursInstructions"), "/serviceHoursInstructions")
       if (request.identity.role == Role.Anonymous) Future.successful(Redirect(routes.UserController.signUp()))
       else
-        authenticationService.setCommunityServiceStatus(request.identity.userId, enabled).map { _ =>
+        userService.setCommunityService(request.identity.userId, enabled).map { _ =>
           cc.loggingService.insert(request.identity.userId, request.ipAddress, s"ServiceHours_Set=$enabled")
           Redirect(target)
         }
@@ -478,7 +478,7 @@ class UserController @Inject() (
                 val newUserId: String = oldUserId.getOrElse(UUID.randomUUID().toString)
                 val newUser           =
                   SidewalkUserWithRole(newUserId, data.username, email, Role.Registered, communityService = false,
-                    false)
+                    false, measurementSystem = None)
                 val pwInfo = passwordHasher.hash(data.password)
 
                 for {

--- a/app/controllers/UserDashboardController.scala
+++ b/app/controllers/UserDashboardController.scala
@@ -2,10 +2,10 @@ package controllers
 
 import controllers.base.{CustomBaseController, CustomControllerComponents}
 import controllers.helper.ControllerUtils
-import controllers.helper.ControllerUtils.MeasurementSystem
+import controllers.helper.ControllerUtils.UnitsOverride
 import formats.json.UserFormats.{settingsSubmissionReads, SettingsSubmission}
 import models.auth.{DefaultEnv, WithAdmin, WithSignedIn}
-import models.user.{Role, SidewalkUserWithRole}
+import models.user.{MeasurementSystem, Role, SidewalkUserWithRole}
 import play.api.Configuration
 import play.api.i18n.Messages
 import play.api.libs.json.{JsError, JsSuccess, Json}
@@ -183,11 +183,7 @@ class UserDashboardController @Inject() (
    */
   def settings = cc.securityService.SecuredAction(WithSignedIn()) { implicit request =>
     val user        = request.identity
-    val unitsChoice = request.cookies
-      .get(MeasurementSystem.CookieName)
-      .map(_.value)
-      .filter(MeasurementSystem.validOverrides.contains)
-      .getOrElse(MeasurementSystem.FollowLanguage)
+    val unitsChoice = ControllerUtils.unitsChoice
     for {
       commonData <- configService.getCommonPageData(request2Messages.lang)
       openTeams  <- userService.getAllOpenTeams
@@ -211,8 +207,8 @@ class UserDashboardController @Inject() (
    * username that fails validation (length, allowed characters, profanity, or already taken) refuses the whole save
    * with a 400 and a user-facing message before anything is written; the rename itself is the last write.
    *
-   * Units are the one setting that isn't a database write: like the language choice it lives in a cookie, so a
-   * submitted change either sets the override or discards it to fall back to the site language (#4404).
+   * Units and community service hours are saved to the account, so they apply in every city (#3720). Units are also
+   * copied into this city's cookie, which is what the site falls back to once the user signs out.
    */
   def saveSettings = cc.securityService.SecuredAction(WithSignedIn(), parse.json) { implicit request =>
     val user                    = request.identity
@@ -223,16 +219,13 @@ class UserDashboardController @Inject() (
       case JsSuccess(s, _) =>
         val teamId       = s.teamId.filter(_ > 0)
         val usernameEdit = s.username.filter(_ != user.username)
-        val unitsWere    = request.cookies
-          .get(MeasurementSystem.CookieName)
-          .map(_.value)
-          .filter(MeasurementSystem.validOverrides.contains)
-          .getOrElse(MeasurementSystem.FollowLanguage)
+        val unitsWere    = ControllerUtils.unitsChoice
         // Absent field means "this caller isn't touching units", which has to stay distinct from an explicit "auto" —
         // otherwise any save that omits it silently wipes the reader's stored choice.
         val unitsSubmitted = s.measurementSystem
-          .filter(system => MeasurementSystem.validOverrides(system) || system == MeasurementSystem.FollowLanguage)
-        val unitsNow = unitsSubmitted.getOrElse(unitsWere)
+          .filter(system => MeasurementSystem.fromString(system).isDefined || system == UnitsOverride.FollowLanguage)
+        val unitsNow                                     = unitsSubmitted.getOrElse(unitsWere)
+        val unitsToSave: Option[MeasurementSystem.Value] = MeasurementSystem.fromString(unitsNow)
 
         // Only the username can be refused, so it's checked before the first write and renamed after the last one.
         val usernameCheck: Future[Either[String, Unit]] = usernameEdit
@@ -248,8 +241,13 @@ class UserDashboardController @Inject() (
                 .map(id => userService.setUserTeam(user.userId, id))
                 .getOrElse(Future.successful(0))
               _ <- s.communityService
-                .map(cs => authenticationService.setCommunityServiceStatus(user.userId, cs))
+                .map(cs => userService.setCommunityService(user.userId, cs))
                 .getOrElse(Future.successful(0))
+              // Compared with what the account has saved rather than with unitsWere, so that a choice only this city's
+              // cookie knew about gets saved to the account the next time the form is saved.
+              _ <-
+                if (unitsToSave != user.measurementSystem) userService.setMeasurementSystem(user.userId, unitsToSave)
+                else Future.successful(0)
               _ <- usernameEdit
                 .map(name => userService.changeUsername(user.userId, name))
                 .getOrElse(Future.successful(Right(user.username)))
@@ -262,10 +260,10 @@ class UserDashboardController @Inject() (
                   .insert(user.userId, request.ipAddress, s"Click_module=ChangeUnits_from=${unitsWere}_to=$unitsNow")
               }
               val result = Ok(Json.obj("success" -> true))
-              if (unitsNow == unitsWere) result
-              else if (MeasurementSystem.validOverrides(unitsNow))
-                result.withCookies(MeasurementSystem.overrideCookie(unitsNow))
-              else result.discardingCookies(MeasurementSystem.clearOverrideCookie)
+              unitsToSave match {
+                case Some(system) => result.withCookies(UnitsOverride.overrideCookie(system))
+                case None         => result.discardingCookies(UnitsOverride.clearOverrideCookie)
+              }
             }
         }
     }

--- a/app/controllers/UserDashboardController.scala
+++ b/app/controllers/UserDashboardController.scala
@@ -2,7 +2,6 @@ package controllers
 
 import controllers.base.{CustomBaseController, CustomControllerComponents}
 import controllers.helper.ControllerUtils
-import controllers.helper.ControllerUtils.UnitsOverride
 import formats.json.UserFormats.{settingsSubmissionReads, SettingsSubmission}
 import models.auth.{DefaultEnv, WithAdmin, WithSignedIn}
 import models.user.{MeasurementSystem, Role, SidewalkUserWithRole}
@@ -183,7 +182,7 @@ class UserDashboardController @Inject() (
    */
   def settings = cc.securityService.SecuredAction(WithSignedIn()) { implicit request =>
     val user        = request.identity
-    val unitsChoice = ControllerUtils.unitsChoice
+    val unitsChoice = MeasurementSystem.choiceName(user.measurementSystem)
     for {
       commonData <- configService.getCommonPageData(request2Messages.lang)
       openTeams  <- userService.getAllOpenTeams
@@ -207,8 +206,7 @@ class UserDashboardController @Inject() (
    * username that fails validation (length, allowed characters, profanity, or already taken) refuses the whole save
    * with a 400 and a user-facing message before anything is written; the rename itself is the last write.
    *
-   * Units and community service hours are saved to the account, so they apply in every city (#3720). Units are also
-   * copied into this city's cookie, which is what the site falls back to once the user signs out.
+   * Units and community service hours are saved to the account, so they apply in every city (#3720).
    */
   def saveSettings = cc.securityService.SecuredAction(WithSignedIn(), parse.json) { implicit request =>
     val user                    = request.identity
@@ -219,13 +217,15 @@ class UserDashboardController @Inject() (
       case JsSuccess(s, _) =>
         val teamId       = s.teamId.filter(_ > 0)
         val usernameEdit = s.username.filter(_ != user.username)
-        val unitsWere    = ControllerUtils.unitsChoice
-        // Absent field means "this caller isn't touching units", which has to stay distinct from an explicit "auto" —
-        // otherwise any save that omits it silently wipes the reader's stored choice.
-        val unitsSubmitted = s.measurementSystem
-          .filter(system => MeasurementSystem.fromString(system).isDefined || system == UnitsOverride.FollowLanguage)
-        val unitsNow                                     = unitsSubmitted.getOrElse(unitsWere)
-        val unitsToSave: Option[MeasurementSystem.Value] = MeasurementSystem.fromString(unitsNow)
+        // An absent field means "this caller isn't touching it" (the /welcome privacy toggles post only their two
+        // flags), which has to stay distinct from an explicit "auto", or those saves would wipe the user's choice.
+        val unitsEdit: Option[Option[MeasurementSystem.Value]] = s.measurementSystem
+          .filter(choice =>
+            choice == MeasurementSystem.FollowLanguage || MeasurementSystem.fromString(choice).isDefined
+          )
+          .map(MeasurementSystem.fromString)
+          .filter(_ != user.measurementSystem)
+        val serviceEdit: Option[Boolean] = s.communityService.filter(_ != user.communityService)
 
         // Only the username can be refused, so it's checked before the first write and renamed after the last one.
         val usernameCheck: Future[Either[String, Unit]] = usernameEdit
@@ -240,14 +240,12 @@ class UserDashboardController @Inject() (
               _ <- teamId
                 .map(id => userService.setUserTeam(user.userId, id))
                 .getOrElse(Future.successful(0))
-              _ <- s.communityService
+              _ <- serviceEdit
                 .map(cs => userService.setCommunityService(user.userId, cs))
                 .getOrElse(Future.successful(0))
-              // Compared with what the account has saved rather than with unitsWere, so that a choice only this city's
-              // cookie knew about gets saved to the account the next time the form is saved.
-              _ <-
-                if (unitsToSave != user.measurementSystem) userService.setMeasurementSystem(user.userId, unitsToSave)
-                else Future.successful(0)
+              _ <- unitsEdit
+                .map(units => userService.setMeasurementSystem(user.userId, units))
+                .getOrElse(Future.successful(0))
               _ <- usernameEdit
                 .map(name => userService.changeUsername(user.userId, name))
                 .getOrElse(Future.successful(Right(user.username)))
@@ -255,15 +253,16 @@ class UserDashboardController @Inject() (
               cc.loggingService.insert(user.userId, request.ipAddress, "Click_module=SaveSettings")
               // Logged separately from the save, and only on a real change, so units can be analyzed the way the
               // navbar's ChangeLanguage already is rather than being buried in every settings save.
-              if (unitsNow != unitsWere) {
-                cc.loggingService
-                  .insert(user.userId, request.ipAddress, s"Click_module=ChangeUnits_from=${unitsWere}_to=$unitsNow")
+              unitsEdit.foreach { units =>
+                val (from, to) =
+                  (MeasurementSystem.choiceName(user.measurementSystem), MeasurementSystem.choiceName(units))
+                cc.loggingService.insert(
+                  user.userId,
+                  request.ipAddress,
+                  s"Click_module=ChangeUnits_from=${from}_to=$to"
+                )
               }
-              val result = Ok(Json.obj("success" -> true))
-              unitsToSave match {
-                case Some(system) => result.withCookies(UnitsOverride.overrideCookie(system))
-                case None         => result.discardingCookies(UnitsOverride.clearOverrideCookie)
-              }
+              Ok(Json.obj("success" -> true))
             }
         }
     }

--- a/app/controllers/helper/ControllerUtils.scala
+++ b/app/controllers/helper/ControllerUtils.scala
@@ -3,7 +3,7 @@ package controllers.helper
 import models.user.{MeasurementSystem, Role, SidewalkUserWithRole}
 import play.api.i18n.Messages
 import play.api.mvc.Results.{Redirect, Unauthorized}
-import play.api.mvc.{Cookie, DiscardingCookie, RequestHeader, Result}
+import play.api.mvc.{RequestHeader, Result}
 import play.silhouette.api.actions.{SecuredRequestHeader, UserAwareRequestHeader}
 
 import java.nio.charset.StandardCharsets
@@ -51,30 +51,6 @@ object ControllerUtils {
   }
 
   /**
-   * What the Settings form submits for units, and the cookie that also holds a units choice.
-   *
-   * The cookie is the fallback when the account has no saved choice, e.g. for a visitor who isn't signed in. It's per
-   * city, since each city is its own domain.
-   */
-  object UnitsOverride {
-
-    /** What the settings form submits, and the select's value, for "follow the site language". */
-    val FollowLanguage: String = "auto"
-
-    val CookieName: String = "PS_UNITS"
-
-    /** A display preference rather than a credential, so it outlives the browser session; a year is effectively forever. */
-    private val cookieMaxAge: Int = 365 * 24 * 60 * 60
-
-    /** The cookie that pins requests to `system`. HttpOnly: client code reads the `<html>` stamp, never the cookie. */
-    def overrideCookie(system: MeasurementSystem.Value): Cookie =
-      Cookie(CookieName, system.toString, maxAge = Some(cookieMaxAge), httpOnly = true)
-
-    /** Clears any override, returning the user to language-derived units. */
-    def clearOverrideCookie: DiscardingCookie = DiscardingCookie(CookieName)
-  }
-
-  /**
    * The user behind a request, whichever kind of action served it.
    *
    * Templates only get a `RequestHeader`, but the one they're handed is the action's own request, which still carries
@@ -90,32 +66,15 @@ object ControllerUtils {
   }
 
   /**
-   * The units the user chose, if any: the choice saved to their account, else this city's cookie.
+   * The measurement system this request should render distances in: the units saved to the user's account (shared by
+   * every city, #3720), else the site language's.
    *
-   * @param request The request whose user and cookies are inspected.
-   * @return        The chosen system, or None to follow the site language.
-   */
-  def unitsOverride(implicit request: RequestHeader): Option[MeasurementSystem.Value] = {
-    requestUser(request)
-      .flatMap(_.measurementSystem)
-      .orElse(
-        request.cookies.get(UnitsOverride.CookieName).flatMap(cookie => MeasurementSystem.fromString(cookie.value))
-      )
-  }
-
-  /** The units choice as the Settings page's select names it: "auto", "metric", or "imperial". */
-  def unitsChoice(implicit request: RequestHeader): String =
-    unitsOverride.map(_.toString).getOrElse(UnitsOverride.FollowLanguage)
-
-  /**
-   * The measurement system this request should render distances in: the user's choice, else the site language's.
-   *
-   * @param request  The request whose user and cookies are inspected.
-   * @param messages The request's messages, supplying the language default when there is no choice.
+   * @param request  The request whose user is inspected.
+   * @param messages The request's messages, supplying the language default when there is no saved choice.
    * @return         Either `MeasurementSystem.Metric` or `MeasurementSystem.Imperial` — never a language's own wording.
    */
   def measurementSystem(implicit request: RequestHeader, messages: Messages): MeasurementSystem.Value = {
-    unitsOverride.getOrElse {
+    requestUser(request).flatMap(_.measurementSystem).getOrElse {
       MeasurementSystem.fromString(messages("measurement.system")).getOrElse(MeasurementSystem.Imperial)
     }
   }

--- a/app/controllers/helper/ControllerUtils.scala
+++ b/app/controllers/helper/ControllerUtils.scala
@@ -1,9 +1,10 @@
 package controllers.helper
 
-import models.user.{Role, SidewalkUserWithRole}
+import models.user.{MeasurementSystem, Role, SidewalkUserWithRole}
 import play.api.i18n.Messages
 import play.api.mvc.Results.{Redirect, Unauthorized}
 import play.api.mvc.{Cookie, DiscardingCookie, RequestHeader, Result}
+import play.silhouette.api.actions.{SecuredRequestHeader, UserAwareRequestHeader}
 
 import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
@@ -50,13 +51,12 @@ object ControllerUtils {
   }
 
   /**
-   * The two measurement systems the site renders distances in, and the cookie that pins a request to one of them.
+   * What the Settings form submits for units, and the cookie that also holds a units choice.
    *
-   * Units can be specified on the User Dashboard, or defaults to the site language (the `measurement.system` message).
+   * The cookie is the fallback when the account has no saved choice, e.g. for a visitor who isn't signed in. It's per
+   * city, since each city is its own domain.
    */
-  object MeasurementSystem {
-    val Metric: String   = "metric"
-    val Imperial: String = "imperial"
+  object UnitsOverride {
 
     /** What the settings form submits, and the select's value, for "follow the site language". */
     val FollowLanguage: String = "auto"
@@ -66,33 +66,58 @@ object ControllerUtils {
     /** A display preference rather than a credential, so it outlives the browser session; a year is effectively forever. */
     private val cookieMaxAge: Int = 365 * 24 * 60 * 60
 
-    /** The values `CookieName` may hold. Anything else is treated as absent. */
-    val validOverrides: Set[String] = Set(Metric, Imperial)
-
     /** The cookie that pins requests to `system`. HttpOnly: client code reads the `<html>` stamp, never the cookie. */
-    def overrideCookie(system: String): Cookie =
-      Cookie(CookieName, system, maxAge = Some(cookieMaxAge), httpOnly = true)
+    def overrideCookie(system: MeasurementSystem.Value): Cookie =
+      Cookie(CookieName, system.toString, maxAge = Some(cookieMaxAge), httpOnly = true)
 
     /** Clears any override, returning the user to language-derived units. */
     def clearOverrideCookie: DiscardingCookie = DiscardingCookie(CookieName)
   }
 
   /**
-   * The measurement system this request should render distances in: users can override on their dashboard settings.
+   * The user behind a request, whichever kind of action served it.
    *
-   * @param request  The request whose override cookie is inspected.
-   * @param messages The request's messages, supplying the language default when there is no override.
+   * Templates only get a `RequestHeader`, but the one they're handed is the action's own request, which still carries
+   * the user Silhouette loaded for it.
+   *
+   * @param request The request to inspect.
+   * @return        The user, or None for a request with no session.
+   */
+  private def requestUser(request: RequestHeader): Option[SidewalkUserWithRole] = request match {
+    case secured: SecuredRequestHeader[_] => Some(secured.identity).collect { case user: SidewalkUserWithRole => user }
+    case aware: UserAwareRequestHeader[_] => aware.identity.collect { case user: SidewalkUserWithRole => user }
+    case _                                => None
+  }
+
+  /**
+   * The units the user chose, if any: the choice saved to their account, else this city's cookie.
+   *
+   * @param request The request whose user and cookies are inspected.
+   * @return        The chosen system, or None to follow the site language.
+   */
+  def unitsOverride(implicit request: RequestHeader): Option[MeasurementSystem.Value] = {
+    requestUser(request)
+      .flatMap(_.measurementSystem)
+      .orElse(
+        request.cookies.get(UnitsOverride.CookieName).flatMap(cookie => MeasurementSystem.fromString(cookie.value))
+      )
+  }
+
+  /** The units choice as the Settings page's select names it: "auto", "metric", or "imperial". */
+  def unitsChoice(implicit request: RequestHeader): String =
+    unitsOverride.map(_.toString).getOrElse(UnitsOverride.FollowLanguage)
+
+  /**
+   * The measurement system this request should render distances in: the user's choice, else the site language's.
+   *
+   * @param request  The request whose user and cookies are inspected.
+   * @param messages The request's messages, supplying the language default when there is no choice.
    * @return         Either `MeasurementSystem.Metric` or `MeasurementSystem.Imperial` — never a language's own wording.
    */
-  def measurementSystem(implicit request: RequestHeader, messages: Messages): String = {
-    request.cookies
-      .get(MeasurementSystem.CookieName)
-      .map(_.value)
-      .filter(MeasurementSystem.validOverrides.contains)
-      .getOrElse {
-        if (messages("measurement.system") == MeasurementSystem.Metric) MeasurementSystem.Metric
-        else MeasurementSystem.Imperial
-      }
+  def measurementSystem(implicit request: RequestHeader, messages: Messages): MeasurementSystem.Value = {
+    unitsOverride.getOrElse {
+      MeasurementSystem.fromString(messages("measurement.system")).getOrElse(MeasurementSystem.Imperial)
+    }
   }
 
   /**

--- a/app/formats/json/UserFormats.scala
+++ b/app/formats/json/UserFormats.scala
@@ -43,13 +43,17 @@ object UserFormats {
   }
   implicit val roleWrites: Writes[Role.Value] = Writes(role => JsString(role.toString))
 
+  implicit val measurementSystemReads: Reads[MeasurementSystem.Value]   = Reads.enumNameReads(MeasurementSystem)
+  implicit val measurementSystemWrites: Writes[MeasurementSystem.Value] = Writes.enumNameWrites
+
   implicit val sidewalkUserWithRoleReads: Reads[SidewalkUserWithRole] = (
     (JsPath \ "userId").read[String] and
       (JsPath \ "username").read[String] and
       (JsPath \ "email").read[String] and
       (JsPath \ "role").read[Role.Value] and
       (JsPath \ "community_service").read[Boolean] and
-      (JsPath \ "infra3d_access").read[Boolean]
+      (JsPath \ "infra3d_access").read[Boolean] and
+      (JsPath \ "measurement_system").readNullable[MeasurementSystem.Value]
   )(SidewalkUserWithRole.apply _)
 
   implicit val sidewalkUserWithRoleWrites: Writes[SidewalkUserWithRole] = (
@@ -58,7 +62,8 @@ object UserFormats {
       (JsPath \ "email").write[String] and
       (JsPath \ "role").write[Role.Value] and
       (JsPath \ "community_service").write[Boolean] and
-      (JsPath \ "infra3d_access").write[Boolean]
+      (JsPath \ "infra3d_access").write[Boolean] and
+      (JsPath \ "measurement_system").writeNullable[MeasurementSystem.Value]
   )(unlift(SidewalkUserWithRole.unapply))
 
   implicit val userStatsWrites: Writes[UserStatsForAdminPage] = (

--- a/app/models/mission/MissionTable.scala
+++ b/app/models/mission/MissionTable.scala
@@ -115,16 +115,6 @@ class MissionTable @Inject() (protected val dbConfigProvider: DatabaseConfigProv
   }
 
   /**
-   * Check if the user has completed onboarding.
-   */
-  def hasCompletedAuditOnboarding(userId: String): DBIO[Boolean] = {
-    completedMissionsQuery(userId, includeOnboarding = true, includeSkipped = true)
-      .filter(_.missionType === MissionType.AuditOnboarding)
-      .exists
-      .result
-  }
-
-  /**
    * Checks if the specified mission is an onboarding mission.
    */
   def isOnboardingMission(missionId: Int): DBIO[Boolean] = {

--- a/app/models/user/MeasurementSystem.scala
+++ b/app/models/user/MeasurementSystem.scala
@@ -1,0 +1,13 @@
+package models.user
+
+/**
+ * The two systems the site shows distances in. A user's saved choice is stored as the `measurement_system` enum in
+ * `user_settings`, whose labels match these values.
+ */
+object MeasurementSystem extends Enumeration {
+  val Metric: Value   = Value("metric")
+  val Imperial: Value = Value("imperial")
+
+  /** Parses a name like "metric". None for anything else, since cookies and form posts come from the visitor. */
+  def fromString(name: String): Option[Value] = values.find(_.toString == name)
+}

--- a/app/models/user/MeasurementSystem.scala
+++ b/app/models/user/MeasurementSystem.scala
@@ -8,6 +8,12 @@ object MeasurementSystem extends Enumeration {
   val Metric: Value   = Value("metric")
   val Imperial: Value = Value("imperial")
 
-  /** Parses a name like "metric". None for anything else, since cookies and form posts come from the visitor. */
+  /** What the Settings page's units select submits for "follow the site language", which is saved as no choice. */
+  val FollowLanguage: String = "auto"
+
+  /** Parses a name like "metric". None for anything else, since form posts come from the visitor. */
   def fromString(name: String): Option[Value] = values.find(_.toString == name)
+
+  /** A saved choice as the Settings select (and the ChangeUnits log event) names it: "auto" when there is none. */
+  def choiceName(saved: Option[Value]): String = saved.map(_.toString).getOrElse(FollowLanguage)
 }

--- a/app/models/user/SidewalkUserTable.scala
+++ b/app/models/user/SidewalkUserTable.scala
@@ -10,13 +10,22 @@ import javax.inject._
 import scala.concurrent.{ExecutionContext, Future}
 
 case class SidewalkUser(userId: String, username: String, email: String)
+
+/**
+ * The user behind a request, loaded on every request. Account-wide settings ride along so pages needn't query again.
+ *
+ * @param communityService  Whether they're tracking their time for community service hours.
+ * @param infra3dAccess     Whether they may view this city's infra3D imagery (always false in non-infra3D cities).
+ * @param measurementSystem The units they chose on the Settings page, or None to follow the site language.
+ */
 case class SidewalkUserWithRole(
     userId: String,
     username: String,
     email: String,
     role: Role.Value,
     communityService: Boolean,
-    infra3dAccess: Boolean
+    infra3dAccess: Boolean,
+    measurementSystem: Option[MeasurementSystem.Value]
 ) extends Identity
 
 class SidewalkUserTableDef(tag: Tag) extends Table[SidewalkUser](tag, "sidewalk_user") {
@@ -47,11 +56,22 @@ class SidewalkUserTable @Inject() (
 
   val sidewalkUser           = TableQuery[SidewalkUserTableDef]
   val userRole               = TableQuery[UserRoleTableDef]
+  val userSettings           = TableQuery[UserSettingsTableDef]
   val sidewalkUserToRoleJoin = sidewalkUser.join(userRole).on(_.userId === _.userId)
-  val sidewalkUserWithRole   = sidewalkUserToRoleJoin
-    .map { case (user, userRole) =>
-      (user.userId, user.username, user.email, userRole.role, userRole.communityService,
-        userRoleTable.infra3dAccessForCurrentCity(userRole))
+  // A left join, because a user with no user_settings row has every setting at its default.
+  val sidewalkUserWithRole = sidewalkUserToRoleJoin
+    .joinLeft(userSettings)
+    .on(_._1.userId === _.userId)
+    .map { case ((user, userRole), settings) =>
+      (
+        user.userId,
+        user.username,
+        user.email,
+        userRole.role,
+        settings.map(_.communityService).getOrElse(false),
+        userRoleTable.infra3dAccessForCurrentCity(userRole),
+        settings.flatMap(_.measurementSystem)
+      )
     }
   val aiUsers    = sidewalkUserToRoleJoin.filter(_._2.role === Role.Ai).map(_._1)
   val humanUsers = sidewalkUserToRoleJoin.filter(_._2.role =!= Role.Ai).map(_._1)

--- a/app/models/user/UserAccountStateTable.scala
+++ b/app/models/user/UserAccountStateTable.scala
@@ -9,20 +9,20 @@ import java.time.OffsetDateTime
 import javax.inject._
 
 /** @param exploreTutorialCompletedAt When the user first finished or skipped the Explore tutorial, in any city. */
-case class UserState(userId: String, exploreTutorialCompletedAt: Option[OffsetDateTime])
+case class UserAccountState(userId: String, exploreTutorialCompletedAt: Option[OffsetDateTime])
 
-class UserStateTableDef(tag: Tag) extends Table[UserState](tag, "user_state") {
+class UserAccountStateTableDef(tag: Tag) extends Table[UserAccountState](tag, "user_account_state") {
   def userId: Rep[String]                                     = column[String]("user_id", O.PrimaryKey)
   def exploreTutorialCompletedAt: Rep[Option[OffsetDateTime]] =
     column[Option[OffsetDateTime]]("explore_tutorial_completed_at")
 
-  def * = (userId, exploreTutorialCompletedAt) <> ((UserState.apply _).tupled, UserState.unapply)
+  def * = (userId, exploreTutorialCompletedAt) <> ((UserAccountState.apply _).tupled, UserAccountState.unapply)
 
-  def user = foreignKey("user_state_user_id_fkey", userId, TableQuery[SidewalkUserTableDef])(_.userId)
+  def user = foreignKey("user_account_state_user_id_fkey", userId, TableQuery[SidewalkUserTableDef])(_.userId)
 }
 
-@ImplementedBy(classOf[UserStateTable])
-trait UserStateTableRepository {}
+@ImplementedBy(classOf[UserAccountStateTable])
+trait UserAccountStateTableRepository {}
 
 /**
  * Things the site records about a user that belong to their account rather than to one city (#3720), like having
@@ -32,30 +32,29 @@ trait UserStateTableRepository {}
  * A row is only written once there's something to record, so a missing row means nothing has been recorded yet.
  */
 @Singleton
-class UserStateTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvider)
-    extends UserStateTableRepository
+class UserAccountStateTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvider)
+    extends UserAccountStateTableRepository
     with HasDatabaseConfigProvider[MyPostgresProfile] {
 
-  val userStates = TableQuery[UserStateTableDef]
+  val userAccountStates = TableQuery[UserAccountStateTableDef]
 
   /** Whether the user has finished or skipped the Explore tutorial in any city. */
   def hasCompletedExploreTutorial(userId: String): DBIO[Boolean] = {
-    userStates.filter(s => s.userId === userId && s.exploreTutorialCompletedAt.isDefined).exists.result
+    userAccountStates.filter(s => s.userId === userId && s.exploreTutorialCompletedAt.isDefined).exists.result
   }
 
   /**
-   * Records that the user finished or skipped the Explore tutorial. A retake keeps the original time, since that's when
-   * they first learned the tool.
+   * Records that the user finished or skipped the Explore tutorial. A retake keeps the original time.
    *
    * @param userId The user who finished it.
    * @return       The number of rows written.
    */
   def markExploreTutorialCompleted(userId: String): DBIO[Int] = {
     sqlu"""
-      INSERT INTO sidewalk_login.user_state (user_id, explore_tutorial_completed_at)
+      INSERT INTO sidewalk_login.user_account_state (user_id, explore_tutorial_completed_at)
       VALUES ($userId, now())
       ON CONFLICT (user_id) DO UPDATE SET explore_tutorial_completed_at =
-        COALESCE(user_state.explore_tutorial_completed_at, EXCLUDED.explore_tutorial_completed_at)
+        COALESCE(user_account_state.explore_tutorial_completed_at, EXCLUDED.explore_tutorial_completed_at)
     """
   }
 }

--- a/app/models/user/UserRoleTable.scala
+++ b/app/models/user/UserRoleTable.scala
@@ -12,20 +12,19 @@ case class UserRole(
     userRoleId: Int,
     userId: String,
     role: Role.Value,
-    communityService: Boolean,
     zurichInfra3dAccess: Boolean,
     winterthurInfra3dAccess: Boolean
 )
 
+// The table still has a community_service column until #5306 drops it. Nothing reads it: user_settings holds it now.
 class UserRoleTableDef(tag: Tag) extends Table[UserRole](tag, "user_role") {
   def userRoleId: Rep[Int]                  = column[Int]("user_role_id", O.PrimaryKey, O.AutoInc)
   def userId: Rep[String]                   = column[String]("user_id")
   def role: Rep[Role.Value]                 = column[Role.Value]("role")
-  def communityService: Rep[Boolean]        = column[Boolean]("community_service", O.Default(false))
   def zurichInfra3dAccess: Rep[Boolean]     = column[Boolean]("zurich_infra3d_access", O.Default(false))
   def winterthurInfra3dAccess: Rep[Boolean] = column[Boolean]("winterthur_infra3d_access", O.Default(false))
 
-  def * = (userRoleId, userId, role, communityService, zurichInfra3dAccess, winterthurInfra3dAccess) <>
+  def * = (userRoleId, userId, role, zurichInfra3dAccess, winterthurInfra3dAccess) <>
     ((UserRole.apply _).tupled, UserRole.unapply)
 
   def user = foreignKey("user_role_user_id_fkey", userId, TableQuery[SidewalkUserTableDef])(_.userId)
@@ -56,36 +55,21 @@ class UserRoleTable @Inject() (protected val dbConfigProvider: DatabaseConfigPro
    * Adds a new role for a user in the database.
    * @param userId The ID of the user to whom the role is being added
    * @param newRole The role to be added to the user
-   * @param communityService Optional parameter to indicate if the user is doing community service, defaults to false
    * @return A DBIO action that returns the newly added UserRole
    */
-  def addRole(userId: String, newRole: Role.Value, communityService: Boolean = false): DBIO[UserRole] = {
+  def addRole(userId: String, newRole: Role.Value): DBIO[UserRole] = {
     (userRoles returning userRoles) +=
-      UserRole(0, userId, newRole, communityService, zurichInfra3dAccess = false, winterthurInfra3dAccess = false)
+      UserRole(0, userId, newRole, zurichInfra3dAccess = false, winterthurInfra3dAccess = false)
   }
 
   /**
    * Updates the role of a user in the database.
    * @param userId The ID of the user whose role is to be updated
    * @param newRole The new role to set for the user
-   * @param communityService Optional parameter to indicate if the user is doing community service, defaults to false
    * @return A DBIO action that returns the number of rows affected
    */
-  def updateRole(userId: String, newRole: Role.Value, communityService: Boolean = false): DBIO[Int] = {
-    userRoles
-      .filter(_.userId === userId)
-      .map(r => (r.role, r.communityService))
-      .update((newRole, communityService))
-  }
-
-  /**
-   * Updates the community service status of the user.
-   * @param userId The ID of the user whose community service status is to be updated
-   * @param newCommServ The new community service status to set
-   * @return A DBIO action that returns the number of rows affected
-   */
-  def updateCommunityService(userId: String, newCommServ: Boolean): DBIO[Int] = {
-    userRoles.filter(_.userId === userId).map(_.communityService).update(newCommServ)
+  def updateRole(userId: String, newRole: Role.Value): DBIO[Int] = {
+    userRoles.filter(_.userId === userId).map(_.role).update(newRole)
   }
 
   /**

--- a/app/models/user/UserSettingsTable.scala
+++ b/app/models/user/UserSettingsTable.scala
@@ -1,0 +1,74 @@
+package models.user
+
+import com.google.inject.ImplementedBy
+import models.utils.MyPostgresProfile
+import models.utils.MyPostgresProfile.api._
+import play.api.db.slick.{DatabaseConfigProvider, HasDatabaseConfigProvider}
+
+import javax.inject._
+
+/**
+ * @param measurementSystem The units the user chose, or None to follow the site language.
+ * @param communityService  Whether the user is tracking their time for community service hours.
+ */
+case class UserSettings(userId: String, measurementSystem: Option[MeasurementSystem.Value], communityService: Boolean)
+
+class UserSettingsTableDef(tag: Tag) extends Table[UserSettings](tag, "user_settings") {
+  def userId: Rep[String]                                     = column[String]("user_id", O.PrimaryKey)
+  def measurementSystem: Rep[Option[MeasurementSystem.Value]] =
+    column[Option[MeasurementSystem.Value]]("measurement_system")
+  def communityService: Rep[Boolean] = column[Boolean]("community_service", O.Default(false))
+
+  def * = (userId, measurementSystem, communityService) <> ((UserSettings.apply _).tupled, UserSettings.unapply)
+
+  def user = foreignKey("user_settings_user_id_fkey", userId, TableQuery[SidewalkUserTableDef])(_.userId)
+}
+
+@ImplementedBy(classOf[UserSettingsTable])
+trait UserSettingsTableRepository {}
+
+/**
+ * Choices a user makes on the Settings page that belong to their account rather than to one city (#3720). The table
+ * lives in the shared `sidewalk_login` schema, so a choice made in one city applies in every city.
+ *
+ * A row is only written once the user changes something, so most accounts (nearly all of them anonymous) have none,
+ * and a missing row means every setting is at its default.
+ */
+@Singleton
+class UserSettingsTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvider)
+    extends UserSettingsTableRepository
+    with HasDatabaseConfigProvider[MyPostgresProfile] {
+
+  val userSettings = TableQuery[UserSettingsTableDef]
+
+  /**
+   * Saves the user's units choice without touching their other settings.
+   *
+   * @param userId The user making the choice.
+   * @param system The units to show distances in, or None to follow the site language.
+   * @return       The number of rows written.
+   */
+  def setMeasurementSystem(userId: String, system: Option[MeasurementSystem.Value]): DBIO[Int] = {
+    val systemName: Option[String] = system.map(_.toString)
+    sqlu"""
+      INSERT INTO sidewalk_login.user_settings (user_id, measurement_system)
+      VALUES ($userId, $systemName::sidewalk_login.measurement_system)
+      ON CONFLICT (user_id) DO UPDATE SET measurement_system = EXCLUDED.measurement_system
+    """
+  }
+
+  /**
+   * Turns community service hour tracking on or off without touching the user's other settings.
+   *
+   * @param userId  The user making the choice.
+   * @param enabled Whether they're tracking their time for community service hours.
+   * @return        The number of rows written.
+   */
+  def setCommunityService(userId: String, enabled: Boolean): DBIO[Int] = {
+    sqlu"""
+      INSERT INTO sidewalk_login.user_settings (user_id, community_service)
+      VALUES ($userId, $enabled)
+      ON CONFLICT (user_id) DO UPDATE SET community_service = EXCLUDED.community_service
+    """
+  }
+}

--- a/app/models/user/UserSettingsTable.scala
+++ b/app/models/user/UserSettingsTable.scala
@@ -31,8 +31,7 @@ trait UserSettingsTableRepository {}
  * Choices a user makes on the Settings page that belong to their account rather than to one city (#3720). The table
  * lives in the shared `sidewalk_login` schema, so a choice made in one city applies in every city.
  *
- * A row is only written once the user changes something, so most accounts (nearly all of them anonymous) have none,
- * and a missing row means every setting is at its default.
+ * A row is only written once the user changes something; a missing row means every setting is at its default.
  */
 @Singleton
 class UserSettingsTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvider)
@@ -60,9 +59,7 @@ class UserSettingsTable @Inject() (protected val dbConfigProvider: DatabaseConfi
   /**
    * Turns community service hour tracking on or off without touching the user's other settings.
    *
-   * Also written to `user_role.community_service` until #5306 drops that column. Prod restarts cities one at a time,
-   * so a city still on the previous release reads that column, and each city's run of evolution 385 syncs
-   * `user_settings` from it.
+   * Also written to `user_role.community_service` until #5306 drops that column.
    *
    * @param userId  The user making the choice.
    * @param enabled Whether they're tracking their time for community service hours.

--- a/app/models/user/UserSettingsTable.scala
+++ b/app/models/user/UserSettingsTable.scala
@@ -60,15 +60,21 @@ class UserSettingsTable @Inject() (protected val dbConfigProvider: DatabaseConfi
   /**
    * Turns community service hour tracking on or off without touching the user's other settings.
    *
+   * Also written to `user_role.community_service` until #5306 drops that column. Prod restarts cities one at a time,
+   * so a city still on the previous release reads that column, and each city's run of evolution 385 syncs
+   * `user_settings` from it.
+   *
    * @param userId  The user making the choice.
    * @param enabled Whether they're tracking their time for community service hours.
-   * @return        The number of rows written.
+   * @return        The number of `user_settings` rows written.
    */
   def setCommunityService(userId: String, enabled: Boolean): DBIO[Int] = {
-    sqlu"""
+    val saveSetting = sqlu"""
       INSERT INTO sidewalk_login.user_settings (user_id, community_service)
       VALUES ($userId, $enabled)
       ON CONFLICT (user_id) DO UPDATE SET community_service = EXCLUDED.community_service
     """
+    val saveToUserRole = sqlu"UPDATE sidewalk_login.user_role SET community_service = $enabled WHERE user_id = $userId"
+    saveToUserRole.andThen(saveSetting).transactionally
   }
 }

--- a/app/models/user/UserStateTable.scala
+++ b/app/models/user/UserStateTable.scala
@@ -1,0 +1,61 @@
+package models.user
+
+import com.google.inject.ImplementedBy
+import models.utils.MyPostgresProfile
+import models.utils.MyPostgresProfile.api._
+import play.api.db.slick.{DatabaseConfigProvider, HasDatabaseConfigProvider}
+
+import java.time.OffsetDateTime
+import javax.inject._
+
+/** @param exploreTutorialCompletedAt When the user first finished or skipped the Explore tutorial, in any city. */
+case class UserState(userId: String, exploreTutorialCompletedAt: Option[OffsetDateTime])
+
+class UserStateTableDef(tag: Tag) extends Table[UserState](tag, "user_state") {
+  def userId: Rep[String]                                     = column[String]("user_id", O.PrimaryKey)
+  def exploreTutorialCompletedAt: Rep[Option[OffsetDateTime]] =
+    column[Option[OffsetDateTime]]("explore_tutorial_completed_at")
+
+  def * = (userId, exploreTutorialCompletedAt) <> ((UserState.apply _).tupled, UserState.unapply)
+
+  def user = foreignKey("user_state_user_id_fkey", userId, TableQuery[SidewalkUserTableDef])(_.userId)
+}
+
+@ImplementedBy(classOf[UserStateTable])
+trait UserStateTableRepository {}
+
+/**
+ * Things the site records about a user that belong to their account rather than to one city (#3720), like having
+ * finished the Explore tutorial. Unlike `user_settings`, the user doesn't choose these. The table lives in the shared
+ * `sidewalk_login` schema so that what a user did in one city carries over to every other city.
+ *
+ * A row is only written once there's something to record, so a missing row means nothing has been recorded yet.
+ */
+@Singleton
+class UserStateTable @Inject() (protected val dbConfigProvider: DatabaseConfigProvider)
+    extends UserStateTableRepository
+    with HasDatabaseConfigProvider[MyPostgresProfile] {
+
+  val userStates = TableQuery[UserStateTableDef]
+
+  /** Whether the user has finished or skipped the Explore tutorial in any city. */
+  def hasCompletedExploreTutorial(userId: String): DBIO[Boolean] = {
+    userStates.filter(s => s.userId === userId && s.exploreTutorialCompletedAt.isDefined).exists.result
+  }
+
+  /**
+   * Records that the user finished or skipped the Explore tutorial. A retake keeps the original time, since that's when
+   * they first learned the tool.
+   *
+   * @param userId The user who finished it.
+   * @return       The number of rows written.
+   */
+  def markExploreTutorialCompleted(userId: String): DBIO[Int] = {
+    sqlu"""
+      INSERT INTO sidewalk_login.user_state (user_id, explore_tutorial_completed_at)
+      VALUES ($userId, now())
+      ON CONFLICT (user_id) DO UPDATE
+      SET explore_tutorial_completed_at = COALESCE(user_state.explore_tutorial_completed_at, EXCLUDED.explore_tutorial_completed_at)
+    """
+  }
+}

--- a/app/models/user/UserStateTable.scala
+++ b/app/models/user/UserStateTable.scala
@@ -54,8 +54,8 @@ class UserStateTable @Inject() (protected val dbConfigProvider: DatabaseConfigPr
     sqlu"""
       INSERT INTO sidewalk_login.user_state (user_id, explore_tutorial_completed_at)
       VALUES ($userId, now())
-      ON CONFLICT (user_id) DO UPDATE
-      SET explore_tutorial_completed_at = COALESCE(user_state.explore_tutorial_completed_at, EXCLUDED.explore_tutorial_completed_at)
+      ON CONFLICT (user_id) DO UPDATE SET explore_tutorial_completed_at =
+        COALESCE(user_state.explore_tutorial_completed_at, EXCLUDED.explore_tutorial_completed_at)
     """
   }
 }

--- a/app/models/utils/MyPostgresProfile.scala
+++ b/app/models/utils/MyPostgresProfile.scala
@@ -15,7 +15,7 @@ import models.street.{
   StreetImagerySource,
   WayType
 }
-import models.user.Role
+import models.user.{MeasurementSystem, Role}
 import models.utils.CommonUtils.{UiSource, ViewerType}
 import models.validation.{ValidationCommentChangeType, ValidationOption}
 import org.locationtech.jts.geom.{Geometry, LineString, MultiPolygon, Point}
@@ -271,6 +271,15 @@ trait MyPostgresProfile
     // Mapper for the role enum type, which lives in the shared sidewalk_login schema rather than the city's.
     implicit val roleMapper: BaseColumnType[Role.Value] =
       createEnumJdbcType[Role.Value]("role", _.toString, Role.withName, quoteName = false)
+
+    // Mapper for the measurement_system enum type, which also lives in the shared sidewalk_login schema.
+    implicit val measurementSystemMapper: BaseColumnType[MeasurementSystem.Value] =
+      createEnumJdbcType[MeasurementSystem.Value](
+        "measurement_system",
+        _.toString,
+        MeasurementSystem.withName,
+        quoteName = false
+      )
   }
 }
 

--- a/app/service/AuthenticationService.scala
+++ b/app/service/AuthenticationService.scala
@@ -44,7 +44,6 @@ trait AuthenticationService extends IdentityService[SidewalkUserWithRole] {
   def validateToken(id: String): Future[Option[AuthToken]]
   def removeToken(id: String): Future[Int]
   def cleanAuthTokens: Future[Int]
-  def setCommunityServiceStatus(userId: String, newCommServiceStatus: Boolean): Future[Int]
   def setInfra3dAccess(userId: String, newAccess: Boolean): Future[Int]
   def updateRole(userId: String, newRole: Role.Value): Future[Int]
 }
@@ -117,7 +116,7 @@ class AuthenticationServiceImpl @Inject() (
       isUserAvailable(username, email).flatMap {
         case true =>
           Future.successful(
-            SidewalkUserWithRole(UUID.randomUUID().toString, username, email, Role.Anonymous, false, false)
+            SidewalkUserWithRole(UUID.randomUUID().toString, username, email, Role.Anonymous, false, false, None)
           )
         case false => tryGenerateUser()
       }
@@ -163,7 +162,7 @@ class AuthenticationServiceImpl @Inject() (
       loginInfoId: Long <- loginInfoTable.insert(DBLoginInfo(0, providerId, user.email.toLowerCase))
       _                 <- userLoginInfoTable.insert(UserLoginInfo(0, user.userId, loginInfoId))
       _ <- userPasswordInfoTable.insert(UserPasswordInfo(0, pwInfo.hasher, pwInfo.password, pwInfo.salt, loginInfoId))
-      _ <- userRoleTable.addRole(user.userId, user.role, user.communityService)
+      _ <- userRoleTable.addRole(user.userId, user.role)
       _ <- insertUserStatForNewUser(user.userId)
     } yield user
     db.run(dbActions.transactionally)
@@ -199,7 +198,7 @@ class AuthenticationServiceImpl @Inject() (
       _ <- sidewalkUserTable.updateUsername(user.userId, user.username)
       _ <- updateEmailDBIO(user.userId, user.email)
       _ <- updatePasswordDBIO(user.userId, pwInfo)
-      _ <- userRoleTable.updateRole(user.userId, user.role, user.communityService)
+      _ <- userRoleTable.updateRole(user.userId, user.role)
     } yield user
     db.run(dbActions.transactionally)
   }
@@ -339,9 +338,6 @@ class AuthenticationServiceImpl @Inject() (
 
   def updateRole(userId: String, newRole: Role.Value): Future[Int] =
     db.run(userRoleTable.updateRole(userId, newRole))
-
-  def setCommunityServiceStatus(userId: String, newCommServiceStatus: Boolean): Future[Int] =
-    db.run(userRoleTable.updateCommunityService(userId, newCommServiceStatus))
 
   def setInfra3dAccess(userId: String, newAccess: Boolean): Future[Int] =
     db.run(userRoleTable.updateInfra3dAccess(userId, newAccess))

--- a/app/service/MissionService.scala
+++ b/app/service/MissionService.scala
@@ -9,7 +9,7 @@ import models.mission.MissionTable.{distanceForLaterMissions, distancesForFirstA
 import models.mission.{Mission, MissionTable, MissionType}
 import models.route.{RouteTable, UserRoute}
 import models.user.SidewalkUserTable.aiUserId
-import models.user.SidewalkUserWithRole
+import models.user.{SidewalkUserWithRole, UserStateTable}
 import models.utils.MyPostgresProfile
 import models.utils.MyPostgresProfile.api._
 import play.api.Logger
@@ -63,6 +63,7 @@ class MissionServiceImpl @Inject() (
     missionTable: MissionTable,
     auditTaskTable: AuditTaskTable,
     routeTable: RouteTable,
+    userStateTable: UserStateTable,
     implicit val ec: ExecutionContext
 ) extends MissionService
     with HasDatabaseConfigProvider[MyPostgresProfile] {
@@ -191,8 +192,9 @@ class MissionServiceImpl @Inject() (
 
     val getMissionAction =
       if (actions.contains("getMission")) {
-        missionTable
-          .hasCompletedAuditOnboarding(userId)
+        // Checked across every city, so a user who did the tutorial in one city never gets it again elsewhere (#3720).
+        userStateTable
+          .hasCompletedExploreTutorial(userId)
           .flatMap { completedOnboarding =>
             // If they still need to do tutorial or are retaking it.
             if (!completedOnboarding || retakingTutorial.get) {
@@ -273,7 +275,7 @@ class MissionServiceImpl @Inject() (
   /**
    * Returns the user's incomplete exploreAddress mission, or creates one if none exists (#4451).
    *
-   * Deliberately bypasses the hasCompletedAuditOnboarding gate in queryMissionTableExploreMissions: address-drop-in
+   * Deliberately bypasses the tutorial check in queryMissionTableExploreMissions: address-drop-in
    * sessions skip the tutorial and go straight to the searched location.
    */
   def resumeOrCreateNewExploreAddressMission(userId: String): DBIO[Mission] = {
@@ -462,7 +464,10 @@ class MissionServiceImpl @Inject() (
         val missionType: Option[MissionType.Value] = mission.map(_.missionType)
         if (missionType.contains(MissionType.AuditOnboarding)) {
           if (missionProgress.completed) {
-            updateCompleteAndGetNextMission(userId, regionId, missionId, skipped)
+            // Recorded before the next mission is picked, since picking it is what checks whether the tutorial is done.
+            userStateTable
+              .markExploreTutorialCompleted(userId)
+              .andThen(updateCompleteAndGetNextMission(userId, regionId, missionId, skipped))
           } else
             DBIO.successful(None)
         } else if (missionType.contains(MissionType.ExploreAddress)) {

--- a/app/service/MissionService.scala
+++ b/app/service/MissionService.scala
@@ -9,7 +9,7 @@ import models.mission.MissionTable.{distanceForLaterMissions, distancesForFirstA
 import models.mission.{Mission, MissionTable, MissionType}
 import models.route.{RouteTable, UserRoute}
 import models.user.SidewalkUserTable.aiUserId
-import models.user.{SidewalkUserWithRole, UserStateTable}
+import models.user.{SidewalkUserWithRole, UserAccountStateTable}
 import models.utils.MyPostgresProfile
 import models.utils.MyPostgresProfile.api._
 import play.api.Logger
@@ -63,7 +63,7 @@ class MissionServiceImpl @Inject() (
     missionTable: MissionTable,
     auditTaskTable: AuditTaskTable,
     routeTable: RouteTable,
-    userStateTable: UserStateTable,
+    userAccountStateTable: UserAccountStateTable,
     implicit val ec: ExecutionContext
 ) extends MissionService
     with HasDatabaseConfigProvider[MyPostgresProfile] {
@@ -192,8 +192,7 @@ class MissionServiceImpl @Inject() (
 
     val getMissionAction =
       if (actions.contains("getMission")) {
-        // Checked across every city, so a user who did the tutorial in one city never gets it again elsewhere (#3720).
-        userStateTable
+        userAccountStateTable
           .hasCompletedExploreTutorial(userId)
           .flatMap { completedOnboarding =>
             // If they still need to do tutorial or are retaking it.
@@ -465,7 +464,7 @@ class MissionServiceImpl @Inject() (
         if (missionType.contains(MissionType.AuditOnboarding)) {
           if (missionProgress.completed) {
             // Recorded before the next mission is picked, since picking it is what checks whether the tutorial is done.
-            userStateTable
+            userAccountStateTable
               .markExploreTutorialCompleted(userId)
               .andThen(updateCompleteAndGetNextMission(userId, regionId, missionId, skipped))
           } else

--- a/app/service/UserService.scala
+++ b/app/service/UserService.scala
@@ -425,6 +425,12 @@ trait UserService {
   def getUserStats(userId: String): Future[Option[UserStat]]
   def getPrivacySettings(userId: String): Future[Option[(Boolean, Boolean)]]
   def updatePrivacySettings(userId: String, onLeaderboard: Boolean, publicProfile: Boolean): Future[Int]
+
+  /** Turns community service hour tracking on or off, for every city. */
+  def setCommunityService(userId: String, enabled: Boolean): Future[Int]
+
+  /** Saves the user's units for every city; None follows the site language. */
+  def setMeasurementSystem(userId: String, system: Option[MeasurementSystem.Value]): Future[Int]
   def getPublicProfile(
       username: String,
       isOwner: Boolean,
@@ -516,6 +522,7 @@ class UserServiceImpl @Inject() (
     userTeamTable: UserTeamTable,
     teamTable: TeamTable,
     userUtmTable: UserUtmTable,
+    userSettingsTable: UserSettingsTable,
     configService: ConfigService,
     cacheApi: AsyncCacheApi,
     implicit val ec: ExecutionContext
@@ -594,6 +601,12 @@ class UserServiceImpl @Inject() (
 
   def updatePrivacySettings(userId: String, onLeaderboard: Boolean, publicProfile: Boolean): Future[Int] =
     db.run(userStatTable.updatePrivacySettings(userId, onLeaderboard, publicProfile))
+
+  def setCommunityService(userId: String, enabled: Boolean): Future[Int] =
+    db.run(userSettingsTable.setCommunityService(userId, enabled))
+
+  def setMeasurementSystem(userId: String, system: Option[MeasurementSystem.Value]): Future[Int] =
+    db.run(userSettingsTable.setMeasurementSystem(userId, system))
 
   def getPublicProfile(
       username: String,

--- a/app/views/serviceHoursInstructions.scala.html
+++ b/app/views/serviceHoursInstructions.scala.html
@@ -5,7 +5,7 @@
 
 @*
 * Instructions for earning community/volunteer service hours (#4375). Reached from the Settings opt-in toggle and the
-* "Service hours" account-menu item (both gated on user_role.community_service). Copy is deliberately structured as a
+* "Service hours" account-menu item (both gated on user_settings.community_service). Copy is deliberately structured as a
 * real sequence: learn → map an hour → email for feedback → repeat until cleared.
 *@
 

--- a/app/views/serviceHoursInstructions.scala.html
+++ b/app/views/serviceHoursInstructions.scala.html
@@ -5,8 +5,8 @@
 
 @*
 * Instructions for earning community/volunteer service hours (#4375). Reached from the Settings opt-in toggle and the
-* "Service hours" account-menu item (both gated on user_settings.community_service). Copy is deliberately structured as a
-* real sequence: learn → map an hour → email for feedback → repeat until cleared.
+* "Service hours" account-menu item (both gated on user_settings.community_service). Copy is deliberately structured
+* as a real sequence: learn → map an hour → email for feedback → repeat until cleared.
 *@
 
 @* Initials derive from the name so the avatar can't drift from it. *@

--- a/app/views/userDashboard/settings.scala.html
+++ b/app/views/userDashboard/settings.scala.html
@@ -1,4 +1,3 @@
-@import controllers.helper.ControllerUtils.UnitsOverride
 @import service.CommonPageData
 @import models.user.MeasurementSystem
 @import models.user.SidewalkUserWithRole
@@ -45,7 +44,7 @@
       <div class="ud-field">
         <label class="ud-label" for="set-units">@Messages("dashboard.settings.units")</label>
         <select class="ps-select ps-select--large" id="set-units">
-          @for(choice <- UnitsOverride.FollowLanguage +: MeasurementSystem.values.toSeq.map(_.toString)) {
+          @for(choice <- MeasurementSystem.FollowLanguage +: MeasurementSystem.values.toSeq.map(_.toString)) {
             <option value="@choice" @selectedIfChosen(choice)>@Messages(s"dashboard.settings.units.$choice")</option>
           }
         </select>

--- a/app/views/userDashboard/settings.scala.html
+++ b/app/views/userDashboard/settings.scala.html
@@ -1,5 +1,6 @@
-@import controllers.helper.ControllerUtils.MeasurementSystem
+@import controllers.helper.ControllerUtils.UnitsOverride
 @import service.CommonPageData
+@import models.user.MeasurementSystem
 @import models.user.SidewalkUserWithRole
 @import models.user.Team
 @import play.api.Configuration
@@ -44,7 +45,7 @@
       <div class="ud-field">
         <label class="ud-label" for="set-units">@Messages("dashboard.settings.units")</label>
         <select class="ps-select ps-select--large" id="set-units">
-          @for(choice <- Seq(MeasurementSystem.FollowLanguage, MeasurementSystem.Metric, MeasurementSystem.Imperial)) {
+          @for(choice <- UnitsOverride.FollowLanguage +: MeasurementSystem.values.toSeq.map(_.toString)) {
             <option value="@choice" @selectedIfChosen(choice)>@Messages(s"dashboard.settings.units.$choice")</option>
           }
         </select>

--- a/conf/evolutions/default/385.sql
+++ b/conf/evolutions/default/385.sql
@@ -1,0 +1,70 @@
+# --- !Ups
+-- Account-wide user data in the shared sidewalk_login schema, so it follows a user from city to city (#3720).
+-- user_settings holds choices the user makes on the Settings page, and user_state holds what the site records about
+-- them. Rows are only written once there's something to store, so a user with no row has every default.
+
+-- Evolutions run once per city schema and CREATE TYPE has no IF NOT EXISTS form, so the enum is guarded on pg_type.
+-- Semicolons inside the block are doubled to survive Play's statement splitter (see docs/evolutions.md).
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type
+                 WHERE typname = 'measurement_system' AND typnamespace = 'sidewalk_login'::regnamespace) THEN
+    CREATE TYPE sidewalk_login.measurement_system AS ENUM ('metric', 'imperial');;
+    -- Otherwise the first city role to get here owns the type, and no other city could ever alter or drop it.
+    ALTER TYPE sidewalk_login.measurement_system OWNER TO sidewalk;;
+  END IF;;
+END $$;
+
+-- A NULL measurement_system means "follow the site language".
+CREATE TABLE IF NOT EXISTS sidewalk_login.user_settings (
+  user_id TEXT PRIMARY KEY REFERENCES sidewalk_login.sidewalk_user (user_id),
+  measurement_system sidewalk_login.measurement_system,
+  community_service BOOLEAN NOT NULL DEFAULT FALSE
+);
+ALTER TABLE sidewalk_login.user_settings OWNER TO sidewalk;
+
+-- user_role.community_service is copied rather than moved. Prod restarts cities one at a time, and a city still on the
+-- old code reads that column on every page, so it's dropped in a later release (#5306). The join skips any user_role
+-- row whose account is missing, which the FK would otherwise reject.
+INSERT INTO sidewalk_login.user_settings (user_id, community_service)
+SELECT user_role.user_id, TRUE
+FROM sidewalk_login.user_role
+INNER JOIN sidewalk_login.sidewalk_user ON sidewalk_user.user_id = user_role.user_id
+WHERE user_role.community_service
+ON CONFLICT (user_id) DO NOTHING;
+
+-- A NULL explore_tutorial_completed_at means the user hasn't finished or skipped the Explore tutorial anywhere yet.
+CREATE TABLE IF NOT EXISTS sidewalk_login.user_state (
+  user_id TEXT PRIMARY KEY REFERENCES sidewalk_login.sidewalk_user (user_id),
+  explore_tutorial_completed_at TIMESTAMPTZ
+);
+ALTER TABLE sidewalk_login.user_state OWNER TO sidewalk;
+
+-- Each city's run adds the users who finished the tutorial in that city, keeping the earliest time across cities.
+-- Skipping it also marks the mission completed, and counts as done. The join leaves out missions from accounts that
+-- no longer exist, which some cities have (#4589).
+INSERT INTO sidewalk_login.user_state (user_id, explore_tutorial_completed_at)
+SELECT mission.user_id, MIN(mission.mission_end)
+FROM mission
+INNER JOIN sidewalk_login.sidewalk_user ON sidewalk_user.user_id = mission.user_id
+WHERE mission.mission_type = 'auditOnboarding' AND mission.completed = TRUE
+GROUP BY mission.user_id
+ON CONFLICT (user_id) DO UPDATE
+SET explore_tutorial_completed_at =
+  LEAST(user_state.explore_tutorial_completed_at, EXCLUDED.explore_tutorial_completed_at);
+
+# --- !Downs
+-- The old code reads community_service from user_role, so changes made since the Ups are copied back first. Downs run
+-- once per city too, so every run after the first finds the tables already gone.
+DO $$
+BEGIN
+  IF to_regclass('sidewalk_login.user_settings') IS NOT NULL THEN
+    UPDATE sidewalk_login.user_role SET community_service = user_settings.community_service
+    FROM sidewalk_login.user_settings
+    WHERE user_role.user_id = user_settings.user_id;;
+  END IF;;
+END $$;
+
+DROP TABLE IF EXISTS sidewalk_login.user_state;
+DROP TABLE IF EXISTS sidewalk_login.user_settings;
+DROP TYPE IF EXISTS sidewalk_login.measurement_system;

--- a/conf/evolutions/default/385.sql
+++ b/conf/evolutions/default/385.sql
@@ -23,15 +23,39 @@ CREATE TABLE IF NOT EXISTS sidewalk_login.user_settings (
 );
 ALTER TABLE sidewalk_login.user_settings OWNER TO sidewalk;
 
--- user_role.community_service is copied rather than moved. Prod restarts cities one at a time, and a city still on the
--- old code reads that column on every page, so it's dropped in a later release (#5306). The join skips any user_role
--- row whose account is missing, which the FK would otherwise reject.
+-- Prod restarts cities one at a time, so for a few minutes some cities still run the previous release, which reads and
+-- writes user_role.community_service. Until #5306 drops that column, this release writes the flag to both places, so
+-- user_role stays current and each city's run can sync user_settings from it. That also carries over changes made in
+-- cities that hadn't restarted yet. The join skips any user_role row whose account is missing, which the FK would
+-- reject. user_role has no index on community_service, so this reads the whole table: about 0.3 s for the 6.2M rows
+-- in the dev copy of the prod users dump. The column is dropped soon, so an index isn't worth building.
 INSERT INTO sidewalk_login.user_settings (user_id, community_service)
-SELECT user_role.user_id, TRUE
+SELECT user_role.user_id, BOOL_OR(user_role.community_service)
 FROM sidewalk_login.user_role
 INNER JOIN sidewalk_login.sidewalk_user ON sidewalk_user.user_id = user_role.user_id
-WHERE user_role.community_service
-ON CONFLICT (user_id) DO NOTHING;
+LEFT JOIN sidewalk_login.user_settings ON user_settings.user_id = user_role.user_id
+WHERE user_role.community_service OR user_settings.user_id IS NOT NULL
+GROUP BY user_role.user_id
+ON CONFLICT (user_id) DO UPDATE SET community_service = EXCLUDED.community_service;
+
+-- The previous release kept a units choice only in a per-city cookie, which this release doesn't read, but it also
+-- logged every change as Click_module=ChangeUnits_from=<choice>_to=<choice>. Each user's latest change in this city
+-- becomes their saved choice unless their account already has one. A latest choice of "auto" means no saved choice.
+-- webpage_activity has no index on activity, so this reads the whole table: about 0.1 s for the dev DB's 2.2M-row
+-- Seattle table.
+INSERT INTO sidewalk_login.user_settings (user_id, measurement_system)
+SELECT latest_change.user_id, latest_change.choice::sidewalk_login.measurement_system
+FROM (
+  SELECT DISTINCT ON (webpage_activity.user_id) webpage_activity.user_id,
+         substring(webpage_activity.activity FROM '_to=([a-z]+)$') AS choice
+  FROM webpage_activity
+  WHERE webpage_activity.activity LIKE 'Click\_module=ChangeUnits\_%'
+  ORDER BY webpage_activity.user_id, webpage_activity.webpage_activity_id DESC
+) AS latest_change
+INNER JOIN sidewalk_login.sidewalk_user ON sidewalk_user.user_id = latest_change.user_id
+WHERE latest_change.choice IN ('metric', 'imperial')
+ON CONFLICT (user_id) DO UPDATE SET measurement_system = EXCLUDED.measurement_system
+WHERE user_settings.measurement_system IS NULL;
 
 -- A NULL explore_tutorial_completed_at means the user hasn't finished or skipped the Explore tutorial anywhere yet.
 CREATE TABLE IF NOT EXISTS sidewalk_login.user_state (
@@ -54,17 +78,6 @@ SET explore_tutorial_completed_at =
   LEAST(user_state.explore_tutorial_completed_at, EXCLUDED.explore_tutorial_completed_at);
 
 # --- !Downs
--- The old code reads community_service from user_role, so changes made since the Ups are copied back first. Downs run
--- once per city too, so every run after the first finds the tables already gone.
-DO $$
-BEGIN
-  IF to_regclass('sidewalk_login.user_settings') IS NOT NULL THEN
-    UPDATE sidewalk_login.user_role SET community_service = user_settings.community_service
-    FROM sidewalk_login.user_settings
-    WHERE user_role.user_id = user_settings.user_id;;
-  END IF;;
-END $$;
-
-DROP TABLE IF EXISTS sidewalk_login.user_state;
-DROP TABLE IF EXISTS sidewalk_login.user_settings;
-DROP TYPE IF EXISTS sidewalk_login.measurement_system;
+-- Deliberately empty. Downs run once per city, so dropping the tables would break every city still running this
+-- release, and the previous release never reads them. Nothing needs copying back either, since this release keeps
+-- user_role.community_service current until #5306.

--- a/conf/evolutions/default/385.sql
+++ b/conf/evolutions/default/385.sql
@@ -1,7 +1,7 @@
 # --- !Ups
 -- Account-wide user data in the shared sidewalk_login schema, so it follows a user from city to city (#3720).
--- user_settings holds choices the user makes on the Settings page, and user_state holds what the site records about
--- them. Rows are only written once there's something to store, so a user with no row has every default.
+-- user_settings holds choices the user makes on the Settings page, and user_account_state holds what the site records
+-- about them. Rows are only written once there's something to store, so a user with no row has every default.
 
 -- Evolutions run once per city schema and CREATE TYPE has no IF NOT EXISTS form, so the enum is guarded on pg_type.
 -- Semicolons inside the block are doubled to survive Play's statement splitter (see docs/evolutions.md).
@@ -58,16 +58,16 @@ ON CONFLICT (user_id) DO UPDATE SET measurement_system = EXCLUDED.measurement_sy
 WHERE user_settings.measurement_system IS NULL;
 
 -- A NULL explore_tutorial_completed_at means the user hasn't finished or skipped the Explore tutorial anywhere yet.
-CREATE TABLE IF NOT EXISTS sidewalk_login.user_state (
+CREATE TABLE IF NOT EXISTS sidewalk_login.user_account_state (
   user_id TEXT PRIMARY KEY REFERENCES sidewalk_login.sidewalk_user (user_id),
   explore_tutorial_completed_at TIMESTAMPTZ
 );
-ALTER TABLE sidewalk_login.user_state OWNER TO sidewalk;
+ALTER TABLE sidewalk_login.user_account_state OWNER TO sidewalk;
 
 -- Each city's run adds the users who finished the tutorial in that city, keeping the earliest time across cities.
 -- Skipping it also marks the mission completed, and counts as done. The join leaves out missions from accounts that
 -- no longer exist, which some cities have (#4589).
-INSERT INTO sidewalk_login.user_state (user_id, explore_tutorial_completed_at)
+INSERT INTO sidewalk_login.user_account_state (user_id, explore_tutorial_completed_at)
 SELECT mission.user_id, MIN(mission.mission_end)
 FROM mission
 INNER JOIN sidewalk_login.sidewalk_user ON sidewalk_user.user_id = mission.user_id
@@ -75,7 +75,7 @@ WHERE mission.mission_type = 'auditOnboarding' AND mission.completed = TRUE
 GROUP BY mission.user_id
 ON CONFLICT (user_id) DO UPDATE
 SET explore_tutorial_completed_at =
-  LEAST(user_state.explore_tutorial_completed_at, EXCLUDED.explore_tutorial_completed_at);
+  LEAST(user_account_state.explore_tutorial_completed_at, EXCLUDED.explore_tutorial_completed_at);
 
 # --- !Downs
 -- Deliberately empty. Downs run once per city, so dropping the tables would break every city still running this

--- a/db/scripts/import-users.sh
+++ b/db/scripts/import-users.sh
@@ -206,7 +206,7 @@ psql -X -q -v ON_ERROR_STOP=1 -v dump_objects="{$dump_objects}" -U sidewalk -d "
     WHERE schemaname = 'sidewalk_login_import'
       AND tablename <> ALL (ARRAY[
         'sidewalk_user', 'login_info', 'user_login_info', 'user_password_info', 'user_role', 'user_utm',
-        'user_settings', 'user_state', 'partner'
+        'user_settings', 'user_account_state', 'partner'
       ]::name[]);
     IF unhandled IS NOT NULL THEN
       RAISE WARNING 'The dump has login tables this script does not merge: %. Add a rule for them to %.',
@@ -325,8 +325,8 @@ psql -X -q -v ON_ERROR_STOP=1 -v dump_objects="{$dump_objects}" -U sidewalk -d "
     'INNER JOIN new_account ON new_account.user_id = user_utm.user_id') AS user_utm_added \gset
   SELECT pg_temp.copy_rows('user_settings', '{}',
     'INNER JOIN new_account ON new_account.user_id = user_settings.user_id') AS user_settings_added \gset
-  SELECT pg_temp.copy_rows('user_state', '{}',
-    'INNER JOIN new_account ON new_account.user_id = user_state.user_id') AS user_state_added \gset
+  SELECT pg_temp.copy_rows('user_account_state', '{}',
+    'INNER JOIN new_account ON new_account.user_id = user_account_state.user_id') AS user_account_state_added \gset
   -- A partner from the dump is added unless that city already has one with the same name. New ones go after the
   -- existing ones in that city's display order.
   SELECT pg_temp.copy_rows('partner', '{partner_id,display_order}',
@@ -365,10 +365,11 @@ psql -X -q -v ON_ERROR_STOP=1 -v dump_objects="{$dump_objects}" -U sidewalk -d "
   \endif
 
   SELECT format('✓ Added %s new accounts (%s login_info, %s user_login_info, %s user_password_info, %s user_role, '
-                '%s user_utm, %s user_settings, %s user_state rows) and %s partners. Kept %s accounts the dump does '
-                'not have. Changed the username or email of %s accounts (%s anonymous) that clashed with a new one.',
+                '%s user_utm, %s user_settings, %s user_account_state rows) and %s partners. Kept %s accounts the '
+                'dump does not have. Changed the username or email of %s accounts (%s anonymous) that clashed with a '
+                'new one.',
                 :accounts_added, :login_info_added, :user_login_info_added, :user_password_info_added,
-                :user_role_added, :user_utm_added, :user_settings_added, :user_state_added, :partner_added,
+                :user_role_added, :user_utm_added, :user_settings_added, :user_account_state_added, :partner_added,
                 (SELECT count(*)
                  FROM sidewalk_login.sidewalk_user
                  WHERE NOT EXISTS (

--- a/db/scripts/import-users.sh
+++ b/db/scripts/import-users.sh
@@ -158,6 +158,12 @@ psql -X -q -v ON_ERROR_STOP=1 -v dump_objects="{$dump_objects}" -U sidewalk -d "
     source_cols text;
     copied bigint;
   BEGIN
+    -- A table only one side has (an older dump, or local accounts no city has evolved yet) has nothing to copy.
+    IF to_regclass(format('sidewalk_login.%I', tbl)) IS NULL
+       OR to_regclass(format('sidewalk_login_import.%I', tbl)) IS NULL THEN
+      RETURN 0;
+    END IF;
+
     WITH live_col AS (
       SELECT attname, attnum, atttypid, atttypmod
       FROM pg_attribute
@@ -195,7 +201,7 @@ psql -X -q -v ON_ERROR_STOP=1 -v dump_objects="{$dump_objects}" -U sidewalk -d "
     FROM pg_tables
     WHERE schemaname = 'sidewalk_login_import'
       AND tablename <> ALL (
-        '{sidewalk_user,login_info,user_login_info,user_password_info,user_role,user_utm,partner}'
+        '{sidewalk_user,login_info,user_login_info,user_password_info,user_role,user_utm,user_settings,user_state,partner}'
       );
     IF unhandled IS NOT NULL THEN
       RAISE WARNING 'The dump has login tables this script does not merge: %. Add a rule for them to %.',
@@ -312,6 +318,10 @@ psql -X -q -v ON_ERROR_STOP=1 -v dump_objects="{$dump_objects}" -U sidewalk -d "
     'INNER JOIN new_account ON new_account.user_id = user_role.user_id') AS user_role_added \gset
   SELECT pg_temp.copy_rows('user_utm', '{user_utm_id}',
     'INNER JOIN new_account ON new_account.user_id = user_utm.user_id') AS user_utm_added \gset
+  SELECT pg_temp.copy_rows('user_settings', '{}',
+    'INNER JOIN new_account ON new_account.user_id = user_settings.user_id') AS user_settings_added \gset
+  SELECT pg_temp.copy_rows('user_state', '{}',
+    'INNER JOIN new_account ON new_account.user_id = user_state.user_id') AS user_state_added \gset
   -- A partner from the dump is added unless that city already has one with the same name. New ones go after the
   -- existing ones in that city's display order.
   SELECT pg_temp.copy_rows('partner', '{partner_id,display_order}',
@@ -350,10 +360,10 @@ psql -X -q -v ON_ERROR_STOP=1 -v dump_objects="{$dump_objects}" -U sidewalk -d "
   \endif
 
   SELECT format('✓ Added %s new accounts (%s login_info, %s user_login_info, %s user_password_info, %s user_role, '
-                '%s user_utm rows) and %s partners. Kept %s accounts the dump does not have. Changed the username '
-                'or email of %s accounts (%s anonymous) that clashed with a new one.',
+                '%s user_utm, %s user_settings, %s user_state rows) and %s partners. Kept %s accounts the dump does '
+                'not have. Changed the username or email of %s accounts (%s anonymous) that clashed with a new one.',
                 :accounts_added, :login_info_added, :user_login_info_added, :user_password_info_added,
-                :user_role_added, :user_utm_added, :partner_added,
+                :user_role_added, :user_utm_added, :user_settings_added, :user_state_added, :partner_added,
                 (SELECT count(*)
                  FROM sidewalk_login.sidewalk_user
                  WHERE NOT EXISTS (

--- a/db/scripts/import-users.sh
+++ b/db/scripts/import-users.sh
@@ -158,9 +158,13 @@ psql -X -q -v ON_ERROR_STOP=1 -v dump_objects="{$dump_objects}" -U sidewalk -d "
     source_cols text;
     copied bigint;
   BEGIN
-    -- A table only one side has (an older dump, or local accounts no city has evolved yet) has nothing to copy.
-    IF to_regclass(format('sidewalk_login.%I', tbl)) IS NULL
-       OR to_regclass(format('sidewalk_login_import.%I', tbl)) IS NULL THEN
+    -- A dump older than the table has nothing to copy.
+    IF to_regclass(format('sidewalk_login_import.%I', tbl)) IS NULL THEN
+      RETURN 0;
+    END IF;
+    IF to_regclass(format('sidewalk_login.%I', tbl)) IS NULL THEN
+      RAISE WARNING 'Your login schema has no % table yet, so the dump''s % rows were not merged. '
+        'Start the app once so your schema catches up to the dump, then re-run.', tbl, tbl;
       RETURN 0;
     END IF;
 
@@ -200,9 +204,10 @@ psql -X -q -v ON_ERROR_STOP=1 -v dump_objects="{$dump_objects}" -U sidewalk -d "
     SELECT string_agg(tablename, ', ') INTO unhandled
     FROM pg_tables
     WHERE schemaname = 'sidewalk_login_import'
-      AND tablename <> ALL (
-        '{sidewalk_user,login_info,user_login_info,user_password_info,user_role,user_utm,user_settings,user_state,partner}'
-      );
+      AND tablename <> ALL (ARRAY[
+        'sidewalk_user', 'login_info', 'user_login_info', 'user_password_info', 'user_role', 'user_utm',
+        'user_settings', 'user_state', 'partner'
+      ]::name[]);
     IF unhandled IS NOT NULL THEN
       RAISE WARNING 'The dump has login tables this script does not merge: %. Add a rule for them to %.',
         unhandled, 'import-users.sh';

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -58,9 +58,9 @@ The backend follows a consistent layering: **routes → Controller → Service �
   JSON, and other slick-pg extensions. Spatial query helpers live in `SpatialQueryDefs.scala`.
 - **Per-city schemas** — each city is its own schema (`sidewalk_<city>`); they're essentially identical.
   Authentication lives in the shared `sidewalk_login` schema, along with anything that belongs to the account rather
-  than to one city: `user_settings` holds choices the user makes (units, service-hours tracking) and `user_state`
-  holds what the site records about them (having finished the Explore tutorial). Both only get a row once there's
-  something to store (#3720). Per-city stats and privacy flags stay in each city's `user_stat`.
+  than to one city: `user_settings` holds choices the user makes (units, service-hours tracking) and
+  `user_account_state` holds what the site records about them (having finished the Explore tutorial). Both only get a
+  row once there's something to store (#3720). Per-city stats and privacy flags stay in each city's `user_stat`.
 - **Evolutions** — schema changes are Play evolutions: numbered SQL files in `conf/evolutions/default/`, each with
   `# --- !Ups` / `# --- !Downs`, auto-applied at startup to every city schema. Numbers are gapless, a PR's changes go
   in one file, every new table gets `ALTER TABLE <name> OWNER TO sidewalk;` and its full set of constraints, and the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -57,7 +57,10 @@ The backend follows a consistent layering: **routes → Controller → Service �
 - **`app/models/utils/MyPostgresProfile.scala`** — a custom Slick Postgres profile wiring in PostGIS geometry,
   JSON, and other slick-pg extensions. Spatial query helpers live in `SpatialQueryDefs.scala`.
 - **Per-city schemas** — each city is its own schema (`sidewalk_<city>`); they're essentially identical.
-  Authentication lives in `sidewalk_login`.
+  Authentication lives in the shared `sidewalk_login` schema, along with anything that belongs to the account rather
+  than to one city: `user_settings` holds choices the user makes (units, service-hours tracking) and `user_state`
+  holds what the site records about them (having finished the Explore tutorial). Both only get a row once there's
+  something to store (#3720). Per-city stats and privacy flags stay in each city's `user_stat`.
 - **Evolutions** — schema changes are Play evolutions: numbered SQL files in `conf/evolutions/default/`, each with
   `# --- !Ups` / `# --- !Downs`, auto-applied at startup to every city schema. Numbers are gapless, a PR's changes go
   in one file, every new table gets `ALTER TABLE <name> OWNER TO sidewalk;` and its full set of constraints, and the

--- a/docs/internationalization.md
+++ b/docs/internationalization.md
@@ -61,10 +61,10 @@ Project Sidewalk has two separate translation systems; which one you use depends
 Units are **not** a property of the language: readers choose metric or imperial on the Settings page (#4404), so every
 language has to be able to render either.
 
-**One verdict, server-side.** `ControllerUtils.measurementSystem` returns `"metric"` or `"imperial"` — the reader's
-override cookie if set, else the language's default from the `measurement.system` message. That message is a sentinel
-the code compares against, so it holds the literal string `metric`, never a translation of the word. Never re-derive
-units from the language.
+**One verdict, server-side.** `ControllerUtils.measurementSystem` returns `MeasurementSystem.Metric` or `.Imperial` —
+the units the reader saved on the Settings page (shared by every city, #3720) if any, else the language's default from
+the `measurement.system` message. That message is a sentinel the code compares against, so it holds the literal string
+`metric`, never a translation of the word. Never re-derive units from the language.
 
 **The unit words live in `conf/messages` only**, as
 `unit.distance.{abbr,abbr.small,name,name.singular}.{metric,imperial}`. `ControllerUtils.distanceUnitWords` resolves

--- a/public/js/user-dashboard/Settings.js
+++ b/public/js/user-dashboard/Settings.js
@@ -43,7 +43,7 @@ class Settings {
       onLeaderboard: document.getElementById('set-on-leaderboard')?.checked ?? true,
       publicProfile: document.getElementById('set-public-profile')?.checked ?? true,
       communityService: document.getElementById('set-community-service')?.checked ?? false,
-      // 'auto' = follow the site language; the server clears the override cookie rather than setting one.
+      // 'auto' = follow the site language, which the server saves as no choice.
       measurementSystem: document.getElementById('set-units')?.value ?? 'auto',
       // null tells the server not to touch team membership: the "Choose a team…" placeholder, or the team they're
       // already on. Leaving is the Leave button (TeamActions.js), never a save (#5147).

--- a/test/controllers/ExploreRouteRequestSpec.scala
+++ b/test/controllers/ExploreRouteRequestSpec.scala
@@ -114,9 +114,9 @@ class ExploreRouteRequestSpec
     createdUserIds += bootstrap.userId
     bootstrap.missionType mustBe "auditOnboarding"
     // A real graduate also gets a mission_end stamp and a finished tutorial task; neither is read on any path under
-    // test. Whether to serve the tutorial is decided by the account-wide user_state row, so that's written too.
+    // test. Whether to serve the tutorial is decided by the account-wide user_account_state row, so that's written too.
     run(sqlu"UPDATE mission SET completed = TRUE WHERE mission_id = ${bootstrap.missionId}") mustBe 1
-    run(sqlu"""INSERT INTO sidewalk_login.user_state (user_id, explore_tutorial_completed_at)
+    run(sqlu"""INSERT INTO sidewalk_login.user_account_state (user_id, explore_tutorial_completed_at)
                VALUES (${bootstrap.userId}, now())""") mustBe 1
   }
 
@@ -142,7 +142,7 @@ class ExploreRouteRequestSpec
             sqlu"DELETE FROM route_street WHERE route_id IN (SELECT route_id FROM route WHERE user_id = $uId)",
             sqlu"DELETE FROM route WHERE user_id = $uId",
             sqlu"DELETE FROM user_current_region WHERE user_id = $uId",
-            sqlu"DELETE FROM sidewalk_login.user_state WHERE user_id = $uId"
+            sqlu"DELETE FROM sidewalk_login.user_account_state WHERE user_id = $uId"
           )
         )
       }

--- a/test/controllers/ExploreRouteRequestSpec.scala
+++ b/test/controllers/ExploreRouteRequestSpec.scala
@@ -114,9 +114,10 @@ class ExploreRouteRequestSpec
     createdUserIds += bootstrap.userId
     bootstrap.missionType mustBe "auditOnboarding"
     // A real graduate also gets a mission_end stamp and a finished tutorial task; neither is read on any path under
-    // test, and the gate itself (MissionTable.hasCompletedAuditOnboarding) asks only whether a completed onboarding
-    // mission exists.
+    // test. Whether to serve the tutorial is decided by the account-wide user_state row, so that's written too.
     run(sqlu"UPDATE mission SET completed = TRUE WHERE mission_id = ${bootstrap.missionId}") mustBe 1
+    run(sqlu"""INSERT INTO sidewalk_login.user_state (user_id, explore_tutorial_completed_at)
+               VALUES (${bootstrap.userId}, now())""") mustBe 1
   }
 
   /**
@@ -140,7 +141,8 @@ class ExploreRouteRequestSpec
                    WHERE route_id IN (SELECT route_id FROM route WHERE user_id = $uId)""",
             sqlu"DELETE FROM route_street WHERE route_id IN (SELECT route_id FROM route WHERE user_id = $uId)",
             sqlu"DELETE FROM route WHERE user_id = $uId",
-            sqlu"DELETE FROM user_current_region WHERE user_id = $uId"
+            sqlu"DELETE FROM user_current_region WHERE user_id = $uId",
+            sqlu"DELETE FROM sidewalk_login.user_state WHERE user_id = $uId"
           )
         )
       }

--- a/test/controllers/ExploreSubmissionSpec.scala
+++ b/test/controllers/ExploreSubmissionSpec.scala
@@ -296,7 +296,7 @@ class ExploreSubmissionSpec
                WHERE audit_task_id IN (SELECT audit_task_id FROM audit_task WHERE user_id = $uId)""",
         sqlu"DELETE FROM audit_task WHERE user_id = $uId",
         sqlu"DELETE FROM mission WHERE user_id = $uId",
-        sqlu"DELETE FROM sidewalk_login.user_state WHERE user_id = $uId"
+        sqlu"DELETE FROM sidewalk_login.user_account_state WHERE user_id = $uId"
       )
     )
   }

--- a/test/controllers/ExploreSubmissionSpec.scala
+++ b/test/controllers/ExploreSubmissionSpec.scala
@@ -295,7 +295,8 @@ class ExploreSubmissionSpec
         sqlu"""DELETE FROM audit_task_user_route
                WHERE audit_task_id IN (SELECT audit_task_id FROM audit_task WHERE user_id = $uId)""",
         sqlu"DELETE FROM audit_task WHERE user_id = $uId",
-        sqlu"DELETE FROM mission WHERE user_id = $uId"
+        sqlu"DELETE FROM mission WHERE user_id = $uId",
+        sqlu"DELETE FROM sidewalk_login.user_state WHERE user_id = $uId"
       )
     )
   }

--- a/test/controllers/MeasurementSystemSpec.scala
+++ b/test/controllers/MeasurementSystemSpec.scala
@@ -1,6 +1,8 @@
 package controllers
 
-import controllers.helper.ControllerUtils.MeasurementSystem
+import controllers.helper.ControllerUtils.UnitsOverride
+import models.user.MeasurementSystem
+import models.utils.MyPostgresProfile.api._
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Application
@@ -8,31 +10,37 @@ import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.mvc.Cookie
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
+import util.{AnonSession, RoleSession, RolledBackDb}
 
 /**
  * The single-measurement-system contract (#4404): `ControllerUtils.measurementSystem` is the one units verdict, and
  * the shared layout stamps it on `<html data-measurement-system>` so `util.isMetric()` reads the server's answer back
- * instead of deriving units from the language separately. These specs pin the three inputs that decide it — the
- * language default, the user's override cookie, and a junk cookie value — because a stamp that disagrees with the
- * server leaves a page showing kilometer numbers under a "miles" label.
+ * instead of deriving units from the language separately. These specs pin the inputs that decide it — the units the
+ * user saved to their account, the override cookie, the language default, and a junk cookie value — because a stamp
+ * that disagrees with the server leaves a page showing kilometer numbers under a "miles" label.
  *
  * Fetches /signIn because it serves every visitor with no session or data requirements.
  *
  * Requires a Postgres+PostGIS database (via DATABASE_URL / DATABASE_USER / DATABASE_PASSWORD env, as in dev/CI).
  */
-class MeasurementSystemSpec extends PlaySpec with GuiceOneAppPerSuite {
+class MeasurementSystemSpec
+    extends PlaySpec
+    with RoleSession
+    with GuiceOneAppPerSuite
+    with AnonSession
+    with RolledBackDb {
 
   override def fakeApplication(): Application =
     new GuiceApplicationBuilder()
       .disable[modules.ActorModule] // No eager background actors during tests.
       .build()
 
-  private def stampOf(langCode: String, override_ : Option[String] = None): String =
-    pageOf("/signIn", langCode, override_)
+  private def stampOf(langCode: String, override_ : Option[MeasurementSystem.Value] = None): String =
+    pageOf("/signIn", langCode, override_.map(_.toString))
 
   private def pageOf(path: String, langCode: String, override_ : Option[String]): String = {
     val base    = FakeRequest(GET, path).withHeaders("Accept-Language" -> langCode)
-    val request = override_.fold(base)(value => base.withCookies(Cookie(MeasurementSystem.CookieName, value)))
+    val request = override_.fold(base)(value => base.withCookies(Cookie(UnitsOverride.CookieName, value)))
     val resp    = route(app, request).get
     status(resp) mustBe OK
     contentAsString(resp)
@@ -51,7 +59,24 @@ class MeasurementSystemSpec extends PlaySpec with GuiceOneAppPerSuite {
 
     // A cookie is visitor-supplied, so an unrecognized value must read as "no override" rather than reaching the page.
     "ignore a cookie value that names neither system" in {
-      stampOf("en-US", Some("furlongs")) must include("data-measurement-system=\"imperial\"")
+      pageOf("/signIn", "en-US", Some("furlongs")) must include("data-measurement-system=\"imperial\"")
+    }
+
+    // The cookie belongs to one city's domain, while the saved choice follows the user to every city (#3720), so the
+    // saved choice has to win wherever the two disagree.
+    "honor the units saved to the account over both the cookie and the language" in {
+      val session = freshAnonSession()
+      val userId  = userIdOf(session)
+      try {
+        run(sqlu"""INSERT INTO sidewalk_login.user_settings (user_id, measurement_system)
+                   VALUES ($userId, 'imperial')""")
+        val request = FakeRequest(GET, "/leaderboard")
+          .withHeaders("Accept-Language" -> "en")
+          .withCookies(session :+ Cookie(UnitsOverride.CookieName, MeasurementSystem.Metric.toString): _*)
+        contentAsString(route(app, request).get) must include("data-measurement-system=\"imperial\"")
+      } finally {
+        val _ = run(sqlu"DELETE FROM sidewalk_login.user_settings WHERE user_id = $userId")
+      }
     }
   }
 
@@ -81,11 +106,11 @@ class MeasurementSystemSpec extends PlaySpec with GuiceOneAppPerSuite {
     "carry the abbreviation of the chosen system on the leaderboard" in {
       // Anchored on the closing tag: a bare " mi" also matches " minutes" and " missions", so it would pass on a page
       // that rendered no distance at all. The community band always renders one, so both directions have a subject.
-      val metric = pageOf("/leaderboard", "en", Some(MeasurementSystem.Metric))
+      val metric = pageOf("/leaderboard", "en", Some(MeasurementSystem.Metric.toString))
       metric must include(" km<")
       metric must not include " mi<"
 
-      val imperial = pageOf("/leaderboard", "en", Some(MeasurementSystem.Imperial))
+      val imperial = pageOf("/leaderboard", "en", Some(MeasurementSystem.Imperial.toString))
       imperial must include(" mi<")
       imperial must not include " km<"
     }

--- a/test/controllers/MeasurementSystemSpec.scala
+++ b/test/controllers/MeasurementSystemSpec.scala
@@ -1,13 +1,11 @@
 package controllers
 
-import controllers.helper.ControllerUtils.UnitsOverride
-import models.user.MeasurementSystem
+import models.user.{MeasurementSystem, UserSettingsTableDef}
 import models.utils.MyPostgresProfile.api._
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
-import play.api.mvc.Cookie
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import util.{AnonSession, RoleSession, RolledBackDb}
@@ -15,11 +13,12 @@ import util.{AnonSession, RoleSession, RolledBackDb}
 /**
  * The single-measurement-system contract (#4404): `ControllerUtils.measurementSystem` is the one units verdict, and
  * the shared layout stamps it on `<html data-measurement-system>` so `util.isMetric()` reads the server's answer back
- * instead of deriving units from the language separately. These specs pin the inputs that decide it — the units the
- * user saved to their account, the override cookie, the language default, and a junk cookie value — because a stamp
- * that disagrees with the server leaves a page showing kilometer numbers under a "miles" label.
+ * instead of deriving units from the language separately. These specs pin the two inputs that decide it, the units
+ * saved to the user's account and the language default, because a stamp that disagrees with the server leaves a page
+ * showing kilometer numbers under a "miles" label.
  *
- * Fetches /signIn because it serves every visitor with no session or data requirements.
+ * A saved choice belongs to an account, so each page is fetched with a fresh session, and their settings rows are
+ * deleted in afterAll. Fetches /leaderboard because it renders for every visitor and always shows a distance.
  *
  * Requires a Postgres+PostGIS database (via DATABASE_URL / DATABASE_USER / DATABASE_PASSWORD env, as in dev/CI).
  */
@@ -33,50 +32,48 @@ class MeasurementSystemSpec
   override def fakeApplication(): Application =
     new GuiceApplicationBuilder()
       .disable[modules.ActorModule] // No eager background actors during tests.
+      .configure("rate-limit.anon-signup.enabled" -> false) // One session per page, more than the limiter allows.
       .build()
 
-  private def stampOf(langCode: String, override_ : Option[MeasurementSystem.Value] = None): String =
-    pageOf("/signIn", langCode, override_.map(_.toString))
+  /** Accounts behind the sessions this suite minted, so afterAll can delete their settings. */
+  private val sessionUserIds = scala.collection.mutable.Set[String]()
 
-  private def pageOf(path: String, langCode: String, override_ : Option[String]): String = {
-    val base    = FakeRequest(GET, path).withHeaders("Accept-Language" -> langCode)
-    val request = override_.fold(base)(value => base.withCookies(Cookie(UnitsOverride.CookieName, value)))
+  /**
+   * Renders a page for a fresh session whose account has `saved` as its units.
+   *
+   * @param langCode The Accept-Language to render in.
+   * @param saved    The account's saved units, or None for no saved choice.
+   * @return         The /leaderboard page body.
+   */
+  private def pageOf(langCode: String, saved: Option[MeasurementSystem.Value] = None): String = {
+    val session = freshAnonSession()
+    val userId  = userIdOf(session)
+    sessionUserIds += userId
+    saved.foreach { system =>
+      val _ = run(sqlu"""INSERT INTO sidewalk_login.user_settings (user_id, measurement_system)
+                         VALUES ($userId, ${system.toString}::sidewalk_login.measurement_system)""")
+    }
+    val request = FakeRequest(GET, "/leaderboard").withHeaders("Accept-Language" -> langCode).withCookies(session: _*)
     val resp    = route(app, request).get
     status(resp) mustBe OK
     contentAsString(resp)
   }
 
+  override def afterAll(): Unit = {
+    val _ = run(TableQuery[UserSettingsTableDef].filter(_.userId inSet sessionUserIds.toSeq).delete)
+    super.afterAll()
+  }
+
   "The layout's data-measurement-system stamp" should {
-    "fall back to the language's own system when the visitor has set no override" in {
-      stampOf("en") must include("data-measurement-system=\"metric\"")
-      stampOf("en-US") must include("data-measurement-system=\"imperial\"")
+    "follow the language's own system when the account has no saved choice" in {
+      pageOf("en") must include("data-measurement-system=\"metric\"")
+      pageOf("en-US") must include("data-measurement-system=\"imperial\"")
     }
 
-    "honor an override cookie over the language default, in both directions" in {
-      stampOf("en", Some(MeasurementSystem.Imperial)) must include("data-measurement-system=\"imperial\"")
-      stampOf("en-US", Some(MeasurementSystem.Metric)) must include("data-measurement-system=\"metric\"")
-    }
-
-    // A cookie is visitor-supplied, so an unrecognized value must read as "no override" rather than reaching the page.
-    "ignore a cookie value that names neither system" in {
-      pageOf("/signIn", "en-US", Some("furlongs")) must include("data-measurement-system=\"imperial\"")
-    }
-
-    // The cookie belongs to one city's domain, while the saved choice follows the user to every city (#3720), so the
-    // saved choice has to win wherever the two disagree.
-    "honor the units saved to the account over both the cookie and the language" in {
-      val session = freshAnonSession()
-      val userId  = userIdOf(session)
-      try {
-        run(sqlu"""INSERT INTO sidewalk_login.user_settings (user_id, measurement_system)
-                   VALUES ($userId, 'imperial')""")
-        val request = FakeRequest(GET, "/leaderboard")
-          .withHeaders("Accept-Language" -> "en")
-          .withCookies(session :+ Cookie(UnitsOverride.CookieName, MeasurementSystem.Metric.toString): _*)
-        contentAsString(route(app, request).get) must include("data-measurement-system=\"imperial\"")
-      } finally {
-        val _ = run(sqlu"DELETE FROM sidewalk_login.user_settings WHERE user_id = $userId")
-      }
+    // A saved choice follows the user into every city (#3720), whatever language each one renders in.
+    "follow the units saved to the account over the language, in both directions" in {
+      pageOf("en", Some(MeasurementSystem.Imperial)) must include("data-measurement-system=\"imperial\"")
+      pageOf("en-US", Some(MeasurementSystem.Metric)) must include("data-measurement-system=\"metric\"")
     }
   }
 
@@ -84,19 +81,19 @@ class MeasurementSystemSpec
     // These are the only unit words the app has: client-side strings write {{unitAbbr}} / {{unitName}} and i18next
     // fills them from here. Lose them and every such string renders with an empty unit.
     "match the request's measurement system" in {
-      val metric = stampOf("en")
+      val metric = pageOf("en")
       metric must include("\"unitAbbr\":\"km\"")
       metric must include("\"unitName\":\"kilometers\"")
 
-      val imperial = stampOf("en-US")
+      val imperial = pageOf("en-US")
       imperial must include("\"unitAbbr\":\"mi\"")
       imperial must include("\"unitName\":\"miles\"")
     }
 
-    "follow an override rather than the language, and stay in the language's own words" in {
-      stampOf("en", Some(MeasurementSystem.Imperial)) must include("\"unitAbbrSmall\":\"ft\"")
-      stampOf("es", Some(MeasurementSystem.Imperial)) must include("\"unitName\":\"millas\"")
-      stampOf("es") must include("\"unitNameSingular\":\"kilómetro\"")
+    "follow a saved choice rather than the language, and stay in the language's own words" in {
+      pageOf("en", Some(MeasurementSystem.Imperial)) must include("\"unitAbbrSmall\":\"ft\"")
+      pageOf("es", Some(MeasurementSystem.Imperial)) must include("\"unitName\":\"millas\"")
+      pageOf("es") must include("\"unitNameSingular\":\"kilómetro\"")
     }
   }
 
@@ -106,11 +103,11 @@ class MeasurementSystemSpec
     "carry the abbreviation of the chosen system on the leaderboard" in {
       // Anchored on the closing tag: a bare " mi" also matches " minutes" and " missions", so it would pass on a page
       // that rendered no distance at all. The community band always renders one, so both directions have a subject.
-      val metric = pageOf("/leaderboard", "en", Some(MeasurementSystem.Metric.toString))
+      val metric = pageOf("en", Some(MeasurementSystem.Metric))
       metric must include(" km<")
       metric must not include " mi<"
 
-      val imperial = pageOf("/leaderboard", "en", Some(MeasurementSystem.Imperial.toString))
+      val imperial = pageOf("en", Some(MeasurementSystem.Imperial))
       imperial must include(" mi<")
       imperial must not include " km<"
     }

--- a/test/service/CrossCityHoursResilienceSpec.scala
+++ b/test/service/CrossCityHoursResilienceSpec.scala
@@ -73,6 +73,7 @@ class CrossCityHoursResilienceSpec extends PlaySpec with GuiceOneAppPerSuite {
     app.injector.instanceOf[models.user.UserTeamTable],
     app.injector.instanceOf[models.user.TeamTable],
     app.injector.instanceOf[models.user.UserUtmTable],
+    app.injector.instanceOf[models.user.UserSettingsTable],
     new ScopedConfigService(scope),
     app.injector.instanceOf[AsyncCacheApi],
     global

--- a/test/service/ExploreRoutePauseSpec.scala
+++ b/test/service/ExploreRoutePauseSpec.scala
@@ -1,7 +1,7 @@
 package service
 
 import formats.json.ExploreFormats._
-import models.mission.{Mission, MissionTableDef, MissionType}
+import models.mission.MissionTableDef
 import models.audit.AuditTaskTableDef
 import models.region.RegionTableDef
 import models.route.{
@@ -14,7 +14,7 @@ import models.route.{
   UserRouteTableDef
 }
 import models.street.{StreetEdgeRegionTableDef, StreetEdgeTable}
-import models.user.{SidewalkUserWithRole, UserCurrentRegionTableDef}
+import models.user.{SidewalkUserWithRole, UserCurrentRegionTableDef, UserStateTable, UserStateTableDef}
 import models.utils.MyPostgresProfile
 import models.utils.MyPostgresProfile.api._
 import org.scalatestplus.play.PlaySpec
@@ -60,6 +60,7 @@ class ExploreRoutePauseSpec
   private val exploreService  = app.injector.instanceOf[ExploreService]
   private val authService     = app.injector.instanceOf[AuthenticationService]
   private val streetEdgeTable = app.injector.instanceOf[StreetEdgeTable]
+  private val userStateTable  = app.injector.instanceOf[UserStateTable]
   // Keep the DatabaseConfig as a stable val and call .db.run inline; binding .db to its own val would infer a
   // path-dependent existential type that needs -language:existentials.
   private val dbConfig                   = app.injector.instanceOf[DatabaseConfigProvider].get[MyPostgresProfile]
@@ -85,11 +86,7 @@ class ExploreRoutePauseSpec
     val pwInfo    = PasswordInfo("bcrypt-sha256", "spec-only-not-a-hash", None)
     val user      = await(authService.createUser(generated, "credentials", pwInfo, oldUserId = None))
     createdUserIds += user.userId
-    val now = OffsetDateTime.now
-    val _   = run(
-      missions += Mission(0, MissionType.AuditOnboarding, user.userId, now, now, completed = true, 0d, paid = false,
-        None, None, None, None, None, None, skipped = false, None, None)
-    )
+    val _ = run(userStateTable.markExploreTutorialCompleted(user.userId))
     user
   }
 
@@ -189,7 +186,8 @@ class ExploreRoutePauseSpec
           userRoutes.filter(_.userId inSet userIds).delete,
           routeStreets.filter(_.routeId in seededRouteIds).delete,
           routes.filter(_.userId inSet userIds).delete,
-          TableQuery[UserCurrentRegionTableDef].filter(_.userId inSet userIds).delete
+          TableQuery[UserCurrentRegionTableDef].filter(_.userId inSet userIds).delete,
+          TableQuery[UserStateTableDef].filter(_.userId inSet userIds).delete
         )
         .transactionally
     )

--- a/test/service/ExploreRoutePauseSpec.scala
+++ b/test/service/ExploreRoutePauseSpec.scala
@@ -14,7 +14,7 @@ import models.route.{
   UserRouteTableDef
 }
 import models.street.{StreetEdgeRegionTableDef, StreetEdgeTable}
-import models.user.{SidewalkUserWithRole, UserCurrentRegionTableDef, UserStateTable, UserStateTableDef}
+import models.user.{SidewalkUserWithRole, UserAccountStateTable, UserAccountStateTableDef, UserCurrentRegionTableDef}
 import models.utils.MyPostgresProfile
 import models.utils.MyPostgresProfile.api._
 import org.scalatestplus.play.PlaySpec
@@ -57,10 +57,10 @@ class ExploreRoutePauseSpec
   override def fakeApplication(): Application =
     new GuiceApplicationBuilder().disable[modules.ActorModule].build()
 
-  private val exploreService  = app.injector.instanceOf[ExploreService]
-  private val authService     = app.injector.instanceOf[AuthenticationService]
-  private val streetEdgeTable = app.injector.instanceOf[StreetEdgeTable]
-  private val userStateTable  = app.injector.instanceOf[UserStateTable]
+  private val exploreService        = app.injector.instanceOf[ExploreService]
+  private val authService           = app.injector.instanceOf[AuthenticationService]
+  private val streetEdgeTable       = app.injector.instanceOf[StreetEdgeTable]
+  private val userAccountStateTable = app.injector.instanceOf[UserAccountStateTable]
   // Keep the DatabaseConfig as a stable val and call .db.run inline; binding .db to its own val would infer a
   // path-dependent existential type that needs -language:existentials.
   private val dbConfig                   = app.injector.instanceOf[DatabaseConfigProvider].get[MyPostgresProfile]
@@ -86,7 +86,7 @@ class ExploreRoutePauseSpec
     val pwInfo    = PasswordInfo("bcrypt-sha256", "spec-only-not-a-hash", None)
     val user      = await(authService.createUser(generated, "credentials", pwInfo, oldUserId = None))
     createdUserIds += user.userId
-    val _ = run(userStateTable.markExploreTutorialCompleted(user.userId))
+    val _ = run(userAccountStateTable.markExploreTutorialCompleted(user.userId))
     user
   }
 
@@ -187,7 +187,7 @@ class ExploreRoutePauseSpec
           routeStreets.filter(_.routeId in seededRouteIds).delete,
           routes.filter(_.userId inSet userIds).delete,
           TableQuery[UserCurrentRegionTableDef].filter(_.userId inSet userIds).delete,
-          TableQuery[UserStateTableDef].filter(_.userId inSet userIds).delete
+          TableQuery[UserAccountStateTableDef].filter(_.userId inSet userIds).delete
         )
         .transactionally
     )

--- a/test/service/ExploreTutorialRouteSpec.scala
+++ b/test/service/ExploreTutorialRouteSpec.scala
@@ -14,7 +14,7 @@ import models.route.{
   UserRouteTableDef
 }
 import models.street.{StreetEdgeRegionTableDef, StreetEdgeTable, StreetEdgeTableDef}
-import models.user.{SidewalkUserWithRole, UserCurrentRegionTableDef, UserStateTable, UserStateTableDef}
+import models.user.{SidewalkUserWithRole, UserAccountStateTable, UserAccountStateTableDef, UserCurrentRegionTableDef}
 import models.utils.{ConfigTableDef, MyPostgresProfile}
 import models.utils.MyPostgresProfile.api._
 import org.scalatestplus.play.PlaySpec
@@ -55,11 +55,11 @@ class ExploreTutorialRouteSpec extends PlaySpec with org.scalatest.BeforeAndAfte
   override def fakeApplication(): Application =
     new GuiceApplicationBuilder().disable[modules.ActorModule].build()
 
-  private val exploreService  = app.injector.instanceOf[ExploreService]
-  private val missionService  = app.injector.instanceOf[MissionService]
-  private val authService     = app.injector.instanceOf[AuthenticationService]
-  private val streetEdgeTable = app.injector.instanceOf[StreetEdgeTable]
-  private val userStateTable  = app.injector.instanceOf[UserStateTable]
+  private val exploreService        = app.injector.instanceOf[ExploreService]
+  private val missionService        = app.injector.instanceOf[MissionService]
+  private val authService           = app.injector.instanceOf[AuthenticationService]
+  private val streetEdgeTable       = app.injector.instanceOf[StreetEdgeTable]
+  private val userAccountStateTable = app.injector.instanceOf[UserAccountStateTable]
   // Keep the DatabaseConfig as a stable val and call .db.run inline; binding .db to its own val would infer a
   // path-dependent existential type that needs -language:existentials.
   private val dbConfig                   = app.injector.instanceOf[DatabaseConfigProvider].get[MyPostgresProfile]
@@ -135,7 +135,7 @@ class ExploreTutorialRouteSpec extends PlaySpec with org.scalatest.BeforeAndAfte
 
   /** Records the tutorial as done on the account, with no tutorial mission in this city, as if done in another. */
   private def markOnboardingComplete(userId: String): Unit = {
-    val _ = run(userStateTable.markExploreTutorialCompleted(userId))
+    val _ = run(userAccountStateTable.markExploreTutorialCompleted(userId))
   }
 
   /**
@@ -172,7 +172,7 @@ class ExploreTutorialRouteSpec extends PlaySpec with org.scalatest.BeforeAndAfte
           routeStreets.filter(_.routeId in seededRouteIds).delete,
           routes.filter(_.userId inSet userIds).delete,
           TableQuery[UserCurrentRegionTableDef].filter(_.userId inSet userIds).delete,
-          TableQuery[UserStateTableDef].filter(_.userId inSet userIds).delete
+          TableQuery[UserAccountStateTableDef].filter(_.userId inSet userIds).delete
         )
         .transactionally
     )
@@ -207,7 +207,7 @@ class ExploreTutorialRouteSpec extends PlaySpec with org.scalatest.BeforeAndAfte
             None, skipped = true)
           val next = run(missionService.updateMissionTableExplore(user.userId, skip))
 
-          run(userStateTable.hasCompletedExploreTutorial(user.userId)) mustBe true
+          run(userAccountStateTable.hasCompletedExploreTutorial(user.userId)) mustBe true
           // Also proves the account is updated before the next mission is picked, or this would be the tutorial again.
           next.value.missionType must not be MissionType.AuditOnboarding
       }

--- a/test/service/ExploreTutorialRouteSpec.scala
+++ b/test/service/ExploreTutorialRouteSpec.scala
@@ -1,6 +1,7 @@
 package service
 
-import models.mission.{Mission, MissionTableDef, MissionType}
+import formats.json.ExploreFormats.AuditMissionProgress
+import models.mission.{MissionTableDef, MissionType}
 import models.audit.AuditTaskTableDef
 import models.region.RegionTableDef
 import models.route.{
@@ -13,7 +14,7 @@ import models.route.{
   UserRouteTableDef
 }
 import models.street.{StreetEdgeRegionTableDef, StreetEdgeTable, StreetEdgeTableDef}
-import models.user.{SidewalkUserWithRole, UserCurrentRegionTableDef}
+import models.user.{SidewalkUserWithRole, UserCurrentRegionTableDef, UserStateTable, UserStateTableDef}
 import models.utils.{ConfigTableDef, MyPostgresProfile}
 import models.utils.MyPostgresProfile.api._
 import org.scalatestplus.play.PlaySpec
@@ -44,6 +45,8 @@ import scala.concurrent.duration._
  * assertions can't pass vacuously. All seeded route/user_route/mission rows are deleted in afterAll — mandatory,
  * not just tidy: the dev DB is shared. Requires a Postgres+PostGIS DB with at least one street/region and a
  * configured tutorial street (as in dev/CI); cancels gracefully otherwise.
+ *
+ * Also covers #3720: the tutorial is shown once per account rather than once per city.
  */
 // BeforeAndAfterAll must be mixed in BEFORE GuiceOneAppPerSuite: linearization then runs afterAll inside the running
 // app, rather than after the app (and its DB pool) has already been stopped.
@@ -53,8 +56,10 @@ class ExploreTutorialRouteSpec extends PlaySpec with org.scalatest.BeforeAndAfte
     new GuiceApplicationBuilder().disable[modules.ActorModule].build()
 
   private val exploreService  = app.injector.instanceOf[ExploreService]
+  private val missionService  = app.injector.instanceOf[MissionService]
   private val authService     = app.injector.instanceOf[AuthenticationService]
   private val streetEdgeTable = app.injector.instanceOf[StreetEdgeTable]
+  private val userStateTable  = app.injector.instanceOf[UserStateTable]
   // Keep the DatabaseConfig as a stable val and call .db.run inline; binding .db to its own val would infer a
   // path-dependent existential type that needs -language:existentials.
   private val dbConfig                   = app.injector.instanceOf[DatabaseConfigProvider].get[MyPostgresProfile]
@@ -128,13 +133,9 @@ class ExploreTutorialRouteSpec extends PlaySpec with org.scalatest.BeforeAndAfte
     routeId
   }
 
-  /** Records tutorial completion the way the schema does: a completed auditOnboarding mission. */
+  /** Records the tutorial as done on the account, with no tutorial mission in this city, as if done in another. */
   private def markOnboardingComplete(userId: String): Unit = {
-    val now = OffsetDateTime.now
-    val _   = run(
-      missions += Mission(0, MissionType.AuditOnboarding, userId, now, now, completed = true, 0d, paid = false, None,
-        None, None, None, None, None, skipped = false, None, None)
-    )
+    val _ = run(userStateTable.markExploreTutorialCompleted(userId))
   }
 
   /**
@@ -170,11 +171,47 @@ class ExploreTutorialRouteSpec extends PlaySpec with org.scalatest.BeforeAndAfte
           userRoutes.filter(_.userId inSet userIds).delete,
           routeStreets.filter(_.routeId in seededRouteIds).delete,
           routes.filter(_.userId inSet userIds).delete,
-          TableQuery[UserCurrentRegionTableDef].filter(_.userId inSet userIds).delete
+          TableQuery[UserCurrentRegionTableDef].filter(_.userId inSet userIds).delete,
+          TableQuery[UserStateTableDef].filter(_.userId inSet userIds).delete
         )
         .transactionally
     )
     super.afterAll()
+  }
+
+  "The Explore tutorial" should {
+    "be skipped for a user who already did it in another city (#3720)" in {
+      seedStreet match {
+        case None    => cancel("No street/region rows in the connected DB; nothing to exercise.")
+        case Some(_) =>
+          val user = newAnonUser()
+          markOnboardingComplete(user.userId)
+
+          pageData(user.userId).mission.missionType must not be MissionType.AuditOnboarding
+          val tutorialMissionsHere =
+            missions.filter(m => m.userId === user.userId && m.missionType === MissionType.AuditOnboarding)
+          run(tutorialMissionsHere.exists.result) mustBe false
+      }
+    }
+
+    "count as done in every city once the user skips it" in {
+      seedStreet match {
+        case None    => cancel("No street/region rows in the connected DB; nothing to exercise.")
+        case Some(_) =>
+          if (!tutorialStreetExists) cancel("No tutorial street configured in the connected DB.")
+          val user     = newAnonUser()
+          val tutorial = pageData(user.userId)
+          tutorial.mission.missionType mustBe MissionType.AuditOnboarding
+
+          val skip = AuditMissionProgress(tutorial.mission.missionId, None, tutorial.region.regionId, completed = true,
+            None, skipped = true)
+          val next = run(missionService.updateMissionTableExplore(user.userId, skip))
+
+          run(userStateTable.hasCompletedExploreTutorial(user.userId)) mustBe true
+          // Also proves the account is updated before the next mission is picked, or this would be the tutorial again.
+          next.value.missionType must not be MissionType.AuditOnboarding
+      }
+    }
   }
 
   "getDataForExplorePage" should {

--- a/test/service/UserSettingsSpec.scala
+++ b/test/service/UserSettingsSpec.scala
@@ -1,0 +1,89 @@
+package service
+
+import models.user.{MeasurementSystem, Role, SidewalkUserWithRole, UserSettingsTableDef}
+import models.utils.MyPostgresProfile
+import models.utils.MyPostgresProfile.api._
+import org.scalatestplus.play.PlaySpec
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
+import play.api.db.slick.DatabaseConfigProvider
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.silhouette.api.util.PasswordInfo
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+/**
+ * DB-backed tests for the account-wide settings in `sidewalk_login.user_settings` (#3720), read back through the same
+ * user lookup every request makes, since that's where pages get them from.
+ *
+ * Creates throwaway anonymous users and deletes their settings rows in afterAll. Requires a Postgres DB (as in dev/CI).
+ */
+// BeforeAndAfterAll must be mixed in BEFORE GuiceOneAppPerSuite: linearization then runs afterAll inside the running
+// app, rather than after the app (and its DB pool) has already been stopped.
+class UserSettingsSpec extends PlaySpec with org.scalatest.BeforeAndAfterAll with GuiceOneAppPerSuite {
+
+  override def fakeApplication(): Application =
+    new GuiceApplicationBuilder().disable[modules.ActorModule].build()
+
+  private val authService = app.injector.instanceOf[AuthenticationService]
+  private val userService = app.injector.instanceOf[UserService]
+  // Keep the DatabaseConfig as a stable val and call .db.run inline; binding .db to its own val would infer a
+  // path-dependent existential type that needs -language:existentials.
+  private val dbConfig                   = app.injector.instanceOf[DatabaseConfigProvider].get[MyPostgresProfile]
+  private def run[T](action: DBIO[T]): T = Await.result(dbConfig.db.run(action), 60.seconds)
+  private def await[T](f: scala.concurrent.Future[T]): T = Await.result(f, 60.seconds)
+
+  /** Every throwaway user the suite creates, so afterAll can sweep their settings. */
+  private val createdUserIds = scala.collection.mutable.Set[String]()
+
+  /** Creates a throwaway anonymous user and registers it for afterAll cleanup. */
+  private def newAnonUser(): SidewalkUserWithRole = {
+    val generated = await(authService.generateUniqueAnonUser())
+    val pwInfo    = PasswordInfo("bcrypt-sha256", "spec-only-not-a-hash", None)
+    val user      = await(authService.createUser(generated, "credentials", pwInfo, oldUserId = None))
+    createdUserIds += user.userId
+    user
+  }
+
+  /** The user as a request would see them. */
+  private def reload(userId: String): SidewalkUserWithRole = await(authService.findByUserId(userId)).value
+
+  /** Deletes the settings rows. The bare user/auth rows are left behind, matching ExploreTutorialRouteSpec. */
+  override def afterAll(): Unit = {
+    val _ = run(TableQuery[UserSettingsTableDef].filter(_.userId inSet createdUserIds.toSeq).delete)
+    super.afterAll()
+  }
+
+  "Account-wide settings" should {
+    "all be at their defaults for a user who has never saved any" in {
+      val user = reload(newAnonUser().userId)
+      user.communityService mustBe false
+      user.measurementSystem mustBe None
+    }
+
+    "save units and service-hours tracking without either one resetting the other" in {
+      val userId = newAnonUser().userId
+      await(userService.setCommunityService(userId, enabled = true))
+      await(userService.setMeasurementSystem(userId, Some(MeasurementSystem.Metric)))
+
+      val saved = reload(userId)
+      saved.communityService mustBe true
+      saved.measurementSystem mustBe Some(MeasurementSystem.Metric)
+
+      await(userService.setMeasurementSystem(userId, None))
+      val cleared = reload(userId)
+      cleared.measurementSystem mustBe None
+      cleared.communityService mustBe true
+    }
+
+    // An admin giving someone a new role mustn't turn off the service-hours tracking they asked for.
+    "keep service-hours tracking on through a role change" in {
+      val userId = newAnonUser().userId
+      await(userService.setCommunityService(userId, enabled = true))
+      await(authService.updateRole(userId, Role.Registered))
+
+      reload(userId).communityService mustBe true
+    }
+  }
+}

--- a/test/service/UserSettingsSpec.scala
+++ b/test/service/UserSettingsSpec.scala
@@ -49,8 +49,15 @@ class UserSettingsSpec extends PlaySpec with org.scalatest.BeforeAndAfterAll wit
   /** The user as a request would see them. */
   private def reload(userId: String): SidewalkUserWithRole = await(authService.findByUserId(userId)).value
 
-  /** Deletes the settings rows. The bare user/auth rows are left behind, matching ExploreTutorialRouteSpec. */
+  /** Accounts a test promoted, put back to Anonymous in afterAll so no standing Registered account is left behind. */
+  private val promotedUserIds = scala.collection.mutable.Set[String]()
+
+  /**
+   * Deletes the settings rows and undoes promotions. The bare user/auth rows are left behind, matching
+   * ExploreTutorialRouteSpec.
+   */
   override def afterAll(): Unit = {
+    promotedUserIds.foreach(userId => await(authService.updateRole(userId, Role.Anonymous)))
     val _ = run(TableQuery[UserSettingsTableDef].filter(_.userId inSet createdUserIds.toSeq).delete)
     super.afterAll()
   }
@@ -81,6 +88,7 @@ class UserSettingsSpec extends PlaySpec with org.scalatest.BeforeAndAfterAll wit
     "keep service-hours tracking on through a role change" in {
       val userId = newAnonUser().userId
       await(userService.setCommunityService(userId, enabled = true))
+      promotedUserIds += userId
       await(authService.updateRole(userId, Role.Registered))
 
       reload(userId).communityService mustBe true

--- a/test/views/AdminUserViewSpec.scala
+++ b/test/views/AdminUserViewSpec.scala
@@ -40,10 +40,10 @@ class AdminUserViewSpec extends PlaySpec with GuiceOneAppPerSuite {
 
   private val admin =
     SidewalkUserWithRole("admin-user", "testadmin", "admin@example.com", Role.Administrator, communityService = false,
-      infra3dAccess = false)
+      infra3dAccess = false, measurementSystem = None)
   private val subject =
     SidewalkUserWithRole("test-user", "testmapper", "test@example.com", Role.Registered, communityService = false,
-      infra3dAccess = false)
+      infra3dAccess = false, measurementSystem = None)
 
   private val userStats = UserStat(1, subject.userId, 0d, None, highQuality = true, None, 0, None, excluded = false,
     onLeaderboard = true, publicProfile = true)

--- a/test/views/ViewSpecFixtures.scala
+++ b/test/views/ViewSpecFixtures.scala
@@ -35,5 +35,5 @@ trait ViewSpecFixtures extends GuiceOneAppPerSuite { self: org.scalatest.TestSui
 
   protected val user: SidewalkUserWithRole =
     SidewalkUserWithRole("test-user", "testmapper", "test@example.com", Role.Registered, communityService = false,
-      infra3dAccess = false)
+      infra3dAccess = false, measurementSystem = None)
 }


### PR DESCRIPTION
resolves #3720

Adds two account-wide tables to the shared `sidewalk_login` schema, so what a user did or chose in one city carries over to the others.

- **`user_account_state`** records things the site tracks about a user. For now that's `explore_tutorial_completed_at`, set when they finish *or* skip the Explore tutorial. Explore checks this instead of the city's own `mission` table, so the tutorial is shown once per account rather than once per city.
- **`user_settings`** holds choices from the Settings page: units (`measurement_system`, a new shared enum; empty means "follow the site language") and `community_service`.

Both tables only get a row once there's something to store, so the millions of anonymous accounts don't each get one.

###### Evolution 385
- **Tutorial:** each city's run backfills that city's completed tutorials into `user_account_state`, keeping the earliest time across cities. About 0.3 s on the biggest dev schema.
- **Units:** the previous release kept a units choice only in a per-city `PS_UNITS` cookie, but it logged every change as `ChangeUnits`. Each city's run saves a user's latest logged choice to their account unless the account already has one.
- **Service hours:** `user_role.community_service` stays until #5306. Prod restarts cities one at a time, and cities still on the previous release read that column. Until the column is dropped, the new code writes the flag to both places, and each city's run syncs `user_settings` from `user_role`, so changes made in cities that haven't restarted yet carry over. About 0.26 s per run against the dev copy of prod's 6.2M `user_role` rows.
- **Downs are deliberately empty.** Downs run per city, so dropping the shared tables would break every city still on this release, and the previous release never reads them.

###### Units
Units come only from the account (`ControllerUtils.measurementSystem`: saved choice → language default). The `PS_UNITS` cookie is no longer read or written. The saved choice rides along on the user object that's already loaded every request, so there's no extra query. A Settings save only writes units or service hours when the request sends them and they changed.

###### Also
- Fixes a bug where an admin changing someone's role reset their community service flag to false.
- `db/scripts/import-users.sh` copies both new tables, and warns when the dump has a table your local schema lacks.

###### Testing
- New `UserSettingsSpec`; new tutorial cases in `ExploreTutorialRouteSpec` (done in another city → no tutorial; skipping is recorded before the next mission is picked); `MeasurementSystemSpec` now checks the saved choice against the language default.
- Ran `EvolutionsApplySpec`, `UserSettingsSpec`, `ExploreTutorialRouteSpec`, `ExploreRoutePauseSpec`, `ExploreRouteRequestSpec`, `ExploreSubmissionSpec`, `MeasurementSystemSpec`, `AdminUserViewSpec`, and `CrossCityHoursResilienceSpec` locally: 55 passed. After 385 applied to dev Seattle, the backfilled counts matched the source data.

###### Related
- #5306: drop `user_role.community_service` and the second write once this has reached every server.
- #5303: whether privacy settings and teams should also be shared across cities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XPyxLQruV8FmuQVLB7h2qw
