### PR TITLE
Inline the ids in getStreetNames: a whole city is over pgjdbc's parameter cap

### DIFF
--- a/app/controllers/helper/ShapefilesCreatorHelper.scala
+++ b/app/controllers/helper/ShapefilesCreatorHelper.scala
@@ -1029,6 +1029,7 @@ class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: M
       "the_geom:LineString:srid=4326," // LineString geometry
       + "streetId:Integer,"            // Street edge ID
       + "osmWayId:String,"             // OSM way ID as String (shapefiles don't handle Long well)
+      + "streetName:String,"           // The OSM way's name tag (null if unnamed); 10 chars, the DBF ceiling
       + "regionId:Integer,"            // Region ID
       + "score:Double,"                // Headline score: mean of the segment and its end intersections (null if none)
       + "segScore:Double,"             // The segment's own score (null if unaudited)
@@ -1048,6 +1049,7 @@ class ShapefilesCreatorHelper @Inject() ()(implicit ec: ExecutionContext, mat: M
       fb.add(s.geometry)
       fb.add(s.streetEdgeId)
       fb.add(s.osmWayId.toString)
+      fb.add(s.streetName.orNull)
       fb.add(s.regionId)
       fb.add(s.score.map(Double.box).orNull)
       fb.add(s.segmentScore.map(Double.box).orNull)

--- a/app/models/street/OsmWayTable.scala
+++ b/app/models/street/OsmWayTable.scala
@@ -107,16 +107,21 @@ class OsmWayTable @Inject() (
   /**
    * Gets the OSM `name` tag for each of the given streets, keyed by street_edge_id.
    *
+   * `inSet` inlines the ids rather than binding them: the AccessScore API passes a whole city's streets, and pgjdbc
+   * caps a statement at 65,535 parameters (Chicago has ~112k) — as `StreetEdgeTable.getStreetLengths` already does.
+   *
    * @return Map from street_edge_id to the way's name; streets with no cached way or an unnamed way are absent.
    */
   def getStreetNames(streetEdgeIds: Seq[Int]): DBIO[Map[Int, String]] = {
-    osmWayStreetEdges
-      .filter(_.streetEdgeId inSetBind streetEdgeIds)
-      .join(osmWays)
-      .on(_.osmWayId === _.osmWayId)
-      .map(x => (x._1.streetEdgeId, x._2.tags.+>>("name").?))
-      .result
-      .map(_.collect { case (streetEdgeId, Some(name)) if name.trim.nonEmpty => streetEdgeId -> name.trim }.toMap)
+    if (streetEdgeIds.isEmpty) DBIO.successful(Map.empty[Int, String])
+    else
+      osmWayStreetEdges
+        .filter(_.streetEdgeId inSet streetEdgeIds)
+        .join(osmWays)
+        .on(_.osmWayId === _.osmWayId)
+        .map(x => (x._1.streetEdgeId, x._2.tags.+>>("name").?))
+        .result
+        .map(_.collect { case (streetEdgeId, Some(name)) if name.trim.nonEmpty => streetEdgeId -> name.trim }.toMap)
   }
 
   /**

--- a/test/controllers/helper/RawLabelExportSpec.scala
+++ b/test/controllers/helper/RawLabelExportSpec.scala
@@ -394,6 +394,7 @@ class RawLabelExportSpec extends PlaySpec with GuiceOneAppPerSuite with OptionVa
       val street = StreetAccessScoreForApi(
         streetEdgeId = 951,
         osmWayId = 11584845L,
+        streetName = Some("Cedar Lane"),
         regionId = 1,
         score = Some(0.8),
         segmentScore = Some(0.7),
@@ -427,7 +428,17 @@ class RawLabelExportSpec extends PlaySpec with GuiceOneAppPerSuite with OptionVa
         features(951).getAttribute("severity_counts_CurbRamp_1") mustBe 2
         features(951).getAttribute("severity_counts_CurbRamp_null") mustBe 0 // Sparse entries are filled with zero.
         features(951).getAttribute("end_intersection_id") mustBe null
+        features(951).getAttribute("street_name") mustBe "Cedar Lane"
         declaredSrsId(gpkg, "access_score_streets") mustBe 4326
+      }
+      // The shapefile has its own hand-written columns, so the name is checked there too.
+      inTempDir("access-score-streets-shp") { base =>
+        val shp = Await
+          .result(shapefileCreator.createStreetAccessScoreShapefile(Source.single(street), base, 1), 60.seconds)
+          .value
+        val (names, features) = readBack(openShapefile(shp), "streetId")
+        names must contain("streetName")
+        features(951).getAttribute("streetName") mustBe "Cedar Lane"
       }
     }
   }

--- a/test/models/street/OsmWayTableSpec.scala
+++ b/test/models/street/OsmWayTableSpec.scala
@@ -129,6 +129,36 @@ class OsmWayTableSpec
         (Json.parse(tags), maxspeed, source, micros(updatedAt), missingSince.map(micros))
       }
 
+  "OsmWayTable.getStreetNames" should {
+    "name a mapped street from its way's name tag and skip unnamed or blank ones" in {
+      val named = runRolledBack(for {
+        namedStreet   <- insertStreet()
+        blankStreet   <- insertStreet()
+        unnamedStreet <- insertStreet()
+        _             <- sqlu"""INSERT INTO osm_way (osm_way_id, tags, maxspeed, geom, source, updated_at)
+                  VALUES ($blankedId, '{"name": " Main St "}'::jsonb, NULL, NULL, 'batch', now()),
+                         ($keptTagsId, '{"name": "  "}'::jsonb, NULL, NULL, 'batch', now()),
+                         ($checkedId, '{"highway": "residential"}'::jsonb, NULL, NULL, 'batch', now())"""
+        _ <- sqlu"""INSERT INTO osm_way_street_edge (osm_way_street_edge_id, osm_way_id, street_edge_id)
+                  VALUES ((SELECT COALESCE(MAX(osm_way_street_edge_id), 0) + 1 FROM osm_way_street_edge),
+                          $blankedId, $namedStreet),
+                         ((SELECT COALESCE(MAX(osm_way_street_edge_id), 0) + 2 FROM osm_way_street_edge),
+                          $keptTagsId, $blankStreet),
+                         ((SELECT COALESCE(MAX(osm_way_street_edge_id), 0) + 3 FROM osm_way_street_edge),
+                          $checkedId, $unnamedStreet)"""
+        names <- osmWayTable.getStreetNames(Seq(namedStreet, blankStreet, unnamedStreet))
+      } yield names)
+      named.values.toSeq mustBe Seq("Main St")
+      named.size mustBe 1
+    }
+
+    "take a whole city's worth of ids: more than pgjdbc's 65,535 bound parameters" in {
+      // Ids that match nothing are fine: the point is that pgjdbc accepts the statement (Chicago's ~112k didn't).
+      run(osmWayTable.getStreetNames(Seq.range(900000000, 900070000))) mustBe Map.empty
+      run(osmWayTable.getStreetNames(Nil)) mustBe Map.empty
+    }
+  }
+
   "OsmWayTable.getWayIdsToBackfill" should {
     "list only the gone ways whose tags are empty and whose history has not been read" in {
       val goneAt = OffsetDateTime.now


### PR DESCRIPTION
Follow-up to #5318 (#5217). Fixes the 500 on Chicago-test and the red test compile on `develop`.

## The Chicago 500

`/v3/api/accessScoreStreets` and `accessScoreIntersections` 500 on Chicago-test since #5318 deployed:

```
PSQLException: PreparedStatement can have at most 65,535 parameters ... Given query has 111,917 parameters
```

`OsmWayTable.getStreetNames`, the lookup behind the new `street_name`, bound every street id as a JDBC parameter, and Chicago has 111,917 streets. It now inlines them with `inSet` and an empty-list guard, exactly as `StreetEdgeTable.getStreetLengths` on the same code path already does (#3855). The other four test stages were fine (dc has 14k streets), which is why neither the review nor a Teaneck QA caught it.

`OsmWayTableSpec` gains two cases: one pushes 70,000 ids through the query — flipped back to `inSetBind` it fails with the production error, so a regression trips the suite — and one pins the name / blank / unnamed contract.

## `develop` doesn't compile its tests

#5319 merged 24 minutes before #5318, and its new GeoPackage spec constructs `StreetAccessScoreForApi` without the `street_name` #5318 added. No textual conflict, so GitHub called #5318 mergeable; the combined tree fails `Test / compile` (the `develop` run of 7c4e316c is red). The spec now names its street and checks the column round-trips through the GeoPackage.

## `street_name` in the shapefile

#5318 said "every format", but the AccessScore streets shapefile's columns are hand-written rather than derived from `ApiFields`, so it never got the name. It carries `streetName` now (10 characters, the DBF ceiling), pinned by the same spec.

## Checks

Run against a throwaway CI-faithful database (evolutions through 385): `OsmWayTableSpec` 16/16, `RawLabelExportSpec` 16/16, `AccessScoreApiSpec` 14/14; scalafmt clean.

##### Testing instructions
1. After the test-stage redeploy, `https://sidewalk-chicago-test.cs.washington.edu/v3/api/accessScoreStreets` returns 200, and `/accessScore` there loads and colors the map.
2. `.../v3/api/accessScoreStreets?filetype=shapefile` — the DBF has a `streetName` column.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 5 (1M context), claude-opus-5[1m]
